### PR TITLE
Suggest a file name when exporting layer or group as layer definition file

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8197,10 +8197,30 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
 
 void QgisApp::saveAsLayerDefinition()
 {
+  QString defaultFileName = "";
+
+  QgsLayerTreeNode *node = mLayerTreeView->currentNode();
+  if (node->nodeType() == QgsLayerTreeNode::NodeLayer)
+  {
+    QgsLayerTreeLayer *layerNode = dynamic_cast<QgsLayerTreeLayer *>(node);
+    if (layerNode && layerNode->layer())
+    {
+      defaultFileName =  QStringLiteral( "/%1.qlr" ).arg( layerNode->layer()->name() );
+    }
+  }
+  else if (node->nodeType() == QgsLayerTreeNode::NodeGroup)
+  {
+    QgsLayerTreeGroup *groupNode = dynamic_cast<QgsLayerTreeGroup *>(node);
+    if (groupNode)
+    {
+      defaultFileName = QStringLiteral( "/%1.qlr" ).arg( groupNode->name() );
+    }
+  }
+
   QgsSettings settings;
   QString lastUsedDir = settings.value( QStringLiteral( "UI/lastQLRDir" ), QDir::homePath() ).toString();
 
-  QString path = QFileDialog::getSaveFileName( this, QStringLiteral( "Save as Layer Definition File" ), lastUsedDir, QStringLiteral( "*.qlr" ) );
+  QString path = QFileDialog::getSaveFileName( this, QStringLiteral( "Save as Layer Definition File" ), QStringLiteral( "%1%2" ).arg( lastUsedDir, defaultFileName ), QStringLiteral( "*.qlr" ) );
   QgsDebugMsgLevel( path, 2 );
   if ( path.isEmpty() )
     return;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8197,9 +8197,12 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
 
 void QgisApp::saveAsLayerDefinition()
 {
-  QString defaultFileName = "";
+  QString defaultFileName;
 
   QgsLayerTreeNode *node = mLayerTreeView->currentNode();
+  if ( !node )
+    return;
+
   if (node->nodeType() == QgsLayerTreeNode::NodeLayer)
   {
     QgsLayerTreeLayer *layerNode = dynamic_cast<QgsLayerTreeLayer *>(node);

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8203,18 +8203,18 @@ void QgisApp::saveAsLayerDefinition()
   if ( !node )
     return;
 
-  if (node->nodeType() == QgsLayerTreeNode::NodeLayer)
+  if ( node->nodeType() == QgsLayerTreeNode::NodeLayer )
   {
-    QgsLayerTreeLayer *layerNode = dynamic_cast<QgsLayerTreeLayer *>(node);
-    if (layerNode && layerNode->layer())
+    QgsLayerTreeLayer *layerNode = dynamic_cast<QgsLayerTreeLayer *>( node );
+    if ( layerNode && layerNode->layer() )
     {
-      defaultFileName =  QStringLiteral( "/%1.qlr" ).arg( layerNode->layer()->name() );
+      defaultFileName = QStringLiteral( "/%1.qlr" ).arg( layerNode->layer()->name() );
     }
   }
-  else if (node->nodeType() == QgsLayerTreeNode::NodeGroup)
+  else if ( node->nodeType() == QgsLayerTreeNode::NodeGroup )
   {
-    QgsLayerTreeGroup *groupNode = dynamic_cast<QgsLayerTreeGroup *>(node);
-    if (groupNode)
+    QgsLayerTreeGroup *groupNode = dynamic_cast<QgsLayerTreeGroup *>( node );
+    if ( groupNode )
     {
       defaultFileName = QStringLiteral( "/%1.qlr" ).arg( groupNode->name() );
     }


### PR DESCRIPTION
## Description

When saving a layer or a layer group as layer definition file (.qlr) the filename field is empty. With this PR the name of the layer or group will be pre-filled as a suggestion for the filename.

This was requested in #61676