### PR TITLE
[fix] Make the Oriented Minimum Bounding Box of a singlepart point return the Bounding Box of the point

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1211,6 +1211,9 @@ If an error was encountered while creating the result, more information
 can be retrieved by calling :py:func:`~QgsGeometry.lastError` on the
 returned geometry.
 
+For singlepart point geometries, the result is equivalent to the
+bounding box of the geometry.
+
 .. seealso:: :py:func:`boundingBox`
 %End
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1211,6 +1211,9 @@ If an error was encountered while creating the result, more information
 can be retrieved by calling :py:func:`~QgsGeometry.lastError` on the
 returned geometry.
 
+For singlepart point geometries, the result is equivalent to the
+bounding box of the geometry.
+
 .. seealso:: :py:func:`boundingBox`
 %End
 

--- a/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.cpp
+++ b/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.cpp
@@ -57,7 +57,7 @@ Qgis::WkbType QgsOrientedMinimumBoundingBoxAlgorithm::outputWkbType( Qgis::WkbTy
 
 QString QgsOrientedMinimumBoundingBoxAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm calculates the minimum area rotated rectangle which covers each feature in an input layer." ) + QStringLiteral( "\n\n" ) + QObject::tr( "For singlepart point features, the output corresponds to the bounding box of the geometry." ) + QStringLiteral( "\n\n" ) + QObject::tr( "See the 'Minimum bounding geometry' algorithm for a oriented bounding box calculation which covers the whole layer or grouped subsets of features." );
+  return QObject::tr( "This algorithm calculates the minimum area rotated rectangle which covers each feature in an input layer." ) + QStringLiteral( "\n\n" ) + QObject::tr( "For singlepart point features, the output corresponds to the bounding box of the geometry." ) + QStringLiteral( "\n\n" ) + QObject::tr( "See the 'Minimum bounding geometry' algorithm for an oriented bounding box calculation which covers the whole layer or grouped subsets of features." );
 }
 
 QString QgsOrientedMinimumBoundingBoxAlgorithm::shortDescription() const

