### PR TITLE
Fix #62337 - Pressing F1 do not open API page

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgscodeeditor.py
+++ b/python/PyQt6/gui/auto_additions/qgscodeeditor.py
@@ -66,7 +66,7 @@ try:
     QgsCodeEditor.getMonospaceFont = staticmethod(QgsCodeEditor.getMonospaceFont)
     QgsCodeEditor.isFixedPitch = staticmethod(QgsCodeEditor.isFixedPitch)
     QgsCodeEditor.__virtual_methods__ = ['language', 'languageCapabilities', 'moveCursorToStart', 'moveCursorToEnd', 'checkSyntax', 'toggleComment', 'initializeLexer', 'populateContextMenu', 'reformatCodeString', 'showMessage']
-    QgsCodeEditor.__overridden_methods__ = ['callTip', 'setText', 'focusOutEvent', 'keyPressEvent', 'contextMenuEvent', 'eventFilter']
+    QgsCodeEditor.__overridden_methods__ = ['callTip', 'setText', 'focusOutEvent', 'keyPressEvent', 'contextMenuEvent', 'event', 'eventFilter']
     QgsCodeEditor.__signal_arguments__ = {'helpRequested': ['word: str']}
     QgsCodeEditor.__group__ = ['codeeditors']
 except (NameError, AttributeError):

--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -601,6 +601,8 @@ Returns ``True`` if a ``font`` is a fixed pitch font.
 
     virtual void contextMenuEvent( QContextMenuEvent *event );
 
+    virtual bool event( QEvent *event );
+
     virtual bool eventFilter( QObject *watched, QEvent *event );
 
     virtual void initializeLexer();

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -185,7 +185,7 @@ class Editor(QgsCodeEditorPython):
                     force_search=True,
                 )
             )
-            context_help_action.setShortcut("F1")
+            context_help_action.setShortcut(QKeySequence.StandardKey.HelpContents)
             menu.addAction(context_help_action)
 
         start_action = QAction(

--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -295,7 +295,7 @@ class ShellOutputScintilla(QgsCodeEditorPython):
             context_help_action.triggered.connect(
                 partial(self.shell_editor.showApiDocumentation, word, force_search=True)
             )
-            context_help_action.setShortcut("F1")
+            context_help_action.setShortcut(QKeySequence.StandardKey.HelpContents)
             menu.addAction(context_help_action)
 
         menu.addSeparator()

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -547,5 +547,5 @@ class ShellScintilla(QgsCodeEditorPython):
             context_help_action.triggered.connect(
                 partial(self.showApiDocumentation, word, force_search=True)
             )
-            context_help_action.setShortcut("F1")
+            context_help_action.setShortcut(QKeySequence.StandardKey.HelpContents)
             menu.addAction(context_help_action)

--- a/python/gui/auto_additions/qgscodeeditor.py
+++ b/python/gui/auto_additions/qgscodeeditor.py
@@ -65,7 +65,7 @@ try:
     QgsCodeEditor.getMonospaceFont = staticmethod(QgsCodeEditor.getMonospaceFont)
     QgsCodeEditor.isFixedPitch = staticmethod(QgsCodeEditor.isFixedPitch)
     QgsCodeEditor.__virtual_methods__ = ['language', 'languageCapabilities', 'moveCursorToStart', 'moveCursorToEnd', 'checkSyntax', 'toggleComment', 'initializeLexer', 'populateContextMenu', 'reformatCodeString', 'showMessage']
-    QgsCodeEditor.__overridden_methods__ = ['callTip', 'setText', 'focusOutEvent', 'keyPressEvent', 'contextMenuEvent', 'eventFilter']
+    QgsCodeEditor.__overridden_methods__ = ['callTip', 'setText', 'focusOutEvent', 'keyPressEvent', 'contextMenuEvent', 'event', 'eventFilter']
     QgsCodeEditor.__signal_arguments__ = {'helpRequested': ['word: str']}
     QgsCodeEditor.__group__ = ['codeeditors']
 except (NameError, AttributeError):

--- a/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
+++ b/python/gui/auto_generated/codeeditors/qgscodeeditor.sip.in
@@ -601,6 +601,8 @@ Returns ``True`` if a ``font`` is a fixed pitch font.
 
     virtual void contextMenuEvent( QContextMenuEvent *event );
 
+    virtual bool event( QEvent *event );
+
     virtual bool eventFilter( QObject *watched, QEvent *event );
 
     virtual void initializeLexer();

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -359,6 +359,23 @@ void QgsCodeEditor::contextMenuEvent( QContextMenuEvent *event )
   }
 }
 
+bool QgsCodeEditor::event( QEvent *event )
+{
+  if ( event->type() == QEvent::ShortcutOverride )
+  {
+    if ( QKeyEvent *keyEvent = dynamic_cast<QKeyEvent *>( event ) )
+    {
+      if ( keyEvent->key() == Qt::Key_F1 )
+      {
+        // If the user pressed F1, we want to prevent the main help dialog to show
+        // and handle the event in QgsCodeEditor::keyPressEvent
+        keyEvent->accept();
+        return true;
+      }
+    }
+  }
+  return QsciScintilla::event( event );
+}
 
 bool QgsCodeEditor::eventFilter( QObject *watched, QEvent *event )
 {

--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -204,7 +204,7 @@ void QgsCodeEditor::keyPressEvent( QKeyEvent *event )
     return;
   }
 
-  if ( event->key() == Qt::Key_F1 )
+  if ( event->matches( QKeySequence::StandardKey::HelpContents ) )
   {
     // Check if some text is selected
     QString text = selectedText();
@@ -365,7 +365,7 @@ bool QgsCodeEditor::event( QEvent *event )
   {
     if ( QKeyEvent *keyEvent = dynamic_cast<QKeyEvent *>( event ) )
     {
-      if ( keyEvent->key() == Qt::Key_F1 )
+      if ( keyEvent->matches( QKeySequence::StandardKey::HelpContents ) )
       {
         // If the user pressed F1, we want to prevent the main help dialog to show
         // and handle the event in QgsCodeEditor::keyPressEvent

--- a/src/gui/codeeditors/qgscodeeditor.h
+++ b/src/gui/codeeditors/qgscodeeditor.h
@@ -611,6 +611,7 @@ class GUI_EXPORT QgsCodeEditor : public QsciScintilla
     void focusOutEvent( QFocusEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
     void contextMenuEvent( QContextMenuEvent *event ) override;
+    bool event( QEvent *event ) override;
     bool eventFilter( QObject *watched, QEvent *event ) override;
     /**
      * Called when the dialect specific code lexer needs to be initialized (or reinitialized).

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -534,7 +534,7 @@ void QgsCodeEditorPython::populateContextMenu( QMenu *menu )
   );
 
   pyQgisHelpAction->setEnabled( hasSelectedText() );
-  pyQgisHelpAction->setShortcut( QStringLiteral( "F1" ) );
+  pyQgisHelpAction->setShortcut( QKeySequence::StandardKey::HelpContents );
   connect( pyQgisHelpAction, &QAction::triggered, this, [text, this] { showApiDocumentation( text ); } );
 
   menu->addSeparator();


### PR DESCRIPTION
 - Fix #62337 
 
## Description
Override the global F1 shortcut while QgsCodeEditor has keyboard focus
