### PR TITLE
[fix] Update Processing toolbox search after updating the provider list

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgsprocessingtoolboxtreeview.py
+++ b/python/PyQt6/gui/auto_additions/qgsprocessingtoolboxtreeview.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/gui/processing/qgsprocessingtoolboxtreeview.h
 try:
-    QgsProcessingToolboxTreeView.__overridden_methods__ = ['keyPressEvent']
+    QgsProcessingToolboxTreeView.__overridden_methods__ = ['reset', 'keyPressEvent']
     QgsProcessingToolboxTreeView.__group__ = ['processing']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingtoolboxtreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingtoolboxtreeview.sip.in
@@ -124,6 +124,12 @@ Sets a ``filter`` string, used to filter out the contents of the view to
 matching algorithms.
 %End
 
+    virtual void reset();
+
+%Docstring
+Expands the tree view if a filter string is set after the view is reset.
+%End
+
   protected:
     virtual void keyPressEvent( QKeyEvent *event );
 

--- a/python/gui/auto_additions/qgsprocessingtoolboxtreeview.py
+++ b/python/gui/auto_additions/qgsprocessingtoolboxtreeview.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/gui/processing/qgsprocessingtoolboxtreeview.h
 try:
-    QgsProcessingToolboxTreeView.__overridden_methods__ = ['keyPressEvent']
+    QgsProcessingToolboxTreeView.__overridden_methods__ = ['reset', 'keyPressEvent']
     QgsProcessingToolboxTreeView.__group__ = ['processing']
 except (NameError, AttributeError):
     pass

--- a/python/gui/auto_generated/processing/qgsprocessingtoolboxtreeview.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingtoolboxtreeview.sip.in
@@ -124,6 +124,12 @@ Sets a ``filter`` string, used to filter out the contents of the view to
 matching algorithms.
 %End
 
+    virtual void reset();
+
+%Docstring
+Expands the tree view if a filter string is set after the view is reset.
+%End
+
   protected:
     virtual void keyPressEvent( QKeyEvent *event );
 

--- a/src/gui/processing/qgsprocessingtoolboxtreeview.cpp
+++ b/src/gui/processing/qgsprocessingtoolboxtreeview.cpp
@@ -67,6 +67,16 @@ void QgsProcessingToolboxTreeView::setFilterString( const QString &filter )
   }
 }
 
+void QgsProcessingToolboxTreeView::reset()
+{
+  QTreeView::reset();
+
+  if ( !mModel->filterString().isEmpty() )
+  {
+    expandAll();
+  }
+}
+
 const QgsProcessingAlgorithm *QgsProcessingToolboxTreeView::algorithmForIndex( const QModelIndex &index )
 {
   const QModelIndex sourceIndex = mModel->mapToSource( index );

--- a/src/gui/processing/qgsprocessingtoolboxtreeview.h
+++ b/src/gui/processing/qgsprocessingtoolboxtreeview.h
@@ -129,6 +129,11 @@ class GUI_EXPORT QgsProcessingToolboxTreeView : public QTreeView
      */
     void setFilterString( const QString &filter );
 
+    /**
+     * Expands the tree view if a filter string is set after the view is reset.
+     */
+    void reset() override;
+
   protected:
     void keyPressEvent( QKeyEvent *event ) override;
 


### PR DESCRIPTION
In other words, expand the Processing tree view when a provider has been added/removed and there is a filter string.

Fix #26435 