### PR TITLE
PostgreSQL move raster overviews to schema

### DIFF
--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -1960,7 +1960,7 @@ void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSche
 
   if ( !ok )
   {
-    return;
+    throw QgsProviderConnectionException( QStringLiteral( "Table `%1` requested for move, does not exist." ).arg( tableName ) );
   }
 
   QString sqlAdditionalCommands;

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -1956,7 +1956,8 @@ void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSche
 
   std::shared_ptr<QgsPoolPostgresConn> conn = std::make_shared<QgsPoolPostgresConn>( QgsPostgresConn::connectionInfo( QgsDataSourceUri( uri() ), false ) );
   QgsPostgresLayerProperty property;
-  bool ok = conn->get()->supportedLayer( property, sourceSchema, tableName );
+  // need property from target schema, it is already moved
+  bool ok = conn->get()->supportedLayer( property, targetSchema, tableName );
 
   if ( !ok )
   {

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -2002,7 +2002,7 @@ void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSche
   if ( resMove.PQresultStatus() == PGRES_FATAL_ERROR )
   {
     conn->get()->rollback();
-    throw QgsProviderConnectionException( QStringLiteral( "Cannot safely move `%1` to schema `%2`." ).arg( tableName ).arg( targetSchema ) );
+    throw QgsProviderConnectionException( QStringLiteral( "Cannot move `%1` to schema `%2`." ).arg( tableName ).arg( targetSchema ) );
   }
 
   conn->get()->commit();

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -1946,17 +1946,6 @@ void QgsPostgresProviderConnection::renameField( const QString &schema, const QS
 
 void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSchema, const QString &tableName, const QString &targetSchema ) const
 {
-  std::shared_ptr<QgsPoolPostgresConn> conn = std::make_shared<QgsPoolPostgresConn>( QgsPostgresConn::connectionInfo( QgsDataSourceUri( uri() ), false ) );
-
-  bool ok { false };
-  QgsPostgresLayerProperty property;
-  ok = conn->get()->supportedLayer( property, sourceSchema, tableName );
-
-  if ( !ok )
-  {
-    return;
-  }
-
   const QString sqlMoveToSchema = QStringLiteral( "ALTER TABLE %1.%2 SET SCHEMA %3;" );
 
   const QString sqlMoveTable = sqlMoveToSchema
@@ -1964,6 +1953,15 @@ void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSche
                                  .arg( QgsPostgresConn::quotedIdentifier( tableName ) )
                                  .arg( QgsPostgresConn::quotedIdentifier( targetSchema ) );
   executeSqlPrivate( sqlMoveTable );
+
+  std::shared_ptr<QgsPoolPostgresConn> conn = std::make_shared<QgsPoolPostgresConn>( QgsPostgresConn::connectionInfo( QgsDataSourceUri( uri() ), false ) );
+  QgsPostgresLayerProperty property;
+  bool ok = conn->get()->supportedLayer( property, sourceSchema, tableName );
+
+  if ( !ok )
+  {
+    return;
+  }
 
   // if raster table is moved the overview info is not updated so we need to do it manually
   // also the overviews are moved to the same schema as the raster

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -1967,8 +1967,7 @@ void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSche
   {
     // first take a look if there were overviews for the moved raster
     const QString sqlOverviews = QStringLiteral( "SELECT o_table_schema, o_table_name, o_raster_column, overview_factor FROM public.raster_overviews WHERE r_table_schema = %1 AND r_table_name = %2;" )
-                                   .arg( QgsPostgresConn::quotedValue( sourceSchema ) )
-                                   .arg( QgsPostgresConn::quotedValue( tableName ) );
+                                   .arg( QgsPostgresConn::quotedValue( sourceSchema ), QgsPostgresConn::quotedValue( tableName ) );
 
     const QList<QVariantList> results = executeSqlPrivate( sqlOverviews );
 

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -1972,7 +1972,7 @@ void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSche
 
     const QList<QVariantList> results = executeSqlPrivate( sqlOverviews );
 
-    for ( QVariantList result : results )
+    for ( const QVariantList &result : std::as_const( results ) )
     {
       const QString overviewSchema = result.at( 0 ).toString();
       const QString overviewTableName = result.at( 1 ).toString();

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -2010,5 +2010,11 @@ void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSche
   }
 
   const QString sqlCompleteCommand = QStringLiteral( "BEGIN; %1 %2 COMMIT;" ).arg( sqlMoveTable ).arg( sqlAdditionalCommands );
-  executeSqlPrivate( sqlCompleteCommand );
+
+  QgsPostgresResult res( conn->get()->LoggedPQexec( "QgsPostgresRasterProviderMetadata", sqlCompleteCommand ) );
+
+  if ( res.PQresultStatus() != PGRES_COMMAND_OK )
+  {
+    throw QgsProviderConnectionException( QStringLiteral( "Cannot safely move `%1` to schema `%2`." ).arg( tableName ).arg( targetSchema ) );
+  }
 }

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -1948,10 +1948,7 @@ void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSche
 {
   const QString sqlMoveToSchema = QStringLiteral( "ALTER TABLE %1.%2 SET SCHEMA %3;" );
 
-  const QString sqlMoveTable = sqlMoveToSchema
-                                 .arg( QgsPostgresConn::quotedIdentifier( sourceSchema ) )
-                                 .arg( QgsPostgresConn::quotedIdentifier( tableName ) )
-                                 .arg( QgsPostgresConn::quotedIdentifier( targetSchema ) );
+  const QString sqlMoveTable = sqlMoveToSchema.arg( QgsPostgresConn::quotedIdentifier( sourceSchema ), QgsPostgresConn::quotedIdentifier( tableName ), QgsPostgresConn::quotedIdentifier( targetSchema ) );
 
   std::shared_ptr<QgsPoolPostgresConn> conn = std::make_shared<QgsPoolPostgresConn>( QgsPostgresConn::connectionInfo( QgsDataSourceUri( uri() ), false ) );
   QgsPostgresLayerProperty property;
@@ -1984,27 +1981,16 @@ void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSche
 
       // drop the overview constraint
       const QString sqlDropConstraint = QStringLiteral( "SELECT DropOverviewConstraints(%1, %2, %3);" )
-                                          .arg( QgsPostgresConn::quotedValue( overviewSchema ) )
-                                          .arg( QgsPostgresConn::quotedValue( overviewTableName ) )
-                                          .arg( QgsPostgresConn::quotedValue( overviewRastCol ) );
+                                          .arg( QgsPostgresConn::quotedValue( overviewSchema ), QgsPostgresConn::quotedValue( overviewTableName ), QgsPostgresConn::quotedValue( overviewRastCol ) );
       sqlAdditionalCommands.append( sqlDropConstraint );
 
       // move overview table to the target schema
-      const QString sqlMoveOverview = sqlMoveToSchema
-                                        .arg( QgsPostgresConn::quotedIdentifier( overviewSchema ) )
-                                        .arg( QgsPostgresConn::quotedIdentifier( overviewTableName ) )
-                                        .arg( QgsPostgresConn::quotedIdentifier( targetSchema ) );
+      const QString sqlMoveOverview = sqlMoveToSchema.arg( QgsPostgresConn::quotedIdentifier( overviewSchema ), QgsPostgresConn::quotedIdentifier( overviewTableName ), QgsPostgresConn::quotedIdentifier( targetSchema ) );
       sqlAdditionalCommands.append( sqlMoveOverview );
 
       // create the overview constraint with updated info
       const QString sqlAddConstraint = QStringLiteral( "SELECT AddOverviewConstraints(%1, %2, %3, %4, %5, %6, %7);" )
-                                         .arg( QgsPostgresConn::quotedValue( targetSchema ) )
-                                         .arg( QgsPostgresConn::quotedValue( overviewTableName ) )
-                                         .arg( QgsPostgresConn::quotedValue( overviewRastCol ) )
-                                         .arg( QgsPostgresConn::quotedValue( targetSchema ) )
-                                         .arg( QgsPostgresConn::quotedValue( tableName ) )
-                                         .arg( QgsPostgresConn::quotedValue( property.geometryColName ) )
-                                         .arg( QgsPostgresConn::quotedValue( overviewFactor ) );
+                                         .arg( QgsPostgresConn::quotedValue( targetSchema ), QgsPostgresConn::quotedValue( overviewTableName ), QgsPostgresConn::quotedValue( overviewRastCol ), QgsPostgresConn::quotedValue( targetSchema ), QgsPostgresConn::quotedValue( tableName ), QgsPostgresConn::quotedValue( property.geometryColName ), QgsPostgresConn::quotedValue( overviewFactor ) );
       sqlAdditionalCommands.append( sqlAddConstraint );
     }
   }

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -1065,7 +1065,7 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
         )
 
         # test moved table exist in the schema
