### PR TITLE
[field calculator] Add map settings to the expression context

### DIFF
--- a/python/PyQt6/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/PyQt6/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -41,6 +41,12 @@ calculated.
          in case of geometry changes.
 %End
 
+    void appendScope( QgsExpressionContextScope *scope );
+%Docstring
+Appends an expression ``scope`` to the expression context of the field
+calculator, ownership is transferred to the field calculator.
+%End
+
   public slots:
     virtual void accept();
 

--- a/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -41,6 +41,12 @@ calculated.
          in case of geometry changes.
 %End
 
+    void appendScope( QgsExpressionContextScope *scope );
+%Docstring
+Appends an expression ``scope`` to the expression context of the field
+calculator, ownership is transferred to the field calculator.
+%End
+
   public slots:
     virtual void accept();
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7969,6 +7969,8 @@ void QgisApp::fieldCalculator()
   }
 
   QgsFieldCalculator calc( myLayer, this );
+  calc.appendScope( QgsExpressionContextUtils::mapSettingsScope( mMapCanvas->mapSettings() ) );
+
   if ( calc.exec() )
   {
     myLayer->triggerRepaint();

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -224,6 +224,15 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
     request.setFilterExpression( filterExpression );
   }
 
+  if ( mLayer && mLayer->isSpatial() )
+  {
+    QgsMapCanvas *mc = QgisApp::instance()->mapCanvas();
+    if ( mc )
+    {
+      request.expressionContext()->appendScope( QgsExpressionContextUtils::mapSettingsScope( mc->mapSettings() ) );
+    }
+  }
+
   // If sort expression requires geometry, we'll need to fetch it
   needsGeom |= mLayer && QgsExpression( mLayer->attributeTableConfig().sortExpression() ).needsGeometry();
   if ( !needsGeom )
@@ -656,6 +665,13 @@ void QgsAttributeTableDialog::mActionOpenFieldCalculator_triggered()
   QgsAttributeTableModel *masterModel = mMainView->masterModel();
 
   QgsFieldCalculator calc( mLayer, this );
+
+  // This may be required for virtual fields $length or $area
+  if ( const QgsMapCanvas *mapCanvas = QgisApp::instance()->mapCanvas() )
+  {
+    calc.appendScope( QgsExpressionContextUtils::mapSettingsScope( mapCanvas->mapSettings() ) );
+  }
+
   if ( calc.exec() == QDialog::Accepted )
   {
     int col = masterModel->fieldCol( calc.changedAttributeId() );

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -318,8 +318,16 @@ void QgsExpression::initGeomCalculator( const QgsExpressionContext *context )
   if ( context && distanceUnits() == Qgis::DistanceUnit::Unknown )
   {
     QString distanceUnitsStr = context->variable( QStringLiteral( "project_distance_units" ) ).toString();
+
     if ( ! distanceUnitsStr.isEmpty() )
       setDistanceUnits( QgsUnitTypes::stringToDistanceUnit( distanceUnitsStr ) );
+
+    if ( distanceUnits() == Qgis::DistanceUnit::Unknown )
+    {
+      distanceUnitsStr = context->variable( QStringLiteral( "map_units" ) ).toString();
+      if ( ! distanceUnitsStr.isEmpty() )
+        setDistanceUnits( QgsUnitTypes::stringToDistanceUnit( distanceUnitsStr ) );
+    }
   }
 
   // Set the area units from the context if it has not been set by setAreaUnits()

--- a/src/core/vector/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/vector/qgsvectorlayerfeatureiterator.cpp
@@ -1341,6 +1341,12 @@ void QgsVectorLayerFeatureIterator::createExpressionContext()
   mExpressionContext->appendScope( QgsExpressionContextUtils::projectScope( QgsProject::instance() ) ); // skip-keyword-check
   mExpressionContext->appendScope( new QgsExpressionContextScope( mSource->mLayerScope ) );
   mExpressionContext->setFeedback( mRequest.feedback() );
+  // We need to keep the map settings scope if set in the original context
+  const int settingsScopeIndex = mRequest.expressionContext()->indexOfScope( QStringLiteral( "Map Settings" ) );
+  if ( settingsScopeIndex != -1 )
+  {
+    mExpressionContext->appendScope( new QgsExpressionContextScope( *( mRequest.expressionContext()->scope( settingsScopeIndex ) ) ) );
+  }
 }
 
 bool QgsVectorLayerFeatureIterator::prepareOrderBy( const QList<QgsFeatureRequest::OrderByClause> &orderBys )

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -26,6 +26,7 @@
 #include "qgsfieldformatter.h"
 #include "qgslogger.h"
 #include "qgsmaplayeraction.h"
+#include "qgsmapcanvas.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
 #include "qgsfieldformatterregistry.h"

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -15,7 +15,6 @@
 
 #include <QMessageBox>
 
-
 #include "qgsfieldcalculator.h"
 #include "moc_qgsfieldcalculator.cpp"
 #include "qgsdistancearea.h"
@@ -174,6 +173,13 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
   setDialogButtonState();
 }
 
+void QgsFieldCalculator::appendScope( QgsExpressionContextScope *scope )
+{
+  QgsExpressionContext context { builder->expressionContext() };
+  context.appendScope( scope );
+  builder->setExpressionContext( context );
+}
+
 void QgsFieldCalculator::accept()
 {
   calculate();
@@ -199,7 +205,15 @@ void QgsFieldCalculator::calculate()
   exp.setDistanceUnits( QgsProject::instance()->distanceUnits() );
   exp.setAreaUnits( QgsProject::instance()->areaUnits() );
 
-  QgsExpressionContext expContext( QgsExpressionContextUtils::globalProjectLayerScopes( mVectorLayer ) );
+  QgsExpressionContext expContext;
+  if ( builder->expressionContext().scopeCount() > 0 )
+  {
+    expContext = builder->expressionContext();
+  }
+  else
+  {
+    expContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( mVectorLayer ) );
+  }
 
   if ( !exp.prepare( &expContext ) )
   {

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -20,6 +20,8 @@
 #include "qgshelp.h"
 #include "qgsfields.h"
 #include "qgis_gui.h"
+#include "qgsmapcanvas.h"
+#include "qgsexpressioncontext.h"
 
 class QgsVectorLayer;
 class QgsMessageBar;
@@ -52,6 +54,12 @@ class GUI_EXPORT QgsFieldCalculator : public QDialog, private Ui::QgsFieldCalcul
      * \returns The field index if attribute values were calculated or -1, e.g. in case of geometry changes.
      */
     int changedAttributeId() const { return mAttributeId; }
+
+    /**
+     * Appends an expression \a scope to the expression context of the field calculator, ownership is transferred to the
+     * field calculator.
+     */
+    void appendScope( QgsExpressionContextScope *scope );
 
   public slots:
     void accept() override;


### PR DESCRIPTION
When map units is not set in the project properties, they are supposed to be taken from the map canvas, but map canvas is not available inside the calculator (or the feature iterator), the fix is to pass the map settings down into the rabbit hole by attaching them to the expression context (in a similar way to what already happens with the project scope variables, with the notable exception that the project is actually available as a global instance while the map canvas is not).

Remaining issue: the settings are not available in the project properties field editor.

Fix #62883

Note: this was tricky, if anyone has a better idea on how to fix this in a better way please let me know and I will be happy to refactor this PR.

