### PR TITLE
[i3s] Add browser GUI support for Scene Servers

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -726,6 +726,7 @@
         <file>themes/default/styleicons/singlebandpseudocolor.svg</file>
         <file>themes/default/mIconAfs.svg</file>
         <file>themes/default/mIconAms.svg</file>
+        <file>themes/default/mIconEsriI3s.svg</file>
         <file>themes/default/mActionAddAmsLayer.svg</file>
         <file>themes/default/mActionAddAfsLayer.svg</file>
         <file>themes/default/mIconFormSelect.svg</file>

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -7828,6 +7828,9 @@ QgsArcGisPortalUtils.GeocodeServer.__doc__ = "GeocodeServer"
 QgsArcGisPortalUtils.Unknown = Qgis.ArcGisRestServiceType.Unknown
 QgsArcGisPortalUtils.Unknown.is_monkey_patched = True
 QgsArcGisPortalUtils.Unknown.__doc__ = "Other unknown/unsupported type"
+QgsArcGisPortalUtils.SceneServer = Qgis.ArcGisRestServiceType.SceneServer
+QgsArcGisPortalUtils.SceneServer.is_monkey_patched = True
+QgsArcGisPortalUtils.SceneServer.__doc__ = "SceneServer"
 Qgis.ArcGisRestServiceType.__doc__ = """Available ArcGIS REST service types.
 
 .. note::
@@ -7852,6 +7855,7 @@ Qgis.ArcGisRestServiceType.__doc__ = """Available ArcGIS REST service types.
 * ``GPServer``: GPServer
 * ``GeocodeServer``: GeocodeServer
 * ``Unknown``: Other unknown/unsupported type
+* ``SceneServer``: SceneServer
 
 """
 # --

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2443,6 +2443,7 @@ The development version
       GPServer,
       GeocodeServer,
       Unknown,
+      SceneServer,
     };
 
     enum class RelationshipType /BaseType=IntEnum/

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -7755,6 +7755,9 @@ QgsArcGisPortalUtils.GeocodeServer.__doc__ = "GeocodeServer"
 QgsArcGisPortalUtils.Unknown = Qgis.ArcGisRestServiceType.Unknown
 QgsArcGisPortalUtils.Unknown.is_monkey_patched = True
 QgsArcGisPortalUtils.Unknown.__doc__ = "Other unknown/unsupported type"
+QgsArcGisPortalUtils.SceneServer = Qgis.ArcGisRestServiceType.SceneServer
+QgsArcGisPortalUtils.SceneServer.is_monkey_patched = True
+QgsArcGisPortalUtils.SceneServer.__doc__ = "SceneServer"
 Qgis.ArcGisRestServiceType.__doc__ = """Available ArcGIS REST service types.
 
 .. note::
@@ -7779,6 +7782,7 @@ Qgis.ArcGisRestServiceType.__doc__ = """Available ArcGIS REST service types.
 * ``GPServer``: GPServer
 * ``GeocodeServer``: GeocodeServer
 * ``Unknown``: Other unknown/unsupported type
+* ``SceneServer``: SceneServer
 
 """
 # --

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -2443,6 +2443,7 @@ The development version
       GPServer,
       GeocodeServer,
       Unknown,
+      SceneServer,
     };
 
     enum class RelationshipType

--- a/src/core/providers/arcgis/qgsarcgisportalutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisportalutils.cpp
@@ -136,6 +136,8 @@ QString QgsArcGisPortalUtils::typeToString( Qgis::ArcGisRestServiceType type )
       return QStringLiteral( "Map Service" );
     case Qgis::ArcGisRestServiceType::ImageServer:
       return QStringLiteral( "Image Service" );
