### PR TITLE
Fix NaN in QgsLineString::extend() 

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
@@ -594,11 +594,22 @@ Returns the geometry converted to the more generic curve type
 :return: the converted geometry. Caller takes ownership
 %End
 
-    void extend( double startDistance, double endDistance );
+    void extend( double startDistance, double endDistance, bool strict = true );
 %Docstring
 Extends the line geometry by extrapolating out the start or end of the
 line by a specified distance. Lines are extended using the bearing of
 the first or last segment in the line.
+
+:param startDistance: distance to extend start of line
+:param endDistance: distance to extend end of line
+:param strict: if ``True``, throws :py:class:`QgsException` when
+               encountering stacked vertices; if ``False``, silently
+               skips stacked vertices (default: ``True``)
+
+:raises QgsException: if strict=``True`` and stacked vertices are
+                      encountered
+
+.. versionadded:: 3.40
 %End
 
 

--- a/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
@@ -594,20 +594,17 @@ Returns the geometry converted to the more generic curve type
 :return: the converted geometry. Caller takes ownership
 %End
 
-    void extend( double startDistance, double endDistance, bool strict = true );
+    void extend( double startDistance, double endDistance );
 %Docstring
 Extends the line geometry by extrapolating out the start or end of the
 line by a specified distance. Lines are extended using the bearing of
 the first or last segment in the line.
 
+New vertices are prepended/appended to the linestring, preserving all
+existing vertices. This follows PostGIS ST_LineExtend behavior.
+
 :param startDistance: distance to extend start of line
 :param endDistance: distance to extend end of line
-:param strict: if ``True``, throws :py:class:`QgsException` when
-               encountering stacked vertices; if ``False``, silently
-               skips stacked vertices (default: ``True``)
-
-:raises QgsException: if strict=``True`` and stacked vertices are
-                      encountered
 
 .. versionadded:: 3.40
 %End

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -594,11 +594,22 @@ Returns the geometry converted to the more generic curve type
 :return: the converted geometry. Caller takes ownership
 %End
 
-    void extend( double startDistance, double endDistance );
+    void extend( double startDistance, double endDistance, bool strict = true );
 %Docstring
 Extends the line geometry by extrapolating out the start or end of the
 line by a specified distance. Lines are extended using the bearing of
 the first or last segment in the line.
+
+:param startDistance: distance to extend start of line
+:param endDistance: distance to extend end of line
+:param strict: if ``True``, throws :py:class:`QgsException` when
+               encountering stacked vertices; if ``False``, silently
+               skips stacked vertices (default: ``True``)
+
+:raises QgsException: if strict=``True`` and stacked vertices are
+                      encountered
+
+.. versionadded:: 3.40
 %End
 
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -594,20 +594,17 @@ Returns the geometry converted to the more generic curve type
 :return: the converted geometry. Caller takes ownership
 %End
 
-    void extend( double startDistance, double endDistance, bool strict = true );
+    void extend( double startDistance, double endDistance );
 %Docstring
 Extends the line geometry by extrapolating out the start or end of the
 line by a specified distance. Lines are extended using the bearing of
 the first or last segment in the line.
 
+New vertices are prepended/appended to the linestring, preserving all
+existing vertices. This follows PostGIS ST_LineExtend behavior.
+
 :param startDistance: distance to extend start of line
 :param endDistance: distance to extend end of line
-:param strict: if ``True``, throws :py:class:`QgsException` when
-               encountering stacked vertices; if ``False``, silently
-               skips stacked vertices (default: ``True``)
-
-:raises QgsException: if strict=``True`` and stacked vertices are
-                      encountered
 
 .. versionadded:: 3.40
 %End

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -19,6 +19,7 @@
 #include "qgsapplication.h"
 #include "qgscompoundcurve.h"
 #include "qgscoordinatetransform.h"
+#include "qgsexception.h"
 #include "qgsgeometryutils.h"
 #include "qgsgeometryutils_base.h"
 #include "qgswkbptr.h"
