### PR TITLE
Server: Add attribute name to WMS GetFeatureInfo response

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2156,6 +2156,7 @@ namespace QgsWms
     QString attributeName = layer->attributeDisplayName( attributeIndex );
     QDomElement attributeElement = doc.createElement( QStringLiteral( "Attribute" ) );
     attributeElement.setAttribute( QStringLiteral( "name" ), attributeName );
+    attributeElement.setAttribute( QStringLiteral( "attrname" ), fields.at( attributeIndex ).name() );
     const QgsEditorWidgetSetup setup = layer->editorWidgetSetup( attributeIndex );
     attributeElement.setAttribute( QStringLiteral( "value" ), QgsExpression::replaceExpressionText( replaceValueMapAndRelation( layer, attributeIndex, featureAttributes[attributeIndex] ), &renderContext.expressionContext() ) );
     featureElem.appendChild( attributeElement );

--- a/tests/testdata/qgis_server/get_postgres_types_json_dict.txt
+++ b/tests/testdata/qgis_server/get_postgres_types_json_dict.txt
@@ -5,9 +5,9 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="json" name="json">
   <Feature id="2">
-   <Attribute value="2" name="pk"/>
-   <Attribute value="{&#xa;    &quot;a&quot;: 1,&#xa;    &quot;b&quot;: 2&#xa;}&#xa;" name="jvalue"/>
-   <Attribute value="{&#xa;    &quot;c&quot;: 4,&#xa;    &quot;d&quot;: 5&#xa;}&#xa;" name="jbvalue"/>
+   <Attribute value="2" name="pk" attrname="pk"/>
+   <Attribute value="{&#xa;    &quot;a&quot;: 1,&#xa;    &quot;b&quot;: 2&#xa;}&#xa;" name="jvalue" attrname="jvalue"/>
+   <Attribute value="{&#xa;    &quot;c&quot;: 4,&#xa;    &quot;d&quot;: 5&#xa;}&#xa;" name="jbvalue" attrname="jbvalue"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/get_postgres_types_json_list.txt
+++ b/tests/testdata/qgis_server/get_postgres_types_json_list.txt
@@ -5,9 +5,9 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="json" name="json">
   <Feature id="1">
-   <Attribute value="1" name="pk"/>
-   <Attribute value="[&#xa;    1,&#xa;    2,&#xa;    3&#xa;]&#xa;" name="jvalue"/>
-   <Attribute value="[&#xa;    4,&#xa;    5,&#xa;    6&#xa;]&#xa;" name="jbvalue"/>
+   <Attribute value="1" name="pk" attrname="pk"/>
+   <Attribute value="[&#xa;    1,&#xa;    2,&#xa;    3&#xa;]&#xa;" name="jvalue" attrname="jvalue"/>
+   <Attribute value="[&#xa;    4,&#xa;    5,&#xa;    6&#xa;]&#xa;" name="jbvalue" attrname="jbvalue"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-group_name-notqueryable.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-group_name-notqueryable.txt
@@ -5,9 +5,9 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="testlayer2" name="testlayer2">
   <Feature id="2">
-   <Attribute value="3" name="id"/>
-   <Attribute value="three" name="name"/>
-   <Attribute value="three èé↓" name="utf8nameè"/>
+   <Attribute value="3" name="id" attrname="id"/>
+   <Attribute value="three" name="name" attrname="name"/>
+   <Attribute value="three èé↓" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-xml.txt
@@ -5,9 +5,9 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="A test vector layer" name="testlayer èé">
   <Feature id="2">
-   <Attribute value="3" name="id"/>
-   <Attribute value="three" name="name"/>
-   <Attribute value="three èé↓" name="utf8nameè"/>
+   <Attribute value="3" name="id" attrname="id"/>
+   <Attribute value="three" name="name" attrname="name"/>
+   <Attribute value="three èé↓" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-thousands-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-thousands-text-xml.txt
@@ -5,11 +5,11 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="testlayer_thousands" name="testlayer_thousands">
   <Feature id="2">
