### PR TITLE
Fix crash when exiting QGIS

### DIFF
--- a/src/core/auth/qgsauthconfigurationstoragedb.cpp
+++ b/src/core/auth/qgsauthconfigurationstoragedb.cpp
@@ -111,7 +111,7 @@ QSqlDatabase QgsAuthConfigurationStorageDb::authDatabaseConnection() const
       // QSqlDatabase::removeDatabase is thread safe, so this is ok to do.
       // Right about now is a good time to re-evaluate your selected career ;)
       // I've done that and I decided to become a musician. I'll probably be a better musician than a software developer.
-      QMetaObject::Connection connection = connect( QThread::currentThread(), &QThread::finished, QThread::currentThread(), [connectionName, this ]
+      QMetaObject::Connection connection = connect( QThread::currentThread(), &QThread::finished, this, [connectionName, this ]
       {
         QMutexLocker locker( &mMutex );
         QSqlDatabase::removeDatabase( connectionName );


### PR DESCRIPTION
## Description

`QgsAuthConfigurationStorageDb` sets a callback on thread exit to do some cleanup. This callback uses member variables from the object, but is currently bound to the thread. This breaks on QGIS exit, since the object may no longer exist. This PR fixes the issue, binding the callback to the `QgsAuthConfigurationStorageDb` object instead, so the callback won't run if the thread exits "out of sequence".

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
