### PR TITLE
 [vector layers][ui] Expose the features sorting order expression driving the features display ordering within the attribute table views and relation editor widgets

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1385,6 +1385,7 @@ void QgsRasterLayerProperties::initMapTipPreview()
   // Note: there's quite a bit of overlap between this and the code in QgsMapTip::showMapTip
   // Create the WebView
   mMapTipPreview = new QgsWebView( mMapTipPreviewContainer );
+  mMapTipPreviewLayout->addWidget( mMapTipPreview );
 
 #if WITH_QTWEBKIT
   mMapTipPreview->page()->setLinkDelegationPolicy( QWebPage::DelegateAllLinks ); //Handle link clicks by yourself

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -206,7 +206,6 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
     return;
   }
 
-  connect( mEnableMapTips, &QAbstractButton::toggled, mHtmlMapTipGroupBox, &QWidget::setEnabled );
   mEnableMapTips->setChecked( mRasterLayer->mapTipsEnabled() );
 
   updateRasterAttributeTableOptionsPage();

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -1869,6 +1869,7 @@ void QgsVectorLayerProperties::initMapTipPreview()
   // Note: there's quite a bit of overlap between this and the code in QgsMapTip::showMapTip
   // Create the WebView
   mMapTipPreview = new QgsWebView( mMapTipPreviewContainer );
+  mMapTipPreviewLayout->addWidget( mMapTipPreview );
 
 #if WITH_QTWEBKIT
   mMapTipPreview->page()->setLinkDelegationPolicy( QWebPage::DelegateAllLinks ); //Handle link clicks by yourself

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -172,7 +172,6 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   if ( !mLayer )
     return;
 
-  connect( mEnableMapTips, &QAbstractButton::toggled, mHtmlMapTipGroupBox, &QWidget::setEnabled );
   mEnableMapTips->setChecked( mLayer->mapTipsEnabled() );
 
   QVBoxLayout *layout = nullptr;

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1465,30 +1465,30 @@ li.checked::marker { content: &quot;\2612&quot;; }
                <number>0</number>
               </property>
               <item row="0" column="0">
-               <widget class="QCheckBox" name="mEnableMapTips">
-                <property name="toolTip">
-                 <string>Indicates whether map tips are displayed for this layer or not</string>
+               <widget class="QGroupBox" name="mEnableMapTips">
+                <property name="title">
+                 <string>Enable Map Tips</string>
                 </property>
-                <property name="text">
-                 <string>Enable map tips</string>
-                </property>
-                <property name="checked">
+                <property name="checkable">
                  <bool>true</bool>
                 </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QGroupBox" name="mHtmlMapTipGroupBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="title">
-                 <string>HTML Map Tip</string>
-                </property>
                 <layout class="QVBoxLayout" name="verticalLayout_22">
+                 <item>
+                  <widget class="QLabel" name="labelMapTipInfo">
+                   <property name="text">
+                    <string>Map tips are shown when moving mouse over raster cells of the currently selected layer when the 'Show Map Tips' action is toggled on.</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
                  <item>
                   <widget class="QSplitter" name="mMapTipSplitter">
                    <property name="sizePolicy">
@@ -1541,16 +1541,6 @@ li.checked::marker { content: &quot;\2612&quot;; }
                    <property name="icon">
                     <iconset resource="../../images/images.qrc">
                      <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelMapTipInfo">
-                   <property name="text">
-                    <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on.</string>
-                   </property>
-                   <property name="wordWrap">
-                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1522,8 +1522,9 @@ li.checked::marker { content: &quot;\2612&quot;; }
                      </size>
                     </property>
                     <property name="title">
-                     <string>Preview</string>
+                     <string>Map Tips Preview</string>
                     </property>
+                    <layout class="QVBoxLayout" name="mMapTipPreviewLayout"/>
                    </widget>
                   </widget>
                  </item>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1590,8 +1590,9 @@
                      </size>
                     </property>
                     <property name="title">
-                     <string>Preview</string>
+                     <string>Map Tips Preview</string>
                     </property>
+                    <layout class="QVBoxLayout" name="mMapTipPreviewLayout"/>
                    </widget>
                   </widget>
                  </item>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1445,30 +1445,30 @@
                </widget>
               </item>
               <item row="1" column="0">
-               <widget class="QCheckBox" name="mEnableMapTips">
-                <property name="toolTip">
-                 <string>Indicates whether map tips are displayed for this layer or not</string>
-                </property>
-                <property name="text">
-                 <string>Enable map tips</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QGroupBox" name="mHtmlMapTipGroupBox">
+                <widget class="QGroupBox" name="mEnableMapTips">
+                 <property name="title">
+                  <string>Enable Map Tips</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="title">
-                 <string>HTML Map Tip</string>
-                </property>
                 <layout class="QVBoxLayout" name="verticalLayout_35">
+                 <item>
+                  <widget class="QLabel" name="labelMapTipInfo">
+                   <property name="text">
+                    <string>Map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on. If no HTML code is set below, the feature display name is used.</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
                  <item>
                   <widget class="QSplitter" name="mMapTipSplitter">
                    <property name="sizePolicy">
@@ -1593,16 +1593,6 @@
                      <string>Preview</string>
                     </property>
                    </widget>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelMapTipInfo">
-                   <property name="text">
-                    <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on. If no HTML code is set, the feature display name is used.</string>
-                   </property>
-                   <property name="wordWrap">
-                    <bool>true</bool>
-                   </property>
                   </widget>
                  </item>
                 </layout>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1444,7 +1444,7 @@
                 </layout>
                </widget>
               </item>
-              <item row="1" column="0">
+              <item row="2" column="0">
                 <widget class="QGroupBox" name="mEnableMapTips">
                  <property name="title">
                   <string>Enable Map Tips</string>
@@ -1594,6 +1594,51 @@
                     </property>
                     <layout class="QVBoxLayout" name="mMapTipPreviewLayout"/>
                    </widget>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QGroupBox" name="featuresSortOrderGroupBox">
+                <property name="title">
+                 <string>Sort Order</string>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <layout class="QGridLayout" name="featuresSortOrderLayout">
+                 <item row="0" column="0">
+                  <widget class="QgsFieldExpressionWidget" name="mFeaturesSortOrderExpressionWidget" native="true">
+                   <property name="focusPolicy">
+                    <enum>Qt::FocusPolicy::StrongFocus</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QToolButton" name="mFeaturesSortOrderDirectionButton">
+                   <property name="toolTip">
+                    <string>Sort direction</string>
+                   </property>
+                   <property name="text">
+                    <string>…</string>
+                   </property>
+                   <property name="arrowType">
+                    <enum>Qt::UpArrow</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0" colspan="2">
+                  <widget class="QLabel" name="labelfeaturesSortOrderInfo">
+                   <property name="text">
+                    <string>The sort order expression is used to sort features displayed in the attribute table's views as well as the relation editor widget.</string>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
                   </widget>
                  </item>
                 </layout>


### PR DESCRIPTION
## Description

This PR exposes the sorting order  expression driving the features display ordering within the attribute table views and relation editor widgets into the vector layer properties dialog within its display panel. Here's how it looks:

<img width="889" height="880" alt="image" src="https://github.com/user-attachments/assets/5b61a33e-4958-46df-8842-416af87582a0" />

This makes the setting for more discoverable and manageable. For the attribute table's dual view and relation editor widget, that setting is also closely tied with the display name used in the features list.

_Note: the PR temporarily includes the improvements from https://github.com/qgis/QGIS/pull/63901 , I'll rebase once that is merged_