### PR TITLE
[app] Export Map to image/PDF: Add option to lock the scale while setting the extent

### DIFF
--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -93,6 +93,7 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
   connect( mOutputHeightSpinBox, &QSpinBox::editingFinished, this, [this] { updateOutputHeight( mOutputHeightSpinBox->value() ); } );
   connect( mExtentGroupBox, &QgsExtentGroupBox::extentChanged, this, &QgsMapSaveDialog::updateExtent );
   connect( mScaleWidget, &QgsScaleWidget::scaleChanged, this, &QgsMapSaveDialog::updateScale );
+  connect( mLockScale, &QToolButton::toggled, this, &QgsMapSaveDialog::lockScaleChanged );
   connect( mLockAspectRatio, &QgsRatioLockButton::lockChanged, this, &QgsMapSaveDialog::lockChanged );
 
   updateOutputSize();
@@ -222,23 +223,38 @@ void QgsMapSaveDialog::updateExtent( const QgsRectangle &extent )
 {
   int currentDpi = 0;
 
-  // reset scale to properly sync output width and height when extent set using
-  // current map view, layer extent, or drawn on canvas buttons
+  // If extent set using current map view, layer extent, or drawn on canvas buttons
   if ( mExtentGroupBox->extentState() != QgsExtentGroupBox::UserExtent )
   {
-    currentDpi = mDpi;
-
-    QgsMapSettings ms = mMapCanvas->mapSettings();
-    ms.setRotation( 0 );
-    mDpi = static_cast<int>( std::round( ms.outputDpi() ) );
-    mSize.setWidth( ms.outputSize().width() * extent.width() / ms.visibleExtent().width() );
-    mSize.setHeight( ms.outputSize().height() * extent.height() / ms.visibleExtent().height() );
-
-    whileBlocking( mScaleWidget )->setScale( ms.scale() );
-
-    if ( currentDpi != mDpi )
+    // reset scale to properly sync output width and height
+    if ( !mLockScale->isChecked() )
     {
-      updateDpi( currentDpi );
+      currentDpi = mDpi;
+
+      QgsMapSettings ms = mMapCanvas->mapSettings();
+      ms.setRotation( 0 );
+      mDpi = static_cast<int>( std::round( ms.outputDpi() ) );
+
+      mSize.setWidth( ms.outputSize().width() * extent.width() / ms.visibleExtent().width() );
+      mSize.setHeight( ms.outputSize().height() * extent.height() / ms.visibleExtent().height() );
+
+      whileBlocking( mScaleWidget )->setScale( ms.scale() );
+
+      if ( currentDpi != mDpi )
+      {
+        updateDpi( currentDpi );
+      }
+    }
+    else // Update size, leave scale untouched
+    {
+      QgsScaleCalculator calculator;
+      calculator.setMapUnits( mExtentGroupBox->currentCrs().mapUnits() );
+      calculator.setDpi( mDpi );
+      calculator.setMethod( QgsProject::instance()->scaleMethod() );
+
+      QSizeF newSize = calculator.calculateImageSize( extent, mScaleWidget->scale() );
+      mSize.setWidth( static_cast<int>( newSize.width() ) );
+      mSize.setHeight( static_cast<int>( newSize.height() ) );
     }
   }
   else
@@ -246,6 +262,7 @@ void QgsMapSaveDialog::updateExtent( const QgsRectangle &extent )
     mSize.setWidth( mSize.width() * extent.width() / mExtent.width() );
     mSize.setHeight( mSize.height() * extent.height() / mExtent.height() );
   }
+
   updateOutputSize();
   checkOutputSize();
 
@@ -389,6 +406,11 @@ void QgsMapSaveDialog::lockChanged( const bool locked )
   {
     mExtentGroupBox->setRatio( QSize( 0, 0 ) );
   }
