### PR TITLE
Add Project and User Bookmarks as variables

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -774,6 +774,7 @@ void QgsExpression::buildVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "project_ellipsoid" ), QCoreApplication::translate( "variable_help", "Name of ellipsoid of current project, used when calculating geodetic areas and lengths of geometries." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "layer_ids" ), QCoreApplication::translate( "variable_help", "List of all map layer IDs from the current project." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "layers" ), QCoreApplication::translate( "variable_help", "List of all map layers from the current project." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "project_bookmarks" ), QCoreApplication::translate( "variable_help", "List of all bookmarks from the current project." ) );
 
   //layer variables
   sVariableHelpTexts()->insert( QStringLiteral( "layer_name" ), QCoreApplication::translate( "variable_help", "Name of current layer." ) );

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -775,6 +775,7 @@ void QgsExpression::buildVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "layer_ids" ), QCoreApplication::translate( "variable_help", "List of all map layer IDs from the current project." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "layers" ), QCoreApplication::translate( "variable_help", "List of all map layers from the current project." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "project_bookmarks" ), QCoreApplication::translate( "variable_help", "List of all bookmarks from the current project." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "user_bookmarks" ), QCoreApplication::translate( "variable_help", "List of all user bookmarks from the current profile." ) );
 
   //layer variables
   sVariableHelpTexts()->insert( QStringLiteral( "layer_name" ), QCoreApplication::translate( "variable_help", "Name of current layer." ) );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -412,6 +412,8 @@ QgsProject::QgsProject( QObject *parent, Qgis::ProjectCapabilities capabilities 
   [this]( const QList< QgsMapLayer * > &layers ) { mProjectScope.reset(); emit layersAdded( layers ); } );
   connect( mLayerStore.get(), &QgsMapLayerStore::layerWasAdded, this,
   [this]( QgsMapLayer * layer ) { mProjectScope.reset(); emit layerWasAdded( layer ); } );
+  connect( mBookmarkManager, &QgsBookmarkManager::bookmarksChanged, this, 
+    [this]{ mProjectScope.reset(); emit customVariablesChanged(); } );
 
   if ( QgsApplication::instance() )
   {
@@ -2960,6 +2962,30 @@ QgsExpressionContextScope *QgsProject::createExpressionContextScope() const
 
   mProjectScope->addFunction( QStringLiteral( "project_color" ), new GetNamedProjectColor( this ) );
   mProjectScope->addFunction( QStringLiteral( "project_color_object" ), new GetNamedProjectColorObject( this ) );
+
+  // bookmarks
+  QVariantList bookmarksList;
+  const auto bookmarks = mBookmarkManager->bookmarks();
+  for (const QgsBookmark &bm : bookmarks)
+  {
+    QVariantMap bmMap;
+    bmMap["name"] = bm.name();
+    bmMap["id"] = bm.id();
+    // Example extent serialization
+    const QgsRectangle ext = bm.extent();
+    bmMap["extent"] = QVariantMap{
+        {"xmin", ext.xMinimum()},
+        {"ymin", ext.yMinimum()},
+        {"xmax", ext.xMaximum()},
+        {"ymax", ext.yMaximum()}
+    };
+    bmMap["width"] = ext.width();
+    bmMap["height"] = ext.height();
+    bmMap["crs"] = bm.crs().authid();
+    bmMap["rotation"] = bm.rotation();
+    bookmarksList << bmMap;
+  }
+  mProjectScope->addVariable(QgsExpressionContextScope::StaticVariable(QStringLiteral("project_bookmarks"), bookmarksList, true, true));
 
   return createExpressionContextScope();
 }

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -2964,46 +2964,46 @@ QgsExpressionContextScope *QgsProject::createExpressionContextScope() const
   // bookmarks
   QVariantMap bookmarksMap;
   const auto bookmarks = mBookmarkManager->bookmarks();
