### PR TITLE
Fix 2d => 3d sync

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -237,8 +237,8 @@ void Qgs3DMapScene::setViewFrom2DExtent( const QgsRectangle &extent )
   QgsPointXY center = extent.center();
   const QgsVector3D origin = mMap.origin();
 
-  const QgsVector3D p1 = mMap.mapToWorldCoordinates( QVector3D( extent.xMinimum(), extent.yMinimum(), 0 ) );
-  const QgsVector3D p2 = mMap.mapToWorldCoordinates( QVector3D( extent.xMaximum(), extent.yMaximum(), 0 ) );
+  const QgsVector3D p1 = mMap.mapToWorldCoordinates( QgsVector3D( extent.xMinimum(), extent.yMinimum(), 0 ) );
+  const QgsVector3D p2 = mMap.mapToWorldCoordinates( QgsVector3D( extent.xMaximum(), extent.yMaximum(), 0 ) );
 
   const float xSide = std::abs( p1.x() - p2.x() );
   const float ySide = std::abs( p1.z() - p2.z() );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -245,7 +245,7 @@ void Qgs3DMapScene::setViewFrom2DExtent( const QgsRectangle &extent )
   const double side = std::max( xSide, ySide );
 
   const double fov = qDegreesToRadians( cameraController()->camera()->fieldOfView() );
-  const double distance = side / 2.0f / std::tan( fov / 2.0f );
+  double distance = side / 2.0f / std::tan( fov / 2.0f );
 
   // adjust by elevation
   const QgsDoubleRange zRange = elevationRange();

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -240,11 +240,11 @@ void Qgs3DMapScene::setViewFrom2DExtent( const QgsRectangle &extent )
   const QgsVector3D p1 = mMap.mapToWorldCoordinates( QgsVector3D( extent.xMinimum(), extent.yMinimum(), 0 ) );
   const QgsVector3D p2 = mMap.mapToWorldCoordinates( QgsVector3D( extent.xMaximum(), extent.yMaximum(), 0 ) );
 
-  const float xSide = std::abs( p1.x() - p2.x() );
-  const float ySide = std::abs( p1.y() - p2.y() );
-  const float side = std::max( xSide, ySide );
+  const double xSide = std::abs( p1.x() - p2.x() );
+  const double ySide = std::abs( p1.y() - p2.y() );
+  const double side = std::max( xSide, ySide );
 
-  const float fov = qDegreesToRadians( cameraController()->camera()->fieldOfView() );
+  const double fov = qDegreesToRadians( cameraController()->camera()->fieldOfView() );
   float distance = side / 2.0f / std::tan( fov / 2.0f );
 
   // adjust by elevation

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -245,18 +245,18 @@ void Qgs3DMapScene::setViewFrom2DExtent( const QgsRectangle &extent )
   const double side = std::max( xSide, ySide );
 
   const double fov = qDegreesToRadians( cameraController()->camera()->fieldOfView() );
-  float distance = side / 2.0f / std::tan( fov / 2.0f );
+  const double distance = side / 2.0f / std::tan( fov / 2.0f );
 
   // adjust by elevation
   const QgsDoubleRange zRange = elevationRange();
   if ( !zRange.isInfinite() )
-    distance += static_cast<float>( zRange.upper() );
+    distance += zRange.upper();
 
   // subtract map origin so coordinates are relative to it
   mCameraController->setViewFromTop(
     static_cast<float>( center.x() - origin.x() ),
     static_cast<float>( center.y() - origin.y() ),
-    distance
+    static_cast<float>( distance )
   );
 }
 

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -241,7 +241,7 @@ void Qgs3DMapScene::setViewFrom2DExtent( const QgsRectangle &extent )
   const QgsVector3D p2 = mMap.mapToWorldCoordinates( QgsVector3D( extent.xMaximum(), extent.yMaximum(), 0 ) );
 
   const float xSide = std::abs( p1.x() - p2.x() );
