### PR TITLE
Update qgsmodeldesignerdialog.cpp

### DIFF
--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -157,6 +157,23 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   connect( mReorderInputsButton, &QPushButton::clicked, this, &QgsModelDesignerDialog::reorderInputs );
   connect( mActionRun, &QAction::triggered, this, [this] { run(); } );
   connect( mActionRunSelectedSteps, &QAction::triggered, this, &QgsModelDesignerDialog::runSelectedSteps );
+  connect( mModel, &QgsProcessingModelAlgorithm::changed, this, &QgsModelDesigner::updateWindowTitle );
+
+connect(
+    QgsProject::instance(),
+    &QgsProject::projectClosed,
+    this,
+    &QgsModelDesigner::onProjectClosed
+);
+
+connect(
+    QgsProject::instance(),
+    &QgsProject::cleared,
+    this,
+    &QgsModelDesigner::onProjectClosed
+);
+
+
 
   mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/Modeler/enableSnapToGrid" ), false ).toBool() );
   connect( mActionSnappingEnabled, &QAction::toggled, this, [this]( bool enabled ) {
@@ -1369,9 +1386,19 @@ void QgsModelChildDependenciesWidget::showDialog()
   }
 }
 
+
 void QgsModelChildDependenciesWidget::updateSummaryText()
 {
   mLineEdit->setText( tr( "%n dependencies selected", nullptr, mValue.count() ) );
+  void QgsModelDesigner::onProjectClosed()
+{
+   
+    setEnabled(false);
+
+   
+    QMetaObject::invokeMethod(this, "close", Qt::QueuedConnection);
+}
+
 }
 
 ///@endcond


### PR DESCRIPTION
This fix follows the same pattern used in other QGIS interfaces (e.g., Data Source Manager, Layout Manager), ensuring UI elements bound to project data do not remain open without a valid project context.

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
