### PR TITLE
Fix spatial index leaks in pgraster provider

### DIFF
--- a/src/providers/postgres/raster/qgspostgresrastershareddata.cpp
+++ b/src/providers/postgres/raster/qgspostgresrastershareddata.cpp
@@ -27,13 +27,7 @@
 #include "qgspolygon.h"
 #include "qgslogger.h"
 
-QgsPostgresRasterSharedData::~QgsPostgresRasterSharedData()
-{
-  for ( const auto &idx : mSpatialIndexes )
-  {
-    delete idx.second;
-  }
-}
+QgsPostgresRasterSharedData::~QgsPostgresRasterSharedData() = default;
 
 QgsPostgresRasterSharedData::TilesResponse QgsPostgresRasterSharedData::tiles( const QgsPostgresRasterSharedData::TilesRequest &request )
 {
@@ -47,7 +41,7 @@ QgsPostgresRasterSharedData::TilesResponse QgsPostgresRasterSharedData::tiles( c
   if ( mSpatialIndexes.find( cacheKey ) == mSpatialIndexes.end() )
   {
     // Create the index
-    mSpatialIndexes.emplace( cacheKey, new QgsGenericSpatialIndex<Tile>() );
+    mSpatialIndexes.emplace( cacheKey, std::make_unique< QgsGenericSpatialIndex<Tile> >() );
     mTiles.emplace( cacheKey, std::map<TileIdType, std::unique_ptr<Tile>>() );
     mLoadedIndexBounds[cacheKey] = QgsGeometry();
   }

--- a/src/providers/postgres/raster/qgspostgresrastershareddata.h
+++ b/src/providers/postgres/raster/qgspostgresrastershareddata.h
@@ -142,9 +142,8 @@ class QgsPostgresRasterSharedData
     /**
     * Tile caches, index is a key generated from the overview factor (1 is the full resolution data)
     * and the where clause
-    * \note cannot be a smart pointer because spatial index cannot be copied
     */
-    std::map<QString, QgsGenericSpatialIndex<Tile> *> mSpatialIndexes;
+    std::map<QString, std::unique_ptr< QgsGenericSpatialIndex<Tile> > > mSpatialIndexes;
 
     //! Memory manager for owned tiles (and for tileId access)
     std::map<QString, std::map<TileIdType, std::unique_ptr<Tile>>> mTiles;


### PR DESCRIPTION
The comment was outdated. Without smart pointers we were leaking data whenever invalidateCache was called, as that method cleared the map without first deleting the heap assigned values.
