### PR TITLE
nix: remove IFD usage for version detection

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,6 @@
     #   extra-substituters = [ "https://example.cachix.org" ];
     #   extra-trusted-public-keys = [ "example.cachix.org-1:xxxx=" ];
 
-    # IFD is required for qgisVersion detection in nix/unwrapped.nix.
-    allow-import-from-derivation = true;
     bash-prompt = "\\[\\033[1m\\][qgis-dev]\\[\\033\[m\\]\\040\\w >\\040";
   };
 

--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -4,7 +4,6 @@
 , fetchFromGitHub
 , makeWrapper
 , replaceVars
-, runCommand
 , wrapGAppsHook3
 , wrapQtAppsHook
 
@@ -65,11 +64,6 @@ let
     };
   });
 
-  versionSourceFiles = lib.fileset.toSource {
-    root = ../.;
-    fileset = ../CMakeLists.txt;
-  };
-
   qgisSourceFiles =
     lib.fileset.difference
       (lib.fileset.gitTracked ../.)
@@ -90,21 +84,19 @@ let
 
   # Version parsing taken from
   # https://github.com/qgis/QGIS/blob/1f0328cff6a8b4cf8a4f8d44a4304b9d9706aa72/rpm/buildrpms.sh#L118
+  cmakeListsFile = lib.readFile ../CMakeLists.txt;
+  extractVersion = pattern:
+    let
+      matches = lib.match ".*[sS][eE][tT]\\(${pattern}[[:space:]]+\"([0-9]+)\".*" cmakeListsFile;
+    in
+      if matches != null then lib.head matches else "0";
   qgisVersion =
-    lib.replaceStrings [ "\n" ] [ "" ]
-      (lib.readFile (
-        runCommand "qgis-version" { } ''
-          major=$(grep -ie 'SET(CPACK_PACKAGE_VERSION_MAJOR' ${versionSourceFiles}/CMakeLists.txt |
-            sed -r 's/.*\"([0-9]+)\".*/\1/g')
-          minor=$(grep -ie 'SET(CPACK_PACKAGE_VERSION_MINOR' ${versionSourceFiles}/CMakeLists.txt |
-            sed -r 's/.*\"([0-9]+)\".*/\1/g')
-          patch=$(grep -ie 'SET(CPACK_PACKAGE_VERSION_PATCH' ${versionSourceFiles}/CMakeLists.txt |
-            sed -r 's/.*\"([0-9]+)\".*/\1/g')
-
-          version=$major.$minor.$patch
-          echo $version > $out
-        ''
-      ));
+    let
+      major = extractVersion "CPACK_PACKAGE_VERSION_MAJOR";
+      minor = extractVersion "CPACK_PACKAGE_VERSION_MINOR";
+      patch = extractVersion "CPACK_PACKAGE_VERSION_PATCH";
+    in
+      "${major}.${minor}.${patch}";
 
   py = python3.override {
     self = py;
@@ -143,7 +135,7 @@ in
 stdenv.mkDerivation
 {
   pname = "qgis-unwrapped";
-  version = qgisVersion;  # this is a "Import from derivation (IFD)" !
+  version = qgisVersion;
   src = lib.fileset.toSource {
     root = ../.;
     fileset = qgisSourceFiles;


### PR DESCRIPTION
## Description

Remove usage of Import From Derivation (IFD) for QGIS version detection.

IFD has signifficant performance implication. Evaluation can only finish
when all required store objects are realised. Since the Nix language
evaluator is sequential, it only finds store paths to read from one at a
time. While realisation is always parallel, in this case it cannot be
done for all required store paths at once, and is therefore much slower
than otherwise.

For more information see:
https://nix.dev/manual/nix/2.32/language/import-from-derivation

cc: @timlinux @autra 


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
