### PR TITLE
Add some timezone related expression functions

### DIFF
--- a/resources/function_help/json/convert_timezone
+++ b/resources/function_help/json/convert_timezone
@@ -11,7 +11,12 @@
     "arg": "timezone",
     "description": "target timezone"
   }],
-  "examples": [{
+  "examples": [
+  {
+    "expression": "convert_timezone(to_datetime('2012-05-04 12:50:00 UTC+03'), timezone_from_id('UTC+10'))",
+    "returns": "datetime 2012-05-04 19:50:00 (UTC+10)"
+  },
+  {
     "expression": "convert_timezone(\"DATE_FIELD\", timezone_from_id('Australia/Darwin'))",
     "returns": "Datetime from DATE_FIELD, converted to the 'Australia/Darwin' timezone"
   }],

--- a/resources/function_help/json/convert_timezone
+++ b/resources/function_help/json/convert_timezone
@@ -1,0 +1,19 @@
+{
+  "name": "convert_timezone",
+  "type": "function",
+  "groups": ["Conversions", "Date and Time"],
+  "description": "Converts a datetime object to a different timezone.",
+  "arguments": [{
+    "arg": "datetime",
+    "description": "datetime value"
+  },
+  {
+    "arg": "timezone",
+    "description": "target timezone"
+  }],
+  "examples": [{
+    "expression": "convert_timezone(\"DATE_FIELD\", timezone_from_id('Australia/Darwin'))",
+    "returns": "Datetime from DATE_FIELD, converted to the 'Australia/Darwin' timezone"
+  }],
+  "tags": ["time", "zone", "date", "datetime", "offset", "utc"]
+}

--- a/resources/function_help/json/convert_timezone
+++ b/resources/function_help/json/convert_timezone
@@ -13,7 +13,7 @@
   }],
   "examples": [
   {
-    "expression": "convert_timezone(to_datetime('2012-05-04 12:50:00 UTC+03'), timezone_from_id('UTC+10'))",
+    "expression": "convert_timezone(to_datetime('2012-05-04 12:50:00+3'), timezone_from_id('UTC+10'))",
     "returns": "datetime 2012-05-04 19:50:00 (UTC+10)"
   },
   {

--- a/resources/function_help/json/get_timezone
+++ b/resources/function_help/json/get_timezone
@@ -1,0 +1,15 @@
+{
+  "name": "get_timezone",
+  "type": "function",
+  "groups": ["Conversions", "Date and Time"],
+  "description": "Returns the timezone object associated with a datetime value.",
+  "arguments": [{
+    "arg": "datetime",
+    "description": "datetime with timezone"
+  }],
+  "examples": [{
+    "expression": "timezone_id(get_timezone(\"DATE_FIELD\"))",
+    "returns": "ID of timezone associated with the DATE_FIELD value"
+  }],
+  "tags": ["time", "zone", "date", "datetime", "offset", "utc"]
+}

--- a/resources/function_help/json/get_timezone
+++ b/resources/function_help/json/get_timezone
@@ -9,7 +9,7 @@
   }],
   "examples": [
   {
-    "expression": "timezone_id(get_timezone(to_datetime('2012-05-04 12:50:00 UTC+03')))",
+    "expression": "timezone_id(get_timezone(to_datetime('2012-05-04 12:50:00+3')))",
     "returns": "'UTC+03'"
   },
   {

--- a/resources/function_help/json/get_timezone
+++ b/resources/function_help/json/get_timezone
@@ -7,7 +7,12 @@
     "arg": "datetime",
     "description": "datetime with timezone"
   }],
-  "examples": [{
+  "examples": [
+  {
+    "expression": "timezone_id(get_timezone(to_datetime('2012-05-04 12:50:00 UTC+03')))",
+    "returns": "'UTC+03'"
+  },
+  {
     "expression": "timezone_id(get_timezone(\"DATE_FIELD\"))",
     "returns": "ID of timezone associated with the DATE_FIELD value"
   }],

--- a/resources/function_help/json/set_timezone
+++ b/resources/function_help/json/set_timezone
@@ -11,7 +11,12 @@
     "arg": "timezone",
     "description": "new timezone for datetime"
   }],
