### PR TITLE
Add QgsArrowArrayStream wrapper

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsarrowiterator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsarrowiterator.sip.in
@@ -271,7 +271,7 @@ This must be set before calling
 :py:func:`~QgsArrowIterator.nextFeatures`.
 %End
 
-    QgsArrowArrayStream toArrayStream(int batchSize = 65536);
+    QgsArrowArrayStream toArrayStream( int batchSize = 65536 ) const;
 %Docstring
 Export this iterator as an ArrowArrayStream
 %End

--- a/python/PyQt6/core/auto_generated/qgsarrowiterator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsarrowiterator.sip.in
@@ -182,6 +182,63 @@ Returns ``True`` if this wrapper object holds a valid ArrowArray
     QgsArrowArray( const QgsArrowArray &other );
 };
 
+class QgsArrowArrayStream
+{
+%Docstring(signature="appended")
+Wrapper around an ArrowArrayStream.
+
+This object provides a helper to allow array streams to be passed to or
+returned from QGIS functions in C++ or Python. See the documentation for
+the Arrow C Stream Interface for how to interact with the underlying
+ArrowArrayStream:
+https://arrow.apache.org/docs/format/CStreamInterface.html
+
+.. versionadded:: 4.0
+%End
+
+%TypeHeaderCode
+#include "qgsarrowiterator.h"
+%End
+  public:
+    QgsArrowArrayStream();
+%Docstring
+Construct invalid array stream holder
+%End
+
+
+
+    ~QgsArrowArrayStream();
+
+
+    unsigned long long cArrayStreamAddress() const;
+%Docstring
+Returns the address of the underlying ArrowArrayStream for import or
+export across boundaries
+
+.. warning::
+
+   This is intended for advanced usage and may cause a crash if used incorrectly.
+%End
+
+    void exportToAddress( unsigned long long otherAddress );
+%Docstring
+Export this array to the address of an empty ArrowArrayStream for export
+across boundaries
+
+.. warning::
+
+   This is intended for advanced usage and may cause a crash if used incorrectly.
+%End
+
+    bool isValid() const;
+%Docstring
+Returns ``True`` if this wrapper object holds a valid ArrowArray
+%End
+
+  private:
+    QgsArrowArrayStream( const QgsArrowArrayStream &other );
+};
+
 class QgsArrowIterator
 {
 %Docstring(signature="appended")
@@ -205,12 +262,18 @@ Construct invalid iterator
 Construct iterator from an existing feature iterator
 %End
 
+
     void setSchema( const QgsArrowSchema &schema );
 %Docstring
 Set the ArrowSchema for the output of all future batches
 
 This must be set before calling
 :py:func:`~QgsArrowIterator.nextFeatures`.
+%End
+
+    QgsArrowArrayStream toArrayStream(int batchSize = 65536);
+%Docstring
+Export this iterator as an ArrowArrayStream
 %End
 
     QgsArrowArray nextFeatures( int n );

--- a/python/core/auto_generated/qgsarrowiterator.sip.in
+++ b/python/core/auto_generated/qgsarrowiterator.sip.in
@@ -271,7 +271,7 @@ This must be set before calling
 :py:func:`~QgsArrowIterator.nextFeatures`.
 %End
 
-    QgsArrowArrayStream toArrayStream(int batchSize = 65536);
+    QgsArrowArrayStream toArrayStream( int batchSize = 65536 ) const;
 %Docstring
 Export this iterator as an ArrowArrayStream
 %End

--- a/python/core/auto_generated/qgsarrowiterator.sip.in
+++ b/python/core/auto_generated/qgsarrowiterator.sip.in
@@ -182,6 +182,63 @@ Returns ``True`` if this wrapper object holds a valid ArrowArray
     QgsArrowArray( const QgsArrowArray &other );
 };
 