--- a/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.cpp
+++ b/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.cpp
@@ -57,7 +57,7 @@ Qgis::WkbType QgsOrientedMinimumBoundingBoxAlgorithm::outputWkbType( Qgis::WkbTy
 
 QString QgsOrientedMinimumBoundingBoxAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm calculates the minimum area rotated rectangle which covers each feature in an input layer." ) + QStringLiteral( "\n\n" ) + QObject::tr( "See the 'Minimum bounding geometry' algorithm for a oriented bounding box calculation which covers the whole layer or grouped subsets of features." );
+  return QObject::tr( "This algorithm calculates the minimum area rotated rectangle which covers each feature in an input layer." ) + QStringLiteral( "\n\n" ) + QObject::tr( "For singlepart point features, the output corresponds to the bounding box of the geometry." ) + QStringLiteral( "\n\n" ) + QObject::tr( "See the 'Minimum bounding geometry' algorithm for a oriented bounding box calculation which covers the whole layer or grouped subsets of features." );
 }
 
 QString QgsOrientedMinimumBoundingBoxAlgorithm::shortDescription() const

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1337,6 +1337,9 @@ QgsGeometry QgsGeometry::orientedMinimumBoundingBox( double &area, double &angle
 {
   mLastError.clear();
 
+  if ( isNull() )
+    return QgsGeometry();
+
   if ( type() == Qgis::GeometryType::Point && d->geometry->partCount() == 1 )
   {
     area = 0;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1336,6 +1336,16 @@ QgsBox3D QgsGeometry::boundingBox3D() const
 QgsGeometry QgsGeometry::orientedMinimumBoundingBox( double &area, double &angle, double &width, double &height ) const
 {
   mLastError.clear();
+
+  if ( type() == Qgis::GeometryType::Point && d->geometry->partCount() == 1 )
+  {
+    area = 0;
+    angle = 0;
+    width = 0;
+    height = 0;
+    return QgsGeometry::fromRect( d->geometry->boundingBox() );
+  }
+
   QgsInternalGeometryEngine engine( *this );
   const QgsGeometry res = engine.orientedMinimumBoundingBox( area, angle, width, height );
   if ( res.isNull() )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1213,6 +1213,8 @@ class CORE_EXPORT QgsGeometry
      * If an error was encountered while creating the result, more information can be retrieved
      * by calling lastError() on the returned geometry.
      *
+     * For singlepart point geometries, the result is equivalent to the bounding box of the geometry.
+     *
      * \see boundingBox()
      */
     QgsGeometry orientedMinimumBoundingBox( double &area SIP_OUT, double &angle SIP_OUT, double &width SIP_OUT, double &height SIP_OUT ) const;
@@ -1224,6 +1226,7 @@ class CORE_EXPORT QgsGeometry
      * If an error was encountered while creating the result, more information can be retrieved
      * by calling lastError() on the returned geometry.
      *
+     * For singlepart point geometries, the result is equivalent to the bounding box of the geometry.
      */
     QgsGeometry orientedMinimumBoundingBox() const SIP_SKIP;
 

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -2292,6 +2292,57 @@ void TestQgsGeometry::orientedMinimumBoundingBox()
   result = geomTest.orientedMinimumBoundingBox();
   resultTestWKT = QStringLiteral( "Polygon ((-57 -30, -55.5 -30, -55.5 -29, -57 -29, -57 -30))" );
   QCOMPARE( result.asWkt( 2 ), resultTestWKT );
+
+  // Issue https://github.com/qgis/QGIS/issues/62126
+  geomTest = QgsGeometry::fromWkt( QStringLiteral( "Point (10 10)" ) );
+  result = geomTest.orientedMinimumBoundingBox();
+  resultTestWKT = QStringLiteral( "Polygon ((10 10, 10 10, 10 10, 10 10, 10 10))" );
+  QCOMPARE( result.asWkt( 2 ), resultTestWKT );
+
+  geomTest = QgsGeometry::fromWkt( QStringLiteral( "Point (10 20)" ) );
+  double area, angle, width, height;
+  result = geomTest.orientedMinimumBoundingBox( area, angle, width, height );
+  resultTestWKT = QStringLiteral( "Polygon ((10 20, 10 20, 10 20, 10 20, 10 20))" );
+  QCOMPARE( result.asWkt( 2 ), resultTestWKT );
+  QCOMPARE( area, 0.0 );
+  QCOMPARE( angle, 0.0 );
+  QCOMPARE( width, 0.0 );
+  QCOMPARE( height, 0.0 );
+
+  // Multipoint with multipart geometry
+  geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT( 0 5, 0 -5, 0 0 )" ) );
+  result = geomTest.orientedMinimumBoundingBox();
+  resultTestWKT = QStringLiteral( "Polygon ((0 -5, 0 -5, 0 5, 0 5, 0 -5))" );
+  QCOMPARE( result.asWkt( 2 ), resultTestWKT );
+
+  geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT( 0 5, 0 -5, 0 0 )" ) );
+  result = geomTest.orientedMinimumBoundingBox( area, angle, width, height );
+  resultTestWKT = QStringLiteral( "Polygon ((0 -5, 0 -5, 0 5, 0 5, 0 -5))" );
+  QCOMPARE( result.asWkt( 2 ), resultTestWKT );
+  QCOMPARE( area, 0.0 );
+  QCOMPARE( angle, 0.0 );
+  QCOMPARE( width, 0.0 );
+  QCOMPARE( height, 10 );
+
+  // Multipoint with singlepart geometry
+  geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT( 0 5 )" ) );
+  result = geomTest.orientedMinimumBoundingBox();
+  resultTestWKT = QStringLiteral( "Polygon ((0 5, 0 5, 0 5, 0 5, 0 5))" );
+  QCOMPARE( result.asWkt( 2 ), resultTestWKT );
+
+  geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT( 0 5 )" ) );
+  result = geomTest.orientedMinimumBoundingBox( area, angle, width, height );
+  resultTestWKT = QStringLiteral( "Polygon ((0 5, 0 5, 0 5, 0 5, 0 5))" );
+  QCOMPARE( result.asWkt( 2 ), resultTestWKT );
+  QCOMPARE( area, 0.0 );
+  QCOMPARE( angle, 0.0 );
+  QCOMPARE( width, 0.0 );
+  QCOMPARE( height, 0.0 );
+
+  geomTest = QgsGeometry::fromWkt( QStringLiteral( "Point EMPTY" ) );
+  result = geomTest.orientedMinimumBoundingBox();
+  resultTestWKT = QLatin1String( "" );
+  QCOMPARE( result.asWkt( 2 ), resultTestWKT );
 }
 
 void TestQgsGeometry::boundingBox()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -4342,6 +4342,8 @@ class TestQgsExpression : public QObject
 
       geom = QgsGeometry::fromPolygonXY( polygon );
       QTest::newRow( "oriented_bbox" ) << "oriented_bbox( $geometry )" << geom << false << true << geom.orientedMinimumBoundingBox();
+      geom = QgsGeometry::fromPointXY( point1 );
+      QTest::newRow( "oriented_bbox_point" ) << "oriented_bbox( $geometry )" << geom << false << true << QgsGeometry::fromWkt( QStringLiteral( "Polygon ((10 20, 10 20, 10 20, 10 20, 10 20))" ) );
       geom = QgsGeometry::fromPolygonXY( polygon );
       QTest::newRow( "minimal_circle" ) << "minimal_circle( $geometry )" << geom << false << true << geom.minimalEnclosingCircle();
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1755,7 +1755,7 @@ class TestQgsExpression : public QObject
       QTest::newRow( "main angle polygon" ) << "round(main_angle( geom_from_wkt('POLYGON((0 0,2 9,9 2,0 0))')))" << false << QVariant( 77 );
       QTest::newRow( "main angle polygon edge case" ) << "round(main_angle( geom_from_wkt('POLYGON((353542.63843526 378974.92373469, 353544.95808017 378975.73690545, 353545.27173175 378974.84218528, 353542.95208684 378974.02901451, 353542.63843526 378974.92373469))')))" << false << QVariant( 71 );
       QTest::newRow( "main angle multi polygon" ) << "round(main_angle( geom_from_wkt('MULTIPOLYGON(((0 0,3 10,1 10,1 6,0 0)))')))" << false << QVariant( 17 );
-      QTest::newRow( "main angle point" ) << "main_angle( geom_from_wkt('POINT (1.5 0.5)') )" << true << QVariant();
+      QTest::newRow( "main angle point" ) << "main_angle( geom_from_wkt('POINT (1.5 0.5)') )" << false << QVariant( 0.0 );
       QTest::newRow( "main angle line" ) << "round(main_angle( geom_from_wkt('LINESTRING (-1 2, 9 12)') ))" << false << QVariant( 45 );
       QTest::newRow( "main angle not geom" ) << "main_angle('g')" << true << QVariant();
       QTest::newRow( "main angle null" ) << "main_angle(NULL)" << false << QVariant();

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -10235,10 +10235,20 @@ class TestQgsGeometry(QgisTestCase):
         bbox, area, angle, width, height = empty.orientedMinimumBoundingBox()
         self.assertFalse(bbox)
 
-        # not a useful geometry
+        # Special case: singlepart point geometry
         point = QgsGeometry.fromWkt("Point(1 2)")
         bbox, area, angle, width, height = point.orientedMinimumBoundingBox()
-        self.assertFalse(bbox)
+        exp = "Polygon ((1 2, 1 2, 1 2, 1 2, 1 2))"
+        result = bbox.asWkt(2)
+
+        self.assertTrue(
+            compareWkt(result, exp),
+            f"Oriented MBBR: mismatch Expected:\n{exp}\nGot:\n{result}\n",
+        )
+        self.assertEqual(area, 0)
+        self.assertEqual(angle, 0)
+        self.assertEqual(width, 0)
+        self.assertEqual(height, 0)
 
         # polygon
         polygon = QgsGeometry.fromWkt(


### PR DESCRIPTION
Thus, the result will now have a valid extent, and more meaningful geometric attributes (area. angle, width, height).

Includes unit tests.

Fix #62126