### PR TITLE
Support Zarr as a STAC cloud-optimised media type (#62838)

### DIFF
--- a/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
@@ -81,7 +81,7 @@ COPC, empty auth configuration
 .. versionadded:: 3.42
 %End
 
-    QgsMimeDataUtils::Uri uri( QString authcfg ) const;
+    QgsMimeDataUtils::Uri uri( const QString &authcfg ) const;
 %Docstring
 Returns a uri for the asset if it is a cloud optimized file like COG or
 COPC

--- a/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
@@ -93,11 +93,15 @@ COPC
 %Docstring
 Returns an HTML representation of the STAC Asset including its ID within
 its container
+
+.. versionadded:: 4.0
 %End
 
     bool isDownloadable() const;
 %Docstring
 Returns whether the asset can be downloaded
+
+.. versionadded:: 4.0
 %End
 
 };

--- a/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
@@ -78,12 +78,13 @@ Returns the format name for cloud optimized formats
 Returns a uri for the asset if it is a cloud optimized file like COG or
 COPC.
 
-:param authcfg: Optional authentication configuration ID.
+:param authcfg: Optional authentication configuration ID (since QGIS
+                4.0).
 
 If the optional @authcfg parameter is set the authentication
 configuration ID will be encoded in the returned URI.
 
-.. versionadded:: 4.0
+.. versionadded:: 3.42
 %End
 
     QString toHtml( const QString &assetId ) const;
@@ -96,7 +97,7 @@ its container
 
     bool isDownloadable() const;
 %Docstring
-Returns whether the asset can be downloaded
+Returns whether the asset can be downloaded.
 
 .. versionadded:: 4.0
 %End

--- a/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
@@ -89,6 +89,17 @@ COPC
 .. versionadded:: 3.42
 %End
 
+    QString toHtml() const;
+%Docstring
+Returns an HTML representation of the STAC Asset without an ID
+%End
+
+    QString toHtml( const QString &assetId ) const;
+%Docstring
+Returns an HTML representation of the STAC Asset including its ID within
+its container
+%End
+
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
@@ -86,7 +86,7 @@ COPC, empty auth configuration
 Returns a uri for the asset if it is a cloud optimized file like COG or
 COPC
 
-.. versionadded:: 3.42
+.. versionadded:: 4.0
 %End
 
     QString toHtml( const QString &assetId ) const;

--- a/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
@@ -76,6 +76,14 @@ Returns the format name for cloud optimized formats
     QgsMimeDataUtils::Uri uri() const;
 %Docstring
 Returns a uri for the asset if it is a cloud optimized file like COG or
+COPC, empty auth configuration
+
+.. versionadded:: 3.42
+%End
+
+    QgsMimeDataUtils::Uri uri( QString authcfg ) const;
+%Docstring
+Returns a uri for the asset if it is a cloud optimized file like COG or
 COPC
 
 .. versionadded:: 3.42

--- a/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
@@ -73,18 +73,15 @@ Returns the format name for cloud optimized formats
 .. versionadded:: 3.42
 %End
 
-    QgsMimeDataUtils::Uri uri() const;
+    QgsMimeDataUtils::Uri uri( const QString &authcfg = QString() ) const;
 %Docstring
 Returns a uri for the asset if it is a cloud optimized file like COG or
-COPC, empty auth configuration
+COPC.
 
-.. versionadded:: 3.42
-%End
+:param authcfg: Optional authentication configuration ID.
 
-    QgsMimeDataUtils::Uri uri( const QString &authcfg ) const;
-%Docstring
-Returns a uri for the asset if it is a cloud optimized file like COG or
-COPC
+If the optional @authcfg parameter is set the authentication
+configuration ID will be encoded in the returned URI.
 
 .. versionadded:: 4.0
 %End

--- a/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/PyQt6/core/auto_generated/stac/qgsstacasset.sip.in
@@ -89,15 +89,15 @@ COPC
 .. versionadded:: 3.42
 %End
 
-    QString toHtml() const;
-%Docstring
-Returns an HTML representation of the STAC Asset without an ID
-%End
-
     QString toHtml( const QString &assetId ) const;
 %Docstring
 Returns an HTML representation of the STAC Asset including its ID within
 its container
+%End
+
+    bool isDownloadable() const;
+%Docstring
+Returns whether the asset can be downloaded
 %End
 
 };

--- a/python/PyQt6/core/auto_generated/stac/qgsstacitem.sip.in
+++ b/python/PyQt6/core/auto_generated/stac/qgsstacitem.sip.in
@@ -82,14 +82,12 @@ Sets the item's additional metadata to ``properties``
 
     QMap< QString, QgsStacAsset > assets() const;
 %Docstring
-Returns a dictionary of asset objects that can be downloaded, each with
-a unique key.
+Returns a dictionary of asset objects, each with a unique key.
 %End
 
     void setAssets( const QMap< QString, QgsStacAsset > &assets );
 %Docstring
-Sets the ``asset`` objects that can be downloaded, each with a unique
-key.
+Sets the ``asset`` objects, each with a unique key.
 %End
 
     QString collection() const;

--- a/python/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/core/auto_generated/stac/qgsstacasset.sip.in
@@ -81,7 +81,7 @@ COPC, empty auth configuration
 .. versionadded:: 3.42
 %End
 
-    QgsMimeDataUtils::Uri uri( QString authcfg ) const;
+    QgsMimeDataUtils::Uri uri( const QString &authcfg ) const;
 %Docstring
 Returns a uri for the asset if it is a cloud optimized file like COG or
 COPC

--- a/python/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/core/auto_generated/stac/qgsstacasset.sip.in
@@ -93,11 +93,15 @@ COPC
 %Docstring
 Returns an HTML representation of the STAC Asset including its ID within
 its container
+
+.. versionadded:: 4.0
 %End
 
     bool isDownloadable() const;
 %Docstring
 Returns whether the asset can be downloaded
+
+.. versionadded:: 4.0
 %End
 
 };

--- a/python/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/core/auto_generated/stac/qgsstacasset.sip.in
@@ -78,12 +78,13 @@ Returns the format name for cloud optimized formats
 Returns a uri for the asset if it is a cloud optimized file like COG or
 COPC.
 
-:param authcfg: Optional authentication configuration ID.
+:param authcfg: Optional authentication configuration ID (since QGIS
+                4.0).
 
 If the optional @authcfg parameter is set the authentication
 configuration ID will be encoded in the returned URI.
 
-.. versionadded:: 4.0
+.. versionadded:: 3.42
 %End
 
     QString toHtml( const QString &assetId ) const;
@@ -96,7 +97,7 @@ its container
 
     bool isDownloadable() const;
 %Docstring
-Returns whether the asset can be downloaded
+Returns whether the asset can be downloaded.
 
 .. versionadded:: 4.0
 %End

--- a/python/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/core/auto_generated/stac/qgsstacasset.sip.in
@@ -89,6 +89,17 @@ COPC
 .. versionadded:: 3.42
 %End
 
+    QString toHtml() const;
+%Docstring
+Returns an HTML representation of the STAC Asset without an ID
+%End
+
+    QString toHtml( const QString &assetId ) const;
+%Docstring
+Returns an HTML representation of the STAC Asset including its ID within
+its container
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/core/auto_generated/stac/qgsstacasset.sip.in
@@ -86,7 +86,7 @@ COPC, empty auth configuration
 Returns a uri for the asset if it is a cloud optimized file like COG or
 COPC
 
-.. versionadded:: 3.42
+.. versionadded:: 4.0
 %End
 
     QString toHtml( const QString &assetId ) const;

--- a/python/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/core/auto_generated/stac/qgsstacasset.sip.in
@@ -76,6 +76,14 @@ Returns the format name for cloud optimized formats
     QgsMimeDataUtils::Uri uri() const;
 %Docstring
 Returns a uri for the asset if it is a cloud optimized file like COG or
+COPC, empty auth configuration
+
+.. versionadded:: 3.42
+%End
+
+    QgsMimeDataUtils::Uri uri( QString authcfg ) const;
+%Docstring
+Returns a uri for the asset if it is a cloud optimized file like COG or
 COPC
 
 .. versionadded:: 3.42

