### PR TITLE
qgsproject: add support for base64 encoded url

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsprojectutils.py
+++ b/python/PyQt6/core/auto_additions/qgsprojectutils.py
@@ -3,6 +3,7 @@ try:
     QgsProjectUtils.layersMatchingPath = staticmethod(QgsProjectUtils.layersMatchingPath)
     QgsProjectUtils.updateLayerPath = staticmethod(QgsProjectUtils.updateLayerPath)
     QgsProjectUtils.layerIsContainedInGroupLayer = staticmethod(QgsProjectUtils.layerIsContainedInGroupLayer)
+    QgsProjectUtils.decodeBase64Filename = staticmethod(QgsProjectUtils.decodeBase64Filename)
     QgsProjectUtils.__group__ = ['project']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/project/qgsprojectutils.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectutils.sip.in
@@ -48,7 +48,15 @@ Returns ``True`` if the specified ``layer`` is a child layer from any
 .. versionadded:: 3.24
 %End
 
+    static QString decodeBase64Filename( const QString &filename );
+%Docstring
+Returns the decoded ``filename``.
 
+If the ``filename`` starts with the scheme 'base64://', this will decode
+what after the scheme and return it. Else returns the filename as it.
+
+.. versionadded:: 3.44
+%End
 };
 
 

--- a/python/core/auto_additions/qgsprojectutils.py
+++ b/python/core/auto_additions/qgsprojectutils.py
@@ -3,6 +3,7 @@ try:
     QgsProjectUtils.layersMatchingPath = staticmethod(QgsProjectUtils.layersMatchingPath)
     QgsProjectUtils.updateLayerPath = staticmethod(QgsProjectUtils.updateLayerPath)
     QgsProjectUtils.layerIsContainedInGroupLayer = staticmethod(QgsProjectUtils.layerIsContainedInGroupLayer)
+    QgsProjectUtils.decodeBase64Filename = staticmethod(QgsProjectUtils.decodeBase64Filename)
     QgsProjectUtils.__group__ = ['project']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/project/qgsprojectutils.sip.in
+++ b/python/core/auto_generated/project/qgsprojectutils.sip.in
@@ -48,7 +48,15 @@ Returns ``True`` if the specified ``layer`` is a child layer from any
 .. versionadded:: 3.24
 %End
 
+    static QString decodeBase64Filename( const QString &filename );
+%Docstring
+Returns the decoded ``filename``.
 
+If the ``filename`` starts with the scheme 'base64://', this will decode
+what after the scheme and return it. Else returns the filename as it.
+
+.. versionadded:: 3.44
+%End
 };
 
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1938,7 +1938,16 @@ bool QgsProject::read( const QString &filename, Qgis::ProjectReadFlags flags )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  mFile.setFileName( filename );
+  QUrl url( filename );
+  if ( url.scheme() == QStringLiteral( "base64" ) )
+  {
+    QByteArray filenameBA = filename.toUtf8();
+    int len = filenameBA.length() - QString( "base64://" ).length();
+    QByteArray decoded = QByteArray::fromBase64( filenameBA.right( len ) );
+    mFile.setFileName( QString::fromUtf8( decoded ) );
+  }
+  else
+    mFile.setFileName( filename );
   mCachedHomePath.clear();
   mProjectScope.reset();
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1938,16 +1938,7 @@ bool QgsProject::read( const QString &filename, Qgis::ProjectReadFlags flags )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
-  QUrl url( filename );
-  if ( url.scheme() == QStringLiteral( "base64" ) )
-  {
-    const QByteArray filenameBA( filename.toUtf8() );
-    const int len = filenameBA.length() - QString( "base64://" ).length();
-    const QByteArray decoded( QByteArray::fromBase64( filenameBA.right( len ) ) );
-    mFile.setFileName( QString::fromUtf8( decoded ) );
-  }
-  else
-    mFile.setFileName( filename );
+  mFile.setFileName( filename );
   mCachedHomePath.clear();
   mProjectScope.reset();
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1941,9 +1941,9 @@ bool QgsProject::read( const QString &filename, Qgis::ProjectReadFlags flags )
   QUrl url( filename );
   if ( url.scheme() == QStringLiteral( "base64" ) )
   {
-    QByteArray filenameBA = filename.toUtf8();
-    int len = filenameBA.length() - QString( "base64://" ).length();
-    QByteArray decoded = QByteArray::fromBase64( filenameBA.right( len ) );
+    const QByteArray filenameBA( filename.toUtf8() );
+    const int len = filenameBA.length() - QString( "base64://" ).length();
+    const QByteArray decoded( QByteArray::fromBase64( filenameBA.right( len ) ) );
     mFile.setFileName( QString::fromUtf8( decoded ) );
   }
   else

--- a/src/core/project/qgsprojectutils.cpp
+++ b/src/core/project/qgsprojectutils.cpp
@@ -89,3 +89,15 @@ bool QgsProjectUtils::layerIsContainedInGroupLayer( QgsProject *project, QgsMapL
   };
   return traverseTree( project->layerTreeRoot() );
 }
