### PR TITLE
Avoid infinite loop if nodes is empty in pointcloud async functions

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -656,6 +656,9 @@ int QgsPointCloudLayerProfileGenerator::visitNodesSync( const QVector<QgsPointCl
 
 int QgsPointCloudLayerProfileGenerator::visitNodesAsync( const QVector<QgsPointCloudNodeId> &nodes, QgsPointCloudIndex &pc, QgsPointCloudRequest &request, const QgsDoubleRange &zRange )
 {
+  if ( nodes.isEmpty() )
+    return 0;
+
   int nodesDrawn = 0;
 
   // see notes about this logic in QgsPointCloudLayerRenderer::renderNodesAsync
@@ -701,7 +704,8 @@ int QgsPointCloudLayerProfileGenerator::visitNodesAsync( const QVector<QgsPointC
   }
 
   // Wait for all point cloud nodes to finish loading
-  loop.exec();
+  if ( !blockRequests.isEmpty() )
+    loop.exec();
 
   // Generation may have got canceled and the event loop exited before finished()
   // was called for all blocks, so let's clean up anything that is left

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -428,6 +428,9 @@ int QgsPointCloudLayerRenderer::renderNodesSync( const QVector<QgsPointCloudNode
 
 int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<QgsPointCloudNodeId> &nodes, QgsPointCloudIndex &pc, QgsPointCloudRenderContext &context, QgsPointCloudRequest &request, bool &canceled )
 {
+  if ( nodes.isEmpty() )
+    return 0;
+
   if ( context.feedback() && context.feedback()->isCanceled() )
     return 0;
 
@@ -504,7 +507,8 @@ int QgsPointCloudLayerRenderer::renderNodesAsync( const QVector<QgsPointCloudNod
   }
 
   // Wait for all point cloud nodes to finish loading
-  loop.exec();
+  if ( !blockRequests.isEmpty() )
+    loop.exec();
 
   // Rendering may have got canceled and the event loop exited before finished()
   // was called for all blocks, so let's clean up anything that is left


### PR DESCRIPTION
## Description
Fixes https://github.com/qgis/QGIS/issues/54349
Fixes https://github.com/qgis/QGIS/issues/62125

Currently, if async functions (which is triggered with distant copc PC layer) are entered but `nodes` is empty, QEventLoop is infinite as `exec()` is called but never `exit()`.

This is a bug which has been introduced in #59073 for elevation profile. For renderer it seems it has always been like this.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
