### PR TITLE
remove output annotation from dijkstra declaration as they can not be used with the %MethodCode

### DIFF
--- a/python/PyQt6/analysis/auto_generated/network/qgsgraphanalyzer.sip.in
+++ b/python/PyQt6/analysis/auto_generated/network/qgsgraphanalyzer.sip.in
@@ -21,20 +21,19 @@ points using different strategies with Dijkstra's algorithm.
 #include "qgsgraphanalyzer.h"
 %End
   public:
-    static SIP_PYLIST  dijkstra( const QgsGraph *source, int startVertexIdx, int criterionNum, QVector<int> *resultTree /Out/ = 0, QVector<double> *resultCost /Out/ = 0 );
+    static SIP_PYLIST  dijkstra( const QgsGraph *source, int startVertexIdx, int criterionNum, QVector<int> *resultTree = 0, QVector<double> *resultCost = 0 );
 %Docstring
 Solve shortest path problem using Dijkstra algorithm
 
 :param source: source graph
 :param startVertexIdx: index of the start vertex
 :param criterionNum: index of the optimization strategy
-
-:return: - resultTree: array that represents shortest path tree.
-           resultTree[ vertexIndex ] == inboundingArcIndex if vertex
-           reachable, otherwise resultTree[ vertexIndex ] == -1. Note
-           that the startVertexIdx will also have a value of -1 and may
-           need special handling by callers.
-         - resultCost: array of the paths costs
+:param resultTree: array that represents shortest path tree. resultTree[
+                   vertexIndex ] == inboundingArcIndex if vertex
+                   reachable, otherwise resultTree[ vertexIndex ] == -1.
+                   Note that the startVertexIdx will also have a value
+                   of -1 and may need special handling by callers.
+:param resultCost: array of the paths costs
 %End
 
 %MethodCode

--- a/python/analysis/auto_generated/network/qgsgraphanalyzer.sip.in
+++ b/python/analysis/auto_generated/network/qgsgraphanalyzer.sip.in
@@ -21,20 +21,19 @@ points using different strategies with Dijkstra's algorithm.
 #include "qgsgraphanalyzer.h"
 %End
   public:
-    static SIP_PYLIST  dijkstra( const QgsGraph *source, int startVertexIdx, int criterionNum, QVector<int> *resultTree /Out/ = 0, QVector<double> *resultCost /Out/ = 0 );
+    static SIP_PYLIST  dijkstra( const QgsGraph *source, int startVertexIdx, int criterionNum, QVector<int> *resultTree = 0, QVector<double> *resultCost = 0 );
 %Docstring
 Solve shortest path problem using Dijkstra algorithm
 
 :param source: source graph
 :param startVertexIdx: index of the start vertex
 :param criterionNum: index of the optimization strategy
-
-:return: - resultTree: array that represents shortest path tree.
-           resultTree[ vertexIndex ] == inboundingArcIndex if vertex
-           reachable, otherwise resultTree[ vertexIndex ] == -1. Note
-           that the startVertexIdx will also have a value of -1 and may
-           need special handling by callers.
-         - resultCost: array of the paths costs
+:param resultTree: array that represents shortest path tree. resultTree[
+                   vertexIndex ] == inboundingArcIndex if vertex
+                   reachable, otherwise resultTree[ vertexIndex ] == -1.
+                   Note that the startVertexIdx will also have a value
+                   of -1 and may need special handling by callers.
+:param resultCost: array of the paths costs
 %End
 
 %MethodCode

--- a/src/analysis/network/qgsgraphanalyzer.h
+++ b/src/analysis/network/qgsgraphanalyzer.h
@@ -40,7 +40,7 @@ class ANALYSIS_EXPORT QgsGraphAnalyzer
      * Note that the startVertexIdx will also have a value of -1 and may need special handling by callers.
      * \param resultCost array of the paths costs
      */
-    static void SIP_PYALTERNATIVETYPE( SIP_PYLIST ) dijkstra( const QgsGraph *source, int startVertexIdx, int criterionNum, QVector<int> *resultTree SIP_OUT = nullptr, QVector<double> *resultCost SIP_OUT = nullptr );
+    static void SIP_PYALTERNATIVETYPE( SIP_PYLIST ) dijkstra( const QgsGraph *source, int startVertexIdx, int criterionNum, QVector<int> *resultTree = nullptr, QVector<double> *resultCost = nullptr );
 
 #ifdef SIP_RUN
     //%MethodCode


### PR DESCRIPTION
## Description

Remove `SIP_OUT` annotations added in #62316, as they don't play well with `%MethodCode` and result in incorrect output (tuple of four lists instead of tuple of two lists).