### PR TITLE
Fix paste style categories on rasters

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsmaplayerutils.py
+++ b/python/PyQt6/core/auto_additions/qgsmaplayerutils.py
@@ -7,5 +7,6 @@ try:
     QgsMapLayerUtils.sortLayersByType = staticmethod(QgsMapLayerUtils.sortLayersByType)
     QgsMapLayerUtils.launderLayerName = staticmethod(QgsMapLayerUtils.launderLayerName)
     QgsMapLayerUtils.isOpenStreetMapLayer = staticmethod(QgsMapLayerUtils.isOpenStreetMapLayer)
+    QgsMapLayerUtils.translateLayerType = staticmethod(QgsMapLayerUtils.translateLayerType)
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgsmaplayerutils.py
+++ b/python/PyQt6/core/auto_additions/qgsmaplayerutils.py
@@ -7,6 +7,6 @@ try:
     QgsMapLayerUtils.sortLayersByType = staticmethod(QgsMapLayerUtils.sortLayersByType)
     QgsMapLayerUtils.launderLayerName = staticmethod(QgsMapLayerUtils.launderLayerName)
     QgsMapLayerUtils.isOpenStreetMapLayer = staticmethod(QgsMapLayerUtils.isOpenStreetMapLayer)
-    QgsMapLayerUtils.translateLayerType = staticmethod(QgsMapLayerUtils.translateLayerType)
+    QgsMapLayerUtils.layerTypeToString = staticmethod(QgsMapLayerUtils.layerTypeToString)
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerutils.sip.in
@@ -94,7 +94,7 @@ Returns ``True`` if the layer is served by OpenStreetMap server.
 .. versionadded:: 3.40
 %End
 
-    static QString translateLayerType( const Qgis::LayerType &type );
+    static QString translateLayerType( Qgis::LayerType type );
 %Docstring
 Returns the translated name of the type for a given layer type.
 

--- a/python/PyQt6/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerutils.sip.in
@@ -94,6 +94,13 @@ Returns ``True`` if the layer is served by OpenStreetMap server.
 .. versionadded:: 3.40
 %End
 
+    static QString translateLayerType( const Qgis::LayerType &type );
+%Docstring
+Returns the translated name of the type for a given layer type.
+
+.. versionadded:: 4.0
+%End
+
 };
 
 

--- a/python/PyQt6/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmaplayerutils.sip.in
@@ -94,7 +94,7 @@ Returns ``True`` if the layer is served by OpenStreetMap server.
 .. versionadded:: 3.40
 %End
 
-    static QString translateLayerType( Qgis::LayerType type );
+    static QString layerTypeToString( Qgis::LayerType type );
 %Docstring
 Returns the translated name of the type for a given layer type.
 

--- a/python/core/auto_additions/qgsmaplayerutils.py
+++ b/python/core/auto_additions/qgsmaplayerutils.py
@@ -7,5 +7,6 @@ try:
     QgsMapLayerUtils.sortLayersByType = staticmethod(QgsMapLayerUtils.sortLayersByType)
     QgsMapLayerUtils.launderLayerName = staticmethod(QgsMapLayerUtils.launderLayerName)
     QgsMapLayerUtils.isOpenStreetMapLayer = staticmethod(QgsMapLayerUtils.isOpenStreetMapLayer)
+    QgsMapLayerUtils.translateLayerType = staticmethod(QgsMapLayerUtils.translateLayerType)
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_additions/qgsmaplayerutils.py
+++ b/python/core/auto_additions/qgsmaplayerutils.py
@@ -7,6 +7,6 @@ try:
     QgsMapLayerUtils.sortLayersByType = staticmethod(QgsMapLayerUtils.sortLayersByType)
     QgsMapLayerUtils.launderLayerName = staticmethod(QgsMapLayerUtils.launderLayerName)
     QgsMapLayerUtils.isOpenStreetMapLayer = staticmethod(QgsMapLayerUtils.isOpenStreetMapLayer)
-    QgsMapLayerUtils.translateLayerType = staticmethod(QgsMapLayerUtils.translateLayerType)
+    QgsMapLayerUtils.layerTypeToString = staticmethod(QgsMapLayerUtils.layerTypeToString)
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/core/auto_generated/qgsmaplayerutils.sip.in
@@ -94,7 +94,7 @@ Returns ``True`` if the layer is served by OpenStreetMap server.
 .. versionadded:: 3.40
 %End
 
-    static QString translateLayerType( const Qgis::LayerType &type );
+    static QString translateLayerType( Qgis::LayerType type );
 %Docstring
 Returns the translated name of the type for a given layer type.
 

