### PR TITLE
Handle GEOS exception when reshaping polygons

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -3749,8 +3749,11 @@ geos::unique_ptr QgsGeos::reshapePolygon( const GEOSGeometry *polygon, const GEO
 
   reshapeResult.reset();
 
-  newRing = GEOSGeom_createLinearRing_r( context, newCoordSequence );
-  if ( !newRing )
+  try
+  {
+    newRing = GEOSGeom_createLinearRing_r( context, newCoordSequence );
+  }
+  catch ( GEOSException & )
   {
     delete [] innerRings;
     return nullptr;

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -3755,6 +3755,11 @@ geos::unique_ptr QgsGeos::reshapePolygon( const GEOSGeometry *polygon, const GEO
   }
   catch ( GEOSException & )
   {
+    // nothing to do: on exception newRing will be null
+  }
+
+  if ( !newRing )
+  {
     delete [] innerRings;
     return nullptr;
   }

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -4521,6 +4521,21 @@ class TestQgsGeometry(QgisTestCase):
             f"testReshape failed: mismatch Expected:\n{expWkt}\nGot:\n{wkt}\n",
         )
 
+        # test should not raise exception
+        expWkt = "Polygon ((0 0, 5 0, 5 2, 0 2, 0 0))"
+        g = QgsGeometry.fromWkt(expWkt)
+        self.assertEqual(
+            g.reshapeGeometry(
+                QgsLineString([QgsPoint(0, 0), QgsPoint(5, 0), QgsPoint(5, 2)])
+            ),
+            QgsGeometry.OperationResult.NothingHappened,
+        )
+        wkt = g.asWkt()
+        self.assertTrue(
+            compareWkt(expWkt, wkt),
+            f"testReshape failed: mismatch Expected:\n{expWkt}\nGot:\n{wkt}\n",
+        )
+
     def testConvertToMultiType(self):
         """Test converting geometries to multi type"""
         point = QgsGeometry.fromWkt("Point (1 2)")


### PR DESCRIPTION
## Description
When reshaping polygons and snapping a segment to a polygon's existing segment, `GEOSGeom_createLinearRing_r` could raise an exception.

![image](https://github.com/user-attachments/assets/56f34571-cc48-45ad-abde-6a7ad112f29e)

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
