### PR TITLE
Fix tooltip for low crs accuracy warning for EPSG:25832

### DIFF
--- a/src/app/qgslayertreeviewlowaccuracyindicator.cpp
+++ b/src/app/qgslayertreeviewlowaccuracyindicator.cpp
@@ -55,6 +55,12 @@ QString QgsLayerTreeViewLowAccuracyIndicatorProvider::tooltipText( QgsMapLayer *
   if ( !crs.isValid() )
     return QString();
 
+  // dynamic crs with no epoch?
+  if ( crs.isDynamic() && std::isnan( crs.coordinateEpoch() ) )
+  {
+    return tr( "%1 is a dynamic CRS, but no coordinate epoch is set. Coordinates are ambiguous and of limited accuracy." ).arg( crs.userFriendlyIdentifier() );
+  }
+
   // based on datum ensemble?
   try
   {
@@ -79,12 +85,6 @@ QString QgsLayerTreeViewLowAccuracyIndicatorProvider::tooltipText( QgsMapLayer *
   }
   catch ( QgsNotSupportedException & )
   {
-  }
-
-  // dynamic crs with no epoch?
-  if ( crs.isDynamic() && std::isnan( crs.coordinateEpoch() ) )
-  {
-    return tr( "%1 is a dynamic CRS, but no coordinate epoch is set. Coordinates are ambiguous and of limited accuracy." ).arg( crs.userFriendlyIdentifier() );
   }
 
   return QString();


### PR DESCRIPTION
The order of the checks should match those from
QgsLayerTreeViewLowAccuracyIndicatorProvider::acceptLayer, so that the tooltip accurately reflects why the warning is being shown.

(Otherwise we get the ensemble accuracy tooltip when the indicator is actually being shown because of the dynamic-crs-without-epoch trigger)
