### PR TITLE
Remove incorrect early exit path

### DIFF
--- a/src/analysis/processing/qgsalgorithmdissolve.cpp
+++ b/src/analysis/processing/qgsalgorithmdissolve.cpp
@@ -42,9 +42,6 @@ QVariantMap QgsCollectorAlgorithm::processCollection( const QVariantMap &paramet
 
   const long count = source->featureCount();
 
-  if ( !( count > 0 ) )
-    return outputs;
-
   QgsFeature f;
   QgsFeatureIterator it = source->getFeatures( QgsFeatureRequest(), sourceFlags );
 


### PR DESCRIPTION
The value returned by featureCount() is allowed to be negative, which represents an unknown feature count. We must still attempt to iterate the layer in this situation, as there may be features in the layer still.
