### PR TITLE
always load Processing GRASS algorithms (fix #61672)

### DIFF
--- a/python/plugins/grassprovider/grass_algorithm.py
+++ b/python/plugins/grassprovider/grass_algorithm.py
@@ -502,6 +502,14 @@ class GrassAlgorithm(QgsProcessingAlgorithm):
                     )
                 )
 
+        version = GrassUtils.installedVersion(True)
+        if version is None:
+            raise QgsProcessingException(
+                self.tr(
+                    "Problem with GRASS installation: GRASS was not found or is not correctly installed"
+                )
+            )
+
         # make a copy of the original parameters dictionary - it gets modified by grass algorithms
         parameters = {k: v for k, v in original_parameters.items()}
 

--- a/python/plugins/grassprovider/grass_provider.py
+++ b/python/plugins/grassprovider/grass_provider.py
@@ -167,17 +167,6 @@ class GrassProvider(QgsProcessingProvider):
         return algs
 
     def loadAlgorithms(self):
-        version = GrassUtils.installedVersion(True)
-        if version is None:
-            QgsMessageLog.logMessage(
-                self.tr(
-                    "Problem with GRASS installation: GRASS was not found or is not correctly installed"
-                ),
-                self.tr("Processing"),
-                Qgis.MessageLevel.Critical,
-            )
-            return
-
         for a in self.parse_algorithms():
             self.addAlgorithm(a)
 


### PR DESCRIPTION
## Description

Load GRASS algorithms in Processing toolbox even if GRASS is not available. This allows users to open models which include GRASS algorithms and also avoids confusion when provider settings are present and editable while there are no algorithms in the toolbox.

Fixes #61672.