### PR TITLE
[feature] Package Layers algorithm: only export features intersecting a given extent

### DIFF
--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -61,6 +61,9 @@ void QgsPackageAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SAVE_METADATA" ), QObject::tr( "Save layer metadata into GeoPackage" ), true ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SELECTED_FEATURES_ONLY" ), QObject::tr( "Save only selected features" ), false ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "EXPORT_RELATED_LAYERS" ), QObject::tr( "Export related layers following relations defined in the project" ), false ) );
+  auto extentParam = std::make_unique<QgsProcessingParameterExtent>( QStringLiteral( "EXTENT" ), QObject::tr( "Extent" ), QVariant(), true );
+  extentParam->setHelp( QObject::tr( "Limit exported features to those with geometries intersecting the provided extent" ) );
+  addParameter( extentParam.release() );
   addOutput( new QgsProcessingOutputMultipleLayers( QStringLiteral( "OUTPUT_LAYERS" ), QObject::tr( "Layers within new package" ) ) );
 }
 
@@ -309,6 +312,7 @@ QVariantMap QgsPackageAlgorithm::processAlgorithm( const QVariantMap &parameters
       throw QgsProcessingException( QObject::tr( "Opening database %1 failed (OGR error: %2)" ).arg( packagePath, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
   }
 
+  const bool validExtent = parameters.value( QStringLiteral( "EXTENT" ) ).isValid();
 
   bool errored = false;
 
@@ -335,12 +339,25 @@ QVariantMap QgsPackageAlgorithm::processAlgorithm( const QVariantMap &parameters
 
     feedback->pushInfo( QObject::tr( "Packaging layer %1/%2: %3" ).arg( i ).arg( mLayers.size() ).arg( layer ? layer->name() : QString() ) );
 
+    QgsRectangle extent;
+
     switch ( layer->type() )
     {
       case Qgis::LayerType::Vector:
       {
         QgsVectorLayer *vectorLayer = qobject_cast<QgsVectorLayer *>( layer.get() );
-        if ( !packageVectorLayer( vectorLayer, packagePath, context, &multiStepFeedback, saveStyles, saveMetadata, selectedFeaturesOnly ) )
+
+        if ( validExtent )
+        {
+          if ( vectorLayer->hasSpatialIndex() == Qgis::SpatialIndexPresence::NotPresent )
+          {
+            feedback->pushWarning( QObject::tr( "No spatial index exists for layer %1, performance will be severely degraded" ).arg( vectorLayer->name() ) );
+          }
+
+          extent = parameterAsExtent( parameters, QStringLiteral( "EXTENT" ), context, layer->crs() );
+        }
+
+        if ( !packageVectorLayer( vectorLayer, packagePath, context, &multiStepFeedback, saveStyles, saveMetadata, selectedFeaturesOnly, extent ) )
           errored = true;
         else
           outputLayers.append( QStringLiteral( "%1|layername=%2" ).arg( packagePath, layer->name() ) );
@@ -408,7 +425,7 @@ QVariantMap QgsPackageAlgorithm::processAlgorithm( const QVariantMap &parameters
   return outputs;
 }
 
-bool QgsPackageAlgorithm::packageVectorLayer( QgsVectorLayer *layer, const QString &path, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool saveStyles, bool saveMetadata, bool selectedFeaturesOnly )
+bool QgsPackageAlgorithm::packageVectorLayer( QgsVectorLayer *layer, const QString &path, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool saveStyles, bool saveMetadata, bool selectedFeaturesOnly, const QgsRectangle &extent )
 {
   QgsVectorFileWriter::SaveVectorOptions options;
   options.driverName = QStringLiteral( "GPKG" );
@@ -448,6 +465,11 @@ bool QgsPackageAlgorithm::packageVectorLayer( QgsVectorLayer *layer, const QStri
   {
     // fid was the only field
     options.skipAttributeCreation = true;
+  }
+
+  if ( !extent.isNull() )
+  {
+    options.filterExtent = extent;
   }
 
   QString error;

--- a/src/analysis/processing/qgsalgorithmpackage.h
+++ b/src/analysis/processing/qgsalgorithmpackage.h
@@ -49,7 +49,7 @@ class QgsPackageAlgorithm : public QgsProcessingAlgorithm
     QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
   private:
-    bool packageVectorLayer( QgsVectorLayer *layer, const QString &path, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool saveStyles, bool saveMetadata, bool selectedFeaturesOnly );
+    bool packageVectorLayer( QgsVectorLayer *layer, const QString &path, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool saveStyles, bool saveMetadata, bool selectedFeaturesOnly, const QgsRectangle &extent );
 
     std::vector<std::unique_ptr<QgsMapLayer>> mLayers;
     QMap<QString, QString> mClonedLayerIds;

--- a/tests/src/python/test_processing_packagelayers.py
+++ b/tests/src/python/test_processing_packagelayers.py
@@ -426,6 +426,20 @@ class TestPackageLayers(QgisTestCase):
             {"region": {1, 2}, "province": {1, 2, 3, 4}, "city": {1, 2, 3, 4}},
         )
 
+        # Test no features intersecting extent
+        parameters["EXTENT"] = "2580700,2581500,1221800,1222000 [EPSG:2056]"
+        _test(
+            parameters,
+            {"region": set(), "province": set(), "city": set()},
+        )
+
+        # Test some layers with features not intersecting extent
+        parameters["EXTENT"] = "2581500,2582000,1220000,1222000 [EPSG:2056]"
+        _test(
+            parameters,
+            {"region": {2}, "province": {3, 4}, "city": set()},
+        )
+
         # Test all features intersecting extent
         parameters["EXTENT"] = "2580000,2582000,1220000,1222000 [EPSG:2056]"
         _test(

--- a/tests/src/python/test_processing_packagelayers.py
+++ b/tests/src/python/test_processing_packagelayers.py
@@ -12,7 +12,7 @@ __copyright__ = "Copyright 2022, The QGIS Project"
 
 import os
 
-from osgeo import ogr
+from osgeo import ogr, osr
 from processing.core.Processing import Processing
 from processing.gui.AlgorithmExecutor import execute
 from qgis.PyQt.QtCore import QCoreApplication, QTemporaryDir
@@ -83,58 +83,146 @@ class TestPackageLayers(QgisTestCase):
             Province 3
             Province 4
                 City 4
+
+        XXXXXXXXXXXXXXXXXXXX
+        X R1     X         X
+        X  O     X         X
+        X        X         X
+        X        X         X
+        X        X         XXXXXXXXXXXXXXXXXXXXX
+        X        X       O X R2                X
+        X     O  X         X                   X
+        X        X         X                   X
+        X P1     X P2      X P3                X
+        XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                           X                   X
+                           X   O               X
+                           X                   X
+                           X P4                X
+                           XXXXXXXXXXXXXXXXXXXXX
         """
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(2056)
 
         ds = ogr.GetDriverByName("GPKG").CreateDataSource(cls.temp_path)
-        lyr = ds.CreateLayer("region", geom_type=ogr.wkbNone)
+        lyr = ds.CreateLayer("region", srs, geom_type=ogr.wkbPolygon)
         lyr.CreateField(ogr.FieldDefn("name", ogr.OFTString))
         f = ogr.Feature(lyr.GetLayerDefn())
         f["name"] = "region one"
+        outring = ogr.Geometry(ogr.wkbLinearRing)
+        outring.AddPoint(2580000, 1220500)
+        outring.AddPoint(2581000, 1220500)
+        outring.AddPoint(2581000, 1221500)
+        outring.AddPoint(2580000, 1221500)
+        outring.AddPoint(2580000, 1220500)
+        polygon = ogr.Geometry(ogr.wkbPolygon)
+        polygon.AddGeometry(outring)
+        f.SetGeometry(polygon)
         lyr.CreateFeature(f)
         f = ogr.Feature(lyr.GetLayerDefn())
         f["name"] = "region two"
+        outring = ogr.Geometry(ogr.wkbLinearRing)
+        outring.AddPoint(2581000, 1220000)
+        outring.AddPoint(2582000, 1220000)
+        outring.AddPoint(2582000, 1221000)
+        outring.AddPoint(2581000, 1221000)
+        outring.AddPoint(2581000, 1220000)
+        polygon = ogr.Geometry(ogr.wkbPolygon)
+        polygon.AddGeometry(outring)
+        f.SetGeometry(polygon)
         lyr.CreateFeature(f)
 
-        lyr = ds.CreateLayer("province", geom_type=ogr.wkbNone)
+        lyr = ds.CreateLayer("province", srs, geom_type=ogr.wkbPolygon)
         lyr.CreateField(ogr.FieldDefn("name", ogr.OFTString))
         lyr.CreateField(ogr.FieldDefn("region", ogr.OFTInteger))
         f = ogr.Feature(lyr.GetLayerDefn())
         f["name"] = "province one"
         f["region"] = 1
+        outring = ogr.Geometry(ogr.wkbLinearRing)
+        outring.AddPoint(2580000, 1220500)
+        outring.AddPoint(2580500, 1220500)
+        outring.AddPoint(2580500, 1221500)
+        outring.AddPoint(2580000, 1221500)
+        outring.AddPoint(2580000, 1220500)
+        polygon = ogr.Geometry(ogr.wkbPolygon)
+        polygon.AddGeometry(outring)
+        f.SetGeometry(polygon)
         lyr.CreateFeature(f)
         f = ogr.Feature(lyr.GetLayerDefn())
         f["name"] = "province two"
         f["region"] = 1
+        outring = ogr.Geometry(ogr.wkbLinearRing)
+        outring.AddPoint(2580500, 1220500)
+        outring.AddPoint(2581000, 1220500)
+        outring.AddPoint(2581000, 1221500)
+        outring.AddPoint(2580500, 1221500)
+        outring.AddPoint(2580500, 1220500)
+        polygon = ogr.Geometry(ogr.wkbPolygon)
+        polygon.AddGeometry(outring)
+        f.SetGeometry(polygon)
         lyr.CreateFeature(f)
         f = ogr.Feature(lyr.GetLayerDefn())
         f["name"] = "province three"
         f["region"] = 2
+        outring = ogr.Geometry(ogr.wkbLinearRing)
+        outring.AddPoint(2581000, 1220000)
+        outring.AddPoint(2582000, 1220000)
+        outring.AddPoint(2582000, 1220500)
+        outring.AddPoint(2581000, 1220500)
+        outring.AddPoint(2581000, 1220000)
+        polygon = ogr.Geometry(ogr.wkbPolygon)
+        polygon.AddGeometry(outring)
+        f.SetGeometry(polygon)
         lyr.CreateFeature(f)
         f = ogr.Feature(lyr.GetLayerDefn())
         f["name"] = "province four"
         f["region"] = 2
+        outring = ogr.Geometry(ogr.wkbLinearRing)
+        outring.AddPoint(2581000, 1220500)
+        outring.AddPoint(2582000, 1220500)
+        outring.AddPoint(2582000, 1221000)
+        outring.AddPoint(2581000, 1221000)
+        outring.AddPoint(2581000, 1220500)
+        polygon = ogr.Geometry(ogr.wkbPolygon)
+        polygon.AddGeometry(outring)
+        f.SetGeometry(polygon)
         lyr.CreateFeature(f)
 
-        lyr = ds.CreateLayer("city", geom_type=ogr.wkbNone)
+        lyr = ds.CreateLayer("city", srs, geom_type=ogr.wkbPoint)
         lyr.CreateField(ogr.FieldDefn("name", ogr.OFTString))
         lyr.CreateField(ogr.FieldDefn("province", ogr.OFTInteger))
         f = ogr.Feature(lyr.GetLayerDefn())
         f["name"] = "city one"
         f["province"] = 1
+        point = ogr.Geometry(ogr.wkbPoint)
+        point.AddPoint(2580200, 1221200)
+        f.SetGeometry(point)
         lyr.CreateFeature(f)
         f = ogr.Feature(lyr.GetLayerDefn())
         f["name"] = "city two"
         f["province"] = 1
+        point = ogr.Geometry(ogr.wkbPoint)
+        point.AddPoint(2580400, 1220700)
+        f.SetGeometry(point)
         lyr.CreateFeature(f)
         f = ogr.Feature(lyr.GetLayerDefn())
         f["name"] = "city three"
         f["province"] = 2
+        point = ogr.Geometry(ogr.wkbPoint)
+        point.AddPoint(2580900, 1220900)
+        f.SetGeometry(point)
         lyr.CreateFeature(f)
         f = ogr.Feature(lyr.GetLayerDefn())
         f["name"] = "city four"
         f["province"] = 4
+        point = ogr.Geometry(ogr.wkbPoint)
+        point.AddPoint(2581200, 1220300)
+        f.SetGeometry(point)
         lyr.CreateFeature(f)
 
+        outring = None
+        polygon = None
+        point = None
         f = None
         ds = None
 
@@ -293,6 +381,76 @@ class TestPackageLayers(QgisTestCase):
         province.selectByIds([3])
         _test(parameters, {"region": {2}, "province": {3}})
         province.selectByIds([])
+
+    def test_extent_filter_export(self):
+        """Test export with extent"""
+
+        alg = self.registry.createAlgorithmById("qgis:package")
+        self.assertIsNotNone(alg)
+
+        def _test(parameters, expected_ids):
+
+            feedback = ConsoleFeedBack()
+            context = QgsProcessingContext()
+            context.setProject(QgsProject.instance())
+            # Note: the following returns true also in case of errors ...
+            self.assertTrue(execute(alg, parameters, context, feedback))
+            # ... so we check the log
+            self.assertEqual(feedback._errors, [])
+
+            # Check export
+            for layer_name in list(expected_ids.keys()):
+                l = QgsVectorLayer(
+                    self.temp_export_path + f"|layername={layer_name}", layer_name
+                )
+                self.assertTrue(l.isValid())
+                ids = {l.id() for l in l.getFeatures()}
+                self.assertEqual(ids, expected_ids[layer_name], layer_name + str(ids))
+
+        region = QgsProject.instance().mapLayersByName("region")[0]
+        province = QgsProject.instance().mapLayersByName("province")[0]
+        city = QgsProject.instance().mapLayersByName("city")[0]
+
+        parameters = {
+            "EXPORT_RELATED_LAYERS": False,
+            "LAYERS": [province, region, city],
+            "OUTPUT": self.temp_export_path,
+            "OVERWRITE": True,
+            "SELECTED_FEATURES_ONLY": False,
+            "EXTENT": None,
+        }
+
+        # Test with no extent given
+        _test(
+            parameters,
+            {"region": {1, 2}, "province": {1, 2, 3, 4}, "city": {1, 2, 3, 4}},
+        )
+
+        # Test all features intersecting extent
+        parameters["EXTENT"] = "2580000,2582000,1220000,1222000 [EPSG:2056]"
+        _test(
+            parameters,
+            {"region": {1, 2}, "province": {1, 2, 3, 4}, "city": {1, 2, 3, 4}},
+        )
+
+        # Test more interesting extent
+        parameters["EXTENT"] = "2580700,2581500,1220000,1222000 [EPSG:2056]"
+        _test(parameters, {"region": {1, 2}, "province": {2, 3, 4}, "city": {3, 4}})
+
+        # Test extent in another CRS
+        parameters["EXTENT"] = "7.184251,7.194712,47.130699,47.148712 [EPSG:4326]"
+        _test(parameters, {"region": {1, 2}, "province": {2, 3, 4}, "city": {3, 4}})
+
+        # Test extent with selected features
+        parameters["EXTENT"] = "2580700,2581500,1220000,1222000 [EPSG:2056]"
+        parameters["SELECTED_FEATURES_ONLY"] = True
+        region.selectByIds([2])
+        province.selectByIds([1, 2, 4])
+        city.selectByIds([2, 3])
+        _test(parameters, {"region": {2}, "province": {2, 4}, "city": {3}})
+        region.selectByIds([])
+        province.selectByIds([])
+        city.selectByIds([])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds an optional parameter `Extent` to the Package Layers algorithm, allowing users to only export features that intersect a given extent from all the selected layers.

![image](https://github.com/user-attachments/assets/3a6a565e-382a-40a6-b2bb-4179a2deba0a)

If none of the features of a specific selected layer intersect the given extent, the layer will still be created and will be empty in the output GeoPackage.


(Includes tests)

--------

Funded by [City of Frankfurt – Stadtplanungsamt](https://www.stadtplanungsamt-frankfurt.de/about_us_5645.html).
