### PR TITLE
Adjust substr_count expression help text

### DIFF
--- a/resources/function_help/json/substr_count
+++ b/resources/function_help/json/substr_count
@@ -16,34 +16,36 @@
     },
     {
       "arg": "overlapping",
-      "description": "Optional flag to control whether overlapping occurrences should be counted. Defaults to false (non-overlapping counting). Set to true to count overlapping occurrences."
+      "optional": true,
+      "default": false,
+      "description": "Optional flag to control whether overlapping occurrences should be counted. Defaults to FALSE (non-overlapping counting). Set to TRUE to count overlapping occurrences."
     }
   ],
   "examples": [
     {
       "expression": "substr_count('banana', 'an')",
       "returns": "2",
-      "description": "Counts non-overlapping occurrences of 'an' in 'banana'."
+      "note": "Counts non-overlapping occurrences of 'an' in 'banana'."
     },
     {
       "expression": "substr_count('Funniness', 'n')",
       "returns": "3",
-      "description": "Counts non-overlapping occurrences of 'n' in 'Funniness'."
+      "note": "Counts non-overlapping occurrences of 'n' in 'Funniness'."
     },
     {
       "expression": "substr_count('aaaaa', 'aa')",
       "returns": "2",
-      "description": "Counts non-overlapping occurrences of 'aa' in 'aaaaa'."
+      "note": "Counts non-overlapping occurrences of 'aa' in 'aaaaa'."
     },
     {
       "expression": "substr_count('aaaaa', 'aa', true)",
       "returns": "4",
-      "description": "Counts overlapping occurrences of 'aa' in 'aaaaa'. The substring 'aa' appears four times in an overlapping fashion."
+      "note": "Counts overlapping occurrences of 'aa' in 'aaaaa'. The substring 'aa' appears four times in an overlapping fashion."
     },
     {
       "expression": "substr_count('BANANA', 'an')",
       "returns": "0",
-      "description": "Counts non-overlapping occurrences of 'an' in 'BANANA'. Case-sensitive, so no match."
+      "note": "Counts non-overlapping occurrences of 'an' in 'BANANA'. Case-sensitive, so no match."
     }
   ],
   "tags": [

--- a/resources/function_help/json/substr_count
+++ b/resources/function_help/json/substr_count
@@ -7,7 +7,7 @@
   "description": "Counts the number of occurrences of a substring within a string. By default, the function counts non-overlapping occurrences (like in Python). If the third argument is set to true, the function counts overlapping occurrences (like in QT).",
   "arguments": [
     {
-      "arg": "input",
+      "arg": "string",
       "description": "The input string to search in."
     },
     {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -8750,7 +8750,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "convert_timezone" ), { QgsExpressionFunction::Parameter( QStringLiteral( "datetime" ) ), QgsExpressionFunction::Parameter( QStringLiteral( "timezone" ) ) }, fcnConvertTimeZone, QStringLiteral( "Date and Time" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "lower" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) ), fcnLower, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "substr_count" ), QgsExpressionFunction::ParameterList()
-                                            << QgsExpressionFunction::Parameter( QStringLiteral( "input" ) )
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "string" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "substring" ) )
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "overlapping" ), true, false ),  // Optional parameter with default value of false
                                             fcnSubstrCount,


### PR DESCRIPTION
Follow-up  #62815, providing more details on the overlapping argument (optional and fdefault value). Also I don't think that [examples](https://github.com/qgis/QGIS/blob/master/src/core/expression/qgsexpression.cpp#L681) do have a "description" key, but "note".

I know I come late in the game (but not too late)... Instead of `substr_count (input, substring [,overlapping=False])`, what about `substr_count (string, characters [,overlapping=False])`? Why? For harmonization. Most of the [string functions](https://docs.qgis.org/testing/en/docs/user_manual/expressions/functions_list.html#string-functions) first argument is named "string" when it expects string. We usually use "input" in the context of Processing. "characters" is proposed to avoid "string -> substring" but is also used in the context of rtrim/ltrim functions.
@tudorbarascu @uclaros @agiudiceandrea ?