### PR TITLE
Fix 3d view shortcuts

### DIFF
--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -286,7 +286,7 @@ class _3D_EXPORT QgsCameraController : public QObject
     //! Rotate to diagonal view. \since QGIS 3.44
     void rotateCameraToHome() { rotateToRespectingTerrain( 45.0f, 45.0f ); }
     //! Rotate to top-down view. \since QGIS 3.44
-    void rotateCameraToTop() { rotateToRespectingTerrain( 0.0f, 90.0f ); }
+    void rotateCameraToTop() { rotateToRespectingTerrain( 0.0f, 0.0f ); }
     //! Rotate to view from the north. \since QGIS 3.44
     void rotateCameraToNorth() { rotateToRespectingTerrain( 90.0f, 180.0f ); }
     //! Rotate to view from the east. \since QGIS 3.44

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -81,7 +81,7 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
   actionCameraControl->setCheckable( true );
 
   QAction *zoomFullAction = toolBar->addAction( QgsApplication::getThemeIcon( QStringLiteral( "mActionZoomFullExtent.svg" ) ), tr( "Zoom Full" ), this, &Qgs3DMapCanvasWidget::resetView );
-  zoomFullAction->setShortcuts( { QKeySequence( tr( "Ctrl+0" ) ), QKeySequence( tr( "Esc" ) ) } );
+  zoomFullAction->setShortcut( QKeySequence( tr( "Ctrl+0" ) ) );
 
   // Editing toolbar
   mEditingToolBar = new QToolBar( this );


### PR DESCRIPTION
## Description
- Make Top view North Up (instead of west up)
- Don't reset the view on `Esc` key.  This shortcut was silently introduced in #61285 and is a poor choice. Especially with 3d map tools exposed to python, it will be very easy to trigger accidentally.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
