### PR TITLE
Fix regression: use exact matches to find coincident vertices with topology edition

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1888,8 +1888,7 @@ QgsPointLocator::MatchList QgsVertexTool::layerVerticesSnappedToPoint( QgsVector
 {
   MatchCollectingFilter myfilter( this );
   QgsPointLocator *loc = canvas()->snappingUtils()->locatorForLayer( layer );
-  double tol = QgsTolerance::vertexSearchRadius( canvas()->mapSettings() );
-  return loc->verticesInRect( mapPoint, tol, &myfilter, true );
+  return loc->verticesInRect( mapPoint, 1e-8, &myfilter, true );
 }
 
 QgsPointLocator::MatchList QgsVertexTool::layerSegmentsSnappedToSegment( QgsVectorLayer *layer, const QgsPointXY &mapPoint1, const QgsPointXY &mapPoint2 )


### PR DESCRIPTION
## Description

Fixes #63305.

PR https://github.com/qgis/QGIS/pull/58352 introduced a regression not caught in review.

Finding coincident vertices for topology edition should not use a search radius, but an exact match.