### PR TITLE
[mssql] Implement field rename capability for connections

### DIFF
--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -96,6 +96,7 @@ void QgsMssqlProviderConnection::setDefaultCapabilities()
     Capability::Schemas,
     Capability::Spatial,
     Capability::TableExists,
+    Capability::RenameField,
     Capability::DeleteField,
     Capability::DeleteFieldCascade,
     Capability::AddField,
@@ -574,6 +575,12 @@ QgsFields QgsMssqlProviderConnection::fields( const QString &schema, const QStri
   }
 
   return details.attributeFields;
+}
+
+void QgsMssqlProviderConnection::renameField( const QString &schema, const QString &tableName, const QString &name, const QString &newName ) const
+{
+  executeSqlPrivate( QStringLiteral( "EXECUTE sp_rename '%1.%2.%3', %4, 'COLUMN'" )
+                       .arg( QgsMssqlUtils::quotedIdentifier( schema ), QgsMssqlUtils::quotedIdentifier( tableName ), QgsMssqlUtils::quotedIdentifier( name ), QgsMssqlUtils::quotedValue( newName ) ) );
 }
 
 QStringList QgsMssqlProviderConnection::schemas() const

--- a/src/providers/mssql/qgsmssqlproviderconnection.h
+++ b/src/providers/mssql/qgsmssqlproviderconnection.h
@@ -62,6 +62,7 @@ class QgsMssqlProviderConnection : public QgsAbstractDatabaseProviderConnection
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema, const TableFlags &flags = TableFlags(), QgsFeedback *feedback = nullptr ) const override;
     QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const override;
     QgsFields fields( const QString &schema, const QString &table, QgsFeedback *feedback = nullptr ) const override;
+    void renameField( const QString &schema, const QString &tableName, const QString &name, const QString &newName ) const override;
     QStringList schemas() const override;
     void store( const QString &name ) const override;
     void remove( const QString &name ) const override;


### PR DESCRIPTION
Allows for renaming fields in the browser for SQL Server tables.

Sponsored by City of Canning