### PR TITLE
Add methods to remove plugin-defined layout items when unloading plugin

### DIFF
--- a/python/PyQt6/core/auto_additions/qgslayoutitemregistry.py
+++ b/python/PyQt6/core/auto_additions/qgslayoutitemregistry.py
@@ -20,8 +20,8 @@ QgsLayoutItemRegistry.LayoutMarker = QgsLayoutItemRegistry.ItemType.LayoutMarker
 QgsLayoutItemRegistry.LayoutElevationProfile = QgsLayoutItemRegistry.ItemType.LayoutElevationProfile
 QgsLayoutItemRegistry.PluginItem = QgsLayoutItemRegistry.ItemType.PluginItem
 try:
-    QgsLayoutItemRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``type`` and visible ``name``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry with the\nspecified ``type``\n', 'multiFrameTypeAdded': 'Emitted whenever a new multiframe type is added to the registry, with\nthe specified ``type`` and visible ``name``.\n'}
-    QgsLayoutItemRegistry.__signal_arguments__ = {'typeAdded': ['type: int', 'name: str'], 'typeRemoved': ['type: int'], 'multiFrameTypeAdded': ['type: int', 'name: str']}
+    QgsLayoutItemRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``type`` and visible ``name``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry with the\nspecified ``type``.\n\n.. versionadded:: 4.0\n', 'multiFrameTypeAdded': 'Emitted whenever a new multiframe type is added to the registry, with\nthe specified ``type`` and visible ``name``.\n', 'multiFrameTypeRemoved': 'Emitted whenever an multiframe type is removed from the registry with\nthe specified ``type``.\n\n.. versionadded:: 4.0\n'}
+    QgsLayoutItemRegistry.__signal_arguments__ = {'typeAdded': ['type: int', 'name: str'], 'typeRemoved': ['type: int'], 'multiFrameTypeAdded': ['type: int', 'name: str'], 'multiFrameTypeRemoved': ['type: int']}
     QgsLayoutItemRegistry.__group__ = ['layout']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgslayoutitemregistry.py
+++ b/python/PyQt6/core/auto_additions/qgslayoutitemregistry.py
@@ -20,8 +20,8 @@ QgsLayoutItemRegistry.LayoutMarker = QgsLayoutItemRegistry.ItemType.LayoutMarker
 QgsLayoutItemRegistry.LayoutElevationProfile = QgsLayoutItemRegistry.ItemType.LayoutElevationProfile
 QgsLayoutItemRegistry.PluginItem = QgsLayoutItemRegistry.ItemType.PluginItem
 try:
-    QgsLayoutItemRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``type`` and visible ``name``.\n', 'multiFrameTypeAdded': 'Emitted whenever a new multiframe type is added to the registry, with\nthe specified ``type`` and visible ``name``.\n'}
-    QgsLayoutItemRegistry.__signal_arguments__ = {'typeAdded': ['type: int', 'name: str'], 'multiFrameTypeAdded': ['type: int', 'name: str']}
+    QgsLayoutItemRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``type`` and visible ``name``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry with the\nspecified ``type``\n', 'multiFrameTypeAdded': 'Emitted whenever a new multiframe type is added to the registry, with\nthe specified ``type`` and visible ``name``.\n'}
+    QgsLayoutItemRegistry.__signal_arguments__ = {'typeAdded': ['type: int', 'name: str'], 'typeRemoved': ['type: int'], 'multiFrameTypeAdded': ['type: int', 'name: str']}
     QgsLayoutItemRegistry.__group__ = ['layout']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemregistry.sip.in
@@ -246,6 +246,26 @@ instance.
 .. seealso:: :py:func:`addLayoutMultiFrameType`
 %End
 
+    bool removeLayoutItemType( int typeId );
+%Docstring
+Unregisters a layout item type
+%End
+
+    bool removeLayoutItemType( QgsLayoutItemAbstractMetadata *metadata );
+%Docstring
+Unregisters a layout item type
+%End
+
+    bool removeLayoutMultiFrameType( int typeId );
+%Docstring
+Unregisters a layout multiframe type
+%End
+
+    bool removeLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata );
+%Docstring
+Unregisters a layout multiframe type
+%End
+
     bool addLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata /Transfer/ );
 %Docstring
 Registers a new layout multiframe type. Takes ownership of the metadata
@@ -288,6 +308,12 @@ Returns a map of available item types to translated name.
 %Docstring
 Emitted whenever a new item type is added to the registry, with the
 specified ``type`` and visible ``name``.
+%End
+
+    void typeRemoved( int type );
+%Docstring
+Emitted whenever an item type is removed from the registry with the
+specified ``type``
 %End
 
     void multiFrameTypeAdded( int type, const QString &name );

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemregistry.sip.in
@@ -248,22 +248,36 @@ instance.
 
     bool removeLayoutItemType( int typeId );
 %Docstring
-Unregisters a layout item type
+Unregisters a layout item type.
+
+.. versionadded:: 4.0
 %End
 
     bool removeLayoutItemType( QgsLayoutItemAbstractMetadata *metadata );
 %Docstring
-Unregisters a layout item type
+Unregisters a layout item type.
+
+The ``metadata`` object will be deleted and should not be used after
+this call.
+
+.. versionadded:: 4.0
 %End
 
     bool removeLayoutMultiFrameType( int typeId );
 %Docstring
-Unregisters a layout multiframe type
+Unregisters a layout multiframe type.
+
+.. versionadded:: 4.0
 %End
 
     bool removeLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata );
 %Docstring
