### PR TITLE
Fix loading textures from SLPK archive

### DIFF
--- a/src/core/tiledscene/qgsgltfutils.cpp
+++ b/src/core/tiledscene/qgsgltfutils.cpp
@@ -779,14 +779,14 @@ int QgsGltfUtils::loadMaterialFromMetadata( const QVariantMap &materialInfo, tin
     QString baseColorTextureUri = materialInfo["pbrBaseColorTexture"].toString();
 
     tinygltf::Image img;
-    if ( baseColorTextureUri.contains(".slpk/") )  // image within SLPK archive
+    if ( baseColorTextureUri.contains( ".slpk/" ) )  // image within SLPK archive
     {
       const QStringList parts = baseColorTextureUri.split( QStringLiteral( ".slpk/" ) );
       if ( parts.size() == 2 )
       {
         QString slpkPath = QUrl( parts[0] + ".slpk" ).toLocalFile();
         QString imagePath = parts[1];
-        
+
         QByteArray imageData;
         if ( QgsZipUtils::extractFileFromZip( slpkPath, imagePath, imageData ) )
         {


### PR DESCRIPTION
Fixes loading image files stored within an SLPK archive as textures.

<img width="1920" height="1035" alt="Screenshot_20251017_161931" src="https://github.com/user-attachments/assets/047c5f61-7d44-469d-a13e-f6366383886b" />