-  "examples": [{
+  "examples": [
+  {
+    "expression": "set_timezone(to_datetime('2012-05-04 12:50:00 UTC+03'), timezone_from_id('UTC+10'))",
+    "returns": "datetime 2012-05-04 12:50:00 (UTC+10)"
+  },
+  {
     "expression": "set_timezone(make_datetime(2020,1,1,10,0,0), timezone_from_id('Australia/Darwin'))",
     "returns": "Datetime of 2020-01-01 10:00:00 with associated timezone 'Australia/Darwin'"
   }],

--- a/resources/function_help/json/set_timezone
+++ b/resources/function_help/json/set_timezone
@@ -13,7 +13,7 @@
   }],
   "examples": [
   {
-    "expression": "set_timezone(to_datetime('2012-05-04 12:50:00 UTC+03'), timezone_from_id('UTC+10'))",
+    "expression": "set_timezone(to_datetime('2012-05-04 12:50:00+3'), timezone_from_id('UTC+10'))",
     "returns": "datetime 2012-05-04 12:50:00 (UTC+10)"
   },
   {

--- a/resources/function_help/json/set_timezone
+++ b/resources/function_help/json/set_timezone
@@ -1,0 +1,19 @@
+{
+  "name": "set_timezone",
+  "type": "function",
+  "groups": ["Conversions", "Date and Time"],
+  "description": "Sets the timezone object associated with a datetime value, without changing the date or time components. This function can be used to replace the timezone for a datetime.",
+  "arguments": [{
+    "arg": "datetime",
+    "description": "datetime value"
+  },
+  {
+    "arg": "timezone",
+    "description": "new timezone for datetime"
+  }],
+  "examples": [{
+    "expression": "set_timezone(make_datetime(2020,1,1,10,0,0), timezone_from_id('Australia/Darwin'))",
+    "returns": "Datetime of 2020-01-01 10:00:00 with associated timezone 'Australia/Darwin'"
+  }],
+  "tags": ["time", "zone", "date", "datetime", "offset", "utc"]
+}

--- a/resources/function_help/json/timezone_from_id
+++ b/resources/function_help/json/timezone_from_id
@@ -1,0 +1,15 @@
+{
+  "name": "timezone_from_id",
+  "type": "function",
+  "groups": ["Conversions", "Date and Time"],
+  "description": "Creates a timezone object from a string ID (from the IANA timezone database). The ID must be one of the available system IDs or a valid UTC-with-offset ID.",
+  "arguments": [{
+    "arg": "id",
+    "description": "string containing the time zone ID"
+  }],
+  "examples": [{
+    "expression": "timezone_from_id('Australia/Brisbane')",
+    "returns": "AEST timezone object"
+  }],
+  "tags": ["time", "zone", "date", "datetime", "offset", "utc"]
+}

--- a/resources/function_help/json/timezone_from_id
+++ b/resources/function_help/json/timezone_from_id
@@ -10,6 +10,14 @@
   "examples": [{
     "expression": "timezone_from_id('Australia/Brisbane')",
     "returns": "AEST timezone object"
+  },
+  {
+    "expression": "timezone_from_id('UTC+10:30')",
+    "returns": "UTC+10:30 timezone object"
+  },
+  {
+    "expression": "timezone_from_id('UTC-3')",
+    "returns": "UTC-03 timezone object"
   }],
   "tags": ["time", "zone", "date", "datetime", "offset", "utc"]
 }

--- a/resources/function_help/json/timezone_id
+++ b/resources/function_help/json/timezone_id
@@ -1,0 +1,15 @@
+{
+  "name": "timezone_id",
+  "type": "function",
+  "groups": ["Conversions", "Date and Time"],
+  "description": "Returns the ID string for a timezone object, using IDs from the IANA timezone database.",
+  "arguments": [{
+    "arg": "timezone",
+    "description": "a valid timezone object"
+  }],
+  "examples": [{
+    "expression": "timezone_id(timezone_from_id('Australia/Brisbane'))",
+    "returns": "'Australia/Brisbane'"
+  }],
+  "tags": ["time", "zone", "date", "datetime", "offset", "utc"]
+}

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -1061,6 +1061,11 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
     const QgsCoordinateReferenceSystem crs = value.value<QgsCoordinateReferenceSystem>();
     return startToken + tr( "crs: %1" ).arg( crs.userFriendlyIdentifier() ) + endToken;
   }
