### PR TITLE
Add editor shortcuts to ShortcutsManager

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -327,8 +327,16 @@ class PythonConsoleWidget(QWidget):
         )
         self.toggleCommentEditorButton.setMenuRole(QAction.MenuRole.PreferencesRole)
         self.toggleCommentEditorButton.setIconVisibleInMenu(True)
-        self.toggleCommentEditorButton.setToolTip(toggleText + " <b>Ctrl+:</b>")
+        self.toggleCommentEditorButton.setShortcut(
+            self.shortcut("mEditorToggleComment", "Ctrl+/")
+        )
         self.toggleCommentEditorButton.setText(toggleText)
+        self.toggleCommentEditorButton.setToolTip(
+            "{} <b>{}</b>".format(
+                self.toggleCommentEditorButton.text(),
+                self.toggleCommentEditorButton.shortcut().toString(),
+            )
+        )
 
         # Action Format code
         reformatCodeText = QCoreApplication.translate("PythonConsole", "Reformat Code")
@@ -340,11 +348,16 @@ class PythonConsoleWidget(QWidget):
         )
         self.reformatCodeEditorButton.setMenuRole(QAction.MenuRole.PreferencesRole)
         self.reformatCodeEditorButton.setIconVisibleInMenu(True)
-        self.reformatCodeEditorButton.setToolTip(
-            reformatCodeText + " <b>Ctrl+Alt+F</b>"
+        self.reformatCodeEditorButton.setShortcut(
+            self.shortcut("mEditorToggleComment", "Ctrl+Alt+F")
         )
-        self.reformatCodeEditorButton.setShortcut("Ctrl+Alt+F")
         self.reformatCodeEditorButton.setText(reformatCodeText)
+        self.reformatCodeEditorButton.setToolTip(
+            "{} <b>{}</b>".format(
+                self.reformatCodeEditorButton.text(),
+                self.reformatCodeEditorButton.shortcut().toString(),
+            )
+        )
 
         # Action for Object browser
         objList = QCoreApplication.translate("PythonConsole", "Object Inspector…")
@@ -800,6 +813,12 @@ class PythonConsoleWidget(QWidget):
         self.splitterObj.restoreState(
             settings.value("pythonConsole/splitterObj", QByteArray())
         )
+
+    def shortcut(self, key, default):
+        action = QgsGui.shortcutsManager().actionByName(key)
+        if action:
+            return action.shortcut()
+        return QKeySequence(default)
 
 
 if __name__ == "__main__":

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -33,7 +33,7 @@ from operator import itemgetter
 from pathlib import Path
 
 from qgis.core import Qgis, QgsApplication, QgsBlockingNetworkRequest, QgsSettings
-from qgis.gui import QgsCodeEditorPython, QgsCodeEditorWidget, QgsMessageBar
+from qgis.gui import QgsCodeEditorPython, QgsCodeEditorWidget, QgsGui, QgsMessageBar
 
 from qgis.PyQt.Qsci import QsciScintilla
 from qgis.PyQt.QtCore import (
@@ -269,8 +269,24 @@ class Editor(QgsCodeEditorPython):
             menu,
         )
         toggle_comment_action.triggered.connect(self.toggleComment)
-        toggle_comment_action.setShortcut("Ctrl+:")
+        toggle_comment_action.setShortcut(
+            self.shortcut("mEditorToggleComment", "Ctrl+/")
+        )
         menu.addAction(toggle_comment_action)
+
+        reformat_code_action = QAction(
+            QgsApplication.getThemeIcon(
+                "console/iconFormatCode.svg",
+                self.palette().color(QPalette.ColorRole.WindowText),
+            ),
+            QCoreApplication.translate("PythonConsole", "Reformat Code"),
+            menu,
+        )
+        reformat_code_action.triggered.connect(self.reformatCode)
+        toggle_comment_action.setShortcut(
+            self.shortcut("mEditorReformatCode", "Ctrl+Alt+F")
+        )
+        menu.addAction(reformat_code_action)
 
         menu.addSeparator()
         gist_menu = QMenu(self)
@@ -540,6 +556,12 @@ class Editor(QgsCodeEditorPython):
         self, text: str, title: str | None = None, level=Qgis.MessageLevel.Info
     ):
         self.editor_tab.showMessage(text, level, title=title)
+
+    def shortcut(self, key, default):
+        action = QgsGui.shortcutsManager().actionByName(key)
+        if action:
+            return action.shortcut()
+        return QKeySequence(default)
 
 
 class EditorTab(QWidget):

--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -122,6 +122,12 @@ class ScriptEditorDialog(BASE, WIDGET):
                 self.palette().color(QPalette.ColorRole.WindowText),
             )
         )
+        self.actionReformatCode.setIcon(
+            QgsApplication.getThemeIcon(
+                "console/iconFormatCode.svg",
+                self.palette().color(QPalette.ColorRole.WindowText),
+            )
+        )
 
         # Connect signals and slots
         self.actionOpenScript.triggered.connect(self.openScript)
