### PR TITLE
Split off QgsLayerTreeView to QgsLayerTreeViewBase

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgslayertreeview.py
+++ b/python/PyQt6/gui/auto_additions/qgslayertreeview.py
@@ -17,3 +17,7 @@ try:
     QgsLayerTreeViewMenuProvider.__group__ = ['layertree']
 except (NameError, AttributeError):
     pass
+try:
+    QgsLayerTreeViewBase.__group__ = ['layertree']
+except (NameError, AttributeError):
+    pass

--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -198,6 +198,176 @@ view's proxy model to the source model.
 .. versionadded:: 3.18
 %End
 
+    QgsLayerTreeNode *currentNode() const;
+%Docstring
+Returns the current node.
+
+May be ``None``.
+%End
+
+    QList<QgsLayerTreeNode *> selectedNodes( bool skipInternal = false ) const;
+%Docstring
+Returns the list of selected layer tree nodes.
+
+:param skipInternal: If ``True``, will ignore nodes which have an
+                     ancestor in the selection
+
+.. seealso:: :py:func:`selectedLayerNodes`
+
+.. seealso:: :py:func:`selectedLegendNodes`
+
+.. seealso:: :py:func:`selectedLayers`
+%End
+
+    QgsMapLayer *currentLayer() const;
+%Docstring
+Returns the currently selected layer, or ``None`` if no layers is
+selected.
+
+.. seealso:: :py:func:`setCurrentLayer`
+%End
+
+    QgsMapLayer *layerForIndex( const QModelIndex &index ) const;
+%Docstring
+Returns the map layer corresponding to a view ``index``.
+
+This method correctly accounts for proxy models set on the tree view.
+
+Returns ``None`` if the index does not correspond to a map layer.
+%End
+
+    QgsLayerTreeGroup *currentGroupNode() const;
+%Docstring
+Returns the current group node.
+
+If a layer is the current node, the function will return the layer's
+parent group.
+
+May be ``None``.
+%End
+
+    QList<QgsLayerTreeLayer *> selectedLayerNodes() const;
+%Docstring
+Returns the list of selected nodes filtered to just layer nodes
+(:py:class:`QgsLayerTreeLayer`).
+
+.. seealso:: :py:func:`selectedNodes`
+
+.. seealso:: :py:func:`selectedLayers`
+
+.. seealso:: :py:func:`selectedLegendNodes`
+%End
+
+    QList<QgsMapLayer *> selectedLayers() const;
+%Docstring
+Returns the list of selected layers.
+
+.. seealso:: :py:func:`selectedNodes`
+
+.. seealso:: :py:func:`selectedLayerNodes`
+
+.. seealso:: :py:func:`selectedLegendNodes`
+%End
+
+    QModelIndex legendNode2index( QgsLayerTreeModelLegendNode *legendNode );
+%Docstring
+Returns the view index for a given legend node.
+
+If the legend node does not belong to the layer tree, the result is
+undefined.
+
+If the legend node belongs to the tree but it is filtered out, an
+invalid model index is returned.
+
+Unlike :py:func:`QgsLayerTreeModel.legendNode2index()`, calling this
+method correctly accounts for mapping the view indexes through the
+view's proxy model to the source model.
+
+.. versionadded:: 3.18
+%End
+
+    QModelIndex legendNode2sourceIndex( QgsLayerTreeModelLegendNode *legendNode );
+%Docstring
+Returns the layer tree source model index for a given legend node.
+
+If the legend node does not belong to the layer tree, the result is
+undefined.
+
+If the legend node belongs to the tree but it is filtered out, an
+invalid model index is returned.
+
+.. warning::
+
+   The returned index belongs the underlying layer tree model, and care should be taken
+   to correctly map to a proxy index if a proxy model is in use.
+
+.. seealso:: :py:func:`legendNode2index`
+
+.. versionadded:: 3.18
+%End
+
+    void setCurrentNode( QgsLayerTreeNode *node );
+%Docstring
+Sets the currently selected ``node``.
+
+If ``node`` is ``None`` then all nodes will be deselected.
+
+.. seealso:: :py:func:`currentNode`
+
+.. versionadded:: 3.40
+%End
+
+    void setCurrentLayer( QgsMapLayer *layer );
+%Docstring
+Sets the currently selected ``layer``.
+
+If ``layer`` is ``None`` then all layers will be deselected.
+
+.. seealso:: :py:func:`currentLayer`
+%End
+
+    QgsLayerTreeModelLegendNode *currentLegendNode() const;
+%Docstring
+Gets current legend node. May be ``None`` if current node is not a
+legend node.
+%End
+
+    QList<QgsLayerTreeModelLegendNode *> selectedLegendNodes() const;
+%Docstring
+Returns the list of selected legend nodes.
+
+.. seealso:: :py:func:`selectedNodes`
+
+.. seealso:: :py:func:`selectedLayerNodes`
+
+.. versionadded:: 3.32
+%End
+
+    QList<QgsMapLayer *> selectedLayersRecursive() const;
+%Docstring
+Gets list of selected layers, including those that are not directly
+selected, but their ancestor groups is selected. If we have a group with
+two layers L1, L2 and just the group node is selected, this method
+returns L1 and L2, while :py:func:`~QgsLayerTreeViewBase.selectedLayers`
+returns an empty list.
+
+.. versionadded:: 3.4
+%End
+
+  public slots:
+
+    void expandAllNodes();
+%Docstring
+Enhancement of QTreeView.expandAll() that also records expanded state in
+layer tree nodes
+%End
+
+    void collapseAllNodes();
+%Docstring
+Enhancement of QTreeView.collapseAll() that also records expanded state
+in layer tree nodes
+%End
+
   protected:
     void updateExpandedStateFromNode( QgsLayerTreeNode *node );
 %Docstring
@@ -307,30 +477,6 @@ the view.
 .. versionadded:: 3.18
 %End
 
-    QModelIndex legendNode2index( QgsLayerTreeModelLegendNode *legendNode );
-%Docstring
-Returns proxy model index for a given legend node. If the legend node
-does not belong to the layer tree, the result is undefined. If the
-legend node is belongs to the tree but it is filtered out, invalid model
-index is returned.
-
-Unlike :py:func:`QgsLayerTreeModel.legendNode2index()`, calling this
-method correctly accounts for mapping the view indexes through the
-view's proxy model to the source model.
-
-.. versionadded:: 3.18
-%End
-
-    QModelIndex legendNode2sourceIndex( QgsLayerTreeModelLegendNode *legendNode );
-%Docstring
-Returns index for a given legend node. If the legend node does not
-belong to the layer tree, the result is undefined. If the legend node is
-belongs to the tree but it is filtered out, invalid model index is
-returned.
-
-.. versionadded:: 3.18
-%End
-
     QgsLayerTreeViewDefaultActions *defaultActions();
 %Docstring
 Gets access to the default actions that may be used with the tree view
@@ -345,14 +491,6 @@ Sets provider for context menu. Takes ownership of the instance
 Returns pointer to the context menu provider. May be ``None``
 %End
 
-    QgsMapLayer *currentLayer() const;
-%Docstring
-Returns the currently selected layer, or ``None`` if no layers is
-selected.
-
-.. seealso:: :py:func:`setCurrentLayer`
-%End
-
     void setLayerVisible( QgsMapLayer *layer, bool visible );
 %Docstring
 Convenience methods which sets the visible state of the specified map
@@ -361,101 +499,6 @@ Convenience methods which sets the visible state of the specified map
 .. seealso:: :py:func:`QgsLayerTreeNode.setItemVisibilityChecked`
 
 .. versionadded:: 3.10
