### PR TITLE
Fix copying min elevation from profile dock to layout item

### DIFF
--- a/src/gui/layout/qgslayoutelevationprofilewidget.cpp
+++ b/src/gui/layout/qgslayoutelevationprofilewidget.cpp
@@ -635,7 +635,7 @@ void QgsLayoutElevationProfileWidget::copySettingsFromProfileCanvas( QgsElevatio
   mDistanceAxisLabelIntervalSpin->setClearValue( canvas->plot().xAxis().labelInterval() );
   mProfile->plot()->xAxis().setLabelInterval( canvas->plot().xAxis().labelInterval() );
 
-  mSpinMinElevation->setValue( canvas->plot().xMinimum() );
+  mSpinMinElevation->setValue( canvas->plot().yMinimum() );
   mSpinMinElevation->setClearValue( canvas->plot().yMinimum() );
   mProfile->plot()->setYMinimum( canvas->plot().yMinimum() );
 


### PR DESCRIPTION
Use the min elevation, not min distance
