### PR TITLE
Use a full layer tree instead of list of layers in QgsElevationProfile

### DIFF
--- a/python/PyQt6/core/auto_generated/elevation/qgselevationprofile.sip.in
+++ b/python/PyQt6/core/auto_generated/elevation/qgselevationprofile.sip.in
@@ -69,18 +69,9 @@ After reading settings from XML, resolves references to any layers in a
 Returns the icon to use for the elevation profile.
 %End
 
-    void setLayers( const QList<QgsMapLayer *> &layers );
+    QgsLayerTree *layerTree();
 %Docstring
-Sets the list of ``layers`` to include in the profile.
-
-.. seealso:: :py:func:`layers`
-%End
-
-    QList<QgsMapLayer *> layers() const;
-%Docstring
-Returns the list of layers included in the profile.
-
-.. seealso:: :py:func:`setLayers`
+Returns the layer tree used by the profile.
 %End
 
     QgsCoordinateReferenceSystem crs() const;

--- a/python/core/auto_generated/elevation/qgselevationprofile.sip.in
+++ b/python/core/auto_generated/elevation/qgselevationprofile.sip.in
@@ -69,18 +69,9 @@ After reading settings from XML, resolves references to any layers in a
 Returns the icon to use for the elevation profile.
 %End
 
-    void setLayers( const QList<QgsMapLayer *> &layers );
+    QgsLayerTree *layerTree();
 %Docstring
-Sets the list of ``layers`` to include in the profile.
-
-.. seealso:: :py:func:`layers`
-%End
-
-    QList<QgsMapLayer *> layers() const;
-%Docstring
-Returns the list of layers included in the profile.
-
-.. seealso:: :py:func:`setLayers`
+Returns the layer tree used by the profile.
 %End
 
     QgsCoordinateReferenceSystem crs() const;

--- a/src/core/elevation/qgselevationprofile.h
+++ b/src/core/elevation/qgselevationprofile.h
@@ -31,6 +31,7 @@ class QDomElement;
 class QgsMapLayer;
 class QgsCurve;
 class QgsLineSymbol;
+class QgsLayerTree;
 
 /**
  * \ingroup core
@@ -89,18 +90,9 @@ class CORE_EXPORT QgsElevationProfile : public QObject
     QIcon icon() const;
 
     /**
-     * Sets the list of \a layers to include in the profile.
-     *
-     * \see layers()
+     * Returns the layer tree used by the profile.
      */
-    void setLayers( const QList<QgsMapLayer *> &layers );
-
-    /**
-     * Returns the list of layers included in the profile.
-     *
-     * \see setLayers()
-     */
-    QList<QgsMapLayer *> layers() const;
+    QgsLayerTree *layerTree();
 
     /**
      * Returns the crs associated with the profile's map coordinates.
@@ -230,7 +222,7 @@ class CORE_EXPORT QgsElevationProfile : public QObject
     QgsCoordinateReferenceSystem mCrs;
     bool mLockAxisScales = false;
     Qgis::DistanceUnit mDistanceUnit = Qgis::DistanceUnit::Unknown;
-    QList< QgsMapLayerRef > mLayers;
+    std::unique_ptr<QgsLayerTree> mLayerTree;
     std::unique_ptr<QgsCurve> mProfileCurve;
     double mTolerance = 0;
     std::unique_ptr<QgsLineSymbol> mSubsectionsSymbol;


### PR DESCRIPTION
Will ultimately enable us to have layer groups in elevation profiles

(needs https://github.com/qgis/QGIS/pull/63654 first)