### PR TITLE
[themes][ui] Fix color for selected tree widget items, when they are disabled

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -988,6 +988,11 @@ QTreeView::item:selected, QTreeView::branch:selected {
     color: @text;
 }
 
+QTreeView::item:selected:disabled, QTreeView::branch:selected:disabled {
+    background-color: @itemalternativebackground;
+    color: @background;
+}
+
 QTreeView::branch:has-children:!has-siblings:closed,
 QTreeView::branch:closed:has-children:has-siblings {
     border-image: none;

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1019,6 +1019,11 @@ QTreeView::item:selected, QTreeView::branch:selected {
     color: @textlight;
 }
 
+QTreeView::item:selected:disabled, QTreeView::branch:selected:disabled {
+    background-color: @itemdarkbackground;
+    color: @background;
+}
+
 QTreeView::branch:has-children:!has-siblings:closed,
 QTreeView::branch:closed:has-children:has-siblings {
     border-image: none;


### PR DESCRIPTION
## Description

This PR fixes the appearance of tree view items when they are both selected and disabled in dark themes. See the following examples of symbol layer items with rule-based symbology.

#### Blend of Gray:
|Before             |  After |
|:-------------------------:|:-------------------------:|
| ![tree_view_item_blend_of_gray_before](https://github.com/user-attachments/assets/d087cfbe-8170-4584-b39a-0dc69ca413c6) | ![tree_view_item_blend_of_gray_after](https://github.com/user-attachments/assets/4e147e4a-62f9-47ed-b75c-e01f6faadf18) |

#### Night Mapping:
| Before             |  After |
|:----:|:---:|
| ![tree_view_item_night_mapping_before](https://github.com/user-attachments/assets/d2d9c34a-0952-4458-bdb8-b2a875884035) | ![tree_view_item_night_mapping_after](https://github.com/user-attachments/assets/6d32eef0-f278-465f-834a-e5963dcc7db1) |

The changes can be backported.

As with #63011, I could not find a way how to fix this issue for the default (light) Fusion theme, in which it is also apparent:

<p align="center"><img title="Selected, but disabled tree view item in the default (fusion) theme" "alt="tree_view_item_fusion" src="https://github.com/user-attachments/assets/8b7e25aa-ea86-47ac-9653-691ec30e31d0" /></p>

