### PR TITLE
Fallback to same logic as = when IS operator uses non-null values, fix serious regression in boolean handling in expressions

### DIFF
--- a/src/core/expression/qgsexpressionnode.cpp
+++ b/src/core/expression/qgsexpressionnode.cpp
@@ -29,8 +29,7 @@ QVariant QgsExpressionNode::eval( QgsExpression *parent, const QgsExpressionCont
   }
   else
   {
-    QVariant res = evalNode( parent, context );
-    return res;
+    return evalNode( parent, context );
   }
 }
 

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -270,25 +270,43 @@ QVariant QgsExpressionNodeBinaryOperator::compareNonNullValues( QgsExpression *p
     // All other variants always return false.
 
     // Note: Boolean logical operators behave the same in C++ and SQL.
-    switch ( mOp )
+    const bool vLBool = vL.toBool();
+    const bool vRBool = vR.toBool();
+    switch ( op )
     {
       case boEQ:
-        return vL.toBool() == vR.toBool() ? TVL_True : TVL_False;
+        return vLBool == vRBool ? TVL_True : TVL_False;
       case boNE:
-        return vL.toBool() != vR.toBool() ? TVL_True : TVL_False;
+        return vLBool != vRBool ? TVL_True : TVL_False;
       case boLT:
-        return vL.toBool() <  vR.toBool() ? TVL_True : TVL_False;
+        return vLBool <  vRBool ? TVL_True : TVL_False;
       case boLE:
-        return vL.toBool() <= vR.toBool() ? TVL_True : TVL_False;
+        return vLBool <= vRBool ? TVL_True : TVL_False;
       case boGT:
-        return vL.toBool() >  vR.toBool() ? TVL_True : TVL_False;
+        return vLBool > vRBool ? TVL_True : TVL_False;
       case boGE:
-        return vL.toBool() >= vR.toBool() ? TVL_True : TVL_False;
-      default:
-        // Can't happen [cosmic ray hits excepted]
-        Q_ASSERT( false );
-        return TVL_Unknown;
+        return vLBool >= vRBool ? TVL_True : TVL_False;
+      case boOr:
+      case boAnd:
+      case boRegexp:
+      case boLike:
+      case boNotLike:
+      case boILike:
+      case boNotILike:
+      case boIs:
+      case boIsNot:
+      case boPlus:
+      case boMinus:
+      case boMul:
+      case boDiv:
+      case boIntDiv:
+      case boMod:
+      case boPow:
+      case boConcat:
+        // should not happen
+        break;
     }
+    return TVL_Unknown;
   }
 
   // warning - QgsExpression::isIntervalSafe is VERY expensive and should not be used here

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -202,6 +202,84 @@ QString QgsExpressionNodeUnaryOperator::text() const
 
 //
 
