### PR TITLE
Add index buffer to QgsTessellator

### DIFF
--- a/python/PyQt6/core/auto_generated/qgstessellator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstessellator.sip.in
@@ -283,6 +283,21 @@ Returns a descriptive error string if the tessellation failed.
 .. versionadded:: 3.34
 %End
 
+    int uniqueVertexCount() const;
+%Docstring
+Returns unique vertex count.
+
+.. versionadded:: 4.0
+%End
+
+    void setMaterialColors( const QColor &diffuse, const QColor &ambient, const QColor &specular );
+%Docstring
+Sets the material colors for data-defined rendering. Colors are not
+applied to the already added polygons.
+
+.. versionadded:: 4.0
+%End
+
 };
 
 

--- a/python/PyQt6/core/auto_generated/qgstessellator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstessellator.sip.in
@@ -232,6 +232,20 @@ Returns array of triangle vertex data
 Vertice coordinates are stored as (x, z, -y)
 %End
 
+    QVector<uint32_t> indexBuffer() const;
+%Docstring
+Returns index buffer for the generated points.
+
+.. versionadded:: 4.0
+%End
+
+    QVector<float> vertexBuffer() const;
+%Docstring
+Returns vertex buffer for the generated points.
+
+.. versionadded:: 4.0
+%End
+
     int dataVerticesCount() const;
 %Docstring
 Returns the number of vertices stored in the output data array
@@ -240,6 +254,11 @@ Returns the number of vertices stored in the output data array
     int stride() const;
 %Docstring
 Returns size of one vertex entry in bytes
+%End
+
+    int indexStride() const;
+%Docstring
+Returns size of one index entry in bytes
 %End
 
 

--- a/python/PyQt6/core/auto_generated/qgstessellator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstessellator.sip.in
@@ -290,14 +290,6 @@ Returns unique vertex count.
 .. versionadded:: 4.0
 %End
 
-    void setMaterialColors( const QColor &diffuse, const QColor &ambient, const QColor &specular );
-%Docstring
-Sets the material colors for data-defined rendering. Colors are not
-applied to the already added polygons.
-
-.. versionadded:: 4.0
-%End
-
 };
 
 

--- a/python/PyQt6/core/auto_generated/qgstessellator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstessellator.sip.in
@@ -225,21 +225,25 @@ Tessellates a triangle and adds its vertex entries to the output data
 array
 %End
 
-    QVector<float> data() const;
+ QVector<float> data() const /Deprecated="Since 4.0. Use vertexBuffer() in combination with indexBuffer()."/;
 %Docstring
 Returns array of triangle vertex data
 
 Vertice coordinates are stored as (x, z, -y)
+
+.. deprecated:: 4.0
+
+   Use :py:func:`~QgsTessellator.vertexBuffer` in combination with :py:func:`~QgsTessellator.indexBuffer`.
 %End
 
-    QVector<uint32_t> indexBuffer() const;
+    QByteArray indexBuffer() const;
 %Docstring
 Returns index buffer for the generated points.
 
 .. versionadded:: 4.0
 %End
 
-    QVector<float> vertexBuffer() const;
+    QByteArray vertexBuffer() const;
 %Docstring
 Returns vertex buffer for the generated points.
 
@@ -259,6 +263,8 @@ Returns size of one vertex entry in bytes
     int indexStride() const;
 %Docstring
 Returns size of one index entry in bytes
+
+.. versionadded:: 4.0
 %End
 
 

--- a/python/PyQt6/core/conversions.sip
+++ b/python/PyQt6/core/conversions.sip
@@ -1672,6 +1672,65 @@ return sipGetState(sipTransferObj);
 %End
 };
 
+%MappedType QVector<uint32_t>
+    /TypeHintIn="Iterable[int]",
+    TypeHintOut="List[int]", TypeHintValue="[]"/
+{
+%TypeHeaderCode
+#include <QVector>
+#include <cstdint>
+%End
+
+%ConvertFromTypeCode
+    // Create the list.
+    PyObject *l = PyList_New(sipCpp->size());
+
+    if (!l)
+        return NULL;
+
+    for (int i = 0; i < sipCpp->size(); ++i)
+    {
+        PyObject *tobj = PyLong_FromUnsignedLong(sipCpp->at(i));
+
+        if (!tobj)
+        {
+            Py_DECREF(l);
+            return NULL;
+        }
+        PyList_SET_ITEM(l, i, tobj);
+    }
+
+    return l;
+%End
+
+%ConvertToTypeCode
+    // Check the type if that is all that is required.
+    if (sipIsErr == NULL)
+        return PyList_Check(sipPy);
+
+    QVector<uint32_t> *qvec = new QVector<uint32_t>;
+    qvec->reserve(PyList_GET_SIZE(sipPy));
+
+    for (Py_ssize_t i = 0; i < PyList_GET_SIZE(sipPy); ++i)
+    {
+        PyObject *item = PyList_GET_ITEM(sipPy, i);
+        unsigned long val = PyLong_AsUnsignedLong(item);
+
+        if (PyErr_Occurred())
+        {
+            delete qvec;
+            *sipIsErr = 1;
+            return 0;
+        }
+
+        qvec->append(static_cast<uint32_t>(val));
+    }
+
+    *sipCppPtr = qvec;
+    return sipGetState(sipTransferObj);
+%End
+};
+
 
 %MappedType QSet<qint64>
 {

--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -611,8 +611,8 @@ Qgs3DExportObject *Qgs3DSceneExporter::processGeometryRenderer( Qt3DRender::QGeo
         tempFeatToAdd += feat;
 
         // keep the feature triangle indexes
-        const uint startIdx = triangleIndex[idx] * 3;
-        const uint endIdx = idx < triangleIndex.size() - 1 ? triangleIndex[idx + 1] * 3 : std::numeric_limits<uint>::max();
+        const uint startIdx = triangleIndex[idx];
+        const uint endIdx = idx < triangleIndex.size() - 1 ? triangleIndex[idx + 1] : std::numeric_limits<uint>::max();
 
         if ( startIdx < endIdx ) // keep only valid intervals
           triangleIndexStartingIndiceToKeep.append( std::pair<uint, uint>( startIdx, endIdx ) );
@@ -705,23 +705,25 @@ Qgs3DExportObject *Qgs3DSceneExporter::processGeometryRenderer( Qt3DRender::QGeo
     int intervalIdx = 0;
     const int triangleIndexStartingIndiceToKeepSize = triangleIndexStartingIndiceToKeep.size();
     const uint indexDataTmpSize = static_cast<uint>( indexDataTmp.size() );
-    for ( uint i = 0; i < indexDataTmpSize; ++i )
+    for ( uint i = 0; i + 2 < indexDataTmpSize; i += 3 )
     {
-      uint idx = indexDataTmp[static_cast<int>( i )];
+      const uint triangleIdx = i / 3;
+
       // search for valid triangle index interval
       while ( intervalIdx < triangleIndexStartingIndiceToKeepSize
-              && idx > triangleIndexStartingIndiceToKeep[intervalIdx].first
-              && idx >= triangleIndexStartingIndiceToKeep[intervalIdx].second )
+              && triangleIdx >= triangleIndexStartingIndiceToKeep[intervalIdx].second )
       {
         intervalIdx++;
       }
 
-      // keep only the one within the triangle index interval
+      // keep only triangles within the triangle index interval
       if ( intervalIdx < triangleIndexStartingIndiceToKeepSize
-           && idx >= triangleIndexStartingIndiceToKeep[intervalIdx].first
-           && idx < triangleIndexStartingIndiceToKeep[intervalIdx].second )
+           && triangleIdx >= triangleIndexStartingIndiceToKeep[intervalIdx].first
+           && triangleIdx < triangleIndexStartingIndiceToKeep[intervalIdx].second )
       {
-        indexData.push_back( idx );
+        indexData.push_back( indexDataTmp[static_cast<int>( i )] );
+        indexData.push_back( indexDataTmp[static_cast<int>( i + 1 )] );
+        indexData.push_back( indexDataTmp[static_cast<int>( i + 2 )] );
       }
     }
   }

--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -469,14 +469,18 @@ void QgsRubberBand3D::updateGeometry()
         QgsMessageLog::logMessage( tessellator.error(), QObject::tr( "3D" ) );
       }
       // extract vertex buffer data from tessellator
-      const QByteArray data( reinterpret_cast<const char *>( tessellator.data().constData() ), static_cast<int>( tessellator.data().count() * sizeof( float ) ) );
-      const int vertexCount = static_cast<int>( data.count() ) / tessellator.stride();
-      mPolygonGeometry->setData( data, vertexCount, QVector<QgsFeatureId>(), QVector<uint>() );
+      const QByteArray vertexBuffer( reinterpret_cast<const char *>( tessellator.vertexBuffer().constData() ), static_cast<int>( tessellator.vertexBuffer().count() * sizeof( float ) ) );
+      const QByteArray indexBuffer( reinterpret_cast<const char *>( tessellator.indexBuffer().constData() ), static_cast<int>( tessellator.indexBuffer().count() * tessellator.indexStride() ) );
+      const int vertexCount = vertexBuffer.count() / tessellator.stride();
+      const size_t indexCount = tessellator.dataVerticesCount();
+
+      mPolygonGeometry->setVertexBufferData( vertexBuffer, vertexCount, QVector<QgsFeatureId>(), QVector<uint>() );
+      mPolygonGeometry->setIndexBufferData( indexBuffer, indexCount );
       mPolygonTransform->setGeoTranslation( mMapSettings->origin() );
     }
     else
     {
-      mPolygonGeometry->setData( QByteArray(), 0, QVector<QgsFeatureId>(), QVector<uint>() );
+      mPolygonGeometry->setVertexBufferData( QByteArray(), 0, QVector<QgsFeatureId>(), QVector<uint>() );
     }
   }
 }

--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -469,8 +469,8 @@ void QgsRubberBand3D::updateGeometry()
         QgsMessageLog::logMessage( tessellator.error(), QObject::tr( "3D" ) );
       }
       // extract vertex buffer data from tessellator
-      const QByteArray vertexBuffer( reinterpret_cast<const char *>( tessellator.vertexBuffer().constData() ), static_cast<int>( tessellator.vertexBuffer().count() * sizeof( float ) ) );
-      const QByteArray indexBuffer( reinterpret_cast<const char *>( tessellator.indexBuffer().constData() ), static_cast<int>( tessellator.indexBuffer().count() * tessellator.indexStride() ) );
+      const QByteArray vertexBuffer = tessellator.vertexBuffer();
+      const QByteArray indexBuffer = tessellator.indexBuffer();
       const size_t vertexCount = tessellator.uniqueVertexCount();
       const size_t indexCount = tessellator.dataVerticesCount();
 
@@ -481,6 +481,7 @@ void QgsRubberBand3D::updateGeometry()
     else
     {
       mPolygonGeometry->setVertexBufferData( QByteArray(), 0, QVector<QgsFeatureId>(), QVector<uint>() );
+      mPolygonGeometry->setIndexBufferData( QByteArray(), 0 );
     }
   }
 }

--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -471,7 +471,7 @@ void QgsRubberBand3D::updateGeometry()
       // extract vertex buffer data from tessellator
       const QByteArray vertexBuffer( reinterpret_cast<const char *>( tessellator.vertexBuffer().constData() ), static_cast<int>( tessellator.vertexBuffer().count() * sizeof( float ) ) );
       const QByteArray indexBuffer( reinterpret_cast<const char *>( tessellator.indexBuffer().constData() ), static_cast<int>( tessellator.indexBuffer().count() * tessellator.indexStride() ) );
