### PR TITLE
"Trim/Extend segment" tool automatically enables/disables snapping on segment

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1189,8 +1189,7 @@ Shift+O to turn segments into straight or curve lines.</string>
    <property name="toolTip">
     <string>Trim/Extend Feature
 - Click to set the reference segment
-- Click on another segment to trim it or extend it to the reference segment (Use Shift to keep the reference segment active)
-Note : Segment snapping must be enabled in the snapping Toolbar</string>
+- Click on another segment to trim it or extend it to the reference segment (Use Shift to keep the reference segment active)</string>
    </property>
   </action>
   <action name="mActionSnappingOptions">


### PR DESCRIPTION
As mentioned in https://github.com/qgis/QGIS/pull/59941
> * Auto enable snapping when activating the tool. Original snapping configuration is restored on tool deactivation