### PR TITLE
[annotations] Brand new annotations selection tool 

### DIFF
--- a/src/app/annotations/qgsannotationitempropertieswidget.cpp
+++ b/src/app/annotations/qgsannotationitempropertieswidget.cpp
@@ -45,9 +45,9 @@ QgsAnnotationItemPropertiesWidget::QgsAnnotationItemPropertiesWidget( QgsAnnotat
   mPageNoItem->setSizePolicy( sizePolicy );
   QVBoxLayout *verticalLayout = new QVBoxLayout();
   verticalLayout->setContentsMargins( 0, 0, 0, 0 );
-  QLabel *label = new QLabel();
-  label->setText( tr( "No item selected." ) );
-  verticalLayout->addWidget( label );
+  mLabel = new QLabel();
+  mLabel->setText( tr( "No item selected." ) );
+  verticalLayout->addWidget( mLabel );
   mPageNoItem->setLayout( verticalLayout );
   mStack->addWidget( mPageNoItem );
   mStack->setCurrentWidget( mPageNoItem );
@@ -218,6 +218,14 @@ void QgsAnnotationItemPropertiesWidget::setItemId( const QString &itemId )
       delete prevWidget;
     }
     mStack->setCurrentWidget( mPageNoItem );
+  }
+}
+
+void QgsAnnotationItemPropertiesWidget::setLabelMessage( const QString &message )
+{
+  if ( mLabel )
+  {
+    mLabel->setText( message );
   }
 }
 

--- a/src/app/annotations/qgsannotationitempropertieswidget.h
+++ b/src/app/annotations/qgsannotationitempropertieswidget.h
@@ -38,6 +38,8 @@ class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget, public
     void setMapLayerConfigWidgetContext( const QgsMapLayerConfigWidgetContext &context ) override;
     void setDockMode( bool dockMode ) final;
 
+    void setLabelMessage( const QString &message );
+
   public slots:
     void apply() override;
     void focusDefaultWidget() override;
@@ -50,6 +52,7 @@ class QgsAnnotationItemPropertiesWidget : public QgsMapLayerConfigWidget, public
   private:
     void setItemId( const QString &itemId );
 
+    QLabel *mLabel = nullptr;
     QPointer<QgsAnnotationLayer> mLayer;
     QPointer<QgsAnnotationItemBaseWidget> mItemWidget;
     QWidget *mPageNoItem = nullptr;

--- a/src/app/maptools/qgsappmaptools.cpp
+++ b/src/app/maptools/qgsappmaptools.cpp
@@ -47,6 +47,7 @@
 #include "qgsmaptoolrotatepointsymbols.h"
 #include "qgsmaptoolscalefeature.h"
 #include "qgsmaptoolselect.h"
+#include "qgsmaptoolselectannotation.h"
 #include "qgsmaptoolshowhidelabels.h"
 #include "qgsmaptoolsimplify.h"
 #include "qgsmaptoolsplitfeatures.h"
@@ -108,6 +109,7 @@ QgsAppMapTools::QgsAppMapTools( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockW
   mTools.insert( Tool::ChangeLabelProperties, new QgsMapToolChangeLabelProperties( canvas, cadDock ) );
   mTools.insert( Tool::EditMeshFrame, new QgsMapToolEditMeshFrame( canvas ) );
   mTools.insert( Tool::AnnotationEdit, new QgsMapToolModifyAnnotation( canvas, cadDock ) );
+  mTools.insert( Tool::AnnotationSelect, new QgsMapToolSelectAnnotation( canvas, cadDock ) );
 }
 
 QgsAppMapTools::~QgsAppMapTools()

--- a/src/app/maptools/qgsappmaptools.h
+++ b/src/app/maptools/qgsappmaptools.h
@@ -79,7 +79,8 @@ class QgsAppMapTools
       ReverseLine,
       TrimExtendFeature,
       EditMeshFrame,
-      AnnotationEdit
+      AnnotationEdit,
+      AnnotationSelect
     };
 
     QgsAppMapTools( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDock );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1928,10 +1928,11 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
   updateCrsStatusBar();
   endProfile();
 
-  connect( qobject_cast<QgsMapToolSelectAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationSelect ) ), &QgsMapToolSelectAnnotation::itemSelected, mMapStyleWidget, &QgsLayerStylingWidget::setAnnotationItem );
-  connect( qobject_cast<QgsMapToolSelectAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationSelect ) ), &QgsMapToolSelectAnnotation::selectionCleared, mMapStyleWidget, [this] { mMapStyleWidget->setAnnotationItem( nullptr, QString() ); } );
+  connect( qobject_cast<QgsMapToolSelectAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationSelect ) ), &QgsMapToolSelectAnnotation::singleItemSelected, mMapStyleWidget, [this]( QgsAnnotationLayer *layer, const QString &itemId ) { mMapStyleWidget->setAnnotationItem( layer, itemId, false ); } );
+  connect( qobject_cast<QgsMapToolSelectAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationSelect ) ), &QgsMapToolSelectAnnotation::multipleItemsSelected, mMapStyleWidget, [this] { mMapStyleWidget->setAnnotationItem( nullptr, QString(), true ); } );
+  connect( qobject_cast<QgsMapToolSelectAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationSelect ) ), &QgsMapToolSelectAnnotation::selectionCleared, mMapStyleWidget, [this] { mMapStyleWidget->setAnnotationItem( nullptr, QString(), false ); } );
 
-  connect( qobject_cast<QgsMapToolModifyAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationEdit ) ), &QgsMapToolModifyAnnotation::itemSelected, mMapStyleWidget, &QgsLayerStylingWidget::setAnnotationItem );
+  connect( qobject_cast<QgsMapToolModifyAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationEdit ) ), &QgsMapToolModifyAnnotation::itemSelected, mMapStyleWidget, [this]( QgsAnnotationLayer *layer, const QString &itemId ) { mMapStyleWidget->setAnnotationItem( layer, itemId, false ); } );
   connect( qobject_cast<QgsMapToolModifyAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationEdit ) ), &QgsMapToolModifyAnnotation::selectionCleared, mMapStyleWidget, [this] { mMapStyleWidget->setAnnotationItem( nullptr, QString() ); } );
 
   // request notification of FileOpen events (double clicking a file icon in Mac OS X Finder)

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1928,6 +1928,9 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
   updateCrsStatusBar();
   endProfile();
 
+  connect( qobject_cast<QgsMapToolSelectAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationSelect ) ), &QgsMapToolSelectAnnotation::itemSelected, mMapStyleWidget, &QgsLayerStylingWidget::setAnnotationItem );
+  connect( qobject_cast<QgsMapToolSelectAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationSelect ) ), &QgsMapToolSelectAnnotation::selectionCleared, mMapStyleWidget, [this] { mMapStyleWidget->setAnnotationItem( nullptr, QString() ); } );
+
   connect( qobject_cast<QgsMapToolModifyAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationEdit ) ), &QgsMapToolModifyAnnotation::itemSelected, mMapStyleWidget, &QgsLayerStylingWidget::setAnnotationItem );
   connect( qobject_cast<QgsMapToolModifyAnnotation *>( mMapTools->mapTool( QgsAppMapTools::AnnotationEdit ) ), &QgsMapToolModifyAnnotation::selectionCleared, mMapStyleWidget, [this] { mMapStyleWidget->setAnnotationItem( nullptr, QString() ); } );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -102,6 +102,7 @@
 
 #include "qgsbrowserwidget.h"
 #include "annotations/qgsannotationitempropertieswidget.h"
+#include "qgsmaptoolselectannotation.h"
 #include "qgsmaptoolmodifyannotation.h"
 #include "qgsannotationlayer.h"
 #include "qgsdockablewidgethelper.h"
@@ -3202,6 +3203,7 @@ void QgisApp::createActions()
   connect( mActionDiagramProperties, &QAction::triggered, this, &QgisApp::diagramProperties );
 
   connect( mActionCreateAnnotationLayer, &QAction::triggered, this, &QgisApp::createAnnotationLayer );
+  connect( mActionSelectAnnotation, &QAction::triggered, this, [this] { mMapCanvas->setMapTool( mMapTools->mapTool( QgsAppMapTools::AnnotationSelect ) ); } );
   connect( mActionModifyAnnotation, &QAction::triggered, this, [this] { mMapCanvas->setMapTool( mMapTools->mapTool( QgsAppMapTools::AnnotationEdit ) ); } );
   connect( mMainAnnotationLayerProperties, &QAction::triggered, this, [this] {
     showLayerProperties( QgsProject::instance()->mainAnnotationLayer() );
@@ -3339,6 +3341,7 @@ void QgisApp::createActionGroups()
   mMapToolGroup->addAction( mActionChangeLabelProperties );
   mMapToolGroup->addAction( mActionReverseLine );
   mMapToolGroup->addAction( mActionTrimExtendFeature );
+  mMapToolGroup->addAction( mActionSelectAnnotation );
   mMapToolGroup->addAction( mActionModifyAnnotation );
 
   //
@@ -4569,6 +4572,7 @@ void QgisApp::setupCanvasTools()
   mMapTools->mapTool( QgsAppMapTools::MoveLabel )->setAction( mActionMoveLabel );
   mMapTools->mapTool( QgsAppMapTools::RotateLabel )->setAction( mActionRotateLabel );
   mMapTools->mapTool( QgsAppMapTools::ChangeLabelProperties )->setAction( mActionChangeLabelProperties );
+  mMapTools->mapTool( QgsAppMapTools::AnnotationSelect )->setAction( mActionSelectAnnotation );
   mMapTools->mapTool( QgsAppMapTools::AnnotationEdit )->setAction( mActionModifyAnnotation );
 
   //ensure that non edit tool is initialized or we will get crashes in some situations

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -12,8 +12,10 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+
 #include "qgslayerstylingwidget.h"
 
+#include "annotations/qgsannotationitempropertieswidget.h"
 #include "qgisapp.h"
 #include "qgsannotationlayer.h"
 #include "qgsapplication.h"
@@ -837,7 +839,7 @@ void QgsLayerStylingWidget::setCurrentPage( QgsLayerStylingWidget::Page page )
   }
 }
 
-void QgsLayerStylingWidget::setAnnotationItem( QgsAnnotationLayer *layer, const QString &itemId )
+void QgsLayerStylingWidget::setAnnotationItem( QgsAnnotationLayer *layer, const QString &itemId, bool multipleItems )
 {
   mContext.setAnnotationId( itemId );
   if ( layer )
@@ -846,9 +848,14 @@ void QgsLayerStylingWidget::setAnnotationItem( QgsAnnotationLayer *layer, const 
     mStackedWidget->setCurrentIndex( mLayerPage );
   }
 
-  if ( QgsMapLayerConfigWidget *configWidget = qobject_cast<QgsMapLayerConfigWidget *>( mWidgetStack->mainPanel() ) )
+  if ( QgsAnnotationItemPropertiesWidget *configWidget = qobject_cast<QgsAnnotationItemPropertiesWidget *>( mWidgetStack->mainPanel() ) )
   {
     configWidget->setMapLayerConfigWidgetContext( mContext );
+
+    if ( itemId.isEmpty() )
+    {
+      configWidget->setLabelMessage( multipleItems ? tr( "Multiple items selected." ) : tr( "No item selected." ) );
+    }
   }
 }
 

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -141,7 +141,7 @@ class APP_EXPORT QgsLayerStylingWidget : public QWidget, private Ui::QgsLayerSty
     /**
      * Sets an annotation item to show in the widget.
      */
