### PR TITLE
Add option to load project extent when project is loaded

### DIFF
--- a/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -102,7 +102,7 @@ should be calculated based on the layers in the project.
 Sets whether the project's preset full extent should be restored when
 the project is loaded.
 
-.. versionadded:: 3.44
+.. versionadded:: 4.0
 %End
 
     bool mainCanvasOpensAtProjectExtent();
@@ -110,7 +110,7 @@ the project is loaded.
 Returns whether the project's preset full extent should be restored when
 the project is loaded.
 
-.. versionadded:: 3.44
+.. versionadded:: 4.0
 %End
 
     QgsReferencedRectangle fullExtent() const;

--- a/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -99,15 +99,15 @@ should be calculated based on the layers in the project.
 
     void setMainCanvasOpensAtProjectExtent( bool state );
 %Docstring
-Sets wheter the project's preset full extent should be loaded when the
-project is loaded.
+Sets whether the project's preset full extent should be restored when
+the project is loaded.
 
 .. versionadded:: 3.44
 %End
 
     bool mainCanvasOpensAtProjectExtent();
 %Docstring
-Returns wheter the project's preset full extent should be loaded when
+Returns whether the project's preset full extent should be restored when
 the project is loaded.
 
 .. versionadded:: 3.44

--- a/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -97,7 +97,7 @@ should be calculated based on the layers in the project.
 .. versionadded:: 3.18
 %End
 
-    void setCanvasUseProjectExtent( bool state );
+    void setMainCanvasOpensAtProjectExtent( bool state );
 %Docstring
 Sets wheter the project's preset full extent should be loaded when the
 project is loaded.
@@ -105,7 +105,7 @@ project is loaded.
 .. versionadded:: 3.44
 %End
 
-    bool canvasUseProjectExtent();
+    bool mainCanvasOpensAtProjectExtent();
 %Docstring
 Returns wheter the project's preset full extent should be loaded when
 the project is loaded.

--- a/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -105,7 +105,7 @@ the project is loaded.
 .. versionadded:: 4.0
 %End
 
-    bool mainCanvasOpensAtProjectExtent();
+    bool restoreProjectExtentOnProjectLoad();
 %Docstring
 Returns whether the project's preset full extent should be restored when
 the project is loaded.

--- a/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -97,7 +97,7 @@ should be calculated based on the layers in the project.
 .. versionadded:: 3.18
 %End
 
-    void setMainCanvasOpensAtProjectExtent( bool state );
+    void setRestoreProjectExtentOnProjectLoad( bool state );
 %Docstring
 Sets whether the project's preset full extent should be restored when
 the project is loaded.

--- a/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -97,6 +97,22 @@ should be calculated based on the layers in the project.
 .. versionadded:: 3.18
 %End
 
+    void setCanvasUseProjectExtent( bool state );
+%Docstring
+Sets wheter the project's preset full extent should be loaded when the
+project is loaded.
+
+.. versionadded:: 3.44
+%End
+
+    bool canvasUseProjectExtent();
+%Docstring
+Returns wheter the project's preset full extent should be loaded when
+the project is loaded.
+
+.. versionadded:: 3.44
+%End
+
     QgsReferencedRectangle fullExtent() const;
 %Docstring
 Returns the full extent of the project, which represents the maximal

--- a/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -102,7 +102,7 @@ should be calculated based on the layers in the project.
 Sets whether the project's preset full extent should be restored when
 the project is loaded.
 
-.. versionadded:: 3.44
+.. versionadded:: 4.0
 %End
 
     bool mainCanvasOpensAtProjectExtent();
@@ -110,7 +110,7 @@ the project is loaded.
 Returns whether the project's preset full extent should be restored when
 the project is loaded.
 
-.. versionadded:: 3.44
+.. versionadded:: 4.0
 %End
 
     QgsReferencedRectangle fullExtent() const;

