### PR TITLE
[OAPIF] Fix to avoid warning message about mismatch between layer and feature geometry types when there are 3D geometries

### DIFF
--- a/src/providers/wfs/oapif/qgsoapifprovider.cpp
+++ b/src/providers/wfs/oapif/qgsoapifprovider.cpp
@@ -271,6 +271,9 @@ bool QgsOapifProvider::init()
   else
     tenFeaturesRequestUrl += QLatin1Char( '&' );
   tenFeaturesRequestUrl += QLatin1String( "limit=10" );
+  if ( mShared->mSourceCrs
+       != QgsCoordinateReferenceSystem::fromOgcWmsCrs( OAPIF_PROVIDER_DEFAULT_CRS ) )
+    tenFeaturesRequestUrl += QStringLiteral( "&crs=%1" ).arg( mShared->mSourceCrs.toOgcUri() );
 
   QgsOapifItemsRequest itemsRequest( mShared->mURI.uri(), mShared->appendExtraQueryParameters( tenFeaturesRequestUrl ), mShared->mFeatureFormat );
   if ( mShared->mCapabilityExtent.isNull() )

--- a/src/providers/wfs/oapif/qgsoapifshareddata.h
+++ b/src/providers/wfs/oapif/qgsoapifshareddata.h
@@ -70,9 +70,6 @@ class QgsOapifSharedData final : public QObject, public QgsBackgroundCachedShare
     //! Datasource URI
     QgsWFSDataSourceURI mURI;
 
-    //! Geometry type of the features in this layer
-    Qgis::WkbType mWKBType = Qgis::WkbType::Unknown;
-
     //! Page size. 0 = disabled
     long long mPageSize = 0;
 

--- a/src/providers/wfs/qgsbackgroundcachedshareddata.h
+++ b/src/providers/wfs/qgsbackgroundcachedshareddata.h
@@ -188,7 +188,7 @@ class QgsBackgroundCachedSharedData
     //! Called when an error must be raised to the provider
     virtual void pushError( const QString &errorMsg ) const = 0;
 
-    //! Geometry type of the features in this layer (used by WFS only)
+    //! Geometry type of the features in this layer
     Qgis::WkbType mWKBType = Qgis::WkbType::Unknown;
 
   protected:


### PR DESCRIPTION
This is a master only/not-present-in-3.44 issue (introduced by 512125ec2851dbbcedfbbf8711a98e93b765c44a)