-%End
-
-    void setCurrentNode( QgsLayerTreeNode *node );
-%Docstring
-Sets the currently selected ``node``.
-
-If ``node`` is ``None`` then all nodes will be deselected.
-
-.. seealso:: :py:func:`currentNode`
-
-.. versionadded:: 3.40
-%End
-
-    void setCurrentLayer( QgsMapLayer *layer );
-%Docstring
-Sets the currently selected ``layer``.
-
-If ``layer`` is ``None`` then all layers will be deselected.
-
-.. seealso:: :py:func:`currentLayer`
-%End
-
-    QgsLayerTreeNode *currentNode() const;
-%Docstring
-Gets current node. May be ``None``
-%End
-    QgsLayerTreeGroup *currentGroupNode() const;
-%Docstring
-Gets current group node. If a layer is current node, the function will
-return parent group. May be ``None``.
-%End
-
-    QgsLayerTreeModelLegendNode *currentLegendNode() const;
-%Docstring
-Gets current legend node. May be ``None`` if current node is not a
-legend node.
-%End
-
-    QList<QgsLayerTreeNode *> selectedNodes( bool skipInternal = false ) const;
-%Docstring
-Returns the list of selected layer tree nodes.
-
-:param skipInternal: If ``True``, will ignore nodes which have an
-                     ancestor in the selection
-
-.. seealso:: :py:func:`selectedLayerNodes`
-
-.. seealso:: :py:func:`selectedLegendNodes`
-
-.. seealso:: :py:func:`selectedLayers`
-%End
-
-    QList<QgsLayerTreeLayer *> selectedLayerNodes() const;
-%Docstring
-Returns the list of selected nodes filtered to just layer nodes
-(:py:class:`QgsLayerTreeLayer`).
-
-.. seealso:: :py:func:`selectedNodes`
-
-.. seealso:: :py:func:`selectedLayers`
-
-.. seealso:: :py:func:`selectedLegendNodes`
-%End
-
-    QList<QgsMapLayer *> selectedLayers() const;
-%Docstring
-Returns the list of selected layers.
-
-.. seealso:: :py:func:`selectedNodes`
-
-.. seealso:: :py:func:`selectedLayerNodes`
-
-.. seealso:: :py:func:`selectedLegendNodes`
-%End
-
-    QList<QgsLayerTreeModelLegendNode *> selectedLegendNodes() const;
-%Docstring
-Returns the list of selected legend nodes.
-
-.. seealso:: :py:func:`selectedNodes`
-
-.. seealso:: :py:func:`selectedLayerNodes`
-
-.. versionadded:: 3.32
-%End
-
-    QList<QgsMapLayer *> selectedLayersRecursive() const;
-%Docstring
-Gets list of selected layers, including those that are not directly
-selected, but their ancestor groups is selected. If we have a group with
-two layers L1, L2 and just the group node is selected, this method
-returns L1 and L2, while :py:func:`~QgsLayerTreeView.selectedLayers`
-returns an empty list.
-
-.. versionadded:: 3.4
 %End
 
     void addIndicator( QgsLayerTreeNode *node, QgsLayerTreeViewIndicator *indicator );
@@ -534,18 +577,6 @@ Force refresh of layer symbology. Normally not needed as the changes of
 layer's renderer are monitored by the model
 %End
 
-    void expandAllNodes();
-%Docstring
-Enhancement of QTreeView.expandAll() that also records expanded state in
-layer tree nodes
-%End
-
-    void collapseAllNodes();
-%Docstring
-Enhancement of QTreeView.collapseAll() that also records expanded state
-in layer tree nodes
-%End
-
     void setLayerMarkWidth( int width );
 %Docstring
 Set width of contextual menu mark, at right of layer node items.
@@ -602,8 +633,6 @@ Allows customization of the menu.
   protected:
     virtual void contextMenuEvent( QContextMenuEvent *event );
 
-
-    QgsMapLayer *layerForIndex( const QModelIndex &index ) const;
 
     virtual void mouseDoubleClickEvent( QMouseEvent *event );
 

--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -354,6 +354,11 @@ returns an empty list.
 .. versionadded:: 3.4
 %End
 
+    QgsLayerTreeViewDefaultActions *defaultActions();
+%Docstring
+Gets access to the default actions that may be used with the tree view
+%End
+
   public slots:
 
     void expandAllNodes();
@@ -391,6 +396,7 @@ This method correctly accounts for proxy models set on the tree view.
 
 .. seealso:: :py:func:`viewIndexToLayerTreeModelIndex`
 %End
+
 
   protected slots:
 
@@ -475,11 +481,6 @@ This can be used to set filters controlling which layers are shown in
 the view.
 
 .. versionadded:: 3.18
-%End
-
-    QgsLayerTreeViewDefaultActions *defaultActions();
-%Docstring
-Gets access to the default actions that may be used with the tree view
 %End
 
     void setMenuProvider( QgsLayerTreeViewMenuProvider *menuProvider /Transfer/ );

--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -85,7 +85,164 @@ Returns ``True`` if the specified ``node`` should be shown.
 };
 
 