--- a/python/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/core/auto_generated/stac/qgsstacasset.sip.in
@@ -73,18 +73,15 @@ Returns the format name for cloud optimized formats
 .. versionadded:: 3.42
 %End
 
-    QgsMimeDataUtils::Uri uri() const;
+    QgsMimeDataUtils::Uri uri( const QString &authcfg = QString() ) const;
 %Docstring
 Returns a uri for the asset if it is a cloud optimized file like COG or
-COPC, empty auth configuration
+COPC.
 
-.. versionadded:: 3.42
-%End
+:param authcfg: Optional authentication configuration ID.
 
-    QgsMimeDataUtils::Uri uri( const QString &authcfg ) const;
-%Docstring
-Returns a uri for the asset if it is a cloud optimized file like COG or
-COPC
+If the optional @authcfg parameter is set the authentication
+configuration ID will be encoded in the returned URI.
 
 .. versionadded:: 4.0
 %End

--- a/python/core/auto_generated/stac/qgsstacasset.sip.in
+++ b/python/core/auto_generated/stac/qgsstacasset.sip.in
@@ -89,15 +89,15 @@ COPC
 .. versionadded:: 3.42
 %End
 
-    QString toHtml() const;
-%Docstring
-Returns an HTML representation of the STAC Asset without an ID
-%End
-
     QString toHtml( const QString &assetId ) const;
 %Docstring
 Returns an HTML representation of the STAC Asset including its ID within
 its container
+%End
+
+    bool isDownloadable() const;
+%Docstring
+Returns whether the asset can be downloaded
 %End
 
 };

--- a/python/core/auto_generated/stac/qgsstacitem.sip.in
+++ b/python/core/auto_generated/stac/qgsstacitem.sip.in
@@ -82,14 +82,12 @@ Sets the item's additional metadata to ``properties``
 
     QMap< QString, QgsStacAsset > assets() const;
 %Docstring
-Returns a dictionary of asset objects that can be downloaded, each with
-a unique key.
+Returns a dictionary of asset objects, each with a unique key.
 %End
 
     void setAssets( const QMap< QString, QgsStacAsset > &assets );
 %Docstring
-Sets the ``asset`` objects that can be downloaded, each with a unique
-key.
+Sets the ``asset`` objects, each with a unique key.
 %End
 
     QString collection() const;

--- a/src/core/stac/qgsstacasset.cpp
+++ b/src/core/stac/qgsstacasset.cpp
@@ -78,11 +78,6 @@ QString QgsStacAsset::formatName() const
   return QString();
 }
 
-QgsMimeDataUtils::Uri QgsStacAsset::uri() const
-{
-  return uri( QString() );
-}
-
 
 QgsMimeDataUtils::Uri QgsStacAsset::uri( const QString &authcfg ) const
 {

--- a/src/core/stac/qgsstacasset.cpp
+++ b/src/core/stac/qgsstacasset.cpp
@@ -154,12 +154,6 @@ QgsMimeDataUtils::Uri QgsStacAsset::uri( QString authcfg ) const
   return uri;
 }
 
-
-QString QgsStacAsset::toHtml() const
-{
-  return toHtml( QString() );
-}
-
 QString QgsStacAsset::toHtml( const QString &assetId ) const
 {
   QString html = QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Asset" ) );
@@ -172,4 +166,21 @@ QString QgsStacAsset::toHtml( const QString &assetId ) const
   html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "roles" ), roles().join( ',' ) );
   html += QStringLiteral( "</table><br/>\n" );
   return html;
+}
+
+bool QgsStacAsset::isDownloadable() const
+{
+  /*
+   * Directory-based data types like Zarr should not offer downloads.
+   * Download attempts might
+   * - fail with 4xx,
+   * - succeed but download an HTML directory listing response, or
+   * - something else that does not meet the user's needs.
+   */
+  if ( formatName() == QLatin1String( "Zarr" ) )
+  {
+    return false;
+  }
+
+  return true;
 }

--- a/src/core/stac/qgsstacasset.cpp
+++ b/src/core/stac/qgsstacasset.cpp
@@ -80,6 +80,12 @@ QString QgsStacAsset::formatName() const
 
 QgsMimeDataUtils::Uri QgsStacAsset::uri() const
 {
+  return uri( QString() );
+}
+
+
+QgsMimeDataUtils::Uri QgsStacAsset::uri( QString authcfg ) const
+{
   QgsMimeDataUtils::Uri uri;
   QUrl url( href() );
   if ( formatName() == QLatin1String( "COG" ) )
@@ -90,6 +96,8 @@ QgsMimeDataUtils::Uri QgsStacAsset::uri() const
          href().startsWith( QLatin1String( "ftp" ), Qt::CaseInsensitive ) )
     {
       uri.uri = QStringLiteral( "/vsicurl/%1" ).arg( href() );
+      if ( !authcfg.isEmpty() )
+        uri.uri.append( QStringLiteral( " authcfg='%1'" ).arg( authcfg ) );
     }
     else if ( href().startsWith( QLatin1String( "s3://" ), Qt::CaseInsensitive ) )
     {
@@ -105,12 +113,16 @@ QgsMimeDataUtils::Uri QgsStacAsset::uri() const
     uri.layerType = QStringLiteral( "pointcloud" );
     uri.providerKey = QStringLiteral( "copc" );
     uri.uri = href();
+    if ( !authcfg.isEmpty() )
+      uri.uri.append( QStringLiteral( " authcfg='%1'" ).arg( authcfg ) );
   }
   else if ( formatName() == QLatin1String( "EPT" ) )
   {
     uri.layerType = QStringLiteral( "pointcloud" );
     uri.providerKey = QStringLiteral( "ept" );
     uri.uri = href();
+    if ( !authcfg.isEmpty() )
+      uri.uri.append( QStringLiteral( " authcfg='%1'" ).arg( authcfg ) );
   }
   else if ( formatName() == QLatin1String( "Zarr" ) )
   {
@@ -120,6 +132,8 @@ QgsMimeDataUtils::Uri QgsStacAsset::uri() const
          href().startsWith( QLatin1String( "ftp" ), Qt::CaseInsensitive ) )
     {
       uri.uri = QStringLiteral( "ZARR:\"/vsicurl/%1\"" ).arg( href() );
+      if ( !authcfg.isEmpty() )
+        uri.uri.append( QStringLiteral( " authcfg='%1'" ).arg( authcfg ) );
     }
     else if ( href().startsWith( QLatin1String( "s3://" ), Qt::CaseInsensitive ) )
     {

--- a/src/core/stac/qgsstacasset.cpp
+++ b/src/core/stac/qgsstacasset.cpp
@@ -153,3 +153,23 @@ QgsMimeDataUtils::Uri QgsStacAsset::uri( QString authcfg ) const
 
   return uri;
 }
+
+
+QString QgsStacAsset::toHtml() const
+{
+  return toHtml( QString() );
+}
+
+QString QgsStacAsset::toHtml( const QString &assetId ) const
+{
+  QString html = QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Asset" ) );
+  html += QStringLiteral( "<table class=\"list-view\">\n" );
+  html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "id" ), assetId );
+  html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "title" ), title() );
+  html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "description" ), description() );
+  html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td><a href=\"%2\">%2</a></td></tr>\n" ).arg( QStringLiteral( "url" ), href() );
+  html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "type" ), mediaType() );
+  html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "roles" ), roles().join( ',' ) );
+  html += QStringLiteral( "</table><br/>\n" );
+  return html;
+}

--- a/src/core/stac/qgsstacasset.cpp
+++ b/src/core/stac/qgsstacasset.cpp
@@ -60,7 +60,8 @@ bool QgsStacAsset::isCloudOptimized() const
   const QString format = formatName();
   return format == QLatin1String( "COG" ) ||
          format == QLatin1String( "COPC" ) ||
