### PR TITLE
update value of the field widget wrapper when new fields set (fix #39351)

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -4677,6 +4677,19 @@ QgsProcessingFieldPanelWidget::QgsProcessingFieldPanelWidget( QWidget *parent, c
 void QgsProcessingFieldPanelWidget::setFields( const QgsFields &fields )
 {
   mFields = fields;
+
+  // ensure that after setting new fields the value does not contain fields
+  // which are not available anymore, see https://github.com/qgis/QGIS/issues/39351
+  QVariantList availableFields;
+  for ( const QgsField &field : std::as_const( mFields ) )
+  {
+    availableFields << field.name();
+  }
+  QList<QVariant>::iterator it = std::remove_if( mValue.begin(), mValue.end(), [&availableFields]( const QVariant &value ) { return !availableFields.contains( value ); } );
+  mValue.erase( it, mValue.end() );
+
+  updateSummaryText();
+  emit changed();
 }
 
 void QgsProcessingFieldPanelWidget::setValue( const QVariant &value )

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -3590,6 +3590,21 @@ void TestProcessingGui::testFieldSelectionPanel()
   QCOMPARE( spy.count(), 3 );
   QCOMPARE( w.value().toList(), QVariantList() );
   QCOMPARE( w.mLineEdit->text(), QStringLiteral( "0 field(s) selected" ) );
+
+  // ensure that settings fields invalidates value and removes values that don't
+  // exists in the fields, see https://github.com/qgis/QGIS/issues/39351
+  w.setValue( QVariantList() << QStringLiteral( "bb" ) << QStringLiteral( "aa" ) << QStringLiteral( "cc" ) );
+  QCOMPARE( spy.count(), 4 );
+  QCOMPARE( w.value().toList(), QVariantList() << QStringLiteral( "bb" ) << QStringLiteral( "aa" ) << QStringLiteral( "cc" ) );
+  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "bb,aa,cc" ) );
+
+  QgsFields fields;
+  fields.append( QgsField( QStringLiteral( "aa" ), QMetaType::Type::QString ) );
+  fields.append( QgsField( QStringLiteral( "cc" ), QMetaType::Type::Int ) );
+  w.setFields( fields );
+  QCOMPARE( spy.count(), 5 );
+  QCOMPARE( w.value().toList(), QVariantList() << QStringLiteral( "aa" ) << QStringLiteral( "cc" ) );
+  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "aa,cc" ) );
 }
 
 void TestProcessingGui::testFieldWrapper()


### PR DESCRIPTION
## Description

In Processing algorithms with multiple fields input (e.g. Dissolve) the field widget wrapper preserves value after changing a parent layer parameter. As a result the field parameter can refer to fields which do not exists in the input layer.

Fixes #39351.