### PR TITLE
Add grid size to QgsGeometry::mergeLines

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2173,7 +2173,7 @@ Since QGIS 3.28 the optional ``parameters`` argument can be used to
 specify parameters which control the union results.
 %End
 
-    QgsGeometry mergeLines() const;
+    QgsGeometry mergeLines( const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
 %Docstring
 Merges any connected lines in a LineString/MultiLineString geometry and
 converts them to single line strings.
@@ -2181,6 +2181,9 @@ converts them to single line strings.
 :return: a LineString or MultiLineString geometry, with any connected
          lines joined. An empty geometry will be returned if the input
          geometry was not a MultiLineString geometry.
+
+Since QGIS 3.44 the optional ``parameters`` argument can be used to
+specify parameters which control the mergeLines results.
 %End
 
     QgsGeometry difference( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
@@ -529,7 +529,7 @@ Returns a GeometryCollection having two elements:
 %End
 
 
-    std::unique_ptr< QgsAbstractGeometry > mergeLines( QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > mergeLines( QString *errorMsg /Out/ = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
 %Docstring
 Merges any connected lines in a LineString/MultiLineString geometry and
 converts them to single line strings.
@@ -540,6 +540,8 @@ converts them to single line strings.
            lines joined. An empty geometry will be returned if the input
            geometry was not a LineString/MultiLineString geometry.
          - errorMsg: descriptive error string if the operation fails
+           :param parameters: can be used to specify parameters which
+           control the mergeLines results (since QGIS 3.44)
 %End
 
     std::unique_ptr< QgsAbstractGeometry > closestPoint( const QgsGeometry &other, QString *errorMsg /Out/ = 0 ) const;

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2173,7 +2173,7 @@ Since QGIS 3.28 the optional ``parameters`` argument can be used to
 specify parameters which control the union results.
 %End
 
-    QgsGeometry mergeLines() const;
+    QgsGeometry mergeLines( const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
 %Docstring
 Merges any connected lines in a LineString/MultiLineString geometry and
 converts them to single line strings.
@@ -2181,6 +2181,9 @@ converts them to single line strings.
 :return: a LineString or MultiLineString geometry, with any connected
          lines joined. An empty geometry will be returned if the input
          geometry was not a MultiLineString geometry.
+
+Since QGIS 3.44 the optional ``parameters`` argument can be used to
+specify parameters which control the mergeLines results.
 %End
 
     QgsGeometry difference( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;

--- a/python/core/auto_generated/geometry/qgsgeos.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeos.sip.in
@@ -529,7 +529,7 @@ Returns a GeometryCollection having two elements:
 %End
 
 
-    std::unique_ptr< QgsAbstractGeometry > mergeLines( QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > mergeLines( QString *errorMsg /Out/ = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
 %Docstring
 Merges any connected lines in a LineString/MultiLineString geometry and
 converts them to single line strings.
@@ -540,6 +540,8 @@ converts them to single line strings.
            lines joined. An empty geometry will be returned if the input
            geometry was not a LineString/MultiLineString geometry.
          - errorMsg: descriptive error string if the operation fails
+           :param parameters: can be used to specify parameters which
+           control the mergeLines results (since QGIS 3.44)
 %End
 
     std::unique_ptr< QgsAbstractGeometry > closestPoint( const QgsGeometry &other, QString *errorMsg /Out/ = 0 ) const;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3086,7 +3086,7 @@ QgsGeometry QgsGeometry::combine( const QgsGeometry &geometry, const QgsGeometry
   return QgsGeometry( std::move( resultGeom ) );
 }
 
-QgsGeometry QgsGeometry::mergeLines() const
+QgsGeometry QgsGeometry::mergeLines( const QgsGeometryParameters &parameters ) const
 {
   if ( !d->geometry )
   {
@@ -3101,7 +3101,7 @@ QgsGeometry QgsGeometry::mergeLines() const
 
   QgsGeos geos( d->geometry.get() );
   mLastError.clear();
-  QgsGeometry result( geos.mergeLines( &mLastError ) );
+  QgsGeometry result( geos.mergeLines( &mLastError, parameters ) );
   result.mLastError = mLastError;
   return result;
 }

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2040,8 +2040,11 @@ class CORE_EXPORT QgsGeometry
      * \returns a LineString or MultiLineString geometry, with any connected lines
      * joined. An empty geometry will be returned if the input geometry was not a
      * MultiLineString geometry.
+     *
+     * Since QGIS 3.44 the optional \a parameters argument can be used to specify parameters which
+     * control the mergeLines results.
      */
-    QgsGeometry mergeLines() const;
+    QgsGeometry mergeLines( const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
 
     /**
      * Returns a geometry representing the points making up this geometry that do not make up other.

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -3050,7 +3050,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::reshapeGeometry( const QgsLineStri
   }
 }
 
-std::unique_ptr< QgsAbstractGeometry > QgsGeos::mergeLines( QString *errorMsg ) const
+std::unique_ptr< QgsAbstractGeometry > QgsGeos::mergeLines( QString *errorMsg, const QgsGeometryParameters &parameters ) const
 {
   if ( !mGeos )
   {
@@ -3064,7 +3064,14 @@ std::unique_ptr< QgsAbstractGeometry > QgsGeos::mergeLines( QString *errorMsg ) 
   geos::unique_ptr geos;
   try
   {
-    geos.reset( GEOSLineMerge_r( context, mGeos.get() ) );
+    double gridSize = parameters.gridSize();
+    if ( gridSize > 0 )
+    {
+      geos::unique_ptr geosFixedSize( GEOSGeom_setPrecision_r( context, mGeos.get(), gridSize, 0 ) );
+      geos.reset( GEOSLineMerge_r( context, geosFixedSize.get() ) );
+    }
+    else
+      geos.reset( GEOSLineMerge_r( context, mGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -594,8 +594,9 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
      * \returns a LineString or MultiLineString geometry, with any connected lines
      * joined. An empty geometry will be returned if the input geometry was not a
      * LineString/MultiLineString geometry.
+     * \param parameters can be used to specify parameters which control the mergeLines results (since QGIS 3.44)
      */
-    std::unique_ptr< QgsAbstractGeometry > mergeLines( QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > mergeLines( QString *errorMsg SIP_OUT = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
 
     /**
      * Returns the closest point on the geometry to the other geometry.

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -14,7 +14,7 @@ import csv
 import math
 import os
 
-from qgis.PyQt.QtCore import QDir, QPointF
+from qgis.PyQt.QtCore import QPointF
 from qgis.PyQt.QtGui import (
     QBrush,
     QColor,

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -13738,6 +13738,16 @@ class TestQgsGeometry(QgisTestCase):
             "MultiPolygon (((0 10, 7 10, 7 0, 0 0, 0 10)),((10 0, 7 0, 7 5, 10 5, 10 0)),((10 10, 10 6, 10 5, 7 5, 7 10, 10 10)),((14 6, 14 5, 10 5, 10 6, 14 6)),((28 6, 28 5, 14 5, 14 6, 28 6)),((55 6, 55 5, 28 5, 28 6, 55 6)),((100 5, 55 5, 55 6, 100 5)),((100 10, 110 10, 110 0, 100 0, 100 5, 100 10)))",
         )
 
+        # mergeLines, gridSize = 1
+        geom_params = QgsGeometryParameters()
+        geom_params.setGridSize(1)
+        a = QgsGeometry.fromWkt("MULTILINESTRING((0 1.8, 11.4 10.7),((11.2 11.1, 19 60))")
+        mergeLinesExpected = a.mergeLines(geom_params)
+        self.assertEqual(
+            mergeLinesExpected.asWkt(),
+            "LineString (0 2, 11 11, 19 60)"
+        )
+
     def testIntersectsMultiPolygonEmptyRect(self):
         """Test intersection between a polygon and an empty rectangle. Fix for GH #51492."""
 


### PR DESCRIPTION
## Description

Following investigations on #61136 I found that `QgsGeometry::mergeLines()` was missing the geometry parameters, like other methods like combine, difference, intersection, subdivide...

This PR add this option to mergeLines method.