### PR TITLE
Add option to sync elevation profile layers with project layers

### DIFF
--- a/python/PyQt6/core/auto_additions/qgselevationprofile.py
+++ b/python/PyQt6/core/auto_additions/qgselevationprofile.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/elevation/qgselevationprofile.h
 try:
-    QgsElevationProfile.__attribute_docs__ = {'nameChanged': 'Emitted when the profile is renamed.\n\n.. seealso:: :py:func:`name`\n\n.. seealso:: :py:func:`setName`\n'}
-    QgsElevationProfile.__signal_arguments__ = {'nameChanged': ['newName: str']}
+    QgsElevationProfile.__attribute_docs__ = {'nameChanged': 'Emitted when the profile is renamed.\n\n.. seealso:: :py:func:`name`\n\n.. seealso:: :py:func:`setName`\n', 'useProjectLayerTreeChanged': 'Emitted when the use project layer tree property is changed.\n\n.. seealso:: :py:func:`setUseProjectLayerTree`\n'}
+    QgsElevationProfile.__signal_arguments__ = {'nameChanged': ['newName: str'], 'useProjectLayerTreeChanged': ['useProjectTree: bool']}
     QgsElevationProfile.__group__ = ['elevation']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/elevation/qgselevationprofile.sip.in
+++ b/python/PyQt6/core/auto_generated/elevation/qgselevationprofile.sip.in
@@ -23,6 +23,7 @@ Represents an elevation profile attached to a project.
 %End
   public:
 
+
     explicit QgsElevationProfile( QgsProject *project );
 %Docstring
 Constructor for QgsElevationProfile.
@@ -72,6 +73,26 @@ Returns the icon to use for the elevation profile.
     QgsLayerTree *layerTree();
 %Docstring
 Returns the layer tree used by the profile.
+
+Will be ``None`` if :py:func:`~QgsElevationProfile.useProjectLayerTree`
+is ``True``.
+
+.. seealso:: :py:func:`useProjectLayerTree`
+
+.. seealso:: :py:func:`setUseProjectLayerTree`
+%End
+
+    bool useProjectLayerTree();
+%Docstring
+Returns ``True`` if the profile should always use the project's layer
+tree
+
+i.e. the profiles layer tree will be synchronized to the project and no
+reordering or re-grouping of layers is supported.
+
+.. seealso:: :py:func:`setUseProjectLayerTree`
+
+.. seealso:: :py:func:`layerTree`
 %End
 
     QgsCoordinateReferenceSystem crs() const;
@@ -197,6 +218,19 @@ Sets the distance ``unit`` used by the profile.
 .. seealso:: :py:func:`distanceUnit`
 %End
 
+
+    void setUseProjectLayerTree( bool useProjectTree );
+%Docstring
+Sets whether the profile should always use the project's layer tree
+
+i.e. the profiles layer tree will be synchronized to the project and no
+reordering or re-grouping of layers is supported.
+
+.. seealso:: :py:func:`useProjectLayerTree`
+
+.. seealso:: :py:func:`layerTree`
+%End
+
   signals:
 
     void nameChanged( const QString &newName );
@@ -206,6 +240,13 @@ Emitted when the profile is renamed.
 .. seealso:: :py:func:`name`
 
 .. seealso:: :py:func:`setName`
+%End
+
+    void useProjectLayerTreeChanged( bool useProjectTree );
+%Docstring
+Emitted when the use project layer tree property is changed.
+
+.. seealso:: :py:func:`setUseProjectLayerTree`
 %End
 
 };

--- a/python/core/auto_additions/qgselevationprofile.py
+++ b/python/core/auto_additions/qgselevationprofile.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/elevation/qgselevationprofile.h
 try:
-    QgsElevationProfile.__attribute_docs__ = {'nameChanged': 'Emitted when the profile is renamed.\n\n.. seealso:: :py:func:`name`\n\n.. seealso:: :py:func:`setName`\n'}
-    QgsElevationProfile.__signal_arguments__ = {'nameChanged': ['newName: str']}
+    QgsElevationProfile.__attribute_docs__ = {'nameChanged': 'Emitted when the profile is renamed.\n\n.. seealso:: :py:func:`name`\n\n.. seealso:: :py:func:`setName`\n', 'useProjectLayerTreeChanged': 'Emitted when the use project layer tree property is changed.\n\n.. seealso:: :py:func:`setUseProjectLayerTree`\n'}
+    QgsElevationProfile.__signal_arguments__ = {'nameChanged': ['newName: str'], 'useProjectLayerTreeChanged': ['useProjectTree: bool']}
     QgsElevationProfile.__group__ = ['elevation']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/elevation/qgselevationprofile.sip.in
