### PR TITLE
Make original (raw) attribute values visible and copyable in Attributetable and Identify Result

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1713,8 +1713,32 @@ void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent *event )
       }
     }
 
-    mActionPopup->addAction( tr( "Copy Attribute Value" ), this, [this] { copyAttributeValue(); } );
-    mActionPopup->addAction( tr( "Copy Raw Attribute Value" ), this, [this] { copyAttributeValue( true ); } );
+    const QVariant displayValue = retrieveAttribute( lstResults->currentItem(), false );
+    if ( displayValue.isValid() )
+    {
+      // get values for preview in menu
+      QString previewDisplayValue = displayValue.toString();
+      if ( previewDisplayValue.length() > 12 )
+      {
+        previewDisplayValue.truncate( 12 );
+        previewDisplayValue.append( QStringLiteral( "…" ) );
+      }
+      mActionPopup->addAction( tr( "Copy Attribute Value (%1)" ).arg( previewDisplayValue ), this, [this, displayValue] { copyAttributeValue( displayValue.toString() ); } );
+    }
+
+    const QVariant rawValue = retrieveAttribute( lstResults->currentItem(), true );
+    if ( rawValue.isValid() )
+    {
+      // get values for preview in menu
+      QString previewRawValue = rawValue.toString();
+      if ( previewRawValue.length() > 12 )
+      {
+        previewRawValue.truncate( 12 );
+        previewRawValue.append( QStringLiteral( "…" ) );
+      }
+      mActionPopup->addAction( tr( "Copy Raw Value (%1)" ).arg( previewRawValue ), this, [this, rawValue] { copyAttributeValue( rawValue.toString() ); } );
+    }
+
     mActionPopup->addAction( tr( "Copy Feature Attributes" ), this, &QgsIdentifyResultsDialog::copyFeatureAttributes );
 
     mActionPopup->addAction( tr( "Select Features by Attribute Value" ), this, &QgsIdentifyResultsDialog::selectFeatureByAttribute );
@@ -2542,13 +2566,11 @@ void QgsIdentifyResultsDialog::collapseAll()
   lstResults->collapseAll();
 }
 
-void QgsIdentifyResultsDialog::copyAttributeValue( const bool raw )
+void QgsIdentifyResultsDialog::copyAttributeValue( const QString &value )
 {
   QClipboard *clipboard = QApplication::clipboard();
-  const QVariant attributeValue = retrieveAttribute( lstResults->currentItem(), raw );
-  const QString text = attributeValue.toString();
-  QgsDebugMsgLevel( QStringLiteral( "set clipboard: %1" ).arg( text ), 2 );
-  clipboard->setText( text );
+  QgsDebugMsgLevel( QStringLiteral( "set clipboard: %1" ).arg( value ), 2 );
+  clipboard->setText( value );
 }
 
 void QgsIdentifyResultsDialog::copyFeatureAttributes()

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -641,7 +641,12 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     item = new QTableWidgetItem( value );
     item->setData( Qt::UserRole, value );
     item->setData( Qt::DisplayRole, value2 );
-
+    QString tooltip = value2;
+    if ( value2 != attrs.at( i ).toString() )
+    {
+      tooltip = tr( "%1 (%2)" ).arg( value2, attrs.at( i ).toString() );
+    }
+    item->setToolTip( tooltip );
     tblResults->setItem( j, 3, item );
 
     // highlight first item
