### PR TITLE
Improve tooltip

### DIFF
--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -268,7 +268,7 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   mSelfSnappingAction = new QAction( tr( "Self-snapping" ), this );
   mSelfSnappingAction->setCheckable( true );
   mSelfSnappingAction->setIcon( QIcon( QgsApplication::getThemeIcon( "/mIconSnappingSelf.svg" ) ) );
-  mSelfSnappingAction->setToolTip( tr( "If self snapping is enabled, snapping will also take the current state of the digitized feature into consideration." ) );
+  mSelfSnappingAction->setToolTip( tr( "Enable Self-snapping" ) + QStringLiteral( "\n\n" ) + tr( "If enabled, snapping will also take the current state of the digitized feature into consideration." ) );
   mSelfSnappingAction->setObjectName( QStringLiteral( "SelfSnappingAction" ) );
   connect( mSelfSnappingAction, &QAction::toggled, this, &QgsSnappingWidget::enableSelfSnapping );
 


### PR DESCRIPTION
Before explaining what an option does, the tooltip should first indicate that it's changing that option
