### PR TITLE
#53721: Introduce logError to disable logging of error messages to the QgsMessageLog

### DIFF
--- a/python/core/auto_generated/network/qgsblockingnetworkrequest.sip.in
+++ b/python/core/auto_generated/network/qgsblockingnetworkrequest.sip.in
@@ -241,6 +241,20 @@ Sets the authentication config id which should be used during the
 request.
 
 .. seealso:: :py:func:`authCfg`
+ %End
+
+    bool logError();
+%Docstring
+Returns whether error messages are logged in the console.
+
+.. seealso:: :py:func:`setLogError`
+%End
+
+void setLogError( bool logError );
+%Docstring
+Sets whether error messages are logged in the console to logError.
+
+.. seealso:: :py:func:`logError`
 %End
 
   public slots:

--- a/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/network/qgsnetworkaccessmanager.sip.in
@@ -284,7 +284,7 @@ If set to 0, no timeout is set.
 .. versionadded:: 3.6
 %End
 
-    static QgsNetworkReplyContent blockingGet( QNetworkRequest &request, const QString &authCfg = QString(), bool forceRefresh = false, QgsFeedback *feedback = 0 );
+    static QgsNetworkReplyContent blockingGet( QNetworkRequest &request, const QString &authCfg = QString(), bool forceRefresh = false, QgsFeedback *feedback = 0, bool logError = true );
 %Docstring
 Posts a GET request to obtain the contents of the target request and
 returns a new :py:class:`QgsNetworkReplyContent` object for reading. The
@@ -305,6 +305,8 @@ prior to calling this method.
 The optional ``feedback`` argument can be used to abort ongoing
 requests.
 
+If ``logError`` is ``False`` no errors will be logged in the console. If it is set to ``True`` errors are logged.
+
 The contents of the reply will be returned after the request is
 completed or an error occurs.
 
@@ -313,7 +315,7 @@ completed or an error occurs.
 .. versionadded:: 3.6
 %End
 
-    static QgsNetworkReplyContent blockingPost( QNetworkRequest &request, const QByteArray &data, const QString &authCfg = QString(), bool forceRefresh = false, QgsFeedback *feedback = 0 );
+    static QgsNetworkReplyContent blockingPost( QNetworkRequest &request, const QByteArray &data, const QString &authCfg = QString(), bool forceRefresh = false, QgsFeedback *feedback = 0, bool logError = true );
 %Docstring
 Posts a POST request to obtain the contents of the target ``request``,
 using the given ``data``, and returns a new
@@ -334,6 +336,8 @@ prior to calling this method.
 
 The optional ``feedback`` argument can be used to abort ongoing
 requests.
+
+If ``logError`` is ``False`` no errors will be logged in the console. If it is set to ``True`` errors are logged.
 
 The contents of the reply will be returned after the request is
 completed or an error occurs.

--- a/src/core/network/qgsblockingnetworkrequest.cpp
+++ b/src/core/network/qgsblockingnetworkrequest.cpp
@@ -57,6 +57,17 @@ void QgsBlockingNetworkRequest::setAuthCfg( const QString &authCfg )
   mAuthCfg = authCfg;
 }
 