-      const int vertexCount = vertexBuffer.count() / tessellator.stride();
+      const size_t vertexCount = tessellator.uniqueVertexCount();
       const size_t indexCount = tessellator.dataVerticesCount();
 
       mPolygonGeometry->setVertexBufferData( vertexBuffer, vertexCount, QVector<QgsFeatureId>(), QVector<uint>() );

--- a/src/3d/qgstessellatedpolygongeometry.cpp
+++ b/src/3d/qgstessellatedpolygongeometry.cpp
@@ -50,10 +50,10 @@ QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals,
   mPositionAttribute->setByteOffset( 0 );
   addAttribute( mPositionAttribute );
 
-  mIndexAttribute = new Qt3DQAttribute( this );
+  mIndexAttribute = new Qt3DCore::QAttribute( this );
   mIndexAttribute->setName( "indexBuffer" );
-  mIndexAttribute->setAttributeType( Qt3DQAttribute::IndexAttribute );
-  mIndexAttribute->setVertexBaseType( Qt3DQAttribute::UnsignedInt );
+  mIndexAttribute->setAttributeType( Qt3DCore::QAttribute::IndexAttribute );
+  mIndexAttribute->setVertexBaseType( Qt3DCore::QAttribute::UnsignedInt );
   mIndexAttribute->setBuffer( mIndexBuffer );
   addAttribute( mIndexAttribute );
 

--- a/src/3d/qgstessellatedpolygongeometry.cpp
+++ b/src/3d/qgstessellatedpolygongeometry.cpp
@@ -33,6 +33,7 @@ QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals,
   , mAddTextureCoords( _addTextureCoords )
 {
   mVertexBuffer = new Qt3DCore::QBuffer( this );
+  mIndexBuffer = new Qt3DCore::QBuffer( this );
 
   QgsTessellator tmpTess;
   tmpTess.setAddNormals( mWithNormals );
@@ -48,6 +49,13 @@ QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals,
   mPositionAttribute->setByteStride( stride );
   mPositionAttribute->setByteOffset( 0 );
   addAttribute( mPositionAttribute );
+
+  mIndexAttribute = new Qt3DQAttribute( this );
+  mIndexAttribute->setName( "indexBuffer" );
+  mIndexAttribute->setAttributeType( Qt3DQAttribute::IndexAttribute );
+  mIndexAttribute->setVertexBaseType( Qt3DQAttribute::UnsignedInt );
+  mIndexAttribute->setBuffer( mIndexBuffer );
+  addAttribute( mIndexAttribute );
 
   if ( mWithNormals )
   {
@@ -75,7 +83,7 @@ QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals,
   }
 }
 
