### PR TITLE
[Backport to release-3.40]  Delete QObjectUniquePtr currently pointed object when moving

### DIFF
--- a/src/core/qobjectuniqueptr.h
+++ b/src/core/qobjectuniqueptr.h
@@ -90,6 +90,7 @@ class QObjectUniquePtr
 
     QObjectUniquePtr &operator=( QObjectUniquePtr &&other ) noexcept
     {
+      delete mPtr.data();
       mPtr = other.mPtr;
       other.clear();
       return *this;

--- a/tests/src/core/testqobjectuniqueptr.cpp
+++ b/tests/src/core/testqobjectuniqueptr.cpp
@@ -136,6 +136,18 @@ void TestQObjectUniquePtr::testVector()
 
   QCOMPARE( objects.at( 0 )->objectName(), "TESTA" );
   QCOMPARE( objects.at( 1 )->objectName(), "TESTB" );
+
+  int nbObjectDestroyed = 0;
+  auto onDestroyed = [&nbObjectDestroyed]() { nbObjectDestroyed++; };
+
+  connect( objects.at( 0 ), &QObject::destroyed, this, onDestroyed );
+  connect( objects.at( 1 ), &QObject::destroyed, this, onDestroyed );
+
+  objects.erase( objects.cbegin() );
+
+  QCOMPARE( objects.size(), 1 );
+  QCOMPARE( nbObjectDestroyed, 1 );
+  QCOMPARE( objects.at( 0 )->objectName(), "TESTB" );
 }
 
 


### PR DESCRIPTION
Manual backport #63373 to 3.40

**Funded by Stadt Frankfurt am Main**