### PR TITLE
[api] Add methods to determine if QgsSymbols will render identically

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsfillsymbollayer.py
+++ b/python/PyQt6/core/auto_additions/qgsfillsymbollayer.py
@@ -51,7 +51,7 @@ except (NameError, AttributeError):
 try:
     QgsRandomMarkerFillSymbolLayer.create = staticmethod(QgsRandomMarkerFillSymbolLayer.create)
     QgsRandomMarkerFillSymbolLayer.__virtual_methods__ = ['setSubSymbol']
-    QgsRandomMarkerFillSymbolLayer.__overridden_methods__ = ['layerType', 'startRender', 'stopRender', 'renderPolygon', 'properties', 'clone', 'canCauseArtifactsBetweenAdjacentTiles', 'setColor', 'color', 'subSymbol', 'setOutputUnit', 'outputUnit', 'usesMapUnits', 'setMapUnitScale', 'mapUnitScale', 'usedAttributes', 'hasDataDefinedProperties', 'startFeatureRender', 'stopFeatureRender']
+    QgsRandomMarkerFillSymbolLayer.__overridden_methods__ = ['layerType', 'startRender', 'stopRender', 'renderPolygon', 'properties', 'clone', 'canCauseArtifactsBetweenAdjacentTiles', 'rendersIdenticallyTo', 'setColor', 'color', 'subSymbol', 'setOutputUnit', 'outputUnit', 'usesMapUnits', 'setMapUnitScale', 'mapUnitScale', 'usedAttributes', 'hasDataDefinedProperties', 'startFeatureRender', 'stopFeatureRender']
     QgsRandomMarkerFillSymbolLayer.__group__ = ['symbology']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgsgeometrygeneratorsymbollayer.py
+++ b/python/PyQt6/core/auto_additions/qgsgeometrygeneratorsymbollayer.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/symbology/qgsgeometrygeneratorsymbollayer.h
 try:
     QgsGeometryGeneratorSymbolLayer.create = staticmethod(QgsGeometryGeneratorSymbolLayer.create)
-    QgsGeometryGeneratorSymbolLayer.__overridden_methods__ = ['layerType', 'startRender', 'stopRender', 'startFeatureRender', 'stopFeatureRender', 'usesMapUnits', 'color', 'outputUnit', 'setOutputUnit', 'mapUnitScale', 'clone', 'properties', 'drawPreviewIcon', 'subSymbol', 'setSubSymbol', 'usedAttributes', 'hasDataDefinedProperties', 'isCompatibleWithSymbol', 'setColor']
+    QgsGeometryGeneratorSymbolLayer.__overridden_methods__ = ['layerType', 'startRender', 'stopRender', 'startFeatureRender', 'stopFeatureRender', 'usesMapUnits', 'color', 'outputUnit', 'setOutputUnit', 'mapUnitScale', 'rendersIdenticallyTo', 'clone', 'properties', 'drawPreviewIcon', 'subSymbol', 'setSubSymbol', 'usedAttributes', 'hasDataDefinedProperties', 'isCompatibleWithSymbol', 'setColor']
     QgsGeometryGeneratorSymbolLayer.__group__ = ['symbology']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgssymbollayer.py
