### PR TITLE
Show distance:elevation scale ratio in profile settings menu

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgselevationprofilecanvas.py
+++ b/python/PyQt6/gui/auto_additions/qgselevationprofilecanvas.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/gui/elevation/qgselevationprofilecanvas.h
 try:
-    QgsElevationProfileCanvas.__attribute_docs__ = {'activeJobCountChanged': 'Emitted when the number of active background jobs changes.\n', 'canvasPointHovered': 'Emitted when the mouse hovers over the specified point (in canvas\ncoordinates).\n\nThe ``profilePoint`` argument gives the hovered profile point, which may\nbe snapped.\n'}
+    QgsElevationProfileCanvas.__attribute_docs__ = {'activeJobCountChanged': 'Emitted when the number of active background jobs changes.\n', 'canvasPointHovered': 'Emitted when the mouse hovers over the specified point (in canvas\ncoordinates).\n\nThe ``profilePoint`` argument gives the hovered profile point, which may\nbe snapped.\n', 'scaleChanged': 'Emitted when the plot scale is changed.\n\n.. versionadded:: 4.0\n'}
     QgsElevationProfileCanvas.__overridden_methods__ = ['crs', 'toMapCoordinates', 'toCanvasCoordinates', 'resizeEvent', 'paintEvent', 'panContentsBy', 'centerPlotOn', 'scalePlot', 'snapToPlot', 'zoomToRect', 'wheelZoom', 'mouseMoveEvent', 'refresh']
     QgsElevationProfileCanvas.__signal_arguments__ = {'activeJobCountChanged': ['count: int'], 'canvasPointHovered': ['point: QgsPointXY', 'profilePoint: QgsProfilePoint']}
     QgsElevationProfileCanvas.__group__ = ['elevation']

--- a/python/PyQt6/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
+++ b/python/PyQt6/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
@@ -330,6 +330,13 @@ The ``profilePoint`` argument gives the hovered profile point, which may
 be snapped.
 %End
 
+    void scaleChanged();
+%Docstring
+Emitted when the plot scale is changed.
+
+.. versionadded:: 4.0
+%End
+
   public slots:
 
     void zoomFull();

--- a/python/PyQt6/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
+++ b/python/PyQt6/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
@@ -237,6 +237,35 @@ Sets whether the distance and elevation scales are locked to each other.
 .. versionadded:: 3.32
 %End
 
+    double axisScaleRatio() const;
+%Docstring
+Returns the current ratio of horizontal (distance) to vertical
+(elevation) scale for the plot.
+
+.. seealso:: :py:func:`setAxisScaleRatio`
+
+.. versionadded:: 4.0
+%End
+
+    void setAxisScaleRatio( double scale );
+%Docstring
+Sets the ratio of horizontal (distance) to vertical (elevation) scale
+for the plot.
+
+E.g. a ``scale`` of 3 indicates a ratio of 3:1 for distance vs
+elevation, whereas a scale of 0.3333 indicates a ratio of 1:3 for
+distance vs elevation.
+
+This will immediately update the visible plot area to match the
+specified scale.
+
+.. seealso:: :py:func:`axisScaleRatio`
+
+.. seealso:: :py:func:`setLockAxisScales`
+
+.. versionadded:: 4.0
+%End
+
     Qgis::DistanceUnit distanceUnit() const;
 %Docstring
 Returns the distance unit used by the canvas.

--- a/python/gui/auto_additions/qgselevationprofilecanvas.py
+++ b/python/gui/auto_additions/qgselevationprofilecanvas.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/gui/elevation/qgselevationprofilecanvas.h
 try:
