### PR TITLE
Tweak Oauth2 authentication configuration dialog

### DIFF
--- a/src/auth/apiheader/gui/qgsauthapiheaderedit.ui
+++ b/src/auth/apiheader/gui/qgsauthapiheaderedit.ui
@@ -14,10 +14,10 @@
    <item row="0" column="0">
     <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
+      <enum>QFrame::Shadow::Plain</enum>
      </property>
      <property name="lineWidth">
       <number>0</number>
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>532</width>
-        <height>492</height>
+        <width>538</width>
+        <height>498</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_2">
@@ -64,7 +64,7 @@
             </size>
            </property>
            <property name="editTriggers">
-            <set>QAbstractItemView::AllEditTriggers</set>
+            <set>QAbstractItemView::EditTrigger::AllEditTriggers</set>
            </property>
            <property name="tabKeyNavigation">
             <bool>true</bool>
@@ -76,13 +76,13 @@
             <bool>true</bool>
            </property>
            <property name="dragDropMode">
-            <enum>QAbstractItemView::DragOnly</enum>
+            <enum>QAbstractItemView::DragDropMode::DragOnly</enum>
            </property>
            <property name="alternatingRowColors">
             <bool>true</bool>
            </property>
            <property name="selectionMode">
-            <enum>QAbstractItemView::SingleSelection</enum>
+            <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
            </property>
            <property name="sortingEnabled">
             <bool>true</bool>
@@ -93,9 +93,6 @@
            <property name="cornerButtonEnabled">
             <bool>true</bool>
            </property>
-           <attribute name="horizontalHeaderMinimumSectionSize">
-            <number>120</number>
-           </attribute>
            <attribute name="horizontalHeaderDefaultSectionSize">
             <number>160</number>
            </attribute>
@@ -135,9 +132,11 @@
              </property>
              <property name="font">
               <font>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
+             </property>
+             <property name="toolTip">
+              <string>Add header pair</string>
              </property>
              <property name="icon">
               <iconset>
@@ -158,9 +157,11 @@
              </property>
              <property name="font">
               <font>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
+             </property>
+             <property name="toolTip">
+              <string>Remove selected header pair</string>
              </property>
              <property name="icon">
               <iconset>
@@ -171,7 +172,7 @@
            <item>
             <spacer name="verticalSpacer">
              <property name="orientation">
-              <enum>Qt::Vertical</enum>
+              <enum>Qt::Orientation::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -199,5 +200,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <resources/>
  <connections/>
 </ui>

--- a/src/auth/oauth2/gui/qgsauthoauth2edit.ui
+++ b/src/auth/oauth2/gui/qgsauthoauth2edit.ui
@@ -59,7 +59,7 @@
    <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="handleWidth">
       <number>4</number>
@@ -157,7 +157,7 @@
                 <string>…</string>
                </property>
                <property name="icon">
-                <iconset resource="oauth2_resources.qrc">
+                <iconset>
                  <normaloff>:/oauth2method/svg/export.svg</normaloff>:/oauth2method/svg/export.svg</iconset>
                </property>
                <property name="iconSize">
@@ -177,7 +177,7 @@
                 <string>…</string>
                </property>
                <property name="icon">
-                <iconset resource="oauth2_resources.qrc">
+                <iconset>
                  <normaloff>:/oauth2method/svg/import.svg</normaloff>:/oauth2method/svg/import.svg</iconset>
                </property>
               </widget>
@@ -190,10 +190,10 @@
         <item>
          <widget class="QgsScrollArea" name="scrollAreaConfigure">
           <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
+           <enum>QFrame::Shape::NoFrame</enum>
           </property>
           <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOn</enum>
+           <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
           </property>
           <property name="widgetResizable">
            <bool>true</bool>
@@ -202,9 +202,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-288</y>
-             <width>401</width>
-             <height>568</height>
+             <y>0</y>
+             <width>392</width>
+             <height>830</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout">
@@ -223,48 +223,26 @@
             <property name="spacing">
              <number>6</number>
             </property>
-            <item row="16" column="0">
-             <widget class="QLabel" name="lblAccessMethod">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Access method</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="11" column="0">
-             <widget class="QLabel" name="lblScope">
-              <property name="text">
-               <string>Scope</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1" colspan="3">
-             <widget class="QLineEdit" name="leRefreshTokenUrl">
+            <item row="2" column="1" colspan="2">
+             <widget class="QLineEdit" name="leTokenUrl">
               <property name="placeholderText">
