### PR TITLE
Copy coordinate context menu: include axis direction suffixes in clipboard output

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1248,10 +1248,10 @@ void QgsMapCanvas::showContextMenu( QgsMapMouseEvent *event )
 
       QAction *copyCoordinateAction = new QAction( QStringLiteral( "%5 (%1%2, %3%4)" ).arg( firstNumber, firstSuffix, secondNumber, secondSuffix, identifier ), &menu );
 
-      connect( copyCoordinateAction, &QAction::triggered, this, [firstNumber, secondNumber, transformedPoint] {
+      connect( copyCoordinateAction, &QAction::triggered, this, [firstNumber, firstSuffix, secondNumber, secondSuffix, transformedPoint] {
         QClipboard *clipboard = QApplication::clipboard();
 
-        const QString coordinates = firstNumber + ',' + secondNumber;
+        const QString coordinates = QStringLiteral( "%1%2, %3%4" ).arg( firstNumber, firstSuffix, secondNumber, secondSuffix );
 
         //if we are on x11 system put text into selection ready for middle button pasting
         if ( clipboard->supportsSelection() )


### PR DESCRIPTION
## Description

When using the `Copy Coordinate -> Map CRS...` action in the map canvas context menu, the coordinate text shown in the menu includes axis direction suffixes (e.g. N, S, E, W) as derived from CRS axis ordering. However the actual copied clipboard content did not include these suffixes, even though users visually see them in the menu.

This PR adds firstSuffix and secondSuffix to the lambda capture, and formats the clipboard coordinate string identically.

**Tested** manually with EPSG:4326/Qt5