### PR TITLE
Fix crash in QgsAbstractProjectStoredObjectManager on qt6

### DIFF
--- a/src/core/elevation/qgselevationprofilemanager.cpp
+++ b/src/core/elevation/qgselevationprofilemanager.cpp
@@ -29,7 +29,10 @@ QgsElevationProfileManager::QgsElevationProfileManager( QgsProject *project )
   connect( this, &QgsProjectStoredObjectManagerBase::objectAboutToBeRemoved, this, &QgsElevationProfileManager::profileAboutToBeRemoved );
 }
 
-QgsElevationProfileManager::~QgsElevationProfileManager() = default;
+QgsElevationProfileManager::~QgsElevationProfileManager()
+{
+  clearObjects();
+}
 
 bool QgsElevationProfileManager::addProfile( QgsElevationProfile *profile )
 {

--- a/src/core/layout/qgslayoutmanager.cpp
+++ b/src/core/layout/qgslayoutmanager.cpp
@@ -35,7 +35,10 @@ QgsLayoutManager::QgsLayoutManager( QgsProject *project )
   connect( this, &QgsProjectStoredObjectManagerBase::objectAboutToBeRemoved, this, &QgsLayoutManager::layoutAboutToBeRemoved );
 }
 
-QgsLayoutManager::~QgsLayoutManager() = default;
+QgsLayoutManager::~QgsLayoutManager()
+{
+  clearObjects();
+}
 
 bool QgsLayoutManager::addLayout( QgsMasterLayoutInterface *layout )
 {

--- a/src/core/project/qgsprojectstoredobjectmanager.cpp
+++ b/src/core/project/qgsprojectstoredobjectmanager.cpp
@@ -47,6 +47,7 @@ QgsAbstractProjectStoredObjectManager<T>::QgsAbstractProjectStoredObjectManager(
 template<class T>
 QgsAbstractProjectStoredObjectManager<T>::~QgsAbstractProjectStoredObjectManager()
 {
+  Q_ASSERT_X( mObjects.isEmpty(), "~QgsAbstractProjectStoredObjectManager", "Subclasses of QgsAbstractProjectStoredObjectManager MUST explicitly call clearObjects() in their class destructor." );
   clearObjects();
 }
 


### PR DESCRIPTION
Debug enabled qt6 builds crash when QgsAbstractProjectStoredObjectManager are called, as the base class destructor tries to emit a signal after the derived class destructor has been executed. This triggers an assert in Qt6.

We need to explicitly clear the objects in the derived class destructors, so that the "XXXremoved" signals are emitted from the derived class destructor in order to avoid this assert.