+  else if ( value.userType() == qMetaTypeId< QTimeZone>() )
+  {
+    const QTimeZone tz = value.value<QTimeZone>();
+    return startToken + tr( "time zone: %1" ).arg( tz.displayName( QTimeZone::GenericTime, QTimeZone::ShortName ) ) + endToken;
+  }
   else if ( value.userType() == qMetaTypeId< QgsInterval>() )
   {
     QgsInterval interval = value.value<QgsInterval>();

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -1064,7 +1064,7 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
   else if ( value.userType() == qMetaTypeId< QTimeZone>() )
   {
     const QTimeZone tz = value.value<QTimeZone>();
-    return startToken + tr( "time zone: %1" ).arg( tz.displayName( QTimeZone::GenericTime, QTimeZone::ShortName ) ) + endToken;
+    return startToken + tr( "time zone: %1" ).arg( tz.isValid() ? tz.displayName( QTimeZone::GenericTime, QTimeZone::ShortName ) : tr( "invalid" ) ) + endToken;
   }
   else if ( value.userType() == qMetaTypeId< QgsInterval>() )
   {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1377,6 +1377,16 @@ static QVariant fcnTimeZoneFromId( const QVariantList &values, const QgsExpressi
   return QVariant::fromValue( tz );
 }
 
+static QVariant fcnGetTimeZone( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const QDateTime datetime = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
+  if ( datetime.isValid() )
+  {
+    return QVariant::fromValue( datetime.timeZone() );
+  }
+  return QVariant();
+}
+
 static QVariant fcnTimeZoneToId( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QTimeZone timeZone = QgsExpressionUtils::getTimeZoneValue( values.at( 0 ), parent );
@@ -1386,7 +1396,6 @@ static QVariant fcnTimeZoneToId( const QVariantList &values, const QgsExpression
   }
   return QVariant();
 }
-
 static QVariant fcnMakeInterval( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const double years = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
@@ -8677,6 +8686,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
                                             fcnMakeInterval, QStringLiteral( "Date and Time" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "timezone_from_id" ), { QgsExpressionFunction::Parameter( QStringLiteral( "id" ) ) }, fcnTimeZoneFromId, QStringLiteral( "Date and Time" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "timezone_id" ), { QgsExpressionFunction::Parameter( QStringLiteral( "timezone" ) ) }, fcnTimeZoneToId, QStringLiteral( "Date and Time" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "get_timezone" ), { QgsExpressionFunction::Parameter( QStringLiteral( "datetime" ) ) }, fcnGetTimeZone, QStringLiteral( "Date and Time" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "lower" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnLower, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "upper" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnUpper, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "title" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnTitle, QStringLiteral( "String" ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1387,6 +1387,29 @@ static QVariant fcnGetTimeZone( const QVariantList &values, const QgsExpressionC
   return QVariant();
 }
 
+static QVariant fcnSetTimeZone( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QDateTime datetime = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
+  const QTimeZone tz = QgsExpressionUtils::getTimeZoneValue( values.at( 1 ), parent );
+  if ( datetime.isValid() && tz.isValid() )
+  {
+    datetime.setTimeZone( tz );
+    return QVariant::fromValue( datetime );
+  }
+  return QVariant();
+}
+
+static QVariant fcnConvertTimeZone( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const QDateTime datetime = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
+  const QTimeZone tz = QgsExpressionUtils::getTimeZoneValue( values.at( 1 ), parent );
+  if ( datetime.isValid() && tz.isValid() )
+  {
+    return QVariant::fromValue( datetime.toTimeZone( tz ) );
+  }
+  return QVariant();
+}
+
 static QVariant fcnTimeZoneToId( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const QTimeZone timeZone = QgsExpressionUtils::getTimeZoneValue( values.at( 0 ), parent );
@@ -1396,6 +1419,7 @@ static QVariant fcnTimeZoneToId( const QVariantList &values, const QgsExpression
   }
   return QVariant();
 }
+
 static QVariant fcnMakeInterval( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const double years = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
@@ -8687,6 +8711,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "timezone_from_id" ), { QgsExpressionFunction::Parameter( QStringLiteral( "id" ) ) }, fcnTimeZoneFromId, QStringLiteral( "Date and Time" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "timezone_id" ), { QgsExpressionFunction::Parameter( QStringLiteral( "timezone" ) ) }, fcnTimeZoneToId, QStringLiteral( "Date and Time" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "get_timezone" ), { QgsExpressionFunction::Parameter( QStringLiteral( "datetime" ) ) }, fcnGetTimeZone, QStringLiteral( "Date and Time" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "set_timezone" ), { QgsExpressionFunction::Parameter( QStringLiteral( "datetime" ) ), QgsExpressionFunction::Parameter( QStringLiteral( "timezone" ) ) }, fcnSetTimeZone, QStringLiteral( "Date and Time" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "convert_timezone" ), { QgsExpressionFunction::Parameter( QStringLiteral( "datetime" ) ), QgsExpressionFunction::Parameter( QStringLiteral( "timezone" ) ) }, fcnConvertTimeZone, QStringLiteral( "Date and Time" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "lower" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnLower, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "upper" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnUpper, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "title" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnTitle, QStringLiteral( "String" ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1359,6 +1359,34 @@ static QVariant fcnMakeDateTime( const QVariantList &values, const QgsExpression
   return QVariant( QDateTime( date, time ) );
 }
 
+static QVariant fcnTimeZoneFromId( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const QString timeZoneId = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
+
+  QTimeZone tz;
+  if ( !timeZoneId.isEmpty() )
+  {
+    tz = QTimeZone( timeZoneId.toUtf8() );
+  }
+
+  if ( !tz.isValid() )
+  {
+    parent->setEvalErrorString( QObject::tr( "'%1' is not a valid time zone ID" ).arg( timeZoneId ) );
+    return QVariant();
+  }
+  return QVariant::fromValue( tz );
+}
+
+static QVariant fcnTimeZoneToId( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const QTimeZone timeZone = QgsExpressionUtils::getTimeZoneValue( values.at( 0 ), parent );
+  if ( timeZone.isValid() )
+  {
+    return QString( timeZone.id() );
+  }
+  return QVariant();
+}
+
 static QVariant fcnMakeInterval( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   const double years = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
@@ -8647,6 +8675,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "minutes" ), true, 0 )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "seconds" ), true, 0 ),
                                             fcnMakeInterval, QStringLiteral( "Date and Time" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "timezone_from_id" ), { QgsExpressionFunction::Parameter( QStringLiteral( "id" ) ) }, fcnTimeZoneFromId, QStringLiteral( "Date and Time" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "timezone_id" ), { QgsExpressionFunction::Parameter( QStringLiteral( "timezone" ) ) }, fcnTimeZoneToId, QStringLiteral( "Date and Time" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "lower" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnLower, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "upper" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnUpper, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "title" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnTitle, QStringLiteral( "String" ) )

--- a/src/core/expression/qgsexpressionutils.cpp
+++ b/src/core/expression/qgsexpressionutils.cpp
@@ -175,6 +175,28 @@ QgsCoordinateReferenceSystem QgsExpressionUtils::getCrsValue( const QVariant &va
   return crs;
 }
 
+QTimeZone QgsExpressionUtils::getTimeZoneValue( const QVariant &value, QgsExpression *parent )
+{
+  if ( QgsVariantUtils::isNull( value ) )
+  {
+    return QTimeZone();
+  }
+
+  QTimeZone tz;
+  bool isTz = false;
+  if ( value.userType() == qMetaTypeId< QTimeZone>() )
+  {
+    isTz = true;
+    tz = value.value<QTimeZone>();
+  }
+
+  if ( !tz.isValid() )
+  {
+    parent->setEvalErrorString( isTz ? QObject::tr( "Input time zone is invalid" )
+                                : QObject::tr( "Cannot convert '%1' to a time zone" ).arg( value.toString() ) );
+  }
+  return tz;
+}
 
 void QgsExpressionUtils::executeLambdaForMapLayer( const QVariant &value, const QgsExpressionContext *context, QgsExpression *expression, const std::function<void ( QgsMapLayer * )> &function, bool &foundLayer )
 {

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -373,6 +373,13 @@ class CORE_EXPORT QgsExpressionUtils
      */
     static QgsCoordinateReferenceSystem getCrsValue( const QVariant &value, QgsExpression *parent );
 
+    /**
+     * Tries to convert a \a value to a time zone.
+     *
+     * \since QGIS 4.0
+     */
+    static QTimeZone getTimeZoneValue( const QVariant &value, QgsExpression *parent );
+
     static QgsExpressionNode *getNode( const QVariant &value, QgsExpression *parent )
     {
       if ( value.canConvert<QgsExpressionNode *>() )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -20,6 +20,7 @@
 
 
 #include <QMetaEnum>
+#include <QTimeZone>
 #include <cfloat>
 #include <memory>
 #include <cmath>
@@ -6237,6 +6238,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::VectorProviderCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapCanvasFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::LayoutRenderFlags )
 Q_DECLARE_METATYPE( Qgis::LayoutRenderFlags )
+Q_DECLARE_METATYPE( QTimeZone )
 
 // hack to workaround warnings when casting void pointers
 // retrieved from QLibrary::resolve to function pointers.

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -294,6 +294,7 @@ void registerMetaTypes()
   qRegisterMetaType< QAuthenticator * >( "QAuthenticator*" );
   qRegisterMetaType< QgsGpsInformation >( "QgsGpsInformation" );
   qRegisterMetaType< QgsSensorThingsExpansionDefinition >( "QgsSensorThingsExpansionDefinition" );
+  qRegisterMetaType< QTimeZone >( "QTimeZone" );
 };
 
 void QgsApplication::init( QString profileFolder )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2061,9 +2061,9 @@ class TestQgsExpression : public QObject
       QTest::newRow( "timezone_id valid timezone" ) << "timezone_id(timezone_from_id('Australia/Brisbane'))" << false << QVariant( QString( "Australia/Brisbane" ) );
       QTest::newRow( "timezone_id UTC+10:30" ) << "timezone_id(timezone_from_id('UTC+10:30'))" << false << QVariant( QString( "UTC+10:30" ) );
       QTest::newRow( "timezone_id UTC-3" ) << "timezone_id(timezone_from_id('UTC-3'))" << false << QVariant( QString( "UTC-03" ) );
-      QTest::newRow( "convert timezone, fixed datetime" ) << "format_date(convert_timezone(to_datetime('2012-05-04 12:50:00 UTC+03'), timezone_from_id('UTC+10')), 'yyyy-MM-dd HH:mm:ss t')" << false << QVariant( QString( "2012-05-04 19:50:00 UTC+10" ) );
-      QTest::newRow( "set timezone, fixed datetime" ) << "format_date(set_timezone(to_datetime('2012-05-04 12:50:00 UTC+03'), timezone_from_id('UTC+10')), 'yyyy-MM-dd HH:mm:ss t')" << false << QVariant( QString( "2012-05-04 12:50:00 UTC+10" ) );
-      QTest::newRow( "get timezone, fixed datetime" ) << "timezone_id(get_timezone(to_datetime('2012-05-04 12:50:00 UTC+03')))" << false << QVariant( QString( "UTC+03" ) );
+      QTest::newRow( "convert timezone, fixed datetime" ) << "format_date(convert_timezone(to_datetime('2012-05-04 12:50:00+3'), timezone_from_id('UTC+10')), 'yyyy-MM-dd HH:mm:ss t')" << false << QVariant( QString( "2012-05-04 19:50:00 UTC+10" ) );
+      QTest::newRow( "set timezone, fixed datetime" ) << "format_date(set_timezone(to_datetime('2012-05-04 12:50:00+3'), timezone_from_id('UTC+10')), 'yyyy-MM-dd HH:mm:ss t')" << false << QVariant( QString( "2012-05-04 12:50:00 UTC+10" ) );
+      QTest::newRow( "get timezone, fixed datetime" ) << "timezone_id(get_timezone(to_datetime('2012-05-04 12:50:00+3')))" << false << QVariant( QString( "UTC+03" ) );
 
 
       // Color functions

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -5368,6 +5368,29 @@ class TestQgsExpression : public QObject
       QVERIFY( !exp.hasEvalError() );
     }
 
+    void testGetTimeZoneValue()
+    {
+      QgsExpression exp;
+      QgsExpressionContext context;
+      // NULL value
+      QTimeZone tz = QgsExpressionUtils::getTimeZoneValue( QVariant(), &exp );
+      QVERIFY( !tz.isValid() );
+      QVERIFY( !exp.hasEvalError() );
+
+      // value which CANNOT be a time zone
+      tz = QgsExpressionUtils::getTimeZoneValue( QVariant::fromValue( QgsGeometry() ), &exp );
+      QVERIFY( !tz.isValid() );
+      QVERIFY( exp.hasEvalError() );
+      QCOMPARE( exp.evalErrorString(), QStringLiteral( "Cannot convert '' to a time zone" ) );
+
+      // good value
+      exp = QgsExpression();
+      tz = QgsExpressionUtils::getTimeZoneValue( QVariant::fromValue( QTimeZone( "Australia/Brisbane" ) ), &exp );
+      QVERIFY( tz.isValid() );
+      QCOMPARE( tz.id(), QStringLiteral( "Australia/Brisbane" ) );
+      QVERIFY( !exp.hasEvalError() );
+    }
+
     void test_env()
     {
       QgsExpressionContext context;

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -4850,6 +4850,20 @@ class TestQgsExpression : public QObject
       QCOMPARE( QgsExpression( "foo + bar" ).isField(), false );
     }
 
+    void testGetTimeZone()
+    {
+      QgsExpressionContext context;
+      QgsExpressionContextScope *scope = new QgsExpressionContextScope();
+      scope->setVariable( QStringLiteral( "dt_with_timezone" ), QDateTime( QDate( 2020, 1, 1 ), QTime( 1, 2, 3 ), QTimeZone( "Australia/Brisbane" ) ) );
+      context.appendScope( scope );
+
+      QCOMPARE( QgsExpression( QString( "timezone_id(get_timezone(@dt_with_timezone))" ) ).evaluate( &context ).toString(), QStringLiteral( "Australia/Brisbane" ) );
+      QCOMPARE( QgsExpression( QString( "get_timezone(NULL)" ) ).evaluate( &context ), QVariant() );
+      QgsExpression invalid( QString( "get_timezone(123)" ) );
+      QCOMPARE( invalid.evaluate( &context ), QVariant() );
+      QCOMPARE( invalid.evalErrorString(), QStringLiteral( "Cannot convert '123' to DateTime" ) );
+    }
+
     void test_expressionToLayerFieldIndex()
     {
       std::unique_ptr layer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2059,6 +2059,12 @@ class TestQgsExpression : public QObject
       QTest::newRow( "timezone_id NULL" ) << "timezone_id(NULL)" << false << QVariant();
       QTest::newRow( "timezone_id not timezone" ) << "timezone_id(123)" << true << QVariant();
       QTest::newRow( "timezone_id valid timezone" ) << "timezone_id(timezone_from_id('Australia/Brisbane'))" << false << QVariant( QString( "Australia/Brisbane" ) );
+      QTest::newRow( "timezone_id UTC+10:30" ) << "timezone_id(timezone_from_id('UTC+10:30'))" << false << QVariant( QString( "UTC+10:30" ) );
+      QTest::newRow( "timezone_id UTC-3" ) << "timezone_id(timezone_from_id('UTC-3'))" << false << QVariant( QString( "UTC-03" ) );
+      QTest::newRow( "convert timezone, fixed datetime" ) << "format_date(convert_timezone(to_datetime('2012-05-04 12:50:00 UTC+03'), timezone_from_id('UTC+10')), 'yyyy-MM-dd HH:mm:ss t')" << false << QVariant( QString( "2012-05-04 19:50:00 UTC+10" ) );
+      QTest::newRow( "set timezone, fixed datetime" ) << "format_date(set_timezone(to_datetime('2012-05-04 12:50:00 UTC+03'), timezone_from_id('UTC+10')), 'yyyy-MM-dd HH:mm:ss t')" << false << QVariant( QString( "2012-05-04 12:50:00 UTC+10" ) );
+      QTest::newRow( "get timezone, fixed datetime" ) << "timezone_id(get_timezone(to_datetime('2012-05-04 12:50:00 UTC+03')))" << false << QVariant( QString( "UTC+03" ) );
+
 
       // Color functions
       QTest::newRow( "ramp color" ) << "ramp_color('Spectral',0.3)" << false << QVariant( "253,190,116,255" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -5444,6 +5444,9 @@ class TestQgsExpression : public QObject
 
       QgsCoordinateReferenceSystem crs( "EPSG:4326" );
       QCOMPARE( QgsExpression::formatPreviewString( QVariant( crs ) ), QStringLiteral( "<i>&lt;crs: EPSG:4326 - WGS 84&gt;</i>" ) );
+
+      QTimeZone tz( "Australia/Brisbane" );
+      QCOMPARE( QgsExpression::formatPreviewString( QVariant::fromValue( tz ) ), QStringLiteral( "<i>&lt;time zone: AEST&gt;</i>" ) );
     }
 
     void test_formatPreviewStringWithLocale()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -5508,6 +5508,8 @@ class TestQgsExpression : public QObject
       QTimeZone tz( "Australia/Brisbane" );
       QString res = QgsExpression::formatPreviewString( QVariant::fromValue( tz ) );
       QVERIFY2( res == QString( "<i>&lt;time zone: AEST&gt;</i>" ) || res == QString( "<i>&lt;time zone: GMT+10&gt;</i>" ), QString( "got %1, expected <i>&lt;time zone: AEST&gt;</i> or <i>&lt;time zone: GMT+10&gt;</i>" ).arg( res ).toLocal8Bit().constData() );
+
+      QCOMPARE( QgsExpression::formatPreviewString( QVariant::fromValue( QTimeZone() ) ), QStringLiteral( "<i>&lt;time zone: invalid&gt;</i>" ) );
     }
 
     void test_formatPreviewStringWithLocale()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2052,6 +2052,14 @@ class TestQgsExpression : public QObject
       QTest::newRow( "formatted string from date with language" ) << "format_date('2019-06-29','d MMMM yyyy','fr')" << false << QVariant( QString( "29 juin 2019" ) );
       QTest::newRow( "formatted string with Z" ) << "format_date(to_datetime('2019-06-29T13:34:56+01:00'),'yyyy-MM-ddTHH:mm:ssZ')" << false << QVariant( QString( "2019-06-29T12:34:56Z" ) );
 
+      // time zone functions
+      QTest::newRow( "timezone_from_id NULL" ) << "timezone_from_id(NULL)" << false << QVariant();
+      QTest::newRow( "timezone_from_id not string" ) << "timezone_from_id(123)" << true << QVariant();
+      QTest::newRow( "timezone_from_id invalid id" ) << "timezone_from_id('xxxx')" << true << QVariant();
+      QTest::newRow( "timezone_id NULL" ) << "timezone_id(NULL)" << false << QVariant();
+      QTest::newRow( "timezone_id not timezone" ) << "timezone_id(123)" << true << QVariant();
+      QTest::newRow( "timezone_id valid timezone" ) << "timezone_id(timezone_from_id('Australia/Brisbane'))" << false << QVariant( QString( "Australia/Brisbane" ) );
+
       // Color functions
       QTest::newRow( "ramp color" ) << "ramp_color('Spectral',0.3)" << false << QVariant( "253,190,116,255" );
       QTest::newRow( "ramp color error" ) << "ramp_color('NotExistingRamp',0.3)" << true << QVariant();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -5506,7 +5506,8 @@ class TestQgsExpression : public QObject
       QCOMPARE( QgsExpression::formatPreviewString( QVariant( crs ) ), QStringLiteral( "<i>&lt;crs: EPSG:4326 - WGS 84&gt;</i>" ) );
 
       QTimeZone tz( "Australia/Brisbane" );
-      QCOMPARE( QgsExpression::formatPreviewString( QVariant::fromValue( tz ) ), QStringLiteral( "<i>&lt;time zone: AEST&gt;</i>" ) );
+      QString res = QgsExpression::formatPreviewString( QVariant::fromValue( tz ) );
+      QVERIFY2( res == QString( "<i>&lt;time zone: AEST&gt;</i>" ) || res == QString( "<i>&lt;time zone: GMT+10&gt;</i>" ), QString( "got %1, expected <i>&lt;time zone: AEST&gt;</i> or <i>&lt;time zone: GMT+10&gt;</i>" ).arg( res ).toLocal8Bit().constData() );
     }
 
     void test_formatPreviewStringWithLocale()


### PR DESCRIPTION
Adds some functions for working with timezones in expressions:

- `timezone_from_id`: Creates a timezone object from a string ID (from the IANA timezone database).
- `timezone_id`: Returns the ID string for a timezone object, using IDs from the IANA timezone database.
- `get_timezone`: Returns the timezone object associated with a datetime value.
- `convert_timezone`: Converts a datetime object to a different timezone.
- `set_timezone`: Sets the timezone object associated with a datetime value, without changing the date or time components. This function can be used to replace the timezone for a datetime.