### PR TITLE
When a project has a 3d basemap layer, hide globe terrain by default

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -4103,6 +4103,7 @@ FileOperationFlags = Qgis  # dirty hack since SIP seems to introduce the flags i
 # monkey patching scoped based enum
 Qgis.MapLayerProperty.UsersCannotToggleEditing.__doc__ = "Indicates that users are not allowed to toggle editing for this layer. Note that this does not imply that the layer is non-editable (see isEditable(), supportsEditing() ), rather that the editable status of the layer cannot be changed by users manually \n.. versionadded:: 3.22"
 Qgis.MapLayerProperty.IsBasemapLayer.__doc__ = "Layer is considered a 'basemap' layer, and certain properties of the layer should be ignored when calculating project-level properties. For instance, the extent of basemap layers is ignored when calculating the extent of a project, as these layers are typically global and extend outside of a project's area of interest \n.. versionadded:: 3.26"
+Qgis.MapLayerProperty.Is3DBasemapLayer.__doc__ = "Layer is considered a '3D basemap' layer. This flag is similar to IsBasemapLayer, but reserved for layers which contain 3D data \n.. versionadded:: 3.44"
 Qgis.MapLayerProperty.__doc__ = """Generic map layer properties.
 
 .. versionadded:: 3.22
@@ -4114,6 +4115,10 @@ Qgis.MapLayerProperty.__doc__ = """Generic map layer properties.
 * ``IsBasemapLayer``: Layer is considered a 'basemap' layer, and certain properties of the layer should be ignored when calculating project-level properties. For instance, the extent of basemap layers is ignored when calculating the extent of a project, as these layers are typically global and extend outside of a project's area of interest
 
   .. versionadded:: 3.26
+
+* ``Is3DBasemapLayer``: Layer is considered a '3D basemap' layer. This flag is similar to IsBasemapLayer, but reserved for layers which contain 3D data
+
+  .. versionadded:: 3.44
 
 
 """
@@ -4141,6 +4146,7 @@ Qgis.AutoRefreshMode.baseClass = Qgis
 Qgis.DataProviderFlag.IsBasemapSource.__doc__ = "Associated source should be considered a 'basemap' layer. See Qgis.MapLayerProperty.IsBasemapLayer."
 Qgis.DataProviderFlag.FastExtent2D.__doc__ = "Provider's 2D extent retrieval via QgsDataProvider.extent() is always guaranteed to be trivial/fast to calculate \n.. versionadded:: 3.38"
 Qgis.DataProviderFlag.FastExtent3D.__doc__ = "Provider's 3D extent retrieval via QgsDataProvider.extent3D() is always guaranteed to be trivial/fast to calculate \n.. versionadded:: 3.38"
+Qgis.DataProviderFlag.Is3DBasemapSource.__doc__ = "Associated source should be considered a '3D basemap' layer. See Qgis.MapLayerProperty.Is3DBasemapLayer. \n.. versionadded:: 3.44"
 Qgis.DataProviderFlag.__doc__ = """Generic data provider flags.
 
 .. versionadded:: 3.26
@@ -4153,6 +4159,10 @@ Qgis.DataProviderFlag.__doc__ = """Generic data provider flags.
 * ``FastExtent3D``: Provider's 3D extent retrieval via QgsDataProvider.extent3D() is always guaranteed to be trivial/fast to calculate
 
   .. versionadded:: 3.38
+
+* ``Is3DBasemapSource``: Associated source should be considered a '3D basemap' layer. See Qgis.MapLayerProperty.Is3DBasemapLayer.
+
+  .. versionadded:: 3.44
 
 
 """

--- a/python/PyQt6/core/auto_additions/qgstiledscenelayer.py
+++ b/python/PyQt6/core/auto_additions/qgstiledscenelayer.py
@@ -8,7 +8,7 @@ except (NameError, AttributeError):
     pass
 try:
     QgsTiledSceneLayer.__virtual_methods__ = ['readStyle', 'writeStyle', 'loadDefaultStyle']
