### PR TITLE
[themes] Improve readability for locator filter titles and group names for dark themes

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -1285,3 +1285,7 @@ QgsAttributeFormWidget QComboBox:disabled {
 QgsAttributeFormWidget QComboBox::down-arrow:disabled {
      image: none;
 }
+
+QgsLocatorResultsView::item:disabled {
+    color: @itemdarkbackground;
+}

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1380,3 +1380,7 @@ QWidget#mCadWidget QLineEdit {
 QWidget#mCadWidget QLineEdit:disabled {
     color: @text;
 }
+
+QgsLocatorResultsView::item:disabled {
+    color: @text;
+}


### PR DESCRIPTION
## Description

This PR aims to improve the readability of the group names and the filter titles in the locator widget for the dark themes (_Night Mapping_, _Blend of Gray_), which can be hard to read, especially on screens with low color fidelity.

| Before | After |
|:---:|:---:|
|![locator_blend_of_gray_before](https://github.com/user-attachments/assets/c00fa167-43cc-466d-a04c-440bddf8ad47)|![locator_blend_of_gray_after](https://github.com/user-attachments/assets/8ca3bf25-6bc4-43e1-8adf-2f154597d9f0)|
|![locator_night_mapping_before](https://github.com/user-attachments/assets/463290f0-1294-41b3-b0d5-479a864ede4e)|![locator_night_mapping_after](https://github.com/user-attachments/assets/05db7af4-0472-4a4b-bf0d-7a8711851ae2)|

The changes can be backported.