### PR TITLE
Cleanup geometry collection creation from wkt

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -380,10 +380,6 @@ Returns whether child type names are omitted from Wkt representations of
 the collection
 %End
 
-    bool fromCollectionWkt( const QString &wkt, const QVector<QgsAbstractGeometry *> &subtypes, const QString &defaultChildWkbType = QString() );
-%Docstring
-Reads a collection from a WKT string.
-%End
 
     virtual QgsBox3D calculateBoundingBox3D() const;
 

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -380,10 +380,6 @@ Returns whether child type names are omitted from Wkt representations of
 the collection
 %End
 
-    bool fromCollectionWkt( const QString &wkt, const QVector<QgsAbstractGeometry *> &subtypes, const QString &defaultChildWkbType = QString() );
-%Docstring
-Reads a collection from a WKT string.
-%End
 
     virtual QgsBox3D calculateBoundingBox3D() const;
 

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -18,17 +18,11 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgsbox3d.h"
 #include "qgsgeometryfactory.h"
 #include "qgsgeometryutils.h"
-#include "qgscircularstring.h"
-#include "qgscompoundcurve.h"
 #include "qgslinestring.h"
 #include "qgsmultilinestring.h"
 #include "qgspoint.h"
 #include "qgsmultipoint.h"
-#include "qgspolygon.h"
 #include "qgsmultipolygon.h"
-#include "qgstriangle.h"
-#include "qgstriangulatedsurface.h"
-#include "qgspolyhedralsurface.h"
 #include "qgswkbptr.h"
 #include "qgsgeos.h"
 #include "qgsfeedback.h"
@@ -385,15 +379,22 @@ bool QgsGeometryCollection::fromWkb( QgsConstWkbPtr &wkbPtr )
 
 bool QgsGeometryCollection::fromWkt( const QString &wkt )
 {
-  return fromCollectionWkt( wkt, QVector<QgsAbstractGeometry *>() << new QgsPoint << new QgsLineString << new QgsPolygon //
-                            << new QgsCircularString << new QgsCompoundCurve       //
-                            << new QgsCurvePolygon                                 //
-                            << new QgsMultiPoint << new QgsMultiLineString         //
-                            << new QgsMultiPolygon << new QgsGeometryCollection    //
-                            << new QgsMultiCurve << new QgsMultiSurface            //
-                            << new QgsTriangle << new QgsPolyhedralSurface         //
-                            << new QgsTriangulatedSurface                          //
-                            ,
+  return fromCollectionWkt( wkt, { Qgis::WkbType::Point,
+                                   Qgis::WkbType::LineString,
+                                   Qgis::WkbType::Polygon,
+                                   Qgis::WkbType::CircularString,
+                                   Qgis::WkbType::CompoundCurve,
+                                   Qgis::WkbType::CurvePolygon,
+                                   Qgis::WkbType::MultiPoint,
+                                   Qgis::WkbType::MultiLineString,
+                                   Qgis::WkbType::MultiPolygon,
+                                   Qgis::WkbType::GeometryCollection,
+                                   Qgis::WkbType::MultiCurve,
+                                   Qgis::WkbType::MultiSurface,
+                                   Qgis::WkbType::Triangle,
+                                   Qgis::WkbType::PolyhedralSurface,
+                                   Qgis::WkbType::TIN
+                                 },
                             QStringLiteral( "GeometryCollection" ) );
 }
 
@@ -710,7 +711,7 @@ double QgsGeometryCollection::perimeter() const
   return perimeter;
 }
 
