### PR TITLE
Add map tool to edit blank segments

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
@@ -57,6 +57,16 @@ Returns the squared 2D distance between (``x1``, ``y1``) and (``x2``,
 Returns the 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
 %End
 
+    static double sqrDistance2D( QPointF point1, QPointF point2 ) /HoldGIL/;
+%Docstring
+Returns the squared 2D distance between ``point1`` and ``point2``
+%End
+
+    static double distance2D( QPointF point1, QPointF point2 ) /HoldGIL/;
+%Docstring
+Returns the 2D distance between ``point1`` and ``point2``
+%End
+
     static double sqrDistToLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double &minDistX /Out/, double &minDistY /Out/, double epsilon ) /HoldGIL/;
 %Docstring
 Returns the squared distance between a point and a line.

--- a/python/PyQt6/core/auto_generated/symbology/qgslinesymbollayer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgslinesymbollayer.sip.in
@@ -987,6 +987,12 @@ Returns the unit for for blank segments start and end distances
     virtual void stopFeatureRender( const QgsFeature &feature, QgsRenderContext &context );
 
 
+    void copyTemplateSymbolProperties( QgsTemplatedLineSymbolLayerBase *destLayer ) const;
+%Docstring
+Copies all common properties of this layer to another templated symbol
+layer ``destLayer``.
+%End
+
   protected:
 
     virtual void setSymbolLineAngle( double angle ) = 0;
@@ -1026,18 +1032,13 @@ If ``selected`` is ``True`` then the symbol will be drawn using the
 style.
 %End
 
-    void copyTemplateSymbolProperties( QgsTemplatedLineSymbolLayerBase *destLayer ) const;
-%Docstring
-Copies all common properties of this layer to another templated symbol
-layer.
-%End
-
     static void setCommonProperties( QgsTemplatedLineSymbolLayerBase *destLayer, const QVariantMap &properties );
 %Docstring
 Sets all common symbol properties in the ``destLayer``, using the
 settings serialized in the ``properties`` map.
 %End
 
+  protected:
 
 };
 

--- a/python/PyQt6/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
@@ -10,6 +10,9 @@
 
 
 
+template<T>
+class QgsMapToolEditBlankSegments;
+
 class QgsSymbolLayerWidget : QWidget, protected QgsExpressionContextGenerator
 {
 %Docstring(signature="appended")
@@ -50,7 +53,7 @@ associated map canvas and expression contexts.
 .. seealso:: :py:func:`setContext`
 %End
 
-    const QgsVectorLayer *vectorLayer() const;
+    QgsVectorLayer *vectorLayer() const;
 %Docstring
 Returns the vector layer associated with the widget.
 %End

--- a/python/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
@@ -57,6 +57,16 @@ Returns the squared 2D distance between (``x1``, ``y1``) and (``x2``,
 Returns the 2D distance between (``x1``, ``y1``) and (``x2``, ``y2``).
 %End
 
+    static double sqrDistance2D( QPointF point1, QPointF point2 ) /HoldGIL/;
+%Docstring
+Returns the squared 2D distance between ``point1`` and ``point2``
+%End
+
+    static double distance2D( QPointF point1, QPointF point2 ) /HoldGIL/;
+%Docstring
+Returns the 2D distance between ``point1`` and ``point2``
+%End
+
     static double sqrDistToLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double &minDistX /Out/, double &minDistY /Out/, double epsilon ) /HoldGIL/;
 %Docstring
 Returns the squared distance between a point and a line.

--- a/python/core/auto_generated/symbology/qgslinesymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgslinesymbollayer.sip.in
@@ -987,6 +987,12 @@ Returns the unit for for blank segments start and end distances
     virtual void stopFeatureRender( const QgsFeature &feature, QgsRenderContext &context );
 
 
+    void copyTemplateSymbolProperties( QgsTemplatedLineSymbolLayerBase *destLayer ) const;
+%Docstring
+Copies all common properties of this layer to another templated symbol
+layer ``destLayer``.
+%End
+
   protected:
 
     virtual void setSymbolLineAngle( double angle ) = 0;
@@ -1026,18 +1032,13 @@ If ``selected`` is ``True`` then the symbol will be drawn using the
 style.
 %End
 
-    void copyTemplateSymbolProperties( QgsTemplatedLineSymbolLayerBase *destLayer ) const;
-%Docstring
-Copies all common properties of this layer to another templated symbol
-layer.
-%End
-
     static void setCommonProperties( QgsTemplatedLineSymbolLayerBase *destLayer, const QVariantMap &properties );
 %Docstring
 Sets all common symbol properties in the ``destLayer``, using the
 settings serialized in the ``properties`` map.
 %End
 
+  protected:
 
 };
 

--- a/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
@@ -10,6 +10,9 @@
 
 
 
