### PR TITLE
Better logic for chancing from Categorized renderer to Rule based renderer

### DIFF
--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -1636,23 +1636,25 @@ QgsRuleBasedRenderer *QgsRuleBasedRenderer::convertFromRenderer( const QgsFeatur
       auto rule = std::make_unique< QgsRuleBasedRenderer::Rule >( nullptr );
 
       rule->setLabel( range.label() );
+      const QString upperValue = QString::number( range.upperValue(), 'f', 16 );
+      const QString lowerValue = QString::number( range.lowerValue(), 'f', 16 );
       // Lower and upper boundaries have to be open-ended
       if ( i == 0 )
       {
         expression = !isInverted ?
-                     QStringLiteral( "%1 <= %2" ).arg( attr, QString::number( range.upperValue(), 'f' ) ) :
-                     QStringLiteral( "%1 > %2" ).arg( attr, QString::number( range.lowerValue(), 'f' ) );
+                     QStringLiteral( "%1 <= %2" ).arg( attr, upperValue ) :
+                     QStringLiteral( "%1 > %2" ).arg( attr, lowerValue );
       }
       else if ( i == ranges.size() - 1 )
       {
         expression = !isInverted ?
-                     QStringLiteral( "%1 > %2" ).arg( attr, QString::number( range.lowerValue(), 'f' ) ) :
-                     QStringLiteral( "%1 <= %2" ).arg( attr, QString::number( range.upperValue(), 'f' ) );
+                     QStringLiteral( "%1 > %2" ).arg( attr, lowerValue ) :
+                     QStringLiteral( "%1 <= %2" ).arg( attr, upperValue );
       }
       else
       {
-        expression = attr + " > " + QString::number( range.lowerValue(), 'f' ) + " AND " + \
-                     attr + " <= " + QString::number( range.upperValue(), 'f' );
+        expression = attr + " > " + lowerValue + " AND " + \
+                     attr + " <= " + upperValue;
       }
       rule->setFilterExpression( expression );
 

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -978,9 +978,9 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       std::unique_ptr<QgsRuleBasedRenderer> r( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 3 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000 AND \"id\" <= 2.000000" );
-      QCOMPARE( r->rootRule()->children()[2]->filterExpression(), "\"id\" > 2.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.0000000000000000 AND \"id\" <= 2.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[2]->filterExpression(), "\"id\" > 2.0000000000000000" );
 
       // Next try the same with inverted ranges
       ranges.clear();
@@ -991,9 +991,9 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 3 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" > 2.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000 AND \"id\" <= 2.000000" );
-      QCOMPARE( r->rootRule()->children()[2]->filterExpression(), "\"id\" <= 1.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" > 2.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.0000000000000000 AND \"id\" <= 2.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[2]->filterExpression(), "\"id\" <= 1.0000000000000000" );
 
       // Next try with an expression based range
       ranges.clear();
@@ -1003,8 +1003,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(id / 2) <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(id / 2) > 1.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(id / 2) <= 1.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(id / 2) > 1.0000000000000000" );
 
       // Last try with an expression which is just a quoted field name
       ranges.clear();
@@ -1014,8 +1014,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.0000000000000000" );
 
       // Next try with a complex name
       ranges.clear();
@@ -1025,8 +1025,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"fa_cy-fie+ld\" <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"fa_cy-fie+ld\" > 1.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"fa_cy-fie+ld\" <= 1.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"fa_cy-fie+ld\" > 1.0000000000000000" );
     }
 
     void testConvertFromGraduatedRendererNoLayer()
@@ -1055,8 +1055,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       std::unique_ptr<QgsRuleBasedRenderer> r( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.0000000000000000" );
 
       // Next try with an expression based range
       ranges.clear();
@@ -1066,8 +1066,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(id / 2) <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(id / 2) > 1.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(id / 2) <= 1.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(id / 2) > 1.0000000000000000" );
 
       // Last try with an expression which is just a quoted field name
       ranges.clear();
@@ -1077,8 +1077,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.0000000000000000" );
 
       // Next try with a complex name -- in this case since we don't have a layer or
       // actual field names available, we must assume the complex field name is actually an expression
@@ -1089,8 +1089,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(fa_cy-fie+ld) <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(fa_cy-fie+ld) > 1.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(fa_cy-fie+ld) <= 1.0000000000000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(fa_cy-fie+ld) > 1.0000000000000000" );
     }
 
     void testConvertFromEmbedded()

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -973,12 +973,27 @@ class TestQgsRuleBasedRenderer : public QgsTest
       QList<QgsRendererRange> ranges;
       ranges.append( QgsRendererRange( 0, 1, new QgsMarkerSymbol(), "0-1" ) );
       ranges.append( QgsRendererRange( 1, 2, new QgsMarkerSymbol(), "1-2" ) );
