### PR TITLE
[wfs] Fix broken server-side feature request filtering

### DIFF
--- a/python/PyQt6/core/auto_additions/qgstestutils.py
+++ b/python/PyQt6/core/auto_additions/qgstestutils.py
@@ -2,5 +2,6 @@
 try:
     QgsTestUtils.testProviderIteratorThreadSafety = staticmethod(QgsTestUtils.testProviderIteratorThreadSafety)
     QgsTestUtils.compareDomElements = staticmethod(QgsTestUtils.compareDomElements)
+    QgsTestUtils.sanitizesFakeHttpEndpoint = staticmethod(QgsTestUtils.sanitizesFakeHttpEndpoint)
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgstestutils.py
+++ b/python/PyQt6/core/auto_additions/qgstestutils.py
@@ -2,6 +2,6 @@
 try:
     QgsTestUtils.testProviderIteratorThreadSafety = staticmethod(QgsTestUtils.testProviderIteratorThreadSafety)
     QgsTestUtils.compareDomElements = staticmethod(QgsTestUtils.compareDomElements)
-    QgsTestUtils.sanitizesFakeHttpEndpoint = staticmethod(QgsTestUtils.sanitizesFakeHttpEndpoint)
+    QgsTestUtils.sanitizeFakeHttpEndpoint = staticmethod(QgsTestUtils.sanitizeFakeHttpEndpoint)
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/qgstestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstestutils.sip.in
@@ -33,6 +33,10 @@ Compares two DOM elements and returns ``True`` if they are equivalent.
 Dumps useful diff information to the console if the elements differ.
 %End
 
+    static QString sanitizesFakeHttpEndpoint( const QString &urlString );
+%Docstring
+Sanitizes fake_qgis_http_endpoint URLs
+%End
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/qgstestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstestutils.sip.in
@@ -33,7 +33,7 @@ Compares two DOM elements and returns ``True`` if they are equivalent.
 Dumps useful diff information to the console if the elements differ.
 %End
 
-    static QString sanitizesFakeHttpEndpoint( const QString &urlString );
+    static QString sanitizeFakeHttpEndpoint( const QString &urlString );
 %Docstring
 Sanitizes fake_qgis_http_endpoint URLs
 %End

--- a/python/core/auto_additions/qgstestutils.py
+++ b/python/core/auto_additions/qgstestutils.py
@@ -2,5 +2,6 @@
 try:
     QgsTestUtils.testProviderIteratorThreadSafety = staticmethod(QgsTestUtils.testProviderIteratorThreadSafety)
     QgsTestUtils.compareDomElements = staticmethod(QgsTestUtils.compareDomElements)
+    QgsTestUtils.sanitizesFakeHttpEndpoint = staticmethod(QgsTestUtils.sanitizesFakeHttpEndpoint)
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_additions/qgstestutils.py
+++ b/python/core/auto_additions/qgstestutils.py
@@ -2,6 +2,6 @@
 try:
     QgsTestUtils.testProviderIteratorThreadSafety = staticmethod(QgsTestUtils.testProviderIteratorThreadSafety)
     QgsTestUtils.compareDomElements = staticmethod(QgsTestUtils.compareDomElements)
-    QgsTestUtils.sanitizesFakeHttpEndpoint = staticmethod(QgsTestUtils.sanitizesFakeHttpEndpoint)
+    QgsTestUtils.sanitizeFakeHttpEndpoint = staticmethod(QgsTestUtils.sanitizeFakeHttpEndpoint)
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/qgstestutils.sip.in
+++ b/python/core/auto_generated/qgstestutils.sip.in
@@ -33,6 +33,10 @@ Compares two DOM elements and returns ``True`` if they are equivalent.
 Dumps useful diff information to the console if the elements differ.
 %End
 
+    static QString sanitizesFakeHttpEndpoint( const QString &urlString );
+%Docstring
+Sanitizes fake_qgis_http_endpoint URLs
+%End
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgstestutils.sip.in
+++ b/python/core/auto_generated/qgstestutils.sip.in
@@ -33,7 +33,7 @@ Compares two DOM elements and returns ``True`` if they are equivalent.
 Dumps useful diff information to the console if the elements differ.
 %End
 
