### PR TITLE
Fix incorrect return value from masterPasswordRowsInDb, cleanup api

### DIFF
--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -552,7 +552,7 @@ bool QgsAuthManager::verifyMasterPassword( const QString &compare )
     return false;
 
   int rows = 0;
-  if ( !masterPasswordRowsInDb( &rows ) )
+  if ( !masterPasswordRowsInDb( rows ) )
   {
     const char *err = QT_TR_NOOP( "Master password: FAILED to access database" );
     QgsDebugError( err );
@@ -3586,14 +3586,14 @@ bool QgsAuthManager::masterPasswordInput()
   return false;
 }
 
-bool QgsAuthManager::masterPasswordRowsInDb( int *rows ) const
+bool QgsAuthManager::masterPasswordRowsInDb( int &rows ) const
 {
   ensureInitialized();
 
   if ( isDisabled() )
     return false;
 
-  *rows = 0;
+  rows = 0;
 
   QMutexLocker locker( mMutex.get() );
 
@@ -3604,7 +3604,7 @@ bool QgsAuthManager::masterPasswordRowsInDb( int *rows ) const
   {
     try
     {
-      *rows += storage->masterPasswords( ).count();
+      rows += storage->masterPasswords( ).count();
     }
     catch ( const QgsNotSupportedException &e )
     {
@@ -3619,7 +3619,6 @@ bool QgsAuthManager::masterPasswordRowsInDb( int *rows ) const
   }
 
   return rows != 0;
-
 }
 
 bool QgsAuthManager::masterPasswordHashInDatabase() const
@@ -3630,7 +3629,7 @@ bool QgsAuthManager::masterPasswordHashInDatabase() const
     return false;
 
   int rows = 0;
-  if ( !masterPasswordRowsInDb( &rows ) )
+  if ( !masterPasswordRowsInDb( rows ) )
   {
     const char *err = QT_TR_NOOP( "Master password: FAILED to access database" );
     QgsDebugError( err );

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -3588,10 +3588,11 @@ bool QgsAuthManager::masterPasswordInput()
 
 bool QgsAuthManager::masterPasswordRowsInDb( int &rows ) const
 {
+  bool res = false;
   ensureInitialized();
 
   if ( isDisabled() )
-    return false;
+    return res;
 
   rows = 0;
 
@@ -3600,25 +3601,29 @@ bool QgsAuthManager::masterPasswordRowsInDb( int &rows ) const
   // Loop through all storages with capability ReadMasterPassword and count the number of master passwords
   const QList<QgsAuthConfigurationStorage *> storages { authConfigurationStorageRegistry()->readyStoragesWithCapability( Qgis::AuthConfigurationStorageCapability::ReadMasterPassword ) };
 
-  for ( QgsAuthConfigurationStorage *storage : std::as_const( storages ) )
-  {
-    try
-    {
-      rows += storage->masterPasswords( ).count();
-    }
-    catch ( const QgsNotSupportedException &e )
-    {
-      // It should not happen because we are checking the capability in advance
-      emit messageLog( e.what(), authManTag(), Qgis::MessageLevel::Critical );
-    }
-  }
-
   if ( storages.empty() )
   {
     emit messageLog( tr( "Could not connect to any authentication configuration storage." ), authManTag(), Qgis::MessageLevel::Critical );
   }
+  else
+  {
+    for ( QgsAuthConfigurationStorage *storage : std::as_const( storages ) )
+    {
+      try
+      {
+        rows += storage->masterPasswords( ).count();
+        // if we successfully queuried at least one storage, the result from this function must be true
+        res = true;
+      }
+      catch ( const QgsNotSupportedException &e )
+      {
+        // It should not happen because we are checking the capability in advance
+        emit messageLog( e.what(), authManTag(), Qgis::MessageLevel::Critical );
+      }
+    }
+  }
 
-  return rows != 0;
+  return res;
 }
 
 bool QgsAuthManager::masterPasswordHashInDatabase() const

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -975,6 +975,12 @@ class CORE_EXPORT QgsAuthManager : public QObject
 
     bool masterPasswordInput();
 
+    /**
+     * Calculate the total number of master password rows in all storages.
+     *
+     * Returns TRUE if the calculation was successful for at least one storage,
+     * or FALSE if no storages could be queried.
+     */
     bool masterPasswordRowsInDb( int &rows ) const;
 
     bool masterPasswordCheckAgainstDb( const QString &compare = QString() ) const;

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -975,7 +975,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
 
     bool masterPasswordInput();
 
-    bool masterPasswordRowsInDb( int *rows ) const;
+    bool masterPasswordRowsInDb( int &rows ) const;
 
     bool masterPasswordCheckAgainstDb( const QString &compare = QString() ) const;
 


### PR DESCRIPTION
Clean up the API and using an int& argument instead, and then fix the broken return value logic which was previously causing us to always return true.

Spin off from https://github.com/qgis/QGIS/pull/63697