### PR TITLE
Try to extract only polygons from Voronoi results

### DIFF
--- a/python/plugins/processing/tests/testdata/custom/voronoi_points_extent_clip.json
+++ b/python/plugins/processing/tests/testdata/custom/voronoi_points_extent_clip.json
@@ -1,0 +1,30 @@
+{
+"type": "FeatureCollection",
+"name": "SuspectPoints_20dp",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+"xy_coordinate_resolution": 1e-20,
+"features": [
+{ "type": "Feature", "properties": { "rownum": 1 }, "geometry": { "type": "Point", "coordinates": [ -4.06625270109031067278, 10.91291423849551200931 ] } },
+{ "type": "Feature", "properties": { "rownum": 2 }, "geometry": { "type": "Point", "coordinates": [ -4.0670860347665094281, 10.91291423849551200931 ] } },
+{ "type": "Feature", "properties": { "rownum": 3 }, "geometry": { "type": "Point", "coordinates": [ -4.06541936741411191747, 10.91291423849551200931 ] } },
+{ "type": "Feature", "properties": { "rownum": 4 }, "geometry": { "type": "Point", "coordinates": [ -4.06625270109031067278, 10.91458090611198095132 ] } },
+{ "type": "Feature", "properties": { "rownum": 5 }, "geometry": { "type": "Point", "coordinates": [ -4.06625270109031067278, 10.91374757230374648032 ] } },
+{ "type": "Feature", "properties": { "rownum": 6 }, "geometry": { "type": "Point", "coordinates": [ -4.06541936741411191747, 10.91374757230374648032 ] } },
+{ "type": "Feature", "properties": { "rownum": 7 }, "geometry": { "type": "Point", "coordinates": [ -4.06541936741411191747, 10.91458090611198095132 ] } },
+{ "type": "Feature", "properties": { "rownum": 8 }, "geometry": { "type": "Point", "coordinates": [ -4.06458603373791405033, 10.9124975715913947738 ] } },
+{ "type": "Feature", "properties": { "rownum": 9 }, "geometry": { "type": "Point", "coordinates": [ -4.06458603373791405033, 10.91374757230374648032 ] } },
+{ "type": "Feature", "properties": { "rownum": 10 }, "geometry": { "type": "Point", "coordinates": [ -4.06541936741411191747, 10.91083090397492405543 ] } },
+{ "type": "Feature", "properties": { "rownum": 11 }, "geometry": { "type": "Point", "coordinates": [ -4.06541936741411191747, 10.90958090326257234892 ] } },
+{ "type": "Feature", "properties": { "rownum": 12 }, "geometry": { "type": "Point", "coordinates": [ -4.06458603373791405033, 10.91124757087904129094 ] } },
+{ "type": "Feature", "properties": { "rownum": 13 }, "geometry": { "type": "Point", "coordinates": [ -4.06708603476650853992, 10.91208090468727576194 ] } },
+{ "type": "Feature", "properties": { "rownum": 14 }, "geometry": { "type": "Point", "coordinates": [ -4.06541936741411191747, 10.91208090468727576194 ] } },
+{ "type": "Feature", "properties": { "rownum": 15 }, "geometry": { "type": "Point", "coordinates": [ -4.0637527000617161832, 10.91208090468727576194 ] } },
+{ "type": "Feature", "properties": { "rownum": 16 }, "geometry": { "type": "Point", "coordinates": [ -4.06875270211890516237, 10.91291423849551023295 ] } },
+{ "type": "Feature", "properties": { "rownum": 17 }, "geometry": { "type": "Point", "coordinates": [ -4.06875270211890516237, 10.91208090468727576194 ] } },
+{ "type": "Feature", "properties": { "rownum": 18 }, "geometry": { "type": "Point", "coordinates": [ -4.0670860347665094281, 10.91374757230374648032 ] } },
+{ "type": "Feature", "properties": { "rownum": 19 }, "geometry": { "type": "Point", "coordinates": [ -4.06875270211890516237, 10.91374757230374648032 ] } },
+{ "type": "Feature", "properties": { "rownum": 20 }, "geometry": { "type": "Point", "coordinates": [ -4.0637527000617161832, 10.91124757087904129094 ] } },
+{ "type": "Feature", "properties": { "rownum": 21 }, "geometry": { "type": "Point", "coordinates": [ -4.0637527000617161832, 10.90958090326257234892 ] } },
+{ "type": "Feature", "properties": { "rownum": 22 }, "geometry": { "type": "Point", "coordinates": [ -4.0637527000617161832, 10.91041423707080681993 ] } }
+]
+}

