### PR TITLE
Move splitter in Execute SQL dialog to include error label 

### DIFF
--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -73,6 +73,7 @@ QgsQueryResultPanelWidget::QgsQueryResultPanelWidget( QWidget *parent, QgsAbstra
   mainLayout->setSpacing( 6 );
   progressLayout->setSpacing( 6 );
 
+  mResultsContainer->hide();
   mQueryResultsTableView->hide();
   mQueryResultsTableView->setItemDelegate( new QgsQueryResultItemDelegate( mQueryResultsTableView ) );
   mQueryResultsTableView->setContextMenuPolicy( Qt::CustomContextMenu );
@@ -233,6 +234,7 @@ void QgsQueryResultPanelWidget::executeQuery()
 {
   mQueryResultsTableView->hide();
   mSqlErrorText->hide();
+  mResultsContainer->hide();
   mFirstRowFetched = false;
 
   cancelRunningQuery();
@@ -440,6 +442,7 @@ void QgsQueryResultPanelWidget::startFetching()
           emit firstResultBatchFetched();
           mFirstRowFetched = true;
           mQueryResultsTableView->show();
+          mResultsContainer->show();
           updateButtons();
           updateSqlLayerColumns();
           mActualRowCount = mModel->queryResult().rowCount();
@@ -452,6 +455,7 @@ void QgsQueryResultPanelWidget::startFetching()
 
       mQueryResultsTableView->setModel( mModel.get() );
       mQueryResultsTableView->show();
+      mResultsContainer->show();
 
       connect( mModel.get(), &QgsQueryResultModel::fetchingComplete, mStopButton, [this] {
         bool ok = false;
@@ -483,10 +487,12 @@ void QgsQueryResultPanelWidget::showError( const QString &title, const QString &
   {
     mSqlErrorText->show();
     mSqlErrorText->setText( message );
+    mResultsContainer->show();
   }
   else
   {
     mMessageBar->pushCritical( title, message );
+    mResultsContainer->hide();
   }
 }
 

--- a/src/ui/qgsqueryresultpanelwidgetbase.ui
+++ b/src/ui/qgsqueryresultpanelwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>662</width>
-    <height>471</height>
+    <height>485</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -43,7 +43,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="mainLayout">
+    <layout class="QVBoxLayout" name="mainLayout" stretch="1,0">
      <property name="leftMargin">
       <number>6</number>
      </property>

--- a/src/ui/qgsqueryresultpanelwidgetbase.ui
+++ b/src/ui/qgsqueryresultpanelwidgetbase.ui
@@ -140,14 +140,32 @@
             </item>
            </layout>
           </widget>
-          <widget class="QTableView" name="mQueryResultsTableView"/>
+          <widget class="QWidget" name="mResultsContainer" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout_5">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QgsCodeEditorSQL" name="mSqlErrorText" native="true"/>
+            </item>
+            <item>
+             <widget class="QTableView" name="mQueryResultsTableView"/>
+            </item>
+           </layout>
+          </widget>
          </widget>
         </item>
        </layout>
       </widget>
-     </item>
-     <item>
-      <widget class="QgsCodeEditorSQL" name="mSqlErrorText" native="true"/>
      </item>
      <item>
       <widget class="QgsCollapsibleGroupBox" name="mLoadAsNewLayerGroupBox">


### PR DESCRIPTION
When there's a SQL error, the splitter was incorrectly including
the error label in the top part of the split, causing the SQL
query editor to resize to a very small vertical height

Move the splitter so that the bottom half always shows the query
result table or error text label