### PR TITLE
provide default value when reading output folder setting to generate destination path in Processing (fix #61965)

### DIFF
--- a/python/plugins/processing/tools/system.py
+++ b/python/plugins/processing/tools/system.py
@@ -41,7 +41,7 @@ def userFolder():
 
 
 def defaultOutputFolder():
-    folder = os.path.join(userFolder(), "outputs")
+    folder = os.path.join(QDir.homePath(), "processing")
     if not QDir(folder).exists():
         QDir().mkpath(folder)
 

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -176,7 +176,7 @@ QVariant QgsProcessingLayerOutputDestinationWidget::value() const
     if ( folder == '.' )
     {
       // output name does not include a folder - use default
-      QString defaultFolder = settings.value( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), QStringLiteral( "%1/processing/outputs" ).arg( QgsApplication::qgisSettingsDirPath() ) ).toString();
+      QString defaultFolder = settings.value( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), QStringLiteral( "%1/processing" ).arg( QDir : homePath() ) ).toString();
       key = QDir( defaultFolder ).filePath( key );
     }
   }

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -176,7 +176,7 @@ QVariant QgsProcessingLayerOutputDestinationWidget::value() const
     if ( folder == '.' )
     {
       // output name does not include a folder - use default
-      QString defaultFolder = settings.value( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), QStringLiteral( "%1/processing" ).arg( QDir : homePath() ) ).toString();
+      QString defaultFolder = settings.value( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), QStringLiteral( "%1/processing" ).arg( QDir::homePath() ) ).toString();
       key = QDir( defaultFolder ).filePath( key );
     }
   }

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -25,6 +25,7 @@
 #include "qgsprocessingcontext.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsfieldmappingwidget.h"
+#include "qgsapplication.h"
 #include <QMenu>
 #include <QFileDialog>
 #include <QInputDialog>
@@ -175,7 +176,7 @@ QVariant QgsProcessingLayerOutputDestinationWidget::value() const
     if ( folder == '.' )
     {
       // output name does not include a folder - use default
-      QString defaultFolder = settings.value( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ) ).toString();
+      QString defaultFolder = settings.value( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), QStringLiteral( "%1/processing/outputs" ).arg( QgsApplication::qgisSettingsDirPath() ) ).toString();
       key = QDir( defaultFolder ).filePath( key );
     }
   }


### PR DESCRIPTION
## Description

If output folder setting in Processing is set to default (and as a result is not saved in the settings file), retrieving value from the `QgsProcessingLayerOutputDestinationWidget` will result in an incorrect path because `settings.value()` call lacks fallback value.

Fixes #61965.