### PR TITLE
Update authentication dialogs

### DIFF
--- a/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.cpp
@@ -588,7 +588,7 @@ void QgsAuthOAuth2Edit::selectCurrentDefinedConfig()
 
 void QgsAuthOAuth2Edit::getDefinedCustomDir()
 {
-  const QString extradir = QFileDialog::getExistingDirectory( this, tr( "Select extra directory to parse" ), QDir::homePath(), QFileDialog::DontResolveSymlinks );
+  const QString extradir = QFileDialog::getExistingDirectory( this, tr( "Select Extra Directory to Parse" ), QDir::homePath(), QFileDialog::DontResolveSymlinks );
   this->raise();
   this->activateWindow();
 
@@ -601,7 +601,7 @@ void QgsAuthOAuth2Edit::getDefinedCustomDir()
 
 void QgsAuthOAuth2Edit::getSoftStatementDir()
 {
-  const QString softStatementFile = QFileDialog::getOpenFileName( this, tr( "Select software statement file" ), QDir::homePath(), tr( "JSON Web Token (*.jwt)" ) );
+  const QString softStatementFile = QFileDialog::getOpenFileName( this, tr( "Select Software Statement File" ), QDir::homePath(), tr( "JSON Web Token (*.jwt)" ) );
   this->raise();
   this->activateWindow();
 

--- a/src/gui/auth/qgsauthconfigedit.cpp
+++ b/src/gui/auth/qgsauthconfigedit.cpp
@@ -83,6 +83,7 @@ QgsAuthConfigEdit::QgsAuthConfigEdit( QWidget *parent, const QString &authcfg, c
     {
       cmbAuthMethods->setCurrentIndex( 0 );
       stkwAuthMethods->setCurrentIndex( 0 );
+      stkwAuthMethods->setSizeMode( QgsStackedWidget::SizeMode::CurrentPageOnly );
     }
 
     loadConfig();

--- a/src/gui/auth/qgsauthconfigedit.cpp
+++ b/src/gui/auth/qgsauthconfigedit.cpp
@@ -23,6 +23,7 @@
 #include "qgsauthmethodedit.h"
 #include "qgsauthmethodmetadata.h"
 #include "qgsgui.h"
+#include "qgshelp.h"
 #include "qgslogger.h"
 
 #include <QPushButton>
@@ -67,6 +68,9 @@ QgsAuthConfigEdit::QgsAuthConfigEdit( QWidget *parent, const QString &authcfg, c
     connect( buttonBox, &QDialogButtonBox::rejected, this, &QWidget::close );
     connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsAuthConfigEdit::saveConfig );
     connect( buttonBox->button( QDialogButtonBox::Reset ), &QAbstractButton::clicked, this, &QgsAuthConfigEdit::resetConfig );
+    connect( buttonBox, &QDialogButtonBox::helpRequested,  this, [] {
+      QgsHelp::openHelp( QStringLiteral( "auth_system/auth_overview.html#authentication-configurations" ) );
+    } );
 
     populateAuthMethods();
 

--- a/src/gui/auth/qgsautheditorwidgets.cpp
+++ b/src/gui/auth/qgsautheditorwidgets.cpp
@@ -23,6 +23,7 @@
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
 #include "qgsauthmethodmetadata.h"
+#include "qgshelp.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgssettings.h"
 
@@ -48,6 +49,9 @@ QgsAuthMethodPlugins::QgsAuthMethodPlugins( QWidget *parent )
   {
     setupUi( this );
     connect( buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+    connect( buttonBox, &QDialogButtonBox::helpRequested,  this, [] {
+      QgsHelp::openHelp( QStringLiteral( "auth_system/auth_overview.html#authentication-methods" ) );
+    } );
 
     setupTable();
     populateTable();

--- a/src/gui/auth/qgsauthguiutils.cpp
+++ b/src/gui/auth/qgsauthguiutils.cpp
@@ -77,7 +77,7 @@ bool QgsAuthGuiUtils::isDisabled( QgsMessageBar *msgbar )
 
 void QgsAuthGuiUtils::exportSelectedAuthenticationConfigs( QStringList authenticationConfigIds, QgsMessageBar *msgbar )
 {
-  const QString password = QInputDialog::getText( msgbar, QObject::tr( "Export Authentication Configurations" ), QObject::tr( "Enter a password encrypt the configuration file:" ), QLineEdit::Password );
+  const QString password = QInputDialog::getText( msgbar, QObject::tr( "Export Authentication Configurations" ), QObject::tr( "Enter a password to encrypt the configuration file:" ), QLineEdit::Password );
   if ( password.isEmpty() )
   {
     if ( QMessageBox::warning( msgbar, QObject::tr( "Export Authentication Configurations" ), QObject::tr( "Exporting authentication configurations with a blank password will result in a plain text file which may contain sensitive information. Are you sure you want to do this?" ), QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel ) == QMessageBox::Cancel )
@@ -100,7 +100,7 @@ void QgsAuthGuiUtils::exportSelectedAuthenticationConfigs( QStringList authentic
 
 void QgsAuthGuiUtils::importAuthenticationConfigs( QgsMessageBar *msgbar )
 {
-  const QString filename = QFileDialog::getOpenFileName( msgbar, QObject::tr( "Export Authentication Configurations" ), QDir::homePath(), QObject::tr( "XML files (*.xml *.XML)" ) );
+  const QString filename = QFileDialog::getOpenFileName( msgbar, QObject::tr( "Import Authentication Configurations" ), QDir::homePath(), QObject::tr( "XML files (*.xml *.XML)" ) );
   if ( filename.isEmpty() )
     return;
 

--- a/src/gui/auth/qgsauthimportcertdialog.cpp
+++ b/src/gui/auth/qgsauthimportcertdialog.cpp
@@ -20,6 +20,7 @@
 #include "qgsauthcertutils.h"
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
+#include "qgshelp.h"
 #include "qgssettings.h"
 
 #include <QDir>
@@ -51,7 +52,9 @@ QgsAuthImportCertDialog::QgsAuthImportCertDialog( QWidget *parent, QgsAuthImport
 
     connect( buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
     connect( buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
-
+    connect( buttonBox, &QDialogButtonBox::helpRequested,  this, [] {
+      QgsHelp::openHelp( QStringLiteral( "auth_system/auth_workflows.html#authentication-authorities" ) );
+    } );
     connect( teCertText, &QPlainTextEdit::textChanged, this, &QgsAuthImportCertDialog::validateCertificates );
 
     connect( radioImportFile, &QAbstractButton::toggled, this, &QgsAuthImportCertDialog::updateGui );

--- a/src/gui/auth/qgsauthimportidentitydialog.cpp
+++ b/src/gui/auth/qgsauthimportidentitydialog.cpp
@@ -22,6 +22,7 @@
 #include "qgsauthconfig.h"
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
+#include "qgshelp.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
 
@@ -55,7 +56,9 @@ QgsAuthImportIdentityDialog::QgsAuthImportIdentityDialog( QgsAuthImportIdentityD
     connect( btnPkiPkcs12Bundle, &QToolButton::clicked, this, &QgsAuthImportIdentityDialog::btnPkiPkcs12Bundle_clicked );
     connect( buttonBox, &QDialogButtonBox::rejected, this, &QWidget::close );
     connect( buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
-
+    connect( buttonBox, &QDialogButtonBox::helpRequested,  this, [] {
+      QgsHelp::openHelp( QStringLiteral( "auth_system/auth_workflows.html#authentication-identities" ) );
+    } );
     mIdentityType = identitytype;
 
     populateIdentityType();

--- a/src/gui/auth/qgsauthimportidentitydialog.cpp
+++ b/src/gui/auth/qgsauthimportidentitydialog.cpp
@@ -100,6 +100,7 @@ void QgsAuthImportIdentityDialog::populateIdentityType()
 
     cmbIdentityTypes->setCurrentIndex( 0 );
     stkwBundleType->setCurrentIndex( 0 );
+    stkwBundleType->setSizeMode( QgsStackedWidget::SizeMode::CurrentPageOnly );
   }
   // else switch stacked widget, and populate/connect according to that type and widget
 }

--- a/src/gui/auth/qgsauthmasterpassresetdialog.cpp
+++ b/src/gui/auth/qgsauthmasterpassresetdialog.cpp
@@ -19,6 +19,7 @@
 #include "qgsapplication.h"
 #include "qgsauthguiutils.h"
 #include "qgsauthmanager.h"
+#include "qgshelp.h"
 
 #include <QLineEdit>
 #include <QPushButton>
@@ -41,6 +42,9 @@ QgsMasterPasswordResetDialog::QgsMasterPasswordResetDialog( QWidget *parent )
     connect( leMasterPassCurrent, &QgsPasswordLineEdit::textChanged, this, &QgsMasterPasswordResetDialog::validatePasswords );
     connect( leMasterPassNew, &QgsPasswordLineEdit::textChanged, this, &QgsMasterPasswordResetDialog::validatePasswords );
     connect( leMasterPassNew2, &QgsPasswordLineEdit::textChanged, this, &QgsMasterPasswordResetDialog::validatePasswords );
+    connect( buttonBox, &QDialogButtonBox::helpRequested,  this, [] {
+      QgsHelp::openHelp( QStringLiteral( "auth_system/auth_overview.html#master-password" ) );
+    } );
 
     if ( QgsApplication::authManager()->sqliteDatabasePath().isEmpty() )
     {

--- a/src/ui/auth/qgsauthconfigedit.ui
+++ b/src/ui/auth/qgsauthconfigedit.ui
@@ -23,7 +23,7 @@
    <item row="8" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Reset|QDialogButtonBox::Save</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Reset|QDialogButtonBox::StandardButton::Save</set>
      </property>
     </widget>
    </item>
@@ -62,7 +62,7 @@
       <string>Note: Saving writes directly to authentication storage</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignCenter</set>
+      <set>Qt::AlignmentFlag::AlignCenter</set>
      </property>
     </widget>
    </item>

--- a/src/ui/auth/qgsauthconfigedit.ui
+++ b/src/ui/auth/qgsauthconfigedit.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Authentication</string>
+   <string>Add or Edit Authentication Configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="8" column="0" colspan="2">

--- a/src/ui/auth/qgsauthconfigedit.ui
+++ b/src/ui/auth/qgsauthconfigedit.ui
@@ -98,7 +98,7 @@
     </widget>
    </item>
    <item row="6" column="0" colspan="2">
-    <widget class="QStackedWidget" name="stkwAuthMethods">
+    <widget class="QgsStackedWidget" name="stkwAuthMethods">
      <property name="currentIndex">
       <number>-1</number>
      </property>
@@ -118,6 +118,12 @@
    <class>QgsAuthConfigIdEdit</class>
    <extends>QWidget</extends>
    <header>qgsauthconfigidedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsStackedWidget</class>
+   <extends>QStackedWidget</extends>
+   <header>qgsstackedwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/auth/qgsauthimportcertdialog.ui
+++ b/src/ui/auth/qgsauthimportcertdialog.ui
@@ -32,7 +32,7 @@
       <string>Import Certificate(s)</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
-      <property name="margin">
+      <property name="margin" stdset="0">
        <number>6</number>
       </property>
       <item>
@@ -46,7 +46,7 @@
            <property name="spacing">
             <number>0</number>
            </property>
-           <property name="margin">
+           <property name="margin" stdset="0">
             <number>0</number>
            </property>
            <item>
@@ -83,17 +83,17 @@
            <string>Import(s) can contain multiple certificates</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
+           <enum>QSizePolicy::Policy::Fixed</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -106,10 +106,10 @@
         <item row="3" column="0">
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
+           <enum>QSizePolicy::Policy::Fixed</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -182,7 +182,7 @@
         <item>
          <spacer name="horizontalSpacer_3">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -200,10 +200,10 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
+      <enum>QSizePolicy::Policy::Fixed</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -225,7 +225,7 @@
       <string>Validation Results</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
-      <property name="margin">
+      <property name="margin" stdset="0">
        <number>6</number>
       </property>
       <item>
@@ -254,10 +254,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/auth/qgsauthimportidentitydialog.ui
+++ b/src/ui/auth/qgsauthimportidentitydialog.ui
@@ -53,7 +53,7 @@
        </layout>
       </item>
       <item>
-       <widget class="QStackedWidget" name="stkwBundleType">
+       <widget class="QgsStackedWidget" name="stkwBundleType">
         <property name="currentIndex">
          <number>1</number>
         </property>
@@ -358,6 +358,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsStackedWidget</class>
+   <extends>QStackedWidget</extends>
+   <header>qgsstackedwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>cmbIdentityTypes</tabstop>
   <tabstop>lePkiPkcs12Bundle</tabstop>

--- a/src/ui/auth/qgsauthimportidentitydialog.ui
+++ b/src/ui/auth/qgsauthimportidentitydialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>350</height>
+    <height>399</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,7 @@
       <string>Import Identity</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
-      <property name="margin">
+      <property name="margin" stdset="0">
        <number>6</number>
       </property>
       <item>
@@ -40,7 +40,7 @@
         <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -59,10 +59,10 @@
         </property>
         <widget class="QWidget" name="pagePkiPaths">
          <layout class="QGridLayout" name="gridLayout_2">
-          <property name="margin">
+          <property name="margin" stdset="0">
            <number>0</number>
           </property>
-          <item row="4" column="0" alignment="Qt::AlignTop">
+          <item row="4" column="0" alignment="Qt::AlignmentFlag::AlignTop">
            <widget class="QLabel" name="lblPkiPathsKey">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -78,7 +78,7 @@
           <item row="10" column="1">
            <spacer name="verticalSpacer_3">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -127,7 +127,7 @@
                  <string>…</string>
                 </property>
                 <property name="popupMode">
-                 <enum>QToolButton::InstantPopup</enum>
+                 <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
                 </property>
                </widget>
               </item>
@@ -138,7 +138,7 @@
               <item>
                <widget class="QLineEdit" name="lePkiPathsKeyPass">
                 <property name="echoMode">
-                 <enum>QLineEdit::Password</enum>
+                 <enum>QLineEdit::EchoMode::Password</enum>
                 </property>
                 <property name="placeholderText">
                  <string>Optional passphrase</string>
@@ -173,7 +173,7 @@
                <string>…</string>
               </property>
               <property name="popupMode">
-               <enum>QToolButton::InstantPopup</enum>
+               <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
               </property>
              </widget>
             </item>
@@ -193,7 +193,7 @@
         </widget>
         <widget class="QWidget" name="pagePkiPkcs12">
          <layout class="QGridLayout" name="gridLayout_8">
-          <property name="margin">
+          <property name="margin" stdset="0">
            <number>0</number>
           </property>
           <item row="1" column="0">
@@ -212,7 +212,7 @@
           <item row="2" column="1">
            <spacer name="verticalSpacer_4">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -233,7 +233,7 @@
                <string>…</string>
               </property>
               <property name="popupMode">
-               <enum>QToolButton::InstantPopup</enum>
+               <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
               </property>
              </widget>
             </item>
@@ -267,7 +267,7 @@
             <item>
              <widget class="QLineEdit" name="lePkiPkcs12KeyPass">
               <property name="echoMode">
-               <enum>QLineEdit::Password</enum>
+               <enum>QLineEdit::EchoMode::Password</enum>
               </property>
               <property name="placeholderText">
                <string>Optional passphrase</string>
@@ -299,10 +299,10 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
+      <enum>QSizePolicy::Policy::Fixed</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -327,7 +327,7 @@
       <property name="spacing">
        <number>12</number>
       </property>
-      <property name="margin">
+      <property name="margin" stdset="0">
        <number>6</number>
       </property>
       <item>
@@ -349,10 +349,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/auth/qgsauthmasterpassresetdialog.ui
+++ b/src/ui/auth/qgsauthmasterpassresetdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>362</width>
-    <height>280</height>
+    <height>290</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,7 +30,7 @@
    <item>
     <widget class="QgsPasswordLineEdit" name="leMasterPassCurrent">
      <property name="echoMode">
-      <enum>QLineEdit::Password</enum>
+      <enum>QLineEdit::EchoMode::Password</enum>
      </property>
      <property name="placeholderText">
       <string>Required</string>
@@ -53,7 +53,7 @@
    <item>
     <widget class="QgsPasswordLineEdit" name="leMasterPassNew">
      <property name="echoMode">
-      <enum>QLineEdit::Password</enum>
+      <enum>QLineEdit::EchoMode::Password</enum>
      </property>
      <property name="placeholderText">
       <string>Required</string>
@@ -76,7 +76,7 @@
    <item>
     <widget class="QgsPasswordLineEdit" name="leMasterPassNew2">
      <property name="echoMode">
-      <enum>QLineEdit::Password</enum>
+      <enum>QLineEdit::EchoMode::Password</enum>
      </property>
      <property name="placeholderText">
       <string>Required</string>
@@ -103,7 +103,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -116,10 +116,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Help|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/auth/qgsauthmethodplugins.ui
+++ b/src/ui/auth/qgsauthmethodplugins.ui
@@ -14,7 +14,7 @@
    <string notr="true">Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+   <property name="margin" stdset="0">
     <number>6</number>
    </property>
    <item>
@@ -30,7 +30,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::StandardButton::Close|QDialogButtonBox::StandardButton::Help</set>
      </property>
     </widget>
    </item>

--- a/src/ui/auth/qgsauthmethodplugins.ui
+++ b/src/ui/auth/qgsauthmethodplugins.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Dialog</string>
+   <string notr="true">Installed Authentication Method Plugins</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="margin" stdset="0">


### PR DESCRIPTION
adding help button to dialogs I could find their description in the docs
adding, fixing or formatting dialog titles 
allowing dialog resizing thanks to qgsstackedwidget
![Peek 08-12-2025 22-10](https://github.com/user-attachments/assets/2a936852-c9a8-4db9-8d92-be97b4680356)
PS: the Oauth2 advanced section and +/- buttons replacement are not in this PR