### PR TITLE
fix crash when make permanent renamed layer gets removed

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8206,7 +8206,7 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
             button->setEnabled( false );
           } );
 
-          connect( button, &QPushButton::clicked, barItem, [button, vl, newLayerName]() {
+          connect( button, &QPushButton::clicked, vl, [button, vl, newLayerName]() {
             vl->setName( newLayerName );
             button->setEnabled( false );
           } );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8202,11 +8202,11 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
           QPushButton *button = new QPushButton( tr( "Also rename layer in layers panel" ), this );
           barItem->setWidget( button );
 
-          connect( vl, &QgsVectorLayer::willBeDeleted, this, [button]() {
+          connect( vl, &QgsVectorLayer::willBeDeleted, barItem, [button]() {
             button->setEnabled( false );
           } );
 
-          connect( button, &QPushButton::clicked, this, [button, vl, newLayerName]() {
+          connect( button, &QPushButton::clicked, barItem, [button, vl, newLayerName]() {
             vl->setName( newLayerName );
             button->setEnabled( false );
           } );


### PR DESCRIPTION
## Description
Bug in #62664. App would still receive the signal when removing a layer after the message bar was removed.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