@@ -1532,7 +1533,7 @@ void QgsLineString::visitPointsByRegularDistance( const double distance, const s
   double pZ = std::numeric_limits<double>::quiet_NaN();
   double pM = std::numeric_limits<double>::quiet_NaN();
   double nextPointDistance = distance;
-  const double eps = 4 * nextPointDistance * std::numeric_limits<double>::epsilon ();
+  const double eps = 4 * nextPointDistance * std::numeric_limits<double>::epsilon();
   for ( int i = 1; i < totalPoints; ++i )
   {
     double thisX = *x++;
@@ -1817,7 +1818,7 @@ QgsCompoundCurve *QgsLineString::toCurveType() const
   return compoundCurve;
 }
 
-void QgsLineString::extend( double startDistance, double endDistance )
+void QgsLineString::extend( double startDistance, double endDistance, bool strict )
 {
   if ( mX.size() < 2 || mY.size() < 2 )
     return;
@@ -1828,21 +1829,81 @@ void QgsLineString::extend( double startDistance, double endDistance )
   // start of line
   if ( extendStart )
   {
-    const double currentLen = std::sqrt( std::pow( mX.at( 0 ) - mX.at( 1 ), 2 ) +
-                                         std::pow( mY.at( 0 ) - mY.at( 1 ), 2 ) );
-    const double newLen = currentLen + startDistance;
-    mX[ 0 ] = mX.at( 1 ) + ( mX.at( 0 ) - mX.at( 1 ) ) / currentLen * newLen;
-    mY[ 0 ] = mY.at( 1 ) + ( mY.at( 0 ) - mY.at( 1 ) ) / currentLen * newLen;
+    // Check for stacked vertices at start
+    double currentLen = std::sqrt( std::pow( mX.at( 0 ) - mX.at( 1 ), 2 ) +
+                                   std::pow( mY.at( 0 ) - mY.at( 1 ), 2 ) );
+
+    if ( qgsDoubleNear( currentLen, 0.0 ) )
+    {
+      if ( strict )
+      {
+        throw QgsException( QObject::tr( "Extending linestring failed. Start segment has zero length." ) );
+      }
+
+      // Find first non-duplicate vertex from start
+      int nextVertex = 1;
+      while ( nextVertex < mX.size() && qgsDoubleNear( currentLen, 0.0 ) )
+      {
+        currentLen = std::sqrt( std::pow( mX.at( 0 ) - mX.at( nextVertex ), 2 ) +
+                                std::pow( mY.at( 0 ) - mY.at( nextVertex ), 2 ) );
+        if ( qgsDoubleNear( currentLen, 0.0 ) )
+          nextVertex++;
+      }
+
+      if ( nextVertex < mX.size() && !qgsDoubleNear( currentLen, 0.0 ) )
+      {
+        const double newLen = currentLen + startDistance;
+        mX[ 0 ] = mX.at( nextVertex ) + ( mX.at( 0 ) - mX.at( nextVertex ) ) / currentLen * newLen;
+        mY[ 0 ] = mY.at( nextVertex ) + ( mY.at( 0 ) - mY.at( nextVertex ) ) / currentLen * newLen;
+      }
+    }
+    else
+    {
+      // Normal case: no stacked vertices
+      const double newLen = currentLen + startDistance;
+      mX[ 0 ] = mX.at( 1 ) + ( mX.at( 0 ) - mX.at( 1 ) ) / currentLen * newLen;
+      mY[ 0 ] = mY.at( 1 ) + ( mY.at( 0 ) - mY.at( 1 ) ) / currentLen * newLen;
+    }
   }
   // end of line
   if ( extendEnd )
   {
     const int last = mX.size() - 1;
-    const double currentLen = std::sqrt( std::pow( mX.at( last ) - mX.at( last - 1 ), 2 ) +
-                                         std::pow( mY.at( last ) - mY.at( last - 1 ), 2 ) );
-    const double newLen = currentLen + endDistance;
-    mX[ last ] = mX.at( last - 1 ) + ( mX.at( last ) - mX.at( last - 1 ) ) / currentLen * newLen;
-    mY[ last ] = mY.at( last - 1 ) + ( mY.at( last ) - mY.at( last - 1 ) ) / currentLen * newLen;
+    // Check for stacked vertices at end
+    double currentLen = std::sqrt( std::pow( mX.at( last ) - mX.at( last - 1 ), 2 ) +
+                                   std::pow( mY.at( last ) - mY.at( last - 1 ), 2 ) );
+
+    if ( qgsDoubleNear( currentLen, 0.0 ) )
+    {
+      if ( strict )
+      {
+        throw QgsException( QObject::tr( "Extending linestring failed. End segment has zero length." ) );
+      }
+
+      // Find first non-duplicate vertex from end
+      int prevVertex = last - 1;
+      while ( prevVertex >= 0 && qgsDoubleNear( currentLen, 0.0 ) )
+      {
+        currentLen = std::sqrt( std::pow( mX.at( last ) - mX.at( prevVertex ), 2 ) +
+                                std::pow( mY.at( last ) - mY.at( prevVertex ), 2 ) );
+        if ( qgsDoubleNear( currentLen, 0.0 ) )
+          prevVertex--;
+      }
+
+      if ( prevVertex >= 0 && !qgsDoubleNear( currentLen, 0.0 ) )
+      {
+        const double newLen = currentLen + endDistance;
+        mX[ last ] = mX.at( prevVertex ) + ( mX.at( last ) - mX.at( prevVertex ) ) / currentLen * newLen;
+        mY[ last ] = mY.at( prevVertex ) + ( mY.at( last ) - mY.at( prevVertex ) ) / currentLen * newLen;
+      }
+    }
+    else
+    {
+      // Normal case: no stacked vertices
+      const double newLen = currentLen + endDistance;
+      mX[ last ] = mX.at( last - 1 ) + ( mX.at( last ) - mX.at( last - 1 ) ) / currentLen * newLen;
+      mY[ last ] = mY.at( last - 1 ) + ( mY.at( last ) - mY.at( last - 1 ) ) / currentLen * newLen;
+    }
   }
 
   if ( extendStart || extendEnd )

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1818,7 +1818,7 @@ QgsCompoundCurve *QgsLineString::toCurveType() const
   return compoundCurve;
 }
 
-void QgsLineString::extend( double startDistance, double endDistance, bool strict )
+void QgsLineString::extend( double startDistance, double endDistance )
 {
   if ( mX.size() < 2 || mY.size() < 2 )
     return;
@@ -1829,80 +1829,61 @@ void QgsLineString::extend( double startDistance, double endDistance, bool stric
   // start of line
   if ( extendStart )
   {
-    // Check for stacked vertices at start
-    double currentLen = std::sqrt( std::pow( mX.at( 0 ) - mX.at( 1 ), 2 ) +
-                                   std::pow( mY.at( 0 ) - mY.at( 1 ), 2 ) );
-
-    if ( qgsDoubleNear( currentLen, 0.0 ) )
+    // Find first non-duplicate vertex from start to determine direction
+    double currentLen = 0.0;
+    int nextVertex = 1;
+    while ( nextVertex < mX.size() )
     {
-      if ( strict )
-      {
-        throw QgsException( QObject::tr( "Extending linestring failed. Start segment has zero length." ) );
-      }
-
-      // Find first non-duplicate vertex from start
-      int nextVertex = 1;
-      while ( nextVertex < mX.size() && qgsDoubleNear( currentLen, 0.0 ) )
-      {
-        currentLen = std::sqrt( std::pow( mX.at( 0 ) - mX.at( nextVertex ), 2 ) +
-                                std::pow( mY.at( 0 ) - mY.at( nextVertex ), 2 ) );
-        if ( qgsDoubleNear( currentLen, 0.0 ) )
-          nextVertex++;
-      }
-
-      if ( nextVertex < mX.size() && !qgsDoubleNear( currentLen, 0.0 ) )
-      {
-        const double newLen = currentLen + startDistance;
-        mX[ 0 ] = mX.at( nextVertex ) + ( mX.at( 0 ) - mX.at( nextVertex ) ) / currentLen * newLen;
-        mY[ 0 ] = mY.at( nextVertex ) + ( mY.at( 0 ) - mY.at( nextVertex ) ) / currentLen * newLen;
-      }
+      currentLen = std::sqrt( std::pow( mX.at( 0 ) - mX.at( nextVertex ), 2 ) +
+                              std::pow( mY.at( 0 ) - mY.at( nextVertex ), 2 ) );
+      if ( !qgsDoubleNear( currentLen, 0.0 ) )
+        break;
+      nextVertex++;
     }
-    else
+
+    if ( nextVertex < mX.size() && !qgsDoubleNear( currentLen, 0.0 ) )
     {
-      // Normal case: no stacked vertices
-      const double newLen = currentLen + startDistance;
-      mX[ 0 ] = mX.at( 1 ) + ( mX.at( 0 ) - mX.at( 1 ) ) / currentLen * newLen;
-      mY[ 0 ] = mY.at( 1 ) + ( mY.at( 0 ) - mY.at( 1 ) ) / currentLen * newLen;
+      // Calculate new start point and prepend it
+      const double newX = mX.at( nextVertex ) + ( mX.at( 0 ) - mX.at( nextVertex ) ) / currentLen * ( currentLen + startDistance );
+      const double newY = mY.at( nextVertex ) + ( mY.at( 0 ) - mY.at( nextVertex ) ) / currentLen * ( currentLen + startDistance );
+
+      mX.prepend( newX );
+      mY.prepend( newY );
+      if ( is3D() )
+        mZ.prepend( mZ.at( 0 ) );
+      if ( isMeasure() )
+        mM.prepend( mM.at( 0 ) );
     }
   }
-  // end of line
+
+  // end of line - append a new vertex (PostGIS behavior)
   if ( extendEnd )
   {
     const int last = mX.size() - 1;
-    // Check for stacked vertices at end
-    double currentLen = std::sqrt( std::pow( mX.at( last ) - mX.at( last - 1 ), 2 ) +
-                                   std::pow( mY.at( last ) - mY.at( last - 1 ), 2 ) );
 
-    if ( qgsDoubleNear( currentLen, 0.0 ) )
+    double currentLen = 0.0;
+    int prevVertex = last - 1;
+    while ( prevVertex >= 0 )
     {
-      if ( strict )
-      {
-        throw QgsException( QObject::tr( "Extending linestring failed. End segment has zero length." ) );
-      }
-
-      // Find first non-duplicate vertex from end
-      int prevVertex = last - 1;
-      while ( prevVertex >= 0 && qgsDoubleNear( currentLen, 0.0 ) )
-      {
-        currentLen = std::sqrt( std::pow( mX.at( last ) - mX.at( prevVertex ), 2 ) +
-                                std::pow( mY.at( last ) - mY.at( prevVertex ), 2 ) );
-        if ( qgsDoubleNear( currentLen, 0.0 ) )
-          prevVertex--;
-      }
-
-      if ( prevVertex >= 0 && !qgsDoubleNear( currentLen, 0.0 ) )
-      {
-        const double newLen = currentLen + endDistance;
-        mX[ last ] = mX.at( prevVertex ) + ( mX.at( last ) - mX.at( prevVertex ) ) / currentLen * newLen;
-        mY[ last ] = mY.at( prevVertex ) + ( mY.at( last ) - mY.at( prevVertex ) ) / currentLen * newLen;
-      }
+      currentLen = std::sqrt( std::pow( mX.at( last ) - mX.at( prevVertex ), 2 ) +
+                              std::pow( mY.at( last ) - mY.at( prevVertex ), 2 ) );
+      if ( !qgsDoubleNear( currentLen, 0.0 ) )
+        break;
+      prevVertex--;
     }
-    else
+
+    if ( prevVertex >= 0 && !qgsDoubleNear( currentLen, 0.0 ) )
     {
-      // Normal case: no stacked vertices
-      const double newLen = currentLen + endDistance;
-      mX[ last ] = mX.at( last - 1 ) + ( mX.at( last ) - mX.at( last - 1 ) ) / currentLen * newLen;
-      mY[ last ] = mY.at( last - 1 ) + ( mY.at( last ) - mY.at( last - 1 ) ) / currentLen * newLen;
+      // Calculate new end point and append it
+      const double newX = mX.at( prevVertex ) + ( mX.at( last ) - mX.at( prevVertex ) ) / currentLen * ( currentLen + endDistance );
+      const double newY = mY.at( prevVertex ) + ( mY.at( last ) - mY.at( prevVertex ) ) / currentLen * ( currentLen + endDistance );
+
+      mX.append( newX );
+      mY.append( newY );
+      if ( is3D() )
+        mZ.append( mZ.at( last ) );
+      if ( isMeasure() )
+        mM.append( mM.at( last ) );
     }
   }
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -930,8 +930,14 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * Extends the line geometry by extrapolating out the start or end of the line
      * by a specified distance. Lines are extended using the bearing of the first or last
      * segment in the line.
+     * \param startDistance distance to extend start of line
+     * \param endDistance distance to extend end of line
+     * \param strict if TRUE, throws QgsException when encountering stacked vertices;
+     *               if FALSE, silently skips stacked vertices (default: TRUE)
+     * \throws QgsException if strict=TRUE and stacked vertices are encountered
+     * \since QGIS 3.40
      */
-    void extend( double startDistance, double endDistance );
+    void extend( double startDistance, double endDistance, bool strict = true );
 
 #ifndef SIP_RUN
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -930,14 +930,15 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * Extends the line geometry by extrapolating out the start or end of the line
      * by a specified distance. Lines are extended using the bearing of the first or last
      * segment in the line.
+     *
+     * New vertices are prepended/appended to the linestring, preserving all existing vertices.
+     * This follows PostGIS ST_LineExtend behavior.
+     *
      * \param startDistance distance to extend start of line
      * \param endDistance distance to extend end of line
-     * \param strict if TRUE, throws QgsException when encountering stacked vertices;
-     *               if FALSE, silently skips stacked vertices (default: TRUE)
-     * \throws QgsException if strict=TRUE and stacked vertices are encountered
      * \since QGIS 3.40
      */
-    void extend( double startDistance, double endDistance, bool strict = true );
+    void extend( double startDistance, double endDistance );
 
 #ifndef SIP_RUN
 

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2310,6 +2310,56 @@ void TestQgsLineString::extend()
   QCOMPARE( ls.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 1, 0 ) );
   QCOMPARE( ls.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 1, 3 ) );
   QCOMPARE( ls.boundingBox(), QgsRectangle( -1, 0, 1, 3 ) );
+
+  QgsLineString lsStackedStart;
+  lsStackedStart.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
+  lsStackedStart.extend( 1, 0, false );  
+  QCOMPARE( lsStackedStart.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
+  QCOMPARE( lsStackedStart.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsStackedStart.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+
+  QgsLineString lsStackedEnd;
+  lsStackedEnd.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  lsStackedEnd.extend( 0, 1, false );  
+  QCOMPARE( lsStackedEnd.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsStackedEnd.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsStackedEnd.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 6, 0 ) );
+
+  QgsLineString lsStackedBoth;
+  lsStackedBoth.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  lsStackedBoth.extend( 1, 1, false );  
+  QCOMPARE( lsStackedBoth.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
+  QCOMPARE( lsStackedBoth.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsStackedBoth.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsStackedBoth.pointN( 3 ), QgsPoint( Qgis::WkbType::Point, 6, 0 ) );
+
+  // Test stacked vertices in strict mode
+  QgsLineString lsStackedStartStrict;
+  lsStackedStartStrict.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedStartStrict.extend( 1, 0, true ), QgsException );
+
+  QgsLineString lsStackedEndStrict;
+  lsStackedEndStrict.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedEndStrict.extend( 0, 1, true ), QgsException );
+
+  QgsLineString lsStackedBothStrict;
+  lsStackedBothStrict.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  QVERIFY_EXCEPTION_THROWN( lsStackedBothStrict.extend( 1, 1, true ), QgsException );
+
+  // Test partial stacked vertices in lenient mode 
+  QgsLineString lsPartialStacked;
+  lsPartialStacked.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
+  lsPartialStacked.extend( 1, 0, false ); 
+  QCOMPARE( lsPartialStacked.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
+  QCOMPARE( lsPartialStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsPartialStacked.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+
+  QgsLineString lsAllStacked;
+  lsAllStacked.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) );
+  lsAllStacked.extend( 1, 1, false );
+  QCOMPARE( lsAllStacked.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsAllStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsAllStacked.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
 }
 
 void TestQgsLineString::addToPainterPath()

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -2301,62 +2301,64 @@ void TestQgsLineString::boundary()
 void TestQgsLineString::extend()
 {
   QgsLineString ls;
-  ls.extend( 10, 10 ); //test no crash
+  ls.extend( 10, 10 );
 
   ls.setPoints( QgsPointSequence() << QgsPoint( 0, 0 ) << QgsPoint( 1, 0 ) << QgsPoint( 1, 1 ) );
   ls.extend( 1, 2 );
 
+
+  QCOMPARE( ls.numPoints(), 5 );
   QCOMPARE( ls.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, -1, 0 ) );
-  QCOMPARE( ls.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 1, 0 ) );
-  QCOMPARE( ls.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 1, 3 ) );
+  QCOMPARE( ls.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 0, 0 ) );
+  QCOMPARE( ls.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 1, 0 ) );
+  QCOMPARE( ls.pointN( 3 ), QgsPoint( Qgis::WkbType::Point, 1, 1 ) );
+  QCOMPARE( ls.pointN( 4 ), QgsPoint( Qgis::WkbType::Point, 1, 3 ) );
   QCOMPARE( ls.boundingBox(), QgsRectangle( -1, 0, 1, 3 ) );
 
   QgsLineString lsStackedStart;
   lsStackedStart.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
