### PR TITLE
[themes] Fix text color of warning message in modeler dialog for the Night Mapping theme

### DIFF
--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -388,7 +388,7 @@ class ModelerDialog(QgsModelDesignerDialog):
                     self.tr("Algorithm is Invalid"),
                     QCoreApplication.translate(
                         "ModelerDialog",
-                        "<p>The “{}” algorithm is invalid, because:</p><ul><li>{}</li></ul>",
+                        '<div style="color:palette(window-text);"><p>The “{}” algorithm is invalid, because:</p><ul><li>{}</li></ul></div>',
                     ).format(alg.description(), "</li><li>".join(errors)),
                     level=Qgis.MessageLevel.Warning,
                 )


### PR DESCRIPTION
## Description

Fix the text color of the warning message details in the modeler dialog for the _Night Mapping_ theme.

The marker color of the list items is not changed by this PR, as I couldn't find a neat way to achieve this through changes in this part of the code.

**Before**:
![modeler_warning_before](https://github.com/user-attachments/assets/f3c89d31-a700-47f3-8cb4-0d605766916b)

**After**:
![modeler_warning_after](https://github.com/user-attachments/assets/77dcf910-19bb-42fa-8c59-69c97a0ee97e)

The text appearance in the _Blend of Gray_ theme remains unaffected. 

The changes can be backported, but possibly only manually, due to recent changes in `ModelerDialog.py`.