### PR TITLE
[core] Reset the QgsApplication message log member _last_ in case other members throw log messages during destruction

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -2993,7 +2993,6 @@ QgsApplication::ApplicationMembers::~ApplicationMembers()
   mFieldFormatterRegistry.reset();
   mGpsConnectionRegistry.reset();
   mGpsBabelFormatRegistry.reset();
-  mMessageLog.reset();
   mPaintEffectRegistry.reset();
   mPluginLayerRegistry.reset();
   mProcessingRegistry.reset();
@@ -3027,6 +3026,7 @@ QgsApplication::ApplicationMembers::~ApplicationMembers()
   mLocalizedDataPathRegistry.reset();
   mCrsRegistry.reset();
   mQueryLogger.reset();
+  mMessageLog.reset();
 }
 
 QgsApplication::ApplicationMembers *QgsApplication::members()


### PR DESCRIPTION
## Description

Title says it all :) -- @nyalldawson , as discussed.