### PR TITLE
[attribute table] Fix missing form feature context for editor widgets such as relation reference editor widget

### DIFF
--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -75,8 +75,9 @@ QWidget *QgsAttributeTableDelegate::createEditor( QWidget *parent, const QStyleO
   context.setFormFeature( vl->getFeature( fid ) );
 
   QgsEditorWidgetWrapper *eww = QgsGui::editorWidgetRegistry()->create( vl, fieldIdx, nullptr, parent, context );
-  QWidget *w = eww->widget();
+  eww->setFeature( context.formFeature() );
 
+  QWidget *w = eww->widget();
   w->setAutoFillBackground( true );
   w->setFocusPolicy( Qt::StrongFocus ); // to make sure QMouseEvents are propagated to the editor widget
 


### PR DESCRIPTION
## Description

The attribute table delegate in charge of creating editor widgets when editing an attribute cell didn't pass on the form feature to the editor widget wrapper, leading several editor widgets using current_* in their filtering expression to fail.