### PR TITLE
Attribute form / relation editor dual view fixes

### DIFF
--- a/python/PyQt6/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/PyQt6/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsFeatureListModel : QSortFilterProxyModel, QgsFeatureModel
 {
 %Docstring(signature="appended")

--- a/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsFeatureListModel : QSortFilterProxyModel, QgsFeatureModel
 {
 %Docstring(signature="appended")

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -242,7 +242,9 @@ void QgsAttributeTableFilterModel::setAttributeTableConfig( const QgsAttributeTa
   }
 
   if ( !config.sortExpression().isEmpty() )
+  {
     sort( config.sortExpression(), config.sortOrder() );
+  }
 }
 
 void QgsAttributeTableFilterModel::setFilterExpression( const QgsExpression &expression, const QgsExpressionContext &context )

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -692,9 +692,13 @@ QVariant QgsAttributeTableModel::data( const QModelIndex &index, int role ) cons
   {
     const unsigned long cacheIndex = role - static_cast<int>( CustomRole::Sort );
     if ( cacheIndex < mSortCaches.size() )
+    {
       return mSortCaches.at( cacheIndex ).sortCache.value( rowId );
+    }
     else
+    {
       return QVariant();
+    }
   }
 
   const QgsField field = mLayer->fields().at( fieldId );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -172,7 +172,14 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   //mTableView->resizeColumnsToContents();
 
   if ( showFirstFeature && mFeatureListModel->rowCount() > 0 )
+  {
     mFeatureListView->setEditSelection( QgsFeatureIds() << mFeatureListModel->data( mFeatureListModel->index( 0, 0 ), QgsFeatureListModel::Role::FeatureRole ).value<QgsFeature>().id() );
+  }
+  else
+  {
+    // Set attribute table config to allow for proper sorting ordering in feature list view
+    setAttributeTableConfig( mLayer->attributeTableConfig() );
+  }
 }
 
 void QgsDualView::initAttributeForm( const QgsFeature &feature )

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -232,7 +232,7 @@ bool QgsFeatureListModel::setDisplayExpression( const QString &expression )
 
   if ( mSortByDisplayExpression )
   {
-    masterModel()->prefetchSortData( expression, 1 );
+    masterModel()->prefetchSortData( expression, QGSFEATURELISTMODEL_CACHE_INDEX );
   }
 
   emit dataChanged( index( 0, 0 ), index( rowCount() - 1, 0 ) );
@@ -297,7 +297,7 @@ void QgsFeatureListModel::setSortByDisplayExpression( bool sortByDisplayExpressi
 {
   if ( !mSortByDisplayExpression && sortByDisplayExpression )
   {
-    masterModel()->prefetchSortData( mDisplayExpression.expression(), 1 );
+    masterModel()->prefetchSortData( mDisplayExpression.expression(), QGSFEATURELISTMODEL_CACHE_INDEX );
   }
 
   mSortByDisplayExpression = sortByDisplayExpression;

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -231,7 +231,9 @@ bool QgsFeatureListModel::setDisplayExpression( const QString &expression )
   mDisplayExpression = exp;
 
   if ( mSortByDisplayExpression )
+  {
     masterModel()->prefetchSortData( expression, 1 );
+  }
 
   emit dataChanged( index( 0, 0 ), index( rowCount() - 1, 0 ) );
 
@@ -293,11 +295,18 @@ bool QgsFeatureListModel::sortByDisplayExpression() const
 
 void QgsFeatureListModel::setSortByDisplayExpression( bool sortByDisplayExpression, Qt::SortOrder order )
 {
+  if ( !mSortByDisplayExpression && sortByDisplayExpression )
+  {
+    masterModel()->prefetchSortData( mDisplayExpression.expression(), 1 );
+  }
+
   mSortByDisplayExpression = sortByDisplayExpression;
 
   // If we are sorting by display expression, we do not support injected null
   if ( mSortByDisplayExpression )
+  {
     setInjectNull( false );
+  }
 
   setSortRole( static_cast<int>( QgsAttributeTableModel::CustomRole::Sort ) + 1 );
   setDynamicSortFilter( mSortByDisplayExpression );

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -32,6 +32,8 @@ class QgsAttributeTableFilterModel;
 class QgsAttributeTableModel;
 class QgsVectorLayerCache;
 
+#define QGSFEATURELISTMODEL_CACHE_INDEX 1
+
 /**
  * \ingroup gui
  * \class QgsFeatureListModel

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -26,6 +26,7 @@
 #include "qgsattributeformeditorwidget.h"
 #include <qgsapplication.h>
 #include "qgsfeatureiterator.h"
+#include "qgsfeaturelistmodel.h"
 #include <qgsvectorlayer.h>
 #include "qgsvectordataprovider.h"
 #include <qgsmapcanvas.h>
@@ -62,6 +63,7 @@ class TestQgsDualView : public QObject
 
     void testAttributeFormSharedValueScanning();
     void testNoGeom();
+    void testNoShowFirstFeature();
 
     void testDuplicateField();
 
@@ -360,6 +362,22 @@ void TestQgsDualView::testNoGeom()
   model = dv->masterModel();
   QVERIFY( model->layerCache()->cacheGeometry() );
   QVERIFY( !( model->request().flags() & Qgis::FeatureRequestFlag::NoGeometry ) );
+}
+
+void TestQgsDualView::testNoShowFirstFeature()
+{
+  auto dv = std::make_unique<QgsDualView>();
+
+  QgsAttributeTableConfig config = mPointsLayer->attributeTableConfig();
+  config.setSortExpression( QStringLiteral( "\"Class\"" ) );
+  mPointsLayer->setAttributeTableConfig( config );
+
+  QgsFeatureRequest req;
+  dv->init( mPointsLayer, mCanvas, req, QgsAttributeEditorContext(), true, false );
+  QCOMPARE( dv->mFeatureListModel->data( dv->mFeatureListModel->index( 0, 0 ), QgsFeatureListModel::Role::FeatureRole ).value<QgsFeature>().attribute( QStringLiteral( "Class" ) ), QStringLiteral( "B52" ) );
+
+  config.setSortExpression( QString() );
+  mPointsLayer->setAttributeTableConfig( config );
 }
 
 #ifdef WITH_QTWEBKIT


### PR DESCRIPTION
## Description

This PR fixes two issues with the dual view used in the attribute form and relation editor.

First, the custom ordering of the dual view's feature list was not respected when the relation editor widget's automatically select first feature toggle option was turned off. 

On top of this, the sort by preview expression (ascending/descending) menu actions were dead, not working due to missing sort prefetch caching. That is addressed too.