### PR TITLE
Introduce geometry backend enum

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -247,15 +247,15 @@ Qgis.LayerFilter.__doc__ = """Filter for layers
 
 .. versionadded:: 3.34.
 
-* ``RasterLayer``: 
-* ``NoGeometry``: 
-* ``PointLayer``: 
-* ``LineLayer``: 
-* ``PolygonLayer``: 
-* ``HasGeometry``: 
-* ``VectorLayer``: 
-* ``PluginLayer``: 
-* ``WritableLayer``: 
+* ``RasterLayer``:
+* ``NoGeometry``:
+* ``PointLayer``:
+* ``LineLayer``:
+* ``PolygonLayer``:
+* ``HasGeometry``:
+* ``VectorLayer``:
+* ``PluginLayer``:
+* ``WritableLayer``:
 * ``MeshLayer``: QgsMeshLayer
 
   .. versionadded:: 3.6
@@ -851,10 +851,10 @@ Qgis.EmbeddedScriptType.__doc__ = """Type of Python Embedded in projects
 
 .. versionadded:: 3.40
 
-* ``Macro``: 
-* ``ExpressionFunction``: 
-* ``Action``: 
-* ``FormInitCode``: 
+* ``Macro``:
+* ``ExpressionFunction``:
+* ``Action``:
+* ``FormInitCode``:
 
 """
 # --
@@ -867,9 +867,9 @@ Qgis.ProjectTrustStatus.__doc__ = """Project trust status
 
 .. versionadded:: 4.0
 
-* ``Undetermined``: 
-* ``Trusted``: 
-* ``Untrusted``: 
+* ``Undetermined``:
+* ``Trusted``:
+* ``Untrusted``:
 
 """
 # --
@@ -3229,8 +3229,8 @@ note Directly mapped from GDALRATTableType enum values.
 
 .. versionadded:: 3.30
 
-* ``Thematic``: 
-* ``Athematic``: 
+* ``Thematic``:
+* ``Athematic``:
 
 """
 # --
@@ -4063,6 +4063,19 @@ Qgis.JoinStyle.__doc__ = """Join styles for buffers.
 # --
 Qgis.JoinStyle.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.GeometryBackend.QGIS.__doc__ = "Use internal implementation"
+Qgis.GeometryBackend.GEOS.__doc__ = "Use GEOS implementation"
+Qgis.GeometryBackend.__doc__ = """Geometry backend for :py:class:`QgsGeometry`.
+
+.. versionadded:: 4.0
+
+* ``QGIS``: Use internal implementation
+* ``GEOS``: Use GEOS implementation
+
+"""
+# --
+Qgis.GeometryBackend.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.JoinStyle3D.Round.__doc__ = "Smooth, rounded buffer around the input geometry"
 Qgis.JoinStyle3D.Flat.__doc__ = "Flat ends and constant width along the linestring"
 Qgis.JoinStyle3D.CylindersAndSpheres.__doc__ = "Cylinders along the linestring segments with spheres at the vertices"
@@ -4077,6 +4090,19 @@ Qgis.JoinStyle3D.__doc__ = """Join styles for 3D buffers.
 """
 # --
 Qgis.JoinStyle3D.baseClass = Qgis
+# monkey patching scoped based enum
+Qgis.GeometryBackend.QGIS.__doc__ = "Use internal implementation"
+Qgis.GeometryBackend.GEOS.__doc__ = "Use GEOS implementation"
+Qgis.GeometryBackend.__doc__ = """Geometry backend for :py:class:`QgsGeometry`.
+
+.. versionadded:: 4.2
+
+* ``QGIS``: Use internal implementation
+* ``GEOS``: Use GEOS implementation
+
+"""
+# --
+Qgis.GeometryBackend.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.GeosCreationFlag.RejectOnInvalidSubGeometry.__doc__ = "Don't allow geometries with invalid sub-geometries to be created"
 Qgis.GeosCreationFlag.SkipEmptyInteriorRings.__doc__ = "Skip any empty polygon interior ring"
@@ -8398,7 +8424,7 @@ Prior to QGIS 3.30 this was available as :py:class:`QgsMapLayerAction`.Target
 * ``Layer``: Action targets a complete layer
 * ``SingleFeature``: Action targets a single feature from a layer
 * ``MultipleFeatures``: Action targets multiple features from a layer
-* ``AllActions``: 
+* ``AllActions``:
 
 """
 # --
@@ -11240,9 +11266,9 @@ Qgis.ProviderStyleStorageCapability.__doc__ = """The StorageCapability enum repr
 
 .. versionadded:: 3.34
 
-* ``SaveToDatabase``: 
-* ``LoadFromDatabase``: 
-* ``DeleteFromDatabase``: 
+* ``SaveToDatabase``:
+* ``LoadFromDatabase``:
+* ``DeleteFromDatabase``:
 
 """
 # --
@@ -12445,10 +12471,10 @@ Qgis.ExtrusionFace.__doc__ = """Extrusion face types for the :py:class:`QgsTesse
 
 .. versionadded:: 4.0
 
-* ``NoFace``: 
-* ``Walls``: 
-* ``Roof``: 
-* ``Floor``: 
+* ``NoFace``:
+* ``Walls``:
+* ``Roof``:
+* ``Floor``:
 
 """
 # --
@@ -12463,8 +12489,8 @@ Qgis.TriangulationAlgorithm.__doc__ = """Triangulation algorithms.
 
 .. versionadded:: 4.0
 
-* ``ConstrainedDelaunay``: 
-* ``Earcut``: 
+* ``ConstrainedDelaunay``:
+* ``Earcut``:
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -247,15 +247,15 @@ Qgis.LayerFilter.__doc__ = """Filter for layers
 
 .. versionadded:: 3.34.
 
-* ``RasterLayer``:
-* ``NoGeometry``:
-* ``PointLayer``:
-* ``LineLayer``:
-* ``PolygonLayer``:
-* ``HasGeometry``:
-* ``VectorLayer``:
-* ``PluginLayer``:
-* ``WritableLayer``:
+* ``RasterLayer``: 
+* ``NoGeometry``: 
+* ``PointLayer``: 
+* ``LineLayer``: 
+* ``PolygonLayer``: 
+* ``HasGeometry``: 
+* ``VectorLayer``: 
+* ``PluginLayer``: 
+* ``WritableLayer``: 
 * ``MeshLayer``: QgsMeshLayer
 
   .. versionadded:: 3.6
@@ -851,10 +851,10 @@ Qgis.EmbeddedScriptType.__doc__ = """Type of Python Embedded in projects
 
 .. versionadded:: 3.40
 
-* ``Macro``:
-* ``ExpressionFunction``:
-* ``Action``:
-* ``FormInitCode``:
+* ``Macro``: 
+* ``ExpressionFunction``: 
+* ``Action``: 
+* ``FormInitCode``: 
 
 """
 # --
@@ -867,9 +867,9 @@ Qgis.ProjectTrustStatus.__doc__ = """Project trust status
 
 .. versionadded:: 4.0
 
-* ``Undetermined``:
-* ``Trusted``:
-* ``Untrusted``:
+* ``Undetermined``: 
+* ``Trusted``: 
+* ``Untrusted``: 
 
 """
 # --
@@ -3229,8 +3229,8 @@ note Directly mapped from GDALRATTableType enum values.
 
 .. versionadded:: 3.30
 
-* ``Thematic``:
-* ``Athematic``:
+* ``Thematic``: 
+* ``Athematic``: 
 
 """
 # --
@@ -4062,19 +4062,6 @@ Qgis.JoinStyle.__doc__ = """Join styles for buffers.
 """
 # --
 Qgis.JoinStyle.baseClass = Qgis
-# monkey patching scoped based enum
-Qgis.GeometryBackend.QGIS.__doc__ = "Use internal implementation"
-Qgis.GeometryBackend.GEOS.__doc__ = "Use GEOS implementation"
-Qgis.GeometryBackend.__doc__ = """Geometry backend for :py:class:`QgsGeometry`.
-
-.. versionadded:: 4.0
-
-* ``QGIS``: Use internal implementation
-* ``GEOS``: Use GEOS implementation
-
-"""
-# --
-Qgis.GeometryBackend.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.JoinStyle3D.Round.__doc__ = "Smooth, rounded buffer around the input geometry"
 Qgis.JoinStyle3D.Flat.__doc__ = "Flat ends and constant width along the linestring"
@@ -8424,7 +8411,7 @@ Prior to QGIS 3.30 this was available as :py:class:`QgsMapLayerAction`.Target
 * ``Layer``: Action targets a complete layer
 * ``SingleFeature``: Action targets a single feature from a layer
 * ``MultipleFeatures``: Action targets multiple features from a layer
-* ``AllActions``:
+* ``AllActions``: 
 
 """
 # --
@@ -11266,9 +11253,9 @@ Qgis.ProviderStyleStorageCapability.__doc__ = """The StorageCapability enum repr
 
 .. versionadded:: 3.34
 
-* ``SaveToDatabase``:
-* ``LoadFromDatabase``:
-* ``DeleteFromDatabase``:
+* ``SaveToDatabase``: 
+* ``LoadFromDatabase``: 
+* ``DeleteFromDatabase``: 
 
 """
 # --
@@ -12471,10 +12458,10 @@ Qgis.ExtrusionFace.__doc__ = """Extrusion face types for the :py:class:`QgsTesse
 
 .. versionadded:: 4.0
 
-* ``NoFace``:
-* ``Walls``:
-* ``Roof``:
-* ``Floor``:
+* ``NoFace``: 
+* ``Walls``: 
+* ``Roof``: 
+* ``Floor``: 
 
 """
 # --
