### PR TITLE
Fix QgsVertexId::vertexEqual

### DIFF
--- a/src/core/geometry/qgsvertexid.h
+++ b/src/core/geometry/qgsvertexid.h
@@ -76,7 +76,7 @@ struct CORE_EXPORT QgsVertexId
    */
   bool vertexEqual( QgsVertexId o ) const SIP_HOLDGIL
   {
-    return ringEqual( o ) && ( vertex >= 0 && o.ring == ring );
+    return ringEqual( o ) && ( vertex >= 0 && o.vertex == vertex );
   }
 
   /**

--- a/tests/src/core/geometry/CMakeLists.txt
+++ b/tests/src/core/geometry/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TESTS
   testqgsregularpolygon.cpp
   testqgstriangle.cpp
   testqgstriangulatedsurface.cpp
+  testqgsvertexid.cpp
   )
 
 foreach(TESTSRC ${TESTS})

--- a/tests/src/core/geometry/testqgsvertexid.cpp
+++ b/tests/src/core/geometry/testqgsvertexid.cpp
@@ -1,0 +1,80 @@
+/***************************************************************************
+                         testqgsvertexid.cpp
+                         -------------------------
+    begin                : November 2025
+    copyright            : (C) 2025 by Stefanos Natsis
+    email                : uclaros at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgis.h"
+#include "qgstest.h"
+
+#include <QObject>
+
+
+class TestQgsVertexId : public QObject
+{
+    Q_OBJECT
+  private slots:
+    void testConstructor();
+    void testOperators();
+    void testMethods();
+};
+
+void TestQgsVertexId::testConstructor()
+{
+  QVERIFY( !QgsVertexId().isValid() );
+  QVERIFY( !QgsVertexId( 0, 0, -1 ).isValid() );
+  QVERIFY( !QgsVertexId( 0, -1, 0 ).isValid() );
+  QVERIFY( !QgsVertexId( -1, 0, 0 ).isValid() );
+  QVERIFY( QgsVertexId( 0, 0, 0 ).isValid() );
+}
+
+void TestQgsVertexId::testOperators()
+{
+  QVERIFY( QgsVertexId() == QgsVertexId() );
+  QVERIFY( QgsVertexId( 1, 2, 3 ) == QgsVertexId( 1, 2, 3 ) );
+  QVERIFY( !( QgsVertexId( 1, 2, 3 ) == QgsVertexId( 0, 2, 3 ) ) );
+  QVERIFY( !( QgsVertexId( 1, 2, 3 ) == QgsVertexId( 1, 0, 3 ) ) );
+  QVERIFY( !( QgsVertexId( 1, 2, 3 ) == QgsVertexId( 1, 2, 0 ) ) );
+
+  QVERIFY( !( QgsVertexId() != QgsVertexId() ) );
+  QVERIFY( !( QgsVertexId( 1, 2, 3 ) != QgsVertexId( 1, 2, 3 ) ) );
+  QVERIFY( QgsVertexId( 1, 2, 3 ) != QgsVertexId( 0, 2, 3 ) );
+  QVERIFY( QgsVertexId( 1, 2, 3 ) != QgsVertexId( 1, 0, 3 ) );
+  QVERIFY( QgsVertexId( 1, 2, 3 ) != QgsVertexId( 1, 2, 0 ) );
+}
+
+void TestQgsVertexId::testMethods()
+{
+  QVERIFY( !QgsVertexId().partEqual( QgsVertexId() ) );
+  QVERIFY( !QgsVertexId().ringEqual( QgsVertexId() ) );
+  QVERIFY( !QgsVertexId().vertexEqual( QgsVertexId() ) );
+
+  QVERIFY( QgsVertexId( 1, 1, 1 ).partEqual( QgsVertexId( 1, 0, 0 ) ) );
+  QVERIFY( QgsVertexId( 1, 1, 1 ).partEqual( QgsVertexId( 1, -1, -1 ) ) );
+  QVERIFY( !QgsVertexId( 1, 1, 1 ).partEqual( QgsVertexId( 0, 1, 1 ) ) );
+
+  QVERIFY( QgsVertexId( 1, 1, 1 ).ringEqual( QgsVertexId( 1, 1, 0 ) ) );
+  QVERIFY( QgsVertexId( 1, 1, 1 ).ringEqual( QgsVertexId( 1, 1, -1 ) ) );
+  QVERIFY( !QgsVertexId( 1, 1, 1 ).ringEqual( QgsVertexId( 0, 0, 0 ) ) );
+  QVERIFY( !QgsVertexId( 1, 1, 1 ).ringEqual( QgsVertexId( -1, 1, 1 ) ) );
+
+  QVERIFY( QgsVertexId( 1, 1, 1 ).vertexEqual( QgsVertexId( 1, 1, 1 ) ) );
+  QVERIFY( !QgsVertexId( 1, 1, 1 ).vertexEqual( QgsVertexId( 1, 1, 0 ) ) );
+  QVERIFY( !QgsVertexId( 1, 1, 1 ).vertexEqual( QgsVertexId( -1, 0, 1 ) ) );
+  QVERIFY( !QgsVertexId( 1, 1, 1 ).vertexEqual( QgsVertexId( 0, -1, 1 ) ) );
+}
+
+QGSTEST_MAIN( TestQgsVertexId )
+#include "testqgsvertexid.moc"


### PR DESCRIPTION
## Description
This was broken for ~10 years!
It's not used in QGIS code, API only.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
