### PR TITLE
qgsdatetimeedit: Properly handle timezone in recent Qt6 versions

### DIFF
--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -363,7 +363,15 @@ void QgsDateTimeEdit::setDateTime( const QDateTime &dateTime )
     mBlockChangedSignal++;
     // We need to set the time spec of the set datetime to the widget, otherwise
     // the dateTime() getter would loose edit, and return local time.
+    // QDateTimeEdit::setTimeZone has been introduced in Qt 6.7 to properly handle
+    // timezone instead of QDateTimeEdit::setTimeSpec
+    // QDateTimeEdit::setTimeSpec has been deprecated since Qt 6.10
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 7, 0 )
+    QDateTimeEdit::setTimeZone( dateTime.timeZone() );
+#else
     QDateTimeEdit::setTimeSpec( dateTime.timeSpec() );
+#endif
+
     QDateTimeEdit::setDateTime( dateTime );
     mBlockChangedSignal--;
     changed( dateTime );

--- a/tests/src/python/test_qgsdatetimeedit.py
+++ b/tests/src/python/test_qgsdatetimeedit.py
@@ -10,7 +10,7 @@ __author__ = "Denis Rouzaud"
 __date__ = "2018-01-04"
 __copyright__ = "Copyright 2017, The QGIS Project"
 
-from qgis.PyQt.QtCore import QDate, QDateTime, Qt, QTime
+from qgis.PyQt.QtCore import QDate, QDateTime, Qt, QTime, QT_VERSION_STR
 from qgis.gui import QgsDateEdit, QgsDateTimeEdit, QgsTimeEdit
 import unittest
 from qgis.testing import start_app, QgisTestCase
@@ -19,21 +19,33 @@ start_app()
 
 DATE = QDateTime.fromString("2018-01-01 01:02:03", Qt.DateFormat.ISODate)
 DATE_Z = QDateTime.fromString("2018-01-01 01:02:03Z", Qt.DateFormat.ISODate)
+DATE_OFFSET = QDateTime.fromString("2025-01-20T12:00:00+03:00", Qt.DateFormat.ISODate)
 
 
 class TestQgsDateTimeEdit(QgisTestCase):
 
+    def check_time_zone(self, widget, expected_date):
+        if int(QT_VERSION_STR.split(".")[0]) > 6 or (
+            int(QT_VERSION_STR.split(".")[0]) == 6
+            and int(QT_VERSION_STR.split(".")[1]) >= 7
+        ):
+            self.assertEqual(widget.timeZone().id(), expected_date.timeZone().id())
+        else:
+            self.assertEqual(widget.timeSpec(), expected_date.timeSpec())
+
     def testSettersGetters(self):
         """test widget handling of null values"""
-        for date in [DATE, DATE_Z]:
+        for date in [DATE, DATE_Z, DATE_OFFSET]:
             w = QgsDateTimeEdit()
             w.setAllowNull(False)
 
             w.setDateTime(date)
             self.assertEqual(w.dateTime(), date)
+            self.check_time_zone(w, date)
             # date should remain when setting an invalid date
             w.setDateTime(QDateTime())
             self.assertEqual(w.dateTime(), date)
+            self.check_time_zone(w, date)
 
     def testNullValueHandling(self):
         """test widget handling of null values"""

--- a/tests/src/python/test_qgsdatetimeedit.py
+++ b/tests/src/python/test_qgsdatetimeedit.py
@@ -25,25 +25,15 @@ class TestQgsDateTimeEdit(QgisTestCase):
 
     def testSettersGetters(self):
         """test widget handling of null values"""
-        w = QgsDateTimeEdit()
-        w.setAllowNull(False)
+        for date in [DATE, DATE_Z]:
+            w = QgsDateTimeEdit()
+            w.setAllowNull(False)
 
-        w.setDateTime(DATE)
-        self.assertEqual(w.dateTime(), DATE)
-        # date should remain when setting an invalid date
-        w.setDateTime(QDateTime())
-        self.assertEqual(w.dateTime(), DATE)
-
-    def testSettersGetters_DATE_Z(self):
-        """test widget handling with Z time spec"""
-        w = QgsDateTimeEdit()
-        w.setAllowNull(False)
-
-        w.setDateTime(DATE_Z)
-        self.assertEqual(w.dateTime(), DATE_Z)
-        # date should remain when setting an invalid date
-        w.setDateTime(QDateTime())
-        self.assertEqual(w.dateTime(), DATE_Z)
+            w.setDateTime(date)
+            self.assertEqual(w.dateTime(), date)
+            # date should remain when setting an invalid date
+            w.setDateTime(QDateTime())
+            self.assertEqual(w.dateTime(), date)
 
     def testNullValueHandling(self):
         """test widget handling of null values"""


### PR DESCRIPTION
## Description

`QDateTimeEdit::setTimeZone` has been introduced in Qt 6.7. According
to the documentation `QDateTimeEdit::timeSpec` is now an indirect
accessor for the `timeZone` property.
Besides, `QDateTimeEdit::setTimeSpec` is deprecated since Qt 6.10.

If `timeSpec` is in `Qt::OffsetFromUTC` format, one get the following
warning since Qt 6.7:
```
Warning: Ignoring attempt to set time-spec Qt::OffsetFromUTC which
needs ancillary data: see setTimeZone()
```

By using `QDateTimeEdit::setTimeZone` for `QT_VERSION >= 6.7`, one
correctly handle timezones and avoid any warning messages.


**Funded by Ifremer**