### PR TITLE
[Tests] Disable 7 tests that break due to expired certificate

### DIFF
--- a/tests/src/core/testqgsauthcertutils.cpp
+++ b/tests/src/core/testqgsauthcertutils.cpp
@@ -64,6 +64,9 @@ void TestQgsAuthCertUtils::cleanupTestCase()
 
 void TestQgsAuthCertUtils::testValidationUtils()
 {
+  // FIXME
+  QSKIP( "Broken test. See https://github.com/qgis/QGIS/issues/62373", SkipSingle );
+
   // null cert
   QSslCertificate cert;
   QVERIFY( !QgsAuthCertUtils::certIsCurrent( cert ) );

--- a/tests/src/core/testqgsauthconfig.cpp
+++ b/tests/src/core/testqgsauthconfig.cpp
@@ -125,6 +125,9 @@ void TestQgsAuthConfig::testMethodConfig()
 
 void TestQgsAuthConfig::testPkiBundle()
 {
+  // FIXME
+  QSKIP( "Broken test. See https://github.com/qgis/QGIS/issues/62373", SkipSingle );
+
   QgsPkiBundle bundle;
   QVERIFY( bundle.isNull() );
   QVERIFY( !bundle.isValid() );

--- a/tests/src/python/test_qgsauthsystem.py
+++ b/tests/src/python/test_qgsauthsystem.py
@@ -147,6 +147,9 @@ class TestQgsAuthManager(QgisTestCase):
 
     def test_040_authorities(self):
 
+        # FIXME
+        self.skipTest("Broken test. See https://github.com/qgis/QGIS/issues/62373")
+
         def rebuild_caches():
             m = "Authorities cache could not be rebuilt"
             self.assertTrue(self.authm.rebuildCaCertsCache(), m)
@@ -660,6 +663,9 @@ class TestQgsAuthManager(QgisTestCase):
     def test_150_verify_keychain(self):
         """Test the verify keychain function"""
 
+        # FIXME
+        self.skipTest("Broken test. See https://github.com/qgis/QGIS/issues/62373")
+
         def testChain(path):
 
             # Test that a chain with an untrusted CA is not valid
@@ -735,6 +741,9 @@ class TestQgsAuthManager(QgisTestCase):
 
     def test_validate_pki_bundle(self):
         """Text the pki bundle validation"""
+
+        # FIXME
+        self.skipTest("Broken test. See https://github.com/qgis/QGIS/issues/62373")
 
         # Valid bundle:
         bundle = self.mkPEMBundle(
@@ -927,6 +936,9 @@ class TestQgsAuthManager(QgisTestCase):
     def test_160_cert_viable(self):
         """Text the viability of a given certificate"""
 
+        # FIXME
+        self.skipTest("Broken test. See https://github.com/qgis/QGIS/issues/62373")
+
         # null cert
         cert = QSslCertificate()
         self.assertFalse(QgsAuthCertUtils.certIsCurrent(cert))
@@ -955,6 +967,9 @@ class TestQgsAuthManager(QgisTestCase):
 
     def test_170_pki_key_encoding(self):
         """Test that a DER/PEM RSA/DSA/EC keys can be opened whatever the extension is"""
+
+        # FIXME
+        self.skipTest("Broken test. See https://github.com/qgis/QGIS/issues/62373")
 
         self.assertFalse(
             QgsAuthCertUtils.keyFromFile(PKIDATA + "/" + "ptolemy_key.pem").isNull()


### PR DESCRIPTION
Workaround for refs #62373
