### PR TITLE
Also detect 'dted' phrase in raster layer names as hints that a layer represents an elevation surface (Fix #62723)

### DIFF
--- a/src/core/raster/qgsrasterlayerelevationproperties.cpp
+++ b/src/core/raster/qgsrasterlayerelevationproperties.cpp
@@ -721,6 +721,7 @@ bool QgsRasterLayerElevationProperties::layerLooksLikeDem( QgsRasterLayer *layer
       QStringLiteral( "height" ),
       QStringLiteral( "elev" ),
       QStringLiteral( "srtm" ),
+      QStringLiteral( "dted" ),
       // French hints
       QStringLiteral( "mne" ),
       QStringLiteral( "mnt" ),


### PR DESCRIPTION
Fixes #62723.