### PR TITLE
Replace label in contextual menu of SQL History item

### DIFF
--- a/src/gui/qgsdbqueryhistoryprovider.cpp
+++ b/src/gui/qgsdbqueryhistoryprovider.cpp
@@ -164,13 +164,13 @@ class DatabaseQueryRootNode : public DatabaseQueryHistoryNode
     {
       if ( QgsDatabaseQueryHistoryWidget *queryHistoryWidget = qobject_cast< QgsDatabaseQueryHistoryWidget * >( context.historyWidget() ) )
       {
-        QAction *executeAction = new QAction(
-          QObject::tr( "Execute SQL Command…" ), menu
+        QAction *loadAction = new QAction(
+          QObject::tr( "Load SQL Command…" ), menu
         );
-        QObject::connect( executeAction, &QAction::triggered, menu, [this, queryHistoryWidget] {
+        QObject::connect( loadAction, &QAction::triggered, menu, [this, queryHistoryWidget] {
           queryHistoryWidget->emitSqlTriggered( mEntry.entry.value( QStringLiteral( "connection" ) ).toString(), mEntry.entry.value( QStringLiteral( "provider" ) ).toString(), mEntry.entry.value( QStringLiteral( "query" ) ).toString() );
         } );
-        menu->addAction( executeAction );
+        menu->addAction( loadAction );
       }
 
       QAction *copyAction = new QAction(


### PR DESCRIPTION
The query contextual menu item loads the query in the main widget, it does not execute it. It behaves the same as double-clicking the query.