### PR TITLE
Fix #59003 - Increase stacksize on Windows to 8MB to avoid some crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -873,7 +873,7 @@ if(MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /utf-8 /std:c++17 /permissive-")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-  # Increase our stack size to 8MB to give us a bit more room and avod stackoverflow crashes
+  # Increase our stack size to 8MB to give us a bit more room and avoid stackoverflow crashes
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8000000")
   # disable macros that offend std::numeric_limits<T>::min()/max()
   add_definitions(-DNOMINMAX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -874,7 +874,7 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
   # Increase our stack size to 8MB to give us a bit more room and avoid stackoverflow crashes
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8000000")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8388608")
   # disable macros that offend std::numeric_limits<T>::min()/max()
   add_definitions(-DNOMINMAX)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -873,6 +873,8 @@ if(MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /utf-8 /std:c++17 /permissive-")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  # Increase our stack size to 8MB to give us a bit more room and avod stackoverflow crashes
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8000000")
   # disable macros that offend std::numeric_limits<T>::min()/max()
   add_definitions(-DNOMINMAX)
 endif()


### PR DESCRIPTION
# Description

Bump the QGIS exe stack reserve to 8MB

While investigating #59003 with @nyalldawson I found that the crash we are getting is over allocation of locals on the stack and running out of stack memory.   The stack includes a call to `__chkstk` which increases in the memory in the stack guard pages to get enough (that isn't the bug itself, it get called in other places just fine)

When looking at the crash in WinDbg and setting a break point before `__chkstk` we are hitting a stack overflow before it is even called which gives us a Stack Overflow First Chance Exception, but once `__chkstk` runs it hits Stack Overflow Second Chance Exception and blows up. So the issues is we are running out of stack space even before this runs.

The Qt6 builds coming out the GitHub actions didn't show this crash only the OSGeo builds. Both use different level of compiler compiler optimization flags meaning we don't always get the crash based on the different builds which is kind of expected but still annoying and we waste time trying to guess code optimize stuff when we really shouldn't need to. Memory is cheap we can just use a little more if needed

## Stack limit defaults

The default stack reserve when using MSVC is set as 1MB and can be seen in dumpbin results. 

```
100000 size of stack reserve
1000 size of stack commit
```

Windows will only commit to the `size of stack commit` at start up time and grow to `size of stack reserve` as required so bumping the stack reserve has no negative effects on the memory usage overall unless we need to use it.

Other applications have also bumped up this limit a bit due to the same kind of issues and given the size and complexity of QGIS I don't see why we shouldn't do the same.

```
Chrome: 800000 size of stack reserve
Android Studio: 200000 size of stack reserve
Node:  800000 size of stack reserve
```

## Debugging

Debugging the crash in WinDbg returns the results that we have blown past the stack limit in this case: 

```
0:000> ?? int(@$teb->NtTib.StackBase) - int(@$teb->DeallocationStack)
int 0n1048576 
0:000> ?? int(@$teb->NtTib.StackBase) - int(@$teb->NtTib.StackLimit)
int 0n1044480
```

~1.04448 MB stack used so good bye QGIS

## This might be the fixes for a lot of other crashes!

Doing a quick issues search for `stack overflow` there is a few  tickets which I suspect are due to this exact thing happening randomly due to many different factors, and these are the ones we know about given that people normally just click close sigh and reopen QGIS.  We might be lucky and are able to stop those from happening if we bump this a little bit.

https://github.com/qgis/QGIS/issues?q=is%3Aissue%20state%3Aopen%20%22Windows%20fatal%20exception%3A%20stack%20overflow%22

Doing some debugging I noticed that when sampling we are close to the stack limit on and off which makes me think this is a hidden bug people hit and we only get a handfull of reports about.

## Confirming the fix with editbin 

You can confirm the fix using `editbin /STACK:8000000 qgis.exe` on the OSGeobuild 

## Crash Stack Dump

```
0:000> k
 # Child-SP          RetAddr               Call Site
00 0000004e`ddeee3e8 00007ffc`c2ed619c     qgis_core!__chkstk+0x37 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\misc\amd64\chkstk.asm @ 109] 
01 0000004e`ddeee400 00007ffc`c124eb4d     qgis_core!QgsExpression::buildFunctionHelp+0xc [C:\src\osgeo4w\src\qgis-qt6-dev\osgeo4w\build\src\core\qgsexpression_texts.cpp @ 4] 
02 0000004e`ddeee410 00007ffc`c124d983     qgis_core!std::invoke<void (__cdecl&)(void)>+0xd [C:\src\osgeo4w\scripts\vs2022\VC\Tools\MSVC\14.38.33130\include\type_traits @ 1732] 
03 0000004e`ddeee440 00007ffc`c17b6b77     qgis_core!std::call_once<void (__cdecl&)(void)>+0x53 [C:\src\osgeo4w\scripts\vs2022\VC\Tools\MSVC\14.38.33130\include\xcall_once.h @ 113] 
04 0000004e`ddeee490 00007ffc`c17ae9b4     qgis_core!QgsExpression::initFunctionHelp+0x17 [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\core\expression\qgsexpression.cpp @ 350] 
05 0000004e`ddeee4c0 00007ffc`d00855f6     qgis_core!QgsExpression::tags+0x44 [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\core\expression\qgsexpression.cpp @ 713] 
06 0000004e`ddeee530 00007ffc`d007daf4     qgis_gui!QgsExpressionTreeView::updateFunctionTree+0x2896 [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\gui\qgsexpressiontreeview.cpp @ 289] 
07 0000004e`ddef0650 00007ffc`d0066329     qgis_gui!QgsExpressionTreeView::QgsExpressionTreeView+0x464 [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\gui\qgsexpressiontreeview.cpp @ 127] 
08 0000004e`ddef07f0 00007ffc`d004dc8c     qgis_gui!Ui_QgsExpressionBuilderWidgetBase::setupUi+0x4e79 [C:\src\osgeo4w\src\qgis-qt6-dev\osgeo4w\build\src\ui\ui_qgsexpressionbuilder.h @ 378] 
09 0000004e`ddef3210 00007ffc`d007a24e     qgis_gui!QgsExpressionBuilderWidget::QgsExpressionBuilderWidget+0x1ac [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\gui\qgsexpressionbuilderwidget.cpp @ 79] 
0a 0000004e`ddef47a0 00007ffc`d0076b28     qgis_gui!Ui_QgsExpressionSelectionDialogBase::setupUi+0xece [C:\src\osgeo4w\src\qgis-qt6-dev\osgeo4w\build\src\ui\ui_qgsexpressionselectiondialogbase.h @ 89] 
0b 0000004e`ddef4cd0 00007ffd`1b5ae84b     qgis_gui!QgsExpressionSelectionDialog::QgsExpressionSelectionDialog+0xd8 [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\gui\qgsexpressionselectiondialog.cpp @ 37] 
0c 0000004e`ddef53b0 00007ffd`1b694ef9     qgis_app!QgisApp::selectByExpression+0x18b [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\app\qgisapp.cpp @ 9921] 
0d 0000004e`ddef54c0 00007ffd`1b63b8c8     qgis_app!`QtPrivate::FunctorCall<QtPrivate::IndexesList<>,QtPrivate::List<>,void,void (__cdecl QWidget::*)(void)>::call'::`2'::<lambda_1>::operator()+0x49 [C:\src\osgeo4w\src\qgis-qt6-dev\osgeo4w\osgeo4w\apps\Qt6\include\QtCore\qobjectdefs_impl.h @ 153] 
0e 0000004e`ddef5500 00007ffd`1b6ab46e     qgis_app!QtPrivate::FunctorCallBase::call_internal<void,`QtPrivate::FunctorCall<QtPrivate::IndexesList<>,QtPrivate::List<>,void,void (__cdecl QgsLayerTreeView::*)(void)>::call'::`2'::<lambda_1> >+0x18 [C:\src\osgeo4w\src\qgis-qt6-dev\osgeo4w\osgeo4w\apps\Qt6\include\QtCore\qobjectdefs_impl.h @ 72] 
0f 0000004e`ddef5530 00007ffd`1b638a0d     qgis_app!QtPrivate::FunctorCall<QtPrivate::IndexesList<>,QtPrivate::List<>,void,void (__cdecl QgsDecorationGrid::*)(void)>::call+0x3e [C:\src\osgeo4w\src\qgis-qt6-dev\osgeo4w\osgeo4w\apps\Qt6\include\QtCore\qobjectdefs_impl.h @ 154] 
10 0000004e`ddef5570 00007ffd`1b6b979e     qgis_app!QtPrivate::FunctionPointer<void (__cdecl QgsDecorationCopyright::*)(void)>::call<QtPrivate::List<>,void>+0x3d [C:\src\osgeo4w\src\qgis-qt6-dev\osgeo4w\osgeo4w\apps\Qt6\include\QtCore\qobjectdefs_impl.h @ 200] 
11 0000004e`ddef55c0 00007ffc`fefd3253     qgis_app!QtPrivate::QCallableObject<void (__cdecl QgsDecorationNorthArrow::*)(void),QtPrivate::List<>,void>::impl+0xbe [C:\src\osgeo4w\src\qgis-qt6-dev\osgeo4w\osgeo4w\apps\Qt6\include\QtCore\qobjectdefs_impl.h @ 573] 
12 0000004e`ddef5640 00007ffc`fefd5d84     Qt6Core!QObject::qt_static_metacall+0x1563
13 0000004e`ddef5770 00007ffc`d61f5751     Qt6Core!QMetaObject::activate+0x84
14 0000004e`ddef57a0 00007ffc`ff5e3757     Qt6Gui!QAction::activate+0x171
15 0000004e`ddef57e0 00007ffc`ff5e4cc0     Qt6Widgets!QAbstractButton::click+0x147
16 0000004e`ddef5810 00007ffc`ff6eddd2     Qt6Widgets!QAbstractButton::mouseReleaseEvent+0xe0
17 0000004e`ddef5850 00007ffc`ff516750     Qt6Widgets!QToolButton::mouseReleaseEvent+0x32
18 0000004e`ddef5880 00007ffc`ff4d2d72     Qt6Widgets!QWidget::event+0x160
19 0000004e`ddef5960 00007ffc`ff4d0ee6     Qt6Widgets!QApplicationPrivate::notify_helper+0x152
1a 0000004e`ddef5990 00007ffc`c1fcfb48     Qt6Widgets!QApplication::notify+0x716
1b 0000004e`ddef5e80 00007ffc`fef937f2     qgis_core!QgsApplication::notify+0x98 [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\core\qgsapplication.cpp @ 629] 
1c 0000004e`ddef6190 00007ffc`ff4d6a16     Qt6Core!QCoreApplication::notifyInternal2+0x122
1d 0000004e`ddef61f0 00007ffc`ff53c860     Qt6Widgets!QApplicationPrivate::sendMouseEvent+0x416
1e 0000004e`ddef6320 00007ffc`ff53a110     Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0x3450
1f 0000004e`ddef6750 00007ffc`ff4d2d72     Qt6Widgets!QWidgetRepaintManager::updateStaticContentsSize+0xd00
20 0000004e`ddef6870 00007ffc`ff4d1ea6     Qt6Widgets!QApplicationPrivate::notify_helper+0x152
21 0000004e`ddef68a0 00007ffc`c1fcfb48     Qt6Widgets!QApplication::notify+0x16d6
22 0000004e`ddef6d90 00007ffc`fef937f2     qgis_core!QgsApplication::notify+0x98 [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\core\qgsapplication.cpp @ 629] 
23 0000004e`ddef70a0 00007ffc`d5e7889c     Qt6Core!QCoreApplication::notifyInternal2+0x122
24 0000004e`ddef7100 00007ffc`d5ed484b     Qt6Gui!QGuiApplicationPrivate::processMouseEvent+0x7cc
25 0000004e`ddef7610 00007ffc`ff121060     Qt6Gui!QWindowSystemInterface::sendWindowSystemEvents+0xfb
26 0000004e`ddef7640 00007ffc`d6189c99     Qt6Core!QEventDispatcherWin32::processEvents+0x90
27 0000004e`ddefa7a0 00007ffc`fef9b6d4     Qt6Gui!QWindowsGuiEventDispatcher::processEvents+0x19
28 0000004e`ddefa7d0 00007ffc`fef91aed     Qt6Core!QEventLoop::exec+0x154
29 0000004e`ddefa870 00007ffd`1c0c5a07     Qt6Core!QCoreApplication::exec+0x15d
2a 0000004e`ddefa8d0 00007ff6`77ac3f1e     qgis_app!main+0x9407 [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\app\main.cpp @ 1822] 
2b 0000004e`ddefec90 00007ff6`77acc93a     qgis_qt6_dev_bin!WinMain+0xc5e [C:\src\osgeo4w\src\qgis-qt6-dev\qgis\src\app\mainwin.cpp @ 215] 
2c (Inline Function) --------`--------     qgis_qt6_dev_bin!invoke_main+0x21 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 102] 
2d 0000004e`ddeffd30 00007ffd`b78fe8d7     qgis_qt6_dev_bin!__scrt_common_main_seh+0x106 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 288] 
2e 0000004e`ddeffd70 00007ffd`b7fbc5dc     KERNEL32!BaseThreadInitThunk+0x17
2f 0000004e`ddeffda0 00000000`00000000     ntdll!RtlUserThreadStart+0x2c

```