### PR TITLE
[3D] Properly handle Z components in buffered lines

### DIFF
--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -150,7 +150,10 @@ void QgsBufferedLine3DSymbolHandler::processFeature( const QgsFeature &feature, 
 
   QgsAbstractGeometry *buffered = engine.buffer( width / 2., nSegments, endCapStyle, joinStyle, mitreLimit ); // factory
   if ( !buffered )
+  {
+    QgsDebugError( QStringLiteral( "Failed to create a buffer for the 3D line." ) );
     return;
+  }
 
   if ( QgsWkbTypes::flatType( buffered->wkbType() ) == Qgis::WkbType::Polygon )
   {


### PR DESCRIPTION
## Description

From the main commit: 

```
When displaying lines in a 3D view, the Z component of the lines is
completely ignored and therefore they are stuck to the terrain even if
altitude clamping is absolute or relative.

This occurs because a GEOS buffer of the input lines is computed
during the preprocessing stage. Indeed, this algorithm completely
discards the Z component of the geometries.

This issue is fixed by using the buffer3D algorithm from SFCGAL,
which does not discard the Z component of the line.

In the SFCGAL case, the generated buffer is a PolyhedralSurface. It is
processed similarly to a MultiPolygon, by iterating over its patches.
```

## Example

3D line

```
LineString Z (321888.10024832194903865 129583.39222279700334184 17.3, 322073.91225017287069932 129679.82072612721822225 27.8, 322129.39166304777609184 129600.56442202019388787 -14.1)
```

### Before

<img width="1920" height="1048" alt="line-before" src="https://github.com/user-attachments/assets/bf1734b5-c12a-4ca3-af3a-90642fa909e2" />

### After

<img width="1920" height="1048" alt="line-after" src="https://github.com/user-attachments/assets/22653d91-3c1e-4ad7-a149-74f90ae8be24" />


cc @benoitdm-oslandia 