### PR TITLE
Postgresql refactor some qgspostgresutils functions

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1206,7 +1206,7 @@ bool QgsPostgresProvider::loadFields()
 
 void QgsPostgresProvider::setEditorWidgets()
 {
-  if ( !QgsPostgresUtils::tableExists( connectionRO(), EDITOR_WIDGET_STYLES_TABLE ) )
+  if ( !QgsPostgresUtils::tableExists( connectionRO(), QStringLiteral( "public" ), EDITOR_WIDGET_STYLES_TABLE ) )
   {
     return;
   }
@@ -5212,11 +5212,11 @@ bool QgsPostgresProviderMetadata::styleExists( const QString &uri, const QString
     return false;
   }
 
-  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "layer_styles" ) ) )
+  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ) ) )
   {
     return false;
   }
-  else if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) )
+  else if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) )
   {
     return false;
   }
@@ -5272,7 +5272,7 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
     return false;
   }
 
-  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "layer_styles" ) ) )
+  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ) ) )
   {
     if ( !QgsPostgresUtils::createStylesTable( conn, QStringLiteral( "QgsPostgresProviderMetadata" ) ) )
     {
@@ -5283,7 +5283,7 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
   }
   else
   {
-    if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) )
+    if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) )
     {
       QgsPostgresResult res( conn->LoggedPQexec( QStringLiteral( "QgsPostgresProviderMetadata" ), "ALTER TABLE layer_styles ADD COLUMN type varchar NULL" ) );
       if ( res.PQresultStatus() != PGRES_COMMAND_OK )
@@ -5431,7 +5431,7 @@ QString QgsPostgresProviderMetadata::loadStoredStyle( const QString &uri, QStrin
     dsUri.setDatabase( conn->currentDatabase() );
   }
 
-  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "layer_styles" ) ) )
+  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ) ) )
   {
     conn->unref();
     return QString();
@@ -5450,7 +5450,7 @@ QString QgsPostgresProviderMetadata::loadStoredStyle( const QString &uri, QStrin
   QString wkbTypeString = QgsPostgresConn::quotedValue( QgsWkbTypes::geometryDisplayString( QgsWkbTypes::geometryType( dsUri.wkbType() ) ) );
 
   // support layer_styles without type column < 3.14
-  if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) )
+  if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) )
   {
     selectQmlQuery = QString( "SELECT styleName, styleQML"
                               " FROM layer_styles"
@@ -5506,7 +5506,7 @@ int QgsPostgresProviderMetadata::listStyles( const QString &uri, QStringList &id
     return -1;
   }
 
-  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "layer_styles" ) ) )
+  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ) ) )
   {
     return -1;
   }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1206,7 +1206,7 @@ bool QgsPostgresProvider::loadFields()
 
 void QgsPostgresProvider::setEditorWidgets()
 {
-  if ( !QgsPostgresUtils::tableExists( connectionRO(), QStringLiteral( "public" ), EDITOR_WIDGET_STYLES_TABLE ) )
+  if ( !QgsPostgresUtils::tableExists( connectionRO(), QString(), EDITOR_WIDGET_STYLES_TABLE ) )
   {
     return;
   }

--- a/src/providers/postgres/qgspostgresutils.cpp
+++ b/src/providers/postgres/qgspostgresutils.cpp
@@ -478,16 +478,22 @@ bool QgsPostgresUtils::deleteSchema( const QString &schema, const QgsDataSourceU
   return true;
 }
 
-bool QgsPostgresUtils::tableExists( QgsPostgresConn *conn, const QString &name )
+bool QgsPostgresUtils::tableExists( QgsPostgresConn *conn, const QString &schema, const QString &table )
 {
-  QgsPostgresResult res( conn->LoggedPQexec( QStringLiteral( "tableExists" ), "SELECT EXISTS ( SELECT oid FROM pg_catalog.pg_class WHERE relname=" + QgsPostgresConn::quotedValue( name ) + ")" ) );
-  return res.PQgetvalue( 0, 0 ).startsWith( 't' );
+  const QString sql = QStringLiteral( "SELECT EXISTS ( SELECT 1 FROM information_schema.tables WHERE table_name = %1 AND table_schema = %2)" )
+                        .arg( QgsPostgresConn::quotedValue( table ), QgsPostgresConn::quotedValue( schema ) );
+  QgsPostgresResult res( conn->LoggedPQexec( QStringLiteral( "tableExists" ), sql ) );
+  return res.PQgetvalue( 0, 0 ).startsWith( QStringLiteral( "t" ) );
 }
 
-bool QgsPostgresUtils::columnExists( QgsPostgresConn *conn, const QString &table, const QString &column )
+bool QgsPostgresUtils::columnExists( QgsPostgresConn *conn, const QString &schema, const QString &table, const QString &column )
 {
-  QgsPostgresResult res( conn->LoggedPQexec( QStringLiteral( "columnExists" ), "SELECT COUNT(*) FROM information_schema.columns WHERE table_name=" + QgsPostgresConn::quotedValue( table ) + " and column_name=" + QgsPostgresConn::quotedValue( column ) ) );
-  return res.PQgetvalue( 0, 0 ).toInt() > 0;
+  const QString sql = QStringLiteral( "SELECT EXISTS( SELECT 1 FROM information_schema.columns "
+                                      "WHERE table_name = %1 AND table_schema = %2 AND column_name = %3)" )
+                        .arg( QgsPostgresConn::quotedValue( table ), QgsPostgresConn::quotedValue( schema ), QgsPostgresConn::quotedValue( column ) );
+
+  QgsPostgresResult res( conn->LoggedPQexec( QStringLiteral( "columnExists" ), sql ) );
+  return res.PQgetvalue( 0, 0 ).startsWith( QStringLiteral( "t" ) );
 }
 
 bool QgsPostgresUtils::createStylesTable( QgsPostgresConn *conn, QString loggedClass )

--- a/src/providers/postgres/qgspostgresutils.h
+++ b/src/providers/postgres/qgspostgresutils.h
@@ -97,9 +97,9 @@ class QgsPostgresUtils
 
     static bool createStylesTable( QgsPostgresConn *conn, QString loggedClass );
 
-    static bool columnExists( QgsPostgresConn *conn, const QString &table, const QString &column );
+    static bool columnExists( QgsPostgresConn *conn, const QString &schema, const QString &table, const QString &column );
 
-    static bool tableExists( QgsPostgresConn *conn, const QString &name );
+    static bool tableExists( QgsPostgresConn *conn, const QString &schema, const QString &table );
 
     /*
     * Check if projects table exists in the specified schema

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -2473,7 +2473,7 @@ bool QgsPostgresRasterProviderMetadata::styleExists( const QString &uri, const Q
     return false;
   }
 
-  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "layer_styles" ) ) || !QgsPostgresUtils::columnExists( conn, QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) || !QgsPostgresUtils::columnExists( conn, QStringLiteral( "layer_styles" ), QStringLiteral( "r_raster_column" ) ) )
+  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ) ) || !QgsPostgresUtils::columnExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) || !QgsPostgresUtils::columnExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ), QStringLiteral( "r_raster_column" ) ) )
   {
     return false;
   }
@@ -2528,7 +2528,7 @@ bool QgsPostgresRasterProviderMetadata::saveStyle( const QString &uri, const QSt
     return false;
   }
 
-  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "layer_styles" ) ) )
+  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ) ) )
   {
     if ( !QgsPostgresUtils::createStylesTable( conn, QStringLiteral( "QgsPostgresRasterProviderMetadata" ) ) )
     {
@@ -2539,7 +2539,7 @@ bool QgsPostgresRasterProviderMetadata::saveStyle( const QString &uri, const QSt
   }
   else
   {
-    if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) )
+    if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) )
     {
       QgsPostgresResult res( conn->LoggedPQexec( QStringLiteral( "QgsPostgresRasterProviderMetadata" ), "ALTER TABLE layer_styles ADD COLUMN type varchar NULL" ) );
       if ( res.PQresultStatus() != PGRES_COMMAND_OK )
@@ -2551,7 +2551,7 @@ bool QgsPostgresRasterProviderMetadata::saveStyle( const QString &uri, const QSt
     }
   }
 
-  if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "layer_styles" ), QStringLiteral( "r_raster_column" ) ) )
+  if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ), QStringLiteral( "r_raster_column" ) ) )
   {
     QgsPostgresResult res( conn->LoggedPQexec( QStringLiteral( "QgsPostgresRasterProviderMetadata" ), "ALTER TABLE layer_styles ADD COLUMN r_raster_column varchar NULL" ) );
     if ( res.PQresultStatus() != PGRES_COMMAND_OK )
@@ -2701,18 +2701,18 @@ QString QgsPostgresRasterProviderMetadata::loadStoredStyle( const QString &uri, 
     dsUri.setDatabase( conn->currentDatabase() );
   }
 
-  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "layer_styles" ) ) )
+  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ) ) )
   {
     conn->unref();
     return QString();
   }
-  else if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "layer_styles" ), QStringLiteral( "r_raster_column" ) ) )
+  else if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ), QStringLiteral( "r_raster_column" ) ) )
   {
     return QString();
   }
 
   // support layer_styles without type column < 3.14
-  if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) )
+  if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ), QStringLiteral( "type" ) ) )
   {
     selectQmlQuery = QString( "SELECT styleName, styleQML"
                               " FROM layer_styles"
@@ -2770,12 +2770,12 @@ int QgsPostgresRasterProviderMetadata::listStyles( const QString &uri, QStringLi
     return -1;
   }
 
-  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "layer_styles" ) ) )
+  if ( !QgsPostgresUtils::tableExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ) ) )
   {
     return -1;
   }
 
-  if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "layer_styles" ), QStringLiteral( "r_raster_column" ) ) )
+  if ( !QgsPostgresUtils::columnExists( conn, QStringLiteral( "public" ), QStringLiteral( "layer_styles" ), QStringLiteral( "r_raster_column" ) ) )
   {
     return false;
   }


### PR DESCRIPTION
## Description

Update `QgsPostgresUtils` functions `columnExists()` and `tableExists()` with `schema` parameter, so that they can be used to search for colums and tables outside of public schema.

This is intended for future updates and work.
