### PR TITLE
Fix referencingLayersElement not being added in writeSymbology

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -3072,7 +3072,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
 
       // Store referencing layers: relations where "this" is the parent layer (the referenced part, that holds the FK)
       QDomElement referencingLayersElement = doc.createElement( QStringLiteral( "referencingLayers" ) );
-      node.appendChild( referencedLayersElement );
+      node.appendChild( referencingLayersElement );
 
       const QList<QgsRelation> referencedRelations { p->relationManager()->referencedRelations( this ) };
       for ( const QgsRelation &rel : referencedRelations )


### PR DESCRIPTION
## Description

I was testing out the layer relation feature and ran into an issue where child -> parent relations would load from saved layer styles but parent -> child relations would not. Tracked it down to QgsVectorLayer::writeSymbology where the referencingLayersElement is created but never added to the node.

https://github.com/qgis/QGIS/issues/62970
