### PR TITLE
Fix aliasing of clipped raster renders on qt 6

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -31,7 +31,6 @@ PyQgsStyleStorageMssql
 PyQgsAnnotation
 PyQgsAuthenticationSystem
 PyQgsLayoutHtml
-PyQgsRasterLayerRenderer
 PyQgsSettings
 PyQgsSettingsEntry
 ProcessingQgisAlgorithmsTestPt4

--- a/src/core/raster/qgsrasterdrawer.cpp
+++ b/src/core/raster/qgsrasterdrawer.cpp
@@ -142,7 +142,7 @@ void QgsRasterDrawer::drawImage( QPainter *p, QgsRasterViewPort *viewPort, const
   const QPoint tlPoint = QPoint( std::floor( viewPort->mTopLeftPoint.x() + topLeftCol / mDpiScaleFactor / mDevicePixelRatio ),
                                  std::floor( viewPort->mTopLeftPoint.y() + topLeftRow / mDpiScaleFactor / mDevicePixelRatio ) );
   const QgsScopedQPainterState painterState( p );
-  p->setRenderHint( QPainter::Antialiasing, false );
+
   // Improve rendering of rasters on high DPI screens with Qt's auto scaling enabled
   if ( !qgsDoubleNear( mDevicePixelRatio, 1.0 ) || !qgsDoubleNear( mDpiScaleFactor, 1.0 ) )
   {

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -543,8 +543,7 @@ bool QgsRasterLayerRenderer::render()
 
   // important -- disable SmoothPixmapTransform and Antialiasing for raster layer renders. We want individual pixels to be clearly defined!
   renderContext()->painter()->setRenderHint( QPainter::SmoothPixmapTransform, false );
-  renderContext()->painter()->setRenderHint( QPainter::Antialiasing, false );
-
+  bool antialiasEnabled = false;
   if ( !mClippingRegions.empty() )
   {
     bool needsPainterClipPath = false;
@@ -557,9 +556,10 @@ bool QgsRasterLayerRenderer::render()
       // rendered using antialiasing along the clip path, or things are very ugly! And since we can't
       // selectively antialias JUST the clip path boundary, we fallback to antialiasing the
       // whole raster render
-      renderContext()->painter()->setRenderHint( QPainter::Antialiasing, true );
+      antialiasEnabled = true;
     }
   }
+  renderContext()->painter()->setRenderHint( QPainter::Antialiasing, antialiasEnabled );
 
   QgsRasterProjector *projector = mPipe->projector();
   bool restoreOldResamplingStage = false;

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -540,6 +540,11 @@ bool QgsRasterLayerRenderer::render()
   //
 
   const QgsScopedQPainterState painterSate( renderContext()->painter() );
+
+  // important -- disable SmoothPixmapTransform and Antialiasing for raster layer renders. We want individual pixels to be clearly defined!
+  renderContext()->painter()->setRenderHint( QPainter::SmoothPixmapTransform, false );
+  renderContext()->painter()->setRenderHint( QPainter::Antialiasing, false );
+
   if ( !mClippingRegions.empty() )
   {
     bool needsPainterClipPath = false;
@@ -566,9 +571,6 @@ bool QgsRasterLayerRenderer::render()
     }
     projector->setCrs( mRasterViewPort->mSrcCRS, mRasterViewPort->mDestCRS, mRasterViewPort->mTransformContext );
   }
-
-  // important -- disable SmoothPixmapTransform for raster layer renders. We want individual pixels to be clearly defined!
-  renderContext()->painter()->setRenderHint( QPainter::SmoothPixmapTransform, false );
 
   preparingProfile.reset();
   std::unique_ptr< QgsScopedRuntimeProfile > renderingProfile;

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -550,7 +550,15 @@ bool QgsRasterLayerRenderer::render()
     bool needsPainterClipPath = false;
     const QPainterPath path = QgsMapClippingUtils::calculatePainterClipRegion( mClippingRegions, *renderContext(), Qgis::LayerType::Raster, needsPainterClipPath );
     if ( needsPainterClipPath )
+    {
       renderContext()->painter()->setClipPath( path, Qt::IntersectClip );
+      // this is an exception to the earlier flag disabling antialiasing!
+      // If we are rendering with clip paths, we WANT the boundaries of the raster to be
+      // rendered using antialiasing along the clip path, or things are very ugly! And since we can't
+      // selectively antialias JUST the clip path boundary, we fallback to antialiasing the
+      // whole raster render
+      renderContext()->painter()->setRenderHint( QPainter::Antialiasing, true );
+    }
   }
 
   QgsRasterProjector *projector = mPipe->projector();


### PR DESCRIPTION
Match the rendering of raster layers with clipping paths to the same appearance as Qt 5, where the clip path forces the raster
to be rendered with antialiasing in order to get nice appearance along the clip path boundaries