### PR TITLE
Add app handling for elevation profiles stored in projects

### DIFF
--- a/src/app/elevation/qgselevationprofilemanagerdialog.cpp
+++ b/src/app/elevation/qgselevationprofilemanagerdialog.cpp
@@ -38,6 +38,7 @@ QgsElevationProfileManagerDialog::QgsElevationProfileManagerDialog( QWidget *par
 {
   setupUi( this );
 
+  setObjectName( "QgsElevationProfileManagerDialog" );
   QgsGui::enableAutoGeometryRestore( this );
 
   mModel = new QgsElevationProfileManagerModel( QgsProject::instance()->elevationProfileManager(), this );

--- a/src/app/elevation/qgselevationprofilemanagerdialog.cpp
+++ b/src/app/elevation/qgselevationprofilemanagerdialog.cpp
@@ -229,7 +229,6 @@ void QgsElevationProfileManagerDialog::removeClicked()
   {
     QgsProject::instance()->elevationProfileManager()->removeProfile( l );
   }
-  QgsProject::instance()->setDirty();
 }
 
 void QgsElevationProfileManagerDialog::showClicked()
@@ -293,8 +292,6 @@ void QgsElevationProfileManagerDialog::renameClicked()
     return;
   }
   currentProfile->setName( newTitle );
-
-  QgsProject::instance()->setDirty();
 }
 
 void QgsElevationProfileManagerDialog::itemDoubleClicked( const QModelIndex &index )

--- a/src/app/elevation/qgselevationprofilemanagerdialog.cpp
+++ b/src/app/elevation/qgselevationprofilemanagerdialog.cpp
@@ -231,9 +231,9 @@ void QgsElevationProfileManagerDialog::showClicked()
   const QModelIndexList profileItems = mProfileListView->selectionModel()->selectedRows();
   for ( const QModelIndex &index : profileItems )
   {
-    if ( QgsElevationProfile *l = mModel->profileFromIndex( mProxyModel->mapToSource( index ) ) )
+    if ( QgsElevationProfile *profile = mModel->profileFromIndex( mProxyModel->mapToSource( index ) ) )
     {
-      Q_UNUSED( l );
+      QgisApp::instance()->openElevationProfile( profile );
     }
   }
 }
@@ -260,8 +260,8 @@ void QgsElevationProfileManagerDialog::renameClicked()
 
 void QgsElevationProfileManagerDialog::itemDoubleClicked( const QModelIndex &index )
 {
-  if ( QgsElevationProfile *l = mModel->profileFromIndex( mProxyModel->mapToSource( index ) ) )
+  if ( QgsElevationProfile *profile = mModel->profileFromIndex( mProxyModel->mapToSource( index ) ) )
   {
-    Q_UNUSED( l );
+    QgisApp::instance()->openElevationProfile( profile );
   }
 }

--- a/src/app/elevation/qgselevationprofilemanagerdialog.cpp
+++ b/src/app/elevation/qgselevationprofilemanagerdialog.cpp
@@ -225,6 +225,7 @@ void QgsElevationProfileManagerDialog::removeClicked()
   {
     QgsProject::instance()->elevationProfileManager()->removeProfile( l );
   }
+  QgsProject::instance()->setDirty();
 }
 
 void QgsElevationProfileManagerDialog::showClicked()
@@ -257,6 +258,8 @@ void QgsElevationProfileManagerDialog::renameClicked()
     return;
   }
   currentProfile->setName( newTitle );
+
+  QgsProject::instance()->setDirty();
 }
 
 void QgsElevationProfileManagerDialog::itemDoubleClicked( const QModelIndex &index )

--- a/src/app/elevation/qgselevationprofilemanagerdialog.h
+++ b/src/app/elevation/qgselevationprofilemanagerdialog.h
@@ -60,6 +60,7 @@ class QgsElevationProfileManagerDialog : public QDialog, private Ui::QgsElevatio
 
     void removeClicked();
     void showClicked();
+    void duplicateClicked();
     void renameClicked();
     void itemDoubleClicked( const QModelIndex &index );
 };

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -1133,7 +1133,7 @@ void QgsElevationProfileWidget::renameProfileTriggered()
   bool titleValid = false;
   QString newTitle = mProfile->name();
 
-  QString chooseMsg = tr( "Enter a unique elevation profile title" );
+  const QString chooseMsg = tr( "Enter a unique elevation profile title" );
   QString titleMsg = chooseMsg;
 
   QStringList profileNames;

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -382,7 +382,6 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
     if ( mProfile )
     {
       mProfile->setTolerance( value );
-      QgsProject::instance()->setDirty();
     }
     settingTolerance->setValue( value );
     createOrUpdateRubberBands();
@@ -426,7 +425,6 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
         if ( mProfile )
         {
           mProfile->setDistanceUnit( unit );
-          QgsProject::instance()->setDirty();
         }
         mCanvas->setDistanceUnit( unit );
       }
@@ -530,11 +528,9 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
   mLayerTreeView->populateInitialSources( QgsProject::instance() );
 
   connect( mProfile->layerTree(), &QgsLayerTree::layerOrderChanged, this, [this] {
-    QgsProject::instance()->setDirty();
     updateCanvasSources();
   } );
   connect( mProfile->layerTree(), &QgsLayerTreeGroup::visibilityChanged, this, [this] {
-    QgsProject::instance()->setDirty();
     updateCanvasSources();
   } );
 
