### PR TITLE
[sip] Add full support for std::unique_ptr

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -134,6 +134,10 @@ if(NOT WITH_SFCGAL)
     set(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} HAVE_SFCGAL_SIP)
 endif()
 
+# sip 6.11 has support for the Movable Mapped Type Annotation
+if(${SIP_VERSION_STR} VERSION_LESS 6.11.0)
+  set(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} MOVABLE_MAPPED_TYPE)
+endif()
 
 # Deprecated annotation supports message only since version 6.9.0 with abi-version 12.16 / 13.9 and above
 if(${SIP_VERSION_STR} VERSION_LESS 6.9.0)

--- a/python/PyQt6/core/conversions.sip
+++ b/python/PyQt6/core/conversions.sip
@@ -1243,23 +1243,62 @@ which are not wrapped by PyQt:
     %End
 };
 
+%If (MOVABLE_MAPPED_TYPE)
 template <TYPE>
-%MappedType std::unique_ptr< TYPE > /NoRelease,AllowNone,TypeHint="Optional[TYPE]",TypeHintValue="TYPE"/
+%MappedType std::unique_ptr<TYPE> /Movable,NoRelease,AllowNone,TypeHint="Optional[TYPE]",TypeHintValue="TYPE"/
+{
+%TypeHeaderCode
+#include <memory>
+#include <utility>      // For std::move().
+%End
+
+%ConvertFromTypeCode
+  const sipTypeDef *sip_type = sipFindType("TYPE*");
+  return sipConvertFromNewType(sipCpp->release(), sip_type, NULL);
+%End
+
+%ConvertToTypeCode
+  const sipTypeDef *sip_type = sipFindType("TYPE");
+
+  if (sipIsErr == NULL)
+    return sipCanConvertToType(sipPy, sip_type, 0);
+
+  if (sipPy == Py_None)
+    return 1;
+
+  int state;
+  TYPE *type_ = reinterpret_cast<TYPE *>(sipConvertToType(sipPy, sip_type, sipTransferObj, 0, &state, sipIsErr));
+
+  sipReleaseType(type_, sip_type, state);
+
+  if (*sipIsErr)
+    return 0;
+
+  *sipCppPtr = new std::unique_ptr<TYPE>(type_);
+  return sipGetState(sipTransferObj);
+%End
+};
+%End
+
+%If (!MOVABLE_MAPPED_TYPE)
+template <TYPE>
+%MappedType std::unique_ptr<TYPE> /NoRelease,AllowNone,TypeHint="Optional[TYPE]",TypeHintValue="TYPE"/
 {
 %TypeHeaderCode
 #include <memory>
 %End
 
 %ConvertFromTypeCode
-    const sipTypeDef *sip_type = sipFindType("TYPE*");
-    return sipConvertFromNewType(sipCpp->release(), sip_type, NULL);
+  const sipTypeDef *sip_type = sipFindType("TYPE*");
+  return sipConvertFromNewType(sipCpp->release(), sip_type, NULL);
 %End
 
 %ConvertToTypeCode
-    // only one way for now...
-    return 0;
+  // only one way for now...
+  return 0;
 %End
 };
+%End
 
 template <TYPE>
 %MappedType QVector< QVector<TYPE> >

--- a/python/PyQt6/core/conversions.sip
+++ b/python/PyQt6/core/conversions.sip
@@ -3167,10 +3167,10 @@ template <TYPE>
     PyTuple_SetItem( obj, 0, v1 );
     PyObject *v2 = PyFloat_FromDouble( ( *it ).second );
     PyTuple_SetItem( obj, 1, v2 );
-    
+
     PyList_SET_ITEM(l, i, obj);
   }
-  
+
   return l;
 %End
 
@@ -3193,7 +3193,7 @@ template <TYPE>
 
     PyObject *sipSecond = PyTuple_GetItem( PyList_GET_ITEM(sipPy, i), 1 );
     double v2 = PyFloat_AsDouble(sipSecond);
-    
+
     ql->append( std::make_pair( v1, v2 ) );
   }
 

--- a/python/PyQt6/core/core.sip.in
+++ b/python/PyQt6/core/core.sip.in
@@ -99,6 +99,7 @@ done:
 %Feature HAVE_WEBENGINE_SIP
 %Feature PYQT6
 %Feature HAVE_SFCGAL_SIP
+%Feature MOVABLE_MAPPED_TYPE
 
 %Import QtXml/QtXmlmod.sip
 %Import QtNetwork/QtNetworkmod.sip

--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -3218,10 +3218,10 @@ template <TYPE>
     PyTuple_SetItem( obj, 0, v1 );
     PyObject *v2 = PyFloat_FromDouble( ( *it ).second );
     PyTuple_SetItem( obj, 1, v2 );
-    
+
     PyList_SET_ITEM(l, i, obj);
   }
-  
+
   return l;
 %End
 
@@ -3244,7 +3244,7 @@ template <TYPE>
 
     PyObject *sipSecond = PyTuple_GetItem( PyList_GET_ITEM(sipPy, i), 1 );
     double v2 = PyFloat_AsDouble(sipSecond);
-    
+
     ql->append( std::make_pair( v1, v2 ) );
   }
 

--- a/python/core/core.sip.in
+++ b/python/core/core.sip.in
@@ -98,6 +98,7 @@ done:
 %Feature VECTOR_MAPPED_TYPE
 %Feature HAVE_WEBENGINE_SIP
 %Feature HAVE_SFCGAL_SIP
+%Feature MOVABLE_MAPPED_TYPE
 
 %Import QtXml/QtXmlmod.sip
 %Import QtNetwork/QtNetworkmod.sip


### PR DESCRIPTION
## Description

sip 6.11 introduced a `/Movable/` mapped type annotation which allows to properly pass and return `std::unique_ptr` by value.

Related: https://github.com/Python-SIP/sip/issues/60

I did some testing with sip 6.14 and it works fine. I'm not sure we want to merge it now. It needs SIP 6.11. Both fedora 42 and Ubuntu 25.04 have SIP 6.10

cc @troopa81 