### PR TITLE
Fix(auth): Preserve username in Postgres SSL connections

### DIFF
--- a/src/auth/identcert/core/qgsauthidentcertmethod.cpp
+++ b/src/auth/identcert/core/qgsauthidentcertmethod.cpp
@@ -51,7 +51,7 @@ QgsAuthIdentCertMethod::QgsAuthIdentCertMethod()
   setVersion( 2 );
   setExpansions( QgsAuthMethod::NetworkRequest | QgsAuthMethod::DataSourceUri );
   setDataProviders( QStringList() << QStringLiteral( "ows" ) << QStringLiteral( "wfs" ) // convert to lowercase
-                    << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
+                                  << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
 }
 
 QgsAuthIdentCertMethod::~QgsAuthIdentCertMethod()
@@ -136,9 +136,9 @@ bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionIt
 
   // save client cert to temp file
   const QString certFilePath = QgsAuthCertUtils::pemTextToTempFile(
-                                 pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-                                 pkibundle->clientCert().toPem()
-                               );
+    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+    pkibundle->clientCert().toPem()
+  );
   if ( certFilePath.isEmpty() )
   {
     return false;
@@ -146,9 +146,9 @@ bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionIt
 
   // save client cert key to temp file
   const QString keyFilePath = QgsAuthCertUtils::pemTextToTempFile(
-                                pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-                                pkibundle->clientCertKey().toPem()
-                              );
+    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+    pkibundle->clientCertKey().toPem()
+  );
   if ( keyFilePath.isEmpty() )
   {
     return false;
@@ -156,9 +156,9 @@ bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionIt
 
   // save CAs to temp file
   const QString caFilePath = QgsAuthCertUtils::pemTextToTempFile(
-                               pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-                               QgsApplication::authManager()->trustedCaCertsPemText()
-                             );
+    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+    QgsApplication::authManager()->trustedCaCertsPemText()
+  );
   if ( caFilePath.isEmpty() )
   {
     return false;

--- a/src/auth/identcert/core/qgsauthidentcertmethod.cpp
+++ b/src/auth/identcert/core/qgsauthidentcertmethod.cpp
@@ -51,7 +51,7 @@ QgsAuthIdentCertMethod::QgsAuthIdentCertMethod()
   setVersion( 2 );
   setExpansions( QgsAuthMethod::NetworkRequest | QgsAuthMethod::DataSourceUri );
   setDataProviders( QStringList() << QStringLiteral( "ows" ) << QStringLiteral( "wfs" ) // convert to lowercase
-                                  << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
+                    << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
 }
 
 QgsAuthIdentCertMethod::~QgsAuthIdentCertMethod()
@@ -136,9 +136,9 @@ bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionIt
 
   // save client cert to temp file
   const QString certFilePath = QgsAuthCertUtils::pemTextToTempFile(
-    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-    pkibundle->clientCert().toPem()
-  );
+                                 pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+                                 pkibundle->clientCert().toPem()
+                               );
   if ( certFilePath.isEmpty() )
   {
     return false;
@@ -146,9 +146,9 @@ bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionIt
 
   // save client cert key to temp file
   const QString keyFilePath = QgsAuthCertUtils::pemTextToTempFile(
-    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-    pkibundle->clientCertKey().toPem()
-  );
+                                pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+                                pkibundle->clientCertKey().toPem()
+                              );
   if ( keyFilePath.isEmpty() )
   {
     return false;
@@ -156,28 +156,31 @@ bool QgsAuthIdentCertMethod::updateDataSourceUriItems( QStringList &connectionIt
 
   // save CAs to temp file
   const QString caFilePath = QgsAuthCertUtils::pemTextToTempFile(
-    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-    QgsApplication::authManager()->trustedCaCertsPemText()
-  );
+                               pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+                               QgsApplication::authManager()->trustedCaCertsPemText()
+                             );
   if ( caFilePath.isEmpty() )
   {
     return false;
   }
 
-  // get common name of the client certificate
-  const QString commonName = QgsAuthCertUtils::resolvedCertName( pkibundle->clientCert(), false );
+  if ( pkibundle->config().config( QStringLiteral( "cnisuser" ), QStringLiteral( "true" ) ) == QLatin1String( "true" ) )
+  {
+    // get common name of the client certificate
+    const QString commonName = QgsAuthCertUtils::resolvedCertName( pkibundle->clientCert(), false );
 
-  // add uri parameters
-  const QString userparam = "user='" + commonName + "'";
-  const thread_local QRegularExpression userRegExp( "^user='.*" );
-  const int userindx = connectionItems.indexOf( userRegExp );
-  if ( userindx != -1 )
-  {
-    connectionItems.replace( userindx, userparam );
-  }
-  else
-  {
-    connectionItems.append( userparam );
+    // add uri parameters
+    const QString userparam = "user='" + commonName + "'";
+    const thread_local QRegularExpression userRegExp( "^user='.*" );
+    const int userindx = connectionItems.indexOf( userRegExp );
+    if ( userindx != -1 )
+    {
+      connectionItems.replace( userindx, userparam );
+    }
+    else
+    {
+      connectionItems.append( userparam );
+    }
   }
 
   const QString certparam = "sslcert='" + certFilePath + "'";

--- a/src/auth/identcert/gui/qgsauthidentcertedit.cpp
+++ b/src/auth/identcert/gui/qgsauthidentcertedit.cpp
@@ -47,6 +47,7 @@ QgsStringMap QgsAuthIdentCertEdit::configMap() const
 {
   QgsStringMap config;
   config.insert( QStringLiteral( "certid" ), cmbIdentityCert->currentData().toString() );
+  config.insert( QStringLiteral( "cnisuser" ), cbCnUsername->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
 
   return config;
 }
@@ -58,6 +59,7 @@ void QgsAuthIdentCertEdit::loadConfig( const QgsStringMap &configmap )
   mConfigMap = configmap;
   const int indx = cmbIdentityCert->findData( configmap.value( QStringLiteral( "certid" ) ) );
   cmbIdentityCert->setCurrentIndex( indx == -1 ? 0 : indx );
+  cbCnUsername->setChecked( configmap.value( QStringLiteral( "cnisuser" ), QStringLiteral( "true" ) ) == QLatin1String( "true" ) );
 
   validateConfig();
 }
@@ -70,6 +72,7 @@ void QgsAuthIdentCertEdit::resetConfig()
 void QgsAuthIdentCertEdit::clearConfig()
 {
   cmbIdentityCert->setCurrentIndex( 0 );
+  cbCnUsername->setChecked( true );
 }
 
 void QgsAuthIdentCertEdit::populateIdentityComboBox()

--- a/src/auth/identcert/gui/qgsauthidentcertedit.ui
+++ b/src/auth/identcert/gui/qgsauthidentcertedit.ui
@@ -40,6 +40,16 @@
     <widget class="QComboBox" name="cmbIdentityCert"/>
    </item>
    <item row="1" column="1">
+    <widget class="QCheckBox" name="cbCnUsername">
+     <property name="toolTip">
+      <string>Allow certificate's Common Name to override username</string>
+     </property>
+     <property name="text">
+      <string>CN is username</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
     <spacer name="verticalSpacer_5">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/auth/pkipaths/core/qgsauthpkipathsmethod.cpp
+++ b/src/auth/pkipaths/core/qgsauthpkipathsmethod.cpp
@@ -50,7 +50,7 @@ QgsAuthPkiPathsMethod::QgsAuthPkiPathsMethod()
   setVersion( 2 );
   setExpansions( QgsAuthMethod::NetworkRequest | QgsAuthMethod::DataSourceUri );
   setDataProviders( QStringList() << QStringLiteral( "ows" ) << QStringLiteral( "wfs" ) // convert to lowercase
-                    << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
+                                  << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
 }
 
 QgsAuthPkiPathsMethod::~QgsAuthPkiPathsMethod()
@@ -149,9 +149,9 @@ bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionIte
 
   // save client cert to temp file
   const QString certFilePath = QgsAuthCertUtils::pemTextToTempFile(
-                                 pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-                                 pkibundle->clientCert().toPem()
-                               );
+    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+    pkibundle->clientCert().toPem()
+  );
   if ( certFilePath.isEmpty() )
   {
     return false;
@@ -159,9 +159,9 @@ bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionIte
 
   // save client cert key to temp file
   const QString keyFilePath = QgsAuthCertUtils::pemTextToTempFile(
-                                pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-                                pkibundle->clientCertKey().toPem()
-                              );
+    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+    pkibundle->clientCertKey().toPem()
+  );
   if ( keyFilePath.isEmpty() )
   {
     return false;
@@ -187,9 +187,9 @@ bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionIte
 
   // save CAs to temp file
   const QString caFilePath = QgsAuthCertUtils::pemTextToTempFile(
-                               pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-                               QgsAuthCertUtils::certsToPemText( cas )
-                             );
+    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+    QgsAuthCertUtils::certsToPemText( cas )
+  );
   if ( caFilePath.isEmpty() )
   {
     return false;

--- a/src/auth/pkipaths/core/qgsauthpkipathsmethod.cpp
+++ b/src/auth/pkipaths/core/qgsauthpkipathsmethod.cpp
@@ -50,7 +50,7 @@ QgsAuthPkiPathsMethod::QgsAuthPkiPathsMethod()
   setVersion( 2 );
   setExpansions( QgsAuthMethod::NetworkRequest | QgsAuthMethod::DataSourceUri );
   setDataProviders( QStringList() << QStringLiteral( "ows" ) << QStringLiteral( "wfs" ) // convert to lowercase
-                                  << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
+                    << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
 }
 
 QgsAuthPkiPathsMethod::~QgsAuthPkiPathsMethod()
@@ -149,9 +149,9 @@ bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionIte
 
   // save client cert to temp file
   const QString certFilePath = QgsAuthCertUtils::pemTextToTempFile(
-    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-    pkibundle->clientCert().toPem()
-  );
+                                 pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+                                 pkibundle->clientCert().toPem()
+                               );
   if ( certFilePath.isEmpty() )
   {
     return false;
@@ -159,9 +159,9 @@ bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionIte
 
   // save client cert key to temp file
   const QString keyFilePath = QgsAuthCertUtils::pemTextToTempFile(
-    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-    pkibundle->clientCertKey().toPem()
-  );
+                                pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+                                pkibundle->clientCertKey().toPem()
+                              );
   if ( keyFilePath.isEmpty() )
   {
     return false;
@@ -187,28 +187,31 @@ bool QgsAuthPkiPathsMethod::updateDataSourceUriItems( QStringList &connectionIte
 
   // save CAs to temp file
   const QString caFilePath = QgsAuthCertUtils::pemTextToTempFile(
-    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-    QgsAuthCertUtils::certsToPemText( cas )
-  );
+                               pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+                               QgsAuthCertUtils::certsToPemText( cas )
+                             );
   if ( caFilePath.isEmpty() )
   {
     return false;
   }
 
-  // get common name of the client certificate
-  const QString commonName = QgsAuthCertUtils::resolvedCertName( pkibundle->clientCert(), false );
+  if ( pkibundle->config().config( QStringLiteral( "cnisuser" ), QStringLiteral( "true" ) ) == QLatin1String( "true" ) )
+  {
+    // get common name of the client certificate
+    const QString commonName = QgsAuthCertUtils::resolvedCertName( pkibundle->clientCert(), false );
 
-  // add uri parameters
-  const QString userparam = "user='" + commonName + "'";
-  const thread_local QRegularExpression userRegExp( "^user='.*" );
-  const int userindx = connectionItems.indexOf( userRegExp );
-  if ( userindx != -1 )
-  {
-    connectionItems.replace( userindx, userparam );
-  }
-  else
-  {
-    connectionItems.append( userparam );
+    // add uri parameters
+    const QString userparam = "user='" + commonName + "'";
+    const thread_local QRegularExpression userRegExp( "^user='.*" );
+    const int userindx = connectionItems.indexOf( userRegExp );
+    if ( userindx != -1 )
+    {
+      connectionItems.replace( userindx, userparam );
+    }
+    else
+    {
+      connectionItems.append( userparam );
+    }
   }
 
   // add uri parameters

--- a/src/auth/pkipaths/gui/qgsauthpkipathsedit.cpp
+++ b/src/auth/pkipaths/gui/qgsauthpkipathsedit.cpp
@@ -94,6 +94,7 @@ QgsStringMap QgsAuthPkiPathsEdit::configMap() const
   config.insert( QStringLiteral( "keypass" ), lePkiPathsKeyPass->text() );
   config.insert( QStringLiteral( "addcas" ), cbAddCas->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
   config.insert( QStringLiteral( "addrootca" ), cbAddRootCa->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  config.insert( QStringLiteral( "cnisuser" ), cbCnUsername->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
 
   return config;
 }
@@ -108,6 +109,7 @@ void QgsAuthPkiPathsEdit::loadConfig( const QgsStringMap &configmap )
   lePkiPathsKeyPass->setText( configmap.value( QStringLiteral( "keypass" ) ) );
   cbAddCas->setChecked( configmap.value( QStringLiteral( "addcas" ), QStringLiteral( "false " ) ) == QLatin1String( "true" ) );
   cbAddRootCa->setChecked( configmap.value( QStringLiteral( "addrootca" ), QStringLiteral( "false " ) ) == QLatin1String( "true" ) );
+  cbCnUsername->setChecked( configmap.value( QStringLiteral( "cnisuser" ), QStringLiteral( "true" ) ) == QLatin1String( "true" ) );
 
   validateConfig();
 }
@@ -122,6 +124,8 @@ void QgsAuthPkiPathsEdit::clearConfig()
   clearPkiPathsCertPath();
   clearPkiPathsKeyPath();
   clearPkiPathsKeyPass();
+  cbCnUsername->setChecked( true );
+
 
   clearPkiMessage( lePkiPathsMsg );
   validateConfig();

--- a/src/auth/pkipaths/gui/qgsauthpkipathsedit.ui
+++ b/src/auth/pkipaths/gui/qgsauthpkipathsedit.ui
@@ -164,6 +164,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="cbCnUsername">
+       <property name="toolTip">
+        <string>Allow certificate's Common Name to override username</string>
+       </property>
+       <property name="text">
+        <string>CN is username</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="verticalSpacer_2">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -193,6 +203,7 @@
   <tabstop>twCas</tabstop>
   <tabstop>cbAddCas</tabstop>
   <tabstop>cbAddRootCa</tabstop>
+  <tabstop>cbCnUsername</tabstop>
   <tabstop>lePkiPathsKey</tabstop>
   <tabstop>btnPkiPathsKey</tabstop>
   <tabstop>lePkiPathsKeyPass</tabstop>

--- a/src/auth/pkipkcs12/core/qgsauthpkcs12method.cpp
+++ b/src/auth/pkipkcs12/core/qgsauthpkcs12method.cpp
@@ -50,7 +50,7 @@ QgsAuthPkcs12Method::QgsAuthPkcs12Method()
   setVersion( 2 );
   setExpansions( QgsAuthMethod::NetworkRequest | QgsAuthMethod::DataSourceUri );
   setDataProviders( QStringList() << QStringLiteral( "ows" ) << QStringLiteral( "wfs" ) // convert to lowercase
-                                  << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
+                    << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
 }
 
 QgsAuthPkcs12Method::~QgsAuthPkcs12Method()
@@ -148,9 +148,9 @@ bool QgsAuthPkcs12Method::updateDataSourceUriItems( QStringList &connectionItems
 
   // save client cert to temp file
   const QString certFilePath = QgsAuthCertUtils::pemTextToTempFile(
-    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-    pkibundle->clientCert().toPem()
-  );
+                                 pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+                                 pkibundle->clientCert().toPem()
+                               );
   if ( certFilePath.isEmpty() )
   {
     return false;
@@ -158,9 +158,9 @@ bool QgsAuthPkcs12Method::updateDataSourceUriItems( QStringList &connectionItems
 
   // save client cert key to temp file
   const QString keyFilePath = QgsAuthCertUtils::pemTextToTempFile(
-    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-    pkibundle->clientCertKey().toPem()
-  );
+                                pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+                                pkibundle->clientCertKey().toPem()
+                              );
   if ( keyFilePath.isEmpty() )
   {
     return false;
@@ -186,29 +186,32 @@ bool QgsAuthPkcs12Method::updateDataSourceUriItems( QStringList &connectionItems
 
   // save CAs to temp file
   const QString caFilePath = QgsAuthCertUtils::pemTextToTempFile(
-    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-    QgsAuthCertUtils::certsToPemText( cas )
-  );
+                               pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+                               QgsAuthCertUtils::certsToPemText( cas )
+                             );
 
   if ( caFilePath.isEmpty() )
   {
     return false;
   }
 
-  // get common name of the client certificate
-  const QString commonName = QgsAuthCertUtils::resolvedCertName( pkibundle->clientCert(), false );
+  if ( pkibundle->config().config( QStringLiteral( "cnisuser" ), QStringLiteral( "true" ) ) == QLatin1String( "true" ) )
+  {
+    // get common name of the client certificate
+    const QString commonName = QgsAuthCertUtils::resolvedCertName( pkibundle->clientCert(), false );
 
-  // add uri parameters
-  const QString userparam = "user='" + commonName + "'";
-  const thread_local QRegularExpression userRegExp( "^user='.*" );
-  const int userindx = connectionItems.indexOf( userRegExp );
-  if ( userindx != -1 )
-  {
-    connectionItems.replace( userindx, userparam );
-  }
-  else
-  {
-    connectionItems.append( userparam );
+    // add uri parameters
+    const QString userparam = "user='" + commonName + "'";
+    const thread_local QRegularExpression userRegExp( "^user='.*" );
+    const int userindx = connectionItems.indexOf( userRegExp );
+    if ( userindx != -1 )
+    {
+      connectionItems.replace( userindx, userparam );
+    }
+    else
+    {
+      connectionItems.append( userparam );
+    }
   }
 
   const QString certparam = "sslcert='" + certFilePath + "'";

--- a/src/auth/pkipkcs12/core/qgsauthpkcs12method.cpp
+++ b/src/auth/pkipkcs12/core/qgsauthpkcs12method.cpp
@@ -50,7 +50,7 @@ QgsAuthPkcs12Method::QgsAuthPkcs12Method()
   setVersion( 2 );
   setExpansions( QgsAuthMethod::NetworkRequest | QgsAuthMethod::DataSourceUri );
   setDataProviders( QStringList() << QStringLiteral( "ows" ) << QStringLiteral( "wfs" ) // convert to lowercase
-                    << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
+                                  << QStringLiteral( "wcs" ) << QStringLiteral( "wms" ) << QStringLiteral( "postgres" ) );
 }
 
 QgsAuthPkcs12Method::~QgsAuthPkcs12Method()
@@ -148,9 +148,9 @@ bool QgsAuthPkcs12Method::updateDataSourceUriItems( QStringList &connectionItems
 
   // save client cert to temp file
   const QString certFilePath = QgsAuthCertUtils::pemTextToTempFile(
-                                 pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-                                 pkibundle->clientCert().toPem()
-                               );
+    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+    pkibundle->clientCert().toPem()
+  );
   if ( certFilePath.isEmpty() )
   {
     return false;
@@ -158,9 +158,9 @@ bool QgsAuthPkcs12Method::updateDataSourceUriItems( QStringList &connectionItems
 
   // save client cert key to temp file
   const QString keyFilePath = QgsAuthCertUtils::pemTextToTempFile(
-                                pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-                                pkibundle->clientCertKey().toPem()
-                              );
+    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+    pkibundle->clientCertKey().toPem()
+  );
   if ( keyFilePath.isEmpty() )
   {
     return false;
@@ -186,9 +186,9 @@ bool QgsAuthPkcs12Method::updateDataSourceUriItems( QStringList &connectionItems
 
   // save CAs to temp file
   const QString caFilePath = QgsAuthCertUtils::pemTextToTempFile(
-                               pkiTempFileBase.arg( QUuid::createUuid().toString() ),
-                               QgsAuthCertUtils::certsToPemText( cas )
-                             );
+    pkiTempFileBase.arg( QUuid::createUuid().toString() ),
+    QgsAuthCertUtils::certsToPemText( cas )
+  );
 
   if ( caFilePath.isEmpty() )
   {

--- a/src/auth/pkipkcs12/gui/qgsauthpkcs12edit.cpp
+++ b/src/auth/pkipkcs12/gui/qgsauthpkcs12edit.cpp
@@ -127,6 +127,7 @@ QgsStringMap QgsAuthPkcs12Edit::configMap() const
   config.insert( QStringLiteral( "bundlepass" ), lePkcs12KeyPass->text() );
   config.insert( QStringLiteral( "addcas" ), cbAddCas->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
   config.insert( QStringLiteral( "addrootca" ), cbAddRootCa->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  config.insert( QStringLiteral( "cnisuser" ), cbCnUsername->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
 
   return config;
 }
@@ -140,6 +141,7 @@ void QgsAuthPkcs12Edit::loadConfig( const QgsStringMap &configmap )
   lePkcs12KeyPass->setText( configmap.value( QStringLiteral( "bundlepass" ) ) );
   cbAddCas->setChecked( configmap.value( QStringLiteral( "addcas" ), QStringLiteral( "false " ) ) == QLatin1String( "true" ) );
   cbAddRootCa->setChecked( configmap.value( QStringLiteral( "addrootca" ), QStringLiteral( "false " ) ) == QLatin1String( "true" ) );
+  cbCnUsername->setChecked( configmap.value( QStringLiteral( "cnisuser" ), QStringLiteral( "true" ) ) == QLatin1String( "true" ) );
 
   validateConfig();
 }
@@ -153,6 +155,7 @@ void QgsAuthPkcs12Edit::clearConfig()
 {
   clearPkcs12BundlePath();
   clearPkcs12BundlePass();
+  cbCnUsername->setChecked( true );
 
   clearPkiMessage( lePkcs12Msg );
   validateConfig();

--- a/src/auth/pkipkcs12/gui/qgsauthpkcs12edit.ui
+++ b/src/auth/pkipkcs12/gui/qgsauthpkcs12edit.ui
@@ -144,6 +144,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="cbCnUsername">
+       <property name="toolTip">
+        <string>Allow certificate's Common Name to override username</string>
+       </property>
+       <property name="text">
+        <string>CN is username</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="verticalSpacer_2">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -173,6 +183,7 @@
   <tabstop>twCas</tabstop>
   <tabstop>cbAddCas</tabstop>
   <tabstop>cbAddRootCa</tabstop>
+  <tabstop>cbCnUsername</tabstop>
   <tabstop>lePkcs12KeyPass</tabstop>
   <tabstop>lePkcs12Msg</tabstop>
  </tabstops>


### PR DESCRIPTION


This commit modifies `QgsAuthManager::updateDataSourceUriItems` to retain the original username if it was present in the initial connection string and the authentication method is not one that is expected to provide its own username (e.g., 'basic' auth). This ensures that the user-provided username is always respected.

Changes limited to PG db and non basic connection

Issue confirmed on a pg GCP cloud server I set up
Issue fixed with this PR on my db
Relevant tests : 
- test_core_authmanager passed 
- test_code_datasource_uri passed 
Many other tests failed on my vm. I am still configuring my env. Hope Github tests won't show some regression.

Fixes #60610
