### PR TITLE
Add QgsVectorLayerUtils.fieldToDataArray(), QgsVectorLayer.field_to_numpy()

### DIFF
--- a/python/PyQt6/core/__init__.py.in
+++ b/python/PyQt6/core/__init__.py.in
@@ -25,6 +25,7 @@ import typing as _typing
 
 from qgis.PyQt.QtCore import NULL
 from qgis.PyQt.QtCore import Qt as _Qt
+from qgis.PyQt.QtCore import QMetaType as _QMetaType
 from qgis._core import *
 
 @MONKEYPATCH_INJECTIONS@
@@ -623,6 +624,21 @@ try:
        }
       return qgis_to_numpy_dtype_dict[dataType]
 
+   def _qvariant_type_to_numeric_data_type(dataType: _QMetaType.Type) -> _typing.Optional[_numpy.dtype]:
+      qmetatype_to_numpy_dtype_dict = {
+        _QMetaType.Type.Int: _numpy.int32,
+            _QMetaType.Type.UInt: _numpy.uint32,
+            _QMetaType.Type.LongLong:_numpy.int64,
+            _QMetaType.Type.ULongLong: _numpy.uint64,
+            _QMetaType.Type.Short: _numpy.int16,
+            _QMetaType.Type.UShort: _numpy.uint16,
+            _QMetaType.Type.Long: _numpy.int64,
+            _QMetaType.Type.ULong: _numpy.uint64,
+            _QMetaType.Type.Float: _numpy.float32,
+            _QMetaType.Type.Double: _numpy.float64,
+       }
+      return qmetatype_to_numpy_dtype_dict.get(dataType)
+
    def _raster_block_as_numpy(self, use_masking:bool = True) -> _typing.Union[_numpy.ndarray, _numpy.ma.MaskedArray]:
       raster_dtype = _qgis_data_type_to_numeric_data_type(self.dataType())
       if not raster_dtype:
@@ -656,6 +672,26 @@ try:
           return _numpy.array(arrays)
 
    QgsRasterLayer.as_numpy = _raster_layer_as_numpy
+
+   def _field_to_numpy(self, field_name: str, null_value: object, request: _typing.Optional[QgsFeatureRequest] = None) -> _numpy.ma.MaskedArray:
+      field_index = self.fields().lookupField(field_name)
+      if field_index < 0:
+         raise KeyError(f"Field '{field_name}' does not exist.")
+      field = self.fields().at(field_index)
+      numpy_dtype = _qvariant_type_to_numeric_data_type(field.type())
+      if numpy_dtype is None:
+         raise TypeError(f"The field data type '{str(field.type())}' is not compatible with NumPy arrays.")
+
+      if request is None:
+         request = QgsFeatureRequest().setFlags(Qgis.FeatureRequestFlag.NoGeometry).setSubsetOfAttributes([
+        field_index
+      ])
+
+      src_array = QgsVectorLayerUtils.fieldToDataArray(self.fields(), field_name, self.getFeatures(request), null_value)
+      numpy_array = _numpy.frombuffer(src_array.data(), dtype=numpy_dtype)
+      return _numpy.ma.masked_equal(numpy_array, null_value)
+
+   QgsVectorLayer.field_to_numpy = _field_to_numpy
 
    def _qgsgeometry_as_numpy(self) -> _typing.Union[_numpy.ndarray, _typing.List[_numpy.ndarray]]:
        wkb_type = self.wkbType()
@@ -730,6 +766,10 @@ except ModuleNotFoundError:
 
    QgsGeometry.as_numpy = _geometry_as_numpy
 
+   def _field_to_numpy(self, field_name: str, null_value, request: _typing.Optional[QgsFeatureRequest] = None):
+      raise QgsNotSupportedException('QgsVectorLayer.field_to_numpy is not available, numpy is not installed on the system')
+
+   QgsVectorLayer.field_to_numpy = _field_to_numpy
 try:
    import shapely as _shapely
    import shapely.geometry as _sg
@@ -845,6 +885,31 @@ All features from the layer are converted to a GeoDataFrame, including their geo
 original layer.
 
 :raises QgsNotSupportedException: if geopandas is not available on the system
