### PR TITLE
[STAC] Allow query parameters in the `/collections` endpoint url

### DIFF
--- a/src/core/stac/qgsstacparser.cpp
+++ b/src/core/stac/qgsstacparser.cpp
@@ -522,7 +522,9 @@ QgsStacCollections *QgsStacParser::collections()
 
   try
   {
-    links = parseLinks( mData.at( "links" ) );
+    // some servers don't include links here, let's be more forgiving
+    if ( mData.contains( "links" ) )
+      links = parseLinks( mData.at( "links" ) );
 
     cols.reserve( mData.at( "collections" ).size() );
     for ( auto &col : mData.at( "collections" ) )

--- a/src/gui/stac/qgsstacsourceselect.cpp
+++ b/src/gui/stac/qgsstacsourceselect.cpp
@@ -297,10 +297,16 @@ void QgsStacSourceSelect::onStacObjectRequestFinished( int requestId, QString er
     for ( auto &l : cat->links() )
     {
       // collections endpoint should have a "data" relation according to spec but some servers don't
-      // so let's be less strict and only check the href
-      if ( l.href().endsWith( "/collections" ) )
+      // so let's be less strict and only check the href and optionally the media type
+      if ( QUrl( l.href() ).path().endsWith( "/collections" ) &&     // allow query parameters in the url
+           ( l.mediaType().isEmpty() ||                              // media type is optional
+             l.mediaType() == QLatin1String( "application/json" ) || // but if it's there it should be json or geojson
+             l.mediaType() == QLatin1String( "application/geo+json" ) ) )
         collectionsUrl = l.href();
-      else if ( l.relation() == "search" )
+      else if ( l.relation() == "search" &&                               // relation needs to be "search" according to spec
+                ( l.mediaType().isEmpty() ||                              // media type is optional
+                  l.mediaType() == QLatin1String( "application/json" ) || // but if it's there it should be json or geojson
+                  l.mediaType() == QLatin1String( "application/geo+json" ) ) )
         mSearchUrl = l.href();
 
       if ( !collectionsUrl.isEmpty() && !mSearchUrl.isEmpty() )


### PR DESCRIPTION
## Description
Geoserver has `/collections` endpoints that look like `geoserver/ogc/stac/v1/collections?f=application%2Fjson`

Also properly handle the cases where there are multiple `/collections` and `/search` endpoints with different media types.

Fixes #62232


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
