### PR TITLE
Report attempt to render invalid layers as a rendering error

### DIFF
--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -873,11 +873,13 @@ calculations only) then ``includeLayerSettings`` should be ``False``.
     virtual void finalizeRestoreFromXml();
 
 
-    QList<QgsMapLayer *> layersToRender( const QgsExpressionContext *context = 0 ) const;
+    QList<QgsMapLayer *> layersToRender( const QgsExpressionContext *context = 0, bool includeInvalidLayers = false ) const;
 %Docstring
 Returns a list of the layers which will be rendered within this map
 item, considering any locked layers, linked map theme, and data defined
 settings.
+
+:param includeInvalidLayers: include invalid layers in the maplayer list
 %End
 
     void addLabelBlockingItem( QgsLayoutItem *item );

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -879,6 +879,7 @@ Returns a list of the layers which will be rendered within this map
 item, considering any locked layers, linked map theme, and data defined
 settings.
 
+:param context: the expression context
 :param includeInvalidLayers: include invalid layers in the maplayer list
 %End
 

--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -873,11 +873,13 @@ calculations only) then ``includeLayerSettings`` should be ``False``.
     virtual void finalizeRestoreFromXml();
 
 
-    QList<QgsMapLayer *> layersToRender( const QgsExpressionContext *context = 0 ) const;
+    QList<QgsMapLayer *> layersToRender( const QgsExpressionContext *context = 0, bool includeInvalidLayers = false ) const;
 %Docstring
 Returns a list of the layers which will be rendered within this map
 item, considering any locked layers, linked map theme, and data defined
 settings.
+
+:param includeInvalidLayers: include invalid layers in the maplayer list
 %End
 
     void addLabelBlockingItem( QgsLayoutItem *item );

--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -879,6 +879,7 @@ Returns a list of the layers which will be rendered within this map
 item, considering any locked layers, linked map theme, and data defined
 settings.
 
+:param context: the expression context
 :param includeInvalidLayers: include invalid layers in the maplayer list
 %End
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1606,7 +1606,7 @@ void QgsLayoutItemMap::drawMap( QPainter *painter, const QgsRectangle &extent, Q
   QgsExpressionContext expressionContext = createExpressionContext();
   if ( layersToRender( &expressionContext, false ).size() != layersToRender( &expressionContext, true ).size() )
   {
-    mRenderingErrors.append( QgsMapRendererJob::Error( QStringLiteral( "" ), QStringLiteral( "Invalid layer(s)" ) ) );
+    mRenderingErrors.append( QgsMapRendererJob::Error( QString(), QStringLiteral( "Invalid layer(s)" ) ) );
   }
 }
 

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -323,7 +323,7 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
   public:
 
     /**
-     * Settings entry - Whether to force rasterised clipping masks, regardless of output format.
+     * Settings entry - Whether to force rasterized clipping masks, regardless of output format.
      *
      * \since QGIS 4.0
      */
@@ -776,8 +776,9 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
     /**
      * Returns a list of the layers which will be rendered within this map item, considering
      * any locked layers, linked map theme, and data defined settings.
+     * \param includeInvalidLayers include invalid layers in the maplayer list
      */
-    QList<QgsMapLayer *> layersToRender( const QgsExpressionContext *context = nullptr ) const;
+    QList<QgsMapLayer *> layersToRender( const QgsExpressionContext *context = nullptr, bool includeInvalidLayers = false ) const;
 
     /**
      * Sets the specified layout \a item as a "label blocking item" for this map.

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -776,6 +776,7 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRan
     /**
      * Returns a list of the layers which will be rendered within this map item, considering
      * any locked layers, linked map theme, and data defined settings.
+     * \param context the expression context
      * \param includeInvalidLayers include invalid layers in the maplayer list
      */
     QList<QgsMapLayer *> layersToRender( const QgsExpressionContext *context = nullptr, bool includeInvalidLayers = false ) const;

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -568,6 +568,7 @@ std::vector<LayerRenderJob> QgsMapRendererJob::prepareJobs( QPainter *painter, Q
     if ( !ml->isValid() )
     {
       QgsDebugMsgLevel( QStringLiteral( "Invalid Layer skipped" ), 3 );
+      mErrors.append( Error( ml->id(), QString( "Layer %1 is invalid, skipped" ).arg( ml->name() ) ) );
       continue;
     }
 


### PR DESCRIPTION
QgsMapRendererJob reports errors during rendering (QgsMapRendererJob::mErrors) . In the server case, it is sometimes really important that the created maps/prints contain all features and GetMap/GetPrint return an error if a datasource is unavailable (GetCapabilities on the other side can always be available). Therefore an attempt to render an invalid layer could be reported as a rendering error and handled by the server (or any other part of QGIS if necessary)

What is your opinion about this?