### PR TITLE
Fix build warnings on Fedora

### DIFF
--- a/src/app/qgspuzzlewidget.cpp
+++ b/src/app/qgspuzzlewidget.cpp
@@ -126,7 +126,7 @@ bool QgsPuzzleWidget::letsGetThePartyStarted()
   mScene = new QGraphicsScene;
 
   QTemporaryFile f;
-  f.open();
+  ( void ) f.open();
   f.close();
 
   const QString filename( f.fileName() );

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2417,6 +2417,10 @@ if(WITH_INTERNAL_SPATIALINDEX)
   check_function_exists(memcpy HAVE_MEMCPY)
   check_function_exists(bcopy HAVE_BCOPY)
 
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set_source_files_properties(${SIDX_SRCS} PROPERTIES COMPILE_OPTIONS "-Wno-type-limits;-Wno-extra;-Wno-overloaded-virtual")
+  endif()
+
   if(HAVE_SRAND48)
     set_source_files_properties(${SIDX_SRCS} PROPERTIES COMPILE_FLAGS -DHAVE_SRAND48=1)
   else()

--- a/src/core/network/qgsnetworkcontentfetcherregistry.cpp
+++ b/src/core/network/qgsnetworkcontentfetcherregistry.cpp
@@ -191,7 +191,12 @@ void QgsFetchedContent::taskCompleted()
 
       mFile = std::make_unique<QTemporaryFile>( extension.isEmpty() ? QString( "XXXXXX" ) :
               QString( "%1/XXXXXX.%2" ).arg( QDir::tempPath(), extension ) );
-      mFile->open();
+      if ( !mFile->open() )
+      {
+        QgsDebugError( QStringLiteral( "Can't open temporary file %1" ).arg( mFile->fileName() ) );
+        mStatus = QgsFetchedContent::Failed;
+        return;
+      }
       mFile->write( reply->readAll() );
       // Qt docs notes that on some system if fileName is not called before close, file might get deleted
       mFilePath = mFile->fileName();

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -5110,7 +5110,11 @@ QString QgsProject::createAttachedFile( const QString &nameTemplate )
   const QDir archiveDir( mArchive->dir() );
   QTemporaryFile tmpFile( archiveDir.filePath( "XXXXXX_" + nameTemplate ), this );
   tmpFile.setAutoRemove( false );
-  tmpFile.open();
+  if ( !tmpFile.open() )
+  {
+    setError( tr( "Unable to open %1" ).arg( tmpFile.fileName() ) );
+    return QString();
+  }
   mArchive->addFile( tmpFile.fileName() );
   return tmpFile.fileName();
 }

--- a/src/core/qgsauxiliarystorage.cpp
+++ b/src/core/qgsauxiliarystorage.cpp
@@ -912,7 +912,11 @@ QString QgsAuxiliaryStorage::filenameForProject( const QgsProject &project )
 void QgsAuxiliaryStorage::initTmpFileName()
 {
   QTemporaryFile tmpFile;
-  tmpFile.open();
+  if ( !tmpFile.open() )
+  {
+    QgsDebugError( QStringLiteral( "Can't open temporary file" ) );
+    return;
+  }
   tmpFile.close();
   mTmpFileName = tmpFile.fileName();
 }

--- a/src/core/qgssourcecache.cpp
+++ b/src/core/qgssourcecache.cpp
@@ -108,7 +108,11 @@ QString QgsSourceCache::fetchSource( const QString &path, bool &isBroken, bool b
         filePath = temporaryDir->filePath( QString::number( ++id ) );
 
       QFile file( filePath );
-      file.open( QIODevice::WriteOnly );
+      if ( !file.open( QIODevice::WriteOnly ) )
+      {
+        QgsDebugError( QStringLiteral( "Can't open file %1" ).arg( filePath ) );
+        return QString();
+      }
       file.write( ba );
       file.close();
     }

--- a/src/core/qgstranslationcontext.cpp
+++ b/src/core/qgstranslationcontext.cpp
@@ -87,7 +87,11 @@ void QgsTranslationContext::writeTsFile( const QString &locale ) const
 
   //write file
   QFile tsFile( fileName() );