--- a/python/plugins/processing/tests/testdata/expected/voronoi_polygons_extent_clip.gml
+++ b/python/plugins/processing/tests/testdata/expected/voronoi_polygons_extent_clip.gml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ voronoi_polygons_extent_clip.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9095809032626 -4.06875270211891</gml:lowerCorner><gml:upperCorner>10.914580906112 -4.06375270006172</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                 
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9095809032626 -4.06875270211891</gml:lowerCorner><gml:upperCorner>10.9124975715914 -4.06791936844271</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.0"><gml:exterior><gml:LinearRing><gml:posList>10.9095809032626 -4.06875270211891 10.9124975715914 -4.06875270211891 10.9124975715914 -4.06791936844271 10.9097197925827 -4.06791936844271 10.9095809032626 -4.06802353544931 10.9095809032626 -4.06875270211891</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>17</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9124975715914 -4.06791936844271</gml:lowerCorner><gml:upperCorner>10.9133309053996 -4.06666936792841</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.1"><gml:exterior><gml:LinearRing><gml:posList>10.9133309053996 -4.06791936844271 10.9133309053996 -4.06791936844271 10.9133309053996 -4.06666936792841 10.9124975715914 -4.06666936792841 10.9124975715914 -4.06791936844271 10.9133309053996 -4.06791936844271</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>2</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9095809032626 -4.06802353544931</gml:lowerCorner><gml:upperCorner>10.9102059036187 -4.06458603373791</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.2"><gml:exterior><gml:LinearRing><gml:posList>10.9095809032626 -4.06802353544931 10.9097197925827 -4.06791936844271 10.9102059036187 -4.06719020177311 10.9102059036187 -4.06469020048045 10.9099975701667 -4.06458603373791 10.9095809032626 -4.06458603373791 10.9095809032626 -4.06802353544931</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>11</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9124975715914 -4.06875270211891</gml:lowerCorner><gml:upperCorner>10.9133309053996 -4.06791936844271</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.3"><gml:exterior><gml:LinearRing><gml:posList>10.9133309053996 -4.06875270211891 10.9133309053996 -4.06791936844271 10.9124975715914 -4.06791936844271 10.9124975715914 -4.06875270211891 10.9133309053996 -4.06875270211891</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>16</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.4">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9133309053996 -4.06875270211891</gml:lowerCorner><gml:upperCorner>10.914580906112 -4.06791936844271</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.4"><gml:exterior><gml:LinearRing><gml:posList>10.914580906112 -4.06875270211891 10.914580906112 -4.06791936844271 10.9133309053996 -4.06791936844271 10.9133309053996 -4.06791936844271 10.9133309053996 -4.06875270211891 10.914580906112 -4.06875270211891</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>19</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.5">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9120809048193 -4.06666936792841</gml:lowerCorner><gml:upperCorner>10.9133309053996 -4.06583603425221</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.5"><gml:exterior><gml:LinearRing><gml:posList>10.9133309053996 -4.06666936792841 10.9133309053996 -4.06583603425221 10.9124975715914 -4.06583603425221 10.9120809048193 -4.06625270109031 10.9124975715914 -4.06666936792841 10.9133309053996 -4.06666936792841</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>1</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.6">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9097197925827 -4.06791936844271</gml:lowerCorner><gml:upperCorner>10.9124975715914 -4.06625270109031</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.6"><gml:exterior><gml:LinearRing><gml:posList>10.9120809048193 -4.06625270109031 10.9114559043311 -4.06625270109031 10.9102059036187 -4.06719020177311 10.9097197925827 -4.06791936844271 10.9124975715914 -4.06791936844271 10.9124975715914 -4.06666936792841 10.9120809048193 -4.06625270109031</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>13</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.7">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9141642392079 -4.06708603489855</gml:lowerCorner><gml:upperCorner>10.914580906112 -4.06583603425221</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.7"><gml:exterior><gml:LinearRing><gml:posList>10.914580906112 -4.06583603425221 10.9141642392079 -4.06583603425221 10.9141642392079 -4.06666936792841 10.914580906112 -4.06708603489855 10.914580906112 -4.06583603425221</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>4</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.8">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9133309053996 -4.06791936844271</gml:lowerCorner><gml:upperCorner>10.914580906112 -4.06666936792841</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.8"><gml:exterior><gml:LinearRing><gml:posList>10.914580906112 -4.06708603489855 10.9141642392079 -4.06666936792841 10.9133309053996 -4.06666936792841 10.9133309053996 -4.06791936844271 10.914580906112 -4.06791936844271 10.914580906112 -4.06708603489855</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>18</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.9">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9102059036187 -4.06719020177311</gml:lowerCorner><gml:upperCorner>10.9114559043311 -4.06465547818892</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.9"><gml:exterior><gml:LinearRing><gml:posList>10.9114559043311 -4.06625270109031 10.9114559043311 -4.06521103406108 10.9103447927628 -4.06465547818892 10.9102059036187 -4.06469020048045 10.9102059036187 -4.06719020177311 10.9114559043311 -4.06625270109031</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>10</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.10">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9133309053996 -4.06666936792841</gml:lowerCorner><gml:upperCorner>10.9141642392079 -4.06583603425221</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.10"><gml:exterior><gml:LinearRing><gml:posList>10.9141642392079 -4.06666936792841 10.9141642392079 -4.06583603425221 10.9133309053996 -4.06583603425221 10.9133309053996 -4.06666936792841 10.9141642392079 -4.06666936792841</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>5</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.11">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9114559043311 -4.06625270109031</gml:lowerCorner><gml:upperCorner>10.9124975715914 -4.06479436709094</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.11"><gml:exterior><gml:LinearRing><gml:posList>10.9120809048193 -4.06625270109031 10.9124975715914 -4.06583603425221 10.9124975715914 -4.06510686731855 10.9118725712352 -4.06479436709094 10.9114559043311 -4.06521103406108 10.9114559043311 -4.06625270109031 10.9120809048193 -4.06625270109031</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>14</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.12">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9133309053996 -4.06583603425221</gml:lowerCorner><gml:upperCorner>10.9141642392079 -4.06500270057601</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.12"><gml:exterior><gml:LinearRing><gml:posList>10.9141642392079 -4.06583603425221 10.9141642392079 -4.06500270057601 10.9133309053996 -4.06500270057601 10.9133309053996 -4.06583603425221 10.9141642392079 -4.06583603425221</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>6</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.13">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9099975701667 -4.06469020048045</gml:lowerCorner><gml:upperCorner>10.9108309039749 -4.06375270006172</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.13"><gml:exterior><gml:LinearRing><gml:posList>10.9099975701667 -4.06375270006172 10.9099975701667 -4.06458603373791 10.9102059036187 -4.06469020048045 10.9103447927628 -4.06465547818892 10.9108309039749 -4.06416936689982 10.9108309039749 -4.06375270006172 10.9099975701667 -4.06375270006172</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>22</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.14">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9124975715914 -4.06583603425221</gml:lowerCorner><gml:upperCorner>10.9133309053996 -4.06479436709095</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.14"><gml:exterior><gml:LinearRing><gml:posList>10.9133309053996 -4.06583603425221 10.9133309053996 -4.06500270057601 10.9131225719476 -4.06479436709095 10.9124975715914 -4.06510686731855 10.9124975715914 -4.06583603425221 10.9133309053996 -4.06583603425221</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>3</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.15">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9103447927628 -4.06521103406108</gml:lowerCorner><gml:upperCorner>10.9118725712352 -4.06416936689982</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.15"><gml:exterior><gml:LinearRing><gml:posList>10.9114559043311 -4.06521103406108 10.9118725712352 -4.06479436709094 10.9118725712352 -4.06437770038488 10.9116642377832 -4.06416936689982 10.9108309039749 -4.06416936689982 10.9103447927628 -4.06465547818892 10.9114559043311 -4.06521103406108</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>12</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.16">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9118725712352 -4.06510686731855</gml:lowerCorner><gml:upperCorner>10.9131225719476 -4.06375270006172</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.16"><gml:exterior><gml:LinearRing><gml:posList>10.9131225716835 -4.06375270006172 10.9118725712352 -4.06437770038488 10.9118725712352 -4.06479436709094 10.9124975715914 -4.06510686731855 10.9131225719476 -4.06479436709095 10.9131225719476 -4.06375270006172 10.9131225716835 -4.06375270006172</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>8</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.17">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9141642392079 -4.06583603425221</gml:lowerCorner><gml:upperCorner>10.914580906112 -4.06458603360588</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.17"><gml:exterior><gml:LinearRing><gml:posList>10.914580906112 -4.06458603360588 10.9141642392079 -4.06500270057601 10.9141642392079 -4.06583603425221 10.914580906112 -4.06583603425221 10.914580906112 -4.06458603360588</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>7</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.18">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9131225719476 -4.06500270057601</gml:lowerCorner><gml:upperCorner>10.914580906112 -4.06375270006172</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.18"><gml:exterior><gml:LinearRing><gml:posList>10.914580906112 -4.06375270006172 10.9131225719476 -4.06375270006172 10.9131225719476 -4.06479436709095 10.9133309053996 -4.06500270057601 10.9141642392079 -4.06500270057601 10.914580906112 -4.06458603360588 10.914580906112 -4.06375270006172</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>9</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.19">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9108309039749 -4.06416936689982</gml:lowerCorner><gml:upperCorner>10.9116642377832 -4.06375270006172</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.19"><gml:exterior><gml:LinearRing><gml:posList>10.9108309039749 -4.06375270006172 10.9108309039749 -4.06416936689982 10.9116642377832 -4.06416936689982 10.9116642377832 -4.06375270006172 10.9108309039749 -4.06375270006172</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>20</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.20">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9116642377832 -4.06437770038488</gml:lowerCorner><gml:upperCorner>10.9131225716835 -4.06375270006172</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.20"><gml:exterior><gml:LinearRing><gml:posList>10.9116642377832 -4.06375270006172 10.9116642377832 -4.06416936689982 10.9118725712352 -4.06437770038488 10.9131225716835 -4.06375270006172 10.9116642377832 -4.06375270006172</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>15</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:voronoi_polygons_extent_clip gml:id="voronoi_polygons_extent_clip.21">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>10.9095809032626 -4.06458603373791</gml:lowerCorner><gml:upperCorner>10.9099975701667 -4.06375270006172</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="voronoi_polygons_extent_clip.geom.21"><gml:exterior><gml:LinearRing><gml:posList>10.9095809032626 -4.06375270006172 10.9095809032626 -4.06458603373791 10.9099975701667 -4.06458603373791 10.9099975701667 -4.06375270006172 10.9095809032626 -4.06375270006172</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:rownum>21</ogr:rownum>
+    </ogr:voronoi_polygons_extent_clip>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/voronoi_polygons_extent_clip.xsd
+++ b/python/plugins/processing/tests/testdata/expected/voronoi_polygons_extent_clip.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="voronoi_polygons_extent_clip" type="ogr:voronoi_polygons_extent_clip_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="voronoi_polygons_extent_clip_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:SurfacePropertyType" nillable="true" minOccurs="0" maxOccurs="1"/> <!-- restricted to Polygon --><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="rownum" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
@@ -354,6 +354,25 @@ tests:
           geometry:
             precision: 2
 
