### PR TITLE
Assign correct labels to "Features inside polygon" algorithm's outputs

### DIFF
--- a/src/analysis/processing/qgsalgorithmcheckgeometrycontained.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrycontained.cpp
@@ -92,10 +92,10 @@ void QgsGeometryCheckContainedAlgorithm::initAlgorithm( const QVariantMap &confi
 
   // outputs
   addParameter( new QgsProcessingParameterFeatureSink(
-    QStringLiteral( "OUTPUT" ), QObject::tr( "Errors from contained features" ), Qgis::ProcessingSourceType::VectorAnyGeometry, QVariant(), true, false
+    QStringLiteral( "ERRORS" ), QObject::tr( "Errors from contained features" ), Qgis::ProcessingSourceType::VectorPoint
   ) );
   addParameter( new QgsProcessingParameterFeatureSink(
-    QStringLiteral( "ERRORS" ), QObject::tr( "Contained features" ), Qgis::ProcessingSourceType::VectorPoint
+    QStringLiteral( "OUTPUT" ), QObject::tr( "Contained features" ), Qgis::ProcessingSourceType::VectorAnyGeometry, QVariant(), true, false
   ) );
 
   std::unique_ptr<QgsProcessingParameterNumber> tolerance = std::make_unique<QgsProcessingParameterNumber>(


### PR DESCRIPTION
They had name and order switched.
In the "Check geometry" group, errors are always listed before optional features output. Let's keep following that unless it breaks our rules (?).