+++ b/python/core/auto_generated/elevation/qgselevationprofile.sip.in
@@ -23,6 +23,7 @@ Represents an elevation profile attached to a project.
 %End
   public:
 
+
     explicit QgsElevationProfile( QgsProject *project );
 %Docstring
 Constructor for QgsElevationProfile.
@@ -72,6 +73,26 @@ Returns the icon to use for the elevation profile.
     QgsLayerTree *layerTree();
 %Docstring
 Returns the layer tree used by the profile.
+
+Will be ``None`` if :py:func:`~QgsElevationProfile.useProjectLayerTree`
+is ``True``.
+
+.. seealso:: :py:func:`useProjectLayerTree`
+
+.. seealso:: :py:func:`setUseProjectLayerTree`
+%End
+
+    bool useProjectLayerTree();
+%Docstring
+Returns ``True`` if the profile should always use the project's layer
+tree
+
+i.e. the profiles layer tree will be synchronized to the project and no
+reordering or re-grouping of layers is supported.
+
+.. seealso:: :py:func:`setUseProjectLayerTree`
+
+.. seealso:: :py:func:`layerTree`
 %End
 
     QgsCoordinateReferenceSystem crs() const;
@@ -197,6 +218,19 @@ Sets the distance ``unit`` used by the profile.
 .. seealso:: :py:func:`distanceUnit`
 %End
 
+
+    void setUseProjectLayerTree( bool useProjectTree );
+%Docstring
+Sets whether the profile should always use the project's layer tree
+
+i.e. the profiles layer tree will be synchronized to the project and no
+reordering or re-grouping of layers is supported.
+
+.. seealso:: :py:func:`useProjectLayerTree`
+
+.. seealso:: :py:func:`layerTree`
+%End
+
   signals:
 
     void nameChanged( const QString &newName );
@@ -206,6 +240,13 @@ Emitted when the profile is renamed.
 .. seealso:: :py:func:`name`
 
 .. seealso:: :py:func:`setName`
+%End
+
+    void useProjectLayerTreeChanged( bool useProjectTree );
+%Docstring
+Emitted when the use project layer tree property is changed.
+
+.. seealso:: :py:func:`setUseProjectLayerTree`
 %End
 
 };

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -145,9 +145,12 @@ class QgsElevationProfileWidget : public QWidget
     void onProjectElevationPropertiesChanged();
     void showSubsectionsTriggered();
     void editSubsectionsSymbology();
+    void syncProjectToggled( bool active );
 
   private:
     void setMainCanvas( QgsMapCanvas *canvas );
+    void setupLayerTreeView( bool resetTree = true );
+    static void copyProjectTree( QgsLayerTree *destination );
 
     QgsElevationProfileCanvas *mCanvas = nullptr;
     QPointer< QgsElevationProfile > mProfile;
@@ -170,6 +173,8 @@ class QgsElevationProfileWidget : public QWidget
     QAction *mLockRatioAction = nullptr;
     QAction *mShowSubsectionsAction = nullptr;
     QAction *mSubsectionsSymbologyAction = nullptr;
+    QAction *mSyncLayerTreeAction = nullptr;
+    QAction *mActionAddGroup = nullptr;
     QMenu *mDistanceUnitMenu = nullptr;
 
     QgsDockableWidgetHelper *mDockableWidgetHelper = nullptr;
@@ -199,6 +204,8 @@ class QgsElevationProfileWidget : public QWidget
     QgsElevationProfileLayerTreeView *mLayerTreeView = nullptr;
 
     std::unique_ptr<QgsLineSymbol> mSubsectionsSymbol;
+
+    QPointer< QgsLayerTree > mLayerTree;
 };
 
 

--- a/src/core/elevation/qgselevationprofile.h
+++ b/src/core/elevation/qgselevationprofile.h
@@ -47,6 +47,8 @@ class CORE_EXPORT QgsElevationProfile : public QObject
 
   public:
 
+    Q_PROPERTY( bool useProjectLayerTree READ useProjectLayerTree WRITE setUseProjectLayerTree NOTIFY useProjectLayerTreeChanged )
+
     /**
      * Constructor for QgsElevationProfile.
      */
@@ -91,8 +93,24 @@ class CORE_EXPORT QgsElevationProfile : public QObject
 
     /**
      * Returns the layer tree used by the profile.
+     *
+     * Will be NULLPTR if useProjectLayerTree() is TRUE.
+     *
+     * \see useProjectLayerTree()
+     * \see setUseProjectLayerTree()
      */
     QgsLayerTree *layerTree();
