### PR TITLE
fix compilation with GCC-15

### DIFF
--- a/src/core/pal/priorityqueue.h
+++ b/src/core/pal/priorityqueue.h
@@ -34,6 +34,7 @@
 
 
 #include <iostream>
+#include <memory>
 
 #define LEFT(x) (2*x+1)
 #define RIGHT(x) (2*x+2)


### PR DESCRIPTION
## Description

GCC-15 removes some implicit includes in libstdc++ headers, so we now have to explicitly include "`<memory>`" in order to use "unique_ptr".