-  tsFile.open( QIODevice::WriteOnly );
+  if ( !tsFile.open( QIODevice::WriteOnly ) )
+  {
+    QgsDebugError( QStringLiteral( "Can't open file %1" ).arg( fileName() ) );
+    return;
+  }
   QTextStream stream( &tsFile );
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   stream.setCodec( "UTF-8" );

--- a/src/server/services/wcs/qgswcsgetcoverage.cpp
+++ b/src/server/services/wcs/qgswcsgetcoverage.cpp
@@ -186,7 +186,10 @@ namespace QgsWcs
     }
 
     QTemporaryFile tempFile;
-    tempFile.open();
+    if ( !tempFile.open() )
+    {
+      throw QgsRequestNotWellFormedException( QStringLiteral( "Cannot open temporary file" ) );
+    }
     QgsRasterFileWriter fileWriter( tempFile.fileName() );
 
     // clone pipe/provider

--- a/src/server/services/wms/qgspdfwriter.cpp
+++ b/src/server/services/wms/qgspdfwriter.cpp
@@ -37,7 +37,11 @@ namespace QgsWms
     context.setFlag( QgsWmsRenderContext::UseTileBuffer );
     context.setParameters( request.wmsParameters() );
     QTemporaryFile tmpFile;
-    tmpFile.open();
+    if ( !tmpFile.open() )
+    {
+      QgsDebugError( QStringLiteral( "Can't open temporary file" ) );
+      // TODO return error to the user?
+    }
     QgsRenderer renderer( context );
     std::unique_ptr<QgsMapRendererTask> pdfTask = renderer.getPdf( tmpFile.fileName() );
     QgsApplication::taskManager()->addTask( pdfTask.get() );

--- a/src/ui/attributeformconfig/qgsattributetypeedit.ui
+++ b/src/ui/attributeformconfig/qgsattributetypeedit.ui
@@ -397,8 +397,6 @@
   <tabstop>isFieldEditableCheckBox</tabstop>
   <tabstop>mEditableExpressionButton</tabstop>
   <tabstop>labelOnTopCheckBox</tabstop>
-  <tabstop>reuseLastValuesCheckBox</tabstop>
-  <tabstop>reuseLastValuesByDefaultCheckBox</tabstop>
   <tabstop>mWidgetTypeComboBox</tabstop>
   <tabstop>notNullCheckBox</tabstop>
   <tabstop>mCheckBoxEnforceNotNull</tabstop>
@@ -409,6 +407,10 @@
   <tabstop>mCheckBoxEnforceExpression</tabstop>
   <tabstop>mExpressionWidget</tabstop>
   <tabstop>mApplyDefaultValueOnUpdateCheckBox</tabstop>
+  <tabstop>mReuseLastValuePolicyComboBox</tabstop>
+  <tabstop>mSplitPolicyComboBox</tabstop>
+  <tabstop>mDuplicatePolicyComboBox</tabstop>
+  <tabstop>mMergePolicyComboBox</tabstop>
  </tabstops>
  <resources>
   <include location="../../../images/images.qrc"/>