+
+    /**
+     * Returns TRUE if the profile should always use the project's layer tree
+     *
+     * i.e. the profiles layer tree will be synchronized to the project and no
+     * reordering or re-grouping of layers is supported.
+     *
+     * \see setUseProjectLayerTree()
+     * \see layerTree()
+     */
+    bool useProjectLayerTree() { return mUseProjectLayerTree; }
 
     /**
      * Returns the crs associated with the profile's map coordinates.
@@ -205,6 +223,18 @@ class CORE_EXPORT QgsElevationProfile : public QObject
      */
     void setDistanceUnit( Qgis::DistanceUnit unit );
 
+
+    /**
+     * Sets whether the profile should always use the project's layer tree
+     *
+     * i.e. the profiles layer tree will be synchronized to the project and no
+     * reordering or re-grouping of layers is supported.
+     *
+     * \see useProjectLayerTree()
+     * \see layerTree()
+     */
+    void setUseProjectLayerTree( bool useProjectTree );
+
   signals:
 
     /**
@@ -214,6 +244,13 @@ class CORE_EXPORT QgsElevationProfile : public QObject
      * \see setName()
      */
     void nameChanged( const QString &newName );
+
+    /**
+     * Emitted when the use project layer tree property is changed.
+     *
+     * \see setUseProjectLayerTree()
+     */
+    void useProjectLayerTreeChanged( bool useProjectTree );
 
   private slots:
 
@@ -229,6 +266,7 @@ class CORE_EXPORT QgsElevationProfile : public QObject
     bool mLockAxisScales = false;
     Qgis::DistanceUnit mDistanceUnit = Qgis::DistanceUnit::Unknown;
     std::unique_ptr<QgsLayerTree> mLayerTree;
+    bool mUseProjectLayerTree = false;
     std::unique_ptr<QgsCurve> mProfileCurve;
     double mTolerance = 0;
     std::unique_ptr<QgsLineSymbol> mSubsectionsSymbol;

