### PR TITLE
[mssql] Respect custom "timeout" parameter in data source URIs

### DIFF
--- a/src/providers/mssql/qgsmssqlconnection.cpp
+++ b/src/providers/mssql/qgsmssqlconnection.cpp
@@ -107,7 +107,7 @@ bool QgsMssqlConnection::dropView( const QString &uri, QString *errorMessage )
   const QgsDataSourceUri dsUri( uri );
 
   // connect to database
-  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri );
   const QString schema = dsUri.schema();
   const QString table = dsUri.table();
 
@@ -134,7 +134,7 @@ bool QgsMssqlConnection::dropTable( const QString &uri, QString *errorMessage )
   const QgsDataSourceUri dsUri( uri );
 
   // connect to database
-  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri );
   const QString schema = dsUri.schema();
   const QString table = dsUri.table();
 
@@ -165,7 +165,7 @@ bool QgsMssqlConnection::truncateTable( const QString &uri, QString *errorMessag
   const QgsDataSourceUri dsUri( uri );
 
   // connect to database
-  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri );
   const QString schema = dsUri.schema();
   const QString table = dsUri.table();
 
@@ -194,7 +194,7 @@ bool QgsMssqlConnection::createSchema( const QString &uri, const QString &schema
   const QgsDataSourceUri dsUri( uri );
 
   // connect to database
-  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri );
 
   if ( !db->isValid() )
   {
@@ -221,7 +221,7 @@ QStringList QgsMssqlConnection::schemas( const QString &uri, QString *errorMessa
   const QgsDataSourceUri dsUri( uri );
 
   // connect to database
-  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri );
 
   return schemas( std::move( db ), errorMessage );
 }

--- a/src/providers/mssql/qgsmssqldatabase.cpp
+++ b/src/providers/mssql/qgsmssqldatabase.cpp
@@ -69,17 +69,6 @@ std::shared_ptr<QgsMssqlDatabase> QgsMssqlDatabase::connectDb( const QString &ur
   return connectDb( dsUri, transaction );
 }
 
