### PR TITLE
[fix] Project Functions: make it clear that project functions are not saved until the project is saved

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -301,7 +301,8 @@ Updates the list of function files found at the given path
 
     void saveProjectFunctionsEntry();
 %Docstring
-Saves the current function editor text to a project entry.
+Writes the current function editor text to a project entry. The project
+becomes dirty.
 
 .. versionadded:: 3.40
 %End
@@ -385,13 +386,15 @@ them (eg. RelationReference).
 
     void autosave();
 %Docstring
-Auto save the current Python function code.
+Auto save the current Python function code. Note: Auto save does not
+apply to Project Functions.
 %End
 
     void setAutoSave( bool enabled );
 %Docstring
 Enabled or disable auto saving. When enabled Python scripts will be auto
-saved when text changes.
+saved when text changes. Note: Auto save does not apply to Project
+Functions.
 
 :param enabled: ``True`` to enable auto saving.
 %End

--- a/python/PyQt6/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -386,15 +386,21 @@ them (eg. RelationReference).
 
     void autosave();
 %Docstring
-Auto save the current Python function code. Note: Auto save does not
-apply to Project Functions.
+Auto save the current Python function code.
+
+.. note::
+
+   Auto save does not apply to Project Functions.
 %End
 
     void setAutoSave( bool enabled );
 %Docstring
 Enabled or disable auto saving. When enabled Python scripts will be auto
-saved when text changes. Note: Auto save does not apply to Project
-Functions.
+saved when text changes.
+
+.. note::
+
+   Auto save does not apply to Project Functions.
 
 :param enabled: ``True`` to enable auto saving.
 %End

--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -301,7 +301,8 @@ Updates the list of function files found at the given path
 
     void saveProjectFunctionsEntry();
 %Docstring
-Saves the current function editor text to a project entry.
+Writes the current function editor text to a project entry. The project
+becomes dirty.
 
 .. versionadded:: 3.40
 %End
@@ -385,13 +386,15 @@ them (eg. RelationReference).
 
     void autosave();
 %Docstring
-Auto save the current Python function code.
+Auto save the current Python function code. Note: Auto save does not
+apply to Project Functions.
 %End
 
     void setAutoSave( bool enabled );
 %Docstring
 Enabled or disable auto saving. When enabled Python scripts will be auto
-saved when text changes.
+saved when text changes. Note: Auto save does not apply to Project
+Functions.
 
 :param enabled: ``True`` to enable auto saving.
 %End

--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -386,15 +386,21 @@ them (eg. RelationReference).
 
     void autosave();
 %Docstring
-Auto save the current Python function code. Note: Auto save does not
-apply to Project Functions.
+Auto save the current Python function code.
+
+.. note::
+
+   Auto save does not apply to Project Functions.
 %End
 
     void setAutoSave( bool enabled );
 %Docstring
 Enabled or disable auto saving. When enabled Python scripts will be auto
