### PR TITLE
Fix vector layer paste style categories

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1763,8 +1763,9 @@ bool QgsMapLayer::importNamedStyle( QDomDocument &myDocument, QString &myErrorMe
     }
   }
 
+  // Pass the intersection between the desired categories and those that are really in the document
   QgsReadWriteContext context = QgsReadWriteContext();
-  return readSymbology( myRoot, myErrorMessage, context, categories ); // TODO: support relative paths in QML?
+  return readSymbology( myRoot, myErrorMessage, context, categories & sourceCategories ); // TODO: support relative paths in QML?
 }
 
 void QgsMapLayer::exportNamedMetadata( QDomDocument &doc, QString &errorMsg ) const

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -5817,7 +5817,7 @@ class TestQgsVectorLayerTransformContext(QgisTestCase):
             )
 
     def test_write_symbology_categories(self):
-        """Test that copy paste styles respect categories: issue GH #"""
+        """Test that copy paste styles respect categories: issue GH #63167"""
 
         layer1 = QgsVectorLayer("Point?field=fldtxt:string", "layer1", "memory")
         layer2 = QgsVectorLayer("Point?field=fldtxt:string", "layer2", "memory")


### PR DESCRIPTION
When pasting styles, the categories actually
present in the copied XML  were not take into account.

Fix #63167
