### PR TITLE
Fix  3D Map crashing with virtual point cloud data - use QueuedConnection

### DIFF
--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -90,7 +90,7 @@ void QgsPointCloudLayerChunkLoader::start()
   // this will be run in a background thread
   //
   mFutureWatcher = new QFutureWatcher<void>( this );
-  connect( mFutureWatcher, &QFutureWatcher<void>::finished, this, &QgsChunkQueueJob::finished );
+  connect( mFutureWatcher, &QFutureWatcher<void>::finished, this, &QgsChunkQueueJob::finished, Qt::QueuedConnection );
 
   const QgsBox3D box3D = node->box3D();
   const QFuture<void> future = QtConcurrent::run( [pc = std::move( pc ), pcNode, box3D, this] {


### PR DESCRIPTION
fixes: #61312

Additional Qt6 related fixes (unreported):
ticking the `Show bounding box` while the 3D Map was open would crash QGIS.
changing the `When zoomed out` option would crash QGIS.
turning off or on any attribute in the symbology widget would crash QGIS.

Reason: we need to handle 3D objects in proper threads, mixing between threads leads to crashes in Qt3DCore.

Crash without the fix:
```
#5  0x00007fb784e28070 in <signal handler called> () at /lib64/libc.so.6
#6  0x00007fb784e81e9c in __pthread_kill_implementation () at /lib64/libc.so.6
#7  0x00007fb784e27f3e in raise () at /lib64/libc.so.6
#8  0x00007fb784e28070 in <signal handler called> () at /lib64/libc.so.6
#9  0x00007fb7867970ef in Qt3DCore::QNode::parentNode() const () at /lib64/libQt63DCore.so.6
#10 0x00007fb786797dcf in Qt3DCore::QNodePrivate::_q_postConstructorInit() () at /lib64/libQt63DCore.so.6
#11 0x00007fb786797f48 in Qt3DCore::NodePostConstructorInit::processNodes() () at /lib64/libQt63DCore.so.6
#12 0x00007fb786776c03 in Qt3DCore::QAspectManager::processFrame() () at /lib64/libQt63DCore.so.6
#13 0x00007fb786776fbd in QtPrivate::QCallableObject<Qt3DCore::QAspectManager::enterSimulationLoop()::{lambda()#1}, QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) () at /lib64/libQt63DCore.so.6
#14 0x00007fb7843654ba in void doActivate<false>(QObject*, int, void**) () at /lib64/libQt6Core.so.6
#15 0x00007fb78449db80 in QAbstractAnimationPrivate::setState(QAbstractAnimation::State) () at /lib64/libQt6Core.so.6
#16 0x00007fb78449e02f in QAnimationTimer::updateAnimationsTime(long long) () at /lib64/libQt6Core.so.6
#17 0x00007fb78449e145 in QUnifiedTimer::updateAnimationTimers() () at /lib64/libQt6Core.so.6
#18 0x00007fb78449e69d in QAnimationDriver::advanceAnimation() () at /lib64/libQt6Core.so.6
#19 0x00007fb7843560b5 in QObject::event(QEvent*) () at /lib64/libQt6Core.so.6
#20 0x00007fb793c3d97f in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /lib64/libQt6Widgets.so.6
#21 0x00007fb799f0f6f7 in QgsApplication::notify (this=0x7fff13a5a530, receiver=0x281cd188, event=0x7fff13a59280) at ../src/core/qgsapplication.cpp:721
        done = true
#22 0x00007fb7842f9678 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /lib64/libQt6Core.so.6
#23 0x00007fb7844c47f8 in QTimerInfoList::activateTimers() () at /lib64/libQt6Core.so.6
#24 0x00007fb784610231 in idleTimerSourceDispatch(_GSource*, int (*)(void*), void*) () at /lib64/libQt6Core.so.6
#25 0x00007fb781b7e863 in g_main_context_dispatch_unlocked.lto_priv () at /lib64/libglib-2.0.so.0
#26 0x00007fb781b877a8 in g_main_context_iterate_unlocked.isra () at /lib64/libglib-2.0.so.0
#27 0x00007fb781b87953 in g_main_context_iteration () at /lib64/libglib-2.0.so.0
#28 0x00007fb7846104ed in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /lib64/libQt6Core.so.6
#29 0x00007fb784307243 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () at /lib64/libQt6Core.so.6
#30 0x00007fb784302b59 in QCoreApplication::exec() () at /lib64/libQt6Core.so.6
#31 0x000000000026cc12 in main (argc=1, argv=0x7fff13a5d508) at ../src/app/main.cpp:1849
```