-         format == QLatin1String( "EPT" );
+         format == QLatin1String( "EPT" ) ||
+         format == QLatin1String( "Zarr" );
 }
 
 QString QgsStacAsset::formatName() const
@@ -72,6 +73,8 @@ QString QgsStacAsset::formatName() const
     return QStringLiteral( "COPC" );
   else if ( mHref.endsWith( QLatin1String( "/ept.json" ) ) )
     return QStringLiteral( "EPT" );
+  else if ( mMediaType == QLatin1String( "application/vnd+zarr" ) )
+    return QStringLiteral( "Zarr" );
   return QString();
 }
 
@@ -108,6 +111,24 @@ QgsMimeDataUtils::Uri QgsStacAsset::uri() const
     uri.layerType = QStringLiteral( "pointcloud" );
     uri.providerKey = QStringLiteral( "ept" );
     uri.uri = href();
+  }
+  else if ( formatName() == QLatin1String( "Zarr" ) )
+  {
+    uri.layerType = QStringLiteral( "raster" );
+    uri.providerKey = QStringLiteral( "gdal" );
+    if ( href().startsWith( QLatin1String( "http" ), Qt::CaseInsensitive ) ||
+         href().startsWith( QLatin1String( "ftp" ), Qt::CaseInsensitive ) )
+    {
+      uri.uri = QStringLiteral( "ZARR:\"/vsicurl/%1\"" ).arg( href() );
+    }
+    else if ( href().startsWith( QLatin1String( "s3://" ), Qt::CaseInsensitive ) )
+    {
+      uri.uri = QStringLiteral( "ZARR:\"/vsis3/%1\"" ).arg( href().mid( 5 ) );
+    }
+    else
+    {
+      uri.uri = href();
+    }
   }
   else
   {

--- a/src/core/stac/qgsstacasset.cpp
+++ b/src/core/stac/qgsstacasset.cpp
@@ -84,7 +84,7 @@ QgsMimeDataUtils::Uri QgsStacAsset::uri() const
 }
 
 
-QgsMimeDataUtils::Uri QgsStacAsset::uri( QString authcfg ) const
+QgsMimeDataUtils::Uri QgsStacAsset::uri( const QString &authcfg ) const
 {
   QgsMimeDataUtils::Uri uri;
   QUrl url( href() );

--- a/src/core/stac/qgsstacasset.cpp
+++ b/src/core/stac/qgsstacasset.cpp
@@ -137,6 +137,7 @@ QgsMimeDataUtils::Uri QgsStacAsset::uri( const QString &authcfg ) const
     }
     else if ( href().startsWith( QLatin1String( "s3://" ), Qt::CaseInsensitive ) )
     {
+      // Remove the s3:// protocol prefix for compatibility with GDAL's /vsis3
       uri.uri = QStringLiteral( "ZARR:\"/vsis3/%1\"" ).arg( href().mid( 5 ) );
     }
     else

--- a/src/core/stac/qgsstacasset.h
+++ b/src/core/stac/qgsstacasset.h
@@ -75,11 +75,11 @@ class CORE_EXPORT QgsStacAsset
     /**
      * Returns a uri for the asset if it is a cloud optimized file like COG or COPC.
      *
-     * \param authcfg Optional authentication configuration ID.
+     * \param authcfg Optional authentication configuration ID (since QGIS 4.0).
      *
      * If the optional @authcfg parameter is set the authentication configuration ID will be encoded in the returned URI.
      *
-     * \since QGIS 4.0
+     * \since QGIS 3.42
      */
     QgsMimeDataUtils::Uri uri( const QString &authcfg = QString() ) const;
 
@@ -90,7 +90,7 @@ class CORE_EXPORT QgsStacAsset
     QString toHtml( const QString &assetId ) const;
 
     /**
-     * Returns whether the asset can be downloaded
+     * Returns whether the asset can be downloaded.
      * \since QGIS 4.0
      */
     bool isDownloadable() const;

--- a/src/core/stac/qgsstacasset.h
+++ b/src/core/stac/qgsstacasset.h
@@ -84,6 +84,16 @@ class CORE_EXPORT QgsStacAsset
      */
     QgsMimeDataUtils::Uri uri( QString authcfg ) const;
 
+    /**
+     * Returns an HTML representation of the STAC Asset without an ID
+     */
+    QString toHtml() const;
+
+    /**
+     * Returns an HTML representation of the STAC Asset including its ID within its container
+     */
+    QString toHtml( const QString &assetId ) const;
+
   private:
     QString mHref;
     QString mTitle;

--- a/src/core/stac/qgsstacasset.h
+++ b/src/core/stac/qgsstacasset.h
@@ -73,10 +73,16 @@ class CORE_EXPORT QgsStacAsset
     QString formatName() const;
 
     /**
-     * Returns a uri for the asset if it is a cloud optimized file like COG or COPC
+     * Returns a uri for the asset if it is a cloud optimized file like COG or COPC, empty auth configuration
      * \since QGIS 3.42
      */
     QgsMimeDataUtils::Uri uri() const;
+
+    /**
+     * Returns a uri for the asset if it is a cloud optimized file like COG or COPC
+     * \since QGIS 3.42
+     */
+    QgsMimeDataUtils::Uri uri( QString authcfg ) const;
 
   private:
     QString mHref;

--- a/src/core/stac/qgsstacasset.h
+++ b/src/core/stac/qgsstacasset.h
@@ -80,7 +80,7 @@ class CORE_EXPORT QgsStacAsset
 
     /**
      * Returns a uri for the asset if it is a cloud optimized file like COG or COPC
-     * \since QGIS 3.42
+     * \since QGIS 4.0
      */
     QgsMimeDataUtils::Uri uri( const QString &authcfg ) const;
 

--- a/src/core/stac/qgsstacasset.h
+++ b/src/core/stac/qgsstacasset.h
@@ -73,16 +73,15 @@ class CORE_EXPORT QgsStacAsset
     QString formatName() const;
 
     /**
-     * Returns a uri for the asset if it is a cloud optimized file like COG or COPC, empty auth configuration
-     * \since QGIS 3.42
-     */
-    QgsMimeDataUtils::Uri uri() const;
-
-    /**
-     * Returns a uri for the asset if it is a cloud optimized file like COG or COPC
+     * Returns a uri for the asset if it is a cloud optimized file like COG or COPC.
+     *
+     * \param authcfg Optional authentication configuration ID.
+     *
+     * If the optional @authcfg parameter is set the authentication configuration ID will be encoded in the returned URI.
+     *
      * \since QGIS 4.0
      */
-    QgsMimeDataUtils::Uri uri( const QString &authcfg ) const;
+    QgsMimeDataUtils::Uri uri( const QString &authcfg = QString() ) const;
 
     /**
      * Returns an HTML representation of the STAC Asset including its ID within its container

--- a/src/core/stac/qgsstacasset.h
+++ b/src/core/stac/qgsstacasset.h
@@ -85,14 +85,14 @@ class CORE_EXPORT QgsStacAsset
     QgsMimeDataUtils::Uri uri( QString authcfg ) const;
 
     /**
-     * Returns an HTML representation of the STAC Asset without an ID
-     */
-    QString toHtml() const;
-
-    /**
      * Returns an HTML representation of the STAC Asset including its ID within its container
      */
     QString toHtml( const QString &assetId ) const;
+
+    /**
+     * Returns whether the asset can be downloaded
+     */
+    bool isDownloadable() const;
 
   private:
     QString mHref;

--- a/src/core/stac/qgsstacasset.h
+++ b/src/core/stac/qgsstacasset.h
@@ -86,11 +86,13 @@ class CORE_EXPORT QgsStacAsset
 
     /**
      * Returns an HTML representation of the STAC Asset including its ID within its container
+     * \since QGIS 4.0
      */
     QString toHtml( const QString &assetId ) const;
 
     /**
      * Returns whether the asset can be downloaded
+     * \since QGIS 4.0
      */
     bool isDownloadable() const;
 