-void QgsTessellatedPolygonGeometry::setData( const QByteArray &vertexBufferData, int vertexCount, const QVector<QgsFeatureId> &triangleIndexFids, const QVector<uint> &triangleIndexStartingIndices )
+void QgsTessellatedPolygonGeometry::setVertexBufferData( const QByteArray &vertexBufferData, int vertexCount, const QVector<QgsFeatureId> &triangleIndexFids, const QVector<uint> &triangleIndexStartingIndices )
 {
   mTriangleIndexStartingIndices = triangleIndexStartingIndices;
   mTriangleIndexFids = triangleIndexFids;
@@ -86,6 +94,12 @@ void QgsTessellatedPolygonGeometry::setData( const QByteArray &vertexBufferData,
     mNormalAttribute->setCount( vertexCount );
   if ( mTextureCoordsAttribute )
     mTextureCoordsAttribute->setCount( vertexCount );
+}
+
+void QgsTessellatedPolygonGeometry::setIndexBufferData( const QByteArray &indexBufferData, size_t indexCount )
+{
+  mIndexBuffer->setData( indexBufferData );
+  mIndexAttribute->setCount( indexCount );
 }
 
 // run binary search on a sorted array, return index i where data[i] <= v < data[i+1]

--- a/src/3d/qgstessellatedpolygongeometry.h
+++ b/src/3d/qgstessellatedpolygongeometry.h
@@ -76,7 +76,13 @@ class QgsTessellatedPolygonGeometry : public Qt3DCore::QGeometry
      * This is an alternative to setPolygons() - this method does not do any expensive work in the body.
      * \since QGIS 3.12
      */
-    void setData( const QByteArray &vertexBufferData, int vertexCount, const QVector<QgsFeatureId> &triangleIndexFids, const QVector<uint> &triangleIndexStartingIndices );
+    void setVertexBufferData( const QByteArray &vertexBufferData, int vertexCount, const QVector<QgsFeatureId> &triangleIndexFids, const QVector<uint> &triangleIndexStartingIndices );
+
+    /**
+     * Sets index buffer data
+     * \since QGIS 4.0
+     */
+    void setIndexBufferData( const QByteArray &indexBufferData, size_t indexCount );
 
     /**
      * Returns ID of the feature to which given triangle index belongs (used for picking).
@@ -93,10 +99,21 @@ class QgsTessellatedPolygonGeometry : public Qt3DCore::QGeometry
     friend class Qgs3DSceneExporter;
 
   private:
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
+    Qt3DRender::QAttribute *mPositionAttribute = nullptr;
+    Qt3DRender::QAttribute *mNormalAttribute = nullptr;
+    Qt3DRender::QAttribute *mTextureCoordsAttribute = nullptr;
+    Qt3DRender::QBuffer *mVertexBuffer = nullptr;
+    Qt3DRender::QBuffer *mIndexBuffer = nullptr;
+    Qt3DRender::QAttribute *mIndexAttribute = nullptr;
+#else
     Qt3DCore::QAttribute *mPositionAttribute = nullptr;
     Qt3DCore::QAttribute *mNormalAttribute = nullptr;
     Qt3DCore::QAttribute *mTextureCoordsAttribute = nullptr;
     Qt3DCore::QBuffer *mVertexBuffer = nullptr;
+    Qt3DCore::QBuffer *mIndexBuffer = nullptr;
+    Qt3DCore::QAttribute *mIndexAttribute = nullptr;
+#endif
 
     QVector<QgsFeatureId> mTriangleIndexFids;
     QVector<uint> mTriangleIndexStartingIndices;

--- a/src/3d/qgstessellatedpolygongeometry.h
+++ b/src/3d/qgstessellatedpolygongeometry.h
@@ -99,21 +99,12 @@ class QgsTessellatedPolygonGeometry : public Qt3DCore::QGeometry
     friend class Qgs3DSceneExporter;
 
   private:
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-    Qt3DRender::QAttribute *mPositionAttribute = nullptr;
-    Qt3DRender::QAttribute *mNormalAttribute = nullptr;
-    Qt3DRender::QAttribute *mTextureCoordsAttribute = nullptr;
-    Qt3DRender::QBuffer *mVertexBuffer = nullptr;
-    Qt3DRender::QBuffer *mIndexBuffer = nullptr;
-    Qt3DRender::QAttribute *mIndexAttribute = nullptr;
-#else
     Qt3DCore::QAttribute *mPositionAttribute = nullptr;
     Qt3DCore::QAttribute *mNormalAttribute = nullptr;
     Qt3DCore::QAttribute *mTextureCoordsAttribute = nullptr;
     Qt3DCore::QBuffer *mVertexBuffer = nullptr;
     Qt3DCore::QBuffer *mIndexBuffer = nullptr;
     Qt3DCore::QAttribute *mIndexAttribute = nullptr;
-#endif
 
     QVector<QgsFeatureId> mTriangleIndexFids;
     QVector<uint> mTriangleIndexStartingIndices;

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -218,8 +218,8 @@ void QgsBufferedLine3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, cons
   QgsMaterial *material = mSymbol->materialSettings()->toMaterial( QgsMaterialSettingsRenderingTechnique::Triangles, materialContext );
 
   // extract vertex buffer data from tessellator
-  const QByteArray vertexBuffer( ( const char * ) lineData.tessellator->vertexBuffer().constData(), static_cast<int>( lineData.tessellator->vertexBuffer().count() * sizeof( float ) ) );
-  const QByteArray indexBuffer( ( const char * ) lineData.tessellator->indexBuffer().constData(), static_cast<int>( lineData.tessellator->indexBuffer().count() * lineData.tessellator->indexStride() ) );
+  const QByteArray vertexBuffer = lineData.tessellator->vertexBuffer();
+  const QByteArray indexBuffer = lineData.tessellator->indexBuffer();
   const int vertexCount = vertexBuffer.count() / lineData.tessellator->stride();
   const size_t indexCount = lineData.tessellator->dataVerticesCount();
 

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -218,13 +218,16 @@ void QgsBufferedLine3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, cons
   QgsMaterial *material = mSymbol->materialSettings()->toMaterial( QgsMaterialSettingsRenderingTechnique::Triangles, materialContext );
 
   // extract vertex buffer data from tessellator
-  const QByteArray data( ( const char * ) lineData.tessellator->data().constData(), static_cast<int>( lineData.tessellator->data().count() * sizeof( float ) ) );
-  const int nVerts = data.count() / lineData.tessellator->stride();
+  const QByteArray vertexBuffer( ( const char * ) lineData.tessellator->vertexBuffer().constData(), static_cast<int>( lineData.tessellator->vertexBuffer().count() * sizeof( float ) ) );
+  const QByteArray indexBuffer( ( const char * ) lineData.tessellator->indexBuffer().constData(), static_cast<int>( lineData.tessellator->indexBuffer().count() * lineData.tessellator->indexStride() ) );
+  const int vertexCount = vertexBuffer.count() / lineData.tessellator->stride();
+  const size_t indexCount = lineData.tessellator->dataVerticesCount();
 
   const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast<const QgsPhongTexturedMaterialSettings *>( mSymbol->materialSettings() );
 
   QgsTessellatedPolygonGeometry *geometry = new QgsTessellatedPolygonGeometry( true, false, false, texturedMaterialSettings ? texturedMaterialSettings->requiresTextureCoordinates() : false );
-  geometry->setData( data, nVerts, lineData.triangleIndexFids, lineData.triangleIndexStartingIndices );
+  geometry->setVertexBufferData( vertexBuffer, vertexCount, lineData.triangleIndexFids, lineData.triangleIndexStartingIndices );
+  geometry->setIndexBufferData( indexBuffer, indexCount );
 
   Qt3DRender::QGeometryRenderer *renderer = new Qt3DRender::QGeometryRenderer;
   renderer->setGeometry( geometry );

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -360,8 +360,8 @@ void QgsPolygon3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs
   QgsMaterial *mat = material( mSymbol.get(), selected, context );
 
   // extract vertex buffer data from tessellator
-  const QByteArray vertexBuffer( reinterpret_cast<const char *>( polyData.tessellator->vertexBuffer().constData() ), static_cast<int>( polyData.tessellator->vertexBuffer().count() * sizeof( float ) ) );
-  const QByteArray indexBuffer( reinterpret_cast<const char *>( polyData.tessellator->indexBuffer().constData() ), static_cast<int>( polyData.tessellator->indexBuffer().count() * polyData.tessellator->indexStride() ) );
+  const QByteArray vertexBuffer = polyData.tessellator->vertexBuffer();
+  const QByteArray indexBuffer = polyData.tessellator->indexBuffer();
   const int vertexCount = polyData.tessellator->uniqueVertexCount();
   const size_t indexCount = polyData.tessellator->dataVerticesCount();
 

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -221,20 +221,6 @@ void QgsPolygon3DSymbolHandler::processPolygon( const QgsPolygon *poly, QgsFeatu
   out.triangleIndexStartingIndices.append( startingTriangleIndex );
   out.triangleIndexFids.append( fid );
 
-  if ( mSymbol->materialSettings()->dataDefinedProperties().hasActiveProperties() )
-  {
-    const QByteArray bytes = mSymbol->materialSettings()->dataDefinedVertexColorsAsByte( context.expressionContext() );
-
-    QColor diffuse;
-    QColor ambient;
-    QColor specular;
-    diffuse.setRgb( static_cast<unsigned char>( bytes[0] ), static_cast<unsigned char>( bytes[1] ), static_cast<unsigned char>( bytes[2] ) );
-    ambient.setRgb( static_cast<unsigned char>( bytes[3] ), static_cast<unsigned char>( bytes[4] ), static_cast<unsigned char>( bytes[5] ) );
-    specular.setRgb( static_cast<unsigned char>( bytes[6] ), static_cast<unsigned char>( bytes[7] ), static_cast<unsigned char>( bytes[8] ) );
-
-    out.tessellator->setMaterialColors( diffuse, ambient, specular );
-  }
-
   const size_t oldVertexCount = out.tessellator->uniqueVertexCount();
   out.tessellator->addPolygon( *polyClone, extrusionHeight );
   if ( !out.tessellator->error().isEmpty() )

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -133,7 +133,6 @@ void QgsPolygon3DSymbolHandler::processPolygon( const QgsPolygon *poly, QgsFeatu
 {
   std::unique_ptr<QgsPolygon> polyClone( poly->clone() );
 
-  const uint oldVerticesCount = out.tessellator->dataVerticesCount();
   if ( mSymbol->edgesEnabled() )
   {
     // add edges before the polygon gets the Z values modified because addLineString() does its own altitude handling
@@ -221,6 +220,22 @@ void QgsPolygon3DSymbolHandler::processPolygon( const QgsPolygon *poly, QgsFeatu
   const uint startingTriangleIndex = static_cast<uint>( out.tessellator->dataVerticesCount() / 3 );
   out.triangleIndexStartingIndices.append( startingTriangleIndex );
   out.triangleIndexFids.append( fid );
+
+  if ( mSymbol->materialSettings()->dataDefinedProperties().hasActiveProperties() )
+  {
+    const QByteArray bytes = mSymbol->materialSettings()->dataDefinedVertexColorsAsByte( context.expressionContext() );
+
+    QColor diffuse;
+    QColor ambient;
+    QColor specular;
+    diffuse.setRgb( static_cast<unsigned char>( bytes[0] ), static_cast<unsigned char>( bytes[1] ), static_cast<unsigned char>( bytes[2] ) );
+    ambient.setRgb( static_cast<unsigned char>( bytes[3] ), static_cast<unsigned char>( bytes[4] ), static_cast<unsigned char>( bytes[5] ) );
+    specular.setRgb( static_cast<unsigned char>( bytes[6] ), static_cast<unsigned char>( bytes[7] ), static_cast<unsigned char>( bytes[8] ) );
+
+    out.tessellator->setMaterialColors( diffuse, ambient, specular );
+  }
+
+  const size_t oldVertexCount = out.tessellator->uniqueVertexCount();
   out.tessellator->addPolygon( *polyClone, extrusionHeight );
   if ( !out.tessellator->error().isEmpty() )
   {
@@ -228,7 +243,10 @@ void QgsPolygon3DSymbolHandler::processPolygon( const QgsPolygon *poly, QgsFeatu
   }
 
   if ( mSymbol->materialSettings()->dataDefinedProperties().hasActiveProperties() )
-    processMaterialDatadefined( out.tessellator->dataVerticesCount() - oldVerticesCount, context.expressionContext(), out );
+  {
+    const uint newUniqueVertices = out.tessellator->uniqueVertexCount() - oldVertexCount;
+    processMaterialDatadefined( newUniqueVertices, context.expressionContext(), out );
+  }
 }
 
 void QgsPolygon3DSymbolHandler::processMaterialDatadefined( uint verticesCount, const QgsExpressionContext &context, QgsPolygon3DSymbolHandler::PolygonData &out )
@@ -358,7 +376,7 @@ void QgsPolygon3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs
   // extract vertex buffer data from tessellator
   const QByteArray vertexBuffer( reinterpret_cast<const char *>( polyData.tessellator->vertexBuffer().constData() ), static_cast<int>( polyData.tessellator->vertexBuffer().count() * sizeof( float ) ) );
   const QByteArray indexBuffer( reinterpret_cast<const char *>( polyData.tessellator->indexBuffer().constData() ), static_cast<int>( polyData.tessellator->indexBuffer().count() * polyData.tessellator->indexStride() ) );
-  const int vertexCount = vertexBuffer.count() / polyData.tessellator->stride();
+  const int vertexCount = polyData.tessellator->uniqueVertexCount();
   const size_t indexCount = polyData.tessellator->dataVerticesCount();
 
   const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast<const QgsPhongTexturedMaterialSettings *>( mSymbol->materialSettings() );

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -356,18 +356,20 @@ void QgsPolygon3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs
   QgsMaterial *mat = material( mSymbol.get(), selected, context );
 
   // extract vertex buffer data from tessellator
-  const QByteArray data( reinterpret_cast<const char *>( polyData.tessellator->data().constData() ), static_cast<int>( polyData.tessellator->data().count() * sizeof( float ) ) );
-  const int nVerts = data.count() / polyData.tessellator->stride();
+  const QByteArray vertexBuffer( reinterpret_cast<const char *>( polyData.tessellator->vertexBuffer().constData() ), static_cast<int>( polyData.tessellator->vertexBuffer().count() * sizeof( float ) ) );
+  const QByteArray indexBuffer( reinterpret_cast<const char *>( polyData.tessellator->indexBuffer().constData() ), static_cast<int>( polyData.tessellator->indexBuffer().count() * polyData.tessellator->indexStride() ) );
+  const int vertexCount = vertexBuffer.count() / polyData.tessellator->stride();
+  const size_t indexCount = polyData.tessellator->dataVerticesCount();
 
   const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast<const QgsPhongTexturedMaterialSettings *>( mSymbol->materialSettings() );
 
   QgsTessellatedPolygonGeometry *geometry = new QgsTessellatedPolygonGeometry( true, mSymbol->invertNormals(), mSymbol->addBackFaces(), texturedMaterialSettings && texturedMaterialSettings->requiresTextureCoordinates() );
 
-  geometry->setData( data, nVerts, polyData.triangleIndexFids, polyData.triangleIndexStartingIndices );
+  geometry->setVertexBufferData( vertexBuffer, vertexCount, polyData.triangleIndexFids, polyData.triangleIndexStartingIndices );
+  geometry->setIndexBufferData( indexBuffer, indexCount );
 
   if ( mSymbol->materialSettings()->dataDefinedProperties().hasActiveProperties() )
-    mSymbol->materialSettings()->applyDataDefinedToGeometry( geometry, nVerts, polyData.materialDataDefined );
-
+    mSymbol->materialSettings()->applyDataDefinedToGeometry( geometry, vertexCount, polyData.materialDataDefined );
   Qt3DRender::QGeometryRenderer *renderer = new Qt3DRender::QGeometryRenderer;
   renderer->setGeometry( geometry );
 

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -1284,7 +1284,10 @@ QVector<QgsPointXY> randomPointsInPolygonPoly2TriBackend( const QgsAbstractGeome
     return QVector< QgsPointXY >();
   }
 
+  // tessellator data() method can be removed when minimum GEOS version is 3.11 or above
+  QT_WARNING_PUSH QT_WARNING_DISABLE_DEPRECATED
   const QVector<float> triangleData = t.data();
+  QT_WARNING_POP
   if ( triangleData.empty() )
     return QVector< QgsPointXY >(); //hm
 

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -539,9 +539,14 @@ double minimumDistanceBetweenCoordinates( const QgsPolygon &polygon )
   return min_d != 1e20 ? std::sqrt( min_d ) : 1e20;
 }
 
-QVector<float> QgsTessellator::vertexBuffer() const
+QByteArray QgsTessellator::vertexBuffer() const
 {
-  return mData;
+  return QByteArray( reinterpret_cast<const char *>( mData.constData() ), sizeof( float ) * mData.size() );
+}
+
+QByteArray QgsTessellator::indexBuffer() const
+{
+  return QByteArray( reinterpret_cast<const char *>( mIndexBuffer.constData() ), sizeof( uint32_t ) * mIndexBuffer.size() );
 }
 
 void QgsTessellator::calculateBaseTransform( const QVector3D &pNormal, QMatrix4x4 *base ) const

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -328,8 +328,12 @@ void QgsTessellator::updateStride()
     mStride += 2 * sizeof( float );
 }
 
-void QgsTessellator::addVertexPoint( const VertexPoint &vertexPoint )
+void QgsTessellator::addVertexPoint( VertexPoint &vertexPoint )
 {
+  vertexPoint.diffuseColor = mDiffuseColor;
+  vertexPoint.ambientColor = mAmbientColor;
+  vertexPoint.specularColor = mSpecularColor;
+
   if ( mVertexBuffer.contains( vertexPoint ) )
   {
     const uint32_t index = mVertexBuffer.value( vertexPoint );
@@ -718,7 +722,7 @@ void QgsTessellator::addTriangleVertices(
 
     if ( mAddTextureCoords )
     {
-      const std::pair<float, float> pr = rotateCoords( static_cast<float>( fx ), static_cast<float>( fy ), 0.0f, 0.0f, mTextureRotation );
+      const std::pair<float, float> pr = rotateCoords( static_cast<float>( pt.x() ), static_cast<float>( pt.y() ), 0.0f, 0.0f, mTextureRotation );
       vertexPoint.u = pr.first;
       vertexPoint.v = pr.second;
     }
@@ -1089,4 +1093,9 @@ QVector<float> QgsTessellator::data() const
   }
 
   return tData;
+}
+
+int QgsTessellator::uniqueVertexCount() const
+{
+  return mVertexBuffer.size();
 }

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -622,7 +622,7 @@ QVector<float> QgsTessellator::vertexBuffer() const
     const VertexPoint &vertex = it.key();
     uint32_t index = it.value();
 
-    int offset = stride() / sizeof( float );
+    size_t offset = stride() / sizeof( float );
 
     vertexData[ index * offset ] = vertex.position.x();
     vertexData[ index * offset + 1 ] = vertex.position.y();
@@ -705,7 +705,7 @@ void QgsTessellator::addTriangleVertices(
 
     if ( mOutputZUp )
     {
-      vertexPoint.position = QVector3D( fx, fy, fz );
+      vertexPoint.position = QVector3D( static_cast<float>( fx ), static_cast<float>( fy ), static_cast<float>( fz ) );
       if ( mAddNormals )
       {
         vertexPoint.normal = normal;
@@ -713,7 +713,7 @@ void QgsTessellator::addTriangleVertices(
     }
     else
     {
-      vertexPoint.position = QVector3D( fx, fz, -fy );
+      vertexPoint.position = QVector3D( static_cast<float>( fx ), static_cast<float>( fz ), static_cast<float>( -fy ) );
       if ( mAddNormals )
       {
         vertexPoint.normal = QVector3D( normal.x(), normal.z(), - normal.y() );

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -103,12 +103,6 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
   textureCoordinates.push_back( u2 );
   textureCoordinates.push_back( v2 );
 
-  textureCoordinates.push_back( u2 );
-  textureCoordinates.push_back( v2 );
-
-  textureCoordinates.push_back( u1 );
-  textureCoordinates.push_back( v1 );
-
   textureCoordinates.push_back( u3 );
   textureCoordinates.push_back( v3 );
 
@@ -119,99 +113,55 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
     textureCoordinates[i + 1] = rotated.second;
   }
 
-  VertexPoint vertexPoint;
-
-  // triangle 1
-  // vertice 1
+  // triangle 1 vertex 1
+  mIndexBuffer << uniqueVertexCount();
   if ( mOutputZUp )
-    vertexPoint.position = QVector3D( pt1.x(), pt1.y(), pt1.z() + height );
+    mData << pt1.x() << pt1.y() << pt1.z() + height;
   else
-    vertexPoint.position = QVector3D( pt1.x(), pt1.z() + height, -pt1.y() );
+    mData << pt1.x() << pt1.z() + height << -pt1.y();
   if ( mAddNormals )
-    vertexPoint.normal = vn;
+    mData << vn.x() << vn.y() << vn.z();
   if ( mAddTextureCoords )
-  {
-    vertexPoint.u = textureCoordinates[0];
-    vertexPoint.v = textureCoordinates[1];
-  }
+    mData << textureCoordinates[0] << textureCoordinates[1];
 
-  addVertexPoint( vertexPoint );
-
-  // vertice 2
+  // triangle 1 vertex 2
+  mIndexBuffer << uniqueVertexCount();
   if ( mOutputZUp )
-    vertexPoint.position = QVector3D( pt2.x(), pt2.y(), pt2.z() + height );
+    mData << pt2.x() << pt2.y() << pt2.z() + height;
   else
-    vertexPoint.position = QVector3D( pt2.x(), pt2.z() + height, -pt2.y() );
+    mData << pt2.x() << pt2.z() + height << -pt2.y();
   if ( mAddNormals )
-    vertexPoint.normal = vn;
+    mData << vn.x() << vn.y() << vn.z();
   if ( mAddTextureCoords )
-  {
-    vertexPoint.u = textureCoordinates[2];
-    vertexPoint.v = textureCoordinates[3];
-  }
+    mData << textureCoordinates[2] << textureCoordinates[3];
 
-  addVertexPoint( vertexPoint );
-
-  // vertice 3
+  // triangle 1 vertex 3
+  mIndexBuffer << uniqueVertexCount();
   if ( mOutputZUp )
-    vertexPoint.position = pt1;
+    mData << pt1.x() << pt1.y() << pt1.z();
   else
-    vertexPoint.position = QVector3D( pt1.x(), pt1.z(), -pt1.y() );
+    mData << pt1.x() << pt1.z() << -pt1.y();
   if ( mAddNormals )
-    vertexPoint.normal = vn;
+    mData << vn.x() << vn.y() << vn.z();
   if ( mAddTextureCoords )
-  {
-    vertexPoint.u = textureCoordinates[4];
-    vertexPoint.v = textureCoordinates[5];
-  }
+    mData << textureCoordinates[4] << textureCoordinates[5];
 
-  addVertexPoint( vertexPoint );
+  // triangle 2 vertex 1
+  mIndexBuffer << uniqueVertexCount() - 1;
 
-  // triangle 2
-  // vertice 1
+  // triangle 2 vertex 2
+  mIndexBuffer << uniqueVertexCount() - 2;
+
+  // triangle 2 vertex 3
+  mIndexBuffer << uniqueVertexCount();
   if ( mOutputZUp )
-    vertexPoint.position = pt1;
+    mData << pt2.x() << pt2.y() << pt2.z();
   else
-    vertexPoint.position = QVector3D( pt1.x(), pt1.z(), -pt1.y() );
+    mData << pt2.x() << pt2.z() << -pt2.y();
   if ( mAddNormals )
-    vertexPoint.normal = vn;
+    mData << vn.x() << vn.y() << vn.z();
   if ( mAddTextureCoords )
-  {
-    vertexPoint.u = textureCoordinates[6];
-    vertexPoint.v = textureCoordinates[7];
-  }
-
-  addVertexPoint( vertexPoint );
-
-  // vertice 2
-  if ( mOutputZUp )
-    vertexPoint.position = QVector3D( pt2.x(), pt2.y(), pt2.z() + height );
-  else
-    vertexPoint.position = QVector3D( pt2.x(), pt2.z() + height, -pt2.y() );
-  if ( mAddNormals )
-    vertexPoint.normal = vn;
-  if ( mAddTextureCoords )
-  {
-    vertexPoint.u = textureCoordinates[8];
-    vertexPoint.v = textureCoordinates[9];
-  }
-
-  addVertexPoint( vertexPoint );
-
-  // vertice 3
-  if ( mOutputZUp )
-    vertexPoint.position = pt2;
-  else
-    vertexPoint.position = QVector3D( pt2.x(), pt2.z(), -pt2.y() );
-  if ( mAddNormals )
-    vertexPoint.normal = vn;
-  if ( mAddTextureCoords )
-  {
-    vertexPoint.u = textureCoordinates[10];
-    vertexPoint.v = textureCoordinates[11];
-  }
-
-  addVertexPoint( vertexPoint );
+    mData << textureCoordinates[6] << textureCoordinates[7];
 }
 
 QgsTessellator::QgsTessellator() = default;
@@ -326,25 +276,6 @@ void QgsTessellator::updateStride()
     mStride += 3 * sizeof( float );
   if ( mAddTextureCoords )
     mStride += 2 * sizeof( float );
-}
-
-void QgsTessellator::addVertexPoint( VertexPoint &vertexPoint )
-{
-  vertexPoint.diffuseColor = mDiffuseColor;
-  vertexPoint.ambientColor = mAmbientColor;
-  vertexPoint.specularColor = mSpecularColor;
-
-  if ( mVertexBuffer.contains( vertexPoint ) )
-  {
-    const uint32_t index = mVertexBuffer.value( vertexPoint );
-    mIndexBuffer << index;
-  }
-  else
-  {
-    const uint32_t index = mVertexBuffer.size();
-    mVertexBuffer.insert( vertexPoint, index );
-    mIndexBuffer << index;
-  }
 }
 
 void QgsTessellator::makeWalls( const QgsLineString &ring, bool ccw, float extrusionHeight )
@@ -610,39 +541,7 @@ double minimumDistanceBetweenCoordinates( const QgsPolygon &polygon )
 
 QVector<float> QgsTessellator::vertexBuffer() const
 {
-  const size_t vertexCount = mVertexBuffer.size();
-  if ( vertexCount == 0 )
-    return QVector<float>();
-
-  QVector<float> vertexData;
-  vertexData.resize( vertexCount * ( stride() / sizeof( float ) ) );
-
-  for ( auto it = mVertexBuffer.constBegin(); it != mVertexBuffer.constEnd(); ++it )
-  {
-    const VertexPoint &vertex = it.key();
-    uint32_t index = it.value();
-
-    size_t offset = stride() / sizeof( float );
-
-    vertexData[ index * offset ] = vertex.position.x();
-    vertexData[ index * offset + 1 ] = vertex.position.y();
-    vertexData[ index * offset + 2 ] = vertex.position.z();
-
-    if ( mAddNormals )
-    {
-      vertexData[ index * offset + 3 ] = vertex.normal.x();
-      vertexData[ index * offset + 4 ] = vertex.normal.y();
-      vertexData[ index * offset + 5 ] = vertex.normal.z();
-    }
-
-    if ( mAddTextureCoords )
-    {
-      vertexData[ index * offset + ( mAddNormals ? 6 : 3 ) ] = vertex.u;
-      vertexData[ index * offset + ( mAddNormals ? 7 : 4 ) ] = vertex.v;
-    }
-  }
-
-  return vertexData;
+  return mData;
 }
 
 void QgsTessellator::calculateBaseTransform( const QVector3D &pNormal, QMatrix4x4 *base ) const
@@ -669,67 +568,38 @@ void QgsTessellator::calculateBaseTransform( const QVector3D &pNormal, QMatrix4x
   }
 }
 
-void QgsTessellator::addTriangleVertices(
-  const std::array<QVector3D, 3> &points,
-  QVector3D pNormal,
+QVector3D QgsTessellator::applyTransformWithExtrusion(
+  const QVector3D point,
   float extrusionHeight,
   QMatrix4x4 *transformMatrix,
-  const QgsPoint *originOffset,
-  bool reverse
+  const QgsPoint *originOffset
 )
 {
-  // if reverse is true, the triangle vertices are added in reverse order and normal is inverted
-  const QVector3D normal = reverse ? -pNormal : pNormal;
-  for ( int i = 0; i < 3; ++i )
-  {
-    const int index = reverse ? 2 - i : i;
+  const float z = mInputZValueIgnored ? 0.0f : point.z();
+  QVector4D pt( point.x(), point.y(), z, 0 );
 
-    // cppcheck-suppress negativeContainerIndex
-    QVector3D point = points[ index ];
-    const float z = mInputZValueIgnored ? 0.0f : point.z();
-    QVector4D pt( point.x(), point.y(), z, 0 );
+  pt = *transformMatrix * pt;
 
-    pt = *transformMatrix * pt;
+  const double fx = pt.x() - mOrigin.x() + originOffset->x();
+  const double fy = pt.y() - mOrigin.y() + originOffset->y();
+  const double baseHeight = mInputZValueIgnored ? 0 : pt.z() - mOrigin.z() + originOffset->z();
+  const double fz = mInputZValueIgnored ? 0.0 : ( baseHeight + extrusionHeight );
 
-    const double fx = pt.x() - mOrigin.x() + originOffset->x();
-    const double fy = pt.y() - mOrigin.y() + originOffset->y();
-    const double baseHeight = mInputZValueIgnored ? 0 : pt.z() - mOrigin.z() + originOffset->z();
-    const double fz = mInputZValueIgnored ? 0.0 : ( baseHeight + extrusionHeight );
+  if ( baseHeight < mZMin )
+    mZMin =  static_cast<float>( baseHeight );
+  if ( baseHeight > mZMax )
+    mZMax = static_cast<float>( baseHeight );
+  if ( fz > mZMax )
+    mZMax = static_cast<float>( fz );
 
-    if ( baseHeight < mZMin )
-      mZMin =  static_cast<float>( baseHeight );
-    if ( baseHeight > mZMax )
-      mZMax = static_cast<float>( baseHeight );
-    if ( fz > mZMax )
-      mZMax = static_cast<float>( fz );
-
-    if ( mOutputZUp )
-    {
-      vertexPoint.position = QVector3D( static_cast<float>( fx ), static_cast<float>( fy ), static_cast<float>( fz ) );
-      if ( mAddNormals )
-      {
-        vertexPoint.normal = normal;
-      }
-    }
-    else
-    {
-      vertexPoint.position = QVector3D( static_cast<float>( fx ), static_cast<float>( fz ), static_cast<float>( -fy ) );
-      if ( mAddNormals )
-      {
-        vertexPoint.normal = QVector3D( normal.x(), normal.z(), - normal.y() );
-      }
-    }
-
-    if ( mAddTextureCoords )
-    {
-      const std::pair<float, float> pr = rotateCoords( static_cast<float>( pt.x() ), static_cast<float>( pt.y() ), 0.0f, 0.0f, mTextureRotation );
-      vertexPoint.u = pr.first;
-      vertexPoint.v = pr.second;
-    }
-
-    addVertexPoint( vertexPoint );
-  }
+  // NOLINTBEGIN(bugprone-branch-clone);
+  if ( mOutputZUp )
+    return QVector3D( static_cast<float>( fx ), static_cast<float>( fy ), static_cast<float>( fz ) );
+  else
+    return QVector3D( static_cast<float>( fx ), static_cast<float>( fz ), static_cast<float>( -fy ) );
+  // NOLINTEND(bugprone-branch-clone)
 }
+
 
 void QgsTessellator::ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, QHash<std::array<double, 2>*, float> *zHash )
 {
@@ -842,6 +712,50 @@ std::vector<QVector3D> QgsTessellator::generateEarcutTriangles( const QgsPolygon
   return trianglePoints;
 }
 
+void QgsTessellator::addVertex( const QVector3D &point, const QVector3D &normal, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset,  QHash<VertexPoint, unsigned int> *vertexBuffer, const size_t &vertexBufferOffset )
+{
+  const QVector3D pt = applyTransformWithExtrusion( point, extrusionHeight, transformMatrix, originOffset );
+  const VertexPoint vertex( pt, normal );
+  if ( vertexBuffer->contains( vertex ) )
+  {
+    unsigned int index = vertexBuffer->value( vertex );
+    mIndexBuffer << vertexBufferOffset + index;
+  }
+  else
+  {
+    unsigned int index = vertexBuffer->size();
+    vertexBuffer->insert( vertex, index );
+    mIndexBuffer << vertexBufferOffset + index;
+
+    mData << pt.x() << pt.y() << pt.z();
+    if ( mAddNormals )
+    {
+      mData << normal.x() << normal.y() << normal.z();
+    }
+    if ( mAddTextureCoords )
+    {
+      const std::pair<float, float> pr = rotateCoords( static_cast<float>( point.x() ), static_cast<float>( point.y() ), 0.0f, 0.0f, mTextureRotation );
+      mData << pr.first << pr.second;
+    }
+  }
+}
+
+void QgsTessellator::addVertex( const QVector3D &point, const QVector3D &normal, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset )
+{
+  const QVector3D pt = applyTransformWithExtrusion( point, extrusionHeight, transformMatrix, originOffset );
+  mIndexBuffer << uniqueVertexCount();
+  mData << pt.x() << pt.y() << pt.z();
+  if ( mAddNormals )
+  {
+    mData << normal.x() << normal.y() << normal.z();
+  }
+  if ( mAddTextureCoords )
+  {
+    const std::pair<float, float> pr = rotateCoords( static_cast<float>( point.x() ), static_cast<float>( point.y() ), 0.0f, 0.0f, mTextureRotation );
+    mData << pr.first << pr.second;
+  }
+}
+
 void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeight )
 {
   const QgsLineString *exterior = qgsgeometry_cast< const QgsLineString * >( polygon.exteriorRing() );
@@ -870,6 +784,15 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
     calculateBaseTransform( pNormal, &base );
     polygonNew.reset( transformPolygonToNewBase( polygon, extrusionOrigin, &base, mScale ) );
 
+    QVector3D normal;
+    if ( !mOutputZUp )
+    {
+      normal = QVector3D( pNormal.x(), pNormal.z(), - pNormal.y() );
+    }
+    else
+    {
+      normal = pNormal;
+    }
     // our 3x3 matrix is orthogonal, so for inverse we only need to transpose it
     base = base.transposed();
 
@@ -881,21 +804,36 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
       const QVector3D p1( static_cast<float>( triangle->xAt( 0 ) ), static_cast<float>( triangle->yAt( 0 ) ), static_cast<float>( triangle->zAt( 0 ) ) );
       const QVector3D p2( static_cast<float>( triangle->xAt( 1 ) ), static_cast<float>( triangle->yAt( 1 ) ), static_cast<float>( triangle->zAt( 1 ) ) );
       const QVector3D p3( static_cast<float>( triangle->xAt( 2 ) ), static_cast<float>( triangle->yAt( 2 ) ), static_cast<float>( triangle->zAt( 2 ) ) );
-      const std::array<QVector3D, 3> points = { { p1, p2, p3 } };
+      std::array<QVector3D, 3> points = { p1, p2, p3 };
 
-      addTriangleVertices( points, pNormal, extrusionHeight, &base, &extrusionOrigin, false );
+      for ( const QVector3D &point : points )
+      {
+        addVertex( point, normal, extrusionHeight, &base, &extrusionOrigin );
+      }
 
       if ( mAddBackFaces )
       {
-        addTriangleVertices( points, pNormal, extrusionHeight, &base, &extrusionOrigin, true );
+        for ( size_t i = points.size(); i-- > 0; )
+        {
+          const QVector3D &point = points[ i ];
+          addVertex( point, -normal, extrusionHeight, &base, &extrusionOrigin );
+        }
       }
 
       if ( extrusionHeight != 0 && buildFloor )
       {
-        addTriangleVertices( points, pNormal, 0, &base, &extrusionOrigin, false );
+        for ( const QVector3D &point : points )
+        {
+          addVertex( point, normal, 0.0, &base, &extrusionOrigin );
+        }
+
         if ( mAddBackFaces )
         {
-          addTriangleVertices( points, pNormal, 0, &base, &extrusionOrigin, true );
+          for ( size_t i = points.size(); i-- > 0; )
+          {
+            const QVector3D &point = points[ i ];
+            addVertex( point, -normal, 0.0, &base, &extrusionOrigin );
+          }
         }
       }
     }
@@ -951,26 +889,41 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
 
         mData.reserve( mData.size() + trianglePoints.size() * 3 * ( stride() / sizeof( float ) ) );
 
+        const size_t vertexBufferSize = uniqueVertexCount();
+        QHash<VertexPoint, unsigned int> vertexBuffer;
         for ( size_t i = 0; i < trianglePoints.size(); i += 3 )
         {
-          const QVector3D p1 = trianglePoints[ i + 0 ];
-          const QVector3D p2 = trianglePoints[ i + 1 ];
-          const QVector3D p3 = trianglePoints[ i + 2 ];
-          const std::array<QVector3D, 3> points = { { p1, p2, p3 } };
+          const std::array<QVector3D, 3> points = { trianglePoints[ i + 0 ], trianglePoints[ i + 1 ], trianglePoints[ i + 2 ] };
 
-          addTriangleVertices( points, pNormal, extrusionHeight, &base, &extrusionOrigin, false );
+          // roof
+          for ( const QVector3D &point : points )
+          {
+            addVertex( point, normal, extrusionHeight, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize );
+          }
 
           if ( mAddBackFaces )
           {
-            addTriangleVertices( points, pNormal, extrusionHeight, &base, &extrusionOrigin, true );
+            for ( size_t i = points.size(); i-- > 0; )
+            {
+              const QVector3D &point = points[ i ];
+              addVertex( point, -normal, extrusionHeight, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize );
+            }
           }
 
           if ( extrusionHeight != 0 && buildFloor )
           {
-            addTriangleVertices( points, pNormal, 0, &base, &extrusionOrigin, true );
+            for ( const QVector3D &point : points )
+            {
+              addVertex( point, normal, 0.0, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize );
+            }
+
             if ( mAddBackFaces )
             {
-              addTriangleVertices( points, pNormal, 0, &base, &extrusionOrigin, false );
+              for ( size_t i = points.size(); i-- > 0; )
+              {
+                const QVector3D &point = points[ i ];
+                addVertex( point, -normal, 0.0, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize );
+              }
             }
           }
         }
@@ -1008,41 +961,27 @@ std::unique_ptr<QgsMultiPolygon> QgsTessellator::asMultiPolygon() const
   Q_ASSERT( nVals % 3 == 0 );
 
   mp->reserve( nVals / 3 );
-
-  QVector<VertexPoint> vertexPoints;
-  vertexPoints.resize( mIndexBuffer.size() );
-
-  for ( auto it = mVertexBuffer.constBegin(); it != mVertexBuffer.constEnd(); ++it )
-  {
-    const VertexPoint &vertex = it.key();
-    const uint32_t index = it.value();
-
-    vertexPoints[ index ] = vertex;
-  }
+  const size_t noOfElements = stride() / sizeof( float );
 
   for ( size_t i = 0; i + 2 < nVals; i += 3 )
   {
-    const uint32_t index1 = mIndexBuffer[ i ];
-    const uint32_t index2 = mIndexBuffer[ i + 1 ];
-    const uint32_t index3 = mIndexBuffer[ i + 2 ];
-
-    const VertexPoint vertex1 = vertexPoints[ index1 ];
-    const VertexPoint vertex2 = vertexPoints[ index2 ];
-    const VertexPoint vertex3 = vertexPoints[ index3  ];
+    const uint32_t index1 = mIndexBuffer[ i ] * noOfElements;
+    const uint32_t index2 = mIndexBuffer[ i + 1 ] * noOfElements;
+    const uint32_t index3 = mIndexBuffer[ i + 2 ] * noOfElements;
 
     if ( mOutputZUp )
     {
-      const QgsPoint p1( vertex1.position.x(), vertex1.position.y(), vertex1.position.z() );
-      const QgsPoint p2( vertex2.position.x(), vertex2.position.y(), vertex2.position.z() );
-      const QgsPoint p3( vertex3.position.x(), vertex3.position.y(), vertex3.position.z() );
+      const QgsPoint p1( mData[ index1 ], mData[ index1 + 1 ], mData[ index1 + 2 ] );
+      const QgsPoint p2( mData[ index2 ], mData[ index2 + 1 ], mData[ index2 + 2 ] );
+      const QgsPoint p3( mData[ index3 ], mData[ index3 + 1 ], mData[ index3 + 2 ] );
       mp->addGeometry( new QgsTriangle( p1, p2, p3 ) );
     }
     else
     {
       // tessellator geometry is x, z, -y
-      const QgsPoint p1( vertex1.position.x(), -vertex1.position.z(), vertex1.position.y() );
-      const QgsPoint p2( vertex2.position.x(), -vertex2.position.z(), vertex2.position.y() );
-      const QgsPoint p3( vertex3.position.x(), -vertex3.position.z(), vertex3.position.y() );
+      const QgsPoint p1( mData[ index1 ], -mData[ index1 + 2 ], mData[ index1 + 1 ] );
+      const QgsPoint p2( mData[ index2 ], -mData[ index2 + 2 ], mData[ index2 + 1 ] );
+      const QgsPoint p3( mData[ index3 ], -mData[ index3 + 2 ], mData[ index3 + 1 ] );
       mp->addGeometry( new QgsTriangle( p1, p2, p3 ) );
     }
   }
@@ -1057,38 +996,14 @@ QVector<float> QgsTessellator::data() const
     return QVector<float>();
 
   QVector<float> tData;
-  tData.reserve( n * ( stride() / sizeof( float ) ) );
+  size_t noOfElements = stride() / sizeof( float );
+  tData.reserve( n * noOfElements );
 
-  QVector<VertexPoint> vertexPoints;
-  vertexPoints.resize( n );
-
-  for ( auto it = mVertexBuffer.constBegin(); it != mVertexBuffer.constEnd(); ++it )
+  for ( auto &index : mIndexBuffer )
   {
-    const VertexPoint &vertex = it.key();
-    const uint32_t index = it.value();
-
-    vertexPoints[ index ] = vertex;
-  }
-
-  for ( uint32_t i : mIndexBuffer )
-  {
-    const VertexPoint vertex = vertexPoints[ i ];
-
-    tData << vertex.position.x();
-    tData << vertex.position.y();
-    tData << vertex.position.z();
-
-    if ( mAddNormals )
+    for ( size_t i = 0; i < noOfElements; i++ )
     {
-      tData << vertex.normal.x();
-      tData << vertex.normal.y();
-      tData << vertex.normal.z();
-    }
-
-    if ( mAddTextureCoords )
-    {
-      tData << vertex.u;
-      tData << vertex.v;
+      tData << mData[ index * noOfElements + i ];
     }
   }
 
@@ -1097,5 +1012,8 @@ QVector<float> QgsTessellator::data() const
 
 int QgsTessellator::uniqueVertexCount() const
 {
-  return mVertexBuffer.size();
+  if ( mData.size() == 0 )
+    return 0;
+
+  return mData.size() / ( stride() / sizeof( float ) );
 }

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -23,9 +23,7 @@
 class QgsPolygon;
 class QgsMultiPolygon;
 class QgsLineString;
-class QgsCurve;
 
-#include <QColor>
 #include <QVector>
 #include <memory>
 
@@ -202,20 +200,22 @@ class CORE_EXPORT QgsTessellator
      * Returns array of triangle vertex data
      *
      * Vertice coordinates are stored as (x, z, -y)
+     *
+     * \deprecated QGIS 4.0. Use vertexBuffer() in combination with indexBuffer().
      */
-    QVector<float> data() const;
+    Q_DECL_DEPRECATED QVector<float> data() const SIP_DEPRECATED;
 
     /**
      * Returns index buffer for the generated points.
      * \since QGIS 4.0
      */
-    QVector<uint32_t> indexBuffer() const { return mIndexBuffer; }
+    QByteArray indexBuffer() const;
 
     /**
      * Returns vertex buffer for the generated points.
      * \since QGIS 4.0
      */
-    QVector<float> vertexBuffer() const;
+    QByteArray vertexBuffer() const;
 
     //! Returns the number of vertices stored in the output data array
     int dataVerticesCount() const;
@@ -223,7 +223,10 @@ class CORE_EXPORT QgsTessellator
     //! Returns size of one vertex entry in bytes
     int stride() const { return mStride; }
 
-    //! Returns size of one index entry in bytes
+    /**
+     * Returns size of one index entry in bytes
+     * \since QGIS 4.0
+    */
     int indexStride() const { return sizeof( uint32_t ); }
 
     /**

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -256,56 +256,33 @@ class CORE_EXPORT QgsTessellator
      */
     int uniqueVertexCount() const;
 
-    /**
-     * Sets the material colors for data-defined rendering.
-     * Colors are not applied to the already added polygons.
-     * \since QGIS 4.0
-     */
-    void setMaterialColors( const QColor &diffuse, const QColor &ambient, const QColor &specular )
-    {
-      mDiffuseColor = diffuse;
-      mAmbientColor = ambient;
-      mSpecularColor = specular;
-    }
-
   private:
     struct VertexPoint
     {
       QVector3D position;
       QVector3D normal;
-      float u = 0.0f;
-      float v = 0.0f;
-      QColor diffuseColor;
-      QColor ambientColor;
-      QColor specularColor;
 
       inline bool operator==( const VertexPoint &other ) const
       {
         return position == other.position
-               && normal == other.normal
-               && u == other.u
-               && v == other.v
-               && diffuseColor == other.diffuseColor
-               && ambientColor == other.ambientColor
-               && specularColor == other.specularColor;
+               && normal == other.normal;
       }
     };
 
     friend uint qHash( const VertexPoint &key )
     {
       return qHash( key.position.x() ) ^ qHash( key.position.y() ) ^ qHash( key.position.z() )
-             ^ qHash( key.normal.x() ) ^ qHash( key.normal.y() ) ^ qHash( key.normal.z() )
-             ^ qHash( key.u ) ^ qHash( key.v ) ^ qHash( key.diffuseColor ) ^ qHash( key.ambientColor ) ^ qHash( key.specularColor );
+             ^ qHash( key.normal.x() ) ^ qHash( key.normal.y() )  ^ qHash( key.normal.z() );
     }
 
-    QHash<VertexPoint, uint32_t> mVertexBuffer;
     QVector<uint32_t> mIndexBuffer;
 
     void updateStride();
     void setExtrusionFacesLegacy( int facade );
     void calculateBaseTransform( const QVector3D &pNormal, QMatrix4x4 *base ) const;
-    void addTriangleVertices( const std::array<QVector3D, 3> &points, QVector3D pNormal, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset, bool reverse );
-    void addVertexPoint( VertexPoint &vertexPoint );
+    QVector3D applyTransformWithExtrusion( const QVector3D point, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset );
+    void addVertex( const QVector3D &point, const QVector3D &normal, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset, QHash<VertexPoint, unsigned int> *vertexBuffer, const size_t &vertexBufferOffset );
+    void addVertex( const QVector3D &point, const QVector3D &normal, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset );
     void makeWalls( const QgsLineString &ring, bool ccw, float extrusionHeight );
     void addExtrusionWallQuad( const QVector3D &pt1, const QVector3D &pt2, float height );
     void ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, QHash<std::array<double, 2>*, float> *zHash );