+++ b/python/PyQt6/core/auto_additions/qgssymbollayer.py
@@ -621,7 +621,7 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsSymbolLayer.__virtual_methods__ = ['flags', 'color', 'setColor', 'setStrokeColor', 'strokeColor', 'setFillColor', 'fillColor', 'startFeatureRender', 'stopFeatureRender', 'toSld', 'ogrFeatureStyle', 'subSymbol', 'setSubSymbol', 'isCompatibleWithSymbol', 'canCauseArtifactsBetweenAdjacentTiles', 'estimateMaxBleed', 'setOutputUnit', 'outputUnit', 'usesMapUnits', 'setMapUnitScale', 'mapUnitScale', 'usedAttributes', 'setDataDefinedProperty', 'writeDxf', 'dxfWidth', 'dxfSize', 'dxfOffset', 'dxfColor', 'dxfAngle', 'dxfCustomDashPattern', 'dxfPenStyle', 'dxfBrushColor', 'dxfBrushStyle', 'prepareExpressions', 'hasDataDefinedProperties', 'masks', 'prepareMasks']
+    QgsSymbolLayer.__virtual_methods__ = ['flags', 'color', 'setColor', 'setStrokeColor', 'strokeColor', 'setFillColor', 'fillColor', 'startFeatureRender', 'stopFeatureRender', 'toSld', 'ogrFeatureStyle', 'subSymbol', 'setSubSymbol', 'isCompatibleWithSymbol', 'rendersIdenticallyTo', 'canCauseArtifactsBetweenAdjacentTiles', 'estimateMaxBleed', 'setOutputUnit', 'outputUnit', 'usesMapUnits', 'setMapUnitScale', 'mapUnitScale', 'usedAttributes', 'setDataDefinedProperty', 'writeDxf', 'dxfWidth', 'dxfSize', 'dxfOffset', 'dxfColor', 'dxfAngle', 'dxfCustomDashPattern', 'dxfPenStyle', 'dxfBrushColor', 'dxfBrushStyle', 'prepareExpressions', 'hasDataDefinedProperties', 'masks', 'prepareMasks']
     QgsSymbolLayer.__abstract_methods__ = ['layerType', 'startRender', 'stopRender', 'clone', 'properties', 'drawPreviewIcon']
     QgsSymbolLayer.__group__ = ['symbology']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -2708,6 +2708,8 @@ Caller takes ownership of the returned symbol layer.
 
     virtual bool canCauseArtifactsBetweenAdjacentTiles() const;
 
+    virtual bool rendersIdenticallyTo( const QgsSymbolLayer *other ) const;
+
 
     virtual void setColor( const QColor &color );
 

--- a/python/PyQt6/core/auto_generated/symbology/qgsgeometrygeneratorsymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsgeometrygeneratorsymbollayer.sip.in
@@ -65,6 +65,8 @@ created by this generator.
 
     virtual QgsMapUnitScale mapUnitScale() const;
 
+    virtual bool rendersIdenticallyTo( const QgsSymbolLayer *other ) const;
+
 
     virtual QgsSymbolLayer *clone() const /Factory/;
 

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbol.sip.in
@@ -560,6 +560,23 @@ Returns a large (roughly 100x100 pixel) preview image for the symbol.
 Returns a string dump of the symbol's properties.
 %End
 
+    bool rendersIdenticallyTo( const QgsSymbol *other ) const;
+%Docstring
+Returns ``True`` if this symbol will always render identically to an
+``other`` symbol.
+
+.. note::
+
+   This method is pessimistic, in that it will return ``False`` in circumstances
+   where it is not possible to guarantee that in 100% of cases the symbol will
+   render pixel-identically to the other symbol. For instance, calling
+   :py:func:`~QgsSymbol.rendersIdenticallyTo` with the same symbol as ``other`` may
+   return ``False`` if the symbol contains data-defined overrides, such
+   as those using feature attributes or expression variables.
+
+.. versionadded:: 4.0
+%End
+
     virtual QgsSymbol *clone() const = 0 /Factory/;
 %Docstring
 Returns a deep copy of this symbol.

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -463,6 +463,23 @@ Sets layer's subsymbol. takes ownership of the passed symbol
 Returns if the layer can be used below the specified symbol
 %End
 
+    virtual bool rendersIdenticallyTo( const QgsSymbolLayer *other ) const;
+%Docstring
+Returns ``True`` if this symbol layer will always render identically to
+an ``other`` symbol layer.
+
+.. note::
+
+   This method is pessimistic, in that it will return ``False`` in circumstances
+   where it is not possible to guarantee that in 100% of cases the layer will
+   render pixel-identically to the other layer. For instance, calling
+   :py:func:`~QgsSymbolLayer.rendersIdenticallyTo` with the same symbol layer as ``other`` may
+   return ``False`` if the symbol layer contains data-defined overrides, such
+   as those using feature attributes or expression variables.
+
+.. versionadded:: 4.0
+%End
+
     virtual bool canCauseArtifactsBetweenAdjacentTiles() const;
 %Docstring
 Returns ``True`` if the symbol layer rendering can cause visible

