### PR TITLE
GeoPackage: Add PolyhedralSurface and TIN support

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1693,6 +1693,20 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
             options[QStringLiteral( "geometryColumn" )] = geometryColumn;
           }
 
+          // Check for non-standard GeoPackage geometry types
+          const Qgis::WkbType flatType = QgsWkbTypes::flatType( geometryType );
+          if ( flatType == Qgis::WkbType::PolyhedralSurface || flatType == Qgis::WkbType::TIN || flatType == Qgis::WkbType::Triangle )
+          {
+            if ( QMessageBox::question( nullptr, QObject::tr( "New Table" ), QObject::tr( "PolyhedralSurface, TIN and Triangle are non-standard GeoPackage geometry types "
+                                                                                          "and may not be recognized by other software.\n\n"
+                                                                                          "Do you want to continue?" ),
+                                        QMessageBox::Yes | QMessageBox::No, QMessageBox::No )
+                 == QMessageBox::No )
+            {
+              return;
+            }
+          }
+
           try
           {
             conn2->createVectorTable( schemaName, tableName, fields, geometryType, crs, true, &options );

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1700,7 +1700,9 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
             {
               try
               {
-                conn2->createSpatialIndex( schemaName, tableName );
+                QgsAbstractDatabaseProviderConnection::SpatialIndexOptions spatialIndexOptions;
+                spatialIndexOptions.geometryColumnName = geometryColumn;
+                conn2->createSpatialIndex( schemaName, tableName, spatialIndexOptions );
               }
               catch ( QgsProviderConnectionException &ex )
               {

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -47,6 +47,7 @@
 #include "qgsfileutils.h"
 #include "qgsgeopackagedataitems.h"
 #include "qgsgui.h"
+#include "qgsguiutils.h"
 #include "qgshistoryproviderregistry.h"
 #include "qgslayeritem.h"
 #include "qgsmessagebar.h"
@@ -1694,17 +1695,9 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
           }
 
           // Check for non-standard GeoPackage geometry types
-          const Qgis::WkbType flatType = QgsWkbTypes::flatType( geometryType );
-          if ( flatType == Qgis::WkbType::PolyhedralSurface || flatType == Qgis::WkbType::TIN || flatType == Qgis::WkbType::Triangle )
+          if ( !QgsGuiUtils::warnAboutNonStandardGeoPackageGeometryType( geometryType, nullptr, QObject::tr( "New Table" ) ) )
           {
-            if ( QMessageBox::question( nullptr, QObject::tr( "New Table" ), QObject::tr( "PolyhedralSurface, TIN and Triangle are non-standard GeoPackage geometry types "
-                                                                                          "and may not be recognized by other software.\n\n"
-                                                                                          "Do you want to continue?" ),
-                                        QMessageBox::Yes | QMessageBox::No, QMessageBox::No )
-                 == QMessageBox::No )
-            {
-              return;
-            }
+            return;
           }
 
           try

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -214,7 +214,7 @@ QList<QgsGeoPackageProviderConnection::TableProperty> QgsGeoPackageProviderConne
 {
 
   // List of GPKG quoted system and dummy tables names to be excluded from the tables listing
-  static const QStringList excludedTableNames { { QStringLiteral( "\"ogr_empty_table\"" ) } };
+  static const QStringList excludedTableNames { { QStringLiteral( "'ogr_empty_table'" ) } };
 
   checkCapability( Capability::Tables );
 

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -359,7 +359,8 @@ void QgsGeoPackageProviderConnection::setDefaultCapabilities()
     GeometryColumnCapability::SingleLineString,
     GeometryColumnCapability::SinglePoint,
     GeometryColumnCapability::SinglePolygon,
-    GeometryColumnCapability::Curves
+    GeometryColumnCapability::Curves,
+    GeometryColumnCapability::PolyhedralSurfaces
   };
   mSqlLayerDefinitionCapabilities =
   {

--- a/src/gui/qgsguiutils.cpp
+++ b/src/gui/qgsguiutils.cpp
@@ -25,6 +25,7 @@
 #include <QApplication>
 #include <QFontDialog>
 #include <QImageWriter>
+#include <QMessageBox>
 #include <QRegularExpression>
 
 namespace QgsGuiUtils
@@ -342,6 +343,38 @@ namespace QgsGuiUtils
       }
     }
     return 0;
+  }
+
+  bool isNonStandardGeoPackageGeometryType( Qgis::WkbType wkbType )
+  {
+    const Qgis::WkbType flatType = QgsWkbTypes::flatType( wkbType );
+    return ( flatType == Qgis::WkbType::PolyhedralSurface || flatType == Qgis::WkbType::TIN || flatType == Qgis::WkbType::Triangle );
+  }
+
+  bool warnAboutNonStandardGeoPackageGeometryType( Qgis::WkbType wkbType, QWidget *parent, const QString &dialogTitle, bool showDialog, bool *isNonStandard )
+  {
+    const bool nonStandard = isNonStandardGeoPackageGeometryType( wkbType );
+
+    if ( isNonStandard )
+    {
+      *isNonStandard = nonStandard;
+    }
+
+    if ( !nonStandard )
+    {
+      return true;
+    }
+
+    if ( !showDialog )
+    {
+      return true;
+    }
+
+    return QMessageBox::question( parent, dialogTitle, QObject::tr( "PolyhedralSurface, TIN and Triangle are non-standard GeoPackage geometry types "
+                                                                    "and may not be recognized by other software.\n\n"
+                                                                    "Do you want to continue?" ),
+                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::No )
+           == QMessageBox::Yes;
   }
 } // namespace QgsGuiUtils
 

