### PR TITLE
Add a meaningful point when 'interior ring not in exterior ring' geometry error is found

### DIFF
--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -217,7 +217,13 @@ void QgsGeometryValidator::validatePolygon( int partIndex, const QgsCurvePolygon
     {
       const QString msg = QObject::tr( "ring %1 of polygon %2 not in exterior ring" ).arg( i + 1 ).arg( partIndex );
       QgsDebugMsgLevel( msg, 2 );
-      emit errorFound( QgsGeometry::Error( msg ) );
+      const QgsCurve *interiorRing = polygon->interiorRing( i );
+
+      if ( interiorRing->numPoints() == 0 )
+        emit errorFound( QgsGeometry::Error( msg ) );
+      else
+        emit errorFound( QgsGeometry::Error( msg, QgsPointXY( interiorRing->startPoint() ) ) );
+
       mErrorCount++;
     }
   }

--- a/tests/src/python/test_qgsgeometryvalidator.py
+++ b/tests/src/python/test_qgsgeometryvalidator.py
@@ -392,6 +392,33 @@ class TestQgsGeometryValidator(QgisTestCase):
         validator.run()
         self.assertEqual(len(spy), 0)
 
+    def test_interior_ring_inside_exterior_ring(self):
+        # Interior ring inside
+        g = QgsGeometry.fromWkt(
+            "Polygon ((0 0, 10 0, 10 10, 0 0), (1 1, 2 1, 2 2, 1 1))"
+        )
+
+        validator = QgsGeometryValidator(g)
+        spy = QSignalSpy(validator.errorFound)
+        validator.run()
+        self.assertEqual(len(spy), 0)
+
+        # Interior ring not inside
+        g = QgsGeometry.fromWkt(
+            "Polygon ((0 0, 10 0, 10 10, 0 0), (1 1, 2 1, 1 -1, 1 1))"
+        )
+
+        validator = QgsGeometryValidator(g)
+        spy = QSignalSpy(validator.errorFound)
+        validator.run()
+
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(spy[0][0].where(), QgsPointXY(1, 1))  # Starting point
+        self.assertEqual(
+            spy[0][0].what(),
+            "ring 1 of polygon 0 not in exterior ring",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Currently, when running `native:checkvalidity` algorithm (with the QGIS validation mode) a NULL point is set for such error feature, making it hard to locate.

For the same error type, GEOS mode passes the start point of the interior ring.

This PR makes sure QGIS mode also passes the start point of the ring, if any.