### PR TITLE
Add QgsCoordinateReferenceSystem.toJsonString()

### DIFF
--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -907,6 +907,21 @@ overridden with these.
 .. versionadded:: 3.10.3
 %End
 
+    std::string toJsonString( bool multiline = false, int indentationWidth = 4, const QString &schema = QString() ) const;
+%Docstring
+Returns a JSON string representation of this CRS.
+
+The returned string will be a PROJJSON string representation of the CRS.
+
+If ``multiline`` is ``True`` then a formatted multiline json string will
+be returned, using the specified ``indentationWidth``.
+
+The ``schema`` argument can be used to set a URL to PROJJSON schema.
+This can be set to empty string to disable it.
+
+.. versionadded:: 4.0
+%End
+
     Qgis::CrsType type() const;
 %Docstring
 Returns the type of the CRS.

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystem.sip.in
@@ -907,6 +907,21 @@ overridden with these.
 .. versionadded:: 3.10.3
 %End
 
+    std::string toJsonString( bool multiline = false, int indentationWidth = 4, const QString &schema = QString() ) const;
+%Docstring
+Returns a JSON string representation of this CRS.
+
+The returned string will be a PROJJSON string representation of the CRS.
+
+If ``multiline`` is ``True`` then a formatted multiline json string will
+be returned, using the specified ``indentationWidth``.
+
+The ``schema`` argument can be used to set a URL to PROJJSON schema.
+This can be set to empty string to disable it.
+
+.. versionadded:: 4.0
+%End
+
     Qgis::CrsType type() const;
 %Docstring
 Returns the type of the CRS.

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1379,7 +1379,8 @@ std::string QgsCoordinateReferenceSystem::toJsonString( bool multiline, int inde
     const QByteArray schemaOption = QStringLiteral( "SCHEMA=%1" ).arg( schema ).toLocal8Bit();
     const char *const options[] = {multiLineOption.constData(), indentatationWidthOption.constData(), schemaOption.constData(), nullptr};
 
-    return std::string{ proj_as_projjson( QgsProjContext::get(), obj, options ) };
+    const char *json = proj_as_projjson( QgsProjContext::get(), obj, options );
+    return json ? std::string{ json } : std::string{};
   }
   else
   {

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1367,6 +1367,26 @@ QString QgsCoordinateReferenceSystem::toProj() const
   return d->mProj4.trimmed();
 }
 
+std::string QgsCoordinateReferenceSystem::toJsonString( bool multiline, int indentationWidth, const QString &schema ) const
+{
+  if ( !d->mIsValid )
+    return {};
+
+  if ( PJ *obj = d->threadLocalProjObject() )
+  {
+    const QByteArray multiLineOption = QStringLiteral( "MULTILINE=%1" ).arg( multiline ? QStringLiteral( "YES" ) : QStringLiteral( "NO" ) ).toLocal8Bit();
+    const QByteArray indentatationWidthOption = QStringLiteral( "INDENTATION_WIDTH=%1" ).arg( multiline ? QString::number( indentationWidth ) : QStringLiteral( "0" ) ).toLocal8Bit();
+    const QByteArray schemaOption = QStringLiteral( "SCHEMA=%1" ).arg( schema ).toLocal8Bit();
+    const char *const options[] = {multiLineOption.constData(), indentatationWidthOption.constData(), schemaOption.constData(), nullptr};
+
+    return std::string{ proj_as_projjson( QgsProjContext::get(), obj, options ) };
+  }
+  else
+  {
+    return {};
+  }
+}
+
 Qgis::CrsType QgsCoordinateReferenceSystem::type() const
 {
   // NOLINTBEGIN(bugprone-branch-clone)

--- a/src/core/proj/qgscoordinatereferencesystem.h
+++ b/src/core/proj/qgscoordinatereferencesystem.h
@@ -756,6 +756,19 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     QString toProj() const;
 
     /**
+     * Returns a JSON string representation of this CRS.
+     *
+     * The returned string will be a PROJJSON string representation of the CRS.
+     *
+     * If \a multiline is TRUE then a formatted multiline json string will be returned, using the specified \a indentationWidth.
+     *
+     * The \a schema argument can be used to set a URL to PROJJSON schema. This can be set to empty string to disable it.
+     *
+     * \since QGIS 4.0
+     */
+    std::string toJsonString( bool multiline = false, int indentationWidth = 4, const QString &schema = QString() ) const;
+
+    /**
      * Returns the type of the CRS.
      *
      * \since QGIS 3.34

--- a/tests/src/python/test_qgscoordinatereferencesystem.py
+++ b/tests/src/python/test_qgscoordinatereferencesystem.py
@@ -12,6 +12,7 @@ __author__ = "(C) 2022 by Nyall Dawson"
 __date__ = "06/04/2022"
 __copyright__ = "Copyright 2022, The QGIS Project"
 
+import json
 
 from qgis.core import Qgis, QgsCoordinateReferenceSystem
 import unittest
@@ -177,6 +178,39 @@ class TestQgsCoordinateReferenceSystem(QgisTestCase):
             float(crs.ellipsoidAcronym().split(":")[2]), 6356078.962818189, -1
         )
         self.assertEqual(crs.celestialBodyName(), "Earth")
+
+    def test_to_json_string(self):
+        self.assertFalse(QgsCoordinateReferenceSystem().toJsonString())
+        proj_json = json.loads(QgsCoordinateReferenceSystem("EPSG:3111").toJsonString())
+        # don't check the whole json, we want this test to be tolerant to changes
+        # in proj library!
+        self.assertEqual(
+            proj_json["type"],
+            "ProjectedCRS",
+        )
+        self.assertEqual(
+            proj_json["name"],
+            "GDA94 / Vicgrid",
+        )
+
+        self.assertNotIn(
+            "\n",
+            QgsCoordinateReferenceSystem("EPSG:3111").toJsonString(multiline=False),
+        )
+        self.assertIn(
+            "\n", QgsCoordinateReferenceSystem("EPSG:3111").toJsonString(multiline=True)
+        )
+        self.assertIn(
+            " " * 30,
+            QgsCoordinateReferenceSystem("EPSG:3111").toJsonString(
+                multiline=True, indentationWidth=30
+            ),
+        )
+
+        proj_json = json.loads(
+            QgsCoordinateReferenceSystem("EPSG:3111").toJsonString(schema="xxx")
+        )
+        self.assertEqual(proj_json["$schema"], "xxx")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Returns a PROJJSON string representation of a CRS.

Before the inevitable questions: :laughing: 

I've opted to return a std::string here NOT a QString, because:

- The string from proj library will ALWAYS be utf8
- Converting this to QString will incur a utf16 conversion
- It's expected that the string returned by this method will be handed off to nohlmann library for parsing (c++), which would then incur a QString -> utf8 std::string conversion as required by that library
- sip is perfectly happy to handle std::string -> python string conversion, so there's no issues there.
- given expected use cases for this api, there's zero benefits for qstring's implicit sharing

