### PR TITLE
Add "wkt" locator filter for loading WKT strings as layers

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -226,6 +226,7 @@ set(QGIS_APP_SRCS
   locator/qgslayoutlocatorfilter.cpp
   locator/qgsnominatimlocatorfilter.cpp
   locator/qgssettingslocatorfilter.cpp
+  locator/qgswktlocatorfilter.cpp
 
   locator/qgslocatoroptionswidget.cpp
 

--- a/src/app/locator/qgswktlocatorfilter.cpp
+++ b/src/app/locator/qgswktlocatorfilter.cpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+                        qgswktlocatorfilter.cpp
+                        ----------------------------
+    begin                : June 2025
+    copyright            : (C) 2025 by Johannes Kröger
+    email                : qgis at johanneskroeger dot de
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgswktlocatorfilter.h"
+#include "moc_qgswktlocatorfilter.cpp"
+#include "qgsproject.h"
+#include "qgisapp.h"
+#include "qgsmessagebar.h"
+
+#include <QClipboard>
+
+
+QgsWktLocatorFilter::QgsWktLocatorFilter( QObject *parent )
+  : QgsLocatorFilter( parent )
+{
+  setUseWithoutPrefix( false );
+}
+
+QgsWktLocatorFilter *QgsWktLocatorFilter::clone() const
+{
+  return new QgsWktLocatorFilter();
+}
+
+void QgsWktLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback * )
+{
+  QgsLocatorResult result;
+  result.filter = this;
+  result.displayString = tr( "Load “%1” as layer" ).arg( string );
+  result.setUserData( string );
+  emit resultFetched( result );
+}
+
+void QgsWktLocatorFilter::triggerResult( const QgsLocatorResult &result )
+{
+  QString string = result.userData().toString();
+
+  QgsGeometry geometry = QgsGeometry::fromWkt( string );
+  if ( geometry.isNull() ) {
+    QgisApp::instance()->messageBar()->pushMessage( tr( "WKT could not be turned into a valid geometry." ), Qgis::MessageLevel::Warning );
+    return;
+  }
+
+  QgsFeature feature = QgsFeature();
+  feature.setGeometry( geometry );
+
+  QgsCoordinateReferenceSystem crs = QgsProject::instance()->crs();
+  QString geometryTypeString = QgsWkbTypes::displayString( geometry.wkbType() );
+  if ( geometryTypeString.isNull() ) {
+    QgisApp::instance()->messageBar()->pushMessage( tr( "Unknown geometry type: %1" ).arg( geometryTypeString ), Qgis::MessageLevel::Warning );
+    return;
+  }
+  QString uri = QString( "%1?crs=%2" ).arg( geometryTypeString ).arg( crs.authid() );
+  QgsVectorLayer* layer = new QgsVectorLayer(uri , QStringLiteral( "WKT" ), QStringLiteral( "memory" ));
+  if ( !layer->isValid() ) {
+    QgisApp::instance()->messageBar()->pushMessage( tr( "WKT could not be turned into a valid layer." ), Qgis::MessageLevel::Warning );
+    return;
+  }
+
+  layer->dataProvider()->addFeature( feature );
+  layer->updateExtents();
+  QgsProject::instance()->addMapLayer( layer );
+}

