### PR TITLE
Pivot around mouse location in globe 3D view

### DIFF
--- a/python/3d/auto_additions/qgscamerapose.py
+++ b/python/3d/auto_additions/qgscamerapose.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/3d/qgscamerapose.h
+try:
+    QgsCameraPose.globeRotation = staticmethod(QgsCameraPose.globeRotation)
+except (NameError, AttributeError):
+    pass

--- a/python/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/3d/auto_generated/qgs3dmapscene.sip.in
@@ -163,6 +163,15 @@ be useful to temporarily disable origin shifts.
 .. versionadded:: 3.44
 %End
 
+    void recomputeOrigin();
+%Docstring
+Recompute the origin if origin shifts are enabled and the camera is far
+enough away from the current origin, see
+:py:func:`~Qgs3DMapScene.hasSceneOriginShiftEnabled` for more details.
+
+.. versionadded:: 4.0
+%End
+
  static QMap<QString, Qgs3DMapScene *> openScenes() /Deprecated="Since 3.36. Use QgisAppInterface.mapCanvases3D() instead."/;
 %Docstring
 Returns a map of 3D map scenes (by name) open in the QGIS application.

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -197,7 +197,7 @@ Rotates the camera on itself.
 .. versionadded:: 3.30
 %End
 
-    void rotateCameraAroundPivot( float newPitch, float newHeading, const QVector3D &pivotPoint );
+    void rotateCameraAroundPivot( QgsCameraPose &oldCamera, float newPitch, float newHeading, const QVector3D &pivotPoint );
 %Docstring
 Rotates the camera around the pivot point (in world coordinates) to the
 given new pitch and heading angle.

--- a/python/3d/auto_generated/qgscamerapose.sip.in
+++ b/python/3d/auto_generated/qgscamerapose.sip.in
@@ -70,6 +70,14 @@ Sets heading (yaw) angle in degrees
 
 
 
+    static QQuaternion globeRotation( double lat, double lon, float pitch, float heading );
+%Docstring
+Calculate rotation to go from a plane tangent at the equator (X up, Y
+east, Z north) to a plane tangent at the given point.
+
+.. versionadded:: 3.44
+%End
+
     QDomElement writeXml( QDomDocument &doc ) const;
 %Docstring
 Writes configuration to a new DOM element and returns it

--- a/python/PyQt6/3d/auto_additions/qgscamerapose.py
+++ b/python/PyQt6/3d/auto_additions/qgscamerapose.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/3d/qgscamerapose.h
+try:
+    QgsCameraPose.globeRotation = staticmethod(QgsCameraPose.globeRotation)
+except (NameError, AttributeError):
+    pass

--- a/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapscene.sip.in
@@ -163,6 +163,15 @@ be useful to temporarily disable origin shifts.
 .. versionadded:: 3.44
 %End
 
+    void recomputeOrigin();
+%Docstring
+Recompute the origin if origin shifts are enabled and the camera is far
+enough away from the current origin, see
+:py:func:`~Qgs3DMapScene.hasSceneOriginShiftEnabled` for more details.
+
+.. versionadded:: 4.0
+%End
+
  static QMap<QString, Qgs3DMapScene *> openScenes() /Deprecated="Since 3.36. Use QgisAppInterface.mapCanvases3D() instead."/;
 %Docstring
 Returns a map of 3D map scenes (by name) open in the QGIS application.

--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -197,7 +197,7 @@ Rotates the camera on itself.
 .. versionadded:: 3.30
 %End
 
-    void rotateCameraAroundPivot( float newPitch, float newHeading, const QVector3D &pivotPoint );
+    void rotateCameraAroundPivot( QgsCameraPose &oldCamera, float newPitch, float newHeading, const QVector3D &pivotPoint );
 %Docstring
 Rotates the camera around the pivot point (in world coordinates) to the
 given new pitch and heading angle.

--- a/python/PyQt6/3d/auto_generated/qgscamerapose.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscamerapose.sip.in
@@ -70,6 +70,14 @@ Sets heading (yaw) angle in degrees
 
 
 
