### PR TITLE
[ui][map layers] Introduce grouped style categories copy/pasting UX

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsmaplayer.py
+++ b/python/PyQt6/core/auto_additions/qgsmaplayer.py
@@ -27,6 +27,8 @@ QgsMapLayer.Temporal = QgsMapLayer.StyleCategory.Temporal
 QgsMapLayer.Legend = QgsMapLayer.StyleCategory.Legend
 QgsMapLayer.Elevation = QgsMapLayer.StyleCategory.Elevation
 QgsMapLayer.Notes = QgsMapLayer.StyleCategory.Notes
+QgsMapLayer.AllVisualStyleCategories = QgsMapLayer.StyleCategory.AllVisualStyleCategories
+QgsMapLayer.AllAttributeCategories = QgsMapLayer.StyleCategory.AllAttributeCategories
 QgsMapLayer.AllStyleCategories = QgsMapLayer.StyleCategory.AllStyleCategories
 QgsMapLayer.StyleCategory.baseClass = QgsMapLayer
 QgsMapLayer.StyleCategories = lambda flags=0: QgsMapLayer.StyleCategory(flags)

--- a/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayer.sip.in
@@ -106,6 +106,8 @@ point cloud, annotations, etc).
       Legend,
       Elevation,
       Notes,
+      AllVisualStyleCategories,
+      AllAttributeCategories,
       AllStyleCategories
     };
     typedef QFlags<QgsMapLayer::StyleCategory> StyleCategories;

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -106,6 +106,8 @@ point cloud, annotations, etc).
       Legend,
       Elevation,
       Notes,
+      AllVisualStyleCategories,
+      AllAttributeCategories,
       AllStyleCategories
     };
     typedef QFlags<QgsMapLayer::StyleCategory> StyleCategories;

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -719,6 +719,8 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           copyStyleMenu->setToolTipsVisible( true );
           QgsMapLayerStyleCategoriesModel *model = new QgsMapLayerStyleCategoriesModel( layer->type(), copyStyleMenu );
           model->setShowAllCategories( true );
+          bool hasGroupedCategory = false;
+          bool groupedCategorySeparatorAdded = false;
           for ( int row = 0; row < model->rowCount(); ++row )
           {
             const QModelIndex index = model->index( row, 0 );
@@ -726,12 +728,25 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
             const QString name = model->data( index, static_cast<int>( QgsMapLayerStyleCategoriesModel::Role::NameRole ) ).toString();
             const QString tooltip = model->data( index, Qt::ToolTipRole ).toString();
             const QIcon icon = model->data( index, Qt::DecorationRole ).value<QIcon>();
+
+            if ( !groupedCategorySeparatorAdded )
+            {
+              if ( category == QgsMapLayer::AllStyleCategories || category == QgsMapLayer::AllVisualStyleCategories || category == QgsMapLayer::AllAttributeCategories )
+              {
+                hasGroupedCategory = true;
+              }
+              else if ( hasGroupedCategory )
+              {
+                // Grouped categories over, add separator
+                copyStyleMenu->addSeparator()->setObjectName( QLatin1String( "CopyStyleSeparator" ) );
+                groupedCategorySeparatorAdded = true;
+              }
+            }
+
             QAction *copyAction = new QAction( icon, name, copyStyleMenu );
             copyAction->setToolTip( tooltip );
             connect( copyAction, &QAction::triggered, this, [app, layer, category]() { app->copyStyle( layer, category ); } );
             copyStyleMenu->addAction( copyAction );
-            if ( category == QgsMapLayer::AllStyleCategories )
-              copyStyleMenu->addSeparator()->setObjectName( QLatin1String( "CopyStyleSeparator" ) );
           }
         }
         else
@@ -758,6 +773,8 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
                 QgsMapLayerStyleCategoriesModel *model = new QgsMapLayerStyleCategoriesModel( layer->type(), pasteStyleMenu );
                 model->setShowAllCategories( true );
+                bool hasGroupedCategory = false;
+                bool groupedCategorySeparatorAdded = false;
                 for ( int row = 0; row < model->rowCount(); ++row )
                 {
                   const QModelIndex index = model->index( row, 0 );
@@ -765,14 +782,29 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
                   const QString name = model->data( index, static_cast<int>( QgsMapLayerStyleCategoriesModel::Role::NameRole ) ).toString();
                   const QString tooltip = model->data( index, Qt::ToolTipRole ).toString();
                   const QIcon icon = model->data( index, Qt::DecorationRole ).value<QIcon>();
+
+                  if ( !groupedCategorySeparatorAdded )
+                  {
+                    if ( category == QgsMapLayer::AllStyleCategories || category == QgsMapLayer::AllVisualStyleCategories || category == QgsMapLayer::AllAttributeCategories )
+                    {
+                      hasGroupedCategory = true;
+                    }
+                    else if ( hasGroupedCategory )
+                    {
+                      // Grouped categories over, add separator
+                      pasteStyleMenu->addSeparator()->setObjectName( QLatin1String( "PasteStyleSeparator" ) );
+                      groupedCategorySeparatorAdded = true;
+                    }
+                  }
+
                   QAction *pasteAction = new QAction( icon, name, pasteStyleMenu );
                   pasteAction->setToolTip( tooltip );
                   connect( pasteAction, &QAction::triggered, this, [app, layer, category]() { app->pasteStyle( layer, category ); } );
                   pasteStyleMenu->addAction( pasteAction );
-                  if ( category == QgsMapLayer::AllStyleCategories )
-                    pasteStyleMenu->addSeparator()->setObjectName( QLatin1String( "PasteStyleSeparator" ) );
-                  else
+                  if ( category != QgsMapLayer::AllStyleCategories && category != QgsMapLayer::AllVisualStyleCategories && category != QgsMapLayer::AllAttributeCategories )
+                  {
                     pasteAction->setEnabled( sourceCategories.testFlag( category ) );
+                  }
                 }
               }
             }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -187,6 +187,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
       Legend             = 1 << 15, //!< Legend settings \since QGIS 3.16
       Elevation          = 1 << 16, //!< Elevation settings \since QGIS 3.18
       Notes              = 1 << 17, //!< Layer user notes \since QGIS 3.20
