### PR TITLE
Avoid corrupted overlapping docks when first changing from dialog to dock

### DIFF
--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -478,7 +478,7 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
   } );
   setLayout( layout );
 
-  mDockableWidgetHelper = new QgsDockableWidgetHelper( mCanvasName, this, QgisApp::instance(), mCanvasName, QStringList(), QgsDockableWidgetHelper::OpeningMode::RespectSetting, false, Qt::DockWidgetArea::BottomDockWidgetArea, QgsDockableWidgetHelper::Option::RaiseTab );
+  mDockableWidgetHelper = new QgsDockableWidgetHelper( mCanvasName, this, QgisApp::instance(), mCanvasName, QStringList(), QgsDockableWidgetHelper::OpeningMode::RespectSetting, true, Qt::DockWidgetArea::BottomDockWidgetArea, QgsDockableWidgetHelper::Option::RaiseTab );
 
   QToolButton *toggleButton = mDockableWidgetHelper->createDockUndockToolButton();
   toggleButton->setToolTip( tr( "Dock Elevation Profile View" ) );

--- a/src/gui/qgsdockablewidgethelper.cpp
+++ b/src/gui/qgsdockablewidgethelper.cpp
@@ -428,7 +428,7 @@ void QgsDockableWidgetHelper::setupDockWidget( const QStringList &tabSiblings )
   QMetaObject::invokeMethod( mDock, [this] {
     if (mIsDockFloating && sSettingsDockGeometry->exists( mSettingKeyDockId ) )
         mDock->restoreGeometry( sSettingsDockGeometry->value( mSettingKeyDockId ).toByteArray() );
-    else
+    else if ( mIsDockFloating )
       mDock->setGeometry( mDockGeometry ); }, Qt::QueuedConnection );
 }
 


### PR DESCRIPTION
Fixes this:

https://github.com/user-attachments/assets/8a2fd06f-ebe8-4808-80c1-3d82d5c0452a

I'm not sure what's changed which has caused this regression -- the git history doesn't explain it. I suspect a bug fix in Qt has impacted the existing code.

