### PR TITLE
[3d] Use safer approach to cleanup canceled terrain texture jobs

### DIFF
--- a/src/3d/terrain/qgsterraintexturegenerator_p.cpp
+++ b/src/3d/terrain/qgsterraintexturegenerator_p.cpp
@@ -51,9 +51,9 @@ int QgsTerrainTextureGenerator::render( const QgsRectangle &extent, QgsChunkNode
   if ( !qgsDoubleNear( clippedExtent.width(), clippedExtent.height() ) )
   {
     if ( clippedExtent.height() > clippedExtent.width() )
-      size.setWidth( std::round( size.width() * clippedExtent.width() / clippedExtent.height() ) );
+      size.setWidth( static_cast< int >( std::round( size.width() * clippedExtent.width() / clippedExtent.height() ) ) );
     else if ( clippedExtent.height() < clippedExtent.width() )
-      size.setHeight( std::round( size.height() * clippedExtent.height() / clippedExtent.width() ) );
+      size.setHeight( static_cast< int >( std::round( size.height() * clippedExtent.height() / clippedExtent.width() ) ) );
   }
   mapSettings.setOutputSize( size );
 
@@ -83,9 +83,9 @@ void QgsTerrainTextureGenerator::cancelJob( int jobId )
     if ( jd.jobId == jobId )
     {
       // QgsDebugMsgLevel( QStringLiteral("canceling job %1").arg( jobId ), 2 );
-      jd.job->cancelWithoutBlocking();
       disconnect( jd.job, &QgsMapRendererJob::finished, this, &QgsTerrainTextureGenerator::onRenderingFinished );
-      jd.job->deleteLater();
+      connect( jd.job, &QgsMapRendererJob::finished, jd.job, &QgsMapRendererSequentialJob::deleteLater );
+      jd.job->cancelWithoutBlocking();
       mJobs.remove( jd.job );
       return;
     }


### PR DESCRIPTION
We can't safely just deleteLater the job, it may still be active when we run the next Qt event loop
