### PR TITLE
Don't try to pass unset attributes to ArcGIS REST backends (Backport)

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsarcgisrestutils.py
+++ b/python/PyQt6/core/auto_additions/qgsarcgisrestutils.py
@@ -2,12 +2,17 @@
 # monkey patching scoped based enum
 QgsArcGisRestUtils.FeatureToJsonFlag.IncludeGeometry.__doc__ = "Whether to include the geometry definition"
 QgsArcGisRestUtils.FeatureToJsonFlag.IncludeNonObjectIdAttributes.__doc__ = "Whether to include any non-objectId attributes"
+QgsArcGisRestUtils.FeatureToJsonFlag.SkipUnsetAttributes.__doc__ = "Skip unset attributes. \n.. versionadded:: 3.44"
 QgsArcGisRestUtils.FeatureToJsonFlag.__doc__ = """Flags which control the behavior of converting features to JSON.
 
 .. versionadded:: 3.28
 
 * ``IncludeGeometry``: Whether to include the geometry definition
 * ``IncludeNonObjectIdAttributes``: Whether to include any non-objectId attributes
+* ``SkipUnsetAttributes``: Skip unset attributes.
+
+  .. versionadded:: 3.44
+
 
 """
 # --

--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -184,6 +184,7 @@ Returns a null rectangle if the value cannot be converted.
     {
       IncludeGeometry,
       IncludeNonObjectIdAttributes,
+      SkipUnsetAttributes,
     };
 
     typedef QFlags<QgsArcGisRestUtils::FeatureToJsonFlag> FeatureToJsonFlags;

--- a/python/core/auto_additions/qgsarcgisrestutils.py
+++ b/python/core/auto_additions/qgsarcgisrestutils.py
@@ -2,12 +2,17 @@
 # monkey patching scoped based enum
 QgsArcGisRestUtils.FeatureToJsonFlag.IncludeGeometry.__doc__ = "Whether to include the geometry definition"
 QgsArcGisRestUtils.FeatureToJsonFlag.IncludeNonObjectIdAttributes.__doc__ = "Whether to include any non-objectId attributes"
+QgsArcGisRestUtils.FeatureToJsonFlag.SkipUnsetAttributes.__doc__ = "Skip unset attributes. \n.. versionadded:: 3.44"
 QgsArcGisRestUtils.FeatureToJsonFlag.__doc__ = """Flags which control the behavior of converting features to JSON.
 
 .. versionadded:: 3.28
 
 * ``IncludeGeometry``: Whether to include the geometry definition
 * ``IncludeNonObjectIdAttributes``: Whether to include any non-objectId attributes
+* ``SkipUnsetAttributes``: Skip unset attributes.
+
+  .. versionadded:: 3.44
+
 
 """
 # --