-Unregisters a layout multiframe type
+Unregisters a layout multiframe type.
+
+The ``metadata`` object will be deleted and should not be used after
+this call.
+
+.. versionadded:: 4.0
 %End
 
     bool addLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata /Transfer/ );
@@ -313,13 +327,23 @@ specified ``type`` and visible ``name``.
     void typeRemoved( int type );
 %Docstring
 Emitted whenever an item type is removed from the registry with the
-specified ``type``
+specified ``type``.
+
+.. versionadded:: 4.0
 %End
 
     void multiFrameTypeAdded( int type, const QString &name );
 %Docstring
 Emitted whenever a new multiframe type is added to the registry, with
 the specified ``type`` and visible ``name``.
+%End
+
+    void multiFrameTypeRemoved( int type );
+%Docstring
+Emitted whenever an multiframe type is removed from the registry with
+the specified ``type``.
+
+.. versionadded:: 4.0
 %End
 
   private:

--- a/python/PyQt6/gui/auto_additions/qgslayoutitemguiregistry.py
+++ b/python/PyQt6/gui/auto_additions/qgslayoutitemguiregistry.py
@@ -8,8 +8,8 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsLayoutItemGuiRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``metadataId``.\n'}
-    QgsLayoutItemGuiRegistry.__signal_arguments__ = {'typeAdded': ['metadataId: int']}
+    QgsLayoutItemGuiRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``metadataId``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry, with the\nspecified ``metadataId``.\n', 'groupRemoved': 'Emitted whenever an item group is removed from the registry\n'}
+    QgsLayoutItemGuiRegistry.__signal_arguments__ = {'typeAdded': ['metadataId: int'], 'typeRemoved': ['metadataId: int'], 'groupRemoved': ['groupId: str']}
     QgsLayoutItemGuiRegistry.__group__ = ['layout']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_additions/qgslayoutitemguiregistry.py
+++ b/python/PyQt6/gui/auto_additions/qgslayoutitemguiregistry.py
@@ -8,7 +8,7 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsLayoutItemGuiRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``metadataId``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry, with the\nspecified ``metadataId``.\n', 'groupRemoved': 'Emitted whenever an item group is removed from the registry\n'}
+    QgsLayoutItemGuiRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``metadataId``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry, with the\nspecified ``metadataId``.\n\n.. versionadded:: 4.0\n', 'groupRemoved': 'Emitted whenever an item group is removed from the registry.\n\n.. versionadded:: 4.0\n'}
     QgsLayoutItemGuiRegistry.__signal_arguments__ = {'typeAdded': ['metadataId: int'], 'typeRemoved': ['metadataId: int'], 'groupRemoved': ['groupId: str']}
     QgsLayoutItemGuiRegistry.__group__ = ['layout']
 except (NameError, AttributeError):

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -224,6 +224,16 @@ Registers the gui metadata for a new layout item type. Takes ownership
 of the metadata instance.
 %End
 
+    bool removeLayoutItemGuiMetadata( int type );
+%Docstring
+Unregisters the gui metadata for a layout item type.
+%End
+
+    bool removeLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata );
+%Docstring
+Unregisters the gui metadata for a layout item type.
+%End
+
     bool addItemGroup( const QgsLayoutItemGuiGroup &group );
 %Docstring
 Registers a new item group with the registry. This must be done before
@@ -234,6 +244,13 @@ Returns ``True`` if group was added, or ``False`` if group could not be
 added (e.g. due to duplicate id value).
 
 .. seealso:: :py:func:`itemGroup`
+%End
+
+    bool removeItemGroup( const QString &id );
+%Docstring
+Unregisters a item group from the registry. This must be done after
+calling :py:func:`~QgsLayoutItemGuiRegistry.removeLayoutItemGuiMetadata`
+for every item types associated with the group.
 %End
 
     const QgsLayoutItemGuiGroup &itemGroup( const QString &id );
@@ -283,6 +300,17 @@ Returns a list of available item metadata ids handled by the registry.
 %Docstring
 Emitted whenever a new item type is added to the registry, with the
 specified ``metadataId``.
+%End
+
+    void typeRemoved( int metadataId );
+%Docstring
+Emitted whenever an item type is removed from the registry, with the
+specified ``metadataId``.
+%End
+
+    void groupRemoved( QString groupId );
+%Docstring
+Emitted whenever an item group is removed from the registry
 %End
 
   private:

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -220,18 +220,25 @@ Returns -1 if no matching metadata is found in the GUI registry.
 
     bool addLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata /Transfer/ );
 %Docstring
-Registers the gui metadata for a new layout item type. Takes ownership
+Registers the GUI metadata for a new layout item type. Takes ownership
 of the metadata instance.
 %End
 
     bool removeLayoutItemGuiMetadata( int type );
 %Docstring
-Unregisters the gui metadata for a layout item type.
+Unregisters the GUI metadata for a layout item type.
+
+.. versionadded:: 4.0
 %End
 
     bool removeLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata );
 %Docstring
-Unregisters the gui metadata for a layout item type.
+Unregisters the GUI metadata for a layout item type.
+
+The ``metadata`` object will be deleted and should not be used after
+this call.
+
+.. versionadded:: 4.0
 %End
 
     bool addItemGroup( const QgsLayoutItemGuiGroup &group );
@@ -248,9 +255,13 @@ added (e.g. due to duplicate id value).
 
     bool removeItemGroup( const QString &id );
 %Docstring
