### PR TITLE
qgsrubberband3d: Properly delete entities in the destructor

### DIFF
--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -80,7 +80,7 @@ QgsRubberBand3D::QgsRubberBand3D( Qgs3DMapSettings &map, QgsAbstract3DEngine *en
 
 void QgsRubberBand3D::setupMarker( Qt3DCore::QEntity *parentEntity )
 {
-  mMarkerEntity = new Qt3DCore::QEntity( parentEntity );
+  mMarkerEntity.reset( new Qt3DCore::QEntity( parentEntity ) );
   mMarkerGeometry = new QgsBillboardGeometry();
   mMarkerGeometryRenderer = new Qt3DRender::QGeometryRenderer;
   mMarkerGeometryRenderer->setPrimitiveType( Qt3DRender::QGeometryRenderer::Points );
@@ -97,7 +97,7 @@ void QgsRubberBand3D::setupMarker( Qt3DCore::QEntity *parentEntity )
 
 void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity, QgsAbstract3DEngine *engine )
 {
-  mLineEntity = new Qt3DCore::QEntity( parentEntity );
+  mLineEntity.reset( new Qt3DCore::QEntity( parentEntity ) );
 
   QgsLineVertexData dummyLineData;
   mLineGeometry = dummyLineData.createGeometry( mLineEntity );
@@ -132,7 +132,7 @@ void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity, QgsAbstract3DE
 
 void QgsRubberBand3D::setupPolygon( Qt3DCore::QEntity *parentEntity )
 {
-  mPolygonEntity = new Qt3DCore::QEntity( parentEntity );
+  mPolygonEntity.reset( new Qt3DCore::QEntity( parentEntity ) );
 
   mPolygonGeometry = new QgsTessellatedPolygonGeometry();
 
@@ -182,11 +182,17 @@ void QgsRubberBand3D::removePoint( int index )
 QgsRubberBand3D::~QgsRubberBand3D()
 {
   if ( mPolygonEntity )
-    delete mPolygonEntity;
+  {
+    mPolygonEntity.reset();
+  }
   if ( mLineEntity )
-    delete mLineEntity;
+  {
+    mLineEntity.reset();
+  }
   if ( mMarkerEntity )
-    delete mMarkerEntity;
+  {
+    mMarkerEntity.reset();
+  }
 }
 
 

--- a/src/3d/qgsrubberband3d.h
+++ b/src/3d/qgsrubberband3d.h
@@ -33,6 +33,7 @@
 #include "qgsgeometry.h"
 #include "qgspolygon.h"
 #include "qgstessellator.h"
+#include "qobjectuniqueptr.h"
 
 #include <QColor>
 
@@ -238,9 +239,9 @@ class _3D_EXPORT QgsRubberBand3D
     bool mEdgesEnabled = true;
     bool mPolygonFillEnabled = true;
 
-    Qt3DCore::QEntity *mLineEntity = nullptr;    // owned by parentEntity (from constructor)
-    Qt3DCore::QEntity *mPolygonEntity = nullptr; // owned by parentEntity (from constructor)
-    Qt3DCore::QEntity *mMarkerEntity = nullptr;  // owned by parentEntity (from constructor)
+    QObjectUniquePtr<Qt3DCore::QEntity> mLineEntity = nullptr;    // owned by parentEntity (from constructor)
+    QObjectUniquePtr<Qt3DCore::QEntity> mPolygonEntity = nullptr; // owned by parentEntity (from constructor)
+    QObjectUniquePtr<Qt3DCore::QEntity> mMarkerEntity = nullptr;  // owned by parentEntity (from constructor)
 
     QgsGeoTransform *mLineTransform = nullptr;
     QgsGeoTransform *mPolygonTransform = nullptr;


### PR DESCRIPTION
## Description

`mPolygonEntity`, `mLineEntity`, `mMarkerEntity` already have their own parent. This means that they are already deleted when their parent is deleted. Therefore, one cannot directly delete these entities in the rubberband destructor. Otherwise, one end up with a double delete.

This issue is fixed by removing the parent relation before deleting thes entities.

This fixes some crashes while using the 3d measure tool.
