### PR TITLE
[ui] Improve UI layout of the vector/raster layer properties' map tips widgets

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1385,6 +1385,7 @@ void QgsRasterLayerProperties::initMapTipPreview()
   // Note: there's quite a bit of overlap between this and the code in QgsMapTip::showMapTip
   // Create the WebView
   mMapTipPreview = new QgsWebView( mMapTipPreviewContainer );
+  mMapTipPreviewLayout->addWidget( mMapTipPreview );
 
 #if WITH_QTWEBKIT
   mMapTipPreview->page()->setLinkDelegationPolicy( QWebPage::DelegateAllLinks ); //Handle link clicks by yourself

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -206,7 +206,6 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
     return;
   }
 
-  connect( mEnableMapTips, &QAbstractButton::toggled, mHtmlMapTipGroupBox, &QWidget::setEnabled );
   mEnableMapTips->setChecked( mRasterLayer->mapTipsEnabled() );
 
   updateRasterAttributeTableOptionsPage();

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1869,6 +1869,7 @@ void QgsVectorLayerProperties::initMapTipPreview()
   // Note: there's quite a bit of overlap between this and the code in QgsMapTip::showMapTip
   // Create the WebView
   mMapTipPreview = new QgsWebView( mMapTipPreviewContainer );
+  mMapTipPreviewLayout->addWidget( mMapTipPreview );
 
 #if WITH_QTWEBKIT
   mMapTipPreview->page()->setLinkDelegationPolicy( QWebPage::DelegateAllLinks ); //Handle link clicks by yourself

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -172,7 +172,6 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   if ( !mLayer )
     return;
 
-  connect( mEnableMapTips, &QAbstractButton::toggled, mHtmlMapTipGroupBox, &QWidget::setEnabled );
   mEnableMapTips->setChecked( mLayer->mapTipsEnabled() );
 
   QVBoxLayout *layout = nullptr;

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1465,30 +1465,30 @@ li.checked::marker { content: &quot;\2612&quot;; }
                <number>0</number>
               </property>
               <item row="0" column="0">
-               <widget class="QCheckBox" name="mEnableMapTips">
-                <property name="toolTip">
-                 <string>Indicates whether map tips are displayed for this layer or not</string>
+               <widget class="QGroupBox" name="mEnableMapTips">
+                <property name="title">
+                 <string>Enable Map Tips</string>
                 </property>
-                <property name="text">
-                 <string>Enable map tips</string>
-                </property>
-                <property name="checked">
+                <property name="checkable">
                  <bool>true</bool>
                 </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QGroupBox" name="mHtmlMapTipGroupBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="title">
-                 <string>HTML Map Tip</string>
-                </property>
                 <layout class="QVBoxLayout" name="verticalLayout_22">
+                 <item>
+                  <widget class="QLabel" name="labelMapTipInfo">
+                   <property name="text">
+                    <string>Map tips are shown when moving mouse over raster cells of the currently selected layer when the 'Show Map Tips' action is toggled on.</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
                  <item>
                   <widget class="QSplitter" name="mMapTipSplitter">
                    <property name="sizePolicy">
@@ -1541,16 +1541,6 @@ li.checked::marker { content: &quot;\2612&quot;; }
                    <property name="icon">
                     <iconset resource="../../images/images.qrc">
                      <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelMapTipInfo">
-                   <property name="text">
-                    <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on.</string>
-                   </property>
-                   <property name="wordWrap">
-                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1522,8 +1522,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </size>
                     </property>
                     <property name="title">
-                     <string>Preview</string>
+                     <string>Map Tips Preview</string>
                     </property>
+                    <layout class="QVBoxLayout" name="mMapTipPreviewLayout"/>
                    </widget>
                   </widget>
                  </item>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1590,8 +1590,9 @@
                      </size>
                     </property>
                     <property name="title">
-                     <string>Preview</string>
+                     <string>Map Tips Preview</string>
                     </property>
+                    <layout class="QVBoxLayout" name="mMapTipPreviewLayout"/>
                    </widget>
                   </widget>
                  </item>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1445,30 +1445,30 @@
                </widget>
               </item>
               <item row="1" column="0">
-               <widget class="QCheckBox" name="mEnableMapTips">
-                <property name="toolTip">
-                 <string>Indicates whether map tips are displayed for this layer or not</string>
-                </property>
-                <property name="text">
-                 <string>Enable map tips</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QGroupBox" name="mHtmlMapTipGroupBox">
+                <widget class="QGroupBox" name="mEnableMapTips">
+                 <property name="title">
+                  <string>Enable Map Tips</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="title">
-                 <string>HTML Map Tip</string>
-                </property>
                 <layout class="QVBoxLayout" name="verticalLayout_35">
+                 <item>
+                  <widget class="QLabel" name="labelMapTipInfo">
+                   <property name="text">
+                    <string>Map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on. If no HTML code is set below, the feature display name is used.</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
                  <item>
                   <widget class="QSplitter" name="mMapTipSplitter">
                    <property name="sizePolicy">
@@ -1593,16 +1593,6 @@
                      <string>Preview</string>
                     </property>
                    </widget>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelMapTipInfo">
-                   <property name="text">
-                    <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on. If no HTML code is set, the feature display name is used.</string>
-                   </property>
-                   <property name="wordWrap">
-                    <bool>true</bool>
-                   </property>
                   </widget>
                  </item>
                 </layout>


### PR DESCRIPTION
## Description

The map tips layout in the vector and raster layer properties dialog is not ideal, has the main toggle disjointed from the HTML settings. This PR improves things considerably.

Before:

<img width="902" height="750" alt="image" src="https://github.com/user-attachments/assets/329043b9-d645-4db1-83e2-d0f0e37ac54c" />

PR:

<img width="889" height="683" alt="image" src="https://github.com/user-attachments/assets/629848c8-44ce-49bf-a02d-6a3961dc67c0" />

This also gives us the opportunity to more easily use some of the space in that panel for additional settings.