### PR TITLE
Fix advanced digitizing test under Qt 6 

### DIFF
--- a/.ci/test_blocklist_qt6.txt
+++ b/.ci/test_blocklist_qt6.txt
@@ -1,6 +1,5 @@
 # Qt6 blocklist
 test_core_compositionconverter
-test_app_advanceddigitizing
 
 # Crashes -- also disabled on qt5 builds!
 test_gui_queryresultwidget

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -276,13 +276,10 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
 
   auto constructionToolBar = qobject_cast<QToolButton *>( mToolbar->widgetForAction( mConstructionAction ) );
   constructionToolBar->setPopupMode( QToolButton::InstantPopup );
-  constructionToolBar->setMenu( constructionMenu );
+  mConstructionAction->setMenu( constructionMenu );
   constructionToolBar->setObjectName( QStringLiteral( "ConstructionButton" ) );
-
-  mConstructionAction->setMenu( mCommonAngleActionsMenu );
   mConstructionAction->setCheckable( true );
   mConstructionAction->setToolTip( tr( "Construction Tools" ) );
-  //  connect( constructionMenu, &QMenu::triggered, this, &QgsAdvancedDigitizingDockWidget::settingsButtonTriggered );
 
   // set tooltips
   mConstructionModeAction->setToolTip( "<b>" + tr( "Construction mode" ) + "</b><br>(" + tr( "press c to toggle on/off" ) + ")" );

--- a/tests/src/app/testqgsadvanceddigitizing.cpp
+++ b/tests/src/app/testqgsadvanceddigitizing.cpp
@@ -128,6 +128,7 @@ void TestQgsAdvancedDigitizing::initTestCase()
   snapConfig.setMode( Qgis::SnappingMode::AllLayers );
   snapConfig.setTypeFlag( Qgis::SnappingType::Vertex );
   snapConfig.setTolerance( 1.0 );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
 
   QgsMapSettings mapSettings;
   mapSettings.setExtent( QgsRectangle( 0, 0, 8, 8 ) );
@@ -144,7 +145,7 @@ void TestQgsAdvancedDigitizing::initTestCase()
   snappingUtils->locatorForLayer( mLayer4326ZM )->init();
 
   mCanvas->setSnappingUtils( snappingUtils );
-
+  QgsProject::instance()->setSnappingConfig( snapConfig );
   // create base map tool
   mCaptureTool = new QgsMapToolAddFeature( mCanvas, mAdvancedDigitizingDockWidget, QgsMapToolCapture::CaptureLine );
   mCanvas->setMapTool( mCaptureTool );
@@ -181,6 +182,7 @@ void TestQgsAdvancedDigitizing::cleanup()
   snapConfig.setMode( Qgis::SnappingMode::AllLayers );
   snapConfig.setTypeFlag( Qgis::SnappingType::Vertex );
   snappingUtils->setConfig( snapConfig );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
 
   // reset all layers
   mLayer3950->rollBack();
@@ -587,6 +589,7 @@ void TestQgsAdvancedDigitizing::coordinateConstraintWhenSnapping()
 
   QgsSnappingConfig snapConfig = mCanvas->snappingUtils()->config();
   snapConfig.setEnabled( true );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
   mCanvas->snappingUtils()->setConfig( snapConfig );
 
   // move to trigger a re-indexing and wait for it to complete
@@ -643,6 +646,7 @@ void TestQgsAdvancedDigitizing::perpendicularConstraint()
   QgsSnappingConfig snapConfig = mCanvas->snappingUtils()->config();
   snapConfig.setEnabled( true );
   snapConfig.setTypeFlag( Qgis::SnappingType::Vertex | Qgis::SnappingType::Segment );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
   mCanvas->snappingUtils()->setConfig( snapConfig );
 
   // test snapping on segment
@@ -682,7 +686,9 @@ void TestQgsAdvancedDigitizing::xyExtensionConstraint()
   QgsSnappingConfig snapConfig = mCanvas->snappingUtils()->config();
   snapConfig.setEnabled( true );
   snapConfig.setTypeFlag( Qgis::SnappingType::Vertex | Qgis::SnappingType::Segment );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
   mCanvas->snappingUtils()->setConfig( snapConfig );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
 
   // test snapping on segment
   utils.mouseMove( 4.9, 5.1 );
