### PR TITLE
Fix enum wrapper behaviour under qt 6

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -3188,7 +3188,7 @@ void QgsProcessingEnumCheckboxPanelWidget::setValue( const QVariant &value )
     if ( v.userType() == QMetaType::Type::QVariantList )
       v = v.toList().value( 0 );
 
-    v = mParam->usesStaticStrings() ? mParam->options().indexOf( v.toString() ) : v;
+    v = mParam->usesStaticStrings() ? static_cast< int >( mParam->options().indexOf( v.toString() ) ) : v;
     if ( mButtons.contains( v ) )
       mButtons.value( v )->setChecked( true );
   }


### PR DESCRIPTION
indexOf returns a size_t on qt6, so we weren't matching to the int key values contained in the QMap< QVariant, ...> mButtons map
