### PR TITLE
Add extract_degrees, extract_minutes, extract_seconds functions

### DIFF
--- a/resources/function_help/json/extract_degrees
+++ b/resources/function_help/json/extract_degrees
@@ -1,0 +1,24 @@
+{
+  "name": "extract_degrees",
+  "type": "function",
+  "groups": ["Conversions"],
+  "description": "Extracts the integer number of degrees from a decimal degrees value. The minutes and seconds components are ignored. The extracted degrees values will be truncated towards zero (not rounded).",
+  "arguments": [{
+    "arg": "value",
+    "description": "A decimal degrees value."
+  }],
+  "examples": [{
+    "expression": "extract_degrees(135.334)",
+    "returns": "135"
+  }, {
+    "expression": "extract_degrees(-135.998)",
+    "returns": "135"
+  }, {
+    "expression": "extract_degrees(-135.334)",
+    "returns": "-135"
+  }, {
+    "expression": "extract_degrees(-135.998)",
+    "returns": "-135"
+  }],
+  "tags": ["dms", "degrees", "decimal", "latitude", "longitude", "coordinate"]
+}

--- a/resources/function_help/json/extract_minutes
+++ b/resources/function_help/json/extract_minutes
@@ -1,0 +1,24 @@
+{
+  "name": "extract_minutes",
+  "type": "function",
+  "groups": ["Conversions"],
+  "description": "Extracts the integer number of minutes from a decimal degrees value. The degrees and seconds components are ignored. The extracted minutes values will be truncated towards zero (not rounded), and will always be a positive value.",
+  "arguments": [{
+    "arg": "value",
+    "description": "A decimal degrees value."
+  }],
+  "examples": [{
+    "expression": "extract_minutes(135.75)",
+    "returns": "45"
+  }, {
+    "expression": "extract_minutes(-135.75)",
+    "returns": "45"
+  }, {
+    "expression": "extract_minutes(-135.7568)",
+    "returns": "45"
+  }, {
+    "expression": "extract_minutes(-135.7568)",
+    "returns": "45"
+  }],
+  "tags": ["dms", "degrees", "minutes", "decimal", "latitude", "longitude", "coordinate"]
+}

--- a/resources/function_help/json/extract_seconds
+++ b/resources/function_help/json/extract_seconds
@@ -1,0 +1,18 @@
+{
+  "name": "extract_seconds",
+  "type": "function",
+  "groups": ["Conversions"],
+  "description": "Extracts the decimal number of seconds from a decimal degrees value. The degrees and minutes components are ignored. The extracted seconds value will always be a positive value.",
+  "arguments": [{
+    "arg": "value",
+    "description": "A decimal degrees value."
+  }],
+  "examples": [{
+    "expression": "extract_seconds(135.7568)",
+    "returns": "24.4799"
+  }, {
+    "expression": "extract_seconds(-135.7568)",
+    "returns": "24.4799"
+  }],
+  "tags": ["dms", "degrees", "seconds", "decimal", "latitude", "longitude", "coordinate"]
+}

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2906,6 +2906,29 @@ static QVariant fcnToDegreeMinuteSecond( const QVariantList &values, const QgsEx
   return floatToDegreeFormat( format, values, context, parent, node );
 }
 
+static QVariant fcnExtractDegrees( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const double decimalDegrees = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
+  return static_cast< int >( decimalDegrees );
+}
+
+static QVariant fcnExtractMinutes( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const double absoluteDecimalDegrees = std::abs( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
+  const double remainder = absoluteDecimalDegrees - static_cast<int>( absoluteDecimalDegrees );
+  return static_cast< int >( remainder * 60 );
+}
+
+static QVariant fcnExtractSeconds( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const double absoluteDecimalDegrees = std::abs( QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent ) );
+  const double remainder = absoluteDecimalDegrees - static_cast<int>( absoluteDecimalDegrees );
+  const double remainderInMinutes = remainder * 60;
+  const double remainderSecondsFraction = remainderInMinutes - static_cast< int >( remainderInMinutes );
+  // do not truncate to int, this function returns decimal seconds!
+  return remainderSecondsFraction * 60;
+}
+
 static QVariant fcnAge( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QDateTime d1 = QgsExpressionUtils::getDateTimeValue( values.at( 0 ), parent );
@@ -8599,6 +8622,9 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "to_dm" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "axis" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "precision" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "formatting" ), true ), fcnToDegreeMinute, QStringLiteral( "Conversions" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "todm" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "to_dms" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "axis" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "precision" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "formatting" ), true ), fcnToDegreeMinuteSecond, QStringLiteral( "Conversions" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "todms" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "to_decimal" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) ), fcnToDecimal, QStringLiteral( "Conversions" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "todecimal" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "extract_degrees" ), { QgsExpressionFunction::Parameter{ QStringLiteral( "value" ) } }, fcnExtractDegrees, QStringLiteral( "Conversions" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "extract_minutes" ), { QgsExpressionFunction::Parameter{ QStringLiteral( "value" ) } }, fcnExtractMinutes, QStringLiteral( "Conversions" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "extract_seconds" ), { QgsExpressionFunction::Parameter{ QStringLiteral( "value" ) } }, fcnExtractSeconds, QStringLiteral( "Conversions" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "coalesce" ), -1, fcnCoalesce, QStringLiteral( "Conditionals" ), QString(), false, QSet<QString>(), false, QStringList(), true )
         << new QgsStaticExpressionFunction( QStringLiteral( "nullif" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "value1" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "value2" ) ), fcnNullIf, QStringLiteral( "Conditionals" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "if" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "condition" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "result_when_true" ) )  << QgsExpressionFunction::Parameter( QStringLiteral( "result_when_false" ) ), fcnIf, QStringLiteral( "Conditionals" ), QString(), false, QSet<QString>(), true )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1196,6 +1196,36 @@ class TestQgsExpression : public QObject
       QTest::newRow( "degree minute second string to decimal" ) << "to_decimal('6°21′16.45″N')" << false << QVariant( 6.35456944444 );
       QTest::newRow( "wrong degree minute second string to decimal" ) << "to_decimal('qgis')" << false << QVariant();
 
