### PR TITLE
[3D Map] Cross section nudging

### DIFF
--- a/python/3d/3d_auto.sip
+++ b/python/3d/3d_auto.sip
@@ -6,6 +6,7 @@
 %Include auto_generated/qgs3dmaptool.sip
 %Include auto_generated/qgs3dtypes.sip
 %Include auto_generated/qgs3dmapcanvas.sip
+%Include auto_generated/qgscrosssection.sip
 %Include auto_generated/qgsabstractvectorlayer3drenderer.sip
 %Include auto_generated/qgsannotationlayer3drenderer.sip
 %Include auto_generated/qgscameracontroller.sip

--- a/python/3d/auto_generated/qgs3dmapcanvas.sip.in
+++ b/python/3d/auto_generated/qgs3dmapcanvas.sip.in
@@ -88,19 +88,12 @@ intersected 3d entities.
 .. versionadded:: 4.0
 %End
 
-    void enableCrossSection( const QgsPointXY &startPoint, const QgsPointXY &endPoint, double tolerance, bool setSideView = true );
+    void enableCrossSection( bool setSideView = true );
 %Docstring
 Enables cross section mode for the 3D map canvas. The 3D scene will be
 clipped by four clipping planes, defined by a cross section line segment
-from ``startPoint`` to ``endPoint`` and two parallel segments at
-distance ``tolerance`` to each side.
+and two parallel segments at cross section half width to each side.
 
-:param startPoint: The start point of the cross section line in 3D map
-                   coordinates.
-:param endPoint: The end point of the cross section line in 3D map
-                 coordinates.
-:param tolerance: The distance in meters between the cross section line
-                  and the left and right clipping planes.
 :param setSideView: When ``True``, the camera will be moved to look at
                     the scene from the right side of the cross section
                     line.
@@ -130,13 +123,13 @@ has other clipping planes applied
 .. versionadded:: 4.0
 %End
 
-    void nudgeCameraXY( double dx, double dy );
+
+    QgsCrossSection crossSection() const;
 %Docstring
-Nudges the camera position by ``dx`` and ``dy`` in world coordinates.
+Returns the current cross section definition for the 3D map canvas.
 
 .. versionadded:: 4.0
 %End
-
     void crossSectionEnabledChanged( bool enabled );
 %Docstring
 Emitted when the cross section mode is enabled or disabled

--- a/python/3d/auto_generated/qgs3dmapcanvas.sip.in
+++ b/python/3d/auto_generated/qgs3dmapcanvas.sip.in
@@ -93,8 +93,6 @@ intersected 3d entities.
 Returns ``True`` if the cross section mode is enabled or the 3d scene
 has other clipping planes applied
 
-.. seealso:: :py:func:`enableCrossSection`
-
 .. versionadded:: 4.0
 %End
 
@@ -120,8 +118,6 @@ Returns the current cross section definition for the 3D map canvas.
     void crossSectionEnabledChanged( bool enabled );
 %Docstring
 Emitted when the cross section mode is enabled or disabled
-
-.. seealso:: :py:func:`enableCrossSection`
 
 .. versionadded:: 4.0
 %End

--- a/python/3d/auto_generated/qgs3dmapcanvas.sip.in
+++ b/python/3d/auto_generated/qgs3dmapcanvas.sip.in
@@ -88,31 +88,6 @@ intersected 3d entities.
 .. versionadded:: 4.0
 %End
 
-    void enableCrossSection( bool setSideView = true );
-%Docstring
-Enables cross section mode for the 3D map canvas. The 3D scene will be
-clipped by four clipping planes, defined by a cross section line segment
-and two parallel segments at cross section half width to each side.
-
-:param setSideView: When ``True``, the camera will be moved to look at
-                    the scene from the right side of the cross section
-                    line.
-
-.. seealso:: :py:func:`disableCrossSection`
-
-.. versionadded:: 4.0
-%End
-
-    void disableCrossSection();
-%Docstring
-disableCrossSection Disables the cross section mode and removes the
-scene's clipping planes
-
-.. seealso:: :py:func:`enableCrossSection`
-
-.. versionadded:: 4.0
-%End
-
     bool crossSectionEnabled() const;
 %Docstring
 Returns ``True`` if the cross section mode is enabled or the 3d scene
@@ -123,6 +98,17 @@ has other clipping planes applied
 .. versionadded:: 4.0
 %End
 
+    void setCrossSection( const QgsCrossSection &crossSection );
+%Docstring
+Sets the cross section definition for the 3D map canvas. The 3D scene
+will be clipped by four clipping planes, defined by a cross section line
+segment and two parallel segments at cross section half width to each
+side. Passing an invalid cross section will disable the clipping.
+
+:param crossSection: The cross section definition
+
+.. versionadded:: 4.0
+%End
 
     QgsCrossSection crossSection() const;
 %Docstring

--- a/python/3d/auto_generated/qgs3dmapcanvas.sip.in
+++ b/python/3d/auto_generated/qgs3dmapcanvas.sip.in
@@ -130,6 +130,13 @@ has other clipping planes applied
 .. versionadded:: 4.0
 %End
 
+    void nudgeCameraXY( double dx, double dy );
+%Docstring
+Nudges the camera position by ``dx`` and ``dy`` in world coordinates.
+
+.. versionadded:: 4.0
+%End
+
     void crossSectionEnabledChanged( bool enabled );
 %Docstring
 Emitted when the cross section mode is enabled or disabled

--- a/python/3d/auto_generated/qgs3dmapcanvas.sip.in
+++ b/python/3d/auto_generated/qgs3dmapcanvas.sip.in
@@ -116,6 +116,7 @@ Returns the current cross section definition for the 3D map canvas.
 
 .. versionadded:: 4.0
 %End
+
     void crossSectionEnabledChanged( bool enabled );
 %Docstring
 Emitted when the cross section mode is enabled or disabled

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -357,6 +357,14 @@ world position from a pixel's coordinates and depth
 .. versionadded:: 3.24
 %End
 
+    void moveCenterPoint( const QVector3D &posDiff );
+%Docstring
+Moves camera position by the given difference vector in world
+coordinates
+
+.. versionadded:: 4.0
+%End
+
   private:
     QgsCameraController();
     QgsCameraController( const QgsCameraController &other );

--- a/python/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/3d/auto_generated/qgscameracontroller.sip.in
@@ -311,6 +311,14 @@ Returns the origin of the scene in map coordinates
 .. versionadded:: 3.44
 %End
 
+    void setCrossSectionSideView( const QgsCrossSection &crossSection );
+%Docstring
+Sets the cross section side view definition for the 3D map canvas. The
+camera will be positioned to look at the cross section from the side.
+
+.. versionadded:: 4.0
+%End
+
     void rotateCameraToHome();
 %Docstring
 .. versionadded:: 3.44

--- a/python/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/3d/auto_generated/qgscrosssection.sip.in
@@ -25,42 +25,38 @@ Defined by a line (p1, p2) and a half-width (extent from the line).
   public:
     QgsCrossSection();
 %Docstring
-construct a default method
+Constructs an invalid cross section
 %End
 
     QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth );
 %Docstring
 Constructs a cross section defined by two points and a half-width
+%End
 
-.. versionadded:: 4.0
+    bool isValid() const;
+%Docstring
+Returns cross section validity. A valid cross section has distinct start
+and end points and a positive half-width.
 %End
 
     QgsPoint startPoint() const;
 %Docstring
 Returns the start point of the cross section
-
-.. versionadded:: 4.0
 %End
 
     QgsPoint endPoint() const;
 %Docstring
 Returns the end point of the cross section
-
-.. versionadded:: 4.0
 %End
 
     double halfWidth() const;
 %Docstring
 Returns the half-width of the cross section
-
-.. versionadded:: 4.0
 %End
 
     void setHalfWidth( const double halfWidth );
 %Docstring
 Sets the half-width of the cross section
-
-.. versionadded:: 4.0
 %End
 
     QgsGeometry asGeometry( const QgsCoordinateTransform *ct = 0 ) const;
@@ -69,22 +65,16 @@ Returns the cross section extent as a geometry (Polygon or LineString).
 If a coordinate transform is provided, the geometry is transformed. The
 transform should be from the cross section CRS (3D map CRS) to the
 destination CRS (2D map canvas CRS).
-
-.. versionadded:: 4.0
 %End
 
     void nudgeLeft( double distance );
 %Docstring
 Nudges the cross section to the left by the specified distance
-
-.. versionadded:: 4.0
 %End
 
     void nudgeRight( double distance );
 %Docstring
 Nudges the cross section to the right by the specified distance
-
-.. versionadded:: 4.0
 %End
 
 };

--- a/python/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/3d/auto_generated/qgscrosssection.sip.in
@@ -15,6 +15,8 @@ class QgsCrossSection
 Encapsulates the definition of a cross section in 3D map coordinates.
 
 Defined by a line (p1, p2) and a half-width (extent from the line).
+
+.. versionadded:: 4.0
 %End
 
 %TypeHeaderCode