@@ -855,7 +851,6 @@ void QgsElevationProfileWidget::setProfileCurve( const QgsGeometry &curve, bool 
     {
       mProfile->setProfileCurve( profileCurve->clone() );
       mProfile->setCrs( QgsProject::instance()->crs3D() );
-      QgsProject::instance()->setDirty();
     }
   }
 }
@@ -1139,7 +1134,6 @@ void QgsElevationProfileWidget::axisScaleLockToggled( bool active )
   if ( mProfile )
   {
     mProfile->setLockAxisScales( active );
-    QgsProject::instance()->setDirty();
   }
   settingLockAxis->setValue( active );
   mCanvas->setLockAxisScales( active );
@@ -1190,7 +1184,6 @@ void QgsElevationProfileWidget::renameProfileTriggered()
 
   mProfile->setName( newTitle );
   mDockableWidgetHelper->setWindowTitle( newTitle );
-  QgsProject::instance()->setDirty();
 }
 
 void QgsElevationProfileWidget::showSubsectionsTriggered()

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -176,7 +176,7 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
   connect( mCanvas, &QgsElevationProfileCanvas::activeJobCountChanged, this, &QgsElevationProfileWidget::onTotalPendingJobsCountChanged );
   connect( mCanvas, &QgsElevationProfileCanvas::canvasPointHovered, this, &QgsElevationProfileWidget::onCanvasPointHovered );
 
-  mCanvas->setLockAxisScales( settingLockAxis->value() );
+  mCanvas->setLockAxisScales( mProfile->lockAxisScales() );
 
   mCanvas->setBackgroundColor( settingBackgroundColor->value() );
   connect( QgsGui::instance(), &QgsGui::optionsChanged, this, [this] {
@@ -366,7 +366,7 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
 
   mLockRatioAction = new QAction( tr( "Lock Distance/Elevation Scales" ), this );
   mLockRatioAction->setCheckable( true );
-  mLockRatioAction->setChecked( settingLockAxis->value() );
+  mLockRatioAction->setChecked( mProfile->lockAxisScales() );
   connect( mLockRatioAction, &QAction::toggled, this, &QgsElevationProfileWidget::axisScaleLockToggled );
   mOptionsMenu->addAction( mLockRatioAction );
 
@@ -382,8 +382,13 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
 
   mToleranceSettingsAction = new QgsElevationProfileToleranceWidgetSettingsAction( mOptionsMenu );
 
-  mToleranceSettingsAction->toleranceSpinBox()->setValue( settingTolerance->value() );
+  mToleranceSettingsAction->toleranceSpinBox()->setValue( mProfile->tolerance() );
   connect( mToleranceSettingsAction->toleranceSpinBox(), qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( double value ) {
+    if ( mProfile )
+    {
+      mProfile->setTolerance( value );
+      QgsProject::instance()->setDirty();
+    }
     settingTolerance->setValue( value );
     createOrUpdateRubberBands();
     scheduleUpdate();

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -62,6 +62,7 @@
 #include "qgsnewnamedialog.h"
 #include "qgssymbolselectordialog.h"
 #include "qgsstyle.h"
+#include "qgselevationprofile.h"
 
 #include <QToolBar>
 #include <QProgressBar>
@@ -144,13 +145,14 @@ void QgsElevationProfileLayersDialog::filterVisible( bool enabled )
 }
 
 
-QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
+QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profile )
   : QWidget( nullptr )
-  , mCanvasName( name )
   , mLayerTree( new QgsLayerTree() )
   , mLayerTreeBridge( new QgsLayerTreeRegistryBridge( mLayerTree.get(), QgsProject::instance(), this ) )
 {
   setObjectName( QStringLiteral( "ElevationProfile" ) );
+
+  mProfile = profile;
 
   setAttribute( Qt::WA_DeleteOnClose );
   const QgsSettings setting;
@@ -491,7 +493,7 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
   } );
   setLayout( layout );
 
-  mDockableWidgetHelper = new QgsDockableWidgetHelper( mCanvasName, this, QgisApp::instance(), mCanvasName, QStringList(), QgsDockableWidgetHelper::OpeningMode::RespectSetting, true, Qt::DockWidgetArea::BottomDockWidgetArea, QgsDockableWidgetHelper::Option::RaiseTab );
+  mDockableWidgetHelper = new QgsDockableWidgetHelper( mProfile->name(), this, QgisApp::instance(), mProfile->name(), QStringList(), QgsDockableWidgetHelper::OpeningMode::RespectSetting, true, Qt::DockWidgetArea::BottomDockWidgetArea, QgsDockableWidgetHelper::Option::RaiseTab );
 
   QToolButton *toggleButton = mDockableWidgetHelper->createDockUndockToolButton();
   toggleButton->setToolTip( tr( "Dock Elevation Profile View" ) );
@@ -552,8 +554,13 @@ QgsElevationProfileWidget::~QgsElevationProfileWidget()
 
 void QgsElevationProfileWidget::setCanvasName( const QString &name )
 {
-  mCanvasName = name;
+  mProfile->setName( name );
   mDockableWidgetHelper->setWindowTitle( name );
+}
+
+QString QgsElevationProfileWidget::canvasName() const
+{
+  return mProfile->name();
 }
 
 void QgsElevationProfileWidget::setMainCanvas( QgsMapCanvas *canvas )

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -450,7 +450,7 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
 
   // show Subsections Indicator Action
   // create a default simple symbology
-  mSubsectionsSymbol = QgsProfilePlotRenderer::defaultSubSectionsSymbol();
+  mSubsectionsSymbol = mProfile->subsectionsSymbol() ? std::unique_ptr<QgsLineSymbol>( mProfile->subsectionsSymbol()->clone() ) : QgsProfilePlotRenderer::defaultSubSectionsSymbol();
   mShowSubsectionsAction = new QAction( tr( "Show Subsections Indicator" ), this );
   mShowSubsectionsAction->setCheckable( true );
   mShowSubsectionsAction->setChecked( settingShowSubsections->value() );
@@ -1169,6 +1169,10 @@ void QgsElevationProfileWidget::editSubsectionsSymbology()
   symbolDialog.setWindowTitle( tr( "Subsections Symbol Selector" ) );
   if ( symbolDialog.exec() )
   {
+    if ( mProfile && mSubsectionsSymbol )
+    {
+      mProfile->setSubsectionsSymbol( mSubsectionsSymbol->clone() );
+    }
     showSubsectionsTriggered();
   }
 }

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -552,6 +552,12 @@ QgsElevationProfileWidget::~QgsElevationProfileWidget()
   delete mDockableWidgetHelper;
 }
 
