### PR TITLE
Fix edit widgets test on qt 6

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -30,7 +30,6 @@ PyQgsStyleStorageMssql
 # To be fixed
 PyQgsAnnotation
 PyQgsAuthenticationSystem
-PyQgsEditWidgets
 PyQgsLayoutHtml
 PyQgsPalLabelingPlacement
 PyQgsRasterLayerRenderer

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -474,7 +474,16 @@ void QgsValueRelationWidgetWrapper::updateValue( const QVariant &value, bool for
       // if value doesn't exist, we show it in '(...)' (just like value map widget)
       if ( QgsVariantUtils::isNull( value ) || !forceComboInsertion )
       {
-        mComboBox->setCurrentIndex( -1 );
+        // we might have an explicit item for null (e.g. "no selection"), if so, set to that
+        for ( int i = 0; i < mComboBox->count(); i++ )
+        {
+          if ( QgsVariantUtils::isNull( mComboBox->itemData( i ) ) )
+          {
+            idx = i;
+            break;
+          }
+        }
+        mComboBox->setCurrentIndex( idx );
       }
       else
       {

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -263,8 +263,8 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   // Check null is selected
   QCOMPARE( w_municipality.mComboBox->count(), 3 );
   QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "(no selection)" ) );
-  QVERIFY( w_municipality.value().isNull() );
-  QCOMPARE( w_municipality.value().toString(), QString() );
+  QCOMPARE( w_municipality.mComboBox->currentIndex(), 0 );
+  QVERIFY( QgsVariantUtils::isNull( w_municipality.value() ) );
 
   // Check order by value false
   cfg_municipality[QStringLiteral( "AllowNull" )] = false;


### PR DESCRIPTION
Differences in null/invalid qvariant handling on qt6 meant that we weren't setting the combobox index to the existing entry with a null (but not invalid) qvariant user data