-    QgsElevationProfileCanvas.__attribute_docs__ = {'activeJobCountChanged': 'Emitted when the number of active background jobs changes.\n', 'canvasPointHovered': 'Emitted when the mouse hovers over the specified point (in canvas\ncoordinates).\n\nThe ``profilePoint`` argument gives the hovered profile point, which may\nbe snapped.\n'}
+    QgsElevationProfileCanvas.__attribute_docs__ = {'activeJobCountChanged': 'Emitted when the number of active background jobs changes.\n', 'canvasPointHovered': 'Emitted when the mouse hovers over the specified point (in canvas\ncoordinates).\n\nThe ``profilePoint`` argument gives the hovered profile point, which may\nbe snapped.\n', 'scaleChanged': 'Emitted when the plot scale is changed.\n\n.. versionadded:: 4.0\n'}
     QgsElevationProfileCanvas.__overridden_methods__ = ['crs', 'toMapCoordinates', 'toCanvasCoordinates', 'resizeEvent', 'paintEvent', 'panContentsBy', 'centerPlotOn', 'scalePlot', 'snapToPlot', 'zoomToRect', 'wheelZoom', 'mouseMoveEvent', 'refresh']
     QgsElevationProfileCanvas.__signal_arguments__ = {'activeJobCountChanged': ['count: int'], 'canvasPointHovered': ['point: QgsPointXY', 'profilePoint: QgsProfilePoint']}
     QgsElevationProfileCanvas.__group__ = ['elevation']

--- a/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
+++ b/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
@@ -330,6 +330,13 @@ The ``profilePoint`` argument gives the hovered profile point, which may
 be snapped.
 %End
 
+    void scaleChanged();
+%Docstring
+Emitted when the plot scale is changed.
+
+.. versionadded:: 4.0
+%End
+
   public slots:
 
     void zoomFull();

--- a/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
+++ b/python/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
@@ -237,6 +237,35 @@ Sets whether the distance and elevation scales are locked to each other.
 .. versionadded:: 3.32
 %End
 
+    double axisScaleRatio() const;
+%Docstring
+Returns the current ratio of horizontal (distance) to vertical
+(elevation) scale for the plot.
+
+.. seealso:: :py:func:`setAxisScaleRatio`
+
+.. versionadded:: 4.0
+%End
+
+    void setAxisScaleRatio( double scale );
+%Docstring
+Sets the ratio of horizontal (distance) to vertical (elevation) scale
+for the plot.
+
+E.g. a ``scale`` of 3 indicates a ratio of 3:1 for distance vs
+elevation, whereas a scale of 0.3333 indicates a ratio of 1:3 for
+distance vs elevation.
+
+This will immediately update the visible plot area to match the
+specified scale.
+
+.. seealso:: :py:func:`axisScaleRatio`
+
+.. seealso:: :py:func:`setLockAxisScales`
+
+.. versionadded:: 4.0
+%End
+
     Qgis::DistanceUnit distanceUnit() const;
 %Docstring
 Returns the distance unit used by the canvas.

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -78,6 +78,7 @@ const QgsSettingsEntryBool *QgsElevationProfileWidget::settingLockAxis = new Qgs
 const QgsSettingsEntryString *QgsElevationProfileWidget::settingLastExportDir = new QgsSettingsEntryString( QStringLiteral( "last-export-dir" ), QgsSettingsTree::sTreeElevationProfile, QString(), QStringLiteral( "Last elevation profile export directory" ) );
 const QgsSettingsEntryColor *QgsElevationProfileWidget::settingBackgroundColor = new QgsSettingsEntryColor( QStringLiteral( "background-color" ), QgsSettingsTree::sTreeElevationProfile, QColor(), QStringLiteral( "Elevation profile chart background color" ) );
 const QgsSettingsEntryBool *QgsElevationProfileWidget::settingShowSubsections = new QgsSettingsEntryBool( QStringLiteral( "show-sub-sections" ), QgsSettingsTree::sTreeElevationProfile, false, QStringLiteral( "Whether to display subsections" ) );
+const QgsSettingsEntryBool *QgsElevationProfileWidget::settingShowScaleRatioInToolbar = new QgsSettingsEntryBool( QStringLiteral( "show-scale-ratio-in-toolbar" ), QgsSettingsTree::sTreeElevationProfile, false, QStringLiteral( "If true, the scale ratio widget will be moved to the toolbar instead of the options menu" ) );
 //
 // QgsElevationProfileLayersDialog
 //
@@ -356,7 +357,11 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
 
   mScaleRatioSettingsAction = new QgsElevationProfileScaleRatioWidgetSettingsAction( mOptionsMenu );
 
-  mOptionsMenu->addAction( mScaleRatioSettingsAction );
+  if ( !settingShowScaleRatioInToolbar->value() )
+  {
+    mScaleRatioSettingsAction->setDefaultWidget( mScaleRatioSettingsAction->newWidget() );
+    mOptionsMenu->addAction( mScaleRatioSettingsAction );
+  }
 
   mOptionsMenu->addSeparator();
 
