### PR TITLE
Reassign correct name to the item selector button in layout vs modeler dialogs

### DIFF
--- a/src/ui/layout/qgslayoutdesignerbase.ui
+++ b/src/ui/layout/qgslayoutdesignerbase.ui
@@ -452,10 +452,10 @@
      <normaloff>:/images/themes/default/mActionSelect.svg</normaloff>:/images/themes/default/mActionSelect.svg</iconset>
    </property>
    <property name="text">
-    <string>Select/Move/Link Item</string>
+    <string>Select/Move Item</string>
    </property>
    <property name="toolTip">
-    <string>Select/Move/Link item</string>
+    <string>Select/Move item</string>
    </property>
    <property name="shortcut">
     <string>V</string>

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -741,10 +741,10 @@
      <normaloff>:/images/themes/default/mActionSelect.svg</normaloff>:/images/themes/default/mActionSelect.svg</iconset>
    </property>
    <property name="text">
-    <string>Select/Move Item</string>
+    <string>Select/Move/Link Item</string>
    </property>
    <property name="toolTip">
-    <string>Select/Move item</string>
+    <string>Select/Move/link item</string>
    </property>
    <property name="shortcut">
     <string>V</string>


### PR DESCRIPTION
Issue introduced at https://github.com/qgis/QGIS/pull/60664/files#diff-54a5087d004255bc283f56b50933c4028c15237bae6bd5972f4ab44b22c8e59d