### PR TITLE
trigger layr repaint when undoing/redoing changes in the Layer Styling panel (fix #60250)

### DIFF
--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -377,12 +377,14 @@ void QgsLayerStylingWidget::apply()
   {
     widget->apply();
     styleWasChanged = true;
+    triggerRepaint = true;
     undoName = QStringLiteral( "Label Change" );
   }
   else if ( QgsDiagramWidget *widget = qobject_cast<QgsDiagramWidget *>( current ) )
   {
     widget->apply();
     styleWasChanged = true;
+    triggerRepaint = true;
     undoName = QStringLiteral( "Diagram Change" );
   }
   else if ( QgsMapLayerConfigWidget *widget = qobject_cast<QgsMapLayerConfigWidget *>( current ) )


### PR DESCRIPTION
## Description

Trigger layer repaint after undo/redo for labeling and diagram changes in the Layer Styling panel to reflect these changes on canvas.

Fixes #60250.