### PR TITLE
Fix temporary file check

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -373,7 +373,7 @@ class Editor(QgsCodeEditorPython):
         msgEditorBlank = QCoreApplication.translate(
             "PythonConsole", "Hey, type something to run!"
         )
-        if filename is None:
+        if not filename:
             if not self.isModified():
                 self.showMessage(msgEditorBlank)
                 return

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -371,7 +371,7 @@ class Editor(QgsCodeEditorPython):
         filename = self.code_editor_widget.filePath()
         filename_override = None
         msgEditorBlank = QCoreApplication.translate(
-            "PythonConsole", "Hey, type something to run!"
+            "PythonConsole", "Empty scripts cannot be run!"
         )
         if not filename:
             if not self.isModified():


### PR DESCRIPTION
## Description

The runScriptCode contains a check to see if an empty temporary file is being launched. However, it didn't work because the variable in this case is a empty string.

I fixed this error in the current PR.

Before:
<img width="965" height="457" alt="image" src="https://github.com/user-attachments/assets/8ba6b6dd-3e47-4330-80f2-ea1865ef8586" />

After:
<img width="1058" height="494" alt="image" src="https://github.com/user-attachments/assets/83854f93-d3e3-4bcf-be39-5dc431376b92" />
