### PR TITLE
Possibility to change the layer name in the layer panel when saving a scratch layer

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8185,11 +8185,17 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
       mLayerTreeView->refreshLayerSymbology( vl->id() );
       this->visibleMessageBar()->pushMessage( tr( "Layer Saved" ), tr( "Successfully saved scratch layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ), Qgis::MessageLevel::Success, 0 );
 
-      QMessageBox question( QMessageBox::Question, tr( "Rename Layer" ), tr( "Would you like to change layer name to `%1` in layers panel?" ).arg( newLayerName ), QMessageBox::Yes | QMessageBox::Cancel, this );
-      int res = question.exec();
-      if ( res == QMessageBox::Yes )
+      if ( ( !newLayerName.isEmpty() ) )
       {
-        vl->setName( newLayerName );
+        if ( newLayerName != vl->name() )
+        {
+          QMessageBox question( QMessageBox::Question, tr( "Rename Layer" ), tr( "Would you like to change layer name to `%1` in layers panel?" ).arg( newLayerName ), QMessageBox::Yes | QMessageBox::Cancel, this );
+          int res = question.exec();
+          if ( res == QMessageBox::Yes )
+          {
+            vl->setName( newLayerName );
+          }
+        }
       }
     }
   };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8192,6 +8192,11 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
         {
           QPushButton *button = new QPushButton( tr( "Also rename layer in layers panel" ), this );
           barItem->setWidget( button );
+
+          connect( vl, &QgsVectorLayer::willBeDeleted, this, [button]() {
+            button->setEnabled( false );
+          } );
+
           connect( button, &QPushButton::clicked, this, [button, vl, newLayerName]() {
             vl->setName( newLayerName );
             button->setEnabled( false );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8184,6 +8184,13 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
 
       mLayerTreeView->refreshLayerSymbology( vl->id() );
       this->visibleMessageBar()->pushMessage( tr( "Layer Saved" ), tr( "Successfully saved scratch layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ), Qgis::MessageLevel::Success, 0 );
+
+      QMessageBox question( QMessageBox::Question, tr( "Rename Layer" ), tr( "Would you like to change layer name to `%1` in layers panel?" ).arg( newLayerName ), QMessageBox::Yes | QMessageBox::Cancel, this );
+      int res = question.exec();
+      if ( res == QMessageBox::Yes )
+      {
+        vl->setName( newLayerName );
+      }
     }
   };
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8189,7 +8189,7 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
       {
         if ( newLayerName != vl->name() )
         {
-          QMessageBox question( QMessageBox::Question, tr( "Rename Layer" ), tr( "Would you like to change layer name to `%1` in layers panel?" ).arg( newLayerName ), QMessageBox::Yes | QMessageBox::Cancel, this );
+          QMessageBox question( QMessageBox::Question, tr( "Rename Layer" ), tr( "Would you like to change layer name to `%1` in layers panel?" ).arg( newLayerName ), QMessageBox::Yes | QMessageBox::No, this );
           int res = question.exec();
           if ( res == QMessageBox::Yes )
           {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8183,20 +8183,23 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
       vl->removeCustomProperty( QStringLiteral( "OnConvertFormatRegeneratePrimaryKey" ) );
 
       mLayerTreeView->refreshLayerSymbology( vl->id() );
-      this->visibleMessageBar()->pushMessage( tr( "Layer Saved" ), tr( "Successfully saved scratch layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ), Qgis::MessageLevel::Success, 0 );
+
+      QgsMessageBarItem *barItem = new QgsMessageBarItem( tr( "Layer Saved" ), tr( "Successfully saved scratch layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ), Qgis::MessageLevel::Success, 0 );
 
       if ( ( !newLayerName.isEmpty() ) )
       {
         if ( newLayerName != vl->name() )
         {
-          QMessageBox question( QMessageBox::Question, tr( "Rename Layer" ), tr( "Would you also like to change the layer name to `%1` in the layers panel?" ).arg( newLayerName ), QMessageBox::Yes | QMessageBox::No, this );
-          int res = question.exec();
-          if ( res == QMessageBox::Yes )
-          {
+          QPushButton *button = new QPushButton( tr( "Rename layer in layers panel" ), this );
+          barItem->setWidget( button );
+          connect( button, &QPushButton::clicked, this, [button, vl, newLayerName]() {
             vl->setName( newLayerName );
-          }
+            button->setEnabled( false );
+          } );
         }
       }
+
+      this->visibleMessageBar()->pushItem( barItem );
     }
   };
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8190,7 +8190,7 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
       {
         if ( newLayerName != vl->name() )
         {
-          QPushButton *button = new QPushButton( tr( "Rename layer in layers panel" ), this );
+          QPushButton *button = new QPushButton( tr( "Also rename layer in layers panel" ), this );
           barItem->setWidget( button );
           connect( button, &QPushButton::clicked, this, [button, vl, newLayerName]() {
             vl->setName( newLayerName );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8189,7 +8189,7 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
       {
         if ( newLayerName != vl->name() )
         {
-          QMessageBox question( QMessageBox::Question, tr( "Rename Layer" ), tr( "Would you like to change layer name to `%1` in layers panel?" ).arg( newLayerName ), QMessageBox::Yes | QMessageBox::No, this );
+          QMessageBox question( QMessageBox::Question, tr( "Rename Layer" ), tr( "Would you also like to change the layer name to `%1` in the layers panel?" ).arg( newLayerName ), QMessageBox::Yes | QMessageBox::No, this );
           int res = question.exec();
           if ( res == QMessageBox::Yes )
           {


### PR DESCRIPTION
## Description

When saving a scratch layer as a permanent layer with a new name (a different file name than the name in the layer panel), a message bar is shown. In this message bar, the user can choose to automatically change the name in the layer panel to the new layer name.

This message bar is only shown if the layer is saved with new name, and currently, this only function only works for some filetypes (it works for geopackages but not for shapefiles).

![Peek 2025-09-21 12-44](https://github.com/user-attachments/assets/ce51f8f7-91e9-4138-a636-99a8e02e87c6)

Fixes #62397

Funded by: QGIS DK user group