@@ -489,6 +494,11 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
   connect( mDockableWidgetHelper, &QgsDockableWidgetHelper::closed, this, [this]() {
     close();
   } );
+
+  if ( settingShowScaleRatioInToolbar->value() )
+  {
+    toolBar->addWidget( mScaleRatioSettingsAction->newWidget() );
+  }
 
   // updating the profile plot is deferred on a timer, so that we don't trigger it too often
   mSetCurveTimer = new QTimer( this );
@@ -1187,6 +1197,10 @@ QgsElevationProfileToleranceWidgetSettingsAction::QgsElevationProfileToleranceWi
 QgsElevationProfileScaleRatioWidgetSettingsAction::QgsElevationProfileScaleRatioWidgetSettingsAction( QWidget *parent )
   : QWidgetAction( parent )
 {
+}
+
+QWidget *QgsElevationProfileScaleRatioWidgetSettingsAction::newWidget()
+{
   QGridLayout *gLayout = new QGridLayout();
   gLayout->setContentsMargins( 3, 2, 3, 2 );
 
@@ -1204,7 +1218,7 @@ QgsElevationProfileScaleRatioWidgetSettingsAction::QgsElevationProfileScaleRatio
   w->setLayout( gLayout );
 
   w->setToolTip( tr( "Specifies the ratio of distance to elevation units used for the profile's scale" ) );
-  setDefaultWidget( w );
+  return w;
 }
 
 QgsAppElevationProfileLayerTreeView::QgsAppElevationProfileLayerTreeView( QgsLayerTree *rootNode, QWidget *parent )

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -367,6 +367,19 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
 
   mOptionsMenu->addAction( mScaleRatioSettingsAction );
 
+  mOptionsMenu->addSeparator();
+
+  mToleranceSettingsAction = new QgsElevationProfileToleranceWidgetSettingsAction( mOptionsMenu );
+
+  mToleranceSettingsAction->toleranceSpinBox()->setValue( settingTolerance->value() );
+  connect( mToleranceSettingsAction->toleranceSpinBox(), qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( double value ) {
+    settingTolerance->setValue( value );
+    createOrUpdateRubberBands();
+    scheduleUpdate();
+  } );
+
+  mOptionsMenu->addAction( mToleranceSettingsAction );
+
   mDistanceUnitMenu = new QMenu( tr( "Distance Units" ), this );
   QActionGroup *unitGroup = new QActionGroup( this );
   for ( Qgis::DistanceUnit unit :
@@ -413,20 +426,6 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
   } );
 
   mOptionsMenu->addMenu( mDistanceUnitMenu );
-  mOptionsMenu->addSeparator();
-
-  mToleranceSettingsAction = new QgsElevationProfileToleranceWidgetSettingsAction( mOptionsMenu );
-
-  mToleranceSettingsAction->toleranceSpinBox()->setValue( settingTolerance->value() );
-  connect( mToleranceSettingsAction->toleranceSpinBox(), qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( double value ) {
-    settingTolerance->setValue( value );
-    createOrUpdateRubberBands();
-    scheduleUpdate();
-  } );
-
-  mOptionsMenu->addAction( mToleranceSettingsAction );
-
-  mOptionsMenu->addSeparator();
 
   // show Subsections Indicator Action
   // create a default simple symbology

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -402,16 +402,16 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
   mOptionsMenu->addMenu( mDistanceUnitMenu );
   mOptionsMenu->addSeparator();
 
-  mSettingsAction = new QgsElevationProfileWidgetSettingsAction( mOptionsMenu );
+  mToleranceSettingsAction = new QgsElevationProfileToleranceWidgetSettingsAction( mOptionsMenu );
 