+
+.. versionadded:: 4.0
+"""
+
+QgsVectorLayer.field_to_numpy.__doc__ = """
+Returns the values from a field as a numpy masked array.
+
+:param field_name: field name to source values from
+:param null_value: value to use when original field value is a null. Must
+                   be of the same data type as the source field. This value will be
+                   used as the mask when converting the array to a numpy masked array, and must
+                   be carefully selected to avoid conflicts with valid, existing field values.
+:param request: optional QgsFeatureRequest to control which features to source values from.
+                If not specified, an optimized feature request over all layer features will
+                be used.
+
+.. warning::
+
+   Only numeric field types are supported.
+
+:raises KeyError: if the field name is not found
+
+:raises TypeError: if the field is of a non-supported type
+
+:raises QgsNotSupportedException: if numpy is not available on the system
 
 .. versionadded:: 4.0
 """

--- a/python/PyQt6/core/__init__.py.in
+++ b/python/PyQt6/core/__init__.py.in
@@ -673,7 +673,7 @@ try:
 
    QgsRasterLayer.as_numpy = _raster_layer_as_numpy
 
-   def _field_to_numpy(self, field_name: str, null_value: object, request: _typing.Optional[QgsFeatureRequest] = None) -> _numpy.ma.MaskedArray:
+   def _field_as_numpy(self, field_name: str, null_value: object, request: _typing.Optional[QgsFeatureRequest] = None) -> _numpy.ma.MaskedArray:
       field_index = self.fields().lookupField(field_name)
       if field_index < 0:
          raise KeyError(f"Field '{field_name}' does not exist.")
@@ -691,7 +691,7 @@ try:
       numpy_array = _numpy.frombuffer(src_array.data(), dtype=numpy_dtype)
       return _numpy.ma.masked_equal(numpy_array, null_value)
 
-   QgsVectorLayer.field_to_numpy = _field_to_numpy
+   QgsVectorLayer.field_as_numpy = _field_as_numpy
 
    def _qgsgeometry_as_numpy(self) -> _typing.Union[_numpy.ndarray, _typing.List[_numpy.ndarray]]:
        wkb_type = self.wkbType()
@@ -766,10 +766,10 @@ except ModuleNotFoundError:
 
    QgsGeometry.as_numpy = _geometry_as_numpy
 
-   def _field_to_numpy(self, field_name: str, null_value, request: _typing.Optional[QgsFeatureRequest] = None):
-      raise QgsNotSupportedException('QgsVectorLayer.field_to_numpy is not available, numpy is not installed on the system')
+   def _field_as_numpy(self, field_name: str, null_value, request: _typing.Optional[QgsFeatureRequest] = None):
+      raise QgsNotSupportedException('QgsVectorLayer.field_as_numpy is not available, numpy is not installed on the system')
 
-   QgsVectorLayer.field_to_numpy = _field_to_numpy
+   QgsVectorLayer.field_as_numpy = _field_as_numpy
 try:
    import shapely as _shapely
    import shapely.geometry as _sg
@@ -889,7 +889,7 @@ original layer.
 .. versionadded:: 4.0
 """
 
-QgsVectorLayer.field_to_numpy.__doc__ = """
+QgsVectorLayer.field_as_numpy.__doc__ = """
 Returns the values from a field as a numpy masked array.
 
 :param field_name: field name to source values from

--- a/python/PyQt6/core/auto_additions/qgsvectorlayerutils.py
+++ b/python/PyQt6/core/auto_additions/qgsvectorlayerutils.py
@@ -22,6 +22,7 @@ try:
     QgsVectorLayerUtils.getFeatureDisplayString = staticmethod(QgsVectorLayerUtils.getFeatureDisplayString)
     QgsVectorLayerUtils.impactsCascadeFeatures = staticmethod(QgsVectorLayerUtils.impactsCascadeFeatures)
     QgsVectorLayerUtils.guessFriendlyIdentifierField = staticmethod(QgsVectorLayerUtils.guessFriendlyIdentifierField)
+    QgsVectorLayerUtils.fieldToDataArray = staticmethod(QgsVectorLayerUtils.fieldToDataArray)
     QgsVectorLayerUtils.__group__ = ['vector']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -422,6 +422,67 @@ first available.
 .. versionadded:: 3.18
 %End
 
