### PR TITLE
Server: Fix endless loop when processing WFS Transaction document with non-mappable attribute names

### DIFF
--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -914,7 +914,7 @@ namespace QgsWfs
       }
 
       QMap<QString, QStringList>::const_iterator fidsMapIt = fidsMap.constBegin();
-      while ( fidsMapIt != fidsMap.constEnd() )
+      for ( ;fidsMapIt != fidsMap.constEnd(); ++fidsMapIt )
       {
         transactionDelete action;
         action.typeName = fidsMapIt.key();

--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -803,7 +803,7 @@ namespace QgsWfs
       QDomNode currentAttributeChild = featureElem.firstChild();
       bool conversionSuccess = true;
 
-      while ( !currentAttributeChild.isNull() )
+      for (;  !currentAttributeChild.isNull(); currentAttributeChild = currentAttributeChild.nextSibling() )
       {
         QDomElement currentAttributeElement = currentAttributeChild.toElement();
         QString attrName = currentAttributeElement.localName();
@@ -815,6 +815,7 @@ namespace QgsWfs
             fieldMapIt = fieldMap.find( attrName );
             if ( fieldMapIt == fieldMap.constEnd() )
             {
+              QgsMessageLog::logMessage( QStringLiteral( "Skipping unknown attribute: name=%1" ).arg( attrName ) );
               continue;
             }
 
@@ -847,7 +848,6 @@ namespace QgsWfs
             feat.setGeometry( g );
           }
         }
-        currentAttributeChild = currentAttributeChild.nextSibling();
       }
       // update feature list
       featList << feat;

--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -891,7 +891,7 @@ namespace QgsWfs
         }
 
         QMap<QString, QStringList>::const_iterator fidsMapIt = fidsMap.constBegin();
-        while ( fidsMapIt != fidsMap.constEnd() )
+        for ( ;fidsMapIt != fidsMap.constEnd(); ++fidsMapIt )
         {
           transactionDelete action;
           action.typeName = fidsMapIt.key();

--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -780,7 +780,7 @@ namespace QgsWfs
         QDomNode currentAttributeChild = featureElem.firstChild();
         bool conversionSuccess = true;
 
-        while ( !currentAttributeChild.isNull() )
+        for (;  !currentAttributeChild.isNull(); currentAttributeChild = currentAttributeChild.nextSibling() )
         {
           QDomElement currentAttributeElement = currentAttributeChild.toElement();
           QString attrName = currentAttributeElement.localName();
@@ -792,6 +792,7 @@ namespace QgsWfs
               fieldMapIt = fieldMap.find( attrName );
               if ( fieldMapIt == fieldMap.constEnd() )
               {
+                QgsMessageLog::logMessage( QStringLiteral( "Skipping unknown attribute: name=%1" ).arg( attrName ) );
                 continue;
               }
 
@@ -824,7 +825,6 @@ namespace QgsWfs
               feat.setGeometry( g );
             }
           }
-          currentAttributeChild = currentAttributeChild.nextSibling();
         }
         // update feature list
         featList << feat;


### PR DESCRIPTION
If the attribute name specified in the transaction document cannot be mapped to a fieldname, `continue` would continue the loop without moving to the next element, resulting in an endless loop.