### PR TITLE
Various minor GUI improvements

### DIFF
--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -193,6 +193,7 @@ void QgsNewHttpConnection::wfsVersionCurrentIndexChanged( int index )
 {
   // For now 2019-06-06, leave paging checkable for some WFS version 1.1 servers with support
   const bool pagingOptionsEnabled = ( index == WFS_VERSION_MAX || index >= WFS_VERSION_1_1 );
+  lblFeaturePaging->setEnabled( pagingOptionsEnabled );
   cmbFeaturePaging->setEnabled( pagingOptionsEnabled );
   lblPageSize->setEnabled( pagingOptionsEnabled );
   txtPageSize->setEnabled( pagingOptionsEnabled );

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -617,7 +617,9 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>scrollArea_2</tabstop>
   <tabstop>mDatasetsListWidget</tabstop>
+  <tabstop>scrollArea</tabstop>
   <tabstop>mUseVirtualProviderCheckBox</tabstop>
   <tabstop>mOutputFormatComboBox</tabstop>
   <tabstop>mOutputGroupNameLineEdit</tabstop>
@@ -627,6 +629,7 @@
   <tabstop>mAllTimesButton</tabstop>
   <tabstop>mStartTimeComboBox</tabstop>
   <tabstop>mEndTimeComboBox</tabstop>
+  <tabstop>mAddResultToProjectCheckBox</tabstop>
   <tabstop>mPlusPushButton</tabstop>
   <tabstop>mMultiplyPushButton</tabstop>
   <tabstop>mOpenBracketPushButton</tabstop>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>880</width>
-    <height>600</height>
+    <height>857</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,7 @@
    <item>
     <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -32,9 +32,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-74</y>
-        <width>855</width>
-        <height>659</height>
+        <y>0</y>
+        <width>868</width>
+        <height>805</height>
        </rect>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout">
@@ -153,12 +153,12 @@
           <item row="9" column="0" colspan="2">
            <spacer name="verticalSpacer">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
               <width>20</width>
-              <height>40</height>
+              <height>0</height>
              </size>
             </property>
            </spacer>
@@ -295,12 +295,12 @@
             <item row="14" column="0" colspan="2">
              <spacer name="verticalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>40</height>
+                <height>0</height>
                </size>
               </property>
              </spacer>
@@ -383,7 +383,11 @@
              </widget>
             </item>
             <item row="5" column="1" colspan="2">
-             <widget class="QComboBox" name="mComboWfsFeatureMode"/>
+             <widget class="QComboBox" name="mComboWfsFeatureMode">
+              <property name="toolTip">
+               <string>Determines whether to return data as simple features or as complex features where nested data structures are exposed by QGIS as JSON</string>
+              </property>
+             </widget>
             </item>
             <item row="6" column="0" colspan="3">
              <widget class="QCheckBox" name="cbxWfsIgnoreAxisOrientation">
@@ -435,12 +439,12 @@
             <item row="10" column="0" colspan="3">
              <spacer name="verticalSpacer_3">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>40</height>
+                <height>0</height>
                </size>
               </property>
              </spacer>
@@ -490,7 +494,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -522,15 +522,10 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>cmbVersion</tabstop>
-  <tabstop>mWfsVersionDetectButton</tabstop>
-  <tabstop>mComboHttpMethod</tabstop>
-  <tabstop>txtMaxNumFeatures</tabstop>
-  <tabstop>cmbFeaturePaging</tabstop>
-  <tabstop>txtPageSize</tabstop>
-  <tabstop>mComboWfsFeatureMode</tabstop>
-  <tabstop>cbxWfsIgnoreAxisOrientation</tabstop>
-  <tabstop>cbxWfsInvertAxisOrientation</tabstop>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>txtName</tabstop>
+  <tabstop>txtUrl</tabstop>
+  <tabstop>mTestConnectionButton</tabstop>
   <tabstop>cmbDpiMode</tabstop>
   <tabstop>cmbTilePixelRatio</tabstop>
   <tabstop>sbFeatureCount</tabstop>
@@ -540,7 +535,17 @@
   <tabstop>cbxWmsIgnoreAxisOrientation</tabstop>
   <tabstop>cbxWmsInvertAxisOrientation</tabstop>
   <tabstop>cbxSmoothPixmapTransform</tabstop>
-  <tabstop>mTestConnectionButton</tabstop>
+  <tabstop>cmbVersion</tabstop>
+  <tabstop>mWfsVersionDetectButton</tabstop>
+  <tabstop>mComboHttpMethod</tabstop>
+  <tabstop>txtMaxNumFeatures</tabstop>
+  <tabstop>cmbFeaturePaging</tabstop>
+  <tabstop>txtPageSize</tabstop>
+  <tabstop>mComboWfsFeatureMode</tabstop>
+  <tabstop>cbxWfsIgnoreAxisOrientation</tabstop>
+  <tabstop>cbxWfsInvertAxisOrientation</tabstop>
+  <tabstop>cbxWfsUseGml2EncodingForTransactions</tabstop>
+  <tabstop>cbxWfsForceInitialGetFeature</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsnewmemorylayerdialogbase.ui
+++ b/src/ui/qgsnewmemorylayerdialogbase.ui
@@ -46,7 +46,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="3">
+   <item row="3" column="1" colspan="2">
     <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
      <property name="focusPolicy">
       <enum>Qt::FocusPolicy::StrongFocus</enum>

--- a/src/ui/qgsqueryresultwidgetbase.ui
+++ b/src/ui/qgsqueryresultwidgetbase.ui
@@ -155,7 +155,7 @@
      <normaloff>:/images/themes/default/console/iconClearConsole.svg</normaloff>:/images/themes/default/console/iconClearConsole.svg</iconset>
    </property>
    <property name="text">
-    <string>Clear</string>
+    <string>Clear SQL Editor</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>

--- a/src/ui/qgsvectorelevationpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorelevationpropertieswidgetbase.ui
@@ -98,7 +98,7 @@
    <item>
     <widget class="QGroupBox" name="mElevationGroupBox">
      <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
      </property>
      <property name="title">
       <string>Elevation Clamping</string>
@@ -179,7 +179,7 @@
    <item>
     <widget class="QGroupBox" name="mBindingGroupBox">
      <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
      </property>
      <property name="title">
       <string>Elevation Binding</string>
@@ -197,7 +197,7 @@
       <item row="2" column="0">
        <widget class="Line" name="line_4">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
        </widget>
       </item>
@@ -217,7 +217,7 @@
    <item>
     <widget class="QGroupBox" name="mExtrusionGroupBox">
      <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
      </property>
      <property name="title">
       <string>Enable Extrusion</string>
@@ -232,7 +232,7 @@
       <item row="3" column="0">
        <widget class="Line" name="line_5">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
        </widget>
       </item>
@@ -269,7 +269,7 @@
          <string>Extrusion controls how high features extend vertically above their base.</string>
         </property>
         <property name="textFormat">
-         <enum>Qt::PlainText</enum>
+         <enum>Qt::TextFormat::PlainText</enum>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -281,11 +281,8 @@
    </item>
    <item>
     <widget class="QGroupBox" name="mToleranceGroupBox">
-     <property name="toolTip">
-      <string>If checked, the layer will use this tolerance instead of the one defined in the Elevation Profile widget.</string>
-     </property>
      <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
      </property>
      <property name="title">
       <string>Custom Tolerance</string>
@@ -300,14 +297,24 @@
       <string notr="true">vectorgeneral</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_Tolerance">
-      <item row="0" column="0">
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_ToleranceExplanation">
+        <property name="text">
+         <string>Tolerance controls how far from the profile line a feature can reside to be included in the results. If set, this value overrides the tolerance defined in the Elevation Profile widget, for this specific layer.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
        <widget class="QLabel" name="label_Tolerance">
         <property name="text">
          <string>Tolerance</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QgsDoubleSpinBox" name="mToleranceSpinBox">
         <property name="decimals">
          <number>6</number>
@@ -317,13 +324,6 @@
         </property>
         <property name="maximum">
          <double>99999999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="Line" name="line_Tolerance">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
         </property>
        </widget>
       </item>
@@ -436,7 +436,7 @@
             <item>
              <spacer name="horizontalSpacer">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -614,7 +614,7 @@
             <item>
              <spacer name="horizontalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -643,7 +643,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/ui/qgsvectorelevationpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorelevationpropertieswidgetbase.ui
@@ -300,7 +300,7 @@
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="label_ToleranceExplanation">
         <property name="text">
-         <string>Tolerance controls how far from the profile line a feature can reside to be included in the results. If set, this value overrides the tolerance defined in the Elevation Profile widget, for this specific layer.</string>
+         <string>Tolerance controls how far from the profile line a feature can reside to be included in the results. If set, this value overrides the tolerance defined in the Elevation Profile for this specific layer.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>


### PR DESCRIPTION
This PR adds a few minor adjustments to GUIs:
* vector layer elevation properties: Add text explaining custom tolerance instead of a tooltip on the group box, matching the display in most of the groups of this tab
  <img width="736" height="259" alt="Copie d'écran_20250731_204308" src="https://github.com/user-attachments/assets/d936bd32-8d31-492c-9241-d4d9be2453d0" />

* Add a tooltip to the "feature mode" option in New WFS connection dialog (rewording welcome). Also adjust paging label not disabling when its combobox is.
  <img width="1048" height="153" alt="image" src="https://github.com/user-attachments/assets/7776c55c-83fa-41ff-86c5-99836e503d78" />
* Rename the "Clear" button in "Execute SQL Query" dialog into "Clear SQL Editor" to make it more obvious when the "SQL History" tab is active. I actually wonder if the toolbar is relevant there given that afaict, none of the tools interact with the history tab contents
  <img width="513" height="249" alt="image" src="https://github.com/user-attachments/assets/302feb3d-8cb9-408d-b405-94c3e1a7198a" />

* tab key order in mesh calc dialog