### PR TITLE
add native total curvature algorithm from the terrain analysis library

### DIFF
--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
@@ -421,3 +421,16 @@ tests:
       OUTPUT:
         name: expected/remove_multipolygon_parts_by_area.gml
         type: vector
+
+  - algorithm: native:totalcurvature
+    name: Total curvature from QGIS analysis library
+    params:
+      INPUT:
+        name: dem.tif
+        type: raster
+      Z_FACTOR: 1.0
+      NODATA: -9999.0
+    results:
+      OUTPUT:
+        hash: fc06f1af668bbfc6ee4fb6d421a4f561265ee20578a074eb763ae380
+        type: rasterhash

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -288,6 +288,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmsymmetricaldifference.cpp
   processing/qgsalgorithmtaperedbuffer.cpp
   processing/qgsalgorithmtinmeshcreation.cpp
+  processing/qgsalgorithmtotalcurvature.cpp
   processing/qgsalgorithmtransect.cpp
   processing/qgsalgorithmtransform.cpp
   processing/qgsalgorithmtranslate.cpp

--- a/src/analysis/processing/qgsalgorithmtotalcurvature.cpp
+++ b/src/analysis/processing/qgsalgorithmtotalcurvature.cpp
@@ -54,7 +54,7 @@ QString QgsTotalCurvatureAlgorithm::shortHelpString() const
 
 QString QgsTotalCurvatureAlgorithm::shortDescription() const
 {
-  return QObject::tr( "Ccalculates total curvature as described by Wilson, Gallant (2000): terrain analysis." );
+  return QObject::tr( "Calculates total curvature as described by Wilson, Gallant (2000): terrain analysis." );
 }
 
 QgsTotalCurvatureAlgorithm *QgsTotalCurvatureAlgorithm::createInstance() const
@@ -79,13 +79,20 @@ void QgsTotalCurvatureAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterRasterDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Total curvature" ) ) );
 }
 
+bool QgsTotalCurvatureAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  QgsRasterLayer *layer = parameterAsRasterLayer( parameters, QStringLiteral( "INPUT" ), context );
+  if ( !layer )
+  {
+    throw QgsProcessingException( invalidRasterError( parameters, QStringLiteral( "INPUT" ) ) );
+  }
+
+  mLayerSource = layer->source();
+  return true;
+}
+
 QVariantMap QgsTotalCurvatureAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
-  QgsRasterLayer *inputLayer = parameterAsRasterLayer( parameters, QStringLiteral( "INPUT" ), context );
-
-  if ( !inputLayer )
-    throw QgsProcessingException( invalidRasterError( parameters, QStringLiteral( "INPUT" ) ) );
-
   const double zFactor = parameterAsDouble( parameters, QStringLiteral( "Z_FACTOR" ), context );
   const QString creationOptions = parameterAsString( parameters, QStringLiteral( "CREATION_OPTIONS" ), context ).trimmed();
   const double outputNodata = parameterAsDouble( parameters, QStringLiteral( "NODATA" ), context );
