### PR TITLE
[vertex tool] fix slow deletion of many vertices

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -811,6 +811,22 @@ is index 0)
          object to help make the distinction?)
 %End
 
+    bool deleteVertices( const QList<int> &vertices );
+%Docstring
+Deletes the vertices at the given positions.
+
+:param vertices: list of vertex indexes to delete
+
+:return: ``True`` if all vertices were deleted, ``False`` if at least
+         one vertex does not correspond to a valid vertex on this
+         geometry (including if this geometry is a Point), or if the
+         number of remaining vertices in the linestring would be less
+         than two. It is up to the caller to distinguish between these
+         error conditions.
+
+.. versionadded:: 4.0
+%End
+
     bool toggleCircularAtVertex( int atVertex );
 %Docstring
 Converts the vertex at the given position from/to circular

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1253,6 +1253,23 @@ Deletes a vertex from a feature.
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
+    Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QList<int> &vertices );
+%Docstring
+Deletes vertices from a feature.
+
+:param featureId: ID of feature to remove vertices from
+:param vertices: list of vertex indices to delete
+
+.. note::
+
+   Calls to :py:func:`~QgsVectorLayer.deleteVertices` are only valid for layers in which edits have been enabled
+   by a call to :py:func:`~QgsVectorLayer.startEditing`. Changes made to features using this method are not committed
+   to the underlying data provider until a :py:func:`~QgsVectorLayer.commitChanges` call is made. Any uncommitted
+   changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
+
+.. versionadded:: 4.0
+%End
+
     bool deleteSelectedFeatures( int *deletedCount = 0, QgsVectorLayer::DeleteContext *context = 0 );
 %Docstring
 Deletes the selected features

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
@@ -57,6 +57,16 @@ Deletes a vertex from a feature.
 :param vertex: index of vertex to delete
 %End
 
+    Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QList<int> &vertices );
+%Docstring
+Deletes multiple vertices from a feature.
+
+:param featureId: ID of feature to remove vertices from
+:param vertices: list of vertex indices to delete
+
+.. versionadded:: 4.0
+%End
+
  Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a ring to polygon/multipolygon features

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -811,6 +811,22 @@ is index 0)
          object to help make the distinction?)
 %End
 
+    bool deleteVertices( const QList<int> &vertices );
+%Docstring
+Deletes the vertices at the given positions.
+
+:param vertices: list of vertex indexes to delete
+
+:return: ``True`` if all vertices were deleted, ``False`` if at least
+         one vertex does not correspond to a valid vertex on this
+         geometry (including if this geometry is a Point), or if the
+         number of remaining vertices in the linestring would be less
+         than two. It is up to the caller to distinguish between these
+         error conditions.
+
+.. versionadded:: 4.0
+%End
+
     bool toggleCircularAtVertex( int atVertex );
 %Docstring
 Converts the vertex at the given position from/to circular

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1253,6 +1253,23 @@ Deletes a vertex from a feature.
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
+    Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QList<int> &vertices );
+%Docstring
+Deletes vertices from a feature.
+
+:param featureId: ID of feature to remove vertices from
+:param vertices: list of vertex indices to delete
+
+.. note::
+
+   Calls to :py:func:`~QgsVectorLayer.deleteVertices` are only valid for layers in which edits have been enabled
+   by a call to :py:func:`~QgsVectorLayer.startEditing`. Changes made to features using this method are not committed
+   to the underlying data provider until a :py:func:`~QgsVectorLayer.commitChanges` call is made. Any uncommitted
+   changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
+
+.. versionadded:: 4.0
+%End
+
     bool deleteSelectedFeatures( int *deletedCount = 0, QgsVectorLayer::DeleteContext *context = 0 );
 %Docstring
 Deletes the selected features

--- a/python/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
@@ -57,6 +57,16 @@ Deletes a vertex from a feature.
 :param vertex: index of vertex to delete
 %End
 
