### PR TITLE
[Bugfix] Fix invalid geometries when reprojecting EPSG:32198 to EPSG:6622

### DIFF
--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -16,7 +16,7 @@
  ***************************************************************************/
 
 #include "qgsalgorithmtransform.h"
-#include "qgsprocessingexception.h"
+#include "qgsexception.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -109,10 +109,11 @@ QgsFeatureList QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsPr
   {
     mCreatedTransform = true;
     if ( !mCoordOp.isEmpty() )
-      mTransformContext.addCoordinateOperation( sourceCrs(), mDestCrs, mCoordOp, false );
+      mTransformContext.addCoordinateOperation( sourceCrs(), mDestCrs, mCoordOp, true );
     mTransform = QgsCoordinateTransform( sourceCrs(), mDestCrs, mTransformContext );
 
-    mTransform.disableFallbackOperationHandler( true );
+    // Don't disable fallbacks - this allows graceful handling of grid shift errors
+    // mTransform.disableFallbackOperationHandler( true );
   }
 
   if ( feature.hasGeometry() )

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -152,7 +152,7 @@ QgsFeatureList QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsPr
 
       const QString msg = QObject::tr( "Coordinate transformation failed for feature id %1 (likely due to missing or inaccessible grid shift file). Error details: %2" )
                             .arg( f.id() )
-                            .arg( QString::fromUtf8( ex.what() ) );
+                            .arg( ex.what() );
       throw QgsProcessingException( msg );
     }
   }

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -17,7 +17,7 @@
 
 #include "qgsalgorithmtransform.h"
 #include "qgsexception.h"
-
+#include "processing/qgsprocessingexception.h"
 ///@cond PRIVATE
 
 

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -140,8 +140,9 @@ QgsFeatureList QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsPr
             bool hasInvalidCoordinates = false;
             for ( auto vertex = abstractGeom->vertices_begin(); vertex != abstractGeom->vertices_end(); ++vertex )
             {
-              if ( !std::isfinite( vertex->x() ) || !std::isfinite( vertex->y() ) || 
-                   ( abstractGeom->is3D() && !std::isfinite( vertex->z() ) ) )
+              const QgsPoint &pt = *vertex;
+              if ( !std::isfinite( pt.x() ) || !std::isfinite( pt.y() ) || 
+                   ( abstractGeom->is3D() && !std::isfinite( pt.z() ) ) )
               {
                 hasInvalidCoordinates = true;
                 break;

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -17,7 +17,6 @@
 
 #include "qgsalgorithmtransform.h"
 #include "qgsexception.h"
-#include "processing/qgsprocessingexception.h"
 ///@cond PRIVATE
 
 


### PR DESCRIPTION

**_[Bugfix] Fix invalid geometries when reprojecting EPSG:32198 to EPSG:6622_**
Fixes an issue where native:reprojectlayer produces invalid geometries with infinite coordinates when using the default OPERATION parameter between these CRS.
The problem occurs because the grid file ca_nrc_NA83SCRS.tif is missing and fallback transformations are disabled.
**Fix: Allow fallbacks when grid-based transformations fail by:**
1. Setting allowFallback=true when adding coordinate operations
2. Removing the explicit fallback handler disabling

