### PR TITLE
Move a bunch of short help string from qgis.yaml to dedicated algorithm py file

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -1,12 +1,6 @@
 qgis:advancedpythonfieldcalculator: >
   This algorithm adds a new attribute to a vector layer, with values resulting from applying an expression to each feature. The expression is defined as a Python function.
 
-qgis:barplot: >
-  This algorithm creates a bar plot from a category and a layer field.
-
-qgis:boxplot: >
-  This algorithm creates a box plot from a category and a layer field.
-
 qgis:concavehull: >
   This algorithm computes the concave hull of the features in an input layer.
 
@@ -38,18 +32,8 @@ qgis:generatepointspixelcentroidsalongline: >
   This algorithm generates a point vector layer from an input raster and line layer.
   The points correspond to the pixel centroids that intersect the line layer.
 
-qgis:heatmapkerneldensityestimation: >
-  Creates a density (heatmap) raster of an input point vector layer using kernel density estimation. Heatmaps allow easy identification of hotspots and clustering of points.
-
-  The density is calculated based on the number of points in a location, with larger numbers of clustered points resulting in larger values.
-
 qgis:hypsometriccurves: >
   This algorithm computes hypsometric curves  for an input Digital Elevation Model. Curves are produced as table files in an output folder specified by the user.
-
-qgis:idwinterpolation: >
-  Generates an Inverse Distance Weighted (IDW) interpolation of a point vector layer.
-
-  Sample points are weighted during interpolation such that the influence of one point relative to another declines with distance from the unknown point you want to create.
 
 qgis:knearestconcavehull: >
   This algorithm generates a concave hull polygon from a set of points. If the input layer is a line or polygon layer, it will use the nodes.
@@ -66,14 +50,8 @@ qgis:linestopolygons: >
 qgis:listuniquevalues: >
   This algorithm generates a report with information about the unique values found in a given attribute (or attributes) of a vector layer.
 
-qgis:meanandstandarddeviationplot: >
-  This algorithm creates a box plot with mean and standard deviation values.
-
 qgis:pointsdisplacement: >
   Offsets nearby point features by moving nearby points by a preset amount to minimize overlapping features.
-
-qgis:polarplot: >
-  This algorithm generates a polar plot based on the value of an input vector layer.
 
 qgis:polygonstolines: >
   This algorithm takes a polygon layer and creates a line layer, with lines representing the rings of the polygons in the input layer.
@@ -130,19 +108,11 @@ qgis:rastercalculator: >
 
   When using the calculator in the batch interface or from the console, the files to use have to be specified. The corresponding layers are referred using the base name of the file (without the full path). For instance, if using a layer at path/to/my/rasterfile.tif, the first band of that layer will be referred as rasterfile.tif@1.
 
-qgis:rasterlayerhistogram: >
-  This algorithm generates a histogram with the values of a raster layer.
-
-  The raster layer must have a single band.
-
 qgis:regularpoints: >
   This algorithm creates a point layer with a given number of regular points, all of them within a given extent.
 
 qgis:relief: >
   This algorithm creates a shaded relief layer from digital elevation data.
-
-qgis:scatter3dplot: >
-  This algorithm creates a 3D scatter plot for a vector layer.
 
 qgis:selectbyattribute: >
   This algorithm creates a selection in a vector layer. The criteria for selected features is defined based on the values of an attribute from the input layer.
@@ -164,35 +134,5 @@ qgis:statisticsbycategories: >
 qgis:texttofloat: >
   This algorithm modifies the type of a given attribute in a vector layer, converting a text attribute containing numeric strings into a numeric attribute.
 