+      AllVisualStyleCategories = Symbology | Symbology3D | Labeling | Diagrams, //!< All categories dealing with map canvas rendering
+      AllAttributeCategories = Fields | Forms | AttributeTable, //!< All categories dealing with attributes and attribute form
       AllStyleCategories = LayerConfiguration | Symbology | Symbology3D | Labeling | Fields | Forms | Actions |
                            MapTips | Diagrams | AttributeTable | Rendering | CustomProperties | GeometryOptions | Relations | Temporal | Legend | Elevation | Notes,
     };

--- a/src/gui/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.cpp
@@ -19,6 +19,7 @@
 
 QgsMapLayerStyleCategoriesModel::QgsMapLayerStyleCategoriesModel( Qgis::LayerType type, QObject *parent )
   : QAbstractListModel( parent )
+  , mLayerType( type )
 {
   switch ( type )
   {
@@ -483,10 +484,9 @@ QVariant QgsMapLayerStyleCategoriesModel::data( const QModelIndex &index, int ro
         case static_cast<int>( Role::NameRole ):
           return name;
         case Qt::DisplayRole:
-
           return htmlStylePattern.arg( name ).arg( description );
         case Qt::ToolTipRole:
-          return QVariant();
+          return description;
         case Qt::DecorationRole:
           return QVariant();
       }
@@ -495,16 +495,15 @@ QVariant QgsMapLayerStyleCategoriesModel::data( const QModelIndex &index, int ro
     case QgsMapLayer::StyleCategory::AllVisualStyleCategories:
     {
       QString name = tr( "All Symbology and Labeling Categories" );
-      QString description = tr( "All symbology and labeling categories" );
+      QString description = mLayerType == Qgis::LayerType::Vector ? tr( "All symbology, labeling and diagram categories" ) : tr( "All symbology and labeling categories" );
       switch ( role )
       {
         case static_cast<int>( Role::NameRole ):
           return name;
         case Qt::DisplayRole:
-
           return htmlStylePattern.arg( name ).arg( description );
         case Qt::ToolTipRole:
-          return QVariant();
+          return description;
         case Qt::DecorationRole:
           return QVariant();
       }
@@ -519,10 +518,8 @@ QVariant QgsMapLayerStyleCategoriesModel::data( const QModelIndex &index, int ro
         case static_cast<int>( Role::NameRole ):
           return name;
         case Qt::DisplayRole:
-
           return htmlStylePattern.arg( name ).arg( description );
         case Qt::ToolTipRole:
-          return QVariant();
         case Qt::DecorationRole:
           return QVariant();
       }

--- a/src/gui/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.cpp
@@ -33,6 +33,7 @@ QgsMapLayerStyleCategoriesModel::QgsMapLayerStyleCategoriesModel( Qgis::LayerTyp
     case Qgis::LayerType::Raster:
       mCategoryList << QgsMapLayer::StyleCategory::LayerConfiguration
                     << QgsMapLayer::StyleCategory::Symbology
+                    << QgsMapLayer::StyleCategory::Labeling
                     << QgsMapLayer::StyleCategory::MapTips
                     << QgsMapLayer::StyleCategory::Rendering
                     << QgsMapLayer::StyleCategory::CustomProperties
@@ -40,6 +41,7 @@ QgsMapLayerStyleCategoriesModel::QgsMapLayerStyleCategoriesModel( Qgis::LayerTyp
                     << QgsMapLayer::StyleCategory::Elevation
                     << QgsMapLayer::StyleCategory::AttributeTable
                     << QgsMapLayer::StyleCategory::Notes
+                    << QgsMapLayer::StyleCategory::AllVisualStyleCategories
                     << QgsMapLayer::StyleCategory::AllStyleCategories;
       break;
     case Qgis::LayerType::Annotation:

--- a/src/gui/qgsmaplayerstylecategoriesmodel.h
+++ b/src/gui/qgsmaplayerstylecategoriesmodel.h
@@ -61,6 +61,8 @@ class GUI_EXPORT QgsMapLayerStyleCategoriesModel : public QAbstractListModel
     Qt::ItemFlags flags( const QModelIndex & ) const override;
 
   private:
+    //! map layer type
+    Qgis::LayerType mLayerType = Qgis::LayerType::Vector;
     //! current data as flags
     QgsMapLayer::StyleCategories mCategories;
     //! map of existing categories


### PR DESCRIPTION
## Description

This PR adds a couple of grouped categories shortcuts in the layer tree menu's copy / paste style sub-menu. This allows for users to rapidly copy/paste a set of grouped categories across layers.

Screenshot time:

<img width="762" height="401" alt="image" src="https://github.com/user-attachments/assets/7c4ab642-d362-476b-afae-85569652f9ef" />

@nyalldawson , while coding this, I noticed the labeling style category was missing for raster layer. It's been addressed here too:

<img width="829" height="492" alt="image" src="https://github.com/user-attachments/assets/8a2143e2-6b7a-4a29-a0e1-06ca6630345f" />