-  const float ySide = std::abs( p1.z() - p2.z() );
+  const float ySide = std::abs( p1.y() - p2.y() );
   const float side = std::max( xSide, ySide );
 
   const float fov = qDegreesToRadians( cameraController()->camera()->fieldOfView() );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -235,24 +235,29 @@ void Qgs3DMapScene::viewZoomFull()
 void Qgs3DMapScene::setViewFrom2DExtent( const QgsRectangle &extent )
 {
   QgsPointXY center = extent.center();
-  QgsVector3D centerWorld = mMap.mapToWorldCoordinates( QVector3D( center.x(), center.y(), 0 ) );
+  QgsVector3D origin = mMap.origin();
+
   QgsVector3D p1 = mMap.mapToWorldCoordinates( QVector3D( extent.xMinimum(), extent.yMinimum(), 0 ) );
   QgsVector3D p2 = mMap.mapToWorldCoordinates( QVector3D( extent.xMaximum(), extent.yMaximum(), 0 ) );
 
   float xSide = std::abs( p1.x() - p2.x() );
   float ySide = std::abs( p1.z() - p2.z() );
-  if ( xSide < ySide )
-  {
-    float fov = 2 * std::atan( std::tan( qDegreesToRadians( cameraController()->camera()->fieldOfView() ) / 2 ) * cameraController()->camera()->aspectRatio() );
-    float r = xSide / 2.0f / std::tan( fov / 2.0f );
-    mCameraController->setViewFromTop( centerWorld.x(), centerWorld.z(), r );
-  }
-  else
-  {
-    float fov = qDegreesToRadians( cameraController()->camera()->fieldOfView() );
-    float r = ySide / 2.0f / std::tan( fov / 2.0f );
-    mCameraController->setViewFromTop( centerWorld.x(), centerWorld.z(), r );
-  }
+  float side = std::max( xSide, ySide );
+
+  float fov = qDegreesToRadians( cameraController()->camera()->fieldOfView() );
+  float r = side / 2.0f / std::tan( fov / 2.0f );
+
+  // adjust by elevation
+  const QgsDoubleRange zRange = elevationRange();
+  if ( !zRange.isInfinite() )
+    r += static_cast<float>( zRange.upper() );
+
+  // subtract map origin so coordinates are relative to it
+  mCameraController->setViewFromTop(
+    static_cast<float>( center.x() - origin.x() ),
+    static_cast<float>( center.y() - origin.y() ),
+    r
+  );
 }
 
 QVector<QgsPointXY> Qgs3DMapScene::viewFrustum2DExtent() const

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -235,28 +235,28 @@ void Qgs3DMapScene::viewZoomFull()
 void Qgs3DMapScene::setViewFrom2DExtent( const QgsRectangle &extent )
 {
   QgsPointXY center = extent.center();
-  QgsVector3D origin = mMap.origin();
+  const QgsVector3D origin = mMap.origin();
 
-  QgsVector3D p1 = mMap.mapToWorldCoordinates( QVector3D( extent.xMinimum(), extent.yMinimum(), 0 ) );
-  QgsVector3D p2 = mMap.mapToWorldCoordinates( QVector3D( extent.xMaximum(), extent.yMaximum(), 0 ) );
+  const QgsVector3D p1 = mMap.mapToWorldCoordinates( QVector3D( extent.xMinimum(), extent.yMinimum(), 0 ) );
+  const QgsVector3D p2 = mMap.mapToWorldCoordinates( QVector3D( extent.xMaximum(), extent.yMaximum(), 0 ) );
 
-  float xSide = std::abs( p1.x() - p2.x() );
-  float ySide = std::abs( p1.z() - p2.z() );
-  float side = std::max( xSide, ySide );
+  const float xSide = std::abs( p1.x() - p2.x() );
+  const float ySide = std::abs( p1.z() - p2.z() );
+  const float side = std::max( xSide, ySide );
 
-  float fov = qDegreesToRadians( cameraController()->camera()->fieldOfView() );
-  float r = side / 2.0f / std::tan( fov / 2.0f );
+  const float fov = qDegreesToRadians( cameraController()->camera()->fieldOfView() );
+  float distance = side / 2.0f / std::tan( fov / 2.0f );
 
   // adjust by elevation
   const QgsDoubleRange zRange = elevationRange();
   if ( !zRange.isInfinite() )
-    r += static_cast<float>( zRange.upper() );
+    distance += static_cast<float>( zRange.upper() );
 
   // subtract map origin so coordinates are relative to it
   mCameraController->setViewFromTop(
     static_cast<float>( center.x() - origin.x() ),
     static_cast<float>( center.y() - origin.y() ),
-    r
+    distance
   );
 }
 


### PR DESCRIPTION
This was completely broken (probably since origin shifts have been introduced). This fix:

 - re-shifts according to origin
 - takes elevation into account (similar to viewZoomFull)