### PR TITLE
Adjust ms planetary computer auth redirect address and help text

### DIFF
--- a/src/auth/planetary_computer/gui/qgsauthplanetarycomputeredit.cpp
+++ b/src/auth/planetary_computer/gui/qgsauthplanetarycomputeredit.cpp
@@ -85,7 +85,7 @@ QgsStringMap QgsAuthPlanetaryComputerEdit::configMap() const
                            "\"password\": null,"
                            "\"persistToken\": false,"
                            "\"queryPairs\": {},"
-                           "\"redirectHost\": \"127.0.0.1\","
+                           "\"redirectHost\": \"localhost\","
                            "\"redirectPort\": 7070,"
                            "\"redirectUrl\": null,"
                            "\"refreshTokenUrl\": null,"
@@ -158,11 +158,7 @@ void QgsAuthPlanetaryComputerEdit::updateServerType( int indx )
   leTenantId->setVisible( isPro );
 
   const QString openHelp = tr( "Use this server type for %1 - the data are publicly accessible and do not require an account." ).arg( QLatin1String( "<a href=\"https://planetarycomputer.microsoft.com/\">https://planetarycomputer.microsoft.com/</a>" ) );
-  const QString proHelp = tr(
-    "Use this server type for <a href=\"https://learn.microsoft.com/en-us/azure/planetary-computer/get-started-planetary-computer\">Planetary Computer Pro</a> instances.<br/>"
-    "The Directory (tenant) and Application (client) IDs can be found in your organization's Microsoft Entra ID main and application page respectively.<br/>"
-    "This authentication method expects to receive an OAuth2 token using the redirect url http://127.0.0.1:7070/"
-  );
+  const QString proHelp = QStringLiteral( "%1<br/>%2: <a href=\"%3\">%3</a>" ).arg( tr( "Contact your Microsoft Entra admin for App Registration details." ), tr( "Setup guide" ), QStringLiteral( "http://aka.ms/qgis" ) );
 
   lblHelp->setText( QStringLiteral( "<html><head/><body><p><span style=\" font-style:italic;\">%1</span></p></body></html>" ).arg( isPro ? proHelp : openHelp ) );
 


### PR DESCRIPTION
## Description
Adjust the redirect address for the Microsoft Planetary Computer Pro auth config from using 127.0.0.1 to using `localhost`

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