@@ -321,9 +298,6 @@ class CORE_EXPORT QgsTessellator
     QVector<float> mData;
     int mStride = 3 * sizeof( float );
     bool mInputZValueIgnored = false;
-    QColor mDiffuseColor = QColor( 0, 0, 0 );
-    QColor mAmbientColor = QColor( 0, 0, 0 );
-    QColor mSpecularColor = QColor( 0, 0, 0 );
     Qgis::ExtrusionFaces mExtrusionFaces = Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof;
     Qgis::TriangulationAlgorithm mTriangulationAlgorithm = Qgis::TriangulationAlgorithm::ConstrainedDelaunay;
     float mTextureRotation = 0.0f;

--- a/tests/src/3d/testqgs3dexporter.cpp
+++ b/tests/src/3d/testqgs3dexporter.cpp
@@ -119,7 +119,7 @@ void TestQgs3DExporter::do3DSceneExport( const QString &testName, int expectedOb
   for ( Qgs3DExportObject *o : std::as_const( exporter.mObjects ) )
   {
     if ( !terrainEntity ) // not compatible with terrain entity
-      QVERIFY( o->indexes().size() * 3 <= o->vertexPosition().size() );
+      QVERIFY( o->indexes().size() <= o->vertexPosition().size() );
     sum += o->indexes().size();
   }
 

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -47,38 +47,6 @@ struct TriangleCoords
       normals[2] = nc;
     }
 
