### PR TITLE
Remove mssql tests from qt6 blocklist

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -23,10 +23,6 @@ test_core_openclutils
 # Relies on a broken/unreliable 3rd party service
 test_core_layerdefinition
 
-# MSSQL requires the MSSQL docker
-PyQgsProviderConnectionMssql
-PyQgsStyleStorageMssql
-
 # To be fixed
 PyQgsAuthenticationSystem
 PyQgsLayoutHtml


### PR DESCRIPTION
These tests won't be run if the mssql docker isn't available anyway, no need to explicitly blocklist them
