### PR TITLE
[fix] Avoid easy crash in the Styling panel (DD Property Assistant)

### DIFF
--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -715,10 +715,6 @@ void QgsPropertyOverrideButton::showAssistant()
       this->emit changed();
     } );
 
-    // if the source layer is removed, we need to dismiss the assistant immediately
-    if ( mVectorLayer )
-      connect( mVectorLayer, &QObject::destroyed, widget, &QgsPanelWidget::acceptPanel );
-
     connect( widget, &QgsPropertyAssistantWidget::panelAccepted, this, [this] { updateGui(); } );
 
     panel->openPanel( widget );


### PR DESCRIPTION
This PR avoids a crash in the Styling panel when closing a project if the DD Property Assistant is open.

**How to reproduce the crash**
Close a project with the DD Property Assistant open in the Styling panel.

**Solution**
This PR removes a connection that will call `QgsPanelWidget::acceptPanel()` after the panel has already been accepted, leading to fail a `Q_ASSERT` inside `QStack::pop()` https://github.com/qgis/QGIS/blob/beed0ad57e455208976b00d1cd886e1d3edcd90f/src/gui/qgspanelwidgetstack.cpp#L166-L168 

Nowadays, we call `panelAccepted()` twice when removing a layer. The other call is set here (the slot calls `acceptAllPanels()`):  https://github.com/qgis/QGIS/blob/beed0ad57e455208976b00d1cd886e1d3edcd90f/src/app/qgslayerstylingwidget.cpp#L84-L86