### PR TITLE
Allow compiling when Qt is built without the timezone feature

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -1069,7 +1069,11 @@ QString QgsExpression::formatPreviewString( const QVariant &value, const bool ht
   else if ( value.userType() == qMetaTypeId< QTimeZone>() )
   {
     const QTimeZone tz = value.value<QTimeZone>();
+#if QT_FEATURE_timezone > 0
     return startToken + tr( "time zone: %1" ).arg( tz.isValid() ? tz.displayName( QTimeZone::GenericTime, QTimeZone::ShortName ) : tr( "invalid" ) ) + endToken;
+#else
+    QgsDebugError( QStringLiteral( "Qt is built without Qt timezone support, timezone preview not available" ) );
+#endif
   }
   else if ( value.userType() == qMetaTypeId< QgsInterval>() )
   {

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1365,6 +1365,8 @@ static QVariant fcnTimeZoneFromId( const QVariantList &values, const QgsExpressi
   const QString timeZoneId = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
 
   QTimeZone tz;
+
+#if QT_FEATURE_timezone > 0
   if ( !timeZoneId.isEmpty() )
   {
     tz = QTimeZone( timeZoneId.toUtf8() );
@@ -1375,21 +1377,31 @@ static QVariant fcnTimeZoneFromId( const QVariantList &values, const QgsExpressi
     parent->setEvalErrorString( QObject::tr( "'%1' is not a valid time zone ID" ).arg( timeZoneId ) );
     return QVariant();
   }
+
+#else
+  parent->setEvalErrorString( QObject::tr( "Qt is built without Qt timezone support, cannot use fcnTimeZoneFromId" ) );
+#endif
   return QVariant::fromValue( tz );
 }
 
 static QVariant fcnGetTimeZone( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
+#if QT_FEATURE_timezone > 0
   const QDateTime datetime = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
   if ( datetime.isValid() )
   {
     return QVariant::fromValue( datetime.timeZone() );
   }
   return QVariant();
+#else
+  parent->setEvalErrorString( QObject::tr( "Qt is built without Qt timezone support, cannot use fcnGetTimeZone" ) );
+  return QVariant();
+#endif
 }
 
 static QVariant fcnSetTimeZone( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
+#if QT_FEATURE_timezone > 0
   QDateTime datetime = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
   const QTimeZone tz = QgsExpressionUtils::getTimeZoneValue( values.at( 1 ), parent );
   if ( datetime.isValid() && tz.isValid() )
@@ -1398,10 +1410,15 @@ static QVariant fcnSetTimeZone( const QVariantList &values, const QgsExpressionC
     return QVariant::fromValue( datetime );
   }
   return QVariant();
+#else
+  parent->setEvalErrorString( QObject::tr( "Qt is built without Qt timezone support, cannot use fcnSetTimeZone" ) );
+  return QVariant();
+#endif
 }
 
 static QVariant fcnConvertTimeZone( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
+#if QT_FEATURE_timezone > 0
   const QDateTime datetime = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
   const QTimeZone tz = QgsExpressionUtils::getTimeZoneValue( values.at( 1 ), parent );
   if ( datetime.isValid() && tz.isValid() )
@@ -1409,16 +1426,25 @@ static QVariant fcnConvertTimeZone( const QVariantList &values, const QgsExpress
     return QVariant::fromValue( datetime.toTimeZone( tz ) );
   }
   return QVariant();
+#else
+  parent->setEvalErrorString( QObject::tr( "Qt is built without Qt timezone support, cannot use fcnConvertTimeZone" ) );
+  return QVariant();
+#endif
 }
 
 static QVariant fcnTimeZoneToId( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
+#if QT_FEATURE_timezone > 0
   const QTimeZone timeZone = QgsExpressionUtils::getTimeZoneValue( values.at( 0 ), parent );
   if ( timeZone.isValid() )
   {
     return QString( timeZone.id() );
   }
   return QVariant();
+#else
+  parent->setEvalErrorString( QObject::tr( "Qt is built without Qt timezone support, cannot use fcnTimeZoneToId" ) );
+  return QVariant();
+#endif
 }
 
 static QVariant fcnMakeInterval( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/src/core/gps/qgsgpslogger.cpp
+++ b/src/core/gps/qgsgpslogger.cpp
@@ -510,12 +510,16 @@ QDateTime QgsGpsLogger::lastTimestamp() const
 
   if ( mTimeStampSpec == Qt::TimeSpec::TimeZone )
   {
+#if QT_FEATURE_timezone > 0
     // Get timezone from the combo
     const QTimeZone destTz( mTimeZone.toUtf8() );
     if ( destTz.isValid() )
     {
       time = time.toTimeZone( destTz );
     }
+#else
+    QgsDebugError( QStringLiteral( "Qt is built without timezone support, cannot convert GPS timestamps to specified timezone." ) );
+#endif
   }
   else if ( mTimeStampSpec == Qt::TimeSpec::LocalTime )
   {

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1784,6 +1784,7 @@ bool QgsLayoutExporter::georeferenceOutputPrivate( const QString &file, QgsLayou
     {
       QString creationDateString;
       const QDateTime creationDateTime = mLayout->project()->metadata().creationDateTime();
+#if QT_FEATURE_timezone > 0
       if ( creationDateTime.isValid() )
       {
         creationDateString = QStringLiteral( "D:%1" ).arg( mLayout->project()->metadata().creationDateTime().toString( QStringLiteral( "yyyyMMddHHmmss" ) ) );
@@ -1797,6 +1798,9 @@ bool QgsLayoutExporter::georeferenceOutputPrivate( const QString &file, QgsLayou
           creationDateString += QStringLiteral( "%1'%2'" ).arg( offsetHours ).arg( offsetMins );
         }
       }
+#else
+      QgsDebugError( QStringLiteral( "Qt is built without timezone support, skipping timezone for pdf export" ) );
+#endif
       GDALSetMetadataItem( outputDS.get(), "CREATION_DATE", creationDateString.toUtf8().constData(), nullptr );
 
       GDALSetMetadataItem( outputDS.get(), "AUTHOR", mLayout->project()->metadata().author().toUtf8().constData(), nullptr );

--- a/src/core/maprenderer/qgsmaprenderertask.cpp
+++ b/src/core/maprenderer/qgsmaprenderertask.cpp
@@ -336,6 +336,7 @@ bool QgsMapRendererTask::run()
           {
             QString creationDateString;
             const QDateTime creationDateTime = mGeospatialPdfExportDetails.creationDateTime;
+#if QT_FEATURE_timezone > 0
             if ( creationDateTime.isValid() )
             {
               creationDateString = QStringLiteral( "D:%1" ).arg( mGeospatialPdfExportDetails.creationDateTime.toString( QStringLiteral( "yyyyMMddHHmmss" ) ) );
@@ -349,6 +350,9 @@ bool QgsMapRendererTask::run()
                 creationDateString += QStringLiteral( "%1'%2'" ).arg( offsetHours ).arg( offsetMins );
               }
             }
+#else
+            QgsDebugError( QStringLiteral( "Qt is built without timezone support, skipping timezone for pdf export" ) );
+#endif
             GDALSetMetadataItem( outputDS.get(), "CREATION_DATE", creationDateString.toUtf8().constData(), nullptr );
 
             GDALSetMetadataItem( outputDS.get(), "AUTHOR", mGeospatialPdfExportDetails.author.toUtf8().constData(), nullptr );

--- a/src/core/qgsabstractgeopdfexporter.cpp
+++ b/src/core/qgsabstractgeopdfexporter.cpp
@@ -330,6 +330,7 @@ QString QgsAbstractGeospatialPdfExporter::createCompositionXml( const QList<Comp
   {
     QDomElement creationDate = doc.createElement( QStringLiteral( "CreationDate" ) );
     QString creationDateString = QStringLiteral( "D:%1" ).arg( details.creationDateTime.toString( QStringLiteral( "yyyyMMddHHmmss" ) ) );
+#if QT_FEATURE_timezone > 0
     if ( details.creationDateTime.timeZone().isValid() )
     {
       int offsetFromUtc = details.creationDateTime.timeZone().offsetFromUtc( details.creationDateTime );
@@ -339,6 +340,9 @@ QString QgsAbstractGeospatialPdfExporter::createCompositionXml( const QList<Comp
       int offsetMins = ( offsetFromUtc % 3600 ) / 60;
       creationDateString += QStringLiteral( "%1'%2'" ).arg( offsetHours ).arg( offsetMins );
     }
+#else
+    QgsDebugError( QStringLiteral( "Qt is built without timezone support, skipping timezone for pdf export" ) );
+#endif
     creationDate.appendChild( doc.createTextNode( creationDateString ) );
     metadata.appendChild( creationDate );
   }


### PR DESCRIPTION
The timezone feature is disabled on WASM, see https://github.com/qt/qtbase/blob/3d75ca4ceb92890184bbfc9814979e7f7f4ec495/src/corelib/configure.cmake#L1154-L1158

This disables corresponding functionality and prints debug messages instead.

Refs https://github.com/qgis/qgis-js/issues/39