### PR TITLE
Do not hardcode vector layer properties dialog icon

### DIFF
--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -19,10 +19,6 @@
   <property name="windowTitle">
    <string>Layer Properties</string>
   </property>
-  <property name="windowIcon">
-   <iconset resource="../../images/images.qrc">
-    <normaloff>:/images/icons/qgis-icon-16x16.png</normaloff>:/images/icons/qgis-icon-16x16.png</iconset>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_26">
    <item>
     <widget class="QSplitter" name="mOptionsSplitter">


### PR DESCRIPTION
- Other dialogs (raster properties) don't hardcode it either
- The default is the qgis icon from the main app
- Specifically linking to a 16px version isn't nice
- Downstream apps might have different icons (discovered on kadas)