### PR TITLE
[WFS] Only use `NAMESPACE` for WFS 1.x and `NAMESPACES` for WFS 2.0.x (Fix #62708)

### DIFF
--- a/src/providers/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/providers/wfs/qgswfsdescribefeaturetype.cpp
@@ -43,14 +43,17 @@ bool QgsWFSDescribeFeatureType::requestFeatureType( const QString &WFSVersion, c
           query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
         }
       }
+      else
+      {
+        if ( !namespaceValue.isEmpty() )
+        {
+          query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+        }
+      }
 
       // Always add singular form for broken servers
       // See: https://github.com/qgis/QGIS/issues/41087
       query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
-      if ( !namespaceValue.isEmpty() )
-      {
-        query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
-      }
 
       url.setQuery( query );
       return sendGET( url, QString(), true, false );

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -335,8 +335,13 @@ QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeat
   if ( !namespaces.isEmpty() )
   {
     if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+    {
       query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaces );
-    query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaces );
+    }
+    else
+    {
+      query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaces );
+    }
   }
 
   getFeatureUrl.setQuery( query );

--- a/src/providers/wfs/qgswfsgetfeature.cpp
+++ b/src/providers/wfs/qgswfsgetfeature.cpp
@@ -48,11 +48,10 @@ bool QgsWFSGetFeature::request( bool synchronous, const QString &WFSVersion, con
       else
       {
         query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
-      }
-
-      if ( !namespaceValue.isEmpty() )
-      {
-        query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+        if ( !namespaceValue.isEmpty() )
+        {
+          query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+        }
       }
 
       if ( !filter.isEmpty() )

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -4642,7 +4642,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 endpoint,
-                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&NAMESPACES=xmlns(my,http://my)&TYPENAME=my:typename&NAMESPACE=xmlns(my,http://my)",
+                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&NAMESPACES=xmlns(my,http://my)&TYPENAME=my:typename",
             ),
             "wb",
         ) as f:
@@ -4677,7 +4677,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 endpoint,
-                "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::32631&NAMESPACES=xmlns(my,http://my)&NAMESPACE=xmlns(my,http://my)",
+                "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::32631&NAMESPACES=xmlns(my,http://my)",
             ),
             "wb",
         ) as f:
@@ -4731,7 +4731,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 endpoint,
-                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&NAMESPACES=xmlns(my,http://my)&TYPENAME=my:typename&NAMESPACE=xmlns(my,http://my)",
+                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&NAMESPACES=xmlns(my,http://my)&TYPENAME=my:typename",
             ),
             "wb",
         ) as f:
@@ -4766,7 +4766,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 endpoint,
-                "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::32631&NAMESPACES=xmlns(my,http://my)&NAMESPACE=xmlns(my,http://my)",
+                "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::32631&NAMESPACES=xmlns(my,http://my)",
             ),
             "wb",
         ) as f:
@@ -4820,7 +4820,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 endpoint,
-                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&NAMESPACES=xmlns(my,http://my)&TYPENAME=my:typename&NAMESPACE=xmlns(my,http://my)",
+                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&NAMESPACES=xmlns(my,http://my)&TYPENAME=my:typename",
             ),
             "wb",
         ) as f:
@@ -4863,7 +4863,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
   <fes:Literal>1</fes:Literal>
  </fes:PropertyIsEqualTo>
 </fes:Filter>
-&NAMESPACES=xmlns(my,http://my)&NAMESPACE=xmlns(my,http://my)""",
+&NAMESPACES=xmlns(my,http://my)""",
             ),
             "wb",
         ) as f:
@@ -4919,7 +4919,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
   </fes:PropertyIsGreaterThan>
  </fes:And>
 </fes:Filter>
-&NAMESPACES=xmlns(my,http://my)&NAMESPACE=xmlns(my,http://my)""",
+&NAMESPACES=xmlns(my,http://my)""",
             ),
             "wb",
         ) as f:
@@ -4970,7 +4970,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
   </fes:PropertyIsEqualTo>
  </fes:And>
 </fes:Filter>
-&NAMESPACES=xmlns(my,http://my)&NAMESPACE=xmlns(my,http://my)""",
+&NAMESPACES=xmlns(my,http://my)""",
             ),
             "wb",
         ) as f:


### PR DESCRIPTION
## Description

TL;DR

This PR makes sure that QGIS follows the WFS 2.0 specifications and that therefore only adds the `NAMESPACES` query item to the `DescribeFeatureType` and `GetFeature` query URLs (it modifies the `QgsWFSDescribeFeatureType::requestFeatureType()`, `QgsWFSGetFeature::request()` and `QgsWFSFeatureDownloaderImpl::buildURL()` functions).

The tests testGetFeatureWithNamespaces, testGetFeatureWithNamespaces2 and testGetFeatureWithNamespaceAndFilter have been modified accordingly.

Fixes https://github.com/qgis/QGIS/issues/62708.

-------
According to the WFS specifications published by OGC ([1.x](https://docs.ogc.org/is/04-094r1/04-094r1.html#109), [2.0.x](https://docs.ogc.org/is/09-025r2/09-025r2.html#67)):
- for WFS 2.0.x, the `NAMESPACES` query item (with format `xmlns(prefix,escaped_url)`) should be used
- for WFS 1.x, the `NAMESPACE` query item (with format `xmlns(prefix=escaped_url)`) should be used

Nevertheless, QGIS behaves incorrectly in two ways for WFS 2.0.x:
- it incorrectly adds both the `NAMESPACES` and the `NAMESPACE` query items to the `DescribeFeatureType` and `GetFeature` URLs (while it should only add the `NAMESPACES` query item)
- the incorrectly added `NAMESPACE` query item is in the incorrect format `xmlns(prefix,escaped_url)` (instead of `xmlns(prefix=escaped_url)`)

Such incorrect behaviour is also inconsistent among various functions (`QgsWFSDescribeFeatureType::requestFeatureType()`, `QgsWFSGetFeature::request()` and `QgsWFSFeatureDownloaderImpl::buildURL()` incorrectly add both `NAMESPACES` and `NAMESPACE`, while `QgsWFSFeatureHitsRequest::getFeatureCount()` correctly only adds `NAMESPACES`).

Such incorrect behaviour creates issues with WFSs that adhere to the WFS 2.0 specifications, as described at https://github.com/qgis/QGIS/issues/62708 and https://github.com/qgis/QGIS/issues/62708#issuecomment-3137908704.

While QGIS also has a similar incorrect behaviour for the `TYPENAMES` and `TYPENAME` query items, it looks like it doesn't create a real issue with WFS 2.0 servers, so I didn't change it.

The issue has become effective for some WFS servers since QGIS 3.44.0 after PR https://github.com/qgis/QGIS/pull/60958 by @nyalldawson: in QGIS <= 3.42.3 neither `NAMESPACES` nor `NAMESPACE` query items were added to the query URL for such WFS 2.0 servers, so the issue didn't occur. Anyway the issue could also occur running QGIS 3.40 for some other WFS 2.0 servers, although not yet reported. 

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
