### PR TITLE
[FEATURE] [OAPIF] Allow user to select an alternate format than GeoJSON in which to download features

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -148,6 +148,8 @@ following parameters (note that parameter keys are case sensitive):
 - InvertAxisOrientation=1: to invert axis order
 - hideDownloadProgressDialog=1: to hide the download progress dialog
 - featureMode=default/simpleFeatures/complexFeatures (QGIS >= 3.44)
+- outputformat=string: output format. Can be set for example to GML3 for
+  some WFS 1.0 servers that can support GML3.
 
 The ‘filter’ key value can either be a QGIS expression or an OGC XML
 filter. If the value is set to a QGIS expression the driver will turn it
@@ -188,6 +190,10 @@ class with the following parameters:
 - maxNumFeatures=number: maximum number of features to retrieve
   (possibly across several multiple paging requests)
 - hideDownloadProgressDialog=1: to hide the download progress dialog.
+- outputformat=string: output format as a MIME type to ask the server to
+  return features. e.g "application/geo+json", "application/flatgeobuf",
+  "application/fg+json", etc. Assumes there is a GDAL driver for the
+  requested format. (QGIS >= 4)
 
 Delimited text file data provider (delimitedtext)
 -------------------------------------------------

--- a/python/PyQt6/gui/auto_generated/qgsnewhttpconnection.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsnewhttpconnection.sip.in
@@ -121,6 +121,8 @@ Returns the invert axis orientation checkbox status.
 
 
 
+
+
     Qgis::HttpMethod preferredHttpMethod() const;
 %Docstring
 Returns the selected preferred HTTP method.

--- a/python/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -148,6 +148,8 @@ following parameters (note that parameter keys are case sensitive):
 - InvertAxisOrientation=1: to invert axis order
 - hideDownloadProgressDialog=1: to hide the download progress dialog
 - featureMode=default/simpleFeatures/complexFeatures (QGIS >= 3.44)
+- outputformat=string: output format. Can be set for example to GML3 for
+  some WFS 1.0 servers that can support GML3.
 
 The ‘filter’ key value can either be a QGIS expression or an OGC XML
 filter. If the value is set to a QGIS expression the driver will turn it
@@ -188,6 +190,10 @@ class with the following parameters:
 - maxNumFeatures=number: maximum number of features to retrieve
   (possibly across several multiple paging requests)
 - hideDownloadProgressDialog=1: to hide the download progress dialog.
+- outputformat=string: output format as a MIME type to ask the server to
+  return features. e.g "application/geo+json", "application/flatgeobuf",
+  "application/fg+json", etc. Assumes there is a GDAL driver for the
+  requested format. (QGIS >= 4)
 
 Delimited text file data provider (delimitedtext)
 -------------------------------------------------

--- a/python/gui/auto_generated/qgsnewhttpconnection.sip.in
+++ b/python/gui/auto_generated/qgsnewhttpconnection.sip.in
@@ -121,6 +121,8 @@ Returns the invert axis orientation checkbox status.
 
 
 
+
+
     Qgis::HttpMethod preferredHttpMethod() const;
 %Docstring
 Returns the selected preferred HTTP method.

--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -69,6 +69,8 @@ const QgsSettingsEntryEnumFlag<Qgis::TilePixelRatio> *QgsOwsConnection::settings
 const QgsSettingsEntryString *QgsOwsConnection::settingsMaxNumFeatures = new QgsSettingsEntryString( QStringLiteral( "max-num-features" ), sTreeOwsConnections ) ;
 const QgsSettingsEntryString *QgsOwsConnection::settingsPagesize = new QgsSettingsEntryString( QStringLiteral( "page-size" ), sTreeOwsConnections ) ;
 const QgsSettingsEntryString *QgsOwsConnection::settingsPagingEnabled = new QgsSettingsEntryString( QStringLiteral( "paging-enabled" ), sTreeOwsConnections, QString( "default" ) ) ;
+const QgsSettingsEntryString *QgsOwsConnection::settingsDefaultFeatureFormat = new QgsSettingsEntryString( QStringLiteral( "default-feature-format" ), sTreeOwsConnections, QString( ) ) ;
+const QgsSettingsEntryStringList *QgsOwsConnection::settingsAvailableFeatureFormats = new QgsSettingsEntryStringList( QStringLiteral( "available-feature-formats" ), sTreeOwsConnections, {} ) ;
 const QgsSettingsEntryString *QgsOwsConnection::settingsWfsFeatureMode = new QgsSettingsEntryString( QStringLiteral( "feature-mode" ), sTreeOwsConnections, QString( "default" ) ) ;
 const QgsSettingsEntryBool *QgsOwsConnection::settingsPreferCoordinatesForWfsT11 = new QgsSettingsEntryBool( QStringLiteral( "prefer-coordinates-for-wfs-T11" ), sTreeOwsConnections, false ) ;
 const QgsSettingsEntryBool *QgsOwsConnection::settingsWfsForceInitialGetFeature = new QgsSettingsEntryBool( QStringLiteral( "force-initial-get-feature" ), sTreeOwsConnections, false ) ;

--- a/src/core/qgsowsconnection.h
+++ b/src/core/qgsowsconnection.h
@@ -110,6 +110,8 @@ class CORE_EXPORT QgsOwsConnection : public QObject
     static const QgsSettingsEntryString *settingsMaxNumFeatures;
     static const QgsSettingsEntryString *settingsPagesize;
     static const QgsSettingsEntryString *settingsPagingEnabled;
