### PR TITLE
update PDAL Wrench

### DIFF
--- a/external/pdal_wrench/alg.cpp
+++ b/external/pdal_wrench/alg.cpp
@@ -173,3 +173,15 @@ void removeFiles(const std::vector<std::string> &tileOutputFiles, bool removePar
         fs::remove(outputDir);
     }
 }
+
+fs::path fileStem(const std::string &filename)
+{
+    fs::path inputBasename = fs::path(filename).stem();
+            
+    while(inputBasename.has_extension())
+    {
+        inputBasename = inputBasename.stem(); 
+    }
+
+    return inputBasename;
+}

--- a/external/pdal_wrench/alg.hpp
+++ b/external/pdal_wrench/alg.hpp
@@ -93,6 +93,8 @@ bool runAlg(std::vector<std::string> args, Alg &alg);
 
 void removeFiles(const std::vector<std::string> &tileOutputFiles, bool removeParentDirIfEmpty = true);
 
+fs::path fileStem(const std::string &filename);
+
 //////////////
 
 

--- a/external/pdal_wrench/clip.cpp
+++ b/external/pdal_wrench/clip.cpp
@@ -191,7 +191,7 @@ void Clip::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipel
 
             // for input file /x/y/z.las that goes to /tmp/hello.vpc,
             // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fs::path(f.filename).stem();
+            fs::path inputBasename = fileStem(f.filename);
             
             // if the output is not VPC  las file format is forced to avoid time spent on compression, files will be later merged into single output and removed anyways
             if (!ends_with(outputFile, ".vpc"))

--- a/external/pdal_wrench/thin.cpp
+++ b/external/pdal_wrench/thin.cpp
@@ -167,7 +167,7 @@ void Thin::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipel
 
             // for input file /x/y/z.las that goes to /tmp/hello.vpc,
             // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fs::path(f.filename).stem();
+            fs::path inputBasename = fileStem(f.filename);
 
             if (!ends_with(outputFile, ".vpc"))
                 tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";

--- a/external/pdal_wrench/to_vector.cpp
+++ b/external/pdal_wrench/to_vector.cpp
@@ -112,7 +112,7 @@ void ToVector::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& p
 
             // for input file /x/y/z.las that goes to /tmp/hello.vpc,
             // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fs::path(f.filename).stem();
+            fs::path inputBasename = fileStem(f.filename);
             tile.outputFilename = (outputSubdir / inputBasename).string() + ".gpkg";
 
             tileOutputFiles.push_back(tile.outputFilename);

--- a/external/pdal_wrench/translate.cpp
+++ b/external/pdal_wrench/translate.cpp
@@ -169,12 +169,12 @@ void Translate::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& 
 
             // for input file /x/y/z.las that goes to /tmp/hello.vpc,
             // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fs::path(f.filename).stem();
+            fs::path inputBasename = fileStem(f.filename);
 
             if (!ends_with(outputFile, ".vpc"))
                 tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
             else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + outputFormat;
+                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
 
             tileOutputFiles.push_back(tile.outputFilename);
 


### PR DESCRIPTION
## Description

Update to **PDAL WRENCH** version 1.2.1

Fixes several issues:

- main issue was in merge which did not run if the output was **copc.laz** that also caused issue in other tools as some of them use Merge as last step
-  for **VPC** there as an issue if the files in **VPC** were **.copc.laz** where the extensions were not stripped correctly for this the  `fs::path fileStem(const std::string &filename)` was introduced which should only return stem of file without any extensions - this avoids potentialy creating files with **.copc.las** extension that might confuse users

Fixes #62415 
