### PR TITLE
qgsauthoauth2method.cpp: signal related fixes

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -292,6 +292,7 @@ void registerMetaTypes()
   qRegisterMetaType<QMap<QNetworkRequest::Attribute, QVariant>>( "QMap<QNetworkRequest::Attribute,QVariant>" );
   qRegisterMetaType<QMap<QNetworkRequest::KnownHeaders, QVariant>>( "QMap<QNetworkRequest::KnownHeaders,QVariant>" );
   qRegisterMetaType<QList<QNetworkReply::RawHeaderPair>>( "QList<QNetworkReply::RawHeaderPair>" );
+  qRegisterMetaType<QNetworkReply::NetworkError>( "QNetworkReply::NetworkError" );
   qRegisterMetaType< QAuthenticator * >( "QAuthenticator*" );
   qRegisterMetaType< QgsGpsInformation >( "QgsGpsInformation" );
   qRegisterMetaType< QgsSensorThingsExpansionDefinition >( "QgsSensorThingsExpansionDefinition" );


### PR DESCRIPTION
- an old style Qt<5 signal connection pattern
- a wrong expected sender() in the onRefreshFinished() slot

None of them seemed to affect normal usage, but the error on the onRefreshFinished() slot generated an erroneous log message 'Token refresh finished but no reply object accessible' that complicates diagnostic.