@@ -792,7 +797,12 @@ QgsIdentifyResultsFeatureItem *QgsIdentifyResultsDialog::createFeatureItem( QgsV
 
     const QString representedValue = representValue( vlayer, setup, fields.at( i ).name(), attrs.at( i ) );
     attrItem->setSortData( 1, representedValue );
-    attrItem->setToolTip( 1, representedValue );
+    QString tooltip = representedValue;
+    if ( representedValue != attrs.at( i ).toString() )
+    {
+      tooltip = tr( "%1 (%2)" ).arg( representedValue, attrs.at( i ).toString() );
+    }
+    attrItem->setToolTip( 1, tooltip );
     attrItem->setData( 1, REPRESENTED_VALUE_ROLE, representedValue );
     attrItem->setData( 1, RAW_STRING_VALUE_ROLE, attrs.at( i ).toString() );
 
@@ -1342,7 +1352,12 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorTileLayer *layer, const QStr
     attrItem->setData( 1, REPRESENTED_VALUE_ROLE, value );
     attrItem->setData( 1, RAW_STRING_VALUE_ROLE, attrs.at( i ).toString() );
     attrItem->setSortData( 1, value );
-    attrItem->setToolTip( 1, value );
+    QString tooltip = value;
+    if ( value != attrs.at( i ).toString() )
+    {
+      tooltip = tr( "%1 (%2)" ).arg( value, attrs.at( i ).toString() );
+    }
+    attrItem->setToolTip( 1, tooltip );
     bool foundLinks = false;
     const QString links = QgsStringUtils::insertLinks( value, &foundLinks );
     if ( foundLinks )

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -252,7 +252,7 @@ class APP_EXPORT QgsIdentifyResultsDialog : public QDialog, private Ui::QgsIdent
     void featureForm();
     void zoomToFeature();
     void identifyFeature();
-    void copyAttributeValue( const bool raw = false );
+    void copyAttributeValue( const QString &value );
     void copyFeature();
     void toggleFeatureSelection();
     void copyFeatureAttributes();

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -252,7 +252,7 @@ class APP_EXPORT QgsIdentifyResultsDialog : public QDialog, private Ui::QgsIdent
     void featureForm();
     void zoomToFeature();
     void identifyFeature();
-    void copyAttributeValue();
+    void copyAttributeValue( const bool raw = false );
     void copyFeature();
     void toggleFeatureSelection();
     void copyFeatureAttributes();
@@ -274,7 +274,7 @@ class APP_EXPORT QgsIdentifyResultsDialog : public QDialog, private Ui::QgsIdent
     void itemExpanded( QTreeWidgetItem *item );
 
     QgsAttributeMap retrieveAttributes( QTreeWidgetItem *item );
-    QVariant retrieveAttribute( QTreeWidgetItem *item );
+    QVariant retrieveAttribute( QTreeWidgetItem *item, const bool raw = false );
 
     void cmbIdentifyMode_currentIndexChanged( int index );
 

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -738,6 +738,10 @@ QVariant QgsAttributeTableModel::data( const QModelIndex &index, int role ) cons
     {
       const WidgetData &widgetData = getWidgetData( index.column() );
       QString tooltip = widgetData.fieldFormatter->representValue( mLayer, fieldId, widgetData.config, widgetData.cache, val );
+      if ( tooltip != val.toString() )
+      {
+        tooltip = tr( "%1 (%2)" ).arg( tooltip, val.toString() );
+      }
       if ( val.userType() == QMetaType::Type::QString && QgsStringUtils::isUrl( val.toString() ) )
       {
         tooltip = tr( "%1 (Ctrl+click to open)" ).arg( tooltip );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -842,7 +842,7 @@ void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &maste
     QApplication::clipboard()->setText( var.toString() );
   } );
 
-  QAction *copyRawContentAction = menu->addAction( tr( "Copy Raw Content" ) );
+  QAction *copyRawContentAction = menu->addAction( tr( "Copy Raw Cell Content" ) );
   menu->addAction( copyRawContentAction );
   connect( copyRawContentAction, &QAction::triggered, this, [masterIndex, this] {
     const QVariant var = mMasterModel->data( masterIndex, Qt::EditRole );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -835,19 +835,43 @@ void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &maste
     return;
   }
 
-  QAction *copyContentAction = menu->addAction( tr( "Copy Cell Content" ) );
-  menu->addAction( copyContentAction );
-  connect( copyContentAction, &QAction::triggered, this, [masterIndex, this] {
-    const QVariant var = mMasterModel->data( masterIndex, Qt::DisplayRole );
-    QApplication::clipboard()->setText( var.toString() );
-  } );
+  const QVariant displayValue = mMasterModel->data( masterIndex, Qt::DisplayRole );
 
-  QAction *copyRawContentAction = menu->addAction( tr( "Copy Raw Cell Content" ) );
-  menu->addAction( copyRawContentAction );
-  connect( copyRawContentAction, &QAction::triggered, this, [masterIndex, this] {
-    const QVariant var = mMasterModel->data( masterIndex, Qt::EditRole );
-    QApplication::clipboard()->setText( var.toString() );
-  } );
+  if ( displayValue.isValid() )
+  {
+    // get values for preview in menu
+    QString previewDisplayValue = displayValue.toString();
+    if ( previewDisplayValue.length() > 12 )
+    {
+      previewDisplayValue.truncate( 12 );
+      previewDisplayValue.append( QStringLiteral( "…" ) );
+    }
+
+
+    QAction *copyContentAction = menu->addAction( tr( "Copy Cell Content (%1)" ).arg( previewDisplayValue ) );
+    menu->addAction( copyContentAction );
+    connect( copyContentAction, &QAction::triggered, this, [displayValue] {
+      QApplication::clipboard()->setText( displayValue.toString() );
+    } );
+  }
+
+  const QVariant rawValue = mMasterModel->data( masterIndex, Qt::EditRole );
+  if ( rawValue.isValid() )
+  {
+    // get values for preview in menu
+    QString previewRawValue = rawValue.toString();
+    if ( previewRawValue.length() > 12 )
+    {
+      previewRawValue.truncate( 12 );
+      previewRawValue.append( QStringLiteral( "…" ) );
+    }
+
+    QAction *copyRawContentAction = menu->addAction( tr( "Copy Raw Value (%1)" ).arg( previewRawValue ) );
+    menu->addAction( copyRawContentAction );
+    connect( copyRawContentAction, &QAction::triggered, this, [rawValue] {
+      QApplication::clipboard()->setText( rawValue.toString() );
+    } );
+  }
 
   QgsVectorLayer *vl = mFilterModel->layer();
   QgsMapCanvas *canvas = mFilterModel->mapCanvas();

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -842,6 +842,13 @@ void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &maste
     QApplication::clipboard()->setText( var.toString() );
   } );
 
