### PR TITLE
Fix rendering of VPCs when overview point cloud is missing

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -79,6 +79,7 @@ QgsPointCloudLayerRenderer::QgsPointCloudLayerRenderer( QgsPointCloudLayer *laye
 
   if ( const QgsVirtualPointCloudProvider *vpcProvider = dynamic_cast<QgsVirtualPointCloudProvider *>( layer->dataProvider() ) )
   {
+    mIsVpc = true;
     mAverageSubIndexWidth = vpcProvider->averageSubIndexWidth();
     mAverageSubIndexHeight = vpcProvider->averageSubIndexHeight();
     mOverviewIndex = vpcProvider->overview();
@@ -201,7 +202,7 @@ bool QgsPointCloudLayerRenderer::render()
   {
     canceled = !renderIndex( mIndex );
   }
-  else if ( mOverviewIndex )
+  else if ( mIsVpc )
   {
     QVector< QgsPointCloudSubIndex > visibleIndexes;
     for ( const QgsPointCloudSubIndex &si : mSubIndexes )
@@ -214,7 +215,7 @@ bool QgsPointCloudLayerRenderer::render()
     const bool zoomedOut = renderExtent.width() > mAverageSubIndexWidth ||
                            renderExtent.height() > mAverageSubIndexHeight;
     // if the overview of virtual point cloud exists, and we are zoomed out, we render just overview
-    if ( mOverviewIndex && zoomedOut &&
+    if ( mOverviewIndex && mOverviewIndex->isValid() && zoomedOut &&
          mRenderer->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverview )
     {
       renderIndex( *mOverviewIndex );
@@ -223,7 +224,7 @@ bool QgsPointCloudLayerRenderer::render()
     {
       // if the overview of virtual point cloud exists, and we are zoomed out, but we want both overview and extents,
       // we render overview
-      if ( mOverviewIndex && zoomedOut &&
+      if ( mOverviewIndex && mOverviewIndex->isValid() && zoomedOut &&
            mRenderer->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverviewAndExtents )
       {
         renderIndex( *mOverviewIndex );

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.h
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.h
@@ -96,6 +96,7 @@ class CORE_EXPORT QgsPointCloudLayerRenderer: public QgsMapLayerRenderer
     QgsGeometry mCloudExtent;
     QList< QgsMapClippingRegion > mClippingRegions;
 
+    bool mIsVpc = false;
     const QVector< QgsPointCloudSubIndex > mSubIndexes;
     std::optional<QgsPointCloudIndex> mOverviewIndex;
     double mAverageSubIndexWidth = 0;


### PR DESCRIPTION
Otherwise 2D rendering would not render anything (and even get stuck!)

If the overview point cloud is missing, `mOverviewIndex` will still evaluate to true, but it will not be valid. Also introduced `mIsVpc` flag, so it is clear when we are dealing with VPCs (rather than relying on `mOverviewIndex` which is slightly confusing, as overview point clouds are optional)