### PR TITLE
Setting Label format, Label Precision and Trailing zeros after pressing the Classify button

### DIFF
--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -1043,6 +1043,10 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
 
 void QgsGraduatedSymbolRendererWidget::classifyGraduatedImpl()
 {
+  mClassificationMethod->setLabelFormat( txtLegendFormat->text() );
+  mClassificationMethod->setLabelPrecision( spinPrecision->value() );
+  mClassificationMethod->setLabelTrimTrailingZeroes( cbxTrimTrailingZeroes->isChecked() );
+
   if ( mBlockUpdates || !mClassificationMethod )
     return;
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -1043,12 +1043,12 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
 
 void QgsGraduatedSymbolRendererWidget::classifyGraduatedImpl()
 {
+  if ( mBlockUpdates || !mClassificationMethod )
+    return;
+
   mClassificationMethod->setLabelFormat( txtLegendFormat->text() );
   mClassificationMethod->setLabelPrecision( spinPrecision->value() );
   mClassificationMethod->setLabelTrimTrailingZeroes( cbxTrimTrailingZeroes->isChecked() );
-
-  if ( mBlockUpdates || !mClassificationMethod )
-    return;
 
   QgsTemporaryCursorOverride override( Qt::WaitCursor );
   QString attrName = mExpressionWidget->currentField();


### PR DESCRIPTION
## Description

mClassificationMethod->setLabelFormat, mClassificationMethod->setLabelPrecision and mClassificationMethod->setLabelTrimTrailingZeroes in classifyGraduatedImpl() which is called after hitting the Classify button

Fixes #63276