### PR TITLE
[ux][field_calculator] Deactivate field editing for RO layers

### DIFF
--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -69,7 +69,7 @@ class GUI_EXPORT QgsFieldCalculator : public QDialog, private Ui::QgsFieldCalcul
     void setPrecisionMinMax();
     void showHelp();
     void calculate();
-    //! show the given message in the Plugin Manager internal message bar
+    //! show the given message in the dialog internal message bar
     void pushMessage( const QString &text, Qgis::MessageLevel level = Qgis::MessageLevel::Info, int duration = -1 );
 
   private:


### PR DESCRIPTION
If layer is read-only deactivate the provider field editing functionality.

Fix #63111

