### PR TITLE
fix layout in the Legend tab of the vector layer properties dialog (fix #64319)

### DIFF
--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1445,18 +1445,18 @@
                </widget>
               </item>
               <item row="2" column="0">
-                <widget class="QGroupBox" name="mEnableMapTips">
-                 <property name="title">
-                  <string>Enable Map Tips</string>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
+               <widget class="QGroupBox" name="mEnableMapTips">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
+                </property>
+                <property name="title">
+                 <string>Enable Map Tips</string>
+                </property>
+                <property name="checkable">
+                 <bool>true</bool>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_35">
                  <item>
@@ -1614,14 +1614,14 @@
               </item>
               <item row="1" column="0">
                <widget class="QGroupBox" name="featuresSortOrderGroupBox">
-                <property name="title">
-                 <string>Sort Order</string>
-                </property>
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
+                </property>
+                <property name="title">
+                 <string>Sort Order</string>
                 </property>
                 <layout class="QGridLayout" name="featuresSortOrderLayout">
                  <item row="0" column="0">
@@ -1640,7 +1640,7 @@
                     <string>…</string>
                    </property>
                    <property name="arrowType">
-                    <enum>Qt::UpArrow</enum>
+                    <enum>Qt::ArrowType::UpArrow</enum>
                    </property>
                   </widget>
                  </item>
@@ -2276,6 +2276,19 @@
                   </item>
                  </layout>
                 </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
              </widget>


### PR DESCRIPTION
## Description

Add spacer to the Legend tab of the vector layer properties dialog to keep widgets nicely placed when all collapsible groupboxes are collapsed.

<img width="1272" height="1206" alt="image" src="https://github.com/user-attachments/assets/ba679fa9-2248-4cdc-a2b6-f101813d612c" />

Fixes #64319.