### PR TITLE
Fix depth map for GLSL compatibility

### DIFF
--- a/src/3d/shaders/depth_render.frag
+++ b/src/3d/shaders/depth_render.frag
@@ -9,7 +9,7 @@ out vec4 fragColor;
 
 void main()
 {
-  float z = texture2D( depthTexture, texCoord ).r;
+  float z = texture( depthTexture, texCoord ).r;
   fragColor.b = float( int(z * 255) ) / 255.0;
   z = z * 255.0 - fragColor.b * 255.0;
   fragColor.g = float( int(z * 255) ) / 255.0;


### PR DESCRIPTION
texture2D is deprecated since GLSL 1.30 and removed in 3.30 and beyond.
Using `texture2D` will fail on recent Windows and macOS installations (for some reason it seems to work on linux).

With this patch in place, terrain based 3D navigation becomes usable on Windows and macOS.

Fixes #62190 #60797 