--- a/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -99,15 +99,15 @@ should be calculated based on the layers in the project.
 
     void setMainCanvasOpensAtProjectExtent( bool state );
 %Docstring
-Sets wheter the project's preset full extent should be loaded when the
-project is loaded.
+Sets whether the project's preset full extent should be restored when
+the project is loaded.
 
 .. versionadded:: 3.44
 %End
 
     bool mainCanvasOpensAtProjectExtent();
 %Docstring
-Returns wheter the project's preset full extent should be loaded when
+Returns whether the project's preset full extent should be restored when
 the project is loaded.
 
 .. versionadded:: 3.44

--- a/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -97,7 +97,7 @@ should be calculated based on the layers in the project.
 .. versionadded:: 3.18
 %End
 
-    void setCanvasUseProjectExtent( bool state );
+    void setMainCanvasOpensAtProjectExtent( bool state );
 %Docstring
 Sets wheter the project's preset full extent should be loaded when the
 project is loaded.
@@ -105,7 +105,7 @@ project is loaded.
 .. versionadded:: 3.44
 %End
 
-    bool canvasUseProjectExtent();
+    bool mainCanvasOpensAtProjectExtent();
 %Docstring
 Returns wheter the project's preset full extent should be loaded when
 the project is loaded.

--- a/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -105,7 +105,7 @@ the project is loaded.
 .. versionadded:: 4.0
 %End
 
-    bool mainCanvasOpensAtProjectExtent();
+    bool restoreProjectExtentOnProjectLoad();
 %Docstring
 Returns whether the project's preset full extent should be restored when
 the project is loaded.

--- a/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -97,7 +97,7 @@ should be calculated based on the layers in the project.
 .. versionadded:: 3.18
 %End
 
-    void setMainCanvasOpensAtProjectExtent( bool state );
+    void setRestoreProjectExtentOnProjectLoad( bool state );
 %Docstring
 Sets whether the project's preset full extent should be restored when
 the project is loaded.

--- a/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
+++ b/python/core/auto_generated/project/qgsprojectviewsettings.sip.in
@@ -97,6 +97,22 @@ should be calculated based on the layers in the project.
 .. versionadded:: 3.18
 %End
 
+    void setCanvasUseProjectExtent( bool state );
+%Docstring
+Sets wheter the project's preset full extent should be loaded when the
+project is loaded.
+
+.. versionadded:: 3.44
+%End
+
+    bool canvasUseProjectExtent();
+%Docstring
+Returns wheter the project's preset full extent should be loaded when
+the project is loaded.
+
+.. versionadded:: 3.44
+%End
+
     QgsReferencedRectangle fullExtent() const;
 %Docstring
 Returns the full extent of the project, which represents the maximal

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -1367,7 +1367,7 @@ void QgsProjectProperties::apply()
     QgsProject::instance()->viewSettings()->setPresetFullExtent( QgsReferencedRectangle() );
   }
 
-  QgsProject::instance()->viewSettings()->setMainCanvasOpensAtProjectExtent( mCheckBoxLoadProjectExtent->isChecked() );
+  QgsProject::instance()->viewSettings()->setRestoreProjectExtentOnProjectLoad( mCheckBoxLoadProjectExtent->isChecked() );
 
   bool isDirty = false;
   const QMap<QString, QgsMapLayer *> &mapLayers = QgsProject::instance()->mapLayers();

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -102,6 +102,11 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mExtentGroupBox->setObjectName( "mExtentGroupBox" );
   mExtentGroupBox->setCheckable( true );
 
+
+  mExtentWidget = new QgsExtentWidget( parent, QgsExtentWidget::ExpandedStyle );
+  QVBoxLayout *mExtentGroupBoxLayout = qobject_cast<QVBoxLayout *>( mExtentGroupBox->layout() );
+  mExtentGroupBoxLayout->insertWidget( 0, mExtentWidget );
+
   mExtentWidget->setMapCanvas( mapCanvas, false );
 
   mCheckBoxLoadProjectExtent->setObjectName( "mCheckBoxLoadProjectExtent" );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -491,7 +491,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   else
     mExtentWidget->setOutputExtentFromUser( presetExtent, presetExtent.crs() );
   mExtentGroupBox->setChecked( !presetExtent.isNull() );