--- a/python/core/auto_additions/qgsfillsymbollayer.py
+++ b/python/core/auto_additions/qgsfillsymbollayer.py
@@ -51,7 +51,7 @@ except (NameError, AttributeError):
 try:
     QgsRandomMarkerFillSymbolLayer.create = staticmethod(QgsRandomMarkerFillSymbolLayer.create)
     QgsRandomMarkerFillSymbolLayer.__virtual_methods__ = ['setSubSymbol']
-    QgsRandomMarkerFillSymbolLayer.__overridden_methods__ = ['layerType', 'startRender', 'stopRender', 'renderPolygon', 'properties', 'clone', 'canCauseArtifactsBetweenAdjacentTiles', 'setColor', 'color', 'subSymbol', 'setOutputUnit', 'outputUnit', 'usesMapUnits', 'setMapUnitScale', 'mapUnitScale', 'usedAttributes', 'hasDataDefinedProperties', 'startFeatureRender', 'stopFeatureRender']
+    QgsRandomMarkerFillSymbolLayer.__overridden_methods__ = ['layerType', 'startRender', 'stopRender', 'renderPolygon', 'properties', 'clone', 'canCauseArtifactsBetweenAdjacentTiles', 'rendersIdenticallyTo', 'setColor', 'color', 'subSymbol', 'setOutputUnit', 'outputUnit', 'usesMapUnits', 'setMapUnitScale', 'mapUnitScale', 'usedAttributes', 'hasDataDefinedProperties', 'startFeatureRender', 'stopFeatureRender']
     QgsRandomMarkerFillSymbolLayer.__group__ = ['symbology']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_additions/qgsgeometrygeneratorsymbollayer.py
+++ b/python/core/auto_additions/qgsgeometrygeneratorsymbollayer.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/symbology/qgsgeometrygeneratorsymbollayer.h
 try:
     QgsGeometryGeneratorSymbolLayer.create = staticmethod(QgsGeometryGeneratorSymbolLayer.create)
-    QgsGeometryGeneratorSymbolLayer.__overridden_methods__ = ['layerType', 'startRender', 'stopRender', 'startFeatureRender', 'stopFeatureRender', 'usesMapUnits', 'color', 'outputUnit', 'setOutputUnit', 'mapUnitScale', 'clone', 'properties', 'drawPreviewIcon', 'subSymbol', 'setSubSymbol', 'usedAttributes', 'hasDataDefinedProperties', 'isCompatibleWithSymbol', 'setColor']
+    QgsGeometryGeneratorSymbolLayer.__overridden_methods__ = ['layerType', 'startRender', 'stopRender', 'startFeatureRender', 'stopFeatureRender', 'usesMapUnits', 'color', 'outputUnit', 'setOutputUnit', 'mapUnitScale', 'rendersIdenticallyTo', 'clone', 'properties', 'drawPreviewIcon', 'subSymbol', 'setSubSymbol', 'usedAttributes', 'hasDataDefinedProperties', 'isCompatibleWithSymbol', 'setColor']
     QgsGeometryGeneratorSymbolLayer.__group__ = ['symbology']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_additions/qgssymbollayer.py
