### PR TITLE
do not treat NULL and empty strings equally in statistical summary

### DIFF
--- a/python/plugins/processing/algs/qgis/StatisticsByCategories.py
+++ b/python/plugins/processing/algs/qgis/StatisticsByCategories.py
@@ -359,7 +359,7 @@ class StatisticsByCategories(QgisAlgorithm):
                     stat.count(),
                     stat.countDistinct(),
                     stat.countMissing(),
-                    stat.count() - stat.countMissing(),
+                    len(v) - stat.countMissing(),
                     stat.min(),
                     stat.max(),
                     stat.minLength(),

--- a/python/plugins/processing/tests/testdata/expected/basic_statistics_string.html
+++ b/python/plugins/processing/tests/testdata/expected/basic_statistics_string.html
@@ -1,14 +1,2 @@
-<html><head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
-<p>Analyzed layer: multipolys.gml</p>
-<p>Analyzed field: Bname</p>
-<p>Minimum length: 0</p>
-<p>Maximum length: 4</p>
-<p>Mean length: 3.0</p>
-<p>Filled values: 3</p>
-<p>NULL (missing) values: 1</p>
-<p>Count: 4</p>
-<p>Unique: 2</p>
-<p>Minimum string value: Test</p>
-<p>Maximum string value: Test</p>
-</body></html>
+<html><head><meta http-equiv="Content-Type" content="text/html;charset=utf-8"/></head><body>
+<p>Analyzed field: Bname</p><p>Count: 3</p><p>Unique values: 1</p><p>NULL (missing) values: 1</p><p>NOT NULL (filled) values: 3</p><p>Minimum value: Test</p><p>Maximum value: Test</p><p>Minimum length: 4</p><p>Maximum length: 4</p><p>Mean length: 4.000000</p><p>Minority: Test</p><p>Majority: Test</p></body></html>

--- a/python/plugins/processing/tests/testdata/expected/statistics_text.gml
+++ b/python/plugins/processing/tests/testdata/expected/statistics_text.gml
@@ -9,16 +9,16 @@
                                                                                                                                                                                                                                                                                                                 
   <ogr:featureMember>
     <ogr:statistics_text gml:id="statistics_text.0">
-      <ogr:count>4</ogr:count>
-      <ogr:unique>2</ogr:unique>
+      <ogr:count>3</ogr:count>
+      <ogr:unique>1</ogr:unique>
       <ogr:empty>1</ogr:empty>
       <ogr:filled>3</ogr:filled>
       <ogr:min>Test</ogr:min>
       <ogr:max>Test</ogr:max>
-      <ogr:min_length>0</ogr:min_length>
+      <ogr:min_length>4</ogr:min_length>
       <ogr:max_length>4</ogr:max_length>
-      <ogr:mean_length>3</ogr:mean_length>
-      <ogr:minority xsi:nil="true"/>
+      <ogr:mean_length>4</ogr:mean_length>
+      <ogr:minority>Test</ogr:minority>
       <ogr:majority>Test</ogr:majority>
     </ogr:statistics_text>
   </ogr:featureMember>

--- a/python/plugins/processing/tests/testdata/expected/stats_by_cat_string.gml
+++ b/python/plugins/processing/tests/testdata/expected/stats_by_cat_string.gml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ogr:FeatureCollection
+     gml:id="aFeatureCollection"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation=""
+     xsi:schemaLocation="http://ogr.maptools.org/ stats_by_cat_string.xsd"
      xmlns:ogr="http://ogr.maptools.org/"
-     xmlns:gml="http://www.opengis.net/gml">
-  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
-                                                                                                                                                                                                                                                                                                
-  <gml:featureMember>
-    <ogr:stats_by_cat_string fid="stats_by_cat_string.0">
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Null /></gml:boundedBy>
+                                                                                                                                                                                                                                                                                                                
+  <ogr:featureMember>
+    <ogr:stats_by_cat_string gml:id="stats_by_cat_string.0">
       <ogr:intval>1</ogr:intval>
       <ogr:count>5</ogr:count>
       <ogr:unique>2</ogr:unique>
