### PR TITLE
fix crash in WCS source widget

### DIFF
--- a/src/gui/qgsowssourcewidget.cpp
+++ b/src/gui/qgsowssourcewidget.cpp
@@ -85,8 +85,8 @@ void QgsOWSSourceWidget::setSourceUri( const QString &uri )
     extent = inverted ? QgsRectangle(
                           coords.at( 1 ).toDouble(),
                           coords.at( 0 ).toDouble(),
-                          coords.at( 2 ).toDouble(),
-                          coords.at( 3 ).toDouble()
+                          coords.at( 3 ).toDouble(),
+                          coords.at( 2 ).toDouble()
                         )
                       : QgsRectangle(
                           coords.at( 0 ).toDouble(),

--- a/src/gui/qgsowssourcewidget.cpp
+++ b/src/gui/qgsowssourcewidget.cpp
@@ -83,16 +83,16 @@ void QgsOWSSourceWidget::setSourceUri( const QString &uri )
   {
     QStringList coords = bbox.split( ',' );
     extent = inverted ? QgsRectangle(
-                          coords.takeAt( 1 ).toDouble(),
-                          coords.takeAt( 0 ).toDouble(),
-                          coords.takeAt( 2 ).toDouble(),
-                          coords.takeAt( 3 ).toDouble()
+                          coords.at( 1 ).toDouble(),
+                          coords.at( 0 ).toDouble(),
+                          coords.at( 2 ).toDouble(),
+                          coords.at( 3 ).toDouble()
                         )
                       : QgsRectangle(
-                          coords.takeAt( 0 ).toDouble(),
-                          coords.takeAt( 1 ).toDouble(),
-                          coords.takeAt( 2 ).toDouble(),
-                          coords.takeAt( 3 ).toDouble()
+                          coords.at( 0 ).toDouble(),
+                          coords.at( 1 ).toDouble(),
+                          coords.at( 2 ).toDouble(),
+                          coords.at( 3 ).toDouble()
                         );
   }
   else


### PR DESCRIPTION
## Description

Fixes unreported crash in WCS source widget which happens when accessing properties of the WCS layer with spatial filter enabled. We can't use `takeAt()` to access individual values as this changes size of the list and triggers out of bounds error.

Also fixes another unreported issue with incorrect extent creation from the `bbox` parameter, we should invert order of the both pairs of coordinates, not only the first pair.