### PR TITLE
Seperate NULL value from default value configuration

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsfieldformatter.py
+++ b/python/PyQt6/core/auto_additions/qgsfieldformatter.py
@@ -2,6 +2,8 @@
 QgsFieldFormatter.CanProvideAvailableValues = QgsFieldFormatter.Flag.CanProvideAvailableValues
 QgsFieldFormatter.Flags = lambda flags=0: QgsFieldFormatter.Flag(flags)
 try:
+    QgsFieldFormatter.__attribute_docs__ = {'NULL_VALUE': "Will be saved in the configuration when a value is NULL.\nIt's the magic UUID {2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"}
+    QgsFieldFormatter.__annotations__ = {'NULL_VALUE': str}
     QgsFieldFormatter.__virtual_methods__ = ['representValue', 'sortValue', 'alignmentFlag', 'createCache', 'availableValues']
     QgsFieldFormatter.__abstract_methods__ = ['id']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_additions/qgsvaluemapfieldformatter.py
+++ b/python/PyQt6/core/auto_additions/qgsvaluemapfieldformatter.py
@@ -1,7 +1,5 @@
 # The following has been generated automatically from src/core/fieldformatter/qgsvaluemapfieldformatter.h
 try:
-    QgsValueMapFieldFormatter.__attribute_docs__ = {'NULL_VALUE': "Will be saved in the configuration when a value is NULL.\nIt's the magic UUID {2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"}
-    QgsValueMapFieldFormatter.__annotations__ = {'NULL_VALUE': str}
     QgsValueMapFieldFormatter.__overridden_methods__ = ['id', 'representValue', 'sortValue', 'availableValues']
     QgsValueMapFieldFormatter.__group__ = ['fieldformatter']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluemapfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/fieldformatter/qgsvaluemapfieldformatter.sip.in
@@ -33,8 +33,6 @@ the above configuration:
 %End
   public:
 
-    static const QString NULL_VALUE;
-
     QgsValueMapFieldFormatter();
 %Docstring
 Default constructor of field formatter for a value map field.

--- a/python/PyQt6/core/auto_generated/qgsfieldformatter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfieldformatter.sip.in
@@ -59,6 +59,8 @@ This is an abstract base class and will always need to be subclassed.
 %End
   public:
 
+    static const QString NULL_VALUE;
+
     QgsFieldFormatter();
 
     virtual ~QgsFieldFormatter();

--- a/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -237,6 +237,16 @@ Controls if the constraint result should be visualized on the widget
                                 (mostly editable status)
 %End
 
+    void updateComboBoxValues( const QVariant &value, QComboBox *comboBox );
+%Docstring
+Adds a value to the combobox, for example the default value or the value
+from :py:func:`QgsEditorWidgetWrapper.setValues()`. Updates the combobox
+to show the new value.
+
+:param value: The new value of the attribute
+:param comboBox: Pointer to the combobox of the widget
+%End
+
   signals:
 
  void valueChanged( const QVariant &value );

--- a/python/core/auto_additions/qgsfieldformatter.py
+++ b/python/core/auto_additions/qgsfieldformatter.py
@@ -1,5 +1,7 @@
 # The following has been generated automatically from src/core/qgsfieldformatter.h
 try:
+    QgsFieldFormatter.__attribute_docs__ = {'NULL_VALUE': "Will be saved in the configuration when a value is NULL.\nIt's the magic UUID {2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"}
+    QgsFieldFormatter.__annotations__ = {'NULL_VALUE': str}
     QgsFieldFormatter.__virtual_methods__ = ['representValue', 'sortValue', 'alignmentFlag', 'createCache', 'availableValues']
     QgsFieldFormatter.__abstract_methods__ = ['id']
 except (NameError, AttributeError):

--- a/python/core/auto_additions/qgsvaluemapfieldformatter.py
+++ b/python/core/auto_additions/qgsvaluemapfieldformatter.py
@@ -1,7 +1,5 @@
 # The following has been generated automatically from src/core/fieldformatter/qgsvaluemapfieldformatter.h
 try:
-    QgsValueMapFieldFormatter.__attribute_docs__ = {'NULL_VALUE': "Will be saved in the configuration when a value is NULL.\nIt's the magic UUID {2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"}
-    QgsValueMapFieldFormatter.__annotations__ = {'NULL_VALUE': str}
     QgsValueMapFieldFormatter.__overridden_methods__ = ['id', 'representValue', 'sortValue', 'availableValues']
     QgsValueMapFieldFormatter.__group__ = ['fieldformatter']
 except (NameError, AttributeError):

--- a/python/core/auto_generated/fieldformatter/qgsvaluemapfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluemapfieldformatter.sip.in
@@ -33,8 +33,6 @@ the above configuration:
 %End
   public:
 
-    static const QString NULL_VALUE;
-
     QgsValueMapFieldFormatter();
 %Docstring
 Default constructor of field formatter for a value map field.

--- a/python/core/auto_generated/qgsfieldformatter.sip.in
+++ b/python/core/auto_generated/qgsfieldformatter.sip.in
@@ -59,6 +59,8 @@ This is an abstract base class and will always need to be subclassed.
 %End
   public:
 
+    static const QString NULL_VALUE;
+
     QgsFieldFormatter();
 
     virtual ~QgsFieldFormatter();

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -237,6 +237,16 @@ Controls if the constraint result should be visualized on the widget
                                 (mostly editable status)
 %End
 
+    void updateComboBoxValues( const QVariant &value, QComboBox *comboBox );
+%Docstring
+Adds a value to the combobox, for example the default value or the value
+from :py:func:`QgsEditorWidgetWrapper.setValues()`. Updates the combobox
+to show the new value.
+
+:param value: The new value of the attribute
+:param comboBox: Pointer to the combobox of the widget
+%End
+
   signals:
 
  void valueChanged( const QVariant &value );

--- a/src/core/fieldformatter/qgsvaluemapfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluemapfieldformatter.cpp
@@ -18,8 +18,6 @@
 #include "qgsvectorlayer.h"
 #include "qgsvariantutils.h"
 
