### PR TITLE
Tag algorithms which respect ellipsoid

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -6665,12 +6665,17 @@ ProcessingAlgorithmFlags = Qgis  # dirty hack since SIP seems to introduce the f
 # monkey patching scoped based enum
 Qgis.ProcessingAlgorithmDocumentationFlag.RegeneratesPrimaryKey.__doc__ = "Algorithm always drops any existing primary keys or FID values and regenerates them in outputs"
 Qgis.ProcessingAlgorithmDocumentationFlag.RegeneratesPrimaryKeyInSomeScenarios.__doc__ = "Algorithm may drop the existing primary keys or FID values in some scenarios, depending on algorithm inputs and parameters"
+Qgis.ProcessingAlgorithmDocumentationFlag.RespectsEllipsoid.__doc__ = "Algorithm respects the context's ellipsoid settings, and uses ellipsoidal based measurements. \n.. versionadded:: 4.0"
 Qgis.ProcessingAlgorithmDocumentationFlag.__doc__ = """Flags describing algorithm behavior for documentation purposes.
 
 .. versionadded:: 3.40
 
 * ``RegeneratesPrimaryKey``: Algorithm always drops any existing primary keys or FID values and regenerates them in outputs
 * ``RegeneratesPrimaryKeyInSomeScenarios``: Algorithm may drop the existing primary keys or FID values in some scenarios, depending on algorithm inputs and parameters
+* ``RespectsEllipsoid``: Algorithm respects the context's ellipsoid settings, and uses ellipsoidal based measurements.
+
+  .. versionadded:: 4.0
+
 
 """
 # --

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2032,6 +2032,7 @@ The development version
     {
       RegeneratesPrimaryKey,
       RegeneratesPrimaryKeyInSomeScenarios,
+      RespectsEllipsoid,
     };
 
     typedef QFlags<Qgis::ProcessingAlgorithmDocumentationFlag> ProcessingAlgorithmDocumentationFlags;

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -6603,12 +6603,17 @@ ProcessingAlgorithmFlags = Qgis  # dirty hack since SIP seems to introduce the f
 # monkey patching scoped based enum
 Qgis.ProcessingAlgorithmDocumentationFlag.RegeneratesPrimaryKey.__doc__ = "Algorithm always drops any existing primary keys or FID values and regenerates them in outputs"
 Qgis.ProcessingAlgorithmDocumentationFlag.RegeneratesPrimaryKeyInSomeScenarios.__doc__ = "Algorithm may drop the existing primary keys or FID values in some scenarios, depending on algorithm inputs and parameters"
+Qgis.ProcessingAlgorithmDocumentationFlag.RespectsEllipsoid.__doc__ = "Algorithm respects the context's ellipsoid settings, and uses ellipsoidal based measurements. \n.. versionadded:: 4.0"
 Qgis.ProcessingAlgorithmDocumentationFlag.__doc__ = """Flags describing algorithm behavior for documentation purposes.
 
 .. versionadded:: 3.40
 
 * ``RegeneratesPrimaryKey``: Algorithm always drops any existing primary keys or FID values and regenerates them in outputs
 * ``RegeneratesPrimaryKeyInSomeScenarios``: Algorithm may drop the existing primary keys or FID values in some scenarios, depending on algorithm inputs and parameters
+* ``RespectsEllipsoid``: Algorithm respects the context's ellipsoid settings, and uses ellipsoidal based measurements.
+
+  .. versionadded:: 4.0
+
 
 """
 # --

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2032,6 +2032,7 @@ The development version
     {
       RegeneratesPrimaryKey,
       RegeneratesPrimaryKeyInSomeScenarios,
+      RespectsEllipsoid,
     };
 
     typedef QFlags<Qgis::ProcessingAlgorithmDocumentationFlag> ProcessingAlgorithmDocumentationFlags;

