### PR TITLE
fix sip QgsRelief missing color

### DIFF
--- a/python/PyQt6/analysis/auto_generated/raster/qgsrelief.sip.in
+++ b/python/PyQt6/analysis/auto_generated/raster/qgsrelief.sip.in
@@ -23,6 +23,7 @@ Produces colored relief rasters from DEM.
     struct ReliefColor
     {
         ReliefColor( const QColor &c, double min, double max );
+        QColor color;
         double minElevation;
         double maxElevation;
     };

--- a/python/analysis/auto_generated/raster/qgsrelief.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrelief.sip.in
@@ -23,6 +23,7 @@ Produces colored relief rasters from DEM.
     struct ReliefColor
     {
         ReliefColor( const QColor &c, double min, double max );
+        QColor color;
         double minElevation;
         double maxElevation;
     };

--- a/src/analysis/raster/qgsrelief.h
+++ b/src/analysis/raster/qgsrelief.h
@@ -42,6 +42,7 @@ class ANALYSIS_EXPORT QgsRelief
     {
         ReliefColor( const QColor &c, double min, double max )
           : color( c ), minElevation( min ), maxElevation( max ) {}
+
         QColor color;
         double minElevation;
         double maxElevation;


### PR DESCRIPTION
supersedes #63598

Fixes https://github.com/qgis/QGIS/issues/63588.