-               <string>Optional</string>
+               <string>Required</string>
               </property>
              </widget>
             </item>
-            <item row="21" column="1">
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
+            <item row="11" column="1" colspan="2">
+             <widget class="QLineEdit" name="leScope">
+              <property name="placeholderText">
+               <string>Optional (space delimiter)</string>
               </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>0</height>
-               </size>
+             </widget>
+            </item>
+            <item row="10" column="1" colspan="2">
+             <widget class="QgsPasswordLineEdit" name="lePassword">
+              <property name="placeholderText">
+               <string>Required</string>
               </property>
-             </spacer>
+             </widget>
             </item>
             <item row="4" column="0">
              <widget class="QLabel" name="lblRedirectUrl">
@@ -276,61 +254,7 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="1" colspan="3">
-             <widget class="QLineEdit" name="leRequestUrl">
-              <property name="placeholderText">
-               <string>Required</string>
-              </property>
-             </widget>
-            </item>
-            <item row="15" column="1" colspan="2">
-             <widget class="QCheckBox" name="chkbxTokenPersist">
-              <property name="text">
-               <string>Persist between launches</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1" colspan="3">
-             <widget class="QLineEdit" name="leTokenUrl">
-              <property name="placeholderText">
-               <string>Required</string>
-              </property>
-             </widget>
-            </item>
-            <item row="7" column="0">
-             <widget class="QLabel" name="lblClientId">
-              <property name="text">
-               <string>Client ID</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="16" column="1" colspan="3">
-             <widget class="QComboBox" name="cmbbxAccessMethod">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Resource access token method</string>
-              </property>
-             </widget>
-            </item>
-            <item row="8" column="0">
-             <widget class="QLabel" name="lblClientSecret">
-              <property name="text">
-               <string>Client secret</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1" colspan="3">
+            <item row="0" column="1" colspan="2">
              <widget class="QPlainTextEdit" name="pteDescription">
               <property name="maximumSize">
                <size>
@@ -340,20 +264,298 @@
               </property>
              </widget>
             </item>
-            <item row="14" column="0" colspan="4">
-             <widget class="QLabel" name="label">
-              <property name="font">
-               <font>
-                <pointsize>12</pointsize>
-                <italic>true</italic>
-               </font>
+            <item row="12" column="1" colspan="2">
+             <widget class="QLineEdit" name="leApiKey">
+              <property name="placeholderText">
+               <string>Optional</string>
               </property>
+             </widget>
+            </item>
+            <item row="10" column="0">
+             <widget class="QLabel" name="lblPassword">
               <property name="text">
+               <string>Password</string>
+              </property>
+             </widget>
+            </item>
+            <item row="13" column="0" colspan="3">
+             <widget class="QgsCollapsibleGroupBoxBasic" name="AdvancedgroupBox">
+              <property name="title">
                <string>Advanced</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
