### PR TITLE
qgsvectorlayerutils: Introduce uniqueValues and use it in QgsCategorizedSymbolRendererWidget

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsvectorlayerutils.py
+++ b/python/PyQt6/core/auto_additions/qgsvectorlayerutils.py
@@ -4,6 +4,7 @@ QgsVectorLayerUtils.CascadedFeatureFlags = lambda flags=0: QgsVectorLayerUtils.C
 try:
     QgsVectorLayerUtils.getValuesIterator = staticmethod(QgsVectorLayerUtils.getValuesIterator)
     QgsVectorLayerUtils.getValues = staticmethod(QgsVectorLayerUtils.getValues)
+    QgsVectorLayerUtils.uniqueValues = staticmethod(QgsVectorLayerUtils.uniqueValues)
     QgsVectorLayerUtils.getDoubleValues = staticmethod(QgsVectorLayerUtils.getDoubleValues)
     QgsVectorLayerUtils.valueExists = staticmethod(QgsVectorLayerUtils.valueExists)
     QgsVectorLayerUtils.createUniqueValue = staticmethod(QgsVectorLayerUtils.createUniqueValue)

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -116,6 +116,29 @@ Fetches all values from a specified field name or expression.
 .. seealso:: :py:func:`getDoubleValues`
 %End
 
+    static QList< QVariant > uniqueValues( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok /Out/, bool selectedOnly = false, int limit = -1, QgsFeedback *feedback = 0 );
+%Docstring
+Fetches all unique values from a specified field name or expression.
+Null values or invalid expression results are skipped.
+
+:param layer: vector layer to retrieve values from
+:param fieldOrExpression: field name or an expression string evaluating
+                          to a double value
+:param selectedOnly: set to ``True`` to get values from selected
+                     features only
+:param limit: Maximum number of unique values to return. Use -1 for no
+              limit.
+:param feedback: optional feedback object to allow cancellation
+
+:return: - list of unique fetched values
+         - ok: ``False`` if field or expression is invalid, otherwise
+           ``True``
+
+.. seealso:: :py:func:`getValues`
+
+.. versionadded:: 4.0
+%End
+
     static QList< double > getDoubleValues( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok, bool selectedOnly = false, int *nullCount = 0, QgsFeedback *feedback = 0 );
 %Docstring
 Fetches all double values from a specified field name or expression.

--- a/python/PyQt6/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -137,7 +137,7 @@ Applies current symbol to selected categories, or to all categories if
 none is selected
 %End
 
-    QList<QVariant> layerUniqueValues( const QString &attrName );
+ QList<QVariant> layerUniqueValues( const QString &attrName ) /Deprecated="Since 4.0. Use QgsVectorLayerUtils.uniqueValues instead."/;
 %Docstring
 Returns the list of unique values in the current widget's layer for
 attribute name ``attrName``.
@@ -145,6 +145,10 @@ attribute name ``attrName``.
 Called by :py:func:`~QgsCategorizedSymbolRendererWidget.addCategories`
 and
 :py:func:`~QgsCategorizedSymbolRendererWidget.deleteUnusedCategories`
+
+.. deprecated:: 4.0
+
+   Use :py:class:`QgsVectorLayerUtils`.uniqueValues instead.
 %End
 
     virtual QList<QgsSymbol *> selectedSymbols();

--- a/python/core/auto_additions/qgsvectorlayerutils.py
+++ b/python/core/auto_additions/qgsvectorlayerutils.py
@@ -2,6 +2,7 @@
 try:
     QgsVectorLayerUtils.getValuesIterator = staticmethod(QgsVectorLayerUtils.getValuesIterator)
     QgsVectorLayerUtils.getValues = staticmethod(QgsVectorLayerUtils.getValues)
+    QgsVectorLayerUtils.uniqueValues = staticmethod(QgsVectorLayerUtils.uniqueValues)
     QgsVectorLayerUtils.getDoubleValues = staticmethod(QgsVectorLayerUtils.getDoubleValues)
     QgsVectorLayerUtils.valueExists = staticmethod(QgsVectorLayerUtils.valueExists)
     QgsVectorLayerUtils.createUniqueValue = staticmethod(QgsVectorLayerUtils.createUniqueValue)

--- a/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -116,6 +116,29 @@ Fetches all values from a specified field name or expression.
 .. seealso:: :py:func:`getDoubleValues`
 %End
 