+class QgsArrowArrayStream
+{
+%Docstring(signature="appended")
+Wrapper around an ArrowArrayStream.
+
+This object provides a helper to allow array streams to be passed to or
+returned from QGIS functions in C++ or Python. See the documentation for
+the Arrow C Stream Interface for how to interact with the underlying
+ArrowArrayStream:
+https://arrow.apache.org/docs/format/CStreamInterface.html
+
+.. versionadded:: 4.0
+%End
+
+%TypeHeaderCode
+#include "qgsarrowiterator.h"
+%End
+  public:
+    QgsArrowArrayStream();
+%Docstring
+Construct invalid array stream holder
+%End
+
+
+
+    ~QgsArrowArrayStream();
+
+
+    unsigned long long cArrayStreamAddress() const;
+%Docstring
+Returns the address of the underlying ArrowArrayStream for import or
+export across boundaries
+
+.. warning::
+
+   This is intended for advanced usage and may cause a crash if used incorrectly.
+%End
+
+    void exportToAddress( unsigned long long otherAddress );
+%Docstring
+Export this array to the address of an empty ArrowArrayStream for export
+across boundaries
+
+.. warning::
+
+   This is intended for advanced usage and may cause a crash if used incorrectly.
+%End
+
+    bool isValid() const;
+%Docstring
+Returns ``True`` if this wrapper object holds a valid ArrowArray
+%End
+
+  private:
+    QgsArrowArrayStream( const QgsArrowArrayStream &other );
+};
+
 class QgsArrowIterator
 {
 %Docstring(signature="appended")
@@ -205,12 +262,18 @@ Construct invalid iterator
 Construct iterator from an existing feature iterator
 %End
 
+
     void setSchema( const QgsArrowSchema &schema );
 %Docstring
 Set the ArrowSchema for the output of all future batches
 
 This must be set before calling
 :py:func:`~QgsArrowIterator.nextFeatures`.
+%End
+
+    QgsArrowArrayStream toArrayStream(int batchSize = 65536);
+%Docstring
+Export this iterator as an ArrowArrayStream
 %End
 
     QgsArrowArray nextFeatures( int n ) throw( QgsException );

--- a/src/core/qgsarrowiterator.cpp
+++ b/src/core/qgsarrowiterator.cpp
@@ -95,11 +95,17 @@ const struct ArrowSchema *QgsArrowSchema::schema() const
 
 unsigned long long QgsArrowSchema::cSchemaAddress() const
 {
+  // In the event QGIS is compiled on platform where unsigned long long is insufficient to
+  // represent a uintptr_t, ensure compilation fails
+  static_assert( sizeof( unsigned long long ) >= sizeof( uintptr_t ) );
+
   return reinterpret_cast<unsigned long long>( &mSchema );
 }
 
 void QgsArrowSchema::exportToAddress( unsigned long long otherAddress )
 {
+  static_assert( sizeof( unsigned long long ) >= sizeof( uintptr_t ) );
+
   struct ArrowSchema *otherArrowSchema = reinterpret_cast<struct ArrowSchema *>( otherAddress );
   QGIS_NANOARROW_THROW_NOT_OK( ArrowSchemaDeepCopy( &mSchema, otherArrowSchema ) );
 }
@@ -153,11 +159,17 @@ const struct ArrowArray *QgsArrowArray::array() const
 
 unsigned long long QgsArrowArray::cArrayAddress() const
 {
+  // In the event QGIS is compiled on platform where unsigned long long is insufficient to
+  // represent a uintptr_t, ensure compilation fails
+  static_assert( sizeof( unsigned long long ) >= sizeof( uintptr_t ) );
+
   return reinterpret_cast<unsigned long long>( &mArray );
 }
 
 void QgsArrowArray::exportToAddress( unsigned long long otherAddress )
 {
+  static_assert( sizeof( unsigned long long ) >= sizeof( uintptr_t ) );
+
   struct ArrowArray *otherArrowArray = reinterpret_cast<struct ArrowArray *>( otherAddress );
   ArrowArrayMove( &mArray, otherArrowArray );
 }
@@ -202,11 +214,17 @@ struct ArrowArrayStream *QgsArrowArrayStream::arrayStream()
 
 unsigned long long QgsArrowArrayStream::cArrayStreamAddress() const
 {
+  // In the event QGIS is compiled on platform where unsigned long long is insufficient to
+  // represent a uintptr_t, ensure compilation fails
+  static_assert( sizeof( unsigned long long ) >= sizeof( uintptr_t ) );
+
   return reinterpret_cast<unsigned long long>( &mArrayStream );
 }
 
 void QgsArrowArrayStream::exportToAddress( unsigned long long otherAddress )
 {
+  static_assert( sizeof( unsigned long long ) >= sizeof( uintptr_t ) );
+
   struct ArrowArrayStream *otherArrowArrayStream = reinterpret_cast<struct ArrowArrayStream *>( otherAddress );
   ArrowArrayStreamMove( &mArrayStream, otherArrowArrayStream );
 }

--- a/src/core/qgsarrowiterator.cpp
+++ b/src/core/qgsarrowiterator.cpp
@@ -545,7 +545,7 @@ namespace
         }
       }
 
-      const char *GetLastError() { return mLastError.c_str(); }
+      const char *GetLastError() const { return mLastError.c_str(); }
 
     private:
       QgsArrowIterator mIterator;