-bool QgsGeometryCollection::fromCollectionWkt( const QString &wkt, const QVector<QgsAbstractGeometry *> &subtypes, const QString &defaultChildWkbType )
+bool QgsGeometryCollection::fromCollectionWkt( const QString &wkt, const QVector<Qgis::WkbType> &subtypes, const QString &defaultChildWkbType )
 {
   clear();
 
@@ -718,7 +719,6 @@ bool QgsGeometryCollection::fromCollectionWkt( const QString &wkt, const QVector
 
   if ( QgsWkbTypes::flatType( parts.first ) != QgsWkbTypes::flatType( wkbType() ) )
   {
-    qDeleteAll( subtypes );
     return false;
   }
   mWkbType = parts.first;
@@ -728,7 +728,6 @@ bool QgsGeometryCollection::fromCollectionWkt( const QString &wkt, const QVector
   if ( ( parts.second.compare( QLatin1String( "EMPTY" ), Qt::CaseInsensitive ) == 0 ) ||
        secondWithoutParentheses.isEmpty() )
   {
-    qDeleteAll( subtypes );
     return true;
   }
 
@@ -740,11 +739,13 @@ bool QgsGeometryCollection::fromCollectionWkt( const QString &wkt, const QVector
     QPair<Qgis::WkbType, QString> childParts = QgsGeometryUtils::wktReadBlock( childWkt );
 
     bool success = false;
-    for ( const QgsAbstractGeometry *geom : subtypes )
+    for ( const Qgis::WkbType subtype : subtypes )
     {
-      if ( QgsWkbTypes::flatType( childParts.first ) == QgsWkbTypes::flatType( geom->wkbType() ) )
+      if ( QgsWkbTypes::flatType( childParts.first ) == QgsWkbTypes::flatType( subtype ) )
       {
-        mGeometries.append( geom->clone() );
+        mGeometries.append(
+          QgsGeometryFactory::geomFromWkbType( subtype ).release()
+        );
         if ( mGeometries.back()->fromWkt( childWkt ) )
         {
           success = true;
@@ -755,11 +756,9 @@ bool QgsGeometryCollection::fromCollectionWkt( const QString &wkt, const QVector
     if ( !success )
     {
       clear();
-      qDeleteAll( subtypes );
       return false;
     }
   }
-  qDeleteAll( subtypes );
 
   //scan through geometries and check if dimensionality of geometries is different to collection.
   //if so, update the type dimensionality of the collection to match

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -456,7 +456,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     /**
      * Reads a collection from a WKT string.
      */
-    bool fromCollectionWkt( const QString &wkt, const QVector<QgsAbstractGeometry *> &subtypes, const QString &defaultChildWkbType = QString() );
+    SIP_SKIP bool fromCollectionWkt( const QString &wkt, const QVector<Qgis::WkbType> &subtypes, const QString &defaultChildWkbType = QString() );
 
     QgsBox3D calculateBoundingBox3D() const override;
     void clearCache() const override;

--- a/src/core/geometry/qgsmulticurve.cpp
+++ b/src/core/geometry/qgsmulticurve.cpp
@@ -72,8 +72,8 @@ QgsMultiCurve *QgsMultiCurve::toCurveType() const
 bool QgsMultiCurve::fromWkt( const QString &wkt )
 {
   return fromCollectionWkt( wkt,
-                            QVector<QgsAbstractGeometry *>() << new QgsLineString << new QgsCircularString << new QgsCompoundCurve,
-                            QStringLiteral( "LineString" ) );
+  {Qgis::WkbType::LineString, Qgis::WkbType::CircularString, Qgis::WkbType::CompoundCurve },
+  QStringLiteral( "LineString" ) );
 }
 
 QDomElement QgsMultiCurve::asGml2( QDomDocument &doc, int precision, const QString &ns, const  AxisOrder axisOrder ) const

--- a/src/core/geometry/qgsmultilinestring.cpp
+++ b/src/core/geometry/qgsmultilinestring.cpp
@@ -15,10 +15,7 @@ email                : marco.hugentobler at sourcepole dot com
 
 #include "qgsmultilinestring.h"
 #include "qgsabstractgeometry.h"
-#include "qgsapplication.h"
 #include "qgscurve.h"
-#include "qgscircularstring.h"
-#include "qgscompoundcurve.h"
 #include "qgsgeometryutils.h"
 #include "qgslinestring.h"
 #include "qgsmulticurve.h"
@@ -94,7 +91,7 @@ void QgsMultiLineString::clear()
 
 bool QgsMultiLineString::fromWkt( const QString &wkt )
 {
-  return fromCollectionWkt( wkt, QVector<QgsAbstractGeometry *>() << new QgsLineString, QStringLiteral( "LineString" ) );
+  return fromCollectionWkt( wkt, {Qgis::WkbType::LineString }, QStringLiteral( "LineString" ) );
 }
 
 QDomElement QgsMultiLineString::asGml2( QDomDocument &doc, int precision, const QString &ns, const AxisOrder axisOrder ) const

--- a/src/core/geometry/qgsmultipoint.cpp
+++ b/src/core/geometry/qgsmultipoint.cpp
@@ -14,10 +14,8 @@ email                : marco.hugentobler at sourcepole dot com
  ***************************************************************************/
 
 #include "qgsmultipoint.h"
-#include "qgsapplication.h"
-#include "qgsgeometryutils.h"
 #include "qgspoint.h"
-#include "qgswkbptr.h"
+#include "qgsvertexid.h"
 
 #include <QJsonArray>
 #include <QJsonObject>
@@ -152,7 +150,7 @@ bool QgsMultiPoint::fromWkt( const QString &wkt )
     collectionWkt.replace( '(', QLatin1String( "((" ) ).replace( ')', QLatin1String( "))" ) ).replace( ',', QLatin1String( "),(" ) );
   }
 
-  return fromCollectionWkt( collectionWkt, QVector<QgsAbstractGeometry *>() << new QgsPoint, QStringLiteral( "Point" ) );
+  return fromCollectionWkt( collectionWkt, { Qgis::WkbType::Point }, QStringLiteral( "Point" ) );
 }
 
 void QgsMultiPoint::clear()

--- a/src/core/geometry/qgsmultipolygon.cpp
+++ b/src/core/geometry/qgsmultipolygon.cpp
@@ -91,7 +91,7 @@ QgsMultiPolygon *QgsMultiPolygon::clone() const
 
 bool QgsMultiPolygon::fromWkt( const QString &wkt )
 {
-  return fromCollectionWkt( wkt, QVector<QgsAbstractGeometry *>() << new QgsPolygon, QStringLiteral( "Polygon" ) );
+  return fromCollectionWkt( wkt, { Qgis::WkbType::Polygon }, QStringLiteral( "Polygon" ) );
 }
 
 QDomElement QgsMultiPolygon::asGml2( QDomDocument &doc, int precision, const QString &ns, const AxisOrder axisOrder ) const

--- a/src/core/geometry/qgsmultisurface.cpp
+++ b/src/core/geometry/qgsmultisurface.cpp
@@ -71,8 +71,8 @@ QgsMultiSurface *QgsMultiSurface::toCurveType() const
 bool QgsMultiSurface::fromWkt( const QString &wkt )
 {
   return fromCollectionWkt( wkt,
-                            QVector<QgsAbstractGeometry *>() << new QgsPolygon << new QgsCurvePolygon,
-                            QStringLiteral( "Polygon" ) );
+  { Qgis::WkbType::Polygon, Qgis::WkbType::CurvePolygon },
+  QStringLiteral( "Polygon" ) );
 }
 
 QDomElement QgsMultiSurface::asGml2( QDomDocument &doc, int precision, const QString &ns, const AxisOrder axisOrder ) const


### PR DESCRIPTION
- don't create a whole set of empty possible geometries, just use wkb types directly
- don't expose to python -- this method is an internal detail. No-one has been relying on it, as calling it would have immediately crashed due to the missing SIP_TRANSFER annotation.
