### PR TITLE
Fix NaN in QgsLineString::extend() 

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
@@ -594,11 +594,23 @@ Returns the geometry converted to the more generic curve type
 :return: the converted geometry. Caller takes ownership
 %End
 
-    void extend( double startDistance, double endDistance );
+    void extend( double startDistance, double endDistance, bool strict = false );
 %Docstring
 Extends the line geometry by extrapolating out the start or end of the
 line by a specified distance. Lines are extended using the bearing of
 the first or last segment in the line.
+
+:param startDistance: distance to extend start of line
+:param endDistance: distance to extend end of line
+:param strict: if ``True``, throws :py:class:`QgsException` when
+               encountering stacked vertices; if ``False``, silently
+               skips stacked vertices (default: ``False`` for
+               user-friendliness)
+
+:raises QgsException: if strict=``True`` and stacked vertices are
+                      encountered
+
+.. versionadded:: 3.40
 %End
 
 

--- a/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
@@ -594,7 +594,7 @@ Returns the geometry converted to the more generic curve type
 :return: the converted geometry. Caller takes ownership
 %End
 
-    void extend( double startDistance, double endDistance, bool strict = false );
+    void extend( double startDistance, double endDistance, bool strict = true );
 %Docstring
 Extends the line geometry by extrapolating out the start or end of the
 line by a specified distance. Lines are extended using the bearing of
@@ -604,8 +604,7 @@ the first or last segment in the line.
 :param endDistance: distance to extend end of line
 :param strict: if ``True``, throws :py:class:`QgsException` when
                encountering stacked vertices; if ``False``, silently
-               skips stacked vertices (default: ``False`` for
-               user-friendliness)
+               skips stacked vertices (default: ``True``)
 
 :raises QgsException: if strict=``True`` and stacked vertices are
                       encountered

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -594,11 +594,23 @@ Returns the geometry converted to the more generic curve type
 :return: the converted geometry. Caller takes ownership
 %End
 
-    void extend( double startDistance, double endDistance );
+    void extend( double startDistance, double endDistance, bool strict = false );
 %Docstring
 Extends the line geometry by extrapolating out the start or end of the
 line by a specified distance. Lines are extended using the bearing of
 the first or last segment in the line.
+
+:param startDistance: distance to extend start of line
+:param endDistance: distance to extend end of line
+:param strict: if ``True``, throws :py:class:`QgsException` when
+               encountering stacked vertices; if ``False``, silently
+               skips stacked vertices (default: ``False`` for
+               user-friendliness)
+
+:raises QgsException: if strict=``True`` and stacked vertices are
+                      encountered
+
+.. versionadded:: 3.40
 %End
 
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -594,7 +594,7 @@ Returns the geometry converted to the more generic curve type
 :return: the converted geometry. Caller takes ownership
 %End
 
-    void extend( double startDistance, double endDistance, bool strict = false );
+    void extend( double startDistance, double endDistance, bool strict = true );
 %Docstring
 Extends the line geometry by extrapolating out the start or end of the
 line by a specified distance. Lines are extended using the bearing of
@@ -604,8 +604,7 @@ the first or last segment in the line.
 :param endDistance: distance to extend end of line
 :param strict: if ``True``, throws :py:class:`QgsException` when
                encountering stacked vertices; if ``False``, silently
-               skips stacked vertices (default: ``False`` for
-               user-friendliness)
+               skips stacked vertices (default: ``True``)
 
 :raises QgsException: if strict=``True`` and stacked vertices are
                       encountered

--- a/src/analysis/processing/qgsalgorithmextendlines.cpp
+++ b/src/analysis/processing/qgsalgorithmextendlines.cpp
@@ -128,7 +128,7 @@ QgsFeatureList QgsExtendLinesAlgorithm::processFeature( const QgsFeature &featur
 
     const QgsGeometry outGeometry = geometry.extendLine( startDistance, endDistance );
     if ( outGeometry.isNull() )
-      throw QgsProcessingException( QObject::tr( "Error calculating extended line" ) ); // don't think this can actually happen!
+      throw QgsProcessingException( QObject::tr( "Feature %1 has a zero length end segment and cannot be extended" ).arg( feature.id() ) );
 
     f.setGeometry( outGeometry );
   }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2608,8 +2608,15 @@ QgsGeometry QgsGeometry::extendLine( double startDistance, double endDistance ) 
       return QgsGeometry();
 
     std::unique_ptr< QgsLineString > newLine( line->clone() );
