### PR TITLE
Save dialog geometry for QgsFeatureSelectionDlg

### DIFF
--- a/src/gui/qgsfeatureselectiondlg.cpp
+++ b/src/gui/qgsfeatureselectiondlg.cpp
@@ -23,6 +23,7 @@
 #include "qgsapplication.h"
 #include "qgsexpressionselectiondialog.h"
 #include "qgsmapcanvas.h"
+#include "qgsgui.h"
 
 #include <QWindow>
 
@@ -32,6 +33,7 @@ QgsFeatureSelectionDlg::QgsFeatureSelectionDlg( QgsVectorLayer *vl, const QgsAtt
   , mContext( context )
 {
   setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
 
   mFeatureSelection = new QgsVectorLayerSelectionManager( vl, mDualView );
 


### PR DESCRIPTION
## Description

The dialog used for linking (1) a feature in a relational attribute now saves its geometry.

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/9de6db34-5555-4e39-acbc-cb49d6dc1019" />

---

Funded by Bordeaux Métropole