### PR TITLE
[fix] Avoid throwing warnings when reading null JSON values from PostgreSQL

### DIFF
--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -899,7 +899,7 @@ QVariant QgsJsonUtils::jsonToVariant( const json &value )
 
 QVariant QgsJsonUtils::parseJson( const QString &jsonString )
 {
-  return parseJson( jsonString.toStdString() );
+  return jsonString.isEmpty() ? QVariant() : parseJson( jsonString.toStdString() );
 }
 
 json QgsJsonUtils::exportAttributesToJsonObject( const QgsFeature &feature, QgsVectorLayer *layer, const QVector<QVariant> &attributeWidgetCaches, bool useFieldFormatters )


### PR DESCRIPTION
Handle empty string (null JSON value) case when converting to variant instead of calling the underlying `nlohmann/json` lib to avoid throwing warnings.

The warnings seem to depend on the `nlohmann/json` lib version, I've seen these ones in different versions:

`Logged warning: Cannot parse json ([json.exception.parse_error.101] parse error at line 1, column 1: attempting to parse an empty input; check that your input string or stream contains the expected JSON):`

`Logged warning: Cannot parse json ([json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal):`


This PR avoids them.

---------------

Fix #42832 