--- a/src/gui/qgsguiutils.h
+++ b/src/gui/qgsguiutils.h
@@ -17,6 +17,7 @@
 
 #include "qgis.h"
 #include "qgis_gui.h"
+#include "qgswkbtypes.h"
 
 #include <QPair>
 #include <QStringList>
@@ -200,6 +201,35 @@ namespace QgsGuiUtils
    * \since QGIS 3.16
    */
   int GUI_EXPORT significantDigits( const Qgis::DataType rasterDataType );
+
+  /**
+   * Returns TRUE if the given \a wkbType is a non-standard GeoPackage geometry
+   * type (PolyhedralSurface, TIN, or Triangle).
+   *
+   * \param wkbType the geometry type to check
+   * \returns TRUE if the geometry type is non-standard for GeoPackage
+   * \since QGIS 4.0
+   */
+  bool GUI_EXPORT isNonStandardGeoPackageGeometryType( Qgis::WkbType wkbType );
+
+  /**
+   * Checks if the given \a wkbType is a non-standard GeoPackage geometry type
+   * (PolyhedralSurface, TIN, or Triangle) and displays a warning message box
+   * asking the user if they want to continue.
+   *
+   * \param wkbType the geometry type to check
+   * \param parent the parent widget for the message box (can be nullptr)
+   * \param dialogTitle the title for the warning dialog
+   * \param showDialog if FALSE, the dialog will not be shown and the function
+   *        will return TRUE for non-standard types (useful for automated testing)
+   * \param isNonStandard if not nullptr, will be set to TRUE if the geometry
+   *        type is non-standard for GeoPackage, FALSE otherwise
+   * \returns TRUE if the geometry type is standard, or if non-standard and the
+   *          user chose to continue; FALSE if non-standard and the user chose
+   *          to cancel
+   * \since QGIS 4.0
+   */
+  bool GUI_EXPORT warnAboutNonStandardGeoPackageGeometryType( Qgis::WkbType wkbType, QWidget *parent, const QString &dialogTitle, bool showDialog = true, bool *isNonStandard = nullptr );
 
 } // namespace QgsGuiUtils
 

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -29,6 +29,7 @@
 #include "qgsapplication.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsgui.h"
+#include "qgsguiutils.h"
 #include "qgshelp.h"
 #include "qgsiconutils.h"
 #include "qgsogrutils.h"
@@ -458,18 +459,11 @@ bool QgsNewGeoPackageLayerDialog::apply()
     wkbType = OGR_GT_SetM( wkbType );
 
   // Check for non-standard GeoPackage geometry types
-  const OGRwkbGeometryType flatType = OGR_GT_Flatten( wkbType );
-  const bool isNonStandardGeomType = ( flatType == wkbPolyhedralSurface || flatType == wkbTIN || flatType == wkbTriangle );
-  if ( isNonStandardGeomType && !property( "hideDialogs" ).toBool() )
+  const Qgis::WkbType qgisWkbType = static_cast<Qgis::WkbType>( wkbType );
+  bool isNonStandardGeomType = false;
+  if ( !QgsGuiUtils::warnAboutNonStandardGeoPackageGeometryType( qgisWkbType, this, tr( "New GeoPackage Layer" ), !property( "hideDialogs" ).toBool(), &isNonStandardGeomType ) )
   {
-    if ( QMessageBox::question( this, tr( "New GeoPackage Layer" ), tr( "PolyhedralSurface, TIN and Triangle are non-standard GeoPackage geometry types "
-                                                                        "and may not be recognized by other software.\n\n"
-                                                                        "Do you want to continue?" ),
-                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No )
-         == QMessageBox::No )
-    {
-      return false;
-    }
+    return false;
   }
 
   OGRSpatialReferenceH hSRS = nullptr;

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -92,6 +92,8 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   addGeomItem( wkbCurvePolygon );
   addGeomItem( wkbMultiCurve );
   addGeomItem( wkbMultiSurface );
+  addGeomItem( wkbPolyhedralSurface );
+  addGeomItem( wkbTIN );
   mGeometryTypeBox->setCurrentIndex( -1 );
 
   mGeometryWithZCheckBox->setEnabled( false );

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -555,12 +555,19 @@ bool QgsNewGeoPackageLayerDialog::apply()
   // issue a command that will force table creation
   CPLErrorReset();
   OGR_L_ResetReading( hLayer );
-  if ( CPLGetLastErrorType() != CE_None )
+  const CPLErr errorType = CPLGetLastErrorType();
+  if ( errorType == CE_Failure || errorType == CE_Fatal )
   {
     const QString msg( tr( "Creation of layer failed (OGR error: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
     if ( !property( "hideDialogs" ).toBool() )
       QMessageBox::critical( this, tr( "New GeoPackage Layer" ), msg );
     return false;
+  }
+  else if ( errorType == CE_Warning )
+  {
+    const QString msg( tr( "Layer created with warning (OGR warning: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
+    if ( !property( "hideDialogs" ).toBool() )
+      QMessageBox::warning( this, tr( "New GeoPackage Layer" ), msg );
   }
   hDS.reset();
 


### PR DESCRIPTION
## Description

Both types are supported by GDAL since [RFC 64](https://gdal.org/en/stable/development/rfc/rfc64_triangle_polyhedralsurface_tin.html)
AFAIK, GeoPackage does not officially offer these types, but they can be considered an extension. And we can save WKB inside it. So, it works (c) (except for drawing tools, but they are conversions that need to be added). 

@rouault do you think it's correct to propose this PR?