### PR TITLE
[themes] Fix options list widget text color on hover for dark themes

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -1241,6 +1241,17 @@ QListWidget#mOptionsListWidget::item {
     padding: 0.1em;
 }
 
+QListWidget#mOptionsListWidget::item:hover
+{
+    background-color: @hover;
+    color: @itemdarkbackground;
+}
+
+QListWidget#mOptionsListWidget::item:selected:hover {
+    background-color: @selection;
+    color: @text;
+}
+
 QWidget#QgsTextFormatWidgetBase QTabWidget#mOptionsTab QTabBar::tab,
 QWidget#QgsRendererMeshPropsWidgetBase QTabWidget#mStyleOptionsTab QTabBar::tab {
     width: 1.2em;

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1332,6 +1332,7 @@ QListWidget#mOptionsListWidget::item:hover
 
 QListWidget#mOptionsListWidget::item:selected:hover {
     background-color: @selection;
+    color: @textlight;
 }
 
 QWidget#QgsTextFormatWidgetBase QTabWidget#mOptionsTab QTabBar::tab,


### PR DESCRIPTION
## Description

This PR fixes the text color of the selected list widget item for option widgets in the Night Mapping theme.  Additionally, it adds the same styling logic for highlighting hovered options list widget items for the Blend of Gray theme. The default light theme is left untouched.

Before, when the mouse pointer hovered over the selected item, the text color changed, as it does for the non-selected items. This caused the text to flicker when the mouse moved further and made the text appear less readable.

#### Night Mapping:
Before             |  After
:----:|:---:
| ![listwidget_night_mapping_before](https://github.com/user-attachments/assets/8e06e749-7a21-48b5-b752-6e249cb65999) | ![listwidget_night_mapping_after](https://github.com/user-attachments/assets/b881b259-d44c-4200-a4fe-d47c76cd0701) |

#### Blend of Gray:
Before             |  After
:-------------------------:|:-------------------------:
| ![listwidget_blend_of_gray_before](https://github.com/user-attachments/assets/4671e09d-69de-4530-aa11-0fa174395051) | ![listwidget_blend_of_gray_after](https://github.com/user-attachments/assets/37438018-3770-4df4-a25e-dfeb42f6752c) |