+void QgsElevationProfileWidget::applyDefaultSettingsToProfile( QgsElevationProfile *profile )
+{
+  profile->setLockAxisScales( QgsElevationProfileWidget::settingLockAxis->value() );
+  profile->setTolerance( QgsElevationProfileWidget::settingTolerance->value() );
+}
+
 void QgsElevationProfileWidget::setCanvasName( const QString &name )
 {
   mProfile->setName( name );

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -558,6 +558,11 @@ void QgsElevationProfileWidget::applyDefaultSettingsToProfile( QgsElevationProfi
   profile->setTolerance( QgsElevationProfileWidget::settingTolerance->value() );
 }
 
+QgsElevationProfile *QgsElevationProfileWidget::profile()
+{
+  return mProfile;
+}
+
 void QgsElevationProfileWidget::setCanvasName( const QString &name )
 {
   mProfile->setName( name );

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -549,8 +549,14 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
     mLayerTree->reorderGroupLayers( selectedLayers );
   }
 
-  connect( mLayerTree.get(), &QgsLayerTree::layerOrderChanged, this, &QgsElevationProfileWidget::updateCanvasSources );
-  connect( mLayerTree.get(), &QgsLayerTreeGroup::visibilityChanged, this, &QgsElevationProfileWidget::updateCanvasSources );
+  connect( mLayerTree.get(), &QgsLayerTree::layerOrderChanged, this, [this] {
+    QgsProject::instance()->setDirty();
+    updateCanvasSources();
+  } );
+  connect( mLayerTree.get(), &QgsLayerTreeGroup::visibilityChanged, this, [this] {
+    QgsProject::instance()->setDirty();
+    updateCanvasSources();
+  } );
 
   connect( QgsProject::instance()->elevationProperties(), &QgsProjectElevationProperties::changed, this, &QgsElevationProfileWidget::onProjectElevationPropertiesChanged );
   connect( QgsProject::instance(), &QgsProject::crs3DChanged, this, &QgsElevationProfileWidget::onProjectElevationPropertiesChanged );

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -148,18 +148,15 @@ void QgsElevationProfileLayersDialog::filterVisible( bool enabled )
 
 QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profile, QgsMapCanvas *canvas )
   : QWidget( nullptr )
-  , mLayerTreeBridge( new QgsLayerTreeRegistryBridge( profile->layerTree(), QgsProject::instance(), this ) )
+  , mProfile( profile )
+  , mLayerTreeBridge( new QgsLayerTreeRegistryBridge( mProfile->layerTree(), QgsProject::instance(), this ) )
 {
   setObjectName( QStringLiteral( "ElevationProfile" ) );
 
-  mProfile = profile;
-  if ( mProfile )
-  {
-    connect( mProfile, &QObject::destroyed, this, &QgsElevationProfileWidget::close );
-    connect( mProfile, &QgsElevationProfile::nameChanged, this, [this]( const QString &newName ) {
-      mDockableWidgetHelper->setWindowTitle( newName );
-    } );
-  }
+  connect( mProfile, &QObject::destroyed, this, &QgsElevationProfileWidget::close );
+  connect( mProfile, &QgsElevationProfile::nameChanged, this, [this]( const QString &newName ) {
+    mDockableWidgetHelper->setWindowTitle( newName );
+  } );
 
   setAttribute( Qt::WA_DeleteOnClose );
   const QgsSettings setting;

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -153,6 +153,10 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
   setObjectName( QStringLiteral( "ElevationProfile" ) );
 
   mProfile = profile;
+  if ( mProfile )
+  {
+    connect( mProfile, &QObject::destroyed, this, &QgsElevationProfileWidget::close );
+  }
 
   setAttribute( Qt::WA_DeleteOnClose );
   const QgsSettings setting;

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -1094,6 +1094,7 @@ void QgsElevationProfileWidget::renameProfileTriggered()
 
   mProfile->setName( newTitle );
   mDockableWidgetHelper->setWindowTitle( newTitle );
+  QgsProject::instance()->setDirty();
 }
 
 void QgsElevationProfileWidget::showSubsectionsTriggered()

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -109,6 +109,8 @@ class QgsElevationProfileWidget : public QWidget
      */
     static void applyDefaultSettingsToProfile( QgsElevationProfile *profile );
 