+    case Qgis::ArcGisRestServiceType::SceneServer:
+      return QStringLiteral( "Scene Service" );
 
     case Qgis::ArcGisRestServiceType::GlobeServer:
     case Qgis::ArcGisRestServiceType::GPServer:

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -353,6 +353,7 @@ void QgsArcGisRestQueryUtils::visitServiceItems( const std::function<void ( cons
       case Qgis::ArcGisRestServiceType::FeatureServer:
       case Qgis::ArcGisRestServiceType::MapServer:
       case Qgis::ArcGisRestServiceType::ImageServer:
+      case Qgis::ArcGisRestServiceType::SceneServer:
         // supported
         break;
 
@@ -415,6 +416,14 @@ void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QS
     const QString parentLayerId = layerInfoMap.value( QStringLiteral( "parentLayerId" ) ).toString();
     const QString name = layerInfoMap.value( QStringLiteral( "name" ) ).toString();
     const QString description = layerInfoMap.value( QStringLiteral( "description" ) ).toString();
+
+    if ( filter == ServiceTypeFilter::Scene )
+    {
+      {
+        visitor( parentLayerId, ServiceTypeFilter::Scene, Qgis::GeometryType::Unknown, id, name, description, parentUrl, false, crs, format );
+      }
+      continue;
+    }
 
     // Yes, potentially we may visit twice, once as as a raster (if applicable), and once as a vector (if applicable)!
     if ( serviceMayRenderMaps && ( filter == ServiceTypeFilter::Raster || filter == ServiceTypeFilter::AllTypes ) )

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -419,9 +419,7 @@ void QgsArcGisRestQueryUtils::addLayerItems( const std::function<void ( const QS
 
     if ( filter == ServiceTypeFilter::Scene )
     {
-      {
-        visitor( parentLayerId, ServiceTypeFilter::Scene, Qgis::GeometryType::Unknown, id, name, description, parentUrl, false, crs, format );
-      }
+      visitor( parentLayerId, ServiceTypeFilter::Scene, Qgis::GeometryType::Unknown, id, name, description, parentUrl, false, crs, format );
       continue;
     }
 

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -45,7 +45,8 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
     {
       AllTypes, //!< All types
       Vector,   //!< Vector type
-      Raster   //!< Raster type
+      Raster,   //!< Raster type
+      Scene    //!< Scene
     };
 
     /**

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1955,6 +1955,8 @@ Qgis::ArcGisRestServiceType QgsArcGisRestUtils::serviceTypeFromString( const QSt
     return Qgis::ArcGisRestServiceType::GPServer;
   else if ( type.compare( QLatin1String( "GeocodeServer" ), Qt::CaseInsensitive ) == 0 )
     return Qgis::ArcGisRestServiceType::GeocodeServer;
+  else if ( type.compare( QLatin1String( "SceneServer" ), Qt::CaseInsensitive ) == 0 )
+    return Qgis::ArcGisRestServiceType::SceneServer;
 
   return Qgis::ArcGisRestServiceType::Unknown;
 }

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4339,6 +4339,7 @@ class CORE_EXPORT Qgis
       GPServer, //!< GPServer
       GeocodeServer, //!< GeocodeServer
       Unknown, //!< Other unknown/unsupported type
+      SceneServer, //!< SceneServer
     };
     Q_ENUM( ArcGisRestServiceType )
 

--- a/src/core/tiledscene/qgsesrii3sdataprovider.cpp
+++ b/src/core/tiledscene/qgsesrii3sdataprovider.cpp
@@ -1100,7 +1100,8 @@ QVariantMap QgsEsriI3SProviderMetadata::decodeUri( const QString &uri ) const
 QString QgsEsriI3SProviderMetadata::encodeUri( const QVariantMap &parts ) const
 {
   QgsDataSourceUri dsUri;
-  dsUri.setParam( QStringLiteral( "url" ), parts.value( parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" ) ).toString() );
+  const QString partsKey = parts.contains( QStringLiteral( "path" ) ) ? QStringLiteral( "path" ) : QStringLiteral( "url" );
+  dsUri.setParam( QStringLiteral( "url" ), parts.value( partsKey ).toString() );
   return dsUri.encodedUri();
 }
 

--- a/src/core/tiledscene/qgsesrii3sdataprovider.h
+++ b/src/core/tiledscene/qgsesrii3sdataprovider.h
@@ -88,7 +88,9 @@ class QgsEsriI3SProviderMetadata : public QgsProviderMetadata
     QString filters( Qgis::FileFilterType type ) override;
     ProviderCapabilities providerCapabilities() const override;
     QList< Qgis::LayerType > supportedLayerTypes() const override;
-
+    QVariantMap decodeUri( const QString &uri ) const override;
+    QString encodeUri( const QVariantMap &parts ) const override;
+    QList<QgsProviderSublayerDetails> querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags, QgsFeedback *feedback ) const override;
 };
 
 ///@endcond

--- a/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
@@ -109,6 +109,14 @@ void QgsArcGisRestDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
     } );
     menu->addAction( viewInfo );
   }
+  else if ( QgsArcGisSceneServiceItem *serviceItem = qobject_cast<QgsArcGisSceneServiceItem *>( item ) )
+  {
+    QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
+    connect( viewInfo, &QAction::triggered, this, [serviceItem] {
+      QDesktopServices::openUrl( QUrl( serviceItem->path() ) );
+    } );
+    menu->addAction( viewInfo );
+  }
   else if ( QgsArcGisRestParentLayerItem *layerItem = qobject_cast<QgsArcGisRestParentLayerItem *>( item ) )
   {
     QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
@@ -137,6 +145,16 @@ void QgsArcGisRestDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
     } );
   }
   else if ( QgsArcGisMapServiceLayerItem *layerItem = qobject_cast<QgsArcGisMapServiceLayerItem *>( item ) )
+  {
+    QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
+    connect( viewInfo, &QAction::triggered, this, [layerItem] {
+      QDesktopServices::openUrl( QUrl( layerItem->path() ) );
+    } );
+    menu->addAction( viewInfo );
+    menu->addSeparator();
+  }
+
+  else if ( QgsArcGisSceneServiceLayerItem *layerItem = qobject_cast<QgsArcGisSceneServiceLayerItem *>( item ) )
   {
     QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
     connect( viewInfo, &QAction::triggered, this, [layerItem] {

--- a/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
@@ -153,7 +153,6 @@ void QgsArcGisRestDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
     menu->addAction( viewInfo );
     menu->addSeparator();
   }
-
   else if ( QgsArcGisSceneServiceLayerItem *layerItem = qobject_cast<QgsArcGisSceneServiceLayerItem *>( item ) )
   {
     QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.h
@@ -211,6 +211,30 @@ class QgsArcGisMapServiceItem : public QgsDataCollectionItem
 };
 
 /**
+ * Represents a ArcGIS REST "Scene Service"
+ *
+ * Usually has no child items, but sometimes services are nested and will contain other QgsArcGisSceneServiceItem children
+ * or QgsArcGisRestFolderItem children.
+ */
+class QgsArcGisSceneServiceItem : public QgsDataCollectionItem
+{
+    Q_OBJECT
+  public:
+    QgsArcGisSceneServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix );
+    void setSupportedFormats( const QString &formats );
+    QVector<QgsDataItem *> createChildren() override;
+    bool equal( const QgsDataItem *other ) override;
+
+  private:
+    QString mFolder;
+    QString mBaseUrl;
+    QString mAuthCfg;
+    QgsHttpHeaders mHeaders;
+    QString mUrlPrefix;
+    QString mSupportedFormats;
+};
+
+/**
  * Represents a "parent layer" containing one or more QgsArcGisFeatureServiceItem or QgsArcGisMapServiceItem children.
  */
 class QgsArcGisRestParentLayerItem : public QgsDataItem
@@ -274,6 +298,16 @@ class QgsArcGisMapServiceLayerItem : public QgsArcGisRestLayerItem
     QString mSupportedFormats;
 };
 
+/**
+ * Represents a ArcGIS REST "Scene Service" layer item.
+ */
+class QgsArcGisSceneServiceLayerItem : public QgsArcGisRestLayerItem
+{
+    Q_OBJECT
+
+  public:
+    QgsArcGisSceneServiceLayerItem( QgsDataItem *parent, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &authcfg, const QgsHttpHeaders &headers, const QString urlPrefix );
+};
 
 //! Provider for ArcGIS REST root data item
 class QgsArcGisRestDataItemProvider : public QgsDataItemProvider

--- a/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
@@ -181,7 +181,7 @@ void QgsArcGisRestSourceSelect::showEvent( QShowEvent * )
   mBrowserView->expand( mProxyModel->index( 0, 0 ) );
   mBrowserView->setHeaderHidden( true );
 
-  mProxyModel->setShownDataItemProviderKeyFilter( QStringList() << QStringLiteral( "AFS" ) << QStringLiteral( "arcgisfeatureserver" ) << QStringLiteral( "AMS" ) << QStringLiteral( "arcgismapserver" ) );
+  mProxyModel->setShownDataItemProviderKeyFilter( QStringList() << QStringLiteral( "AFS" ) << QStringLiteral( "arcgisfeatureserver" ) << QStringLiteral( "AMS" ) << QStringLiteral( "arcgismapserver" ) << QStringLiteral( "I3S" ) << QStringLiteral( "esrii3s" ) );
 
   const QModelIndex afsSourceIndex = mBrowserModel->findPath( QStringLiteral( "arcgisfeatureserver:" ) );
   mBrowserView->setRootIndex( mProxyModel->mapFromSource( afsSourceIndex ) );
@@ -346,6 +346,10 @@ void QgsArcGisRestSourceSelect::addButtonClicked()
         emit addRasterLayer( uri, layerName, QStringLiteral( "arcgismapserver" ) );
         Q_NOWARN_DEPRECATED_POP
         emit addLayer( Qgis::LayerType::Raster, uri, layerName, QStringLiteral( "arcgismapserver" ) );
+        break;
+
+      case Qgis::ArcGisRestServiceType::SceneServer:
+        emit addLayer( Qgis::LayerType::TiledScene, uri, layerName, QStringLiteral( "esrii3s" ) );
         break;
 
       case Qgis::ArcGisRestServiceType::ImageServer:
@@ -579,6 +583,10 @@ QString QgsArcGisRestSourceSelect::indexToUri( const QModelIndex &proxyIndex, QS
       uri.removeParam( QStringLiteral( "format" ) );
       uri.setParam( QStringLiteral( "format" ), getSelectedImageEncoding() );
       serviceType = Qgis::ArcGisRestServiceType::MapServer;
+    }
+    else if ( qobject_cast<QgsArcGisSceneServiceLayerItem *>( layerItem ) )
+    {
+      serviceType = Qgis::ArcGisRestServiceType::SceneServer;
     }
     return uri.uri( false );
   }

--- a/tests/src/python/test_qgsesrii3slayer.py
+++ b/tests/src/python/test_qgsesrii3slayer.py
@@ -50,7 +50,7 @@ def _make_tmp_eslpk_dataset(
 
 class TestQgsEsriI3sLayer(unittest.TestCase):
     def test_invalid_source(self):
-        layer = QgsTiledSceneLayer("file:///nope", "my layer", "esrii3s")
+        layer = QgsTiledSceneLayer("url=file:///nope", "my layer", "esrii3s")
         self.assertFalse(layer.dataProvider().isValid())
 
     def test_invalid_json(self):
@@ -62,7 +62,7 @@ class TestQgsEsriI3sLayer(unittest.TestCase):
             """
             _make_tmp_eslpk_dataset(temp_dir, layer_json, "")
 
-            layer = QgsTiledSceneLayer("file://" + temp_dir, "my layer", "esrii3s")
+            layer = QgsTiledSceneLayer("url=file://" + temp_dir, "my layer", "esrii3s")
             self.assertFalse(layer.dataProvider().isValid())
             self.assertEqual(
                 layer.error().summary(),
@@ -73,7 +73,7 @@ class TestQgsEsriI3sLayer(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             _make_tmp_eslpk_dataset(temp_dir, "", "", "1.6")
 
-            layer = QgsTiledSceneLayer("file://" + temp_dir, "my layer", "esrii3s")
+            layer = QgsTiledSceneLayer("url=file://" + temp_dir, "my layer", "esrii3s")
             self.assertFalse(layer.dataProvider().isValid())
             self.assertEqual(
                 layer.error().summary(),
@@ -118,7 +118,7 @@ class TestQgsEsriI3sLayer(unittest.TestCase):
             """
             _make_tmp_eslpk_dataset(temp_dir, layer_json, nodepage_json)
 
-            layer = QgsTiledSceneLayer("file://" + temp_dir, "my layer", "esrii3s")
+            layer = QgsTiledSceneLayer("url=file://" + temp_dir, "my layer", "esrii3s")
             self.assertTrue(layer.dataProvider().isValid())
 
             self.assertEqual(layer.crs(), QgsCoordinateReferenceSystem("EPSG:4979"))
@@ -198,7 +198,7 @@ class TestQgsEsriI3sLayer(unittest.TestCase):
             """
             _make_tmp_eslpk_dataset(temp_dir, layer_json, nodepage_json)
 
-            layer = QgsTiledSceneLayer("file://" + temp_dir, "my layer", "esrii3s")
+            layer = QgsTiledSceneLayer("url=file://" + temp_dir, "my layer", "esrii3s")
             self.assertTrue(layer.dataProvider().isValid())
 
             self.assertEqual(layer.crs(), QgsCoordinateReferenceSystem("EPSG:5514"))
@@ -561,7 +561,7 @@ class TestQgsEsriI3sLayer(unittest.TestCase):
             """
             _make_tmp_eslpk_dataset(temp_dir, layer_json, nodepage_json)
 
-            layer = QgsTiledSceneLayer("file://" + temp_dir, "my layer", "esrii3s")
+            layer = QgsTiledSceneLayer("url=file://" + temp_dir, "my layer", "esrii3s")
             self.assertTrue(layer.dataProvider().isValid())
 
             index = layer.dataProvider().index()


### PR DESCRIPTION
This PR adds browser GUI support for ESRI I3S provider.

Scene Servers are accessible from the browser panel and ground work is done for the loading of local SLPK files.

<img width="317" height="550" alt="image" src="https://github.com/user-attachments/assets/cea22118-3e7a-4307-89a9-888ba3d3274e" />

<img width="1608" height="1019" alt="image" src="https://github.com/user-attachments/assets/c6f0bc1b-aad9-40d7-a87d-38ba7fd00060" />


Funded by [QGIS 3D for Open Source Digital Twins](https://www.lutraconsulting.co.uk/crowdfunding/qgis-3d-for-open-source-digital-twins)