### PR TITLE
Fix QGIS Server WFS GetFeature request with BBOX or EXP_FILTER or FILTER and SORTBY

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -838,7 +838,6 @@ namespace QgsWfs
         getFeatureQuery &query = *qIt;
         query.featureRequest.setFilterRect( extent ).setFlags( query.featureRequest.flags() | Qgis::FeatureRequestFlag::ExactIntersect );
       }
-      return request;
     }
     else if ( paramContainsFilters )
     {
@@ -875,7 +874,6 @@ namespace QgsWfs
           ++filterIt;
         }
       }
-      return request;
     }
 
     QStringList sortByList = mWfsParameters.sortBy();

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -212,6 +212,10 @@ class TestQgsServerWFS(QgsServerTestBase):
         tests.append(("sortby", "GetFeature&TYPENAME=testlayer&SORTBY=id D"))
         tests.append(("hits", "GetFeature&TYPENAME=testlayer&RESULTTYPE=hits"))
 
+        # SORTBY is apply even if a bbox or filter is provided
+        tests.append(("sortby", "GetFeature&TYPENAME=testlayer&EXP_FILTER=True&SORTBY=id D"))
+        tests.append(("sortby_bbox", "GetFeature&TYPENAME=testlayer&BBOX=8.203127,44.9012765,8.204138,44.901632&SORTBY=id D"))
+
         for id, req in tests:
             self.wfs_getfeature_compare(id, req)
 

--- a/tests/testdata/qgis_server/wfs_getfeature_sortby_bbox.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_sortby_bbox.txt
@@ -1,0 +1,60 @@
+Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/ale/dev/QGIS/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SORTBY=id D&amp;SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=XMLSCHEMA">
+<gml:boundedBy>
+ <gml:Box srsName="EPSG:4326">
+  <gml:coordinates cs="," ts=" ">8.203127,44.9012765 8.204138,44.901632</gml:coordinates>
+ </gml:Box>
+</gml:boundedBy>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.2">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20345931,44.90139484 8.20345931,44.90139484</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20345931,44.90139484</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>3</qgs:id>
+  <qgs:name>three</qgs:name>
+  <qgs:utf8nameè>three èé↓</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.1">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20354699,44.90143568 8.20354699,44.90143568</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20354699,44.90143568</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>2</qgs:id>
+  <qgs:name>two</qgs:name>
+  <qgs:utf8nameè>two àò</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.0">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:4326">
+    <gml:coordinates cs="," ts=" ">8.20349634,44.90148253 8.20349634,44.90148253</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:4326">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">8.20349634,44.90148253</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>1</qgs:id>
+  <qgs:name>one</qgs:name>
+  <qgs:utf8nameè>one èé</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+</wfs:FeatureCollection>


### PR DESCRIPTION
The SORTBY parameter is not apply if a filter is defined with BBOX, FILTER and EXP_FILTER parameter.

Funded By 3Liz