-    /**
-   * Constructs from tessellator output. We expect the tessellator is run with zUp=true,
-   * so that the Y and Z axes are not flipped
-   */
-    TriangleCoords( const float *data, bool withNormal )
-    {
-#define FLOAT3_TO_VECTOR( x ) QVector3D( data[0], data[1], data[2] )
-
-      pts[0] = FLOAT3_TO_VECTOR( data );
-      data += 3;
-      if ( withNormal )
-      {
-        normals[0] = FLOAT3_TO_VECTOR( data );
-        data += 3;
-      }
-
-      pts[1] = FLOAT3_TO_VECTOR( data );
-      data += 3;
-      if ( withNormal )
-      {
-        normals[1] = FLOAT3_TO_VECTOR( data );
-        data += 3;
-      }
-
-      pts[2] = FLOAT3_TO_VECTOR( data );
-      data += 3;
-      if ( withNormal )
-      {
-        normals[2] = FLOAT3_TO_VECTOR( data );
-        data += 3;
-      }
-    }
 
     //! Compares two triangles
     bool operator==( const TriangleCoords &other ) const
@@ -135,27 +103,70 @@ struct TriangleCoords
     QVector3D normals[3];
 };
 
-
-bool checkTriangleOutput( const QVector<float> &data, bool withNormals, const QList<TriangleCoords> &expected )
+QList<TriangleCoords> extractTriangles( QgsTessellator &tessellator, bool withNormals )
 {
-  const int valuesPerTriangle = withNormals ? 18 : 9;
-  if ( data.count() != expected.count() * valuesPerTriangle )
+  QList<TriangleCoords> triangles;
+
+  const QByteArray vertexBuffer = tessellator.vertexBuffer();
+  const QByteArray indexBuffer = tessellator.indexBuffer();
+
+  if ( vertexBuffer.isEmpty() || indexBuffer.isEmpty() )
+    return triangles;
+
+  const int vertexStride = tessellator.stride();
+  const int indexStride = tessellator.indexStride();
+
+  const char *vertices = vertexBuffer.constData();
+  const char *indices = indexBuffer.constData();
+
+  size_t triangleCount = indexBuffer.size() / ( 3 * indexStride );
+  triangles.reserve( triangleCount );
+
+  for ( size_t i = 0; i < triangleCount; i++ )
   {
-    qDebug() << "expected" << expected.count() << "triangles, got" << data.count() / valuesPerTriangle;
+    size_t index0 = 0;
+    size_t index1 = 0;
+    size_t index2 = 0;
+    std::memcpy( &index0, indices + ( 3 * i + 0 ) * indexStride, indexStride );
+    std::memcpy( &index1, indices + ( 3 * i + 1 ) * indexStride, indexStride );
+    std::memcpy( &index2, indices + ( 3 * i + 2 ) * indexStride, indexStride );
+
+    const float *vertex0 = reinterpret_cast<const float *>( vertices + index0 * vertexStride );
+    const float *vertex1 = reinterpret_cast<const float *>( vertices + index1 * vertexStride );
+    const float *vertex2 = reinterpret_cast<const float *>( vertices + index2 * vertexStride );
+
+    QVector3D p0( vertex0[0], vertex0[1], vertex0[2] );
+    QVector3D p1( vertex1[0], vertex1[1], vertex1[2] );
+    QVector3D p2( vertex2[0], vertex2[1], vertex2[2] );
+
+    if ( withNormals )
+    {
+      QVector3D n0( vertex0[3], vertex0[4], vertex0[5] );
+      QVector3D n1( vertex1[3], vertex1[4], vertex1[5] );
+      QVector3D n2( vertex2[3], vertex2[4], vertex2[5] );
+
+      triangles.append( TriangleCoords( p0, p1, p2, n0, n1, n2 ) );
+    }
+    else
+    {
+      triangles.append( TriangleCoords( p0, p1, p2 ) );
+    }
+  }
+
+  return triangles;
+}
+
+bool checkTriangleOutput( const QList<TriangleCoords> &output, const QList<TriangleCoords> &expected )
+{
+  if ( output.size() != expected.size() )
+  {
     return false;
   }
 
   QList<TriangleCoords> sortedExpected = expected;
   std::sort( sortedExpected.begin(), sortedExpected.end() );
 
-  QList<TriangleCoords> sortedOutput;
-  const float *dataRaw = data.constData();
-  for ( int i = 0; i < expected.count(); ++i )
-  {
-    const TriangleCoords out( dataRaw, withNormals );
-    sortedOutput.append( out );
-    dataRaw += withNormals ? 18 : 9;
-  }
+  QList<TriangleCoords> sortedOutput = output;
   std::sort( sortedOutput.begin(), sortedOutput.end() );
 
   for ( int i = 0; i < expected.count(); ++i )
@@ -272,7 +283,7 @@ void TestQgsTessellator::testBasic()
   tesCD.setAddNormals( false );
   tesCD.setOutputZUp( true );
   tesCD.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesCD.data(), false, trianglesCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesCD, false ), trianglesCD ) );
 
   QCOMPARE( tesCD.zMinimum(), 0 );
   QCOMPARE( tesCD.zMaximum(), 0 );