@@ -735,6 +741,7 @@ void TestQgsAdvancedDigitizing::lineExtensionConstraint()
   QgsSnappingConfig snapConfig = mCanvas->snappingUtils()->config();
   snapConfig.setEnabled( true );
   snapConfig.setTypeFlag( Qgis::SnappingType::Vertex | Qgis::SnappingType::Segment );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
   mCanvas->snappingUtils()->setConfig( snapConfig );
 
   // test snapping on segment
@@ -784,6 +791,7 @@ void TestQgsAdvancedDigitizing::lineExtensionConstraintGeographicCrs()
   snapConfig.setEnabled( true );
   snapConfig.setTypeFlag( Qgis::SnappingType::Vertex | Qgis::SnappingType::Segment );
   mCanvas->snappingUtils()->setConfig( snapConfig );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
 
   // Wait for indexing to complete
   if ( QgsPointLocator *loc = mCanvas->snappingUtils()->locatorForLayer( mLayer4326 ) )
@@ -889,6 +897,7 @@ void TestQgsAdvancedDigitizing::lockedSnapVertices()
   QgsSnappingConfig snapConfig = mCanvas->snappingUtils()->config();
   snapConfig.setEnabled( true );
   mCanvas->snappingUtils()->setConfig( snapConfig );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
 
   // no locked snap vertex while xy vertex constraint or line extension
   QCOMPARE( mAdvancedDigitizingDockWidget->lockedSnapVertices().size(), 0 );
@@ -989,6 +998,7 @@ void TestQgsAdvancedDigitizing::currentPointWhenSanpping()
 
   QgsSnappingConfig snapConfig = mCanvas->snappingUtils()->config();
   snapConfig.setEnabled( true );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
   mCanvas->snappingUtils()->setConfig( snapConfig );
 
   QCOMPARE( mCanvas->snappingUtils()->currentLayer(), mLayer3950 );
@@ -1031,6 +1041,7 @@ void TestQgsAdvancedDigitizing::currentPointWhenSanppingWithDiffCanvasCRS()
 
   QgsSnappingConfig snapConfig = mCanvas->snappingUtils()->config();
   snapConfig.setEnabled( true );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
   mCanvas->snappingUtils()->setConfig( snapConfig );
 
   QCOMPARE( mCanvas->snappingUtils()->currentLayer(), mLayer4326 );
@@ -1056,6 +1067,13 @@ void TestQgsAdvancedDigitizing::releaseLockAfterDisable()
 {
   // activate advanced digitizing
   getMapToolDigitizingUtils( mLayer4326 );
+
+  // enable snapping
+  QgsSnappingConfig snapConfig = mCanvas->snappingUtils()->config();
+  snapConfig.setEnabled( true );
+  snapConfig.setTypeFlag( Qgis::SnappingType::Vertex | Qgis::SnappingType::Segment );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
+  mCanvas->snappingUtils()->setConfig( snapConfig );
 
   QVERIFY( mAdvancedDigitizingDockWidget->cadEnabled() );
 
@@ -1179,6 +1197,7 @@ void TestQgsAdvancedDigitizing::constructionGuides()
 
   QgsSnappingConfig snapConfig = mCanvas->snappingUtils()->config();
   snapConfig.setEnabled( true );
+  QgsProject::instance()->setSnappingConfig( snapConfig );
   mCanvas->snappingUtils()->setConfig( snapConfig );
 
   mAdvancedDigitizingDockWidget->mSnapToConstructionGuides->setChecked( true );


### PR DESCRIPTION
Root cause of issue is that the test was calling QAction::trigger on a disabled action. On Qt 5 this wasn't an issue, and the
slot connected to the action's triggered signal was still called. On Qt 6 this slot is NOT called for disabled actions.

So we need to ensure that the action's triggered in the test ARE correctly enabled, and the way to do this is to call
QgsAdvancedDigitizingDockWidget::updateCapacity. This slot is connected to QgsProject::snappingConfigChanged.

Ensure that we set the snapping config on the project as well as the canvas in tests to make sure that this happens.

(outside of tests, the canvas snapping utils settings are set whenever the project snapping config is changed.. so now
the tests better mimic what's actually happening in app too)