### PR TITLE
Fix crash when creating virtual layer from invalid vector layer

### DIFF
--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -127,6 +127,11 @@ bool QgsVirtualLayerProvider::loadSourceLayers()
         PROVIDER_ERROR( QString( "Layer %1 is not a vector layer" ).arg( layer.reference() ) );
         return false;
       }
+      if ( !l->isValid() )
+      {
+        PROVIDER_ERROR( QString( "Layer %1 is invalid" ).arg( layer.reference() ) );
+        return false;
+      }
       // add the layer to the list
       QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( l );
       mLayers << SourceLayer( vl, layer.name() );

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -704,6 +704,31 @@ class TestQgsVirtualLayerProvider(QgisTestCase, ProviderTestCase):
         # check that it does not crash
         print(sum([f.id() for f in l2.getFeatures()]))
 
+    def test_refLayer_invalid_provider(self):
+        bad = QgsVectorLayer(
+            "Point?field=id:integer",
+            "bad",
+            "bogus",
+            QgsVectorLayer.LayerOptions(False),
+        )
+        self.assertFalse(bad.isValid())
+        QgsProject.instance().addMapLayer(bad)
+
+        try:
+            vl = QgsVectorLayer(
+                f"?layer_ref={bad.id()}",
+                "vtab",
+                "virtual",
+                QgsVectorLayer.LayerOptions(False),
+            )
+            self.assertFalse(vl.isValid())
+            self.assertIn(
+                f"Layer {bad.id()} is invalid",
+                vl.dataProvider().error().message(),
+            )
+        finally:
+            QgsProject.instance().removeMapLayer(bad.id())
+    
     def test_refLayers(self):
         l1 = QgsVectorLayer(
             QUrl.fromLocalFile(

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -728,8 +728,9 @@ class TestQgsVirtualLayerProvider(QgisTestCase, ProviderTestCase):
             )
         finally:
             QgsProject.instance().removeMapLayer(bad.id())
-    
+
     def test_refLayers(self):
+
         l1 = QgsVectorLayer(
             QUrl.fromLocalFile(
                 os.path.join(self.testDataDir, "delimitedtext/test.csv")


### PR DESCRIPTION
This fix prevents a QGIS crash that occurs when an invalid vector layer is used as the source of a virtual layer during vector layer creation.

A vector layer can legitimately exist in an invalid state (e.g. when loading a project with DontResolveLayers), and in this case its data provider is null. When such a layer is passed to a virtual layer definition, QGIS currently crashes instead of handling the layer as invalid.

This change ensures that vector layers created from virtual layer definitions are properly marked as null when the source layer is invalid, consistent with existing validity checks, preventing unexpected crashes.

## Description

To reproduce the bug, you need to load a layer without a data provider, then create a virtual layer that runs a SELECT on this layer’s data, and finally create a vector layer starting from the virtual layer. Below is the code to reproduce the issue.

```python 
p = QgsProject.instance()
p.read("path to an existing project", Qgis.ProjectReadFlag.DontResolveLayers)
# now you need to select a layer from the layer tree let's say the layer is called wastewater
l = iface.activeLayer()
# you can check with l.dataProvider() that the data provider is None
vld = QgsVirtualLayerDefinition()
vld.addSource(l.name(), l.id())
vld.setQuery("select * from wastewater")
vl = QgsVectorLayer(vld.toString(), "new layer name", "virtual")
# at this point QGIS crashes
```