-    void setAnnotationItem( QgsAnnotationLayer *layer, const QString &itemId );
+    void setAnnotationItem( QgsAnnotationLayer *layer, const QString &itemId, bool multipleItems = false );
 
     /**
      * Sets a layer tree group to show in the widget.

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -127,6 +127,8 @@ set(QGIS_GUI_SRCS
   annotations/qgscreateannotationitemmaptool.cpp
   annotations/qgscreateannotationitemmaptool_impl.cpp
   annotations/qgsmaptoolmodifyannotation.cpp
+  annotations/qgsmaptoolselectannotation.cpp
+  annotations/qgsmaptoolselectannotationmousehandles.cpp
 
   auth/qgsauthauthoritieseditor.cpp
   auth/qgsauthcertificateinfo.cpp
@@ -1110,6 +1112,8 @@ set(QGIS_GUI_HDRS
   annotations/qgscreateannotationitemmaptool.h
   annotations/qgscreateannotationitemmaptool_impl.h
   annotations/qgsmaptoolmodifyannotation.h
+  annotations/qgsmaptoolselectannotation.h
+  annotations/qgsmaptoolselectannotationmousehandles.h
 
   attributeformconfig/qgsattributeformcontaineredit.h
   attributeformconfig/qgsattributetypedialog.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -124,6 +124,7 @@ set(QGIS_GUI_SRCS
   annotations/qgsannotationitemguiregistry.cpp
   annotations/qgsannotationitemwidget.cpp
   annotations/qgsannotationitemwidget_impl.cpp
+  annotations/qgsannotationmaptool.cpp
   annotations/qgscreateannotationitemmaptool.cpp
   annotations/qgscreateannotationitemmaptool_impl.cpp
   annotations/qgsmaptoolmodifyannotation.cpp
@@ -1109,6 +1110,7 @@ set(QGIS_GUI_HDRS
   annotations/qgsannotationitemcommonpropertieswidget.h
   annotations/qgsannotationitemguiregistry.h
   annotations/qgsannotationitemwidget.h
+  annotations/qgsannotationmaptool.h
   annotations/qgscreateannotationitemmaptool.h
   annotations/qgscreateannotationitemmaptool_impl.h
   annotations/qgsmaptoolmodifyannotation.h

--- a/src/gui/annotations/qgsannotationmaptool.cpp
+++ b/src/gui/annotations/qgsannotationmaptool.cpp
@@ -1,0 +1,74 @@
+/***************************************************************************
+    qgsmaptoolannotation.cpp
+    ----------------
+    copyright            : (C) 2025 by Mathieu Pellerin
+    email                : mathieu at opengis dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsannotationmaptool.h"
+
+#include "qgsannotationitem.h"
+#include "qgsannotationlayer.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaptoolselectannotationmousehandles.h"
+#include "qgsproject.h"
+#include "qgsrenderedannotationitemdetails.h"
+#include "qgsrendereditemdetails.h"
+#include "qgsrendereditemresults.h"
+
+#include "moc_qgsannotationmaptool.cpp"
+
+QgsAnnotationMapTool::QgsAnnotationMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+  : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
+{
+}
+
+const QgsRenderedAnnotationItemDetails *QgsAnnotationMapTool::findClosestItemToPoint( const QgsPointXY &mapPoint, const QList<const QgsRenderedAnnotationItemDetails *> &items, QgsRectangle &bounds )
+{
+  const QgsRenderedAnnotationItemDetails *closestItem = nullptr;
+  double closestItemDistance = std::numeric_limits<double>::max();
+  double closestItemArea = std::numeric_limits<double>::max();
+
+  for ( const QgsRenderedAnnotationItemDetails *item : items )
+  {
+    const QgsAnnotationItem *annotationItem = annotationItemFromId( item->layerId(), item->itemId() );
+    if ( !annotationItem )
+      continue;
+
+    const QgsRectangle itemBounds = item->boundingBox();
+    const double itemDistance = itemBounds.contains( mapPoint ) ? 0 : itemBounds.distance( mapPoint );
+    if ( !closestItem || itemDistance < closestItemDistance || ( itemDistance == closestItemDistance && itemBounds.area() < closestItemArea ) )
+    {
+      closestItem = item;
+      closestItemDistance = itemDistance;
+      closestItemArea = itemBounds.area();
+      bounds = itemBounds;
+    }
+  }
+  return closestItem;
+}
+
+QgsAnnotationLayer *QgsAnnotationMapTool::annotationLayerFromId( const QString &layerId )
+{
+  QgsAnnotationLayer *layer = qobject_cast<QgsAnnotationLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+  if ( !layer && layerId == QgsProject::instance()->mainAnnotationLayer()->id() )
+  {
+    layer = QgsProject::instance()->mainAnnotationLayer();
+  }
+  return layer;
+}
+
+QgsAnnotationItem *QgsAnnotationMapTool::annotationItemFromId( const QString &layerId, const QString &itemId )
+{
+  QgsAnnotationLayer *layer = annotationLayerFromId( layerId );
+  return layer ? layer->item( itemId ) : nullptr;
+}

--- a/src/gui/annotations/qgsannotationmaptool.h
+++ b/src/gui/annotations/qgsannotationmaptool.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+    qgsannotationmaptool.h
+    ----------------
+    copyright            : (C) 2025 by Mathieu Pellerin
+    email                : mathieu at opengis dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSANNOTATIONMAPTOOL_H
+#define QGSANNOTATIONMAPTOOL_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgsmapmouseevent.h"
+#include "qgsmaptooladvanceddigitizing.h"
+#include "qgsmaptooledit.h"
+
+class QgsRenderedAnnotationItemDetails;
+class QgsAnnotationLayer;
+class QgsAnnotationItem;
+
+#define SIP_NO_FILE
+
+
+/**
+ * \ingroup gui
+ * \brief A base class for annotation map tools
+ * \note Not available in Python bindings
+ * \since QGIS 4.0
+ */
+class GUI_EXPORT QgsAnnotationMapTool : public QgsMapToolAdvancedDigitizing
+{
+    Q_OBJECT
+
+  public:
+    /**
+     * Constructor for QgsAnnotationMapTool
+     */
+    explicit QgsAnnotationMapTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+    ~QgsAnnotationMapTool() override = default;
+
+    /**
+     * Returns the closest item from a list of annotation items to a given map point.
+     * \param mapPoint the map point
+     * \param items the rendered annotation items list
+     * \param bounds the bounds
+     */
+    const QgsRenderedAnnotationItemDetails *findClosestItemToPoint( const QgsPointXY &mapPoint, const QList<const QgsRenderedAnnotationItemDetails *> &items, QgsRectangle &bounds );
+
+    /**
+     * Returns the annotation layer matching a given ID.
+     * \param layerId the annotation layer ID
+     */
+    QgsAnnotationLayer *annotationLayerFromId( const QString &layerId );
+
+    /**
+     * Returns the annotation item matching a given pair of layer and item IDs.
+     * \param layerId the layer ID
+     * \param itemId the item ID
+     */
+    QgsAnnotationItem *annotationItemFromId( const QString &layerId, const QString &itemId );
+};
+
+#endif // QGSANNOTATIONMAPTOOL_H

--- a/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
@@ -22,7 +22,6 @@
 #include "qgsannotationitemnode.h"
 #include "qgsannotationlayer.h"
 #include "qgsmapcanvas.h"
-#include "qgsmapmouseevent.h"
 #include "qgsproject.h"
 #include "qgsrenderedannotationitemdetails.h"
 #include "qgsrendereditemdetails.h"
