### PR TITLE
[mssql] Fix refreshing connection causes all schemas to collapse

### DIFF
--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -107,24 +107,11 @@ void QgsMssqlConnectionItem::refresh()
   QgsDebugMsgLevel( "mPath = " + mPath, 3 );
   stop();
 
-  // Clear all children
-  const QVector<QgsDataItem *> allChildren = children();
-  for ( QgsDataItem *item : allChildren )
-  {
-    removeChildItem( item );
-    delete item;
-  }
-
-  // read up the schemas and layers from database
-  const QVector<QgsDataItem *> items = createChildren();
-  for ( QgsDataItem *item : items )
-    addChildItem( item, true );
+  QgsDataCollectionItem::refresh();
 }
 
 QVector<QgsDataItem *> QgsMssqlConnectionItem::createChildren()
 {
-  setState( Qgis::BrowserItemState::Populating );
-
   stop();
 
   QVector<QgsDataItem *> children;
@@ -184,30 +171,6 @@ QVector<QgsDataItem *> QgsMssqlConnectionItem::createChildren()
       layer.pkCols = QStringList(); //TODO
       layer.isGeography = false;
 
-      // skip layers which are added already
-      bool skip = false;
-      const auto constMChildren = mChildren;
-      for ( QgsDataItem *child : constMChildren )
-      {
-        if ( child->name() == layer.schemaName )
-        {
-          const auto constChildren = child->children();
-          for ( QgsDataItem *child2 : constChildren )
-          {
-            QgsMssqlLayerItem *layerItem = qobject_cast<QgsMssqlLayerItem *>( child2 );
-            if ( child2->name() == layer.tableName && layerItem && layerItem->disableInvalidGeometryHandling() == disableInvalidGeometryHandling )
-            {
-              newLayers.append( child2 );
-              skip = true; // already added
-              break;
-            }
-          }
-        }
-      }
-
-      if ( skip )
-        continue;
-
       QString type = layer.type;
       QString srid = layer.srid;
 
@@ -250,18 +213,6 @@ QVector<QgsDataItem *> QgsMssqlConnectionItem::createChildren()
       QgsMssqlLayerItem *added = schemaItem->addLayer( layer, false );
       if ( added )
         newLayers.append( added );
-    }
-
-    // Remove no more present items
-    const auto constMChildren = mChildren;
-    for ( QgsDataItem *child : constMChildren )
-    {
-      const auto constChildren = child->children();
-      for ( QgsDataItem *child2 : constChildren )
-      {
-        if ( findItem( newLayers, child2 ) < 0 )
-          child->deleteChildItem( child2 );
-      }
     }
 
     // add missing schemas (i.e., empty schemas)


### PR DESCRIPTION
Drop (probably?) unnecessary code in QgsMssqlConnectionItem which drops existing child items, as this logic is present in a better way in the base class implementation. (The base class implementation compares the list of new children vs the existing, and doesn't delete and then re-add items which are identical. This retains their existing view properties, such as expansion state)