--- a/tests/src/3d/testqgs3dexporter.cpp
+++ b/tests/src/3d/testqgs3dexporter.cpp
@@ -128,7 +128,7 @@ void TestQgs3DExporter::do3DSceneExport( const QString &testName, int zoomLevels
   QCOMPARE( exporter.mObjects.size(), expectedObjectCount );
 
   QFile file( QString( "%1/%2.obj" ).arg( QDir::tempPath(), objFileName ) );
-  file.open( QIODevice::ReadOnly | QIODevice::Text );
+  QVERIFY( file.open( QIODevice::ReadOnly | QIODevice::Text ) );
   QTextStream fileStream( &file );
 
   // check the generated obj file

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -392,7 +392,7 @@ void TestQgs3DUtils::testExportToObj()
 
 
     QFile file( myTmpDir + "all_faces.obj" );
-    file.open( QIODevice::ReadWrite | QIODevice::Text | QIODevice::Truncate );
+    QVERIFY( file.open( QIODevice::ReadWrite | QIODevice::Text | QIODevice::Truncate ) );
     QTextStream out( &file );
 
     out << "o " << object.name() << "\n";
@@ -431,7 +431,7 @@ void TestQgs3DUtils::testExportToObj()
     QCOMPARE( object.normals().size(), normalsData.size() );
 
     QFile file( myTmpDir + "sparse_faces.obj" );
-    file.open( QIODevice::ReadWrite | QIODevice::Text | QIODevice::Truncate );
+    QVERIFY( file.open( QIODevice::ReadWrite | QIODevice::Text | QIODevice::Truncate ) );
     QTextStream out( &file );
     out << "o " << object.name() << "\n";
     object.saveTo( out, 1.0, QVector3D( 0, 0, 0 ), 3 );

--- a/tests/src/analysis/testqgsmeshcalculator.cpp
+++ b/tests/src/analysis/testqgsmeshcalculator.cpp
@@ -221,7 +221,7 @@ void TestQgsMeshCalculator::calcWithVertexLayers()
   const QgsRectangle extent( 1000.000, 1000.000, 3000.000, 3000.000 );
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   const QString tmpName = tmpFile.fileName();
   tmpFile.close();
 
@@ -239,7 +239,7 @@ void TestQgsMeshCalculator::calcWithFaceLayers()
   const QgsRectangle extent( 1000.000, 1000.000, 3000.000, 3000.000 );
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   const QString tmpName = tmpFile.fileName();
   tmpFile.close();
 
@@ -257,7 +257,7 @@ void TestQgsMeshCalculator::calcWithMixedLayers()
   const QgsRectangle extent( 1000.000, 1000.000, 3000.000, 3000.000 );
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   const QString tmpName = tmpFile.fileName();
   tmpFile.close();
 

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -1263,7 +1263,7 @@ void TestQgsProcessingAlgsPt1::createDirectory()
   if ( QFile::exists( outputPath ) )
     QFile::remove( outputPath );
   QFile file( outputPath );
-  file.open( QIODevice::ReadWrite );
+  QVERIFY( file.open( QIODevice::ReadWrite ) );
   file.close();
 
   QVariantMap parameters;
@@ -2508,7 +2508,7 @@ void TestQgsProcessingAlgsPt1::rasterLogicOp()
   {
     // generate unique filename (need to open the file first to generate it)
     QTemporaryFile tmpFile;
-    tmpFile.open();
+    QVERIFY( tmpFile.open() );
     tmpFile.close();
 
     // create a GeoTIFF - this will create data provider in editable mode
@@ -2547,7 +2547,7 @@ void TestQgsProcessingAlgsPt1::rasterLogicOp()
 
   // make destination OR raster
   QTemporaryFile tmpFile2;
-  tmpFile2.open();
+  QVERIFY( tmpFile2.open() );
   tmpFile2.close();
 
   // create a GeoTIFF - this will create data provider in editable mode
@@ -2557,7 +2557,7 @@ void TestQgsProcessingAlgsPt1::rasterLogicOp()
 
   // make destination AND raster
   QTemporaryFile tmpFile3;
-  tmpFile3.open();
+  QVERIFY( tmpFile3.open() );
   tmpFile3.close();
 
   // create a GeoTIFF - this will create data provider in editable mode
@@ -4436,7 +4436,7 @@ void TestQgsProcessingAlgsPt1::styleFromProject()
 
   // using a project path
   QTemporaryFile tmpFile;
-  tmpFile.open();
+  QVERIFY( tmpFile.open() );
   tmpFile.close();
   QVERIFY( p.write( tmpFile.fileName() ) );
   p.clear();
@@ -4478,11 +4478,11 @@ void TestQgsProcessingAlgsPt1::combineStyles()
   s2.addTextFormat( QStringLiteral( "format2" ), QgsTextFormat::fromQFont( QgsFontUtils::getStandardTestFont() ), true );
 
   QTemporaryFile tmpFile;
-  tmpFile.open();
+  QVERIFY( tmpFile.open() );
   tmpFile.close();
   QVERIFY( s1.exportXml( tmpFile.fileName() ) );
   QTemporaryFile tmpFile2;
-  tmpFile2.open();
+  QVERIFY( tmpFile2.open() );
   tmpFile2.close();
   QVERIFY( s2.exportXml( tmpFile2.fileName() ) );
 

--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -462,7 +462,7 @@ void TestQgsRasterCalculator::calcWithLayers()
   QgsRectangle extent( 783235, 3348110, 783350, 3347960 );
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   QString tmpName = tmpFile.fileName();
   tmpFile.close();
 
@@ -521,7 +521,7 @@ void TestQgsRasterCalculator::calcWithReprojectedLayers()
   QgsRectangle extent( 783235, 3348110, 783350, 3347960 );
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   QString tmpName = tmpFile.fileName();
   tmpFile.close();
 
@@ -777,7 +777,7 @@ void TestQgsRasterCalculator::errors()
   QgsRectangle extent( 783235, 3348110, 783350, 3347960 );
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   QString tmpName = tmpFile.fileName();
   tmpFile.close();
 
@@ -878,7 +878,7 @@ void TestQgsRasterCalculator::testOutputCrsFromRasterEntries()
   QgsRectangle extent( 783235, 3348110, 783350, 3347960 );
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   QString tmpName = tmpFile.fileName();
   tmpFile.close();
 
@@ -919,7 +919,7 @@ void TestQgsRasterCalculator::calcFormulasWithReprojectedLayers()
 #endif
 
     QTemporaryFile tmpFile;
-    tmpFile.open(); // fileName is not available until open
+    QVERIFY( tmpFile.open() ); // fileName is not available until open
     QString tmpName = tmpFile.fileName();
     tmpFile.close();
     QgsRasterCalculator rc( formula, tmpName, QStringLiteral( "GTiff" ), extent, crs, 2, 3, entries, QgsProject::instance()->transformContext() );
@@ -981,7 +981,7 @@ void TestQgsRasterCalculator::testStatistics()
   entry1.ref = QStringLiteral( "landsat@1" );
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   QString tmpName = tmpFile.fileName();
   tmpFile.close();
 
@@ -1042,7 +1042,7 @@ void TestQgsRasterCalculator::testFunctionTypeWithLayer()
   QgsRectangle extent( 783235, 3348110, 783350, 3347960 );
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   QString tmpName = tmpFile.fileName();
   tmpFile.close();
 
@@ -1148,7 +1148,7 @@ void TestQgsRasterCalculator::testCreationOptions()
 
   QTemporaryFile tmpFile;
   tmpFile.setFileTemplate( "rc-XXXXXX.tif" );
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   QString tmpName = tmpFile.fileName();
   tmpFile.close();
 
@@ -1178,7 +1178,7 @@ void TestQgsRasterCalculator::testNoDataValue()
   QgsRectangle extent( 783235, 3348110, 783350, 3347960 );
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   QString tmpName = tmpFile.fileName();
   tmpFile.close();
 

--- a/tests/src/app/testqgsmergeattributesdialog.cpp
+++ b/tests/src/app/testqgsmergeattributesdialog.cpp
@@ -54,7 +54,7 @@ class TestQgsMergeattributesDialog : public QgsTest
       QgsVectorLayer ml( "Polygon", "test", "memory" );
       QVERIFY( ml.isValid() );
       QTemporaryFile tmpFile( QDir::tempPath() + "/TestQgsMergeattributesDialog" );
-      tmpFile.open();
+      QVERIFY( tmpFile.open() );
       const QString fileName( tmpFile.fileName() );
       options.driverName = "GPKG";
       options.layerName = "test";

--- a/tests/src/app/testqgsmeshcalculatordialog.cpp
+++ b/tests/src/app/testqgsmeshcalculatordialog.cpp
@@ -90,7 +90,7 @@ void TestQgsMeshCalculatorDialog::testCalc()
   const int groupCount = mpMeshLayer->dataProvider()->datasetGroupCount();
 
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   const QString tmpName = tmpFile.fileName();
   tmpFile.close();
 

--- a/tests/src/core/testqgsconnectionpool.cpp
+++ b/tests/src/core/testqgsconnectionpool.cpp
@@ -77,7 +77,7 @@ void TestQgsConnectionPool::layersFromSameDatasetGPX()
   const int nRoutePts = 10;
   QTemporaryFile testFile( QStringLiteral( "testXXXXXX.gpx" ) );
   testFile.setAutoRemove( false );
-  testFile.open();
+  QVERIFY( testFile.open() );
   testFile.write( "<gpx version=\"1.1\" creator=\"qgis\">\n" );
   for ( int i = 0; i < nWaypoints; ++i )
   {

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -648,7 +648,7 @@ void TestQgsDxfExport::testMTextEscapeLineBreaks()
   QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
 
-  dxfFile.open( QIODevice::ReadOnly );
+  QVERIFY( dxfFile.open( QIODevice::ReadOnly ) );
   const QString fileContent = QTextStream( &dxfFile ).readAll();
   dxfFile.close();
   QVERIFY( fileContent.contains( "A\\~text\\~with\\~\\Pline\\~break" ) );

--- a/tests/src/core/testqgsgml.cpp
+++ b/tests/src/core/testqgsgml.cpp
@@ -125,7 +125,7 @@ void TestQgsGML::testFromURL()
   QgsGml gmlParser( QStringLiteral( "mytypename" ), QStringLiteral( "mygeom" ), fields );
   Qgis::WkbType wkbType;
   QTemporaryFile tmpFile;
-  tmpFile.open();
+  QVERIFY( tmpFile.open() );
   tmpFile.write( data1.toLatin1() );
   tmpFile.flush();
   QCOMPARE( gmlParser.getFeatures( QUrl::fromLocalFile( tmpFile.fileName() ).toString(), &wkbType ), 0 );

--- a/tests/src/core/testqgsmesheditor.cpp
+++ b/tests/src/core/testqgsmesheditor.cpp
@@ -1906,9 +1906,9 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
   QFile expectedFile( QString( mDataDir + "/quad_flower_to_edit_expected.2dm" ) );
   QFile original( QString( mDataDir + "/quad_flower.2dm" ) );
 
-  alteredFile.open( QIODevice::ReadOnly );
-  original.open( QIODevice::ReadOnly );
-  expectedFile.open( QIODevice::ReadOnly );
+  QVERIFY( alteredFile.open( QIODevice::ReadOnly ) );
+  QVERIFY( original.open( QIODevice::ReadOnly ) );
+  QVERIFY( expectedFile.open( QIODevice::ReadOnly ) );
 
   QTextStream streamAltered( &alteredFile );
   QTextStream streamOriginal( &original );
@@ -1922,7 +1922,7 @@ void TestQgsMeshEditor::meshEditorFromMeshLayer_quadFlower()
   meshLayerQuadFlower->commitFrameEditing( transform, false );
   QVERIFY( meshLayerQuadFlower->meshEditor() == nullptr );
 
-  alteredFile.open( QIODevice::WriteOnly );
+  QVERIFY( alteredFile.open( QIODevice::WriteOnly ) );
   streamAltered << streamOriginal.readAll();
 }
 

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -1067,8 +1067,8 @@ void TestQgsMeshLayer::test_reload()
   auto copyToTemporaryFile = []( QFile &fileTocopy, QTemporaryFile &tempFile ) {
     QDataStream streamToCopy( &fileTocopy );
     QDataStream streamTemporaryFile( &tempFile );
-    tempFile.open();
-    fileTocopy.open( QIODevice::ReadOnly );
+    QVERIFY( tempFile.open() );
+    QVERIFY( fileTocopy.open( QIODevice::ReadOnly ) );
 
     while ( !streamToCopy.atEnd() )
     {
@@ -1148,8 +1148,8 @@ void TestQgsMeshLayer::test_reload_extra_dataset()
   auto copyToTemporaryFile = []( QFile &fileTocopy, QTemporaryFile &tempFile ) {
     QDataStream streamToCopy( &fileTocopy );
     QDataStream streamTemporaryFile( &tempFile );
-    tempFile.open();
-    fileTocopy.open( QIODevice::ReadOnly );
+    QVERIFY( tempFile.open() );
+    QVERIFY( fileTocopy.open( QIODevice::ReadOnly ) );
 
     while ( !streamToCopy.atEnd() )
     {

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -176,7 +176,7 @@ void TestQgsProject::testPathResolver()
 
   // test older style relative path - file must exist for this to work
   QTemporaryFile tmpFile;
-  tmpFile.open(); // fileName is not available until we open the file
+  QVERIFY( tmpFile.open() ); // fileName is not available until we open the file
   const QString tmpName = tmpFile.fileName();
   tmpFile.close();
   const QgsPathResolver tempRel( tmpName );
@@ -817,7 +817,7 @@ void TestQgsProject::testAttachmentsQgs()
   // Verify that attachment is exists after re-reading project
   {
     QTemporaryFile projFile( QDir::temp().absoluteFilePath( "XXXXXX_test.qgs" ) );
-    projFile.open();
+    QVERIFY( projFile.open() );
 
     QgsProject p;
     QFile file;
@@ -846,12 +846,12 @@ void TestQgsProject::testAttachmentsQgs()
   // Verify that attachment paths can be used as layer filenames
   {
     QTemporaryFile projFile( QDir::temp().absoluteFilePath( "XXXXXX_test.qgs" ) );
-    projFile.open();
+    QVERIFY( projFile.open() );
 
     QgsProject p;
     const QString fileName = p.createAttachedFile( "testlayer.gpx" );
     QFile file( fileName );
-    file.open( QIODevice::WriteOnly );
+    QVERIFY( file.open( QIODevice::WriteOnly ) );
     file.write( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" );
     file.write( "<gpx version=\"1.0\">" );
     file.write( "<name>Example gpx</name>" );
@@ -904,7 +904,7 @@ void TestQgsProject::testAttachmentsQgz()
   // Verify that attachment is exists after re-reading project
   {
     QTemporaryFile projFile( QDir::temp().absoluteFilePath( "XXXXXX_test.qgz" ) );
-    projFile.open();
+    QVERIFY( projFile.open() );
 
     QgsProject p;
     QFile file;
@@ -929,12 +929,12 @@ void TestQgsProject::testAttachmentsQgz()
   // Verify that attachment paths can be used as layer filenames
   {
     QTemporaryFile projFile( QDir::temp().absoluteFilePath( "XXXXXX_test.qgz" ) );
-    projFile.open();
+    QVERIFY( projFile.open() );
 
     QgsProject p;
     const QString fileName = p.createAttachedFile( "testlayer.gpx" );
     QFile file( fileName );
-    file.open( QIODevice::WriteOnly );
+    QVERIFY( file.open( QIODevice::WriteOnly ) );
     file.write( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" );
     file.write( "<gpx version=\"1.0\">" );
     file.write( "<name>Example gpx</name>" );
@@ -968,7 +968,7 @@ void TestQgsProject::testAttachmentIdentifier()
   // Verify attachment identifiers
   {
     QTemporaryFile projFile( QDir::temp().absoluteFilePath( "XXXXXX_test.qgz" ) );
-    projFile.open();
+    QVERIFY( projFile.open() );
 
     QgsProject p;
     const QString attachmentFileName = p.createAttachedFile( "test.jpg" );
@@ -1097,7 +1097,7 @@ void TestQgsProject::testAsynchronousLayerLoading()
   QCOMPARE( project->mapLayers( false ).count(), layersCount );
 
   QTemporaryFile projFile( QDir::temp().absoluteFilePath( "XXXXXX_test.qgs" ) );
-  projFile.open();
+  QVERIFY( projFile.open() );
   QVERIFY( project->write( projFile.fileName() ) );
 
   project = std::make_unique<QgsProject>();

--- a/tests/src/core/testqgsquantizedmeshtiles.cpp
+++ b/tests/src/core/testqgsquantizedmeshtiles.cpp
@@ -67,7 +67,7 @@ static void runTest( QString testName, bool skirt, double skirtDepth, bool texCo
   }
 
   QFile sampleFile( sampleFilePath );
-  sampleFile.open( QIODevice::ReadOnly );
+  QVERIFY( sampleFile.open( QIODevice::ReadOnly ) );
   auto sampleData = sampleFile.readAll();
 
   auto tile = QgsQuantizedMeshTile( sampleData );
@@ -91,7 +91,7 @@ static void runTest( QString testName, bool skirt, double skirtDepth, bool texCo
   if ( checkOutput )
   {
     QFile correctOutFile( QStringLiteral( TEST_DATA_DIR ) + "/quantized_mesh.terrain." + testName + ".gltf" );
-    correctOutFile.open( QIODevice::ReadOnly );
+    QVERIFY( correctOutFile.open( QIODevice::ReadOnly ) );
     auto correctOutput = correctOutFile.readAll();
     std::ostringstream newOutputStream;
     gltfLoader.WriteGltfSceneToStream( &model, newOutputStream, true, false );

--- a/tests/src/core/testqgsrasterblock.cpp
+++ b/tests/src/core/testqgsrasterblock.cpp
@@ -173,7 +173,7 @@ void TestQgsRasterBlock::testWrite()
 
   // generate unique filename (need to open the file first to generate it)
   QTemporaryFile tmpFile;
-  tmpFile.open();
+  QVERIFY( tmpFile.open() );
   tmpFile.close();
 
   // create a GeoTIFF - this will create data provider in editable mode

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -1409,7 +1409,7 @@ class TestQgsRuleBasedRenderer : public QgsTest
       Q_ASSERT( sld.contains( QStringLiteral( "<se:ElseFilter" ) ) );
 
       QTemporaryFile sldFile;
-      sldFile.open();
+      QVERIFY( sldFile.open() );
       sldFile.write( sld.toUtf8() );
       sldFile.close();
 

--- a/tests/src/core/testqgstranslateproject.cpp
+++ b/tests/src/core/testqgstranslateproject.cpp
@@ -103,7 +103,7 @@ void TestQgsTranslateProject::createTsFile()
   QFile tsFile( tsFileName );
   QVERIFY( tsFile.exists() );
 
-  tsFile.open( QIODevice::ReadWrite );
+  QVERIFY( tsFile.open( QIODevice::ReadWrite ) );
 
   const QString tsFileContent( tsFile.readAll() );
 

--- a/tests/src/core/testqgsvectorfilewriter.cpp
+++ b/tests/src/core/testqgsvectorfilewriter.cpp
@@ -482,7 +482,7 @@ void TestQgsVectorFileWriter::prepareWriteAsVectorFormat()
   ml.dataProvider()->addFeature( ft );
   QVERIFY( ml.isValid() );
   QTemporaryFile tmpFile( QDir::tempPath() + "/test_qgsvectorfilewriter_XXXXXX.gpkg" );
-  tmpFile.open();
+  QVERIFY( tmpFile.open() );
   const QString fileName( tmpFile.fileName() );
   options.driverName = "GPKG";
   options.layerName = "test";
@@ -507,7 +507,7 @@ void TestQgsVectorFileWriter::prepareWriteAsVectorFormat()
 void TestQgsVectorFileWriter::testTextFieldLength()
 {
   QTemporaryFile tmpFile( QDir::tempPath() + "/test_qgsvectorfilewriter2_XXXXXX.gpkg" );
-  tmpFile.open();
+  QVERIFY( tmpFile.open() );
   const QString fileName( tmpFile.fileName() );
   QgsVectorLayer vl( "Point?field=firstfield:string(1024)", "test", "memory" );
   QCOMPARE( vl.fields().at( 0 ).length(), 1024 );
@@ -539,7 +539,7 @@ void TestQgsVectorFileWriter::testTextFieldLength()
 void TestQgsVectorFileWriter::testExportArrayToGpkg()
 {
   QTemporaryFile tmpFile( QDir::tempPath() + "/test_qgsvectorfilewriter3_XXXXXX.gpkg" );
-  tmpFile.open();
+  QVERIFY( tmpFile.open() );
   const QString fileName( tmpFile.fileName() );
   QgsVectorLayer vl( "Point?field=arrayfield:integerlist&field=arrayfield2:stringlist", "test", "memory" );
   QCOMPARE( vl.fields().at( 0 ).type(), QMetaType::Type::QVariantList );
@@ -581,7 +581,7 @@ void TestQgsVectorFileWriter::testExportArrayToGpkg()
 void TestQgsVectorFileWriter::_testExportToGpx( const QString &geomTypeName, const QString &wkt, const QString &expectedLayerName, const QString &inputLayerName, const QStringList &layerOptions )
 {
   QTemporaryFile tmpFile( QDir::tempPath() + "/test_qgsvectorfilewriter_testExportToGpx" + geomTypeName + "_XXXXXX.gpx" );
-  tmpFile.open();
+  QVERIFY( tmpFile.open() );
   const QString fileName( tmpFile.fileName() );
   QString memLayerDef( geomTypeName );
   if ( inputLayerName == QLatin1String( "track_points" ) )

--- a/tests/src/core/testqgsvectortileutils.cpp
+++ b/tests/src/core/testqgsvectortileutils.cpp
@@ -68,7 +68,7 @@ void TestQgsVectorTileUtils::test_urlsFromStyle()
 {
   QString dataDir( TEST_DATA_DIR );
   QFile style1File( dataDir + "/vector_tile/styles/style1.json" );
-  style1File.open( QIODevice::Text | QIODevice::ReadOnly );
+  QVERIFY( style1File.open( QIODevice::Text | QIODevice::ReadOnly ) );
   QString style1Content = style1File.readAll();
   style1File.close();
   style1Content.replace( QString( "_TILE_SOURCE_TEST_PATH_" ), "file://" + dataDir + "/vector_tile/styles" );

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -161,7 +161,7 @@ void TestQgsMapCanvas::testMagnification()
 
   QTemporaryFile tmpFile;
   tmpFile.setAutoRemove( false );
-  tmpFile.open(); // fileName is not available until open
+  QVERIFY( tmpFile.open() ); // fileName is not available until open
   const QString tmpName = tmpFile.fileName();
   tmpFile.close();
 

--- a/tests/src/gui/testqgsogrprovidergui.cpp
+++ b/tests/src/gui/testqgsogrprovidergui.cpp
@@ -82,7 +82,7 @@ void TestQgsOgrProviderGui::cleanupTestCase()
 void TestQgsOgrProviderGui::testGpkgDataItemRename()
 {
   QTemporaryFile tmpFile( QDir::temp().absoluteFilePath( QStringLiteral( "qgis-XXXXXX.gpkg" ) ) );
-  tmpFile.open();
+  QVERIFY( tmpFile.open() );
   tmpFile.close();
   const QString fileName { tmpFile.fileName() };
   tmpFile.remove();

--- a/tests/src/gui/testqgsrasterlayersaveasdialog.cpp
+++ b/tests/src/gui/testqgsrasterlayersaveasdialog.cpp
@@ -113,7 +113,11 @@ QString TestQgsRasterLayerSaveAsDialog::prepareDb()
   // Preparation: make a test gpk DB with a vector layer in it
   QTemporaryFile tmpFile( QDir::tempPath() + QStringLiteral( "/test_qgsrasterlayersavesdialog_XXXXXX.gpkg" ) );
   tmpFile.setAutoRemove( false );
-  tmpFile.open();
+  if ( !tmpFile.open() )
+  {
+    Q_ASSERT( false );
+    return QString();
+  }
   const QString fileName( tmpFile.fileName() );
   QgsVectorLayer vl( QStringLiteral( "Point?field=firstfield:string(1024)" ), "test_vector_layer", "memory" );
 

--- a/tests/src/providers/testqgswcsprovider.cpp
+++ b/tests/src/providers/testqgswcsprovider.cpp
@@ -111,10 +111,10 @@ void TestQgsWcsProvider::read()
   identifiers << QStringLiteral( "band3_float32_noct_epsg4326" );
 
   // How to reasonably log multiple fails within this loop?
-  QTemporaryFile *tmpFile = new QTemporaryFile( QStringLiteral( "qgis-wcs-test-XXXXXX.tif" ) );
-  tmpFile->open();
-  const QString tmpFilePath = tmpFile->fileName();
-  delete tmpFile; // removes the file
+  QTemporaryFile tmpFile( QStringLiteral( "qgis-wcs-test-XXXXXX.tif" ) );
+  QVERIFY( tmpFile.open() );
+  const QString tmpFilePath = tmpFile.fileName();
+  tmpFile.close(); // removes the file
   for ( const QString &version : versions )
   {
     for ( const QString &identifier : identifiers )


### PR DESCRIPTION
- Suppress build warnings related to vendored libspatialindex
- qgsattributetypeedit.ui: fix warning about non existing widgets in tabstop
- src/: fix warnings related to not checking QFile::open() return value
- tests/: fix warnings related to not checking QFile::open() return value
