### PR TITLE
Update condition for documentation comment action

### DIFF
--- a/.github/workflows/pr-needs-documentation.yml
+++ b/.github/workflows/pr-needs-documentation.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
       - name: Create comment about documentation
-        if: github.event.label.name == 'Needs Documentation'
+        if: github.event.pull_request.merged == false && github.event.label.name == 'Needs Documentation'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.GH_TOKEN_BOT }}


### PR DESCRIPTION
When "needs documentation" label is added to an already merged PR, there is no need to ask PR author to adjust the description for docs (it has already been pulled). And experience has proven that very, very few people follow that advice.
Also hiding that message will lead to less noise, and hopefully help focusing on the information that an issue has been created in docs repo _for them_.