### PR TITLE
Fix QVariant comparison functions and operators

### DIFF
--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -3807,7 +3807,7 @@ for incorrect numbers of digits between thousand separators
 .. versionadded:: 3.4
 %End
 
-int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs );
+int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs, bool strictTypeCheck = false );
 %Docstring
 Compares two QVariant values.
 
@@ -3818,6 +3818,10 @@ various QVariant data types (such as strings, numeric values, dates and
 times)
 
 Invalid < NULL < Values
+
+Since QGIS 4.0 the ``strictTypeCheck`` argument can be used to specify
+that variants of different types should be compared using their userType
+ID only, and not attempt to check the actual variant value.
 
 .. seealso:: :py:func:`qgsVariantLessThan`
 

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -3807,7 +3807,7 @@ for incorrect numbers of digits between thousand separators
 .. versionadded:: 3.4
 %End
 
-int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs );
+int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs, bool strictTypeCheck = false );
 %Docstring
 Compares two QVariant values.
 
@@ -3818,6 +3818,10 @@ various QVariant data types (such as strings, numeric values, dates and
 times)
 
 Invalid < NULL < Values
+
+Since QGIS 4.0 the ``strictTypeCheck`` argument can be used to specify
+that variants of different types should be compared using their userType
+ID only, and not attempt to check the actual variant value.
 
 .. seealso:: :py:func:`qgsVariantLessThan`
 

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -169,6 +169,14 @@ int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs, bool strictType
           return lhsInt < rhsInt ? -1 : ( lhsInt == rhsInt ? 0 : 1 );
         }
 
+        case QMetaType::Type::Long:
+        case QMetaType::Type::LongLong:
+        {
+          const long long lhsInt = lhs.toLongLong();
+          const long long rhsInt = rhs.toLongLong();
+          return lhsInt < rhsInt ? -1 : ( lhsInt == rhsInt ? 0 : 1 );
+        }
+
         case QMetaType::Type::Double:
         case QMetaType::Type::Float:
         {
@@ -223,6 +231,47 @@ int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs, bool strictType
           return lhsUInt < rhsUInt ? -1 : ( lhsUInt == rhsUInt ? 0 : 1 );
         }
 
+        case QMetaType::Type::ULong:
+        case QMetaType::Type::ULongLong:
+        {
+          const qulonglong lhsInt = lhs.toULongLong();
+          const qulonglong rhsInt = rhs.toULongLong();
+          return lhsInt < rhsInt ? -1 : ( lhsInt == rhsInt ? 0 : 1 );
+        }
+
+        case QMetaType::Type::Double:
+        case QMetaType::Type::Float:
+        {
+          const double lhsDouble = static_cast< double >( lhs.toUInt() );
+          const double rhsDouble = rhs.toDouble();
+
+          // consider NaN < any non-NaN
+          const bool lhsIsNan = std::isnan( lhsDouble );
+          const bool rhsIsNan = std::isnan( rhsDouble );
+          if ( lhsIsNan )
+          {
+            return rhsIsNan ? 0 : -1;
+          }
+          else if ( rhsIsNan )
+          {
+            return 1;
+          }
+
+          return lhsDouble < rhsDouble ? -1 : ( lhsDouble == rhsDouble ? 0 : 1 );
+        }
+
+        case QMetaType::Type::QString:
+        {
+          bool ok = false;
+          const double rhsDouble = rhs.toDouble( &ok );
+          if ( ok )
+          {
+            const double lhsDouble = static_cast< double >( lhs.toUInt() );
+            return lhsDouble < rhsDouble ? -1 : ( lhsDouble == rhsDouble ? 0 : 1 );
+          }
+          break;
+        }
+
         default:
           break;
       }
