### PR TITLE
[FEATURE] Processing algorithms: add a way to specify the raster format, particularly for COG output

### DIFF
--- a/python/PyQt6/analysis/auto_additions/qgspdalalgorithms.py
+++ b/python/PyQt6/analysis/auto_additions/qgspdalalgorithms.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/analysis/processing/pdal/qgspdalalgorithms.h
 try:
-    QgsPdalAlgorithms.__overridden_methods__ = ['icon', 'svgIconPath', 'id', 'helpId', 'name', 'supportsNonFileBasedOutput', 'supportedOutputVectorLayerExtensions', 'supportedOutputRasterLayerExtensions', 'supportedOutputPointCloudLayerExtensions', 'loadAlgorithms']
+    QgsPdalAlgorithms.__overridden_methods__ = ['icon', 'svgIconPath', 'id', 'helpId', 'name', 'supportsNonFileBasedOutput', 'supportedOutputVectorLayerExtensions', 'supportedOutputRasterLayerFormatAndExtensions', 'supportedOutputPointCloudLayerExtensions', 'loadAlgorithms']
     QgsPdalAlgorithms.__group__ = ['processing', 'pdal']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/analysis/auto_generated/interpolation/qgsgridfilewriter.sip.in
+++ b/python/PyQt6/analysis/auto_generated/interpolation/qgsgridfilewriter.sip.in
@@ -23,7 +23,7 @@ file.
 #include "qgsgridfilewriter.h"
 %End
   public:
-    QgsGridFileWriter( QgsInterpolator *interpolator, const QString &outputPath, const QgsRectangle &extent, int nCols, int nRows );
+    QgsGridFileWriter( QgsInterpolator *interpolator, const QString &outputPath, const QgsRectangle &extent, int nCols, int nRows, const QString &outputFormat = QString() );
 %Docstring
 Constructor for QgsGridFileWriter, for the specified ``interpolator``.
 
@@ -31,6 +31,9 @@ The ``outputPath`` argument is used to set the output file path.
 
 The ``extent`` and ``nCols``, ``nRows`` arguments dictate the extent and
 size of the output raster.
+
+The ``outputFormat`` (available since QGIS 4.0), if not explicitly set,
+is inferred from the ``outputPath`` extension.
 %End
 
     int writeFile( QgsFeedback *feedback = 0 );

--- a/python/PyQt6/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
+++ b/python/PyQt6/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
@@ -42,7 +42,7 @@ Constructor for QgsPdalAlgorithms.
 
     virtual QStringList supportedOutputVectorLayerExtensions() const;
 
-    virtual QStringList supportedOutputRasterLayerExtensions() const;
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
 
     virtual QStringList supportedOutputPointCloudLayerExtensions() const;
 

--- a/python/PyQt6/core/auto_additions/qgsprocessingparameters.py
+++ b/python/PyQt6/core/auto_additions/qgsprocessingparameters.py
@@ -40,6 +40,7 @@ try:
     QgsProcessingParameters.parameterAsLayer = staticmethod(QgsProcessingParameters.parameterAsLayer)
     QgsProcessingParameters.parameterAsRasterLayer = staticmethod(QgsProcessingParameters.parameterAsRasterLayer)
     QgsProcessingParameters.parameterAsOutputLayer = staticmethod(QgsProcessingParameters.parameterAsOutputLayer)
+    QgsProcessingParameters.parameterAsOutputFormat = staticmethod(QgsProcessingParameters.parameterAsOutputFormat)
     QgsProcessingParameters.parameterAsFileOutput = staticmethod(QgsProcessingParameters.parameterAsFileOutput)
     QgsProcessingParameters.parameterAsVectorLayer = staticmethod(QgsProcessingParameters.parameterAsVectorLayer)
     QgsProcessingParameters.parameterAsMeshLayer = staticmethod(QgsProcessingParameters.parameterAsMeshLayer)
@@ -262,7 +263,7 @@ except (NameError, AttributeError):
 try:
     QgsProcessingParameterRasterDestination.typeName = staticmethod(QgsProcessingParameterRasterDestination.typeName)
     QgsProcessingParameterRasterDestination.fromScriptCode = staticmethod(QgsProcessingParameterRasterDestination.fromScriptCode)
-    QgsProcessingParameterRasterDestination.__virtual_methods__ = ['supportedOutputRasterLayerExtensions']
+    QgsProcessingParameterRasterDestination.__virtual_methods__ = ['supportedOutputRasterLayerExtensions', 'supportedOutputRasterLayerFormatAndExtensions']
     QgsProcessingParameterRasterDestination.__overridden_methods__ = ['clone', 'type', 'checkValueIsAcceptable', 'valueAsPythonString', 'toOutputDefinition', 'defaultFileExtension', 'createFileFilter']
     QgsProcessingParameterRasterDestination.__group__ = ['processing']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_additions/qgsprocessingprovider.py
+++ b/python/PyQt6/core/auto_additions/qgsprocessingprovider.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/processing/qgsprocessingprovider.h
 try:
     QgsProcessingProvider.__attribute_docs__ = {'algorithmsLoaded': 'Emitted when the provider has loaded (or refreshed) its list of\navailable algorithms.\n\n.. seealso:: :py:func:`refreshAlgorithms`\n'}
-    QgsProcessingProvider.__virtual_methods__ = ['icon', 'svgIconPath', 'flags', 'helpId', 'longName', 'versionInfo', 'canBeActivated', 'warningMessage', 'isActive', 'supportedOutputRasterLayerExtensions', 'supportedOutputVectorLayerExtensions', 'supportedOutputPointCloudLayerExtensions', 'supportedOutputVectorTileLayerExtensions', 'supportedOutputTableExtensions', 'isSupportedOutputValue', 'defaultVectorFileExtension', 'defaultRasterFileExtension', 'defaultPointCloudFileExtension', 'defaultVectorTileFileExtension', 'supportsNonFileBasedOutput', 'load', 'unload']
+    QgsProcessingProvider.__virtual_methods__ = ['icon', 'svgIconPath', 'flags', 'helpId', 'longName', 'versionInfo', 'canBeActivated', 'warningMessage', 'isActive', 'supportedOutputRasterLayerFormatAndExtensions', 'supportedOutputVectorLayerExtensions', 'supportedOutputPointCloudLayerExtensions', 'supportedOutputVectorTileLayerExtensions', 'supportedOutputTableExtensions', 'isSupportedOutputValue', 'defaultVectorFileExtension', 'defaultRasterFileExtension', 'defaultPointCloudFileExtension', 'defaultVectorTileFileExtension', 'supportsNonFileBasedOutput', 'load', 'unload']
     QgsProcessingProvider.__abstract_methods__ = ['id', 'name', 'loadAlgorithms']
     QgsProcessingProvider.__group__ = ['processing']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_additions/qgsprocessingprovider.py
+++ b/python/PyQt6/core/auto_additions/qgsprocessingprovider.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/processing/qgsprocessingprovider.h
 try:
     QgsProcessingProvider.__attribute_docs__ = {'algorithmsLoaded': 'Emitted when the provider has loaded (or refreshed) its list of\navailable algorithms.\n\n.. seealso:: :py:func:`refreshAlgorithms`\n'}
-    QgsProcessingProvider.__virtual_methods__ = ['icon', 'svgIconPath', 'flags', 'helpId', 'longName', 'versionInfo', 'canBeActivated', 'warningMessage', 'isActive', 'supportedOutputRasterLayerFormatAndExtensions', 'supportedOutputVectorLayerExtensions', 'supportedOutputPointCloudLayerExtensions', 'supportedOutputVectorTileLayerExtensions', 'supportedOutputTableExtensions', 'isSupportedOutputValue', 'defaultVectorFileExtension', 'defaultRasterFileExtension', 'defaultPointCloudFileExtension', 'defaultVectorTileFileExtension', 'supportsNonFileBasedOutput', 'load', 'unload']
+    QgsProcessingProvider.__virtual_methods__ = ['icon', 'svgIconPath', 'flags', 'helpId', 'longName', 'versionInfo', 'canBeActivated', 'warningMessage', 'isActive', 'supportedOutputRasterLayerFormatAndExtensions', 'supportedOutputVectorLayerExtensions', 'supportedOutputPointCloudLayerExtensions', 'supportedOutputVectorTileLayerExtensions', 'supportedOutputTableExtensions', 'isSupportedOutputValue', 'defaultVectorFileExtension', 'defaultRasterFileFormat', 'defaultPointCloudFileExtension', 'defaultVectorTileFileExtension', 'supportsNonFileBasedOutput', 'load', 'unload']
     QgsProcessingProvider.__abstract_methods__ = ['id', 'name', 'loadAlgorithms']
     QgsProcessingProvider.__group__ = ['processing']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_additions/qgsprocessingutils.py
+++ b/python/PyQt6/core/auto_additions/qgsprocessingutils.py
@@ -72,6 +72,7 @@ try:
     QgsProcessingUtils.fieldNamesToIndices = staticmethod(QgsProcessingUtils.fieldNamesToIndices)
     QgsProcessingUtils.indicesToFields = staticmethod(QgsProcessingUtils.indicesToFields)
     QgsProcessingUtils.defaultVectorExtension = staticmethod(QgsProcessingUtils.defaultVectorExtension)
+    QgsProcessingUtils.defaultRasterFormat = staticmethod(QgsProcessingUtils.defaultRasterFormat)
     QgsProcessingUtils.defaultRasterExtension = staticmethod(QgsProcessingUtils.defaultRasterExtension)
     QgsProcessingUtils.defaultPointCloudExtension = staticmethod(QgsProcessingUtils.defaultPointCloudExtension)
     QgsProcessingUtils.defaultVectorTileExtension = staticmethod(QgsProcessingUtils.defaultVectorTileExtension)

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -964,7 +964,7 @@ Evaluates the parameter with matching ``name`` to a output format
 
 Output format may be empty.
 
-.. versionadded:: 3.40
+.. versionadded:: 4.0
 %End
 
     QString parameterAsOutputRasterFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
@@ -974,7 +974,7 @@ Evaluates the parameter with matching ``name`` to a output format
 If no explicit output format is attached to the parameter, one will be
 attempted to be guessed from the file name extension.
 