+    static const QgsSettingsEntryString *settingsDefaultFeatureFormat;
+    static const QgsSettingsEntryStringList *settingsAvailableFeatureFormats;
     static const QgsSettingsEntryString *settingsWfsFeatureMode;
     static const QgsSettingsEntryBool *settingsWfsForceInitialGetFeature;
     static const QgsSettingsEntryString *settingsDefaultImageFormat;

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -206,6 +206,7 @@ typedef QSet<int> QgsAttributeIds;
  * - InvertAxisOrientation=1: to invert axis order
  * - hideDownloadProgressDialog=1: to hide the download progress dialog
  * - featureMode=default/simpleFeatures/complexFeatures (QGIS >= 3.44)
+ * - outputformat=string: output format. Can be set for example to GML3 for some WFS 1.0 servers that can support GML3.
  *
  * The ‘filter’ key value can either be a QGIS expression
  * or an OGC XML filter. If the value is set to a QGIS expression the driver will
@@ -239,6 +240,7 @@ typedef QSet<int> QgsAttributeIds;
  * - pageSize=number: number of features to retrieve in a single request
  * - maxNumFeatures=number: maximum number of features to retrieve (possibly across several multiple paging requests)
  * - hideDownloadProgressDialog=1: to hide the download progress dialog.
+ * - outputformat=string: output format as a MIME type to ask the server to return features. e.g "application/geo+json", "application/flatgeobuf", "application/fg+json", etc. Assumes there is a GDAL driver for the requested format. (QGIS >= 4)
  *
  * \subsection delimitedtext Delimited text file data provider (delimitedtext)
  *

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -97,6 +97,9 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
   cmbVersion->addItem( tr( "OGC API - Features" ) );
   connect( cmbVersion, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsNewHttpConnection::wfsVersionCurrentIndexChanged );
 
+  mFeatureFormatComboBox->clear();
+  mFeatureFormatComboBox->addItem( tr( "Default" ), QStringLiteral( "default" ) );
+
   mComboWfsFeatureMode->clear();
   mComboWfsFeatureMode->addItem( tr( "Default" ), QStringLiteral( "default" ) );
   mComboWfsFeatureMode->addItem( tr( "Simple Features" ), QStringLiteral( "simpleFeatures" ) );
@@ -211,6 +214,9 @@ void QgsNewHttpConnection::wfsVersionCurrentIndexChanged( int index )
   cbxWfsIgnoreAxisOrientation->setEnabled( index != WFS_VERSION_1_0 && index != WFS_VERSION_API_FEATURES_1_0 );
   cbxWfsInvertAxisOrientation->setEnabled( index != WFS_VERSION_API_FEATURES_1_0 );
   wfsUseGml2EncodingForTransactions()->setEnabled( index == WFS_VERSION_1_1 );
+
+  featureFormatComboBox()->setEnabled( index == WFS_VERSION_MAX || index == WFS_VERSION_API_FEATURES_1_0 );
+  featureFormatDetectButton()->setEnabled( index == WFS_VERSION_MAX || index == WFS_VERSION_API_FEATURES_1_0 );
 }
 
 void QgsNewHttpConnection::wfsFeaturePagingCurrentIndexChanged( int index )
@@ -314,6 +320,16 @@ QPushButton *QgsNewHttpConnection::wfsVersionDetectButton()
 QComboBox *QgsNewHttpConnection::wfsVersionComboBox()
 {
   return cmbVersion;
+}
+
+QPushButton *QgsNewHttpConnection::featureFormatDetectButton()
+{
+  return mFeatureFormatDetectButton;
+}
+
+QComboBox *QgsNewHttpConnection::featureFormatComboBox()
+{
+  return mFeatureFormatComboBox;
 }
 
 QComboBox *QgsNewHttpConnection::wfsPagingComboBox()
@@ -469,6 +485,17 @@ void QgsNewHttpConnection::accept()
     QgsOwsConnection::settingsInvertAxisOrientation->setValue( cbxWfsInvertAxisOrientation->isChecked(), detailsParameters );
     QgsOwsConnection::settingsPreferCoordinatesForWfsT11->setValue( cbxWfsUseGml2EncodingForTransactions->isChecked(), detailsParameters );
     QgsOwsConnection::settingsWfsForceInitialGetFeature->setValue( cbxWfsForceInitialGetFeature->isChecked(), detailsParameters );
+
+    // Get all values from the combo
+    QStringList availableFormats;
+    for ( int i = 0; i < mFeatureFormatComboBox->count(); ++i )
+    {
+      availableFormats.append( mFeatureFormatComboBox->itemData( i ).toString() );
+    }
+    QString format = mFeatureFormatComboBox->currentData().toString();
+    QgsOwsConnection::settingsDefaultFeatureFormat->setValue( format, detailsParameters );
+    settings.setValue( QStringLiteral( "/qgis/lastFeatureFormatEncoding" ), format );
+    QgsOwsConnection::settingsAvailableFeatureFormats->setValue( availableFormats, detailsParameters );
   }
   if ( mTypes & ConnectionWms || mTypes & ConnectionWcs )
   {

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -192,6 +192,18 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
     QComboBox *wfsVersionComboBox() SIP_SKIP;
 
     /**
+     * Returns the "Feature format detect" button.
+     * \since QGIS 4.0
+     */
+    QPushButton *featureFormatDetectButton() SIP_SKIP;
+
+    /**
+     * Returns the "Feature format" combobox.
+     * \since QGIS 4.0
+     */
+    QComboBox *featureFormatComboBox() SIP_SKIP;
+
+    /**
      * Returns the "WFS paging" combobox
      * \since QGIS 3.36
      */

--- a/src/providers/wfs/oapif/qgsoapifcollection.cpp
+++ b/src/providers/wfs/oapif/qgsoapifcollection.cpp
@@ -77,6 +77,15 @@ bool QgsOapifCollection::deserialize( const json &j, const json &jCollections )
     if ( link.length > 0 )
       mdLink.size = QString::number( link.length );
     mLayerMetadata.addLink( mdLink );
+
+    if ( link.rel == QLatin1String( "items" ) )
+    {
+      if ( link.type == QLatin1String( "application/geo+json" ) || link.type == QLatin1String( "application/flatgeobuf" ) || link.type == QLatin1String( "application/fg+json" ) )
+      {
+        mFeatureFormats << link.type;
+        mMapFeatureFormatToUrl[link.type] = link.href;
+      }
+    }
   }
 
   if ( j.contains( "title" ) )
