### PR TITLE
feat:Remove redundant DEPENDS from custom command(Fix CMake Policy CMP0175)

### DIFF
--- a/cmake/SIPMacros.cmake
+++ b/cmake/SIPMacros.cmake
@@ -209,7 +209,6 @@ MACRO(BUILD_SIP_PYTHON_MODULE MODULE_NAME SIP_FILES EXTRA_OBJECTS)
     ADD_CUSTOM_COMMAND(TARGET ${_logical_name} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E echo "Copying extension ${_child_module_name}"
       COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${_logical_name}>" "${_runtime_output}/${_child_module_name}.pyd"
-      DEPENDS ${_logical_name}
       )
   ENDIF(WIN32)
 


### PR DESCRIPTION
Eliminates the unnecessary DEPENDS argument from the ADD_CUSTOM_COMMAND in BUILD_SIP_PYTHON_MODULE for Windows, as the command is already attached to the target's POST_BUILD event.

## Description

This PR removes the invalid and unnecessary `DEPENDS` keyword from the Windows-specific `ADD_CUSTOM_COMMAND(TARGET … POST_BUILD …)` block inside `SIPMacros.cmake`.

### What was the issue?

Recent CMake versions introduce Policy **CMP0175**, which enforces stricter argument validation for `add_custom_command()`.  
When using the **TARGET** signature, arguments such as `DEPENDS` are not supported. This triggers repeated developer warnings during QGIS configuration:

```
The following keywords are not supported when using add_custom_command(TARGET): DEPENDS.
Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
```

Although older versions of CMake ignored this invalid argument silently, modern versions warn, and future versions may fail.

### What does this PR change?

Inside `BUILD_SIP_PYTHON_MODULE`, the following code existed:

```cmake
ADD_CUSTOM_COMMAND(TARGET ${_logical_name} POST_BUILD
  COMMAND ...
  COMMAND ...
  DEPENDS ${_logical_name}
)
```

The `DEPENDS` argument is **not allowed** here and also **redundant**, because:

- A `POST_BUILD` command is already guaranteed by CMake to run after the target is built.
- The dependency does not provide any additional build logic.
- It violates CMP0175 and generates warnings on newer CMake versions.

This PR simply removes the unsupported argument while keeping 100% of the existing behavior intact.

### Why is this safe?

- The generated Python extension modules still build and copy correctly.
- Removing `DEPENDS` does not change the execution order of POST_BUILD commands.
- The change eliminates CMP0175 warnings and makes the SIP build macros compliant with modern CMake.
- Tested locally on Windows SIP module builds (QGIS 3.44.x) — no functional differences observed.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