+      QTest::newRow( "extract degrees positive int" ) << "extract_degrees(135)" << false << QVariant( 135 );
+      QTest::newRow( "extract degrees negative int" ) << "extract_degrees(-135)" << false << QVariant( -135 );
+      // make sure these aren't rounding, but should instead truncate towards zero
+      QTest::newRow( "extract degrees positive float low" ) << "extract_degrees(135.112341)" << false << QVariant( 135 );
+      QTest::newRow( "extract degrees negative float low" ) << "extract_degrees(-135.11234)" << false << QVariant( -135 );
+      QTest::newRow( "extract degrees positive float high" ) << "extract_degrees(135.78785)" << false << QVariant( 135 );
+      QTest::newRow( "extract degrees negative float high" ) << "extract_degrees(-135.7878)" << false << QVariant( -135 );
+
+      QTest::newRow( "extract minutes positive int" ) << "extract_minutes(135)" << false << QVariant( 0 );
+      QTest::newRow( "extract minutes negative int" ) << "extract_minutes(-135)" << false << QVariant( 0 );
+      QTest::newRow( "extract minutes positive round minutes" ) << "extract_minutes(135 + 45/60)" << false << QVariant( 45 );
+      QTest::newRow( "extract minutes negative round minutes" ) << "extract_minutes(-135 - 45/60)" << false << QVariant( 45 );
+      QTest::newRow( "extract minutes positive with low seconds" ) << "extract_minutes(135 + 45.123/60)" << false << QVariant( 45 );
+      QTest::newRow( "extract minutes negative with low seconds" ) << "extract_minutes(-135 - 45.123/60)" << false << QVariant( 45 );
+      QTest::newRow( "extract minutes positive with high seconds" ) << "extract_minutes(135 + 45.888/60)" << false << QVariant( 45 );
+      QTest::newRow( "extract minutes negative with high seconds" ) << "extract_minutes(-135 - 45.888/60)" << false << QVariant( 45 );
+
+      QTest::newRow( "extract seconds positive int" ) << "extract_seconds(135)" << false << QVariant( 0.0 );
+      QTest::newRow( "extract seconds negative int" ) << "extract_seconds(-135)" << false << QVariant( 0.0 );
+      QTest::newRow( "extract seconds positive round minutes" ) << "extract_seconds(135 + 45/60)" << false << QVariant( 0.0 );
+      QTest::newRow( "extract seconds negative round minutes" ) << "extract_seconds(-135 - 45/60)" << false << QVariant( 0.0 );
+      QTest::newRow( "extract seconds positive with round low seconds" ) << "extract_seconds(135 + 45/60 + 12/3600)" << false << QVariant( 12.0 );
+      QTest::newRow( "extract seconds negative with round low seconds" ) << "extract_seconds(-135 - 45/60 - 12/3600)" << false << QVariant( 12.0 );
+      QTest::newRow( "extract seconds positive with round high seconds" ) << "extract_seconds(135 + 45/60 + 58/3600)" << false << QVariant( 58.0 );
+      QTest::newRow( "extract seconds negative with round high seconds" ) << "extract_seconds(-135 - 45/60 - 58/3600)" << false << QVariant( 58.0 );
+      QTest::newRow( "extract seconds positive with decimal low seconds" ) << "round(extract_seconds(135 + 45/60 + 12.222/3600), 3)" << false << QVariant( 12.222 );
+      QTest::newRow( "extract seconds negative with decimal low seconds" ) << "round(extract_seconds(-135 - 45/60 - 12.222/3600), 3)" << false << QVariant( 12.222 );
+      QTest::newRow( "extract seconds positive with decimal high seconds" ) << "round(extract_seconds(135 + 45/60 + 58.222/3600), 3)" << false << QVariant( 58.222 );
+      QTest::newRow( "extract seconds negative with decimal high seconds" ) << "round(extract_seconds(-135 - 45/60 - 58.222/3600), 3)" << false << QVariant( 58.222 );
+
       // geometry functions
       QTest::newRow( "geom_to_wkb" ) << "geom_to_wkt(geom_from_wkb(geom_to_wkb(make_point(4,5))))" << false << QVariant( "Point (4 5)" );
       QTest::newRow( "geom_to_wkb not geom" ) << "geom_to_wkt(geom_from_wkb(geom_to_wkb('a')))" << true << QVariant();


### PR DESCRIPTION
These functions are designed to make it easy to customise the display of a degree based grid annotation, by allowing easy extraction of the individual components of the decimal degree value for individual formatting (eg displaying the degrees in bold)

- extract_degrees: Extracts the integer number of degrees from a decimal degrees value. The minutes and seconds components are ignored. The extracted degrees values will be truncated towards zero (not rounded).
- extract_minutes: Extracts the integer number of minutes from a decimal degrees value. The degrees and seconds components are ignored. The extracted minutes values will be truncated towards zero (not rounded), and will always be a positive value.
- Extracts the decimal number of seconds from a decimal degrees value. The degrees and minutes components are ignored. The extracted seconds value will always be a positive value.

Sponsored by LINZ