+bool QgsBlockingNetworkRequest::logError()
+{
+    return mlogError;
+}
+
+void QgsBlockingNetworkRequest::setLogError(bool logError)
+{
+    mlogError = logError;
+}
+
+
 QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::get( QNetworkRequest &request, bool forceRefresh, QgsFeedback *feedback, RequestFlags requestFlags )
 {
   return doRequest( Qgis::HttpMethod::Get, request, forceRefresh, feedback, requestFlags );
@@ -146,7 +157,9 @@ QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::doRequest( Qgis:
   {
     mErrorCode = NetworkError;
     mErrorMessage = errorMessageFailedAuth();
-    QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+    if (mlogError) {
+        QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+    }
     return NetworkError;
   }
 
@@ -186,7 +199,9 @@ QgsBlockingNetworkRequest::ErrorCode QgsBlockingNetworkRequest::doRequest( Qgis:
     {
       mErrorCode = NetworkError;
       mErrorMessage = errorMessageFailedAuth();
-      QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+      if (mlogError) {
+          QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+      }
       if ( requestMadeFromMainThread )
         authRequestBufferNotEmpty.wakeAll();
       success = false;
@@ -353,7 +368,9 @@ void QgsBlockingNetworkRequest::replyFinished()
         if ( toUrl == mReply->url() )
         {
           mErrorMessage = tr( "Redirect loop detected: %1" ).arg( toUrl.toString() );
-          QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+          if (mlogError) {
+              QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+          }
           mReplyContent.clear();
         }
         else
@@ -365,7 +382,9 @@ void QgsBlockingNetworkRequest::replyFinished()
             mReplyContent.clear();
             mErrorMessage = errorMessageFailedAuth();
             mErrorCode = NetworkError;
-            QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+            if (mlogError) {
+                QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+            }
             emit finished();
             Q_NOWARN_DEPRECATED_PUSH
             emit downloadFinished();
@@ -396,7 +415,9 @@ void QgsBlockingNetworkRequest::replyFinished()
             mReplyContent.clear();
             mErrorMessage = errorMessageFailedAuth();
             mErrorCode = NetworkError;
-            QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+            if (mlogError) {
+                QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+            }
             emit finished();
             Q_NOWARN_DEPRECATED_PUSH
             emit downloadFinished();
@@ -455,7 +476,9 @@ void QgsBlockingNetworkRequest::replyFinished()
         {
           mErrorMessage = tr( "empty response: %1" ).arg( mReply->errorString() );
           mErrorCode = ServerExceptionError;
-          QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+          if (mlogError) {
+              QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+          }
         }
         mReplyContent.setContent( content );
       }
@@ -466,7 +489,9 @@ void QgsBlockingNetworkRequest::replyFinished()
       {
         mErrorMessage = mReply->errorString();
         mErrorCode = ServerExceptionError;
-        QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+        if (mlogError) {
+            QgsMessageLog::logMessage( mErrorMessage, tr( "Network" ) );
+        }
       }
       mReplyContent = QgsNetworkReplyContent( mReply );
       mReplyContent.setContent( mReply->readAll() );

--- a/src/core/network/qgsblockingnetworkrequest.h
+++ b/src/core/network/qgsblockingnetworkrequest.h
@@ -204,6 +204,16 @@ class CORE_EXPORT QgsBlockingNetworkRequest : public QObject
     QString errorMessage() const { return mErrorMessage; }
 
     /**
+     * Returns whether error messages are logged in the console.
+     */
+    bool logError();
+
+    /**
+     * Sets whether error messages are logged in the console to logError.
+     */
+    void setLogError(bool logError);
+
+    /**
      * Returns the content of the network reply, after a get(), post(), head() or put() request has been made.
      */
     QgsNetworkReplyContent reply() const { return mReplyContent; }
@@ -274,6 +284,9 @@ class CORE_EXPORT QgsBlockingNetworkRequest : public QObject
 
     //! Error code
     ErrorCode mErrorCode = NoError;
+
+    //! Whether error messages are logged
+    bool mlogError = true;
 
     QgsNetworkReplyContent mReplyContent;
 

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -801,17 +801,19 @@ void QgsNetworkAccessManager::setTimeout( const int time )
   settingsNetworkTimeout->setValue( time );
 }
 
-QgsNetworkReplyContent QgsNetworkAccessManager::blockingGet( QNetworkRequest &request, const QString &authCfg, bool forceRefresh, QgsFeedback *feedback )
+QgsNetworkReplyContent QgsNetworkAccessManager::blockingGet( QNetworkRequest &request, const QString &authCfg, bool forceRefresh, QgsFeedback *feedback,  bool logError)
 {
   QgsBlockingNetworkRequest br;
+  br.setLogError(logError);
   br.setAuthCfg( authCfg );
   br.get( request, forceRefresh, feedback );
   return br.reply();
 }
 
-QgsNetworkReplyContent QgsNetworkAccessManager::blockingPost( QNetworkRequest &request, const QByteArray &data, const QString &authCfg, bool forceRefresh, QgsFeedback *feedback )
+QgsNetworkReplyContent QgsNetworkAccessManager::blockingPost( QNetworkRequest &request, const QByteArray &data, const QString &authCfg, bool forceRefresh, QgsFeedback *feedback,  bool logError)
 {
   QgsBlockingNetworkRequest br;
+  br.setLogError(logError);
   br.setAuthCfg( authCfg );
   br.post( request, data, forceRefresh, feedback );
   return br.reply();

--- a/src/core/network/qgsnetworkaccessmanager.h
+++ b/src/core/network/qgsnetworkaccessmanager.h
@@ -480,7 +480,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * \see blockingPost()
      * \since QGIS 3.6
      */
-    static QgsNetworkReplyContent blockingGet( QNetworkRequest &request, const QString &authCfg = QString(), bool forceRefresh = false, QgsFeedback *feedback = nullptr );
+    static QgsNetworkReplyContent blockingGet( QNetworkRequest &request, const QString &authCfg = QString(), bool forceRefresh = false, QgsFeedback *feedback = nullptr, bool logError = true );
 
     /**
      * Posts a POST request to obtain the contents of the target \a request, using the given \a data, and returns a new
@@ -502,7 +502,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * \see blockingGet()
      * \since QGIS 3.6
      */
-    static QgsNetworkReplyContent blockingPost( QNetworkRequest &request, const QByteArray &data, const QString &authCfg = QString(), bool forceRefresh = false, QgsFeedback *feedback = nullptr );
+    static QgsNetworkReplyContent blockingPost( QNetworkRequest &request, const QByteArray &data, const QString &authCfg = QString(), bool forceRefresh = false, QgsFeedback *feedback = nullptr, bool logError = true);
 
     /**
      * Sets a request pre-processor function, which allows manipulation of a network request before it is processed.


### PR DESCRIPTION
## Description

Link to feature request: https://github.com/qgis/qgis/issues/53721

"One might use QGIS' networking classes to send requests involving sensitive data such as API keys or login details in URLS or POST data.

Currently QgsBlockingNetworkRequest will log whole URLs and potentially other sensitive data to the message log when encountering errors."

Changes made:

A boolean mLogError is introduced to QgsBlockingNetworkRequest and can be set via setLogError. Doing the request error messages will only be logged to the QGSMessageLog, if mLogError is true. 

Default is true, so that backward compability is ensured. 

QgsNetworlAccessManager::blockingPost and blockingGet have logError as a new optional parameter which defaults to true. The mLogError of the QgsBlockingNetworkRequest created by the methods is set to logError. 

The sip files were adjusted accordingly. 


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
