### PR TITLE
[server][wms] Change order of advertised output formats in GetCapabilities -> PNG first

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -422,11 +422,11 @@ namespace QgsWms
 
     //wms:GetMap
     elem = doc.createElement( QStringLiteral( "GetMap" ) /*wms:GetMap*/ );
-    appendFormat( elem, QStringLiteral( "image/jpeg" ) );
-    appendFormat( elem, QStringLiteral( "image/png" ) );
+    appendFormat( elem, QStringLiteral( "image/png" ) ); //QGIS Desktop uses first advertised format as default, png supports transparency
     appendFormat( elem, QStringLiteral( "image/png; mode=16bit" ) );
     appendFormat( elem, QStringLiteral( "image/png; mode=8bit" ) );
     appendFormat( elem, QStringLiteral( "image/png; mode=1bit" ) );
+    appendFormat( elem, QStringLiteral( "image/jpeg" ) );
     appendFormat( elem, QStringLiteral( "application/dxf" ) );
     appendFormat( elem, QStringLiteral( "application/pdf" ) );
     elem.appendChild( dcpTypeElem.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'

--- a/tests/testdata/qgis_server/getcapabilities-map.txt
+++ b/tests/testdata/qgis_server/getcapabilities-map.txt
@@ -34,11 +34,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -34,11 +34,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -35,11 +35,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/getcapabilities_without_map_param.txt
+++ b/tests/testdata/qgis_server/getcapabilities_without_map_param.txt
@@ -34,11 +34,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -34,11 +34,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -34,11 +34,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
@@ -35,11 +35,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
@@ -34,11 +34,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
@@ -26,11 +26,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
@@ -26,11 +26,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/wms_getcapabilities_rewriting.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_rewriting.txt
@@ -34,11 +34,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/wms_getcapabilities_scale_denominator.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_scale_denominator.txt
@@ -33,11 +33,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
@@ -28,11 +28,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -35,11 +35,11 @@ Content-Type: text/xml; charset=utf-8
     </DCPType>
    </GetCapabilities>
    <GetMap>
-    <Format>image/jpeg</Format>
     <Format>image/png</Format>
     <Format>image/png; mode=16bit</Format>
     <Format>image/png; mode=8bit</Format>
     <Format>image/png; mode=1bit</Format>
+    <Format>image/jpeg</Format>
     <Format>application/dxf</Format>
     <Format>application/pdf</Format>
     <DCPType>


### PR DESCRIPTION
Until https://github.com/qgis/QGIS/pull/60221, WMS layer added via QGIS browser were using PNG as image format.

With the change in https://github.com/qgis/QGIS/pull/60221, this is no longer the case:

> 
> - when adding a WMS layer via Data Source Manager we update /qgis/lastWmsImageEncoding setting with the used image encoding
> - Browser and Data Source Manager will try to use as a default the first image encoding from the capabilities supported by the server and provider

We have received some feedback from users on our WMS provided by QGIS Server because they were confused that there is no more transparency when they add layers via the QGIS browser.

This is because the first output format advertised by QGIS Server is `JPEG`, which does not support transparency.

In addition, you must change the format to PNG each time you want transparency when adding a WMS layer from the Data Source Manager.

The [WMS spec](https://portal.ogc.org/files/?artifact_id=14416) says nothing about the order in GetCapabilities, so it is fine to put `PNG` at the top, which is also the format that should at least be offered by WMS.

From the spec "6.6 Output formats":

> A server may offer multiple map formats. The formats it offers are enumerated in <Format> elements in its service
> metadata. Use of a specific format is not required by this International Standard. However, for maps that portray
> vector features the server should offer at least one format that supports transparency in order that maps may be
> overlaid without obscuring other maps below (see the discussion about transparency in 7.3.3.9). Also, for ease of
> use, the server should offer at least one format that can be displayed by common Web browsers without
> additional software. Based on these considerations, the server should offer at least the PNG format.


