### PR TITLE
Fix Z/m logic in translate algorithm 

### DIFF
--- a/src/analysis/processing/qgsalgorithmexportmesh.cpp
+++ b/src/analysis/processing/qgsalgorithmexportmesh.cpp
@@ -690,7 +690,10 @@ QVariantMap QgsExportMeshOnGridAlgorithm::processAlgorithm( const QVariantMap &p
         feat.setGeometry( geom );
         feat.setAttributes( attributes );
 
-        sink->addFeature( feat );
+        if ( !sink->addFeature( feat, QgsFeatureSink::FastInsert ) )
+        {
+          throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QString() ) );
+        }
       }
     }
   }

--- a/src/analysis/processing/qgsalgorithmtranslate.cpp
+++ b/src/analysis/processing/qgsalgorithmtranslate.cpp
@@ -139,9 +139,9 @@ QgsFeatureList QgsTranslateAlgorithm::processFeature( const QgsFeature &feature,
     if ( mDynamicDeltaM )
       deltaM = mDeltaMProperty.valueAsDouble( context.expressionContext(), deltaM );
 
-    if ( deltaZ != 0.0 && !geometry.constGet()->is3D() )
+    if ( QgsWkbTypes::hasZ( mOutputWkbType ) && !geometry.constGet()->is3D() )
       geometry.get()->addZValue( 0 );
-    if ( deltaM != 0.0 && !geometry.constGet()->isMeasure() )
+    if ( QgsWkbTypes::hasM( mOutputWkbType ) && !geometry.constGet()->isMeasure() )
       geometry.get()->addMValue( 0 );
 
     geometry.translate( deltaX, deltaY, deltaZ, deltaM );
@@ -152,12 +152,12 @@ QgsFeatureList QgsTranslateAlgorithm::processFeature( const QgsFeature &feature,
 
 Qgis::WkbType QgsTranslateAlgorithm::outputWkbType( Qgis::WkbType inputWkbType ) const
 {
-  Qgis::WkbType wkb = inputWkbType;
+  mOutputWkbType = inputWkbType;
   if ( mDynamicDeltaZ || mDeltaZ != 0.0 )
-    wkb = QgsWkbTypes::addZ( wkb );
+    mOutputWkbType = QgsWkbTypes::addZ( mOutputWkbType );
   if ( mDynamicDeltaM || mDeltaM != 0.0 )
-    wkb = QgsWkbTypes::addM( wkb );
-  return wkb;
+    mOutputWkbType = QgsWkbTypes::addM( mOutputWkbType );
+  return mOutputWkbType;
 }
 
 bool QgsTranslateAlgorithm::supportInPlaceEdit( const QgsMapLayer *l ) const

--- a/src/analysis/processing/qgsalgorithmtranslate.h
+++ b/src/analysis/processing/qgsalgorithmtranslate.h
@@ -50,6 +50,7 @@ class QgsTranslateAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     Qgis::WkbType outputWkbType( Qgis::WkbType inputWkbType ) const override;
 
   private:
+    mutable Qgis::WkbType mOutputWkbType = Qgis::WkbType::Unknown;
     double mDeltaX = 0.0;
     bool mDynamicDeltaX = false;
     QgsProperty mDeltaXProperty;

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -1196,7 +1196,12 @@ QVariantMap QgsProcessingFeatureBasedAlgorithm::processAlgorithm( const QVariant
     context.expressionContext().setFeature( f );
     const QgsFeatureList transformed = processFeature( f, context, feedback );
     for ( QgsFeature transformedFeature : transformed )
-      sink->addFeature( transformedFeature, QgsFeatureSink::FastInsert );
+    {
+      if ( !sink->addFeature( transformedFeature, QgsFeatureSink::FastInsert ) )
+      {
+        throw QgsProcessingException( writeFeatureError( sink.get(), parameters, QString() ) );
+      }
+    }
 
     feedback->setProgress( current * step );
     current++;

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -1049,10 +1049,21 @@ QString QgsProcessingAlgorithm::writeFeatureError( QgsFeatureSink *sink, const Q
 {
   Q_UNUSED( sink );
   Q_UNUSED( parameters );
-  if ( !name.isEmpty() )
-    return QObject::tr( "Could not write feature into %1" ).arg( name );
+  const QString lastError = sink->lastError();
+  if ( !lastError.isEmpty() )
+  {
+    if ( !name.isEmpty() )
+      return QObject::tr( "Could not write feature into %1: %2" ).arg( name, lastError );
+    else
+      return QObject::tr( "Could not write feature: %1" ).arg( lastError );
+  }
   else
-    return QObject::tr( "Could not write feature" );
+  {
+    if ( !name.isEmpty() )
+      return QObject::tr( "Could not write feature into %1" ).arg( name );
+    else
+      return QObject::tr( "Could not write feature" );
+  }
 }
 
 bool QgsProcessingAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) const


### PR DESCRIPTION
When promoting from non z/m geometries to z/m geometries, we still need to ensure the output geometry has z/m values even if we aren't directly translating those (ie. translation is zero).

Spin off from https://github.com/qgis/QGIS/pull/63771