--- a/python/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/3d/auto_generated/qgscrosssection.sip.in
@@ -48,6 +48,11 @@ Returns the end point of the cross section
 %End
 
     double halfWidth() const;
+%Docstring
+Returns the half-width of the cross section
+
+.. versionadded:: 4.0
+%End
 
     void setHalfWidth( const double halfWidth );
 %Docstring

--- a/python/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/3d/auto_generated/qgscrosssection.sip.in
@@ -22,14 +22,39 @@ Defined by a line (p1, p2) and a half-width (extent from the line).
 %End
   public:
     QgsCrossSection();
+%Docstring
+construct a default method
+%End
+
     QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth );
+%Docstring
+Constructs a cross section defined by two points and a half-width
+
+.. versionadded:: 4.0
+%End
 
     QgsPoint startPoint() const;
+%Docstring
+Returns the start point of the cross section
+
+.. versionadded:: 4.0
+%End
+
     QgsPoint endPoint() const;
+%Docstring
+Returns the end point of the cross section
+
+.. versionadded:: 4.0
+%End
 
     double halfWidth() const;
 
     void setHalfWidth( const double halfWidth );
+%Docstring
+Sets the half-width of the cross section
+
+.. versionadded:: 4.0
+%End
 
     QgsGeometry asGeometry( const QgsCoordinateTransform *ct = 0 ) const;
 %Docstring
@@ -40,8 +65,18 @@ destination CRS (2D map canvas CRS).
 %End
 
     void nudgeLeft( double distance );
+%Docstring
+Nudges the cross section to the left by the specified distance
+
+.. versionadded:: 4.0
+%End
 
     void nudgeRight( double distance );
+%Docstring
+Nudges the cross section to the right by the specified distance
+
+.. versionadded:: 4.0
+%End
 
 };
 

--- a/python/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/3d/auto_generated/qgscrosssection.sip.in
@@ -67,6 +67,8 @@ Returns the cross section extent as a geometry (Polygon or LineString).
 If a coordinate transform is provided, the geometry is transformed. The
 transform should be from the cross section CRS (3D map CRS) to the
 destination CRS (2D map canvas CRS).
+
+.. versionadded:: 4.0
 %End
 
     void nudgeLeft( double distance );

--- a/python/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/3d/auto_generated/qgscrosssection.sip.in
@@ -1,0 +1,54 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/qgscrosssection.h                                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/
+
+
+
+
+class QgsCrossSection
+{
+%Docstring(signature="appended")
+Encapsulates the definition of a cross section in 3D map coordinates.
+
+Defined by a line (p1, p2) and a half-width (extent from the line).
+%End
+
+%TypeHeaderCode
+#include "qgscrosssection.h"
+%End
+  public:
+    QgsCrossSection();
+    QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth );
+
+    QgsPoint startPoint() const;
+    QgsPoint endPoint() const;
+
+    double halfWidth() const;
+
+    void setHalfWidth( const double halfWidth );
+
+    QgsGeometry asGeometry( const QgsCoordinateTransform *ct = 0 ) const;
+%Docstring
+Returns the cross section extent as a geometry (Polygon or LineString).
+If a coordinate transform is provided, the geometry is transformed. The
+transform should be from the cross section CRS (3D map CRS) to the
+destination CRS (2D map canvas CRS).
+%End
+
+    void nudgeLeft( double distance );
+
+    void nudgeRight( double distance );
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/qgscrosssection.h                                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/

--- a/python/PyQt6/3d/3d_auto.sip
+++ b/python/PyQt6/3d/3d_auto.sip
@@ -6,6 +6,7 @@
 %Include auto_generated/qgs3dmaptool.sip
 %Include auto_generated/qgs3dtypes.sip
 %Include auto_generated/qgs3dmapcanvas.sip
+%Include auto_generated/qgscrosssection.sip
 %Include auto_generated/qgsabstractvectorlayer3drenderer.sip
 %Include auto_generated/qgsannotationlayer3drenderer.sip
 %Include auto_generated/qgscameracontroller.sip

--- a/python/PyQt6/3d/auto_generated/qgs3dmapcanvas.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapcanvas.sip.in
@@ -88,19 +88,12 @@ intersected 3d entities.
 .. versionadded:: 4.0
 %End
 
-    void enableCrossSection( const QgsPointXY &startPoint, const QgsPointXY &endPoint, double tolerance, bool setSideView = true );
+    void enableCrossSection( bool setSideView = true );
 %Docstring
 Enables cross section mode for the 3D map canvas. The 3D scene will be
 clipped by four clipping planes, defined by a cross section line segment
-from ``startPoint`` to ``endPoint`` and two parallel segments at
-distance ``tolerance`` to each side.
+and two parallel segments at cross section half width to each side.
 
-:param startPoint: The start point of the cross section line in 3D map
-                   coordinates.
-:param endPoint: The end point of the cross section line in 3D map
-                 coordinates.
-:param tolerance: The distance in meters between the cross section line
-                  and the left and right clipping planes.
 :param setSideView: When ``True``, the camera will be moved to look at
                     the scene from the right side of the cross section
                     line.
@@ -130,13 +123,13 @@ has other clipping planes applied
 .. versionadded:: 4.0
 %End
 
-    void nudgeCameraXY( double dx, double dy );
+
+    QgsCrossSection crossSection() const;
 %Docstring
-Nudges the camera position by ``dx`` and ``dy`` in world coordinates.
+Returns the current cross section definition for the 3D map canvas.
 
 .. versionadded:: 4.0
 %End
-
     void crossSectionEnabledChanged( bool enabled );
 %Docstring
 Emitted when the cross section mode is enabled or disabled

--- a/python/PyQt6/3d/auto_generated/qgs3dmapcanvas.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapcanvas.sip.in
@@ -93,8 +93,6 @@ intersected 3d entities.
 Returns ``True`` if the cross section mode is enabled or the 3d scene
 has other clipping planes applied
 
-.. seealso:: :py:func:`enableCrossSection`
-
 .. versionadded:: 4.0
 %End
 
@@ -120,8 +118,6 @@ Returns the current cross section definition for the 3D map canvas.
     void crossSectionEnabledChanged( bool enabled );
 %Docstring
 Emitted when the cross section mode is enabled or disabled
-
-.. seealso:: :py:func:`enableCrossSection`
 
 .. versionadded:: 4.0
 %End

--- a/python/PyQt6/3d/auto_generated/qgs3dmapcanvas.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapcanvas.sip.in
@@ -88,31 +88,6 @@ intersected 3d entities.
 .. versionadded:: 4.0
 %End
 
-    void enableCrossSection( bool setSideView = true );
-%Docstring
-Enables cross section mode for the 3D map canvas. The 3D scene will be
-clipped by four clipping planes, defined by a cross section line segment
-and two parallel segments at cross section half width to each side.
-
-:param setSideView: When ``True``, the camera will be moved to look at
-                    the scene from the right side of the cross section
-                    line.
-
-.. seealso:: :py:func:`disableCrossSection`
-
-.. versionadded:: 4.0
-%End
-
-    void disableCrossSection();
-%Docstring
-disableCrossSection Disables the cross section mode and removes the
-scene's clipping planes
-
-.. seealso:: :py:func:`enableCrossSection`
-
-.. versionadded:: 4.0
-%End
-
     bool crossSectionEnabled() const;
 %Docstring
 Returns ``True`` if the cross section mode is enabled or the 3d scene
@@ -123,6 +98,17 @@ has other clipping planes applied
 .. versionadded:: 4.0
 %End
 
+    void setCrossSection( const QgsCrossSection &crossSection );
+%Docstring
+Sets the cross section definition for the 3D map canvas. The 3D scene
+will be clipped by four clipping planes, defined by a cross section line
+segment and two parallel segments at cross section half width to each
+side. Passing an invalid cross section will disable the clipping.
+
+:param crossSection: The cross section definition
+
+.. versionadded:: 4.0
+%End
 
     QgsCrossSection crossSection() const;
 %Docstring

--- a/python/PyQt6/3d/auto_generated/qgs3dmapcanvas.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapcanvas.sip.in
@@ -130,6 +130,13 @@ has other clipping planes applied
 .. versionadded:: 4.0
 %End
 
+    void nudgeCameraXY( double dx, double dy );
+%Docstring
+Nudges the camera position by ``dx`` and ``dy`` in world coordinates.
+
+.. versionadded:: 4.0
+%End
+
     void crossSectionEnabledChanged( bool enabled );
 %Docstring
 Emitted when the cross section mode is enabled or disabled

--- a/python/PyQt6/3d/auto_generated/qgs3dmapcanvas.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapcanvas.sip.in
@@ -116,6 +116,7 @@ Returns the current cross section definition for the 3D map canvas.
 
 .. versionadded:: 4.0
 %End
+
     void crossSectionEnabledChanged( bool enabled );
 %Docstring
 Emitted when the cross section mode is enabled or disabled

--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -357,6 +357,14 @@ world position from a pixel's coordinates and depth
 .. versionadded:: 3.24
 %End
 