+    static QList< QVariant > uniqueValues( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok /Out/, bool selectedOnly = false, int limit = -1, QgsFeedback *feedback = 0 );
+%Docstring
+Fetches all unique values from a specified field name or expression.
+Null values or invalid expression results are skipped.
+
+:param layer: vector layer to retrieve values from
+:param fieldOrExpression: field name or an expression string evaluating
+                          to a double value
+:param selectedOnly: set to ``True`` to get values from selected
+                     features only
+:param limit: Maximum number of unique values to return. Use -1 for no
+              limit.
+:param feedback: optional feedback object to allow cancellation
+
+:return: - list of unique fetched values
+         - ok: ``False`` if field or expression is invalid, otherwise
+           ``True``
+
+.. seealso:: :py:func:`getValues`
+
+.. versionadded:: 4.0
+%End
+
     static QList< double > getDoubleValues( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok, bool selectedOnly = false, int *nullCount = 0, QgsFeedback *feedback = 0 );
 %Docstring
 Fetches all double values from a specified field name or expression.

--- a/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -137,7 +137,7 @@ Applies current symbol to selected categories, or to all categories if
 none is selected
 %End
 
-    QList<QVariant> layerUniqueValues( const QString &attrName );
+ QList<QVariant> layerUniqueValues( const QString &attrName ) /Deprecated="Since 4.0. Use QgsVectorLayerUtils.uniqueValues instead."/;
 %Docstring
 Returns the list of unique values in the current widget's layer for
 attribute name ``attrName``.
@@ -145,6 +145,10 @@ attribute name ``attrName``.
 Called by :py:func:`~QgsCategorizedSymbolRendererWidget.addCategories`
 and
 :py:func:`~QgsCategorizedSymbolRendererWidget.deleteUnusedCategories`
+
+.. deprecated:: 4.0
+
+   Use :py:class:`QgsVectorLayerUtils`.uniqueValues instead.
 %End
 
     virtual QList<QgsSymbol *> selectedSymbols();

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -136,6 +136,21 @@ class CORE_EXPORT QgsVectorLayerUtils
     static QList< QVariant > getValues( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok, bool selectedOnly = false, QgsFeedback *feedback = nullptr );
 
     /**
+     * Fetches all unique values from a specified field name or expression. Null values or
+     * invalid expression results are skipped.
+     * \param layer vector layer to retrieve values from
+     * \param fieldOrExpression field name or an expression string evaluating to a double value
+     * \param ok will be set to FALSE if field or expression is invalid, otherwise TRUE
+     * \param selectedOnly set to TRUE to get values from selected features only
+     * \param limit Maximum number of unique values to return. Use -1 for no limit.
+     * \param feedback optional feedback object to allow cancellation
+     * \returns list of unique fetched values
+     * \see getValues
+     * \since QGIS 4.0
+     */
+    static QList< QVariant > uniqueValues( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok SIP_OUT, bool selectedOnly = false, int limit = -1, QgsFeedback *feedback = nullptr );
+
+    /**
      * Fetches all double values from a specified field name or expression. Null values or
      * invalid expression results are skipped.
      * \param layer vector layer to retrieve values from

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -245,8 +245,10 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
      * Returns the list of unique values in the current widget's layer for attribute name \a attrName.
      *
      * Called by addCategories() and deleteUnusedCategories()
+     *
+     * \deprecated QGIS 4.0. Use QgsVectorLayerUtils::uniqueValues instead.
      */
-    QList<QVariant> layerUniqueValues( const QString &attrName );
+    Q_DECL_DEPRECATED QList<QVariant> layerUniqueValues( const QString &attrName ) SIP_DEPRECATED;
 
     QList<QgsSymbol *> selectedSymbols() override;
     QgsCategoryList selectedCategoryList();

--- a/tests/src/core/testqgsvectorlayerutils.cpp
+++ b/tests/src/core/testqgsvectorlayerutils.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-     test_template.cpp
+     testqgsvectorlayerutils.cpp
      --------------------------------------
     Date                 : Sun Sep 16 12:22:23 AKDT 2007
     Copyright            : (C) 2007 by Gary E. Sherman
@@ -16,7 +16,11 @@
 
 #include "qgsvectorlayerutils.h"
 #include "qgsvectorlayer.h"
+
+#include <QMetaType>
 #include <QThread>
