### PR TITLE
Add help button to SQL Query dialogs

### DIFF
--- a/src/app/qgsappdbutils.cpp
+++ b/src/app/qgsappdbutils.cpp
@@ -41,6 +41,7 @@ QgsQueryHistoryDialog::QgsQueryHistoryDialog( QWidget *parent )
   setWindowTitle( tr( "Query History" ) );
 
   QVBoxLayout *vl = new QVBoxLayout();
+  vl->setContentsMargins( 6, 6, 6, 6 );
   mWidget = new QgsDatabaseQueryHistoryWidget();
   vl->addWidget( mWidget, 1 );
   connect( mWidget, &QgsDatabaseQueryHistoryWidget::sqlTriggered, this, &QgsQueryHistoryDialog::openQueryDialog );

--- a/src/app/qgsappdbutils.cpp
+++ b/src/app/qgsappdbutils.cpp
@@ -16,10 +16,10 @@
 #include "qgsappdbutils.h"
 #include "moc_qgsappdbutils.cpp"
 #include "qgisapp.h"
-#include "qgsgui.h"
 #include "qgsdbqueryhistoryprovider.h"
 #include "qgshistoryproviderregistry.h"
 #include "qgsgui.h"
+#include "qgshelp.h"
 #include "qgsdataitemguiproviderregistry.h"
 #include "browser/qgsinbuiltdataitemproviders.h"
 
@@ -45,7 +45,7 @@ QgsQueryHistoryDialog::QgsQueryHistoryDialog( QWidget *parent )
   vl->addWidget( mWidget, 1 );
   connect( mWidget, &QgsDatabaseQueryHistoryWidget::sqlTriggered, this, &QgsQueryHistoryDialog::openQueryDialog );
 
-  mButtonBox = new QDialogButtonBox( QDialogButtonBox::Close );
+  mButtonBox = new QDialogButtonBox( QDialogButtonBox::StandardButton::Close | QDialogButtonBox::StandardButton::Help );
 
   QPushButton *clearButton = new QPushButton( tr( "Clear" ) );
   clearButton->setToolTip( tr( "Clear history" ) );
@@ -53,7 +53,9 @@ QgsQueryHistoryDialog::QgsQueryHistoryDialog( QWidget *parent )
 
   connect( clearButton, &QPushButton::clicked, this, &QgsQueryHistoryDialog::clearHistory );
   connect( mButtonBox->button( QDialogButtonBox::Close ), &QPushButton::clicked, mWidget, [this]() { close(); } );
-
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, mWidget, [this]() {
+    QgsHelp::openHelp( QStringLiteral( "managing_data_source/create_layers.html#sql-history" ) );
+  } );
   vl->addWidget( mButtonBox );
 
   setLayout( vl );

--- a/src/app/qgsappdbutils.cpp
+++ b/src/app/qgsappdbutils.cpp
@@ -54,7 +54,7 @@ QgsQueryHistoryDialog::QgsQueryHistoryDialog( QWidget *parent )
 
   connect( clearButton, &QPushButton::clicked, this, &QgsQueryHistoryDialog::clearHistory );
   connect( mButtonBox->button( QDialogButtonBox::Close ), &QPushButton::clicked, mWidget, [this]() { close(); } );
