### PR TITLE
Fix `loading x tiles` message in 3d views with flat terrain

### DIFF
--- a/src/3d/chunks/qgschunkloader.cpp
+++ b/src/3d/chunks/qgschunkloader.cpp
@@ -62,7 +62,8 @@ QVector<QgsChunkNode *> QgsQuadtreeChunkLoaderFactory::createChildren( QgsChunkN
     const double chZMax = box3D.zMaximum();
     const QgsBox3D childBox3D( chXMin, chYMin, chZMin, chXMax, chYMax, chZMax );
 
-    if ( mClippingBox3D.isEmpty() || childBox3D.intersects( mClippingBox3D ) )
+    // When there's a clipping box defined, only keep intersecting children. Note that a QgsBox3D.isEmpty() == true when is2d() == true
+    if ( mClippingBox3D.isNull() || childBox3D.intersects( mClippingBox3D ) )
       children << new QgsChunkNode( childId, childBox3D, childError, node );
   }
   return children;


### PR DESCRIPTION
## Description
On 3D views with a flat terrain, near the top and right borders of the scene's 2D extent, when zoomed in, we only want to keep the chunk nodes that actually intersect this 2d clipping extent, and ignore those that do not.

The `QgsQuadtreeChunkLoaderFactory` would erroneously check if the clipping extent is set by calling `QgsBox3D::isEmpty()` , which would always return `true`.
This would cause all those clipped chunks to be added, triggering `QgsTerrainTextureGenerator::render()` to render on an empty extent. `QgsMapRendererJob::finished` was emitted early on the failed render job and `QgsTerrainTileLoader::onImageReady()` was eventually reached before `mTextureJobId` was actually set, so `QgsTerrainTileLoader::finished` was never emitted.

@m-kuhn Do you have a project (or exact steps) that would replicate the issue you described in https://github.com/qgis/QGIS/pull/62858? I wonder if eventually it was the same cause as the one described here.

Once we drop QT5 support, we can tidy this up with `QPromise`s

Fixes #63340
Should also fix #62959
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