-qgis:tininterpolation: >
-  Generates a Triangulated Irregular Network (TIN) interpolation of a point vector layer.
-
-  With the TIN method you can create a surface formed by triangles of nearest neighbor points.
-  To do this, circumcircles around selected sample points are created and their intersections are connected to a network of non overlapping and as compact as possible triangles.
-  The resulting surfaces are not smooth.
-
-  The algorithm creates both the raster layer of the interpolated values and the vector line layer with the triangulation boundaries.
-
-qgis:topologicalcoloring: >
-  This algorithm assigns a color index to polygon features in such a way that no adjacent polygons share the same color index, whilst minimizing the number of colors required.
-
-  An optional minimum distance between features assigned the same color can be set to prevent nearby (but non-touching) features from being assigned equal colors.
-
-  The algorithm allows choice of method to use when assigning colors. The default method attempts to assign colors so that the count of features assigned to each individual color index is balanced.
-
-  The 'by assigned area' mode instead assigns colors so that the total area of features assigned to each color is balanced. This mode can be useful to help avoid large features resulting in one of the colors appearing more dominant on a colored map.
-
-  The 'by distance between colors' mode will assign colors in order to maximize the distance between features of the same color. This mode helps to create a more uniform distribution of colors across a map.
-
-  A minimum number of colors can be specified if desired. The color index is saved to a new attribute named color_id.
-
 qgis:variabledistancebuffer: >
   This algorithm computes a buffer area for all the features in an input layer. The size of the buffer for a given feature is defined by an attribute, so it allows different features to have different buffer sizes.
-
-qgis:vectorlayerhistogram: >
-  This algorithm generates a histogram with the values of the attribute of a vector layer.
-
-  The attribute to use for computing the histogram must be a numeric attribute.
-
-qgis:vectorlayerscatterplot: >
-  This algorithm creates a simple X - Y scatter plot for a vector layer.

--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -75,8 +75,6 @@ qgis:pointsdisplacement: >
 qgis:polarplot: >
   This algorithm generates a polar plot based on the value of an input vector layer.
 
-  Two fields must be entered as parameters: one that define the category (to group features) and another one with the variable to plot (this has to be a numeric one)
-
 qgis:polygonstolines: >
   This algorithm takes a polygon layer and creates a line layer, with lines representing the rings of the polygons in the input layer.
 

--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -107,6 +107,9 @@ class BarPlot(QgisAlgorithm):
     def shortDescription(self):
         return self.tr("Creates a bar plot from a category and a layer field.")
 
+    def shortHelpString(self):
+        return self.tr("This algorithm creates a bar plot from a category and a layer field.")
+
     def processAlgorithm(self, parameters, context, feedback):
         try:
             # importing plotly throws Python warnings from within the library - filter these out

--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -108,7 +108,9 @@ class BarPlot(QgisAlgorithm):
         return self.tr("Creates a bar plot from a category and a layer field.")
 
     def shortHelpString(self):
-        return self.tr("This algorithm creates a bar plot from a category and a layer field.")
+        return self.tr(
+            "This algorithm creates a bar plot from a category and a layer field."
+        )
 
     def processAlgorithm(self, parameters, context, feedback):
         try:

--- a/python/plugins/processing/algs/qgis/BoxPlot.py
+++ b/python/plugins/processing/algs/qgis/BoxPlot.py
@@ -120,6 +120,9 @@ class BoxPlot(QgisAlgorithm):
     def shortDescription(self):
         return self.tr("Creates a box plot from a category and a layer field.")
 
+    def shortHelpString(self):
+        return self.tr("This algorithm creates a box plot from a category and a layer field.")
+
     def processAlgorithm(self, parameters, context, feedback):
         try:
             # importing plotly throws Python warnings from within the library - filter these out

--- a/python/plugins/processing/algs/qgis/BoxPlot.py
+++ b/python/plugins/processing/algs/qgis/BoxPlot.py
@@ -121,7 +121,9 @@ class BoxPlot(QgisAlgorithm):
         return self.tr("Creates a box plot from a category and a layer field.")
 
     def shortHelpString(self):
-        return self.tr("This algorithm creates a box plot from a category and a layer field.")
+        return self.tr(
+            "This algorithm creates a box plot from a category and a layer field."
+        )
 
     def processAlgorithm(self, parameters, context, feedback):
         try:

--- a/python/plugins/processing/algs/qgis/Heatmap.py
+++ b/python/plugins/processing/algs/qgis/Heatmap.py
@@ -78,6 +78,14 @@ class Heatmap(QgisAlgorithm):
     def shortDescription(self):
         return self.tr("Creates a heatmap from points using kernel density estimation.")
 
+    def shortHelpString(self):
+        return self.tr(
+            "This algorithm creates a density (heatmap) raster of an input point vector layer using kernel density estimation. "
+            "Heatmaps allow easy identification of hotspots and clustering of points.\n"
+            "The density is calculated based on the number of points in a location, "
+            "with larger numbers of clustered points resulting in larger values."
+        )
+
     def __init__(self):
         super().__init__()
 

