### PR TITLE
[ux] Open a specific tab in the Message Log Panel

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
@@ -1284,9 +1284,7 @@ Add a toolbar
 Opens the message log dock widget, and optionally activates a specific
 tab by name.
 
-:param tabName: Name of the tab to be activated.
-
-.. versionadded:: 3.44
+:param tabName: Name of the tab to be activated (since QGIS 3.44)
 %End
 
     virtual void addUserInputWidget( QWidget *widget ) = 0;

--- a/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgisinterface.sip.in
@@ -1279,9 +1279,14 @@ Add toolbar with specified name
 Add a toolbar
 %End
 
-    virtual void openMessageLog() = 0;
+    virtual void openMessageLog( const QString &tabName = QString() ) = 0;
 %Docstring
-Opens the message log dock widget.
+Opens the message log dock widget, and optionally activates a specific
+tab by name.
+
+:param tabName: Name of the tab to be activated.
+
+.. versionadded:: 3.44
 %End
 
     virtual void addUserInputWidget( QWidget *widget ) = 0;

--- a/python/PyQt6/gui/auto_generated/qgsmessagelogviewer.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmessagelogviewer.sip.in
@@ -33,6 +33,13 @@ to the system's :py:func:`QgsApplication.messageLog()` instance.
 Logs a ``message`` to the viewer.
 %End
 
+    void showTab( const QString &tag );
+%Docstring
+Activates the tab whose title matches the given ``tag``, if any.
+
+.. versionadded:: 3.44
+%End
+
   protected:
     virtual void closeEvent( QCloseEvent *e );
 

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1284,9 +1284,7 @@ Add a toolbar
 Opens the message log dock widget, and optionally activates a specific
 tab by name.
 
-:param tabName: Name of the tab to be activated.
-
-.. versionadded:: 3.44
+:param tabName: Name of the tab to be activated (since QGIS 3.44)
 %End
 
     virtual void addUserInputWidget( QWidget *widget ) = 0;

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1279,9 +1279,14 @@ Add toolbar with specified name
 Add a toolbar
 %End
 
-    virtual void openMessageLog() = 0;
+    virtual void openMessageLog( const QString &tabName = QString() ) = 0;
 %Docstring
-Opens the message log dock widget.
+Opens the message log dock widget, and optionally activates a specific
+tab by name.
+
+:param tabName: Name of the tab to be activated.
+
+.. versionadded:: 3.44
 %End
 
     virtual void addUserInputWidget( QWidget *widget ) = 0;

--- a/python/gui/auto_generated/qgsmessagelogviewer.sip.in
+++ b/python/gui/auto_generated/qgsmessagelogviewer.sip.in
@@ -33,6 +33,13 @@ to the system's :py:func:`QgsApplication.messageLog()` instance.
 Logs a ``message`` to the viewer.
 %End
 
+    void showTab( const QString &tag );
+%Docstring
+Activates the tab whose title matches the given ``tag``, if any.
+
+.. versionadded:: 3.44
+%End
+
   protected:
     virtual void closeEvent( QCloseEvent *e );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4840,7 +4840,8 @@ void QgisApp::toggleLogMessageIcon( bool hasLogMessage )
 void QgisApp::openMessageLog( const QString &tabName )
 {
   mLogDock->setUserVisible( true );
-  mLogViewer->showTab( tabName );
+  if ( !tabName.isEmpty() )
+    mLogViewer->showTab( tabName );
 }
 
 void QgisApp::addUserInputWidget( QWidget *widget )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4837,9 +4837,10 @@ void QgisApp::toggleLogMessageIcon( bool hasLogMessage )
   }
 }
 
-void QgisApp::openMessageLog()
+void QgisApp::openMessageLog( const QString &tabName )
 {
   mLogDock->setUserVisible( true );
+  mLogViewer->showTab( tabName );
 }
 
 void QgisApp::addUserInputWidget( QWidget *widget )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -326,8 +326,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Returns the messageBar object which allows displaying unobtrusive messages to the user.
     QgsMessageBar *messageBar();
 