--- a/python/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/core/auto_generated/qgsmaplayerutils.sip.in
@@ -94,6 +94,13 @@ Returns ``True`` if the layer is served by OpenStreetMap server.
 .. versionadded:: 3.40
 %End
 
+    static QString translateLayerType( const Qgis::LayerType &type );
+%Docstring
+Returns the translated name of the type for a given layer type.
+
+.. versionadded:: 4.0
+%End
+
 };
 
 

--- a/python/core/auto_generated/qgsmaplayerutils.sip.in
+++ b/python/core/auto_generated/qgsmaplayerutils.sip.in
@@ -94,7 +94,7 @@ Returns ``True`` if the layer is served by OpenStreetMap server.
 .. versionadded:: 3.40
 %End
 
-    static QString translateLayerType( Qgis::LayerType type );
+    static QString layerTypeToString( Qgis::LayerType type );
 %Docstring
 Returns the translated name of the type for a given layer type.
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -74,7 +74,7 @@
 #include <QWindow>
 #include <QActionGroup>
 
-#include "qgsmaplayerutils.cpp"
+#include "qgsmaplayerutils.h"
 #include "qgsscreenhelper.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsnetworkaccessmanager.h"

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10425,7 +10425,7 @@ void QgisApp::pasteStyle( QgsMapLayer *destinationLayer, QgsMapLayer::StyleCateg
       const Qgis::LayerType styleOriginType { qgsEnumKeyToValue( rootElement.attribute( QStringLiteral( "layerType" ) ), Qgis::LayerType::Vector ) };
       if ( selectionLayer->type() != styleOriginType )
       {
-        visibleMessageBar()->pushMessage( tr( "Cannot paste style to layer '%1' because the type doesn't match (%2 → %3)" ).arg( selectionLayer->name(), qgsEnumValueToKey( styleOriginType ), qgsEnumValueToKey( selectionLayer->type() ) ), errorMsg, Qgis::MessageLevel::Warning );
+        visibleMessageBar()->pushMessage( tr( "Cannot paste style to layer '%1' because the type doesn't match (%2 → %3)" ).arg( selectionLayer->name(), QgsMapLayerUtils::translateLayerType( styleOriginType ), QgsMapLayerUtils::translateLayerType( selectionLayer->type() ) ), errorMsg, Qgis::MessageLevel::Warning );
         return;
       }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10421,9 +10421,11 @@ void QgisApp::pasteStyle( QgsMapLayer *destinationLayer, QgsMapLayer::StyleCateg
         return;
       }
 
-      bool isVectorStyle = doc.elementsByTagName( QStringLiteral( "pipe" ) ).isEmpty();
-      if ( ( selectionLayer->type() == Qgis::LayerType::Raster && isVectorStyle ) || ( selectionLayer->type() == Qgis::LayerType::Vector && !isVectorStyle ) )
+      const QDomElement rootElement { doc.firstChildElement( QStringLiteral( "qgis" ) ) };
+      const Qgis::LayerType styleOriginType { qgsEnumKeyToValue( rootElement.attribute( QStringLiteral( "layerType" ) ), Qgis::LayerType::Vector ) };
+      if ( selectionLayer->type() != styleOriginType )
       {
+        visibleMessageBar()->pushMessage( tr( "Cannot paste style to layer '%1' because the type doesn't match (%2 → %3)" ).arg( selectionLayer->name(), qgsEnumValueToKey( styleOriginType ), qgsEnumValueToKey( selectionLayer->type() ) ), errorMsg, Qgis::MessageLevel::Warning );
         return;
       }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10426,7 +10426,7 @@ void QgisApp::pasteStyle( QgsMapLayer *destinationLayer, QgsMapLayer::StyleCateg
       const Qgis::LayerType styleOriginType { qgsEnumKeyToValue( rootElement.attribute( QStringLiteral( "layerType" ) ), Qgis::LayerType::Vector ) };
       if ( selectionLayer->type() != styleOriginType )
       {
-        visibleMessageBar()->pushMessage( tr( "Cannot paste style to layer '%1' because the type doesn't match (%2 → %3)" ).arg( selectionLayer->name(), QgsMapLayerUtils::translateLayerType( styleOriginType ), QgsMapLayerUtils::translateLayerType( selectionLayer->type() ) ), errorMsg, Qgis::MessageLevel::Warning );
+        visibleMessageBar()->pushMessage( tr( "Cannot paste style to layer '%1' because the type doesn't match (%2 → %3)" ).arg( selectionLayer->name(), QgsMapLayerUtils::layerTypeToString( styleOriginType ), QgsMapLayerUtils::layerTypeToString( selectionLayer->type() ) ), errorMsg, Qgis::MessageLevel::Warning );
         return;
       }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -74,6 +74,7 @@
 #include <QWindow>
 #include <QActionGroup>
 
+#include "qgsmaplayerutils.cpp"
 #include "qgsscreenhelper.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsnetworkaccessmanager.h"

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -846,6 +846,9 @@ void QgsMapLayer::writeCommonStyle( QDomElement &layerElement, QDomDocument &doc
   const QString categoriesKeys( metaEnum.valueToKeys( static_cast<int>( categories ) ) );
   layerElement.setAttribute( QStringLiteral( "styleCategories" ), categoriesKeys );
 
+  // Store layer type
+  layerElement.setAttribute( QStringLiteral( "layerType" ), qgsEnumValueToKey( type() ) );
+
   if ( categories.testFlag( Rendering ) )
   {
     // use scale dependent visibility flag

--- a/src/core/qgsmaplayerlegend.cpp
+++ b/src/core/qgsmaplayerlegend.cpp
@@ -48,7 +48,10 @@ void QgsMapLayerLegend::readXml( const QDomElement &elem, const QgsReadWriteCont
 QDomElement QgsMapLayerLegend::writeXml( QDomDocument &doc, const QgsReadWriteContext & ) const
 {
   QDomElement elem = doc.createElement( QStringLiteral( "legend" ) );
-  elem.setAttribute( QStringLiteral( "excludeByDefault" ), mFlags.testFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault ) ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+  if ( mFlags.testFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault ) )
+  {
+    elem.setAttribute( QStringLiteral( "excludeByDefault" ),  QStringLiteral( "1" ) );
+  }
   return elem;
 }
 

--- a/src/core/qgsmaplayerlegend.cpp
+++ b/src/core/qgsmaplayerlegend.cpp
@@ -42,17 +42,14 @@ QgsMapLayerLegend::QgsMapLayerLegend( QObject *parent )
 void QgsMapLayerLegend::readXml( const QDomElement &elem, const QgsReadWriteContext & )
 {
   mFlags = Qgis::MapLayerLegendFlags();
-  mFlags.setFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault, elem.attribute( QStringLiteral( "excludeByDefault" ), QStringLiteral( "0" ) ).toInt() );
+  mFlags.setFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault, elem.attribute( QStringLiteral( "excludeByDefault" ), QStringLiteral( "0" ) ).toInt() == 1 );
 }
 
 QDomElement QgsMapLayerLegend::writeXml( QDomDocument &doc, const QgsReadWriteContext & ) const
 {
   QDomElement elem = doc.createElement( QStringLiteral( "legend" ) );
-
-  if ( mFlags.testFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault ) )
-    elem.setAttribute( QStringLiteral( "excludeByDefault" ), QStringLiteral( "1" ) );
-
-  return elem.attributes().isEmpty() ? QDomElement() : elem;
+  elem.setAttribute( QStringLiteral( "excludeByDefault" ), mFlags.testFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault ) ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+  return elem;
 }
 
 QgsMapLayerLegend *QgsMapLayerLegend::defaultVectorLegend( QgsVectorLayer *vl )

--- a/src/core/qgsmaplayerutils.cpp
+++ b/src/core/qgsmaplayerutils.cpp
@@ -187,7 +187,7 @@ bool QgsMapLayerUtils::isOpenStreetMapLayer( QgsMapLayer *layer )
   return false;
 }
 
