### PR TITLE
Retain non-bounding double quotes in paths

### DIFF
--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -115,7 +115,7 @@ QStringList QgsFileWidget::splitFilePaths( const QString &path )
 
   QgsMessageLog::logMessage( "# Final Paths", "PathQuoteProcessing", Qgis::MessageLevel::Warning );
 
-  const thread_local QRegularExpression cleanRe( QStringLiteral( "(^\\s*\")|(\"\\s*$)" ) );
+  const thread_local QRegularExpression cleanRe( QStringLiteral( "(^\\s*('|\"))|(('|\")\\s*$)" ) );
   paths.reserve( pathParts.size() );
   for ( const QString &pathsPart : pathParts )
   {

--- a/tests/src/gui/testqgsfilewidget.cpp
+++ b/tests/src/gui/testqgsfilewidget.cpp
@@ -209,6 +209,26 @@ void TestQgsFileWidget::testSplitFilePaths()
   QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( " \"%1\"   \"%1\" " ).arg( path ) ), QStringList() << path << path );
   QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( "\"%1\"   \"%1\" " ).arg( path ) ), QStringList() << path << path );
   QCOMPARE( QgsFileWidget::splitFilePaths( path ), QStringList() << path );
+
+  const QString pathPrefixed = QString( TEST_DATA_DIR + QStringLiteral( "ZARR:\"/path/to/store.zarr\"" ) );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( "\"%1\" \"%1\"" ).arg( pathPrefixed ) ), QStringList() << pathPrefixed << pathPrefixed );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( "\"%1\"   \"%1\"" ).arg( pathPrefixed ) ), QStringList() << pathPrefixed << pathPrefixed );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( " \"%1\"   \"%1\"" ).arg( pathPrefixed ) ), QStringList() << pathPrefixed << pathPrefixed );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( " \"%1\"   \"%1\" " ).arg( pathPrefixed ) ), QStringList() << pathPrefixed << pathPrefixed );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( "\"%1\"   \"%1\" " ).arg( pathPrefixed ) ), QStringList() << pathPrefixed << pathPrefixed );
+  QCOMPARE( QgsFileWidget::splitFilePaths( pathPrefixed ), QStringList() << pathPrefixed );
+
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( "\"%1\" \"%2\"" ).arg( path, pathPrefixed ) ), QStringList() << path << pathPrefixed );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( "\"%1\"   \"%2\"" ).arg( path, pathPrefixed ) ), QStringList() << path << pathPrefixed );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( " \"%1\"   \"%2\"" ).arg( path, pathPrefixed ) ), QStringList() << path << pathPrefixed );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( " \"%1\"   \"%2\" " ).arg( path, pathPrefixed ) ), QStringList() << path << pathPrefixed );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( "\"%1\"   \"%2\" " ).arg( path, pathPrefixed ) ), QStringList() << path << pathPrefixed );
+
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( "\"%1\" \"%2\"" ).arg( pathPrefixed, path ) ), QStringList() << pathPrefixed << path );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( "\"%1\"   \"%2\"" ).arg( pathPrefixed, path ) ), QStringList() << pathPrefixed << path );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( " \"%1\"   \"%2\"" ).arg( pathPrefixed, path ) ), QStringList() << pathPrefixed << path );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( " \"%1\"   \"%2\" " ).arg( pathPrefixed, path ) ), QStringList() << pathPrefixed << path );
+  QCOMPARE( QgsFileWidget::splitFilePaths( QStringLiteral( "\"%1\"   \"%2\" " ).arg( pathPrefixed, path ) ), QStringList() << pathPrefixed << path );
 }
 
 QGSTEST_MAIN( TestQgsFileWidget )


### PR DESCRIPTION
## Description

This PR addresses #62837 and implements the second approach identified in [this comment](https://github.com/qgis/QGIS/issues/62837#issuecomment-3198345715) to only strip wrapping double quotes, instead of all double quotes.

Existing tests targeting `QgsFileWidget::splitFilePaths` are unchanged and pass. Additional tests designed to validate new behaviour also pass.

The intent of `QgsFileWidget::splitFilePaths` is to support multiple double-quoted and space-separated paths provided via the file widget. Previously, `path` was split on double quote pairs separated by whitespace. This produced one or more path parts that may have leading or trailing double quotes, which were then stripped if present.

This change ensures that double quotes are only stripped from split `path` parts if those double quotes wrap the entire part. This does not change how the function handles multiple double-quoted and space-separated paths, however it does give the user more control over the resulting string.

## Before This Change

<img width="1008" height="746" alt="62837-before" src="https://github.com/user-attachments/assets/ba88790f-22bc-430a-ba28-abbc569a9892" />

## After This Change

<img width="1090" height="828" alt="62837-after" src="https://github.com/user-attachments/assets/4b699e44-c374-4e92-a2ff-b9212921549c" />
