### PR TITLE
fixes for Processing geometry checker algorithms

### DIFF
--- a/python/PyQt6/analysis/auto_additions/qgsgeometrycheck.py
+++ b/python/PyQt6/analysis/auto_additions/qgsgeometrycheck.py
@@ -9,6 +9,23 @@ QgsGeometryCheck.ChangeChanged = QgsGeometryCheck.ChangeType.ChangeChanged
 QgsGeometryCheck.FeatureNodeCheck = QgsGeometryCheck.CheckType.FeatureNodeCheck
 QgsGeometryCheck.FeatureCheck = QgsGeometryCheck.CheckType.FeatureCheck
 QgsGeometryCheck.LayerCheck = QgsGeometryCheck.CheckType.LayerCheck
+# monkey patching scoped based enum
+QgsGeometryCheck.Result.Success.__doc__ = "Operation completed successfully"
+QgsGeometryCheck.Result.Canceled.__doc__ = "User canceled calculation"
+QgsGeometryCheck.Result.DuplicatedUniqueId.__doc__ = "Found duplicated unique ID value"
+QgsGeometryCheck.Result.InvalidReferenceLayer.__doc__ = "Missed or invalid reference layer"
+QgsGeometryCheck.Result.GeometryOverlayError.__doc__ = "Error performing geometry overlay operation"
+QgsGeometryCheck.Result.__doc__ = """
+.. versionadded:: 4.0
+
+* ``Success``: Operation completed successfully
+* ``Canceled``: User canceled calculation
+* ``DuplicatedUniqueId``: Found duplicated unique ID value
+* ``InvalidReferenceLayer``: Missed or invalid reference layer
+* ``GeometryOverlayError``: Error performing geometry overlay operation
+
+"""
+# --
 QgsGeometryCheck.AvailableInValidation = QgsGeometryCheck.Flag.AvailableInValidation
 QgsGeometryCheck.Flags = lambda flags=0: QgsGeometryCheck.Flag(flags)
 QgsGeometryCheck.Flags.baseClass = QgsGeometryCheck
@@ -23,8 +40,8 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsGeometryCheck.__virtual_methods__ = ['prepare', 'isCompatible', 'flags', 'availableResolutionMethods', 'resolutionMethods']
-    QgsGeometryCheck.__abstract_methods__ = ['compatibleGeometryTypes', 'collectErrors', 'description', 'id', 'checkType']
+    QgsGeometryCheck.__virtual_methods__ = ['prepare', 'isCompatible', 'flags', 'collectErrors', 'availableResolutionMethods', 'resolutionMethods']
+    QgsGeometryCheck.__abstract_methods__ = ['compatibleGeometryTypes', 'description', 'id', 'checkType']
     QgsGeometryCheck.__group__ = ['vector', 'geometry_checker']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
@@ -127,6 +127,15 @@ the system is aware of the available geometry checks.
       LayerCheck
     };
 
+    enum class Result /BaseType=IntEnum/
+    {
+      Success,
+      Canceled,
+      DuplicatedUniqueId,
+      InvalidReferenceLayer,
+      GeometryOverlayError
+    };
+
     enum Flag /BaseType=IntEnum/
     {
       AvailableInValidation
@@ -193,13 +202,16 @@ A list of geometry types for which this check can be performed.
 Flags for this geometry check.
 %End
 
-    virtual void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors /In,Out/, QStringList &messages /In,Out/, QgsFeedback *feedback, const LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const = 0;
+    virtual Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors /In,Out/, QStringList &messages /In,Out/, QgsFeedback *feedback, const LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const;
 %Docstring
 The main worker method. Check all features available from
 ``featurePools`` and write errors found to ``errors``. Other status
 messages can be written to ``messages``. Progress should be reported to
 ``feedback``. Only features and layers listed in ``ids`` should be
 checked.
+
+:return: QgsGeometryCheck.Result.Success in case of success or error
+         value on failure.
 
 .. versionadded:: 3.4
 %End
@@ -252,6 +264,7 @@ Returns the context
 %End
 
   protected:
+
 
 
 

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
@@ -24,7 +24,7 @@ Base configuration for geometry checks.
 #include "qgsgeometrycheckcontext.h"
 %End
   public:
-    QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *mProject );
+    QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *mProject = 0, const int uniqueIdFieldIndex = -1 );
 %Docstring
 Creates a new QgsGeometryCheckContext.
 %End
@@ -36,6 +36,8 @@ Creates a new QgsGeometryCheckContext.
     const QgsCoordinateReferenceSystem mapCrs;
 
     const QgsCoordinateTransformContext transformContext;
+
+    const int uniqueIdFieldIndex;
 
     const QgsProject *project() const;
 %Docstring

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
@@ -27,6 +27,17 @@ Base configuration for geometry checks.
     QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *mProject = 0, const int uniqueIdFieldIndex = -1 );
 %Docstring
 Creates a new QgsGeometryCheckContext.
+
+:param precision: The precision used to define gemetry check tolerance.
+                  Tolerance is calculated as pow(10, -precision)
+:param mapCrs: The coordinate system in which calculations should be
+               done
+:param transformContext: The coordinate transform context
+:param mProject: The project used to resolve additional layers
+:param uniqueIdFieldIndex: The index of the unique ID field used to
+                           identify features. If set to valid field
+                           index, geometry checker will fail if this
+                           field is not unique (since QGIS 4.0)
 %End
 
     const double tolerance;

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgssinglegeometrycheck.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgssinglegeometrycheck.sip.in
@@ -132,7 +132,7 @@ Subclasses need to implement the processGeometry method.
 Creates a new single geometry check.
 %End
 
-    virtual void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback = 0, const QgsGeometryCheck::LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const ${SIP_FINAL};
+    virtual QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback = 0, const QgsGeometryCheck::LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const ${SIP_FINAL};
 
 
     virtual QList<QgsSingleGeometryCheckError *> processGeometry( const QgsGeometry &geometry ) const = 0;

--- a/python/analysis/auto_additions/qgsgeometrycheck.py
+++ b/python/analysis/auto_additions/qgsgeometrycheck.py
@@ -1,4 +1,21 @@
 # The following has been generated automatically from src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+# monkey patching scoped based enum
+QgsGeometryCheck.Result.Success.__doc__ = "Operation completed successfully"
+QgsGeometryCheck.Result.Canceled.__doc__ = "User canceled calculation"
+QgsGeometryCheck.Result.DuplicatedUniqueId.__doc__ = "Found duplicated unique ID value"
+QgsGeometryCheck.Result.InvalidReferenceLayer.__doc__ = "Missed or invalid reference layer"
+QgsGeometryCheck.Result.GeometryOverlayError.__doc__ = "Error performing geometry overlay operation"
+QgsGeometryCheck.Result.__doc__ = """
+.. versionadded:: 4.0
+
+* ``Success``: Operation completed successfully
+* ``Canceled``: User canceled calculation
+* ``DuplicatedUniqueId``: Found duplicated unique ID value
+* ``InvalidReferenceLayer``: Missed or invalid reference layer
+* ``GeometryOverlayError``: Error performing geometry overlay operation
+
+"""
+# --
 QgsGeometryCheck.Flags.baseClass = QgsGeometryCheck
 Flags = QgsGeometryCheck  # dirty hack since SIP seems to introduce the flags in module
 try:
@@ -11,8 +28,8 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsGeometryCheck.__virtual_methods__ = ['prepare', 'isCompatible', 'flags', 'availableResolutionMethods', 'resolutionMethods']
-    QgsGeometryCheck.__abstract_methods__ = ['compatibleGeometryTypes', 'collectErrors', 'description', 'id', 'checkType']
+    QgsGeometryCheck.__virtual_methods__ = ['prepare', 'isCompatible', 'flags', 'collectErrors', 'availableResolutionMethods', 'resolutionMethods']
+    QgsGeometryCheck.__abstract_methods__ = ['compatibleGeometryTypes', 'description', 'id', 'checkType']
     QgsGeometryCheck.__group__ = ['vector', 'geometry_checker']
 except (NameError, AttributeError):
     pass

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
@@ -127,6 +127,15 @@ the system is aware of the available geometry checks.
       LayerCheck
     };
 
+    enum class Result
+    {
+      Success,
+      Canceled,
+      DuplicatedUniqueId,
+      InvalidReferenceLayer,
+      GeometryOverlayError
+    };
+
     enum Flag
     {
       AvailableInValidation
@@ -193,13 +202,16 @@ A list of geometry types for which this check can be performed.
 Flags for this geometry check.
 %End
 
-    virtual void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors /In,Out/, QStringList &messages /In,Out/, QgsFeedback *feedback, const LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const = 0;
+    virtual Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors /In,Out/, QStringList &messages /In,Out/, QgsFeedback *feedback, const LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const;
 %Docstring
 The main worker method. Check all features available from
 ``featurePools`` and write errors found to ``errors``. Other status
 messages can be written to ``messages``. Progress should be reported to
 ``feedback``. Only features and layers listed in ``ids`` should be
 checked.
+
+:return: QgsGeometryCheck.Result.Success in case of success or error
+         value on failure.
 
 .. versionadded:: 3.4
 %End
@@ -252,6 +264,7 @@ Returns the context
 %End
 
   protected:
+
 
 
 

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
@@ -24,7 +24,7 @@ Base configuration for geometry checks.
 #include "qgsgeometrycheckcontext.h"
 %End
   public:
-    QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *mProject );
+    QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *mProject = 0, const int uniqueIdFieldIndex = -1 );
 %Docstring
 Creates a new QgsGeometryCheckContext.
 %End
@@ -36,6 +36,8 @@ Creates a new QgsGeometryCheckContext.
     const QgsCoordinateReferenceSystem mapCrs;
 
     const QgsCoordinateTransformContext transformContext;
+
+    const int uniqueIdFieldIndex;
 
     const QgsProject *project() const;
 %Docstring

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
@@ -27,6 +27,17 @@ Base configuration for geometry checks.
     QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *mProject = 0, const int uniqueIdFieldIndex = -1 );
 %Docstring
 Creates a new QgsGeometryCheckContext.
+
+:param precision: The precision used to define gemetry check tolerance.
+                  Tolerance is calculated as pow(10, -precision)
+:param mapCrs: The coordinate system in which calculations should be
+               done
+:param transformContext: The coordinate transform context
+:param mProject: The project used to resolve additional layers
+:param uniqueIdFieldIndex: The index of the unique ID field used to
+                           identify features. If set to valid field
+                           index, geometry checker will fail if this
+                           field is not unique (since QGIS 4.0)
 %End
 
     const double tolerance;

--- a/python/analysis/auto_generated/vector/geometry_checker/qgssinglegeometrycheck.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgssinglegeometrycheck.sip.in
@@ -132,7 +132,7 @@ Subclasses need to implement the processGeometry method.
 Creates a new single geometry check.
 %End
 
-    virtual void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback = 0, const QgsGeometryCheck::LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const ${SIP_FINAL};
+    virtual QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback = 0, const QgsGeometryCheck::LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const ${SIP_FINAL};
 
 
     virtual QList<QgsSingleGeometryCheckError *> processGeometry( const QgsGeometry &geometry ) const = 0;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryangle.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryangle.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckAngleAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckAngleAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckAngleAlgorithm *QgsGeometryCheckAngleAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometryangle.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryangle.cpp
@@ -75,7 +75,6 @@ void QgsGeometryCheckAngleAlgorithm::initAlgorithm( const QVariantMap &configura
 {
   Q_UNUSED( configuration )
 
-  // inputs
   addParameter(
     new QgsProcessingParameterFeatureSource(
       QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ),
@@ -89,7 +88,6 @@ void QgsGeometryCheckAngleAlgorithm::initAlgorithm( const QVariantMap &configura
     QStringLiteral( "MIN_ANGLE" ), QObject::tr( "Minimum angle (in degrees)" ), Qgis::ProcessingNumberParameterType::Double, 0, false, 0.0, 180.0
   ) );
 
-  // outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "ERRORS" ), QObject::tr( "Small angle errors" ), Qgis::ProcessingSourceType::VectorPoint
   ) );
