### PR TITLE
[vector layer] Favor "name" over "somethingname" when determining friendly identifier field

### DIFF
--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -1233,14 +1233,20 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
                                     };
 
   QString bestCandidateName;
-  QString bestCandidateNameWithAntiCandidate;
+  QString bestCandidateContainsName;
+  QString bestCandidateContainsNameWithAntiCandidate;
 
   for ( const QString &candidate : sCandidates )
   {
     for ( const QgsField &field : fields )
     {
       const QString fldName = field.name();
-      if ( fldName.contains( candidate, Qt::CaseInsensitive ) )
+
+      if ( fldName.compare( candidate, Qt::CaseInsensitive ) == 0 )
+      {
+        bestCandidateName = fldName;
+      }
+      else if ( fldName.contains( candidate, Qt::CaseInsensitive ) )
       {
         bool isAntiCandidate = false;
         for ( const QString &antiCandidate : sAntiCandidates )
@@ -1254,15 +1260,17 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
 
         if ( isAntiCandidate )
         {
-          if ( bestCandidateNameWithAntiCandidate.isEmpty() )
+          if ( bestCandidateContainsNameWithAntiCandidate.isEmpty() )
           {
-            bestCandidateNameWithAntiCandidate = fldName;
+            bestCandidateContainsNameWithAntiCandidate = fldName;
           }
         }
         else
         {
-          bestCandidateName = fldName;
-          break;
+          if ( bestCandidateContainsName.isEmpty() )
+          {
+            bestCandidateContainsName = fldName;
+          }
         }
       }
     }
@@ -1271,7 +1279,12 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
       break;
   }
 
-  QString candidateName = bestCandidateName.isEmpty() ? bestCandidateNameWithAntiCandidate : bestCandidateName;
+  QString candidateName = bestCandidateName;
+  if ( candidateName.isEmpty() )
+  {
+    candidateName = bestCandidateContainsName.isEmpty() ? bestCandidateContainsNameWithAntiCandidate : bestCandidateContainsName;
+  }
+
   if ( !candidateName.isEmpty() )
   {
     // Special case for layers got from WFS using the OGR GMLAS field parsing logic.

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -4171,7 +4171,7 @@ class TestQgsVectorLayer(QgisTestCase, FeatureSourceTestCase):
         self.assertEqual(layer.displayExpression(), '"NAME"')
         self.assertEqual(layer.displayField(), "NAME")
         layer = QgsVectorLayer(
-            "Polygon?crs=epsg:2056&field=pk:int&field=DESCRIPTION:string&field=fid:int&field=BETTER_NAME:string&field=NAME:string",
+            "Polygon?crs=epsg:2056&field=pk:int&field=DESCRIPTION:string&field=fid:int&field=BETTER_NAME:string&field=ALT_NAME:string",
             "vl",
             "memory",
         )

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -1104,6 +1104,17 @@ class TestQgsVectorLayerUtils(QgisTestCase):
             QgsVectorLayerUtils.guessFriendlyIdentifierField(fields), "areaadminname"
         )
 
+        fields = QgsFields()
+        fields.append(QgsField("amenity", QVariant.String))
+        fields.append(QgsField("housename", QVariant.String))
+        fields.append(QgsField("housenumber", QVariant.String))
+        fields.append(QgsField("name", QVariant.String))
+        fields.append(QgsField("name_de", QVariant.String))
+        fields.append(QgsField("office", QVariant.String))
+        self.assertEqual(
+            QgsVectorLayerUtils.guessFriendlyIdentifierField(fields), "name"
+        )
+
         # if no good matches by name found, the first string field should be used
         fields = QgsFields()
         fields.append(QgsField("id", QVariant.Int))


### PR DESCRIPTION
## Description

Handling OSM layers, I'm realizing our way of determining a friendly identifier field can be improved a tiny bit in this scenario:

![image](https://github.com/user-attachments/assets/34f1fe75-df8f-453f-9683-6cde96757415)

ATM, we'd pick the "officename" field as the friendly identifier field because a/ it comes up early due to the field names being in alphabetical order and more importantly b/ we don't favor "name" over "officename", which IMHO we should. 

This PR does exactly that.