@@ -575,7 +575,7 @@ void QgsArrowIterator::setSchema( const QgsArrowSchema &schema )
   mSchema = schema;
 }
 
-QgsArrowArrayStream QgsArrowIterator::toArrayStream( int batchSize )
+QgsArrowArrayStream QgsArrowIterator::toArrayStream( int batchSize ) const
 {
   QgsArrowArrayStream out;
   nanoarrow::ArrayStreamFactory<ArrowIteratorArrayStreamImpl>::InitArrayStream( new ArrowIteratorArrayStreamImpl( *this, batchSize ), out.arrayStream() );

--- a/src/core/qgsarrowiterator.cpp
+++ b/src/core/qgsarrowiterator.cpp
@@ -538,9 +538,19 @@ namespace
           ArrowArrayMove( batch.array(), array );
           return NANOARROW_OK;
         }
+        catch ( QgsException &e )
+        {
+          mLastError = e.what().toStdString();
+          return EINVAL;
+        }
         catch ( std::exception &e )
         {
           mLastError = e.what();
+          return EINVAL;
+        }
+        catch ( ... )
+        {
+          mLastError = "unknown error";
           return EINVAL;
         }
       }

--- a/src/core/qgsarrowiterator.cpp
+++ b/src/core/qgsarrowiterator.cpp
@@ -521,8 +521,8 @@ namespace
   class ArrowIteratorArrayStreamImpl
   {
     public:
-      explicit ArrowIteratorArrayStreamImpl( QgsArrowIterator iterator )
-        : mIterator( iterator ) {}
+      ArrowIteratorArrayStreamImpl( QgsArrowIterator iterator, int batchSize )
+        : mIterator( iterator ), mBatchSize( batchSize ) {}
 
       int GetSchema( struct ArrowSchema *schema )
       {
@@ -575,10 +575,10 @@ void QgsArrowIterator::setSchema( const QgsArrowSchema &schema )
   mSchema = schema;
 }
 
-QgsArrowArrayStream QgsArrowIterator::toArrayStream()
+QgsArrowArrayStream QgsArrowIterator::toArrayStream( int batchSize )
 {
   QgsArrowArrayStream out;
-  nanoarrow::ArrayStreamFactory<ArrowIteratorArrayStreamImpl>::InitArrayStream( new ArrowIteratorArrayStreamImpl( *this ), out.arrayStream() );
+  nanoarrow::ArrayStreamFactory<ArrowIteratorArrayStreamImpl>::InitArrayStream( new ArrowIteratorArrayStreamImpl( *this, batchSize ), out.arrayStream() );
   return out;
 }
 

--- a/src/core/qgsarrowiterator.cpp
+++ b/src/core/qgsarrowiterator.cpp
@@ -167,6 +167,55 @@ bool QgsArrowArray::isValid() const
   return mArray.release;
 }
 
