### PR TITLE
testqgs3dcameracontroller: Ensure proper OpenGL context

### DIFF
--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -1213,6 +1213,9 @@ void TestQgs3DCameraController::testResetViewRaster()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *mapSettings, &engine );
   engine.setRootEntity( scene );
 
+  // This ensures that the OpenGL context is properly created
+  Qgs3DUtils::captureSceneImage( engine, scene );
+
   // compare raster layer + vector layer
   scene->viewZoomFull();
   QGSCOMPARENEAR( scene->cameraController()->distance(), 2172, 1 );
@@ -1242,6 +1245,9 @@ void TestQgs3DCameraController::testResetViewPointCloud()
   engine.setSize( QSize( winSize.x(), winSize.y() ) );
   Qgs3DMapScene *scene = new Qgs3DMapScene( *mapSettings, &engine );
   engine.setRootEntity( scene );
+
+  // This ensures that the OpenGL context is properly created
+  Qgs3DUtils::captureSceneImage( engine, scene );
 
   // compare virtual point cloud layer
   scene->viewZoomFull();


### PR DESCRIPTION
## Description

This fixes the following warning in `testResetViewRaster` and
`testResetViewPointCloud` tests:

```
Failed to make context current: OpenGL resources will not be destroyed
```