+    QgsElevationProfile *profile();
+
     QgsDockableWidgetHelper *dockableWidgetHelper() { return mDockableWidgetHelper; }
 
     void setCanvasName( const QString &name );

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -28,7 +28,9 @@
 #include <QWidgetAction>
 #include <QElapsedTimer>
 #include <QTimer>
+#include <QPointer>
 
+class QgsElevationProfile;
 class QgsDockableWidgetHelper;
 class QgsMapCanvas;
 class QProgressBar;
@@ -99,13 +101,13 @@ class QgsElevationProfileWidget : public QWidget
     static const QgsSettingsEntryBool *settingShowSubsections;
     static const QgsSettingsEntryBool *settingShowScaleRatioInToolbar;
 
-    QgsElevationProfileWidget( const QString &name );
+    QgsElevationProfileWidget( QgsElevationProfile *profile );
     ~QgsElevationProfileWidget();
 
     QgsDockableWidgetHelper *dockableWidgetHelper() { return mDockableWidgetHelper; }
 
     void setCanvasName( const QString &name );
-    QString canvasName() const { return mCanvasName; }
+    QString canvasName() const;
 
     void setMainCanvas( QgsMapCanvas *canvas );
 
@@ -143,8 +145,8 @@ class QgsElevationProfileWidget : public QWidget
 
   private:
     QgsElevationProfileCanvas *mCanvas = nullptr;
+    QPointer< QgsElevationProfile > mProfile;
 
-    QString mCanvasName;
     QgsMapCanvas *mMainCanvas = nullptr;
 
     QProgressBar *mProgressPendingJobs = nullptr;

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -101,7 +101,7 @@ class QgsElevationProfileWidget : public QWidget
     static const QgsSettingsEntryBool *settingShowSubsections;
     static const QgsSettingsEntryBool *settingShowScaleRatioInToolbar;
 
-    QgsElevationProfileWidget( QgsElevationProfile *profile );
+    QgsElevationProfileWidget( QgsElevationProfile *profile, QgsMapCanvas *canvas );
     ~QgsElevationProfileWidget();
 
     /**
@@ -112,8 +112,6 @@ class QgsElevationProfileWidget : public QWidget
     QgsElevationProfile *profile();
 
     QgsDockableWidgetHelper *dockableWidgetHelper() { return mDockableWidgetHelper; }
-
-    void setMainCanvas( QgsMapCanvas *canvas );
 
     QgsElevationProfileCanvas *profileCanvas() { return mCanvas; }
 
@@ -130,7 +128,7 @@ class QgsElevationProfileWidget : public QWidget
     void addLayersInternal( const QList<QgsMapLayer *> &layers );
     void updateCanvasSources();
     void onTotalPendingJobsCountChanged( int count );
-    void setProfileCurve( const QgsGeometry &curve, bool resetView );
+    void setProfileCurve( const QgsGeometry &curve, bool resetView, bool storeCurve = true );
     void onCanvasPointHovered( const QgsPointXY &point, const QgsProfilePoint &profilePoint );
     void updatePlot();
     void scheduleUpdate();
@@ -148,6 +146,8 @@ class QgsElevationProfileWidget : public QWidget
     void editSubsectionsSymbology();
 
   private:
+    void setMainCanvas( QgsMapCanvas *canvas );
+
     QgsElevationProfileCanvas *mCanvas = nullptr;
     QPointer< QgsElevationProfile > mProfile;
 

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -104,6 +104,11 @@ class QgsElevationProfileWidget : public QWidget
     QgsElevationProfileWidget( QgsElevationProfile *profile );
     ~QgsElevationProfileWidget();
 
+    /**
+     * Modifies an elevation \a profile to apply default QGIS app settings to it.
+     */
+    static void applyDefaultSettingsToProfile( QgsElevationProfile *profile );
+
     QgsDockableWidgetHelper *dockableWidgetHelper() { return mDockableWidgetHelper; }
 
     void setCanvasName( const QString &name );

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -113,9 +113,6 @@ class QgsElevationProfileWidget : public QWidget
 
     QgsDockableWidgetHelper *dockableWidgetHelper() { return mDockableWidgetHelper; }
 
-    void setCanvasName( const QString &name );
-    QString canvasName() const;
-
     void setMainCanvas( QgsMapCanvas *canvas );
 
     QgsElevationProfileCanvas *profileCanvas() { return mCanvas; }

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -194,7 +194,6 @@ class QgsElevationProfileWidget : public QWidget
     int mBlockScaleRatioChanges = 0;
     QgsElevationProfileScaleRatioWidgetSettingsAction *mScaleRatioSettingsAction = nullptr;
 
-    std::unique_ptr<QgsLayerTree> mLayerTree;
     QgsLayerTreeRegistryBridge *mLayerTreeBridge = nullptr;
     QgsElevationProfileLayerTreeView *mLayerTreeView = nullptr;
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2175,8 +2175,9 @@ QgisApp::~QgisApp()
   qDeleteAll( mCustomDropHandlers );
   qDeleteAll( mCustomLayoutDropHandlers );
 
