### PR TITLE
Add create or delete Spatial Index to the Manage menu in Browser

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1964,7 +1964,7 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
 
       QgsAbstractDatabaseProviderConnection::TableProperty tableProperty = conn->table( item->parent()->name(), item->name() );
 
-      bool indexExist = conn->spatialIndexExists( tableProperty.schema(), tableProperty.tableName(), tableProperty.geometryColumn() );
+      const bool indexExist = conn->spatialIndexExists( tableProperty.schema(), tableProperty.tableName(), tableProperty.geometryColumn() );
 
       // this action should sit in the Manage menu. If one does not exist, create it now
       bool foundExistingManageMenu = false;


### PR DESCRIPTION
## Description

Add context menu to **create** or **delete** Spatial Index into **Manage** table menu for providers that support addition and removal of spatial indexes.

<img width="558" height="212" alt="2025-08-27-13-23-14" src="https://github.com/user-attachments/assets/25ecdb84-172b-4af1-9625-5d708525c349" />

<img width="571" height="206" alt="2025-08-27-13-22-59" src="https://github.com/user-attachments/assets/83446027-d31c-42c2-80a1-884d1ca12f9d" />

Funded by Ocean Winds