+    Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QList<int> &vertices );
+%Docstring
+Deletes multiple vertices from a feature.
+
+:param featureId: ID of feature to remove vertices from
+:param vertices: list of vertex indices to delete
+
+.. versionadded:: 4.0
+%End
+
  Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /Deprecated="Since 3.12. Will be removed in QGIS 4.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a ring to polygon/multipolygon features

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2518,19 +2518,13 @@ void QgsVertexTool::deleteVertex()
       QgsFeatureId fid = it2.key();
       QList<int> &vertexIds = it2.value();
 
-      Qgis::VectorEditResult res = Qgis::VectorEditResult::Success;
-      std::sort( vertexIds.begin(), vertexIds.end(), std::greater<int>() );
-      for ( int vertexId : vertexIds )
+      Qgis::VectorEditResult res = layer->deleteVertices( fid, vertexIds );
+      if ( res != Qgis::VectorEditResult::Success && res != Qgis::VectorEditResult::EmptyGeometry )
       {
-        if ( res != Qgis::VectorEditResult::EmptyGeometry )
-          res = layer->deleteVertex( fid, vertexId );
-        if ( res != Qgis::VectorEditResult::EmptyGeometry && res != Qgis::VectorEditResult::Success )
-        {
-          QgsDebugError( QStringLiteral( "failed to delete vertex %1 %2 %3!" ).arg( layer->name() ).arg( fid ).arg( vertexId ) );
-          success = false;
-        }
+        QgsDebugError( QStringLiteral( "failed to delete vertices from feature %1 %2!" ).arg( layer->name() ).arg( fid ) );
+        success = false;
       }
