### PR TITLE
Fix segfault on layout legend item with atlas enabled

### DIFF
--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -1216,18 +1216,20 @@ void QgsLayoutItemLegend::doUpdateFilterByMap()
     QgsLayerTreeFilterSettings filterSettings( mapSettings );
 
     QList<QgsMapLayer *> layersToClip;
-    if ( !atlasGeometry.isNull() && mMap->atlasClippingSettings()->enabled() )
+    if ( mMap )
     {
-      layersToClip = mMap->atlasClippingSettings()->layersToClip();
-      for ( QgsMapLayer *layer : std::as_const( layersToClip ) )
+      if ( !atlasGeometry.isNull() && mMap->atlasClippingSettings()->enabled() )
       {
-        QList<QgsMapLayer *> mapLayers { filterSettings.mapSettings().layers( true ) };
-        mapLayers.removeAll( layer );
-        filterSettings.mapSettings().setLayers( mapLayers );
-        filterSettings.addVisibleExtentForLayer( layer, QgsReferencedGeometry( atlasGeometry, mapSettings.destinationCrs() ) );
+        layersToClip = mMap->atlasClippingSettings()->layersToClip();
+        for ( QgsMapLayer *layer : std::as_const( layersToClip ) )
+        {
+          QList<QgsMapLayer *> mapLayers { filterSettings.mapSettings().layers( true ) };
+          mapLayers.removeAll( layer );
+          filterSettings.mapSettings().setLayers( mapLayers );
+          filterSettings.addVisibleExtentForLayer( layer, QgsReferencedGeometry( atlasGeometry, mapSettings.destinationCrs() ) );
+        }
       }
     }
-
 
     if ( !linkedFilterMaps.empty() )
     {


### PR DESCRIPTION
## Description

Fixes #59610

The example layout shared in the issue has a legend item that is not associated with any map item.

Then we fall into a nullptr when calling mMap->atlasClippingSettings()