### PR TITLE
Fix OGC API Features conformance tests

### DIFF
--- a/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
@@ -101,7 +101,7 @@ Registers an OGC API ``handler``, ownership of the handler is
 transferred to the API
 %End
 
-    static QUrl sanitizeUrl( const QUrl &url );
+    static QUrl sanitizeUrl( const QString &url );
 %Docstring
 Returns a sanitized ``url`` with extra slashes removed and the path URL
 component that always starts with a slash.

--- a/python/server/auto_generated/qgsserverogcapi.sip.in
+++ b/python/server/auto_generated/qgsserverogcapi.sip.in
@@ -101,7 +101,7 @@ Registers an OGC API ``handler``, ownership of the handler is
 transferred to the API
 %End
 
-    static QUrl sanitizeUrl( const QUrl &url );
+    static QUrl sanitizeUrl( const QString &url );
 %Docstring
 Returns a sanitized ``url`` with extra slashes removed and the path URL
 component that always starts with a slash.

--- a/src/server/qgsserverogcapi.cpp
+++ b/src/server/qgsserverogcapi.cpp
@@ -61,20 +61,20 @@ void QgsServerOgcApi::registerHandler( QgsServerOgcApiHandler *handler )
   mHandlers.emplace_back( std::move( hp ) );
 }
 
-QUrl QgsServerOgcApi::sanitizeUrl( const QUrl &url )
+QUrl QgsServerOgcApi::sanitizeUrl( const QString &url )
 {
   // Since QT 5.12 NormalizePathSegments does not collapse double slashes
-  QUrl u { url.adjusted( QUrl::StripTrailingSlash | QUrl::NormalizePathSegments ) };
-  if ( u.path().contains( QLatin1String( "//" ) ) )
+  QString u = url;
+  if ( u.contains( QLatin1String( "//" ) ) )
   {
-    u.setPath( u.path().replace( QLatin1String( "//" ), QChar( '/' ) ) );
+    u = u.replace( QLatin1String( "//" ), QChar( '/' ) );
   }
   // Make sure the path starts with '/'
-  if ( !u.path().startsWith( '/' ) )
+  if ( !u.startsWith( '/' ) )
   {
-    u.setPath( u.path().prepend( '/' ) );
+    u = u.prepend( '/' );
   }
-  return u;
+  return QUrl(u).adjusted( QUrl::StripTrailingSlash | QUrl::NormalizePathSegments );
 }
 
 void QgsServerOgcApi::executeRequest( const QgsServerApiContext &context ) const

--- a/src/server/qgsserverogcapi.h
+++ b/src/server/qgsserverogcapi.h
@@ -142,7 +142,7 @@ class SERVER_EXPORT QgsServerOgcApi : public QgsServerApi
      * Returns a sanitized \a url with extra slashes removed and the path URL component that
      * always starts with a slash.
      */
-    static QUrl sanitizeUrl( const QUrl &url );
+    static QUrl sanitizeUrl( const QString &url );
 
     /**
      * Returns the string representation of \a rel attribute.

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -172,7 +172,7 @@ std::string QgsServerOgcApiHandler::href( const QgsServerApiContext &context, co
     }
     url.setPath( path + '.' + extension );
   }
-  return QgsServerOgcApi::sanitizeUrl( url ).toString( QUrl::FullyEncoded ).toStdString();
+  return QgsServerOgcApi::sanitizeUrl( url.path() ).toString( QUrl::FullyEncoded ).toStdString();
 }
 
 void QgsServerOgcApiHandler::jsonDump( json &data, const QgsServerApiContext &context, const QString &contentType ) const

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -283,7 +283,7 @@ void QgsWfs3ConformanceHandler::handleRequest( const QgsServerApiContext &contex
 json QgsWfs3ConformanceHandler::schema( const QgsServerApiContext &context ) const
 {
   json data;
-  const std::string path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "/conformance" ), context.request()->url() ).toStdString() };
+  const std::string path { QgsServerApiUtils::appendMapParameter( QStringLiteral( "/conformance" ), context.request()->url() ).toStdString() };
   data[path] = {
     { "get", { { "tags", jsonTags() }, { "summary", summary() }, { "description", description() }, { "operationId", operationId() }, { "responses", { { "200", { { "description", description() }, { "content", { { "application/json", { { "schema", { { "$ref", "#/components/schemas/root" } } } } }, { "text/html", { { "schema", { { "type", "string" } } } } } } } } }, { "default", defaultResponse() } } } }
     }


### PR DESCRIPTION
## Description

After upgrading the OGC API Features testsuite image in `pyogctest`, several tests started failing due to issues in QGIS Server. This PR addresses two problems related to the `validateConformanceOperationAndResponse` test.

#### Conformance path in openapi document

The document returned by QGIS Server at the `wfs3/api.openapi3` endpoint contains the following content:

``` json
    "/wfs3/conformance": {
      "get": {
        "description": "List all requirements classes specified in a standard (e.g., WFS 3.0 Part 1: Core) that the server conforms to.",
        "operationId": "getRequirementClasses",
        "responses": {
          "200": {
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/root"
                }
              },
```

The testsuite expects a `/conformance` endpoint instead of the `/wfs3/conformance` path. The `QgsWfs3ConformanceHandler::schema` method has been updated accordingly.

#### Conformance document URL

The testsuite attempts to retrieve the conformance classes using several paths, one of which is `/wfs3%2F%2Fconformance`. This triggers an issue in `QgsServerOgcApi::sanitizeUrl`, which incorrectly "sanitizes" `//conformance` into `/`. The method has been fixed accordingly.