-Unregisters a item group from the registry. This must be done after
-calling :py:func:`~QgsLayoutItemGuiRegistry.removeLayoutItemGuiMetadata`
-for every item types associated with the group.
+Unregisters an item group from the registry.
+
+This must be done after calling
+:py:func:`~QgsLayoutItemGuiRegistry.removeLayoutItemGuiMetadata` for
+every item types associated with the group.
+
+.. versionadded:: 4.0
 %End
 
     const QgsLayoutItemGuiGroup &itemGroup( const QString &id );
@@ -306,11 +317,15 @@ specified ``metadataId``.
 %Docstring
 Emitted whenever an item type is removed from the registry, with the
 specified ``metadataId``.
+
+.. versionadded:: 4.0
 %End
 
     void groupRemoved( QString groupId );
 %Docstring
-Emitted whenever an item group is removed from the registry
+Emitted whenever an item group is removed from the registry.
+
+.. versionadded:: 4.0
 %End
 
   private:

--- a/python/core/auto_additions/qgslayoutitemregistry.py
+++ b/python/core/auto_additions/qgslayoutitemregistry.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/layout/qgslayoutitemregistry.h
 try:
-    QgsLayoutItemRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``type`` and visible ``name``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry with the\nspecified ``type``\n', 'multiFrameTypeAdded': 'Emitted whenever a new multiframe type is added to the registry, with\nthe specified ``type`` and visible ``name``.\n'}
-    QgsLayoutItemRegistry.__signal_arguments__ = {'typeAdded': ['type: int', 'name: str'], 'typeRemoved': ['type: int'], 'multiFrameTypeAdded': ['type: int', 'name: str']}
+    QgsLayoutItemRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``type`` and visible ``name``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry with the\nspecified ``type``.\n\n.. versionadded:: 4.0\n', 'multiFrameTypeAdded': 'Emitted whenever a new multiframe type is added to the registry, with\nthe specified ``type`` and visible ``name``.\n', 'multiFrameTypeRemoved': 'Emitted whenever an multiframe type is removed from the registry with\nthe specified ``type``.\n\n.. versionadded:: 4.0\n'}
+    QgsLayoutItemRegistry.__signal_arguments__ = {'typeAdded': ['type: int', 'name: str'], 'typeRemoved': ['type: int'], 'multiFrameTypeAdded': ['type: int', 'name: str'], 'multiFrameTypeRemoved': ['type: int']}
     QgsLayoutItemRegistry.__group__ = ['layout']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_additions/qgslayoutitemregistry.py
+++ b/python/core/auto_additions/qgslayoutitemregistry.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/layout/qgslayoutitemregistry.h
 try:
-    QgsLayoutItemRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``type`` and visible ``name``.\n', 'multiFrameTypeAdded': 'Emitted whenever a new multiframe type is added to the registry, with\nthe specified ``type`` and visible ``name``.\n'}
-    QgsLayoutItemRegistry.__signal_arguments__ = {'typeAdded': ['type: int', 'name: str'], 'multiFrameTypeAdded': ['type: int', 'name: str']}
+    QgsLayoutItemRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``type`` and visible ``name``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry with the\nspecified ``type``\n', 'multiFrameTypeAdded': 'Emitted whenever a new multiframe type is added to the registry, with\nthe specified ``type`` and visible ``name``.\n'}
+    QgsLayoutItemRegistry.__signal_arguments__ = {'typeAdded': ['type: int', 'name: str'], 'typeRemoved': ['type: int'], 'multiFrameTypeAdded': ['type: int', 'name: str']}
     QgsLayoutItemRegistry.__group__ = ['layout']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/layout/qgslayoutitemregistry.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemregistry.sip.in
@@ -246,6 +246,26 @@ instance.
 .. seealso:: :py:func:`addLayoutMultiFrameType`
 %End
 
+    bool removeLayoutItemType( int typeId );
+%Docstring
+Unregisters a layout item type
+%End
+
+    bool removeLayoutItemType( QgsLayoutItemAbstractMetadata *metadata );
+%Docstring
+Unregisters a layout item type
+%End
+
+    bool removeLayoutMultiFrameType( int typeId );
+%Docstring
+Unregisters a layout multiframe type
+%End
+
+    bool removeLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata );
+%Docstring
+Unregisters a layout multiframe type
+%End
+
     bool addLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata /Transfer/ );
 %Docstring
 Registers a new layout multiframe type. Takes ownership of the metadata
@@ -288,6 +308,12 @@ Returns a map of available item types to translated name.
 %Docstring
 Emitted whenever a new item type is added to the registry, with the
 specified ``type`` and visible ``name``.
+%End
+
+    void typeRemoved( int type );
+%Docstring
+Emitted whenever an item type is removed from the registry with the
+specified ``type``
 %End
 
     void multiFrameTypeAdded( int type, const QString &name );

--- a/python/core/auto_generated/layout/qgslayoutitemregistry.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemregistry.sip.in
@@ -248,22 +248,36 @@ instance.
 
     bool removeLayoutItemType( int typeId );
 %Docstring
-Unregisters a layout item type
+Unregisters a layout item type.
+
+.. versionadded:: 4.0
 %End
 
     bool removeLayoutItemType( QgsLayoutItemAbstractMetadata *metadata );
 %Docstring
-Unregisters a layout item type
+Unregisters a layout item type.
+
+The ``metadata`` object will be deleted and should not be used after
+this call.
+
+.. versionadded:: 4.0
 %End
 
     bool removeLayoutMultiFrameType( int typeId );
 %Docstring
-Unregisters a layout multiframe type
+Unregisters a layout multiframe type.
+
+.. versionadded:: 4.0
 %End
 
     bool removeLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata );
 %Docstring
