### PR TITLE
[fix] Remove extra item in the Actions container (Available Widgets tree view)

### DIFF
--- a/src/gui/vector/qgsattributesformmodel.cpp
+++ b/src/gui/vector/qgsattributesformmodel.cpp
@@ -621,9 +621,12 @@ void QgsAttributesAvailableWidgetsModel::populateLayerActions( const QList< QgsA
     }
   }
 
-  beginInsertRows( actionsIndex, 0, count );
-  populateActionItems( actions );
-  endInsertRows();
+  if ( count > 0 )
+  {
+    beginInsertRows( actionsIndex, 0, count - 1 );
+    populateActionItems( actions );
+    endInsertRows();
+  }
 }
 
 void QgsAttributesAvailableWidgetsModel::populateActionItems( const QList<QgsAction> actions )


### PR DESCRIPTION
Follow-up #61544

In #61544, I overlooked a `last` parameter for `beginInsertRows()` and passed the count with an extra item, which creates a nonexistent action item (with no text):

![image](https://github.com/user-attachments/assets/a2bbcad7-a9d1-4216-ae45-5f1f4d39abba)

This PR makes sure we pass the correct count and thus, removes the extra action item.