### PR TITLE
Implement vector table rename for QgsMssqlProviderConnection

### DIFF
--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -87,6 +87,7 @@ void QgsMssqlProviderConnection::setDefaultCapabilities()
   mCapabilities = {
     Capability::DropVectorTable,
     Capability::CreateVectorTable,
+    Capability::RenameVectorTable,
     Capability::DropSchema,
     Capability::CreateSchema,
     Capability::ExecuteSql,
@@ -144,6 +145,12 @@ void QgsMssqlProviderConnection::dropTablePrivate( const QString &schema, const 
                               QgsMssqlUtils::quotedValue( name ), QgsMssqlUtils::quotedValue( schema ), QgsMssqlUtils::quotedIdentifier( name ), QgsMssqlUtils::quotedIdentifier( schema ) ) };
 
   executeSqlPrivate( sql );
+}
+
+void QgsMssqlProviderConnection::renameTablePrivate( const QString &schema, const QString &name, const QString &newName ) const
+{
+  executeSqlPrivate( QStringLiteral( "EXECUTE sp_rename '%1.%2', %3" )
+                       .arg( QgsMssqlUtils::quotedIdentifier( schema ), QgsMssqlUtils::quotedIdentifier( name ), QgsMssqlUtils::quotedValue( newName ) ) );
 }
 
 void QgsMssqlProviderConnection::createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, Qgis::WkbType wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const
@@ -214,6 +221,11 @@ void QgsMssqlProviderConnection::dropVectorTable( const QString &schema, const Q
   dropTablePrivate( schema, name );
 }
 
+void QgsMssqlProviderConnection::renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const
+{
+  checkCapability( Capability::RenameVectorTable );
+  renameTablePrivate( schema, name, newName );
+}
 
 void QgsMssqlProviderConnection::createSchema( const QString &schemaName ) const
 {

--- a/src/providers/mssql/qgsmssqlproviderconnection.h
+++ b/src/providers/mssql/qgsmssqlproviderconnection.h
@@ -55,6 +55,7 @@ class QgsMssqlProviderConnection : public QgsAbstractDatabaseProviderConnection
     QString createVectorLayerExporterDestinationUri( const VectorLayerExporterOptions &options, QVariantMap &providerOptions ) const override;
     QString tableUri( const QString &schema, const QString &name ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
+    void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;
     void createSchema( const QString &name ) const override;
     void dropSchema( const QString &name, bool force = false ) const override;
     QgsAbstractDatabaseProviderConnection::QueryResult execSql( const QString &sql, QgsFeedback *feedback ) const override;


### PR DESCRIPTION
Note that no new tests are required here, as the QgsAbstractDatabaseProviderConnection test suite already dynamically adapts to the new capability and runs conformance tests on the renameVectorTable implementation.

Sponsored by City of Canning