-   <Attribute value="3" name="id"/>
-   <Attribute value="three" name="name"/>
-   <Attribute value="three èé↓" name="utf8nameè"/>
-   <Attribute value="123456" name="long_int"/>
-   <Attribute value="123456.8900" name="long_float"/>
+   <Attribute value="3" name="id" attrname="id"/>
+   <Attribute value="three" name="name" attrname="name"/>
+   <Attribute value="three èé↓" name="utf8nameè" attrname="utf8nameè"/>
+   <Attribute value="123456" name="long_int" attrname="long_int"/>
+   <Attribute value="123456.8900" name="long_float" attrname="long_float"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values0-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values0-text-xml.txt
@@ -5,21 +5,21 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="layer0" name="layer0">
   <Feature id="1">
-   <Attribute value="1" name="id"/>
-   <Attribute value="one" name="name"/>
-   <Attribute value="First Value" name="utf8nameè"/>
+   <Attribute value="1" name="id" attrname="id"/>
+   <Attribute value="one" name="name" attrname="name"/>
+   <Attribute value="First Value" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
   </Feature>
   <Feature id="2">
-   <Attribute value="2" name="id"/>
-   <Attribute value="two" name="name"/>
-   <Attribute value="Second Value" name="utf8nameè"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="two" name="name" attrname="name"/>
+   <Attribute value="Second Value" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
   <Feature id="3">
-   <Attribute value="3" name="id"/>
-   <Attribute value="three" name="name"/>
-   <Attribute value="Third èé↓" name="utf8nameè"/>
+   <Attribute value="3" name="id" attrname="id"/>
+   <Attribute value="three" name="name" attrname="name"/>
+   <Attribute value="Third èé↓" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values1-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values1-text-xml.txt
@@ -5,23 +5,23 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="layer1" name="layer1">
   <Feature id="1">
-   <Attribute value="Id no. 1 value" name="id"/>
-   <Attribute value="one_value" name="name"/>
-   <Attribute value="one èé" name="utf8nameè"/>
+   <Attribute value="Id no. 1 value" name="id" attrname="id"/>
+   <Attribute value="one_value" name="name" attrname="name"/>
+   <Attribute value="one èé" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
    <Attribute type="derived" value="Point (913209.0358 5606025.2373)" name="geometry"/>
   </Feature>
   <Feature id="2">
-   <Attribute value="Id no. 2 value" name="id"/>
-   <Attribute value="two_val" name="name"/>
-   <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="Id no. 2 value" name="id" attrname="id"/>
+   <Attribute value="two_val" name="name" attrname="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
    <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
   <Feature id="3">
-   <Attribute value="Id número 3 value" name="id"/>
-   <Attribute value="three_val" name="name"/>
-   <Attribute value="three èé↓" name="utf8nameè"/>
+   <Attribute value="Id número 3 value" name="id" attrname="id"/>
+   <Attribute value="three_val" name="name" attrname="name"/>
+   <Attribute value="three èé↓" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
    <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values2-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values2-text-xml.txt
@@ -5,23 +5,23 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer name="layer2">
   <Feature id="1">
-   <Attribute value="value PE 1000 PN6" name="id"/>
-   <Attribute value="one" name="name"/>
-   <Attribute value="one èé" name="utf8nameè"/>
+   <Attribute value="value PE 1000 PN6" name="id" attrname="id"/>
+   <Attribute value="one" name="name" attrname="name"/>
+   <Attribute value="one èé" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
    <Attribute type="derived" value="Point (913209.0358 5606025.2373)" name="geometry"/>
   </Feature>
   <Feature id="2">
-   <Attribute value="value PE" name="id"/>
-   <Attribute value="two" name="name"/>
-   <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="value PE" name="id" attrname="id"/>
+   <Attribute value="two" name="name" attrname="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
    <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
   <Feature id="3">
-   <Attribute value="value PE 1000 PN8" name="id"/>
-   <Attribute value="three" name="name"/>
-   <Attribute value="three èé↓" name="utf8nameè"/>
+   <Attribute value="value PE 1000 PN8" name="id" attrname="id"/>
+   <Attribute value="three" name="name" attrname="name"/>
+   <Attribute value="three èé↓" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
    <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values3-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values3-text-xml.txt
@@ -5,20 +5,20 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="layer3" name="layer3">
   <Feature id="1">
