### PR TITLE
[PyQt5_to_PyQt6] Fix all imports coming from Qt module

### DIFF
--- a/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
+++ b/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
@@ -449,8 +449,9 @@ def fix_file(filename: str, qgis3_compat: bool, dry_run: bool = False) -> int:
                 has_unfixed_errors = True
 
         if _node.module == "qgis.PyQt.Qt":
-            extra_imports["qgis.PyQt.QtCore"].update({"Qt"})
-            removed_imports["qgis.PyQt.Qt"].update({"Qt"})
+            for node_name in _node.names:
+                extra_imports["qgis.PyQt.QtCore"].update({node_name.name})
+                removed_imports["qgis.PyQt.Qt"].update({node_name.name})
 
     tree = ast.parse(contents, filename=filename)
     for parent in ast.walk(tree):
@@ -688,7 +689,7 @@ def fix_file(filename: str, qgis3_compat: bool, dry_run: bool = False) -> int:
 
                 imports_to_add = extra_imports.get(module, set()) - current_imports
                 if imports_to_add:
-                    additional_import_string = ", ".join(imports_to_add)
+                    additional_import_string = ", ".join(sorted(imports_to_add))
                     if tokens[token_index - 1].src == ")":
                         token_index -= 1
                         while tokens[token_index].src.strip() in ("", ",", ")"):

--- a/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
+++ b/scripts/pyqt5_to_pyqt6/pyqt5_to_pyqt6.py
@@ -226,6 +226,7 @@ def fix_file(filename: str, qgis3_compat: bool, dry_run: bool = False) -> int:
     extra_imports = defaultdict(set)
     removed_imports = defaultdict(set)
     import_offsets = {}
+    has_unfixed_errors = False  # True if there is at least one error impossible to fix
 
     object_types = {}
 
@@ -424,6 +425,9 @@ def fix_file(filename: str, qgis3_compat: bool, dry_run: bool = False) -> int:
                 )
 
     def visit_import(_node: ast.ImportFrom, _parent):
+
+        nonlocal has_unfixed_errors
+
         import_offsets[Offset(node.lineno, node.col_offset)] = (
             node.module,
             {name.name for name in node.names},
@@ -434,12 +438,16 @@ def fix_file(filename: str, qgis3_compat: bool, dry_run: bool = False) -> int:
         for name in node.names:
             if name.name in import_warnings:
                 logging.warning(f"{filename}: {import_warnings[name.name]}")
+                has_unfixed_errors = True
+
             if name.name == "resources_rc":
                 logging.warning(
                     f"{filename}:{_node.lineno}:{_node.col_offset} - WARNING: support for compiled resources "
                     "is removed in Qt6. Directly load icon resources by file path and load UI fields using "
                     "uic.loadUiType by file path instead.\n"
                 )
+                has_unfixed_errors = True
+
         if _node.module == "qgis.PyQt.Qt":
             extra_imports["qgis.PyQt.QtCore"].update({"Qt"})
             removed_imports["qgis.PyQt.Qt"].update({"Qt"})
@@ -541,6 +549,7 @@ def fix_file(filename: str, qgis3_compat: bool, dry_run: bool = False) -> int:
             logging.warning(
                 f"{filename}: Missing import, manually add {import_statement}"
             )
+            has_unfixed_errors = True
 
     if dry_run:
         for key, value in fix_qt_enums.items():
@@ -598,7 +607,7 @@ def fix_file(filename: str, qgis3_compat: bool, dry_run: bool = False) -> int:
             token_renames,
         ]
     ):
-        return 0
+        return has_unfixed_errors
 
     tokens = src_to_tokens(contents)
     for i, token in reversed_enumerate(tokens):
@@ -772,7 +781,7 @@ def fix_file(filename: str, qgis3_compat: bool, dry_run: bool = False) -> int:
     with open(filename, "w") as f:
         f.write(new_contents)
 
-    return new_contents != contents
+    return has_unfixed_errors or new_contents != contents
 
 
 def get_class_enums(item):

--- a/scripts/pyqt5_to_pyqt6/tests/expected/qurl_import.py
+++ b/scripts/pyqt5_to_pyqt6/tests/expected/qurl_import.py
@@ -1,0 +1,1 @@
+from qgis.PyQt.QtCore import QObject, Qt, QUrl

--- a/scripts/pyqt5_to_pyqt6/tests/expected/regexp_import.py
+++ b/scripts/pyqt5_to_pyqt6/tests/expected/regexp_import.py
@@ -1,0 +1,1 @@
+from qgis.PyQt.QtCore import QRegExp

--- a/scripts/pyqt5_to_pyqt6/tests/expected/regexp_import_and_qvariant_null.py
+++ b/scripts/pyqt5_to_pyqt6/tests/expected/regexp_import_and_qvariant_null.py
@@ -1,0 +1,3 @@
+from qgis.PyQt.QtCore import QRegExp
+
+var = NULL

--- a/scripts/pyqt5_to_pyqt6/tests/launchTests.sh
+++ b/scripts/pyqt5_to_pyqt6/tests/launchTests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+
+
+TEST_ROOT_DIR=/tmp/pyqt5_to_pyqt6_tests
+rm -Rf $TEST_ROOT_DIR && mkdir $TEST_ROOT_DIR
+
+SCRIPT_DIR=$(dirname "$0")
+
+RES=0
+for testfile in $(ls $SCRIPT_DIR/src/*.py);
+do
+  TESTNAME=$(basename $testfile .py)
+  TESTDIR=$TEST_ROOT_DIR/$TESTNAME
+  mkdir -p $TESTDIR
+  cp $testfile $TESTDIR
+
+  if python $SCRIPT_DIR/../pyqt5_to_pyqt6.py $TESTDIR &> $TESTDIR/output.log; then
+    echo "Test '$TESTNAME' failed: expect error code different from 0"
+    RES=1
+  elif ! diff $SCRIPT_DIR/expected/$(basename $testfile) $TESTDIR/$(basename $testfile) &> $TESTDIR/diff.log; then
+    echo "Test '$TESTNAME' failed: There are differences between actual and expected file"
+    cat $TESTDIR/diff.log
+    RES=1
+  fi
+done
+
+exit $RES

--- a/scripts/pyqt5_to_pyqt6/tests/launch_tests.sh
+++ b/scripts/pyqt5_to_pyqt6/tests/launch_tests.sh
@@ -24,4 +24,6 @@ do
   fi
 done
 
+rm -Rf $TEST_ROOT_DIR
+
 exit $RES

--- a/scripts/pyqt5_to_pyqt6/tests/src/qurl_import.py
+++ b/scripts/pyqt5_to_pyqt6/tests/src/qurl_import.py
@@ -1,0 +1,2 @@
+from qgis.PyQt.Qt import Qt, QUrl
+from qgis.PyQt.QtCore import QObject

--- a/scripts/pyqt5_to_pyqt6/tests/src/regexp_import.py
+++ b/scripts/pyqt5_to_pyqt6/tests/src/regexp_import.py
@@ -1,0 +1,1 @@
+from qgis.PyQt.QtCore import QRegExp

--- a/scripts/pyqt5_to_pyqt6/tests/src/regexp_import_and_qvariant_null.py
+++ b/scripts/pyqt5_to_pyqt6/tests/src/regexp_import_and_qvariant_null.py
@@ -1,0 +1,3 @@
+from qgis.PyQt.QtCore import QRegExp
+
+var = QVariant()


### PR DESCRIPTION
Before Qt6, all core module could have been imported from qgis.PyQt like QObject or QUrl, not only Qt

Rely on #63526