### PR TITLE
Move logic for handling checkbox double clicks to QgsLayerTreeViewBase

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgslayertreeview.py
+++ b/python/PyQt6/gui/auto_additions/qgslayertreeview.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/gui/layertree/qgslayertreeview.h
 try:
     QgsLayerTreeView.__attribute_docs__ = {'currentLayerChanged': 'Emitted when a current layer is changed\n', 'datasetsDropped': 'Emitted when datasets are dropped onto the layer tree view\n', 'contextMenuAboutToShow': 'Emitted when the context menu is about to show.\n\nAllows customization of the menu.\n\n.. versionadded:: 3.32\n'}
-    QgsLayerTreeView.__overridden_methods__ = ['setModel', 'contextMenuEvent', 'mouseDoubleClickEvent', 'mouseReleaseEvent', 'keyPressEvent', 'dragEnterEvent', 'dragMoveEvent', 'dropEvent', 'resizeEvent']
+    QgsLayerTreeView.__overridden_methods__ = ['setModel', 'contextMenuEvent', 'mouseReleaseEvent', 'keyPressEvent', 'dragEnterEvent', 'dragMoveEvent', 'dropEvent', 'resizeEvent']
     QgsLayerTreeView.__signal_arguments__ = {'currentLayerChanged': ['layer: QgsMapLayer'], 'datasetsDropped': ['event: QDropEvent'], 'contextMenuAboutToShow': ['menu: QMenu']}
     QgsLayerTreeView.__group__ = ['layertree']
 except (NameError, AttributeError):
@@ -18,6 +18,7 @@ try:
 except (NameError, AttributeError):
     pass
 try:
+    QgsLayerTreeViewBase.__overridden_methods__ = ['mouseDoubleClickEvent']
     QgsLayerTreeViewBase.__group__ = ['layertree']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -114,6 +114,9 @@ Constructor for QgsLayerTreeViewBase
 %End
     ~QgsLayerTreeViewBase();
 
+    virtual void mouseDoubleClickEvent( QMouseEvent *event );
+
+
     void setLayerTreeModel( QgsLayerTreeModel *model );
 %Docstring
 Associates a layer tree model with the view.
@@ -634,8 +637,6 @@ Allows customization of the menu.
   protected:
     virtual void contextMenuEvent( QContextMenuEvent *event );
 
-
-    virtual void mouseDoubleClickEvent( QMouseEvent *event );
 
     virtual void mouseReleaseEvent( QMouseEvent *event );
 

--- a/python/gui/auto_additions/qgslayertreeview.py
+++ b/python/gui/auto_additions/qgslayertreeview.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/gui/layertree/qgslayertreeview.h
 try:
     QgsLayerTreeView.__attribute_docs__ = {'currentLayerChanged': 'Emitted when a current layer is changed\n', 'datasetsDropped': 'Emitted when datasets are dropped onto the layer tree view\n', 'contextMenuAboutToShow': 'Emitted when the context menu is about to show.\n\nAllows customization of the menu.\n\n.. versionadded:: 3.32\n'}
-    QgsLayerTreeView.__overridden_methods__ = ['setModel', 'contextMenuEvent', 'mouseDoubleClickEvent', 'mouseReleaseEvent', 'keyPressEvent', 'dragEnterEvent', 'dragMoveEvent', 'dropEvent', 'resizeEvent']
+    QgsLayerTreeView.__overridden_methods__ = ['setModel', 'contextMenuEvent', 'mouseReleaseEvent', 'keyPressEvent', 'dragEnterEvent', 'dragMoveEvent', 'dropEvent', 'resizeEvent']
     QgsLayerTreeView.__signal_arguments__ = {'currentLayerChanged': ['layer: QgsMapLayer'], 'datasetsDropped': ['event: QDropEvent'], 'contextMenuAboutToShow': ['menu: QMenu']}
     QgsLayerTreeView.__group__ = ['layertree']
 except (NameError, AttributeError):
@@ -18,6 +18,7 @@ try:
 except (NameError, AttributeError):
     pass
 try:
+    QgsLayerTreeViewBase.__overridden_methods__ = ['mouseDoubleClickEvent']
     QgsLayerTreeViewBase.__group__ = ['layertree']
 except (NameError, AttributeError):
     pass

--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -114,6 +114,9 @@ Constructor for QgsLayerTreeViewBase
 %End
     ~QgsLayerTreeViewBase();
 
+    virtual void mouseDoubleClickEvent( QMouseEvent *event );
+
+
     void setLayerTreeModel( QgsLayerTreeModel *model );
 %Docstring
 Associates a layer tree model with the view.
@@ -634,8 +637,6 @@ Allows customization of the menu.
   protected:
     virtual void contextMenuEvent( QContextMenuEvent *event );
 
-
-    virtual void mouseDoubleClickEvent( QMouseEvent *event );
 
     virtual void mouseReleaseEvent( QMouseEvent *event );
 

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -134,6 +134,8 @@ class GUI_EXPORT QgsLayerTreeViewBase : public QTreeView
     explicit QgsLayerTreeViewBase( QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsLayerTreeViewBase() override;
 
+    void mouseDoubleClickEvent( QMouseEvent *event ) override;
+
     /**
      * Associates a layer tree model with the view.
      *
@@ -396,8 +398,13 @@ class GUI_EXPORT QgsLayerTreeViewBase : public QTreeView
      */
     void onModelReset();
 
+  private slots:
+
+    void onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles );
+
   private:
     QgsLayerTreeModel *mLayerTreeModel = nullptr;
+    QTimer *mBlockDoubleClickTimer = nullptr;
 };
 
 
@@ -585,7 +592,6 @@ class GUI_EXPORT QgsLayerTreeView : public QgsLayerTreeViewBase
   protected:
     void contextMenuEvent( QContextMenuEvent *event ) override;
 
-    void mouseDoubleClickEvent( QMouseEvent *event ) override;
     void mouseReleaseEvent( QMouseEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
 
@@ -630,7 +636,6 @@ class GUI_EXPORT QgsLayerTreeView : public QgsLayerTreeViewBase
     bool mShowPrivateLayers = false;
     bool mHideValidLayers = false;
 
-    QTimer *mBlockDoubleClickTimer = nullptr;
     // For model  debugging
     // void checkModel( );
 


### PR DESCRIPTION
Move this logic from QgsLayerTreeView to QgsLayerTreeViewBase, so that other subclasses of QgsLayerTreeViewBase also gain the suppression of double-clicks on the view checkboxes.

(This logic is in place to avoid opening eg layer properties dialog when a user rapidly toggles a layers visiblity on and off)
