### PR TITLE
QgsGeometryutils: Add support for 3d points in pointsAreCollinear

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsgeometryutils_base.py
+++ b/python/PyQt6/core/auto_additions/qgsgeometryutils_base.py
@@ -30,6 +30,7 @@ try:
     QgsGeometryUtilsBase.pointFractionAlongLine = staticmethod(QgsGeometryUtilsBase.pointFractionAlongLine)
     QgsGeometryUtilsBase.weightedPointInTriangle = staticmethod(QgsGeometryUtilsBase.weightedPointInTriangle)
     QgsGeometryUtilsBase.pointsAreCollinear = staticmethod(QgsGeometryUtilsBase.pointsAreCollinear)
+    QgsGeometryUtilsBase.points3DAreCollinear = staticmethod(QgsGeometryUtilsBase.points3DAreCollinear)
     QgsGeometryUtilsBase.angleBisector = staticmethod(QgsGeometryUtilsBase.angleBisector)
     QgsGeometryUtilsBase.bisector = staticmethod(QgsGeometryUtilsBase.bisector)
     QgsGeometryUtilsBase.lineIntersection = staticmethod(QgsGeometryUtilsBase.lineIntersection)

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -1372,6 +1372,26 @@ Applies fillet to a vertex in a curve geometry.
 %End
 
 
+    static bool pointsAreCollinear( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, double epsilon );
+%Docstring
+Checks if three points are collinear within a given tolerance.
+
+This function determines whether the points `pt1`, `pt2`, and `pt3` lie
+on the same straight line, considering a numerical tolerance `epsilon`.
+The function works only with 2D and 3D points. The measure component (if
+present) is ignored.
+
+:param pt1: The first point.
+:param pt2: The second point.
+:param pt3: The third point.
+:param epsilon: The tolerance used to account for floating-point
+                inaccuracies.
+
+:return: true if the points are collinear, false otherwise.
+
+.. versionadded:: 4.0
+%End
+
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
@@ -461,6 +461,15 @@ specified tolerance ``epsilon``.
 .. versionadded:: 3.32
 %End
 
+    static bool points3DAreCollinear( double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double epsilon );
+%Docstring
+Given the points (``x1``, ``y1``, ``z1``), (``x2``, ``y2``, ``z2``) and
+(``x3``, ``y3``, ``z3``) returns ``True`` if these points can be
+considered collinear with a specified tolerance ``epsilon``.
+
+.. versionadded:: 4.0
+%End
+
 
     static bool angleBisector( double aX, double aY, double bX, double bY, double cX, double cY, double dX, double dY,
                                double &pointX /Out/, double &pointY /Out/, double &angle /Out/ ) /HoldGIL/;

--- a/python/core/auto_additions/qgsgeometryutils_base.py
+++ b/python/core/auto_additions/qgsgeometryutils_base.py
@@ -30,6 +30,7 @@ try:
     QgsGeometryUtilsBase.pointFractionAlongLine = staticmethod(QgsGeometryUtilsBase.pointFractionAlongLine)
     QgsGeometryUtilsBase.weightedPointInTriangle = staticmethod(QgsGeometryUtilsBase.weightedPointInTriangle)
     QgsGeometryUtilsBase.pointsAreCollinear = staticmethod(QgsGeometryUtilsBase.pointsAreCollinear)
+    QgsGeometryUtilsBase.points3DAreCollinear = staticmethod(QgsGeometryUtilsBase.points3DAreCollinear)
     QgsGeometryUtilsBase.angleBisector = staticmethod(QgsGeometryUtilsBase.angleBisector)
     QgsGeometryUtilsBase.bisector = staticmethod(QgsGeometryUtilsBase.bisector)
     QgsGeometryUtilsBase.lineIntersection = staticmethod(QgsGeometryUtilsBase.lineIntersection)

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -1372,6 +1372,26 @@ Applies fillet to a vertex in a curve geometry.
 %End
 
 
