### PR TITLE
Add WITH_AUTH

### DIFF
--- a/.github/workflows/vcpkg-update-report.yml
+++ b/.github/workflows/vcpkg-update-report.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           vcpkg-manifest-dir: vcpkg
           triplet: x64-linux
-          features: 3d,bindings,gui,opencl,quick,server,exiv2
+          features: auth,3d,bindings,gui,opencl,quick,server,exiv2
 
       - name: Schedule report comment
         uses: ./.github/actions/post_sticky_comment

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set (WITH_DESKTOP TRUE CACHE BOOL "Determines whether QGIS desktop should be bui
 set (WITH_GUI TRUE CACHE BOOL "Determines whether QGIS GUI library should be built")
 set (WITH_ORACLE FALSE CACHE BOOL "Determines whether Oracle support should be built")
 set (WITH_EXIV2 TRUE CACHE BOOL "Determines whether exiv2 functionality should be added")
+set (WITH_AUTH TRUE CACHE BOOL "Determines whether AUTH support should be included")
 set (WITH_VCPKG FALSE CACHE BOOL "Use the vcpkg submodule for dependency management.")
 
 set (SDK_PATH "" CACHE STRING "Build with VCPKG SDK")
@@ -716,7 +717,9 @@ if(WITH_CORE)
     find_package(Qt5Keychain CONFIG REQUIRED)
   endif()
   # Master password hash and authentication encryption
-  find_package(QCA REQUIRED)
+  if(WITH_AUTH)
+    find_package(QCA REQUIRED)
+  endif()
   # Check for runtime dependency of qca-ossl plugin
   # REQUIRED if unit tests are to be run from build directory
   if(NOT MSVC)

--- a/cmake/VcpkgToolchain.cmake
+++ b/cmake/VcpkgToolchain.cmake
@@ -20,6 +20,9 @@ endif()
 if(WITH_EXIV2)
   list(APPEND VCPKG_MANIFEST_FEATURES "exiv2")
 endif()
+if(WITH_AUTH)
+  list(APPEND VCPKG_MANIFEST_FEATURES "auth")
+endif()
 
 # Binarycache can only be used on Windows or if mono is available.
 find_program(_VCPKG_MONO mono)

--- a/python/PyQt6/core/core_auto.sip
+++ b/python/PyQt6/core/core_auto.sip
@@ -249,13 +249,6 @@
 %Include auto_generated/annotations/qgsrenderedannotationitemdetails.sip
 %Include auto_generated/annotations/qgssvgannotation.sip
 %Include auto_generated/annotations/qgstextannotation.sip
-%Include auto_generated/auth/qgsauthcertutils.sip
-%Include auto_generated/auth/qgsauthconfig.sip
-%Include auto_generated/auth/qgsauthconfigurationstorage.sip
-%Include auto_generated/auth/qgsauthconfigurationstorageregistry.sip
-%Include auto_generated/auth/qgsauthmanager.sip
-%Include auto_generated/auth/qgsauthmethod.sip
-%Include auto_generated/auth/qgsauthconfigurationstoragedb.sip
 %Include auto_generated/browser/qgsbrowsermodel.sip
 %Include auto_generated/browser/qgsbrowserproxymodel.sip
 %Include auto_generated/browser/qgsconnectionsitem.sip
@@ -843,6 +836,13 @@
 %Include auto_generated/vectortile/qgsvectortileutils.sip
 %Include auto_generated/vectortile/qgsvectortilewriter.sip
 %Include auto_generated/vectortile/qgsvtpktiles.sip
+%Include auto_generated/auth/qgsauthcertutils.sip
+%Include auto_generated/auth/qgsauthconfig.sip
+%Include auto_generated/auth/qgsauthconfigurationstorage.sip
+%Include auto_generated/auth/qgsauthconfigurationstorageregistry.sip
+%Include auto_generated/auth/qgsauthmanager.sip
+%Include auto_generated/auth/qgsauthmethod.sip
+%Include auto_generated/auth/qgsauthconfigurationstoragedb.sip
 %If ( HAVE_WEBENGINE_SIP )
 %Include auto_generated/web/qgswebenginepage.sip
 %End

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -249,13 +249,6 @@
 %Include auto_generated/annotations/qgsrenderedannotationitemdetails.sip
 %Include auto_generated/annotations/qgssvgannotation.sip
 %Include auto_generated/annotations/qgstextannotation.sip
-%Include auto_generated/auth/qgsauthcertutils.sip
-%Include auto_generated/auth/qgsauthconfig.sip
-%Include auto_generated/auth/qgsauthconfigurationstorage.sip
-%Include auto_generated/auth/qgsauthconfigurationstorageregistry.sip
-%Include auto_generated/auth/qgsauthmanager.sip
-%Include auto_generated/auth/qgsauthmethod.sip
-%Include auto_generated/auth/qgsauthconfigurationstoragedb.sip
 %Include auto_generated/browser/qgsbrowsermodel.sip
 %Include auto_generated/browser/qgsbrowserproxymodel.sip
 %Include auto_generated/browser/qgsconnectionsitem.sip
@@ -843,6 +836,13 @@
 %Include auto_generated/vectortile/qgsvectortileutils.sip
 %Include auto_generated/vectortile/qgsvectortilewriter.sip
 %Include auto_generated/vectortile/qgsvtpktiles.sip
+%Include auto_generated/auth/qgsauthcertutils.sip
+%Include auto_generated/auth/qgsauthconfig.sip
+%Include auto_generated/auth/qgsauthconfigurationstorage.sip
+%Include auto_generated/auth/qgsauthconfigurationstorageregistry.sip
+%Include auto_generated/auth/qgsauthmanager.sip
+%Include auto_generated/auth/qgsauthmethod.sip
+%Include auto_generated/auth/qgsauthconfigurationstoragedb.sip
 %If ( HAVE_WEBENGINE_SIP )
 %Include auto_generated/web/qgswebenginepage.sip
 %End

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -213,20 +213,6 @@ set(QGIS_CORE_SRCS
   numericformats/qgspercentagenumericformat.cpp
   numericformats/qgsscientificnumericformat.cpp
 
-  auth/qgsauthcertutils.cpp
-  auth/qgsauthconfig.cpp
-  auth/qgsauthcrypto.cpp
-  auth/qgsauthconfigurationstorage.cpp
-  auth/qgsauthconfigurationstorageregistry.cpp
-  auth/qgsauthmanager.cpp
-  auth/qgsauthmethod.cpp
-  auth/qgsauthmethodmetadata.cpp
-  auth/qgsauthmethodregistry.cpp
-  auth/qgsauthorizationsettings.cpp
-
-  auth/qgsauthconfigurationstoragesqlite.cpp
-  auth/qgsauthconfigurationstoragedb.cpp
-
   annotations/qgsannotation.cpp
   annotations/qgsannotationitem.cpp
   annotations/qgsannotationitemeditoperation.cpp
@@ -1048,8 +1034,41 @@ set(QGIS_CORE_SRCS
 
   qgsuserprofile.cpp
   qgsuserprofilemanager.cpp
-
 )
+
+if(WITH_AUTH)
+  list(APPEND QGIS_CORE_SRCS
+    auth/qgsauthcertutils.cpp
+    auth/qgsauthconfig.cpp
+    auth/qgsauthcrypto.cpp
+    auth/qgsauthconfigurationstorage.cpp
+    auth/qgsauthconfigurationstorageregistry.cpp
+    auth/qgsauthmanager.cpp
+    auth/qgsauthmethod.cpp
+    auth/qgsauthmethodmetadata.cpp
+    auth/qgsauthmethodregistry.cpp
+    auth/qgsauthorizationsettings.cpp
+
+    auth/qgsauthconfigurationstoragesqlite.cpp
+    auth/qgsauthconfigurationstoragedb.cpp
+  )
+
+  list(APPEND QGIS_CORE_HDRS
+    auth/qgsauthcertutils.h
+    auth/qgsauthconfig.h
+    auth/qgsauthcrypto.h
+    auth/qgsauthconfigurationstorage.h
+    auth/qgsauthconfigurationstorageregistry.h
+    auth/qgsauthmanager.h
+    auth/qgsauthmethod.h
+    auth/qgsauthmethodmetadata.h
+    auth/qgsauthmethodregistry.h
+    auth/qgsauthorizationsettings.h
+
+    auth/qgsauthconfigurationstoragesqlite.h
+    auth/qgsauthconfigurationstoragedb.h
+  )
+endif()
 
 if (WITH_INTERNAL_POLY2TRI)
   set(QGIS_CORE_SRCS ${QGIS_CORE_SRCS}
@@ -1407,20 +1426,6 @@ set(QGIS_CORE_HDRS
   annotations/qgsrenderedannotationitemdetails.h
   annotations/qgssvgannotation.h
   annotations/qgstextannotation.h
-
-  auth/qgsauthcertutils.h
-  auth/qgsauthconfig.h
-  auth/qgsauthcrypto.h
-  auth/qgsauthconfigurationstorage.h
-  auth/qgsauthconfigurationstorageregistry.h
-  auth/qgsauthmanager.h
-  auth/qgsauthmethod.h
-  auth/qgsauthmethodmetadata.h
-  auth/qgsauthmethodregistry.h
-  auth/qgsauthorizationsettings.h
-
-  auth/qgsauthconfigurationstoragesqlite.h
-  auth/qgsauthconfigurationstoragedb.h
 
   browser/qgsbrowsermodel.h
   browser/qgsbrowserproxymodel.h
@@ -2526,10 +2531,14 @@ endif()
 target_include_directories(qgis_core SYSTEM PUBLIC
   ${LIBZIP_INCLUDE_DIRS}
   ${SPATIALINDEX_INCLUDE_DIR} # before GEOS for case-insensitive filesystems
-  ${QCA_INCLUDE_DIR}
   ${Protobuf_INCLUDE_DIRS}
   ${ZLIB_INCLUDE_DIRS}
 )
+if(WITH_AUTH)
+  target_include_directories(qgis_core SYSTEM PUBLIC
+    ${QCA_INCLUDE_DIR}
+  )
+endif()
 
 target_include_directories(qgis_core PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -2676,7 +2685,6 @@ target_link_libraries(qgis_core
   ${QT_VERSION_BASE}::Concurrent
   ${QT_VERSION_BASE}::Positioning
   ${OPTIONAL_QTWEBKIT}
-  ${QCA_LIBRARY}
   GEOS::geos_c
   GDAL::GDAL
   EXPAT::EXPAT
@@ -2691,6 +2699,12 @@ target_link_libraries(qgis_core
 if(WITH_EXIV2)
   target_link_libraries(qgis_core
     exiv2lib
+  )
+endif()
+
+if(WITH_AUTH)
+  target_link_libraries(qgis_core
+    ${QCA_LIBRARY}
   )
 endif()
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1036,40 +1036,6 @@ set(QGIS_CORE_SRCS
   qgsuserprofilemanager.cpp
 )
 
-if(WITH_AUTH)
-  list(APPEND QGIS_CORE_SRCS
-    auth/qgsauthcertutils.cpp
-    auth/qgsauthconfig.cpp
-    auth/qgsauthcrypto.cpp
-    auth/qgsauthconfigurationstorage.cpp
-    auth/qgsauthconfigurationstorageregistry.cpp
-    auth/qgsauthmanager.cpp
-    auth/qgsauthmethod.cpp
-    auth/qgsauthmethodmetadata.cpp
-    auth/qgsauthmethodregistry.cpp
-    auth/qgsauthorizationsettings.cpp
-
-    auth/qgsauthconfigurationstoragesqlite.cpp
-    auth/qgsauthconfigurationstoragedb.cpp
-  )
-
-  list(APPEND QGIS_CORE_HDRS
-    auth/qgsauthcertutils.h
-    auth/qgsauthconfig.h
-    auth/qgsauthcrypto.h
-    auth/qgsauthconfigurationstorage.h
-    auth/qgsauthconfigurationstorageregistry.h
-    auth/qgsauthmanager.h
-    auth/qgsauthmethod.h
-    auth/qgsauthmethodmetadata.h
-    auth/qgsauthmethodregistry.h
-    auth/qgsauthorizationsettings.h
-
-    auth/qgsauthconfigurationstoragesqlite.h
-    auth/qgsauthconfigurationstoragedb.h
-  )
-endif()
-
 if (WITH_INTERNAL_POLY2TRI)
   set(QGIS_CORE_SRCS ${QGIS_CORE_SRCS}
     ${CMAKE_SOURCE_DIR}/external/poly2tri/common/shapes.cc
@@ -2185,6 +2151,40 @@ set(QGIS_CORE_HDRS
   vectortile/qgsvtpkvectortiledataprovider.h
   vectortile/qgsxyzvectortiledataprovider.h
 )
+
+if(WITH_AUTH)
+  set(QGIS_CORE_SRCS ${QGIS_CORE_SRCS}
+    auth/qgsauthcertutils.cpp
+    auth/qgsauthconfig.cpp
+    auth/qgsauthcrypto.cpp
+    auth/qgsauthconfigurationstorage.cpp
+    auth/qgsauthconfigurationstorageregistry.cpp
+    auth/qgsauthmanager.cpp
+    auth/qgsauthmethod.cpp
+    auth/qgsauthmethodmetadata.cpp
+    auth/qgsauthmethodregistry.cpp
+    auth/qgsauthorizationsettings.cpp
+
+    auth/qgsauthconfigurationstoragesqlite.cpp
+    auth/qgsauthconfigurationstoragedb.cpp
+  )
+
+  set(QGIS_CORE_HDRS ${QGIS_CORE_HDRS}
+    auth/qgsauthcertutils.h
+    auth/qgsauthconfig.h
+    auth/qgsauthcrypto.h
+    auth/qgsauthconfigurationstorage.h
+    auth/qgsauthconfigurationstorageregistry.h
+    auth/qgsauthmanager.h
+    auth/qgsauthmethod.h
+    auth/qgsauthmethodmetadata.h
+    auth/qgsauthmethodregistry.h
+    auth/qgsauthorizationsettings.h
+
+    auth/qgsauthconfigurationstoragesqlite.h
+    auth/qgsauthconfigurationstoragedb.h
+  )
+endif()
 
 set(QGIS_CORE_PRIVATE_HDRS
   qgsexpressionsorter_p.h

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -66,13 +66,6 @@
     "proj",
     "protobuf",
     {
-      "name": "qca",
-      "default-features": false,
-      "features": [
-        "ossl"
-      ]
-    },
-    {
       "name": "qtbase",
       "features": [
         "sql-odbc"
@@ -145,7 +138,18 @@
         "python3"
       ]
     },
-
+    "auth": {
+      "description": "Determines whether the EXIV2 should be built",
+      "dependencies": [
+        {
+          "name": "qca",
+          "default-features": false,
+          "features": [
+            "ossl"
+          ]
+        }
+      ]
+    },
     "exiv2": {
       "description": "Determines whether EXIV2 should be built",
       "dependencies": [


### PR DESCRIPTION
## Description

Makes building the auth subsystem optional, especially the QCA dependency.
A new `WITH_AUTH` option gives the control to deactivate auth.
Preparation for wasm builds, along the lines of https://github.com/qgis/QGIS/pull/64075

No functional change

Refs https://github.com/qgis/qgis-js/issues/39