### PR TITLE
fix message for incompatible plugins in Plugin Manager (fix #62606)

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -862,8 +862,8 @@ class Plugins(QObject):
                 error = "incompatible"
                 errorDetails = QCoreApplication.translate(
                     "QgsPluginInstaller",
-                    f"Plugin designed for QGIS {qgisMinimumVersion} - {qgisMaximumVersion}",
-                )
+                    "Plugin designed for QGIS {minVersion} - {maxVersion}",
+                ).format(minVersion=qgisMinimumVersion, maxVersion=qgisMaximumVersion)
         elif not os.path.exists(metadataFile):
             error = "broken"
             errorDetails = QCoreApplication.translate(

--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -860,7 +860,10 @@ class Plugins(QObject):
                 pyQgisVersion(), qgisMinimumVersion, qgisMaximumVersion
             ):
                 error = "incompatible"
-                errorDetails = f"{qgisMinimumVersion} - {qgisMaximumVersion}"
+                errorDetails = QCoreApplication.translate(
+                    "QgsPluginInstaller",
+                    f"Plugin designed for QGIS {qgisMinimumVersion} - {qgisMaximumVersion}",
+                )
         elif not os.path.exists(metadataFile):
             error = "broken"
             errorDetails = QCoreApplication.translate(

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -830,7 +830,7 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
     QString errorMsg;
     if ( metadata->value( QStringLiteral( "error" ) ) == QLatin1String( "incompatible" ) )
     {
-      errorMsg = QStringLiteral( "<b>%1</b><br/>%2" ).arg( tr( "This plugin is incompatible with this version of QGIS" ), tr( "Plugin designed for QGIS %1", "compatible QGIS version(s)" ).arg( metadata->value( QStringLiteral( "error_details" ) ) ) );
+      errorMsg = QStringLiteral( "<b>%1</b><br/>%2" ).arg( tr( "This plugin is incompatible with this version of QGIS" ), metadata->value( QStringLiteral( "error_details" ) ) );
     }
     else if ( metadata->value( QStringLiteral( "error" ) ) == QLatin1String( "dependent" ) )
     {


### PR DESCRIPTION
## Description

Return a full error message about incompatible plugin from the plugin installer code instead of generating it in the C++ code. As we have two different messages, old approach leads to unclear error.

FIxes #62606.