-        table = conn.table("schema_test", "raster_for_move")
+        table = conn.table("qgis_schema_test", "raster_for_move")
         self.assertEqual(table.tableName(), "raster_for_move")
 
         # look at overviews after move

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -1110,7 +1110,7 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
         tables = conn.executeSql(sqlTables)
 
         self.assertEqual(
-            [["o_2_raster_for_move", "o_4_raster_for_move", "raster_for_move"]],
+            [["o_2_raster_for_move"], ["o_4_raster_for_move"], ["raster_for_move"]],
             tables,
         )
 

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -1110,7 +1110,7 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
         tables = conn.executeSql(sqlTables)
 
         self.assertEqual(
-            ["o_2_raster_for_move", "o_4_raster_for_move", "raster_for_move"],
+            [["o_2_raster_for_move", "o_4_raster_for_move", "raster_for_move"]],
             tables,
         )
 

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -1044,7 +1044,8 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
 
         # check that overviews were created
         sqlOverviews = """
-        SELECT o_table_schema, o_table_name FROM public.raster_overviews
+        SELECT o_table_schema, o_table_name FROM public.raster_overviews 
+        WHERE r_table_schema = 'qgis_test' AND r_table_name = 'raster_for_move' ORDER BY r_table_name;
         """
         overviews = conn.executeSql(sqlOverviews)
 
