### PR TITLE
Make layout scalebar "map units" choice more user-friendly

### DIFF
--- a/src/gui/layout/qgslayoutscalebarwidget.cpp
+++ b/src/gui/layout/qgslayoutscalebarwidget.cpp
@@ -118,7 +118,8 @@ QgsLayoutScaleBarWidget::QgsLayoutScaleBarWidget( QgsLayoutItemScaleBar *scaleBa
   mAlignmentComboBox->setAvailableAlignments( Qt::AlignLeft | Qt::AlignHCenter | Qt::AlignRight );
 
   //units combo box
-  mUnitsComboBox->addItem( tr( "Map units" ), static_cast<int>( Qgis::DistanceUnit::Unknown ) );
+
+  mUnitsComboBox->addItem( linkedMapUnitsString( scaleBar ), static_cast<int>( Qgis::DistanceUnit::Unknown ) );
   mUnitsComboBox->addItem( tr( "Meters" ), static_cast<int>( Qgis::DistanceUnit::Meters ) );
   mUnitsComboBox->addItem( tr( "Kilometers" ), static_cast<int>( Qgis::DistanceUnit::Kilometers ) );
   mUnitsComboBox->addItem( tr( "Feet" ), static_cast<int>( Qgis::DistanceUnit::Feet ) );
@@ -823,6 +824,8 @@ void QgsLayoutScaleBarWidget::mapChanged( QgsLayoutItem *item )
   mScalebar->update();
   connectUpdateSignal();
   mScalebar->endCommand();
+
+  mUnitsComboBox->setItemText( mUnitsComboBox->findData( static_cast<int>( Qgis::DistanceUnit::Unknown ) ), linkedMapUnitsString( mScalebar ) );
 }
 
 void QgsLayoutScaleBarWidget::mMinWidthSpinBox_valueChanged( double )
@@ -865,4 +868,21 @@ void QgsLayoutScaleBarWidget::populateDataDefinedButtons()
   updateDataDefinedButton( mHeightDDBtn );
   updateDataDefinedButton( mSubdivisionHeightDDBtn );
   updateDataDefinedButton( mRightSegmentSubdivisionsDDBtn );
+}
+
+QString QgsLayoutScaleBarWidget::linkedMapUnitsString( QgsLayoutItemScaleBar *scalebar )
+{
+  QString mapUnit;
+  if ( scalebar )
+  {
+    if ( QgsLayoutItemMap *map = scalebar->linkedMap() )
+    {
+      const Qgis::DistanceUnit mapCrsUnits = map->crs().mapUnits();
+      if ( mapCrsUnits != Qgis::DistanceUnit::Unknown )
+      {
+        mapUnit = QgsUnitTypes::toString( mapCrsUnits );
+      }
+    }
+  }
+  return mapUnit.isEmpty() ? tr( "Map Units" ) : tr( "Map Units (%1)" ).arg( mapUnit );
 }

--- a/src/gui/layout/qgslayoutscalebarwidget.h
+++ b/src/gui/layout/qgslayoutscalebarwidget.h
@@ -103,6 +103,8 @@ class GUI_EXPORT QgsLayoutScaleBarWidget : public QgsLayoutItemBaseWidget, publi
     void connectUpdateSignal();
     void disconnectUpdateSignal();
     void populateDataDefinedButtons();
+
+    static QString linkedMapUnitsString( QgsLayoutItemScaleBar *scalebar );
 };
 
 #endif //QGSLAYOUTSCALEBARWIDGET_H


### PR DESCRIPTION
Explicitly list the actual map units in the item text, eg "Map Units (meters)", so that users know exactly what unit the scalebar is using.

Refs https://www.reddit.com/r/QGIS/comments/1nsgbhz/why_is_my_scale_bar_not_working/
