### PR TITLE
Don't return success when nothing happened during reshape

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -2981,7 +2981,13 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::reshapeGeometry( const QgsLineStri
     }
 
     if ( errorCode )
-      *errorCode = Success;
+    {
+      if ( reshapedGeometry )
+        *errorCode = Success;
+      else
+        *errorCode = NothingHappened;
+    }
+
     std::unique_ptr< QgsAbstractGeometry > reshapeResult = fromGeos( reshapedGeometry.get() );
     return reshapeResult;
   }

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -42,6 +42,7 @@ class TestQgsMapToolReshape : public QObject
     void initTestCase();    // will be called before the first testfunction is executed.
     void cleanupTestCase(); // will be called after the last testfunction was executed.
 
+    void testReshapeNoChange();
     void testReshapeZ();
     void testTopologicalEditing();
     void testAvoidIntersectionAndTopoEdit();
@@ -216,6 +217,25 @@ void TestQgsMapToolReshape::cleanupTestCase()
   delete mCaptureTool;
   delete mCanvas;
   QgsApplication::exitQgis();
+}
+
+void TestQgsMapToolReshape::testReshapeNoChange()
+{
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+  // no snapping for this test
+  QgsSnappingConfig cfg = mCanvas->snappingUtils()->config();
+  cfg.setEnabled( false );
+  mCanvas->snappingUtils()->setConfig( cfg );
+
+  utils.mouseClick( 2, 2, Qt::LeftButton );
+  utils.mouseClick( 3, 2, Qt::LeftButton );
+  utils.mouseClick( 3, 2, Qt::RightButton );
+
+  // activate back snapping
+  cfg.setEnabled( true );
+  mCanvas->snappingUtils()->setConfig( cfg );
+
+  QCOMPARE( mLayerLineZ->undoStack()->index(), 0 );
 }
 
 void TestQgsMapToolReshape::testReshapeZ()

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -4365,7 +4365,8 @@ class TestQgsGeometry(QgisTestCase):
         # no overlap
         g = QgsGeometry.fromWkt("LineString (0 0, 5 0, 5 1, 6 1, 6 0, 7 0)")
         self.assertEqual(
-            g.reshapeGeometry(QgsLineString([QgsPoint(4, 2), QgsPoint(7, 2)])), 0
+            g.reshapeGeometry(QgsLineString([QgsPoint(4, 2), QgsPoint(7, 2)])),
+            QgsGeometry.OperationResult.NothingHappened,
         )
         expWkt = "LineString (0 0, 5 0, 5 1, 6 1, 6 0, 7 0)"
         wkt = g.asWkt()
@@ -4419,7 +4420,8 @@ class TestQgsGeometry(QgisTestCase):
         g = QgsGeometry.fromWkt("LineString (0 0, 5 0, 5 1)")
         # extend start
         self.assertEqual(
-            g.reshapeGeometry(QgsLineString([QgsPoint(0, 0), QgsPoint(-1, 0)])), 0
+            g.reshapeGeometry(QgsLineString([QgsPoint(0, 0), QgsPoint(-1, 0)])),
+            QgsGeometry.OperationResult.Success,
         )
         expWkt = "LineString (-1 0, 0 0, 5 0, 5 1)"
         wkt = g.asWkt()
@@ -4431,7 +4433,7 @@ class TestQgsGeometry(QgisTestCase):
             g.reshapeGeometry(
                 QgsLineString([QgsPoint(5, 1), QgsPoint(10, 1), QgsPoint(10, 2)])
             ),
-            0,
+            QgsGeometry.OperationResult.Success,
         )
         expWkt = "LineString (-1 0, 0 0, 5 0, 5 1, 10 1, 10 2)"
         wkt = g.asWkt()
@@ -4442,7 +4444,8 @@ class TestQgsGeometry(QgisTestCase):
         g = QgsGeometry.fromWkt("LineString (0 0, 5 0, 5 1)")
         # extend start
         self.assertEqual(
-            g.reshapeGeometry(QgsLineString([QgsPoint(-1, 0), QgsPoint(0, 0)])), 0
+            g.reshapeGeometry(QgsLineString([QgsPoint(-1, 0), QgsPoint(0, 0)])),
+            QgsGeometry.OperationResult.Success,
         )
         expWkt = "LineString (-1 0, 0 0, 5 0, 5 1)"
         wkt = g.asWkt()
@@ -4454,7 +4457,7 @@ class TestQgsGeometry(QgisTestCase):
             g.reshapeGeometry(
                 QgsLineString([QgsPoint(10, 2), QgsPoint(10, 1), QgsPoint(5, 1)])
             ),
-            0,
+            QgsGeometry.OperationResult.Success,
         )
         expWkt = "LineString (-1 0, 0 0, 5 0, 5 1, 10 1, 10 2)"
         wkt = g.asWkt()
@@ -4465,7 +4468,8 @@ class TestQgsGeometry(QgisTestCase):
         # reshape where reshape line exactly overlaps some portions of geometry
         g = QgsGeometry.fromWkt("LineString (0 0, 5 0, 5 1, 6 1, 6 0, 7 0)")
         self.assertEqual(
-            g.reshapeGeometry(QgsLineString([QgsPoint(2, 0), QgsPoint(6, 0)])), 0
+            g.reshapeGeometry(QgsLineString([QgsPoint(2, 0), QgsPoint(6, 0)])),
+            QgsGeometry.OperationResult.Success,
         )
         expWkt = "LineString (0 0, 2 0, 5 0, 6 0, 7 0)"
         wkt = g.asWkt()
@@ -4476,7 +4480,8 @@ class TestQgsGeometry(QgisTestCase):
 
         g = QgsGeometry.fromWkt("LineString (0 0, 5 0, 5 1, 6 1, 6 0, 7 0)")
         self.assertEqual(
-            g.reshapeGeometry(QgsLineString([QgsPoint(5, 0), QgsPoint(7, 0)])), 0
+            g.reshapeGeometry(QgsLineString([QgsPoint(5, 0), QgsPoint(7, 0)])),
+            QgsGeometry.OperationResult.Success,
         )
         expWkt = "LineString (0 0, 5 0, 6 0, 7 0)"
         wkt = g.asWkt()
@@ -4488,7 +4493,8 @@ class TestQgsGeometry(QgisTestCase):
         # reshape line overlaps at both start and end
         g = QgsGeometry.fromWkt("LineString (0 0, 5 0, 5 1, 6 1, 6 0, 7 0)")
         self.assertEqual(
-            g.reshapeGeometry(QgsLineString([QgsPoint(4, 0), QgsPoint(7, 0)])), 0
+            g.reshapeGeometry(QgsLineString([QgsPoint(4, 0), QgsPoint(7, 0)])),
+            QgsGeometry.OperationResult.Success,
         )
         expWkt = "LineString (0 0, 4 0, 5 0, 6 0, 7 0)"
         wkt = g.asWkt()
@@ -4512,7 +4518,7 @@ class TestQgsGeometry(QgisTestCase):
                     ]
                 )
             ),
-            0,
+            QgsGeometry.OperationResult.Success,
         )
         expWkt = "LineString (152.96371 -25.60916, 152.96371 -25.60913, 152.96401 -25.60859, 152.96423 -25.60858, 152.96423 -25.60858, 152.96428 -25.60858, 152.96538 -25.60854, 152.96576 -25.6088)"
         wkt = g.asWkt(5)


### PR DESCRIPTION
## Description
When reshaping and the reshape line touches a feature but does not eventually change it, `Success` was returned instead of `NothingHappened`

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
