### PR TITLE
[FEATURE] QgsRasterFileWriter/QgsRasterLayerSaveAsDialog: handle COG (GDAL >= 3.13.0)

### DIFF
--- a/python/PyQt6/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -86,6 +86,9 @@ QGIS 3.16 creation flags are specified within the ``flags`` value.
     virtual QgsRasterDataProvider *clone() const = 0;
 
 
+
+
+
     virtual Qgis::RasterProviderCapabilities providerCapabilities() const;
 %Docstring
 Returns flags containing the supported capabilities of the data

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterfilewriter.sip.in
@@ -199,7 +199,7 @@ Returns the pyramid building option.
 .. seealso:: :py:func:`setBuildPyramidsFlag`
 %End
 
-    void setBuildPyramidsFlag( Qgis::RasterBuildPyramidOption f );
+    void setBuildPyramidsFlag( Qgis::RasterBuildPyramidOption flag );
 %Docstring
 Sets the pyramid building option.
 

--- a/python/PyQt6/gui/auto_generated/qgsrasterpyramidsoptionswidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsrasterpyramidsoptionswidget.sip.in
@@ -39,6 +39,13 @@ Returns the selected pyramid format.
     void setRasterLayer( QgsRasterLayer *rasterLayer );
     void setRasterFileName( const QString &file );
 
+    void tuneForFormat( const QString &driverName );
+%Docstring
+Tune settings of the widget for the given format (in particular for COG)
+
+.. versionadded:: 4.0
+%End
+
   public slots:
 
     void apply();

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -86,6 +86,9 @@ QGIS 3.16 creation flags are specified within the ``flags`` value.
     virtual QgsRasterDataProvider *clone() const = 0;
 
 
+
+
+
     virtual Qgis::RasterProviderCapabilities providerCapabilities() const;
 %Docstring
 Returns flags containing the supported capabilities of the data

--- a/python/core/auto_generated/raster/qgsrasterfilewriter.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterfilewriter.sip.in
@@ -199,7 +199,7 @@ Returns the pyramid building option.
 .. seealso:: :py:func:`setBuildPyramidsFlag`
 %End
 
-    void setBuildPyramidsFlag( Qgis::RasterBuildPyramidOption f );
+    void setBuildPyramidsFlag( Qgis::RasterBuildPyramidOption flag );
 %Docstring
 Sets the pyramid building option.
 

--- a/python/gui/auto_generated/qgsrasterpyramidsoptionswidget.sip.in
+++ b/python/gui/auto_generated/qgsrasterpyramidsoptionswidget.sip.in
@@ -39,6 +39,13 @@ Returns the selected pyramid format.
     void setRasterLayer( QgsRasterLayer *rasterLayer );
     void setRasterFileName( const QString &file );
 
+    void tuneForFormat( const QString &driverName );
+%Docstring
+Tune settings of the widget for the given format (in particular for COG)
+
+.. versionadded:: 4.0
+%End
+
   public slots:
 
     void apply();

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2365,7 +2365,12 @@ QString QgsGdalProvider::buildPyramids( const QList<QgsRasterPyramid> &rasterPyr
                                   0, nullptr,
                                   progressCallback, &myProg ); //this is the arg for the gdal progress callback
 
