### PR TITLE
Let GDAL handle .gdb.zip files directly to fix layer naming

### DIFF
--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -842,7 +842,8 @@ QStringList QgsGdalUtils::multiLayerFileExtensions()
     QStringLiteral( "vrt" ),
     QStringLiteral( "nc" ),
     QStringLiteral( "dxf" ),
-    QStringLiteral( "shp.zip" ) };
+    QStringLiteral( "shp.zip" ),
+    QStringLiteral( "gdb.zip" ) };
   return SUPPORTED_DB_LAYERS_EXTENSIONS;
 #endif
 }
@@ -856,9 +857,10 @@ QString QgsGdalUtils::vsiPrefixForPath( const QString &path )
   if ( vsiMatch.hasMatch() )
     return vsiMatch.captured( 1 );
 
-  if ( path.endsWith( QLatin1String( ".shp.zip" ), Qt::CaseInsensitive ) )
+  if ( path.endsWith( QLatin1String( ".shp.zip" ), Qt::CaseInsensitive ) ||
+       path.endsWith( QLatin1String( ".gdb.zip" ), Qt::CaseInsensitive ) )
   {
-    // GDAL 3.1 Shapefile driver directly handles .shp.zip files
+    // GDAL 3.1 Shapefile/OpenFileGDB drivers directly handle .shp.zip and .gdb.zip files
     if ( GDALIdentifyDriverEx( path.toUtf8().constData(), GDAL_OF_VECTOR, nullptr, nullptr ) )
       return QString();
     return QStringLiteral( "/vsizip/" );


### PR DESCRIPTION
## Description

Previous to this commit, importing a `.gdb.zip` file into a project leads to the GDB-internal layer names (such as "`a0000000a.gdbtable`") to be displayed in the UI instead of their human-readable counterparts. This is fixed by letting GDAL handle the import of the zip directly - as is already done for `.shp.zip` (but contrary to the later, layers in zipped GDBs are readonly).

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->

Fixes #50402
