### PR TITLE
[layouts] Insure that @layout_page and @layout_numpages reflect the actual page index and count during export

### DIFF
--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -640,7 +640,17 @@ QgsExpressionContextScope *QgsExpressionContextUtils::layoutScope( const QgsLayo
   if ( const QgsMasterLayoutInterface *l = dynamic_cast< const QgsMasterLayoutInterface * >( layout ) )
     scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_name" ), l->name(), true ) );
 
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_numpages" ), layout->pageCollection()->pageCount(), true ) );
+  // get the list of pages
+  QList<int> pages;
+  for ( int i = 0; i < layout->pageCollection()->pageCount(); i++ )
+  {
+    if ( layout->renderContext().isPreviewRender() || ( layout->pageCollection()->shouldExportPage( i ) ) )
+    {
+      pages << i;
+    }
+  }
+
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_numpages" ), pages.size(), true ) );
   if ( layout->pageCollection()->pageCount() > 0 )
   {
     // just take first page size
@@ -652,8 +662,11 @@ QgsExpressionContextScope *QgsExpressionContextUtils::layoutScope( const QgsLayo
   QVariantList offsets;
   for ( int i = 0; i < layout->pageCollection()->pageCount(); i++ )
   {
-    const QPointF p = layout->pageCollection()->pagePositionToLayoutPosition( i, QgsLayoutPoint( 0, 0 ) );
-    offsets << p.y();
+    if ( pages.contains( i ) )
+    {
+      const QPointF p = layout->pageCollection()->pagePositionToLayoutPosition( i, QgsLayoutPoint( 0, 0 ) );
+      offsets << p.y();
+    }
   }
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_pageoffsets" ), offsets, true ) );
 
@@ -778,10 +791,33 @@ QgsExpressionContextScope *QgsExpressionContextUtils::layoutItemScope( const Qgs
     scope->setVariable( variableName, varValue );
   }
 
+  int itemPage = 1;
+  bool itemPageFound = false;
+  if ( item->layout() )
+  {
+    for ( int i = 0; i < item->layout()->pageCollection()->pageCount(); i++ )
+    {
+      if ( item->layout()->renderContext().isPreviewRender() || ( item->layout()->pageCollection()->shouldExportPage( i ) ) )
+      {
+        if ( i == item->page() )
+        {
+          itemPageFound = true;
+          break;
+        }
+
+        itemPage++;
+      }
+    }
+  }
+  if ( !itemPageFound )
+  {
+    itemPage = -1;
+  }
+
   //add known layout item context variables
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_id" ), item->id(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "item_uuid" ), item->uuid(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_page" ), item->page() + 1, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "layout_page" ), itemPage, true ) );
 
   if ( item->layout() )
   {

--- a/tests/src/core/testqgslayout.cpp
+++ b/tests/src/core/testqgslayout.cpp
@@ -25,6 +25,7 @@
 #include "qgslayoutitemlabel.h"
 #include "qgslayoutitempolyline.h"
 #include "qgslayoutitemhtml.h"
+#include "qgslayoutitemmanualtable.h"
 #include "qgslayoutframe.h"
 #include "qgsprintlayout.h"
 #include "qgslayoutatlas.h"
@@ -66,6 +67,7 @@ class TestQgsLayout : public QgsTest
 #ifdef WITH_QTWEBKIT
     void shouldExportPage();
 #endif
+    void expressionContextPageVariables();
     void pageIsEmpty();
     void clear();
     void georeference();
@@ -738,6 +740,114 @@ void TestQgsLayout::shouldExportPage()
   QVERIFY( !l.pageCollection()->shouldExportPage( 1 ) );
 }
 #endif