@@ -234,12 +283,48 @@ int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs, bool strictType
     {
       switch ( rhs.userType() )
       {
+        case QMetaType::Type::Int:
+        case QMetaType::Type::Char:
+        case QMetaType::Type::Short:
         case QMetaType::Type::LongLong:
         case QMetaType::Type::Long:
         {
           const qlonglong lhsLongLong = lhs.toLongLong();
           const qlonglong rhsLongLong = rhs.toLongLong();
           return lhsLongLong < rhsLongLong ? -1 : ( lhsLongLong == rhsLongLong ? 0 : 1 );
+        }
+
+        case QMetaType::Type::Double:
+        case QMetaType::Type::Float:
+        {
+          const double lhsDouble = static_cast< double >( lhs.toLongLong() );
+          const double rhsDouble = rhs.toDouble();
+
+          // consider NaN < any non-NaN
+          const bool lhsIsNan = std::isnan( lhsDouble );
+          const bool rhsIsNan = std::isnan( rhsDouble );
+          if ( lhsIsNan )
+          {
+            return rhsIsNan ? 0 : -1;
+          }
+          else if ( rhsIsNan )
+          {
+            return 1;
+          }
+
+          return lhsDouble < rhsDouble ? -1 : ( lhsDouble == rhsDouble ? 0 : 1 );
+        }
+
+        case QMetaType::Type::QString:
+        {
+          bool ok = false;
+          const double rhsDouble = rhs.toDouble( &ok );
+          if ( ok )
+          {
+            const double lhsDouble = static_cast< double >( lhs.toLongLong() );
+            return lhsDouble < rhsDouble ? -1 : ( lhsDouble == rhsDouble ? 0 : 1 );
+          }
+          break;
         }
 
         default:
@@ -253,6 +338,9 @@ int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs, bool strictType
     {
       switch ( rhs.userType() )
       {
+        case QMetaType::Type::UInt:
+        case QMetaType::Type::UChar:
+        case QMetaType::Type::UShort:
         case QMetaType::Type::ULongLong:
         case QMetaType::Type::ULong:
         {

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -158,134 +158,341 @@ int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs, bool strictType
     case QMetaType::Type::Char:
     case QMetaType::Type::Short:
     {
-      const int lhsInt = lhs.toInt();
-      const int rhsInt = rhs.toInt();
-      return lhsInt < rhsInt ? -1 : ( lhsInt == rhsInt ? 0 : 1 );
+      switch ( rhs.userType() )
+      {
+        case QMetaType::Type::Int:
+        case QMetaType::Type::Char:
+        case QMetaType::Type::Short:
+        {
+          const int lhsInt = lhs.toInt();
+          const int rhsInt = rhs.toInt();
+          return lhsInt < rhsInt ? -1 : ( lhsInt == rhsInt ? 0 : 1 );
+        }
+
+        case QMetaType::Type::Double:
+        case QMetaType::Type::Float:
+        {
+          const double lhsDouble = static_cast< double >( lhs.toInt() );
+          const double rhsDouble = rhs.toDouble();
+
+          // consider NaN < any non-NaN
+          const bool lhsIsNan = std::isnan( lhsDouble );
+          const bool rhsIsNan = std::isnan( rhsDouble );
+          if ( lhsIsNan )
+          {
+            return rhsIsNan ? 0 : -1;
+          }
+          else if ( rhsIsNan )
+          {
+            return 1;
+          }
+
+          return lhsDouble < rhsDouble ? -1 : ( lhsDouble == rhsDouble ? 0 : 1 );
+        }
+
+        case QMetaType::Type::QString:
+        {
+          bool ok = false;
+          const double rhsDouble = rhs.toDouble( &ok );
+          if ( ok )
+          {
+            const double lhsDouble = static_cast< double >( lhs.toInt() );
+            return lhsDouble < rhsDouble ? -1 : ( lhsDouble == rhsDouble ? 0 : 1 );
+          }
+          break;
+        }
+
+        default:
+          break;
+      }
+      break;
     }
+
     case QMetaType::Type::UInt:
     case QMetaType::Type::UChar:
     case QMetaType::Type::UShort:
     {
-      const uint lhsUInt = lhs.toUInt();
-      const uint rhsUInt = rhs.toUInt();
-      return lhsUInt < rhsUInt ? -1 : ( lhsUInt == rhsUInt ? 0 : 1 );
+      switch ( rhs.userType() )
+      {
+        case QMetaType::Type::UInt:
+        case QMetaType::Type::UChar:
+        case QMetaType::Type::UShort:
+        {
+          const uint lhsUInt = lhs.toUInt();
+          const uint rhsUInt = rhs.toUInt();
+          return lhsUInt < rhsUInt ? -1 : ( lhsUInt == rhsUInt ? 0 : 1 );
+        }
+
+        default:
+          break;
+      }
+      break;
     }
+
     case QMetaType::Type::LongLong:
     case QMetaType::Type::Long:
     {
-      const qlonglong lhsLongLong = lhs.toLongLong();
-      const qlonglong rhsLongLong = rhs.toLongLong();
-      return lhsLongLong < rhsLongLong ? -1 : ( lhsLongLong == rhsLongLong ? 0 : 1 );
+      switch ( rhs.userType() )
+      {
+        case QMetaType::Type::LongLong:
+        case QMetaType::Type::Long:
+        {
+          const qlonglong lhsLongLong = lhs.toLongLong();
+          const qlonglong rhsLongLong = rhs.toLongLong();
+          return lhsLongLong < rhsLongLong ? -1 : ( lhsLongLong == rhsLongLong ? 0 : 1 );
+        }
+
+        default:
+          break;
+      }
+      break;
     }
+
     case QMetaType::Type::ULongLong:
     case QMetaType::Type::ULong:
     {
-      const qulonglong lhsULongLong = lhs.toULongLong();
-      const qulonglong rhsULongLong = rhs.toULongLong();
-      return lhsULongLong < rhsULongLong ? -1 : ( lhsULongLong == rhsULongLong ? 0 : 1 );
+      switch ( rhs.userType() )
+      {
+        case QMetaType::Type::ULongLong:
+        case QMetaType::Type::ULong:
+        {
+          const qulonglong lhsULongLong = lhs.toULongLong();
+          const qulonglong rhsULongLong = rhs.toULongLong();
+          return lhsULongLong < rhsULongLong ? -1 : ( lhsULongLong == rhsULongLong ? 0 : 1 );
+        }
+
+        default:
+          break;
+      }
+      break;
     }
+
     case QMetaType::Type::Double:
     {
-      const double lhsDouble = lhs.toDouble();
-      const double rhsDouble = rhs.toDouble();
-
-      // consider NaN < any non-NaN
-      const bool lhsIsNan = std::isnan( lhsDouble );
-      const bool rhsIsNan = std::isnan( rhsDouble );
-      if ( lhsIsNan )
+      switch ( rhs.userType() )
       {
-        return rhsIsNan ? 0 : -1;
-      }
-      else if ( rhsIsNan )
-      {
-        return 1;
-      }
+        case QMetaType::Type::Int:
+        case QMetaType::Type::Char:
+        case QMetaType::Type::Short:
+        case QMetaType::Type::Double:
+        case QMetaType::Type::Float:
+        case QMetaType::Type::LongLong:
+        case QMetaType::Type::Long:
+        case QMetaType::Type::ULongLong:
+        case QMetaType::Type::ULong:
+        case QMetaType::Type::QString:
+        {
+          const double lhsDouble = lhs.toDouble();
+          bool rhsIsDoubleCompatible = false;
+          const double rhsDouble = rhs.toDouble( &rhsIsDoubleCompatible );
+          if ( rhsIsDoubleCompatible )
+          {
+            // consider NaN < any non-NaN
+            const bool lhsIsNan = std::isnan( lhsDouble );
+            const bool rhsIsNan = std::isnan( rhsDouble );
+            if ( lhsIsNan )
+            {
+              return rhsIsNan ? 0 : -1;
+            }
+            else if ( rhsIsNan )
+            {
+              return 1;
+            }
 
-      return lhsDouble < rhsDouble ? -1 : ( lhsDouble == rhsDouble ? 0 : 1 );
+            return lhsDouble < rhsDouble ? -1 : ( lhsDouble == rhsDouble ? 0 : 1 );
+          }
+          break;
+        }
+
+        default:
+          break;
+      }
+      break;
     }
+
     case QMetaType::Type::Float:
     {
-      const float lhsFloat = lhs.toFloat();
-      const float rhsFloat = rhs.toFloat();
-
-      // consider NaN < any non-NaN
-      const bool lhsIsNan = std::isnan( lhsFloat );
-      const bool rhsIsNan = std::isnan( rhsFloat );
-      if ( lhsIsNan )
+      switch ( rhs.userType() )
       {
-        return rhsIsNan ? 0 : -1;
-      }
-      else if ( rhsIsNan )
-      {
-        return 1;
-      }
+        case QMetaType::Type::Int:
+        case QMetaType::Type::Char:
+        case QMetaType::Type::Short:
+        case QMetaType::Type::Double:
+        case QMetaType::Type::Float:
+        case QMetaType::Type::LongLong:
+        case QMetaType::Type::Long:
+        case QMetaType::Type::ULongLong:
+        case QMetaType::Type::ULong:
+        case QMetaType::Type::QString:
+        {
+          const float lhsFloat = lhs.toFloat();
+          bool rhsIsFloatCompatible = false;
+          const float rhsFloat = rhs.toFloat( &rhsIsFloatCompatible );
+          if ( rhsIsFloatCompatible )
+          {
+            // consider NaN < any non-NaN
+            const bool lhsIsNan = std::isnan( lhsFloat );
+            const bool rhsIsNan = std::isnan( rhsFloat );
+            if ( lhsIsNan )
+            {
+              return rhsIsNan ? 0 : -1;
+            }
+            else if ( rhsIsNan )
+            {
+              return 1;
+            }
 
-      return lhsFloat < rhsFloat ? -1 : ( lhsFloat == rhsFloat ? 0 : 1 );
+            return lhsFloat < rhsFloat ? -1 : ( lhsFloat == rhsFloat ? 0 : 1 );
+          }
+          break;
+        }
+        default:
+          break;
+      }
+      break;
     }
+
     case QMetaType::Type::QChar:
     {
-      const QChar lhsChar = lhs.toChar();
-      const QChar rhsChar = rhs.toChar();
-      return lhsChar < rhsChar ? -1 : ( lhsChar == rhsChar ? 0 : 1 );
+      if ( rhs.userType() == QMetaType::Type::QChar )
+      {
+        const QChar lhsChar = lhs.toChar();
+        const QChar rhsChar = rhs.toChar();
+        return lhsChar < rhsChar ? -1 : ( lhsChar == rhsChar ? 0 : 1 );
+      }
+      break;
     }
+
     case QMetaType::Type::QDate:
     {
-      const QDate lhsDate = lhs.toDate();
-      const QDate rhsDate = rhs.toDate();
-      return lhsDate < rhsDate ? -1 : ( lhsDate == rhsDate ? 0 : 1 );
+      if ( rhs.userType() == QMetaType::Type::QDate )
+      {
+        const QDate lhsDate = lhs.toDate();
+        const QDate rhsDate = rhs.toDate();
+        return lhsDate < rhsDate ? -1 : ( lhsDate == rhsDate ? 0 : 1 );
+      }
+      break;
     }
+
     case QMetaType::Type::QTime:
     {
-      const QTime lhsTime = lhs.toTime();
-      const QTime rhsTime = rhs.toTime();
-      return lhsTime < rhsTime ? -1 : ( lhsTime == rhsTime ? 0 : 1 );
+      if ( rhs.userType() == QMetaType::Type::QTime )
+      {
+        const QTime lhsTime = lhs.toTime();
+        const QTime rhsTime = rhs.toTime();
+        return lhsTime < rhsTime ? -1 : ( lhsTime == rhsTime ? 0 : 1 );
+      }
+      break;
     }
+
     case QMetaType::Type::QDateTime:
     {
-      const QDateTime lhsTime = lhs.toDateTime();
-      const QDateTime rhsTime = rhs.toDateTime();
-      return lhsTime < rhsTime ? -1 : ( lhsTime == rhsTime ? 0 : 1 );
+      if ( rhs.userType() == QMetaType::Type::QDateTime )
+      {
+        const QDateTime lhsTime = lhs.toDateTime();
+        const QDateTime rhsTime = rhs.toDateTime();
+        return lhsTime < rhsTime ? -1 : ( lhsTime == rhsTime ? 0 : 1 );
+      }
+      break;
     }
+
     case QMetaType::Type::Bool:
     {
-      const bool lhsBool = lhs.toBool();
-      const bool rhsBool = rhs.toBool();
-      return lhsBool == rhsBool ? 0 : ( lhsBool ? 1 : -1 );
+      if ( rhs.userType() == QMetaType::Type::Bool )
+      {
+        const bool lhsBool = lhs.toBool();
+        const bool rhsBool = rhs.toBool();
+        return lhsBool == rhsBool ? 0 : ( lhsBool ? 1 : -1 );
+      }
+      break;
     }
 
     case QMetaType::Type::QVariantList:
     {
-      const QList<QVariant> &lhsl = lhs.toList();
-      const QList<QVariant> &rhsl = rhs.toList();
+      if ( rhs.userType() == QMetaType::Type::QVariantList )
+      {
+        const QList<QVariant> &lhsl = lhs.toList();
+        const QList<QVariant> &rhsl = rhs.toList();
 
-      int i, n = std::min( lhsl.size(), rhsl.size() );
-      for ( i = 0; i < n && lhsl[i].userType() == rhsl[i].userType() && qgsVariantCompare( lhsl[i], rhsl[i] ) == 0; i++ )
-        ;
+        int i, n = std::min( lhsl.size(), rhsl.size() );
+        for ( i = 0; i < n && lhsl[i].userType() == rhsl[i].userType() && qgsVariantCompare( lhsl[i], rhsl[i] ) == 0; i++ )
+          ;
 
-      if ( i == n )
-        return lhsl.size() < rhsl.size() ? -1 : ( lhsl.size() > rhsl.size() ? 1 : 0 );
-      else
-        return qgsVariantCompare( lhsl[i], rhsl[i] );
+        if ( i == n )
+          return lhsl.size() < rhsl.size() ? -1 : ( lhsl.size() > rhsl.size() ? 1 : 0 );
+        else
+          return qgsVariantCompare( lhsl[i], rhsl[i] );
+      }
+      break;
     }
 
     case QMetaType::Type::QStringList:
     {
-      const QStringList &lhsl = lhs.toStringList();
-      const QStringList &rhsl = rhs.toStringList();
+      if ( rhs.userType() == QMetaType::Type::QStringList )
+      {
+        const QStringList &lhsl = lhs.toStringList();
+        const QStringList &rhsl = rhs.toStringList();
 
-      int i, n = std::min( lhsl.size(), rhsl.size() );
-      for ( i = 0; i < n && lhsl[i] == rhsl[i]; i++ )
-        ;
+        int i, n = std::min( lhsl.size(), rhsl.size() );
+        for ( i = 0; i < n && lhsl[i] == rhsl[i]; i++ )
+          ;
 
-      if ( i == n )
-        return lhsl.size() < rhsl.size() ? -1 : ( lhsl.size() > rhsl.size() ? 1 : 0 );
-      else
-        return lhsl[i] < rhsl[i] ? -1 : ( lhsl[i] == rhsl[i] ? 0 : 1 );
+        if ( i == n )
+          return lhsl.size() < rhsl.size() ? -1 : ( lhsl.size() > rhsl.size() ? 1 : 0 );
+        else
+          return lhsl[i] < rhsl[i] ? -1 : ( lhsl[i] == rhsl[i] ? 0 : 1 );
+      }
+      break;
+    }
+
+    case QMetaType::Type::QString:
+    {
+      switch ( rhs.userType() )
+      {
+        case QMetaType::Type::Int:
+        case QMetaType::Type::Char:
+        case QMetaType::Type::Short:
+        case QMetaType::Type::Double:
+        case QMetaType::Type::Float:
+        case QMetaType::Type::LongLong:
+        case QMetaType::Type::Long:
+        case QMetaType::Type::ULongLong:
+        case QMetaType::Type::ULong:
+        {
+          // try string to numeric conversion
+          bool lhsIsDoubleCompatible = false;
+          const double lhsDouble = lhs.toDouble( &lhsIsDoubleCompatible );
+          if ( lhsIsDoubleCompatible )
+          {
+            const double rhsDouble = rhs.toDouble();
+            // consider NaN < any non-NaN
+            const bool lhsIsNan = std::isnan( lhsDouble );
+            const bool rhsIsNan = std::isnan( rhsDouble );
+            if ( lhsIsNan )
+            {
+              return rhsIsNan ? 0 : -1;
+            }
+            else if ( rhsIsNan )
+            {
+              return 1;
+            }
+
+            return lhsDouble < rhsDouble ? -1 : ( lhsDouble == rhsDouble ? 0 : 1 );
+          }
+          break;
+        }
+
+        default:
+          break;
+      }
+
+      break;
     }
 
     default:
-      return std::clamp( QString::localeAwareCompare( lhs.toString(), rhs.toString() ), -1, 1 );
+      break;
   }
+  return std::clamp( QString::localeAwareCompare( lhs.toString(), rhs.toString() ), -1, 1 );
 }
 
 bool qgsVariantLessThan( const QVariant &lhs, const QVariant &rhs )

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -126,7 +126,7 @@ void qgsFree( void *ptr )
   free( ptr );
 }
 