-    QgsTiledSceneLayer.__overridden_methods__ = ['clone', 'extent', 'dataProvider', 'readXml', 'writeXml', 'readSymbology', 'writeSymbology', 'setTransformContext', 'encodedSource', 'decodedSource', 'htmlMetadata', 'createMapRenderer', 'loadDefaultMetadata', 'elevationProperties']
+    QgsTiledSceneLayer.__overridden_methods__ = ['clone', 'extent', 'dataProvider', 'readXml', 'writeXml', 'readSymbology', 'writeSymbology', 'setTransformContext', 'encodedSource', 'decodedSource', 'htmlMetadata', 'createMapRenderer', 'loadDefaultMetadata', 'elevationProperties', 'properties']
     QgsTiledSceneLayer.__group__ = ['tiledscene']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1302,6 +1302,7 @@ The development version
     {
       UsersCannotToggleEditing,
       IsBasemapLayer,
+      Is3DBasemapLayer,
     };
     typedef QFlags<Qgis::MapLayerProperty> MapLayerProperties;
 
@@ -1318,6 +1319,7 @@ The development version
       IsBasemapSource,
       FastExtent2D,
       FastExtent3D,
+      Is3DBasemapSource,
     };
     typedef QFlags<Qgis::DataProviderFlag> DataProviderFlags;
 

--- a/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenelayer.sip.in
+++ b/python/PyQt6/core/auto_generated/tiledscene/qgstiledscenelayer.sip.in
@@ -89,6 +89,8 @@ Constructor for QgsTiledSceneLayer.
 
     virtual QgsMapLayerElevationProperties *elevationProperties();
 
+    virtual Qgis::MapLayerProperties properties() const;
+
 
     QgsTiledSceneRenderer *renderer();
 %Docstring

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -4061,6 +4061,7 @@ FileOperationFlags = Qgis  # dirty hack since SIP seems to introduce the flags i
 # monkey patching scoped based enum
 Qgis.MapLayerProperty.UsersCannotToggleEditing.__doc__ = "Indicates that users are not allowed to toggle editing for this layer. Note that this does not imply that the layer is non-editable (see isEditable(), supportsEditing() ), rather that the editable status of the layer cannot be changed by users manually \n.. versionadded:: 3.22"
 Qgis.MapLayerProperty.IsBasemapLayer.__doc__ = "Layer is considered a 'basemap' layer, and certain properties of the layer should be ignored when calculating project-level properties. For instance, the extent of basemap layers is ignored when calculating the extent of a project, as these layers are typically global and extend outside of a project's area of interest \n.. versionadded:: 3.26"
+Qgis.MapLayerProperty.Is3DBasemapLayer.__doc__ = "Layer is considered a '3D basemap' layer. This flag is similar to IsBasemapLayer, but reserved for layers which contain 3D data \n.. versionadded:: 3.44"
 Qgis.MapLayerProperty.__doc__ = """Generic map layer properties.
 
 .. versionadded:: 3.22
@@ -4072,6 +4073,10 @@ Qgis.MapLayerProperty.__doc__ = """Generic map layer properties.
 * ``IsBasemapLayer``: Layer is considered a 'basemap' layer, and certain properties of the layer should be ignored when calculating project-level properties. For instance, the extent of basemap layers is ignored when calculating the extent of a project, as these layers are typically global and extend outside of a project's area of interest
 
   .. versionadded:: 3.26
+
+* ``Is3DBasemapLayer``: Layer is considered a '3D basemap' layer. This flag is similar to IsBasemapLayer, but reserved for layers which contain 3D data
+
+  .. versionadded:: 3.44
 
 
 """
@@ -4098,6 +4103,7 @@ Qgis.AutoRefreshMode.baseClass = Qgis
 Qgis.DataProviderFlag.IsBasemapSource.__doc__ = "Associated source should be considered a 'basemap' layer. See Qgis.MapLayerProperty.IsBasemapLayer."
 Qgis.DataProviderFlag.FastExtent2D.__doc__ = "Provider's 2D extent retrieval via QgsDataProvider.extent() is always guaranteed to be trivial/fast to calculate \n.. versionadded:: 3.38"
 Qgis.DataProviderFlag.FastExtent3D.__doc__ = "Provider's 3D extent retrieval via QgsDataProvider.extent3D() is always guaranteed to be trivial/fast to calculate \n.. versionadded:: 3.38"
+Qgis.DataProviderFlag.Is3DBasemapSource.__doc__ = "Associated source should be considered a '3D basemap' layer. See Qgis.MapLayerProperty.Is3DBasemapLayer. \n.. versionadded:: 3.44"
 Qgis.DataProviderFlag.__doc__ = """Generic data provider flags.
 
 .. versionadded:: 3.26