+  QAction *copyRawContentAction = menu->addAction( tr( "Copy Raw Content" ) );
+  menu->addAction( copyRawContentAction );
+  connect( copyRawContentAction, &QAction::triggered, this, [masterIndex, this] {
+    const QVariant var = mMasterModel->data( masterIndex, Qt::EditRole );
+    QApplication::clipboard()->setText( var.toString() );
+  } );
+
   QgsVectorLayer *vl = mFilterModel->layer();
   QgsMapCanvas *canvas = mFilterModel->mapCanvas();
   if ( canvas && vl && vl->isSpatial() )

--- a/tests/src/app/testqgsidentify.cpp
+++ b/tests/src/app/testqgsidentify.cpp
@@ -61,11 +61,12 @@ class TestQgsIdentify : public QObject
     void identifyRasterFloat32(); // test pixel identification and decimal precision
     void identifyRasterFloat64(); // test pixel identification and decimal precision
     void identifyRasterTemporal();
-    void identifyRasterDerivedAttributes(); // test derived pixel attributes
-    void identifyMesh();                    // test identification for mesh layer
-    void identifyVectorTile();              // test identification for vector tile layer
-    void identifyInvalidPolygons();         // test selecting invalid polygons
-    void clickxy();                         // test if click_x and click_y variables are propagated
+    void identifyRasterDerivedAttributes();      // test derived pixel attributes
+    void identifyMesh();                         // test identification for mesh layer
+    void identifyVectorTile();                   // test identification for vector tile layer
+    void identifyInvalidPolygons();              // test selecting invalid polygons
+    void identifyFeatureWithRepresentedValues(); // test locale representations values (and raw values)
+    void clickxy();                              // test if click_x and click_y variables are propagated
     void closestPoint();
     void testRelations();
     void testPointZ();
@@ -136,6 +137,9 @@ void TestQgsIdentify::cleanupTestCase()
 void TestQgsIdentify::init()
 {
   canvas = new QgsMapCanvas();
+  // enforce C locale because the tests expect it
+  // (decimal separators / thousand separators)
+  QLocale::setDefault( QLocale::c() );
 }
 
 void TestQgsIdentify::cleanup()
@@ -304,6 +308,7 @@ void TestQgsIdentify::closestPoint()
   QVERIFY( urlAttributeItem );
   // urlAttributeItem has a delegate widget, but we should still be able to retrieve the raw field value from it
   QCOMPARE( dlg->retrieveAttribute( urlAttributeItem ).toString(), QStringLiteral( "home: http://qgis.org" ) );
+  QCOMPARE( dlg->retrieveAttribute( urlAttributeItem, true ).toString(), QStringLiteral( "home: http://qgis.org" ) );
 
   // polygons
   //create a temporary layer
@@ -980,6 +985,51 @@ void TestQgsIdentify::identifyInvalidPolygons()
   identified = testIdentifyVector( memoryLayer.get(), 6, 4 );
   QCOMPARE( identified.length(), 1 );
   QCOMPARE( identified[0].mFeature.attribute( "pk" ), QVariant( 1 ) );
