### PR TITLE
server: Use URNs by default for WFS 1.1

### DIFF
--- a/python/PyQt6/server/auto_additions/qgsserverprojectutils.py
+++ b/python/PyQt6/server/auto_additions/qgsserverprojectutils.py
@@ -43,6 +43,7 @@ try:
     QgsServerProjectUtils.wmsRootName = staticmethod(QgsServerProjectUtils.wmsRootName)
     QgsServerProjectUtils.wmsRestrictedLayers = staticmethod(QgsServerProjectUtils.wmsRestrictedLayers)
     QgsServerProjectUtils.wmsOutputCrsList = staticmethod(QgsServerProjectUtils.wmsOutputCrsList)
+    QgsServerProjectUtils.wmsOutputCrsListAsOgcUrn = staticmethod(QgsServerProjectUtils.wmsOutputCrsListAsOgcUrn)
     QgsServerProjectUtils.wmsExtent = staticmethod(QgsServerProjectUtils.wmsExtent)
     QgsServerProjectUtils.wfsServiceUrl = staticmethod(QgsServerProjectUtils.wfsServiceUrl)
     QgsServerProjectUtils.wfsLayerIds = staticmethod(QgsServerProjectUtils.wfsLayerIds)

--- a/python/PyQt6/server/auto_generated/qgsserverprojectutils.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverprojectutils.sip.in
@@ -446,6 +446,17 @@ Returns the WMS output CRS list.
 :return: the WMS output CRS list.
 %End
 
+    static QStringList wmsOutputCrsListAsOgcUrn( const QgsProject &project );
+%Docstring
+Returns the WMS output CRS list as OGC URNs.
+
+:param project: the QGIS project
+
+:return: the WMS output CRS list.
+
+.. versionadded:: 4.0
+%End
+
     static QgsRectangle wmsExtent( const QgsProject &project );
 %Docstring
 Returns the WMS Extent restriction.

--- a/python/server/auto_additions/qgsserverprojectutils.py
+++ b/python/server/auto_additions/qgsserverprojectutils.py
@@ -43,6 +43,7 @@ try:
     QgsServerProjectUtils.wmsRootName = staticmethod(QgsServerProjectUtils.wmsRootName)
     QgsServerProjectUtils.wmsRestrictedLayers = staticmethod(QgsServerProjectUtils.wmsRestrictedLayers)
     QgsServerProjectUtils.wmsOutputCrsList = staticmethod(QgsServerProjectUtils.wmsOutputCrsList)
+    QgsServerProjectUtils.wmsOutputCrsListAsOgcUrn = staticmethod(QgsServerProjectUtils.wmsOutputCrsListAsOgcUrn)
     QgsServerProjectUtils.wmsExtent = staticmethod(QgsServerProjectUtils.wmsExtent)
     QgsServerProjectUtils.wfsServiceUrl = staticmethod(QgsServerProjectUtils.wfsServiceUrl)
     QgsServerProjectUtils.wfsLayerIds = staticmethod(QgsServerProjectUtils.wfsLayerIds)

--- a/python/server/auto_generated/qgsserverprojectutils.sip.in
+++ b/python/server/auto_generated/qgsserverprojectutils.sip.in
@@ -446,6 +446,17 @@ Returns the WMS output CRS list.
 :return: the WMS output CRS list.
 %End
 
+    static QStringList wmsOutputCrsListAsOgcUrn( const QgsProject &project );
+%Docstring
+Returns the WMS output CRS list as OGC URNs.
+
+:param project: the QGIS project
+
+:return: the WMS output CRS list.
+
+.. versionadded:: 4.0
+%End
+
     static QgsRectangle wmsExtent( const QgsProject &project );
 %Docstring
 Returns the WMS Extent restriction.

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -156,49 +156,48 @@ QgsGeometry QgsOgcUtils::geometryFromGML( const QDomNode &geometryNode, const Co
     return geometry;
   }
 
