### PR TITLE
Move more code layout checks to pre-commit scripts

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -58,22 +58,6 @@ jobs:
       - name: Run License Check
         run: ./tests/code_layout/test_licenses.sh
 
-  banned_keywords_check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Run Banned Keywords Test
-        run: ./tests/code_layout/test_banned_keywords.sh
-
-  class_name_check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Run class naming conventions check
-        run: ./tests/code_layout/test_class_names.sh
-
   def_window_title_check:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,16 @@ repos:
 
   - repo: local
     hooks:
+      - id: class_names
+        name: class_names
+        entry: ./scripts/pre_commit/prepare_commit_class_names.sh
+        language: system
+        always_run: true
+        pass_filenames: true
+        verbose: true
+
+  - repo: local
+    hooks:
       - id: spell_check
         name: spell_check
         entry: ./scripts/pre_commit/prepare_commit_spell_check.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,16 @@ fail_fast: false
 repos:
   - repo: local
     hooks:
+      - id: banned_keywords
+        name: banned_keywords
+        entry: ./scripts/pre_commit/prepare_commit_banned_keywords.sh
+        language: system
+        always_run: true
+        pass_filenames: true
+        verbose: true
+
+  - repo: local
+    hooks:
       - id: spell_check
         name: spell_check
         entry: ./scripts/pre_commit/prepare_commit_spell_check.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
         language: system
         always_run: true
         pass_filenames: true
-        verbose: true
 
   - repo: local
     hooks:
@@ -25,7 +24,6 @@ repos:
         language: system
         always_run: true
         pass_filenames: true
-        verbose: true
 
   - repo: local
     hooks:
@@ -35,7 +33,6 @@ repos:
         language: system
         always_run: true
         pass_filenames: true
-        verbose: true
 
   - repo: local
     hooks:
@@ -45,7 +42,6 @@ repos:
         language: system
         always_run: true
         pass_filenames: true
-        verbose: true
 
   - repo: local
     hooks:
@@ -55,7 +51,6 @@ repos:
         language: system
         always_run: true
         pass_filenames: true
-        verbose: true
 
   - repo: local
     hooks:
@@ -65,7 +60,6 @@ repos:
         language: system
         always_run: true
         pass_filenames: true
-        verbose: true
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.6
@@ -78,27 +72,23 @@ repos:
         (?x)^(
             src/core/.*
         )$
-      verbose: true
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: [--py39-plus]
-        verbose: true
 
   - repo: https://github.com/psf/black
     rev: 24.10.0
     hooks:
       - id: black
-        verbose: true
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
-        verbose: true
 
   # MUST run last
   - repo: local
@@ -109,4 +99,3 @@ repos:
         language: system
         always_run: true
         pass_filenames: true
-        verbose: true

--- a/scripts/pre_commit/prepare_commit.sh
+++ b/scripts/pre_commit/prepare_commit.sh
@@ -27,7 +27,6 @@ fi
 MODIFIED="$@"
 
 if [ -z "$MODIFIED" ]; then
-  echo nothing was modified
   exit 0
 fi
 

--- a/scripts/pre_commit/prepare_commit_banned_keywords.sh
+++ b/scripts/pre_commit/prepare_commit_banned_keywords.sh
@@ -209,7 +209,6 @@ for f in $MODIFIED; do
 done
 
 if [ -z "$MODIFIED_KEYWORD_FILES" ]; then
-  echo nothing was modified
   exit 0
 fi
 

--- a/scripts/pre_commit/prepare_commit_class_names.sh
+++ b/scripts/pre_commit/prepare_commit_class_names.sh
@@ -23,7 +23,6 @@ for f in $MODIFIED; do
 done
 
 if [ -z "$FILES_TO_CHECK" ]; then
-  echo nothing was modified
   exit 0
 fi
 

--- a/scripts/pre_commit/prepare_commit_doxygen_test.sh
+++ b/scripts/pre_commit/prepare_commit_doxygen_test.sh
@@ -20,7 +20,6 @@ set -e
 MODIFIED="$@"
 
 if [ -z "$MODIFIED" ]; then
-  echo nothing was modified
   exit 0
 fi
 

--- a/scripts/pre_commit/prepare_commit_shellcheck.sh
+++ b/scripts/pre_commit/prepare_commit_shellcheck.sh
@@ -21,7 +21,6 @@ set -e
 MODIFIED="$@"
 
 if [ -z "$MODIFIED" ]; then
-  echo nothing was modified
   exit 0
 fi
 

--- a/scripts/pre_commit/prepare_commit_sip.sh
+++ b/scripts/pre_commit/prepare_commit_sip.sh
@@ -26,7 +26,6 @@ fi
 MODIFIED="$@"
 
 if [ -z "$MODIFIED" ]; then
-  echo nothing was modified
   exit 0
 fi
 

--- a/scripts/pre_commit/prepare_commit_spell_check.sh
+++ b/scripts/pre_commit/prepare_commit_spell_check.sh
@@ -22,7 +22,6 @@ set -e
 MODIFIED="$@"
 
 if [ -z "$MODIFIED" ]; then
-  echo nothing was modified
   exit 0
 fi
 

--- a/tests/code_layout/CMakeLists.txt
+++ b/tests/code_layout/CMakeLists.txt
@@ -4,7 +4,6 @@ macro (add_qgis_test_script TESTNAME TESTSRC)
   set_tests_properties(${TESTNAME} PROPERTIES FIXTURES_REQUIRED SOURCETREE)
 endmacro()
 
-add_qgis_test_script(qgis_class_names tests/code_layout/test_class_names.sh)
 add_qgis_test_script(qgis_licenses tests/code_layout/test_licenses.sh)
 add_qgis_test_script(qgis_defwindowtitle tests/code_layout/test_defwindowtitle.sh)
 add_qgis_test_script(qgis_qvariant_no_brace_init tests/code_layout/test_qvariant_no_brace_init.sh)

--- a/tests/code_layout/CMakeLists.txt
+++ b/tests/code_layout/CMakeLists.txt
@@ -4,7 +4,6 @@ macro (add_qgis_test_script TESTNAME TESTSRC)
   set_tests_properties(${TESTNAME} PROPERTIES FIXTURES_REQUIRED SOURCETREE)
 endmacro()
 
-add_qgis_test_script(qgis_banned_keywords tests/code_layout/test_banned_keywords.sh)
 add_qgis_test_script(qgis_class_names tests/code_layout/test_class_names.sh)
 add_qgis_test_script(qgis_licenses tests/code_layout/test_licenses.sh)
 add_qgis_test_script(qgis_defwindowtitle tests/code_layout/test_defwindowtitle.sh)


### PR DESCRIPTION
It makes sense to catch these checks early (on the developer's system), rather then waiting for a whole CI cycle to flag them. 