### PR TITLE
qgsrasterattributetable: Add std:: to bare isnan()

### DIFF
--- a/src/core/raster/qgsrasterattributetable.cpp
+++ b/src/core/raster/qgsrasterattributetable.cpp
@@ -1374,7 +1374,7 @@ QgsGradientColorRamp QgsRasterAttributeTable::colorRamp( QStringList &labels, co
       if ( range != 0 )
       {
 
-        if ( ! isnan( min ) && ! isnan( max ) )
+        if ( ! std::isnan( min ) && ! std::isnan( max ) )
         {
           const QList<QVariantList> dataCopy( orderedRows() );
 


### PR DESCRIPTION
## Description

Standards say that compilers may make available names without std::, but this is not required.    I've run into unqualified references like this before, and we've always just added std::.

With this change, the file builds (qgis master, qt5, NetBSD 10, amd64, gcc10), whereas without the compiler errored.  Because of other unrelated issues, my build doesn't complete.

I have also applied this change to 3.44.4 (and before that 3.40.x) via pkgsrc.  The resulting sources build and work.

This change should be backported to 3.44.   I don't have an opinion about 3.40.