--- a/src/gui/elevation/qgselevationprofilelayertreeview.cpp
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.cpp
@@ -438,9 +438,20 @@ bool QgsElevationProfileLayerTreeProxyModel::filterAcceptsRow( int sourceRow, co
 
 QgsElevationProfileLayerTreeView::QgsElevationProfileLayerTreeView( QgsLayerTree *rootNode, QWidget *parent )
   : QgsLayerTreeViewBase( parent )
-  , mLayerTree( rootNode )
 {
-  mModel = new QgsElevationProfileLayerTreeModel( rootNode, this );
+  setLayerTree( rootNode );
+}
+
+void QgsElevationProfileLayerTreeView::setLayerTree( QgsLayerTree *rootNode )
+{
+  if ( mModel )
+  {
+    mModel->deleteLater();
+  }
+
+  mLayerTree = rootNode;
+
+  mModel = new QgsElevationProfileLayerTreeModel( mLayerTree, this );
 
   connect( mModel, &QgsElevationProfileLayerTreeModel::addLayers, this, &QgsElevationProfileLayerTreeView::addLayers );
   mProxyModel = new QgsElevationProfileLayerTreeProxyModel( mModel, this );

--- a/src/gui/elevation/qgselevationprofilelayertreeview.cpp
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.cpp
@@ -463,10 +463,7 @@ QgsElevationProfileLayerTreeView::QgsElevationProfileLayerTreeView( QgsLayerTree
 
 void QgsElevationProfileLayerTreeView::setLayerTree( QgsLayerTree *rootNode )
 {
-  if ( mModel )
-  {
-    mModel->deleteLater();
-  }
+  QgsElevationProfileLayerTreeModel *oldModel = mModel;
 
   mLayerTree = rootNode;
 
@@ -477,6 +474,8 @@ void QgsElevationProfileLayerTreeView::setLayerTree( QgsLayerTree *rootNode )
 
   setModel( mProxyModel );
   setLayerTreeModel( mModel );
+
+  delete oldModel;
 }
 
 void QgsElevationProfileLayerTreeView::populateMissingLayers( QgsProject *project )

--- a/src/gui/elevation/qgselevationprofilelayertreeview.h
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.h
@@ -62,6 +62,20 @@ class GUI_EXPORT QgsElevationProfileLayerTreeModel : public QgsLayerTreeModel
     bool dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) override;
     QMimeData *mimeData( const QModelIndexList &indexes ) const override;
 
+    /**
+     * Sets whether modifications like renaming, reordering nodes are supported.
+     *
+     * \since QGIS 4.0
+     */
+    void setAllowModifications( bool allow );
+
+    /**
+     * Returns TRUE if modifications like renaming, reordering nodes are supported.
+     *
+     * \since QGIS 4.0
+     */
+    bool allowModifications() const { return mAllowModifications; }
+
   signals:
 
     /**
@@ -75,6 +89,8 @@ class GUI_EXPORT QgsElevationProfileLayerTreeModel : public QgsLayerTreeModel
 #ifdef SIP_RUN
     QgsElevationProfileLayerTreeModel( const QgsElevationProfileLayerTreeModel &other );
 #endif
+
+    bool mAllowModifications = true;
 };
 
 /**

--- a/src/gui/elevation/qgselevationprofilelayertreeview.h
+++ b/src/gui/elevation/qgselevationprofilelayertreeview.h
@@ -119,9 +119,16 @@ class GUI_EXPORT QgsElevationProfileLayerTreeView : public QgsLayerTreeViewBase
 
     /**
      * Construct a new tree view with given layer tree (root node must not be NULLPTR).
-     * The root node is not transferred by the view.
+     * The root node is not transferred to the view.
      */
     explicit QgsElevationProfileLayerTreeView( QgsLayerTree *rootNode, QWidget *parent = nullptr );
+
+    /**
+     * Sets a new layer tree root node to use for the view.
+     *
+     * The root node is not transferred to the view.
+     */
+    void setLayerTree( QgsLayerTree *rootNode );
 
     /**
      * Initially populates the tree view using layers from a \a project, as well as sources from the source registry.

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -86,6 +86,13 @@ void QgsLayerTreeViewBase::mouseDoubleClickEvent( QMouseEvent *event )
 
 void QgsLayerTreeViewBase::setLayerTreeModel( QgsLayerTreeModel *model )
 {
+  if ( mLayerTreeModel )
+  {
+    disconnect( mLayerTreeModel->rootGroup(), &QgsLayerTreeNode::expandedChanged, this, &QgsLayerTreeViewBase::onExpandedChanged );
+    disconnect( mLayerTreeModel, &QAbstractItemModel::modelReset, this, &QgsLayerTreeViewBase::onModelReset );
+    disconnect( mLayerTreeModel, &QAbstractItemModel::dataChanged, this, &QgsLayerTreeViewBase::onDataChanged );
+  }
+
   mLayerTreeModel = model;
 
   mLayerTreeModel->addTargetScreenProperties( QgsScreenProperties( screen() ) );

--- a/tests/src/python/test_qgselevationprofile.py
+++ b/tests/src/python/test_qgselevationprofile.py
@@ -83,6 +83,7 @@ class TestQgsElevationProfile(QgisTestCase):
         self.assertTrue(profile2.lockAxisScales())
         self.assertEqual(profile2.distanceUnit(), Qgis.DistanceUnit.Feet)
         self.assertEqual(profile2.subsectionsSymbol().color().name(), "#ff0000")
+        self.assertFalse(profile2.useProjectLayerTree())
 
         # restoration of layers requires resolving references
         self.assertEqual(
@@ -101,6 +102,49 @@ class TestQgsElevationProfile(QgisTestCase):
         )
         group = profile2.layerTree().findGroup("my group")
         self.assertEqual([l.name() for l in group.children()], ["l2"])
+
+    def test_sync_project_layer_tree(self):
+        project = QgsProject()
+        profile = QgsElevationProfile(project)
+
+        layer1 = QgsVectorLayer(
+            "Point?field=fldtxt:string&field=fldint:integer", "l1", "memory"
+        )
+        layer2 = QgsVectorLayer(
+            "Point?field=fldtxt:string&field=fldint:integer", "l2", "memory"
+        )
+        project.addMapLayers([layer1, layer2])
+
+        profile.setName("test profile")
+        self.assertFalse(profile.useProjectLayerTree())
+
+        spy = QSignalSpy(profile.useProjectLayerTreeChanged)
+        profile.setUseProjectLayerTree(True)
+        self.assertEqual(len(spy), 1)
+        self.assertIsNone(profile.layerTree())
+
+        profile.setUseProjectLayerTree(True)
+        self.assertEqual(len(spy), 1)
+
+        profile.setUseProjectLayerTree(False)
+        self.assertFalse(profile.useProjectLayerTree())
+        self.assertEqual(len(spy), 2)
+        profile.setUseProjectLayerTree(True)
+
+        # save to xml
+        context = QgsReadWriteContext()
+        doc = QDomDocument("testdoc")
+        elem = profile.writeXml(doc, context)
+        doc.appendChild(elem)
+
+        # restore from xml
+        profile2 = QgsElevationProfile(project)
+        self.assertTrue(profile2.readXml(elem, doc, context))
+        self.assertEqual(profile2.name(), "test profile")
+        self.assertTrue(profile2.useProjectLayerTree())
+        # no action, no crash
+        profile2.resolveReferences(project)
+        self.assertIsNone(profile2.layerTree())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This new option is available from an elevation profile's settings menu as "Synchronize Layers to Project". (It's unchecked by default)

If checked, then the elevation profile's layers will always exactly match the project's main canvas layer structure, including groups
and layer orders. Groups cannot be created in the elevation profile.

Any changes made to the main project's layer tree will immediately be reflected in the elevation profile's layer setup.