@@ -4110,6 +4116,10 @@ Qgis.DataProviderFlag.__doc__ = """Generic data provider flags.
 * ``FastExtent3D``: Provider's 3D extent retrieval via QgsDataProvider.extent3D() is always guaranteed to be trivial/fast to calculate
 
   .. versionadded:: 3.38
+
+* ``Is3DBasemapSource``: Associated source should be considered a '3D basemap' layer. See Qgis.MapLayerProperty.Is3DBasemapLayer.
+
+  .. versionadded:: 3.44
 
 
 """

--- a/python/core/auto_additions/qgstiledscenelayer.py
+++ b/python/core/auto_additions/qgstiledscenelayer.py
@@ -8,7 +8,7 @@ except (NameError, AttributeError):
     pass
 try:
     QgsTiledSceneLayer.__virtual_methods__ = ['readStyle', 'writeStyle', 'loadDefaultStyle']
-    QgsTiledSceneLayer.__overridden_methods__ = ['clone', 'extent', 'dataProvider', 'readXml', 'writeXml', 'readSymbology', 'writeSymbology', 'setTransformContext', 'encodedSource', 'decodedSource', 'htmlMetadata', 'createMapRenderer', 'loadDefaultMetadata', 'elevationProperties']
+    QgsTiledSceneLayer.__overridden_methods__ = ['clone', 'extent', 'dataProvider', 'readXml', 'writeXml', 'readSymbology', 'writeSymbology', 'setTransformContext', 'encodedSource', 'decodedSource', 'htmlMetadata', 'createMapRenderer', 'loadDefaultMetadata', 'elevationProperties', 'properties']
     QgsTiledSceneLayer.__group__ = ['tiledscene']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -1302,6 +1302,7 @@ The development version
     {
       UsersCannotToggleEditing,
       IsBasemapLayer,
+      Is3DBasemapLayer,
     };
     typedef QFlags<Qgis::MapLayerProperty> MapLayerProperties;
 
@@ -1318,6 +1319,7 @@ The development version
       IsBasemapSource,
       FastExtent2D,
       FastExtent3D,
+      Is3DBasemapSource,
     };
     typedef QFlags<Qgis::DataProviderFlag> DataProviderFlags;
 

--- a/python/core/auto_generated/tiledscene/qgstiledscenelayer.sip.in
+++ b/python/core/auto_generated/tiledscene/qgstiledscenelayer.sip.in
@@ -89,6 +89,8 @@ Constructor for QgsTiledSceneLayer.
 
     virtual QgsMapLayerElevationProperties *elevationProperties();
 
+    virtual Qgis::MapLayerProperties properties() const;
+
 
     QgsTiledSceneRenderer *renderer();
 %Docstring

--- a/src/core/project/qgsprojectviewsettings.cpp
+++ b/src/core/project/qgsprojectviewsettings.cpp
@@ -89,7 +89,7 @@ QgsReferencedRectangle QgsProjectViewSettings::fullExtent() const
     QList< QgsMapLayer * > nonBaseMapLayers;
     std::copy_if( layers.begin(), layers.end(),
                   std::back_inserter( nonBaseMapLayers ),
-    []( const QgsMapLayer * layer ) { return !( layer->properties() & Qgis::MapLayerProperty::IsBasemapLayer ); } );
+    []( const QgsMapLayer * layer ) { return !( layer->properties() & Qgis::MapLayerProperty::IsBasemapLayer ) && !( layer->properties() & Qgis::MapLayerProperty::Is3DBasemapLayer ); } );
 
     // unless ALL layers from the project are basemap layers, we exclude these by default as their extent won't be useful for the project.
     if ( !nonBaseMapLayers.empty( ) )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2229,6 +2229,7 @@ class CORE_EXPORT Qgis
     {
       UsersCannotToggleEditing = 1 << 0, //!< Indicates that users are not allowed to toggle editing for this layer. Note that this does not imply that the layer is non-editable (see isEditable(), supportsEditing() ), rather that the editable status of the layer cannot be changed by users manually \since QGIS 3.22
       IsBasemapLayer = 1 << 1, //!< Layer is considered a 'basemap' layer, and certain properties of the layer should be ignored when calculating project-level properties. For instance, the extent of basemap layers is ignored when calculating the extent of a project, as these layers are typically global and extend outside of a project's area of interest \since QGIS 3.26
+      Is3DBasemapLayer = 1 << 2, //!< Layer is considered a '3D basemap' layer. This flag is similar to IsBasemapLayer, but reserved for layers which contain 3D data \since QGIS 3.44
     };
     //! Map layer properties
     Q_DECLARE_FLAGS( MapLayerProperties, MapLayerProperty )