-              </property>
+              <layout class="QGridLayout" name="gridLayout_5">
+               <item row="2" column="1">
+                <widget class="QComboBox" name="cmbbxAccessMethod">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Resource access token method</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QLabel" name="mExtraTokensHeaderLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Extra token header(s)</string>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLineEdit" name="mTokenHeaderLineEdit">
+                 <property name="toolTip">
+                  <string>If set, the specified header key will be used instead of the default HTTP Authorization header when sending authenticated requests</string>
+                 </property>
+                 <property name="placeholderText">
+                  <string>Default</string>
+                 </property>
+                 <property name="clearButtonEnabled">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0" rowspan="2">
+                <widget class="QLabel" name="lblTokenPersist">
+                 <property name="text">
+                  <string>Token session</string>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="mTokenHeaderLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Token header</string>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="lblAccessMethod">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Access method</string>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_6">
+                 <property name="spacing">
+                  <number>3</number>
+                 </property>
+                 <item>
+                  <widget class="QTableWidget" name="mExtraTokensTable">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                     <horstretch>1</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>50</width>
+                     <height>70</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>These extra tokens will be included in the request headers sent to the resource when provided by the token endpoint</string>
+                   </property>
+                   <property name="editTriggers">
+                    <set>QAbstractItemView::EditTrigger::AllEditTriggers</set>
+                   </property>
+                   <property name="dragEnabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="dragDropMode">
+                    <enum>QAbstractItemView::DragDropMode::DragOnly</enum>
+                   </property>
+                   <property name="selectionMode">
+                    <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
+                   </property>
+                   <property name="sortingEnabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>false</bool>
+                   </property>
+                   <attribute name="horizontalHeaderMinimumSectionSize">
+                    <number>120</number>
+                   </attribute>
+                   <attribute name="horizontalHeaderDefaultSectionSize">
+                    <number>120</number>
+                   </attribute>
+                   <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+                    <bool>true</bool>
+                   </attribute>
+                   <attribute name="horizontalHeaderStretchLastSection">
+                    <bool>true</bool>
+                   </attribute>
+                   <attribute name="verticalHeaderVisible">
+                    <bool>false</bool>
+                   </attribute>
+                   <column>
+                    <property name="text">
+                     <string>Header Name</string>
+                    </property>
+                   </column>
+                   <column>
+                    <property name="text">
+                     <string>Token Response Field</string>
+                    </property>
+                   </column>
+                  </widget>
+                 </item>
+                 <item>
+                  <layout class="QVBoxLayout" name="verticalLayout_8">
+                   <item>
+                    <widget class="QToolButton" name="mAddExtraTokenButton">
+                     <property name="minimumSize">
+                      <size>
+                       <width>24</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="font">
+                      <font>
+                       <bold>true</bold>
+                      </font>
+                     </property>
+                     <property name="toolTip">
+                      <string notr="true">Add extra token</string>
+                     </property>
+                     <property name="text">
+                      <string>...</string>
+                     </property>
+                     <property name="icon">
+                      <iconset>
+                       <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QToolButton" name="mRemoveExtraTokenButton">
+                     <property name="minimumSize">
+                      <size>
+                       <width>24</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="font">
+                      <font>
+                       <bold>true</bold>
+                      </font>
+                     </property>
+                     <property name="toolTip">
+                      <string notr="true">Remove selected extra token</string>
+                     </property>
+                     <property name="text">
+                      <string notr="true">...</string>
+                     </property>
+                     <property name="icon">
+                      <iconset>
+                       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacer_7">
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </item>
+               <item row="1" column="1">
+                <widget class="QCheckBox" name="chkbxTokenPersist">
+                 <property name="text">
+                  <string>Persist between launches</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QLabel" name="lblRequestTimeout">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Request timeout</string>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="5" column="1">
+                <widget class="QSpinBox" name="spnbxRequestTimeout">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Authorization-related timeout</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                 </property>
+                 <property name="suffix">
+                  <string> seconds</string>
+                 </property>
+                 <property name="minimum">
+                  <number>5</number>
+                 </property>
+                 <property name="maximum">
+                  <number>3600</number>
+                 </property>
+                 <property name="value">
+                  <number>30</number>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </widget>
             </item>
             <item row="1" column="0">
@@ -363,60 +565,6 @@
               </property>
               <property name="wordWrap">
                <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="20" column="0">
-             <widget class="QLabel" name="lblRequestTimeout">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Request timeout</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="9" column="0">
-             <widget class="QLabel" name="lblUsername">
-              <property name="text">
-               <string>Username</string>
-              </property>
-             </widget>
-            </item>
-            <item row="9" column="1" colspan="3">
-             <widget class="QLineEdit" name="leUsername">
-              <property name="placeholderText">
-               <string>Required</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblDescription">
-              <property name="text">
-               <string>Description</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="13" column="0" colspan="4">
-             <widget class="Line" name="line">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="11" column="1" colspan="3">
-             <widget class="QLineEdit" name="leScope">
-              <property name="placeholderText">
-               <string>Optional (space delimiter)</string>
               </property>
              </widget>
             </item>
@@ -430,7 +578,27 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="1" colspan="3">
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblDescription">
+              <property name="text">
+               <string>Description</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="lblTokenUrl">
+              <property name="text">
+               <string>Token URL</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1" colspan="2">
              <widget class="QFrame" name="frameRedirectUrl">
               <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,0,0,0,0">
                <property name="spacing">
@@ -470,7 +638,7 @@
                   <string>Port number</string>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignCenter</set>
+                  <set>Qt::AlignmentFlag::AlignCenter</set>
                  </property>
                  <property name="minimum">
                   <number>0</number>
@@ -509,74 +677,83 @@
               </layout>
              </widget>
             </item>
