### PR TITLE
Add floors to tessellator

### DIFF
--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -526,7 +526,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
     polygonNew.reset( _transform_polygon_to_new_base( polygon, pt0, toNewBase.get(), scale ) );
   };
 
-  auto addTriangleVertices = [&]( QgsLineString *triangle, bool reverse, float extrusion )
+  auto addTriangleVertices = [&]( QgsLineString * triangle, bool reverse, float extrusion )
   {
     const QVector3D normal = reverse ? -pNormal : pNormal;
     for ( int i = 0; i < 3; i++ )
@@ -608,6 +608,8 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
     case 4: // Walls, Roofs and Floors
       tessellate = ( facade == 1 || facade == 2 );
       break;
+    default:
+      break;
   }
 
   if ( pCount == 4 && polygon.numInteriorRings() == 0 && tessellate )
@@ -622,7 +624,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
 
     // polygon is a triangle - write vertices to the output data array without triangulation
     addTriangleVertices( triangle, false, extrusionHeight );
-    
+
     if ( addFloor )  // floor
     {
       addTriangleVertices( triangle, true, 0 );
@@ -700,7 +702,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
 
       mData.reserve( mData.size() + 3 * triangles.size() * ( stride() / sizeof( float ) ) );  // TODO: move to before triangulation?
 
-      auto addTriangulatedVertices = [&]( p2t::Triangle *t, bool reverse, float extrusion )
+      auto addTriangulatedVertices = [&]( p2t::Triangle * t, bool reverse, float extrusion )
       {
         const QVector3D normal = reverse ? -pNormal : pNormal;
         for ( int i = 0; i < 3; ++i )

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -489,7 +489,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
   float zMaxExtruded = -std::numeric_limits<float>::max();
 
   const float scale = mBounds.isNull() ? 1.0 : std::max( 10000.0 / mBounds.width(), 10000.0 / mBounds.height() );
-  const bool addFloor = ( mTessellatedFacade == 4 ) && ( extrusionHeight != 0 )
+  const bool addFloor = ( mTessellatedFacade == 4 ) && ( extrusionHeight != 0 );
 
   std::unique_ptr<QMatrix4x4> toNewBase, toOldBase;
   QgsPoint ptStart, pt0;

--- a/src/ui/3d/polygon3dsymbolwidget.ui
+++ b/src/ui/3d/polygon3dsymbolwidget.ui
@@ -23,78 +23,11 @@
    <property name="rightMargin">
     <number>0</number>
    </property>
-   <item row="0" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinOffset">
-     <property name="minimum">
-      <double>-99999.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>99999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Extrusion</string>
+      <string>Altitude clamping</string>
      </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="3">
-    <widget class="QgsCollapsibleGroupBox" name="groupShading">
-     <property name="title">
-      <string>Shading</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QgsMaterialWidget" name="widgetMaterial" native="true"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QgsPropertyOverrideButton" name="btnExtrusionDD">
-     <property name="text">
-      <string>…</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QCheckBox" name="chkInvertNormals">
-     <property name="text">
-      <string>Invert normals (experimental)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="cboAltClamping">
-     <item>
-      <property name="text">
-       <string>Absolute</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Relative</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Terrain</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="1" column="1">
@@ -104,15 +37,12 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
+   <item row="0" column="0">
+    <widget class="QLabel" name="labelOffset">
      <property name="text">
-      <string>Altitude binding</string>
+      <string>Offset</string>
      </property>
     </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="cboCullingMode"/>
    </item>
    <item row="3" column="1">
     <widget class="QComboBox" name="cboAltBinding">
@@ -128,17 +58,10 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QgsPropertyOverrideButton" name="btnHeightDD">
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_8">
      <property name="text">
-      <string>…</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Altitude clamping</string>
+      <string>Rendered facade</string>
      </property>
     </widget>
    </item>
@@ -203,31 +126,10 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Culling mode</string>
-     </property>
-    </widget>
-   </item>
    <item row="6" column="0" colspan="2">
     <widget class="QCheckBox" name="chkAddBackFaces">
      <property name="text">
       <string>Add back faces</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="labelOffset">
-     <property name="text">
-      <string>Offset</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>Rendered facade</string>
      </property>
     </widget>
    </item>
@@ -256,7 +158,110 @@
        <string>Walls and Roofs</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>Walls and Roofs and Floors</string>
+      </property>
+     </item>
     </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Culling mode</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QCheckBox" name="chkInvertNormals">
+     <property name="text">
+      <string>Invert normals (experimental)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QgsPropertyOverrideButton" name="btnExtrusionDD">
+     <property name="text">
+      <string>…</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="3">
+    <widget class="QgsCollapsibleGroupBox" name="groupShading">
+     <property name="title">
+      <string>Shading</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QgsMaterialWidget" name="widgetMaterial" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QgsPropertyOverrideButton" name="btnHeightDD">
+     <property name="text">
+      <string>…</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Extrusion</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsDoubleSpinBox" name="spinOffset">
+     <property name="minimum">
+      <double>-99999.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>99999.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Altitude binding</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="cboAltClamping">
+     <item>
+      <property name="text">
+       <string>Absolute</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Relative</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Terrain</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="cboCullingMode"/>
    </item>
   </layout>
  </widget>

--- a/src/ui/3d/polygon3dsymbolwidget.ui
+++ b/src/ui/3d/polygon3dsymbolwidget.ui
@@ -160,7 +160,7 @@
      </item>
      <item>
       <property name="text">
-       <string>Walls and Roofs and Floors</string>
+       <string>Walls, Roofs and Floors</string>
       </property>
      </item>
     </widget>


### PR DESCRIPTION
This PR adds optional creation of floors in 3D map view.

[walls roofs and floors.webm](https://github.com/user-attachments/assets/8d530037-d87e-4106-a4b0-cbc3f0fc2995)


Hi @raymondnijssen, do you have a better suggestion for the placement of the new option or is the 5th option in this combobox OK (Walls, Roofs and Floors)?

Funded by https://www.lutraconsulting.co.uk/crowdfunding/qgis-3d-for-open-source-digital-twins