### PR TITLE
[Feature] GDAL processing algs: add Dataset Identification

### DIFF
--- a/python/plugins/processing/algs/gdal/DatasetIdentify.py
+++ b/python/plugins/processing/algs/gdal/DatasetIdentify.py
@@ -1,0 +1,140 @@
+"""
+***************************************************************************
+    DatasetIdentify.py
+    ------------------
+    Date                 : December 2025
+    Copyright            : (C) 2025 by Even Rouault
+    Email                : even dot rouault at spatialys dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = "Even Rouault"
+__date__ = "December 2025"
+__copyright__ = "(C) 2025, Even Rouault"
+
+from osgeo import gdal
+import os
+
+from qgis.core import (
+    Qgis,
+    QgsProcessing,
+    QgsProcessingException,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterBoolean,
+    QgsProcessingParameterVectorDestination,
+)
+from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
+from processing.algs.gdal.GdalUtils import GdalUtils
+
+pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
+
+
+class DatasetIdentify(GdalAlgorithm):
+    INPUT = "INPUT"
+    RECURSIVE = "RECURSIVE"
+    DETAILS = "DETAILS"
+    OUTPUT = "OUTPUT"
+
+    def __init__(self):
+        super().__init__()
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.INPUT,
+                self.tr("Input folder"),
+                Qgis.ProcessingFileParameterBehavior.Folder,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterBoolean(
+                self.RECURSIVE,
+                self.tr("Perform recursive exploration of the input folder"),
+                defaultValue=True,
+            )
+        )
+
+        detailsParam = QgsProcessingParameterBoolean(
+            self.DETAILS,
+            self.tr("Add details about identified datasets in the output"),
+            defaultValue=True,
+        )
+        detailsParam.setHelp(
+            self.tr(
+                "Reports if the file is a Cloud Optimized GeoTIFF (COG), the list of files that compose the dataset, if it has georeferencing (has_geotransform and has_crs fields) and overviews"
+            )
+        )
+        self.addParameter(detailsParam)
+
+        self.addParameter(
+            QgsProcessingParameterVectorDestination(
+                self.OUTPUT,
+                self.tr("Output file"),
+                QgsProcessing.SourceType.TypeVector,
+            )
+        )
+
+    def name(self):
+        return "dataset_identify"
+
+    def displayName(self):
+        return self.tr("Dataset identification")
+
+    def group(self):
+        return self.tr("Miscellaneous")
+
+    def groupId(self):
+        return "miscellaneous"
+
+    def commandName(self):
+        return "gdal dataset identify"
+
+    def getConsoleCommands(self, parameters, context, feedback, executing=True):
+        arguments = []
+        if self.parameterAsBoolean(parameters, self.RECURSIVE, context):
+            arguments.append("--recursive")
+        if self.parameterAsBoolean(parameters, self.DETAILS, context):
+            arguments.append("--detailed")
+
+        inDirectory = self.parameterAsFile(parameters, self.INPUT, context)
+        if not os.path.exists(inDirectory):
+            raise QgsProcessingException(
+                self.tr("Directory {} does not exist").format(inDirectory)
+            )
+        arguments.append("--input")
+        arguments.append(inDirectory)
+
+        outFile = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
+        self.setOutputValue(self.OUTPUT, outFile)
+        arguments.append("--output")
+        arguments.append(outFile)
+
+        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+
+    def processAlgorithm(self, parameters, context, feedback):
+        if int(gdal.VersionInfo()) < 3130000:
+            raise QgsProcessingException(
+                self.tr("GDAL 3.13 or later is needed to run this algorithm")
+            )
+        return super().processAlgorithm(parameters, context, feedback)
+
+    def shortHelpString(self):
+        return self.tr(
+            "This algorithm reports the name of GDAL drivers that can open "
+            "files contained in a folder, with optional additional details, "
+            "and write the result into an output vector layer."
+        )
+
+    def shortDescription(self):
+        return self.tr(
+            "Reports the name of GDAL drivers that can open files contained in a folder, "
+            "with optional details."
+        )

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -76,6 +76,7 @@ from .rasterize_over import rasterize_over
 from .Buffer import Buffer
 from .ClipVectorByExtent import ClipVectorByExtent
 from .ClipVectorByMask import ClipVectorByMask
+from .DatasetIdentify import DatasetIdentify
 from .Dissolve import Dissolve
 from .ExecuteSql import ExecuteSql
 from .OffsetCurve import OffsetCurve
@@ -202,6 +203,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             OneSideBuffer(),
             PointsAlongLines(),
             # Ogr2OgrTableToPostGisList(),
+            DatasetIdentify(),
         ]
 
         if int(gdal.VersionInfo()) > 3010000:

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -83,6 +83,7 @@ from processing.algs.gdal.viewshed import viewshed
 from processing.algs.gdal.roughness import roughness
 from processing.algs.gdal.pct2rgb import pct2rgb
 from processing.algs.gdal.rgb2pct import rgb2pct
+from processing.algs.gdal.DatasetIdentify import DatasetIdentify
 
 testDataPath = os.path.join(os.path.dirname(__file__), "testdata")
 
@@ -6586,6 +6587,31 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                     + outdir
                     + "/check.tif "
                     + "-of GTiff -b 1 --config X Y --config Z A",
+                ],
+            )
+
+    def testDatasetIdentify(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+
+        with tempfile.TemporaryDirectory() as indir, tempfile.TemporaryDirectory() as outdir:
+            outsource = outdir + "/out.csv"
+            alg = DatasetIdentify()
+            alg.initAlgorithm()
+
+            # defaults
+            self.assertEqual(
+                alg.getConsoleCommands(
+                    {
+                        "INPUT": indir,
+                        "OUTPUT": outsource,
+                    },
+                    context,
+                    feedback,
+                ),
+                [
+                    "gdal dataset identify",
+                    f"--recursive --detailed --input {indir} --output {outsource}",
                 ],
             )
 


### PR DESCRIPTION
Requires GDAL 3.13.0 as it uses the new capabilities of [gdal dataset identify](https://gdal--13506.org.readthedocs.build/en/13506/programs/gdal_dataset_identify.html)

Access:

<img width="251" height="54" alt="image" src="https://github.com/user-attachments/assets/31ec6c7d-182b-4b48-80c9-29769b5e9484" />

Dialog:

<img width="818" height="496" alt="image" src="https://github.com/user-attachments/assets/8a53a336-ffd5-4dcd-a8d5-a1be2a4d3d62" />

Result:

<img width="1305" height="490" alt="image" src="https://github.com/user-attachments/assets/a01f1d61-3682-437a-ad72-add1b3989655" />


Funded by: QGIS Anwendergruppe Deutschland