@@ -143,6 +149,7 @@ class ScriptEditorDialog(BASE, WIDGET):
         self.actionIncreaseFontSize.triggered.connect(self.editor.zoomIn)
         self.actionDecreaseFontSize.triggered.connect(self.editor.zoomOut)
         self.actionToggleComment.triggered.connect(self.editor.toggleComment)
+        self.actionReformatCode.triggered.connect(self.editor.reformatCode)
         self.editor.modificationChanged.connect(self._on_text_modified)
 
         self.run_dialog = None

--- a/python/plugins/processing/ui/DlgScriptEditor.ui
+++ b/python/plugins/processing/ui/DlgScriptEditor.ui
@@ -61,6 +61,7 @@
    <addaction name="actionDecreaseFontSize"/>
    <addaction name="separator"/>
    <addaction name="actionToggleComment"/>
+   <addaction name="actionReformatCode"/>
   </widget>
   <action name="actionOpenScript">
    <property name="text">
@@ -188,6 +189,11 @@
   <action name="actionToggleComment">
    <property name="text">
     <string>Toggle Comment</string>
+   </property>
+  </action>
+  <action name="actionReformatCode">
+   <property name="text">
+    <string>Reformat Code</string>
    </property>
   </action>
  </widget>

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1877,6 +1877,18 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
   registerShortcuts( QStringLiteral( "Ctrl+Alt+," ), QStringLiteral( "mProfileToolNudgeLeft" ), tr( "Nudge profile tool curve to the left" ) );
   registerShortcuts( QStringLiteral( "Ctrl+Alt+." ), QStringLiteral( "mProfileToolNudgeRight" ), tr( "Nudge profile tool curve to the right" ) );
 
+  // Register editor actions
+  auto registerEditorAction = [=]( const QIcon &icon, const QString &text, const QString &sequence, const QString &objectName ) {
+    QAction *action = new QAction( icon, text, this );
+    setObjectName( objectName );
+    // We do not want these actions to be enabled, they are just there to be able to change
+    // the shortcuts in the Shortcuts Manager.
+    action->setEnabled( false );
+    QgsGui::shortcutsManager()->registerAction( action, sequence, QStringLiteral( "Editor" ) );
+  };
+  registerEditorAction( QgsApplication::getThemeIcon( QStringLiteral( "console/iconCommentEditorConsole.svg" ) ), tr( "Toggle Comment" ), QStringLiteral( "Ctrl+/" ), QStringLiteral( "mEditorToggleComment" ) );
+  registerEditorAction( QgsApplication::getThemeIcon( QStringLiteral( "console/iconFormatCode.svg" ) ), tr( "Reformat Code" ), QStringLiteral( "Ctrl+Alt+F" ), QStringLiteral( "mEditorReformatCode" ) );
+
   QgsGui::providerGuiRegistry()->registerGuis( this );
 
   setupLayoutManagerConnections();

--- a/src/gui/qgsshortcutsmanager.cpp
+++ b/src/gui/qgsshortcutsmanager.cpp
@@ -93,7 +93,7 @@ bool QgsShortcutsManager::registerAction( QAction *action, const QString &defaul
     QgsLogger::warning( QStringLiteral( "Duplicate shortcut registered: %1" ).arg( key ) );
 #endif
 
-  const QString settingKey = mSettingsPath + section + key;
+  const QString settingKey = mSettingsPath + ( section.isEmpty() || section.endsWith( QStringLiteral( "/" ) ) ? section : section + QStringLiteral( "/" ) ) + key;
 
   mActions.insert( action, { defaultSequence, settingKey } );
   connect( action, &QObject::destroyed, this, [action, this]() { actionDestroyed( action ); } );
@@ -129,8 +129,7 @@ bool QgsShortcutsManager::registerShortcut( QShortcut *shortcut, const QString &
   else if ( actionByName( shortcut->objectName() ) || shortcutByName( shortcut->objectName() ) )
     QgsLogger::warning( QStringLiteral( "Duplicate shortcut registered: %1" ).arg( shortcut->objectName() ) );
 #endif
-
-  const QString settingKey = mSettingsPath + section + shortcut->objectName();
+  const QString settingKey = mSettingsPath + ( section.isEmpty() || section.endsWith( QStringLiteral( "/" ) ) ? section : section + QStringLiteral( "/" ) ) + shortcut->objectName();
 
   mShortcuts.insert( shortcut, { defaultSequence, settingKey } );
   connect( shortcut, &QObject::destroyed, this, [shortcut, this]() { shortcutDestroyed( shortcut ); } );


### PR DESCRIPTION
- Fix #61355

## Description

Make "Toggle Comment" and "reformat code" QgsCodeEditor actions customizable from the ShortcutsManager.
Also change Toggle Comment default shortcut from `Ctrl+:` to `Ctrl+/`