### PR TITLE
Fix fragile pgraster test segfaults

### DIFF
--- a/tests/src/python/test_provider_postgresraster.py
+++ b/tests/src/python/test_provider_postgresraster.py
@@ -591,10 +591,7 @@ class TestPyQgsPostgresRasterProvider(QgisTestCase):
             decoded = md.decodeUri(uri)
             self.assertEqual(decoded, md.decodeUri(md.encodeUri(decoded)))
 
-        uri = (
-            self.dbconn
-            + ' sslmode=disable key=\'rid\' srid=3035  table="public"."raster_tiled_3035" sql='
-        )
+        uri = 'service=qgis_test sslmode=disable key=\'rid\' srid=3035  table="public"."raster_tiled_3035" sql='
         md = QgsProviderRegistry.instance().providerMetadata("postgresraster")
         decoded = md.decodeUri(uri)
         self.assertEqual(
@@ -609,10 +606,30 @@ class TestPyQgsPostgresRasterProvider(QgisTestCase):
             },
         )
 
+        # with database details
+        decoded = md.decodeUri(
+            "dbname='qgis_db' host=127.0.0.1 port=5432 user='qgis_user' password='qgis_pw' sslmode=disable key='rid' srid=3035  table=\"public\".\"raster_tiled_3035\" sql="
+        )
+        self.assertEqual(
+            decoded,
+            {
+                "dbname": "qgis_db",
+                "host": "127.0.0.1",
+                "key": "rid",
+                "password": "qgis_pw",
+                "port": "5432",
+                "schema": "public",
+                "srid": "3035",
+                "sslmode": 1,
+                "table": "raster_tiled_3035",
+                "username": "qgis_user",
+            },
+        )
+
         _round_trip(uri)
 
         uri = (
-            self.dbconn
+            "service=qgis_test"
             + " sslmode=prefer key='rid' srid=3035 temporalFieldIndex=2 temporalDefaultTime=2020-03-02 "
             + "authcfg=afebeff username='my username' password='my secret password=' "
             + 'enableTime=true table="public"."raster_tiled_3035" (rast) sql="a_field" != 1223223'

--- a/tests/src/python/test_provider_postgresraster.py
+++ b/tests/src/python/test_provider_postgresraster.py
@@ -22,7 +22,7 @@ import os
 import time
 import unittest
 
-from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication, QSize
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsApplication,
@@ -40,7 +40,6 @@ from qgis.core import QgsProject
 from qgis.gui import QgsMapCanvas, QgsLayerTreeMapCanvasBridge
 from qgis.testing import start_app, QgisTestCase
 
-from qgis.testing.mocked import get_iface
 from utilities import compareWkt, unitTestDataPath
 
 QGISAPP = start_app()
@@ -75,7 +74,6 @@ class TestPyQgsPostgresRasterProvider(QgisTestCase):
     def setUpClass(cls):
         """Run before all tests"""
         super().setUpClass()
-        cls.iface = get_iface()
         cls.dbconn = "service=qgis_test"
         if "QGIS_PGTEST_DB" in os.environ:
             cls.dbconn = os.environ["QGIS_PGTEST_DB"]
@@ -887,7 +885,8 @@ class TestPyQgsPostgresRasterProvider(QgisTestCase):
     def testSparseRaster(self):
         """Test issue GH #55753"""
         project: QgsProject = QgsProject.instance()
-        canvas: QgsMapCanvas = self.iface.mapCanvas()
+        canvas: QgsMapCanvas = QgsMapCanvas()
+        canvas.resize(QSize(400, 400))
         project.setCrs(QgsCoordinateReferenceSystem("EPSG:3035"))
         canvas.setExtent(QgsRectangle(4080050, 2430625, 4080200, 2430750))
 


### PR DESCRIPTION
Avoids segfaults on test exit because of missing application cleanup. We don't actually need to use a whole mocked interface here, just directly using a QgsMapCanvas which gets deleted at the end of the test is sufficient.
