### PR TITLE
Improve panning in 3D with orthographic projection

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -604,31 +604,58 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     }
 
     QVector3D cameraBeforeDragPos = mCameraBefore->position();
-
     QVector3D moveToPosition = Qgs3DUtils::screenPointToWorldPos( { mouse->x(), mouse->y() }, mDragDepth, mScene->engine()->size(), mCameraBefore.get() );
-    QVector3D cameraBeforeToMoveToPos = ( moveToPosition - mCameraBefore->position() ).normalized();
-    QVector3D cameraBeforeToDragPointPos = ( mDragPoint - mCameraBefore->position() ).normalized();
 
-    // Make sure the rays are not horizontal (add small z shift if it is)
-    if ( cameraBeforeToMoveToPos.z() == 0 )
+    QVector3D shiftVector;
+    switch ( mScene->mapSettings()->projectionType() )
     {
-      cameraBeforeToMoveToPos.setZ( 0.01 );
-      cameraBeforeToMoveToPos = cameraBeforeToMoveToPos.normalized();
+      case Qt3DRender::QCameraLens::OrthographicProjection:
+      {
+        // For orthographic projection, compute angle of camera's view vector to
+        // ground and decide if moving the cursor up-down should change altitude or
+        // latitude/longitude.
+        float angle = std::acos( QVector3D::dotProduct( QVector3D( 0, 1, 0 ), mCameraBefore->viewVector().normalized() ) );
+        bool changeAltitude = angle < M_PI / 3;
+
+        if ( changeAltitude )
+          shiftVector = mDragPoint - moveToPosition;
+        else
+          // Project change to XY plane.
+          // This isn't quite accurate at higher angles, "desyncing" the mouse
+          // cursor and the dragged point.
+          shiftVector = { mDragPoint.x() - moveToPosition.x(), mDragPoint.y() - moveToPosition.y(), 0 };
+        break;
+      }
+      case Qt3DRender::QCameraLens::PerspectiveProjection:
+      {
+        QVector3D cameraBeforeToMoveToPos = ( moveToPosition - mCameraBefore->position() ).normalized();
+        QVector3D cameraBeforeToDragPointPos = ( mDragPoint - mCameraBefore->position() ).normalized();
+
+        // Make sure the rays are not horizontal (add small z shift if it is)
+        if ( cameraBeforeToMoveToPos.z() == 0 )
+        {
+          cameraBeforeToMoveToPos.setZ( 0.01 );
+          cameraBeforeToMoveToPos = cameraBeforeToMoveToPos.normalized();
+        }
+
+        if ( cameraBeforeToDragPointPos.z() == 0 )
+        {
+          cameraBeforeToDragPointPos.setZ( 0.01 );
+          cameraBeforeToDragPointPos = cameraBeforeToDragPointPos.normalized();
+        }
+
+        double d1 = ( mDragPoint.z() - cameraBeforeDragPos.z() ) / cameraBeforeToMoveToPos.z();
+        double d2 = ( mDragPoint.z() - cameraBeforeDragPos.z() ) / cameraBeforeToDragPointPos.z();
+
+        QVector3D from = cameraBeforeDragPos + d1 * cameraBeforeToMoveToPos;
+        QVector3D to = cameraBeforeDragPos + d2 * cameraBeforeToDragPointPos;
+
+        shiftVector = to - from;
+        break;
+      }
+      default:
+        QgsDebugError("Unhandled 3D projection type");
     }
-
-    if ( cameraBeforeToDragPointPos.z() == 0 )
-    {
-      cameraBeforeToDragPointPos.setZ( 0.01 );
-      cameraBeforeToDragPointPos = cameraBeforeToDragPointPos.normalized();
-    }
-
-    double d1 = ( mDragPoint.z() - cameraBeforeDragPos.z() ) / cameraBeforeToMoveToPos.z();
-    double d2 = ( mDragPoint.z() - cameraBeforeDragPos.z() ) / cameraBeforeToDragPointPos.z();
-
-    QVector3D from = cameraBeforeDragPos + d1 * cameraBeforeToMoveToPos;
-    QVector3D to = cameraBeforeDragPos + d2 * cameraBeforeToDragPointPos;
-
-    QVector3D shiftVector = to - from;
 
     mCameraPose.setCenterPoint( mCameraBefore->viewCenter() + shiftVector );
     updateCameraFromPose();

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -644,8 +644,8 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
           cameraBeforeToDragPointPos = cameraBeforeToDragPointPos.normalized();
         }
 
