### PR TITLE
qgscategorizedsymbolrendererwidget: Properly initialize invalid QVariant

### DIFF
--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -1134,7 +1134,7 @@ void QgsCategorizedSymbolRendererWidget::addCategory()
   if ( !mModel )
     return;
   QgsSymbol *symbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
-  const QgsRendererCategory cat( QString(), symbol, QString(), true );
+  const QgsRendererCategory cat( QVariant(), symbol, QString(), true );
   mModel->addCategory( cat );
   emit widgetChanged();
 }


### PR DESCRIPTION
## Description

This fixes the following warning:

```
NULL QString was stored in a QVariant -- stop it! Always use an
invalid QVariant() instead
```

