### PR TITLE
Changed QLineEdit property to placeholderText. Fixes #63683

### DIFF
--- a/src/ui/qgsqueryresultpanelwidgetbase.ui
+++ b/src/ui/qgsqueryresultpanelwidgetbase.ui
@@ -234,7 +234,7 @@
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QLineEdit" name="mLayerNameLineEdit">
-            <property name="text">
+            <property name="placeholderText">
              <string>QueryLayer</string>
             </property>
            </widget>


### PR DESCRIPTION
## Description

Displays a placeholder text 'QueryLayer' in the Layer Name field in the "Execute SQL" dialog, both from a loaded layer or from the Browser Panel.

This is what it looks like either from the Browser Panel or the Layer Panel:
<img width="952" height="210" alt="image" src="https://github.com/user-attachments/assets/abc4a101-6711-4d42-ba1b-f197c8254ea1" />




Fixes #63683