### PR TITLE
run sipify action only in the qgis/QGIS repository (fix #62313)

### DIFF
--- a/.github/workflows/sipify-bot.yml
+++ b/.github/workflows/sipify-bot.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   sipify:
+    if: github.repository == 'qgis/QGIS'
     runs-on: [ubuntu-latest]
     steps:
 


### PR DESCRIPTION
## Description

Do not run the `sipify-bot` action on the forks of [qgis/QGIS](https://github.com/qgis/QGIS) repository, as this may lead to diverged commit history.

Fixes #62313.