-  mSettingsAction->toleranceSpinBox()->setValue( settingTolerance->value() );
-  connect( mSettingsAction->toleranceSpinBox(), qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( double value ) {
+  mToleranceSettingsAction->toleranceSpinBox()->setValue( settingTolerance->value() );
+  connect( mToleranceSettingsAction->toleranceSpinBox(), qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( double value ) {
     settingTolerance->setValue( value );
     createOrUpdateRubberBands();
     scheduleUpdate();
   } );
 
-  mOptionsMenu->addAction( mSettingsAction );
+  mOptionsMenu->addAction( mToleranceSettingsAction );
 
   mOptionsMenu->addSeparator();
 
@@ -711,7 +711,7 @@ void QgsElevationProfileWidget::onCanvasPointHovered( const QgsPointXY &, const 
 
 void QgsElevationProfileWidget::updatePlot()
 {
-  mCanvas->setTolerance( mSettingsAction->toleranceSpinBox()->value() );
+  mCanvas->setTolerance( mToleranceSettingsAction->toleranceSpinBox()->value() );
   mCanvas->setCrs( QgsProject::instance()->crs3D() );
   showSubsectionsTriggered();
 
@@ -905,7 +905,7 @@ void QgsElevationProfileWidget::exportResults( Qgis::ProfileExportType type )
 
   QgsProfileRequest request( profileCurve.release() );
   request.setCrs( QgsProject::instance()->crs3D() );
-  request.setTolerance( mSettingsAction->toleranceSpinBox()->value() );
+  request.setTolerance( mToleranceSettingsAction->toleranceSpinBox()->value() );
   request.setTransformContext( QgsProject::instance()->transformContext() );
   request.setTerrainProvider( QgsProject::instance()->elevationProperties()->terrainProvider() ? QgsProject::instance()->elevationProperties()->terrainProvider()->clone() : nullptr );
   QgsExpressionContext context;
@@ -972,7 +972,7 @@ void QgsElevationProfileWidget::nudgeCurve( Qgis::BufferSide side )
   // for now we match the nudge distance to the tolerance distance, so that nudging results in
   // a completely different set of point features in the curve. We may want to revisit and expose
   // this as a user configurable setting at some point...
-  const double distance = mSettingsAction->toleranceSpinBox()->value() * 2;
+  const double distance = mToleranceSettingsAction->toleranceSpinBox()->value() * 2;
 
   const QgsGeometry nudgedCurve = mProfileCurve.offsetCurve( side == Qgis::BufferSide::Left ? distance : -distance, 8, Qgis::JoinStyle::Miter, 2 );
   setProfileCurve( nudgedCurve, false );
@@ -1075,7 +1075,7 @@ void QgsElevationProfileWidget::createOrUpdateRubberBands()
 
   mRubberBand->setToGeometry( mProfileCurve );
 
-  const double tolerance = mSettingsAction->toleranceSpinBox()->value();
+  const double tolerance = mToleranceSettingsAction->toleranceSpinBox()->value();
   if ( !qgsDoubleNear( tolerance, 0, 0.000001 ) )
   {
     if ( !mToleranceRubberBand )
@@ -1131,7 +1131,11 @@ void QgsElevationProfileWidget::onProjectElevationPropertiesChanged()
   }
 }
 
-QgsElevationProfileWidgetSettingsAction::QgsElevationProfileWidgetSettingsAction( QWidget *parent )
+//
+// QgsElevationProfileToleranceWidgetSettingsAction
+//
+
+QgsElevationProfileToleranceWidgetSettingsAction::QgsElevationProfileToleranceWidgetSettingsAction( QWidget *parent )
   : QWidgetAction( parent )
 {
   QGridLayout *gLayout = new QGridLayout();

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -1201,6 +1201,8 @@ QgsElevationProfileScaleRatioWidgetSettingsAction::QgsElevationProfileScaleRatio
 
   QWidget *w = new QWidget();
   w->setLayout( gLayout );
+
+  w->setToolTip( tr( "Specifies the ratio of distance to elevation units used for the profile's scale" ) );
   setDefaultWidget( w );
 }
 

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -43,6 +43,7 @@ class QgsPlotToolZoom;
 class QgsPlotToolXAxisZoom;
 class QgsDoubleSpinBox;
 class QgsElevationProfileToleranceWidgetSettingsAction;
+class QgsElevationProfileScaleRatioWidgetSettingsAction;
 class QgsLayerTree;
 class QgsLayerTreeRegistryBridge;
 class QgsElevationProfileToolIdentify;
@@ -55,6 +56,7 @@ class QgsSettingsEntryString;
 class QgsSettingsEntryColor;
 class QgsMapLayerProxyModel;
 class QgsLineSymbol;
+class QgsScaleComboBox;
 
 class QgsAppElevationProfileLayerTreeView : public QgsElevationProfileLayerTreeView
 {
@@ -182,6 +184,8 @@ class QgsElevationProfileWidget : public QWidget
     QgsElevationProfileToolIdentify *mIdentifyTool = nullptr;
 
     QgsElevationProfileToleranceWidgetSettingsAction *mToleranceSettingsAction = nullptr;
+    int mBlockScaleRatioChanges = 0;
+    QgsElevationProfileScaleRatioWidgetSettingsAction *mScaleRatioSettingsAction = nullptr;
 
     std::unique_ptr<QgsLayerTree> mLayerTree;
     QgsLayerTreeRegistryBridge *mLayerTreeBridge = nullptr;
@@ -203,5 +207,19 @@ class QgsElevationProfileToleranceWidgetSettingsAction : public QWidgetAction
   private:
     QgsDoubleSpinBox *mToleranceWidget = nullptr;
 };
+
+class QgsElevationProfileScaleRatioWidgetSettingsAction : public QWidgetAction
+{
+    Q_OBJECT
+
+  public:
+    QgsElevationProfileScaleRatioWidgetSettingsAction( QWidget *parent = nullptr );
+
+    QgsScaleComboBox *scaleRatioWidget() { return mScaleRatioWidget; }
+
+  private:
+    QgsScaleComboBox *mScaleRatioWidget = nullptr;
+};
+
 
 #endif // QGSELEVATIONPROFILEWIDGET_H

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -42,7 +42,7 @@ class QgsPlotToolPan;
 class QgsPlotToolZoom;
 class QgsPlotToolXAxisZoom;
 class QgsDoubleSpinBox;
-class QgsElevationProfileWidgetSettingsAction;
+class QgsElevationProfileToleranceWidgetSettingsAction;
 class QgsLayerTree;
 class QgsLayerTreeRegistryBridge;
 class QgsElevationProfileToolIdentify;
@@ -181,7 +181,7 @@ class QgsElevationProfileWidget : public QWidget
     QgsPlotToolZoom *mZoomTool = nullptr;
     QgsElevationProfileToolIdentify *mIdentifyTool = nullptr;
 
-    QgsElevationProfileWidgetSettingsAction *mSettingsAction = nullptr;
+    QgsElevationProfileToleranceWidgetSettingsAction *mToleranceSettingsAction = nullptr;
 
     std::unique_ptr<QgsLayerTree> mLayerTree;
     QgsLayerTreeRegistryBridge *mLayerTreeBridge = nullptr;
@@ -191,12 +191,12 @@ class QgsElevationProfileWidget : public QWidget
 };
 
 
-class QgsElevationProfileWidgetSettingsAction : public QWidgetAction
+class QgsElevationProfileToleranceWidgetSettingsAction : public QWidgetAction
 {
     Q_OBJECT
 
   public:
-    QgsElevationProfileWidgetSettingsAction( QWidget *parent = nullptr );
+    QgsElevationProfileToleranceWidgetSettingsAction( QWidget *parent = nullptr );
 
     QgsDoubleSpinBox *toleranceSpinBox() { return mToleranceWidget; }
 

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -97,6 +97,7 @@ class QgsElevationProfileWidget : public QWidget
     static const QgsSettingsEntryString *settingLastExportDir;
     static const QgsSettingsEntryColor *settingBackgroundColor;
     static const QgsSettingsEntryBool *settingShowSubsections;
+    static const QgsSettingsEntryBool *settingShowScaleRatioInToolbar;
 
     QgsElevationProfileWidget( const QString &name );
     ~QgsElevationProfileWidget();
@@ -214,6 +215,7 @@ class QgsElevationProfileScaleRatioWidgetSettingsAction : public QWidgetAction
 
   public:
     QgsElevationProfileScaleRatioWidgetSettingsAction( QWidget *parent = nullptr );
+    QWidget *newWidget();
 
     QgsScaleComboBox *scaleRatioWidget() { return mScaleRatioWidget; }
 

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -639,6 +639,7 @@ void QgsElevationProfileCanvas::setDistanceUnit( Qgis::DistanceUnit unit )
   mPlotItem->setXMinimum( oldMin / mPlotItem->mXScaleFactor );
   mPlotItem->setXMaximum( oldMax / mPlotItem->mXScaleFactor );
   mPlotItem->updatePlot();
+  emit scaleChanged();
 }
 
 void QgsElevationProfileCanvas::setBackgroundColor( const QColor &color )
@@ -700,6 +701,7 @@ void QgsElevationProfileCanvas::setLockAxisScales( bool lock )
     refineResults();
     mPlotItem->updatePlot();
     emit plotAreaChanged();
+    emit scaleChanged();
   }
 }
 