+}
+
+void TestQgsIdentify::identifyFeatureWithRepresentedValues()
+{
+  QLocale::setDefault( QLocale( QLocale::German, QLocale::Germany ) );
+
+  //create a temporary layer
+  QgsVectorLayer *layerA = new QgsVectorLayer( QStringLiteral( "Point?field=pk:int&field=doubleval:double" ), QStringLiteral( "layerA" ), QStringLiteral( "memory" ) );
+  QVERIFY( layerA->isValid() );
+  QgsFeature f1( layerA->dataProvider()->fields(), 1 );
+  f1.setAttribute( QStringLiteral( "pk" ), 1000 );
+  f1.setAttribute( QStringLiteral( "doubleval" ), 1000.5 );
+  layerA->dataProvider()->addFeatures( QgsFeatureList() << f1 );
+
+  auto dialog = std::make_unique<QgsIdentifyResultsDialog>( canvas );
+  dialog->addFeature( layerA, f1, QMap<QString, QString>() );
+
+  QCOMPARE( dialog->lstResults->topLevelItemCount(), 1 );
+  QTreeWidgetItem *topLevelItem = dialog->lstResults->topLevelItem( 0 );
+  QCOMPARE( topLevelItem->childCount(), 1 );
+
+  QgsIdentifyResultsFeatureItem *featureItem = dynamic_cast<QgsIdentifyResultsFeatureItem *>( topLevelItem->child( 0 ) );
+  QVERIFY( featureItem );
+
+  QTreeWidgetItem *pkAttributeItem = nullptr;
+  QTreeWidgetItem *doublevalAttributeItem = nullptr;
+  for ( int row = 0; row < featureItem->childCount(); ++row )
+  {
+    if ( featureItem->child( row )->text( 0 ) == tr( "pk" ) )
+    {
+      pkAttributeItem = featureItem->child( row );
+    }
+    else if ( featureItem->child( row )->text( 0 ) == tr( "doubleval" ) )
+    {
+      doublevalAttributeItem = featureItem->child( row );
+    }
+  }
+  QVERIFY( pkAttributeItem );
+  QCOMPARE( pkAttributeItem->text( 1 ), QStringLiteral( "1.000" ) );
+  QCOMPARE( dialog->retrieveAttribute( pkAttributeItem ).toString(), QStringLiteral( "1.000" ) );
+  QCOMPARE( dialog->retrieveAttribute( pkAttributeItem, true ).toString(), QStringLiteral( "1000" ) );
+  QVERIFY( doublevalAttributeItem );
+  QCOMPARE( doublevalAttributeItem->text( 1 ), QStringLiteral( "1.000,50000" ) );
+  QCOMPARE( dialog->retrieveAttribute( doublevalAttributeItem ).toString(), QStringLiteral( "1.000,50000" ) );
+  QCOMPARE( dialog->retrieveAttribute( doublevalAttributeItem, true ).toString(), QStringLiteral( "1000.5" ) );
 }
 
 void TestQgsIdentify::testRelations()


### PR DESCRIPTION
## Description

### Current behavior
The values are displayed in it's represented form. Means e.g. numbers are formatted concerning the locale settings or e.g. foreign keys according to the configured display value:
<img width="963" height="83" alt="image" src="https://github.com/user-attachments/assets/c5a056a9-7794-4db1-8ce0-b09122420fa9" />

<img width="696" height="170" alt="image" src="https://github.com/user-attachments/assets/0c111cc0-2bff-4c27-aff8-bb8088f73193" />

E.g. integer and double value in the German format (with point as thousand separator and comma as decimal sign), as well as the date-time and the text value as representation of the foreign key in a relation (that would otherwise be a UUID).

### New feature
Sometimes it's usable to be able to get the value that is actually stored in the data source. This is the new option in the context menu **"Copy Raw Cell Content"** is introduced.

<img width="1031" height="156" alt="image" src="https://github.com/user-attachments/assets/eda0e279-d531-4d45-a0e4-4e8973fc82bf" />

What would copy here the value "11000.5" instead of 11.000,5 (as we would get it with "Copy Cell Content". 

Same is possible in the Identify Result list (on Vector Layers):

<img width="886" height="223" alt="image" src="https://github.com/user-attachments/assets/0d7c9507-eb3d-4c57-b435-6b951e686953" />

Btw. preview values get truncated after 12 chars:
<img width="885" height="190" alt="image" src="https://github.com/user-attachments/assets/df1b8915-0e46-4263-be2d-929bce7c67af" />

As well the **tooltips** are improved that if the original value differs from the display value, the original value is written in brackets:

<img width="722" height="117" alt="image" src="https://github.com/user-attachments/assets/070764a6-afe2-44bc-869c-df09b2c76605" />

<img width="722" height="117" alt="image" src="https://github.com/user-attachments/assets/19058d2a-3765-4542-a838-80b7b90e36f9" />

Financed by Ct. Solothurn