+++ b/python/core/auto_additions/qgssymbollayer.py
@@ -618,7 +618,7 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsSymbolLayer.__virtual_methods__ = ['flags', 'color', 'setColor', 'setStrokeColor', 'strokeColor', 'setFillColor', 'fillColor', 'startFeatureRender', 'stopFeatureRender', 'toSld', 'ogrFeatureStyle', 'subSymbol', 'setSubSymbol', 'isCompatibleWithSymbol', 'canCauseArtifactsBetweenAdjacentTiles', 'estimateMaxBleed', 'setOutputUnit', 'outputUnit', 'usesMapUnits', 'setMapUnitScale', 'mapUnitScale', 'usedAttributes', 'setDataDefinedProperty', 'writeDxf', 'dxfWidth', 'dxfSize', 'dxfOffset', 'dxfColor', 'dxfAngle', 'dxfCustomDashPattern', 'dxfPenStyle', 'dxfBrushColor', 'dxfBrushStyle', 'prepareExpressions', 'hasDataDefinedProperties', 'masks', 'prepareMasks']
+    QgsSymbolLayer.__virtual_methods__ = ['flags', 'color', 'setColor', 'setStrokeColor', 'strokeColor', 'setFillColor', 'fillColor', 'startFeatureRender', 'stopFeatureRender', 'toSld', 'ogrFeatureStyle', 'subSymbol', 'setSubSymbol', 'isCompatibleWithSymbol', 'rendersIdenticallyTo', 'canCauseArtifactsBetweenAdjacentTiles', 'estimateMaxBleed', 'setOutputUnit', 'outputUnit', 'usesMapUnits', 'setMapUnitScale', 'mapUnitScale', 'usedAttributes', 'setDataDefinedProperty', 'writeDxf', 'dxfWidth', 'dxfSize', 'dxfOffset', 'dxfColor', 'dxfAngle', 'dxfCustomDashPattern', 'dxfPenStyle', 'dxfBrushColor', 'dxfBrushStyle', 'prepareExpressions', 'hasDataDefinedProperties', 'masks', 'prepareMasks']
     QgsSymbolLayer.__abstract_methods__ = ['layerType', 'startRender', 'stopRender', 'clone', 'properties', 'drawPreviewIcon']
     QgsSymbolLayer.__group__ = ['symbology']
 except (NameError, AttributeError):

--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -2708,6 +2708,8 @@ Caller takes ownership of the returned symbol layer.
 
     virtual bool canCauseArtifactsBetweenAdjacentTiles() const;
 
+    virtual bool rendersIdenticallyTo( const QgsSymbolLayer *other ) const;
+
 
     virtual void setColor( const QColor &color );
 

--- a/python/core/auto_generated/symbology/qgsgeometrygeneratorsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsgeometrygeneratorsymbollayer.sip.in
@@ -65,6 +65,8 @@ created by this generator.
 
     virtual QgsMapUnitScale mapUnitScale() const;
 
+    virtual bool rendersIdenticallyTo( const QgsSymbolLayer *other ) const;
+
 
     virtual QgsSymbolLayer *clone() const /Factory/;
 

--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -560,6 +560,23 @@ Returns a large (roughly 100x100 pixel) preview image for the symbol.
 Returns a string dump of the symbol's properties.
 %End
 
+    bool rendersIdenticallyTo( const QgsSymbol *other ) const;
+%Docstring
+Returns ``True`` if this symbol will always render identically to an
+``other`` symbol.
+
+.. note::
+
+   This method is pessimistic, in that it will return ``False`` in circumstances
+   where it is not possible to guarantee that in 100% of cases the symbol will
+   render pixel-identically to the other symbol. For instance, calling
+   :py:func:`~QgsSymbol.rendersIdenticallyTo` with the same symbol as ``other`` may
+   return ``False`` if the symbol contains data-defined overrides, such
+   as those using feature attributes or expression variables.
+
+.. versionadded:: 4.0
+%End
+
     virtual QgsSymbol *clone() const = 0 /Factory/;
 %Docstring
 Returns a deep copy of this symbol.

--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -463,6 +463,23 @@ Sets layer's subsymbol. takes ownership of the passed symbol
 Returns if the layer can be used below the specified symbol
 %End
 
