### PR TITLE
always build PDAL Processing algorithms (fix #63106)

### DIFF
--- a/python/PyQt6/analysis/analysis_auto.sip
+++ b/python/PyQt6/analysis/analysis_auto.sip
@@ -21,6 +21,7 @@
 %Include auto_generated/network/qgsvectorlayerdirector.sip
 %Include auto_generated/processing/qgsalgorithmbatchgeocode.sip
 %Include auto_generated/processing/qgsnativealgorithms.sip
+%Include auto_generated/processing/pdal/qgspdalalgorithms.sip
 %Include auto_generated/raster/qgsalignraster.sip
 %Include auto_generated/raster/qgsaspectfilter.sip
 %Include auto_generated/raster/qgsderivativefilter.sip
@@ -46,6 +47,3 @@
 %Include auto_generated/vector/qgsgeometrysnapper.sip
 %Include auto_generated/vector/qgsgeometrysnappersinglesource.sip
 %Include auto_generated/vector/qgszonalstatistics.sip
-%If ( HAVE_PDAL_PROVIDER )
-%Include auto_generated/processing/pdal/qgspdalalgorithms.sip
-%End

--- a/python/PyQt6/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
+++ b/python/PyQt6/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsPdalAlgorithms : QgsProcessingProvider
 {
 %Docstring(signature="appended")

--- a/python/analysis/analysis_auto.sip
+++ b/python/analysis/analysis_auto.sip
@@ -21,6 +21,7 @@
 %Include auto_generated/network/qgsvectorlayerdirector.sip
 %Include auto_generated/processing/qgsalgorithmbatchgeocode.sip
 %Include auto_generated/processing/qgsnativealgorithms.sip
+%Include auto_generated/processing/pdal/qgspdalalgorithms.sip
 %Include auto_generated/raster/qgsalignraster.sip
 %Include auto_generated/raster/qgsaspectfilter.sip
 %Include auto_generated/raster/qgsderivativefilter.sip
@@ -46,6 +47,3 @@
 %Include auto_generated/vector/qgsgeometrysnapper.sip
 %Include auto_generated/vector/qgsgeometrysnappersinglesource.sip
 %Include auto_generated/vector/qgszonalstatistics.sip
-%If ( HAVE_PDAL_PROVIDER )
-%Include auto_generated/processing/pdal/qgspdalalgorithms.sip
-%End

--- a/python/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
+++ b/python/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsPdalAlgorithms : QgsProcessingProvider
 {
 %Docstring(signature="appended")

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -196,6 +196,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmmultiringconstantbuffer.cpp
   processing/qgsalgorithmmultiunion.cpp
   processing/qgsalgorithmnearestneighbouranalysis.cpp
+  processing/qgsalgorithmnetworkanalysisbase.cpp
   processing/qgsalgorithmoffsetlines.cpp
   processing/qgsalgorithmorderbyexpression.cpp
   processing/qgsalgorithmorientedminimumboundingbox.cpp
@@ -311,12 +312,30 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsprojectstylealgorithms.cpp
   processing/qgsstylealgorithms.cpp
 
-  processing/qgsalgorithmnetworkanalysisbase.cpp
-
   processing/qgsnativealgorithms.cpp
   processing/qgsoverlayutils.cpp
   processing/qgsrasteranalysisutils.cpp
   processing/qgsreclassifyutils.cpp
+
+  processing/pdal/qgspdalalgorithms.cpp
+  processing/pdal/qgspdalalgorithmbase.cpp
+  processing/pdal/qgsalgorithmpdalassignprojection.cpp
+  processing/pdal/qgsalgorithmpdalboundary.cpp
+  processing/pdal/qgsalgorithmpdalbuildvpc.cpp
+  processing/pdal/qgsalgorithmpdalclip.cpp
+  processing/pdal/qgsalgorithmpdalconvertformat.cpp
+  processing/pdal/qgsalgorithmpdalcreatecopc.cpp
+  processing/pdal/qgsalgorithmpdaldensity.cpp
+  processing/pdal/qgsalgorithmpdalexportraster.cpp
+  processing/pdal/qgsalgorithmpdalexportrastertin.cpp
+  processing/pdal/qgsalgorithmpdalexportvector.cpp
+  processing/pdal/qgsalgorithmpdalfilter.cpp
+  processing/pdal/qgsalgorithmpdalinformation.cpp
+  processing/pdal/qgsalgorithmpdalmerge.cpp
+  processing/pdal/qgsalgorithmpdalreproject.cpp
+  processing/pdal/qgsalgorithmpdalthinbydecimate.cpp
+  processing/pdal/qgsalgorithmpdalthinbyradius.cpp
+  processing/pdal/qgsalgorithmpdaltile.cpp
 
   raster/qgsalignraster.cpp
   raster/qgsninecellfilter.cpp
@@ -431,6 +450,8 @@ set(QGIS_ANALYSIS_HDRS
   processing/qgsalgorithmurlopener.h
   processing/qgsalgorithmhttprequest.h
 
+  processing/pdal/qgspdalalgorithms.h
+
   raster/qgsalignraster.h
   raster/qgsaspectfilter.h
   raster/qgsderivativefilter.h
@@ -486,37 +507,13 @@ set(QGIS_ANALYSIS_HDRS
   vector/qgszonalstatistics.h
 )
 
-if (WITH_PDAL AND PDAL_2_5_OR_HIGHER)
+if (WITH_PDAL)
   set(QGIS_ANALYSIS_SRCS ${QGIS_ANALYSIS_SRCS}
     ${CMAKE_SOURCE_DIR}/external/untwine/api/QgisUntwine.cpp
-
-    processing/pdal/qgspdalalgorithms.cpp
-
-    processing/pdal/qgspdalalgorithmbase.cpp
-
-    processing/pdal/qgsalgorithmpdalassignprojection.cpp
-    processing/pdal/qgsalgorithmpdalboundary.cpp
-    processing/pdal/qgsalgorithmpdalbuildvpc.cpp
-    processing/pdal/qgsalgorithmpdalclip.cpp
-    processing/pdal/qgsalgorithmpdalconvertformat.cpp
-    processing/pdal/qgsalgorithmpdalcreatecopc.cpp
-    processing/pdal/qgsalgorithmpdaldensity.cpp
-    processing/pdal/qgsalgorithmpdalexportraster.cpp
-    processing/pdal/qgsalgorithmpdalexportrastertin.cpp
-    processing/pdal/qgsalgorithmpdalexportvector.cpp
-    processing/pdal/qgsalgorithmpdalfilter.cpp
-    processing/pdal/qgsalgorithmpdalinformation.cpp
-    processing/pdal/qgsalgorithmpdalmerge.cpp
-    processing/pdal/qgsalgorithmpdalreproject.cpp
-    processing/pdal/qgsalgorithmpdalthinbydecimate.cpp
-    processing/pdal/qgsalgorithmpdalthinbyradius.cpp
-    processing/pdal/qgsalgorithmpdaltile.cpp
   )
 
   set(QGIS_ANALYSIS_HDRS ${QGIS_ANALYSIS_HDRS}
     ${CMAKE_SOURCE_DIR}/external/untwine/api/QgisUntwine.hpp
-
-    processing/pdal/qgspdalalgorithms.h
   )
 
   include_directories(

--- a/src/analysis/processing/pdal/qgsalgorithmpdalcreatecopc.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalcreatecopc.cpp
@@ -22,7 +22,9 @@
 #include <QFileInfo>
 #include <QDir>
 
+#ifdef WITH_PDAL
 #include "QgisUntwine.hpp"
+#endif
 #include "qgsapplication.h"
 #include "qgspointcloudlayer.h"
 
@@ -70,8 +72,22 @@ void QgsPdalCreateCopcAlgorithm::initAlgorithm( const QVariantMap & )
   addOutput( new QgsProcessingOutputMultipleLayers( QStringLiteral( "OUTPUT_LAYERS" ), QObject::tr( "Output layers" ) ) );
 }
 
+bool QgsPdalCreateCopcAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  Q_UNUSED( parameters )
+  Q_UNUSED( context )
+  Q_UNUSED( feedback )
+
+#ifdef WITH_PDAL
+  return true;
+#else
+  throw QgsProcessingException( QObject::tr( "This algorithm requires a QGIS installation with PDAL support enabled." ) );
+#endif
+}
+
 QVariantMap QgsPdalCreateCopcAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
+#ifdef WITH_PDAL
   const QList<QgsMapLayer *> layers = parameterAsLayerList( parameters, QStringLiteral( "LAYERS" ), context, QgsProcessing::LayerOptionsFlag::SkipIndexGeneration );
   if ( layers.empty() )
   {
@@ -181,6 +197,12 @@ QVariantMap QgsPdalCreateCopcAlgorithm::processAlgorithm( const QVariantMap &par
   QVariantMap outputs;
   outputs.insert( QStringLiteral( "OUTPUT_LAYERS" ), outputLayers );
   return outputs;
+#else
+  Q_UNUSED( parameters )
+  Q_UNUSED( context )
+  Q_UNUSED( feedback )
+  throw QgsProcessingException( QObject::tr( "This algorithm requires a QGIS installation with PDAL support enabled." ) );
+#endif
 }
 
 ///@endcond

--- a/src/analysis/processing/pdal/qgsalgorithmpdalcreatecopc.h
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalcreatecopc.h
@@ -42,6 +42,7 @@ class QgsPdalCreateCopcAlgorithm : public QgsProcessingAlgorithm
     QgsPdalCreateCopcAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
     friend class TestQgsProcessingPdalAlgs;

--- a/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithmbase.cpp
@@ -169,6 +169,11 @@ QVariantMap QgsPdalAlgorithmBase::processAlgorithm( const QVariantMap &parameter
   const QStringList processArgs = createArgumentLists( parameters, context, feedback );
   const QString wrenchPath = wrenchExecutableBinary();
 
+  if ( !QFileInfo::exists( wrenchPath ) )
+  {
+    throw QgsProcessingException( QObject::tr( "wrench executable is not found. Either use QGIS build with PDAL support or provide correct path via QGIS_WRENCH_EXECUTABLE environment variable." ) );
+  }
+
   QStringList logArgs;
   const thread_local QRegularExpression re( "[\\s\\\"\\'\\(\\)\\&;]" );
   for ( const QString &arg : processArgs )

--- a/src/analysis/processing/pdal/qgspdalalgorithms.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithms.h
@@ -22,8 +22,6 @@
 #include "qgis_sip.h"
 #include "qgsprocessingprovider.h"
 
-SIP_IF_MODULE( HAVE_PDAL_PROVIDER )
-
 /**
  * \ingroup analysis
  * \class QgsPdalAlgorithms

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -639,9 +639,9 @@ if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   target_link_libraries(qgis ${EXECINFO_LIBRARY})
 endif()
 
+target_include_directories(qgis_app PRIVATE ${CMAKE_SOURCE_DIR}/src/analysis/processing/pdal)
 if (WITH_PDAL)
   target_link_libraries(qgis_app ${PDAL_LIBRARIES})
-  target_include_directories(qgis_app PRIVATE ${CMAKE_SOURCE_DIR}/src/analysis/processing/pdal)
 endif()
 
 if(MSVC)

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -351,6 +351,7 @@
 #include "qgsnewmemorylayerdialog.h"
 #include "qgsnewmeshlayerdialog.h"
 #include "options/qgsoptions.h"
+#include "qgspdalalgorithms.h"
 #include "qgspluginlayer.h"
 #include "qgspluginlayerregistry.h"
 #include "qgspluginmanager.h"
@@ -508,9 +509,6 @@
 
 #ifdef HAVE_PDAL_QGIS
 #include <pdal/pdal.hpp>
-#if PDAL_VERSION_MAJOR_INT > 2 || ( PDAL_VERSION_MAJOR_INT == 2 && PDAL_VERSION_MINOR_INT >= 5 )
-#include "qgspdalalgorithms.h"
-#endif
 #endif
 
 //
@@ -13160,11 +13158,7 @@ void QgisApp::initNativeProcessing()
   QgsApplication::processingRegistry()->addProvider( new Qgs3DAlgorithms( QgsApplication::processingRegistry() ) );
 #endif
 
-#ifdef HAVE_PDAL_QGIS
-#if PDAL_VERSION_MAJOR_INT > 1 && PDAL_VERSION_MINOR_INT >= 5
   QgsApplication::processingRegistry()->addProvider( new QgsPdalAlgorithms( QgsApplication::processingRegistry() ) );
-#endif
-#endif
 }
 
 void QgisApp::initLayouts()

--- a/src/process/CMakeLists.txt
+++ b/src/process/CMakeLists.txt
@@ -34,11 +34,9 @@ if (UNIX AND NOT ANDROID)
   )
 endif()
 
-if (WITH_PDAL)
-  target_include_directories(qgis_process PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/analysis/processing/pdal
-  )
-endif()
+target_include_directories(qgis_process PRIVATE
+  ${CMAKE_SOURCE_DIR}/src/analysis/processing/pdal
+)
 
 if (WITH_3D)
   include_directories(SYSTEM

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -24,11 +24,7 @@
 #ifdef HAVE_3D
 #include "qgs3dalgorithms.h"
 #endif
-#ifdef HAVE_PDAL_QGIS
-#if PDAL_VERSION_MAJOR_INT > 2 || ( PDAL_VERSION_MAJOR_INT == 2 && PDAL_VERSION_MINOR_INT >= 5 )
 #include "qgspdalalgorithms.h"
-#endif
-#endif
 #ifdef WITH_SFCGAL
 #include <SFCGAL/capi/sfcgal_c.h>
 #endif
@@ -266,12 +262,7 @@ int QgsProcessingExec::run( const QStringList &args, Qgis::ProcessingLogLevel lo
 #ifdef HAVE_3D
   QgsApplication::processingRegistry()->addProvider( new Qgs3DAlgorithms( QgsApplication::processingRegistry() ) );
 #endif
-
-#ifdef HAVE_PDAL_QGIS
-#if PDAL_VERSION_MAJOR_INT > 1 && PDAL_VERSION_MINOR_INT >= 5
   QgsApplication::processingRegistry()->addProvider( new QgsPdalAlgorithms( QgsApplication::processingRegistry() ) );
-#endif
-#endif
 
 #ifdef WITH_BINDINGS
   if ( !( mFlags & Flag::SkipPython ) )

--- a/tests/src/analysis/CMakeLists.txt
+++ b/tests/src/analysis/CMakeLists.txt
@@ -39,7 +39,7 @@ if(HAVE_GSL)
   set(TESTS ${TESTS} testqgsgcptransformer.cpp)
 endif()
 
-if (WITH_PDAL AND PDAL_2_5_OR_HIGHER)
+if (WITH_PDAL)
   set(TESTS ${TESTS} testqgsprocessingpdalalgs.cpp)
 endif()
 


### PR DESCRIPTION
## Description

Always build PDAL Processing algorithms, even if QGIS is compiled without PDAL support. If `wrench` is not available these algorithms will throw an exception when run.

Fixes #63106.