### PR TITLE
QgsOptions: Locale value is saved only if it is not empty

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -1851,9 +1851,17 @@ void QgsOptions::saveOptions()
   //
   // Locale settings
   //
-  QgsApplication::settingsLocaleUserLocale->setValue( cboTranslation->currentData().toString() );
+  if ( grpLocale->isChecked() )
+  {
+    QString newLocale = cboTranslation->currentData().toString();
+    if ( !newLocale.isEmpty() )
+      QgsApplication::settingsLocaleUserLocale->setValue( newLocale );
+
+    QString newGlobalLocale = cboGlobalLocale->currentData().toString();
+    if ( !newGlobalLocale.isEmpty() )
+      QgsApplication::settingsLocaleGlobalLocale->setValue( newGlobalLocale );
+  }
   QgsApplication::settingsLocaleOverrideFlag->setValue( grpLocale->isChecked() );
-  QgsApplication::settingsLocaleGlobalLocale->setValue( cboGlobalLocale->currentData().toString() );
 
   // Number settings
   QgsApplication::settingsLocaleShowGroupSeparator->setValue( cbShowGroupSeparator->isChecked() );


### PR DESCRIPTION
## Description

Before this fix, QgsSettings().value("locale/userLocale") was cleared when one saved the options dialog without changing the locale, or even changed despite the override locale check box unchecked (see details below).

This is problematic for plugins accessing this setting value, which is no longer available then.

## Fix the locale being cleared

1. Execute the following command in the python console (example for a system configured in French)

```python
>>> QgsSettings().value("locale/userLocale")
'fr_FR'
```

2. Open the options dialog (`Settings` -> `Options...`), clic on `Ok` to save
3. Execute the same python command again, returns `None`

```python
>>> QgsSettings().value("locale/userLocale")

>>> QgsSettings().value("locale/userLocale") is None
True
```

## Fix the locale being changed

The locale is changed when

1. Open the options dialog (`Settings` -> `Options...`)
2. Check the `Override System Locale` group box
3. Choose a new locale (i.e. 'ar')
4. Uncheck the group box
5. Clic `Ok` to save
6. See that the new locale has been changed

```python
>>> QgsSettings().value("locale/userLocale")
'ar'
```