--- a/src/core/stac/qgsstacasset.h
+++ b/src/core/stac/qgsstacasset.h
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsStacAsset
      * Returns a uri for the asset if it is a cloud optimized file like COG or COPC
      * \since QGIS 3.42
      */
-    QgsMimeDataUtils::Uri uri( QString authcfg ) const;
+    QgsMimeDataUtils::Uri uri( const QString &authcfg ) const;
 
     /**
      * Returns an HTML representation of the STAC Asset including its ID within its container

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -69,7 +69,12 @@ bool QgsStacAssetItem::equal( const QgsDataItem * )
 
 void QgsStacAssetItem::updateToolTip()
 {
-  mToolTip = QStringLiteral( "STAC Asset:\n%1\n%2" ).arg( mName, mStacAsset->title() );
+  QString title = mStacAsset->title();
+  if ( title.isNull() || title.isEmpty() )
+  {
+    title = mName;
+  }
+  mToolTip = QStringLiteral( "STAC Asset:\n%1\n%2" ).arg( title, mStacAsset->href() );
 }
 
 //

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -36,7 +36,7 @@ QgsStacAssetItem::QgsStacAssetItem( QgsDataItem *parent, const QString &name, co
     mStacAsset( asset ),
     mName( name )
 {
-  mIconName = QStringLiteral( "mActionPropertiesWidget.svg" );
+  mIconName = mStacAsset->isCloudOptimized() ? QStringLiteral( "mActionAddLayer.svg" ) : QStringLiteral( "downloading_svg.svg" );
   updateToolTip();
   setState( Qgis::BrowserItemState::Populated );
 }

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -114,6 +114,7 @@ QgsStacItemItem::QgsStacItemItem( QgsDataItem *parent, const QString &name, cons
   : QgsDataItem( Qgis::BrowserItemType::Custom, parent, name.isEmpty() ? path : name, path, QStringLiteral( "special:Stac" ) )
 {
   mIconName = QStringLiteral( "mActionPropertiesWidget.svg" );
+  mCapabilities |= Qgis::BrowserItemCapability::Fast;
   updateToolTip();
 }
 
@@ -126,6 +127,7 @@ QVector<QgsDataItem *> QgsStacItemItem::createChildren()
   if ( !mStacItem )
     return { new QgsErrorItem( this, error, path() + QStringLiteral( "/error" ) ) };
 
+  setState( Qgis::BrowserItemState::Populating );
   QVector<QgsDataItem *> contents;
   contents.reserve( mStacItem->assets().size() );
   const QMap<QString, QgsStacAsset> assets = mStacItem->assets();
@@ -318,7 +320,6 @@ void QgsStacCatalogItem::childrenCreated()
       if ( item->state() != Qgis::BrowserItemState::NotPopulated )
         continue;
 
-      item->setIconName( QStringLiteral( "mActionIdentify.svg" ) );
       const int requestId = stacController()->fetchStacObjectAsync( item->path() );
       item->setProperty( "requestId", requestId );
     }
@@ -523,9 +524,7 @@ QVector< QgsDataItem * > QgsStacCatalogItem::createItems( const QVector<QgsStacI
 
     QgsStacItemItem *i = new QgsStacItemItem( this, name, item->url() );
     i->setStacItem( std::move( object ) );
-    // create any assets beneath the item, so that they can be individually drag-dropped as layers if compatible
-    i->populate( true );
-    i->setState( Qgis::BrowserItemState::Populated );
+    i->setState( Qgis::BrowserItemState::NotPopulated );
     contents.append( i );
   }
   return contents;

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -109,44 +109,10 @@ QgsMimeDataUtils::UriList QgsStacItemItem::mimeUris() const
     {
       uri.uri = it->href();
     }
-    else if ( it->mediaType() == QLatin1String( "image/tiff; application=geotiff; profile=cloud-optimized" ) ||
-              it->mediaType() == QLatin1String( "image/vnd.stac.geotiff; cloud-optimized=true" ) )
+    else
     {
-      uri.layerType = QStringLiteral( "raster" );
-      uri.providerKey = QStringLiteral( "gdal" );
-      if ( it->href().startsWith( QLatin1String( "http" ), Qt::CaseInsensitive ) ||
-           it->href().startsWith( QLatin1String( "ftp" ), Qt::CaseInsensitive ) )
-      {
-        uri.uri = QStringLiteral( "/vsicurl/%1" ).arg( it->href() );
-        if ( !authcfg.isEmpty() )
-          uri.uri.append( QStringLiteral( " authcfg='%1'" ).arg( authcfg ) );
-      }
-      else if ( it->href().startsWith( QLatin1String( "s3://" ), Qt::CaseInsensitive ) )
-      {
-        uri.uri = QStringLiteral( "/vsis3/%1" ).arg( it->href().mid( 5 ) );
-      }
-      else
-      {
-        uri.uri = it->href();
-      }
+      uri = it->uri( authcfg );
     }
-    else if ( it->mediaType() == QLatin1String( "application/vnd.laszip+copc" ) )
-    {
-      uri.layerType = QStringLiteral( "pointcloud" );
-      uri.providerKey = QStringLiteral( "copc" );
-      uri.uri = it->href();
-      if ( !authcfg.isEmpty() )
-        uri.uri.append( QStringLiteral( " authcfg='%1'" ).arg( authcfg ) );
-    }
-    else if ( it->href().endsWith( QLatin1String( "/ept.json" ) ) )
-    {
-      uri.layerType = QStringLiteral( "pointcloud" );
-      uri.providerKey = QStringLiteral( "ept" );
-      uri.uri = it->href();
-      if ( !authcfg.isEmpty() )
-        uri.uri.append( QStringLiteral( " authcfg='%1'" ).arg( authcfg ) );
-    }
-    uri.name = it->title().isEmpty() ? url.fileName() : it->title();
     uris.append( uri );
   }
 

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -22,6 +22,8 @@
 #include "qgsstacitemcollection.h"
 #include "qgsstaccollection.h"
 #include "qgsstaccollectionlist.h"
+#include "qgsprovidermetadata.h"
+#include "qgsproviderregistry.h"
 
 
 constexpr int MAX_DISPLAYED_ITEMS = 20;
@@ -36,7 +38,14 @@ QgsStacAssetItem::QgsStacAssetItem( QgsDataItem *parent, const QString &name, co
     mStacAsset( asset ),
     mName( name )
 {
-  mIconName = mStacAsset->isCloudOptimized() ? QStringLiteral( "mActionAddLayer.svg" ) : QStringLiteral( "downloading_svg.svg" );
+  if ( QgsProviderMetadata *metadata = QgsProviderRegistry::instance()->providerMetadata( asset->uri().providerKey ) )
+  {
+    mIcon = metadata->icon();
+  }
+  else
+  {
+    mIconName = QStringLiteral( "downloading_svg.svg" );
+  }
   updateToolTip();
   setState( Qgis::BrowserItemState::Populated );
 }

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -48,6 +48,9 @@ bool QgsStacAssetItem::hasDragEnabled() const
 
 QgsMimeDataUtils::UriList QgsStacAssetItem::mimeUris() const
 {
+  QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( parent() );
+  const QString authcfg = itemItem->stacController()->authCfg();
+
   QgsMimeDataUtils::Uri uri;
   QUrl url( mStacAsset->href() );
   if ( url.isLocalFile() )
@@ -56,7 +59,7 @@ QgsMimeDataUtils::UriList QgsStacAssetItem::mimeUris() const
   }
   else
   {
-    uri = mStacAsset->uri();
+    uri = mStacAsset->uri( authcfg );
   }
 
   return { uri };

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -174,17 +174,11 @@ QgsMimeDataUtils::UriList QgsStacItemItem::mimeUris() const
   const QMap<QString, QgsStacAsset> assets = mStacItem->assets();
   for ( auto it = assets.constBegin(); it != assets.constEnd(); ++it )
   {
-    QgsMimeDataUtils::Uri uri;
-    QUrl url( it->href() );
-    if ( url.isLocalFile() )
+    QgsMimeDataUtils::Uri uri = it->uri( authcfg );
+    if ( uri.isValid() )
     {
-      uri.uri = it->href();
+      uris.append( uri );
     }
-    else
-    {
-      uri = it->uri( authcfg );
-    }
-    uris.append( uri );
   }
 
   return uris;

--- a/src/core/stac/qgsstacdataitems.h
+++ b/src/core/stac/qgsstacdataitems.h
@@ -30,6 +30,29 @@ class QgsStacCollection;
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
+
+/**
+ * \brief Item for STAC Asset within a collection or item.
+ * \since QGIS 3.44
+*/
+class CORE_EXPORT QgsStacAssetItem : public QgsDataItem
+{
+    Q_OBJECT
+  public:
+    QgsStacAssetItem( QgsDataItem *parent, const QString &name, const QgsStacAsset *asset );
+
+    bool hasDragEnabled() const override;
+    QgsMimeDataUtils::UriList mimeUris() const override;
+    bool equal( const QgsDataItem *other ) override;
+    QVariant sortKey() const override { return QStringLiteral( "4 %1" ).arg( mName ); }
+
+    void updateToolTip();
+
+  private:
+    const QgsStacAsset *mStacAsset;
+    const QString mName;
+};
+
 /**
  * \brief Item to display that there are additional STAC items which are not loaded.
  * \since QGIS 3.40

--- a/src/core/stac/qgsstacdataitems.h
+++ b/src/core/stac/qgsstacdataitems.h
@@ -33,7 +33,7 @@ class QgsStacCollection;
 
 /**
  * \brief Item for STAC Asset within a collection or item.
- * \since QGIS 3.44
+ * \since QGIS 4.0
 */
 class CORE_EXPORT QgsStacAssetItem : public QgsDataItem
 {

--- a/src/core/stac/qgsstacdataitems.h
+++ b/src/core/stac/qgsstacdataitems.h
@@ -45,8 +45,8 @@ class CORE_EXPORT QgsStacAssetItem : public QgsDataItem
     QgsMimeDataUtils::UriList mimeUris() const override;
     bool equal( const QgsDataItem *other ) override;
     QVariant sortKey() const override { return QStringLiteral( "4 %1" ).arg( mName ); }
-
     void updateToolTip();
+    const QgsStacAsset *stacAsset() { return mStacAsset; }
 
   private:
     const QgsStacAsset *mStacAsset;

--- a/src/core/stac/qgsstacitem.cpp
+++ b/src/core/stac/qgsstacitem.cpp
@@ -38,9 +38,7 @@ Qgis::StacObjectType QgsStacItem::type() const
 
 QString QgsStacItem::toHtml() const
 {
-  QString html = QStringLiteral( "<html><head></head>\n<body>\n" );
-
-  html += QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Item" ) );
+  QString html = QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Item" ) );
   html += QLatin1String( "<table class=\"list-view\">\n" );
   html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "id" ), id() );
   html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "stac_version" ), stacVersion() );