+    void moveCenterPoint( const QVector3D &posDiff );
+%Docstring
+Moves camera position by the given difference vector in world
+coordinates
+
+.. versionadded:: 4.0
+%End
+
   private:
     QgsCameraController();
     QgsCameraController( const QgsCameraController &other );

--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -311,6 +311,14 @@ Returns the origin of the scene in map coordinates
 .. versionadded:: 3.44
 %End
 
+    void setCrossSectionSideView( const QgsCrossSection &crossSection );
+%Docstring
+Sets the cross section side view definition for the 3D map canvas. The
+camera will be positioned to look at the cross section from the side.
+
+.. versionadded:: 4.0
+%End
+
     void rotateCameraToHome();
 %Docstring
 .. versionadded:: 3.44

--- a/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
@@ -25,42 +25,38 @@ Defined by a line (p1, p2) and a half-width (extent from the line).
   public:
     QgsCrossSection();
 %Docstring
-construct a default method
+Constructs an invalid cross section
 %End
 
     QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth );
 %Docstring
 Constructs a cross section defined by two points and a half-width
+%End
 
-.. versionadded:: 4.0
+    bool isValid() const;
+%Docstring
+Returns cross section validity. A valid cross section has distinct start
+and end points and a positive half-width.
 %End
 
     QgsPoint startPoint() const;
 %Docstring
 Returns the start point of the cross section
-
-.. versionadded:: 4.0
 %End
 
     QgsPoint endPoint() const;
 %Docstring
 Returns the end point of the cross section
-
-.. versionadded:: 4.0
 %End
 
     double halfWidth() const;
 %Docstring
 Returns the half-width of the cross section
-
-.. versionadded:: 4.0
 %End
 
     void setHalfWidth( const double halfWidth );
 %Docstring
 Sets the half-width of the cross section
-
-.. versionadded:: 4.0
 %End
 
     QgsGeometry asGeometry( const QgsCoordinateTransform *ct = 0 ) const;
@@ -69,22 +65,16 @@ Returns the cross section extent as a geometry (Polygon or LineString).
 If a coordinate transform is provided, the geometry is transformed. The
 transform should be from the cross section CRS (3D map CRS) to the
 destination CRS (2D map canvas CRS).
-
-.. versionadded:: 4.0
 %End
 
     void nudgeLeft( double distance );
 %Docstring
 Nudges the cross section to the left by the specified distance
-
-.. versionadded:: 4.0
 %End
 
     void nudgeRight( double distance );
 %Docstring
 Nudges the cross section to the right by the specified distance
-
-.. versionadded:: 4.0
 %End
 
 };

--- a/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
@@ -15,6 +15,8 @@ class QgsCrossSection
 Encapsulates the definition of a cross section in 3D map coordinates.
 
 Defined by a line (p1, p2) and a half-width (extent from the line).
+
+.. versionadded:: 4.0
 %End
 
 %TypeHeaderCode

--- a/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
@@ -48,6 +48,11 @@ Returns the end point of the cross section
 %End
 
     double halfWidth() const;
+%Docstring
+Returns the half-width of the cross section
+
+.. versionadded:: 4.0
+%End
 
     void setHalfWidth( const double halfWidth );
 %Docstring

--- a/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
@@ -22,14 +22,39 @@ Defined by a line (p1, p2) and a half-width (extent from the line).
 %End
   public:
     QgsCrossSection();
+%Docstring
+construct a default method
+%End
+
     QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth );
+%Docstring
+Constructs a cross section defined by two points and a half-width
+
+.. versionadded:: 4.0
+%End
 
     QgsPoint startPoint() const;
+%Docstring
+Returns the start point of the cross section
+
+.. versionadded:: 4.0
+%End
+
     QgsPoint endPoint() const;
+%Docstring
+Returns the end point of the cross section
+
+.. versionadded:: 4.0
+%End
 
     double halfWidth() const;
 
     void setHalfWidth( const double halfWidth );
+%Docstring
+Sets the half-width of the cross section
+
+.. versionadded:: 4.0
+%End
 
     QgsGeometry asGeometry( const QgsCoordinateTransform *ct = 0 ) const;
 %Docstring
@@ -40,8 +65,18 @@ destination CRS (2D map canvas CRS).
 %End
 
     void nudgeLeft( double distance );
+%Docstring
+Nudges the cross section to the left by the specified distance
+
+.. versionadded:: 4.0
+%End
 
     void nudgeRight( double distance );
+%Docstring
+Nudges the cross section to the right by the specified distance
+
+.. versionadded:: 4.0
+%End
 
 };
 

--- a/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
@@ -67,6 +67,8 @@ Returns the cross section extent as a geometry (Polygon or LineString).
 If a coordinate transform is provided, the geometry is transformed. The
 transform should be from the cross section CRS (3D map CRS) to the
 destination CRS (2D map canvas CRS).
+
+.. versionadded:: 4.0
 %End
 
     void nudgeLeft( double distance );

