### PR TITLE
[3d] qgs3dsceneexporter/qgs3dexportobject misc cleanups

### DIFF
--- a/src/3d/qgs3dexportobject.cpp
+++ b/src/3d/qgs3dexportobject.cpp
@@ -107,7 +107,7 @@ void Qgs3DExportObject::setupMaterial( QgsAbstractMaterialSettings *material )
   }
 }
 
-void Qgs3DExportObject::objectBounds( float &minX, float &minY, float &minZ, float &maxX, float &maxY, float &maxZ )
+void Qgs3DExportObject::objectBounds( float &minX, float &minY, float &minZ, float &maxX, float &maxY, float &maxZ ) const
 {
   if ( mType != TriangularFaces )
     return;
@@ -123,7 +123,7 @@ void Qgs3DExportObject::objectBounds( float &minX, float &minY, float &minZ, flo
   }
 }
 
-void Qgs3DExportObject::saveTo( QTextStream &out, float scale, const QVector3D &center, int precision )
+void Qgs3DExportObject::saveTo( QTextStream &out, float scale, const QVector3D &center, int precision ) const
 {
   // Set groups
   // turns out grouping doest work as expected in blender
@@ -210,7 +210,7 @@ void Qgs3DExportObject::saveTo( QTextStream &out, float scale, const QVector3D &
   }
 }
 
-QString Qgs3DExportObject::saveMaterial( QTextStream &mtlOut, const QString &folderPath )
+QString Qgs3DExportObject::saveMaterial( QTextStream &mtlOut, const QString &folderPath ) const
 {
   QString materialName = mName + "_material";
   if ( mMaterialParameters.size() == 0 && ( mTexturesUV.size() == 0 || mTextureImage.isNull() ) )

--- a/src/3d/qgs3dexportobject.cpp
+++ b/src/3d/qgs3dexportobject.cpp
@@ -62,17 +62,31 @@ void Qgs3DExportObject::setupPositionCoordinates( const QVector<float> &position
   }
 }
 
-void Qgs3DExportObject::setupFaces( const QVector<uint> &facesIndexes )
+void Qgs3DExportObject::setupTriangle( const QVector<float> &positionsBuffer, const QVector<uint> &facesIndexes, const QMatrix4x4 &transform )
 {
+  mType = Qgs3DExportObject::TriangularFaces;
+  setupPositionCoordinates( positionsBuffer, transform );
+
+  // setup faces
   mIndexes.clear();
   insertIndexData<uint>( mIndexes, facesIndexes );
 }
 
-void Qgs3DExportObject::setupLine()
+void Qgs3DExportObject::setupLine( const QVector<float> &positionsBuffer )
 {
+  mType = Qgs3DExportObject::LineStrip;
+  setupPositionCoordinates( positionsBuffer );
+
+  // setup indexes
   mIndexes.clear();
   for ( int i = 0; i < mVertexPosition.size(); i += 3 )
     mIndexes << i / 3 + 1;
+}
+
+void Qgs3DExportObject::setupPoint( const QVector<float> &positionsBuffer )
+{
+  mType = Qgs3DExportObject::Points;
+  setupPositionCoordinates( positionsBuffer );
 }
 
 void Qgs3DExportObject::setupNormalCoordinates( const QVector<float> &normalsBuffer, const QMatrix4x4 &transform )

--- a/src/3d/qgs3dexportobject.cpp
+++ b/src/3d/qgs3dexportobject.cpp
@@ -103,7 +103,7 @@ void Qgs3DExportObject::setupMaterial( QgsAbstractMaterialSettings *material )
   QMap<QString, QString> parameters = material->toExportParameters();
   for ( auto it = parameters.begin(); it != parameters.end(); ++it )
   {
-    setMaterialParameter( it.key(), it.value() );
+    mMaterialParameters[it.key()] = it.value();
   }
 }
 

--- a/src/3d/qgs3dexportobject.cpp
+++ b/src/3d/qgs3dexportobject.cpp
@@ -66,9 +66,8 @@ void Qgs3DExportObject::setupFaces( const QVector<uint> &facesIndexes )
   insertIndexData<uint>( mIndexes, facesIndexes );
 }
 