@@ -471,6 +480,13 @@ void QgsOapifCollectionsRequest::processReply()
               // use the one from the collection set.
               collection.mLayerMetadata.setLicenses( licenses );
             }
+
+            // Create a merged map of feature formats
+            for ( const QString &format : collection.mFeatureFormats )
+            {
+              mFeatureFormats << format;
+            }
+
             mCollections.emplace_back( collection );
           }
         }

--- a/src/providers/wfs/oapif/qgsoapifcollection.h
+++ b/src/providers/wfs/oapif/qgsoapifcollection.h
@@ -54,6 +54,12 @@ struct QgsOapifCollection
     //! Feature count when advertised (currently only through ldproxy's itemCount)
     int64_t mFeatureCount = -1;
 
+    //! Set of media type for feature formats
+    QSet<QString> mFeatureFormats;
+
+    //! Map of media type to /items url
+    QMap<QString, QString> mMapFeatureFormatToUrl;
+
     //! Fills a collection from its JSON serialization
     bool deserialize( const json &j, const json &jCollections );
 };
@@ -85,6 +91,9 @@ class QgsOapifCollectionsRequest : public QgsBaseNetworkRequest
     //! Return the url of the next page (extension to the spec)
     const QString &nextUrl() const { return mNextUrl; }
 
+    //! Return the set of media type for feature formats
+    const QSet<QString> &featureFormats() const { return mFeatureFormats; }
+
   signals:
     //! emitted when the capabilities have been fully parsed, or an error occurred
     void gotResponse();
@@ -103,6 +112,9 @@ class QgsOapifCollectionsRequest : public QgsBaseNetworkRequest
     QString mNextUrl;
 
     ApplicationLevelError mAppLevelError = ApplicationLevelError::NoError;
+
+    //! Set of media type for feature formats
+    QSet<QString> mFeatureFormats;
 };
 
 //! Manages the /collection/{collectionId} request

--- a/src/providers/wfs/oapif/qgsoapifitemsrequest.cpp
+++ b/src/providers/wfs/oapif/qgsoapifitemsrequest.cpp
@@ -24,10 +24,11 @@ using namespace nlohmann;
 
 #include "cpl_vsi.h"
 
+#include <QRegularExpression>
 #include <QTextCodec>
 
-QgsOapifItemsRequest::QgsOapifItemsRequest( const QgsDataSourceUri &baseUri, const QString &url )
-  : QgsBaseNetworkRequest( QgsAuthorizationSettings( baseUri.username(), baseUri.password(), QgsHttpHeaders(), baseUri.authConfigId() ), tr( "OAPIF" ) ), mUrl( url )
+QgsOapifItemsRequest::QgsOapifItemsRequest( const QgsDataSourceUri &baseUri, const QString &url, const QString &featureFormat )
+  : QgsBaseNetworkRequest( QgsAuthorizationSettings( baseUri.username(), baseUri.password(), QgsHttpHeaders(), baseUri.authConfigId() ), tr( "OAPIF" ) ), mUrl( url ), mFeatureFormat( featureFormat )
 {
   // Using Qt::DirectConnection since the download might be running on a different thread.
   // In this case, the request was sent from the main thread and is executed with the main
@@ -38,8 +39,15 @@ QgsOapifItemsRequest::QgsOapifItemsRequest( const QgsDataSourceUri &baseUri, con
 
 bool QgsOapifItemsRequest::request( bool synchronous, bool forceRefresh )
 {
+  QString acceptHeader = QStringLiteral( "application/geo+json, application/json" );
+  if ( !mFeatureFormat.isEmpty() )
+  {
+    acceptHeader = mFeatureFormat;
+  }
+  const bool isGeoJSON = mFeatureFormat.isEmpty() || mFeatureFormat == QStringLiteral( "application/geo+json" );
+  mFakeResponseHasHeaders = !isGeoJSON;
   QgsDebugMsgLevel( QStringLiteral( " QgsOapifItemsRequest::request() start time: %1" ).arg( time( nullptr ) ), 5 );
-  if ( !sendGET( QUrl::fromEncoded( mUrl.toLatin1() ), QString( "application/geo+json, application/json" ), synchronous, forceRefresh ) )
+  if ( !sendGET( QUrl::fromEncoded( mUrl.toLatin1() ), acceptHeader, synchronous, forceRefresh ) )
   {
     emit gotResponse();
     return false;
@@ -108,22 +116,27 @@ void QgsOapifItemsRequest::processReply()
     return;
   }
 
-  if ( buffer.size() <= 200 )
+  const bool isGeoJSON = mFeatureFormat.isEmpty() || mFeatureFormat == QStringLiteral( "application/geo+json" );
+
+  if ( isGeoJSON )
   {
-    QgsDebugMsgLevel( QStringLiteral( "parsing items response: " ) + buffer, 4 );
-  }
-  else
-  {
-    QgsDebugMsgLevel( QStringLiteral( "parsing items response: " ) + buffer.left( 100 ) + QStringLiteral( "[... snip ...]" ) + buffer.right( 100 ), 4 );
+    if ( buffer.size() <= 200 )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "parsing items response: " ) + buffer, 4 );
+    }
+    else
+    {
+      QgsDebugMsgLevel( QStringLiteral( "parsing items response: " ) + buffer.left( 100 ) + QStringLiteral( "[... snip ...]" ) + buffer.right( 100 ), 4 );
+    }
+
+    // Remove extraneous indentation spaces from the string. This helps a bit
+    // improving JSON parsing performance afterwards
+    QgsDebugMsgLevel( QStringLiteral( "JSON compaction start time: %1" ).arg( time( nullptr ) ), 5 );
+    removeUselessSpacesFromJSONBuffer( buffer );
+    QgsDebugMsgLevel( QStringLiteral( "JSON compaction end time: %1" ).arg( time( nullptr ) ), 5 );
   }
 
