### PR TITLE
Silence dllimport attribute ignored warnings

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsscreenproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsscreenproperties.sip.in
@@ -113,6 +113,8 @@ settings.
 };
 
 
+
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/PyQt6/core/auto_generated/qgstiles.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstiles.sip.in
@@ -62,6 +62,7 @@ Returns tile coordinates in a formatted string
 
 
 
+
 class QgsTileRange
 {
 %Docstring(signature="appended")

--- a/python/PyQt6/core/auto_generated/qgsunsetattributevalue.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsunsetattributevalue.sip.in
@@ -57,6 +57,7 @@ Returns the original data provider's default value clause.
 
 bool operator==( const QgsUnsetAttributeValue &value, const QString &other );
 
+
 bool operator!=( const QgsUnsetAttributeValue &value, const QString &other );
 
 

--- a/python/core/auto_generated/qgsscreenproperties.sip.in
+++ b/python/core/auto_generated/qgsscreenproperties.sip.in
@@ -113,6 +113,8 @@ settings.
 };
 
 
+
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/qgstiles.sip.in
+++ b/python/core/auto_generated/qgstiles.sip.in
@@ -62,6 +62,7 @@ Returns tile coordinates in a formatted string
 
 
 
+
 class QgsTileRange
 {
 %Docstring(signature="appended")

--- a/python/core/auto_generated/qgsunsetattributevalue.sip.in
+++ b/python/core/auto_generated/qgsunsetattributevalue.sip.in
@@ -57,6 +57,7 @@ Returns the original data provider's default value clause.
 
 bool operator==( const QgsUnsetAttributeValue &value, const QString &other );
 
+
 bool operator!=( const QgsUnsetAttributeValue &value, const QString &other );
 
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -6941,7 +6941,6 @@ typedef unsigned long long qgssize;
   __pragma(warning(disable:4702))
 #define Q_NOWARN_UNREACHABLE_POP \
   __pragma(warning(pop))
-
 #else
 
 #define Q_NOWARN_DEPRECATED_PUSH

--- a/src/core/qgsscreenproperties.h
+++ b/src/core/qgsscreenproperties.h
@@ -126,6 +126,16 @@ class CORE_EXPORT QgsScreenProperties
     double mPhysicalDpi = 96;
 };
 
+#ifndef SIP_RUN
+#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#elif defined(_MSC_VER)
+__pragma( warning( push ) )
+__pragma( warning( disable: 4273 ) )
+#endif
+#endif
+
 /**
  * Returns a hash for a screen \a properties.
  *
@@ -135,5 +145,13 @@ CORE_EXPORT inline uint qHash( const QgsScreenProperties &properties ) SIP_SKIP
 {
   return qHash( properties.devicePixelRatio() ) + qHash( properties.physicalDpi() );
 }
+
+#ifndef SIP_RUN
+#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+__pragma( warning( pop ) )
+#endif
+#endif
 
 #endif // QGSSCREENPROPERTIES_H

--- a/src/core/qgstiles.h
+++ b/src/core/qgstiles.h
@@ -72,6 +72,16 @@ class CORE_EXPORT QgsTileXYZ
     int mZoomLevel = -1;
 };
 
+#ifndef SIP_RUN
+#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#elif defined(_MSC_VER)
+__pragma( warning( push ) )
+__pragma( warning( disable: 4273 ) )
+#endif
+#endif
+
 /**
  * Returns a hash for a tile \a id.
  *
@@ -85,6 +95,13 @@ CORE_EXPORT inline uint qHash( QgsTileXYZ id ) SIP_SKIP
   return h1 ^ ( h2 << 1 ) ^ ( h3 << 2 );
 }
 
+#ifndef SIP_RUN
+#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+__pragma( warning( pop ) )
+#endif
+#endif
 
 /**
  * \ingroup core

--- a/src/core/qgsunsetattributevalue.h
+++ b/src/core/qgsunsetattributevalue.h
@@ -19,6 +19,7 @@
 #define QGSUNSETATTRIBUTEVALUE_H
 
 #include "qgis_core.h"
+#include "qgis.h"
 #include <QString>
 #include <QVariant>
 
@@ -80,11 +81,28 @@ class CORE_EXPORT QgsUnsetAttributeValue
 
 Q_DECLARE_METATYPE( QgsUnsetAttributeValue )
 
+#ifndef SIP_RUN
+#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#elif defined(_MSC_VER)
+__pragma( warning( push ) )
+__pragma( warning( disable: 4273 ) )
+#endif
+#endif
 
 inline bool CORE_EXPORT operator==( const QgsUnsetAttributeValue &value, const QString &other )
 {
   return other == value.defaultValueClause();
 }
+
+#ifndef SIP_RUN
+#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+__pragma( warning( pop ) )
+#endif
+#endif
 
 inline bool operator!=( const QgsUnsetAttributeValue &value, const QString &other )
 {


### PR DESCRIPTION
Silence noisy and harmless 'inline function declared as dllimport: attribute ignored' warnings.

These can be safely ignored, but cause thousands of lines of warnings during windows builds (eg mingw builds)

(Unfortunately a macro based approach CANNOT be used here -- that breaks the mingw build, as it seems to have issues with nesting _Pragma along with __declspec)
