### PR TITLE
fix: create default processing output directory only when needed

### DIFF
--- a/python/plugins/processing/tools/system.py
+++ b/python/plugins/processing/tools/system.py
@@ -42,9 +42,6 @@ def userFolder():
 
 def defaultOutputFolder():
     folder = os.path.join(QDir.homePath(), "processing")
-    if not QDir(folder).exists():
-        QDir().mkpath(folder)
-
     return str(QDir.toNativeSeparators(folder))
 
 

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -177,7 +177,15 @@ QVariant QgsProcessingLayerOutputDestinationWidget::value() const
     {
       // output name does not include a folder - use default
       QString defaultFolder = settings.value( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), QStringLiteral( "%1/processing" ).arg( QDir::homePath() ) ).toString();
-      key = QDir( defaultFolder ).filePath( key );
+      QDir destDir( defaultFolder );
+      if ( !destDir.exists() )
+      {
+        if ( !QDir().mkpath( defaultFolder ) )
+        {
+          QgsDebugError( QStringLiteral( "Can't create output folder '%1'" ).arg( defaultFolder ) );
+        }
+      }
+      key = destDir.filePath( key );
     }
   }
 

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -178,12 +178,9 @@ QVariant QgsProcessingLayerOutputDestinationWidget::value() const
       // output name does not include a folder - use default
       QString defaultFolder = settings.value( QStringLiteral( "/Processing/Configuration/OUTPUTS_FOLDER" ), QStringLiteral( "%1/processing" ).arg( QDir::homePath() ) ).toString();
       QDir destDir( defaultFolder );
-      if ( !destDir.exists() )
+      if ( !destDir.exists() && !QDir().mkpath( defaultFolder ) )
       {
-        if ( !QDir().mkpath( defaultFolder ) )
-        {
-          QgsDebugError( QStringLiteral( "Can't create output folder '%1'" ).arg( defaultFolder ) );
-        }
+        QgsDebugError( QStringLiteral( "Can't create output folder '%1'" ).arg( defaultFolder ) );
       }
       key = destDir.filePath( key );
     }


### PR DESCRIPTION
This avoids systematic creation of default processing output directory into the user home directory. If the user has already set the "Processing/Configuration/OUTPUTS_FOLDER" setting, there is no need to create the defaut directory.

The default output directory will only be created if it has to be used.

Ref #61965
