### PR TITLE
Fix wrong naming of in place algorithms in the locator

### DIFF
--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -154,7 +154,7 @@ class InPlaceAlgorithmLocatorFilter(QgsLocatorFilter):
         return "edit_features"
 
     def displayName(self):
-        return self.tr("Edit Selected Features")
+        return self.tr("Edit Features In-Place")
 
     def priority(self):
         return QgsLocatorFilter.Priority.Low


### PR DESCRIPTION
The titel of the in-place-filtered algorithms should be called "Edit FEatures In-Place" instead of "Edit selected features"

This fixes #64200
