### PR TITLE
support max-triangle-edge-length in PDAL Export to raster (TIN) algorithm

### DIFF
--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
@@ -68,6 +68,10 @@ void QgsPdalExportRasterTinAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "RESOLUTION" ), QObject::tr( "Resolution of the density raster" ), Qgis::ProcessingNumberParameterType::Double, 1, false, 1e-6 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "TILE_SIZE" ), QObject::tr( "Tile size for parallel runs" ), Qgis::ProcessingNumberParameterType::Integer, 1000, false, 1 ) );
 
+#if PDAL_VERSION_MAJOR_INT > 2 || ( PDAL_VERSION_MAJOR_INT == 2 && PDAL_VERSION_MINOR_INT >= 6 )
+  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MAX_EDGE_LENGTH" ), QObject::tr( "Maximum triangle edge length" ), Qgis::ProcessingNumberParameterType::Double, QVariant(), true, 0, 1e8 ) );
+#endif
+
   createCommonParameters();
 
   auto paramOriginX = std::make_unique<QgsProcessingParameterNumber>( QStringLiteral( "ORIGIN_X" ), QObject::tr( "X origin of a tile for parallel runs" ), Qgis::ProcessingNumberParameterType::Double, QVariant(), true, 0 );
@@ -111,6 +115,13 @@ QStringList QgsPdalExportRasterTinAlgorithm::createArgumentLists( const QVariant
     args << QStringLiteral( "--tile-origin-x=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "ORIGIN_X" ), context ) );
     args << QStringLiteral( "--tile-origin-y=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "ORIGIN_Y" ), context ) );
   }
+
+#if PDAL_VERSION_MAJOR_INT > 2 || ( PDAL_VERSION_MAJOR_INT == 2 && PDAL_VERSION_MINOR_INT >= 6 )
+  if ( parameters.value( QStringLiteral( "MAX_EDGE_LENGTH" ) ).isValid() )
+  {
+    args << QStringLiteral( "--max_triangle_edge_length=%1" ).arg( parameterAsDouble( parameters, QStringLiteral( "MAX_EDGE_LENGTH" ), context ) );
+  }
+#endif
 
   applyCommonParameters( args, layer->crs(), parameters, context );
   applyThreadsParameter( args, context );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalexportrastertin.cpp
@@ -68,8 +68,10 @@ void QgsPdalExportRasterTinAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "RESOLUTION" ), QObject::tr( "Resolution of the density raster" ), Qgis::ProcessingNumberParameterType::Double, 1, false, 1e-6 ) );
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "TILE_SIZE" ), QObject::tr( "Tile size for parallel runs" ), Qgis::ProcessingNumberParameterType::Integer, 1000, false, 1 ) );
 
+#ifdef HAVE_PDAL_QGIS
 #if PDAL_VERSION_MAJOR_INT > 2 || ( PDAL_VERSION_MAJOR_INT == 2 && PDAL_VERSION_MINOR_INT >= 6 )
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MAX_EDGE_LENGTH" ), QObject::tr( "Maximum triangle edge length" ), Qgis::ProcessingNumberParameterType::Double, QVariant(), true, 0, 1e8 ) );
+#endif
 #endif
 
   createCommonParameters();
@@ -116,11 +118,13 @@ QStringList QgsPdalExportRasterTinAlgorithm::createArgumentLists( const QVariant
     args << QStringLiteral( "--tile-origin-y=%1" ).arg( parameterAsInt( parameters, QStringLiteral( "ORIGIN_Y" ), context ) );
   }
 
+#ifdef HAVE_PDAL_QGIS
 #if PDAL_VERSION_MAJOR_INT > 2 || ( PDAL_VERSION_MAJOR_INT == 2 && PDAL_VERSION_MINOR_INT >= 6 )
   if ( parameters.value( QStringLiteral( "MAX_EDGE_LENGTH" ) ).isValid() )
   {
     args << QStringLiteral( "--max_triangle_edge_length=%1" ).arg( parameterAsDouble( parameters, QStringLiteral( "MAX_EDGE_LENGTH" ), context ) );
   }
+#endif
 #endif
 
   applyCommonParameters( args, layer->crs(), parameters, context );

--- a/tests/src/analysis/testqgsprocessingpdalalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingpdalalgs.cpp
@@ -497,6 +497,15 @@ void TestQgsProcessingPdalAlgs::exportRasterTin()
   args = alg->createArgumentLists( parameters, *context, &feedback );
   QCOMPARE( args, QStringList() << QStringLiteral( "to_raster_tin" ) << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath ) << QStringLiteral( "--output=%1" ).arg( outputFile ) << QStringLiteral( "--resolution=0.5" ) << QStringLiteral( "--tile-size=100" ) << QStringLiteral( "--tile-origin-x=1" ) << QStringLiteral( "--tile-origin-y=10" ) );
 
+#ifdef HAVE_PDAL_QGIS
+#if PDAL_VERSION_MAJOR_INT > 2 || ( PDAL_VERSION_MAJOR_INT == 2 && PDAL_VERSION_MINOR_INT >= 6 )
+  parameters.insert( QStringLiteral( "MAX_EDGE_LENGTH" ), 25 );
+  args = alg->createArgumentLists( parameters, *context, &feedback );
+  QCOMPARE( args, QStringList() << QStringLiteral( "to_raster_tin" ) << QStringLiteral( "--input=%1" ).arg( mPointCloudLayerPath ) << QStringLiteral( "--output=%1" ).arg( outputFile ) << QStringLiteral( "--resolution=0.5" ) << QStringLiteral( "--tile-size=100" ) << QStringLiteral( "--tile-origin-x=1" ) << QStringLiteral( "--tile-origin-y=10" ) << QStringLiteral( "--max_triangle_edge_length=25" ) );
+  parameters.remove( QStringLiteral( "MAX_EDGE_LENGTH" ) );
+#endif
+#endif
+
   // filter expression
   parameters.insert( QStringLiteral( "FILTER_EXPRESSION" ), QStringLiteral( "Intensity > 50" ) );
   args = alg->createArgumentLists( parameters, *context, &feedback );


### PR DESCRIPTION
## Description

Add support for max-triagnle-edge-length parameter to PDAL Export to raster (TIN), so that triangles where the edge length is bigger than threshold can be ignored.

This feature needs PDAL >= 2.6.0 and wrench >=1.2.2.

Fixes #60113.