### PR TITLE
Remove locale formatting in numeric value on default filter widget

### DIFF
--- a/tests/src/python/test_qgssearchwidgetwrapper.py
+++ b/tests/src/python/test_qgssearchwidgetwrapper.py
@@ -63,7 +63,7 @@ class PyQgsDefaultSearchWidgetWrapper(QgisTestCase):
     def testCreateExpression(self):
         """Test creating an expression using the widget"""
         layer = QgsVectorLayer(
-            "Point?field=fldtxt:string&field=fldint:integer&field=flddate:datetime",
+            "Point?field=fldtxt:string&field=fldint:integer&field=flddate:datetime&field=flddouble:double",
             "test",
             "memory",
         )
@@ -169,6 +169,42 @@ class PyQgsDefaultSearchWidgetWrapper(QgisTestCase):
         self.assertEqual(
             w.createExpression(QgsSearchWidgetWrapper.FilterFlag.LessThanOrEqualTo),
             '"fldint"<=5.5',
+        )
+
+        # remove locale specific formattings
+        line_edit.setText("5,000")
+        self.assertEqual(
+            w.createExpression(QgsSearchWidgetWrapper.FilterFlag.LessThan),
+            '"fldint"<5000',
+        )
+        self.assertEqual(
+            w.createExpression(QgsSearchWidgetWrapper.FilterFlag.GreaterThanOrEqualTo),
+            '"fldint">=5000',
+        )
+        self.assertEqual(
+            w.createExpression(QgsSearchWidgetWrapper.FilterFlag.LessThanOrEqualTo),
+            '"fldint"<=5000',
+        )
+
+        # numeric field (double)
+        parent = QWidget()
+        w = QgsDefaultSearchWidgetWrapper(layer, 3)
+        w.initWidget(parent)
+
+        # remove locale specific formattings
+        line_edit = w.lineEdit()
+        line_edit.setText("5,000.5")
+        self.assertEqual(
+            w.createExpression(QgsSearchWidgetWrapper.FilterFlag.LessThan),
+            '"flddouble"<5000.5',
+        )
+        self.assertEqual(
+            w.createExpression(QgsSearchWidgetWrapper.FilterFlag.GreaterThanOrEqualTo),
+            '"flddouble">=5000.5',
+        )
+        self.assertEqual(
+            w.createExpression(QgsSearchWidgetWrapper.FilterFlag.LessThanOrEqualTo),
+            '"flddouble"<=5000.5',
         )
 
         # date/time/datetime

--- a/tests/src/python/test_qgssearchwidgetwrapper.py
+++ b/tests/src/python/test_qgssearchwidgetwrapper.py
@@ -10,7 +10,7 @@ __author__ = "Nyall Dawson"
 __date__ = "2016-05"
 __copyright__ = "Copyright 2016, The QGIS Project"
 
-from qgis.PyQt.QtCore import QDate, QDateTime, QTime
+from qgis.PyQt.QtCore import QDate, QDateTime, QTime, QLocale
 from qgis.PyQt.QtWidgets import QWidget
 from qgis.core import QgsFeature, QgsProject, QgsRelation, QgsVectorLayer
 from qgis.gui import (
@@ -59,6 +59,11 @@ class PyQgsSearchWidgetWrapper(QgisTestCase):
 
 
 class PyQgsDefaultSearchWidgetWrapper(QgisTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        QLocale.setDefault(QLocale(QLocale.Language.English))
+        super().setUpClass()
 
     def testCreateExpression(self):
         """Test creating an expression using the widget"""

--- a/tests/src/python/test_qgssearchwidgetwrapper.py
+++ b/tests/src/python/test_qgssearchwidgetwrapper.py
@@ -204,6 +204,57 @@ class PyQgsDefaultSearchWidgetWrapper(QgisTestCase):
             "\"flddate\"<='2015-06-03'",
         )
 
+    def testSetExpression(self):
+        """Test creating an expression using the widget"""
+        layer = QgsVectorLayer(
+            "Point?field=fldint:integer&field=flddouble:double",
+            "test",
+            "memory",
+        )
+        # numeric field
+        parent = QWidget()
+        w = QgsDefaultSearchWidgetWrapper(layer, 0)
+        w.initWidget(parent)
+
+        line_edit = w.lineEdit()
+
+        line_edit.setText("10000")
+        self.assertEqual(
+            w.expression(),
+            "\"fldint\" = '10000'",
+        )
+        line_edit.setText("10,000")
+        self.assertEqual(
+            w.expression(),
+            "\"fldint\" = '10000'",
+        )
+
+        w = QgsDefaultSearchWidgetWrapper(layer, 1)
+        w.initWidget(parent)
+
+        line_edit = w.lineEdit()
+
+        line_edit.setText("10000")
+        self.assertEqual(
+            w.expression(),
+            "\"flddouble\" = '10000'",
+        )
+        line_edit.setText("10,000")
+        self.assertEqual(
+            w.expression(),
+            "\"flddouble\" = '10000'",
+        )
+        line_edit.setText("10000.5")
+        self.assertEqual(
+            w.expression(),
+            "\"flddouble\" = '10000.5'",
+        )
+        line_edit.setText("10,000.5")
+        self.assertEqual(
+            w.expression(),
+            "\"flddouble\" = '10000.5'",
+        )
+
 
 class PyQgsValueMapSearchWidgetWrapper(QgisTestCase):
 


### PR DESCRIPTION
When pasting a formatted numeric value from the current locale setting into a filter input like form filter or field filter in the attribute table, it converts the value in the expression to a proper numeric value without formatting.

This fixes #63712