### PR TITLE
Fix leak in embedded projects

### DIFF
--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -787,7 +787,7 @@ Returns an empty string if the matching layer is not embedded.
 %End
 
 
-    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers,  Qgis::ProjectReadFlags flags = Qgis::ProjectReadFlags() );
+    std::unique_ptr< QgsLayerTreeGroup > createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers,  Qgis::ProjectReadFlags flags = Qgis::ProjectReadFlags() );
 %Docstring
 Create layer group instance defined in an arbitrary project file.
 

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -787,7 +787,7 @@ Returns an empty string if the matching layer is not embedded.
 %End
 
 
-    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers,  Qgis::ProjectReadFlags flags = Qgis::ProjectReadFlags() );
+    std::unique_ptr< QgsLayerTreeGroup > createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers,  Qgis::ProjectReadFlags flags = Qgis::ProjectReadFlags() );
 %Docstring
 Create layer group instance defined in an arbitrary project file.
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13080,10 +13080,10 @@ void QgisApp::addEmbeddedItems( const QString &projectFile, const QStringList &g
   QStringList::const_iterator groupIt = groups.constBegin();
   for ( ; groupIt != groups.constEnd(); ++groupIt )
   {
-    QgsLayerTreeGroup *newGroup = QgsProject::instance()->createEmbeddedGroup( *groupIt, projectFile, QStringList() );
+    std::unique_ptr< QgsLayerTreeGroup > newGroup = QgsProject::instance()->createEmbeddedGroup( *groupIt, projectFile, QStringList() );
 
     if ( newGroup )
-      QgsProject::instance()->layerTreeRoot()->addChildNode( newGroup );
+      QgsProject::instance()->layerTreeRoot()->addChildNode( newGroup.release() );
   }
 
   //layer ids

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -757,7 +757,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * The optional \a flags argument can be used to control layer reading behavior.
      *
      */
-    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers,  Qgis::ProjectReadFlags flags = Qgis::ProjectReadFlags() );
+    std::unique_ptr< QgsLayerTreeGroup > createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers,  Qgis::ProjectReadFlags flags = Qgis::ProjectReadFlags() );
 
     //! Convenience function to set topological editing
     void setTopologicalEditing( bool enabled );

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -713,7 +713,7 @@ void TestQgsLayerTree::testEmbeddedGroup()
   //
 
   QgsProject projectMaster;
-  QgsLayerTreeGroup *embeddedGroup = projectMaster.createEmbeddedGroup( grp->name(), projectFilename, QStringList() );
+  std::unique_ptr< QgsLayerTreeGroup > embeddedGroup = projectMaster.createEmbeddedGroup( grp->name(), projectFilename, QStringList() );
   QVERIFY( embeddedGroup );
   QCOMPARE( embeddedGroup->children().size(), 3 );
 
@@ -721,7 +721,7 @@ void TestQgsLayerTree::testEmbeddedGroup()
   {
     QVERIFY( QgsLayerTree::toLayer( child )->layer() );
   }
-  projectMaster.layerTreeRoot()->addChildNode( embeddedGroup );
+  projectMaster.layerTreeRoot()->addChildNode( embeddedGroup.release() );
 
   const QString projectMasterFilename = dirPath + QStringLiteral( "/projectMaster.qgs" );
   projectMaster.write( projectMasterFilename );

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -563,7 +563,7 @@ void TestQgsProject::testEmbeddedLayerGroupFromQgz()
 
   QgsProject p1;
   p1.createEmbeddedLayer( points->id(), p0.fileName(), brokenNodes );
-  p1.createEmbeddedGroup( "group1", p0.fileName(), QStringList() );
+  std::unique_ptr< QgsLayerTreeGroup > group = p1.createEmbeddedGroup( "group1", p0.fileName(), QStringList() );
 
   QCOMPARE( p1.layerIsEmbedded( points->id() ), path );
   QCOMPARE( p1.layerIsEmbedded( polys->id() ), path );


### PR DESCRIPTION
Use unique_ptr to avoid leak when creating embedded project groups