+    static QQuaternion globeRotation( double lat, double lon, float pitch, float heading );
+%Docstring
+Calculate rotation to go from a plane tangent at the equator (X up, Y
+east, Z north) to a plane tangent at the given point.
+
+.. versionadded:: 3.44
+%End
+
     QDomElement writeXml( QDomDocument &doc ) const;
 %Docstring
 Writes configuration to a new DOM element and returns it

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -325,6 +325,11 @@ void Qgs3DMapScene::onCameraChanged()
   QVector<QgsPointXY> extent2D = viewFrustum2DExtent();
   emit viewed2DExtentFrom3DChanged( extent2D );
 
+  recomputeOrigin();
+}
+
+void Qgs3DMapScene::recomputeOrigin()
+{
   // The magic to make things work better in large scenes (e.g. more than 50km across)
   // is here: we will simply move the origin of the scene, and update transforms
   // of the camera and all other entities. That should ensure we will not need to deal

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -243,6 +243,15 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     void setSceneOriginShiftEnabled( bool enabled ) { mSceneOriginShiftEnabled = enabled; }
 
     /**
+     * Recompute the origin if origin shifts are enabled and the camera is far
+     * enough away from the current origin, see hasSceneOriginShiftEnabled()
+     * for more details.
+     *
+     * \since QGIS 4.0
+     */
+    void recomputeOrigin();
+
+    /**
      * Returns a map of 3D map scenes (by name) open in the QGIS application.
      *
      * \note Only available from the QGIS desktop application.

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -206,6 +206,10 @@ void QgsCameraController::zoomCameraAroundPivot( const QVector3D &oldCameraPosit
   mCameraPose.setDistanceFromCenterPoint( newDistance );
   mCameraPose.setCenterPoint( newViewCenter );
   updateCameraFromPose();
+
+  // Recompute the origin right away and not on the next frame to avoid
+  // unpleasant jitters when far away from the scene.
+  mScene->recomputeOrigin();
 }
 
 void QgsCameraController::frameTriggered( float dt )

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -190,14 +190,14 @@ void QgsCameraController::zoomCameraAroundPivot( const QVector3D &oldCameraPosit
     {
       QgsVector3D viewCenterLonLat = globeViewCenterLonLat();
       QQuaternion q = QgsCameraPose::globeRotation( viewCenterLonLat.y(), viewCenterLonLat.x(), mCameraPose.pitchAngle(), mCameraPose.headingAngle() );
-      newViewCenter = newCamPosition + ( q * QVector3D( -newDistance, 0, 0 ) );
+      newViewCenter = newCamPosition + ( q * QVector3D( static_cast<float>( -newDistance ), 0, 0 ) );
       break;
     }
 
     case Qgis::SceneMode::Local:
     {
       QQuaternion q = Qgs3DUtils::rotationFromPitchHeadingAngles( mCameraPose.pitchAngle(), mCameraPose.headingAngle() );
-      QVector3D cameraToCenter = q * QVector3D( 0, 0, -newDistance );
+      QVector3D cameraToCenter = q * QVector3D( 0, 0, static_cast<float>( -newDistance ) );
       newViewCenter = newCamPosition + cameraToCenter;
       break;
     }

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -434,7 +434,7 @@ void QgsCameraController::refreshViewCenter( QVector3D &near )
   // Find projection of near onto camera -> viewCenter ray.
   QgsVector3D newCenterPoint = ray.project( near );
   const double diff = newCenterPoint.distance( mCameraPose.centerPoint() );
-  const double diffMult = abs( ( newCenterPoint.distance( mCamera->position() ) ) / mCameraPose.distanceFromCenterPoint() );
+  const double diffMult = ( newCenterPoint.distance( mCamera->position() ) ) / mCameraPose.distanceFromCenterPoint();
   if ( diff > DISTANCE_THRESHOLD && ( diffMult < MULT_THRESHOLD || diffMult > 1 / MULT_THRESHOLD ) )
   {
     mCameraPose.setDistanceFromCenterPoint( static_cast<float>( newCenterPoint.distance( mCamera->position() ) ) );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -426,10 +426,10 @@ class _3D_EXPORT QgsCameraController : public QObject
     QgsVector3D globeViewCenterLonLat();
 
     /*
-     * Raycast our view center to the current terrain, sometimes it ends up way
-     * below/above.
+     * Reset our view center to the closest possible point to near, sometimes
+     * it ends up way below/above.
      */
-    void refreshViewCenter();
+    void refreshViewCenter( QVector3D &near );
 
     //! The 3d scene the controller uses
     Qgs3DMapScene *mScene = nullptr;

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -206,7 +206,7 @@ class _3D_EXPORT QgsCameraController : public QObject
      * to the given new pitch and heading angle.
      * \since QGIS 3.42
      */
-    void rotateCameraAroundPivot( float newPitch, float newHeading, const QVector3D &pivotPoint );
+    void rotateCameraAroundPivot( QgsCameraPose &oldCamera, float newPitch, float newHeading, const QVector3D &pivotPoint );
 
     /**
      * Zooms camera by given zoom factor (>1 one means zoom in)
@@ -449,11 +449,15 @@ class _3D_EXPORT QgsCameraController : public QObject
     // nullptr when !mDepthBufferIsReady
     std::unique_ptr<Qt3DRender::QCamera> mDepthBufferCamera;
 
+    // Set at start of movements so that changes can be calculated relative to
+    // a stable baseline and not incrementaly per-event, which would lead to
+    // numerical instability.
     std::unique_ptr<Qt3DRender::QCamera> mCameraBefore;
+    QgsCameraPose mCameraPoseBefore;
 
     bool mRotationCenterCalculated = false;
     QVector3D mRotationCenter;
-    double mRotationDistanceFromCenter = 0;
+    // pitch & yaw at start of rotation.
     float mRotationPitch = 0;
     float mRotationYaw = 0;
 

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -422,6 +422,9 @@ class _3D_EXPORT QgsCameraController : public QObject
     // Moves given point (in ECEF) by specified lat/lon angle difference (in degrees) and returns new ECEF point
     QgsVector3D moveGeocentricPoint( const QgsVector3D &point, double latDiff, double lonDiff );
 
+    //! Get current camera view center in lon,lat,elev
+    QgsVector3D globeViewCenterLonLat();
+
     //! The 3d scene the controller uses
     Qgs3DMapScene *mScene = nullptr;
 

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -425,6 +425,12 @@ class _3D_EXPORT QgsCameraController : public QObject
     //! Get current camera view center in lon,lat,elev
     QgsVector3D globeViewCenterLonLat();
 
+    /*
+     * Raycast our view center to the current terrain, sometimes it ends up way
+     * below/above.
+     */
+    void refreshViewCenter();
+
     //! The 3d scene the controller uses
     Qgs3DMapScene *mScene = nullptr;
 

--- a/src/3d/qgscamerapose.h
+++ b/src/3d/qgscamerapose.h
@@ -75,6 +75,13 @@ class _3D_EXPORT QgsCameraPose
      */
     void updateCameraGlobe( Qt3DRender::QCamera *camera, double lat, double lon ) SIP_SKIP;
 
+    /**
+     * Calculate rotation to go from a plane tangent at the equator (X up, Y
+     * east, Z north) to a plane tangent at the given point.
+     * \since QGIS 3.44
+     */
+    static QQuaternion globeRotation( double lat, double lon, float pitch, float heading );
+
     //! Writes configuration to a new DOM element and returns it
     QDomElement writeXml( QDomDocument &doc ) const;
     //! Reads configuration from a DOM element previously written using writeXml()

--- a/src/3d/qgsraycastingutils.cpp
+++ b/src/3d/qgsraycastingutils.cpp
@@ -149,7 +149,7 @@ namespace QgsRayCastingUtils
   QVector3D Ray3D::project( QVector3D vector ) const
   {
     const QVector3D norm = m_direction.normalized();
-    return QVector3D::dotProduct( vector, norm ) * norm;
+    return m_origin + QVector3D::dotProduct( vector - m_origin, norm ) * norm;
   }
 
 

--- a/src/3d/qgsraycastingutils_p.h
+++ b/src/3d/qgsraycastingutils_p.h
@@ -69,6 +69,7 @@ namespace QgsRayCastingUtils
       QVector3D point( float t ) const;
       float projectedDistance( QVector3D point ) const;
 
+      //! Project \a vector onto line defined by the ray.
       QVector3D project( QVector3D vector ) const;
 
       float distance( QVector3D point ) const;

--- a/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
+++ b/tests/src/3d/sandbox/qgis_3d_sandbox.cpp
@@ -280,8 +280,8 @@ int main( int argc, char *argv[] )
   container->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
   Qgs3DDebugWidget *debugWidget = new Qgs3DDebugWidget( canvas );
   debugWidget->setMapSettings( canvas->mapSettings() );
-  debugWidget->setVisible( false );
-  QObject::connect( canvas->mapSettings(), &Qgs3DMapSettings::showDebugPanelChanged, windowWidget, [debugWidget]( const bool enabled ) {
+  debugWidget->setVisible( canvas->mapSettings()->showDebugPanel() );
+  QObject::connect( canvas->mapSettings(), &Qgs3DMapSettings::showDebugPanelChanged, windowWidget, [=]( const bool enabled ) {
     debugWidget->setVisible( enabled );
   } );
 

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -259,7 +259,6 @@ void TestQgs3DCameraController::testZoomWheel()
   mapSettings->setTerrainGenerator( flatTerrain );
 
   QPoint winSize = QPoint( 640, 480 ); // default window size
-  QPoint midPos = winSize / 2;
   QgsOffscreen3DEngine engine;
   engine.setSize( QSize( winSize.x(), winSize.y() ) );
   Qgs3DMapScene *scene = new Qgs3DMapScene( *mapSettings, &engine );
@@ -271,7 +270,7 @@ void TestQgs3DCameraController::testZoomWheel()
   // this call is not used but ensures to synchronize the scene
   Qgs3DUtils::captureSceneImage( engine, scene );
 
-  QWheelEvent wheelEvent( midPos, midPos, QPoint(), QPoint( 0, 200 ), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false, Qt::MouseEventSynthesizedByApplication );
+  QWheelEvent wheelEvent( QPoint( 0, 0 ), QPoint( 0, 0 ), QPoint(), QPoint( 0, 200 ), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false, Qt::MouseEventSynthesizedByApplication );
   scene->cameraController()->onWheel( new Qt3DInput::QWheelEvent( wheelEvent ) );
   QCOMPARE( scene->cameraController()->mClickPoint, QPoint() );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::ZoomWheel );
@@ -520,7 +519,7 @@ void TestQgs3DCameraController::testRotationCenterZoomWheelRotationCenter()
   initialPitch = scene->cameraController()->pitch();
   initialYaw = scene->cameraController()->yaw();
 
-  QWheelEvent wheelEvent( midPos, midPos, QPoint(), QPoint( 0, 200 ), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false, Qt::MouseEventSynthesizedByApplication );
+  QWheelEvent wheelEvent( midPos + movement1 + movement2, midPos + movement1 + movement2, QPoint(), QPoint( 0, 200 ), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false, Qt::MouseEventSynthesizedByApplication );
   scene->cameraController()->onWheel( new Qt3DInput::QWheelEvent( wheelEvent ) );
   QCOMPARE( scene->cameraController()->mClickPoint, midPos );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::ZoomWheel );


### PR DESCRIPTION
## Description

Currently, zooming or rotating the view in 3D globe views is done around the view center, no matter where the user clicked with their mouse, unlike in traditional planar 3D views. This PR fixes this discrepancy, changing `QgsCameraController` to also pivot around the drag point when in globe mode.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
