### PR TITLE
Fix camera movement and frustum culling in orthogonal projection

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -489,6 +489,8 @@ void Qgs3DMapScene::onFrameTriggered( float dt )
   mCameraController->frameTriggered( dt );
 
   if( updateScene() )
+    // If the scene was changed, node bboxes might have changed, so we need to
+    // update near/far planes.
     updateCameraNearFarPlanes();
 
   // lock changing the FPS counter to 5 fps

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -382,7 +382,8 @@ class _3D_EXPORT Qgs3DMapScene : public QObject
     void addCameraRotationCenterEntity( QgsCameraController *controller );
     void setSceneState( SceneState state );
     void updateSceneState();
-    void updateScene( bool forceUpdate = false );
+    //! \returns whether at least one node was told to update
+    bool updateScene( bool forceUpdate = false );
     void finalizeNewEntity( Qt3DCore::QEntity *newEntity );
     int maximumTextureSize() const;
 

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -775,9 +775,9 @@ QVector3D Qgs3DUtils::screenPointToWorldPos( const QPoint &screenPoint, double d
   // Transform pixel coordinates and [0.0, 1.0]-range sampled depth to [-1.0, 1.0]
   // normalised device coordinates used by projection matrix.
   QVector3D screenPointNdc {
-    (screenPoint.x() / (screenSize.width() / 2.0f) - 1.0f),
-    -(screenPoint.y() / (screenSize.height() / 2.0f) - 1.0f),
-    static_cast<float>(depth * 2 - 1),
+    ( static_cast<float>( screenPoint.x() ) / ( static_cast<float>( screenSize.width() ) / 2.0f ) - 1.0f ),
+    -( static_cast<float>( screenPoint.y() ) / ( static_cast<float>( screenSize.height() ) / 2.0f ) - 1.0f ),
+    static_cast<float>( depth * 2 - 1 ),
   };
 
   // Apply inverse of projection matrix, then view matrix, to get from NDC to world coords.

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -16,6 +16,7 @@
 #include "qgs3dutils.h"
 
 #include "qgs3dmapcanvas.h"
+#include "qgsapplication.h"
 #include "qgslinestring.h"
 #include "qgspolygon.h"
 #include "qgsfeaturerequest.h"
@@ -79,6 +80,14 @@ void Qgs3DUtils::waitForFrame( QgsAbstract3DEngine &engine, Qgs3DMapScene *scene
   frameAction->deleteLater();
 
   engine.renderSettings()->setRenderPolicy( oldPolicy );
+}
+
+void Qgs3DUtils::waitForEntitiesLoaded( Qgs3DMapScene *scene )
+{
+  while ( scene->totalPendingJobsCount() > 0 )
+  {
+    QgsApplication::processEvents();
+  }
 }
 
 QImage Qgs3DUtils::captureSceneImage( QgsAbstract3DEngine &engine, Qgs3DMapScene *scene )

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -205,6 +205,10 @@ class _3D_EXPORT Qgs3DUtils
 
     /**
      * Converts the clicked mouse position to the corresponding 3D world coordinates
+     * \param screenPoint point on screen in pixel from top-left corner
+     * \param depth value from depth buffer in [0.0, 1.0] interval
+     * \param screenSize size of screen in pixels
+     * \param camera camera whose view/projection matrices are used
      * \since QGIS 3.24
      */
     static QVector3D screenPointToWorldPos( const QPoint &screenPoint, double depth, const QSize &screenSize, Qt3DRender::QCamera *camera );

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -66,13 +66,15 @@ class _3D_EXPORT Qgs3DUtils
     static QImage captureSceneImage( QgsAbstract3DEngine &engine, Qgs3DMapScene *scene );
 
     /**
-     * Waits for a frame to be rendered. Useful to trigger once-per-frame updates
+     * Waits for a frame to be rendered. Useful to trigger once-per-frame updates.
+     * \warning Not to be used outside of tests!
      * \since QGIS 3.42
      */
     static void waitForFrame( QgsAbstract3DEngine &engine, Qgs3DMapScene *scene );
 
     /**
      * Waits for all entities in the scene to be loaded.
+     * \warning Not to be used outside of tests!
      * \since QGIS 4.0
      */
     static void waitForEntitiesLoaded( Qgs3DMapScene *scene );

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -72,6 +72,12 @@ class _3D_EXPORT Qgs3DUtils
     static void waitForFrame( QgsAbstract3DEngine &engine, Qgs3DMapScene *scene );
 
     /**
+     * Waits for all entities in the scene to be loaded.
+     * \since QGIS 4.0
+     */
+    static void waitForEntitiesLoaded( Qgs3DMapScene *scene );
+
+    /**
      * Captures the depth buffer of the current 3D scene of a 3D engine. The function waits
      * until the scene is not fully loaded/updated before capturing the image.
      *

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -585,7 +585,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
 
     QVector3D cameraBeforeDragPos = mCameraBefore->position();
 
-    QVector3D moveToPosition = Qgs3DUtils::screenPointToWorldPos( mMousePos, mDragDepth, mScene->engine()->size(), mCameraBefore.get() );
+    QVector3D moveToPosition = Qgs3DUtils::screenPointToWorldPos( { mouse->x(), mouse->y() }, mDragDepth, mScene->engine()->size(), mCameraBefore.get() );
     QVector3D cameraBeforeToMoveToPos = ( moveToPosition - mCameraBefore->position() ).normalized();
     QVector3D cameraBeforeToDragPointPos = ( mDragPoint - mCameraBefore->position() ).normalized();
 

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -139,20 +139,11 @@ void TestQgs3DCameraController::testTranslate()
   QImage depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   scene->cameraController()->depthBufferCaptured( depthImage );
 
-  // the first mouse event only updates the mouse position
-  // the second one will update the camera
   QPoint movement1( 220, 42 );
   QMouseEvent mouseMoveEvent1( QEvent::MouseMove, midPos + movement1, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
   scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent1 ) );
   QCOMPARE( scene->cameraController()->mClickPoint, midPos );
   QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 );
-  QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
-
-  QPoint movement2( 1, 1 );
-  QMouseEvent mouseMoveEvent2( QEvent::MouseMove, midPos + movement1 + movement2, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
-  scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent2 ) );
-  QCOMPARE( scene->cameraController()->mClickPoint, midPos );
-  QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 + movement2 );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   QVector3D diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
@@ -638,13 +629,6 @@ void TestQgs3DCameraController::testTranslateRotationCenterTranslate()
   QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
-  QPoint movement2( 1, 1 );
-  QMouseEvent mouseMoveEvent2( QEvent::MouseMove, midPos + movement1 + movement2, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
-  scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent2 ) );
-  QCOMPARE( scene->cameraController()->mClickPoint, midPos );
-  QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 + movement2 );
-  QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
-
   QVector3D diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
   QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -944.6, 180.3, 0.0 ), 4.0 );
   QVector3D diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
@@ -661,12 +645,12 @@ void TestQgs3DCameraController::testTranslateRotationCenterTranslate()
   initialPitch = scene->cameraController()->pitch();
   initialYaw = scene->cameraController()->yaw();
 
-  // the first mouse event only updates the mouse position
-  // the second one will update the camera
+  QPoint movement2( 1, 1 );
   QMouseEvent mouseMoveEvent3( QEvent::MouseMove, midPos + movement1 + movement2, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
   scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent3 ) );
-  QCOMPARE( scene->cameraController()->mClickPoint, midPos + movement1 + movement2 );
-  QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 + movement2 );
+  QCOMPARE( scene->cameraController()->mClickPoint, midPos + movement1 );
+  // mMousePos is not updated, because processing the event is cut short by not having the depth buffer
+  QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::RotationCenter );
 
   depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
@@ -674,18 +658,18 @@ void TestQgs3DCameraController::testTranslateRotationCenterTranslate()
 
   QMouseEvent mouseMoveEvent4( QEvent::MouseMove, midPos + movement1 + 10 * movement2, Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
   scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent4 ) );
-  QCOMPARE( scene->cameraController()->mClickPoint, midPos + movement1 + movement2 );
+  QCOMPARE( scene->cameraController()->mClickPoint, midPos + movement1 );
   QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 + 10 * movement2 );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::RotationCenter );
 
   diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 9.1, 42.0, 8.2 ), 4.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 9.1, 46.0, 8.2 ), 4.0 );
   diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( 3.8, -68.3, 5.3 ), 4.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( 3.8, -76.3, 5.3 ), 4.0 );
   float diffPitch = scene->cameraController()->pitch() - initialPitch;
   float diffYaw = scene->cameraController()->yaw() - initialYaw;
-  QGSCOMPARENEAR( diffPitch, 2.5, 0.1 );
-  QGSCOMPARENEAR( diffYaw, -2.5, 0.1 );
+  QGSCOMPARENEAR( diffPitch, 2.8, 0.1 );
+  QGSCOMPARENEAR( diffYaw, -2.8, 0.1 );
 
   //
   // 3. Translate
@@ -780,20 +764,11 @@ void TestQgs3DCameraController::testTranslateZoomWheelTranslate()
   QImage depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   scene->cameraController()->depthBufferCaptured( depthImage );
 
-  // the first mouse event only updates the mouse position
-  // the second one will update the camera
   QPoint movement1( 220, 42 );
   QMouseEvent mouseMoveEvent1( QEvent::MouseMove, midPos + movement1, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
   scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent1 ) );
   QCOMPARE( scene->cameraController()->mClickPoint, midPos );
   QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 );
-  QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
-
-  QPoint movement2( 1, 1 );
-  QMouseEvent mouseMoveEvent2( QEvent::MouseMove, midPos + movement1 + movement2, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
-  scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent2 ) );
-  QCOMPARE( scene->cameraController()->mClickPoint, midPos );
-  QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 + movement2 );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   QVector3D diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
@@ -811,7 +786,7 @@ void TestQgs3DCameraController::testTranslateZoomWheelTranslate()
   initialCamViewCenter = scene->cameraController()->camera()->viewCenter();
   initialCamPosition = scene->cameraController()->camera()->position();
 
-  QWheelEvent wheelEvent( midPos + movement1 + movement2, midPos + movement1 + movement2, QPoint(), QPoint( 0, 200 ), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false, Qt::MouseEventSynthesizedByApplication );
+  QWheelEvent wheelEvent( midPos + movement1, midPos + movement1, QPoint(), QPoint( 0, 200 ), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false, Qt::MouseEventSynthesizedByApplication );
   scene->cameraController()->onWheel( new Qt3DInput::QWheelEvent( wheelEvent ) );
   QCOMPARE( scene->cameraController()->mClickPoint, midPos );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::ZoomWheel );
@@ -822,9 +797,9 @@ void TestQgs3DCameraController::testTranslateZoomWheelTranslate()
   depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   scene->cameraController()->depthBufferCaptured( depthImage );
 
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( 4.8, -4.4, 9.9 ), 1.0 );
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -650.47, 123.10, 3.10 ), 4.0 );
-  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1723.55, 2.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( 0, 0, 10 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -651, 124, 3 ), 4.0 );
+  QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1723, 2.0 );
   QCOMPARE( scene->cameraController()->mCumulatedWheelY, 0 );
   QCOMPARE( scene->cameraController()->mClickPoint, QPoint() );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::None );
@@ -839,19 +814,20 @@ void TestQgs3DCameraController::testTranslateZoomWheelTranslate()
   initialCamPosition = scene->cameraController()->camera()->position();
 
   // switch to translation
-  QMouseEvent mouseMoveEvent3( QEvent::MouseMove, midPos + movement1 + movement2, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
+  QMouseEvent mouseMoveEvent3( QEvent::MouseMove, midPos + movement1, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
   scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent3 ) );
-  QCOMPARE( scene->cameraController()->mClickPoint, midPos + movement1 + movement2 );
-  QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 + movement2 );
+  QCOMPARE( scene->cameraController()->mClickPoint, midPos + movement1 );
+  QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   scene->cameraController()->depthBufferCaptured( depthImage );
 
   // this updates the mouse position
+  QPoint movement2(1, 1);
   QMouseEvent mouseMoveEvent4( QEvent::MouseMove, midPos + movement1 + 5 * movement2, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
   scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent4 ) );
-  QCOMPARE( scene->cameraController()->mClickPoint, midPos + movement1 + movement2 );
+  QCOMPARE( scene->cameraController()->mClickPoint, midPos + movement1 );
   QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 + 5 * movement2 );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
@@ -859,14 +835,14 @@ void TestQgs3DCameraController::testTranslateZoomWheelTranslate()
   // this updates the camera
   QMouseEvent mouseMoveEvent5( QEvent::MouseMove, midPos + movement1 + 5 * movement2, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
   scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent5 ) );
-  QCOMPARE( scene->cameraController()->mClickPoint, midPos + movement1 + movement2 );
+  QCOMPARE( scene->cameraController()->mClickPoint, midPos + movement1 );
   QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 + 5 * movement2 );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -11.9, 11.9, 0.0 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( -14.8, 14.8, 0.0 ), 1.0 );
   diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
-  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -11.9, 11.9, 0.0 ), 1.0 );
+  QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( -14.8, 14.8, 0.0 ), 1.0 );
   QCOMPARE( scene->cameraController()->pitch(), initialPitch );
   QCOMPARE( scene->cameraController()->yaw(), initialYaw );
 
@@ -924,20 +900,11 @@ void TestQgs3DCameraController::testTranslateRotationCameraTranslate()
   QImage depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   scene->cameraController()->depthBufferCaptured( depthImage );
 
-  // the first mouse event only updates the mouse position
-  // the second one will update the camera
   QPoint movement1( 220, 42 );
   QMouseEvent mouseMoveEvent1( QEvent::MouseMove, midPos + movement1, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
   scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent1 ) );
   QCOMPARE( scene->cameraController()->mClickPoint, midPos );
   QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 );
-  QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
-
-  QPoint movement2( 1, 1 );
-  QMouseEvent mouseMoveEvent2( QEvent::MouseMove, midPos + movement1 + movement2, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
-  scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent2 ) );
-  QCOMPARE( scene->cameraController()->mClickPoint, midPos );
-  QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 + movement2 );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::Translation );
 
   QVector3D diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
@@ -954,12 +921,11 @@ void TestQgs3DCameraController::testTranslateRotationCameraTranslate()
   initialCamViewCenter = scene->cameraController()->camera()->viewCenter();
   initialCamPosition = scene->cameraController()->camera()->position();
 
-  // the first mouse event only updates the mouse position
-  // the second one will update the camera
-  QMouseEvent mouseMoveEvent3( QEvent::MouseMove, midPos + movement1 + movement2, Qt::LeftButton, Qt::LeftButton, Qt::ControlModifier );
+  QPoint movement2( 1, 1 );
+  QMouseEvent mouseMoveEvent3( QEvent::MouseMove, midPos + movement1, Qt::LeftButton, Qt::LeftButton, Qt::ControlModifier );
   scene->cameraController()->onPositionChanged( new Qt3DInput::QMouseEvent( mouseMoveEvent3 ) );
   QCOMPARE( scene->cameraController()->mClickPoint, QPoint() );
-  QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 + movement2 );
+  QCOMPARE( scene->cameraController()->mMousePos, midPos + movement1 );
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::RotationCamera );
 
   depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
@@ -972,13 +938,13 @@ void TestQgs3DCameraController::testTranslateRotationCameraTranslate()
   QCOMPARE( scene->cameraController()->mCurrentOperation, QgsCameraController::MouseOperation::RotationCamera );
 
   diffViewCenter = scene->cameraController()->camera()->viewCenter() - initialCamViewCenter;
-  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 2.7, 78.0, 1.5 ), 2.0 );
+  QGSCOMPARENEARVECTOR3D( diffViewCenter, QVector3D( 2.7, 87.0, 1.5 ), 2.0 );
   diffPosition = scene->cameraController()->camera()->position() - initialCamPosition;
   QGSCOMPARENEARVECTOR3D( diffPosition, QVector3D( 0.0, 0.0, 0.0 ), 2.0 );
   float diffPitch = scene->cameraController()->pitch() - initialPitch;
   float diffYaw = scene->cameraController()->yaw() - initialYaw;
-  QGSCOMPARENEAR( diffPitch, 1.8, 0.1 );
-  QGSCOMPARENEAR( diffYaw, -1.8, 0.1 );
+  QGSCOMPARENEAR( diffPitch, 2.0, 0.1 );
+  QGSCOMPARENEAR( diffYaw, -2.0, 0.1 );
 
   //
   // 3. Translate

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -1299,7 +1299,7 @@ void TestQgs3DCameraController::testOrthographic()
   QImage depthImage = Qgs3DUtils::captureSceneDepthBuffer( engine, scene );
   scene->cameraController()->depthBufferCaptured( depthImage );
 
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( -2500, 1875, 0.0 ), 5.0 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->mZoomPoint, QVector3D( -2500, 1875, 0.0 ), 15.0 );
   QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QVector3D( -776.5, 582.3, 0.0 ), 5.0 );
   QGSCOMPARENEAR( scene->cameraController()->cameraPose().distanceFromCenterPoint(), 1723.55, 5.0 );
   QGSCOMPARENEARVECTOR3D( scene->cameraController()->camera()->position(), QVector3D( -776, 582, 1723 ), 5 );


### PR DESCRIPTION
## Description

This PR makes two fixes to get the 3D view mostly working with orthogonal/orthographic (same thing) projection:

- It changes `Qgs3DUtils::screenPointToWorldPos` to use inverses of projection and view matrices instead of the current hardcoded inverse calculation.

  This means calculating the inverse of two matrices every query, instead of having it "baked in" with code, but from a cursory `perf` profile it doesn't seem to matter.

- It updates `Qgs3DMapScene::updateScene` with a projection matrix for the orthogonal projection.

The camera handling still isn't perfect at higher angles, but that's because moving forward/backward isn't very meaningful with an orthogonal projection. I aim to work on that next in a later PR.

Funded by: [QGIS 3D for Open Source Digital Twins crowdfunding](https://www.lutraconsulting.co.uk/crowdfunding/qgis-3d-for-open-source-digital-twins)

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