+  - algorithm: native:voronoipolygons
+    name: Voronoi polygons, ensure filtering output to only polygon parts
+    params:
+      BUFFER: 0.0
+      COPY_ATTRIBUTES: true
+      INPUT:
+        name: custom/voronoi_points_extent_clip.json
+        type: vector
+      TOLERANCE: 0.0
+    results:
+      OUTPUT:
+        name: expected/voronoi_polygons_extent_clip.gml
+        type: vector
+        compare:
+          fields:
+            gml_id: skip
+          geometry:
+            precision: 2
+
   - algorithm: native:explodelines
     name: Explode lines
     params:

--- a/src/analysis/processing/qgsalgorithmvoronoipolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmvoronoipolygons.cpp
@@ -168,7 +168,8 @@ QString QgsVoronoiPolygonsAlgorithm::voronoiWithAttributes( const QVariantMap &p
     std::unique_ptr<QgsGeometryEngine> engine;
     std::unique_ptr<QgsGeometryEngine> extentEngine( QgsGeometry::createGeometryEngine( clippingGeom.constGet() ) );
     const QVector<QgsGeometry> collection = voronoiDiagram.asGeometryCollection();
-    for ( int i = 0; i < collection.length(); i++ )
+    int i = 0;
+    for ( const QgsGeometry &collectionPart : collection )
     {
       if ( feedback->isCanceled() )
       {
@@ -176,21 +177,28 @@ QString QgsVoronoiPolygonsAlgorithm::voronoiWithAttributes( const QVariantMap &p
       }
       QgsFeature f;
       f.setFields( fields );
-      f.setGeometry( QgsGeometry( extentEngine->intersection( collection[i].constGet() ) ) );
-      const QList<QgsFeatureId> intersected = index.intersects( collection[i].boundingBox() );
-      engine.reset( QgsGeometry::createGeometryEngine( collection[i].constGet() ) );
-      engine->prepareGeometry();
-      for ( const QgsFeatureId id : intersected )
+
+      QgsGeometry voronoiClippedToExtent = QgsGeometry( extentEngine->intersection( collectionPart.constGet() ) );
+      voronoiClippedToExtent.convertGeometryCollectionToSubclass( Qgis::GeometryType::Polygon );
+      if ( !voronoiClippedToExtent.isEmpty() )
       {
-        if ( engine->intersects( index.geometry( id ).constGet() ) )
+        f.setGeometry( QgsGeometry( voronoiClippedToExtent.constGet()->simplifiedTypeRef()->clone() ) );
+        const QList<QgsFeatureId> intersected = index.intersects( collectionPart.boundingBox() );
+        engine.reset( QgsGeometry::createGeometryEngine( collectionPart.constGet() ) );
+        engine->prepareGeometry();
+        for ( const QgsFeatureId id : intersected )
         {
-          f.setAttributes( attributeCache.value( id ) );
-          break;
+          if ( engine->intersects( index.geometry( id ).constGet() ) )
+          {
+            f.setAttributes( attributeCache.value( id ) );
+            break;
+          }
         }
+        if ( !sink->addFeature( f, QgsFeatureSink::FastInsert ) )
+          throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
       }
-      if ( !sink->addFeature( f, QgsFeatureSink::FastInsert ) )
-        throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QStringLiteral( "OUTPUT" ) ) );
       feedback->setProgress( 50 + i * step );
+      i++;
     }
   }
 


### PR DESCRIPTION
It can be that the intersection of the voronoi result with the extent geometry gives non polygon parts (eg lines), so filter those out before trying to add the feature to the output layer.

Fixes #62158
