### PR TITLE
Remove hardcoded white background for the QGIS API documentation website

### DIFF
--- a/doc/api_custom.css
+++ b/doc/api_custom.css
@@ -1,7 +1,3 @@
-body {
-    background-color: #fff;
-}
-
 .title {
 	font: 400 18px/28px Roboto,sans-serif;
 	font-size: 250%;


### PR DESCRIPTION
## Description

These days, our API website is reactive to the browser's dark theme mode. We however have a hard-coded white color as background, which results it a needlessly hard to read mid gray text on white:

<img width="693" height="512" alt="image" src="https://github.com/user-attachments/assets/3da203db-c7d7-4279-8cec-3ff459cd8b1d" />

Removing the custom CSS background-color is an instant readability boost:

<img width="693" height="512" alt="image" src="https://github.com/user-attachments/assets/6eb45025-6293-40a2-b9ab-50ebbf4ee71f" />
