### PR TITLE
Add sqlite3 with omit-load-extension feature

### DIFF
--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -83,7 +83,7 @@
       "features": [
         "omit-load-extension"
       ]
-    }
+    },
     "zlib"
   ],
   "features": {

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -78,6 +78,12 @@
     "qtquickcontrols2",
     "qtsvg",
     "qttools",
+    {
+      "name": "sqlite3",
+      "features": [
+        "omit-load-extension"
+      ]
+    }
     "zlib"
   ],
   "features": {


### PR DESCRIPTION
Enable loading extensions with sqlite3

Implements https://github.com/qgis/QGIS/issues/64164