-   <Attribute value="1" name="id"/>
-   <Attribute value="Id no. 1 value, Id no. 2 value, Id número 3 value" name="location"/>
+   <Attribute value="1" name="id" attrname="id"/>
+   <Attribute value="Id no. 1 value, Id no. 2 value, Id número 3 value" name="location" attrname="location"/>
    <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
    <Attribute type="derived" value="Point (913209.0358 5606025.2373)" name="geometry"/>
   </Feature>
   <Feature id="2">
-   <Attribute value="2" name="id"/>
-   <Attribute value="" name="location"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="" name="location" attrname="location"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
    <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
   <Feature id="3">
-   <Attribute value="3" name="id"/>
-   <Attribute value="" name="location"/>
+   <Attribute value="3" name="id" attrname="id"/>
+   <Attribute value="" name="location" attrname="location"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
    <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values4-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values4-text-xml.txt
@@ -5,26 +5,26 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="layer4" name="layer4">
   <Feature id="1">
-   <Attribute value="one èé" name="utf8nameè"/>
-   <Attribute value="Id no. 1 value" name="j_value_id"/>
-   <Attribute value="Id no. 1 value" name="id"/>
-   <Attribute value="one_value" name="name"/>
+   <Attribute value="one èé" name="utf8nameè" attrname="utf8nameè"/>
+   <Attribute value="Id no. 1 value" name="j_value_id" attrname="j_value_id"/>
+   <Attribute value="Id no. 1 value" name="id" attrname="id"/>
+   <Attribute value="one_value" name="name" attrname="name"/>
    <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
    <Attribute type="derived" value="Point (913209.0358 5606025.2373)" name="geometry"/>
   </Feature>
   <Feature id="2">
-   <Attribute value="two àò" name="utf8nameè"/>
-   <Attribute value="Id no. 2 value" name="j_value_id"/>
-   <Attribute value="Id no. 2 value" name="id"/>
-   <Attribute value="two_val" name="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
+   <Attribute value="Id no. 2 value" name="j_value_id" attrname="j_value_id"/>
+   <Attribute value="Id no. 2 value" name="id" attrname="id"/>
+   <Attribute value="two_val" name="name" attrname="name"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
    <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
   <Feature id="3">
-   <Attribute value="three èé↓" name="utf8nameè"/>
-   <Attribute value="Id número 3 value" name="j_value_id"/>
-   <Attribute value="Id número 3 value" name="id"/>
-   <Attribute value="three_val" name="name"/>
+   <Attribute value="three èé↓" name="utf8nameè" attrname="utf8nameè"/>
+   <Attribute value="Id número 3 value" name="j_value_id" attrname="j_value_id"/>
+   <Attribute value="Id número 3 value" name="id" attrname="id"/>
+   <Attribute value="three_val" name="name" attrname="name"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
    <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values5-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values5-text-xml.txt
@@ -5,23 +5,23 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="layer3" name="layer3">
   <Feature id="1">
-   <Attribute value="one èé" name="utf8nameè"/>
-   <Attribute value="Id no. 1 value" name="id"/>
-   <Attribute value="one_value" name="name"/>
+   <Attribute value="one èé" name="utf8nameè" attrname="utf8nameè"/>
+   <Attribute value="Id no. 1 value" name="id" attrname="id"/>
+   <Attribute value="one_value" name="name" attrname="name"/>
    <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
    <Attribute type="derived" value="Point (913209.0358 5606025.2373)" name="geometry"/>
   </Feature>
   <Feature id="2">
-   <Attribute value="two àò" name="utf8nameè"/>
-   <Attribute value="Id no. 2 value" name="id"/>
-   <Attribute value="two_val" name="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
+   <Attribute value="Id no. 2 value" name="id" attrname="id"/>
+   <Attribute value="two_val" name="name" attrname="name"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
    <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
   <Feature id="3">
-   <Attribute value="three èé↓" name="utf8nameè"/>
-   <Attribute value="Id número 3 value" name="id"/>
-   <Attribute value="three_val" name="name"/>
+   <Attribute value="three èé↓" name="utf8nameè" attrname="utf8nameè"/>
+   <Attribute value="Id número 3 value" name="id" attrname="id"/>
+   <Attribute value="three_val" name="name" attrname="name"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
    <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter.txt
@@ -6,9 +6,9 @@ Content-Type: text/xml; charset=utf-8
  <BoundingBox maxy="5606017.87425818" maxx="913214.67407005" miny="5606017.87425818" CRS="EPSG:3857" minx="913214.67407005"/>
  <Layer title="A test vector layer" name="testlayer èé">
   <Feature id="1">