@@ -1068,6 +1069,11 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
         self.assertEqual(table.tableName(), "raster_for_move")
 
         # look at overviews after move
+        sqlOverviews = """
+        SELECT o_table_schema, o_table_name FROM public.raster_overviews 
+        WHERE r_table_schema = 'schema_test' AND r_table_name = 'raster_for_move' ORDER BY r_table_name;
+        """
+
         overviews = conn.executeSql(sqlOverviews)
 
         self.assertEqual(

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -974,7 +974,7 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
             id SERIAL PRIMARY KEY,
             geom geometry(Geometry,4326)
         );
-        CREATE SCHEMA IF NOT EXISTS schema_test;
+        CREATE SCHEMA IF NOT EXISTS qgis_schema_test;
         """
 
         conn.executeSql(sql)
@@ -1018,7 +1018,7 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
 
         # create raster table
         sql = """
-        CREATE SCHEMA IF NOT EXISTS schema_test;
+        CREATE SCHEMA IF NOT EXISTS qgis_schema_test;
         CREATE TABLE qgis_test.raster_for_move (
             id serial PRIMARY KEY,
             rast raster
@@ -1061,7 +1061,7 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
         conn.moveTableToSchema(
             "qgis_test",
             "raster_for_move",
-            "schema_test",
+            "qgis_schema_test",
         )
 
         # test moved table exist in the schema
@@ -1071,7 +1071,7 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
         # look at overviews after move
         sqlOverviews = """
         SELECT o_table_schema, o_table_name FROM public.raster_overviews 
-        WHERE r_table_schema = 'schema_test' AND r_table_name = 'raster_for_move' ORDER BY r_table_name;
+        WHERE r_table_schema = 'qgis_schema_test' AND r_table_name = 'raster_for_move' ORDER BY r_table_name;
         """
 
         overviews = conn.executeSql(sqlOverviews)

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -1084,6 +1084,36 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
             overviews,
         )
 
+        # look for original overviews after move - should be empty
+        sqlTables = """
+        SELECT * FROM pg_catalog.pg_tables 
+        WHERE schemaname = 'qgis_test' 
+        AND tablename LIKE '%raster_for_move'
+        ORDER BY tablename;
+        """
+
+        tables = conn.executeSql(sqlTables)
+
+        self.assertEqual(
+            [],
+            tables,
+        )
+
+        # look for overviews after move in the new schema - should be present
+        sqlTables = """
+        SELECT * FROM pg_catalog.pg_tables 
+        WHERE schemaname = 'qgis_schema_test' 
+        AND tablename LIKE '%raster_for_move'
+        ORDER BY tablename;
+        """
+
+        tables = conn.executeSql(sqlTables)
+
+        self.assertEqual(
+            ["o_2_raster_for_move", "o_4_raster_for_move", "raster_for_move"],
+            tables,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -1003,11 +1003,11 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
         conn.moveTableToSchema(
             "qgis_test",
             "table_to_move",
-            "schema_test",
+            "qgis_schema_test",
         )
 
         # test moved table exist in the schema
-        table = conn.table("schema_test", "table_to_move")
+        table = conn.table("qgis_schema_test", "table_to_move")
         self.assertEqual(table.tableName(), "table_to_move")
 
     def test_move_raster_with_overviews_to_schema(self):
@@ -1078,8 +1078,8 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
 
         self.assertEqual(
             [
-                ["schema_test", "o_2_raster_for_move"],
-                ["schema_test", "o_4_raster_for_move"],
+                ["qgis_schema_test", "o_2_raster_for_move"],
+                ["qgis_schema_test", "o_4_raster_for_move"],
             ],
             overviews,
         )

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -1086,7 +1086,7 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
 
         # look for original overviews after move - should be empty
         sqlTables = """
-        SELECT * FROM pg_catalog.pg_tables 
+        SELECT tablename FROM pg_catalog.pg_tables 
         WHERE schemaname = 'qgis_test' 
         AND tablename LIKE '%raster_for_move'
         ORDER BY tablename;
@@ -1101,7 +1101,7 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
 
         # look for overviews after move in the new schema - should be present
         sqlTables = """
-        SELECT * FROM pg_catalog.pg_tables 
+        SELECT tablename FROM pg_catalog.pg_tables 
         WHERE schemaname = 'qgis_schema_test' 
         AND tablename LIKE '%raster_for_move'
         ORDER BY tablename;


### PR DESCRIPTION
## Description

When moving raster table to another schema that has existing overviews, move the overviews to target schema as well and update constraints related to overviews accordingly.

Funded by Ocean Winds