### PR TITLE
Move ApplicationMembers struct out of header

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -168,6 +168,64 @@ const QgsSettingsEntryInteger *QgsApplication::settingsConnectionPoolMaximumConc
 
 #define CONN_POOL_MAX_CONCURRENT_CONNS      4
 
+struct QgsApplication::ApplicationMembers
+{
+  std::unique_ptr<QgsSettingsRegistryCore > mSettingsRegistryCore;
+  std::unique_ptr<QgsCoordinateReferenceSystemRegistry > mCrsRegistry;
+  std::unique_ptr<Qgs3DRendererRegistry > m3DRendererRegistry;
+  std::unique_ptr<Qgs3DSymbolRegistry > m3DSymbolRegistry;
+  std::unique_ptr<QgsActionScopeRegistry > mActionScopeRegistry;
+  std::unique_ptr<QgsAnnotationRegistry > mAnnotationRegistry;
+  std::unique_ptr<QgsColorSchemeRegistry > mColorSchemeRegistry;
+  std::unique_ptr<QgsLocalizedDataPathRegistry > mLocalizedDataPathRegistry;
+  std::unique_ptr<QgsNumericFormatRegistry > mNumericFormatRegistry;
+  std::unique_ptr<QgsFieldFormatterRegistry > mFieldFormatterRegistry;
+  std::unique_ptr<QgsGpsConnectionRegistry > mGpsConnectionRegistry;
+  std::unique_ptr<QgsBabelFormatRegistry > mGpsBabelFormatRegistry;
+  std::unique_ptr<QgsNetworkContentFetcherRegistry > mNetworkContentFetcherRegistry;
+  std::unique_ptr<QgsScaleBarRendererRegistry > mScaleBarRendererRegistry;
+  std::unique_ptr<QgsLabelingEngineRuleRegistry > mLabelingEngineRuleRegistry;
+  std::unique_ptr<QgsValidityCheckRegistry > mValidityCheckRegistry;
+  std::unique_ptr<QgsMessageLog > mMessageLog;
+  std::unique_ptr<QgsPaintEffectRegistry > mPaintEffectRegistry;
+  std::unique_ptr<QgsPluginLayerRegistry > mPluginLayerRegistry;
+  std::unique_ptr<QgsClassificationMethodRegistry > mClassificationMethodRegistry;
+  std::unique_ptr<QgsProcessingRegistry > mProcessingRegistry;
+  std::unique_ptr<QgsConnectionRegistry > mConnectionRegistry;
+  std::unique_ptr<QgsProjectStorageRegistry > mProjectStorageRegistry;
+  std::unique_ptr<QgsLayerMetadataProviderRegistry > mLayerMetadataProviderRegistry;
+  std::unique_ptr<QgsExternalStorageRegistry > mExternalStorageRegistry;
+  std::unique_ptr<QgsProfileSourceRegistry > mProfileSourceRegistry;
+  std::unique_ptr<QgsPageSizeRegistry > mPageSizeRegistry;
+  std::unique_ptr<QgsRasterRendererRegistry > mRasterRendererRegistry;
+  std::unique_ptr<QgsRendererRegistry > mRendererRegistry;
+  std::unique_ptr<QgsPointCloudRendererRegistry > mPointCloudRendererRegistry;
+  std::unique_ptr<QgsTiledSceneRendererRegistry > mTiledSceneRendererRegistry;
+  std::unique_ptr<QgsSvgCache > mSvgCache;
+  std::unique_ptr<QgsImageCache > mImageCache;
+  std::unique_ptr<QgsSourceCache > mSourceCache;
+  std::unique_ptr<QgsSymbolLayerRegistry > mSymbolLayerRegistry;
+  std::unique_ptr<QgsCalloutRegistry > mCalloutRegistry;
+  std::unique_ptr<QgsTaskManager > mTaskManager;
+  std::unique_ptr<QgsLayoutItemRegistry > mLayoutItemRegistry;
+  std::unique_ptr<QgsAnnotationItemRegistry > mAnnotationItemRegistry;
+  std::unique_ptr<QgsSensorRegistry > mSensorRegistry;
+  std::unique_ptr<QgsPlotRegistry > mPlotRegistry;
+  std::unique_ptr<QgsBookmarkManager > mBookmarkManager;
+  std::unique_ptr<QgsTileDownloadManager > mTileDownloadManager;
+  std::unique_ptr<QgsStyleModel > mStyleModel;
+  std::unique_ptr<QgsRecentStyleHandler > mRecentStyleHandler;
+  std::unique_ptr<QgsDatabaseQueryLog > mQueryLogger;
+  std::unique_ptr<QgsFontManager > mFontManager;
+  QString mNullRepresentation;
+  QStringList mSvgPathCache;
+  bool mSvgPathCacheValid = false;
+
+  ApplicationMembers();
+  ~ApplicationMembers();
+};
+
+
 QObject *ABISYM( QgsApplication::mFileOpenEventReceiver ) = nullptr;
 bool ABISYM( QgsApplication::mInitialized ) = false;
 bool ABISYM( QgsApplication::mRunningFromBuildDir ) = false;

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -1169,62 +1169,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     std::unique_ptr<QgsDataItemProviderRegistry> mDataItemProviderRegistry;
     QgsAuthManager *mAuthManager = nullptr;
 