-        double d1 = ( mDragPoint.z() - cameraBeforeDragPos.z() ) / cameraBeforeToMoveToPos.z();
-        double d2 = ( mDragPoint.z() - cameraBeforeDragPos.z() ) / cameraBeforeToDragPointPos.z();
+        float d1 = ( mDragPoint.z() - cameraBeforeDragPos.z() ) / cameraBeforeToMoveToPos.z();
+        float d2 = ( mDragPoint.z() - cameraBeforeDragPos.z() ) / cameraBeforeToDragPointPos.z();
 
         QVector3D from = cameraBeforeDragPos + d1 * cameraBeforeToMoveToPos;
         QVector3D to = cameraBeforeDragPos + d2 * cameraBeforeToDragPointPos;
@@ -654,7 +654,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
         break;
       }
       default:
-        QgsDebugError("Unhandled 3D projection type");
+        QgsDebugError( "Unhandled 3D projection type" );
     }
 
     mCameraPose.setCenterPoint( mCameraBefore->viewCenter() + shiftVector );

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -1350,7 +1350,7 @@ void TestQgs3DCameraController::testOrthographic()
   QMouseEvent mouseReleaseEvent3( QEvent::MouseButtonRelease, midPos + movement3, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
   scene->cameraController()->onMouseReleased( new Qt3DInput::QMouseEvent( mouseReleaseEvent3 ) );
 
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QgsVector3D( -2338, 502, 142 ), 5 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QgsVector3D( -2338, 502, 137 ), 5 );
 
   delete scene;
   mapSettings->setLayers( {} );

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -1316,7 +1316,7 @@ void TestQgs3DCameraController::testOrthographic()
   QMouseEvent mouseReleaseEvent1( QEvent::MouseButtonRelease, midPos + movement1, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
   scene->cameraController()->onMouseReleased( new Qt3DInput::QMouseEvent( mouseReleaseEvent1 ) );
 
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QgsVector3D( -1853, 582, 0 ), 5 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QgsVector3D( -2338, 582, 0 ), 5 );
 
   // Rotate to look sideways
   QMouseEvent mousePressEvent2( QEvent::MouseButtonPress, midPos, Qt::LeftButton, Qt::LeftButton, Qt::ControlModifier );
@@ -1332,7 +1332,7 @@ void TestQgs3DCameraController::testOrthographic()
   QMouseEvent mouseReleaseEvent2( QEvent::MouseButtonRelease, midPos + movement2, Qt::LeftButton, Qt::LeftButton, Qt::ControlModifier );
   scene->cameraController()->onMouseReleased( new Qt3DInput::QMouseEvent( mouseReleaseEvent2 ) );
 
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QgsVector3D( -1853, 1690, 403 ), 5 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QgsVector3D( -2338, 1690, 403 ), 5 );
   QGSCOMPARENEAR( scene->cameraController()->pitch(), 40, 1 );
   QGSCOMPARENEAR( scene->cameraController()->yaw(), 0, 1 );
 
@@ -1350,7 +1350,7 @@ void TestQgs3DCameraController::testOrthographic()
   QMouseEvent mouseReleaseEvent3( QEvent::MouseButtonRelease, midPos + movement3, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier );
   scene->cameraController()->onMouseReleased( new Qt3DInput::QMouseEvent( mouseReleaseEvent3 ) );
 
-  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QgsVector3D( -1853, -193, 403 ), 5 );
+  QGSCOMPARENEARVECTOR3D( scene->cameraController()->cameraPose().centerPoint(), QgsVector3D( -2338, 502, 142 ), 5 );
 
   delete scene;
   mapSettings->setLayers( {} );


### PR DESCRIPTION
## Description

This PR builds on the work done in  #63480 and changes the 3D camera when using the orthographic projection to move either up/down or forward/back depending on the pitch angle. This is useful for e.g. the cross section tool.

The forward/back movement calculation isn't quite correct: The dragged point doesn't quite stay under the mouse cursor. I still think it's a big step forward from the current mostly-broken panning.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