+    static bool pointsAreCollinear( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, double epsilon );
+%Docstring
+Checks if three points are collinear within a given tolerance.
+
+This function determines whether the points `pt1`, `pt2`, and `pt3` lie
+on the same straight line, considering a numerical tolerance `epsilon`.
+The function works only with 2D and 3D points. The measure component (if
+present) is ignored.
+
+:param pt1: The first point.
+:param pt2: The second point.
+:param pt3: The third point.
+:param epsilon: The tolerance used to account for floating-point
+                inaccuracies.
+
+:return: true if the points are collinear, false otherwise.
+
+.. versionadded:: 4.0
+%End
+
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
@@ -461,6 +461,15 @@ specified tolerance ``epsilon``.
 .. versionadded:: 3.32
 %End
 
+    static bool points3DAreCollinear( double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double epsilon );
+%Docstring
+Given the points (``x1``, ``y1``, ``z1``), (``x2``, ``y2``, ``z2``) and
+(``x3``, ``y3``, ``z3``) returns ``True`` if these points can be
+considered collinear with a specified tolerance ``epsilon``.
+
+.. versionadded:: 4.0
+%End
+
 
     static bool angleBisector( double aX, double aY, double bX, double bY, double cX, double cY, double dX, double dY,
                                double &pointX /Out/, double &pointY /Out/, double &angle /Out/ ) /HoldGIL/;

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1739,3 +1739,15 @@ std::unique_ptr< QgsAbstractGeometry > QgsGeometryUtils::doChamferFilletOnVertex
 
   throw QgsInvalidArgumentException( "While generating output: curse is not a QgsLineString nor a QgsCompoundCurve." );
 }
+
+bool QgsGeometryUtils::pointsAreCollinear( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, double epsilon )
+{
+  if ( pt1.is3D() )
+  {
+    return QgsGeometryUtilsBase::points3DAreCollinear( pt1.x(), pt1.y(), pt1.z(), pt2.x(), pt2.y(), pt2.z(), pt3.x(), pt3.y(), pt3.z(), epsilon );
+  }
+  else
+  {
+    return QgsGeometryUtilsBase::pointsAreCollinear( pt1.x(), pt1.y(), pt2.x(), pt2.y(), pt3.x(), pt3.y(), epsilon );
+  }
+}

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -1450,6 +1450,23 @@ class CORE_EXPORT QgsGeometryUtils
                                    QgsPoint filletPoints[3],
                                    double epsilon = 1e-8 ) SIP_SKIP;
 
