### PR TITLE
Fix pre-commit workflow on backports

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -3,6 +3,9 @@ name: Pre-commit checks
 on:
   pull_request_target:
   push:
+    branches:
+      - master
+      - release-*
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
Do not run on push on backport branches, only on master and release-*

