### PR TITLE
fix handling of tiled scene and vector tile layers in Processing

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -6463,6 +6463,9 @@ QgsProcessing.TypeVectorTile = Qgis.ProcessingSourceType.VectorTile
 QgsProcessing.SourceType.TypeVectorTile = Qgis.ProcessingSourceType.VectorTile
 QgsProcessing.TypeVectorTile.is_monkey_patched = True
 QgsProcessing.TypeVectorTile.__doc__ = "Vector tile layers \n.. versionadded:: 3.32"
+QgsProcessing.TiledScene = Qgis.ProcessingSourceType.TiledScene
+QgsProcessing.TiledScene.is_monkey_patched = True
+QgsProcessing.TiledScene.__doc__ = "Tiled scene layers \n.. versionadded:: 3.46"
 Qgis.ProcessingSourceType.__doc__ = """Processing data source types.
 
 .. note::
@@ -6537,6 +6540,10 @@ Qgis.ProcessingSourceType.__doc__ = """Processing data source types.
 
 
   Available as ``QgsProcessing.TypeVectorTile`` in older QGIS releases.
+
+* ``TiledScene``: Tiled scene layers
+
+  .. versionadded:: 3.46
 
 
 """

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -6465,7 +6465,7 @@ QgsProcessing.TypeVectorTile.is_monkey_patched = True
 QgsProcessing.TypeVectorTile.__doc__ = "Vector tile layers \n.. versionadded:: 3.32"
 QgsProcessing.TiledScene = Qgis.ProcessingSourceType.TiledScene
 QgsProcessing.TiledScene.is_monkey_patched = True
-QgsProcessing.TiledScene.__doc__ = "Tiled scene layers \n.. versionadded:: 3.46"
+QgsProcessing.TiledScene.__doc__ = "Tiled scene layers \n.. versionadded:: 4.0"
 Qgis.ProcessingSourceType.__doc__ = """Processing data source types.
 
 .. note::
@@ -6543,7 +6543,7 @@ Qgis.ProcessingSourceType.__doc__ = """Processing data source types.
 
 * ``TiledScene``: Tiled scene layers
 
-  .. versionadded:: 3.46
+  .. versionadded:: 4.0
 
 
 """

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2022,7 +2022,8 @@ The development version
       Plugin,
       PointCloud,
       Annotation,
-      VectorTile
+      VectorTile,
+      TiledScene
     };
 
 

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -6402,6 +6402,9 @@ QgsProcessing.TypeVectorTile = Qgis.ProcessingSourceType.VectorTile
 QgsProcessing.SourceType.TypeVectorTile = Qgis.ProcessingSourceType.VectorTile
 QgsProcessing.TypeVectorTile.is_monkey_patched = True
 QgsProcessing.TypeVectorTile.__doc__ = "Vector tile layers \n.. versionadded:: 3.32"
+QgsProcessing.TiledScene = Qgis.ProcessingSourceType.TiledScene
+QgsProcessing.TiledScene.is_monkey_patched = True
+QgsProcessing.TiledScene.__doc__ = "Tiled scene layers \n.. versionadded:: 3.46"
 Qgis.ProcessingSourceType.__doc__ = """Processing data source types.
 
 .. note::
@@ -6476,6 +6479,10 @@ Qgis.ProcessingSourceType.__doc__ = """Processing data source types.
 
 
   Available as ``QgsProcessing.TypeVectorTile`` in older QGIS releases.
+
+* ``TiledScene``: Tiled scene layers
+
+  .. versionadded:: 3.46
 
 
 """

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -6404,7 +6404,7 @@ QgsProcessing.TypeVectorTile.is_monkey_patched = True
 QgsProcessing.TypeVectorTile.__doc__ = "Vector tile layers \n.. versionadded:: 3.32"
 QgsProcessing.TiledScene = Qgis.ProcessingSourceType.TiledScene
 QgsProcessing.TiledScene.is_monkey_patched = True
-QgsProcessing.TiledScene.__doc__ = "Tiled scene layers \n.. versionadded:: 3.46"
+QgsProcessing.TiledScene.__doc__ = "Tiled scene layers \n.. versionadded:: 4.0"
 Qgis.ProcessingSourceType.__doc__ = """Processing data source types.
 
 .. note::
