### PR TITLE
QgsOrientedBox3D: new constructor using rotation + longestSide()

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsorientedbox3d.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsorientedbox3d.sip.in
@@ -45,6 +45,14 @@ Constructor for a oriented box, with a specified center and half axes
 matrix.
 %End
 
+    QgsOrientedBox3D( const QgsVector3D &center, const QgsVector3D &halfSizes, const QQuaternion &quaternion );
+%Docstring
+Constructor for a oriented box, with a specified center, half sizes in
+each dimension and rotation.
+
+.. versionadded:: 4.0
+%End
+
     static QgsOrientedBox3D fromBox3D( const QgsBox3D &box );
 %Docstring
 Constructs an oriented box from an axis-aligned bounding box.
@@ -110,6 +118,13 @@ Returns an array of all corners as 3D vectors.
     QgsVector3D size() const /HoldGIL/;
 %Docstring
 Returns size of sides of the box.
+%End
+
+    double longestSide() const /HoldGIL/;
+%Docstring
+Returns size of the longest side of the box.
+
+.. versionadded:: 4.0
 %End
 
     QgsBox3D reprojectedExtent( const QgsCoordinateTransform &ct ) const  /HoldGIL/;

--- a/python/core/auto_generated/geometry/qgsorientedbox3d.sip.in
+++ b/python/core/auto_generated/geometry/qgsorientedbox3d.sip.in
@@ -45,6 +45,14 @@ Constructor for a oriented box, with a specified center and half axes
 matrix.
 %End
 
+    QgsOrientedBox3D( const QgsVector3D &center, const QgsVector3D &halfSizes, const QQuaternion &quaternion );
+%Docstring
+Constructor for a oriented box, with a specified center, half sizes in
+each dimension and rotation.
+
+.. versionadded:: 4.0
+%End
+
     static QgsOrientedBox3D fromBox3D( const QgsBox3D &box );
 %Docstring
 Constructs an oriented box from an axis-aligned bounding box.
@@ -110,6 +118,13 @@ Returns an array of all corners as 3D vectors.
     QgsVector3D size() const /HoldGIL/;
 %Docstring
 Returns size of sides of the box.
+%End
+
+    double longestSide() const /HoldGIL/;
+%Docstring
+Returns size of the longest side of the box.
+
+.. versionadded:: 4.0
 %End
 
     QgsBox3D reprojectedExtent( const QgsCoordinateTransform &ct ) const throw( QgsCsException ) /HoldGIL/;

--- a/src/core/geometry/qgsorientedbox3d.cpp
+++ b/src/core/geometry/qgsorientedbox3d.cpp
@@ -22,6 +22,8 @@
 #include "qgsmatrix4x4.h"
 #include "qgsvector3d.h"
 
+#include <QQuaternion>
+
 QgsOrientedBox3D::QgsOrientedBox3D() = default;
 
 QgsOrientedBox3D::QgsOrientedBox3D( const QList<double> &center, const QList<double> &halfAxes )
@@ -55,6 +57,26 @@ QgsOrientedBox3D::QgsOrientedBox3D( const QgsVector3D &center, const QList<QgsVe
       mHalfAxes[static_cast< int >( i * 3 + 2 )] = halfAxes.at( i ).z();
     }
   }
+}
+
+QgsOrientedBox3D::QgsOrientedBox3D( const QgsVector3D &center, const QgsVector3D &halfSizes, const QQuaternion &quaternion )
+{
+  mCenter[0] = center.x();
+  mCenter[1] = center.y();
+  mCenter[2] = center.z();
+
+  QgsVector3D v1 = QgsVector3D( quaternion.rotatedVector( QVector3D( 1, 0, 0 ) ) ) * halfSizes.x();
+  QgsVector3D v2 = QgsVector3D( quaternion.rotatedVector( QVector3D( 0, 1, 0 ) ) ) * halfSizes.y();
+  QgsVector3D v3 = QgsVector3D( quaternion.rotatedVector( QVector3D( 0, 0, 1 ) ) ) * halfSizes.z();
+  mHalfAxes[0] = v1.x();
+  mHalfAxes[1] = v1.y();
+  mHalfAxes[2] = v1.z();
+  mHalfAxes[3] = v2.x();
+  mHalfAxes[4] = v2.y();
+  mHalfAxes[5] = v2.z();
+  mHalfAxes[6] = v3.x();
+  mHalfAxes[7] = v3.y();
+  mHalfAxes[8] = v3.z();
 }
 
 QgsOrientedBox3D QgsOrientedBox3D::fromBox3D( const QgsBox3D &box )
@@ -128,6 +150,14 @@ QgsVector3D QgsOrientedBox3D::size() const
   QgsVector3D axis2( mHalfAxes[3], mHalfAxes[4], mHalfAxes[5] );
   QgsVector3D axis3( mHalfAxes[6], mHalfAxes[7], mHalfAxes[8] );
   return QgsVector3D( 2 * axis1.length(), 2 * axis2.length(), 2 * axis3.length() );
