### PR TITLE
Skip invalid layers when rendering canvas

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -774,6 +774,13 @@ QList<QgsMapLayer *> filterLayersForRender( const QList<QgsMapLayer *> &layers )
     }
     filteredLayers.append( layer );
   }
+
+  // remove any invalid layers
+  filteredLayers.erase( std::remove_if( filteredLayers.begin(), filteredLayers.end(), []( QgsMapLayer *layer ) {
+                          return !layer || !layer->isValid();
+                        } ),
+                        filteredLayers.end() );
+
   return filteredLayers;
 }
 


### PR DESCRIPTION
Since https://github.com/qgis/QGIS/pull/62950 the user is spammed with errors for every invalid layer in the project on every canvas map render. Avoid this by erasing invalid layers from the canvas render job map settings in advance.

Unfortunately (and against development policies) #62950 was merged with any review, resulting in this regression.