### PR TITLE
Rename C++ class GEOSException to QgsGeosException

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -33,13 +33,13 @@ email                : marco.hugentobler at sourcepole dot com
 #define DEFAULT_QUADRANT_SEGMENTS 8
 
 #define CATCH_GEOS(r) \
-  catch (GEOSException &) \
+  catch (QgsGeosException &) \
   { \
     return r; \
   }
 
 #define CATCH_GEOS_WITH_ERRMSG(r) \
-  catch (GEOSException &e) \
+  catch (QgsGeosException &e) \
   { \
     if ( errorMsg ) \
     { \
@@ -50,7 +50,7 @@ email                : marco.hugentobler at sourcepole dot com
 
 /// @cond PRIVATE
 
-static void throwGEOSException( const char *fmt, ... )
+static void throwQgsGeosException( const char *fmt, ... )
 {
   va_list ap;
   char buffer[1024];
@@ -62,14 +62,14 @@ static void throwGEOSException( const char *fmt, ... )
   QString message = QString::fromUtf8( buffer );
 
 #ifdef _MSC_VER
-  // stupid stupid MSVC, *SOMETIMES* raises it's own exception if we throw GEOSException, resulting in a crash!
+  // stupid stupid MSVC, *SOMETIMES* raises it's own exception if we throw QgsGeosException, resulting in a crash!
   // see https://github.com/qgis/QGIS/issues/22709
   // if you want to test alternative fixes for this, run the testqgsexpression.cpp test suite - that will crash
-  // and burn on the "line_interpolate_point point" test if a GEOSException is thrown.
+  // and burn on the "line_interpolate_point point" test if a QgsGeosException is thrown.
   // TODO - find a real fix for the underlying issue
   try
   {
-    throw GEOSException( message );
+    throw QgsGeosException( message );
   }
   catch ( ... )
   {
@@ -77,7 +77,7 @@ static void throwGEOSException( const char *fmt, ... )
     // just throw nothing instead (except your mouse at your monitor)
   }
 #else
-  throw GEOSException( message );
+  throw QgsGeosException( message );
 #endif
 }
 
@@ -112,9 +112,9 @@ QgsGeosContext::QgsGeosContext()
 #if GEOS_VERSION_MAJOR>3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR>=5 )
   mContext = GEOS_init_r();
   GEOSContext_setNoticeHandler_r( mContext, printGEOSNotice );
-  GEOSContext_setErrorHandler_r( mContext, throwGEOSException );
+  GEOSContext_setErrorHandler_r( mContext, throwQgsGeosException );
 #else
-  mContext = initGEOS_r( printGEOSNotice, throwGEOSException );
+  mContext = initGEOS_r( printGEOSNotice, throwQgsGeosException );
 #endif
 }
 
@@ -240,7 +240,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::makeValid( Qgis::MakeValidMethod m
     geos.reset( GEOSMakeValidWithParams_r( context, mGeos.get(), params ) );
     GEOSMakeValidParams_destroy_r( context, params );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     if ( errorMsg )
     {
@@ -336,7 +336,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::clip( const QgsRectangle &rect, QS
     geos::unique_ptr opGeom( GEOSClipByRect_r( QgsGeosContext::get(), mGeos.get(), rect.xMinimum(), rect.yMinimum(), rect.xMaximum(), rect.yMaximum() ) );
     return fromGeos( opGeom.get() );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
@@ -741,7 +741,7 @@ bool QgsGeos::contains( double x, double y, QString *errorMsg ) const
 
     result = ( GEOSContains_r( context, mGeos.get(), point.get() ) == 1 );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
@@ -863,7 +863,7 @@ bool QgsGeos::intersects( const QgsAbstractGeometry *geom, QString *errorMsg ) c
       {
         return GEOSPreparedIntersectsXY_r( QgsGeosContext::get(), mGeosPrepared.get(), point->x(), point->y() ) == 1;
       }
-      catch ( GEOSException &e )
+      catch ( QgsGeosException &e )
       {
         logError( QStringLiteral( "GEOS" ), e.what() );
         if ( errorMsg )
@@ -916,7 +916,7 @@ bool QgsGeos::contains( const QgsAbstractGeometry *geom, QString *errorMsg ) con
       {
         return GEOSPreparedContainsXY_r( QgsGeosContext::get(), mGeosPrepared.get(), point->x(), point->y() ) == 1;
       }
-      catch ( GEOSException &e )
+      catch ( QgsGeosException &e )
       {
         logError( QStringLiteral( "GEOS" ), e.what() );
         if ( errorMsg )
@@ -961,7 +961,7 @@ QString QgsGeos::relate( const QgsAbstractGeometry *geom, QString *errorMsg ) co
       GEOSFree_r( context, r );
     }
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
@@ -992,7 +992,7 @@ bool QgsGeos::relatePattern( const QgsAbstractGeometry *geom, const QString &pat
   {
     result = ( GEOSRelatePattern_r( context, mGeos.get(), geosGeom.get(), pattern.toLocal8Bit().constData() ) == 1 );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
@@ -1554,7 +1554,7 @@ geos::unique_ptr QgsGeos::createGeosCollection( int typeId, std::vector<geos::un
   {
     geomRes.reset( GEOSGeom_createCollection_r( context, typeId, geomarr.data(), geomarr.size() ) );
   }
-  catch ( GEOSException & )
+  catch ( QgsGeosException & )
   {
     for ( GEOSGeometry *geom : geomarr )
     {
@@ -1989,7 +1989,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry
     }
     return fromGeos( opGeom.get() );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
@@ -2071,7 +2071,7 @@ bool QgsGeos::relation( const QgsAbstractGeometry *geom, Relation r, QString *er
         break;
     }
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
@@ -3114,7 +3114,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::closestPoint( const QgsGeometry &o
     ( void )GEOSCoordSeq_getX_r( context, nearestCoord.get(), 0, &nx );
     ( void )GEOSCoordSeq_getY_r( context, nearestCoord.get(), 0, &ny );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
@@ -3169,7 +3169,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsGeos::shortestLine( const QgsAbstractG
     ( void )GEOSCoordSeq_getX_r( context, nearestCoord.get(), 1, &nx2 );
     ( void )GEOSCoordSeq_getY_r( context, nearestCoord.get(), 1, &ny2 );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
@@ -3203,7 +3203,7 @@ double QgsGeos::lineLocatePoint( const QgsPoint &point, QString *errorMsg ) cons
   {
     distance = GEOSProject_r( QgsGeosContext::get(), mGeos.get(), otherGeom.get() );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
@@ -3232,7 +3232,7 @@ double QgsGeos::lineLocatePoint( double x, double y, QString *errorMsg ) const
   {
     distance = GEOSProject_r( QgsGeosContext::get(), mGeos.get(), point.get() );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     logError( QStringLiteral( "GEOS" ), e.what() );
     if ( errorMsg )
@@ -3270,7 +3270,7 @@ QgsGeometry QgsGeos::polygonize( const QVector<const QgsAbstractGeometry *> &geo
     delete[] lineGeosGeometries;
     return QgsGeometry( fromGeos( result.get() ) );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     if ( errorMsg )
     {
@@ -3475,7 +3475,7 @@ geos::unique_ptr QgsGeos::reshapeLine( const GEOSGeometry *line, const GEOSGeome
       }
     }
   }
-  catch ( GEOSException & )
+  catch ( QgsGeosException & )
   {
     atLeastTwoIntersections = false;
   }
@@ -3736,7 +3736,7 @@ geos::unique_ptr QgsGeos::reshapePolygon( const GEOSGeometry *polygon, const GEO
       }
     }
   }
-  catch ( GEOSException & )
+  catch ( QgsGeosException & )
   {
     nIntersections = 0;
   }
@@ -3766,7 +3766,7 @@ geos::unique_ptr QgsGeos::reshapePolygon( const GEOSGeometry *polygon, const GEO
   {
     newRing = GEOSGeom_createLinearRing_r( context, newCoordSequence );
   }
-  catch ( GEOSException & )
+  catch ( QgsGeosException & )
   {
     // nothing to do: on exception newRing will be null
   }

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -945,10 +945,10 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
 
 #ifndef SIP_RUN
 
-class GEOSException : public std::runtime_error
+class QgsGeosException : public std::runtime_error
 {
   public:
-    explicit GEOSException( const QString &message )
+    explicit QgsGeosException( const QString &message )
       : std::runtime_error( message.toUtf8().constData() )
     {
     }

--- a/src/core/labeling/rules/qgslabelingenginerule_impl.cpp
+++ b/src/core/labeling/rules/qgslabelingenginerule_impl.cpp
@@ -226,7 +226,7 @@ bool QgsAbstractLabelingEngineRuleDistanceFromFeature::candidateExceedsTolerance
       return false;
 #endif
     }
-    catch ( GEOSException &e )
+    catch ( QgsGeosException &e )
     {
       QgsDebugError( QStringLiteral( "GEOS exception: %1" ).arg( e.what() ) );
     }
@@ -457,7 +457,7 @@ bool QgsLabelingEngineRuleMinimumDistanceLabelToLabel::candidatesAreConflicting(
       return false;
 #endif
     }
-    catch ( GEOSException &e )
+    catch ( QgsGeosException &e )
     {
       QgsDebugError( QStringLiteral( "GEOS exception: %1" ).arg( e.what() ) );
     }
@@ -609,7 +609,7 @@ bool QgsLabelingEngineRuleAvoidLabelOverlapWithFeature::candidateIsIllegal( cons
       if ( GEOSPreparedIntersects_r( geosctxt, candidateGeos, featureCandidate.get() ) == 1 )
         return true;
     }
-    catch ( GEOSException &e )
+    catch ( QgsGeosException &e )
     {
       QgsDebugError( QStringLiteral( "GEOS exception: %1" ).arg( e.what() ) );
     }

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -420,7 +420,7 @@ std::unique_ptr<LabelPosition> FeaturePart::createCandidatePointOnSurface( Point
       GEOSCoordSeq_getXY_r( geosctxt, coordSeq, 0, &px, &py );
     }
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -2424,7 +2424,7 @@ bool FeaturePart::isConnected( FeaturePart *p2 )
     return ( GEOSPreparedIntersects_r( geosctxt, preparedGeom(), p2OtherEnd.get() ) != 1 );
 #endif
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -2465,7 +2465,7 @@ bool FeaturePart::mergeWithFeaturePart( FeaturePart *other )
     extractCoords( mGeos );
     return true;
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );

--- a/src/core/pal/geomfunction.cpp
+++ b/src/core/pal/geomfunction.cpp
@@ -336,7 +336,7 @@ bool GeomFunction::containsCandidate( const GEOSPreparedGeometry *geom, double x
     const bool result = ( GEOSPreparedContainsProperly_r( geosctxt, geom, bboxGeos.get() ) == 1 );
     return result;
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     Q_NOWARN_UNREACHABLE_PUSH

--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -190,7 +190,7 @@ bool LabelPosition::intersects( const GEOSPreparedGeometry *geometry )
       return mNextPart->intersects( geometry );
     }
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -217,7 +217,7 @@ bool LabelPosition::within( const GEOSPreparedGeometry *geometry )
       return mNextPart->within( geometry );
     }
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -301,7 +301,7 @@ bool LabelPosition::isInConflict( const LabelPosition *lp ) const
           QgsMessageLog::logMessage( QStringLiteral( "label margin distance requires GEOS 3.10+" ) );
 #endif
         }
-        catch ( GEOSException &e )
+        catch ( QgsGeosException &e )
         {
           QgsDebugError( QStringLiteral( "GEOS exception: %1" ).arg( e.what() ) );
         }
@@ -318,7 +318,7 @@ bool LabelPosition::isInConflict( const LabelPosition *lp ) const
                                 mOuterBoundsGeos ? mOuterBoundsGeos.get() : mGeos ) == 1 );
           return result;
         }
-        catch ( GEOSException &e )
+        catch ( QgsGeosException &e )
         {
           qWarning( "GEOS exception: %s", e.what() );
           QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -364,7 +364,7 @@ bool LabelPosition::isInConflictMultiPart( const LabelPosition *lp ) const
       QgsMessageLog::logMessage( QStringLiteral( "label margin distance requires GEOS 3.10+" ) );
 #endif
     }
-    catch ( GEOSException &e )
+    catch ( QgsGeosException &e )
     {
       QgsDebugError( QStringLiteral( "GEOS exception: %1" ).arg( e.what() ) );
     }
@@ -376,7 +376,7 @@ bool LabelPosition::isInConflictMultiPart( const LabelPosition *lp ) const
       const bool result = ( GEOSPreparedIntersects_r( geosctxt, preparedMultiPartGeom(), lp->mMultipartGeos ) == 1 );
       return result;
     }
-    catch ( GEOSException &e )
+    catch ( QgsGeosException &e )
     {
       qWarning( "GEOS exception: %s", e.what() );
       QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -695,7 +695,7 @@ double LabelPosition::getDistanceToPoint( double xp, double yp, bool useOuterBou
         geos::unique_ptr point( GEOSGeom_createPointFromXY_r( geosctxt, xp, yp ) );
         contains = ( GEOSPreparedContainsProperly_r( geosctxt, mPreparedOuterBoundsGeos, point.get() ) == 1 );
       }
-      catch ( GEOSException & )
+      catch ( QgsGeosException & )
       {
         contains = false;
       }
@@ -747,7 +747,7 @@ double LabelPosition::getDistanceToPoint( double xp, double yp, bool useOuterBou
             distance = QgsGeometryUtilsBase::sqrDistance2D( xp, yp, nx, ny );
           }
         }
-        catch ( GEOSException &e )
+        catch ( QgsGeosException &e )
         {
           qWarning( "GEOS exception: %s", e.what() );
           QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -788,7 +788,7 @@ bool LabelPosition::crossesLine( PointSet *line ) const
       return mNextPart->crossesLine( line );
     }
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -820,7 +820,7 @@ bool LabelPosition::crossesBoundary( PointSet *polygon ) const
       return mNextPart->crossesBoundary( polygon );
     }
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -855,7 +855,7 @@ bool LabelPosition::intersectsWithPolygon( PointSet *polygon ) const
       return true;
     }
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -914,7 +914,7 @@ double LabelPosition::polygonIntersectionCostForParts( PointSet *polygon ) const
         cost += 4;
     }
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -790,7 +790,7 @@ bool Pal::candidatesAreConflicting( const LabelPosition *lp1, const LabelPositio
       QgsMessageLog::logMessage( QStringLiteral( "label margin distance requires GEOS 3.10+" ) );
 #endif
     }
-    catch ( GEOSException &e )
+    catch ( QgsGeosException &e )
     {
       QgsDebugError( QStringLiteral( "GEOS exception: %1" ).arg( e.what() ) );
     }

--- a/src/core/pal/pointset.cpp
+++ b/src/core/pal/pointset.cpp
@@ -278,7 +278,7 @@ bool PointSet::containsPoint( double x, double y ) const
 
     return result;
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -617,7 +617,7 @@ void PointSet::offsetCurveByDistance( double distance )
     x = std::move( newX );
     y = std::move( newY );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -907,7 +907,7 @@ double PointSet::minDistanceToPoint( double px, double py, double *rx, double *r
 
     return QgsGeometryUtilsBase::sqrDistance2D( px, py, nx, ny );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -954,7 +954,7 @@ void PointSet::getCentroid( double &px, double &py, bool forceInside ) const
       }
     }
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -1023,7 +1023,7 @@ geos::unique_ptr PointSet::interpolatePoint( double distance ) const
     geos::unique_ptr res( GEOSInterpolate_r( QgsGeosContext::get(), thisGeos, distance ) );
     return res;
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     return nullptr;
@@ -1041,7 +1041,7 @@ double PointSet::lineLocatePoint( const GEOSGeometry *point ) const
   {
     distance = GEOSProject_r( QgsGeosContext::get(), thisGeos, point );
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     return -1;
@@ -1076,7 +1076,7 @@ double PointSet::length() const
     ( void )GEOSLength_r( geosctxt, mGeos, &mLength );
     return mLength;
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -1103,7 +1103,7 @@ double PointSet::area() const
     mArea = std::fabs( mArea );
     return mArea;
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );
@@ -1137,7 +1137,7 @@ QString PointSet::toWkt() const
 
     return res;
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     qWarning( "GEOS exception: %s", e.what() );
     QgsMessageLog::logMessage( QObject::tr( "Exception: %1" ).arg( e.what() ), QObject::tr( "GEOS" ) );

--- a/src/core/qgstracer.cpp
+++ b/src/core/qgstracer.cpp
@@ -579,7 +579,7 @@ bool QgsTracer::initGraph()
 
     mpl = noded.asMultiPolyline();
   }
-  catch ( GEOSException &e )
+  catch ( QgsGeosException &e )
   {
     // no big deal... we will just not have nicely noded linework, potentially
     // missing some intersections


### PR DESCRIPTION
This will help making it clear that this is a QGIS C++ class and help reducing the confusion with GEOS own geos::util::GEOSException class.

Cf https://github.com/qgis/QGIS/pull/62322#issuecomment-2995358032 for context