### PR TITLE
Display icon with new log message instead of jumping to it

### DIFF
--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -41,6 +41,10 @@ QgsMessageLogViewer::QgsMessageLogViewer( QWidget *parent, Qt::WindowFlags fl )
 
   connect( tabWidget, &QTabWidget::tabCloseRequested, this, &QgsMessageLogViewer::closeTab );
 
+  connect( tabWidget, &QTabWidget::currentChanged, this, [this]( int index ) {
+    tabWidget->setTabIcon( index, QIcon() );
+  } );
+
   mTabBarContextMenu = new QMenu( this );
   tabWidget->tabBar()->setContextMenuPolicy( Qt::CustomContextMenu );
   connect( tabWidget->tabBar(), &QWidget::customContextMenuRequested, this, &QgsMessageLogViewer::showContextMenuForTabBar );
@@ -131,9 +135,6 @@ void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag
     w->setReadOnly( true );
     w->viewport()->installEventFilter( this );
     i = tabWidget->addTab( w, QgsApplication::getThemeIcon( QStringLiteral( "mMessageLog.svg" ) ), cleanedTag );
-    connect( tabWidget, &QTabWidget::currentChanged, this, [this]( int index ) {
-      tabWidget->setTabIcon( index, QIcon() );
-    } );
   }
 
   QString levelString;

--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -120,15 +120,20 @@ void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag
   if ( i < tabWidget->count() )
   {
     w = qobject_cast<QPlainTextEdit *>( tabWidget->widget( i ) );
-    tabWidget->setCurrentIndex( i );
+    if ( i != tabWidget->currentIndex() )
+    {
+      tabWidget->setTabIcon( i, QgsApplication::getThemeIcon( QStringLiteral( "mMessageLog.svg" ) ) );
+    }
   }
   else
   {
     w = new QPlainTextEdit( this );
     w->setReadOnly( true );
     w->viewport()->installEventFilter( this );
-    tabWidget->addTab( w, cleanedTag );
-    tabWidget->setCurrentIndex( tabWidget->count() - 1 );
+    i = tabWidget->addTab( w, QgsApplication::getThemeIcon( QStringLiteral( "mMessageLog.svg" ) ), cleanedTag );
+    connect( tabWidget, &QTabWidget::currentChanged, this, [this]( int index ) {
+      tabWidget->setTabIcon( index, QIcon() );
+    } );
   }
 
   QString levelString;


### PR DESCRIPTION
## Description

When a new message is added in the log, the respective tab will now display the `mMessageLog.svg` in the tab header. 
Formerly the `tabWidget` would be switched to the tab that the new message was pushed to.  This could be irritating when waiting for a message in a specific tab.

![image](https://github.com/user-attachments/assets/d8138ca9-7a0f-4b61-8cc4-dd8e4fc21455)

Closes #62240

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