-   <Attribute value="2" name="id"/>
-   <Attribute value="two" name="name"/>
-   <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="two" name="name" attrname="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_gpkg.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_gpkg.txt
@@ -6,9 +6,9 @@ Content-Type: text/xml; charset=utf-8
  <BoundingBox maxy="5606017.87425818" maxx="913214.67407005" miny="5606017.87425818" CRS="EPSG:3857" minx="913214.67407005"/>
  <Layer title="testlayer èé" name="testlayer èé">
   <Feature id="2">
-   <Attribute value="2" name="id"/>
-   <Attribute value="two" name="name"/>
-   <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="two" name="name" attrname="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_no_crs.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_no_crs.txt
@@ -6,9 +6,9 @@ Content-Type: text/xml; charset=utf-8
  <BoundingBox maxy="44.90143568" maxx="8.20354699" miny="44.90143568" CRS="EPSG:4326" minx="8.20354699"/>
  <Layer title="A test vector layer" name="testlayer èé">
   <Feature id="1">
-   <Attribute value="2" name="id"/>
-   <Attribute value="two" name="name"/>
-   <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="two" name="name" attrname="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="44.9014" maxx="8.2035" miny="44.9014" CRS="EPSG:4326" minx="8.2035"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_no_width.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_no_width.txt
@@ -6,9 +6,9 @@ Content-Type: text/xml; charset=utf-8
  <BoundingBox maxy="5606017.87425818" maxx="913214.67407005" miny="5606017.87425818" CRS="EPSG:3857" minx="913214.67407005"/>
  <Layer title="A test vector layer" name="testlayer èé">
   <Feature id="1">
-   <Attribute value="2" name="id"/>
-   <Attribute value="two" name="name"/>
-   <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="two" name="name" attrname="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or.txt
@@ -6,15 +6,15 @@ Content-Type: text/xml; charset=utf-8
  <BoundingBox maxy="5606017.87425818" maxx="913214.67407005" miny="5606011.45647302" CRS="EPSG:3857" minx="913204.91280263"/>
  <Layer title="A test vector layer" name="testlayer èé">
   <Feature id="1">
-   <Attribute value="2" name="id"/>
-   <Attribute value="two" name="name"/>
-   <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="two" name="name" attrname="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
   <Feature id="2">
-   <Attribute value="3" name="id"/>
-   <Attribute value="three" name="name"/>
-   <Attribute value="three èé↓" name="utf8nameè"/>
+   <Attribute value="3" name="id" attrname="id"/>
+   <Attribute value="three" name="name" attrname="name"/>
+   <Attribute value="three èé↓" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or_utf8.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or_utf8.txt
@@ -6,15 +6,15 @@ Content-Type: text/xml; charset=utf-8
  <BoundingBox maxy="5606017.87425818" maxx="913214.67407005" miny="5606011.45647302" CRS="EPSG:3857" minx="913204.91280263"/>
  <Layer title="A test vector layer" name="testlayer èé">
   <Feature id="1">
-   <Attribute value="2" name="id"/>
-   <Attribute value="two" name="name"/>
-   <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="two" name="name" attrname="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
   <Feature id="2">
-   <Attribute value="3" name="id"/>
-   <Attribute value="three" name="name"/>
-   <Attribute value="three èé↓" name="utf8nameè"/>
+   <Attribute value="3" name="id" attrname="id"/>
+   <Attribute value="three" name="name" attrname="name"/>
+   <Attribute value="three èé↓" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_and_exp_filter_exclude.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_and_exp_filter_exclude.txt
@@ -6,9 +6,9 @@ Content-Type: text/xml; charset=utf-8
  <BoundingBox maxy="44.90143568" maxx="8.20354699" miny="44.90143568" CRS="EPSG:4326" minx="8.20354699"/>
  <Layer title="A test vector layer" name="testlayer èé">
   <Feature id="1">
-   <Attribute value="2" name="id"/>
-   <Attribute value="two" name="name"/>
-   <Attribute value="two àò" name="utf8nameè"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="two" name="name" attrname="name"/>
+   <Attribute value="two àò" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="44.9014" maxx="8.2035" miny="44.9014" CRS="EPSG:4326" minx="8.2035"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_filter.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_filter.txt
@@ -5,9 +5,9 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="A test vector layer" name="testlayer èé">
   <Feature id="1">