+template<T>
+class QgsMapToolEditBlankSegments;
+
 class QgsSymbolLayerWidget : QWidget, protected QgsExpressionContextGenerator
 {
 %Docstring(signature="appended")
@@ -50,7 +53,7 @@ associated map canvas and expression contexts.
 .. seealso:: :py:func:`setContext`
 %End
 
-    const QgsVectorLayer *vectorLayer() const;
+    QgsVectorLayer *vectorLayer() const;
 %Docstring
 Returns the vector layer associated with the widget.
 %End

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2003,6 +2003,7 @@ set(QGIS_CORE_HDRS
   stac/qgsstacparser.h
   stac/qgsstacprovider.h
 
+  symbology/line_p.h
   symbology/qgs25drenderer.h
   symbology/qgsarrowsymbollayer.h
 

--- a/src/core/geometry/qgsgeometryutils_base.h
+++ b/src/core/geometry/qgsgeometryutils_base.h
@@ -59,6 +59,16 @@ class CORE_EXPORT QgsGeometryUtilsBase
     static double distance2D( double x1, double y1, double x2, double y2 ) SIP_HOLDGIL {return std::sqrt( sqrDistance2D( x1, y1, x2, y2 ) ); }
 
     /**
+     * Returns the squared 2D distance between \a point1 and \a point2
+     */
+    static double sqrDistance2D( QPointF point1, QPointF point2 ) SIP_HOLDGIL {return sqrDistance2D( point1.x(), point1.y(), point2.x(), point2.y() ); }
+
+    /**
+     * Returns the 2D distance between \a point1 and \a point2
+     */
+    static double distance2D( QPointF point1, QPointF point2 ) SIP_HOLDGIL {return distance2D( point1.x(), point1.y(), point2.x(), point2.y() );}
+
+    /**
      * Returns the squared distance between a point and a line.
      */
     static double sqrDistToLine( double ptX, double ptY, double x1, double y1, double x2, double y2, double &minDistX SIP_OUT, double &minDistY SIP_OUT, double epsilon ) SIP_HOLDGIL;

--- a/src/core/symbology/line_p.h
+++ b/src/core/symbology/line_p.h
@@ -1,0 +1,92 @@
+/***************************************************************************
+    line_p.h
+    ---------------------
+    begin                : 2025/09/25
+    copyright            : (C) 2025 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef LINE_P_H
+#define LINE_P_H
+
+#define SIP_NO_FILE
+
+#include <QPointF>
+
+/////////
+
+///@cond PRIVATE
+
+class Line
+{
+  public:
+    Line( QPointF p1, QPointF p2 )
+      : mVertical( false )
+      , mIncreasing( false )
+      , mT( 0.0 )
+      , mLength( 0.0 )
+    {
+      if ( p1 == p2 )
+        return; // invalid
+
+      // tangent and direction
+      if ( qgsDoubleNear( p1.x(), p2.x() ) )
+      {
+        // vertical line - tangent undefined
+        mVertical = true;
+        mIncreasing = ( p2.y() > p1.y() );
+      }
+      else
+      {
+        mVertical = false;
+        mT = ( p2.y() - p1.y() ) / ( p2.x() - p1.x() );
+        mIncreasing = ( p2.x() > p1.x() );
+      }
+
+      // length
+      double x = ( p2.x() - p1.x() );
+      double y = ( p2.y() - p1.y() );
+      mLength = std::sqrt( x * x + y * y );
+    }
+
+    // return angle in radians
+    double angle()
+    {
+      double a = ( mVertical ? M_PI_2 : std::atan( mT ) );
+
+      if ( !mIncreasing )
+        a += M_PI;
+      return a;
+    }
+
+    // return difference for x,y when going along the line with specified interval
+    QPointF diffForInterval( double interval ) const
+    {
+      if ( mVertical )
+        return ( mIncreasing ? QPointF( 0, interval ) : QPointF( 0, -interval ) );
+
+      double alpha = std::atan( mT );
+      double dx = std::cos( alpha ) * interval;
+      double dy = std::sin( alpha ) * interval;
+      return ( mIncreasing ? QPointF( dx, dy ) : QPointF( -dx, -dy ) );
+    }
+
+    double length() const { return mLength; }
+
+  protected:
+    bool mVertical;
+    bool mIncreasing;
+    double mT;
+    double mLength;
+};
+
+///@endcond
+
+#endif

--- a/src/core/symbology/line_p.h
+++ b/src/core/symbology/line_p.h
@@ -18,19 +18,24 @@
 
 #define SIP_NO_FILE
 
-#include <QPointF>
+#include "qgsgeometryutils_base.h"
 
 /////////
 
 ///@cond PRIVATE
 
+
+/**
+*   \brief Helper private class to compute line operation (angle, length, difference from a given interval).
+*   Used in line symbol layer classes
+ */
 class Line
 {
   public:
     Line( QPointF p1, QPointF p2 )
       : mVertical( false )
       , mIncreasing( false )
-      , mT( 0.0 )
+      , mTangent( 0.0 )
       , mLength( 0.0 )
     {
       if ( p1 == p2 )
@@ -46,20 +51,17 @@ class Line
       else
       {
         mVertical = false;
-        mT = ( p2.y() - p1.y() ) / ( p2.x() - p1.x() );
+        mTangent = ( p2.y() - p1.y() ) / ( p2.x() - p1.x() );
         mIncreasing = ( p2.x() > p1.x() );
       }
 
-      // length
-      double x = ( p2.x() - p1.x() );
-      double y = ( p2.y() - p1.y() );
-      mLength = std::sqrt( x * x + y * y );
+      mLength = QgsGeometryUtilsBase::distance2D( p1, p2 );
     }
 
     // return angle in radians
     double angle()
     {
-      double a = ( mVertical ? M_PI_2 : std::atan( mT ) );
+      double a = ( mVertical ? M_PI_2 : std::atan( mTangent ) );
 
       if ( !mIncreasing )
         a += M_PI;
@@ -72,7 +74,7 @@ class Line
       if ( mVertical )
         return ( mIncreasing ? QPointF( 0, interval ) : QPointF( 0, -interval ) );
 
-      double alpha = std::atan( mT );
+      double alpha = std::atan( mTangent );
       double dx = std::cos( alpha ) * interval;
       double dy = std::sin( alpha ) * interval;
       return ( mIncreasing ? QPointF( dx, dy ) : QPointF( -dx, -dy ) );
@@ -83,7 +85,7 @@ class Line
   protected:
     bool mVertical;
     bool mIncreasing;
-    double mT;
+    double mTangent;
     double mLength;
 };
 

--- a/src/core/symbology/qgsblanksegmentutils.h
+++ b/src/core/symbology/qgsblanksegmentutils.h
@@ -38,6 +38,11 @@ class CORE_EXPORT QgsBlankSegmentUtils
 
     /**
      * Parse blank segments string representation \a strBlankSegments
+     *
+     * Blank segments format is expected to be in the form (((2.90402 7.36,11.8776 30.4499),()),((2 7))) with 3 levels
+     * of parenthesis like MultiPolygon to deal with multi parts and inner rings. Empty opening-closing parenthesis are allowed
+     * to define the lack of blank segments for some multi part or inner rings.
+     *
      * The blank segments are expected to be expressed in \a unit and converted in pixels regarding render context \a renderContext
      * \a error is populated with a descritive message if the string representation is not well formatted
      * Returns a list of start and end distance expressed in pixels for each part and rings

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -13,12 +13,11 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "line_p.h"
-#include "qgsgeometryutils.h"
 #include "qgslinesymbollayer.h"
 
 #include <algorithm>
 #include <cmath>
+#include <line_p.h>
 #include <memory>
 
 #include "qgsapplication.h"

--- a/src/core/symbology/qgslinesymbollayer.h
+++ b/src/core/symbology/qgslinesymbollayer.h
@@ -833,6 +833,11 @@ class CORE_EXPORT QgsTemplatedLineSymbolLayerBase : public QgsLineSymbolLayer
     void startFeatureRender( const QgsFeature &feature, QgsRenderContext &context ) override;
     void stopFeatureRender( const QgsFeature &feature, QgsRenderContext &context ) override;
 
+    /**
+     * Copies all common properties of this layer to another templated symbol layer \a destLayer.
+     */
+    void copyTemplateSymbolProperties( QgsTemplatedLineSymbolLayerBase *destLayer ) const;
+
   protected:
 
     /**
@@ -868,22 +873,20 @@ class CORE_EXPORT QgsTemplatedLineSymbolLayerBase : public QgsLineSymbolLayer
     virtual void renderSymbol( const QPointF &point, const QgsFeature *feature, QgsRenderContext &context, int layer = -1, bool selected = false ) = 0;
 
     /**
-     * Copies all common properties of this layer to another templated symbol layer.
-     */
-    void copyTemplateSymbolProperties( QgsTemplatedLineSymbolLayerBase *destLayer ) const;
-
-    /**
      * Sets all common symbol properties in the \a destLayer, using the settings
      * serialized in the \a properties map.
      */
     static void setCommonProperties( QgsTemplatedLineSymbolLayerBase *destLayer, const QVariantMap &properties );
 
+  protected:
+    int mRingIndex = 0; // current ring index while rendering
 
   private:
 
     void renderPolylineInterval( const QPolygonF &points, QgsSymbolRenderContext &context, double averageAngleOver, const QgsBlankSegmentUtils::BlankSegments &blankSegments );
     void renderPolylineVertex( const QPolygonF &points, QgsSymbolRenderContext &context, Qgis::MarkerLinePlacement placement, const QgsBlankSegmentUtils::BlankSegments &blankSegments );
     void renderPolylineCentral( const QPolygonF &points, QgsSymbolRenderContext &context, double averageAngleOver, const QgsBlankSegmentUtils::BlankSegments &blankSegments );
+
     double markerAngle( const QPolygonF &points, bool isRing, int vertex );
 
     /**
@@ -900,7 +903,7 @@ class CORE_EXPORT QgsTemplatedLineSymbolLayerBase : public QgsLineSymbolLayer
      * \see setOffsetAlongLineUnit
      */
     void renderOffsetVertexAlongLine( const QPolygonF &points, int vertex, double distance, QgsSymbolRenderContext &context,
-                                      Qgis::MarkerLinePlacement placement, const QList<QPair<double, double>> &blankSegments );
+                                      Qgis::MarkerLinePlacement placement, const QgsBlankSegmentUtils::BlankSegments &blankSegments );
 
 
     static void collectOffsetPoints( const QVector< QPointF> &points,
@@ -928,7 +931,6 @@ class CORE_EXPORT QgsTemplatedLineSymbolLayerBase : public QgsLineSymbolLayer
     QPointF mFinalVertex;
     bool mCurrentFeatureIsSelected = false;
     double mFeatureSymbolOpacity = 1;
-    int mRingIndex = 0; // current ring index while rendering
 
     friend class TestQgsMarkerLineSymbol;
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -357,8 +357,9 @@ set(QGIS_GUI_SRCS
   maptools/qgsmaptoolcapture.cpp
   maptools/qgsmaptoolcapturelayergeometry.cpp
   maptools/qgsmaptoolcapturerubberband.cpp
-  maptools/qgsmaptooledit.cpp
   maptools/qgsmaptooldigitizefeature.cpp
+  maptools/qgsmaptooledit.cpp
+  maptools/qgsmaptooleditblanksegments.cpp
   maptools/qgsmaptoolemitpoint.cpp
   maptools/qgsmaptoolextent.cpp
   maptools/qgsmaptoolidentify.cpp
@@ -1370,6 +1371,7 @@ set(QGIS_GUI_HDRS
   maptools/qgsmaptoolcapturerubberband.h
   maptools/qgsmaptooldigitizefeature.h
   maptools/qgsmaptooledit.h
+  maptools/qgsmaptooleditblanksegments.h
   maptools/qgsmaptoolemitpoint.h
   maptools/qgsmaptoolextent.h
   maptools/qgsmaptoolidentify.h

--- a/src/gui/maptools/qgsmaptooleditblanksegments.cpp
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.cpp
@@ -656,6 +656,7 @@ void QgsMapToolEditBlankSegmentsBase::setCurrentBlankSegment( int currentBlankSe
   }
 
   mCurrentBlankSegmentIndex = currentBlankSegmentIndex;
+  // NOLINTBEGIN(bugprone-branch-clone)
   if ( mCurrentBlankSegmentIndex > -1 && mCurrentBlankSegmentIndex < static_cast<int>( mBlankSegments.size() ) )
   {
     mBlankSegments.at( mCurrentBlankSegmentIndex )->setVisible( false );
@@ -665,6 +666,7 @@ void QgsMapToolEditBlankSegmentsBase::setCurrentBlankSegment( int currentBlankSe
   {
     mEditedBlankSegment->setVisible( false );
   }
+  // NOLINTEND(bugprone-branch-clone)
 
   updateStartEndRubberBand();
 }

--- a/src/gui/maptools/qgsmaptooleditblanksegments.cpp
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.cpp
@@ -1,0 +1,944 @@
+/***************************************************************************
+    qgsmaptooleditblanksegments.cpp
+    ---------------------
+    begin                : 2025/08/19
+    copyright            : (C) 2025 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscoordinatetransform.h"
+#include "qgsfeatureid.h"
+#include "qgsmaptooleditblanksegments.h"
+
+#include "line_p.h"
+#include "qgsmapcanvas.h"
+#include "qgsvectorlayer.h"
+#include "qgslinesymbollayer.h"
+#include "qgssinglesymbolrenderer.h"
+#include "qgssymbol.h"
+#include "qgsnullpainterdevice.h"
+#include "qgsmapmouseevent.h"
+#include "qgsrubberband.h"
+#include "qgssettingsregistrycore.h"
+#include "qgssettingsentryimpl.h"
+#include "qgsguiutils.h"
+#include "qgssnappingutils.h"
+#include "qgsstyleentityvisitor.h"
+
+constexpr int TOLERANCE = 20;
+
+
+/////////
+
+///@cond PRIVATE
+
+namespace
+{
+
+  class SymbolLayerVisitor : public QgsStyleEntityVisitorInterface
+  {
+    public:
+      //! constructor
+      SymbolLayerVisitor( const QString &symbolLayerId )
+        : mSymbolLayerId( symbolLayerId ) {}
+
+      bool visitEnter( const QgsStyleEntityVisitorInterface::Node &node ) override
+      {
+        if ( node.type != QgsStyleEntityVisitorInterface::NodeType::SymbolRule )
+          return false;
+
+        return true;
+      }
+
+      bool visitSymbol( const QgsSymbol *symbol, const QString &leafIdentifier )
+      {
+        if ( symbol && !mSymbol )
+          mSymbol = symbol;
+
+        for ( int idx = 0; idx < symbol->symbolLayerCount(); idx++ )
+        {
+          const QgsSymbolLayer *sl = symbol->symbolLayer( idx );
+          if ( sl->id() == mSymbolLayerId )
+          {
+            mSymbolLayer = dynamic_cast<const QgsTemplatedLineSymbolLayerBase *>( sl );
+            mSymbolLayerIndex = idx;
+            return false;
+          }
+
+          // recurse over sub symbols
+          if ( const QgsSymbol *subSymbol = const_cast<QgsSymbolLayer *>( sl )->subSymbol();
+               subSymbol && !visitSymbol( subSymbol, leafIdentifier ) )
+          {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      bool visit( const QgsStyleEntityVisitorInterface::StyleLeaf &leaf ) override
+      {
+        if ( leaf.entity && leaf.entity->type() == QgsStyle::SymbolEntity )
+        {
+          auto symbolEntity = static_cast<const QgsStyleSymbolEntity *>( leaf.entity );
+          if ( symbolEntity->symbol() )
+            visitSymbol( symbolEntity->symbol(), leaf.identifier );
+        }
+        return true;
+      }
+
+      const QgsSymbol *symbol() const { return mSymbol; }
+      const QgsTemplatedLineSymbolLayerBase *symbolLayer() const { return mSymbolLayer; }
+      int symbolLayerIndex() const { return mSymbolLayerIndex; }
+
+      bool found() const { return mSymbol && mSymbolLayer; }
+
+    private:
+      const QgsSymbol *mSymbol = nullptr;
+      const QgsTemplatedLineSymbolLayerBase *mSymbolLayer = nullptr;
+      int mSymbolLayerIndex = -1;
+      const QString &mSymbolLayerId;
+  };
+
+} //namespace
+///@endcond
+
+QgsMapToolEditBlankSegmentsBase::QgsMapToolEditBlankSegmentsBase( QgsMapCanvas *canvas, QgsVectorLayer *layer, QgsLineSymbolLayer *symbolLayer, int blankSegmentFieldIndex )
+  : QgsMapTool( canvas )
+  , mLayer( layer )
+  , mSymbolLayerId( symbolLayer->id() )
+  , mBlankSegmentsFieldIndex( blankSegmentFieldIndex )
+  , mEditedBlankSegment( new BlankSegment( canvas, mPoints ) )
+  , mStartRubberBand( new QgsRubberBand( canvas, Qgis::GeometryType::Point ) )
+  , mEndRubberBand( new QgsRubberBand( canvas, Qgis::GeometryType::Point ) )
+{
+  auto initRubberBand = []( QgsRubberBand *rb ) {
+    rb->setWidth( QgsGuiUtils::scaleIconSize( 4 ) );
+    rb->setColor( QgsSettingsRegistryCore::settingsDigitizingLineColor->value() );
+    rb->setIcon( QgsRubberBand::IconType::ICON_BOX );
+  };
+
+  initRubberBand( mStartRubberBand );
+  initRubberBand( mEndRubberBand );
+
+  mEditedBlankSegment->setHighlighted( true );
+}
+
+QgsMapToolEditBlankSegmentsBase::~QgsMapToolEditBlankSegmentsBase() = default;
+
+void QgsMapToolEditBlankSegmentsBase::activate()
+{
+  if ( !mLayer || !mLayer->renderer() )
+    return;
+
+  if ( !mSymbol || !mSymbolLayer )
+  {
+    // search and symbol and symbol layer
+    SymbolLayerVisitor visitor( mSymbolLayerId );
+    mLayer->renderer()->accept( &visitor );
+    if ( visitor.symbol() && visitor.symbolLayer() && visitor.symbolLayerIndex() > -1 )
+    {
+      mSymbol.reset( visitor.symbol()->clone() );
+      if ( mSymbolLayer = createRenderedPointsSymbolLayer( visitor.symbolLayer() ); mSymbolLayer )
+      {
+        // set our on symbol layer to later retrieve rendered points
+        mSymbol->changeSymbolLayer( visitor.symbolLayerIndex(), mSymbolLayer );
+      }
+      else
+      {
+        mSymbol.reset();
+        QgsDebugError( "Fail to create fake templated line symbol layer" );
+      }
+    }
+    else
+    {
+      QgsDebugError( "Fail to retrieve symbol and templated line symbol layer" );
+    }
+  }
+
+  QgsMapTool::activate();
+}
+
+enum Status
+{
+  OK,            // ok, point is on the segment
+  LINE_EMPTY,    // line is empty, cannot project point
+  NOT_ON_SEGMENT // point is on the line, but not on the segment
+};
+
+// Returns point projected on segment defined by lineStartPt and lineEndPt
+// distance is updated with the distance between the point and the returned projected point
+QPointF projectedPoint( const QPointF &lineStartPt, const QPointF &lineEndPt, const QPointF &point, double &distance, Status &status )
+{
+  status = Status::OK;
+  distance = -1;
+
+  const double Ax = lineStartPt.x();
+  const double Ay = lineStartPt.y();
+  const double Bx = lineEndPt.x();
+  const double By = lineEndPt.y();
+  const double Cx = point.x();
+  const double Cy = point.y();
+
+  const double length = QgsGeometryUtilsBase::distance2D( Ax, Ay, Bx, By );
+  if ( length == 0 )
+  {
+    status = Status::LINE_EMPTY;
+    return QPointF();
+  }
+
+  const double r = ( ( Cx - Ax ) * ( Bx - Ax ) + ( Cy - Ay ) * ( By - Ay ) ) / std::pow( length, 2 );
+  if ( r < 0 or r > 1 )
+  {
+    status = Status::NOT_ON_SEGMENT;
+  }
+
+  // projected point
+  const double Px = Ax + r * ( Bx - Ax );
+  const double Py = Ay + r * ( By - Ay );
+
+  distance = QgsGeometryUtilsBase::distance2D( Cx, Cy, Px, Py );
+
+  return QPointF( Px, Py );
+}
+
+void QgsMapToolEditBlankSegmentsBase::canvasMoveEvent( QgsMapMouseEvent *e )
+{
+  if ( !mSymbol || mPoints.isEmpty() )
+    return;
+
+  const QPoint &pos = e->pos();
+
+  if ( canvas()->extent() != mExtent )
+  {
+    loadFeaturePoints();
+
+    // If edition has been started, we cancel them because they are no longer in the same extent reference
+    switch ( mState )
+    {
+      case State::SELECT_FEATURE:
+      case State::BLANK_SEGMENT_SELECTED:
+      case State::FEATURE_SELECTED:
+        break;
+
+      case State::BLANK_SEGMENT_CREATION_STARTED:
+        mState = State::FEATURE_SELECTED;
+        setCurrentBlankSegment( -1 );
+        break;
+
+      case State::BLANK_SEGMENT_MODIFICATION_STARTED:
+        mState = State::BLANK_SEGMENT_SELECTED;
+        // force original blank segment
+        setCurrentBlankSegment( mCurrentBlankSegmentIndex );
+        break;
+    }
+  }
+
+  switch ( mState )
+  {
+    case State::SELECT_FEATURE:
+      return;
+
+    case State::BLANK_SEGMENT_SELECTED:
+      updateHoveredBlankSegment( pos );
+      break;
+
+    case State::FEATURE_SELECTED:
+    {
+      updateHoveredBlankSegment( pos );
+
+      // display current start point to create a new blank segment
+      mStartRubberBand->setVisible( mHoveredBlankSegmentIndex == -1 );
+      if ( mHoveredBlankSegmentIndex == -1 )
+      {
+        const QgsMapToPixel &m2p = *( canvas()->getCoordinateTransform() );
+        mStartRubberBand->reset( Qgis::GeometryType::Point );
+        double distance;
+        int partIndex = -1, ringIndex = -1, pointIndex = -1;
+        const QPointF closestPoint = getClosestPoint( pos, distance, partIndex, ringIndex, pointIndex );
+
+        // for now end point is the same as start one
+        mStartRubberBand->addPoint( m2p.toMapCoordinates( closestPoint.x(), closestPoint.y() ) );
+      }
+
+      break;
+    }
+
+    case State::BLANK_SEGMENT_MODIFICATION_STARTED:
+    case State::BLANK_SEGMENT_CREATION_STARTED:
+    {
+      double distance = -1;
+      int partIndex = -1;
+      int pointIndex = -1;
+      int ringIndex = -1;
+      QPointF P = getClosestPoint( pos, distance, partIndex, ringIndex, pointIndex );
+      if ( distance > -1 && pointIndex > -1 )
+      {
+        mEditedBlankSegment->setPoints( partIndex, ringIndex, mEditedBlankSegment->getStartIndex(), pointIndex, mEditedBlankSegment->getStartPoint(), P );
+        updateStartEndRubberBand();
+      }
+    }
+    break;
+  }
+}
+
+void QgsMapToolEditBlankSegmentsBase::canvasPressEvent( QgsMapMouseEvent *e )
+{
+  switch ( mState )
+  {
+    case State::SELECT_FEATURE:
+    {
+      //find the closest feature to the pressed position
+      const QgsPointLocator::Match m = mCanvas->snappingUtils()->snapToCurrentLayer( e->pos(), QgsPointLocator::Area );
+      if ( !m.isValid() )
+      {
+        emit messageEmitted( tr( "No feature was detected at the clicked position. Please click closer to the feature or enhance the search tolerance under Settings->Options->Digitizing->Search radius for vertex edits" ), Qgis::MessageLevel::Critical );
+        return;
+      }
+
+      mCurrentFeatureId = m.featureId();
+      loadFeaturePoints();
+      updateHoveredBlankSegment( e->pos() );
+
+      mState = State::FEATURE_SELECTED;
+      break;
+    }
+    case State::FEATURE_SELECTED:
+
+      // new blank segment selected
+      if ( mHoveredBlankSegmentIndex > -1 )
+      {
+        mState = State::BLANK_SEGMENT_SELECTED;
+        setCurrentBlankSegment( mHoveredBlankSegmentIndex );
+      }
+      // init first point of new blank segment
+      else
+      {
+        mState = State::BLANK_SEGMENT_CREATION_STARTED;
+        double distance = -1;
+        int partIndex = -1;
+        int pointIndex = -1;
+        int ringIndex = -1;
+        QPointF P = getClosestPoint( e->pos(), distance, partIndex, ringIndex, pointIndex );
+        if ( distance > -1 && pointIndex > -1 )
+        {
+          mEditedBlankSegment->setPoints( partIndex, ringIndex, pointIndex, pointIndex, P, P );
+          updateStartEndRubberBand();
+        }
+      }
+
+      break;
+
+    case State::BLANK_SEGMENT_SELECTED:
+    {
+      Q_ASSERT( mCurrentBlankSegmentIndex > -1 && mCurrentBlankSegmentIndex < static_cast<int>( mBlankSegments.size() ) );
+      const QObjectUniquePtr<BlankSegment> &currentBlankSegment = mBlankSegments.at( mCurrentBlankSegmentIndex );
+
+      // selected blank segment has changed
+      if ( mHoveredBlankSegmentIndex > -1 && mHoveredBlankSegmentIndex != mCurrentBlankSegmentIndex )
+      {
+        setCurrentBlankSegment( mHoveredBlankSegmentIndex );
+      }
+      else
+      {
+        const double distanceFromStart = ( currentBlankSegment->getStartPoint() - e->pos() ).manhattanLength();
+        const double distanceFromEnd = ( currentBlankSegment->getEndPoint() - e->pos() ).manhattanLength();
+
+        // user clicked on start or end point to move it
+        if ( std::min( distanceFromStart, distanceFromEnd ) < TOLERANCE )
+        {
+          if ( distanceFromStart < distanceFromEnd )
+          {
+            // start point become end point because we always edit end point
+            mEditedBlankSegment->setPoints( currentBlankSegment->getPartIndex(), currentBlankSegment->getRingIndex(), currentBlankSegment->getEndIndex(), currentBlankSegment->getStartIndex(), currentBlankSegment->getEndPoint(), currentBlankSegment->getStartPoint() );
+          }
+
+          mState = State::BLANK_SEGMENT_MODIFICATION_STARTED;
+        }
+      }
+    }
+
+    break;
+
+    case State::BLANK_SEGMENT_MODIFICATION_STARTED:
+    case State::BLANK_SEGMENT_CREATION_STARTED:
+
+      // this is a new one
+      if ( mCurrentBlankSegmentIndex < 0 )
+      {
+        mBlankSegments.emplace_back( new BlankSegment( canvas(), mPoints ) );
+        mBlankSegments.back()->copyFrom( *mEditedBlankSegment );
+        mState = State::FEATURE_SELECTED;
+      }
+      // modify an existing one
+      else
+      {
+        QObjectUniquePtr<BlankSegment> &blankSegment = mBlankSegments.at( mCurrentBlankSegmentIndex );
+        blankSegment->copyFrom( *mEditedBlankSegment );
+        mState = State::BLANK_SEGMENT_SELECTED;
+      }
+
+      updateAttribute();
+      break;
+  }
+}
+
+void QgsMapToolEditBlankSegmentsBase::keyPressEvent( QKeyEvent *e )
+{
+  // !!! We need to ignore event instead of accept them if we want to consume them
+  // see QgsMapCanvas::keyPressEvent
+
+  switch ( mState )
+  {
+    case State::SELECT_FEATURE:
+      return;
+
+    case State::BLANK_SEGMENT_SELECTED:
+      if ( e->matches( QKeySequence::Delete ) && mCurrentBlankSegmentIndex > -1 )
+      {
+        mState = State::FEATURE_SELECTED;
+        int toRemoveIndex = mCurrentBlankSegmentIndex;
+        setCurrentBlankSegment( -1 );
+        mBlankSegments.erase( mBlankSegments.begin() + toRemoveIndex );
+        updateAttribute();
+        e->ignore();
+      }
+      else if ( e->matches( QKeySequence::Cancel ) )
+      {
+        mState = State::FEATURE_SELECTED;
+        setCurrentBlankSegment( -1 );
+        e->ignore();
+      }
+
+      break;
+
+    case State::FEATURE_SELECTED:
+      if ( e->matches( QKeySequence::Cancel ) )
+      {
+        mCurrentFeatureId = FID_NULL;
+        mState = State::SELECT_FEATURE;
+        loadFeaturePoints();
+        e->ignore();
+      }
+      break;
+
+    case State::BLANK_SEGMENT_CREATION_STARTED:
+      if ( e->matches( QKeySequence::Cancel ) )
+      {
+        mState = State::FEATURE_SELECTED;
+        setCurrentBlankSegment( -1 );
+        e->ignore();
+      }
+      break;
+
+    case State::BLANK_SEGMENT_MODIFICATION_STARTED:
+      if ( e->matches( QKeySequence::Cancel ) )
+      {
+        mState = State::BLANK_SEGMENT_SELECTED;
+        // force original blank segment
+        setCurrentBlankSegment( mCurrentBlankSegmentIndex );
+        e->ignore();
+      }
+      break;
+  }
+}
+
+
+const QPointF &pointAt( const QList<QList<QPolygonF>> &points, int partIndex, int ringIndex, int pointIndex )
+{
+  if ( partIndex < 0 || partIndex >= points.count() )
+    throw std::invalid_argument( "Blank segments internal error : Invalid part index" );
+
+  const QList<QPolygonF> &rings = points.at( partIndex );
+  if ( ringIndex < 0 || ringIndex >= rings.count() )
+    throw std::invalid_argument( "blank segments internal error : Invalid ring index" );
+
+  const QPolygonF &pts = rings.at( ringIndex );
+  if ( pointIndex < 0 || pointIndex >= pts.count() )
+    throw std::invalid_argument( "blank segments internal error : Invalid point index" );
+
+  return pts.at( pointIndex );
+}
+
+QPair<double, double> QgsMapToolEditBlankSegmentsBase::BlankSegment::getStartEndDistance( Qgis::RenderUnit unit ) const
+{
+  double startDistance = 0;
+  const int startIndex = mNeedSwap ? mEndIndex : mStartIndex;
+  const QPointF startPt = mNeedSwap ? mEndPt : mStartPt;
+  for ( int i = 1; i < startIndex; i++ )
+  {
+    startDistance += QgsGeometryUtilsBase::distance2D( ::pointAt( mPoints, mPartIndex, mRingIndex, i - 1 ), ::pointAt( mPoints, mPartIndex, mRingIndex, i ) );
+  }
+
+  startDistance += QgsGeometryUtilsBase::distance2D( ::pointAt( mPoints, mPartIndex, mRingIndex, startIndex - 1 ), startPt );
+
+  double endDistance = startDistance;
+  for ( int i = 1; i < pointsCount(); i++ )
+  {
+    endDistance += QgsGeometryUtilsBase::distance2D( pointAt( i ), pointAt( i - 1 ) );
+  }
+
+  QgsRenderContext renderContext = QgsRenderContext::fromMapSettings( mMapCanvas->mapSettings() );
+
+  startDistance = renderContext.convertFromPainterUnits( startDistance, unit );
+  endDistance = renderContext.convertFromPainterUnits( endDistance, unit );
+
+  return QPair<double, double>( startDistance, endDistance );
+}
+
+int QgsMapToolEditBlankSegmentsBase::getClosestBlankSegmentIndex( const QPointF &point, double &distance ) const
+{
+  // search for closest blankSegment
+  distance = -1;
+  int iBlankSegment = -1;
+  for ( int i = 0; i < static_cast<int>( mBlankSegments.size() ); i++ )
+  {
+    const QObjectUniquePtr<BlankSegment> &blankSegment = mBlankSegments.at( i );
+    for ( int iPoint = 1; iPoint < blankSegment->pointsCount(); iPoint++ )
+    {
+      double d = 0;
+      Status status = Status::OK;
+
+      try
+      {
+        projectedPoint( blankSegment->pointAt( iPoint - 1 ), blankSegment->pointAt( iPoint ), point, d, status );
+      }
+      catch ( std::invalid_argument e )
+      {
+        QgsDebugError( e.what() );
+        continue;
+      }
+
+      switch ( status )
+      {
+        case Status::LINE_EMPTY:
+          continue;
+
+        case Status::NOT_ON_SEGMENT:
+          d = std::min( ( blankSegment->getStartPoint() - point ).manhattanLength(), ( blankSegment->getEndPoint() - point ).manhattanLength() );
+          break;
+
+        case Status::OK:
+          break;
+      }
+
+      if ( distance == -1 || d < distance )
+      {
+        distance = d;
+        iBlankSegment = i;
+      }
+    }
+  }
+
+  return iBlankSegment;
+}
+
+QPointF QgsMapToolEditBlankSegmentsBase::getClosestPoint( const QPointF &point, double &distance, int &partIndex, int &ringIndex, int &pointIndex ) const
+{
+  distance = -1;
+  QPointF currentPoint;
+
+  // iterate through all points from parts and ring to get the closest one
+  for ( int iPart = 0; iPart < mPoints.count(); iPart++ )
+  {
+    const QList<QPolygonF> &rings = mPoints.at( iPart );
+    for ( int iRing = 0; iRing < rings.count(); iRing++ )
+    {
+      const QPolygonF &points = rings.at( iRing );
+      for ( int i = 1; i < points.count(); i++ )
+      {
+        double d = 0;
+        Status status = Status::OK;
+        QPointF P = projectedPoint( points.at( i - 1 ), points.at( i ), point, d, status );
+        switch ( status )
+        {
+          case Status::LINE_EMPTY:
+          case Status::NOT_ON_SEGMENT:
+            continue;
+
+          case Status::OK:
+            break;
+        }
+
+        if ( distance == -1 || d < distance )
+        {
+          distance = d;
+          currentPoint = P;
+          partIndex = iPart;
+          ringIndex = iRing;
+          pointIndex = i;
+        }
+      }
+    }
+  }
+  return currentPoint;
+}
+
+
+void QgsMapToolEditBlankSegmentsBase::updateStartEndRubberBand()
+{
+  mStartRubberBand->reset( Qgis::GeometryType::Point );
+  mEndRubberBand->reset( Qgis::GeometryType::Point );
+
+  bool displayEndPoint = true;
+  switch ( mState )
+  {
+    case State::SELECT_FEATURE:
+    case State::BLANK_SEGMENT_CREATION_STARTED:
+      return;
+
+    case State::FEATURE_SELECTED:
+      displayEndPoint = false;
+      [[fallthrough]];
+
+    case State::BLANK_SEGMENT_SELECTED:
+    case State::BLANK_SEGMENT_MODIFICATION_STARTED:
+      break;
+  }
+
+  const QgsMapToPixel &m2p = *( canvas()->getCoordinateTransform() );
+
+  const QPointF &startPoint = mEditedBlankSegment->getStartPoint();
+  mStartRubberBand->addPoint( m2p.toMapCoordinates( startPoint.x(), startPoint.y() ) );
+
+  if ( displayEndPoint )
+  {
+    const QPointF &endPoint = mEditedBlankSegment->getEndPoint();
+    mEndRubberBand->addPoint( m2p.toMapCoordinates( endPoint.x(), endPoint.y() ) );
+  }
+}
+
+void QgsMapToolEditBlankSegmentsBase::updateHoveredBlankSegment( const QPoint &pos )
+{
+  double distance = -1;
+  int iBlankSegment = getClosestBlankSegmentIndex( pos, distance );
+
+  if ( mHoveredBlankSegmentIndex > -1
+       && mHoveredBlankSegmentIndex < static_cast<int>( mBlankSegments.size() )
+       && mHoveredBlankSegmentIndex != mCurrentBlankSegmentIndex )
+  {
+    mBlankSegments.at( mHoveredBlankSegmentIndex )->setHighlighted( false );
+  }
+
+  // blank segment is hovered
+  if ( iBlankSegment > -1 && distance < TOLERANCE )
+  {
+    mHoveredBlankSegmentIndex = iBlankSegment;
+    if ( mHoveredBlankSegmentIndex < static_cast<int>( mBlankSegments.size() ) )
+    {
+      mBlankSegments.at( mHoveredBlankSegmentIndex )->setHighlighted( true );
+    }
+  }
+  // no blank segment hovered, display the first point to create a new blank segment
+  else
+  {
+    mHoveredBlankSegmentIndex = -1;
+  }
+}
+
+void QgsMapToolEditBlankSegmentsBase::setCurrentBlankSegment( int currentBlankSegmentIndex )
+{
+  // copy current blank segment so we can edit it later (and hide the original one)
+
+  if ( mCurrentBlankSegmentIndex > -1
+       && mCurrentBlankSegmentIndex < static_cast<int>( mBlankSegments.size() ) )
+  {
+    mBlankSegments.at( mCurrentBlankSegmentIndex )->setVisible( true );
+    mBlankSegments.at( mCurrentBlankSegmentIndex )->setHighlighted( false );
+  }
+
+  mCurrentBlankSegmentIndex = currentBlankSegmentIndex;
+  if ( mCurrentBlankSegmentIndex > -1 && mCurrentBlankSegmentIndex < static_cast<int>( mBlankSegments.size() ) )
+  {
+    mBlankSegments.at( mCurrentBlankSegmentIndex )->setVisible( false );
+    mEditedBlankSegment->copyFrom( *( mBlankSegments.at( mCurrentBlankSegmentIndex ).get() ) );
+  }
+  else
+  {
+    mEditedBlankSegment->setVisible( false );
+  }
+
+  updateStartEndRubberBand();
+}
+
+void QgsMapToolEditBlankSegmentsBase::updateAttribute()
+{
+  if ( !mSymbolLayer )
+    return;
+
+  QList<QList<QgsBlankSegmentUtils::BlankSegments>> blankSegments;
+  for ( const QObjectUniquePtr<BlankSegment> &blankSegment : mBlankSegments )
+  {
+    try
+    {
+      QPair<double, double> startEndDistance = blankSegment->getStartEndDistance( mSymbolLayer->blankSegmentsUnit() );
+
+      const int partIndex = blankSegment->getPartIndex();
+      if ( partIndex >= blankSegments.count() )
+        blankSegments.resize( partIndex + 1 );
+
+      QList<QgsBlankSegmentUtils::BlankSegments> &rings = blankSegments[partIndex];
+      const int ringIndex = blankSegment->getRingIndex();
+      if ( ringIndex >= rings.count() )
+        rings.resize( ringIndex + 1 );
+
+      QgsBlankSegmentUtils::BlankSegments &segments = rings[ringIndex];
+      segments << startEndDistance;
+    }
+    catch ( std::invalid_argument e )
+    {
+      QgsDebugError( e.what() );
+      return;
+    }
+  }
+
+  QStringList strParts;
+  for ( QList<QgsBlankSegmentUtils::BlankSegments> &part : blankSegments )
+  {
+    QStringList strRings;
+    for ( QgsBlankSegmentUtils::BlankSegments &ring : part )
+    {
+      std::sort( ring.begin(), ring.end() );
+      QStringList strDistances;
+      for ( const QPair<double, double> &distance : ring )
+      {
+        strDistances << ( QString::number( distance.first ) + " " + QString::number( distance.second ) );
+      }
+
+      strRings << "(" + strDistances.join( "," ) + ")";
+    }
+
+    strParts << "(" + strRings.join( "," ) + ")";
+  }
+
+  QString strNewBlankSegments = "(" + strParts.join( "," ) + ")";
+
+  mLayer->beginEditCommand( tr( "Set blank segment list" ) );
+  if ( mLayer->changeAttributeValue( mCurrentFeatureId, mBlankSegmentsFieldIndex, strNewBlankSegments ) )
+  {
+    mLayer->endEditCommand();
+    mLayer->triggerRepaint();
+  }
+  else
+  {
+    mLayer->destroyEditCommand();
+  }
+}
+
+void QgsMapToolEditBlankSegmentsBase::loadFeaturePoints()
+{
+  mPoints.clear();
+  mExtent = canvas()->extent();
+  mBlankSegments.clear();
+  setCurrentBlankSegment( -1 );
+
+  if ( FID_IS_NULL( mCurrentFeatureId ) || !mSymbolLayer )
+    return;
+
+  QgsFeature feature;
+  feature = mLayer->getFeature( mCurrentFeatureId );
+  QString currentBlankSegments = feature.attribute( mBlankSegmentsFieldIndex ).toString();
+
+
+  // render feature to update mPoints
+  QgsRenderContext context = QgsRenderContext::fromMapSettings( canvas()->mapSettings() );
+  QgsCoordinateTransform transform( canvas()->mapSettings().layerTransform( mLayer ) );
+  QgsNullPaintDevice nullPaintDevice;
+  QPainter painter( &nullPaintDevice );
+  context.setPainter( &painter );
+  context.setCoordinateTransform( transform );
+  mSymbol->startRender( context );
+  mSymbol->renderFeature( feature, context );
+  mSymbol->stopRender( context );
+
+  if ( mPoints.isEmpty() )
+    return;
+
+  QString error;
+  QList<QList<QgsBlankSegmentUtils::BlankSegments>> allBlankSegments = QgsBlankSegmentUtils::parseBlankSegments( currentBlankSegments, context, mSymbolLayer->blankSegmentsUnit(), error );
+  if ( !error.isEmpty() )
+  {
+    emit messageEmitted( tr( "Error while parsing feature blank segments: %1" ).arg( error ), Qgis::MessageLevel::Critical );
+    return;
+  }
+
+  // iterate through all points from parts and ring to get the closest one
+  for ( int iPart = 0; iPart < mPoints.count(); iPart++ )
+  {
+    const QList<QPolygonF> &rings = mPoints.at( iPart );
+    for ( int iRing = 0; iRing < rings.count(); iRing++ )
+    {
+      if ( iPart >= allBlankSegments.count() || iRing >= allBlankSegments.at( iPart ).count() )
+        continue;
+
+      const QgsBlankSegmentUtils::BlankSegments &blankSegments = allBlankSegments.at( iPart ).at( iRing );
+
+      double currentLength = 0;
+      int iPoint = 0;
+      const QPolygonF &points = rings.at( iRing );
+      for ( QPair<double, double> ba : blankSegments )
+      {
+        while ( iPoint < points.count() - 1 && currentLength < ba.first )
+        {
+          iPoint++;
+          currentLength += QgsGeometryUtilsBase::distance2D( points.at( iPoint ), points.at( iPoint - 1 ) );
+        }
+
+        if ( iPoint == points.count() )
+          break;
+
+        int startIndex = iPoint;
+        Line l( points.at( iPoint ), points.at( iPoint - 1 ) );
+        QPointF startPt = points.at( iPoint ) + l.diffForInterval( currentLength - ba.first );
+
+        while ( iPoint < points.count() - 1 && currentLength < ba.second )
+        {
+          iPoint++;
+          currentLength += QgsGeometryUtilsBase::distance2D( points.at( iPoint ), points.at( iPoint - 1 ) );
+        }
+
+        if ( iPoint == points.count() )
+          break;
+
+        int endIndex = iPoint;
+        Line l2( points.at( iPoint ), points.at( iPoint - 1 ) );
+        QPointF endPt = points.at( iPoint ) + l2.diffForInterval( currentLength - ba.second );
+
+        mBlankSegments.emplace_back( new BlankSegment( iPart, iRing, startIndex, endIndex, startPt, endPt, canvas(), mPoints ) );
+      }
+    }
+  }
+}
+
+QgsMapToolEditBlankSegmentsBase::BlankSegment::BlankSegment( QgsMapCanvas *canvas, const FeaturePoints &points )
+  : QgsRubberBand( canvas )
+  , mPoints( points )
+{
+  setHighlighted( false );
+  setColor( QgsSettingsRegistryCore::settingsDigitizingLineColor->value() );
+}
+
+QgsMapToolEditBlankSegmentsBase::BlankSegment::BlankSegment( int partIndex, int ringIndex, int startIndex, int endIndex, QPointF startPt, QPointF endPt, QgsMapCanvas *canvas, const FeaturePoints &points )
+  : BlankSegment( canvas, points )
+{
+  setPoints( partIndex, ringIndex, startIndex, endIndex, startPt, endPt );
+}
+
+void QgsMapToolEditBlankSegmentsBase::BlankSegment::setPoints( int partIndex, int ringIndex, int startIndex, int endIndex, QPointF startPt, QPointF endPt )
+{
+  mPartIndex = partIndex;
+  mRingIndex = ringIndex;
+  mStartIndex = startIndex;
+  mEndIndex = endIndex;
+  mStartPt = startPt;
+  mEndPt = endPt;
+
+  mNeedSwap = false;
+  if ( mStartIndex == mEndIndex )
+  {
+    try
+    {
+      if ( const QPointF &startIndexPoint = ::pointAt( mPoints, mPartIndex, mRingIndex, mStartIndex );
+           QgsGeometryUtilsBase::distance2D( startPt, startIndexPoint ) < QgsGeometryUtilsBase::distance2D( endPt, startIndexPoint ) )
+      {
+        mNeedSwap = true;
+      }
+    }
+    catch ( std::invalid_argument e )
+    {
+      QgsDebugError( e.what() );
+    }
+  }
+  else if ( mStartIndex > mEndIndex )
+  {
+    mNeedSwap = true;
+  }
+
+  updatePoints();
+}
+
+void QgsMapToolEditBlankSegmentsBase::BlankSegment::updatePoints()
+{
+  const QgsMapToPixel &m2p = *( mMapCanvas->getCoordinateTransform() );
+
+  reset();
+  for ( int iPoint = 0; iPoint < pointsCount(); iPoint++ )
+  {
+    try
+    {
+      const QPointF &point = pointAt( iPoint );
+      const QgsPointXY mapPoint = m2p.toMapCoordinates( point.x(), point.y() );
+      addPoint( mapPoint, iPoint == pointsCount() - 1 ); // update only last one
+    }
+    catch ( std::invalid_argument e )
+    {
+      QgsDebugError( e.what() );
+    }
+  }
+}
+
+
+void QgsMapToolEditBlankSegmentsBase::BlankSegment::copyFrom( const BlankSegment &blankSegment )
+{
+  setPoints( blankSegment.mPartIndex, blankSegment.mRingIndex, blankSegment.getStartIndex(), blankSegment.getEndIndex(), blankSegment.getStartPoint(), blankSegment.getEndPoint() );
+}
+
+void QgsMapToolEditBlankSegmentsBase::BlankSegment::setHighlighted( bool highlighted )
+{
+  setWidth( QgsGuiUtils::scaleIconSize( highlighted ? 4 : 2 ) );
+  update();
+}
+
+
+const QPointF &QgsMapToolEditBlankSegmentsBase::BlankSegment::getStartPoint() const
+{
+  return mStartPt;
+}
+
+const QPointF &QgsMapToolEditBlankSegmentsBase::BlankSegment::getEndPoint() const
+{
+  return mEndPt;
+}
+
+int QgsMapToolEditBlankSegmentsBase::BlankSegment::getStartIndex() const
+{
+  return mStartIndex;
+}
+
+int QgsMapToolEditBlankSegmentsBase::BlankSegment::getEndIndex() const
+{
+  return mEndIndex;
+}
+
+int QgsMapToolEditBlankSegmentsBase::BlankSegment::getPartIndex() const
+{
+  return mPartIndex;
+}
+
+int QgsMapToolEditBlankSegmentsBase::BlankSegment::getRingIndex() const
+{
+  return mRingIndex;
+}
+
+int QgsMapToolEditBlankSegmentsBase::BlankSegment::pointsCount() const
+{
+  return std::abs( mEndIndex - mStartIndex ) + 2;
+}
+
+const QPointF &QgsMapToolEditBlankSegmentsBase::BlankSegment::pointAt( int index ) const
+{
+  return index == 0 ?
+                    // first point
+           ( mNeedSwap ? mEndPt : mStartPt )
+                    // last point
+                    : ( index == pointsCount() - 1 ? ( mNeedSwap ? mStartPt : mEndPt )
+                                                   // point in between
+                                                   : ::pointAt( mPoints, mPartIndex, mRingIndex, ( mNeedSwap ? mEndIndex : mStartIndex ) + index - 1 ) );
+}

--- a/src/gui/maptools/qgsmaptooleditblanksegments.cpp
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.cpp
@@ -52,7 +52,7 @@ namespace
   {
     public:
       /**
-       * Contructor
+       * Constructor
        * \param symbolLayerId symbol layer id to search
        */
       SymbolLayerFinder( const QString &symbolLayerId )

--- a/src/gui/maptools/qgsmaptooleditblanksegments.cpp
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.cpp
@@ -16,6 +16,7 @@
 #include "qgscoordinatetransform.h"
 #include "qgsfeatureid.h"
 #include "qgsmaptooleditblanksegments.h"
+#include "moc_qgsmaptooleditblanksegments.cpp"
 
 #include "line_p.h"
 #include "qgsmapcanvas.h"

--- a/src/gui/maptools/qgsmaptooleditblanksegments.cpp
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.cpp
@@ -198,7 +198,9 @@ namespace
 
 
 /**
- * Rubber band used to draw blank segments on edition
+ * \ingroup gui
+ * \brief Rubber band used to draw blank segments on edition
+ * \since QGIS 4.0
  */
 class QgsMapToolEditBlankSegmentsBase::BlankSegmentRubberBand : public QgsRubberBand
 {

--- a/src/gui/maptools/qgsmaptooleditblanksegments.h
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.h
@@ -67,7 +67,7 @@ class GUI_EXPORT QgsMapToolEditBlankSegmentsBase : public QgsMapTool
     /**
      * Destructor
      */
-    ~QgsMapToolEditBlankSegmentsBase();
+    ~QgsMapToolEditBlankSegmentsBase() override;
 
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
     void canvasPressEvent( QgsMapMouseEvent *e ) override;
@@ -111,6 +111,7 @@ class GUI_EXPORT QgsMapToolEditBlankSegmentsBase : public QgsMapTool
 
     /**
      * Returns rendered point closest to \a point
+     * \param point point we want to be the closest to
      * \param distance updated with the distance between \a point and the returned rendered point
      * \param partIndex will be set to the geometry part index of the returned point
      * \param ringIndex will be set to the geometry ring index of the returned point

--- a/src/gui/maptools/qgsmaptooleditblanksegments.h
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.h
@@ -39,9 +39,7 @@ class QgsSymbolLayer;
  * This tool allows to:
  *
  * - Click in the neighborhood of the rendered line to start creating a blank segment, click again to
- *
- * finish editing the segment.
- *
+ *   finish editing the segment.
  * - Select a blank segment, press Del key to remove it
  * - Drag the start/end of an already existing blank segment and move it along the line to
  *
@@ -136,7 +134,9 @@ class GUI_EXPORT QgsMapToolEditBlankSegmentsBase : public QgsMapTool
     void setCurrentBlankSegment( int currentBlankSegmentIndex );
 
     /**
-     * Rubber band used to draw blank segments on edition
+     * \ingroup gui
+     * \brief Rubber band used to draw blank segments on edition
+     * \since QGIS 4.0
      */
     class BlankSegmentRubberBand;
 

--- a/src/gui/maptools/qgsmaptooleditblanksegments.h
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.h
@@ -104,8 +104,8 @@ class GUI_EXPORT QgsMapToolEditBlankSegmentsBase : public QgsMapTool
 
     /**
      * Returns feature blank segment index closest to \a point, -1 if none could be found (there is
-     * no existing blank segments for instance).
-     * \param distance will be set to the distance between \a point and the returned blank segment
+     * no existing blank segments for instance). \a distance will be set to the distance between
+     * \a point and the returned blank segment
      */
     int getClosestBlankSegmentIndex( const QPointF &point, double &distance ) const;
 
@@ -120,7 +120,7 @@ class GUI_EXPORT QgsMapToolEditBlankSegmentsBase : public QgsMapTool
 
     /**
      * Update start and end rubber band (anchor points used to resize the blank segment rubber band)
-     * accoring to current map tool state and selected blank segment
+     * according to current map tool state and selected blank segment
      */
     void updateStartEndRubberBand();
 

--- a/src/gui/maptools/qgsmaptooleditblanksegments.h
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.h
@@ -151,7 +151,7 @@ class GUI_EXPORT QgsMapToolEditBlankSegmentsBase : public QgsMapTool
 
 /**
  * \ingroup gui
- * \brief This class specialize the map tool to edit blank segments given the targeted symbol
+ * \brief Specializes the map tool to edit blank segments given the targeted symbol
  * layer type (QgsMarkerLineSymbolLayer and QgsHashedLineSymbolLayer).
  * \since QGIS 4.0
 */
@@ -159,6 +159,13 @@ template<class T>
 class GUI_EXPORT QgsMapToolEditBlankSegments : public QgsMapToolEditBlankSegmentsBase
 {
   public:
+    /**
+     * Constructor
+     * \param canvas map canvas where the edit take place
+     * \param layer layer to be edited
+     * \param symbolLayer symbol layer affected by the blank segments
+     * \param blankSegmentFieldIndex index of the field containing the digitized blank segments
+     */
     QgsMapToolEditBlankSegments<T>( QgsMapCanvas *canvas, QgsVectorLayer *layer, QgsLineSymbolLayer *symbolLayer, int blankSegmentFieldIndex )
       : QgsMapToolEditBlankSegmentsBase( canvas, layer, symbolLayer, blankSegmentFieldIndex )
     {

--- a/src/gui/maptools/qgsmaptooleditblanksegments.h
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.h
@@ -1,0 +1,214 @@
+/***************************************************************************
+    qgsmaptooleditblanksegments.h
+    ---------------------
+    begin                : 2025/08/19
+    copyright            : (C) 2025 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLEDITBLANKSEGMENTS_H
+#define QGSMAPTOOLEDITBLANKSEGMENTS_H
+
+#define SIP_NO_FILE
+
+#include "qgsmaptool.h"
+#include "qgsmapcanvasitem.h"
+#include "qgsfeatureid.h"
+#include "qobjectuniqueptr.h"
+#include "qgslinesymbollayer.h"
+#include "qgssymbol.h"
+#include "qgsrubberband.h"
+
+class QgsMapToolBlankSegmentRubberBand;
+class QgsVectorLayer;
+class QgsSymbol;
+class QgsSymbolLayer;
+
+/**
+ * \ingroup gui
+ * \brief Map tool base class to edit blank segments. Digitized blank segments are stored per feature
+ * inside a field as a string ( \see QgsBlankSegmentUtils::parseBlankSegments for string format)
+ * \see QgsMapToolEditBlankSegments
+ * \since QGIS 4.0
+*/
+class GUI_EXPORT QgsMapToolEditBlankSegmentsBase : public QgsMapTool
+{
+    Q_OBJECT
+
+  public:
+    /**
+     * Constructor
+     * \param canvas map canvas where the edit take place
+     * \param layer layer to be edited
+     * \param symbolLayer symbol layer affected by the blank segments
+     * \param blankSegmentFieldIndex index of the field containing the digitized blank segments
+     */
+    QgsMapToolEditBlankSegmentsBase( QgsMapCanvas *canvas, QgsVectorLayer *layer, QgsLineSymbolLayer *symbolLayer, int blankSegmentFieldIndex );
+
+    /**
+     * Destructor
+     */
+    ~QgsMapToolEditBlankSegmentsBase();
+
+    void canvasMoveEvent( QgsMapMouseEvent *e ) override;
+    void canvasPressEvent( QgsMapMouseEvent *e ) override;
+    void keyPressEvent( QKeyEvent *e ) override;
+
+    void activate() override;
+
+  protected:
+    typedef QList<QList<QPolygonF>> FeaturePoints;
+    FeaturePoints mPoints;
+
+  private:
+    // compute and return current blank segment start and end distance
+    QPair<double, double> getStartEndDistance() const;
+    void updateAttribute();
+    void loadFeaturePoints();
+
+    virtual QgsTemplatedLineSymbolLayerBase *createRenderedPointsSymbolLayer( const QgsTemplatedLineSymbolLayerBase *original ) = 0;
+
+    int getClosestBlankSegmentIndex( const QPointF &point, double &distance ) const;
+    QPointF getClosestPoint( const QPointF &point, double &distance, int &partIndex, int &ringIndex, int &pointIndex ) const;
+
+    void updateStartEndRubberBand();
+    void updateHoveredBlankSegment( const QPoint &pos );
+    void setCurrentBlankSegment( int currentBlankSegmentIndex );
+
+    class BlankSegment : public QgsRubberBand
+    {
+      public:
+        BlankSegment( int partIndex, int ringIndex, int startIndex, int endIndex, QPointF startPt, QPointF endPt, QgsMapCanvas *canvas, const FeaturePoints &points );
+        BlankSegment( QgsMapCanvas *canvas, const FeaturePoints &points );
+
+        void setPoints( int partIndex, int ringIndex, int startIndex, int endIndex, QPointF startPt, QPointF endPt );
+        void copyFrom( const BlankSegment &blankSegment );
+        void setHighlighted( bool highlighted );
+
+        const QPointF &getStartPoint() const;
+        const QPointF &getEndPoint() const;
+        int getStartIndex() const;
+        int getEndIndex() const;
+        int getPartIndex() const;
+        int getRingIndex() const;
+
+        QPair<double, double> getStartEndDistance( Qgis::RenderUnit unit ) const;
+
+        int pointsCount() const;
+        const QPointF &pointAt( int index ) const;
+
+      private:
+        void updatePoints();
+
+        int mPartIndex = -1;
+        int mRingIndex = -1;
+        int mStartIndex = -1;
+        int mEndIndex = -1;
+        QPointF mStartPt;
+        QPointF mEndPt;
+        bool mNeedSwap = false;
+        const FeaturePoints &mPoints; //! all feature rendered points
+    };
+
+    enum State
+    {
+      SELECT_FEATURE,
+      FEATURE_SELECTED,
+      BLANK_SEGMENT_SELECTED,
+      BLANK_SEGMENT_MODIFICATION_STARTED,
+      BLANK_SEGMENT_CREATION_STARTED
+    };
+
+    std::vector<QObjectUniquePtr<BlankSegment>> mBlankSegments;
+    QgsVectorLayer *mLayer = nullptr;
+    std::unique_ptr<QgsSymbol> mSymbol;
+    const QString mSymbolLayerId;
+    QgsTemplatedLineSymbolLayerBase *mSymbolLayer = nullptr;
+
+    int mBlankSegmentsFieldIndex = -1;
+    QgsFeatureId mCurrentFeatureId = FID_NULL;
+    QgsRectangle mExtent;
+    State mState = State::SELECT_FEATURE;
+    int mCurrentBlankSegmentIndex = -1;
+    int mHoveredBlankSegmentIndex = -1;
+
+    // currently edited blank segment, start point is the fixed point and end point is the currently
+    // modified one
+    QObjectUniquePtr<BlankSegment> mEditedBlankSegment;
+    QObjectUniquePtr<QgsRubberBand> mStartRubberBand;
+    QObjectUniquePtr<QgsRubberBand> mEndRubberBand;
+
+
+    friend class TestQgsMapToolEditBlankSegments;
+};
+
+/**
+ * \ingroup gui
+ * \brief This class specialize the map tool to edit blank segments given the targeted symbol
+ * layer type (QgsMarkerLineSymbolLayer and QgsHashedLineSymbolLayer).
+ * \since QGIS 4.0
+*/
+template<class T>
+class GUI_EXPORT QgsMapToolEditBlankSegments : public QgsMapToolEditBlankSegmentsBase
+{
+  public:
+    QgsMapToolEditBlankSegments<T>( QgsMapCanvas *canvas, QgsVectorLayer *layer, QgsLineSymbolLayer *symbolLayer, int blankSegmentFieldIndex )
+      : QgsMapToolEditBlankSegmentsBase( canvas, layer, symbolLayer, blankSegmentFieldIndex )
+    {
+    }
+
+    QgsTemplatedLineSymbolLayerBase *createRenderedPointsSymbolLayer( const QgsTemplatedLineSymbolLayerBase *originalSl ) override
+    {
+      const T *sl = dynamic_cast<const T *>( originalSl );
+      return sl ? new QgsRenderedPointsSymbolLayer( sl, mPoints ) : nullptr;
+    }
+
+  private:
+    /**
+     * Helper class to retrieve the rendered points from symbol layer. It extends the original
+     * template type (either QgsMarkerLineSymbolLayer or QgsHashedLineSymbolLayer)
+     */
+    class QgsRenderedPointsSymbolLayer : public T
+    {
+      public:
+        /**
+         * Construct symbol layer based on the \a original symbol layer. \a points will be updated with
+         * the generated rendered points
+         */
+        QgsRenderedPointsSymbolLayer( const T *original, FeaturePoints &points )
+          : T( original->rotateSymbols(), original->interval() )
+          , mPoints( points )
+        {
+          original->copyTemplateSymbolProperties( this );
+        }
+
+        void renderPolyline( const QPolygonF &points, QgsSymbolRenderContext &context ) override
+        {
+          const int iPart = context.geometryPartNum() - 1;
+          if ( iPart < 0 || QgsRenderedPointsSymbolLayer::mRingIndex < 0 )
+            return;
+
+          if ( iPart >= mPoints.count() )
+            mPoints.resize( iPart + 1 );
+
+          QVector<QPolygonF> &rings = mPoints[iPart];
+          if ( QgsRenderedPointsSymbolLayer::mRingIndex >= rings.count() )
+            rings.resize( QgsRenderedPointsSymbolLayer::mRingIndex + 1 );
+
+          rings[QgsRenderedPointsSymbolLayer::mRingIndex] = points;
+        }
+
+      private:
+        FeaturePoints &mPoints;
+    };
+};
+
+
+#endif

--- a/src/gui/maptools/qgsmaptooleditblanksegments.h
+++ b/src/gui/maptools/qgsmaptooleditblanksegments.h
@@ -18,13 +18,13 @@
 
 #define SIP_NO_FILE
 
-#include "qgsmaptool.h"
-#include "qgsmapcanvasitem.h"
 #include "qgsfeatureid.h"
-#include "qobjectuniqueptr.h"
 #include "qgslinesymbollayer.h"
-#include "qgssymbol.h"
+#include "qgsmapcanvasitem.h"
+#include "qgsmaptool.h"
 #include "qgsrubberband.h"
+#include "qgssymbol.h"
+#include "qobjectuniqueptr.h"
 
 class QgsMapToolBlankSegmentRubberBand;
 class QgsVectorLayer;
@@ -82,40 +82,7 @@ class GUI_EXPORT QgsMapToolEditBlankSegmentsBase : public QgsMapTool
     void updateHoveredBlankSegment( const QPoint &pos );
     void setCurrentBlankSegment( int currentBlankSegmentIndex );
 
-    class BlankSegment : public QgsRubberBand
-    {
-      public:
-        BlankSegment( int partIndex, int ringIndex, int startIndex, int endIndex, QPointF startPt, QPointF endPt, QgsMapCanvas *canvas, const FeaturePoints &points );
-        BlankSegment( QgsMapCanvas *canvas, const FeaturePoints &points );
-
-        void setPoints( int partIndex, int ringIndex, int startIndex, int endIndex, QPointF startPt, QPointF endPt );
-        void copyFrom( const BlankSegment &blankSegment );
-        void setHighlighted( bool highlighted );
-
-        const QPointF &getStartPoint() const;
-        const QPointF &getEndPoint() const;
-        int getStartIndex() const;
-        int getEndIndex() const;
-        int getPartIndex() const;
-        int getRingIndex() const;
-
-        QPair<double, double> getStartEndDistance( Qgis::RenderUnit unit ) const;
-
-        int pointsCount() const;
-        const QPointF &pointAt( int index ) const;
-
-      private:
-        void updatePoints();
-
-        int mPartIndex = -1;
-        int mRingIndex = -1;
-        int mStartIndex = -1;
-        int mEndIndex = -1;
-        QPointF mStartPt;
-        QPointF mEndPt;
-        bool mNeedSwap = false;
-        const FeaturePoints &mPoints; //! all feature rendered points
-    };
+    class BlankSegmentRubberBand;
 
     enum State
     {
@@ -126,7 +93,7 @@ class GUI_EXPORT QgsMapToolEditBlankSegmentsBase : public QgsMapTool
       BLANK_SEGMENT_CREATION_STARTED
     };
 
-    std::vector<QObjectUniquePtr<BlankSegment>> mBlankSegments;
+    std::vector<QObjectUniquePtr<BlankSegmentRubberBand>> mBlankSegments;
     QgsVectorLayer *mLayer = nullptr;
     std::unique_ptr<QgsSymbol> mSymbol;
     const QString mSymbolLayerId;
@@ -141,7 +108,7 @@ class GUI_EXPORT QgsMapToolEditBlankSegmentsBase : public QgsMapTool
 
     // currently edited blank segment, start point is the fixed point and end point is the currently
     // modified one
-    QObjectUniquePtr<BlankSegment> mEditedBlankSegment;
+    QObjectUniquePtr<BlankSegmentRubberBand> mEditedBlankSegment;
     QObjectUniquePtr<QgsRubberBand> mStartRubberBand;
     QObjectUniquePtr<QgsRubberBand> mEndRubberBand;
 

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -14,7 +14,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgspropertyoverridebutton.h"
 #include "qgssymbollayerwidget.h"
 
 #include "characterwidget.h"
@@ -34,17 +33,18 @@
 #include "qgslinesymbol.h"
 #include "qgslinesymbollayer.h"
 #include "qgsmapcanvas.h"
+#include "qgsmaptooleditblanksegments.h"
 #include "qgsmarkersymbol.h"
 #include "qgsmarkersymbollayer.h"
 #include "qgsnewauxiliaryfielddialog.h"
 #include "qgsnewauxiliarylayerdialog.h"
 #include "qgsnumericformatselectorwidget.h"
 #include "qgsproperty.h"
+#include "qgspropertyoverridebutton.h"
 #include "qgssvgcache.h"
 #include "qgssvgselectorwidget.h"
 #include "qgssymbollayerutils.h"
 #include "qgsvectorlayer.h"
-#include "qgsmaptooleditblanksegments.h"
 
 #include <QAbstractButton>
 #include <QAction>
@@ -1893,12 +1893,14 @@ QgsTemplatedLineSymbolLayerWidget::QgsTemplatedLineSymbolLayerWidget( TemplatedS
   connect( mOffsetAlongLineUnitWidget, &QgsUnitSelectionWidget::changed, this, &QgsTemplatedLineSymbolLayerWidget::mOffsetAlongLineUnitWidget_changed );
   connect( mAverageAngleUnit, &QgsUnitSelectionWidget::changed, this, &QgsTemplatedLineSymbolLayerWidget::averageAngleUnitChanged );
   connect( mBlankSegmentsUnitWidget, &QgsUnitSelectionWidget::changed, this, &QgsTemplatedLineSymbolLayerWidget::blankSegmentsUnitChanged );
-  mIntervalUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << Qgis::RenderUnit::Millimeters << Qgis::RenderUnit::MetersInMapUnits << Qgis::RenderUnit::MapUnits << Qgis::RenderUnit::Pixels << Qgis::RenderUnit::Points << Qgis::RenderUnit::Inches );
-  mOffsetUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << Qgis::RenderUnit::Millimeters << Qgis::RenderUnit::MetersInMapUnits << Qgis::RenderUnit::MapUnits << Qgis::RenderUnit::Pixels << Qgis::RenderUnit::Points << Qgis::RenderUnit::Inches );
-  mOffsetAlongLineUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << Qgis::RenderUnit::Millimeters << Qgis::RenderUnit::MetersInMapUnits << Qgis::RenderUnit::MapUnits << Qgis::RenderUnit::Pixels << Qgis::RenderUnit::Points << Qgis::RenderUnit::Inches << Qgis::RenderUnit::Percentage );
-  mAverageAngleUnit->setUnits( QgsUnitTypes::RenderUnitList() << Qgis::RenderUnit::Millimeters << Qgis::RenderUnit::MetersInMapUnits << Qgis::RenderUnit::MapUnits << Qgis::RenderUnit::Pixels << Qgis::RenderUnit::Points << Qgis::RenderUnit::Inches );
-  mIntervalUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << Qgis::RenderUnit::Millimeters << Qgis::RenderUnit::MetersInMapUnits << Qgis::RenderUnit::MapUnits << Qgis::RenderUnit::Pixels << Qgis::RenderUnit::Points << Qgis::RenderUnit::Inches );
-  mBlankSegmentsUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << Qgis::RenderUnit::Millimeters << Qgis::RenderUnit::MetersInMapUnits << Qgis::RenderUnit::MapUnits << Qgis::RenderUnit::Pixels << Qgis::RenderUnit::Points << Qgis::RenderUnit::Inches );
+
+  const QgsUnitTypes::RenderUnitList units = { Qgis::RenderUnit::Millimeters, Qgis::RenderUnit::MetersInMapUnits, Qgis::RenderUnit::MapUnits, Qgis::RenderUnit::Pixels, Qgis::RenderUnit::Points, Qgis::RenderUnit::Inches };
+  mIntervalUnitWidget->setUnits( units );
+  mOffsetUnitWidget->setUnits( units );
+  mOffsetAlongLineUnitWidget->setUnits( QgsUnitTypes::RenderUnitList( units ) << Qgis::RenderUnit::Percentage );
+  mAverageAngleUnit->setUnits( units );
+  mIntervalUnitWidget->setUnits( units );
+  mBlankSegmentsUnitWidget->setUnits( units );
 
   mRingFilterComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "mIconAllRings.svg" ) ), tr( "All Rings" ), QgsLineSymbolLayer::AllRings );
   mRingFilterComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "mIconExteriorRing.svg" ) ), tr( "Exterior Ring Only" ), QgsLineSymbolLayer::ExteriorRingOnly );

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -1916,6 +1916,8 @@ QgsTemplatedLineSymbolLayerWidget::QgsTemplatedLineSymbolLayerWidget( TemplatedS
   mHashRotationSpinBox->setClearValue( 0 );
   mSpinAverageAngleLength->setClearValue( 4.0 );
 
+  mBlankSegmentsGrpBox->setCollapsed( true );
+
   connect( spinInterval, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsTemplatedLineSymbolLayerWidget::setInterval );
   connect( mSpinOffsetAlongLine, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsTemplatedLineSymbolLayerWidget::setOffsetAlongLine );
   connect( mSpinHashLength, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsTemplatedLineSymbolLayerWidget::setHashLength );

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -1916,8 +1916,6 @@ QgsTemplatedLineSymbolLayerWidget::QgsTemplatedLineSymbolLayerWidget( TemplatedS
   mHashRotationSpinBox->setClearValue( 0 );
   mSpinAverageAngleLength->setClearValue( 4.0 );
 
-  mBlankSegmentsGrpBox->setCollapsed( true );
-
   connect( spinInterval, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsTemplatedLineSymbolLayerWidget::setInterval );
   connect( mSpinOffsetAlongLine, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsTemplatedLineSymbolLayerWidget::setOffsetAlongLine );
   connect( mSpinHashLength, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsTemplatedLineSymbolLayerWidget::setHashLength );

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -2292,7 +2292,18 @@ void QgsTemplatedLineSymbolLayerWidget::toggleMapToolEditBlankSegments( bool tog
 void QgsTemplatedLineSymbolLayerWidget::updateBlankSegmentsWidget()
 {
   mEditBlankSegmentsBtn->setEnabled( blankSegmentsFieldIndex() > -1 );
-  QString tooltip = tr( "Tool to create blank segments where marker lines won't be displayed" );
+  QString tooltip;
+  switch ( mSymbolType )
+  {
+    case TemplatedSymbolType::Hash:
+      tooltip = tr( "Tool to create blank segments where hashed lines won't be displayed" );
+      break;
+
+    case TemplatedSymbolType::Marker:
+      tooltip = tr( "Tool to create blank segments where marker lines won't be displayed" );
+      break;
+  }
+
   if ( !mEditBlankSegmentsBtn->isEnabled() )
   {
     tooltip += QStringLiteral( "<br/><br/>" ) + tr( "This tool is disabled because no valid field property has been set" );

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -2276,6 +2276,7 @@ void QgsTemplatedLineSymbolLayerWidget::toggleMapToolEditBlankSegments( bool tog
   {
     switch ( mSymbolType )
     {
+      // NOLINTBEGIN(bugprone-branch-clone)
       case TemplatedSymbolType::Hash:
         mMapToolEditBlankSegments.reset( new QgsMapToolEditBlankSegments<QgsHashedLineSymbolLayer>( context().mapCanvas(), vectorLayer(), mLayer, blankSegmentsFieldIndex() ) );
         break;
@@ -2283,6 +2284,7 @@ void QgsTemplatedLineSymbolLayerWidget::toggleMapToolEditBlankSegments( bool tog
       case TemplatedSymbolType::Marker:
         mMapToolEditBlankSegments.reset( new QgsMapToolEditBlankSegments<QgsMarkerLineSymbolLayer>( context().mapCanvas(), vectorLayer(), mLayer, blankSegmentsFieldIndex() ) );
         break;
+        // NOLINTEND(bugprone-branch-clone)
     }
 
     context().mapCanvas()->setMapTool( mMapToolEditBlankSegments );

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -21,6 +21,7 @@
 #include "qgspropertyoverridebutton.h"
 #include "qgssymbollayer.h"
 #include "qgssymbolwidgetcontext.h"
+#include "qobjectuniqueptr.h"
 
 #include <QStandardItemModel>
 #include <QWidget>
@@ -28,6 +29,9 @@
 class QgsVectorLayer;
 class QgsMarkerSymbol;
 class QgsLineSymbol;
+
+template<class T>
+class GUI_EXPORT QgsMapToolEditBlankSegments;
 
 /**
  * \ingroup gui
@@ -68,7 +72,7 @@ class GUI_EXPORT QgsSymbolLayerWidget : public QWidget, protected QgsExpressionC
     /**
      * Returns the vector layer associated with the widget.
      */
-    const QgsVectorLayer *vectorLayer() const { return mVectorLayer; }
+    QgsVectorLayer *vectorLayer() const { return mVectorLayer; }
 
   protected:
     /**
@@ -450,6 +454,7 @@ class GUI_EXPORT QgsShapeburstFillSymbolLayerWidget : public QgsSymbolLayerWidge
 #include "ui_widget_templatedline.h"
 
 class QgsTemplatedLineSymbolLayerBase;
+class QgsMapToolEditBlankSegmentsBase;
 
 /**
  * \ingroup gui
@@ -510,11 +515,19 @@ class GUI_EXPORT QgsTemplatedLineSymbolLayerWidget : public QgsSymbolLayerWidget
     void mOffsetAlongLineUnitWidget_changed();
     void hashLengthUnitWidgetChanged();
     void averageAngleUnitChanged();
+    void blankSegmentsUnitChanged();
     void setAverageAngle( double val );
+    void toggleMapToolEditBlankSegments( bool toggled );
+
+    void updateBlankSegmentsWidget();
 
   private:
+    // Returns blank segments field index, -1 if no dd property field has been set
+    int blankSegmentsFieldIndex() const;
+
     QgsTemplatedLineSymbolLayerBase *mLayer = nullptr;
     TemplatedSymbolType mSymbolType = TemplatedSymbolType::Hash;
+    QObjectUniquePtr<QgsMapToolEditBlankSegmentsBase> mMapToolEditBlankSegments;
 };
 
 /**

--- a/src/ui/symbollayer/widget_templatedline.ui
+++ b/src/ui/symbollayer/widget_templatedline.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>385</width>
-    <height>535</height>
+    <height>678</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,13 +23,6 @@
    <property name="bottomMargin">
     <number>1</number>
    </property>
-   <item row="0" column="0">
-    <widget class="QLabel" name="mPlacementLabel">
-     <property name="text">
-      <string>Hash placement</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0" colspan="3">
     <layout class="QGridLayout" name="gridLayout_3">
      <property name="leftMargin">
@@ -162,39 +155,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="1">
-    <widget class="QgsPropertyOverrideButton" name="mPlacementDDBtn">
-     <property name="text">
-      <string>…</string>
-     </property>
-    </widget>
    </item>
    <item row="2" column="0" colspan="3">
     <layout class="QGridLayout" name="gridLayout">
@@ -487,6 +447,106 @@
      </item>
     </layout>
    </item>
+   <item row="3" column="0" colspan="3">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Blank segments</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_7">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QToolButton" name="mEditBlankSegmentsBtn">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionRemoveAllFromOverview.svg</normaloff>:/images/themes/default/mActionRemoveAllFromOverview.svg</iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsUnitSelectionWidget" name="mBlankSegmentsUnitWidget" native="true">
+          <property name="minimumSize">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::TabFocus</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsPropertyOverrideButton" name="mBlankSegmentsDDButton">
+          <property name="text">
+           <string>…</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsPropertyOverrideButton" name="mPlacementDDBtn">
+     <property name="text">
+      <string>…</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mPlacementLabel">
+     <property name="text">
+      <string>Hash placement</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -537,6 +597,8 @@
   <tabstop>mLineOffsetDDBtn</tabstop>
   <tabstop>mRingFilterComboBox</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/ui/symbollayer/widget_templatedline.ui
+++ b/src/ui/symbollayer/widget_templatedline.ui
@@ -23,6 +23,400 @@
    <property name="bottomMargin">
     <number>1</number>
    </property>
+   <item row="3" column="0" colspan="3">
+    <widget class="QgsCollapsibleGroupBox" name="mBlankSegmentsGrpBox">
+     <property name="title">
+      <string>Blank Segments</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <widget class="QToolButton" name="mEditBlankSegmentsBtn">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionShowAllLayers.svg</normaloff>:/images/themes/default/mActionShowAllLayers.svg</iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsUnitSelectionWidget" name="mBlankSegmentsUnitWidget" native="true">
+          <property name="minimumSize">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::TabFocus</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsPropertyOverrideButton" name="mBlankSegmentsDDButton">
+          <property name="text">
+           <string>…</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsPropertyOverrideButton" name="mPlacementDDBtn">
+     <property name="text">
+      <string>…</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mPlacementLabel">
+     <property name="text">
+      <string>Hash placement</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item row="3" column="4">
+      <widget class="QgsPropertyOverrideButton" name="mHashRotationDDBtn">
+       <property name="text">
+        <string>…</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="3">
+      <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="2" colspan="3">
+      <widget class="QComboBox" name="mRingFilterComboBox"/>
+     </item>
+     <item row="4" column="0" colspan="5">
+      <widget class="QCheckBox" name="chkRotateMarker">
+       <property name="text">
+        <string>Rotate hash to follow line direction</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Average angle over</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QgsDoubleSpinBox" name="mSpinHashLength">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="maximum">
+        <double>10000000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0" colspan="2">
+      <widget class="QLabel" name="mHashLengthLabel">
+       <property name="text">
+        <string>Hash length</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QgsDoubleSpinBox" name="mSpinAverageAngleLength">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="maximum">
+        <double>10000000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="5" column="4">
+      <widget class="QgsPropertyOverrideButton" name="mAverageAngleDDBtn">
+       <property name="text">
+        <string>…</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="QgsUnitSelectionWidget" name="mHashLengthUnitWidget" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="QgsPropertyOverrideButton" name="mOffsetAlongLineDDBtn">
+       <property name="text">
+        <string>…</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0" colspan="5">
+      <widget class="QCheckBox" name="mCheckPlaceOnEveryPart">
+       <property name="toolTip">
+        <string>If checked, the &quot;first vertex&quot; or &quot;last vertex&quot; placements will also render at the first and last vertex for every part of multipart geometries</string>
+       </property>
+       <property name="text">
+        <string>Place on every part extremity</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0" colspan="2">
+      <widget class="QLabel" name="mRingsLabel">
+       <property name="text">
+        <string>Rings</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="QgsDoubleSpinBox" name="spinOffset">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="minimum">
+        <double>-999999999.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>999999999.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QgsDoubleSpinBox" name="mHashRotationSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="wrapping">
+        <bool>true</bool>
+       </property>
+       <property name="suffix">
+        <string> °</string>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="minimum">
+        <double>-360.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.500000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="4">
+      <widget class="QgsPropertyOverrideButton" name="mLineOffsetDDBtn">
+       <property name="text">
+        <string>…</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QgsUnitSelectionWidget" name="mOffsetAlongLineUnitWidget" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QgsDoubleSpinBox" name="mSpinOffsetAlongLine">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="minimum">
+        <double>-10000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>10000000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0" colspan="2">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Line offset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="QLabel" name="mHashRotationLabel">
+       <property name="text">
+        <string>Hash rotation</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Offset along line</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="3">
+      <widget class="QgsUnitSelectionWidget" name="mAverageAngleUnit" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="4">
+      <widget class="QgsPropertyOverrideButton" name="mHashLengthDDBtn">
+       <property name="text">
+        <string>…</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="1" column="0" colspan="3">
     <layout class="QGridLayout" name="gridLayout_3">
      <property name="leftMargin">
@@ -156,400 +550,15 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="0" colspan="3">
-    <layout class="QGridLayout" name="gridLayout">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item row="5" column="0">
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="2" column="0" colspan="2">
-      <widget class="QLabel" name="mHashLengthLabel">
-       <property name="text">
-        <string>Hash length</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0" colspan="2">
-      <widget class="QLabel" name="mHashRotationLabel">
-       <property name="text">
-        <string>Hash rotation</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="2">
-      <widget class="QgsDoubleSpinBox" name="mSpinAverageAngleLength">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>10000000.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.200000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="4">
-      <widget class="QgsPropertyOverrideButton" name="mHashLengthDDBtn">
-       <property name="text">
-        <string>…</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="3">
-      <widget class="QgsUnitSelectionWidget" name="mHashLengthUnitWidget" native="true">
-       <property name="minimumSize">
-        <size>
-         <width>20</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="focusPolicy">
-        <enum>Qt::TabFocus</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="4">
-      <widget class="QgsPropertyOverrideButton" name="mOffsetAlongLineDDBtn">
-       <property name="text">
-        <string>…</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QgsDoubleSpinBox" name="mSpinOffsetAlongLine">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="minimum">
-        <double>-10000000.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>10000000.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.200000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QgsDoubleSpinBox" name="mSpinHashLength">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="maximum">
-        <double>10000000.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.200000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="4">
-      <widget class="QgsPropertyOverrideButton" name="mHashRotationDDBtn">
-       <property name="text">
-        <string>…</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="2" colspan="3">
-      <widget class="QComboBox" name="mRingFilterComboBox"/>
-     </item>
-     <item row="3" column="2">
-      <widget class="QgsDoubleSpinBox" name="mHashRotationSpinBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="wrapping">
-        <bool>true</bool>
-       </property>
-       <property name="suffix">
-        <string> °</string>
-       </property>
-       <property name="decimals">
-        <number>2</number>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0" colspan="2">
-      <widget class="QLabel" name="mRingsLabel">
-       <property name="text">
-        <string>Rings</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0" colspan="2">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Line offset</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0" colspan="5">
-      <widget class="QCheckBox" name="chkRotateMarker">
-       <property name="text">
-        <string>Rotate hash to follow line direction</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="4">
-      <widget class="QgsPropertyOverrideButton" name="mLineOffsetDDBtn">
-       <property name="text">
-        <string>…</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Average angle over</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="3">
-      <widget class="QgsUnitSelectionWidget" name="mOffsetUnitWidget" native="true">
-       <property name="minimumSize">
-        <size>
-         <width>20</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="focusPolicy">
-        <enum>Qt::TabFocus</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="4">
-      <widget class="QgsPropertyOverrideButton" name="mAverageAngleDDBtn">
-       <property name="text">
-        <string>…</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="2">
-      <widget class="QgsDoubleSpinBox" name="spinOffset">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="decimals">
-        <number>6</number>
-       </property>
-       <property name="minimum">
-        <double>-999999999.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>999999999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.200000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0" colspan="2">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Offset along line</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="3">
-      <widget class="QgsUnitSelectionWidget" name="mOffsetAlongLineUnitWidget" native="true">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="focusPolicy">
-        <enum>Qt::TabFocus</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="3">
-      <widget class="QgsUnitSelectionWidget" name="mAverageAngleUnit" native="true">
-       <property name="minimumSize">
-        <size>
-         <width>20</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="focusPolicy">
-        <enum>Qt::TabFocus</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0" colspan="5">
-      <widget class="QCheckBox" name="mCheckPlaceOnEveryPart">
-       <property name="toolTip">
-        <string>If checked, the &quot;first vertex&quot; or &quot;last vertex&quot; placements will also render at the first and last vertex for every part of multipart geometries</string>
-       </property>
-       <property name="text">
-        <string>Place on every part extremity</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="0" colspan="3">
-    <widget class="QgsCollapsibleGroupBoxBasic" name="mBlankSegmentsGrpBox">
-     <property name="title">
-      <string>Blank segments</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_7">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QToolButton" name="mEditBlankSegmentsBtn">
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset resource="../../../images/images.qrc">
-            <normaloff>:/images/themes/default/mActionShowAllLayers.svg</normaloff>:/images/themes/default/mActionShowAllLayers.svg</iconset>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QgsUnitSelectionWidget" name="mBlankSegmentsUnitWidget" native="true">
-          <property name="minimumSize">
-           <size>
-            <width>20</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="focusPolicy">
-           <enum>Qt::TabFocus</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QgsPropertyOverrideButton" name="mBlankSegmentsDDButton">
-          <property name="text">
-           <string>…</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QgsPropertyOverrideButton" name="mPlacementDDBtn">
-     <property name="text">
-      <string>…</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="mPlacementLabel">
-     <property name="text">
-      <string>Hash placement</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
@@ -564,12 +573,6 @@
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/symbollayer/widget_templatedline.ui
+++ b/src/ui/symbollayer/widget_templatedline.ui
@@ -448,7 +448,7 @@
     </layout>
    </item>
    <item row="3" column="0" colspan="3">
-    <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
+    <widget class="QgsCollapsibleGroupBoxBasic" name="mBlankSegmentsGrpBox">
      <property name="title">
       <string>Blank segments</string>
      </property>

--- a/src/ui/symbollayer/widget_templatedline.ui
+++ b/src/ui/symbollayer/widget_templatedline.ui
@@ -448,7 +448,7 @@
     </layout>
    </item>
    <item row="3" column="0" colspan="3">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
      <property name="title">
       <string>Blank segments</string>
      </property>
@@ -456,26 +456,13 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_9">
         <item>
-         <spacer name="horizontalSpacer_7">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
          <widget class="QToolButton" name="mEditBlankSegmentsBtn">
           <property name="text">
            <string/>
           </property>
           <property name="icon">
            <iconset resource="../../../images/images.qrc">
-            <normaloff>:/images/themes/default/mActionRemoveAllFromOverview.svg</normaloff>:/images/themes/default/mActionRemoveAllFromOverview.svg</iconset>
+            <normaloff>:/images/themes/default/mActionShowAllLayers.svg</normaloff>:/images/themes/default/mActionShowAllLayers.svg</iconset>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -501,6 +488,19 @@
            <string>…</string>
           </property>
          </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </item>
@@ -564,6 +564,12 @@
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TESTS
   testqgsfiledownloader.cpp
   testqgslayoutgui.cpp
   testqgslayoutview.cpp
+  testqgsmaptooleditblanksegments.cpp
   testqgsvaluemapwidgetwrapper.cpp
   testqgsvaluemapconfigdlg.cpp
   testqgsvaluerelationwidgetwrapper.cpp

--- a/tests/src/gui/testqgsmaptooleditblanksegments.cpp
+++ b/tests/src/gui/testqgsmaptooleditblanksegments.cpp
@@ -14,13 +14,14 @@
  ***************************************************************************/
 
 #include "qgslinesymbollayer.h"
-#include "qgssymbollayer.h"
-#include "qgstest.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaptooleditblanksegments.h"
+#include "qgssinglesymbolrenderer.h"
+#include "qgssymbollayer.h"
+#include "qgstest.h"
 #include "qgsvectorlayer.h"
 #include "testqgsmaptoolutils.h"
-#include "qgssinglesymbolrenderer.h"
+
 #include <qstringliteral.h>
 
 class TestQgsMapToolEditBlankSegments : public QgsTest

--- a/tests/src/gui/testqgsmaptooleditblanksegments.cpp
+++ b/tests/src/gui/testqgsmaptooleditblanksegments.cpp
@@ -1,0 +1,216 @@
+/***************************************************************************
+    testqgsmaptooleditblankareas.cpp
+    ---------------------
+    begin                : 2025/09/17
+    copyright            : (C) 2025 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslinesymbollayer.h"
+#include "qgssymbollayer.h"
+#include "qgstest.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaptooleditblanksegments.h"
+#include "qgsvectorlayer.h"
+#include "testqgsmaptoolutils.h"
+#include "qgssinglesymbolrenderer.h"
+#include <qstringliteral.h>
+
+class TestQgsMapToolEditBlankSegments : public QgsTest
+{
+    Q_OBJECT
+
+  public:
+    TestQgsMapToolEditBlankSegments()
+      : QgsTest( QStringLiteral( "Blank Segments Map Tool Tests" ) ) {}
+
+  private slots:
+    void initTestCase();    // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init();            // will be called before each testfunction is executed.
+    void cleanup();         // will be called after every testfunction.
+
+    void testSelectFeature();
+    void testCreateBlankSegment();
+
+  private:
+    void compareBlankSegments( const QString &strBlankSegments, const QList<QList<QgsBlankSegmentUtils::BlankSegments>> &expected );
+    int nbRubberBandVisible() const;
+
+    QObjectUniquePtr<QgsMapToolEditBlankSegments<QgsMarkerLineSymbolLayer>> mMapToolEditBlankSegments;
+    std::unique_ptr<QgsMapCanvas> mCanvas;
+    std::unique_ptr<QgsVectorLayer> mLayer;
+    QgsMarkerLineSymbolLayer *mSymbolLayer = new QgsMarkerLineSymbolLayer();
+};
+
+void TestQgsMapToolEditBlankSegments::initTestCase()
+{
+  mCanvas = std::make_unique<QgsMapCanvas>();
+  mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3946" ) ) );
+  mCanvas->setFrameStyle( QFrame::NoFrame );
+  mCanvas->resize( 512, 512 );
+  mCanvas->setExtent( QgsRectangle( 0, 0, 25, 10 ) );
+  mCanvas->show(); // to make the canvas resize
+  mCanvas->hide();
+
+  mLayer = std::make_unique<QgsVectorLayer>( QStringLiteral( "MultiPolygon?field=pk:int&field=bas:string&crs=EPSG:3946" ), QStringLiteral( "polys" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayer->isValid() );
+  QCOMPARE( mLayer->fields().count(), 2 );
+
+  const QString wkt1 = "MultiPolygon (((0 0, 10 0, 10 3, 12 4, 8 5, 12 6, 8 7, 10 8, 10 10, 0 10, 0 0),(2 3, 6 3, 6 8, 2 8, 2 3)),((13 0, 16 0, 16 10, 13 10, 13 0)))";
+  QgsFeature f1;
+  f1.setGeometry( QgsGeometry::fromWkt( wkt1 ) );
+
+  const QString wkt2 = "MultiPolygon (((20 0, 25 0, 25 5, 20 5, 20 0)))";
+  QgsFeature f2;
+  f2.setGeometry( QgsGeometry::fromWkt( wkt2 ) );
+
+  mLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 );
+  QCOMPARE( mLayer->featureCount(), ( long ) 2 );
+  QCOMPARE( mLayer->getFeature( 1 ).geometry().asWkt(), wkt1 );
+  QCOMPARE( mLayer->getFeature( 2 ).geometry().asWkt(), wkt2 );
+
+  mCanvas->setCurrentLayer( mLayer.get() );
+
+  QgsSingleSymbolRenderer *renderer = dynamic_cast<QgsSingleSymbolRenderer *>( mLayer->renderer() );
+  QVERIFY( renderer );
+  QVERIFY( renderer->symbol() );
+
+  mSymbolLayer = new QgsMarkerLineSymbolLayer();
+  mSymbolLayer->setPlacements( Qgis::MarkerLinePlacement::Interval );
+
+  renderer->symbol()->changeSymbolLayer( 0, mSymbolLayer );
+}
+
+void TestQgsMapToolEditBlankSegments::cleanupTestCase()
+{
+}
+
+void TestQgsMapToolEditBlankSegments::init()
+{
+  mMapToolEditBlankSegments.reset( new QgsMapToolEditBlankSegments<QgsMarkerLineSymbolLayer>( mCanvas.get(), mLayer.get(), mSymbolLayer, 1 ) );
+  mCanvas->setMapTool( mMapToolEditBlankSegments );
+}
+
+void TestQgsMapToolEditBlankSegments::cleanup()
+{
+  mCanvas->unsetMapTool( mMapToolEditBlankSegments );
+  mMapToolEditBlankSegments.reset();
+}
+
+int TestQgsMapToolEditBlankSegments::nbRubberBandVisible() const
+{
+  int result = 0;
+  for ( QGraphicsItem *item : mCanvas->items() )
+  {
+    if ( QgsRubberBand *rubberBand = dynamic_cast<QgsRubberBand *>( item );
+         rubberBand && rubberBand->isVisible() )
+    {
+      result++;
+    }
+  }
+
+  return result;
+}
+
+void TestQgsMapToolEditBlankSegments::compareBlankSegments( const QString &strBlankSegments, const QList<QList<QgsBlankSegmentUtils::BlankSegments>> &expectedBlankSegments )
+{
+  QString error;
+  QList<QList<QgsBlankSegmentUtils::BlankSegments>> blankSegments = QgsBlankSegmentUtils::parseBlankSegments( strBlankSegments, QgsRenderContext(), Qgis::RenderUnit::Pixels, error );
+  QVERIFY( error.isEmpty() );
+
+  QVERIFY2( expectedBlankSegments.count() == blankSegments.count(), QStringLiteral( "Part number differs (Actual: %1 != Expected: %2). Returned blank segments: %3" ).arg( blankSegments.count() ).arg( expectedBlankSegments.count() ).arg( strBlankSegments ).toLatin1().constData() );
+
+  for ( int iPart = 0; iPart < expectedBlankSegments.count(); iPart++ )
+  {
+    const QList<QgsBlankSegmentUtils::BlankSegments> &expectedRings = expectedBlankSegments.at( iPart );
+    const QList<QgsBlankSegmentUtils::BlankSegments> &rings = blankSegments.at( iPart );
+    QVERIFY2( expectedRings.count() == rings.count(), QStringLiteral( "Rings number differs (Actual: %1 != Expected: %2) for part %3. Returned blank segments: %4" ).arg( rings.count() ).arg( expectedRings.count() ).arg( iPart ).arg( strBlankSegments ).toLatin1().constData() );
+
+    for ( int iRing = 0; iRing < rings.count(); iRing++ )
+    {
+      const QgsBlankSegmentUtils::BlankSegments &expectedSegments = expectedRings.at( iRing );
+      const QgsBlankSegmentUtils::BlankSegments &segments = rings.at( iRing );
+      QVERIFY2( expectedSegments.count() == segments.count(), QStringLiteral( "Segments number differs (Actual: %1 != Expected: %2) for part %3 and ring %4. Returned blank segments: %5" ).arg( segments.count() ).arg( expectedSegments.count() ).arg( iPart ).arg( iRing ).arg( strBlankSegments ).toLatin1().constData() );
+      for ( int iSegment = 0; iSegment < segments.count(); iSegment++ )
+      {
+        QVERIFY2( qgsDoubleNear( segments.at( iSegment ).first, expectedSegments.at( iSegment ).first, 0.1 ), QString( "Value differs (Actual: %1 != Expected: %2) for part %3, ring %4, segment %5, start distance. Returned blank segments: %6" ).arg( segments.at( iSegment ).first ).arg( expectedSegments.at( iSegment ).first ).arg( iPart ).arg( iRing ).arg( iSegment ).arg( strBlankSegments ).toLatin1().constData() );
+
+        QVERIFY2( qgsDoubleNear( segments.at( iSegment ).second, expectedSegments.at( iSegment ).second, 0.1 ), QString( "Value differs (Actual: %1 != Expected: %2) for part %3, ring %4, segment %5, end distance. Returned blank segments: %6" ).arg( segments.at( iSegment ).second ).arg( expectedSegments.at( iSegment ).second ).arg( iPart ).arg( iRing ).arg( iSegment ).arg( strBlankSegments ).toLatin1().constData() );
+      }
+    }
+  }
+}
+
+
+void TestQgsMapToolEditBlankSegments::testSelectFeature()
+{
+  TestQgsMapToolUtils utils( mMapToolEditBlankSegments.get() );
+
+  QVERIFY( FID_IS_NULL( mMapToolEditBlankSegments->mCurrentFeatureId ) );
+
+  // select first feature
+  utils.mouseClick( 1, 1, Qt::LeftButton );
+  QCOMPARE( mMapToolEditBlankSegments->mCurrentFeatureId, 1 );
+
+  QCOMPARE( nbRubberBandVisible(), 0 );
+  utils.mouseMove( 1, 1 );
+  QCOMPARE( nbRubberBandVisible(), 1 ); // start point rubber band
+
+  // escape
+  utils.keyClick( Qt::Key_Escape );
+  QVERIFY( FID_IS_NULL( mMapToolEditBlankSegments->mCurrentFeatureId ) );
+  QCOMPARE( nbRubberBandVisible(), 0 );
+
+  // select second feature
+  utils.mouseClick( 21, 1, Qt::LeftButton );
+  QCOMPARE( mMapToolEditBlankSegments->mCurrentFeatureId, 2 );
+  utils.mouseMove( 21, 1 );
+  QCOMPARE( nbRubberBandVisible(), 1 );
+
+  // escape
+  utils.keyClick( Qt::Key_Escape );
+  QVERIFY( FID_IS_NULL( mMapToolEditBlankSegments->mCurrentFeatureId ) );
+  QCOMPARE( nbRubberBandVisible(), 0 );
+}
+
+void TestQgsMapToolEditBlankSegments::testCreateBlankSegment()
+{
+  TestQgsMapToolUtils utils( mMapToolEditBlankSegments.get() );
+  mLayer->startEditing();
+
+  QVERIFY( FID_IS_NULL( mMapToolEditBlankSegments->mCurrentFeatureId ) );
+
+  utils.mouseClick( 1, 1, Qt::LeftButton );
+  QCOMPARE( mMapToolEditBlankSegments->mCurrentFeatureId, 1 );
+
+  utils.mouseClick( 11, 2, Qt::LeftButton );
+  utils.mouseMove( 9, 9 );
+  utils.mouseClick( 9, 9, Qt::LeftButton );
+
+  utils.mouseClick( 4, 1, Qt::LeftButton );
+  utils.mouseMove( 7, 1 );
+  utils.mouseClick( 7, 1, Qt::LeftButton );
+
+  QgsFeature feat = mLayer->getFeature( 1 );
+  QVERIFY( feat.isValid() );
+
+  compareBlankSegments( feat.attribute( 1 ).toString(), { { { { 4, 7 }, { 12, 32.8 } } } } );
+
+  // escape
+  utils.keyClick( Qt::Key_Escape );
+  QVERIFY( FID_IS_NULL( mMapToolEditBlankSegments->mCurrentFeatureId ) );
+  QCOMPARE( nbRubberBandVisible(), 0 );
+
+  mLayer->rollBack();
+}
+
+QGSTEST_MAIN( TestQgsMapToolEditBlankSegments )
+#include "testqgsmaptooleditblanksegments.moc"

--- a/tests/src/python/test_qgsmarkerlinesymbollayer.py
+++ b/tests/src/python/test_qgsmarkerlinesymbollayer.py
@@ -1715,6 +1715,45 @@ class TestQgsMarkerLineSymbolLayer(QgisTestCase):
             )
         )
 
+    def testBlankSegmentsOnCircularString(self):
+        """
+        Test using blank area on circular string with vertex placements
+        """
+
+        s = QgsLineSymbol()
+        s.deleteSymbolLayer(0)
+
+        sl = QgsMarkerLineSymbolLayer()
+        sl.setPlacements(
+            Qgis.MarkerLinePlacements(
+                Qgis.MarkerLinePlacement.Vertex | Qgis.MarkerLinePlacement.CurvePoint
+            )
+        )
+
+        markerSl = sl.subSymbol().symbolLayers()[0]
+        self.assertTrue(markerSl)
+        markerSl.setShape(Qgis.MarkerShape.HalfSquare)
+        markerSl.setStrokeStyle(Qt.PenStyle.NoPen)
+        s.appendSymbolLayer(sl)
+
+        g = QgsGeometry.fromWkt("""CircularString (0 0, 3 7, 10 10)""")
+
+        sl.setDataDefinedProperty(
+            QgsSymbolLayer.Property.BlankSegments,
+            QgsProperty.fromExpression("'(((3 8)))'"),
+        )
+
+        rendered_image = self.renderGeometry(s, g)
+        self.assertTrue(
+            self.image_check(
+                "markerline_blanksegments_circularstring",
+                "markerline_blanksegments_circularstring",
+                rendered_image,
+                color_tolerance=2,
+                allowed_mismatch=20,
+            )
+        )
+
     def renderGeometry(self, symbol, geom, buffer=20):
         f = QgsFeature()
         f.setGeometry(geom)

--- a/tests/src/python/test_qgsmarkerlinesymbollayer.py
+++ b/tests/src/python/test_qgsmarkerlinesymbollayer.py
@@ -1715,45 +1715,6 @@ class TestQgsMarkerLineSymbolLayer(QgisTestCase):
             )
         )
 
-    def testBlankSegmentsOnCircularString(self):
-        """
-        Test using blank area on circular string with vertex placements
-        """
-
-        s = QgsLineSymbol()
-        s.deleteSymbolLayer(0)
-
-        sl = QgsMarkerLineSymbolLayer()
-        sl.setPlacements(
-            Qgis.MarkerLinePlacements(
-                Qgis.MarkerLinePlacement.Vertex | Qgis.MarkerLinePlacement.CurvePoint
-            )
-        )
-
-        markerSl = sl.subSymbol().symbolLayers()[0]
-        self.assertTrue(markerSl)
-        markerSl.setShape(Qgis.MarkerShape.HalfSquare)
-        markerSl.setStrokeStyle(Qt.PenStyle.NoPen)
-        s.appendSymbolLayer(sl)
-
-        g = QgsGeometry.fromWkt("""CircularString (0 0, 3 7, 10 10)""")
-
-        sl.setDataDefinedProperty(
-            QgsSymbolLayer.Property.BlankSegments,
-            QgsProperty.fromExpression("'(((3 8)))'"),
-        )
-
-        rendered_image = self.renderGeometry(s, g)
-        self.assertTrue(
-            self.image_check(
-                "markerline_blanksegments_circularstring",
-                "markerline_blanksegments_circularstring",
-                rendered_image,
-                color_tolerance=2,
-                allowed_mismatch=20,
-            )
-        )
-
     def renderGeometry(self, symbol, geom, buffer=20):
         f = QgsFeature()
         f.setGeometry(geom)


### PR DESCRIPTION
This is the map tool to edit blank segments described in QEP [#345](https://github.com/qgis/QGIS-Enhancement-Proposals/pull/345)

![blanksegments_maptool](https://github.com/user-attachments/assets/4b357590-ec8f-4d93-a26f-8d70213c6c40)

It allows to define blank segments per feature on templated line symbology. Hashes or Markers won't be drawn inside those blank segments. The blank segments are stored on a data defined property (data field or auxiliary storage field). This tool allows to:
- Click in the neighborhood of the line to start creating a segment, click again to finish editing
- Select a segment, press Del key to remove it
- Drag the start/end of an already existing segment and move it along the line to reduce/enlarge it

**Funded by Stadt Frankfurt am Main and Oslandia**