### PR TITLE
Fix avoid overlaps when reshaping whith an active selection

### DIFF
--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -45,6 +45,8 @@ class TestQgsMapToolReshape : public QObject
     void testReshapeZ();
     void testTopologicalEditing();
     void testAvoidIntersectionAndTopoEdit();
+    void testAvoidIntersectionAndTopoEditSameLayer();
+    void testAvoidIntersectionAndTopoEditSameLayerSelection();
     void reshapeWithBindingLine();
     void testWithTracing();
     void testKeepDirection();
@@ -322,6 +324,97 @@ void TestQgsMapToolReshape::testAvoidIntersectionAndTopoEdit()
   QCOMPARE( mLayerTopo->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon ((0 0, 4 0, 4 4, 0 4))" ) );
   QCOMPARE( mLayerTopo->getFeature( 2 ).geometry().asWkt(), QStringLiteral( "Polygon ((7 0, 8 0, 8 4, 7 4))" ) );
 
+  QgsProject::instance()->setTopologicalEditing( topologicalEditing );
+  QgsProject::instance()->setAvoidIntersectionsMode( mode );
+  QgsProject::instance()->setAvoidIntersectionsLayers( vlayers );
+  mCaptureTool->setAutoSnapEnabled( isAutoSnapEnabled );
+}
+
+void TestQgsMapToolReshape::testAvoidIntersectionAndTopoEditSameLayer()
+{
+  QList<QgsMapLayer *> layers = { mLayerTopo, mLayerTopo2 };
+  QgsProject::instance()->addMapLayers( layers );
+  mCanvas->setLayers( layers );
+
+  // backup project settings
+  const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+  const Qgis::AvoidIntersectionsMode mode( QgsProject::instance()->avoidIntersectionsMode() );
+  const QList<QgsVectorLayer *> vlayers = QgsProject::instance()->avoidIntersectionsLayers();
+  const bool isAutoSnapEnabled = mCaptureTool->isAutoSnapEnabled();
+
+  QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AvoidIntersectionsLayers );
+  QgsProject::instance()->setAvoidIntersectionsLayers( { mLayerTopo, mLayerTopo2 } );
+  QgsProject::instance()->setTopologicalEditing( true );
+  mCanvas->setCurrentLayer( mLayerTopo );
+  mCaptureTool->setAutoSnapEnabled( false );
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  // reshape mLayerTopo feature 1 with two points inside mLayerTopo feature 2, both features should be reshaped
+  utils.mouseClick( 4, 4, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 7, 4, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 7.5, 3, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 7.5, 1, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 7, 0, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 4, 0, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 4, 0, Qt::RightButton );
+
+  QCOMPARE( mLayerTopo2->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon ((0 5, 4 5, 4 7, 0 7, 0 5))" ) );
+  QCOMPARE( mLayerTopo->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon ((4 0, 7 0, 7.5 1, 7.5 3, 7 4, 4 4, 0 4, 0 0, 4 0))" ) );
+  QCOMPARE( mLayerTopo->getFeature( 2 ).geometry().asWkt(), QStringLiteral( "Polygon ((7 0, 8 0, 8 4, 7 4, 7.5 3, 7.5 1, 7 0))" ) );
+
+  mLayerTopo->undoStack()->undo();
+
+  QCOMPARE( mLayerTopo2->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon ((0 5, 4 5, 4 7, 0 7, 0 5))" ) );
+  QCOMPARE( mLayerTopo->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon ((0 0, 4 0, 4 4, 0 4, 0 0))" ) );
+  QCOMPARE( mLayerTopo->getFeature( 2 ).geometry().asWkt(), QStringLiteral( "Polygon ((7 0, 8 0, 8 4, 7 4, 7 0))" ) );
+
+  QgsProject::instance()->setTopologicalEditing( topologicalEditing );
+  QgsProject::instance()->setAvoidIntersectionsMode( mode );
+  QgsProject::instance()->setAvoidIntersectionsLayers( vlayers );
+  mCaptureTool->setAutoSnapEnabled( isAutoSnapEnabled );
+}
+
+void TestQgsMapToolReshape::testAvoidIntersectionAndTopoEditSameLayerSelection()
+{
+  QList<QgsMapLayer *> layers = { mLayerTopo, mLayerTopo2 };
+  QgsProject::instance()->addMapLayers( layers );
+  mCanvas->setLayers( layers );
+
+  // backup project settings
+  const bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+  const Qgis::AvoidIntersectionsMode mode( QgsProject::instance()->avoidIntersectionsMode() );
+  const QList<QgsVectorLayer *> vlayers = QgsProject::instance()->avoidIntersectionsLayers();
+  const bool isAutoSnapEnabled = mCaptureTool->isAutoSnapEnabled();
+
+  QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AvoidIntersectionsLayers );
+  QgsProject::instance()->setAvoidIntersectionsLayers( { mLayerTopo, mLayerTopo2 } );
+  QgsProject::instance()->setTopologicalEditing( true );
+  mCanvas->setCurrentLayer( mLayerTopo );
+  mCaptureTool->setAutoSnapEnabled( false );
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  mLayerTopo->selectByIds( { 1 } );
+
+  // reshape mLayerTopo feature 1 with two points inside mLayerTopo feature 2, only the selected feature should be reshaped
+  utils.mouseClick( 4, 4, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 7, 4, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 7.5, 3, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 7.5, 1, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 7, 0, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 4, 0, Qt::LeftButton, Qt::KeyboardModifiers() );
+  utils.mouseClick( 4, 0, Qt::RightButton );
+
+  QCOMPARE( mLayerTopo2->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon ((0 5, 4 5, 4 7, 0 7, 0 5))" ) );
+  QCOMPARE( mLayerTopo->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon ((4 0, 0 0, 0 4, 4 4, 7 4, 7 0, 4 0))" ) );
+  QCOMPARE( mLayerTopo->getFeature( 2 ).geometry().asWkt(), QStringLiteral( "Polygon ((7 0, 8 0, 8 4, 7 4, 7 0))" ) );
+
+  mLayerTopo->undoStack()->undo();
+
+  QCOMPARE( mLayerTopo2->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon ((0 5, 4 5, 4 7, 0 7, 0 5))" ) );
+  QCOMPARE( mLayerTopo->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon ((0 0, 4 0, 4 4, 0 4, 0 0))" ) );
+  QCOMPARE( mLayerTopo->getFeature( 2 ).geometry().asWkt(), QStringLiteral( "Polygon ((7 0, 8 0, 8 4, 7 4, 7 0))" ) );
+
+  mLayerTopo->removeSelection();
   QgsProject::instance()->setTopologicalEditing( topologicalEditing );
   QgsProject::instance()->setAvoidIntersectionsMode( mode );
   QgsProject::instance()->setAvoidIntersectionsLayers( vlayers );


### PR DESCRIPTION
## Description
When reshaping, an assumption was made that all features of the same layer should be ignored during overlap avoidance since they will also be reshaped. This is not true since there are cases where the reshape line will not reshape a feature (eg crossing a feature more than once) and also when there are selected features (unselected features will not get modified)

With this PR reshaping and overlap avoidance is performed in two separate passes:
First perform the reshape logic while storing the results, then perform the avoid overlaps logic while ignoring the previously stored reshaped features.

Fix #61720
Fix #24884

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