@@ -95,18 +93,9 @@ QString QgsStacItem::toHtml() const
     html += QStringLiteral( "<h1>%1</h1>\n<hr>\n" ).arg( QLatin1String( "Assets" ) );
     for ( auto it = mAssets.constBegin(); it != mAssets.constEnd(); ++it )
     {
-      html += QLatin1String( "<table class=\"list-view\">\n" );
-      html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "id" ), it.key() );
-      html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "title" ), it->title() );
-      html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "description" ), it->description() );
-      html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td><a href=\"%2\">%2</a></td></tr>\n" ).arg( QStringLiteral( "url" ), it->href() );
-      html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "type" ), it->mediaType() );
-      html += QStringLiteral( "<tr><td class=\"highlight\">%1</td><td>%2</td></tr>\n" ).arg( QStringLiteral( "roles" ), it->roles().join( ',' ) );
-      html += QLatin1String( "</table><br/>\n" );
+      html += it->toHtml( it.key() );
     }
   }
-
-  html += QLatin1String( "\n</body>\n</html>\n" );
   return html;
 }
 

--- a/src/core/stac/qgsstacitem.h
+++ b/src/core/stac/qgsstacitem.h
@@ -76,10 +76,10 @@ class CORE_EXPORT QgsStacItem : public QgsStacObject
     //! Sets the item's additional metadata to \a properties
     void setProperties( const QVariantMap &properties );
 
-    //! Returns a dictionary of asset objects that can be downloaded, each with a unique key.
+    //! Returns a dictionary of asset objects, each with a unique key.
     QMap< QString, QgsStacAsset > assets() const;
 
-    //! Sets the \a asset objects that can be downloaded, each with a unique key.
+    //! Sets the \a asset objects, each with a unique key.
     void setAssets( const QMap< QString, QgsStacAsset > &assets );
 
     //! Returns the id of the STAC Collection this Item references to