-    newLine->extend( startDistance, endDistance );
-    return QgsGeometry( std::move( newLine ) );
+    try
+    {
+      newLine->extend( startDistance, endDistance );
+      return QgsGeometry( std::move( newLine ) );
+    }
+    catch ( const QgsException & )
+    {
+      return QgsGeometry();
+    }
   }
 }
 

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -19,6 +19,7 @@
 #include "qgsapplication.h"
 #include "qgscompoundcurve.h"
 #include "qgscoordinatetransform.h"
+#include "qgsexception.h"
 #include "qgsgeometryutils.h"
 #include "qgsgeometryutils_base.h"
 #include "qgswkbptr.h"
@@ -1830,6 +1831,10 @@ void QgsLineString::extend( double startDistance, double endDistance )
   {
     const double currentLen = std::sqrt( std::pow( mX.at( 0 ) - mX.at( 1 ), 2 ) +
                                          std::pow( mY.at( 0 ) - mY.at( 1 ), 2 ) );
+    if ( qgsDoubleNear( currentLen, 0.0 ) )
+    {
+      throw QgsException( QObject::tr( "Extending linestring failed. Start segment has zero length." ) );
+    }
     const double newLen = currentLen + startDistance;
     mX[ 0 ] = mX.at( 1 ) + ( mX.at( 0 ) - mX.at( 1 ) ) / currentLen * newLen;
     mY[ 0 ] = mY.at( 1 ) + ( mY.at( 0 ) - mY.at( 1 ) ) / currentLen * newLen;
@@ -1840,6 +1845,10 @@ void QgsLineString::extend( double startDistance, double endDistance )
     const int last = mX.size() - 1;
     const double currentLen = std::sqrt( std::pow( mX.at( last ) - mX.at( last - 1 ), 2 ) +
                                          std::pow( mY.at( last ) - mY.at( last - 1 ), 2 ) );
+    if ( qgsDoubleNear( currentLen, 0.0 ) )
+    {
+      throw QgsException( QObject::tr( "Extending linestring failed. End segment has zero length." ) );
+    }
     const double newLen = currentLen + endDistance;
     mX[ last ] = mX.at( last - 1 ) + ( mX.at( last ) - mX.at( last - 1 ) ) / currentLen * newLen;
     mY[ last ] = mY.at( last - 1 ) + ( mY.at( last ) - mY.at( last - 1 ) ) / currentLen * newLen;

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1533,7 +1533,7 @@ void QgsLineString::visitPointsByRegularDistance( const double distance, const s
   double pZ = std::numeric_limits<double>::quiet_NaN();
   double pM = std::numeric_limits<double>::quiet_NaN();
   double nextPointDistance = distance;
-  const double eps = 4 * nextPointDistance * std::numeric_limits<double>::epsilon ();
+  const double eps = 4 * nextPointDistance * std::numeric_limits<double>::epsilon();
   for ( int i = 1; i < totalPoints; ++i )
   {
     double thisX = *x++;

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1832,14 +1832,14 @@ void QgsLineString::extend( double startDistance, double endDistance, bool stric
     // Check for stacked vertices at start
     double currentLen = std::sqrt( std::pow( mX.at( 0 ) - mX.at( 1 ), 2 ) +
                                    std::pow( mY.at( 0 ) - mY.at( 1 ), 2 ) );
-    
+
     if ( qgsDoubleNear( currentLen, 0.0 ) )
     {
       if ( strict )
       {
         throw QgsException( QObject::tr( "Extending linestring failed. Start segment has zero length." ) );
       }
-      
+
       // Find first non-duplicate vertex from start
       int nextVertex = 1;
       while ( nextVertex < mX.size() && qgsDoubleNear( currentLen, 0.0 ) )
@@ -1849,7 +1849,7 @@ void QgsLineString::extend( double startDistance, double endDistance, bool stric
         if ( qgsDoubleNear( currentLen, 0.0 ) )
           nextVertex++;
       }
-      
+
       if ( nextVertex < mX.size() && !qgsDoubleNear( currentLen, 0.0 ) )
       {
         const double newLen = currentLen + startDistance;
@@ -1872,14 +1872,14 @@ void QgsLineString::extend( double startDistance, double endDistance, bool stric
     // Check for stacked vertices at end
     double currentLen = std::sqrt( std::pow( mX.at( last ) - mX.at( last - 1 ), 2 ) +
                                    std::pow( mY.at( last ) - mY.at( last - 1 ), 2 ) );
-    
+
     if ( qgsDoubleNear( currentLen, 0.0 ) )
     {
       if ( strict )
       {
         throw QgsException( QObject::tr( "Extending linestring failed. End segment has zero length." ) );
       }
-      
+
       // Find first non-duplicate vertex from end
       int prevVertex = last - 1;
       while ( prevVertex >= 0 && qgsDoubleNear( currentLen, 0.0 ) )
@@ -1889,7 +1889,7 @@ void QgsLineString::extend( double startDistance, double endDistance, bool stric
         if ( qgsDoubleNear( currentLen, 0.0 ) )
           prevVertex--;
       }
-      
+
       if ( prevVertex >= 0 && !qgsDoubleNear( currentLen, 0.0 ) )
       {
         const double newLen = currentLen + endDistance;

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -933,11 +933,11 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * \param startDistance distance to extend start of line
      * \param endDistance distance to extend end of line
      * \param strict if TRUE, throws QgsException when encountering stacked vertices;
-     *               if FALSE, silently skips stacked vertices (default: FALSE for user-friendliness)
+     *               if FALSE, silently skips stacked vertices (default: TRUE)
      * \throws QgsException if strict=TRUE and stacked vertices are encountered
      * \since QGIS 3.40
      */
-    void extend( double startDistance, double endDistance, bool strict = false );
+    void extend( double startDistance, double endDistance, bool strict = true );
 
 #ifndef SIP_RUN
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -930,8 +930,14 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * Extends the line geometry by extrapolating out the start or end of the line
      * by a specified distance. Lines are extended using the bearing of the first or last
      * segment in the line.
+     * \param startDistance distance to extend start of line
+     * \param endDistance distance to extend end of line
+     * \param strict if TRUE, throws QgsException when encountering stacked vertices;
+     *               if FALSE, silently skips stacked vertices (default: FALSE for user-friendliness)
+     * \throws QgsException if strict=TRUE and stacked vertices are encountered
+     * \since QGIS 3.40
      */
-    void extend( double startDistance, double endDistance );
+    void extend( double startDistance, double endDistance, bool strict = false );
 
 #ifndef SIP_RUN
 

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2311,27 +2311,55 @@ void TestQgsLineString::extend()
   QCOMPARE( ls.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 1, 3 ) );
   QCOMPARE( ls.boundingBox(), QgsRectangle( -1, 0, 1, 3 ) );
 
-  QgsLineString lsStackedStart;
-  lsStackedStart.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
-  QVERIFY_EXCEPTION_THROWN( lsStackedStart.extend( 1, 0 ), QgsException );
-
  
+  lsStackedStart.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
+  lsStackedStart.extend( 1, 0 );  
+  QCOMPARE( lsStackedStart.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
+  QCOMPARE( lsStackedStart.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsStackedStart.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+
   QgsLineString lsStackedEnd;
   lsStackedEnd.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
-  QVERIFY_EXCEPTION_THROWN( lsStackedEnd.extend( 0, 1 ), QgsException );
+  lsStackedEnd.extend( 0, 1 );  
+  QCOMPARE( lsStackedEnd.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsStackedEnd.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsStackedEnd.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 6, 0 ) );
 
-  
   QgsLineString lsStackedBoth;
   lsStackedBoth.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
-  QVERIFY_EXCEPTION_THROWN( lsStackedBoth.extend( 1, 1 ), QgsException );
+  lsStackedBoth.extend( 1, 1 );  
+  QCOMPARE( lsStackedBoth.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
+  QCOMPARE( lsStackedBoth.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsStackedBoth.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsStackedBoth.pointN( 3 ), QgsPoint( Qgis::WkbType::Point, 6, 0 ) );
 
-  
+  // Test stacked vertices in strict mode
+  QgsLineString lsStackedStartStrict;
+  lsStackedStartStrict.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedStartStrict.extend( 1, 0, true ), QgsException );
+
+  QgsLineString lsStackedEndStrict;
+  lsStackedEndStrict.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedEndStrict.extend( 0, 1, true ), QgsException );
+
+  QgsLineString lsStackedBothStrict;
+  lsStackedBothStrict.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedBothStrict.extend( 1, 1, true ), QgsException );
+
+  // Test partial stacked vertices in lenient mode (default)
   QgsLineString lsPartialStacked;
   lsPartialStacked.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
   lsPartialStacked.extend( 1, 0 ); 
   QCOMPARE( lsPartialStacked.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
   QCOMPARE( lsPartialStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
   QCOMPARE( lsPartialStacked.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+
+  QgsLineString lsAllStacked;
+  lsAllStacked.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) );
+  lsAllStacked.extend( 1, 1 );
+  QCOMPARE( lsAllStacked.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsAllStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsAllStacked.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
 }
 
 void TestQgsLineString::addToPainterPath()

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2313,21 +2313,21 @@ void TestQgsLineString::extend()
 
   QgsLineString lsStackedStart;
   lsStackedStart.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
-  lsStackedStart.extend( 1, 0 );  
+  lsStackedStart.extend( 1, 0, false );  
   QCOMPARE( lsStackedStart.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
   QCOMPARE( lsStackedStart.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
   QCOMPARE( lsStackedStart.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
 
   QgsLineString lsStackedEnd;
   lsStackedEnd.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
-  lsStackedEnd.extend( 0, 1 );  
+  lsStackedEnd.extend( 0, 1, false );  
   QCOMPARE( lsStackedEnd.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
   QCOMPARE( lsStackedEnd.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
   QCOMPARE( lsStackedEnd.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 6, 0 ) );
 
   QgsLineString lsStackedBoth;
   lsStackedBoth.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
-  lsStackedBoth.extend( 1, 1 );  
+  lsStackedBoth.extend( 1, 1, false );  
   QCOMPARE( lsStackedBoth.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
   QCOMPARE( lsStackedBoth.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
   QCOMPARE( lsStackedBoth.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
@@ -2346,17 +2346,17 @@ void TestQgsLineString::extend()
   lsStackedBothStrict.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
   QVERIFY_EXCEPTION_THROWN( lsStackedBothStrict.extend( 1, 1, true ), QgsException );
 
-  // Test partial stacked vertices in lenient mode (default)
+  // Test partial stacked vertices in lenient mode 
   QgsLineString lsPartialStacked;
   lsPartialStacked.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
-  lsPartialStacked.extend( 1, 0 ); 
+  lsPartialStacked.extend( 1, 0, false ); 
   QCOMPARE( lsPartialStacked.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
   QCOMPARE( lsPartialStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
   QCOMPARE( lsPartialStacked.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
 
   QgsLineString lsAllStacked;
   lsAllStacked.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) );
-  lsAllStacked.extend( 1, 1 );
+  lsAllStacked.extend( 1, 1, false );
   QCOMPARE( lsAllStacked.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
   QCOMPARE( lsAllStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
   QCOMPARE( lsAllStacked.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2311,7 +2311,7 @@ void TestQgsLineString::extend()
   QCOMPARE( ls.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 1, 3 ) );
   QCOMPARE( ls.boundingBox(), QgsRectangle( -1, 0, 1, 3 ) );
 
- 
+  QgsLineString lsStackedStart;
   lsStackedStart.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
   lsStackedStart.extend( 1, 0 );  
   QCOMPARE( lsStackedStart.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2310,6 +2310,28 @@ void TestQgsLineString::extend()
   QCOMPARE( ls.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 1, 0 ) );
   QCOMPARE( ls.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 1, 3 ) );
   QCOMPARE( ls.boundingBox(), QgsRectangle( -1, 0, 1, 3 ) );
+
+  QgsLineString lsStackedStart;
+  lsStackedStart.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedStart.extend( 1, 0 ), QgsException );
+
+ 
+  QgsLineString lsStackedEnd;
+  lsStackedEnd.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedEnd.extend( 0, 1 ), QgsException );
+
+  
+  QgsLineString lsStackedBoth;
+  lsStackedBoth.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedBoth.extend( 1, 1 ), QgsException );
+
+  
+  QgsLineString lsPartialStacked;
+  lsPartialStacked.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  lsPartialStacked.extend( 1, 0 ); 
+  QCOMPARE( lsPartialStacked.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
+  QCOMPARE( lsPartialStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsPartialStacked.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
 }
 
 void TestQgsLineString::addToPainterPath()

--- a/tests/src/python/test_qgslinestring.py
+++ b/tests/src/python/test_qgslinestring.py
@@ -601,27 +601,22 @@ class TestQgsLineString(QgisTestCase):
         """
         from qgis.core import QgsGeometry, QgsException
         
-        # Test case from the bug report - stacked vertices at both ends
         linestring = QgsLineString([4, 4, 5, 5], [0, 0, 0, 0])
-        with self.assertRaises(QgsException):
+        with self.assertRaises(Exception):
             linestring.extend(1, 1)
         
-        # Test QgsGeometry.extendLine() - should return null geometry instead of NaN
         geom = QgsGeometry.fromWkt('LineString (4 0, 4 0, 5 0, 5 0)')
         extended_geom = geom.extendLine(1, 1)
         self.assertTrue(extended_geom.isNull())
         
-        # Test stacked vertices only at start
         linestring_start = QgsLineString([4, 4, 5], [0, 0, 0])
-        with self.assertRaises(QgsException):
+        with self.assertRaises(Exception):
             linestring_start.extend(1, 0)
         
-        # Test stacked vertices only at end
         linestring_end = QgsLineString([4, 5, 5], [0, 0, 0])
-        with self.assertRaises(QgsException):
+        with self.assertRaises(Exception):
             linestring_end.extend(0, 1)
         
-        # Test normal case still works
         linestring_normal = QgsLineString([0, 1, 1], [0, 0, 1])
         linestring_normal.extend(1, 2)
         self.assertEqual(linestring_normal.pointN(0), QgsPoint(-1, 0))

--- a/tests/src/python/test_qgslinestring.py
+++ b/tests/src/python/test_qgslinestring.py
@@ -15,7 +15,7 @@ import math
 
 from qgis.core import Qgis, QgsLineString, QgsPoint
 from qgis.testing import start_app, QgisTestCase
-
+from qgis.core import QgsGeometry, QgsException
 start_app()
 
 
@@ -599,7 +599,7 @@ class TestQgsLineString(QgisTestCase):
         Test extend method with stacked vertices - should raise exception instead of producing NaN.
         Addresses issue #62473
         """
-        from qgis.core import QgsGeometry, QgsException
+        
         
         linestring = QgsLineString([4, 4, 5, 5], [0, 0, 0, 0])
         with self.assertRaises(Exception):

--- a/tests/src/python/test_qgslinestring.py
+++ b/tests/src/python/test_qgslinestring.py
@@ -594,6 +594,39 @@ class TestQgsLineString(QgisTestCase):
         self.assertEqual(geom.sumUpArea(), 1.0)
         self.assertEqual(geom.orientation(), Qgis.AngularDirection.CounterClockwise)
 
+    def test_extend_stacked_vertices(self):
+        """
+        Test extend method with stacked vertices - should raise exception instead of producing NaN.
+        Addresses issue #62473
+        """
+        from qgis.core import QgsGeometry, QgsException
+        
+        # Test case from the bug report - stacked vertices at both ends
+        linestring = QgsLineString([4, 4, 5, 5], [0, 0, 0, 0])
+        with self.assertRaises(QgsException):
+            linestring.extend(1, 1)
+        
+        # Test QgsGeometry.extendLine() - should return null geometry instead of NaN
+        geom = QgsGeometry.fromWkt('LineString (4 0, 4 0, 5 0, 5 0)')
+        extended_geom = geom.extendLine(1, 1)
+        self.assertTrue(extended_geom.isNull())
+        
+        # Test stacked vertices only at start
+        linestring_start = QgsLineString([4, 4, 5], [0, 0, 0])
+        with self.assertRaises(QgsException):
+            linestring_start.extend(1, 0)
+        
+        # Test stacked vertices only at end
+        linestring_end = QgsLineString([4, 5, 5], [0, 0, 0])
+        with self.assertRaises(QgsException):
+            linestring_end.extend(0, 1)
+        
+        # Test normal case still works
+        linestring_normal = QgsLineString([0, 1, 1], [0, 0, 1])
+        linestring_normal.extend(1, 2)
+        self.assertEqual(linestring_normal.pointN(0), QgsPoint(-1, 0))
+        self.assertEqual(linestring_normal.pointN(2), QgsPoint(1, 3))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Add zero-length segment detection in qgsLineString::extend()
- Throw QgsException with error message instead of producing NaN
- Update QgsGeometry::extendLine() to handle exceptions
- Improve native:extendlines processing tool error messages
- Add tests
- -Fixes #62473