### PR TITLE
Fix zooming with right mouse button in 3D views

### DIFF
--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -205,13 +205,26 @@ given new pitch and heading angle.
 .. versionadded:: 3.42
 %End
 
-    void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint );
+ void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint ) /Deprecated="Since 3.44.4. Use version with oldDistanceFromCenterPoint argument instead."/;
 %Docstring
 Zooms camera by given zoom factor (>1 one means zoom in) while keeping
 the pivot point (given in world coordinates) at the same screen
 coordinates after the zoom.
 
 .. versionadded:: 3.42
+
+.. deprecated:: 3.44.4
+
+   Use version with oldDistanceFromCenterPoint argument instead.
+%End
+
+    void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double oldDistanceFromCenterPoint, double zoomFactor, const QVector3D &pivotPoint );
+%Docstring
+Zooms camera by given zoom factor (>1 one means zoom in) while keeping
+the pivot point (given in world coordinates) at the same screen
+coordinates after the zoom.
+
+.. versionadded:: 3.44.4
 %End
 
     bool keyboardEventFilter( QKeyEvent *event );

--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -205,13 +205,26 @@ given new pitch and heading angle.
 .. versionadded:: 3.42
 %End
 
-    void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint );
+ void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint ) /Deprecated="Since 3.44.4. Use version with oldDistanceFromCenterPoint argument instead."/;
 %Docstring
 Zooms camera by given zoom factor (>1 one means zoom in) while keeping
 the pivot point (given in world coordinates) at the same screen
 coordinates after the zoom.
 
 .. versionadded:: 3.42
+
+.. deprecated:: 3.44.4
+
+   Use version with oldDistanceFromCenterPoint argument instead.
+%End
+
+    void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double oldDistanceFromCenterPoint, double zoomFactor, const QVector3D &pivotPoint );
+%Docstring
+Zooms camera by given zoom factor (>1 one means zoom in) while keeping
+the pivot point (given in world coordinates) at the same screen
+coordinates after the zoom.
+
+.. versionadded:: 3.44.4
 %End
 
     bool keyboardEventFilter( QKeyEvent *event );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -648,7 +648,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     if ( win )
     {
       yOffset = win->mapToGlobal( QPoint( 0, 0 ) ).y();
-      screenHeight = win->screen()->size().height();
+      screenHeight = win->screen()->virtualSize().height();
     }
 
     // Applies smoothing

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -655,8 +655,8 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
       }
     }
 
-    float oldDist = ( mCameraBefore->position() - mDragPoint ).length();
-    float newDist = oldDist;
+    const double oldDist = ( QgsVector3D( mCameraBefore->position() ) - QgsVector3D( mDragPoint ) ).length();
+    double newDist = oldDist;
 
     int yOffset = 0;
     int screenHeight = mScene->engine()->size().height();
@@ -683,7 +683,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
       newDist = newDist + 2 * newDist * f;
     }
 
-    double zoomFactor = newDist / oldDist;
+    const double zoomFactor = newDist / oldDist;
     zoomCameraAroundPivot( mCameraBefore->position(), mCameraBefore->viewCenter().distanceToPoint( mCameraBefore->position() ), zoomFactor, mDragPoint );
   }
 

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -213,8 +213,17 @@ class _3D_EXPORT QgsCameraController : public QObject
      * while keeping the pivot point (given in world coordinates) at the
      * same screen coordinates after the zoom.
      * \since QGIS 3.42
+     * \deprecated QGIS 3.44.4. Use version with oldDistanceFromCenterPoint argument instead.
      */
-    void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint );
+    Q_DECL_DEPRECATED void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double zoomFactor, const QVector3D &pivotPoint ) SIP_DEPRECATED;
+
+    /**
+     * Zooms camera by given zoom factor (>1 one means zoom in)
+     * while keeping the pivot point (given in world coordinates) at the
+     * same screen coordinates after the zoom.
+     * \since QGIS 3.44.4
+     */
+    void zoomCameraAroundPivot( const QVector3D &oldCameraPosition, double oldDistanceFromCenterPoint, double zoomFactor, const QVector3D &pivotPoint );
 
     /**
      * If the event is relevant, handles the event and returns TRUE, otherwise FALSE.


### PR DESCRIPTION
## Description
This PR fixes two unreported issues in 3D views when zooming with the right mouse button.

1. If the 3D view is on a different screen than main QGIS window, and the two windows have different Y global coordinates (eg one screen is directly above the other) than zoom in (drag down) would not work.

2. When zooming out (drag up), the distance to center point would increase exponentially causing floating point precision instability, eventually braking camera controls.



<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