-.. versionadded:: 3.40
+.. versionadded:: 4.0
 %End
 
     QString parameterAsFileOutput( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -958,6 +958,25 @@ Evaluates the parameter with matching ``name`` to a output layer
 destination.
 %End
 
+    QString parameterAsOutputFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
+%Docstring
+Evaluates the parameter with matching ``name`` to a output format
+
+Output format may be empty.
+
+.. versionadded:: 3.40
+%End
+
+    QString parameterAsOutputRasterFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
+%Docstring
+Evaluates the parameter with matching ``name`` to a output format
+
+If no explicit output format is attached to the parameter, one will be
+attempted to be guessed from the file name extension.
+
+.. versionadded:: 3.40
+%End
+
     QString parameterAsFileOutput( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a file based output

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -569,7 +569,7 @@ fallback when the returned format is not usable.
 
 .. note::
 
-   Since QGIS 3.40, this method returns a GDAL format name. In prior versions, this was a file extension.
+   Since QGIS 4.0, this method returns a GDAL format name. In prior versions, this was a file extension.
 
 .. versionadded:: 3.10
 %End
@@ -594,7 +594,7 @@ creating these outputs.
 
 .. note::
 
-   Since QGIS 3.40, this method expects a GDAL format name. In prior versions, this was a file extension.
+   Since QGIS 4.0, this method expects a GDAL format name. In prior versions, this was a file extension.
 
 .. versionadded:: 3.10
 %End

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -549,10 +549,10 @@ creating these outputs.
 %Docstring
 Returns the preferred raster format to use for raster outputs.
 
-This method returns a file extension to use when creating raster outputs
-(e.g. "tif"). Generally, it is preferable to use the extension
-associated with a particular parameter, which can be retrieved through
-:py:func:`QgsProcessingDestinationParameter.defaultFileExtension()`.
+This method returns a file format to use when creating raster outputs
+(e.g. "GTiff"). Generally, it is preferable to use the format associated
+with a particular parameter, which can be retrieved through
+:py:func:`QgsProcessingParameterRasterDestination.defaultFileFormat()`.
 However, in some cases, a specific parameter may not be available to
 call this method on (e.g. for an algorithm which has only an output
 folder parameter and which creates multiple output layers in that
@@ -567,6 +567,10 @@ fallback when the returned format is not usable.
 
 .. seealso:: :py:func:`preferredVectorFormat`
 
+.. note::
+
+   Since QGIS 3.40, this method returns a GDAL format name. In prior versions, this was a file extension.
+
 .. versionadded:: 3.10
 %End
 
@@ -574,10 +578,10 @@ fallback when the returned format is not usable.
 %Docstring
 Sets the preferred raster ``format`` to use for raster outputs.
 
-This method sets a file extension to use when creating raster outputs
-(e.g. "tif"). Generally, it is preferable to use the extension
-associated with a particular parameter, which can be retrieved through
-:py:func:`QgsProcessingDestinationParameter.defaultFileExtension()`.
+This method sets a file format to use when creating raster outputs (e.g.
+"GTiff"). Generally, it is preferable to use the format associated with
+a particular parameter, which can be retrieved through
+:py:func:`QgsProcessingParameterRasterDestination.defaultFileFormat()`.
 However, in some cases, a specific parameter may not be available to
 call this method on (e.g. for an algorithm which has only an output
 folder parameter and which creates multiple output layers in that
@@ -587,6 +591,10 @@ creating these outputs.
 .. seealso:: :py:func:`preferredRasterFormat`
 
 .. seealso:: :py:func:`setPreferredVectorFormat`
+
+.. note::
+
+   Since QGIS 3.40, this method expects a GDAL format name. In prior versions, this was a file extension.
 
 .. versionadded:: 3.10
 %End

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -4193,6 +4193,15 @@ Returns the type name for the parameter class.
 
     virtual QString defaultFileExtension() const;
 
+
+    QString defaultFileFormat() const;
+%Docstring
+Returns the default file format for destination file paths associated
+with this parameter.
+
+.. versionadded:: 3.40
+%End
+
     virtual QString createFileFilter() const;
 
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -269,6 +269,24 @@ Calling this method will set
 .. versionadded:: 3.14
 %End
 
+    QString format() const;
+%Docstring
+Returns the format (if set)
+
+.. seealso:: :py:func:`setFormat`
+
+.. versionadded:: 4.0
+%End
+
+    void setFormat( const QString &format );
+%Docstring
+Sets the ``format`` of the output dataset
+
+.. seealso:: :py:func:`format`
+
+.. versionadded:: 4.0
+%End
+
     QVariant toVariant() const;
 %Docstring
 Saves this output layer definition to a QVariantMap, wrapped in a
@@ -1420,6 +1438,15 @@ testing only. This prevents default behavior such as output
 post-processing which would otherwise occur.
 
 .. versionadded:: 3.4
+%End
+
+    static QString parameterAsOutputFormat( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
+%Docstring
+Evaluates the parameter with matching ``definition`` to a output format
+
+Output format may be empty.
+
+.. versionadded:: 3.40
 %End
 
     static QString parameterAsFileOutput( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
@@ -4169,14 +4196,23 @@ Returns the type name for the parameter class.
     virtual QString createFileFilter() const;
 
 
-    virtual QStringList supportedOutputRasterLayerExtensions() const;
+ virtual QStringList supportedOutputRasterLayerExtensions() const /Deprecated="Since 3.40. Use supportedOutputRasterLayerFormatAndExtensions() instead."/;
 %Docstring
 Returns a list of the raster format file extensions supported for this
 parameter.
 
 .. seealso:: :py:func:`defaultFileExtension`
 
-.. versionadded:: 3.2
+.. deprecated:: 3.40
+
+   Use :py:func:`~QgsProcessingParameterRasterDestination.supportedOutputRasterLayerFormatAndExtensions` instead.
+%End
+
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+%Docstring
+Returns a list of (format, file extension) supported by this provider.
+
+.. versionadded:: 3.40
 %End
 
     static QgsProcessingParameterRasterDestination *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -151,7 +151,7 @@ provider.
 
 .. note::
 
-   Since QGIS 3.40, this method is no longer virtual and use internally
+   Since QGIS 4.0, this method is no longer virtual and use internally
    :py:func:`~QgsProcessingProvider.supportedOutputRasterLayerFormatAndExtensions` instead.
 %End
 
@@ -159,7 +159,7 @@ provider.
 %Docstring
 Returns a list of (format, file extension) supported by this provider.
 
-.. versionadded:: 3.40
+.. versionadded:: 4.0
 %End
 
 
@@ -292,7 +292,7 @@ Otherwise the first reported supported raster format will be used.
 
 .. seealso:: :py:func:`defaultRasterFileExtension`
 
-.. versionadded:: 3.40
+.. versionadded:: 4.0
 %End
 
     QString defaultRasterFileExtension() const;
@@ -300,7 +300,7 @@ Otherwise the first reported supported raster format will be used.
 Returns the default file extension to use for raster outputs created by
 the provider.
 
-Starting with QGIS 3.40, this method is no longer virtual, and relies on
+Starting with QGIS 4.0, this method is no longer virtual, and relies on
 :py:func:`~QgsProcessingProvider.defaultRasterFileFormat`
 
 .. seealso:: :py:func:`defaultRasterFileFormat`

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -138,7 +138,7 @@ providers in a "beta" or "untrustworthy" state.
 Returns ``True`` if the provider is active and able to run algorithms.
 %End
 
-    virtual QStringList supportedOutputRasterLayerExtensions() const;
+    QStringList supportedOutputRasterLayerExtensions() const;
 %Docstring
 Returns a list of the raster format file extensions supported by this
 provider.
@@ -148,7 +148,20 @@ provider.
 .. seealso:: :py:func:`supportedOutputPointCloudLayerExtensions`
 
 .. seealso:: :py:func:`supportedOutputVectorTileLayerExtensions`
+
+.. note::
+
+   Since QGIS 3.40, this method is no longer virtual and use internally
+   :py:func:`~QgsProcessingProvider.supportedOutputRasterLayerFormatAndExtensions` instead.
 %End
+
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+%Docstring
+Returns a list of (format, file extension) supported by this provider.
+
+.. versionadded:: 3.40
+%End
+
 
     virtual QStringList supportedOutputVectorLayerExtensions() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -278,17 +278,32 @@ Otherwise the first reported supported vector format will be used.
 .. seealso:: :py:func:`defaultVectorTileFileExtension`
 %End
 
-    virtual QString defaultRasterFileExtension() const;
+    virtual QString defaultRasterFileFormat() const;
+%Docstring
+Returns the default file format to use for raster outputs created by the
+provider.
+
+The default implementation returns the user's default Processing raster
+output format setting, if it's supported by the provider (see
+:py:func:`~QgsProcessingProvider.supportedOutputRasterLayerFormatAndExtensions`).
+Otherwise the first reported supported raster format will be used.
+
+.. seealso:: :py:func:`supportedOutputRasterLayerFormatAndExtensions`
+
+.. seealso:: :py:func:`defaultRasterFileExtension`
+
+.. versionadded:: 3.40
+%End
+
+    QString defaultRasterFileExtension() const;
 %Docstring
 Returns the default file extension to use for raster outputs created by
 the provider.
 
-The default implementation returns the user's default Processing raster
-output format setting, if it's supported by the provider (see
-:py:func:`~QgsProcessingProvider.supportedOutputRasterLayerExtensions`).
-Otherwise the first reported supported raster format will be used.
+Starting with QGIS 3.40, this method is no longer virtual, and relies on
+:py:func:`~QgsProcessingProvider.defaultRasterFileFormat`
 
-.. seealso:: :py:func:`supportedOutputRasterLayerExtensions`
+.. seealso:: :py:func:`defaultRasterFileFormat`
 
 .. seealso:: :py:func:`defaultVectorFileExtension`
 

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -601,6 +601,19 @@ settings, or a fallback value of "gpkg".
 .. versionadded:: 3.10
 %End
 
+    static QString defaultRasterFormat();
+%Docstring
+Returns the default raster format to use, in the absence of all other
+constraints (e.g. provider based support for extensions).
+
+This method returns the user-set default format from the processing
+settings, or a fallback value of "GTiff".
+
+.. seealso:: :py:func:`defaultRasterExtension`
+
+.. versionadded:: 4.0
+%End
+
     static QString defaultRasterExtension();
 %Docstring
 Returns the default raster extension to use, in the absence of all other

--- a/python/analysis/auto_additions/qgspdalalgorithms.py
+++ b/python/analysis/auto_additions/qgspdalalgorithms.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/analysis/processing/pdal/qgspdalalgorithms.h
 try:
-    QgsPdalAlgorithms.__overridden_methods__ = ['icon', 'svgIconPath', 'id', 'helpId', 'name', 'supportsNonFileBasedOutput', 'supportedOutputVectorLayerExtensions', 'supportedOutputRasterLayerExtensions', 'supportedOutputPointCloudLayerExtensions', 'loadAlgorithms']
+    QgsPdalAlgorithms.__overridden_methods__ = ['icon', 'svgIconPath', 'id', 'helpId', 'name', 'supportsNonFileBasedOutput', 'supportedOutputVectorLayerExtensions', 'supportedOutputRasterLayerFormatAndExtensions', 'supportedOutputPointCloudLayerExtensions', 'loadAlgorithms']
     QgsPdalAlgorithms.__group__ = ['processing', 'pdal']
 except (NameError, AttributeError):
     pass

--- a/python/analysis/auto_generated/interpolation/qgsgridfilewriter.sip.in
+++ b/python/analysis/auto_generated/interpolation/qgsgridfilewriter.sip.in
@@ -23,7 +23,7 @@ file.
 #include "qgsgridfilewriter.h"
 %End
   public:
-    QgsGridFileWriter( QgsInterpolator *interpolator, const QString &outputPath, const QgsRectangle &extent, int nCols, int nRows );
+    QgsGridFileWriter( QgsInterpolator *interpolator, const QString &outputPath, const QgsRectangle &extent, int nCols, int nRows, const QString &outputFormat = QString() );
 %Docstring
 Constructor for QgsGridFileWriter, for the specified ``interpolator``.
 
@@ -31,6 +31,9 @@ The ``outputPath`` argument is used to set the output file path.
 
 The ``extent`` and ``nCols``, ``nRows`` arguments dictate the extent and
 size of the output raster.
+
+The ``outputFormat`` (available since QGIS 4.0), if not explicitly set,
+is inferred from the ``outputPath`` extension.
 %End
 
     int writeFile( QgsFeedback *feedback = 0 );

--- a/python/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
+++ b/python/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
@@ -42,7 +42,7 @@ Constructor for QgsPdalAlgorithms.
 
     virtual QStringList supportedOutputVectorLayerExtensions() const;
 
-    virtual QStringList supportedOutputRasterLayerExtensions() const;
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
 
     virtual QStringList supportedOutputPointCloudLayerExtensions() const;
 

--- a/python/core/auto_additions/qgsprocessingparameters.py
+++ b/python/core/auto_additions/qgsprocessingparameters.py
@@ -40,6 +40,7 @@ try:
     QgsProcessingParameters.parameterAsLayer = staticmethod(QgsProcessingParameters.parameterAsLayer)
     QgsProcessingParameters.parameterAsRasterLayer = staticmethod(QgsProcessingParameters.parameterAsRasterLayer)
     QgsProcessingParameters.parameterAsOutputLayer = staticmethod(QgsProcessingParameters.parameterAsOutputLayer)
+    QgsProcessingParameters.parameterAsOutputFormat = staticmethod(QgsProcessingParameters.parameterAsOutputFormat)
     QgsProcessingParameters.parameterAsFileOutput = staticmethod(QgsProcessingParameters.parameterAsFileOutput)
     QgsProcessingParameters.parameterAsVectorLayer = staticmethod(QgsProcessingParameters.parameterAsVectorLayer)
     QgsProcessingParameters.parameterAsMeshLayer = staticmethod(QgsProcessingParameters.parameterAsMeshLayer)
@@ -262,7 +263,7 @@ except (NameError, AttributeError):
 try:
     QgsProcessingParameterRasterDestination.typeName = staticmethod(QgsProcessingParameterRasterDestination.typeName)
     QgsProcessingParameterRasterDestination.fromScriptCode = staticmethod(QgsProcessingParameterRasterDestination.fromScriptCode)
-    QgsProcessingParameterRasterDestination.__virtual_methods__ = ['supportedOutputRasterLayerExtensions']
+    QgsProcessingParameterRasterDestination.__virtual_methods__ = ['supportedOutputRasterLayerExtensions', 'supportedOutputRasterLayerFormatAndExtensions']
     QgsProcessingParameterRasterDestination.__overridden_methods__ = ['clone', 'type', 'checkValueIsAcceptable', 'valueAsPythonString', 'toOutputDefinition', 'defaultFileExtension', 'createFileFilter']
     QgsProcessingParameterRasterDestination.__group__ = ['processing']
 except (NameError, AttributeError):

--- a/python/core/auto_additions/qgsprocessingprovider.py
+++ b/python/core/auto_additions/qgsprocessingprovider.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/processing/qgsprocessingprovider.h
 try:
     QgsProcessingProvider.__attribute_docs__ = {'algorithmsLoaded': 'Emitted when the provider has loaded (or refreshed) its list of\navailable algorithms.\n\n.. seealso:: :py:func:`refreshAlgorithms`\n'}
-    QgsProcessingProvider.__virtual_methods__ = ['icon', 'svgIconPath', 'flags', 'helpId', 'longName', 'versionInfo', 'canBeActivated', 'warningMessage', 'isActive', 'supportedOutputRasterLayerExtensions', 'supportedOutputVectorLayerExtensions', 'supportedOutputPointCloudLayerExtensions', 'supportedOutputVectorTileLayerExtensions', 'supportedOutputTableExtensions', 'isSupportedOutputValue', 'defaultVectorFileExtension', 'defaultRasterFileExtension', 'defaultPointCloudFileExtension', 'defaultVectorTileFileExtension', 'supportsNonFileBasedOutput', 'load', 'unload']
+    QgsProcessingProvider.__virtual_methods__ = ['icon', 'svgIconPath', 'flags', 'helpId', 'longName', 'versionInfo', 'canBeActivated', 'warningMessage', 'isActive', 'supportedOutputRasterLayerFormatAndExtensions', 'supportedOutputVectorLayerExtensions', 'supportedOutputPointCloudLayerExtensions', 'supportedOutputVectorTileLayerExtensions', 'supportedOutputTableExtensions', 'isSupportedOutputValue', 'defaultVectorFileExtension', 'defaultRasterFileExtension', 'defaultPointCloudFileExtension', 'defaultVectorTileFileExtension', 'supportsNonFileBasedOutput', 'load', 'unload']
     QgsProcessingProvider.__abstract_methods__ = ['id', 'name', 'loadAlgorithms']
     QgsProcessingProvider.__group__ = ['processing']
 except (NameError, AttributeError):

--- a/python/core/auto_additions/qgsprocessingprovider.py
+++ b/python/core/auto_additions/qgsprocessingprovider.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/processing/qgsprocessingprovider.h
 try:
     QgsProcessingProvider.__attribute_docs__ = {'algorithmsLoaded': 'Emitted when the provider has loaded (or refreshed) its list of\navailable algorithms.\n\n.. seealso:: :py:func:`refreshAlgorithms`\n'}
-    QgsProcessingProvider.__virtual_methods__ = ['icon', 'svgIconPath', 'flags', 'helpId', 'longName', 'versionInfo', 'canBeActivated', 'warningMessage', 'isActive', 'supportedOutputRasterLayerFormatAndExtensions', 'supportedOutputVectorLayerExtensions', 'supportedOutputPointCloudLayerExtensions', 'supportedOutputVectorTileLayerExtensions', 'supportedOutputTableExtensions', 'isSupportedOutputValue', 'defaultVectorFileExtension', 'defaultRasterFileExtension', 'defaultPointCloudFileExtension', 'defaultVectorTileFileExtension', 'supportsNonFileBasedOutput', 'load', 'unload']
+    QgsProcessingProvider.__virtual_methods__ = ['icon', 'svgIconPath', 'flags', 'helpId', 'longName', 'versionInfo', 'canBeActivated', 'warningMessage', 'isActive', 'supportedOutputRasterLayerFormatAndExtensions', 'supportedOutputVectorLayerExtensions', 'supportedOutputPointCloudLayerExtensions', 'supportedOutputVectorTileLayerExtensions', 'supportedOutputTableExtensions', 'isSupportedOutputValue', 'defaultVectorFileExtension', 'defaultRasterFileFormat', 'defaultPointCloudFileExtension', 'defaultVectorTileFileExtension', 'supportsNonFileBasedOutput', 'load', 'unload']
     QgsProcessingProvider.__abstract_methods__ = ['id', 'name', 'loadAlgorithms']
     QgsProcessingProvider.__group__ = ['processing']
 except (NameError, AttributeError):

--- a/python/core/auto_additions/qgsprocessingutils.py
+++ b/python/core/auto_additions/qgsprocessingutils.py
@@ -72,6 +72,7 @@ try:
     QgsProcessingUtils.fieldNamesToIndices = staticmethod(QgsProcessingUtils.fieldNamesToIndices)
     QgsProcessingUtils.indicesToFields = staticmethod(QgsProcessingUtils.indicesToFields)
     QgsProcessingUtils.defaultVectorExtension = staticmethod(QgsProcessingUtils.defaultVectorExtension)
+    QgsProcessingUtils.defaultRasterFormat = staticmethod(QgsProcessingUtils.defaultRasterFormat)
     QgsProcessingUtils.defaultRasterExtension = staticmethod(QgsProcessingUtils.defaultRasterExtension)
     QgsProcessingUtils.defaultPointCloudExtension = staticmethod(QgsProcessingUtils.defaultPointCloudExtension)
     QgsProcessingUtils.defaultVectorTileExtension = staticmethod(QgsProcessingUtils.defaultVectorTileExtension)

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -964,7 +964,7 @@ Evaluates the parameter with matching ``name`` to a output format
 
 Output format may be empty.
 
-.. versionadded:: 3.40
+.. versionadded:: 4.0
 %End
 
     QString parameterAsOutputRasterFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
@@ -974,7 +974,7 @@ Evaluates the parameter with matching ``name`` to a output format
 If no explicit output format is attached to the parameter, one will be
 attempted to be guessed from the file name extension.
 
-.. versionadded:: 3.40
+.. versionadded:: 4.0
 %End
 
     QString parameterAsFileOutput( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -958,6 +958,25 @@ Evaluates the parameter with matching ``name`` to a output layer
 destination.
 %End
 
+    QString parameterAsOutputFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
+%Docstring
+Evaluates the parameter with matching ``name`` to a output format
+
+Output format may be empty.
+
+.. versionadded:: 3.40
+%End
+
+    QString parameterAsOutputRasterFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
+%Docstring
+Evaluates the parameter with matching ``name`` to a output format
+
+If no explicit output format is attached to the parameter, one will be
+attempted to be guessed from the file name extension.
+
+.. versionadded:: 3.40
+%End
+
     QString parameterAsFileOutput( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a file based output

--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -569,7 +569,7 @@ fallback when the returned format is not usable.
 
 .. note::
 
-   Since QGIS 3.40, this method returns a GDAL format name. In prior versions, this was a file extension.
+   Since QGIS 4.0, this method returns a GDAL format name. In prior versions, this was a file extension.
 
 .. versionadded:: 3.10
 %End
@@ -594,7 +594,7 @@ creating these outputs.
 
 .. note::
 
-   Since QGIS 3.40, this method expects a GDAL format name. In prior versions, this was a file extension.
+   Since QGIS 4.0, this method expects a GDAL format name. In prior versions, this was a file extension.
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -549,10 +549,10 @@ creating these outputs.
 %Docstring
 Returns the preferred raster format to use for raster outputs.
 
-This method returns a file extension to use when creating raster outputs
-(e.g. "tif"). Generally, it is preferable to use the extension
-associated with a particular parameter, which can be retrieved through
-:py:func:`QgsProcessingDestinationParameter.defaultFileExtension()`.
+This method returns a file format to use when creating raster outputs
+(e.g. "GTiff"). Generally, it is preferable to use the format associated
+with a particular parameter, which can be retrieved through
+:py:func:`QgsProcessingParameterRasterDestination.defaultFileFormat()`.
 However, in some cases, a specific parameter may not be available to
 call this method on (e.g. for an algorithm which has only an output
 folder parameter and which creates multiple output layers in that
@@ -567,6 +567,10 @@ fallback when the returned format is not usable.
 
 .. seealso:: :py:func:`preferredVectorFormat`
 
+.. note::
+
+   Since QGIS 3.40, this method returns a GDAL format name. In prior versions, this was a file extension.
+
 .. versionadded:: 3.10
 %End
 
@@ -574,10 +578,10 @@ fallback when the returned format is not usable.
 %Docstring
 Sets the preferred raster ``format`` to use for raster outputs.
 
-This method sets a file extension to use when creating raster outputs
-(e.g. "tif"). Generally, it is preferable to use the extension
-associated with a particular parameter, which can be retrieved through
-:py:func:`QgsProcessingDestinationParameter.defaultFileExtension()`.
+This method sets a file format to use when creating raster outputs (e.g.
+"GTiff"). Generally, it is preferable to use the format associated with
+a particular parameter, which can be retrieved through
+:py:func:`QgsProcessingParameterRasterDestination.defaultFileFormat()`.
 However, in some cases, a specific parameter may not be available to
 call this method on (e.g. for an algorithm which has only an output
 folder parameter and which creates multiple output layers in that
@@ -587,6 +591,10 @@ creating these outputs.
 .. seealso:: :py:func:`preferredRasterFormat`
 
 .. seealso:: :py:func:`setPreferredVectorFormat`
+
+.. note::
+
+   Since QGIS 3.40, this method expects a GDAL format name. In prior versions, this was a file extension.
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -4193,6 +4193,15 @@ Returns the type name for the parameter class.
 
     virtual QString defaultFileExtension() const;
 
+
+    QString defaultFileFormat() const;
+%Docstring
+Returns the default file format for destination file paths associated
+with this parameter.
+
+.. versionadded:: 3.40
+%End
+
     virtual QString createFileFilter() const;
 
 

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -269,6 +269,24 @@ Calling this method will set
 .. versionadded:: 3.14
 %End
 
+    QString format() const;
+%Docstring
+Returns the format (if set)
+
+.. seealso:: :py:func:`setFormat`
+
+.. versionadded:: 4.0
+%End
+
+    void setFormat( const QString &format );
+%Docstring
+Sets the ``format`` of the output dataset
+
+.. seealso:: :py:func:`format`
+
+.. versionadded:: 4.0
+%End
+
     QVariant toVariant() const;
 %Docstring
 Saves this output layer definition to a QVariantMap, wrapped in a
@@ -1420,6 +1438,15 @@ testing only. This prevents default behavior such as output
 post-processing which would otherwise occur.
 
 .. versionadded:: 3.4
+%End
+
+    static QString parameterAsOutputFormat( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
+%Docstring
+Evaluates the parameter with matching ``definition`` to a output format
+
+Output format may be empty.
+
+.. versionadded:: 3.40
 %End
 
     static QString parameterAsFileOutput( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
@@ -4169,14 +4196,23 @@ Returns the type name for the parameter class.
     virtual QString createFileFilter() const;
 
 
-    virtual QStringList supportedOutputRasterLayerExtensions() const;
+ virtual QStringList supportedOutputRasterLayerExtensions() const /Deprecated="Since 3.40. Use supportedOutputRasterLayerFormatAndExtensions() instead."/;
 %Docstring
 Returns a list of the raster format file extensions supported for this
 parameter.
 
 .. seealso:: :py:func:`defaultFileExtension`
 
-.. versionadded:: 3.2
+.. deprecated:: 3.40
+
+   Use :py:func:`~QgsProcessingParameterRasterDestination.supportedOutputRasterLayerFormatAndExtensions` instead.
+%End
+
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+%Docstring
+Returns a list of (format, file extension) supported by this provider.
+
+.. versionadded:: 3.40
 %End
 
     static QgsProcessingParameterRasterDestination *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;

--- a/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -151,7 +151,7 @@ provider.
 
 .. note::
 
-   Since QGIS 3.40, this method is no longer virtual and use internally
+   Since QGIS 4.0, this method is no longer virtual and use internally
    :py:func:`~QgsProcessingProvider.supportedOutputRasterLayerFormatAndExtensions` instead.
 %End
 
@@ -159,7 +159,7 @@ provider.
 %Docstring
 Returns a list of (format, file extension) supported by this provider.
 
-.. versionadded:: 3.40
+.. versionadded:: 4.0
 %End
 
 
@@ -292,7 +292,7 @@ Otherwise the first reported supported raster format will be used.
 
 .. seealso:: :py:func:`defaultRasterFileExtension`
 
-.. versionadded:: 3.40
+.. versionadded:: 4.0
 %End
 
     QString defaultRasterFileExtension() const;
@@ -300,7 +300,7 @@ Otherwise the first reported supported raster format will be used.
 Returns the default file extension to use for raster outputs created by
 the provider.
 
-Starting with QGIS 3.40, this method is no longer virtual, and relies on
+Starting with QGIS 4.0, this method is no longer virtual, and relies on
 :py:func:`~QgsProcessingProvider.defaultRasterFileFormat`
 
 .. seealso:: :py:func:`defaultRasterFileFormat`

--- a/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -138,7 +138,7 @@ providers in a "beta" or "untrustworthy" state.
 Returns ``True`` if the provider is active and able to run algorithms.
 %End
 
-    virtual QStringList supportedOutputRasterLayerExtensions() const;
+    QStringList supportedOutputRasterLayerExtensions() const;
 %Docstring
 Returns a list of the raster format file extensions supported by this
 provider.
@@ -148,7 +148,20 @@ provider.
 .. seealso:: :py:func:`supportedOutputPointCloudLayerExtensions`
 
 .. seealso:: :py:func:`supportedOutputVectorTileLayerExtensions`
+
+.. note::
+
+   Since QGIS 3.40, this method is no longer virtual and use internally
+   :py:func:`~QgsProcessingProvider.supportedOutputRasterLayerFormatAndExtensions` instead.
 %End
+
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+%Docstring
+Returns a list of (format, file extension) supported by this provider.
+
+.. versionadded:: 3.40
+%End
+
 
     virtual QStringList supportedOutputVectorLayerExtensions() const;
 %Docstring

--- a/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -278,17 +278,32 @@ Otherwise the first reported supported vector format will be used.
 .. seealso:: :py:func:`defaultVectorTileFileExtension`
 %End
 
-    virtual QString defaultRasterFileExtension() const;
+    virtual QString defaultRasterFileFormat() const;
+%Docstring
+Returns the default file format to use for raster outputs created by the
+provider.
+
+The default implementation returns the user's default Processing raster
+output format setting, if it's supported by the provider (see
+:py:func:`~QgsProcessingProvider.supportedOutputRasterLayerFormatAndExtensions`).
+Otherwise the first reported supported raster format will be used.
+
+.. seealso:: :py:func:`supportedOutputRasterLayerFormatAndExtensions`
+
+.. seealso:: :py:func:`defaultRasterFileExtension`
+
+.. versionadded:: 3.40
+%End
+
+    QString defaultRasterFileExtension() const;
 %Docstring
 Returns the default file extension to use for raster outputs created by
 the provider.
 
-The default implementation returns the user's default Processing raster
-output format setting, if it's supported by the provider (see
-:py:func:`~QgsProcessingProvider.supportedOutputRasterLayerExtensions`).
-Otherwise the first reported supported raster format will be used.
+Starting with QGIS 3.40, this method is no longer virtual, and relies on
+:py:func:`~QgsProcessingProvider.defaultRasterFileFormat`
 
-.. seealso:: :py:func:`supportedOutputRasterLayerExtensions`
+.. seealso:: :py:func:`defaultRasterFileFormat`
 
 .. seealso:: :py:func:`defaultVectorFileExtension`
 

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -601,6 +601,19 @@ settings, or a fallback value of "gpkg".
 .. versionadded:: 3.10
 %End
 
+    static QString defaultRasterFormat();
+%Docstring
+Returns the default raster format to use, in the absence of all other
+constraints (e.g. provider based support for extensions).
+
+This method returns the user-set default format from the processing
+settings, or a fallback value of "GTiff".
+
+.. seealso:: :py:func:`defaultRasterExtension`
+
+.. versionadded:: 4.0
+%End
+
     static QString defaultRasterExtension();
 %Docstring
 Returns the default raster extension to use, in the absence of all other

--- a/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
@@ -251,7 +251,7 @@ class ClipRasterByExtent(GdalAlgorithm):
 
             arguments.append("-ot " + self.TYPES[data_type])
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/ClipRasterByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByMask.py
@@ -360,7 +360,7 @@ class ClipRasterByMask(GdalAlgorithm):
 
             arguments.append("-ot " + self.TYPES[data_type])
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/ColorRelief.py
+++ b/python/plugins/processing/algs/gdal/ColorRelief.py
@@ -164,7 +164,7 @@ class ColorRelief(GdalAlgorithm):
         self.setOutputValue(self.OUTPUT, out)
         arguments.append(out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/GdalAlgorithm.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithm.py
@@ -34,6 +34,7 @@ from qgis.core import (
     QgsProcessingFeedback,
     QgsProviderRegistry,
     QgsDataSourceUri,
+    QgsRasterFileWriter,
 )
 
 from processing.algs.gdal.GdalAlgorithmDialog import GdalAlgorithmDialog
@@ -213,3 +214,12 @@ class GdalAlgorithm(QgsProcessingAlgorithm):
         if context == "":
             context = self.__class__.__name__
         return QCoreApplication.translate(context, string)
+
+    def outputFormat(self, parameters, parameterName, context):
+        output_format = self.parameterAsOutputFormat(parameters, parameterName, context)
+        if not output_format:
+            out = self.parameterAsOutputLayer(parameters, parameterName, context)
+            output_format = QgsRasterFileWriter.driverForExtension(
+                os.path.splitext(out)[1]
+            )
+        return output_format

--- a/python/plugins/processing/algs/gdal/GridAverage.py
+++ b/python/plugins/processing/algs/gdal/GridAverage.py
@@ -259,7 +259,7 @@ class GridAverage(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/GridDataMetrics.py
+++ b/python/plugins/processing/algs/gdal/GridDataMetrics.py
@@ -276,7 +276,7 @@ class GridDataMetrics(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/GridInverseDistance.py
+++ b/python/plugins/processing/algs/gdal/GridInverseDistance.py
@@ -295,7 +295,7 @@ class GridInverseDistance(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/GridInverseDistanceNearestNeighbor.py
+++ b/python/plugins/processing/algs/gdal/GridInverseDistanceNearestNeighbor.py
@@ -266,7 +266,7 @@ class GridInverseDistanceNearestNeighbor(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/GridLinear.py
+++ b/python/plugins/processing/algs/gdal/GridLinear.py
@@ -216,7 +216,7 @@ class GridLinear(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/GridNearestNeighbor.py
+++ b/python/plugins/processing/algs/gdal/GridNearestNeighbor.py
@@ -244,7 +244,7 @@ class GridNearestNeighbor(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/aspect.py
+++ b/python/plugins/processing/algs/gdal/aspect.py
@@ -165,7 +165,7 @@ class aspect(GdalAlgorithm):
         arguments.append(out)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/fillnodata.py
+++ b/python/plugins/processing/algs/gdal/fillnodata.py
@@ -202,7 +202,7 @@ class fillnodata(GdalAlgorithm):
             arguments.append("-mask")
             arguments.append(mask.source())
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/hillshade.py
+++ b/python/plugins/processing/algs/gdal/hillshade.py
@@ -205,7 +205,7 @@ class hillshade(GdalAlgorithm):
         self.setOutputValue(self.OUTPUT, out)
         arguments.append(out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/merge.py
+++ b/python/plugins/processing/algs/gdal/merge.py
@@ -230,7 +230,7 @@ class merge(GdalAlgorithm):
 
         arguments.append("-ot " + self.TYPES[data_type])
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/nearblack.py
+++ b/python/plugins/processing/algs/gdal/nearblack.py
@@ -146,7 +146,7 @@ class nearblack(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/pansharp.py
+++ b/python/plugins/processing/algs/gdal/pansharp.py
@@ -164,7 +164,7 @@ class pansharp(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/pct2rgb.py
+++ b/python/plugins/processing/algs/gdal/pct2rgb.py
@@ -99,7 +99,7 @@ class pct2rgb(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/proximity.py
+++ b/python/plugins/processing/algs/gdal/proximity.py
@@ -282,7 +282,7 @@ class proximity(GdalAlgorithm):
 
         arguments.append("-ot " + self.TYPES[data_type])
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -315,7 +315,7 @@ class rasterize(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/rearrange_bands.py
+++ b/python/plugins/processing/algs/gdal/rearrange_bands.py
@@ -173,7 +173,7 @@ class rearrange_bands(GdalAlgorithm):
 
             arguments.append("-ot " + self.TYPES[data_type])
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/rgb2pct.py
+++ b/python/plugins/processing/algs/gdal/rgb2pct.py
@@ -95,7 +95,7 @@ class rgb2pct(GdalAlgorithm):
             )
         input_details = GdalUtils.gdal_connection_details_from_layer(raster)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/roughness.py
+++ b/python/plugins/processing/algs/gdal/roughness.py
@@ -126,7 +126,7 @@ class roughness(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/sieve.py
+++ b/python/plugins/processing/algs/gdal/sieve.py
@@ -141,7 +141,7 @@ class sieve(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/slope.py
+++ b/python/plugins/processing/algs/gdal/slope.py
@@ -164,7 +164,7 @@ class slope(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/translate.py
+++ b/python/plugins/processing/algs/gdal/translate.py
@@ -213,7 +213,7 @@ class translate(GdalAlgorithm):
 
             arguments.append("-ot " + self.TYPES[data_type])
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/algs/gdal/viewshed.py
+++ b/python/plugins/processing/algs/gdal/viewshed.py
@@ -183,7 +183,7 @@ class viewshed(GdalAlgorithm):
             "-md",
             f"{self.parameterAsDouble(parameters, self.MAX_DISTANCE, context)}",
             "-f",
-            QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1]),
+            self.outputFormat(parameters, self.OUTPUT, context),
         ]
 
         options = self.parameterAsString(parameters, self.CREATION_OPTIONS, context)

--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -313,7 +313,7 @@ class warp(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)
 
-        output_format = QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1])
+        output_format = self.outputFormat(parameters, self.OUTPUT, context)
         if not output_format:
             raise QgsProcessingException(self.tr("Output format is invalid"))
 

--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -59,7 +59,7 @@ class ProcessingConfig:
     SHOW_PROVIDERS_TOOLTIP = "SHOW_PROVIDERS_TOOLTIP"
     SHOW_ALGORITHMS_KNOWN_ISSUES = "SHOW_ALGORITHMS_KNOWN_ISSUES"
     MAX_THREADS = "MAX_THREADS"
-    DEFAULT_OUTPUT_RASTER_LAYER_EXT = "default-output-raster-ext"
+    DEFAULT_OUTPUT_RASTER_LAYER_FORMAT = "default-output-raster-format"
     DEFAULT_OUTPUT_VECTOR_LAYER_EXT = "default-output-vector-ext"
     TEMP_PATH = "temp-path"
     RESULTS_GROUP_NAME = "RESULTS_GROUP_NAME"
@@ -232,15 +232,15 @@ class ProcessingConfig:
             )
         )
 
-        extensions = QgsRasterFileWriter.supportedFormatExtensions()
+        filtersAndFormats = QgsRasterFileWriter.supportedFiltersAndFormats()
         ProcessingConfig.addSetting(
             Setting(
                 ProcessingConfig.tr("General"),
-                ProcessingConfig.DEFAULT_OUTPUT_RASTER_LAYER_EXT,
-                ProcessingConfig.tr("Default output raster layer extension"),
-                "tif",
+                ProcessingConfig.DEFAULT_OUTPUT_RASTER_LAYER_FORMAT,
+                ProcessingConfig.tr("Default output raster layer format"),
+                "GTiff",
                 valuetype=Setting.SELECTION_STORE_STRING,
-                options=extensions,
+                options=[x.driverName for x in filtersAndFormats],
                 hasSettingEntry=True,
             )
         )

--- a/src/analysis/interpolation/qgsgridfilewriter.cpp
+++ b/src/analysis/interpolation/qgsgridfilewriter.cpp
@@ -26,7 +26,7 @@
 
 #include <QFileInfo>
 
-QgsGridFileWriter::QgsGridFileWriter( QgsInterpolator *i, const QString &outputPath, const QgsRectangle &extent, int nCols, int nRows )
+QgsGridFileWriter::QgsGridFileWriter( QgsInterpolator *i, const QString &outputPath, const QgsRectangle &extent, int nCols, int nRows, const QString &outputFormat )
   : mInterpolator( i )
   , mOutputFilePath( outputPath )
   , mInterpolationExtent( extent )
@@ -34,19 +34,17 @@ QgsGridFileWriter::QgsGridFileWriter( QgsInterpolator *i, const QString &outputP
   , mNumRows( nRows )
   , mCellSizeX( extent.width() / nCols )
   , mCellSizeY( extent.height() / nRows )
+  , mOutputFormat( outputFormat.isEmpty() ? QgsRasterFileWriter::driverForExtension( QFileInfo( mOutputFilePath ).suffix() ) : outputFormat )
 {}
 
 int QgsGridFileWriter::writeFile( QgsFeedback *feedback )
 {
-  const QFileInfo fi( mOutputFilePath );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
-
   QgsInterpolator::LayerData ld = mInterpolator->layerData().at( 0 );
   const QgsCoordinateReferenceSystem crs = ld.source->sourceCrs();
 
   auto writer = std::make_unique<QgsRasterFileWriter>( mOutputFilePath );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );
-  writer->setOutputFormat( outputFormat );
+  writer->setOutputFormat( mOutputFormat );
   writer->setCreationOptions( mCreationOptions );
 
   std::unique_ptr<QgsRasterDataProvider> provider( writer->createOneBandRaster( Qgis::DataType::Float32, mNumColumns, mNumRows, mInterpolationExtent, crs ) );

--- a/src/analysis/interpolation/qgsgridfilewriter.h
+++ b/src/analysis/interpolation/qgsgridfilewriter.h
@@ -42,8 +42,10 @@ class ANALYSIS_EXPORT QgsGridFileWriter
      * The \a outputPath argument is used to set the output file path.
      *
      * The \a extent and \a nCols, \a nRows arguments dictate the extent and size of the output raster.
+     *
+     * The \a outputFormat (available since QGIS 4.0), if not explicitly set, is inferred from the \a outputPath extension.
      */
-    QgsGridFileWriter( QgsInterpolator *interpolator, const QString &outputPath, const QgsRectangle &extent, int nCols, int nRows );
+    QgsGridFileWriter( QgsInterpolator *interpolator, const QString &outputPath, const QgsRectangle &extent, int nCols, int nRows, const QString &outputFormat = QString() );
 
     /**
      * Writes the grid file.
@@ -97,6 +99,8 @@ class ANALYSIS_EXPORT QgsGridFileWriter
 
     double mCellSizeX = 0;
     double mCellSizeY = 0;
+
+    QString mOutputFormat;
 
     QStringList mCreationOptions;
     double mNoDataValue = -9999.0;

--- a/src/analysis/processing/pdal/qgspdalalgorithms.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithms.cpp
@@ -80,9 +80,9 @@ QStringList QgsPdalAlgorithms::supportedOutputVectorLayerExtensions() const
   return QStringList() << QStringLiteral( "gpkg" );
 }
 
-QStringList QgsPdalAlgorithms::supportedOutputRasterLayerExtensions() const
+QList<QPair<QString, QString>> QgsPdalAlgorithms::supportedOutputRasterLayerFormatAndExtensions() const
 {
-  return QStringList() << QStringLiteral( "tif" );
+  return QList<QPair<QString, QString>>() << QPair<QString, QString>( QString(), QStringLiteral( "tif" ) );
 }
 
 QStringList QgsPdalAlgorithms::supportedOutputPointCloudLayerExtensions() const

--- a/src/analysis/processing/pdal/qgspdalalgorithms.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithms.h
@@ -47,7 +47,7 @@ class ANALYSIS_EXPORT QgsPdalAlgorithms : public QgsProcessingProvider
     bool supportsNonFileBasedOutput() const override;
 
     QStringList supportedOutputVectorLayerExtensions() const override;
-    QStringList supportedOutputRasterLayerExtensions() const override;
+    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override;
     QStringList supportedOutputPointCloudLayerExtensions() const override;
 
   protected:

--- a/src/analysis/processing/qgsalgorithmaspect.cpp
+++ b/src/analysis/processing/qgsalgorithmaspect.cpp
@@ -83,8 +83,7 @@ QVariantMap QgsAspectAlgorithm::processAlgorithm( const QVariantMap &parameters,
   const double zFactor = parameterAsDouble( parameters, QStringLiteral( "Z_FACTOR" ), context );
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   QgsAspectFilter aspect( inputLayer->source(), outputFile, outputFormat );
   aspect.setZFactor( zFactor );

--- a/src/analysis/processing/qgsalgorithmcellstatistics.cpp
+++ b/src/analysis/processing/qgsalgorithmcellstatistics.cpp
@@ -140,8 +140,7 @@ QVariantMap QgsCellStatisticsAlgorithmBase::processAlgorithm( const QVariantMap 
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   auto writer = std::make_unique<QgsRasterFileWriter>( outputFile );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );

--- a/src/analysis/processing/qgsalgorithmconstantraster.cpp
+++ b/src/analysis/processing/qgsalgorithmconstantraster.cpp
@@ -177,8 +177,7 @@ QVariantMap QgsConstantRasterAlgorithm::processAlgorithm( const QVariantMap &par
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   // round up width and height to the nearest integer as GDAL does (e.g. in gdal_rasterize)
   // see https://github.com/qgis/QGIS/issues/43547

--- a/src/analysis/processing/qgsalgorithmexportmesh.cpp
+++ b/src/analysis/processing/qgsalgorithmexportmesh.cpp
@@ -866,8 +866,7 @@ QVariantMap QgsMeshRasterizeAlgorithm::processAlgorithm( const QVariantMap &para
     creationOptions = optionsString;
 
   const QString fileName = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fileInfo( fileName );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fileInfo.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
   QgsRasterFileWriter rasterFileWriter( fileName );
   rasterFileWriter.setOutputProviderKey( QStringLiteral( "gdal" ) );
   if ( !creationOptions.isEmpty() )

--- a/src/analysis/processing/qgsalgorithmfillnodata.cpp
+++ b/src/analysis/processing/qgsalgorithmfillnodata.cpp
@@ -124,8 +124,7 @@ QVariantMap QgsFillNoDataAlgorithm::processAlgorithm( const QVariantMap &paramet
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
   auto writer = std::make_unique<QgsRasterFileWriter>( outputFile );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );
   if ( !creationOptions.isEmpty() )

--- a/src/analysis/processing/qgsalgorithmfillsinkswangliu.cpp
+++ b/src/analysis/processing/qgsalgorithmfillsinkswangliu.cpp
@@ -195,8 +195,7 @@ QVariantMap QgsFillSinksWangLiuAlgorithm::processAlgorithm( const QVariantMap &p
 
   if ( !filledDemOutputFile.isEmpty() )
   {
-    const QFileInfo fi( filledDemOutputFile );
-    const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+    const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT_FILLED_DEM" ), context );
 
     filledDemWriter = std::make_unique<QgsRasterFileWriter>( filledDemOutputFile );
     filledDemWriter->setOutputProviderKey( QStringLiteral( "gdal" ) );
@@ -222,8 +221,7 @@ QVariantMap QgsFillSinksWangLiuAlgorithm::processAlgorithm( const QVariantMap &p
 
   if ( !flowDirectionsOutputFile.isEmpty() )
   {
-    const QFileInfo fi( flowDirectionsOutputFile );
-    const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+    const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT_FLOW_DIRECTIONS" ), context );
 
     flowDirectionsWriter = std::make_unique<QgsRasterFileWriter>( flowDirectionsOutputFile );
     flowDirectionsWriter->setOutputProviderKey( QStringLiteral( "gdal" ) );
@@ -245,8 +243,7 @@ QVariantMap QgsFillSinksWangLiuAlgorithm::processAlgorithm( const QVariantMap &p
 
   if ( !watershedBasinsOutputFile.isEmpty() )
   {
-    const QFileInfo fi( watershedBasinsOutputFile );
-    const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+    const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT_WATERSHED_BASINS" ), context );
 
     watershedBasinsWriter = std::make_unique<QgsRasterFileWriter>( watershedBasinsOutputFile );
     watershedBasinsWriter->setOutputProviderKey( QStringLiteral( "gdal" ) );

--- a/src/analysis/processing/qgsalgorithmfuzzifyraster.cpp
+++ b/src/analysis/processing/qgsalgorithmfuzzifyraster.cpp
@@ -99,8 +99,7 @@ QVariantMap QgsFuzzifyRasterAlgorithmBase::processAlgorithm( const QVariantMap &
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   auto writer = std::make_unique<QgsRasterFileWriter>( outputFile );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );

--- a/src/analysis/processing/qgsalgorithmhillshade.cpp
+++ b/src/analysis/processing/qgsalgorithmhillshade.cpp
@@ -86,8 +86,7 @@ QVariantMap QgsHillshadeAlgorithm::processAlgorithm( const QVariantMap &paramete
   const double vAngle = parameterAsDouble( parameters, QStringLiteral( "V_ANGLE" ), context );
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   QgsHillshadeFilter hillshade( inputLayer->source(), outputFile, outputFormat, azimuth, vAngle );
   hillshade.setZFactor( zFactor );

--- a/src/analysis/processing/qgsalgorithmlinedensity.cpp
+++ b/src/analysis/processing/qgsalgorithmlinedensity.cpp
@@ -157,8 +157,7 @@ QVariantMap QgsLineDensityAlgorithm::processAlgorithm( const QVariantMap &parame
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   // round up width and height to the nearest integer as GDAL does (e.g. in gdal_rasterize)
   // see https://github.com/qgis/QGIS/issues/43547

--- a/src/analysis/processing/qgsalgorithmrandomraster.cpp
+++ b/src/analysis/processing/qgsalgorithmrandomraster.cpp
@@ -94,8 +94,7 @@ QVariantMap QgsRandomRasterAlgorithmBase::processAlgorithm( const QVariantMap &p
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   // round up width and height to the nearest integer as GDAL does (e.g. in gdal_rasterize)
   // see https://github.com/qgis/QGIS/issues/43547

--- a/src/analysis/processing/qgsalgorithmrastercalculator.cpp
+++ b/src/analysis/processing/qgsalgorithmrastercalculator.cpp
@@ -180,8 +180,7 @@ QVariantMap QgsRasterCalculatorAlgorithm::processAlgorithm( const QVariantMap &p
   const QString creationOptions = parameterAsString( parameters, QStringLiteral( "CREATION_OPTIONS" ), context ).trimmed();
   const QString expression = parameterAsExpression( parameters, QStringLiteral( "EXPRESSION" ), context );
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   double width = std::round( ( bbox.xMaximum() - bbox.xMinimum() ) / cellSize );
   double height = std::round( ( bbox.yMaximum() - bbox.yMinimum() ) / cellSize );
@@ -321,8 +320,7 @@ QVariantMap QgsRasterCalculatorModelerAlgorithm::processAlgorithm( const QVarian
 
   const QString expression = parameterAsExpression( parameters, QStringLiteral( "EXPRESSION" ), context );
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   double width = std::round( ( bbox.xMaximum() - bbox.xMinimum() ) / cellSize );
   double height = std::round( ( bbox.yMaximum() - bbox.yMinimum() ) / cellSize );

--- a/src/analysis/processing/qgsalgorithmrasterdtmslopebasedfilter.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterdtmslopebasedfilter.cpp
@@ -157,8 +157,7 @@ QVariantMap QgsRasterDtmSlopeBasedFilterAlgorithm::processAlgorithm( const QVari
 
   if ( !groundOutputFile.isEmpty() )
   {
-    const QFileInfo fi( groundOutputFile );
-    const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+    const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT_GROUND" ), context );
 
     groundWriter = std::make_unique<QgsRasterFileWriter>( groundOutputFile );
     groundWriter->setOutputProviderKey( QStringLiteral( "gdal" ) );
@@ -185,8 +184,7 @@ QVariantMap QgsRasterDtmSlopeBasedFilterAlgorithm::processAlgorithm( const QVari
 
   if ( !nonGroundOutputFile.isEmpty() )
   {
-    const QFileInfo fi( groundOutputFile );
-    const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+    const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT_NONGROUND" ), context );
 
     nonGroundWriter = std::make_unique<QgsRasterFileWriter>( nonGroundOutputFile );
     nonGroundWriter->setOutputProviderKey( QStringLiteral( "gdal" ) );

--- a/src/analysis/processing/qgsalgorithmrasterfrequencybycomparisonoperator.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterfrequencybycomparisonoperator.cpp
@@ -129,8 +129,7 @@ QVariantMap QgsRasterFrequencyByComparisonOperatorBase::processAlgorithm( const 
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   auto writer = std::make_unique<QgsRasterFileWriter>( outputFile );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );

--- a/src/analysis/processing/qgsalgorithmrasterize.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterize.cpp
@@ -228,7 +228,7 @@ QVariantMap QgsRasterizeAlgorithm::processAlgorithm( const QVariantMap &paramete
     }
   }
 
-  const QString driverName { QgsRasterFileWriter::driverForExtension( QFileInfo( outputLayerFileName ).suffix() ) };
+  const QString driverName = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
   if ( driverName.isEmpty() )
   {
     throw QgsProcessingException( QObject::tr( "Invalid output raster format" ) );

--- a/src/analysis/processing/qgsalgorithmrasterlogicalop.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterlogicalop.cpp
@@ -136,8 +136,7 @@ QVariantMap QgsRasterBooleanLogicAlgorithmBase::processAlgorithm( const QVariant
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   auto writer = std::make_unique<QgsRasterFileWriter>( outputFile );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );

--- a/src/analysis/processing/qgsalgorithmrasterrank.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterrank.cpp
@@ -220,8 +220,7 @@ QVariantMap QgsRasterRankAlgorithm::processAlgorithm( const QVariantMap &paramet
   qgssize rows = static_cast<qgssize>( std::round( ( outputExtent.yMaximum() - outputExtent.yMinimum() ) / outputCellSizeY ) );
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   auto writer = std::make_unique<QgsRasterFileWriter>( outputFile );
   writer->setOutputFormat( outputFormat );

--- a/src/analysis/processing/qgsalgorithmrasterstackposition.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterstackposition.cpp
@@ -125,8 +125,7 @@ QVariantMap QgsRasterStackPositionAlgorithmBase::processAlgorithm( const QVarian
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   auto writer = std::make_unique<QgsRasterFileWriter>( outputFile );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );

--- a/src/analysis/processing/qgsalgorithmreclassifybylayer.cpp
+++ b/src/analysis/processing/qgsalgorithmreclassifybylayer.cpp
@@ -143,8 +143,7 @@ QVariantMap QgsReclassifyAlgorithmBase::processAlgorithm( const QVariantMap &par
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   auto writer = std::make_unique<QgsRasterFileWriter>( outputFile );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );

--- a/src/analysis/processing/qgsalgorithmrescaleraster.cpp
+++ b/src/analysis/processing/qgsalgorithmrescaleraster.cpp
@@ -154,8 +154,7 @@ QVariantMap QgsRescaleRasterAlgorithm::processAlgorithm( const QVariantMap &para
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
   auto writer = std::make_unique<QgsRasterFileWriter>( outputFile );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );
   if ( !creationOptions.isEmpty() )

--- a/src/analysis/processing/qgsalgorithmroundrastervalues.cpp
+++ b/src/analysis/processing/qgsalgorithmroundrastervalues.cpp
@@ -150,8 +150,7 @@ QVariantMap QgsRoundRasterValuesAlgorithm::processAlgorithm( const QVariantMap &
     creationOptions = optionsString;
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
   auto writer = std::make_unique<QgsRasterFileWriter>( outputFile );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );
   if ( !creationOptions.isEmpty() )

--- a/src/analysis/processing/qgsalgorithmruggedness.cpp
+++ b/src/analysis/processing/qgsalgorithmruggedness.cpp
@@ -85,8 +85,7 @@ QVariantMap QgsRuggednessAlgorithm::processAlgorithm( const QVariantMap &paramet
   const double zFactor = parameterAsDouble( parameters, QStringLiteral( "Z_FACTOR" ), context );
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   QgsRuggednessFilter ruggedness( inputLayer->source(), outputFile, outputFormat );
   ruggedness.setZFactor( zFactor );

--- a/src/analysis/processing/qgsalgorithmslope.cpp
+++ b/src/analysis/processing/qgsalgorithmslope.cpp
@@ -82,8 +82,7 @@ QVariantMap QgsSlopeAlgorithm::processAlgorithm( const QVariantMap &parameters, 
   const double zFactor = parameterAsDouble( parameters, QStringLiteral( "Z_FACTOR" ), context );
 
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
-  const QFileInfo fi( outputFile );
-  const QString outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
   QgsSlopeFilter slope( inputLayer->source(), outputFile, outputFormat );
   slope.setZFactor( zFactor );

--- a/src/core/processing/qgsprocessing.cpp
+++ b/src/core/processing/qgsprocessing.cpp
@@ -25,7 +25,7 @@ const QgsSettingsEntryString *QgsProcessing::settingsTempPath = new QgsSettingsE
 
 const QgsSettingsEntryString *QgsProcessing::settingsDefaultOutputVectorLayerExt = new QgsSettingsEntryString( QStringLiteral( "default-output-vector-ext" ), sTreeConfiguration, QString(), QObject::tr( "Default output vector layer extension" ) );
 
-const QgsSettingsEntryString *QgsProcessing::settingsDefaultOutputRasterLayerExt = new QgsSettingsEntryString( QStringLiteral( "default-output-raster-ext" ), sTreeConfiguration, QString(), QObject::tr( "Default output raster layer extension" ) );
+const QgsSettingsEntryString *QgsProcessing::settingsDefaultOutputRasterLayerFormat = new QgsSettingsEntryString( QStringLiteral( "default-output-raster-format" ), sTreeConfiguration, QString(), QObject::tr( "Default output raster layer format" ) );
 
 const QString QgsProcessing::TEMPORARY_OUTPUT = QStringLiteral( "TEMPORARY_OUTPUT" );
 

--- a/src/core/processing/qgsprocessing.h
+++ b/src/core/processing/qgsprocessing.h
@@ -128,8 +128,8 @@ class CORE_EXPORT QgsProcessing
     static const QgsSettingsEntryString *settingsTempPath;
     //! Settings entry default output vector layer ext
     static const QgsSettingsEntryString *settingsDefaultOutputVectorLayerExt;
-    //! Settings entry default output raster layer ext
-    static const QgsSettingsEntryString *settingsDefaultOutputRasterLayerExt;
+    //! Settings entry default output raster layer format
+    static const QgsSettingsEntryString *settingsDefaultOutputRasterLayerFormat;
 #endif
 };
 

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -31,6 +31,7 @@
 #include "qgsprocessingparameters.h"
 #include "qgsprocessingprovider.h"
 #include "qgsprocessingutils.h"
+#include "qgsrasterfilewriter.h"
 #include "qgsrectangle.h"
 #include "qgsvectorlayer.h"
 
@@ -809,6 +810,26 @@ QgsMeshLayer *QgsProcessingAlgorithm::parameterAsMeshLayer( const QVariantMap &p
 QString QgsProcessingAlgorithm::parameterAsOutputLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const
 {
   return QgsProcessingParameters::parameterAsOutputLayer( parameterDefinition( name ), parameters, context );
+}
+
+QString QgsProcessingAlgorithm::parameterAsOutputFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const
+{
+  return QgsProcessingParameters::parameterAsOutputFormat( parameterDefinition( name ), parameters, context );
+}
+
+QString QgsProcessingAlgorithm::parameterAsOutputRasterFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const
+{
+  QString outputFormat = parameterAsOutputFormat( parameters, name, context );
+  if ( outputFormat.isEmpty() )
+  {
+    QString outputFile = parameterAsOutputLayer( parameters, name, context );
+    if ( !outputFile.isEmpty() )
+    {
+      const QFileInfo fi( outputFile );
+      outputFormat = QgsRasterFileWriter::driverForExtension( fi.suffix() );
+    }
+  }
+  return outputFormat;
 }
 
 QString QgsProcessingAlgorithm::parameterAsFileOutput( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -854,7 +854,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
      *
      * Output format may be empty.
      *
-     * \since QGIS 3.40
+     * \since QGIS 4.0
      */
     QString parameterAsOutputFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 
@@ -864,7 +864,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
      * If no explicit output format is attached to the parameter, one will be
      * attempted to be guessed from the file name extension.
      *
-     * \since QGIS 3.40
+     * \since QGIS 4.0
      */
     QString parameterAsOutputRasterFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -850,6 +850,25 @@ class CORE_EXPORT QgsProcessingAlgorithm
     QString parameterAsOutputLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
 
     /**
+     * Evaluates the parameter with matching \a name to a output format
+     *
+     * Output format may be empty.
+     *
+     * \since QGIS 3.40
+     */
+    QString parameterAsOutputFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
+
+    /**
+     * Evaluates the parameter with matching \a name to a output format
+     *
+     * If no explicit output format is attached to the parameter, one will be
+     * attempted to be guessed from the file name extension.
+     *
+     * \since QGIS 3.40
+     */
+    QString parameterAsOutputRasterFormat( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;
+
+    /**
      * Evaluates the parameter with matching \a name to a file based output destination.
      */
     QString parameterAsFileOutput( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;

--- a/src/core/processing/qgsprocessingcontext.cpp
+++ b/src/core/processing/qgsprocessingcontext.cpp
@@ -28,7 +28,7 @@
 
 QgsProcessingContext::QgsProcessingContext()
   : mPreferredVectorFormat( QgsProcessingUtils::defaultVectorExtension() )
-  , mPreferredRasterFormat( QgsProcessingUtils::defaultRasterExtension() )
+  , mPreferredRasterFormat( QgsProcessingUtils::defaultRasterFormat() )
 {
   auto callback = [this]( const QgsFeature & feature )
   {

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -603,9 +603,9 @@ class CORE_EXPORT QgsProcessingContext
     /**
      * Returns the preferred raster format to use for raster outputs.
      *
-     * This method returns a file extension to use when creating raster outputs (e.g. "tif"). Generally,
-     * it is preferable to use the extension associated with a particular parameter, which can be retrieved through
-     * QgsProcessingDestinationParameter::defaultFileExtension(). However, in some cases, a specific parameter
+     * This method returns a file format to use when creating raster outputs (e.g. "GTiff"). Generally,
+     * it is preferable to use the format associated with a particular parameter, which can be retrieved through
+     * QgsProcessingParameterRasterDestination::defaultFileFormat(). However, in some cases, a specific parameter
      * may not be available to call this method on (e.g. for an algorithm which has only an output folder parameter
      * and which creates multiple output layers in that folder). In this case, the format returned by this
      * function should be used when creating these outputs.
@@ -616,6 +616,8 @@ class CORE_EXPORT QgsProcessingContext
      * \see setPreferredRasterFormat()
      * \see preferredVectorFormat()
      *
+     * \note Since QGIS 3.40, this method returns a GDAL format name. In prior versions, this was a file extension.
+     *
      * \since QGIS 3.10
      */
     QString preferredRasterFormat() const SIP_HOLDGIL { return mPreferredRasterFormat; }
@@ -623,15 +625,17 @@ class CORE_EXPORT QgsProcessingContext
     /**
      * Sets the preferred raster \a format to use for raster outputs.
      *
-     * This method sets a file extension to use when creating raster outputs (e.g. "tif"). Generally,
-     * it is preferable to use the extension associated with a particular parameter, which can be retrieved through
-     * QgsProcessingDestinationParameter::defaultFileExtension(). However, in some cases, a specific parameter
+     * This method sets a file format to use when creating raster outputs (e.g. "GTiff"). Generally,
+     * it is preferable to use the format associated with a particular parameter, which can be retrieved through
+     * QgsProcessingParameterRasterDestination::defaultFileFormat(). However, in some cases, a specific parameter
      * may not be available to call this method on (e.g. for an algorithm which has only an output folder parameter
      * and which creates multiple output layers in that folder). In this case, the format set by this
      * function will be used when creating these outputs.
      *
      * \see preferredRasterFormat()
      * \see setPreferredVectorFormat()
+     *
+     * \note Since QGIS 3.40, this method expects a GDAL format name. In prior versions, this was a file extension.
      *
      * \since QGIS 3.10
      */

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -616,7 +616,7 @@ class CORE_EXPORT QgsProcessingContext
      * \see setPreferredRasterFormat()
      * \see preferredVectorFormat()
      *
-     * \note Since QGIS 3.40, this method returns a GDAL format name. In prior versions, this was a file extension.
+     * \note Since QGIS 4.0, this method returns a GDAL format name. In prior versions, this was a file extension.
      *
      * \since QGIS 3.10
      */
@@ -635,7 +635,7 @@ class CORE_EXPORT QgsProcessingContext
      * \see preferredRasterFormat()
      * \see setPreferredVectorFormat()
      *
-     * \note Since QGIS 3.40, this method expects a GDAL format name. In prior versions, this was a file extension.
+     * \note Since QGIS 4.0, this method expects a GDAL format name. In prior versions, this was a file extension.
      *
      * \since QGIS 3.10
      */

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -7122,20 +7122,30 @@ QgsProcessingOutputDefinition *QgsProcessingParameterRasterDestination::toOutput
   return new QgsProcessingOutputRasterLayer( name(), description() );
 }
 
-QString QgsProcessingParameterRasterDestination::defaultFileExtension() const
+QString QgsProcessingParameterRasterDestination::defaultFileFormat() const
 {
   if ( auto *lOriginalProvider = originalProvider() )
   {
-    return lOriginalProvider->defaultRasterFileExtension();
+    return lOriginalProvider->defaultRasterFileFormat();
   }
   else if ( QgsProcessingProvider *p = provider() )
   {
-    return p->defaultRasterFileExtension();
+    return p->defaultRasterFileFormat();
   }
   else
   {
-    return QgsProcessingUtils::defaultRasterExtension();
+    return QgsProcessingUtils::defaultRasterFormat();
   }
+}
+
+QString QgsProcessingParameterRasterDestination::defaultFileExtension() const
+{
+  QString format = defaultFileFormat();
+  QStringList extensions = QgsRasterFileWriter::extensionsForFormat( format );
+  if ( !extensions.isEmpty() )
+    return extensions[0];
+
+  return QStringLiteral( "tif" );
 }
 
 QString QgsProcessingParameterRasterDestination::createFileFilter() const

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -975,6 +975,23 @@ QString QgsProcessingParameters::parameterAsOutputLayer( const QgsProcessingPara
   return parameterAsOutputLayer( definition, val, context );
 }
 
+QString QgsProcessingParameters::parameterAsOutputFormat( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext & )
+{
+  QString format;
+  QVariant val;
+  if ( definition )
+  {
+    val = parameters.value( definition->name() );
+    if ( val.userType() == qMetaTypeId<QgsProcessingOutputLayerDefinition>() )
+    {
+      // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
+      const QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
+      format = fromVar.format();
+    }
+  }
+  return format;
+}
+
 QString QgsProcessingParameters::parameterAsOutputLayer( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context, bool testOnly )
 {
   QVariant val = value;
@@ -7123,28 +7140,44 @@ QString QgsProcessingParameterRasterDestination::defaultFileExtension() const
 
 QString QgsProcessingParameterRasterDestination::createFileFilter() const
 {
-  const QStringList exts = supportedOutputRasterLayerExtensions();
   QStringList filters;
-  for ( const QString &ext : exts )
+  const QList<QPair<QString, QString>> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
+  for ( const QPair<QString, QString> &formatAndExt : std::as_const( formatAndExtensions ) )
   {
-    filters << QObject::tr( "%1 files (*.%2)" ).arg( ext.toUpper(), ext.toLower() );
+    QString format = formatAndExt.first;
+    const QString &extension = formatAndExt.second;
+    if ( format.isEmpty() )
+      format = extension;
+    filters << QObject::tr( "%1 files (*.%2)" ).arg( format.toUpper(), extension.toLower() );
   }
+
   return filters.join( QLatin1String( ";;" ) ) + QStringLiteral( ";;" ) + QObject::tr( "All files (*.*)" );
 }
 
 QStringList QgsProcessingParameterRasterDestination::supportedOutputRasterLayerExtensions() const
 {
+  const QList<QPair<QString, QString>> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
+  QSet< QString > extensions;
+  for ( const QPair<QString, QString> &formatAndExt : std::as_const( formatAndExtensions ) )
+  {
+    extensions.insert( formatAndExt.second );
+  }
+  return QStringList( extensions.constBegin(), extensions.constEnd() );
+}
+
+QList<QPair<QString, QString>>  QgsProcessingParameterRasterDestination::supportedOutputRasterLayerFormatAndExtensions() const
+{
   if ( auto *lOriginalProvider = originalProvider() )
   {
-    return lOriginalProvider->supportedOutputRasterLayerExtensions();
+    return lOriginalProvider->supportedOutputRasterLayerFormatAndExtensions();
   }
   else if ( QgsProcessingProvider *p = provider() )
   {
-    return p->supportedOutputRasterLayerExtensions();
+    return p->supportedOutputRasterLayerFormatAndExtensions();
   }
   else
   {
-    return QgsRasterFileWriter::supportedFormatExtensions();
+    return QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensionsDefault();
   }
 }
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -3815,6 +3815,15 @@ class CORE_EXPORT QgsProcessingParameterRasterDestination : public QgsProcessing
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
     QgsProcessingOutputDefinition *toOutputDefinition() const override SIP_FACTORY;
     QString defaultFileExtension() const override;
+
+    /**
+     * Returns the default file format for destination file paths
+     * associated with this parameter.
+     *
+     * \since QGIS 3.40
+     */
+    QString defaultFileFormat() const;
+
     QString createFileFilter() const override;
 
     /**

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -375,6 +375,23 @@ class CORE_EXPORT QgsProcessingOutputLayerDefinition
     void setRemappingDefinition( const QgsRemappingSinkDefinition &definition );
 
     /**
+     * Returns the format (if set)
+     *
+     * \see setFormat()
+     * \since QGIS 4.0
+     */
+    QString format() const { return mFormat; }
+
+    /**
+     * Sets the \a format of the output dataset
+     *
+     * \see format()
+     *
+     * \since QGIS 4.0
+     */
+    void setFormat( const QString &format ) { mFormat = format; }
+
+    /**
      * Saves this output layer definition to a QVariantMap, wrapped in a QVariant.
      * You can use QgsXmlUtils::writeVariant to save it to an XML document.
      * \see loadVariant()
@@ -404,6 +421,7 @@ class CORE_EXPORT QgsProcessingOutputLayerDefinition
 
     bool mUseRemapping = false;
     QgsRemappingSinkDefinition mRemappingDefinition = QgsRemappingSinkDefinition();
+    QString mFormat;
 
 };
 
@@ -1428,6 +1446,15 @@ class CORE_EXPORT QgsProcessingParameters
      * \since QGIS 3.4
      */
     static QString parameterAsOutputLayer( const QgsProcessingParameterDefinition *definition, const QVariant &value, QgsProcessingContext &context, bool testOnly = false );
+
+    /**
+     * Evaluates the parameter with matching \a definition to a output format
+     *
+     * Output format may be empty.
+     *
+     * \since QGIS 3.40
+     */
+    static QString parameterAsOutputFormat( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );
 
     /**
      * Evaluates the parameter with matching \a definition to a file based output destination.
@@ -3793,9 +3820,17 @@ class CORE_EXPORT QgsProcessingParameterRasterDestination : public QgsProcessing
     /**
      * Returns a list of the raster format file extensions supported for this parameter.
      * \see defaultFileExtension()
-     * \since QGIS 3.2
+     *
+     * \deprecated QGIS 3.40. Use supportedOutputRasterLayerFormatAndExtensions() instead.
      */
-    virtual QStringList supportedOutputRasterLayerExtensions() const;
+    Q_DECL_DEPRECATED virtual QStringList supportedOutputRasterLayerExtensions() const SIP_DEPRECATED;
+
+    /**
+     * Returns a list of (format, file extension) supported by this provider.
+     *
+     * \since QGIS 3.40
+     */
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
 
     /**
      * Creates a new parameter using the definition from a script code.

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -319,25 +319,39 @@ QString QgsProcessingProvider::defaultVectorFileExtension( bool hasGeometry ) co
   }
 }
 
-QString QgsProcessingProvider::defaultRasterFileExtension() const
+QString QgsProcessingProvider::defaultRasterFileFormat() const
 {
-  const QString userDefault = QgsProcessingUtils::defaultRasterExtension();
+  const QString userDefault = QgsProcessingUtils::defaultRasterFormat();
 
-  const QStringList supportedExtensions = supportedOutputRasterLayerExtensions();
-  if ( supportedExtensions.contains( userDefault, Qt::CaseInsensitive ) )
+  const QList<QPair<QString, QString>> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
+  for ( const QPair<QString, QString> &formatAndExt : std::as_const( formatAndExtensions ) )
   {
-    // user set default is supported by provider, use that
-    return userDefault;
+    if ( formatAndExt.first.compare( userDefault, Qt::CaseInsensitive ) == 0 )
+    {
+      // user set default is supported by provider, use that
+      return userDefault;
+    }
   }
-  else if ( !supportedExtensions.empty() )
+
+  if ( !formatAndExtensions.empty() )
   {
-    return supportedExtensions.at( 0 );
+    return formatAndExtensions.at( 0 ).first;
   }
   else
   {
     // who knows? provider says it has no file support at all...
-    return QStringLiteral( "tif" );
+    return QStringLiteral( "GTiff" );
   }
+}
+
+QString QgsProcessingProvider::defaultRasterFileExtension() const
+{
+  QString format = defaultRasterFileFormat();
+  QStringList extensions = QgsRasterFileWriter::extensionsForFormat( format );
+  if ( !extensions.isEmpty() )
+    return extensions[0];
+
+  return QStringLiteral( "tif" );
 }
 
 QString QgsProcessingProvider::defaultPointCloudFileExtension() const

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -246,19 +246,33 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
     virtual QString defaultVectorFileExtension( bool hasGeometry = true ) const;
 
     /**
-     * Returns the default file extension to use for raster outputs created by the
+     * Returns the default file format to use for raster outputs created by the
      * provider.
      *
      * The default implementation returns the user's default Processing raster output format
-     * setting, if it's supported by the provider (see supportedOutputRasterLayerExtensions()).
+     * setting, if it's supported by the provider (see supportedOutputRasterLayerFormatAndExtensions()).
      * Otherwise the first reported supported raster format will be used.
      *
-     * \see supportedOutputRasterLayerExtensions()
+     * \see supportedOutputRasterLayerFormatAndExtensions()
+     * \see defaultRasterFileExtension()
+     *
+     * \since QGIS 3.40
+     */
+    virtual QString defaultRasterFileFormat() const;
+
+    /**
+     * Returns the default file extension to use for raster outputs created by the
+     * provider.
+     *
+     * Starting with QGIS 3.40, this method is no longer virtual, and relies on
+     * defaultRasterFileFormat()
+     *
+     * \see defaultRasterFileFormat()
      * \see defaultVectorFileExtension()
      * \see defaultPointCloudFileExtension()
      * \see defaultVectorTileFileExtension()
      */
-    virtual QString defaultRasterFileExtension() const;
+    QString defaultRasterFileExtension() const;
 
     /**
      * Returns the default file extension to use for point cloud outputs created by the

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -143,8 +143,25 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * \see supportedOutputVectorLayerExtensions()
      * \see supportedOutputPointCloudLayerExtensions()
      * \see supportedOutputVectorTileLayerExtensions()
+     *
+     * \note Since QGIS 3.40, this method is no longer virtual and use internally
+     * supportedOutputRasterLayerFormatAndExtensions() instead.
      */
-    virtual QStringList supportedOutputRasterLayerExtensions() const;
+    QStringList supportedOutputRasterLayerExtensions() const;
+
+    /**
+     * Returns a list of (format, file extension) supported by this provider.
+     *
+     * \since QGIS 3.40
+     */
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+
+    /**
+     * Returns a list of (format, file extension) supported by GDAL
+     *
+     * \since QGIS 3.40
+     */
+    static QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensionsDefault() SIP_SKIP;
 
     /**
      * Returns a list of the vector format file extensions supported by this provider.

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -144,7 +144,7 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * \see supportedOutputPointCloudLayerExtensions()
      * \see supportedOutputVectorTileLayerExtensions()
      *
-     * \note Since QGIS 3.40, this method is no longer virtual and use internally
+     * \note Since QGIS 4.0, this method is no longer virtual and use internally
      * supportedOutputRasterLayerFormatAndExtensions() instead.
      */
     QStringList supportedOutputRasterLayerExtensions() const;
@@ -152,14 +152,14 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
     /**
      * Returns a list of (format, file extension) supported by this provider.
      *
-     * \since QGIS 3.40
+     * \since QGIS 4.0
      */
     virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
 
     /**
      * Returns a list of (format, file extension) supported by GDAL
      *
-     * \since QGIS 3.40
+     * \since QGIS 4.0
      */
     static QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensionsDefault() SIP_SKIP;
 
@@ -256,7 +256,7 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * \see supportedOutputRasterLayerFormatAndExtensions()
      * \see defaultRasterFileExtension()
      *
-     * \since QGIS 3.40
+     * \since QGIS 4.0
      */
     virtual QString defaultRasterFileFormat() const;
 
@@ -264,7 +264,7 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * Returns the default file extension to use for raster outputs created by the
      * provider.
      *
-     * Starting with QGIS 3.40, this method is no longer virtual, and relies on
+     * Starting with QGIS 4.0, this method is no longer virtual, and relies on
      * defaultRasterFileFormat()
      *
      * \see defaultRasterFileFormat()

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -1597,20 +1597,31 @@ QString QgsProcessingUtils::defaultVectorExtension()
   return setting;
 }
 
+QString QgsProcessingUtils::defaultRasterFormat()
+{
+  QString setting = QgsProcessing::settingsDefaultOutputRasterLayerFormat->value().trimmed();
+  if ( setting.isEmpty() )
+    return QStringLiteral( "GTiff" );
+
+  const QList< QgsRasterFileWriter::FilterFormatDetails > supportedFiltersFormats =
+    QgsRasterFileWriter::supportedFiltersAndFormats();
+  for ( const QgsRasterFileWriter::FilterFormatDetails &detail : std::as_const( supportedFiltersFormats ) )
+  {
+    if ( detail.driverName.compare( setting, Qt::CaseInsensitive ) == 0 )
+      return detail.driverName;
+  }
+
+  return QStringLiteral( "GTiff" );
+}
+
 QString QgsProcessingUtils::defaultRasterExtension()
 {
-  QString setting = QgsProcessing::settingsDefaultOutputRasterLayerExt->value().trimmed();
-  if ( setting.isEmpty() )
-    return QStringLiteral( "tif" );
+  QString format = defaultRasterFormat();
+  QStringList extensions = QgsRasterFileWriter::extensionsForFormat( format );
+  if ( !extensions.isEmpty() )
+    return extensions[0];
 
-  if ( setting.startsWith( '.' ) )
-    setting = setting.mid( 1 );
-
-  const QStringList supportedFormats = QgsRasterFileWriter::supportedFormatExtensions();
-  if ( !supportedFormats.contains( setting, Qt::CaseInsensitive ) )
-    return QStringLiteral( "tif" );
-
-  return setting;
+  return QStringLiteral( "tif" );
 }
 
 QString QgsProcessingUtils::defaultPointCloudExtension()

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -550,6 +550,18 @@ class CORE_EXPORT QgsProcessingUtils
     static QString defaultVectorExtension();
 
     /**
+     * Returns the default raster format to use, in the absence of all other constraints (e.g.
+     * provider based support for extensions).
+     *
+     * This method returns the user-set default format from the processing settings, or
+     * a fallback value of "GTiff".
+     *
+     * \see defaultRasterExtension()
+     * \since QGIS 4.0
+     */
+    static QString defaultRasterFormat();
+
+    /**
      * Returns the default raster extension to use, in the absence of all other constraints (e.g.
      * provider based support for extensions).
      *

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -198,6 +198,8 @@ QVariant QgsProcessingLayerOutputDestinationWidget::value() const
   value.createOptions.insert( QStringLiteral( "fileEncoding" ), mEncoding );
   if ( mUseRemapping )
     value.setRemappingDefinition( mRemapDefinition );
+  if ( !mFormat.isEmpty() )
+    value.setFormat( mFormat );
   return value;
 }
 
@@ -429,6 +431,14 @@ void QgsProcessingLayerOutputDestinationWidget::selectFile()
   {
     mUseTemporary = false;
     mUseRemapping = false;
+    if ( mParameter->type() == QgsProcessingParameterRasterDestination::typeName() )
+    {
+      int spacePos = static_cast<int>( lastFilter.indexOf( ' ' ) );
+      if ( spacePos > 0 )
+      {
+        mFormat = lastFilter.left( spacePos );
+      }
+    }
     filename = QgsFileUtils::addExtensionFromFilter( filename, lastFilter );
 
     leText->setText( filename );

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.h
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.h
@@ -139,6 +139,8 @@ class GUI_EXPORT QgsProcessingLayerOutputDestinationWidget : public QWidget, pri
     QgsRemappingSinkDefinition mRemapDefinition;
     bool mUseRemapping = false;
 
+    QString mFormat;
+
     QgsProcessingContext *mContext = nullptr;
 
     friend class TestProcessingGui;

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -1377,6 +1377,6 @@ void QgsProcessingExec::addProviderInformation( QVariantMap &providerJson, QgsPr
   providerJson.insert( QStringLiteral( "supported_output_vector_extensions" ), provider->supportedOutputVectorLayerExtensions() );
   providerJson.insert( QStringLiteral( "supported_output_table_extensions" ), provider->supportedOutputTableExtensions() );
   providerJson.insert( QStringLiteral( "default_vector_file_extension" ), provider->defaultVectorFileExtension() );
-  providerJson.insert( QStringLiteral( "default_raster_file_extension" ), provider->defaultRasterFileExtension() );
+  providerJson.insert( QStringLiteral( "default_raster_file_format" ), provider->defaultRasterFileFormat() );
   providerJson.insert( QStringLiteral( "supports_non_file_based_output" ), provider->supportsNonFileBasedOutput() );
 }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -250,6 +250,12 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
       QCOMPARE( rasterParam->defaultFileExtension(), QStringLiteral( "tif" ) ); // before alg is accessible
       QVERIFY( addParameter( rasterParam ) );
       QCOMPARE( rasterParam->defaultFileExtension(), QStringLiteral( "pcx" ) );
+
+      // test parameterAsOutputRasterFormat()
+      QVariantMap parameters;
+      parameters.insert( QStringLiteral( "raster2" ), QStringLiteral( "test.bmp" ) );
+      QgsProcessingContext context;
+      QCOMPARE( parameterAsOutputRasterFormat( parameters, QStringLiteral( "raster2" ), context ), QStringLiteral( "BMP" ) );
     }
 
     void runOutputChecks()
@@ -612,9 +618,11 @@ class DummyProvider3 : public QgsProcessingProvider // clazy:exclude=missing-qob
       return QStringList() << QStringLiteral( "dbf" );
     }
 
-    QStringList supportedOutputRasterLayerExtensions() const override
+    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override
     {
-      return QStringList() << QStringLiteral( "mig" ) << QStringLiteral( "sdat" );
+      return QList<QPair<QString, QString>>()
+             << QPair<QString, QString>( QString(), QStringLiteral( "mig" ) )
+             << QPair<QString, QString>( QString(), QStringLiteral( "sdat" ) );
     }
 
     QStringList supportedOutputPointCloudLayerExtensions() const override
@@ -645,9 +653,10 @@ class DummyProvider4 : public QgsProcessingProvider // clazy:exclude=missing-qob
       return QStringList() << QStringLiteral( "mif" );
     }
 
-    QStringList supportedOutputRasterLayerExtensions() const override
+    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override
     {
-      return QStringList() << QStringLiteral( "mig" );
+      return QList<QPair<QString, QString>>()
+             << QPair<QString, QString>( QString(), QStringLiteral( "mig" ) );
     }
 
     void loadAlgorithms() override
@@ -8502,8 +8511,14 @@ void TestQgsProcessing::parameterRasterOut()
   QVariantMap params;
   params.insert( "non_optional", "test.tif" );
   QCOMPARE( QgsProcessingParameters::parameterAsOutputLayer( def.get(), params, context ), QStringLiteral( "test.tif" ) );
+  QCOMPARE( QgsProcessingParameters::parameterAsOutputFormat( def.get(), params, context ), QString() );
   params.insert( "non_optional", QgsProcessingOutputLayerDefinition( "test.tif" ) );
   QCOMPARE( QgsProcessingParameters::parameterAsOutputLayer( def.get(), params, context ), QStringLiteral( "test.tif" ) );
+
+  QgsProcessingOutputLayerDefinition outputLayerDef( "test.tif" );
+  outputLayerDef.setFormat( "foo" );
+  params.insert( "non_optional", outputLayerDef );
+  QCOMPARE( QgsProcessingParameters::parameterAsOutputFormat( def.get(), params, context ), QStringLiteral( "foo" ) );
 
   QCOMPARE( def->valueAsPythonString( QStringLiteral( "abc" ), context ), QStringLiteral( "'abc'" ) );
   QCOMPARE( def->valueAsPythonString( QVariant::fromValue( QgsProcessingOutputLayerDefinition( "abc" ) ), context ), QStringLiteral( "'abc'" ) );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -249,7 +249,7 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
       QgsProcessingParameterRasterDestination *rasterParam = new QgsProcessingParameterRasterDestination( "raster2" );
       QCOMPARE( rasterParam->defaultFileExtension(), QStringLiteral( "tif" ) ); // before alg is accessible
       QVERIFY( addParameter( rasterParam ) );
-      QCOMPARE( rasterParam->defaultFileExtension(), QStringLiteral( "pcx" ) );
+      QCOMPARE( rasterParam->defaultFileFormat(), QStringLiteral( "next-gen-format" ) );
 
       // test parameterAsOutputRasterFormat()
       QVariantMap parameters;
@@ -523,9 +523,9 @@ class DummyProvider : public QgsProcessingProvider // clazy:exclude=missing-qobj
       return "xshp"; // shape-X. Just like shapefiles, but to the max!
     }
 
-    QString defaultRasterFileExtension() const override
+    QString defaultRasterFileFormat() const override
     {
-      return "pcx"; // next-gen raster storage
+      return "next-gen-format";
     }
 
     bool supportsNonFileBasedOutput() const override
@@ -621,8 +621,8 @@ class DummyProvider3 : public QgsProcessingProvider // clazy:exclude=missing-qob
     QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override
     {
       return QList<QPair<QString, QString>>()
-             << QPair<QString, QString>( QString(), QStringLiteral( "mig" ) )
-             << QPair<QString, QString>( QString(), QStringLiteral( "sdat" ) );
+             << QPair<QString, QString>( QStringLiteral( "XYZ" ), QStringLiteral( "xyz" ) )
+             << QPair<QString, QString>( QStringLiteral( "BMP" ), QStringLiteral( "bmp" ) );
     }
 
     QStringList supportedOutputPointCloudLayerExtensions() const override
@@ -8614,9 +8614,9 @@ void TestQgsProcessing::parameterRasterOut()
   QVERIFY( !provider.isSupportedOutputValue( "d:/test.tif", def.get(), context, error ) );
   QVERIFY( !provider.isSupportedOutputValue( "d:/test.TIF", def.get(), context, error ) );
   QVERIFY( !provider.isSupportedOutputValue( QgsProcessingOutputLayerDefinition( "d:/test.tif" ), def.get(), context, error ) );
-  QVERIFY( provider.isSupportedOutputValue( "d:/test.mig", def.get(), context, error ) );
-  QVERIFY( provider.isSupportedOutputValue( "d:/test.MIG", def.get(), context, error ) );
-  QVERIFY( provider.isSupportedOutputValue( QgsProcessingOutputLayerDefinition( "d:/test.MIG" ), def.get(), context, error ) );
+  QVERIFY( provider.isSupportedOutputValue( "d:/test.xyz", def.get(), context, error ) );
+  QVERIFY( provider.isSupportedOutputValue( "d:/test.XYZ", def.get(), context, error ) );
+  QVERIFY( provider.isSupportedOutputValue( QgsProcessingOutputLayerDefinition( "d:/test.XYZ" ), def.get(), context, error ) );
 
   // test layers to load on completion
   def = std::make_unique<QgsProcessingParameterRasterDestination>( "x", QStringLiteral( "desc" ), QStringLiteral( "default.tif" ), true );
@@ -13170,30 +13170,32 @@ void TestQgsProcessing::defaultExtensionsForProvider()
   const DummyProvider3 provider;
   // default implementation should return first supported format for provider
   QCOMPARE( provider.defaultVectorFileExtension( true ), QStringLiteral( "mif" ) );
-  QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "mig" ) );
+  QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "xyz" ) );
 
   // a default context should use reasonable defaults
   const QgsProcessingContext context;
   QCOMPARE( context.preferredVectorFormat(), QStringLiteral( "gpkg" ) );
-  QCOMPARE( context.preferredRasterFormat(), QStringLiteral( "tif" ) );
+  QCOMPARE( context.preferredRasterFormat(), QStringLiteral( "GTiff" ) );
 
   // unless the user has set a default format, which IS supported by that provider
   QgsProcessing::settingsDefaultOutputVectorLayerExt->setValue( QStringLiteral( "tab" ) );
-  QgsProcessing::settingsDefaultOutputRasterLayerExt->setValue( QStringLiteral( "sdat" ) );
+  QgsProcessing::settingsDefaultOutputRasterLayerFormat->setValue( QStringLiteral( "BMP" ) );
 
   QCOMPARE( provider.defaultVectorFileExtension( true ), QStringLiteral( "tab" ) );
-  QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "sdat" ) );
+  QCOMPARE( provider.defaultRasterFileFormat(), QStringLiteral( "BMP" ) );
+  QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "bmp" ) );
 
   // context should respect these as preferred formats
   const QgsProcessingContext context2;
   QCOMPARE( context2.preferredVectorFormat(), QStringLiteral( "tab" ) );
-  QCOMPARE( context2.preferredRasterFormat(), QStringLiteral( "sdat" ) );
+  QCOMPARE( context2.preferredRasterFormat(), QStringLiteral( "BMP" ) );
 
   // but if default is not supported by provider, we use a supported format
   QgsProcessing::settingsDefaultOutputVectorLayerExt->setValue( QStringLiteral( "gpkg" ) );
-  QgsProcessing::settingsDefaultOutputRasterLayerExt->setValue( QStringLiteral( "ecw" ) );
+  QgsProcessing::settingsDefaultOutputRasterLayerFormat->setValue( QStringLiteral( "ECW" ) );
   QCOMPARE( provider.defaultVectorFileExtension( true ), QStringLiteral( "mif" ) );
-  QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "mig" ) );
+  QCOMPARE( provider.defaultRasterFileFormat(), QStringLiteral( "XYZ" ) );
+  QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "xyz" ) );
 }
 
 void TestQgsProcessing::supportedExtensions()

--- a/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
+++ b/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
@@ -128,9 +128,9 @@ class DummyProvider4 : public QgsProcessingProvider // clazy:exclude=missing-qob
       return QStringList() << QStringLiteral( "mif" );
     }
 
-    QStringList supportedOutputRasterLayerExtensions() const override
+    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override
     {
-      return QStringList() << QStringLiteral( "mig" );
+      return QList<QPair<QString, QString>>() << QPair<QString, QString>( QString(), QStringLiteral( "mig" ) );
     }
 
     void loadAlgorithms() override
@@ -1815,7 +1815,9 @@ void TestQgsProcessingModelAlgorithm::modelWithProviderWithLimitedTypes()
   QCOMPARE( alg.destinationParameterDefinitions().at( 0 )->name(), QStringLiteral( "my_output" ) );
   QCOMPARE( alg.destinationParameterDefinitions().at( 0 )->description(), QStringLiteral( "my output" ) );
   QCOMPARE( static_cast<const QgsProcessingDestinationParameter *>( alg.destinationParameterDefinitions().at( 0 ) )->originalProvider()->id(), QStringLiteral( "dummy4" ) );
+  Q_NOWARN_DEPRECATED_PUSH
   QCOMPARE( static_cast<const QgsProcessingParameterRasterDestination *>( alg.destinationParameterDefinitions().at( 0 ) )->supportedOutputRasterLayerExtensions(), QStringList() << QStringLiteral( "mig" ) );
+  Q_NOWARN_DEPRECATED_POP
   QCOMPARE( static_cast<const QgsProcessingParameterRasterDestination *>( alg.destinationParameterDefinitions().at( 0 ) )->defaultFileExtension(), QStringLiteral( "mig" ) );
   QVERIFY( static_cast<const QgsProcessingParameterRasterDestination *>( alg.destinationParameterDefinitions().at( 0 ) )->generateTemporaryDestination().endsWith( QLatin1String( ".mig" ) ) );
   QVERIFY( !static_cast<const QgsProcessingDestinationParameter *>( alg.destinationParameterDefinitions().at( 0 ) )->supportsNonFileBasedOutput() );

--- a/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
+++ b/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
@@ -130,7 +130,7 @@ class DummyProvider4 : public QgsProcessingProvider // clazy:exclude=missing-qob
 
     QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override
     {
-      return QList<QPair<QString, QString>>() << QPair<QString, QString>( QString(), QStringLiteral( "mig" ) );
+      return QList<QPair<QString, QString>>() << QPair<QString, QString>( QStringLiteral( "XYZ" ), QStringLiteral( "xyz" ) );
     }
 
     void loadAlgorithms() override
@@ -1816,10 +1816,10 @@ void TestQgsProcessingModelAlgorithm::modelWithProviderWithLimitedTypes()
   QCOMPARE( alg.destinationParameterDefinitions().at( 0 )->description(), QStringLiteral( "my output" ) );
   QCOMPARE( static_cast<const QgsProcessingDestinationParameter *>( alg.destinationParameterDefinitions().at( 0 ) )->originalProvider()->id(), QStringLiteral( "dummy4" ) );
   Q_NOWARN_DEPRECATED_PUSH
-  QCOMPARE( static_cast<const QgsProcessingParameterRasterDestination *>( alg.destinationParameterDefinitions().at( 0 ) )->supportedOutputRasterLayerExtensions(), QStringList() << QStringLiteral( "mig" ) );
+  QCOMPARE( static_cast<const QgsProcessingParameterRasterDestination *>( alg.destinationParameterDefinitions().at( 0 ) )->supportedOutputRasterLayerExtensions(), QStringList() << QStringLiteral( "xyz" ) );
   Q_NOWARN_DEPRECATED_POP
-  QCOMPARE( static_cast<const QgsProcessingParameterRasterDestination *>( alg.destinationParameterDefinitions().at( 0 ) )->defaultFileExtension(), QStringLiteral( "mig" ) );
-  QVERIFY( static_cast<const QgsProcessingParameterRasterDestination *>( alg.destinationParameterDefinitions().at( 0 ) )->generateTemporaryDestination().endsWith( QLatin1String( ".mig" ) ) );
+  QCOMPARE( static_cast<const QgsProcessingParameterRasterDestination *>( alg.destinationParameterDefinitions().at( 0 ) )->defaultFileExtension(), QStringLiteral( "xyz" ) );
+  QVERIFY( static_cast<const QgsProcessingParameterRasterDestination *>( alg.destinationParameterDefinitions().at( 0 ) )->generateTemporaryDestination().endsWith( QLatin1String( ".xyz" ) ) );
   QVERIFY( !static_cast<const QgsProcessingDestinationParameter *>( alg.destinationParameterDefinitions().at( 0 ) )->supportsNonFileBasedOutput() );
 
   QCOMPARE( alg.destinationParameterDefinitions().at( 1 )->name(), QStringLiteral( "my_output_2" ) );


### PR DESCRIPTION
Currently the logic is entirely based on file format extension, which breaks for COG, since both GDAL GTiff and COG drivers use .tif/.tiff

<img width="1659" height="943" alt="image" src="https://github.com/user-attachments/assets/bbce45ec-ca84-48a5-8242-ad2deec85c19" />

<img width="903" height="614" alt="image" src="https://github.com/user-attachments/assets/99d0badb-1907-4582-809c-d91cf3d6d087" />

Funded by: QGIS Anwendergruppe Deutschland