### PR TITLE
[themes] Fix text color for disabled QHeaderView for dark themes

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -1100,20 +1100,21 @@ QTableView QTableCornerButton::section {
 }
 
 QHeaderView {
-    background-color:transparent;
-    border:0;
+    background-color: transparent;
+    border: 0;
+    color: @text;
 }
 
 QHeaderView:disabled {
-    background-color:transparent;
-    border:0;
+    background-color: transparent;
+    border: 0;
+    color: @itemdarkbackground;
 }
 
 QHeaderView::section, QHeaderView::section:vertical {
     padding: 0.1m 0.2em 0.1em 0.2em;
     background: transparent;
     background-color: @background;
-    color: @text;
     border: 1px solid @itemdarkbackground;
     border-left: 0;
     border-top: 0;

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1183,20 +1183,21 @@ QTableView QTableCornerButton::section {
 }
 
 QHeaderView {
-    background-color:transparent;
-    border:0;
+    background-color: transparent;
+    border: 0;
+    color: @text;
 }
 
 QHeaderView:disabled {
-    background-color:transparent;
-    border:0;
+    background-color: transparent;
+    border: 0;
+    color: @itemdarkbackground;
 }
 
 QHeaderView::section, QHeaderView::section:vertical {
     padding: 0.1m 0.2em 0.1em 0.2em;
     background: transparent;
     background-color: @background;
-    color: @text;
     border: 1px solid @itemdarkbackground;
     border-left: 0;
     border-top: 0;


### PR DESCRIPTION
Fix the text color for disabled `QHeaderView` sections for dark themes.

In the stylesheets, I moved the text color property from the `QHeaderView::section`-selector to the `QHeaderView`-selector to avoid adding a new QSS rule for disabled sections.

#### Examples
| Before | After |
:----:|:---:
| ![header_view_opacity_before](https://github.com/user-attachments/assets/9aabcada-1a79-466c-a195-284d1a796749) | ![header_view_opacity_after](https://github.com/user-attachments/assets/4c7763de-8dd4-42c9-be09-e1741bc72f2f) |
| ![layer_legend_settings_before](https://github.com/user-attachments/assets/869f883a-6a79-46f1-8567-9d429d4743e6) | ![layer_legend_settings_after](https://github.com/user-attachments/assets/2a397054-877c-4eb2-99ef-5cbbbb349b06) |



The same changes are applied to the *Blend of Gray* theme. They can be backported to the 3.44-branch.
