### PR TITLE
[FEATURE] Add a setting variable to remember the last used export DPI

### DIFF
--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -66,7 +66,8 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
   mDevicePixelRatio = ms.devicePixelRatio();
   mLockAspectRatio->setLocked( true );
 
-  mResolutionSpinBox->setValue( static_cast<int>( std::round( mDpi ) ) );
+  QgsSettings settings;
+  mResolutionSpinBox->setValue( settings.value( QStringLiteral( "UI/lastExportDpi" ), static_cast<int>( std::round( mDpi ) ) ).toInt() );
 
   mExtentGroupBox->setOutputCrs( ms.destinationCrs() );
   mExtentGroupBox->setCurrentExtent( mExtent, ms.destinationCrs() );
@@ -393,6 +394,9 @@ void QgsMapSaveDialog::lockChanged( const bool locked )
 
 void QgsMapSaveDialog::copyToClipboard()
 {
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "UI/lastExportDpi" ), mResolutionSpinBox->value() );
+
   QgsMapSettings ms = QgsMapSettings();
   applyMapSettings( ms );
 
@@ -457,6 +461,9 @@ void QgsMapSaveDialog::accept()
 
 void QgsMapSaveDialog::onAccepted()
 {
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "UI/lastExportDpi" ), mResolutionSpinBox->value() );
+
   switch ( mDialogType )
   {
     case Image:


### PR DESCRIPTION
## Description

This PR introduces a `QgsSettings` variable to remember the last used export DPI, covering both `Save` and `Copy to Clipboard` actions.
I successfully built QGIS locally on Arch Linux, and the feature works as expected.
~~**Note**: my local build was based on `tags/final-3_40_10`, while this PR targets `master`.~~

## Why

As mentioned in issue #41318 and also based on my own productivity needs, I believe this is a valuable improvement. I’d appreciate your review and feedback.

[EDIT]
Local built based on both `tags/final-3_40_10` and `master`(this PR's branch) works as expected.