+QVariant QgsExpressionNodeBinaryOperator::compareNonNullValues( QgsExpression *parent, const QgsExpressionContext *, const QVariant &vL, const QVariant &vR, BinaryOperator op )
+{
+  if ( ( vL.userType() == QMetaType::Type::QDateTime && vR.userType() == QMetaType::Type::QDateTime ) )
+  {
+    QDateTime dL = QgsExpressionUtils::getDateTimeValue( vL, parent );
+    ENSURE_NO_EVAL_ERROR
+    QDateTime dR = QgsExpressionUtils::getDateTimeValue( vR, parent );
+    ENSURE_NO_EVAL_ERROR
+
+    // while QDateTime has innate handling of timezones, we don't expose these ANYWHERE
+    // in QGIS. So to avoid confusion where seemingly equal datetime values give unexpected
+    // results (due to different hidden timezones), we force all datetime comparisons to treat
+    // all datetime values as having the same time zone
+    dL.setTimeSpec( Qt::UTC );
+    dR.setTimeSpec( Qt::UTC );
+
+    return compare( dR.msecsTo( dL ), op ) ? TVL_True : TVL_False;
+  }
+  else if ( ( vL.userType() == QMetaType::Type::QDate && vR.userType() == QMetaType::Type::QDate ) )
+  {
+    const QDate dL = QgsExpressionUtils::getDateValue( vL, parent );
+    ENSURE_NO_EVAL_ERROR
+    const QDate dR = QgsExpressionUtils::getDateValue( vR, parent );
+    ENSURE_NO_EVAL_ERROR
+    return compare( dR.daysTo( dL ), op ) ? TVL_True : TVL_False;
+  }
+  else if ( ( vL.userType() == QMetaType::Type::QTime && vR.userType() == QMetaType::Type::QTime ) )
+  {
+    const QTime dL = QgsExpressionUtils::getTimeValue( vL, parent );
+    ENSURE_NO_EVAL_ERROR
+    const QTime dR = QgsExpressionUtils::getTimeValue( vR, parent );
+    ENSURE_NO_EVAL_ERROR
+    return compare( dR.msecsTo( dL ), op ) ? TVL_True : TVL_False;
+  }
+  else if ( ( vL.userType() != QMetaType::Type::QString || vR.userType() != QMetaType::Type::QString ) &&
+            QgsExpressionUtils::isDoubleSafe( vL ) && QgsExpressionUtils::isDoubleSafe( vR ) )
+  {
+    // do numeric comparison if both operators can be converted to numbers,
+    // and they aren't both string
+    double fL = QgsExpressionUtils::getDoubleValue( vL, parent );
+    ENSURE_NO_EVAL_ERROR
+    double fR = QgsExpressionUtils::getDoubleValue( vR, parent );
+    ENSURE_NO_EVAL_ERROR
+    return compare( fL - fR, op ) ? TVL_True : TVL_False;
+  }
+
+  else if ( vL.userType() == QMetaType::Type::Bool || vR.userType() == QMetaType::Type::Bool )
+  {
+    // if one of value is boolean, then the other must also be boolean,
+    // in order to avoid confusion between different expression evaluations
+    // amongst providers and QVariant, that can consider or not the string
+    // 'false' as boolean or text
+    if ( vL.userType() == QMetaType::Type::Bool && vR.userType() == QMetaType::Type::Bool )
+      return vL.toBool() == vR.toBool() ? TVL_True : TVL_False;
+    return TVL_False;
+  }
+
+  // warning - QgsExpression::isIntervalSafe is VERY expensive and should not be used here
+  else if ( vL.userType() == qMetaTypeId< QgsInterval>() && vR.userType() == qMetaTypeId< QgsInterval>() )
+  {
+    double fL = QgsExpressionUtils::getInterval( vL, parent ).seconds();
+    ENSURE_NO_EVAL_ERROR
+    double fR = QgsExpressionUtils::getInterval( vR, parent ).seconds();
+    ENSURE_NO_EVAL_ERROR
+    return compare( fL - fR, op ) ? TVL_True : TVL_False;
+  }
+  else
+  {
+    // do string comparison otherwise
+    QString sL = QgsExpressionUtils::getStringValue( vL, parent );
+    ENSURE_NO_EVAL_ERROR
+    QString sR = QgsExpressionUtils::getStringValue( vR, parent );
+    ENSURE_NO_EVAL_ERROR
+    int diff = QString::compare( sL, sR );
+    return compare( diff, op ) ? TVL_True : TVL_False;
+  }
+}
+
 QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const QgsExpressionContext *context )
 {
   QVariant vL = mOpLeft->eval( parent, context );
@@ -428,112 +506,25 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
             return TVL_Unknown;
         }
       }