-    struct ApplicationMembers
-    {
-      std::unique_ptr<QgsSettingsRegistryCore > mSettingsRegistryCore;
-      std::unique_ptr<QgsCoordinateReferenceSystemRegistry > mCrsRegistry;
-      std::unique_ptr<Qgs3DRendererRegistry > m3DRendererRegistry;
-      std::unique_ptr<Qgs3DSymbolRegistry > m3DSymbolRegistry;
-      std::unique_ptr<QgsActionScopeRegistry > mActionScopeRegistry;
-      std::unique_ptr<QgsAnnotationRegistry > mAnnotationRegistry;
-      std::unique_ptr<QgsColorSchemeRegistry > mColorSchemeRegistry;
-      std::unique_ptr<QgsLocalizedDataPathRegistry > mLocalizedDataPathRegistry;
-      std::unique_ptr<QgsNumericFormatRegistry > mNumericFormatRegistry;
-      std::unique_ptr<QgsFieldFormatterRegistry > mFieldFormatterRegistry;
-      std::unique_ptr<QgsGpsConnectionRegistry > mGpsConnectionRegistry;
-      std::unique_ptr<QgsBabelFormatRegistry > mGpsBabelFormatRegistry;
-      std::unique_ptr<QgsNetworkContentFetcherRegistry > mNetworkContentFetcherRegistry;
-      std::unique_ptr<QgsScaleBarRendererRegistry > mScaleBarRendererRegistry;
-      std::unique_ptr<QgsLabelingEngineRuleRegistry > mLabelingEngineRuleRegistry;
-      std::unique_ptr<QgsValidityCheckRegistry > mValidityCheckRegistry;
-      std::unique_ptr<QgsMessageLog > mMessageLog;
-      std::unique_ptr<QgsPaintEffectRegistry > mPaintEffectRegistry;
-      std::unique_ptr<QgsPluginLayerRegistry > mPluginLayerRegistry;
-      std::unique_ptr<QgsClassificationMethodRegistry > mClassificationMethodRegistry;
-      std::unique_ptr<QgsProcessingRegistry > mProcessingRegistry;
-      std::unique_ptr<QgsConnectionRegistry > mConnectionRegistry;
-      std::unique_ptr<QgsProjectStorageRegistry > mProjectStorageRegistry;
-      std::unique_ptr<QgsLayerMetadataProviderRegistry > mLayerMetadataProviderRegistry;
-      std::unique_ptr<QgsExternalStorageRegistry > mExternalStorageRegistry;
-      std::unique_ptr<QgsProfileSourceRegistry > mProfileSourceRegistry;
-      std::unique_ptr<QgsPageSizeRegistry > mPageSizeRegistry;
-      std::unique_ptr<QgsRasterRendererRegistry > mRasterRendererRegistry;
-      std::unique_ptr<QgsRendererRegistry > mRendererRegistry;
-      std::unique_ptr<QgsPointCloudRendererRegistry > mPointCloudRendererRegistry;
-      std::unique_ptr<QgsTiledSceneRendererRegistry > mTiledSceneRendererRegistry;
-      std::unique_ptr<QgsSvgCache > mSvgCache;
-      std::unique_ptr<QgsImageCache > mImageCache;
-      std::unique_ptr<QgsSourceCache > mSourceCache;
-      std::unique_ptr<QgsSymbolLayerRegistry > mSymbolLayerRegistry;
-      std::unique_ptr<QgsCalloutRegistry > mCalloutRegistry;
-      std::unique_ptr<QgsTaskManager > mTaskManager;
-      std::unique_ptr<QgsLayoutItemRegistry > mLayoutItemRegistry;
-      std::unique_ptr<QgsAnnotationItemRegistry > mAnnotationItemRegistry;
-      std::unique_ptr<QgsSensorRegistry > mSensorRegistry;
-      std::unique_ptr<QgsPlotRegistry > mPlotRegistry;
-      std::unique_ptr<QgsBookmarkManager > mBookmarkManager;
-      std::unique_ptr<QgsTileDownloadManager > mTileDownloadManager;
-      std::unique_ptr<QgsStyleModel > mStyleModel;
-      std::unique_ptr<QgsRecentStyleHandler > mRecentStyleHandler;
-      std::unique_ptr<QgsDatabaseQueryLog > mQueryLogger;
-      std::unique_ptr<QgsFontManager > mFontManager;
-      QString mNullRepresentation;
-      QStringList mSvgPathCache;
-      bool mSvgPathCacheValid = false;
-
-      ApplicationMembers();
-      ~ApplicationMembers();
-    };
+    struct ApplicationMembers;
 
     // Applications members which belong to an instance of QgsApplication
     std::unique_ptr<ApplicationMembers> mApplicationMembers;


### PR DESCRIPTION
## Description

This PR moves the `QgsApplication::ApplicationMembers` from `qgsapplication.h` to `qgsapplication.cpp` to speed up the build of all C++ source files that include `qgsapplication.h`.

The reasoning here is that, sadly, instantiating `std::unique_ptr<T>` takes a nontrivial amount of time for each `T` present in a compilation unit (per clang's `-ftime-trace`, it's about 9 ms on my laptop). On my Ryzen 3700X desktop, this change improved build times of a single C++ file by over 200 ms (using GCC, the average build time of `qgsfield.cpp` went from 1.97 to 1.72 s, with std.dev. around 60 ms).

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