@@ -93,7 +100,7 @@ QVariantMap QgsTotalCurvatureAlgorithm::processAlgorithm( const QVariantMap &par
   const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
   const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
 
-  QgsTotalCurvatureFilter curvature( inputLayer->source(), outputFile, outputFormat );
+  QgsTotalCurvatureFilter curvature( mLayerSource, outputFile, outputFormat );
   curvature.setZFactor( zFactor );
   if ( !creationOptions.isEmpty() )
   {

--- a/src/analysis/processing/qgsalgorithmtotalcurvature.cpp
+++ b/src/analysis/processing/qgsalgorithmtotalcurvature.cpp
@@ -1,0 +1,110 @@
+/***************************************************************************
+                         qgsalgorithmtotalcurvature.cpp
+                         ---------------------
+    begin                : December 2025
+    copyright            : (C) 2025 by Alexander Bruy
+    email                : alexander dot bruy at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmtotalcurvature.h"
+
+#include "qgsrasterfilewriter.h"
+#include "qgstotalcurvaturefilter.h"
+
+///@cond PRIVATE
+
+QString QgsTotalCurvatureAlgorithm::name() const
+{
+  return QStringLiteral( "totalcurvature" );
+}
+
+QString QgsTotalCurvatureAlgorithm::displayName() const
+{
+  return QObject::tr( "Total curvature" );
+}
+
+QStringList QgsTotalCurvatureAlgorithm::tags() const
+{
+  return QObject::tr( "dem,total curvature,terrain" ).split( ',' );
+}
+
+QString QgsTotalCurvatureAlgorithm::group() const
+{
+  return QObject::tr( "Raster terrain analysis" );
+}
+
+QString QgsTotalCurvatureAlgorithm::groupId() const
+{
+  return QStringLiteral( "rasterterrainanalysis" );
+}
+
+QString QgsTotalCurvatureAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm calculates total curvature of the input raster as described by Wilson, Gallant (2000): terrain analysis." );
+}
+
+QString QgsTotalCurvatureAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Ccalculates total curvature as described by Wilson, Gallant (2000): terrain analysis." );
+}
+
+QgsTotalCurvatureAlgorithm *QgsTotalCurvatureAlgorithm::createInstance() const
+{
+  return new QgsTotalCurvatureAlgorithm();
+}
+
+void QgsTotalCurvatureAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "INPUT" ), QObject::tr( "Elevation layer" ) ) );
+  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "Z_FACTOR" ), QObject::tr( "Z factor" ), Qgis::ProcessingNumberParameterType::Double, 1, false, 0 ) );
+
+  auto outputNodataParam = std::make_unique<QgsProcessingParameterNumber>( QStringLiteral( "NODATA" ), QObject::tr( "Output NoData value" ), Qgis::ProcessingNumberParameterType::Double, -9999.0 );
+  outputNodataParam->setFlags( outputNodataParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
+  addParameter( outputNodataParam.release() );
+
+  auto creationOptsParam = std::make_unique<QgsProcessingParameterString>( QStringLiteral( "CREATION_OPTIONS" ), QObject::tr( "Creation options" ), QVariant(), false, true );
+  creationOptsParam->setMetadata( QVariantMap( { { QStringLiteral( "widget_wrapper" ), QVariantMap( { { QStringLiteral( "widget_type" ), QStringLiteral( "rasteroptions" ) } } ) } } ) );
+  creationOptsParam->setFlags( creationOptsParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
+  addParameter( creationOptsParam.release() );
+
+  addParameter( new QgsProcessingParameterRasterDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Total curvature" ) ) );
+}
+
+QVariantMap QgsTotalCurvatureAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  QgsRasterLayer *inputLayer = parameterAsRasterLayer( parameters, QStringLiteral( "INPUT" ), context );
+
+  if ( !inputLayer )
+    throw QgsProcessingException( invalidRasterError( parameters, QStringLiteral( "INPUT" ) ) );
+
+  const double zFactor = parameterAsDouble( parameters, QStringLiteral( "Z_FACTOR" ), context );
+  const QString creationOptions = parameterAsString( parameters, QStringLiteral( "CREATION_OPTIONS" ), context ).trimmed();
+  const double outputNodata = parameterAsDouble( parameters, QStringLiteral( "NODATA" ), context );
+
+  const QString outputFile = parameterAsOutputLayer( parameters, QStringLiteral( "OUTPUT" ), context );
+  const QString outputFormat = parameterAsOutputRasterFormat( parameters, QStringLiteral( "OUTPUT" ), context );
+
+  QgsTotalCurvatureFilter curvature( inputLayer->source(), outputFile, outputFormat );
+  curvature.setZFactor( zFactor );
+  if ( !creationOptions.isEmpty() )
+  {
+    curvature.setCreationOptions( creationOptions.split( '|' ) );
+  }
+  curvature.setOutputNodataValue( outputNodata );
+  curvature.processRaster( feedback );
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), outputFile );
+  return outputs;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmtotalcurvature.h
+++ b/src/analysis/processing/qgsalgorithmtotalcurvature.h
@@ -44,7 +44,11 @@ class QgsTotalCurvatureAlgorithm : public QgsProcessingAlgorithm
     QgsTotalCurvatureAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+    QString mLayerSource;
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmtotalcurvature.h
+++ b/src/analysis/processing/qgsalgorithmtotalcurvature.h
@@ -1,0 +1,52 @@
+/***************************************************************************
+                         qgsalgorithmtotalcurvature.h
+                         ------------------------------
+    begin                : December 2025
+    copyright            : (C) 2025 by Alexander Bruy
+    email                : alexander dot bruy at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef QGSALGORITHMTOTALCURVATURE_H
+#define QGSALGORITHMTOTALCURVATURE_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native total curvature algorithm.
+ */
+class QgsTotalCurvatureAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+    QgsTotalCurvatureAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsTotalCurvatureAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+    QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMTOTALCURVATURE_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -273,6 +273,7 @@
 #include "qgsalgorithmsymmetricaldifference.h"
 #include "qgsalgorithmtaperedbuffer.h"
 #include "qgsalgorithmtinmeshcreation.h"
+#include "qgsalgorithmtotalcurvature.h"
 #include "qgsalgorithmtransect.h"
 #include "qgsalgorithmtransform.h"
 #include "qgsalgorithmtranslate.h"
@@ -638,6 +639,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsSymmetricalDifferenceAlgorithm() );
   addAlgorithm( new QgsTaperedBufferAlgorithm() );
   addAlgorithm( new QgsTinMeshCreationAlgorithm() );
+  addAlgorithm( new QgsTotalCurvatureAlgorithm() );
   addAlgorithm( new QgsTransectAlgorithm() );
   addAlgorithm( new QgsTransferAnnotationsFromMainAlgorithm() );
   addAlgorithm( new QgsTransformAlgorithm() );


### PR DESCRIPTION
## Description

Adds the Total curvature algorithm to Processing.

The total curvature filter has existed in the terrain analysis library for years, but it was never exposed in the GUI. This PR adds it to Processing alongside the terrain analysis filters that are already present.