### PR TITLE
Correct extent on layer while editing

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1034,6 +1034,10 @@ QgsRectangle QgsVectorLayer::extent() const
   if ( !isSpatial() )
     return rect;
 
+  // Don't do lazy extent if the layer is currently in edit mode
+  if ( mLazyExtent2D && isEditable() )
+    mLazyExtent2D = false;
+
   if ( mDataProvider && mDataProvider->isValid() && ( mDataProvider->flags() & Qgis::DataProviderFlag::FastExtent2D ) )
   {
     // Provider has a trivial 2D extent calculation => always get extent from provider.

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -811,6 +811,14 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
         checkAfter()
         self.assertEqual(layer.dataProvider().featureCount(), 1)
 
+        # now start from an empty layer and check extent after adding the first feature
+        layer = createEmptyLayerWithFields()
+        feat = QgsFeature(layer.fields())
+        feat.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(1, 2)))
+        layer.startEditing()
+        self.assertTrue(layer.addFeature(feat))
+        checkAfter()
+
     # ADD FEATURES
 
     def test_AddFeatures(self):


### PR DESCRIPTION
## Description

Fixes #60830

When `QgsVectorLayer::extent()` is called the first time, it is always called in a "lazy" mode which gets the extent from the data provider.

For a layer of any type (memory, gpkg...) modifying features and then calling `extent()`
-  gives a Null extent if this is the first call to `extent()` and the layer was empty
-  gives the old extent (the extent before any modification) if this is the first call to `extent()` and the layer was not empty
-  gives the correct extent if this is not the first call to `extent()` [1]

This PR proposes to set lazy mode to `false` if the layer is editable.

---

[1] i.e. the user has consulted the layer properties, or the layer is the first layer to be added to the project...