-            <item row="8" column="1" colspan="3">
+            <item row="8" column="1" colspan="2">
              <widget class="QgsPasswordLineEdit" name="leClientSecret">
               <property name="placeholderText">
                <string>Required</string>
               </property>
              </widget>
             </item>
-            <item row="7" column="1" colspan="3">
-             <widget class="QLineEdit" name="leClientId">
+            <item row="3" column="1" colspan="2">
+             <widget class="QLineEdit" name="leRefreshTokenUrl">
               <property name="placeholderText">
-               <string>Required</string>
+               <string>Optional</string>
               </property>
              </widget>
             </item>
             <item row="20" column="1">
-             <widget class="QSpinBox" name="spnbxRequestTimeout">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
-              <property name="toolTip">
-               <string>Authorization-related timeout</string>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
-              </property>
-              <property name="suffix">
-               <string> seconds</string>
-              </property>
-              <property name="minimum">
-               <number>5</number>
-              </property>
-              <property name="maximum">
-               <number>3600</number>
-              </property>
-              <property name="value">
-               <number>30</number>
-              </property>
-             </widget>
+             </spacer>
             </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="lblTokenUrl">
+            <item row="8" column="0">
+             <widget class="QLabel" name="lblClientSecret">
               <property name="text">
-               <string>Token URL</string>
+               <string>Client secret</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
               </property>
              </widget>
             </item>
-            <item row="10" column="0">
-             <widget class="QLabel" name="lblPassword">
-              <property name="text">
-               <string>Password</string>
-              </property>
-             </widget>
-            </item>
-            <item row="12" column="1" colspan="3">
-             <widget class="QLineEdit" name="leApiKey">
+            <item row="7" column="1" colspan="2">
+             <widget class="QLineEdit" name="leClientId">
               <property name="placeholderText">
-               <string>Optional</string>
+               <string>Required</string>
               </property>
              </widget>
             </item>
-            <item row="10" column="1" colspan="3">
-             <widget class="QgsPasswordLineEdit" name="lePassword">
+            <item row="7" column="0">
+             <widget class="QLabel" name="lblClientId">
+              <property name="text">
+               <string>Client ID</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="11" column="0">
+             <widget class="QLabel" name="lblScope">
+              <property name="text">
+               <string>Scope</string>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="0">
+             <widget class="QLabel" name="lblUsername">
+              <property name="text">
+               <string>Username</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1" colspan="2">
+             <widget class="QLineEdit" name="leRequestUrl">
+              <property name="placeholderText">
+               <string>Required</string>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="1" colspan="2">
+             <widget class="QLineEdit" name="leUsername">
               <property name="placeholderText">
                <string>Required</string>
               </property>
@@ -597,185 +774,6 @@
                <bool>true</bool>
               </property>
              </widget>