-  // Handle srsName if context has information about the layer and the transformation context
-  if ( context.layer )
+  // Handle srsName
+  // Check if the XY coordinates of geometry need to be swapped by checking the srs from the GML
+  QgsCoordinateReferenceSystem geomSrs;
+  if ( geometryTypeElement.hasAttribute( QStringLiteral( "srsName" ) ) )
   {
-    QgsCoordinateReferenceSystem geomSrs;
+    QString srsName { geometryTypeElement.attribute( QStringLiteral( "srsName" ) ) };
 
-    if ( geometryTypeElement.hasAttribute( QStringLiteral( "srsName" ) ) )
+    // The logic here follows WFS GeoServer conventions from https://docs.geoserver.org/latest/en/user/services/wfs/axis_order.html
+    const bool ignoreAxisOrientation { srsName.startsWith( QLatin1String( "http://www.opengis.net/gml/srs/" ) ) || srsName.startsWith( QLatin1String( "EPSG:" ) ) };
+
+    // GDAL does not recognise http://www.opengis.net/gml/srs/epsg.xml#4326 but it does
+    // http://www.opengis.net/def/crs/EPSG/0/4326 so, let's try that
+    if ( srsName.startsWith( QLatin1String( "http://www.opengis.net/gml/srs/" ) ) )
     {
-      QString srsName { geometryTypeElement.attribute( QStringLiteral( "srsName" ) ) };
-
-      // The logic here follows WFS GeoServer conventions from https://docs.geoserver.org/latest/en/user/services/wfs/axis_order.html
-      const bool ignoreAxisOrientation { srsName.startsWith( QLatin1String( "http://www.opengis.net/gml/srs/" ) ) || srsName.startsWith( QLatin1String( "EPSG:" ) ) };
-
-      // GDAL does not recognise http://www.opengis.net/gml/srs/epsg.xml#4326 but it does
-      // http://www.opengis.net/def/crs/EPSG/0/4326 so, let's try that
-      if ( srsName.startsWith( QLatin1String( "http://www.opengis.net/gml/srs/" ) ) )
+      const auto parts { srsName.split( QRegularExpression( QStringLiteral( R"raw(/|#|\.)raw" ) ) ) };
+      if ( parts.length() == 10 )
       {
-        const auto parts { srsName.split( QRegularExpression( QStringLiteral( R"raw(/|#|\.)raw" ) ) ) };
-        if ( parts.length() == 10 )
-        {
-          srsName = QStringLiteral( "http://www.opengis.net/def/crs/%1/0/%2" ).arg( parts[ 7 ].toUpper(), parts[ 9 ] );
-        }
+        srsName = QStringLiteral( "http://www.opengis.net/def/crs/%1/0/%2" ).arg( parts[ 7 ].toUpper(), parts[ 9 ] );
       }
-      geomSrs.createFromUserInput( srsName );
-      if ( geomSrs.isValid() && geomSrs != context.layer->crs() )
+    }
+    geomSrs.createFromUserInput( srsName );
+    if ( geomSrs.isValid() && geomSrs.hasAxisInverted() && !ignoreAxisOrientation )
+    {
+      geometry.get()->swapXy();
+    }
+  }
+
+  // Apply a coordinate transformation if context has information about the layer and the transformation context
+  if ( geomSrs.isValid() && context.layer && geomSrs != context.layer->crs() )
+  {
+    const QgsCoordinateTransform transformer { geomSrs, context.layer->crs(), context.transformContext };
+    try
+    {
+      const Qgis::GeometryOperationResult result = geometry.transform( transformer );
+      if ( result != Qgis::GeometryOperationResult::Success )
       {
-        if ( geomSrs.hasAxisInverted() && ! ignoreAxisOrientation )
-        {
-          geometry.get()->swapXy();
-        }
-        const QgsCoordinateTransform transformer { geomSrs, context.layer->crs(), context.transformContext };
-        try
-        {
-          const Qgis::GeometryOperationResult result = geometry.transform( transformer );
-          if ( result != Qgis::GeometryOperationResult::Success )
-          {
-            QgsDebugMsgLevel( QStringLiteral( "Error transforming geometry: %1" ).arg( qgsEnumValueToKey( result ) ), 2 );
-          }
-        }
-        catch ( QgsCsException & )
-        {
-          QgsDebugMsgLevel( QStringLiteral( "CS error transforming geometry" ), 2 );
-        }
+        QgsDebugMsgLevel( QStringLiteral( "Error transforming geometry: %1" ).arg( qgsEnumValueToKey( result ) ), 2 );
       }
+    }
+    catch ( QgsCsException & )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "CS error transforming geometry" ), 2 );
     }
   }
 

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -333,6 +333,55 @@ QStringList QgsServerProjectUtils::wmsOutputCrsList( const QgsProject &project )
   return crsList;
 }
 
+QStringList QgsServerProjectUtils::wmsOutputCrsListAsOgcUrn( const QgsProject &project )
+{
+  QStringList crsList;
+  const QStringList wmsCrsList = project.readListEntry( QStringLiteral( "WMSCrsList" ), QStringLiteral( "/" ), QStringList() );
+  if ( !wmsCrsList.isEmpty() )
+  {
+    for ( int i = 0; i < wmsCrsList.size(); ++i )
+    {
+      const QString crsString = wmsCrsList.at( i );
+      if ( !crsString.isEmpty() )
+      {
+        QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsString );
+        crsList.append( crs.toOgcUrn() );
+      }
+    }
+  }
+  if ( crsList.isEmpty() )
+  {
+    const QStringList valueList = project.readListEntry( QStringLiteral( "WMSEpsgList" ), QStringLiteral( "/" ), QStringList() );
+    bool conversionOk;
+    for ( int i = 0; i < valueList.size(); ++i )
+    {
+      const int epsgNr = valueList.at( i ).toInt( &conversionOk );
+      if ( conversionOk )
+      {
+        QString crsOgcUrn = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "EPSG:%1" ).arg( epsgNr ) ).toOgcUrn();
+        crsList.append( crsOgcUrn );
+      }
+    }
+  }
+  if ( crsList.isEmpty() )
+  {
+    //no CRS restriction defined in the project. Provide project CRS, wgs84 and pseudo mercator
+    const QString projectCrsOgcUrn = project.crs().toOgcUrn();
+    crsList.append( projectCrsOgcUrn );
+    QString crsOgcUrn4326 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( "EPSG:4326" ).toOgcUrn();
+    QString crsOgcUrn3857 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( "EPSG:3857" ).toOgcUrn();
+    if ( projectCrsOgcUrn.compare( crsOgcUrn4326, Qt::CaseInsensitive ) != 0 )
+    {
+      crsList.append( crsOgcUrn4326 );
+    }
+    if ( projectCrsOgcUrn.compare( crsOgcUrn3857, Qt::CaseInsensitive ) != 0 )
+    {
+      crsList.append( crsOgcUrn3857 );
+    }
+  }
+  return crsList;
+}
+
 QString QgsServerProjectUtils::serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings )
 {
   const QString serviceUpper = service.toUpper();

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -335,51 +335,14 @@ QStringList QgsServerProjectUtils::wmsOutputCrsList( const QgsProject &project )
 
 QStringList QgsServerProjectUtils::wmsOutputCrsListAsOgcUrn( const QgsProject &project )
 {
-  QStringList crsList;
-  const QStringList wmsCrsList = project.readListEntry( QStringLiteral( "WMSCrsList" ), QStringLiteral( "/" ), QStringList() );
-  if ( !wmsCrsList.isEmpty() )
+  const QStringList crsList = wmsOutputCrsList( project );
+  QStringList crsListAsOgcUrn;
+  for ( const QString &crsString : crsList )
   {
-    for ( int i = 0; i < wmsCrsList.size(); ++i )
-    {
-      const QString crsString = wmsCrsList.at( i );
-      if ( !crsString.isEmpty() )
-      {
-        QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsString );
-        crsList.append( crs.toOgcUrn() );
-      }
-    }
+    crsListAsOgcUrn.append( QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsString ).toOgcUrn() );
   }