-Unregisters a layout multiframe type
+Unregisters a layout multiframe type.
+
+The ``metadata`` object will be deleted and should not be used after
+this call.
+
+.. versionadded:: 4.0
 %End
 
     bool addLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata /Transfer/ );
@@ -313,13 +327,23 @@ specified ``type`` and visible ``name``.
     void typeRemoved( int type );
 %Docstring
 Emitted whenever an item type is removed from the registry with the
-specified ``type``
+specified ``type``.
+
+.. versionadded:: 4.0
 %End
 
     void multiFrameTypeAdded( int type, const QString &name );
 %Docstring
 Emitted whenever a new multiframe type is added to the registry, with
 the specified ``type`` and visible ``name``.
+%End
+
+    void multiFrameTypeRemoved( int type );
+%Docstring
+Emitted whenever an multiframe type is removed from the registry with
+the specified ``type``.
+
+.. versionadded:: 4.0
 %End
 
   private:

--- a/python/gui/auto_additions/qgslayoutitemguiregistry.py
+++ b/python/gui/auto_additions/qgslayoutitemguiregistry.py
@@ -6,8 +6,8 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsLayoutItemGuiRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``metadataId``.\n'}
-    QgsLayoutItemGuiRegistry.__signal_arguments__ = {'typeAdded': ['metadataId: int']}
+    QgsLayoutItemGuiRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``metadataId``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry, with the\nspecified ``metadataId``.\n', 'groupRemoved': 'Emitted whenever an item group is removed from the registry\n'}
+    QgsLayoutItemGuiRegistry.__signal_arguments__ = {'typeAdded': ['metadataId: int'], 'typeRemoved': ['metadataId: int'], 'groupRemoved': ['groupId: str']}
     QgsLayoutItemGuiRegistry.__group__ = ['layout']
 except (NameError, AttributeError):
     pass

--- a/python/gui/auto_additions/qgslayoutitemguiregistry.py
+++ b/python/gui/auto_additions/qgslayoutitemguiregistry.py
@@ -6,7 +6,7 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsLayoutItemGuiRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``metadataId``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry, with the\nspecified ``metadataId``.\n', 'groupRemoved': 'Emitted whenever an item group is removed from the registry\n'}
+    QgsLayoutItemGuiRegistry.__attribute_docs__ = {'typeAdded': 'Emitted whenever a new item type is added to the registry, with the\nspecified ``metadataId``.\n', 'typeRemoved': 'Emitted whenever an item type is removed from the registry, with the\nspecified ``metadataId``.\n\n.. versionadded:: 4.0\n', 'groupRemoved': 'Emitted whenever an item group is removed from the registry.\n\n.. versionadded:: 4.0\n'}
     QgsLayoutItemGuiRegistry.__signal_arguments__ = {'typeAdded': ['metadataId: int'], 'typeRemoved': ['metadataId: int'], 'groupRemoved': ['groupId: str']}
     QgsLayoutItemGuiRegistry.__group__ = ['layout']
 except (NameError, AttributeError):

--- a/python/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -224,6 +224,16 @@ Registers the gui metadata for a new layout item type. Takes ownership
 of the metadata instance.
 %End
 
+    bool removeLayoutItemGuiMetadata( int type );
+%Docstring
+Unregisters the gui metadata for a layout item type.
+%End
+
+    bool removeLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata );
+%Docstring
+Unregisters the gui metadata for a layout item type.
+%End
+
     bool addItemGroup( const QgsLayoutItemGuiGroup &group );
 %Docstring
 Registers a new item group with the registry. This must be done before
@@ -234,6 +244,13 @@ Returns ``True`` if group was added, or ``False`` if group could not be
 added (e.g. due to duplicate id value).
 
 .. seealso:: :py:func:`itemGroup`
+%End
+
+    bool removeItemGroup( const QString &id );
+%Docstring
+Unregisters a item group from the registry. This must be done after
+calling :py:func:`~QgsLayoutItemGuiRegistry.removeLayoutItemGuiMetadata`
+for every item types associated with the group.
 %End
 
     const QgsLayoutItemGuiGroup &itemGroup( const QString &id );
@@ -283,6 +300,17 @@ Returns a list of available item metadata ids handled by the registry.
 %Docstring
 Emitted whenever a new item type is added to the registry, with the
 specified ``metadataId``.
+%End
+
+    void typeRemoved( int metadataId );
+%Docstring
+Emitted whenever an item type is removed from the registry, with the
+specified ``metadataId``.
+%End
+
+    void groupRemoved( QString groupId );
+%Docstring
+Emitted whenever an item group is removed from the registry
 %End
 
   private:

--- a/python/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutitemguiregistry.sip.in
@@ -220,18 +220,25 @@ Returns -1 if no matching metadata is found in the GUI registry.
 
     bool addLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata /Transfer/ );
 %Docstring
-Registers the gui metadata for a new layout item type. Takes ownership
+Registers the GUI metadata for a new layout item type. Takes ownership
 of the metadata instance.
 %End
 
     bool removeLayoutItemGuiMetadata( int type );
 %Docstring
-Unregisters the gui metadata for a layout item type.
+Unregisters the GUI metadata for a layout item type.
+
+.. versionadded:: 4.0
 %End
 
     bool removeLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata );
 %Docstring
-Unregisters the gui metadata for a layout item type.
+Unregisters the GUI metadata for a layout item type.
+
+The ``metadata`` object will be deleted and should not be used after
+this call.
+
+.. versionadded:: 4.0
 %End
 
     bool addItemGroup( const QgsLayoutItemGuiGroup &group );