-int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs )
+int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs, bool strictTypeCheck )
 {
   // invalid < NULL < any value
   if ( !lhs.isValid() )
@@ -144,6 +144,11 @@ int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs )
   else if ( !rhs.isValid() || rhs.isNull() )
   {
     return 1;
+  }
+
+  if ( strictTypeCheck && lhs.userType() != rhs.userType() )
+  {
+    return lhs.userType() < rhs.userType() ? -1 : 1;
   }
 
   // both valid
@@ -292,7 +297,6 @@ bool qgsVariantGreaterThan( const QVariant &lhs, const QVariant &rhs )
 {
   return qgsVariantCompare( lhs, rhs ) > 0;
 }
-
 
 QString qgsVsiPrefix( const QString &path )
 {
@@ -444,4 +448,3 @@ bool qMapLessThanKey<QVariantList>( const QVariantList &key1, const QVariantList
   return qgsVariantGreaterThan( key1, key2 ) && key1 != key2;
 }
 #endif
-

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -6792,12 +6792,16 @@ CORE_EXPORT qlonglong qgsPermissiveToLongLong( QString string, bool &ok );
  *
  * Invalid < NULL < Values
  *
+ * Since QGIS 4.0 the \a strictTypeCheck argument can be used to specify that variants
+ * of different types should be compared using their userType ID only, and not attempt
+ * to check the actual variant value.
+ *
  * \see qgsVariantLessThan()
  * \see qgsVariantGreaterThan()
  *
  * \since QGIS 3.44
  */
-CORE_EXPORT int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs );
+CORE_EXPORT int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs, bool strictTypeCheck = false );
 
 /**
  * Compares two QVariant values and returns whether the first is less than the second.
@@ -6805,7 +6809,7 @@ CORE_EXPORT int qgsVariantCompare( const QVariant &lhs, const QVariant &rhs );
  * QVariant data types (such as strings, numeric values, dates and times)
  *
  * Invalid < NULL < Values
- *
+
  * \see qgsVariantGreaterThan()
  * \see qgsVariantCompare()
  */