-saved when text changes. Note: Auto save does not apply to Project
-Functions.
+saved when text changes.
+
+.. note::
+
+   Auto save does not apply to Project Functions.
 
 :param enabled: ``True`` to enable auto saving.
 %End

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -548,11 +548,7 @@ void QgsExpressionBuilderWidget::cmbFileNames_currentItemChanged( QListWidgetIte
 {
   if ( lastitem )
   {
-    if ( lastitem->data( Qt::UserRole ) == QLatin1String( "project" ) )
-    {
-      saveProjectFunctionsEntry();
-    }
-    else
+    if ( lastitem->data( Qt::UserRole ) != QLatin1String( "project" ) )
     {
       QString filename = lastitem->text();
       saveFunctionFile( filename );
@@ -561,12 +557,28 @@ void QgsExpressionBuilderWidget::cmbFileNames_currentItemChanged( QListWidgetIte
 
   if ( item->data( Qt::UserRole ) == QLatin1String( "project" ) )
   {
+    // Avoid making the project dirty when just loading functions
+    txtPython->blockSignals( true );
     loadCodeFromProjectFunctions();
+    txtPython->blockSignals( false );
+
+    btnRun->setText( tr( "Run and Load Functions" ) );
+    btnRun->setToolTip( tr( "Run the current editor text in QGIS.\n"
+                            "\n"
+                            "Use this when testing your functions.\n"
+                            "\n"
+                            "Note the functions will only be stored when saving the project." ) );
   }
   else
   {
     QString path = mFunctionsPath + QDir::separator() + item->text();
     loadCodeFromFile( path );
+    btnRun->setText( tr( "Save and Load Functions" ) );
+    btnRun->setToolTip( tr( "Run the current editor text in QGIS (also saves current script).\n"
+                            "\n"
+                            "Use this when testing your functions.\n"
+                            "\n"
+                            "Saved scripts are auto loaded on QGIS startup." ) );
   }
 }
 
@@ -1049,8 +1061,19 @@ void QgsExpressionBuilderWidget::loadAllUsedValues()
 
 void QgsExpressionBuilderWidget::txtPython_textChanged()
 {
-  lblAutoSave->setText( tr( "Saving…" ) );
-  if ( mAutoSave )
+  if ( tabWidget->currentIndex() != 1 )
+    return;
+
+  QListWidgetItem *item = cmbFileNames->currentItem();
+  if ( !item )
+    return;
+
+  if ( item->data( Qt::UserRole ) == QLatin1String( "project" ) )
+  {
+    saveProjectFunctionsEntry(); // Makes project dirty
+    displayTemporaryLabel( tr( "Project changed" ) );
+  }
+  else if ( mAutoSave )
   {
     autosave();
   }
@@ -1066,17 +1089,17 @@ void QgsExpressionBuilderWidget::autosave()
   if ( !item )
     return;
 
-  if ( item->data( Qt::UserRole ) == QLatin1String( "project" ) )
-  {
-    saveProjectFunctionsEntry();
-  }
-  else
+  if ( item->data( Qt::UserRole ) != QLatin1String( "project" ) )
   {
     QString file = item->text();
     saveFunctionFile( file );
+    displayTemporaryLabel( tr( "Saved" ) );
   }
+}
 
-  lblAutoSave->setText( QStringLiteral( "Saved" ) );
+void QgsExpressionBuilderWidget::displayTemporaryLabel( const QString &text )
+{
+  lblAutoSave->setText( text );
   QGraphicsOpacityEffect *effect = new QGraphicsOpacityEffect();
   lblAutoSave->setGraphicsEffect( effect );
   QPropertyAnimation *anim = new QPropertyAnimation( effect, "opacity" );

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -562,10 +562,8 @@ void QgsExpressionBuilderWidget::cmbFileNames_currentItemChanged( QListWidgetIte
     loadCodeFromProjectFunctions();
     txtPython->blockSignals( false );
 
-    btnRun->setText( tr( "Run and Load Functions" ) );
-    btnRun->setToolTip( tr( "Run the current editor text in QGIS.\n"
-                            "\n"
-                            "Use this when testing your functions.\n"
+    btnRun->setText( tr( "Load or update functions" ) );
+    btnRun->setToolTip( tr( "Loads or updates functions from current script file in QGIS.\n"
                             "\n"
                             "Note the functions will only be stored when saving the project." ) );
   }
@@ -573,12 +571,20 @@ void QgsExpressionBuilderWidget::cmbFileNames_currentItemChanged( QListWidgetIte
   {
     QString path = mFunctionsPath + QDir::separator() + item->text();
     loadCodeFromFile( path );
-    btnRun->setText( tr( "Save and Load Functions" ) );
-    btnRun->setToolTip( tr( "Run the current editor text in QGIS (also saves current script).\n"
-                            "\n"
-                            "Use this when testing your functions.\n"
-                            "\n"
-                            "Saved scripts are auto loaded on QGIS startup." ) );
+    if ( mAutoSave )
+    {
+      btnRun->setText( tr( "Load or update functions" ) );
+      btnRun->setToolTip( tr( "Loads or updates functions from current script file in QGIS.\n"
+                              "\n"
+                              "Saved scripts are auto loaded on QGIS startup." ) );
+    }
+    else
+    {
+      btnRun->setText( tr( "Save and Load Functions" ) );
+      btnRun->setToolTip( tr( "Saves current script file and loads or updates its functions in QGIS.\n"
+                              "\n"
+                              "Saved scripts are auto loaded on QGIS startup." ) );
+    }
   }
 }
 
@@ -1093,7 +1099,7 @@ void QgsExpressionBuilderWidget::autosave()
   {
     QString file = item->text();
     saveFunctionFile( file );
-    displayTemporaryLabel( tr( "Saved" ) );
+    displayTemporaryLabel( tr( "Function file saved" ) );
   }
 }
 

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -369,14 +369,14 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     /**
      * Auto save the current Python function code.
-     * Note: Auto save does not apply to Project Functions.
+     * \note Auto save does not apply to Project Functions.
      */
     void autosave();
 
     /**
      * Enabled or disable auto saving. When enabled Python scripts will be auto saved
      * when text changes.
-     * Note: Auto save does not apply to Project Functions.
+     * \note Auto save does not apply to Project Functions.
      * \param enabled TRUE to enable auto saving.
      */
     void setAutoSave( bool enabled ) { mAutoSave = enabled; }

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -285,7 +285,8 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void updateFunctionFileList( const QString &path );
 
     /**
-     * Saves the current function editor text to a project entry.
+     * Writes the current function editor text to a project entry.
+     * The project becomes dirty.
      *
      * \since QGIS 3.40
      */
@@ -368,12 +369,14 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     /**
      * Auto save the current Python function code.
+     * Note: Auto save does not apply to Project Functions.
      */
     void autosave();
 
     /**
      * Enabled or disable auto saving. When enabled Python scripts will be auto saved
      * when text changes.
+     * Note: Auto save does not apply to Project Functions.
      * \param enabled TRUE to enable auto saving.
      */
     void setAutoSave( bool enabled ) { mAutoSave = enabled; }
@@ -484,6 +487,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void clearFunctionMarkers();
     void clearErrors();
     void runPythonCode( const QString &code );
+    void displayTemporaryLabel( const QString &text );
     QgsVectorLayer *contextLayer( const QgsExpressionItem *item ) const;
     void fillFieldValues( const QString &fieldName, QgsVectorLayer *layer, int countLimit, bool forceUsedValues = false );
     QString getFunctionHelp( QgsExpressionFunction *function );


### PR DESCRIPTION
This PR replaces the Run button's text and tooltip when `[Project Functions]` is selected in the functions list to avoid any reference to "Save".

From the Expression builder dialog, we only make the project dirty when editing a Project Function, i.e., `autoSave()` does not apply to Project Functions.

Also, avoid making the project dirty if not needed (e.g., when just loading functions to the Python editor).

<img width="834" height="510" alt="image" src="https://github.com/user-attachments/assets/ce606637-9a13-4b08-8ce8-3ba4b1955f16" />


Fix #62752