### PR TITLE
[3D] rubberband: avoid duplicates marker material

### DIFF
--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -125,7 +125,7 @@ void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity, QgsAbstract3DE
 
   mLineEntity->addComponent( mLineMaterial );
 
-  mLineTransform = new QgsGeoTransform( mLineEntity );
+  mLineTransform = new QgsGeoTransform;
   mLineTransform->setOrigin( mMapSettings->origin() );
   mLineEntity->addComponent( mLineTransform );
 }


### PR DESCRIPTION
## Description

This fixes 2 issues: 
- do not set parent in the line material component. This avoid potential segfaults if a line entity is quickly created and deleted
- avoid creating multiple marker material when `updateMarkerMaterial` is called multiple times