@@ -115,7 +114,7 @@ class QgsAnnotationItemNodesSpatialIndex : public RTree<int, float, 2, float>
 
 
 QgsMapToolModifyAnnotation::QgsMapToolModifyAnnotation( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
-  : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
+  : QgsAnnotationMapTool( canvas, cadDockWidget )
   , mSnapIndicator( new QgsSnapIndicator( canvas ) )
 {
   connect( QgsMapToolModifyAnnotation::canvas(), &QgsMapCanvas::mapCanvasRefreshed, this, &QgsMapToolModifyAnnotation::onCanvasRefreshed );
@@ -712,45 +711,6 @@ QSizeF QgsMapToolModifyAnnotation::deltaForKeyEvent( QgsAnnotationLayer *layer, 
   const QgsPointXY afterMoveLayerPoint = toLayerCoordinates( layer, afterMoveMapPoint );
 
   return QSizeF( afterMoveLayerPoint.x() - beforeMoveLayerPoint.x(), afterMoveLayerPoint.y() - beforeMoveLayerPoint.y() );
-}
-
-const QgsRenderedAnnotationItemDetails *QgsMapToolModifyAnnotation::findClosestItemToPoint( const QgsPointXY &mapPoint, const QList<const QgsRenderedAnnotationItemDetails *> &items, QgsRectangle &bounds )
-{
-  const QgsRenderedAnnotationItemDetails *closestItem = nullptr;
-  double closestItemDistance = std::numeric_limits<double>::max();
-  double closestItemArea = std::numeric_limits<double>::max();
-
-  for ( const QgsRenderedAnnotationItemDetails *item : items )
-  {
-    const QgsAnnotationItem *annotationItem = annotationItemFromId( item->layerId(), item->itemId() );
-    if ( !annotationItem )
-      continue;
-
-    const QgsRectangle itemBounds = item->boundingBox();
-    const double itemDistance = itemBounds.contains( mapPoint ) ? 0 : itemBounds.distance( mapPoint );
-    if ( !closestItem || itemDistance < closestItemDistance || ( itemDistance == closestItemDistance && itemBounds.area() < closestItemArea ) )
-    {
-      closestItem = item;
-      closestItemDistance = itemDistance;
-      closestItemArea = itemBounds.area();
-      bounds = itemBounds;
-    }
-  }
-  return closestItem;
-}
-
-QgsAnnotationLayer *QgsMapToolModifyAnnotation::annotationLayerFromId( const QString &layerId )
-{
-  QgsAnnotationLayer *layer = qobject_cast<QgsAnnotationLayer *>( QgsProject::instance()->mapLayer( layerId ) );
-  if ( !layer && layerId == QgsProject::instance()->mainAnnotationLayer()->id() )
-    layer = QgsProject::instance()->mainAnnotationLayer();
-  return layer;
-}
-
-QgsAnnotationItem *QgsMapToolModifyAnnotation::annotationItemFromId( const QString &layerId, const QString &itemId )
-{
-  QgsAnnotationLayer *layer = annotationLayerFromId( layerId );
-  return layer ? layer->item( itemId ) : nullptr;
 }
 
 void QgsMapToolModifyAnnotation::setHoveredItemFromPoint( const QgsPointXY &mapPoint )

--- a/src/gui/annotations/qgsmaptoolmodifyannotation.h
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.h
@@ -20,7 +20,7 @@
 #include "qgis_gui.h"
 #include "qgis_sip.h"
 #include "qgsannotationitemnode.h"
-#include "qgsmaptooladvanceddigitizing.h"
+#include "qgsannotationmaptool.h"
 #include "qgspointxy.h"
 #include "qgsrectangle.h"
 #include "qobjectuniqueptr.h"
@@ -40,7 +40,7 @@ class QgsSnapIndicator;
  * \note Not available in Python bindings
  * \since QGIS 3.22
  */
-class GUI_EXPORT QgsMapToolModifyAnnotation : public QgsMapToolAdvancedDigitizing
+class GUI_EXPORT QgsMapToolModifyAnnotation : public QgsAnnotationMapTool
 {
     Q_OBJECT
 
@@ -49,7 +49,6 @@ class GUI_EXPORT QgsMapToolModifyAnnotation : public QgsMapToolAdvancedDigitizin
      * Constructor for QgsMapToolModifyAnnotation
      */
     explicit QgsMapToolModifyAnnotation( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
-
     ~QgsMapToolModifyAnnotation() override;
 
     void deactivate() override;
@@ -86,9 +85,6 @@ class GUI_EXPORT QgsMapToolModifyAnnotation : public QgsMapToolAdvancedDigitizin
     void createHoverBand();
     void createHoveredNodeBand();
     void createSelectedItemBand();
-    const QgsRenderedAnnotationItemDetails *findClosestItemToPoint( const QgsPointXY &mapPoint, const QList<const QgsRenderedAnnotationItemDetails *> &items, QgsRectangle &bounds );
-    QgsAnnotationLayer *annotationLayerFromId( const QString &layerId );
-    QgsAnnotationItem *annotationItemFromId( const QString &layerId, const QString &itemId );
 
     void setHoveredItemFromPoint( const QgsPointXY &mapPoint );
     void setHoveredItem( const QgsRenderedAnnotationItemDetails *item, const QgsRectangle &itemMapBounds );

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -632,9 +632,13 @@ void QgsMapToolSelectAnnotation::setSelectedItemFromPoint( const QgsPointXY &map
 
 void QgsMapToolSelectAnnotation::updateSelectedItem()
 {
-  if ( mSelectedItems.size() == 1 )
+  if ( mSelectedItems.size() > 1 )
   {
-    emit itemSelected( mSelectedItems[0]->layer(), mSelectedItems[0]->itemId() );
+    emit multipleItemsSelected();
+  }
+  else if ( mSelectedItems.size() == 1 )
+  {
+    emit singleItemSelected( mSelectedItems[0]->layer(), mSelectedItems[0]->itemId() );
   }
   else
   {

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -396,7 +396,7 @@ void QgsMapToolSelectAnnotation::keyPressEvent( QKeyEvent *event )
       }
       delete selectedItem;
     }
-    emit selectionChanged();
+    emit selectedItemsChanged();
     event->ignore();
   }
   else if ( event->key() == Qt::Key_Left
@@ -468,7 +468,7 @@ void QgsMapToolSelectAnnotation::onCanvasRefreshed()
 
   if ( needsSelectedItemsUpdate )
   {
-    emit selectionChanged();
+    emit selectedItemsChanged();
   }
 }
 
@@ -569,7 +569,9 @@ void QgsMapToolSelectAnnotation::setSelectedItemsFromRect( const QgsRectangle &m
       mSelectedItems << rubberband.release();
     }
   }
-  emit selectionChanged();
+  emit selectedItemsChanged();
+
+  updateSelectedItem();
 }
 
 void QgsMapToolSelectAnnotation::setSelectedItemFromPoint( const QgsPointXY &mapPoint, bool toggleSelection )
@@ -623,7 +625,21 @@ void QgsMapToolSelectAnnotation::setSelectedItemFromPoint( const QgsPointXY &map
     rubberband->updateBoundingBox( closestItem->boundingBox() );
     mSelectedItems << rubberband.release();
   }
-  emit selectionChanged();
+  emit selectedItemsChanged();
+
+  updateSelectedItem();
+}
+
+void QgsMapToolSelectAnnotation::updateSelectedItem()
+{
+  if ( mSelectedItems.size() == 1 )
+  {
+    emit itemSelected( mSelectedItems[0]->layer(), mSelectedItems[0]->itemId() );
+  }
+  else
+  {
+    emit selectionCleared();
+  }
 }
 
 void QgsMapToolSelectAnnotation::clearSelectedItems()
@@ -633,6 +649,6 @@ void QgsMapToolSelectAnnotation::clearSelectedItems()
   mSelectedItems.clear();
   if ( hadSelection )
   {
-    emit selectionChanged();
+    emit selectedItemsChanged();
   }
 }

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -1,0 +1,638 @@
+/***************************************************************************
+    qgsmaptoolselectannotation.cpp
+    ----------------
+    copyright            : (C) 2025 by Mathieu Pellerin
+    email                : mathieu at opengis dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaptoolselectannotation.h"
+#include "moc_qgsmaptoolselectannotation.cpp"
+#include "qgsapplication.h"
+#include "qgsrubberband.h"
+#include "qgsmapmouseevent.h"
+#include "qgsmapcanvas.h"
+#include "qgsrendereditemresults.h"
+#include "qgsrendereditemdetails.h"
+#include "qgsannotationlayer.h"
+#include "qgsproject.h"
+#include "qgsrenderedannotationitemdetails.h"
+#include "qgsmaptoolselectannotationmousehandles.h"
+#include "qgsannotationitem.h"
+#include "qgsannotationitemnode.h"
+#include "qgsannotationitemeditoperation.h"
+#include "qgssnapindicator.h"
+
+#include <QGraphicsSceneHoverEvent>
+#include <QTransform>
+#include <QWindow>
+#include <QScreen>
+
+
+QgsAnnotationItemRubberBand::QgsAnnotationItemRubberBand( const QString &layerId, const QString &itemId, QgsMapCanvas *canvas )
+  : QgsRubberBand( canvas, Qgis::GeometryType::Line )
+  , mLayerId( layerId )
+  , mItemId( itemId )
+{
+  setFlags( flags() | QGraphicsItem::ItemIsSelectable );
+
+  setWidth( canvas->fontMetrics().xHeight() * .2 );
+  setSecondaryStrokeColor( QColor( 255, 255, 255, 100 ) );
+  setColor( QColor( 50, 50, 50, 200 ) );
+  setZValue( 10 );
+
+  QgsAnnotationItem *annotationItem = item();
+  mNeedsUpdatedBoundingBox = annotationItem && ( annotationItem->flags() & Qgis::AnnotationItemFlag::ScaleDependentBoundingBox );
+}
+
+QgsAnnotationItemRubberBand::~QgsAnnotationItemRubberBand()
+{
+}
+
+QgsAnnotationLayer *QgsAnnotationItemRubberBand::layer() const
+{
+  QgsAnnotationLayer *lyr = qobject_cast<QgsAnnotationLayer *>( QgsProject::instance()->mapLayer( mLayerId ) );
+  if ( !lyr && mLayerId == QgsProject::instance()->mainAnnotationLayer()->id() )
+  {
+    lyr = QgsProject::instance()->mainAnnotationLayer();
+  }
+  return lyr;
+}
+
+QgsAnnotationItem *QgsAnnotationItemRubberBand::item() const
+{
+  QgsAnnotationLayer *lyr = layer();
+  return lyr ? lyr->item( mItemId ) : nullptr;
+}
+
+void QgsAnnotationItemRubberBand::updateBoundingBox( const QgsRectangle &boundingBox )
+{
+  mBoundingBox = boundingBox;
+
+  reset( Qgis::GeometryType::Line );
+  addPoint( QgsPointXY( boundingBox.xMinimum(), boundingBox.yMinimum() ) );
+  addPoint( QgsPointXY( boundingBox.xMaximum(), boundingBox.yMinimum() ) );
+  addPoint( QgsPointXY( boundingBox.xMaximum(), boundingBox.yMaximum() ) );
+  addPoint( QgsPointXY( boundingBox.xMinimum(), boundingBox.yMaximum() ) );
+  addPoint( QgsPointXY( boundingBox.xMinimum(), boundingBox.yMinimum() ) );
+
+  show();
+  setSelected( true );
+}
+
+void QgsAnnotationItemRubberBand::attemptMoveBy( double deltaX, double deltaY )
+{
+  if ( QgsAnnotationItem *annotationItem = item() )
+  {
+    const double mupp = mMapCanvas->mapSettings().mapUnitsPerPixel();
+    QgsVector translation( deltaX * mupp, -deltaY * mupp );
+    QgsAnnotationLayer *annotationLayer = layer();
+
+    QgsAnnotationItemEditContext context;
+    context.setCurrentItemBounds( mBoundingBox );
+    context.setRenderContext( QgsRenderContext::fromMapSettings( mMapCanvas->mapSettings() ) );
+
+    const QList<QgsAnnotationItemNode> itemNodes = annotationItem->nodesV2( context );
+    for ( const QgsAnnotationItemNode &node : itemNodes )
+    {
+      QgsPointXY mapPoint = mMapCanvas->mapSettings().layerToMapCoordinates( annotationLayer, node.point() );
+      mapPoint += translation;
+      QgsPointXY modifiedPoint = mMapCanvas->mapSettings().mapToLayerCoordinates( annotationLayer, mapPoint );
+
+      QgsAnnotationItemEditOperationMoveNode operation( mItemId, node.id(), QgsPoint( node.point() ), QgsPoint( modifiedPoint ) );
+      switch ( annotationLayer->applyEditV2( &operation, context ) )
+      {
+        case Qgis::AnnotationItemEditOperationResult::Success:
+          QgsProject::instance()->setDirty( true );
+          mNeedsUpdatedBoundingBox = true;
+          break;
+
+        case Qgis::AnnotationItemEditOperationResult::Invalid:
+        case Qgis::AnnotationItemEditOperationResult::ItemCleared:
+          break;
+      }
+    }
+    mBoundingBox += translation;
+  }
+}
+
+void QgsAnnotationItemRubberBand::attemptRotateBy( double deltaDegree )
+{
+  if ( QgsAnnotationItem *annotationItem = item() )
+  {
+    QgsAnnotationLayer *annotationLayer = layer();
+
+    const double deltaRadian = -deltaDegree * M_PI / 180;
+    const QgsRectangle boundingBox = mMapCanvas->mapSettings().mapToLayerCoordinates( annotationLayer, mBoundingBox );
+    const QgsPointXY centroid = boundingBox.center();
+
+    QgsAnnotationItemEditContext context;
+    context.setCurrentItemBounds( boundingBox );
+    context.setRenderContext( QgsRenderContext::fromMapSettings( mMapCanvas->mapSettings() ) );
+
+    const QList<QgsAnnotationItemNode> itemNodes = annotationItem->nodesV2( context );
+    for ( const QgsAnnotationItemNode &node : itemNodes )
+    {
+      const double translatedX = node.point().x() - centroid.x();
+      const double translatedY = node.point().y() - centroid.y();
+      const double rotatedX = translatedX * std::cos( deltaRadian ) - translatedY * std::sin( deltaRadian );
+      const double rotatedY = translatedX * std::sin( deltaRadian ) + translatedY * std::cos( deltaRadian );
+      QgsPointXY modifiedPoint( rotatedX + centroid.x(), rotatedY + centroid.y() );
+      QgsAnnotationItemEditOperationMoveNode operation( mItemId, node.id(), QgsPoint( node.point() ), QgsPoint( modifiedPoint ) );
+      switch ( annotationLayer->applyEditV2( &operation, context ) )
+      {
+        case Qgis::AnnotationItemEditOperationResult::Success:
+          QgsProject::instance()->setDirty( true );
+          mNeedsUpdatedBoundingBox = true;
+          break;
+
+        case Qgis::AnnotationItemEditOperationResult::Invalid:
+        case Qgis::AnnotationItemEditOperationResult::ItemCleared:
+          break;
+      }
+    }
+  }
+}
+
+void QgsAnnotationItemRubberBand::attemptSetSceneRect( const QRectF &rect )
+{
+  const double widthRatio = rect.width() / boundingRect().width();
+  const double heightRatio = rect.height() / boundingRect().height();
+  const double deltaX = rect.x() - x() + 1;
+  const double deltaY = rect.y() - y() + 1;
+  attemptMoveBy( deltaX, deltaY );
+
+  if ( QgsAnnotationItem *annotationItem = item() )
+  {
+    QgsAnnotationLayer *annotationLayer = layer();
+
+    const QgsRectangle boundingBox = mMapCanvas->mapSettings().mapToLayerCoordinates( annotationLayer, mBoundingBox );
+    const QgsRectangle modifiedBoundingBox( boundingBox.xMinimum(), boundingBox.yMaximum() - boundingBox.height() * heightRatio, boundingBox.xMinimum() + boundingBox.width() * widthRatio, boundingBox.yMaximum() );
+
+    QgsAnnotationItemEditContext context;
+    context.setCurrentItemBounds( boundingBox );
+    context.setRenderContext( QgsRenderContext::fromMapSettings( mMapCanvas->mapSettings() ) );
+
+    const QList<QgsAnnotationItemNode> itemNodes = annotationItem->nodesV2( context );
+    for ( const QgsAnnotationItemNode &node : itemNodes )
+    {
+      const double modifiedX = modifiedBoundingBox.xMinimum() + modifiedBoundingBox.width() * ( ( node.point().x() - boundingBox.xMinimum() ) / boundingBox.width() );
+      const double modifiedY = modifiedBoundingBox.yMaximum() - modifiedBoundingBox.height() * ( ( boundingBox.yMaximum() - node.point().y() ) / boundingBox.height() );
+      QgsPointXY modifiedPoint( modifiedX, modifiedY );
+      QgsAnnotationItemEditOperationMoveNode operation( mItemId, node.id(), QgsPoint( node.point() ), QgsPoint( modifiedPoint ) );
+      switch ( annotationLayer->applyEditV2( &operation, context ) )
+      {
+        case Qgis::AnnotationItemEditOperationResult::Success:
+          QgsProject::instance()->setDirty( true );
+          mNeedsUpdatedBoundingBox = true;
+          break;
+
+        case Qgis::AnnotationItemEditOperationResult::Invalid:
+        case Qgis::AnnotationItemEditOperationResult::ItemCleared:
+          break;
+      }
+    }
+  }
+}
+
+bool QgsAnnotationItemRubberBand::operator==( const QgsAnnotationItemRubberBand &other ) const
+{
+  return mLayerId == other.mLayerId && mItemId == other.mItemId;
+}
+
+
+QgsMapToolSelectAnnotation::QgsMapToolSelectAnnotation( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+  : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
+{
+  connect( QgsMapToolSelectAnnotation::canvas(), &QgsMapCanvas::mapCanvasRefreshed, this, &QgsMapToolSelectAnnotation::onCanvasRefreshed );
+}
+
+QgsMapToolSelectAnnotation::~QgsMapToolSelectAnnotation()
+{
+  mSelectionRubberBand.reset();
+  mMouseHandles.reset();
+
+  qDeleteAll( mSelectedItems );
+}
+
+void QgsMapToolSelectAnnotation::activate()
+{
+  mMouseHandles.reset( new QgsMapToolSelectAnnotationMouseHandles( this, mCanvas ) );
+
+  QgsMapToolAdvancedDigitizing::activate();
+}
+
+void QgsMapToolSelectAnnotation::deactivate()
+{
+  mSelectionRubberBand.reset();
+  mMouseHandles.reset();
+
+  qDeleteAll( mSelectedItems );
+  mSelectedItems.clear();
+
+  QgsMapToolAdvancedDigitizing::deactivate();
+}
+
+void QgsMapToolSelectAnnotation::cadCanvasMoveEvent( QgsMapMouseEvent *event )
+{
+  const QPointF scenePos = mCanvas->mapToScene( event->pos() );
+
+  if ( ( event->buttons() == Qt::NoButton ) )
+  {
+    if ( mMouseHandles->sceneBoundingRect().contains( scenePos ) )
+    {
+      QGraphicsSceneHoverEvent forwardedEvent( QEvent::GraphicsSceneHoverMove );
+      forwardedEvent.setPos( mMouseHandles->mapFromScene( scenePos ) );
+      forwardedEvent.setScenePos( scenePos );
+      mMouseHandles->hoverMoveEvent( &forwardedEvent );
+      mHoveringMouseHandles = true;
+    }
+    else if ( mHoveringMouseHandles )
+    {
+      QGraphicsSceneHoverEvent forwardedEvent( QEvent::GraphicsSceneHoverLeave );
+      forwardedEvent.setPos( mMouseHandles->mapFromScene( scenePos ) );
+      forwardedEvent.setScenePos( scenePos );
+      mMouseHandles->hoverMoveEvent( &forwardedEvent );
+      mHoveringMouseHandles = false;
+    }
+  }
+  else if ( ( event->buttons() == Qt::LeftButton ) )
+  {
+    if ( mMouseHandles->shouldBlockEvent( event ) )
+    {
+      QGraphicsSceneMouseEvent forwardedEvent( QEvent::GraphicsSceneMouseMove );
+      forwardedEvent.setPos( mMouseHandles->mapFromScene( scenePos ) );
+      forwardedEvent.setScenePos( scenePos );
+      forwardedEvent.setLastScenePos( mLastScenePos );
+      forwardedEvent.setButton( Qt::LeftButton );
+      mMouseHandles->mouseMoveEvent( &forwardedEvent );
+    }
+    else
+    {
+      if ( !mDragging )
+      {
+        mDragging = true;
+        mSelectionRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Polygon ) );
+        QColor color( Qt::blue );
+        color.setAlpha( 63 );
+        mSelectionRubberBand->setColor( color );
+        mSelectionRect.setTopLeft( event->pos() );
+      }
+
+      mSelectionRect.setBottomRight( event->pos() );
+      if ( mSelectionRubberBand )
+      {
+        mSelectionRubberBand->setToCanvasRectangle( mSelectionRect );
+        mSelectionRubberBand->show();
+      }
+    }
+  }
+
+  mLastScenePos = scenePos;
+}
+
+void QgsMapToolSelectAnnotation::cadCanvasPressEvent( QgsMapMouseEvent *event )
+{
+  if ( event->button() != Qt::LeftButton )
+  {
+    return;
+  }
+
+  QPointF scenePos = mCanvas->mapToScene( event->pos() );
+
+  if ( !mSelectedItems.isEmpty() && mMouseHandles->sceneBoundingRect().contains( scenePos ) )
+  {
+    QGraphicsSceneMouseEvent forwardedEvent( QEvent::GraphicsSceneMousePress );
+    forwardedEvent.setPos( mMouseHandles->mapFromScene( scenePos ) );
+    forwardedEvent.setScenePos( scenePos );
+    forwardedEvent.setLastScenePos( mLastScenePos );
+    forwardedEvent.setButton( Qt::LeftButton );
+    mMouseHandles->mousePressEvent( &forwardedEvent );
+  }
+  else
+  {
+    mSelectionRect.setTopLeft( event->pos() );
+    mSelectionRect.setBottomRight( event->pos() );
+  }
+
+  mLastScenePos = scenePos;
+}
+
+void QgsMapToolSelectAnnotation::cadCanvasReleaseEvent( QgsMapMouseEvent *event )
+{
+  if ( event->button() != Qt::LeftButton )
+  {
+    return;
+  }
+
+  QPointF scenePos = mCanvas->mapToScene( event->pos() );
+
+  if ( mMouseHandles->shouldBlockEvent( event ) )
+  {
+    QGraphicsSceneMouseEvent forwardedEvent( QEvent::GraphicsSceneMouseRelease );
+    forwardedEvent.setPos( mMouseHandles->mapFromScene( scenePos ) );
+    forwardedEvent.setScenePos( scenePos );
+    forwardedEvent.setLastScenePos( mLastScenePos );
+    forwardedEvent.setButton( Qt::LeftButton );
+    mMouseHandles->mouseReleaseEvent( &forwardedEvent );
+  }
+  else
+  {
+    if ( mCanceled )
+    {
+      mCanceled = false;
+      mDragging = false;
+      return;
+    }
+
+    if ( mDragging )
+    {
+      mDragging = false;
+      mSelectionRubberBand.reset();
+
+      const QgsPointXY topLeft = toMapCoordinates( mSelectionRect.topLeft() );
+      const QgsPointXY bottomRight = toMapCoordinates( mSelectionRect.bottomRight() );
+      const QgsRectangle searchRect( topLeft, bottomRight );
+
+      setSelectedItemsFromRect( searchRect, ( event->modifiers() & Qt::ShiftModifier ) );
+    }
+    else
+    {
+      setSelectedItemFromPoint( event->mapPoint(), ( event->modifiers() & Qt::ShiftModifier ) );
+    }
+
+    mMouseHandles->setSelected( !mSelectedItems.isEmpty() );
+  }
+}
+
+void QgsMapToolSelectAnnotation::keyPressEvent( QKeyEvent *event )
+{
+  if ( mMouseHandles->isDragging() || mMouseHandles->isResizing() )
+  {
+    return;
+  }
+
+  if ( mSelectedItems.isEmpty() )
+  {
+    return;
+  }
+
+  if ( event->key() == Qt::Key_Backspace || event->key() == Qt::Key_Delete )
+  {
+    while ( !mSelectedItems.isEmpty() )
+    {
+      QgsAnnotationItemRubberBand *selectedItem = mSelectedItems.takeLast();
+      if ( QgsAnnotationLayer *annotationLayer = selectedItem->layer() )
+      {
+        annotationLayer->removeItem( selectedItem->itemId() );
+      }
+      delete selectedItem;
+    }
+    emit selectionChanged();
+    event->ignore();
+  }
+  else if ( event->key() == Qt::Key_Left
+            || event->key() == Qt::Key_Right
+            || event->key() == Qt::Key_Up
+            || event->key() == Qt::Key_Down )
+  {
+    const int pixels = event->modifiers() & Qt::ShiftModifier ? 1 : 50;
+    int deltaX = 0;
+    int deltaY = 0;
+    if ( event->key() == Qt::Key_Up )
+    {
+      deltaY = -pixels;
+    }
+    else if ( event->key() == Qt::Key_Down )
+    {
+      deltaY = pixels;
+    }
+    else if ( event->key() == Qt::Key_Left )
+    {
+      deltaX = -pixels;
+    }
+    else if ( event->key() == Qt::Key_Right )
+    {
+      deltaX = pixels;
+    }
+
+    for ( QgsAnnotationItemRubberBand *selectedItem : mSelectedItems )
+    {
+      selectedItem->attemptMoveBy( deltaX, deltaY );
+    }
+    event->ignore();
+  }
+}
+
+void QgsMapToolSelectAnnotation::onCanvasRefreshed()
+{
+  const QgsRenderedItemResults *renderedItemResults = canvas()->renderedItemResults( false );
+  if ( !renderedItemResults )
+  {
+    return;
+  }
+
+  const QList<QgsRenderedItemDetails *> items = renderedItemResults->renderedItems();
+  bool needsSelectedItemsUpdate = false;
+  for ( QgsAnnotationItemRubberBand *selectedItem : mSelectedItems )
+  {
+    if ( selectedItem->needsUpdatedBoundingBox() )
+    {
+      needsSelectedItemsUpdate = true;
+
+      auto it = std::find_if( items.begin(), items.end(), [this, selectedItem]( const QgsRenderedItemDetails *item ) {
+        if ( const QgsRenderedAnnotationItemDetails *annotationItem = dynamic_cast<const QgsRenderedAnnotationItemDetails *>( item ) )
+        {
+          if ( annotationItem->itemId() == selectedItem->itemId() && annotationItem->layerId() == selectedItem->layerId() )
+          {
+            return true;
+          }
+        }
+        return false;
+      } );
+
+      if ( it != items.end() )
+      {
+        selectedItem->updateBoundingBox( ( *it )->boundingBox() );
+      }
+    }
+  }
+
+  if ( needsSelectedItemsUpdate )
+  {
+    emit selectionChanged();
+  }
+}
+
+const QgsRenderedAnnotationItemDetails *QgsMapToolSelectAnnotation::findClosestItemToPoint( const QgsPointXY &mapPoint, const QList<const QgsRenderedAnnotationItemDetails *> &items, QgsRectangle &bounds )
+{
+  const QgsRenderedAnnotationItemDetails *closestItem = nullptr;
+  double closestItemDistance = std::numeric_limits<double>::max();
+  double closestItemArea = std::numeric_limits<double>::max();
+
+  for ( const QgsRenderedAnnotationItemDetails *item : items )
+  {
+    const QgsAnnotationItem *annotationItem = annotationItemFromId( item->layerId(), item->itemId() );
+    if ( !annotationItem )
+      continue;
+
+    const QgsRectangle itemBounds = item->boundingBox();
+    const double itemDistance = itemBounds.contains( mapPoint ) ? 0 : itemBounds.distance( mapPoint );
+    if ( !closestItem || itemDistance < closestItemDistance || ( itemDistance == closestItemDistance && itemBounds.area() < closestItemArea ) )
+    {
+      closestItem = item;
+      closestItemDistance = itemDistance;
+      closestItemArea = itemBounds.area();
+      bounds = itemBounds;
+    }
+  }
+  return closestItem;
+}
+
+QgsAnnotationLayer *QgsMapToolSelectAnnotation::annotationLayerFromId( const QString &layerId )
+{
+  QgsAnnotationLayer *layer = qobject_cast<QgsAnnotationLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+  if ( !layer && layerId == QgsProject::instance()->mainAnnotationLayer()->id() )
+  {
+    layer = QgsProject::instance()->mainAnnotationLayer();
+  }
+  return layer;
+}
+
+QgsAnnotationItem *QgsMapToolSelectAnnotation::annotationItemFromId( const QString &layerId, const QString &itemId )
+{
+  QgsAnnotationLayer *layer = annotationLayerFromId( layerId );
+  return layer ? layer->item( itemId ) : nullptr;
+}
+
+QgsAnnotationItemRubberBand *QgsMapToolSelectAnnotation::annotationItemRubberBandFromId( const QString &layerId, const QString &itemId )
+{
+  if ( mSelectedItems.isEmpty() )
+  {
+    return nullptr;
+  }
+
+  auto it = std::find_if( mSelectedItems.begin(), mSelectedItems.end(), [&layerId, &itemId]( QgsAnnotationItemRubberBand *item ) { return item->layerId() == layerId && item->itemId() == itemId; } );
+  return it != mSelectedItems.end() ? *it : nullptr;
+}
+
+void QgsMapToolSelectAnnotation::setSelectedItemsFromRect( const QgsRectangle &mapRect, bool toggleSelection )
+{
+  const QgsRenderedItemResults *renderedItemResults = canvas()->renderedItemResults( false );
+  if ( !renderedItemResults )
+  {
+    if ( !toggleSelection )
+    {
+      clearSelectedItems();
+    }
+    return;
+  }
+
+  const QList<const QgsRenderedAnnotationItemDetails *> items = renderedItemResults->renderedAnnotationItemsInBounds( mapRect );
+  if ( items.empty() )
+  {
+    if ( !toggleSelection )
+    {
+      clearSelectedItems();
+    }
+    return;
+  }
+
+  if ( !toggleSelection )
+  {
+    qDeleteAll( mSelectedItems );
+    mSelectedItems.clear();
+  }
+  for ( const QgsRenderedAnnotationItemDetails *item : items )
+  {
+    QgsAnnotationItem *annotationItem = annotationItemFromId( item->layerId(), item->itemId() );
+    if ( annotationItem )
+    {
+      if ( toggleSelection )
+      {
+        if ( QgsAnnotationItemRubberBand *preexistingItem = annotationItemRubberBandFromId( item->layerId(), item->itemId() ) )
+        {
+          delete mSelectedItems.takeAt( mSelectedItems.indexOf( preexistingItem ) );
+          continue;
+        }
+      }
+      std::unique_ptr<QgsAnnotationItemRubberBand> rubberband = std::make_unique<QgsAnnotationItemRubberBand>( item->layerId(), item->itemId(), mCanvas );
+      rubberband->updateBoundingBox( item->boundingBox() );
+      mSelectedItems << rubberband.release();
+    }
+  }
+  emit selectionChanged();
+}
+
+void QgsMapToolSelectAnnotation::setSelectedItemFromPoint( const QgsPointXY &mapPoint, bool toggleSelection )
+{
+  QgsRectangle searchRect = QgsRectangle( mapPoint.x(), mapPoint.y(), mapPoint.x(), mapPoint.y() );
+  searchRect.grow( searchRadiusMU( canvas() ) );
+
+  const QgsRenderedItemResults *renderedItemResults = canvas()->renderedItemResults( false );
+  if ( !renderedItemResults )
+  {
+    clearSelectedItems();
+    return;
+  }
+
+  const QList<const QgsRenderedAnnotationItemDetails *> items = renderedItemResults->renderedAnnotationItemsInBounds( searchRect );
+  if ( items.empty() )
+  {
+    if ( !toggleSelection )
+    {
+      clearSelectedItems();
+    }
+    return;
+  }
+
+  QgsRectangle itemBounds;
+  const QgsRenderedAnnotationItemDetails *closestItem = findClosestItemToPoint( mapPoint, items, itemBounds );
+  if ( !closestItem )
+  {
+    if ( !toggleSelection )
+    {
+      clearSelectedItems();
+    }
+    return;
+  }
+
+  if ( QgsAnnotationItemRubberBand *preexistingItem = annotationItemRubberBandFromId( closestItem->layerId(), closestItem->itemId() ) )
+  {
+    if ( toggleSelection )
+    {
+      delete mSelectedItems.takeAt( mSelectedItems.indexOf( preexistingItem ) );
+    }
+  }
+  else
+  {
+    if ( !toggleSelection )
+    {
+      qDeleteAll( mSelectedItems );
+      mSelectedItems.clear();
+    }
+    std::unique_ptr<QgsAnnotationItemRubberBand> rubberband = std::make_unique<QgsAnnotationItemRubberBand>( closestItem->layerId(), closestItem->itemId(), mCanvas );
+    rubberband->updateBoundingBox( closestItem->boundingBox() );
+    mSelectedItems << rubberband.release();
+  }
+  emit selectionChanged();
+}
+
+void QgsMapToolSelectAnnotation::clearSelectedItems()
+{
+  const bool hadSelection = !mSelectedItems.isEmpty();
+  qDeleteAll( mSelectedItems );
+  mSelectedItems.clear();
+  if ( hadSelection )
+  {
+    emit selectionChanged();
+  }
+}

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -435,7 +435,7 @@ void QgsMapToolSelectAnnotation::keyPressEvent( QKeyEvent *event )
             || event->key() == Qt::Key_Up
             || event->key() == Qt::Key_Down )
   {
-    const int pixels = event->modifiers() & Qt::ShiftModifier ? 1 : 50;
+    const int pixels = ( event->modifiers() & Qt::ShiftModifier ) ? 1 : 50;
     int deltaX = 0;
     int deltaY = 0;
     if ( event->key() == Qt::Key_Up )
@@ -489,7 +489,7 @@ void QgsMapToolSelectAnnotation::onCanvasRefreshed()
     {
       needsSelectedItemsUpdate = true;
 
-      auto it = std::find_if( items.begin(), items.end(), [this, &selectedItem]( const QgsRenderedItemDetails *item ) {
+      auto it = std::find_if( items.begin(), items.end(), [&selectedItem]( const QgsRenderedItemDetails *item ) {
         if ( const QgsRenderedAnnotationItemDetails *annotationItem = dynamic_cast<const QgsRenderedAnnotationItemDetails *>( item ) )
         {
           if ( annotationItem->itemId() == selectedItem->itemId() && annotationItem->layerId() == selectedItem->layerId() )

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -94,6 +94,8 @@ QgsMapToolSelectAnnotation::QgsMapToolSelectAnnotation( QgsMapCanvas *canvas, Qg
 {
   connect( QgsMapToolSelectAnnotation::canvas(), &QgsMapCanvas::mapCanvasRefreshed, this, &QgsMapToolSelectAnnotation::onCanvasRefreshed );
   connect( this, &QgsMapToolSelectAnnotation::selectedItemsChanged, this, &QgsMapToolSelectAnnotation::updateSelectedItem );
+
+  setAdvancedDigitizingAllowed( false );
 }
 
 QgsMapToolSelectAnnotation::~QgsMapToolSelectAnnotation()

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -297,8 +297,9 @@ void QgsMapToolSelectAnnotation::cadCanvasPressEvent( QgsMapMouseEvent *event )
   }
 
   QPointF scenePos = mCanvas->mapToScene( event->pos() );
+  const bool toggleSelection = event->modifiers() & Qt::ShiftModifier;
 
-  if ( !mSelectedItems.empty() && mMouseHandles->sceneBoundingRect().contains( scenePos ) )
+  if ( !toggleSelection && !mSelectedItems.empty() && mMouseHandles->sceneBoundingRect().contains( scenePos ) )
   {
     QGraphicsSceneMouseEvent forwardedEvent( QEvent::GraphicsSceneMousePress );
     forwardedEvent.setPos( mMouseHandles->mapFromScene( scenePos ) );

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -52,10 +52,6 @@ QgsAnnotationItemRubberBand::QgsAnnotationItemRubberBand( const QString &layerId
   mNeedsUpdatedBoundingBox = true;
 }
 
-QgsAnnotationItemRubberBand::~QgsAnnotationItemRubberBand()
-{
-}
-
 QgsAnnotationLayer *QgsAnnotationItemRubberBand::layer() const
 {
   QgsAnnotationLayer *lyr = qobject_cast<QgsAnnotationLayer *>( QgsProject::instance()->mapLayer( mLayerId ) );
@@ -203,12 +199,6 @@ void QgsAnnotationItemRubberBand::attemptSetSceneRect( const QRectF &rect )
     }
   }
 }
-
-bool QgsAnnotationItemRubberBand::operator==( const QgsAnnotationItemRubberBand &other ) const
-{
-  return mLayerId == other.mLayerId && mItemId == other.mItemId;
-}
-
 
 QgsMapToolSelectAnnotation::QgsMapToolSelectAnnotation( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
   : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )

--- a/src/gui/annotations/qgsmaptoolselectannotation.h
+++ b/src/gui/annotations/qgsmaptoolselectannotation.h
@@ -179,7 +179,7 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsAnnotationMapTool
     void onCanvasRefreshed();
 
   private:
-    qsizetype annotationItemRubberBandIndexFromId( const QString &layerId, const QString &itemId );
+    long long annotationItemRubberBandIndexFromId( const QString &layerId, const QString &itemId );
 
     void setSelectedItemFromPoint( const QgsPointXY &mapPoint, bool toggleSelection = false );
     void setSelectedItemsFromRect( const QgsRectangle &mapRect, bool toggleSelection = false );

--- a/src/gui/annotations/qgsmaptoolselectannotation.h
+++ b/src/gui/annotations/qgsmaptoolselectannotation.h
@@ -100,17 +100,22 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizin
   signals:
 
     /**
-     * Emitted when the selected item has changed.
+     * Emitted when the selected items list has changed.
      */
     void selectedItemsChanged();
 
     /**
-     * Emitted when the selected item is changed.
+     * Emitted when the selected items list has changed and a single item is selected.
      */
