### PR TITLE
show only column name without alias

### DIFF
--- a/src/gui/qgsfieldmappingmodel.cpp
+++ b/src/gui/qgsfieldmappingmodel.cpp
@@ -129,7 +129,7 @@ QVariant QgsFieldMappingModel::data( const QModelIndex &index, int role ) const
           }
           case ColumnDataIndex::DestinationName:
           {
-            return f.field.displayNameWithAlias();
+            return f.field.name();
           }
           case ColumnDataIndex::DestinationType:
           {

--- a/tests/src/python/test_qgsfieldmappingwidget.py
+++ b/tests/src/python/test_qgsfieldmappingwidget.py
@@ -113,7 +113,7 @@ class TestPyQgsFieldMappingModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(1, 1), Qt.ItemDataRole.DisplayRole),
-            "destination_field2 (my alias)",
+            "destination_field2",
         )
         self.assertEqual(
             model.data(model.index(1, 6), Qt.ItemDataRole.DisplayRole), "my alias"
@@ -224,7 +224,7 @@ class TestPyQgsFieldMappingModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(1, 1), Qt.ItemDataRole.DisplayRole),
-            "destination_field2 (my alias)",
+            "destination_field2",
         )
         self.assertEqual(
             model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole),


### PR DESCRIPTION
## Description

In QgsFieldMappingModel the DestinationName column should only show name() of the field without alias. Originally it showed **column name (column alias)** fixed version should only show **column name**. That is much better for **Import Vector Layer...** in Browser.

Fixes #63593

Funded by: Ocean Winds