--- a/python/plugins/processing/algs/qgis/IdwInterpolation.py
+++ b/python/plugins/processing/algs/qgis/IdwInterpolation.py
@@ -136,6 +136,13 @@ class IdwInterpolation(QgisAlgorithm):
             "Generates an Inverse Distance Weighted (IDW) interpolation of a point vector layer."
         )
 
+    def shortHelpString(self):
+        return self.tr(
+            "This algorithm generates an Inverse Distance Weighted (IDW) interpolation of a point vector layer.\n"
+            "Sample points are weighted during interpolation such that the influence of one point relative "
+            "to another declines with distance from the unknown point you want to create."
+        )
+
     def processAlgorithm(self, parameters, context, feedback):
         interpolationData = ParameterInterpolationData.parseValue(
             parameters[self.INTERPOLATION_DATA]

--- a/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
+++ b/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
@@ -86,7 +86,9 @@ class MeanAndStdDevPlot(QgisAlgorithm):
         return self.tr("Creates a box plot with mean and standard deviation values.")
 
     def shortHelpString(self):
-        return self.tr("This algorithm creates a box plot with mean and standard deviation values.")
+        return self.tr(
+            "This algorithm creates a box plot with mean and standard deviation values."
+        )
 
     def processAlgorithm(self, parameters, context, feedback):
         try:

--- a/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
+++ b/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
@@ -85,6 +85,9 @@ class MeanAndStdDevPlot(QgisAlgorithm):
     def shortDescription(self):
         return self.tr("Creates a box plot with mean and standard deviation values.")
 
+    def shortHelpString(self):
+        return self.tr("This algorithm creates a box plot with mean and standard deviation values.")
+
     def processAlgorithm(self, parameters, context, feedback):
         try:
             # importing plotly throws Python warnings from within the library - filter these out

--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -77,6 +77,11 @@ class PolarPlot(QgisAlgorithm):
             "Generates a polar plot based on the value of an input vector layer."
         )
 
+    def shortHelpString(self):
+        return self.tr(
+            "This algorithm generates a polar plot based on the value of an input vector layer."
+        )
+
     def processAlgorithm(self, parameters, context, feedback):
         try:
             # importing plotly throws Python warnings from within the library - filter these out

--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -36,7 +36,6 @@ from qgis.PyQt.QtCore import QCoreApplication
 class PolarPlot(QgisAlgorithm):
     INPUT = "INPUT"
     OUTPUT = "OUTPUT"
-    NAME_FIELD = "NAME_FIELD"
     VALUE_FIELD = "VALUE_FIELD"
 
     def group(self):

--- a/python/plugins/processing/algs/qgis/RasterLayerHistogram.py
+++ b/python/plugins/processing/algs/qgis/RasterLayerHistogram.py
@@ -78,6 +78,12 @@ class RasterLayerHistogram(QgisAlgorithm):
     def shortDescription(self):
         return self.tr("Generates a histogram with the values of a raster layer.")
 
+    def shortHelpString(self):
+        return self.tr(
+            "This algorithm generates a histogram with the values of a raster layer.\n"
+            "The raster layer must have a single band."
+        )
+
     def processAlgorithm(self, parameters, context, feedback):
         try:
             # importing plotly throws Python warnings from within the library - filter these out

--- a/python/plugins/processing/algs/qgis/TinInterpolation.py
+++ b/python/plugins/processing/algs/qgis/TinInterpolation.py
@@ -149,6 +149,17 @@ class TinInterpolation(QgisAlgorithm):
             "Generates a Triangulated Irregular Network (TIN) interpolation of a point vector layer."
         )
 
+    def shortHelpString(self):
+        return self.tr(
+            "This algorithm generates a Triangulated Irregular Network (TIN) interpolation of a point vector layer.\n"
+            "With the TIN method you can create a surface formed by triangles of nearest neighbor points."
+            "To do this, circumcircles around selected sample points are created and their intersections "
+            "are connected to a network of non overlapping and as compact as possible triangles."
+            "The resulting surfaces are not smooth.\n"
+            "The algorithm creates both the raster layer of the interpolated values "
+            "and the vector line layer with the triangulation boundaries."
+        )
+
     def processAlgorithm(self, parameters, context, feedback):
         interpolationData = ParameterInterpolationData.parseValue(
             parameters[self.INTERPOLATION_DATA]

--- a/python/plugins/processing/algs/qgis/TopoColors.py
+++ b/python/plugins/processing/algs/qgis/TopoColors.py
@@ -129,6 +129,23 @@ class TopoColor(QgisAlgorithm):
             "Assigns a color index to polygon features, so no adjacent polygons share the same color index."
         )
 
