### PR TITLE
Fix extension of GEOJSON link in QgsWfs3DescribeCollectionHandler

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerserverproperties.sip.in
@@ -282,6 +282,13 @@ layer.
 .. versionadded:: 3.38
 %End
 
+    QString wfsTypeName() const;
+%Docstring
+Returns WFS typename for the layer
+
+.. versionadded:: 4.0.0
+%End
+
     void setTitle( const QString &title );
 %Docstring
 Sets the ``title`` of the layer used by QGIS Server in GetCapabilities

--- a/python/core/auto_generated/qgsmaplayerserverproperties.sip.in
+++ b/python/core/auto_generated/qgsmaplayerserverproperties.sip.in
@@ -282,6 +282,13 @@ layer.
 .. versionadded:: 3.38
 %End
 
+    QString wfsTypeName() const;
+%Docstring
+Returns WFS typename for the layer
+
+.. versionadded:: 4.0.0
+%End
+
     void setTitle( const QString &title );
 %Docstring
 Sets the ``title`` of the layer used by QGIS Server in GetCapabilities

--- a/src/core/qgsmaplayerserverproperties.cpp
+++ b/src/core/qgsmaplayerserverproperties.cpp
@@ -297,6 +297,17 @@ void QgsMapLayerServerProperties::reset() // cppcheck-suppress duplInheritedMemb
   QgsServerWmsDimensionProperties::reset();
 }
 
+QString QgsMapLayerServerProperties::wfsTypeName() const
+{
+  QString name = mLayer ? mLayer->name() : QString();
+  if ( !mShortName.isEmpty() )
+    name = mShortName;
+
+  name.replace( ' ', '_' ).replace( ':', '-' ).replace( QChar( 0x2014 ) /* em-dash */, '-' );
+
+  return name.toLocal8Bit();
+}
+
 void QgsMapLayerServerProperties::readXml( const QDomNode &layerNode ) // cppcheck-suppress duplInheritedMember
 {
   QgsServerMetadataUrlProperties::readXml( layerNode );

--- a/src/core/qgsmaplayerserverproperties.h
+++ b/src/core/qgsmaplayerserverproperties.h
@@ -345,6 +345,12 @@ class CORE_EXPORT QgsMapLayerServerProperties: public QgsServerMetadataUrlProper
     QString shortName() const { return mShortName; }
 
     /**
+     * Returns WFS typename for the layer
+     * \since QGIS 4.0.0
+     */
+    QString wfsTypeName() const;
+
+    /**
      * Sets the \a title of the layer used by QGIS Server in GetCapabilities request.
      *
      * \see title()

--- a/src/server/services/wfs/qgswfsdescribefeaturetypegml.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetypegml.cpp
@@ -112,7 +112,7 @@ QDomDocument QgsWfsDescribeFeatureTypeGml::createDescribeFeatureTypeDocument( Qg
       continue;
     }
 
-    const QString name = layerTypeName( layer );
+    const QString name = layer->serverProperties()->wfsTypeName();
 
     if ( !typeNameList.isEmpty() && !typeNameList.contains( name ) )
     {
@@ -150,7 +150,7 @@ void QgsWfsDescribeFeatureTypeGml::setSchemaLayer( QDomElement &parentElement, Q
     return;
   }
 
-  const QString typeName = layerTypeName( layer );
+  const QString typeName = layer->serverProperties()->wfsTypeName();
 
   //xsd:element
   QDomElement elementElem = doc.createElement( QStringLiteral( "element" ) /*xsd:element*/ );

--- a/src/server/services/wfs/qgswfsdescribefeaturetypejson.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetypejson.cpp
@@ -72,7 +72,7 @@ QJsonObject QgsWfsDescribeFeatureTypeJson::createDescribeFeatureTypeDocument( Qg
       continue;
     }
 