-  // Remove extraneous indentation spaces from the string. This helps a bit
-  // improving JSON parsing performance afterwards
-  QgsDebugMsgLevel( QStringLiteral( "JSON compaction start time: %1" ).arg( time( nullptr ) ), 5 );
-  removeUselessSpacesFromJSONBuffer( buffer );
-  QgsDebugMsgLevel( QStringLiteral( "JSON compaction end time: %1" ).arg( time( nullptr ) ), 5 );
-
-  const QString vsimemFilename = QStringLiteral( "/vsimem/oaipf_%1.json" ).arg( reinterpret_cast<quintptr>( &buffer ), QT_POINTER_SIZE * 2, 16, QLatin1Char( '0' ) );
+  const QString vsimemFilename = mFeatureFormat == QStringLiteral( "application/flatgeobuf" ) ? QStringLiteral( "/vsimem/oaipf_%1.fgb" ).arg( reinterpret_cast<quintptr>( &buffer ), QT_POINTER_SIZE * 2, 16, QLatin1Char( '0' ) ) : QStringLiteral( "/vsimem/oaipf_%1.json" ).arg( reinterpret_cast<quintptr>( &buffer ), QT_POINTER_SIZE * 2, 16, QLatin1Char( '0' ) );
   VSIFCloseL( VSIFileFromMemBuffer( vsimemFilename.toUtf8().constData(), const_cast<GByte *>( reinterpret_cast<const GByte *>( buffer.constData() ) ), buffer.size(), false ) );
   QgsProviderRegistry *pReg = QgsProviderRegistry::instance();
   const QgsDataProvider::ProviderOptions providerOptions;
@@ -150,74 +163,160 @@ void QgsOapifItemsRequest::processReply()
   }
   QgsDebugMsgLevel( QStringLiteral( "OGR feature iteration start time: %1" ).arg( time( nullptr ) ), 5 );
   auto iter = vectorProvider->getFeatures();
+
+  int idField = -1;
+  if ( !isGeoJSON )
+  {
+    idField = mFields.indexOf( QStringLiteral( "id" ) );
+    // If no "id" field, then use the first field if it contains "id" in it.
+    if ( idField < 0 && mFields.size() >= 1 && mFields[0].name().indexOf( QLatin1String( "id" ), 0, Qt::CaseInsensitive ) )
+    {
+      idField = 0;
+    }
+  }
+
   while ( true )
   {
     QgsFeature f;
     if ( !iter.nextFeature( f ) )
       break;
-    mFeatures.push_back( QgsFeatureUniqueIdPair( f, QString() ) );
+    QString id;
+    if ( idField >= 0 )
+    {
+      id = f.attribute( idField ).toString();
+    }
+    mFeatures.push_back( QgsFeatureUniqueIdPair( f, id ) );
   }
   QgsDebugMsgLevel( QStringLiteral( "OGR feature iteration end time: %1" ).arg( time( nullptr ) ), 5 );
   vectorProvider.reset();
   VSIUnlink( vsimemFilename.toUtf8().constData() );
 
