### PR TITLE
Provide `__class__.__name__` as translation context instead of hardcoded class name

### DIFF
--- a/python/plugins/grassprovider/grass_algorithm.py
+++ b/python/plugins/grassprovider/grass_algorithm.py
@@ -221,10 +221,8 @@ class GrassAlgorithm(QgsProcessingAlgorithm):
             | QgsProcessingAlgorithm.Flag.FlagDisplayNameIsLiteral
         )
 
-    def tr(self, string, context=""):
-        if context == "":
-            context = self.__class__.__name__
-        return QCoreApplication.translate(context, string)
+    def tr(self, string: str):
+        return QCoreApplication.translate(self.__class__.__name__, string)
 
     def helpUrl(self):
         helpPath = GrassUtils.grassHelpPath()
@@ -287,10 +285,8 @@ class GrassAlgorithm(QgsProcessingAlgorithm):
                 parameter = getParameterFromString(param_string, "GrassAlgorithm")
             except Exception as e:
                 QgsMessageLog.logMessage(
-                    QCoreApplication.translate(
-                        "GrassAlgorithm", "Could not open GRASS GIS algorithm: {0}"
-                    ).format(self._name),
-                    QCoreApplication.translate("GrassAlgorithm", "Processing"),
+                    self.tr("Could not open GRASS GIS algorithm: {0}").format(self._name),
+                    self.tr("Processing"),
                     Qgis.MessageLevel.Critical,
                 )
                 raise e

--- a/python/plugins/grassprovider/grass_provider.py
+++ b/python/plugins/grassprovider/grass_provider.py
@@ -222,7 +222,5 @@ class GrassProvider(QgsProcessingProvider):
     def canBeActivated(self):
         return not bool(GrassUtils.checkGrassIsInstalled())
 
-    def tr(self, string, context=""):
-        if context == "":
-            context = "Grass7AlgorithmProvider"
-        return QCoreApplication.translate(context, string)
+    def tr(self, string: str):
+        return QCoreApplication.translate(self.__class__.__name__, string)

--- a/python/plugins/grassprovider/grass_utils.py
+++ b/python/plugins/grassprovider/grass_utils.py
@@ -628,11 +628,9 @@ class GrassUtils:
                     "Please install it or configure your PATH environment variable."
                 )
 
-    @staticmethod
-    def tr(string, context=""):
-        if context == "":
-            context = "Grass7Utils"
-        return QCoreApplication.translate(context, string)
+    @classmethod
+    def tr(cls, string: str):
+        return QCoreApplication.translate(cls.__name__, string)
 
     @staticmethod
     def writeCommand(output, command):


### PR DESCRIPTION
It bugged me that https://github.com/qgis/QGIS/pull/59194 didn't work properly until I figured out that context was wrong after grass version number was removed from class names