--- a/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscrosssection.sip.in
@@ -1,0 +1,54 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/qgscrosssection.h                                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/
+
+
+
+
+class QgsCrossSection
+{
+%Docstring(signature="appended")
+Encapsulates the definition of a cross section in 3D map coordinates.
+
+Defined by a line (p1, p2) and a half-width (extent from the line).
+%End
+
+%TypeHeaderCode
+#include "qgscrosssection.h"
+%End
+  public:
+    QgsCrossSection();
+    QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth );
+
+    QgsPoint startPoint() const;
+    QgsPoint endPoint() const;
+
+    double halfWidth() const;
+
+    void setHalfWidth( const double halfWidth );
+
+    QgsGeometry asGeometry( const QgsCoordinateTransform *ct = 0 ) const;
+%Docstring
+Returns the cross section extent as a geometry (Polygon or LineString).
+If a coordinate transform is provided, the geometry is transformed. The
+transform should be from the cross section CRS (3D map CRS) to the
+destination CRS (2D map canvas CRS).
+%End
+
+    void nudgeLeft( double distance );
+
+    void nudgeRight( double distance );
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/qgscrosssection.h                                             *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -17,6 +17,7 @@ set(QGIS_3D_SRCS
   qgs3dmapsettings.cpp
   qgs3dmaptool.cpp
   qgs3dmapcanvas.cpp
+  qgscrosssection.cpp
   qgs3drendercontext.cpp
   qgs3dsceneexporter.cpp
   qgs3dutils.cpp
@@ -156,6 +157,7 @@ set(QGIS_3D_HDRS
   qgs3dtypes.h
   qgs3dutils.h
   qgs3dmapcanvas.h
+  qgscrosssection.h
   qgs3dwiredmesh_p.h
   qgsaabb.h
   qgsabstract3dengine.h

--- a/src/3d/qgs3dmapcanvas.cpp
+++ b/src/3d/qgs3dmapcanvas.cpp
@@ -230,6 +230,23 @@ void Qgs3DMapCanvas::enableCrossSection( const QgsPointXY &startPoint, const Qgs
   emit crossSectionEnabledChanged( true );
 }
 
+void Qgs3DMapCanvas::nudgeCameraXY( double dx, double dy )
+{
+  if ( !mScene )
+    return;
+
+  QgsCameraController *controller = mScene->cameraController();
+
+  QgsCameraPose cameraPose = controller->cameraPose();
+  QgsVector3D cameraCenter = cameraPose.centerPoint();
+
+  cameraCenter.setX( cameraCenter.x() + dx );
+  cameraCenter.setY( cameraCenter.y() + dy );
+  cameraPose.setCenterPoint( cameraCenter );
+
+  controller->setCameraPose( cameraPose );
+}
+
 void Qgs3DMapCanvas::disableCrossSection()
 {
   if ( !mScene )

--- a/src/3d/qgs3dmapcanvas.cpp
+++ b/src/3d/qgs3dmapcanvas.cpp
@@ -192,10 +192,14 @@ QgsRayCastResult Qgs3DMapCanvas::castRay( const QPoint &screenPoint, QgsRayCastC
   return res;
 }
 
-void Qgs3DMapCanvas::enableCrossSection( const QgsPointXY &startPoint, const QgsPointXY &endPoint, double width, bool setSideView )
+void Qgs3DMapCanvas::enableCrossSection( bool setSideView )
 {
-  if ( !mScene )
+  if ( !mScene || mCrossSection.halfWidth() <= 0.0 )
     return;
+
+  const QgsPoint startPoint = mCrossSection.startPoint();
+  const QgsPoint endPoint = mCrossSection.endPoint();
+  const double width = mCrossSection.halfWidth();
 
   const QgsVector3D startVec { startPoint.x(), startPoint.y(), 0 };
   const QgsVector3D endVec { endPoint.x(), endPoint.y(), 0 };
@@ -230,21 +234,9 @@ void Qgs3DMapCanvas::enableCrossSection( const QgsPointXY &startPoint, const Qgs
   emit crossSectionEnabledChanged( true );
 }
 
-void Qgs3DMapCanvas::nudgeCameraXY( double dx, double dy )
+void Qgs3DMapCanvas::setCrossSection( const QgsCrossSection &crossSection )
 {
-  if ( !mScene )
-    return;
-
-  QgsCameraController *controller = mScene->cameraController();
-
-  QgsCameraPose cameraPose = controller->cameraPose();
-  QgsVector3D cameraCenter = cameraPose.centerPoint();
-
-  cameraCenter.setX( cameraCenter.x() + dx );
-  cameraCenter.setY( cameraCenter.y() + dy );
-  cameraPose.setCenterPoint( cameraCenter );
-
-  controller->setCameraPose( cameraPose );
+  mCrossSection = crossSection;
 }
 
 void Qgs3DMapCanvas::disableCrossSection()

--- a/src/3d/qgs3dmapcanvas.h
+++ b/src/3d/qgs3dmapcanvas.h
@@ -18,6 +18,7 @@
 
 #include "qgis.h"
 #include "qgis_3d.h"
+#include "qgscrosssection.h"
 #include "qgsrange.h"
 #include "qgsraycastresult.h"
 
@@ -120,17 +121,14 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
 
     /**
      * Enables cross section mode for the 3D map canvas.
-     * The 3D scene will be clipped by four clipping planes, defined by a cross section line segment from \a startPoint to \a endPoint and
-     * two parallel segments at distance \a tolerance to each side.
+     * The 3D scene will be clipped by four clipping planes, defined by a cross section line segment and
+     * two parallel segments at cross section half width to each side.
      *
-     * \param startPoint The start point of the cross section line in 3D map coordinates.
-     * \param endPoint The end point of the cross section line in 3D map coordinates.
-     * \param tolerance The distance in meters between the cross section line and the left and right clipping planes.
      * \param setSideView When TRUE, the camera will be moved to look at the scene from the right side of the cross section line.
      * \see disableCrossSection()
      * \since QGIS 4.0
      */
-    void enableCrossSection( const QgsPointXY &startPoint, const QgsPointXY &endPoint, double tolerance, bool setSideView = true );
+    void enableCrossSection( bool setSideView = true );
 
     /**
      * \brief disableCrossSection Disables the cross section mode and removes the scene's clipping planes
@@ -148,17 +146,25 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
     bool crossSectionEnabled() const;
 
     /**
-     * Nudges the camera position by \a dx and \a dy in world coordinates.
+     * Sets the cross section definition for the 3D map canvas.
      * \since QGIS 4.0
      */
-    void nudgeCameraXY( double dx, double dy );
+    void setCrossSection( const QgsCrossSection &crossSection ) SIP_SKIP;
+
+    /**
+     * Returns the current cross section definition for the 3D map canvas.
+     * \since QGIS 4.0
+     */
+    QgsCrossSection crossSection() const { return mCrossSection; }
+    SIP_SKIP
 
 #ifndef SIP_RUN
 
     /**
      * Sets the specified root entity of the scene.
      */
-    void setRootEntity( Qt3DCore::QEntity *root );
+    void
+      setRootEntity( Qt3DCore::QEntity *root );
 
     /**
      * Activates the specified activeFrameGraph.
@@ -307,6 +313,8 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
 
     //! This holds and owns the rubber bands for highlighting identified features
     QMap<QgsMapLayer *, QgsRubberBand3D *> mHighlights;
+
+    QgsCrossSection mCrossSection;
 };
 
 #endif //QGS3DMAPCANVAS_H

--- a/src/3d/qgs3dmapcanvas.h
+++ b/src/3d/qgs3dmapcanvas.h
@@ -120,24 +120,6 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
     QgsRayCastResult castRay( const QPoint &screenPoint, QgsRayCastContext context );
 
     /**
-     * Enables cross section mode for the 3D map canvas.
-     * The 3D scene will be clipped by four clipping planes, defined by a cross section line segment and
-     * two parallel segments at cross section half width to each side.
-     *
-     * \param setSideView When TRUE, the camera will be moved to look at the scene from the right side of the cross section line.
-     * \see disableCrossSection()
-     * \since QGIS 4.0
-     */
-    void enableCrossSection( bool setSideView = true );
-
-    /**
-     * \brief disableCrossSection Disables the cross section mode and removes the scene's clipping planes
-     * \see enableCrossSection()
-     * \since QGIS 4.0
-     */
-    void disableCrossSection();
-
-    /**
      * Returns TRUE if the cross section mode is enabled or the 3d scene has other clipping planes applied
      *
      * \see enableCrossSection()
@@ -147,9 +129,13 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
 
     /**
      * Sets the cross section definition for the 3D map canvas.
+     * The 3D scene will be clipped by four clipping planes, defined by a cross section line segment and
+     * two parallel segments at cross section half width to each side.
+     * Passing an invalid cross section will disable the clipping.
+     * \param crossSection The cross section definition
      * \since QGIS 4.0
      */
-    void setCrossSection( const QgsCrossSection &crossSection ) SIP_SKIP;
+    void setCrossSection( const QgsCrossSection &crossSection );
 
     /**
      * Returns the current cross section definition for the 3D map canvas.

--- a/src/3d/qgs3dmapcanvas.h
+++ b/src/3d/qgs3dmapcanvas.h
@@ -142,15 +142,13 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
      * \since QGIS 4.0
      */
     QgsCrossSection crossSection() const { return mCrossSection; }
-    SIP_SKIP
 
 #ifndef SIP_RUN
 
     /**
      * Sets the specified root entity of the scene.
      */
-    void
-      setRootEntity( Qt3DCore::QEntity *root );
+    void setRootEntity( Qt3DCore::QEntity *root );
 
     /**
      * Activates the specified activeFrameGraph.

--- a/src/3d/qgs3dmapcanvas.h
+++ b/src/3d/qgs3dmapcanvas.h
@@ -122,7 +122,6 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
     /**
      * Returns TRUE if the cross section mode is enabled or the 3d scene has other clipping planes applied
      *
-     * \see enableCrossSection()
      * \since QGIS 4.0
      */
     bool crossSectionEnabled() const;
@@ -235,7 +234,6 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
 #endif
     /**
      *  Emitted when the cross section mode is enabled or disabled
-     *  \see enableCrossSection()
      *  \since QGIS 4.0
      */
     void crossSectionEnabledChanged( bool enabled );

--- a/src/3d/qgs3dmapcanvas.h
+++ b/src/3d/qgs3dmapcanvas.h
@@ -147,6 +147,12 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
      */
     bool crossSectionEnabled() const;
 
+    /**
+     * Nudges the camera position by \a dx and \a dy in world coordinates.
+     * \since QGIS 4.0
+     */
+    void nudgeCameraXY( double dx, double dy );
+
 #ifndef SIP_RUN
 
     /**

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -480,7 +480,7 @@ void QgsCameraController::updateCameraFromPose()
   }
 }
 
-void QgsCameraController::moveCameraPositionBy( const QVector3D &posDiff )
+void QgsCameraController::moveCenterPoint( const QVector3D &posDiff )
 {
   mCameraPose.setCenterPoint( mCameraPose.centerPoint() + posDiff );
   updateCameraFromPose();
@@ -1114,7 +1114,7 @@ void QgsCameraController::walkView( double tx, double ty, double tz )
     cameraPosDiff += static_cast<float>( tz ) * QVector3D( 0.0f, 0.0f, 1.0f );
   }
 
-  moveCameraPositionBy( cameraPosDiff );
+  moveCenterPoint( cameraPosDiff );
 }
 
 void QgsCameraController::applyFlyModeKeyMovements()
@@ -1197,14 +1197,14 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     const QVector3D cameraFront = ( QVector3D( mCameraPose.centerPoint().x(), mCameraPose.centerPoint().y(), mCameraPose.centerPoint().z() ) - mCamera->position() ).normalized();
     const QVector3D cameraLeft = QVector3D::crossProduct( cameraUp, cameraFront );
     const QVector3D cameraPosDiff = -dx * cameraLeft - dy * cameraUp;
-    moveCameraPositionBy( mCameraMovementSpeed * cameraPosDiff / 10.0 );
+    moveCenterPoint( mCameraMovementSpeed * cameraPosDiff / 10.0 );
   }
   else if ( hasRightButton )
   {
     // right button drag = camera dolly
     const QVector3D cameraFront = ( QVector3D( mCameraPose.centerPoint().x(), mCameraPose.centerPoint().y(), mCameraPose.centerPoint().z() ) - mCamera->position() ).normalized();
     const QVector3D cameraPosDiff = dy * cameraFront;
-    moveCameraPositionBy( mCameraMovementSpeed * cameraPosDiff / 5.0 );
+    moveCenterPoint( mCameraMovementSpeed * cameraPosDiff / 5.0 );
   }
   else
   {

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -1197,14 +1197,14 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     const QVector3D cameraFront = ( QVector3D( mCameraPose.centerPoint().x(), mCameraPose.centerPoint().y(), mCameraPose.centerPoint().z() ) - mCamera->position() ).normalized();
     const QVector3D cameraLeft = QVector3D::crossProduct( cameraUp, cameraFront );
     const QVector3D cameraPosDiff = -dx * cameraLeft - dy * cameraUp;
-    moveCenterPoint( mCameraMovementSpeed * cameraPosDiff / 10.0 );
+    moveCenterPoint( static_cast<float>( mCameraMovementSpeed ) * cameraPosDiff / 10.0 );
   }
   else if ( hasRightButton )
   {
     // right button drag = camera dolly
     const QVector3D cameraFront = ( QVector3D( mCameraPose.centerPoint().x(), mCameraPose.centerPoint().y(), mCameraPose.centerPoint().z() ) - mCamera->position() ).normalized();
     const QVector3D cameraPosDiff = dy * cameraFront;
-    moveCenterPoint( mCameraMovementSpeed * cameraPosDiff / 5.0 );
+    moveCenterPoint( static_cast<float>( mCameraMovementSpeed ) * cameraPosDiff / 5.0 );
   }
   else
   {

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -48,6 +48,7 @@ class QgsCameraPose;
 class QgsVector3D;
 class QgsWindow3DEngine;
 class Qgs3DMapScene;
+class QgsCrossSection;
 
 /**
  * \ingroup qgis_3d
@@ -290,6 +291,13 @@ class _3D_EXPORT QgsCameraController : public QObject
      * \since QGIS 3.44
      */
     const QgsVector3D origin() const { return mOrigin; }
+
+    /**
+     * Sets the cross section side view definition for the 3D map canvas.
+     * The camera will be positioned to look at the cross section from the side.
+     * \since QGIS 4.0
+     */
+    void setCrossSectionSideView( const QgsCrossSection &crossSection );
 
     // Convenience methods to set camera view to standard positions
     //! Rotate to diagonal view. \since QGIS 3.44

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -321,6 +321,12 @@ class _3D_EXPORT QgsCameraController : public QObject
      */
     void depthBufferCaptured( const QImage &depthImage );
 
+    /**
+     * Moves camera position by the given difference vector in world coordinates
+     * \since QGIS 4.0
+     */
+    void moveCenterPoint( const QVector3D &posDiff );
+
   private:
 #ifdef SIP_RUN
     QgsCameraController();
@@ -328,7 +334,6 @@ class _3D_EXPORT QgsCameraController : public QObject
 #endif
 
     void updateCameraFromPose();
-    void moveCameraPositionBy( const QVector3D &posDiff );
     //! Returns a pointer to the scene's engine's window or nullptr if engine is QgsOffscreen3DEngine
     QWindow *window() const;
 

--- a/src/3d/qgscrosssection.cpp
+++ b/src/3d/qgscrosssection.cpp
@@ -81,3 +81,8 @@ void QgsCrossSection::nudge( double distance )
   mStartPoint += offset;
   mEndPoint += offset;
 }
+
+bool QgsCrossSection::isValid() const
+{
+  return ( mStartPoint != mEndPoint ) && ( mHalfWidth > 0.0 );
+}

--- a/src/3d/qgscrosssection.cpp
+++ b/src/3d/qgscrosssection.cpp
@@ -1,0 +1,83 @@
+/***************************************************************************
+    qgscrosssection.cpp
+    ---------------------
+    begin                : January 2026
+    copyright            : (C) 2026 by Dominik Cindrić
+    email                : viper dot miniq at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscrosssection.h"
+
+#include "qgscoordinatetransform.h"
+#include "qgslinestring.h"
+#include "qgspolygon.h"
+
+QgsCrossSection::QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth )
+  : mStartPoint( p1 )
+  , mEndPoint( p2 )
+  , mHalfWidth( halfWidth )
+{
+}
+
+QgsGeometry QgsCrossSection::asGeometry( const QgsCoordinateTransform *ct ) const
+{
+  QgsVector vec( mEndPoint - mStartPoint );
+  vec = vec.normalized().perpVector();
+
+  QgsGeometry geom;
+  if ( mHalfWidth == 0.0 )
+  {
+    QVector<QgsPointXY> points = { mStartPoint, mEndPoint };
+    geom = QgsGeometry( new QgsLineString( points ) );
+  }
+  else
+  {
+    QVector<QgsPointXY> points = {
+      mStartPoint + vec * mHalfWidth,
+      mEndPoint + vec * mHalfWidth,
+      mEndPoint - vec * mHalfWidth,
+      mStartPoint - vec * mHalfWidth
+    };
+    geom = QgsGeometry( new QgsPolygon( new QgsLineString( points ) ) );
+  }
+
+  if ( ct )
+  {
+    try
+    {
+      geom.transform( *ct, Qgis::TransformDirection::Reverse );
+    }
+    catch ( const QgsCsException & )
+    {
+      geom = QgsGeometry();
+    }
+  }
+  return geom;
+}
+
+void QgsCrossSection::nudgeLeft( double distance )
+{
+  nudge( distance );
+}
+
+void QgsCrossSection::nudgeRight( double distance )
+{
+  nudge( -distance );
+}
+
+void QgsCrossSection::nudge( double distance )
+{
+  QgsVector vec( mEndPoint - mStartPoint );
+  vec = vec.normalized().perpVector();
+
+  const QgsVector offset = vec * distance;
+  mStartPoint += offset;
+  mEndPoint += offset;
+}

--- a/src/3d/qgscrosssection.h
+++ b/src/3d/qgscrosssection.h
@@ -68,6 +68,7 @@ class _3D_EXPORT QgsCrossSection
      * Returns the cross section extent as a geometry (Polygon or LineString).
      * If a coordinate transform is provided, the geometry is transformed.
      * The transform should be from the cross section CRS (3D map CRS) to the destination CRS (2D map canvas CRS).
+     * \since QGIS 4.0
      */
     QgsGeometry asGeometry( const QgsCoordinateTransform *ct = nullptr ) const;
 

--- a/src/3d/qgscrosssection.h
+++ b/src/3d/qgscrosssection.h
@@ -1,0 +1,63 @@
+/***************************************************************************
+    qgscrosssection.h
+    ---------------------
+    begin                : January 2026
+    copyright            : (C) 2026 by Dominik Cindrić
+    email                : viper dot miniq at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCROSSSECTION_H
+#define QGSCROSSSECTION_H
+
+#include "qgis_3d.h"
+#include "qgsgeometry.h"
+#include "qgspointxy.h"
+
+class QgsCoordinateTransform;
+
+/**
+ * \ingroup 3d
+ * \brief Encapsulates the definition of a cross section in 3D map coordinates.
+ *
+ * Defined by a line (p1, p2) and a half-width (extent from the line).
+ */
+class _3D_EXPORT QgsCrossSection
+{
+  public:
+    QgsCrossSection() = default;
+    QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth );
+
+    QgsPoint startPoint() const { return mStartPoint; }
+    QgsPoint endPoint() const { return mEndPoint; }
+
+    double halfWidth() const { return mHalfWidth; }
+
+    void setHalfWidth( const double halfWidth ) { mHalfWidth = halfWidth; }
+
+    /**
+     * Returns the cross section extent as a geometry (Polygon or LineString).
+     * If a coordinate transform is provided, the geometry is transformed.
+     * The transform should be from the cross section CRS (3D map CRS) to the destination CRS (2D map canvas CRS).
+     */
+    QgsGeometry asGeometry( const QgsCoordinateTransform *ct = nullptr ) const;
+
+    void nudgeLeft( double distance );
+
+    void nudgeRight( double distance );
+
+  private:
+    QgsPoint mStartPoint;
+    QgsPoint mEndPoint;
+    double mHalfWidth = 0.0;
+
+    void nudge( double distance );
+};
+
+#endif // QGSCROSSSECTION_H

--- a/src/3d/qgscrosssection.h
+++ b/src/3d/qgscrosssection.h
@@ -27,6 +27,7 @@ class QgsCoordinateTransform;
  * \brief Encapsulates the definition of a cross section in 3D map coordinates.
  *
  * Defined by a line (p1, p2) and a half-width (extent from the line).
+ * \since QGIS 4.0
  */
 class _3D_EXPORT QgsCrossSection
 {

--- a/src/3d/qgscrosssection.h
+++ b/src/3d/qgscrosssection.h
@@ -32,57 +32,40 @@ class QgsCoordinateTransform;
 class _3D_EXPORT QgsCrossSection
 {
   public:
-    //! construct a default method
+    //! Constructs an invalid cross section
     QgsCrossSection() = default;
 
-    /**
-     * Constructs a cross section defined by two points and a half-width
-     * \since QGIS 4.0
-     */
+    //! Constructs a cross section defined by two points and a half-width
     QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth );
 
-    /**
-     * Returns the start point of the cross section
-     * \since QGIS 4.0
-     */
+    /*Returns cross section validity.
+    * A valid cross section has distinct start and end points and a positive half-width.
+    */
+    bool isValid() const;
+
+    //! Returns the start point of the cross section
     QgsPoint startPoint() const { return mStartPoint; }
 
-    /**
-     * Returns the end point of the cross section
-     * \since QGIS 4.0
-     */
+    //! Returns the end point of the cross section
     QgsPoint endPoint() const { return mEndPoint; }
 
-    /**
-     * Returns the half-width of the cross section
-     * \since QGIS 4.0
-     */
+    //! Returns the half-width of the cross section
     double halfWidth() const { return mHalfWidth; }
 
-    /**
-     * Sets the half-width of the cross section
-     * \since QGIS 4.0
-     */
+    //! Sets the half-width of the cross section
     void setHalfWidth( const double halfWidth ) { mHalfWidth = halfWidth; }
 
     /**
      * Returns the cross section extent as a geometry (Polygon or LineString).
      * If a coordinate transform is provided, the geometry is transformed.
      * The transform should be from the cross section CRS (3D map CRS) to the destination CRS (2D map canvas CRS).
-     * \since QGIS 4.0
      */
     QgsGeometry asGeometry( const QgsCoordinateTransform *ct = nullptr ) const;
 
-    /**
-     * Nudges the cross section to the left by the specified distance
-     * \since QGIS 4.0
-     */
+    //! Nudges the cross section to the left by the specified distance
     void nudgeLeft( double distance );
 
-    /**
-     * Nudges the cross section to the right by the specified distance
-     * \since QGIS 4.0
-     */
+    //! Nudges the cross section to the right by the specified distance
     void nudgeRight( double distance );
 
   private:

--- a/src/3d/qgscrosssection.h
+++ b/src/3d/qgscrosssection.h
@@ -23,7 +23,7 @@
 class QgsCoordinateTransform;
 
 /**
- * \ingroup 3d
+ * \ingroup qgis_3d
  * \brief Encapsulates the definition of a cross section in 3D map coordinates.
  *
  * Defined by a line (p1, p2) and a half-width (extent from the line).
@@ -31,14 +31,33 @@ class QgsCoordinateTransform;
 class _3D_EXPORT QgsCrossSection
 {
   public:
+    //! construct a default method
     QgsCrossSection() = default;
+
+    /**
+     * Constructs a cross section defined by two points and a half-width
+     * \since QGIS 4.0
+     */
     QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth );
 
+    /**
+     * Returns the start point of the cross section
+     * \since QGIS 4.0
+     */
     QgsPoint startPoint() const { return mStartPoint; }
+
+    /**
+     * Returns the end point of the cross section
+     * \since QGIS 4.0
+     */
     QgsPoint endPoint() const { return mEndPoint; }
 
     double halfWidth() const { return mHalfWidth; }
 
+    /**
+     * Sets the half-width of the cross section
+     * \since QGIS 4.0
+     */
     void setHalfWidth( const double halfWidth ) { mHalfWidth = halfWidth; }
 
     /**
@@ -48,8 +67,16 @@ class _3D_EXPORT QgsCrossSection
      */
     QgsGeometry asGeometry( const QgsCoordinateTransform *ct = nullptr ) const;
 
+    /**
+     * Nudges the cross section to the left by the specified distance
+     * \since QGIS 4.0
+     */
     void nudgeLeft( double distance );
 
+    /**
+     * Nudges the cross section to the right by the specified distance
+     * \since QGIS 4.0
+     */
     void nudgeRight( double distance );
 
   private:

--- a/src/3d/qgscrosssection.h
+++ b/src/3d/qgscrosssection.h
@@ -52,6 +52,10 @@ class _3D_EXPORT QgsCrossSection
      */
     QgsPoint endPoint() const { return mEndPoint; }
 
+    /**
+     * Returns the half-width of the cross section
+     * \since QGIS 4.0
+     */
     double halfWidth() const { return mHalfWidth; }
 
     /**

--- a/src/3d/qgscrosssection.h
+++ b/src/3d/qgscrosssection.h
@@ -38,9 +38,10 @@ class _3D_EXPORT QgsCrossSection
     //! Constructs a cross section defined by two points and a half-width
     QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double halfWidth );
 
-    /*Returns cross section validity.
-    * A valid cross section has distinct start and end points and a positive half-width.
-    */
+    /**
+     * Returns cross section validity.
+     * A valid cross section has distinct start and end points and a positive half-width.
+     */
     bool isValid() const;
 
     //! Returns the start point of the cross section

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -294,6 +294,9 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
   connect( mActionNudgeLeft, &QAction::triggered, this, &Qgs3DMapCanvasWidget::nudgeLeft );
   connect( mActionNudgeRight, &QAction::triggered, this, &Qgs3DMapCanvasWidget::nudgeRight );
 
+  createShortcuts( u"m3DCrossSectionNudgeLeft"_s, &Qgs3DMapCanvasWidget::nudgeLeft );
+  createShortcuts( u"m3DCrossSectionNudgeRight"_s, &Qgs3DMapCanvasWidget::nudgeRight );
+
   mCrossSectionMenu->addAction( mActionNudgeLeft );
   mCrossSectionMenu->addAction( mActionNudgeRight );
 

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -65,7 +65,7 @@
 #include "moc_qgs3dmapcanvaswidget.cpp"
 
 const QgsSettingsEntryDouble *Qgs3DMapCanvasWidget::settingClippingTolerance = new QgsSettingsEntryDouble( u"tolerance"_s, QgsSettingsTree::sTree3DMap, 100, u"Tolerance distance for 3D Map cross section"_s, Qgis::SettingsOptions(), 0 );
-const QgsSettingsEntryBool *Qgs3DMapCanvasWidget::settingDynamicClipping = new QgsSettingsEntryBool( u"cross-section-tolerance-locked"_s, QgsSettingsTree::sTree3DMap, true, u"Whether cross section tolerance is locked"_s );
+const QgsSettingsEntryBool *Qgs3DMapCanvasWidget::settingCrossSectionToleranceLocked = new QgsSettingsEntryBool( u"cross-section-tolerance-locked"_s, QgsSettingsTree::sTree3DMap, true, u"Whether cross section tolerance is locked"_s );
 
 
 Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1328,7 +1328,7 @@ void Qgs3DMapCanvasWidget::nudgeCurve( Qgis::BufferSide side )
   mCrossSectionRubberBand->setToGeometry( crossSection.asGeometry( &ct ) );
   mCanvas->enableCrossSection( false );
 
-  mCanvas->scene()->cameraController()->moveCenterPoint( QVector3D( cameraOffset.x(), cameraOffset.y(), 0 ) );
+  mCanvas->scene()->cameraController()->moveCenterPoint( QVector3D( static_cast<float>( cameraOffset.x() ), static_cast<float>( cameraOffset.y() ), 0 ) );
 }
 
 void Qgs3DMapCanvasWidget::updateClippingRubberBand()

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -134,7 +134,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     void setSceneExtentOn2DCanvas();
     void setSceneExtent( const QgsRectangle &extent );
     void setClippingPlanesOn2DCanvas();
-    void disableCrossSection() const;
+    void disableCrossSection();
 
     void onMainCanvasLayersChanged();
     void onMainCanvasColorChanged();

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -158,7 +158,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
   private:
     void updateCheckedActionsFromMapSettings( const Qgs3DMapSettings *mapSettings ) const;
     void setClippingTolerance( double tolerance );
-    void setCrossSectionRubberBandPolygonFromGeometry( const QgsGeometry &geom, const double width );
+    void setCrossSectionRubberBandPolygonFromGeometry( const QgsGeometry &geom, const double width, bool setSideView );
     void setDynamicCrossSectionClippingTolerance( bool enabled );
     void updateClippingRubberBand();
 

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -181,6 +181,9 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QAction *mActionUndo = nullptr;
     QAction *mActionRedo = nullptr;
     QAction *mEditingToolsAction = nullptr;
+    QAction *mActionNudgeLeft = nullptr;
+    QAction *mActionNudgeRight = nullptr;
+    QAction *mActionDynamicClipping = nullptr;
     QToolBar *mPointCloudEditingToolbar = nullptr;
     QgsDockableWidgetHelper *mDockableWidgetHelper = nullptr;
     QObjectUniquePtr<QgsRubberBand> mViewFrustumHighlight;
@@ -205,7 +208,23 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QAction *mSpinChangeAttributeValueAction = nullptr;
     QString mChangeAttributePointFilter;
 
+    Qgs3DMapClippingToleranceWidgetSettingsAction *mClippingToleranceAction = nullptr;
+    double mClippingTolerance = 0.0;
+
     QMenu *mToolbarMenu = nullptr;
+};
+
+class Qgs3DMapClippingToleranceWidgetSettingsAction : public QWidgetAction
+{
+    Q_OBJECT
+
+  public:
+    Qgs3DMapClippingToleranceWidgetSettingsAction( QWidget *parent = nullptr );
+
+    QgsDoubleSpinBox *toleranceSpinBox() { return mToleranceWidget; }
+
+  private:
+    QgsDoubleSpinBox *mToleranceWidget = nullptr;
 };
 
 #endif // QGS3DMAPCANVASWIDGET_H

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -232,7 +232,6 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QString mChangeAttributePointFilter;
 
     Qgs3DMapClippingToleranceWidgetSettingsAction *mClippingToleranceAction = nullptr;