-  try
+  if ( isGeoJSON )
   {
-    QgsDebugMsgLevel( QStringLiteral( "json::parse() start time: %1" ).arg( time( nullptr ) ), 5 );
-    const json j = json::parse( buffer.constData(), buffer.constData() + buffer.size() );
-    QgsDebugMsgLevel( QStringLiteral( "json::parse() end time: %1" ).arg( time( nullptr ) ), 5 );
-    if ( j.is_object() && j.contains( "features" ) )
+    try
     {
-      const json &features = j["features"];
-      if ( features.is_array() && features.size() == mFeatures.size() )
+      QgsDebugMsgLevel( QStringLiteral( "json::parse() start time: %1" ).arg( time( nullptr ) ), 5 );
+      const json j = json::parse( buffer.constData(), buffer.constData() + buffer.size() );
+      QgsDebugMsgLevel( QStringLiteral( "json::parse() end time: %1" ).arg( time( nullptr ) ), 5 );
+      if ( j.is_object() && j.contains( "features" ) )
       {
-        for ( size_t i = 0; i < features.size(); i++ )
+        const json &features = j["features"];
+        if ( features.is_array() && features.size() == mFeatures.size() )
         {
-          const json &jFeature = features[i];
-          if ( jFeature.is_object() && jFeature.contains( "id" ) )
+          for ( size_t i = 0; i < features.size(); i++ )
           {
-            const json &id = jFeature["id"];
-            mFoundIdTopLevel = true;
-            if ( id.is_string() )
+            const json &jFeature = features[i];
+            if ( jFeature.is_object() && jFeature.contains( "id" ) )
             {
-              mFeatures[i].second = QString::fromStdString( id.get<std::string>() );
+              const json &id = jFeature["id"];
+              mFoundIdTopLevel = true;
+              if ( id.is_string() )
+              {
+                mFeatures[i].second = QString::fromStdString( id.get<std::string>() );
+              }
+              else if ( id.is_number_integer() )
+              {
+                mFeatures[i].second = QString::number( id.get<qint64>() );
+              }
             }
-            else if ( id.is_number_integer() )
+            if ( jFeature.is_object() && jFeature.contains( "properties" ) )
             {
-              mFeatures[i].second = QString::number( id.get<qint64>() );
-            }
-          }
-          if ( jFeature.is_object() && jFeature.contains( "properties" ) )
-          {
-            const json &properties = jFeature["properties"];
-            if ( properties.is_object() && properties.contains( "id" ) )
-            {
-              mFoundIdInProperties = true;
+              const json &properties = jFeature["properties"];
+              if ( properties.is_object() && properties.contains( "id" ) )
+              {
+                mFoundIdInProperties = true;
+              }
             }
           }
         }
       }
-    }
 
-    const auto links = QgsOAPIFJson::parseLinks( j );
-    mNextUrl = QgsOAPIFJson::findLink( links, QStringLiteral( "next" ), { QStringLiteral( "application/geo+json" ) } );
+      const auto links = QgsOAPIFJson::parseLinks( j );
+      mNextUrl = QgsOAPIFJson::findLink( links, QStringLiteral( "next" ), { QStringLiteral( "application/geo+json" ) } );
 
-    if ( j.is_object() && j.contains( "numberMatched" ) )
-    {
-      const auto numberMatched = j["numberMatched"];
-      if ( numberMatched.is_number_integer() )
+      if ( j.is_object() && j.contains( "numberMatched" ) )
       {
-        mNumberMatched = numberMatched.get<int>();
+        const auto numberMatched = j["numberMatched"];
+        if ( numberMatched.is_number_integer() )
+        {
+          mNumberMatched = numberMatched.get<int>();
+        }
       }
     }
+    catch ( const json::parse_error &ex )
+    {
+      mErrorCode = QgsBaseNetworkRequest::ApplicationLevelError;
+      mAppLevelError = ApplicationLevelError::JsonError;
+      mErrorMessage = errorMessageWithReason( tr( "Cannot decode JSON document: %1" ).arg( QString::fromStdString( ex.what() ) ) );
+      emit gotResponse();
+      return;
+    }
   }
-  catch ( const json::parse_error &ex )
+  else
   {
-    mErrorCode = QgsBaseNetworkRequest::ApplicationLevelError;
-    mAppLevelError = ApplicationLevelError::JsonError;
-    mErrorMessage = errorMessageWithReason( tr( "Cannot decode JSON document: %1" ).arg( QString::fromStdString( ex.what() ) ) );
-    emit gotResponse();
-    return;
+    // Get numberMatched and next link from HTTP response headers
+    for ( const auto &headerKeyValue : mResponseHeaders )
+    {
+      if ( headerKeyValue.first.compare( QByteArray( "OGC-NumberMatched" ), Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+      {
+        bool ok = false;
+        const int val = QString::fromUtf8( headerKeyValue.second ).toInt( &ok );
+        if ( ok )
+          mNumberMatched = val;
+      }
+      else if ( headerKeyValue.first.compare( QByteArray( "Link" ), Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+      {
+        // Parse stuff like:
+        //  <https://ogc-api.nrw.de/lika/v1/collections/flurstueck/items?f=html>; rel="alternate"; title="This document as HTML"; type="text/html", <https://ogc-api.nrw.de/lika/v1/collections/flurstueck/items?f=fgb&offset=10>; rel="next"; title="Next page"; type="application/flatgeobuf"
+
+        // Split on commas, except when they are in double quotes or between <...>, and skip padding space before/after separator
+        const thread_local QRegularExpression splitOnComma( R"(\s*,\s*(?=(?:[^"<]|"[^"]*"|<[^>]*>)*$))" );
+        const QStringList links = QString::fromUtf8( headerKeyValue.second ).split( splitOnComma );
+        for ( const QString &link : std::as_const( links ) )
+        {
+          if ( link.isEmpty() || link[0] != QLatin1Char( '<' ) )
+            continue;
+          const int idxClosingBracket = static_cast<int>( link.indexOf( QLatin1Char( '>' ) ) );
+          if ( idxClosingBracket < 0 )
+            continue;
+          const QString href = link.mid( 1, idxClosingBracket - 1 );
+          const int idxSemiColon = static_cast<int>( link.indexOf( QLatin1Char( ';' ), idxClosingBracket ) );
+          if ( idxSemiColon < 0 )
+            continue;
+          // Split on semi-colon, except when they are in double quotes, and skip padding space before/after separator
+          const thread_local QRegularExpression splitOnSemiColon( R"(\s*;\s*(?=(?:[^"]*"[^"]*")*[^"]*$))" );
+          const QStringList linkParts = link.mid( idxSemiColon + 1 ).split( splitOnSemiColon );
+          QString rel, type;
+          for ( const QString &linkPart : std::as_const( linkParts ) )
+          {
+            // Split on equal, except when they are in double quotes, and skip padding space before/after separator
+            const thread_local QRegularExpression splitOnEqual( R"(\s*\=\s*(?=(?:[^"]*"[^"]*")*[^"]*$))" );
+            const QStringList keyValue = linkPart.split( splitOnEqual );
+            if ( keyValue.size() == 2 )
+            {
+              const QString key = keyValue[0].trimmed();
+              QString value = keyValue[1].trimmed();
+              if ( !value.isEmpty() && value[0] == QLatin1Char( '"' ) && value.back() == QLatin1Char( '"' ) )
+              {
+                value = value.mid( 1, value.size() - 2 );
+              }
+              if ( key == QLatin1String( "rel" ) )
+              {
+                rel = value;
+              }
+              else if ( key == QLatin1String( "type" ) )
+              {
+                type = value;
+              }
+            }
+          }
+          if ( rel == QLatin1String( "next" ) && type == mFeatureFormat )
+          {
+            mNextUrl = href;
+          }
+        }
+      }
+    }
   }
 
   QgsDebugMsgLevel( QStringLiteral( "processReply end time: %1" ).arg( time( nullptr ) ), 5 );