-  mCheckBoxLoadProjectExtent->setChecked( QgsProject::instance()->viewSettings()->mainCanvasOpensAtProjectExtent() );
+  mCheckBoxLoadProjectExtent->setChecked( QgsProject::instance()->viewSettings()->restoreProjectExtentOnProjectLoad() );
 
   mLayerCapabilitiesModel = new QgsLayerCapabilitiesModel( QgsProject::instance(), this );
   mLayerCapabilitiesModel->setLayerTreeModel( new QgsLayerTreeModel( QgsProject::instance()->layerTreeRoot(), mLayerCapabilitiesModel ) );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -98,7 +98,6 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
 
   setupUi( this );
 
-
   mExtentGroupBox->setObjectName( "mExtentGroupBox" );
   mExtentGroupBox->setCheckable( true );
 

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -98,8 +98,13 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
 
   setupUi( this );
 
-  mExtentGroupBox->setTitleBase( tr( "Set Project Full Extent" ) );
-  mExtentGroupBox->setMapCanvas( mapCanvas, false );
+
+  mExtentGroupBox->setObjectName( "mExtentGroupBox" );
+  mExtentGroupBox->setCheckable( true );
+
+  mExtentWidget->setMapCanvas( mapCanvas, false );
+
+  mCheckBoxLoadProjectExtent->setObjectName( "mCheckBoxLoadProjectExtent" );
 
   mAdvertisedExtentServer->setOutputCrs( QgsProject::instance()->crs() );
   mAdvertisedExtentServer->setMapCanvas( mapCanvas, false );
@@ -476,12 +481,13 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   grpProjectScales->setChecked( QgsProject::instance()->viewSettings()->useProjectScales() );
 
   const QgsReferencedRectangle presetExtent = QgsProject::instance()->viewSettings()->presetFullExtent();
-  mExtentGroupBox->setOutputCrs( QgsProject::instance()->crs() );
+  mExtentWidget->setOutputCrs( QgsProject::instance()->crs() );
   if ( presetExtent.isNull() )
-    mExtentGroupBox->setOutputExtentFromUser( QgsProject::instance()->viewSettings()->fullExtent(), QgsProject::instance()->crs() );
+    mExtentWidget->setOutputExtentFromUser( QgsProject::instance()->viewSettings()->fullExtent(), QgsProject::instance()->crs() );
   else
-    mExtentGroupBox->setOutputExtentFromUser( presetExtent, presetExtent.crs() );
+    mExtentWidget->setOutputExtentFromUser( presetExtent, presetExtent.crs() );
   mExtentGroupBox->setChecked( !presetExtent.isNull() );
+  mCheckBoxLoadProjectExtent->setChecked( QgsProject::instance()->viewSettings()->canvasUseProjectExtent() );
 
   mLayerCapabilitiesModel = new QgsLayerCapabilitiesModel( QgsProject::instance(), this );
   mLayerCapabilitiesModel->setLayerTreeModel( new QgsLayerTreeModel( QgsProject::instance()->layerTreeRoot(), mLayerCapabilitiesModel ) );
@@ -1212,6 +1218,7 @@ void QgsProjectProperties::apply()
     }
   }
 
+
   mMapCanvas->enableMapTileRendering( mMapTileRenderingCheckBox->isChecked() );
   QgsProject::instance()->writeEntry( QStringLiteral( "RenderMapTile" ), QStringLiteral( "/" ), mMapTileRenderingCheckBox->isChecked() );
 
