### PR TITLE
[GUI] Remove incorrect tooltip for label placement

### DIFF
--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -4829,9 +4829,6 @@ font-style: italic;</string>
                              <height>0</height>
                             </size>
                            </property>
-                           <property name="toolTip">
-                            <string>Allowed label placement for lines. At least one position must be selected.</string>
-                           </property>
                            <property name="frameShape">
                             <enum>QFrame::NoFrame</enum>
                            </property>


### PR DESCRIPTION
## Description

Currently the tooltip "Allowed label placement for lines. At least one position must be selected." is incorrectly showed for the "Allow placing labels outside of polygons" option in Label->Placement for polygon layers (probably due to an oversight in https://github.com/qgis/QGIS/pull/36106).

<img width="1018" height="618" alt="image" src="https://github.com/user-attachments/assets/8963f82e-8068-426d-be76-77c3a0f0e7f7" />

This PR just removes the incorrect tooltip.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