--- a/src/providers/wfs/oapif/qgsoapifitemsrequest.h
+++ b/src/providers/wfs/oapif/qgsoapifitemsrequest.h
@@ -31,7 +31,7 @@ class QgsOapifItemsRequest : public QgsBaseNetworkRequest
 {
     Q_OBJECT
   public:
-    explicit QgsOapifItemsRequest( const QgsDataSourceUri &uri, const QString &url );
+    explicit QgsOapifItemsRequest( const QgsDataSourceUri &uri, const QString &url, const QString &featureFormat );
 
     //! Ask to compute the bbox of the returned items.
     void setComputeBbox() { mComputeBbox = true; }
@@ -85,7 +85,9 @@ class QgsOapifItemsRequest : public QgsBaseNetworkRequest
     QString errorMessageWithReason( const QString &reason ) override;
 
   private:
-    QString mUrl;
+    const QString mUrl;
+
+    const QString mFeatureFormat;
 
     bool mComputeBbox = false;
 

--- a/src/providers/wfs/oapif/qgsoapifprovider.h
+++ b/src/providers/wfs/oapif/qgsoapifprovider.h
@@ -127,7 +127,7 @@ class QgsOapifProvider final : public QgsVectorDataProvider
     //! Layer metadata
     QgsLayerMetadata mLayerMetadata;
 
-    //! Feature count when advertized (currently only through ldproxy's itemCount)
+    //! Feature count when known (currently only through ldproxy's itemCount)
     int64_t mFeatureCount = -1;
 
     //! Set to true by reloadProviderData()
@@ -212,6 +212,9 @@ class QgsOapifSharedData final : public QObject, public QgsBackgroundCachedShare
 
     //! Url to /collections/{collectionId}/items
     QString mItemsUrl;
+
+    //! Media type of feature format requests to /items. May be empty for default
+    QString mFeatureFormat;
 
     //! Server filter
     QString mServerFilter;

--- a/src/providers/wfs/qgsbasenetworkrequest.h
+++ b/src/providers/wfs/qgsbasenetworkrequest.h
@@ -158,6 +158,12 @@ class QgsBaseNetworkRequest : public QObject
     bool sendPOSTOrPUTOrPATCH( const QUrl &url, const QByteArray &verb, const QString &contentTypeHeader, const QByteArray &data, bool synchronous, const QList<QNetworkReply::RawHeaderPair> &extraHeaders = QList<QNetworkReply::RawHeaderPair>() );
 
     bool issueRequest( QNetworkRequest &request, const QByteArray &verb, const QByteArray *data, bool synchronous );
+
+    // For unit tests in simulated HTTP mode, when the mFakeResponseHasHeaders
+    // has been set by the derived class, this method will read HTTP response
+    // headers contained at the top of the response file and set them into
+    // mResponseHeaders, while stripping them from mResponse.
+    void extractResponseHeadersForUnitTests();
 };
 
 

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -48,7 +48,16 @@ QgsWfsLayerItem::QgsWfsLayerItem( QgsDataItem *parent, QString name, const QgsDa
 {
   const QgsSettings settings;
   const bool useCurrentViewExtent = settings.value( QStringLiteral( "Windows/WFSSourceSelect/FeatureCurrentViewExtent" ), true ).toBool();
-  mUri = QgsWFSDataSourceURI::build( uri.uri( false ), featureType, crsString, QString(), QString(), useCurrentViewExtent );
+
+  const QStringList detailsParameters = { QStringLiteral( "wfs" ), parent->name() };
+  QString featureFormat = QgsOwsConnection::settingsDefaultFeatureFormat->value( detailsParameters );
+  if ( featureFormat.isEmpty() )
+  {
+    // Read from global default setting
+    featureFormat = QgsSettings().value( QStringLiteral( "qgis/lastFeatureFormatEncoding" ), QString() ).toString();
+  }
+
+  mUri = QgsWFSDataSourceURI::build( uri.uri( false ), featureType, crsString, QString(), QString(), useCurrentViewExtent, featureFormat );
   setState( Qgis::BrowserItemState::Populated );
   mIconName = QStringLiteral( "mIconWfs.svg" );
   mBaseUri = uri.param( QStringLiteral( "url" ) );

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -524,7 +524,7 @@ QgsWFSDataSourceURI::FeatureMode QgsWFSDataSourceURI::featureMode() const
   }
 }
 
