### PR TITLE
[ui] Fix dark progress bar title in statistics panel

### DIFF
--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -616,6 +616,7 @@ QMenu::separator
 
 QProgressBar
 {
+    color: @textlight;
     height: 1.3em;
     border-width: 1px;
     border-color: @itemdarkbackground;


### PR DESCRIPTION
## Description

Fixes the dark text color in progress bars for the *Night Mapping* theme, which AFAIK only occurs in the statistics panel, by adding the `color` property to the `QProgressBar`-selector.

I am not sure if this is another Windows-only issue, which I've observed in the past, see #57407.

Before:

![dark_title_progress_bar](https://github.com/user-attachments/assets/6eafaa51-1eb6-4aa6-bbc2-8250a3265304)

After:

![light_title_progress_bar](https://github.com/user-attachments/assets/da8ccda9-68d1-4590-a56f-a0ee132dbddb)

If there are any foreseeable problems with this general approach, another solution would be to only add it for the `mCalculatingProgressBar` objects.