+}
+
+double QgsOrientedBox3D::longestSide() const
+{
+  QgsVector3D axis1( mHalfAxes[0], mHalfAxes[1], mHalfAxes[2] );
+  QgsVector3D axis2( mHalfAxes[3], mHalfAxes[4], mHalfAxes[5] );
+  QgsVector3D axis3( mHalfAxes[6], mHalfAxes[7], mHalfAxes[8] );
+  return 2 * std::max( std::max( axis1.length(), axis2.length() ), axis3.length() );
 }
 
 QgsBox3D QgsOrientedBox3D::reprojectedExtent( const QgsCoordinateTransform &ct ) const

--- a/src/core/geometry/qgsorientedbox3d.h
+++ b/src/core/geometry/qgsorientedbox3d.h
@@ -60,6 +60,12 @@ class CORE_EXPORT QgsOrientedBox3D
     QgsOrientedBox3D( const QgsVector3D &center, const QList< QgsVector3D > &halfAxes );
 
     /**
+     * Constructor for a oriented box, with a specified center, half sizes in each dimension and rotation.
+     * \since QGIS 4.0
+     */
+    QgsOrientedBox3D( const QgsVector3D &center, const QgsVector3D &halfSizes, const QQuaternion &quaternion );
+
+    /**
      * Constructs an oriented box from an axis-aligned bounding box.
      */
     static QgsOrientedBox3D fromBox3D( const QgsBox3D &box );
@@ -143,6 +149,12 @@ class CORE_EXPORT QgsOrientedBox3D
      * Returns size of sides of the box.
      */
     QgsVector3D size() const SIP_HOLDGIL;
+
+    /**
+     * Returns size of the longest side of the box.
+     * \since QGIS 4.0
+     */
+    double longestSide() const SIP_HOLDGIL;
 
     /**
      * Reprojects corners of this box using the given coordinate \a transform

--- a/tests/src/python/test_qgsorientedbox3d.py
+++ b/tests/src/python/test_qgsorientedbox3d.py
@@ -13,6 +13,7 @@ __date__ = "10/07/2023"
 __copyright__ = "Copyright 2023, The QGIS Project"
 
 import math
+from qgis.PyQt.QtGui import QQuaternion, QVector3D
 from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsCoordinateTransform,
@@ -97,6 +98,27 @@ class TestQgsOrientedBox3D(QgisTestCase):
                 0.7071067811865476,
             ],
         )
+
+        # constructor with rotation quaternion (45 degree y axis rotation)
+        box = QgsOrientedBox3D(
+            QgsVector3D(4, 5, 6),
+            QgsVector3D(1, 1, 1),
+            QQuaternion.fromAxisAndAngle(QVector3D(0, 1, 0), -45)
+        )
+        self.assertEqual(box.centerX(), 4)
+        self.assertEqual(box.centerY(), 5)
+        self.assertEqual(box.centerZ(), 6)
+        boxHalfAxes = box.halfAxes()
+        # "almost equal" by default rounds to 7 decimal places
+        self.assertAlmostEqual(boxHalfAxes[0], 0.7071067)
+        self.assertAlmostEqual(boxHalfAxes[1], 0.0)
+        self.assertAlmostEqual(boxHalfAxes[2], 0.7071068)
+        self.assertAlmostEqual(boxHalfAxes[3], 0.0)
+        self.assertAlmostEqual(boxHalfAxes[4], 0.9999999)
+        self.assertAlmostEqual(boxHalfAxes[5], 0.0000001)
+        self.assertAlmostEqual(boxHalfAxes[6], -0.7071068)
+        self.assertAlmostEqual(boxHalfAxes[7], 0.0)
+        self.assertAlmostEqual(boxHalfAxes[8], 0.7071068)
 
     def test_repr(self):
         box = QgsOrientedBox3D([1, 2, 3], [10, 11, 12, 21, 20, 22, 31, 32, 30])
@@ -276,6 +298,16 @@ class TestQgsOrientedBox3D(QgisTestCase):
 
         box = QgsOrientedBox3D([1, 2, 3], [10, 0, 0, 0, 20, 0, 0, 0, 30])
         self.assertEqual(box.size(), QgsVector3D(20, 40, 60))
+
+    def test_longestSide(self):
+      box = QgsOrientedBox3D([1, 2, 3], [1, 0, 0, 0, 1, 0, 0, 0, 1])
+      self.assertEqual(box.longestSide(), 2)
+
+      box = QgsOrientedBox3D([10, 10, 10], [1, 0, 0, 0, 2, 0, 0, 0, 3])
+      self.assertEqual(box.longestSide(), 6)
+
+      box = QgsOrientedBox3D([1, 2, 3], [10, 0, 0, 0, 20, 0, 0, 0, 30])
+      self.assertEqual(box.longestSide(), 60)
 
     def test_reprojectedExtent(self):
         box = QgsOrientedBox3D(


### PR DESCRIPTION
The new OBB constructor will be useful when handling I3S data, where OBB is defined by 1. center, 2. half sizes, 3. rotation quaternion:
https://github.com/Esri/i3s-spec/blob/master/docs/1.7/obb.cmn.md

As a bonus, adding longestSide() method.