-QString QgsWFSDataSourceURI::build( const QString &baseUri, const QString &typeName, const QString &crsString, const QString &sql, const QString &filter, bool restrictToCurrentViewExtent )
+QString QgsWFSDataSourceURI::build( const QString &baseUri, const QString &typeName, const QString &crsString, const QString &sql, const QString &filter, bool restrictToCurrentViewExtent, const QString &featureFormat )
 {
   QgsWFSDataSourceURI uri( baseUri );
   uri.setTypeName( typeName );
@@ -536,6 +536,10 @@ QString QgsWFSDataSourceURI::build( const QString &baseUri, const QString &typeN
   if ( uri.version() == QLatin1String( "OGC_API_FEATURES" ) )
   {
     uri.setVersion( QString() );
+  }
+  if ( !featureFormat.isEmpty() && featureFormat != QLatin1String( "default" ) )
+  {
+    uri.setOutputFormat( featureFormat );
   }
   return uri.uri();
 }

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -150,7 +150,7 @@ class QgsWFSDataSourceURI
     FeatureMode featureMode() const;
 
     //! Builds a derived uri from a base uri
-    static QString build( const QString &uri, const QString &typeName, const QString &crsString = QString(), const QString &sql = QString(), const QString &filter = QString(), bool restrictToCurrentViewExtent = false );
+    static QString build( const QString &uri, const QString &typeName, const QString &crsString, const QString &sql, const QString &filter, bool restrictToCurrentViewExtent, const QString &featureFormat );
 
     //! Sets Get DCP endpoints
     void setGetEndpoints( const QgsStringMap &map );

--- a/src/providers/wfs/qgswfsnewconnection.h
+++ b/src/providers/wfs/qgswfsnewconnection.h
@@ -20,6 +20,7 @@
 #include "qgswfsgetcapabilities.h"
 #include "qgsoapiflandingpagerequest.h"
 #include "qgsoapifapirequest.h"
+#include "qgsoapifcollection.h"
 
 class QgsWFSNewConnection : public QgsNewHttpConnection
 {
@@ -32,18 +33,26 @@ class QgsWFSNewConnection : public QgsNewHttpConnection
 
   private slots:
     void versionDetectButton();
+    void detectFormat();
     void capabilitiesReplyFinished();
     void oapifLandingPageReplyFinished();
     void oapifApiReplyFinished();
+    void oapifCollectionsReplyFinished();
 
   private:
     QgsDataSourceUri createUri();
+    void startCapabilitiesRequest();
     void startOapifLandingPageRequest();
     void startOapifApiRequest();
+    void startOapifCollectionsRequest();
 
     std::unique_ptr<QgsWfsGetCapabilitiesRequest> mCapabilities;
     std::unique_ptr<QgsOapifLandingPageRequest> mOAPIFLandingPage;
     std::unique_ptr<QgsOapifApiRequest> mOAPIFApi;
+    std::unique_ptr<QgsOapifCollectionsRequest> mOAPIFCollectionsRequest;
+    QString mOAPIFCollectionsUrl;
+    QString mOAPIFApiUrl;
+    bool mDetectFormatInProgress = false;
 };
 
 #endif //QGSWFSNEWCONNECTION_H

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -517,6 +517,14 @@ void QgsWFSSourceSelect::addButtonClicked()
   if ( gbCRS->isEnabled() )
     pCrsString = labelCoordRefSys->text();
 
+  const QStringList detailsParameters = { QStringLiteral( "wfs" ), cmbConnections->currentText() };
+  QString featureFormat = QgsOwsConnection::settingsDefaultFeatureFormat->value( detailsParameters );
+  if ( featureFormat.isEmpty() )
+  {
+    // Read from global default setting
+    featureFormat = QgsSettings().value( QStringLiteral( "qgis/lastFeatureFormatEncoding" ), QString() ).toString();
+  }
+
   //create layers that user selected from this WFS source
   QModelIndexList list = treeView->selectionModel()->selectedRows();
   for ( int i = 0; i < list.size(); i++ )
@@ -533,7 +541,7 @@ void QgsWFSSourceSelect::addButtonClicked()
     QString layerName = typeName;
     QgsDebugMsgLevel( "Layer " + typeName + " SQL is " + sql, 3 );
 
-    mUri = QgsWFSDataSourceURI::build( connection.uri().uri( false ), typeName, pCrsString, isOapif() ? QString() : sql, isOapif() ? sql : QString(), cbxFeatureCurrentViewExtent->isChecked() );
+    mUri = QgsWFSDataSourceURI::build( connection.uri().uri( false ), typeName, pCrsString, isOapif() ? QString() : sql, isOapif() ? sql : QString(), cbxFeatureCurrentViewExtent->isChecked(), featureFormat );
 
     Q_NOWARN_DEPRECATED_PUSH
     emit addVectorLayer( mUri, layerName, isOapif() ? QgsOapifProvider::OAPIF_PROVIDER_KEY : QgsWFSProvider::WFS_PROVIDER_KEY );

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -340,42 +340,6 @@
             <string>WFS Options</string>
            </property>
            <layout class="QGridLayout" name="gridLayout1">
-            <item row="3" column="0">
-             <widget class="QLabel" name="lblFeaturePaging">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Feature paging</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QPushButton" name="mWfsVersionDetectButton">
-              <property name="text">
-               <string>Detect</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="lblVersion_2">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Preferred HTTP method</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1" colspan="2">
-             <widget class="QComboBox" name="mComboHttpMethod"/>
-            </item>
             <item row="0" column="0">
              <widget class="QLabel" name="lblVersion">
               <property name="sizePolicy">
@@ -389,7 +353,98 @@
               </property>
              </widget>
             </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="cmbVersion"/>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="mWfsVersionDetectButton">
+              <property name="text">
+               <string>Detect</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="lblFeatureFormat">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Feature format</string>
+              </property>
+              <property name="toolTip">
+               <string>Only used for OGC-API Features</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="mFeatureFormatComboBox"/>
+            </item>
+            <item row="1" column="2">
+             <widget class="QPushButton" name="mFeatureFormatDetectButton">
+              <property name="text">
+               <string>Detect</string>
+              </property>
+              <property name="toolTip">
+               <string>Only used for OGC-API Features</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="lblVersion_2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Preferred HTTP method</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1" colspan="2">
+             <widget class="QComboBox" name="mComboHttpMethod"/>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="lblMaxNumFeatures">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Max. number of features</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1" colspan="2">
+             <widget class="QLineEdit" name="txtMaxNumFeatures">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a number to limit the maximum number of features retrieved per feature request. If empty, no limit is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
             <item row="4" column="0">
+             <widget class="QLabel" name="lblFeaturePaging">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Feature paging</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1" colspan="2">
+             <widget class="QComboBox" name="cmbFeaturePaging"/>
+            </item>
+            <item row="5" column="0">
              <widget class="QLabel" name="lblPageSize">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -403,47 +458,13 @@
              </widget>
             </item>
             <item row="5" column="1" colspan="2">
-             <widget class="QComboBox" name="mComboWfsFeatureMode">
-              <property name="toolTip">
-               <string>Determines whether to return data as simple features or as complex features where nested data structures are exposed by QGIS as JSON</string>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="0" colspan="3">
-             <widget class="QCheckBox" name="cbxWfsIgnoreAxisOrientation">
-              <property name="text">
-               <string>Ignore axis orientation (WFS 1.1/WFS 2.0)</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1" colspan="2">
-             <widget class="QLineEdit" name="txtMaxNumFeatures">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a number to limit the maximum number of features retrieved per feature request. If let to empty, no limit is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1" colspan="2">
              <widget class="QLineEdit" name="txtPageSize">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a number to limit the maximum number of features retrieved in a single GetFeature request when paging is enabled. If let to empty, server default will apply.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="1" colspan="2">
-             <widget class="QComboBox" name="cmbFeaturePaging"/>
-            </item>
-            <item row="7" column="0" colspan="3">
-             <widget class="QCheckBox" name="cbxWfsInvertAxisOrientation">
-              <property name="text">
-               <string>Invert axis orientation</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QComboBox" name="cmbVersion"/>
-            </item>
-            <item row="5" column="0">
+            <item row="6" column="0">
              <widget class="QLabel" name="lblFeatureMode">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -456,7 +477,48 @@
               </property>
              </widget>
             </item>
-            <item row="10" column="0" colspan="3">
+            <item row="6" column="1" colspan="2">
+             <widget class="QComboBox" name="mComboWfsFeatureMode">
+              <property name="toolTip">
+               <string>Determines whether to return data as simple features or as complex features where nested data structures are exposed by QGIS as JSON</string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="0" colspan="3">
+             <widget class="QCheckBox" name="cbxWfsIgnoreAxisOrientation">
+              <property name="text">
+               <string>Ignore axis orientation (WFS 1.1/WFS 2.0)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="0" colspan="3">
+             <widget class="QCheckBox" name="cbxWfsInvertAxisOrientation">
+              <property name="text">
+               <string>Invert axis orientation</string>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="0">
+             <widget class="QCheckBox" name="cbxWfsUseGml2EncodingForTransactions">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This might be necessary on some &lt;span style=&quot; font-weight:600;&quot;&gt;broken&lt;/span&gt; ESRI map servers when using WFS-T 1.1.0.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Use GML2 encoding for transactions</string>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="0">
+             <widget class="QCheckBox" name="cbxWfsForceInitialGetFeature">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, an initial GetFeature call will always be issued in order to determine the geometry type from the first downloaded feature.&lt;/p&gt;&lt;p&gt;This option can be used if the layer contains features with Z axis coordinates that are otherwise not correctly identified.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Force initial GetFeature</string>
+              </property>
+             </widget>
+            </item>
+            <item row="11" column="0" colspan="3">
              <spacer name="verticalSpacer_3">
               <property name="orientation">
                <enum>Qt::Orientation::Vertical</enum>
@@ -468,39 +530,6 @@
                </size>
               </property>
              </spacer>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="lblMaxNumFeatures">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Max. number of features</string>
-              </property>
-             </widget>
-            </item>
-            <item row="8" column="0">
-             <widget class="QCheckBox" name="cbxWfsUseGml2EncodingForTransactions">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This might be necessary on some &lt;span style=&quot; font-weight:600;&quot;&gt;broken&lt;/span&gt; ESRI map servers when using WFS-T 1.1.0.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Use GML2 encoding for transactions</string>
-              </property>
-             </widget>
-            </item>
-            <item row="9" column="0">
-             <widget class="QCheckBox" name="cbxWfsForceInitialGetFeature">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, an initial GetFeature call will always be issued in order to determine the geometry type from the first downloaded feature.&lt;/p&gt;&lt;p&gt;This option can be used if the layer contains features with Z axis coordinates that are otherwise not correctly identified.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Force initial GetFeature</string>
-              </property>
-             </widget>
             </item>
            </layout>
           </widget>
@@ -556,6 +585,8 @@
   <tabstop>cbxSmoothPixmapTransform</tabstop>
   <tabstop>cmbVersion</tabstop>
   <tabstop>mWfsVersionDetectButton</tabstop>
+  <tabstop>mFeatureFormatComboBox</tabstop>
+  <tabstop>mFeatureFormatDetectButton</tabstop>
   <tabstop>mComboHttpMethod</tabstop>
   <tabstop>txtMaxNumFeatures</tabstop>
   <tabstop>cmbFeaturePaging</tabstop>


### PR DESCRIPTION
- Honour 'outputFormat' in connection URI to use formats others than GeoJSON

- UI: add a combo box to select the format of features (e.g. FlatGeoBuf, GeoJSON, etc.), and save results and selection in connection setting, as well as a "qgis/lastFeatureFormatEncoding" global setting. Strongly inspired from recent work by @elpaso on WMS in 188a0aa2ed85fbb9ad84f8e3528847b3fa59cab5

<img width="1225" height="604" alt="image" src="https://github.com/user-attachments/assets/be616e83-dc23-4866-b48d-402d6a46a848" />

Funded by: QGIS Anwendergruppe Deutschland