@@ -1353,12 +1360,14 @@ void QgsProjectProperties::apply()
 
   if ( mExtentGroupBox->isChecked() )
   {
-    QgsProject::instance()->viewSettings()->setPresetFullExtent( QgsReferencedRectangle( mExtentGroupBox->outputExtent(), mExtentGroupBox->outputCrs() ) );
+    QgsProject::instance()->viewSettings()->setPresetFullExtent( QgsReferencedRectangle( mExtentWidget->outputExtent(), mExtentWidget->outputCrs() ) );
   }
   else
   {
     QgsProject::instance()->viewSettings()->setPresetFullExtent( QgsReferencedRectangle() );
   }
+
+  QgsProject::instance()->viewSettings()->setCanvasUseProjectExtent( mCheckBoxLoadProjectExtent->isChecked() );
 
   bool isDirty = false;
   const QMap<QString, QgsMapLayer *> &mapLayers = QgsProject::instance()->mapLayers();
@@ -2047,7 +2056,7 @@ void QgsProjectProperties::crsChanged( const QgsCoordinateReferenceSystem &crs )
     cmbEllipsoid->setEnabled( false );
   }
 
-  mExtentGroupBox->setOutputCrs( crs );
+  mExtentWidget->setOutputCrs( crs );
   mAdvertisedExtentServer->setOutputCrs( crs );
 }
 

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -98,17 +98,13 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
 
   setupUi( this );
 
-  mExtentGroupBox->setObjectName( "mExtentGroupBox" );
   mExtentGroupBox->setCheckable( true );
-
 
   mExtentWidget = new QgsExtentWidget( parent, QgsExtentWidget::ExpandedStyle );
   QVBoxLayout *mExtentGroupBoxLayout = qobject_cast<QVBoxLayout *>( mExtentGroupBox->layout() );
   mExtentGroupBoxLayout->insertWidget( 0, mExtentWidget );
 
   mExtentWidget->setMapCanvas( mapCanvas, false );
-
-  mCheckBoxLoadProjectExtent->setObjectName( "mCheckBoxLoadProjectExtent" );
 
   mAdvertisedExtentServer->setOutputCrs( QgsProject::instance()->crs() );
   mAdvertisedExtentServer->setMapCanvas( mapCanvas, false );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -487,7 +487,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   else
     mExtentWidget->setOutputExtentFromUser( presetExtent, presetExtent.crs() );
   mExtentGroupBox->setChecked( !presetExtent.isNull() );
-  mCheckBoxLoadProjectExtent->setChecked( QgsProject::instance()->viewSettings()->canvasUseProjectExtent() );
+  mCheckBoxLoadProjectExtent->setChecked( QgsProject::instance()->viewSettings()->mainCanvasOpensAtProjectExtent() );
 
   mLayerCapabilitiesModel = new QgsLayerCapabilitiesModel( QgsProject::instance(), this );
   mLayerCapabilitiesModel->setLayerTreeModel( new QgsLayerTreeModel( QgsProject::instance()->layerTreeRoot(), mLayerCapabilitiesModel ) );
@@ -1367,7 +1367,7 @@ void QgsProjectProperties::apply()
     QgsProject::instance()->viewSettings()->setPresetFullExtent( QgsReferencedRectangle() );
   }
 
-  QgsProject::instance()->viewSettings()->setCanvasUseProjectExtent( mCheckBoxLoadProjectExtent->isChecked() );
+  QgsProject::instance()->viewSettings()->setMainCanvasOpensAtProjectExtent( mCheckBoxLoadProjectExtent->isChecked() );
 
   bool isDirty = false;
   const QMap<QString, QgsMapLayer *> &mapLayers = QgsProject::instance()->mapLayers();

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -250,6 +250,8 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
 
     QDoubleSpinBox *mWMSDefaultMapUnitsPerMm = nullptr;
     QgsScaleWidget *mWMSDefaultMapUnitScale = nullptr;
