### PR TITLE
Fix crash when layer from layout elevation profile is removed

### DIFF
--- a/src/core/layout/qgslayoutitemelevationprofile.cpp
+++ b/src/core/layout/qgslayoutitemelevationprofile.cpp
@@ -685,6 +685,8 @@ void QgsLayoutItemElevationProfile::paint( QPainter *painter, const QStyleOption
         sources << QgsApplication::profileSourceRegistry()->profileSources();
         for ( const QgsMapLayerRef &layer : std::as_const( mLayers ) )
         {
+          if ( !layer )
+            continue;
           if ( QgsAbstractProfileSource *source = layer->profileSource() )
             sources.append( source );
         }
@@ -740,6 +742,8 @@ void QgsLayoutItemElevationProfile::paint( QPainter *painter, const QStyleOption
         sources << QgsApplication::profileSourceRegistry()->profileSources();
         for ( const QgsMapLayerRef &layer : std::as_const( mLayers ) )
         {
+          if ( !layer )
+            continue;
           if ( QgsAbstractProfileSource *source = layer->profileSource() )
             sources.append( source );
         }
@@ -997,6 +1001,8 @@ void QgsLayoutItemElevationProfile::recreateCachedImageInBackground()
   sources << QgsApplication::profileSourceRegistry()->profileSources();
   for ( const QgsMapLayerRef &layer : std::as_const( mLayers ) )
   {
+    if ( !layer )
+      continue;
     if ( QgsAbstractProfileSource *source = layer->profileSource() )
       sources.append( source );
   }


### PR DESCRIPTION
Refs #64218

Fixes the issue for 3.44 only -- master is broken in a much worse way :scream: 