### PR TITLE
[3d] qgs3daxis: Fix cube picking in qt6 when clicking on a label

### DIFF
--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -197,7 +197,7 @@ bool Qgs3DAxis::handleEvent( QEvent *event )
 
 void Qgs3DAxis::onTouchedByRay( const Qt3DRender::QAbstractRayCaster::Hits &hits )
 {
-  int mHitsFound = -1;
+  int hitFoundIdx = -1;
   if ( !hits.empty() )
   {
     if ( 2 <= QgsLogger::debugLevel() )
@@ -215,7 +215,7 @@ void Qgs3DAxis::onTouchedByRay( const Qt3DRender::QAbstractRayCaster::Hits &hits
       QgsDebugMsgLevel( os.str().c_str(), 2 );
     }
 
-    for ( int i = 0; i < hits.length() && mHitsFound == -1; ++i )
+    for ( int i = 0; i < hits.length() && hitFoundIdx == -1; ++i )
     {
       Qt3DCore::QEntity *hitEntity = hits.at( i ).entity();
       // In Qt6, a Qt3DExtras::Text2DEntity contains a private entity: Qt3DExtras::DistanceFieldTextRenderer
@@ -226,14 +226,14 @@ void Qgs3DAxis::onTouchedByRay( const Qt3DRender::QAbstractRayCaster::Hits &hits
       }
       if ( hits.at( i ).distance() < 500.0f && hitEntity && ( hitEntity == mCubeRoot || hitEntity == mAxisRoot || hitEntity->parent() == mCubeRoot || hitEntity->parent() == mAxisRoot ) )
       {
-        mHitsFound = i;
+        hitFoundIdx = i;
       }
     }
   }
 
   if ( mLastClickedButton == Qt::NoButton ) // hover
   {
-    if ( mHitsFound != -1 )
+    if ( hitFoundIdx != -1 )
     {
       if ( mCanvas->cursor() != Qt::ArrowCursor )
       {
@@ -250,7 +250,7 @@ void Qgs3DAxis::onTouchedByRay( const Qt3DRender::QAbstractRayCaster::Hits &hits
       }
     }
   }
-  else if ( mLastClickedButton == Qt::MouseButton::RightButton && mHitsFound != -1 ) // show menu
+  else if ( mLastClickedButton == Qt::MouseButton::RightButton && hitFoundIdx != -1 ) // show menu
   {
     displayMenuAt( mLastClickedPos );
   }
@@ -258,16 +258,16 @@ void Qgs3DAxis::onTouchedByRay( const Qt3DRender::QAbstractRayCaster::Hits &hits
   {
     hideMenu();
 
-    if ( mHitsFound != -1 )
+    if ( hitFoundIdx != -1 )
     {
-      Qt3DCore::QEntity *hitEntity = hits.at( mHitsFound ).entity();
+      Qt3DCore::QEntity *hitEntity = hits.at( hitFoundIdx ).entity();
       if ( hitEntity && qobject_cast<Qt3DExtras::QText2DEntity *>( hitEntity->parentEntity() ) )
       {
         hitEntity = hitEntity->parentEntity();
       }
       if ( hitEntity == mCubeRoot || hitEntity->parent() == mCubeRoot )
       {
-        switch ( hits.at( mHitsFound ).primitiveIndex() / 2 )
+        switch ( hits.at( hitFoundIdx ).primitiveIndex() / 2 )
         {
           case 0: // "East face";
             QgsDebugMsgLevel( "Qgs3DAxis: East face clicked", 2 );

--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -217,7 +217,14 @@ void Qgs3DAxis::onTouchedByRay( const Qt3DRender::QAbstractRayCaster::Hits &hits
 
     for ( int i = 0; i < hits.length() && mHitsFound == -1; ++i )
     {
-      if ( hits.at( i ).distance() < 500.0f && hits.at( i ).entity() && ( hits.at( i ).entity() == mCubeRoot || hits.at( i ).entity() == mAxisRoot || hits.at( i ).entity()->parent() == mCubeRoot || hits.at( i ).entity()->parent() == mAxisRoot ) )
+      Qt3DCore::QEntity *hitEntity = hits.at( i ).entity();
+      // In Qt6, a Qt3DExtras::Text2DEntity contains a private entity: Qt3DExtras::DistanceFieldTextRenderer
+      // The Text2DEntity needs to be retrieved to handle proper picking
+      if ( hitEntity && qobject_cast<Qt3DExtras::QText2DEntity *>( hitEntity->parentEntity() ) )
+      {
+        hitEntity = hitEntity->parentEntity();
+      }
+      if ( hits.at( i ).distance() < 500.0f && hitEntity && ( hitEntity == mCubeRoot || hitEntity == mAxisRoot || hitEntity->parent() == mCubeRoot || hitEntity->parent() == mAxisRoot ) )
       {
         mHitsFound = i;
       }
@@ -253,7 +260,12 @@ void Qgs3DAxis::onTouchedByRay( const Qt3DRender::QAbstractRayCaster::Hits &hits
 
     if ( mHitsFound != -1 )
     {
-      if ( hits.at( mHitsFound ).entity() == mCubeRoot || hits.at( mHitsFound ).entity()->parent() == mCubeRoot )
+      Qt3DCore::QEntity *hitEntity = hits.at( mHitsFound ).entity();
+      if ( hitEntity && qobject_cast<Qt3DExtras::QText2DEntity *>( hitEntity->parentEntity() ) )
+      {
+        hitEntity = hitEntity->parentEntity();
+      }
+      if ( hitEntity == mCubeRoot || hitEntity->parent() == mCubeRoot )
       {
         switch ( hits.at( mHitsFound ).primitiveIndex() / 2 )
         {


### PR DESCRIPTION
## Description

From the main commit message:

The cube has labels to represent the different
faces. `Qt3DExtras::Text2DEntity` objects are used for this
purpose. In Qt6, `Qt3DExtras::Text2DEntity` contains a private entity:
`Qt3DExtras::DistanceFieldTextRenderer`. This entity is picked by the
ray caster. However, the picking logic assumes that the clicked object
or the clicked object's parent is `mCubeRoot`. When clicking on a
label, the `Qt3DExtras::DistanceFieldTextRenderer` is retrieved. Its
parent is a `Qt3DExtras::Text2DEntity` not `mCubeRoot`. Hence, the hit
logic does not work.

This issue is fixed by retrieving the parent entity if the hit found
is a `Qt3DExtras::DistanceFieldTextRenderer`.

cc @benoitdm-oslandia 