-    void itemSelected( QgsAnnotationLayer *layer, const QString &itemId );
+    void singleItemSelected( QgsAnnotationLayer *layer, const QString &itemId );
 
     /**
-     * Emitted when the selected item is cleared.
+     * Emitted when the selected items list has changed and multiple items are selected.
+     */
+    void multipleItemsSelected();
+
+    /**
+     * Emitted when the selected items list is cleared.
      */
     void selectionCleared();
 

--- a/src/gui/annotations/qgsmaptoolselectannotation.h
+++ b/src/gui/annotations/qgsmaptoolselectannotation.h
@@ -1,0 +1,135 @@
+/***************************************************************************
+    qgsmaptoolselectannotation.h
+    ----------------
+    copyright            : (C) 2025 by Mathieu Pellerin
+    email                : mathieu at opengis dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLSELECTANNOTATION_H
+#define QGSMAPTOOLSELECTANNOTATION_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgsmaptoolselectannotationmousehandles.h"
+#include "qgsmaptooladvanceddigitizing.h"
+#include "qobjectuniqueptr.h"
+#include "qgspointxy.h"
+#include "qgsannotationitemnode.h"
+#include "qgsrectangle.h"
+#include "qgsrubberband.h"
+
+class QgsRubberBand;
+class QgsRenderedAnnotationItemDetails;
+class QgsAnnotationItem;
+class QgsAnnotationLayer;
+class QgsAnnotationItemNodesSpatialIndex;
+class QgsMapToolSelectAnnotationMouseHandles;
+class QgsSnapIndicator;
+
+#define SIP_NO_FILE
+
+class GUI_EXPORT QgsAnnotationItemRubberBand : public QgsRubberBand
+{
+    Q_OBJECT
+
+  public:
+    /**
+     * Constructor for QgsAnnotationItemRubberBand
+     */
+    explicit QgsAnnotationItemRubberBand( const QString &layerId, const QString &itemId, QgsMapCanvas *canvas );
+    ~QgsAnnotationItemRubberBand() override;
+
+    QString layerId() const { return mLayerId; }
+    QgsAnnotationLayer *layer() const;
+
+    QString itemId() const { return mItemId; }
+    QgsAnnotationItem *item() const;
+
+    void updateBoundingBox( const QgsRectangle &boundingBox );
+    bool needsUpdatedBoundingBox() const { return mNeedsUpdatedBoundingBox; }
+
+    void attemptMoveBy( double deltaX, double deltaY );
+    void attemptRotateBy( double deltaDegree );
+    void attemptSetSceneRect( const QRectF &rect );
+
+    bool operator==( const QgsAnnotationItemRubberBand &other ) const;
+
+  private:
+    QString mLayerId;
+    QString mItemId;
+    QgsRectangle mBoundingBox;
+    bool mNeedsUpdatedBoundingBox = false;
+};
+
+/**
+ * \ingroup gui
+ * \brief A map tool for selecting, moving, and rotating annotations in a QgsAnnotationLayer
+ * \note Not available in Python bindings
+ * \since QGIS 4.0
+ */
+class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizing
+{
+    Q_OBJECT
+
+  public:
+    /**
+     * Constructor for QgsMapToolSelectAnnotation
+     */
+    explicit QgsMapToolSelectAnnotation( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+
+    ~QgsMapToolSelectAnnotation() override;
+
+    void activate() override;
+    void deactivate() override;
+    void cadCanvasMoveEvent( QgsMapMouseEvent *event ) override;
+    void cadCanvasPressEvent( QgsMapMouseEvent *event ) override;
+    void cadCanvasReleaseEvent( QgsMapMouseEvent *event ) override;
+    void keyPressEvent( QKeyEvent *event ) override;
+
+    QList<QgsAnnotationItemRubberBand *> selectedItems() const { return mSelectedItems; };
+
+  signals:
+
+    /**
+     * Emitted when the selected item has changed;
+     */
+    void selectionChanged();
+
+  private slots:
+    void onCanvasRefreshed();
+
+  private:
+    const QgsRenderedAnnotationItemDetails *findClosestItemToPoint( const QgsPointXY &mapPoint, const QList<const QgsRenderedAnnotationItemDetails *> &items, QgsRectangle &bounds );
+    QgsAnnotationLayer *annotationLayerFromId( const QString &layerId );
+    QgsAnnotationItem *annotationItemFromId( const QString &layerId, const QString &itemId );
+    QgsAnnotationItemRubberBand *annotationItemRubberBandFromId( const QString &layerId, const QString &itemId );
+
+    void setSelectedItemFromPoint( const QgsPointXY &mapPoint, bool toggleSelection = false );
+    void setSelectedItemsFromRect( const QgsRectangle &mapRect, bool toggleSelection = false );
+    void clearSelectedItems();
+
+    QList<QgsAnnotationItemRubberBand *> mSelectedItems;
+
+    bool mRefreshSelectedItemAfterRedraw = false;
+
+    QObjectUniquePtr<QgsMapToolSelectAnnotationMouseHandles> mMouseHandles;
+    bool mHoveringMouseHandles = false;
+    QPointF mLastScenePos;
+
+    QObjectUniquePtr<QgsRubberBand> mSelectionRubberBand;
+    QRect mSelectionRect;
+
+    bool mDragging = false;
+    bool mCanceled = false;
+};
+
+#endif // QGSMAPTOOLSELECTANNOTATION_H

--- a/src/gui/annotations/qgsmaptoolselectannotation.h
+++ b/src/gui/annotations/qgsmaptoolselectannotation.h
@@ -19,13 +19,14 @@
 
 #include "qgis_gui.h"
 #include "qgis_sip.h"
-#include "qgsmaptoolselectannotationmousehandles.h"
-#include "qgsmaptooladvanceddigitizing.h"
-#include "qobjectuniqueptr.h"
-#include "qgspointxy.h"
 #include "qgsannotationitemnode.h"
+#include "qgsannotationmaptool.h"
+#include "qgsmaptooladvanceddigitizing.h"
+#include "qgsmaptoolselectannotationmousehandles.h"
+#include "qgspointxy.h"
 #include "qgsrectangle.h"
 #include "qgsrubberband.h"
+#include "qobjectuniqueptr.h"
 
 class QgsRubberBand;
 class QgsRenderedAnnotationItemDetails;
@@ -92,7 +93,7 @@ class GUI_EXPORT QgsAnnotationItemRubberBand : public QgsRubberBand
 
     /**
      * Attempts to rotate the annotation item.
-     * \param deltaDegree the rotation value in degree 
+     * \param deltaDegree the rotation value in degree
      */
     void attemptRotateBy( double deltaDegree );
 
@@ -106,7 +107,7 @@ class GUI_EXPORT QgsAnnotationItemRubberBand : public QgsRubberBand
     QString mLayerId;
     QString mItemId;
     QgsRectangle mBoundingBox;
-    bool mNeedsUpdatedBoundingBox = false;
+    bool mNeedsUpdatedBoundingBox = true;
 };
 
 