@@ -6482,7 +6482,7 @@ Qgis.ProcessingSourceType.__doc__ = """Processing data source types.
 
 * ``TiledScene``: Tiled scene layers
 
-  .. versionadded:: 3.46
+  .. versionadded:: 4.0
 
 
 """

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2022,7 +2022,8 @@ The development version
       Plugin,
       PointCloud,
       Annotation,
-      VectorTile
+      VectorTile,
+      TiledScene
     };
 
 

--- a/src/core/processing/qgsprocessing.h
+++ b/src/core/processing/qgsprocessing.h
@@ -98,6 +98,8 @@ class CORE_EXPORT QgsProcessing
           return QStringLiteral( "TypeAnnotation" );
         case Qgis::ProcessingSourceType::VectorTile:
           return QStringLiteral( "TypeVectorTile" );
+        case Qgis::ProcessingSourceType::TiledScene:
+          return QStringLiteral( "TiledScene" );
       }
       return QString();
     }

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -3378,6 +3378,14 @@ QString QgsProcessingParameterMapLayer::asScriptCode() const
         code += QLatin1String( "annotation " );
         break;
 
+      case Qgis::ProcessingSourceType::VectorTile:
+        code += QLatin1String( "vectortile " );
+        break;
+
+      case Qgis::ProcessingSourceType::TiledScene:
+        code += QLatin1String( "tiledscene " );
+        break;
+
       default:
         break;
     }
@@ -3450,6 +3458,18 @@ QgsProcessingParameterMapLayer *QgsProcessingParameterMapLayer::fromScriptCode( 
     else if ( def.startsWith( QLatin1String( "annotation" ), Qt::CaseInsensitive ) )
     {
       types << static_cast< int >( Qgis::ProcessingSourceType::Annotation );
+      def = def.mid( 11 );
+      continue;
+    }
+    else if ( def.startsWith( QLatin1String( "vectortile" ), Qt::CaseInsensitive ) )
+    {
+      types << static_cast< int >( Qgis::ProcessingSourceType::VectorTile );
+      def = def.mid( 11 );
+      continue;
+    }
+    else if ( def.startsWith( QLatin1String( "tiledscene" ), Qt::CaseInsensitive ) )
+    {
+      types << static_cast< int >( Qgis::ProcessingSourceType::TiledScene );
       def = def.mid( 11 );
       continue;
     }
@@ -4591,6 +4611,7 @@ QString QgsProcessingParameterMultipleLayers::createFileFilter() const
     case Qgis::ProcessingSourceType::Plugin:
     case Qgis::ProcessingSourceType::Annotation:
     case Qgis::ProcessingSourceType::VectorTile:
+    case Qgis::ProcessingSourceType::TiledScene:
       return createAllMapLayerFileFilter();
   }
   return QString();
@@ -6792,6 +6813,7 @@ bool QgsProcessingParameterFeatureSink::hasGeometry() const
     case Qgis::ProcessingSourceType::Plugin:
     case Qgis::ProcessingSourceType::PointCloud:
     case Qgis::ProcessingSourceType::Annotation:
+    case Qgis::ProcessingSourceType::TiledScene:
       return false;
   }
   return true;
@@ -7514,6 +7536,7 @@ bool QgsProcessingParameterVectorDestination::hasGeometry() const
     case Qgis::ProcessingSourceType::Plugin:
     case Qgis::ProcessingSourceType::PointCloud:
     case Qgis::ProcessingSourceType::Annotation:
+    case Qgis::ProcessingSourceType::TiledScene:
       return false;
   }
   return true;

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3504,7 +3504,8 @@ class CORE_EXPORT Qgis
       Plugin SIP_MONKEYPATCH_COMPAT_NAME( TypePlugin ) = 7, //!< Plugin layers \since QGIS 3.22
       PointCloud SIP_MONKEYPATCH_COMPAT_NAME( TypePointCloud ) = 8, //!< Point cloud layers \since QGIS 3.22
       Annotation SIP_MONKEYPATCH_COMPAT_NAME( TypeAnnotation ) = 9, //!< Annotation layers \since QGIS 3.22
