### PR TITLE
Fix paste functionality in Python console with Ctrl+V

### DIFF
--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -347,6 +347,7 @@ class ShellScintilla(QgsCodeEditorPython):
         self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord("Z") + ctrl)
         self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord("Y") + ctrl)
         self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord("L") + ctrl + shift)
+        self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord("V") + ctrl)
 
         # New QShortcut = ctrl+space/ctrl+alt+space for Autocomplete
         self.newShortcutCSS = QShortcut(
@@ -389,6 +390,14 @@ class ShellScintilla(QgsCodeEditorPython):
         self.console_widget.callWidgetMessageBar(msgText)
 
     def keyPressEvent(self, e):
+        if (
+            e.modifiers()
+            & (Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.MetaModifier)
+            and e.key() == Qt.Key.Key_V
+        ):
+            self.paste()
+            e.accept()
+            return
 
         if (
             e.modifiers()
@@ -426,9 +435,6 @@ class ShellScintilla(QgsCodeEditorPython):
     def paste(self):
         """
         Method to display data from the clipboard.
-
-        XXX: It should reimplement the virtual QScintilla.paste method,
-        but it seems not used by QScintilla code.
         """
         stringPaste = QApplication.clipboard().text()
         if self.isCursorOnLastLine():


### PR DESCRIPTION
## Description

Deactivates `QScintillas` native paste functionality and adds logic to `keyPressEvent` to use the custom logic previously implemented. 

Closes #64070

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