-  lsStackedStart.extend( 1, 0, false );  
+  lsStackedStart.extend( 1, 0 );
+  QCOMPARE( lsStackedStart.numPoints(), 4 );
   QCOMPARE( lsStackedStart.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
   QCOMPARE( lsStackedStart.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
-  QCOMPARE( lsStackedStart.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsStackedStart.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsStackedStart.pointN( 3 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
 
   QgsLineString lsStackedEnd;
   lsStackedEnd.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
-  lsStackedEnd.extend( 0, 1, false );  
+  lsStackedEnd.extend( 0, 1 );
+  QCOMPARE( lsStackedEnd.numPoints(), 4 );
   QCOMPARE( lsStackedEnd.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
   QCOMPARE( lsStackedEnd.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
-  QCOMPARE( lsStackedEnd.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 6, 0 ) );
+  QCOMPARE( lsStackedEnd.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsStackedEnd.pointN( 3 ), QgsPoint( Qgis::WkbType::Point, 6, 0 ) );
 
   QgsLineString lsStackedBoth;
   lsStackedBoth.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
-  lsStackedBoth.extend( 1, 1, false );  
+  lsStackedBoth.extend( 1, 1 );
+  QCOMPARE( lsStackedBoth.numPoints(), 6 );
   QCOMPARE( lsStackedBoth.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
   QCOMPARE( lsStackedBoth.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
-  QCOMPARE( lsStackedBoth.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
-  QCOMPARE( lsStackedBoth.pointN( 3 ), QgsPoint( Qgis::WkbType::Point, 6, 0 ) );
+  QCOMPARE( lsStackedBoth.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
+  QCOMPARE( lsStackedBoth.pointN( 3 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsStackedBoth.pointN( 4 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsStackedBoth.pointN( 5 ), QgsPoint( Qgis::WkbType::Point, 6, 0 ) );
 
-  // Test stacked vertices in strict mode
-  QgsLineString lsStackedStartStrict;
-  lsStackedStartStrict.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) );
-  QVERIFY_EXCEPTION_THROWN( lsStackedStartStrict.extend( 1, 0, true ), QgsException );
 
-  QgsLineString lsStackedEndStrict;
-  lsStackedEndStrict.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
-  QVERIFY_EXCEPTION_THROWN( lsStackedEndStrict.extend( 0, 1, true ), QgsException );
-
-  QgsLineString lsStackedBothStrict;
-  lsStackedBothStrict.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
-  QVERIFY_EXCEPTION_THROWN( lsStackedBothStrict.extend( 1, 1, true ), QgsException );
-
-  // Test partial stacked vertices in lenient mode 
   QgsLineString lsPartialStacked;
   lsPartialStacked.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 5, 0 ) << QgsPoint( 5, 0 ) );
-  lsPartialStacked.extend( 1, 0, false ); 
+  lsPartialStacked.extend( 1, 0 );
+  QCOMPARE( lsPartialStacked.numPoints(), 4 );
   QCOMPARE( lsPartialStacked.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 3, 0 ) );
-  QCOMPARE( lsPartialStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsPartialStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
   QCOMPARE( lsPartialStacked.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+  QCOMPARE( lsPartialStacked.pointN( 3 ), QgsPoint( Qgis::WkbType::Point, 5, 0 ) );
+
 
   QgsLineString lsAllStacked;
   lsAllStacked.setPoints( QgsPointSequence() << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) << QgsPoint( 4, 0 ) );
-  lsAllStacked.extend( 1, 1, false );
+  lsAllStacked.extend( 1, 1 );
+  QCOMPARE( lsAllStacked.numPoints(), 3 );
   QCOMPARE( lsAllStacked.pointN( 0 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
   QCOMPARE( lsAllStacked.pointN( 1 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );
   QCOMPARE( lsAllStacked.pointN( 2 ), QgsPoint( Qgis::WkbType::Point, 4, 0 ) );

--- a/tests/src/python/test_qgslinestring.py
+++ b/tests/src/python/test_qgslinestring.py
@@ -16,6 +16,7 @@ import math
 from qgis.core import Qgis, QgsLineString, QgsPoint
 from qgis.testing import start_app, QgisTestCase
 from qgis.core import QgsGeometry, QgsException
+
 start_app()
 
 
@@ -599,24 +600,23 @@ class TestQgsLineString(QgisTestCase):
         Test extend method with stacked vertices - should raise exception instead of producing NaN.
         Addresses issue #62473
         """
-        
-        
+
         linestring = QgsLineString([4, 4, 5, 5], [0, 0, 0, 0])
-        with self.assertRaises(Exception):
+        with self.assertRaises(QgsException):
             linestring.extend(1, 1)
-        
-        geom = QgsGeometry.fromWkt('LineString (4 0, 4 0, 5 0, 5 0)')
-        extended_geom = geom.extendLine(1, 1)
-        self.assertTrue(extended_geom.isNull())
-        
+
+        geom = QgsGeometry.fromWkt("LineString (4 0, 4 0, 5 0, 5 0)")
+        with self.assertRaises(QgsException):
+            geom.extendLine(1, 1)
+
         linestring_start = QgsLineString([4, 4, 5], [0, 0, 0])
-        with self.assertRaises(Exception):
+        with self.assertRaises(QgsException):
             linestring_start.extend(1, 0)
-        
+
         linestring_end = QgsLineString([4, 5, 5], [0, 0, 0])
-        with self.assertRaises(Exception):
+        with self.assertRaises(QgsException):
             linestring_end.extend(0, 1)
-        
+
         linestring_normal = QgsLineString([0, 1, 1], [0, 0, 1])
         linestring_normal.extend(1, 2)
         self.assertEqual(linestring_normal.pointN(0), QgsPoint(-1, 0))

--- a/tests/src/python/test_qgslinestring.py
+++ b/tests/src/python/test_qgslinestring.py
@@ -597,30 +597,47 @@ class TestQgsLineString(QgisTestCase):
 
     def test_extend_stacked_vertices(self):
         """
-        Test extend method with stacked vertices - should raise exception instead of producing NaN.
+        Test extend method with stacked vertices - follows PostGIS ST_LineExtend behavior.
+        New vertices are prepended/appended, preserving all existing vertices.
         Addresses issue #62473
         """
 
         linestring = QgsLineString([4, 4, 5, 5], [0, 0, 0, 0])
-        with self.assertRaises(QgsException):
-            linestring.extend(1, 1)
+        linestring.extend(1, 1)
+        self.assertEqual(linestring.numPoints(), 6)
+        self.assertEqual(linestring.pointN(0), QgsPoint(3, 0))
+        self.assertEqual(linestring.pointN(1), QgsPoint(4, 0))
+        self.assertEqual(linestring.pointN(2), QgsPoint(4, 0))
+        self.assertEqual(linestring.pointN(3), QgsPoint(5, 0))
+        self.assertEqual(linestring.pointN(4), QgsPoint(5, 0))
+        self.assertEqual(linestring.pointN(5), QgsPoint(6, 0))
 
-        geom = QgsGeometry.fromWkt("LineString (4 0, 4 0, 5 0, 5 0)")
-        with self.assertRaises(QgsException):
-            geom.extendLine(1, 1)
-
+        # Test stacked vertices at start
         linestring_start = QgsLineString([4, 4, 5], [0, 0, 0])
-        with self.assertRaises(QgsException):
-            linestring_start.extend(1, 0)
+        linestring_start.extend(1, 0)
+        self.assertEqual(linestring_start.numPoints(), 4)
+        self.assertEqual(linestring_start.pointN(0), QgsPoint(3, 0))
+        self.assertEqual(linestring_start.pointN(1), QgsPoint(4, 0))
+        self.assertEqual(linestring_start.pointN(2), QgsPoint(4, 0))
+        self.assertEqual(linestring_start.pointN(3), QgsPoint(5, 0))
 
+        # Test stacked vertices at end
         linestring_end = QgsLineString([4, 5, 5], [0, 0, 0])
-        with self.assertRaises(QgsException):
-            linestring_end.extend(0, 1)
+        linestring_end.extend(0, 1)
+        self.assertEqual(linestring_end.numPoints(), 4)
+        self.assertEqual(linestring_end.pointN(0), QgsPoint(4, 0))
+        self.assertEqual(linestring_end.pointN(1), QgsPoint(5, 0))
+        self.assertEqual(linestring_end.pointN(2), QgsPoint(5, 0))
+        self.assertEqual(linestring_end.pointN(3), QgsPoint(6, 0))
 
         linestring_normal = QgsLineString([0, 1, 1], [0, 0, 1])
         linestring_normal.extend(1, 2)
+        self.assertEqual(linestring_normal.numPoints(), 5)
         self.assertEqual(linestring_normal.pointN(0), QgsPoint(-1, 0))
-        self.assertEqual(linestring_normal.pointN(2), QgsPoint(1, 3))
+        self.assertEqual(linestring_normal.pointN(1), QgsPoint(0, 0))
+        self.assertEqual(linestring_normal.pointN(2), QgsPoint(1, 0))
+        self.assertEqual(linestring_normal.pointN(3), QgsPoint(1, 1))
+        self.assertEqual(linestring_normal.pointN(4), QgsPoint(1, 3))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add zero-length segment detection in qgsLineString::extend()
Throw QgsException with error message instead of producing NaN
Update QgsGeometry::extendLine() to handle exceptions
improve native:extendlines processing tool error messages
Add tests
-Fixes https://github.com/qgis/QGIS/issues/62473