-      VectorTile SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorTile ) = 10 //!< Vector tile layers \since QGIS 3.32
+      VectorTile SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorTile ) = 10, //!< Vector tile layers \since QGIS 3.32
+      TiledScene = 11 //!< Tiled scene layers \since QGIS 3.46
     };
     Q_ENUM( ProcessingSourceType )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -3505,7 +3505,7 @@ class CORE_EXPORT Qgis
       PointCloud SIP_MONKEYPATCH_COMPAT_NAME( TypePointCloud ) = 8, //!< Point cloud layers \since QGIS 3.22
       Annotation SIP_MONKEYPATCH_COMPAT_NAME( TypeAnnotation ) = 9, //!< Annotation layers \since QGIS 3.22
       VectorTile SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorTile ) = 10, //!< Vector tile layers \since QGIS 3.32
-      TiledScene = 11 //!< Tiled scene layers \since QGIS 3.46
+      TiledScene = 11 //!< Tiled scene layers \since QGIS 4.0
     };
     Q_ENUM( ProcessingSourceType )
 

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -200,6 +200,12 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
       filters |= Qgis::LayerFilter::MeshLayer;
     if ( dataTypes.contains( static_cast<int>( Qgis::ProcessingSourceType::PointCloud ) ) )
       filters |= Qgis::LayerFilter::PointCloudLayer;
+    if ( dataTypes.contains( static_cast<int>( Qgis::ProcessingSourceType::Annotation ) ) )
+      filters |= Qgis::LayerFilter::AnnotationLayer;
+    if ( dataTypes.contains( static_cast<int>( Qgis::ProcessingSourceType::VectorTile ) ) )
+      filters |= Qgis::LayerFilter::VectorTileLayer;
+    if ( dataTypes.contains( static_cast<int>( Qgis::ProcessingSourceType::TiledScene ) ) )
+      filters |= Qgis::LayerFilter::TiledSceneLayer;
     if ( !filters )
       filters = Qgis::LayerFilter::All;
   }

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -26,6 +26,7 @@
 #include "qgspointcloudlayer.h"
 #include "qgsannotationlayer.h"
 #include "qgsvectortilelayer.h"
+#include "qgstiledscenelayer.h"
 #include "qgsproject.h"
 #include "processing/models/qgsprocessingmodelchildparametersource.h"
 #include <QStandardItemModel>
