### PR TITLE
update CRS icon in the statusbar when project is cleared and default CRS is set to "no projection" (fix #53768)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4373,6 +4373,9 @@ void QgisApp::setupConnections()
 
   // project crs connections
   connect( QgsProject::instance(), &QgsProject::crsChanged, this, &QgisApp::projectCrsChanged );
+  // When default project CRS is set to "no projection" and new project is created we need to update
+  // mOnTheFlyProjectionStatusButton with the correct icon, see https://github.com/qgis/QGIS/issues/53768
+  connect( QgsProject::instance(), &QgsProject::cleared, this, &QgisApp::updateCrsStatusBar );
 
   connect( QgsProject::instance()->viewSettings(), &QgsProjectViewSettings::mapScalesChanged, this, [=] { mScaleWidget->updateScales(); } );
 


### PR DESCRIPTION
## Description

When default CRS for new projects is set to "No CRS (or unknown /non-Earth projection)" creating a new project does not update CRS icon in the QGIS status bar.

This happens because `QgsProject::clear()` sets project CRS to an invalid CRS and then assigning default CRS to the project won't trigger `crsChanged()` signal as the new CRS is also invalid.

Fixes #53768.