### PR TITLE
Fix PDF theme export

### DIFF
--- a/src/core/qgsabstractgeopdfexporter.cpp
+++ b/src/core/qgsabstractgeopdfexporter.cpp
@@ -513,7 +513,7 @@ QString QgsAbstractGeospatialPdfExporter::createCompositionXml( const QList<Comp
 
     if ( !component.mapLayerId.isEmpty() )
     {
-      createdLayerIds.insert( component.mapLayerId );
+      createdLayerIds.insert( id );
     }
   }
 

--- a/tests/src/core/testqgsgeopdfexport.cpp
+++ b/tests/src/core/testqgsgeopdfexport.cpp
@@ -1042,6 +1042,11 @@ void TestQgsGeospatialPdfExport::testGroupsWithSameLayer()
   detail.group = u"group_1_and_2"_s;
   renderedLayers << detail;
 
+  detail.mapLayerId = u"raster_layer"_s;
+  detail.name = u"raster_layer_global"_s;
+  detail.group = u""_s;
+  renderedLayers << detail;
+
   QgsAbstractGeospatialPdfExporter::ExportDetails details;
 
   QString composition = geospatialPdfExporter.createCompositionXml( renderedLayers, details );
@@ -1050,7 +1055,7 @@ void TestQgsGeospatialPdfExport::testGroupsWithSameLayer()
   doc.setContent( composition );
 
   QDomNodeList layerTreeList = doc.elementsByTagName( u"LayerTree"_s ).at( 0 ).toElement().childNodes();
-  QCOMPARE( layerTreeList.count(), 3 );
+  QCOMPARE( layerTreeList.count(), 4 );
 
   QCOMPARE( layerTreeList.at( 0 ).toElement().attribute( u"name"_s ), u"group1"_s );
   QCOMPARE( layerTreeList.at( 0 ).toElement().childNodes().count(), 2 );
@@ -1073,22 +1078,32 @@ void TestQgsGeospatialPdfExport::testGroupsWithSameLayer()
   QCOMPARE( layerTreeList.at( 2 ).toElement().childNodes().at( 2 ).toElement().attribute( u"id"_s ), u"group_1_and_2_raster_layer"_s );
   QCOMPARE( layerTreeList.at( 2 ).toElement().childNodes().at( 2 ).toElement().attribute( u"name"_s ), u"raster_layer_g1and2"_s );
 
+  QCOMPARE( layerTreeList.at( 3 ).toElement().attribute( u"name"_s ), u"raster_layer_global"_s );
+  QCOMPARE( layerTreeList.at( 3 ).toElement().childNodes().count(), 0 );
+
   QCOMPARE( doc.elementsByTagName( u"Content"_s ).count(), 1 );
   QDomNodeList ifLayerOnList = doc.elementsByTagName( u"Content"_s ).at( 0 ).toElement().childNodes();
-  QCOMPARE( ifLayerOnList.count(), 6 );
+  QCOMPARE( ifLayerOnList.count(), 7 );
 
-  QStringList layerIds;
+  QStringList groupedLayerIds;
+  QStringList rootLayerIds;
   for ( int i = 0; i < ifLayerOnList.count(); i++ )
   {
     QCOMPARE( ifLayerOnList.at( i ).toElement().childNodes().count(), 1 );
-    QCOMPARE( ifLayerOnList.at( i ).toElement().childNodes().at( 0 ).toElement().tagName(), u"IfLayerOn"_s );
-    layerIds << ifLayerOnList.at( i ).toElement().childNodes().at( 0 ).toElement().attribute( u"layerId"_s );
+    const QDomElement child = ifLayerOnList.at( i ).toElement().childNodes().at( 0 ).toElement();
+    const QString tagName = child.tagName();
+    QVERIFY( ( QStringList() << u"IfLayerOn"_s << u"PDF"_s ).contains( tagName ) );
+    if ( tagName == "IfLayerOn"_L1 )
+      groupedLayerIds << child.attribute( u"layerId"_s );
+    else
+      rootLayerIds << ifLayerOnList.at( i ).toElement().attribute( u"layerId"_s );
   }
 
-  std::sort( layerIds.begin(), layerIds.end() );
+  std::sort( groupedLayerIds.begin(), groupedLayerIds.end() );
 
-  const QStringList ref { "group1_layer1", "group1_raster_layer", "group2_layer2", "group_1_and_2_layer1", "group_1_and_2_layer2", "group_1_and_2_raster_layer" };
-  QCOMPARE( layerIds, ref );
+  const QStringList ref { u"group1_layer1"_s, u"group1_raster_layer"_s, u"group2_layer2"_s, u"group_1_and_2_layer1"_s, u"group_1_and_2_layer2"_s, u"group_1_and_2_raster_layer"_s };
+  QCOMPARE( groupedLayerIds, ref );
+  QCOMPARE( rootLayerIds, QStringList() << u"raster_layer"_s );
 }
 
 QGSTEST_MAIN( TestQgsGeospatialPdfExport )


### PR DESCRIPTION
Include group name in layerId key when mapping from layerId to tree node. 

If not, same layer would be mapped to only one and only group if this layer is included in different groups (with themes for instance).

Fixes https://github.com/qgis/QGIS/issues/62014

