### PR TITLE
[Backport to release-3.40] Correctly deal with copy/move in QObjectUniquePtr

### DIFF
--- a/src/core/qobjectuniqueptr.h
+++ b/src/core/qobjectuniqueptr.h
@@ -69,7 +69,6 @@ class QObjectUniquePtr
      */
     inline QObjectUniquePtr( T *p ) : mPtr( p )
     { }
-    // compiler-generated copy/move ctor/assignment operators are fine!
 
     /**
      * Will delete the contained QObject if it still exists.
@@ -78,6 +77,22 @@ class QObjectUniquePtr
     {
       // Will be a nullptr if the QObject has been deleted from somewhere else (e.g. through parent ownership)
       delete mPtr.data();
+    }
+
+    // This is a unique ptr, so copy is forbidden and we need to implement the move constructor/operator
+    QObjectUniquePtr( const QObjectUniquePtr &other ) = delete;
+    QObjectUniquePtr &operator=( const QObjectUniquePtr &other ) = delete;
+
+    QObjectUniquePtr( QObjectUniquePtr &&other )
+    {
+      *this = std::move( other );
+    }
+
+    QObjectUniquePtr &operator=( QObjectUniquePtr &&other ) noexcept
+    {
+      mPtr = other.mPtr;
+      other.clear();
+      return *this;
     }
 
     /**

--- a/tests/src/core/testqobjectuniqueptr.cpp
+++ b/tests/src/core/testqobjectuniqueptr.cpp
@@ -30,6 +30,7 @@ class TestQObjectUniquePtr : public QObject
     void testSwap();
     void testOperatorArrow();
     void testDeleteLater();
+    void testVector();
 };
 
 void TestQObjectUniquePtr::testMemLeak()
@@ -122,6 +123,21 @@ void TestQObjectUniquePtr::testDeleteLater()
   QVERIFY( obj.isNull() );
   QVERIFY( obj2.isNull() );
 }
+
+void TestQObjectUniquePtr::testVector()
+{
+  std::vector<QObjectUniquePtr<QObject>> objects;
+
+  objects.emplace_back( new QObject )->setObjectName( "TESTA" );
+  objects.emplace_back( new QObject )->setObjectName( "TESTB" );
+
+  QVERIFY( !objects.at( 0 ).isNull() );
+  QVERIFY( !objects.at( 1 ).isNull() );
+
+  QCOMPARE( objects.at( 0 )->objectName(), "TESTA" );
+  QCOMPARE( objects.at( 1 )->objectName(), "TESTB" );
+}
+
 
 QGSTEST_MAIN( TestQObjectUniquePtr )
 #include "testqobjectuniqueptr.moc"


### PR DESCRIPTION
Manual Backport of #63206 to 3.40