### PR TITLE
Don't add undo step when model algorithm was not modified

### DIFF
--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -190,6 +190,10 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
             alg = dlg.createAlgorithm()
             alg.setChildId(self.component().childId())
             alg.copyNonDefinitionPropertiesFromModel(self.model())
+            if alg.toVariant() == self.component().toVariant():
+                # nothing changed, treat as cancel was pressed
+                return
+
             self.aboutToChange.emit(self.tr("Edit {}").format(alg.description()))
             self.model().setChildAlgorithm(alg)
             self.requestModelRepaint.emit()

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -195,24 +195,8 @@ class ModelerParametersDialog(QDialog):
         return self.widget.createAlgorithm()
 
     def okPressed(self):
-        alg = self.createAlgorithm()
-        if alg is None:
-            return
-
-        try:
-            modelAlg = self.model.childAlgorithms()[alg.childId()]
-        except KeyError:
-            # Algorithm is being added to the model, just accept it
+        if self.createAlgorithm() is not None:
             self.accept()
-            return
-        else:
-            # Algorithm is being modified, match the non-definition properties and then check for changes
-            alg.copyNonDefinitionProperties(modelAlg)
-            if modelAlg.toVariant() != alg.toVariant():
-                self.accept()
-                return
-        # No changes were made to the algorithm, treat as 'Cancel' to prevent unnecessary undo steps
-        self.reject()
 
     def openHelp(self):
         algHelp = self.widget.algorithm().helpUrl()

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -195,8 +195,24 @@ class ModelerParametersDialog(QDialog):
         return self.widget.createAlgorithm()
 
     def okPressed(self):
-        if self.createAlgorithm() is not None:
+        alg = self.createAlgorithm()
+        if alg is None:
+            return
+
+        try:
+            modelAlg = self.model.childAlgorithms()[alg.childId()]
+        except KeyError:
+            # Algorithm is being added to the model, just accept it
             self.accept()
+            return
+        else:
+            # Algorithm is being modified, match the non-definition properties and then check for changes
+            alg.copyNonDefinitionProperties(modelAlg)
+            if modelAlg.toVariant() != alg.toVariant():
+                self.accept()
+                return
+        # No changes were made to the algorithm, treat as 'Cancel' to prevent unnecessary undo steps
+        self.reject()
 
     def openHelp(self):
         algHelp = self.widget.algorithm().helpUrl()


### PR DESCRIPTION
## Description
When editing an algorithm in a model, clicking OK would create an undo step even if nothing was changed.
With this PR, _OK_ is treated as a _Cancel_ when the algorithm's parameters, comment and comment color (anything that can be modified in the algorithm's dialog) has not changed, keeping the undo stack clean.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
