### PR TITLE
Allow rename of layer in the layer panel when saving a scratch layer for sources without explicit layer name

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8190,23 +8190,33 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
 
       QgsMessageBarItem *barItem = new QgsMessageBarItem( tr( "Layer Saved" ), tr( "Successfully saved scratch layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ), Qgis::MessageLevel::Success, 0 );
 
-      if ( ( !newLayerName.isEmpty() ) )
+      QString layerNameForRename;
+
+      if ( newLayerName.isEmpty() )
       {
-        if ( newLayerName != vl->name() )
-        {
-          QPushButton *button = new QPushButton( tr( "Also rename layer in layers panel" ), this );
-          barItem->setWidget( button );
-
-          connect( vl, &QgsVectorLayer::willBeDeleted, this, [button]() {
-            button->setEnabled( false );
-          } );
-
-          connect( button, &QPushButton::clicked, this, [button, vl, newLayerName]() {
-            vl->setName( newLayerName );
-            button->setEnabled( false );
-          } );
-        }
+        QFileInfo fileInfoSource( source );
+        layerNameForRename = fileInfoSource.baseName();
       }
+      else
+      {
+        layerNameForRename = newLayerName;
+      }
+
+      if ( layerNameForRename != vl->name() )
+      {
+        QPushButton *button = new QPushButton( tr( "Also rename layer in layers panel" ), this );
+        barItem->setWidget( button );
+
+        connect( vl, &QgsVectorLayer::willBeDeleted, this, [button]() {
+          button->setEnabled( false );
+        } );
+
+        connect( button, &QPushButton::clicked, this, [button, vl, layerNameForRename]() {
+          vl->setName( layerNameForRename );
+          button->setEnabled( false );
+        } );
+      }
+
 
       this->visibleMessageBar()->pushItem( barItem );
     }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8217,7 +8217,6 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
         } );
       }
 
-
       this->visibleMessageBar()->pushItem( barItem );
     }
   };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8207,11 +8207,11 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
         QPushButton *button = new QPushButton( tr( "Also rename layer in layers panel" ), this );
         barItem->setWidget( button );
 
-        connect( vl, &QgsVectorLayer::willBeDeleted, this, [button]() {
+        connect( vl, &QgsVectorLayer::willBeDeleted, barItem, [button]() {
           button->setEnabled( false );
         } );
 
-        connect( button, &QPushButton::clicked, this, [button, vl, layerNameForRename]() {
+        connect( button, &QPushButton::clicked, vl, [button, vl, layerNameForRename]() {
           vl->setName( layerNameForRename );
           button->setEnabled( false );
         } );


### PR DESCRIPTION
## Description

This is a follow up for #62664 based also on discussion here [https://github.com/qgis/QGIS-Documentation/issues/10336](https://github.com/qgis/QGIS-Documentation/issues/10336). 

Allows renaming of layers even if layer name is not specified, in such cases use file stem as layername.

Funded by: QGIS DK user group