@@ -248,9 +255,13 @@ added (e.g. due to duplicate id value).
 
     bool removeItemGroup( const QString &id );
 %Docstring
-Unregisters a item group from the registry. This must be done after
-calling :py:func:`~QgsLayoutItemGuiRegistry.removeLayoutItemGuiMetadata`
-for every item types associated with the group.
+Unregisters an item group from the registry.
+
+This must be done after calling
+:py:func:`~QgsLayoutItemGuiRegistry.removeLayoutItemGuiMetadata` for
+every item types associated with the group.
+
+.. versionadded:: 4.0
 %End
 
     const QgsLayoutItemGuiGroup &itemGroup( const QString &id );
@@ -306,11 +317,15 @@ specified ``metadataId``.
 %Docstring
 Emitted whenever an item type is removed from the registry, with the
 specified ``metadataId``.
+
+.. versionadded:: 4.0
 %End
 
     void groupRemoved( QString groupId );
 %Docstring
-Emitted whenever an item group is removed from the registry
+Emitted whenever an item group is removed from the registry.
+
+.. versionadded:: 4.0
 %End
 
   private:

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -365,6 +365,8 @@ class QgsLayoutDesignerDialog : public QMainWindow, public Ui::QgsLayoutDesigner
     void setTitle( const QString &title );
 
     void itemTypeAdded( int id );
+    void itemTypeRemoved( int id );
+    void itemGroupRemoved( const QString &groupId );
     void statusZoomCombo_currentIndexChanged( int index );
     void statusZoomCombo_zoomEntered();
     void sliderZoomChanged( int value );

--- a/src/core/layout/qgslayoutitemregistry.cpp
+++ b/src/core/layout/qgslayoutitemregistry.cpp
@@ -115,7 +115,7 @@ bool QgsLayoutItemRegistry::removeLayoutItemType( int typeId )
   if ( !mMetadata.contains( typeId ) )
     return false;
   mMetadata.remove( typeId );
-  emit multiFrameTypeRemoved( typeId );
+  emit typeRemoved( typeId );
   return true;
 }
 
@@ -139,7 +139,7 @@ bool QgsLayoutItemRegistry::removeLayoutMultiFrameType( int typeId )
   if ( !mMultiFrameMetadata.contains( typeId ) )
     return false;
   mMultiFrameMetadata.remove( typeId );
-  emit typeRemoved( typeId );
+  emit multiFrameTypeRemoved( typeId );
   return true;
 }
 

--- a/src/core/layout/qgslayoutitemregistry.cpp
+++ b/src/core/layout/qgslayoutitemregistry.cpp
@@ -110,6 +110,20 @@ bool QgsLayoutItemRegistry::addLayoutItemType( QgsLayoutItemAbstractMetadata *me
   return true;
 }
 
+bool QgsLayoutItemRegistry::removeLayoutItemType( int typeId )
+{
+  if ( !mMetadata.contains( typeId ) )
+    return false;
+  mMetadata.remove( typeId );
+  emit typeRemoved( typeId );
+  return true;
+}
+
+bool QgsLayoutItemRegistry::removeLayoutItemType( QgsLayoutItemAbstractMetadata *metadata )
+{
+  return removeLayoutItemType( metadata->type() );
+}
+
 bool QgsLayoutItemRegistry::addLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata )
 {
   if ( !metadata || mMultiFrameMetadata.contains( metadata->type() ) )
@@ -118,6 +132,20 @@ bool QgsLayoutItemRegistry::addLayoutMultiFrameType( QgsLayoutMultiFrameAbstract
   mMultiFrameMetadata[metadata->type()] = metadata;
   emit multiFrameTypeAdded( metadata->type(), metadata->visibleName() );
   return true;
+}
+
+bool QgsLayoutItemRegistry::removeLayoutMultiFrameType( int typeId )
+{
+  if ( !mMultiFrameMetadata.contains( typeId ) )
+    return false;
+  mMultiFrameMetadata.remove( typeId );
+  emit typeRemoved( typeId );
+  return true;
+}
+
+bool QgsLayoutItemRegistry::removeLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata )
+{
+  return removeLayoutMultiFrameType( metadata->type() );
 }
 
 QgsLayoutItem *QgsLayoutItemRegistry::createItem( int type, QgsLayout *layout ) const

--- a/src/core/layout/qgslayoutitemregistry.cpp
+++ b/src/core/layout/qgslayoutitemregistry.cpp
@@ -115,7 +115,7 @@ bool QgsLayoutItemRegistry::removeLayoutItemType( int typeId )
   if ( !mMetadata.contains( typeId ) )
     return false;
   mMetadata.remove( typeId );
-  emit typeRemoved( typeId );
+  emit multiFrameTypeRemoved( typeId );
   return true;
 }
 

--- a/src/core/layout/qgslayoutitemregistry.h
+++ b/src/core/layout/qgslayoutitemregistry.h
@@ -429,22 +429,34 @@ class CORE_EXPORT QgsLayoutItemRegistry : public QObject
     bool addLayoutItemType( QgsLayoutItemAbstractMetadata *metadata SIP_TRANSFER );
 
     /**
-     * Unregisters a layout item type
+     * Unregisters a layout item type.
+     *
+     * \since QGIS 4.0
      */
     bool removeLayoutItemType( int typeId );
 
     /**
-     * Unregisters a layout item type
+     * Unregisters a layout item type.
+     *
+     * The \a metadata object will be deleted and should not be used after this call.
+     *
+     * \since QGIS 4.0
      */
     bool removeLayoutItemType( QgsLayoutItemAbstractMetadata *metadata );
 
     /**
-     * Unregisters a layout multiframe type
+     * Unregisters a layout multiframe type.
+     *
+     * \since QGIS 4.0
      */
     bool removeLayoutMultiFrameType( int typeId );
 
     /**
-     * Unregisters a layout multiframe type
+     * Unregisters a layout multiframe type.
+     *
+     * The \a metadata object will be deleted and should not be used after this call.
+     *
+     * \since QGIS 4.0
      */
     bool removeLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata );
 
