### PR TITLE
Two small fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if (USE_CCACHE AND MSVC)
   # CCache doesn't work yet with precompiled headers (cf https://github.com/ccache/ccache/issues/1383)
   set(USE_PRECOMPILED_HEADERS OFF)
 else()
-  set(USE_PRECOMPILED_HEADERS ON)
+  option(USE_PRECOMPILED_HEADERS "Use precompiled headers" ON)
 endif()
 
 if (IOS)

--- a/src/core/pal/priorityqueue.cpp
+++ b/src/core/pal/priorityqueue.cpp
@@ -28,6 +28,7 @@
  */
 
 #include <cstdio>
+#include <memory>
 
 #include "internalexception.h"
 #include "priorityqueue.h"


### PR DESCRIPTION
- CMakeLists.txt: make USE_PRECOMPILED_HEADERS an option that can be disabled
- src/core/pal/priorityqueue.cpp: add missing inclusion

triggered by https://lists.osgeo.org/pipermail/qgis-developer/2025-November/067871.html