@@ -116,7 +117,7 @@ class GUI_EXPORT QgsAnnotationItemRubberBand : public QgsRubberBand
  * \note Not available in Python bindings
  * \since QGIS 4.0
  */
-class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizing
+class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsAnnotationMapTool
 {
     Q_OBJECT
 
@@ -125,7 +126,6 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizin
      * Constructor for QgsMapToolSelectAnnotation
      */
     explicit QgsMapToolSelectAnnotation( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
-
     ~QgsMapToolSelectAnnotation() override;
 
     void activate() override;
@@ -166,9 +166,6 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizin
     void onCanvasRefreshed();
 
   private:
-    const QgsRenderedAnnotationItemDetails *findClosestItemToPoint( const QgsPointXY &mapPoint, const QList<const QgsRenderedAnnotationItemDetails *> &items, QgsRectangle &bounds );
-    QgsAnnotationLayer *annotationLayerFromId( const QString &layerId );
-    QgsAnnotationItem *annotationItemFromId( const QString &layerId, const QString &itemId );
     qsizetype annotationItemRubberBandIndexFromId( const QString &layerId, const QString &itemId );
 
     void setSelectedItemFromPoint( const QgsPointXY &mapPoint, bool toggleSelection = false );

--- a/src/gui/annotations/qgsmaptoolselectannotation.h
+++ b/src/gui/annotations/qgsmaptoolselectannotation.h
@@ -33,10 +33,15 @@ class QgsAnnotationItem;
 class QgsAnnotationLayer;
 class QgsAnnotationItemNodesSpatialIndex;
 class QgsMapToolSelectAnnotationMouseHandles;
-class QgsSnapIndicator;
 
 #define SIP_NO_FILE
 
+/**
+ * \ingroup gui
+ * \brief An annotation item rubberband used by QgsMapToolSelectAnnotation to represent selected items.
+ * \note Not available in Python bindings
+ * \since QGIS 4.0
+ */
 class GUI_EXPORT QgsAnnotationItemRubberBand : public QgsRubberBand
 {
     Q_OBJECT
@@ -46,22 +51,56 @@ class GUI_EXPORT QgsAnnotationItemRubberBand : public QgsRubberBand
      * Constructor for QgsAnnotationItemRubberBand
      */
     explicit QgsAnnotationItemRubberBand( const QString &layerId, const QString &itemId, QgsMapCanvas *canvas );
-    ~QgsAnnotationItemRubberBand() override;
+    ~QgsAnnotationItemRubberBand() override = default;
 
+    /**
+     * Returns the annotation layer ID.
+     */
     QString layerId() const { return mLayerId; }
+
+    /**
+     * Returns a pointer to the annotation layer.
+     */
     QgsAnnotationLayer *layer() const;
 
+    /**
+     * Returns the annotation item ID.
+     */
     QString itemId() const { return mItemId; }
+
+    /**
+     * Returns a pointer to the annotation item.
+     */
     QgsAnnotationItem *item() const;
 
+    /**
+     * Update the rubberband using the provided annotation item bounding box.
+     */
     void updateBoundingBox( const QgsRectangle &boundingBox );
+
+    /**
+     * Returns TRUE if the bounding box requires updating on fresh annotation item rendering.
+     */
     bool needsUpdatedBoundingBox() const { return mNeedsUpdatedBoundingBox; }
 
+    /**
+     * Attempts to move the annotation item.
+     * \param deltaX the X-axis movement in pixel value
+     * \param deltaY the Y-axis movement in pixel value
+     */
     void attemptMoveBy( double deltaX, double deltaY );
-    void attemptRotateBy( double deltaDegree );
-    void attemptSetSceneRect( const QRectF &rect );
 
-    bool operator==( const QgsAnnotationItemRubberBand &other ) const;
+    /**
+     * Attempts to rotate the annotation item.
+     * \param deltaDegree the rotation value in degree 
+     */
+    void attemptRotateBy( double deltaDegree );
+
+    /**
+     * Attempts to move and resize the annotation item.
+     * \param rect the rectangular area (in scene units) within which the annotation item will fit in
+     */
+    void attemptSetSceneRect( const QRectF &rect );
 
   private:
     QString mLayerId;
@@ -69,6 +108,7 @@ class GUI_EXPORT QgsAnnotationItemRubberBand : public QgsRubberBand
     QgsRectangle mBoundingBox;
     bool mNeedsUpdatedBoundingBox = false;
 };
+
 
 /**
  * \ingroup gui
@@ -95,6 +135,9 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizin
     void cadCanvasReleaseEvent( QgsMapMouseEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
 
+    /**
+     * Returns the current list of selected annotation item rubberband items.
+     */
     QList<QgsAnnotationItemRubberBand *> selectedItems() const;
 
   signals:

--- a/src/gui/annotations/qgsmaptoolselectannotation.h
+++ b/src/gui/annotations/qgsmaptoolselectannotation.h
@@ -75,6 +75,11 @@ class GUI_EXPORT QgsAnnotationItemRubberBand : public QgsRubberBand
     QgsAnnotationItem *item() const;
 
     /**
+     * Returns the item bounding box.
+     */
+    QgsRectangle boundingBox() const { return mBoundingBox; }
+
+    /**
      * Update the rubberband using the provided annotation item bounding box.
      */
     void updateBoundingBox( const QgsRectangle &boundingBox );
@@ -85,23 +90,9 @@ class GUI_EXPORT QgsAnnotationItemRubberBand : public QgsRubberBand
     bool needsUpdatedBoundingBox() const { return mNeedsUpdatedBoundingBox; }
 
     /**
-     * Attempts to move the annotation item.
-     * \param deltaX the X-axis movement in pixel value
-     * \param deltaY the Y-axis movement in pixel value
+     * Sets whether the bounding box requires  updating on fresh annotation item rendering.
      */
-    void attemptMoveBy( double deltaX, double deltaY );
-
-    /**
-     * Attempts to rotate the annotation item.
-     * \param deltaDegree the rotation value in degree
-     */
-    void attemptRotateBy( double deltaDegree );
-
-    /**
-     * Attempts to move and resize the annotation item.
-     * \param rect the rectangular area (in scene units) within which the annotation item will fit in
-     */
-    void attemptSetSceneRect( const QRectF &rect );
+    void setNeedsUpdatedBoundingBox( bool needsUpdatedBoundingBox );
 
   private:
     QString mLayerId;
@@ -139,6 +130,28 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsAnnotationMapTool
      * Returns the current list of selected annotation item rubberband items.
      */
     QList<QgsAnnotationItemRubberBand *> selectedItems() const;
+
+    /**
+     * Attempts to move an annotation item.
+     * \param annotationItemRubberBand the annotation item rubber band
+     * \param deltaX the X-axis movement in pixel value
+     * \param deltaY the Y-axis movement in pixel value
+     */
+    void attemptMoveBy( QgsAnnotationItemRubberBand *annotationItemRubberBand, double deltaX, double deltaY );
+
+    /**
+     * Attempts to rotate am annotation item.
+     * \param annotationItemRubberBand the annotation item rubber band
+     * \param deltaDegree the rotation value in degree
+     */
+    void attemptRotateBy( QgsAnnotationItemRubberBand *annotationItemRubberBand, double deltaDegree );
+
+    /**
+     * Attempts to move and resize an annotation item.
+     * \param annotationItemRubberBand the annotation item rubber band
+     * \param rect the rectangular area (in scene units) within which the annotation item will fit in
+     */
+    void attemptSetSceneRect( QgsAnnotationItemRubberBand *annotationItemRubberBand, const QRectF &rect );
 
   signals:
 

--- a/src/gui/annotations/qgsmaptoolselectannotation.h
+++ b/src/gui/annotations/qgsmaptoolselectannotation.h
@@ -95,7 +95,7 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizin
     void cadCanvasReleaseEvent( QgsMapMouseEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
 
-    QList<QgsAnnotationItemRubberBand *> selectedItems() const { return mSelectedItems; };
+    QList<QgsAnnotationItemRubberBand *> selectedItems() const;
 
   signals:
 
@@ -126,14 +126,14 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizin
     const QgsRenderedAnnotationItemDetails *findClosestItemToPoint( const QgsPointXY &mapPoint, const QList<const QgsRenderedAnnotationItemDetails *> &items, QgsRectangle &bounds );
     QgsAnnotationLayer *annotationLayerFromId( const QString &layerId );
     QgsAnnotationItem *annotationItemFromId( const QString &layerId, const QString &itemId );
-    QgsAnnotationItemRubberBand *annotationItemRubberBandFromId( const QString &layerId, const QString &itemId );
+    qsizetype annotationItemRubberBandIndexFromId( const QString &layerId, const QString &itemId );
 
     void setSelectedItemFromPoint( const QgsPointXY &mapPoint, bool toggleSelection = false );
     void setSelectedItemsFromRect( const QgsRectangle &mapRect, bool toggleSelection = false );
     void clearSelectedItems();
     void updateSelectedItem();
 
-    QList<QgsAnnotationItemRubberBand *> mSelectedItems;
+    std::vector<std::unique_ptr<QgsAnnotationItemRubberBand>> mSelectedItems;
     QList<QPair<QString, QString>> mCopiedItems;
     QgsPointXY mCopiedItemsTopLeft;
 

--- a/src/gui/annotations/qgsmaptoolselectannotation.h
+++ b/src/gui/annotations/qgsmaptoolselectannotation.h
@@ -100,9 +100,19 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizin
   signals:
 
     /**
-     * Emitted when the selected item has changed;
+     * Emitted when the selected item has changed.
      */
-    void selectionChanged();
+    void selectedItemsChanged();
+
+    /**
+     * Emitted when the selected item is changed.
+     */
+    void itemSelected( QgsAnnotationLayer *layer, const QString &itemId );
+
+    /**
+     * Emitted when the selected item is cleared.
+     */
+    void selectionCleared();
 
   private slots:
     void onCanvasRefreshed();
@@ -116,6 +126,7 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizin
     void setSelectedItemFromPoint( const QgsPointXY &mapPoint, bool toggleSelection = false );
     void setSelectedItemsFromRect( const QgsRectangle &mapRect, bool toggleSelection = false );
     void clearSelectedItems();
+    void updateSelectedItem();
 
     QList<QgsAnnotationItemRubberBand *> mSelectedItems;
 

--- a/src/gui/annotations/qgsmaptoolselectannotation.h
+++ b/src/gui/annotations/qgsmaptoolselectannotation.h
@@ -134,6 +134,8 @@ class GUI_EXPORT QgsMapToolSelectAnnotation : public QgsMapToolAdvancedDigitizin
     void updateSelectedItem();
 
     QList<QgsAnnotationItemRubberBand *> mSelectedItems;
+    QList<QPair<QString, QString>> mCopiedItems;
+    QgsPointXY mCopiedItemsTopLeft;
 
     bool mRefreshSelectedItemAfterRedraw = false;
 

--- a/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
@@ -36,7 +36,7 @@ QgsMapToolSelectAnnotationMouseHandles::QgsMapToolSelectAnnotationMouseHandles( 
 {
   setZValue( 100 );
 
-  connect( mMapTool, &QgsMapToolSelectAnnotation::selectionChanged, this, &QgsMapToolSelectAnnotationMouseHandles::selectionChanged );
+  connect( mMapTool, &QgsMapToolSelectAnnotation::selectedItemsChanged, this, &QgsMapToolSelectAnnotationMouseHandles::selectionChanged );
   connect( mCanvas, &QgsMapCanvas::extentsChanged, this, [this] { updateHandles(); } );
   mCanvas->scene()->addItem( this );
 

--- a/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
@@ -16,16 +16,19 @@
  ***************************************************************************/
 
 #include "qgsmaptoolselectannotationmousehandles.h"
-#include "moc_qgsmaptoolselectannotationmousehandles.cpp"
+
+#include <limits>
+
 #include "qgis.h"
 #include "qgsgui.h"
 #include "qgsmaptoolselectannotation.h"
 
-#include <QGraphicsView>
 #include <QGraphicsSceneHoverEvent>
+#include <QGraphicsView>
 #include <QPainter>
 #include <QWidget>
-#include <limits>
+
+#include "moc_qgsmaptoolselectannotationmousehandles.cpp"
 
 ///@cond PRIVATE
 

--- a/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
@@ -20,6 +20,10 @@
 #include <limits>
 
 #include "qgis.h"
+#include "qgsannotationitem.h"
+#include "qgsannotationitemeditoperation.h"
+#include "qgsannotationitemnode.h"
+#include "qgsannotationlayer.h"
 #include "qgsgui.h"
 #include "qgsmaptoolselectannotation.h"
 
@@ -96,19 +100,21 @@ QRectF QgsMapToolSelectAnnotationMouseHandles::itemRect( QGraphicsItem *item ) c
 
 void QgsMapToolSelectAnnotationMouseHandles::moveItem( QGraphicsItem *item, double deltaX, double deltaY )
 {
-  qgis::down_cast<QgsAnnotationItemRubberBand *>( item )->attemptMoveBy( deltaX, deltaY );
+  QgsAnnotationItemRubberBand *annotationRubberBandItem = qgis::down_cast<QgsAnnotationItemRubberBand *>( item );
+  mMapTool->attemptMoveBy( annotationRubberBandItem, deltaX, deltaY );
 }
 
 void QgsMapToolSelectAnnotationMouseHandles::rotateItem( QGraphicsItem *item, double deltaDegree, double deltaCenterX, double deltaCenterY )
 {
-  QgsAnnotationItemRubberBand *annotationItem = qgis::down_cast<QgsAnnotationItemRubberBand *>( item );
-  annotationItem->attemptMoveBy( deltaCenterX, deltaCenterY );
-  annotationItem->attemptRotateBy( deltaDegree );
+  QgsAnnotationItemRubberBand *annotationRubberBandItem = qgis::down_cast<QgsAnnotationItemRubberBand *>( item );
+  mMapTool->attemptMoveBy( annotationRubberBandItem, deltaCenterX, deltaCenterY );
+  mMapTool->attemptRotateBy( annotationRubberBandItem, deltaDegree );
 }
 
 void QgsMapToolSelectAnnotationMouseHandles::setItemRect( QGraphicsItem *item, QRectF rect )
 {
-  qgis::down_cast<QgsAnnotationItemRubberBand *>( item )->attemptSetSceneRect( rect );
+  QgsAnnotationItemRubberBand *annotationRubberBandItem = qgis::down_cast<QgsAnnotationItemRubberBand *>( item );
+  mMapTool->attemptSetSceneRect( annotationRubberBandItem, rect );
 }
 
 ///@endcond PRIVATE

--- a/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
@@ -65,7 +65,7 @@ QList<QGraphicsItem *> QgsMapToolSelectAnnotationMouseHandles::sceneItemsAtPoint
 {
   QList<QGraphicsItem *> graphicsItems;
   const QList<QgsAnnotationItemRubberBand *> items = mMapTool->selectedItems();
-  for ( QgsAnnotationItemRubberBand *item : items )
+  for ( auto item : items )
   {
     if ( item->sceneBoundingRect().contains( scenePoint ) )
     {
@@ -79,7 +79,7 @@ QList<QGraphicsItem *> QgsMapToolSelectAnnotationMouseHandles::selectedSceneItem
 {
   QList<QGraphicsItem *> graphicsItems;
   const QList<QgsAnnotationItemRubberBand *> items = mMapTool->selectedItems();
-  for ( QgsAnnotationItemRubberBand *item : items )
+  for ( auto item : items )
   {
     graphicsItems << item;
   }

--- a/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
@@ -1,0 +1,111 @@
+/***************************************************************************
+                    qgsmaptoolselectannotationmousehandles.cpp
+                             -----------------------
+    begin                : November 2025
+    copyright            : (C) 2025 by Mathieu Pellrin
+    email                : mathieu at opengis dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaptoolselectannotationmousehandles.h"
+#include "moc_qgsmaptoolselectannotationmousehandles.cpp"
+#include "qgis.h"
+#include "qgsgui.h"
+#include "qgsmaptoolselectannotation.h"
+
+#include <QGraphicsView>
+#include <QGraphicsSceneHoverEvent>
+#include <QPainter>
+#include <QWidget>
+#include <limits>
+
+///@cond PRIVATE
+
+QgsMapToolSelectAnnotationMouseHandles::QgsMapToolSelectAnnotationMouseHandles( QgsMapToolSelectAnnotation *mapTool, QgsMapCanvas *canvas )
+  : QgsGraphicsViewMouseHandles( canvas )
+  , mMapTool( mapTool )
+  , mCanvas( canvas )
+{
+  setZValue( 100 );
+
+  connect( mMapTool, &QgsMapToolSelectAnnotation::selectionChanged, this, &QgsMapToolSelectAnnotationMouseHandles::selectionChanged );
+  connect( mCanvas, &QgsMapCanvas::extentsChanged, this, [this] { updateHandles(); } );
+  mCanvas->scene()->addItem( this );
+
+  setRotationEnabled( true );
+}
+
+void QgsMapToolSelectAnnotationMouseHandles::paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget )
+{
+  paintInternal( painter, true, true, true, option, widget );
+}
+
+void QgsMapToolSelectAnnotationMouseHandles::selectionChanged()
+{
+  updateHandles();
+}
+
+void QgsMapToolSelectAnnotationMouseHandles::setViewportCursor( Qt::CursorShape cursor )
+{
+  if ( qobject_cast<QgsMapToolSelectAnnotation *>( mCanvas->mapTool() ) )
+  {
+    mCanvas->viewport()->setCursor( cursor );
+  }
+}
+
+QList<QGraphicsItem *> QgsMapToolSelectAnnotationMouseHandles::sceneItemsAtPoint( QPointF scenePoint )
+{
+  QList<QGraphicsItem *> graphicsItems;
+  const QList<QgsAnnotationItemRubberBand *> items = mMapTool->selectedItems();
+  for ( QgsAnnotationItemRubberBand *item : items )
+  {
+    if ( item->sceneBoundingRect().contains( scenePoint ) )
+    {
+      graphicsItems << item;
+    }
+  }
+  return graphicsItems;
+}
+
+QList<QGraphicsItem *> QgsMapToolSelectAnnotationMouseHandles::selectedSceneItems( bool ) const
+{
+  QList<QGraphicsItem *> graphicsItems;
+  const QList<QgsAnnotationItemRubberBand *> items = mMapTool->selectedItems();
+  for ( QgsAnnotationItemRubberBand *item : items )
+  {
+    graphicsItems << item;
+  }
+  return graphicsItems;
+}
+
+QRectF QgsMapToolSelectAnnotationMouseHandles::itemRect( QGraphicsItem *item ) const
+{
+  return item->boundingRect();
+}
+
+void QgsMapToolSelectAnnotationMouseHandles::moveItem( QGraphicsItem *item, double deltaX, double deltaY )
+{
+  qgis::down_cast<QgsAnnotationItemRubberBand *>( item )->attemptMoveBy( deltaX, deltaY );
+}
+
+void QgsMapToolSelectAnnotationMouseHandles::rotateItem( QGraphicsItem *item, double deltaDegree, double deltaCenterX, double deltaCenterY )
+{
+  QgsAnnotationItemRubberBand *annotationItem = qgis::down_cast<QgsAnnotationItemRubberBand *>( item );
+  annotationItem->attemptMoveBy( deltaCenterX, deltaCenterY );
+  annotationItem->attemptRotateBy( deltaDegree );
+}
+
+void QgsMapToolSelectAnnotationMouseHandles::setItemRect( QGraphicsItem *item, QRectF rect )
+{
+  qgis::down_cast<QgsAnnotationItemRubberBand *>( item )->attemptSetSceneRect( rect );
+}
+
+///@endcond PRIVATE

--- a/src/gui/annotations/qgsmaptoolselectannotationmousehandles.h
+++ b/src/gui/annotations/qgsmaptoolselectannotationmousehandles.h
@@ -20,14 +20,14 @@
 // We don't want to expose this in the public API
 #define SIP_NO_FILE
 
-#include "qgsmaptoolselectannotation.h"
-#include "qgsgraphicsviewmousehandles.h"
-#include "qgsmapcanvas.h"
-
-#include <QPointer>
 #include <memory>
 
 #include "qgis_gui.h"
+#include "qgsgraphicsviewmousehandles.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaptoolselectannotation.h"
+
+#include <QPointer>
 
 class QGraphicsView;
 class QInputEvent;

--- a/src/gui/annotations/qgsmaptoolselectannotationmousehandles.h
+++ b/src/gui/annotations/qgsmaptoolselectannotationmousehandles.h
@@ -1,0 +1,75 @@
+/***************************************************************************
+                    qgsmaptoolselectannotationmousehandles.h
+                             -----------------------
+    begin                : November 2025
+    copyright            : (C) 2025 by Mathieu Pellrin
+    email                : mathieu at opengis dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSMAPTOOLSELECTANNOTATIONMOUSEHANDLES_H
+#define QGSMAPTOOLSELECTANNOTATIONMOUSEHANDLES_H
+
+// We don't want to expose this in the public API
+#define SIP_NO_FILE
+
+#include "qgsmaptoolselectannotation.h"
+#include "qgsgraphicsviewmousehandles.h"
+#include "qgsmapcanvas.h"
+
+#include <QPointer>
+#include <memory>
+
+#include "qgis_gui.h"
+
+class QGraphicsView;
+class QInputEvent;
+class QgsMapToolSelectAnnotation;
+
+///@cond PRIVATE
+
+/**
+ * \ingroup gui
+ * \brief Handles drawing of selection outlines and mouse handles for annotations in a QgsMapCanvas
+ *
+ * Also is responsible for mouse interactions such as resizing and moving selected annotation items.
+ *
+ * \note not available in Python bindings
+ * \since QGIS 4.0
+ */
+class GUI_EXPORT QgsMapToolSelectAnnotationMouseHandles : public QgsGraphicsViewMouseHandles
+{
+    Q_OBJECT
+  public:
+    QgsMapToolSelectAnnotationMouseHandles( QgsMapToolSelectAnnotation *mapTool, QgsMapCanvas *canvas );
+
+    void paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr ) override;
+
+  protected:
+    void setViewportCursor( Qt::CursorShape cursor ) override;
+    QList<QGraphicsItem *> sceneItemsAtPoint( QPointF scenePoint ) override;
+    QList<QGraphicsItem *> selectedSceneItems( bool includeLockedItems = true ) const override;
+    QRectF itemRect( QGraphicsItem *item ) const override;
+    void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) override;
+    void rotateItem( QGraphicsItem *item, double deltaDegree, double deltaCenterX, double deltaCenterY ) override;
+    void setItemRect( QGraphicsItem *item, QRectF rect ) override;
+
+  public slots:
+
+    void selectionChanged();
+
+  private:
+    QPointer<QgsMapToolSelectAnnotation> mMapTool;
+    QPointer<QgsMapCanvas> mCanvas;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSMAPTOOLSELECTANNOTATIONMOUSEHANDLES_H

--- a/src/gui/codeeditors/qgscodeeditorcolorschemeregistry.cpp
+++ b/src/gui/codeeditors/qgscodeeditorcolorschemeregistry.cpp
@@ -16,6 +16,8 @@
 
 #include <QObject>
 
+using namespace Qt::StringLiterals;
+
 QgsCodeEditorColorSchemeRegistry::QgsCodeEditorColorSchemeRegistry()
 {
   QgsCodeEditorColorScheme defaultScheme( u"default"_s, QObject::tr( "Default" ) );

--- a/src/gui/maptools/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/maptools/qgsmaptooladvanceddigitizing.h
@@ -20,10 +20,10 @@
 #include <memory>
 
 #include "qgis_gui.h"
+#include "qgsmapmouseevent.h"
 #include "qgsmaptooledit.h"
 #include "qgsreferencedgeometry.h"
 
-class QgsMapMouseEvent;
 class QgsAdvancedDigitizingDockWidget;
 class QgsSnapToGridCanvasItem;
 class QgsSnapIndicator;

--- a/src/gui/qgsexpressionhighlighter.cpp
+++ b/src/gui/qgsexpressionhighlighter.cpp
@@ -17,6 +17,8 @@
 
 #include "moc_qgsexpressionhighlighter.cpp"
 
+using namespace Qt::StringLiterals;
+
 QgsExpressionHighlighter::QgsExpressionHighlighter( QTextDocument *parent )
   : QSyntaxHighlighter( parent )
 {

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -562,7 +562,7 @@ Qgis::MouseHandlesAction QgsGraphicsViewMouseHandles::mouseActionForScenePos( QP
 
 bool QgsGraphicsViewMouseHandles::shouldBlockEvent( QInputEvent * ) const
 {
-  return mIsDragging || mIsResizing;
+  return mIsDragging || mIsResizing || mIsRotating;
 }
 
 void QgsGraphicsViewMouseHandles::startMove( QPointF sceneCoordPos )
@@ -730,7 +730,10 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
 
   // Mouse may have been grabbed from the QgsLayoutViewSelectTool, so we need to release it explicitly
   // otherwise, hover events will not be received
-  ungrabMouse();
+  if ( mView->scene()->mouseGrabberItem() == this )
+  {
+    ungrabMouse();
+  }
 
   QPointF mouseMoveStopPoint = event->lastScenePos();
   double diffX = mouseMoveStopPoint.x() - mMouseMoveStartPos.x();
@@ -921,6 +924,7 @@ void QgsGraphicsViewMouseHandles::updateHandles()
     //no items selected, hide handles
     hide();
   }
+
   //force redraw
   update();
 }

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -572,7 +572,6 @@ void QgsGraphicsViewMouseHandles::startMove( QPointF sceneCoordPos )
   //save current item geometry
   mBeginMouseEventPos = sceneCoordPos;
   mBeginHandlePos = scenePos();
-  qDebug() << "startMove --- " << mBeginHandlePos;
   mBeginHandleWidth = rect().width();
   mBeginHandleHeight = rect().height();
   mCurrentMouseMoveAction = Qgis::MouseHandlesAction::MoveItem;
@@ -628,7 +627,6 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
   //save current item geometry
   mBeginMouseEventPos = event->lastScenePos();
   mBeginHandlePos = scenePos();
-  qDebug() << "mousePressEvent --- " << mBeginHandlePos;
   mBeginHandleWidth = rect().width();
   mBeginHandleHeight = rect().height();
   //type of mouse move action
@@ -695,7 +693,6 @@ void QgsGraphicsViewMouseHandles::mouseMoveEvent( QGraphicsSceneMouseEvent *even
 {
   if ( isDragging() )
   {
-    qDebug() << "mouseMoveEvent -> isDragging()";
     //currently dragging a selection
     //if shift depressed, constrain movement to horizontal/vertical
     //if control depressed, ignore snapping
@@ -760,9 +757,6 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
 
     QPointF mEndHandleMovePos = scenePos();
 
-    qDebug() << "---";
-    qDebug() << mBeginHandlePos;
-    qDebug() << mEndHandleMovePos;
     double deltaX = mEndHandleMovePos.x() - mBeginHandlePos.x();
     double deltaY = mEndHandleMovePos.y() - mBeginHandlePos.y();
 
@@ -967,7 +961,6 @@ void QgsGraphicsViewMouseHandles::rotateMouseMove( QPointF currentPosition, bool
 
 void QgsGraphicsViewMouseHandles::dragMouseMove( QPointF currentPosition, bool lockMovement, bool preventSnap )
 {
-  qDebug() << "dragMouseMove";
   if ( !scene() )
   {
     return;
@@ -976,7 +969,6 @@ void QgsGraphicsViewMouseHandles::dragMouseMove( QPointF currentPosition, bool l
   //calculate total amount of mouse movement since drag began
   double moveX = currentPosition.x() - mBeginMouseEventPos.x();
   double moveY = currentPosition.y() - mBeginMouseEventPos.y();
-  qDebug() << "in!" << moveX << moveY;
 
   //find target position before snapping (in scene coordinates)
   QPointF upperLeftPoint( mBeginHandlePos.x() + moveX, mBeginHandlePos.y() + moveY );

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -572,6 +572,7 @@ void QgsGraphicsViewMouseHandles::startMove( QPointF sceneCoordPos )
   //save current item geometry
   mBeginMouseEventPos = sceneCoordPos;
   mBeginHandlePos = scenePos();
+  qDebug() << "startMove --- " << mBeginHandlePos;
   mBeginHandleWidth = rect().width();
   mBeginHandleHeight = rect().height();
   mCurrentMouseMoveAction = Qgis::MouseHandlesAction::MoveItem;
@@ -627,6 +628,7 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
   //save current item geometry
   mBeginMouseEventPos = event->lastScenePos();
   mBeginHandlePos = scenePos();
+  qDebug() << "mousePressEvent --- " << mBeginHandlePos;
   mBeginHandleWidth = rect().width();
   mBeginHandleHeight = rect().height();
   //type of mouse move action
@@ -693,6 +695,7 @@ void QgsGraphicsViewMouseHandles::mouseMoveEvent( QGraphicsSceneMouseEvent *even
 {
   if ( isDragging() )
   {
+    qDebug() << "mouseMoveEvent -> isDragging()";
     //currently dragging a selection
     //if shift depressed, constrain movement to horizontal/vertical
     //if control depressed, ignore snapping
@@ -757,6 +760,9 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
 
     QPointF mEndHandleMovePos = scenePos();
 
+    qDebug() << "---";
+    qDebug() << mBeginHandlePos;
+    qDebug() << mEndHandleMovePos;
     double deltaX = mEndHandleMovePos.x() - mBeginHandlePos.x();
     double deltaY = mEndHandleMovePos.y() - mBeginHandlePos.y();
 
@@ -961,6 +967,7 @@ void QgsGraphicsViewMouseHandles::rotateMouseMove( QPointF currentPosition, bool
 
 void QgsGraphicsViewMouseHandles::dragMouseMove( QPointF currentPosition, bool lockMovement, bool preventSnap )
 {
+  qDebug() << "dragMouseMove";
   if ( !scene() )
   {
     return;
@@ -969,6 +976,7 @@ void QgsGraphicsViewMouseHandles::dragMouseMove( QPointF currentPosition, bool l
   //calculate total amount of mouse movement since drag began
   double moveX = currentPosition.x() - mBeginMouseEventPos.x();
   double moveY = currentPosition.y() - mBeginMouseEventPos.y();
+  qDebug() << "in!" << moveX << moveY;
 
   //find target position before snapping (in scene coordinates)
   QPointF upperLeftPoint( mBeginHandlePos.x() + moveX, mBeginHandlePos.y() + moveY );

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -281,6 +281,8 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
 
     //! Finds out the appropriate cursor for the current mouse position in the widget (e.g. move in the middle, resize at border)
     Qt::CursorShape cursorForPosition( QPointF itemCoordPos );
+
+    friend class QgsMapToolSelectAnnotation;
 };
 
 ///@endcond PRIVATE

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -140,6 +140,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
   setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
   setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
   setMouseTracking( true );
+  viewport()->setMouseTracking( true );
   setFocusPolicy( Qt::StrongFocus );
 
   mScreenHelper = new QgsScreenHelper( this );
@@ -2553,6 +2554,7 @@ void QgsMapCanvas::mousePressEvent( QMouseEvent *e )
       {
         auto me = std::make_unique<QgsMapMouseEvent>( this, e );
         mMapTool->canvasPressEvent( me.get() );
+        QGraphicsView::mousePressEvent( e );
       }
     }
   }
@@ -2602,6 +2604,7 @@ void QgsMapCanvas::mouseReleaseEvent( QMouseEvent *e )
     {
       auto me = std::make_unique<QgsMapMouseEvent>( this, e );
       mMapTool->canvasReleaseEvent( me.get() );
+      QGraphicsView::mouseReleaseEvent( e );
     }
   }
 
@@ -2781,6 +2784,7 @@ void QgsMapCanvas::mouseMoveEvent( QMouseEvent *e )
     {
       auto me = std::make_unique<QgsMapMouseEvent>( this, e );
       mMapTool->canvasMoveEvent( me.get() );
+      QGraphicsView::mouseMoveEvent( e );
     }
   }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -140,7 +140,6 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
   setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
   setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
   setMouseTracking( true );
-  viewport()->setMouseTracking( true );
   setFocusPolicy( Qt::StrongFocus );
 
   mScreenHelper = new QgsScreenHelper( this );
@@ -2554,7 +2553,6 @@ void QgsMapCanvas::mousePressEvent( QMouseEvent *e )
       {
         auto me = std::make_unique<QgsMapMouseEvent>( this, e );
         mMapTool->canvasPressEvent( me.get() );
-        QGraphicsView::mousePressEvent( e );
       }
     }
   }
@@ -2604,7 +2602,6 @@ void QgsMapCanvas::mouseReleaseEvent( QMouseEvent *e )
     {
       auto me = std::make_unique<QgsMapMouseEvent>( this, e );
       mMapTool->canvasReleaseEvent( me.get() );
-      QGraphicsView::mouseReleaseEvent( e );
     }
   }
 
@@ -2784,7 +2781,6 @@ void QgsMapCanvas::mouseMoveEvent( QMouseEvent *e )
     {
       auto me = std::make_unique<QgsMapMouseEvent>( this, e );
       mMapTool->canvasMoveEvent( me.get() );
-      QGraphicsView::mouseMoveEvent( e );
     }
   }
 

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -807,6 +807,7 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
+   <addaction name="mActionSelectAnnotation"/>
    <addaction name="mActionModifyAnnotation"/>
   </widget>
   <action name="mActionNewProject">
@@ -3308,13 +3309,28 @@ Shows placeholders for labels which could not be placed, e.g. due to overlaps wi
     <string>New Annotation Layer</string>
    </property>
   </action>
-  <action name="mActionModifyAnnotation">
+  <action name="mActionSelectAnnotation">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="icon">
     <iconset resource="../../images/images.qrc">
      <normaloff>:/images/themes/default/mActionSelect.svg</normaloff>:/images/themes/default/mActionSelect.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Select Annotations</string>
+   </property>
+   <property name="toolTip">
+    <string>Select Annotations</string>
+   </property>
+  </action>
+  <action name="mActionModifyAnnotation">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditNodesItem.svg</normaloff>:/images/themes/default/mActionEditNodesItem.svg</iconset>
    </property>
    <property name="text">
     <string>Modify Annotations</string>

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -33,6 +33,7 @@ set(TESTS
   testqgsmaptoolselect.cpp
   testqgsmaptoolreshape.cpp
   testqgsmaptoolrotatefeature.cpp
+  testqgsmaptoolselectannotation.cpp
   testqgsmaptoolscalefeature.cpp
   testqgsmaptoolcircularstring.cpp
   testqgsmaptooleditmesh.cpp

--- a/tests/src/app/testqgsmaptoolselectannotation.cpp
+++ b/tests/src/app/testqgsmaptoolselectannotation.cpp
@@ -1,0 +1,317 @@
+/***************************************************************************
+    testqgsmaptoolselectannotation.cpp
+     --------------------------------------
+    Date                 : December 2025
+    Copyright            : (C) 2025 by Mathieu Pellerin
+    Email                : mathieu at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsadvanceddigitizingdockwidget.h"
+#include "qgsannotationlayer.h"
+#include "qgsannotationpolygonitem.h"
+#include "qgsapplication.h"
+#include "qgsguiutils.h"
+#include "qgslinestring.h"
+#include "qgslogger.h"
+#include "qgsmapcanvas.h"
+#include "qgsmapmouseevent.h"
+#include "qgsmaptooladvanceddigitizing.h"
+#include "qgsmaptoolselectannotation.h"
+#include "qgspolygon.h"
+#include "qgsproject.h"
+#include "qgsrendereditemresults.h"
+#include "qgstest.h"
+#include "testqgsmaptoolutils.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+
+class TestQgsMapToolSelectAnnotation : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsMapToolSelectAnnotation() = default;
+
+  private slots:
+    void initTestCase();    // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init();            // will be called before each testfunction is executed.
+    void cleanup();         // will be called after every testfunction.
+
+    void testSelectItem();
+    void testDeleteItem();
+    void testMoveItem();
+};
+
+void TestQgsMapToolSelectAnnotation::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsApplication::showSettings();
+}
+
+void TestQgsMapToolSelectAnnotation::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsMapToolSelectAnnotation::init()
+{
+}
+
+void TestQgsMapToolSelectAnnotation::cleanup()
+{
+}
+
+void TestQgsMapToolSelectAnnotation::testSelectItem()
+{
+  QgsProject::instance()->clear();
+  QgsMapCanvas canvas;
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  canvas.setFrameStyle( QFrame::NoFrame );
+  canvas.resize( 600, 600 );
+  canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+  canvas.show(); // to make the canvas resize
+
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QVERIFY( layer->isValid() );
+  QgsAnnotationLayer *layer2 = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QVERIFY( layer2->isValid() );
+  QgsProject::instance()->addMapLayers( { layer, layer2 } );
+
+  QgsAnnotationPolygonItem *item1 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 1 ), QgsPoint( 5, 1 ), QgsPoint( 5, 5 ), QgsPoint( 1, 5 ), QgsPoint( 1, 1 ) } ) ) );
+  item1->setZIndex( 1 );
+  const QString i1id = layer->addItem( item1 );
+
+  QgsAnnotationPolygonItem *item2 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 4 ), QgsPoint( 1.6, 4 ), QgsPoint( 1.6, 4.6 ), QgsPoint( 1, 4.6 ), QgsPoint( 1, 4 ) } ) ) );
+  item2->setZIndex( 0 );
+  const QString i2id = layer->addItem( item2 );
+
+  QgsAnnotationPolygonItem *item3 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 7, 1 ), QgsPoint( 8, 1 ), QgsPoint( 8, 2 ), QgsPoint( 7, 2 ), QgsPoint( 7, 1 ) } ) ) );
+  item3->setZIndex( 3 );
+  const QString i3id = layer2->addItem( item3 );
+
+  layer->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  layer2->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+
+  canvas.setLayers( { layer, layer2 } );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+  QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 3 );
+
+  QgsAdvancedDigitizingDockWidget cadDock( &canvas );
+  QgsMapToolSelectAnnotation tool( &canvas, &cadDock );
+  canvas.setMapTool( &tool );
+
+  QSignalSpy spySingleItemSelected( &tool, &QgsMapToolSelectAnnotation::singleItemSelected );
+  QSignalSpy spySelectedItemsChanged( &tool, &QgsMapToolSelectAnnotation::selectedItemsChanged );
+  TestQgsMapToolUtils utils( &tool );
+
+  // click outside of items
+  utils.mouseMove( 9, 9 );
+  utils.mouseClick( 9, 9, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spySingleItemSelected.count(), 0 );
+  QCOMPARE( spySelectedItemsChanged.count(), 0 );
+
+  // click on items
+  utils.mouseMove( 1.5, 1.5 );
+  utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spySingleItemSelected.count(), 1 );
+  QCOMPARE( spySelectedItemsChanged.count(), 1 );
+  QCOMPARE( spySingleItemSelected.at( 0 ).at( 1 ).toString(), i1id );
+
+  // click outside of items to deselect
+  utils.mouseMove( 9, 9 );
+  utils.mouseClick( 9, 9, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spySingleItemSelected.count(), 1 );
+  QCOMPARE( spySelectedItemsChanged.count(), 2 );
+
+  // overlapping items, smallest area item should be selected
+  utils.mouseMove( 1.5, 4.5 );
+  utils.mouseClick( 1.5, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spySingleItemSelected.count(), 2 );
+  QCOMPARE( spySelectedItemsChanged.count(), 3 );
+  QCOMPARE( spySingleItemSelected.at( 1 ).at( 1 ).toString(), i2id );
+
+  // click on third item
+  utils.mouseMove( 7.5, 1.5 );
+  utils.mouseClick( 7.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spySingleItemSelected.count(), 3 );
+  QCOMPARE( spySelectedItemsChanged.count(), 4 );
+  QCOMPARE( spySingleItemSelected.at( 2 ).at( 1 ).toString(), i3id );
+
+  // click on third item using shift to toggle selection off
+  utils.mouseMove( 7.5, 1.5 );
+  utils.mouseClick( 7.5, 1.5, Qt::LeftButton, Qt::ShiftModifier, true );
+  QCOMPARE( spySingleItemSelected.count(), 3 );
+  QCOMPARE( spySelectedItemsChanged.count(), 5 );
+
+  // click on third item using shift to toggle selection back on
+  utils.mouseMove( 7.5, 1.5 );
+  utils.mouseClick( 7.5, 1.5, Qt::LeftButton, Qt::ShiftModifier, true );
+  QCOMPARE( spySingleItemSelected.count(), 4 );
+  QCOMPARE( spySelectedItemsChanged.count(), 6 );
+
+  // click on no item - should clear selection
+  QSignalSpy spySelectionCleared( &tool, &QgsMapToolSelectAnnotation::selectionCleared );
+  utils.mouseMove( 9.5, 9.5 );
+  utils.mouseClick( 9.5, 9.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spySingleItemSelected.count(), 4 );
+  QCOMPARE( spySelectedItemsChanged.count(), 7 );
+  QCOMPARE( spySelectionCleared.count(), 1 );
+}
+
+void TestQgsMapToolSelectAnnotation::testDeleteItem()
+{
+  QgsProject::instance()->clear();
+  QgsMapCanvas canvas;
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  canvas.setFrameStyle( QFrame::NoFrame );
+  canvas.resize( 600, 600 );
+  canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+  canvas.show(); // to make the canvas resize
+
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QVERIFY( layer->isValid() );
+  QgsProject::instance()->addMapLayers( { layer } );
+
+  QgsAnnotationPolygonItem *item1 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 1 ), QgsPoint( 5, 1 ), QgsPoint( 5, 5 ), QgsPoint( 1, 5 ), QgsPoint( 1, 1 ) } ) ) );
+  item1->setZIndex( 1 );
+  const QString i1id = layer->addItem( item1 );
+
+  QgsAnnotationPolygonItem *item2 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 4 ), QgsPoint( 5, 4 ), QgsPoint( 5, 9 ), QgsPoint( 1, 9 ), QgsPoint( 1, 4 ) } ) ) );
+  item2->setZIndex( 2 );
+  const QString i2id = layer->addItem( item2 );
+
+  QgsAnnotationPolygonItem *item3 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 7, 1 ), QgsPoint( 8, 1 ), QgsPoint( 8, 2 ), QgsPoint( 7, 2 ), QgsPoint( 7, 1 ) } ) ) );
+  item3->setZIndex( 3 );
+  const QString i3id = layer->addItem( item3 );
+
+  layer->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+
+  canvas.setLayers( { layer } );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+  QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 3 );
+
+  QgsAdvancedDigitizingDockWidget cadDock( &canvas );
+  QgsMapToolSelectAnnotation tool( &canvas, &cadDock );
+  canvas.setMapTool( &tool );
+
+  TestQgsMapToolUtils utils( &tool );
+
+  // no selected item
+  utils.mouseMove( 9, 9 );
+  utils.mouseClick( 9, 9, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.keyClick( Qt::Key_Delete );
+  QCOMPARE( qgis::listToSet( layer->items().keys() ), QSet<QString>( { i1id, i2id, i3id } ) );
+
+  // with selected item
+  utils.mouseMove( 1.5, 1.5 );
+  utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.keyClick( Qt::Key_Delete );
+  QCOMPARE( qgis::listToSet( layer->items().keys() ), QSet<QString>( { i2id, i3id } ) );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+
+  utils.mouseMove( 1.5, 4.5 );
+  utils.mouseClick( 1.5, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.keyClick( Qt::Key_Delete );
+  QCOMPARE( qgis::listToSet( layer->items().keys() ), QSet<QString>( { i3id } ) );
+}
+
+void TestQgsMapToolSelectAnnotation::testMoveItem()
+{
+  QgsProject::instance()->clear();
+  QgsMapCanvas canvas;
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  canvas.setFrameStyle( QFrame::NoFrame );
+  canvas.resize( 600, 600 );
+  canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+  canvas.show(); // to make the canvas resize
+
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QVERIFY( layer->isValid() );
+  QgsProject::instance()->addMapLayers( { layer } );
+
+  QgsAnnotationPolygonItem *item1 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 1 ), QgsPoint( 5, 1 ), QgsPoint( 5, 5 ), QgsPoint( 1, 5 ), QgsPoint( 1, 1 ) } ) ) );
+  item1->setZIndex( 1 );
+  const QString i1id = layer->addItem( item1 );
+  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt(), QStringLiteral( "Polygon ((1 1, 5 1, 5 5, 1 5, 1 1))" ) );
+
+  layer->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+
+  canvas.setLayers( { layer } );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+  QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 1 );
+
+  QgsAdvancedDigitizingDockWidget cadDock( &canvas );
+  QgsMapToolSelectAnnotation tool( &canvas, &cadDock );
+  canvas.setMapTool( &tool );
+
+  QSignalSpy spy( &tool, &QgsMapToolSelectAnnotation::singleItemSelected );
+  TestQgsMapToolUtils utils( &tool );
+
+  // click on item
+  utils.mouseMove( 1.5, 1.5 );
+  utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 1 ).toString(), i1id );
+
+  // a mouse press on the item will start moving the item
+  utils.mousePress( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+
+  // move mouse and click to end item move
+  utils.mouseMove( 4.5, 4.5, Qt::LeftButton );
+  utils.mouseMove( 4.5, 4.5, Qt::LeftButton );
+  utils.mouseRelease( 4.5, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+  QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 1 );
+
+  // check that item was moved
+  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt(), QStringLiteral( "Polygon ((4 4, 8 4, 8 8, 4 8, 4 4))" ) );
+
+  // start a new move
+  utils.mouseMove( 4.6, 4.5 );
+  utils.mousePress( 4.6, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseMove( 1.5, 1.5, Qt::LeftButton );
+  utils.mouseMove( 1.5, 1.5, Qt::LeftButton );
+  utils.mouseRelease( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  while ( !canvas.isDrawing() )
+  {
+    QgsApplication::processEvents();
+  }
+  canvas.waitWhileRendering();
+  QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 1 );
+
+  // check that item was moved
+  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt( 1 ), QStringLiteral( "Polygon ((0.9 1, 4.9 1, 4.9 5, 0.9 5, 0.9 1))" ) );
+}
+
+
+QGSTEST_MAIN( TestQgsMapToolSelectAnnotation )
+#include "testqgsmaptoolselectannotation.moc"

--- a/tests/src/app/testqgsmaptoolselectannotation.cpp
+++ b/tests/src/app/testqgsmaptoolselectannotation.cpp
@@ -32,6 +32,9 @@
 
 #include <QCoreApplication>
 #include <QSignalSpy>
+#include <QString>
+
+using namespace Qt::StringLiterals;
 
 class TestQgsMapToolSelectAnnotation : public QObject
 {
@@ -74,15 +77,15 @@ void TestQgsMapToolSelectAnnotation::testSelectItem()
 {
   QgsProject::instance()->clear();
   QgsMapCanvas canvas;
-  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
   canvas.setFrameStyle( QFrame::NoFrame );
   canvas.resize( 600, 600 );
   canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
   canvas.show(); // to make the canvas resize
 
-  QgsAnnotationLayer *layer = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( u"test"_s, QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
   QVERIFY( layer->isValid() );
-  QgsAnnotationLayer *layer2 = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QgsAnnotationLayer *layer2 = new QgsAnnotationLayer( u"test"_s, QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
   QVERIFY( layer2->isValid() );
   QgsProject::instance()->addMapLayers( { layer, layer2 } );
 
@@ -98,8 +101,8 @@ void TestQgsMapToolSelectAnnotation::testSelectItem()
   item3->setZIndex( 3 );
   const QString i3id = layer2->addItem( item3 );
 
-  layer->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
-  layer2->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  layer->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
+  layer2->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
 
   canvas.setLayers( { layer, layer2 } );
   while ( !canvas.isDrawing() )
@@ -175,13 +178,13 @@ void TestQgsMapToolSelectAnnotation::testDeleteItem()
 {
   QgsProject::instance()->clear();
   QgsMapCanvas canvas;
-  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
   canvas.setFrameStyle( QFrame::NoFrame );
   canvas.resize( 600, 600 );
   canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
   canvas.show(); // to make the canvas resize
 
-  QgsAnnotationLayer *layer = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( u"test"_s, QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
   QVERIFY( layer->isValid() );
   QgsProject::instance()->addMapLayers( { layer } );
 
@@ -197,7 +200,7 @@ void TestQgsMapToolSelectAnnotation::testDeleteItem()
   item3->setZIndex( 3 );
   const QString i3id = layer->addItem( item3 );
 
-  layer->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  layer->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
 
   canvas.setLayers( { layer } );
   while ( !canvas.isDrawing() )
@@ -240,22 +243,22 @@ void TestQgsMapToolSelectAnnotation::testMoveItem()
 {
   QgsProject::instance()->clear();
   QgsMapCanvas canvas;
-  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  canvas.setDestinationCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
   canvas.setFrameStyle( QFrame::NoFrame );
   canvas.resize( 600, 600 );
   canvas.setExtent( QgsRectangle( 0, 0, 10, 10 ) );
   canvas.show(); // to make the canvas resize
 
-  QgsAnnotationLayer *layer = new QgsAnnotationLayer( QStringLiteral( "test" ), QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
+  QgsAnnotationLayer *layer = new QgsAnnotationLayer( u"test"_s, QgsAnnotationLayer::LayerOptions( QgsProject::instance()->transformContext() ) );
   QVERIFY( layer->isValid() );
   QgsProject::instance()->addMapLayers( { layer } );
 
   QgsAnnotationPolygonItem *item1 = new QgsAnnotationPolygonItem( new QgsPolygon( new QgsLineString( QVector<QgsPoint> { QgsPoint( 1, 1 ), QgsPoint( 5, 1 ), QgsPoint( 5, 5 ), QgsPoint( 1, 5 ), QgsPoint( 1, 1 ) } ) ) );
   item1->setZIndex( 1 );
   const QString i1id = layer->addItem( item1 );
-  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt(), QStringLiteral( "Polygon ((1 1, 5 1, 5 5, 1 5, 1 1))" ) );
+  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt(), u"Polygon ((1 1, 5 1, 5 5, 1 5, 1 1))"_s );
 
-  layer->setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  layer->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
 
   canvas.setLayers( { layer } );
   while ( !canvas.isDrawing() )
@@ -293,7 +296,7 @@ void TestQgsMapToolSelectAnnotation::testMoveItem()
   QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 1 );
 
   // check that item was moved
-  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt(), QStringLiteral( "Polygon ((4 4, 8 4, 8 8, 4 8, 4 4))" ) );
+  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt(), u"Polygon ((4 4, 8 4, 8 8, 4 8, 4 4))"_s );
 
   // start a new move
   utils.mouseMove( 4.6, 4.5 );
@@ -309,7 +312,7 @@ void TestQgsMapToolSelectAnnotation::testMoveItem()
   QCOMPARE( canvas.renderedItemResults()->renderedItems().size(), 1 );
 
   // check that item was moved
-  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt( 1 ), QStringLiteral( "Polygon ((0.9 1, 4.9 1, 4.9 5, 0.9 5, 0.9 1))" ) );
+  QCOMPARE( qgis::down_cast<QgsAnnotationPolygonItem *>( layer->item( i1id ) )->geometry()->asWkt( 1 ), u"Polygon ((0.9 1, 4.9 1, 4.9 5, 0.9 5, 0.9 1))"_s );
 }
 
 

--- a/tests/src/gui/testqgsmaptoolutils.h
+++ b/tests/src/gui/testqgsmaptoolutils.h
@@ -62,9 +62,9 @@ class TestQgsMapToolAdvancedDigitizingUtils
       return QPoint( std::round( pt.x() ), std::round( pt.y() ) );
     }
 
-    void mouseMove( double mapX, double mapY )
+    void mouseMove( double mapX, double mapY, Qt::MouseButton button = Qt::NoButton )
     {
-      QgsMapMouseEvent e( mMapTool->canvas(), QEvent::MouseMove, mapToScreen( mapX, mapY ) );
+      QgsMapMouseEvent e( mMapTool->canvas(), QEvent::MouseMove, mapToScreen( mapX, mapY ), button, button );
       mMapTool->canvasMoveEvent( &e );
     }
 
@@ -163,9 +163,9 @@ class TestQgsMapToolUtils
       return QPoint( std::round( pt.x() ), std::round( pt.y() ) );
     }
 
-    void mouseMove( double mapX, double mapY )
+    void mouseMove( double mapX, double mapY, Qt::MouseButton button = Qt::NoButton )
     {
-      QgsMapMouseEvent e( mMapTool->canvas(), QEvent::MouseMove, mapToScreen( mapX, mapY ) );
+      QgsMapMouseEvent e( mMapTool->canvas(), QEvent::MouseMove, mapToScreen( mapX, mapY ), button, button );
       mMapTool->canvasMoveEvent( &e );
     }
 


### PR DESCRIPTION
## Description

This PR implements part of [QEP 344: Copy, move and rotate annotation layers](https://github.com/qgis/QGIS-Enhancement-Proposals/pull/344). Video showcase:

https://github.com/user-attachments/assets/44d89614-3210-4449-ac76-33c526cc6051

What's implemented in here:
- selection of annotation item(s), with shift modifier to toggle selection of additional item(s)
- mouse and keyboard movement of selected item(s)
- deletion of selected item(s)
- resizing of selected item(s) using the mouse handlers
- rotation of selected item(s) using the mouse handlers

There's a bit more to do complete the QEP but with over a thousand lines in, I would like for this to be reviewed and merged so smaller follow up PRs can be opened afterwards (e.g. to implement the click-click movement for e.g.).

The new tool feels really nice to use (IMHO of course :wink:)!