-  for (const QgsBookmark &bm : bookmarks)
+  for ( const QgsBookmark &bm : bookmarks )
   {
-      QVariantMap bmMap;
-      bmMap["name"] = bm.name();
-      bmMap["id"] = bm.id();
-      QVariantMap extentMap;
-      extentMap["x_min"] = bm.extent().xMinimum();
-      extentMap["y_min"] = bm.extent().yMinimum();
-      extentMap["x_max"] = bm.extent().xMaximum();
-      extentMap["y_max"] = bm.extent().yMaximum();
-      bmMap["extent"] = extentMap;
-      bmMap["width"] = bm.extent().width();
-      bmMap["height"] = bm.extent().height();
-      bmMap["crs"] = bm.extent().crs().authid();
-      bmMap["rotation"] = bm.rotation();
-      bookmarksMap[bm.name()] = bmMap;
+    QVariantMap bmMap;
+    bmMap["name"] = bm.name();
+    bmMap["id"] = bm.id();
+    QVariantMap extentMap;
+    extentMap["x_min"] = bm.extent().xMinimum();
+    extentMap["y_min"] = bm.extent().yMinimum();
+    extentMap["x_max"] = bm.extent().xMaximum();
+    extentMap["y_max"] = bm.extent().yMaximum();
+    bmMap["extent"] = extentMap;
+    bmMap["width"] = bm.extent().width();
+    bmMap["height"] = bm.extent().height();
+    bmMap["crs"] = bm.extent().crs().authid();
+    bmMap["rotation"] = bm.rotation();
+    bookmarksMap[bm.name()] = bmMap;
   }
-  mProjectScope->addVariable(QgsExpressionContextScope::StaticVariable(QStringLiteral("project_bookmarks"), bookmarksMap, true, true));
+  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_bookmarks" ), bookmarksMap, true, true ) );
 
   // Profile bookmarks
   QVariantMap userBookmarksMap;
   const auto profileBookmarks = QgsApplication::bookmarkManager()->bookmarks();
-  for (const QgsBookmark &bm : profileBookmarks)
+  for ( const QgsBookmark &bm : profileBookmarks )
   {
-      QVariantMap bmMap;
-      bmMap["name"] = bm.name();
-      bmMap["id"] = bm.id();
-      QVariantMap extentMap;
-      extentMap["x_min"] = bm.extent().xMinimum();
-      extentMap["y_min"] = bm.extent().yMinimum();
-      extentMap["x_max"] = bm.extent().xMaximum();
-      extentMap["y_max"] = bm.extent().yMaximum();
-      bmMap["extent"] = extentMap;
-      bmMap["width"] = bm.extent().width();
-      bmMap["height"] = bm.extent().height();
-      bmMap["crs"] = bm.extent().crs().authid();
-      bmMap["rotation"] = bm.rotation();
-      userBookmarksMap[bm.name()] = bmMap;
+    QVariantMap bmMap;
+    bmMap["name"] = bm.name();
+    bmMap["id"] = bm.id();
+    QVariantMap extentMap;
+    extentMap["x_min"] = bm.extent().xMinimum();
+    extentMap["y_min"] = bm.extent().yMinimum();
+    extentMap["x_max"] = bm.extent().xMaximum();
+    extentMap["y_max"] = bm.extent().yMaximum();
+    bmMap["extent"] = extentMap;
+    bmMap["width"] = bm.extent().width();
+    bmMap["height"] = bm.extent().height();
+    bmMap["crs"] = bm.extent().crs().authid();
+    bmMap["rotation"] = bm.rotation();
+    userBookmarksMap[bm.name()] = bmMap;
   }
-  mProjectScope->addVariable(QgsExpressionContextScope::StaticVariable(QStringLiteral("user_bookmarks"), userBookmarksMap, true, true));
+  mProjectScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "user_bookmarks" ), userBookmarksMap, true, true ) );
 
   return createExpressionContextScope();
 }


### PR DESCRIPTION
## Description

[FEATURE]

The PR adds two new variables to be used in the expression engine:
1. `project_bookmarks` - a map object containing the bookmarks saved in the project (bookmarks need to be added and the project saved to appear).
2. `user_bookmarks` -  a map object containing the bookmarks saved under `User Bookmarks` for the current profile.

The variables are maps and not lists for ease of access to specific bookmarks.
Each bookmark object contains the following properties:
1. name
2. id
3. extent - an object containing 
  3.1. x_min
  3.2. y_min
  3.3. x_max
  3.4. y_max
4. width
5. height
6. crs - string authID
7. rotation - float

The idea behind the changes are to allow users to use bookmark properties to set specific data driven overrides as well as display them.

The changes are:

1. in `src/core/project/qgsproject.cpp` under `QgsProject::createExpressionContextScope()` the bookmark maps are built from the project and application BookmarkManagers and added to context.
2. in `src/core/expression/qgsexpression.cpp` under `QgsExpression::buildVariableHelp()` added help strings for both variables.

Built successfully without issues on Ubuntu 24.04.
