### PR TITLE
Add (hidden) setting to force raster clip masks for layout exports (3.44 backport)

### DIFF
--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -314,6 +314,7 @@ Layout graphical items for displaying a map.
 %End
   public:
 
+
     enum AtlasScalingMode /BaseType=IntEnum/
     {
       Fixed,

--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -314,6 +314,7 @@ Layout graphical items for displaying a map.
 %End
   public:
 
+
     enum AtlasScalingMode
     {
       Fixed,

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -40,12 +40,15 @@
 #include "qgslabelingresults.h"
 #include "qgsvectortileutils.h"
 #include "qgsunittypes.h"
+#include "qgssettingstree.h"
 
 #include <QApplication>
 #include <QPainter>
 #include <QScreen>
 #include <QStyleOptionGraphicsItem>
 #include <QTimer>
+
+const QgsSettingsEntryBool *QgsLayoutItemMap::settingForceRasterMasks = new QgsSettingsEntryBool( QStringLiteral( "force-raster-masks" ), QgsSettingsTree::sTreeLayout, false, QStringLiteral( "Whether to force rasterised clipping masks, regardless of output format." ) );
 
 QgsLayoutItemMap::QgsLayoutItemMap( QgsLayout *layout )
   : QgsLayoutItem( layout )
@@ -1751,6 +1754,10 @@ QgsMapSettings QgsLayoutItemMap::mapSettings( const QgsRectangle &extent, QSizeF
     jobMapSettings.setSimplifyMethod( mLayout->renderContext().simplifyMethod() );
     jobMapSettings.setMaskSettings( mLayout->renderContext().maskSettings() );
     jobMapSettings.setRendererUsage( Qgis::RendererUsage::Export );
+    if ( settingForceRasterMasks->value() )
+    {
+      jobMapSettings.setFlag( Qgis::MapSettingsFlag::ForceRasterMasks, true );
+    }
   }
   else
   {

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -322,6 +322,13 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
   public:
 
     /**
+     * Settings entry - Whether to force rasterised clipping masks, regardless of output format.
+     *
+     * \since QGIS 4.0
+     */
+    static const QgsSettingsEntryBool *settingForceRasterMasks SIP_SKIP;
+
+    /**
      * Scaling modes used for the serial rendering (atlas)
      */
     enum AtlasScalingMode


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/62488