### PR TITLE
Fix reshape when snapping to segment

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1241,7 +1241,17 @@ Qgis::GeometryOperationResult QgsGeometry::reshapeGeometry( const QgsLineString 
     return Qgis::GeometryOperationResult::InvalidBaseGeometry;
   }
 
-  QgsGeos geos( d->geometry.get() );
+  // We're trying adding the reshape line's vertices to the geometry so that
+  // snap to segment always produces a valid reshape
+  QgsPointSequence reshapePoints;
+  reshapeLineString.points( reshapePoints );
+  QgsGeometry tmpGeom( *this );
+  for ( const QgsPoint &v : std::as_const( reshapePoints ) )
+  {
+    tmpGeom.addTopologicalPoint( v );
+  }
+
+  QgsGeos geos( tmpGeom.get() );
   QgsGeometryEngine::EngineOperationResult errorCode = QgsGeometryEngine::Success;
   mLastError.clear();
   std::unique_ptr< QgsAbstractGeometry > geom( geos.reshapeGeometry( reshapeLineString, &errorCode, &mLastError ) );

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -48,6 +48,7 @@ class TestQgsMapToolReshape : public QObject
     void reshapeWithBindingLine();
     void testWithTracing();
     void testKeepDirection();
+    void testWithSnapToSegment();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -474,11 +475,42 @@ void TestQgsMapToolReshape::testKeepDirection()
   QString wkt3 = QStringLiteral( "LineString (13 1, 12 1, 12 3, 13 3, 14 3, 14 5, 13 5, 12 5, 12 7, 13 7, 13 8, 19 11, 25 8, 25 0, 13 0, 13 1)" );
   QCOMPARE( mLayerLine->getFeature( 3 ).geometry().asWkt(), wkt3 );
 
+  // undo the three changes
+  mLayerLine->undoStack()->undo();
+  mLayerLine->undoStack()->undo();
+  mLayerLine->undoStack()->undo();
+
   // activate back snapping
   cfg.setEnabled( true );
   mCanvas->snappingUtils()->setConfig( cfg );
 }
 
+void TestQgsMapToolReshape::testWithSnapToSegment()
+{
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+  mCanvas->setLayers( { mLayerPolygonZ } );
+  mCanvas->setCurrentLayer( mLayerPolygonZ );
+  mCanvas->setDestinationCrs( mLayerPolygonZ->crs() );
+
+  QgsSnappingConfig cfg = mCanvas->snappingUtils()->config();
+  cfg.setTypeFlag( static_cast<Qgis::SnappingTypes>( Qgis::SnappingType::Segment ) );
+  mCanvas->snappingUtils()->setConfig( cfg );
+
+  QCOMPARE( mLayerPolygonZ->getFeature( 1 ).geometry().asWkt(), QStringLiteral( "Polygon Z ((7 5 4, 3 2 1, 0 1 2, 7 5 4))" ) );
+
+  // snap to segment on a diagonal
+  utils.mouseClick( 5.5, 4.5, Qt::LeftButton, {}, true );
+  utils.mouseClick( 1, 5, Qt::LeftButton );
+  utils.mouseClick( 1, 2, Qt::LeftButton, {}, true );
+  utils.mouseClick( 1, 2, Qt::RightButton );
+
+  QCOMPARE( mLayerPolygonZ->getFeature( 1 ).geometry().asWkt( 1 ), QStringLiteral( "Polygon Z ((1.2 1.7 333, 1 5 333, 5.7 4.2 333, 7 5 4, 3 2 1, 0 1 2, 1.2 1.7 333))" ) );
+
+  mLayerLine->undoStack()->undo();
+
+  cfg.setTypeFlag( static_cast<Qgis::SnappingTypes>( Qgis::SnappingType::Vertex | Qgis::SnappingType::Segment ) );
+  mCanvas->snappingUtils()->setConfig( cfg );
+}
 
 QGSTEST_MAIN( TestQgsMapToolReshape )
 #include "testqgsmaptoolreshape.moc"


### PR DESCRIPTION
## Description
When using the reshape tool and snapping to segments it is not guaranteed that the reshape will succeed as the reshape-line might not actually intersect the geometry due to numerical precision.

This PR solves this by trying to add the reshape-line points as topological points before performing the reshape.
The same logic has already been applied for the split tool (#56811)


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
