### PR TITLE
[Backport queued_ltr_backports] Store new url when remote copc requests are redirected

### DIFF
--- a/src/core/pointcloud/qgslazinfo.cpp
+++ b/src/core/pointcloud/qgslazinfo.cpp
@@ -327,6 +327,13 @@ QgsLazInfo QgsLazInfo::fromUrl( QUrl &url )
     QByteArray lazHeaderData = reply.content();
 
     lazInfo.parseRawHeader( lazHeaderData.data(), lazHeaderData.size() );
+
+    // If request was redirected, let's update our url for all next calls
+    const QUrl requestedUrl = reply.request().url();
+    if ( requestedUrl != url )
+    {
+      url.setUrl( requestedUrl.toString() );
+    }
   }
 
   // Fetch VLR data

--- a/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
+++ b/src/core/pointcloud/qgsremotecopcpointcloudindex.cpp
@@ -56,9 +56,9 @@ std::unique_ptr<QgsPointCloudIndex> QgsRemoteCopcPointCloudIndex::clone() const
 
 void QgsRemoteCopcPointCloudIndex::load( const QString &uri )
 {
-  mUri = uri;
   QUrl url( uri );
   mLazInfo.reset( new QgsLazInfo( QgsLazInfo::fromUrl( url ) ) );
+  mUri = url.toString();
   mIsValid = mLazInfo->isValid();
   if ( mIsValid )
   {


### PR DESCRIPTION
## Description
manual backport of e2983d2 to queued-ltr-backports

In ltr remote and local copc indexes were not unified yet, so `qgsremotecopcpointcloudindex.cpp` was modified instead.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