-  const QList<QgsElevationProfileWidget *> elevationProfileWidgets = findChildren<QgsElevationProfileWidget *>();
-  for ( QgsElevationProfileWidget *widget : elevationProfileWidgets )
+  // don't iterate over mElevationProfileWidgets -- it will get modified during the cleanup!
+  const QSet<QgsElevationProfileWidget * > profileWidgets = mElevationProfileWidgets;
+  for ( QgsElevationProfileWidget *widget : profileWidgets )
   {
     widget->cancelJobs();
     delete widget;
@@ -13255,9 +13256,7 @@ void QgisApp::initLayouts()
 
   QgsLayoutElevationProfileWidget::sBuildCopyMenuFunction = [this]( QgsLayoutElevationProfileWidget *layoutWidget, QMenu *menu ) {
     menu->clear();
-    const QList<QgsElevationProfileWidget *> elevationProfileWidgets = findChildren<QgsElevationProfileWidget *>();
-
-    if ( elevationProfileWidgets.empty() )
+    if ( mElevationProfileWidgets.empty() )
     {
       QAction *action = new QAction( tr( "No Elevation Profiles Found" ), menu );
       action->setEnabled( false );
@@ -13265,7 +13264,7 @@ void QgisApp::initLayouts()
     }
     else
     {
-      for ( QgsElevationProfileWidget *widget : elevationProfileWidgets )
+      for ( QgsElevationProfileWidget *widget : mElevationProfileWidgets )
       {
         QAction *action = new QAction( tr( "Copy From %1" ).arg( widget->canvasName() ), menu );
         connect( action, &QAction::triggered, widget, [layoutWidget, widget] {
@@ -13313,9 +13312,7 @@ QgsElevationProfileWidget *QgisApp::createNewElevationProfile()
   profile->setName( QgsProject::instance()->elevationProfileManager()->generateUniqueTitle() );
   if ( QgsProject::instance()->elevationProfileManager()->addProfile( profile ) )
   {
-    QgsElevationProfileWidget *widget = new QgsElevationProfileWidget( profile );
-    widget->setMainCanvas( mMapCanvas );
-    return widget;
+    return openElevationProfile( profile );
   }
   return nullptr;
 }
@@ -13325,8 +13322,7 @@ QgsElevationProfileWidget *QgisApp::openElevationProfile( QgsElevationProfile *p
   if ( !profile )
     return nullptr;
 
-  const QList< QgsElevationProfileWidget * > existingProfileWidgets = findChildren< QgsElevationProfileWidget * >();
-  for ( QgsElevationProfileWidget *existingWidget : existingProfileWidgets )
+  for ( QgsElevationProfileWidget *existingWidget : mElevationProfileWidgets )
   {
     if ( existingWidget->profile() == profile )
     {
@@ -13337,6 +13333,13 @@ QgsElevationProfileWidget *QgisApp::openElevationProfile( QgsElevationProfile *p
 
   QgsElevationProfileWidget *widget = new QgsElevationProfileWidget( profile );
   widget->setMainCanvas( mMapCanvas );
+
+  connect( widget, &QgsElevationProfileWidget::destroyed, this, [this, widget] {
+    mElevationProfileWidgets.remove( widget );
+  } );
+
+  mElevationProfileWidgets.insert( widget );
+
   return widget;
 }
 
@@ -13824,8 +13827,9 @@ void QgisApp::closeProject()
   mLegendExpressionFilterButton->setChecked( false );
   mFilterLegendByMapContentAction->setChecked( false );
 
-  const QList<QgsElevationProfileWidget *> elevationProfileWidgets = findChildren<QgsElevationProfileWidget *>();
-  for ( QgsElevationProfileWidget *widget : elevationProfileWidgets )
+  // don't iterate over mElevationProfileWidgets -- it will get modified during the cleanup!
+  const QSet<QgsElevationProfileWidget * > profileWidgets = mElevationProfileWidgets;
+  for ( QgsElevationProfileWidget *widget : profileWidgets )
   {
     delete widget;
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -132,6 +132,7 @@
 
 #include "layers/qgsapplayerhandling.h"
 #include "qgsmaplayerstylemanager.h"
+#include "qgselevationprofilemanager.h"
 
 #include "canvas/qgsappcanvasfiltering.h"
 #include "canvas/qgscanvasrefreshblocker.h"
@@ -13263,35 +13264,7 @@ QgsElevationProfileWidget *QgisApp::createNewElevationProfile()
 {
   const QList<QgsElevationProfileWidget *> elevationProfileWidgets = findChildren<QgsElevationProfileWidget *>();
 
-  // find first available unused title
-  QString title;
-  int counter = 1;
-  while ( true )
-  {
-    if ( counter == 1 )
-    {
-      title = tr( "Elevation Profile" );
-    }
-    else
-    {
-      title = tr( "Elevation Profile (%1)" ).arg( counter );
-    }
-
-    bool canvasExists = false;
-    for ( QgsElevationProfileWidget *existingWidget : elevationProfileWidgets )
-    {
-      if ( existingWidget->canvasName() == title )
-      {
-        canvasExists = true;
-        break;
-      }
-    }
-
-    if ( !canvasExists )
-      break;
-
-    counter++;
-  }
+  const QString title = QgsProject::instance()->elevationProfileManager()->generateUniqueTitle();
 
   QgsElevationProfileWidget *widget = new QgsElevationProfileWidget( title );
   widget->setMainCanvas( mMapCanvas );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13266,7 +13266,7 @@ void QgisApp::initLayouts()
     {
       for ( QgsElevationProfileWidget *widget : mElevationProfileWidgets )
       {
-        QAction *action = new QAction( tr( "Copy From %1" ).arg( widget->canvasName() ), menu );
+        QAction *action = new QAction( tr( "Copy From %1" ).arg( widget->profile()->name() ), menu );
         connect( action, &QAction::triggered, widget, [layoutWidget, widget] {
           layoutWidget->copySettingsFromProfileCanvas( widget->profileCanvas() );
         } );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13331,8 +13331,7 @@ QgsElevationProfileWidget *QgisApp::openElevationProfile( QgsElevationProfile *p
     }
   }
 
-  QgsElevationProfileWidget *widget = new QgsElevationProfileWidget( profile );
-  widget->setMainCanvas( mMapCanvas );
+  QgsElevationProfileWidget *widget = new QgsElevationProfileWidget( profile, mMapCanvas );
 
   connect( widget, &QgsElevationProfileWidget::destroyed, this, [this, widget] {
     mElevationProfileWidgets.remove( widget );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9314,21 +9314,13 @@ void QgisApp::elevationProfilesMenuAboutToShow()
 
 void QgisApp::populateElevationProfilesMenu( QMenu *menu )
 {
-  for ( QAction *action : menu->actions() )
-  {
-    if ( action->property( "profile_name" ).isValid() )
-    {
-      delete action;
-    }
-  }
-
+  menu->clear();
   QList<QAction *> actions;
   const QList<QgsElevationProfile *> objects = QgsProject::instance()->elevationProfileManager()->objects();
   actions.reserve( objects.size() );
   for ( QgsElevationProfile *object : objects )
   {
     QAction *a = new QAction( object->name(), menu );
-    a->setProperty( "profile_name", object->name() );
     QPointer< QgsElevationProfile > profilePointer( object );
     connect( a, &QAction::triggered, this, [this, profilePointer] {
       if ( profilePointer )
@@ -9343,11 +9335,11 @@ void QgisApp::populateElevationProfilesMenu( QMenu *menu )
   }
   if ( !actions.isEmpty() )
   {
-    QAction *separator = new QAction();
-    separator->setSeparator( true );
-    actions.append( separator );
-    menu->insertActions( menu->actions().value( 0 ), actions );
+    menu->addActions( actions );
+    menu->addSeparator();
   }
+  menu->addAction( mActionElevationProfile );
+  menu->addAction( mActionManageElevationProfiles );
 }
 
 void QgisApp::populate3DMapviewsMenu( QMenu *menu )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13266,9 +13266,7 @@ QgsElevationProfileWidget *QgisApp::createNewElevationProfile()
   const QList<QgsElevationProfileWidget *> elevationProfileWidgets = findChildren<QgsElevationProfileWidget *>();
 
   QgsElevationProfile *profile = new QgsElevationProfile( QgsProject::instance() );
-
-  profile->setLockAxisScales( QgsElevationProfileWidget::settingLockAxis->value() );
-  // TODO other defaults
+  QgsElevationProfileWidget::applyDefaultSettingsToProfile( profile );
 
   profile->setName( QgsProject::instance()->elevationProfileManager()->generateUniqueTitle() );
   if ( QgsProject::instance()->elevationProfileManager()->addProfile( profile ) )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4485,6 +4485,7 @@ void QgisApp::setupConnections()
   connect( mUndoWidget, &QgsUndoWidget::undoStackChanged, this, &QgisApp::updateUndoActions );
 
   connect( mLayoutsMenu, &QMenu::aboutToShow, this, &QgisApp::layoutsMenuAboutToShow );
+  connect( mMenuElevationProfiles, &QMenu::aboutToShow, this, &QgisApp::elevationProfilesMenuAboutToShow );
 
   connect( m3DMapViewsMenu, &QMenu::aboutToShow, this, &QgisApp::views3DMenuAboutToShow );
 }
@@ -9305,6 +9306,49 @@ void QgisApp::populateLayoutsMenu( QMenu *menu )
   menu->addActions( acts );
 }
 
+void QgisApp::elevationProfilesMenuAboutToShow()
+{
+  populateElevationProfilesMenu( mMenuElevationProfiles );
+}
+
+void QgisApp::populateElevationProfilesMenu( QMenu *menu )
+{
+  for ( QAction *action : menu->actions() )
+  {
+    if ( action->property( "profile_name" ).isValid() )
+    {
+      delete action;
+    }
+  }
+
+  QList<QAction *> actions;
+  const QList<QgsElevationProfile *> objects = QgsProject::instance()->elevationProfileManager()->objects();
+  actions.reserve( objects.size() );
+  for ( QgsElevationProfile *object : objects )
+  {
+    QAction *a = new QAction( object->name(), menu );
+    a->setProperty( "profile_name", object->name() );
+    QPointer< QgsElevationProfile > profilePointer( object );
+    connect( a, &QAction::triggered, this, [this, profilePointer] {
+      if ( profilePointer )
+        openElevationProfile( profilePointer.data() );
+    } );
+    actions << a;
+  }
+  if ( actions.size() > 1 )
+  {
+    // sort actions by text
+    std::sort( actions.begin(), actions.end(), cmpByText_ );
+  }
+  if ( !actions.isEmpty() )
+  {
+    QAction *separator = new QAction();
+    separator->setSeparator( true );
+    actions.append( separator );
+    menu->insertActions( menu->actions().value( 0 ), actions );
+  }
+}
+
 void QgisApp::populate3DMapviewsMenu( QMenu *menu )
 {
 #ifdef HAVE_3D
@@ -13263,8 +13307,6 @@ Qgs3DMapCanvasWidget *QgisApp::createNew3DMapCanvasDock( const QString &name, bo
 
 QgsElevationProfileWidget *QgisApp::createNewElevationProfile()
 {
-  const QList<QgsElevationProfileWidget *> elevationProfileWidgets = findChildren<QgsElevationProfileWidget *>();
-
   QgsElevationProfile *profile = new QgsElevationProfile( QgsProject::instance() );
   QgsElevationProfileWidget::applyDefaultSettingsToProfile( profile );
 
@@ -13276,6 +13318,26 @@ QgsElevationProfileWidget *QgisApp::createNewElevationProfile()
     return widget;
   }
   return nullptr;
+}
+
+QgsElevationProfileWidget *QgisApp::openElevationProfile( QgsElevationProfile *profile )
+{
+  if ( !profile )
+    return nullptr;
+
+  const QList< QgsElevationProfileWidget * > existingProfileWidgets = findChildren< QgsElevationProfileWidget * >();
+  for ( QgsElevationProfileWidget *existingWidget : existingProfileWidgets )
+  {
+    if ( existingWidget->profile() == profile )
+    {
+      existingWidget->dockableWidgetHelper()->setUserVisible( true );
+      return existingWidget;
+    }
+  }
+
+  QgsElevationProfileWidget *widget = new QgsElevationProfileWidget( profile );
+  widget->setMainCanvas( mMapCanvas );
+  return widget;
 }
 
 void QgisApp::new3DMapCanvas()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -133,6 +133,7 @@
 #include "layers/qgsapplayerhandling.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgselevationprofilemanager.h"
+#include "qgselevationprofile.h"
 
 #include "canvas/qgsappcanvasfiltering.h"
 #include "canvas/qgscanvasrefreshblocker.h"
@@ -13264,11 +13265,19 @@ QgsElevationProfileWidget *QgisApp::createNewElevationProfile()
 {
   const QList<QgsElevationProfileWidget *> elevationProfileWidgets = findChildren<QgsElevationProfileWidget *>();
 
-  const QString title = QgsProject::instance()->elevationProfileManager()->generateUniqueTitle();
+  QgsElevationProfile *profile = new QgsElevationProfile( QgsProject::instance() );
 
-  QgsElevationProfileWidget *widget = new QgsElevationProfileWidget( title );
-  widget->setMainCanvas( mMapCanvas );
-  return widget;
+  profile->setLockAxisScales( QgsElevationProfileWidget::settingLockAxis->value() );
+  // TODO other defaults
+
+  profile->setName( QgsProject::instance()->elevationProfileManager()->generateUniqueTitle() );
+  if ( QgsProject::instance()->elevationProfileManager()->addProfile( profile ) )
+  {
+    QgsElevationProfileWidget *widget = new QgsElevationProfileWidget( profile );
+    widget->setMainCanvas( mMapCanvas );
+    return widget;
+  }
+  return nullptr;
 }
 
 void QgisApp::new3DMapCanvas()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -54,6 +54,7 @@ class QgsCustomProjectOpenHandler;
 class QgsCustomLayerOrderWidget;
 class QgsDockWidget;
 class QgsDoubleSpinBox;
+class QgsElevationProfile;
 class QgsFeature;
 class QgsFeatureStore;
 class QgsGeometry;
@@ -347,6 +348,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Populates a menu with actions for opening layout designers
     void populateLayoutsMenu( QMenu *menu );
 
+    //! Populates a menu with actions for opening elevation profiles
+    void populateElevationProfilesMenu( QMenu *menu );
+
     //! Populates a menu with actions for 3D views
     void populate3DMapviewsMenu( QMenu *menu );
 
@@ -452,6 +456,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * If a designer already exists for this layout then it will be activated.
      */
     QgsLayoutDesignerDialog *openLayoutDesignerDialog( QgsMasterLayoutInterface *layout );
+
+    /**
+     * Opens an elevation profile widget for an existing \a profile.
+     * If a widget already exists for this profile then it will be activated.
+     */
+    QgsElevationProfileWidget *openElevationProfile( QgsElevationProfile *profile );
 
     /**
      * Returns a list of all 3D map canvases open in the app.
@@ -1784,6 +1794,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Slot to handle display of layouts menu, e.g. sorting
     void layoutsMenuAboutToShow();
+
+    //! Slot to handle display of elevation profiles menu
+    void elevationProfilesMenuAboutToShow();
 
     //! Slot to handle display of 3D views menu
     void views3DMenuAboutToShow();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2612,6 +2612,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Currently open layout designer dialogs
     QSet<QgsLayoutDesignerDialog *> mLayoutDesignerDialogs;
 
+    QSet<QgsElevationProfileWidget * > mElevationProfileWidgets;
+
     //! QGIS-internal vector feature clipboard
     QgsClipboard *mInternalClipboard = nullptr;
 

--- a/src/core/elevation/qgselevationprofile.h
+++ b/src/core/elevation/qgselevationprofile.h
@@ -215,7 +215,13 @@ class CORE_EXPORT QgsElevationProfile : public QObject
      */
     void nameChanged( const QString &newName );
 
+  private slots:
+
+    void dirtyProject();
+
   private:
+
+    void setupLayerTreeConnections();
 
     QPointer< QgsProject > mProject;
     QString mName;

--- a/src/gui/elevation/qgselevationprofilelayertreeview.cpp
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.cpp
@@ -445,6 +445,10 @@ void QgsElevationProfileLayerTreeView::populateInitialLayers( QgsProject *projec
   std::reverse( sortedLayers.begin(), sortedLayers.end() );
   for ( QgsMapLayer *layer : std::as_const( sortedLayers ) )
   {
+    // don't re-add existing layers
+    if ( mLayerTree->findLayer( layer ) )
+      continue;
+
     QgsLayerTreeLayer *node = mLayerTree->addLayer( layer );
 
     if ( layer->customProperty( QStringLiteral( "_include_in_elevation_profiles" ) ).isValid() )
@@ -461,7 +465,7 @@ void QgsElevationProfileLayerTreeView::populateInitialLayers( QgsProject *projec
 void QgsElevationProfileLayerTreeView::populateInitialSources( QgsProject *project )
 {
   const QList< QgsAbstractProfileSource * > sources = QgsApplication::profileSourceRegistry()->profileSources();
-  for ( auto *source : sources )
+  for ( QgsAbstractProfileSource *source : sources )
   {
     addNodeForRegisteredSource( source->profileSourceId(), source->profileSourceName() );
   }

--- a/src/gui/elevation/qgselevationprofilelayertreeview.cpp
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.cpp
@@ -47,6 +47,7 @@ QgsElevationProfileLayerTreeModel::QgsElevationProfileLayerTreeModel( QgsLayerTr
   setFlag( QgsLayerTreeModel::AllowNodeChangeVisibility );
   setFlag( QgsLayerTreeModel::ShowLegendAsTree );
   setFlag( QgsLayerTreeModel::AllowLegendChangeState, false );
+  setFlag( QgsLayerTreeModel::AllowNodeRename );
 }
 
 QVariant QgsElevationProfileLayerTreeModel::data( const QModelIndex &index, int role ) const
@@ -262,6 +263,20 @@ bool QgsElevationProfileLayerTreeModel::setData( const QModelIndex &index, const
   }
 
   return QgsLayerTreeModel::setData( index, value, role );
+}
+
+Qt::ItemFlags QgsElevationProfileLayerTreeModel::flags( const QModelIndex &index ) const
+{
+  Qt::ItemFlags f = QgsLayerTreeModel::flags( index );
+
+  // the elevation tree model only supports group renames, not layer renames (otherwise
+  // we'd be renaming the actual layer, which is likely NOT what users expect)
+  QgsLayerTreeNode *node = index2node( index );
+  if ( !QgsLayerTree::isGroup( node ) )
+  {
+    f.setFlag( Qt::ItemFlag::ItemIsEditable, false );
+  }
+  return f;
 }
 
 bool QgsElevationProfileLayerTreeModel::canDropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) const

--- a/src/gui/elevation/qgselevationprofilelayertreeview.h
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.h
@@ -56,7 +56,7 @@ class GUI_EXPORT QgsElevationProfileLayerTreeModel : public QgsLayerTreeModel
 
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
-
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
     bool canDropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) const override;
     bool dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) override;
     QMimeData *mimeData( const QModelIndexList &indexes ) const override;

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -160,7 +160,7 @@
      <addaction name="mActionTemporalController"/>
      <addaction name="mActionElevationController"/>
     </widget>
-    <widget class="QMenu" name="menuElevation_Profiles">
+    <widget class="QMenu" name="mMenuElevationProfiles">
      <property name="title">
       <string>Elevation Profiles</string>
      </property>
@@ -178,7 +178,7 @@
     <addaction name="mActionIdentify"/>
     <addaction name="mMenuMeasure"/>
     <addaction name="mActionStatisticalSummary"/>
-    <addaction name="menuElevation_Profiles"/>
+    <addaction name="mMenuElevationProfiles"/>
     <addaction name="separator"/>
     <addaction name="mActionZoomFullExtent"/>
     <addaction name="mActionZoomToSelected"/>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -164,8 +164,6 @@
      <property name="title">
       <string>Elevation Profiles</string>
      </property>
-     <addaction name="mActionElevationProfile"/>
-     <addaction name="mActionManageElevationProfiles"/>
     </widget>
     <addaction name="mActionNewMapCanvas"/>
     <addaction name="m3DMapViewsMenu"/>

--- a/src/ui/qgselevationprofilemanagerbase.ui
+++ b/src/ui/qgselevationprofilemanagerbase.ui
@@ -26,6 +26,19 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0">
+     <item row="1" column="3">
+      <widget class="QToolButton" name="mRenameButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Re&amp;name…</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="0">
       <widget class="QToolButton" name="mShowButton">
        <property name="sizePolicy">
@@ -39,7 +52,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="1" column="2">
       <widget class="QToolButton" name="mRemoveButton">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -52,20 +65,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="QToolButton" name="mRenameButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Re&amp;name…</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0" colspan="3">
+     <item row="0" column="0" colspan="4">
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
        <property name="spacing">
         <number>0</number>
@@ -92,6 +92,19 @@
        </item>
       </layout>
      </item>
+     <item row="1" column="1">
+      <widget class="QToolButton" name="mDuplicateButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;Duplicate…</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -117,6 +130,7 @@
   <tabstop>mSearchLineEdit</tabstop>
   <tabstop>mProfileListView</tabstop>
   <tabstop>mShowButton</tabstop>
+  <tabstop>mDuplicateButton</tabstop>
   <tabstop>mRemoveButton</tabstop>
   <tabstop>mRenameButton</tabstop>
  </tabstops>


### PR DESCRIPTION
This continues on work started in https://github.com/qgis/QGIS/pull/62757, and links the app handling of elevation profiles to the project elevation profile manager.

Now, elevation profiles stored in the project can be re-opened after opening a project, and changes made to the profile will be stored in the project.

The elevation profile manager dialog is also fully functional, able to show/rename/remove profiles from the project.

Sponsored by Erftverband