-  if ( crsList.isEmpty() )
-  {
-    const QStringList valueList = project.readListEntry( QStringLiteral( "WMSEpsgList" ), QStringLiteral( "/" ), QStringList() );
-    bool conversionOk;
-    for ( int i = 0; i < valueList.size(); ++i )
-    {
-      const int epsgNr = valueList.at( i ).toInt( &conversionOk );
-      if ( conversionOk )
-      {
-        QString crsOgcUrn = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "EPSG:%1" ).arg( epsgNr ) ).toOgcUrn();
-        crsList.append( crsOgcUrn );
-      }
-    }
-  }
-  if ( crsList.isEmpty() )
-  {
-    //no CRS restriction defined in the project. Provide project CRS, wgs84 and pseudo mercator
-    const QString projectCrsOgcUrn = project.crs().toOgcUrn();
-    crsList.append( projectCrsOgcUrn );
-    QString crsOgcUrn4326 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( "EPSG:4326" ).toOgcUrn();
-    QString crsOgcUrn3857 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( "EPSG:3857" ).toOgcUrn();
-    if ( projectCrsOgcUrn.compare( crsOgcUrn4326, Qt::CaseInsensitive ) != 0 )
-    {
-      crsList.append( crsOgcUrn4326 );
-    }
-    if ( projectCrsOgcUrn.compare( crsOgcUrn3857, Qt::CaseInsensitive ) != 0 )
-    {
-      crsList.append( crsOgcUrn3857 );
-    }
-  }
-  return crsList;
+
+  return crsListAsOgcUrn;
 }
 
 QString QgsServerProjectUtils::serviceUrl( const QString &service, const QgsServerRequest &request, const QgsServerSettings &settings )

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -294,9 +294,8 @@ QStringList QgsServerProjectUtils::wmsOutputCrsList( const QgsProject &project )
   const QStringList wmsCrsList = project.readListEntry( QStringLiteral( "WMSCrsList" ), QStringLiteral( "/" ), QStringList() );
   if ( !wmsCrsList.isEmpty() )
   {
-    for ( int i = 0; i < wmsCrsList.size(); ++i )
+    for ( const auto &crs : std::as_const( wmsCrsList ) )
     {
-      const QString crs = wmsCrsList.at( i );
       if ( !crs.isEmpty() )
       {
         crsList.append( crs );
@@ -307,9 +306,9 @@ QStringList QgsServerProjectUtils::wmsOutputCrsList( const QgsProject &project )
   {
     const QStringList valueList = project.readListEntry( QStringLiteral( "WMSEpsgList" ), QStringLiteral( "/" ), QStringList() );
     bool conversionOk;
-    for ( int i = 0; i < valueList.size(); ++i )
+    for ( const auto &espgStr : valueList )
     {
-      const int epsgNr = valueList.at( i ).toInt( &conversionOk );
+      const int epsgNr = espgStr.toInt( &conversionOk );
       if ( conversionOk )
       {
         crsList.append( QStringLiteral( "EPSG:%1" ).arg( epsgNr ) );

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -371,6 +371,14 @@ class SERVER_EXPORT QgsServerProjectUtils
     static QStringList wmsOutputCrsList( const QgsProject &project );
 
     /**
+   * Returns the WMS output CRS list as OGC URNs.
+   * \param project the QGIS project
+   * \returns the WMS output CRS list.
+   * \since QGIS 4.0
+   */
+    static QStringList wmsOutputCrsListAsOgcUrn( const QgsProject &project );
+
+    /**
    * Returns the WMS Extent restriction.
    * \param project the QGIS project
    * \returns the WMS Extent restriction.

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -491,14 +491,14 @@ namespace QgsWfs
       }
 
       //create DefaultSRS element
-      const QString defaultSrs = layer->crs().authid();
+      const QString defaultSrs = layer->crs().toOgcUrn();
       QDomElement srsElem = doc.createElement( QStringLiteral( "DefaultSRS" ) );
       const QDomText srsText = doc.createTextNode( defaultSrs );
       srsElem.appendChild( srsText );
       layerElem.appendChild( srsElem );
 
       //create OtherSRS elements
-      const QStringList outputCrsList = QgsServerProjectUtils::wmsOutputCrsList( *project );
+      const QStringList outputCrsList = QgsServerProjectUtils::wmsOutputCrsListAsOgcUrn( *project );
       for ( const QString &crs : outputCrsList )
       {
         if ( crs == defaultSrs )

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -93,6 +93,18 @@ namespace QgsWfs
     QgsJsonExporter mJsonExporter;
   } // namespace
 
+  QString getSrsNameFromVersion( const QgsCoordinateReferenceSystem &crs )
+  {
+    if ( mWfsParameters.versionAsNumber() >= QgsProjectVersion( 1, 1, 0 ) )
+    {
+      return crs.toOgcUrn();
+    }
+    else
+    {
+      return crs.authid();
+    }
+  }
+
   void writeGetFeature( QgsServerInterface *serverIface, const QgsProject *project, const QString &version, const QgsServerRequest &request, QgsServerResponse &response )
   {
     Q_UNUSED( version )
@@ -429,7 +441,7 @@ namespace QgsWfs
       {
         // fallback to a default value
         // geojson uses 'EPSG:4326' by default
-        outputSrsName = ( aRequest.outputFormat == QgsWfsParameters::Format::GeoJSON ) ? QStringLiteral( "EPSG:4326" ) : vlayer->crs().authid();
+        outputSrsName = ( aRequest.outputFormat == QgsWfsParameters::Format::GeoJSON ) ? QStringLiteral( "EPSG:4326" ) : getSrsNameFromVersion( vlayer->crs() );
       }
 
       QgsCoordinateReferenceSystem outputCrs;
@@ -1261,7 +1273,7 @@ namespace QgsWfs
         {
           // If requested SRS (outputSrsName) is different from rect CRS (crs) we need to transform the envelope
           const QString requestSrsName = request.serverParameters().value( QStringLiteral( "SRSNAME" ) );
-          const QString outputSrsName = !requestSrsName.isEmpty() ? requestSrsName : crs.authid();
+          const QString outputSrsName = !requestSrsName.isEmpty() ? requestSrsName : getSrsNameFromVersion( crs );
           QgsCoordinateReferenceSystem outputCrs;
           outputCrs.createFromUserInput( outputSrsName );
 
@@ -1291,7 +1303,7 @@ namespace QgsWfs
           {
             if ( crs.isValid() && outputSrsName.isEmpty() )
             {
-              envElem.setAttribute( QStringLiteral( "srsName" ), crs.authid() );
+              envElem.setAttribute( QStringLiteral( "srsName" ), getSrsNameFromVersion( crs ) );
             }
             bbElem.appendChild( envElem );
             doc.appendChild( bbElem );
@@ -1304,7 +1316,7 @@ namespace QgsWfs
           {
             if ( crs.isValid() )
             {
-              boxElem.setAttribute( QStringLiteral( "srsName" ), crs.authid() );
+              boxElem.setAttribute( QStringLiteral( "srsName" ), getSrsNameFromVersion( crs ) );
             }
             bbElem.appendChild( boxElem );
             doc.appendChild( bbElem );
@@ -1473,8 +1485,8 @@ namespace QgsWfs
 
           if ( crs.isValid() )
           {
-            boxElem.setAttribute( QStringLiteral( "srsName" ), crs.authid() );
-            gmlElem.setAttribute( QStringLiteral( "srsName" ), crs.authid() );
+            boxElem.setAttribute( QStringLiteral( "srsName" ), getSrsNameFromVersion( crs ) );
+            gmlElem.setAttribute( QStringLiteral( "srsName" ), getSrsNameFromVersion( crs ) );
           }
 
           bbElem.appendChild( boxElem );
@@ -1566,8 +1578,8 @@ namespace QgsWfs
 
           if ( crs.isValid() && params.srsName.isEmpty() )
           {
-            boxElem.setAttribute( QStringLiteral( "srsName" ), crs.authid() );
-            gmlElem.setAttribute( QStringLiteral( "srsName" ), crs.authid() );
+            boxElem.setAttribute( QStringLiteral( "srsName" ), getSrsNameFromVersion( crs ) );
+            gmlElem.setAttribute( QStringLiteral( "srsName" ), getSrsNameFromVersion( crs ) );
           }
           else if ( !params.srsName.isEmpty() )
           {

--- a/src/server/services/wfs/qgswfsgetfeature.h
+++ b/src/server/services/wfs/qgswfsgetfeature.h
@@ -77,6 +77,8 @@ namespace QgsWfs
    */
   void writeGetFeature( QgsServerInterface *serverIface, const QgsProject *project, const QString &version, const QgsServerRequest &request, QgsServerResponse &response );
 
+  QString getSrsNameFromVersion( const QgsCoordinateReferenceSystem &crs );
+
 } // namespace QgsWfs
 
 #endif

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -105,6 +105,13 @@ void TestQgsOgcUtils::testGeometryFromGML()
   QVERIFY( !geomBox.isNull() );
   QVERIFY( geomBox.wkbType() == Qgis::WkbType::Polygon );
 
+  // Test point GML2 with EPSG:4326
+  // X/Y coordinates are not inverted
+  geom = QgsOgcUtils::geometryFromGML( QStringLiteral( "<gml:Point srsName=\"EPSG:4326\"><gml:coordinates>4,45</gml:coordinates></gml:Point>" ) );
+  QVERIFY( !geom.isNull() );
+  QVERIFY( geom.wkbType() == Qgis::WkbType::Point );
+  QVERIFY( geom.equals( QgsGeometry::fromWkt( QStringLiteral( "POINT (4 45)" ) ) ) );
+
 
   // Test GML3
   geom = QgsOgcUtils::geometryFromGML( QStringLiteral( "<Point><pos>123 456</pos></Point>" ) );
@@ -133,6 +140,21 @@ void TestQgsOgcUtils::testGeometryFromGML()
   QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == Qgis::WkbType::LineStringZ );
   QVERIFY( geom.equals( QgsGeometry::fromWkt( QStringLiteral( "LINESTRINGZ(0 0 1200, 0 1 1250, 1 1 1230, 1 0 1210)" ) ) ) );
+
+  // Test point GML3 with urn:ogc:def:crs:EPSG::4326
+  // X/Y coordinates are inverted
+  geom = QgsOgcUtils::geometryFromGML( QStringLiteral( "<gml:Point srsName=\"urn:ogc:def:crs:EPSG::4326\"><gml:pos>45 4</gml:pos></gml:Point>" ) );
+  QVERIFY( !geom.isNull() );
+  QVERIFY( geom.wkbType() == Qgis::WkbType::Point );
+  QVERIFY( geom.equals( QgsGeometry::fromWkt( QStringLiteral( "POINT (4 45)" ) ) ) );
+
+
+  // Test point GML3 with urn:ogc:def:crs:EPSG::3857
+  // X/Y coordinates are not inverted
+  geom = QgsOgcUtils::geometryFromGML( QStringLiteral( "<gml:Point srsName=\"urn:ogc:def:crs:EPSG::3857\"><gml:pos>32 2</gml:pos></gml:Point>" ) );
+  QVERIFY( !geom.isNull() );
+  QVERIFY( geom.wkbType() == Qgis::WkbType::Point );
+  QVERIFY( geom.equals( QgsGeometry::fromWkt( QStringLiteral( "POINT (32 2)" ) ) ) );
 }
 
 void TestQgsOgcUtils::testGeometryFromGMLWithZ_data()

--- a/tests/testdata/qgis_server/wfs_getCapabilities_1_1_0_no_data.txt
+++ b/tests/testdata/qgis_server/wfs_getCapabilities_1_1_0_no_data.txt
@@ -80,8 +80,8 @@ Content-Type: text/xml; charset=utf-8
   <FeatureType>
    <Name>test_wfs_no_data</Name>
    <Title>test_wfs_no_data</Title>
-   <DefaultSRS>EPSG:4326</DefaultSRS>
-   <OtherSRS>EPSG:3857</OtherSRS>
+   <DefaultSRS>urn:ogc:def:crs:EPSG::4326</DefaultSRS>
+   <OtherSRS>urn:ogc:def:crs:EPSG::3857</OtherSRS>
    <Operations>
     <Operation>Query</Operation>
    </Operations>

--- a/tests/testdata/qgis_server/wfs_getFeature_1_1_0_featureid_0_1_1_0_srsname.txt
+++ b/tests/testdata/qgis_server/wfs_getFeature_1_1_0_featureid_0_1_1_0_srsname.txt
@@ -2,22 +2,22 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 
 <wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/etienne/dev/qgis/qgis-master/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=text/xml; subtype%3Dgml/3.1.1">
 <gml:boundedBy>
- <gml:Envelope srsName="EPSG:4326">
-  <gml:lowerCorner>8.20345931 44.90139484</gml:lowerCorner>
-  <gml:upperCorner>8.20354699 44.90148253</gml:upperCorner>
+ <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+  <gml:lowerCorner>44.90139484 8.20345931</gml:lowerCorner>
+  <gml:upperCorner>44.90148253 8.20354699</gml:upperCorner>
  </gml:Envelope>
 </gml:boundedBy>
 <gml:featureMember>
  <qgs:testlayer gml:id="testlayer.0">
   <gml:boundedBy>
-   <gml:Envelope srsName="EPSG:4326">
-    <gml:lowerCorner>8.20349634 44.90148253</gml:lowerCorner>
-    <gml:upperCorner>8.20349634 44.90148253</gml:upperCorner>
+   <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+    <gml:lowerCorner>44.90148253 8.20349634</gml:lowerCorner>
+    <gml:upperCorner>44.90148253 8.20349634</gml:upperCorner>
    </gml:Envelope>
   </gml:boundedBy>
   <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">8.20349634 44.90148253</pos>
+   <Point xmlns="http://www.opengis.net/gml" srsName="urn:ogc:def:crs:EPSG::4326">
+    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">44.90148253 8.20349634</pos>
    </Point>
   </qgs:geometry>
   <qgs:id>1</qgs:id>

--- a/tests/testdata/qgis_server/wfs_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wfs_getcapabilities.txt
@@ -88,8 +88,8 @@ Content-Type: text/xml; charset=utf-8
    <Name>testlayer</Name>
    <Title>A test wfs vector layer</Title>
    <Abstract>A test vector layer with unicode òà</Abstract>
-   <DefaultSRS>EPSG:4326</DefaultSRS>
-   <OtherSRS>EPSG:3857</OtherSRS>
+   <DefaultSRS>urn:ogc:def:crs:EPSG::4326</DefaultSRS>
+   <OtherSRS>urn:ogc:def:crs:EPSG::3857</OtherSRS>
    <Operations>
     <Operation>Query</Operation>
     <Operation>Insert</Operation>
@@ -104,8 +104,8 @@ Content-Type: text/xml; charset=utf-8
   <FeatureType>
    <Name>Testing_Layer_(copy)</Name>
    <Title>Testing Layer (copy)</Title>
-   <DefaultSRS>EPSG:4326</DefaultSRS>
-   <OtherSRS>EPSG:3857</OtherSRS>
+   <DefaultSRS>urn:ogc:def:crs:EPSG::4326</DefaultSRS>
+   <OtherSRS>urn:ogc:def:crs:EPSG::3857</OtherSRS>
    <Operations>
     <Operation>Query</Operation>
    </Operations>

--- a/tests/testdata/qgis_server/wfs_getfeature_limit2_post_1_1_0.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_limit2_post_1_1_0.txt
@@ -2,22 +2,22 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 
 <wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.qgis.org/gml ?">
 <gml:boundedBy>
- <gml:Envelope srsName="EPSG:4326">
-  <gml:lowerCorner>8 44</gml:lowerCorner>
-  <gml:upperCorner>9 45</gml:upperCorner>
+ <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+  <gml:lowerCorner>44 8</gml:lowerCorner>
+  <gml:upperCorner>45 9</gml:upperCorner>
  </gml:Envelope>
 </gml:boundedBy>
 <gml:featureMember>
  <qgs:testlayer gml:id="testlayer.0">
   <gml:boundedBy>
-   <gml:Envelope srsName="EPSG:4326">
-    <gml:lowerCorner>8.20349634 44.90148253</gml:lowerCorner>
-    <gml:upperCorner>8.20349634 44.90148253</gml:upperCorner>
+   <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+    <gml:lowerCorner>44.90148253 8.20349634</gml:lowerCorner>
+    <gml:upperCorner>44.90148253 8.20349634</gml:upperCorner>
    </gml:Envelope>
   </gml:boundedBy>
   <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">8.20349634 44.90148253</pos>
+   <Point xmlns="http://www.opengis.net/gml" srsName="urn:ogc:def:crs:EPSG::4326">
+    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">44.90148253 8.20349634</pos>
    </Point>
   </qgs:geometry>
   <qgs:id>1</qgs:id>
@@ -28,14 +28,14 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 <gml:featureMember>
  <qgs:testlayer gml:id="testlayer.1">
   <gml:boundedBy>
-   <gml:Envelope srsName="EPSG:4326">
-    <gml:lowerCorner>8.20354699 44.90143568</gml:lowerCorner>
-    <gml:upperCorner>8.20354699 44.90143568</gml:upperCorner>
+   <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+    <gml:lowerCorner>44.90143568 8.20354699</gml:lowerCorner>
+    <gml:upperCorner>44.90143568 8.20354699</gml:upperCorner>
    </gml:Envelope>
   </gml:boundedBy>
   <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">8.20354699 44.90143568</pos>
+   <Point xmlns="http://www.opengis.net/gml" srsName="urn:ogc:def:crs:EPSG::4326">
+    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">44.90143568 8.20354699</pos>
    </Point>
   </qgs:geometry>
   <qgs:id>2</qgs:id>

--- a/tests/testdata/qgis_server/wfs_getfeature_nobbox_post_1_1_0.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_nobbox_post_1_1_0.txt
@@ -2,22 +2,22 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 
 <wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.qgis.org/gml ?">
 <gml:boundedBy>
- <gml:Envelope srsName="EPSG:4326">
-  <gml:lowerCorner>8 44</gml:lowerCorner>
-  <gml:upperCorner>9 45</gml:upperCorner>
+ <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+  <gml:lowerCorner>44 8</gml:lowerCorner>
+  <gml:upperCorner>45 9</gml:upperCorner>
  </gml:Envelope>
 </gml:boundedBy>
 <gml:featureMember>
  <qgs:testlayer gml:id="testlayer.0">
   <gml:boundedBy>
-   <gml:Envelope srsName="EPSG:4326">
-    <gml:lowerCorner>8.20349634 44.90148253</gml:lowerCorner>
-    <gml:upperCorner>8.20349634 44.90148253</gml:upperCorner>
+   <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+    <gml:lowerCorner>44.90148253 8.20349634</gml:lowerCorner>
+    <gml:upperCorner>44.90148253 8.20349634</gml:upperCorner>
    </gml:Envelope>
   </gml:boundedBy>
   <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">8.20349634 44.90148253</pos>
+   <Point xmlns="http://www.opengis.net/gml" srsName="urn:ogc:def:crs:EPSG::4326">
+    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">44.90148253 8.20349634</pos>
    </Point>
   </qgs:geometry>
   <qgs:id>1</qgs:id>
@@ -28,14 +28,14 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 <gml:featureMember>
  <qgs:testlayer gml:id="testlayer.1">
   <gml:boundedBy>
-   <gml:Envelope srsName="EPSG:4326">
-    <gml:lowerCorner>8.20354699 44.90143568</gml:lowerCorner>
-    <gml:upperCorner>8.20354699 44.90143568</gml:upperCorner>
+   <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+    <gml:lowerCorner>44.90143568 8.20354699</gml:lowerCorner>
+    <gml:upperCorner>44.90143568 8.20354699</gml:upperCorner>
    </gml:Envelope>
   </gml:boundedBy>
   <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">8.20354699 44.90143568</pos>
+   <Point xmlns="http://www.opengis.net/gml" srsName="urn:ogc:def:crs:EPSG::4326">
+    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">44.90143568 8.20354699</pos>
    </Point>
   </qgs:geometry>
   <qgs:id>2</qgs:id>
@@ -46,14 +46,14 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 <gml:featureMember>
  <qgs:testlayer gml:id="testlayer.2">
   <gml:boundedBy>
-   <gml:Envelope srsName="EPSG:4326">
-    <gml:lowerCorner>8.20345931 44.90139484</gml:lowerCorner>
-    <gml:upperCorner>8.20345931 44.90139484</gml:upperCorner>
+   <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+    <gml:lowerCorner>44.90139484 8.20345931</gml:lowerCorner>
+    <gml:upperCorner>44.90139484 8.20345931</gml:upperCorner>
    </gml:Envelope>
   </gml:boundedBy>
   <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">8.20345931 44.90139484</pos>
+   <Point xmlns="http://www.opengis.net/gml" srsName="urn:ogc:def:crs:EPSG::4326">
+    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">44.90139484 8.20345931</pos>
    </Point>
   </qgs:geometry>
   <qgs:id>3</qgs:id>

--- a/tests/testdata/qgis_server/wfs_getfeature_srsname_post_1_1_0.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_srsname_post_1_1_0.txt
@@ -2,9 +2,9 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 
 <wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.qgis.org/gml ?">
 <gml:boundedBy>
- <gml:Envelope srsName="EPSG:4326">
-  <gml:lowerCorner>8 44</gml:lowerCorner>
-  <gml:upperCorner>9 45</gml:upperCorner>
+ <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+  <gml:lowerCorner>44 8</gml:lowerCorner>
+  <gml:upperCorner>45 9</gml:upperCorner>
  </gml:Envelope>
 </gml:boundedBy>
 <gml:featureMember>

--- a/tests/testdata/qgis_server/wfs_getfeature_srsname_post_1_1_0_urn.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_srsname_post_1_1_0_urn.txt
@@ -2,9 +2,9 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 
 <wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.qgis.org/gml ?">
 <gml:boundedBy>
- <gml:Envelope srsName="EPSG:4326">
-  <gml:lowerCorner>8 44</gml:lowerCorner>
-  <gml:upperCorner>9 45</gml:upperCorner>
+ <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+  <gml:lowerCorner>44 8</gml:lowerCorner>
+  <gml:upperCorner>45 9</gml:upperCorner>
  </gml:Envelope>
 </gml:boundedBy>
 <gml:featureMember>

--- a/tests/testdata/qgis_server/wfs_getfeature_start1_limit1_post_1_1_0.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_start1_limit1_post_1_1_0.txt
@@ -2,22 +2,22 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 
 <wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.qgis.org/gml ?">
 <gml:boundedBy>
- <gml:Envelope srsName="EPSG:4326">
-  <gml:lowerCorner>8 44</gml:lowerCorner>
-  <gml:upperCorner>9 45</gml:upperCorner>
+ <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+  <gml:lowerCorner>44 8</gml:lowerCorner>
+  <gml:upperCorner>45 9</gml:upperCorner>
  </gml:Envelope>
 </gml:boundedBy>
 <gml:featureMember>
  <qgs:testlayer gml:id="testlayer.1">
   <gml:boundedBy>
-   <gml:Envelope srsName="EPSG:4326">
-    <gml:lowerCorner>8.20354699 44.90143568</gml:lowerCorner>
-    <gml:upperCorner>8.20354699 44.90143568</gml:upperCorner>
+   <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+    <gml:lowerCorner>44.90143568 8.20354699</gml:lowerCorner>
+    <gml:upperCorner>44.90143568 8.20354699</gml:upperCorner>
    </gml:Envelope>
   </gml:boundedBy>
   <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">8.20354699 44.90143568</pos>
+   <Point xmlns="http://www.opengis.net/gml" srsName="urn:ogc:def:crs:EPSG::4326">
+    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">44.90143568 8.20354699</pos>
    </Point>
   </qgs:geometry>
   <qgs:id>2</qgs:id>

--- a/tests/testdata/qgis_server/wfs_getfeature_startindex2_post_1_1_0.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_startindex2_post_1_1_0.txt
@@ -2,22 +2,22 @@ Content-Type: text/xml; subtype=gml/3.1.1; charset=utf-8
 
 <wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd http://www.qgis.org/gml ?">
 <gml:boundedBy>
- <gml:Envelope srsName="EPSG:4326">
-  <gml:lowerCorner>8 44</gml:lowerCorner>
-  <gml:upperCorner>9 45</gml:upperCorner>
+ <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+  <gml:lowerCorner>44 8</gml:lowerCorner>
+  <gml:upperCorner>45 9</gml:upperCorner>
  </gml:Envelope>
 </gml:boundedBy>
 <gml:featureMember>
  <qgs:testlayer gml:id="testlayer.2">
   <gml:boundedBy>
-   <gml:Envelope srsName="EPSG:4326">
-    <gml:lowerCorner>8.20345931 44.90139484</gml:lowerCorner>
-    <gml:upperCorner>8.20345931 44.90139484</gml:upperCorner>
+   <gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+    <gml:lowerCorner>44.90139484 8.20345931</gml:lowerCorner>
+    <gml:upperCorner>44.90139484 8.20345931</gml:upperCorner>
    </gml:Envelope>
   </gml:boundedBy>
   <qgs:geometry>
-   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
-    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">8.20345931 44.90139484</pos>
+   <Point xmlns="http://www.opengis.net/gml" srsName="urn:ogc:def:crs:EPSG::4326">
+    <pos xmlns="http://www.opengis.net/gml" srsDimension="2">44.90139484 8.20345931</pos>
    </Point>
   </qgs:geometry>
   <qgs:id>3</qgs:id>


### PR DESCRIPTION
## Description

From the main commit:
```
QGIS server and the the WFS provider do not have the same behavior
regarding "ESPG:4326" and axis inversion for WFS 1.1.

QGIS server follows Geoserver convention and does not invert the
coordinates with EPSG:4326. However, the WFS provider inverts the
coordinates in that case.

Based on earlier discussions, there is no clear consensus what the
expected behavior is. However, QGIS server would be better using URNs
for WFS 1.1. this would remove this ambiguity.

With this change, the WFS 1.1 requests from QGIS server now expose
URNs by default. There is no change in the 1.0 case.

The unit tests are updated to reflect this change.

Related: https://github.com/qgis/QGIS/pull/57357
```

## qgsogcutils::geometryFromGML change

However, this PR also contains an other commit which might be seen as controversial: a change in `qgsogcutils::geometryFromGML`

Indeed, when changing from "EPSG:4326"  to "urn:ogc:def:crs:EPSG::4326", this introduced a regression in `PyQgsServerWFST` unit test.   
This test launches a QGIS server and uses the WFS provider to do some transactions (insertion, update, deletion). There is an axis inversion in the 1.1 test. Here is what happens:

In the unit test, one want to insert a Point: "POINT (9 45)" with EPSG 4326 and then get the feature to verify the insertion

#### Insert request

 1. QgsWFSProvider prepares a transation and creates a GML3 by calling `ogcUtils::geometryToGML`  with the `invertAxisOrientation` parameter set to `True` because the SRS "urn:ogc:def:crs:EPSG::4326" => GML(Y,X) (correct)
 2. QGIS server recieves the requestion (`qgswfstransaction::performTransaction`) and call QgsOgcUtils::geometryFromGML` to convert the GML3 to a `QgsGeometry`. The destinationCrs is the same as the source crs, therefore no inversion  => QgsGeometry(Y X) Error

#### getFeature request

3. QGIS server recieves a request with "urn:ogc:def:crs:EPSG::4326". It creates a GML3 output in `QgsWfsGetFeature::createFeatureGML3` which itself calls QgsAbstractGeometry::asGml3 with `QgsAbstractGeometry::AxisOrder::YX` to swap XY => GML3(X,Y). The behavior is correct. However, it propagates the error from the step 2.
4. QgsWFSProvider receives the GML and creates a `QgsGeometry` in `QgsGmlStreamingParser::endElement`. It creates a QgsGeometry from the GML and then applies a `QTransform` to make the inversion. The behavior is correct. However it still propagates the error from step 2.

Basically, the question is: what should be the output of `QgsOgcUtils::geometryFromGML( QStringLiteral( "<gml:Point srsName=\"urn:ogc:def:crs:EPSG::4326\"><gml:pos>45 4</gml:pos></gml:Point>" ) )`

At the moment, it is: "POINT (45 4)" (no inversion), I think it should be  "POINT (4 45)" (inversion).

I checked what the ecosystem does. Both `GDAL` and PostGIS` do the inversion without any ambiguity

#### GDAL

```python
#!/usr/bin/env python3

from pathlib import Path
from osgeo import gdal, ogr, osr

point_wkt = "POINT (4 45)"
print(f"input as WKT : {point_wkt}")

# remove files from a previous run
gml_filename = Path("point.gml")
xsd_filename = gml_filename.with_suffix(".xsd")
if gml_filename.is_file():
    gml_filename.unlink()
if xsd_filename.is_file():
    xsd_filename.unlink()


print("Use GML driver to generate a gml file from the WKT")
ds = ogr.GetDriverByName("GML").CreateDataSource(
    gml_filename, options=["FORMAT=" + "GML3"]
)
srs = osr.SpatialReference()
srs.ImportFromEPSG(4326)
layer = ds.CreateLayer("test", srs=srs, geom_type=ogr.wkbMultiPolygon)
feature = ogr.Feature(layer.GetLayerDefn())
feature.SetGeometryDirectly(
    ogr.CreateGeometryFromWkt(point_wkt)
)
layer.CreateFeature(feature)
feature = None
ds = None

print("GML output")
with open(gml_filename) as gml_file:
    print(gml_file.read())
print("-" * 50)

print("check the created GML")
# vérification
file_ = gdal.VSIFOpenL(xsd_filename, "rb")
data = gdal.VSIFReadL(1, 10000, file_)
gdal.VSIFCloseL(file_)
assert b'<!-- srsName="urn:ogc:def:crs:EPSG::4326" -->' in data

ds = ogr.Open(gml_filename)
new_layer = ds.GetLayer(0)
new_srs = new_layer.GetSpatialRef()
assert new_srs.GetAuthorityCode(None) == "4326"
assert new_srs.GetDataAxisToSRSAxisMapping() == [2, 1]
new_feature = new_layer.GetNextFeature()
print(f"WKT Geometry from the gml file {new_feature.GetGeometryRef().ExportToWkt()}")
assert new_feature.GetGeometryRef().ExportToWkt() == point_wkt
```

output
```
input as WKT : POINT (4 45)
Use GML driver to generate a gml file from the WKT
/usr/lib/python3/dist-packages/osgeo/gdal.py:330: FutureWarning: Neither gdal.UseExceptions() nor gdal.DontUseExceptions() has been explicitly called. In GDAL 4.0, exceptions will be enabled by default.
  warnings.warn(
GML output
<?xml version="1.0" encoding="utf-8" ?>
<ogr:FeatureCollection
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://ogr.maptools.org/ point.xsd"
     xmlns:ogr="http://ogr.maptools.org/"
     xmlns:gml="http://www.opengis.net/gml">
  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45 4</gml:lowerCorner><gml:upperCorner>45 4</gml:upperCorner></gml:Envelope></gml:boundedBy>
                                                                                                                                                                            
  <ogr:featureMember>
    <ogr:test gml:id="test.0">
      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>45 4</gml:lowerCorner><gml:upperCorner>45 4</gml:upperCorner></gml:Envelope></gml:boundedBy>
      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326"><gml:pos>45 4</gml:pos></gml:Point></ogr:geometryProperty>
    </ogr:test>
  </ogr:featureMember>
</ogr:FeatureCollection>

--------------------------------------------------
check the created GML
WKT Geometry from the gml file POINT (4 45)
```

#### PostGIS

```python
import psycopg2

point_wkt = "POINT (4 45)"
print(f"input as WKT : {point_wkt}")

conn = psycopg2.connect(service="test")
cursor = conn.cursor()

print("convert to GML3 (ST_GeomFromText)")
req = f"Select ST_AsGML(3, ST_GeomFromText('{point_wkt}', 4326), 5, 17)"
print(req)
cursor.execute(req)
res = cursor.fetchone()
if res:
    gml = res[0]
print(f"GML3 output {gml}")


print("convert GML3 to a Geometry (ST_GeomFromGML)")
req = f"SELECT St_AsText(ST_GeomFromGML('{gml}'))"
cursor.execute(req)
res = cursor.fetchone()
if res:
    geom = res[0]
print(f"WKT Geometry from the GML {geom}")

cursor.close()
conn.close()
```

output

```
input as WKT : POINT (4 45)
convert to GML3 (ST_GeomFromText)
Select ST_AsGML(3, ST_GeomFromText('POINT (4 45)', 4326), 5, 17)
GML3 output <gml:Point srsName="urn:ogc:def:crs:EPSG::4326"><gml:pos srsDimension="2">45 4</gml:pos></gml:Point>
convert GML3 to a Geometry (ST_GeomFromGML)
WKT Geometry from the GML POINT(4 45)
```

The `qgsogcutils::geometryFromGML` change has been discussed a lot with @troopa81 which agrees with me
cc @rouault @elpaso 

**Funded by Ifremer**