### PR TITLE
[afs] Add temporary workaround to consider 'Autogenerate' strings as unset

### DIFF
--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -373,6 +373,21 @@ bool QgsAfsProvider::addFeatures( QgsFeatureList &flist, Flags )
   if ( flist.isEmpty() )
     return true; // for consistency!
 
+  // special handling for object ID field -- explicitly reset "Autogenerate" strings for
+  // field to QgsUnsetAttributeValue. This is required to maintain stable API which allowed
+  // provider default value clause strings to be used as an alias for unset attributes.
+  // TODO QGIS 5 - We can remove this when we no longer need to respect that.
+  for ( int i = 0; i < flist.size(); ++i )
+  {
+    QgsFeature &f = flist[i];
+    if ( mSharedData->mObjectIdFieldIdx >= 0
+         && f.attributes().size() > mSharedData->mObjectIdFieldIdx
+         && f.attribute( mSharedData->mObjectIdFieldIdx ) == QLatin1String( "Autogenerate" ) )
+    {
+      f.setAttribute( mSharedData->mObjectIdFieldIdx, QgsUnsetAttributeValue() );
+    }
+  }
+
   QString error;
   QgsFeedback feedback;
   const bool res = mSharedData->addFeatures( flist, error, &feedback );


### PR DESCRIPTION
We can safely remove this for QGIS 5

Forward port from https://github.com/qgis/QGIS/pull/62249
