### PR TITLE
Explain non obvious options in the "New MS SQL Connection" dialog

### DIFF
--- a/src/providers/mssql/qgsmssqlconnection.h
+++ b/src/providers/mssql/qgsmssqlconnection.h
@@ -53,7 +53,7 @@ class QgsMssqlConnection
     static void setGeometryColumnsOnly( const QString &name, bool enabled );
 
     /**
-     * Returns whether the connection with matching \a name should,
+     * Returns whether the connection with matching \a name should
      * use the extent manually specified in the geometry_columns table using additional
      * QGIS-specific columns: qgis_xmin, qgis_xmax, qgis_ymin, qgis_ymax.
      *
@@ -68,6 +68,13 @@ class QgsMssqlConnection
 
     /**
      * Sets whether the connection with matching \a name should
+     * use the extent manually specified in the geometry_columns table using additional
+     * QGIS-specific columns: qgis_xmin, qgis_xmax, qgis_ymin, qgis_ymax.
+     *
+     * This is an optional optimization that allows QGIS to skip extent calculation when loading
+     * layers and thus lowering the amount of time needed to load them. The disadvantage
+     * is that the extent needs to be manually set and updated by database admins and it requires
+     * adding custom columns to the geometry_columns table.
      *
      * \see extentInGeometryColumns()
      */
@@ -92,6 +99,16 @@ class QgsMssqlConnection
 
     /**
      * Sets whether the connection with matching \a name should
+     * determine primary key's column name from a manually specified value in the geometry_columns table using
+     * an additional QGIS-specific column called "qgis_pkey". If more than one column is used for the primary key,
+     * value of "qgis_pkey" can contain multiple column names separated by comma.
+     *
+     * Note: this option only applies to views: for tables the primary key is automatically fetched from table definition.
+     *
+     * This is an optional optimization that allows QGIS to skip primary key calculation for views when loading
+     * layers and thus lowering the amount of time needed to load them. The disadvantage
+     * is that the primary key column name needs to be manually set and updated by database admins
+     * and it requires adding a custom column to the geometry_columns table.
      *
      * \see primaryKeyInGeometryColumns()
      */

--- a/src/ui/qgsmssqlnewconnectionbase.ui
+++ b/src/ui/qgsmssqlnewconnectionbase.ui
@@ -257,6 +257,9 @@ Untick save if you don't wish to be the case.</string>
          </property>
          <item>
           <widget class="QCheckBox" name="checkBoxExtentFromGeometryColumns">
+           <property name="toolTip">
+            <string>If checked, QGIS will skip extent calculation when loading layers and thus speeds up loading time. This requires manually setting the extent in dedicated columns (qgis_xmin, qgis_xmax, qgis_ymin, qgis_ymax) in the geometry_columns metadata table.</string>
+           </property>
            <property name="text">
             <string>Use layer extent from geometry_columns table</string>
            </property>
@@ -267,6 +270,9 @@ Untick save if you don't wish to be the case.</string>
       </item>
       <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBoxPKFromGeometryColumns">
+        <property name="toolTip">
+         <string>If checked, QGIS will skip primary key calculation when loading views and thus speeds up loading time. This requires manually setting the primary key(s) name in a dedicated qgis_pkey column in the geometry_columns metadata table.</string>
+        </property>
         <property name="text">
          <string>Use primary key from geometry_columns table</string>
         </property>


### PR DESCRIPTION
Well, I never touched a MS SQL database so these options looked obscure to me, but now that I found what they do, I'm pretty sure that most MS SQL users don't know what they do, unless they browsed the code. Hopefully this improves their experience.

My wish for QGIS 4: **No new setting without a clear tooltip**.