@@ -12489,8 +12476,8 @@ Qgis.TriangulationAlgorithm.__doc__ = """Triangulation algorithms.
 
 .. versionadded:: 4.0
 
-* ``ConstrainedDelaunay``:
-* ``Earcut``:
+* ``ConstrainedDelaunay``: 
+* ``Earcut``: 
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgsgeometryengine.py
+++ b/python/PyQt6/core/auto_additions/qgsgeometryengine.py
@@ -9,7 +9,7 @@ QgsGeometryEngine.InvalidInput = QgsGeometryEngine.EngineOperationResult.Invalid
 QgsGeometryEngine.SplitCannotSplitPoint = QgsGeometryEngine.EngineOperationResult.SplitCannotSplitPoint
 try:
     QgsGeometryEngine.__virtual_methods__ = ['splitGeometry']
-    QgsGeometryEngine.__abstract_methods__ = ['geometryChanged', 'prepareGeometry', 'intersection', 'difference', 'combine', 'symDifference', 'buffer', 'simplify', 'interpolate', 'envelope', 'centroid', 'pointOnSurface', 'convexHull', 'distance', 'distanceWithin', 'intersects', 'touches', 'crosses', 'within', 'overlaps', 'contains', 'disjoint', 'relate', 'relatePattern', 'area', 'length', 'isValid', 'isEqual', 'isEmpty', 'isSimple', 'offsetCurve']
+    QgsGeometryEngine.__abstract_methods__ = ['geometryChanged', 'prepareGeometry', 'intersection', 'difference', 'combine', 'symDifference', 'buffer', 'simplify', 'interpolate', 'envelope', 'centroid', 'pointOnSurface', 'convexHull', 'distance', 'distanceWithin', 'intersects', 'touches', 'crosses', 'within', 'overlaps', 'contains', 'disjoint', 'relate', 'relatePattern', 'area', 'length', 'isValid', 'isEqual', 'isFuzzyEqual', 'isEmpty', 'isSimple', 'offsetCurve']
     QgsGeometryEngine.__group__ = ['geometry']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgsgeos.py
+++ b/python/PyQt6/core/auto_additions/qgsgeos.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/core/geometry/qgsgeos.h
 try:
-    QgsGeos.__overridden_methods__ = ['geometryChanged', 'prepareGeometry', 'intersection', 'difference', 'combine', 'symDifference', 'buffer', 'simplify', 'interpolate', 'envelope', 'centroid', 'pointOnSurface', 'convexHull', 'distance', 'distanceWithin', 'intersects', 'touches', 'crosses', 'within', 'overlaps', 'contains', 'disjoint', 'relate', 'relatePattern', 'area', 'length', 'isValid', 'isEqual', 'isEmpty', 'isSimple', 'splitGeometry', 'offsetCurve']
+    QgsGeos.__overridden_methods__ = ['geometryChanged', 'prepareGeometry', 'intersection', 'difference', 'combine', 'symDifference', 'buffer', 'simplify', 'interpolate', 'envelope', 'centroid', 'pointOnSurface', 'convexHull', 'distance', 'distanceWithin', 'intersects', 'touches', 'crosses', 'within', 'overlaps', 'contains', 'disjoint', 'relate', 'relatePattern', 'area', 'length', 'isValid', 'isEqual', 'isFuzzyEqual', 'isEmpty', 'isSimple', 'splitGeometry', 'offsetCurve']
     QgsGeos.__group__ = ['geometry']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -383,7 +383,7 @@ always return ``True`` for :py:func:`~QgsGeometry.isEmpty`.
 Returns ``True`` if WKB of the geometry is of WKBMulti* type
 %End
 
-    bool equals( const QgsGeometry &geometry ) const;
+ bool equals( const QgsGeometry &geometry ) const /Deprecated="Since 4.0. Will be removed in QGIS 5.0. Use isEqual which accepts Qgis.GeometryBackend."/;
 %Docstring
 Test if this geometry is exactly equal to another ``geometry``.
 
@@ -397,10 +397,12 @@ test performed by :py:func:`~QgsGeometry.isGeosEqual`.
 
    Comparing two null geometries will return ``False``.
 
-.. seealso:: :py:func:`isGeosEqual`
+.. deprecated:: 4.0
+
+   Will be removed in QGIS 5.0. Use isEqual which accepts :py:class:`Qgis`.GeometryBackend.
 %End
 
-    bool isGeosEqual( const QgsGeometry & ) const;
+ bool isGeosEqual( const QgsGeometry & ) const /Deprecated="Since 4.0. Will be removed in QGIS 5.0. Use isEqual which accepts Qgis.GeometryBackend."/;
 %Docstring
 Compares the geometry with another geometry using GEOS.
 
@@ -416,7 +418,26 @@ Consider using the much faster, stricter equality test performed by
 
    Comparing two null geometries will return ``False``.
 
-.. seealso:: :py:func:`equals`
+.. deprecated:: 4.0
+
+   Will be removed in QGIS 5.0. Use isEqual which accepts :py:class:`Qgis`.GeometryBackend.
+%End
+
+    bool isEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
+%Docstring
+Compares the geometry with another geometry using the specified
+``backend``.
+
+Implementations:
+
+- GEOS: this method performs a slow, topological check, where geometries are considered equal if all of the their component edges overlap. E.g. lines with the same vertex locations but opposite direction will be considered equal by this method.
+- QGIS: this is a strict equality check, where the underlying geometries must have exactly the same type, component vertices and vertex order.
+
+The QGIS internal implementation is chosen by default.
+
+.. note::
+
+   Comparing two null geometries will return ``False``.
 %End
 
     bool isGeosValid( Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -438,6 +438,9 @@ Implementations:
 
 The QGIS internal implementation is chosen by default.
 
+:param geometry: geometry to compare with
+:param backend: backend implementation
+
 .. note::
 
    Comparing two null geometries will return ``False``.
@@ -461,6 +464,9 @@ Implementations:
 
 The GEOS implementation is chosen by default.
 
+:param geometry: geometry to compare with
+:param backend: backend implementation
+
 .. note::
 
    Comparing two null geometries will return ``False``.
@@ -479,6 +485,10 @@ Implementations:
 - QGIS
 
 The QGIS internal implementation is chosen by default.
+
+:param geometry: geometry to compare with
+:param epsilon: maximum difference for coordinates between the objects
+:param backend: backend implementation
 
 .. note::
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -383,7 +383,7 @@ always return ``True`` for :py:func:`~QgsGeometry.isEmpty`.
 Returns ``True`` if WKB of the geometry is of WKBMulti* type
 %End
 
- bool equals( const QgsGeometry &geometry ) const /Deprecated="Since 4.0. Will be removed in QGIS 5.0. Use isExactlyEqual which accepts Qgis.GeometryBackend."/;
+ bool equals( const QgsGeometry &geometry ) const /Deprecated="Since 4.2. Will be removed in QGIS 5.0. Use isExactlyEqual which accepts Qgis.GeometryBackend."/;
 %Docstring
 Test if this geometry is exactly equal to another ``geometry``.
 
@@ -397,12 +397,12 @@ test performed by :py:func:`~QgsGeometry.isGeosEqual`.
 
    Comparing two null geometries will return ``False``.
 
-.. deprecated:: 4.0
+.. deprecated:: 4.2
 
    Will be removed in QGIS 5.0. Use isExactlyEqual which accepts :py:class:`Qgis`.GeometryBackend.
 %End
 
- bool isGeosEqual( const QgsGeometry & ) const /Deprecated="Since 4.0. Will be removed in QGIS 5.0. Use isTopologicallyEqual which accepts Qgis.GeometryBackend."/;
+ bool isGeosEqual( const QgsGeometry & ) const /Deprecated="Since 4.2. Will be removed in QGIS 5.0. Use isTopologicallyEqual which accepts Qgis.GeometryBackend."/;
 %Docstring
 Compares the geometry with another geometry using GEOS.
 
@@ -418,7 +418,7 @@ Consider using the much faster, stricter equality test performed by
 
    Comparing two null geometries will return ``False``.
 
-.. deprecated:: 4.0
+.. deprecated:: 4.2
 
    Will be removed in QGIS 5.0. Use isTopologicallyEqual which accepts :py:class:`Qgis`.GeometryBackend.
 %End
@@ -445,7 +445,9 @@ The QGIS internal implementation is chosen by default.
 
    Comparing two null geometries will return ``False``.
 
-.. versionadded:: 4.0
+:raises QgsNotSupportedException: when backend is not supported
+
+.. versionadded:: 4.2
 %End
 
     bool isTopologicallyEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::GEOS ) const;
@@ -471,7 +473,9 @@ The GEOS implementation is chosen by default.
 
    Comparing two null geometries will return ``False``.
 
-.. versionadded:: 4.0
+:raises QgsNotSupportedException: when backend is not supported
+
+.. versionadded:: 4.2
 %End
 
     bool isFuzzyEqual( const QgsGeometry &geometry, double epsilon, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
@@ -494,7 +498,9 @@ The QGIS internal implementation is chosen by default.
 
    Comparing two null geometries will return ``False``.
 
-.. versionadded:: 4.0
+:raises QgsNotSupportedException: when backend is not supported
+
+.. versionadded:: 4.2
 %End
 
     bool isGeosValid( Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -383,7 +383,7 @@ always return ``True`` for :py:func:`~QgsGeometry.isEmpty`.
 Returns ``True`` if WKB of the geometry is of WKBMulti* type
 %End
 
- bool equals( const QgsGeometry &geometry ) const /Deprecated="Since 4.0. Will be removed in QGIS 5.0. Use isEqual which accepts Qgis.GeometryBackend."/;
+ bool equals( const QgsGeometry &geometry ) const /Deprecated="Since 4.0. Will be removed in QGIS 5.0. Use isExactlyEqual which accepts Qgis.GeometryBackend."/;
 %Docstring
 Test if this geometry is exactly equal to another ``geometry``.
 
@@ -399,10 +399,10 @@ test performed by :py:func:`~QgsGeometry.isGeosEqual`.
 
 .. deprecated:: 4.0
 
-   Will be removed in QGIS 5.0. Use isEqual which accepts :py:class:`Qgis`.GeometryBackend.
+   Will be removed in QGIS 5.0. Use isExactlyEqual which accepts :py:class:`Qgis`.GeometryBackend.
 %End
 
- bool isGeosEqual( const QgsGeometry & ) const /Deprecated="Since 4.0. Will be removed in QGIS 5.0. Use isEqual which accepts Qgis.GeometryBackend."/;
+ bool isGeosEqual( const QgsGeometry & ) const /Deprecated="Since 4.0. Will be removed in QGIS 5.0. Use isTopologicallyEqual which accepts Qgis.GeometryBackend."/;
 %Docstring
 Compares the geometry with another geometry using GEOS.
 
@@ -420,24 +420,71 @@ Consider using the much faster, stricter equality test performed by
 
 .. deprecated:: 4.0
 
-   Will be removed in QGIS 5.0. Use isEqual which accepts :py:class:`Qgis`.GeometryBackend.
+   Will be removed in QGIS 5.0. Use isTopologicallyEqual which accepts :py:class:`Qgis`.GeometryBackend.
 %End
 
-    bool isEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
+    bool isExactlyEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
 %Docstring
 Compares the geometry with another geometry using the specified
 ``backend``.
 
+This is a strict equality check, where the underlying geometries must
+have exactly the same type, component vertices and vertex order.
+
 Implementations:
 
-- GEOS: this method performs a slow, topological check, where geometries are considered equal if all of the their component edges overlap. E.g. lines with the same vertex locations but opposite direction will be considered equal by this method.
-- QGIS: this is a strict equality check, where the underlying geometries must have exactly the same type, component vertices and vertex order.
+- GEOS
+- QGIS
 
 The QGIS internal implementation is chosen by default.
 
 .. note::
 
    Comparing two null geometries will return ``False``.
+
+.. versionadded:: 4.0
+%End
+
+    bool isTopologicallyEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::GEOS ) const;
+%Docstring
+Compares the geometry with another geometry using the specified
+``backend``.
+
+This method performs a slow, topological check, where geometries are
+considered equal if all of the their component edges overlap. E.g. lines
+with the same vertex locations but opposite direction will be considered
+equal by this method.
+
+Implementations:
+
+- GEOS
+
+The GEOS implementation is chosen by default.
+
+.. note::
+
+   Comparing two null geometries will return ``False``.
+
+.. versionadded:: 4.0
+%End
+
+    bool isFuzzyEqual( const QgsGeometry &geometry, double epsilon, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
+%Docstring
+Compares the geometry with another geometry within the tolerance
+``epsilon`` using the specified ``backend``.
+
+Implementations:
+
+- GEOS
+- QGIS
+
+The QGIS internal implementation is chosen by default.
+
+.. note::
+
+   Comparing two null geometries will return ``False``.
+
+.. versionadded:: 4.0
 %End
 
     bool isGeosValid( Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryengine.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryengine.sip.in
@@ -293,6 +293,7 @@ the distance tolerance of the corresponding vertex in ``geom``. If both
 are Null geometries, ```False``` is returned.
 
 :param geom: geometry to compare with
+:param epsilon: maximum difference for coordinates between the objects
 :param errorMsg: destination storage for any error message
 
 :return: true if fuzzy equivalent, else false

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryengine.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryengine.sip.in
@@ -282,8 +282,13 @@ error location.
 
     virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
 %Docstring
-Checks if this is equal to ``geom``. If both are Null geometries,
-```False``` is returned.
+Check if geometries that are topologically equivalent
+
+:param geom: other geom to compare with
+:param errorMsg: will be set to descriptive error string if the
+                 operation fails
+
+:return: true if topologically equivalent, else false
 %End
 
     virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = 0 ) const = 0;
@@ -293,10 +298,14 @@ the distance tolerance of the corresponding vertex in ``geom``. If both
 are Null geometries, ```False``` is returned.
 
 :param geom: geometry to compare with
-:param epsilon: maximum difference for coordinates between the objects
+:param epsilon: maximum difference for coordinates between the objects.
+                With a near zreo epsilon, this function will behave as
+                an exact comparison.
 :param errorMsg: destination storage for any error message
 
 :return: true if fuzzy equivalent, else false
+
+.. versionadded:: 4.2
 %End
 
     virtual bool isEmpty( QString *errorMsg ) const = 0;

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryengine.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryengine.sip.in
@@ -285,6 +285,19 @@ error location.
 Checks if this is equal to ``geom``. If both are Null geometries,
 ```False``` is returned.
 %End
+
+    virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = 0 ) const = 0;
+%Docstring
+Checks if this is equal to ``geom`` ie. if each vertex of this is within
+the distance tolerance of the corresponding vertex in ``geom``. If both
+are Null geometries, ```False``` is returned.
+
+:param geom: geometry to compare with
+:param errorMsg: destination storage for any error message
+
+:return: true if fuzzy equivalent, else false
+%End
+
     virtual bool isEmpty( QString *errorMsg ) const = 0;
 
     virtual bool isSimple( QString *errorMsg = 0 ) const = 0;

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
@@ -309,16 +309,6 @@ This method requires a QGIS build based on GEOS 3.7 or later.
 
     virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
 
-%Docstring
-Check if geometries that are topologically equivalent
-
-:param geom: other geom to compare with
-:param errorMsg: will be set to descriptive error string if the
-                 operation fails
-
-:return: true if topologically equivalent, else false
-%End
-
     virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = 0 ) const;
 
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
@@ -306,7 +306,21 @@ This method requires a QGIS build based on GEOS 3.7 or later.
 
     virtual bool isValid( QString *errorMsg = 0, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = 0 ) const;
 
+
     virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+
+%Docstring
+Check if geometries that are topologically equivalent
+
+:param geom: other geom to compare with
+:param errorMsg: will be set to descriptive error string if the
+                 operation fails
+
+:return: true if topologically equivalent, else false
+%End
+
+    virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = 0 ) const;
+
 
     virtual bool isEmpty( QString *errorMsg = 0 ) const;
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1300,6 +1300,12 @@ The development version
       CylindersAndSpheres,
     };
 
+    enum class GeometryBackend /BaseType=IntEnum/
+    {
+      QGIS,
+      GEOS,
+    };
+
     enum class GeosCreationFlag /BaseType=IntFlag/
     {
       RejectOnInvalidSubGeometry,

--- a/resources/function_help/json/equals
+++ b/resources/function_help/json/equals
@@ -2,7 +2,7 @@
   "name": "equals",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Tests whether two geometries are equal. Note that the order of their vertices matters. Returns TRUE if geometry1 is exactly equal to geometry2.",
+  "description": "Alias for 'exactly_equals' with default geometry backend QGIS. Tests whether two geometries are equal. Note that the order of their vertices matters. Returns TRUE if geometry1 is exactly equal to geometry2.",
   "arguments": [{
     "arg": "geometry1",
     "description": "a geometry"

--- a/resources/function_help/json/exactly_equals
+++ b/resources/function_help/json/exactly_equals
@@ -1,0 +1,41 @@
+{
+  "name": "exactly_equals",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Tests whether two geometries are exactly equal. Note that the order of their vertices matters. Returns TRUE if geometry1 is exactly equal to geometry2.",
+  "arguments": [{
+    "arg": "geometry1",
+    "description": "a geometry"
+  }, {
+    "arg": "geometry2",
+    "description": "a geometry"
+  }, {
+    "arg": "backend",
+    "optional": true,
+    "default": "QGIS",
+    "description": "Geometry backend implementation: QGIS or GEOS"
+  }],
+  "examples": [{
+    "expression": "exactly_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'POINT( 0 0 )' ) )",
+    "returns": "TRUE"
+  }, {
+    "expression": "exactly_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'POINT( 0 0 )' ), 'QGIS' )",
+    "returns": "TRUE"
+  }, {
+    "expression": "exactly_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'MULTIPOINT( ( 0 0 ) )' ) )",
+    "returns": "FALSE"
+  }, {
+    "expression": "exactly_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'MULTIPOINT( ( 0 0 ) )' ), 'GEOS' )",
+    "returns": "FALSE"
+  }, {
+    "expression": "exactly_equals( geom_from_wkt( 'LINESTRING( 0 0, 1 1 )' ), geom_from_wkt( 'LINESTRING( 0 0, 1 1 )' ) )",
+    "returns": "TRUE"
+  }, {
+    "expression": "exactly_equals( geom_from_wkt( 'LINESTRING( 0 0, 1 1 )' ), geom_from_wkt( 'LINESTRING( 1 1, 0 0 )' ) )",
+    "returns": "FALSE"
+  }, {
+    "expression": "exactly_equals( geom_from_wkt( 'POLYGON(( 0 0, 0 1, 1 1, 0 0 ))' ), geom_from_wkt( 'POLYGON(( 0 0, 1 1, 0 1, 0 0 ))' ) )",
+    "returns": "FALSE"
+  }],
+  "tags": ["tests", "equal", "equals", "exactly", "exactly_equals"]
+}

--- a/resources/function_help/json/fuzzy_equals
+++ b/resources/function_help/json/fuzzy_equals
@@ -1,0 +1,43 @@
+{
+  "name": "fuzzy_equals",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Tests whether two geometries are fuzzy equal. Note that the order of their vertices matters. Returns TRUE if geometry1 is fuzzy equal to geometry2.",
+  "arguments": [{
+    "arg": "geometry1",
+    "description": "a geometry"
+  }, {
+    "arg": "geometry2",
+    "description": "a geometry"
+  }, {
+    "arg": "backend",
+    "optional": true,
+    "default": "QGIS",
+    "description": "Geometry backend implementation: QGIS or GEOS"
+  }, {
+    "arg": "epsilon",
+    "optional": true,
+    "default": "1e-8",
+    "description": "maximum difference for coordinates between the objects"
+  }],
+  "examples": [{
+    "expression": "fuzzy_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'POINT( 0 0 )' ) )",
+    "returns": "TRUE"
+  }, {
+    "expression": "fuzzy_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'POINT( 0.5 0.5 )' ), epsilon:=1 )",
+    "returns": "TRUE"
+  }, {
+    "expression": "fuzzy_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'MULTIPOINT( ( 0 0 ) )' ) )",
+    "returns": "FALSE"
+  }, {
+    "expression": "fuzzy_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'MULTIPOINT( ( 0 0 ) )' ), 'GEOS' )",
+    "returns": "TRUE"
+  }, {
+    "expression": "fuzzy_equals( geom_from_wkt( 'LINESTRING( 0 0, 1 1 )' ), geom_from_wkt( 'LINESTRING( 0 0, 1.5 1.5 )' ), 'GEOS', 0.8 )",
+    "returns": "TRUE"
+  }, {
+    "expression": "fuzzy_equals( geom_from_wkt( 'LINESTRING( 0 0, 1 1 )' ), geom_from_wkt( 'LINESTRING( 0 0, 1.5 1.5 )' ), 'QGIS', 0.8 )",
+    "returns": "TRUE"
+  }],
+  "tags": ["tests", "equal", "equals", "fuzzy", "fuzzy_equals"]
+}

--- a/resources/function_help/json/overlay_exactly_equals
+++ b/resources/function_help/json/overlay_exactly_equals
@@ -1,8 +1,8 @@
 {
-  "name": "overlay_equals",
+  "name": "overlay_exactly_equals",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Alias for 'overlay_exactly_equals' with default geometry backend QGIS. Returns whether the current feature's geometry is exactly equal to at least one feature's geometry from a target layer, or returns an array of expression-based results for the features in the target layer whose geometry is exactly equal to the current feature's geometry. Note that the order of vertices matters.",
+  "description": "Returns whether the current feature's geometry is exactly equal to at least one feature's geometry from a target layer, or returns an array of expression-based results for the features in the target layer whose geometry is exactly equal to the current feature's geometry. Note that the order of vertices matters.",
   "arguments": [{
     "arg": "layer",
     "description": "the layer whose overlay is checked"
@@ -23,24 +23,32 @@
     "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
     "optional": true,
     "default": "false"
+  }, {
+    "arg": "backend",
+    "optional": true,
+    "default": "QGIS",
+    "description": "Geometry backend implementation: QGIS or GEOS"
   }],
   "examples": [{
-    "expression": "overlay_equals('regions')",
+    "expression": "overlay_exactly_equals('regions')",
     "returns": "TRUE if the current feature's geometry is exactly the same as the geometry of a region"
   }, {
-    "expression": "overlay_equals('regions', filter:= population > 10000)",
+    "expression": "overlay_exactly_equals('regions', filter:= population > 10000)",
     "returns": "TRUE if the current feature's geometry is exactly the same as the geometry of a region whose population is greater than 10000"
   }, {
-    "expression": "overlay_equals('regions', name)",
+    "expression": "overlay_exactly_equals('regions', name)",
     "returns": "an array of names, for the regions exactly equal to the current feature"
   }, {
-    "expression": "array_to_string(overlay_equals('regions', name))",
+    "expression": "overlay_exactly_equals('regions', name, backend:='QGIS')",
+    "returns": "an array of names, for the regions exactly equal to the current feature"
+  }, {
+    "expression": "array_to_string(overlay_exactly_equals('regions', name))",
     "returns": "a string as a comma separated list of names, for the regions exactly equal to the current feature"
   }, {
-    "expression": "array_sort(overlay_equals(layer:='regions', expression:=\"name\", filter:= population > 10000))",
+    "expression": "array_sort(overlay_exactly_equals(layer:='regions', expression:=\"name\", filter:= population > 10000))",
     "returns": "an ordered array of names, for the regions exactly equal to the current feature and with a population greater than 10000"
   }, {
-    "expression": "overlay_equals(layer:='regions', expression:= geom_to_wkt(@geometry), limit:=2)",
+    "expression": "overlay_exactly_equals(layer:='regions', expression:= geom_to_wkt(@geometry), limit:=2)",
     "returns": "an array of geometries (in WKT), for up to two regions exactly equal to the current feature"
   }],
   "notes": "This function requires exact equality of geometries, meaning that the geometries 'LINESTRING( 0 0, 1 1 )' and 'LINESTRING( 1 1, 0 0 )' are different.",

--- a/resources/function_help/json/overlay_fuzzy_equals
+++ b/resources/function_help/json/overlay_fuzzy_equals
@@ -1,0 +1,61 @@
+{
+  "name": "overlay_fuzzy_equals",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Returns whether the current feature's geometry is fuzzy equal to at least one feature's geometry from a target layer, or returns an array of expression-based results for the features in the target layer whose geometry is fuzzy equal to the current feature's geometry. Note that the order of vertices matters.",
+  "arguments": [{
+    "arg": "layer",
+    "description": "the layer whose overlay is checked"
+  }, {
+    "arg": "expression",
+    "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
+    "optional": true
+  }, {
+    "arg": "filter",
+    "description": "an optional expression to filter the target features to check. If not set, all the features will be checked.",
+    "optional": true
+  }, {
+    "arg": "limit",
+    "description": "an optional integer to limit the number of matching features. If not set, all the matching features will be returned.",
+    "optional": true
+  }, {
+    "arg": "cache",
+    "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
+    "optional": true,
+    "default": "false"
+  }, {
+    "arg": "backend",
+    "optional": true,
+    "default": "QGIS",
+    "description": "Geometry backend implementation: QGIS or GEOS"
+  }, {
+    "arg": "epsilon",
+    "optional": true,
+    "default": "1e-8",
+    "description": "maximum difference for coordinates between the objects"
+  }],
+  "examples": [{
+    "expression": "overlay_fuzzy_equals('regions')",
+    "returns": "TRUE if the current feature's geometry is fuzzy the same as the geometry of a region"
+  }, {
+    "expression": "overlay_fuzzy_equals('regions', filter:= population > 10000)",
+    "returns": "TRUE if the current feature's geometry is fuzzy the same as the geometry of a region whose population is greater than 10000"
+  }, {
+    "expression": "overlay_fuzzy_equals('regions', name)",
+    "returns": "an array of names, for the regions fuzzy equal to the current feature"
+  }, {
+    "expression": "overlay_fuzzy_equals('regions', name, backend:='QGIS')",
+    "returns": "an array of names, for the regions fuzzy equal to the current feature"
+  }, {
+    "expression": "array_to_string(overlay_fuzzy_equals('regions', name, epsilon:=0.5))",
+    "returns": "a string as a comma separated list of names, for the regions fuzzy equal to the current feature"
+  }, {
+    "expression": "array_sort(overlay_fuzzy_equals(layer:='regions', expression:=\"name\", filter:= population > 10000))",
+    "returns": "an ordered array of names, for the regions fuzzy equal to the current feature and with a population greater than 10000"
+  }, {
+    "expression": "overlay_fuzzy_equals(layer:='regions', expression:= geom_to_wkt(@geometry), limit:=2)",
+    "returns": "an array of geometries (in WKT), for up to two regions fuzzy equal to the current feature"
+  }],
+  "notes": "This function requires exact equality of geometries, meaning that the geometries 'LINESTRING( 0 0, 1 1 )' and 'LINESTRING( 1 1, 0 0 )' are different.",
+  "tags": ["predicate", "current", "equals", "equal", "target", "array", "fuzzy", "described", "underlying", "features"]
+}

--- a/resources/function_help/json/overlay_topologically_equals
+++ b/resources/function_help/json/overlay_topologically_equals
@@ -1,0 +1,56 @@
+{
+  "name": "overlay_topologically_equals",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Returns whether the current feature's geometry is topologically equal to at least one feature's geometry from a target layer, or returns an array of expression-based results for the features in the target layer whose geometry is topologically equal to the current feature's geometry. Note that the order of vertices matters.",
+  "arguments": [{
+    "arg": "layer",
+    "description": "the layer whose overlay is checked"
+  }, {
+    "arg": "expression",
+    "description": "an optional expression to evaluate on the features from the target layer. If not set, the function will just return a boolean indicating whether there is at least one match.",
+    "optional": true
+  }, {
+    "arg": "filter",
+    "description": "an optional expression to filter the target features to check. If not set, all the features will be checked.",
+    "optional": true
+  }, {
+    "arg": "limit",
+    "description": "an optional integer to limit the number of matching features. If not set, all the matching features will be returned.",
+    "optional": true
+  }, {
+    "arg": "cache",
+    "description": "set this to true to build a local spatial index (most of the time, this is unwanted, unless you are working with a particularly slow data provider)",
+    "optional": true,
+    "default": "false"
+  }, {
+    "arg": "backend",
+    "optional": true,
+    "default": "GEOS",
+    "description": "Geometry backend implementation: GEOS"
+  }],
+  "examples": [{
+    "expression": "overlay_topologically_equals('regions')",
+    "returns": "TRUE if the current feature's geometry is topologically the same as the geometry of a region"
+  }, {
+    "expression": "overlay_topologically_equals('regions', filter:= population > 10000)",
+    "returns": "TRUE if the current feature's geometry is topologically the same as the geometry of a region whose population is greater than 10000"
+  }, {
+    "expression": "overlay_topologically_equals('regions', name)",
+    "returns": "an array of names, for the regions topologically equal to the current feature"
+  }, {
+    "expression": "overlay_topologically_equals('regions', name, backend:='GEOS')",
+    "returns": "an array of names, for the regions topologically equal to the current feature"
+  }, {
+    "expression": "array_to_string(overlay_topologically_equals('regions', name))",
+    "returns": "a string as a comma separated list of names, for the regions topologically equal to the current feature"
+  }, {
+    "expression": "array_sort(overlay_topologically_equals(layer:='regions', expression:=\"name\", filter:= population > 10000))",
+    "returns": "an ordered array of names, for the regions topologically equal to the current feature and with a population greater than 10000"
+  }, {
+    "expression": "overlay_topologically_equals(layer:='regions', expression:= geom_to_wkt(@geometry), limit:=2)",
+    "returns": "an array of geometries (in WKT), for up to two regions topologically equal to the current feature"
+  }],
+  "notes": "This function requires exact equality of geometries, meaning that the geometries 'LINESTRING( 0 0, 1 1 )' and 'LINESTRING( 1 1, 0 0 )' are different.",
+  "tags": ["predicate", "current", "equals", "equal", "target", "array", "topologically", "described", "underlying", "features"]
+}

--- a/resources/function_help/json/topologically_equals
+++ b/resources/function_help/json/topologically_equals
@@ -1,0 +1,35 @@
+{
+  "name": "topologically_equals",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Tests whether two geometries are topologically equal. Note that the order of their vertices matters. Returns TRUE if geometry1 is topologically equal to geometry2.",
+  "arguments": [{
+    "arg": "geometry1",
+    "description": "a geometry"
+  }, {
+    "arg": "geometry2",
+    "description": "a geometry"
+  }, {
+    "arg": "backend",
+    "optional": true,
+    "default": "GEOS",
+    "description": "Geometry backend implementation: GEOS"
+  }],
+  "examples": [{
+    "expression": "topologically_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'POINT( 0 0 )' ) )",
+    "returns": "TRUE"
+  }, {
+    "expression": "topologically_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'POINT( 0 0 )' ), 'GEOS' )",
+    "returns": "TRUE"
+  }, {
+    "expression": "topologically_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'MULTIPOINT( ( 0 0 ) )' ) )",
+    "returns": "TRUE"
+  }, {
+    "expression": "topologically_equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'MULTIPOINT( ( 0 0 ) )' ), 'GEOS' )",
+    "returns": "TRUE"
+  }, {
+    "expression": "topologically_equals( geom_from_wkt( 'LINESTRING( 0 0, 1 1 )' ), geom_from_wkt( 'LINESTRING( 0 0, 1 1 )' ) )",
+    "returns": "TRUE"
+  }],
+  "tags": ["tests", "equal", "equals", "topologically", "topologically_equals"]
+}

--- a/src/analysis/processing/qgsalgorithmdeleteduplicategeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmdeleteduplicategeometries.cpp
@@ -167,7 +167,7 @@ QVariantMap QgsDeleteDuplicateGeometriesAlgorithm::processAlgorithm( const QVari
         }
 
         const QgsGeometry candidateGeom = geometries.value( candidateId );
-        if ( geometry.isGeosEqual( candidateGeom ) )
+        if ( geometry.isEqual( candidateGeom, Qgis::GeometryBackend::GEOS ) )
         {
           // candidate is a duplicate of feature
           uniqueFeatures.remove( candidateId );

--- a/src/analysis/processing/qgsalgorithmdeleteduplicategeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmdeleteduplicategeometries.cpp
@@ -167,7 +167,7 @@ QVariantMap QgsDeleteDuplicateGeometriesAlgorithm::processAlgorithm( const QVari
         }
 
         const QgsGeometry candidateGeom = geometries.value( candidateId );
-        if ( geometry.isEqual( candidateGeom, Qgis::GeometryBackend::GEOS ) )
+        if ( geometry.isTopologicallyEqual( candidateGeom ) )
         {
           // candidate is a duplicate of feature
           uniqueFeatures.remove( candidateId );

--- a/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
+++ b/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
@@ -335,12 +335,12 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
         {
           case Topological:
           {
-            geometryMatch = revised.isGeosEqual( original );
+            geometryMatch = revised.isEqual( original, Qgis::GeometryBackend::GEOS );
             break;
           }
 
           case Exact:
-            geometryMatch = revised.equals( original );
+            geometryMatch = revised.isEqual( original, Qgis::GeometryBackend::QGIS );
             break;
         }
 

--- a/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
+++ b/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
@@ -335,12 +335,12 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
         {
           case Topological:
           {
-            geometryMatch = revised.isEqual( original, Qgis::GeometryBackend::GEOS );
+            geometryMatch = revised.isTopologicallyEqual( original );
             break;
           }
 
           case Exact:
-            geometryMatch = revised.isEqual( original, Qgis::GeometryBackend::QGIS );
+            geometryMatch = revised.isExactlyEqual( original );
             break;
         }
 

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
@@ -65,7 +65,7 @@ void QgsSingleGeometryCheckError::update( const QgsSingleGeometryCheckError *oth
 
 bool QgsSingleGeometryCheckError::isEqual( const QgsSingleGeometryCheckError *other ) const
 {
-  return mGeometry.equals( other->mGeometry ) && mCheck == other->mCheck && mErrorLocation.equals( other->mErrorLocation ) && mVertexId == other->mVertexId;
+  return mGeometry.isEqual( other->mGeometry ) && mCheck == other->mCheck && mErrorLocation.isEqual( other->mErrorLocation ) && mVertexId == other->mVertexId;
 }
 
 bool QgsSingleGeometryCheckError::handleChanges( const QList<QgsGeometryCheck::Change> &changes )

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
@@ -65,7 +65,7 @@ void QgsSingleGeometryCheckError::update( const QgsSingleGeometryCheckError *oth
 
 bool QgsSingleGeometryCheckError::isEqual( const QgsSingleGeometryCheckError *other ) const
 {
-  return mGeometry.isEqual( other->mGeometry ) && mCheck == other->mCheck && mErrorLocation.isEqual( other->mErrorLocation ) && mVertexId == other->mVertexId;
+  return mGeometry.isExactlyEqual( other->mGeometry ) && mCheck == other->mCheck && mErrorLocation.isExactlyEqual( other->mErrorLocation ) && mVertexId == other->mVertexId;
 }
 
 bool QgsSingleGeometryCheckError::handleChanges( const QList<QgsGeometryCheck::Change> &changes )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5300,7 +5300,61 @@ static QVariant fcnEquals( const QVariantList &values, const QgsExpressionContex
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
-  return fGeom.equals( sGeom ) ? TVL_True : TVL_False;
+  return fGeom.isExactlyEqual( sGeom ) ? TVL_True : TVL_False;
+}
+
+static QVariant fcnIsExactlyEqual( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
+  QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
+  const QString backendStr = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
+
+  bool ok;
+  Qgis::GeometryBackend backend = qgsEnumKeyToValue( backendStr, Qgis::GeometryBackend::QGIS, false, &ok );
+  if ( !ok )
+    SET_EVAL_ERROR( u"Geometry backend '%1' does not exist!"_s.arg( backendStr ) );
+
+  return fGeom.isExactlyEqual( sGeom, backend ) ? TVL_True : TVL_False;
+}
+
+static QVariant fcnIsTopologicallyEqual( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
+  QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
+  const QString backendStr = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
+
+  bool ok;
+  Qgis::GeometryBackend backend = qgsEnumKeyToValue( backendStr, Qgis::GeometryBackend::GEOS, false, &ok );
+  if ( !ok )
+    SET_EVAL_ERROR( u"Geometry backend '%1' does not exist!"_s.arg( backendStr ) );
+
+  QVariant ret = TVL_False;
+  try
+  {
+    ret = fGeom.isTopologicallyEqual( sGeom, backend ) ? TVL_True : TVL_False;
+  }
+  catch ( QgsNotSupportedException &e )
+  {
+    SET_EVAL_ERROR( e.what() );
+  }
+  return ret;
+}
+
+static QVariant fcnIsFuzzyEqual( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
+  QgsGeometry sGeom = QgsExpressionUtils::getGeometry( values.at( 1 ), parent );
+  const QString backendStr = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
+
+  bool ok;
+  Qgis::GeometryBackend backend = qgsEnumKeyToValue( backendStr, Qgis::GeometryBackend::QGIS, false, &ok );
+  if ( !ok )
+    SET_EVAL_ERROR( u"Geometry backend '%1' does not exist!"_s.arg( backendStr ) );
+
+  double epsilon = QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent );
+  qDebug() << "fcnIsFuzzyEqual epsilon:" << epsilon;
+
+  return fGeom.isFuzzyEqual( sGeom, epsilon, backend ) ? TVL_True : TVL_False;
 }
 
 static QVariant fcnBuffer( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
@@ -8879,9 +8933,43 @@ static QVariant fcnGeomOverlayCrosses( const QVariantList &values, const QgsExpr
 
 static QVariant fcnGeomOverlayEquals( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
+  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
+  {
+    return geometry.isExactlyEqual( other, Qgis::GeometryBackend::QGIS );
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
+}
+
+static QVariant fcnGeomOverlayExactlyEqual( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
   RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend backend ) -> bool
   {
-    return geometry.isEqual( other, backend );
+    return geometry.isExactlyEqual( other, backend );
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
+}
+
+static QVariant fcnGeomOverlayTopologicallyEqual( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend backend ) -> bool
+  {
+    return geometry.isTopologicallyEqual( other, backend );
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
+}
+
+static QVariant fcnGeomOverlayFuzzyEqual( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  // This parameter is the epsilon tolerance
+  QgsExpressionNode *node = QgsExpressionUtils::getNode( values.at( 10 ), parent );
+  ENSURE_NO_EVAL_ERROR
+  QVariant epsilonValue = node->eval( parent, context );
+  ENSURE_NO_EVAL_ERROR
+  double epsilon = QgsExpressionUtils::getDoubleValue( epsilonValue, parent );
+
+  RelationFunction geomFunction = [epsilon]( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend backend ) -> bool
+  {
+    return geometry.isFuzzyEqual( other, epsilon, backend );
   };
   return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
 }
@@ -9673,6 +9761,9 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
       { u"overlay_contains"_s, fcnGeomOverlayContains },
       { u"overlay_crosses"_s, fcnGeomOverlayCrosses },
       { u"overlay_equals"_s, fcnGeomOverlayEquals },
+      { u"overlay_exactly_equals"_s, fcnGeomOverlayExactlyEqual },
+      { u"overlay_topologically_equals"_s, fcnGeomOverlayTopologicallyEqual },
+      { u"overlay_fuzzy_equals"_s, fcnGeomOverlayFuzzyEqual },
       { u"overlay_touches"_s, fcnGeomOverlayTouches },
       { u"overlay_disjoint"_s, fcnGeomOverlayDisjoint },
       { u"overlay_within"_s, fcnGeomOverlayWithin },
@@ -9694,7 +9785,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
           << QgsExpressionFunction::Parameter( u"min_inscribed_circle_radius"_s, true, QVariant( -1 ), false )
           << QgsExpressionFunction::Parameter( u"return_details"_s, true, false, false )
           << QgsExpressionFunction::Parameter( u"sort_by_intersection_size"_s, true, QString(), false )
-          << QgsExpressionFunction::Parameter( u"backend"_s, true, defaultBackend, false ),
+          << QgsExpressionFunction::Parameter( u"backend"_s, true, defaultBackend, false )
+          << QgsExpressionFunction::Parameter( u"epsilon"_s, true, 1e-8, false ),
         i.value(),
         u"GeometryGroup"_s,
         QString(),
@@ -9856,6 +9948,34 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
       << new QgsStaticExpressionFunction( u"overlaps"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry1"_s ) << QgsExpressionFunction::Parameter( u"geometry2"_s ), fcnOverlaps, u"GeometryGroup"_s )
       << new QgsStaticExpressionFunction( u"within"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry1"_s ) << QgsExpressionFunction::Parameter( u"geometry2"_s ), fcnWithin, u"GeometryGroup"_s )
       << new QgsStaticExpressionFunction( u"equals"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry1"_s ) << QgsExpressionFunction::Parameter( u"geometry2"_s ), fcnEquals, u"GeometryGroup"_s )
+      << new QgsStaticExpressionFunction(
+           u"isExactlyEqual"_s,
+           QgsExpressionFunction::ParameterList()
+             << QgsExpressionFunction::Parameter( u"geometry1"_s )
+             << QgsExpressionFunction::Parameter( u"geometry2"_s )
+             << QgsExpressionFunction::Parameter( u"backend"_s, true, u"QGIS"_s ),
+           fcnIsExactlyEqual,
+           u"GeometryGroup"_s
+         )
+      << new QgsStaticExpressionFunction(
+           u"isTopologicallyEqual"_s,
+           QgsExpressionFunction::ParameterList()
+             << QgsExpressionFunction::Parameter( u"geometry1"_s )
+             << QgsExpressionFunction::Parameter( u"geometry2"_s )
+             << QgsExpressionFunction::Parameter( u"backend"_s, true, u"GEOS"_s ),
+           fcnIsTopologicallyEqual,
+           u"GeometryGroup"_s
+         )
+      << new QgsStaticExpressionFunction(
+           u"isFuzzyEqual"_s,
+           QgsExpressionFunction::ParameterList()
+             << QgsExpressionFunction::Parameter( u"geometry1"_s )
+             << QgsExpressionFunction::Parameter( u"geometry2"_s )
+             << QgsExpressionFunction::Parameter( u"backend"_s, true, u"QGIS"_s )
+             << QgsExpressionFunction::Parameter( u"epsilon"_s, true, 1e-8 ),
+           fcnIsFuzzyEqual,
+           u"GeometryGroup"_s
+         )
       << new QgsStaticExpressionFunction( u"translate"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry"_s ) << QgsExpressionFunction::Parameter( u"dx"_s ) << QgsExpressionFunction::Parameter( u"dy"_s ), fcnTranslate, u"GeometryGroup"_s )
       << new QgsStaticExpressionFunction(
            u"rotate"_s,

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5314,7 +5314,16 @@ static QVariant fcnIsExactlyEqual( const QVariantList &values, const QgsExpressi
   if ( !ok )
     SET_EVAL_ERROR( u"Geometry backend '%1' does not exist!"_s.arg( backendStr ) );
 
-  return fGeom.isExactlyEqual( sGeom, backend ) ? TVL_True : TVL_False;
+  QVariant ret = TVL_False;
+  try
+  {
+    ret = fGeom.isExactlyEqual( sGeom, backend ) ? TVL_True : TVL_False;
+  }
+  catch ( QgsNotSupportedException &e )
+  {
+    SET_EVAL_ERROR( e.what() );
+  }
+  return ret;
 }
 
 static QVariant fcnIsTopologicallyEqual( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
@@ -5352,9 +5361,17 @@ static QVariant fcnIsFuzzyEqual( const QVariantList &values, const QgsExpression
     SET_EVAL_ERROR( u"Geometry backend '%1' does not exist!"_s.arg( backendStr ) );
 
   double epsilon = QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent );
-  qDebug() << "fcnIsFuzzyEqual epsilon:" << epsilon;
 
-  return fGeom.isFuzzyEqual( sGeom, epsilon, backend ) ? TVL_True : TVL_False;
+  QVariant ret = TVL_False;
+  try
+  {
+    ret = fGeom.isFuzzyEqual( sGeom, epsilon, backend ) ? TVL_True : TVL_False;
+  }
+  catch ( QgsNotSupportedException &e )
+  {
+    SET_EVAL_ERROR( e.what() );
+  }
+  return ret;
 }
 
 static QVariant fcnBuffer( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
@@ -8906,35 +8923,25 @@ static QVariant executeGeomOverlay(
 
 static QVariant fcnGeomOverlayIntersects( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
-  {
-    return geometry.intersects( other );
-  };
+  RelationFunction geomFunction = []( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &, Qgis::GeometryBackend ) -> bool { return geometry.intersects( other ); };
   return executeGeomOverlay( values, context, parent, geomFunction, false, 0, false, true );
 }
 
 static QVariant fcnGeomOverlayContains( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
-  {
-    return geometry.contains( other );
-  };
+  RelationFunction geomFunction = []( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &, Qgis::GeometryBackend ) -> bool { return geometry.contains( other ); };
   return executeGeomOverlay( values, context, parent, geomFunction );
 }
 
 static QVariant fcnGeomOverlayCrosses( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
-  {
-    return geometry.crosses( other );
-  };
+  RelationFunction geomFunction = []( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &, Qgis::GeometryBackend ) -> bool { return geometry.crosses( other ); };
   return executeGeomOverlay( values, context, parent, geomFunction );
 }
 
 static QVariant fcnGeomOverlayEquals( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
-  {
+  RelationFunction geomFunction = []( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &, Qgis::GeometryBackend ) -> bool {
     return geometry.isExactlyEqual( other, Qgis::GeometryBackend::QGIS );
   };
   return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
@@ -8942,8 +8949,7 @@ static QVariant fcnGeomOverlayEquals( const QVariantList &values, const QgsExpre
 
 static QVariant fcnGeomOverlayExactlyEqual( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend backend ) -> bool
-  {
+  RelationFunction geomFunction = []( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &, Qgis::GeometryBackend backend ) -> bool {
     return geometry.isExactlyEqual( other, backend );
   };
   return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
@@ -8951,8 +8957,7 @@ static QVariant fcnGeomOverlayExactlyEqual( const QVariantList &values, const Qg
 
 static QVariant fcnGeomOverlayTopologicallyEqual( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend backend ) -> bool
-  {
+  RelationFunction geomFunction = []( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &, Qgis::GeometryBackend backend ) -> bool {
     return geometry.isTopologicallyEqual( other, backend );
   };
   return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
@@ -8967,8 +8972,7 @@ static QVariant fcnGeomOverlayFuzzyEqual( const QVariantList &values, const QgsE
   ENSURE_NO_EVAL_ERROR
   double epsilon = QgsExpressionUtils::getDoubleValue( epsilonValue, parent );
 
-  RelationFunction geomFunction = [epsilon]( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend backend ) -> bool
-  {
+  RelationFunction geomFunction = [epsilon]( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &, Qgis::GeometryBackend backend ) -> bool {
     return geometry.isFuzzyEqual( other, epsilon, backend );
   };
   return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
@@ -8976,35 +8980,25 @@ static QVariant fcnGeomOverlayFuzzyEqual( const QVariantList &values, const QgsE
 
 static QVariant fcnGeomOverlayTouches( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
-  {
-    return geometry.touches( other );
-  };
+  RelationFunction geomFunction = []( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &, Qgis::GeometryBackend ) -> bool { return geometry.touches( other ); };
   return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
 }
 
 static QVariant fcnGeomOverlayWithin( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
-  {
-    return geometry.within( other );
-  };
+  RelationFunction geomFunction = []( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &, Qgis::GeometryBackend ) -> bool { return geometry.within( other ); };
   return executeGeomOverlay( values, context, parent, geomFunction );
 }
 
 static QVariant fcnGeomOverlayDisjoint( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
-  {
-    return geometry.intersects( other );
-  };
+  RelationFunction geomFunction = []( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &, Qgis::GeometryBackend ) -> bool { return geometry.intersects( other ); };
   return executeGeomOverlay( values, context, parent, geomFunction, true, 0, false, true );
 }
 
 static QVariant fcnGeomOverlayNearest( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  RelationFunction geomFunction = []( const QgsGeometry &, const QgsGeometry &, const QVariantList &, Qgis::GeometryBackend ) -> bool
-  {
+  RelationFunction geomFunction = []( const QgsGeometry &, const QgsGeometry &, const QVariantList &, Qgis::GeometryBackend ) -> bool {
     return true; // does nothing on purpose
   };
   return executeGeomOverlay( values, context, parent, geomFunction, false, 0, true );
@@ -9772,7 +9766,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     while ( i.hasNext() )
     {
       i.next();
-      QString defaultBackend = i.key() == u"overlay_equals"_s ? QString( "QGIS" ) : QString( "GEOS" );
+      QString defaultBackend = i.key() == "overlay_equals"_L1 ? QString( "QGIS" ) : QString( "GEOS" );
       QgsStaticExpressionFunction *fcnGeomOverlayFunc = new QgsStaticExpressionFunction(
         i.key(),
         QgsExpressionFunction::ParameterList()
@@ -9949,7 +9943,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
       << new QgsStaticExpressionFunction( u"within"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry1"_s ) << QgsExpressionFunction::Parameter( u"geometry2"_s ), fcnWithin, u"GeometryGroup"_s )
       << new QgsStaticExpressionFunction( u"equals"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry1"_s ) << QgsExpressionFunction::Parameter( u"geometry2"_s ), fcnEquals, u"GeometryGroup"_s )
       << new QgsStaticExpressionFunction(
-           u"isExactlyEqual"_s,
+           u"exactly_equals"_s,
            QgsExpressionFunction::ParameterList()
              << QgsExpressionFunction::Parameter( u"geometry1"_s )
              << QgsExpressionFunction::Parameter( u"geometry2"_s )
@@ -9958,7 +9952,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
            u"GeometryGroup"_s
          )
       << new QgsStaticExpressionFunction(
-           u"isTopologicallyEqual"_s,
+           u"topologically_equals"_s,
            QgsExpressionFunction::ParameterList()
              << QgsExpressionFunction::Parameter( u"geometry1"_s )
              << QgsExpressionFunction::Parameter( u"geometry2"_s )
@@ -9967,7 +9961,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
            u"GeometryGroup"_s
          )
       << new QgsStaticExpressionFunction(
-           u"isFuzzyEqual"_s,
+           u"fuzzy_equals"_s,
            QgsExpressionFunction::ParameterList()
              << QgsExpressionFunction::Parameter( u"geometry1"_s )
              << QgsExpressionFunction::Parameter( u"geometry2"_s )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -8217,7 +8217,8 @@ static QVariant fcnFromBase64( const QVariantList &values, const QgsExpressionCo
   return QVariant( decoded );
 }
 
-typedef bool ( QgsGeometry::*RelationFunction )( const QgsGeometry &geometry ) const;
+//! allows geometry function with different parameters to be used with the same executeGeomOverlay function
+typedef std::function<bool( const QgsGeometry &geometry, const QgsGeometry &other, const QVariantList &values, Qgis::GeometryBackend backend )> RelationFunction;
 
 static QVariant executeGeomOverlay(
   const QVariantList &values,
@@ -8287,28 +8288,9 @@ static QVariant executeGeomOverlay(
   ENSURE_NO_EVAL_ERROR
   qlonglong limit = QgsExpressionUtils::getIntValue( limitValue, parent );
 
-  // Fifth parameter (for nearest only) is the max distance
   double max_distance = 0;
-  if ( isNearestFunc ) //maxdistance param handling
-  {
-    node = QgsExpressionUtils::getNode( values.at( 4 ), parent );
-    ENSURE_NO_EVAL_ERROR
-    QVariant distanceValue = node->eval( parent, context );
-    ENSURE_NO_EVAL_ERROR
-    max_distance = QgsExpressionUtils::getDoubleValue( distanceValue, parent );
-  }
+  bool cacheEnabled = false;
 
-  // Fifth or sixth (for nearest only) parameter is the cache toggle
-  node = QgsExpressionUtils::getNode( values.at( isNearestFunc ? 5 : 4 ), parent );
-  ENSURE_NO_EVAL_ERROR
-  QVariant cacheValue = node->eval( parent, context );
-  ENSURE_NO_EVAL_ERROR
-  bool cacheEnabled = cacheValue.toBool();
-
-  // Sixth parameter (for intersects only) is the min overlap (area or length)
-  // Seventh parameter (for intersects only) is the min inscribed circle radius
-  // Eighth parameter (for intersects only) is the return_details
-  // Ninth parameter (for intersects only) is the sort_by_intersection_size flag
   double minOverlap { -1 };
   double minInscribedCircleRadius { -1 };
   bool returnDetails = false; //#spellok
@@ -8316,21 +8298,54 @@ static QVariant executeGeomOverlay(
   bool sortAscending = false;
   bool requireMeasures = false;
   bool overlapOrRadiusFilter = false;
-  if ( isIntersectsFunc )
+
+  Qgis::GeometryBackend backend = Qgis::GeometryBackend::GEOS;
+
+  if ( isNearestFunc ) //maxdistance param handling
   {
+    // Fifth parameter (for nearest only) is the max distance
+    node = QgsExpressionUtils::getNode( values.at( 4 ), parent );
+    ENSURE_NO_EVAL_ERROR
+    QVariant distanceValue = node->eval( parent, context );
+    ENSURE_NO_EVAL_ERROR
+    max_distance = QgsExpressionUtils::getDoubleValue( distanceValue, parent );
+
+    // Sixth (for nearest only) parameter is the cache toggle
+    node = QgsExpressionUtils::getNode( values.at( 5 ), parent );
+    ENSURE_NO_EVAL_ERROR
+    QVariant cacheValue = node->eval( parent, context );
+    ENSURE_NO_EVAL_ERROR
+    cacheEnabled = cacheValue.toBool();
+  }
+  else
+  {
+    // Fifth parameter is the cache toggle
+    node = QgsExpressionUtils::getNode( values.at( 4 ), parent );
+    ENSURE_NO_EVAL_ERROR
+    QVariant cacheValue = node->eval( parent, context );
+    ENSURE_NO_EVAL_ERROR
+    cacheEnabled = cacheValue.toBool();
+
+    // Sixth parameter is the min overlap (area or length)
     node = QgsExpressionUtils::getNode( values.at( 5 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
     ENSURE_NO_EVAL_ERROR
     const QVariant minOverlapValue = node->eval( parent, context );
     ENSURE_NO_EVAL_ERROR
     minOverlap = QgsExpressionUtils::getDoubleValue( minOverlapValue, parent );
+
+    // Seventh parameter is the min inscribed circle radius
     node = QgsExpressionUtils::getNode( values.at( 6 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
     ENSURE_NO_EVAL_ERROR
     const QVariant minInscribedCircleRadiusValue = node->eval( parent, context );
     ENSURE_NO_EVAL_ERROR
     minInscribedCircleRadius = QgsExpressionUtils::getDoubleValue( minInscribedCircleRadiusValue, parent );
+
+    // Eighth parameter is the return_details
     node = QgsExpressionUtils::getNode( values.at( 7 ), parent );
     // Return measures is only effective when an expression is set
     returnDetails = !testOnly && node->eval( parent, context ).toBool(); //#spellok
+
+    // Ninth parameter is the sort_by_intersection_size flag
     node = QgsExpressionUtils::getNode( values.at( 8 ), parent );
     // Sort by measures is only effective when an expression is set
     const QString sorting { node->eval( parent, context ).toString().toLower() };
@@ -8338,8 +8353,18 @@ static QVariant executeGeomOverlay(
     sortAscending = sorting.startsWith( "asc" );
     requireMeasures = sortByMeasure || returnDetails; //#spellok
     overlapOrRadiusFilter = minInscribedCircleRadius != -1 || minOverlap != -1;
-  }
 
+    // Tenth parameter is the geometry backend
+    node = QgsExpressionUtils::getNode( values.at( 9 ), parent ); //in expressions overlay functions throw the exception: Eval Error: Cannot convert '' to int
+    ENSURE_NO_EVAL_ERROR
+    const QString backendStr = node->eval( parent, context ).toString().toUpper();
+    ENSURE_NO_EVAL_ERROR
+
+    bool ok;
+    backend = qgsEnumKeyToValue( backendStr, Qgis::GeometryBackend::GEOS, false, &ok );
+    if ( !ok )
+      SET_EVAL_ERROR( u"Geometry backend '%1' does not exist!"_s.arg( backendStr ) );
+  }
 
   FEAT_FROM_CONTEXT( context, feat )
   const QgsGeometry geometry = feat.geometry();
@@ -8549,45 +8574,72 @@ static QVariant executeGeomOverlay(
   QVariantList results;
 
   QListIterator<QgsFeature> i( features );
-  while ( i.hasNext() && ( sortByMeasure || limit == -1 || foundCount < limit ) )
+  try
   {
-    QgsFeature feat2 = i.next();
-
-
-    if ( !relationFunction || ( geometry.*relationFunction )( feat2.geometry() ) ) // Calls the method provided as template argument for the function (e.g. QgsGeometry::intersects)
+    while ( i.hasNext() && ( sortByMeasure || limit == -1 || foundCount < limit ) )
     {
-      double overlapValue = -1;
-      double radiusValue = -1;
+      QgsFeature feat2 = i.next();
 
-      if ( isIntersectsFunc && ( requireMeasures || overlapOrRadiusFilter ) )
+
+      if ( relationFunction( geometry, feat2.geometry(), values, backend ) ) // Calls the method provided as template argument for the function (e.g. QgsGeometry::intersects)
       {
-        QgsGeometry intersection { geometry.intersection( feat2.geometry() ) };
+        double overlapValue = -1;
+        double radiusValue = -1;
 
-        // Pre-process collections: if the tested geometry is a polygon we take the polygons from the collection
-        if ( intersection.wkbType() == Qgis::WkbType::GeometryCollection )
+        if ( isIntersectsFunc && ( requireMeasures || overlapOrRadiusFilter ) )
         {
-          const QVector<QgsGeometry> geometries { intersection.asGeometryCollection() };
-          intersection = QgsGeometry();
-          QgsMultiPolygonXY poly;
-          QgsMultiPolylineXY line;
-          QgsMultiPointXY point;
-          for ( const auto &geom : std::as_const( geometries ) )
+          QgsGeometry intersection { geometry.intersection( feat2.geometry(), QgsGeometryParameters() ) };
+
+          // Pre-process collections: if the tested geometry is a polygon we take the polygons from the collection
+          if ( intersection.wkbType() == Qgis::WkbType::GeometryCollection )
           {
-            switch ( geom.type() )
+            const QVector<QgsGeometry> geometries { intersection.asGeometryCollection() };
+            intersection = QgsGeometry();
+            QgsMultiPolygonXY poly;
+            QgsMultiPolylineXY line;
+            QgsMultiPointXY point;
+            for ( const auto &geom : std::as_const( geometries ) )
+            {
+              switch ( geom.type() )
+              {
+                case Qgis::GeometryType::Polygon:
+                {
+                  poly.append( geom.asPolygon() );
+                  break;
+                }
+                case Qgis::GeometryType::Line:
+                {
+                  line.append( geom.asPolyline() );
+                  break;
+                }
+                case Qgis::GeometryType::Point:
+                {
+                  point.append( geom.asPoint() );
+                  break;
+                }
+                case Qgis::GeometryType::Unknown:
+                case Qgis::GeometryType::Null:
+                {
+                  break;
+                }
+              }
+            }
+
+            switch ( geometry.type() )
             {
               case Qgis::GeometryType::Polygon:
               {
-                poly.append( geom.asPolygon() );
+                intersection = QgsGeometry::fromMultiPolygonXY( poly );
                 break;
               }
               case Qgis::GeometryType::Line:
               {
-                line.append( geom.asPolyline() );
+                intersection = QgsGeometry::fromMultiPolylineXY( line );
                 break;
               }
               case Qgis::GeometryType::Point:
               {
-                point.append( geom.asPoint() );
+                intersection = QgsGeometry::fromMultiPointXY( point );
                 break;
               }
               case Qgis::GeometryType::Unknown:
@@ -8598,164 +8650,145 @@ static QVariant executeGeomOverlay(
             }
           }
 
-          switch ( geometry.type() )
+          // Depending on the intersection geometry type and on the geometry type of
+          // the tested geometry we can run different tests and collect different measures
+          // that can be used for sorting (if required).
+          switch ( intersection.type() )
           {
             case Qgis::GeometryType::Polygon:
             {
-              intersection = QgsGeometry::fromMultiPolygonXY( poly );
-              break;
-            }
-            case Qgis::GeometryType::Line:
-            {
-              intersection = QgsGeometry::fromMultiPolylineXY( line );
-              break;
-            }
-            case Qgis::GeometryType::Point:
-            {
-              intersection = QgsGeometry::fromMultiPointXY( point );
-              break;
-            }
-            case Qgis::GeometryType::Unknown:
-            case Qgis::GeometryType::Null:
-            {
-              break;
-            }
-          }
-        }
-
-        // Depending on the intersection geometry type and on the geometry type of
-        // the tested geometry we can run different tests and collect different measures
-        // that can be used for sorting (if required).
-        switch ( intersection.type() )
-        {
-          case Qgis::GeometryType::Polygon:
-          {
-            // Overlap and inscribed circle tests must be checked both (if the values are != -1)
-            bool testResult { testPolygon( intersection, radiusValue, overlapValue ) };
-
-            if ( !testResult && overlapOrRadiusFilter )
-            {
-              continue;
-            }
-
-            break;
-          }
-
-          case Qgis::GeometryType::Line:
-          {
-            // If the intersection is a linestring and a minimum circle is required
-            // we can discard this result immediately.
-            if ( minInscribedCircleRadius != -1 )
-            {
-              continue;
-            }
-
-            // Otherwise a test for the overlap value is performed.
-            const bool testResult { testLinestring( intersection, overlapValue ) };
-
-            if ( !testResult && overlapOrRadiusFilter )
-            {
-              continue;
-            }
-
-            break;
-          }
-
-          case Qgis::GeometryType::Point:
-          {
-            // If the intersection is a point and a minimum circle is required
-            // we can discard this result immediately.
-            if ( minInscribedCircleRadius != -1 )
-            {
-              continue;
-            }
-
-            bool testResult { false };
-            if ( minOverlap != -1 || requireMeasures )
-            {
-              // Initially set this to 0 because it's a point intersection...
-              overlapValue = 0;
-              // ... but if the target geometry is not a point and the source
-              // geometry is a point, we must record the length or the area
-              // of the intersected geometry and use that as a measure for
-              // sorting or reporting.
-              if ( geometry.type() == Qgis::GeometryType::Point )
-              {
-                switch ( feat2.geometry().type() )
-                {
-                  case Qgis::GeometryType::Unknown:
-                  case Qgis::GeometryType::Null:
-                  case Qgis::GeometryType::Point:
-                  {
-                    break;
-                  }
-                  case Qgis::GeometryType::Line:
-                  {
-                    testResult = testLinestring( feat2.geometry(), overlapValue );
-                    break;
-                  }
-                  case Qgis::GeometryType::Polygon:
-                  {
-                    testResult = testPolygon( feat2.geometry(), radiusValue, overlapValue );
-                    break;
-                  }
-                }
-              }
+              // Overlap and inscribed circle tests must be checked both (if the values are != -1)
+              bool testResult { testPolygon( intersection, radiusValue, overlapValue ) };
 
               if ( !testResult && overlapOrRadiusFilter )
               {
                 continue;
               }
-            }
-            break;
-          }
 
-          case Qgis::GeometryType::Null:
-          case Qgis::GeometryType::Unknown:
-          {
-            continue;
+              break;
+            }
+
+            case Qgis::GeometryType::Line:
+            {
+              // If the intersection is a linestring and a minimum circle is required
+              // we can discard this result immediately.
+              if ( minInscribedCircleRadius != -1 )
+              {
+                continue;
+              }
+
+              // Otherwise a test for the overlap value is performed.
+              const bool testResult { testLinestring( intersection, overlapValue ) };
+
+              if ( !testResult && overlapOrRadiusFilter )
+              {
+                continue;
+              }
+
+              break;
+            }
+
+            case Qgis::GeometryType::Point:
+            {
+              // If the intersection is a point and a minimum circle is required
+              // we can discard this result immediately.
+              if ( minInscribedCircleRadius != -1 )
+              {
+                continue;
+              }
+
+              bool testResult { false };
+              if ( minOverlap != -1 || requireMeasures )
+              {
+                // Initially set this to 0 because it's a point intersection...
+                overlapValue = 0;
+                // ... but if the target geometry is not a point and the source
+                // geometry is a point, we must record the length or the area
+                // of the intersected geometry and use that as a measure for
+                // sorting or reporting.
+                if ( geometry.type() == Qgis::GeometryType::Point )
+                {
+                  switch ( feat2.geometry().type() )
+                  {
+                    case Qgis::GeometryType::Unknown:
+                    case Qgis::GeometryType::Null:
+                    case Qgis::GeometryType::Point:
+                    {
+                      break;
+                    }
+                    case Qgis::GeometryType::Line:
+                    {
+                      testResult = testLinestring( feat2.geometry(), overlapValue );
+                      break;
+                    }
+                    case Qgis::GeometryType::Polygon:
+                    {
+                      testResult = testPolygon( feat2.geometry(), radiusValue, overlapValue );
+                      break;
+                    }
+                  }
+                }
+
+                if ( !testResult && overlapOrRadiusFilter )
+                {
+                  continue;
+                }
+              }
+              break;
+            }
+
+            case Qgis::GeometryType::Null:
+            case Qgis::GeometryType::Unknown:
+            {
+              continue;
+            }
           }
         }
-      }
 
-      found = true;
-      foundCount++;
+        found = true;
+        foundCount++;
 
-      // We just want a single boolean result if there is any intersect: finish and return true
-      if ( testOnly )
-        break;
+        // We just want a single boolean result if there is any intersect: finish and return true
+        if ( testOnly )
+          break;
 
-      if ( !invert )
-      {
-        // We want a list of attributes / geometries / other expression values, evaluate now
-        subContext.setFeature( feat2 );
-        const QVariant expResult = subExpression.evaluate( &subContext );
-
-        if ( requireMeasures )
+        if ( !invert )
         {
-          QVariantMap resultRecord;
-          resultRecord.insert( u"id"_s, feat2.id() );
-          resultRecord.insert( u"result"_s, expResult );
-          // Overlap is always added because return measures was set
-          resultRecord.insert( u"overlap"_s, overlapValue );
-          // Radius is only added when is different than -1 (because for linestrings is not set)
-          if ( radiusValue != -1 )
+          // We want a list of attributes / geometries / other expression values, evaluate now
+          subContext.setFeature( feat2 );
+          const QVariant expResult = subExpression.evaluate( &subContext );
+
+          if ( requireMeasures )
           {
-            resultRecord.insert( u"radius"_s, radiusValue );
+            QVariantMap resultRecord;
+            resultRecord.insert( u"id"_s, feat2.id() );
+            resultRecord.insert( u"result"_s, expResult );
+            // Overlap is always added because return measures was set
+            resultRecord.insert( u"overlap"_s, overlapValue );
+            // Radius is only added when is different than -1 (because for linestrings is not set)
+            if ( radiusValue != -1 )
+            {
+              resultRecord.insert( u"radius"_s, radiusValue );
+            }
+            results.append( resultRecord );
           }
-          results.append( resultRecord );
+          else
+          {
+            results.append( expResult );
+          }
         }
         else
         {
-          results.append( expResult );
+          // If not, results is a list of found ids, which we'll inverse and evaluate below
+          results.append( feat2.id() );
         }
       }
-      else
-      {
-        // If not, results is a list of found ids, which we'll inverse and evaluate below
-        results.append( feat2.id() );
-      }
     }
+  }
+  catch ( QgsException &e )
+  {
+    parent->setEvalErrorString( e.what() );
+    return false;
   }
 
   if ( testOnly )
@@ -8819,42 +8852,74 @@ static QVariant executeGeomOverlay(
 
 static QVariant fcnGeomOverlayIntersects( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  return executeGeomOverlay( values, context, parent, &QgsGeometry::intersects, false, 0, false, true );
+  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
+  {
+    return geometry.intersects( other );
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction, false, 0, false, true );
 }
 
 static QVariant fcnGeomOverlayContains( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  return executeGeomOverlay( values, context, parent, &QgsGeometry::contains );
+  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
+  {
+    return geometry.contains( other );
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction );
 }
 
 static QVariant fcnGeomOverlayCrosses( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  return executeGeomOverlay( values, context, parent, &QgsGeometry::crosses );
+  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
+  {
+    return geometry.crosses( other );
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction );
 }
 
 static QVariant fcnGeomOverlayEquals( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  return executeGeomOverlay( values, context, parent, &QgsGeometry::equals, false, 0.01 ); //grow amount should adapt to current units
+  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend backend ) -> bool
+  {
+    return geometry.isEqual( other, backend );
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
 }
 
 static QVariant fcnGeomOverlayTouches( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  return executeGeomOverlay( values, context, parent, &QgsGeometry::touches, false, 0.01 ); //grow amount should adapt to current units
+  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
+  {
+    return geometry.touches( other );
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction, false, 0.01 ); //grow amount should adapt to current units
 }
 
 static QVariant fcnGeomOverlayWithin( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  return executeGeomOverlay( values, context, parent, &QgsGeometry::within );
+  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
+  {
+    return geometry.within( other );
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction );
 }
 
 static QVariant fcnGeomOverlayDisjoint( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  return executeGeomOverlay( values, context, parent, &QgsGeometry::intersects, true, 0, false, true );
+  RelationFunction geomFunction = []( const QgsGeometry & geometry, const QgsGeometry & other, const QVariantList &, Qgis::GeometryBackend ) -> bool
+  {
+    return geometry.intersects( other );
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction, true, 0, false, true );
 }
 
 static QVariant fcnGeomOverlayNearest( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  return executeGeomOverlay( values, context, parent, nullptr, false, 0, true );
+  RelationFunction geomFunction = []( const QgsGeometry &, const QgsGeometry &, const QVariantList &, Qgis::GeometryBackend ) -> bool
+  {
+    return true; // does nothing on purpose
+  };
+  return executeGeomOverlay( values, context, parent, geomFunction, false, 0, true );
 }
 
 const QList<QgsExpressionFunction *> &QgsExpression::Functions()
@@ -9616,6 +9681,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     while ( i.hasNext() )
     {
       i.next();
+      QString defaultBackend = i.key() == u"overlay_equals"_s ? QString( "QGIS" ) : QString( "GEOS" );
       QgsStaticExpressionFunction *fcnGeomOverlayFunc = new QgsStaticExpressionFunction(
         i.key(),
         QgsExpressionFunction::ParameterList()
@@ -9627,7 +9693,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
           << QgsExpressionFunction::Parameter( u"min_overlap"_s, true, QVariant( -1 ), false )
           << QgsExpressionFunction::Parameter( u"min_inscribed_circle_radius"_s, true, QVariant( -1 ), false )
           << QgsExpressionFunction::Parameter( u"return_details"_s, true, false, false )
-          << QgsExpressionFunction::Parameter( u"sort_by_intersection_size"_s, true, QString(), false ),
+          << QgsExpressionFunction::Parameter( u"sort_by_intersection_size"_s, true, QString(), false )
+          << QgsExpressionFunction::Parameter( u"backend"_s, true, defaultBackend, false ),
         i.value(),
         u"GeometryGroup"_s,
         QString(),

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1630,7 +1630,7 @@ bool QgsGeometry::disjoint( const QgsGeometry &geometry ) const
 
 bool QgsGeometry::equals( const QgsGeometry &geometry ) const
 {
-  return isEqual( geometry, Qgis::GeometryBackend::QGIS );
+  return isExactlyEqual( geometry );
 }
 
 bool QgsGeometry::touches( const QgsGeometry &geometry ) const
@@ -3711,10 +3711,54 @@ bool QgsGeometry::isAxisParallelRectangle( double maximumDeviation, bool simpleR
 
 bool QgsGeometry::isGeosEqual( const QgsGeometry &g ) const
 {
-  return isEqual( g, Qgis::GeometryBackend::GEOS );
+  return isTopologicallyEqual( g, Qgis::GeometryBackend::GEOS );
 }
 
-bool QgsGeometry::isEqual( const QgsGeometry &g, Qgis::GeometryBackend backend ) const
+bool QgsGeometry::isExactlyEqual( const QgsGeometry &g, Qgis::GeometryBackend backend ) const
+{
+  if ( !d->geometry || g.isNull() )
+  {
+    return false;
+  }
+
+  // fast check - are they shared copies of the same underlying geometry?
+  if ( d == g.d )
+    return true;
+
+  // fast check - distinct geometry types?
+  if ( type() != g.type() )
+    return false;
+
+  //  another nice fast check upfront -- if the bounding boxes aren't equal, the geometries themselves can't be equal!
+  if ( d->geometry->boundingBox() != g.d->geometry->boundingBox() )
+    return false;
+
+  mLastError.clear();
+  switch ( backend )
+  {
+    case Qgis::GeometryBackend::GEOS:
+    {
+      // avoid calling geos for trivial point case
+      if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == Qgis::WkbType::Point
+           && QgsWkbTypes::flatType( g.d->geometry->wkbType() ) == Qgis::WkbType::Point )
+        return *d->geometry == *g.d->geometry;
+
+      QgsGeos geos( d->geometry.get() );
+      return geos.isFuzzyEqual( g.d->geometry.get(), 1e-8, &mLastError );
+    }
+
+    case Qgis::GeometryBackend::QGIS:
+    {
+      // slower check - actually test the geometries
+      return *d->geometry == *g.d->geometry;
+    }
+
+    default:
+      throw QgsNotSupportedException( u"Geometry backend '%1' is not supported by this function."_s.arg( qgsEnumValueToKey( backend ) ) );
+  }
+}
+
+bool QgsGeometry::isTopologicallyEqual( const QgsGeometry &g, Qgis::GeometryBackend backend ) const
 {
   if ( !d->geometry || !g.d->geometry )
   {
@@ -3747,10 +3791,39 @@ bool QgsGeometry::isEqual( const QgsGeometry &g, Qgis::GeometryBackend backend )
       return geos.isEqual( g.d->geometry.get(), &mLastError );
     }
 
+    default:
+      throw QgsNotSupportedException( u"Geometry backend '%1' is not supported by this function."_s.arg( qgsEnumValueToKey( backend ) ) );
+  }
+}
+
+bool QgsGeometry::isFuzzyEqual( const QgsGeometry &g, double epsilon, Qgis::GeometryBackend backend ) const
+{
+  if ( !d->geometry || g.isNull() )
+  {
+    return false;
+  }
+
+  // fast check - are they shared copies of the same underlying geometry?
+  if ( d == g.d )
+    return true;
+
+  // fast check - distinct geometry types?
+  if ( type() != g.type() )
+    return false;
+
+  mLastError.clear();
+  switch ( backend )
+  {
+    case Qgis::GeometryBackend::GEOS:
+    {
+      QgsGeos geos( d->geometry.get() );
+      return geos.isFuzzyEqual( g.d->geometry.get(), epsilon, &mLastError );
+    }
+
     case Qgis::GeometryBackend::QGIS:
     {
       // slower check - actually test the geometries
-      return *d->geometry == *g.d->geometry;
+      return d->geometry->fuzzyEqual( *g.d->geometry, epsilon );
     }
 
     default:

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3729,21 +3729,22 @@ bool QgsGeometry::isExactlyEqual( const QgsGeometry &g, Qgis::GeometryBackend ba
   if ( type() != g.type() )
     return false;
 
-  //  another nice fast check upfront -- if the bounding boxes aren't equal, the geometries themselves can't be equal!
-  if ( d->geometry->boundingBox() != g.d->geometry->boundingBox() )
-    return false;
-
   mLastError.clear();
   switch ( backend )
   {
     case Qgis::GeometryBackend::GEOS:
     {
+      //  another nice fast check upfront -- if the bounding boxes aren't equal, the geometries themselves can't be equal!
+      if ( d->geometry->boundingBox() != g.d->geometry->boundingBox() )
+        return false;
+
       // avoid calling geos for trivial point case
       if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == Qgis::WkbType::Point
            && QgsWkbTypes::flatType( g.d->geometry->wkbType() ) == Qgis::WkbType::Point )
         return *d->geometry == *g.d->geometry;
 
       QgsGeos geos( d->geometry.get() );
+      // fuzzy check call, with near zero epsilon, will behave as an exact comparison
       return geos.isFuzzyEqual( g.d->geometry.get(), 1e-8, &mLastError );
     }
 
@@ -3752,9 +3753,6 @@ bool QgsGeometry::isExactlyEqual( const QgsGeometry &g, Qgis::GeometryBackend ba
       // slower check - actually test the geometries
       return *d->geometry == *g.d->geometry;
     }
-
-    default:
-      throw QgsNotSupportedException( u"Geometry backend '%1' is not supported by this function."_s.arg( qgsEnumValueToKey( backend ) ) );
   }
 }
 
@@ -3791,7 +3789,7 @@ bool QgsGeometry::isTopologicallyEqual( const QgsGeometry &g, Qgis::GeometryBack
       return geos.isEqual( g.d->geometry.get(), &mLastError );
     }
 
-    default:
+    case Qgis::GeometryBackend::QGIS:
       throw QgsNotSupportedException( u"Geometry backend '%1' is not supported by this function."_s.arg( qgsEnumValueToKey( backend ) ) );
   }
 }
@@ -3825,9 +3823,6 @@ bool QgsGeometry::isFuzzyEqual( const QgsGeometry &g, double epsilon, Qgis::Geom
       // slower check - actually test the geometries
       return d->geometry->fuzzyEqual( *g.d->geometry, epsilon );
     }
-
-    default:
-      throw QgsNotSupportedException( u"Geometry backend '%1' is not supported by this function."_s.arg( qgsEnumValueToKey( backend ) ) );
   }
 }
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1630,21 +1630,7 @@ bool QgsGeometry::disjoint( const QgsGeometry &geometry ) const
 
 bool QgsGeometry::equals( const QgsGeometry &geometry ) const
 {
-  if ( !d->geometry || geometry.isNull() )
-  {
-    return false;
-  }
-
-  // fast check - are they shared copies of the same underlying geometry?
-  if ( d == geometry.d )
-    return true;
-
-  // fast check - distinct geometry types?
-  if ( type() != geometry.type() )
-    return false;
-
-  // slower check - actually test the geometries
-  return *d->geometry == *geometry.d->geometry;
+  return isEqual( geometry, Qgis::GeometryBackend::QGIS );
 }
 
 bool QgsGeometry::touches( const QgsGeometry &geometry ) const
@@ -3725,6 +3711,11 @@ bool QgsGeometry::isAxisParallelRectangle( double maximumDeviation, bool simpleR
 
 bool QgsGeometry::isGeosEqual( const QgsGeometry &g ) const
 {
+  return isEqual( g, Qgis::GeometryBackend::GEOS );
+}
+
+bool QgsGeometry::isEqual( const QgsGeometry &g, Qgis::GeometryBackend backend ) const
+{
   if ( !d->geometry || !g.d->geometry )
   {
     return false;
@@ -3738,19 +3729,33 @@ bool QgsGeometry::isGeosEqual( const QgsGeometry &g ) const
   if ( type() != g.type() )
     return false;
 
-  // avoid calling geos for trivial point case
-  if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == Qgis::WkbType::Point && QgsWkbTypes::flatType( g.d->geometry->wkbType() ) == Qgis::WkbType::Point )
-  {
-    return equals( g );
-  }
-
   //  another nice fast check upfront -- if the bounding boxes aren't equal, the geometries themselves can't be equal!
   if ( d->geometry->boundingBox() != g.d->geometry->boundingBox() )
     return false;
 
-  QgsGeos geos( d->geometry.get() );
   mLastError.clear();
-  return geos.isEqual( g.d->geometry.get(), &mLastError );
+  switch ( backend )
+  {
+    case Qgis::GeometryBackend::GEOS:
+    {
+      // avoid calling geos for trivial point case
+      if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == Qgis::WkbType::Point
+           && QgsWkbTypes::flatType( g.d->geometry->wkbType() ) == Qgis::WkbType::Point )
+        return *d->geometry == *g.d->geometry;
+
+      QgsGeos geos( d->geometry.get() );
+      return geos.isEqual( g.d->geometry.get(), &mLastError );
+    }
+
+    case Qgis::GeometryBackend::QGIS:
+    {
+      // slower check - actually test the geometries
+      return *d->geometry == *g.d->geometry;
+    }
+
+    default:
+      throw QgsNotSupportedException( u"Geometry backend '%1' is not supported by this function."_s.arg( qgsEnumValueToKey( backend ) ) );
+  }
 }
 
 QgsGeometry QgsGeometry::unaryUnion( const QVector<QgsGeometry> &geometries, const QgsGeometryParameters &parameters )

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3739,8 +3739,7 @@ bool QgsGeometry::isExactlyEqual( const QgsGeometry &g, Qgis::GeometryBackend ba
         return false;
 
       // avoid calling geos for trivial point case
-      if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == Qgis::WkbType::Point
-           && QgsWkbTypes::flatType( g.d->geometry->wkbType() ) == Qgis::WkbType::Point )
+      if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == Qgis::WkbType::Point && QgsWkbTypes::flatType( g.d->geometry->wkbType() ) == Qgis::WkbType::Point )
         return *d->geometry == *g.d->geometry;
 
       QgsGeos geos( d->geometry.get() );
@@ -3781,8 +3780,7 @@ bool QgsGeometry::isTopologicallyEqual( const QgsGeometry &g, Qgis::GeometryBack
     case Qgis::GeometryBackend::GEOS:
     {
       // avoid calling geos for trivial point case
-      if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == Qgis::WkbType::Point
-           && QgsWkbTypes::flatType( g.d->geometry->wkbType() ) == Qgis::WkbType::Point )
+      if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == Qgis::WkbType::Point && QgsWkbTypes::flatType( g.d->geometry->wkbType() ) == Qgis::WkbType::Point )
         return *d->geometry == *g.d->geometry;
 
       QgsGeos geos( d->geometry.get() );

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -441,9 +441,9 @@ class CORE_EXPORT QgsGeometry
      *
      * \note Comparing two null geometries will return FALSE.
      *
-     * \see isGeosEqual()
+     * \deprecated QGIS 4.0. Will be removed in QGIS 5.0. Use isEqual which accepts Qgis::GeometryBackend.
      */
-    bool equals( const QgsGeometry &geometry ) const;
+    Q_DECL_DEPRECATED bool equals( const QgsGeometry &geometry ) const SIP_DEPRECATED;
 
     /**
      * Compares the geometry with another geometry using GEOS.
@@ -458,9 +458,23 @@ class CORE_EXPORT QgsGeometry
      *
      * \note Comparing two null geometries will return FALSE.
      *
-     * \see equals()
+     * \deprecated QGIS 4.0. Will be removed in QGIS 5.0. Use isEqual which accepts Qgis::GeometryBackend.
      */
-    bool isGeosEqual( const QgsGeometry & ) const;
+    Q_DECL_DEPRECATED bool isGeosEqual( const QgsGeometry & ) const SIP_DEPRECATED;
+
+    /**
+     * Compares the geometry with another geometry using the specified \a backend.
+     *
+     * Implementations:
+     *
+     * - GEOS: this method performs a slow, topological check, where geometries are considered equal if all of the their component edges overlap. E.g. lines with the same vertex locations but opposite direction will be considered equal by this method.
+     * - QGIS: this is a strict equality check, where the underlying geometries must have exactly the same type, component vertices and vertex order.
+     *
+     * The QGIS internal implementation is chosen by default.
+     *
+     * \note Comparing two null geometries will return FALSE.
+     */
+    bool isEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
 
     /**
      * Checks validity of the geometry using GEOS.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -474,6 +474,8 @@ class CORE_EXPORT QgsGeometry
      *
      * The QGIS internal implementation is chosen by default.
      *
+     * \param geometry geometry to compare with
+     * \param backend backend implementation
      * \note Comparing two null geometries will return FALSE.
      * \since QGIS 4.0
      */
@@ -490,6 +492,8 @@ class CORE_EXPORT QgsGeometry
      *
      * The GEOS implementation is chosen by default.
      *
+     * \param geometry geometry to compare with
+     * \param backend backend implementation
      * \note Comparing two null geometries will return FALSE.
      * \since QGIS 4.0
      */
@@ -505,6 +509,9 @@ class CORE_EXPORT QgsGeometry
      *
      * The QGIS internal implementation is chosen by default.
      *
+     * \param geometry geometry to compare with
+     * \param epsilon maximum difference for coordinates between the objects
+     * \param backend backend implementation
      * \note Comparing two null geometries will return FALSE.
      * \since QGIS 4.0
      */

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -441,7 +441,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \note Comparing two null geometries will return FALSE.
      *
-     * \deprecated QGIS 4.0. Will be removed in QGIS 5.0. Use isEqual which accepts Qgis::GeometryBackend.
+     * \deprecated QGIS 4.0. Will be removed in QGIS 5.0. Use isExactlyEqual which accepts Qgis::GeometryBackend.
      */
     Q_DECL_DEPRECATED bool equals( const QgsGeometry &geometry ) const SIP_DEPRECATED;
 
@@ -458,23 +458,57 @@ class CORE_EXPORT QgsGeometry
      *
      * \note Comparing two null geometries will return FALSE.
      *
-     * \deprecated QGIS 4.0. Will be removed in QGIS 5.0. Use isEqual which accepts Qgis::GeometryBackend.
+     * \deprecated QGIS 4.0. Will be removed in QGIS 5.0. Use isTopologicallyEqual which accepts Qgis::GeometryBackend.
      */
     Q_DECL_DEPRECATED bool isGeosEqual( const QgsGeometry & ) const SIP_DEPRECATED;
 
     /**
      * Compares the geometry with another geometry using the specified \a backend.
      *
+     * This is a strict equality check, where the underlying geometries must have exactly the same type, component vertices and vertex order.
+     *
      * Implementations:
      *
-     * - GEOS: this method performs a slow, topological check, where geometries are considered equal if all of the their component edges overlap. E.g. lines with the same vertex locations but opposite direction will be considered equal by this method.
-     * - QGIS: this is a strict equality check, where the underlying geometries must have exactly the same type, component vertices and vertex order.
+     * - GEOS
+     * - QGIS
      *
      * The QGIS internal implementation is chosen by default.
      *
      * \note Comparing two null geometries will return FALSE.
+     * \since QGIS 4.0
      */
-    bool isEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
+    bool isExactlyEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
+
+    /**
+     * Compares the geometry with another geometry using the specified \a backend.
+     *
+     * This method performs a slow, topological check, where geometries are considered equal if all of the their component edges overlap. E.g. lines with the same vertex locations but opposite direction will be considered equal by this method.
+     *
+     * Implementations:
+     *
+     * - GEOS
+     *
+     * The GEOS implementation is chosen by default.
+     *
+     * \note Comparing two null geometries will return FALSE.
+     * \since QGIS 4.0
+     */
+    bool isTopologicallyEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::GEOS ) const;
+
+    /**
+     * Compares the geometry with another geometry within the tolerance \a epsilon using the specified \a backend.
+     *
+     * Implementations:
+     *
+     * - GEOS
+     * - QGIS
+     *
+     * The QGIS internal implementation is chosen by default.
+     *
+     * \note Comparing two null geometries will return FALSE.
+     * \since QGIS 4.0
+     */
+    bool isFuzzyEqual( const QgsGeometry &geometry, double epsilon, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
 
     /**
      * Checks validity of the geometry using GEOS.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -441,7 +441,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \note Comparing two null geometries will return FALSE.
      *
-     * \deprecated QGIS 4.0. Will be removed in QGIS 5.0. Use isExactlyEqual which accepts Qgis::GeometryBackend.
+     * \deprecated QGIS 4.2. Will be removed in QGIS 5.0. Use isExactlyEqual which accepts Qgis::GeometryBackend.
      */
     Q_DECL_DEPRECATED bool equals( const QgsGeometry &geometry ) const SIP_DEPRECATED;
 
@@ -458,7 +458,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \note Comparing two null geometries will return FALSE.
      *
-     * \deprecated QGIS 4.0. Will be removed in QGIS 5.0. Use isTopologicallyEqual which accepts Qgis::GeometryBackend.
+     * \deprecated QGIS 4.2. Will be removed in QGIS 5.0. Use isTopologicallyEqual which accepts Qgis::GeometryBackend.
      */
     Q_DECL_DEPRECATED bool isGeosEqual( const QgsGeometry & ) const SIP_DEPRECATED;
 
@@ -477,9 +477,10 @@ class CORE_EXPORT QgsGeometry
      * \param geometry geometry to compare with
      * \param backend backend implementation
      * \note Comparing two null geometries will return FALSE.
-     * \since QGIS 4.0
+     * \throws QgsNotSupportedException when backend is not supported
+     * \since QGIS 4.2
      */
-    bool isExactlyEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
+    bool isExactlyEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Compares the geometry with another geometry using the specified \a backend.
@@ -495,9 +496,10 @@ class CORE_EXPORT QgsGeometry
      * \param geometry geometry to compare with
      * \param backend backend implementation
      * \note Comparing two null geometries will return FALSE.
-     * \since QGIS 4.0
+     * \throws QgsNotSupportedException when backend is not supported
+     * \since QGIS 4.2
      */
-    bool isTopologicallyEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::GEOS ) const;
+    bool isTopologicallyEqual( const QgsGeometry &geometry, Qgis::GeometryBackend backend = Qgis::GeometryBackend::GEOS ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Compares the geometry with another geometry within the tolerance \a epsilon using the specified \a backend.
@@ -513,9 +515,10 @@ class CORE_EXPORT QgsGeometry
      * \param epsilon maximum difference for coordinates between the objects
      * \param backend backend implementation
      * \note Comparing two null geometries will return FALSE.
-     * \since QGIS 4.0
+     * \throws QgsNotSupportedException when backend is not supported
+     * \since QGIS 4.2
      */
-    bool isFuzzyEqual( const QgsGeometry &geometry, double epsilon, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const;
+    bool isFuzzyEqual( const QgsGeometry &geometry, double epsilon, Qgis::GeometryBackend backend = Qgis::GeometryBackend::QGIS ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Checks validity of the geometry using GEOS.

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -318,6 +318,7 @@ class QgsAbstractGeometry;
      * Checks if this is equal to \a geom ie. if each vertex of this is within the distance tolerance of the corresponding vertex in \a geom.
      * If both are Null geometries, `FALSE` is returned.
      * \param geom geometry to compare with
+     * \param epsilon maximum difference for coordinates between the objects
      * \param errorMsg destination storage for any error message
      * \return true if fuzzy equivalent, else false
      */

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -313,6 +313,16 @@ class QgsAbstractGeometry;
      *
      */
     virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+
+    /**
+     * Checks if this is equal to \a geom ie. if each vertex of this is within the distance tolerance of the corresponding vertex in \a geom.
+     * If both are Null geometries, `FALSE` is returned.
+     * \param geom geometry to compare with
+     * \param errorMsg destination storage for any error message
+     * \return true if fuzzy equivalent, else false
+     */
+    virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = nullptr ) const = 0;
+
     virtual bool isEmpty( QString *errorMsg ) const = 0;
 
     /**

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -308,9 +308,10 @@ class QgsAbstractGeometry;
     virtual bool isValid( QString *errorMsg = nullptr, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = nullptr ) const = 0;
 
     /**
-     * Checks if this is equal to \a geom.
-     * If both are Null geometries, `FALSE` is returned.
-     *
+     * Check if geometries that are topologically equivalent
+     * \param geom other geom to compare with
+     * \param errorMsg will be set to descriptive error string if the operation fails
+     * \return true if topologically equivalent, else false
      */
     virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
 
@@ -318,9 +319,10 @@ class QgsAbstractGeometry;
      * Checks if this is equal to \a geom ie. if each vertex of this is within the distance tolerance of the corresponding vertex in \a geom.
      * If both are Null geometries, `FALSE` is returned.
      * \param geom geometry to compare with
-     * \param epsilon maximum difference for coordinates between the objects
+     * \param epsilon maximum difference for coordinates between the objects. With a near zreo epsilon, this function will behave as an exact comparison.
      * \param errorMsg destination storage for any error message
      * \return true if fuzzy equivalent, else false
+     * \since QGIS 4.2
      */
     virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = nullptr ) const = 0;
 

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -2424,6 +2424,26 @@ bool QgsGeos::isEqual( const QgsAbstractGeometry *geom, QString *errorMsg ) cons
   CATCH_GEOS_WITH_ERRMSG( false )
 }
 
+bool QgsGeos::isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg ) const
+{
+  if ( !mGeos || !geom )
+  {
+    return false;
+  }
+
+  try
+  {
+    geos::unique_ptr geosGeom( asGeos( geom, mPrecision ) );
+    if ( !geosGeom )
+    {
+      return false;
+    }
+    bool equal = GEOSEqualsExact_r( QgsGeosContext::get(), mGeos.get(), geosGeom.get(), epsilon );
+    return equal;
+  }
+  CATCH_GEOS_WITH_ERRMSG( false )
+}
+
 bool QgsGeos::isEmpty( QString *errorMsg ) const
 {
   if ( !mGeos )

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -383,14 +383,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
     double length( QString *errorMsg = nullptr ) const override;
     bool isValid( QString *errorMsg = nullptr, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = nullptr ) const override;
 
-    /**
-     * Check if geometries that are topologically equivalent
-     * \param geom other geom to compare with
-     * \param errorMsg will be set to descriptive error string if the operation fails
-     * \return true if topologically equivalent, else false
-     */
     bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-
     bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = nullptr ) const override;
 
     bool isEmpty( QString *errorMsg = nullptr ) const override;

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -382,7 +382,17 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
     double area( QString *errorMsg = nullptr ) const override;
     double length( QString *errorMsg = nullptr ) const override;
     bool isValid( QString *errorMsg = nullptr, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = nullptr ) const override;
+
+    /**
+     * Check if geometries that are topologically equivalent
+     * \param geom other geom to compare with
+     * \param errorMsg will be set to descriptive error string if the operation fails
+     * \return true if topologically equivalent, else false
+     */
     bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
+
+    bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = nullptr ) const override;
+
     bool isEmpty( QString *errorMsg = nullptr ) const override;
     bool isSimple( QString *errorMsg = nullptr ) const override;
 

--- a/src/core/geometry/qgsreferencedgeometry.cpp
+++ b/src/core/geometry/qgsreferencedgeometry.cpp
@@ -60,7 +60,7 @@ QgsReferencedGeometry::QgsReferencedGeometry( const QgsGeometry &geom, const Qgs
 
 bool QgsReferencedGeometry::operator==( const QgsReferencedGeometry &other ) const
 {
-  return ( ( this->isNull() && other.isNull() ) || this->equals( other ) ) && crs() == other.crs();
+  return ( ( this->isNull() && other.isNull() ) || this->isEqual( other ) ) && crs() == other.crs();
 }
 
 bool QgsReferencedGeometry::operator!=( const QgsReferencedGeometry &other ) const

--- a/src/core/geometry/qgsreferencedgeometry.cpp
+++ b/src/core/geometry/qgsreferencedgeometry.cpp
@@ -60,7 +60,7 @@ QgsReferencedGeometry::QgsReferencedGeometry( const QgsGeometry &geom, const Qgs
 
 bool QgsReferencedGeometry::operator==( const QgsReferencedGeometry &other ) const
 {
-  return ( ( this->isNull() && other.isNull() ) || this->isEqual( other ) ) && crs() == other.crs();
+  return ( ( this->isNull() && other.isNull() ) || this->isExactlyEqual( other ) ) && crs() == other.crs();
 }
 
 bool QgsReferencedGeometry::operator!=( const QgsReferencedGeometry &other ) const

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2219,6 +2219,18 @@ int QgisEvent = QEvent::User + 1;
     Q_ENUM( JoinStyle3D )
 
     /**
+     * Geometry backend for QgsGeometry.
+     *
+     * \since QGIS 4.2
+     */
+    enum class GeometryBackend : int
+    {
+      QGIS = 1, //!< Use internal implementation
+      GEOS,     //!< Use GEOS implementation
+    };
+    Q_ENUM( GeometryBackend )
+
+    /**
      * Flags which control geos geometry creation behavior.
      *
      * \since QGIS 3.40

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -80,7 +80,7 @@ bool QgsFeature::operator==( const QgsFeature &other ) const
     return true;
   else if ( d->geometry.isNull() || other.d->geometry.isNull() )
     return false;
-  else if ( !d->geometry.isEqual( other.d->geometry ) )
+  else if ( !d->geometry.isExactlyEqual( other.d->geometry ) )
     return false;
 
   return true;

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -80,7 +80,7 @@ bool QgsFeature::operator==( const QgsFeature &other ) const
     return true;
   else if ( d->geometry.isNull() || other.d->geometry.isNull() )
     return false;
-  else if ( !d->geometry.equals( other.d->geometry ) )
+  else if ( !d->geometry.isEqual( other.d->geometry ) )
     return false;
 
   return true;

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -196,7 +196,7 @@ bool QgsFeatureRequest::compare( const QgsFeatureRequest &rh ) const
          && mFilter == rh.mFilter
          && mSpatialFilter == rh.mSpatialFilter
          && mFilterRect == rh.mFilterRect
-         && ( ( mReferenceGeometry.isNull() && rh.mReferenceGeometry.isNull() ) || mReferenceGeometry.isExactlyEqual( rh.mReferenceGeometry ) )
+         && ( ( mReferenceGeometry.isNull() && rh.mReferenceGeometry.isNull() ) || mReferenceGeometry.isEqual( rh.mReferenceGeometry ) )
          && mDistanceWithin == rh.mDistanceWithin
          && mFilterFid == rh.mFilterFid
          && mFilterFids == rh.mFilterFids

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -196,7 +196,7 @@ bool QgsFeatureRequest::compare( const QgsFeatureRequest &rh ) const
          && mFilter == rh.mFilter
          && mSpatialFilter == rh.mSpatialFilter
          && mFilterRect == rh.mFilterRect
-         && ( ( mReferenceGeometry.isNull() && rh.mReferenceGeometry.isNull() ) || mReferenceGeometry.equals( rh.mReferenceGeometry ) )
+         && ( ( mReferenceGeometry.isNull() && rh.mReferenceGeometry.isNull() ) || mReferenceGeometry.isExactlyEqual( rh.mReferenceGeometry ) )
          && mDistanceWithin == rh.mDistanceWithin
          && mFilterFid == rh.mFilterFid
          && mFilterFids == rh.mFilterFids

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -196,7 +196,7 @@ bool QgsFeatureRequest::compare( const QgsFeatureRequest &rh ) const
          && mFilter == rh.mFilter
          && mSpatialFilter == rh.mSpatialFilter
          && mFilterRect == rh.mFilterRect
-         && ( ( mReferenceGeometry.isNull() && rh.mReferenceGeometry.isNull() ) || mReferenceGeometry.isEqual( rh.mReferenceGeometry ) )
+         && ( ( mReferenceGeometry.isNull() && rh.mReferenceGeometry.isNull() ) || mReferenceGeometry.isExactlyEqual( rh.mReferenceGeometry ) )
          && mDistanceWithin == rh.mDistanceWithin
          && mFilterFid == rh.mFilterFid
          && mFilterFids == rh.mFilterFids

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1379,7 +1379,7 @@ bool QgsVectorLayer::updateFeature( QgsFeature &updatedFeature, bool skipDefault
     bool hasChanged = false;
     bool hasError = false;
 
-    if ( ( updatedFeature.hasGeometry() || currentFeature.hasGeometry() ) && !updatedFeature.geometry().isEqual( currentFeature.geometry() ) )
+    if ( ( updatedFeature.hasGeometry() || currentFeature.hasGeometry() ) && !updatedFeature.geometry().isExactlyEqual( currentFeature.geometry() ) )
     {
       QgsGeometry geometry = updatedFeature.geometry();
       if ( changeGeometry( updatedFeature.id(), geometry, true ) )

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1379,7 +1379,7 @@ bool QgsVectorLayer::updateFeature( QgsFeature &updatedFeature, bool skipDefault
     bool hasChanged = false;
     bool hasError = false;
 
-    if ( ( updatedFeature.hasGeometry() || currentFeature.hasGeometry() ) && !updatedFeature.geometry().equals( currentFeature.geometry() ) )
+    if ( ( updatedFeature.hasGeometry() || currentFeature.hasGeometry() ) && !updatedFeature.geometry().isEqual( currentFeature.geometry() ) )
     {
       QgsGeometry geometry = updatedFeature.geometry();
       if ( changeGeometry( updatedFeature.id(), geometry, true ) )

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -730,7 +730,7 @@ void QgsVectorTileLayer::selectByGeometry(
   else
   {
     // we have a polygon - maybe it is a rectangle - in such case we can avoid costly instersection tests later
-    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isGeosEqual( selectionGeom );
+    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isEqual( selectionGeom, Qgis::GeometryBackend::GEOS );
   }
 
   auto addDerivedFields = []( QgsFeature &feature, const int tileZoom, const QString &layer ) {

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -730,7 +730,7 @@ void QgsVectorTileLayer::selectByGeometry(
   else
   {
     // we have a polygon - maybe it is a rectangle - in such case we can avoid costly instersection tests later
-    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isEqual( selectionGeom, Qgis::GeometryBackend::GEOS );
+    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isTopologicallyEqual( selectionGeom );
   }
 
   auto addDerivedFields = []( QgsFeature &feature, const int tileZoom, const QString &layer ) {

--- a/src/gui/maptools/qgsmaptoolidentify.cpp
+++ b/src/gui/maptools/qgsmaptoolidentify.cpp
@@ -475,7 +475,7 @@ bool QgsMapToolIdentify::identifyVectorTileLayer( QList<QgsMapToolIdentify::Iden
   else
   {
     // we have a polygon - maybe it is a rectangle - in such case we can avoid costly insterestion tests later
-    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isEqual( selectionGeom, Qgis::GeometryBackend::GEOS );
+    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isTopologicallyEqual( selectionGeom );
   }
 
   int featureCount = 0;
@@ -656,7 +656,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::Identify
   else
   {
     // we have a polygon - maybe it is a rectangle - in such case we can avoid costly insterestion tests later
-    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isEqual( selectionGeom, Qgis::GeometryBackend::GEOS );
+    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isTopologicallyEqual( selectionGeom );
   }
 
   QgsFeatureList featureList;

--- a/src/gui/maptools/qgsmaptoolidentify.cpp
+++ b/src/gui/maptools/qgsmaptoolidentify.cpp
@@ -475,7 +475,7 @@ bool QgsMapToolIdentify::identifyVectorTileLayer( QList<QgsMapToolIdentify::Iden
   else
   {
     // we have a polygon - maybe it is a rectangle - in such case we can avoid costly insterestion tests later
-    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isGeosEqual( selectionGeom );
+    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isEqual( selectionGeom, Qgis::GeometryBackend::GEOS );
   }
 
   int featureCount = 0;
@@ -656,7 +656,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::Identify
   else
   {
     // we have a polygon - maybe it is a rectangle - in such case we can avoid costly insterestion tests later
-    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isGeosEqual( selectionGeom );
+    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isEqual( selectionGeom, Qgis::GeometryBackend::GEOS );
   }
 
   QgsFeatureList featureList;

--- a/src/plugins/topology/topolTest.cpp
+++ b/src/plugins/topology/topolTest.cpp
@@ -271,7 +271,7 @@ ErrorList topolTest::checkDuplicates( QgsVectorLayer *layer1, QgsVectorLayer *la
         continue;
       }
 
-      if ( g1.isEqual( g2, Qgis::GeometryBackend::GEOS ) )
+      if ( g1.isTopologicallyEqual( g2 ) )
       {
         duplicate = true;
         duplicateIds.append( mFeatureMap2[*cit].feature.id() );

--- a/src/plugins/topology/topolTest.cpp
+++ b/src/plugins/topology/topolTest.cpp
@@ -271,7 +271,7 @@ ErrorList topolTest::checkDuplicates( QgsVectorLayer *layer1, QgsVectorLayer *la
         continue;
       }
 
-      if ( g1.isGeosEqual( g2 ) )
+      if ( g1.isEqual( g2, Qgis::GeometryBackend::GEOS ) )
       {
         duplicate = true;
         duplicateIds.append( mFeatureMap2[*cit].feature.id() );

--- a/src/quickgui/qgsquickelevationprofilecanvas.cpp
+++ b/src/quickgui/qgsquickelevationprofilecanvas.cpp
@@ -481,7 +481,7 @@ void QgsQuickElevationProfileCanvas::setCrs( const QgsCoordinateReferenceSystem 
 
 void QgsQuickElevationProfileCanvas::setProfileCurve( QgsGeometry curve )
 {
-  if ( mProfileCurve.equals( curve ) )
+  if ( mProfileCurve.isEqual( curve ) )
     return;
 
   mProfileCurve = curve.type() == Qgis::GeometryType::Line ? curve : QgsGeometry();

--- a/src/quickgui/qgsquickelevationprofilecanvas.cpp
+++ b/src/quickgui/qgsquickelevationprofilecanvas.cpp
@@ -481,7 +481,7 @@ void QgsQuickElevationProfileCanvas::setCrs( const QgsCoordinateReferenceSystem 
 
 void QgsQuickElevationProfileCanvas::setProfileCurve( QgsGeometry curve )
 {
-  if ( mProfileCurve.isEqual( curve ) )
+  if ( mProfileCurve.isExactlyEqual( curve ) )
     return;
 
   mProfileCurve = curve.type() == Qgis::GeometryType::Line ? curve : QgsGeometry();

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -1440,7 +1440,7 @@ void TestQgsProcessingAlgsPt1::polygonsToLines()
 
   const QgsFeature result = runForFeature( alg, feature, u"Polygon"_s );
 
-  QVERIFY2( result.geometry().equals( expectedGeometry ), u"Result: %1, Expected: %2"_s.arg( result.geometry().asWkt(), expectedGeometry.asWkt() ).toUtf8().constData() );
+  QVERIFY2( result.geometry().isEqual( expectedGeometry ), u"Result: %1, Expected: %2"_s.arg( result.geometry().asWkt(), expectedGeometry.asWkt() ).toUtf8().constData() );
 }
 
 void TestQgsProcessingAlgsPt1::roundness_data()
@@ -1978,7 +1978,7 @@ void TestQgsProcessingAlgsPt1::densifyGeometries()
   if ( expectedGeometry.isNull() )
     QVERIFY( result.geometry().isNull() );
   else
-    QVERIFY2( result.geometry().equals( expectedGeometry ), u"Result: %1, Expected: %2"_s.arg( result.geometry().asWkt(), expectedGeometry.asWkt() ).toUtf8().constData() );
+    QVERIFY2( result.geometry().isEqual( expectedGeometry ), u"Result: %1, Expected: %2"_s.arg( result.geometry().asWkt(), expectedGeometry.asWkt() ).toUtf8().constData() );
 }
 
 void TestQgsProcessingAlgsPt1::fillNoData_data()

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -1440,7 +1440,7 @@ void TestQgsProcessingAlgsPt1::polygonsToLines()
 
   const QgsFeature result = runForFeature( alg, feature, u"Polygon"_s );
 
-  QVERIFY2( result.geometry().isEqual( expectedGeometry ), u"Result: %1, Expected: %2"_s.arg( result.geometry().asWkt(), expectedGeometry.asWkt() ).toUtf8().constData() );
+  QVERIFY2( result.geometry().isExactlyEqual( expectedGeometry ), u"Result: %1, Expected: %2"_s.arg( result.geometry().asWkt(), expectedGeometry.asWkt() ).toUtf8().constData() );
 }
 
 void TestQgsProcessingAlgsPt1::roundness_data()
@@ -1978,7 +1978,7 @@ void TestQgsProcessingAlgsPt1::densifyGeometries()
   if ( expectedGeometry.isNull() )
     QVERIFY( result.geometry().isNull() );
   else
-    QVERIFY2( result.geometry().isEqual( expectedGeometry ), u"Result: %1, Expected: %2"_s.arg( result.geometry().asWkt(), expectedGeometry.asWkt() ).toUtf8().constData() );
+    QVERIFY2( result.geometry().isExactlyEqual( expectedGeometry ), u"Result: %1, Expected: %2"_s.arg( result.geometry().asWkt(), expectedGeometry.asWkt() ).toUtf8().constData() );
 }
 
 void TestQgsProcessingAlgsPt1::fillNoData_data()

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
@@ -38,7 +38,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isEqual( g2 );
+    return g1.isExactlyEqual( g2 );
 }
 
 namespace QTest
@@ -705,7 +705,7 @@ void TestQgsMapToolAddFeatureLine::testSelfSnapping()
   utils.mouseClick( 2, 5.1, Qt::RightButton );
 
   const QgsFeatureId newFid1 = utils.newFeatureId( oldFids );
-  QVERIFY( !mLayerSelfSnapLine->getFeature( newFid1 ).geometry().isEqual( QgsGeometry::fromWkt( targetWkt ) ) );
+  QVERIFY( !mLayerSelfSnapLine->getFeature( newFid1 ).geometry().isExactlyEqual( QgsGeometry::fromWkt( targetWkt ) ) );
   mLayerSelfSnapLine->undoStack()->undo();
 
   // With self snapping, endpoint will snap to start point

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeatureline.cpp
@@ -38,7 +38,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.equals( g2 );
+    return g1.isEqual( g2 );
 }
 
 namespace QTest
@@ -705,7 +705,7 @@ void TestQgsMapToolAddFeatureLine::testSelfSnapping()
   utils.mouseClick( 2, 5.1, Qt::RightButton );
 
   const QgsFeatureId newFid1 = utils.newFeatureId( oldFids );
-  QVERIFY( !mLayerSelfSnapLine->getFeature( newFid1 ).geometry().equals( QgsGeometry::fromWkt( targetWkt ) ) );
+  QVERIFY( !mLayerSelfSnapLine->getFeature( newFid1 ).geometry().isEqual( QgsGeometry::fromWkt( targetWkt ) ) );
   mLayerSelfSnapLine->undoStack()->undo();
 
   // With self snapping, endpoint will snap to start point

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinem.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinem.cpp
@@ -36,7 +36,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.equals( g2 );
+    return g1.isEqual( g2 );
 }
 
 namespace QTest

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinem.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinem.cpp
@@ -36,7 +36,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isEqual( g2 );
+    return g1.isExactlyEqual( g2 );
 }
 
 namespace QTest

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinez.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinez.cpp
@@ -39,7 +39,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.equals( g2 );
+    return g1.isEqual( g2 );
 }
 
 namespace QTest

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinez.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinez.cpp
@@ -39,7 +39,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isEqual( g2 );
+    return g1.isExactlyEqual( g2 );
 }
 
 namespace QTest

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm.cpp
@@ -39,7 +39,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.equals( g2 );
+    return g1.isEqual( g2 );
 }
 
 namespace QTest

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm.cpp
@@ -39,7 +39,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isEqual( g2 );
+    return g1.isExactlyEqual( g2 );
 }
 
 namespace QTest

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm_crs.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm_crs.cpp
@@ -40,7 +40,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.equals( g2 );
+    return g1.isEqual( g2 );
 }
 
 namespace QTest

--- a/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm_crs.cpp
+++ b/tests/src/app/maptooladdfeatureline/testqgsmaptooladdfeaturelinezm_crs.cpp
@@ -40,7 +40,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isEqual( g2 );
+    return g1.isExactlyEqual( g2 );
 }
 
 namespace QTest

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -39,7 +39,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isGeosEqual( g2 );
+    return g1.isEqual( g2, Qgis::GeometryBackend::GEOS );
 }
 
 namespace QTest

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -39,7 +39,7 @@ bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
   if ( g1.isNull() && g2.isNull() )
     return true;
   else
-    return g1.isEqual( g2, Qgis::GeometryBackend::GEOS );
+    return g1.isTopologicallyEqual( g2 );
 }
 
 namespace QTest

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -499,38 +499,57 @@ void TestQgsGeometry::isValid()
 void TestQgsGeometry::equality()
 {
   // null geometries
-  QVERIFY( !QgsGeometry().isEqual( QgsGeometry() ) );
+  QVERIFY( !QgsGeometry().isExactlyEqual( QgsGeometry() ) );
 
   // compare to null
   QgsGeometry g1( std::make_unique<QgsPoint>( 1.0, 2.0 ) );
-  QVERIFY( !g1.isEqual( QgsGeometry() ) );
-  QVERIFY( !QgsGeometry().isEqual( g1 ) );
+  QVERIFY( !g1.isExactlyEqual( QgsGeometry() ) );
+  QVERIFY( !QgsGeometry().isExactlyEqual( g1 ) );
 
   // compare implicitly shared copies
   QgsGeometry g2( g1 );
-  QVERIFY( g2.isEqual( g1 ) );
-  QVERIFY( g1.isEqual( g2 ) );
-  QVERIFY( g1.isEqual( g1 ) );
+  QVERIFY( g2.isExactlyEqual( g1 ) );
+  QVERIFY( g1.isExactlyEqual( g2 ) );
+  QVERIFY( g1.isExactlyEqual( g1 ) );
 
   // equal geometry, but different internal data
   g2 = QgsGeometry::fromWkt( "Point( 1.0 2.0 )" );
-  QVERIFY( g2.isEqual( g1 ) );
-  QVERIFY( g1.isEqual( g2 ) );
+  QVERIFY( g2.isExactlyEqual( g1 ) );
+  QVERIFY( g1.isExactlyEqual( g2 ) );
+
+  // tpopologically equal
+  g2 = QgsGeometry::fromWkt( "MultiPoint(( 1.0 2.0 ))" );
+  QVERIFY( g2.isTopologicallyEqual( g1 ) );
+  QVERIFY( g1.isTopologicallyEqual( g2 ) );
+
+  g2 = QgsGeometry::fromWkt( "MultiPoint(( 1.0 2.0 ), ( 3.0 2.0 ))" );
+  QVERIFY( !g2.isTopologicallyEqual( g1 ) );
+  QVERIFY( !g1.isTopologicallyEqual( g2 ) );
+
+  // fuzzy equal
+  g2 = QgsGeometry::fromWkt( "Point( 1.5 2.5 ))" );
+  QVERIFY( g2.isFuzzyEqual( g1, 0.50, Qgis::GeometryBackend::QGIS ) );
+  QVERIFY( g1.isFuzzyEqual( g2, 0.50, Qgis::GeometryBackend::QGIS ) );
+  QVERIFY( g2.isFuzzyEqual( g1, 0.71, Qgis::GeometryBackend::GEOS ) );
+  QVERIFY( g1.isFuzzyEqual( g2, 0.71, Qgis::GeometryBackend::GEOS ) );
+
+  QVERIFY( !g2.isFuzzyEqual( g1, 0.49, Qgis::GeometryBackend::QGIS ) );
+  QVERIFY( !g2.isFuzzyEqual( g1, 0.70, Qgis::GeometryBackend::GEOS ) );
 
   // different dimensionality
   g2 = QgsGeometry::fromWkt( "PointM( 1.0 2.0 3.0)" );
-  QVERIFY( !g2.isEqual( g1 ) );
-  QVERIFY( !g1.isEqual( g2 ) );
+  QVERIFY( !g2.isExactlyEqual( g1 ) );
+  QVERIFY( !g1.isExactlyEqual( g2 ) );
 
   // different type
   g2 = QgsGeometry::fromWkt( "LineString( 1.0 2.0, 3.0 4.0 )" );
-  QVERIFY( !g2.isEqual( g1 ) );
-  QVERIFY( !g1.isEqual( g2 ) );
+  QVERIFY( !g2.isExactlyEqual( g1 ) );
+  QVERIFY( !g1.isExactlyEqual( g2 ) );
 
   // different direction
   g1 = QgsGeometry::fromWkt( "LineString( 3.0 4.0, 1.0 2.0 )" );
-  QVERIFY( !g2.isEqual( g1 ) );
-  QVERIFY( !g1.isEqual( g2 ) );
+  QVERIFY( !g2.isExactlyEqual( g1 ) );
+  QVERIFY( !g1.isExactlyEqual( g2 ) );
 }
 
 void TestQgsGeometry::vertexIterator()

--- a/tests/src/core/geometry/testqgsgeometry.cpp
+++ b/tests/src/core/geometry/testqgsgeometry.cpp
@@ -499,38 +499,38 @@ void TestQgsGeometry::isValid()
 void TestQgsGeometry::equality()
 {
   // null geometries
-  QVERIFY( !QgsGeometry().equals( QgsGeometry() ) );
+  QVERIFY( !QgsGeometry().isEqual( QgsGeometry() ) );
 
   // compare to null
   QgsGeometry g1( std::make_unique<QgsPoint>( 1.0, 2.0 ) );
-  QVERIFY( !g1.equals( QgsGeometry() ) );
-  QVERIFY( !QgsGeometry().equals( g1 ) );
+  QVERIFY( !g1.isEqual( QgsGeometry() ) );
+  QVERIFY( !QgsGeometry().isEqual( g1 ) );
 
   // compare implicitly shared copies
   QgsGeometry g2( g1 );
-  QVERIFY( g2.equals( g1 ) );
-  QVERIFY( g1.equals( g2 ) );
-  QVERIFY( g1.equals( g1 ) );
+  QVERIFY( g2.isEqual( g1 ) );
+  QVERIFY( g1.isEqual( g2 ) );
+  QVERIFY( g1.isEqual( g1 ) );
 
   // equal geometry, but different internal data
   g2 = QgsGeometry::fromWkt( "Point( 1.0 2.0 )" );
-  QVERIFY( g2.equals( g1 ) );
-  QVERIFY( g1.equals( g2 ) );
+  QVERIFY( g2.isEqual( g1 ) );
+  QVERIFY( g1.isEqual( g2 ) );
 
   // different dimensionality
   g2 = QgsGeometry::fromWkt( "PointM( 1.0 2.0 3.0)" );
-  QVERIFY( !g2.equals( g1 ) );
-  QVERIFY( !g1.equals( g2 ) );
+  QVERIFY( !g2.isEqual( g1 ) );
+  QVERIFY( !g1.isEqual( g2 ) );
 
   // different type
   g2 = QgsGeometry::fromWkt( "LineString( 1.0 2.0, 3.0 4.0 )" );
-  QVERIFY( !g2.equals( g1 ) );
-  QVERIFY( !g1.equals( g2 ) );
+  QVERIFY( !g2.isEqual( g1 ) );
+  QVERIFY( !g1.isEqual( g2 ) );
 
   // different direction
   g1 = QgsGeometry::fromWkt( "LineString( 3.0 4.0, 1.0 2.0 )" );
-  QVERIFY( !g2.equals( g1 ) );
-  QVERIFY( !g1.equals( g2 ) );
+  QVERIFY( !g2.isEqual( g1 ) );
+  QVERIFY( !g1.isEqual( g2 ) );
 }
 
 void TestQgsGeometry::vertexIterator()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -4715,10 +4715,26 @@ class TestQgsExpression : public QObject
       QTest::newRow( "No Equals multipoint" ) << "equals( $geometry, geomFromWKT('MULTIPOINT( ( 0 0 ) )') )" << QgsGeometry::fromPointXY( point ) << false << QVariant( 0 );
       QTest::newRow( "No Equals line" ) << "equals( $geometry, geomFromWKT('LINESTRING( 10 10, 0 0 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 0 );
       QTest::newRow( "Equals line" ) << "equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10 10 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
-      QTest::newRow( "Topological equals line bad backend" ) << "topologically_equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10 10 )'), backend:='QGIS' )" << QgsGeometry::fromPolylineXY( line ) << true << QVariant( 0 );
-      QTest::newRow( "Topological equals line" ) << "topologically_equals( $geometry, geomFromWKT('MULTILINESTRING(( 0 0, 10 10 ))'), backend:='GEOS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
-      QTest::newRow( "Fuzzy equals line QGIS backend" ) << "fuzzy_equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10.5 10.5 )'), epsilon:=1, backend:='QGIS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
-      QTest::newRow( "Fuzzy equals line GEOS backend" ) << "fuzzy_equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10.5 10.5 )'), epsilon:=1, backend:='GEOS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "Topological equals line bad backend" )
+        << "topologically_equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10 10 )'), backend:='QGIS' )"
+        << QgsGeometry::fromPolylineXY( line )
+        << true
+        << QVariant( 0 );
+      QTest::newRow( "Topological equals line" )
+        << "topologically_equals( $geometry, geomFromWKT('MULTILINESTRING(( 0 0, 10 10 ))'), backend:='GEOS' )"
+        << QgsGeometry::fromPolylineXY( line )
+        << false
+        << QVariant( 1 );
+      QTest::newRow( "Fuzzy equals line QGIS backend" )
+        << "fuzzy_equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10.5 10.5 )'), epsilon:=1, backend:='QGIS' )"
+        << QgsGeometry::fromPolylineXY( line )
+        << false
+        << QVariant( 1 );
+      QTest::newRow( "Fuzzy equals line GEOS backend" )
+        << "fuzzy_equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10.5 10.5 )'), epsilon:=1, backend:='GEOS' )"
+        << QgsGeometry::fromPolylineXY( line )
+        << false
+        << QVariant( 1 );
       QTest::newRow( "No Equals polygon" ) << "equals( $geometry, geomFromWKT('POLYGON(( 0 0, 10 0, 10 10, 0 0 ))') )" << QgsGeometry::fromPolygonXY( polygon ) << false << QVariant( 0 );
       QTest::newRow( "Equals polygon" ) << "equals( $geometry, geomFromWKT('POLYGON(( 0 0, 10 10, 10 0, 0 0 ))') )" << QgsGeometry::fromPolygonXY( polygon ) << false << QVariant( 1 );
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -4715,10 +4715,10 @@ class TestQgsExpression : public QObject
       QTest::newRow( "No Equals multipoint" ) << "equals( $geometry, geomFromWKT('MULTIPOINT( ( 0 0 ) )') )" << QgsGeometry::fromPointXY( point ) << false << QVariant( 0 );
       QTest::newRow( "No Equals line" ) << "equals( $geometry, geomFromWKT('LINESTRING( 10 10, 0 0 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 0 );
       QTest::newRow( "Equals line" ) << "equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10 10 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
-      QTest::newRow( "Topological equals line bad backend" ) << "isTopologicallyEqual( $geometry, geomFromWKT('LINESTRING( 0 0, 10 10 )'), backend:='QGIS' )" << QgsGeometry::fromPolylineXY( line ) << true << QVariant( 0 );
-      QTest::newRow( "Topological equals line" ) << "isTopologicallyEqual( $geometry, geomFromWKT('MULTILINESTRING(( 0 0, 10 10 ))'), backend:='GEOS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
-      QTest::newRow( "Fuzzy equals line QGIS backend" ) << "isFuzzyEqual( $geometry, geomFromWKT('LINESTRING( 0 0, 10.5 10.5 )'), epsilon:=1, backend:='QGIS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
-      QTest::newRow( "Fuzzy equals line GEOS backend" ) << "isFuzzyEqual( $geometry, geomFromWKT('LINESTRING( 0 0, 10.5 10.5 )'), epsilon:=1, backend:='GEOS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "Topological equals line bad backend" ) << "topologically_equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10 10 )'), backend:='QGIS' )" << QgsGeometry::fromPolylineXY( line ) << true << QVariant( 0 );
+      QTest::newRow( "Topological equals line" ) << "topologically_equals( $geometry, geomFromWKT('MULTILINESTRING(( 0 0, 10 10 ))'), backend:='GEOS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "Fuzzy equals line QGIS backend" ) << "fuzzy_equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10.5 10.5 )'), epsilon:=1, backend:='QGIS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "Fuzzy equals line GEOS backend" ) << "fuzzy_equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10.5 10.5 )'), epsilon:=1, backend:='GEOS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
       QTest::newRow( "No Equals polygon" ) << "equals( $geometry, geomFromWKT('POLYGON(( 0 0, 10 0, 10 10, 0 0 ))') )" << QgsGeometry::fromPolygonXY( polygon ) << false << QVariant( 0 );
       QTest::newRow( "Equals polygon" ) << "equals( $geometry, geomFromWKT('POLYGON(( 0 0, 10 10, 10 0, 0 0 ))') )" << QgsGeometry::fromPolygonXY( polygon ) << false << QVariant( 1 );
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -335,7 +335,7 @@ class TestQgsExpression : public QObject
       QVariant out = expression.evaluate( &context );
       QgsGeometry outGeom = out.value<QgsGeometry>();
       QgsGeometry geom( new QgsPoint( 2500, 2500, 800 ) );
-      QCOMPARE( geom.isEqual( outGeom ), true );
+      QCOMPARE( geom.isExactlyEqual( outGeom ), true );
 
       context.appendScope( QgsExpressionContextUtils::meshExpressionScope( QgsMesh::Face ) );
       context.lastScope()->setVariable( u"_mesh_face_index"_s, 2 );
@@ -4627,7 +4627,7 @@ class TestQgsExpression : public QObject
 
       QCOMPARE( out.userType() == qMetaTypeId<QgsGeometry>(), true );
       QgsGeometry outGeom = out.value<QgsGeometry>();
-      QCOMPARE( geom.isEqual( outGeom ), true );
+      QCOMPARE( geom.isExactlyEqual( outGeom ), true );
     }
 
     void eval_geometry_access_transform_data()
@@ -4689,7 +4689,7 @@ class TestQgsExpression : public QObject
       QCOMPARE( exp.hasEvalError(), evalError );
       QCOMPARE( out.userType() == qMetaTypeId<QgsGeometry>(), true );
       QgsGeometry outGeom = out.value<QgsGeometry>();
-      QCOMPARE( geom.isEqual( outGeom ), true );
+      QCOMPARE( geom.isExactlyEqual( outGeom ), true );
     }
 
     void eval_spatial_operator_data()
@@ -4715,6 +4715,10 @@ class TestQgsExpression : public QObject
       QTest::newRow( "No Equals multipoint" ) << "equals( $geometry, geomFromWKT('MULTIPOINT( ( 0 0 ) )') )" << QgsGeometry::fromPointXY( point ) << false << QVariant( 0 );
       QTest::newRow( "No Equals line" ) << "equals( $geometry, geomFromWKT('LINESTRING( 10 10, 0 0 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 0 );
       QTest::newRow( "Equals line" ) << "equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10 10 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "Topological equals line bad backend" ) << "isTopologicallyEqual( $geometry, geomFromWKT('LINESTRING( 0 0, 10 10 )'), backend:='QGIS' )" << QgsGeometry::fromPolylineXY( line ) << true << QVariant( 0 );
+      QTest::newRow( "Topological equals line" ) << "isTopologicallyEqual( $geometry, geomFromWKT('MULTILINESTRING(( 0 0, 10 10 ))'), backend:='GEOS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "Fuzzy equals line QGIS backend" ) << "isFuzzyEqual( $geometry, geomFromWKT('LINESTRING( 0 0, 10.5 10.5 )'), epsilon:=1, backend:='QGIS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
+      QTest::newRow( "Fuzzy equals line GEOS backend" ) << "isFuzzyEqual( $geometry, geomFromWKT('LINESTRING( 0 0, 10.5 10.5 )'), epsilon:=1, backend:='GEOS' )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
       QTest::newRow( "No Equals polygon" ) << "equals( $geometry, geomFromWKT('POLYGON(( 0 0, 10 0, 10 10, 0 0 ))') )" << QgsGeometry::fromPolygonXY( polygon ) << false << QVariant( 0 );
       QTest::newRow( "Equals polygon" ) << "equals( $geometry, geomFromWKT('POLYGON(( 0 0, 10 10, 10 0, 0 0 ))') )" << QgsGeometry::fromPolygonXY( polygon ) << false << QVariant( 1 );
 
@@ -4746,11 +4750,15 @@ class TestQgsExpression : public QObject
       f.setGeometry( geom );
 
       QgsExpression exp( string );
+      if ( exp.hasParserError() )
+        qDebug() << "Parser error:" << exp.parserErrorString();
       QCOMPARE( exp.hasParserError(), false );
       QCOMPARE( exp.needsGeometry(), true );
 
       QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f, QgsFields() );
       QVariant out = exp.evaluate( &context );
+      if ( exp.hasEvalError() && exp.hasEvalError() != evalError )
+        qDebug() << "Eval error:" << exp.evalErrorString();
       QCOMPARE( exp.hasEvalError(), evalError );
       QCOMPARE( out.toInt(), result.toInt() );
     }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -335,7 +335,7 @@ class TestQgsExpression : public QObject
       QVariant out = expression.evaluate( &context );
       QgsGeometry outGeom = out.value<QgsGeometry>();
       QgsGeometry geom( new QgsPoint( 2500, 2500, 800 ) );
-      QCOMPARE( geom.equals( outGeom ), true );
+      QCOMPARE( geom.isEqual( outGeom ), true );
 
       context.appendScope( QgsExpressionContextUtils::meshExpressionScope( QgsMesh::Face ) );
       context.lastScope()->setVariable( u"_mesh_face_index"_s, 2 );
@@ -4627,7 +4627,7 @@ class TestQgsExpression : public QObject
 
       QCOMPARE( out.userType() == qMetaTypeId<QgsGeometry>(), true );
       QgsGeometry outGeom = out.value<QgsGeometry>();
-      QCOMPARE( geom.equals( outGeom ), true );
+      QCOMPARE( geom.isEqual( outGeom ), true );
     }
 
     void eval_geometry_access_transform_data()
@@ -4689,7 +4689,7 @@ class TestQgsExpression : public QObject
       QCOMPARE( exp.hasEvalError(), evalError );
       QCOMPARE( out.userType() == qMetaTypeId<QgsGeometry>(), true );
       QgsGeometry outGeom = out.value<QgsGeometry>();
-      QCOMPARE( geom.equals( outGeom ), true );
+      QCOMPARE( geom.isEqual( outGeom ), true );
     }
 
     void eval_spatial_operator_data()

--- a/tests/src/core/testqgsmaptopixelgeometrysimplifier.cpp
+++ b/tests/src/core/testqgsmaptopixelgeometrysimplifier.cpp
@@ -176,7 +176,7 @@ void TestQgsMapToPixelGeometrySimplifier::testWkbDimensionMismatch()
   const int fl = QgsMapToPixelSimplifier::SimplifyGeometry;
   const QgsMapToPixelSimplifier simplifier( fl, 20.0 );
   const QgsGeometry ret = simplifier.simplify( g12416 );
-  QVERIFY( !ret.equals( g12416 ) );
+  QVERIFY( !ret.isEqual( g12416 ) );
 }
 
 void TestQgsMapToPixelGeometrySimplifier::testCircularString()

--- a/tests/src/core/testqgsmaptopixelgeometrysimplifier.cpp
+++ b/tests/src/core/testqgsmaptopixelgeometrysimplifier.cpp
@@ -176,7 +176,7 @@ void TestQgsMapToPixelGeometrySimplifier::testWkbDimensionMismatch()
   const int fl = QgsMapToPixelSimplifier::SimplifyGeometry;
   const QgsMapToPixelSimplifier simplifier( fl, 20.0 );
   const QgsGeometry ret = simplifier.simplify( g12416 );
-  QVERIFY( !ret.isEqual( g12416 ) );
+  QVERIFY( !ret.isExactlyEqual( g12416 ) );
 }
 
 void TestQgsMapToPixelGeometrySimplifier::testCircularString()

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -112,7 +112,7 @@ void TestQgsOgcUtils::testGeometryFromGML()
   geom = QgsOgcUtils::geometryFromGML( u"<gml:Point srsName=\"EPSG:4326\"><gml:coordinates>4,45</gml:coordinates></gml:Point>"_s );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::Point );
-  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"POINT (4 45)"_s ) ) );
+  QVERIFY( geom.isExactlyEqual( QgsGeometry::fromWkt( u"POINT (4 45)"_s ) ) );
 
 
   // Test GML3
@@ -129,7 +129,7 @@ void TestQgsOgcUtils::testGeometryFromGML()
   geom = QgsOgcUtils::geometryFromGML( u"<gml:Point srsName=\"EPSG:4326\"><gml:pos srsDimension=\"3\">0 1 2</gml:pos></gml:Point>"_s );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::PointZ );
-  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"POINTZ(0 1 2)"_s ) ) );
+  QVERIFY( geom.isExactlyEqual( QgsGeometry::fromWkt( u"POINTZ(0 1 2)"_s ) ) );
 
   // Test polygon GML3 Z
   geom = QgsOgcUtils::geometryFromGML( QStringLiteral(
@@ -137,20 +137,20 @@ void TestQgsOgcUtils::testGeometryFromGML()
   ) );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::PolygonZ );
-  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"POLYGONZ((0 0 1200, 0 1 1250, 1 1 1230, 1 0 1210, 0 0 1200))"_s ) ) );
+  QVERIFY( geom.isExactlyEqual( QgsGeometry::fromWkt( u"POLYGONZ((0 0 1200, 0 1 1250, 1 1 1230, 1 0 1210, 0 0 1200))"_s ) ) );
 
   // Test linestring GML3 Z
   geom = QgsOgcUtils::geometryFromGML( QStringLiteral( R"GML(<gml:LineString srsName="EPSG:4326"><gml:posList srsDimension="3">0 0 1200 0 1 1250 1 1 1230 1 0 1210</gml:posList></gml:LineString>)GML" ) );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::LineStringZ );
-  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"LINESTRINGZ(0 0 1200, 0 1 1250, 1 1 1230, 1 0 1210)"_s ) ) );
+  QVERIFY( geom.isExactlyEqual( QgsGeometry::fromWkt( u"LINESTRINGZ(0 0 1200, 0 1 1250, 1 1 1230, 1 0 1210)"_s ) ) );
 
   // Test point GML3 with urn:ogc:def:crs:EPSG::4326
   // X/Y coordinates are inverted
   geom = QgsOgcUtils::geometryFromGML( u"<gml:Point srsName=\"urn:ogc:def:crs:EPSG::4326\"><gml:pos>45 4</gml:pos></gml:Point>"_s );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::Point );
-  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"POINT (4 45)"_s ) ) );
+  QVERIFY( geom.isExactlyEqual( QgsGeometry::fromWkt( u"POINT (4 45)"_s ) ) );
 
 
   // Test point GML3 with urn:ogc:def:crs:EPSG::3857
@@ -158,7 +158,7 @@ void TestQgsOgcUtils::testGeometryFromGML()
   geom = QgsOgcUtils::geometryFromGML( u"<gml:Point srsName=\"urn:ogc:def:crs:EPSG::3857\"><gml:pos>32 2</gml:pos></gml:Point>"_s );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::Point );
-  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"POINT (32 2)"_s ) ) );
+  QVERIFY( geom.isExactlyEqual( QgsGeometry::fromWkt( u"POINT (32 2)"_s ) ) );
 }
 
 void TestQgsOgcUtils::testGeometryFromGMLWithZ_data()
@@ -223,7 +223,7 @@ void TestQgsOgcUtils::testGeometryFromGMLWithZ()
   QgsGeometry geom = QgsOgcUtils::geometryFromGML( xmlText );
   QVERIFY( !geom.isNull() );
   QCOMPARE( geom.wkbType(), type );
-  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( WKT ) ) );
+  QVERIFY( geom.isExactlyEqual( QgsGeometry::fromWkt( WKT ) ) );
 }
 
 static QDomElement comparableElement( const QString &xmlText )

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -112,7 +112,7 @@ void TestQgsOgcUtils::testGeometryFromGML()
   geom = QgsOgcUtils::geometryFromGML( u"<gml:Point srsName=\"EPSG:4326\"><gml:coordinates>4,45</gml:coordinates></gml:Point>"_s );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::Point );
-  QVERIFY( geom.equals( QgsGeometry::fromWkt( u"POINT (4 45)"_s ) ) );
+  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"POINT (4 45)"_s ) ) );
 
 
   // Test GML3
@@ -129,7 +129,7 @@ void TestQgsOgcUtils::testGeometryFromGML()
   geom = QgsOgcUtils::geometryFromGML( u"<gml:Point srsName=\"EPSG:4326\"><gml:pos srsDimension=\"3\">0 1 2</gml:pos></gml:Point>"_s );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::PointZ );
-  QVERIFY( geom.equals( QgsGeometry::fromWkt( u"POINTZ(0 1 2)"_s ) ) );
+  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"POINTZ(0 1 2)"_s ) ) );
 
   // Test polygon GML3 Z
   geom = QgsOgcUtils::geometryFromGML( QStringLiteral(
@@ -137,20 +137,20 @@ void TestQgsOgcUtils::testGeometryFromGML()
   ) );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::PolygonZ );
-  QVERIFY( geom.equals( QgsGeometry::fromWkt( u"POLYGONZ((0 0 1200, 0 1 1250, 1 1 1230, 1 0 1210, 0 0 1200))"_s ) ) );
+  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"POLYGONZ((0 0 1200, 0 1 1250, 1 1 1230, 1 0 1210, 0 0 1200))"_s ) ) );
 
   // Test linestring GML3 Z
   geom = QgsOgcUtils::geometryFromGML( QStringLiteral( R"GML(<gml:LineString srsName="EPSG:4326"><gml:posList srsDimension="3">0 0 1200 0 1 1250 1 1 1230 1 0 1210</gml:posList></gml:LineString>)GML" ) );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::LineStringZ );
-  QVERIFY( geom.equals( QgsGeometry::fromWkt( u"LINESTRINGZ(0 0 1200, 0 1 1250, 1 1 1230, 1 0 1210)"_s ) ) );
+  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"LINESTRINGZ(0 0 1200, 0 1 1250, 1 1 1230, 1 0 1210)"_s ) ) );
 
   // Test point GML3 with urn:ogc:def:crs:EPSG::4326
   // X/Y coordinates are inverted
   geom = QgsOgcUtils::geometryFromGML( u"<gml:Point srsName=\"urn:ogc:def:crs:EPSG::4326\"><gml:pos>45 4</gml:pos></gml:Point>"_s );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::Point );
-  QVERIFY( geom.equals( QgsGeometry::fromWkt( u"POINT (4 45)"_s ) ) );
+  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"POINT (4 45)"_s ) ) );
 
 
   // Test point GML3 with urn:ogc:def:crs:EPSG::3857
@@ -158,7 +158,7 @@ void TestQgsOgcUtils::testGeometryFromGML()
   geom = QgsOgcUtils::geometryFromGML( u"<gml:Point srsName=\"urn:ogc:def:crs:EPSG::3857\"><gml:pos>32 2</gml:pos></gml:Point>"_s );
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::Point );
-  QVERIFY( geom.equals( QgsGeometry::fromWkt( u"POINT (32 2)"_s ) ) );
+  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( u"POINT (32 2)"_s ) ) );
 }
 
 void TestQgsOgcUtils::testGeometryFromGMLWithZ_data()
@@ -223,7 +223,7 @@ void TestQgsOgcUtils::testGeometryFromGMLWithZ()
   QgsGeometry geom = QgsOgcUtils::geometryFromGML( xmlText );
   QVERIFY( !geom.isNull() );
   QCOMPARE( geom.wkbType(), type );
-  QVERIFY( geom.equals( QgsGeometry::fromWkt( WKT ) ) );
+  QVERIFY( geom.isEqual( QgsGeometry::fromWkt( WKT ) ) );
 }
 
 static QDomElement comparableElement( const QString &xmlText )

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -196,10 +196,26 @@ void TestQgsOverlayExpression::testOverlay_data()
   QTest::newRow( "equals" ) << "overlay_equals('rectangles')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
   QTest::newRow( "equals [cached]" ) << "overlay_equals('rectangles',cache:=true)" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
 
-  QTest::newRow( "equals GEOS" ) << "overlay_equals('rectangles', backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
-  QTest::newRow( "equals GEOS [cached]" ) << "overlay_equals('rectangles',cache:=true, backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
-
   QTest::newRow( "equals NOTEXIST" ) << "overlay_equals('rectangles', backend:='NOTEXIST')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << false;
+
+  // topological
+  QTest::newRow( "equals topological GEOS" ) << "overlay_topologically_equals('rectangles', backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
+  QTest::newRow( "equals topological GEOS [cached]" ) << "overlay_topologically_equals('rectangles',cache:=true, backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
+  QTest::newRow( "equals topological QGIS" ) << "overlay_topologically_equals('rectangles',cache:=true, backend:='QGIS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << false;
+
+  // exact
+  QTest::newRow( "equals exact GEOS" ) << "overlay_exactly_equals('rectangles', backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
+  QTest::newRow( "equals exact GEOS [cached]" ) << "overlay_exactly_equals('rectangles',cache:=true, backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
+
+  QTest::newRow( "equals exact QGIS" ) << "overlay_exactly_equals('rectangles', backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
+  QTest::newRow( "equals exact QGIS [cached]" ) << "overlay_exactly_equals('rectangles',cache:=true, backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
+
+  // fuzzy
+  QTest::newRow( "equals fuzzy GEOS" ) << "overlay_fuzzy_equals('rectangles', epsilon:=0.71, backend:='GEOS')" << "MULTIPOLYGON(((-160.5 50.5, -145 50, -145 35, -160 35, -160.5 50.5)))" << true;
+  QTest::newRow( "equals fuzzy GEOS [cached]" ) << "overlay_fuzzy_equals('rectangles',cache:=true, epsilon:=0.71, backend:='GEOS')" << "MULTIPOLYGON(((-160.5 50.5, -145 50, -145 35, -160 35, -160.5 50.5)))" << true;
+
+  QTest::newRow( "equals fuzzy QGIS" ) << "overlay_fuzzy_equals('rectangles', epsilon:=0.50, backend:='QGIS')" << "MULTIPOLYGON(((-160.5 50.5, -145 50, -145 35, -160 35, -160.5 50.5)))" << true;
+  QTest::newRow( "equals fuzzy QGIS [cached]" ) << "overlay_fuzzy_equals('rectangles',cache:=true, epsilon:=0.50, backend:='QGIS')" << "MULTIPOLYGON(((-160.5 50.5, -145 50, -145 35, -160 35, -160.5 50.5)))" << true;
 
   QTest::newRow( "equals no match" ) << "overlay_equals('rectangles')" << "POLYGON((-156 46, -149 46, -148 37, -156 46))" << false;
   QTest::newRow( "equals no match [cached]" ) << "overlay_equals('rectangles',cache:=true)" << "POLYGON((-156 46, -149 46, -148 37, -156 46))" << false;

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -155,6 +155,8 @@ void TestQgsOverlayExpression::testOverlay()
   const QVariant result = exp.evaluate( &context );
 
   QCOMPARE( result.toBool(), expectedResult );
+  if ( !exp.parserErrorString().isEmpty() || !exp.evalErrorString().isEmpty() )
+    qDebug() << "testOverlay has errors! Parser error:" << exp.parserErrorString() << "/ eval error:" << exp.evalErrorString();
 }
 
 void TestQgsOverlayExpression::testOverlay_data()
@@ -194,10 +196,18 @@ void TestQgsOverlayExpression::testOverlay_data()
   QTest::newRow( "equals" ) << "overlay_equals('rectangles')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
   QTest::newRow( "equals [cached]" ) << "overlay_equals('rectangles',cache:=true)" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
 
+  QTest::newRow( "equals GEOS" ) << "overlay_equals('rectangles', backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
+  QTest::newRow( "equals GEOS [cached]" ) << "overlay_equals('rectangles',cache:=true, backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << true;
+
+  QTest::newRow( "equals NOTEXIST" ) << "overlay_equals('rectangles', backend:='NOTEXIST')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << false;
+
   QTest::newRow( "equals no match" ) << "overlay_equals('rectangles')" << "POLYGON((-156 46, -149 46, -148 37, -156 46))" << false;
   QTest::newRow( "equals no match [cached]" ) << "overlay_equals('rectangles',cache:=true)" << "POLYGON((-156 46, -149 46, -148 37, -156 46))" << false;
   QTest::newRow( "equals no match different vertices order" ) << "overlay_equals('rectangles')" << "POLYGON((-160 50, -160 35, -145 35, -145 50, -160 50))" << false;
   QTest::newRow( "equals no match different vertices order [cached]" ) << "overlay_equals('rectangles',cache:=true)" << "POLYGON((-160 50, -160 35, -145 35, -145 50, -160 50))" << false;
+
+  QTest::newRow( "equals no match GEOS" ) << "overlay_equals('rectangles', backend:='GEOS')" << "POLYGON((-156 46, -149 46, -148 37, -156 46))" << false;
+  QTest::newRow( "equals no match GEOS [cached]" ) << "overlay_equals('rectangles',cache:=true, backend:='GEOS')" << "POLYGON((-156 46, -149 46, -148 37, -156 46))" << false;
 
   QTest::newRow( "disjoint" ) << "overlay_disjoint('rectangles')" << "LINESTRING(-155 15, -122 55, -84 4)" << true;
   QTest::newRow( "disjoint [cached]" ) << "overlay_disjoint('rectangles',cache:=true)" << "LINESTRING(-155 15, -122 55, -84 4)" << true;
@@ -634,6 +644,9 @@ void TestQgsOverlayExpression::testOverlayExpression_data()
 
   QTest::newRow( "equals get ids" ) << "overlay_equals('rectangles',id)" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << QVariantList { 1 };
   QTest::newRow( "equals get ids [cached]" ) << "overlay_equals('rectangles',id,cache:=true)" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << QVariantList { 1 };
+
+  QTest::newRow( "equals get ids GEOS" ) << "overlay_equals('rectangles',id, backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << QVariantList { 1 };
+  QTest::newRow( "equals get ids [cached] GEOS" ) << "overlay_equals('rectangles',id,cache:=true, backend:='GEOS')" << "MULTIPOLYGON(((-160 50, -145 50, -145 35, -160 35, -160 50)))" << QVariantList { 1 };
 
   QTest::newRow( "disjoint get ids" ) << "overlay_disjoint('rectangles',id)" << "LINESTRING(-155 15, -122 55, -84 4)" << QVariantList { 1, 2, 3 };
   QTest::newRow( "disjoint get ids [cached]" ) << "overlay_disjoint('rectangles',id,cache:=true)" << "LINESTRING(-155 15, -122 55, -84 4)" << QVariantList { 1, 2, 3 };

--- a/tests/src/providers/grass/testqgsgrassprovider.cpp
+++ b/tests/src/providers/grass/testqgsgrassprovider.cpp
@@ -1483,7 +1483,7 @@ QList<QgsFeature> TestQgsGrassProvider::getFeatures( QgsVectorLayer *layer )
 bool TestQgsGrassProvider::equal( QgsFeature feature, QgsFeature expectedFeature )
 {
   QgsGeometry expectedGeom = expectedFeature.geometry();
-  if ( !feature.geometry().equals( expectedGeom ) )
+  if ( !feature.geometry().isEqual( expectedGeom ) )
   {
     return false;
   }

--- a/tests/src/providers/grass/testqgsgrassprovider.cpp
+++ b/tests/src/providers/grass/testqgsgrassprovider.cpp
@@ -1483,7 +1483,7 @@ QList<QgsFeature> TestQgsGrassProvider::getFeatures( QgsVectorLayer *layer )
 bool TestQgsGrassProvider::equal( QgsFeature feature, QgsFeature expectedFeature )
 {
   QgsGeometry expectedGeom = expectedFeature.geometry();
-  if ( !feature.geometry().isEqual( expectedGeom ) )
+  if ( !feature.geometry().isExactlyEqual( expectedGeom ) )
   {
     return false;
   }


### PR DESCRIPTION
This PR is a pre work for the [SFCGAL QEP](https://github.com/qgis/QGIS-Enhancement-Proposals/pull/340).

This PR introduce geometry backend concept in QgsGeometry. Apply it by creating new `isEqual` function with backend parameter.

This new concept introduces also changes in `QgsExpressionFunction` in order to handle this new backend parameter:

* replace RelateFunction by lambda
* read backend parameter from expression