@@ -712,6 +713,17 @@ void QgsProcessingMultipleInputPanelWidget::populateFromProject( QgsProject *pro
     {
       const QList<QgsVectorTileLayer *> options = QgsProcessingUtils::compatibleVectorTileLayers( project, false );
       for ( const QgsVectorTileLayer *layer : options )
+      {
+        addLayer( layer );
+      }
+
+      break;
+    }
+
+    case Qgis::ProcessingSourceType::TiledScene:
+    {
+      const QList<QgsTiledSceneLayer *> options = QgsProcessingUtils::compatibleTiledSceneLayers( project, false );
+      for ( const QgsTiledSceneLayer *layer : options )
       {
         addLayer( layer );
       }

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -7235,6 +7235,12 @@ void QgsProcessingMultipleLayerPanelWidget::setModel( QgsProcessingModelAlgorith
       break;
     }
 
+    case Qgis::ProcessingSourceType::TiledScene:
+    {
+      mModelSources = model->availableSourcesForChild( modelChildAlgorithmID, QStringList() << QgsProcessingParameterMapLayer::typeName() << QgsProcessingParameterMultipleLayers::typeName(), QStringList() << QgsProcessingOutputMapLayer::typeName() << QgsProcessingOutputMultipleLayers::typeName() );
+      break;
+    }
+
     case Qgis::ProcessingSourceType::Vector:
     {
       mModelSources = model->availableSourcesForChild( modelChildAlgorithmID, QStringList() << QgsProcessingParameterFeatureSource::typeName() << QgsProcessingParameterVectorLayer::typeName() << QgsProcessingParameterFile::typeName() << QgsProcessingParameterMultipleLayers::typeName(), QStringList() << QgsProcessingOutputFile::typeName() << QgsProcessingOutputVectorLayer::typeName() << QgsProcessingOutputMapLayer::typeName() << QgsProcessingOutputMultipleLayers::typeName(), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::Vector ) );

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -102,6 +102,7 @@
 #include "qgspluginlayer.h"
 #include "qgspointcloudlayer.h"
 #include "qgsannotationlayer.h"
+#include "qgstiledscenelayer.h"
 #include "qgsprocessingparameteralignrasterlayers.h"
 #include "qgsprocessingalignrasterlayerswidgetwrapper.h"
 #include "qgsprocessingrasteroptionswidgetwrapper.h"
@@ -6692,6 +6693,9 @@ void TestProcessingGui::mapLayerComboBox()
   QgsPointCloudLayer *pointCloud = new QgsPointCloudLayer( QStringLiteral( TEST_DATA_DIR ) + "/point_clouds/ept/sunshine-coast/ept.json", QStringLiteral( "Point cloud" ), QStringLiteral( "ept" ) );
   QVERIFY( pointCloud->isValid() );
   QgsProject::instance()->addMapLayer( pointCloud );
+  QgsTiledSceneLayer *tiledScene = new QgsTiledSceneLayer( "tiled_scene_source", QStringLiteral( "tiled scene" ), QStringLiteral( "test_tiled_scene_provider" ) );
+  QVERIFY( tiledScene->isValid() );
+  QgsProject::instance()->addMapLayer( tiledScene );
 
   // map layer param, all types are acceptable
   param = std::make_unique<QgsProcessingParameterMapLayer>( QStringLiteral( "param" ), QString() );
@@ -6710,6 +6714,8 @@ void TestProcessingGui::mapLayerComboBox()
   QCOMPARE( combo->currentLayer(), raster );
   combo->setLayer( pointCloud );
   QCOMPARE( combo->currentLayer(), pointCloud );
+  combo->setLayer( tiledScene );
+  QCOMPARE( combo->currentLayer(), tiledScene );
   combo.reset();
   param.reset();
 
@@ -6730,6 +6736,30 @@ void TestProcessingGui::mapLayerComboBox()
   QCOMPARE( combo->currentLayer(), raster );
   combo->setLayer( pointCloud );
   QVERIFY( !combo->currentLayer() );
+  combo->setLayer( tiledScene );
+  QVERIFY( !combo->currentLayer() );
+  combo.reset();
+  param.reset();
+
+  // map layer param, only tiled scene layers are acceptable
+  param = std::make_unique<QgsProcessingParameterMapLayer>( QStringLiteral( "param" ), QString(), QVariant(), false, QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::TiledScene ) );
+  combo = std::make_unique<QgsProcessingMapLayerComboBox>( param.get() );
+  combo->setLayer( point );
+  QVERIFY( !combo->currentLayer() );
+  combo->setLayer( line );
+  QVERIFY( !combo->currentLayer() );
+  combo->setLayer( polygon );
+  QVERIFY( !combo->currentLayer() );
+  combo->setLayer( noGeom );
+  QVERIFY( !combo->currentLayer() );
+  combo->setLayer( mesh );
+  QVERIFY( !combo->currentLayer() );
+  combo->setLayer( raster );
+  QVERIFY( !combo->currentLayer() );
+  combo->setLayer( pointCloud );
+  QVERIFY( !combo->currentLayer() );
+  combo->setLayer( tiledScene );
+  QCOMPARE( combo->currentLayer(), tiledScene );
   combo.reset();
   param.reset();
 
@@ -6749,6 +6779,8 @@ void TestProcessingGui::mapLayerComboBox()
   combo->setLayer( raster );
   QCOMPARE( combo->currentLayer(), raster );
   combo->setLayer( pointCloud );
+  QVERIFY( !combo->currentLayer() );
+  combo->setLayer( tiledScene );
   QVERIFY( !combo->currentLayer() );
   combo.reset();
   param.reset();
@@ -6770,6 +6802,8 @@ void TestProcessingGui::mapLayerComboBox()
   QVERIFY( !combo->currentLayer() );
   combo->setLayer( pointCloud );
   QVERIFY( !combo->currentLayer() );
+  combo->setLayer( tiledScene );
+  QVERIFY( !combo->currentLayer() );
   combo.reset();
   param.reset();
 
@@ -6790,6 +6824,8 @@ void TestProcessingGui::mapLayerComboBox()
   QVERIFY( !combo->currentLayer() );
   combo->setLayer( pointCloud );
   QCOMPARE( combo->currentLayer(), pointCloud );
+  combo->setLayer( tiledScene );
+  QVERIFY( !combo->currentLayer() );
   combo.reset();
   param.reset();
 


### PR DESCRIPTION
## Description

Add missed bits to allow filtering tiled scene and vector tile layers in the Processing map layer parameter and associated widget wrappers.