### PR TITLE
sipify: Unify struct and class handling to fix bugs

### DIFF
--- a/python/3d/auto_generated/qgsrulebased3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsrulebased3drenderer.sip.in
@@ -64,16 +64,13 @@ specification of rules for 3D symbols.
     typedef QHash<const QgsRuleBased3DRenderer::Rule *, QgsFeature3DHandler *> RuleToHandlerMap;
 
     class Rule
-{
+    {
 %Docstring(signature="appended")
 A child rule for a QgsRuleBased3DRenderer.
 
 .. versionadded:: 3.6
 %End
 
-%TypeHeaderCode
-#include "qgsrulebased3drenderer.h"
-%End
       public:
         Rule( QgsAbstract3DSymbol *symbol /Transfer/, const QString &filterExp = QString(), const QString &description = QString(), bool elseRule = false );
 %Docstring

--- a/python/PyQt6/3d/auto_generated/qgsrulebased3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgsrulebased3drenderer.sip.in
@@ -64,16 +64,13 @@ specification of rules for 3D symbols.
     typedef QHash<const QgsRuleBased3DRenderer::Rule *, QgsFeature3DHandler *> RuleToHandlerMap;
 
     class Rule
-{
+    {
 %Docstring(signature="appended")
 A child rule for a QgsRuleBased3DRenderer.
 
 .. versionadded:: 3.6
 %End
 
-%TypeHeaderCode
-#include "qgsrulebased3drenderer.h"
-%End
       public:
         Rule( QgsAbstract3DSymbol *symbol /Transfer/, const QString &filterExp = QString(), const QString &description = QString(), bool elseRule = false );
 %Docstring

--- a/python/PyQt6/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
+++ b/python/PyQt6/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
@@ -17,6 +17,9 @@
 
 struct QgsInterpolatorVertexData
 {
+%TypeHeaderCode
+#include "qgsinterpolator.h"
+%End
     QgsInterpolatorVertexData( double x, double y, double z );
 %Docstring
 Constructor for QgsInterpolatorVertexData with the specified ``x``,

--- a/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerutils.sip.in
+++ b/python/PyQt6/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerutils.sip.in
@@ -28,7 +28,7 @@ Contains utilities required for geometry checks.
 %End
   public:
     class LayerFeature
-{
+    {
 %Docstring(signature="appended")
 A layer feature combination to uniquely identify and access a feature in
 a set of layers.
@@ -36,9 +36,6 @@ a set of layers.
 .. versionadded:: 3.4
 %End
 
-%TypeHeaderCode
-#include "qgsgeometrycheckerutils.h"
-%End
       public:
         LayerFeature( const QgsFeaturePool *pool, const QgsFeature &feature, const QgsGeometryCheckContext *context, bool useMapCrs );
 %Docstring
@@ -83,7 +80,7 @@ Returns if the geometry is reprojected to the map CRS or not.
     };
 
     class LayerFeatures
-{
+    {
 %Docstring(signature="appended")
 Contains a set of layers and feature ids in those layers to pass to a
 geometry check.
@@ -91,9 +88,6 @@ geometry check.
 .. versionadded:: 3.4
 %End
 
-%TypeHeaderCode
-#include "qgsgeometrycheckerutils.h"
-%End
       public:
 
       private:

--- a/python/PyQt6/core/auto_additions/qgslayoutitemmapgrid.py
+++ b/python/PyQt6/core/auto_additions/qgslayoutitemmapgrid.py
@@ -10,3 +10,8 @@ try:
     QgsLayoutItemMapGridStack.__group__ = ['layout']
 except (NameError, AttributeError):
     pass
+try:
+    QgsLayoutItemMapGrid.GridLine.__doc__ = """Helper that represents a grid line, for drawing the line itself an the
+anotations on the frame."""
+except (NameError, AttributeError):
+    pass

--- a/python/PyQt6/core/auto_additions/qgsmergedfeaturerenderer.py
+++ b/python/PyQt6/core/auto_additions/qgsmergedfeaturerenderer.py
@@ -9,3 +9,8 @@ try:
     QgsMergedFeatureRenderer.__group__ = ['symbology']
 except (NameError, AttributeError):
     pass
+try:
+    QgsMergedFeatureRenderer.FeatureDecoration.__doc__ = """Class used to represent features that must be rendered
+with decorations (selection, vertex markers)"""
+except (NameError, AttributeError):
+    pass

--- a/python/PyQt6/core/auto_additions/qgstranslationcontext.py
+++ b/python/PyQt6/core/auto_additions/qgstranslationcontext.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/core/qgstranslationcontext.h
+try:
+    QgsTranslationContext.TranslatableObject.__doc__ = """Object that could be translated by the QTranslator with the qm file."""
+except (NameError, AttributeError):
+    pass

--- a/python/PyQt6/core/auto_generated/callouts/qgscallout.sip.in
+++ b/python/PyQt6/core/auto_generated/callouts/qgscallout.sip.in
@@ -216,7 +216,7 @@ The default order is QgsCallout.OrderBelowIndividualLabels.
 %End
 
     class QgsCalloutContext
-{
+    {
 %Docstring(signature="appended")
 Contains additional contextual information about the context in which a
 callout is being rendered.
@@ -224,9 +224,6 @@ callout is being rendered.
 .. versionadded:: 3.10
 %End
 
-%TypeHeaderCode
-#include "qgscallout.h"
-%End
       public:
         bool allFeaturePartsLabeled;
 

--- a/python/PyQt6/core/auto_generated/expression/qgsexpressionfunction.sip.in
+++ b/python/PyQt6/core/auto_generated/expression/qgsexpressionfunction.sip.in
@@ -24,14 +24,11 @@ An abstract base class for defining :py:class:`QgsExpression` functions.
 
 
     class Parameter
-{
+    {
 %Docstring(signature="appended")
 Represents a single parameter passed to a function.
 %End
 
-%TypeHeaderCode
-#include "qgsexpressionfunction.h"
-%End
       public:
 
         Parameter( const QString &name,

--- a/python/PyQt6/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/PyQt6/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -86,14 +86,11 @@ Constructor for NamedNode
     };
 
     class NodeList
-{
+    {
 %Docstring(signature="appended")
 A list of expression nodes.
 %End
 
-%TypeHeaderCode
-#include "qgsexpressionnode.h"
-%End
       public:
         virtual ~NodeList();
         void append( QgsExpressionNode *node /Transfer/ );

--- a/python/PyQt6/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
+++ b/python/PyQt6/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
@@ -582,15 +582,12 @@ An expression node for CASE WHEN clauses.
   public:
 
     class WhenThen
-{
+    {
 %Docstring(signature="appended")
 Represents a "WHEN... THEN..." portation of a CASE WHEN clause in an
 expression.
 %End
 
-%TypeHeaderCode
-#include "qgsexpressionnodeimpl.h"
-%End
       public:
 
         WhenThen( QgsExpressionNode *whenExp, QgsExpressionNode *thenExp );

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2845,14 +2845,11 @@ This convention matches the OGC Simple Features specification.
 %End
 
     class Error
-{
+    {
 %Docstring(signature="appended")
 A geometry error.
 %End
 
-%TypeHeaderCode
-#include "qgsgeometry.h"
-%End
       public:
         Error();
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsvertexid.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsvertexid.sip.in
@@ -11,6 +11,9 @@
 
 struct QgsVertexId
 {
+%TypeHeaderCode
+#include "qgsvertexid.h"
+%End
 
   explicit QgsVertexId( int _part = -1, int _ring = -1, int _vertex = -1, Qgis::VertexType _type = Qgis::VertexType::Segment ) /HoldGIL/;
 %Docstring

--- a/python/PyQt6/core/auto_generated/labeling/qgsrulebasedlabeling.sip.in
+++ b/python/PyQt6/core/auto_generated/labeling/qgsrulebasedlabeling.sip.in
@@ -24,14 +24,11 @@ Rule based labeling for a vector layer.
   public:
 
     class Rule
-{
+    {
 %Docstring(signature="appended")
 A child rule for QgsRuleBasedLabeling.
 %End
 
-%TypeHeaderCode
-#include "qgsrulebasedlabeling.h"
-%End
       public:
         Rule( QgsPalLayerSettings *settings /Transfer/, double maximumScale = 0, double minimumScale = 0, const QString &filterExp = QString(), const QString &description = QString(), bool elseRule = false );
 %Docstring

--- a/python/PyQt6/core/auto_generated/layout/qgslayoutitemchart.sip.in
+++ b/python/PyQt6/core/auto_generated/layout/qgslayoutitemchart.sip.in
@@ -23,7 +23,7 @@ A layout item subclass that renders chart plots.
   public:
 
     class SeriesDetails
-{
+    {
 %Docstring(signature="appended")
 Chart series details covering all supported series types.
 
@@ -35,9 +35,6 @@ Chart series details covering all supported series types.
 .. versionadded:: 4.0
 %End
 
-%TypeHeaderCode
-#include "qgslayoutitemchart.h"
-%End
       public:
 
         explicit SeriesDetails( const QString &name = QString() );

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -18,6 +18,9 @@
 
 struct QgsMesh
 {
+%TypeHeaderCode
+#include "qgsmeshdataprovider.h"
+%End
 
   enum ElementType /BaseType=IntEnum/
   {

--- a/python/PyQt6/core/auto_generated/mesh/qgstopologicalmesh.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgstopologicalmesh.sip.in
@@ -33,7 +33,7 @@ A topological face must:
     typedef QVector<int> FaceNeighbors;
 
     class TopologicalFaces
-{
+    {
 %Docstring(signature="appended")
 Contains independent faces and topological information about these
 faces.
@@ -43,9 +43,6 @@ This class supports unique shared vertices between faces.
 .. versionadded:: 3.22
 %End
 
-%TypeHeaderCode
-#include "qgstopologicalmesh.h"
-%End
       public:
 
 
@@ -64,7 +61,7 @@ Returns a face linked to the vertices with index ``vertexIndex``
 
 
     class Changes
-{
+    {
 %Docstring(signature="appended")
 Contains topological differences between two states of a topological
 mesh, only accessible from the QgsTopologicalMesh class.
@@ -72,9 +69,6 @@ mesh, only accessible from the QgsTopologicalMesh class.
 .. versionadded:: 3.22
 %End
 
-%TypeHeaderCode
-#include "qgstopologicalmesh.h"
-%End
       public:
 
 

--- a/python/PyQt6/core/auto_generated/metadata/qgsabstractlayermetadataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/metadata/qgsabstractlayermetadataprovider.sip.in
@@ -11,6 +11,9 @@
 
 struct QgsMetadataSearchContext
 {
+%TypeHeaderCode
+#include "qgsabstractlayermetadataprovider.h"
+%End
   QgsCoordinateTransformContext transformContext;
 };
 

--- a/python/PyQt6/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
+++ b/python/PyQt6/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
@@ -24,14 +24,11 @@ Abstract base class for metadata validators.
   public:
 
     class ValidationResult
-{
+    {
 %Docstring(signature="appended")
 Contains the parameters describing a metadata validation failure.
 %End
 
-%TypeHeaderCode
-#include "qgslayermetadatavalidator.h"
-%End
       public:
 
         ValidationResult( const QString &section, const QString &note, const QVariant &identifier = QVariant() );

--- a/python/PyQt6/core/auto_generated/network/qgsnewsfeedparser.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnewsfeedparser.sip.in
@@ -27,16 +27,13 @@ See https://github.com/elpaso/qgis-feed.
 
 
     class Entry
-{
+    {
 %Docstring(signature="appended")
 Represents a single entry from a news feed.
 
 .. versionadded:: 3.10
 %End
 
-%TypeHeaderCode
-#include "qgsnewsfeedparser.h"
-%End
       public:
 
         int key;

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudstatistics.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudstatistics.sip.in
@@ -17,6 +17,9 @@
 
 struct QgsPointCloudAttributeStatistics
 {
+%TypeHeaderCode
+#include "qgspointcloudstatistics.h"
+%End
   double minimum;
   double maximum;
   double mean;

--- a/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -552,15 +552,12 @@ sources
 %End
 
     class VariableDefinition
-{
+    {
 %Docstring(signature="appended")
 Definition of a expression context variable available during model
 execution.
 %End
 
-%TypeHeaderCode
-#include "qgsprocessingmodelalgorithm.h"
-%End
       public:
 
         VariableDefinition( const QVariant &value = QVariant(), const QgsProcessingModelChildParameterSource &source = QgsProcessingModelChildParameterSource::fromStaticValue( QVariant() ), const QString &description = QString() );

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -206,14 +206,11 @@ during algorithm execution.
 %End
 
     class LayerDetails
-{
+    {
 %Docstring(signature="appended")
 Details for layers to load into projects.
 %End
 
-%TypeHeaderCode
-#include "qgsprocessingcontext.h"
-%End
       public:
 
         LayerDetails( const QString &name, QgsProject *project, const QString &outputName = QString(), QgsProcessingUtils::LayerHint layerTypeHint = QgsProcessingUtils::LayerHint::UnknownType );

--- a/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
@@ -40,16 +40,13 @@ Constructor for QgsCoordinateReferenceSystemRegistry, with the specified
     ~QgsCoordinateReferenceSystemRegistry();
 
     class UserCrsDetails
-{
+    {
 %Docstring(signature="appended")
 Contains details of a custom (user defined) CRS.
 
 .. versionadded:: 3.18
 %End
 
-%TypeHeaderCode
-#include "qgscoordinatereferencesystemregistry.h"
-%End
       public:
 
         long id;

--- a/python/PyQt6/core/auto_generated/project/qgsprojectstorage.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsprojectstorage.sip.in
@@ -26,16 +26,13 @@ backends and registered in :py:class:`QgsProjectStorageRegistry`.
   public:
 
     class Metadata
-{
+    {
 %Docstring(signature="appended")
 Metadata associated with a project.
 
 .. versionadded:: 3.2
 %End
 
-%TypeHeaderCode
-#include "qgsprojectstorage.h"
-%End
       public:
         QString name;
         QDateTime lastModified;

--- a/python/PyQt6/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -398,16 +398,13 @@ the specified layer ``type``.
 %End
 
     class ProviderCandidateDetails
-{
+    {
 %Docstring(signature="appended")
 Contains information pertaining to a candidate provider.
 
 .. versionadded:: 3.18
 %End
 
-%TypeHeaderCode
-#include "qgsproviderregistry.h"
-%End
       public:
 
         ProviderCandidateDetails( QgsProviderMetadata *metadata, const QList< Qgis::LayerType > &layerTypes );
@@ -457,7 +454,7 @@ URI then all of these providers will be returned.
 %End
 
     class UnusableUriDetails
-{
+    {
 %Docstring(signature="appended")
 Contains information about unusable URIs which aren't handled by any
 registered providers.
@@ -470,9 +467,6 @@ used on their QGIS build.
 .. versionadded:: 3.18.1
 %End
 
-%TypeHeaderCode
-#include "qgsproviderregistry.h"
-%End
       public:
 
         UnusableUriDetails( const QString &uri = QString(), const QString &warning = QString(), const QList< Qgis::LayerType > &layerTypes = QList< Qgis::LayerType >() );
@@ -501,7 +495,7 @@ which are usually valid options for opening the URI.
     };
 
     class UnusableUriHandlerInterface
-{
+    {
 %Docstring(signature="appended")
 An interface used to handle unusable URIs which aren't handled by any
 registered providers, and construct user-friendly warnings as to why the
@@ -515,9 +509,6 @@ used on their QGIS build.
 .. versionadded:: 3.18.1
 %End
 
-%TypeHeaderCode
-#include "qgsproviderregistry.h"
-%End
       public:
 
         virtual ~UnusableUriHandlerInterface();

--- a/python/PyQt6/core/auto_generated/providers/qgsprovidersublayermodel.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsprovidersublayermodel.sip.in
@@ -60,7 +60,7 @@ added by calling :py:func:`~addNonLayerItem`.
     };
 
     class NonLayerItem
-{
+    {
 %Docstring(signature="appended")
 Contains details for a non-sublayer item to include in a
 QgsProviderSublayerModel.
@@ -68,9 +68,6 @@ QgsProviderSublayerModel.
 .. versionadded:: 3.22
 %End
 
-%TypeHeaderCode
-#include "qgsprovidersublayermodel.h"
-%End
       public:
 
         QString type() const;

--- a/python/PyQt6/core/auto_generated/qgscadutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscadutils.sip.in
@@ -22,14 +22,11 @@ Provides routines for CAD editing.
   public:
 
     class AlignMapPointConstraint
-{
+    {
 %Docstring(signature="appended")
 Structure with details of one constraint.
 %End
 
-%TypeHeaderCode
-#include "qgscadutils.h"
-%End
       public:
 
         AlignMapPointConstraint( bool locked = false, bool relative = false, double value = 0 );
@@ -43,14 +40,11 @@ Constructor for AlignMapPointConstraint.
     };
 
     class AlignMapPointOutput
-{
+    {
 %Docstring(signature="appended")
 Structure returned from :py:func:`~QgsCadUtils.alignMapPoint` method.
 %End
 
-%TypeHeaderCode
-#include "qgscadutils.h"
-%End
       public:
         bool valid;
 
@@ -68,15 +62,12 @@ Structure returned from :py:func:`~QgsCadUtils.alignMapPoint` method.
     };
 
     class AlignMapPointContext
-{
+    {
 %Docstring(signature="appended")
 Defines constraints for the :py:func:`QgsCadUtils.alignMapPoint()`
 method.
 %End
 
-%TypeHeaderCode
-#include "qgscadutils.h"
-%End
       public:
         QgsSnappingUtils *snappingUtils;
         double mapUnitsPerPixel;

--- a/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfeaturerequest.sip.in
@@ -70,7 +70,7 @@ Examples:
   public:
 
     class OrderByClause
-{
+    {
 %Docstring(signature="appended")
 The OrderByClause class represents an order by clause for a
 QgsFeatureRequest.
@@ -96,9 +96,6 @@ will be respected for the features returned by the iterator but
 internally all features will be requested from the provider.
 %End
 
-%TypeHeaderCode
-#include "qgsfeaturerequest.h"
-%End
       public:
 
         OrderByClause( const QString &expression, bool ascending = true );
@@ -197,15 +194,12 @@ Dumps the content to an SQL equivalent
 
 
     class OrderBy
-{
+    {
 %Docstring(signature="appended")
 Represents a list of OrderByClauses, with the most important first and
 the least important last.
 %End
 
-%TypeHeaderCode
-#include "qgsfeaturerequest.h"
-%End
       public:
 
         OrderBy();

--- a/python/PyQt6/core/auto_generated/qgslayerdefinition.sip.in
+++ b/python/PyQt6/core/auto_generated/qgslayerdefinition.sip.in
@@ -128,15 +128,12 @@ and joins
 %End
 
     class DependencySorter
-{
+    {
 %Docstring(signature="appended")
 Handles sorting of dependencies stored in a XML project or layer
 definition file.
 %End
 
-%TypeHeaderCode
-#include "qgslayerdefinition.h"
-%End
       public:
 
         explicit DependencySorter( const QDomDocument &doc );

--- a/python/PyQt6/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmapthemecollection.sip.in
@@ -24,14 +24,11 @@ map layers and layer styles.
   public:
 
     class MapThemeLayerRecord
-{
+    {
 %Docstring(signature="appended")
 Individual record of a visible layer in a map theme record.
 %End
 
-%TypeHeaderCode
-#include "qgsmapthemecollection.h"
-%End
       public:
         MapThemeLayerRecord( QgsMapLayer *l = 0 );
 %Docstring
@@ -66,14 +63,11 @@ Sets the map layer for this record
     };
 
     class MapThemeRecord
-{
+    {
 %Docstring(signature="appended")
 Individual map theme record of visible layers and styles.
 %End
 
-%TypeHeaderCode
-#include "qgsmapthemecollection.h"
-%End
       public:
 
         bool operator==( const QgsMapThemeCollection::MapThemeRecord &other ) const;

--- a/python/PyQt6/core/auto_generated/qgsmargins.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmargins.sip.in
@@ -13,7 +13,6 @@
 
 class QgsMargins
 {
-
 %TypeHeaderCode
 #include "qgsmargins.h"
 %End

--- a/python/PyQt6/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssnappingconfig.sip.in
@@ -80,15 +80,12 @@ Convenient method to return an icon corresponding to the enum type
 %End
 
     class IndividualLayerSettings
-{
+    {
 %Docstring(signature="appended")
 A container of advanced configuration (per layer) of the snapping of the
 project.
 %End
 
-%TypeHeaderCode
-#include "qgssnappingconfig.h"
-%End
       public:
 
  IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, Qgis::MapToolUnit units ) /Deprecated="Since 3.12. Use the method with Qgis.SnappingTypes instead."/;

--- a/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/PyQt6/core/auto_generated/qgssqlstatement.sip.in
@@ -184,14 +184,11 @@ Returns a quoted version of a string (in single quotes)
     };
 
     class Node
-{
+    {
 %Docstring(signature="appended")
 Abstract node class for SQL statement nodes.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
 %ConvertToSubClassCode
         switch ( sipCpp->nodeType() )
         {
@@ -252,14 +249,11 @@ For any implementation this should look like
     };
 
     class NodeList
-{
+    {
 %Docstring(signature="appended")
 A list of nodes.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
 
         NodeList();
@@ -299,14 +293,11 @@ Dump list
     };
 
     class NodeUnaryOperator : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Unary logical/arithmetical operator ( NOT, - ).
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeUnaryOperator( QgsSQLStatement::UnaryOperator op, QgsSQLStatement::Node *operand /Transfer/ );
 %Docstring
@@ -337,14 +328,11 @@ Operand
     };
 
     class NodeBinaryOperator : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Binary logical/arithmetical operator (AND, OR, =, +, ...).
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeBinaryOperator( QgsSQLStatement::BinaryOperator op, QgsSQLStatement::Node *opLeft /Transfer/, QgsSQLStatement::Node *opRight /Transfer/ );
 %Docstring
@@ -391,14 +379,11 @@ Is left associative ?
     };
 
     class NodeInOperator : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 An 'x IN (y, z)' operator.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeInOperator( QgsSQLStatement::Node *node /Transfer/, QgsSQLStatement::NodeList *list /Transfer/, bool notin = false );
 %Docstring
@@ -434,14 +419,11 @@ Values list
     };
 
     class NodeBetweenOperator : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 An 'X BETWEEN y and z' operator.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeBetweenOperator( QgsSQLStatement::Node *node /Transfer/, QgsSQLStatement::Node *minVal /Transfer/, QgsSQLStatement::Node *maxVal /Transfer/, bool notBetween = false );
 %Docstring
@@ -481,14 +463,11 @@ Maximum bound
     };
 
     class NodeFunction : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Function with a name and arguments node.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeFunction( const QString &name, QgsSQLStatement::NodeList *args  /Transfer/ );
 %Docstring
@@ -520,14 +499,11 @@ Returns arguments
     };
 
     class NodeLiteral : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Literal value (integer, integer64, double, string).
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeLiteral( const QVariant &value );
 %Docstring
@@ -551,14 +527,11 @@ The value of the literal.
     };
 
     class NodeColumnRef : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Reference to a column.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeColumnRef( const QString &name, bool star );
 %Docstring
@@ -610,14 +583,11 @@ Clone with same type return
     };
 
     class NodeSelectedColumn : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Selected column.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeSelectedColumn( QgsSQLStatement::Node *node /Transfer/ );
 %Docstring
@@ -657,14 +627,11 @@ Clone with same type return
     };
 
     class NodeCast : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 CAST operator.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeCast( QgsSQLStatement::Node *node /Transfer/, const QString &type );
 %Docstring
@@ -695,14 +662,11 @@ Type
     };
 
     class NodeTableDef : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Table definition.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeTableDef( const QString &name );
 %Docstring
@@ -753,14 +717,11 @@ Clone with same type return
     };
 
     class NodeJoin : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Join definition.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeJoin( QgsSQLStatement::NodeTableDef *tabledef /Transfer/, QgsSQLStatement::Node *onExpr /Transfer/, QgsSQLStatement::JoinType type );
 %Docstring
@@ -810,14 +771,11 @@ Clone with same type return
     };
 
     class NodeColumnSorted : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Column in a ORDER BY.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeColumnSorted( QgsSQLStatement::NodeColumnRef *column /Transfer/, bool asc );
 %Docstring
@@ -852,14 +810,11 @@ Clone with same type return
     };
 
     class NodeSelect : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 SELECT node.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeSelect( const QList<QgsSQLStatement::NodeTableDef *> &tableList /Transfer/, const QList<QgsSQLStatement::NodeSelectedColumn *> &columns /Transfer/, bool distinct );
 %Docstring
@@ -924,15 +879,12 @@ Returns the list of order by columns
 
 
     class Visitor
-{
+    {
 %Docstring(signature="appended")
 Support for visitor pattern - algorithms dealing with the statement may
 be implemented without modifying the Node classes.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         virtual ~Visitor();
         virtual void visit( const QgsSQLStatement::NodeUnaryOperator &n ) = 0;
@@ -990,14 +942,11 @@ Visit NodeCast
     };
 
     class RecursiveVisitor: QgsSQLStatement::Visitor
-{
+    {
 %Docstring(signature="appended")
 A visitor that recursively explores all children.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
 
         RecursiveVisitor();

--- a/python/PyQt6/core/auto_generated/qgstestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstestutils.sip.in
@@ -12,7 +12,6 @@
 
 class QgsTestUtils
 {
-
 %TypeHeaderCode
 #include "qgstestutils.h"
 %End

--- a/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -36,15 +36,12 @@ There are two possibilities how to use this class:
     };
 
     class Option
-{
+    {
 %Docstring(signature="appended")
 Describes an available option for configuring file writing for a
 particular output format.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         Option( const QString &docString, QgsVectorFileWriter::OptionType type );
 
@@ -53,15 +50,12 @@ particular output format.
     };
 
     class SetOption : QgsVectorFileWriter::Option
-{
+    {
 %Docstring(signature="appended")
 An available option for configuring file writing for a particular output
 format, presenting a choice of preset values.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         SetOption( const QString &docString, const QStringList &values, const QString &defaultValue, bool allowNone = false );
 
@@ -71,15 +65,12 @@ format, presenting a choice of preset values.
     };
 
     class StringOption: QgsVectorFileWriter::Option
-{
+    {
 %Docstring(signature="appended")
 An available option for configuring file writing for a particular output
 format, presenting a freeform string option.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         StringOption( const QString &docString, const QString &defaultValue = QString() );
 
@@ -87,15 +78,12 @@ format, presenting a freeform string option.
     };
 
     class IntOption: QgsVectorFileWriter::Option
-{
+    {
 %Docstring(signature="appended")
 An available option for configuring file writing for a particular output
 format, presenting an integer option.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         IntOption( const QString &docString, int defaultValue );
 
@@ -103,28 +91,22 @@ format, presenting an integer option.
     };
 
     class BoolOption : QgsVectorFileWriter::SetOption
-{
+    {
 %Docstring(signature="appended")
 An available option for configuring file writing for a particular output
 format, presenting an boolean option.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         BoolOption( const QString &docString, bool defaultValue );
     };
 
     class HiddenOption : QgsVectorFileWriter::Option
-{
+    {
 %Docstring(signature="appended")
 A hidden option for file writing for a particular output format.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         explicit HiddenOption( const QString &value );
 
@@ -178,14 +160,11 @@ A hidden option for file writing for a particular output format.
 
 
     class FieldValueConverter
-{
+    {
 %Docstring(signature="appended")
 Interface to convert raw field values to their user-friendly values.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
 
         FieldValueConverter();
@@ -381,14 +360,11 @@ Writes a layer out to a vector file.
 %End
 
     class SaveVectorOptions
-{
+    {
 %Docstring(signature="appended")
 Options to pass to :py:func:`QgsVectorFileWriter.writeAsVectorFormat()`.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
 
         SaveVectorOptions();

--- a/python/PyQt6/core/auto_generated/qgsvirtuallayerdefinition.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvirtuallayerdefinition.sip.in
@@ -25,15 +25,12 @@ types have been detected.
   public:
 
     class SourceLayer
-{
+    {
 %Docstring(signature="appended")
 Either a reference to a live layer in the registry or all the parameters
 needed to load it (provider key, source, etc.).
 %End
 
-%TypeHeaderCode
-#include "qgsvirtuallayerdefinition.h"
-%End
       public:
         SourceLayer( const QString &name, const QString &ref );
 %Docstring

--- a/python/PyQt6/core/auto_generated/raster/qgsexiftools.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsexiftools.sip.in
@@ -61,16 +61,13 @@ Returns ``True`` if the image at ``imagePath`` contains a valid geotag.
 %End
 
     class GeoTagDetails
-{
+    {
 %Docstring(signature="appended")
 Extended image geotag details.
 
 .. versionadded:: 3.6
 %End
 
-%TypeHeaderCode
-#include "qgsexiftools.h"
-%End
       public:
 
         GeoTagDetails();

--- a/python/PyQt6/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
@@ -36,7 +36,7 @@ Constructor for Class
     };
 
     class MultiValueClass
-{
+    {
 %Docstring(signature="appended")
 Properties of a multi value class: a class that contains multiple
 values.
@@ -44,9 +44,6 @@ values.
 .. versionadded:: 3.30
 %End
 
-%TypeHeaderCode
-#include "qgspalettedrasterrenderer.h"
-%End
       public:
 
         MultiValueClass( const QVector< QVariant > &values, const QColor &color = QColor(), const QString &label = QString() );

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterattributetable.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterattributetable.sip.in
@@ -28,16 +28,13 @@ file.
   public:
 
     class UsageInformation
-{
+    {
 %Docstring(signature="appended")
 The UsageInformation class represents information about a field usage.
 
 .. versionadded:: 3.30
 %End
 
-%TypeHeaderCode
-#include "qgsrasterattributetable.h"
-%End
       public:
 
         QString description;
@@ -58,7 +55,7 @@ The UsageInformation class represents information about a field usage.
     };
 
     class Field
-{
+    {
 %Docstring(signature="appended")
 The Field class represents a Raster Attribute Table field, including its
 name, usage and type.
@@ -66,9 +63,6 @@ name, usage and type.
 .. versionadded:: 3.30
 %End
 
-%TypeHeaderCode
-#include "qgsrasterattributetable.h"
-%End
       public:
 
         Field( const QString &name, const Qgis::RasterAttributeTableFieldUsage &usage, const QMetaType::Type type );
@@ -104,7 +98,7 @@ AlphaMin/AlphaMax) information.
     };
 
     class MinMaxClass
-{
+    {
 %Docstring(signature="appended")
 The Field class represents a Raster Attribute Table classification entry
 for a thematic Raster Attribute Table.
@@ -112,9 +106,6 @@ for a thematic Raster Attribute Table.
 .. versionadded:: 3.30
 %End
 
-%TypeHeaderCode
-#include "qgsrasterattributetable.h"
-%End
       public:
         QString name;
 

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterviewport.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterviewport.sip.in
@@ -12,9 +12,8 @@
 struct QgsRasterViewPort
 {
 %TypeHeaderCode
-#include <qgsrasterviewport.h>
+#include "qgsrasterviewport.h"
 %End
-
   QgsPointXY mTopLeftPoint;
 
   QgsPointXY mBottomRightPoint;

--- a/python/PyQt6/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
@@ -77,7 +77,7 @@ symbol.
     typedef QList<QgsRuleBasedRenderer::Rule *> RuleList;
 
     class Rule
-{
+    {
 %Docstring(signature="appended")
 Represents an individual rule for a rule-based renderer.
 
@@ -88,9 +88,6 @@ zero, there is no lower/upper bound for scales. A rule matches if both
 filter and scale range match.
 %End
 
-%TypeHeaderCode
-#include "qgsrulebasedrenderer.h"
-%End
       public:
         enum RenderResult /BaseType=IntEnum/
         {

--- a/python/PyQt6/core/auto_generated/textrenderer/qgstextformat.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgstextformat.sip.in
@@ -565,16 +565,13 @@ The units are specified using
 %End
 
     class Tab
-{
+    {
 %Docstring(signature="appended")
 Defines a tab position for a text format.
 
 .. versionadded:: 3.42
 %End
 
-%TypeHeaderCode
-#include "qgstextformat.h"
-%End
       public:
 
         explicit Tab( double position );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -71,16 +71,13 @@ source ``expression``.
     };
 
     class ExportOptions
-{
+    {
 %Docstring(signature="appended")
 Encapsulates options for use with QgsVectorLayerExporter.
 
 .. versionadded:: 3.44
 %End
 
-%TypeHeaderCode
-#include "qgsvectorlayerexporter.h"
-%End
       public:
 
         void setSelectedOnly( bool selected );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -23,15 +23,12 @@ Contains utility methods for working with :py:class:`QgsVectorLayers`.
   public:
 
     class QgsDuplicateFeatureContext
-{
+    {
 %Docstring(signature="appended")
 Contains mainly the QMap with :py:class:`QgsVectorLayer` and
 :py:class:`QgsFeatureIds` which list all the duplicated features.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorlayerutils.h"
-%End
       public:
 
         QgsDuplicateFeatureContext();
@@ -50,7 +47,7 @@ Returns the duplicated features in the given layer
     };
 
     class QgsFeatureData
-{
+    {
 %Docstring(signature="appended")
 Encapsulate geometry and attributes for new features, to be passed to
 createFeatures.
@@ -60,9 +57,6 @@ createFeatures.
 .. versionadded:: 3.6
 %End
 
-%TypeHeaderCode
-#include "qgsvectorlayerutils.h"
-%End
       public:
 
         QgsFeatureData( const QgsGeometry &geometry = QgsGeometry(), const QgsAttributeMap &attributes = QgsAttributeMap() );

--- a/python/PyQt6/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
@@ -66,7 +66,7 @@ specified in metadata by the client, tile writer also writes "name",
     QgsVectorTileWriter();
 
     class Layer
-{
+    {
 %Docstring(signature="appended")
 Configuration of a single input vector layer to be included in the
 output.
@@ -74,9 +74,6 @@ output.
 .. versionadded:: 3.14
 %End
 
-%TypeHeaderCode
-#include "qgsvectortilewriter.h"
-%End
       public:
         explicit Layer( QgsVectorLayer *layer );
 %Docstring

--- a/python/PyQt6/gui/auto_generated/elevation/qgselevationcontrollerwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/elevation/qgselevationcontrollerwidget.sip.in
@@ -15,7 +15,6 @@
 
 class QgsElevationControllerSettingsAction : QWidgetAction
 {
-
 %TypeHeaderCode
 #include "qgselevationcontrollerwidget.h"
 %End

--- a/python/PyQt6/gui/auto_generated/history/qgshistoryproviderregistry.sip.in
+++ b/python/PyQt6/gui/auto_generated/history/qgshistoryproviderregistry.sip.in
@@ -65,16 +65,13 @@ Returns a list of the registered provider IDs.
 %End
 
     class HistoryEntryOptions
-{
+    {
 %Docstring(signature="appended")
 Contains options for storing history entries.
 
 .. versionadded:: 3.24
 %End
 
-%TypeHeaderCode
-#include "qgshistoryproviderregistry.h"
-%End
       public:
         HistoryEntryOptions();
 %Docstring

--- a/python/PyQt6/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
@@ -406,7 +406,7 @@ Activates a standard layout designer ``tool``.
 %End
 
     class ExportResults
-{
+    {
 %Docstring(signature="appended")
 Encapsulates the results of an export operation performed in the
 designer.
@@ -414,9 +414,6 @@ designer.
 .. versionadded:: 3.20
 %End
 
-%TypeHeaderCode
-#include "qgslayoutdesignerinterface.h"
-%End
       public:
         QgsLayoutExporter::ExportResult result;
 

--- a/python/PyQt6/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -147,7 +147,6 @@ Updates both the name text edit and the model name itself.
 
 class QgsModelChildDependenciesWidget : QWidget
 {
-
 %TypeHeaderCode
 #include "qgsmodeldesignerdialog.h"
 %End

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingguiutils.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingguiutils.sip.in
@@ -26,16 +26,13 @@ Contains utility functions relating to Processing GUI components.
 %End
   public:
     class ResultLayerDetails
-{
+    {
 %Docstring(signature="appended")
 Contains details of a layer result from running an algorithm.
 
 .. versionadded:: 3.44
 %End
 
-%TypeHeaderCode
-#include "qgsprocessingguiutils.h"
-%End
       public:
         ResultLayerDetails( QgsMapLayer *layer /Transfer/ );
 %Docstring

--- a/python/PyQt6/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -46,7 +46,7 @@ implementing filters called from
 
 
     class CadConstraint
-{
+    {
 %Docstring(signature="appended")
 The CadConstraint is a class for all basic constraints
 (angle/distance/x/y). It contains all values (locked, value, relative)
@@ -57,9 +57,6 @@ and pointers to corresponding widgets.
    Relative is not mandatory since it is not used for distance.
 %End
 
-%TypeHeaderCode
-#include "qgsadvanceddigitizingdockwidget.h"
-%End
       public:
         enum LockMode /BaseType=IntEnum/
         {

--- a/python/PyQt6/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -115,7 +115,7 @@ can be used in an expression.
 %End
   public:
     class MenuProvider
-{
+    {
 %Docstring(signature="appended")
 Implementation of this interface can be implemented to allow
 QgsExpressionTreeView instance to provide custom context menus (opened
@@ -124,9 +124,6 @@ upon right-click).
 .. versionadded:: 3.14
 %End
 
-%TypeHeaderCode
-#include "qgsexpressiontreeview.h"
-%End
       public:
         explicit MenuProvider();
         virtual ~MenuProvider();

--- a/python/PyQt6/gui/auto_generated/qgsoptionswidgetfactory.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsoptionswidgetfactory.sip.in
@@ -78,7 +78,6 @@ options dialogs. This can be used to provide a custom implementation of
 
 class QgsOptionsWidgetFactory : QObject
 {
-
 %TypeHeaderCode
 #include "qgsoptionswidgetfactory.h"
 %End

--- a/python/PyQt6/gui/auto_generated/qgsstoredquerymanager.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsstoredquerymanager.sip.in
@@ -70,16 +70,13 @@ Returns the query definition with matching ``name``, from the specified
 %End
 
     class QueryDetails
-{
+    {
 %Docstring(signature="appended")
 Contains details about a stored query.
 
 .. versionadded:: 3.44
 %End
 
-%TypeHeaderCode
-#include "qgsstoredquerymanager.h"
-%End
       public:
         QString name;
 

--- a/python/PyQt6/server/auto_generated/qgsserverresponse.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverresponse.sip.in
@@ -14,7 +14,6 @@
 
 class QgsServerResponse
 {
-
 %TypeHeaderCode
 #include "qgsserverresponse.h"
 %End

--- a/python/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
+++ b/python/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
@@ -17,6 +17,9 @@
 
 struct QgsInterpolatorVertexData
 {
+%TypeHeaderCode
+#include "qgsinterpolator.h"
+%End
     QgsInterpolatorVertexData( double x, double y, double z );
 %Docstring
 Constructor for QgsInterpolatorVertexData with the specified ``x``,

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerutils.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerutils.sip.in
@@ -28,7 +28,7 @@ Contains utilities required for geometry checks.
 %End
   public:
     class LayerFeature
-{
+    {
 %Docstring(signature="appended")
 A layer feature combination to uniquely identify and access a feature in
 a set of layers.
@@ -36,9 +36,6 @@ a set of layers.
 .. versionadded:: 3.4
 %End
 
-%TypeHeaderCode
-#include "qgsgeometrycheckerutils.h"
-%End
       public:
         LayerFeature( const QgsFeaturePool *pool, const QgsFeature &feature, const QgsGeometryCheckContext *context, bool useMapCrs );
 %Docstring
@@ -83,7 +80,7 @@ Returns if the geometry is reprojected to the map CRS or not.
     };
 
     class LayerFeatures
-{
+    {
 %Docstring(signature="appended")
 Contains a set of layers and feature ids in those layers to pass to a
 geometry check.
@@ -91,9 +88,6 @@ geometry check.
 .. versionadded:: 3.4
 %End
 
-%TypeHeaderCode
-#include "qgsgeometrycheckerutils.h"
-%End
       public:
 
       private:

--- a/python/core/auto_additions/qgslayoutitemmapgrid.py
+++ b/python/core/auto_additions/qgslayoutitemmapgrid.py
@@ -10,3 +10,8 @@ try:
     QgsLayoutItemMapGridStack.__group__ = ['layout']
 except (NameError, AttributeError):
     pass
+try:
+    QgsLayoutItemMapGrid.GridLine.__doc__ = """Helper that represents a grid line, for drawing the line itself an the
+anotations on the frame."""
+except (NameError, AttributeError):
+    pass

--- a/python/core/auto_additions/qgsmergedfeaturerenderer.py
+++ b/python/core/auto_additions/qgsmergedfeaturerenderer.py
@@ -6,3 +6,8 @@ try:
     QgsMergedFeatureRenderer.__group__ = ['symbology']
 except (NameError, AttributeError):
     pass
+try:
+    QgsMergedFeatureRenderer.FeatureDecoration.__doc__ = """Class used to represent features that must be rendered
+with decorations (selection, vertex markers)"""
+except (NameError, AttributeError):
+    pass

--- a/python/core/auto_additions/qgstranslationcontext.py
+++ b/python/core/auto_additions/qgstranslationcontext.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/core/qgstranslationcontext.h
+try:
+    QgsTranslationContext.TranslatableObject.__doc__ = """Object that could be translated by the QTranslator with the qm file."""
+except (NameError, AttributeError):
+    pass

--- a/python/core/auto_generated/callouts/qgscallout.sip.in
+++ b/python/core/auto_generated/callouts/qgscallout.sip.in
@@ -216,7 +216,7 @@ The default order is QgsCallout.OrderBelowIndividualLabels.
 %End
 
     class QgsCalloutContext
-{
+    {
 %Docstring(signature="appended")
 Contains additional contextual information about the context in which a
 callout is being rendered.
@@ -224,9 +224,6 @@ callout is being rendered.
 .. versionadded:: 3.10
 %End
 
-%TypeHeaderCode
-#include "qgscallout.h"
-%End
       public:
         bool allFeaturePartsLabeled;
 

--- a/python/core/auto_generated/expression/qgsexpressionfunction.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionfunction.sip.in
@@ -24,14 +24,11 @@ An abstract base class for defining :py:class:`QgsExpression` functions.
 
 
     class Parameter
-{
+    {
 %Docstring(signature="appended")
 Represents a single parameter passed to a function.
 %End
 
-%TypeHeaderCode
-#include "qgsexpressionfunction.h"
-%End
       public:
 
         Parameter( const QString &name,

--- a/python/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -86,14 +86,11 @@ Constructor for NamedNode
     };
 
     class NodeList
-{
+    {
 %Docstring(signature="appended")
 A list of expression nodes.
 %End
 
-%TypeHeaderCode
-#include "qgsexpressionnode.h"
-%End
       public:
         virtual ~NodeList();
         void append( QgsExpressionNode *node /Transfer/ );

--- a/python/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
@@ -582,15 +582,12 @@ An expression node for CASE WHEN clauses.
   public:
 
     class WhenThen
-{
+    {
 %Docstring(signature="appended")
 Represents a "WHEN... THEN..." portation of a CASE WHEN clause in an
 expression.
 %End
 
-%TypeHeaderCode
-#include "qgsexpressionnodeimpl.h"
-%End
       public:
 
         WhenThen( QgsExpressionNode *whenExp, QgsExpressionNode *thenExp );

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2845,14 +2845,11 @@ This convention matches the OGC Simple Features specification.
 %End
 
     class Error
-{
+    {
 %Docstring(signature="appended")
 A geometry error.
 %End
 
-%TypeHeaderCode
-#include "qgsgeometry.h"
-%End
       public:
         Error();
 

--- a/python/core/auto_generated/geometry/qgsvertexid.sip.in
+++ b/python/core/auto_generated/geometry/qgsvertexid.sip.in
@@ -11,6 +11,9 @@
 
 struct QgsVertexId
 {
+%TypeHeaderCode
+#include "qgsvertexid.h"
+%End
 
   explicit QgsVertexId( int _part = -1, int _ring = -1, int _vertex = -1, Qgis::VertexType _type = Qgis::VertexType::Segment ) /HoldGIL/;
 %Docstring

--- a/python/core/auto_generated/labeling/qgsrulebasedlabeling.sip.in
+++ b/python/core/auto_generated/labeling/qgsrulebasedlabeling.sip.in
@@ -24,14 +24,11 @@ Rule based labeling for a vector layer.
   public:
 
     class Rule
-{
+    {
 %Docstring(signature="appended")
 A child rule for QgsRuleBasedLabeling.
 %End
 
-%TypeHeaderCode
-#include "qgsrulebasedlabeling.h"
-%End
       public:
         Rule( QgsPalLayerSettings *settings /Transfer/, double maximumScale = 0, double minimumScale = 0, const QString &filterExp = QString(), const QString &description = QString(), bool elseRule = false );
 %Docstring

--- a/python/core/auto_generated/layout/qgslayoutitemchart.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemchart.sip.in
@@ -23,7 +23,7 @@ A layout item subclass that renders chart plots.
   public:
 
     class SeriesDetails
-{
+    {
 %Docstring(signature="appended")
 Chart series details covering all supported series types.
 
@@ -35,9 +35,6 @@ Chart series details covering all supported series types.
 .. versionadded:: 4.0
 %End
 
-%TypeHeaderCode
-#include "qgslayoutitemchart.h"
-%End
       public:
 
         explicit SeriesDetails( const QString &name = QString() );

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -18,6 +18,9 @@
 
 struct QgsMesh
 {
+%TypeHeaderCode
+#include "qgsmeshdataprovider.h"
+%End
 
   enum ElementType
   {

--- a/python/core/auto_generated/mesh/qgstopologicalmesh.sip.in
+++ b/python/core/auto_generated/mesh/qgstopologicalmesh.sip.in
@@ -33,7 +33,7 @@ A topological face must:
     typedef QVector<int> FaceNeighbors;
 
     class TopologicalFaces
-{
+    {
 %Docstring(signature="appended")
 Contains independent faces and topological information about these
 faces.
@@ -43,9 +43,6 @@ This class supports unique shared vertices between faces.
 .. versionadded:: 3.22
 %End
 
-%TypeHeaderCode
-#include "qgstopologicalmesh.h"
-%End
       public:
 
 
@@ -64,7 +61,7 @@ Returns a face linked to the vertices with index ``vertexIndex``
 
 
     class Changes
-{
+    {
 %Docstring(signature="appended")
 Contains topological differences between two states of a topological
 mesh, only accessible from the QgsTopologicalMesh class.
@@ -72,9 +69,6 @@ mesh, only accessible from the QgsTopologicalMesh class.
 .. versionadded:: 3.22
 %End
 
-%TypeHeaderCode
-#include "qgstopologicalmesh.h"
-%End
       public:
 
 

--- a/python/core/auto_generated/metadata/qgsabstractlayermetadataprovider.sip.in
+++ b/python/core/auto_generated/metadata/qgsabstractlayermetadataprovider.sip.in
@@ -11,6 +11,9 @@
 
 struct QgsMetadataSearchContext
 {
+%TypeHeaderCode
+#include "qgsabstractlayermetadataprovider.h"
+%End
   QgsCoordinateTransformContext transformContext;
 };
 

--- a/python/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
+++ b/python/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
@@ -24,14 +24,11 @@ Abstract base class for metadata validators.
   public:
 
     class ValidationResult
-{
+    {
 %Docstring(signature="appended")
 Contains the parameters describing a metadata validation failure.
 %End
 
-%TypeHeaderCode
-#include "qgslayermetadatavalidator.h"
-%End
       public:
 
         ValidationResult( const QString &section, const QString &note, const QVariant &identifier = QVariant() );

--- a/python/core/auto_generated/network/qgsnewsfeedparser.sip.in
+++ b/python/core/auto_generated/network/qgsnewsfeedparser.sip.in
@@ -27,16 +27,13 @@ See https://github.com/elpaso/qgis-feed.
 
 
     class Entry
-{
+    {
 %Docstring(signature="appended")
 Represents a single entry from a news feed.
 
 .. versionadded:: 3.10
 %End
 
-%TypeHeaderCode
-#include "qgsnewsfeedparser.h"
-%End
       public:
 
         int key;

--- a/python/core/auto_generated/pointcloud/qgspointcloudstatistics.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudstatistics.sip.in
@@ -17,6 +17,9 @@
 
 struct QgsPointCloudAttributeStatistics
 {
+%TypeHeaderCode
+#include "qgspointcloudstatistics.h"
+%End
   double minimum;
   double maximum;
   double mean;

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -552,15 +552,12 @@ sources
 %End
 
     class VariableDefinition
-{
+    {
 %Docstring(signature="appended")
 Definition of a expression context variable available during model
 execution.
 %End
 
-%TypeHeaderCode
-#include "qgsprocessingmodelalgorithm.h"
-%End
       public:
 
         VariableDefinition( const QVariant &value = QVariant(), const QgsProcessingModelChildParameterSource &source = QgsProcessingModelChildParameterSource::fromStaticValue( QVariant() ), const QString &description = QString() );

--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -206,14 +206,11 @@ during algorithm execution.
 %End
 
     class LayerDetails
-{
+    {
 %Docstring(signature="appended")
 Details for layers to load into projects.
 %End
 
-%TypeHeaderCode
-#include "qgsprocessingcontext.h"
-%End
       public:
 
         LayerDetails( const QString &name, QgsProject *project, const QString &outputName = QString(), QgsProcessingUtils::LayerHint layerTypeHint = QgsProcessingUtils::LayerHint::UnknownType );

--- a/python/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
+++ b/python/core/auto_generated/proj/qgscoordinatereferencesystemregistry.sip.in
@@ -40,16 +40,13 @@ Constructor for QgsCoordinateReferenceSystemRegistry, with the specified
     ~QgsCoordinateReferenceSystemRegistry();
 
     class UserCrsDetails
-{
+    {
 %Docstring(signature="appended")
 Contains details of a custom (user defined) CRS.
 
 .. versionadded:: 3.18
 %End
 
-%TypeHeaderCode
-#include "qgscoordinatereferencesystemregistry.h"
-%End
       public:
 
         long id;

--- a/python/core/auto_generated/project/qgsprojectstorage.sip.in
+++ b/python/core/auto_generated/project/qgsprojectstorage.sip.in
@@ -26,16 +26,13 @@ backends and registered in :py:class:`QgsProjectStorageRegistry`.
   public:
 
     class Metadata
-{
+    {
 %Docstring(signature="appended")
 Metadata associated with a project.
 
 .. versionadded:: 3.2
 %End
 
-%TypeHeaderCode
-#include "qgsprojectstorage.h"
-%End
       public:
         QString name;
         QDateTime lastModified;

--- a/python/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -398,16 +398,13 @@ the specified layer ``type``.
 %End
 
     class ProviderCandidateDetails
-{
+    {
 %Docstring(signature="appended")
 Contains information pertaining to a candidate provider.
 
 .. versionadded:: 3.18
 %End
 
-%TypeHeaderCode
-#include "qgsproviderregistry.h"
-%End
       public:
 
         ProviderCandidateDetails( QgsProviderMetadata *metadata, const QList< Qgis::LayerType > &layerTypes );
@@ -457,7 +454,7 @@ URI then all of these providers will be returned.
 %End
 
     class UnusableUriDetails
-{
+    {
 %Docstring(signature="appended")
 Contains information about unusable URIs which aren't handled by any
 registered providers.
@@ -470,9 +467,6 @@ used on their QGIS build.
 .. versionadded:: 3.18.1
 %End
 
-%TypeHeaderCode
-#include "qgsproviderregistry.h"
-%End
       public:
 
         UnusableUriDetails( const QString &uri = QString(), const QString &warning = QString(), const QList< Qgis::LayerType > &layerTypes = QList< Qgis::LayerType >() );
@@ -501,7 +495,7 @@ which are usually valid options for opening the URI.
     };
 
     class UnusableUriHandlerInterface
-{
+    {
 %Docstring(signature="appended")
 An interface used to handle unusable URIs which aren't handled by any
 registered providers, and construct user-friendly warnings as to why the
@@ -515,9 +509,6 @@ used on their QGIS build.
 .. versionadded:: 3.18.1
 %End
 
-%TypeHeaderCode
-#include "qgsproviderregistry.h"
-%End
       public:
 
         virtual ~UnusableUriHandlerInterface();

--- a/python/core/auto_generated/providers/qgsprovidersublayermodel.sip.in
+++ b/python/core/auto_generated/providers/qgsprovidersublayermodel.sip.in
@@ -60,7 +60,7 @@ added by calling :py:func:`~addNonLayerItem`.
     };
 
     class NonLayerItem
-{
+    {
 %Docstring(signature="appended")
 Contains details for a non-sublayer item to include in a
 QgsProviderSublayerModel.
@@ -68,9 +68,6 @@ QgsProviderSublayerModel.
 .. versionadded:: 3.22
 %End
 
-%TypeHeaderCode
-#include "qgsprovidersublayermodel.h"
-%End
       public:
 
         QString type() const;

--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -22,14 +22,11 @@ Provides routines for CAD editing.
   public:
 
     class AlignMapPointConstraint
-{
+    {
 %Docstring(signature="appended")
 Structure with details of one constraint.
 %End
 
-%TypeHeaderCode
-#include "qgscadutils.h"
-%End
       public:
 
         AlignMapPointConstraint( bool locked = false, bool relative = false, double value = 0 );
@@ -43,14 +40,11 @@ Constructor for AlignMapPointConstraint.
     };
 
     class AlignMapPointOutput
-{
+    {
 %Docstring(signature="appended")
 Structure returned from :py:func:`~QgsCadUtils.alignMapPoint` method.
 %End
 
-%TypeHeaderCode
-#include "qgscadutils.h"
-%End
       public:
         bool valid;
 
@@ -68,15 +62,12 @@ Structure returned from :py:func:`~QgsCadUtils.alignMapPoint` method.
     };
 
     class AlignMapPointContext
-{
+    {
 %Docstring(signature="appended")
 Defines constraints for the :py:func:`QgsCadUtils.alignMapPoint()`
 method.
 %End
 
-%TypeHeaderCode
-#include "qgscadutils.h"
-%End
       public:
         QgsSnappingUtils *snappingUtils;
         double mapUnitsPerPixel;

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -70,7 +70,7 @@ Examples:
   public:
 
     class OrderByClause
-{
+    {
 %Docstring(signature="appended")
 The OrderByClause class represents an order by clause for a
 QgsFeatureRequest.
@@ -96,9 +96,6 @@ will be respected for the features returned by the iterator but
 internally all features will be requested from the provider.
 %End
 
-%TypeHeaderCode
-#include "qgsfeaturerequest.h"
-%End
       public:
 
         OrderByClause( const QString &expression, bool ascending = true );
@@ -197,15 +194,12 @@ Dumps the content to an SQL equivalent
 
 
     class OrderBy
-{
+    {
 %Docstring(signature="appended")
 Represents a list of OrderByClauses, with the most important first and
 the least important last.
 %End
 
-%TypeHeaderCode
-#include "qgsfeaturerequest.h"
-%End
       public:
 
         OrderBy();

--- a/python/core/auto_generated/qgslayerdefinition.sip.in
+++ b/python/core/auto_generated/qgslayerdefinition.sip.in
@@ -128,15 +128,12 @@ and joins
 %End
 
     class DependencySorter
-{
+    {
 %Docstring(signature="appended")
 Handles sorting of dependencies stored in a XML project or layer
 definition file.
 %End
 
-%TypeHeaderCode
-#include "qgslayerdefinition.h"
-%End
       public:
 
         explicit DependencySorter( const QDomDocument &doc );

--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -24,14 +24,11 @@ map layers and layer styles.
   public:
 
     class MapThemeLayerRecord
-{
+    {
 %Docstring(signature="appended")
 Individual record of a visible layer in a map theme record.
 %End
 
-%TypeHeaderCode
-#include "qgsmapthemecollection.h"
-%End
       public:
         MapThemeLayerRecord( QgsMapLayer *l = 0 );
 %Docstring
@@ -66,14 +63,11 @@ Sets the map layer for this record
     };
 
     class MapThemeRecord
-{
+    {
 %Docstring(signature="appended")
 Individual map theme record of visible layers and styles.
 %End
 
-%TypeHeaderCode
-#include "qgsmapthemecollection.h"
-%End
       public:
 
         bool operator==( const QgsMapThemeCollection::MapThemeRecord &other ) const;

--- a/python/core/auto_generated/qgsmargins.sip.in
+++ b/python/core/auto_generated/qgsmargins.sip.in
@@ -13,7 +13,6 @@
 
 class QgsMargins
 {
-
 %TypeHeaderCode
 #include "qgsmargins.h"
 %End

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -80,15 +80,12 @@ Convenient method to return an icon corresponding to the enum type
 %End
 
     class IndividualLayerSettings
-{
+    {
 %Docstring(signature="appended")
 A container of advanced configuration (per layer) of the snapping of the
 project.
 %End
 
-%TypeHeaderCode
-#include "qgssnappingconfig.h"
-%End
       public:
 
  IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, Qgis::MapToolUnit units ) /Deprecated="Since 3.12. Use the method with Qgis.SnappingTypes instead."/;

--- a/python/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/core/auto_generated/qgssqlstatement.sip.in
@@ -184,14 +184,11 @@ Returns a quoted version of a string (in single quotes)
     };
 
     class Node
-{
+    {
 %Docstring(signature="appended")
 Abstract node class for SQL statement nodes.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
 %ConvertToSubClassCode
         switch ( sipCpp->nodeType() )
         {
@@ -252,14 +249,11 @@ For any implementation this should look like
     };
 
     class NodeList
-{
+    {
 %Docstring(signature="appended")
 A list of nodes.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
 
         NodeList();
@@ -299,14 +293,11 @@ Dump list
     };
 
     class NodeUnaryOperator : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Unary logical/arithmetical operator ( NOT, - ).
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeUnaryOperator( QgsSQLStatement::UnaryOperator op, QgsSQLStatement::Node *operand /Transfer/ );
 %Docstring
@@ -337,14 +328,11 @@ Operand
     };
 
     class NodeBinaryOperator : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Binary logical/arithmetical operator (AND, OR, =, +, ...).
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeBinaryOperator( QgsSQLStatement::BinaryOperator op, QgsSQLStatement::Node *opLeft /Transfer/, QgsSQLStatement::Node *opRight /Transfer/ );
 %Docstring
@@ -391,14 +379,11 @@ Is left associative ?
     };
 
     class NodeInOperator : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 An 'x IN (y, z)' operator.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeInOperator( QgsSQLStatement::Node *node /Transfer/, QgsSQLStatement::NodeList *list /Transfer/, bool notin = false );
 %Docstring
@@ -434,14 +419,11 @@ Values list
     };
 
     class NodeBetweenOperator : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 An 'X BETWEEN y and z' operator.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeBetweenOperator( QgsSQLStatement::Node *node /Transfer/, QgsSQLStatement::Node *minVal /Transfer/, QgsSQLStatement::Node *maxVal /Transfer/, bool notBetween = false );
 %Docstring
@@ -481,14 +463,11 @@ Maximum bound
     };
 
     class NodeFunction : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Function with a name and arguments node.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeFunction( const QString &name, QgsSQLStatement::NodeList *args  /Transfer/ );
 %Docstring
@@ -520,14 +499,11 @@ Returns arguments
     };
 
     class NodeLiteral : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Literal value (integer, integer64, double, string).
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeLiteral( const QVariant &value );
 %Docstring
@@ -551,14 +527,11 @@ The value of the literal.
     };
 
     class NodeColumnRef : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Reference to a column.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeColumnRef( const QString &name, bool star );
 %Docstring
@@ -610,14 +583,11 @@ Clone with same type return
     };
 
     class NodeSelectedColumn : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Selected column.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeSelectedColumn( QgsSQLStatement::Node *node /Transfer/ );
 %Docstring
@@ -657,14 +627,11 @@ Clone with same type return
     };
 
     class NodeCast : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 CAST operator.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeCast( QgsSQLStatement::Node *node /Transfer/, const QString &type );
 %Docstring
@@ -695,14 +662,11 @@ Type
     };
 
     class NodeTableDef : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Table definition.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeTableDef( const QString &name );
 %Docstring
@@ -753,14 +717,11 @@ Clone with same type return
     };
 
     class NodeJoin : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Join definition.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeJoin( QgsSQLStatement::NodeTableDef *tabledef /Transfer/, QgsSQLStatement::Node *onExpr /Transfer/, QgsSQLStatement::JoinType type );
 %Docstring
@@ -810,14 +771,11 @@ Clone with same type return
     };
 
     class NodeColumnSorted : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 Column in a ORDER BY.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeColumnSorted( QgsSQLStatement::NodeColumnRef *column /Transfer/, bool asc );
 %Docstring
@@ -852,14 +810,11 @@ Clone with same type return
     };
 
     class NodeSelect : QgsSQLStatement::Node
-{
+    {
 %Docstring(signature="appended")
 SELECT node.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         NodeSelect( const QList<QgsSQLStatement::NodeTableDef *> &tableList /Transfer/, const QList<QgsSQLStatement::NodeSelectedColumn *> &columns /Transfer/, bool distinct );
 %Docstring
@@ -924,15 +879,12 @@ Returns the list of order by columns
 
 
     class Visitor
-{
+    {
 %Docstring(signature="appended")
 Support for visitor pattern - algorithms dealing with the statement may
 be implemented without modifying the Node classes.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
         virtual ~Visitor();
         virtual void visit( const QgsSQLStatement::NodeUnaryOperator &n ) = 0;
@@ -990,14 +942,11 @@ Visit NodeCast
     };
 
     class RecursiveVisitor: QgsSQLStatement::Visitor
-{
+    {
 %Docstring(signature="appended")
 A visitor that recursively explores all children.
 %End
 
-%TypeHeaderCode
-#include "qgssqlstatement.h"
-%End
       public:
 
         RecursiveVisitor();

--- a/python/core/auto_generated/qgstestutils.sip.in
+++ b/python/core/auto_generated/qgstestutils.sip.in
@@ -12,7 +12,6 @@
 
 class QgsTestUtils
 {
-
 %TypeHeaderCode
 #include "qgstestutils.h"
 %End

--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -36,15 +36,12 @@ There are two possibilities how to use this class:
     };
 
     class Option
-{
+    {
 %Docstring(signature="appended")
 Describes an available option for configuring file writing for a
 particular output format.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         Option( const QString &docString, QgsVectorFileWriter::OptionType type );
 
@@ -53,15 +50,12 @@ particular output format.
     };
 
     class SetOption : QgsVectorFileWriter::Option
-{
+    {
 %Docstring(signature="appended")
 An available option for configuring file writing for a particular output
 format, presenting a choice of preset values.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         SetOption( const QString &docString, const QStringList &values, const QString &defaultValue, bool allowNone = false );
 
@@ -71,15 +65,12 @@ format, presenting a choice of preset values.
     };
 
     class StringOption: QgsVectorFileWriter::Option
-{
+    {
 %Docstring(signature="appended")
 An available option for configuring file writing for a particular output
 format, presenting a freeform string option.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         StringOption( const QString &docString, const QString &defaultValue = QString() );
 
@@ -87,15 +78,12 @@ format, presenting a freeform string option.
     };
 
     class IntOption: QgsVectorFileWriter::Option
-{
+    {
 %Docstring(signature="appended")
 An available option for configuring file writing for a particular output
 format, presenting an integer option.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         IntOption( const QString &docString, int defaultValue );
 
@@ -103,28 +91,22 @@ format, presenting an integer option.
     };
 
     class BoolOption : QgsVectorFileWriter::SetOption
-{
+    {
 %Docstring(signature="appended")
 An available option for configuring file writing for a particular output
 format, presenting an boolean option.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         BoolOption( const QString &docString, bool defaultValue );
     };
 
     class HiddenOption : QgsVectorFileWriter::Option
-{
+    {
 %Docstring(signature="appended")
 A hidden option for file writing for a particular output format.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
         explicit HiddenOption( const QString &value );
 
@@ -178,14 +160,11 @@ A hidden option for file writing for a particular output format.
 
 
     class FieldValueConverter
-{
+    {
 %Docstring(signature="appended")
 Interface to convert raw field values to their user-friendly values.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
 
         FieldValueConverter();
@@ -381,14 +360,11 @@ Writes a layer out to a vector file.
 %End
 
     class SaveVectorOptions
-{
+    {
 %Docstring(signature="appended")
 Options to pass to :py:func:`QgsVectorFileWriter.writeAsVectorFormat()`.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorfilewriter.h"
-%End
       public:
 
         SaveVectorOptions();

--- a/python/core/auto_generated/qgsvirtuallayerdefinition.sip.in
+++ b/python/core/auto_generated/qgsvirtuallayerdefinition.sip.in
@@ -25,15 +25,12 @@ types have been detected.
   public:
 
     class SourceLayer
-{
+    {
 %Docstring(signature="appended")
 Either a reference to a live layer in the registry or all the parameters
 needed to load it (provider key, source, etc.).
 %End
 
-%TypeHeaderCode
-#include "qgsvirtuallayerdefinition.h"
-%End
       public:
         SourceLayer( const QString &name, const QString &ref );
 %Docstring

--- a/python/core/auto_generated/raster/qgsexiftools.sip.in
+++ b/python/core/auto_generated/raster/qgsexiftools.sip.in
@@ -61,16 +61,13 @@ Returns ``True`` if the image at ``imagePath`` contains a valid geotag.
 %End
 
     class GeoTagDetails
-{
+    {
 %Docstring(signature="appended")
 Extended image geotag details.
 
 .. versionadded:: 3.6
 %End
 
-%TypeHeaderCode
-#include "qgsexiftools.h"
-%End
       public:
 
         GeoTagDetails();

--- a/python/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
@@ -36,7 +36,7 @@ Constructor for Class
     };
 
     class MultiValueClass
-{
+    {
 %Docstring(signature="appended")
 Properties of a multi value class: a class that contains multiple
 values.
@@ -44,9 +44,6 @@ values.
 .. versionadded:: 3.30
 %End
 
-%TypeHeaderCode
-#include "qgspalettedrasterrenderer.h"
-%End
       public:
 
         MultiValueClass( const QVector< QVariant > &values, const QColor &color = QColor(), const QString &label = QString() );

--- a/python/core/auto_generated/raster/qgsrasterattributetable.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterattributetable.sip.in
@@ -28,16 +28,13 @@ file.
   public:
 
     class UsageInformation
-{
+    {
 %Docstring(signature="appended")
 The UsageInformation class represents information about a field usage.
 
 .. versionadded:: 3.30
 %End
 
-%TypeHeaderCode
-#include "qgsrasterattributetable.h"
-%End
       public:
 
         QString description;
@@ -58,7 +55,7 @@ The UsageInformation class represents information about a field usage.
     };
 
     class Field
-{
+    {
 %Docstring(signature="appended")
 The Field class represents a Raster Attribute Table field, including its
 name, usage and type.
@@ -66,9 +63,6 @@ name, usage and type.
 .. versionadded:: 3.30
 %End
 
-%TypeHeaderCode
-#include "qgsrasterattributetable.h"
-%End
       public:
 
         Field( const QString &name, const Qgis::RasterAttributeTableFieldUsage &usage, const QMetaType::Type type );
@@ -104,7 +98,7 @@ AlphaMin/AlphaMax) information.
     };
 
     class MinMaxClass
-{
+    {
 %Docstring(signature="appended")
 The Field class represents a Raster Attribute Table classification entry
 for a thematic Raster Attribute Table.
@@ -112,9 +106,6 @@ for a thematic Raster Attribute Table.
 .. versionadded:: 3.30
 %End
 
-%TypeHeaderCode
-#include "qgsrasterattributetable.h"
-%End
       public:
         QString name;
 

--- a/python/core/auto_generated/raster/qgsrasterviewport.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterviewport.sip.in
@@ -12,9 +12,8 @@
 struct QgsRasterViewPort
 {
 %TypeHeaderCode
-#include <qgsrasterviewport.h>
+#include "qgsrasterviewport.h"
 %End
-
   QgsPointXY mTopLeftPoint;
 
   QgsPointXY mBottomRightPoint;

--- a/python/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
@@ -77,7 +77,7 @@ symbol.
     typedef QList<QgsRuleBasedRenderer::Rule *> RuleList;
 
     class Rule
-{
+    {
 %Docstring(signature="appended")
 Represents an individual rule for a rule-based renderer.
 
@@ -88,9 +88,6 @@ zero, there is no lower/upper bound for scales. A rule matches if both
 filter and scale range match.
 %End
 
-%TypeHeaderCode
-#include "qgsrulebasedrenderer.h"
-%End
       public:
         enum RenderResult
         {

--- a/python/core/auto_generated/textrenderer/qgstextformat.sip.in
+++ b/python/core/auto_generated/textrenderer/qgstextformat.sip.in
@@ -565,16 +565,13 @@ The units are specified using
 %End
 
     class Tab
-{
+    {
 %Docstring(signature="appended")
 Defines a tab position for a text format.
 
 .. versionadded:: 3.42
 %End
 
-%TypeHeaderCode
-#include "qgstextformat.h"
-%End
       public:
 
         explicit Tab( double position );

--- a/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerexporter.sip.in
@@ -71,16 +71,13 @@ source ``expression``.
     };
 
     class ExportOptions
-{
+    {
 %Docstring(signature="appended")
 Encapsulates options for use with QgsVectorLayerExporter.
 
 .. versionadded:: 3.44
 %End
 
-%TypeHeaderCode
-#include "qgsvectorlayerexporter.h"
-%End
       public:
 
         void setSelectedOnly( bool selected );

--- a/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -23,15 +23,12 @@ Contains utility methods for working with :py:class:`QgsVectorLayers`.
   public:
 
     class QgsDuplicateFeatureContext
-{
+    {
 %Docstring(signature="appended")
 Contains mainly the QMap with :py:class:`QgsVectorLayer` and
 :py:class:`QgsFeatureIds` which list all the duplicated features.
 %End
 
-%TypeHeaderCode
-#include "qgsvectorlayerutils.h"
-%End
       public:
 
         QgsDuplicateFeatureContext();
@@ -50,7 +47,7 @@ Returns the duplicated features in the given layer
     };
 
     class QgsFeatureData
-{
+    {
 %Docstring(signature="appended")
 Encapsulate geometry and attributes for new features, to be passed to
 createFeatures.
@@ -60,9 +57,6 @@ createFeatures.
 .. versionadded:: 3.6
 %End
 
-%TypeHeaderCode
-#include "qgsvectorlayerutils.h"
-%End
       public:
 
         QgsFeatureData( const QgsGeometry &geometry = QgsGeometry(), const QgsAttributeMap &attributes = QgsAttributeMap() );

--- a/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilewriter.sip.in
@@ -66,7 +66,7 @@ specified in metadata by the client, tile writer also writes "name",
     QgsVectorTileWriter();
 
     class Layer
-{
+    {
 %Docstring(signature="appended")
 Configuration of a single input vector layer to be included in the
 output.
@@ -74,9 +74,6 @@ output.
 .. versionadded:: 3.14
 %End
 
-%TypeHeaderCode
-#include "qgsvectortilewriter.h"
-%End
       public:
         explicit Layer( QgsVectorLayer *layer );
 %Docstring

--- a/python/gui/auto_generated/elevation/qgselevationcontrollerwidget.sip.in
+++ b/python/gui/auto_generated/elevation/qgselevationcontrollerwidget.sip.in
@@ -15,7 +15,6 @@
 
 class QgsElevationControllerSettingsAction : QWidgetAction
 {
-
 %TypeHeaderCode
 #include "qgselevationcontrollerwidget.h"
 %End

--- a/python/gui/auto_generated/history/qgshistoryproviderregistry.sip.in
+++ b/python/gui/auto_generated/history/qgshistoryproviderregistry.sip.in
@@ -65,16 +65,13 @@ Returns a list of the registered provider IDs.
 %End
 
     class HistoryEntryOptions
-{
+    {
 %Docstring(signature="appended")
 Contains options for storing history entries.
 
 .. versionadded:: 3.24
 %End
 
-%TypeHeaderCode
-#include "qgshistoryproviderregistry.h"
-%End
       public:
         HistoryEntryOptions();
 %Docstring

--- a/python/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
@@ -406,7 +406,7 @@ Activates a standard layout designer ``tool``.
 %End
 
     class ExportResults
-{
+    {
 %Docstring(signature="appended")
 Encapsulates the results of an export operation performed in the
 designer.
@@ -414,9 +414,6 @@ designer.
 .. versionadded:: 3.20
 %End
 
-%TypeHeaderCode
-#include "qgslayoutdesignerinterface.h"
-%End
       public:
         QgsLayoutExporter::ExportResult result;
 

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -147,7 +147,6 @@ Updates both the name text edit and the model name itself.
 
 class QgsModelChildDependenciesWidget : QWidget
 {
-
 %TypeHeaderCode
 #include "qgsmodeldesignerdialog.h"
 %End

--- a/python/gui/auto_generated/processing/qgsprocessingguiutils.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingguiutils.sip.in
@@ -26,16 +26,13 @@ Contains utility functions relating to Processing GUI components.
 %End
   public:
     class ResultLayerDetails
-{
+    {
 %Docstring(signature="appended")
 Contains details of a layer result from running an algorithm.
 
 .. versionadded:: 3.44
 %End
 
-%TypeHeaderCode
-#include "qgsprocessingguiutils.h"
-%End
       public:
         ResultLayerDetails( QgsMapLayer *layer /Transfer/ );
 %Docstring

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -46,7 +46,7 @@ implementing filters called from
 
 
     class CadConstraint
-{
+    {
 %Docstring(signature="appended")
 The CadConstraint is a class for all basic constraints
 (angle/distance/x/y). It contains all values (locked, value, relative)
@@ -57,9 +57,6 @@ and pointers to corresponding widgets.
    Relative is not mandatory since it is not used for distance.
 %End
 
-%TypeHeaderCode
-#include "qgsadvanceddigitizingdockwidget.h"
-%End
       public:
         enum LockMode
         {

--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -115,7 +115,7 @@ can be used in an expression.
 %End
   public:
     class MenuProvider
-{
+    {
 %Docstring(signature="appended")
 Implementation of this interface can be implemented to allow
 QgsExpressionTreeView instance to provide custom context menus (opened
@@ -124,9 +124,6 @@ upon right-click).
 .. versionadded:: 3.14
 %End
 
-%TypeHeaderCode
-#include "qgsexpressiontreeview.h"
-%End
       public:
         explicit MenuProvider();
         virtual ~MenuProvider();

--- a/python/gui/auto_generated/qgsoptionswidgetfactory.sip.in
+++ b/python/gui/auto_generated/qgsoptionswidgetfactory.sip.in
@@ -78,7 +78,6 @@ options dialogs. This can be used to provide a custom implementation of
 
 class QgsOptionsWidgetFactory : QObject
 {
-
 %TypeHeaderCode
 #include "qgsoptionswidgetfactory.h"
 %End

--- a/python/gui/auto_generated/qgsstoredquerymanager.sip.in
+++ b/python/gui/auto_generated/qgsstoredquerymanager.sip.in
@@ -70,16 +70,13 @@ Returns the query definition with matching ``name``, from the specified
 %End
 
     class QueryDetails
-{
+    {
 %Docstring(signature="appended")
 Contains details about a stored query.
 
 .. versionadded:: 3.44
 %End
 
-%TypeHeaderCode
-#include "qgsstoredquerymanager.h"
-%End
       public:
         QString name;
 

--- a/python/server/auto_generated/qgsserverresponse.sip.in
+++ b/python/server/auto_generated/qgsserverresponse.sip.in
@@ -14,7 +14,6 @@
 
 class QgsServerResponse
 {
-
 %TypeHeaderCode
 #include "qgsserverresponse.h"
 %End

--- a/scripts/sipify.py
+++ b/scripts/sipify.py
@@ -2114,45 +2114,34 @@ def try_process_sip_skip():
         return True
 
 
-def process_struct_decl():
-    struct_match = re.match(
-        r"^\s*struct(\s+\w+_EXPORT)?\s+(?P<structname>\w+)$", CONTEXT.current_line
-    )
-    if struct_match:
-        dbg_info("  going to struct => public")
-        CONTEXT.class_and_struct.append(struct_match.group("structname"))
-        CONTEXT.classname.append(
-            CONTEXT.classname[-1]
-            if CONTEXT.classname
-            else struct_match.group("structname")
-        )  # fake new class since struct has considered similarly
-        if CONTEXT.access[-1] != Visibility.Private:
-            CONTEXT.all_fully_qualified_class_names.append(
-                CONTEXT.current_fully_qualified_struct_name()
-            )
-        CONTEXT.access.append(Visibility.Public)
-        CONTEXT.exported.append(CONTEXT.exported[-1])
-        CONTEXT.bracket_nesting_idx.append(0)
-
-
 def process_class_decl():
     # class declaration started
     # https://regex101.com/r/KMQdF5/1 (older versions: https://regex101.com/r/6FWntP/16)
     class_pattern = re.compile(
-        r"""^(\s*(class))\s+([A-Z0-9_]+_EXPORT\s+)?(Q_DECL_DEPRECATED\s+)?(?P<classname>\w+)(?P<domain>\s*:\s*(public|protected|private)\s+\w+(< *(\w|::)+ *(, *(\w|::)+ *)*>)?(::\w+(<(\w|::)+(, *(\w|::)+)*>)?)*(,\s*(public|protected|private)\s+\w+(< *(\w|::)+ *(, *(\w|::)+)*>)?(::\w+(<\w+(, *(\w|::)+)?>)?)*)*)?(?P<annot>\s*/?/?\s*SIP_\w+)?\s*?(//.*|(?!;))$"""
+        r"""^(\s*(?P<kind>class|struct))\s+([A-Z0-9_]+_EXPORT\s+)?(Q_DECL_DEPRECATED\s+)?(?P<classname>\w+)(?P<domain>\s*:\s*(public|protected|private)\s+\w+(< *(\w|::)+ *(, *(\w|::)+ *)*>)?(::\w+(<(\w|::)+(, *(\w|::)+)*>)?)*(,\s*(public|protected|private)\s+\w+(< *(\w|::)+ *(, *(\w|::)+)*>)?(::\w+(<\w+(, *(\w|::)+)?>)?)*)*)?(?P<annot>\s*/?/?\s*SIP_\w+)?\s*?(//.*|(?!;))$"""
     )
     class_pattern_match = class_pattern.match(CONTEXT.current_line)
 
     if class_pattern_match:
         dbg_info("class definition started")
-        CONTEXT.exported.append(0)
         CONTEXT.bracket_nesting_idx.append(0)
         template_inheritance_template = []
         template_inheritance_class1 = []
         template_inheritance_class2 = []
         template_inheritance_class3 = []
 
-        CONTEXT.classname.append(class_pattern_match.group("classname"))
+        if class_pattern_match.group("kind") == "class":
+            CONTEXT.classname.append(class_pattern_match.group("classname"))
+            CONTEXT.exported.append(0)
+        else:
+            assert class_pattern_match.group("kind") == "struct"
+            CONTEXT.classname.append(
+                CONTEXT.classname[-1]
+                if CONTEXT.classname
+                else class_pattern_match.group("classname")
+            )
+            CONTEXT.exported.append(CONTEXT.exported[-1])
+
         CONTEXT.class_and_struct.append(class_pattern_match.group("classname"))
         if CONTEXT.access[-1] != Visibility.Private:
             CONTEXT.all_fully_qualified_class_names.append(
@@ -2222,36 +2211,54 @@ def process_class_decl():
             CONTEXT.current_line += class_pattern_match.group("annot")
             CONTEXT.current_line = fix_annotations(CONTEXT.current_line)
 
-        CONTEXT.current_line += "\n{\n"
+        # Get indentation from opening bracket on next line
+        bracket_line = CONTEXT.input_lines[CONTEXT.line_idx]
+        if not re.match(r"^\s*{\s*$", bracket_line):
+            exit_with_error("expecting { after class definition")
+        CONTEXT.current_line += f"\n{bracket_line}"
+
         if CONTEXT.comment.strip():
-            validate_docstring(CONTEXT.comment)
-            # find out how long the first paragraph in the class docstring is.
-            paragraphs = split_to_paragraphs(CONTEXT.comment)
+            # SIP 4 doesn't support docstrings on structs
+            # TODO: Delete this condition when we finally drop ancient versions of SIP.
+            if class_pattern_match.group("kind") == "struct":
+                class_name = CONTEXT.current_fully_qualified_struct_name()
+                CONTEXT.struct_docstrings[class_name] = CONTEXT.comment
+            else:
+                validate_docstring(CONTEXT.comment)
+                # find out how long the first paragraph in the class docstring is.
+                paragraphs = split_to_paragraphs(CONTEXT.comment)
 
-            first_paragraph = wrap_docstring_paragraph(paragraphs[0])
-            if re.search(
-                r"(?<![a-z]\.[a-z])(?<!e\.g)(?<!i\.e)(?<!\w\.\w)(?<![A-Z][a-z]\.)(?<![A-Z]\.)(?<=\w)\.(?=\s+[A-Z])",
-                first_paragraph,
-            ):
-                exit_with_error(
-                    f"First paragraph in docstring for {CONTEXT.current_fully_qualified_class_name()} is multi-sentence. Please split to separate paragraphs.\n\n{first_paragraph}"
+                first_paragraph = wrap_docstring_paragraph(paragraphs[0])
+                if re.search(
+                    r"(?<![a-z]\.[a-z])(?<!e\.g)(?<!i\.e)(?<!\w\.\w)(?<![A-Z][a-z]\.)(?<![A-Z]\.)(?<=\w)\.(?=\s+[A-Z])",
+                    first_paragraph,
+                ):
+                    exit_with_error(
+                        f"First paragraph in docstring for {CONTEXT.current_fully_qualified_class_name()} is multi-sentence. Please split to separate paragraphs.\n\n{first_paragraph}"
+                    )
+                if first_paragraph.strip()[-1] != ".":
+                    exit_with_error(
+                        f"First paragraph in docstring for {CONTEXT.current_fully_qualified_class_name()} is not a complete sentence. Ensure it has a trailing '.':\n\n{first_paragraph}"
+                    )
+
+                docstring = first_paragraph
+                for paragraph in paragraphs[1:]:
+                    docstring += "\n\n" + wrap_docstring_paragraph(paragraph)
+
+                CONTEXT.current_line += (
+                    '\n%Docstring(signature="appended")\n' + docstring + "\n%End\n"
                 )
-            if first_paragraph.strip()[-1] != ".":
-                exit_with_error(
-                    f"First paragraph in docstring for {CONTEXT.current_fully_qualified_class_name()} is not a complete sentence. Ensure it has a trailing '.':\n\n{first_paragraph}"
-                )
 
-            docstring = first_paragraph
-            for paragraph in paragraphs[1:]:
-                docstring += "\n\n" + wrap_docstring_paragraph(paragraph)
-
+        # Nested classes don't need this #include, since SIP will also include
+        # the one defined on the parent class
+        write_include = len(CONTEXT.class_and_struct) <= 1
+        write_header_code = write_include or template_inheritance_template
+        if write_header_code:
+            CONTEXT.current_line += "\n%TypeHeaderCode"
+        if write_include:
             CONTEXT.current_line += (
-                '%Docstring(signature="appended")\n' + docstring + "\n%End\n"
+                f'\n#include "{os.path.basename(CONTEXT.header_file)}"'
             )
-
-        CONTEXT.current_line += (
-            f'\n%TypeHeaderCode\n#include "{os.path.basename(CONTEXT.header_file)}"'
-        )
 
         # for template based inheritance, add a typedef to define the base type,
         # since SIP doesn't allow inheriting from template classes directly
@@ -2292,15 +2299,16 @@ def process_class_decl():
         CONTEXT.access[-1] = Visibility.Private  # private by default
         write_output("CLS", f"{CONTEXT.current_line}\n")
 
-        # Skip opening curly bracket, incrementing hereunder
-        skip = read_line()
-        if not re.match(r"^\s*{\s*$", skip):
-            exit_with_error("expecting { after class definition")
+        # Increment bracket count and skip line for previously-handled bracket
+        read_line()
         CONTEXT.bracket_nesting_idx[-1] += 1
 
         CONTEXT.reset_method_state()
-        CONTEXT.header_code = True
-        CONTEXT.access[-1] = Visibility.Private
+        CONTEXT.header_code = write_header_code
+        if class_pattern_match.group("kind") == "class":
+            CONTEXT.access[-1] = Visibility.Private
+        else:
+            CONTEXT.access[-1] = Visibility.Public
         return True
 
 
@@ -3580,8 +3588,6 @@ def process_input():
         if try_process_sip_skip():
             continue
         if detect_comment_block():
-            continue
-        if process_struct_decl():
             continue
         if process_class_decl():
             continue

--- a/src/core/raster/qgsrasterviewport.h
+++ b/src/core/raster/qgsrasterviewport.h
@@ -33,12 +33,6 @@
 
 struct CORE_EXPORT QgsRasterViewPort
 {
-#ifdef SIP_RUN
-  % TypeHeaderCode
-#include <qgsrasterviewport.h>
-  % End
-#endif
-
   /**
    * \brief Coordinate (in output device coordinate system) of top left corner
    * of the part of the raster that is to be rendered.

--- a/tests/code_layout/sipify/test_sipfiles.sh
+++ b/tests/code_layout/sipify/test_sipfiles.sh
@@ -37,11 +37,16 @@ for root_dir in python python/PyQt6; do
           code=1
         fi
         if [[ -f $root_dir/${module}/auto_additions/${pyfile}.temp ]]; then
-          outdiff2=$(diff $root_dir/${module}/auto_additions/${pyfile} $root_dir/${module}/auto_additions/${pyfile}.temp)
-          if [[ -n "$outdiff2" ]]; then
-            echo " *** Python addition file not up to date: $root_dir/$pyfile"
-            echo " $outdiff2 "
+          if [[ ! -f $root_dir/${module}/auto_additions/${pyfile} ]]; then
+            echo " *** Python addition file missing: $root_dir/$pyfile"
             code=1
+          else
+            outdiff2=$(diff $root_dir/${module}/auto_additions/${pyfile} $root_dir/${module}/auto_additions/${pyfile}.temp)
+            if [[ -n "$outdiff2" ]]; then
+              echo " *** Python addition file not up to date: $root_dir/$pyfile"
+              echo " $outdiff2 "
+              code=1
+            fi
           fi
         fi
       fi


### PR DESCRIPTION
## Description

This PR unifies handling of structs and classes in `sipify.py`, treating structs as just classes that have `private` members by default. The motivation here was to fix a bug where a `%TypeHeaderCode #include ...` block wasn't generated, so the C++ code then generated by SIP didn't have the proper includes and would fail to compile if it wasn't by chance put in a block with some other code that included that header (this was the cause of at least some `SIP_CONCAT_PARTS` issues).

~~A nice benefit is that we now propagate docstrings on structs.~~ Turns out omitting those was intentional.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