@@ -488,7 +500,9 @@ class CORE_EXPORT QgsLayoutItemRegistry : public QObject
 
     /**
      * Emitted whenever an item type is removed from the registry with the specified
-     * \a type
+     * \a type.
+     *
+     * \since QGIS 4.0
      */
     void typeRemoved( int type );
 
@@ -497,6 +511,14 @@ class CORE_EXPORT QgsLayoutItemRegistry : public QObject
      * \a type and visible \a name.
      */
     void multiFrameTypeAdded( int type, const QString &name );
+
+    /**
+     * Emitted whenever an multiframe type is removed from the registry with the specified
+     * \a type.
+     *
+     * \since QGIS 4.0
+     */
+    void multiFrameTypeRemoved( int type );
 
   private:
 #ifdef SIP_RUN

--- a/src/core/layout/qgslayoutitemregistry.h
+++ b/src/core/layout/qgslayoutitemregistry.h
@@ -429,6 +429,26 @@ class CORE_EXPORT QgsLayoutItemRegistry : public QObject
     bool addLayoutItemType( QgsLayoutItemAbstractMetadata *metadata SIP_TRANSFER );
 
     /**
+     * Unregisters a layout item type
+     */
+    bool removeLayoutItemType( int typeId );
+
+    /**
+     * Unregisters a layout item type
+     */
+    bool removeLayoutItemType( QgsLayoutItemAbstractMetadata *metadata );
+
+    /**
+     * Unregisters a layout multiframe type
+     */
+    bool removeLayoutMultiFrameType( int typeId );
+
+    /**
+     * Unregisters a layout multiframe type
+     */
+    bool removeLayoutMultiFrameType( QgsLayoutMultiFrameAbstractMetadata *metadata );
+
+    /**
      * Registers a new layout multiframe type. Takes ownership of the metadata instance.
      * \see addLayoutItemType()
      */
@@ -465,6 +485,12 @@ class CORE_EXPORT QgsLayoutItemRegistry : public QObject
      * \a type and visible \a name.
      */
     void typeAdded( int type, const QString &name );
+
+    /**
+     * Emitted whenever an item type is removed from the registry with the specified
+     * \a type
+     */
+    void typeRemoved( int type );
 
     /**
      * Emitted whenever a new multiframe type is added to the registry, with the specified

--- a/src/gui/layout/qgslayoutitemguiregistry.cpp
+++ b/src/gui/layout/qgslayoutitemguiregistry.cpp
@@ -89,6 +89,23 @@ bool QgsLayoutItemGuiRegistry::addLayoutItemGuiMetadata( QgsLayoutItemAbstractGu
   return true;
 }
 
+bool QgsLayoutItemGuiRegistry::removeLayoutItemGuiMetadata( int typeId )
+{
+  int metadataId = metadataIdForItemType( typeId );
+  if ( !mMetadata.contains( metadataId ) )
+    return false;
+  mMetadata.remove( metadataId );
+  emit typeRemoved( metadataId );
+  return true;
+}
+
+bool QgsLayoutItemGuiRegistry::removeLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata )
+{
+  if ( !metadata )
+    return false;
+  return removeLayoutItemGuiMetadata( metadata->type() );
+}
+
 bool QgsLayoutItemGuiRegistry::addItemGroup( const QgsLayoutItemGuiGroup &group )
 {
   if ( mItemGroups.contains( group.id ) )
@@ -101,6 +118,16 @@ bool QgsLayoutItemGuiRegistry::addItemGroup( const QgsLayoutItemGuiGroup &group 
 const QgsLayoutItemGuiGroup &QgsLayoutItemGuiRegistry::itemGroup( const QString &id )
 {
   return mItemGroups[id];
+}
+
+bool QgsLayoutItemGuiRegistry::removeItemGroup( const QString &id )
+{
+  if ( !mItemGroups.contains( id ) )
+    return false;
+
+  mItemGroups.remove( id );
+  emit groupRemoved( id );
+  return true;
 }
 
 QgsLayoutItem *QgsLayoutItemGuiRegistry::createItem( int metadataId, QgsLayout *layout ) const

--- a/src/gui/layout/qgslayoutitemguiregistry.h
+++ b/src/gui/layout/qgslayoutitemguiregistry.h
@@ -414,6 +414,16 @@ class GUI_EXPORT QgsLayoutItemGuiRegistry : public QObject
     bool addLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata SIP_TRANSFER );
 
     /**
+     * Unregisters the gui metadata for a layout item type.
+     */
+    bool removeLayoutItemGuiMetadata( int type );
+
+    /**
+     * Unregisters the gui metadata for a layout item type.
+     */
+    bool removeLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata );
+
+    /**
      * Registers a new item group with the registry. This must be done before calling
      * addLayoutItemGuiMetadata() for any item types associated with the group.
      *
@@ -423,6 +433,13 @@ class GUI_EXPORT QgsLayoutItemGuiRegistry : public QObject
      * \see itemGroup()
      */
     bool addItemGroup( const QgsLayoutItemGuiGroup &group );
