### PR TITLE
Fix range widget defaults to zero precision for GPKG real fields

### DIFF
--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -17,6 +17,7 @@
 #include "moc_qgsrangeconfigdlg.cpp"
 
 #include "qgsvectorlayer.h"
+#include "qgsrangewidgetwrapper.h"
 
 QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer *vl, int fieldIdx, QWidget *parent )
   : QgsEditorConfigWidget( vl, fieldIdx, parent )
@@ -159,7 +160,10 @@ void QgsRangeConfigDlg::setConfig( const QVariantMap &config )
   rangeWidget->setCurrentIndex( rangeWidget->findData( config.value( QStringLiteral( "Style" ), "SpinBox" ) ) );
   suffixLineEdit->setText( config.value( QStringLiteral( "Suffix" ) ).toString() );
   allowNullCheckBox->setChecked( config.value( QStringLiteral( "AllowNull" ), true ).toBool() );
-  precisionSpinBox->setValue( config.value( QStringLiteral( "Precision" ), layer()->fields().at( field() ).precision() ).toInt() );
+
+  const QgsField layerField = layer()->fields().at( field() );
+  const int fieldPrecision = QgsRangeWidgetWrapper::defaultFieldPrecision( layerField );
+  precisionSpinBox->setValue( config.value( QStringLiteral( "Precision" ), fieldPrecision ).toInt() );
 }
 
 void QgsRangeConfigDlg::rangeWidgetChanged( int index )

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -31,6 +31,27 @@ QgsRangeWidgetWrapper::QgsRangeWidgetWrapper( QgsVectorLayer *layer, int fieldId
 {
 }
 
+int QgsRangeWidgetWrapper::defaultFieldPrecision( const QgsField &field )
+{
+  constexpr int DEFAULT_PRECISION_DOUBLE = 4;
+  const int fieldPrecision = field.precision();
+  switch ( field.type() )
+  {
+    case QMetaType::Type::Float:
+    case QMetaType::Type::Double:
+      return fieldPrecision > 0 ? fieldPrecision : DEFAULT_PRECISION_DOUBLE;
+
+    // we use the double spin box for long long fields in order to get sufficient range of min/max values
+    case QMetaType::Type::LongLong:
+      return 0;
+
+    default:
+      break;
+  }
+
+  return fieldPrecision;
+}
+
 QWidget *QgsRangeWidgetWrapper::createWidget( QWidget *parent )
 {
   QWidget *editor = nullptr;
@@ -102,9 +123,7 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
     const double maxval = max.isValid() ? max.toDouble() : std::numeric_limits<double>::max();
 
     const QgsField field = layer()->fields().at( fieldIdx() );
-    // we use the double spin box for long long fields in order to get sufficient range of min/max values
-    const int precisionval = field.type() == QMetaType::Type::LongLong ? 0 : ( precision.isValid() ? precision.toInt() : field.precision() );
-
+    const int precisionval = precision.isValid() ? precision.toInt() : defaultFieldPrecision( field );
     mDoubleSpinBox->setDecimals( precisionval );
 
     QgsDoubleSpinBox *qgsWidget = qobject_cast<QgsDoubleSpinBox *>( mDoubleSpinBox );

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.h
@@ -61,6 +61,15 @@ class GUI_EXPORT QgsRangeWidgetWrapper : public QgsEditorWidgetWrapper
      */
     explicit QgsRangeWidgetWrapper( QgsVectorLayer *layer, int fieldIdx, QWidget *editor, QWidget *parent = nullptr );
 
+    /**
+     * Returns the default field precision to use for a \a field.
+     *
+     * This precision will be used by the widget if the user has not manually set a precision.
+     *
+     * \since QGIS 4.0
+     */
+    static int defaultFieldPrecision( const QgsField &field );
+
     // QgsEditorWidgetWrapper interface
   public:
     QVariant value() const override;

--- a/tests/src/gui/testqgsrangewidgetwrapper.cpp
+++ b/tests/src/gui/testqgsrangewidgetwrapper.cpp
@@ -52,6 +52,7 @@ class TestQgsRangeWidgetWrapper : public QObject
     void test_setDoubleRange();
     void test_setDoubleSmallerRange();
     void test_setDoubleLimits();
+    void test_doubleExplicitPrecision();
     void test_nulls();
     void test_negativeIntegers(); // see GH issue #32149
     void test_focus();
@@ -155,16 +156,17 @@ void TestQgsRangeWidgetWrapper::test_setDoubleRange()
   widget1->setFeature( vl->getFeature( 1 ) );
   widget2->setFeature( vl->getFeature( 1 ) );
   QCOMPARE( vl->fields().at( 1 ).precision(), 9 );
-  // Default is 0 !!! for double, really ?
+  // Field precision is 0, which from the QgsField::precision docs indicates "not applicable" to this field.
+  // That is correct, as memory layers do not support field precision for real
   QCOMPARE( vl->fields().at( 2 ).precision(), 0 );
-  QCOMPARE( editor->decimals(), vl->fields().at( 1 ).precision() );
   QCOMPARE( editor->decimals(), 9 );
-  QCOMPARE( editor2->decimals(), vl->fields().at( 2 ).precision() );
+  // for double fields without explicit precision, we should default to a reasonable, non-zero value (currently hardcoded to 4)
+  QCOMPARE( editor2->decimals(), 4 );
   QCOMPARE( editor->valueFromText( feat.attribute( 1 ).toString() ), 123.123456789 );
   QCOMPARE( feat.attribute( 1 ).toString(), QStringLiteral( "123.123456789" ) );
   QCOMPARE( editor2->valueFromText( feat.attribute( 1 ).toString() ), 123.123456789 );
   QCOMPARE( editor->value(), 123.123456789 );
-  QCOMPARE( editor2->value(), 123.0 );
+  QCOMPARE( editor2->value(), 123.1235 );
   QCOMPARE( editor->minimum(), std::numeric_limits<double>::lowest() );
   QCOMPARE( editor2->minimum(), std::numeric_limits<double>::lowest() );
   QCOMPARE( editor->maximum(), std::numeric_limits<double>::max() );
@@ -178,7 +180,7 @@ void TestQgsRangeWidgetWrapper::test_setDoubleRange()
   widget1->setFeature( vl->getFeature( 3 ) );
   widget2->setFeature( vl->getFeature( 3 ) );
   QCOMPARE( editor->value(), -123.123456789 );
-  QCOMPARE( editor2->value(), -123.0 );
+  QCOMPARE( editor2->value(), -123.1235 );
 }
 
 void TestQgsRangeWidgetWrapper::test_setDoubleSmallerRange()
@@ -205,10 +207,12 @@ void TestQgsRangeWidgetWrapper::test_setDoubleSmallerRange()
   widget2->setFeature( vl->getFeature( 1 ) );
 
   QCOMPARE( vl->fields().at( 1 ).precision(), 9 );
-  // Default is 0 !!! for double, really ?
+  // Field precision is 0, which from the QgsField::precision docs indicates "not applicable" to this field.
+  // That is correct, as memory layers do not support field precision for real
   QCOMPARE( vl->fields().at( 2 ).precision(), 0 );
   QCOMPARE( editor->decimals(), vl->fields().at( 1 ).precision() );
-  QCOMPARE( editor2->decimals(), vl->fields().at( 2 ).precision() );
+  // for double fields without explicit precision, we should default to a reasonable, non-zero value (currently hardcoded to 4)
+  QCOMPARE( editor2->decimals(), 4 );
   // value was changed to the maximum (not NULL) accepted value
   QCOMPARE( editor->value(), 100.0 );
   // value was changed to the maximum (not NULL) accepted value
@@ -216,7 +220,7 @@ void TestQgsRangeWidgetWrapper::test_setDoubleSmallerRange()
   // minimum was lowered by the precision (10e-9)
   QCOMPARE( editor->minimum(), -100.000000001 );
   // minimum was lowered by step (1)
-  QCOMPARE( editor2->minimum(), ( double ) -101 );
+  QCOMPARE( editor2->minimum(), ( double ) -100.0001 );
   QCOMPARE( editor->maximum(), ( double ) 100 );
   QCOMPARE( editor2->maximum(), ( double ) 100 );
 
@@ -263,12 +267,14 @@ void TestQgsRangeWidgetWrapper::test_setDoubleLimits()
   widget2->setFeature( vl->getFeature( 1 ) );
 
   QCOMPARE( vl->fields().at( 1 ).precision(), 9 );
-  // Default is 0 !!! for double, really ?
+  // Field precision is 0, which from the QgsField::precision docs indicates "not applicable" to this field.
+  // That is correct, as memory layers do not support field precision for real
   QCOMPARE( vl->fields().at( 2 ).precision(), 0 );
   QCOMPARE( editor->decimals(), vl->fields().at( 1 ).precision() );
-  QCOMPARE( editor2->decimals(), vl->fields().at( 2 ).precision() );
+  // for double fields without explicit precision, we should default to a reasonable, non-zero value (currently hardcoded to 4)
+  QCOMPARE( editor2->decimals(), 4 );
   QCOMPARE( editor->value(), 123.123456789 );
-  QCOMPARE( editor2->value(), 123.0 );
+  QCOMPARE( editor2->value(), 123.1235 );
 
   // NULL, NULL
   widget1->setFeature( vl->getFeature( 2 ) );
@@ -281,7 +287,60 @@ void TestQgsRangeWidgetWrapper::test_setDoubleLimits()
   widget2->setFeature( vl->getFeature( 3 ) );
   // value was changed to the minimum
   QCOMPARE( editor->value(), -123.123456789 );
-  QCOMPARE( editor2->value(), -123.0 );
+  QCOMPARE( editor2->value(), -123.1235 );
+}
+
+void TestQgsRangeWidgetWrapper::test_doubleExplicitPrecision()
+{
+  // Same test but check double numeric limits
+  QVariantMap cfg;
+  cfg.insert( QStringLiteral( "Min" ), std::numeric_limits<double>::lowest() );
+  cfg.insert( QStringLiteral( "Max" ), std::numeric_limits<double>::max() );
+  cfg.insert( QStringLiteral( "Step" ), 1 );
+  // explicitly set precision for field
+  cfg.insert( QStringLiteral( "Precision" ), 3 );
+  widget1->setConfig( cfg );
+  QgsDoubleSpinBox *editor = qobject_cast<QgsDoubleSpinBox *>( widget1->createWidget( nullptr ) );
+  QVERIFY( editor );
+  widget1->initWidget( editor );
+
+  widget2->setConfig( cfg );
+  QgsDoubleSpinBox *editor2 = qobject_cast<QgsDoubleSpinBox *>( widget2->createWidget( nullptr ) );
+  QVERIFY( editor2 );
+  widget2->initWidget( editor2 );
+
+  QCOMPARE( editor->minimum(), std::numeric_limits<double>::lowest() );
+  QCOMPARE( editor2->minimum(), std::numeric_limits<double>::lowest() );
+  QCOMPARE( editor->maximum(), std::numeric_limits<double>::max() );
+  QCOMPARE( editor2->maximum(), std::numeric_limits<double>::max() );
+
+  const QgsFeature feat( vl->getFeature( 1 ) );
+  QVERIFY( feat.isValid() );
+  QCOMPARE( feat.attribute( 1 ).toDouble(), 123.123456789 );
+  widget1->setFeature( vl->getFeature( 1 ) );
+  widget2->setFeature( vl->getFeature( 1 ) );
+
+  QCOMPARE( vl->fields().at( 1 ).precision(), 9 );
+  // Field precision is 0, which from the QgsField::precision docs indicates "not applicable" to this field.
+  // That is correct, as memory layers do not support field precision for real
+  QCOMPARE( vl->fields().at( 2 ).precision(), 0 );
+  QCOMPARE( editor->decimals(), 3 );
+  QCOMPARE( editor2->decimals(), 3 );
+  QCOMPARE( editor->value(), 123.123 );
+  QCOMPARE( editor2->value(), 123.123 );
+
+  // NULL, NULL
+  widget1->setFeature( vl->getFeature( 2 ) );
+  widget2->setFeature( vl->getFeature( 2 ) );
+  QCOMPARE( editor->value(), editor->minimum() );
+  QCOMPARE( editor2->value(), editor2->minimum() );
+
+  // negative, negative
+  widget1->setFeature( vl->getFeature( 3 ) );
+  widget2->setFeature( vl->getFeature( 3 ) );
+  // value was changed to the minimum
+  QCOMPARE( editor->value(), -123.123 );
+  QCOMPARE( editor2->value(), -123.123 );
 }
 
 void TestQgsRangeWidgetWrapper::test_nulls()


### PR DESCRIPTION
The range widget was incorrectly interpreting a double/real field of 0 as "no decimal places", where it explicitly means "not applicable to this field" (as taken from the documentation for QgsField::precision)

This meant that applying a range widget to a GPKG real field would result in the widget showing ZERO decimal places by default, which was a confusing mess for users.

Now, correctly handle 0 precision double fields as "not applicable" and default to a reasonable number of decimals for the range widget (currently hardcoded to 4)