-const QString QgsValueMapFieldFormatter::NULL_VALUE = QStringLiteral( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
-
 QgsValueMapFieldFormatter::QgsValueMapFieldFormatter()
 {
   setFlags( flags() | QgsFieldFormatter::CanProvideAvailableValues );

--- a/src/core/fieldformatter/qgsvaluemapfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluemapfieldformatter.h
@@ -43,12 +43,6 @@ class CORE_EXPORT QgsValueMapFieldFormatter : public QgsFieldFormatter
   public:
 
     /**
-     * Will be saved in the configuration when a value is NULL.
-     * It's the magic UUID {2839923C-8B7D-419E-B84B-CA2FE9B80EC7}
-     */
-    static const QString NULL_VALUE;
-
-    /**
       * Default constructor of field formatter for a value map field.
       */
     QgsValueMapFieldFormatter();

--- a/src/core/qgsfieldformatter.cpp
+++ b/src/core/qgsfieldformatter.cpp
@@ -21,6 +21,8 @@
 #include "qgsvectordataprovider.h"
 #include "qgsapplication.h"
 
+const QString QgsFieldFormatter::NULL_VALUE = QStringLiteral( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
+
 QString QgsFieldFormatter::representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const
 {
   Q_UNUSED( config )

--- a/src/core/qgsfieldformatter.h
+++ b/src/core/qgsfieldformatter.h
@@ -69,6 +69,12 @@ class CORE_EXPORT QgsFieldFormatter
 {
   public:
 
+    /**
+     * Will be saved in the configuration when a value is NULL.
+     * It's the magic UUID {2839923C-8B7D-419E-B84B-CA2FE9B80EC7}
+     */
+    static const QString NULL_VALUE;
+
     QgsFieldFormatter() = default;
 
     virtual ~QgsFieldFormatter() = default;

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -21,6 +21,8 @@
 #include "qgsvectorlayerutils.h"
 #include "qgsvectorlayerjoinbuffer.h"
 #include "qgsvectorlayerjoininfo.h"
+#include "qgsfieldformatter.h"
+#include "qgsapplication.h"
 
 #include <QTableView>
 
@@ -145,6 +147,26 @@ void QgsEditorWidgetWrapper::updateValues( const QVariant &value, const QVariant
   if ( !isRunningDeprecatedSetValue )
     setValue( value );
   Q_NOWARN_DEPRECATED_POP
+}
+
+void QgsEditorWidgetWrapper::updateComboBoxValues( const QVariant &value, QComboBox *comboBox )
+{
+  if ( comboBox )
+  {
+    if ( !QgsVariantUtils::isNull( value ) )
+    {
+      QString v = value.toString();
+      if ( comboBox->findData( v ) == -1 )
+      {
+        comboBox->addItem( v.prepend( '(' ).append( ')' ), v );
+      }
+    }
+    // only when "allow null" is checked a null value is added
+    else if ( config( QStringLiteral( "AllowNull" ) ).toBool() && comboBox->findData( QgsFieldFormatter::NULL_VALUE ) == -1 )
+    {
+      comboBox->addItem( QgsApplication::nullRepresentation().prepend( '(' ).append( ')' ), QgsFieldFormatter::NULL_VALUE );
+    }
+  }
 }
 
 QgsEditorWidgetWrapper::ConstraintResult QgsEditorWidgetWrapper::constraintResult() const

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -20,6 +20,7 @@
 #include "qgis_sip.h"
 #include <QMap>
 #include <QVariant>
+#include <QComboBox>
 
 class QgsVectorLayer;
 class QgsField;
@@ -233,6 +234,15 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * \param constraintResultVisible if constraintResult should be displayed (mostly editable status)
      */
     void setConstraintResultVisible( bool constraintResultVisible );
+
+    /**
+    * Adds a value to the combobox, for example the default value or the value from QgsEditorWidgetWrapper::setValues().
+    * Updates the combobox to show the new value.
+    *
+    * \param value The new value of the attribute
+    * \param comboBox Pointer to the combobox of the widget
+    */
+    void updateComboBoxValues( const QVariant &value, QComboBox *comboBox );
 
   signals:
 

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -17,7 +17,7 @@
 #include "moc_qgsvaluemapconfigdlg.cpp"
 
 #include "qgsattributetypeloaddialog.h"
-#include "qgsvaluemapfieldformatter.h"
+#include "qgsfieldformatter.h"
 #include "qgsapplication.h"
 #include "qgssettings.h"
 
@@ -65,7 +65,7 @@ QVariantMap QgsValueMapConfigDlg::config()
 
     QString ks = ki->text();
     if ( ( ks == QgsApplication::nullRepresentation() ) && !( ki->flags() & Qt::ItemIsEditable ) )
-      ks = QgsValueMapFieldFormatter::NULL_VALUE;
+      ks = QgsFieldFormatter::NULL_VALUE;
 
     QVariantMap value;
 
@@ -131,7 +131,7 @@ void QgsValueMapConfigDlg::vCellChanged( int row, int column )
   {
     // check cell value
     QTableWidgetItem *item = tableWidget->item( row, 0 );
-    if ( item && item->data( Qt::ItemDataRole::UserRole ) != QgsValueMapFieldFormatter::NULL_VALUE )
+    if ( item && item->data( Qt::ItemDataRole::UserRole ) != QgsFieldFormatter::NULL_VALUE )
     {
       const QString validValue = checkValueLength( item->text() );
       if ( validValue.length() != item->text().length() )
@@ -198,7 +198,7 @@ void QgsValueMapConfigDlg::updateMap( const QList<QPair<QString, QVariant>> &lis
 
   if ( insertNull )
   {
-    setRow( row, QgsValueMapFieldFormatter::NULL_VALUE, QStringLiteral( "<NULL>" ) );
+    setRow( row, QgsFieldFormatter::NULL_VALUE, QStringLiteral( "<NULL>" ) );
     ++row;
   }
 
@@ -246,7 +246,7 @@ void QgsValueMapConfigDlg::updateMap( const QList<QPair<QString, QVariant>> &lis
 
 QString QgsValueMapConfigDlg::checkValueLength( const QString &value )
 {
-  if ( value == QgsValueMapFieldFormatter::NULL_VALUE || value == QgsApplication::nullRepresentation() )
+  if ( value == QgsFieldFormatter::NULL_VALUE || value == QgsApplication::nullRepresentation() )
   {
     return value;
   }
@@ -272,7 +272,7 @@ void QgsValueMapConfigDlg::populateComboBox( QComboBox *comboBox, const QVariant
     {
       const QVariantMap valueMap = value.toMap();
 
-      if ( skipNull && valueMap.constBegin().value() == QgsValueMapFieldFormatter::NULL_VALUE )
+      if ( skipNull && valueMap.constBegin().value() == QgsFieldFormatter::NULL_VALUE )
         continue;
 
       comboBox->addItem( valueMap.constBegin().key(), valueMap.constBegin().value() );
@@ -283,7 +283,7 @@ void QgsValueMapConfigDlg::populateComboBox( QComboBox *comboBox, const QVariant
     const QVariantMap map = config.value( QStringLiteral( "map" ) ).toMap();
     for ( auto it = map.constBegin(); it != map.constEnd(); ++it )
     {
-      if ( skipNull && it.value() == QgsValueMapFieldFormatter::NULL_VALUE )
+      if ( skipNull && it.value() == QgsFieldFormatter::NULL_VALUE )
         continue;
 
       comboBox->addItem( it.key(), it.value() );
@@ -312,12 +312,12 @@ void QgsValueMapConfigDlg::setRow( int row, const QString &value, const QString 
   QTableWidgetItem *valueCell = nullptr;
   QTableWidgetItem *descriptionCell = new QTableWidgetItem( description );
   tableWidget->insertRow( row );
-  if ( value == QgsValueMapFieldFormatter::NULL_VALUE )
+  if ( value == QgsFieldFormatter::NULL_VALUE )
   {
     QFont cellFont;
     cellFont.setItalic( true );
     valueCell = new QTableWidgetItem( QgsApplication::nullRepresentation() );
-    valueCell->setData( Qt::ItemDataRole::UserRole, QgsValueMapFieldFormatter::NULL_VALUE );
+    valueCell->setData( Qt::ItemDataRole::UserRole, QgsFieldFormatter::NULL_VALUE );
     valueCell->setFont( cellFont );
     valueCell->setFlags( Qt::ItemIsSelectable | Qt::ItemIsEnabled );
     descriptionCell->setFont( cellFont );
@@ -359,7 +359,7 @@ void QgsValueMapConfigDlg::copySelectionToClipboard()
 
 void QgsValueMapConfigDlg::addNullButtonPushed()
 {
-  setRow( tableWidget->rowCount() - 1, QgsValueMapFieldFormatter::NULL_VALUE, QStringLiteral( "<NULL>" ) );
+  setRow( tableWidget->rowCount() - 1, QgsFieldFormatter::NULL_VALUE, QStringLiteral( "<NULL>" ) );
 }
 
 void QgsValueMapConfigDlg::loadFromLayerButtonPushed()
@@ -413,7 +413,7 @@ void QgsValueMapConfigDlg::loadMapFromCSV( const QString &filePath )
     QString key = ceils[0];
     QString val = ceils[1];
     if ( key == QgsApplication::nullRepresentation() )
-      key = QgsValueMapFieldFormatter::NULL_VALUE;
+      key = QgsFieldFormatter::NULL_VALUE;
     map.append( qMakePair( key, val ) );
   }
 

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -16,7 +16,7 @@
 #include "qgsvaluemapwidgetwrapper.h"
 #include "moc_qgsvaluemapwidgetwrapper.cpp"
 #include "qgsvaluemapconfigdlg.h"
-#include "qgsvaluemapfieldformatter.h"
+#include "qgsfieldformatter.h"
 #include "qgsapplication.h"
 
 #include <QSettings>
@@ -37,7 +37,7 @@ QVariant QgsValueMapWidgetWrapper::value() const
     v = mComboBox->currentData();
   }
 
-  if ( v == QgsValueMapFieldFormatter::NULL_VALUE )
+  if ( v == QgsFieldFormatter::NULL_VALUE )
     v = QgsVariantUtils::createNullVariant( field().type() );
 
   return v;
@@ -80,7 +80,7 @@ void QgsValueMapWidgetWrapper::updateValues( const QVariant &value, const QVaria
 {
   QString v;
   if ( QgsVariantUtils::isNull( value ) )
-    v = QgsValueMapFieldFormatter::NULL_VALUE;
+    v = QgsFieldFormatter::NULL_VALUE;
   else
     v = value.toString();
 

--- a/tests/src/gui/testqgsvaluemapwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluemapwidgetwrapper.cpp
@@ -20,7 +20,7 @@
 #include "qgsapplication.h"
 #include "qgseditorwidgetwrapper.h"
 #include "editorwidgets/qgsvaluemapwidgetwrapper.h"
-#include "qgsvaluemapfieldformatter.h"
+#include "qgsfieldformatter.h"
 #include "editorwidgets/qgsvaluemapconfigdlg.h"
 #include "qgsgui.h"
 
@@ -64,7 +64,7 @@ void TestQgsValueMapWidgetWrapper::testPopulateComboBox()
   QVariantMap config;
   QList<QVariant> valueList;
   QVariantMap nullValue;
-  nullValue.insert( QgsApplication::nullRepresentation(), QgsValueMapFieldFormatter::NULL_VALUE );
+  nullValue.insert( QgsApplication::nullRepresentation(), QgsFieldFormatter::NULL_VALUE );
   valueList.append( nullValue );
   QVariantMap value1;
   value1.insert( QStringLiteral( "desc 1" ), QStringLiteral( "val 1" ) );
@@ -83,7 +83,7 @@ void TestQgsValueMapWidgetWrapper::testPopulateComboBox()
 
   QCOMPARE( combo->count(), 3 );
   QCOMPARE( combo->itemText( 0 ), QgsApplication::nullRepresentation() );
-  QCOMPARE( combo->itemData( 0 ).toString(), QgsValueMapFieldFormatter::NULL_VALUE );
+  QCOMPARE( combo->itemData( 0 ).toString(), QgsFieldFormatter::NULL_VALUE );
   QCOMPARE( combo->itemText( 1 ), QStringLiteral( "desc 1" ) );
   QCOMPARE( combo->itemData( 1 ).toString(), QStringLiteral( "val 1" ) );
   QCOMPARE( combo->itemText( 2 ), QStringLiteral( "desc 2" ) );
@@ -102,7 +102,7 @@ void TestQgsValueMapWidgetWrapper::testPopulateComboBox()
   // old style config map (2.x)
   config.clear();
   QVariantMap mapValue;
-  mapValue.insert( QgsApplication::nullRepresentation(), QgsValueMapFieldFormatter::NULL_VALUE );
+  mapValue.insert( QgsApplication::nullRepresentation(), QgsFieldFormatter::NULL_VALUE );
   mapValue.insert( QStringLiteral( "desc 1" ), QStringLiteral( "val 1" ) );
   mapValue.insert( QStringLiteral( "desc 2" ), QStringLiteral( "val 2" ) );
   config.insert( QStringLiteral( "map" ), mapValue );
@@ -113,7 +113,7 @@ void TestQgsValueMapWidgetWrapper::testPopulateComboBox()
 
   QCOMPARE( combo->count(), 3 );
   QCOMPARE( combo->itemText( 0 ), QgsApplication::nullRepresentation() );
-  QCOMPARE( combo->itemData( 0 ).toString(), QgsValueMapFieldFormatter::NULL_VALUE );
+  QCOMPARE( combo->itemData( 0 ).toString(), QgsFieldFormatter::NULL_VALUE );
   QCOMPARE( combo->itemText( 1 ), QStringLiteral( "desc 1" ) );
   QCOMPARE( combo->itemData( 1 ).toString(), QStringLiteral( "val 1" ) );
   QCOMPARE( combo->itemText( 2 ), QStringLiteral( "desc 2" ) );


### PR DESCRIPTION
I first created the PR [Value map allow null value checkbox](https://github.com/qgis/QGIS/pull/62775) which fixes [this](https://github.com/qgis/QGIS/issues/45088) issue. As the modified version of the virtual `QgsEditorWidgetWrapper::updateValues()` can be applied to all widgets with ComboBoxes, I decided to implement my modification as a non-virtual function beside the virtual one, to avoid identical overrides for all 6 widgets with comboboxes. 

There are two motivations for making the change for 4 other combobox widgets besides value map ([unique values,](https://github.com/qgis/QGIS/pull/62750), relation reference, [classification](https://github.com/qgis/QGIS/pull/62802) and value relation) now:
1. alignment of functionality. 
2. continuation of PR [Disable comboboxes with no and one item](https://github.com/qgis/QGIS/pull/61864) : 
    in the case of only one available value, this value has to be selected by default, because the combobox will be disabled 

This PR contains all general changes needed for adding the Allow null value checkbox for the 5 combobox widget types.