### PR TITLE
Make pdal provider get metadata from reader instead of table

### DIFF
--- a/src/providers/pdal/qgspdalprovider.cpp
+++ b/src/providers/pdal/qgspdalprovider.cpp
@@ -298,16 +298,10 @@ bool QgsPdalProvider::load( const QString &uri )
         options.add( pdal::Option( "filename", uri.toStdString() ) );
         reader->setOptions( std::move( options ) );
       }
-      pdal::PointTable table;
-      reader->prepare( table );
-
-      const std::string tableMetadata = pdal::Utils::toJSON( table.metadata() );
-      const QVariantMap readerMetadata = QgsJsonUtils::parseJson( tableMetadata ).toMap().value( QStringLiteral( "root" ) ).toMap();
-      // source metadata is only value present here!
-      if ( !readerMetadata.empty() )
-        mOriginalMetadata = readerMetadata.constBegin().value().toMap();
-
       const pdal::QuickInfo quickInfo( reader->preview() );
+      const std::string readerMetadata = pdal::Utils::toJSON( reader->getMetadata() );
+      mOriginalMetadata = QgsJsonUtils::parseJson( readerMetadata ).toMap();
+
       const double xmin = quickInfo.m_bounds.minx;
       const double xmax = quickInfo.m_bounds.maxx;
       const double ymin = quickInfo.m_bounds.miny;


### PR DESCRIPTION
## Description
In recent pdal versions (2.9.0?) calling `reader.prepare()` will cause extra byte attributes to be listed twice, causing `reader.preview()` to fail.
We can get the metadata directly from the reader instead.

Fixes #62496

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