@@ -281,7 +292,7 @@ void TestQgsTessellator::testBasic()
   tesZCD.setAddNormals( false );
   tesZCD.setOutputZUp( true );
   tesZCD.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesZCD.data(), false, trianglesZCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesZCD, false ), trianglesZCD ) );
 
   QgsTessellator tesEarcut;
   tesEarcut.setOrigin( QgsVector3D( 0, 0, 0 ) );
@@ -289,7 +300,7 @@ void TestQgsTessellator::testBasic()
   tesEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesEarcut.setOutputZUp( true );
   tesEarcut.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesEarcut.data(), false, trianglesEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesEarcut, false ), trianglesEarcut ) );
 
   QCOMPARE( tesEarcut.zMinimum(), 0 );
   QCOMPARE( tesEarcut.zMaximum(), 0 );
@@ -299,7 +310,7 @@ void TestQgsTessellator::testBasic()
   tesZEarcut.setOutputZUp( true );
   tesZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesZEarcut.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesZEarcut.data(), false, trianglesZEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesZEarcut, false ), trianglesZEarcut ) );
 
   QCOMPARE( tesZEarcut.zMinimum(), 3 );
   QCOMPARE( tesZEarcut.zMaximum(), 3 );
@@ -309,7 +320,7 @@ void TestQgsTessellator::testBasic()
   tesNormalsCD.setAddNormals( true );
   tesNormalsCD.setOutputZUp( true );
   tesNormalsCD.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesNormalsCD.data(), true, trianglesNormalsCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsCD, true ), trianglesNormalsCD ) );
   QCOMPARE( tesNormalsCD.zMinimum(), 0 );
   QCOMPARE( tesNormalsCD.zMaximum(), 0 );
 