+
+QString QgsProjectUtils::decodeBase64Filename( const QString &filename )
+{
+  const QString base64Prefix = QStringLiteral( "base64://" );
+  if ( !filename.startsWith( base64Prefix ) )
+    return filename;
+
+  const QByteArray filenameBA( filename.toUtf8() );
+  const int len = filenameBA.length() - base64Prefix.length();
+  const QByteArray decoded( QByteArray::fromBase64( filenameBA.right( len ) ) );
+  return QString::fromUtf8( decoded );
+}

--- a/src/core/project/qgsprojectutils.h
+++ b/src/core/project/qgsprojectutils.h
@@ -58,7 +58,15 @@ class CORE_EXPORT QgsProjectUtils
      */
     static bool layerIsContainedInGroupLayer( QgsProject *project, QgsMapLayer *layer );
 
-
+    /**
+     * Returns the decoded \a filename.
+     *
+     * If the \a filename starts with the scheme 'base64://', this will decode what after the scheme and return it.
+     * Else returns the filename as it.
+     *
+     * \since QGIS 3.44
+     */
+    static QString decodeBase64Filename( const QString &filename );
 };
 
 #endif // QGSPROJECTUTILS_H

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -37,6 +37,7 @@ while QGIS server internal logging is printed to stderr.
 #include "qgsbufferserverresponse.h"
 #include "qgsapplication.h"
 #include "qgsmessagelog.h"
+#include "qgsprojectutils.h"
 
 #include <QFontDatabase>
 #include <QString>
@@ -591,7 +592,7 @@ int main( int argc, char *argv[] )
   if ( !parser.value( projectOption ).isEmpty() )
   {
     // Check it!
-    const QString projectFilePath { parser.value( projectOption ) };
+    const QString projectFilePath = QgsProjectUtils::decodeBase64Filename( parser.value( projectOption ) );
     if ( !QgsProject::instance()->read( projectFilePath, Qgis::ProjectReadFlag::DontResolveLayers | Qgis::ProjectReadFlag::DontLoadLayouts | Qgis::ProjectReadFlag::DontStoreOriginalStyles | Qgis::ProjectReadFlag::DontLoad3DViews | Qgis::ProjectReadFlag::DontUpgradeAnnotations ) )
     {
       std::cout << QObject::tr( "Project file not found, the option will be ignored." ).toStdString() << std::endl;

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -20,6 +20,7 @@
 #include "qgsserverexception.h"
 #include "qgsstorebadlayerinfo.h"
 #include "qgsserverprojectutils.h"
+#include "qgsprojectutils.h"
 
 #include <QFile>
 
@@ -136,7 +137,8 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
       }
     }
 
-    if ( prj->read( path, readFlags ) )
+    QString decodedPath = QgsProjectUtils::decodeBase64Filename( path );
+    if ( prj->read( decodedPath, readFlags ) )
     {
       if ( !badLayerHandler->badLayers().isEmpty() )
       {
@@ -162,7 +164,7 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
           if ( !settings || !settings->ignoreBadLayers() )
           {
             QgsMessageLog::logMessage(
-              QStringLiteral( "Error, Layer(s) %1 not valid in project %2" ).arg( unrestrictedBadLayers.join( QLatin1String( ", " ) ), path ),
+              QStringLiteral( "Error, Layer(s) %1 not valid in project %2" ).arg( unrestrictedBadLayers.join( QLatin1String( ", " ) ), decodedPath ),
               QStringLiteral( "Server" ), Qgis::MessageLevel::Critical
             );
             throw QgsServerException( QStringLiteral( "Layer(s) not valid" ) );
@@ -170,7 +172,7 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
           else
           {
             QgsMessageLog::logMessage(
-              QStringLiteral( "Warning, Layer(s) %1 not valid in project %2" ).arg( unrestrictedBadLayers.join( QLatin1String( ", " ) ), path ),
+              QStringLiteral( "Warning, Layer(s) %1 not valid in project %2" ).arg( unrestrictedBadLayers.join( QLatin1String( ", " ) ), decodedPath ),
               QStringLiteral( "Server" ), Qgis::MessageLevel::Warning
             );
           }
@@ -181,7 +183,7 @@ const QgsProject *QgsConfigCache::project( const QString &path, const QgsServerS
     else
     {
       QgsMessageLog::logMessage(
-        QStringLiteral( "Error when loading project file '%1': %2 " ).arg( path, prj->error() ),
+        QStringLiteral( "Error when loading project file '%1': %2 " ).arg( decodedPath, prj->error() ),
         QStringLiteral( "Server" ), Qgis::MessageLevel::Critical
       );
     }


### PR DESCRIPTION
In QgsDataSourceUri, if the 'url' field references a QGIS server then the 'MAP' parameter can contain an url to the project file. When the project is saved in a postgresql db, the connection url will also contains '&' and '=' characters. One solution is to urlencod twice this url and another solution is to use the encode the project file url to base64 and use the 'base64://' scheme.

closes #31192