+      ranges.append( QgsRendererRange( 2, 3, new QgsMarkerSymbol(), "2-3" ) );
       auto c = std::make_unique<QgsGraduatedSymbolRenderer>( "id", ranges );
 
       std::unique_ptr<QgsRuleBasedRenderer> r( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
-      QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" >= 0.000000 AND \"id\" <= 1.000000" );
+      QCOMPARE( r->rootRule()->children().size(), 3 );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.000000" );
       QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000 AND \"id\" <= 2.000000" );
+      QCOMPARE( r->rootRule()->children()[2]->filterExpression(), "\"id\" > 2.000000" );
+
+      // Next try the same with inverted ranges
+      ranges.clear();
+      ranges.append( QgsRendererRange( 2, 3, new QgsMarkerSymbol(), "2-3" ) );
+      ranges.append( QgsRendererRange( 1, 2, new QgsMarkerSymbol(), "1-2" ) );
+      ranges.append( QgsRendererRange( 0, 1, new QgsMarkerSymbol(), "0-1" ) );
+      c = std::make_unique<QgsGraduatedSymbolRenderer>( "id", ranges );
+
+      r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
+      QCOMPARE( r->rootRule()->children().size(), 3 );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" > 2.000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000 AND \"id\" <= 2.000000" );
+      QCOMPARE( r->rootRule()->children()[2]->filterExpression(), "\"id\" <= 1.000000" );
 
       // Next try with an expression based range
       ranges.clear();
@@ -988,8 +1003,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(id / 2) >= 0.000000 AND (id / 2) <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(id / 2) > 1.000000 AND (id / 2) <= 2.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(id / 2) <= 1.000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(id / 2) > 1.000000" );
 
       // Last try with an expression which is just a quoted field name
       ranges.clear();
@@ -999,8 +1014,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" >= 0.000000 AND \"id\" <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000 AND \"id\" <= 2.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000" );
 
       // Next try with a complex name
       ranges.clear();
@@ -1010,8 +1025,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get(), layer.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"fa_cy-fie+ld\" >= 0.000000 AND \"fa_cy-fie+ld\" <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"fa_cy-fie+ld\" > 1.000000 AND \"fa_cy-fie+ld\" <= 2.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"fa_cy-fie+ld\" <= 1.000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"fa_cy-fie+ld\" > 1.000000" );
     }
 
     void testConvertFromGraduatedRendererNoLayer()
@@ -1040,8 +1055,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       std::unique_ptr<QgsRuleBasedRenderer> r( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" >= 0.000000 AND \"id\" <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000 AND \"id\" <= 2.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000" );
 
       // Next try with an expression based range
       ranges.clear();
@@ -1051,8 +1066,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(id / 2) >= 0.000000 AND (id / 2) <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(id / 2) > 1.000000 AND (id / 2) <= 2.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(id / 2) <= 1.000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(id / 2) > 1.000000" );
 
       // Last try with an expression which is just a quoted field name
       ranges.clear();
@@ -1062,8 +1077,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" >= 0.000000 AND \"id\" <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000 AND \"id\" <= 2.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "\"id\" <= 1.000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "\"id\" > 1.000000" );
 
       // Next try with a complex name -- in this case since we don't have a layer or
       // actual field names available, we must assume the complex field name is actually an expression
@@ -1074,8 +1089,8 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
       r.reset( QgsRuleBasedRenderer::convertFromRenderer( c.get() ) );
       QCOMPARE( r->rootRule()->children().size(), 2 );
-      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(fa_cy-fie+ld) >= 0.000000 AND (fa_cy-fie+ld) <= 1.000000" );
-      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(fa_cy-fie+ld) > 1.000000 AND (fa_cy-fie+ld) <= 2.000000" );
+      QCOMPARE( r->rootRule()->children()[0]->filterExpression(), "(fa_cy-fie+ld) <= 1.000000" );
+      QCOMPARE( r->rootRule()->children()[1]->filterExpression(), "(fa_cy-fie+ld) > 1.000000" );
     }
 
     void testConvertFromEmbedded()


### PR DESCRIPTION
## Description

This PR improves chancing from Categorized renderer to Rule based renderer by:
- Chancing lower and upper boundaries open-ended since it does not really make sense to use closed ends here since nature of the graduated renderer is to include all values
- Using better floating point precision for values

Fixes #59410

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