@@ -317,7 +328,7 @@ void TestQgsTessellator::testBasic()
   tesNormalsZCD.setAddNormals( true );
   tesNormalsZCD.setOutputZUp( true );
   tesNormalsZCD.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesNormalsZCD.data(), true, trianglesNormalsZCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsZCD, true ), trianglesNormalsZCD ) );
 
   QCOMPARE( tesNormalsZCD.zMinimum(), 3 );
   QCOMPARE( tesNormalsZCD.zMaximum(), 3 );
@@ -327,7 +338,7 @@ void TestQgsTessellator::testBasic()
   tesNormalsEarcut.setOutputZUp( true );
   tesNormalsEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesNormalsEarcut.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesNormalsEarcut.data(), true, trianglesNormalsEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsEarcut, true ), trianglesNormalsEarcut ) );
 
   QCOMPARE( tesNormalsEarcut.zMinimum(), 0 );
   QCOMPARE( tesNormalsEarcut.zMaximum(), 0 );
@@ -337,7 +348,7 @@ void TestQgsTessellator::testBasic()
   tesNormalsZEarcut.setOutputZUp( true );
   tesNormalsZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesNormalsZEarcut.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesNormalsZEarcut.data(), true, trianglesNormalsZEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsZEarcut, true ), trianglesNormalsZEarcut ) );
 
   QCOMPARE( tesNormalsZEarcut.zMinimum(), 3 );
   QCOMPARE( tesNormalsZEarcut.zMaximum(), 3 );
@@ -364,7 +375,7 @@ void TestQgsTessellator::testBasic()
   tesInvertedNormalsCD.setInvertNormals( true );
   tesInvertedNormalsCD.setOutputZUp( true );
   tesInvertedNormalsCD.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesInvertedNormalsCD.data(), true, trianglesInvertedNormalsCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsCD, true ), trianglesInvertedNormalsCD ) );
 
   QCOMPARE( tesInvertedNormalsCD.zMinimum(), 0 );
   QCOMPARE( tesInvertedNormalsCD.zMaximum(), 0 );
@@ -375,7 +386,7 @@ void TestQgsTessellator::testBasic()
   tesInvertedNormalsZCD.setInvertNormals( true );
   tesInvertedNormalsZCD.setOutputZUp( true );
   tesInvertedNormalsZCD.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesInvertedNormalsZCD.data(), true, trianglesInvertedNormalsZCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsZCD, true ), trianglesInvertedNormalsZCD ) );
 
   QCOMPARE( tesInvertedNormalsZCD.zMinimum(), 3 );
   QCOMPARE( tesInvertedNormalsZCD.zMaximum(), 3 );
@@ -386,7 +397,7 @@ void TestQgsTessellator::testBasic()
   tesInvertedNormalsEarcut.setOutputZUp( true );
   tesInvertedNormalsEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesInvertedNormalsEarcut.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesInvertedNormalsEarcut.data(), true, trianglesInvertedNormalsEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsEarcut, true ), trianglesInvertedNormalsEarcut ) );
 
   QCOMPARE( tesInvertedNormalsEarcut.zMinimum(), 0 );
   QCOMPARE( tesInvertedNormalsEarcut.zMaximum(), 0 );
@@ -397,7 +408,7 @@ void TestQgsTessellator::testBasic()
   tesInvertedNormalsZEarcut.setOutputZUp( true );
   tesInvertedNormalsZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesInvertedNormalsZEarcut.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesInvertedNormalsZEarcut.data(), true, trianglesInvertedNormalsZEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsZEarcut, true ), trianglesInvertedNormalsZEarcut ) );
 
   QCOMPARE( tesInvertedNormalsZEarcut.zMinimum(), 3 );
   QCOMPARE( tesInvertedNormalsZEarcut.zMaximum(), 3 );
@@ -451,7 +462,7 @@ void TestQgsTessellator::testBasicClockwise()
   QgsTessellator tesCD;
   tesCD.setOutputZUp( true );
   tesCD.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesCD.data(), false, trianglesCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesCD, false ), trianglesCD ) );
 
   QCOMPARE( tesCD.zMinimum(), 0 );
   QCOMPARE( tesCD.zMaximum(), 0 );
@@ -459,7 +470,7 @@ void TestQgsTessellator::testBasicClockwise()
   QgsTessellator tesZCD;
   tesZCD.setOutputZUp( true );
   tesZCD.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesZCD.data(), false, trianglesZCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesZCD, false ), trianglesZCD ) );
 
   QCOMPARE( tesZCD.zMinimum(), 3 );
   QCOMPARE( tesZCD.zMaximum(), 3 );
@@ -469,7 +480,7 @@ void TestQgsTessellator::testBasicClockwise()
   tesN.setAddNormals( true );
   tesN.setOutputZUp( true );
   tesN.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesN.data(), true, trianglesNormalsCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesN, true ), trianglesNormalsCD ) );
 
   QCOMPARE( tesN.zMinimum(), 0 );
   QCOMPARE( tesN.zMaximum(), 0 );
@@ -478,7 +489,7 @@ void TestQgsTessellator::testBasicClockwise()
   tesNZ.setAddNormals( true );
   tesNZ.setOutputZUp( true );
   tesNZ.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesNZ.data(), true, trianglesNormalsZCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesNZ, true ), trianglesNormalsZCD ) );
 
   QCOMPARE( tesNZ.zMinimum(), 3 );
   QCOMPARE( tesNZ.zMaximum(), 3 );
@@ -488,7 +499,7 @@ void TestQgsTessellator::testBasicClockwise()
   tesEarcut.setOutputZUp( true );
   tesEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesEarcut.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesEarcut.data(), true, trianglesNormalsEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesEarcut, true ), trianglesNormalsEarcut ) );
 
   QCOMPARE( tesEarcut.zMinimum(), 0 );
   QCOMPARE( tesEarcut.zMaximum(), 0 );
@@ -498,7 +509,7 @@ void TestQgsTessellator::testBasicClockwise()
   tesZEarcut.setOutputZUp( true );
   tesZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesZEarcut.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesZEarcut.data(), true, trianglesNormalsZEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesZEarcut, true ), trianglesNormalsZEarcut ) );
 
   QCOMPARE( tesZEarcut.zMinimum(), 3 );
   QCOMPARE( tesZEarcut.zMaximum(), 3 );
@@ -526,7 +537,7 @@ void TestQgsTessellator::testBasicClockwise()
   tesInvertedNormalsCD.setInvertNormals( true );
   tesInvertedNormalsCD.setOutputZUp( true );
   tesInvertedNormalsCD.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesInvertedNormalsCD.data(), true, trianglesInvertedNormalsCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsCD, true ), trianglesInvertedNormalsCD ) );
 
   QCOMPARE( tesInvertedNormalsCD.zMinimum(), 0 );
   QCOMPARE( tesInvertedNormalsCD.zMaximum(), 0 );
@@ -536,7 +547,7 @@ void TestQgsTessellator::testBasicClockwise()
   tesInvertedNormalsZCD.setInvertNormals( true );
   tesInvertedNormalsZCD.setOutputZUp( true );
   tesInvertedNormalsZCD.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesInvertedNormalsZCD.data(), true, trianglesInvertedNormalsZCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsZCD, true ), trianglesInvertedNormalsZCD ) );
 
   QCOMPARE( tesInvertedNormalsZCD.zMinimum(), 3 );
   QCOMPARE( tesInvertedNormalsZCD.zMaximum(), 3 );
@@ -547,7 +558,7 @@ void TestQgsTessellator::testBasicClockwise()
   tesInvertedNormalsEarcut.setOutputZUp( true );
   tesInvertedNormalsEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesInvertedNormalsEarcut.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesInvertedNormalsEarcut.data(), true, trianglesInvertedNormalsEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsEarcut, true ), trianglesInvertedNormalsEarcut ) );
 
   QCOMPARE( tesInvertedNormalsEarcut.zMinimum(), 0 );
   QCOMPARE( tesInvertedNormalsEarcut.zMaximum(), 0 );
@@ -558,7 +569,7 @@ void TestQgsTessellator::testBasicClockwise()
   tesInvertedNormalsZEarcut.setOutputZUp( true );
   tesInvertedNormalsZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesInvertedNormalsZEarcut.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesInvertedNormalsZEarcut.data(), true, trianglesInvertedNormalsZEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsZEarcut, true ), trianglesInvertedNormalsZEarcut ) );
 
   QCOMPARE( tesInvertedNormalsZEarcut.zMinimum(), 3 );
   QCOMPARE( tesInvertedNormalsZEarcut.zMaximum(), 3 );
@@ -591,7 +602,7 @@ void TestQgsTessellator::testWalls()
   tRect.setAddNormals( true );
   tRect.setOutputZUp( true );
   tRect.addPolygon( rect, 1 );
-  QVERIFY( checkTriangleOutput( tRect.data(), true, tcRect ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tRect, true ), tcRect ) );
   QCOMPARE( tRect.zMinimum(), 0 );
   QCOMPARE( tRect.zMaximum(), 1 );
 
@@ -604,7 +615,7 @@ void TestQgsTessellator::testWalls()
   tRectRev.setAddNormals( true );
   tRectRev.setOutputZUp( true );
   tRectRev.addPolygon( rectRev, 1 );
-  QVERIFY( checkTriangleOutput( tRectRev.data(), true, tcRect ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tRectRev, true ), tcRect ) );
   QCOMPARE( tRectRev.zMinimum(), 0 );
   QCOMPARE( tRectRev.zMaximum(), 1 );
 
@@ -630,7 +641,7 @@ void TestQgsTessellator::testWalls()
   QgsTessellator tZ;
   tZ.setOutputZUp( true );
   tZ.addPolygon( polygonZ, 10 );
