### PR TITLE
qgsplotcanvas: Fix mousePressEvent when no tool is set

### DIFF
--- a/src/gui/plot/qgsplotcanvas.cpp
+++ b/src/gui/plot/qgsplotcanvas.cpp
@@ -166,7 +166,7 @@ void QgsPlotCanvas::mousePressEvent( QMouseEvent *event )
       setTool( mMidMouseButtonPanTool );
       event->accept();
     }
-    else if ( event->button() == Qt::RightButton && mTool->flags() & Qgis::PlotToolFlag::ShowContextMenu )
+    else if ( event->button() == Qt::RightButton && mTool && mTool->flags() & Qgis::PlotToolFlag::ShowContextMenu )
     {
       auto me = std::make_unique<QgsPlotMouseEvent>( this, event );
       showContextMenu( me.get() );


### PR DESCRIPTION
## Description

In that case, `mTool->flags()` cannot be checked. Fix the issue by also checking that `mTool` is set.

Closes: https://github.com/qgis/QGIS/issues/62800