@@ -727,6 +729,7 @@ void QgsElevationProfileCanvas::setAxisScaleRatio( double scale )
   refineResults();
   mPlotItem->updatePlot();
   emit plotAreaChanged();
+  emit scaleChanged();
 }
 
 QgsPointXY QgsElevationProfileCanvas::snapToPlot( QPoint point )
@@ -774,6 +777,7 @@ void QgsElevationProfileCanvas::scalePlot( double xFactor, double yFactor )
   refineResults();
   mPlotItem->updatePlot();
   emit plotAreaChanged();
+  emit scaleChanged();
 }
 
 void QgsElevationProfileCanvas::zoomToRect( const QRectF &rect )
@@ -798,6 +802,7 @@ void QgsElevationProfileCanvas::zoomToRect( const QRectF &rect )
   refineResults();
   mPlotItem->updatePlot();
   emit plotAreaChanged();
+  emit scaleChanged();
 }
 
 void QgsElevationProfileCanvas::wheelZoom( QWheelEvent *event )
@@ -854,6 +859,7 @@ void QgsElevationProfileCanvas::wheelZoom( QWheelEvent *event )
     scalePlot( 1 / zoomFactor );
   }
   emit plotAreaChanged();
+  emit scaleChanged();
 }
 
 void QgsElevationProfileCanvas::mouseMoveEvent( QMouseEvent *e )