-      else if ( ( vL.userType() == QMetaType::Type::QDateTime && vR.userType() == QMetaType::Type::QDateTime ) )
-      {
-        QDateTime dL = QgsExpressionUtils::getDateTimeValue( vL, parent );
-        ENSURE_NO_EVAL_ERROR
-        QDateTime dR = QgsExpressionUtils::getDateTimeValue( vR, parent );
-        ENSURE_NO_EVAL_ERROR
-
-        // while QDateTime has innate handling of timezones, we don't expose these ANYWHERE
-        // in QGIS. So to avoid confusion where seemingly equal datetime values give unexpected
-        // results (due to different hidden timezones), we force all datetime comparisons to treat
-        // all datetime values as having the same time zone
-        dL.setTimeSpec( Qt::UTC );
-        dR.setTimeSpec( Qt::UTC );
-
-        return compare( dR.msecsTo( dL ) ) ? TVL_True : TVL_False;
-      }
-      else if ( ( vL.userType() == QMetaType::Type::QDate && vR.userType() == QMetaType::Type::QDate ) )
-      {
-        const QDate dL = QgsExpressionUtils::getDateValue( vL, parent );
-        ENSURE_NO_EVAL_ERROR
-        const QDate dR = QgsExpressionUtils::getDateValue( vR, parent );
-        ENSURE_NO_EVAL_ERROR
-        return compare( dR.daysTo( dL ) ) ? TVL_True : TVL_False;
-      }
-      else if ( ( vL.userType() == QMetaType::Type::QTime && vR.userType() == QMetaType::Type::QTime ) )
-      {
-        const QTime dL = QgsExpressionUtils::getTimeValue( vL, parent );
-        ENSURE_NO_EVAL_ERROR
-        const QTime dR = QgsExpressionUtils::getTimeValue( vR, parent );
-        ENSURE_NO_EVAL_ERROR
-        return compare( dR.msecsTo( dL ) ) ? TVL_True : TVL_False;
-      }
-      else if ( ( vL.userType() != QMetaType::Type::QString || vR.userType() != QMetaType::Type::QString ) &&
-                QgsExpressionUtils::isDoubleSafe( vL ) && QgsExpressionUtils::isDoubleSafe( vR ) )
-      {
-        // do numeric comparison if both operators can be converted to numbers,
-        // and they aren't both string
-        double fL = QgsExpressionUtils::getDoubleValue( vL, parent );
-        ENSURE_NO_EVAL_ERROR
-        double fR = QgsExpressionUtils::getDoubleValue( vR, parent );
-        ENSURE_NO_EVAL_ERROR
-        return compare( fL - fR ) ? TVL_True : TVL_False;
-      }
-
-      else if ( vL.userType() == QMetaType::Type::Bool || vR.userType() == QMetaType::Type::Bool )
-      {
-        // if one of value is boolean, then the other must also be boolean,
-        // in order to avoid confusion between different expression evaluations
-        // amongst providers and QVariant, that can consider or not the string
-        // 'false' as boolean or text
-        if ( vL.userType() == QMetaType::Type::Bool && vR.userType() == QMetaType::Type::Bool )
-          return vL.toBool() == vR.toBool() ? TVL_True : TVL_False;
-        return TVL_False;
-      }
-
-      // warning - QgsExpression::isIntervalSafe is VERY expensive and should not be used here
-      else if ( vL.userType() == qMetaTypeId< QgsInterval>() && vR.userType() == qMetaTypeId< QgsInterval>() )
-      {
-        double fL = QgsExpressionUtils::getInterval( vL, parent ).seconds();
-        ENSURE_NO_EVAL_ERROR
-        double fR = QgsExpressionUtils::getInterval( vR, parent ).seconds();
-        ENSURE_NO_EVAL_ERROR
-        return compare( fL - fR ) ? TVL_True : TVL_False;
-      }
       else
       {
-        // do string comparison otherwise
-        QString sL = QgsExpressionUtils::getStringValue( vL, parent );
-        ENSURE_NO_EVAL_ERROR
-        QString sR = QgsExpressionUtils::getStringValue( vR, parent );
-        ENSURE_NO_EVAL_ERROR
-        int diff = QString::compare( sL, sR );
-        return compare( diff ) ? TVL_True : TVL_False;
+        return compareNonNullValues( parent, context, vL, vR, mOp );
       }
 
     case boIs:
     case boIsNot:
