### PR TITLE
Initialize plugin path (initQgis) before QgsNetworkAccessManager

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -997,6 +997,8 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
   connect( mUserProfileManager, &QgsUserProfileManager::profilesChanged, this, &QgisApp::refreshProfileMenu );
   endProfile();
 
+  QgsApplication::initQgis();
+
   // start the network logger early, we want all requests logged!
   startProfile( tr( "Create network logger" ) );
   mNetworkLogger = new QgsNetworkLogger( QgsNetworkAccessManager::instance(), this );
@@ -1042,8 +1044,6 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
 
   mSplash->showMessage( tr( "Setting up the GUI" ), Qt::AlignHCenter | Qt::AlignBottom, splashTextColor );
   qApp->processEvents();
-
-  QgsApplication::initQgis();
 
   // setup connections to auth system
   masterPasswordSetup();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -997,6 +997,7 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
   connect( mUserProfileManager, &QgsUserProfileManager::profilesChanged, this, &QgisApp::refreshProfileMenu );
   endProfile();
 
+  // Initialize QGIS (and the plugins) before the network
   QgsApplication::initQgis();
 
   // start the network logger early, we want all requests logged!


### PR DESCRIPTION
An authentication config can be used for the network proxy. When this is approach is taken, the auth system will be initialized when the QgsNetworkAccessManager is used first, which is "early" according to the comment in the code. The auth system initialization requires the plugin path to be set. The plugin path is initialized in initQgis, we therefore move the call to `initQgis` to even earlier.

Fixes https://github.com/qgis/QGIS/issues/61043