-QString QgsMapLayerUtils::translateLayerType( const Qgis::LayerType &type )
+QString QgsMapLayerUtils::translateLayerType( Qgis::LayerType type )
 {
   switch ( type )
   {

--- a/src/core/qgsmaplayerutils.cpp
+++ b/src/core/qgsmaplayerutils.cpp
@@ -187,7 +187,7 @@ bool QgsMapLayerUtils::isOpenStreetMapLayer( QgsMapLayer *layer )
   return false;
 }
 
-QString QgsMapLayerUtils::translateLayerType( Qgis::LayerType type )
+QString QgsMapLayerUtils::layerTypeToString( Qgis::LayerType type )
 {
   switch ( type )
   {

--- a/src/core/qgsmaplayerutils.cpp
+++ b/src/core/qgsmaplayerutils.cpp
@@ -186,3 +186,30 @@ bool QgsMapLayerUtils::isOpenStreetMapLayer( QgsMapLayer *layer )
   }
   return false;
 }
+
+QString QgsMapLayerUtils::translateLayerType( const Qgis::LayerType &type )
+{
+  switch ( type )
+  {
+    case Qgis::LayerType::Vector:
+      return QObject::tr( "Vector" );
+    case Qgis::LayerType::Raster:
+      return QObject::tr( "Raster" );
+    case Qgis::LayerType::Mesh:
+      return QObject::tr( "Mesh" );
+    case Qgis::LayerType::PointCloud:
+      return QObject::tr( "Point Cloud" );
+    case Qgis::LayerType::Annotation:
+      return QObject::tr( "Annotation" );
+    case Qgis::LayerType::VectorTile:
+      return QObject::tr( "Vector Tile" );
+    case Qgis::LayerType::Plugin:
+      return QObject::tr( "Plugin" );
+    case Qgis::LayerType::Group:
+      return QObject::tr( "Group" );
+    case Qgis::LayerType::TiledScene:
+      return QObject::tr( "Tiled Scene" );
+  }
+  Q_ASSERT( false );
+  return QString();
+}

--- a/src/core/qgsmaplayerutils.h
+++ b/src/core/qgsmaplayerutils.h
@@ -109,7 +109,7 @@ class CORE_EXPORT QgsMapLayerUtils
      *
      * \since QGIS 4.0
      */
-    static QString translateLayerType( const Qgis::LayerType &type );
+    static QString translateLayerType( Qgis::LayerType type );
 
 };
 

