### PR TITLE
Add remove group action to elevation profile layer tree

### DIFF
--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreenode.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreenode.sip.in
@@ -106,6 +106,39 @@ Custom properties that have already been used within QGIS:
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
+    Py_ssize_t __len__() const;
+%Docstring
+Returns the number of children contained in the node.
+
+.. versionadded:: 4.0
+%End
+%MethodCode
+    sipRes = sipCpp->children().count();
+%End
+
+    SIP_PYOBJECT __getitem__( int index ) /TypeHint="QgsLayerTreeNode"/;
+%Docstring
+Returns the child node at the specified ``index``.
+
+:raises IndexError: if no child with the specified ``index`` exists.
+
+.. versionadded:: 4.0
+%End
+%MethodCode
+    const QList< QgsLayerTreeNode * > children = sipCpp->children();
+    const int count = children.count();
+    if ( a0 < 0 || a0 >= count )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      QgsLayerTreeNode *child = children.at( a0 );
+      sipRes = sipConvertFromType( child, sipType_QgsLayerTreeNode, NULL );
+    }
+%End
+
     NodeType nodeType() const;
 %Docstring
 Find out about type of the node. It is usually shorter to use

--- a/python/PyQt6/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/PyQt6/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -33,10 +33,49 @@ The object will be parented to the specified ``view``.
 %End
 
     QAction *actionAddGroup( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action which adds a group.
+%End
+
     QAction *actionRemoveGroupOrLayer( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action which removes either a group or layer, depending on
+the selected node.
+
+If a group is removed, all children for that group will also be removed.
+
+.. seealso:: :py:func:`actionRemoveGroupPromoteLayers`
+%End
+
+    QAction *actionRemoveGroupPromoteLayers( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action which removes a group.
+
+Any existing children in the group will be moved up to the parent of the
+removed group.
+
+.. seealso:: :py:func:`actionRemoveGroupOrLayer`
+
+.. versionadded:: 4.0
+%End
+
     QAction *actionShowInOverview( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action for toggling whether a layer is shown in the map
+overview.
+%End
+
     QAction *actionRenameGroupOrLayer( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action for renaming a group or layer, depending on the
+selected node.
+%End
+
     QAction *actionShowFeatureCount( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action for toggling whether the feature count is shown for
+a layer.
+%End
 
     QAction *actionCheckAndAllChildren( QObject *parent = 0 );
 %Docstring
@@ -145,6 +184,15 @@ Zooms a map ``canvas`` to all the selected layer(s) in the layer tree
 
   protected slots:
     void removeGroupOrLayer();
+
+    void removeGroupPromoteLayers();
+%Docstring
+Removes the selected group node, promoting all child nodes up into the
+removed group's parent node.
+
+.. versionadded:: 4.0
+%End
+
     void renameGroupOrLayer();
     void showFeatureCount();
 

--- a/python/core/auto_generated/layertree/qgslayertreenode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreenode.sip.in
@@ -106,6 +106,39 @@ Custom properties that have already been used within QGIS:
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
+    int __len__() const;
+%Docstring
+Returns the number of children contained in the node.
+
+.. versionadded:: 4.0
+%End
+%MethodCode
+    sipRes = sipCpp->children().count();
+%End
+
+    SIP_PYOBJECT __getitem__( int index ) /TypeHint="QgsLayerTreeNode"/;
+%Docstring
+Returns the child node at the specified ``index``.
+
+:raises IndexError: if no child with the specified ``index`` exists.
+
+.. versionadded:: 4.0
+%End
+%MethodCode
+    const QList< QgsLayerTreeNode * > children = sipCpp->children();
+    const int count = children.count();
+    if ( a0 < 0 || a0 >= count )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      QgsLayerTreeNode *child = children.at( a0 );
+      sipRes = sipConvertFromType( child, sipType_QgsLayerTreeNode, NULL );
+    }
+%End
+
     NodeType nodeType() const;
 %Docstring
 Find out about type of the node. It is usually shorter to use

--- a/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -33,10 +33,49 @@ The object will be parented to the specified ``view``.
 %End
 
     QAction *actionAddGroup( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action which adds a group.
+%End
+
     QAction *actionRemoveGroupOrLayer( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action which removes either a group or layer, depending on
+the selected node.
+
+If a group is removed, all children for that group will also be removed.
+
+.. seealso:: :py:func:`actionRemoveGroupPromoteLayers`
+%End
+
+    QAction *actionRemoveGroupPromoteLayers( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action which removes a group.
+
+Any existing children in the group will be moved up to the parent of the
+removed group.
+
+.. seealso:: :py:func:`actionRemoveGroupOrLayer`
+
+.. versionadded:: 4.0
+%End
+
     QAction *actionShowInOverview( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action for toggling whether a layer is shown in the map
+overview.
+%End
+
     QAction *actionRenameGroupOrLayer( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action for renaming a group or layer, depending on the
+selected node.
+%End
+
     QAction *actionShowFeatureCount( QObject *parent = 0 ) /Factory/;
+%Docstring
+Returns a new action for toggling whether the feature count is shown for
+a layer.
+%End
 
     QAction *actionCheckAndAllChildren( QObject *parent = 0 );
 %Docstring
@@ -145,6 +184,15 @@ Zooms a map ``canvas`` to all the selected layer(s) in the layer tree
 
   protected slots:
     void removeGroupOrLayer();
+
+    void removeGroupPromoteLayers();
+%Docstring
+Removes the selected group node, promoting all child nodes up into the
+removed group's parent node.
+
+.. versionadded:: 4.0
+%End
+
     void renameGroupOrLayer();
     void showFeatureCount();
 

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -1416,6 +1416,7 @@ void QgsAppElevationProfileLayerTreeView::contextMenuEvent( QContextMenuEvent *e
     if ( QgsLayerTree::isGroup( node ) )
     {
       menu->addAction( defaultActions()->actionRenameGroupOrLayer( menu ) );
+      menu->addAction( defaultActions()->actionRemoveGroupPromoteLayers( menu ) );
     }
   }
 

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -116,6 +116,38 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     QString str = QStringLiteral( "<QgsLayerTreeNode: %1>" ).arg( sipCpp->name() );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
+
+    /**
+     * Returns the number of children contained in the node.
+     *
+     * \since QGIS 4.0
+     */
+    int __len__() const;
+    % MethodCode
+    sipRes = sipCpp->children().count();
+    % End
+
+    /**
+     * Returns the child node at the specified ``index``.
+     *
+     * \throws IndexError if no child with the specified ``index`` exists.
+     * \since QGIS 4.0
+     */
+    SIP_PYOBJECT __getitem__( int index ) SIP_TYPEHINT( QgsLayerTreeNode );
+    % MethodCode
+    const QList< QgsLayerTreeNode * > children = sipCpp->children();
+    const int count = children.count();
+    if ( a0 < 0 || a0 >= count )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      QgsLayerTreeNode *child = children.at( a0 );
+      sipRes = sipConvertFromType( child, sipType_QgsLayerTreeNode, NULL );
+    }
+    % End
 #endif
 
     //! Find out about type of the node. It is usually shorter to use convenience functions from QgsLayerTree namespace for that

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -45,10 +45,44 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
      */
     QgsLayerTreeViewDefaultActions( QgsLayerTreeViewBase *view );
 
+    /**
+     * Returns a new action which adds a group.
+     */
     QAction *actionAddGroup( QObject *parent = nullptr ) SIP_FACTORY;
+
+    /**
+     * Returns a new action which removes either a group or layer, depending on the selected node.
+     *
+     * If a group is removed, all children for that group will also be removed.
+     *
+     * \see actionRemoveGroupPromoteLayers()
+     */
     QAction *actionRemoveGroupOrLayer( QObject *parent = nullptr ) SIP_FACTORY;
+
+    /**
+     * Returns a new action which removes a group.
+     *
+     * Any existing children in the group will be moved up to the parent of
+     * the removed group.
+     *
+     * \see actionRemoveGroupOrLayer()
+     * \since QGIS 4.0
+     */
+    QAction *actionRemoveGroupPromoteLayers( QObject *parent = nullptr ) SIP_FACTORY;
+
+    /**
+     * Returns a new action for toggling whether a layer is shown in the map overview.
+     */
     QAction *actionShowInOverview( QObject *parent = nullptr ) SIP_FACTORY;
+
+    /**
+     * Returns a new action for renaming a group or layer, depending on the selected node.
+     */
     QAction *actionRenameGroupOrLayer( QObject *parent = nullptr ) SIP_FACTORY;
+
+    /**
+     * Returns a new action for toggling whether the feature count is shown for a layer.
+     */
     QAction *actionShowFeatureCount( QObject *parent = nullptr ) SIP_FACTORY;
 
     //! Action to check a group and all its children
@@ -134,6 +168,15 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
 
   protected slots:
     void removeGroupOrLayer();
+
+    /**
+     * Removes the selected group node, promoting all child nodes up into the removed
+     * group's parent node.
+     *
+     * \since QGIS 4.0
+     */
+    void removeGroupPromoteLayers();
+
     void renameGroupOrLayer();
     void showFeatureCount();
 

--- a/tests/src/python/test_qgslayertree.py
+++ b/tests/src/python/test_qgslayertree.py
@@ -40,6 +40,39 @@ class TestQgsLayerTree(QgisTestCase):
         """Run once on class initialization."""
         QgisTestCase.__init__(self, methodName)
 
+    def test_python(self):
+        """
+        Test python methods for layer tree classes
+        """
+        group = QgsLayerTreeGroup("test")
+        self.assertEqual(len(group), 0)
+        with self.assertRaises(IndexError):
+            group[0]
+        with self.assertRaises(IndexError):
+            group[-1]
+        group2 = group.addGroup("test 2")
+        self.assertEqual(len(group), 1)
+        self.assertEqual(group[0], group2)
+        with self.assertRaises(IndexError):
+            group[1]
+        with self.assertRaises(IndexError):
+            group[-1]
+        group3 = group.addGroup("test 3")
+        self.assertEqual(len(group), 2)
+        self.assertEqual(group[0], group2)
+        self.assertEqual(group[1], group3)
+        with self.assertRaises(IndexError):
+            group[2]
+
+        layer = QgsVectorLayer("Point?field=fldtxt:string", "layer1", "memory")
+        layer_node = group.addLayer(layer)
+        self.assertEqual(len(group), 3)
+        self.assertEqual(group[0], group2)
+        self.assertEqual(group[1], group3)
+        self.assertEqual(group[2], layer_node)
+        with self.assertRaises(IndexError):
+            group[3]
+
     def testCustomLayerOrder(self):
         """test project layer order"""
         prj = QgsProject()


### PR DESCRIPTION
We had UI to add groups, but nothing to remove them

Use a new action for removing a group but promoting children, as we don't want the remove the child layers here. Elevation
profile layer tree groups are purely for organisation, not as owning containers for layers.