### PR TITLE
[3D] Add support to highlight a polygon feature selected by the identify tool

### DIFF
--- a/python/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
@@ -99,6 +99,7 @@ Returns tiling settings of the renderer
     virtual void resolveReferences( const QgsProject &project );
 
 
+
   protected:
     void copyBaseProperties( QgsAbstractVectorLayer3DRenderer *r ) const;
 %Docstring

--- a/python/3d/auto_generated/qgsrulebased3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsrulebased3drenderer.sip.in
@@ -260,6 +260,7 @@ Returns pointer to the root rule
     virtual QgsRuleBased3DRenderer *clone() const /Factory/;
 
 
+
     virtual void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
 
     virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context );

--- a/python/3d/auto_generated/qgsrulebased3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsrulebased3drenderer.sip.in
@@ -239,6 +239,7 @@ store labeling info to XML element
 
 
 
+
       private:
         Rule( const QgsRuleBased3DRenderer::Rule &rh );
     };

--- a/python/3d/auto_generated/qgsvectorlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsvectorlayer3drenderer.sip.in
@@ -69,6 +69,7 @@ Returns 3D symbol associated with the renderer
     virtual QgsVectorLayer3DRenderer *clone() const /Factory/;
 
 
+
     virtual void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
 
     virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context );

--- a/python/PyQt6/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
@@ -99,6 +99,7 @@ Returns tiling settings of the renderer
     virtual void resolveReferences( const QgsProject &project );
 
 
+
   protected:
     void copyBaseProperties( QgsAbstractVectorLayer3DRenderer *r ) const;
 %Docstring

--- a/python/PyQt6/3d/auto_generated/qgsrulebased3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgsrulebased3drenderer.sip.in
@@ -260,6 +260,7 @@ Returns pointer to the root rule
     virtual QgsRuleBased3DRenderer *clone() const /Factory/;
 
 
+
     virtual void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
 
     virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context );

--- a/python/PyQt6/3d/auto_generated/qgsrulebased3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgsrulebased3drenderer.sip.in
@@ -239,6 +239,7 @@ store labeling info to XML element
 
 
 
+
       private:
         Rule( const QgsRuleBased3DRenderer::Rule &rh );
     };

--- a/python/PyQt6/3d/auto_generated/qgsvectorlayer3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgsvectorlayer3drenderer.sip.in
@@ -69,6 +69,7 @@ Returns 3D symbol associated with the renderer
     virtual QgsVectorLayer3DRenderer *clone() const /Factory/;
 
 