@@ -19,9 +20,10 @@
       <ogr:max_length>2</ogr:max_length>
       <ogr:mean_length>2</ogr:mean_length>
     </ogr:stats_by_cat_string>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:stats_by_cat_string fid="stats_by_cat_string.1">
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:stats_by_cat_string gml:id="stats_by_cat_string.1">
+      <ogr:intval xsi:nil="true"/>
       <ogr:count>3</ogr:count>
       <ogr:unique>2</ogr:unique>
       <ogr:empty>0</ogr:empty>
@@ -32,23 +34,23 @@
       <ogr:max_length>2</ogr:max_length>
       <ogr:mean_length>2</ogr:mean_length>
     </ogr:stats_by_cat_string>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:stats_by_cat_string fid="stats_by_cat_string.2">
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:stats_by_cat_string gml:id="stats_by_cat_string.2">
       <ogr:intval>120</ogr:intval>
       <ogr:count>1</ogr:count>
       <ogr:unique>1</ogr:unique>
-      <ogr:empty>1</ogr:empty>
-      <ogr:filled>0</ogr:filled>
+      <ogr:empty>0</ogr:empty>
+      <ogr:filled>1</ogr:filled>
       <ogr:min></ogr:min>
       <ogr:max></ogr:max>
       <ogr:min_length>0</ogr:min_length>
       <ogr:max_length>0</ogr:max_length>
       <ogr:mean_length>0</ogr:mean_length>
     </ogr:stats_by_cat_string>
-  </gml:featureMember>
-  <gml:featureMember>
-    <ogr:stats_by_cat_string fid="stats_by_cat_string.3">
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:stats_by_cat_string gml:id="stats_by_cat_string.3">
       <ogr:intval>2</ogr:intval>
       <ogr:count>1</ogr:count>
       <ogr:unique>1</ogr:unique>
@@ -60,5 +62,5 @@
       <ogr:max_length>2</ogr:max_length>
       <ogr:mean_length>2</ogr:mean_length>
     </ogr:stats_by_cat_string>
-  </gml:featureMember>
+  </ogr:featureMember>
 </ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests1.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests1.yaml
@@ -547,13 +547,13 @@ tests:
         type: regex
         rules:
           - 'Analyzed field: Bname'
-          - 'Count: 4'
-          - 'Unique values: 2'
+          - 'Count: 3'
+          - 'Unique values: 1'
           - 'Minimum value: Test'
           - 'Maximum value: Test'
-          - 'Minimum length: 0'
+          - 'Minimum length: 4'
           - 'Maximum length: 4'
-          - 'Mean length: 3.0'
+          - 'Mean length: 4.000000'
           - 'NULL \(missing\) values: 1'
 
   - algorithm: native:listuniquevalues