--- a/src/core/qgsmaplayerutils.h
+++ b/src/core/qgsmaplayerutils.h
@@ -109,7 +109,7 @@ class CORE_EXPORT QgsMapLayerUtils
      *
      * \since QGIS 4.0
      */
-    static QString translateLayerType( Qgis::LayerType type );
+    static QString layerTypeToString( Qgis::LayerType type );
 
 };
 

--- a/src/core/qgsmaplayerutils.h
+++ b/src/core/qgsmaplayerutils.h
@@ -104,6 +104,13 @@ class CORE_EXPORT QgsMapLayerUtils
      */
     static bool isOpenStreetMapLayer( QgsMapLayer *layer );
 
+    /**
+     * Returns the translated name of the type for a given layer type.
+     *
+     * \since QGIS 4.0
+     */
+    static QString translateLayerType( const Qgis::LayerType &type );
+
 };
 
 #endif // QGSMAPLAYERUTILS_H

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2284,9 +2284,15 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
     QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Legend" ) );
 
     const QDomElement legendElem = layer_node.firstChildElement( QStringLiteral( "legend" ) );
-    if ( QgsMapLayerLegend *l = legend(); !legendElem.isNull() )
+    QgsMapLayerLegend *rasterLegend = legend();
+    if ( rasterLegend && !legendElem.isNull() )
     {
-      l->readXml( legendElem, context );
+      rasterLegend->readXml( legendElem, context );
+    }
+    else if ( rasterLegend )
+    {
+      // Temporary fix for #63346 because legend was not saved if empty
+      rasterLegend->setFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault, false );
     }
   }
 

--- a/tests/src/app/testqgisapp.cpp
+++ b/tests/src/app/testqgisapp.cpp
@@ -39,15 +39,16 @@ class TestQgisApp : public QObject
     void cleanupTestCase(); // will be called after the last testfunction was executed.
     void init();            // will be called before each testfunction is executed.
     void cleanup();         // will be called after every testfunction.
+    //! Test for issue GH #63346
+    void pasteRasterStyleCategory();
 
+  public slots:
     void addVectorLayerShp();
     void addVectorLayerGeopackageSingleLayer();
     void addVectorLayerGeopackageSingleLayerAlreadyLayername();
     void addVectorLayerInvalid();
     void addEmbeddedGroup();
     void pasteFeature();
-    //! Test for issue GH #63346
-    void pasteRasterStyleCategory();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -222,6 +223,18 @@ void TestQgisApp::pasteRasterStyleCategory()
   mQgisApp->pasteStyle( &rl2, QgsMapLayer::StyleCategory::Legend );
 
   QVERIFY( rl2.legend()->flags().testFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault ) );
+
+  // Check the other way round
+  rl1.legend()->setFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault, false );
+  rl2.legend()->setFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault, true );
+  QVERIFY( !rl1.legend()->flags().testFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault ) );
+  QVERIFY( rl2.legend()->flags().testFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault ) );
+
+  // Copy style from raster 1
+  mQgisApp->copyStyle( &rl1, QgsMapLayer::StyleCategory::Legend );
+  // Paste style to raster 2
+  mQgisApp->pasteStyle( &rl2, QgsMapLayer::StyleCategory::Legend );
+  QVERIFY( !rl2.legend()->flags().testFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault ) );
 }
 
 


### PR DESCRIPTION
Fix paste style categories on rasters.

Pasting raster categories other than symbology was a no-op

Fix https://github.com/qgis/QGIS/issues/63346