--- a/src/gui/stac/qgsstacdataitemguiprovider.cpp
+++ b/src/gui/stac/qgsstacdataitemguiprovider.cpp
@@ -89,16 +89,17 @@ void QgsStacDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
     {
       menu->addSeparator();
 
-      int downloadableAssets = 0;
+      bool hasDownloadableAssets = false;
       const QMap<QString, QgsStacAsset> assets = itemItem->stacItem()->assets();
       for ( auto it = assets.constBegin(); it != assets.constEnd(); ++it )
       {
         if ( it.value().isDownloadable() )
         {
-          downloadableAssets += 1;
+          hasDownloadableAssets = true;
+          break;
         }
       }
-      if ( downloadableAssets > 0 )
+      if ( hasDownloadableAssets )
       {
         QAction *actionDownload = new QAction( tr( "Download Assets…" ), menu );
         connect( actionDownload, &QAction::triggered, this, [itemItem, context] { downloadAssets( itemItem, context ); } );

--- a/src/gui/stac/qgsstacdataitemguiprovider.cpp
+++ b/src/gui/stac/qgsstacdataitemguiprovider.cpp
@@ -188,36 +188,36 @@ void QgsStacDataItemGuiProvider::loadConnections( QgsDataItem *item )
 
 void QgsStacDataItemGuiProvider::showDetails( QgsDataItem *item )
 {
-  QgsStacObject *stacObj = nullptr;
   QString authcfg;
 
-  if ( QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( item ) )
+  QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( item );
+  QgsStacCatalogItem *catalogItem = qobject_cast<QgsStacCatalogItem *>( item );
+  QgsStacAssetItem *assetItem = qobject_cast<QgsStacAssetItem *>( item );
+
+  if ( !( itemItem || catalogItem || assetItem ) )
   {
-    stacObj = itemItem->stacItem();
-    authcfg = itemItem->stacController()->authCfg();
-  }
-  else if ( QgsStacCatalogItem *catalogItem = qobject_cast<QgsStacCatalogItem *>( item ) )
-  {
-    stacObj = catalogItem->stacCatalog();
-  }
-  if ( stacObj )
-  {
-    QgsStacObjectDetailsDialog d;
-    d.setAuthcfg( authcfg );
-    d.setContentFromStacObject( stacObj );
-    d.exec();
     return;
   }
 
-  if ( QgsStacAssetItem *assetItem = qobject_cast<QgsStacAssetItem *>( item ) )
+  QgsStacObjectDetailsDialog d;
+  if ( itemItem )
   {
-    QgsStacObjectDetailsDialog d;
-    QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( assetItem->parent() );
-    d.setAuthcfg( itemItem->stacController()->authCfg() );
-    d.setContentFromStacAsset( assetItem->name(), assetItem->stacAsset() );
-    d.exec();
-    return;
+    authcfg = itemItem->stacController()->authCfg();
+    d.setContentFromStacObject( itemItem->stacItem() );
   }
+  else if ( catalogItem )
+  {
+    d.setContentFromStacObject( catalogItem->stacCatalog() );
+  }
+  else if ( assetItem )
+  {
+    QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( assetItem->parent() );
+    authcfg = itemItem->stacController()->authCfg();
+    d.setContentFromStacAsset( assetItem->name(), assetItem->stacAsset() );
+  }
+  d.setAuthcfg( authcfg );
+  d.exec();
+  return;
 }
 
 void QgsStacDataItemGuiProvider::downloadAssets( QgsDataItem *item, QgsDataItemGuiContext context )

--- a/src/gui/stac/qgsstacdownloadassetsdialog.cpp
+++ b/src/gui/stac/qgsstacdownloadassetsdialog.cpp
@@ -150,23 +150,32 @@ void QgsStacDownloadAssetsDialog::setStacItem( QgsStacItem *stacItem )
   const QMap<QString, QgsStacAsset> assets = stacItem->assets();
   for ( auto it = assets.constBegin(); it != assets.constEnd(); ++it )
   {
-    QTreeWidgetItem *item = new QTreeWidgetItem();
-    item->setText( 0, it.key() );
-    item->setToolTip( 0, it.key() );
-    item->setCheckState( 0, Qt::Checked );
-    item->setText( 1, it->title() );
-    item->setToolTip( 1, it->title() );
-    item->setText( 2, it->description() );
-    item->setToolTip( 2, it->description() );
-    item->setText( 3, it->roles().join( "," ) );
-    item->setToolTip( 3, it->roles().join( "," ) );
-    item->setText( 4, it->mediaType() );
-    item->setToolTip( 4, it->mediaType() );
-    item->setText( 5, it->href() );
-    item->setToolTip( 5, it->href() );
-
-    mTreeWidget->addTopLevelItem( item );
+    if ( it.value().isDownloadable() )
+    {
+      addStacAsset( it.key(), &it.value() );
+    }
   }
+}
+
+void QgsStacDownloadAssetsDialog::addStacAsset( const QString &assetId, const QgsStacAsset *stacAsset )
+{
+  QTreeWidgetItem *item = new QTreeWidgetItem();
+
+  item->setText( 0, assetId );
+  item->setToolTip( 0, assetId );
+  item->setCheckState( 0, Qt::Checked );
+  item->setText( 1, stacAsset->title() );
+  item->setToolTip( 1, stacAsset->title() );
+  item->setText( 2, stacAsset->description() );
+  item->setToolTip( 2, stacAsset->description() );
+  item->setText( 3, stacAsset->roles().join( "," ) );
+  item->setToolTip( 3, stacAsset->roles().join( "," ) );
+  item->setText( 4, stacAsset->mediaType() );
+  item->setToolTip( 4, stacAsset->mediaType() );
+  item->setText( 5, stacAsset->href() );
+  item->setToolTip( 5, stacAsset->href() );
+
+  mTreeWidget->addTopLevelItem( item );
 }
 
 QString QgsStacDownloadAssetsDialog::selectedFolder()

--- a/src/gui/stac/qgsstacdownloadassetsdialog.h
+++ b/src/gui/stac/qgsstacdownloadassetsdialog.h
@@ -38,6 +38,7 @@ class QgsStacDownloadAssetsDialog : public QDialog, private Ui::QgsStacDownloadA
     void setAuthCfg( const QString &authCfg );
     void setMessageBar( QgsMessageBar *bar );
     void setStacItem( QgsStacItem *stacItem );
+    void addStacAsset( const QString &assetId, const QgsStacAsset *stacAsset );
     QString selectedFolder();
     QStringList selectedUrls();
 

--- a/src/gui/stac/qgsstacobjectdetailsdialog.cpp
+++ b/src/gui/stac/qgsstacobjectdetailsdialog.cpp
@@ -56,14 +56,14 @@ void QgsStacObjectDetailsDialog::setContentFromStacObject( QgsStacObject *stacOb
 }
 
 
-void QgsStacObjectDetailsDialog::setContentFromStacAsset( const QgsStacAsset *stacAsset )
+void QgsStacObjectDetailsDialog::setContentFromStacAsset( const QString &assetId, const QgsStacAsset *stacAsset )
 {
   QString thumbnailHtml = QString( "" );
   if ( isThumbnailAsset( stacAsset ) )
   {
     thumbnailHtml = thumbnailHtmlContent( stacAsset );
   }
-  QString bodyHtml = stacAsset->toHtml();
+  QString bodyHtml = stacAsset->toHtml( assetId );
   setContent( bodyHtml, thumbnailHtml );
 }
 

--- a/src/gui/stac/qgsstacobjectdetailsdialog.cpp
+++ b/src/gui/stac/qgsstacobjectdetailsdialog.cpp
@@ -31,7 +31,8 @@ QgsStacObjectDetailsDialog::QgsStacObjectDetailsDialog( QWidget *parent )
   QgsGui::enableAutoGeometryRestore( this );
 }
 
-void QgsStacObjectDetailsDialog::setStacObject( QgsStacObject *stacObject )
+
+void QgsStacObjectDetailsDialog::setContentFromStacObject( QgsStacObject *stacObject )
 {
   if ( !stacObject )
     return;
@@ -42,30 +43,40 @@ void QgsStacObjectDetailsDialog::setStacObject( QgsStacObject *stacObject )
     const QMap<QString, QgsStacAsset> assets = item->assets();
     for ( auto it = assets.constBegin(); it != assets.constEnd(); ++it )
     {
-      if ( it->roles().contains( QLatin1String( "thumbnail" ) ) )
+      if ( isThumbnailAsset( &it.value() ) )
       {
-        QString uri = it->href();
-        if ( !mAuthcfg.isEmpty() )
-        {
-          QStringList connectionItems;
-          connectionItems << uri;
-          if ( QgsApplication::authManager()->updateDataSourceUriItems( connectionItems, mAuthcfg ) )
-          {
-            uri = connectionItems.first();
-          }
-        }
-
-        thumbnails.append( QStringLiteral( "<img src=\"%1\" border=1><br>" ).arg( uri ) );
+        thumbnails.append( thumbnailHtmlContent( &it.value() ) );
       }
     }
   }
 
-  const QString myStyle = QgsApplication::reportStyleSheet( QgsApplication::StyleSheetType::WebBrowser );
-  // inject thumbnails
-  QString html = stacObject->toHtml().replace( QLatin1String( "<head>" ), QStringLiteral( "<head>\n%1" ).arg( thumbnails.join( QString() ) ) );
-  // inject stylesheet
-  html = html.replace( QLatin1String( "<head>" ), QStringLiteral( R"raw(<head><style type="text/css">%1</style>)raw" ) ).arg( myStyle );
+  QString thumbnailHtml = thumbnails.join( QString() );
+  QString bodyHtml = stacObject->toHtml();
+  setContent( bodyHtml, thumbnailHtml );
+}
 
