### PR TITLE
Fix 3D terrain texture tiles stop loading

### DIFF
--- a/src/3d/chunks/qgschunkedentity.cpp
+++ b/src/3d/chunks/qgschunkedentity.cpp
@@ -703,7 +703,8 @@ void QgsChunkedEntity::startJobs()
     delete entry;
 
     QgsChunkQueueJob *job = startJob( node );
-    mActiveJobs.append( job );
+    if ( !job->isFinished() )
+      mActiveJobs.append( job );
   }
 }
 
@@ -716,6 +717,7 @@ QgsChunkQueueJob *QgsChunkedEntity::startJob( QgsChunkNode *node )
 
     QgsChunkLoader *loader = mChunkLoaderFactory->createChunkLoader( node );
     connect( loader, &QgsChunkQueueJob::finished, this, &QgsChunkedEntity::onActiveJobFinished );
+    loader->start();
     node->setLoading( loader );
     return loader;
   }
@@ -725,6 +727,7 @@ QgsChunkQueueJob *QgsChunkedEntity::startJob( QgsChunkNode *node )
 
     node->setUpdating();
     connect( node->updater(), &QgsChunkQueueJob::finished, this, &QgsChunkedEntity::onActiveJobFinished );
+    node->updater()->start();
     return node->updater();
   }
   else

--- a/src/3d/chunks/qgschunkqueuejob.cpp
+++ b/src/3d/chunks/qgschunkqueuejob.cpp
@@ -18,9 +18,20 @@
 
 ///@cond PRIVATE
 
+QgsChunkQueueJob::QgsChunkQueueJob(QgsChunkNode *node)
+  : mNode( node )
+{
+  connect( this, &QgsChunkQueueJob::finished, this, [this]() { mFinished = true; });
+}
+
 void QgsChunkQueueJob::cancel()
 {
   // TODO: what to do...
+}
+
+bool QgsChunkQueueJob::isFinished() const
+{
+  return mFinished;
 }
 
 /// @endcond

--- a/src/3d/chunks/qgschunkqueuejob.h
+++ b/src/3d/chunks/qgschunkqueuejob.h
@@ -42,9 +42,9 @@ namespace Qt3DCore
  * \ingroup qgis_3d
  * \brief  Base class for chunk queue jobs.
  *
- * Job implementations start their work when they are created
- * and all work is done asynchronously, i.e. constructor should exit as soon as possible and
- * all work should be done in a worker thread. Once the job is done, finished() signal is emitted
+ * Job implementations do all their work asynchronously,
+ * i.e. all work should be done in a worker thread once start() is called.
+ * Once the job is done, finished() signal is emitted
  * and will be processed by the parent chunked entity.
  *
  * There are currently two types of queue jobs:
@@ -58,10 +58,13 @@ class QgsChunkQueueJob : public QObject
     Q_OBJECT
   public:
     //! Constructs a job for given chunk node
-    QgsChunkQueueJob( QgsChunkNode *node )
-      : mNode( node )
-    {
-    }
+    QgsChunkQueueJob( QgsChunkNode *node );
+
+    /**
+     * Start the actual work, make sure you have connected to `finished()`
+     * before calling start().
+     */
+    virtual void start() = 0;
 
     //! Returns chunk node of this job
     QgsChunkNode *chunk() { return mNode; }
@@ -76,12 +79,20 @@ class QgsChunkQueueJob : public QObject
      */
     virtual void cancel();
 
+    /**
+     * Returns if this job is finished.
+     * A job is initialized as not finished and will be set to finished, once the `finished` signal
+     * has been emitted.
+     */
+    bool isFinished() const;
+
   signals:
     //! Emitted when the asynchronous job has finished. Not emitted if the job got canceled.
     void finished();
 
   protected:
     QgsChunkNode *mNode = nullptr;
