### PR TITLE
Reload current symbol on double click

### DIFF
--- a/src/gui/qgsstyleitemslistwidget.cpp
+++ b/src/gui/qgsstyleitemslistwidget.cpp
@@ -251,6 +251,12 @@ void QgsStyleItemsListWidget::setStyle( QgsStyle *style )
 
   mSymbolTreeView->setSelectionModel( viewSymbols->selectionModel() );
   connect( viewSymbols->selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsStyleItemsListWidget::onSelectionChanged );
+  connect( viewSymbols, &QListView::activated, this, [this]( const QModelIndex &index ) {
+    onSelectionChanged( index, QModelIndex() );
+  } );
+  connect( mSymbolTreeView, &QTreeView::activated, this, [this]( const QModelIndex &index ) {
+    onSelectionChanged( index, QModelIndex() );
+  } );
 
   populateGroups();
   connect( groupsCombo, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsStyleItemsListWidget::groupsCombo_currentIndexChanged );
@@ -556,9 +562,12 @@ void QgsStyleItemsListWidget::openStyleManager()
   }
 }
 
-void QgsStyleItemsListWidget::onSelectionChanged( const QModelIndex &index )
+void QgsStyleItemsListWidget::onSelectionChanged( const QModelIndex &index, const QModelIndex &previous )
 {
   if ( !mModel )
+    return;
+
+  if ( index.row() == previous.row() )
     return;
 
   const QString symbolName = mModel->data( mModel->index( index.row(), QgsStyleModel::Name ) ).toString();

--- a/src/gui/qgsstyleitemslistwidget.h
+++ b/src/gui/qgsstyleitemslistwidget.h
@@ -200,7 +200,7 @@ class GUI_EXPORT QgsStyleItemsListWidget : public QWidget, private Ui::QgsStyleI
   private slots:
     void groupsCombo_currentIndexChanged( int index );
     void updateModelFilters();
-    void onSelectionChanged( const QModelIndex &index );
+    void onSelectionChanged( const QModelIndex &index, const QModelIndex &previous );
     void populateGroups();
     void openStyleManager();
 


### PR DESCRIPTION
## Description
Fixes #63742

The symbol was activated upon any selection model change, that's why it would get triggered when clicking between the _name_ and _tags_ columns of the same style.
With the proposed solution, the currently selected symbol needs to be _double clicked_ in order to be reloaded. Single clicking on the same row does not apply the symbol. Selecting a _different_ symbol still works as before.



<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