@@ -2258,6 +2259,7 @@ class CORE_EXPORT Qgis
       IsBasemapSource = 1 << 1, //!< Associated source should be considered a 'basemap' layer. See Qgis::MapLayerProperty::IsBasemapLayer.
       FastExtent2D = 1 << 2, //!< Provider's 2D extent retrieval via QgsDataProvider::extent() is always guaranteed to be trivial/fast to calculate \since QGIS 3.38
       FastExtent3D = 1 << 3, //!< Provider's 3D extent retrieval via QgsDataProvider::extent3D() is always guaranteed to be trivial/fast to calculate \since QGIS 3.38
+      Is3DBasemapSource = 1 << 4, //!< Associated source should be considered a '3D basemap' layer. See Qgis::MapLayerProperty::Is3DBasemapLayer. \since QGIS 3.44
     };
     //! Data provider flags
     Q_DECLARE_FLAGS( DataProviderFlags, DataProviderFlag )

--- a/src/core/tiledscene/qgscesiumtilesdataprovider.h
+++ b/src/core/tiledscene/qgscesiumtilesdataprovider.h
@@ -72,6 +72,8 @@ class CORE_EXPORT QgsCesiumTilesDataProvider final: public QgsTiledSceneDataProv
 
     std::shared_ptr<QgsCesiumTilesDataProviderSharedData> mShared;  //!< Mutable data shared between provider instances
 
+    Qgis::DataProviderFlags mProviderFlags = Qgis::DataProviderFlag::FastExtent2D;
+
 };
 
 

--- a/src/core/tiledscene/qgstiledscenelayer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayer.cpp
@@ -115,6 +115,22 @@ QgsMapLayerElevationProperties *QgsTiledSceneLayer::elevationProperties()
   return mElevationProperties;
 }
 
+Qgis::MapLayerProperties QgsTiledSceneLayer::properties() const
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  Qgis::MapLayerProperties res;
+  if ( mDataProvider && ( mDataProvider->flags() & Qgis::DataProviderFlag::IsBasemapSource ) )
+  {
+    res |= Qgis::MapLayerProperty::IsBasemapLayer;
+  }
+  if ( mDataProvider && ( mDataProvider->flags() & Qgis::DataProviderFlag::Is3DBasemapSource ) )
+  {
+    res |= Qgis::MapLayerProperty::Is3DBasemapLayer;
+  }
+  return res;
+}
+
 QgsMapLayerRenderer *QgsTiledSceneLayer::createMapRenderer( QgsRenderContext &context )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS

--- a/src/core/tiledscene/qgstiledscenelayer.h
+++ b/src/core/tiledscene/qgstiledscenelayer.h
@@ -114,6 +114,7 @@ class CORE_EXPORT QgsTiledSceneLayer : public QgsMapLayer
     QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) override SIP_FACTORY;
     QString loadDefaultMetadata( bool &resultFlag SIP_OUT ) override;
     QgsMapLayerElevationProperties *elevationProperties() override;
+    Qgis::MapLayerProperties properties() const override;
 
     /**
      * Returns the 2D renderer for the tiled scene.


### PR DESCRIPTION
@wonder-sk @uclaros I'm interested in your thoughts on this approach -- the goal is to hide the terrain by default if the user has a layer like the Google 3D map tiles loaded.