### PR TITLE
Override nix libspatialindex to use version 2.0.0

### DIFF
--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -15,6 +15,7 @@
 , draco
 , exiv2
 , fcgi
+, fetchFromGitHub
 , flex
 , geos
 , grass
@@ -50,6 +51,20 @@
 }:
 
 let
+  # Override libspatialindex to use version 2.0.0
+  # See https://github.com/libspatialindex/libspatialindex/issues/276
+  # An alternative would be to make this available/downgrade the version
+  # from the nixpkgs side.
+  libspatialindex_2_0 = libspatialindex.overrideAttrs (oldAttrs: rec {
+    version = "2.0.0";
+    src = fetchFromGitHub {
+      owner = "libspatialindex";
+      repo = "libspatialindex";
+      rev = version;
+      sha256 = "sha256-hZyAXz1ddRStjZeqDf4lYkV/g0JLqLy7+GrSUh75k20=";
+    };
+  });
+
   versionSourceFiles = lib.fileset.toSource {
     root = ../.;
     fileset = ../CMakeLists.txt;
@@ -153,7 +168,7 @@ stdenv.mkDerivation
     gsl
     hdf5
     libpq
-    libspatialindex
+    libspatialindex_2_0
     libspatialite
     libzip
     netcdf

--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 
+, fetchFromGitHub
 , makeWrapper
 , replaceVars
 , runCommand
@@ -15,7 +16,6 @@
 , draco
 , exiv2
 , fcgi
-, fetchFromGitHub
 , flex
 , geos
 , grass


### PR DESCRIPTION
## Description

On NixOS, when building QGIS with the nix command `nix run github:qgis/QGIS#qgis` or `nix run github:qgis/QGIS/release-3_44#qgis` or `nix run github:qgis/QGIS/release-3_40#qgis` as mentioned at https://qgis.org/resources/installation-guide/#running-developer-snapshots---remote, the command fails with the following error:

```
> -- Found Spatialindex: /nix/store/np65w0ahxmhr0mrpy9ij672fzfsz27z9-libspatialindex-2.1.0/lib/libspatialindex.so (2.1.0)
       > CMake Error at CMakeLists.txt:460 (message):
       >   Cannot build QGIS using libspatialindex >= 2.1, see
       >   https://github.com/libspatialindex/libspatialindex/issues/276
```

The suggestion here is to override libspatialindex from `nixpkgs` to use version 2.0.0 for now, and use this in the build inputs.

Cc @timlinux

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