+
     virtual void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
 
     virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context );

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -7,6 +7,7 @@ set(QGIS_3D_SRCS
   qgs3daxissettings.cpp
   qgsaabb.cpp
   qgsabstract3dengine.cpp
+  qgsabstractvectorlayer3dhighlightfactory_p.cpp
   qgsabstractvectorlayer3drenderer.cpp
   qgsannotationlayer3drenderer.cpp
   qgsannotationlayerchunkloader_p.cpp
@@ -35,12 +36,14 @@ set(QGIS_3D_SRCS
   qgsraycastcontext.cpp
   qgsraycasthit.cpp
   qgsraycastresult.cpp
+  qgsrulebased3dhighlightfactory_p.cpp
   qgsrulebased3drenderer.cpp
   qgsrulebasedchunkloader_p.cpp
   qgstessellatedpolygongeometry.cpp
   qgstiledscenechunkloader_p.cpp
   qgstiledscenelayer3drenderer.cpp
   qgstilingscheme.cpp
+  qgsvectorlayer3dhighlightfactory_p.cpp
   qgsvectorlayer3drenderer.cpp
   qgsvectorlayerchunkloader_p.cpp
   qgsmeshlayer3drenderer.cpp
@@ -256,7 +259,10 @@ set(QGIS_3D_HDRS
 )
 
 set(QGIS_3D_PRIVATE_HDRS
+  qgsabstractvectorlayer3dhighlightfactory_p.h
+  qgsrulebased3dhighlightfactory_p.h
   qgsrulebasedchunkloader_p.h
+  qgsvectorlayer3dhighlightfactory_p.h
   qgsvectorlayerchunkloader_p.h
   qgspointcloudlayerchunkloader_p.h
   qgsvirtualpointcloudentity_p.h

--- a/src/3d/framegraph/qgsframegraph.cpp
+++ b/src/3d/framegraph/qgsframegraph.cpp
@@ -158,6 +158,10 @@ Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructPostprocessingPass()
   // sub passes:
   constructSubPostPassForProcessing()->setParent( mRenderCaptureTargetSelector );
   constructDebugTexturePass( mRenderCaptureTargetSelector );
+
+  // rubber bands (they should be always on top)
+  constructRubberBandsPass()->setParent( mRenderCaptureTargetSelector );
+
   constructSubPostPassForRenderCapture()->setParent( mRenderCaptureTargetSelector );
 
   return mRenderCaptureTargetSelector;
@@ -174,7 +178,7 @@ void QgsFrameGraph::constructAmbientOcclusionRenderPass()
 Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructRubberBandsPass()
 {
   mRubberBandsCameraSelector = new Qt3DRender::QCameraSelector;
-  mRubberBandsCameraSelector->setObjectName( "RubberBands Pass CameraSelector" );
+  mRubberBandsCameraSelector->setObjectName( "rubberBandsPass" );
   mRubberBandsCameraSelector->setCamera( mMainCamera );
 
   mRubberBandsLayerFilter = new Qt3DRender::QLayerFilter( mRubberBandsCameraSelector );
@@ -269,11 +273,6 @@ QgsFrameGraph::QgsFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *m
 
   // Forward render
   constructForwardRenderPass();
-
-  // rubber bands (they should be always on top)
-  Qt3DRender::QFrameGraphNode *rubberBandsPass = constructRubberBandsPass();
-  rubberBandsPass->setObjectName( "rubberBandsPass" );
-  rubberBandsPass->setParent( mMainViewPort );
 
   // shadow rendering pass
   constructShadowRenderPass();

--- a/src/3d/framegraph/qgsframegraph.cpp
+++ b/src/3d/framegraph/qgsframegraph.cpp
@@ -198,12 +198,6 @@ Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructRubberBandsPass()
   mRubberBandsStateSet->addRenderState( blendState );
   mRubberBandsStateSet->addRenderState( blendEquation );
 
-  // Here we attach our drawings to the render target also used by forward pass.
-  // This is kind of okay, but as a result, post-processing effects get applied
-  // to rubber bands too. Ideally we would want them on top of everything.
-  mRubberBandsRenderTargetSelector = new Qt3DRender::QRenderTargetSelector( mRubberBandsStateSet );
-  mRubberBandsRenderTargetSelector->setTarget( forwardRenderView().renderTargetSelector()->target() );
-
   return mRubberBandsCameraSelector;
 }
 

--- a/src/3d/framegraph/qgsframegraph.h
+++ b/src/3d/framegraph/qgsframegraph.h
@@ -85,6 +85,9 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     //! Returns entity for all rubber bands (to show them always on top)
     Qt3DCore::QEntity *rubberBandsRootEntity() { return mRubberBandsRootEntity; }
 
+    //! Returns entity for highlights (to show them always on top)
+    Qt3DCore::QEntity *highlightsRootEntity() { return mHighlightsRootEntity; }
+
     //! Returns the render capture object used to take an image of the scene
     Qt3DRender::QRenderCapture *renderCapture();
 
@@ -255,10 +258,12 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     Qt3DCore::QEntity *mRootEntity = nullptr;
 
     Qt3DRender::QLayer *mRubberBandsLayer = nullptr;
+    Qt3DRender::QLayer *mHighlightsLayer = nullptr;
 
     QgsPostprocessingEntity *mPostprocessingEntity = nullptr;
 
     Qt3DCore::QEntity *mRubberBandsRootEntity = nullptr;
+    Qt3DCore::QEntity *mHighlightsRootEntity = nullptr;
 
     //! shadow texture debugging
     QgsDebugTextureEntity *mShadowTextureDebugging = nullptr;
@@ -271,6 +276,7 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     Qt3DRender::QFrameGraphNode *constructPostprocessingPass();
     void constructDepthRenderPass();
     void constructAmbientOcclusionRenderPass();
+    Qt3DRender::QFrameGraphNode *constructHighlightsPass();
     Qt3DRender::QFrameGraphNode *constructRubberBandsPass();
 
     Qt3DRender::QFrameGraphNode *constructSubPostPassForProcessing();

--- a/src/3d/framegraph/qgsframegraph.h
+++ b/src/3d/framegraph/qgsframegraph.h
@@ -247,7 +247,6 @@ class QgsFrameGraph : public Qt3DCore::QEntity
     Qt3DRender::QCameraSelector *mRubberBandsCameraSelector = nullptr;
     Qt3DRender::QLayerFilter *mRubberBandsLayerFilter = nullptr;
     Qt3DRender::QRenderStateSet *mRubberBandsStateSet = nullptr;
-    Qt3DRender::QRenderTargetSelector *mRubberBandsRenderTargetSelector = nullptr;
 
     QSize mSize = QSize( 1024, 768 );
 

--- a/src/3d/qgs3dmapcanvas.cpp
+++ b/src/3d/qgs3dmapcanvas.cpp
@@ -442,7 +442,7 @@ void Qgs3DMapCanvas::highlightFeature( const QgsFeature &feature, QgsMapLayer *l
       band->setWidth( pcRenderer->symbol()->pointSize() + 1 );
     }
     mHighlights[layer] = QObjectUniquePtr<Qt3DCore::QEntity>( band );
-    connect( layer, &QgsMapLayer::renderer3DChanged, this, &Qgs3DMapCanvas::updateHighlightSizes );
+    connect( layer, &QgsMapLayer::renderer3DChanged, this, &Qgs3DMapCanvas::updateHighlightParameters );
   }
   if ( QgsRubberBand3D *band = dynamic_cast<QgsRubberBand3D *>( mHighlights[layer].get() ) )
   {
@@ -450,7 +450,7 @@ void Qgs3DMapCanvas::highlightFeature( const QgsFeature &feature, QgsMapLayer *l
   }
 }
 
-void Qgs3DMapCanvas::updateHighlightSizes()
+void Qgs3DMapCanvas::updateHighlightParameters()
 {
   if ( QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( sender() ) )
   {

--- a/src/3d/qgs3dmapcanvas.cpp
+++ b/src/3d/qgs3dmapcanvas.cpp
@@ -87,8 +87,8 @@ Qgs3DMapCanvas::~Qgs3DMapCanvas()
   mScene = nullptr;
   mMapSettings->deleteLater();
   mMapSettings = nullptr;
-  qDeleteAll( mHighlights );
-  mHighlights.clear();
+
+  clearHighlights();
 
   delete m_aspectEngine;
 }

--- a/src/3d/qgs3dmapcanvas.cpp
+++ b/src/3d/qgs3dmapcanvas.cpp
@@ -427,7 +427,6 @@ void Qgs3DMapCanvas::highlightFeature( const QgsFeature &feature, QgsMapLayer *l
     return;
 
   const QgsGeometry geom = feature.geometry();
-  const QgsPoint pt( geom.vertexAt( 0 ) );
 
   if ( !mHighlights.contains( layer ) )
   {

--- a/src/3d/qgs3dmapcanvas.h
+++ b/src/3d/qgs3dmapcanvas.h
@@ -20,7 +20,9 @@
 #include "qgis_3d.h"
 #include "qgsrange.h"
 #include "qgsraycastresult.h"
+#include "qobjectuniqueptr.h"
 
+#include <Qt3DCore/QEntity>
 #include <QtGui/QWindow>
 
 #ifndef SIP_RUN
@@ -28,7 +30,6 @@ namespace Qt3DCore
 {
   class QAspectEngine;
   class QAbstractAspect;
-  class QEntity;
 } // namespace Qt3DCore
 
 namespace Qt3DRender
@@ -299,8 +300,8 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
 
     QgsTemporalController *mTemporalController = nullptr;
 
-    //! This holds and owns the rubber bands for highlighting identified features
-    QMap<QgsMapLayer *, QgsRubberBand3D *> mHighlights;
+    //! This holds and owns the entities for highlighting identified features
+    std::map<QgsMapLayer *, QObjectUniquePtr<Qt3DCore::QEntity>> mHighlights;
 };
 
 #endif //QGS3DMAPCANVAS_H

--- a/src/3d/qgs3dmapcanvas.h
+++ b/src/3d/qgs3dmapcanvas.h
@@ -249,7 +249,7 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
     void captureDepthBuffer();
     void updateTemporalRange( const QgsDateTimeRange &timeRange );
     void onNavigationModeChanged( Qgis::NavigationMode mode );
-    void updateHighlightSizes();
+    void updateHighlightParameters();
 
   protected:
     /**

--- a/src/3d/qgs3dmapcanvas.h
+++ b/src/3d/qgs3dmapcanvas.h
@@ -18,6 +18,7 @@
 
 #include "qgis.h"
 #include "qgis_3d.h"
+#include "qgsfeature.h"
 #include "qgsrange.h"
 #include "qgsraycastresult.h"
 #include "qobjectuniqueptr.h"
@@ -65,7 +66,6 @@ class QgsCameraController;
 class QgsTemporalController;
 class Qgs3DMapScene;
 class Qgs3DMapSettings;
-class QgsFeature;
 class QgsMapLayer;
 class QgsRubberBand3D;
 class QgsRayCastContext;
@@ -249,7 +249,6 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
     void captureDepthBuffer();
     void updateTemporalRange( const QgsDateTimeRange &timeRange );
     void onNavigationModeChanged( Qgis::NavigationMode mode );
-    void updateHighlightParameters();
 
   protected:
     /**
@@ -263,6 +262,10 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
     void resizeEvent( QResizeEvent * ) override;
 
     bool eventFilter( QObject *watched, QEvent *event ) override;
+
+  private:
+    void updateHighlightParameters( const QgsFeature &feature );
+    void createVectorHighlight( QgsMapLayer *layer, const QgsFeature &feature );
 
   private:
     Qt3DCore::QAspectEngine *m_aspectEngine;

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -1318,6 +1318,12 @@ void Qgs3DMapScene::onOriginChanged()
     transform->setOrigin( mMap.origin() );
   }
 
+  const QList<QgsGeoTransform *> highlightsGeoTransforms = mEngine->frameGraph()->highlightsRootEntity()->findChildren<QgsGeoTransform *>();
+  for ( QgsGeoTransform *transform : highlightsGeoTransforms )
+  {
+    transform->setOrigin( mMap.origin() );
+  }
+
   const QgsVector3D oldOrigin = mCameraController->origin();
   mCameraController->setOrigin( mMap.origin() );
 

--- a/src/3d/qgsabstractvectorlayer3dhighlightfactory_p.cpp
+++ b/src/3d/qgsabstractvectorlayer3dhighlightfactory_p.cpp
@@ -1,0 +1,91 @@
+/***************************************************************************
+  qgsabstractvectorlayer3dhighlightfactory_p.cpp
+  --------------------------------------
+  Date                 : December 2025
+  Copyright            : (C) 2025 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsabstractvectorlayer3dhighlightfactory_p.h"
+
+#include "qgs3dmapsettings.h"
+#include "qgsabstract3dengine.h"
+#include "qgsgeotransform.h"
+#include "qgsline3dsymbol.h"
+#include "qgslinematerial_p.h"
+#include "qgsphongmaterialsettings.h"
+#include "qgspoint3dsymbol.h"
+#include "qgspolygon3dsymbol.h"
+#include "qgsvectorlayer.h"
+
+///@cond PRIVATE
+
+QgsAbstractVectorLayer3DHighlightFactory::QgsAbstractVectorLayer3DHighlightFactory( Qgs3DMapSettings *mapSettings, QgsVectorLayer *vLayer )
+  : mMapSettings( mapSettings )
+  , mLayer( vLayer )
+{
+}
+
+std::unique_ptr<QgsAbstract3DSymbol> QgsAbstractVectorLayer3DHighlightFactory::prepareSymbol( const QgsAbstract3DSymbol *symbol, const QColor &fillColor, const QColor &edgeColor )
+{
+  if ( !symbol )
+  {
+    return nullptr;
+  }
+
+  std::unique_ptr<QgsPhongMaterialSettings> phong( static_cast<QgsPhongMaterialSettings *>( QgsPhongMaterialSettings::create() ) );
+  phong->setAmbient( fillColor );
+  phong->setDiffuse( Qt::darkGray );
+  phong->setOpacity( 1.0f );
+
+  std::unique_ptr<QgsAbstract3DSymbol> clonedSymbol( symbol->clone() );
+  if ( QgsPolygon3DSymbol *polygonSymbol = dynamic_cast<QgsPolygon3DSymbol *>( clonedSymbol.get() ) )
+  {
+    polygonSymbol->setMaterialSettings( phong.release() );
+    polygonSymbol->setAddBackFaces( false );
+    polygonSymbol->setCullingMode( Qgs3DTypes::CullingMode::NoCulling );
+    polygonSymbol->setEdgesEnabled( true );
+    polygonSymbol->setEdgeColor( edgeColor );
+    polygonSymbol->setEdgeWidth( 2.0f );
+  }
+  else if ( QgsPoint3DSymbol *pointSymbol = dynamic_cast<QgsPoint3DSymbol *>( clonedSymbol.get() ) )
+  {
+    pointSymbol->setMaterialSettings( phong.release() );
+  }
+  else if ( QgsLine3DSymbol *lineSymbol = dynamic_cast<QgsLine3DSymbol *>( clonedSymbol.get() ) )
+  {
+    lineSymbol->setMaterialSettings( phong.release() );
+  }
+
+  return clonedSymbol;
+}
+
+void QgsAbstractVectorLayer3DHighlightFactory::finalizeEntities( QList<Qt3DCore::QEntity *> newEntities, QgsAbstract3DEngine *engine, const QgsVector3D &dataOrigin )
+{
+  for ( auto *childEntity : newEntities )
+  {
+    for ( QgsGeoTransform *transform : childEntity->findChildren<QgsGeoTransform *>() )
+    {
+      transform->setGeoTranslation( dataOrigin );
+      transform->setOrigin( mMapSettings->origin() );
+    }
+
+    for ( QgsLineMaterial *lm : childEntity->findChildren<QgsLineMaterial *>() )
+    {
+      QObject::connect( engine, &QgsAbstract3DEngine::sizeChanged, lm, [lm, engine] {
+        lm->setViewportSize( engine->size() );
+      } );
+
+      lm->setViewportSize( engine->size() );
+    }
+  }
+}
+
+/// @endcond

--- a/src/3d/qgsabstractvectorlayer3dhighlightfactory_p.h
+++ b/src/3d/qgsabstractvectorlayer3dhighlightfactory_p.h
@@ -1,0 +1,108 @@
+/***************************************************************************
+  qgsabstractvectorlayer3dhighlightfactory_p.h
+  --------------------------------------
+  Date                 : December 2025
+  Copyright            : (C) 2025 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSABSTRACTVECTORLAYERH3DHIGHLIGHTFACTORY_H
+#define QGSABSTRACTVECTORLAYERH3DHIGHLIGHTFACTORY_H
+
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+
+#include "qgsabstract3dsymbol.h"
+#include "qgsfeature.h"
+
+class Qgs3DMapSettings;
+class QgsVectorLayer;
+class QgsAbstract3DEngine;
+
+namespace Qt3DCore
+{
+  class QEntity;
+}
+
+/**
+ * \ingroup qgis_3d
+ *
+ * \brief Abstract factory for creating 3D highlight entities for vector layer features.
+ *
+ * It is responsible for generating Qt3D entities used to highlight
+ * vector features in a 3D scene. Subclasses must implement create() to define
+ * how highlight entities are built for a given feature.
+ *
+ * The prepareSymbol() method must be called to replace the feature symbol with a new symbol
+ * which highlights the feature.
+ * The finalizeEntities() method must be called at the end of the create() function to configure
+ * the components of the newly created entities.
+ *
+ * \since QGIS 4.0
+ */
+class QgsAbstractVectorLayer3DHighlightFactory
+{
+  public:
+    //! Constructs the factory for a layer
+    QgsAbstractVectorLayer3DHighlightFactory( Qgs3DMapSettings *mapSettings, QgsVectorLayer *vLayer );
+
+    virtual ~QgsAbstractVectorLayer3DHighlightFactory() = default;
+
+    /**
+     * Creates 3D highlight entities for a specific feature.
+     *
+     * Implementations must create and return one or more entities
+     * representing the highlighted version of the given feature.
+     *
+     * \param feature Feature to be highlighted. Its geometry must be in the 3D scene CRS.
+     * \param engine 3D engine
+     * \param parent Parent for the created highlight entities.
+     * \param fillColor Color used to fill the highlighted geometry.
+     * \param edgeColor Color used to render edges of the highlighted geometry.
+     *
+     * \return List of created Qt3D entities representing the highlight.
+     */
+    virtual QList<Qt3DCore::QEntity *> create( const QgsFeature &feature, QgsAbstract3DEngine *engine, Qt3DCore::QEntity *parent, const QColor &fillColor, const QColor &edgeColor ) = 0;
+
+    /**
+     * Prepares a 3D symbol for highlight rendering.
+     *
+     * This clones the given symbol and replaces its material
+     * settings by a phong material with fill and edge colors.
+     *
+     * \param symbol Original 3D symbol used by the feature.
+     * \param fillColor Color used to fill the highlighted symbol.
+     * \param edgeColor Color used to render edges of the highlighted geometry.
+     *
+     * \return A newly prepared 3D symbol suitable for highlight rendering.
+     */
+    std::unique_ptr<QgsAbstract3DSymbol> prepareSymbol( const QgsAbstract3DSymbol *symbol, const QColor &fillColor, const QColor &edgeColor );
+
+    /**
+     * Finalizes newly created highlight entities.
+     *
+     * It configures material listeners and updates the QgsGeoTransform
+     * based on the provided data origin.
+     *
+     * \param newEntities List of newly created Qt3D entities.
+     * \param engine 3D engine
+     * \param dataOrigin Origin used to transform entity coordinates.
+     */
+    void finalizeEntities( QList<Qt3DCore::QEntity *> newEntities, QgsAbstract3DEngine *engine, const QgsVector3D &dataOrigin );
+
+  protected:
+    Qgs3DMapSettings *mMapSettings = nullptr;
+    QgsVectorLayer *mLayer = nullptr;
+};
+
+/// @endcond
+
+#endif // QGSABSTRACTVECTORLAYERH3DHIGHLIGHTFACTORY_H

--- a/src/3d/qgsabstractvectorlayer3drenderer.h
+++ b/src/3d/qgsabstractvectorlayer3drenderer.h
@@ -19,6 +19,7 @@
 #include "qgis_3d.h"
 #include "qgis_sip.h"
 #include "qgsabstract3drenderer.h"
+#include "qgsabstractvectorlayer3dhighlightfactory_p.h"
 #include "qgsmaplayerref.h"
 
 class QgsVectorLayer;
@@ -88,6 +89,9 @@ class _3D_EXPORT QgsAbstractVectorLayer3DRenderer : public QgsAbstract3DRenderer
     QgsVectorLayer3DTilingSettings tilingSettings() const { return mTilingSettings; }
 
     void resolveReferences( const QgsProject &project ) override;
+
+    /// Creates a factory to highlight a feature.
+    virtual std::unique_ptr<QgsAbstractVectorLayer3DHighlightFactory> createHighlightFactory( Qgs3DMapSettings *mapSettings ) const = 0 SIP_SKIP;
 
   protected:
     //! Copies common properties of this object to another object

--- a/src/3d/qgsfeature3dhandler_p.h
+++ b/src/3d/qgsfeature3dhandler_p.h
@@ -61,7 +61,7 @@ class QgsFeature3DHandler
      * When feature iteration has finished, finalize() is called to turn the extracted data
      * to a 3D entity object(s) attached to the given parent.
      */
-    virtual void finalize( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context ) = 0;
+    virtual QList<Qt3DCore::QEntity *> finalize( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context ) = 0;
 
     /**
      * Returns minimal Z value of the data (in world coordinates).

--- a/src/3d/qgsrubberband3d.h
+++ b/src/3d/qgsrubberband3d.h
@@ -31,11 +31,12 @@
 
 #include "qgis_3d.h"
 #include "qgsgeometry.h"
+#include "qgsmarkersymbol.h"
 #include "qgspolygon.h"
 #include "qgstessellator.h"
-#include "qobjectuniqueptr.h"
 
 #include <QColor>
+#include <Qt3DCore/QEntity>
 
 class QgsGeometry;
 class QgsAbstract3DEngine;
@@ -46,13 +47,11 @@ class QgsTessellatedPolygonGeometry;
 class QgsLineMaterial;
 class Qgs3DMapSettings;
 class QgsBillboardGeometry;
-class QgsMarkerSymbol;
 class QgsPoint3DBillboardMaterial;
 class QgsGeoTransform;
 
 namespace Qt3DCore
 {
-  class QEntity;
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 0, 0 )
   class QBuffer;
   class QGeometry;
@@ -81,8 +80,10 @@ namespace Qt3DRender
  * \note Currently only supports multi point, linestring and polygon geometry.
  * \since QGIS 3.20
  */
-class _3D_EXPORT QgsRubberBand3D
+class _3D_EXPORT QgsRubberBand3D : public Qt3DCore::QEntity
 {
+    Q_OBJECT
+
   public:
     //! Icons
     enum MarkerType
@@ -100,7 +101,6 @@ class _3D_EXPORT QgsRubberBand3D
     };
 
     QgsRubberBand3D( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine, Qt3DCore::QEntity *parentEntity, Qgis::GeometryType geometryType = Qgis::GeometryType::Line );
-    ~QgsRubberBand3D();
 
     //! Returns the rubber band width in pixels
     float width() const;
@@ -213,9 +213,9 @@ class _3D_EXPORT QgsRubberBand3D
   private:
     void updateGeometry();
     void updateMarkerMaterial();
-    void setupMarker( Qt3DCore::QEntity *parentEntity );
-    void setupLine( Qt3DCore::QEntity *parentEntity, QgsAbstract3DEngine *engine );
-    void setupPolygon( Qt3DCore::QEntity *parentEntity );
+    void setupMarker();
+    void setupLine( QgsAbstract3DEngine *engine );
+    void setupPolygon();
     //! negative index counts from end
     void removePoint( int index );
 
@@ -239,9 +239,9 @@ class _3D_EXPORT QgsRubberBand3D
     bool mEdgesEnabled = true;
     bool mPolygonFillEnabled = true;
 
-    QObjectUniquePtr<Qt3DCore::QEntity> mLineEntity = nullptr;    // owned by parentEntity (from constructor)
-    QObjectUniquePtr<Qt3DCore::QEntity> mPolygonEntity = nullptr; // owned by parentEntity (from constructor)
-    QObjectUniquePtr<Qt3DCore::QEntity> mMarkerEntity = nullptr;  // owned by parentEntity (from constructor)
+    Qt3DCore::QEntity *mLineEntity = nullptr;
+    Qt3DCore::QEntity *mPolygonEntity = nullptr;
+    Qt3DCore::QEntity *mMarkerEntity = nullptr;
 
     QgsGeoTransform *mLineTransform = nullptr;
     QgsGeoTransform *mPolygonTransform = nullptr;

--- a/src/3d/qgsrulebased3dhighlightfactory_p.cpp
+++ b/src/3d/qgsrulebased3dhighlightfactory_p.cpp
@@ -1,0 +1,79 @@
+/***************************************************************************
+  qgsrulebased3dhighlightfactory_p.cpp
+  --------------------------------------
+  Date                 : December 2025
+  Copyright            : (C) 2025 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrulebased3dhighlightfactory_p.h"
+
+#include "qgs3drendercontext.h"
+#include "qgsfeature3dhandler_p.h"
+
+///@cond PRIVATE
+
+QgsRuleBased3DHighlightFactory::QgsRuleBased3DHighlightFactory( Qgs3DMapSettings *mapSettings, QgsVectorLayer *vLayer, QgsRuleBased3DRenderer::Rule *rootRule )
+  : QgsAbstractVectorLayer3DHighlightFactory( mapSettings, vLayer )
+  , mRootRule( rootRule->clone() )
+{
+}
+
+QgsRuleBased3DHighlightFactory::~QgsRuleBased3DHighlightFactory()
+{
+  qDeleteAll( mHandlers );
+  mHandlers.clear();
+}
+
+QList<Qt3DCore::QEntity *> QgsRuleBased3DHighlightFactory::create( const QgsFeature &feature, QgsAbstract3DEngine *engine, Qt3DCore::QEntity *parent, const QColor &fillColor, const QColor &edgeColor )
+{
+  const QgsBox3D box = feature.geometry().constGet()->boundingBox3D();
+  QgsVector3D dataOrigin = box.center();
+  if ( std::isnan( dataOrigin.z() ) )
+  {
+    dataOrigin.setZ( 0.0 );
+  }
+
+  Qgs3DRenderContext renderContext = Qgs3DRenderContext::fromMapSettings( mMapSettings );
+
+  // replace the symbol of the rule associated with the feature
+  for ( QgsRuleBased3DRenderer::Rule *rule : mRootRule->children() )
+  {
+    if ( rule->isFilterOK( feature, renderContext ) && rule->symbol() )
+    {
+      rule->setSymbol( prepareSymbol( rule->symbol(), fillColor, edgeColor ).release() );
+      break;
+    }
+  }
+
+  mRootRule->createHandlers( mLayer, mHandlers );
+
+  QSet<QString> attributeNames;
+  mRootRule->prepare( renderContext, attributeNames, dataOrigin, mHandlers );
+  mRootRule->registerFeature( feature, renderContext, mHandlers );
+
+  QList<Qt3DCore::QEntity *> highlightEntities;
+  finalizeEntities( highlightEntities, engine, QgsVector3D() );
+  for ( auto it = mHandlers.constBegin(); it != mHandlers.constEnd(); ++it )
+  {
+    QgsFeature3DHandler *handler = it.value();
+    highlightEntities = handler->finalize( parent, renderContext );
+    // feature handler found
+    if ( !highlightEntities.empty() )
+    {
+      break;
+    }
+  }
+
+  finalizeEntities( highlightEntities, engine, dataOrigin );
+  return highlightEntities;
+}
+
+/// @endcond

--- a/src/3d/qgsrulebased3dhighlightfactory_p.h
+++ b/src/3d/qgsrulebased3dhighlightfactory_p.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+  qgsrulebased3dhighlightfactory_p.h
+  --------------------------------------
+  Date                 : December 2025
+  Copyright            : (C) 2025 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRULEBASED3DHIGHLIGHTFACTORY_H
+#define QGSRULEBASED3DHIGHLIGHTFACTORY_H
+
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+
+#include "qgsabstractvectorlayer3dhighlightfactory_p.h"
+#include "qgsrulebased3drenderer.h"
+
+namespace Qt3DCore
+{
+  class QEntity;
+}
+
+/**
+ * \ingroup qgis_3d
+ *
+ * \brief 3D highlight factory based on a rule-based 3D renderer.
+ *
+ * This factory creates 3D highlight entities for vector layer features
+ * using a rule-based 3D renderer. It evaluates the feature
+ * against the renderer rules and generates highlight entities according
+ * to the matching rules.
+ *
+ * \since QGIS 4.0
+ */
+class QgsRuleBased3DHighlightFactory : public QgsAbstractVectorLayer3DHighlightFactory
+{
+  public:
+    QgsRuleBased3DHighlightFactory( Qgs3DMapSettings *mapSettings, QgsVectorLayer *vLayer, QgsRuleBased3DRenderer::Rule *rootRule );
+
+    virtual ~QgsRuleBased3DHighlightFactory() override;
+
+    QList<Qt3DCore::QEntity *> create( const QgsFeature &feature, QgsAbstract3DEngine *engine, Qt3DCore::QEntity *parent, const QColor &fillColor, const QColor &edgeColor ) override;
+
+  private:
+    std::unique_ptr<QgsRuleBased3DRenderer::Rule> mRootRule = nullptr;
+    QgsRuleBased3DRenderer::RuleToHandlerMap mHandlers;
+};
+
+/// @endcond
+
+#endif // QGSRULEBASED3DHIGHLIGHTFACTORY_H

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -337,7 +337,7 @@ QgsRuleBased3DRenderer::Rule::RegisterResult QgsRuleBased3DRenderer::Rule::regis
 }
 
 
-bool QgsRuleBased3DRenderer::Rule::isFilterOK( QgsFeature &f, Qgs3DRenderContext &context ) const
+bool QgsRuleBased3DRenderer::Rule::isFilterOK( const QgsFeature &f, Qgs3DRenderContext &context ) const
 {
   if ( !mFilter || mElseRule )
     return true;

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -337,12 +337,12 @@ QgsRuleBased3DRenderer::Rule::RegisterResult QgsRuleBased3DRenderer::Rule::regis
 }
 
 
-bool QgsRuleBased3DRenderer::Rule::isFilterOK( const QgsFeature &f, Qgs3DRenderContext &context ) const
+bool QgsRuleBased3DRenderer::Rule::isFilterOK( const QgsFeature &feature, Qgs3DRenderContext &context ) const
 {
   if ( !mFilter || mElseRule )
     return true;
 
-  context.expressionContext().setFeature( f );
+  context.expressionContext().setFeature( feature );
   QVariant res = mFilter->evaluate( &context.expressionContext() );
   return res.toInt() != 0;
 }

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -22,6 +22,7 @@
 #include "qgs3dutils.h"
 #include "qgsapplication.h"
 #include "qgsfeature3dhandler_p.h"
+#include "qgsrulebased3dhighlightfactory_p.h"
 #include "qgsrulebasedchunkloader_p.h"
 #include "qgsvectorlayer.h"
 #include "qgsxmlutils.h"
@@ -413,4 +414,16 @@ void QgsRuleBased3DRenderer::readXml( const QDomElement &elem, const QgsReadWrit
   readXmlBaseProperties( elem, context );
 
   // root rule is read before class constructed
+}
+
+std::unique_ptr<QgsAbstractVectorLayer3DHighlightFactory> QgsRuleBased3DRenderer::createHighlightFactory( Qgs3DMapSettings *mapSettings ) const
+{
+  QgsVectorLayer *vectorLayer = layer();
+
+  if ( !vectorLayer )
+  {
+    return nullptr;
+  }
+
+  return std::make_unique<QgsRuleBased3DHighlightFactory>( mapSettings, vectorLayer, mRootRule );
 }

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -288,7 +288,7 @@ void QgsRuleBased3DRenderer::Rule::prepare( const Qgs3DRenderContext &context, Q
   }
 }
 
-QgsRuleBased3DRenderer::Rule::RegisterResult QgsRuleBased3DRenderer::Rule::registerFeature( QgsFeature &feature, Qgs3DRenderContext &context, QgsRuleBased3DRenderer::RuleToHandlerMap &handlers ) const
+QgsRuleBased3DRenderer::Rule::RegisterResult QgsRuleBased3DRenderer::Rule::registerFeature( const QgsFeature &feature, Qgs3DRenderContext &context, QgsRuleBased3DRenderer::RuleToHandlerMap &handlers ) const
 {
   if ( !isFilterOK( feature, context ) )
     return Filtered;

--- a/src/3d/qgsrulebased3drenderer.h
+++ b/src/3d/qgsrulebased3drenderer.h
@@ -251,7 +251,7 @@ class _3D_EXPORT QgsRuleBased3DRenderer : public QgsAbstractVectorLayer3DRendere
          * register individual features
          * \note not available in Python bindings
          */
-        RegisterResult registerFeature( QgsFeature &feature, Qgs3DRenderContext &context, RuleToHandlerMap &handlers ) const SIP_SKIP;
+        RegisterResult registerFeature( const QgsFeature &feature, Qgs3DRenderContext &context, RuleToHandlerMap &handlers ) const SIP_SKIP;
 
         /**
          * Check if a given feature shall be labelled by this rule

--- a/src/3d/qgsrulebased3drenderer.h
+++ b/src/3d/qgsrulebased3drenderer.h
@@ -306,6 +306,8 @@ class _3D_EXPORT QgsRuleBased3DRenderer : public QgsAbstractVectorLayer3DRendere
     QgsRuleBased3DRenderer *clone() const override SIP_FACTORY;
     Qt3DCore::QEntity *createEntity( Qgs3DMapSettings *map ) const override SIP_SKIP;
 
+    std::unique_ptr<QgsAbstractVectorLayer3DHighlightFactory> createHighlightFactory( Qgs3DMapSettings *mapSettings ) const override SIP_SKIP;
+
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
     void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
 

--- a/src/3d/qgsrulebased3drenderer.h
+++ b/src/3d/qgsrulebased3drenderer.h
@@ -253,19 +253,19 @@ class _3D_EXPORT QgsRuleBased3DRenderer : public QgsAbstractVectorLayer3DRendere
          */
         RegisterResult registerFeature( QgsFeature &feature, Qgs3DRenderContext &context, RuleToHandlerMap &handlers ) const SIP_SKIP;
 
+        /**
+         * Check if a given feature shall be labelled by this rule
+         *
+         * \param feature   The feature to test
+         * \param context   The context in which the rendering happens
+         * \returns         TRUE if the feature shall be rendered
+         */
+        bool isFilterOK( const QgsFeature &feature, Qgs3DRenderContext &context ) const SIP_SKIP;
+
       private:
 #ifdef SIP_RUN
         Rule( const QgsRuleBased3DRenderer::Rule &rh );
 #endif
-
-        /**
-         * Check if a given feature shall be labelled by this rule
-         *
-         * \param f         The feature to test
-         * \param context   The context in which the rendering happens
-         * \returns          TRUE if the feature shall be rendered
-         */
-        bool isFilterOK( const QgsFeature &f, Qgs3DRenderContext &context ) const;
 
         /**
          * Initialize filters. Automatically called by setFilterExpression.

--- a/src/3d/qgsrulebased3drenderer.h
+++ b/src/3d/qgsrulebased3drenderer.h
@@ -265,7 +265,7 @@ class _3D_EXPORT QgsRuleBased3DRenderer : public QgsAbstractVectorLayer3DRendere
          * \param context   The context in which the rendering happens
          * \returns          TRUE if the feature shall be rendered
          */
-        bool isFilterOK( QgsFeature &f, Qgs3DRenderContext &context ) const;
+        bool isFilterOK( const QgsFeature &f, Qgs3DRenderContext &context ) const;
 
         /**
          * Initialize filters. Automatically called by setFilterExpression.

--- a/src/3d/qgsvectorlayer3dhighlightfactory_p.cpp
+++ b/src/3d/qgsvectorlayer3dhighlightfactory_p.cpp
@@ -1,0 +1,57 @@
+/***************************************************************************
+  qgsvectorlayer3dhighlightfactory_p.cpp
+  --------------------------------------
+  Date                 : December 2025
+  Copyright            : (C) 2025 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectorlayer3dhighlightfactory_p.h"
+
+#include <memory>
+
+#include "qgs3drendercontext.h"
+#include "qgs3dsymbolregistry.h"
+#include "qgsabstract3dengine.h"
+#include "qgsabstract3dsymbol.h"
+#include "qgsapplication.h"
+#include "qgsfeature3dhandler_p.h"
+
+///@cond PRIVATE
+
+QgsVectorLayer3DHighlightFactory::QgsVectorLayer3DHighlightFactory( Qgs3DMapSettings *mapSettings, QgsVectorLayer *vLayer, QgsAbstract3DSymbol *symbol )
+  : QgsAbstractVectorLayer3DHighlightFactory( mapSettings, vLayer )
+  , mSymbol( symbol )
+{
+}
+
+QList<Qt3DCore::QEntity *> QgsVectorLayer3DHighlightFactory::create( const QgsFeature &feature, QgsAbstract3DEngine *engine, Qt3DCore::QEntity *parent, const QColor &fillColor, const QColor &edgeColor )
+{
+  const QgsBox3D box = feature.geometry().constGet()->boundingBox3D();
+  QgsVector3D dataOrigin = box.center();
+  if ( std::isnan( dataOrigin.z() ) )
+  {
+    dataOrigin.setZ( 0.0 );
+  }
+
+  std::unique_ptr<QgsAbstract3DSymbol> highlightSymbol = prepareSymbol( mSymbol, fillColor, edgeColor );
+  std::unique_ptr<QgsFeature3DHandler> feat3DHandler( QgsApplication::symbol3DRegistry()->createHandlerForSymbol( mLayer, highlightSymbol.get() ) );
+
+  const Qgs3DRenderContext renderContext = Qgs3DRenderContext::fromMapSettings( mMapSettings );
+  QSet<QString> attributeNames;
+  feat3DHandler->prepare( renderContext, attributeNames, dataOrigin );
+  feat3DHandler->processFeature( feature, renderContext );
+  QList<Qt3DCore::QEntity *> highlightEntities = feat3DHandler->finalize( parent, renderContext );
+
+  finalizeEntities( highlightEntities, engine, dataOrigin );
+  return highlightEntities;
+}
+
+/// @endcond

--- a/src/3d/qgsvectorlayer3dhighlightfactory_p.h
+++ b/src/3d/qgsvectorlayer3dhighlightfactory_p.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+  qgsvectorlayer3dhighlightfactory_p.h
+  --------------------------------------
+  Date                 : December 2025
+  Copyright            : (C) 2025 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORLAYER3DHIGHLIGHTFACTORY_H
+#define QGSVECTORLAYER3DHIGHLIGHTFACTORY_H
+
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+
+#include "qgsabstractvectorlayer3dhighlightfactory_p.h"
+#include "qgsfeature.h"
+
+class Qgs3DMapSettings;
+class QgsVectorLayer;
+class QgsAbstract3DSymbol;
+
+namespace Qt3DCore
+{
+  class QEntity;
+}
+
+/**
+ * \ingroup qgis_3d
+ *
+ * \brief 3D highlight factory based on a single 3D symbol.
+ *
+ * This factory creates 3D highlight entities for vector layer features
+ * using a single 3D symbol by replacing the existing symbol with a symbol with highlight colors.
+ *
+ * \since QGIS 4.0
+ */
+class QgsVectorLayer3DHighlightFactory : public QgsAbstractVectorLayer3DHighlightFactory
+{
+  public:
+    QgsVectorLayer3DHighlightFactory( Qgs3DMapSettings *mapSettings, QgsVectorLayer *vLayer, QgsAbstract3DSymbol *symbol );
+
+    QList<Qt3DCore::QEntity *> create( const QgsFeature &feature, QgsAbstract3DEngine *engine, Qt3DCore::QEntity *parent, const QColor &fillColor, const QColor &edgeColor ) override;
+
+  private:
+    QgsAbstract3DSymbol *mSymbol = nullptr;
+};
+
+/// @endcond
+
+#endif // QGSVECTORLAYER3DHIGHLIGHTFACTORY_H

--- a/src/3d/qgsvectorlayer3drenderer.cpp
+++ b/src/3d/qgsvectorlayer3drenderer.cpp
@@ -19,6 +19,7 @@
 #include "qgs3dutils.h"
 #include "qgsapplication.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectorlayer3dhighlightfactory_p.h"
 #include "qgsvectorlayerchunkloader_p.h"
 #include "qgsxmlutils.h"
 
@@ -101,4 +102,16 @@ void QgsVectorLayer3DRenderer::readXml( const QDomElement &elem, const QgsReadWr
   mSymbol.reset( QgsApplication::symbol3DRegistry()->createSymbol( symbolType ) );
   if ( mSymbol )
     mSymbol->readXml( elemSymbol, context );
+}
+
+std::unique_ptr<QgsAbstractVectorLayer3DHighlightFactory> QgsVectorLayer3DRenderer::createHighlightFactory( Qgs3DMapSettings *mapSettings ) const
+{
+  QgsVectorLayer *vectorLayer = layer();
+
+  if ( !vectorLayer )
+  {
+    return nullptr;
+  }
+
+  return std::make_unique<QgsVectorLayer3DHighlightFactory>( mapSettings, vectorLayer, mSymbol.get() );
 }

--- a/src/3d/qgsvectorlayer3drenderer.h
+++ b/src/3d/qgsvectorlayer3drenderer.h
@@ -66,6 +66,8 @@ class _3D_EXPORT QgsVectorLayer3DRenderer : public QgsAbstractVectorLayer3DRende
     QgsVectorLayer3DRenderer *clone() const override SIP_FACTORY;
     Qt3DCore::QEntity *createEntity( Qgs3DMapSettings *map ) const override SIP_SKIP;
 
+    std::unique_ptr<QgsAbstractVectorLayer3DHighlightFactory> createHighlightFactory( Qgs3DMapSettings *mapSettings ) const override SIP_SKIP;
+
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
     void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
 

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
@@ -46,6 +46,5 @@
       (Qt3DRender::QCameraSelector{184/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
         (Qt3DRender::QLayerFilter{185/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mRubberBandsLayer} ]) ]
           (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
-            (Qt3DRender::QRenderTargetSelector{190/<no_name>}) [ (outputs:[ (Depth:{18[DepthFormat]/<no_name>), (Color0:{17[RGB8_UNorm]/<no_name>) ]) ]
-      (Qt3DRender::QNoDraw{191/Sub pass RenderCapture})
-        (Qt3DRender::QRenderCapture{192/<no_name>})
+      (Qt3DRender::QNoDraw{190/Sub pass RenderCapture})
+        (Qt3DRender::QRenderCapture{191/<no_name>})

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
@@ -1,50 +1,54 @@
-(Qt3DRender::QRenderSurfaceSelector{8/<no_name>})
-  (Qt3DRender::QViewport{9/<no_name>})
-    (Qt3DRender::QNoDraw{10/forward::NoDraw}) [D]
-      (Qt3DRender::QSubtreeEnabler{11/forward::SubtreeEnabler})
-        (Qt3DRender::QCameraSelector{14/forward::CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-          (Qt3DRender::QLayerFilter{15/<no_name>}) [ (AcceptAnyMatchingLayers:[ {12/forward::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{16/forward::Clip Plane RenderStateSet}) [  ]
-              (Qt3DRender::QRenderTargetSelector{22/<no_name>}) [ (outputs:[ (Depth:{18[DepthFormat]/<no_name>), (Color0:{17[RGB8_UNorm]/<no_name>) ]) ]
-                (Qt3DRender::QLayerFilter{23/<no_name>}) [ (DiscardAnyMatchingLayers:[ {13/forward::TransparentLayer} ]) ]
-                  (Qt3DRender::QRenderStateSet{24/<no_name>}) [ (QDepthTest:Less), (QCullFace:Back) ]
-                    (Qt3DRender::QFrustumCulling{27/<no_name>})
-                      (Qt3DRender::QClearBuffers{28/<no_name>})
-                        (Qt3DRender::QDebugOverlay{41/<no_name>}) [D]
-                (Qt3DRender::QLayerFilter{29/<no_name>}) [ (AcceptAnyMatchingLayers:[ {13/forward::TransparentLayer} ]) ]
-                  (Qt3DRender::QSortPolicy{30/<no_name>})
-                    (Qt3DRender::QRenderStateSet{31/<no_name>}) [ (QDepthTest:Less), (QNoDepthMask), (QCullFace:NoCulling), (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                    (Qt3DRender::QRenderStateSet{37/<no_name>}) [ (QDepthTest:Less), (QColorMask:[ (red:false), (green:false), (blue:false), (alpha:false) ]), (QCullFace:NoCulling) ]
-    (Qt3DRender::QNoDraw{42/shadow::NoDraw})
-      (Qt3DRender::QSubtreeEnabler{43/shadow::SubtreeEnabler}) [D]
-        (Qt3DRender::QCameraSelector{48/shadow::CameraSelector}) [ (Qt3DRender::QCamera:{44/shadow::LightCamera}) ]
-          (Qt3DRender::QLayerFilter{49/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {47/shadow::Layer} ]) ]
-            (Qt3DRender::QRenderTargetSelector{50/<no_name>}) [ (outputs:[ (Depth:{56[DepthFormat]/shadow::MapTexture) ]) ]
-              (Qt3DRender::QClearBuffers{51/<no_name>})
-                (Qt3DRender::QRenderStateSet{52/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
-    (Qt3DRender::QNoDraw{59/depth::NoDraw}) [D]
-      (Qt3DRender::QSubtreeEnabler{60/depth::SubtreeEnabler})
-        (Qt3DRender::QLayerFilter{62/<no_name>}) [ (AcceptAnyMatchingLayers:[ {61/depth::Layer} ]) ]
-          (Qt3DRender::QRenderTargetSelector{63/<no_name>}) [ (outputs:[ (Color0:{65[RGB8_UNorm]/depth::mColorTexture) ]) ]
-            (Qt3DRender::QRenderCapture{67/<no_name>})
-    (Qt3DRender::QNoDraw{80/ambient_occlusion::NoDraw})
-      (Qt3DRender::QSubtreeEnabler{81/ambient_occlusion::SubtreeEnabler}) [D]
-        (Qt3DRender::QRenderStateSet{84/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-          (Qt3DRender::QLayerFilter{87/<no_name>}) [ (AcceptAnyMatchingLayers:[ {82/ambient_occlusion::Layer(AO)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{91/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{89[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
-        (Qt3DRender::QRenderStateSet{114/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-          (Qt3DRender::QLayerFilter{117/<no_name>}) [ (AcceptAnyMatchingLayers:[ {83/ambient_occlusion::Layer(Blur)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{121/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{119[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
-    (Qt3DRender::QRenderTargetSelector{134/PostProcessingPass}) [D] [ (outputs:[ (Color0:{137[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{139[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
-      (Qt3DRender::QCameraSelector{140/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{44/shadow::LightCamera}) ]
-        (Qt3DRender::QLayerFilter{141/<no_name>}) [ (AcceptAnyMatchingLayers:[ {143/<no_name>} ]) ]
-          (Qt3DRender::QClearBuffers{142/<no_name>})
-      (Qt3DRender::QNoDraw{177/debug_texture::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{178/debug_texture::SubtreeEnabler}) [D]
-          (Qt3DRender::QLayerFilter{180/<no_name>}) [ (AcceptAnyMatchingLayers:[ {179/debug_texture::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{181/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-      (Qt3DRender::QCameraSelector{184/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-        (Qt3DRender::QLayerFilter{185/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mRubberBandsLayer} ]) ]
-          (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
-      (Qt3DRender::QNoDraw{190/Sub pass RenderCapture})
-        (Qt3DRender::QRenderCapture{191/<no_name>})
+(Qt3DRender::QRenderSurfaceSelector{9/<no_name>})
+  (Qt3DRender::QViewport{10/<no_name>})
+    (Qt3DRender::QNoDraw{11/forward::NoDraw}) [D]
+      (Qt3DRender::QSubtreeEnabler{12/forward::SubtreeEnabler})
+        (Qt3DRender::QCameraSelector{15/forward::CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+          (Qt3DRender::QLayerFilter{16/<no_name>}) [ (AcceptAnyMatchingLayers:[ {13/forward::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{17/forward::Clip Plane RenderStateSet}) [  ]
+              (Qt3DRender::QRenderTargetSelector{23/<no_name>}) [ (outputs:[ (Depth:{19[DepthFormat]/<no_name>), (Color0:{18[RGB8_UNorm]/<no_name>) ]) ]
+                (Qt3DRender::QLayerFilter{24/<no_name>}) [ (DiscardAnyMatchingLayers:[ {14/forward::TransparentLayer} ]) ]
+                  (Qt3DRender::QRenderStateSet{25/<no_name>}) [ (QDepthTest:Less), (QCullFace:Back) ]
+                    (Qt3DRender::QFrustumCulling{28/<no_name>})
+                      (Qt3DRender::QClearBuffers{29/<no_name>})
+                        (Qt3DRender::QDebugOverlay{42/<no_name>}) [D]
+                (Qt3DRender::QLayerFilter{30/<no_name>}) [ (AcceptAnyMatchingLayers:[ {14/forward::TransparentLayer} ]) ]
+                  (Qt3DRender::QSortPolicy{31/<no_name>})
+                    (Qt3DRender::QRenderStateSet{32/<no_name>}) [ (QDepthTest:Less), (QNoDepthMask), (QCullFace:NoCulling), (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                    (Qt3DRender::QRenderStateSet{38/<no_name>}) [ (QDepthTest:Less), (QColorMask:[ (red:false), (green:false), (blue:false), (alpha:false) ]), (QCullFace:NoCulling) ]
+    (Qt3DRender::QNoDraw{43/shadow::NoDraw})
+      (Qt3DRender::QSubtreeEnabler{44/shadow::SubtreeEnabler}) [D]
+        (Qt3DRender::QCameraSelector{49/shadow::CameraSelector}) [ (Qt3DRender::QCamera:{45/shadow::LightCamera}) ]
+          (Qt3DRender::QLayerFilter{50/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {48/shadow::Layer} ]) ]
+            (Qt3DRender::QRenderTargetSelector{51/<no_name>}) [ (outputs:[ (Depth:{57[DepthFormat]/shadow::MapTexture) ]) ]
+              (Qt3DRender::QClearBuffers{52/<no_name>})
+                (Qt3DRender::QRenderStateSet{53/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
+    (Qt3DRender::QNoDraw{60/depth::NoDraw}) [D]
+      (Qt3DRender::QSubtreeEnabler{61/depth::SubtreeEnabler})
+        (Qt3DRender::QLayerFilter{63/<no_name>}) [ (AcceptAnyMatchingLayers:[ {62/depth::Layer} ]) ]
+          (Qt3DRender::QRenderTargetSelector{64/<no_name>}) [ (outputs:[ (Color0:{66[RGB8_UNorm]/depth::mColorTexture) ]) ]
+            (Qt3DRender::QRenderCapture{68/<no_name>})
+    (Qt3DRender::QNoDraw{81/ambient_occlusion::NoDraw})
+      (Qt3DRender::QSubtreeEnabler{82/ambient_occlusion::SubtreeEnabler}) [D]
+        (Qt3DRender::QRenderStateSet{85/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{88/<no_name>}) [ (AcceptAnyMatchingLayers:[ {83/ambient_occlusion::Layer(AO)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{92/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{90[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
+        (Qt3DRender::QRenderStateSet{115/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{118/<no_name>}) [ (AcceptAnyMatchingLayers:[ {84/ambient_occlusion::Layer(Blur)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{122/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{120[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
+    (Qt3DRender::QRenderTargetSelector{135/PostProcessingPass}) [D] [ (outputs:[ (Color0:{138[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{140[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
+      (Qt3DRender::QCameraSelector{141/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{45/shadow::LightCamera}) ]
+        (Qt3DRender::QLayerFilter{142/<no_name>}) [ (AcceptAnyMatchingLayers:[ {144/<no_name>} ]) ]
+          (Qt3DRender::QClearBuffers{143/<no_name>})
+      (Qt3DRender::QNoDraw{178/debug_texture::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{179/debug_texture::SubtreeEnabler}) [D]
+          (Qt3DRender::QLayerFilter{181/<no_name>}) [ (AcceptAnyMatchingLayers:[ {180/debug_texture::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{182/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+      (Qt3DRender::QCameraSelector{185/highlightsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+        (Qt3DRender::QLayerFilter{186/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mHighlightsLayer} ]) ]
+          (Qt3DRender::QRenderStateSet{190/<no_name>}) [ (QDepthTest:LessOrEqual), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
+            (Qt3DRender::QClearBuffers{191/<no_name>})
+      (Qt3DRender::QCameraSelector{192/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+        (Qt3DRender::QLayerFilter{193/<no_name>}) [ (AcceptAnyMatchingLayers:[ {8/mRubberBandsLayer} ]) ]
+          (Qt3DRender::QRenderStateSet{196/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
+      (Qt3DRender::QNoDraw{198/Sub pass RenderCapture})
+        (Qt3DRender::QRenderCapture{199/<no_name>})

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
@@ -15,37 +15,37 @@
                   (Qt3DRender::QSortPolicy{30/<no_name>})
                     (Qt3DRender::QRenderStateSet{31/<no_name>}) [ (QDepthTest:Less), (QNoDepthMask), (QCullFace:NoCulling), (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
                     (Qt3DRender::QRenderStateSet{37/<no_name>}) [ (QDepthTest:Less), (QColorMask:[ (red:false), (green:false), (blue:false), (alpha:false) ]), (QCullFace:NoCulling) ]
-    (Qt3DRender::QCameraSelector{42/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-      (Qt3DRender::QLayerFilter{43/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mRubberBandsLayer} ]) ]
-        (Qt3DRender::QRenderStateSet{46/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
-          (Qt3DRender::QRenderTargetSelector{48/<no_name>}) [ (outputs:[ (Depth:{18[DepthFormat]/<no_name>), (Color0:{17[RGB8_UNorm]/<no_name>) ]) ]
-    (Qt3DRender::QNoDraw{49/shadow::NoDraw})
-      (Qt3DRender::QSubtreeEnabler{50/shadow::SubtreeEnabler}) [D]
-        (Qt3DRender::QCameraSelector{55/shadow::CameraSelector}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
-          (Qt3DRender::QLayerFilter{56/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {54/shadow::Layer} ]) ]
-            (Qt3DRender::QRenderTargetSelector{57/<no_name>}) [ (outputs:[ (Depth:{63[DepthFormat]/shadow::MapTexture) ]) ]
-              (Qt3DRender::QClearBuffers{58/<no_name>})
-                (Qt3DRender::QRenderStateSet{59/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
-    (Qt3DRender::QNoDraw{66/depth::NoDraw}) [D]
-      (Qt3DRender::QSubtreeEnabler{67/depth::SubtreeEnabler})
-        (Qt3DRender::QLayerFilter{69/<no_name>}) [ (AcceptAnyMatchingLayers:[ {68/depth::Layer} ]) ]
-          (Qt3DRender::QRenderTargetSelector{70/<no_name>}) [ (outputs:[ (Color0:{72[RGB8_UNorm]/depth::mColorTexture) ]) ]
-            (Qt3DRender::QRenderCapture{74/<no_name>})
-    (Qt3DRender::QNoDraw{87/ambient_occlusion::NoDraw})
-      (Qt3DRender::QSubtreeEnabler{88/ambient_occlusion::SubtreeEnabler}) [D]
-        (Qt3DRender::QRenderStateSet{91/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-          (Qt3DRender::QLayerFilter{94/<no_name>}) [ (AcceptAnyMatchingLayers:[ {89/ambient_occlusion::Layer(AO)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{98/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{96[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
-        (Qt3DRender::QRenderStateSet{121/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-          (Qt3DRender::QLayerFilter{124/<no_name>}) [ (AcceptAnyMatchingLayers:[ {90/ambient_occlusion::Layer(Blur)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{128/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{126[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
-    (Qt3DRender::QRenderTargetSelector{141/PostProcessingPass}) [D] [ (outputs:[ (Color0:{144[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{146[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
-      (Qt3DRender::QCameraSelector{147/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
-        (Qt3DRender::QLayerFilter{148/<no_name>}) [ (AcceptAnyMatchingLayers:[ {150/<no_name>} ]) ]
-          (Qt3DRender::QClearBuffers{149/<no_name>})
-      (Qt3DRender::QNoDraw{184/debug_texture::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{185/debug_texture::SubtreeEnabler}) [D]
-          (Qt3DRender::QLayerFilter{187/<no_name>}) [ (AcceptAnyMatchingLayers:[ {186/debug_texture::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+    (Qt3DRender::QNoDraw{42/shadow::NoDraw})
+      (Qt3DRender::QSubtreeEnabler{43/shadow::SubtreeEnabler}) [D]
+        (Qt3DRender::QCameraSelector{48/shadow::CameraSelector}) [ (Qt3DRender::QCamera:{44/shadow::LightCamera}) ]
+          (Qt3DRender::QLayerFilter{49/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {47/shadow::Layer} ]) ]
+            (Qt3DRender::QRenderTargetSelector{50/<no_name>}) [ (outputs:[ (Depth:{56[DepthFormat]/shadow::MapTexture) ]) ]
+              (Qt3DRender::QClearBuffers{51/<no_name>})
+                (Qt3DRender::QRenderStateSet{52/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
+    (Qt3DRender::QNoDraw{59/depth::NoDraw}) [D]
+      (Qt3DRender::QSubtreeEnabler{60/depth::SubtreeEnabler})
+        (Qt3DRender::QLayerFilter{62/<no_name>}) [ (AcceptAnyMatchingLayers:[ {61/depth::Layer} ]) ]
+          (Qt3DRender::QRenderTargetSelector{63/<no_name>}) [ (outputs:[ (Color0:{65[RGB8_UNorm]/depth::mColorTexture) ]) ]
+            (Qt3DRender::QRenderCapture{67/<no_name>})
+    (Qt3DRender::QNoDraw{80/ambient_occlusion::NoDraw})
+      (Qt3DRender::QSubtreeEnabler{81/ambient_occlusion::SubtreeEnabler}) [D]
+        (Qt3DRender::QRenderStateSet{84/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{87/<no_name>}) [ (AcceptAnyMatchingLayers:[ {82/ambient_occlusion::Layer(AO)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{91/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{89[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
+        (Qt3DRender::QRenderStateSet{114/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{117/<no_name>}) [ (AcceptAnyMatchingLayers:[ {83/ambient_occlusion::Layer(Blur)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{121/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{119[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
+    (Qt3DRender::QRenderTargetSelector{134/PostProcessingPass}) [D] [ (outputs:[ (Color0:{137[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{139[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
+      (Qt3DRender::QCameraSelector{140/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{44/shadow::LightCamera}) ]
+        (Qt3DRender::QLayerFilter{141/<no_name>}) [ (AcceptAnyMatchingLayers:[ {143/<no_name>} ]) ]
+          (Qt3DRender::QClearBuffers{142/<no_name>})
+      (Qt3DRender::QNoDraw{177/debug_texture::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{178/debug_texture::SubtreeEnabler}) [D]
+          (Qt3DRender::QLayerFilter{180/<no_name>}) [ (AcceptAnyMatchingLayers:[ {179/debug_texture::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{181/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+      (Qt3DRender::QCameraSelector{184/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+        (Qt3DRender::QLayerFilter{185/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mRubberBandsLayer} ]) ]
+          (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
+            (Qt3DRender::QRenderTargetSelector{190/<no_name>}) [ (outputs:[ (Depth:{18[DepthFormat]/<no_name>), (Color0:{17[RGB8_UNorm]/<no_name>) ]) ]
       (Qt3DRender::QNoDraw{191/Sub pass RenderCapture})
         (Qt3DRender::QRenderCapture{192/<no_name>})

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
@@ -1,50 +1,54 @@
-(Qt3DRender::QRenderSurfaceSelector{8/<no_name>})
-  (Qt3DRender::QViewport{9/<no_name>})
-    (Qt3DRender::QNoDraw{10/forward::NoDraw}) [D]
-      (Qt3DRender::QSubtreeEnabler{11/forward::SubtreeEnabler})
-        (Qt3DRender::QCameraSelector{14/forward::CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-          (Qt3DRender::QLayerFilter{15/<no_name>}) [ (AcceptAnyMatchingLayers:[ {12/forward::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{16/forward::Clip Plane RenderStateSet}) [  ]
-              (Qt3DRender::QRenderTargetSelector{22/<no_name>}) [ (outputs:[ (Depth:{18[DepthFormat]/<no_name>), (Color0:{17[RGB8_UNorm]/<no_name>) ]) ]
-                (Qt3DRender::QLayerFilter{23/<no_name>}) [ (DiscardAnyMatchingLayers:[ {13/forward::TransparentLayer} ]) ]
-                  (Qt3DRender::QRenderStateSet{24/<no_name>}) [ (QDepthTest:Less), (QCullFace:Back) ]
-                    (Qt3DRender::QFrustumCulling{27/<no_name>})
-                      (Qt3DRender::QClearBuffers{28/<no_name>})
-                        (Qt3DRender::QDebugOverlay{41/<no_name>}) [D]
-                (Qt3DRender::QLayerFilter{29/<no_name>}) [ (AcceptAnyMatchingLayers:[ {13/forward::TransparentLayer} ]) ]
-                  (Qt3DRender::QSortPolicy{30/<no_name>})
-                    (Qt3DRender::QRenderStateSet{31/<no_name>}) [ (QDepthTest:Less), (QNoDepthMask), (QCullFace:NoCulling), (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                    (Qt3DRender::QRenderStateSet{37/<no_name>}) [ (QDepthTest:Less), (QColorMask:[ (red:false), (green:false), (blue:false), (alpha:false) ]), (QCullFace:NoCulling) ]
-    (Qt3DRender::QNoDraw{42/shadow::NoDraw})
-      (Qt3DRender::QSubtreeEnabler{43/shadow::SubtreeEnabler}) [D]
-        (Qt3DRender::QCameraSelector{48/shadow::CameraSelector}) [ (Qt3DRender::QCamera:{44/shadow::LightCamera}) ]
-          (Qt3DRender::QLayerFilter{49/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {47/shadow::Layer} ]) ]
-            (Qt3DRender::QRenderTargetSelector{50/<no_name>}) [ (outputs:[ (Depth:{56[DepthFormat]/shadow::MapTexture) ]) ]
-              (Qt3DRender::QClearBuffers{51/<no_name>})
-                (Qt3DRender::QRenderStateSet{52/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
-    (Qt3DRender::QNoDraw{59/depth::NoDraw}) [D]
-      (Qt3DRender::QSubtreeEnabler{60/depth::SubtreeEnabler})
-        (Qt3DRender::QLayerFilter{62/<no_name>}) [ (AcceptAnyMatchingLayers:[ {61/depth::Layer} ]) ]
-          (Qt3DRender::QRenderTargetSelector{63/<no_name>}) [ (outputs:[ (Color0:{65[RGB8_UNorm]/depth::mColorTexture) ]) ]
-            (Qt3DRender::QRenderCapture{67/<no_name>})
-    (Qt3DRender::QNoDraw{80/ambient_occlusion::NoDraw}) [D]
-      (Qt3DRender::QSubtreeEnabler{81/ambient_occlusion::SubtreeEnabler})
-        (Qt3DRender::QRenderStateSet{84/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-          (Qt3DRender::QLayerFilter{87/<no_name>}) [ (AcceptAnyMatchingLayers:[ {82/ambient_occlusion::Layer(AO)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{91/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{89[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
-        (Qt3DRender::QRenderStateSet{114/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-          (Qt3DRender::QLayerFilter{117/<no_name>}) [ (AcceptAnyMatchingLayers:[ {83/ambient_occlusion::Layer(Blur)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{121/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{119[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
-    (Qt3DRender::QRenderTargetSelector{134/PostProcessingPass}) [D] [ (outputs:[ (Color0:{137[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{139[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
-      (Qt3DRender::QCameraSelector{140/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{44/shadow::LightCamera}) ]
-        (Qt3DRender::QLayerFilter{141/<no_name>}) [ (AcceptAnyMatchingLayers:[ {143/<no_name>} ]) ]
-          (Qt3DRender::QClearBuffers{142/<no_name>})
-      (Qt3DRender::QNoDraw{177/debug_texture::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{178/debug_texture::SubtreeEnabler}) [D]
-          (Qt3DRender::QLayerFilter{180/<no_name>}) [ (AcceptAnyMatchingLayers:[ {179/debug_texture::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{181/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-      (Qt3DRender::QCameraSelector{184/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-        (Qt3DRender::QLayerFilter{185/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mRubberBandsLayer} ]) ]
-          (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
-      (Qt3DRender::QNoDraw{190/Sub pass RenderCapture})
-        (Qt3DRender::QRenderCapture{191/<no_name>})
+(Qt3DRender::QRenderSurfaceSelector{9/<no_name>})
+  (Qt3DRender::QViewport{10/<no_name>})
+    (Qt3DRender::QNoDraw{11/forward::NoDraw}) [D]
+      (Qt3DRender::QSubtreeEnabler{12/forward::SubtreeEnabler})
+        (Qt3DRender::QCameraSelector{15/forward::CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+          (Qt3DRender::QLayerFilter{16/<no_name>}) [ (AcceptAnyMatchingLayers:[ {13/forward::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{17/forward::Clip Plane RenderStateSet}) [  ]
+              (Qt3DRender::QRenderTargetSelector{23/<no_name>}) [ (outputs:[ (Depth:{19[DepthFormat]/<no_name>), (Color0:{18[RGB8_UNorm]/<no_name>) ]) ]
+                (Qt3DRender::QLayerFilter{24/<no_name>}) [ (DiscardAnyMatchingLayers:[ {14/forward::TransparentLayer} ]) ]
+                  (Qt3DRender::QRenderStateSet{25/<no_name>}) [ (QDepthTest:Less), (QCullFace:Back) ]
+                    (Qt3DRender::QFrustumCulling{28/<no_name>})
+                      (Qt3DRender::QClearBuffers{29/<no_name>})
+                        (Qt3DRender::QDebugOverlay{42/<no_name>}) [D]
+                (Qt3DRender::QLayerFilter{30/<no_name>}) [ (AcceptAnyMatchingLayers:[ {14/forward::TransparentLayer} ]) ]
+                  (Qt3DRender::QSortPolicy{31/<no_name>})
+                    (Qt3DRender::QRenderStateSet{32/<no_name>}) [ (QDepthTest:Less), (QNoDepthMask), (QCullFace:NoCulling), (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                    (Qt3DRender::QRenderStateSet{38/<no_name>}) [ (QDepthTest:Less), (QColorMask:[ (red:false), (green:false), (blue:false), (alpha:false) ]), (QCullFace:NoCulling) ]
+    (Qt3DRender::QNoDraw{43/shadow::NoDraw})
+      (Qt3DRender::QSubtreeEnabler{44/shadow::SubtreeEnabler}) [D]
+        (Qt3DRender::QCameraSelector{49/shadow::CameraSelector}) [ (Qt3DRender::QCamera:{45/shadow::LightCamera}) ]
+          (Qt3DRender::QLayerFilter{50/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {48/shadow::Layer} ]) ]
+            (Qt3DRender::QRenderTargetSelector{51/<no_name>}) [ (outputs:[ (Depth:{57[DepthFormat]/shadow::MapTexture) ]) ]
+              (Qt3DRender::QClearBuffers{52/<no_name>})
+                (Qt3DRender::QRenderStateSet{53/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
+    (Qt3DRender::QNoDraw{60/depth::NoDraw}) [D]
+      (Qt3DRender::QSubtreeEnabler{61/depth::SubtreeEnabler})
+        (Qt3DRender::QLayerFilter{63/<no_name>}) [ (AcceptAnyMatchingLayers:[ {62/depth::Layer} ]) ]
+          (Qt3DRender::QRenderTargetSelector{64/<no_name>}) [ (outputs:[ (Color0:{66[RGB8_UNorm]/depth::mColorTexture) ]) ]
+            (Qt3DRender::QRenderCapture{68/<no_name>})
+    (Qt3DRender::QNoDraw{81/ambient_occlusion::NoDraw}) [D]
+      (Qt3DRender::QSubtreeEnabler{82/ambient_occlusion::SubtreeEnabler})
+        (Qt3DRender::QRenderStateSet{85/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{88/<no_name>}) [ (AcceptAnyMatchingLayers:[ {83/ambient_occlusion::Layer(AO)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{92/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{90[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
+        (Qt3DRender::QRenderStateSet{115/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{118/<no_name>}) [ (AcceptAnyMatchingLayers:[ {84/ambient_occlusion::Layer(Blur)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{122/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{120[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
+    (Qt3DRender::QRenderTargetSelector{135/PostProcessingPass}) [D] [ (outputs:[ (Color0:{138[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{140[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
+      (Qt3DRender::QCameraSelector{141/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{45/shadow::LightCamera}) ]
+        (Qt3DRender::QLayerFilter{142/<no_name>}) [ (AcceptAnyMatchingLayers:[ {144/<no_name>} ]) ]
+          (Qt3DRender::QClearBuffers{143/<no_name>})
+      (Qt3DRender::QNoDraw{178/debug_texture::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{179/debug_texture::SubtreeEnabler}) [D]
+          (Qt3DRender::QLayerFilter{181/<no_name>}) [ (AcceptAnyMatchingLayers:[ {180/debug_texture::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{182/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+      (Qt3DRender::QCameraSelector{185/highlightsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+        (Qt3DRender::QLayerFilter{186/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mHighlightsLayer} ]) ]
+          (Qt3DRender::QRenderStateSet{190/<no_name>}) [ (QDepthTest:LessOrEqual), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
+            (Qt3DRender::QClearBuffers{191/<no_name>})
+      (Qt3DRender::QCameraSelector{192/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+        (Qt3DRender::QLayerFilter{193/<no_name>}) [ (AcceptAnyMatchingLayers:[ {8/mRubberBandsLayer} ]) ]
+          (Qt3DRender::QRenderStateSet{196/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
+      (Qt3DRender::QNoDraw{198/Sub pass RenderCapture})
+        (Qt3DRender::QRenderCapture{199/<no_name>})

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
@@ -46,6 +46,5 @@
       (Qt3DRender::QCameraSelector{184/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
         (Qt3DRender::QLayerFilter{185/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mRubberBandsLayer} ]) ]
           (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
-            (Qt3DRender::QRenderTargetSelector{190/<no_name>}) [ (outputs:[ (Depth:{18[DepthFormat]/<no_name>), (Color0:{17[RGB8_UNorm]/<no_name>) ]) ]
-      (Qt3DRender::QNoDraw{191/Sub pass RenderCapture})
-        (Qt3DRender::QRenderCapture{192/<no_name>})
+      (Qt3DRender::QNoDraw{190/Sub pass RenderCapture})
+        (Qt3DRender::QRenderCapture{191/<no_name>})

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
@@ -15,37 +15,37 @@
                   (Qt3DRender::QSortPolicy{30/<no_name>})
                     (Qt3DRender::QRenderStateSet{31/<no_name>}) [ (QDepthTest:Less), (QNoDepthMask), (QCullFace:NoCulling), (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
                     (Qt3DRender::QRenderStateSet{37/<no_name>}) [ (QDepthTest:Less), (QColorMask:[ (red:false), (green:false), (blue:false), (alpha:false) ]), (QCullFace:NoCulling) ]
-    (Qt3DRender::QCameraSelector{42/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-      (Qt3DRender::QLayerFilter{43/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mRubberBandsLayer} ]) ]
-        (Qt3DRender::QRenderStateSet{46/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
-          (Qt3DRender::QRenderTargetSelector{48/<no_name>}) [ (outputs:[ (Depth:{18[DepthFormat]/<no_name>), (Color0:{17[RGB8_UNorm]/<no_name>) ]) ]
-    (Qt3DRender::QNoDraw{49/shadow::NoDraw})
-      (Qt3DRender::QSubtreeEnabler{50/shadow::SubtreeEnabler}) [D]
-        (Qt3DRender::QCameraSelector{55/shadow::CameraSelector}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
-          (Qt3DRender::QLayerFilter{56/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {54/shadow::Layer} ]) ]
-            (Qt3DRender::QRenderTargetSelector{57/<no_name>}) [ (outputs:[ (Depth:{63[DepthFormat]/shadow::MapTexture) ]) ]
-              (Qt3DRender::QClearBuffers{58/<no_name>})
-                (Qt3DRender::QRenderStateSet{59/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
-    (Qt3DRender::QNoDraw{66/depth::NoDraw}) [D]
-      (Qt3DRender::QSubtreeEnabler{67/depth::SubtreeEnabler})
-        (Qt3DRender::QLayerFilter{69/<no_name>}) [ (AcceptAnyMatchingLayers:[ {68/depth::Layer} ]) ]
-          (Qt3DRender::QRenderTargetSelector{70/<no_name>}) [ (outputs:[ (Color0:{72[RGB8_UNorm]/depth::mColorTexture) ]) ]
-            (Qt3DRender::QRenderCapture{74/<no_name>})
-    (Qt3DRender::QNoDraw{87/ambient_occlusion::NoDraw}) [D]
-      (Qt3DRender::QSubtreeEnabler{88/ambient_occlusion::SubtreeEnabler})
-        (Qt3DRender::QRenderStateSet{91/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-          (Qt3DRender::QLayerFilter{94/<no_name>}) [ (AcceptAnyMatchingLayers:[ {89/ambient_occlusion::Layer(AO)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{98/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{96[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
-        (Qt3DRender::QRenderStateSet{121/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-          (Qt3DRender::QLayerFilter{124/<no_name>}) [ (AcceptAnyMatchingLayers:[ {90/ambient_occlusion::Layer(Blur)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{128/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{126[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
-    (Qt3DRender::QRenderTargetSelector{141/PostProcessingPass}) [D] [ (outputs:[ (Color0:{144[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{146[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
-      (Qt3DRender::QCameraSelector{147/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{51/shadow::LightCamera}) ]
-        (Qt3DRender::QLayerFilter{148/<no_name>}) [ (AcceptAnyMatchingLayers:[ {150/<no_name>} ]) ]
-          (Qt3DRender::QClearBuffers{149/<no_name>})
-      (Qt3DRender::QNoDraw{184/debug_texture::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{185/debug_texture::SubtreeEnabler}) [D]
-          (Qt3DRender::QLayerFilter{187/<no_name>}) [ (AcceptAnyMatchingLayers:[ {186/debug_texture::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+    (Qt3DRender::QNoDraw{42/shadow::NoDraw})
+      (Qt3DRender::QSubtreeEnabler{43/shadow::SubtreeEnabler}) [D]
+        (Qt3DRender::QCameraSelector{48/shadow::CameraSelector}) [ (Qt3DRender::QCamera:{44/shadow::LightCamera}) ]
+          (Qt3DRender::QLayerFilter{49/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {47/shadow::Layer} ]) ]
+            (Qt3DRender::QRenderTargetSelector{50/<no_name>}) [ (outputs:[ (Depth:{56[DepthFormat]/shadow::MapTexture) ]) ]
+              (Qt3DRender::QClearBuffers{51/<no_name>})
+                (Qt3DRender::QRenderStateSet{52/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
+    (Qt3DRender::QNoDraw{59/depth::NoDraw}) [D]
+      (Qt3DRender::QSubtreeEnabler{60/depth::SubtreeEnabler})
+        (Qt3DRender::QLayerFilter{62/<no_name>}) [ (AcceptAnyMatchingLayers:[ {61/depth::Layer} ]) ]
+          (Qt3DRender::QRenderTargetSelector{63/<no_name>}) [ (outputs:[ (Color0:{65[RGB8_UNorm]/depth::mColorTexture) ]) ]
+            (Qt3DRender::QRenderCapture{67/<no_name>})
+    (Qt3DRender::QNoDraw{80/ambient_occlusion::NoDraw}) [D]
+      (Qt3DRender::QSubtreeEnabler{81/ambient_occlusion::SubtreeEnabler})
+        (Qt3DRender::QRenderStateSet{84/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{87/<no_name>}) [ (AcceptAnyMatchingLayers:[ {82/ambient_occlusion::Layer(AO)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{91/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{89[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
+        (Qt3DRender::QRenderStateSet{114/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+          (Qt3DRender::QLayerFilter{117/<no_name>}) [ (AcceptAnyMatchingLayers:[ {83/ambient_occlusion::Layer(Blur)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{121/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{119[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
+    (Qt3DRender::QRenderTargetSelector{134/PostProcessingPass}) [D] [ (outputs:[ (Color0:{137[RGB8_UNorm]/PostProcessingPass::ColorTarget), (Depth:{139[DepthFormat]/PostProcessingPass::DepthTarget) ]) ]
+      (Qt3DRender::QCameraSelector{140/Sub pass Postprocessing}) [ (Qt3DRender::QCamera:{44/shadow::LightCamera}) ]
+        (Qt3DRender::QLayerFilter{141/<no_name>}) [ (AcceptAnyMatchingLayers:[ {143/<no_name>} ]) ]
+          (Qt3DRender::QClearBuffers{142/<no_name>})
+      (Qt3DRender::QNoDraw{177/debug_texture::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{178/debug_texture::SubtreeEnabler}) [D]
+          (Qt3DRender::QLayerFilter{180/<no_name>}) [ (AcceptAnyMatchingLayers:[ {179/debug_texture::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{181/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+      (Qt3DRender::QCameraSelector{184/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+        (Qt3DRender::QLayerFilter{185/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mRubberBandsLayer} ]) ]
+          (Qt3DRender::QRenderStateSet{188/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
+            (Qt3DRender::QRenderTargetSelector{190/<no_name>}) [ (outputs:[ (Depth:{18[DepthFormat]/<no_name>), (Color0:{17[RGB8_UNorm]/<no_name>) ]) ]
       (Qt3DRender::QNoDraw{191/Sub pass RenderCapture})
         (Qt3DRender::QRenderCapture{192/<no_name>})


### PR DESCRIPTION
## Description

This PR adds support to highlight a 3D polygon feature in the 3D view. The change should work for any kind of vector features (points, lines and polygon). However, it only works for polygons at the moment because the ray tracing worflow only handles polygon geometries.

This support is added by introduced two new logics: 
- a factory to create a 3D entity from a vector feature and its 3d renderer. The existing symbol is replaced by a new symbol where the colors are changed. Each vector renderer needs to implements its own `create` method of the factory.
- a new pass in `QgsFramegraph` to draw the highlight entities after the forward view and before the rubberband pass. This ensures that the highlight entities are correctly displayed and that the rubberbands are still visible on top of the highlights.

Then the existing logic in `Qgs3DMapCanvas::highlightFeature` is extended to add support for vector layers by calling the factory.

## Demo

[qgis-3d-highlight-entities.webm](https://github.com/user-attachments/assets/6ca6cfc8-5ede-4cf7-87f2-6f0c42b8eae4)


**Funded by Stadt Frankfurt am Main**