-  QVERIFY( checkTriangleOutput( tZ.data(), false, tc ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tZ, false ), tc ) );
 
   QCOMPARE( tZ.zMinimum(), 1 );
   QCOMPARE( tZ.zMaximum(), 14 );
@@ -655,7 +666,7 @@ void TestQgsTessellator::testBackEdges()
   tN.setBackFacesEnabled( true );
   tN.setOutputZUp( true );
   tN.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tN.data(), true, tcNormals ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tN, true ), tcNormals ) );
 
   QCOMPARE( tN.zMinimum(), 0 );
   QCOMPARE( tN.zMaximum(), 0 );
@@ -680,7 +691,7 @@ void TestQgsTessellator::test2DTriangle()
     tessellatorNormalsCD.setAddNormals( true );
     tessellatorNormalsCD.setOutputZUp( true );
     tessellatorNormalsCD.addPolygon( polygon, 0 );
-    QVERIFY( checkTriangleOutput( tessellatorNormalsCD.data(), true, trianglesNormalsCD ) );
+    QVERIFY( checkTriangleOutput( extractTriangles( tessellatorNormalsCD, true ), trianglesNormalsCD ) );
 
     QCOMPARE( tessellatorNormalsCD.zMinimum(), 0 );
     QCOMPARE( tessellatorNormalsCD.zMaximum(), 0 );
@@ -693,7 +704,7 @@ void TestQgsTessellator::test2DTriangle()
     tessellatorNormalsEarcut.setOutputZUp( true );
     tessellatorNormalsEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
     tessellatorNormalsEarcut.addPolygon( polygon, 0 );
-    QVERIFY( checkTriangleOutput( tessellatorNormalsEarcut.data(), true, trianglesNormalsEarcut ) );
+    QVERIFY( checkTriangleOutput( extractTriangles( tessellatorNormalsEarcut, true ), trianglesNormalsEarcut ) );
 
     QCOMPARE( tessellatorNormalsEarcut.zMinimum(), 0 );
     QCOMPARE( tessellatorNormalsEarcut.zMaximum(), 0 );
@@ -728,7 +739,7 @@ void TestQgsTessellator::test2DTriangle()
     tesNormalsCD.setAddNormals( true );
     tesNormalsCD.setOutputZUp( true );
     tesNormalsCD.addPolygon( polygon, 7 );
-    QVERIFY( checkTriangleOutput( tesNormalsCD.data(), true, trianglesNormalsCD ) );
+    QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsCD, true ), trianglesNormalsCD ) );
 
     QCOMPARE( tesNormalsCD.zMinimum(), 0 );
     QCOMPARE( tesNormalsCD.zMaximum(), 7 );
@@ -754,7 +765,7 @@ void TestQgsTessellator::test3DTriangle()
     tN.setAddNormals( true );
     tN.setOutputZUp( true );
     tN.addPolygon( polygon, 0 );
-    QVERIFY( checkTriangleOutput( tN.data(), true, tcNormals ) );
+    QVERIFY( checkTriangleOutput( extractTriangles( tN, true ), tcNormals ) );
 
     QCOMPARE( tN.zMinimum(), 5 );
     QCOMPARE( tN.zMaximum(), 5 );
@@ -791,7 +802,7 @@ void TestQgsTessellator::test3DTriangle()
     tesNormalsEarcut.setOutputZUp( true );
     tesNormalsEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
     tesNormalsEarcut.addPolygon( polygon, 7 );
-    QVERIFY( checkTriangleOutput( tesNormalsEarcut.data(), true, trianglesNormalsEarcut ) );
+    QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsEarcut, true ), trianglesNormalsEarcut ) );
 
     QCOMPARE( tesNormalsEarcut.zMinimum(), 5 );
     QCOMPARE( tesNormalsEarcut.zMaximum(), 5 + 7 );
@@ -835,7 +846,7 @@ void TestQgsTessellator::testBadCoordinates()
   QgsTessellator tesZCD;
   tesZCD.setOutputZUp( true );
   tesZCD.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesZCD.data(), false, trianglesZCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesZCD, false ), trianglesZCD ) );
 
   QCOMPARE( tesZCD.zMinimum(), 1.0f );
   QCOMPARE( tesZCD.zMaximum(), 2.0f );
@@ -845,7 +856,7 @@ void TestQgsTessellator::testBadCoordinates()
   tesZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesZEarcut.addPolygon( polygonZ, 0 );
 
-  QVERIFY( checkTriangleOutput( tesZEarcut.data(), false, trianglesZEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesZEarcut, false ), trianglesZEarcut ) );
 
   QCOMPARE( tesZEarcut.zMinimum(), 1.0f );
   QCOMPARE( tesZEarcut.zMaximum(), 2.0f );
@@ -866,7 +877,7 @@ void TestQgsTessellator::testBadCoordinates()
   QgsTessellator tesCD;
   tesCD.setOutputZUp( true );
   tesCD.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesCD.data(), false, trianglesCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesCD, false ), trianglesCD ) );
 
   QCOMPARE( tesCD.zMinimum(), 0 );
   QCOMPARE( tesCD.zMaximum(), 0 );
@@ -875,7 +886,7 @@ void TestQgsTessellator::testBadCoordinates()
   tesEarcut.setOutputZUp( true );
   tesEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesEarcut.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( tesEarcut.data(), false, trianglesEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesEarcut, false ), trianglesEarcut ) );
 
   QCOMPARE( tesEarcut.zMinimum(), 0 );
   QCOMPARE( tesEarcut.zMaximum(), 0 );
@@ -946,7 +957,7 @@ void TestQgsTessellator::testBoundsScaling()
   t.setAddNormals( true );
   t.setOutputZUp( true );
   t.addPolygon( polygon, 0 );
-  QCOMPARE( t.data().size(), 0 );
+  QCOMPARE( t.uniqueVertexCount(), 0 );
 
   // using bounds scaling, expect good result
   QgsTessellator t2;
@@ -954,7 +965,7 @@ void TestQgsTessellator::testBoundsScaling()
   t2.setAddNormals( true );
   t2.setOutputZUp( true );
   t2.addPolygon( polygon, 0 );
-  QVERIFY( checkTriangleOutput( t2.data(), true, tc ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( t2, true ), tc ) );
   QCOMPARE( t2.zMinimum(), 0 );
   QCOMPARE( t2.zMaximum(), 0 );
 }
@@ -974,7 +985,7 @@ void TestQgsTessellator::testNoZ()
   t.setInputZValueIgnored( true );
   t.setOutputZUp( true );
   t.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( t.data(), false, tc ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( t, false ), tc ) );
   QCOMPARE( t.zMinimum(), 0 );
   QCOMPARE( t.zMaximum(), 0 );
 }
@@ -1042,34 +1053,16 @@ void TestQgsTessellator::testOutputZUp()
   tYUp.setOutputZUp( false );
   tYUp.addPolygon( polygon, 0 );
 
-  QVector<float> expectedOutputZUp = {
-    //   triangle 1
-    // pos     normal
-    1, 2, 0, 0, 0, 1,
-    2, 1, 0, 0, 0, 1,
-    3, 2, 0, 0, 0, 1,
-    //   triangle 2
-    // pos     normal
-    1, 2, 0, 0, 0, 1,
-    1, 1, 0, 0, 0, 1,
-    2, 1, 0, 0, 0, 1
-  };
+  QList<TriangleCoords> expectedOutputZUp;
+  expectedOutputZUp << TriangleCoords( QVector3D( 1, 2, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 3, 2, 0 ), QVector3D( 0, 0, 1 ), QVector3D( 0, 0, 1 ), QVector3D( 0, 0, 1 ) );
+  expectedOutputZUp << TriangleCoords( QVector3D( 1, 2, 0 ), QVector3D( 1, 1, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 0, 0, 1 ), QVector3D( 0, 0, 1 ), QVector3D( 0, 0, 1 ) );
 
-  QVector<float> expectedOutputYUp = {
-    //   triangle 1
-    // pos     normal
-    1, 0, -2, 0, 1, 0,
-    2, 0, -1, 0, 1, 0,
-    3, 0, -2, 0, 1, 0,
-    //   triangle 2
-    // pos     normal
-    1, 0, -2, 0, 1, 0,
-    1, 0, -1, 0, 1, 0,
-    2, 0, -1, 0, 1, 0
-  };
+  QList<TriangleCoords> expectedOutputYUp;
+  expectedOutputYUp << TriangleCoords( QVector3D( 1, 0, -2 ), QVector3D( 2, 0, -1 ), QVector3D( 3, 0, -2 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ) );
+  expectedOutputYUp << TriangleCoords( QVector3D( 1, 0, -2 ), QVector3D( 1, 0, -1 ), QVector3D( 2, 0, -1 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ) );
 
-  QCOMPARE( tZUp.data(), expectedOutputZUp );
-  QCOMPARE( tYUp.data(), expectedOutputYUp );
+  QVERIFY( checkTriangleOutput( extractTriangles( tZUp, true ), expectedOutputZUp ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tYUp, true ), expectedOutputYUp ) );
 }
 
 void TestQgsTessellator::testDuplicatePoints()
@@ -1088,13 +1081,13 @@ void TestQgsTessellator::testDuplicatePoints()
   QgsTessellator tesZCD;
   tesZCD.setOutputZUp( true );
   tesZCD.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesZCD.data(), false, trianglesZCD ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesZCD, false ), trianglesZCD ) );
 
   QgsTessellator tesZEarcut;
   tesZEarcut.setOutputZUp( true );
   tesZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesZEarcut.addPolygon( polygonZ, 0 );
-  QVERIFY( checkTriangleOutput( tesZEarcut.data(), false, trianglesZEarcut ) );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesZEarcut, false ), trianglesZEarcut ) );
 }
 
 QGSTEST_MAIN( TestQgsTessellator )

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -119,10 +119,10 @@ QList<TriangleCoords> extractTriangles( QgsTessellator &tessellator, bool withNo
   const char *vertices = vertexBuffer.constData();
   const char *indices = indexBuffer.constData();
 
-  size_t triangleCount = indexBuffer.size() / ( 3 * indexStride );
+  qsizetype triangleCount = indexBuffer.size() / ( 3 * indexStride );
   triangles.reserve( triangleCount );
 
-  for ( size_t i = 0; i < triangleCount; i++ )
+  for ( qsizetype i = 0; i < triangleCount; i++ )
   {
     size_t index0 = 0;
     size_t index1 = 0;

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -119,7 +119,7 @@ QList<TriangleCoords> extractTriangles( QgsTessellator &tessellator, bool withNo
   const char *vertices = vertexBuffer.constData();
   const char *indices = indexBuffer.constData();
 
-  qsizetype triangleCount = indexBuffer.size() / ( 3 * indexStride );
+  qsizetype triangleCount = indexBuffer.size() / static_cast<qsizetype>( 3 * indexStride );
   triangles.reserve( triangleCount );
 
   for ( qsizetype i = 0; i < triangleCount; i++ )


### PR DESCRIPTION
This PR adds an index buffer to QgsTessellator.

When tessellating geometry, we currently store duplicate points where the tessellated triangles meet. By introducing an index buffer, we can store only unique vertices and keep track of their indices within a single vertex array.

This reduces memory usage when displaying data in the 3D Map. The actual amount of memory saved depends on the geometry.

A getter for the size of a single element in the index buffer has been added, although it currently uses a hardcoded value, since elements are initialized as `uint32_t` regardless of the amount of vertices. In the future, this could be extended to support other data types to further optimize memory usage.

Some "private” static functions with an underscore have been renamed to avoid clang tidy warnings.