### PR TITLE
Allow to activate in a row an algorithm and its parents within a model

### DIFF
--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -174,11 +174,15 @@ algorithms which depend on the child algorithm will also be deactivated.
 .. seealso:: :py:func:`activateChildAlgorithm`
 %End
 
-    bool activateChildAlgorithm( const QString &id );
+    bool activateChildAlgorithm( const QString &id, bool recursive = false );
 %Docstring
-Attempts to activate the child algorithm with matching ``id``. If any
-child algorithms on which the child depends are not active, then the
-child will not be activated and ``False`` will be returned.
+Attempts to activate the child algorithm with matching ``id`` and
+returns ``True`` if all the child algorithms on which it depends are
+also active.
+
+If any child algorithms on which the child depends are not active, and
+``recursive`` is set to ``False`` then the child will not be activated
+and ``False`` will be returned.
 
 .. seealso:: :py:func:`deactivateChildAlgorithm`
 %End

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -174,11 +174,15 @@ algorithms which depend on the child algorithm will also be deactivated.
 .. seealso:: :py:func:`activateChildAlgorithm`
 %End
 
-    bool activateChildAlgorithm( const QString &id );
+    bool activateChildAlgorithm( const QString &id, bool recursive = false );
 %Docstring
-Attempts to activate the child algorithm with matching ``id``. If any
-child algorithms on which the child depends are not active, then the
-child will not be activated and ``False`` will be returned.
+Attempts to activate the child algorithm with matching ``id`` and
+returns ``True`` if all the child algorithms on which it depends are
+also active.
+
+If any child algorithms on which the child depends are not active, and
+``recursive`` is set to ``False`` then the child will not be activated
+and ``False`` will be returned.
 
 .. seealso:: :py:func:`deactivateChildAlgorithm`
 %End

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -1973,13 +1973,17 @@ void QgsProcessingModelAlgorithm::deactivateChildAlgorithm( const QString &id )
   updateDestinationParameters();
 }
 
-bool QgsProcessingModelAlgorithm::activateChildAlgorithm( const QString &id )
+bool QgsProcessingModelAlgorithm::activateChildAlgorithm( const QString &id, bool recursive )
 {
   const auto constDependsOnChildAlgorithms = dependsOnChildAlgorithms( id );
   for ( const QString &child : constDependsOnChildAlgorithms )
   {
-    if ( !childAlgorithm( child ).isActive() )
-      return false;
+    if ( !recursive )
+    {
+      if ( !childAlgorithm( child ).isActive() )
+        return false;
+    }
+    activateChildAlgorithm( child, true );
   }
   childAlgorithm( id ).setActive( true );
   updateDestinationParameters();

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -150,12 +150,15 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     void deactivateChildAlgorithm( const QString &id );
 
     /**
-     * Attempts to activate the child algorithm with matching \a id.
+     * Attempts to activate the child algorithm with matching \a id
+     * and returns TRUE if all the child algorithms on which it depends are also active.
+     *
      * If any child algorithms on which the child depends are not active,
-     * then the child will not be activated and FALSE will be returned.
+     * and \a recursive is set to FALSE then the child will not be activated
+     * and FALSE will be returned.
      * \see deactivateChildAlgorithm()
      */
-    bool activateChildAlgorithm( const QString &id );
+    bool activateChildAlgorithm( const QString &id, bool recursive = false );
 
     /**
      * Returns a list of the child algorithm IDs depending on the child

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -1219,12 +1219,17 @@ void QgsModelChildAlgorithmGraphicItem::activateAlgorithm()
     }
     else
     {
-      QMessageBox::warning( nullptr, QObject::tr( "Could not activate algorithm" ), QObject::tr( "The selected algorithm depends on other currently non-active algorithms.\n"
-                                                                                                 "Activate them them before trying to activate it.." ) );
+      int res = QMessageBox::warning( nullptr, QObject::tr( "Could not activate algorithm" ), QObject::tr( "The selected algorithm depends on other currently non-active algorithms.\n"
+                                                                                                 "These need to be activated before you can activate this algorithm.\n"
+                                                                                                 "Do you want to activate them also?" ),
+                                                                                                 QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        if ( res != QMessageBox::Yes )
+          return;
+        // Reactivate also the algorithms the child algorithm depends on
+        model()->activateChildAlgorithm( child->childId(), true );     
     }
   }
 }
-
 
 QgsModelOutputGraphicItem::QgsModelOutputGraphicItem( QgsProcessingModelOutput *output, QgsProcessingModelAlgorithm *model, QGraphicsItem *parent )
   : QgsModelComponentGraphicItem( output, model, parent )

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -1213,21 +1213,18 @@ void QgsModelChildAlgorithmGraphicItem::activateAlgorithm()
 {
   if ( const QgsProcessingModelChildAlgorithm *child = dynamic_cast<const QgsProcessingModelChildAlgorithm *>( component() ) )
   {
-    if ( model()->activateChildAlgorithm( child->childId() ) )
-    {
-      emit requestModelRepaint();
-    }
-    else
+    if ( !model()->activateChildAlgorithm( child->childId() ) )
     {
       int res = QMessageBox::warning( nullptr, QObject::tr( "Could not activate algorithm" ), QObject::tr( "The selected algorithm depends on other currently non-active algorithms.\n"
                                                                                                  "These need to be activated before you can activate this algorithm.\n"
                                                                                                  "Do you want to activate them also?" ),
                                                                                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
-        if ( res != QMessageBox::Yes )
-          return;
-        // Reactivate also the algorithms the child algorithm depends on
-        model()->activateChildAlgorithm( child->childId(), true );     
+      if ( res != QMessageBox::Yes )
+        return;
+      // Reactivate also the algorithms the child algorithm depends on
+      model()->activateChildAlgorithm( child->childId(), true );
     }
+    emit requestModelRepaint();
   }
 }
 


### PR DESCRIPTION
Fixes #45686
When in a model, you have many algorithms deactivated and you want to reactivate one, you need to make sure you activated also the ones it depends one. Doable one by one, from the eldest to the youngest. This PR proposes to allow doing it in a row (all and only its parents are turned on).
Issue: As you can see below, I think I'm missing a signal to get the algorithms displayed as active in the GUI. You need to click "activate" twice to get it done. Any guidance would be appreciated.

![Peek 07-08-2025 07-46](https://github.com/user-attachments/assets/50ddfbb7-2063-4ec2-861a-159e54e525e3)
