### PR TITLE
Add a bit more thread-safety to QgsMapSettings

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmapsettings.sip.in
@@ -1101,6 +1101,7 @@ renders is permitted.
 
 
 
+
     void updateDerived();
 
 };

--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -1101,6 +1101,7 @@ renders is permitted.
 
 
 
+
     void updateDerived();
 
 };

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -299,12 +299,19 @@ void QgsMapSettings::setDpiTarget( double dpi )
 
 QStringList QgsMapSettings::layerIds( bool expandGroupLayers ) const
 {
-  const QList<QgsMapLayer * > mapLayers = layers( expandGroupLayers );
-  QStringList res;
-  res.reserve( mapLayers.size() );
-  for ( const QgsMapLayer *layer : mapLayers )
-    res << layer->id();
-  return res;
+  if ( !expandGroupLayers || !mHasGroupLayers )
+  {
+    return mLayerIds;
+  }
+  else
+  {
+    const QList<QgsMapLayer * > mapLayers = layers( expandGroupLayers );
+    QStringList res;
+    res.reserve( mapLayers.size() );
+    for ( const QgsMapLayer *layer : mapLayers )
+      res << layer->id();
+    return res;
+  }
 }
 
 QList<QgsMapLayer *> QgsMapSettings::layers( bool expandGroupLayers ) const
@@ -363,6 +370,18 @@ void QgsMapSettings::setLayers( const QList<QgsMapLayer *> &layers )
   } ), filteredList.end() );
 
   mLayers = _qgis_listRawToQPointer( filteredList );
+
+  // pre-generate and store layer IDs, so that we can safely access them from other threads
+  // without needing to touch the actual map layer object
+  mLayerIds.clear();
+  mHasGroupLayers = false;
+  mLayerIds.reserve( mLayers.size() );
+  for ( const QgsMapLayer *layer : std::as_const( mLayers ) )
+  {
+    mLayerIds << layer->id();
+    if ( layer->type() == Qgis::LayerType::Group )
+      mHasGroupLayers = true;
+  }
 }
 
 QMap<QString, QString> QgsMapSettings::layerStyleOverrides() const

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -957,6 +957,9 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
 
     //! list of layers to be rendered (stored as weak pointers)
     QgsWeakMapLayerPointerList mLayers;
+    QStringList mLayerIds;
+    bool mHasGroupLayers = false;
+
     QMap<QString, QString> mLayerStyleOverrides;
     QString mCustomRenderFlags;
     QVariantMap mCustomRenderingFlags;


### PR DESCRIPTION
Avoid accessing layers to retrieve their IDs in common situations