+    /**
+     * Checks if three points are collinear within a given tolerance.
+     *
+     * This function determines whether the points `pt1`, `pt2`, and `pt3` lie
+     * on the same straight line, considering a numerical tolerance `epsilon`.
+     * The function works only with 2D and 3D points. The measure component (if present) is ignored.
+     *
+     * \param pt1 The first point.
+     * \param pt2 The second point.
+     * \param pt3 The third point.
+     * \param epsilon The tolerance used to account for floating-point inaccuracies.
+     * \return true if the points are collinear, false otherwise.
+     *
+     * \since QGIS 4.0
+     */
+    static bool pointsAreCollinear( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, double epsilon );
+
   private:
 
     /**

--- a/src/core/geometry/qgsgeometryutils_base.cpp
+++ b/src/core/geometry/qgsgeometryutils_base.cpp
@@ -752,6 +752,17 @@ bool QgsGeometryUtilsBase::pointsAreCollinear( double x1, double y1, double x2, 
   return qgsDoubleNear( x1 * ( y2 - y3 ) + x2 * ( y3 - y1 ) + x3 * ( y1 - y2 ), 0, epsilon );
 };
 
+bool QgsGeometryUtilsBase::points3DAreCollinear( double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double epsilon )
+{
+  // crossproduct
+  const double cx = ( y2 - y1 ) * ( z3 - z1 ) - ( z2 - z1 ) * ( y3 - y1 );
+  const double cy = ( z2 - z1 ) * ( x3 - x1 ) - ( x2 - x1 ) * ( z3 - z1 );
+  const double cz = ( x2 - x1 ) * ( y3 - y1 ) - ( y2 - y1 ) * ( x3 - x1 );
+
+  // The magnitude of the cross product must be close to 0
+  return qgsDoubleNear( cx * cx + cy * cy + cz * cz, 0.0, epsilon * epsilon );
+}
+
 double QgsGeometryUtilsBase::azimuth( double x1, double y1, double x2, double y2 )
 {
   const double dx = x2 - x1;

--- a/src/core/geometry/qgsgeometryutils_base.h
+++ b/src/core/geometry/qgsgeometryutils_base.h
@@ -398,6 +398,14 @@ class CORE_EXPORT QgsGeometryUtilsBase
     static bool pointsAreCollinear( double x1, double y1, double x2, double y2, double x3, double y3, double epsilon );
 
     /**
+     * Given the points (\a x1, \a y1, \a z1), (\a x2, \a y2, \a z2) and (\a x3, \a y3, \a z3)
+     * returns TRUE if these points can be considered collinear with a specified tolerance \a epsilon.
+     *
+     * \since QGIS 4.0
+     */
+    static bool points3DAreCollinear( double x1, double y1, double z1, double x2, double y2, double z2, double x3, double y3, double z3, double epsilon );
+
+    /**
      * Returns the point (\a pointX, \a pointY) forming the bisector from segment (\a aX \a aY) (\a bX \a bY)
      * and segment (\a bX, \a bY) (\a dX, \a dY).
      * The bisector segment of AB-CD is (point, projection of point by \a angle)

--- a/tests/src/core/geometry/testqgsgeometryutils.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutils.cpp
@@ -93,6 +93,7 @@ class TestQgsGeometryUtils : public QObject
     void transferFirstMValueToPoint();
     void transferFirstZOrMValueToPoint_qgspointsequence();
     void transferFirstZOrMValueToPoint_qgsgeometry();
+    void testPointsAreCollinear();
 };
 
 
@@ -1963,6 +1964,26 @@ void TestQgsGeometryUtils::transferFirstZOrMValueToPoint_qgsgeometry()
   QCOMPARE( ret, true );
   QCOMPARE( point.z(), 3.0 );
   QCOMPARE( point.m(), 5.0 );
+}
+
+void TestQgsGeometryUtils::testPointsAreCollinear()
+{
+  // 2D version
+  QVERIFY( QgsGeometryUtils::pointsAreCollinear( QgsPoint( 0, 10 ), QgsPoint( 10, 10 ), QgsPoint( 20, 10 ), 0.00001 ) );
+  QVERIFY( QgsGeometryUtils::pointsAreCollinear( QgsPoint( 2, 3 ), QgsPoint( 2, 7 ), QgsPoint( 2, -5 ), 0.00001 ) );
+  QVERIFY( !QgsGeometryUtils::pointsAreCollinear( QgsPoint( 2, 3 ), QgsPoint( 4, 3 ), QgsPoint( 7, 2 ), 0.00001 ) );
+
+  // 3D version
+  QVERIFY( QgsGeometryUtils::pointsAreCollinear( QgsPoint( 0, 10, 0 ), QgsPoint( 10, 10, 0 ), QgsPoint( 20, 10, 0 ), 0.00001 ) );
+  QVERIFY( QgsGeometryUtils::pointsAreCollinear( QgsPoint( 0, 10, 2 ), QgsPoint( 10, 10, 2 ), QgsPoint( 20, 10, 2 ), 0.00001 ) );
+  QVERIFY( QgsGeometryUtils::pointsAreCollinear( QgsPoint( 2, 2, 2 ), QgsPoint( 2, 2, 3 ), QgsPoint( 2, 2, 5 ), 0.00001 ) );
+  QVERIFY( !QgsGeometryUtils::pointsAreCollinear( QgsPoint( 2, 2, 2 ), QgsPoint( 2, 2, 3 ), QgsPoint( 2, 3, 5 ), 0.00001 ) );
+
+  // Measure components are ignored
+  QVERIFY( QgsGeometryUtils::pointsAreCollinear( QgsPoint( 0, 10, 3, 3, Qgis::WkbType::PointM ), QgsPoint( 10, 10, 3, 3, Qgis::WkbType::PointM ), QgsPoint( 20, 10, 3, 3, Qgis::WkbType::PointM ), 0.00001 ) );
+  QVERIFY( !QgsGeometryUtils::pointsAreCollinear( QgsPoint( 2, 3, 2, 2, Qgis::WkbType::PointM ), QgsPoint( 4, 3, 2, 2, Qgis::WkbType::PointM ), QgsPoint( 7, 2, 2, 2, Qgis::WkbType::PointM ), 0.00001 ) );
+  QVERIFY( QgsGeometryUtils::pointsAreCollinear( QgsPoint( 0, 10, 0, 2 ), QgsPoint( 10, 10, 0, 17 ), QgsPoint( 20, 10, 0, 43 ), 0.00001 ) );
+  QVERIFY( !QgsGeometryUtils::pointsAreCollinear( QgsPoint( 2, 2, 2, 2 ), QgsPoint( 2, 2, 3, 2 ), QgsPoint( 2, 3, 5, 2 ), 0.00001 ) );
 }
 
 QGSTEST_MAIN( TestQgsGeometryUtils )

--- a/tests/src/core/geometry/testqgsgeometryutils.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutils.cpp
@@ -76,7 +76,6 @@ class TestQgsGeometryUtils : public QObject
     void testInterpolatePointOnLineByValue();
     void testPointOnLineWithDistance();
     void testPointFractionAlongLine();
-    void testPointsAreCollinear();
     void interpolatePointOnArc();
     void testSegmentizeArcHalfCircle();
     void testSegmentizeArcHalfCircleOtherDirection();
@@ -1383,20 +1382,6 @@ void TestQgsGeometryUtils::testPointFractionAlongLine()
   QGSCOMPARENEAR( QgsGeometryUtilsBase::pointFractionAlongLine( 0, 10, 20, 30, 20, 30 ), 1.0, 0.00001 );
   QGSCOMPARENEAR( QgsGeometryUtilsBase::pointFractionAlongLine( 0, 10, 20, 10, 10, 10 ), 0.5, 0.00001 );
   QGSCOMPARENEAR( QgsGeometryUtilsBase::pointFractionAlongLine( 40000.0, 40000.00001, 40000.00002, 40000.00001, 40000.00001, 40000.00001 ), 0.5, 0.0000002 );
-}
-
-void TestQgsGeometryUtils::testPointsAreCollinear()
-{
-  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 0, 10, 10, 10, 20, 10, 0.00001 ) );
-  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 10, 0, 10, 20, 10, 0.00001 ) );
-  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 20, 10, 10, 10, 0, 10, 0.00001 ) );
-  QVERIFY( !QgsGeometryUtilsBase::pointsAreCollinear( 20, 15, 10, 10, 0, 10, 0.00001 ) );
-  QVERIFY( !QgsGeometryUtilsBase::pointsAreCollinear( 20, 10, 10, 15, 0, 10, 0.00001 ) );
-  QVERIFY( !QgsGeometryUtilsBase::pointsAreCollinear( 20, 10, 10, 10, 0, 15, 0.00001 ) );
-  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 0, 10, 10, 10, 20, 0.00001 ) );
-  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 0, 10, 20, 10, 10, 0.00001 ) );
-  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 20, 10, 0, 10, 10, 0.00001 ) );
-  QVERIFY( !QgsGeometryUtilsBase::pointsAreCollinear( 15, 20, 10, 10, 10, 20, 0.00001 ) );
 }
 
 void TestQgsGeometryUtils::interpolatePointOnArc()

--- a/tests/src/core/geometry/testqgsgeometryutilsbase.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutilsbase.cpp
@@ -403,6 +403,7 @@ void TestQgsGeometryUtilsBase::testCreateFilletBase()
 
 void TestQgsGeometryUtilsBase::testPointsAreCollinear()
 {
+  // 2D version
   QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 0, 10, 10, 10, 20, 10, 0.00001 ) );
   QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 10, 0, 10, 20, 10, 0.00001 ) );
   QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 20, 10, 10, 10, 0, 10, 0.00001 ) );
@@ -413,6 +414,16 @@ void TestQgsGeometryUtilsBase::testPointsAreCollinear()
   QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 0, 10, 20, 10, 10, 0.00001 ) );
   QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 20, 10, 0, 10, 10, 0.00001 ) );
   QVERIFY( !QgsGeometryUtilsBase::pointsAreCollinear( 15, 20, 10, 10, 10, 20, 0.00001 ) );
+
+  // 3D version
+  QVERIFY( QgsGeometryUtilsBase::points3DAreCollinear( 0, 0, 0, 1, 1, 1, 2, 2, 2, 0.00001 ) );
+  QVERIFY( QgsGeometryUtilsBase::points3DAreCollinear( 1, 1, 1, 0, 0, 0, 2, 2, 2, 0.00001 ) );
+  QVERIFY( QgsGeometryUtilsBase::points3DAreCollinear( 2, 2, 2, 0, 0, 0, 1, 1, 1, 0.00001 ) );
+  QVERIFY( QgsGeometryUtilsBase::points3DAreCollinear( 0, 0, 0, 0, 0, 1, 0, 0, 2, 0.00001 ) );
+  QVERIFY( QgsGeometryUtilsBase::points3DAreCollinear( 0, 0, 1, 0, 0, 0, 0, 0, 2, 0.00001 ) );
+  QVERIFY( QgsGeometryUtilsBase::points3DAreCollinear( 0, 0, 2, 0, 0, 0, 0, 0, 1, 0.00001 ) );
+  QVERIFY( !QgsGeometryUtilsBase::points3DAreCollinear( 0, 0, 0, 1, 0, 0, 0, 1, 1, 0.00001 ) );
+  QVERIFY( !QgsGeometryUtilsBase::points3DAreCollinear( 1, 0, 0, 0, 0, 0, 0, 1, 1, 0.00001 ) );
 }
 
 QGSTEST_MAIN( TestQgsGeometryUtilsBase )

--- a/tests/src/core/geometry/testqgsgeometryutilsbase.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutilsbase.cpp
@@ -31,6 +31,7 @@ class TestQgsGeometryUtilsBase : public QObject
     void testCreateChamferBase();
     void testCreateFilletBase_data();
     void testCreateFilletBase();
+    void testPointsAreCollinear();
 };
 
 void TestQgsGeometryUtilsBase::testFuzzyEqual()
@@ -398,6 +399,20 @@ void TestQgsGeometryUtilsBase::testCreateFilletBase()
     QVERIFY2( qgsDoubleNear( dist2, calculatedRadius, 0.001 ), QString( "Distance from center to point 2: %1, should be %2" ).arg( dist2 ).arg( calculatedRadius ).toLatin1() );
     QVERIFY2( qgsDoubleNear( dist3, calculatedRadius, 0.001 ), QString( "Distance from center to point 3: %1, should be %2" ).arg( dist3 ).arg( calculatedRadius ).toLatin1() );
   }
+}
+
+void TestQgsGeometryUtilsBase::testPointsAreCollinear()
+{
+  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 0, 10, 10, 10, 20, 10, 0.00001 ) );
+  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 10, 0, 10, 20, 10, 0.00001 ) );
+  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 20, 10, 10, 10, 0, 10, 0.00001 ) );
+  QVERIFY( !QgsGeometryUtilsBase::pointsAreCollinear( 20, 15, 10, 10, 0, 10, 0.00001 ) );
+  QVERIFY( !QgsGeometryUtilsBase::pointsAreCollinear( 20, 10, 10, 15, 0, 10, 0.00001 ) );
+  QVERIFY( !QgsGeometryUtilsBase::pointsAreCollinear( 20, 10, 10, 10, 0, 15, 0.00001 ) );
+  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 0, 10, 10, 10, 20, 0.00001 ) );
+  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 0, 10, 20, 10, 10, 0.00001 ) );
+  QVERIFY( QgsGeometryUtilsBase::pointsAreCollinear( 10, 20, 10, 0, 10, 10, 0.00001 ) );
+  QVERIFY( !QgsGeometryUtilsBase::pointsAreCollinear( 15, 20, 10, 10, 10, 20, 0.00001 ) );
 }
 
 QGSTEST_MAIN( TestQgsGeometryUtilsBase )


### PR DESCRIPTION
## Description

The existing `QgsGeometryUtilsBase::pointsAreCollinear` only works for 2D points. This PR introduces: 
-  `QgsGeometryUtilsBase::points3DAreCollinear`, which works for 3D points
- `QgsGeometryUtils::pointsAreCollinear` which works for 2D and 3D points and calls the corresponding `QgsGeometryUtilsBase` function

**Funded by Stadt Frankfurt am Main**