--- a/src/analysis/processing/qgsalgorithmbasicstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmbasicstatistics.cpp
@@ -362,7 +362,7 @@ QVariantMap QgsBasicStatisticsAlgorithm::calculateStringStatistics( const int fi
   outputs.insert( QStringLiteral( "COUNT" ), stat.count() );
   outputs.insert( QStringLiteral( "UNIQUE" ), stat.countDistinct() );
   outputs.insert( QStringLiteral( "EMPTY" ), stat.countMissing() );
-  outputs.insert( QStringLiteral( "FILLED" ), stat.count() - stat.countMissing() );
+  outputs.insert( QStringLiteral( "FILLED" ), count - stat.countMissing() );
   outputs.insert( QStringLiteral( "MIN" ), stat.min() );
   outputs.insert( QStringLiteral( "MAX" ), stat.max() );
   outputs.insert( QStringLiteral( "MIN_LENGTH" ), stat.minLength() );

--- a/src/core/qgsstringstatisticalsummary.cpp
+++ b/src/core/qgsstringstatisticalsummary.cpp
@@ -68,7 +68,11 @@ void QgsStringStatisticalSummary::addString( const QString &string )
 
 void QgsStringStatisticalSummary::addValue( const QVariant &value )
 {
-  if ( QgsVariantUtils::isNull( value ) || value.userType() == QMetaType::Type::QString )
+  if ( QgsVariantUtils::isNull( value ) )
+  {
+    testString( QString() );
+  }
+  else if ( value.userType() == QMetaType::Type::QString )
   {
     testString( value.toString() );
   }
@@ -100,7 +104,11 @@ void QgsStringStatisticalSummary::calculateFromVariants( const QVariantList &val
   const auto constValues = values;
   for ( const QVariant &variant : constValues )
   {
-    if ( QgsVariantUtils::isNull( variant ) || variant.userType() == QMetaType::Type::QString )
+    if ( QgsVariantUtils::isNull( variant ) )
+    {
+      testString( QString() );
+    }
+    else if ( variant.userType() == QMetaType::Type::QString )
     {
       testString( variant.toString() );
     }
@@ -111,10 +119,13 @@ void QgsStringStatisticalSummary::calculateFromVariants( const QVariantList &val
 
 void QgsStringStatisticalSummary::testString( const QString &string )
 {
-  mCount++;
-
-  if ( string.isEmpty() )
+  if ( string.isNull() )
+  {
     mCountMissing++;
+    return;
+  }
+
+  mCount++;
 
   if ( mStatistics & Qgis::StringStatistic::CountDistinct || mStatistics & Qgis::StringStatistic::Majority || mStatistics & Qgis::StringStatistic::Minority )
   {

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3059,11 +3059,11 @@ class TestQgsExpression : public QObject
       QTest::newRow( "minority" ) << "minority(\"col3\")" << false << QVariant( 1 );
       QTest::newRow( "majority" ) << "majority(\"col3\")" << false << QVariant( 2 );
       QTest::newRow( "minority string" ) << "minority(\"col2\")" << false << QVariant( "test" );
-      QTest::newRow( "majority string" ) << "majority(\"col2\")" << false << QVariant( "" );
+      QTest::newRow( "majority string" ) << "majority(\"col2\")" << false << QVariant( "test4" );
       QTest::newRow( "q1" ) << "q1(\"col1\")" << false << QVariant( 2.5 );
       QTest::newRow( "q3" ) << "q3(\"col1\")" << false << QVariant( 6.5 );
       QTest::newRow( "iqr" ) << "iqr(\"col1\")" << false << QVariant( 4 );
-      QTest::newRow( "min_length" ) << "min_length(\"col2\")" << false << QVariant( 0 );
+      QTest::newRow( "min_length" ) << "min_length(\"col2\")" << false << QVariant( 4 );
       QTest::newRow( "max_length" ) << "max_length(\"col2\")" << false << QVariant( 7 );
       QTest::newRow( "concatenate" ) << "concatenate(\"col2\",concatenator:=',')" << false << QVariant( "test,,test333,test4,,test4,test7" );
       QTest::newRow( "concatenate with order 1" ) << "concatenate(\"col2\",concatenator:=',', order_by:=col1)" << false << QVariant( ",test4,test333,test,,test4,test7" );

--- a/tests/src/python/test_qgsaggregatecalculator.py
+++ b/tests/src/python/test_qgsaggregatecalculator.py
@@ -192,7 +192,7 @@ class TestQgsAggregateCalculator(QgisTestCase):
         layer = QgsVectorLayer("Point?field=fldstring:string", "layer", "memory")
         pr = layer.dataProvider()
 
-        values = ["cc", "aaaa", "bbbbbbbb", "aaaa", "eeee", "", "eeee", "", "dddd"]
+        values = ["cc", "aaaa", "bbbbbbbb", "aaaa", "eeee", "", "eeee", None, "dddd"]
         features = []
         for v in values:
             f = QgsFeature()
@@ -202,9 +202,9 @@ class TestQgsAggregateCalculator(QgisTestCase):
         assert pr.addFeatures(features)
 
         tests = [
-            [QgsAggregateCalculator.Aggregate.Count, "fldstring", 9],
+            [QgsAggregateCalculator.Aggregate.Count, "fldstring", 8],
             [QgsAggregateCalculator.Aggregate.CountDistinct, "fldstring", 6],
-            [QgsAggregateCalculator.Aggregate.CountMissing, "fldstring", 2],
+            [QgsAggregateCalculator.Aggregate.CountMissing, "fldstring", 1],
             [QgsAggregateCalculator.Aggregate.Min, "fldstring", "aaaa"],
             [QgsAggregateCalculator.Aggregate.Max, "fldstring", "eeee"],
             [QgsAggregateCalculator.Aggregate.StringMinimumLength, "fldstring", 0],
@@ -225,12 +225,12 @@ class TestQgsAggregateCalculator(QgisTestCase):
             QgsAggregateCalculator.Aggregate.StringConcatenate, "fldstring"
         )
         self.assertTrue(ok)
-        self.assertEqual(val, "cc,aaaa,bbbbbbbb,aaaa,eeee,,eeee,,dddd")
+        self.assertEqual(val, "cc,aaaa,bbbbbbbb,aaaa,eeee,,eeee,0,dddd")
         val, ok = agg.calculate(
             QgsAggregateCalculator.Aggregate.StringConcatenateUnique, "fldstring"
         )
         self.assertTrue(ok)
-        self.assertEqual(val, "cc,aaaa,bbbbbbbb,eeee,,dddd")
+        self.assertEqual(val, "cc,aaaa,bbbbbbbb,eeee,,0,dddd")
 
         # bad tests - the following stats should not be calculatable for string fields
         for t in [
@@ -253,7 +253,7 @@ class TestQgsAggregateCalculator(QgisTestCase):
             QgsAggregateCalculator.Aggregate.ArrayAggregate, "fldstring"
         )
         self.assertEqual(
-            val, ["cc", "aaaa", "bbbbbbbb", "aaaa", "eeee", "", "eeee", "", "dddd"]
+            val, ["cc", "aaaa", "bbbbbbbb", "aaaa", "eeee", "", "eeee", None, "dddd"]
         )
         params = QgsAggregateCalculator.AggregateParameters()
         params.orderBy = QgsFeatureRequest.OrderBy(
@@ -264,16 +264,16 @@ class TestQgsAggregateCalculator(QgisTestCase):
             QgsAggregateCalculator.Aggregate.ArrayAggregate, "fldstring"
         )
         self.assertEqual(
-            val, ["", "", "aaaa", "aaaa", "bbbbbbbb", "cc", "dddd", "eeee", "eeee"]
+            val, ["", "aaaa", "aaaa", "bbbbbbbb", "cc", "dddd", "eeee", "eeee", None]
         )
         val, ok = agg.calculate(
             QgsAggregateCalculator.Aggregate.StringConcatenate, "fldstring"
         )
-        self.assertEqual(val, "aaaaaaaabbbbbbbbccddddeeeeeeee")
+        self.assertEqual(val, "aaaaaaaabbbbbbbbccddddeeeeeeee0")
         val, ok = agg.calculate(QgsAggregateCalculator.Aggregate.Minority, "fldstring")
-        self.assertEqual(val, "bbbbbbbb")
-        val, ok = agg.calculate(QgsAggregateCalculator.Aggregate.Majority, "fldstring")
         self.assertEqual(val, "")
+        val, ok = agg.calculate(QgsAggregateCalculator.Aggregate.Majority, "fldstring")
+        self.assertEqual(val, "aaaa")
 
     def testDateTime(self):
         """Test calculation of aggregates on date/datetime fields"""

--- a/tests/src/python/test_qgsstringstatisticalsummary.py
+++ b/tests/src/python/test_qgsstringstatisticalsummary.py
@@ -39,16 +39,16 @@ class PyQgsStringStatisticalSummary(unittest.TestCase):
         for string in strings:
             s2.addString(string)
         s2.finalize()
-        self.assertEqual(s.count(), 10)
-        self.assertEqual(s2.count(), 10)
+        self.assertEqual(s.count(), 9)
+        self.assertEqual(s2.count(), 9)
         self.assertEqual(s.countDistinct(), 6)
         self.assertEqual(s2.countDistinct(), 6)
         self.assertEqual(
             set(s.distinctValues()), {"cc", "aaaa", "bbbbbbbb", "eeee", "dddd", ""}
         )
         self.assertEqual(s2.distinctValues(), s.distinctValues())
-        self.assertEqual(s.countMissing(), 2)
-        self.assertEqual(s2.countMissing(), 2)
+        self.assertEqual(s.countMissing(), 1)
+        self.assertEqual(s2.countMissing(), 1)
         self.assertEqual(s.min(), "aaaa")
         self.assertEqual(s2.min(), "aaaa")
         self.assertEqual(s.max(), "eeee")
@@ -57,10 +57,10 @@ class PyQgsStringStatisticalSummary(unittest.TestCase):
         self.assertEqual(s2.minLength(), 0)
         self.assertEqual(s.maxLength(), 8)
         self.assertEqual(s2.maxLength(), 8)
-        self.assertEqual(s.meanLength(), 3.4)
-        self.assertEqual(s2.meanLength(), 3.4)
-        self.assertEqual(s.minority(), "bbbbbbbb")
-        self.assertEqual(s2.minority(), "bbbbbbbb")
+        self.assertAlmostEqual(s.meanLength(), 3.7777777777777777)
+        self.assertAlmostEqual(s2.meanLength(), 3.7777777777777777)
+        self.assertEqual(s.minority(), "")
+        self.assertEqual(s2.minority(), "")
         self.assertEqual(s.majority(), "aaaa")
         self.assertEqual(s2.majority(), "aaaa")
 
@@ -72,12 +72,12 @@ class PyQgsStringStatisticalSummary(unittest.TestCase):
         # tests calculation of statistics one at a time, to make sure statistic calculations are not
         # dependent on each other
         tests = [
-            {"stat": QgsStringStatisticalSummary.Statistic.Count, "expected": 10},
+            {"stat": QgsStringStatisticalSummary.Statistic.Count, "expected": 9},
             {
                 "stat": QgsStringStatisticalSummary.Statistic.CountDistinct,
                 "expected": 6,
             },
-            {"stat": QgsStringStatisticalSummary.Statistic.CountMissing, "expected": 2},
+            {"stat": QgsStringStatisticalSummary.Statistic.CountMissing, "expected": 1},
             {"stat": QgsStringStatisticalSummary.Statistic.Min, "expected": "aaaa"},
             {"stat": QgsStringStatisticalSummary.Statistic.Max, "expected": "eeee"},
             {
@@ -88,10 +88,13 @@ class PyQgsStringStatisticalSummary(unittest.TestCase):
                 "stat": QgsStringStatisticalSummary.Statistic.MaximumLength,
                 "expected": 8,
             },
-            {"stat": QgsStringStatisticalSummary.Statistic.MeanLength, "expected": 3.4},
+            {
+                "stat": QgsStringStatisticalSummary.Statistic.MeanLength,
+                "expected": 3.7777777777777777,
+            },
             {
                 "stat": QgsStringStatisticalSummary.Statistic.Minority,
-                "expected": "bbbbbbbb",
+                "expected": "",
             },
             {
                 "stat": QgsStringStatisticalSummary.Statistic.Majority,
@@ -119,7 +122,7 @@ class PyQgsStringStatisticalSummary(unittest.TestCase):
                 "",
                 "eeee",
                 "aaaa",
-                "",
+                None,
                 "dddd",
             ]
             s.calculate(strings)
@@ -139,10 +142,10 @@ class PyQgsStringStatisticalSummary(unittest.TestCase):
     def testVariantStats(self):
         s = QgsStringStatisticalSummary()
         self.assertEqual(s.statistics(), QgsStringStatisticalSummary.Statistic.All)
-        s.calculateFromVariants(["cc", 5, "bbbb", "aaaa", "eeee", 6, 9, "9", None])
+        s.calculateFromVariants(["cc", 5, "bbbb", "aaaa", "eeee", 6, 9, "", "9", None])
         self.assertEqual(s.count(), 6)
         self.assertEqual(
-            set(s.distinctValues()), {"cc", "aaaa", "bbbb", "eeee", "", "9"}
+            set(s.distinctValues()), {"cc", "bbbb", "aaaa", "eeee", "", "9"}
         )
         self.assertEqual(s.countMissing(), 1)
         self.assertEqual(s.min(), "9")
@@ -151,7 +154,7 @@ class PyQgsStringStatisticalSummary(unittest.TestCase):
     def testAddVariantStats(self):
         s = QgsStringStatisticalSummary()
         self.assertEqual(s.statistics(), QgsStringStatisticalSummary.Statistic.All)
-        for v in ["cc", 5, "bbbb", "aaaa", "eeee", 6, 9, "9", None]:
+        for v in ["cc", 5, "bbbb", "aaaa", "eeee", 6, 9, "", "9", None]:
             s.addValue(v)
         self.assertEqual(s.count(), 6)
         self.assertEqual(


### PR DESCRIPTION
## Description

When calculating statistical summary for string field empty strings and NULL values are treated equally, leading to wrong count and count missing values.

Proposed PR fixes this by excluding NULL values from the count and not considering empty strings as missed values, aligning behavior with the numeric statistical summary.

Fixes #35433.