### PR TITLE
Drop always-true asserts in the internal spatialindex

### DIFF
--- a/external/spatialindex/src/mvrtree/Node.cc
+++ b/external/spatialindex/src/mvrtree/Node.cc
@@ -5,7 +5,7 @@
  * Copyright (c) 2002, Marios Hadjieleftheriou
  *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -321,7 +321,7 @@ void Node::insertEntry(uint32_t dataLength, uint8_t* pData, TimeRegion& mbr, id_
 
 bool Node::deleteEntry(uint32_t index)
 {
-	assert(index >= 0 && index < m_children);
+	assert(index < m_children);
 
 	// cache it, since I might need it for "touches" later.
 	TimeRegionPtr ptrR = m_ptrMBR[index];

--- a/external/spatialindex/src/mvrtree/PointerPoolNode.h
+++ b/external/spatialindex/src/mvrtree/PointerPoolNode.h
@@ -92,7 +92,6 @@ namespace Tools
 		uint32_t getCapacity() const { return m_capacity; }
 		void setCapacity(uint32_t c)
 		{
-			assert (c >= 0);
 			m_capacity = c;
 		}
 

--- a/external/spatialindex/src/rtree/Node.cc
+++ b/external/spatialindex/src/rtree/Node.cc
@@ -5,7 +5,7 @@
  * Copyright (c) 2002, Marios Hadjieleftheriou
  *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -301,7 +301,7 @@ void Node::insertEntry(uint32_t dataLength, uint8_t* pData, Region& mbr, id_type
 
 void Node::deleteEntry(uint32_t index)
 {
-	assert(index >= 0 && index < m_children);
+	assert(index < m_children);
 
 	// cache it, since I might need it for "touches" later.
 	RegionPtr ptrR = m_ptrMBR[index];

--- a/external/spatialindex/src/rtree/PointerPoolNode.h
+++ b/external/spatialindex/src/rtree/PointerPoolNode.h
@@ -97,7 +97,6 @@ namespace Tools
 		uint32_t getCapacity() const { return m_capacity; }
 		void setCapacity(uint32_t c)
 		{
-			assert (c >= 0);
 			m_capacity = c;
 		}
 

--- a/external/spatialindex/src/tprtree/Node.cc
+++ b/external/spatialindex/src/tprtree/Node.cc
@@ -381,7 +381,7 @@ bool Node::insertEntry(uint32_t dataLength, uint8_t* pData, MovingRegion& mbr, i
 
 void Node::deleteEntry(uint32_t index)
 {
-	assert(index >= 0 && index < m_children);
+	assert(index < m_children);
 
 	// cache it, since I might need it for "touches" later.
 	MovingRegionPtr ptrR = m_ptrMBR[index];

--- a/external/spatialindex/src/tprtree/PointerPoolNode.h
+++ b/external/spatialindex/src/tprtree/PointerPoolNode.h
@@ -93,7 +93,6 @@ namespace Tools
 		uint32_t getCapacity() const { return m_capacity; }
 		void setCapacity(uint32_t c)
 		{
-			assert (c >= 0);
 			m_capacity = c;
 		}
 


### PR DESCRIPTION
Removes warnings coming out with -Wtype-limits switch of GCC 14.2 (on Debian 12 Trixie)
