### PR TITLE
fix double event when saving changes in options

### DIFF
--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -191,6 +191,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
         return;
       }
     }
+    saveOptions();
     accept();
   } );
 
@@ -200,7 +201,6 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   connect( cmbIconSize, qOverload<int>( &QComboBox::highlighted ), this, &QgsOptions::iconSizeChanged );
   connect( cmbIconSize, &QComboBox::editTextChanged, this, &QgsOptions::iconSizeChanged );
 
-  connect( this, &QDialog::accepted, this, &QgsOptions::saveOptions );
   connect( this, &QDialog::rejected, this, &QgsOptions::rejectOptions );
 
   QStringList styles = QStyleFactory::keys();
@@ -1466,15 +1466,6 @@ void QgsOptions::selectProjectOnLaunch()
 
 void QgsOptions::saveOptions()
 {
-  for ( QgsOptionsPageWidget *widget : std::as_const( mAdditionalOptionWidgets ) )
-  {
-    if ( !widget->isValid() )
-    {
-      setCurrentPage( widget->objectName() );
-      return;
-    }
-  }
-
   QgsSettings settings;
 
   mSettings->setValue( QStringLiteral( "UI/UITheme" ), cmbUITheme->currentText() );


### PR DESCRIPTION
fix #57239 

`connect `on `QDialog:accepted` is not needed, as the dialog is accepted in the `connect( mOptButtonBox )`.
This triggers the `saveOptions `function twice on Windows, but not on Linux.
The result was double creation of user defined CRS or double deletion of the user created CRS along with all the other options being saved twice, thus wasting time.

Why this didn't affect Linux, I have a guess, but am not sure.
Fix was tested on both Windows and Linux.

Backport is requested.