-    if ( ( feedback && feedback->isCanceled() ) || myError == CE_Failure || CPLGetLastErrorNo() == CPLE_NotSupported )
+    if ( ( feedback && feedback->isCanceled() ) ||
+         myError == CE_Failure ||
+         ( CPLGetLastErrorNo() == CPLE_NotSupported &&
+           // GDAL 3.12.0 wrongly sets a SPARSE_OK option internally
+           // which causes a harmless warning to be emitted
+           !( format == Qgis::RasterPyramidFormat::Erdas && strstr( CPLGetLastErrorMsg(), "SPARSE_OK" ) != nullptr ) ) )
     {
       QgsDebugError( u"Building pyramids failed using resampling method [%1]"_s.arg( method ) );
       //something bad happenend

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -4155,7 +4155,7 @@ QgsGdalProvider *QgsGdalProviderMetadata::createRasterDataProvider(
   }
   if ( !GDALGetMetadataItem( driver, GDAL_DCAP_CREATE, nullptr ) )
   {
-    QgsError error( "GDAL driver " + format + " does not implement the Create interface", QStringLiteral( "GDAL provider" ) );
+    QgsError error( "GDAL driver " + format + " does not implement the Create interface", u"GDAL provider"_s );
     return new QgsGdalProvider( uri, error );
   }
 

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -476,8 +476,9 @@ bool QgsGdalProvider::hasReportsDuringClose() const
 bool QgsGdalProvider::closeWithProgress( [[maybe_unused]] QgsFeedback *feedback )
 {
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,13,0)
-  if ( !mValid )
+  if ( !mValid || mInClosing )
     return false;
+  mInClosing = true;
   QgsGdalProgress progress;
   progress.feedback = feedback;
   return GDALDatasetRunCloseWithoutDestroyingEx( mGdalDataset, progressCallback, &progress ) == CE_None;
@@ -508,6 +509,8 @@ void QgsGdalProvider::closeDataset()
 
 void QgsGdalProvider::reloadProviderData()
 {
+  if ( mInClosing )
+    return;
   QMutexLocker locker( mpMutex );
   invalidateNetworkCache();
   closeDataset();
@@ -518,6 +521,9 @@ void QgsGdalProvider::reloadProviderData()
 
 void QgsGdalProvider::loadMetadata()
 {
+  if ( mInClosing )
+    return;
+
   // Set default, may be overridden by stored metadata
   mLayerMetadata.setCrs( crs() );
 
@@ -543,6 +549,9 @@ void QgsGdalProvider::loadMetadata()
 
 QString QgsGdalProvider::htmlMetadata() const
 {
+  if ( mInClosing )
+    return QString();
+
   QMutexLocker locker( mpMutex );
   if ( !const_cast< QgsGdalProvider * >( this )->initIfNeeded() )
     return QString();
@@ -675,6 +684,9 @@ QString QgsGdalProvider::htmlMetadata() const
 
 QString QgsGdalProvider::bandDescription( int bandNumber )
 {
+  if ( mInClosing )
+    return QString();
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return QString();
@@ -705,6 +717,8 @@ QString QgsGdalProvider::bandDescription( int bandNumber )
 QgsRasterBlock *QgsGdalProvider::block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback )
 {
   auto block = std::make_unique< QgsRasterBlock >( dataType( bandNo ), width, height );
+  if ( mInClosing )
+    return block.release();
   if ( !initIfNeeded() )
     return block.release();
   if ( sourceHasNoDataValue( bandNo ) && useSourceNoDataValue( bandNo ) )
@@ -745,6 +759,8 @@ QgsRasterBlock *QgsGdalProvider::block( int bandNo, const QgsRectangle &extent, 
 
 bool QgsGdalProvider::readBlock( int bandNo, int xBlock, int yBlock, void *data )
 {
+  if ( mInClosing )
+    return false;
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return false;
@@ -776,6 +792,9 @@ bool QgsGdalProvider::canDoResampling(
   int bufferWidthPix,
   int bufferHeightPix )
 {
+  if ( mInClosing )
+    return false;
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return false;
@@ -879,6 +898,9 @@ static GDALRIOResampleAlg getGDALResamplingAlg( Qgis::RasterResamplingMethod met
 
 bool QgsGdalProvider::readBlock( int bandNo, QgsRectangle  const &reqExtent, int bufferWidthPix, int bufferHeightPix, void *data, QgsRasterBlockFeedback *feedback )
 {
+  if ( mInClosing )
+    return false;
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return false;
@@ -1286,6 +1308,9 @@ bool QgsGdalProvider::readBlock( int bandNo, QgsRectangle  const &reqExtent, int
  */
 QList<QgsColorRampShader::ColorRampItem> QgsGdalProvider::colorTable( int bandNumber )const
 {
+  if ( mInClosing )
+    return QList<QgsColorRampShader::ColorRampItem>();
+
   QMutexLocker locker( mpMutex );
   if ( !const_cast<QgsGdalProvider *>( this )->initIfNeeded() )
     return QList<QgsColorRampShader::ColorRampItem>();
@@ -1320,6 +1345,9 @@ int QgsGdalProvider::ySize() const { return mHeight; }
 
 QString QgsGdalProvider::generateBandName( int bandNumber ) const
 {
+  if ( mInClosing )
+    return QString();
+
   QMutexLocker locker( mpMutex );
   if ( !const_cast<QgsGdalProvider *>( this )->initIfNeeded() )
     return QString();
@@ -1404,6 +1432,9 @@ QgsLayerMetadata QgsGdalProvider::layerMetadata() const
 
 QgsRasterIdentifyResult QgsGdalProvider::identify( const QgsPointXY &point, Qgis::RasterIdentifyFormat format, const QgsRectangle &boundingBox, int width, int height, int /*dpi*/ )
 {
+  if ( mInClosing )
+    return QgsRasterIdentifyResult( ERR( tr( "Cannot read data" ) ) );
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return QgsRasterIdentifyResult( ERR( tr( "Cannot read data" ) ) );
@@ -1516,6 +1547,9 @@ double QgsGdalProvider::sample( const QgsPointXY &point, int band, bool *ok, con
 {
   if ( ok )
     *ok = false;
+
+  if ( mInClosing )
+    return std::numeric_limits<double>::quiet_NaN();
 
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
@@ -1681,6 +1715,9 @@ double QgsGdalProvider::sample( const QgsPointXY &point, int band, bool *ok, con
 
 Qgis::RasterInterfaceCapabilities QgsGdalProvider::capabilities() const
 {
+  if ( mInClosing )
+    return Qgis::RasterInterfaceCapabilities();
+
   QMutexLocker locker( mpMutex );
   if ( !const_cast<QgsGdalProvider *>( this )->initIfNeeded() )
     return Qgis::RasterInterfaceCapabilities();
@@ -1699,6 +1736,9 @@ Qgis::RasterInterfaceCapabilities QgsGdalProvider::capabilities() const
 
 Qgis::DataType QgsGdalProvider::sourceDataType( int bandNo ) const
 {
+  if ( mInClosing )
+    return dataTypeFromGdal( GDT_Byte );
+
   QMutexLocker locker( mpMutex );
   if ( !const_cast<QgsGdalProvider *>( this )->initIfNeeded() )
     return dataTypeFromGdal( GDT_Byte );
@@ -1756,6 +1796,9 @@ Qgis::DataType QgsGdalProvider::dataType( int bandNo ) const
 
 double QgsGdalProvider::bandScale( int bandNo ) const
 {
+  if ( mInClosing )
+    return 1.0;
+
   QMutexLocker locker( mpMutex );
   if ( !const_cast<QgsGdalProvider *>( this )->initIfNeeded() )
     return 1.0;
@@ -1773,6 +1816,9 @@ double QgsGdalProvider::bandScale( int bandNo ) const
 
 double QgsGdalProvider::bandOffset( int bandNo ) const
 {
+  if ( mInClosing )
+    return 0.0;
+
   QMutexLocker locker( mpMutex );
   if ( !const_cast<QgsGdalProvider *>( this )->initIfNeeded() )
     return 0.0;
@@ -1800,6 +1846,9 @@ int QgsGdalProvider::bandCount() const
 
 Qgis::RasterColorInterpretation QgsGdalProvider::colorInterpretation( int bandNo ) const
 {
+  if ( mInClosing )
+    return colorInterpretationFromGdal( GCI_Undefined );
+
   QMutexLocker locker( mpMutex );
   if ( !const_cast<QgsGdalProvider *>( this )->initIfNeeded() )
     return colorInterpretationFromGdal( GCI_Undefined );
@@ -1971,6 +2020,9 @@ bool QgsGdalProvider::hasHistogram( int bandNo,
                                     int sampleSize,
                                     bool includeOutOfRange )
 {
+  if ( mInClosing )
+    return false;
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return false;
@@ -2059,6 +2111,9 @@ QgsRasterHistogram QgsGdalProvider::histogram( int bandNo,
     int sampleSize,
     bool includeOutOfRange, QgsRasterBlockFeedback *feedback )
 {
+  if ( mInClosing )
+    return QgsRasterHistogram();
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return QgsRasterHistogram();
@@ -2219,6 +2274,9 @@ QString QgsGdalProvider::buildPyramids( const QList<QgsRasterPyramid> &rasterPyr
                                         const QString &resamplingMethod, Qgis::RasterPyramidFormat format,
                                         const QStringList &configOptions, QgsRasterBlockFeedback *feedback )
 {
+  if ( mInClosing )
+    return QString();
+
   QMutexLocker locker( mpMutex );
 
   //TODO: Consider making rasterPyramidList modifiable by this method to indicate if the pyramid exists after build attempt
@@ -2517,6 +2575,9 @@ QList<QgsRasterPyramid> QgsGdalProvider::buildPyramidList()
 
 QList<QgsRasterPyramid> QgsGdalProvider::buildPyramidList( const QList<int> &list )
 {
+  if ( mInClosing )
+    return  QList<QgsRasterPyramid>();
+
   QList< int > overviewList = list;
   QMutexLocker locker( mpMutex );
 
@@ -3071,6 +3132,9 @@ bool QgsGdalProvider::hasStatistics( int bandNo,
                                      const QgsRectangle &boundingBox,
                                      int sampleSize )
 {
+  if ( mInClosing )
+    return false;
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return false;
@@ -3154,6 +3218,9 @@ bool QgsGdalProvider::hasStatistics( int bandNo,
 
 QgsRasterBandStats QgsGdalProvider::bandStatistics( int bandNo, Qgis::RasterBandStatistics stats, const QgsRectangle &boundingBox, int sampleSize, QgsRasterBlockFeedback *feedback )
 {
+  if ( mInClosing )
+    return QgsRasterBandStats();
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return QgsRasterBandStats();
@@ -3374,6 +3441,9 @@ static void sanitizeVRTFile( QString const &fileName )
 }
 bool QgsGdalProvider::initIfNeeded()
 {
+  if ( mInClosing )
+    return false;
+
   if ( mHasInit )
     return mValid;
 
@@ -3591,6 +3661,9 @@ bool QgsGdalProvider::readNativeAttributeTable( QString *errorMessage )
 
 bool QgsGdalProvider::writeNativeAttributeTable( QString *errorMessage ) //#spellok
 {
+  if ( mInClosing )
+    return false;
+
   bool success { false };
   bool wasReopenedReadWrite { false };
   for ( int band = 1; band <= bandCount(); band++ )
@@ -3711,6 +3784,9 @@ bool QgsGdalProvider::writeNativeAttributeTable( QString *errorMessage ) //#spel
 
 void QgsGdalProvider::initBaseDataset()
 {
+  if ( mInClosing )
+    return;
+
   mDriverName = GDALGetDriverShortName( GDALGetDatasetDriver( mGdalBaseDataset ) );
   mHasInit = true;
   mValid = true;
@@ -4106,6 +4182,9 @@ QgsGdalProvider *QgsGdalProviderMetadata::createRasterDataProvider(
 
 bool QgsGdalProvider::write( const void *data, int band, int width, int height, int xOffset, int yOffset )
 {
+  if ( mInClosing )
+    return false;
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return false;
@@ -4138,6 +4217,9 @@ bool QgsGdalProvider::write( const void *data, int band, int width, int height, 
 
 bool QgsGdalProvider::setNoDataValue( int bandNo, double noDataValue )
 {
+  if ( mInClosing )
+    return false;
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return false;
@@ -4352,6 +4434,9 @@ bool QgsGdalProvider::isEditable() const
 
 bool QgsGdalProvider::setEditable( bool enabled )
 {
+  if ( mInClosing )
+    return false;
+
   QMutexLocker locker( mpMutex );
   if ( !initIfNeeded() )
     return false;
@@ -4392,6 +4477,9 @@ bool QgsGdalProvider::setEditable( bool enabled )
 
 GDALRasterBandH QgsGdalProvider::getBand( int bandNo ) const
 {
+  if ( mInClosing )
+    return nullptr;
+
   QMutexLocker locker( mpMutex );
   if ( !const_cast<QgsGdalProvider *>( this )->initIfNeeded() )
     return nullptr;

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -82,6 +82,10 @@ class QgsGdalProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
 
     ~QgsGdalProvider() override;
 
+    bool hasReportsDuringClose() const override;
+
+    bool closeWithProgress( QgsFeedback *feedback ) override;
+
     /**
      * Gets the data source specification. This may be a path or a protocol
      * connection string

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -277,6 +277,9 @@ class QgsGdalProvider final: public QgsRasterDataProvider, QgsGdalProviderBase
     //! \brief Whether this raster has overviews / pyramids or not
     bool mHasPyramids = false;
 
+    //! Flag indicating if the dataset is in closing
+    bool mInClosing = false;
+
     /**
      * \brief Gdal data types used to represent data in in QGIS,
      * may be longer than source data type to keep nulls

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -1062,4 +1062,15 @@ QString QgsRasterDataProvider::encodeVirtualRasterProviderUri( const VirtualRast
   return QString( QUrl::toPercentEncoding( uri.toEncoded() ) );
 }
 
+bool QgsRasterDataProvider::hasReportsDuringClose() const
+{
+  return false;
+}
+
+bool QgsRasterDataProvider::closeWithProgress( QgsFeedback * /* feedback */ )
+{
+  return false;
+}
+
+
 #undef ERR

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -107,6 +107,31 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
 
     QgsRasterDataProvider *clone() const override = 0;
 
+
+    /**
+     * Returns whether closeWithProgress() will actually report closing progress.
+     *
+     * \since QGIS 4.0
+     */
+    virtual bool hasReportsDuringClose() const SIP_SKIP;
+
+    /**
+     * Close the provider with feedback.
+     *
+     * Only implemented at time of writing for GDAL COG driver in GDAL >= 3.13.
+     * For other providers/drivers, this method does nothing.
+     *
+     * Use with great caution. After that method has been called, the only valid
+     * action on the provider is to destroy it. Other method calls will likely
+     * result in a crash.
+     *
+     * \param feedback Feedback object on which to report the progress, or nullptr.
+     * \returns true if the closing was successful.
+     *
+     * \since QGIS 4.0
+     */
+    virtual bool closeWithProgress( QgsFeedback *feedback ) SIP_SKIP;
+
     /**
      * Returns flags containing the supported capabilities of the data provider.
      */

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -477,7 +477,7 @@ Qgis::RasterFileWriterResult QgsRasterFileWriter::writeDataRaster( const QgsRast
         {
           if ( mBuildPyramidsFlag == Qgis::RasterBuildPyramidOption::Yes &&
                // Pyramid creation is done by the driver itself
-               mOutputFormat != QLatin1String( "COG" ) )
+               mOutputFormat != "COG"_L1 )
           {
             if ( !buildPyramids( mOutputUrl, destProvider.get() ) )
             {
@@ -815,7 +815,7 @@ Qgis::RasterFileWriterResult QgsRasterFileWriter::writeImageRaster( QgsRasterIte
 
     if ( mBuildPyramidsFlag == Qgis::RasterBuildPyramidOption::Yes &&
          // Pyramid creation is done by the driver itself
-         mOutputFormat != QLatin1String( "COG" ) )
+         mOutputFormat != "COG"_L1 )
     {
       if ( !buildPyramids( mOutputUrl ) )
         return Qgis::RasterFileWriterResult::WriteError;
@@ -1083,7 +1083,7 @@ QgsRasterDataProvider *QgsRasterFileWriter::createPartProvider( const QgsRectang
 void QgsRasterFileWriter::setOutputFormat( const QString &format )
 {
   mOutputFormat = format;
-  if ( !mBuildPyramidsFlagSet && format == QLatin1String( "COG" ) )
+  if ( !mBuildPyramidsFlagSet && format == "COG"_L1 )
   {
     setBuildPyramidsFlag( Qgis::RasterBuildPyramidOption::Yes );
   }
@@ -1113,13 +1113,13 @@ QgsRasterDataProvider *QgsRasterFileWriter::initOutput( int nCols, int nRows, co
       mCreationOptions << "COPY_SRC_OVERVIEWS=YES";
 #endif
     QStringList creationOptions( mCreationOptions );
-    if ( mOutputFormat == QLatin1String( "COG" ) )
+    if ( mOutputFormat == "COG"_L1 )
     {
       if ( mBuildPyramidsFlag == Qgis::RasterBuildPyramidOption::No )
-        creationOptions << QStringLiteral( "OVERVIEWS=NO" );
+        creationOptions << u"OVERVIEWS=NO"_s;
       else
       {
-        creationOptions << QStringLiteral( "OVERVIEW_RESAMPLING=" ) + mPyramidsResampling;
+        creationOptions << u"OVERVIEW_RESAMPLING="_s + mPyramidsResampling;
         for ( const QString &opt : std::as_const( mPyramidsConfigOptions ) )
         {
           const std::string optStr( opt.toStdString() );
@@ -1129,15 +1129,15 @@ QgsRasterDataProvider *QgsRasterFileWriter::initOutput( int nCols, int nRows, co
           {
             if ( EQUAL( key, "JPEG_QUALITY_OVERVIEW" ) )
             {
-              creationOptions << QStringLiteral( "OVERVIEW_QUALITY=" ) + value;
+              creationOptions << u"OVERVIEW_QUALITY="_s + value;
             }
             else if ( EQUAL( key, "COMPRESS_OVERVIEW" ) )
             {
-              creationOptions << QStringLiteral( "OVERVIEW_COMPRESS=" ) + value;
+              creationOptions << u"OVERVIEW_COMPRESS="_s + value;
             }
             else if ( EQUAL( key, "PREDICTOR_OVERVIEW" ) )
             {
-              creationOptions << QStringLiteral( "OVERVIEW_PREDICTOR=" ) + value;
+              creationOptions << u"OVERVIEW_PREDICTOR="_s + value;
             }
           }
           CPLFree( key );

--- a/src/core/raster/qgsrasterfilewriter.h
+++ b/src/core/raster/qgsrasterfilewriter.h
@@ -378,7 +378,8 @@ class CORE_EXPORT QgsRasterFileWriter
         Qgis::DataType destDataType,
         const QList<bool> &destHasNoDataValueList,
         const QList<double> &destNoDataValueList,
-        QgsRasterDataProvider *destProvider,
+        // This method can nullify the passed destProvider
+        std::unique_ptr<QgsRasterDataProvider> &destProvider,
         QgsRasterBlockFeedback *feedback = nullptr );
 
     Qgis::RasterFileWriterResult writeImageRaster( QgsRasterIterator *iter, int nCols, int nRows, const QgsRectangle &outputExtent,

--- a/src/core/raster/qgsrasterfilewriter.h
+++ b/src/core/raster/qgsrasterfilewriter.h
@@ -401,7 +401,7 @@ class CORE_EXPORT QgsRasterFileWriter
     bool writeVRT( const QString &file );
     //add file entry to vrt
     void addToVRT( const QString &filename, int band, int xSize, int ySize, int xOffset, int yOffset );
-    void buildPyramids( const QString &filename, QgsRasterDataProvider *destProviderIn = nullptr );
+    bool buildPyramids( const QString &filename, QgsRasterDataProvider *destProviderIn = nullptr );
 
     //! Create provider and datasource for a part image (vrt mode)
     QgsRasterDataProvider *createPartProvider( const QgsRectangle &extent, int nCols, int iterCols, int iterRows,

--- a/src/core/raster/qgsrasterfilewriter.h
+++ b/src/core/raster/qgsrasterfilewriter.h
@@ -123,7 +123,7 @@ class CORE_EXPORT QgsRasterFileWriter
      *
      * \see outputFormat()
      */
-    void setOutputFormat( const QString &format ) { mOutputFormat = format; }
+    void setOutputFormat( const QString &format );
 
     /**
      * Returns the output format.
@@ -197,7 +197,7 @@ class CORE_EXPORT QgsRasterFileWriter
      *
      * \see buildPyramidsFlag()
      */
-    void setBuildPyramidsFlag( Qgis::RasterBuildPyramidOption f ) { mBuildPyramidsFlag = f; }
+    void setBuildPyramidsFlag( Qgis::RasterBuildPyramidOption flag );
 
     /**
      * Returns the list of pyramids which will be created for the output file.
@@ -445,6 +445,7 @@ class CORE_EXPORT QgsRasterFileWriter
 
     QList< int > mPyramidsList;
     QString mPyramidsResampling = u"AVERAGE"_s;
+    bool mBuildPyramidsFlagSet = false;
     Qgis::RasterBuildPyramidOption mBuildPyramidsFlag = Qgis::RasterBuildPyramidOption::No;
     Qgis::RasterPyramidFormat mPyramidsFormat = Qgis::RasterPyramidFormat::GeoTiff;
     QStringList mPyramidsConfigOptions;

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -350,6 +350,15 @@ void QgsRasterLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( const QStr
   {
     mLayerName->setText( QString() );
   }
+
+  const bool isCOG = ( outputFormat() == QLatin1String( "COG" ) );
+  if ( isCOG )
+  {
+    mPyramidsGroupBox->setChecked( true );
+  }
+  mPyramidResolutionsLabel->setVisible( !isCOG );
+  mPyramidResolutionsLineEdit->setVisible( !isCOG );
+  mPyramidsOptionsWidget->tuneForFormat( outputFormat() );
 }
 
 int QgsRasterLayerSaveAsDialog::nColumns() const

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -351,7 +351,7 @@ void QgsRasterLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( const QStr
     mLayerName->setText( QString() );
   }
 
-  const bool isCOG = ( outputFormat() == QLatin1String( "COG" ) );
+  const bool isCOG = ( outputFormat() == "COG"_L1 );
   if ( isCOG )
   {
     mPyramidsGroupBox->setChecked( true );

--- a/src/gui/qgsrasterpyramidsoptionswidget.cpp
+++ b/src/gui/qgsrasterpyramidsoptionswidget.cpp
@@ -161,7 +161,7 @@ void QgsRasterPyramidsOptionsWidget::apply()
 
 void QgsRasterPyramidsOptionsWidget::tuneForFormat( const QString &driverName )
 {
-  const bool visible = ( driverName != QLatin1String( "COG" ) );
+  const bool visible = ( driverName != "COG"_L1 );
   labelOverviewFormat->setVisible( visible );
   cbxPyramidsFormat->setVisible( visible );
   labelLevels->setVisible( visible );

--- a/src/gui/qgsrasterpyramidsoptionswidget.cpp
+++ b/src/gui/qgsrasterpyramidsoptionswidget.cpp
@@ -159,6 +159,18 @@ void QgsRasterPyramidsOptionsWidget::apply()
   mSaveOptionsWidget->apply();
 }
 
+void QgsRasterPyramidsOptionsWidget::tuneForFormat( const QString &driverName )
+{
+  const bool visible = ( driverName != QLatin1String( "COG" ) );
+  labelOverviewFormat->setVisible( visible );
+  cbxPyramidsFormat->setVisible( visible );
+  labelLevels->setVisible( visible );
+  for ( auto it = mOverviewCheckBoxes.constBegin(); it != mOverviewCheckBoxes.constEnd(); ++it )
+    it.value()->setVisible( visible );
+  cbxPyramidsLevelsCustom->setVisible( visible );
+  lePyramidsLevels->setVisible( visible );
+}
+
 void QgsRasterPyramidsOptionsWidget::checkAllLevels( bool checked )
 {
   for ( auto it = mOverviewCheckBoxes.constBegin(); it != mOverviewCheckBoxes.constEnd(); ++it )

--- a/src/gui/qgsrasterpyramidsoptionswidget.h
+++ b/src/gui/qgsrasterpyramidsoptionswidget.h
@@ -50,6 +50,13 @@ class GUI_EXPORT QgsRasterPyramidsOptionsWidget : public QWidget, private Ui::Qg
     void setRasterLayer( QgsRasterLayer *rasterLayer ) { mSaveOptionsWidget->setRasterLayer( rasterLayer ); }
     void setRasterFileName( const QString &file ) { mSaveOptionsWidget->setRasterFileName( file ); }
 
+    /**
+     * Tune settings of the widget for the given format (in particular for COG)
+     *
+     * \since QGIS 4.0
+     */
+    void tuneForFormat( const QString &driverName );
+
   public slots:
 
     void apply();

--- a/src/ui/qgsrasterpyramidsoptionswidgetbase.ui
+++ b/src/ui/qgsrasterpyramidsoptionswidgetbase.ui
@@ -47,7 +47,7 @@
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="label_5">
+    <widget class="QLabel" name="labelLevels">
      <property name="text">
       <string>Levels</string>
      </property>
@@ -115,7 +115,7 @@
     <widget class="QgsRasterFormatSaveOptionsWidget" name="mSaveOptionsWidget" native="true"/>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="labelOverviewFormat">
      <property name="text">
       <string>Overview format</string>
      </property>

--- a/tests/src/python/test_qgsrasterfilewriter.py
+++ b/tests/src/python/test_qgsrasterfilewriter.py
@@ -569,6 +569,86 @@ class TestQgsRasterFileWriter(QgisTestCase):
                 "90",
             )
 
+    @unittest.skipIf(
+        int(gdal.VersionInfo("VERSION_NUM")) < GDAL_COMPUTE_VERSION(3, 13, 0),
+        "GDAL 3.13.0 required",
+    )
+    def testWriteCOGAsImage(self):
+        """Test COG support"""
+        tmpName = tempfile.mktemp(suffix=".grd")
+        source = QgsRasterLayer(
+            os.path.join(self.testDataDir, "raster", "byte.tif"), "my", "gdal"
+        )
+        self.assertTrue(source.isValid())
+        provider = source.dataProvider()
+        fw = QgsRasterFileWriter(tmpName)
+        fw.setOutputFormat("COG")
+        fw.setPyramidsConfigOptions(
+            ["COMPRESS_OVERVIEW=JPEG", "JPEG_QUALITY_OVERVIEW=90"]
+        )
+        assert fw.buildPyramidsFlag() == Qgis.RasterBuildPyramidOption.Yes
+
+        source.setContrastEnhancement(
+            algorithm=QgsContrastEnhancement.ContrastEnhancementAlgorithm.NoEnhancement
+        )
+        feedback = QgsRasterBlockFeedback()
+
+        class Progress:
+            def __init__(self, test):
+                self.test = test
+                self.last_percentage = 0
+                self.percentage_between_0_50_found = False
+                self.percentage_between_50_100_found = False
+
+            def onProgressChanged(self, percentage):
+                self.test.assertGreater(percentage, self.last_percentage)
+                if percentage > 0 and percentage < 50:
+                    self.percentage_between_0_50_found = True
+                if percentage > 50 and percentage < 100:
+                    self.percentage_between_50_100_found = True
+                self.last_percentage = percentage
+
+        progress = Progress(self)
+        feedback.progressChanged.connect(progress.onProgressChanged)
+
+        self.assertEqual(
+            fw.writeRaster(
+                source.pipe(),
+                1025,
+                1024,
+                provider.extent(),
+                provider.crs(),
+                QgsCoordinateTransformContext(),
+                feedback,
+            ),
+            QgsRasterFileWriter.WriterError.NoError,
+        )
+
+        self.assertEqual(progress.last_percentage, 100.0)
+        self.assertTrue(progress.percentage_between_0_50_found)
+        self.assertTrue(progress.percentage_between_50_100_found)
+
+        del fw
+
+        with gdal.Open(tmpName) as ds:
+            self.assertEqual(ds.RasterXSize, 1025)
+            self.assertEqual(ds.RasterYSize, 1024)
+            self.assertTrue(ds.GetRasterBand(1).GetOverviewCount() > 0)
+            self.assertEqual(
+                ds.GetRasterBand(1)
+                .GetOverview(0)
+                .GetDataset()
+                .GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE"),
+                "JPEG",
+            )
+            self.assertEqual(
+                ds.GetRasterBand(1)
+                .GetOverview(0)
+                .GetDataset()
+                .GetMetadataItem("JPEG_QUALITY", "IMAGE_STRUCTURE"),
+                "90",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<s>Set as draft because it shouldn't be merged while GDAL' https://github.com/OSGeo/gdal/pull/13506 hasn't been merged</s>  ==> GDAL' PR #13506 now merged

- QgsRasterFileWriter::writeRaster(): make it report better progress when creating COG files (GDAL >= 3.13.0)
- QgsGdalProvider::buildPyramids(): workaround a bug of GDAL 3.12.0 regarding Erdas Imagine overview creation
- QgsRasterFileWriter::buildPyramids(): report errors without calling QMessageBox
- QgsRasterFileWriter/QgsRasterLayerSaveAsDialog: take into account COG specificities regarding pyramid generation

Fixes #41949

<img width="583" height="894" alt="image" src="https://github.com/user-attachments/assets/afad9ff1-b9a2-48f4-8611-1d7b0354113c" />

Funded by: QGIS Anwendergruppe Deutschland