+
+void QgsStacObjectDetailsDialog::setContentFromStacAsset( const QgsStacAsset *stacAsset )
+{
+  QString thumbnailHtml = QString( "" );
+  if ( isThumbnailAsset( stacAsset ) )
+  {
+    thumbnailHtml = thumbnailHtmlContent( stacAsset );
+  }
+  QString bodyHtml = stacAsset->toHtml();
+  setContent( bodyHtml, thumbnailHtml );
+}
+
+
+void QgsStacObjectDetailsDialog::setContent( QString bodyHtml, QString thumbnailHtml )
+{
+  const QString myStyle = QgsApplication::reportStyleSheet( QgsApplication::StyleSheetType::WebBrowser );
+  QString html = QStringLiteral( "<html>\n<head>\n" );
+  html += QStringLiteral( "<style type=\"text/css\">%1</style>\n" ).arg( myStyle );
+  html += QStringLiteral( "%1\n" ).arg( thumbnailHtml );
+  html += QStringLiteral( "</head>\n<body>\n" );
+  html += QStringLiteral( "%1\n" ).arg( bodyHtml );
+  html += QLatin1String( "</body>\n</html>\n" );
   mWebView->page()->setLinkDelegationPolicy( QWebPage::LinkDelegationPolicy::DelegateAllLinks );
   connect( mWebView, &QgsWebView::linkClicked, this, []( const QUrl &url ) {
     QDesktopServices::openUrl( url );
@@ -76,6 +87,26 @@ void QgsStacObjectDetailsDialog::setStacObject( QgsStacObject *stacObject )
 void QgsStacObjectDetailsDialog::setAuthcfg( const QString &authcfg )
 {
   mAuthcfg = authcfg;
+}
+
+bool QgsStacObjectDetailsDialog::isThumbnailAsset( const QgsStacAsset *stacAsset )
+{
+  return stacAsset->roles().contains( QLatin1String( "thumbnail" ) );
+}
+
+QString QgsStacObjectDetailsDialog::thumbnailHtmlContent( const QgsStacAsset *stacAsset )
+{
+  QString uri = stacAsset->href();
+  if ( !mAuthcfg.isEmpty() )
+  {
+    QStringList connectionItems;
+    connectionItems << uri;
+    if ( QgsApplication::authManager()->updateDataSourceUriItems( connectionItems, mAuthcfg ) )
+    {
+      uri = connectionItems.first();
+    }
+  }
+  return QStringLiteral( "<img src=\"%1\" border=1><br>" ).arg( uri );
 }
 
 ///@endcond

--- a/src/gui/stac/qgsstacobjectdetailsdialog.cpp
+++ b/src/gui/stac/qgsstacobjectdetailsdialog.cpp
@@ -58,12 +58,8 @@ void QgsStacObjectDetailsDialog::setContentFromStacObject( QgsStacObject *stacOb
 
 void QgsStacObjectDetailsDialog::setContentFromStacAsset( const QString &assetId, const QgsStacAsset *stacAsset )
 {
-  QString thumbnailHtml;
-  if ( isThumbnailAsset( stacAsset ) )
-  {
-    thumbnailHtml = thumbnailHtmlContent( stacAsset );
-  }
-  QString bodyHtml = stacAsset->toHtml( assetId );
+  const QString thumbnailHtml = isThumbnailAsset( stacAsset ) ? thumbnailHtmlContent( stacAsset ) : QString();
+  const QString bodyHtml = stacAsset->toHtml( assetId );
   setContent( bodyHtml, thumbnailHtml );
 }
 

--- a/src/gui/stac/qgsstacobjectdetailsdialog.cpp
+++ b/src/gui/stac/qgsstacobjectdetailsdialog.cpp
@@ -50,8 +50,8 @@ void QgsStacObjectDetailsDialog::setContentFromStacObject( QgsStacObject *stacOb
     }
   }
 
-  QString thumbnailHtml = thumbnails.join( QString() );
-  QString bodyHtml = stacObject->toHtml();
+  const QString thumbnailHtml = thumbnails.join( QString() );
+  const QString bodyHtml = stacObject->toHtml();
   setContent( bodyHtml, thumbnailHtml );
 }
 

--- a/src/gui/stac/qgsstacobjectdetailsdialog.cpp
+++ b/src/gui/stac/qgsstacobjectdetailsdialog.cpp
@@ -58,7 +58,7 @@ void QgsStacObjectDetailsDialog::setContentFromStacObject( QgsStacObject *stacOb
 
 void QgsStacObjectDetailsDialog::setContentFromStacAsset( const QString &assetId, const QgsStacAsset *stacAsset )
 {
-  QString thumbnailHtml = QString( "" );
+  QString thumbnailHtml;
   if ( isThumbnailAsset( stacAsset ) )
   {
     thumbnailHtml = thumbnailHtmlContent( stacAsset );

--- a/src/gui/stac/qgsstacobjectdetailsdialog.h
+++ b/src/gui/stac/qgsstacobjectdetailsdialog.h
@@ -19,6 +19,7 @@
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
+#include "qgsstacasset.h"
 #include "qgsstacobject.h"
 #include "ui_qgsstacobjectdetailsdialog.h"
 
@@ -31,12 +32,16 @@ class QgsStacObjectDetailsDialog : public QDialog, private Ui::QgsStacObjectDeta
   public:
     explicit QgsStacObjectDetailsDialog( QWidget *parent = nullptr );
 
-    void setStacObject( QgsStacObject *stacObject );
-
     void setAuthcfg( const QString &authcfg );
+
+    void setContentFromStacObject( QgsStacObject *stacObject );
+    void setContentFromStacAsset( const QgsStacAsset *stacAsset );
 
   private:
     QString mAuthcfg;
+    void setContent( QString bodyHtml, QString thumbnailHtml );
+    bool isThumbnailAsset( const QgsStacAsset *stacAsset );
+    QString thumbnailHtmlContent( const QgsStacAsset *stacAsset );
 };
 
 ///@endcond

--- a/src/gui/stac/qgsstacobjectdetailsdialog.h
+++ b/src/gui/stac/qgsstacobjectdetailsdialog.h
@@ -19,11 +19,12 @@
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
-#include "qgsstacasset.h"
-#include "qgsstacobject.h"
 #include "ui_qgsstacobjectdetailsdialog.h"
 
 #include <QDialog>
+
+class QgsStacAsset;
+class QgsStacObject;
 
 class QgsStacObjectDetailsDialog : public QDialog, private Ui::QgsStacObjectDetailsDialog
 {

--- a/src/gui/stac/qgsstacobjectdetailsdialog.h
+++ b/src/gui/stac/qgsstacobjectdetailsdialog.h
@@ -35,7 +35,7 @@ class QgsStacObjectDetailsDialog : public QDialog, private Ui::QgsStacObjectDeta
     void setAuthcfg( const QString &authcfg );
 
     void setContentFromStacObject( QgsStacObject *stacObject );
-    void setContentFromStacAsset( const QgsStacAsset *stacAsset );
+    void setContentFromStacAsset( const QString &assetId, const QgsStacAsset *stacAsset );
 
   private:
     QString mAuthcfg;

--- a/src/gui/stac/qgsstacsourceselect.cpp
+++ b/src/gui/stac/qgsstacsourceselect.cpp
@@ -142,7 +142,7 @@ void QgsStacSourceSelect::showItemDetails( const QModelIndex &index )
 {
   QgsStacObjectDetailsDialog details( this );
   details.setAuthcfg( mStac->authCfg() );
-  details.setStacObject( index.data( QgsStacItemListModel::Role::StacObject ).value<QgsStacObject *>() );
+  details.setContentFromStacObject( index.data( QgsStacItemListModel::Role::StacObject ).value<QgsStacObject *>() );
   details.exec();
 }
 

--- a/tests/src/core/testqgsstac.cpp
+++ b/tests/src/core/testqgsstac.cpp
@@ -172,11 +172,13 @@ void TestQgsStac::testParseLocalItem()
   QCOMPARE( item->description(), QStringLiteral( "A sample STAC Item that includes examples of all common metadata" ) );
 
   const QgsMimeDataUtils::UriList uris = item->uris();
-  QCOMPARE( uris.size(), 2 );
-  QCOMPARE( uris.first().uri, QStringLiteral( "file://%1%2" ).arg( mDataDir, QStringLiteral( "20201211_223832_CS2_analytic.tif" ) ) );
-  QCOMPARE( uris.first().name, QStringLiteral( "4-Band Analytic" ) );
-  QCOMPARE( uris.last().uri, QStringLiteral( "/vsicurl/https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.tif" ) );
-  QCOMPARE( uris.last().name, QStringLiteral( "3-Band Visual" ) );
+  QCOMPARE( uris.size(), 3 );
+  QCOMPARE( uris.at( 0 ).uri, QStringLiteral( "file://%1%2" ).arg( mDataDir, QStringLiteral( "20201211_223832_CS2_analytic.tif" ) ) );
+  QCOMPARE( uris.at( 0 ).name, QStringLiteral( "4-Band Analytic" ) );
+  QCOMPARE( uris.at( 1 ).uri, QStringLiteral( "/vsicurl/https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.tif" ) );
+  QCOMPARE( uris.at( 1 ).name, QStringLiteral( "3-Band Visual" ) );
+  QCOMPARE( uris.at( 2 ).uri, QStringLiteral( "ZARR:\"/vsicurl/https://objectstore.eodc.eu:2222/e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/22/products/cpm_v256/S2B_MSIL2A_20250522T125039_N0511_R095_T26TML_20250522T133252.zarr\"" ) );
+  QCOMPARE( uris.at( 2 ).name, QStringLiteral( "Example Zarr Store" ) );
 
   // check that relative links are correctly resolved into absolute links
   const QVector<QgsStacLink> links = item->links();
@@ -187,7 +189,7 @@ void TestQgsStac::testParseLocalItem()
   QCOMPARE( links.at( 2 ).href(), QStringLiteral( "%1collection.json" ).arg( basePath ) );
   QCOMPARE( links.at( 3 ).href(), QStringLiteral( "http://remotedata.io/catalog/20201211_223832_CS2/index.html" ) );
 
-  QCOMPARE( item->assets().size(), 6 );
+  QCOMPARE( item->assets().size(), 7 );
   QgsStacAsset asset = item->assets().value( QStringLiteral( "analytic" ), QgsStacAsset( {}, {}, {}, {}, {} ) );
   QCOMPARE( asset.href(), basePath + QStringLiteral( "20201211_223832_CS2_analytic.tif" ) );
   QVERIFY( asset.isCloudOptimized() );
@@ -214,6 +216,12 @@ void TestQgsStac::testParseLocalItem()
   QVERIFY( !uri.isValid() );
   QVERIFY( uri.uri.isEmpty() );
   QVERIFY( uri.name.isEmpty() );
+
+  // Zarr recognised as cloud optimized
+  asset = item->assets().value( QStringLiteral( "zarr-store" ), QgsStacAsset( {}, {}, {}, {}, {} ) );
+  QVERIFY( asset.isCloudOptimized() );
+  QCOMPARE( asset.formatName(), QStringLiteral( "Zarr" ) );
+  QCOMPARE( asset.uri().layerType, QStringLiteral( "raster" ) );
 }
 
 void TestQgsStac::testParseLocalItemCollection()

--- a/tests/src/core/testqgsstac.cpp
+++ b/tests/src/core/testqgsstac.cpp
@@ -194,6 +194,7 @@ void TestQgsStac::testParseLocalItem()
   QCOMPARE( asset.href(), basePath + QStringLiteral( "20201211_223832_CS2_analytic.tif" ) );
   QVERIFY( asset.isCloudOptimized() );
   QCOMPARE( asset.formatName(), QStringLiteral( "COG" ) );
+  QVERIFY( asset.isDownloadable() );
 
   QgsMimeDataUtils::Uri uri = asset.uri();
   QCOMPARE( uri.uri, basePath + QStringLiteral( "20201211_223832_CS2_analytic.tif" ) );
@@ -207,6 +208,7 @@ void TestQgsStac::testParseLocalItem()
   QVERIFY( !uri.isValid() );
   QVERIFY( uri.uri.isEmpty() );
   QVERIFY( uri.name.isEmpty() );
+  QVERIFY( asset.isDownloadable() );
 
   // normal geotiff is not cloud optimized
   asset = item->assets().value( QStringLiteral( "udm" ), QgsStacAsset( {}, {}, {}, {}, {} ) );
@@ -216,12 +218,14 @@ void TestQgsStac::testParseLocalItem()
   QVERIFY( !uri.isValid() );
   QVERIFY( uri.uri.isEmpty() );
   QVERIFY( uri.name.isEmpty() );
+  QVERIFY( asset.isDownloadable() );
 
   // Zarr recognised as cloud optimized
   asset = item->assets().value( QStringLiteral( "zarr-store" ), QgsStacAsset( {}, {}, {}, {}, {} ) );
   QVERIFY( asset.isCloudOptimized() );
   QCOMPARE( asset.formatName(), QStringLiteral( "Zarr" ) );
   QCOMPARE( asset.uri().layerType, QStringLiteral( "raster" ) );
+  QVERIFY( !asset.isDownloadable() );
 }
 
 void TestQgsStac::testParseLocalItemCollection()

--- a/tests/testdata/stac/core-item.json
+++ b/tests/testdata/stac/core-item.json
@@ -120,6 +120,15 @@
     "ephemeris": {
       "href": "http://cool-sat.com/catalog/20201211_223832_CS2/20201211_223832_CS2.EPH",
       "title": "Satellite Ephemeris Metadata"
+    },
+    "zarr-store": {
+      "href": "https://objectstore.eodc.eu:2222/e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/22/products/cpm_v256/S2B_MSIL2A_20250522T125039_N0511_R095_T26TML_20250522T133252.zarr",
+      "title": "Example Zarr Store",
+      "type": "application/vnd+zarr",
+      "roles": [
+        "data",
+        "metadata"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Description

Closes #62838 

Incorporates the following changes.

### sip

Updated sip.in files by running `sipify_all.sh` script (which generates some changes not directly triggered by this change).

### Cloud-Optimised

Recognised Zarr as a cloud-optimised media type in QgsStacAsset logic and added Zarr handling logic in the `uri` function to correctly prefix STAC Asset `href`s with `ZARR:/vsicurl/` so that Zarr STAC Assets can be added as layers.

<img width="1143" height="882" alt="qgis-stac-asset-drag-drop-layer" src="https://github.com/user-attachments/assets/ef45201f-d500-4a5b-9f62-e367e5638e3f" />

### Assets in Browser Pane

Added a further nesting beneath STAC Items in the Browser pane showing assets. This allows individual cloud-optimised STAC Assets to be drag-dropped into the Layers pane. Previously only STAC Items could be drag-dropped into the Layers pane if they contained at least one cloud-optimised STAC Asset, at which point *all* of the STAC Item's cloud-optimised STAC Assets were added to the Layers pane. This change adds greater flexibility and better supports STAC Items with many cloud-optimised STAC Assets.

<img width="1143" height="882" alt="qgis-stac-assets-with-tooltip" src="https://github.com/user-attachments/assets/bcd162d1-0f08-4ba0-a6d5-0932fd8c520a" />

---

> [!NOTE]
> As part of this change logic to generate HTML representations of STAC Assets for STAC Items' Details modal was extracted to a separate function so that individual STAC Assets can have their own Details modal.
>
> <img width="1143" height="882" alt="qgis-stac-asset-details" src="https://github.com/user-attachments/assets/20e617c5-12af-45cb-b8eb-9effe3e69e45" />


### Downloadable Assets

Added `QgsStacAsset::isDownloadable` to determine if assets should provide a download option. Zarr assets should not be offered for download as the STAC Asset's `href` points to a directory rather than a data file or archive. Zarr download attempts in QGIS will either fail with 4xx or download a directory listing response.

<img width="1143" height="882" alt="qgis-stac-item-downloadable-assets" src="https://github.com/user-attachments/assets/3d8bfff2-c4a3-41f6-a2ff-9e3cac28d0e8" />

### DRY

Removed duplication in STAC Asset handling logic.

> [!NOTE]
> Prior to this change logic in the QgsStacAsset class was duplicated in QgsStacItemItem and this change includes a DRY consolidation. The QgsStacAsset class's [`formatName` function](https://github.com/qgis/QGIS/blob/33cebb73e33fa37858f3098fe107bfb32f7f5023/src/core/stac/qgsstacasset.cpp#L66) and [`uri` function](https://github.com/qgis/QGIS/blob/33cebb73e33fa37858f3098fe107bfb32f7f5023/src/core/stac/qgsstacasset.cpp#L78) were effecitvely duplicated in the QgsStacItemItem class's [`mimeUris` function](https://github.com/qgis/QGIS/blob/33cebb73e33fa37858f3098fe107bfb32f7f5023/src/core/stac/qgsstacdataitems.cpp#L94). The QgsStacItemItem has been changed to reference the consolidated logic. Commit [fa4192dbe9bda7c4aa721500ca9f8ca0523abaa6](https://github.com/qgis/QGIS/commit/fa4192dbe9bda7c4aa721500ca9f8ca0523abaa6) added auth handling to `QgsStacItemItem::mimeUris` but not to `QgsStacAsset::uri`. This DRY consolidation implements the same auth handling in `QgsStacAsset::uri`, which is why the PR shows that function being edited.

