### PR TITLE
Add Python package metadata to QGIS installer for better pip/Poetry integration

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -469,3 +469,6 @@ foreach(module ${PY_MODULES})
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${module}/auto_generated DESTINATION ${SIP_DEFAULT_SIP_DIR}/qgis/${module})
   endif()
 endforeach(module)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml.in ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml DESTINATION "${QGIS_PYTHON_INSTALL_DIR}/")

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -1,0 +1,12 @@
+[project]
+name = "qgis"
+version = "@COMPLETE_VERSION@"
+description = "QGIS Python bindings (PyQGIS)"
+authors = [{ name = "QGIS Development Team" }]
+license = { text = "GPL-2.0-or-later" }
+requires-python = ">=@MIN_PYTHON_VERSION@"
+dependencies = []
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Add `pyproject.toml` and package metadata to QGIS Python bindings to make `pyqgis` discoverable as a standard Python package.
Enables `pip install file://...` usage, improves IDE support, and simplifies dependency management in external Python projects.

This does NOT make qgis installable as a pip package (and a discussion about this is not intended in here!), but if qgis is installed with python bindings, this integrates well with the local python environment.