+    def shortHelpString(self):
+        return self.tr(
+            "This algorithm assigns a color index to polygon features in such a way that "
+            "no adjacent polygons share the same color index, whilst minimizing the number of colors required.\n"
+            "An optional minimum distance between features assigned the same color can be set to prevent nearby "
+            "(but non-touching) features from being assigned equal colors.\n"
+            "The algorithm allows choice of method to use when assigning colors. "
+            "The default method attempts to assign colors so that the count of features assigned "
+            "to each individual color index is balanced.\n"
+            "The 'by assigned area' mode instead assigns colors so that the total area of features "
+            "assigned to each color is balanced. This mode can be useful to help avoid large features "
+            "resulting in one of the colors appearing more dominant on a colored map.\n"
+            "The 'by distance between colors' mode will assign colors in order to maximize the distance "
+            "between features of the same color. This mode helps to create a more uniform distribution of colors across a map.\n"
+            "A minimum number of colors can be specified if desired. The color index is saved to a new attribute named color_id."
+        )
+
     def processAlgorithm(self, parameters, context, feedback):
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:

--- a/python/plugins/processing/algs/qgis/VectorLayerHistogram.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerHistogram.py
@@ -84,6 +84,12 @@ class VectorLayerHistogram(QgisAlgorithm):
             "Generates a histogram with the values of the attribute of a vector layer."
         )
 
+    def shortHelpString(self):
+        return self.tr(
+            "This algorithm generates a histogram with the values of the attribute of a vector layer.\n"
+            "The attribute to use for computing the histogram must be a numeric attribute."
+        )
+
     def processAlgorithm(self, parameters, context, feedback):
         try:
             # importing plotly throws Python warnings from within the library - filter these out

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -139,6 +139,9 @@ class VectorLayerScatterplot(QgisAlgorithm):
     def shortDescription(self):
         return self.tr("Creates a simple X - Y scatter plot for a vector layer.")
 
+    def shortHelpString(self):
+        return self.tr("This algorithm creates a simple X - Y scatter plot for a vector layer.")
+
     def processAlgorithm(self, parameters, context, feedback):
         try:
             # importing plotly throws Python warnings from within the library - filter these out

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -140,7 +140,9 @@ class VectorLayerScatterplot(QgisAlgorithm):
         return self.tr("Creates a simple X - Y scatter plot for a vector layer.")
 
     def shortHelpString(self):
-        return self.tr("This algorithm creates a simple X - Y scatter plot for a vector layer.")
+        return self.tr(
+            "This algorithm creates a simple X - Y scatter plot for a vector layer."
+        )
 
     def processAlgorithm(self, parameters, context, feedback):
         try:

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -122,7 +122,9 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
         return self.tr("Creates a 3D scatter plot for a vector layer.")
 
     def shortHelpString(self):
-        return self.tr("This algorithm creates a 3D scatter plot for a vector layer.")
+        return self.tr(
+            "This algorithm creates a 3D scatter plot for a vector layer."
+        )
 
     def processAlgorithm(self, parameters, context, feedback):
         try:

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -122,9 +122,7 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
         return self.tr("Creates a 3D scatter plot for a vector layer.")
 
     def shortHelpString(self):
-        return self.tr(
-            "This algorithm creates a 3D scatter plot for a vector layer."
-        )
+        return self.tr("This algorithm creates a 3D scatter plot for a vector layer.")
 
     def processAlgorithm(self, parameters, context, feedback):
         try:

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -121,6 +121,9 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
     def shortDescription(self):
         return self.tr("Creates a 3D scatter plot for a vector layer.")
 
+    def shortHelpString(self):
+        return self.tr("This algorithm creates a 3D scatter plot for a vector layer.")
+
     def processAlgorithm(self, parameters, context, feedback):
         try:
             # importing plotly throws Python warnings from within the library - filter these out


### PR DESCRIPTION
This PR completes:
- #64238: it removes leftover variable and adjusts the short help string to remove reference to the category field
- #62154: Move short help string of Python-based algorithms that already have a short Description to the .py file