### PR TITLE
[fix] When saving SLD to DB, make sure errors are reported to callers

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -2674,6 +2674,7 @@ void QgsMapLayer::saveStyleToDatabase( const QString &name, const QString &descr
   QDomDocument sldDocument = this->exportSldStyleV3( sldContext );
   if ( !sldContext.errors().empty() )
   {
+    msgError = sldContext.errors().join( QStringLiteral( "\n" ) );
     return;
   }
   sldStyle = sldDocument.toString();


### PR DESCRIPTION
For instance, the `Package layers` algorithm.

Currently, if the SLD export fails, the user gets no error message, and can easily think everything went well, when it's not the case.

Sample project: https://docs.qfield.org/assets/projects/bee_farming_project.zip
Try to run the `Package layers` algorithm, selecting the `Apiary` layer and activating `Save layer styles into GeoPackage`.

Before this PR:

![image](https://github.com/user-attachments/assets/3d86e194-7889-4408-ad5b-73a0c1409e38)


After this PR:

![Screenshot from 2025-06-18 19-42-20](https://github.com/user-attachments/assets/3d2da1c6-92a3-4778-a964-7ca0475a3ce3)