+    QgsExtentWidget *mExtentWidget;
+
 
     QgsCoordinateReferenceSystem mCrs;
 

--- a/src/core/project/qgsprojectviewsettings.cpp
+++ b/src/core/project/qgsprojectviewsettings.cpp
@@ -20,10 +20,13 @@
 #include "qgsmaplayerutils.h"
 #include "qgscoordinatetransform.h"
 #include <QDomElement>
+#include "qgsmessagelog.h"
+
 
 QgsProjectViewSettings::QgsProjectViewSettings( QgsProject *project )
   : QObject( project )
   , mProject( project )
+  , mLoadProjectExtent( false )
 {
 
 }
@@ -70,6 +73,17 @@ void QgsProjectViewSettings::setPresetFullExtent( const QgsReferencedRectangle &
   mPresetFullExtent = extent;
   emit presetFullExtentChanged();
 }
+
+void QgsProjectViewSettings::setCanvasUseProjectExtent( bool state )
+{
+  mLoadProjectExtent = state;
+}
+
+bool QgsProjectViewSettings::canvasUseProjectExtent( )
+{
+  return mLoadProjectExtent;
+}
+
 
 QgsReferencedRectangle QgsProjectViewSettings::fullExtent() const
 {
@@ -198,6 +212,7 @@ bool QgsProjectViewSettings::readXml( const QDomElement &element, const QgsReadW
   }
 
   mDefaultRotation = element.attribute( QStringLiteral( "rotation" ), QStringLiteral( "0" ) ).toDouble();
+  mLoadProjectExtent = element.attribute( QStringLiteral( "LoadProjectExtent" ), QStringLiteral( "0" ) ).toInt();
 
   return true;
 }