-    static QString sanitizesFakeHttpEndpoint( const QString &urlString );
+    static QString sanitizeFakeHttpEndpoint( const QString &urlString );
 %Docstring
 Sanitizes fake_qgis_http_endpoint URLs
 %End

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -2089,39 +2089,26 @@ QDomElement QgsOgcUtils::expressionToOgcExpression( const QgsExpression &express
   if ( !node )
     return QDomElement();
 
-  switch ( node->nodeType() )
+  QgsOgcUtilsExprToFilter utils( doc, gmlVersion, filterVersion, QString(), QString(), geometryName, srsName, honourAxisOrientation, invertAxisOrientation, fieldNameToXPathMap, namespacePrefixToUriMap );
+  const QDomElement exprRootElem = utils.expressionNodeToOgcFilter( node, &exp, &context );
+
+  if ( errorMessage )
   {
-    case QgsExpressionNode::ntFunction:
-    case QgsExpressionNode::ntLiteral:
-    case QgsExpressionNode::ntColumnRef:
-    case QgsExpressionNode::ntUnaryOperator:
-    {
-      QgsOgcUtilsExprToFilter utils( doc, gmlVersion, filterVersion, QString(), QString(), geometryName, srsName, honourAxisOrientation, invertAxisOrientation, fieldNameToXPathMap, namespacePrefixToUriMap );
-      const QDomElement exprRootElem = utils.expressionNodeToOgcFilter( node, &exp, &context );
-
-      if ( errorMessage )
-        *errorMessage = utils.errorMessage();
-
-      if ( !exprRootElem.isNull() )
-      {
-        if ( requiresFilterElement )
-        {
-          QDomElement filterElem = filterElement( doc, gmlVersion, filterVersion, utils.GMLNamespaceUsed() );
-
-          filterElem.appendChild( exprRootElem );
-          return filterElem;
-        }
-        return exprRootElem;
-      }
-      break;
-    }
-    default:
-    {
-      if ( errorMessage )
-        *errorMessage = QObject::tr( "Node type not supported in expression translation: %1" ).arg( node->nodeType() );
-    }
+    *errorMessage = utils.errorMessage();
   }
-  // got an error
+
+  if ( !exprRootElem.isNull() )
+  {
+    if ( requiresFilterElement )
+    {
+      QDomElement filterElem = filterElement( doc, gmlVersion, filterVersion, utils.GMLNamespaceUsed() );
+
+      filterElem.appendChild( exprRootElem );
+      return filterElem;
+    }
+    return exprRootElem;
+  }
+
   return QDomElement();
 }
 

--- a/src/core/qgstestutils.cpp
+++ b/src/core/qgstestutils.cpp
@@ -153,7 +153,7 @@ bool QgsTestUtils::compareDomElements( const QDomElement &element1, const QDomEl
   return true;
 }
 
-QString QgsTestUtils::sanitizesFakeHttpEndpoint( const QString &urlString )
+QString QgsTestUtils::sanitizeFakeHttpEndpoint( const QString &urlString )
 {
   QString modifiedUrlString = urlString;
 

--- a/src/core/qgstestutils.h
+++ b/src/core/qgstestutils.h
@@ -44,6 +44,10 @@ class CORE_EXPORT QgsTestUtils
      */
     static bool compareDomElements( const QDomElement &element1, const QDomElement &element2 );
 
+    /**
+     * Sanitizes fake_qgis_http_endpoint URLs
+     */
+    static QString sanitizesFakeHttpEndpoint( const QString &urlString );
 };
 
 ///@endcond

--- a/src/core/qgstestutils.h
+++ b/src/core/qgstestutils.h
@@ -47,7 +47,7 @@ class CORE_EXPORT QgsTestUtils
     /**
      * Sanitizes fake_qgis_http_endpoint URLs
      */
-    static QString sanitizesFakeHttpEndpoint( const QString &urlString );
+    static QString sanitizeFakeHttpEndpoint( const QString &urlString );
 };
 
 ///@endcond

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -165,7 +165,7 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
     const auto posQuotationMark = modifiedUrlString.indexOf( '?' );
     if ( posQuotationMark > 0 )
     {
-      modifiedUrlString = QgsTestUtils::sanitizesFakeHttpEndpoint( modifiedUrlString );
+      modifiedUrlString = QgsTestUtils::sanitizeFakeHttpEndpoint( modifiedUrlString );
     }
     QgsDebugMsgLevel( QStringLiteral( "Get %1 (after laundering)" ).arg( modifiedUrlString ), 4 );
     modifiedUrl = QUrl::fromLocalFile( modifiedUrlString );

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -22,10 +22,10 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgssetrequestinitiator_p.h"
 #include "qgssettings.h"
+#include "qgstestutils.h"
 #include "qgsvariantutils.h"
 
 #include <QCache>
-#include <QCryptographicHash>
 #include <QEventLoop>
 #include <QFuture>
 #include <QNetworkCacheMetaData>
@@ -162,35 +162,10 @@ bool QgsBaseNetworkRequest::sendGET( const QUrl &url, const QString &acceptHeade
     }
 #endif
 
