### PR TITLE
Fix incorrect selectedFeatureCount when selectByIds called with non-existent ID

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -640,12 +640,19 @@ void QgsVectorLayer::selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior
 
   // Filter out non-existent feature IDs to ensure only valid features are selected
   QgsFeatureIds validIds;
-  for ( QgsFeatureId id : ids )
+  if ( !ids.isEmpty() )
   {
-    QgsFeature feature = getFeature( id );
-    if ( feature.isValid() )
+    // request only feature IDs without geometry or attributes
+    QgsFeatureRequest request;
+    request.setFilterFids( ids );
+    request.setFlags( Qgis::FeatureRequestFlag::NoGeometry );
+    request.setNoAttributes();
+
+    QgsFeatureIterator it = getFeatures( request );
+    QgsFeature feature;
+    while ( it.nextFeature( feature ) )
     {
-      validIds.insert( id );
+      validIds.insert( feature.id() );
     }
   }
 

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -638,24 +638,35 @@ void QgsVectorLayer::selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
+  // Filter out non-existent feature IDs to ensure only valid features are selected
+  QgsFeatureIds validIds;
+  for ( QgsFeatureId id : ids )
+  {
+    QgsFeature feature = getFeature( id );
+    if ( feature.isValid() )
+    {
+      validIds.insert( id );
+    }
+  }
+
   QgsFeatureIds newSelection;
 
   switch ( behavior )
   {
     case Qgis::SelectBehavior::SetSelection:
-      newSelection = ids;
+      newSelection = validIds;
       break;
 
     case Qgis::SelectBehavior::AddToSelection:
-      newSelection = mSelectedFeatureIds + ids;
+      newSelection = mSelectedFeatureIds + validIds;
       break;
 
     case Qgis::SelectBehavior::RemoveFromSelection:
-      newSelection = mSelectedFeatureIds - ids;
+      newSelection = mSelectedFeatureIds - validIds;
       break;
 
     case Qgis::SelectBehavior::IntersectSelection:
-      newSelection = mSelectedFeatureIds.intersect( ids );
+      newSelection = mSelectedFeatureIds.intersect( validIds );
       break;
   }
 

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -549,9 +549,9 @@ void TestQgsVectorLayer::testSelectByIdsNonExistentIds()
   QVERIFY( layer->isValid() );
   
   QgsFeature f1, f2, f3;
-  f1.setAttributes( QgsAttributeList() << 1 << "feature1" );
-  f2.setAttributes( QgsAttributeList() << 2 << "feature2" );
-  f3.setAttributes( QgsAttributeList() << 3 << "feature3" );
+  f1.setAttributes( QVariantList() << 1 << "feature1" );
+  f2.setAttributes( QVariantList() << 2 << "feature2" );
+  f3.setAttributes( QVariantList() << 3 << "feature3" );
   
   layer->dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 << f3 );
   

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -549,9 +549,9 @@ void TestQgsVectorLayer::testSelectByIdsNonExistentIds()
   QVERIFY( layer->isValid() );
   
   QgsFeature f1, f2, f3;
-  f1.setAttributes( QVariantList() << 1 << "feature1" );
-  f2.setAttributes( QVariantList() << 2 << "feature2" );
-  f3.setAttributes( QVariantList() << 3 << "feature3" );
+  f1.setAttributes( QgsAttributes() << 1 << "feature1" );
+  f2.setAttributes( QgsAttributes() << 2 << "feature2" );
+  f3.setAttributes( QgsAttributes() << 3 << "feature3" );
   
   layer->dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 << f3 );
   


### PR DESCRIPTION
**### Fix incorrect selectedFeatureCount when selectByIds called with non-existent IDs**

- Filter out non-existent feature IDs in QgsVectorLayer::selectByIds()
- Add test cases for the fix
- Resolves issue #61604"