@@ -1226,6 +1232,8 @@ void QgsElevationProfileCanvas::resizeEvent( QResizeEvent *event )
 
   mPlotItem->updateRect();
   mCrossHairsItem->updateRect();
+
+  emit scaleChanged();
 }
 
 void QgsElevationProfileCanvas::paintEvent( QPaintEvent *event )
@@ -1344,6 +1352,7 @@ void QgsElevationProfileCanvas::zoomFull()
   refineResults();
   mPlotItem->updatePlot();
   emit plotAreaChanged();
+  emit scaleChanged();
 }
 
 void QgsElevationProfileCanvas::setVisiblePlotRange( double minimumDistance, double maximumDistance, double minimumElevation, double maximumElevation )
@@ -1360,6 +1369,7 @@ void QgsElevationProfileCanvas::setVisiblePlotRange( double minimumDistance, dou
   refineResults();
   mPlotItem->updatePlot();
   emit plotAreaChanged();
+  emit scaleChanged();
 }
 
 QgsDoubleRange QgsElevationProfileCanvas::visibleDistanceRange() const

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -240,6 +240,29 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     void setLockAxisScales( bool lock );
 
     /**
+     * Returns the current ratio of horizontal (distance) to vertical (elevation) scale
+     * for the plot.
+     *
+     * \see setAxisScaleRatio()
+     * \since QGIS 4.0
+     */
+    double axisScaleRatio() const;
+
+    /**
+     * Sets the ratio of horizontal (distance) to vertical (elevation) scale for the plot.
+     *
+     * E.g. a \a scale of 3 indicates a ratio of 3:1 for distance vs elevation, whereas a scale
+     * of 0.3333 indicates a ratio of 1:3 for distance vs elevation.
+     *
+     * This will immediately update the visible plot area to match the specified scale.
+     *
+     * \see axisScaleRatio()
+     * \see setLockAxisScales()
+     * \since QGIS 4.0
+     */
+    void setAxisScaleRatio( double scale );
+
+    /**
      * Returns the distance unit used by the canvas.
      *
      * \see setDistanceUnit()
@@ -340,6 +363,7 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     QgsScreenHelper *mScreenHelper = nullptr;
 
     bool mLockAxisScales = false;
+    double mLockedAxisScale = 1;
 
     QgsCoordinateReferenceSystem mCrs;
     QgsProject *mProject = nullptr;

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -322,6 +322,13 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
      */
     void canvasPointHovered( const QgsPointXY &point, const QgsProfilePoint &profilePoint );
 
