### PR TITLE
[queued_ltr_backports] [OAPIF provider] Fix issue with collection bbox reprojection

### DIFF
--- a/src/providers/wfs/oapif/qgsoapifprovider.cpp
+++ b/src/providers/wfs/oapif/qgsoapifprovider.cpp
@@ -197,8 +197,9 @@ bool QgsOapifProvider::init()
   }
   else if ( implementsPart2 && mLayerMetadata.crs().isValid() )
   {
-    // WORKAROUND: Recreate a CRS object with fromOgcWmsCrs because when copying the
-    // CRS his mPj pointer gets deleted and it is impossible to create a transform
+    // Recreate a CRS object with fromOgcWmsCrs  because its mPj pointer got
+    // deleted because it got acquired by a thread that has now disappeared
+    // and without it, it is impossible to create a transform
     mShared->mSourceCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( mLayerMetadata.crs().authid() );
     mShared->mSourceCrs.setCoordinateEpoch( mLayerMetadata.crs().coordinateEpoch() );
   }
@@ -213,7 +214,15 @@ bool QgsOapifProvider::init()
   // Reproject extent of /collection request to the layer CRS
   if ( !mShared->mCapabilityExtent.isNull() && collectionRequest->collection().mBboxCrs != mShared->mSourceCrs )
   {
-    QgsCoordinateTransform ct( collectionRequest->collection().mBboxCrs, mShared->mSourceCrs, transformContext() );
+    const QgsOapifCollection &collectionDesc = collectionRequest->collection();
+
+    // Recreate a CRS object with fromOgcWmsCrs because its mPj pointer got
+    // deleted because it got acquired by a thread that has now disappeared
+    // and without it, it is impossible to create a transform
+    QgsCoordinateReferenceSystem bboxCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( collectionDesc.mBboxCrs.authid() );
+    bboxCrs.setCoordinateEpoch( collectionDesc.mBboxCrs.coordinateEpoch() );
+
+    QgsCoordinateTransform ct( bboxCrs, mShared->mSourceCrs, transformContext() );
     ct.setBallparkTransformsAreAppropriate( true );
     QgsDebugMsgLevel( "before ext:" + mShared->mCapabilityExtent.toString(), 4 );
     try


### PR DESCRIPTION
Due to a threading related issue, the bounding box of the layer reported in the /collection response couldn't be reprojected from OGC:CRS84 to the native CRS of the layer, causing later warnings about the bounding box not being correct (on projected layers)

Backport of PR #63984