### PR TITLE
Workaround bug in Qt6 ODBC driver

### DIFF
--- a/tests/src/python/test_provider_mssql.py
+++ b/tests/src/python/test_provider_mssql.py
@@ -928,14 +928,14 @@ class TestPyQgsMssqlProvider(QgisTestCase, MssqlProviderTestBase):
         fields = vl.fields()
 
         f = next(
-            vl.getFeatures(QgsFeatureRequest().setFilterExpression("pk3 = 3.14159274"))
+            vl.getFeatures(QgsFeatureRequest().setFilterExpression("pk3 = 3.141592741"))
         )
         # first of all: we must be able to fetch a valid feature
         self.assertTrue(f.isValid())
         self.assertEqual(f["pk1"], 1)
         self.assertEqual(f["pk2"], 2)
 
-        self.assertAlmostEqual(f["pk3"], 3.14159274, 5)
+        self.assertAlmostEqual(f["pk3"], 3.141592741, 8)
         self.assertEqual(f["value"], "test 2")
 
         # can we edit a field?
@@ -951,13 +951,12 @@ class TestPyQgsMssqlProvider(QgisTestCase, MssqlProviderTestBase):
         )
         self.assertTrue(vl2.isValid())
         f2 = next(
-            vl.getFeatures(QgsFeatureRequest().setFilterExpression("pk3 = 3.14159274"))
+            vl.getFeatures(QgsFeatureRequest().setFilterExpression("pk3 = 3.141592741"))
         )
         self.assertTrue(f2.isValid())
 
         # just making sure we have the correct feature
-        # Only 6 decimals for PostgreSQL 11.
-        self.assertAlmostEqual(f2["pk3"], 3.14159274, 5)
+        self.assertAlmostEqual(f2["pk3"], 3.141592741, 8)
 
         # Then, making sure we really did change our value.
         self.assertEqual(f2["value"], "Edited Test 2")

--- a/tests/testdata/provider/testdata_mssql.sql
+++ b/tests/testdata/provider/testdata_mssql.sql
@@ -288,7 +288,7 @@ CREATE TABLE [qgis_test].[tb_test_composite_float_pk]
 (
     pk1 integer,
     pk2 bigint,
-    pk3 real,
+    pk3 float,
     value nvarchar(16),
     geom geometry,
     PRIMARY KEY (pk1, pk2, pk3)


### PR DESCRIPTION
Use float instead of real for column. Qt6 is incorrectly reading 'real' column values as string values only, leading to truncation of decimals.

(It seems that QSqlDatabase may be ignoring the numerical precision policy set on the database for the ODBC driver, at least for 'real' column types)

**I don't have the specific SQL Server knowledge to understand if this a critical issue, or whether use of 'real' for the column types implies a low-precision value inherently. All I'm doing here is hiding the issue by changing our CI tests to use float values instead!**