-    double mClippingTolerance = 0.0;
 
     QMenu *mToolbarMenu = nullptr;
 };

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -79,7 +79,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
 
   public:
     static const QgsSettingsEntryDouble *settingClippingTolerance;
-    static const QgsSettingsEntryBool *settingDynamicClipping;
+    static const QgsSettingsEntryBool *settingCrossSectionToleranceLocked;
 
     Qgs3DMapCanvasWidget( const QString &name, bool isDocked );
     ~Qgs3DMapCanvasWidget() override;
@@ -153,13 +153,12 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
 
     void onPointCloudChangeAttributeSettingsChanged();
 
-    void onCrossSectionToolFinished( const QgsGeometry &geom, const double width );
+    void onCrossSectionToolFinished();
 
   private:
     void updateCheckedActionsFromMapSettings( const Qgs3DMapSettings *mapSettings ) const;
     void setClippingTolerance( double tolerance );
-    void setCrossSectionRubberBandPolygonFromGeometry( const QgsGeometry &geom, const double width, bool setSideView );
-    void setDynamicCrossSectionClippingTolerance( bool enabled );
+    void lockCrossSectionTolerance( bool enabled );
     void updateClippingRubberBand();
 
     QString mCanvasName;

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -26,6 +26,7 @@
 #include <QMenu>
 #include <QPointer>
 #include <QToolBar>