+    bool mFinished = false;
 };
 
 /**

--- a/src/3d/mesh/qgsmeshterraingenerator.cpp
+++ b/src/3d/mesh/qgsmeshterraingenerator.cpp
@@ -32,6 +32,10 @@ QgsMeshTerrainTileLoader::QgsMeshTerrainTileLoader( QgsTerrainEntity *terrain, Q
   , mTriangularMesh( triangularMesh )
   , mSymbol( symbol->clone() )
 {
+}
+
+void QgsMeshTerrainTileLoader::start()
+{
   loadTexture();
 }
 

--- a/src/3d/mesh/qgsmeshterraintileloader_p.h
+++ b/src/3d/mesh/qgsmeshterraintileloader_p.h
@@ -34,6 +34,8 @@ class QgsMeshTerrainTileLoader : public QgsTerrainTileLoader
     //! Construct the loader for a node
     QgsMeshTerrainTileLoader( QgsTerrainEntity *terrain, QgsChunkNode *node, const QgsTriangularMesh &triangularMesh, const QgsMesh3DSymbol *symbol );
 
+    void start() override;
+
     //! Create the 3D entity and returns it
     Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent ) override;
 

--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -308,6 +308,7 @@ QgsTerrainTileEntity *Qgs3DSceneExporter::getFlatTerrainEntity( QgsTerrainEntity
 {
   QgsFlatTerrainGenerator *generator = dynamic_cast<QgsFlatTerrainGenerator *>( terrain->mapSettings()->terrainGenerator() );
   FlatTerrainChunkLoader *flatTerrainLoader = qobject_cast<FlatTerrainChunkLoader *>( generator->createChunkLoader( node ) );
+  flatTerrainLoader->start();
   if ( mExportTextures )
     terrain->textureGenerator()->waitForFinished();
   // the entity we created will be deallocated once the scene exporter is deallocated
@@ -323,6 +324,7 @@ QgsTerrainTileEntity *Qgs3DSceneExporter::getDemTerrainEntity( QgsTerrainEntity 
   QgsDemTerrainGenerator *generator = dynamic_cast<QgsDemTerrainGenerator *>( terrain->mapSettings()->terrainGenerator()->clone() );
   generator->setResolution( mTerrainResolution );
   QgsDemTerrainTileLoader *loader = qobject_cast<QgsDemTerrainTileLoader *>( generator->createChunkLoader( node ) );
+  loader->start();
   generator->heightMapGenerator()->waitForFinished();
   if ( mExportTextures )
     terrain->textureGenerator()->waitForFinished();
@@ -335,6 +337,7 @@ QgsTerrainTileEntity *Qgs3DSceneExporter::getMeshTerrainEntity( QgsTerrainEntity
 {
   QgsMeshTerrainGenerator *generator = dynamic_cast<QgsMeshTerrainGenerator *>( terrain->mapSettings()->terrainGenerator() );
   QgsMeshTerrainTileLoader *loader = qobject_cast<QgsMeshTerrainTileLoader *>( generator->createChunkLoader( node ) );
+  loader->start();
   // TODO: export textures
   QgsTerrainTileEntity *tileEntity = qobject_cast<QgsTerrainTileEntity *>( loader->createEntity( this ) );
   return tileEntity;

--- a/src/3d/qgsglobechunkedentity.cpp
+++ b/src/3d/qgsglobechunkedentity.cpp
@@ -275,37 +275,17 @@ QgsGlobeChunkLoader::QgsGlobeChunkLoader( QgsChunkNode *node, QgsTerrainTextureG
   , mTextureGenerator( textureGenerator )
   , mGlobeCrsToLatLon( globeCrsToLatLon )
 {
-<<<<<<< HEAD
+}
+
+void QgsGlobeChunkLoader::start()
+{
+  QgsChunkNode *node = chunk();
+
   connect( mTextureGenerator, &QgsTerrainTextureGenerator::tileReady, this, [this]( int job, const QImage &img ) {
     if ( job == mJobId )
     {
       mTexture = img;
       emit finished();
-=======
-  public:
-    QgsGlobeChunkLoader( QgsChunkNode *node, QgsTerrainTextureGenerator *textureGenerator, const QgsCoordinateTransform &globeCrsToLatLon )
-      : QgsChunkLoader( node )
-      , mTextureGenerator( textureGenerator )
-      , mGlobeCrsToLatLon( globeCrsToLatLon )
-    {}
-
-    void start() override
-    {
-      QgsChunkNode *node = chunk();
-
-      connect( mTextureGenerator, &QgsTerrainTextureGenerator::tileReady, this, [this]( int job, const QImage &img ) {
-        if ( job == mJobId )
-        {
-          mTexture = img;
-          emit finished();
-        }
-      } );
-
-      double latMin, latMax, lonMin, lonMax;
-      globeNodeIdToLatLon( node->tileId(), latMin, latMax, lonMin, lonMax );
-      QgsRectangle extent( lonMin, latMin, lonMax, latMax );
-      mJobId = mTextureGenerator->render( extent, node->tileId(), node->tileId().text() );
->>>>>>> 6b7c743bb1e (Cleaner approach)
     }
   } );
 

--- a/src/3d/qgsglobechunkedentity.cpp
+++ b/src/3d/qgsglobechunkedentity.cpp
@@ -410,7 +410,7 @@ QgsGlobeMapUpdateJob::QgsGlobeMapUpdateJob( QgsTerrainTextureGenerator *textureG
 {
 }
 
-QgsGlobeMapUpdateJob::start()
+void QgsGlobeMapUpdateJob::start()
 {
   QgsChunkNode *node = chunk();
 

--- a/src/3d/qgsglobechunkedentity.h
+++ b/src/3d/qgsglobechunkedentity.h
@@ -48,6 +48,7 @@ class QgsGlobeChunkLoader : public QgsChunkLoader
     Q_OBJECT
   public:
     QgsGlobeChunkLoader( QgsChunkNode *node, QgsTerrainTextureGenerator *textureGenerator, const QgsCoordinateTransform &globeCrsToLatLon );
+    void start() override;
 
     Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent ) override;
 

--- a/src/3d/qgsglobechunkedentity.h
+++ b/src/3d/qgsglobechunkedentity.h
@@ -72,7 +72,7 @@ class QgsGlobeMapUpdateJob : public QgsChunkQueueJob
 
   private:
     QgsTerrainTextureGenerator *mTextureGenerator = nullptr;
-    int mJobId;
+    int mJobId = -1;
 };
 
 class QgsGlobeChunkLoaderFactory : public QgsChunkLoaderFactory

--- a/src/3d/qgsglobechunkedentity.h
+++ b/src/3d/qgsglobechunkedentity.h
@@ -55,7 +55,7 @@ class QgsGlobeChunkLoader : public QgsChunkLoader
   private:
     QgsTerrainTextureGenerator *mTextureGenerator;
     QgsCoordinateTransform mGlobeCrsToLatLon;
-    int mJobId;
+    int mJobId = -1;
     QImage mTexture;
 };
 

--- a/src/3d/qgsglobechunkedentity.h
+++ b/src/3d/qgsglobechunkedentity.h
@@ -65,6 +65,7 @@ class QgsGlobeMapUpdateJob : public QgsChunkQueueJob
     Q_OBJECT
   public:
     QgsGlobeMapUpdateJob( QgsTerrainTextureGenerator *textureGenerator, QgsChunkNode *node );
+    void start() override;
 
     void cancel() override;
 

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -52,6 +52,11 @@ QgsPointCloudLayerChunkLoader::QgsPointCloudLayerChunkLoader( const QgsPointClou
   , mFactory( factory )
   , mContext( factory->mRenderContext, coordinateTransform, std::move( symbol ), zValueScale, zValueOffset )
 {
+}
+
+void QgsPointCloudLayerChunkLoader::start()
+{
+  QgsChunkNode *node = chunk();
   QgsPointCloudIndex pc = mFactory->mPointCloudIndex;
   mContext.setAttributes( pc.attributes() );
 

--- a/src/3d/qgspointcloudlayerchunkloader_p.h
+++ b/src/3d/qgspointcloudlayerchunkloader_p.h
@@ -102,6 +102,7 @@ class QgsPointCloudLayerChunkLoader : public QgsChunkLoader
     QgsPointCloudLayerChunkLoader( const QgsPointCloudLayerChunkLoaderFactory *factory, QgsChunkNode *node, std::unique_ptr<QgsPointCloud3DSymbol> symbol, const QgsCoordinateTransform &coordinateTransform, double zValueScale, double zValueOffset );
     ~QgsPointCloudLayerChunkLoader() override;
 
+    void start() override;
     virtual void cancel() override;
     virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent ) override;
 

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -44,6 +44,11 @@ QgsRuleBasedChunkLoader::QgsRuleBasedChunkLoader( const QgsRuleBasedChunkLoaderF
   , mContext( factory->mRenderContext )
   , mSource( new QgsVectorLayerFeatureSource( factory->mLayer ) )
 {
+}
+
+void QgsRuleBasedChunkLoader::start()
+{
+  QgsChunkNode *node = chunk();
   if ( node->level() < mFactory->mLeafLevel )
   {
     QTimer::singleShot( 0, this, &QgsRuleBasedChunkLoader::finished );

--- a/src/3d/qgsrulebasedchunkloader_p.h
+++ b/src/3d/qgsrulebasedchunkloader_p.h
@@ -89,6 +89,7 @@ class QgsRuleBasedChunkLoader : public QgsChunkLoader
     QgsRuleBasedChunkLoader( const QgsRuleBasedChunkLoaderFactory *factory, QgsChunkNode *node );
     ~QgsRuleBasedChunkLoader() override;
 
+    void start() override;
     virtual void cancel() override;
     virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent ) override;
 

--- a/src/3d/qgstiledscenechunkloader_p.h
+++ b/src/3d/qgstiledscenechunkloader_p.h
@@ -56,6 +56,7 @@ class QgsTiledSceneChunkLoader : public QgsChunkLoader
     Q_OBJECT
   public:
     QgsTiledSceneChunkLoader( QgsChunkNode *node, const QgsTiledSceneIndex &index, const QgsTiledSceneChunkLoaderFactory &factory, double zValueScale, double zValueOffset );
+    void start() override;
 
     ~QgsTiledSceneChunkLoader();
 
@@ -63,6 +64,8 @@ class QgsTiledSceneChunkLoader : public QgsChunkLoader
 
   private:
     const QgsTiledSceneChunkLoaderFactory &mFactory;
+    double mZValueScale;
+    double mZValueOffset;
     QgsTiledSceneIndex mIndex;
     QFutureWatcher<void> *mFutureWatcher = nullptr;
     Qt3DCore::QEntity *mEntity = nullptr;

--- a/src/3d/qgstiledscenechunkloader_p.h
+++ b/src/3d/qgstiledscenechunkloader_p.h
@@ -60,7 +60,7 @@ class QgsTiledSceneChunkLoader : public QgsChunkLoader
 
     ~QgsTiledSceneChunkLoader();
 
-    virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent );
+    virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent ) override;
 
   private:
     const QgsTiledSceneChunkLoaderFactory &mFactory;

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -45,6 +45,11 @@ QgsVectorLayerChunkLoader::QgsVectorLayerChunkLoader( const QgsVectorLayerChunkL
   , mRenderContext( factory->mRenderContext )
   , mSource( new QgsVectorLayerFeatureSource( factory->mLayer ) )
 {
+}
+
+void QgsVectorLayerChunkLoader::start()
+{
+  QgsChunkNode *node = chunk();
   if ( node->level() < mFactory->mLeafLevel )
   {
     QTimer::singleShot( 0, this, &QgsVectorLayerChunkLoader::finished );

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -89,6 +89,7 @@ class QgsVectorLayerChunkLoader : public QgsChunkLoader
     QgsVectorLayerChunkLoader( const QgsVectorLayerChunkLoaderFactory *factory, QgsChunkNode *node );
     ~QgsVectorLayerChunkLoader() override;
 
+    void start() override;
     virtual void cancel() override;
     virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent ) override;
 

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -61,17 +61,23 @@ static void _heightMapMinMax( const QByteArray &heightMap, float &zMin, float &z
 QgsDemTerrainTileLoader::QgsDemTerrainTileLoader( QgsTerrainEntity *terrain, QgsChunkNode *node, QgsTerrainGenerator *terrainGenerator )
   : QgsTerrainTileLoader( terrain, node )
   , mResolution( 0 )
+  , mTerrainGenerator( terrainGenerator )
+{}
+
+void QgsDemTerrainTileLoader::start()
 {
+  QgsChunkNode *node = chunk();
+
   QgsDemHeightMapGenerator *heightMapGenerator = nullptr;
-  if ( terrainGenerator->type() == QgsTerrainGenerator::Dem )
+  if ( mTerrainGenerator->type() == QgsTerrainGenerator::Dem )
   {
-    QgsDemTerrainGenerator *generator = static_cast<QgsDemTerrainGenerator *>( terrainGenerator );
+    QgsDemTerrainGenerator *generator = static_cast<QgsDemTerrainGenerator *>( mTerrainGenerator );
     heightMapGenerator = generator->heightMapGenerator();
     mSkirtHeight = generator->skirtHeight();
   }
-  else if ( terrainGenerator->type() == QgsTerrainGenerator::Online )
+  else if ( mTerrainGenerator->type() == QgsTerrainGenerator::Online )
   {
-    QgsOnlineTerrainGenerator *generator = static_cast<QgsOnlineTerrainGenerator *>( terrainGenerator );
+    QgsOnlineTerrainGenerator *generator = static_cast<QgsOnlineTerrainGenerator *>( mTerrainGenerator );
     heightMapGenerator = generator->heightMapGenerator();
     mSkirtHeight = generator->skirtHeight();
   }

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -60,7 +60,6 @@ static void _heightMapMinMax( const QByteArray &heightMap, float &zMin, float &z
 
 QgsDemTerrainTileLoader::QgsDemTerrainTileLoader( QgsTerrainEntity *terrain, QgsChunkNode *node, QgsTerrainGenerator *terrainGenerator )
   : QgsTerrainTileLoader( terrain, node )
-  , mResolution( 0 )
   , mTerrainGenerator( terrainGenerator )
 {}
 

--- a/src/3d/terrain/qgsdemterraintileloader_p.h
+++ b/src/3d/terrain/qgsdemterraintileloader_p.h
@@ -56,6 +56,8 @@ class QgsDemTerrainTileLoader : public QgsTerrainTileLoader
     //! Constructs loader for the given chunk node
     QgsDemTerrainTileLoader( QgsTerrainEntity *terrain, QgsChunkNode *node, QgsTerrainGenerator *terrainGenerator );
 
+    void start() override;
+
     Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent ) override;
 
   private slots:
@@ -66,6 +68,7 @@ class QgsDemTerrainTileLoader : public QgsTerrainTileLoader
     QByteArray mHeightMap;
     int mResolution;
     float mSkirtHeight;
+    QgsTerrainGenerator *mTerrainGenerator;
 };
 
 

--- a/src/3d/terrain/qgsdemterraintileloader_p.h
+++ b/src/3d/terrain/qgsdemterraintileloader_p.h
@@ -64,10 +64,10 @@ class QgsDemTerrainTileLoader : public QgsTerrainTileLoader
     void onHeightMapReady( int jobId, const QByteArray &heightMap );
 
   private:
-    int mHeightMapJobId;
+    int mHeightMapJobId = -1;
     QByteArray mHeightMap;
-    int mResolution;
-    float mSkirtHeight;
+    int mResolution = 0;
+    float mSkirtHeight = 0;
     QgsTerrainGenerator *mTerrainGenerator;
 };
 

--- a/src/3d/terrain/qgsflatterraingenerator.cpp
+++ b/src/3d/terrain/qgsflatterraingenerator.cpp
@@ -32,6 +32,9 @@
 
 FlatTerrainChunkLoader::FlatTerrainChunkLoader( QgsTerrainEntity *terrain, QgsChunkNode *node )
   : QgsTerrainTileLoader( terrain, node )
+{}
+
+void FlatTerrainChunkLoader::start()
 {
   loadTexture();
 }

--- a/src/3d/terrain/qgsflatterraingenerator.h
+++ b/src/3d/terrain/qgsflatterraingenerator.h
@@ -35,6 +35,8 @@ class FlatTerrainChunkLoader : public QgsTerrainTileLoader
     //! Construct the loader for a node
     FlatTerrainChunkLoader( QgsTerrainEntity *terrain, QgsChunkNode *mNode );
 
+    void start() override;
+
     Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent ) override;
 
   private:

--- a/src/3d/terrain/qgsterrainentity.cpp
+++ b/src/3d/terrain/qgsterrainentity.cpp
@@ -230,9 +230,15 @@ TerrainMapUpdateJob::TerrainMapUpdateJob( QgsTerrainTextureGenerator *textureGen
   : QgsChunkQueueJob( node )
   , mTextureGenerator( textureGenerator )
 {
+}
+
+void TerrainMapUpdateJob::start()
+{
+  QgsChunkNode *node = chunk();
+
   QgsTerrainTileEntity *entity = qobject_cast<QgsTerrainTileEntity *>( node->entity() );
-  connect( textureGenerator, &QgsTerrainTextureGenerator::tileReady, this, &TerrainMapUpdateJob::onTileReady );
-  mJobId = textureGenerator->render( entity->textureImage()->imageExtent(), node->tileId(), entity->textureImage()->imageDebugText() );
+  connect( mTextureGenerator, &QgsTerrainTextureGenerator::tileReady, this, &TerrainMapUpdateJob::onTileReady );
+  mJobId = mTextureGenerator->render( entity->textureImage()->imageExtent(), node->tileId(), entity->textureImage()->imageDebugText() );
 }
 
 void TerrainMapUpdateJob::cancel()

--- a/src/3d/terrain/qgsterrainentity.h
+++ b/src/3d/terrain/qgsterrainentity.h
@@ -97,6 +97,8 @@ class TerrainMapUpdateJob : public QgsChunkQueueJob
   public:
     TerrainMapUpdateJob( QgsTerrainTextureGenerator *textureGenerator, QgsChunkNode *mNode );
 
+    void start() override;
+
     void cancel() override;
 
   private slots:
@@ -104,7 +106,7 @@ class TerrainMapUpdateJob : public QgsChunkQueueJob
 
   private:
     QgsTerrainTextureGenerator *mTextureGenerator = nullptr;
-    int mJobId;
+    int mJobId = -1;
 };
 
 /// @endcond

--- a/src/3d/terrain/qgsterraintileloader.cpp
+++ b/src/3d/terrain/qgsterraintileloader.cpp
@@ -48,7 +48,7 @@ QgsTerrainTileLoader::QgsTerrainTileLoader( QgsTerrainEntity *terrain, QgsChunkN
 
 void QgsTerrainTileLoader::loadTexture()
 {
-  connect( mTerrain->textureGenerator(), &QgsTerrainTextureGenerator::tileReady, this, &QgsTerrainTileLoader::onImageReady, Qt::QueuedConnection );
+  connect( mTerrain->textureGenerator(), &QgsTerrainTextureGenerator::tileReady, this, &QgsTerrainTileLoader::onImageReady );
   mTextureJobId = mTerrain->textureGenerator()->render( mExtentMapCrs, mNode->tileId(), mTileDebugText );
 }
 

--- a/src/3d/terrain/qgsterraintileloader.cpp
+++ b/src/3d/terrain/qgsterraintileloader.cpp
@@ -48,7 +48,7 @@ QgsTerrainTileLoader::QgsTerrainTileLoader( QgsTerrainEntity *terrain, QgsChunkN
 
 void QgsTerrainTileLoader::loadTexture()
 {
-  connect( mTerrain->textureGenerator(), &QgsTerrainTextureGenerator::tileReady, this, &QgsTerrainTileLoader::onImageReady );
+  connect( mTerrain->textureGenerator(), &QgsTerrainTextureGenerator::tileReady, this, &QgsTerrainTileLoader::onImageReady, Qt::QueuedConnection );
   mTextureJobId = mTerrain->textureGenerator()->render( mExtentMapCrs, mNode->tileId(), mTileDebugText );
 }
 


### PR DESCRIPTION
This happens e.g. in combination with WMTS layers.

The symptom is, that the rendering progress bar doesn't disappear and it consistently shows that some tiles are still being loaded.


https://github.com/user-attachments/assets/04dc5209-03bd-4052-88df-51baeca140bb



This is caused by the signal of the loader being fired still in the constructor when consumers of the loader couldn't connect to the finished signal. By using a `Qt::QueuedConnection` we make sure that the signal is only sent later.

On line 717, the loader is created (which might already fire a `finished` signal at that stage)
On line 718, the signal is connected (which is then too late)

https://github.com/qgis/QGIS/blob/19d87693db46cd048d008cb47b77913275ac1c40/src/3d/chunks/qgschunkedentity.cpp#L717-L718

Since we load at most 4 tiles at a time, we stop loading tiles once we have 4 active tile loaders going.

# Potential alternative approach

This approach fixes the imminent issue, but I am not sure if there are more hidden problems like this. E.g. the following snippet looks suspicious too.

https://github.com/qgis/QGIS/blob/19d87693db46cd048d008cb47b77913275ac1c40/src/3d/qgsglobechunkedentity.cpp#L278-L284

I wonder if it wouldn't be better to explicitly start loading after the constructor (but this changes API, so I'm not sure that's a good idea).

```cpp
QgsChunkLoader *loader = mChunkLoaderFactory->createChunkLoader( node );
connect( loader, &QgsChunkQueueJob::finished, this, &QgsChunkedEntity::onActiveJobFinished );
loader->load(); // Make this call explicit so we can be sure that the connection is there before finish() is emitted
```