-void Qgs3DExportObject::setupLine( const QVector<uint> &lineIndexes )
+void Qgs3DExportObject::setupLine()
 {
-  Q_UNUSED( lineIndexes );
   for ( int i = 0; i < mVertexPosition.size(); i += 3 )
     mIndexes << i / 3 + 1;
 }

--- a/src/3d/qgs3dexportobject.cpp
+++ b/src/3d/qgs3dexportobject.cpp
@@ -53,6 +53,7 @@ void insertIndexData( QVector<uint> &vertexIndex, const QVector<T> &faceIndex )
 
 void Qgs3DExportObject::setupPositionCoordinates( const QVector<float> &positionsBuffer, const QMatrix4x4 &transform )
 {
+  mVertexPosition.clear();
   for ( int i = 0; i < positionsBuffer.size(); i += 3 )
   {
     const QVector3D position( positionsBuffer[i], positionsBuffer[i + 1], positionsBuffer[i + 2] );
@@ -63,17 +64,21 @@ void Qgs3DExportObject::setupPositionCoordinates( const QVector<float> &position
 
 void Qgs3DExportObject::setupFaces( const QVector<uint> &facesIndexes )
 {
+  mIndexes.clear();
   insertIndexData<uint>( mIndexes, facesIndexes );
 }
 
 void Qgs3DExportObject::setupLine()
 {
+  mIndexes.clear();
   for ( int i = 0; i < mVertexPosition.size(); i += 3 )
     mIndexes << i / 3 + 1;
 }
 
 void Qgs3DExportObject::setupNormalCoordinates( const QVector<float> &normalsBuffer, const QMatrix4x4 &transform )
 {
+  mNormals.clear();
+
   // Qt does not provide QMatrix3x3 * QVector3D multiplication so we use QMatrix4x4
   QMatrix3x3 normal3x3 = transform.normalMatrix();
   QMatrix4x4 normal4x4( normal3x3( 0, 0 ), normal3x3( 0, 1 ), normal3x3( 0, 2 ), 0, normal3x3( 1, 0 ), normal3x3( 1, 1 ), normal3x3( 1, 2 ), 0, normal3x3( 2, 0 ), normal3x3( 2, 1 ), normal3x3( 2, 2 ), 0, 0, 0, 0, 1 );
@@ -95,11 +100,13 @@ void Qgs3DExportObject::setupNormalCoordinates( const QVector<float> &normalsBuf
 
 void Qgs3DExportObject::setupTextureCoordinates( const QVector<float> &texturesBuffer )
 {
+  mTexturesUV.clear();
   mTexturesUV << texturesBuffer;
 }
 
 void Qgs3DExportObject::setupMaterial( QgsAbstractMaterialSettings *material )
 {
+  mMaterialParameters.clear();
   QMap<QString, QString> parameters = material->toExportParameters();
   for ( auto it = parameters.begin(); it != parameters.end(); ++it )
   {

--- a/src/3d/qgs3dexportobject.cpp
+++ b/src/3d/qgs3dexportobject.cpp
@@ -36,21 +36,6 @@ typedef Qt3DCore::QBuffer Qt3DQBuffer;
 #include "qgsabstractmaterialsettings.h"
 
 
-template<typename T>
-void insertIndexData( QVector<uint> &vertexIndex, const QVector<T> &faceIndex )
-{
-  for ( int i = 0; i < faceIndex.size(); i += 3 )
-  {
-    if ( i + 2 >= faceIndex.size() )
-      continue;
-    // skip invalid triangles
-    if ( faceIndex[i] == faceIndex[i + 1] || faceIndex[i + 1] == faceIndex[i + 2] || faceIndex[i] == faceIndex[i + 2] )
-      continue;
-    for ( int j = 0; j < 3; ++j )
-      vertexIndex << faceIndex[i + j];
-  }
-}
-
 void Qgs3DExportObject::setupPositionCoordinates( const QVector<float> &positionsBuffer, const QMatrix4x4 &transform )
 {
   mVertexPosition.clear();
@@ -69,7 +54,16 @@ void Qgs3DExportObject::setupTriangle( const QVector<float> &positionsBuffer, co
 
   // setup faces
   mIndexes.clear();
-  insertIndexData<uint>( mIndexes, facesIndexes );
+  for ( int i = 0; i < facesIndexes.size(); i += 3 )
+  {
+    if ( i + 2 >= facesIndexes.size() )
+      continue;
+    // skip invalid triangles
+    if ( facesIndexes[i] == facesIndexes[i + 1] || facesIndexes[i + 1] == facesIndexes[i + 2] || facesIndexes[i] == facesIndexes[i + 2] )
+      continue;
+    for ( int j = 0; j < 3; ++j )
+      mIndexes << facesIndexes[i + j];
+  }
 }
 
 void Qgs3DExportObject::setupLine( const QVector<float> &positionsBuffer )

--- a/src/3d/qgs3dexportobject.h
+++ b/src/3d/qgs3dexportobject.h
@@ -82,7 +82,7 @@ class _3D_EXPORT Qgs3DExportObject
     void setupNormalCoordinates( const QVector<float> &normalsBuffer, const QMatrix4x4 &transform );
     //! Sets texture coordinates for each vertex
     void setupTextureCoordinates( const QVector<float> &texturesBuffer );
-    //! Sets the material parameters (diffuse color, shininess...) from phong material
+    //! Sets the material parameters (diffuse color, shininess...) to be exported in the .mtl file
     void setupMaterial( QgsAbstractMaterialSettings *material );
 
     //! Sets the texture image used by the object
@@ -96,9 +96,6 @@ class _3D_EXPORT Qgs3DExportObject
      * This expands the bounding box if the current object outside the bounds of the already established bounds
      */
     void objectBounds( float &minX, float &minY, float &minZ, float &maxX, float &maxY, float &maxZ );
-
-    //! Sets a material parameter to be exported in the .mtl file
-    void setMaterialParameter( const QString &parameter, const QString &value ) { mMaterialParameters[parameter] = value; }
 
     //! Saves the current object to the output stream while scaling the object and centering it to be visible in exported scene
     void saveTo( QTextStream &out, float scale, const QVector3D &center, int precision = 6 );

--- a/src/3d/qgs3dexportobject.h
+++ b/src/3d/qgs3dexportobject.h
@@ -95,12 +95,12 @@ class _3D_EXPORT Qgs3DExportObject
      * Updates the box bounds explained with the current object bounds
      * This expands the bounding box if the current object outside the bounds of the already established bounds
      */
-    void objectBounds( float &minX, float &minY, float &minZ, float &maxX, float &maxY, float &maxZ );
+    void objectBounds( float &minX, float &minY, float &minZ, float &maxX, float &maxY, float &maxZ ) const;
 
     //! Saves the current object to the output stream while scaling the object and centering it to be visible in exported scene
-    void saveTo( QTextStream &out, float scale, const QVector3D &center, int precision = 6 );
+    void saveTo( QTextStream &out, float scale, const QVector3D &center, int precision = 6 ) const;
     //! saves the texture of the object and material information
-    QString saveMaterial( QTextStream &mtlOut, const QString &folder );
+    QString saveMaterial( QTextStream &mtlOut, const QString &folder ) const;
 
     //! Returns the vertex coordinates
     QVector<float> vertexPosition() const { return mVertexPosition; }

--- a/src/3d/qgs3dexportobject.h
+++ b/src/3d/qgs3dexportobject.h
@@ -76,7 +76,7 @@ class _3D_EXPORT Qgs3DExportObject
     //! Sets the faces in facesIndexes to the faces in the object
     void setupFaces( const QVector<uint> &facesIndexes );
     //! sets line vertex indexes
-    void setupLine( const QVector<uint> &facesIndexes );
+    void setupLine();
 
     //! Sets normal coordinates for each vertex
     void setupNormalCoordinates( const QVector<float> &normalsBuffer, const QMatrix4x4 &transform );

--- a/src/3d/qgs3dexportobject.h
+++ b/src/3d/qgs3dexportobject.h
@@ -22,6 +22,7 @@
 #include <QVector3D>
 #include <QImage>
 #include <QMap>
+#include <QMatrix4x4>
 
 #include "qgis_3d.h"
 
@@ -63,20 +64,20 @@ class _3D_EXPORT Qgs3DExportObject
 
     //! Returns the object type
     ObjectType type() const { return mType; }
-    //! Sets the object type
-    void setType( ObjectType type ) { mType = type; }
 
     //! Returns whether object edges will look smooth
     bool smoothEdges() const { return mSmoothEdges; }
     //! Sets whether triangles edges will look smooth
     void setSmoothEdges( bool smoothEdges ) { mSmoothEdges = smoothEdges; }
 
-    //! Sets positions coordinates and does the translation, rotation and scaling
-    void setupPositionCoordinates( const QVector<float> &positionsBuffer, const QMatrix4x4 &transform );
-    //! Sets the faces in facesIndexes to the faces in the object
-    void setupFaces( const QVector<uint> &facesIndexes );
-    //! sets line vertex indexes
-    void setupLine();
+    //! sets line indexes and positions coordinates
+    void setupLine( const QVector<float> &positionsBuffer );
+
+    //! sets triangle indexes and positions coordinates
+    void setupTriangle( const QVector<float> &positionsBuffer, const QVector<uint> &facesIndexes, const QMatrix4x4 &transform );
+
+    //! sets point positions coordinates
+    void setupPoint( const QVector<float> &positionsBuffer );
 
     //! Sets normal coordinates for each vertex
     void setupNormalCoordinates( const QVector<float> &normalsBuffer, const QMatrix4x4 &transform );
@@ -113,6 +114,10 @@ class _3D_EXPORT Qgs3DExportObject
 
     //! Returns the vertex indexes
     QVector<unsigned int> indexes() const { return mIndexes; }
+
+  private:
+    //! Sets positions coordinates and does the translation, rotation and scaling
+    void setupPositionCoordinates( const QVector<float> &positionsBuffer, const QMatrix4x4 &transform = QMatrix4x4() );
 
   private:
     QString mName;

--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -769,12 +769,11 @@ QVector<Qgs3DExportObject *> Qgs3DSceneExporter::processLines( Qt3DCore::QEntity
       continue;
     }
     const QVector<float> positionData = getAttributeData<float>( positionAttribute, vertexBytes );
-    const QVector<uint> indexData = getIndexData( indexAttribute, indexBytes );
 
     Qgs3DExportObject *exportObject = new Qgs3DExportObject( getObjectName( objectNamePrefix + QStringLiteral( "line" ) ) );
     exportObject->setType( Qgs3DExportObject::LineStrip );
     exportObject->setupPositionCoordinates( positionData, QMatrix4x4() );
-    exportObject->setupLine( indexData );
+    exportObject->setupLine();
 
     objs.push_back( exportObject );
   }

--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -394,8 +394,7 @@ void Qgs3DSceneExporter::parseFlatTile( QgsTerrainTileEntity *tileEntity, const 
   mObjects.push_back( object );
 
   object->setSmoothEdges( mSmoothEdges );
-  object->setupPositionCoordinates( positionBuffer, transform->matrix() );
-  object->setupFaces( indexesBuffer );
+  object->setupTriangle( positionBuffer, indexesBuffer, transform->matrix() );
 
   if ( mExportNormals )
   {
@@ -444,8 +443,7 @@ void Qgs3DSceneExporter::parseDemTile( QgsTerrainTileEntity *tileEntity, const Q
   mObjects.push_back( object );
 
   object->setSmoothEdges( mSmoothEdges );
-  object->setupPositionCoordinates( positionBuffer, transform->matrix() );
-  object->setupFaces( indexBuffer );
+  object->setupTriangle( positionBuffer, indexBuffer, transform->matrix() );
 
   Qt3DQAttribute *normalsAttributes = tileGeometry->normalAttribute();
   if ( mExportNormals && normalsAttributes )
@@ -529,8 +527,7 @@ QVector<Qgs3DExportObject *> Qgs3DSceneExporter::processInstancedPointGeometry( 
       objects.push_back( object );
       QMatrix4x4 instanceTransform;
       instanceTransform.translate( instancePosition[i], instancePosition[i + 1], instancePosition[i + 2] );
-      object->setupPositionCoordinates( positionData, instanceTransform );
-      object->setupFaces( indexData );
+      object->setupTriangle( positionData, indexData, instanceTransform );
 
       object->setSmoothEdges( mSmoothEdges );
 
@@ -722,8 +719,7 @@ Qgs3DExportObject *Qgs3DSceneExporter::processGeometryRenderer( Qt3DRender::QGeo
 
   // === Create Qgs3DExportObject
   Qgs3DExportObject *object = new Qgs3DExportObject( getObjectName( objectNamePrefix + QStringLiteral( "mesh_geometry" ) ) );
-  object->setupPositionCoordinates( positionData, transformMatrix );
-  object->setupFaces( indexData );
+  object->setupTriangle( positionData, indexData, transformMatrix );
 
   Qt3DQAttribute *normalsAttribute = findAttribute( geometry, Qt3DQAttribute::defaultNormalAttributeName(), Qt3DQAttribute::VertexAttribute );
   if ( mExportNormals && normalsAttribute )
@@ -771,9 +767,7 @@ QVector<Qgs3DExportObject *> Qgs3DSceneExporter::processLines( Qt3DCore::QEntity
     const QVector<float> positionData = getAttributeData<float>( positionAttribute, vertexBytes );
 
     Qgs3DExportObject *exportObject = new Qgs3DExportObject( getObjectName( objectNamePrefix + QStringLiteral( "line" ) ) );
-    exportObject->setType( Qgs3DExportObject::LineStrip );
-    exportObject->setupPositionCoordinates( positionData, QMatrix4x4() );
-    exportObject->setupLine();
+    exportObject->setupLine( positionData );
 
     objs.push_back( exportObject );
   }
@@ -805,8 +799,7 @@ Qgs3DExportObject *Qgs3DSceneExporter::processPoints( Qt3DCore::QEntity *entity,
     points << positions;
   }
   Qgs3DExportObject *obj = new Qgs3DExportObject( getObjectName( objectNamePrefix + QStringLiteral( "points" ) ) );
-  obj->setType( Qgs3DExportObject::Points );
-  obj->setupPositionCoordinates( points, QMatrix4x4() );
+  obj->setupPoint( points );
   return obj;
 }
 

--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -877,12 +877,12 @@ bool Qgs3DSceneExporter::save( const QString &sceneName, const QString &sceneFol
 QString Qgs3DSceneExporter::getObjectName( const QString &name )
 {
   QString ret = name;
-  if ( usedObjectNamesCounter.contains( name ) )
+  if ( mUsedObjectNamesCounter.contains( name ) )
   {
-    ret = QStringLiteral( "%1%2" ).arg( name ).arg( usedObjectNamesCounter[name] );
-    usedObjectNamesCounter[name]++;
+    ret = QStringLiteral( "%1%2" ).arg( name ).arg( mUsedObjectNamesCounter[name] );
+    mUsedObjectNamesCounter[name]++;
   }
   else
-    usedObjectNamesCounter[name] = 2;
+    mUsedObjectNamesCounter[name] = 2;
   return ret;
 }

--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -236,7 +236,7 @@ bool Qgs3DSceneExporter::parseVectorLayerEntity( Qt3DCore::QEntity *entity, QgsV
   return false;
 }
 
-void Qgs3DSceneExporter::processEntityMaterial( Qt3DCore::QEntity *entity, Qgs3DExportObject *object )
+void Qgs3DSceneExporter::processEntityMaterial( Qt3DCore::QEntity *entity, Qgs3DExportObject *object ) const
 {
   Qt3DExtras::QPhongMaterial *phongMaterial = findTypedComponent<Qt3DExtras::QPhongMaterial>( entity );
   if ( phongMaterial )
@@ -811,7 +811,7 @@ Qgs3DExportObject *Qgs3DSceneExporter::processPoints( Qt3DCore::QEntity *entity,
   return obj;
 }
 
-bool Qgs3DSceneExporter::save( const QString &sceneName, const QString &sceneFolderPath, int precision )
+bool Qgs3DSceneExporter::save( const QString &sceneName, const QString &sceneFolderPath, int precision ) const
 {
   if ( mObjects.isEmpty() )
   {

--- a/src/3d/qgs3dsceneexporter.h
+++ b/src/3d/qgs3dsceneexporter.h
@@ -80,7 +80,7 @@ class _3D_EXPORT Qgs3DSceneExporter : public Qt3DCore::QEntity
      * Saves the scene to a .obj file
      * Returns FALSE if the operation failed
      */
-    bool save( const QString &sceneName, const QString &sceneFolderPath, int precision = 6 );
+    bool save( const QString &sceneName, const QString &sceneFolderPath, int precision = 6 ) const;
 
     //! Sets whether the triangles will look smooth
     void setSmoothEdges( bool smoothEdges ) { mSmoothEdges = smoothEdges; }
@@ -119,7 +119,7 @@ class _3D_EXPORT Qgs3DSceneExporter : public Qt3DCore::QEntity
     //! Constructs Qgs3DExportObject from geometry renderer
     Qgs3DExportObject *processGeometryRenderer( Qt3DRender::QGeometryRenderer *mesh, const QString &objectNamePrefix, const QMatrix4x4 &sceneTransform = QMatrix4x4() );
     //! Extracts material information from geometry renderer and inserts it into the export object
-    void processEntityMaterial( Qt3DCore::QEntity *entity, Qgs3DExportObject *object );
+    void processEntityMaterial( Qt3DCore::QEntity *entity, Qgs3DExportObject *object ) const;
     //! Constricts Qgs3DExportObject from line entity
     QVector<Qgs3DExportObject *> processLines( Qt3DCore::QEntity *entity, const QString &objectNamePrefix );
     //! Constricts Qgs3DExportObject from billboard point entity

--- a/src/3d/qgs3dsceneexporter.h
+++ b/src/3d/qgs3dsceneexporter.h
@@ -142,7 +142,7 @@ class _3D_EXPORT Qgs3DSceneExporter : public Qt3DCore::QEntity
     QString getObjectName( const QString &name );
 
   private:
-    QMap<QString, int> usedObjectNamesCounter;
+    QMap<QString, int> mUsedObjectNamesCounter;
     QVector<Qgs3DExportObject *> mObjects;
 
     bool mSmoothEdges = false;

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -346,8 +346,6 @@ void TestQgs3DUtils::testExportToObj()
   // case where all vertices are used
   {
     Qgs3DExportObject object( "all_faces" );
-    object.setupPositionCoordinates( positionData, QMatrix4x4() );
-    QCOMPARE( object.vertexPosition().size(), positionData.size() );
 
     // exported vertice indexes
     QVector<uint> indexData = {
@@ -383,7 +381,9 @@ void TestQgs3DUtils::testExportToObj()
       29,
     };
 
-    object.setupFaces( indexData );
+    object.setupTriangle( positionData, indexData, QMatrix4x4() );
+    QCOMPARE( object.vertexPosition().size(), positionData.size() );
+
     QCOMPARE( object.indexes().size(), indexData.size() );
 
     object.setupNormalCoordinates( normalsData, QMatrix4x4() );
@@ -421,10 +421,9 @@ void TestQgs3DUtils::testExportToObj()
     };
 
     Qgs3DExportObject object( "sparse_faces" );
-    object.setupPositionCoordinates( positionData, QMatrix4x4() );
+    object.setupTriangle( positionData, indexData, QMatrix4x4() );
     QCOMPARE( object.vertexPosition().size(), positionData.size() );
 
-    object.setupFaces( indexData );
     QCOMPARE( object.indexes().size(), indexData.size() );
 
     object.setupNormalCoordinates( normalsData, QMatrix4x4() );


### PR DESCRIPTION
## Description

- make some methods `const`
- merge redundant functions
- simplify the logic to setup a `Qgs3dExportObject`
- remove some unused variables

**Funded by Stadt Frankfurt am Main**