### PR TITLE
fix(VectorLayerEditUtils): prevent Add Part tool from reversing LineString vertices

### DIFF
--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -404,7 +404,7 @@ Qgis::GeometryOperationResult QgsVectorLayerEditUtils::addPart( QgsCurve *ring, 
   else
   {
     geometry = f.geometry();
-    if ( ring->orientation() != geometry.polygonOrientation() )
+    if ( mLayer->geometryType() == Qgis::GeometryType::Polygon && ring->orientation() != geometry.polygonOrientation() )
     {
       ring = ring->reversed();
     }


### PR DESCRIPTION
## Description

The orientation check introduced in PR #55306 for OGC polygon ring ordering was incorrectly applied to all geometry types. For LineStrings, polygonOrientation() returns NoOrientation, causing the condition to always be true and systematically reversing added line parts.


https://github.com/user-attachments/assets/ea55c719-2624-4130-b582-ed0b5b3a0ee3



Fixes #64265
