### PR TITLE
[qt6] Avoid deadlock when reading malformed images on main thread

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -422,6 +422,7 @@ void myMessageOutput( QtMsgType type, const QMessageLogContext &, const QString 
       // Only seems to happen on windows
       if ( !msg.startsWith( QLatin1String( "QColor::setNamedColor: Unknown color name 'param" ), Qt::CaseInsensitive )
            && !msg.startsWith( QLatin1String( "Trying to create a QVariant instance of QMetaType::Void type, an invalid QVariant will be constructed instead" ), Qt::CaseInsensitive )
+           && !msg.startsWith( QLatin1String( "QBuffer::seek: Invalid pos" ), Qt::CaseInsensitive ) // raised internally by QImageReader when reading some malformed images -- this causes a deadlock if we try to show in messagebar, as showing in messagebar requires another QImageReader and is internally locked by Qt
            && !msg.startsWith( QLatin1String( "Logged warning" ), Qt::CaseInsensitive ) )
       {
         // TODO: Verify this code in action.


### PR DESCRIPTION
Don't try to show "QBuffer::seek: Invalid pos" qt warnings in message bar. These lead to a deadlock in the Qt image reader internals, as QImageReader plugins may raise the QBuffer warning when reading malformed images -- the deadlock then occurs when trying to show in message bar as that requires loading an icon, which in turns requires a QImageReader call. And these concurrent calls hang on an internal mutex in the QImageReader class.
