### PR TITLE
allow geometryless layers as inputs in the Execute SQL Processing algorithm (fix #63218)

### DIFF
--- a/python/plugins/processing/algs/qgis/ExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/ExecuteSQL.py
@@ -102,6 +102,7 @@ class ExecuteSQL(QgisAlgorithm):
                 description=self.tr(
                     "Input data sources (called input1, .., inputN in the query)"
                 ),
+                layerType=Qgis.ProcessingSourceType.Vector,
                 optional=True,
             )
         )


### PR DESCRIPTION
## Description

Processing algorithm Execute SQL, which creates a virtual layer, is limited to accept only layers with geometry as input. This PR allows geometry-less layers to be used as input, aligning algorithm functionality with the core feature.

Fixes #63218.