### PR TITLE
Fix 3D map crashing (QgsTerrainGenerator)

### DIFF
--- a/src/3d/qgs3drendercontext.cpp
+++ b/src/3d/qgs3drendercontext.cpp
@@ -30,7 +30,7 @@ Qgs3DRenderContext::Qgs3DRenderContext( const Qgs3DRenderContext &other )
   , mTerrainRenderingEnabled( other.mTerrainRenderingEnabled )
   , mTerrainSettings( std::unique_ptr<QgsAbstractTerrainSettings>( other.mTerrainSettings->clone() ) )
   , mExpressionContext( other.mExpressionContext )
-  , mTerrainGenerator( other.mTerrainGenerator ? std::unique_ptr<QgsTerrainGenerator>( other.mTerrainGenerator->clone() ) : nullptr )
+  , mTerrainGenerator( other.mTerrainGenerator )
 {
 }
 
@@ -52,7 +52,7 @@ Qgs3DRenderContext &Qgs3DRenderContext::operator=( const Qgs3DRenderContext &oth
   mTerrainRenderingEnabled = other.mTerrainRenderingEnabled;
   mTerrainSettings.reset( other.mTerrainSettings->clone() );
   mExpressionContext = other.mExpressionContext;
-  mTerrainGenerator.reset( other.mTerrainGenerator ? other.mTerrainGenerator->clone() : nullptr );
+  mTerrainGenerator = other.mTerrainGenerator;
   return *this;
 }
 
@@ -71,7 +71,7 @@ Qgs3DRenderContext Qgs3DRenderContext::fromMapSettings( const Qgs3DMapSettings *
   res.mFieldOfView = mapSettings->fieldOfView();
   res.mTerrainRenderingEnabled = mapSettings->terrainRenderingEnabled();
   res.mTerrainSettings = std::unique_ptr<QgsAbstractTerrainSettings>( mapSettings->terrainSettings()->clone() );
-  res.mTerrainGenerator = mapSettings->terrainGenerator() ? std::unique_ptr<QgsTerrainGenerator>( mapSettings->terrainGenerator()->clone() ) : nullptr;
+  res.mTerrainGenerator = mapSettings->terrainGenerator();
   return res;
 }
 

--- a/src/3d/qgs3drendercontext.cpp
+++ b/src/3d/qgs3drendercontext.cpp
@@ -30,7 +30,7 @@ Qgs3DRenderContext::Qgs3DRenderContext( const Qgs3DRenderContext &other )
   , mTerrainRenderingEnabled( other.mTerrainRenderingEnabled )
   , mTerrainSettings( std::unique_ptr<QgsAbstractTerrainSettings>( other.mTerrainSettings->clone() ) )
   , mExpressionContext( other.mExpressionContext )
-  , mTerrainGenerator( other.mTerrainGenerator )
+  , mTerrainGenerator( other.mTerrainGenerator ? std::unique_ptr<QgsTerrainGenerator>( other.mTerrainGenerator->clone() ) : nullptr )
 {
 }
 
@@ -52,7 +52,7 @@ Qgs3DRenderContext &Qgs3DRenderContext::operator=( const Qgs3DRenderContext &oth
   mTerrainRenderingEnabled = other.mTerrainRenderingEnabled;
   mTerrainSettings.reset( other.mTerrainSettings->clone() );
   mExpressionContext = other.mExpressionContext;
-  mTerrainGenerator = other.mTerrainGenerator;
+  mTerrainGenerator.reset( other.mTerrainGenerator ? other.mTerrainGenerator->clone() : nullptr );
   return *this;
 }
 
@@ -71,7 +71,7 @@ Qgs3DRenderContext Qgs3DRenderContext::fromMapSettings( const Qgs3DMapSettings *
   res.mFieldOfView = mapSettings->fieldOfView();
   res.mTerrainRenderingEnabled = mapSettings->terrainRenderingEnabled();
   res.mTerrainSettings = std::unique_ptr<QgsAbstractTerrainSettings>( mapSettings->terrainSettings()->clone() );
-  res.mTerrainGenerator = mapSettings->terrainGenerator();
+  res.mTerrainGenerator = mapSettings->terrainGenerator() ? std::unique_ptr<QgsTerrainGenerator>( mapSettings->terrainGenerator()->clone() ) : nullptr;
   return res;
 }
 

