### PR TITLE
feat(threadutils): Add FreeBSD/OpenBSD and fix warnings about unused 'name'

### DIFF
--- a/src/core/qgsthreadingutils.h
+++ b/src/core/qgsthreadingutils.h
@@ -34,9 +34,9 @@
 #include <memory>
 
 
-#if defined(Q_OS_LINUX) && !defined(QT_LINUXBASE)
+#if defined( Q_OS_LINUX ) && !defined( QT_LINUXBASE )
 #include <sys/prctl.h>
-#elif defined(Q_OS_FREEBSD)
+#elif defined( Q_OS_FREEBSD ) || defined( Q_OS_OPENBSD )
 #include <pthread.h>
 #include <pthread_np.h>
 #endif
@@ -50,7 +50,7 @@
 #define QGIS_PROTECT_QOBJECT_THREAD_ACCESS                                                                                                                                                                                                                                                                                                                                         \
   if ( QThread::currentThread() != thread() )                                                                                                                                                                                                                                                                                                                                      \
   {                                                                                                                                                                                                                                                                                                                                                                                \
-    qFatal( "%s", QStringLiteral ( "%2 (%1:%3) is run from a different thread than the object '%4' lives in [0x%5 vs 0x%6]" ).arg( QString( __FILE__ ), QString( __FUNCTION__ ), QString::number( __LINE__ ), objectName() ).arg( reinterpret_cast< qint64 >( QThread::currentThread() ), 0, 16 ).arg( reinterpret_cast< qint64 >( thread() ), 0, 16 ).toLocal8Bit().constData() ); \
+    qFatal( "%s", QStringLiteral( "%2 (%1:%3) is run from a different thread than the object '%4' lives in [0x%5 vs 0x%6]" ).arg( QString( __FILE__ ), QString( __FUNCTION__ ), QString::number( __LINE__ ), objectName() ).arg( reinterpret_cast< qint64 >( QThread::currentThread() ), 0, 16 ).arg( reinterpret_cast< qint64 >( thread() ), 0, 16 ).toLocal8Bit().constData() ); \
   }
 #elif defined( QGISDEBUG )
 #define QGIS_PROTECT_QOBJECT_THREAD_ACCESS                                                                                                                                                                                                                                                                                                                                       \
@@ -154,7 +154,6 @@
 class QgsScopedAssignObjectToCurrentThread
 {
   public:
-
     /**
      * Assigns \a object to the current thread.
      *
@@ -191,7 +190,6 @@ class QgsScopedAssignObjectToCurrentThread
 class CORE_EXPORT QgsThreadingUtils
 {
   public:
-
     /**
      * Guarantees that \a func is executed on the main thread. If this is called
      * from another thread, the other thread will be blocked until the function
@@ -297,17 +295,16 @@ class CORE_EXPORT QgsThreadingUtils
 class QgsScopedThreadName
 {
   public:
-
     /**
      * Constructor for QgsScopedThreadName.
      */
     QgsScopedThreadName( const QString &name )
     {
-#if ( defined(Q_OS_LINUX) && !defined(QT_LINUXBASE) ) || defined(Q_OS_FREEBSD)
+#if ( defined( Q_OS_LINUX ) && !defined( QT_LINUXBASE ) ) || defined( Q_OS_FREEBSD ) || defined( Q_OS_OPENBSD )
       mOldName = getCurrentThreadName();
       setCurrentThreadName( name );
 #else
-      ( void )name;
+      ( void ) name;
 #endif
     }
 
@@ -316,23 +313,22 @@ class QgsScopedThreadName
      */
     ~QgsScopedThreadName()
     {
-#if ( defined(Q_OS_LINUX) && !defined(QT_LINUXBASE) ) || defined(Q_OS_FREEBSD)
+#if ( defined( Q_OS_LINUX ) && !defined( QT_LINUXBASE ) ) || defined( Q_OS_FREEBSD ) || defined( Q_OS_OPENBSD )
       setCurrentThreadName( mOldName );
 #endif
     }
 
   private:
-
-#if ( defined(Q_OS_LINUX) && !defined(QT_LINUXBASE) ) || defined(Q_OS_FREEBSD)
+#if ( defined( Q_OS_LINUX ) && !defined( QT_LINUXBASE ) ) || defined( Q_OS_FREEBSD ) || defined( Q_OS_OPENBSD )
     QString mOldName;
 
     static QString getCurrentThreadName()
     {
-#if defined(Q_OS_LINUX) && !defined(QT_LINUXBASE)
+#if defined( Q_OS_LINUX ) && !defined( QT_LINUXBASE )
       char name[16];
       prctl( PR_GET_NAME, name, 0, 0, 0 );
       return QString( name );
-#elif defined(Q_OS_FREEBSD)
+#elif defined( Q_OS_FREEBSD ) || defined( Q_OS_OPENBSD )
       char name[16];
       pthread_get_name_np( pthread_self(), name, sizeof( name ) );
       return QString( name );
@@ -343,12 +339,12 @@ class QgsScopedThreadName
 
     static void setCurrentThreadName( const QString &name )
     {
-#if defined(Q_OS_LINUX) && !defined(QT_LINUXBASE)
+#if defined( Q_OS_LINUX ) && !defined( QT_LINUXBASE )
       prctl( PR_SET_NAME, name.toLocal8Bit().constData(), 0, 0, 0 );
-#elif defined(Q_OS_FREEBSD)
+#elif defined( Q_OS_FREEBSD ) || defined( Q_OS_OPENBSD )
       pthread_set_name_np( pthread_self(), name.toLocal8Bit().constData() );
 #else
-      ( void )name;
+      ( void ) name;
 #endif
     }
 #endif


### PR DESCRIPTION
## Description

Initially, it was to remove an annoying warning:

> src/core/qgsthreadingutils.h:301:41: warning: unused parameter 'name' [-Wunused-parameter]
>   301 |     QgsScopedThreadName( const QString &name )
>       |                                         ^
> 1 warning generated.

But I think we could use these methods also on FreeBSD.

cc @rhurlin 
