### PR TITLE
[Backport release-3_40] RelationReference save edits on embedded form

### DIFF
--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -255,7 +255,6 @@ Set the limit of fetched features (0 means all features)
 .. versionadded:: 3.32
 %End
 
-
   public slots:
     void openForm();
 %Docstring
@@ -270,6 +269,13 @@ activate the map tool to select a new related feature on the map
     void deleteForeignKeys();
 %Docstring
 unset the currently related feature
+%End
+
+    bool saveReferencedAttributeForm();
+%Docstring
+Trigger save of the embedded referenced attribute form.
+
+.. versionadded:: 3.42
 %End
 
   protected:

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -274,6 +274,7 @@ unset the currently related feature
     bool saveReferencedAttributeForm();
 %Docstring
 Trigger save of the embedded referenced attribute form.
+Returns ``True`` on success or if no embedded form is present.
 
 .. versionadded:: 3.42
 %End

--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -273,10 +273,10 @@ unset the currently related feature
 
     bool saveReferencedAttributeForm();
 %Docstring
-Trigger save of the embedded referenced attribute form.
-Returns ``True`` on success or if no embedded form is present.
+Trigger save of the embedded referenced attribute form. Returns ``True``
+on success or if no embedded form is present.
 
-.. versionadded:: 3.42
+.. versionadded:: 3.40
 %End
 
   protected:

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -255,7 +255,6 @@ Set the limit of fetched features (0 means all features)
 .. versionadded:: 3.32
 %End
 
-
   public slots:
     void openForm();
 %Docstring
@@ -270,6 +269,13 @@ activate the map tool to select a new related feature on the map
     void deleteForeignKeys();
 %Docstring
 unset the currently related feature
+%End
+
+    bool saveReferencedAttributeForm();
+%Docstring
+Trigger save of the embedded referenced attribute form.
+
+.. versionadded:: 3.42
 %End
 
   protected:

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -274,6 +274,7 @@ unset the currently related feature
     bool saveReferencedAttributeForm();
 %Docstring
 Trigger save of the embedded referenced attribute form.
+Returns ``True`` on success or if no embedded form is present.
 
 .. versionadded:: 3.42
 %End

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -273,10 +273,10 @@ unset the currently related feature
 
     bool saveReferencedAttributeForm();
 %Docstring
-Trigger save of the embedded referenced attribute form.
-Returns ``True`` on success or if no embedded form is present.
+Trigger save of the embedded referenced attribute form. Returns ``True``
+on success or if no embedded form is present.
 
-.. versionadded:: 3.42
+.. versionadded:: 3.40
 %End
 
   protected:

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -293,6 +293,15 @@ void QgsRelationReferenceWidget::deleteForeignKeys()
   emitForeignKeysChanged( foreignKeys() );
 }
 
+bool QgsRelationReferenceWidget::saveReferencedAttributeForm()
+{
+  if ( !mEmbedForm )
+    // if there is no embedded form, everything is fine anyway
+    return true;
+
+  return mReferencedAttributeForm->save();
+}
+
 QgsFeature QgsRelationReferenceWidget::referencedFeature() const
 {
   QgsFeature f;

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -265,7 +265,6 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
      */
     void setFetchLimit( int fetchLimit ) { mFetchLimit = fetchLimit; }
 
-
   public slots:
     //! open the form of the related feature in a new dialog
     void openForm();
@@ -275,6 +274,13 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
 
     //! unset the currently related feature
     void deleteForeignKeys();
+
+    /**
+      * Trigger save of the embedded referenced attribute form.
+      *
+      * \since QGIS 3.42
+      */
+    bool saveReferencedAttributeForm();
 
   protected:
     void showEvent( QShowEvent *e ) override;

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -277,6 +277,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
 
     /**
       * Trigger save of the embedded referenced attribute form.
+      * Returns TRUE on success or if no embedded form is present.
       *
       * \since QGIS 3.42
       */

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -279,7 +279,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
       * Trigger save of the embedded referenced attribute form.
       * Returns TRUE on success or if no embedded form is present.
       *
-      * \since QGIS 3.42
+      * \since QGIS 3.40
       */
     bool saveReferencedAttributeForm();
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -126,6 +126,12 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   connect( mWidget, &QgsRelationReferenceWidget::foreignKeysChanged, this, &QgsRelationReferenceWidgetWrapper::foreignKeysChanged );
 }
 
+void QgsRelationReferenceWidgetWrapper::aboutToSave()
+{
+  // Save changes in the embedded form
+  mWidget->saveReferencedAttributeForm();
+}
+
 QVariant QgsRelationReferenceWidgetWrapper::value() const
 {
   if ( !mWidget )

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -75,6 +75,7 @@ class GUI_EXPORT QgsRelationReferenceWidgetWrapper : public QgsEditorWidgetWrapp
     void widgetValueChanged( const QString &attribute, const QVariant &newValue, bool attributeChanged );
 
   private:
+    void aboutToSave() override;
     void updateValues( const QVariant &val, const QVariantList &additionalValues = QVariantList() ) override;
 
     QString mExpression;


### PR DESCRIPTION
This is a manual backport of #60932 introduced to 3.44.0 and already backported to 3.42.2, what means it had some time to proof the stability. Like proposed here https://github.com/qgis/QGIS/pull/60932#issuecomment-2739963939 to have some more time than the usual queued-buffer.

Backport of #60932

> You have been able to change values in the embedded form of the relation reference widget, but they were not stored. Only when changing something in the main form the save has been triggered (via vector layer modified).
> Now it triggers the save of the embedded form whenever the "OK" button of t he main form is pressed or the index in the attribute table form view is changed.




