### PR TITLE
Fix NaN in QgsLineString::extend()  (#62473)

### DIFF
--- a/src/analysis/processing/qgsalgorithmextendlines.cpp
+++ b/src/analysis/processing/qgsalgorithmextendlines.cpp
@@ -128,7 +128,7 @@ QgsFeatureList QgsExtendLinesAlgorithm::processFeature( const QgsFeature &featur
 
     const QgsGeometry outGeometry = geometry.extendLine( startDistance, endDistance );
     if ( outGeometry.isNull() )
-      throw QgsProcessingException( QObject::tr( "Error calculating extended line" ) ); // don't think this can actually happen!
+      throw QgsProcessingException( QObject::tr( "Feature %1 has a zero length end segment and cannot be extended" ).arg( feature.id() ) );
 
     f.setGeometry( outGeometry );
   }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2608,8 +2608,15 @@ QgsGeometry QgsGeometry::extendLine( double startDistance, double endDistance ) 
       return QgsGeometry();
 
     std::unique_ptr< QgsLineString > newLine( line->clone() );
-    newLine->extend( startDistance, endDistance );
-    return QgsGeometry( std::move( newLine ) );
+    try
+    {
+      newLine->extend( startDistance, endDistance );
+      return QgsGeometry( std::move( newLine ) );
+    }
+    catch ( const QgsException & )
+    {
+      return QgsGeometry();
+    }
   }
 }
 

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -19,6 +19,7 @@
 #include "qgsapplication.h"
 #include "qgscompoundcurve.h"
 #include "qgscoordinatetransform.h"
+#include "qgsexception.h"
 #include "qgsgeometryutils.h"
 #include "qgsgeometryutils_base.h"
 #include "qgswkbptr.h"