+
+#include <memory>
 
 /**
  * \ingroup UnitTests
@@ -36,6 +40,11 @@ class TestQgsVectorLayerUtils : public QObject
     void cleanup() {}       // will be called after every testfunction.
 
     void testGetFeatureSource();
+    void testGetValues();
+    void testUniqueValues();
+
+  private:
+    QString mTestDataDir;
 };
 
 void TestQgsVectorLayerUtils::initTestCase()
@@ -43,6 +52,9 @@ void TestQgsVectorLayerUtils::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
   QgsApplication::showSettings();
+
+  const QString myDataDir( TEST_DATA_DIR ); //defined in CmakeLists.txt
+  mTestDataDir = myDataDir + '/';
 }
 
 void TestQgsVectorLayerUtils::cleanupTestCase()
@@ -123,6 +135,261 @@ void TestQgsVectorLayerUtils::testGetFeatureSource()
     QCoreApplication::processEvents();
   QVERIFY( result.isNull() );
   thread2->quit();
+}
+
+void TestQgsVectorLayerUtils::testGetValues()
+{
+  const QString pointFileName = mTestDataDir + "points.shp";
+  const QFileInfo pointFileInfo( pointFileName );
+
+  std::unique_ptr<QgsVectorLayer> pointsLayer = std::make_unique<QgsVectorLayer>( pointFileInfo.filePath(), pointFileInfo.completeBaseName(), QStringLiteral( "ogr" ) );
+  QVERIFY( pointsLayer->isValid() );
+
+  // from an attribute
+  bool retrievedValues = false;
+  QList<QVariant> valuesAttr = QgsVectorLayerUtils::getValues( pointsLayer.get(), QStringLiteral( "Class" ), retrievedValues );
+  QVERIFY( retrievedValues );
+  QCOMPARE( valuesAttr.size(), 17 );
+  QCOMPARE( valuesAttr[0].typeId(), QMetaType::QString );
+
+  int nrJet = 0;
+  int nrBiPlane = 0;
+  int nrB52 = 0;
+  for ( const QVariant &value : valuesAttr )
+  {
+    if ( value.toString() == "Jet" )
+    {
+      nrJet += 1;
+    }
+    else if ( value.toString() == "Biplane" )
+    {
+      nrBiPlane += 1;
+    }
+    else if ( value.toString() == "B52" )
+    {
+      nrB52 += 1;
+    }
+  }
+
+  QCOMPARE( nrJet, 8 );
+  QCOMPARE( nrBiPlane, 5 );
+  QCOMPARE( nrB52, 4 );
+
+  // from an expression
+  retrievedValues = false;
+  QList<QVariant> valuesExp = QgsVectorLayerUtils::getValues( pointsLayer.get(), QStringLiteral( "Pilots+4" ), retrievedValues );
+  QVERIFY( retrievedValues );
+  QCOMPARE( valuesExp.size(), 17 );
+  QCOMPARE( valuesExp[0].typeId(), QMetaType::LongLong );
+  double minVal = std::numeric_limits<int>::max();
+  double maxVal = -std::numeric_limits<int>::max();
+  for ( const QVariant &value : valuesExp )
+  {
+    const double valI = value.toInt();
+    if ( valI > maxVal )
+    {
+      maxVal = valI;
+    }
+    if ( valI < minVal )
+    {
+      minVal = valI;
+    }
+  }
+
+  QCOMPARE( minVal, 5 );
+  QCOMPARE( maxVal, 7 );
+}
+
+void TestQgsVectorLayerUtils::testUniqueValues()
+{
+  const QString pointFileName = mTestDataDir + "points.shp";
+  const QFileInfo pointFileInfo( pointFileName );
+
+  std::unique_ptr<QgsVectorLayer> pointsLayer = std::make_unique<QgsVectorLayer>( pointFileInfo.filePath(), pointFileInfo.completeBaseName(), QStringLiteral( "ogr" ) );
+
+  // from an attribute
+  {
+    bool retrievedValues = false;
+    QList<QVariant> valuesAttr = QgsVectorLayerUtils::uniqueValues( pointsLayer.get(), QStringLiteral( "Class" ), retrievedValues );
+    QVERIFY( retrievedValues );
+    QCOMPARE( valuesAttr.size(), 3 );
+    QCOMPARE( valuesAttr[0].typeId(), QMetaType::QString );
+
+    std::sort( valuesAttr.begin(), valuesAttr.end(), []( const QVariant &a, const QVariant &b ) {
+      return a.toString() < b.toString();
+    } );
+
+    QList<QVariant> expectedAttr;
+    expectedAttr << QStringLiteral( "B52" ) << QStringLiteral( "Biplane" ) << QStringLiteral( "Jet" );
+    QCOMPARE( valuesAttr, expectedAttr );
+  }
+
+  // from an attribute - limit to 2 values
+  {
+    bool retrievedValues = false;
+    QList<QVariant> valuesAttr = QgsVectorLayerUtils::uniqueValues( pointsLayer.get(), QStringLiteral( "Class" ), retrievedValues, false, 2 );
+    QVERIFY( retrievedValues );
+    QCOMPARE( valuesAttr.size(), 2 );
+    QCOMPARE( valuesAttr[0].typeId(), QMetaType::QString );
+
+    std::sort( valuesAttr.begin(), valuesAttr.end(), []( const QVariant &a, const QVariant &b ) {
+      return a.toString() < b.toString();
+    } );
+
+    QList<QVariant> expectedAttr;
+    expectedAttr << QStringLiteral( "B52" ) << QStringLiteral( "Biplane" );
+    QCOMPARE( valuesAttr, expectedAttr );
+  }
+
+  // from an attribute - selected only
+  {
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 0 );
+    QgsFeatureIds selectedFeatures = { 1, 4, 7 };
+    pointsLayer->selectByIds( selectedFeatures );
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 3 );
+
+    bool retrievedValues = false;
+    QList<QVariant> valuesAttr = QgsVectorLayerUtils::uniqueValues( pointsLayer.get(), QStringLiteral( "Class" ), retrievedValues, true );
+    QVERIFY( retrievedValues );
+    QCOMPARE( valuesAttr.size(), 2 );
+    QCOMPARE( valuesAttr[0].typeId(), QMetaType::QString );
+
+    std::sort( valuesAttr.begin(), valuesAttr.end(), []( const QVariant &a, const QVariant &b ) {
+      return a.toString() < b.toString();
+    } );
+
+    QList<QVariant> expectedAttr;
+    expectedAttr << QStringLiteral( "Biplane" ) << QStringLiteral( "Jet" );
+    QCOMPARE( valuesAttr, expectedAttr );
+
+    pointsLayer->deselect( selectedFeatures );
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 0 );
+  }
+
+  // from an attribute - selected only - limit to 1
+  {
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 0 );
+    QgsFeatureIds selectedFeatures = { 1, 4, 7 };
+    pointsLayer->selectByIds( selectedFeatures );
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 3 );
+
+    bool retrievedValues = false;
+    const QList<QVariant> valuesAttr = QgsVectorLayerUtils::uniqueValues( pointsLayer.get(), QStringLiteral( "Class" ), retrievedValues, true, 1 );
+    QVERIFY( retrievedValues );
+    QCOMPARE( valuesAttr.size(), 1 );
+    QCOMPARE( valuesAttr[0].typeId(), QMetaType::QString );
+
+    QList<QVariant> expectedAttr = { QStringLiteral( "Biplane" ) };
+    QCOMPARE( valuesAttr, expectedAttr );
+
+    pointsLayer->deselect( selectedFeatures );
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 0 );
+  }
+
+  // from an attribute - layer with a null value
+  {
+    std::unique_ptr<QgsVectorLayer> uniqueLayer = std::make_unique<QgsVectorLayer>( "Point?crs=EPSG:4326", "points_test", "memory" );
+    QVERIFY( uniqueLayer->isValid() );
+    uniqueLayer->dataProvider()->addAttributes( { QgsField( "name", QMetaType::Type::QString ) } );
+    uniqueLayer->updateFields();
+
+    QList<QgsFeature> features;
+    for ( int i = 0; i < 5; i++ )
+    {
+      QgsFeature feature( uniqueLayer->fields() );
+      feature.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( i, i ) ) );
+      if ( i != 2 )
+      {
+        feature.setAttribute( "name", QString( "Point_%1" ).arg( i ) );
+      }
+      features.append( feature );
+    }
+    uniqueLayer->dataProvider()->addFeatures( features );
+
+    bool retrievedValues = false;
+    QList<QVariant> valuesAttr = QgsVectorLayerUtils::uniqueValues( uniqueLayer.get(), QStringLiteral( "name" ), retrievedValues );
+    QVERIFY( retrievedValues );
+    QCOMPARE( valuesAttr.size(), 4 );
+    std::sort( valuesAttr.begin(), valuesAttr.end(), []( const QVariant &a, const QVariant &b ) {
+      return a.toString() < b.toString();
+    } );
+
+    QList<QVariant> expectedAttr;
+    expectedAttr << QStringLiteral( "Point_0" ) << QStringLiteral( "Point_1" ) << QStringLiteral( "Point_3" ) << QStringLiteral( "Point_4" );
+    QCOMPARE( valuesAttr, expectedAttr );
+  }
+
+  // from an expression
+  {
+    bool retrievedValues = false;
+    QList<QVariant> valuesExp = QgsVectorLayerUtils::uniqueValues( pointsLayer.get(), QStringLiteral( "Pilots+4" ), retrievedValues );
+    QVERIFY( retrievedValues );
+    QCOMPARE( valuesExp.size(), 3 );
+    QCOMPARE( valuesExp[0].typeId(), QMetaType::LongLong );
+    std::sort( valuesExp.begin(), valuesExp.end(), []( const QVariant &a, const QVariant &b ) {
+      return a.toInt() < b.toInt();
+    } );
+    QList<QVariant> expectedExp;
+    expectedExp << 5 << 6 << 7;
+    QCOMPARE( valuesExp, expectedExp );
+  }
+
+  // from an expression - limit to 2 values
+  {
+    bool retrievedValues = false;
+    QList<QVariant> valuesExp = QgsVectorLayerUtils::uniqueValues( pointsLayer.get(), QStringLiteral( "Pilots+4" ), retrievedValues, false, 2 );
+    QVERIFY( retrievedValues );
+    QCOMPARE( valuesExp.size(), 2 );
+    QCOMPARE( valuesExp[0].typeId(), QMetaType::LongLong );
+    std::sort( valuesExp.begin(), valuesExp.end(), []( const QVariant &a, const QVariant &b ) {
+      return a.toInt() < b.toInt();
+    } );
+    QList<QVariant> expectedExp;
+    expectedExp << 6 << 7;
+    QCOMPARE( valuesExp, expectedExp );
+  }
+
+  // from an expression - selected only
+  {
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 0 );
+    QgsFeatureIds selectedFeatures = { 1, 8, 9 };
+    pointsLayer->selectByIds( selectedFeatures );
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 3 );
+
+    bool retrievedValues = false;
+    QList<QVariant> valuesExp = QgsVectorLayerUtils::uniqueValues( pointsLayer.get(), QStringLiteral( "Pilots+4" ), retrievedValues, true );
+    QVERIFY( retrievedValues );
+    QCOMPARE( valuesExp.size(), 2 );
+    QCOMPARE( valuesExp[0].typeId(), QMetaType::LongLong );
+    std::sort( valuesExp.begin(), valuesExp.end(), []( const QVariant &a, const QVariant &b ) {
+      return a.toInt() < b.toInt();
+    } );
+    QList<QVariant> expectedExp;
+    expectedExp << 6 << 7;
+    QCOMPARE( valuesExp, expectedExp );
+
+    pointsLayer->deselect( selectedFeatures );
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 0 );
+  }
+
+  // from an expression - selected only - limit to 1
+  {
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 0 );
+    QgsFeatureIds selectedFeatures = { 1, 8, 9 };
+    pointsLayer->selectByIds( selectedFeatures );
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 3 );
+
+    bool retrievedValues = false;
+    QList<QVariant> valuesExp = QgsVectorLayerUtils::uniqueValues( pointsLayer.get(), QStringLiteral( "Pilots+4" ), retrievedValues, true, 1 );
+    QVERIFY( retrievedValues );
+    QCOMPARE( valuesExp.size(), 1 );
+    QCOMPARE( valuesExp[0].typeId(), QMetaType::LongLong );
+    QList<QVariant> expectedExp = { 7 };
+    QCOMPARE( valuesExp, expectedExp );
+
+    pointsLayer->deselect( selectedFeatures );
+    QCOMPARE( pointsLayer->selectedFeatureCount(), 0 );
+  }
 }
 
 QGSTEST_MAIN( TestQgsVectorLayerUtils )


### PR DESCRIPTION
## Description

`QgsCategorizedSymbolRendererWidget` has a `layerUniqueValues` method which is used to create and deletecategories. There is nothing specific to it. One can create a `getUniqueValues` method in `QgsVectorLayerUtils` similar to the existing `getValues` and use it in `QgsCategorizedSymbolRendererWidget`


