### PR TITLE
Indicate correct field name for setting geometry type when connecting PostgreSQL data

### DIFF
--- a/src/providers/postgres/qgspgtablemodel.cpp
+++ b/src/providers/postgres/qgspgtablemodel.cpp
@@ -101,7 +101,7 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty &layerProper
     {
       if ( wkbType == Qgis::WkbType::Unknown )
       {
-        tip = tr( "Specify a geometry type in the '%1' column" ).arg( tr( "Data Type" ) );
+        tip = tr( "Specify a geometry type in the '%1' column" ).arg( tr( "Spatial Type" ) );
       }
       else if ( wkbType != Qgis::WkbType::NoGeometry && srid == std::numeric_limits<int>::min() )
       {
@@ -395,7 +395,7 @@ bool QgsPgTableModel::setData( const QModelIndex &idx, const QVariant &value, in
     QString tip;
     if ( wkbType == Qgis::WkbType::Unknown )
     {
-      tip = tr( "Specify a geometry type in the '%1' column" ).arg( tr( "Data Type" ) );
+      tip = tr( "Specify a geometry type in the '%1' column" ).arg( tr( "Spatial Type" ) );
     }
     else if ( wkbType != Qgis::WkbType::NoGeometry )
     {


### PR DESCRIPTION
When connected to PG in the Data Source Manager dialog, and you have layers whose geometry type is undefined, the warning on the left suggests to adjust it in the "Data type" column while this one is read-only and the drop-down is in the  "Spatial type" column.

Sorry, fix untested (but looked trivial); I noticed the bug by chance yesterday and won't have a PG enabled machine for weeks.