+    virtual bool rendersIdenticallyTo( const QgsSymbolLayer *other ) const;
+%Docstring
+Returns ``True`` if this symbol layer will always render identically to
+an ``other`` symbol layer.
+
+.. note::
+
+   This method is pessimistic, in that it will return ``False`` in circumstances
+   where it is not possible to guarantee that in 100% of cases the layer will
+   render pixel-identically to the other layer. For instance, calling
+   :py:func:`~QgsSymbolLayer.rendersIdenticallyTo` with the same symbol layer as ``other`` may
+   return ``False`` if the symbol layer contains data-defined overrides, such
+   as those using feature attributes or expression variables.
+
+.. versionadded:: 4.0
+%End
+
     virtual bool canCauseArtifactsBetweenAdjacentTiles() const;
 %Docstring
 Returns ``True`` if the symbol layer rendering can cause visible

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -5805,6 +5805,19 @@ bool QgsRandomMarkerFillSymbolLayer::canCauseArtifactsBetweenAdjacentTiles() con
   return true;
 }
 
+bool QgsRandomMarkerFillSymbolLayer::rendersIdenticallyTo( const QgsSymbolLayer *other ) const
+{
+  if ( !QgsFillSymbolLayer::rendersIdenticallyTo( other ) )
+    return false;
+
+  // special case -- two QgsRandomMarkerFillSymbolLayer will render differently if they have
+  // no seed value set.
+  if ( mSeed == 0 )
+    return false;
+
+  return true;
+}
+
 QgsSymbol *QgsRandomMarkerFillSymbolLayer::subSymbol()
 {
   return mMarker.get();

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -2325,6 +2325,7 @@ class CORE_EXPORT QgsRandomMarkerFillSymbolLayer : public QgsFillSymbolLayer
     QVariantMap properties() const override;
     QgsRandomMarkerFillSymbolLayer *clone() const override SIP_FACTORY;
     bool canCauseArtifactsBetweenAdjacentTiles() const override;
+    bool rendersIdenticallyTo( const QgsSymbolLayer *other ) const override;
 
     void setColor( const QColor &color ) override;
     QColor color() const override;

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
@@ -178,6 +178,15 @@ QgsMapUnitScale QgsGeometryGeneratorSymbolLayer::mapUnitScale() const
   return QgsMapUnitScale();
 }
 
+bool QgsGeometryGeneratorSymbolLayer::rendersIdenticallyTo( const QgsSymbolLayer * ) const
+{
+  // since rendersIdenticallyTo must be pessimistic, we always return FALSE here as it's
+  // non-trivial to determine if a QGIS expression will always return the same result
+  // TODO: we could potentially investigate the actual expression and catch cases where we
+  // are CERTAIN that the result will always be the same
+  return false;
+}
+
 QgsSymbolLayer *QgsGeometryGeneratorSymbolLayer::clone() const
 {
   QgsGeometryGeneratorSymbolLayer *clone = new QgsGeometryGeneratorSymbolLayer( mExpression->expression() );

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsGeometryGeneratorSymbolLayer : public QgsSymbolLayer
     Qgis::RenderUnit outputUnit() const override;
     void setOutputUnit( Qgis::RenderUnit unit ) override;
     QgsMapUnitScale mapUnitScale() const override;
+    bool rendersIdenticallyTo( const QgsSymbolLayer *other ) const override;
 
     QgsSymbolLayer *clone() const override SIP_FACTORY;
 

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -1367,6 +1367,43 @@ QString QgsSymbol::dump() const
   return s;
 }
 