-      if ( QgsExpressionUtils::isNull( vL ) && QgsExpressionUtils::isNull( vR ) ) // both operators null
+    {
+      const bool vLNull = QgsExpressionUtils::isNull( vL );
+      const bool vRNull = QgsExpressionUtils::isNull( vR );
+      if ( vLNull && vRNull ) // both operators null
         return ( mOp == boIs ? TVL_True : TVL_False );
-      else if ( QgsExpressionUtils::isNull( vL ) || QgsExpressionUtils::isNull( vR ) ) // one operator null
+      else if ( vLNull || vRNull ) // one operator null
         return ( mOp == boIs ? TVL_False : TVL_True );
       else // both operators non-null
       {
-        bool equal = false;
-        if ( QgsExpressionUtils::isDoubleSafe( vL ) && QgsExpressionUtils::isDoubleSafe( vR ) &&
-             ( vL.userType() != QMetaType::Type::QString || vR.userType() != QMetaType::Type::QString ) )
-        {
-          double fL = QgsExpressionUtils::getDoubleValue( vL, parent );
-          ENSURE_NO_EVAL_ERROR
-          double fR = QgsExpressionUtils::getDoubleValue( vR, parent );
-          ENSURE_NO_EVAL_ERROR
-          equal = qgsDoubleNear( fL, fR );
-        }
-        else
-        {
-          QString sL = QgsExpressionUtils::getStringValue( vL, parent );
-          ENSURE_NO_EVAL_ERROR
-          QString sR = QgsExpressionUtils::getStringValue( vR, parent );
-          ENSURE_NO_EVAL_ERROR
-          equal = QString::compare( sL, sR ) == 0;
-        }
-        if ( equal )
-          return mOp == boIs ? TVL_True : TVL_False;
-        else
-          return mOp == boIs ? TVL_False : TVL_True;
+        return compareNonNullValues( parent, context, vL, vR, mOp == boIs ? boEQ : boNE );
       }
+    }
 
     case boRegexp:
     case boLike:
@@ -611,9 +602,9 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
   return QVariant();
 }
 
