### PR TITLE
Improve OAuth 2.0 verification finished page

### DIFF
--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -170,8 +170,8 @@ void QgsO2::setVerificationResponseContent()
   if ( verhtml.open( QIODevice::ReadOnly | QIODevice::Text ) )
   {
     setReplyContent( QString::fromUtf8( verhtml.readAll() )
-                       .replace( QLatin1String( "{{ H2_TITLE }}" ), tr( "QGIS OAuth2 verification has finished" ) )
-                       .replace( QLatin1String( "{{ H3_TITLE }}" ), tr( "If you have not been returned to QGIS, bring the application to the forefront." ) )
+                       .replace( QLatin1String( "{{ H2_TITLE }}" ), tr( "QGIS OAuth2 verification has finished." ) )
+                       .replace( QLatin1String( "{{ H3_TITLE }}" ), tr( "You can close this window and bring QGIS to the forefront." ) )
                        .toUtf8()
     );
   }

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -172,7 +172,6 @@ void QgsO2::setVerificationResponseContent()
     setReplyContent( QString::fromUtf8( verhtml.readAll() )
                        .replace( QLatin1String( "{{ H2_TITLE }}" ), tr( "QGIS OAuth2 verification has finished" ) )
                        .replace( QLatin1String( "{{ H3_TITLE }}" ), tr( "If you have not been returned to QGIS, bring the application to the forefront." ) )
-                       .replace( QLatin1String( "{{ CLOSE_WINDOW }}" ), tr( "Close window" ) )
                        .toUtf8()
     );
   }

--- a/src/auth/oauth2/core/qgso2.cpp
+++ b/src/auth/oauth2/core/qgso2.cpp
@@ -171,7 +171,7 @@ void QgsO2::setVerificationResponseContent()
   {
     setReplyContent( QString::fromUtf8( verhtml.readAll() )
                        .replace( QLatin1String( "{{ H2_TITLE }}" ), tr( "QGIS OAuth2 verification has finished." ) )
-                       .replace( QLatin1String( "{{ H3_TITLE }}" ), tr( "You can close this window and bring QGIS to the forefront." ) )
+                       .replace( QLatin1String( "{{ H3_TITLE }}" ), tr( "You can close this window and return to QGIS." ) )
                        .toUtf8()
     );
   }

--- a/src/auth/oauth2/resources/oauth2_verification_finished.html
+++ b/src/auth/oauth2/resources/oauth2_verification_finished.html
@@ -26,6 +26,5 @@
 
     <h3>{{ H3_TITLE }}</h3>
 
-    <p><a href="#" onclick="window.close()">{{ CLOSE_WINDOW }}</a></p>
   </body>
 </html>


### PR DESCRIPTION
## Description

Before this PR, the OAuth 2.0 verification finished page included a "Close window" button which was not working as expected because of the `Scripts may not close windows that were not opened by script.` error, see [here](https://developer.mozilla.org/fr/docs/Web/API/Window/close). Moreover, the page evokes a scenario ("If you have not been returned to QGIS [...]") which does not hold, as the QGIS window cannot be automatically brought back to the forefront.

<img width="1653" height="223" alt="image" src="https://github.com/user-attachments/assets/46b5ed12-c912-4d02-b7f9-7299f14d1ba7" />

This PR removes the concerned button and improves the verification finished message.

I take advantage of this PR, my first here, to congratulate all the contributors for making QGIS such a great software. Thank you!

_Funded by République et canton de Genève_