-
+    
       if ( res == Qgis::VectorEditResult::EmptyGeometry )
       {
         emit messageEmitted( tr( "Geometry has been cleared. Use the add part tool to set geometry for this feature." ) );

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -693,20 +693,6 @@ bool QgsGeometry::deleteVertices( const QList<int> &vertices )
   QList<int> sortedVertices = vertices;
   std::sort( sortedVertices.begin(), sortedVertices.end(), std::greater<int>() );
 
-  // maintain compatibility with < 2.10 API
-  if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == Qgis::WkbType::MultiPoint )
-  {
-    detach();
-    QgsGeometryCollection *collection = static_cast< QgsGeometryCollection * >( d->geometry.get() );
-    
-    for ( int vertex : sortedVertices )
-    {
-      if ( !collection->removeGeometry( vertex ) )
-        return false;
-    }
-    return true;
-  }
-
   // If it's a point and we're deleting any vertex, set geometry to null
   if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == Qgis::WkbType::Point )
   {

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -863,6 +863,17 @@ class CORE_EXPORT QgsGeometry
     bool deleteVertex( int atVertex );
 
     /**
+     * Deletes the vertices at the given positions.
+     * \param vertices list of vertex indexes to delete
+     * \returns TRUE if all vertices were deleted, FALSE if at least one vertex
+     * does not correspond to a valid vertex on this geometry (including if this geometry is a Point),
+     * or if the number of remaining vertices in the linestring would be less than two.
+     * It is up to the caller to distinguish between these error conditions.
+     * \since QGIS 4.0
+     */
+    bool deleteVertices( const QList<int> &vertices );
+
+    /**
      * Converts the vertex at the given position from/to circular
      * \returns FALSE if atVertex does not correspond to a valid vertex
      * on this geometry (including if this geometry is a Point),

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1521,6 +1521,20 @@ Qgis::VectorEditResult QgsVectorLayer::deleteVertex( QgsFeatureId featureId, int
   return result;
 }
 
+Qgis::VectorEditResult QgsVectorLayer::deleteVertices( QgsFeatureId featureId, const QList<int> &vertices )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  if ( !isValid() || !mEditBuffer || !mDataProvider )
+    return Qgis::VectorEditResult::InvalidLayer;
+
+  QgsVectorLayerEditUtils utils( this );
+  Qgis::VectorEditResult result = utils.deleteVertices( featureId, vertices );
+
+  if ( result == Qgis::VectorEditResult::Success )
+    updateExtents();
+  return result;
+}
 
 bool QgsVectorLayer::deleteSelectedFeatures( int *deletedCount, QgsVectorLayer::DeleteContext *context )
 {

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -1276,6 +1276,18 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     Qgis::VectorEditResult deleteVertex( QgsFeatureId featureId, int vertex );
 
     /**
+     * Deletes vertices from a feature.
+     * \param featureId ID of feature to remove vertices from
+     * \param vertices list of vertex indices to delete
+     * \note Calls to deleteVertices() are only valid for layers in which edits have been enabled
+     * by a call to startEditing(). Changes made to features using this method are not committed
+     * to the underlying data provider until a commitChanges() call is made. Any uncommitted
+     * changes can be discarded by calling rollBack().
+     * \since QGIS 4.0
+     */
+    Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QList<int> &vertices );
+
+    /**
      * Deletes the selected features
      * \param deletedCount The number of successfully deleted features
      * \param context The chain of features who will be deleted for feedback and to avoid endless recursions

--- a/src/core/vector/qgsvectorlayereditutils.h
+++ b/src/core/vector/qgsvectorlayereditutils.h
@@ -71,6 +71,14 @@ class CORE_EXPORT QgsVectorLayerEditUtils
     Qgis::VectorEditResult deleteVertex( QgsFeatureId featureId, int vertex );
 
     /**
+     * Deletes multiple vertices from a feature.
+     * \param featureId ID of feature to remove vertices from
+     * \param vertices list of vertex indices to delete
+     * \since QGIS 4.0
+     */
+    Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QList<int> &vertices );
+
+    /**
      * Adds a ring to polygon/multipolygon features
      * \param ring ring to add
      * \param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -2665,17 +2665,21 @@ class TestQgsGeometry(QgisTestCase):
         # ! 5-+-+-+-4
         # |
         # 1-+-+-+-+-0
-        
+
         linestringwkt = "LineString (5 0, 0 0, 0 4, 5 4, 5 1, 1 1, 1 3, 4 3, 4 2, 2 2)"
         linestring = QgsGeometry.fromWkt(linestringwkt)
 
         # test invalid range
-        assert not linestring.deleteVertices([-5]), "Delete vertices [-5] unexpectedly succeeded"
+        assert not linestring.deleteVertices(
+            [-5]
+        ), "Delete vertices [-5] unexpectedly succeeded"
         assert not linestring.deleteVertices(
             [100]
         ), "Delete vertices 100 unexpectedly succeeded"
         # single invalid value should fail
-        assert not linestring.deleteVertices([1, 10]), "Delete vertices [1, 10] unexpectedly succeeded"
+        assert not linestring.deleteVertices(
+            [1, 10]
+        ), "Delete vertices [1, 10] unexpectedly succeeded"
 
         # test deletion of single vertex
         assert linestring.deleteVertices([3]), "Delete vertices [5 4] failed"
@@ -2686,7 +2690,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of multiple vertices
         linestring = QgsGeometry.fromWkt(linestringwkt)
 
-        assert linestring.deleteVertices([0, 1, 8, 9]), "Delete vertices 5 0, 0 0, 4 2, 2 2 failed"
+        assert linestring.deleteVertices(
+            [0, 1, 8, 9]
+        ), "Delete vertices 5 0, 0 0, 4 2, 2 2 failed"
         expwkt = "LineString (0 4, 5 4, 5 1, 1 1, 1 3, 4 3)"
         wkt = linestring.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2694,7 +2700,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of entire geometry (remove all but one in linestring)
         linestring = QgsGeometry.fromWkt(linestringwkt)
 
-        assert linestring.deleteVertices([1, 2, 3, 4, 5, 6, 7, 8, 9]), "Delete vertices [1, 2, 3, 4, 5, 7, 8, 9, 9] failed"
+        assert linestring.deleteVertices(
+            [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        ), "Delete vertices [1, 2, 3, 4, 5, 7, 8, 9, 9] failed"
         expwkt = "LineString EMPTY"
         wkt = linestring.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2702,7 +2710,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of entire geometry (list all vertices)
         linestring = QgsGeometry.fromWkt(linestringwkt)
 
-        assert linestring.deleteVertices([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), "Delete vertices [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] failed"
+        assert linestring.deleteVertices(
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        ), "Delete vertices [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] failed"
         expwkt = "LineString EMPTY"
         wkt = linestring.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2711,16 +2721,22 @@ class TestQgsGeometry(QgisTestCase):
         #   | | |   |
         # 0-1 4 5   8-9
 
-        multilinestringwkt = "MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 0), (3 0, 3 1, 5 1, 5 0, 6 0))"
+        multilinestringwkt = (
+            "MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 0), (3 0, 3 1, 5 1, 5 0, 6 0))"
+        )
         multilinestring = QgsGeometry.fromWkt(multilinestringwkt)
 
         # test invalid range
-        assert not multilinestring.deleteVertices([-5]), "Delete vertices [-5] unexpectedly succeeded"
+        assert not multilinestring.deleteVertices(
+            [-5]
+        ), "Delete vertices [-5] unexpectedly succeeded"
         assert not multilinestring.deleteVertices(
             [100]
         ), "Delete vertices 100 unexpectedly succeeded"
         # single invalid value should fail
-        assert not multilinestring.deleteVertices([1, 10]), "Delete vertices [1, 10] unexpectedly succeeded"
+        assert not multilinestring.deleteVertices(
+            [1, 10]
+        ), "Delete vertices [1, 10] unexpectedly succeeded"
 
         # test deletion of single vertex
         assert multilinestring.deleteVertices([0]), "Delete vertex [0] failed"
@@ -2731,7 +2747,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of multiple vertices
         multilinestring = QgsGeometry.fromWkt(multilinestringwkt)
 
-        assert multilinestring.deleteVertices([0, 1, 8, 9]), "Delete vertices [0, 1, 8, 9] failed"
+        assert multilinestring.deleteVertices(
+            [0, 1, 8, 9]
+        ), "Delete vertices [0, 1, 8, 9] failed"
         expwkt = "MultiLineString ((1 1, 2 1, 2 0), (3 0, 3 1, 5 1))"
         wkt = multilinestring.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2739,7 +2757,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of a part of multilinestring (list all but one)
         multilinestring = QgsGeometry.fromWkt(multilinestringwkt)
 
-        assert multilinestring.deleteVertices([6, 7, 8, 9]), "Delete vertices [6, 7, 8, 9] failed"
+        assert multilinestring.deleteVertices(
+            [6, 7, 8, 9]
+        ), "Delete vertices [6, 7, 8, 9] failed"
         expwkt = "MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 0))"
         wkt = multilinestring.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2747,7 +2767,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of a part of multilinestring (list all)
         multilinestring = QgsGeometry.fromWkt(multilinestringwkt)
 
-        assert multilinestring.deleteVertices([5, 6, 7, 8, 9]), "Delete vertices [5, 6, 7, 8, 9] failed"
+        assert multilinestring.deleteVertices(
+            [5, 6, 7, 8, 9]
+        ), "Delete vertices [5, 6, 7, 8, 9] failed"
         expwkt = "MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 0))"
         wkt = multilinestring.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2755,7 +2777,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of entire geometry (remove all but one in multilinestring)
         multilinestring = QgsGeometry.fromWkt(multilinestringwkt)
 
-        assert multilinestring.deleteVertices([1, 2, 3, 4, 5, 6, 7, 8, 9]), "Delete vertices [1, 2, 3, 4, 5, 6, 7, 8, 9] failed"
+        assert multilinestring.deleteVertices(
+            [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        ), "Delete vertices [1, 2, 3, 4, 5, 6, 7, 8, 9] failed"
         expwkt = "MultiLineString EMPTY"
         wkt = multilinestring.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2763,7 +2787,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of entire geometry (list all vertices)
         multilinestring = QgsGeometry.fromWkt(multilinestringwkt)
 
-        assert multilinestring.deleteVertices([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), "Delete vertices [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] failed"
+        assert multilinestring.deleteVertices(
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        ), "Delete vertices [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] failed"
         expwkt = "MultiLineString EMPTY"
         wkt = multilinestring.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2778,12 +2804,16 @@ class TestQgsGeometry(QgisTestCase):
         polygon = QgsGeometry.fromWkt(polygonwkt)
 
         # test invalid range
-        assert not polygon.deleteVertices([-5]), "Delete vertices -5 unexpectedly succeeded"
+        assert not polygon.deleteVertices(
+            [-5]
+        ), "Delete vertices -5 unexpectedly succeeded"
         assert not polygon.deleteVertices(
             [100]
         ), "Delete vertices 100 unexpectedly succeeded"
         # single invalid value should fail
-        assert not polygon.deleteVertices([1, 10]), "Delete vertices [1, 10] unexpectedly succeeded"
+        assert not polygon.deleteVertices(
+            [1, 10]
+        ), "Delete vertices [1, 10] unexpectedly succeeded"
 
         # test deletion of single vertex
         assert polygon.deleteVertices([0]), "Delete vertices [0] failed"
@@ -2810,7 +2840,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of entire geometry (list all but two)
         polygon = QgsGeometry.fromWkt(polygonwkt)
 
-        assert polygon.deleteVertices([2, 3, 4, 5]), "Delete vertices [2, 3, 4, 5] failed"
+        assert polygon.deleteVertices(
+            [2, 3, 4, 5]
+        ), "Delete vertices [2, 3, 4, 5] failed"
         expwkt = "Polygon EMPTY"
         wkt = polygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2818,7 +2850,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of entire geometry (list all but one)
         polygon = QgsGeometry.fromWkt(polygonwkt)
 
-        assert polygon.deleteVertices([1, 2, 3, 4, 5]), "Delete vertices [1, 2, 3, 4, 5] failed"
+        assert polygon.deleteVertices(
+            [1, 2, 3, 4, 5]
+        ), "Delete vertices [1, 2, 3, 4, 5] failed"
         expwkt = "Polygon EMPTY"
         wkt = polygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2826,7 +2860,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of entire geometry (list all)
         polygon = QgsGeometry.fromWkt(polygonwkt)
 
-        assert polygon.deleteVertices([0, 1, 2, 3, 4, 5]), "Delete vertices [0, 1, 2, 3, 4, 5] failed"
+        assert polygon.deleteVertices(
+            [0, 1, 2, 3, 4, 5]
+        ), "Delete vertices [0, 1, 2, 3, 4, 5] failed"
         expwkt = "Polygon EMPTY"
         wkt = polygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2884,7 +2920,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of multiple interior rings
         polygon = QgsGeometry.fromWkt(polygonwkt)
 
-        assert polygon.deleteVertices([5, 6, 9, 15, 16]), "Delete vertices [5, 6, 9, 15, 16] failed"
+        assert polygon.deleteVertices(
+            [5, 6, 9, 15, 16]
+        ), "Delete vertices [5, 6, 9, 15, 16] failed"
         expwkt = "Polygon ((0 0, 5 0, 5 7, 0 7, 0 0), (1 4, 4 4, 4 3, 1 3, 1 4))"
         wkt = polygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2917,11 +2955,15 @@ class TestQgsGeometry(QgisTestCase):
         wkt = multipolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 
-        # test multiple deletion 
+        # test multiple deletion
         multipolygon = QgsGeometry.fromWkt(multipolygonwkt)
 
-        assert multipolygon.deleteVertices([0, 1, 11, 12]), "Delete vertices [0, 1, 10, 11] failed"
-        expwkt = "MultiPolygon (((1 1, 2 1, 2 2, 0 2, 1 1)), ((4 0, 5 0, 5 2, 3 2, 4 0)))"
+        assert multipolygon.deleteVertices(
+            [0, 1, 11, 12]
+        ), "Delete vertices [0, 1, 10, 11] failed"
+        expwkt = (
+            "MultiPolygon (((1 1, 2 1, 2 2, 0 2, 1 1)), ((4 0, 5 0, 5 2, 3 2, 4 0)))"
+        )
         wkt = multipolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
 
@@ -2946,7 +2988,9 @@ class TestQgsGeometry(QgisTestCase):
         multipolygon = QgsGeometry.fromWkt(multipolygonwkt)
 
         # test deletion of start and endpoint of exterior and interior rings
-        assert multipolygon.deleteVertices([0, 4, 5, 9, 20, 24, 25, 29]), "Delete vertices [0, 4, 5, 9, 20, 24, 25, 29] failed"
+        assert multipolygon.deleteVertices(
+            [0, 4, 5, 9, 20, 24, 25, 29]
+        ), "Delete vertices [0, 4, 5, 9, 20, 24, 25, 29] failed"
         expwkt = "MultiPolygon (((0 7, 5 0, 5 7, 0 7), (1 5, 4 6, 4 5, 1 5), (1 4, 4 4, 4 3, 1 3, 1 4), (1 2, 4 2, 4 1, 1 1, 1 2)), ((6 7, 11 0, 11 7, 6 7), (7 5, 10 6, 10 5, 7 5), (7 4, 10 4, 10 3, 7 3, 7 4), (7 2, 10 2, 10 1, 7 1, 7 2)))"
         wkt = multipolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2954,7 +2998,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of multiple interior rings of both polygons
         multipolygon = QgsGeometry.fromWkt(multipolygonwkt)
 
-        assert multipolygon.deleteVertices([10, 13, 15, 18, 30, 33, 35, 38]), "Delete vertices [10, 13, 15, 18, 30, 33, 35, 38] failed"
+        assert multipolygon.deleteVertices(
+            [10, 13, 15, 18, 30, 33, 35, 38]
+        ), "Delete vertices [10, 13, 15, 18, 30, 33, 35, 38] failed"
         expwkt = "MultiPolygon (((0 0, 5 0, 5 7, 0 7, 0 0), (1 6, 4 6, 4 5, 1 5, 1 6)), ((6 0, 11 0, 11 7, 6 7, 6 0), (7 6, 10 6, 10 5, 7 5, 7 6)))"
         wkt = multipolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"
@@ -2962,7 +3008,9 @@ class TestQgsGeometry(QgisTestCase):
         # test deletion of entire part
         multipolygon = QgsGeometry.fromWkt(multipolygonwkt)
 
-        assert multipolygon.deleteVertices([0, 1, 5, 6, 10, 11, 17, 18]), "Delete vertices [0, 1, 5, 6, 10, 11, 17, 18] failed"
+        assert multipolygon.deleteVertices(
+            [0, 1, 5, 6, 10, 11, 17, 18]
+        ), "Delete vertices [0, 1, 5, 6, 10, 11, 17, 18] failed"
         expwkt = "MultiPolygon (((6 0, 11 0, 11 7, 6 7, 6 0), (7 6, 10 6, 10 5, 7 5, 7 6), (7 4, 10 4, 10 3, 7 3, 7 4), (7 2, 10 2, 10 1, 7 1, 7 2)))"
         wkt = multipolygon.asWkt()
         assert compareWkt(expwkt, wkt), f"Expected:\n{expwkt}\nGot:\n{wkt}\n"


### PR DESCRIPTION
refs: #58536

This PR adds a new function `deleteVertices` to avoid constant calls to `detach()` (which clones the geometry) which cooks the CPU when a large number of vertices are to be deleted. During my debugging, I didn't notice reference count to geometry being less than 2 at any time, so `detach()` is always being called.

Debug information is added to the function on fails.

In order to avoid code duplication and easier future fixes/additions, I suggest to modify `deleteVertex` to add a vertex to a list and internally call `deleteVertices`. Waiting for opinions on this.