+
+    /**
+     * Unregisters a item group from the registry. This must be done after calling
+     * removeLayoutItemGuiMetadata() for every item types associated with the group.
+     *
+     */
+    bool removeItemGroup( const QString &id );
 
     /**
      * Returns a reference to the item group with matching \a id.
@@ -508,6 +525,17 @@ class GUI_EXPORT QgsLayoutItemGuiRegistry : public QObject
      * \a metadataId.
      */
     void typeAdded( int metadataId );
+
+    /**
+     * Emitted whenever an item type is removed from the registry, with the specified
+     * \a metadataId.
+     */
+    void typeRemoved( int metadataId );
+
+    /**
+     * Emitted whenever an item group is removed from the registry
+     */
+    void groupRemoved( QString groupId );
 
   private:
 #ifdef SIP_RUN

--- a/src/gui/layout/qgslayoutitemguiregistry.h
+++ b/src/gui/layout/qgslayoutitemguiregistry.h
@@ -409,17 +409,23 @@ class GUI_EXPORT QgsLayoutItemGuiRegistry : public QObject
     int metadataIdForItemType( int type ) const;
 
     /**
-     * Registers the gui metadata for a new layout item type. Takes ownership of the metadata instance.
+     * Registers the GUI metadata for a new layout item type. Takes ownership of the metadata instance.
      */
     bool addLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata SIP_TRANSFER );
 
     /**
-     * Unregisters the gui metadata for a layout item type.
+     * Unregisters the GUI metadata for a layout item type.
+     *
+     * \since QGIS 4.0
      */
     bool removeLayoutItemGuiMetadata( int type );
 
     /**
-     * Unregisters the gui metadata for a layout item type.
+     * Unregisters the GUI metadata for a layout item type.
+     *
+     * The \a metadata object will be deleted and should not be used after this call.
+     *
+     * \since QGIS 4.0
      */
     bool removeLayoutItemGuiMetadata( QgsLayoutItemAbstractGuiMetadata *metadata );
 
@@ -435,9 +441,12 @@ class GUI_EXPORT QgsLayoutItemGuiRegistry : public QObject
     bool addItemGroup( const QgsLayoutItemGuiGroup &group );
 
     /**
-     * Unregisters a item group from the registry. This must be done after calling
+     * Unregisters an item group from the registry.
+     *
+     * This must be done after calling
      * removeLayoutItemGuiMetadata() for every item types associated with the group.
      *
+     * \since QGIS 4.0
      */
     bool removeItemGroup( const QString &id );
 
@@ -529,11 +538,15 @@ class GUI_EXPORT QgsLayoutItemGuiRegistry : public QObject
     /**
      * Emitted whenever an item type is removed from the registry, with the specified
      * \a metadataId.
+     * 
+     * \since QGIS 4.0
      */
     void typeRemoved( int metadataId );
 
     /**
-     * Emitted whenever an item group is removed from the registry
+     * Emitted whenever an item group is removed from the registry.
+     *
+     * \since QGIS 4.0
      */
     void groupRemoved( QString groupId );
 

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -244,7 +244,7 @@ void TestQgsLayoutItem::registry()
   QVERIFY( !registry.addLayoutItemType( metadata ) );
   QCOMPARE( spyTypeAdded.count(), 1 );
 
-  //retrieve metadata
+  // retrieve metadata
   QVERIFY( !registry.itemMetadata( -1 ) );
   QCOMPARE( registry.itemMetadata( 2 )->visibleName(), QStringLiteral( "my type" ) );
   QCOMPARE( registry.itemMetadata( 2 )->visiblePluralName(), QStringLiteral( "my types" ) );
@@ -261,7 +261,24 @@ void TestQgsLayoutItem::registry()
   registry.resolvePaths( 2, props, QgsPathResolver(), true );
   QVERIFY( props.isEmpty() );
 
-  //test populate
+  // Test remove item type
+  QgsLayoutItemMetadata *metadata_42 = new QgsLayoutItemMetadata( 42, QStringLiteral( "my other type" ), QStringLiteral( "my other types" ), create, resolve );
+  QVERIFY( registry.addLayoutItemType( metadata_42 ) );
+  QCOMPARE( registry.itemTypes().count(), 2 );
+  QCOMPARE( spyTypeAdded.value( 1 ).at( 0 ).toInt(), 42 );
+
+  const QSignalSpy spyTypeRemoved( &registry, &QgsLayoutItemRegistry::typeRemoved );
+  QVERIFY( registry.removeLayoutItemType( 2 ) ); // Remove by id
+  QCOMPARE( spyTypeRemoved.count(), 1 );
+  QCOMPARE( spyTypeRemoved.value( 0 ).at( 0 ).toInt(), 2 );
+  QCOMPARE( registry.itemTypes().count(), 1 );
+
+  QVERIFY( registry.removeLayoutItemType( metadata_42 ) ); // Remove by metadata
+  QCOMPARE( spyTypeRemoved.count(), 2 );
+  QCOMPARE( spyTypeRemoved.value( 1 ).at( 0 ).toInt(), 42 );
+  QCOMPARE( registry.itemTypes().count(), 0 );
+
+  // test populate
   QgsLayoutItemRegistry reg2;
   QVERIFY( reg2.itemTypes().isEmpty() );
   QVERIFY( reg2.populate() );

--- a/tests/src/core/testqgslayoutmultiframe.cpp
+++ b/tests/src/core/testqgslayoutmultiframe.cpp
@@ -538,6 +538,23 @@ void TestQgsLayoutMultiFrame::registry()
   QCOMPARE( props.size(), 1 );
   registry.resolvePaths( QgsLayoutItemRegistry::PluginItem + 1, props, QgsPathResolver(), true );
   QVERIFY( props.isEmpty() );
