### PR TITLE
[3d] qgs3dmapcanvaswidget: Correctly synchronize checked actions

### DIFF
--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -680,12 +680,7 @@ void Qgs3DMapCanvasWidget::toggleDebugWidget() const
 
 void Qgs3DMapCanvasWidget::setMapSettings( Qgs3DMapSettings *map )
 {
-  whileBlocking( mActionEnableShadows )->setChecked( map->shadowSettings().renderShadows() );
-  whileBlocking( mActionEnableEyeDome )->setChecked( map->eyeDomeLightingEnabled() );
-  whileBlocking( mActionEnableAmbientOcclusion )->setChecked( map->ambientOcclusionSettings().isEnabled() );
-  whileBlocking( mActionSync2DNavTo3D )->setChecked( map->viewSyncMode().testFlag( Qgis::ViewSyncModeFlag::Sync2DTo3D ) );
-  whileBlocking( mActionSync3DNavTo2D )->setChecked( map->viewSyncMode().testFlag( Qgis::ViewSyncModeFlag::Sync3DTo2D ) );
-  whileBlocking( mShowFrustumPolygon )->setChecked( map->viewFrustumVisualizationEnabled() );
+  updateCheckedActionsFromMapSettings( map );
 
   mCanvas->setMapSettings( map );
   connect( map, &Qgs3DMapSettings::showDebugPanelChanged, this, qOverload<bool>( &Qgs3DMapCanvasWidget::toggleDebugWidget ) );
@@ -816,12 +811,7 @@ void Qgs3DMapCanvasWidget::configure()
 
   mConfigureDialog->show();
 
-  whileBlocking( mActionEnableShadows )->setChecked( map->shadowSettings().renderShadows() );
-  whileBlocking( mActionEnableEyeDome )->setChecked( map->eyeDomeLightingEnabled() );
-  whileBlocking( mActionEnableAmbientOcclusion )->setChecked( map->ambientOcclusionSettings().isEnabled() );
-  whileBlocking( mActionSync2DNavTo3D )->setChecked( map->viewSyncMode().testFlag( Qgis::ViewSyncModeFlag::Sync2DTo3D ) );
-  whileBlocking( mActionSync3DNavTo2D )->setChecked( map->viewSyncMode().testFlag( Qgis::ViewSyncModeFlag::Sync3DTo2D ) );
-  whileBlocking( mShowFrustumPolygon )->setChecked( map->viewFrustumVisualizationEnabled() );
+  updateCheckedActionsFromMapSettings( map );
 }
 
 void Qgs3DMapCanvasWidget::exportScene()
@@ -1231,6 +1221,16 @@ void Qgs3DMapCanvasWidget::disableClippingPlanes() const
   mCanvas->scene()->disableClipping();
   mMapToolClippingPlanes->clearHighLightedArea();
   mActionDisableClippingPlanes->setDisabled( true );
+}
+
+void Qgs3DMapCanvasWidget::updateCheckedActionsFromMapSettings( const Qgs3DMapSettings *mapSettings ) const
+{
+  whileBlocking( mActionEnableShadows )->setChecked( mapSettings->shadowSettings().renderShadows() );
+  whileBlocking( mActionEnableEyeDome )->setChecked( mapSettings->eyeDomeLightingEnabled() );
+  whileBlocking( mActionEnableAmbientOcclusion )->setChecked( mapSettings->ambientOcclusionSettings().isEnabled() );
+  whileBlocking( mActionSync2DNavTo3D )->setChecked( mapSettings->viewSyncMode().testFlag( Qgis::ViewSyncModeFlag::Sync2DTo3D ) );
+  whileBlocking( mActionSync3DNavTo2D )->setChecked( mapSettings->viewSyncMode().testFlag( Qgis::ViewSyncModeFlag::Sync3DTo2D ) );
+  whileBlocking( mShowFrustumPolygon )->setChecked( mapSettings->viewFrustumVisualizationEnabled() );
 }
 
 ClassValidator::ClassValidator( QWidget *parent )

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -792,11 +792,14 @@ void Qgs3DMapCanvasWidget::configure()
   };
 
   connect( buttons, &QDialogButtonBox::rejected, mConfigureDialog, &QDialog::reject );
-  connect( buttons, &QDialogButtonBox::clicked, mConfigureDialog, [this, buttons, applyConfig]( QAbstractButton *button ) {
+  connect( buttons, &QDialogButtonBox::clicked, mConfigureDialog, [this, buttons, applyConfig, map]( QAbstractButton *button ) {
     if ( button == buttons->button( QDialogButtonBox::Apply ) || button == buttons->button( QDialogButtonBox::Ok ) )
       applyConfig();
     if ( button == buttons->button( QDialogButtonBox::Ok ) )
+    {
       mConfigureDialog->accept();
+      updateCheckedActionsFromMapSettings( map );
+    }
   } );
   connect( buttons, &QDialogButtonBox::helpRequested, w, []() { QgsHelp::openHelp( QStringLiteral( "map_views/3d_map_view.html#scene-configuration" ) ); } );
 
@@ -810,8 +813,6 @@ void Qgs3DMapCanvasWidget::configure()
   layout->addWidget( buttons );
 
   mConfigureDialog->show();
-
-  updateCheckedActionsFromMapSettings( map );
 }
 
 void Qgs3DMapCanvasWidget::exportScene()

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -140,6 +140,8 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     // void onPointCloudChangeAttributePointFilterChanged();
 
   private:
+    void updateCheckedActionsFromMapSettings( const Qgs3DMapSettings *mapSettings ) const;
+
     QString mCanvasName;
     Qgs3DMapCanvas *mCanvas = nullptr;
     Qgs3DAnimationWidget *mAnimationWidget = nullptr;


### PR DESCRIPTION
## Description

The actions checked status are updated once the configuration dialog
is shown based on the current 3d map settings. However, these settings
may be updated by the configuration dialog. This means that the
actions need to be updated if the dialog is accepted instead.