### PR TITLE
[Backport release-3_40] [WFS] Only use `NAMESPACE` for WFS 1.x and `NAMESPACES` for WFS 2.0.x (Fix #62708)

### DIFF
--- a/src/providers/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/providers/wfs/qgswfsdescribefeaturetype.cpp
@@ -39,14 +39,17 @@ bool QgsWFSDescribeFeatureType::requestFeatureType( const QString &WFSVersion, c
       query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaceValue );
     }
   }
+  else
+  {
+    if ( !namespaceValue.isEmpty() )
+    {
+      query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+    }
+  }
 
   // Always add singular form for broken servers
   // See: https://github.com/qgis/QGIS/issues/41087
   query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
-  if ( !namespaceValue.isEmpty() )
-  {
-    query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
-  }
 
   url.setQuery( query );
   return sendGET( url, QString(), true, false );

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -315,8 +315,13 @@ QUrl QgsWFSFeatureDownloaderImpl::buildURL( qint64 startIndex, long long maxFeat
   if ( !namespaces.isEmpty() )
   {
     if ( mShared->mWFSVersion.startsWith( QLatin1String( "2.0" ) ) )
+    {
       query.addQueryItem( QStringLiteral( "NAMESPACES" ), namespaces );
-    query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaces );
+    }
+    else
+    {
+      query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaces );
+    }
   }
 
   getFeatureUrl.setQuery( query );

--- a/src/providers/wfs/qgswfsgetfeature.cpp
+++ b/src/providers/wfs/qgswfsgetfeature.cpp
@@ -42,11 +42,10 @@ bool QgsWFSGetFeature::request( bool synchronous, const QString &WFSVersion, con
   else
   {
     query.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
-  }
-
-  if ( !namespaceValue.isEmpty() )
-  {
-    query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+    if ( !namespaceValue.isEmpty() )
+    {
+      query.addQueryItem( QStringLiteral( "NAMESPACE" ), namespaceValue );
+    }
   }
 
   if ( !filter.isEmpty() )

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -4630,7 +4630,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 endpoint,
-                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&NAMESPACES=xmlns(my,http://my)&TYPENAME=my:typename&NAMESPACE=xmlns(my,http://my)",
+                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&NAMESPACES=xmlns(my,http://my)&TYPENAME=my:typename",
             ),
             "wb",
         ) as f:
@@ -4665,7 +4665,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 endpoint,
-                "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::32631&NAMESPACES=xmlns(my,http://my)&NAMESPACE=xmlns(my,http://my)",
+                "?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::32631&NAMESPACES=xmlns(my,http://my)",
             ),
             "wb",
         ) as f:
@@ -4719,7 +4719,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 endpoint,
-                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&NAMESPACES=xmlns(my,http://my)&TYPENAME=my:typename&NAMESPACE=xmlns(my,http://my)",
+                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&NAMESPACES=xmlns(my,http://my)&TYPENAME=my:typename",
             ),
             "wb",
         ) as f:
@@ -4762,7 +4762,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
   <fes:Literal>1</fes:Literal>
  </fes:PropertyIsEqualTo>
 </fes:Filter>
-&NAMESPACES=xmlns(my,http://my)&NAMESPACE=xmlns(my,http://my)""",
+&NAMESPACES=xmlns(my,http://my)""",
             ),
             "wb",
         ) as f:
@@ -4818,7 +4818,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
   </fes:PropertyIsGreaterThan>
  </fes:And>
 </fes:Filter>
-&NAMESPACES=xmlns(my,http://my)&NAMESPACE=xmlns(my,http://my)""",
+&NAMESPACES=xmlns(my,http://my)""",
             ),
             "wb",
         ) as f:
@@ -4869,7 +4869,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
   </fes:PropertyIsEqualTo>
  </fes:And>
 </fes:Filter>
-&NAMESPACES=xmlns(my,http://my)&NAMESPACE=xmlns(my,http://my)""",
+&NAMESPACES=xmlns(my,http://my)""",
             ),
             "wb",
         ) as f:


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/62863