-    // For REST API using URL subpaths, normalize the subpaths
-    const int afterEndpointStartPos = static_cast<int>( modifiedUrlString.indexOf( "fake_qgis_http_endpoint" ) + strlen( "fake_qgis_http_endpoint" ) );
-    QString afterEndpointStart = modifiedUrlString.mid( afterEndpointStartPos );
-    afterEndpointStart.replace( QLatin1String( "/" ), QLatin1String( "_" ) );
-    modifiedUrlString = modifiedUrlString.mid( 0, afterEndpointStartPos ) + afterEndpointStart;
-
     const auto posQuotationMark = modifiedUrlString.indexOf( '?' );
     if ( posQuotationMark > 0 )
     {
-      QString args = modifiedUrlString.mid( posQuotationMark );
-      if ( modifiedUrlString.size() > 256 )
-      {
-        QgsDebugMsgLevel( QStringLiteral( "Args before MD5: %1" ).arg( args ), 4 );
-        args = QCryptographicHash::hash( args.toUtf8(), QCryptographicHash::Md5 ).toHex();
-      }
-      else
-      {
-        args.replace( '?', '_' );
-        args.replace( '&', '_' );
-        args.replace( '<', '_' );
-        args.replace( '>', '_' );
-        args.replace( '\'', '_' );
-        args.replace( '\"', '_' );
-        args.replace( ' ', '_' );
-        args.replace( ':', '_' );
-        args.replace( '/', '_' );
-        args.replace( '\n', '_' );
-      }
-      modifiedUrlString = modifiedUrlString.mid( 0, modifiedUrlString.indexOf( '?' ) ) + args;
+      modifiedUrlString = QgsTestUtils::sanitizesFakeHttpEndpoint( modifiedUrlString );
     }
     QgsDebugMsgLevel( QStringLiteral( "Get %1 (after laundering)" ).arg( modifiedUrlString ), 4 );
     modifiedUrl = QUrl::fromLocalFile( modifiedUrlString );

--- a/tests/src/python/test_provider_oapif.py
+++ b/tests/src/python/test_provider_oapif.py
@@ -40,7 +40,7 @@ from providertestbase import ProviderTestCase
 
 
 def sanitize(endpoint, query_params):
-    return QgsTestUtils.sanitizesFakeHttpEndpoint(f"{endpoint}{query_params}")
+    return QgsTestUtils.sanitizeFakeHttpEndpoint(f"{endpoint}{query_params}")
 
 
 def GDAL_COMPUTE_VERSION(maj, min, rev):

--- a/tests/src/python/test_provider_oapif.py
+++ b/tests/src/python/test_provider_oapif.py
@@ -29,6 +29,7 @@ from qgis.core import (
     QgsGeometry,
     QgsRectangle,
     QgsSettings,
+    QgsTestUtils,
     QgsVectorLayer,
     QgsWkbTypes,
 )
@@ -39,37 +40,7 @@ from providertestbase import ProviderTestCase
 
 
 def sanitize(endpoint, query_params):
