### PR TITLE
Bug snapping crash

### DIFF
--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -1160,11 +1160,14 @@ bool QgsPointLocator::rebuildIndex( int maxFeaturesToIndex )
   }
 
   QgsPointLocator_Stream stream( dataList );
-  try {
+  try
+  {
     mRTree.reset( RTree::createAndBulkLoadNewRTree( RTree::BLM_STR, stream, *mStorage, fillFactor, indexCapacity,
-                leafCapacity, dimension, variant, indexId ) );
-  } catch (const std::exception& e) {
-    QgsDebugError(QStringLiteral("An exception has occurred during the creation of RTree: %1").arg(e.what()));
+                  leafCapacity, dimension, variant, indexId ) );
+  }
+  catch ( const std::exception &e )
+  {
+    QgsDebugError( QStringLiteral( "An exception has occurred during the creation of RTree: %1" ).arg( e.what() ) );
     destroyIndex();
     return false;
   }

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -1160,8 +1160,15 @@ bool QgsPointLocator::rebuildIndex( int maxFeaturesToIndex )
   }
 
   QgsPointLocator_Stream stream( dataList );
-  mRTree.reset( RTree::createAndBulkLoadNewRTree( RTree::BLM_STR, stream, *mStorage, fillFactor, indexCapacity,
+  try {
+    mRTree.reset( RTree::createAndBulkLoadNewRTree( RTree::BLM_STR, stream, *mStorage, fillFactor, indexCapacity,
                 leafCapacity, dimension, variant, indexId ) );
+  } catch (const std::exception& e) {
+    QgsDebugError(QStringLiteral("An exception has occurred during the creation of RTree: %1").arg(e.what()));
+    destroyIndex();
+    return false;
+  }
+
 
   if ( ctx && mRenderer )
   {


### PR DESCRIPTION
## Description

There's a bug in 3.40 which causes QGIS to crash. When we were using one of our QGIS projects in my company one of the testers has come across the SIGABORT crash. It happens when trying to add a new feature with snapping enabled. The directory in which the project resided in was owned by root and had 755 permissions if I recall correctly. QGIS was run by a regular user and while one of the layers was being indexed an exception was thrown by one of the worker threads and QGIS crashed without any warning. 

# Probable reason for crash
I've investigated a little bit and found out the exception was thrown in the spatialindex library implementation of createAndBulkLoadNewRTree(). It appears that somewhere in the code the library tried to create a temporary file in the working directory which was impossible due to permissions.

# Solution
My solution to this problem was to wrap createAndBulkLoadNewRTree() function call in a try..catch block and handle the exception. Since I'm new to QGIS please feel encouraged to check my fix if it is semantically correct. I'm not sure if ending the indexing process at that moment causes problems later.

