### PR TITLE
QgsRectangle: introduce isValid

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -324,9 +324,22 @@ Test if the rectangle is null (holding no spatial information).
 
 A rectangle is considered null if all its coordinates are NaN, if it has
 not been defined yet, or if it has been explicitly initialized as null.
-A null rectangle is also an empty rectangle.
+A null rectangle is also an empty rectangle and an invalid rectangle.
 
 .. seealso:: :py:func:`setNull`
+%End
+
+    bool isValid() const;
+%Docstring
+Test if the rectangle is valid
+
+A rectangle is considered invalid if at least one of its coordinates is
+NaN or infinite, or if a maximum coordinate is less than or equal to the
+corresponding minimum coordinate.
+
+.. seealso:: :py:func:`isNull`
+
+.. versionadded:: 4.0
 %End
 
     bool isMaximal() const;

--- a/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -322,6 +322,8 @@ segment).
 %Docstring
 Test if the rectangle is null (holding no spatial information).
 
+A rectangle is considered null if all its coordinates are NaN, if it has
+not been defined yet, or if it has been explicitly initialized as null.
 A null rectangle is also an empty rectangle.
 
 .. seealso:: :py:func:`setNull`

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -324,9 +324,22 @@ Test if the rectangle is null (holding no spatial information).
 
 A rectangle is considered null if all its coordinates are NaN, if it has
 not been defined yet, or if it has been explicitly initialized as null.
-A null rectangle is also an empty rectangle.
+A null rectangle is also an empty rectangle and an invalid rectangle.
 
 .. seealso:: :py:func:`setNull`
+%End
+
+    bool isValid() const;
+%Docstring
+Test if the rectangle is valid
+
+A rectangle is considered invalid if at least one of its coordinates is
+NaN or infinite, or if a maximum coordinate is less than or equal to the
+corresponding minimum coordinate.
+
+.. seealso:: :py:func:`isNull`
+
+.. versionadded:: 4.0
 %End
 
     bool isMaximal() const;

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -322,6 +322,8 @@ segment).
 %Docstring
 Test if the rectangle is null (holding no spatial information).
 