-std::shared_ptr<QgsMssqlDatabase> QgsMssqlDatabase::connectDb( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction )
-{
-  QgsDataSourceUri uri;
-  uri.setService( service );
-  uri.setHost( host );
-  uri.setDatabase( database );
-  uri.setUsername( username );
-  uri.setPassword( password );
-  return connectDb( uri, transaction );
-}
-
 std::shared_ptr<QgsMssqlDatabase> QgsMssqlDatabase::connectDb( const QgsDataSourceUri &uri, bool transaction )
 {
   // try to use existing conn or create a new one

--- a/src/providers/mssql/qgsmssqldatabase.h
+++ b/src/providers/mssql/qgsmssqldatabase.h
@@ -63,7 +63,6 @@ class QgsMssqlDatabase
      * \note The function is thread-safe
      */
     static std::shared_ptr<QgsMssqlDatabase> connectDb( const QString &uri, bool transaction = false );
-    static std::shared_ptr<QgsMssqlDatabase> connectDb( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction = false );
     static std::shared_ptr<QgsMssqlDatabase> connectDb( const QgsDataSourceUri &uri, bool transaction = false );
 
     /////

--- a/src/providers/mssql/qgsmssqldatabase.h
+++ b/src/providers/mssql/qgsmssqldatabase.h
@@ -124,7 +124,7 @@ class QgsMssqlDatabase
      * The database may not be open -- openDatabase() should be called to
      * ensure that it is ready for use.
      */
-    static QSqlDatabase getDatabase( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction = false );
+    static QSqlDatabase getDatabase( const QString &service, const QString &host, const QString &database, const QString &username, const QString &password, bool transaction = false, int timeout = 0 );
 
     static QMap<QString, std::weak_ptr<QgsMssqlDatabase>> sConnections;
 

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -133,7 +133,13 @@ QVector<QgsDataItem *> QgsMssqlConnectionItem::createChildren()
 
   readConnectionSettings();
 
-  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( mService, mHost, mDatabase, mUsername, mPassword );
+  QgsDataSourceUri uri;
+  uri.setService( mService );
+  uri.setHost( mHost );
+  uri.setDatabase( mDatabase );
+  uri.setUsername( mUsername );
+  uri.setPassword( mPassword );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( uri );
 
   if ( !db->isValid() )
   {

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -454,7 +454,7 @@ bool QgsMssqlFeatureIterator::fetchFeature( QgsFeature &feature )
     {
       // No existing connection, so set it up now. It's safe to do here as we're now in
       // the thread were iteration is actually occurring.
-      mDatabase = QgsMssqlDatabase::connectDb( mSource->mService, mSource->mHost, mSource->mDatabaseName, mSource->mUserName, mSource->mPassword );
+      mDatabase = QgsMssqlDatabase::connectDb( mSource->mUri );
     }
 
     if ( !mDatabase->isValid() )
@@ -710,11 +710,7 @@ QgsMssqlFeatureSource::QgsMssqlFeatureSource( const QgsMssqlProvider *p )
   , mSchemaName( p->mSchemaName )
   , mTableName( p->mTableName )
   , mQuery( p->mQuery )
-  , mUserName( p->mUserName )
-  , mPassword( p->mPassword )
-  , mService( p->mService )
-  , mDatabaseName( p->mDatabaseName )
-  , mHost( p->mHost )
+  , mUri( p->mUri )
   , mSqlWhereClause( p->mSqlWhereClause )
   , mDisableInvalidGeometryHandling( p->mDisableInvalidGeometryHandling )
   , mCrs( p->crs() )

--- a/src/providers/mssql/qgsmssqlfeatureiterator.h
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.h
@@ -59,13 +59,7 @@ class QgsMssqlFeatureSource final : public QgsAbstractFeatureSource
     QString mQuery;
 
     // login
-    QString mUserName;
-    QString mPassword;
-
-    // server access
-    QString mService;
-    QString mDatabaseName;
-    QString mHost;
+    QgsDataSourceUri mUri;
 
     // SQL statement used to limit the features retrieved
     QString mSqlWhereClause;

--- a/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
+++ b/src/providers/mssql/qgsmssqlgeomcolumntypethread.cpp
@@ -48,7 +48,14 @@ void QgsMssqlGeomColumnTypeThread::run()
 {
   mStopped = false;
 
-  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( mService, mHost, mDatabase, mUsername, mPassword );
+  QgsDataSourceUri uri;
+  uri.setService( mService );
+  uri.setHost( mHost );
+  uri.setDatabase( mDatabase );
+  uri.setUsername( mUsername );
+  uri.setPassword( mPassword );
+
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( uri );
   if ( !db->isValid() )
   {
     QgsDebugError( db->errorText() );

--- a/src/providers/mssql/qgsmssqlnewconnection.cpp
+++ b/src/providers/mssql/qgsmssqlnewconnection.cpp
@@ -293,7 +293,13 @@ std::shared_ptr<QgsMssqlDatabase> QgsMssqlNewConnection::getDatabase( const QStr
     database = item->text();
   }
 
-  return QgsMssqlDatabase::connectDb( txtService->text().trimmed(), txtHost->text().trimmed(), database, txtUsername->text().trimmed(), txtPassword->text().trimmed() );
+  QgsDataSourceUri uri;
+  uri.setService( txtService->text().trimmed() );
+  uri.setHost( txtHost->text().trimmed() );
+  uri.setDatabase( database );
+  uri.setUsername( txtUsername->text().trimmed() );
+  uri.setPassword( txtPassword->text().trimmed() );
+  return QgsMssqlDatabase::connectDb( uri );
 }
 
 

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -213,18 +213,11 @@ class QgsMssqlProvider final : public QgsVectorDataProvider
 
     mutable Qgis::WkbType mWkbType = Qgis::WkbType::Unknown;
 
+    QgsDataSourceUri mUri;
+
     // current layer name
     QString mSchemaName;
     QString mTableName;
-
-    // login
-    QString mUserName;
-    QString mPassword;
-
-    // server access
-    QString mService;
-    QString mDatabaseName;
-    QString mHost;
 
     // available tables
     QStringList mTables;

--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -256,7 +256,7 @@ QgsAbstractDatabaseProviderConnection::QueryResult QgsMssqlProviderConnection::e
   const QgsDataSourceUri dsUri { uri() };
 
   // connect to database
-  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri.service(), dsUri.host(), dsUri.database(), dsUri.username(), dsUri.password() );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( dsUri );
 
   if ( !db->isValid() )
   {

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -404,7 +404,14 @@ void QgsMssqlSourceSelect::btnConnect_clicked()
     mConnInfo += " service='" + service + '\'';
 
   QgsDebugMsgLevel( QStringLiteral( "GetDatabase" ), 2 );
-  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( service, host, database, username, password );
+
+  QgsDataSourceUri uri;
+  uri.setService( service );
+  uri.setHost( host );
+  uri.setDatabase( database );
+  uri.setUsername( username );
+  uri.setPassword( password );
+  std::shared_ptr<QgsMssqlDatabase> db = QgsMssqlDatabase::connectDb( uri );
 
   if ( !db->isValid() )
   {


### PR DESCRIPTION
When constructing a URI for a SQL server connection, you can now set a custom timeout for the connection using:

    ds = QgsDataSourceUri()
    # set host, etc
    ...
    # set connection timeout to 20 seconds
    ds.setParam('timeout', '20')
    
    vl = QgsVectorLayer(ds.uri(), 'my layer', 'mssql')


This is API only, not exposed through the UI

Sponsored by North Road, thanks to SLYR