### PR TITLE
Follow up,  github actions to automatically check the user is running supported QGIS version 

### DIFF
--- a/.github/workflows/check-user-reported-qgis-version.yml
+++ b/.github/workflows/check-user-reported-qgis-version.yml
@@ -61,8 +61,8 @@ jobs:
 
 
             // Match qgis version reported e.g : "3.40.0-Bratislava"
-            // More example here : https://regex101.com/r/jvHJAf/1
-            var regex = /QGIS version \| (\d)\.(\d{2})\.(\d*)-[A-Z]{1}[a-z]+/
+            // More example here : https://regex101.com/r/jvHJAf/2
+            var regex = /QGIS [Vv]ersion(?:: | \| )(\d)\.(\d{2})\.(\d*)-[A-Z][a-z]+/
 
             var m = ISSUE_BODY.match(regex)
 


### PR DESCRIPTION
## Description

#61602 introduced a new actions that checked the user is running a support version, however the regex used to match the version reported didn't account for the format used in QGIS  in-app crash report  

Thanks @nicogodet  for providing the updated regex

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
