### PR TITLE
Respect app icon on macos

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1326,9 +1326,6 @@ int main( int argc, char *argv[] )
 #ifdef Q_OS_MAC
   // Set hidpi icons; use SVG icons, as PNGs will be relatively too small
   QCoreApplication::setAttribute( Qt::AA_UseHighDpiPixmaps );
-
-  // Set 1024x1024 icon for dock, app switcher, etc., rendering
-  myApp.setWindowIcon( QIcon( QgsApplication::iconsPath() + QStringLiteral( "qgis-icon-macos.png" ) ) );
 #else
   QgsApplication::setWindowIcon( QIcon( QgsApplication::appIconPath() ) );
 #endif


### PR DESCRIPTION
On macos, we ship two mac'ish looking icons which are defined in Info.plist one for light and one for dark mode. We don't want these to be changed at runtime.

Fixes https://github.com/qgis/QGIS/issues/63590

https://github.com/qgis/QGIS/blob/master/platform/macos/Info.plist.in#L24-L44