-  connect( mButtonBox, &QDialogButtonBox::helpRequested, mWidget, [this]() {
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [] {
     QgsHelp::openHelp( QStringLiteral( "managing_data_source/create_layers.html#sql-history" ) );
   } );
   vl->addWidget( mButtonBox );

--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -1220,7 +1220,7 @@ QgsQueryResultDialog::QgsQueryResultDialog( QgsAbstractDatabaseProviderConnectio
 
   mWidget = new QgsQueryResultWidget( this, connection );
   QVBoxLayout *l = new QVBoxLayout();
-  l->setContentsMargins( 0, 0, 0, 0 );
+  l->setContentsMargins( 6, 6, 6, 6 );
 
   QDialogButtonBox *mButtonBox = new QDialogButtonBox( QDialogButtonBox::StandardButton::Close | QDialogButtonBox::StandardButton::Help );
   connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::close );
@@ -1258,6 +1258,7 @@ QgsQueryResultMainWindow::QgsQueryResultMainWindow( QgsAbstractDatabaseProviderC
 
   mWidget = new QgsQueryResultWidget( nullptr, connection );
   setCentralWidget( mWidget );
+  mWidget->layout()->setContentsMargins( 6, 6, 6, 6 );
 
   connect( mWidget, &QgsQueryResultWidget::requestDialogTitleUpdate, this, &QgsQueryResultMainWindow::updateWindowTitle );
 

--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -1224,7 +1224,7 @@ QgsQueryResultDialog::QgsQueryResultDialog( QgsAbstractDatabaseProviderConnectio
 
   QDialogButtonBox *mButtonBox = new QDialogButtonBox( QDialogButtonBox::StandardButton::Close | QDialogButtonBox::StandardButton::Help );
   connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::close );
-  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [=] {
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [] {
     QgsHelp::openHelp( QStringLiteral( "managing_data_source/create_layers.html#execute-sql" ) );
   } );
   l->addWidget( mWidget );

--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -29,6 +29,7 @@
 #include "qgsprovidermetadata.h"
 #include "qgscodeeditorwidget.h"
 #include "qgsfileutils.h"
+#include "qgshelp.h"
 #include "qgsstoredquerymanager.h"
 #include "qgsproject.h"
 #include "qgsnewnamedialog.h"
@@ -36,6 +37,7 @@
 #include "qgsdbqueryhistoryprovider.h"
 
 #include <QClipboard>
+#include <QDialogButtonBox>
 #include <QShortcut>
 #include <QFileDialog>
 #include <QMessageBox>
@@ -1219,7 +1221,15 @@ QgsQueryResultDialog::QgsQueryResultDialog( QgsAbstractDatabaseProviderConnectio
   mWidget = new QgsQueryResultWidget( this, connection );
   QVBoxLayout *l = new QVBoxLayout();
   l->setContentsMargins( 0, 0, 0, 0 );
+
+  QDialogButtonBox *mButtonBox = new QDialogButtonBox( QDialogButtonBox::StandardButton::Close | QDialogButtonBox::StandardButton::Help );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::close );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [=] {
+    QgsHelp::openHelp( QStringLiteral( "managing_data_source/create_layers.html#execute-sql" ) );
+  } );
   l->addWidget( mWidget );
+  l->addWidget( mButtonBox );
+
   setLayout( l );
 }
 

--- a/src/ui/qgsqueryresultpanelwidgetbase.ui
+++ b/src/ui/qgsqueryresultpanelwidgetbase.ui
@@ -45,16 +45,16 @@
    <item>
     <layout class="QVBoxLayout" name="mainLayout" stretch="1,0">
      <property name="leftMargin">
-      <number>6</number>
+      <number>0</number>
      </property>
      <property name="topMargin">
       <number>0</number>
      </property>
      <property name="rightMargin">
-      <number>6</number>
+      <number>0</number>
      </property>
      <property name="bottomMargin">
-      <number>6</number>
+      <number>0</number>
      </property>
      <item>
       <widget class="QWidget" name="widget" native="true">
@@ -74,10 +74,10 @@
         <item>
          <widget class="QSplitter" name="splitter">
           <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
+           <enum>QFrame::Shape::NoFrame</enum>
           </property>
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <widget class="QWidget" name="verticalLayoutWidget">
            <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -119,7 +119,7 @@
               <item>
                <spacer name="horizontalSpacer">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -246,7 +246,7 @@
           <item>
            <spacer name="horizontalSpacer_2">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -291,6 +291,17 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCheckableComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgscheckablecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsCodeEditorSQL</class>
    <extends>QWidget</extends>
    <header>qgscodeeditorsql.h</header>
@@ -301,17 +312,6 @@
    <extends>QWidget</extends>
    <header>qgsmessagebar.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCheckableComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgscheckablecombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
This PR is meant to add help button to the dialogs derived from "Execute SQL" but I can't understand how the widgets are embedded , so it only adds the help button to the "SQL History" and the "Update SQL Query" dialogs. Any help to add it to the "Execute SQL" dialog would be appreciated.

![Peek 30-07-2025 01-46](https://github.com/user-attachments/assets/6f060734-5d08-410e-8697-7d726d1c423a)
