### PR TITLE
Blocklist fragile server tests on Ubuntu CI

### DIFF
--- a/.ci/test_blocklist_qt6_ubuntu.txt
+++ b/.ci/test_blocklist_qt6_ubuntu.txt
@@ -16,3 +16,8 @@ test_core_openclutils
 
 # Relies on a broken/unreliable 3rd party service
 test_core_layerdefinition
+
+# Randomly segfault on Ubuntu 25.04, for unknown reasons
+PyQgsServerApi
+PyQgsServerWMS
+PyQgsServerConfigCache


### PR DESCRIPTION
These tests have started segfaulting randomly since upgrade from 24.10 to 25.04. It's a Ubuntu 25.04 specific issue, as the tests have been run on the Fedora CI (and older Ubuntu) for years without issue.

At this stage the cause is unknown, but the failures are just noise and risk hiding real issues. Given that the Fedora CI is still running these tests then we don't have any drop in test coverage by blocking them from running on the Ubuntu builds.

**(Please don't add comments like "can we fix the tests instead?" -- multiple developers have tried to diagnose this without success)**
