### PR TITLE
Remove unused NAME_FIELD parameter and dead code from PolarPlot

### DIFF
--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -54,13 +54,6 @@ class PolarPlot(QgisAlgorithm):
         )
         self.addParameter(
             QgsProcessingParameterField(
-                self.NAME_FIELD,
-                self.tr("Category name field"),
-                parentLayerParameterName=self.INPUT,
-            )
-        )  # FIXME unused?
-        self.addParameter(
-            QgsProcessingParameterField(
                 self.VALUE_FIELD,
                 self.tr("Value field"),
                 parentLayerParameterName=self.INPUT,
@@ -117,9 +110,6 @@ class PolarPlot(QgisAlgorithm):
                 self.invalidSourceError(parameters, self.INPUT)
             )
 
-        namefieldname = self.parameterAsString(
-            parameters, self.NAME_FIELD, context
-        )  # NOQA  FIXME unused?
         valuefieldname = self.parameterAsString(parameters, self.VALUE_FIELD, context)
 
         output = self.parameterAsFileOutput(parameters, self.OUTPUT, context)


### PR DESCRIPTION
Removed the unused `NAME_FIELD` parameter and its retrieval logic from `PolarPlot.py`.

The parameter definition was marked with a `# FIXME unused?` comment. I analyzed the code and confirmed that while `namefieldname` was being assigned, the variable was never actually used in the graph generation logic or anywhere else in the file.
This cleanup removes the dead code and the confusing parameter.