### PR TITLE
Rename "Reproject" to "Reproject point cloud", fixes #63255

### DIFF
--- a/src/analysis/processing/pdal/qgsalgorithmpdalreproject.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalreproject.cpp
@@ -29,7 +29,7 @@ QString QgsPdalReprojectAlgorithm::name() const
 
 QString QgsPdalReprojectAlgorithm::displayName() const
 {
-  return QObject::tr( "Reproject" );
+  return QObject::tr( "Reproject point cloud" );
 }
 
 QString QgsPdalReprojectAlgorithm::group() const


### PR DESCRIPTION
## Description

Providing a more specific algorithm display name avoids confusion, as described in #63255
