### PR TITLE
Don't update default values while initializing multi edit form

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1128,7 +1128,7 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
   updateConstraints( eww );
 
   // Update dependent fields (only if form is not initializing)
-  if ( mValuesInitialized )
+  if ( mValuesInitialized && !mIsSettingMultiEditFeatures )
   {
     //append field index here, so it's not updated recursive
     mAlreadyUpdatedFields.append( eww->fieldIdx() );


### PR DESCRIPTION
## Description
This PR prevents the multi edit form for updating depending default values when setting multi edit values during form initialization.

Fixes #63921

Backport  needed for 3.44
