### PR TITLE
Fix processing_gui test on qt6

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -2,7 +2,6 @@
 test_core_compositionconverter
 test_core_labelingengine
 test_core_layoutpicture
-test_gui_processinggui
 test_app_advanceddigitizing
 test_app_vertextool
 

--- a/src/gui/processing/qgsprocessingaggregatewidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingaggregatewidgetwrapper.cpp
@@ -77,6 +77,11 @@ void QgsProcessingAggregatePanelWidget::setLayer( QgsVectorLayer *layer )
     return;
   }
 
+  if ( mSkipConfirmDialog )
+  {
+    return;
+  }
+
   QMessageBox dlg( this );
   dlg.setText( tr( "Do you want to reset the field mapping?" ) );
   dlg.setStandardButtons(

--- a/src/gui/processing/qgsprocessingaggregatewidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingaggregatewidgetwrapper.h
@@ -60,6 +60,9 @@ class GUI_EXPORT QgsProcessingAggregatePanelWidget : public QgsPanelWidget, priv
 
     QgsVectorLayer *mLayer = nullptr;
     bool mBlockChangedSignal = false;
+
+    bool mSkipConfirmDialog = false;
+    friend class TestProcessingGui;
 };
 
 

--- a/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.cpp
@@ -79,6 +79,11 @@ void QgsProcessingFieldMapPanelWidget::setLayer( QgsVectorLayer *layer )
     return;
   }
 
+  if ( mSkipConfirmDialog )
+  {
+    return;
+  }
+
   QMessageBox dlg( this );
   dlg.setText( tr( "Do you want to reset the field mapping?" ) );
   dlg.setStandardButtons(

--- a/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingfieldmapwidgetwrapper.h
@@ -60,6 +60,8 @@ class GUI_EXPORT QgsProcessingFieldMapPanelWidget : public QgsPanelWidget, priva
     QgsFieldMappingModel *mModel = nullptr;
 
     QgsVectorLayer *mLayer = nullptr;
+    bool mSkipConfirmDialog = false;
+
     bool mBlockChangedSignal = false;
     friend class TestProcessingGui;
 };

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -8791,6 +8791,7 @@ void TestProcessingGui::testDatabaseTableWrapper()
 void TestProcessingGui::testFieldMapWidget()
 {
   QgsProcessingFieldMapPanelWidget widget;
+  widget.mSkipConfirmDialog = true;
 
   QVariantMap map;
   map.insert( QStringLiteral( "name" ), QStringLiteral( "n" ) );
@@ -8862,6 +8863,7 @@ void TestProcessingGui::testFieldMapWrapper()
 
     QgsProcessingContext context;
     QWidget *w = wrapper.createWrappedWidget( context );
+    qobject_cast<QgsProcessingFieldMapPanelWidget *>( w )->mSkipConfirmDialog = true;
 
     QVariantMap map;
     map.insert( QStringLiteral( "name" ), QStringLiteral( "n" ) );
@@ -8920,6 +8922,7 @@ void TestProcessingGui::testFieldMapWrapper()
     param.setParentLayerParameterName( QStringLiteral( "other" ) );
     QgsProcessingFieldMapWidgetWrapper wrapper2( &param, type );
     w = wrapper2.createWrappedWidget( context );
+    qobject_cast<QgsProcessingFieldMapPanelWidget *>( w )->mSkipConfirmDialog = true;
 
     QSignalSpy spy2( &wrapper2, &QgsProcessingFieldMapWidgetWrapper::widgetValueHasChanged );
     wrapper2.setWidgetValue( QVariantList() << map, context );
@@ -9062,6 +9065,7 @@ void TestProcessingGui::testAggregateWrapper()
 
     QgsProcessingContext context;
     QWidget *w = wrapper.createWrappedWidget( context );
+    qobject_cast<QgsProcessingAggregatePanelWidget *>( w )->mSkipConfirmDialog = true;
 
     QVariantMap map;
     map.insert( QStringLiteral( "name" ), QStringLiteral( "n" ) );
@@ -9122,6 +9126,7 @@ void TestProcessingGui::testAggregateWrapper()
     param.setParentLayerParameterName( QStringLiteral( "other" ) );
     QgsProcessingAggregateWidgetWrapper wrapper2( &param, type );
     w = wrapper2.createWrappedWidget( context );
+    qobject_cast<QgsProcessingAggregatePanelWidget *>( w )->mSkipConfirmDialog = true;
 
     QSignalSpy spy2( &wrapper2, &QgsProcessingAggregateWidgetWrapper::widgetValueHasChanged );
     wrapper2.setWidgetValue( QVariantList() << map, context );


### PR DESCRIPTION
The test was only passing on qt5 builds because QMessageBox::exec was immediately returning false WITHOUT showing the dialog. On Qt 6 builds the dialog WAS correctly showing, and since its a blocking dialog it hangs the test.

Workaround by disabling the confirmation dialog when running as unit tests.
