### PR TITLE
Don't finalize string stats after every value addition

### DIFF
--- a/src/core/qgsstringstatisticalsummary.cpp
+++ b/src/core/qgsstringstatisticalsummary.cpp
@@ -72,7 +72,6 @@ void QgsStringStatisticalSummary::addValue( const QVariant &value )
   {
     testString( value.toString() );
   }
-  finalize();
 }
 
 void QgsStringStatisticalSummary::finalize()


### PR DESCRIPTION
The docs explicitly state that finalize must be called MANUALLY once after all values have been added.

Avoids a bunch of needless calculations when adding many values for a string statistic calculation.

Fixes #62122