+
+
+    static QByteArray fieldToDataArray( const QgsFields &fields, const QString &fieldName, QgsFeatureIterator &it, const QVariant &nullValue );
+%Docstring
+Converts field values from an iterator to an array of data.
+
+:param fields: layer fields
+:param fieldName: field name to source values from
+:param it: feature iterator for features to include
+:param nullValue: value to use when original field value is a null. Must
+                  be of the same data type as the source field.
+
+.. warning::
+
+   Only numeric field types are supported.
+
+:raises KeyError: if the field name is not found
+
+:raises TypeError: if the field is of a non-supported type
+
+.. versionadded:: 4.0
+%End
+%MethodCode
+
+    const int fieldIndex = a0->lookupField( *a1 );
+    if ( fieldIndex == -1 )
+    {
+      PyErr_SetString( PyExc_KeyError, QStringLiteral( "Field %1 does not exist." ).arg( *a1 ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    else
+    {
+      const QgsField field = a0->at( fieldIndex );
+      switch ( field.type() )
+      {
+        case QMetaType::Type::Int:
+        case QMetaType::Type::UInt:
+        case QMetaType::Type::Long:
+        case QMetaType::Type::LongLong:
+        case QMetaType::Type::ULong:
+        case QMetaType::Type::ULongLong:
+        case QMetaType::Type::Float:
+        case QMetaType::Type::Double:
+        case QMetaType::Type::Short:
+        case QMetaType::Type::UShort:
+        {
+          Py_BEGIN_ALLOW_THREADS
+          sipRes = new QByteArray( QgsVectorLayerUtils::fieldToDataArray( *a0, *a1, *a2, *a3 ) );
+          Py_END_ALLOW_THREADS
+          break;
+        }
+
+        default:
+        {
+          PyErr_SetString( PyExc_TypeError, QStringLiteral( "Field type (%1) cannot be converted to a data array." ).arg( QMetaType::typeName( field.type() ) ).toUtf8().constData() );
+          sipIsErr = 1;
+        }
+      }
+    }
+%End
+
 };
 
 

--- a/python/core/__init__.py.in
+++ b/python/core/__init__.py.in
@@ -25,6 +25,7 @@ import typing as _typing
 
 from qgis.PyQt.QtCore import NULL
 from qgis.PyQt.QtCore import Qt as _Qt
+from qgis.PyQt.QtCore import QMetaType as _QMetaType
 from qgis._core import *
 
 @MONKEYPATCH_INJECTIONS@
@@ -634,9 +635,24 @@ try:
        }
       return qgis_to_numpy_dtype_dict[dataType]
 
+   def _qvariant_type_to_numeric_data_type(dataType: _QMetaType.Type) -> _typing.Optional[_numpy.dtype]:
+      qmetatype_to_numpy_dtype_dict = {
+        _QMetaType.Type.Int: _numpy.int32,
+            _QMetaType.Type.UInt: _numpy.uint32,
+            _QMetaType.Type.LongLong:_numpy.int64,
+            _QMetaType.Type.ULongLong: _numpy.uint64,
+            _QMetaType.Type.Short: _numpy.int16,
+            _QMetaType.Type.UShort: _numpy.uint16,
+            _QMetaType.Type.Long: _numpy.int64,
+            _QMetaType.Type.ULong: _numpy.uint64,
+            _QMetaType.Type.Float: _numpy.float32,
+            _QMetaType.Type.Double: _numpy.float64,
+       }
+      return qmetatype_to_numpy_dtype_dict.get(dataType)
+
    def _raster_block_as_numpy(self, use_masking:bool = True) -> _typing.Union[_numpy.ndarray, _numpy.ma.MaskedArray]:
       raster_dtype = _qgis_data_type_to_numeric_data_type(self.dataType())
-      if not raster_dtype:
+      if raster_dtype is None:
          raise ValueError(f"The raster block data type '{str(self.dataType())}' is not compatible with NumPy arrays.")
       src_array = _numpy.frombuffer(self.data(), dtype=raster_dtype)
       src_array = src_array.reshape((self.height(), self.width()))
@@ -667,6 +683,26 @@ try:
           return _numpy.array(arrays)
 
    QgsRasterLayer.as_numpy = _raster_layer_as_numpy
+
+   def _field_to_numpy(self, field_name: str, null_value: object, request: _typing.Optional[QgsFeatureRequest] = None) -> _numpy.ma.MaskedArray:
+      field_index = self.fields().lookupField(field_name)
+      if field_index < 0:
+         raise KeyError(f"Field '{field_name}' does not exist.")
+      field = self.fields().at(field_index)
+      numpy_dtype = _qvariant_type_to_numeric_data_type(field.type())
+      if numpy_dtype is None:
+         raise TypeError(f"The field data type '{str(field.type())}' is not compatible with NumPy arrays.")
+
+      if request is None:
+         request = QgsFeatureRequest().setFlags(Qgis.FeatureRequestFlag.NoGeometry).setSubsetOfAttributes([
+        field_index
+      ])
+
+      src_array = QgsVectorLayerUtils.fieldToDataArray(self.fields(), field_name, self.getFeatures(request), null_value)
+      numpy_array = _numpy.frombuffer(src_array.data(), dtype=numpy_dtype)
+      return _numpy.ma.masked_equal(numpy_array, null_value)
+
+   QgsVectorLayer.field_to_numpy = _field_to_numpy
 
    def _qgsgeometry_as_numpy(self) -> _typing.Union[_numpy.ndarray, _typing.List[_numpy.ndarray]]:
        wkb_type = self.wkbType()
@@ -740,6 +776,11 @@ except ModuleNotFoundError:
       raise QgsNotSupportedException('QgsGeometry.as_numpy is not available, numpy is not installed on the system')
 
    QgsGeometry.as_numpy = _geometry_as_numpy
+
+   def _field_to_numpy(self, field_name: str, null_value, request: _typing.Optional[QgsFeatureRequest] = None):
+      raise QgsNotSupportedException('QgsVectorLayer.field_to_numpy is not available, numpy is not installed on the system')
+
+   QgsVectorLayer.field_to_numpy = _field_to_numpy
 
 try:
    import shapely as _shapely
@@ -856,6 +897,31 @@ All features from the layer are converted to a GeoDataFrame, including their geo
 original layer.
 
 :raises QgsNotSupportedException: if geopandas is not available on the system
+
+.. versionadded:: 4.0
+"""
+
+QgsVectorLayer.field_to_numpy.__doc__ = """
+Returns the values from a field as a numpy masked array.
+
+:param field_name: field name to source values from
+:param null_value: value to use when original field value is a null. Must
+                   be of the same data type as the source field. This value will be
+                   used as the mask when converting the array to a numpy masked array, and must
+                   be carefully selected to avoid conflicts with valid, existing field values.
+:param request: optional QgsFeatureRequest to control which features to source values from.
+                If not specified, an optimized feature request over all layer features will
+                be used.
+
+.. warning::
+
+   Only numeric field types are supported.
+
+:raises KeyError: if the field name is not found
+
+:raises TypeError: if the field is of a non-supported type
+
+:raises QgsNotSupportedException: if numpy is not available on the system
 
 .. versionadded:: 4.0
 """

--- a/python/core/__init__.py.in
+++ b/python/core/__init__.py.in
@@ -684,7 +684,7 @@ try:
 
    QgsRasterLayer.as_numpy = _raster_layer_as_numpy
 
-   def _field_to_numpy(self, field_name: str, null_value: object, request: _typing.Optional[QgsFeatureRequest] = None) -> _numpy.ma.MaskedArray:
+   def _field_as_numpy(self, field_name: str, null_value: object, request: _typing.Optional[QgsFeatureRequest] = None) -> _numpy.ma.MaskedArray:
       field_index = self.fields().lookupField(field_name)
       if field_index < 0:
          raise KeyError(f"Field '{field_name}' does not exist.")
@@ -702,7 +702,7 @@ try:
       numpy_array = _numpy.frombuffer(src_array.data(), dtype=numpy_dtype)
       return _numpy.ma.masked_equal(numpy_array, null_value)
 
-   QgsVectorLayer.field_to_numpy = _field_to_numpy
+   QgsVectorLayer.field_as_numpy = _field_as_numpy
 
    def _qgsgeometry_as_numpy(self) -> _typing.Union[_numpy.ndarray, _typing.List[_numpy.ndarray]]:
        wkb_type = self.wkbType()
@@ -777,10 +777,10 @@ except ModuleNotFoundError:
 
    QgsGeometry.as_numpy = _geometry_as_numpy
 
-   def _field_to_numpy(self, field_name: str, null_value, request: _typing.Optional[QgsFeatureRequest] = None):
-      raise QgsNotSupportedException('QgsVectorLayer.field_to_numpy is not available, numpy is not installed on the system')
+   def _field_as_numpy(self, field_name: str, null_value, request: _typing.Optional[QgsFeatureRequest] = None):
+      raise QgsNotSupportedException('QgsVectorLayer.field_as_numpy is not available, numpy is not installed on the system')
 
-   QgsVectorLayer.field_to_numpy = _field_to_numpy
+   QgsVectorLayer.field_as_numpy = _field_as_numpy
 
 try:
    import shapely as _shapely
@@ -901,7 +901,7 @@ original layer.
 .. versionadded:: 4.0
 """
 
-QgsVectorLayer.field_to_numpy.__doc__ = """
+QgsVectorLayer.field_as_numpy.__doc__ = """
 Returns the values from a field as a numpy masked array.
 
 :param field_name: field name to source values from

--- a/python/core/auto_additions/qgsvectorlayerutils.py
+++ b/python/core/auto_additions/qgsvectorlayerutils.py
@@ -20,6 +20,7 @@ try:
     QgsVectorLayerUtils.getFeatureDisplayString = staticmethod(QgsVectorLayerUtils.getFeatureDisplayString)
     QgsVectorLayerUtils.impactsCascadeFeatures = staticmethod(QgsVectorLayerUtils.impactsCascadeFeatures)
     QgsVectorLayerUtils.guessFriendlyIdentifierField = staticmethod(QgsVectorLayerUtils.guessFriendlyIdentifierField)
+    QgsVectorLayerUtils.fieldToDataArray = staticmethod(QgsVectorLayerUtils.fieldToDataArray)
     QgsVectorLayerUtils.__group__ = ['vector']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -422,6 +422,67 @@ first available.
 .. versionadded:: 3.18
 %End
 
+
+
+    static QByteArray fieldToDataArray( const QgsFields &fields, const QString &fieldName, QgsFeatureIterator &it, const QVariant &nullValue );
+%Docstring
+Converts field values from an iterator to an array of data.
+
+:param fields: layer fields
+:param fieldName: field name to source values from
+:param it: feature iterator for features to include
+:param nullValue: value to use when original field value is a null. Must
+                  be of the same data type as the source field.
+
+.. warning::
+
+   Only numeric field types are supported.
+
+:raises KeyError: if the field name is not found
+
+:raises TypeError: if the field is of a non-supported type
+
+.. versionadded:: 4.0
+%End
+%MethodCode
+
+    const int fieldIndex = a0->lookupField( *a1 );
+    if ( fieldIndex == -1 )
+    {
+      PyErr_SetString( PyExc_KeyError, QStringLiteral( "Field %1 does not exist." ).arg( *a1 ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    else
+    {
+      const QgsField field = a0->at( fieldIndex );
+      switch ( field.type() )
+      {
+        case QMetaType::Type::Int:
+        case QMetaType::Type::UInt:
+        case QMetaType::Type::Long:
+        case QMetaType::Type::LongLong:
+        case QMetaType::Type::ULong:
+        case QMetaType::Type::ULongLong:
+        case QMetaType::Type::Float:
+        case QMetaType::Type::Double:
+        case QMetaType::Type::Short:
+        case QMetaType::Type::UShort:
+        {
+          Py_BEGIN_ALLOW_THREADS
+          sipRes = new QByteArray( QgsVectorLayerUtils::fieldToDataArray( *a0, *a1, *a2, *a3 ) );
+          Py_END_ALLOW_THREADS
+          break;
+        }
+
+        default:
+        {
+          PyErr_SetString( PyExc_TypeError, QStringLiteral( "Field type (%1) cannot be converted to a data array." ).arg( QMetaType::typeName( field.type() ) ).toUtf8().constData() );
+          sipIsErr = 1;
+        }
+      }
+    }
+%End
+
 };
 
 

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -1334,7 +1334,7 @@ QString QgsVectorLayerUtils::guessFriendlyIdentifierField( const QgsFields &fiel
 }
 
 template <typename T, typename ConverterFunc>
-void populateDataArray( const QVector<QVariant> &values, const QVariant &nullValue, QByteArray &res, ConverterFunc converter )
+void populateFieldDataArray( const QVector<QVariant> &values, const QVariant &nullValue, QByteArray &res, ConverterFunc converter )
 {
   res.resize( values.size() * sizeof( T ) );
   T *data = reinterpret_cast<T *>( res.data() );
@@ -1370,61 +1370,61 @@ QByteArray QgsVectorLayerUtils::fieldToDataArray( const QgsFields &fields, const
   {
     case QMetaType::Int:
     {
-      populateDataArray<int>( values, nullValue, res, []( const QVariant & v ) { return v.toInt(); } );
+      populateFieldDataArray<int>( values, nullValue, res, []( const QVariant & v ) { return v.toInt(); } );
       break;
     }
 
     case QMetaType::UInt:
     {
-      populateDataArray<unsigned int>( values, nullValue, res, []( const QVariant & v ) { return v.toUInt(); } );
+      populateFieldDataArray<unsigned int>( values, nullValue, res, []( const QVariant & v ) { return v.toUInt(); } );
       break;
     }
 
     case QMetaType::LongLong:
     {
-      populateDataArray<long long>( values, nullValue, res, []( const QVariant & v ) { return v.toLongLong(); } );
+      populateFieldDataArray<long long>( values, nullValue, res, []( const QVariant & v ) { return v.toLongLong(); } );
       break;
     }
 
     case QMetaType::ULongLong:
     {
-      populateDataArray<unsigned long long>( values, nullValue, res, []( const QVariant & v ) { return v.toULongLong(); } );
+      populateFieldDataArray<unsigned long long>( values, nullValue, res, []( const QVariant & v ) { return v.toULongLong(); } );
       break;
     }
 
     case QMetaType::Double:
     {
-      populateDataArray<double>( values, nullValue, res, []( const QVariant & v ) { return v.toDouble(); } );
+      populateFieldDataArray<double>( values, nullValue, res, []( const QVariant & v ) { return v.toDouble(); } );
       break;
     }
 
     case QMetaType::Long:
     {
-      populateDataArray<long>( values, nullValue, res, []( const QVariant & v ) { return v.toLongLong(); } );
+      populateFieldDataArray<long>( values, nullValue, res, []( const QVariant & v ) { return v.toLongLong(); } );
       break;
     }
 
     case QMetaType::Short:
     {
-      populateDataArray<short>( values, nullValue, res, []( const QVariant & v ) { return v.toInt(); } );
+      populateFieldDataArray<short>( values, nullValue, res, []( const QVariant & v ) { return v.toInt(); } );
       break;
     }
 
     case QMetaType::ULong:
     {
-      populateDataArray<unsigned long>( values, nullValue, res, []( const QVariant & v ) { return v.toULongLong(); } );
+      populateFieldDataArray<unsigned long>( values, nullValue, res, []( const QVariant & v ) { return v.toULongLong(); } );
       break;
     }
 
     case QMetaType::UShort:
     {
-      populateDataArray<unsigned short>( values, nullValue, res, []( const QVariant & v ) { return v.toUInt(); } );
+      populateFieldDataArray<unsigned short>( values, nullValue, res, []( const QVariant & v ) { return v.toUInt(); } );
       break;
     }
 
     case QMetaType::Float:
     {
-      populateDataArray<float>( values, nullValue, res, []( const QVariant & v ) { return v.toFloat(); } );
+      populateFieldDataArray<float>( values, nullValue, res, []( const QVariant & v ) { return v.toFloat(); } );
       break;
     }
 

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -452,6 +452,79 @@ class CORE_EXPORT QgsVectorLayerUtils
     static QString guessFriendlyIdentifierField( const QgsFields &fields );
 #endif
 
+
+#ifndef SIP_RUN
+    /**
+     * Converts field values from an iterator to an array of data.
+     *
+     * \param fields layer fields
+     * \param fieldName field name to source values from
+     * \param it feature iterator for features to include
+     * \param nullValue value to use when original field value is a null. Must be of the same data type as the source field.
+     *
+     * \warning Only numeric field types are supported.
+     *
+     * \since QGIS 4.0
+     */
+    static QByteArray fieldToDataArray( const QgsFields &fields, const QString &fieldName, QgsFeatureIterator &it, const QVariant &nullValue );
+#else
+
+    /**
+     * Converts field values from an iterator to an array of data.
+     *
+     * \param fields layer fields
+     * \param fieldName field name to source values from
+     * \param it feature iterator for features to include
+     * \param nullValue value to use when original field value is a null. Must be of the same data type as the source field.
+     *
+     * \warning Only numeric field types are supported.
+     *
+     * \throws KeyError if the field name is not found
+     * \throws TypeError if the field is of a non-supported type
+     *
+     * \since QGIS 4.0
+     */
+    static QByteArray fieldToDataArray( const QgsFields &fields, const QString &fieldName, QgsFeatureIterator &it, const QVariant &nullValue );
+    % MethodCode
+
+    const int fieldIndex = a0->lookupField( *a1 );
+    if ( fieldIndex == -1 )
+    {
+      PyErr_SetString( PyExc_KeyError, QStringLiteral( "Field %1 does not exist." ).arg( *a1 ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    else
+    {
+      const QgsField field = a0->at( fieldIndex );
+      switch ( field.type() )
+      {
+        case QMetaType::Type::Int:
+        case QMetaType::Type::UInt:
+        case QMetaType::Type::Long:
+        case QMetaType::Type::LongLong:
+        case QMetaType::Type::ULong:
+        case QMetaType::Type::ULongLong:
+        case QMetaType::Type::Float:
+        case QMetaType::Type::Double:
+        case QMetaType::Type::Short:
+        case QMetaType::Type::UShort:
+        {
+          Py_BEGIN_ALLOW_THREADS
+          sipRes = new QByteArray( QgsVectorLayerUtils::fieldToDataArray( *a0, *a1, *a2, *a3 ) );
+          Py_END_ALLOW_THREADS
+          break;
+        }
+
+        default:
+        {
+          PyErr_SetString( PyExc_TypeError, QStringLiteral( "Field type (%1) cannot be converted to a data array." ).arg( QMetaType::typeName( field.type() ) ).toUtf8().constData() );
+          sipIsErr = 1;
+        }
+      }
+    }
+    % End
+
+#endif
 };
 
 

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -92,6 +92,7 @@ from utilities import unitTestDataPath
 import geopandas as gpd
 import pandas as pd
 import shapely
+import numpy as np
 
 TEST_DATA_DIR = unitTestDataPath()
 
@@ -6134,6 +6135,63 @@ class TestQgsVectorLayerTransformContext(QgisTestCase):
         self.assertEqual(len(gdf), 1)
         self.assertEqual(list(gdf.columns), ["id", "name", "geometry"])
         self.assertTrue(gdf.iloc[0]["geometry"] is None)
+
+    def test_field_to_numpy(self):
+        layer = QgsVectorLayer(
+            "Point?field=fldtxt:string&field=fldint:integer&field=fldlong:int8&field=flddouble:double",
+            "addfeat",
+            "memory",
+        )
+        self.assertTrue(layer.isValid())
+
+        pr = layer.dataProvider()
+        attributes = [
+            ["my string", 30, 123123123123123, 15.6],
+            ["another string", 31, -456456456456456, 0.4],
+            [NULL, NULL, NULL, NULL],
+        ]
+        for a in attributes:
+            f = QgsFeature()
+            f.setAttributes(a)
+            self.assertTrue(pr.addFeatures([f]))
+
+        with self.assertRaises(KeyError):
+            array = layer.field_to_numpy("not_here", 0)
+        with self.assertRaises(TypeError):
+            array = layer.field_to_numpy("fldtxt", 0)
+
+        array = layer.field_to_numpy("fldint", -99)
+        self.assertTrue((array == np.array([30, 31, -99])).all())
+        self.assertEqual(array.dtype, np.int32)
+        array = layer.field_to_numpy("fldint", -999)
+        self.assertTrue((array == np.array([30, 31, -999])).all())
+        self.assertEqual(array.dtype, np.int32)
+
+        array = layer.field_to_numpy("fldlong", -99)
+        self.assertTrue(
+            (array == np.array([123123123123123, -456456456456456, -99])).all()
+        )
+        self.assertEqual(array.dtype, np.int64)
+        array = layer.field_to_numpy("fldlong", -999)
+        self.assertTrue(
+            (array == np.array([123123123123123, -456456456456456, -999])).all()
+        )
+        self.assertEqual(array.dtype, np.int64)
+
+        array = layer.field_to_numpy("flddouble", -99)
+        self.assertTrue((array == np.array([15.6, 0.4, -99])).all())
+        self.assertEqual(array.dtype, np.float64)
+
+        array = layer.field_to_numpy("flddouble", -999)
+        self.assertTrue((array == np.array([15.6, 0.4, -999])).all())
+        self.assertEqual(array.dtype, np.float64)
+
+        # with custom request
+        array = layer.field_to_numpy(
+            "flddouble", -999, QgsFeatureRequest().setFilterFid(0)
+        )
+        self.assertTrue((array == np.array([15.6])).all())
+        self.assertEqual(array.dtype, np.float64)
 
 
 # TODO:

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -6136,7 +6136,7 @@ class TestQgsVectorLayerTransformContext(QgisTestCase):
         self.assertEqual(list(gdf.columns), ["id", "name", "geometry"])
         self.assertTrue(gdf.iloc[0]["geometry"] is None)
 
-    def test_field_to_numpy(self):
+    def test_field_as_numpy(self):
         layer = QgsVectorLayer(
             "Point?field=fldtxt:string&field=fldint:integer&field=fldlong:int8&field=flddouble:double",
             "addfeat",
@@ -6156,38 +6156,38 @@ class TestQgsVectorLayerTransformContext(QgisTestCase):
             self.assertTrue(pr.addFeatures([f]))
 
         with self.assertRaises(KeyError):
-            array = layer.field_to_numpy("not_here", 0)
+            array = layer.field_as_numpy("not_here", 0)
         with self.assertRaises(TypeError):
-            array = layer.field_to_numpy("fldtxt", 0)
+            array = layer.field_as_numpy("fldtxt", 0)
 
-        array = layer.field_to_numpy("fldint", -99)
+        array = layer.field_as_numpy("fldint", -99)
         self.assertTrue((array == np.array([30, 31, -99])).all())
         self.assertEqual(array.dtype, np.int32)
-        array = layer.field_to_numpy("fldint", -999)
+        array = layer.field_as_numpy("fldint", -999)
         self.assertTrue((array == np.array([30, 31, -999])).all())
         self.assertEqual(array.dtype, np.int32)
 
-        array = layer.field_to_numpy("fldlong", -99)
+        array = layer.field_as_numpy("fldlong", -99)
         self.assertTrue(
             (array == np.array([123123123123123, -456456456456456, -99])).all()
         )
         self.assertEqual(array.dtype, np.int64)
-        array = layer.field_to_numpy("fldlong", -999)
+        array = layer.field_as_numpy("fldlong", -999)
         self.assertTrue(
             (array == np.array([123123123123123, -456456456456456, -999])).all()
         )
         self.assertEqual(array.dtype, np.int64)
 
-        array = layer.field_to_numpy("flddouble", -99)
+        array = layer.field_as_numpy("flddouble", -99)
         self.assertTrue((array == np.array([15.6, 0.4, -99])).all())
         self.assertEqual(array.dtype, np.float64)
 
-        array = layer.field_to_numpy("flddouble", -999)
+        array = layer.field_as_numpy("flddouble", -999)
         self.assertTrue((array == np.array([15.6, 0.4, -999])).all())
         self.assertEqual(array.dtype, np.float64)
 
         # with custom request
-        array = layer.field_to_numpy(
+        array = layer.field_as_numpy(
             "flddouble", -999, QgsFeatureRequest().setFilterFid(0)
         )
         self.assertTrue((array == np.array([15.6])).all())

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -1140,6 +1140,78 @@ class TestQgsVectorLayerUtils(QgisTestCase):
         fields.append(QgsField("gml_name", QVariant.String))
         self.assertEqual(QgsVectorLayerUtils.guessFriendlyIdentifierField(fields), "id")
 
+    def test_field_to_data_array(self):
+        layer = QgsVectorLayer(
+            "Point?field=fldtxt:string&field=fldint:integer&field=fldlong:int8&field=flddouble:double",
+            "addfeat",
+            "memory",
+        )
+        self.assertTrue(layer.isValid())
+
+        pr = layer.dataProvider()
+        attributes = [
+            ["my string", 30, 123123123123123, 15.6],
+            ["another string", 31, -456456456456456, 0.4],
+            [NULL, NULL, NULL, NULL],
+        ]
+        for a in attributes:
+            f = QgsFeature()
+            f.setAttributes(a)
+            self.assertTrue(pr.addFeatures([f]))
+
+        it = layer.getFeatures()
+        with self.assertRaises(KeyError):
+            array = QgsVectorLayerUtils.fieldToDataArray(
+                layer.fields(), "not_here", it, 0
+            )
+        with self.assertRaises(TypeError):
+            array = QgsVectorLayerUtils.fieldToDataArray(
+                layer.fields(), "fldtxt", it, 0
+            )
+
+        it = layer.getFeatures()
+        array = QgsVectorLayerUtils.fieldToDataArray(layer.fields(), "fldint", it, -99)
+        self.assertEqual(
+            array.data(), b"\x1e\x00\x00\x00\x1f\x00\x00\x00\x9d\xff\xff\xff"
+        )
+        it = layer.getFeatures()
+        array = QgsVectorLayerUtils.fieldToDataArray(layer.fields(), "fldint", it, -999)
+        self.assertEqual(
+            array.data(), b"\x1e\x00\x00\x00\x1f\x00\x00\x00\x19\xfc\xff\xff"
+        )
+
+        it = layer.getFeatures()
+        array = QgsVectorLayerUtils.fieldToDataArray(layer.fields(), "fldlong", it, -99)
+        self.assertEqual(
+            array.data(),
+            b"\xb3s\x04\xd6\xfao\x00\x00\xf8\xb6\x0e\xf3\xda`\xfe\xff\x9d\xff\xff\xff\xff\xff\xff\xff",
+        )
+        it = layer.getFeatures()
+        array = QgsVectorLayerUtils.fieldToDataArray(
+            layer.fields(), "fldlong", it, -999
+        )
+        self.assertEqual(
+            array.data(),
+            b"\xb3s\x04\xd6\xfao\x00\x00\xf8\xb6\x0e\xf3\xda`\xfe\xff\x19\xfc\xff\xff\xff\xff\xff\xff",
+        )
+
+        it = layer.getFeatures()
+        array = QgsVectorLayerUtils.fieldToDataArray(
+            layer.fields(), "flddouble", it, -99
+        )
+        self.assertEqual(
+            array.data(),
+            b"333333/@\x9a\x99\x99\x99\x99\x99\xd9?\x00\x00\x00\x00\x00\xc0X\xc0",
+        )
+        it = layer.getFeatures()
+        array = QgsVectorLayerUtils.fieldToDataArray(
+            layer.fields(), "flddouble", it, -999
+        )
+        self.assertEqual(
+            array.data(),
+            b"333333/@\x9a\x99\x99\x99\x99\x99\xd9?\x00\x00\x00\x00\x008\x8f\xc0",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
QgsVectorLayerUtils.fieldToDataArray:

Converts field values from an iterator to a binary array of data. The conversion is heavily optimised to provide fastest possible
conversion to binary data. Only numeric data types are supported, other types will raise a Python TypeError exception.

QgsVectorLayer.field_to_numpy:

Returns the values from a field as a numpy masked array. Heavily optimised to provide fantastic performance. Supports numeric fields only, other types raise a TypeError.