@@ -131,8 +129,8 @@ QVariantMap QgsGeometryCheckAngleAlgorithm::processAlgorithm( const QVariantMap 
   if ( !input )
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
 
-  QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
-  int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
+  const QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
+  const int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
   if ( uniqueIdFieldIdx == -1 )
     throw QgsProcessingException( QObject::tr( "Missing field %1 in input layer" ).arg( uniqueIdFieldName ) );
 

--- a/src/analysis/processing/qgsalgorithmcheckgeometryangle.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryangle.cpp
@@ -151,7 +151,7 @@ QVariantMap QgsGeometryCheckAngleAlgorithm::processAlgorithm( const QVariantMap 
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -173,7 +173,19 @@ QVariantMap QgsGeometryCheckAngleAlgorithm::processAlgorithm( const QVariantMap 
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( featurePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( featurePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometryangle.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryangle.cpp
@@ -147,9 +147,7 @@ QVariantMap QgsGeometryCheckAngleAlgorithm::processAlgorithm( const QVariantMap 
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryarea.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryarea.cpp
@@ -75,7 +75,6 @@ void QgsGeometryCheckAreaAlgorithm::initAlgorithm( const QVariantMap &configurat
 {
   Q_UNUSED( configuration )
 
-  // inputs
   addParameter(
     new QgsProcessingParameterFeatureSource(
       QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ),
@@ -89,7 +88,6 @@ void QgsGeometryCheckAreaAlgorithm::initAlgorithm( const QVariantMap &configurat
     QStringLiteral( "AREATHRESHOLD" ), QObject::tr( "Area threshold" ), 0, QStringLiteral( "INPUT" )
   ) );
 
-  // outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "ERRORS" ), QObject::tr( "Small polygons errors" ), Qgis::ProcessingSourceType::VectorPoint
   ) );
@@ -134,8 +132,8 @@ QVariantMap QgsGeometryCheckAreaAlgorithm::processAlgorithm( const QVariantMap &
   if ( !input )
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
 
-  QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
-  int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
+  const QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
+  const int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
   if ( uniqueIdFieldIdx == -1 )
     throw QgsProcessingException( QObject::tr( "Missing field %1 in input layer" ).arg( uniqueIdFieldName ) );
 
@@ -156,7 +154,7 @@ QVariantMap QgsGeometryCheckAreaAlgorithm::processAlgorithm( const QVariantMap &
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  QgsProject *project = QgsProject::instance();
+  const QgsProject *project = QgsProject::instance();
 
   QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 

--- a/src/analysis/processing/qgsalgorithmcheckgeometryarea.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryarea.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckAreaAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckAreaAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckAreaAlgorithm *QgsGeometryCheckAreaAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometryarea.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryarea.cpp
@@ -154,9 +154,7 @@ QVariantMap QgsGeometryCheckAreaAlgorithm::processAlgorithm( const QVariantMap &
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrycontained.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrycontained.cpp
@@ -76,7 +76,6 @@ void QgsGeometryCheckContainedAlgorithm::initAlgorithm( const QVariantMap &confi
 {
   Q_UNUSED( configuration )
 
-  // inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ),
     QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPoint )
@@ -90,7 +89,6 @@ void QgsGeometryCheckContainedAlgorithm::initAlgorithm( const QVariantMap &confi
     QStringLiteral( "POLYGONS" ), QObject::tr( "Polygon layers" ), Qgis::ProcessingSourceType::VectorPolygon
   ) );
 
-  // outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "ERRORS" ), QObject::tr( "Errors from contained features" ), Qgis::ProcessingSourceType::VectorPoint
   ) );
@@ -138,7 +136,6 @@ QVariantMap QgsGeometryCheckContainedAlgorithm::processAlgorithm( const QVariant
   QList<QgsMapLayer *> polygonLayers = parameterAsLayerList( parameters, QStringLiteral( "POLYGONS" ), context );
   if ( polygonLayers.isEmpty() )
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "POLYGONS" ) ) );
-
 
   const QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
   const int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrycontained.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrycontained.cpp
@@ -160,9 +160,7 @@ QVariantMap QgsGeometryCheckContainedAlgorithm::processAlgorithm( const QVariant
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrycontained.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrycontained.cpp
@@ -165,7 +165,7 @@ QVariantMap QgsGeometryCheckContainedAlgorithm::processAlgorithm( const QVariant
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -194,7 +194,19 @@ QVariantMap QgsGeometryCheckContainedAlgorithm::processAlgorithm( const QVariant
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrycontained.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrycontained.cpp
@@ -64,7 +64,7 @@ QString QgsGeometryCheckContainedAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckContainedAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckContainedAlgorithm *QgsGeometryCheckContainedAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrydangle.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrydangle.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckDangleAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckDangleAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckDangleAlgorithm *QgsGeometryCheckDangleAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrydangle.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrydangle.cpp
@@ -118,7 +118,6 @@ QgsFields QgsGeometryCheckDangleAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckDangleAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrydangle.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrydangle.cpp
@@ -151,7 +151,7 @@ QVariantMap QgsGeometryCheckDangleAlgorithm::processAlgorithm( const QVariantMap
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
   const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -169,7 +169,19 @@ QVariantMap QgsGeometryCheckDangleAlgorithm::processAlgorithm( const QVariantMap
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrydangle.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrydangle.cpp
@@ -149,8 +149,7 @@ QVariantMap QgsGeometryCheckDangleAlgorithm::processAlgorithm( const QVariantMap
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrydegeneratepolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrydegeneratepolygon.cpp
@@ -146,7 +146,7 @@ QVariantMap QgsGeometryCheckDegeneratePolygonAlgorithm::processAlgorithm( const 
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, project->crs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, project->crs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -164,7 +164,19 @@ QVariantMap QgsGeometryCheckDegeneratePolygonAlgorithm::processAlgorithm( const 
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrydegeneratepolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrydegeneratepolygon.cpp
@@ -62,7 +62,7 @@ QString QgsGeometryCheckDegeneratePolygonAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckDegeneratePolygonAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckDegeneratePolygonAlgorithm *QgsGeometryCheckDegeneratePolygonAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrydegeneratepolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrydegeneratepolygon.cpp
@@ -144,9 +144,7 @@ QVariantMap QgsGeometryCheckDegeneratePolygonAlgorithm::processAlgorithm( const 
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, project->crs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryduplicate.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryduplicate.cpp
@@ -153,8 +153,7 @@ QVariantMap QgsGeometryCheckDuplicateAlgorithm::processAlgorithm( const QVariant
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryduplicate.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryduplicate.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckDuplicateAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckDuplicateAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckDuplicateAlgorithm *QgsGeometryCheckDuplicateAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometryduplicate.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryduplicate.cpp
@@ -124,7 +124,6 @@ QgsFields QgsGeometryCheckDuplicateAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckDuplicateAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;
@@ -140,7 +139,6 @@ QVariantMap QgsGeometryCheckDuplicateAlgorithm::processAlgorithm( const QVariant
     throw QgsProcessingException( QObject::tr( "Missing field %1 in input layer" ).arg( uniqueIdFieldName ) );
 
   const QgsField uniqueIdField = input->fields().at( uniqueIdFieldIdx );
-
   QgsFields fields = outputFields();
   fields.append( uniqueIdField );
 

--- a/src/analysis/processing/qgsalgorithmcheckgeometryduplicate.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryduplicate.cpp
@@ -156,7 +156,7 @@ QVariantMap QgsGeometryCheckDuplicateAlgorithm::processAlgorithm( const QVariant
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
   const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -174,7 +174,19 @@ QVariantMap QgsGeometryCheckDuplicateAlgorithm::processAlgorithm( const QVariant
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometryduplicatenodes.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryduplicatenodes.cpp
@@ -149,9 +149,7 @@ QVariantMap QgsGeometryCheckDuplicateNodesAlgorithm::processAlgorithm( const QVa
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryduplicatenodes.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryduplicatenodes.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckDuplicateNodesAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckDuplicateNodesAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckDuplicateNodesAlgorithm *QgsGeometryCheckDuplicateNodesAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometryduplicatenodes.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryduplicatenodes.cpp
@@ -119,7 +119,6 @@ QgsFields QgsGeometryCheckDuplicateNodesAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckDuplicateNodesAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryduplicatenodes.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryduplicatenodes.cpp
@@ -152,7 +152,7 @@ QVariantMap QgsGeometryCheckDuplicateNodesAlgorithm::processAlgorithm( const QVa
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -172,7 +172,19 @@ QVariantMap QgsGeometryCheckDuplicateNodesAlgorithm::processAlgorithm( const QVa
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometryfollowboundaries.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryfollowboundaries.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckFollowBoundariesAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckFollowBoundariesAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckFollowBoundariesAlgorithm *QgsGeometryCheckFollowBoundariesAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometryfollowboundaries.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryfollowboundaries.cpp
@@ -122,7 +122,6 @@ QgsFields QgsGeometryCheckFollowBoundariesAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckFollowBoundariesAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryfollowboundaries.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryfollowboundaries.cpp
@@ -155,7 +155,7 @@ QVariantMap QgsGeometryCheckFollowBoundariesAlgorithm::processAlgorithm( const Q
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -175,7 +175,23 @@ QVariantMap QgsGeometryCheckFollowBoundariesAlgorithm::processAlgorithm( const Q
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( featurePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( featurePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::InvalidReferenceLayer )
+  {
+    throw QgsProcessingException( QObject::tr( "Invalid reference layer." ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometryfollowboundaries.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryfollowboundaries.cpp
@@ -152,9 +152,7 @@ QVariantMap QgsGeometryCheckFollowBoundariesAlgorithm::processAlgorithm( const Q
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrygap.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrygap.cpp
@@ -181,9 +181,7 @@ QVariantMap QgsGeometryCheckGapAlgorithm::processAlgorithm( const QVariantMap &p
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrygap.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrygap.cpp
@@ -139,7 +139,6 @@ QgsFields QgsGeometryCheckGapAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckGapAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;
@@ -166,8 +165,8 @@ QVariantMap QgsGeometryCheckGapAlgorithm::processAlgorithm( const QVariantMap &p
   if ( !sink_errors )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "ERRORS" ) ) );
 
-  QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
-  int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
+  const QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
+  const int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
   if ( uniqueIdFieldIdx == -1 )
     throw QgsProcessingException( QObject::tr( "Missing field %1 in input layer" ).arg( uniqueIdFieldName ) );
 

--- a/src/analysis/processing/qgsalgorithmcheckgeometrygap.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrygap.cpp
@@ -67,7 +67,7 @@ QString QgsGeometryCheckGapAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckGapAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckGapAlgorithm *QgsGeometryCheckGapAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometryhole.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryhole.cpp
@@ -152,9 +152,7 @@ QVariantMap QgsGeometryCheckHoleAlgorithm::processAlgorithm( const QVariantMap &
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryhole.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryhole.cpp
@@ -75,7 +75,6 @@ void QgsGeometryCheckHoleAlgorithm::initAlgorithm( const QVariantMap &configurat
 {
   Q_UNUSED( configuration )
 
-  // inputs
   addParameter(
     new QgsProcessingParameterFeatureSource(
       QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ),
@@ -86,7 +85,6 @@ void QgsGeometryCheckHoleAlgorithm::initAlgorithm( const QVariantMap &configurat
     QStringLiteral( "UNIQUE_ID" ), QObject::tr( "Unique feature identifier" ), QString(), QStringLiteral( "INPUT" )
   ) );
 
-  // outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "ERRORS" ), QObject::tr( "Holes errors" ), Qgis::ProcessingSourceType::VectorPoint
   ) );
@@ -132,8 +130,8 @@ QVariantMap QgsGeometryCheckHoleAlgorithm::processAlgorithm( const QVariantMap &
   if ( !input )
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
 
-  QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
-  int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
+  const QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
+  const int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
   if ( uniqueIdFieldIdx == -1 )
     throw QgsProcessingException( QObject::tr( "Missing field %1 in input layer" ).arg( uniqueIdFieldName ) );
 
@@ -154,7 +152,7 @@ QVariantMap QgsGeometryCheckHoleAlgorithm::processAlgorithm( const QVariantMap &
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  QgsProject *project = QgsProject::instance();
+  const QgsProject *project = QgsProject::instance();
 
   QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 

--- a/src/analysis/processing/qgsalgorithmcheckgeometryhole.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryhole.cpp
@@ -156,7 +156,7 @@ QVariantMap QgsGeometryCheckHoleAlgorithm::processAlgorithm( const QVariantMap &
 
   QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -174,7 +174,19 @@ QVariantMap QgsGeometryCheckHoleAlgorithm::processAlgorithm( const QVariantMap &
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( featurePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( featurePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometryhole.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryhole.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckHoleAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckHoleAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckHoleAlgorithm *QgsGeometryCheckHoleAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrylineintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrylineintersection.cpp
@@ -118,7 +118,6 @@ QgsFields QgsGeometryCheckLineIntersectionAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckLineIntersectionAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrylineintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrylineintersection.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckLineIntersectionAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckLineIntersectionAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckLineIntersectionAlgorithm *QgsGeometryCheckLineIntersectionAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrylineintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrylineintersection.cpp
@@ -151,7 +151,7 @@ QVariantMap QgsGeometryCheckLineIntersectionAlgorithm::processAlgorithm( const Q
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -169,7 +169,19 @@ QVariantMap QgsGeometryCheckLineIntersectionAlgorithm::processAlgorithm( const Q
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrylineintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrylineintersection.cpp
@@ -148,9 +148,7 @@ QVariantMap QgsGeometryCheckLineIntersectionAlgorithm::processAlgorithm( const Q
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrylinelayerintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrylinelayerintersection.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckLineLayerIntersectionAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckLineLayerIntersectionAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckLineLayerIntersectionAlgorithm *QgsGeometryCheckLineLayerIntersectionAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrylinelayerintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrylinelayerintersection.cpp
@@ -124,7 +124,6 @@ QgsFields QgsGeometryCheckLineLayerIntersectionAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckLineLayerIntersectionAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;
@@ -159,9 +158,7 @@ QVariantMap QgsGeometryCheckLineLayerIntersectionAlgorithm::processAlgorithm( co
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QVariantMap configurationCheck;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrylinelayerintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrylinelayerintersection.cpp
@@ -161,7 +161,7 @@ QVariantMap QgsGeometryCheckLineLayerIntersectionAlgorithm::processAlgorithm( co
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QVariantMap configurationCheck;
@@ -185,7 +185,19 @@ QVariantMap QgsGeometryCheckLineLayerIntersectionAlgorithm::processAlgorithm( co
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrymissingvertex.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrymissingvertex.cpp
@@ -149,9 +149,7 @@ QVariantMap QgsGeometryCheckMissingVertexAlgorithm::processAlgorithm( const QVar
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrymissingvertex.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrymissingvertex.cpp
@@ -64,7 +64,7 @@ QString QgsGeometryCheckMissingVertexAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckMissingVertexAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckMissingVertexAlgorithm *QgsGeometryCheckMissingVertexAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrymissingvertex.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrymissingvertex.cpp
@@ -76,7 +76,6 @@ void QgsGeometryCheckMissingVertexAlgorithm::initAlgorithm( const QVariantMap &c
 {
   Q_UNUSED( configuration )
 
-  // inputs
   addParameter(
     new QgsProcessingParameterFeatureSource(
       QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ),
@@ -87,7 +86,6 @@ void QgsGeometryCheckMissingVertexAlgorithm::initAlgorithm( const QVariantMap &c
     QStringLiteral( "UNIQUE_ID" ), QObject::tr( "Unique feature identifier" ), QString(), QStringLiteral( "INPUT" )
   ) );
 
-  // outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "ERRORS" ), QObject::tr( "Missing vertices errors" ), Qgis::ProcessingSourceType::VectorPoint
   ) );
@@ -133,8 +131,8 @@ QVariantMap QgsGeometryCheckMissingVertexAlgorithm::processAlgorithm( const QVar
   if ( !input )
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
 
-  QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
-  int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
+  const QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
+  const int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
   if ( uniqueIdFieldIdx == -1 )
     throw QgsProcessingException( QObject::tr( "Missing field %1 in input layer" ).arg( uniqueIdFieldName ) );
 
@@ -151,7 +149,7 @@ QVariantMap QgsGeometryCheckMissingVertexAlgorithm::processAlgorithm( const QVar
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  QgsProject *project = QgsProject::instance();
+  const QgsProject *project = QgsProject::instance();
 
   QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 

--- a/src/analysis/processing/qgsalgorithmcheckgeometrymissingvertex.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrymissingvertex.cpp
@@ -153,7 +153,7 @@ QVariantMap QgsGeometryCheckMissingVertexAlgorithm::processAlgorithm( const QVar
 
   QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -170,7 +170,19 @@ QVariantMap QgsGeometryCheckMissingVertexAlgorithm::processAlgorithm( const QVar
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( featurePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( featurePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrymultipart.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrymultipart.cpp
@@ -152,8 +152,7 @@ QVariantMap QgsGeometryCheckMultipartAlgorithm::processAlgorithm( const QVariant
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrymultipart.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrymultipart.cpp
@@ -154,7 +154,7 @@ QVariantMap QgsGeometryCheckMultipartAlgorithm::processAlgorithm( const QVariant
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
   const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -172,7 +172,19 @@ QVariantMap QgsGeometryCheckMultipartAlgorithm::processAlgorithm( const QVariant
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( featurePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( featurePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrymultipart.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrymultipart.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckMultipartAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckMultipartAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckMultipartAlgorithm *QgsGeometryCheckMultipartAlgorithm::createInstance() const
@@ -121,7 +121,6 @@ QgsFields QgsGeometryCheckMultipartAlgorithm::outputFields()
   fields.append( QgsField( QStringLiteral( "gc_error" ), QMetaType::QString ) );
   return fields;
 }
-
 
 QVariantMap QgsGeometryCheckMultipartAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {

--- a/src/analysis/processing/qgsalgorithmcheckgeometryoverlap.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryoverlap.cpp
@@ -152,9 +152,7 @@ QVariantMap QgsGeometryCheckOverlapAlgorithm::processAlgorithm( const QVariantMa
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryoverlap.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryoverlap.cpp
@@ -155,7 +155,7 @@ QVariantMap QgsGeometryCheckOverlapAlgorithm::processAlgorithm( const QVariantMa
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -177,7 +177,19 @@ QVariantMap QgsGeometryCheckOverlapAlgorithm::processAlgorithm( const QVariantMa
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometryoverlap.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryoverlap.cpp
@@ -198,6 +198,11 @@ QVariantMap QgsGeometryCheckOverlapAlgorithm::processAlgorithm( const QVariantMa
 
   for ( const QgsGeometryCheckError *error : checkErrors )
   {
+    if ( feedback->isCanceled() )
+    {
+      break;
+    }
+
     const QgsGeometryOverlapCheckError *overlapError = dynamic_cast<const QgsGeometryOverlapCheckError *>( error );
     if ( !overlapError )
       break;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryoverlap.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryoverlap.cpp
@@ -119,7 +119,6 @@ QgsFields QgsGeometryCheckOverlapAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckOverlapAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;
@@ -128,8 +127,8 @@ QVariantMap QgsGeometryCheckOverlapAlgorithm::processAlgorithm( const QVariantMa
   if ( !input )
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
 
-  QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
-  int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
+  const QString uniqueIdFieldName( parameterAsString( parameters, QStringLiteral( "UNIQUE_ID" ), context ) );
+  const int uniqueIdFieldIdx = input->fields().indexFromName( uniqueIdFieldName );
   if ( uniqueIdFieldIdx == -1 )
     throw QgsProcessingException( QObject::tr( "Missing field %1 in input layer" ).arg( uniqueIdFieldName ) );
 

--- a/src/analysis/processing/qgsalgorithmcheckgeometryoverlap.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryoverlap.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckOverlapAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckOverlapAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckOverlapAlgorithm *QgsGeometryCheckOverlapAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrypointcoveredbyline.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrypointcoveredbyline.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckPointCoveredByLineAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckPointCoveredByLineAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckPointCoveredByLineAlgorithm *QgsGeometryCheckPointCoveredByLineAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrypointcoveredbyline.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrypointcoveredbyline.cpp
@@ -150,7 +150,7 @@ QVariantMap QgsGeometryCheckPointCoveredByLineAlgorithm::processAlgorithm( const
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -179,7 +179,19 @@ QVariantMap QgsGeometryCheckPointCoveredByLineAlgorithm::processAlgorithm( const
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrypointcoveredbyline.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrypointcoveredbyline.cpp
@@ -147,9 +147,7 @@ QVariantMap QgsGeometryCheckPointCoveredByLineAlgorithm::processAlgorithm( const
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrypointcoveredbyline.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrypointcoveredbyline.cpp
@@ -118,7 +118,6 @@ QgsFields QgsGeometryCheckPointCoveredByLineAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckPointCoveredByLineAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_errors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrypointinpolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrypointinpolygon.cpp
@@ -150,7 +150,7 @@ QVariantMap QgsGeometryCheckPointInPolygonAlgorithm::processAlgorithm( const QVa
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -178,7 +178,19 @@ QVariantMap QgsGeometryCheckPointInPolygonAlgorithm::processAlgorithm( const QVa
   }
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrypointinpolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrypointinpolygon.cpp
@@ -147,9 +147,7 @@ QVariantMap QgsGeometryCheckPointInPolygonAlgorithm::processAlgorithm( const QVa
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrypointinpolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrypointinpolygon.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckPointInPolygonAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckPointInPolygonAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckPointInPolygonAlgorithm *QgsGeometryCheckPointInPolygonAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrypointinpolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrypointinpolygon.cpp
@@ -118,7 +118,6 @@ QgsFields QgsGeometryCheckPointInPolygonAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckPointInPolygonAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_errors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrysegmentlength.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrysegmentlength.cpp
@@ -152,9 +152,7 @@ QVariantMap QgsGeometryCheckSegmentLengthAlgorithm::processAlgorithm( const QVar
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrysegmentlength.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrysegmentlength.cpp
@@ -123,7 +123,6 @@ QgsFields QgsGeometryCheckSegmentLengthAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckSegmentLengthAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrysegmentlength.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrysegmentlength.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckSegmentLengthAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckSegmentLengthAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckSegmentLengthAlgorithm *QgsGeometryCheckSegmentLengthAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometryselfcontact.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryselfcontact.cpp
@@ -152,7 +152,7 @@ QVariantMap QgsGeometryCheckSelfContactAlgorithm::processAlgorithm( const QVaria
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -170,7 +170,19 @@ QVariantMap QgsGeometryCheckSelfContactAlgorithm::processAlgorithm( const QVaria
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometryselfcontact.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryselfcontact.cpp
@@ -149,9 +149,7 @@ QVariantMap QgsGeometryCheckSelfContactAlgorithm::processAlgorithm( const QVaria
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryselfcontact.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryselfcontact.cpp
@@ -119,7 +119,6 @@ QgsFields QgsGeometryCheckSelfContactAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckSelfContactAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryselfcontact.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryselfcontact.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckSelfContactAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckSelfContactAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckSelfContactAlgorithm *QgsGeometryCheckSelfContactAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometryselfintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryselfintersection.cpp
@@ -153,9 +153,7 @@ QVariantMap QgsGeometryCheckSelfIntersectionAlgorithm::processAlgorithm( const Q
 
   QgsProcessingMultiStepFeedback multiStepFeedback( 3, feedback );
 
-  const QgsProject *project = QgsProject::instance();
-
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryselfintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryselfintersection.cpp
@@ -123,7 +123,6 @@ QgsFields QgsGeometryCheckSelfIntersectionAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckSelfIntersectionAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryselfintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryselfintersection.cpp
@@ -195,6 +195,11 @@ QVariantMap QgsGeometryCheckSelfIntersectionAlgorithm::processAlgorithm( const Q
 
   for ( const QgsGeometryCheckError *error : checkErrors )
   {
+    if ( feedback->isCanceled() )
+    {
+      break;
+    }
+
     const QgsGeometryCheckErrorSingle *singleError = dynamic_cast<const QgsGeometryCheckErrorSingle *>( error );
     if ( !singleError )
       break;

--- a/src/analysis/processing/qgsalgorithmcheckgeometryselfintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryselfintersection.cpp
@@ -63,7 +63,7 @@ QString QgsGeometryCheckSelfIntersectionAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckSelfIntersectionAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckSelfIntersectionAlgorithm *QgsGeometryCheckSelfIntersectionAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometryselfintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometryselfintersection.cpp
@@ -156,7 +156,7 @@ QVariantMap QgsGeometryCheckSelfIntersectionAlgorithm::processAlgorithm( const Q
 
   const QgsProject *project = QgsProject::instance();
 
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
 
   // Test detection
   QList<QgsGeometryCheckError *> checkErrors;
@@ -174,7 +174,19 @@ QVariantMap QgsGeometryCheckSelfIntersectionAlgorithm::processAlgorithm( const Q
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( featurePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( featurePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrysliverpolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrysliverpolygon.cpp
@@ -68,7 +68,7 @@ QString QgsGeometryCheckSliverPolygonAlgorithm::shortHelpString() const
 
 Qgis::ProcessingAlgorithmFlags QgsGeometryCheckSliverPolygonAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 QgsGeometryCheckSliverPolygonAlgorithm *QgsGeometryCheckSliverPolygonAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmcheckgeometrysliverpolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrysliverpolygon.cpp
@@ -170,8 +170,8 @@ QVariantMap QgsGeometryCheckSliverPolygonAlgorithm::processAlgorithm( const QVar
   QVariantMap configurationCheck;
   configurationCheck.insert( "maxArea", maxArea );
   configurationCheck.insert( "threshold", maxThinness );
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
+
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project(), uniqueIdFieldIdx );
   const QgsGeometrySliverPolygonCheck check( &checkContext, configurationCheck );
 
   multiStepFeedback.setCurrentStep( 1 );

--- a/src/analysis/processing/qgsalgorithmcheckgeometrysliverpolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrysliverpolygon.cpp
@@ -130,7 +130,6 @@ QgsFields QgsGeometryCheckSliverPolygonAlgorithm::outputFields()
   return fields;
 }
 
-
 QVariantMap QgsGeometryCheckSliverPolygonAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QString dest_output;

--- a/src/analysis/processing/qgsalgorithmcheckgeometrysliverpolygon.cpp
+++ b/src/analysis/processing/qgsalgorithmcheckgeometrysliverpolygon.cpp
@@ -172,7 +172,7 @@ QVariantMap QgsGeometryCheckSliverPolygonAlgorithm::processAlgorithm( const QVar
   configurationCheck.insert( "maxArea", maxArea );
   configurationCheck.insert( "threshold", maxThinness );
   const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project, uniqueIdFieldIdx );
   const QgsGeometrySliverPolygonCheck check( &checkContext, configurationCheck );
 
   multiStepFeedback.setCurrentStep( 1 );
@@ -185,7 +185,19 @@ QVariantMap QgsGeometryCheckSliverPolygonAlgorithm::processAlgorithm( const QVar
 
   multiStepFeedback.setCurrentStep( 2 );
   feedback->setProgressText( QObject::tr( "Collecting errors…" ) );
-  check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  QgsGeometryCheck::Result res = check.collectErrors( checkerFeaturePools, checkErrors, messages, feedback );
+  if ( res == QgsGeometryCheck::Result::Success )
+  {
+    feedback->pushInfo( QObject::tr( "Errors collected successfully." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::Canceled )
+  {
+    throw QgsProcessingException( QObject::tr( "Operation was canceled." ) );
+  }
+  else if ( res == QgsGeometryCheck::Result::DuplicatedUniqueId )
+  {
+    throw QgsProcessingException( QObject::tr( "Field '%1' contains non-unique values and can not be used as unique ID." ).arg( uniqueIdFieldName ) );
+  }
 
   multiStepFeedback.setCurrentStep( 3 );
   feedback->setProgressText( QObject::tr( "Exporting errors…" ) );

--- a/src/analysis/processing/qgsalgorithmfixgeometryangle.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryangle.cpp
@@ -72,7 +72,6 @@ void QgsFixGeometryAngleAlgorithm::initAlgorithm( const QVariantMap &configurati
 {
   Q_UNUSED( configuration )
 
-  // Inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon ) << static_cast<int>( Qgis::ProcessingSourceType::VectorLine )
   ) );
@@ -99,7 +98,6 @@ void QgsFixGeometryAngleAlgorithm::initAlgorithm( const QVariantMap &configurati
     Qgis::ProcessingFieldParameterDataType::Numeric
   ) );
 
-  // Outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "OUTPUT" ), QObject::tr( "Small angle fixed layer" ), Qgis::ProcessingSourceType::VectorAnyGeometry
   ) );
@@ -146,7 +144,7 @@ QVariantMap QgsFixGeometryAngleAlgorithm::processAlgorithm( const QVariantMap &p
   if ( inputIdFieldIndex == -1 )
     throw QgsProcessingException( QObject::tr( "Field %1 does not exist in input layer." ).arg( featIdFieldName ) );
 
-  QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
+  const QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
   if ( inputFeatIdField.type() != errors->fields().at( errors->fields().indexFromName( featIdFieldName ) ).type() )
     throw QgsProcessingException( QObject::tr( "Field %1 does not have the same type as in the error layer." ).arg( featIdFieldName ) );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometryangle.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryangle.cpp
@@ -165,8 +165,7 @@ QVariantMap QgsFixGeometryAngleAlgorithm::processAlgorithm( const QVariantMap &p
   if ( !sink_report )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "REPORT" ) ) );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project() );
   QVariantMap configurationCheck;
 
   // maximum limit, we know that every feature to process is an error (otherwise it is not treated and marked as obsolete)

--- a/src/analysis/processing/qgsalgorithmfixgeometryangle.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryangle.cpp
@@ -278,7 +278,7 @@ bool QgsFixGeometryAngleAlgorithm::prepareAlgorithm( const QVariantMap &paramete
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometryAngleAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometryarea.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryarea.cpp
@@ -304,7 +304,7 @@ bool QgsFixGeometryAreaAlgorithm::prepareAlgorithm( const QVariantMap &parameter
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometryAreaAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometryarea.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryarea.cpp
@@ -177,8 +177,7 @@ QVariantMap QgsFixGeometryAreaAlgorithm::processAlgorithm( const QVariantMap &pa
   if ( !sink_report )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "REPORT" ) ) );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project() );
   QVariantMap configurationCheck;
 
   // maximum limit, we know that every feature to process is an error (otherwise it is not treated and marked as obsolete)

--- a/src/analysis/processing/qgsalgorithmfixgeometryarea.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryarea.cpp
@@ -68,7 +68,6 @@ void QgsFixGeometryAreaAlgorithm::initAlgorithm( const QVariantMap &configuratio
 {
   Q_UNUSED( configuration )
 
-  // Inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon )
   ) );
@@ -76,7 +75,6 @@ void QgsFixGeometryAreaAlgorithm::initAlgorithm( const QVariantMap &configuratio
     QStringLiteral( "ERRORS" ), QObject::tr( "Error layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPoint )
   ) );
 
-  // Specific inputs for this check
   QStringList methods;
   {
     QList<QgsGeometryCheckResolutionMethod> checkMethods = QgsGeometryAreaCheck( nullptr, QVariantMap() ).availableResolutionMethods();
@@ -112,7 +110,6 @@ void QgsFixGeometryAreaAlgorithm::initAlgorithm( const QVariantMap &configuratio
     Qgis::ProcessingFieldParameterDataType::Numeric
   ) );
 
-  // Outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "OUTPUT" ), QObject::tr( "Small polygons merged layer" ), Qgis::ProcessingSourceType::VectorPolygon
   ) );
@@ -159,11 +156,11 @@ QVariantMap QgsFixGeometryAreaAlgorithm::processAlgorithm( const QVariantMap &pa
     throw QgsProcessingException( QObject::tr( "Field %1 does not exist in the error layer." ).arg( ringIdxFieldName ) );
   if ( errors->fields().indexFromName( vertexIdxFieldName ) == -1 )
     throw QgsProcessingException( QObject::tr( "Field %1 does not exist in the error layer." ).arg( vertexIdxFieldName ) );
-  int inputIdFieldIndex = input->fields().indexFromName( featIdFieldName );
+  const int inputIdFieldIndex = input->fields().indexFromName( featIdFieldName );
   if ( inputIdFieldIndex == -1 )
     throw QgsProcessingException( QObject::tr( "Field %1 does not exist in input layer." ).arg( featIdFieldName ) );
 
-  QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
+  const QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
   if ( inputFeatIdField.type() != errors->fields().at( errors->fields().indexFromName( featIdFieldName ) ).type() )
     throw QgsProcessingException( QObject::tr( "Field %1 does not have the same type as in the error layer." ).arg( featIdFieldName ) );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometrydeletefeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrydeletefeatures.cpp
@@ -185,7 +185,7 @@ QVariantMap QgsFixGeometryDeleteFeaturesAlgorithm::processAlgorithm( const QVari
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometryDeleteFeaturesAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometrydeletefeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrydeletefeatures.cpp
@@ -70,7 +70,6 @@ void QgsFixGeometryDeleteFeaturesAlgorithm::initAlgorithm( const QVariantMap &co
 {
   Q_UNUSED( configuration )
 
-  // Inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ),
     QList<int>()
@@ -86,7 +85,6 @@ void QgsFixGeometryDeleteFeaturesAlgorithm::initAlgorithm( const QVariantMap &co
     QString(), QStringLiteral( "ERRORS" )
   ) );
 
-  // Outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "OUTPUT" ), QObject::tr( "Cleaned layer" ), Qgis::ProcessingSourceType::VectorAnyGeometry
   ) );

--- a/src/analysis/processing/qgsalgorithmfixgeometrydeletefeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrydeletefeatures.cpp
@@ -185,7 +185,7 @@ QVariantMap QgsFixGeometryDeleteFeaturesAlgorithm::processAlgorithm( const QVari
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometryDeleteFeaturesAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometryduplicatenodes.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryduplicatenodes.cpp
@@ -162,8 +162,7 @@ QVariantMap QgsFixGeometryDuplicateNodesAlgorithm::processAlgorithm( const QVari
   if ( !sink_report )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "REPORT" ) ) );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project() );
 
   const QgsGeometryDuplicateNodesCheck check( &checkContext, QVariantMap() );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometryduplicatenodes.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryduplicatenodes.cpp
@@ -69,7 +69,6 @@ void QgsFixGeometryDuplicateNodesAlgorithm::initAlgorithm( const QVariantMap &co
 {
   Q_UNUSED( configuration )
 
-  // Inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon ) << static_cast<int>( Qgis::ProcessingSourceType::VectorLine )
   ) );
@@ -96,7 +95,6 @@ void QgsFixGeometryDuplicateNodesAlgorithm::initAlgorithm( const QVariantMap &co
     Qgis::ProcessingFieldParameterDataType::Numeric
   ) );
 
-  // Outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "OUTPUT" ), QObject::tr( "Fixed duplicate vertices layer" ), Qgis::ProcessingSourceType::VectorAnyGeometry
   ) );
@@ -143,7 +141,7 @@ QVariantMap QgsFixGeometryDuplicateNodesAlgorithm::processAlgorithm( const QVari
   if ( inputIdFieldIndex == -1 )
     throw QgsProcessingException( QObject::tr( "Field \"%1\" does not exist in input layer." ).arg( featIdFieldName ) );
 
-  QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
+  const QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
   if ( inputFeatIdField.type() != errors->fields().at( errors->fields().indexFromName( featIdFieldName ) ).type() )
     throw QgsProcessingException( QObject::tr( "Field \"%1\" does not have the same type as in the error layer." ).arg( featIdFieldName ) );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometryduplicatenodes.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryduplicatenodes.cpp
@@ -267,7 +267,7 @@ bool QgsFixGeometryDuplicateNodesAlgorithm::prepareAlgorithm( const QVariantMap 
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometryDuplicateNodesAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometrygap.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrygap.cpp
@@ -305,7 +305,7 @@ bool QgsFixGeometryGapAlgorithm::prepareAlgorithm( const QVariantMap &parameters
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometryGapAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometrygap.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrygap.cpp
@@ -68,7 +68,6 @@ void QgsFixGeometryGapAlgorithm::initAlgorithm( const QVariantMap &configuration
 {
   Q_UNUSED( configuration )
 
-  // Inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon )
   ) );
@@ -79,7 +78,6 @@ void QgsFixGeometryGapAlgorithm::initAlgorithm( const QVariantMap &configuration
     QStringLiteral( "GAPS" ), QObject::tr( "Gaps layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon )
   ) );
 
-  // Specific inputs for this check
   QStringList methods;
   {
     QList<QgsGeometryCheckResolutionMethod> checkMethods = QgsGeometryGapCheck( nullptr, QVariantMap() ).availableResolutionMethods();
@@ -100,7 +98,6 @@ void QgsFixGeometryGapAlgorithm::initAlgorithm( const QVariantMap &configuration
     Qgis::ProcessingFieldParameterDataType::Numeric
   ) );
 
-  // Outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "OUTPUT" ), QObject::tr( "Gaps-filled layer" ), Qgis::ProcessingSourceType::VectorPolygon
   ) );
@@ -158,7 +155,7 @@ QVariantMap QgsFixGeometryGapAlgorithm::processAlgorithm( const QVariantMap &par
     throw QgsProcessingException( QObject::tr( "Field \"%1\" does not exist in the gaps layer." ).arg( errorIdFieldName ) );
   if ( neighbors->fields().indexFromName( featIdFieldName ) == -1 )
     throw QgsProcessingException( QObject::tr( "Field \"%1\" does not exist in the neighbors layer." ).arg( featIdFieldName ) );
-  int inputIdFieldIndex = input->fields().indexFromName( featIdFieldName );
+  const int inputIdFieldIndex = input->fields().indexFromName( featIdFieldName );
   if ( inputIdFieldIndex == -1 )
     throw QgsProcessingException( QObject::tr( "Field \"%1\" does not exist in input layer." ).arg( featIdFieldName ) );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometrygap.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrygap.cpp
@@ -181,10 +181,8 @@ QVariantMap QgsFixGeometryGapAlgorithm::processAlgorithm( const QVariantMap &par
   if ( !sink_report )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "REPORT" ) ) );
 
-  QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext(
-    mTolerance, input->sourceCrs(), project->transformContext(), project
-  );
+  //QgsProject *project = QgsProject::instance();
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project() );
 
   const QgsGeometryGapCheck check( &checkContext, QVariantMap() );
 
@@ -198,7 +196,7 @@ QVariantMap QgsFixGeometryGapAlgorithm::processAlgorithm( const QVariantMap &par
   // To add features into the layer, the geometry checker looks for the layer in the project
   if ( method == QgsGeometryGapCheck::ResolutionMethod::CreateNewFeature )
   {
-    project->addMapLayer( fixedLayer.get(), false, false );
+    context.project()->addMapLayer( fixedLayer.get(), false, false );
     fixedLayer->startEditing();
   }
 
@@ -268,7 +266,7 @@ QVariantMap QgsFixGeometryGapAlgorithm::processAlgorithm( const QVariantMap &par
   {
     if ( !fixedLayer->commitChanges() )
       throw QgsProcessingException( QObject::tr( "Unable to add gap features" ) );
-    project->removeMapLayer( fixedLayer.get() );
+    context.project()->removeMapLayer( fixedLayer.get() );
   }
 
   progression = 0;

--- a/src/analysis/processing/qgsalgorithmfixgeometrygap.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrygap.cpp
@@ -181,7 +181,6 @@ QVariantMap QgsFixGeometryGapAlgorithm::processAlgorithm( const QVariantMap &par
   if ( !sink_report )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "REPORT" ) ) );
 
-  //QgsProject *project = QgsProject::instance();
   QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project() );
 
   const QgsGeometryGapCheck check( &checkContext, QVariantMap() );

--- a/src/analysis/processing/qgsalgorithmfixgeometryhole.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryhole.cpp
@@ -268,7 +268,7 @@ bool QgsFixGeometryHoleAlgorithm::prepareAlgorithm( const QVariantMap &parameter
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometryHoleAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometryhole.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryhole.cpp
@@ -158,8 +158,7 @@ QVariantMap QgsFixGeometryHoleAlgorithm::processAlgorithm( const QVariantMap &pa
   if ( !sink_report )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "REPORT" ) ) );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project() );
 
   const QgsGeometryHoleCheck check( &checkContext, QVariantMap() );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometryhole.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryhole.cpp
@@ -69,7 +69,6 @@ void QgsFixGeometryHoleAlgorithm::initAlgorithm( const QVariantMap &configuratio
 {
   Q_UNUSED( configuration )
 
-  // Inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon ) << static_cast<int>( Qgis::ProcessingSourceType::VectorLine )
   ) );
@@ -96,7 +95,6 @@ void QgsFixGeometryHoleAlgorithm::initAlgorithm( const QVariantMap &configuratio
     Qgis::ProcessingFieldParameterDataType::Numeric
   ) );
 
-  // Outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "OUTPUT" ), QObject::tr( "Holes-filled layer" ), Qgis::ProcessingSourceType::VectorAnyGeometry
   ) );
@@ -143,7 +141,7 @@ QVariantMap QgsFixGeometryHoleAlgorithm::processAlgorithm( const QVariantMap &pa
   if ( inputIdFieldIndex == -1 )
     throw QgsProcessingException( QObject::tr( "Field %1 does not exist in input layer." ).arg( featIdFieldName ) );
 
-  QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
+  const QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
   if ( inputFeatIdField.type() != errors->fields().at( errors->fields().indexFromName( featIdFieldName ) ).type() )
     throw QgsProcessingException( QObject::tr( "Field %1 does not have the same type as in the error layer." ).arg( featIdFieldName ) );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometrymissingvertex.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrymissingvertex.cpp
@@ -69,7 +69,6 @@ void QgsFixGeometryMissingVertexAlgorithm::initAlgorithm( const QVariantMap &con
 {
   Q_UNUSED( configuration )
 
-  // Inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon )
   ) );
@@ -97,7 +96,6 @@ void QgsFixGeometryMissingVertexAlgorithm::initAlgorithm( const QVariantMap &con
     Qgis::ProcessingFieldParameterDataType::Numeric
   ) );
 
-  // Outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "OUTPUT" ), QObject::tr( "Border vertices fixed layer" ), Qgis::ProcessingSourceType::VectorPolygon
   ) );
@@ -140,11 +138,11 @@ QVariantMap QgsFixGeometryMissingVertexAlgorithm::processAlgorithm( const QVaria
     throw QgsProcessingException( QObject::tr( "Field %1 does not exist in the error layer." ).arg( ringIdxFieldName ) );
   if ( errors->fields().indexFromName( vertexIdxFieldName ) == -1 )
     throw QgsProcessingException( QObject::tr( "Field %1 does not exist in the error layer." ).arg( vertexIdxFieldName ) );
-  int inputIdFieldIndex = input->fields().indexFromName( featIdFieldName );
+  const int inputIdFieldIndex = input->fields().indexFromName( featIdFieldName );
   if ( inputIdFieldIndex == -1 )
     throw QgsProcessingException( QObject::tr( "Field %1 does not exist in input layer." ).arg( featIdFieldName ) );
 
-  QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
+  const QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
   if ( inputFeatIdField.type() != errors->fields().at( errors->fields().indexFromName( featIdFieldName ) ).type() )
     throw QgsProcessingException( QObject::tr( "Field %1 does not have the same type as in the error layer." ).arg( featIdFieldName ) );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometrymissingvertex.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrymissingvertex.cpp
@@ -274,7 +274,7 @@ bool QgsFixGeometryMissingVertexAlgorithm::prepareAlgorithm( const QVariantMap &
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometryMissingVertexAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometrymissingvertex.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrymissingvertex.cpp
@@ -163,8 +163,7 @@ QVariantMap QgsFixGeometryMissingVertexAlgorithm::processAlgorithm( const QVaria
   if ( !sink_report )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "REPORT" ) ) );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project() );
 
   const QgsGeometryMissingVertexCheck check( &checkContext, QVariantMap() );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometrymultipart.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrymultipart.cpp
@@ -241,7 +241,7 @@ bool QgsFixGeometryMultipartAlgorithm::prepareAlgorithm( const QVariantMap &para
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometryMultipartAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometrymultipart.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrymultipart.cpp
@@ -140,8 +140,7 @@ QVariantMap QgsFixGeometryMultipartAlgorithm::processAlgorithm( const QVariantMa
   if ( !sink_report )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "REPORT" ) ) );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project() );
 
   const QgsGeometryMultipartCheck check( &checkContext, QVariantMap() );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometrymultipart.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometrymultipart.cpp
@@ -71,7 +71,6 @@ void QgsFixGeometryMultipartAlgorithm::initAlgorithm( const QVariantMap &configu
 {
   Q_UNUSED( configuration )
 
-  // Inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon ) << static_cast<int>( Qgis::ProcessingSourceType::VectorLine )
   ) );
@@ -83,7 +82,6 @@ void QgsFixGeometryMultipartAlgorithm::initAlgorithm( const QVariantMap &configu
     QStringLiteral( "id" ), QStringLiteral( "ERRORS" )
   ) );
 
-  // Outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "OUTPUT" ), QObject::tr( "Strictly-multipart layer" ), Qgis::ProcessingSourceType::VectorAnyGeometry
   ) );
@@ -121,7 +119,7 @@ QVariantMap QgsFixGeometryMultipartAlgorithm::processAlgorithm( const QVariantMa
   if ( inputIdFieldIndex == -1 )
     throw QgsProcessingException( QObject::tr( "Field \"%1\" does not exist in input layer." ).arg( featIdFieldName ) );
 
-  QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
+  const QgsField inputFeatIdField = input->fields().at( inputIdFieldIndex );
   if ( inputFeatIdField.type() != errors->fields().at( errors->fields().indexFromName( featIdFieldName ) ).type() )
     throw QgsProcessingException( QObject::tr( "Field \"%1\" does not have the same type as in the error layer." ).arg( featIdFieldName ) );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometryoverlap.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryoverlap.cpp
@@ -161,8 +161,7 @@ QVariantMap QgsFixGeometryOverlapAlgorithm::processAlgorithm( const QVariantMap 
   if ( !sink_report )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "REPORT" ) ) );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project() );
 
   const QgsGeometryOverlapCheck check( &checkContext, QVariantMap() );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometryoverlap.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryoverlap.cpp
@@ -278,7 +278,7 @@ bool QgsFixGeometryOverlapAlgorithm::prepareAlgorithm( const QVariantMap &parame
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometryOverlapAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometryoverlap.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryoverlap.cpp
@@ -69,7 +69,6 @@ void QgsFixGeometryOverlapAlgorithm::initAlgorithm( const QVariantMap &configura
 {
   Q_UNUSED( configuration )
 
-  // Inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon )
   ) );
@@ -91,7 +90,6 @@ void QgsFixGeometryOverlapAlgorithm::initAlgorithm( const QVariantMap &configura
     Qgis::ProcessingFieldParameterDataType::Numeric
   ) );
 
-  // Outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "OUTPUT" ), QObject::tr( "No-overlap layer" ), Qgis::ProcessingSourceType::VectorPolygon
   ) );

--- a/src/analysis/processing/qgsalgorithmfixgeometryselfintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryselfintersection.cpp
@@ -353,7 +353,7 @@ bool QgsFixGeometrySelfIntersectionAlgorithm::prepareAlgorithm( const QVariantMa
 
 Qgis::ProcessingAlgorithmFlags QgsFixGeometrySelfIntersectionAlgorithm::flags() const
 {
-  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading;
+  return QgsProcessingAlgorithm::flags() | Qgis::ProcessingAlgorithmFlag::NoThreading | Qgis::ProcessingAlgorithmFlag::RequiresProject;
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmfixgeometryselfintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryselfintersection.cpp
@@ -195,8 +195,7 @@ QVariantMap QgsFixGeometrySelfIntersectionAlgorithm::processAlgorithm( const QVa
   if ( !sink_report )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "REPORT" ) ) );
 
-  const QgsProject *project = QgsProject::instance();
-  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), project->transformContext(), project );
+  QgsGeometryCheckContext checkContext = QgsGeometryCheckContext( mTolerance, input->sourceCrs(), context.transformContext(), context.project() );
 
   const QgsGeometrySelfIntersectionCheck check( &checkContext, QVariantMap() );
 

--- a/src/analysis/processing/qgsalgorithmfixgeometryselfintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryselfintersection.cpp
@@ -69,7 +69,6 @@ void QgsFixGeometrySelfIntersectionAlgorithm::initAlgorithm( const QVariantMap &
 {
   Q_UNUSED( configuration )
 
-  // Inputs
   addParameter( new QgsProcessingParameterFeatureSource(
     QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ),
     QList<int>()
@@ -80,7 +79,6 @@ void QgsFixGeometrySelfIntersectionAlgorithm::initAlgorithm( const QVariantMap &
     QStringLiteral( "ERRORS" ), QObject::tr( "Error layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPoint )
   ) );
 
-  // Specific inputs for this check
   QStringList methods;
   {
     QList<QgsGeometryCheckResolutionMethod> checkMethods = QgsGeometrySelfIntersectionCheck( nullptr, QVariantMap() ).availableResolutionMethods();
@@ -121,7 +119,6 @@ void QgsFixGeometrySelfIntersectionAlgorithm::initAlgorithm( const QVariantMap &
     Qgis::ProcessingFieldParameterDataType::Numeric
   ) );
 
-  // Outputs
   addParameter( new QgsProcessingParameterFeatureSink(
     QStringLiteral( "OUTPUT" ), QObject::tr( "Self-intersections fixed layer" ), Qgis::ProcessingSourceType::VectorPolygon
   ) );
@@ -157,7 +154,6 @@ QVariantMap QgsFixGeometrySelfIntersectionAlgorithm::processAlgorithm( const QVa
   const QString segment1FieldName = parameterAsString( parameters, QStringLiteral( "SEGMENT_1" ), context );
   const QString segment2FieldName = parameterAsString( parameters, QStringLiteral( "SEGMENT_2" ), context );
 
-  // Specific inputs for this check
   const int method = parameterAsEnum( parameters, QStringLiteral( "METHOD" ), context );
 
   // Verify that input fields exists
@@ -173,7 +169,7 @@ QVariantMap QgsFixGeometrySelfIntersectionAlgorithm::processAlgorithm( const QVa
     throw QgsProcessingException( QObject::tr( "Field \"%1\" does not exist in the error layer." ).arg( segment1FieldName ) );
   if ( errors->fields().indexFromName( segment2FieldName ) == -1 )
     throw QgsProcessingException( QObject::tr( "Field \"%1\" does not exist in the error layer." ).arg( segment2FieldName ) );
-  int inputIdFieldIndex = input->fields().indexFromName( featIdFieldName );
+  const int inputIdFieldIndex = input->fields().indexFromName( featIdFieldName );
   if ( inputIdFieldIndex == -1 )
     throw QgsProcessingException( QObject::tr( "Field \"%1\" does not exist in input layer." ).arg( featIdFieldName ) );
 

--- a/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
@@ -34,6 +34,11 @@ QgsGeometryCheck::Result QgsGeometryAngleCheck::collectErrors( const QMap<QStrin
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, context() );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );

--- a/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometryanglecheck.h"
 #include "qgsgeometryutils.h"
@@ -24,13 +25,24 @@ QList<Qgis::GeometryType> QgsGeometryAngleCheck::compatibleGeometryTypes() const
   return factoryCompatibleGeometryTypes();
 }
 
-void QgsGeometryAngleCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryAngleCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
+
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, context() );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
+
     const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
@@ -69,6 +81,7 @@ void QgsGeometryAngleCheck::collectErrors( const QMap<QString, QgsFeaturePool *>
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryAngleCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes &changes ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.h
@@ -39,7 +39,7 @@ class ANALYSIS_EXPORT QgsGeometryAngleCheck : public QgsGeometryCheck
       , mMinAngle( configuration.value( QStringLiteral( "minAngle" ), 0.0 ).toDouble() )
     {}
 
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
 
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override;

--- a/src/analysis/vector/geometry_checker/qgsgeometryareacheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryareacheck.cpp
@@ -20,13 +20,24 @@
 #include "qgsfeaturepool.h"
 #include "qgsgeometrycheckerror.h"
 
-void QgsGeometryAreaCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryAreaCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
+
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
+
     const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     const double layerToMapUnits = scaleFactor( layerFeature.layer() );
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
@@ -39,6 +50,7 @@ void QgsGeometryAreaCheck::collectErrors( const QMap<QString, QgsFeaturePool *> 
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryAreaCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometryareacheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryareacheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometryengine.h"
 #include "qgsgeometrycollection.h"
@@ -29,6 +30,11 @@ QgsGeometryCheck::Result QgsGeometryAreaCheck::collectErrors( const QMap<QString
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );

--- a/src/analysis/vector/geometry_checker/qgsgeometryareacheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryareacheck.h
@@ -44,7 +44,7 @@ class ANALYSIS_EXPORT QgsGeometryAreaCheck : public QgsGeometryCheck
       , mAreaThreshold( configurationValue<double>( "areaThreshold" ) )
     {}
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     QString id() const override { return factoryId(); }

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
@@ -46,6 +46,18 @@ QgsGeometryCheck::Flags QgsGeometryCheck::flags() const
   return QgsGeometryCheck::Flags();
 }
 
+QgsGeometryCheck::Result QgsGeometryCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors SIP_INOUT, QStringList &messages SIP_INOUT, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+{
+  Q_UNUSED( featurePools )
+  Q_UNUSED( errors )
+  Q_UNUSED( messages )
+  Q_UNUSED( feedback )
+  Q_UNUSED( ids )
+
+  return QgsGeometryCheck::Result::Success;
+}
+
+
 void QgsGeometryCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, QgsGeometryCheck::Changes &changes ) const
 {
   Q_UNUSED( featurePools )
@@ -174,4 +186,27 @@ double QgsGeometryCheck::scaleFactor( const QPointer<QgsVectorLayer> &layer ) co
     scaleFactor = ct.scaleFactor( lyr->extent() );
   }
   return scaleFactor;
+}
+
+QgsGeometryCheck::Result QgsGeometryCheck::checkUniqueId( const QgsGeometryCheckerUtils::LayerFeature layerFeature, QMap< QString, QSet<QVariant> > &uniqueIds ) const
+{
+  const int uniqueIdFieldIndex = mContext->uniqueIdFieldIndex;
+  if ( uniqueIdFieldIndex == -1 )
+  {
+    return QgsGeometryCheck::Result::Success;
+  }
+
+  if ( !uniqueIds.contains( layerFeature.layerId() ) )
+  {
+    uniqueIds.insert( layerFeature.layerId(), QSet<QVariant>() );
+  }
+
+  const QVariant uniqueIdValue = layerFeature.feature().attribute( uniqueIdFieldIndex );
+  if ( uniqueIds[layerFeature.layerId()].contains( uniqueIdValue ) )
+  {
+    return QgsGeometryCheck::Result::DuplicatedUniqueId;
+  }
+  uniqueIds[layerFeature.layerId()].insert( uniqueIdValue );
+
+  return QgsGeometryCheck::Result::Success;
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
@@ -196,17 +196,17 @@ QgsGeometryCheck::Result QgsGeometryCheck::checkUniqueId( const QgsGeometryCheck
     return QgsGeometryCheck::Result::Success;
   }
 
-  if ( !uniqueIds.contains( layerFeature.layerId() ) )
+  auto uniqueIdIt = uniqueIds.find( layerFeature.layerId() );
+  if ( uniqueIdIt == uniqueIds.end() )
   {
-    uniqueIds.insert( layerFeature.layerId(), QSet<QVariant>() );
+    uniqueIdIt = uniqueIds.insert( layerFeature.layerId(), QSet<QVariant>() );
   }
-
   const QVariant uniqueIdValue = layerFeature.feature().attribute( uniqueIdFieldIndex );
-  if ( uniqueIds[layerFeature.layerId()].contains( uniqueIdValue ) )
+  if ( uniqueIdIt.value().contains( uniqueIdValue ) )
   {
     return QgsGeometryCheck::Result::DuplicatedUniqueId;
   }
-  uniqueIds[layerFeature.layerId()].insert( uniqueIdValue );
+  uniqueIdIt.value().insert( uniqueIdValue );
 
   return QgsGeometryCheck::Result::Success;
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -157,6 +157,16 @@ class ANALYSIS_EXPORT QgsGeometryCheck
       LayerCheck        //!< The check controls a whole layer (topology checks)
     };
 
+    //! Result of the geometry checker operation \since QGIS 4.0
+    enum class Result : int
+    {
+      Success = 0,               //!< Operation completed successfully
+      Canceled = 1,              //!< User canceled calculation
+      DuplicatedUniqueId = 2,    //!< Found duplicated unique ID value
+      InvalidReferenceLayer = 3, //!< Missed or invalid reference layer
+      GeometryOverlayError = 4   //!< Error performing geometry overlay operation
+    };
+
     /**
      * Flags for geometry checks.
      */
@@ -269,14 +279,16 @@ class ANALYSIS_EXPORT QgsGeometryCheck
      * Check all features available from \a featurePools and write errors found to \a errors.
      * Other status messages can be written to \a messages.
      * Progress should be reported to \a feedback. Only features and layers listed in \a ids should be checked.
+     * \returns QgsGeometryCheck::Result::Success in case of success or error value on failure.
      *
      * \since QGIS 3.4
      */
-    virtual void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors SIP_INOUT, QStringList &messages SIP_INOUT, QgsFeedback *feedback, const LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const = 0;
+    virtual Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors SIP_INOUT, QStringList &messages SIP_INOUT, QgsFeedback *feedback, const LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const;
 
     /**
      * Fixes the error \a error with the specified \a method.
      * Is executed on the main thread.
+     *
      *
      * \see availableResolutionMethods()
      * \since QGIS 3.4
@@ -370,6 +382,14 @@ class ANALYSIS_EXPORT QgsGeometryCheck
      * \since QGIS 3.4
      */
     double scaleFactor( const QPointer<QgsVectorLayer> &layer ) const SIP_SKIP;
+
+    /**
+     * Checks that there are no duplicated unique IDs
+     * \returns QgsGeometryCheck::Result::Success in case if there are no duplicates or error value on failure.
+     *
+     * \since QGIS 4.0
+     */
+    Result checkUniqueId( const QgsGeometryCheckerUtils::LayerFeature layerFeature, QMap< QString, QSet<QVariant> > &uniqueIds ) const SIP_SKIP;
 };
 
 #endif // QGS_GEOMETRY_CHECK_H

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.cpp
@@ -16,11 +16,12 @@
 #include "qgsgeometrycheckcontext.h"
 #include <QThread>
 
-QgsGeometryCheckContext::QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *project )
+QgsGeometryCheckContext::QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *project, const int uniqueIdFieldIndex )
   : tolerance( std::pow( 10, -precision ) )
   , reducedTolerance( std::pow( 10, -precision / 2 ) )
   , mapCrs( mapCrs )
   , transformContext( transformContext )
+  , uniqueIdFieldIndex( uniqueIdFieldIndex )
   , mProject( project )
 {
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
@@ -34,7 +34,7 @@ class ANALYSIS_EXPORT QgsGeometryCheckContext
     /**
      * Creates a new QgsGeometryCheckContext.
      */
-    QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *mProject );
+    QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *mProject = nullptr, const int uniqueIdFieldIndex = -1 );
 
     /**
      * The tolerance to allow for in geometry checks.
@@ -60,6 +60,13 @@ class ANALYSIS_EXPORT QgsGeometryCheckContext
      * The coordinate transform context with which transformations will be done.
      */
     const QgsCoordinateTransformContext transformContext;
+
+    /**
+     * The index of the unique ID field used to identify features.
+     *
+     * \since QGIS 4.0
+     */
+    const int uniqueIdFieldIndex;
 
     /**
      * The project can be used to resolve additional layers.

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
@@ -33,6 +33,13 @@ class ANALYSIS_EXPORT QgsGeometryCheckContext
   public:
     /**
      * Creates a new QgsGeometryCheckContext.
+     * \param precision The precision used to define gemetry check tolerance. Tolerance is calculated as pow(10, -precision)
+     * \param mapCrs The coordinate system in which calculations should be done
+     * \param transformContext The coordinate transform context
+     * \param mProject The project used to resolve additional layers
+     * \param uniqueIdFieldIndex The index of the unique ID field used to identify features. If set to valid field index, geometry checker will fail if
+     * this field is not unique (since QGIS 4.0)
+     *
      */
     QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *mProject = nullptr, const int uniqueIdFieldIndex = -1 );
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometryengine.h"
 #include "qgsgeometrycontainedcheck.h"
@@ -27,6 +28,11 @@ QgsGeometryCheck::Result QgsGeometryContainedCheck::collectErrors( const QMap<QS
   const QgsGeometryCheckerUtils::LayerFeatures layerFeaturesA( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureA : layerFeaturesA )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeatureA, uniqueIds );
@@ -46,6 +52,11 @@ QgsGeometryCheck::Result QgsGeometryContainedCheck::collectErrors( const QMap<QS
     const QgsGeometryCheckerUtils::LayerFeatures layerFeaturesB( featurePools, featureIds.keys(), bboxA, compatibleGeometryTypes(), mContext );
     for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureB : layerFeaturesB )
     {
+      if ( feedback && feedback->isCanceled() )
+      {
+        return QgsGeometryCheck::Result::Canceled;
+      }
+
       if ( layerFeatureA == layerFeatureB )
       {
         continue;

--- a/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.h
@@ -46,7 +46,8 @@ class ANALYSIS_EXPORT QgsGeometryContainedCheckError : public QgsGeometryCheckEr
 
 /**
  * \ingroup analysis
- * \brief A contained check.
+ * \brief A contained check.  QMap<QString, QSet<QVariant>> uniqueIds;
+  const QString uniqueIdFieldName = context()->uniqueIdFieldName;
  */
 class ANALYSIS_EXPORT QgsGeometryContainedCheck : public QgsGeometryCheck
 {
@@ -61,7 +62,7 @@ class ANALYSIS_EXPORT QgsGeometryContainedCheck : public QgsGeometryCheck
     explicit QgsGeometryContainedCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration ) {}
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     QString id() const override { return factoryId(); }

--- a/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.cpp
@@ -19,13 +19,24 @@
 #include "qgsvectorlayer.h"
 #include "qgsgeometrycheckerror.h"
 
-void QgsGeometryDangleCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryDangleCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
+
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
+
     const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
@@ -92,6 +103,7 @@ void QgsGeometryDangleCheck::collectErrors( const QMap<QString, QgsFeaturePool *
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryDangleCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes & /*changes*/ ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometrydanglecheck.h"
 #include "qgslinestring.h"
@@ -28,6 +29,11 @@ QgsGeometryCheck::Result QgsGeometryDangleCheck::collectErrors( const QMap<QStri
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
@@ -64,6 +70,11 @@ QgsGeometryCheck::Result QgsGeometryDangleCheck::collectErrors( const QMap<QStri
       const QgsGeometryCheckerUtils::LayerFeatures checkFeatures( featurePools, QList<QString>() << layerFeature.layer()->id(), line->boundingBox(), { Qgis::GeometryType::Line }, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
+        if ( feedback && feedback->isCanceled() )
+        {
+          return QgsGeometryCheck::Result::Canceled;
+        }
+
         const QgsAbstractGeometry *testGeom = checkFeature.geometry().constGet();
         for ( int jPart = 0, mParts = testGeom->partCount(); jPart < mParts; ++jPart )
         {

--- a/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.h
@@ -34,7 +34,7 @@ class ANALYSIS_EXPORT QgsGeometryDangleCheck : public QgsGeometryCheck
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
 
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     QString description() const override { return factoryDescription(); }
     QString id() const override { return factoryId(); }

--- a/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.cpp
@@ -19,14 +19,24 @@
 #include "qgsgeometrycheckerror.h"
 
 
-void QgsGeometryDegeneratePolygonCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryDegeneratePolygonCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
 
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
+
     const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
@@ -40,6 +50,7 @@ void QgsGeometryDegeneratePolygonCheck::collectErrors( const QMap<QString, QgsFe
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryDegeneratePolygonCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes &changes ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometrydegeneratepolygoncheck.h"
 #include "qgsfeaturepool.h"
@@ -28,6 +29,11 @@ QgsGeometryCheck::Result QgsGeometryDegeneratePolygonCheck::collectErrors( const
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );

--- a/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.h
@@ -37,7 +37,7 @@ class ANALYSIS_EXPORT QgsGeometryDegeneratePolygonCheck : public QgsGeometryChec
     explicit QgsGeometryDegeneratePolygonCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration ) {}
 
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
 
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometryengine.h"
 #include "qgsgeometryduplicatecheck.h"
@@ -47,6 +48,11 @@ QgsGeometryCheck::Result QgsGeometryDuplicateCheck::collectErrors( const QMap<QS
   QList<QString> layerIds = featureIds.keys();
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureA : layerFeaturesA )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeatureA, uniqueIds );
@@ -73,6 +79,11 @@ QgsGeometryCheck::Result QgsGeometryDuplicateCheck::collectErrors( const QMap<QS
     const QgsGeometryCheckerUtils::LayerFeatures layerFeaturesB( featurePools, QList<QString>() << layerFeatureA.layer()->id() << layerIds, bboxA, { geomType }, mContext );
     for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureB : layerFeaturesB )
     {
+      if ( feedback && feedback->isCanceled() )
+      {
+        return QgsGeometryCheck::Result::Canceled;
+      }
+
       // only report overlaps within same layer once
       if ( layerFeatureA.layer()->id() == layerFeatureB.layer()->id() && layerFeatureB.feature().id() >= layerFeatureA.feature().id() )
       {

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.h
@@ -62,7 +62,7 @@ class ANALYSIS_EXPORT QgsGeometryDuplicateCheck : public QgsGeometryCheck
   public:
     explicit QgsGeometryDuplicateCheck( QgsGeometryCheckContext *context, const QVariantMap &configuration )
       : QgsGeometryCheck( context, configuration ) {}
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
 
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
@@ -19,16 +19,26 @@
 #include "qgsfeaturepool.h"
 #include "qgsgeometrycheckerror.h"
 
-void QgsGeometryDuplicateNodesCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryDuplicateNodesCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
 
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   const double sqrTolerance = mContext->tolerance * mContext->tolerance;
 
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
+
     const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
@@ -49,6 +59,7 @@ void QgsGeometryDuplicateNodesCheck::collectErrors( const QMap<QString, QgsFeatu
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryDuplicateNodesCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes &changes ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometryduplicatenodescheck.h"
 #include "qgsgeometryutils.h"
@@ -27,9 +28,13 @@ QgsGeometryCheck::Result QgsGeometryDuplicateNodesCheck::collectErrors( const QM
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   const double sqrTolerance = mContext->tolerance * mContext->tolerance;
-
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.h
@@ -33,7 +33,7 @@ class ANALYSIS_EXPORT QgsGeometryDuplicateNodesCheck : public QgsGeometryCheck
     static QList<Qgis::GeometryType> factoryCompatibleGeometryTypes() { return { Qgis::GeometryType::Line, Qgis::GeometryType::Polygon }; }
     static bool factoryIsCompatible( QgsVectorLayer *layer ) SIP_SKIP { return factoryCompatibleGeometryTypes().contains( layer->geometryType() ); }
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     static QString factoryDescription() { return tr( "Duplicate node" ); }

--- a/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometryfollowboundariescheck.h"
 #include "qgsgeometryengine.h"
@@ -51,6 +52,11 @@ QgsGeometryCheck::Result QgsGeometryFollowBoundariesCheck::collectErrors( const 
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
@@ -88,6 +94,11 @@ QgsGeometryCheck::Result QgsGeometryFollowBoundariesCheck::collectErrors( const 
       QgsFeature refFeature;
       while ( refFeatureIt.nextFeature( refFeature ) )
       {
+        if ( feedback && feedback->isCanceled() )
+        {
+          return QgsGeometryCheck::Result::Canceled;
+        }
+
         const QgsAbstractGeometry *refGeom = refFeature.geometry().constGet();
         std::unique_ptr<QgsGeometryEngine> refgeomEngine( QgsGeometry::createGeometryEngine( refGeom, mContext->tolerance ) );
         const QgsGeometry reducedRefGeom( refgeomEngine->buffer( -mContext->tolerance, 0 ) );

--- a/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.h
@@ -36,7 +36,7 @@ class ANALYSIS_EXPORT QgsGeometryFollowBoundariesCheck : public QgsGeometryCheck
     static QList<Qgis::GeometryType> factoryCompatibleGeometryTypes() { return { Qgis::GeometryType::Polygon }; }
     static bool factoryIsCompatible( QgsVectorLayer *layer ) SIP_SKIP { return factoryCompatibleGeometryTypes().contains( layer->geometryType() ); }
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     static QString factoryDescription() { return tr( "Polygon does not follow boundaries" ); }

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometryengine.h"
 #include "qgsgeometrygapcheck.h"
@@ -70,6 +71,11 @@ QgsGeometryCheck::Result QgsGeometryGapCheck::collectErrors( const QMap<QString,
 
     while ( iterator.nextFeature( feature ) )
     {
+      if ( feedback && feedback->isCanceled() )
+      {
+        return QgsGeometryCheck::Result::Canceled;
+      }
+
       const QgsGeometry geom = feature.geometry();
       const QgsGeometry gg = geom.buffer( mAllowedGapsBuffer, 20 );
       allowedGaps.append( gg );
@@ -90,6 +96,11 @@ QgsGeometryCheck::Result QgsGeometryGapCheck::collectErrors( const QMap<QString,
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), nullptr, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
@@ -100,11 +111,6 @@ QgsGeometryCheck::Result QgsGeometryGapCheck::collectErrors( const QMap<QString,
     }
 
     geomList.append( layerFeature.geometry() );
-
-    if ( feedback && feedback->isCanceled() )
-    {
-      return QgsGeometryCheck::Result::Canceled;
-    }
   }
 
   std::unique_ptr<QgsGeometryEngine> geomEngine( QgsGeometry::createGeometryEngine( nullptr, mContext->tolerance ) );
@@ -148,6 +154,11 @@ QgsGeometryCheck::Result QgsGeometryGapCheck::collectErrors( const QMap<QString,
   QgsGeometryPartIterator parts = diffGeom->parts();
   while ( parts.hasNext() )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     const QgsAbstractGeometry *gapGeom = parts.next();
     // Skip the gap between features and boundingbox
     const double spacing = context()->tolerance;
@@ -171,6 +182,11 @@ QgsGeometryCheck::Result QgsGeometryGapCheck::collectErrors( const QMap<QString,
     gapGeomEngine->prepareGeometry();
     for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
     {
+      if ( feedback && feedback->isCanceled() )
+      {
+        return QgsGeometryCheck::Result::Canceled;
+      }
+
       const QgsGeometry geom = layerFeature.geometry();
       if ( gapGeomEngine->distance( geom.constGet() ) < mContext->tolerance )
       {

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -276,8 +276,7 @@ void QgsGeometryGapCheck::fixError( const QMap<QString, QgsFeaturePool *> &featu
       case CreateNewFeature:
       {
         QgsGeometryGapCheckError *gapCheckError = static_cast<QgsGeometryGapCheckError *>( error );
-        QgsProject *project = QgsProject::instance();
-        QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( project->mapLayer( gapCheckError->neighbors().keys().first() ) );
+        QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( context()->project()->mapLayer( gapCheckError->neighbors().keys().first() ) );
         if ( layer )
         {
           const QgsGeometry geometry = error->geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
@@ -107,7 +107,7 @@ class ANALYSIS_EXPORT QgsGeometryGapCheck : public QgsGeometryCheck
     void prepare( const QgsGeometryCheckContext *context, const QVariantMap &configuration ) override;
 
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
 

--- a/src/analysis/vector/geometry_checker/qgsgeometryholecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryholecheck.cpp
@@ -20,14 +20,24 @@
 #include "qgsfeaturepool.h"
 #include "qgsgeometrycheckerror.h"
 
-void QgsGeometryHoleCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryHoleCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
 
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
+
     const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
@@ -44,6 +54,7 @@ void QgsGeometryHoleCheck::collectErrors( const QMap<QString, QgsFeaturePool *> 
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryHoleCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes &changes ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometryholecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryholecheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometryholecheck.h"
 #include "qgscurve.h"
@@ -29,6 +30,11 @@ QgsGeometryCheck::Result QgsGeometryHoleCheck::collectErrors( const QMap<QString
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );

--- a/src/analysis/vector/geometry_checker/qgsgeometryholecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryholecheck.h
@@ -33,7 +33,7 @@ class ANALYSIS_EXPORT QgsGeometryHoleCheck : public QgsGeometryCheck
     static QList<Qgis::GeometryType> factoryCompatibleGeometryTypes() { return { Qgis::GeometryType::Polygon }; }
     static bool factoryIsCompatible( QgsVectorLayer *layer ) SIP_SKIP { return factoryCompatibleGeometryTypes().contains( layer->geometryType() ); }
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     static QString factoryDescription() { return tr( "Polygon with hole" ); }

--- a/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometrylineintersectioncheck.h"
 #include "qgslinestring.h"
@@ -29,6 +30,11 @@ QgsGeometryCheck::Result QgsGeometryLineIntersectionCheck::collectErrors( const 
   QList<QString> layerIds = featureIds.keys();
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureA : layerFeaturesA )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeatureA, uniqueIds );
@@ -55,7 +61,12 @@ QgsGeometryCheck::Result QgsGeometryLineIntersectionCheck::collectErrors( const 
       const QgsGeometryCheckerUtils::LayerFeatures layerFeaturesB( featurePools, QList<QString>() << layerFeatureA.layer()->id() << layerIds, line->boundingBox(), { Qgis::GeometryType::Line }, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureB : layerFeaturesB )
       {
-        // > : only report intersections within same layer once
+        if ( feedback && feedback->isCanceled() )
+        {
+          return QgsGeometryCheck::Result::Canceled;
+        }
+
+        // only report intersections within same layer once
         if ( layerFeatureA.layer()->id() == layerFeatureB.layer()->id() && layerFeatureB.feature().id() > layerFeatureA.feature().id() )
         {
           continue;

--- a/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.cpp
@@ -19,15 +19,25 @@
 #include "qgsvectorlayer.h"
 #include "qgsgeometrycheckerror.h"
 
-void QgsGeometryLineIntersectionCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryLineIntersectionCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
 
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeaturesA( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext, true );
   QList<QString> layerIds = featureIds.keys();
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureA : layerFeaturesA )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeatureA, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
+
     // Ensure each pair of layers only gets compared once: remove the current layer from the layerIds, but add it to the layerList for layerFeaturesB
     layerIds.removeOne( layerFeatureA.layer()->id() );
 
@@ -73,6 +83,7 @@ void QgsGeometryLineIntersectionCheck::collectErrors( const QMap<QString, QgsFea
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryLineIntersectionCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes & /*changes*/ ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.h
@@ -34,7 +34,7 @@ class ANALYSIS_EXPORT QgsGeometryLineIntersectionCheck : public QgsGeometryCheck
     static QList<Qgis::GeometryType> factoryCompatibleGeometryTypes() { return { Qgis::GeometryType::Line }; }
     static bool factoryIsCompatible( QgsVectorLayer *layer ) SIP_SKIP { return factoryCompatibleGeometryTypes().contains( layer->geometryType() ); }
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     static QString factoryDescription() { return tr( "Intersection" ); }

--- a/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometrylinelayerintersectioncheck.h"
 #include "qgspolygon.h"
@@ -30,6 +31,11 @@ QgsGeometryCheck::Result QgsGeometryLineLayerIntersectionCheck::collectErrors( c
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
@@ -52,6 +58,11 @@ QgsGeometryCheck::Result QgsGeometryLineLayerIntersectionCheck::collectErrors( c
       const QgsGeometryCheckerUtils::LayerFeatures checkFeatures( featurePools, QStringList() << mCheckLayer, line->boundingBox(), { Qgis::GeometryType::Line, Qgis::GeometryType::Polygon }, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
+        if ( feedback && feedback->isCanceled() )
+        {
+          return QgsGeometryCheck::Result::Canceled;
+        }
+
         const QgsAbstractGeometry *testGeom = checkFeature.geometry().constGet();
         for ( int jPart = 0, mParts = testGeom->partCount(); jPart < mParts; ++jPart )
         {

--- a/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.cpp
@@ -20,15 +20,24 @@
 #include "qgsfeaturepool.h"
 #include "qgsgeometrycheckerror.h"
 
-void QgsGeometryLineLayerIntersectionCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryLineLayerIntersectionCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
 
+  QMap<QString, QSet<QVariant>> uniqueIds;
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   featureIds.remove( mCheckLayer ); // Don't check layer against itself
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
     const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
@@ -71,6 +80,7 @@ void QgsGeometryLineLayerIntersectionCheck::collectErrors( const QMap<QString, Q
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryLineLayerIntersectionCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes & /*changes*/ ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.h
@@ -35,7 +35,7 @@ class ANALYSIS_EXPORT QgsGeometryLineLayerIntersectionCheck : public QgsGeometry
     static QList<Qgis::GeometryType> factoryCompatibleGeometryTypes() { return { Qgis::GeometryType::Line }; }
     static bool factoryIsCompatible( QgsVectorLayer *layer ) SIP_SKIP { return factoryCompatibleGeometryTypes().contains( layer->geometryType() ); }
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     static QString factoryDescription() { return tr( "Intersection" ); }

--- a/src/analysis/vector/geometry_checker/qgsgeometrymissingvertexcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrymissingvertexcheck.cpp
@@ -30,23 +30,30 @@ QgsGeometryMissingVertexCheck::QgsGeometryMissingVertexCheck( const QgsGeometryC
 
 {}
 
-void QgsGeometryMissingVertexCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryMissingVertexCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
   if ( feedback )
     feedback->setProgress( feedback->progress() + 1.0 );
 
+  QMap<QString, QSet<QVariant>> uniqueIds;
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
-
   QgsFeaturePool *featurePool = featurePools.value( featureIds.firstKey() );
-
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), nullptr, mContext, true );
-
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     if ( feedback && feedback->isCanceled() )
     {
-      break;
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
     }
 
     const QgsGeometry geometry = layerFeature.geometry();
@@ -68,6 +75,7 @@ void QgsGeometryMissingVertexCheck::collectErrors( const QMap<QString, QgsFeatur
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryMissingVertexCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes &changes ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometrymissingvertexcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrymissingvertexcheck.h
@@ -98,7 +98,7 @@ class ANALYSIS_EXPORT QgsGeometryMissingVertexCheck : public QgsGeometryCheck
      * Creates a new missing vertex geometry check with \a context and the provided \a geometryCheckConfiguration.
      */
     explicit QgsGeometryMissingVertexCheck( const QgsGeometryCheckContext *context, const QVariantMap &geometryCheckConfiguration );
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
 

--- a/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.cpp
@@ -28,15 +28,26 @@ QgsGeometryOverlapCheck::QgsGeometryOverlapCheck( const QgsGeometryCheckContext 
 {
 }
 
-void QgsGeometryOverlapCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryOverlapCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeaturesA( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext, true );
   QList<QString> layerIds = featureIds.keys();
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureA : layerFeaturesA )
   {
     if ( feedback && feedback->isCanceled() )
-      break;
+      return QgsGeometryCheck::Result::Canceled;
+
+
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeatureA, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
 
     // Ensure each pair of layers only gets compared once: remove the current layer from the layerIds, but add it to the layerList for layerFeaturesB
     layerIds.removeOne( layerFeatureA.layer()->id() );
@@ -55,9 +66,9 @@ void QgsGeometryOverlapCheck::collectErrors( const QMap<QString, QgsFeaturePool 
     for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureB : layerFeaturesB )
     {
       if ( feedback && feedback->isCanceled() )
-        break;
+        return QgsGeometryCheck::Result::Canceled;
 
-      // > : only report overlaps within same layer once
+      // only report overlaps within same layer once
       if ( layerFeatureA.layerId() == layerFeatureB.layerId() && layerFeatureB.feature().id() >= layerFeatureA.feature().id() )
       {
         continue;
@@ -89,6 +100,7 @@ void QgsGeometryOverlapCheck::collectErrors( const QMap<QString, QgsFeaturePool 
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryOverlapCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes &changes ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.h
@@ -107,7 +107,7 @@ class ANALYSIS_EXPORT QgsGeometryOverlapCheck : public QgsGeometryCheck
      */
     QgsGeometryOverlapCheck( const QgsGeometryCheckContext *context, const QVariantMap &configuration );
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometrypointcoveredbylinecheck.h"
 #include "qgslinestring.h"
@@ -28,6 +29,11 @@ QgsGeometryCheck::Result QgsGeometryPointCoveredByLineCheck::collectErrors( cons
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
@@ -51,6 +57,11 @@ QgsGeometryCheck::Result QgsGeometryPointCoveredByLineCheck::collectErrors( cons
       const QgsGeometryCheckerUtils::LayerFeatures checkFeatures( featurePools, featureIds.keys(), rect, { Qgis::GeometryType::Line }, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
+        if ( feedback && feedback->isCanceled() )
+        {
+          return QgsGeometryCheck::Result::Canceled;
+        }
+
         const QgsAbstractGeometry *testGeom = checkFeature.geometry().constGet();
         for ( int jPart = 0, mParts = testGeom->partCount(); jPart < mParts; ++jPart )
         {

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.cpp
@@ -19,14 +19,23 @@
 #include "qgsfeaturepool.h"
 #include "qgsgeometrycheckerror.h"
 
-void QgsGeometryPointCoveredByLineCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometryPointCoveredByLineCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
 
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
     const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
@@ -68,6 +77,7 @@ void QgsGeometryPointCoveredByLineCheck::collectErrors( const QMap<QString, QgsF
       errors.append( new QgsGeometryCheckError( this, layerFeature, *point, QgsVertexId( iPart, 0, 0 ) ) );
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometryPointCoveredByLineCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes & /*changes*/ ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.h
@@ -34,7 +34,7 @@ class ANALYSIS_EXPORT QgsGeometryPointCoveredByLineCheck : public QgsGeometryChe
     static QList<Qgis::GeometryType> factoryCompatibleGeometryTypes() { return { Qgis::GeometryType::Point }; }
     static bool factoryIsCompatible( QgsVectorLayer *layer ) SIP_SKIP { return factoryCompatibleGeometryTypes().contains( layer->geometryType() ); }
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     static QString factoryDescription() { return tr( "Point not covered by line" ); }

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointinpolygoncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointinpolygoncheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometrypointinpolygoncheck.h"
 #include "qgsgeometryengine.h"
@@ -25,6 +26,11 @@ QgsGeometryCheck::Result QgsGeometryPointInPolygonCheck::collectErrors( const QM
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
@@ -50,6 +56,11 @@ QgsGeometryCheck::Result QgsGeometryPointInPolygonCheck::collectErrors( const QM
       const QgsGeometryCheckerUtils::LayerFeatures checkFeatures( featurePools, featureIds.keys(), rect, { Qgis::GeometryType::Polygon }, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
+        if ( feedback && feedback->isCanceled() )
+        {
+          return QgsGeometryCheck::Result::Canceled;
+        }
+
         ++nTested;
         const QgsAbstractGeometry *testGeom = checkFeature.geometry().constGet();
         std::unique_ptr<QgsGeometryEngine> testGeomEngine( QgsGeometry::createGeometryEngine( testGeom, mContext->reducedTolerance ) );

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointinpolygoncheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointinpolygoncheck.h
@@ -34,7 +34,7 @@ class ANALYSIS_EXPORT QgsGeometryPointInPolygonCheck : public QgsGeometryCheck
     static QList<Qgis::GeometryType> factoryCompatibleGeometryTypes() { return { Qgis::GeometryType::Point }; }
     static bool factoryIsCompatible( QgsVectorLayer *layer ) SIP_SKIP { return factoryCompatibleGeometryTypes().contains( layer->geometryType() ); }
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     static QString factoryDescription() { return tr( "Point not in polygon" ); }

--- a/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
@@ -19,14 +19,24 @@
 #include "qgsfeaturepool.h"
 #include "qgsgeometrycheckerror.h"
 
-void QgsGeometrySegmentLengthCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsGeometrySegmentLengthCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
 
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
+
     const double layerToMapUnits = scaleFactor( layerFeature.layer() );
     const double minLength = mMinLengthMapUnits / layerToMapUnits;
 
@@ -56,6 +66,7 @@ void QgsGeometrySegmentLengthCheck::collectErrors( const QMap<QString, QgsFeatur
       }
     }
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 void QgsGeometrySegmentLengthCheck::fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes & /*changes*/ ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgsgeometrysegmentlengthcheck.h"
 #include "qgsgeometryutils.h"
@@ -28,6 +29,11 @@ QgsGeometryCheck::Result QgsGeometrySegmentLengthCheck::collectErrors( const QMa
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );

--- a/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.h
@@ -35,7 +35,7 @@ class ANALYSIS_EXPORT QgsGeometrySegmentLengthCheck : public QgsGeometryCheck
     static QList<Qgis::GeometryType> factoryCompatibleGeometryTypes() { return { Qgis::GeometryType::Line, Qgis::GeometryType::Polygon }; }
     static bool factoryIsCompatible( QgsVectorLayer *layer ) SIP_SKIP { return factoryCompatibleGeometryTypes().contains( layer->geometryType() ); }
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     Q_DECL_DEPRECATED QStringList resolutionMethods() const override;
     static QString factoryDescription() { return tr( "Minimal segment length" ); }

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
@@ -13,6 +13,7 @@ email                : matthias@opengis.ch
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsfeedback.h"
 #include "qgssinglegeometrycheck.h"
 #include "qgsgeometrycheckcontext.h"
 #include "qgspoint.h"
@@ -26,6 +27,11 @@ QgsGeometryCheck::Result QgsSingleGeometryCheck::collectErrors( const QMap<QStri
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( feedback && feedback->isCanceled() )
+    {
+      return QgsGeometryCheck::Result::Canceled;
+    }
+
     if ( context()->uniqueIdFieldIndex != -1 )
     {
       QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
@@ -18,17 +18,28 @@ email                : matthias@opengis.ch
 #include "qgspoint.h"
 
 
-void QgsSingleGeometryCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
+QgsGeometryCheck::Result QgsSingleGeometryCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids ) const
 {
   Q_UNUSED( messages )
+  QMap<QString, QSet<QVariant>> uniqueIds;
   const QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds( featurePools ) : ids.toMap();
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( featurePools, featureIds, compatibleGeometryTypes(), feedback, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
+    if ( context()->uniqueIdFieldIndex != -1 )
+    {
+      QgsGeometryCheck::Result result = checkUniqueId( layerFeature, uniqueIds );
+      if ( result != QgsGeometryCheck::Result::Success )
+      {
+        return result;
+      }
+    }
+
     const auto singleErrors = processGeometry( layerFeature.geometry() );
     for ( const auto error : singleErrors )
       errors.append( convertToGeometryCheckError( error, layerFeature ) );
   }
+  return QgsGeometryCheck::Result::Success;
 }
 
 QgsGeometryCheckErrorSingle *QgsSingleGeometryCheck::convertToGeometryCheckError( QgsSingleGeometryCheckError *singleGeometryCheckError, const QgsGeometryCheckerUtils::LayerFeature &layerFeature ) const

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.h
@@ -155,7 +155,7 @@ class ANALYSIS_EXPORT QgsSingleGeometryCheck : public QgsGeometryCheck
       : QgsGeometryCheck( context, configuration )
     {}
 
-    void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback = nullptr, const QgsGeometryCheck::LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const FINAL;
+    QgsGeometryCheck::Result collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback = nullptr, const QgsGeometryCheck::LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const FINAL;
 
     /**
      * Check the \a geometry for errors. It may make use of \a configuration options.

--- a/tests/src/analysis/testqgsprocessingcheckgeometry.cpp
+++ b/tests/src/analysis/testqgsprocessingcheckgeometry.cpp
@@ -669,6 +669,7 @@ void TestQgsProcessingCheckGeometry::gapAlg()
     bool ok = false;
     QgsProcessingFeedback feedback;
     auto context = std::make_unique< QgsProcessingContext >();
+    context->setProject( QgsProject::instance() );
 
     QVariantMap results;
     results = alg->run( parameters, *context, &feedback, &ok );
@@ -709,6 +710,7 @@ void TestQgsProcessingCheckGeometry::gapAlg()
     bool ok = false;
     QgsProcessingFeedback feedback;
     auto context = std::make_unique< QgsProcessingContext >();
+    context->setProject( QgsProject::instance() );
 
     QVariantMap results;
     results = alg->run( parameters, *context, &feedback, &ok );

--- a/tests/src/analysis/testqgsprocessingfixgeometry.cpp
+++ b/tests/src/analysis/testqgsprocessingfixgeometry.cpp
@@ -507,6 +507,10 @@ void TestQgsProcessingFixGeometry::fixGapAlg()
   QVERIFY( gapsLayer.isValid() );
   QVERIFY( neighborsLayer.isValid() );
 
+  QgsProject::instance()->addMapLayer( &sourceLayer );
+  QgsProject::instance()->addMapLayer( &gapsLayer );
+  QgsProject::instance()->addMapLayer( &neighborsLayer );
+
   QFETCH( QStringList, reportList );
   QFETCH( int, method );
   QFETCH( int, featureCount );
@@ -528,6 +532,7 @@ void TestQgsProcessingFixGeometry::fixGapAlg()
   bool ok = false;
   QgsProcessingFeedback feedback;
   auto context = std::make_unique<QgsProcessingContext>();
+  context->setProject( QgsProject::instance() );
 
   QVariantMap results;
   results = alg->run( parameters, *context, &feedback, &ok );


### PR DESCRIPTION
## Description

Various fixes for Processing check/fix geometry algorithms:

- raise an exception in geometry checker algorithms if selected unique ID field contains duplicated values to prevent failures at the geometry repair step (fixes #61398)
- avoid use of `QgsProject::instance()` in algorithms
- correctly mark algorithms which require project with the corresponding flag
- added cancellation support in geometry checks
