### PR TITLE
fix sipify_all failing on whitespace in path

### DIFF
--- a/scripts/sipify_all.sh
+++ b/scripts/sipify_all.sh
@@ -37,7 +37,7 @@ if [[ "$OSTYPE" == *bsd* ]] || [[ "$OSTYPE" =~ darwin* ]]; then
   GP=g
 fi
 
-pushd ${DIR} > /dev/null
+pushd "${DIR}" > /dev/null
 
 count=0
 


### PR DESCRIPTION
`sipify_all.sh` would fail if a path contained whitespace.