-            </item>
-            <item row="15" column="0">
-             <widget class="QLabel" name="lblTokenPersist">
-              <property name="text">
-               <string>Token session</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="18" column="0">
-             <widget class="QLabel" name="mTokenHeaderLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Token header</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="18" column="1" colspan="3">
-             <widget class="QLineEdit" name="mTokenHeaderLineEdit">
-              <property name="toolTip">
-               <string>If set, the specified header key will be used instead of the default HTTP Authorization header when sending authenticated requests</string>
-              </property>
-              <property name="placeholderText">
-               <string>Default</string>
-              </property>
-              <property name="clearButtonEnabled">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="19" column="0">
-             <widget class="QLabel" name="mExtraTokensHeaderLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Extra token header(s)</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="19" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_6">
-              <property name="spacing">
-               <number>3</number>
-              </property>
-              <item>
-               <widget class="QTableWidget" name="mExtraTokensTable">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-                  <horstretch>1</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>50</width>
-                  <height>70</height>
-                 </size>
-                </property>
-                <property name="editTriggers">
-                 <set>QAbstractItemView::AllEditTriggers</set>
-                </property>
-                <property name="dragEnabled">
-                 <bool>true</bool>
-                </property>
-                <property name="dragDropMode">
-                 <enum>QAbstractItemView::DragOnly</enum>
-                </property>
-                <property name="selectionMode">
-                 <enum>QAbstractItemView::SingleSelection</enum>
-                </property>
-                <property name="sortingEnabled">
-                 <bool>true</bool>
-                </property>
-                <property name="wordWrap">
-                 <bool>false</bool>
-                </property>
-                <attribute name="horizontalHeaderMinimumSectionSize">
-                 <number>120</number>
-                </attribute>
-                <attribute name="horizontalHeaderDefaultSectionSize">
-                 <number>120</number>
-                </attribute>
-                <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
-                 <bool>true</bool>
-                </attribute>
-                <attribute name="horizontalHeaderStretchLastSection">
-                 <bool>true</bool>
-                </attribute>
-                <attribute name="verticalHeaderVisible">
-                 <bool>false</bool>
-                </attribute>
-                <column>
-                 <property name="text">
-                  <string>Header Name</string>
-                 </property>
-                </column>
-                <column>
-                 <property name="text">
-                  <string>Token Response Field</string>
-                 </property>
-                </column>
-                <property name="toolTip">
-                 <string>These extra tokens will be included in the request headers sent to the resource when provided by the token endpoint</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <layout class="QVBoxLayout" name="verticalLayout_8">
-                <item>
-                 <widget class="QToolButton" name="mAddExtraTokenButton">
-                  <property name="minimumSize">
-                   <size>
-                    <width>24</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="font">
-                   <font>
-                    <weight>75</weight>
-                    <bold>true</bold>
-                   </font>
-                  </property>
-                  <property name="text">
-                   <string notr="true">+</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QToolButton" name="mRemoveExtraTokenButton">
-                  <property name="minimumSize">
-                   <size>
-                    <width>24</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="font">
-                   <font>
-                    <weight>75</weight>
-                    <bold>true</bold>
-                   </font>
-                  </property>
-                  <property name="text">
-                   <string notr="true">–</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="verticalSpacer_7">
-                  <property name="orientation">
-                   <enum>Qt::Vertical</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-             </layout>
             </item>
            </layout>
           </widget>
@@ -822,10 +820,10 @@
              </font>
             </property>
             <property name="verticalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOn</enum>
+             <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
             </property>
             <property name="editTriggers">
-             <set>QAbstractItemView::NoEditTriggers</set>
+             <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
             </property>
             <property name="showDropIndicator" stdset="0">
              <bool>false</bool>
@@ -834,7 +832,7 @@
              <bool>true</bool>
             </property>
             <property name="verticalScrollMode">
-             <enum>QAbstractItemView::ScrollPerItem</enum>
+             <enum>QAbstractItemView::ScrollMode::ScrollPerItem</enum>
             </property>
             <property name="spacing">
              <number>2</number>
@@ -877,7 +875,7 @@
              <string>…</string>
             </property>
             <property name="icon">
-             <iconset resource="oauth2_resources.qrc">
+             <iconset>
               <normaloff>:/oauth2method/svg/fileopen.svg</normaloff>:/oauth2method/svg/fileopen.svg</iconset>
             </property>
             <property name="iconSize">
@@ -901,7 +899,7 @@
          <number>6</number>
         </property>
         <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
+         <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
         </property>
         <item>
          <layout class="QGridLayout" name="gridLayout_4">
@@ -925,7 +923,7 @@
              <string>…</string>
             </property>
             <property name="icon">
-             <iconset resource="oauth2_resources.qrc">
+             <iconset>
               <normaloff>:/oauth2method/svg/fileopen.svg</normaloff>:/oauth2method/svg/fileopen.svg</iconset>
             </property>
            </widget>
@@ -959,7 +957,7 @@
         <item>
          <spacer name="verticalSpacer_2">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -1001,7 +999,7 @@
        <item>
         <widget class="QgsScrollArea" name="scrollAreaAdvanced">
          <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
          <property name="widgetResizable">
           <bool>true</bool>
@@ -1011,8 +1009,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>413</width>
-            <height>275</height>
+            <width>415</width>
+            <height>279</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
@@ -1032,7 +1030,6 @@
             <number>6</number>
            </property>
            <item row="3" column="0" colspan="2">
-			   
             <layout class="QHBoxLayout" name="horizontalLayout_5">
              <property name="spacing">
               <number>3</number>
@@ -1040,16 +1037,16 @@
              <item>
               <widget class="QTableWidget" name="tblwdgQueryPairs">
                <property name="editTriggers">
-                <set>QAbstractItemView::AllEditTriggers</set>
+                <set>QAbstractItemView::EditTrigger::AllEditTriggers</set>
                </property>
                <property name="dragEnabled">
                 <bool>true</bool>
                </property>
                <property name="dragDropMode">
