### PR TITLE
[VectorTile] Accept connection with only style url

### DIFF
--- a/src/core/vectortile/qgsvectortileconnection.cpp
+++ b/src/core/vectortile/qgsvectortileconnection.cpp
@@ -155,7 +155,7 @@ QStringList QgsVectorTileProviderConnection::connectionList()
 
 QgsVectorTileProviderConnection::Data QgsVectorTileProviderConnection::connection( const QString &name )
 {
-  if ( !settingsUrl->exists( name ) )
+  if ( !settingsUrl->exists( name ) && !settingsStyleUrl->exists( name ) )
     return QgsVectorTileProviderConnection::Data();
 
   QgsVectorTileProviderConnection::Data conn;


### PR DESCRIPTION
Because style contains url.See #58663 for reference

Without this modification, settings with only styleUrl wouldn't work

cc @Guts 

@3nids Do you mind reviewing?


