### PR TITLE
Avoid warnings about unsecure functions

### DIFF
--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -565,8 +565,6 @@ bool QgsSpatiaLiteConnection::isRasterlite1Datasource( sqlite3 *handle, const ch
   bool exists = false;
 
   QString tableRaster = QString::fromUtf8( table );
-  if ( tableRaster.size() < 9 )
-    return false;
   if ( !tableRaster.endsWith( QLatin1String( "_metadata" ) ) )
     return false;
 

--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -580,7 +580,7 @@ bool QgsSpatiaLiteConnection::isRasterlite1Datasource( sqlite3 *handle, const ch
   )
                      .arg( tableRaster.replace( '\'', QLatin1String( "''" ) ) );
 
-  ret = sqlite3_get_table( handle, sql.toUtf8().constData(), &results, &rows, &columns, nullptr );
+  ret = sqlite3_get_table( handle, sqlStr.toUtf8().constData(), &results, &rows, &columns, nullptr );
   if ( ret != SQLITE_OK )
     return false;
 

--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -563,38 +563,34 @@ bool QgsSpatiaLiteConnection::isRasterlite1Datasource( sqlite3 *handle, const ch
   int rows;
   int columns;
   bool exists = false;
-  char table_raster[4192];
-  char sql[4258];
 
-  strncpy( table_raster, table, sizeof table_raster );
-  table_raster[sizeof table_raster - 1] = '\0';
-
-  const size_t len = strlen( table_raster );
-  if ( strlen( table_raster ) < 9 )
+  QString tableRaster = QString::fromUtf8( table );
+  if ( tableRaster.size() < 9 )
     return false;
-  if ( strcmp( table_raster + len - 9, "_metadata" ) != 0 )
+  if ( !tableRaster.endsWith( QLatin1String( "_metadata" ) ) )
     return false;
-  // OK, possible candidate
-  strcpy( table_raster + len - 9, "_rasters" );
 
-  // checking if the related "_RASTERS table exists
-  sprintf( sql, "SELECT name FROM sqlite_master WHERE type = 'table' AND name = '%s'", table_raster );
+  // OK, possible candidate → replace suffix
+  tableRaster.chop( 9 );
+  tableRaster += QLatin1String( "_rasters" );
 
-  ret = sqlite3_get_table( handle, sql, &results, &rows, &columns, nullptr );
+  // checking if the related "_RASTERS" table exists
+  QString sqlStr = QStringLiteral(
+                     "SELECT name FROM sqlite_master WHERE type = 'table' AND name = '%1'"
+  )
+                     .arg( tableRaster.replace( '\'', QLatin1String( "''" ) ) );
+
+  ret = sqlite3_get_table( handle, sql.toUtf8().constData(), &results, &rows, &columns, nullptr );
   if ( ret != SQLITE_OK )
     return false;
-  if ( rows < 1 )
-    ;
-  else
+
+  for ( i = 1; i <= rows; i++ )
   {
-    for ( i = 1; i <= rows; i++ )
+    const char *name = results[( i * columns ) + 0];
+    if ( name )
     {
-      if ( results[( i * columns ) + 0] )
-      {
-        const char *name = results[( i * columns ) + 0];
-        if ( name )
-          exists = true;
-      }
+      exists = true;
+      break;
     }
   }
   sqlite3_free_table( results );


### PR DESCRIPTION
and modernize code

See

```
/Users/runner/work/QGIS/QGIS/src/providers/spatialite/qgsspatialiteconnection.cpp:581:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  sprintf( sql, "SELECT name FROM sqlite_master WHERE type = 'table' AND name = '%s'", table_raster );
  ^
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/usr/include/stdio.h:180:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 warning generated.
```

https://github.com/qgis/QGIS/actions/runs/17819590584/job/50659286131#step:15:1873