+}
+
+void QgsMapSaveDialog::lockScaleChanged( bool locked )
+{
+  mScaleWidget->setEnabled( !locked );
 }
 
 void QgsMapSaveDialog::copyToClipboard()

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -109,6 +109,8 @@ class APP_EXPORT QgsMapSaveDialog : public QDialog, private Ui::QgsMapSaveDialog
     float mDevicePixelRatio;
 
     QString mInfoDetails;
+
+    friend class TestQgsMapSaveDialog;
 };
 
 #endif // QGSMAPSAVEDIALOG_H

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -82,8 +82,9 @@ class APP_EXPORT QgsMapSaveDialog : public QDialog, private Ui::QgsMapSaveDialog
 
   private slots:
     void onAccepted();
-
     void updatePdfExportWarning();
+    void lockScaleChanged( bool locked );
+    void showHelp();
 
   private:
     void lockChanged( bool locked );
@@ -108,10 +109,6 @@ class APP_EXPORT QgsMapSaveDialog : public QDialog, private Ui::QgsMapSaveDialog
     float mDevicePixelRatio;
 
     QString mInfoDetails;
-
-  private slots:
-
-    void showHelp();
 };
 
 #endif // QGSMAPSAVEDIALOG_H

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -54,7 +54,31 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QgsScaleWidget" name="mScaleWidget" native="true"/>
+      <layout class="QHBoxLayout">
+       <item>
+        <widget class="QgsScaleWidget" name="mScaleWidget"/>
+       </item>
+       <item>
+        <widget class="QToolButton" name="mLockScale">
+         <property name="toolTip">
+          <string>Lock scale while setting the extent</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/lockedGray.svg</normaloff>:/images/themes/default/lockedGray.svg</iconset>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item row="0" column="0" colspan="2">
       <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
@@ -245,7 +269,7 @@ Rasterizing the map is recommended when such effects are used.</string>
          <property name="maximum">
           <number>99999</number>
          </property>
-         <property name="showClearButton" stdset="0">
+         <property name="showClearButton">
           <bool>false</bool>
          </property>
         </widget>
@@ -296,7 +320,7 @@ Rasterizing the map is recommended when such effects are used.</string>
          <property name="maximum">
           <number>99999</number>
          </property>
-         <property name="showClearButton" stdset="0">
+         <property name="showClearButton">
           <bool>false</bool>
          </property>
         </widget>
@@ -317,7 +341,7 @@ Rasterizing the map is recommended when such effects are used.</string>
        <property name="maximum">
         <number>3000</number>
        </property>
-       <property name="showClearButton" stdset="0">
+       <property name="showClearButton">
         <bool>false</bool>
        </property>
       </widget>
@@ -374,26 +398,26 @@ Rasterizing the map is recommended when such effects are used.</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsExtentGroupBox</class>
    <extends>QgsCollapsibleGroupBox</extends>
    <header>qgsextentgroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsScaleWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsRatioLockButton</class>
    <extends>QToolButton</extends>
    <header>qgsratiolockbutton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsScaleWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalewidget.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
@@ -410,6 +434,8 @@ Rasterizing the map is recommended when such effects are used.</string>
  </customwidgets>
  <tabstops>
   <tabstop>mExtentGroupBox</tabstop>
+  <tabstop>mScaleWidget</tabstop>
+  <tabstop>mLockScale</tabstop>
   <tabstop>mResolutionSpinBox</tabstop>
   <tabstop>mOutputWidthSpinBox</tabstop>
   <tabstop>mLockAspectRatio</tabstop>

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TESTS
   testqgsidentify.cpp
   testqgslayerpropertiesdialogs.cpp
   testqgsmapcanvasdockwidget.cpp
+  testqgsmapsavedialog.cpp
   testqgsmaptooladdpart.cpp
   testqgsmaptooldeletepart.cpp
   testqgsmaptooladdring.cpp

