### PR TITLE
[ogr] Only retrieve layer crs once

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -830,6 +830,20 @@ void QgsOgrProvider::loadFields()
     QMutexLocker locker( mutex );
     mOGRGeomType = getOgrGeomType( mGDALDriverName, ogrLayer );
   }
+
+  mCrs = QgsCoordinateReferenceSystem();
+  if ( mOGRGeomType != wkbNone )
+  {
+    if ( OGRSpatialReferenceH spatialRefSys = mOgrLayer->GetSpatialRef() )
+    {
+      mCrs = QgsOgrUtils::OGRSpatialReferenceToCrs( spatialRefSys );
+    }
+    else
+    {
+      QgsDebugMsgLevel( QStringLiteral( "no spatial reference found" ), 2 );
+    }
+  }
+
   QgsOgrFeatureDefn &fdef = mOgrLayer->GetLayerDefn();
 
   // Expose the OGR FID if it comes from a "real" column (typically GPKG)
@@ -3866,18 +3880,9 @@ QgsCoordinateReferenceSystem QgsOgrProvider::crs() const
 {
   QgsCoordinateReferenceSystem srs;
   if ( !mValid || ( mOGRGeomType == wkbNone ) )
-    return srs;
+    return QgsCoordinateReferenceSystem();
 
-  if ( OGRSpatialReferenceH spatialRefSys = mOgrLayer->GetSpatialRef() )
-  {
-    srs = QgsOgrUtils::OGRSpatialReferenceToCrs( spatialRefSys );
-  }
-  else
-  {
-    QgsDebugMsgLevel( QStringLiteral( "no spatial reference found" ), 2 );
-  }
-
-  return srs;
+  return mCrs;
 }
 
 QString QgsOgrProvider::dataComment() const

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3878,7 +3878,6 @@ QString  QgsOgrProvider::description() const
 
 QgsCoordinateReferenceSystem QgsOgrProvider::crs() const
 {
-  QgsCoordinateReferenceSystem srs;
   if ( !mValid || ( mOGRGeomType == wkbNone ) )
     return QgsCoordinateReferenceSystem();
 

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -304,6 +304,7 @@ class QgsOgrProvider final: public QgsVectorDataProvider
     bool mValid = false;
 
     OGRwkbGeometryType mOGRGeomType = wkbUnknown;
+    QgsCoordinateReferenceSystem mCrs;
 
     //! Whether the next call to featureCount() should refresh the feature count
     mutable bool mRefreshFeatureCount = true;


### PR DESCRIPTION
Instead of retrieving and converting the layer crs with every call to ::crs(), just read it once when determining the layer properties and store for later retrieval.

Speeds up construction of OGR feature sources, which occurs on the main thread when starting a new map render and adds significant cost to the map render preparation.
