### PR TITLE
Fix jumpy scroll area when using mouse wheel on qt6 builds

### DIFF
--- a/src/gui/qgsscrollarea.cpp
+++ b/src/gui/qgsscrollarea.cpp
@@ -22,7 +22,7 @@
 #include <QAbstractItemView>
 
 // milliseconds to swallow child wheel events for after a scroll occurs
-#define TIMEOUT 1000
+constexpr qint64 TIMEOUT = 1000;
 
 QgsScrollArea::QgsScrollArea( QWidget *parent )
   : QScrollArea( parent )
@@ -48,18 +48,18 @@ void QgsScrollArea::resizeEvent( QResizeEvent *event )
 
 void QgsScrollArea::scrollOccurred()
 {
-  mTimer.setSingleShot( true );
-  mTimer.start( TIMEOUT );
+  mTimer.restart();
+  mTimerActive = true;
 }
 
 bool QgsScrollArea::hasScrolled() const
 {
-  return mTimer.isActive();
+  return mTimerActive && mTimer.elapsed() < TIMEOUT;
 }
 
 void QgsScrollArea::resetHasScrolled()
 {
-  mTimer.stop();
+  mTimerActive = false;
 }
 
 void QgsScrollArea::setVerticalOnly( bool verticalOnly )

--- a/src/gui/qgsscrollarea.cpp
+++ b/src/gui/qgsscrollarea.cpp
@@ -20,6 +20,11 @@
 #include <QMouseEvent>
 #include <QScrollBar>
 #include <QAbstractItemView>
+#include <QComboBox>
+#include <QAbstractSpinBox>
+#include <QAbstractButton>
+#include <QAbstractSlider>
+#include <QDateTimeEdit>
 
 // milliseconds to swallow child wheel events for after a scroll occurs
 constexpr qint64 TIMEOUT = 1000;
@@ -125,7 +130,11 @@ bool ScrollAreaFilter::eventFilter( QObject *obj, QEvent *event )
         // scrolling scroll area - kick off the timer to block wheel events in children
         mScrollAreaWidget->scrollOccurred();
       }
-      else
+      else if ( qobject_cast< QComboBox * >( obj )
+                || qobject_cast< QAbstractSpinBox * >( obj )
+                || qobject_cast< QAbstractButton *>( obj )
+                || qobject_cast< QAbstractSlider *>( obj )
+                || qobject_cast< QDateTimeEdit * >( obj ) )
       {
         if ( mScrollAreaWidget->hasScrolled() )
         {

--- a/src/gui/qgsscrollarea.h
+++ b/src/gui/qgsscrollarea.h
@@ -19,7 +19,7 @@
 #include <QScrollArea>
 #include "qgis_sip.h"
 #include "qgis_gui.h"
-#include <QTimer>
+#include <QElapsedTimer>
 class ScrollAreaFilter;
 
 /**
@@ -81,7 +81,8 @@ class GUI_EXPORT QgsScrollArea : public QScrollArea
     void resizeEvent( QResizeEvent *event ) override;
 
   private:
-    QTimer mTimer;
+    bool mTimerActive = false;
+    QElapsedTimer mTimer;
     ScrollAreaFilter *mFilter = nullptr;
     bool mVerticalOnly = false;
 };


### PR DESCRIPTION
Fixes QgsScrollArea to use a blocklist of widgets to "freeze" while scrolling is occurring, instead of blocking everything
except the scroll area viewport.

I'm actually unsure how this was working on qt5, as on qt6 the events are getting swallowed before they bubble up to the scroll area viewport, so everything is triggering the freeze and ignoring wheel events occurring within 1 second of each other.