### PR TITLE
Remove redundant function call

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -1075,7 +1075,6 @@ void QgsAppLayerTreeViewMenuProvider::addLegendLayerActionForLayer( QAction *act
   if ( !action || !layer )
     return;
 
-  legendLayerActions( layer->type() );
   if ( !mLegendLayerActionMap.contains( layer->type() ) )
     return;
 


### PR DESCRIPTION
This function does not do anything beside returning a list, and we were discarding the result