@@ -6835,27 +6839,34 @@ CORE_EXPORT bool qgsVariantGreaterThan( const QVariant &lhs, const QVariant &rhs
 
 /**
  * Compares two QVariant values and returns whether the first is greater than the second.
- * Useful for sorting lists of variants, correctly handling sorting of the various
- * QVariant data types (such as strings, numeric values, dates and times)
+ *
+ * \note This method performs strict type checking, and considers variants of different
+ * types using their userType ID only. It is accordingly appropriate for use with QMap
+ * with QVariant keys. If loose type checking is required then the qgsVariantGreaterThan()
+ * function should be used.
+ *
  * \see qgsVariantLessThan()
+ * \see qgsVariantGreaterThan()
  */
 inline bool operator> ( const QVariant &v1, const QVariant &v2 )
 {
-  return qgsVariantGreaterThan( v1, v2 );
+  return qgsVariantCompare( v1, v2, true ) > 0;
 }
 
 /**
  * Compares two QVariant values and returns whether the first is less than the second.
- * Useful for sorting lists of variants, correctly handling sorting of the various
- * QVariant data types (such as strings, numeric values, dates and times)
  *
- * Invalid < NULL < Values
+ * \note This method performs strict type checking, and considers variants of different
+ * types using their userType ID only. It is accordingly appropriate for use with QMap
+ * with QVariant keys. If loose type checking is required then the qgsVariantLessThan()
+ * function should be used.
  *
+ * \see qgsVariantLessThan()
  * \see qgsVariantGreaterThan()
  */
 inline bool operator< ( const QVariant &v1, const QVariant &v2 )
 {
-  return qgsVariantLessThan( v1, v2 );
+  return qgsVariantCompare( v1, v2, true ) < 0;
 }
 #endif
 

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -406,17 +406,48 @@ void TestQgis::qVariantCompare_data()
   QTest::newRow( "int vs float greater than truncation" ) << QVariant( -2 ) << QVariant( -2.1f ) << false << true << 1;
   QTest::newRow( "int vs float same" ) << QVariant( 1 ) << QVariant( 1.0f ) << false << false << 0;
 
+  QTest::newRow( "long long vs double less than" ) << QVariant( 1LL ) << QVariant( 2.0 ) << true << false << -1;
+  QTest::newRow( "long long vs double less than truncation" ) << QVariant( 1LL ) << QVariant( 1.1 ) << true << false << -1;
+  QTest::newRow( "long long vs double greater than" ) << QVariant( 2LL ) << QVariant( 1.0 ) << false << true << 1;
+  QTest::newRow( "long long vs double greater than truncation" ) << QVariant( -2LL ) << QVariant( -2.1 ) << false << true << 1;
+  QTest::newRow( "long long vs double same" ) << QVariant( 1LL ) << QVariant( 1.0 ) << false << false << 0;
+
+  QTest::newRow( "long long vs float less than" ) << QVariant( 1LL ) << QVariant( 2.0f ) << true << false << -1;
+  QTest::newRow( "long long vs float less than truncation" ) << QVariant( 1LL ) << QVariant( 1.1f ) << true << false << -1;
+  QTest::newRow( "long long vs float greater than" ) << QVariant( 2LL ) << QVariant( 1.0f ) << false << true << 1;
+  QTest::newRow( "long long vs float greater than truncation" ) << QVariant( -2LL ) << QVariant( -2.1f ) << false << true << 1;
+  QTest::newRow( "long long vs float same" ) << QVariant( 1LL ) << QVariant( 1.0f ) << false << false << 0;
+
+  QTest::newRow( "long long vs int less than" ) << QVariant( 1LL ) << QVariant( 2 ) << true << false << -1;
+  QTest::newRow( "long long vs int greater than" ) << QVariant( 2LL ) << QVariant( 1 ) << false << true << 1;
+  QTest::newRow( "long long vs int same" ) << QVariant( 1LL ) << QVariant( 1 ) << false << false << 0;
+  QTest::newRow( "int vs long long less than" ) << QVariant( 1 ) << QVariant( 2LL ) << true << false << -1;
+  QTest::newRow( "int vs long long greater than" ) << QVariant( 2 ) << QVariant( 1LL ) << false << true << 1;
+  QTest::newRow( "int vs long long same" ) << QVariant( 1 ) << QVariant( 1LL ) << false << false << 0;
+
   QTest::newRow( "double vs int less than" ) << QVariant( 1.0 ) << QVariant( 2 ) << true << false << -1;
   QTest::newRow( "double vs int less than truncation" ) << QVariant( -2.1 ) << QVariant( -2 ) << true << false << -1;
   QTest::newRow( "double vs int greater than" ) << QVariant( 2.0 ) << QVariant( 1 ) << false << true << 1;
   QTest::newRow( "double vs int greater than truncation" ) << QVariant( 1.1 ) << QVariant( 1 ) << false << true << 1;
   QTest::newRow( "double vs int same" ) << QVariant( 1.0 ) << QVariant( 1 ) << false << false << 0;
 
+  QTest::newRow( "double vs long long less than" ) << QVariant( 1.0 ) << QVariant( 2LL ) << true << false << -1;
+  QTest::newRow( "double vs long long less than truncation" ) << QVariant( -2.1 ) << QVariant( -2LL ) << true << false << -1;
+  QTest::newRow( "double vs long long greater than" ) << QVariant( 2.0 ) << QVariant( 1LL ) << false << true << 1;
+  QTest::newRow( "double vs long long greater than truncation" ) << QVariant( 1.1 ) << QVariant( 1LL ) << false << true << 1;
+  QTest::newRow( "double vs long long same" ) << QVariant( 1.0 ) << QVariant( 1LL ) << false << false << 0;
+
   QTest::newRow( "float vs int less than" ) << QVariant( 1.0f ) << QVariant( 2 ) << true << false << -1;
   QTest::newRow( "float vs int less than truncation" ) << QVariant( -2.1f ) << QVariant( -2 ) << true << false << -1;
   QTest::newRow( "float vs int greater than" ) << QVariant( 2.0f ) << QVariant( 1 ) << false << true << 1;
   QTest::newRow( "float vs int greater than truncation" ) << QVariant( 1.1f ) << QVariant( 1 ) << false << true << 1;
   QTest::newRow( "float vs int same" ) << QVariant( 1.0f ) << QVariant( 1 ) << false << false << 0;
+
+  QTest::newRow( "float vs long long less than" ) << QVariant( 1.0f ) << QVariant( 2LL ) << true << false << -1;
+  QTest::newRow( "float vs long long less than truncation" ) << QVariant( -2.1f ) << QVariant( -2LL ) << true << false << -1;
+  QTest::newRow( "float vs long long greater than" ) << QVariant( 2.0f ) << QVariant( 1LL ) << false << true << 1;
+  QTest::newRow( "float vs long long greater than truncation" ) << QVariant( 1.1f ) << QVariant( 1LL ) << false << true << 1;
+  QTest::newRow( "float vs long long same" ) << QVariant( 1.0f ) << QVariant( 1LL ) << false << false << 0;
 
   QTest::newRow( "int vs string less than" ) << QVariant( 1 ) << QVariant( "2" ) << true << false << -1;
   QTest::newRow( "int vs string greater than" ) << QVariant( 2 ) << QVariant( "1" ) << false << true << 1;
@@ -426,11 +457,24 @@ void TestQgis::qVariantCompare_data()
   QTest::newRow( "int 0 vs string non numeric" ) << QVariant( 0 ) << QVariant( "aaaa" ) << true << false << -1;
   QTest::newRow( "non numeric string vs int 0" ) << QVariant( "abc" ) << QVariant( 0 ) << false << true << 1;
 
+  QTest::newRow( "long long vs string less than" ) << QVariant( 1LL ) << QVariant( "2" ) << true << false << -1;
+  QTest::newRow( "long long vs string greater than" ) << QVariant( 2LL ) << QVariant( "1" ) << false << true << 1;
+  QTest::newRow( "long long vs string same" ) << QVariant( 2LL ) << QVariant( "2" ) << false << false << 0;
+  QTest::newRow( "long long vs string non numeric" ) << QVariant( 2LL ) << QVariant( "aaaa" ) << true << false << -1;
+  QTest::newRow( "non numeric string vs long long" ) << QVariant( "abc" ) << QVariant( 2LL ) << false << true << 1;
+  QTest::newRow( "long long 0 vs string non numeric" ) << QVariant( 0LL ) << QVariant( "aaaa" ) << true << false << -1;
+  QTest::newRow( "non numeric string vs long long 0" ) << QVariant( "abc" ) << QVariant( 0LL ) << false << true << 1;
+
   QTest::newRow( "int vs double string less than" ) << QVariant( 1 ) << QVariant( "2.0" ) << true << false << -1;
   QTest::newRow( "int vs double string less than truncation" ) << QVariant( 1 ) << QVariant( "1.1" ) << true << false << -1;
   QTest::newRow( "int vs double string greater than" ) << QVariant( 2 ) << QVariant( "1.0" ) << false << true << 1;
   QTest::newRow( "int vs double string greater than truncation" ) << QVariant( -2 ) << QVariant( "-2.1" ) << false << true << 1;
   QTest::newRow( "int vs double string same" ) << QVariant( 2 ) << QVariant( "2.0" ) << false << false << 0;
+  QTest::newRow( "long long vs double string less than" ) << QVariant( 1LL ) << QVariant( "2.0" ) << true << false << -1;
+  QTest::newRow( "long long vs double string less than truncation" ) << QVariant( 1LL ) << QVariant( "1.1" ) << true << false << -1;
+  QTest::newRow( "long long vs double string greater than" ) << QVariant( 2LL ) << QVariant( "1.0" ) << false << true << 1;
+  QTest::newRow( "long long vs double string greater than truncation" ) << QVariant( -2LL ) << QVariant( "-2.1" ) << false << true << 1;
+  QTest::newRow( "long long vs double string same" ) << QVariant( 2LL ) << QVariant( "2.0" ) << false << false << 0;
   QTest::newRow( "double vs non numeric string" ) << QVariant( 2.1 ) << QVariant( "abc" ) << true << false << -1;
   QTest::newRow( "double 0 vs non numeric string" ) << QVariant( 0 ) << QVariant( "abc" ) << true << false << -1;
   QTest::newRow( "non numeric string vs double" ) << QVariant( "abc" ) << QVariant( 2.0 ) << false << true << 1;
@@ -444,6 +488,13 @@ void TestQgis::qVariantCompare_data()
   QTest::newRow( "string vs int greater than truncation" ) << QVariant( "2.1" ) << QVariant( 2 ) << false << true << 1;
   QTest::newRow( "string vs int same" ) << QVariant( "2" ) << QVariant( 2 ) << false << false << 0;
   QTest::newRow( "string double vs int same" ) << QVariant( "2.0" ) << QVariant( 2 ) << false << false << 0;
+
+  QTest::newRow( "string vs long long less than" ) << QVariant( "1" ) << QVariant( 2LL ) << true << false << -1;
+  QTest::newRow( "string vs long long less than truncation" ) << QVariant( "-2.1" ) << QVariant( -2LL ) << true << false << -1;
+  QTest::newRow( "string vs long long greater than" ) << QVariant( "2" ) << QVariant( 1LL ) << false << true << 1;
+  QTest::newRow( "string vs long long greater than truncation" ) << QVariant( "2.1" ) << QVariant( 2LL ) << false << true << 1;
+  QTest::newRow( "string vs long long same" ) << QVariant( "2" ) << QVariant( 2LL ) << false << false << 0;
+  QTest::newRow( "string double vs long long same" ) << QVariant( "2.0" ) << QVariant( 2LL ) << false << false << 0;
 
   QTest::newRow( "string vs double same" ) << QVariant( "2" ) << QVariant( 2.0 ) << false << false << 0;
   QTest::newRow( "string vs double less than" ) << QVariant( "1" ) << QVariant( 2.0 ) << true << false << -1;

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -393,6 +393,71 @@ void TestQgis::qVariantCompare_data()
   QTest::newRow( "null to value" ) << QgsVariantUtils::createNullVariant( QMetaType::Type::QString ) << QVariant( "a" ) << true << false << -1;
   QTest::newRow( "null to value 2" ) << QVariant( "a" ) << QgsVariantUtils::createNullVariant( QMetaType::Type::QString ) << false << true << 1;
 
+  // type mismatches -- we DO compare the values here, and are tolerant to different variant types!
+  QTest::newRow( "int vs double less than" ) << QVariant( 1 ) << QVariant( 2.0 ) << true << false << -1;
+  QTest::newRow( "int vs double less than truncation" ) << QVariant( 1 ) << QVariant( 1.1 ) << true << false << -1;
+  QTest::newRow( "int vs double greater than" ) << QVariant( 2 ) << QVariant( 1.0 ) << false << true << 1;
+  QTest::newRow( "int vs double greater than truncation" ) << QVariant( -2 ) << QVariant( -2.1 ) << false << true << 1;
+  QTest::newRow( "int vs double same" ) << QVariant( 1 ) << QVariant( 1.0 ) << false << false << 0;
+
+  QTest::newRow( "int vs float less than" ) << QVariant( 1 ) << QVariant( 2.0f ) << true << false << -1;
+  QTest::newRow( "int vs float less than truncation" ) << QVariant( 1 ) << QVariant( 1.1f ) << true << false << -1;
+  QTest::newRow( "int vs float greater than" ) << QVariant( 2 ) << QVariant( 1.0f ) << false << true << 1;
+  QTest::newRow( "int vs float greater than truncation" ) << QVariant( -2 ) << QVariant( -2.1f ) << false << true << 1;
+  QTest::newRow( "int vs float same" ) << QVariant( 1 ) << QVariant( 1.0f ) << false << false << 0;
+
+  QTest::newRow( "double vs int less than" ) << QVariant( 1.0 ) << QVariant( 2 ) << true << false << -1;
+  QTest::newRow( "double vs int less than truncation" ) << QVariant( -2.1 ) << QVariant( -2 ) << true << false << -1;
+  QTest::newRow( "double vs int greater than" ) << QVariant( 2.0 ) << QVariant( 1 ) << false << true << 1;
+  QTest::newRow( "double vs int greater than truncation" ) << QVariant( 1.1 ) << QVariant( 1 ) << false << true << 1;
+  QTest::newRow( "double vs int same" ) << QVariant( 1.0 ) << QVariant( 1 ) << false << false << 0;
+
+  QTest::newRow( "float vs int less than" ) << QVariant( 1.0f ) << QVariant( 2 ) << true << false << -1;
+  QTest::newRow( "float vs int less than truncation" ) << QVariant( -2.1f ) << QVariant( -2 ) << true << false << -1;
+  QTest::newRow( "float vs int greater than" ) << QVariant( 2.0f ) << QVariant( 1 ) << false << true << 1;
+  QTest::newRow( "float vs int greater than truncation" ) << QVariant( 1.1f ) << QVariant( 1 ) << false << true << 1;
+  QTest::newRow( "float vs int same" ) << QVariant( 1.0f ) << QVariant( 1 ) << false << false << 0;
+
+  QTest::newRow( "int vs string less than" ) << QVariant( 1 ) << QVariant( "2" ) << true << false << -1;
+  QTest::newRow( "int vs string greater than" ) << QVariant( 2 ) << QVariant( "1" ) << false << true << 1;
+  QTest::newRow( "int vs string same" ) << QVariant( 2 ) << QVariant( "2" ) << false << false << 0;
+  QTest::newRow( "int vs string non numeric" ) << QVariant( 2 ) << QVariant( "aaaa" ) << true << false << -1;
+  QTest::newRow( "non numeric string vs int" ) << QVariant( "abc" ) << QVariant( 2 ) << false << true << 1;
+  QTest::newRow( "int 0 vs string non numeric" ) << QVariant( 0 ) << QVariant( "aaaa" ) << true << false << -1;
+  QTest::newRow( "non numeric string vs int 0" ) << QVariant( "abc" ) << QVariant( 0 ) << false << true << 1;
+
+  QTest::newRow( "int vs double string less than" ) << QVariant( 1 ) << QVariant( "2.0" ) << true << false << -1;
+  QTest::newRow( "int vs double string less than truncation" ) << QVariant( 1 ) << QVariant( "1.1" ) << true << false << -1;
+  QTest::newRow( "int vs double string greater than" ) << QVariant( 2 ) << QVariant( "1.0" ) << false << true << 1;
+  QTest::newRow( "int vs double string greater than truncation" ) << QVariant( -2 ) << QVariant( "-2.1" ) << false << true << 1;
+  QTest::newRow( "int vs double string same" ) << QVariant( 2 ) << QVariant( "2.0" ) << false << false << 0;
+  QTest::newRow( "double vs non numeric string" ) << QVariant( 2.1 ) << QVariant( "abc" ) << true << false << -1;
+  QTest::newRow( "double 0 vs non numeric string" ) << QVariant( 0 ) << QVariant( "abc" ) << true << false << -1;
+  QTest::newRow( "non numeric string vs double" ) << QVariant( "abc" ) << QVariant( 2.0 ) << false << true << 1;
+  QTest::newRow( "float vs non numeric string" ) << QVariant( 2.1f ) << QVariant( "abc" ) << true << false << -1;
+  QTest::newRow( "float 0 vs non numeric string" ) << QVariant( 0.f ) << QVariant( "abc" ) << true << false << -1;
+  QTest::newRow( "non numeric string vs float" ) << QVariant( "abc" ) << QVariant( 2.0f ) << false << true << 1;
+
+  QTest::newRow( "string vs int less than" ) << QVariant( "1" ) << QVariant( 2 ) << true << false << -1;
+  QTest::newRow( "string vs int less than truncation" ) << QVariant( "-2.1" ) << QVariant( -2 ) << true << false << -1;
+  QTest::newRow( "string vs int greater than" ) << QVariant( "2" ) << QVariant( 1 ) << false << true << 1;
+  QTest::newRow( "string vs int greater than truncation" ) << QVariant( "2.1" ) << QVariant( 2 ) << false << true << 1;
+  QTest::newRow( "string vs int same" ) << QVariant( "2" ) << QVariant( 2 ) << false << false << 0;
+  QTest::newRow( "string double vs int same" ) << QVariant( "2.0" ) << QVariant( 2 ) << false << false << 0;
+
+  QTest::newRow( "string vs double same" ) << QVariant( "2" ) << QVariant( 2.0 ) << false << false << 0;
+  QTest::newRow( "string vs double less than" ) << QVariant( "1" ) << QVariant( 2.0 ) << true << false << -1;
+  QTest::newRow( "string vs double less than truncation" ) << QVariant( "1" ) << QVariant( 1.1 ) << true << false << -1;
+  QTest::newRow( "string vs double greater than" ) << QVariant( "3" ) << QVariant( 2.0 ) << false << true << 1;
+  QTest::newRow( "string vs double greater than truncation" ) << QVariant( "-3" ) << QVariant( -3.1 ) << false << true << 1;
+  QTest::newRow( "string double vs double same" ) << QVariant( "2.1" ) << QVariant( 2.1 ) << false << false << 0;
+  QTest::newRow( "string double vs double less than" ) << QVariant( "2.05" ) << QVariant( 2.1 ) << true << false << -1;
+  QTest::newRow( "string double vs double greater than" ) << QVariant( "2.15" ) << QVariant( 2.1 ) << false << true << 1;
+  QTest::newRow( "string vs float same" ) << QVariant( "2" ) << QVariant( 2.0f ) << false << false << 0;
+  QTest::newRow( "string double vs float less than" ) << QVariant( "2.05" ) << QVariant( 2.1f ) << true << false << -1;
+  QTest::newRow( "string double vs float greater than" ) << QVariant( "2.15" ) << QVariant( 2.1f ) << false << true << 1;
+  QTest::newRow( "string double vs float" ) << QVariant( "2.1" ) << QVariant( 2.2f ) << true << false << -1;
+
   QTest::newRow( "int" ) << QVariant( 1 ) << QVariant( 2 ) << true << false << -1;
   QTest::newRow( "int 2" ) << QVariant( 1 ) << QVariant( -2 ) << false << true << 1;
   QTest::newRow( "int 3" ) << QVariant( 0 ) << QVariant( 1 ) << true << false << -1;


### PR DESCRIPTION
The issues are exposed in the qt 6 builds, but the broken qgsVariant comparison functions for variants of different types also impacts Qt 5 builds.