-    //! Open the message log dock widget
-    void openMessageLog();
+    /**
+     * Opens the message log dock widget, and optionally activates a specific tab by name.
+     *
+     * \param tabName Name of the tab to be activated.
+     */
+    void openMessageLog( const QString &tabName = QString() );
 
     //! Adds a widget to the user input tool bar
     void addUserInputWidget( QWidget *widget );

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -427,9 +427,9 @@ QgsMessageBar *QgisAppInterface::messageBar()
   return qgis->messageBar();
 }
 
-void QgisAppInterface::openMessageLog()
+void QgisAppInterface::openMessageLog( const QString &tabName )
 {
-  qgis->openMessageLog();
+  qgis->openMessageLog( tabName );
 }
 
 

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -115,7 +115,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QgsLayerTreeMapCanvasBridge *layerTreeCanvasBridge() override;
     QWidget *mainWindow() override;
     QgsMessageBar *messageBar() override;
-    void openMessageLog() override;
+    void openMessageLog( const QString &tabName = QString() ) override;
     void addUserInputWidget( QWidget *widget ) override;
     void showLayoutManager() override;
     QList<QgsLayoutDesignerInterface *> openLayoutDesigners() override;

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -1060,9 +1060,7 @@ class GUI_EXPORT QgisInterface : public QObject
     /**
      * Opens the message log dock widget, and optionally activates a specific tab by name.
      *
-     * \param tabName Name of the tab to be activated.
-     *
-     * \since QGIS 3.44
+     * \param tabName Name of the tab to be activated (since QGIS 3.44)
      */
     virtual void openMessageLog( const QString &tabName = QString() ) = 0;
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -1058,9 +1058,13 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void addToolBar( QToolBar *toolbar SIP_TRANSFER, Qt::ToolBarArea area = Qt::TopToolBarArea ) = 0;
 
     /**
-     * Opens the message log dock widget.
+     * Opens the message log dock widget, and optionally activates a specific tab by name.
+     *
+     * \param tabName Name of the tab to be activated.
+     *
+     * \since QGIS 3.44
      */
-    virtual void openMessageLog() = 0;
+    virtual void openMessageLog( const QString &tabName = QString() ) = 0;
 
     //! Adds a widget to the user input tool bar.
     virtual void addUserInputWidget( QWidget *widget ) = 0;

--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -174,6 +174,18 @@ void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag
   emptyLabel->hide();
 }
 
+void QgsMessageLogViewer::showTab( const QString &tag )
+{
+  for ( int i = 0; i < tabWidget->count(); i++ )
+  {
+    if ( tabWidget->tabText( i ).remove( QChar( '&' ) ) == tag )
+    {
+      tabWidget->setCurrentIndex( i );
+      return;
+    }
+  }
+}
+
 void QgsMessageLogViewer::closeTab( int index )
 {
   tabWidget->removeTab( index );

--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -50,6 +50,13 @@ class GUI_EXPORT QgsMessageLogViewer : public QDialog, private Ui::QgsMessageLog
      */
     void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
 
+    /**
+     * Activates the tab whose title matches the given \a tag, if any.
+     *
+     * \since QGIS 3.44
+     */
+    void showTab( const QString &tag );
+
   protected:
     void closeEvent( QCloseEvent *e ) override;
     void reject() override;


### PR DESCRIPTION
Because sometimes we want to take users to read messages in a specific tab in the `Message Log Panel`, for instance, a tab from a provider or from a given plugin.

If the tab is not found by its name, the panel will be shown in its current status.

Also exposed via iface, so developers can now use:

`iface.openMessageLog( tab_name )`

----------

Funded by [City of Frankfurt – Stadtplanungsamt](https://www.stadtplanungsamt-frankfurt.de/about_us_5645.html).
