### PR TITLE
qgs3dmapconfigwidget: Only enable camera movement speed in walk mode

### DIFF
--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -55,6 +55,8 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
 
   mCameraNavigationModeCombo->addItem( tr( "Terrain Based" ), QVariant::fromValue( mMap->sceneMode() == Qgis::SceneMode::Globe ? Qgis::NavigationMode::GlobeTerrainBased : Qgis::NavigationMode::TerrainBased ) );
   mCameraNavigationModeCombo->addItem( tr( "Walk Mode (First Person)" ), QVariant::fromValue( Qgis::NavigationMode::Walk ) );
+  connect( mCameraNavigationModeCombo, qOverload<int>( &QComboBox::currentIndexChanged ), this, &Qgs3DMapConfigWidget::onNavigationModeChanged );
+  onNavigationModeChanged();
 
   // get rid of annoying outer focus rect on Mac
   m3DOptionsListWidget->setAttribute( Qt::WA_MacShowFocusRect, false );
@@ -528,4 +530,18 @@ void Qgs3DMapConfigWidget::on3DAxisChanged()
   }
 
   mMap->set3DAxisSettings( s );
+}
+
+void Qgs3DMapConfigWidget::onNavigationModeChanged()
+{
+  if ( mCameraNavigationModeCombo->currentData().value<Qgis::NavigationMode>() == Qgis::NavigationMode::Walk )
+  {
+    mCameraMovementSpeed->setEnabled( true );
+    mCameraMovementSpeed->setToolTip( "" );
+  }
+  else
+  {
+    mCameraMovementSpeed->setEnabled( false );
+    mCameraMovementSpeed->setToolTip( tr( "Movement speed is only applicable in Walk Mode" ) );
+  }
 }

--- a/src/app/3d/qgs3dmapconfigwidget.h
+++ b/src/app/3d/qgs3dmapconfigwidget.h
@@ -51,6 +51,7 @@ class APP_EXPORT Qgs3DMapConfigWidget : public QWidget, private Ui::Map3DConfigW
     void updateMaxZoomLevel();
     void validate();
     void on3DAxisChanged();
+    void onNavigationModeChanged();
 
   private:
     Qgs3DMapSettings *mMap = nullptr;


### PR DESCRIPTION
## Description

This parameter is only applicable in this mode.

![image](https://github.com/user-attachments/assets/09593e69-98c6-43c4-9c9c-fbdebd12c200)