+
+  // Test remove multi frame type
+  QgsLayoutMultiFrameMetadata *metadata_42 = new QgsLayoutMultiFrameMetadata( QgsLayoutItemRegistry::PluginItem + 42, QStringLiteral( "TestMultiFrame42" ), create, resolve );
+  QVERIFY( registry.addLayoutMultiFrameType( metadata_42 ) );
+  QCOMPARE( registry.itemTypes().count(), 2 );
+  QCOMPARE( spyTypeAdded.value( 1 ).at( 0 ).toInt(), QgsLayoutItemRegistry::PluginItem + 42 );
+
+  const QSignalSpy spyTypeRemoved( &registry, &QgsLayoutItemRegistry::multiFrameTypeRemoved );
+  QVERIFY( registry.removeLayoutMultiFrameType( QgsLayoutItemRegistry::PluginItem + 1 ) ); // Remove by id
+  QCOMPARE( spyTypeRemoved.count(), 1 );
+  QCOMPARE( spyTypeRemoved.value( 0 ).at( 0 ).toInt(), QgsLayoutItemRegistry::PluginItem + 1 );
+  QCOMPARE( registry.itemTypes().count(), 1 );
+
+  QVERIFY( registry.removeLayoutMultiFrameType( metadata_42 ) ); // Remove by metadata
+  QCOMPARE( spyTypeRemoved.count(), 2 );
+  QCOMPARE( spyTypeRemoved.value( 1 ).at( 0 ).toInt(), QgsLayoutItemRegistry::PluginItem + 42 );
+  QCOMPARE( registry.itemTypes().count(), 0 );
 }
 
 void TestQgsLayoutMultiFrame::deleteFrame()

--- a/tests/src/gui/testqgslayoutview.cpp
+++ b/tests/src/gui/testqgslayoutview.cpp
@@ -328,6 +328,27 @@ void TestQgsLayoutView::guiRegistry()
   QCOMPARE( item->type(), QgsLayoutItemRegistry::LayoutItem + 101 );
   QCOMPARE( static_cast<TestItem *>( item )->mFlag, 2 );
   delete item;
+
+  // test removing item metadata
+  QCOMPARE( registry.itemMetadataIds().count(), 3 );
+  const QSignalSpy spyTypeRemoved( &registry, &QgsLayoutItemGuiRegistry::typeRemoved );
+  QVERIFY( registry.removeLayoutItemGuiMetadata( QgsLayoutItemRegistry::LayoutItem + 101 ) );
+  QCOMPARE( registry.itemMetadataIds().count(), 2 );
+  QVERIFY( registry.removeLayoutItemGuiMetadata( QgsLayoutItemRegistry::LayoutItem + 101 ) );
+  QCOMPARE( registry.itemMetadataIds().count(), 1 );
+  QVERIFY( registry.removeLayoutItemGuiMetadata( QgsLayoutItemRegistry::LayoutItem + 101 ) );
+  QCOMPARE( registry.itemMetadataIds().count(), 0 );
+  QCOMPARE( registry.removeLayoutItemGuiMetadata( QgsLayoutItemRegistry::LayoutItem + 101 ), false );
+  QCOMPARE( spyTypeRemoved.count(), 3 );
+  QCOMPARE( registry.itemMetadataIds().count(), 0 );
+
+  // test removing item group
+  const QSignalSpy spyGroupRemoved( &registry, &QgsLayoutItemGuiRegistry::groupRemoved );
+  QVERIFY( registry.removeItemGroup( QStringLiteral( "g1" ) ) );
+  QCOMPARE( spyGroupRemoved.count(), 1 );
+  QCOMPARE( spyGroupRemoved.at( 0 ).at( 0 ).toString(), QStringLiteral( "g1" ) );
+  // can't remove group again
+  QVERIFY( !registry.removeItemGroup( QStringLiteral( "g1" ) ) );
 }
 
 void TestQgsLayoutView::rubberBand()


### PR DESCRIPTION
## Description

When a plugin registers custom layout items, there's currently no way to unload them when the plugin is unloaded/uninstalled. 

This also makes developping plugins that adds custom print layout item quite painful.

This PR adds several method to unregister items:
- `QgsLayoutItemRegistry::removeLayoutItemType`: Unregister a custom item from the registry
- `QgsLayoutItemRegistry::removeLayoutMultiFrameType`: Same, but for QgsLayoutMultiFrames
- `QgsLayoutItemGuiRegistry::removeLayoutItemGuiMetadata`: Remove tool button & menu in the layout designer
- `QgsLayoutItemGuiRegistry::removeItemGroup`: Remove the parent menu and button (if any)



### Plugin Init

```python
metadata = MyCustomItemMetadata()
QgsApplication.layoutItemRegistry().addLayoutItemType(MyCustomItemMetadata())

gui_metadata = MyCustomItemGuiMetadata()
registry = QgsGui.layoutItemGuiRegistry()
registry.addItemGroup(QgsLayoutItemGuiGroup(gui_metadata.groupId(), "My Group", QIcon("/path/to/my/icon.svg"))
registry.addLayoutItemGuiMetadata(gui_metadata)
```

### Plugin unload

```python
gui_metadata = MyCustomItemGuiMetadata()
registry = QgsGui.removeLayoutItemGuiMetadata()
registry.removeItemGroup(gui_metadata.groupId())
registry.removeLayoutItemGuiMetadata(gui_metadata.type())

metadata = MyCustomItemMetadata()
QgsLayoutItemRegistry.removeLayoutItemType(metadata)
```