+#include <QToolButton>
 #include <QWidgetAction>
 
 #define SIP_NO_FILE
@@ -158,7 +159,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     void updateCheckedActionsFromMapSettings( const Qgs3DMapSettings *mapSettings ) const;
     void setClippingTolerance( double tolerance );
     void setCrossSectionRubberBandPolygonFromGeometry( const QgsGeometry &geom, const double width );
-    void setDynamicClipping( bool enabled );
+    void setDynamicCrossSectionClippingTolerance( bool enabled );
     void updateClippingRubberBand();
 
     QString mCanvasName;
@@ -181,6 +182,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QMenu *mExportMenu = nullptr;
     QMenu *mMapThemeMenu = nullptr;
     QMenu *mCameraMenu = nullptr;
+    QMenu *mCrossSectionMenu = nullptr;
     QMenu *mEffectsMenu = nullptr;
     QMenu *mEditingToolsMenu = nullptr;
     QList<QAction *> mMapThemeMenuPresetActions;
@@ -194,6 +196,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QAction *mActionExport = nullptr;
     QAction *mActionMapThemes = nullptr;
     QAction *mActionCamera = nullptr;
+    QAction *mActionCrossSection = nullptr;
     QAction *mActionEffects = nullptr;
     QAction *mActionSetSceneExtent = nullptr;
     QAction *mActionSetClippingPlanes = nullptr;