--- a/src/3d/qgs3drendercontext.h
+++ b/src/3d/qgs3drendercontext.h
@@ -129,7 +129,7 @@ class _3D_EXPORT Qgs3DRenderContext
     /**
      * Returns the terrain generator.
      */
-    QgsTerrainGenerator *terrainGenerator() const { return mTerrainGenerator; }
+    QgsTerrainGenerator *terrainGenerator() const { return mTerrainGenerator.get(); }
 
     /**
      * Sets the expression context. This context is used for all expression evaluation
@@ -171,7 +171,7 @@ class _3D_EXPORT Qgs3DRenderContext
 
     // not owned, currently a pointer to the Qgs3DMapSettings terrain generator.
     // TODO -- fix during implementation of https://github.com/qgis/QGIS-Enhancement-Proposals/issues/301
-    QgsTerrainGenerator *mTerrainGenerator = nullptr; //!< Implementation of the terrain generation
+    std::unique_ptr<QgsTerrainGenerator> mTerrainGenerator; //!< Implementation of the terrain generation
 };
 
 

--- a/src/3d/qgs3drendercontext.h
+++ b/src/3d/qgs3drendercontext.h
@@ -24,10 +24,10 @@
 #include "qgscoordinatetransformcontext.h"
 #include "qgsexpressioncontext.h"
 #include "qgsabstractterrainsettings.h"
+#include "qgsterraingenerator.h"
 
 #include <QColor>
 
-class QgsTerrainGenerator;
 class Qgs3DMapSettings;
 
 #define SIP_NO_FILE
@@ -129,7 +129,7 @@ class _3D_EXPORT Qgs3DRenderContext
     /**
      * Returns the terrain generator.
      */
-    QgsTerrainGenerator *terrainGenerator() const { return mTerrainGenerator.get(); }
+    QgsTerrainGenerator *terrainGenerator() const { return mTerrainGenerator; }
 
     /**
      * Sets the expression context. This context is used for all expression evaluation
@@ -171,7 +171,7 @@ class _3D_EXPORT Qgs3DRenderContext
 
     // not owned, currently a pointer to the Qgs3DMapSettings terrain generator.
     // TODO -- fix during implementation of https://github.com/qgis/QGIS-Enhancement-Proposals/issues/301
-    std::unique_ptr<QgsTerrainGenerator> mTerrainGenerator; //!< Implementation of the terrain generation
+    QPointer<QgsTerrainGenerator> mTerrainGenerator; //!< Implementation of the terrain generation
 };
 
 


### PR DESCRIPTION
See the source of my misery: #63646

This dirty solution prevents the crash from happening, but it is meant to start a discussion on how to handle `QgsTerrainGenerator` in `Qgs3DRenderContext`.

`Qgs3DRenderContext` holds a pointer to `QgsTerrainGenerator` which, on window closing, gets destroyed while the loop is still active and when the loop tries to use a method from `QgsTerrainGenerator` (now a `nullptr`), it crashes QGIS.

In `Qgs3DMapSettings`, there is a setter for `QgsTerrainGenerator`. 
Is the point of having a raw pointer in `Qgs3DRenderContext` so that it always points to the `QgsTerrainGenerator` stored in `Qgs3DMapSettings`, so even if the generator changes there, `Qgs3DRenderContext` always fetches the most recent one? It seems like the solution was only ever meant to be a temporary one, but I feel like I am missing some context on what the final outcome was envisioned to be.

`QgsAbstractTerrainSettings` has a method `virtual std::unique_ptr<QgsTerrainGenerator> createTerrainGenerator( const Qgs3DRenderContext &context )`.
It takes `Qgs3DRenderContext` to create a `QgsTerrainGenerator`, `Qgs3DMapSettings` stores it, but then `Qgs3DRenderContext` is then set to point to that `QgsTerrainGenerator`??

My brain hurts…

Copying `QgsTerrainGenerator` in `Qgs3DRenderContext` prevents the crash, but how often is `Qgs3DRenderContext` created? How expensive is it to copy it during creation of `Qgs3DRenderContext`?

`Qgs3DRenderContext` holds a pointer to `QgsAbstractTerrainSettings`, does that mean it can pass itself to `QgsAbstractTerrainSettings::createTerrainGenerator( const Qgs3DRenderContext &context )` and store the created generator? Seems like some of the listed things shouldn’t be possible.

(ping @wonder-sk and @nyalldawson)