### PR TITLE
fix wrong BBOX parameter when requesting WCS layer with spatial filter enabled

### DIFF
--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -126,9 +126,10 @@ void QgsOWSSourceSelect::prepareExtent()
   if ( !canvas )
     return;
   QgsCoordinateReferenceSystem destinationCrs = canvas->mapSettings().destinationCrs();
-  mSpatialExtentBox->setCurrentExtent( destinationCrs.bounds(), destinationCrs );
+  mSpatialExtentBox->setCurrentExtent( canvas->extent(), destinationCrs );
   mSpatialExtentBox->setOutputExtentFromCurrent();
   mSpatialExtentBox->setMapCanvas( canvas );
+  mSpatialExtentBox->setChecked( false );
 }
 
 void QgsOWSSourceSelect::refresh()

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -163,8 +163,10 @@ QgsWcsProvider::QgsWcsProvider( const QString &uri, const ProviderOptions &optio
   int height;
   QString crs;
   QgsRectangle box; // box to use to calc extent
-  // Prefer native CRS
-  if ( !mCoverageSummary.nativeCrs.isEmpty() && !mCoverageSummary.nativeBoundingBox.isEmpty() && mCoverageSummary.supportedCrs.contains( mCoverageSummary.nativeCrs ) && mHasSize )
+  // Prefer native CRS, but only if spatial filter is not set. With spatial filter we should
+  // use actual requested extent to get data, otherwise getCache() will use wrong bbox and no
+  // data will be retrieved.
+  if ( !mCoverageSummary.nativeCrs.isEmpty() && !mCoverageSummary.nativeBoundingBox.isEmpty() && mCoverageSummary.supportedCrs.contains( mCoverageSummary.nativeCrs ) && mHasSize && mBBOX.isEmpty() )
   {
     box = mCoverageSummary.nativeBoundingBox;
     width = mWidth;


### PR DESCRIPTION
## Description

If spatial filter is active in the Add WCS Layer dialog, take it into account when retrieving information about raster data type and bands count. If spatial filter is ignored at this step, extent used to get information may be invalid as it won't overlap with the spatial filter.

Also disable spatial filter by default and use canvas extent instead of canvas CRS bounds as a default spatial filter.

Fixes #50432 and #62528.