### PR TITLE
qgsxmlutils: Add support for QRect in {read/write}Variant

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsxmlutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsxmlutils.sip.in
@@ -95,6 +95,7 @@ Supported types are
 - QVariant.Int
 - QVariant.Double
 - QVariant.String
+- QVariant.Rect (since QGIS 4.0)
 - :py:class:`QgsProperty` (since QGIS 3.4)
 - :py:class:`QgsCoordinateReferenceSystem` (since QGIS 3.4)
 %End

--- a/python/core/auto_generated/qgsxmlutils.sip.in
+++ b/python/core/auto_generated/qgsxmlutils.sip.in
@@ -95,6 +95,7 @@ Supported types are
 - QVariant.Int
 - QVariant.Double
 - QVariant.String
+- QVariant.Rect (since QGIS 4.0)
 - :py:class:`QgsProperty` (since QGIS 3.4)
 - :py:class:`QgsCoordinateReferenceSystem` (since QGIS 3.4)
 %End

--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -194,6 +194,18 @@ QDomElement QgsXmlUtils::writeVariant( const QVariant &value, QDomDocument &doc 
       break;
     }
 
+    case QMetaType::Type::QRect:
+    {
+      element.setAttribute( QStringLiteral( "type" ), "QRect" );
+
+      const QRect rect = value.toRect();
+      element.setAttribute( QStringLiteral( "x" ), rect.x() );
+      element.setAttribute( QStringLiteral( "y" ), rect.y() );
+      element.setAttribute( QStringLiteral( "width" ), rect.width() );
+      element.setAttribute( QStringLiteral( "height" ), rect.height() );
+      break;
+    }
+
     case QMetaType::Type::Int:
     case QMetaType::Type::UInt:
     case QMetaType::Type::Bool:
@@ -382,6 +394,15 @@ QVariant QgsXmlUtils::readVariant( const QDomElement &element )
       list.append( readVariant( elem ).toString() );
     }
     return list;
+  }
+  else if ( type == QLatin1String( "QRect" ) )
+  {
+    const int x = element.attribute( "x" ).toInt();
+    const int y = element.attribute( "y" ).toInt();
+    const int width = element.attribute( "width" ).toInt();
+    const int height = element.attribute( "height" ).toInt();
+
+    return QRect( x, y, width, height );
   }
   else if ( type == QLatin1String( "QgsProperty" ) )
   {

--- a/src/core/qgsxmlutils.h
+++ b/src/core/qgsxmlutils.h
@@ -96,6 +96,7 @@ class CORE_EXPORT QgsXmlUtils
      * - QVariant::Int
      * - QVariant::Double
      * - QVariant::String
+     * - QVariant::Rect (since QGIS 4.0)
      * - QgsProperty (since QGIS 3.4)
      * - QgsCoordinateReferenceSystem (since QGIS 3.4)
      */

--- a/tests/src/python/test_qgsxmlutils.py
+++ b/tests/src/python/test_qgsxmlutils.py
@@ -10,7 +10,7 @@ __author__ = "Matthias Kuhn"
 __date__ = "18/11/2016"
 __copyright__ = "Copyright 2016, The QGIS Project"
 
-from qgis.PyQt.QtCore import QDate, QDateTime, QTime, QVariant
+from qgis.PyQt.QtCore import QDate, QDateTime, QRect, QRectF, QTime, QVariant
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (
@@ -298,6 +298,21 @@ class TestQgsXmlUtils(QgisTestCase):
         c = QgsXmlUtils.readVariant(elem)
         self.assertEqual(c.sink.staticValue(), "my sink")
         self.assertEqual(c.createOptions, {"opt": 1, "opt2": 2})
+
+    def test_rect(self):
+        """
+        Test that QRect values are correctly loaded and written
+        """
+        doc = QDomDocument("properties")
+
+        rect = QRect(3, 5, 250, 420)
+        elem = QgsXmlUtils.writeVariant(rect, doc)
+        new_rect = QgsXmlUtils.readVariant(elem)
+        self.assertEqual(new_rect, rect)
+
+        elem = QgsXmlUtils.writeVariant(QRect(), doc)
+        new_rect = QgsXmlUtils.readVariant(elem)
+        self.assertEqual(new_rect, NULL)
 
     def testRemappingDefinition(self):
         fields = QgsFields()

--- a/tests/src/python/test_qgsxmlutils.py
+++ b/tests/src/python/test_qgsxmlutils.py
@@ -10,7 +10,7 @@ __author__ = "Matthias Kuhn"
 __date__ = "18/11/2016"
 __copyright__ = "Copyright 2016, The QGIS Project"
 
-from qgis.PyQt.QtCore import QDate, QDateTime, QRect, QRectF, QTime, QVariant
+from qgis.PyQt.QtCore import QDate, QDateTime, QRect, QTime, QVariant
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (


### PR DESCRIPTION
## Description

This adds support for `QRect` in `readVariant` and `writeVariant`
There is already logic to store a `QgsRectangle`, but `QRect` when storing values in integer format.

