### PR TITLE
Set GENERATE_TAGFILE to output QGIS tag file

### DIFF
--- a/cmake_templates/Doxyfile.in
+++ b/cmake_templates/Doxyfile.in
@@ -2475,7 +2475,7 @@ TAGFILES               = @DOXYGEN_TAGS@
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = @CMAKE_CURRENT_BINARY_DIR@/api/qgis.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external classes and namespaces
 # will be listed in the class and namespace index. If set to NO, only the


### PR DESCRIPTION
this allows downstream project to link to the QGIS API documentation

