### PR TITLE
Make QGIS 3D Mount Everest compatible

### DIFF
--- a/src/3d/terrain/qgsterraingenerator.cpp
+++ b/src/3d/terrain/qgsterraingenerator.cpp
@@ -42,7 +42,7 @@ void QgsTerrainGenerator::rootChunkHeightRange( float &hMin, float &hMax ) const
 {
   // TODO: makes sense to have kind of default implementation?
   hMin = 0;
-  hMax = 400;
+  hMax = 8848;
 }
 
 float QgsTerrainGenerator::heightAt( double x, double y, const Qgs3DRenderContext &context ) const


### PR DESCRIPTION
**TLDR; QGIS currently only shows terrains between 0-144 masl (unless a terrain provider overrides this). This pull request proposes to increase that (default) range from 0-8848.**

Fun fact: QGIS hardcodes a bounding box from 0-400 masl (as default implementation for terrain generators and this is used for the DEM generator.

This becomes apparent when higher resolution tiles are not loaded because they fall outside this range, when they are filtered here

https://github.com/qgis/QGIS/blob/19d87693db46cd048d008cb47b77913275ac1c40/src/3d/chunks/qgschunkloader.cpp#L65

For the area where I happen to enjoy spending my spare time, this is rather unfortunate. So let's at least bump the max up to the highest place on our local home planet.

This is a quick fix (which will improve the situation for many cases nonetheless) and does not really solve the underlying issue.
We should be reading the values from the height provider, but reading raster stats can be very slow, so we need to do something smart like sampling some values and adding some safety margins or so.

I'll leave the adjustment of the lower bound to deep sea researchers and mariana trench enthusiasts (or possibly some Dutchmen might already need to lower that below sea level CC @rduivenvoorde @raymondnijssen )