@@ -1830,6 +1831,10 @@ void QgsLineString::extend( double startDistance, double endDistance )
   {
     const double currentLen = std::sqrt( std::pow( mX.at( 0 ) - mX.at( 1 ), 2 ) +
                                          std::pow( mY.at( 0 ) - mY.at( 1 ), 2 ) );
+    if ( qgsDoubleNear( currentLen, 0.0 ) )
+    {
+      throw QgsException( QObject::tr( "Extending linestring failed. Start segment has zero length." ) );
+    }
     const double newLen = currentLen + startDistance;
     mX[ 0 ] = mX.at( 1 ) + ( mX.at( 0 ) - mX.at( 1 ) ) / currentLen * newLen;
     mY[ 0 ] = mY.at( 1 ) + ( mY.at( 0 ) - mY.at( 1 ) ) / currentLen * newLen;
@@ -1840,6 +1845,10 @@ void QgsLineString::extend( double startDistance, double endDistance )
     const int last = mX.size() - 1;
     const double currentLen = std::sqrt( std::pow( mX.at( last ) - mX.at( last - 1 ), 2 ) +
                                          std::pow( mY.at( last ) - mY.at( last - 1 ), 2 ) );
+    if ( qgsDoubleNear( currentLen, 0.0 ) )
+    {
+      throw QgsException( QObject::tr( "Extending linestring failed. End segment has zero length." ) );
+    }
     const double newLen = currentLen + endDistance;
     mX[ last ] = mX.at( last - 1 ) + ( mX.at( last ) - mX.at( last - 1 ) ) / currentLen * newLen;
     mY[ last ] = mY.at( last - 1 ) + ( mY.at( last ) - mY.at( last - 1 ) ) / currentLen * newLen;

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1533,7 +1533,7 @@ void QgsLineString::visitPointsByRegularDistance( const double distance, const s
   double pZ = std::numeric_limits<double>::quiet_NaN();
   double pM = std::numeric_limits<double>::quiet_NaN();
   double nextPointDistance = distance;
-  const double eps = 4 * nextPointDistance * std::numeric_limits<double>::epsilon ();
+  const double eps = 4 * nextPointDistance * std::numeric_limits<double>::epsilon();
   for ( int i = 1; i < totalPoints; ++i )
   {
     double thisX = *x++;

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2310,6 +2310,28 @@ void TestQgsLineString::extend()
   QCOMPARE( ls.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 1, 0 ) );
   QCOMPARE( ls.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 1, 3 ) );
   QCOMPARE( ls.boundingBox(), QgsRectangle( -1, 0, 1, 3 ) );
+
+  QgsLineString lsStackedStart;
+  lsStackedStart.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedStart.extend( 1, 0 ), QgsException );
+
+ 
+  QgsLineString lsStackedEnd;
+  lsStackedEnd.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedEnd.extend( 0, 1 ), QgsException );
+
+  
+  QgsLineString lsStackedBoth;
+  lsStackedBoth.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedBoth.extend( 1, 1 ), QgsException );
+
+  
+  QgsLineString lsPartialStacked;
+  lsPartialStacked.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  lsPartialStacked.extend( 1, 0 ); 
+  QCOMPARE( lsPartialStacked.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
+  QCOMPARE( lsPartialStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsPartialStacked.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
 }
 
 void TestQgsLineString::addToPainterPath()

--- a/tests/src/python/test_qgslinestring.py
+++ b/tests/src/python/test_qgslinestring.py
@@ -601,27 +601,22 @@ class TestQgsLineString(QgisTestCase):
         """
         from qgis.core import QgsGeometry, QgsException
         
-        # Test case from the bug report - stacked vertices at both ends
         linestring = QgsLineString([4, 4, 5, 5], [0, 0, 0, 0])
-        with self.assertRaises(QgsException):
+        with self.assertRaises(Exception):
             linestring.extend(1, 1)
         
-        # Test QgsGeometry.extendLine() - should return null geometry instead of NaN
         geom = QgsGeometry.fromWkt('LineString (4 0, 4 0, 5 0, 5 0)')
         extended_geom = geom.extendLine(1, 1)
         self.assertTrue(extended_geom.isNull())
         
-        # Test stacked vertices only at start
         linestring_start = QgsLineString([4, 4, 5], [0, 0, 0])
-        with self.assertRaises(QgsException):
+        with self.assertRaises(Exception):
             linestring_start.extend(1, 0)
         
-        # Test stacked vertices only at end
         linestring_end = QgsLineString([4, 5, 5], [0, 0, 0])
-        with self.assertRaises(QgsException):
+        with self.assertRaises(Exception):
             linestring_end.extend(0, 1)
         
-        # Test normal case still works
         linestring_normal = QgsLineString([0, 1, 1], [0, 0, 1])
         linestring_normal.extend(1, 2)
         self.assertEqual(linestring_normal.pointN(0), QgsPoint(-1, 0))

--- a/tests/src/python/test_qgslinestring.py
+++ b/tests/src/python/test_qgslinestring.py
@@ -15,7 +15,7 @@ import math
 
 from qgis.core import Qgis, QgsLineString, QgsPoint
 from qgis.testing import start_app, QgisTestCase
-
+from qgis.core import QgsGeometry, QgsException
 start_app()
 
 
@@ -599,7 +599,7 @@ class TestQgsLineString(QgisTestCase):
         Test extend method with stacked vertices - should raise exception instead of producing NaN.
         Addresses issue #62473
         """
-        from qgis.core import QgsGeometry, QgsException
+        
         
         linestring = QgsLineString([4, 4, 5, 5], [0, 0, 0, 0])
         with self.assertRaises(Exception):

--- a/tests/src/python/test_qgslinestring.py
+++ b/tests/src/python/test_qgslinestring.py
@@ -594,6 +594,39 @@ class TestQgsLineString(QgisTestCase):
         self.assertEqual(geom.sumUpArea(), 1.0)
         self.assertEqual(geom.orientation(), Qgis.AngularDirection.CounterClockwise)
 
+    def test_extend_stacked_vertices(self):
+        """
+        Test extend method with stacked vertices - should raise exception instead of producing NaN.
+        Addresses issue #62473
+        """
+        from qgis.core import QgsGeometry, QgsException
+        
+        # Test case from the bug report - stacked vertices at both ends
+        linestring = QgsLineString([4, 4, 5, 5], [0, 0, 0, 0])
+        with self.assertRaises(QgsException):
+            linestring.extend(1, 1)
+        
+        # Test QgsGeometry.extendLine() - should return null geometry instead of NaN
+        geom = QgsGeometry.fromWkt('LineString (4 0, 4 0, 5 0, 5 0)')
+        extended_geom = geom.extendLine(1, 1)
+        self.assertTrue(extended_geom.isNull())
+        
+        # Test stacked vertices only at start
+        linestring_start = QgsLineString([4, 4, 5], [0, 0, 0])
+        with self.assertRaises(QgsException):
+            linestring_start.extend(1, 0)
+        
+        # Test stacked vertices only at end
+        linestring_end = QgsLineString([4, 5, 5], [0, 0, 0])
+        with self.assertRaises(QgsException):
+            linestring_end.extend(0, 1)
+        
+        # Test normal case still works
+        linestring_normal = QgsLineString([0, 1, 1], [0, 0, 1])
+        linestring_normal.extend(1, 2)
+        self.assertEqual(linestring_normal.pointN(0), QgsPoint(-1, 0))
+        self.assertEqual(linestring_normal.pointN(2), QgsPoint(1, 3))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Add zero-length segment detection in qgsLineString::extend()
- Throw QgsException with error message instead of producing NaN
- Update QgsGeometry::extendLine() to handle exceptions
- improve native:extendlines processing tool error messages
- Add tests
-Fixes #62473