@@ -243,9 +246,14 @@ class Qgs3DMapClippingToleranceWidgetSettingsAction : public QWidgetAction
     Qgs3DMapClippingToleranceWidgetSettingsAction( QWidget *parent = nullptr );
 
     QgsDoubleSpinBox *toleranceSpinBox() { return mToleranceWidget; }
+    bool isLocked() const { return mLockButton && mLockButton->isChecked(); }
+
+  signals:
+    void lockStateChanged( bool locked );
 
   private:
     QgsDoubleSpinBox *mToleranceWidget = nullptr;
+    QToolButton *mLockButton = nullptr;
 };
 
 #endif // QGS3DMAPCANVASWIDGET_H

--- a/src/app/3d/qgsmaptoolclippingplanes.cpp
+++ b/src/app/3d/qgsmaptoolclippingplanes.cpp
@@ -117,7 +117,6 @@ void QgsMapToolClippingPlanes::canvasReleaseEvent( QgsMapMouseEvent *e )
   if ( e->button() == Qt::LeftButton )
   {
     const QgsPointXY point = toMapCoordinates( e->pos() );
-    // not a dynamic capture, we should return a line geometry
     if ( mRubberBandPoints->numberOfVertices() == 1 && !mToleranceLocked )
     {
       QgsPointXY pt0 = *mRubberBandPoints->getPoint( 0, 0 );
@@ -138,7 +137,6 @@ void QgsMapToolClippingPlanes::canvasReleaseEvent( QgsMapMouseEvent *e )
         QgsDebugError( u"Could not reproject cross section coordinates to 3d map crs."_s );
       }
     }
-    // dynamic capture, we return a polygon
     else if ( mRubberBandPoints->numberOfVertices() == 2 )
     {
       QgsPointXY pt0 = *mRubberBandPoints->getPoint( 0, 0 );
@@ -153,7 +151,6 @@ void QgsMapToolClippingPlanes::canvasReleaseEvent( QgsMapMouseEvent *e )
       }
       catch ( const QgsCsException & )
       {
-        crossSectionPolygon.set( nullptr );
         QgsDebugError( u"Could not reproject cross-section extent to 3d map canvas crs."_s );
         return;
       }

--- a/src/app/3d/qgsmaptoolclippingplanes.cpp
+++ b/src/app/3d/qgsmaptoolclippingplanes.cpp
@@ -22,6 +22,7 @@
 #include "qgs3dmapscene.h"
 #include "qgs3dutils.h"
 #include "qgscoordinatetransform.h"
+#include "qgscrosssection.h"
 #include "qgsmapcanvas.h"
 #include "qgsmapmouseevent.h"
 #include "qgspolygon.h"
@@ -88,20 +89,9 @@ void QgsMapToolClippingPlanes::canvasMoveEvent( QgsMapMouseEvent *e )
       const QgsPointXY endPointMap3d = mCt->transform( *mRubberBandPoints->getPoint( 0, 1 ) );
       const QgsPointXY widthPointMap3d = mCt->transform( point );
       mRectangleWidth = endPointMap3d.distance( widthPointMap3d );
-      QgsVector vec( endPointMap3d - startPointMap3d );
-      vec = vec.normalized().perpVector();
 