@@ -206,6 +221,8 @@ QDomElement QgsProjectViewSettings::writeXml( QDomDocument &doc, const QgsReadWr
 {
   QDomElement element = doc.createElement( QStringLiteral( "ProjectViewSettings" ) );
   element.setAttribute( QStringLiteral( "UseProjectScales" ), mUseProjectScales ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+
+  element.setAttribute( QStringLiteral( "LoadProjectExtent" ), mLoadProjectExtent ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
 
   element.setAttribute( QStringLiteral( "rotation" ), qgsDoubleToString( mDefaultRotation ) );
 

--- a/src/core/project/qgsprojectviewsettings.cpp
+++ b/src/core/project/qgsprojectviewsettings.cpp
@@ -26,7 +26,7 @@
 QgsProjectViewSettings::QgsProjectViewSettings( QgsProject *project )
   : QObject( project )
   , mProject( project )
-  , mLoadProjectExtent( false )
+  , mRestoreProjectExtentOnProjectLoad( false )
 {
 
 }
@@ -76,12 +76,12 @@ void QgsProjectViewSettings::setPresetFullExtent( const QgsReferencedRectangle &
 
 void QgsProjectViewSettings::setMainCanvasOpensAtProjectExtent( bool state )
 {
-  mLoadProjectExtent = state;
+  mRestoreProjectExtentOnProjectLoad = state;
 }
 
 bool QgsProjectViewSettings::mainCanvasOpensAtProjectExtent( )
 {
-  return mLoadProjectExtent;
+  return mRestoreProjectExtentOnProjectLoad;
 }
 
 
@@ -212,7 +212,7 @@ bool QgsProjectViewSettings::readXml( const QDomElement &element, const QgsReadW
   }
 
   mDefaultRotation = element.attribute( QStringLiteral( "rotation" ), QStringLiteral( "0" ) ).toDouble();
-  mLoadProjectExtent = element.attribute( QStringLiteral( "LoadProjectExtent" ), QStringLiteral( "0" ) ).toInt();
+  mRestoreProjectExtentOnProjectLoad = element.attribute( QStringLiteral( "LoadProjectExtent" ), QStringLiteral( "0" ) ).toInt();
 
   return true;
 }
@@ -222,7 +222,7 @@ QDomElement QgsProjectViewSettings::writeXml( QDomDocument &doc, const QgsReadWr
   QDomElement element = doc.createElement( QStringLiteral( "ProjectViewSettings" ) );
   element.setAttribute( QStringLiteral( "UseProjectScales" ), mUseProjectScales ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
 
-  element.setAttribute( QStringLiteral( "LoadProjectExtent" ), mLoadProjectExtent ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+  element.setAttribute( QStringLiteral( "LoadProjectExtent" ), mRestoreProjectExtentOnProjectLoad ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
 
   element.setAttribute( QStringLiteral( "rotation" ), qgsDoubleToString( mDefaultRotation ) );
 

--- a/src/core/project/qgsprojectviewsettings.cpp
+++ b/src/core/project/qgsprojectviewsettings.cpp
@@ -79,7 +79,7 @@ void QgsProjectViewSettings::setRestoreProjectExtentOnProjectLoad( bool projectE
   mRestoreProjectExtentOnProjectLoad = projectExtentCheckboxState;
 }
 
-bool QgsProjectViewSettings::mainCanvasOpensAtProjectExtent( )
+bool QgsProjectViewSettings::restoreProjectExtentOnProjectLoad( )
 {
   return mRestoreProjectExtentOnProjectLoad;
 }

--- a/src/core/project/qgsprojectviewsettings.cpp
+++ b/src/core/project/qgsprojectviewsettings.cpp
@@ -74,9 +74,9 @@ void QgsProjectViewSettings::setPresetFullExtent( const QgsReferencedRectangle &
   emit presetFullExtentChanged();
 }
 
-void QgsProjectViewSettings::setMainCanvasOpensAtProjectExtent( bool state )
+void QgsProjectViewSettings::setRestoreProjectExtentOnProjectLoad( bool projectExtentCheckboxState )
 {
-  mRestoreProjectExtentOnProjectLoad = state;
+  mRestoreProjectExtentOnProjectLoad = projectExtentCheckboxState;
 }
 
 bool QgsProjectViewSettings::mainCanvasOpensAtProjectExtent( )

--- a/src/core/project/qgsprojectviewsettings.cpp
+++ b/src/core/project/qgsprojectviewsettings.cpp
@@ -74,12 +74,12 @@ void QgsProjectViewSettings::setPresetFullExtent( const QgsReferencedRectangle &
   emit presetFullExtentChanged();
 }
 
-void QgsProjectViewSettings::setCanvasUseProjectExtent( bool state )
+void QgsProjectViewSettings::setMainCanvasOpensAtProjectExtent( bool state )
 {
   mLoadProjectExtent = state;
 }
 
-bool QgsProjectViewSettings::canvasUseProjectExtent( )
+bool QgsProjectViewSettings::mainCanvasOpensAtProjectExtent( )
 {
   return mLoadProjectExtent;
 }

--- a/src/core/project/qgsprojectviewsettings.h
+++ b/src/core/project/qgsprojectviewsettings.h
@@ -105,6 +105,20 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
     void setPresetFullExtent( const QgsReferencedRectangle &extent );
 
     /**
+     * Sets wheter the project's preset full extent should be loaded when the project is loaded.
+     *
+     * \since QGIS 3.44
+     */
+    void setCanvasUseProjectExtent( bool state );
+
+    /**
+     * Returns wheter the project's preset full extent should be loaded when the project is loaded.
+     *
+     * \since QGIS 3.44
+     */
+    bool canvasUseProjectExtent();
+
+    /**
      * Returns the full extent of the project, which represents the maximal limits of the project.
      *
      * The returned extent will be in the project's CRS.
@@ -228,6 +242,7 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
     bool mUseProjectScales = false;
     QgsReferencedRectangle mDefaultViewExtent;
     QgsReferencedRectangle mPresetFullExtent;
+    bool mLoadProjectExtent;
     double mDefaultRotation = 0;
 };
 

--- a/src/core/project/qgsprojectviewsettings.h
+++ b/src/core/project/qgsprojectviewsettings.h
@@ -242,7 +242,7 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
     bool mUseProjectScales = false;
     QgsReferencedRectangle mDefaultViewExtent;
     QgsReferencedRectangle mPresetFullExtent;
-    bool mLoadProjectExtent;
+    bool mRestoreProjectExtentOnProjectLoad;
     double mDefaultRotation = 0;
 };
 

--- a/src/core/project/qgsprojectviewsettings.h
+++ b/src/core/project/qgsprojectviewsettings.h
@@ -107,14 +107,14 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
     /**
      * Sets whether the project's preset full extent should be restored when the project is loaded.
      *
-     * \since QGIS 3.44
+     * \since QGIS 4.0
      */
     void setRestoreProjectExtentOnProjectLoad( bool state );
 
     /**
      * Returns whether the project's preset full extent should be restored when the project is loaded.
      *
-     * \since QGIS 3.44
+     * \since QGIS 4.0
      */
     bool mainCanvasOpensAtProjectExtent();
 

--- a/src/core/project/qgsprojectviewsettings.h
+++ b/src/core/project/qgsprojectviewsettings.h
@@ -109,7 +109,7 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
      *
      * \since QGIS 3.44
      */
-    void setMainCanvasOpensAtProjectExtent( bool state );
+    void setRestoreProjectExtentOnProjectLoad( bool state );
 
     /**
      * Returns whether the project's preset full extent should be restored when the project is loaded.

--- a/src/core/project/qgsprojectviewsettings.h
+++ b/src/core/project/qgsprojectviewsettings.h
@@ -105,14 +105,14 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
     void setPresetFullExtent( const QgsReferencedRectangle &extent );
 
     /**
-     * Sets wheter the project's preset full extent should be loaded when the project is loaded.
+     * Sets whether the project's preset full extent should be restored when the project is loaded.
      *
      * \since QGIS 3.44
      */
     void setMainCanvasOpensAtProjectExtent( bool state );
 
     /**
-     * Returns wheter the project's preset full extent should be loaded when the project is loaded.
+     * Returns whether the project's preset full extent should be restored when the project is loaded.
      *
      * \since QGIS 3.44
      */

--- a/src/core/project/qgsprojectviewsettings.h
+++ b/src/core/project/qgsprojectviewsettings.h
@@ -116,7 +116,7 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
      *
      * \since QGIS 4.0
      */
-    bool mainCanvasOpensAtProjectExtent();
+    bool restoreProjectExtentOnProjectLoad();
 
     /**
      * Returns the full extent of the project, which represents the maximal limits of the project.

--- a/src/core/project/qgsprojectviewsettings.h
+++ b/src/core/project/qgsprojectviewsettings.h
@@ -109,14 +109,14 @@ class CORE_EXPORT QgsProjectViewSettings : public QObject
      *
      * \since QGIS 3.44
      */
-    void setCanvasUseProjectExtent( bool state );
+    void setMainCanvasOpensAtProjectExtent( bool state );
 
     /**
      * Returns wheter the project's preset full extent should be loaded when the project is loaded.
      *
      * \since QGIS 3.44
      */
-    bool canvasUseProjectExtent();
+    bool mainCanvasOpensAtProjectExtent();
 
     /**
      * Returns the full extent of the project, which represents the maximal limits of the project.

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -3271,7 +3271,7 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
       // never manually set the crs for the main canvas - this is instead connected to the project CRS
       setDestinationCrs( tmpSettings.destinationCrs() );
     }
-    if ( QgsProject::instance()->viewSettings()->mainCanvasOpensAtProjectExtent() && objectName() == QLatin1String( "theMapCanvas" ) )
+    if ( QgsProject::instance()->viewSettings()->restoreProjectExtentOnProjectLoad() && objectName() == QLatin1String( "theMapCanvas" ) )
     {
       zoomToProjectExtent();
     }

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -3271,7 +3271,7 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
       // never manually set the crs for the main canvas - this is instead connected to the project CRS
       setDestinationCrs( tmpSettings.destinationCrs() );
     }
-    if ( QgsProject::instance()->viewSettings()->canvasUseProjectExtent() && objectName() == QLatin1String( "theMapCanvas" ) )
+    if ( QgsProject::instance()->viewSettings()->mainCanvasOpensAtProjectExtent() && objectName() == QLatin1String( "theMapCanvas" ) )
     {
       zoomToProjectExtent();
     }

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -3271,7 +3271,14 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
       // never manually set the crs for the main canvas - this is instead connected to the project CRS
       setDestinationCrs( tmpSettings.destinationCrs() );
     }
-    setExtent( tmpSettings.extent() );
+    if ( QgsProject::instance()->viewSettings()->canvasUseProjectExtent() && objectName() == QLatin1String( "theMapCanvas" ) )
+    {
+      zoomToProjectExtent();
+    }
+    else
+    {
+      setExtent( tmpSettings.extent() );
+    }
     setRotation( tmpSettings.rotation() );
     enableMapTileRendering( tmpSettings.testFlag( Qgis::MapSettingsFlag::RenderMapTile ) );
 

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -1016,9 +1016,6 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_30">
               <item>
-               <widget class="QgsExtentWidget" name="mExtentWidget" native="true"/>
-              </item>
-              <item>
                <widget class="QCheckBox" name="mCheckBoxLoadProjectExtent">
                 <property name="text">
                  <string>Use as extent for the main canvas when opening the project</string>
@@ -1135,8 +1132,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>528</width>
-                <height>85</height>
+                <width>685</width>
+                <height>791</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -1010,19 +1010,22 @@
             </widget>
            </item>
            <item>
-            <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
-             <property name="toolTip">
-              <string>If checked the preset extent will be used as the full extent of the project. If unchecked, the project's full extent will be calculated using the full extent of all layers in the project.</string>
-             </property>
+            <widget class="QgsCollapsibleGroupBox" name="mExtentGroupBox">
              <property name="title">
-              <string>Extent (current: none)</string>
+              <string>Set Project Full Extent</string>
              </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_30">
+              <item>
+               <widget class="QgsExtentWidget" name="mExtentWidget" native="true"/>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="mCheckBoxLoadProjectExtent">
+                <property name="text">
+                 <string>Use as extent for each canvas when opening the project</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
            <item>
@@ -3609,12 +3612,6 @@
    <header>qgsdatetimeedit.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsExtentGroupBox</class>
-   <extends>QgsCollapsibleGroupBox</extends>
-   <header>qgsextentgroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsFontButton</class>
    <extends>QToolButton</extends>
    <header>qgsfontbutton.h</header>
@@ -3706,7 +3703,6 @@
   <tabstop>pbnRemoveScale</tabstop>
   <tabstop>pbnImportScales</tabstop>
   <tabstop>pbnExportScales</tabstop>
-  <tabstop>mExtentGroupBox</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>mShowDatumTransformDialogCheckBox</tabstop>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -1021,7 +1021,7 @@
               <item>
                <widget class="QCheckBox" name="mCheckBoxLoadProjectExtent">
                 <property name="text">
-                 <string>Use as extent for each canvas when opening the project</string>
+                 <string>Use as extent for the main canvas when opening the project</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
## Description

Adds an option to load the extent saved under `Project Properties -> View Settings -> Set Project Full Extent` for the main canvas when a project is loaded. Also reworks the setting to use `QgsExtentWidget` instead of `QgsExtentGroupBox`.

Original idea by @3nids.

![image](https://github.com/user-attachments/assets/755154a1-1562-437a-8f56-332dd4b2acae)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
