### PR TITLE
Limit "Other layers" to a max of 10 for RasterLayerProperties dialog

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2691,9 +2691,16 @@ QString QgsWmsProvider::htmlMetadata() const
     // Layer properties
     if ( n < mCaps.mLayersSupported.size() )
     {
-      metadata += u"<tr><th class=\"strong\" id=\"otherlayers\">"_s % tr( "Other Layers" ) % u"</th></tr>"_s;
+      static const int MAX_OTHERLAYERS_COUNT = 10;
+      QString description = tr( "Other Layers" );
+      if ( mCaps.mLayersSupported.size() > MAX_OTHERLAYERS_COUNT )
+      {
+        description += tr( " (only the first %1 are listed)" ).arg( MAX_OTHERLAYERS_COUNT );
+      }
 
-      for ( int i = 0; i < mCaps.mLayersSupported.size(); i++ )
+      metadata += u"<tr><th class=\"strong\" id=\"otherlayers\">"_s % description % u"</th></tr>"_s;
+
+      for ( int i = 0; i < std::min( static_cast<int>( mCaps.mLayersSupported.size() ), MAX_OTHERLAYERS_COUNT ); i++ )
       {
         if ( !mSettings.mActiveSubLayers.contains( mCaps.mLayersSupported[i].name ) )
         {


### PR DESCRIPTION
Rendering the "Informations" tab of properties dialog for WMS layers can be very slow in case the provider has thousands of layers as described in #59633.

The rendering is probably slow only when QGIS is built without WebKit and the content is rendered inside a QTextBrowser. At first I tried to use QWebEngineView, but it is not suited because the [setHtml](https://doc.qt.io/qt-6/qwebengineview.html#setHtml) method has a limit of 2 megabytes, which can be easily exceeded.  

This PR reduces the content of the "Information from provider" data section by limiting the "Other layers" section to a max (arbitrary chosen) of 10 layers.

<img width="1386" height="1297" alt="image" src="https://github.com/user-attachments/assets/456151fc-ca3f-4b70-89eb-bf7c029f662d" />