-bool QgsExpressionNodeBinaryOperator::compare( double diff )
+bool QgsExpressionNodeBinaryOperator::compare( double diff, BinaryOperator op )
 {
-  switch ( mOp )
+  switch ( op )
   {
     case boEQ:
       return qgsDoubleNear( diff, 0.0 );

--- a/src/core/expression/qgsexpressionnodeimpl.h
+++ b/src/core/expression/qgsexpressionnodeimpl.h
@@ -218,7 +218,7 @@ class CORE_EXPORT QgsExpressionNodeBinaryOperator : public QgsExpressionNode
     QgsExpressionNodeBinaryOperator( const QgsExpressionNodeBinaryOperator &other );
 #endif
 
-    bool compare( double diff );
+    static bool compare( double diff, BinaryOperator op );
     qlonglong computeInt( qlonglong x, qlonglong y );
     double computeDouble( double x, double y );
 
@@ -228,6 +228,11 @@ class CORE_EXPORT QgsExpressionNodeBinaryOperator : public QgsExpressionNode
      * \param i interval to add or subtract (depending on mOp)
      */
     QDateTime computeDateTimeFromInterval( const QDateTime &d, QgsInterval *i );
+
+    /**
+     * Compares two values, which are guaranteed to be non-null, using the specified operator.
+     */
+    static QVariant compareNonNullValues( QgsExpression *parent, const QgsExpressionContext *context, const QVariant &vL, const QVariant &vR, BinaryOperator op );
 
     BinaryOperator mOp;
     std::unique_ptr<QgsExpressionNode> mOpLeft;

--- a/src/core/expression/qgsexpressionnodeimpl.h
+++ b/src/core/expression/qgsexpressionnodeimpl.h
@@ -217,8 +217,6 @@ class CORE_EXPORT QgsExpressionNodeBinaryOperator : public QgsExpressionNode
 #ifdef SIP_RUN
     QgsExpressionNodeBinaryOperator( const QgsExpressionNodeBinaryOperator &other );
 #endif
-
-    static bool compare( double diff, BinaryOperator op );
     qlonglong computeInt( qlonglong x, qlonglong y );
     double computeDouble( double x, double y );
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -792,21 +792,101 @@ class TestQgsExpression : public QObject
       QTest::newRow( "int division by zero with floats" ) << "1.0//0.0" << false << QVariant();
 
       // comparison
+
+      // equal
+
       QTest::newRow( "eq int" ) << "1+1 = 2" << false << QVariant( 1 );
       QTest::newRow( "eq double" ) << "3.2 = 2.2+1" << false << QVariant( 1 );
       QTest::newRow( "eq string" ) << "'a' = 'b'" << false << QVariant( 0 );
       QTest::newRow( "eq null" ) << "2 = null" << false << QVariant();
       QTest::newRow( "eq mixed" ) << "'a' = 1" << false << QVariant( 0 );
+
+      // equal, boolean values
+
+      QTest::newRow( "eq bool both true/true" ) << "TRUE = TRUE" << false << QVariant( 1 );
+      QTest::newRow( "eq bool both true/false" ) << "TRUE = FALSE" << false << QVariant( 0 );
+      QTest::newRow( "eq bool both false/true" ) << "FALSE = TRUE" << false << QVariant( 0 );
+      QTest::newRow( "eq bool both false/false" ) << "FALSE = FALSE" << false << QVariant( 1 );
+      QTest::newRow( "eq bool first int second true true/true" ) << "TRUE = 1" << false << QVariant( 1 );
+      QTest::newRow( "eq bool first int second false true/false" ) << "TRUE = 0" << false << QVariant( 0 );
+      QTest::newRow( "eq bool first int second true false/true" ) << "FALSE = 1" << false << QVariant( 0 );
+      QTest::newRow( "eq bool first int second false false/false" ) << "FALSE = 0" << false << QVariant( 1 );
+      QTest::newRow( "eq int first bool second true true/true" ) << "1 = TRUE" << false << QVariant( 1 );
+      QTest::newRow( "eq int first bool second false true/false" ) << "1 = FALSE" << false << QVariant( 0 );
+      QTest::newRow( "eq int first bool second true false/true" ) << "0 = TRUE" << false << QVariant( 0 );
+      QTest::newRow( "eq int first bool second false false/false" ) << "0 = FALSE" << false << QVariant( 1 );
+      QTest::newRow( "eq bool first string int second true true/true" ) << "TRUE = '1'" << false << QVariant( 1 );
+      QTest::newRow( "eq bool first string int second false true/false" ) << "TRUE = '0'" << false << QVariant( 0 );
+      QTest::newRow( "eq bool first string int second true false/true" ) << "FALSE = '1'" << false << QVariant( 0 );
+      QTest::newRow( "eq bool first string int second false false/false" ) << "FALSE = '0'" << false << QVariant( 1 );
+      QTest::newRow( "eq string int first bool second true true/true" ) << "'1' = TRUE" << false << QVariant( 1 );
+      QTest::newRow( "eq string int first bool second false true/false" ) << "'1' = FALSE" << false << QVariant( 0 );
+      QTest::newRow( "eq string int first bool second true false/true" ) << "'0' = TRUE" << false << QVariant( 0 );
+      QTest::newRow( "eq string int first bool second false false/false" ) << "'0' = FALSE" << false << QVariant( 1 );
+      QTest::newRow( "eq bool first string bool second true true/true" ) << "TRUE = 'true'" << false << QVariant( 1 );
+      QTest::newRow( "eq bool first string bool second false true/false" ) << "TRUE = 'false'" << false << QVariant( 0 );
+      QTest::newRow( "eq bool first string bool second true false/true" ) << "FALSE = 'true'" << false << QVariant( 0 );
+      QTest::newRow( "eq bool first string bool second false false/false" ) << "FALSE = 'false'" << false << QVariant( 1 );
+      QTest::newRow( "eq string bool first bool second true true/true" ) << "'true' = TRUE" << false << QVariant( 1 );
+      QTest::newRow( "eq string bool first bool second false true/false" ) << "'true' = FALSE" << false << QVariant( 0 );
+      QTest::newRow( "eq string bool first bool second true false/true" ) << "'false' = TRUE" << false << QVariant( 0 );
+      QTest::newRow( "eq string bool first bool second false false/false" ) << "'false' = FALSE" << false << QVariant( 1 );
+
+      // not equal
       QTest::newRow( "ne int 1" ) << "3 != 4" << false << QVariant( 1 );
       QTest::newRow( "ne int 2" ) << "3 != 3" << false << QVariant( 0 );
+
+      // not equal, boolean values
+
+      QTest::newRow( "ne bool both true/true" ) << "TRUE != TRUE" << false << QVariant( 0 );
+      QTest::newRow( "ne bool both true/false" ) << "TRUE != FALSE" << false << QVariant( 1 );
+      QTest::newRow( "ne bool both false/true" ) << "FALSE != TRUE" << false << QVariant( 1 );
+      QTest::newRow( "ne bool both false/false" ) << "FALSE != FALSE" << false << QVariant( 0 );
+      QTest::newRow( "ne bool first int second true true/true" ) << "TRUE != 1" << false << QVariant( 0 );
+      QTest::newRow( "ne bool first int second false true/false" ) << "TRUE != 0" << false << QVariant( 1 );
+      QTest::newRow( "ne bool first int second true false/true" ) << "FALSE != 1" << false << QVariant( 1 );
+      QTest::newRow( "ne bool first int second false false/false" ) << "FALSE != 0" << false << QVariant( 0 );
+      QTest::newRow( "ne int first bool second true true/true" ) << "1 != TRUE" << false << QVariant( 0 );
+      QTest::newRow( "ne int first bool second false true/false" ) << "1 != FALSE" << false << QVariant( 1 );
+      QTest::newRow( "ne int first bool second true false/true" ) << "0 != TRUE" << false << QVariant( 1 );
+      QTest::newRow( "ne int first bool second false false/false" ) << "0 != FALSE" << false << QVariant( 0 );
+      QTest::newRow( "ne bool first string int second true true/true" ) << "TRUE != '1'" << false << QVariant( 0 );
+      QTest::newRow( "ne bool first string int second false true/false" ) << "TRUE != '0'" << false << QVariant( 1 );
+      QTest::newRow( "ne bool first string int second true false/true" ) << "FALSE != '1'" << false << QVariant( 1 );
+      QTest::newRow( "ne bool first string int second false false/false" ) << "FALSE != '0'" << false << QVariant( 0 );
+      QTest::newRow( "ne string int first bool second true true/true" ) << "'1' != TRUE" << false << QVariant( 0 );
+      QTest::newRow( "ne string int first bool second false true/false" ) << "'1' != FALSE" << false << QVariant( 1 );
+      QTest::newRow( "ne string int first bool second true false/true" ) << "'0' != TRUE" << false << QVariant( 1 );
+      QTest::newRow( "ne string int first bool second false false/false" ) << "'0' != FALSE" << false << QVariant( 0 );
+      QTest::newRow( "ne bool first string bool second true true/true" ) << "TRUE != 'true'" << false << QVariant( 0 );
+      QTest::newRow( "ne bool first string bool second false true/false" ) << "TRUE != 'false'" << false << QVariant( 1 );
+      QTest::newRow( "ne bool first string bool second true false/true" ) << "FALSE != 'true'" << false << QVariant( 1 );
+      QTest::newRow( "ne bool first string bool second false false/false" ) << "FALSE != 'false'" << false << QVariant( 0 );
+      QTest::newRow( "ne string bool first bool second true true/true" ) << "'true' != TRUE" << false << QVariant( 0 );
+      QTest::newRow( "ne string bool first bool second false true/false" ) << "'true' != FALSE" << false << QVariant( 1 );
+      QTest::newRow( "ne string bool first bool second true false/true" ) << "'false' != TRUE" << false << QVariant( 1 );
+      QTest::newRow( "ne string bool first bool second false false/false" ) << "'false' != FALSE" << false << QVariant( 0 );
+
+      // less than
+
       QTest::newRow( "lt int 1" ) << "3 < 4" << false << QVariant( 1 );
       QTest::newRow( "lt int 2" ) << "3 < 3" << false << QVariant( 0 );
+
+      // greater than
+
       QTest::newRow( "gt int 1" ) << "3 > 4" << false << QVariant( 0 );
       QTest::newRow( "gt int 2" ) << "3 > 3" << false << QVariant( 0 );
+
+      // less than or equal to
+
       QTest::newRow( "le int 1" ) << "3 <= 4" << false << QVariant( 1 );
       QTest::newRow( "le int 2" ) << "3 <= 3" << false << QVariant( 1 );
+
+      // greater than or equal to
+
       QTest::newRow( "ge int 1" ) << "3 >= 4" << false << QVariant( 0 );
       QTest::newRow( "ge int 2" ) << "3 >= 3" << false << QVariant( 1 );
+
       QTest::newRow( "lt text 1" ) << "'bar' < 'foo'" << false << QVariant( 1 );
       QTest::newRow( "lt text 2" ) << "'foo' < 'bar'" << false << QVariant( 0 );
       QTest::newRow( "'nan'='nan'" ) << "'nan'='nan'" << false << QVariant( 1 );
@@ -870,6 +950,68 @@ class TestQgsExpression : public QObject
       QTest::newRow( "'1.1' is '1.10000'" ) << "'1.1' is '1.10000'" << false << QVariant( 0 );
       QTest::newRow( "1.1 is '1.10'" ) << "1.1 is '1.10'" << false << QVariant( 1 );
       QTest::newRow( "'1.10' is 1.1" ) << "'1.10' is 1.1" << false << QVariant( 1 );
+
+      // is, boolean values
+
+      QTest::newRow( "is bool both true/true" ) << "TRUE IS TRUE" << false << QVariant( 1 );
+      QTest::newRow( "is bool both true/false" ) << "TRUE IS FALSE" << false << QVariant( 0 );
+      QTest::newRow( "is bool both false/true" ) << "FALSE IS TRUE" << false << QVariant( 0 );
+      QTest::newRow( "is bool both false/false" ) << "FALSE IS FALSE" << false << QVariant( 1 );
+      QTest::newRow( "is bool first int second true true/true" ) << "TRUE IS 1" << false << QVariant( 1 );
+      QTest::newRow( "is bool first int second false true/false" ) << "TRUE IS 0" << false << QVariant( 0 );
+      QTest::newRow( "is bool first int second true false/true" ) << "FALSE IS 1" << false << QVariant( 0 );
+      QTest::newRow( "is bool first int second false false/false" ) << "FALSE IS 0" << false << QVariant( 1 );
+      QTest::newRow( "is int first bool second true true/true" ) << "1 IS TRUE" << false << QVariant( 1 );
+      QTest::newRow( "is int first bool second false true/false" ) << "1 IS FALSE" << false << QVariant( 0 );
+      QTest::newRow( "is int first bool second true false/true" ) << "0 IS TRUE" << false << QVariant( 0 );
+      QTest::newRow( "is int first bool second false false/false" ) << "0 IS FALSE" << false << QVariant( 1 );
+      QTest::newRow( "is bool first string int second true true/true" ) << "TRUE IS '1'" << false << QVariant( 1 );
+      QTest::newRow( "is bool first string int second false true/false" ) << "TRUE IS '0'" << false << QVariant( 0 );
+      QTest::newRow( "is bool first string int second true false/true" ) << "FALSE IS '1'" << false << QVariant( 0 );
+      QTest::newRow( "is bool first string int second false false/false" ) << "FALSE IS '0'" << false << QVariant( 1 );
+      QTest::newRow( "is string int first bool second true true/true" ) << "'1' IS TRUE" << false << QVariant( 1 );
+      QTest::newRow( "is string int first bool second false true/false" ) << "'1' IS FALSE" << false << QVariant( 0 );
+      QTest::newRow( "is string int first bool second true false/true" ) << "'0' IS TRUE" << false << QVariant( 0 );
+      QTest::newRow( "is string int first bool second false false/false" ) << "'0' IS FALSE" << false << QVariant( 1 );
+      QTest::newRow( "is bool first string bool second true true/true" ) << "TRUE IS 'true'" << false << QVariant( 1 );
+      QTest::newRow( "is bool first string bool second false true/false" ) << "TRUE IS 'false'" << false << QVariant( 0 );
+      QTest::newRow( "is bool first string bool second true false/true" ) << "FALSE IS 'true'" << false << QVariant( 0 );
+      QTest::newRow( "is bool first string bool second false false/false" ) << "FALSE IS 'false'" << false << QVariant( 1 );
+      QTest::newRow( "is string bool first bool second true true/true" ) << "'true' IS TRUE" << false << QVariant( 1 );
+      QTest::newRow( "is string bool first bool second false true/false" ) << "'true' IS FALSE" << false << QVariant( 0 );
+      QTest::newRow( "is string bool first bool second true false/true" ) << "'false' IS TRUE" << false << QVariant( 0 );
+      QTest::newRow( "is string bool first bool second false false/false" ) << "'false' IS FALSE" << false << QVariant( 1 );
+
+      // is not, boolean values
+
+      QTest::newRow( "is not bool both true/true" ) << "TRUE IS NOT TRUE" << false << QVariant( 0 );
+      QTest::newRow( "is not bool both true/false" ) << "TRUE IS NOT FALSE" << false << QVariant( 1 );
+      QTest::newRow( "is not bool both false/true" ) << "FALSE IS NOT TRUE" << false << QVariant( 1 );
+      QTest::newRow( "is not bool both false/false" ) << "FALSE IS NOT FALSE" << false << QVariant( 0 );
+      QTest::newRow( "is not bool first int second true true/true" ) << "TRUE IS NOT 1" << false << QVariant( 0 );
+      QTest::newRow( "is not bool first int second false true/false" ) << "TRUE IS NOT 0" << false << QVariant( 1 );
+      QTest::newRow( "is not bool first int second true false/true" ) << "FALSE IS NOT 1" << false << QVariant( 1 );
+      QTest::newRow( "is not bool first int second false false/false" ) << "FALSE IS NOT 0" << false << QVariant( 0 );
+      QTest::newRow( "is not int first bool second true true/true" ) << "1 IS NOT TRUE" << false << QVariant( 0 );
+      QTest::newRow( "is not int first bool second false true/false" ) << "1 IS NOT FALSE" << false << QVariant( 1 );
+      QTest::newRow( "is not int first bool second true false/true" ) << "0 IS NOT TRUE" << false << QVariant( 1 );
+      QTest::newRow( "is not int first bool second false false/false" ) << "0 IS NOT FALSE" << false << QVariant( 0 );
+      QTest::newRow( "is not bool first string int second true true/true" ) << "TRUE IS NOT '1'" << false << QVariant( 0 );
+      QTest::newRow( "is not bool first string int second false true/false" ) << "TRUE IS NOT '0'" << false << QVariant( 1 );
+      QTest::newRow( "is not bool first string int second true false/true" ) << "FALSE IS NOT '1'" << false << QVariant( 1 );
+      QTest::newRow( "is not bool first string int second false false/false" ) << "FALSE IS NOT '0'" << false << QVariant( 0 );
+      QTest::newRow( "is not string int first bool second true true/true" ) << "'1' IS NOT TRUE" << false << QVariant( 0 );
+      QTest::newRow( "is not string int first bool second false true/false" ) << "'1' IS NOT FALSE" << false << QVariant( 1 );
+      QTest::newRow( "is not string int first bool second true false/true" ) << "'0' IS NOT TRUE" << false << QVariant( 1 );
+      QTest::newRow( "is not string int first bool second false false/false" ) << "'0' IS NOT FALSE" << false << QVariant( 0 );
+      QTest::newRow( "is not bool first string bool second true true/true" ) << "TRUE IS NOT 'true'" << false << QVariant( 0 );
+      QTest::newRow( "is not bool first string bool second false true/false" ) << "TRUE IS NOT 'false'" << false << QVariant( 1 );
+      QTest::newRow( "is not bool first string bool second true false/true" ) << "FALSE IS NOT 'true'" << false << QVariant( 1 );
+      QTest::newRow( "is not bool first string bool second false false/false" ) << "FALSE IS NOT 'false'" << false << QVariant( 0 );
+      QTest::newRow( "is not string bool first bool second true true/true" ) << "'true' IS NOT TRUE" << false << QVariant( 0 );
+      QTest::newRow( "is not string bool first bool second false true/false" ) << "'true' IS NOT FALSE" << false << QVariant( 1 );
+      QTest::newRow( "is not string bool first bool second true false/true" ) << "'false' IS NOT TRUE" << false << QVariant( 1 );
+      QTest::newRow( "is not string bool first bool second false false/false" ) << "'false' IS NOT FALSE" << false << QVariant( 0 );
 
       //  logical
       QTest::newRow( "T or F" ) << "1=1 or 2=3" << false << QVariant( 1 );


### PR DESCRIPTION
If we know that the compared values are definitely non null, then
an IS operator should be identical to = (and similar for IS NOT/not
equal)

This makes IS/IS NOT use the same refined and optimised logic
for value comparison as equals.