### PR TITLE
Value relation widget wrapper: cut queries

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -560,6 +560,11 @@ void QgsValueRelationWidgetWrapper::widgetValueChanged( const QString &attribute
 
 void QgsValueRelationWidgetWrapper::setFeature( const QgsFeature &feature )
 {
+  // No need to proceed further because the status of the object doesn't need to be updated.
+  if ( !formFeature().isValid() && !feature.isValid() && !mCache.isEmpty() )
+  {
+    return;
+  }
   setFormFeature( feature );
   whileBlocking( this )->populate();
   whileBlocking( this )->setValue( feature.attribute( fieldIdx() ) );


### PR DESCRIPTION
There is no need to re-populate an already populated cache if the feature is still unvalid.

Cut two unnecessary queries when opening an attribute table.

Partially fix #63410
