### PR TITLE
qgspoint3dsymbol_p: Do not create entities with empty geometries

### DIFF
--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -206,6 +206,11 @@ void QgsInstancedPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
 
 void QgsInstancedPoint3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )
 {
+  if ( out.positions.isEmpty() )
+  {
+    return; // nothing to show - no need to create the entity
+  }
+
   // build the default material
   QgsMaterialContext materialContext;
   materialContext.setIsSelected( selected );
@@ -485,6 +490,11 @@ void QgsModelPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qg
 
 void QgsModelPoint3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )
 {
+  if ( out.positions.isEmpty() )
+  {
+    return; // nothing to show - no need to create the entity
+  }
+
   if ( selected )
   {
     addMeshEntities( context, out.positions, mChunkOrigin, mSymbol.get(), parent, true );
@@ -658,6 +668,11 @@ void QgsPoint3DBillboardSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
 
 void QgsPoint3DBillboardSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )
 {
+  if ( out.positions.isEmpty() )
+  {
+    return; // nothing to show - no need to create the entity
+  }
+
   // Billboard Geometry
   QgsBillboardGeometry *billboardGeometry = new QgsBillboardGeometry();
   billboardGeometry->setPositions( out.positions );


### PR DESCRIPTION
## Description

The `Point3DSymbolHandler::finalize` function creates two entities: one for normal features and one for selected features. However, if an entity does not contain any feature (for example the selected entity if there are no selected entities), a useless entity with no geometry is created.

This issue is fixed by checking if the requested entity has a geometry in `makeEntity` . This is similar to what is already done for line and polygon symbols.


**Funded by Stadt Frankfurt am Main**