+QgsArrowArrayStream::QgsArrowArrayStream( QgsArrowArrayStream &&other )
+{
+  if ( mArrayStream.release )
+  {
+    ArrowArrayStreamRelease( &mArrayStream );
+  }
+
+  ArrowArrayStreamMove( other.array_stream(), &mArrayStream );
+}
+
+QgsArrowArrayStream &QgsArrowArrayStream::operator=( QgsArrowArrayStream &&other )
+{
+  if ( this != &other )
+  {
+    ArrowArrayStreamMove( other.array_stream(), &mArrayStream );
+  }
+
+  return *this;
+}
+
+QgsArrowArrayStream::~QgsArrowArrayStream()
+{
+  if ( mArrayStream.release )
+  {
+    ArrowArrayStreamRelease( &mArrayStream );
+  }
+}
+
+struct ArrowArrayStream *QgsArrowArrayStream::array_stream()
+{
+  return &mArrayStream;
+}
+
+unsigned long long QgsArrowArrayStream::cArrayStreamAddress() const
+{
+  return reinterpret_cast<unsigned long long>( &mArrayStream );
+}
+
+void QgsArrowArrayStream::exportToAddress( unsigned long long otherAddress )
+{
+  struct ArrowArrayStream *otherArrowArrayStream = reinterpret_cast<struct ArrowArrayStream *>( otherAddress );
+  ArrowArrayStreamMove( &mArrayStream, otherArrowArrayStream );
+}
+
+bool QgsArrowArrayStream::isValid() const
+{
+  return mArrayStream.release;
+}
+
 namespace
 {
 

--- a/src/core/qgsarrowiterator.cpp
+++ b/src/core/qgsarrowiterator.cpp
@@ -95,7 +95,7 @@ const struct ArrowSchema *QgsArrowSchema::schema() const
 
 unsigned long long QgsArrowSchema::cSchemaAddress() const
 {
-  // In the event QGIS is compiled on platform where unsigned long long is insufficient to
+  // In the event QGIS is built on platform where unsigned long long is insufficient to
   // represent a uintptr_t, ensure compilation fails
   static_assert( sizeof( unsigned long long ) >= sizeof( uintptr_t ) );
 
@@ -159,7 +159,7 @@ const struct ArrowArray *QgsArrowArray::array() const
 
 unsigned long long QgsArrowArray::cArrayAddress() const
 {
-  // In the event QGIS is compiled on platform where unsigned long long is insufficient to
+  // In the event QGIS is built on platform where unsigned long long is insufficient to
   // represent a uintptr_t, ensure compilation fails
   static_assert( sizeof( unsigned long long ) >= sizeof( uintptr_t ) );
 
@@ -214,7 +214,7 @@ struct ArrowArrayStream *QgsArrowArrayStream::arrayStream()
 
 unsigned long long QgsArrowArrayStream::cArrayStreamAddress() const
 {
-  // In the event QGIS is compiled on platform where unsigned long long is insufficient to
+  // In the event QGIS is built on platform where unsigned long long is insufficient to
   // represent a uintptr_t, ensure compilation fails
   static_assert( sizeof( unsigned long long ) >= sizeof( uintptr_t ) );
 

--- a/src/core/qgsarrowiterator.h
+++ b/src/core/qgsarrowiterator.h
@@ -344,7 +344,7 @@ class CORE_EXPORT QgsArrowIterator
     void setSchema( const QgsArrowSchema &schema );
 
     //! Export this iterator as an ArrowArrayStream
-    QgsArrowArrayStream toArrayStream(int batchSize = 65536) const;
+    QgsArrowArrayStream toArrayStream( int batchSize = 65536 ) const;
 
     /**
      * Build an ArrowArray using the next n features (or fewer depending on the number of features remaining)

--- a/src/core/qgsarrowiterator.h
+++ b/src/core/qgsarrowiterator.h
@@ -344,7 +344,7 @@ class CORE_EXPORT QgsArrowIterator
     void setSchema( const QgsArrowSchema &schema );
 
     //! Export this iterator as an ArrowArrayStream
-    QgsArrowArrayStream toArrayStream(int batchSize = 65536);
+    QgsArrowArrayStream toArrayStream(int batchSize = 65536) const;
 
     /**
      * Build an ArrowArray using the next n features (or fewer depending on the number of features remaining)

--- a/src/core/qgsarrowiterator.h
+++ b/src/core/qgsarrowiterator.h
@@ -289,7 +289,7 @@ class CORE_EXPORT QgsArrowArrayStream
 
 #ifndef SIP_RUN
     //! Access the underlying ArrowArray from C++
-    struct ArrowArrayStream *array_stream();
+    struct ArrowArrayStream *arrayStream();
 #endif
 
     /**
@@ -331,12 +331,19 @@ class CORE_EXPORT QgsArrowIterator
     //! Construct iterator from an existing feature iterator
     explicit QgsArrowIterator( QgsFeatureIterator featureIterator );
 
+#ifndef SIP_RUN
+    //! Access the output ArrowSchema from C++
+    struct ArrowSchema *schema();
+#endif
+
     /**
      * Set the ArrowSchema for the output of all future batches
      *
      * This must be set before calling nextFeatures().
      */
     void setSchema( const QgsArrowSchema &schema );
+
+    QgsArrowArrayStream toArrayStream();
 
     /**
      * Build an ArrowArray using the next n features (or fewer depending on the number of features remaining)

--- a/src/core/qgsarrowiterator.h
+++ b/src/core/qgsarrowiterator.h
@@ -259,6 +259,66 @@ class CORE_EXPORT QgsArrowArray
 
 /**
  * \ingroup core
+ * \brief Wrapper around an ArrowArrayStream.
+ *
+ * This object provides a helper to allow array streams to be passed to or returned from
+ * QGIS functions in C++ or Python. See the documentation for the
+ * Arrow C Stream Interface for how to interact with the underlying ArrowArrayStream:
+ * https://arrow.apache.org/docs/format/CStreamInterface.html
+ *
+ * \since QGIS 4.0
+ */
+class CORE_EXPORT QgsArrowArrayStream
+{
+  public:
+    //! Construct invalid array stream holder
+    QgsArrowArrayStream() = default;
+
+    QgsArrowArrayStream &operator=( QgsArrowArrayStream &other ) = delete;
+    QgsArrowArrayStream( const QgsArrowArrayStream &other ) = delete;
+
+#ifndef SIP_RUN
+    //! Move constructor
+    QgsArrowArrayStream( QgsArrowArrayStream &&other );
+
+    //! Move-assign constructor
+    QgsArrowArrayStream &operator=( QgsArrowArrayStream &&other );
+#endif
+
+    ~QgsArrowArrayStream();
+
+#ifndef SIP_RUN
+    //! Access the underlying ArrowArray from C++
+    struct ArrowArrayStream *array_stream();
+#endif
+
+    /**
+     * Returns the address of the underlying ArrowArrayStream for import or export across boundaries
+     *
+     * \warning This is intended for advanced usage and may cause a crash if used incorrectly.
+     */
+    unsigned long long cArrayStreamAddress() const;
+
+    /**
+     * Export this array to the address of an empty ArrowArrayStream for export across boundaries
+     *
+     * \warning This is intended for advanced usage and may cause a crash if used incorrectly.
+     */
+    void exportToAddress( unsigned long long otherAddress );
+
+    //! Returns TRUE if this wrapper object holds a valid ArrowArray
+    bool isValid() const;
+
+  private:
+    struct ArrowArrayStream mArrayStream {};
+
+#ifdef SIP_RUN
+    QgsArrowArrayStream( const QgsArrowArrayStream &other );
+#endif
+};
+
+/**
+ * \ingroup core
  * \brief Wrapper for an Arrow reader of features from vector data provider or vector layer.
  * \since QGIS 4.0
  */

--- a/src/core/qgsarrowiterator.h
+++ b/src/core/qgsarrowiterator.h
@@ -343,7 +343,8 @@ class CORE_EXPORT QgsArrowIterator
      */
     void setSchema( const QgsArrowSchema &schema );
 
-    QgsArrowArrayStream toArrayStream();
+    //! Export this iterator as an ArrowArrayStream
+    QgsArrowArrayStream toArrayStream(int batchSize = 65536);
 
     /**
      * Build an ArrowArray using the next n features (or fewer depending on the number of features remaining)

--- a/tests/src/python/test_qgsarrowiterator.py
+++ b/tests/src/python/test_qgsarrowiterator.py
@@ -15,6 +15,11 @@ import json
 import unittest
 
 try:
+    import geopandas
+except ImportError:
+    geopandas = None
+
+try:
     import pyarrow as pa
 except ImportError:
     pa = None
@@ -49,6 +54,7 @@ from qgis.PyQt.QtCore import (
 from qgis.testing import QgisTestCase
 
 
+@unittest.skipIf(geopandas is None, "geopandas is not available")
 @unittest.skipIf(pa is None, "pyarrow is not available")
 @unittest.skipIf(shapely is None, "shapely is not available")
 class TestQgsArrowIterator(QgisTestCase):
@@ -155,6 +161,33 @@ class TestQgsArrowIterator(QgisTestCase):
 
         batch_invalid = iterator.nextFeatures(4)
         assert batch_invalid.isValid() is False
+
+    def test_layer_to_stream(self):
+        crs = QgsCoordinateReferenceSystem("EPSG:4326")
+        layer = self.create_test_layer_with_geometry(crs)
+
+        schema = QgsArrowIterator.inferSchema(layer)
+        iterator = QgsArrowIterator(layer.getFeatures())
+        iterator.setSchema(schema)
+
+        stream = iterator.toArrayStream()
+        reader = pa.RecordBatchReader._import_from_c(stream.cArrayStreamAddress())
+        df = geopandas.GeoDataFrame.from_arrow(reader)
+
+        assert list(df.id) == list(range(1, 11))
+        assert df.crs == "EPSG:4326"
+        assert list(df.geometry.to_wkt()) == [
+            "POINT (0 20)",
+            "POINT (1 21)",
+            "POINT (2 22)",
+            "POINT (3 23)",
+            "POINT (4 24)",
+            "POINT (5 25)",
+            "POINT (6 26)",
+            "POINT (7 27)",
+            "POINT (8 28)",
+            "POINT (9 29)",
+        ]
 
     def test_type_int(self):
         layer = self.create_test_layer_single_field(


### PR DESCRIPTION
## Description

This PR adds the `QgsArrowArrayStream`, which is a wrapper around the C `ArrowArrayStream` typically used to pass an iterator of ArrowArrays like `QgsArrowIterator` between libraries (C, Python, or otherwise).

This is one of a few issues as part of adding Arrow support to speed up specific paths (summarised in #64110 and started in #63749).

~I'll also try to implement the `__arrow_c_stream__`, `__arrow_c_array__`, and `__arrow_c_schema__` Python protocol methods here.~ (I'll follow up with that since this is a nicely self-contained change 🙂 )

