### PR TITLE
[GUI] Add missing creation options and values for CSV format in vectorfilewriter

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1216,6 +1216,13 @@ class QgsVectorFileWriterMetadataContainer
                              false  // Default value
                            ) );
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,12,0)
+      layerOptions.insert( QStringLiteral( "HEADER" ), new QgsVectorFileWriter::BoolOption(
+                             QObject::tr( "Whether to write a header line with the field names." ),
+                             true  // Default value
+                           ) );
+#endif
+
       driverMetadata.insert( QStringLiteral( "CSV" ),
                              QgsVectorFileWriter::MetaData(
                                QStringLiteral( "Comma Separated Value [CSV]" ),

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1194,7 +1194,8 @@ class QgsVectorFileWriterMetadataContainer
                              QStringList()
                              << QStringLiteral( "COMMA" )
                              << QStringLiteral( "SEMICOLON" )
-                             << QStringLiteral( "TAB" ),
+                             << QStringLiteral( "TAB" )
+                             << QStringLiteral( "SPACE" ),
                              QStringLiteral( "COMMA" ) // Default value
                            ) );
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1195,8 +1195,11 @@ class QgsVectorFileWriterMetadataContainer
                              << QStringLiteral( "COMMA" )
                              << QStringLiteral( "SEMICOLON" )
                              << QStringLiteral( "TAB" )
-                             << QStringLiteral( "SPACE" ),
-                             QStringLiteral( "COMMA" ) // Default value
+                             << QStringLiteral( "SPACE" )
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,12,0)
+                             << QStringLiteral( "PIPE" )
+#endif
+                             , QStringLiteral( "COMMA" ) // Default value
                            ) );
 
       layerOptions.insert( QStringLiteral( "STRING_QUOTING" ), new QgsVectorFileWriter::SetOption(

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1177,6 +1177,11 @@ class QgsVectorFileWriterMetadataContainer
                              true // Allow None
                            ) );
 
+      layerOptions.insert( QStringLiteral( "GEOMETRY_NAME" ), new QgsVectorFileWriter::StringOption(
+                             QObject::tr( "Name of geometry column. Only used if GEOMETRY=AS_WKT. Defaults to 'WKT'." ),
+                             QStringLiteral( "WKT" )  // Default value
+                           ) );
+
       layerOptions.insert( QStringLiteral( "CREATE_CSVT" ), new QgsVectorFileWriter::BoolOption(
                              QObject::tr( "Create the associated .csvt file to describe the type of each "
                                           "column of the layer and its optional width and precision. "


### PR DESCRIPTION
## Description

Adds:
- the `GEOMETRY_NAME` creation option (defaults to `WKT`)
- the `SPACE` and `PIPE` (available since GDAL/OGR 3.12, see https://github.com/OSGeo/gdal/pull/12499) values for the `SEPARATOR` creation option
- the HEADER creation option (defaults to `YES`, available since GDAL/OGR 3.12, see https://github.com/OSGeo/gdal/pull/12504)

See https://gdal.org/en/latest/drivers/vector/csv.html#layer-creation-options.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
