### PR TITLE
show layer name in the identify menu if there are overlapping features from the same layer (fix #50049)

### DIFF
--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -428,6 +428,11 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
     if ( featureTitle.isEmpty() )
       featureTitle = QString::number( result.mFeature.id() );
 
+    // if results are from the same layer we still add layer name to the feature
+    // title to be consistent with other cases, see https://github.com/qgis/QGIS/issues/50049
+    if ( layerMenu == this )
+      featureTitle = QStringLiteral( "%1 (%2)" ).arg( layer->name(), featureTitle );
+
     if ( customFeatureActions.isEmpty() && ( !featureActionMenu || featureActionMenu->actions().isEmpty() ) )
     {
       featureAction = new QAction( featureTitle, layerMenu );


### PR DESCRIPTION
## Description

In case when there are several overlapping features in the same layer identify menu, shows only feature title/ID while in cases when there is a single feature or several features from different layers menu entries include layer name as well as feature title/ID.

Before
![Screencast_20250925_131734](https://github.com/user-attachments/assets/28f4a42d-15d5-4811-ad49-5be767aedd5c)

After
![Screencast_20250925_131628](https://github.com/user-attachments/assets/f709848b-abbc-4d11-8d7e-93c73a550f1f)

Fixes #50049.
