### PR TITLE
Fix convertFromPainterUnits when used with Qgis::RenderUnit::MetersInMapUnits

### DIFF
--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -546,7 +546,7 @@ double QgsRenderContext::convertFromPainterUnits( double size, Qgis::RenderUnit 
     case Qgis::RenderUnit::MetersInMapUnits:
     {
       if ( mMapToPixel.isValid() )
-        size = 1 / convertMetersToMapUnits( size );
+        size = size / convertMetersToMapUnits( 1 );
       // Fall through to RenderMapUnits with size in meters converted to size in MapUnits
       [[fallthrough]];
     }

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -941,6 +941,21 @@ class TestQgsRenderContext(QgisTestCase):
         size = r.convertFromPainterUnits(2, QgsUnitTypes.RenderUnit.RenderPixels)
         self.assertAlmostEqual(size, 2.0, places=5)
 
+    def testConvertFromPainterUnitsToMetersInMapUnits(self):
+
+        ms = QgsMapSettings()
+        ms.setExtent(QgsRectangle(0, 0, 0.05242, 0.05242))
+        ms.setOutputSize(QSize(1108, 1108))
+        ms.setOutputDpi(300)
+        ms.setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:4326"))
+        r = QgsRenderContext.fromMapSettings(ms)
+
+        meters = r.convertFromPainterUnits(100, Qgis.RenderUnit.MetersInMapUnits)
+        self.assertAlmostEqual(meters, 526.6576805877552, places=5)
+
+        pixels = r.convertToPainterUnits(meters, Qgis.RenderUnit.MetersInMapUnits)
+        self.assertAlmostEqual(pixels, 100, places=5)
+
     def testPixelSizeScaleFactor(self):
         ms = QgsMapSettings()
         ms.setExtent(QgsRectangle(0, 0, 100, 100))


### PR DESCRIPTION
As far as I am aware, the function was only used with this enum in [QgsHighLight](https://github.com/qgis/QGIS/blob/8dff2a4d663632cbb45b27d108f4ee90d2d041e4/src/gui/qgshighlight.cpp#L196) and so it fixes identify when used with stroke width define in "meters at scale".

Before fix
<img width="588" height="306" alt="beforefix" src="https://github.com/user-attachments/assets/b3e324d9-3fe8-44ab-9572-c43f60c63611" />

After fix
<img width="599" height="311" alt="afterfix" src="https://github.com/user-attachments/assets/c2cec0d7-3e40-4aaa-a350-a554f1b08316" />


Added a test to check that we can convert from and to painter units and gets the same value.

**Funded by Stadt Frankfurt am Main**