--- a/tests/src/app/testqgsmapsavedialog.cpp
+++ b/tests/src/app/testqgsmapsavedialog.cpp
@@ -1,0 +1,94 @@
+/***************************************************************************
+     testqgsmapsavedialog.cpp
+     ------------------------------
+    Date                 : September 2025
+    Copyright            : (C) 2025 by Germán Carrillo
+    Email                : german at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include <QObject>
+
+#include "qgisapp.h"
+#include "qgsapplication.h"
+#include "qgsmapsavedialog.h"
+#include "qgsmapcanvas.h"
+
+
+class TestQgsMapSaveDialog : public QgsTest
+{
+    Q_OBJECT
+
+  public:
+    TestQgsMapSaveDialog()
+      : QgsTest( QStringLiteral( "Map save dialogs" ) )
+    {}
+
+  private:
+    QgisApp *mQgisApp = nullptr;
+
+  private slots:
+
+    void initTestCase()
+    {
+      QgsApplication::init();
+      QgsApplication::initQgis();
+      mQgisApp = new QgisApp();
+    }
+
+    void cleanupTestCase()
+    {
+      QgsApplication::exitQgis();
+    }
+
+    void testUpdateExtent()
+    {
+      // Set up base canvas
+      QgsMapCanvas canvas;
+      canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) );
+      canvas.setFrameStyle( QFrame::NoFrame );
+      canvas.resize( 800, 600 );
+      canvas.show(); // to make the canvas resize
+      canvas.hide();
+      canvas.setExtent( QgsRectangle( 623913, 5720967, 1215325, 6068610 ) );
+
+      // Set up dialog
+      QgsMapSaveDialog dialog( nullptr, &canvas );
+      dialog.updateDpi( 96 );
+      dialog.mLockScale->setChecked( false ); // Default, let's make it explicit
+
+      // Check initial status
+      QCOMPARE( dialog.mScaleWidget->scale(), 2794072 );
+      QCOMPARE( dialog.mDpi, 96 );
+
+      // Check update extent without locking the scale
+      dialog.mScaleWidget->setScale( 10000 ); // First set a different arbitrary scale
+      QCOMPARE( dialog.mScaleWidget->scale(), 10000 );
+
+      QgsRectangle canvasExtent( 1028930.8433, 5910111.234, 1031976.2192, 5912395.266 );
+      canvas.setExtent( canvasExtent );
+      dialog.mExtentGroupBox->setOutputExtentFromCurrent(); // Same as set extent from "Map Canvas Extent"
+      QCOMPARE( dialog.mExtentGroupBox->outputExtent(), canvasExtent );
+      QCOMPARE( dialog.mScaleWidget->scale(), 14388 );
+
+      // Check update extent locking the scale
+      dialog.mScaleWidget->setScale( 10000 ); // First set a different arbitrary scale
+      QCOMPARE( dialog.mScaleWidget->scale(), 10000 );
+      dialog.mLockScale->setChecked( true );
+
+      canvas.setExtent( canvasExtent );
+      dialog.mExtentGroupBox->setOutputExtentFromCurrent(); // Same as set extent from "Map Canvas Extent"
+      QCOMPARE( dialog.mExtentGroupBox->outputExtent(), canvasExtent );
+      QCOMPARE( dialog.mScaleWidget->scale(), 10000 ); // Our arbitrary scale is kept!
+    }
+};
+
+QGSTEST_MAIN( TestQgsMapSaveDialog )
+#include "testqgsmapsavedialog.moc"


### PR DESCRIPTION
Before this PR, setting the extent using current map view, layer extent, or drawn on canvas buttons will always reset the scale to match canvas scale.

This PR makes it possible to **use a lock button to keep the scale as is** in the dialog when setting the extent by any of the aforementioned methods.


<img width="818" height="488" alt="lock_scale" src="https://github.com/user-attachments/assets/b8127348-4485-4ef9-a077-7ff4e7fa54b9" />



https://github.com/user-attachments/assets/39b7864a-3c06-4de6-aa3a-103b66dc50f3


-------------

Includes unit tests.

-------------

Funded by [City of Frankfurt – Stadtplanungsamt](https://www.stadtplanungsamt-frankfurt.de/about_us_5645.html).