--- a/python/plugins/processing/algs/qgis/HubDistanceLines.py
+++ b/python/plugins/processing/algs/qgis/HubDistanceLines.py
@@ -21,6 +21,7 @@ __copyright__ = "(C) 2010, Michael Minn"
 
 from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (
+    Qgis,
     QgsField,
     QgsFields,
     QgsProcessingUtils,
@@ -66,6 +67,9 @@ class HubDistanceLines(QgisAlgorithm):
 
     def groupId(self):
         return "vectoranalysis"
+
+    def documentationFlags(self):
+        return Qgis.ProcessingAlgorithmDocumentationFlag.RespectsEllipsoid
 
     def __init__(self):
         super().__init__()

--- a/python/plugins/processing/algs/qgis/HubDistancePoints.py
+++ b/python/plugins/processing/algs/qgis/HubDistancePoints.py
@@ -21,6 +21,7 @@ __copyright__ = "(C) 2010, Michael Minn"
 
 from qgis.PyQt.QtCore import QMetaType
 from qgis.core import (
+    Qgis,
     QgsField,
     QgsFields,
     QgsProcessingUtils,
@@ -63,6 +64,9 @@ class HubDistancePoints(QgisAlgorithm):
 
     def groupId(self):
         return "vectoranalysis"
+
+    def documentationFlags(self):
+        return Qgis.ProcessingAlgorithmDocumentationFlag.RespectsEllipsoid
 
     def __init__(self):
         super().__init__()

--- a/python/plugins/processing/algs/qgis/PointDistance.py
+++ b/python/plugins/processing/algs/qgis/PointDistance.py
@@ -26,6 +26,7 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtCore import QMetaType
 
 from qgis.core import (
+    Qgis,
     QgsApplication,
     QgsFeatureRequest,
     QgsField,
@@ -71,6 +72,9 @@ class PointDistance(QgisAlgorithm):
 
     def groupId(self):
         return "vectoranalysis"
+
+    def documentationFlags(self):
+        return Qgis.ProcessingAlgorithmDocumentationFlag.RespectsEllipsoid
 
     def __init__(self):
         super().__init__()

--- a/python/plugins/processing/algs/qgis/RandomPointsAlongLines.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsAlongLines.py
@@ -108,7 +108,10 @@ class RandomPointsAlongLines(QgisAlgorithm):
         return self.tr("Random points along line")
 
     def documentationFlags(self):
-        return Qgis.ProcessingAlgorithmDocumentationFlag.RegeneratesPrimaryKey
+        return Qgis.ProcessingAlgorithmDocumentationFlags(
+            Qgis.ProcessingAlgorithmDocumentationFlag.RegeneratesPrimaryKey
+            | Qgis.ProcessingAlgorithmDocumentationFlag.RespectsEllipsoid
+        )
 
     def processAlgorithm(self, parameters, context, feedback):
         source = self.parameterAsSource(parameters, self.INPUT, context)

--- a/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
@@ -153,7 +153,10 @@ class RandomPointsPolygons(QgisAlgorithm):
         return self.tr("Random points inside polygons")
 
     def documentationFlags(self):
-        return Qgis.ProcessingAlgorithmDocumentationFlag.RegeneratesPrimaryKey
+        return Qgis.ProcessingAlgorithmDocumentationFlags(
+            Qgis.ProcessingAlgorithmDocumentationFlag.RegeneratesPrimaryKey
+            | Qgis.ProcessingAlgorithmDocumentationFlag.RespectsEllipsoid
+        )
 
     def processAlgorithm(self, parameters, context, feedback):
         source = self.parameterAsSource(parameters, self.INPUT, context)

--- a/src/analysis/processing/qgsalgorithmaggregate.cpp
+++ b/src/analysis/processing/qgsalgorithmaggregate.cpp
@@ -45,6 +45,11 @@ QString QgsAggregateAlgorithm::shortDescription() const
   return QObject::tr( "Aggregates features based on a group by expression, combining geometries (if present) into one multipart geometry for each group." );
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsAggregateAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 QStringList QgsAggregateAlgorithm::tags() const
 {
   return QObject::tr( "attributes,sum,mean,collect,dissolve,statistics" ).split( ',' );

--- a/src/analysis/processing/qgsalgorithmaggregate.h
+++ b/src/analysis/processing/qgsalgorithmaggregate.h
@@ -41,6 +41,7 @@ class QgsAggregateAlgorithm : public QgsProcessingAlgorithm
     QString shortHelpString() const override;
     QString shortDescription() const override;
     bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     QgsAggregateAlgorithm *createInstance() const override SIP_FACTORY;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
 

--- a/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
+++ b/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
@@ -83,6 +83,11 @@ QString QgsCalculateVectorOverlapsAlgorithm::shortDescription() const
                       "are overlapped by features from a selection of overlay layers." );
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsCalculateVectorOverlapsAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 QgsCalculateVectorOverlapsAlgorithm *QgsCalculateVectorOverlapsAlgorithm::createInstance() const
 {
   return new QgsCalculateVectorOverlapsAlgorithm();

--- a/src/analysis/processing/qgsalgorithmcalculateoverlaps.h
+++ b/src/analysis/processing/qgsalgorithmcalculateoverlaps.h
@@ -44,6 +44,7 @@ class QgsCalculateVectorOverlapsAlgorithm : public QgsProcessingAlgorithm
     QString groupId() const override;
     QString shortHelpString() const override;
     QString shortDescription() const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     QgsCalculateVectorOverlapsAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:

--- a/src/analysis/processing/qgsalgorithmexportgeometryattributes.cpp
+++ b/src/analysis/processing/qgsalgorithmexportgeometryattributes.cpp
@@ -61,6 +61,11 @@ QString QgsExportGeometryAttributesAlgorithm::shortDescription() const
   return QObject::tr( "Computes geometric properties of the features in a vector layer." );
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsExportGeometryAttributesAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 QgsExportGeometryAttributesAlgorithm *QgsExportGeometryAttributesAlgorithm::createInstance() const
 {
   return new QgsExportGeometryAttributesAlgorithm();

--- a/src/analysis/processing/qgsalgorithmexportgeometryattributes.h
+++ b/src/analysis/processing/qgsalgorithmexportgeometryattributes.h
@@ -44,6 +44,7 @@ class QgsExportGeometryAttributesAlgorithm : public QgsProcessingAlgorithm
     QString groupId() const override;
     QString shortHelpString() const override;
     QString shortDescription() const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     QgsExportGeometryAttributesAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:

--- a/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
+++ b/src/analysis/processing/qgsalgorithmfieldcalculator.cpp
@@ -57,6 +57,11 @@ QList<int> QgsFieldCalculatorAlgorithm::inputLayerTypes() const
   return QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::Vector );
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsFieldCalculatorAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 Qgis::ProcessingFeatureSourceFlags QgsFieldCalculatorAlgorithm::sourceFlags() const
 {
   return Qgis::ProcessingFeatureSourceFlag::SkipGeometryValidityChecks;

--- a/src/analysis/processing/qgsalgorithmfieldcalculator.h
+++ b/src/analysis/processing/qgsalgorithmfieldcalculator.h
@@ -42,6 +42,7 @@ class QgsFieldCalculatorAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString shortHelpString() const override;
     QString shortDescription() const override;
     QList<int> inputLayerTypes() const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     QgsFieldCalculatorAlgorithm *createInstance() const override SIP_FACTORY;
     bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 

--- a/src/analysis/processing/qgsalgorithmlinedensity.cpp
+++ b/src/analysis/processing/qgsalgorithmlinedensity.cpp
@@ -79,6 +79,11 @@ QString QgsLineDensityAlgorithm::shortHelpString() const
   );
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsLineDensityAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 QString QgsLineDensityAlgorithm::shortDescription() const
 {
   return QObject::tr( "Calculates a density measure of linear features "

--- a/src/analysis/processing/qgsalgorithmlinedensity.h
+++ b/src/analysis/processing/qgsalgorithmlinedensity.h
@@ -50,6 +50,7 @@ class QgsLineDensityAlgorithm : public QgsProcessingAlgorithm
     QString groupId() const override;
     QString shortDescription() const override;
     QString shortHelpString() const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     QgsLineDensityAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:

--- a/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.cpp
+++ b/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.cpp
@@ -70,6 +70,11 @@ QIcon QgsNearestNeighbourAnalysisAlgorithm::icon() const
   return QgsApplication::getThemeIcon( QStringLiteral( "/algorithms/mAlgorithmNearestNeighbour.svg" ) );
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsNearestNeighbourAnalysisAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 QgsNearestNeighbourAnalysisAlgorithm *QgsNearestNeighbourAnalysisAlgorithm::createInstance() const
 {
   return new QgsNearestNeighbourAnalysisAlgorithm();

--- a/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.h
+++ b/src/analysis/processing/qgsalgorithmnearestneighbouranalysis.h
@@ -41,6 +41,7 @@ class QgsNearestNeighbourAnalysisAlgorithm : public QgsProcessingAlgorithm
     QString shortDescription() const override;
     QString svgIconPath() const override;
     QIcon icon() const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QgsNearestNeighbourAnalysisAlgorithm *createInstance() const override SIP_FACTORY;
 

--- a/src/analysis/processing/qgsalgorithmnetworkanalysisbase.cpp
+++ b/src/analysis/processing/qgsalgorithmnetworkanalysisbase.cpp
@@ -44,6 +44,11 @@ Qgis::ProcessingAlgorithmFlags QgsNetworkAnalysisAlgorithmBase::flags() const
   return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsNetworkAnalysisAlgorithmBase::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 void QgsNetworkAnalysisAlgorithmBase::addCommonParams()
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Vector layer representing network" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorLine ) ) );

--- a/src/analysis/processing/qgsalgorithmnetworkanalysisbase.h
+++ b/src/analysis/processing/qgsalgorithmnetworkanalysisbase.h
@@ -40,6 +40,7 @@ class QgsNetworkAnalysisAlgorithmBase : public QgsProcessingAlgorithm
     QString groupId() const final;
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/algorithms/mAlgorithmNetworkAnalysis.svg" ) ); }
     QString svgIconPath() const override { return QgsApplication::iconPath( QStringLiteral( "/algorithms/mAlgorithmNetworkAnalysis.svg" ) ); }
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     Qgis::ProcessingAlgorithmFlags flags() const override;
 
   protected:

--- a/src/analysis/processing/qgsalgorithmpointstopaths.cpp
+++ b/src/analysis/processing/qgsalgorithmpointstopaths.cpp
@@ -50,6 +50,11 @@ QString QgsPointsToPathsAlgorithm::shortDescription() const
   return QObject::tr( "Takes a point layer and connects its features to create a new line layer." );
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsPointsToPathsAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 QStringList QgsPointsToPathsAlgorithm::tags() const
 {
   return QObject::tr( "create,lines,points,connect,convert,join,path" ).split( ',' );

--- a/src/analysis/processing/qgsalgorithmpointstopaths.h
+++ b/src/analysis/processing/qgsalgorithmpointstopaths.h
@@ -40,6 +40,7 @@ class QgsPointsToPathsAlgorithm : public QgsProcessingAlgorithm
     QString groupId() const override;
     QString shortHelpString() const override;
     QString shortDescription() const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     QgsPointsToPathsAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:

--- a/src/analysis/processing/qgsalgorithmrefactorfields.cpp
+++ b/src/analysis/processing/qgsalgorithmrefactorfields.cpp
@@ -71,6 +71,11 @@ QList<int> QgsRefactorFieldsAlgorithm::inputLayerTypes() const
   return QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::Vector );
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsRefactorFieldsAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 Qgis::ProcessingFeatureSourceFlags QgsRefactorFieldsAlgorithm::sourceFlags() const
 {
   return Qgis::ProcessingFeatureSourceFlag::SkipGeometryValidityChecks;

--- a/src/analysis/processing/qgsalgorithmrefactorfields.h
+++ b/src/analysis/processing/qgsalgorithmrefactorfields.h
@@ -41,6 +41,7 @@ class QgsRefactorFieldsAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString shortHelpString() const override;
     QString shortDescription() const override;
     QList<int> inputLayerTypes() const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     QgsRefactorFieldsAlgorithm *createInstance() const override SIP_FACTORY;
     bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
 

--- a/src/analysis/processing/qgsalgorithmsplitlineantimeridian.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitlineantimeridian.cpp
@@ -67,6 +67,11 @@ QString QgsSplitGeometryAtAntimeridianAlgorithm::shortHelpString() const
                       "created at the antimeridian." );
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsSplitGeometryAtAntimeridianAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 QList<int> QgsSplitGeometryAtAntimeridianAlgorithm::inputLayerTypes() const
 {
   return QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorLine );

--- a/src/analysis/processing/qgsalgorithmsplitlineantimeridian.h
+++ b/src/analysis/processing/qgsalgorithmsplitlineantimeridian.h
@@ -40,6 +40,7 @@ class QgsSplitGeometryAtAntimeridianAlgorithm : public QgsProcessingFeatureBased
     QString groupId() const override;
     QString shortDescription() const override;
     QString shortHelpString() const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     QList<int> inputLayerTypes() const override;
     Qgis::ProcessingSourceType outputLayerType() const override;
     QgsSplitGeometryAtAntimeridianAlgorithm *createInstance() const override SIP_FACTORY;

--- a/src/analysis/processing/qgsalgorithmsumlinelength.cpp
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.cpp
@@ -76,6 +76,11 @@ QString QgsSumLineLengthAlgorithm::shortDescription() const
                       "them that cross each polygon." );
 }
 
+Qgis::ProcessingAlgorithmDocumentationFlags QgsSumLineLengthAlgorithm::documentationFlags() const
+{
+  return Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid;
+}
+
 QgsSumLineLengthAlgorithm *QgsSumLineLengthAlgorithm::createInstance() const
 {
   return new QgsSumLineLengthAlgorithm();

--- a/src/analysis/processing/qgsalgorithmsumlinelength.h
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.h
@@ -41,6 +41,7 @@ class QgsSumLineLengthAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString groupId() const override;
     QString shortHelpString() const override;
     QString shortDescription() const override;
+    Qgis::ProcessingAlgorithmDocumentationFlags documentationFlags() const override;
     QgsSumLineLengthAlgorithm *createInstance() const override SIP_FACTORY;
     void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
     QList<int> inputLayerTypes() const override;

--- a/src/core/processing/qgsprocessing.cpp
+++ b/src/core/processing/qgsprocessing.cpp
@@ -36,6 +36,8 @@ QString QgsProcessing::documentationFlagToString( Qgis::ProcessingAlgorithmDocum
       return QObject::tr( "This algorithm drops existing primary keys or FID values and regenerates them in output layers." );
     case Qgis::ProcessingAlgorithmDocumentationFlag::RegeneratesPrimaryKeyInSomeScenarios:
       return QObject::tr( "This algorithm may drop existing primary keys or FID values and regenerate them in output layers, depending on the input parameters." );
+    case Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid:
+      return QObject::tr( "This algorithm uses ellipsoidal based measurements and respects the current ellipsoid settings." );
   }
   BUILTIN_UNREACHABLE
 }

--- a/src/core/processing/qgsprocessing.cpp
+++ b/src/core/processing/qgsprocessing.cpp
@@ -37,7 +37,7 @@ QString QgsProcessing::documentationFlagToString( Qgis::ProcessingAlgorithmDocum
     case Qgis::ProcessingAlgorithmDocumentationFlag::RegeneratesPrimaryKeyInSomeScenarios:
       return QObject::tr( "This algorithm may drop existing primary keys or FID values and regenerate them in output layers, depending on the input parameters." );
     case Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid:
-      return QObject::tr( "This algorithm uses ellipsoidal based measurements and respects the current ellipsoid settings." );
+      return QObject::tr( "This algorithm uses ellipsoid based measurements and respects the current ellipsoid settings." );
   }
   BUILTIN_UNREACHABLE
 }

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3520,6 +3520,7 @@ class CORE_EXPORT Qgis
     {
       RegeneratesPrimaryKey = 1 << 0, //!< Algorithm always drops any existing primary keys or FID values and regenerates them in outputs
       RegeneratesPrimaryKeyInSomeScenarios = 1 << 1, //!< Algorithm may drop the existing primary keys or FID values in some scenarios, depending on algorithm inputs and parameters
+      RespectsEllipsoid = 1 << 2, //!< Algorithm respects the context's ellipsoid settings, and uses ellipsoidal based measurements. \since QGIS 4.0
     };
     Q_ENUM( ProcessingAlgorithmDocumentationFlag )
 

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -1350,6 +1350,9 @@ void QgsProcessingExec::addAlgorithmInformation( QVariantMap &algorithmJson, con
           case Qgis::ProcessingAlgorithmDocumentationFlag::RegeneratesPrimaryKeyInSomeScenarios:
             documentationFlags << QStringLiteral( "regenerates_primary_key_in_some_scenarios" );
             break;
+          case Qgis::ProcessingAlgorithmDocumentationFlag::RespectsEllipsoid:
+            documentationFlags << QStringLiteral( "respects_ellipsoid" );
+            break;
         }
         algorithmJson.insert( QStringLiteral( "documentation_flags" ), documentationFlags );
       }


### PR DESCRIPTION
Adds an explicit note to algorithms which respect the current ellipsoid settings:

<img width="799" height="185" alt="image" src="https://github.com/user-attachments/assets/023dd9cc-9b8f-449b-8c45-fa7b2c397b22" />
