### PR TITLE
Make API memory safe

### DIFF
--- a/python/PyQt6/core/auto_generated/layertree/qgslayertree.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertree.sip.in
@@ -145,7 +145,7 @@ This property is read only.
 .. versionadded:: 4.0
 %End
 
-    static QgsLayerTree *readXml( QDomElement &element, const QgsReadWriteContext &context );
+    static std::unique_ptr< QgsLayerTree > readXml( const QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Load the layer tree from an XML element. It is not required that layers
 are loaded at this point. :py:func:`~QgsLayerTree.resolveReferences`

--- a/python/core/auto_generated/layertree/qgslayertree.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertree.sip.in
@@ -145,7 +145,7 @@ This property is read only.
 .. versionadded:: 4.0
 %End
 
-    static QgsLayerTree *readXml( QDomElement &element, const QgsReadWriteContext &context );
+    static std::unique_ptr< QgsLayerTree > readXml( const QDomElement &element, const QgsReadWriteContext &context );
 %Docstring
 Load the layer tree from an XML element. It is not required that layers
 are loaded at this point. :py:func:`~QgsLayerTree.resolveReferences`

--- a/src/core/layertree/qgslayertree.cpp
+++ b/src/core/layertree/qgslayertree.cpp
@@ -110,9 +110,9 @@ QList< QgsLayerTreeNode * > QgsLayerTree::layerAndCustomNodeOrder() const
   return layerAndCustomNodeOrderRespectingGroupLayers();
 }
 
-QgsLayerTree *QgsLayerTree::readXml( QDomElement &element, const QgsReadWriteContext &context ) // cppcheck-suppress duplInheritedMember
+std::unique_ptr< QgsLayerTree > QgsLayerTree::readXml( const QDomElement &element, const QgsReadWriteContext &context ) // cppcheck-suppress duplInheritedMember
 {
-  QgsLayerTree *tree = new QgsLayerTree();
+  auto tree = std::make_unique< QgsLayerTree >();
 
   tree->readCommonXml( element );
 

--- a/src/core/layertree/qgslayertree.h
+++ b/src/core/layertree/qgslayertree.h
@@ -207,7 +207,7 @@ class CORE_EXPORT QgsLayerTree : public QgsLayerTreeGroup
      * before using the tree.
      *
      */
-    static QgsLayerTree *readXml( QDomElement &element, const QgsReadWriteContext &context ); // cppcheck-suppress duplInheritedMember
+    static std::unique_ptr< QgsLayerTree > readXml( const QDomElement &element, const QgsReadWriteContext &context ); // cppcheck-suppress duplInheritedMember
 
     /**
      * Load the layer order from an XML element.

--- a/src/core/layout/qgscompositionconverter.cpp
+++ b/src/core/layout/qgscompositionconverter.cpp
@@ -1326,10 +1326,10 @@ bool QgsCompositionConverter::readLegendXml( QgsLayoutItemLegend *layoutItem, co
 
   if ( !layerTreeElem.isNull() )
   {
-    QgsLayerTree *tree( QgsLayerTree::readXml( layerTreeElem, context ) );
+    std::unique_ptr< QgsLayerTree > tree( QgsLayerTree::readXml( layerTreeElem, context ) );
     if ( project )
       tree->resolveReferences( project, true );
-    layoutItem->setCustomLayerTree( tree );
+    layoutItem->setCustomLayerTree( tree.release() );
   }
   else
   {


### PR DESCRIPTION
And fix leak when calling from python caused by missing /Factory/ annotation