+    /**
+     * Emitted when the plot scale is changed.
+     *
+     * \since QGIS 4.0
+     */
+    void scaleChanged();
+
   public slots:
 
     /**

--- a/tests/src/python/test_qgselevationprofilecanvas.py
+++ b/tests/src/python/test_qgselevationprofilecanvas.py
@@ -256,24 +256,24 @@ class TestQgsElevationProfileCanvas(QgisTestCase):
 
         canvas.setAxisScaleRatio(0.5)
         self.assertAlmostEqual(canvas.axisScaleRatio(), 0.5, 1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, 1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, 1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 50.0, 1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 150.0, 1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, delta=1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, delta=1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 50.0, delta=1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 150.0, delta=1)
 
         canvas.setAxisScaleRatio(1.0)
         self.assertAlmostEqual(canvas.axisScaleRatio(), 1.0, 1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, 1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, 1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 75.0, 1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 125.0, 1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, delta=1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, delta=1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 75.0, delta=1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 125.0, delta=1)
 
         canvas.setAxisScaleRatio(2.0)
         self.assertAlmostEqual(canvas.axisScaleRatio(), 2.0, 1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, 1)
-        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, 1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 87.5, 1)
-        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 112.5, 1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, delta=1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, delta=1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 87.5, delta=1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 112.5, delta=1)
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgselevationprofilecanvas.py
+++ b/tests/src/python/test_qgselevationprofilecanvas.py
@@ -225,6 +225,56 @@ class TestQgsElevationProfileCanvas(QgisTestCase):
         canvas.wheelEvent(wheel_event)
         self.assertEqual(tool.events[-1].type(), QEvent.Type.Wheel)
 
+    def test_ratio(self):
+        """
+        Test axis scale ratio logic
+        """
+        canvas = QgsElevationProfileCanvas()
+        canvas.setCrs(QgsCoordinateReferenceSystem("EPSG:4326"))
+        canvas.setFrameStyle(0)
+        # make a 2:1 canvas, to make the maths easier!
+        canvas.resize(800, 400)
+        canvas.setProject(QgsProject.instance())
+        canvas.show()
+        self.assertEqual(canvas.width(), 800)
+        self.assertEqual(canvas.height(), 400)
+
+        canvas.setVisiblePlotRange(100, 200, 50, 150)
+        # showing 100m distance, 100m elevation
+        # distance:elevation ratio is 1:2, as canvas is twice as wide as high
+        self.assertAlmostEqual(canvas.axisScaleRatio(), 0.5, 1)
+
+        canvas.setVisiblePlotRange(100, 300, 50, 150)
+        # showing 200m distance, 100m elevation
+        # distance:elevation ratio is 1:1, as canvas is twice as wide as high
+        self.assertAlmostEqual(canvas.axisScaleRatio(), 1.0, 1)
+
+        canvas.setVisiblePlotRange(100, 500, 50, 150)
+        # showing 400m distance, 100m elevation
+        # distance:elevation ratio is 2:1, as canvas is twice as wide as high
+        self.assertAlmostEqual(canvas.axisScaleRatio(), 2.0, delta=0.1)
+
+        canvas.setAxisScaleRatio(0.5)
+        self.assertAlmostEqual(canvas.axisScaleRatio(), 0.5, 1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, 1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, 1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 50.0, 1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 150.0, 1)
+
+        canvas.setAxisScaleRatio(1.0)
+        self.assertAlmostEqual(canvas.axisScaleRatio(), 1.0, 1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, 1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, 1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 75.0, 1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 125.0, 1)
+
+        canvas.setAxisScaleRatio(2.0)
+        self.assertAlmostEqual(canvas.axisScaleRatio(), 2.0, 1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().lower(), 248.024, 1)
+        self.assertAlmostEqual(canvas.visibleDistanceRange().upper(), 351.976, 1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().lower(), 87.5, 1)
+        self.assertAlmostEqual(canvas.visibleElevationRange().upper(), 112.5, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds a new widget for display of the current distance:elevation scale ratio for elevation profile plots. The widget can also be
used to set a specific ratio. If the "lock" option is enabled for the plot, then this scale ratio will be used instead of the default 1:1 ratio when zooming and navigating the plot.

Sponsored by Erftverband

![Peek 2025-08-07 12-22](https://github.com/user-attachments/assets/d2bae491-51fa-44ef-8744-4878cd386642)
