### PR TITLE
[themes][ui] Fix color for disabled, read-only line edits/widgets for dark themes

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -224,7 +224,7 @@ QMenu::indicator
     width: 0em;
 }
 
-QWidget:disabled, QWidget:editable:disabled
+QWidget:disabled, QWidget:editable:disabled, QWidget:read-only:disabled
 {
     color: @itemalternativebackground;
     background-color: @background;

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -215,7 +215,7 @@ QMenu::indicator
     width: 0em;
 }
 
-QWidget:disabled, QWidget:editable:disabled
+QWidget:disabled, QWidget:editable:disabled, QWidget:read-only:disabled
 {
     color: @itemdarkbackground;
     background-color: @background;


### PR DESCRIPTION
## Description

This PR fixes the incorrect text color of read-only line edits that are also disabled in dark themes.

The issue can be observed in the *Geometry* section of the *Create a Virtual Layer* dialog:

<img width="619" height="259" alt="lineedit_before" src="https://github.com/user-attachments/assets/06c48ae7-43f9-4c21-a38e-2e131e66c516" />

After applying the proposed changes to the Style Sheet, the colors match the theme again:

![lineedit_after](https://github.com/user-attachments/assets/86404f79-012d-4aa9-b555-40daab8c8ba9)

The fix also makes sure that other disabled, read-only widgets will have the correct color matching the theme.

I think the changes can be safely backported.