-      const QVector<QgsPointXY> points3DMap( {
-        startPointMap3d + vec * mRectangleWidth, //! top left corner
-        endPointMap3d + vec * mRectangleWidth,   //! top right corner
-        endPointMap3d - vec * mRectangleWidth,   //! bottom right corner
-        startPointMap3d - vec * mRectangleWidth  //! bottom left corner
-      } );
-
-      // build a polygon and transform it back to 2d map canvas coordinates
-      QgsGeometry geom( new QgsPolygon( new QgsLineString( points3DMap ) ) );
-      geom.transform( *mCt, Qgis::TransformDirection::Reverse );
-      mRubberBandPolygon->setToGeometry( geom );
+      QgsCrossSection crossSection( QgsPoint( startPointMap3d ), QgsPoint( endPointMap3d ), mRectangleWidth );
+      mRubberBandPolygon->setToGeometry( crossSection.asGeometry( mCt.get() ) );
     }
     catch ( const QgsCsException & )
     {
@@ -128,7 +118,7 @@ void QgsMapToolClippingPlanes::canvasReleaseEvent( QgsMapMouseEvent *e )
   {
     const QgsPointXY point = toMapCoordinates( e->pos() );
     // not a dynamic capture, we should return a line geometry
-    if ( mRubberBandPoints->numberOfVertices() == 1 && !mDynamicCapture )
+    if ( mRubberBandPoints->numberOfVertices() == 1 && !mToleranceLocked )
     {
       QgsPointXY pt0 = *mRubberBandPoints->getPoint( 0, 0 );
       QgsPointXY pt1 = point;
@@ -137,16 +127,11 @@ void QgsMapToolClippingPlanes::canvasReleaseEvent( QgsMapMouseEvent *e )
       {
         const QgsPointXY startPointMap3d = mCt->transform( pt0 );
         const QgsPointXY endPointMap3d = mCt->transform( pt1 );
-        QgsVector vec( endPointMap3d - startPointMap3d );
-        vec = vec.normalized().perpVector();
 
-        const QVector<QgsPointXY> points3DMap( { startPointMap3d + vec, endPointMap3d + vec } );
+        QgsCrossSection crossSection( QgsPoint( startPointMap3d ), QgsPoint( endPointMap3d ), 0.0 );
+        m3DCanvasWidget->mapCanvas3D()->setCrossSection( crossSection );
 
-        // build a geometry and transform it back to 2d map canvas coordinates
-        QgsGeometry geom( new QgsLineString( points3DMap ) );
-        geom.transform( *mCt, Qgis::TransformDirection::Reverse );
-
-        emit finishedSuccessfully( geom, 0 );
+        emit finishedSuccessfully();
       }
       catch ( const QgsCsException & )
       {
@@ -156,18 +141,24 @@ void QgsMapToolClippingPlanes::canvasReleaseEvent( QgsMapMouseEvent *e )
     // dynamic capture, we return a polygon
     else if ( mRubberBandPoints->numberOfVertices() == 2 )
     {
-      //check if cross-section is in canvas extents
-      QgsGeometry crossSectionPolygon = mRubberBandPolygon->asGeometry();
+      QgsPointXY pt0 = *mRubberBandPoints->getPoint( 0, 0 );
+      QgsPointXY pt1 = *mRubberBandPoints->getPoint( 0, 1 );
 
+      QgsCrossSection crossSection;
       try
       {
-        crossSectionPolygon.transform( *mCt );
+        pt0 = mCt->transform( pt0 );
+        pt1 = mCt->transform( pt1 );
+        crossSection = QgsCrossSection( QgsPoint( pt0 ), QgsPoint( pt1 ), mRectangleWidth );
       }
       catch ( const QgsCsException & )
       {
         crossSectionPolygon.set( nullptr );
         QgsDebugError( u"Could not reproject cross-section extent to 3d map canvas crs."_s );
+        return;
       }
+
+      QgsGeometry crossSectionPolygon = crossSection.asGeometry();
 
       if ( !crossSectionPolygon.intersects( m3DCanvasWidget->mapCanvas3D()->scene()->sceneExtent() ) )
       {
@@ -179,31 +170,8 @@ void QgsMapToolClippingPlanes::canvasReleaseEvent( QgsMapMouseEvent *e )
       }
       else
       {
-        QgsPointXY pt0 = *mRubberBandPoints->getPoint( 0, 0 );
-        QgsPointXY pt1 = *mRubberBandPoints->getPoint( 0, 1 );
-        try
-        {
-          pt0 = mCt->transform( pt0 );
-          pt1 = mCt->transform( pt1 );
-        }
-        catch ( const QgsCsException & )
-        {
-          emit messageEmitted( tr( "Could not reproject the cross-section extent to 3D map coordinates." ), Qgis::MessageLevel::Warning );
-        }
-
-        m3DCanvasWidget->mapCanvas3D()->enableCrossSection(
-          pt0,
-          pt1,
-          mRectangleWidth,
-          true
-        );
-
-        const QgsSettings settings;
-        QColor highlightColor = QColor( settings.value( u"Map/highlight/color"_s, Qgis::DEFAULT_HIGHLIGHT_COLOR.name() ).toString() );
-        highlightColor.setAlphaF( 0.5 );
-        mRubberBandPolygon->setColor( highlightColor );
-
-        emit finishedSuccessfully( geom, mRectangleWidth );
+        m3DCanvasWidget->mapCanvas3D()->setCrossSection( crossSection );
+        emit finishedSuccessfully();
       }
     }
     else
@@ -244,7 +212,7 @@ QgsGeometry QgsMapToolClippingPlanes::clippedPolygon() const
   return mRubberBandPolygon->asGeometry();
 }
 
-void QgsMapToolClippingPlanes::setDynamicCapture( const bool enable )
+void QgsMapToolClippingPlanes::setToleranceLocked( const bool enable )
 {
-  mDynamicCapture = enable;
+  mToleranceLocked = enable;
 }

--- a/src/app/3d/qgsmaptoolclippingplanes.h
+++ b/src/app/3d/qgsmaptoolclippingplanes.h
@@ -52,12 +52,12 @@ class QgsMapToolClippingPlanes : public QgsMapTool
     //! Returns the Geometry of clipped area
     QgsGeometry clippedPolygon() const;
     //! Sets the type of capture: dynamic requires third point, static required just two points
-    void setDynamicCapture( bool enable );
+    void setToleranceLocked( bool enable );
     //!Returns the current capture type, true for dynamic, false for static
-    bool isDynamicCapture() { return mDynamicCapture; }
+    bool isToleranceLocked() { return mToleranceLocked; }
 
   signals:
-    void finishedSuccessfully( const QgsGeometry &geom, const double width );
+    void finishedSuccessfully();
 
   private:
     void clearRubberBand() const;
@@ -67,7 +67,7 @@ class QgsMapToolClippingPlanes : public QgsMapTool
     QObjectUniquePtr<QgsRubberBand> mRubberBandPoints;
     std::unique_ptr<QgsCoordinateTransform> mCt;
     Qgs3DMapCanvasWidget *m3DCanvasWidget = nullptr;
-    bool mDynamicCapture = true;
+    bool mToleranceLocked = true;
     double mRectangleWidth = 0.0;
 };
 

--- a/src/app/3d/qgsmaptoolclippingplanes.h
+++ b/src/app/3d/qgsmaptoolclippingplanes.h
@@ -51,9 +51,13 @@ class QgsMapToolClippingPlanes : public QgsMapTool
     void clearHighLightedArea() const;
     //! Returns the Geometry of clipped area
     QgsGeometry clippedPolygon() const;
+    //! Sets the type of capture: dynamic requires third point, static required just two points
+    void setDynamicCapture( bool enable );
+    //!Returns the current capture type, true for dynamic, false for static
+    bool isDynamicCapture() { return mDynamicCapture; }
 
   signals:
-    void finishedSuccessfully();
+    void finishedSuccessfully( const QgsGeometry &geom, const double width );
 
   private:
     void clearRubberBand() const;
@@ -63,7 +67,8 @@ class QgsMapToolClippingPlanes : public QgsMapTool
     QObjectUniquePtr<QgsRubberBand> mRubberBandPoints;
     std::unique_ptr<QgsCoordinateTransform> mCt;
     Qgs3DMapCanvasWidget *m3DCanvasWidget = nullptr;
-    double mRectangleWidth = 0;
+    bool mDynamicCapture = true;
+    double mRectangleWidth = 0.0;
 };
 
 #endif //QGSMAPTOOLCLIPPINGPLANES_H

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1893,8 +1893,8 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
 
 #ifdef HAVE_3D
   registerShortcuts( u"Ctrl+Shift+E"_s, u"m3DSetSceneExtent"_s, tr( "Set 3D Scene Extent on 2D Map View" ) );
-  registerShortcuts( u"Ctrl+Shift+,"_s, u"m3DCrossSectionNudgeLeft"_s, tr( "Nudge 3D Cross section to the left" ) );
-  registerShortcuts( u"Ctrl+Shift+."_s, u"m3DCrossSectionNudgeRight"_s, tr( "Nudge 3D Cross section to the right" ) );
+  registerShortcuts( u"Ctrl+Shift+]"_s, u"m3DCrossSectionNudgeLeft"_s, tr( "Nudge 3D Cross section to the left" ) );
+  registerShortcuts( u"Ctrl+Shift+["_s, u"m3DCrossSectionNudgeRight"_s, tr( "Nudge 3D Cross section to the right" ) );
   connect( QgsProject::instance()->viewsManager(), &QgsMapViewsManager::views3DListChanged, this, &QgisApp::views3DMenuAboutToShow );
 
   Qgs3DMapScene::sOpenScenesFunction = [this]() -> QMap<QString, Qgs3DMapScene *> {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1893,6 +1893,8 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
 
 #ifdef HAVE_3D
   registerShortcuts( u"Ctrl+Shift+E"_s, u"m3DSetSceneExtent"_s, tr( "Set 3D Scene Extent on 2D Map View" ) );
+  registerShortcuts( u"Ctrl+Shift+,"_s, u"m3DCrossSectionNudgeLeft"_s, tr( "Nudge 3D Cross section to the left" ) );
+  registerShortcuts( u"Ctrl+Shift+."_s, u"m3DCrossSectionNudgeRight"_s, tr( "Nudge 3D Cross section to the right" ) );
   connect( QgsProject::instance()->viewsManager(), &QgsMapViewsManager::views3DListChanged, this, &QgisApp::views3DMenuAboutToShow );
 
   Qgs3DMapScene::sOpenScenesFunction = [this]() -> QMap<QString, Qgs3DMapScene *> {

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -68,6 +68,7 @@ class CORE_EXPORT QgsSettingsTree
     static inline QgsSettingsTreeNode *sTreeWindowState = sTreeGui->createChildNode( u"window-state"_s );
     static inline QgsSettingsTreeNode *sTreeAuthentication = treeRoot()->createChildNode( u"authentication"_s );
     static inline QgsSettingsTreeNode *sTreeDatabase = treeRoot()->createChildNode( u"database"_s );
+    static inline QgsSettingsTreeNode *sTree3DMap = treeRoot()->createChildNode( u"3dmap"_s );
 
 #endif
 


### PR DESCRIPTION
This PR implements cross section nudging in the similar way the elevation profile nudging works.

The user is able to set the tolerance (the width of the cross section) and nudging it left or right offsets the rubberband polygon and the cross section by that amount.

[Screencast_20251215_102832.webm](https://github.com/user-attachments/assets/d542cb23-dabf-41a4-87e0-7ed9251a34dc)

We are keeping the current functionality as it is, the user is still able to dynamically set the width of the polygon by drawing the third point on the canvas. 

The user is able to nudge the canvas rubberband polygon by pressing the nudge left/right buttons in the menu, or by using keyboard shortcuts (customizable from the shortcuts manager) when the menu is not being shown.
