### PR TITLE
[ux] When loading PG views in the Data Source Manager, only show warning if 'Feature id' is not set

### DIFF
--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -1329,7 +1329,18 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addDatabaseLayers( const QStringList &
       QgsMessageLog::logMessage( QObject::tr( "%1 is an invalid layer - not loaded" ).arg( layerPath ) );
       QLabel *msgLabel = new QLabel( QObject::tr( "%1 is an invalid layer and cannot be loaded. Please check the <a href=\"#messageLog\">message log</a> for further info." ).arg( layerPath ), QgisApp::instance()->messageBar() );
       msgLabel->setWordWrap( true );
-      QObject::connect( msgLabel, &QLabel::linkActivated, QgisApp::instance()->logDock(), &QWidget::show );
+
+      if ( providerKey == QLatin1String( "postgres" ) )
+      {
+        QObject::connect( msgLabel, &QLabel::linkActivated, QgisApp::instance(), [] {
+          QgisApp::instance()->openMessageLog( QObject::tr( "PostGIS" ) );
+        } );
+      }
+      else
+      {
+        QObject::connect( msgLabel, &QLabel::linkActivated, QgisApp::instance()->logDock(), &QWidget::show );
+      }
+
       QgsMessageBarItem *item = new QgsMessageBarItem( msgLabel, Qgis::MessageLevel::Warning );
       QgisApp::instance()->messageBar()->pushItem( item );
       delete layer;

--- a/src/providers/postgres/qgspgtablemodel.cpp
+++ b/src/providers/postgres/qgspgtablemodel.cpp
@@ -96,7 +96,7 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty &layerProper
     }
 
     QString tip;
-    bool withTipButSelectable = false;
+    bool layerNeedsFeatureId = false;
     if ( !layerProperty.isRaster )
     {
       if ( wkbType == Qgis::WkbType::Unknown )
@@ -110,7 +110,7 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty &layerProper
       else if ( !layerProperty.pkCols.isEmpty() )
       {
         tip = tr( "Select columns in the '%1' column that uniquely identify features of this layer" ).arg( tr( "Feature id" ) );
-        withTipButSelectable = true;
+        layerNeedsFeatureId = true;
       }
     }
 
@@ -160,7 +160,9 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty &layerProper
       pkItem->setFlags( pkItem->flags() | Qt::ItemIsEditable );
     }
     else
+    {
       pkItem->setFlags( pkItem->flags() & ~Qt::ItemIsEditable );
+    }
 
     pkItem->setData( layerProperty.pkCols, Qt::UserRole + 1 );
 
@@ -176,7 +178,16 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty &layerProper
 
     pkItem->setData( defPk, Qt::UserRole + 2 );
     if ( !defPk.isEmpty() )
+    {
       pkItem->setText( defPk.join( ',' ) );
+
+      // Reset the tip since we're pre-selecting fields in the Feature id combo box.
+      // Note we don't reset the tip if Geom type or SRID need some action from users.
+      if ( layerNeedsFeatureId )
+      {
+        tip = QString();
+      }
+    }
 
     QStandardItem *selItem = new QStandardItem( QString() );
     selItem->setFlags( selItem->flags() | Qt::ItemIsUserCheckable );
@@ -237,28 +248,10 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty &layerProper
     childItemList << checkPkUnicityItem;
     childItemList << sqlItem;
 
-    const auto constChildItemList = childItemList;
-    for ( QStandardItem *item : constChildItemList )
+    for ( int column = 0; column < childItemList.count(); column++ )
     {
-      if ( tip.isEmpty() || withTipButSelectable )
-        item->setFlags( item->flags() | Qt::ItemIsSelectable );
-      else
-        item->setFlags( item->flags() & ~Qt::ItemIsSelectable );
-
-      if ( item->toolTip().isEmpty() && tip.isEmpty() && item != checkPkUnicityItem && item != selItem )
-      {
-        item->setToolTip( QString() );
-      }
-      else
-      {
-        if ( item == schemaNameItem )
-          item->setData( QgsApplication::getThemeIcon( QStringLiteral( "/mIconWarning.svg" ) ), Qt::DecorationRole );
-
-        if ( item == schemaNameItem || item == tableItem || item == geomItem )
-        {
-          item->setToolTip( tip );
-        }
-      }
+      QStandardItem *item = childItemList.at( column );
+      setItemStatus( item, tip, column );
     }
 
     if ( !schemaItem )
@@ -282,6 +275,38 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty &layerProper
     schemaItem->appendRow( childItemList );
 
     ++mTableCount;