-class QgsLayerTreeView : QTreeView
+class QgsLayerTreeViewBase : QTreeView
+{
+%Docstring(signature="appended")
+Base class for QTreeView widgets which display a layer tree.
+
+The view updates expanded state of layer tree nodes and also listens to
+changes to expanded states in the layer tree.
+
+.. warning::
+
+   Subclasses must take care to call both :py:func:`~setLayerTreeModel` and QTreeView.setModel()
+   in order to have a fully functional tree view. This is by design, as it permits use of
+   a custom proxy model in the view.
+
+.. seealso:: :py:class:`QgsLayerTreeView`
+
+.. versionadded:: 4.0
+%End
+
+%TypeHeaderCode
+#include "qgslayertreeview.h"
+%End
+  public:
+    explicit QgsLayerTreeViewBase( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsLayerTreeViewBase
+%End
+    ~QgsLayerTreeViewBase();
+
+    void setLayerTreeModel( QgsLayerTreeModel *model );
+%Docstring
+Associates a layer tree model with the view.
+
+.. warning::
+
+   This does NOT explicitly set the view's model, and a subsequent call
+   to QTreeView.setModel() must be made. This is by design, as it permits use of
+   a custom proxy model in the view.
+
+.. seealso:: :py:func:`layerTreeModel`
+%End
+
+    QgsLayerTreeModel *layerTreeModel() const;
+%Docstring
+Returns the associated layer tree model.
+
+.. seealso:: :py:func:`setLayerTreeModel`
+%End
+
+    QgsLayerTreeNode *index2node( const QModelIndex &index ) const;
+%Docstring
+Returns the layer tree node for given view ``index``.
+
+Returns root node for an invalid index.
+
+Returns ``None`` if index does not refer to a layer tree node (e.g. it
+is a legend node).
+
+Unlike :py:func:`QgsLayerTreeViewBase.index2Node()`, calling this method
+correctly accounts for mapping the view indexes through the view's proxy
+model to the source model.
+
+.. seealso:: :py:func:`node2index`
+
+.. versionadded:: 3.18
+%End
+
+    QModelIndex node2index( QgsLayerTreeNode *node ) const;
+%Docstring
+Returns the view model index for a given ``node``.
+
+If the ``node`` does not belong to the layer tree, the result is
+undefined.
+
+Unlike :py:func:`QgsLayerTreeModel.node2index()`, calling this method
+correctly accounts for mapping the view indexes through the view's proxy
+model to the source model.
+
+.. seealso:: :py:func:`index2node`
+
+.. versionadded:: 3.18
+%End
+
+    QModelIndex node2sourceIndex( QgsLayerTreeNode *node ) const;
+%Docstring
+Returns the layer tree source model index for a given ``node``.
+
+If the ``node`` does not belong to the layer tree, the result is
+undefined.
+
+.. warning::
+
+   The returned index belongs the underlying layer tree model, and care should be taken
+   to correctly map to a proxy index if a proxy model is in use.
+
+.. seealso:: :py:func:`node2index`
+
+.. versionadded:: 3.18
+%End
+
+    QgsLayerTreeModelLegendNode *index2legendNode( const QModelIndex &index ) const;
+%Docstring
+Returns legend node for given view ``index``.
+
+Returns ``None`` for invalid index.
+
+Unlike :py:func:`QgsLayerTreeModel.index2legendNode()`, calling this
+method correctly accounts for mapping the view indexes through the
+view's proxy model to the source model.
+
+.. versionadded:: 3.18
+%End
+
+  protected:
+    void updateExpandedStateFromNode( QgsLayerTreeNode *node );
+%Docstring
+Updates the expanded state from a ``node``.
+%End
+
+    QModelIndex viewIndexToLayerTreeModelIndex( const QModelIndex &index ) const;
+%Docstring
+Returns the view index corresponding with a layer tree model ``index``.
+
+This method correctly accounts for proxy models set on the tree view.
+
+.. seealso:: :py:func:`layerTreeModelIndexToViewIndex`
+%End
+
+    QModelIndex layerTreeModelIndexToViewIndex( const QModelIndex &index ) const;
+%Docstring
+Returns the layer tree model index corresponding with a view ``index``.
+
+This method correctly accounts for proxy models set on the tree view.
+
+.. seealso:: :py:func:`viewIndexToLayerTreeModelIndex`
+%End
+
+  protected slots:
+
+    void updateExpandedStateToNode( const QModelIndex &index );
+%Docstring
+Stores the expanded state to a node with matching ``index``.
+%End
+
+    void onExpandedChanged( QgsLayerTreeNode *node, bool expanded );
+%Docstring
+Called when the expanded state changes for a node.
+%End
+
+    void onModelReset();
+%Docstring
+Called when the model is reset.
+%End
+
+};
+
+
+class QgsLayerTreeView : QgsLayerTreeViewBase
 {
 %Docstring(signature="appended")
 Extends QTreeView and provides additional functionality when working
@@ -140,64 +297,12 @@ Use this method when a custom proxy model is required.
 .. versionadded:: 4.0
 %End
 
-    QgsLayerTreeModel *layerTreeModel() const;
-%Docstring
-Gets access to the model casted to :py:class:`QgsLayerTreeModel`
-%End
-
     QgsLayerTreeProxyModel *proxyModel() const;
 %Docstring
 Returns the proxy model used by the view.
 
 This can be used to set filters controlling which layers are shown in
 the view.
-
-.. versionadded:: 3.18
-%End
-
-    QgsLayerTreeNode *index2node( const QModelIndex &index ) const;
-%Docstring
-Returns layer tree node for given proxy model tree ``index``. Returns
-root node for invalid index. Returns ``None`` if index does not refer to
-a layer tree node (e.g. it is a legend node)
-
-Unlike :py:func:`QgsLayerTreeModel.index2Node()`, calling this method
-correctly accounts for mapping the view indexes through the view's proxy
-model to the source model.
-
-.. versionadded:: 3.18
-%End
-
-    QModelIndex node2index( QgsLayerTreeNode *node ) const;
-%Docstring
-Returns proxy model index for a given node. If the node does not belong
-to the layer tree, the result is undefined
-
-Unlike :py:func:`QgsLayerTreeModel.node2index()`, calling this method
-correctly accounts for mapping the view indexes through the view's proxy
-model to the source model.
-
-.. versionadded:: 3.18
-%End
-
-
-    QModelIndex node2sourceIndex( QgsLayerTreeNode *node ) const;
-%Docstring
-Returns source model index for a given node. If the node does not belong
-to the layer tree, the result is undefined
-
-.. versionadded:: 3.18
-%End
-
-
-    QgsLayerTreeModelLegendNode *index2legendNode( const QModelIndex &index ) const;
-%Docstring
-Returns legend node for given proxy model tree ``index``. Returns
-``None`` for invalid index
-
-Unlike :py:func:`QgsLayerTreeModel.index2legendNode()`, calling this
-method correctly accounts for mapping the view indexes through the
-view's proxy model to the source model.
 
 .. versionadded:: 3.18
 %End
@@ -498,8 +603,6 @@ Allows customization of the menu.
     virtual void contextMenuEvent( QContextMenuEvent *event );
 
 
-    void updateExpandedStateFromNode( QgsLayerTreeNode *node );
-
     QgsMapLayer *layerForIndex( const QModelIndex &index ) const;
 
     virtual void mouseDoubleClickEvent( QMouseEvent *event );
@@ -524,11 +627,7 @@ Allows customization of the menu.
     void modelRowsInserted( const QModelIndex &index, int start, int end );
     void modelRowsRemoved();
 
-    void updateExpandedStateToNode( const QModelIndex &index );
-
     void onCurrentChanged();
-    void onExpandedChanged( QgsLayerTreeNode *node, bool expanded );
-    void onModelReset();
 
   protected:
 

--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -25,6 +25,12 @@ tree view.
 %End
   public:
     QgsLayerTreeViewDefaultActions( QgsLayerTreeViewBase *view );
+%Docstring
+Constructor for QgsLayerTreeViewDefaultActions, creating actions for a
+``view``.
+
+The object will be parented to the specified ``view``.
+%End
 
     QAction *actionAddGroup( QObject *parent = 0 ) /Factory/;
     QAction *actionRemoveGroupOrLayer( QObject *parent = 0 ) /Factory/;

--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -24,7 +24,7 @@ tree view.
 #include "qgslayertreeviewdefaultactions.h"
 %End
   public:
-    QgsLayerTreeViewDefaultActions( QgsLayerTreeView *view );
+    QgsLayerTreeViewDefaultActions( QgsLayerTreeViewBase *view );
 
     QAction *actionAddGroup( QObject *parent = 0 ) /Factory/;
     QAction *actionRemoveGroupOrLayer( QObject *parent = 0 ) /Factory/;

--- a/python/gui/auto_additions/qgslayertreeview.py
+++ b/python/gui/auto_additions/qgslayertreeview.py
@@ -17,3 +17,7 @@ try:
     QgsLayerTreeViewMenuProvider.__group__ = ['layertree']
 except (NameError, AttributeError):
     pass
+try:
+    QgsLayerTreeViewBase.__group__ = ['layertree']
+except (NameError, AttributeError):
+    pass

--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -198,6 +198,176 @@ view's proxy model to the source model.
 .. versionadded:: 3.18
 %End
 
+    QgsLayerTreeNode *currentNode() const;
+%Docstring
+Returns the current node.
+
+May be ``None``.
+%End
+
+    QList<QgsLayerTreeNode *> selectedNodes( bool skipInternal = false ) const;
+%Docstring
+Returns the list of selected layer tree nodes.
+
+:param skipInternal: If ``True``, will ignore nodes which have an
+                     ancestor in the selection
+
+.. seealso:: :py:func:`selectedLayerNodes`
+
+.. seealso:: :py:func:`selectedLegendNodes`
+
+.. seealso:: :py:func:`selectedLayers`
+%End
+
+    QgsMapLayer *currentLayer() const;
+%Docstring
+Returns the currently selected layer, or ``None`` if no layers is
+selected.
+
+.. seealso:: :py:func:`setCurrentLayer`
+%End
+
+    QgsMapLayer *layerForIndex( const QModelIndex &index ) const;
+%Docstring
+Returns the map layer corresponding to a view ``index``.
+
+This method correctly accounts for proxy models set on the tree view.
+
+Returns ``None`` if the index does not correspond to a map layer.
+%End
+
+    QgsLayerTreeGroup *currentGroupNode() const;
+%Docstring
+Returns the current group node.
+
+If a layer is the current node, the function will return the layer's
+parent group.
+
+May be ``None``.
+%End
+
+    QList<QgsLayerTreeLayer *> selectedLayerNodes() const;
+%Docstring
+Returns the list of selected nodes filtered to just layer nodes
+(:py:class:`QgsLayerTreeLayer`).
+
+.. seealso:: :py:func:`selectedNodes`
+
+.. seealso:: :py:func:`selectedLayers`
+
+.. seealso:: :py:func:`selectedLegendNodes`
+%End
+
+    QList<QgsMapLayer *> selectedLayers() const;
+%Docstring
+Returns the list of selected layers.
+
+.. seealso:: :py:func:`selectedNodes`
+
+.. seealso:: :py:func:`selectedLayerNodes`
+
+.. seealso:: :py:func:`selectedLegendNodes`
+%End
+
+    QModelIndex legendNode2index( QgsLayerTreeModelLegendNode *legendNode );
+%Docstring
+Returns the view index for a given legend node.
+
+If the legend node does not belong to the layer tree, the result is
+undefined.
+
+If the legend node belongs to the tree but it is filtered out, an
+invalid model index is returned.
+
+Unlike :py:func:`QgsLayerTreeModel.legendNode2index()`, calling this
+method correctly accounts for mapping the view indexes through the
+view's proxy model to the source model.
+
+.. versionadded:: 3.18
+%End
+
+    QModelIndex legendNode2sourceIndex( QgsLayerTreeModelLegendNode *legendNode );
+%Docstring
+Returns the layer tree source model index for a given legend node.
+
+If the legend node does not belong to the layer tree, the result is
+undefined.
+
+If the legend node belongs to the tree but it is filtered out, an
+invalid model index is returned.
+
+.. warning::
+
+   The returned index belongs the underlying layer tree model, and care should be taken
+   to correctly map to a proxy index if a proxy model is in use.
+
+.. seealso:: :py:func:`legendNode2index`
+
+.. versionadded:: 3.18
+%End
+
+    void setCurrentNode( QgsLayerTreeNode *node );
+%Docstring
+Sets the currently selected ``node``.
+
+If ``node`` is ``None`` then all nodes will be deselected.
+
+.. seealso:: :py:func:`currentNode`
+
+.. versionadded:: 3.40
+%End
+
+    void setCurrentLayer( QgsMapLayer *layer );
+%Docstring
+Sets the currently selected ``layer``.
+
+If ``layer`` is ``None`` then all layers will be deselected.
+
+.. seealso:: :py:func:`currentLayer`
+%End
+
+    QgsLayerTreeModelLegendNode *currentLegendNode() const;
+%Docstring
+Gets current legend node. May be ``None`` if current node is not a
+legend node.
+%End
+
+    QList<QgsLayerTreeModelLegendNode *> selectedLegendNodes() const;
+%Docstring
+Returns the list of selected legend nodes.
+
+.. seealso:: :py:func:`selectedNodes`
+
+.. seealso:: :py:func:`selectedLayerNodes`
+
+.. versionadded:: 3.32
+%End
+
+    QList<QgsMapLayer *> selectedLayersRecursive() const;
+%Docstring
+Gets list of selected layers, including those that are not directly
+selected, but their ancestor groups is selected. If we have a group with
+two layers L1, L2 and just the group node is selected, this method
+returns L1 and L2, while :py:func:`~QgsLayerTreeViewBase.selectedLayers`
+returns an empty list.
+
+.. versionadded:: 3.4
+%End
+
+  public slots:
+
+    void expandAllNodes();
+%Docstring
+Enhancement of QTreeView.expandAll() that also records expanded state in
+layer tree nodes
+%End
+
+    void collapseAllNodes();
+%Docstring
+Enhancement of QTreeView.collapseAll() that also records expanded state
+in layer tree nodes
+%End
+
   protected:
     void updateExpandedStateFromNode( QgsLayerTreeNode *node );
 %Docstring
@@ -307,30 +477,6 @@ the view.
 .. versionadded:: 3.18
 %End
 
-    QModelIndex legendNode2index( QgsLayerTreeModelLegendNode *legendNode );
-%Docstring
-Returns proxy model index for a given legend node. If the legend node
-does not belong to the layer tree, the result is undefined. If the
-legend node is belongs to the tree but it is filtered out, invalid model
-index is returned.
-
-Unlike :py:func:`QgsLayerTreeModel.legendNode2index()`, calling this
-method correctly accounts for mapping the view indexes through the
-view's proxy model to the source model.
-
-.. versionadded:: 3.18
-%End
-
-    QModelIndex legendNode2sourceIndex( QgsLayerTreeModelLegendNode *legendNode );
-%Docstring
-Returns index for a given legend node. If the legend node does not
-belong to the layer tree, the result is undefined. If the legend node is
-belongs to the tree but it is filtered out, invalid model index is
-returned.
-
-.. versionadded:: 3.18
-%End
-
     QgsLayerTreeViewDefaultActions *defaultActions();
 %Docstring
 Gets access to the default actions that may be used with the tree view
@@ -345,14 +491,6 @@ Sets provider for context menu. Takes ownership of the instance
 Returns pointer to the context menu provider. May be ``None``
 %End
 
-    QgsMapLayer *currentLayer() const;
-%Docstring
-Returns the currently selected layer, or ``None`` if no layers is
-selected.
-
-.. seealso:: :py:func:`setCurrentLayer`
-%End
-
     void setLayerVisible( QgsMapLayer *layer, bool visible );
 %Docstring
 Convenience methods which sets the visible state of the specified map
@@ -361,101 +499,6 @@ Convenience methods which sets the visible state of the specified map
 .. seealso:: :py:func:`QgsLayerTreeNode.setItemVisibilityChecked`
 
 .. versionadded:: 3.10
-%End
-
-    void setCurrentNode( QgsLayerTreeNode *node );
-%Docstring
-Sets the currently selected ``node``.
-
-If ``node`` is ``None`` then all nodes will be deselected.
-
-.. seealso:: :py:func:`currentNode`
-
-.. versionadded:: 3.40
-%End
-
-    void setCurrentLayer( QgsMapLayer *layer );
-%Docstring
-Sets the currently selected ``layer``.
-
-If ``layer`` is ``None`` then all layers will be deselected.
-
-.. seealso:: :py:func:`currentLayer`
-%End
-
-    QgsLayerTreeNode *currentNode() const;
-%Docstring
-Gets current node. May be ``None``
-%End
-    QgsLayerTreeGroup *currentGroupNode() const;
-%Docstring
-Gets current group node. If a layer is current node, the function will
-return parent group. May be ``None``.
-%End
-
-    QgsLayerTreeModelLegendNode *currentLegendNode() const;
-%Docstring
-Gets current legend node. May be ``None`` if current node is not a
-legend node.
-%End
-
-    QList<QgsLayerTreeNode *> selectedNodes( bool skipInternal = false ) const;
-%Docstring
-Returns the list of selected layer tree nodes.
-
-:param skipInternal: If ``True``, will ignore nodes which have an
-                     ancestor in the selection
-
-.. seealso:: :py:func:`selectedLayerNodes`
-
-.. seealso:: :py:func:`selectedLegendNodes`
-
-.. seealso:: :py:func:`selectedLayers`
-%End
-
-    QList<QgsLayerTreeLayer *> selectedLayerNodes() const;
-%Docstring
-Returns the list of selected nodes filtered to just layer nodes
-(:py:class:`QgsLayerTreeLayer`).
-
-.. seealso:: :py:func:`selectedNodes`
-
-.. seealso:: :py:func:`selectedLayers`
-
-.. seealso:: :py:func:`selectedLegendNodes`
-%End
-
-    QList<QgsMapLayer *> selectedLayers() const;
-%Docstring
-Returns the list of selected layers.
-
-.. seealso:: :py:func:`selectedNodes`
-
-.. seealso:: :py:func:`selectedLayerNodes`
-
-.. seealso:: :py:func:`selectedLegendNodes`
-%End
-
-    QList<QgsLayerTreeModelLegendNode *> selectedLegendNodes() const;
-%Docstring
-Returns the list of selected legend nodes.
-
-.. seealso:: :py:func:`selectedNodes`
-
-.. seealso:: :py:func:`selectedLayerNodes`
-
-.. versionadded:: 3.32
-%End
-
-    QList<QgsMapLayer *> selectedLayersRecursive() const;
-%Docstring
-Gets list of selected layers, including those that are not directly
-selected, but their ancestor groups is selected. If we have a group with
-two layers L1, L2 and just the group node is selected, this method
-returns L1 and L2, while :py:func:`~QgsLayerTreeView.selectedLayers`
-returns an empty list.
-
-.. versionadded:: 3.4
 %End
 
     void addIndicator( QgsLayerTreeNode *node, QgsLayerTreeViewIndicator *indicator );
@@ -534,18 +577,6 @@ Force refresh of layer symbology. Normally not needed as the changes of
 layer's renderer are monitored by the model
 %End
 
-    void expandAllNodes();
-%Docstring
-Enhancement of QTreeView.expandAll() that also records expanded state in
-layer tree nodes
-%End
-
-    void collapseAllNodes();
-%Docstring
-Enhancement of QTreeView.collapseAll() that also records expanded state
-in layer tree nodes
-%End
-
     void setLayerMarkWidth( int width );
 %Docstring
 Set width of contextual menu mark, at right of layer node items.
@@ -602,8 +633,6 @@ Allows customization of the menu.
   protected:
     virtual void contextMenuEvent( QContextMenuEvent *event );
 
-
-    QgsMapLayer *layerForIndex( const QModelIndex &index ) const;
 
     virtual void mouseDoubleClickEvent( QMouseEvent *event );
 

--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -354,6 +354,11 @@ returns an empty list.
 .. versionadded:: 3.4
 %End
 
+    QgsLayerTreeViewDefaultActions *defaultActions();
+%Docstring
+Gets access to the default actions that may be used with the tree view
+%End
+
   public slots:
 
     void expandAllNodes();
@@ -391,6 +396,7 @@ This method correctly accounts for proxy models set on the tree view.
 
 .. seealso:: :py:func:`viewIndexToLayerTreeModelIndex`
 %End
+
 
   protected slots:
 
@@ -475,11 +481,6 @@ This can be used to set filters controlling which layers are shown in
 the view.
 
 .. versionadded:: 3.18
-%End
-
-    QgsLayerTreeViewDefaultActions *defaultActions();
-%Docstring
-Gets access to the default actions that may be used with the tree view
 %End
 
     void setMenuProvider( QgsLayerTreeViewMenuProvider *menuProvider /Transfer/ );

--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -85,7 +85,164 @@ Returns ``True`` if the specified ``node`` should be shown.
 };
 
 
-class QgsLayerTreeView : QTreeView
+class QgsLayerTreeViewBase : QTreeView
+{
+%Docstring(signature="appended")
+Base class for QTreeView widgets which display a layer tree.
+
+The view updates expanded state of layer tree nodes and also listens to
+changes to expanded states in the layer tree.
+
+.. warning::
+
+   Subclasses must take care to call both :py:func:`~setLayerTreeModel` and QTreeView.setModel()
+   in order to have a fully functional tree view. This is by design, as it permits use of
+   a custom proxy model in the view.
+
+.. seealso:: :py:class:`QgsLayerTreeView`
+
+.. versionadded:: 4.0
+%End
+
+%TypeHeaderCode
+#include "qgslayertreeview.h"
+%End
+  public:
+    explicit QgsLayerTreeViewBase( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsLayerTreeViewBase
+%End
+    ~QgsLayerTreeViewBase();
+
+    void setLayerTreeModel( QgsLayerTreeModel *model );
+%Docstring
+Associates a layer tree model with the view.
+
+.. warning::
+
+   This does NOT explicitly set the view's model, and a subsequent call
+   to QTreeView.setModel() must be made. This is by design, as it permits use of
+   a custom proxy model in the view.
+
+.. seealso:: :py:func:`layerTreeModel`
+%End
+
+    QgsLayerTreeModel *layerTreeModel() const;
+%Docstring
+Returns the associated layer tree model.
+
+.. seealso:: :py:func:`setLayerTreeModel`
+%End
+
+    QgsLayerTreeNode *index2node( const QModelIndex &index ) const;
+%Docstring
+Returns the layer tree node for given view ``index``.
+
+Returns root node for an invalid index.
+
+Returns ``None`` if index does not refer to a layer tree node (e.g. it
+is a legend node).
+
+Unlike :py:func:`QgsLayerTreeViewBase.index2Node()`, calling this method
+correctly accounts for mapping the view indexes through the view's proxy
+model to the source model.
+
+.. seealso:: :py:func:`node2index`
+
+.. versionadded:: 3.18
+%End
+
+    QModelIndex node2index( QgsLayerTreeNode *node ) const;
+%Docstring
+Returns the view model index for a given ``node``.
+
+If the ``node`` does not belong to the layer tree, the result is
+undefined.
+
+Unlike :py:func:`QgsLayerTreeModel.node2index()`, calling this method
+correctly accounts for mapping the view indexes through the view's proxy
+model to the source model.
+
+.. seealso:: :py:func:`index2node`
+
+.. versionadded:: 3.18
+%End
+
+    QModelIndex node2sourceIndex( QgsLayerTreeNode *node ) const;
+%Docstring
+Returns the layer tree source model index for a given ``node``.
+
+If the ``node`` does not belong to the layer tree, the result is
+undefined.
+
+.. warning::
+
+   The returned index belongs the underlying layer tree model, and care should be taken
+   to correctly map to a proxy index if a proxy model is in use.
+
+.. seealso:: :py:func:`node2index`
+
+.. versionadded:: 3.18
+%End
+
+    QgsLayerTreeModelLegendNode *index2legendNode( const QModelIndex &index ) const;
+%Docstring
+Returns legend node for given view ``index``.
+
+Returns ``None`` for invalid index.
+
+Unlike :py:func:`QgsLayerTreeModel.index2legendNode()`, calling this
+method correctly accounts for mapping the view indexes through the
+view's proxy model to the source model.
+
+.. versionadded:: 3.18
+%End
+
+  protected:
+    void updateExpandedStateFromNode( QgsLayerTreeNode *node );
+%Docstring
+Updates the expanded state from a ``node``.
+%End
+
+    QModelIndex viewIndexToLayerTreeModelIndex( const QModelIndex &index ) const;
+%Docstring
+Returns the view index corresponding with a layer tree model ``index``.
+
+This method correctly accounts for proxy models set on the tree view.
+
+.. seealso:: :py:func:`layerTreeModelIndexToViewIndex`
+%End
+
+    QModelIndex layerTreeModelIndexToViewIndex( const QModelIndex &index ) const;
+%Docstring
+Returns the layer tree model index corresponding with a view ``index``.
+
+This method correctly accounts for proxy models set on the tree view.
+
+.. seealso:: :py:func:`viewIndexToLayerTreeModelIndex`
+%End
+
+  protected slots:
+
+    void updateExpandedStateToNode( const QModelIndex &index );
+%Docstring
+Stores the expanded state to a node with matching ``index``.
+%End
+
+    void onExpandedChanged( QgsLayerTreeNode *node, bool expanded );
+%Docstring
+Called when the expanded state changes for a node.
+%End
+
+    void onModelReset();
+%Docstring
+Called when the model is reset.
+%End
+
+};
+
+
+class QgsLayerTreeView : QgsLayerTreeViewBase
 {
 %Docstring(signature="appended")
 Extends QTreeView and provides additional functionality when working
@@ -140,64 +297,12 @@ Use this method when a custom proxy model is required.
 .. versionadded:: 4.0
 %End
 
-    QgsLayerTreeModel *layerTreeModel() const;
-%Docstring
-Gets access to the model casted to :py:class:`QgsLayerTreeModel`
-%End
-
     QgsLayerTreeProxyModel *proxyModel() const;
 %Docstring
 Returns the proxy model used by the view.
 
 This can be used to set filters controlling which layers are shown in
 the view.
-
-.. versionadded:: 3.18
-%End
-
-    QgsLayerTreeNode *index2node( const QModelIndex &index ) const;
-%Docstring
-Returns layer tree node for given proxy model tree ``index``. Returns
-root node for invalid index. Returns ``None`` if index does not refer to
-a layer tree node (e.g. it is a legend node)
-
-Unlike :py:func:`QgsLayerTreeModel.index2Node()`, calling this method
-correctly accounts for mapping the view indexes through the view's proxy
-model to the source model.
-
-.. versionadded:: 3.18
-%End
-
-    QModelIndex node2index( QgsLayerTreeNode *node ) const;
-%Docstring
-Returns proxy model index for a given node. If the node does not belong
-to the layer tree, the result is undefined
-
-Unlike :py:func:`QgsLayerTreeModel.node2index()`, calling this method
-correctly accounts for mapping the view indexes through the view's proxy
-model to the source model.
-
-.. versionadded:: 3.18
-%End
-
-
-    QModelIndex node2sourceIndex( QgsLayerTreeNode *node ) const;
-%Docstring
-Returns source model index for a given node. If the node does not belong
-to the layer tree, the result is undefined
-
-.. versionadded:: 3.18
-%End
-
-
-    QgsLayerTreeModelLegendNode *index2legendNode( const QModelIndex &index ) const;
-%Docstring
-Returns legend node for given proxy model tree ``index``. Returns
-``None`` for invalid index
-
-Unlike :py:func:`QgsLayerTreeModel.index2legendNode()`, calling this
-method correctly accounts for mapping the view indexes through the
-view's proxy model to the source model.
 
 .. versionadded:: 3.18
 %End
@@ -498,8 +603,6 @@ Allows customization of the menu.
     virtual void contextMenuEvent( QContextMenuEvent *event );
 
 
-    void updateExpandedStateFromNode( QgsLayerTreeNode *node );
-
     QgsMapLayer *layerForIndex( const QModelIndex &index ) const;
 
     virtual void mouseDoubleClickEvent( QMouseEvent *event );
@@ -524,11 +627,7 @@ Allows customization of the menu.
     void modelRowsInserted( const QModelIndex &index, int start, int end );
     void modelRowsRemoved();
 
-    void updateExpandedStateToNode( const QModelIndex &index );
-
     void onCurrentChanged();
-    void onExpandedChanged( QgsLayerTreeNode *node, bool expanded );
-    void onModelReset();
 
   protected:
 

--- a/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -25,6 +25,12 @@ tree view.
 %End
   public:
     QgsLayerTreeViewDefaultActions( QgsLayerTreeViewBase *view );
+%Docstring
+Constructor for QgsLayerTreeViewDefaultActions, creating actions for a
+``view``.
+
+The object will be parented to the specified ``view``.
+%End
 
     QAction *actionAddGroup( QObject *parent = 0 ) /Factory/;
     QAction *actionRemoveGroupOrLayer( QObject *parent = 0 ) /Factory/;

--- a/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -24,7 +24,7 @@ tree view.
 #include "qgslayertreeviewdefaultactions.h"
 %End
   public:
-    QgsLayerTreeViewDefaultActions( QgsLayerTreeView *view );
+    QgsLayerTreeViewDefaultActions( QgsLayerTreeViewBase *view );
 
     QAction *actionAddGroup( QObject *parent = 0 ) /Factory/;
     QAction *actionRemoveGroupOrLayer( QObject *parent = 0 ) /Factory/;

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -179,7 +179,7 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( const QString &name )
   connect( mLayerTreeView, &QgsAppElevationProfileLayerTreeView::addLayers, this, &QgsElevationProfileWidget::addLayersInternal );
 
   connect( mLayerTreeView, &QAbstractItemView::doubleClicked, this, [this]( const QModelIndex &index ) {
-    if ( QgsMapLayer *layer = mLayerTreeView->indexToLayer( index ) )
+    if ( QgsMapLayer *layer = mLayerTreeView->layerForIndex( index ) )
     {
       QgisApp::instance()->showLayerProperties( layer, QStringLiteral( "mOptsPage_Elevation" ) );
     }
@@ -1247,7 +1247,7 @@ void QgsAppElevationProfileLayerTreeView::contextMenuEvent( QContextMenuEvent *e
   if ( !index.isValid() )
     setCurrentIndex( QModelIndex() );
 
-  if ( QgsMapLayer *layer = indexToLayer( index ) )
+  if ( QgsMapLayer *layer = layerForIndex( index ) )
   {
     QMenu *menu = new QMenu();
 

--- a/src/gui/elevation/qgselevationprofilelayertreeview.cpp
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.cpp
@@ -415,35 +415,21 @@ bool QgsElevationProfileLayerTreeProxyModel::filterAcceptsRow( int sourceRow, co
 
 
 QgsElevationProfileLayerTreeView::QgsElevationProfileLayerTreeView( QgsLayerTree *rootNode, QWidget *parent )
-  : QTreeView( parent )
+  : QgsLayerTreeViewBase( parent )
   , mLayerTree( rootNode )
 {
   mModel = new QgsElevationProfileLayerTreeModel( rootNode, this );
+
   connect( mModel, &QgsElevationProfileLayerTreeModel::addLayers, this, &QgsElevationProfileLayerTreeView::addLayers );
   mProxyModel = new QgsElevationProfileLayerTreeProxyModel( mModel, this );
 
-  setHeaderHidden( true );
-
-  setDragEnabled( true );
-  setAcceptDrops( true );
-  setDropIndicatorShown( true );
-  setExpandsOnDoubleClick( false );
-
-  // Ensure legend graphics are scrollable
-  header()->setStretchLastSection( false );
-  header()->setSectionResizeMode( QHeaderView::ResizeToContents );
-
-  // If vertically scrolling by item, legend graphics can get clipped
-  setVerticalScrollMode( QAbstractItemView::ScrollPerPixel );
-
-  setDefaultDropAction( Qt::MoveAction );
-
   setModel( mProxyModel );
+  setLayerTreeModel( mModel );
 }
 
 QgsMapLayer *QgsElevationProfileLayerTreeView::indexToLayer( const QModelIndex &index )
 {
-  if ( QgsLayerTreeNode *node = mModel->index2node( mProxyModel->mapToSource( index ) ) )
+  if ( QgsLayerTreeNode *node = index2node( index ) )
   {
     if ( QgsLayerTreeLayer *layerTreeLayerNode = mLayerTree->toLayer( node ) )
     {

--- a/src/gui/elevation/qgselevationprofilelayertreeview.cpp
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.cpp
@@ -427,18 +427,6 @@ QgsElevationProfileLayerTreeView::QgsElevationProfileLayerTreeView( QgsLayerTree
   setLayerTreeModel( mModel );
 }
 
-QgsMapLayer *QgsElevationProfileLayerTreeView::indexToLayer( const QModelIndex &index )
-{
-  if ( QgsLayerTreeNode *node = index2node( index ) )
-  {
-    if ( QgsLayerTreeLayer *layerTreeLayerNode = mLayerTree->toLayer( node ) )
-    {
-      return layerTreeLayerNode->layer();
-    }
-  }
-  return nullptr;
-}
-
 void QgsElevationProfileLayerTreeView::populateInitialLayers( QgsProject *project )
 {
   const QList<QgsMapLayer *> layers = project->layers<QgsMapLayer *>().toList();

--- a/src/gui/elevation/qgselevationprofilelayertreeview.h
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.h
@@ -123,11 +123,6 @@ class GUI_EXPORT QgsElevationProfileLayerTreeView : public QgsLayerTreeViewBase
     explicit QgsElevationProfileLayerTreeView( QgsLayerTree *rootNode, QWidget *parent = nullptr );
 
     /**
-     * Converts a view \a index to a map layer.
-     */
-    QgsMapLayer *indexToLayer( const QModelIndex &index );
-
-    /**
      * Initially populates the tree view using layers from a \a project, as well as sources from the source registry.
      */
     void populateInitialSources( QgsProject *project );

--- a/src/gui/elevation/qgselevationprofilelayertreeview.h
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.h
@@ -20,6 +20,7 @@
 
 #include "qgsconfig.h"
 #include "qgslayertreemodel.h"
+#include "qgslayertreeview.h"
 #include "qgis_gui.h"
 
 #include <QSortFilterProxyModel>
@@ -108,7 +109,7 @@ class GUI_EXPORT QgsElevationProfileLayerTreeProxyModel : public QSortFilterProx
  *
  * \since QGIS 3.30
  */
-class GUI_EXPORT QgsElevationProfileLayerTreeView : public QTreeView
+class GUI_EXPORT QgsElevationProfileLayerTreeView : public QgsLayerTreeViewBase
 {
     Q_OBJECT
 

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -433,6 +433,12 @@ void QgsLayerTreeViewBase::collapseAllNodes()
   collapseAll();
 }
 
+QgsLayerTreeViewDefaultActions *QgsLayerTreeViewBase::defaultActions()
+{
+  if ( !mDefaultActions )
+    mDefaultActions = new QgsLayerTreeViewDefaultActions( this );
+  return mDefaultActions;
+}
 
 //
 // QgsLayerTreeView
@@ -500,13 +506,6 @@ void QgsLayerTreeView::setModel( QgsLayerTreeModel *treeModel, QgsLayerTreeProxy
   connect( treeModel, &QAbstractItemModel::dataChanged, this, &QgsLayerTreeView::onDataChanged );
 
   //checkModel();
-}
-
-QgsLayerTreeViewDefaultActions *QgsLayerTreeView::defaultActions()
-{
-  if ( !mDefaultActions )
-    mDefaultActions = new QgsLayerTreeViewDefaultActions( this );
-  return mDefaultActions;
 }
 
 void QgsLayerTreeView::setMenuProvider( QgsLayerTreeViewMenuProvider *menuProvider )

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -337,6 +337,9 @@ class GUI_EXPORT QgsLayerTreeViewBase : public QTreeView
      */
     QList<QgsMapLayer *> selectedLayersRecursive() const;
 
+    //! Gets access to the default actions that may be used with the tree view
+    QgsLayerTreeViewDefaultActions *defaultActions();
+
   public slots:
 
     /**
@@ -372,6 +375,9 @@ class GUI_EXPORT QgsLayerTreeViewBase : public QTreeView
      * \see viewIndexToLayerTreeModelIndex()
      */
     QModelIndex layerTreeModelIndexToViewIndex( const QModelIndex &index ) const;
+
+    //! helper class with default actions. Lazily initialized.
+    QgsLayerTreeViewDefaultActions *mDefaultActions = nullptr;
 
   protected slots:
 
@@ -451,9 +457,6 @@ class GUI_EXPORT QgsLayerTreeView : public QgsLayerTreeViewBase
      * \since QGIS 3.18
      */
     QgsLayerTreeProxyModel *proxyModel() const;
-
-    //! Gets access to the default actions that may be used with the tree view
-    QgsLayerTreeViewDefaultActions *defaultActions();
 
     //! Sets provider for context menu. Takes ownership of the instance
     void setMenuProvider( QgsLayerTreeViewMenuProvider *menuProvider SIP_TRANSFER );
@@ -607,8 +610,6 @@ class GUI_EXPORT QgsLayerTreeView : public QgsLayerTreeViewBase
     void onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles );
 
   protected:
-    //! helper class with default actions. Lazily initialized.
-    QgsLayerTreeViewDefaultActions *mDefaultActions = nullptr;
     //! Context menu provider. Owned by the view.
     QgsLayerTreeViewMenuProvider *mMenuProvider = nullptr;
     //! Keeps track of current layer ID (to check when to emit signal about change of current layer)

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -204,6 +204,151 @@ class GUI_EXPORT QgsLayerTreeViewBase : public QTreeView
      */
     QgsLayerTreeModelLegendNode *index2legendNode( const QModelIndex &index ) const;
 
+    /**
+     * Returns the current node.
+     *
+     * May be NULLPTR.
+     */
+    QgsLayerTreeNode *currentNode() const;
+
+    /**
+     * Returns the list of selected layer tree nodes.
+     *
+     * \param skipInternal If TRUE, will ignore nodes which have an ancestor in the selection
+     *
+     * \see selectedLayerNodes()
+     * \see selectedLegendNodes()
+     * \see selectedLayers()
+     */
+    QList<QgsLayerTreeNode *> selectedNodes( bool skipInternal = false ) const;
+
+    /**
+     * Returns the currently selected layer, or NULLPTR if no layers is selected.
+     *
+     * \see setCurrentLayer()
+     */
+    QgsMapLayer *currentLayer() const;
+
+    /**
+     * Returns the map layer corresponding to a view \a index.
+     *
+     * This method correctly accounts for proxy models set on the tree view.
+     *
+     * Returns NULLPTR if the index does not correspond to a map layer.
+     */
+    QgsMapLayer *layerForIndex( const QModelIndex &index ) const;
+
+    /**
+     * Returns the current group node.
+     *
+     * If a layer is the current node, the function will return the layer's parent group.
+     *
+     * May be NULLPTR.
+     */
+    QgsLayerTreeGroup *currentGroupNode() const;
+
+    /**
+     * Returns the list of selected nodes filtered to just layer nodes (QgsLayerTreeLayer).
+     *
+     * \see selectedNodes()
+     * \see selectedLayers()
+     * \see selectedLegendNodes()
+     */
+    QList<QgsLayerTreeLayer *> selectedLayerNodes() const;
+
+    /**
+     * Returns the list of selected layers.
+     *
+     * \see selectedNodes()
+     * \see selectedLayerNodes()
+     * \see selectedLegendNodes()
+     */
+    QList<QgsMapLayer *> selectedLayers() const;
+
+    /**
+     * Returns the view index for a given legend node.
+     *
+     * If the legend node does not belong to the layer tree, the result is undefined.
+     *
+     * If the legend node belongs to the tree but it is filtered out, an invalid model index is returned.
+     *
+     * Unlike QgsLayerTreeModel::legendNode2index(), calling this method correctly accounts
+     * for mapping the view indexes through the view's proxy model to the source model.
+     *
+     * \since QGIS 3.18
+     */
+    QModelIndex legendNode2index( QgsLayerTreeModelLegendNode *legendNode );
+
+    /**
+     * Returns the layer tree source model index for a given legend node.
+     *
+     * If the legend node does not belong to the layer tree, the result is undefined.
+     *
+     * If the legend node belongs to the tree but it is filtered out, an invalid model index is returned.
+     *
+     * \warning The returned index belongs the underlying layer tree model, and care should be taken
+     * to correctly map to a proxy index if a proxy model is in use.
+     *
+     * \see legendNode2index()
+     *
+     * \since QGIS 3.18
+     */
+    QModelIndex legendNode2sourceIndex( QgsLayerTreeModelLegendNode *legendNode );
+
+    /**
+     * Sets the currently selected \a node.
+     *
+     * If \a node is NULLPTR then all nodes will be deselected.
+     *
+     * \see currentNode()
+     * \since QGIS 3.40
+     */
+    void setCurrentNode( QgsLayerTreeNode *node );
+
+    /**
+     * Sets the currently selected \a layer.
+     *
+     * If \a layer is NULLPTR then all layers will be deselected.
+     *
+     * \see currentLayer()
+     */
+    void setCurrentLayer( QgsMapLayer *layer );
+
+    /**
+     * Gets current legend node. May be NULLPTR if current node is not a legend node.
+     */
+    QgsLayerTreeModelLegendNode *currentLegendNode() const;
+
+    /**
+     * Returns the list of selected legend nodes.
+     *
+     * \see selectedNodes()
+     * \see selectedLayerNodes()
+     *
+     * \since QGIS 3.32
+     */
+    QList<QgsLayerTreeModelLegendNode *> selectedLegendNodes() const;
+
+    /**
+     * Gets list of selected layers, including those that are not directly selected, but their
+     * ancestor groups is selected. If we have a group with two layers L1, L2 and just the group
+     * node is selected, this method returns L1 and L2, while selectedLayers() returns an empty list.
+     * \since QGIS 3.4
+     */
+    QList<QgsMapLayer *> selectedLayersRecursive() const;
+
+  public slots:
+
+    /**
+     * Enhancement of QTreeView::expandAll() that also records expanded state in layer tree nodes
+     */
+    void expandAllNodes();
+
+    /**
+     * Enhancement of QTreeView::collapseAll() that also records expanded state in layer tree nodes
+     */
+    void collapseAllNodes();
+
   protected:
     /**
      * Updates the expanded state from a \a node.
@@ -307,25 +452,6 @@ class GUI_EXPORT QgsLayerTreeView : public QgsLayerTreeViewBase
      */
     QgsLayerTreeProxyModel *proxyModel() const;
 
-    /**
-     * Returns proxy model index for a given legend node. If the legend node does not belong to the layer tree, the result is undefined.
-     * If the legend node is belongs to the tree but it is filtered out, invalid model index is returned.
-     *
-     * Unlike QgsLayerTreeModel::legendNode2index(), calling this method correctly accounts
-     * for mapping the view indexes through the view's proxy model to the source model.
-     *
-     * \since QGIS 3.18
-     */
-    QModelIndex legendNode2index( QgsLayerTreeModelLegendNode *legendNode );
-
-    /**
-     * Returns index for a given legend node. If the legend node does not belong to the layer tree, the result is undefined.
-     * If the legend node is belongs to the tree but it is filtered out, invalid model index is returned.
-     *
-     * \since QGIS 3.18
-     */
-    QModelIndex legendNode2sourceIndex( QgsLayerTreeModelLegendNode *legendNode );
-
     //! Gets access to the default actions that may be used with the tree view
     QgsLayerTreeViewDefaultActions *defaultActions();
 
@@ -335,95 +461,12 @@ class GUI_EXPORT QgsLayerTreeView : public QgsLayerTreeViewBase
     QgsLayerTreeViewMenuProvider *menuProvider() const { return mMenuProvider; }
 
     /**
-     * Returns the currently selected layer, or NULLPTR if no layers is selected.
-     *
-     * \see setCurrentLayer()
-     */
-    QgsMapLayer *currentLayer() const;
-
-    /**
      * Convenience methods which sets the visible state of the specified map \a layer.
      *
      * \see QgsLayerTreeNode::setItemVisibilityChecked()
      * \since QGIS 3.10
      */
     void setLayerVisible( QgsMapLayer *layer, bool visible );
-
-    /**
-     * Sets the currently selected \a node.
-     *
-     * If \a node is NULLPTR then all nodes will be deselected.
-     *
-     * \see currentNode()
-     * \since QGIS 3.40
-     */
-    void setCurrentNode( QgsLayerTreeNode *node );
-
-    /**
-     * Sets the currently selected \a layer.
-     *
-     * If \a layer is NULLPTR then all layers will be deselected.
-     *
-     * \see currentLayer()
-     */
-    void setCurrentLayer( QgsMapLayer *layer );
-
-    //! Gets current node. May be NULLPTR
-    QgsLayerTreeNode *currentNode() const;
-    //! Gets current group node. If a layer is current node, the function will return parent group. May be NULLPTR.
-    QgsLayerTreeGroup *currentGroupNode() const;
-
-    /**
-     * Gets current legend node. May be NULLPTR if current node is not a legend node.
-     */
-    QgsLayerTreeModelLegendNode *currentLegendNode() const;
-
-    /**
-     * Returns the list of selected layer tree nodes.
-     *
-     * \param skipInternal If TRUE, will ignore nodes which have an ancestor in the selection
-     *
-     * \see selectedLayerNodes()
-     * \see selectedLegendNodes()
-     * \see selectedLayers()
-     */
-    QList<QgsLayerTreeNode *> selectedNodes( bool skipInternal = false ) const;
-
-    /**
-     * Returns the list of selected nodes filtered to just layer nodes (QgsLayerTreeLayer).
-     *
-     * \see selectedNodes()
-     * \see selectedLayers()
-     * \see selectedLegendNodes()
-     */
-    QList<QgsLayerTreeLayer *> selectedLayerNodes() const;
-
-    /**
-     * Returns the list of selected layers.
-     *
-     * \see selectedNodes()
-     * \see selectedLayerNodes()
-     * \see selectedLegendNodes()
-     */
-    QList<QgsMapLayer *> selectedLayers() const;
-
-    /**
-     * Returns the list of selected legend nodes.
-     *
-     * \see selectedNodes()
-     * \see selectedLayerNodes()
-     *
-     * \since QGIS 3.32
-     */
-    QList<QgsLayerTreeModelLegendNode *> selectedLegendNodes() const;
-
-    /**
-     * Gets list of selected layers, including those that are not directly selected, but their
-     * ancestor groups is selected. If we have a group with two layers L1, L2 and just the group
-     * node is selected, this method returns L1 and L2, while selectedLayers() returns an empty list.
-     * \since QGIS 3.4
-     */
-    QList<QgsMapLayer *> selectedLayersRecursive() const;
 
     /**
      * Adds an indicator to the given layer tree node. Indicators are icons shown next to layer/group names
@@ -494,16 +537,6 @@ class GUI_EXPORT QgsLayerTreeView : public QgsLayerTreeViewBase
     void refreshLayerSymbology( const QString &layerId );
 
     /**
-     * Enhancement of QTreeView::expandAll() that also records expanded state in layer tree nodes
-     */
-    void expandAllNodes();
-
-    /**
-     * Enhancement of QTreeView::collapseAll() that also records expanded state in layer tree nodes
-     */
-    void collapseAllNodes();
-
-    /**
      * Set width of contextual menu mark, at right of layer node items.
      * \see layerMarkWidth
      * \since QGIS 3.8
@@ -548,8 +581,6 @@ class GUI_EXPORT QgsLayerTreeView : public QgsLayerTreeViewBase
 
   protected:
     void contextMenuEvent( QContextMenuEvent *event ) override;
-
-    QgsMapLayer *layerForIndex( const QModelIndex &index ) const;
 
     void mouseDoubleClickEvent( QMouseEvent *event ) override;
     void mouseReleaseEvent( QMouseEvent *event ) override;

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -26,7 +26,7 @@
 
 #include <QAction>
 
-QgsLayerTreeViewDefaultActions::QgsLayerTreeViewDefaultActions( QgsLayerTreeView *view )
+QgsLayerTreeViewDefaultActions::QgsLayerTreeViewDefaultActions( QgsLayerTreeViewBase *view )
   : QObject( view )
   , mView( view )
 {

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -23,7 +23,7 @@
 class QAction;
 
 class QgsLayerTreeGroup;
-class QgsLayerTreeView;
+class QgsLayerTreeViewBase;
 class QgsMapCanvas;
 class QgsMapLayer;
 
@@ -38,7 +38,7 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
 {
     Q_OBJECT
   public:
-    QgsLayerTreeViewDefaultActions( QgsLayerTreeView *view );
+    QgsLayerTreeViewDefaultActions( QgsLayerTreeViewBase *view );
 
     QAction *actionAddGroup( QObject *parent = nullptr ) SIP_FACTORY;
     QAction *actionRemoveGroupOrLayer( QObject *parent = nullptr ) SIP_FACTORY;
@@ -193,7 +193,7 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     QString uniqueGroupName( QgsLayerTreeGroup *parentGroup );
 
   protected:
-    QgsLayerTreeView *mView = nullptr;
+    QgsLayerTreeViewBase *mView = nullptr;
 };
 
 

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -38,6 +38,11 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
 {
     Q_OBJECT
   public:
+    /**
+     * Constructor for QgsLayerTreeViewDefaultActions, creating actions for a \a view.
+     *
+     * The object will be parented to the specified \a view.
+     */
     QgsLayerTreeViewDefaultActions( QgsLayerTreeViewBase *view );
 
     QAction *actionAddGroup( QObject *parent = nullptr ) SIP_FACTORY;


### PR DESCRIPTION
This moves basic common functionality from QgsLayerTreeView to a new base class QgsLayerTreeViewBase. It is designed to
permit easier creation of custom layer tree view widgets, where the advanced functionality of QgsLayerTreeView is not required
(e.g. indicators, custom menu providers) yet the low-level integration between a tree view and QgsLayerTree is desired (e.g. correct handling of expanded/condensed states).

(This is especially useful because QgsLayerTreeView is very tightly bound to QgsLayerTreeProxyModel, preventing it from being used with custom proxy models. In particular QgsElevationProfileLayerTreeView was not able to use QgsLayerTreeView as it relies on a custom proxy model)

Note that while the diff here looks scary, it is just moving existing code from QgsLayerTreeView to QgsLayerTreeViewBase. Accordingly the public api of QgsLayerTreeView remains unchanged.