### PR TITLE
do not show error in the native interpolation algorithms when input layer can not be obtained from the value (fix #62224)

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py
@@ -164,8 +164,10 @@ class InterpolationDataWidget(BASE, WIDGET):
             layer = QgsProcessingUtils.mapLayerFromString(
                 v[0], dataobjects.createContext()
             )
-            field_index = int(v[2])
+            if layer is None or not layer.isValid():
+                continue
 
+            field_index = int(v[2])
             if field_index == -1:
                 field_name = "Z_COORD"
             else:


### PR DESCRIPTION
## Description

Check if input layer is actually a layer object and is valid before trying to get layer fields in the native interpolation algorithms.

Fixes #62224.