+  }
+}
+
+void QgsPgTableModel::setItemStatus( QStandardItem *item, const QString &tip, int column )
+{
+  if ( tip.isEmpty() )
+  {
+    item->setFlags( item->flags() | Qt::ItemIsSelectable );
+
+    if ( column == DbtmSchema || column == DbtmTable || column == DbtmGeomCol )
+    {
+      item->setToolTip( QString() );
+
+      if ( column == DbtmSchema )
+      {
+        item->setData( QVariant(), Qt::DecorationRole );
+      }
+    }
+  }
+  else
+  {
+    item->setFlags( item->flags() & ~Qt::ItemIsSelectable );
+
+    if ( column == DbtmSchema || column == DbtmTable || column == DbtmGeomCol )
+    {
+      item->setToolTip( tip );
+
+      if ( column == DbtmSchema )
+      {
+        item->setData( QgsApplication::getThemeIcon( QStringLiteral( "/mIconWarning.svg" ) ), Qt::DecorationRole );
+      }
+    }
   }
 }
 
@@ -362,6 +387,7 @@ bool QgsPgTableModel::setData( const QModelIndex &idx, const QVariant &value, in
   if ( !QStandardItemModel::setData( idx, value, role ) )
     return false;
 
+  // After changes in type, srid, or feature id columns, update other sibling columns
   if ( idx.column() == DbtmType || idx.column() == DbtmSrid || idx.column() == DbtmPkCol )
   {
     const Qgis::WkbType wkbType = static_cast<Qgis::WkbType>( idx.sibling( idx.row(), DbtmType ).data( Qt::UserRole + 2 ).toInt() );
@@ -386,35 +412,15 @@ bool QgsPgTableModel::setData( const QModelIndex &idx, const QVariant &value, in
       const QSet<QString> s0( qgis::listToSet( idx.sibling( idx.row(), DbtmPkCol ).data( Qt::UserRole + 2 ).toStringList() ) );
       const QSet<QString> s1( qgis::listToSet( pkCols ) );
       if ( !s0.intersects( s1 ) )
+      {
         tip = tr( "Select columns in the '%1' column that uniquely identify features of this layer" ).arg( tr( "Feature id" ) );
+      }
     }
 
-    for ( int i = 0; i < columnCount(); i++ )
+    for ( int column = 0; column < columnCount(); column++ )
     {
-      QStandardItem *item = itemFromIndex( idx.sibling( idx.row(), i ) );
-      if ( tip.isEmpty() )
-      {
-        if ( i == DbtmSchema )
-        {
-          item->setData( QVariant(), Qt::DecorationRole );
-        }
-
-        item->setFlags( item->flags() | Qt::ItemIsSelectable );
-        item->setToolTip( QString() );
-      }
-      else
-      {
-        item->setFlags( item->flags() & ~Qt::ItemIsSelectable );
-
-        if ( i == DbtmSchema )
-          item->setData( QgsApplication::getThemeIcon( QStringLiteral( "/mIconWarning.svg" ) ), Qt::DecorationRole );
-
-        if ( i == DbtmSchema || i == DbtmTable || i == DbtmGeomCol )
-        {
-          item->setFlags( item->flags() );
-          item->setToolTip( tip );
-        }
-      }
+      QStandardItem *item = itemFromIndex( idx.sibling( idx.row(), column ) );
+      setItemStatus( item, tip, column );
     }
   }
 

--- a/src/providers/postgres/qgspgtablemodel.h
+++ b/src/providers/postgres/qgspgtablemodel.h
@@ -69,6 +69,15 @@ class QgsPgTableModel : public QgsAbstractDbTableModel
 
     void setConnectionName( const QString &connName ) { mConnName = connName; }
 
+    /**
+     * Sets flags, tool tips and decorators to the schema, table and geometry column items.
+     *
+     * \param item                Item to be modified.
+     * \param tip                 Tool tip to be applied to the item.
+     * \param column              Column where the item is located in the current row.
+     */
+    void setItemStatus( QStandardItem *item, const QString &tip, int column );
+
   private:
     //! Number of tables in the model
     int mTableCount = 0;


### PR DESCRIPTION
Example of warning for PG views:

![image](https://github.com/user-attachments/assets/1fc97264-40eb-49c0-b0bb-e07e07fe42ab)

The warning lets users know a unique field should be selected, but QGIS automatically picks the first available column from the view definition, in case users don't select any field. Therefore, the warning will be hidden by default and will only appear if the "Feature id" is missing after some manipulation from the user.

----

This PR also helps to remove code duplication, which was causing strange stuff, like removing all tool tips when configuring geometry column, srid, or feature id in the listed tables.

-----

Funded by [City of Frankfurt – Stadtplanungsamt](https://www.stadtplanungsamt-frankfurt.de/about_us_5645.html).