-   <Attribute name="id" value="2"/>
-   <Attribute name="name" value="two"/>
-   <Attribute name="utf8nameè" value="two àò"/>
+   <Attribute name="id" attrname="id" value="2"/>
+   <Attribute name="name" attrname="name" value="two"/>
+   <Attribute name="utf8nameè" attrname="utf8nameè" value="two àò"/>
    <BoundingBox CRS="EPSG:4326" minx="8.2035" maxx="8.2035" miny="44.9014" maxy="44.9014"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_filter_3857.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_filter_3857.txt
@@ -5,9 +5,9 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="A test vector layer" name="testlayer èé">
   <Feature id="1">
-   <Attribute name="id" value="2"/>
-   <Attribute name="name" value="two"/>
-   <Attribute name="utf8nameè" value="two àò"/>
+   <Attribute name="id" attrname="id" value="2"/>
+   <Attribute name="name" attrname="name" value="two"/>
+   <Attribute name="utf8nameè" attrname="utf8nameè" value="two àò"/>
    <BoundingBox CRS="EPSG:3857" minx="913214.6741" maxx="913214.6741" miny="5606017.8743" maxy="5606017.8743"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_line_tolerance_20_text_xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_line_tolerance_20_text_xml.txt
@@ -5,7 +5,7 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="ls2d" name="ls2d">
   <Feature id="1">
-   <Attribute value="1" name="id"/>
+   <Attribute value="1" name="id" attrname="id"/>
    <BoundingBox maxy="111325.1429" maxx="111319.4908" miny="0" CRS="EPSG:3857" minx="0"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_notvisible.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_notvisible.txt
@@ -5,9 +5,9 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="A test vector layer" name="layer0">
   <Feature id="2">
-   <Attribute value="3" name="id"/>
-   <Attribute value="three" name="name"/>
-   <Attribute value="three èé↓" name="utf8nameè"/>
+   <Attribute value="3" name="id" attrname="id"/>
+   <Attribute value="three" name="name" attrname="name"/>
+   <Attribute value="three èé↓" name="utf8nameè" attrname="utf8nameè"/>
    <BoundingBox maxy="44.9014" maxx="8.2035" miny="44.9014" SRS="EPSG:4326" minx="8.2035"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_point_tolerance_0_text_xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_point_tolerance_0_text_xml.txt
@@ -5,8 +5,8 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="layer3" name="layer3">
   <Feature id="2">
-   <Attribute value="2" name="id"/>
-   <Attribute value="" name="location"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="" name="location" attrname="location"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_point_tolerance_20_text_xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_point_tolerance_20_text_xml.txt
@@ -5,13 +5,13 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="layer3" name="layer3">
   <Feature id="1">
-   <Attribute value="1" name="id"/>
-   <Attribute value="Id no. 1 value, Id no. 2 value, Id número 3 value" name="location"/>
+   <Attribute value="1" name="id" attrname="id"/>
+   <Attribute value="Id no. 1 value, Id no. 2 value, Id número 3 value" name="location" attrname="location"/>
    <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
   </Feature>
   <Feature id="2">
-   <Attribute value="2" name="id"/>
-   <Attribute value="" name="location"/>
+   <Attribute value="2" name="id" attrname="id"/>
+   <Attribute value="" name="location" attrname="location"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_polygon_tolerance_20_text_xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_polygon_tolerance_20_text_xml.txt
@@ -5,7 +5,7 @@ Content-Type: text/xml; charset=utf-8
 <GetFeatureInfoResponse>
  <Layer title="p2d" name="p2d">
   <Feature id="1">
-   <Attribute value="1" name="id"/>
+   <Attribute value="1" name="id" attrname="id"/>
    <BoundingBox maxy="111325.1429" maxx="111319.4908" miny="0" CRS="EPSG:3857" minx="0"/>
   </Feature>
  </Layer>


### PR DESCRIPTION
Rationale: if an attribute alias is set, `name` will contain the attribute alias. But for technical uses (say filtering out fields by attribute name) it is useful to also have the technical attribute name in the response.