### PR TITLE
fix build issue

### DIFF
--- a/src/core/pal/priorityqueue.h
+++ b/src/core/pal/priorityqueue.h
@@ -34,6 +34,7 @@
 
 
 #include <iostream>
+#include <memory>
 
 #define LEFT(x) (2*x+1)
 #define RIGHT(x) (2*x+2)


### PR DESCRIPTION
## Description 

this patch fixes the compiler error below
```
src/core/pal/priorityqueue.h:96:12: Fehler: »unique_ptr« in Namensraum »std« bezeichnet keinen Templatetyp
   96 |       std::unique_ptr<int[]> heap;
      |            ^~~~~~~~~~
src/core/pal/priorityqueue.h:37:1: Anmerkung: »std::unique_ptr« ist im Header »<memory>« definiert; um das zu beheben, könnten Sie »#include <memory>« hinzufügen
   36 | #include <iostream>
  +++ |+#include <memory>
   37 |
```