### PR TITLE
Set a descriptive thread name for map layer renderers

### DIFF
--- a/src/core/annotations/qgsannotationlayerrenderer.cpp
+++ b/src/core/annotations/qgsannotationlayerrenderer.cpp
@@ -20,11 +20,13 @@
 #include "qgsrenderedannotationitemdetails.h"
 #include "qgspainteffect.h"
 #include "qgsrendercontext.h"
+#include "qgsthreadingutils.h"
 #include <optional>
 
 QgsAnnotationLayerRenderer::QgsAnnotationLayerRenderer( QgsAnnotationLayer *layer, QgsRenderContext &context )
   : QgsMapLayerRenderer( layer->id(), &context )
   , mFeedback( std::make_unique< QgsFeedback >() )
+  , mLayerName( layer->name() )
   , mLayerOpacity( layer->opacity() )
   , mLayerBlendMode( layer->blendMode() )
 {
@@ -79,6 +81,8 @@ QgsFeedback *QgsAnnotationLayerRenderer::feedback() const
 
 bool QgsAnnotationLayerRenderer::render()
 {
+  QgsScopedThreadName threadName( QStringLiteral( "render:%1" ).arg( mLayerName ) );
+
   QgsRenderContext &context = *renderContext();
 
   if ( mPaintEffect )

--- a/src/core/annotations/qgsannotationlayerrenderer.h
+++ b/src/core/annotations/qgsannotationlayerrenderer.h
@@ -53,6 +53,7 @@ class CORE_EXPORT QgsAnnotationLayerRenderer : public QgsMapLayerRenderer
   private:
     std::vector < std::pair< QString, std::unique_ptr< QgsAnnotationItem > > > mItems;
     std::unique_ptr< QgsFeedback > mFeedback;
+    QString mLayerName;
     double mLayerOpacity = 1.0;
     QPainter::CompositionMode mLayerBlendMode = QPainter::CompositionMode::CompositionMode_SourceOver;
     std::unique_ptr< QgsPaintEffect > mPaintEffect;

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -45,6 +45,7 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgsmeshlayerelevationproperties.h"
 #include "qgsrenderedlayerstatistics.h"
+#include "qgsthreadingutils.h"
 
 QgsMeshLayerRenderer::QgsMeshLayerRenderer(
   QgsMeshLayer *layer,
@@ -418,6 +419,8 @@ void QgsMeshLayerRenderer::copyVectorDatasetValues( QgsMeshLayer *layer )
 
 bool QgsMeshLayerRenderer::render()
 {
+  QgsScopedThreadName threadName( QStringLiteral( "render:%1" ).arg( mLayerName ) );
+
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   std::unique_ptr< QgsScopedRuntimeProfile > preparingProfile;
   if ( mEnableProfile )

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -37,6 +37,7 @@
 #include "qgsrendercontext.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsvirtualpointcloudprovider.h"
+#include "qgsthreadingutils.h"
 
 #include <delaunator.hpp>
 
@@ -96,6 +97,8 @@ QgsPointCloudLayerRenderer::QgsPointCloudLayerRenderer( QgsPointCloudLayer *laye
 
 bool QgsPointCloudLayerRenderer::render()
 {
+  QgsScopedThreadName threadName( QStringLiteral( "render:%1" ).arg( mLayerName ) );
+
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   if ( mEnableProfile )
   {

--- a/src/core/qgsthreadingutils.h
+++ b/src/core/qgsthreadingutils.h
@@ -286,7 +286,6 @@ class CORE_EXPORT QgsThreadingUtils
  * Temporarily overrides the current thread name.
  *
  * \warning This class is not supported on all platforms.
- * \warning This class has no impact on non-debug enabled builds.
  *
  * \note Not available in Python bindings
  * \since QGIS 4.0
@@ -300,11 +299,9 @@ class QgsScopedThreadName
      */
     QgsScopedThreadName( const QString &name )
     {
-#ifdef QGISDEBUG
+#if defined(Q_OS_LINUX) && !defined(QT_LINUXBASE)
       mOldName = getCurrentThreadName();
       setCurrentThreadName( name );
-#else
-      ( void )name;
 #endif
     }
 
@@ -313,14 +310,14 @@ class QgsScopedThreadName
      */
     ~QgsScopedThreadName()
     {
-#ifdef QGISDEBUG
+#if defined(Q_OS_LINUX) && !defined(QT_LINUXBASE)
       setCurrentThreadName( mOldName );
 #endif
     }
 
   private:
 
-#ifdef QGISDEBUG
+#if defined(Q_OS_LINUX) && !defined(QT_LINUXBASE)
     QString mOldName;
 
     static QString getCurrentThreadName()
@@ -343,7 +340,6 @@ class QgsScopedThreadName
 #endif
     }
 #endif
-
 };
 
 

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -41,6 +41,7 @@
 #include "qgsrasternuller.h"
 #include "qgsrenderedlayerstatistics.h"
 #include "qgsrasterlabeling.h"
+#include "qgsthreadingutils.h"
 
 #include <QElapsedTimer>
 #include <QPointer>
@@ -510,6 +511,8 @@ QgsRasterLayerRenderer::~QgsRasterLayerRenderer()
 
 bool QgsRasterLayerRenderer::render()
 {
+  QgsScopedThreadName threadName( QStringLiteral( "render:%1" ).arg( mLayerName ) );
+
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   if ( mEnableProfile )
   {

--- a/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
+++ b/src/core/tiledscene/qgstiledscenelayerrenderer.cpp
@@ -34,6 +34,7 @@
 #include "qgstextrenderer.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsapplication.h"
+#include "qgsthreadingutils.h"
 
 #include <QMatrix4x4>
 #include <qglobal.h>
@@ -76,6 +77,8 @@ QgsTiledSceneLayerRenderer::~QgsTiledSceneLayerRenderer() = default;
 
 bool QgsTiledSceneLayerRenderer::render()
 {
+  QgsScopedThreadName threadName( QStringLiteral( "render:%1" ).arg( mLayerName ) );
+
   if ( !mIndex.isValid() )
     return false;
 

--- a/src/core/vector/qgsvectorlayerrenderer.cpp
+++ b/src/core/vector/qgsvectorlayerrenderer.cpp
@@ -42,6 +42,7 @@
 #include "qgssettingsentryimpl.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsapplication.h"
+#include "qgsthreadingutils.h"
 
 #include <QPicture>
 #include <QTimer>
@@ -236,6 +237,8 @@ Qgis::MapLayerRendererFlags QgsVectorLayerRenderer::flags() const
 
 bool QgsVectorLayerRenderer::render()
 {
+  QgsScopedThreadName threadName( QStringLiteral( "render:%1" ).arg( mLayerName ) );
+
   if ( mGeometryType == Qgis::GeometryType::Null || mGeometryType == Qgis::GeometryType::Unknown )
   {
     mReadyToCompose = true;

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -29,6 +29,7 @@
 #include "qgstextrenderer.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsapplication.h"
+#include "qgsthreadingutils.h"
 
 #include <QElapsedTimer>
 #include <QThread>
@@ -73,6 +74,8 @@ QgsVectorTileLayerRenderer::~QgsVectorTileLayerRenderer() = default;
 
 bool QgsVectorTileLayerRenderer::render()
 {
+  QgsScopedThreadName threadName( QStringLiteral( "render:%1" ).arg( mLayerName ) );
+
   std::unique_ptr< QgsScopedRuntimeProfile > profile;
   if ( mEnableProfile )
   {


### PR DESCRIPTION
Introduces QgsScopedThreadName

Scoped object for setting the current thread name. Supported for
linux only.

Qt does not provide anyway to do this for us. By default it uses
the QThread object name for threads, but that only works if the
thread object name is set BEFORE the thread is started.

As a result it is impossible to change the name for a thread
constructed and started as part of a thread pool, and Qt just
assigns a default "Thread (pooled)" name to those.

This makes debugging annoying!

The new QgsScopedThreadName class allows temporarily overriding
the name of a thread to something descriptive.

Using this we now set a descriptive thread name for map layer renderer threads.