### PR TITLE
[Backport queued_ltr_backports] Don't trigger reshape logic when using less than two points

### DIFF
--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -67,14 +67,10 @@ void QgsMapToolReshape::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   {
     deleteTempRubberBand();
 
-    //find out bounding box of mCaptureList
-    if ( size() < 1 )
+    if ( size() > 1 )
     {
-      stopCapturing();
-      return;
+      reshape( vlayer );
     }
-
-    reshape( vlayer );
 
     stopCapturing();
   }

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -27,6 +27,8 @@
 #include "qgsmapcanvastracer.h"
 #include "testqgsmaptoolutils.h"
 
+#include <QSignalSpy>
+
 
 /**
  * \ingroup UnitTests
@@ -42,6 +44,7 @@ class TestQgsMapToolReshape : public QObject
     void initTestCase();    // will be called before the first testfunction is executed.
     void cleanupTestCase(); // will be called after the last testfunction was executed.
 
+    void testReshapeNotEnoughPoints();
     void testReshapeNoChange();
     void testReshapeZ();
     void testTopologicalEditing();
@@ -221,6 +224,27 @@ void TestQgsMapToolReshape::cleanupTestCase()
   delete mCaptureTool;
   delete mCanvas;
   QgsApplication::exitQgis();
+}
+
+void TestQgsMapToolReshape::testReshapeNotEnoughPoints()
+{
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+  // no snapping for this test
+  QgsSnappingConfig cfg = mCanvas->snappingUtils()->config();
+  cfg.setEnabled( false );
+  mCanvas->snappingUtils()->setConfig( cfg );
+
+  const QSignalSpy editCommandSpy( mLayerLineZ, &QgsVectorLayer::editCommandStarted );
+
+  utils.mouseClick( 2, 2, Qt::LeftButton );
+  utils.mouseClick( 3, 2, Qt::RightButton );
+
+  // activate back snapping
+  cfg.setEnabled( true );
+  mCanvas->snappingUtils()->setConfig( cfg );
+
+  QCOMPARE( editCommandSpy.count(), 0 );
+  QCOMPARE( mLayerLineZ->undoStack()->index(), 0 );
 }
 
 void TestQgsMapToolReshape::testReshapeNoChange()


### PR DESCRIPTION
## Description
Manual backport #62324 to queued_ltr_backports

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
