### PR TITLE
Fix copy/paste error in QgsPalLayerSettings::calculateLabelSize for rotation based orientation text size

### DIFF
--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -1746,7 +1746,7 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF *fm, const QSt
       double widthHorizontal = 0.0;
       for ( const QString &line : std::as_const( multiLineSplit ) )
       {
-        widthHorizontal = std::max( w, fm->horizontalAdvance( line ) );
+        widthHorizontal = std::max( widthHorizontal, fm->horizontalAdvance( line ) );
       }
 
       double widthVertical = 0.0;


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/63687