-    const QString name = layerTypeName( layer );
+    const QString name = layer->serverProperties()->wfsTypeName();
 
     if ( !typeNameList.isEmpty() && !typeNameList.contains( name ) )
     {
@@ -107,7 +107,7 @@ QJsonObject QgsWfsDescribeFeatureTypeJson::createDescribeFeatureTypeDocument( Qg
 
 QJsonObject QgsWfsDescribeFeatureTypeJson::schemaLayerToJson( const QgsVectorLayer *layer ) const
 {
-  const QString typeName = layerTypeName( layer );
+  const QString typeName = layer->serverProperties()->wfsTypeName();
 
   QJsonObject json;
   QJsonArray properties;

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -447,7 +447,7 @@ namespace QgsWfs
 
       //create Name
       QDomElement nameElem = doc.createElement( QStringLiteral( "Name" ) );
-      const QDomText nameText = doc.createTextNode( layerTypeName( layer ) );
+      const QDomText nameText = doc.createTextNode( layer->serverProperties()->wfsTypeName() );
       nameElem.appendChild( nameText );
       layerElem.appendChild( nameElem );
 

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -160,7 +160,7 @@ namespace QgsWfs
         continue;
       }
 
-      QString name = layerTypeName( layer );
+      QString name = layer->serverProperties()->wfsTypeName();
 
       if ( typeNameList.contains( name ) )
       {

--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -269,7 +269,7 @@ namespace QgsWfs
         continue;
       }
 
-      QString name = layerTypeName( layer );
+      QString name = layer->serverProperties()->wfsTypeName();
 
       if ( !typeNameList.contains( name ) )
       {

--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -249,7 +249,7 @@ namespace QgsWfs
           continue;
         }
 
-        QString name = layerTypeName( layer );
+        QString name = layer->serverProperties()->wfsTypeName();
 
         if ( !typeNameList.contains( name ) )
         {

--- a/src/server/services/wfs/qgswfsutils.cpp
+++ b/src/server/services/wfs/qgswfsutils.cpp
@@ -63,17 +63,6 @@ namespace QgsWfs
     return href.toString();
   }
 
-  QString layerTypeName( const QgsMapLayer *layer )
-  {
-    QString name = layer->name();
-    if ( !layer->serverProperties()->shortName().isEmpty() )
-      name = layer->serverProperties()->shortName();
-
-    name.replace( ' ', '_' ).replace( ':', '-' ).replace( QChar( 0x2014 ) /* em-dash */, '-' );
-
-    return name.toLocal8Bit();
-  }
-
   QgsVectorLayer *layerByTypeName( const QgsProject *project, const QString &typeName )
   {
     QStringList layerIds = QgsServerProjectUtils::wfsLayerIds( *project );
@@ -89,7 +78,7 @@ namespace QgsWfs
         continue;
       }
 
-      if ( layerTypeName( layer ) == typeName )
+      if ( layer->serverProperties()->wfsTypeName() == typeName )
       {
         return qobject_cast<QgsVectorLayer *>( layer );
       }

--- a/src/server/services/wfs/qgswfsutils.h
+++ b/src/server/services/wfs/qgswfsutils.h
@@ -51,11 +51,6 @@ namespace QgsWfs
   QString serviceUrl( const QgsServerRequest &request, const QgsProject *project, const QgsServerSettings &settings );
 
   /**
-   * Returns typename from vector layer
-   */
-  QString layerTypeName( const QgsMapLayer *layer );
-
-  /**
    * Retrieve a layer by typename
    */
   QgsVectorLayer *layerByTypeName( const QgsProject *project, const QString &typeName );

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -442,7 +442,7 @@ void QgsWfs3DescribeCollectionHandler::handleRequest( const QgsServerApiContext 
   const std::string title { mapLayer->serverProperties()->wfsTitle().isEmpty() ? mapLayer->name().toStdString() : mapLayer->serverProperties()->wfsTitle().toStdString() };
   const std::string itemsTitle { title + " items" };
   const QString shortName { mapLayer->serverProperties()->shortName().isEmpty() ? mapLayer->name() : mapLayer->serverProperties()->shortName() };
-  const QString typeName = QString( shortName ).replace( ' ', '_' ).replace( ':', '-' ).replace( QChar( 0x2014 ) /* em-dash */, '-' );
+  const QString typeName { mapLayer->serverProperties()->wfsTypeName() };
   json linksList = links( context );
   linksList.push_back(
     { { "href", href( context, QStringLiteral( "/items" ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::GEOJSON ) ) },

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -442,6 +442,7 @@ void QgsWfs3DescribeCollectionHandler::handleRequest( const QgsServerApiContext 
   const std::string title { mapLayer->serverProperties()->wfsTitle().isEmpty() ? mapLayer->name().toStdString() : mapLayer->serverProperties()->wfsTitle().toStdString() };
   const std::string itemsTitle { title + " items" };
   const QString shortName { mapLayer->serverProperties()->shortName().isEmpty() ? mapLayer->name() : mapLayer->serverProperties()->shortName() };
+  const QString typeName = QString( shortName ).replace( ' ', '_' ).replace( ':', '-' ).replace( QChar( 0x2014 ) /* em-dash */, '-' );
   json linksList = links( context );
   linksList.push_back(
     { { "href", href( context, QStringLiteral( "/items" ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::GEOJSON ) ) },
@@ -460,7 +461,7 @@ void QgsWfs3DescribeCollectionHandler::handleRequest( const QgsServerApiContext 
   );
 
   linksList.push_back(
-    { { "href", parentLink( context.request()->url(), 3 ).toStdString() + "?request=DescribeFeatureType&typename=" + QUrlQuery( shortName ).toString( QUrl::EncodeSpaces ).toStdString() + "&service=WFS&version=2.0"
+    { { "href", parentLink( context.request()->url(), 3 ).toStdString() + "?request=DescribeFeatureType&typename=" + QUrlQuery( typeName ).toString( QUrl::EncodeSpaces ).toStdString() + "&service=WFS&version=2.0"
       },
       { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::describedBy ) },
       { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::XML ) },

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -460,7 +460,7 @@ void QgsWfs3DescribeCollectionHandler::handleRequest( const QgsServerApiContext 
   );
 
   linksList.push_back(
-    { { "href", parentLink( context.request()->url(), 3 ).toStdString() + "?request=DescribeFeatureType&typenames=" + QUrlQuery( shortName ).toString( QUrl::EncodeSpaces ).toStdString() + "&service=WFS&version=2.0"
+    { { "href", parentLink( context.request()->url(), 3 ).toStdString() + "?request=DescribeFeatureType&typename=" + QUrlQuery( shortName ).toString( QUrl::EncodeSpaces ).toStdString() + "&service=WFS&version=2.0"
       },
       { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::describedBy ) },
       { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::XML ) },

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -371,7 +371,7 @@ void QgsWfs3CollectionsHandler::handleRequest( const QgsServerApiContext &contex
                                         } } }
             },
             { "links", {
-                         { { "href", href( context, QStringLiteral( "/%1/items" ).arg( shortName ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::JSON ) ) }, { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::items ) }, { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::GEOJSON ) }, { "title", title + " as GeoJSON" } }, { { "href", href( context, QStringLiteral( "/%1/items" ).arg( shortName ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::HTML ) ) }, { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::items ) }, { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::HTML ) }, { "title", title + " as HTML" } } /* TODO: not sure what these "concepts" are about, neither if they are mandatory
+                         { { "href", href( context, QStringLiteral( "/%1/items" ).arg( shortName ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::GEOJSON ) ) }, { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::items ) }, { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::GEOJSON ) }, { "title", title + " as GeoJSON" } }, { { "href", href( context, QStringLiteral( "/%1/items" ).arg( shortName ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::HTML ) ) }, { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::items ) }, { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::HTML ) }, { "title", title + " as HTML" } } /* TODO: not sure what these "concepts" are about, neither if they are mandatory
             {
               { "href", href( api, context.request(), QStringLiteral( "/%1/concepts" ).arg( shortName ) )  },
               { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::item ) },
@@ -444,7 +444,7 @@ void QgsWfs3DescribeCollectionHandler::handleRequest( const QgsServerApiContext 
   const QString shortName { mapLayer->serverProperties()->shortName().isEmpty() ? mapLayer->name() : mapLayer->serverProperties()->shortName() };
   json linksList = links( context );
   linksList.push_back(
-    { { "href", href( context, QStringLiteral( "/items" ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::JSON ) ) },
+    { { "href", href( context, QStringLiteral( "/items" ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::GEOJSON ) ) },
       { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::items ) },
       { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::GEOJSON ) },
       { "title", itemsTitle + " as " + QgsServerOgcApi::contentTypeToStdString( QgsServerOgcApi::ContentType::GEOJSON ) }

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_layer1_with_short_name.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_layer1_with_short_name.json
@@ -38,7 +38,7 @@ Content-Type: application/json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.json",
+      "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.geojson",
       "rel": "items",
       "title": "A Layer1 with a short name items as GEOJSON",
       "type": "application/geo+json"

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_layer1_with_short_name.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_layer1_with_short_name.json
@@ -50,7 +50,7 @@ Content-Type: application/json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/?request=DescribeFeatureType&typenames=layer1_with_short_name&service=WFS&version=2.0",
+      "href": "http://server.qgis.org/?request=DescribeFeatureType&typename=layer1_with_short_name&service=WFS&version=2.0",
       "rel": "describedBy",
       "title": "Schema for A Layer1 with a short name",
       "type": "application/xml"

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_points_timefilters.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_points_timefilters.json
@@ -43,7 +43,7 @@ Content-Type: application/json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/wfs3/collections/points/items.json",
+      "href": "http://server.qgis.org/wfs3/collections/points/items.geojson",
       "rel": "items",
       "title": "points items as GEOJSON",
       "type": "application/geo+json"

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_points_timefilters.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_points_timefilters.json
@@ -55,7 +55,7 @@ Content-Type: application/json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/?request=DescribeFeatureType&typenames=points&service=WFS&version=2.0",
+      "href": "http://server.qgis.org/?request=DescribeFeatureType&typename=points&service=WFS&version=2.0",
       "rel": "describedBy",
       "title": "Schema for points",
       "type": "application/xml"

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
@@ -27,7 +27,7 @@
 
     <link rel="self" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9.html" title="Feature collection as HTML" type="text/html">
 
-    <link rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.json" title="A test wfs vector layer èé items as GEOJSON" type="application/geo+json">
+    <link rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson" title="A test wfs vector layer èé items as GEOJSON" type="application/geo+json">
 
     <link rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html" title="A test wfs vector layer èé items as HTML" type="text/html">
 
@@ -113,7 +113,7 @@
                 
             
                 
-                <li><a rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.json">A test wfs vector layer èé items as GEOJSON</a></li>
+                <li><a rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson">A test wfs vector layer èé items as GEOJSON</a></li>
                 
             
                 

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
@@ -31,7 +31,7 @@
 
     <link rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html" title="A test wfs vector layer èé items as HTML" type="text/html">
 
-    <link rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer%20èé&service=WFS&version=2.0" title="Schema for A test wfs vector layer èé" type="application/xml">
+    <link rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer_èé&service=WFS&version=2.0" title="Schema for A test wfs vector layer èé" type="application/xml">
 
 
 
@@ -121,7 +121,7 @@
                 
             
                 
-                <li><a rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer%20èé&service=WFS&version=2.0">Schema for A test wfs vector layer èé</a></li>
+                <li><a rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer_èé&service=WFS&version=2.0">Schema for A test wfs vector layer èé</a></li>
                 
             
             </ul>

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
@@ -31,7 +31,7 @@
 
     <link rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html" title="A test wfs vector layer èé items as HTML" type="text/html">
 
-    <link rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typenames=testlayer%20èé&service=WFS&version=2.0" title="Schema for A test wfs vector layer èé" type="application/xml">
+    <link rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer%20èé&service=WFS&version=2.0" title="Schema for A test wfs vector layer èé" type="application/xml">
 
 
 
@@ -121,7 +121,7 @@
                 
             
                 
-                <li><a rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typenames=testlayer%20èé&service=WFS&version=2.0">Schema for A test wfs vector layer èé</a></li>
+                <li><a rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer%20èé&service=WFS&version=2.0">Schema for A test wfs vector layer èé</a></li>
                 
             
             </ul>

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.json
@@ -50,7 +50,7 @@ Content-Type: application/json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/?request=DescribeFeatureType&typenames=testlayer%20èé&service=WFS&version=2.0",
+      "href": "http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer%20èé&service=WFS&version=2.0",
       "rel": "describedBy",
       "title": "Schema for A test wfs vector layer èé",
       "type": "application/xml"

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.json
@@ -38,7 +38,7 @@ Content-Type: application/json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.json",
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson",
       "rel": "items",
       "title": "A test wfs vector layer èé items as GEOJSON",
       "type": "application/geo+json"

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.json
@@ -50,7 +50,7 @@ Content-Type: application/json
       "type": "text/html"
     },
     {
-      "href": "http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer%20èé&service=WFS&version=2.0",
+      "href": "http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer_èé&service=WFS&version=2.0",
       "rel": "describedBy",
       "title": "Schema for A test wfs vector layer èé",
       "type": "application/xml"

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_project.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_project.json
@@ -29,7 +29,7 @@ Content-Type: application/json
       "id": "testlayer èé",
       "links": [
         {
-          "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.json",
+          "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson",
           "rel": "items",
           "title": "A test wfs vector layer èé as GeoJSON",
           "type": "application/geo+json"
@@ -70,7 +70,7 @@ Content-Type: application/json
       "id": "layer1_with_short_name",
       "links": [
         {
-          "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.json",
+          "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.geojson",
           "rel": "items",
           "title": "A Layer1 with a short name as GeoJSON",
           "type": "application/geo+json"
@@ -111,7 +111,7 @@ Content-Type: application/json
       "id": "exclude_attribute",
       "links": [
         {
-          "href": "http://server.qgis.org/wfs3/collections/exclude_attribute/items.json",
+          "href": "http://server.qgis.org/wfs3/collections/exclude_attribute/items.geojson",
           "rel": "items",
           "title": "A test vector layer exclude attrs as GeoJSON",
           "type": "application/geo+json"
@@ -152,7 +152,7 @@ Content-Type: application/json
       "id": "fields_alias",
       "links": [
         {
-          "href": "http://server.qgis.org/wfs3/collections/fields_alias/items.json",
+          "href": "http://server.qgis.org/wfs3/collections/fields_alias/items.geojson",
           "rel": "items",
           "title": "A test vector layer with aliases as GeoJSON",
           "type": "application/geo+json"


### PR DESCRIPTION
The OAPIF `collections/<layername>` page contains a link

```
        {
            "href": "<...>/collections/<layername>/items.json",
            "rel": "items",
            "title": "Edit Lines items as GEOJSON",
            "type": "application/geo+json"
        },
```

which `json` as extension even though the content-type is `application/geo+json`. The `collections/<layername>/items.json` however contains the self-link as 
```
        {
            "href": "<...>/collections/<layername>/items.geojson",
            "rel": "self",
            "title": "Retrieve the features of the collection as GEOJSON",
            "type": "application/geo+json"
        },
```

This PR ensures that also the former link uses GEOJSON as extension.