--- a/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -184,6 +184,7 @@ Returns a null rectangle if the value cannot be converted.
     {
       IncludeGeometry,
       IncludeNonObjectIdAttributes,
+      SkipUnsetAttributes,
     };
 
     typedef QFlags<QgsArcGisRestUtils::FeatureToJsonFlag> FeatureToJsonFlags;

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1831,8 +1831,17 @@ QVariantMap QgsArcGisRestUtils::featureToJson( const QgsFeature &feature, const 
   const QgsFields fields = feature.fields();
   for ( const QgsField &field : fields )
   {
+    QVariant value = feature.attribute( field.name() );
+    if ( value.userType() == qMetaTypeId< QgsUnsetAttributeValue >() )
+    {
+      if ( flags.testFlag( FeatureToJsonFlag::SkipUnsetAttributes ) )
+        continue;
+      else
+        value = QVariant(); // reset to null, we can't store 'QgsUnsetAttributeValue' as json
+    }
+
     if ( ( flags & FeatureToJsonFlag::IncludeNonObjectIdAttributes ) || field.name() == context.objectIdFieldName() )
-      attributes.insert( field.name(), variantToAttributeValue( feature.attribute( field.name() ), field.type(), context ) );
+      attributes.insert( field.name(), variantToAttributeValue( value, field.type(), context ) );
   }
   if ( !attributes.isEmpty() )
   {

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -229,6 +229,7 @@ class CORE_EXPORT QgsArcGisRestUtils
     {
       IncludeGeometry = 1 << 0, //!< Whether to include the geometry definition
       IncludeNonObjectIdAttributes = 1 << 1, //!< Whether to include any non-objectId attributes
+      SkipUnsetAttributes = 1 << 2, //!< Skip unset attributes. \since QGIS 3.44
     };
     Q_ENUM( FeatureToJsonFlag );
 

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -373,6 +373,21 @@ bool QgsAfsProvider::addFeatures( QgsFeatureList &flist, Flags )
   if ( flist.isEmpty() )
     return true; // for consistency!
 
+  // special handling for object ID field -- explicitly reset "Autogenerate" strings for
+  // field to QgsUnsetAttributeValue. This is required to maintain stable API which allowed
+  // provider default value clause strings to be used as an alias for unset attributes.
+  // TODO QGIS 5 - We can remove this when we no longer need to respect that.
+  for ( int i = 0; i < flist.size(); ++i )
+  {
+    QgsFeature &f = flist[i];
+    if ( mSharedData->mObjectIdFieldIdx >= 0
+         && f.attributes().size() > mSharedData->mObjectIdFieldIdx
+         && f.attribute( mSharedData->mObjectIdFieldIdx ) == QLatin1String( "Autogenerate" ) )
+    {
+      f.setAttribute( mSharedData->mObjectIdFieldIdx, QgsUnsetAttributeValue() );
+    }
+  }
+
   QString error;
   QgsFeedback feedback;
   const bool res = mSharedData->addFeatures( flist, error, &feedback );

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -362,7 +362,7 @@ bool QgsAfsSharedData::addFeatures( QgsFeatureList &features, QString &errorMess
   featuresJson.reserve( features.size() );
   for ( const QgsFeature &feature : features )
   {
-    featuresJson.append( QgsArcGisRestUtils::featureToJson( feature, context ) );
+    featuresJson.append( QgsArcGisRestUtils::featureToJson( feature, context, QgsCoordinateReferenceSystem(), QgsArcGisRestUtils::FeatureToJsonFlag::IncludeGeometry | QgsArcGisRestUtils::FeatureToJsonFlag::IncludeNonObjectIdAttributes | QgsArcGisRestUtils::FeatureToJsonFlag::SkipUnsetAttributes ) );
   }
 
   const QString json = QString::fromStdString( QgsJsonUtils::jsonFromVariant( featuresJson ).dump( 2 ) );
@@ -418,7 +418,7 @@ bool QgsAfsSharedData::updateFeatures( const QgsFeatureList &features, bool incl
   if ( includeGeometries )
     flags |= QgsArcGisRestUtils::FeatureToJsonFlag::IncludeGeometry;
   if ( includeAttributes )
-    flags |= QgsArcGisRestUtils::FeatureToJsonFlag::IncludeNonObjectIdAttributes;
+    flags |= QgsArcGisRestUtils::FeatureToJsonFlag::IncludeNonObjectIdAttributes | QgsArcGisRestUtils::FeatureToJsonFlag::SkipUnsetAttributes;
 
   QVariantList featuresJson;
   featuresJson.reserve( features.size() );

--- a/tests/src/python/test_qgsarcgisrestutils.py
+++ b/tests/src/python/test_qgsarcgisrestutils.py
@@ -23,6 +23,7 @@ from qgis.core import (
     QgsFieldConstraints,
     QgsFields,
     QgsGeometry,
+    QgsUnsetAttributeValue,
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -769,6 +770,53 @@ class TestQgsArcGisRestUtils(QgisTestCase):
                     "a_double_field": 5.5,
                     "a_int_field": 5,
                     "a_string_field": """aaa%5C%22%20'%20%2C%20.%20-%20%3B%20%3A%20%C3%A4%20%C3%B6%20%C3%BC%20%C3%A8%20%C3%A9%20%C3%A0%20%3F%20%2B%20%26%20%5C%5C%20%2F""",
+                    "a_null_value": None,
+                }
+            },
+        )
+
+        # unset attribute value
+        attributes[0] = QgsUnsetAttributeValue()
+        test_feature.setAttributes(attributes)
+        res = QgsArcGisRestUtils.featureToJson(
+            test_feature,
+            context,
+            flags=QgsArcGisRestUtils.FeatureToJsonFlags(
+                QgsArcGisRestUtils.FeatureToJsonFlag.IncludeNonObjectIdAttributes
+            ),
+        )
+        self.assertEqual(
+            res,
+            {
+                "attributes": {
+                    "a_boolean_field": True,
+                    "a_datetime_field": 1646395994000,
+                    "a_date_field": 1646352000000,
+                    "a_double_field": 5.5,
+                    "a_int_field": 5,
+                    "a_string_field": None,
+                    "a_null_value": None,
+                }
+            },
+        )
+        res = QgsArcGisRestUtils.featureToJson(
+            test_feature,
+            context,
+            flags=QgsArcGisRestUtils.FeatureToJsonFlags(
+                QgsArcGisRestUtils.FeatureToJsonFlag.IncludeNonObjectIdAttributes
+                | QgsArcGisRestUtils.FeatureToJsonFlag.SkipUnsetAttributes
+            ),
+        )
+        # unset attribute should not be present
+        self.assertEqual(
+            res,
+            {
+                "attributes": {
+                    "a_boolean_field": True,
+                    "a_datetime_field": 1646395994000,
+                    "a_date_field": 1646352000000,
+                    "a_double_field": 5.5,
+                    "a_int_field": 5,
                     "a_null_value": None,
                 }
             },


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/62061, with additional hack to maintain deprecated api allowing string storage of default provider clauses to be considered as unset attributes. That's needed on 3.40 as we had less internal use of QgsUnsetAttributeValues in 3.40 branch.

I'll forward port this second commit to master in a separate PR.