-                <enum>QAbstractItemView::DragOnly</enum>
+                <enum>QAbstractItemView::DragDropMode::DragOnly</enum>
                </property>
                <property name="selectionMode">
-                <enum>QAbstractItemView::SingleSelection</enum>
+                <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
                </property>
                <property name="sortingEnabled">
                 <bool>true</bool>
@@ -1096,12 +1093,18 @@
                  </property>
                  <property name="font">
                   <font>
-                   <weight>75</weight>
                    <bold>true</bold>
                   </font>
                  </property>
+                 <property name="toolTip">
+                  <string notr="true">Add query pair</string>
+                 </property>
                  <property name="text">
-                  <string notr="true">+</string>
+                  <string>...</string>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                  </property>
                 </widget>
                </item>
@@ -1115,19 +1118,25 @@
                  </property>
                  <property name="font">
                   <font>
-                   <weight>75</weight>
                    <bold>true</bold>
                   </font>
                  </property>
+                 <property name="toolTip">
+                  <string notr="true">Remove selected query pair</string>
+                 </property>
                  <property name="text">
-                  <string notr="true">–</string>
+                  <string>...</string>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                  </property>
                 </widget>
                </item>
                <item>
                 <spacer name="verticalSpacer_8">
                  <property name="orientation">
-                  <enum>Qt::Vertical</enum>
+                  <enum>Qt::Orientation::Vertical</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -1140,7 +1149,6 @@
               </layout>
              </item>
             </layout>
-           
            </item>
           </layout>
          </widget>
@@ -1154,25 +1162,29 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsPasswordLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgspasswordlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBoxBasic</class>
-   <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPasswordLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgspasswordlineedit.h</header>
-  </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>tabConfigs</tabstop>
   <tabstop>cmbbxGrantFlow</tabstop>
+  <tabstop>btnExport</tabstop>
+  <tabstop>btnImport</tabstop>
+  <tabstop>scrollAreaConfigure</tabstop>
   <tabstop>pteDescription</tabstop>
   <tabstop>leRequestUrl</tabstop>
   <tabstop>leTokenUrl</tabstop>
@@ -1188,19 +1200,23 @@
   <tabstop>leApiKey</tabstop>
   <tabstop>chkbxTokenPersist</tabstop>
   <tabstop>cmbbxAccessMethod</tabstop>
+  <tabstop>mTokenHeaderLineEdit</tabstop>
+  <tabstop>mExtraTokensTable</tabstop>
+  <tabstop>mAddExtraTokenButton</tabstop>
+  <tabstop>mRemoveExtraTokenButton</tabstop>
   <tabstop>spnbxRequestTimeout</tabstop>
+  <tabstop>lstwdgDefinedConfigs</tabstop>
+  <tabstop>pteDefinedDesc</tabstop>
+  <tabstop>leDefinedDirPath</tabstop>
+  <tabstop>btnGetDefinedDirPath</tabstop>
+  <tabstop>leSoftwareStatementConfigUrl</tabstop>
+  <tabstop>leSoftwareStatementJwtPath</tabstop>
+  <tabstop>btnSoftStatementDir</tabstop>
+  <tabstop>btnRegister</tabstop>
   <tabstop>scrollAreaAdvanced</tabstop>
   <tabstop>tblwdgQueryPairs</tabstop>
   <tabstop>btnAddQueryPair</tabstop>
   <tabstop>btnRemoveQueryPair</tabstop>
-  <tabstop>btnExport</tabstop>
-  <tabstop>btnImport</tabstop>
-  <tabstop>leDefinedDirPath</tabstop>
-  <tabstop>tabConfigs</tabstop>
-  <tabstop>scrollAreaConfigure</tabstop>
-  <tabstop>btnGetDefinedDirPath</tabstop>
-  <tabstop>lstwdgDefinedConfigs</tabstop>
-  <tabstop>pteDefinedDesc</tabstop>
  </tabstops>
  <resources>
   <include location="oauth2_resources.qrc"/>


### PR DESCRIPTION
using a collapsible group box, more usual icons, hiding scrollbar when unneeded, and add tooltip to buttons
<img width="1431" height="1060" alt="Copie d&#39;écran_20251209_081251" src="https://github.com/user-attachments/assets/d32dd8b1-2cff-4e6e-9893-4834c4f7a8bc" />
