### PR TITLE
[3D] qgs3daxis: Fix axis label visibility in qt6

### DIFF
--- a/src/3d/qgs3daxis.cpp
+++ b/src/3d/qgs3daxis.cpp
@@ -314,7 +314,7 @@ void Qgs3DAxis::constructLabelsScene( Qt3DCore::QEntity *parent3DScene )
   mTwoDLabelSceneEntity->setEnabled( true );
 
   mTwoDLabelCamera = mRenderView->labelCamera();
-  mTwoDLabelCamera->setUpVector( QVector3D( 0.0f, 0.0f, 1.0f ) );
+  mTwoDLabelCamera->setUpVector( QVector3D( 0.0f, 1.0f, 0.0f ) );
   mTwoDLabelCamera->setViewCenter( QVector3D( 0.0f, 0.0f, 0.0f ) );
   mTwoDLabelCamera->setPosition( QVector3D( 0.0f, 0.0f, 100.0f ) );
 }


### PR DESCRIPTION
## Description

In axis mode, the axis labels (E, N, up) are displayed by using an orthographic camera. This camera has the following parameters:
- position: (0,0,100)
- up vector: (0,0,1)

The up vector is wrong. Indeed, if the camera is at position (0,0,100), the up vector needs to be set at (0,1,0) to have the labels visible.

By accident, this worked in Qt5 but this does not work in Qt6 anymore. This issue is fixed by setting the correct `up vector`. This works in both qt5 and qt6.

### without the fix

<img width="111" height="118" alt="Capture d’écran du 2025-10-16 19-30-51" src="https://github.com/user-attachments/assets/25a095cb-6e06-49ac-bb6a-1615b55a6a03" />

### with the fix

<img width="111" height="118" alt="Capture d’écran du 2025-10-16 19-31-54" src="https://github.com/user-attachments/assets/a1678236-c58d-4eac-a01f-15add7f55548" />


cc @benoitdm-oslandia 