+
+void TestQgsLayout::expressionContextPageVariables()
+{
+  QgsProject proj;
+  QgsLayout l( &proj );
+  QgsLayoutItemPage *page = new QgsLayoutItemPage( &l );
+  page->setPageSize( "A4" );
+  l.pageCollection()->addPage( page );
+  QgsLayoutItemPage *page2 = new QgsLayoutItemPage( &l );
+  page2->setPageSize( "A4" );
+  l.pageCollection()->addPage( page2 );
+  QgsLayoutItemPage *page3 = new QgsLayoutItemPage( &l );
+  page3->setPageSize( "A4" );
+  l.pageCollection()->addPage( page3 );
+
+  QgsLayoutItemLabel *labelItem = new QgsLayoutItemLabel( &l );
+  labelItem->attemptSetSceneRect( QRectF( 0, 640, 100, 100 ) );
+
+  QgsLayoutItemManualTable *manualTableItem = new QgsLayoutItemManualTable( &l );
+  //frame on page 1
+  QgsLayoutFrame *frame1 = new QgsLayoutFrame( &l, manualTableItem );
+  frame1->attemptSetSceneRect( QRectF( 0, 0, 100, 100 ) );
+  //frame on page 2
+  QgsLayoutFrame *frame2 = new QgsLayoutFrame( &l, manualTableItem );
+  frame2->attemptSetSceneRect( QRectF( 0, 320, 100, 100 ) );
+  frame2->setHidePageIfEmpty( true );
+  manualTableItem->addFrame( frame1 );
+  manualTableItem->addFrame( frame2 );
+
+  QgsTableContents contents;
+  for ( int i = 0; i < 10; i++ )
+  {
+    contents << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Iterator value" ) ) << QgsTableCell( i ) );
+  }
+  manualTableItem->setTableContents( contents );
+
+  QgsExpressionContext context;
+
+  l.renderContext().mIsPreviewRender = true;
+  context = labelItem->createExpressionContext();
+  QCOMPARE( context.variable( "layout_page" ).toInt(), 3 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 3 );
+  l.renderContext().mIsPreviewRender = false;
+  context = labelItem->createExpressionContext();
+  QCOMPARE( context.variable( "layout_page" ).toInt(), 2 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 2 );
+  context = frame2->createExpressionContext();
+  //insure that the layout_page variable for items on skipped pages return -1
+  QCOMPARE( context.variable( "layout_page" ).toInt(), -1 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 2 );
+
+  for ( int i = 0; i < 10; i++ )
+  {
+    contents << ( QgsTableRow() << QgsTableCell( QStringLiteral( "Iterator value" ) ) << QgsTableCell( i ) );
+  }
+  manualTableItem->setTableContents( contents );
+
+  l.renderContext().mIsPreviewRender = true;
+  context = labelItem->createExpressionContext();
+  QCOMPARE( context.variable( "layout_page" ).toInt(), 3 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 3 );
+  l.renderContext().mIsPreviewRender = false;
+  context = labelItem->createExpressionContext();
+  QCOMPARE( context.variable( "layout_page" ).toInt(), 3 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 3 );
+
+  // get rid of frames
+  l.removeItem( frame1 );
+  l.removeItem( frame2 );
+  l.removeMultiFrame( manualTableItem );
+  delete manualTableItem;
+  QgsApplication::sendPostedEvents( nullptr, QEvent::DeferredDelete );
+
+  l.renderContext().mIsPreviewRender = true;
+  context = labelItem->createExpressionContext();
+  QCOMPARE( context.variable( "layout_page" ).toInt(), 3 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 3 );
+  l.renderContext().mIsPreviewRender = false;
+  context = labelItem->createExpressionContext();
+  QCOMPARE( context.variable( "layout_page" ).toInt(), 3 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 3 );
+
+  // explicitly set exclude from exports
+  l.pageCollection()->page( 0 )->setExcludeFromExports( true );
+
+  l.renderContext().mIsPreviewRender = true;
+  context = labelItem->createExpressionContext();
+  QCOMPARE( context.variable( "layout_page" ).toInt(), 3 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 3 );
+  l.renderContext().mIsPreviewRender = false;
+  context = labelItem->createExpressionContext();
+  QCOMPARE( context.variable( "layout_page" ).toInt(), 2 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 2 );
+
+  l.pageCollection()->page( 1 )->setExcludeFromExports( false );
+  l.pageCollection()->page( 0 )->dataDefinedProperties().setProperty( QgsLayoutObject::DataDefinedProperty::ExcludeFromExports, QgsProperty::fromExpression( "1" ) );
+  l.pageCollection()->page( 1 )->dataDefinedProperties().setProperty( QgsLayoutObject::DataDefinedProperty::ExcludeFromExports, QgsProperty::fromValue( true ) );
+  l.refresh();
+
+  l.renderContext().mIsPreviewRender = true;
+  context = labelItem->createExpressionContext();
+  QCOMPARE( context.variable( "layout_page" ).toInt(), 3 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 3 );
+  l.renderContext().mIsPreviewRender = false;
+  context = labelItem->createExpressionContext();
+  QCOMPARE( context.variable( "layout_page" ).toInt(), 1 );
+  QCOMPARE( context.variable( "layout_numpages" ).toInt(), 1 );
+}
 
 void TestQgsLayout::pageIsEmpty()
 {


### PR DESCRIPTION
## Description

This PR addresses issue https://github.com/qgis/QGIS/issues/59258 , whereas the @layout_page and @layout_numpages expression context variables do not reflect the exported values when page(s) are excluded.

This allows for layouts with pages excluded through data-defined properties, empty multi-frame page exclusion, etc. to have proper page footer / header with page index and sum that reflects the exported outputs (PDF, individual image pages, etc.).

Test coverage has been added too, which doubles as a test for the QgsPageCollection::shouldExportPage() when QGIS is not built against QtWebkit.