+bool QgsSymbol::rendersIdenticallyTo( const QgsSymbol *other ) const
+{
+  if ( !other )
+    return false;
+
+  if ( mType != other->mType
+       || !qgsDoubleNear( mExtentBuffer, other->mExtentBuffer )
+       || mExtentBufferSizeUnit != other->mExtentBufferSizeUnit
+       || !qgsDoubleNear( mOpacity, other->mOpacity )
+       || mRenderHints != other->mRenderHints
+       || mSymbolFlags != other->mSymbolFlags
+       || mClipFeaturesToExtent != other->mClipFeaturesToExtent
+       || mForceRHR != other->mForceRHR
+
+       // TODO: consider actual buffer settings
+       || mBufferSettings
+       || other->mBufferSettings
+
+       // TODO: consider actual animation settings
+       || mAnimationSettings.isAnimated()
+       || other->mAnimationSettings.isAnimated() )
+    return false;
+
+  // TODO -- we could slacken this check if we ignore disabled layers
+  if ( mLayers.count() != other->mLayers.count() )
+  {
+    return false;
+  }
+
+  for ( int i = 0; i < mLayers.count(); ++i )
+  {
+    if ( !mLayers.at( i )->rendersIdenticallyTo( other->mLayers.at( i ) ) )
+      return false;
+  }
+  return true;
+}
+
 void QgsSymbol::toSld( QDomDocument &doc, QDomElement &element, QVariantMap props ) const
 {
   QgsSldExportContext context;

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -566,6 +566,21 @@ class CORE_EXPORT QgsSymbol
     QString dump() const;
 
     /**
+     * Returns TRUE if this symbol will always render identically
+     * to an \a other symbol.
+     *
+     * \note This method is pessimistic, in that it will return FALSE in circumstances
+     * where it is not possible to guarantee that in 100% of cases the symbol will
+     * render pixel-identically to the other symbol. For instance, calling
+     * rendersIdenticallyTo() with the same symbol as \a other may
+     * return FALSE if the symbol contains data-defined overrides, such
+     * as those using feature attributes or expression variables.
+     *
+     * \since QGIS 4.0
+     */
+    bool rendersIdenticallyTo( const QgsSymbol *other ) const;
+
+    /**
      * Returns a deep copy of this symbol.
      *
      * Ownership is transferred to the caller.

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -254,6 +254,34 @@ QgsSymbolLayer::QgsSymbolLayer( Qgis::SymbolType type, bool locked )
 {
 }
 
+bool QgsSymbolLayer::rendersIdenticallyTo( const QgsSymbolLayer *other ) const
+{
+  if ( !other )
+    return false;
+
+  if ( layerType() != other->layerType() )
+    return false;
+
+  // TODO -- we could consider each property individually
+  if ( hasDataDefinedProperties() || other->hasDataDefinedProperties() )
+    return false;
+
+  // shortcut now that we know there's no randomness/changing overrides involved
+  if ( other == this )
+    return true;
+
+  if ( mEnabled != other->mEnabled
+       || mColor != other->mColor
+       || mRenderingPass != other->mRenderingPass
+
+       // TODO -- we could consider the actual settings of the paint effect
+       || ( mPaintEffect && !QgsPaintEffectRegistry::isDefaultStack( mPaintEffect.get() ) )
+       || ( other->mPaintEffect && !QgsPaintEffectRegistry::isDefaultStack( other->mPaintEffect.get() ) ) )
+    return false;
+
+  return properties() == other->properties();
+}
+
 Qgis::SymbolLayerFlags QgsSymbolLayer::flags() const
 {
   return Qgis::SymbolLayerFlags();

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -465,6 +465,21 @@ class CORE_EXPORT QgsSymbolLayer
     virtual bool isCompatibleWithSymbol( QgsSymbol *symbol ) const;
 
     /**
+     * Returns TRUE if this symbol layer will always render identically
+     * to an \a other symbol layer.
+     *
+     * \note This method is pessimistic, in that it will return FALSE in circumstances
+     * where it is not possible to guarantee that in 100% of cases the layer will
+     * render pixel-identically to the other layer. For instance, calling
+     * rendersIdenticallyTo() with the same symbol layer as \a other may
+     * return FALSE if the symbol layer contains data-defined overrides, such
+     * as those using feature attributes or expression variables.
+     *
+     * \since QGIS 4.0
+     */
+    virtual bool rendersIdenticallyTo( const QgsSymbolLayer *other ) const;
+
+    /**
      * Returns TRUE if the symbol layer rendering can cause visible artifacts across a single feature
      * when the feature is rendered as a series of adjacent map tiles each containing a portion of the feature's geometry.
      *

--- a/tests/src/python/test_qgssymbol.py
+++ b/tests/src/python/test_qgssymbol.py
@@ -2121,6 +2121,101 @@ class TestQgsFillSymbol(QgisTestCase):
         s1 = QgsSymbol.defaultSymbol(Qgis.GeometryType.Point)
         self.assertEqual(s1.color().spec(), QColor.Spec.Cmyk)
 
+    def test_renders_identically_to(self):
+        symbol1 = QgsLineSymbol.createSimple({})
+
+        # simple tests
+        self.assertTrue(symbol1.rendersIdenticallyTo(symbol1))
+        self.assertTrue(symbol1.rendersIdenticallyTo(QgsLineSymbol.createSimple({})))
+
+        # type mismatches
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+
+        # extent buffer mismatch
+        symbol1 = QgsMarkerSymbol.createSimple({})
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        symbol2.setExtentBuffer(5)
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+        symbol1.setExtentBuffer(5)
+        self.assertTrue(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertTrue(symbol2.rendersIdenticallyTo(symbol1))
+        symbol1.setExtentBufferSizeUnit(Qgis.RenderUnit.Inches)
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+
+        # opacity mismatch
+        symbol1 = QgsMarkerSymbol.createSimple({})
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        symbol2.setOpacity(0.5)
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+
+        # render hint mismatch
+        symbol1 = QgsMarkerSymbol.createSimple({})
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        symbol2.setRenderHints(Qgis.SymbolRenderHint.IsSymbolLayerSubSymbol)
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+
+        # symbol flags mismatch
+        symbol1 = QgsMarkerSymbol.createSimple({})
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        symbol2.setFlags(Qgis.SymbolFlag.AffectsLabeling)
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+
+        # clip features mismatch
+        symbol1 = QgsMarkerSymbol.createSimple({})
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        symbol2.setClipFeaturesToExtent(False)
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+        symbol1.setClipFeaturesToExtent(False)
+        self.assertTrue(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertTrue(symbol2.rendersIdenticallyTo(symbol1))
+
+        # force rhr mismatch
+        symbol1 = QgsMarkerSymbol.createSimple({})
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        symbol2.setForceRHR(True)
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+
+        # buffer settings
+        symbol1 = QgsMarkerSymbol.createSimple({})
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        buffer_settings = QgsSymbolBufferSettings()
+        buffer_settings.setEnabled(True)
+        buffer_settings.setSize(3)
+        symbol2.setBufferSettings(buffer_settings)
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+
+        # animation settings
+        symbol1 = QgsMarkerSymbol.createSimple({})
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        symbol2.animationSettings().setIsAnimated(True)
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+
+        # different symbol layer count
+        symbol1 = QgsMarkerSymbol.createSimple({})
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        symbol2.appendSymbolLayer(QgsSimpleMarkerSymbolLayer())
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+
+        # different symbol layer properties
+        symbol1 = QgsMarkerSymbol.createSimple({})
+        symbol1[0].setColor(QColor(255, 0, 255))
+        symbol2 = QgsMarkerSymbol.createSimple({})
+        symbol2[0].setColor(QColor(255, 0, 0))
+        self.assertFalse(symbol1.rendersIdenticallyTo(symbol2))
+        self.assertFalse(symbol2.rendersIdenticallyTo(symbol1))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgssymbollayer.py
+++ b/tests/src/python/test_qgssymbollayer.py
@@ -81,6 +81,8 @@ from qgis.core import (
     QgsVectorFieldSymbolLayer,
     QgsVectorLayer,
     QgsSymbolRenderContext,
+    QgsDropShadowEffect,
+    QgsInnerGlowEffect,
 )
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -1304,6 +1306,71 @@ class TestQgsSymbolLayer(QgisTestCase):
             renderHints=Qgis.SymbolRenderHint.ForceVectorRendering,
         )
         self.assertTrue(context.forceVectorRendering())
+
+    def test_renders_identically_to(self):
+        layer1 = QgsSimpleLineSymbolLayer()
+        layer2 = QgsSimpleMarkerSymbolLayer()
+
+        # simple tests
+        self.assertTrue(layer1.rendersIdenticallyTo(layer1))
+        self.assertTrue(layer1.rendersIdenticallyTo(QgsSimpleLineSymbolLayer()))
+        self.assertTrue(layer2.rendersIdenticallyTo(layer2))
+        self.assertTrue(layer2.rendersIdenticallyTo(QgsSimpleMarkerSymbolLayer()))
+
+        # type mismatches
+        self.assertFalse(layer1.rendersIdenticallyTo(layer2))
+        self.assertFalse(layer2.rendersIdenticallyTo(layer1))
+
+        # data defined properties
+        layer1 = QgsSimpleLineSymbolLayer()
+        layer2 = QgsSimpleLineSymbolLayer()
+        self.assertTrue(layer1.rendersIdenticallyTo(layer2))
+        # a data defined property should force a False return, as we are being pessimistic and don't currently
+        # have a means to check if the expression will always return the same result
+        layer1.setDataDefinedProperty(
+            QgsSymbolLayer.Property.StrokeColor, QgsProperty.fromExpression("@red")
+        )
+        self.assertFalse(layer1.rendersIdenticallyTo(layer2))
+
+        # one layer disabled
+        layer1 = QgsSimpleLineSymbolLayer()
+        layer2 = QgsSimpleLineSymbolLayer()
+        layer2.setEnabled(False)
+        self.assertFalse(layer1.rendersIdenticallyTo(layer2))
+        self.assertFalse(layer2.rendersIdenticallyTo(layer1))
+        layer1.setEnabled(False)
+        self.assertTrue(layer1.rendersIdenticallyTo(layer2))
+
+        # different color
+        layer1.setColor(QColor(255, 0, 0))
+        layer2.setColor(QColor(255, 255, 0))
+        self.assertFalse(layer1.rendersIdenticallyTo(layer2))
+        self.assertFalse(layer2.rendersIdenticallyTo(layer1))
+
+        # different render pass
+        layer1 = QgsSimpleLineSymbolLayer()
+        layer2 = QgsSimpleLineSymbolLayer()
+        layer2.setRenderingPass(5)
+        self.assertFalse(layer1.rendersIdenticallyTo(layer2))
+        self.assertFalse(layer2.rendersIdenticallyTo(layer1))
+
+        # paint effect. Currently we are pessimistic and treat all paint
+        # effects as different
+        layer1 = QgsSimpleLineSymbolLayer()
+        layer2 = QgsSimpleLineSymbolLayer()
+        layer2.setPaintEffect(QgsDropShadowEffect())
+        self.assertFalse(layer1.rendersIdenticallyTo(layer2))
+        self.assertFalse(layer2.rendersIdenticallyTo(layer1))
+        layer1.setPaintEffect(QgsInnerGlowEffect())
+        self.assertFalse(layer1.rendersIdenticallyTo(layer2))
+        self.assertFalse(layer2.rendersIdenticallyTo(layer1))
+
+        # different properties
+        layer1 = QgsSimpleLineSymbolLayer()
+        layer2 = QgsSimpleLineSymbolLayer()
+        layer2.setPenStyle(Qt.PenStyle.DashLine)
+        self.assertFalse(layer1.rendersIdenticallyTo(layer2))
+        self.assertFalse(layer2.rendersIdenticallyTo(layer1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These methods are pessimistic, in that they return false in circumstances where it is not possible to guarantee that in 100% of cases the layer will symbols will render pixel-identically to each other. For instance, calling rendersIdenticallyTo with the same symbol as another will return false if the symbol contains data-defined overrides, such as those using feature attributes or expression variables (where we cannot determine in advance that the render result will be identical).