--- a/src/app/locator/qgswktlocatorfilter.h
+++ b/src/app/locator/qgswktlocatorfilter.h
@@ -1,0 +1,42 @@
+/***************************************************************************
+                         qgswktlocatorfilter.h
+                         --------------------------
+    begin                : June 2025
+    copyright            : (C) 2025 by Johannes Kröger
+    email                : qgis at johanneskroeger dot de
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSWKTLOCATORFILTER_H
+#define QGSWKTLOCATORFILTER_H
+
+#include "qgis_app.h"
+#include "qgslocatorfilter.h"
+
+
+class APP_EXPORT QgsWktLocatorFilter : public QgsLocatorFilter
+{
+    Q_OBJECT
+
+  public:
+    QgsWktLocatorFilter( QObject *parent = nullptr );
+    QgsWktLocatorFilter *clone() const override;
+    QString name() const override { return QStringLiteral( "wkt" ); }
+    QString displayName() const override { return tr( "Load WKT" ); }
+    Priority priority() const override { return Highest; }
+    QString prefix() const override { return QStringLiteral( "wkt" ); }
+    QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }
+
+    void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
+    void triggerResult( const QgsLocatorResult &result ) override;
+};
+
+#endif // QGSWKTLOCATORFILTER_H

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -319,6 +319,7 @@
 #include "qgslayoutlocatorfilter.h"
 #include "qgsnominatimlocatorfilter.h"
 #include "qgssettingslocatorfilter.h"
+#include "qgswktlocatorfilter.h"
 #include "qgsnominatimgeocoder.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
@@ -4111,6 +4112,7 @@ void QgisApp::createStatusBar()
   mLocatorWidget->locator()->registerFilter( new QgsSettingsLocatorFilter() );
   mLocatorWidget->locator()->registerFilter( new QgsGotoLocatorFilter() );
   mLocatorWidget->locator()->registerFilter( new QgsLayerMetadataLocatorFilter() );
+  mLocatorWidget->locator()->registerFilter( new QgsWktLocatorFilter() );
 
   mNominatimGeocoder = std::make_unique<QgsNominatimGeocoder>();
   mLocatorWidget->locator()->registerFilter( new QgsNominatimLocatorFilter( mNominatimGeocoder.get(), mMapCanvas ) );


### PR DESCRIPTION
Posting as a draft because it is not fully ready yet but I am open for early feedback and could use help on tests.

# Description
This adds a QgsLocatorFilter for the prefix `wkt` which enables users to easily load WKT strings as new layers. The coordinates will be considered to be in the current project CRS.

Every WKT string shown on https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry works, except for the `POLYHEDRALSURFACE Z`. QGIS cannot create a `QgsGeometry` from that.

No special handling for GeometryCollections. QGIS will actually add them as a new layer without error but not display any geometry. I found no processing tool to "explode" the GeometryCollection to its "plain" geometry types but still assume that allowing these WKT objects to be loaded as such is more useful than explicitly forbiding it.

I did not test every return value of every function, i.e. I assume that the following never fail here:
- Setting the geometry for the feature
- Adding the feature to the layer
- Adding the layer to the project

# TODO
- [ ] Unit tests, what where how? Can someone give me some pointers for that? I am not sure how to test this. Really the whole way from input to the resulting layer? Is there a existing list of nice test WKTs somewhere in the QGIS testing code?
- [ ] Check if the entered string plus "wkt " prefix is >32767 characters and log an error then, this is the maximum length. It is not enough for detailed polygons like e.g. Germany from the included `world` dataset
  - On my list, just not today :)

# Screenshots

## New locator in list
![new locator in list](https://github.com/user-attachments/assets/e1d66ccb-70fc-4e2a-a790-4b7058101998)

## Point
![point to be loaded](https://github.com/user-attachments/assets/679e6144-9f8a-48d7-b6b5-3d856ee857ed)
![point](https://github.com/user-attachments/assets/3788d454-8836-418e-96c2-b745725d659d)

## MultiPolygon
![multipolygon to be loaded](https://github.com/user-attachments/assets/67058657-e0d6-49d7-82f9-e71a06ca6a67)
![example loaded multipolygon](https://github.com/user-attachments/assets/15e1ed6e-72cb-4836-b292-4cb057076813)

## Denmark (MultiPolygon)
![denmark](https://github.com/user-attachments/assets/e5f6d787-167c-4ca5-8809-caed27b7b9dd)


## Example of error message on non-WKT input
![example bad input 1](https://github.com/user-attachments/assets/f197db2c-1358-4b1a-8d78-34b7bcb16f5c)

![example bad input 2 error message](https://github.com/user-attachments/assets/630aa0a8-e36d-4611-8093-c3e814acf300)