-    # Implement the logic of QgsBaseNetworkRequest::sendGET()
-    # Note query_params can actually contain subpaths, so create the full url
-    # by concatenating boths, and then figure out things...
-
-    url = endpoint + query_params
-    # For REST API using URL subpaths, normalize the subpaths
-    afterEndpointStartPos = url.find("fake_qgis_http_endpoint") + len(
-        "fake_qgis_http_endpoint"
-    )
-    afterEndpointStart = url[afterEndpointStartPos:]
-    afterEndpointStart = afterEndpointStart.replace("/", "_")
-    url = url[0:afterEndpointStartPos] + afterEndpointStart
-    posQuotationMark = url.find("?")
-    endpoint = url[0:posQuotationMark]
-    query_params = url[posQuotationMark:]
-
-    if len(endpoint + query_params) > 256:
-        ret = endpoint + hashlib.md5(query_params.encode()).hexdigest()
-        # print('Before: ' + endpoint + query_params)
-        # print('After:  ' + ret)
-        return ret
-    ret = endpoint + query_params.replace("?", "_").replace("&", "_").replace(
-        "<", "_"
-    ).replace(">", "_").replace('"', "_").replace("'", "_").replace(" ", "_").replace(
-        ":", "_"
-    ).replace(
-        "/", "_"
-    ).replace(
-        "\n", "_"
-    )
-    return ret
+    return QgsTestUtils.sanitizesFakeHttpEndpoint(f"{endpoint}{query_params}")
 
 
 def GDAL_COMPUTE_VERSION(maj, min, rev):

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -403,6 +403,162 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             sanitize(
                 endpoint,
+                """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:And>
+  <fes:PropertyIsEqualTo xmlns:fes="http://www.opengis.net/fes/2.0">
+   <fes:Function xmlns:fes="http://www.opengis.net/fes/2.0" name="length">
+    <fes:ValueReference>name</fes:ValueReference>
+   </fes:Function>
+   <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">5</fes:Literal>
+  </fes:PropertyIsEqualTo>
+  <fes:And xmlns:fes="http://www.opengis.net/fes/2.0">
+   <fes:PropertyIsGreaterThan xmlns:fes="http://www.opengis.net/fes/2.0">
+    <fes:ValueReference>cnt</fes:ValueReference>
+    <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">100</fes:Literal>
+   </fes:PropertyIsGreaterThan>
+   <fes:PropertyIsLessThan xmlns:fes="http://www.opengis.net/fes/2.0">
+    <fes:ValueReference>cnt</fes:ValueReference>
+    <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">410</fes:Literal>
+   </fes:PropertyIsLessThan>
+  </fes:And>
+ </fes:And>
+</fes:Filter>
+""",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="3" numberReturned="3" timeStamp="2016-03-25T14:51:48.998Z">
+  <wfs:member>
+    <my:typename gml:id="typename.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+      <my:pk>2</my:pk>
+      <my:cnt>200</my:cnt>
+      <my:name>Apple</my:name>
+      <my:name2>Apple</my:name2>
+      <my:num_char>2</my:num_char>
+    </my:typename>
+  </wfs:member>
+  <wfs:member>
+    <my:typename gml:id="typename.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>78.3 -65.32</gml:lowerCorner><gml:upperCorner>78.3 -65.32</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.2"><gml:pos>78.3 -65.32</gml:pos></gml:Point></my:geometryProperty>
+      <my:pk>4</my:pk>
+      <my:cnt>400</my:cnt>
+      <my:name>Honey</my:name>
+      <my:name2>Honey</my:name2>
+      <my:num_char>4</my:num_char>
+    </my:typename>
+  </wfs:member>
+  <wfs:member>
+    <my:typename gml:id="typename.3">
+      <my:pk>3</my:pk>
+      <my:cnt>300</my:cnt>
+      <my:name>Pear</my:name>
+      <my:name2>PEaR</my:name2>
+      <my:num_char>3</my:num_char>
+    </my:typename>
+  </wfs:member>
+</wfs:FeatureCollection>"""
+            )
+
+        with open(
+            sanitize(
+                endpoint,
+                """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsLike wildCard="%" matchCase="false" escapeChar="\\" singleChar="_">
+  <fes:ValueReference>name</fes:ValueReference>
+  <fes:Literal>%a%</fes:Literal>
+ </fes:PropertyIsLike>
+</fes:Filter>
+""",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="3" numberReturned="3" timeStamp="2016-03-25T14:51:48.998Z">
+  <wfs:member>
+    <my:typename gml:id="typename.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+      <my:pk>2</my:pk>
+      <my:cnt>200</my:cnt>
+      <my:name>Apple</my:name>
+      <my:name2>Apple</my:name2>
+      <my:num_char>2</my:num_char>
+    </my:typename>
+  </wfs:member>
+  <wfs:member>
+    <my:typename gml:id="typename.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>66.33 -70.332</gml:lowerCorner><gml:upperCorner>66.33 -70.332</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.0"><gml:pos>66.33 -70.332</gml:pos></gml:Point></my:geometryProperty>
+      <my:pk>1</my:pk>
+      <my:cnt>100</my:cnt>
+      <my:name>Orange</my:name>
+      <my:name2>oranGe</my:name2>
+      <my:num_char>1</my:num_char>
+    </my:typename>
+  </wfs:member>
+  <wfs:member>
+    <my:typename gml:id="typename.3">
+      <my:pk>3</my:pk>
+      <my:cnt>300</my:cnt>
+      <my:name>Pear</my:name>
+      <my:name2>PEaR</my:name2>
+      <my:num_char>3</my:num_char>
+    </my:typename>
+  </wfs:member>
+</wfs:FeatureCollection>"""
+            )
+
+        with open(
+            sanitize(
+                endpoint,
+                """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:PropertyIsLike wildCard="%" matchCase="false" escapeChar="\\" singleChar="_">
+  <fes:ValueReference>name</fes:ValueReference>
+  <fes:Literal>%ney%</fes:Literal>
+ </fes:PropertyIsLike>
+</fes:Filter>
+""",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="3" numberReturned="3" timeStamp="2016-03-25T14:51:48.998Z">
+  <wfs:member>
+    <my:typename gml:id="typename.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>78.3 -65.32</gml:lowerCorner><gml:upperCorner>78.3 -65.32</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.2"><gml:pos>78.3 -65.32</gml:pos></gml:Point></my:geometryProperty>
+      <my:pk>4</my:pk>
+      <my:cnt>400</my:cnt>
+      <my:name>Honey</my:name>
+      <my:name2>Honey</my:name2>
+      <my:num_char>4</my:num_char>
+    </my:typename>
+  </wfs:member>
+</wfs:FeatureCollection>"""
+            )
+
+        with open(
+            sanitize(
+                endpoint,
                 """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
  <fes:And>
   <fes:PropertyIsGreaterThan>
@@ -441,6 +597,61 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
    <fes:ValueReference>cnt</fes:ValueReference>
    <fes:Literal>400</fes:Literal>
   </fes:PropertyIsLessThan>
+ </fes:And>
+</fes:Filter>
+""",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+<wfs:FeatureCollection
+                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                       xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:my="http://my"
+                       numberMatched="2" numberReturned="2" timeStamp="2016-03-25T14:51:48.998Z">
+  <wfs:member>
+    <my:typename gml:id="typename.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+      <my:pk>2</my:pk>
+      <my:cnt>200</my:cnt>
+      <my:name>Apple</my:name>
+      <my:name2>Apple</my:name2>
+      <my:num_char>2</my:num_char>
+    </my:typename>
+  </wfs:member>
+  <wfs:member>
+    <my:typename gml:id="typename.3">
+      <my:pk>3</my:pk>
+      <my:cnt>300</my:cnt>
+      <my:name>Pear</my:name>
+      <my:name2>PEaR</my:name2>
+      <my:num_char>3</my:num_char>
+    </my:typename>
+  </wfs:member>
+</wfs:FeatureCollection>"""
+            )
+
+        with open(
+            sanitize(
+                endpoint,
+                """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
+ <fes:And>
+  <fes:PropertyIsLike xmlns:fes="http://www.opengis.net/fes/2.0" wildCard="%" matchCase="false" escapeChar="\\" singleChar="_">
+   <fes:ValueReference>name</fes:ValueReference>
+   <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">%a%</fes:Literal>
+  </fes:PropertyIsLike>
+  <fes:And xmlns:fes="http://www.opengis.net/fes/2.0">
+   <fes:PropertyIsGreaterThan xmlns:fes="http://www.opengis.net/fes/2.0">
+    <fes:ValueReference>cnt</fes:ValueReference>
+    <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">100</fes:Literal>
+   </fes:PropertyIsGreaterThan>
+   <fes:PropertyIsLessThan xmlns:fes="http://www.opengis.net/fes/2.0">
+    <fes:ValueReference>cnt</fes:ValueReference>
+    <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">400</fes:Literal>
+   </fes:PropertyIsLessThan>
+  </fes:And>
  </fes:And>
 </fes:Filter>
 """,
@@ -6631,6 +6842,36 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
   </wfs:FeatureCollection>"""
             )
 
+        with open(
+            sanitize(
+                endpoint,
+                """?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.0.0&TYPENAME=my:typename&SRSNAME=EPSG:32631&FILTER=<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+ <ogc:PropertyIsEqualTo>
+  <ogc:PropertyName>FOO</ogc:PropertyName>
+  <ogc:Literal>2</ogc:Literal>
+ </ogc:PropertyIsEqualTo>
+</ogc:Filter>
+""",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+  <wfs:FeatureCollection
+                      xmlns:wfs="http://www.opengis.net/wfs"
+                      xmlns:gml="http://www.opengis.net/gml"
+                      xmlns:my="http://my">
+  <gml:boundedBy><gml:null>unknown</gml:null></gml:boundedBy>
+  <gml:featureMember>
+  <my:typename fid="typename.0">
+    <my:foo>1</my:foo>
+    <my:FOO>2</my:FOO>
+    <my:FOO2>3</my:FOO2>
+  </my:typename>
+  </gml:featureMember>
+  </wfs:FeatureCollection>"""
+            )
+
         vl = QgsVectorLayer(
             "url='http://" + endpoint + "' typename='my:typename' version='1.0.0'",
             "test",
@@ -8954,6 +9195,100 @@ class TestPyQgsWFSProviderPost(QgisTestCase, ProviderTestCase):
                         </my:typename>
                       </wfs:member>
                     </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:And>\n    <fes:PropertyIsEqualTo xmlns:fes="http://www.opengis.net/fes/2.0">\n     <fes:Function name="length" xmlns:fes="http://www.opengis.net/fes/2.0">\n      <fes:ValueReference>name</fes:ValueReference>\n     </fes:Function>\n     <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">5</fes:Literal>\n    </fes:PropertyIsEqualTo>\n    <fes:And xmlns:fes="http://www.opengis.net/fes/2.0">\n     <fes:PropertyIsGreaterThan xmlns:fes="http://www.opengis.net/fes/2.0">\n      <fes:ValueReference>cnt</fes:ValueReference>\n      <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">100</fes:Literal>\n     </fes:PropertyIsGreaterThan>\n     <fes:PropertyIsLessThan xmlns:fes="http://www.opengis.net/fes/2.0">\n      <fes:ValueReference>cnt</fes:ValueReference>\n      <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">410</fes:Literal>\n     </fes:PropertyIsLessThan>\n    </fes:And>\n   </fes:And>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           xmlns:my="http://my"
+                                           numberMatched="3" numberReturned="3" timeStamp="2016-03-25T14:51:48.998Z">
+                      <wfs:member>
+                        <my:typename gml:id="typename.1">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>2</my:pk>
+                          <my:cnt>200</my:cnt>
+                          <my:name>Apple</my:name>
+                          <my:name2>Apple</my:name2>
+                          <my:num_char>2</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.2">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>78.3 -65.32</gml:lowerCorner><gml:upperCorner>78.3 -65.32</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.2"><gml:pos>78.3 -65.32</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>4</my:pk>
+                          <my:cnt>400</my:cnt>
+                          <my:name>Honey</my:name>
+                          <my:name2>Honey</my:name2>
+                          <my:num_char>4</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.3">
+                          <my:pk>3</my:pk>
+                          <my:cnt>300</my:cnt>
+                          <my:name>Pear</my:name>
+                          <my:name2>PEaR</my:name2>
+                          <my:num_char>3</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                    </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:PropertyIsLike wildCard="%" matchCase="false" escapeChar="\\" singleChar="_">\n    <fes:ValueReference>name</fes:ValueReference>\n    <fes:Literal>%a%</fes:Literal>\n   </fes:PropertyIsLike>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           xmlns:my="http://my"
+                                           numberMatched="3" numberReturned="3" timeStamp="2016-03-25T14:51:48.998Z">
+                      <wfs:member>
+                        <my:typename gml:id="typename.1">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>2</my:pk>
+                          <my:cnt>200</my:cnt>
+                          <my:name>Apple</my:name>
+                          <my:name2>Apple</my:name2>
+                          <my:num_char>2</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.0">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>66.33 -70.332</gml:lowerCorner><gml:upperCorner>66.33 -70.332</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.0"><gml:pos>66.33 -70.332</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>1</my:pk>
+                          <my:cnt>100</my:cnt>
+                          <my:name>Orange</my:name>
+                          <my:name2>oranGe</my:name2>
+                          <my:num_char>1</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.3">
+                          <my:pk>3</my:pk>
+                          <my:cnt>300</my:cnt>
+                          <my:name>Pear</my:name>
+                          <my:name2>PEaR</my:name2>
+                          <my:num_char>3</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                    </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:PropertyIsLike wildCard="%" matchCase="false" escapeChar="\\" singleChar="_">\n    <fes:ValueReference>name</fes:ValueReference>\n    <fes:Literal>%ney%</fes:Literal>\n   </fes:PropertyIsLike>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           xmlns:my="http://my"
+                                           numberMatched="3" numberReturned="3" timeStamp="2016-03-25T14:51:48.998Z">
+                      <wfs:member>
+                        <my:typename gml:id="typename.2">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>78.3 -65.32</gml:lowerCorner><gml:upperCorner>78.3 -65.32</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.2"><gml:pos>78.3 -65.32</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>4</my:pk>
+                          <my:cnt>400</my:cnt>
+                          <my:name>Honey</my:name>
+                          <my:name2>Honey</my:name2>
+                          <my:num_char>4</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                    </wfs:FeatureCollection>""",
                 b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:PropertyIsEqualTo>\n    <fes:ValueReference>name</fes:ValueReference>\n    <fes:Literal>AppleBearOrangePear</fes:Literal>\n   </fes:PropertyIsEqualTo>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
             <wfs:FeatureCollection
                                    xmlns:wfs="http://www.opengis.net/wfs/2.0"
@@ -9063,6 +9398,36 @@ class TestPyQgsWFSProviderPost(QgisTestCase, ProviderTestCase):
                       </wfs:member>
                     </wfs:FeatureCollection>""",
                 b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:And>\n    <fes:PropertyIsGreaterThan>\n     <fes:ValueReference>cnt</fes:ValueReference>\n     <fes:Literal>100</fes:Literal>\n    </fes:PropertyIsGreaterThan>\n    <fes:PropertyIsLessThan>\n     <fes:ValueReference>cnt</fes:ValueReference>\n     <fes:Literal>400</fes:Literal>\n    </fes:PropertyIsLessThan>\n   </fes:And>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                    <wfs:FeatureCollection
+                                           xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                                           xmlns:gml="http://www.opengis.net/gml/3.2"
+                                           xmlns:my="http://my"
+                                           numberMatched="2" numberReturned="2" timeStamp="2016-03-25T14:51:48.998Z">
+                      <wfs:member>
+                        <my:typename gml:id="typename.1">
+                          <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                          <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
+                          <my:pk>2</my:pk>
+                          <my:cnt>200</my:cnt>
+                          <my:name>Apple</my:name>
+                          <my:name2>Apple</my:name2>
+                          <my:num_char>2</my:num_char>
+                          <my:dt>2020-05-04 12:14:14</my:dt>
+                          <my:date>2020-05-04</my:date>
+                          <my:time>12:14:14</my:time>
+                        </my:typename>
+                      </wfs:member>
+                      <wfs:member>
+                        <my:typename gml:id="typename.3">
+                          <my:pk>3</my:pk>
+                          <my:cnt>300</my:cnt>
+                          <my:name>Pear</my:name>
+                          <my:name2>PEaR</my:name2>
+                          <my:num_char>3</my:num_char>
+                        </my:typename>
+                      </wfs:member>
+                    </wfs:FeatureCollection>""",
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:And>\n    <fes:PropertyIsLike wildCard="%" matchCase="false" escapeChar="\\" xmlns:fes="http://www.opengis.net/fes/2.0" singleChar="_">\n     <fes:ValueReference>name</fes:ValueReference>\n     <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">%a%</fes:Literal>\n    </fes:PropertyIsLike>\n    <fes:And xmlns:fes="http://www.opengis.net/fes/2.0">\n     <fes:PropertyIsGreaterThan xmlns:fes="http://www.opengis.net/fes/2.0">\n      <fes:ValueReference>cnt</fes:ValueReference>\n      <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">100</fes:Literal>\n     </fes:PropertyIsGreaterThan>\n     <fes:PropertyIsLessThan xmlns:fes="http://www.opengis.net/fes/2.0">\n      <fes:ValueReference>cnt</fes:ValueReference>\n      <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">400</fes:Literal>\n     </fes:PropertyIsLessThan>\n    </fes:And>\n   </fes:And>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
                     <wfs:FeatureCollection
                                            xmlns:wfs="http://www.opengis.net/wfs/2.0"
                                            xmlns:gml="http://www.opengis.net/gml/3.2"

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -79,7 +79,7 @@ TEST_DATA_DIR = unitTestDataPath()
 
 
 def sanitize(endpoint, x):
-    return QgsTestUtils.sanitizesFakeHttpEndpoint(f"{endpoint}{x}")
+    return QgsTestUtils.sanitizeFakeHttpEndpoint(f"{endpoint}{x}")
 
 
 class MessageLogger(QObject):

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -458,7 +458,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
             sanitize(
                 endpoint,
                 """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
- <fes:PropertyIsLike wildCard="%" matchCase="false" escapeChar="\\" singleChar="_">
+ <fes:PropertyIsLike escapeChar="\\" matchCase="false" singleChar="_" wildCard="%">
   <fes:ValueReference>name</fes:ValueReference>
   <fes:Literal>%a%</fes:Literal>
  </fes:PropertyIsLike>
@@ -512,7 +512,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
             sanitize(
                 endpoint,
                 """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
- <fes:PropertyIsLike wildCard="%" matchCase="false" escapeChar="\\" singleChar="_">
+ <fes:PropertyIsLike escapeChar="\\" matchCase="false" singleChar="_" wildCard="%">
   <fes:ValueReference>name</fes:ValueReference>
   <fes:Literal>%ney%</fes:Literal>
  </fes:PropertyIsLike>
@@ -624,7 +624,7 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
                 endpoint,
                 """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
  <fes:And>
-  <fes:PropertyIsLike xmlns:fes="http://www.opengis.net/fes/2.0" wildCard="%" matchCase="false" escapeChar="\\" singleChar="_">
+  <fes:PropertyIsLike xmlns:fes="http://www.opengis.net/fes/2.0" escapeChar="\\" matchCase="false" singleChar="_" wildCard="%">
    <fes:ValueReference>name</fes:ValueReference>
    <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">%a%</fes:Literal>
   </fes:PropertyIsLike>
@@ -9219,7 +9219,7 @@ class TestPyQgsWFSProviderPost(QgisTestCase, ProviderTestCase):
                         </my:typename>
                       </wfs:member>
                     </wfs:FeatureCollection>""",
-                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:PropertyIsLike wildCard="%" matchCase="false" escapeChar="\\" singleChar="_">\n    <fes:ValueReference>name</fes:ValueReference>\n    <fes:Literal>%a%</fes:Literal>\n   </fes:PropertyIsLike>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:PropertyIsLike escapeChar="\\" matchCase="false" singleChar="_" wildCard="%">\n    <fes:ValueReference>name</fes:ValueReference>\n    <fes:Literal>%a%</fes:Literal>\n   </fes:PropertyIsLike>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
                     <wfs:FeatureCollection
                                            xmlns:wfs="http://www.opengis.net/wfs/2.0"
                                            xmlns:gml="http://www.opengis.net/gml/3.2"
@@ -9257,7 +9257,7 @@ class TestPyQgsWFSProviderPost(QgisTestCase, ProviderTestCase):
                         </my:typename>
                       </wfs:member>
                     </wfs:FeatureCollection>""",
-                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:PropertyIsLike wildCard="%" matchCase="false" escapeChar="\\" singleChar="_">\n    <fes:ValueReference>name</fes:ValueReference>\n    <fes:Literal>%ney%</fes:Literal>\n   </fes:PropertyIsLike>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:PropertyIsLike escapeChar="\\" matchCase="false" singleChar="_" wildCard="%">\n    <fes:ValueReference>name</fes:ValueReference>\n    <fes:Literal>%ney%</fes:Literal>\n   </fes:PropertyIsLike>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
                     <wfs:FeatureCollection
                                            xmlns:wfs="http://www.opengis.net/wfs/2.0"
                                            xmlns:gml="http://www.opengis.net/gml/3.2"
@@ -9413,7 +9413,7 @@ class TestPyQgsWFSProviderPost(QgisTestCase, ProviderTestCase):
                         </my:typename>
                       </wfs:member>
                     </wfs:FeatureCollection>""",
-                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:And>\n    <fes:PropertyIsLike wildCard="%" matchCase="false" escapeChar="\\" xmlns:fes="http://www.opengis.net/fes/2.0" singleChar="_">\n     <fes:ValueReference>name</fes:ValueReference>\n     <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">%a%</fes:Literal>\n    </fes:PropertyIsLike>\n    <fes:And xmlns:fes="http://www.opengis.net/fes/2.0">\n     <fes:PropertyIsGreaterThan xmlns:fes="http://www.opengis.net/fes/2.0">\n      <fes:ValueReference>cnt</fes:ValueReference>\n      <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">100</fes:Literal>\n     </fes:PropertyIsGreaterThan>\n     <fes:PropertyIsLessThan xmlns:fes="http://www.opengis.net/fes/2.0">\n      <fes:ValueReference>cnt</fes:ValueReference>\n      <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">400</fes:Literal>\n     </fes:PropertyIsLessThan>\n    </fes:And>\n   </fes:And>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
+                b'<?xml version="1.0" encoding="UTF-8"?>\n<wfs:GetFeature xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfs="http://www.opengis.net/wfs/2.0" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" service="WFS" version="2.0.0" xmlns:fes="http://www.opengis.net/fes/2.0">\n <wfs:Query typeNames="my:typename" srsName="urn:ogc:def:crs:EPSG::4326">\n  <fes:Filter>\n   <fes:And>\n    <fes:PropertyIsLike xmlns:fes="http://www.opengis.net/fes/2.0" escapeChar="\\" matchCase="false" singleChar="_" wildCard="%">\n     <fes:ValueReference>name</fes:ValueReference>\n     <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">%a%</fes:Literal>\n    </fes:PropertyIsLike>\n    <fes:And xmlns:fes="http://www.opengis.net/fes/2.0">\n     <fes:PropertyIsGreaterThan xmlns:fes="http://www.opengis.net/fes/2.0">\n      <fes:ValueReference>cnt</fes:ValueReference>\n      <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">100</fes:Literal>\n     </fes:PropertyIsGreaterThan>\n     <fes:PropertyIsLessThan xmlns:fes="http://www.opengis.net/fes/2.0">\n      <fes:ValueReference>cnt</fes:ValueReference>\n      <fes:Literal xmlns:fes="http://www.opengis.net/fes/2.0">400</fes:Literal>\n     </fes:PropertyIsLessThan>\n    </fes:And>\n   </fes:And>\n  </fes:Filter>\n </wfs:Query>\n</wfs:GetFeature>\n': b"""
                     <wfs:FeatureCollection
                                            xmlns:wfs="http://www.opengis.net/wfs/2.0"
                                            xmlns:gml="http://www.opengis.net/gml/3.2"

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -79,21 +79,7 @@ TEST_DATA_DIR = unitTestDataPath()
 
 
 def sanitize(endpoint, x):
-    if len(endpoint + x) > 256:
-        # print('Before: ' + endpoint + x)
-        x = x.replace("/", "_").encode()
-        ret = endpoint + hashlib.md5(x).hexdigest()
-        # print('After:  ' + ret)
-        return ret
-    ret = endpoint + x.replace("?", "_").replace("&", "_").replace("<", "_").replace(
-        ">", "_"
-    ).replace('"', "_").replace("'", "_").replace(" ", "_").replace(":", "_").replace(
-        "/", "_"
-    ).replace(
-        "\n", "_"
-    )
-    # print('Sanitize: ' + x)
-    return ret
+    return QgsTestUtils.sanitizesFakeHttpEndpoint(f"{endpoint}{x}")
 
 
 class MessageLogger(QObject):


### PR DESCRIPTION
## Description

The QgsOgcUtils::expressionToOgcExpression function had a bogus switch block that had binary and in operator node types missing. We can safely remove this switch in favor of the one done in expressionNodeToOgcFilter. 

In turn, this fixes a bad issue we had with our WFS provider whereas a QgsFeatureRequest with a simple "attribute" = 'value' filter expression wouldn't be done server-side and force QGIS to download the whole remote dataset.