+A rectangle is considered null if all its coordinates are NaN, if it has
+not been defined yet, or if it has been explicitly initialized as null.
 A null rectangle is also an empty rectangle.
 
 .. seealso:: :py:func:`setNull`

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -517,6 +517,8 @@ class CORE_EXPORT QgsRectangle
     /**
      * Test if the rectangle is null (holding no spatial information).
      *
+     * A rectangle is considered null if all its coordinates are NaN,
+     * if it has not been defined yet, or if it has been explicitly initialized as null.
      * A null rectangle is also an empty rectangle.
      *
      * \see setNull()

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -55,6 +55,7 @@ class CORE_EXPORT QgsRectangle
     Q_PROPERTY( QgsPointXY center READ center )
     Q_PROPERTY( bool isEmpty READ isEmpty )
     Q_PROPERTY( bool isNull READ isNull )
+    Q_PROPERTY( bool isValid READ isValid )
 
   public:
 
@@ -519,7 +520,7 @@ class CORE_EXPORT QgsRectangle
      *
      * A rectangle is considered null if all its coordinates are NaN,
      * if it has not been defined yet, or if it has been explicitly initialized as null.
-     * A null rectangle is also an empty rectangle.
+     * A null rectangle is also an empty rectangle and an invalid rectangle.
      *
      * \see setNull()
      *
@@ -531,6 +532,24 @@ class CORE_EXPORT QgsRectangle
       return ( std::isnan( mXmin )  && std::isnan( mXmax ) && std::isnan( mYmin ) && std::isnan( mYmax ) ) ||
              ( qgsDoubleNear( mXmin, std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmin, std::numeric_limits<double>::max() ) &&
                qgsDoubleNear( mXmax, -std::numeric_limits<double>::max() ) && qgsDoubleNear( mYmax, -std::numeric_limits<double>::max() ) );
+    }
+
+    /**
+     * Test if the rectangle is valid
+     *
+     * A rectangle is considered invalid if at least one of its coordinates is NaN or infinite,
+     * or if a maximum coordinate is less than or equal to the corresponding minimum coordinate.
+     *
+     * \see isNull()
+     * \since QGIS 4.0
+     */
+    bool isValid() const
+    {
+      if ( ( !isFinite() ) || ( mXmax <= mXmin ) || ( mYmax <= mYmin ) )
+      {
+        return false;
+      }
+      return true;
     }
 
     /**

--- a/tests/src/core/geometry/testqgsrectangle.cpp
+++ b/tests/src/core/geometry/testqgsrectangle.cpp
@@ -50,6 +50,7 @@ class TestQgsRectangle : public QObject
     void snappedToGrid();
     void distanceToPoint();
     void center();
+    void isValid();
 };
 
 void TestQgsRectangle::isEmpty()
@@ -649,6 +650,42 @@ void TestQgsRectangle::center()
   rect = QgsRectangle( std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max() );
   QCOMPARE( rect.center().x(), 0.0 );
   QCOMPARE( rect.center().y(), 0.0 );
+}
+
+void TestQgsRectangle::isValid()
+{
+  // a default rectangle is not valid
+  QgsRectangle rect;
+  QVERIFY( !rect.isValid() );
+  QVERIFY( rect.isNull() );
+
+  // all the values are valid, xMin < xMax, yMin, yMax
+  QgsRectangle rect2( 10, 12, 15, 25 );
+  QVERIFY( rect2.isValid() );
+  QVERIFY( !rect2.isNull() );
+
+  // xMax < xMin
+  // not valid
+  rect2.setXMaximum( 9 );
+  QVERIFY( !rect2.isValid() );
+  QVERIFY( !rect2.isNull() );
+
+  // One of the coordinates is NaN
+  // not valid
+  QgsRectangle rect3( -3, 5, 2500, 4200 );
+  QVERIFY( rect3.isValid() );
+  rect3.setYMinimum( std::numeric_limits<double>::quiet_NaN() );
+  QVERIFY( !rect3.isValid() );
+  QVERIFY( !rect3.isNull() );
+
+  // One of the coordinates is infinity
+  // not valid
+  QgsRectangle rect4( 22, 15, 33, 55 );
+  QVERIFY( rect4.isValid() );
+  QVERIFY( !rect4.isNull() );
+  rect4.setXMaximum( std::numeric_limits<double>::infinity() );
+  QVERIFY( !rect4.isValid() );
+  QVERIFY( !rect4.isNull() );
 }
 
 QGSTEST_MAIN( TestQgsRectangle )

--- a/tests/src/python/test_qgsrectangle.py
+++ b/tests/src/python/test_qgsrectangle.py
@@ -182,6 +182,34 @@ class TestQgsRectangle(QgisTestCase):
         self.assertEqual(rect.xMaximum(), 0.3)
         self.assertEqual(rect.yMaximum(), 0.2)
 
+    def testValid(self):
+        # a default rectangle is not valid
+        rect = QgsRectangle()
+        self.assertFalse(rect.isValid())
+
+        # all the values are valid, xMin < xMax, yMin, yMax
+        rect2 = QgsRectangle(10, 12, 15, 25)
+        self.assertTrue(rect2.isValid())
+
+        # xMax < xMin
+        # not valid
+        rect2.setXMaximum(9)
+        self.assertFalse(rect2.isValid())
+
+        # One of the coordinates is NaN
+        # not valid
+        rect3 = QgsRectangle(-3, 5, 2500, 4200)
+        self.assertTrue(rect3.isValid())
+        rect3.setYMinimum(float("nan"))
+        self.assertFalse(rect3.isValid())
+
+        # One of the coordinates is infinity
+        # not valid
+        rect4 = QgsRectangle(22, 15, 33, 55)
+        self.assertTrue(rect4.isValid())
+        rect4.setXMaximum(float("inf"))
+        self.assertFalse(rect4.isValid())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

This introduces a new method `isValid` which completes the existing `isNull` as discussed in https://github.com/qgis/QGIS/pull/58346 and in particular this [comment](https://github.com/qgis/QGIS/pull/58346#issuecomment-2328039671):

```
I think, we should distinguish between two separate functions:

    isNull():
        Returns true only if all coordinates are NaN values.
        Indicates that a rectangle has not been defined yet or has been explicitly initialized as null.

    isValid():
        Should be a distinct function from isNull().
        Returns false if any coordinate is NaN or infinite.
        Checks if the rectangle is well-defined and usable for calculations.

A rectangle can be created "empty" (thus null) or defined (thus not null) but invalid if one or more of its coordinates are NaN or infinite, for example, due to a calculation error.

Having both functions, well-explained, can be beneficial as seen in several codebases using this "double" check approach.
```

cc @lbartoletti 