### PR TITLE
Rewrite customization code

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -26,6 +26,7 @@ set(QGIS_APP_SRCS
   qgsbookmarkeditordialog.cpp
   qgsclipboard.cpp
   qgscustomization.cpp
+  qgscustomizationdialog.cpp
   qgsdatumtransformtablewidget.cpp
   qgscontributorsmapcanvas.cpp
   qgsdevtoolspanelwidget.cpp

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1459,12 +1459,11 @@ int main( int argc, char *argv[] )
     customizationfile = profileFolder + QDir::separator() + u"QGIS"_s + QDir::separator() + u"QGISCUSTOMIZATION.xml"_s;
   }
 
-  auto customization = std::make_unique<QgsCustomization>( profileFolder + QDir::separator() + QStringLiteral( "QGIS" ) + QDir::separator() + QStringLiteral( "QGISCUSTOMIZATION.xml" ) );
+  auto customization = std::make_unique<QgsCustomization>( customizationfile );
   if ( !hasCustomization )
   {
     customization->setEnabled( false );
   }
-
 
   //set up splash screen
   QString splashPath( customization->splashPath() );

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -579,7 +579,7 @@ int main( int argc, char *argv[] )
 #endif
 
   bool myRestoreDefaultWindowState = false;
-  bool hasCustomization = true;
+  bool enableCustomization = true;
 
   QString dxfOutputFile;
   Qgis::FeatureSymbologyExport dxfSymbologyMode = Qgis::FeatureSymbologyExport::PerSymbolLayer;
@@ -680,7 +680,7 @@ int main( int argc, char *argv[] )
         }
         else if ( arg == "--nocustomization"_L1 || arg == "-C"_L1 )
         {
-          hasCustomization = false;
+          enableCustomization = false;
         }
         else if ( i + 1 < argc && ( arg == "--profile"_L1 ) )
         {
@@ -1460,7 +1460,7 @@ int main( int argc, char *argv[] )
   }
 
   auto customization = std::make_unique<QgsCustomization>( customizationfile );
-  if ( !hasCustomization )
+  if ( !enableCustomization )
   {
     customization->setEnabled( false );
   }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -579,7 +579,7 @@ int main( int argc, char *argv[] )
 #endif
 
   bool myRestoreDefaultWindowState = false;
-  bool myCustomization = true;
+  bool hasCustomization = true;
 
   QString dxfOutputFile;
   Qgis::FeatureSymbologyExport dxfSymbologyMode = Qgis::FeatureSymbologyExport::PerSymbolLayer;
@@ -680,7 +680,7 @@ int main( int argc, char *argv[] )
         }
         else if ( arg == "--nocustomization"_L1 || arg == "-C"_L1 )
         {
-          myCustomization = false;
+          hasCustomization = false;
         }
         else if ( i + 1 < argc && ( arg == "--profile"_L1 ) )
         {
@@ -926,13 +926,6 @@ int main( int argc, char *argv[] )
                    .toUtf8()
                    .constData();
     exit( 1 ); //exit for now until a version of qgis is capable of running non interactive
-  }
-
-  // GUI customization is enabled according to settings (loaded when instance is created)
-  // we force disabled here if --nocustomization argument is used
-  if ( !myCustomization )
-  {
-    QgsCustomization::instance()->setEnabled( false );
   }
 
   QCoreApplication::setOrganizationName( QgsApplication::QGIS_ORGANIZATION_NAME );
@@ -1313,26 +1306,6 @@ int main( int argc, char *argv[] )
   QgsApplication::setWindowIcon( QIcon( QgsApplication::appIconPath() ) );
 #endif
 
-  // TODO: use QgsSettings
-  QSettings *customizationsettings = nullptr;
-
-  if ( !customizationfile.isEmpty() )
-  {
-    // Using the customizationfile option always overrides the option and config path options.
-    QgsCustomization::instance()->setEnabled( true );
-  }
-  else
-  {
-    // Use the default file location
-    customizationfile = profileFolder + QDir::separator() + u"QGIS"_s + QDir::separator() + u"QGISCUSTOMIZATION3.ini"_s;
-  }
-
-  customizationsettings = new QSettings( customizationfile, QSettings::IniFormat );
-
-  // Load and set possible default customization, must be done after QgsApplication init and QgsSettings ( QCoreApplication ) init
-  QgsCustomization::instance()->setSettings( customizationsettings );
-  QgsCustomization::instance()->loadDefault();
-
 #ifdef Q_OS_MACOS
   if ( !getenv( "GDAL_DRIVER_PATH" ) )
   {
@@ -1480,8 +1453,21 @@ int main( int argc, char *argv[] )
     QgsApplication::setAuthDatabaseDirPath( authdbdirectory );
   }
 
+  if ( customizationfile.isEmpty() )
+  {
+    // Use the default file location
+    customizationfile = profileFolder + QDir::separator() + u"QGIS"_s + QDir::separator() + u"QGISCUSTOMIZATION.xml"_s;
+  }
+
+  auto customization = std::make_unique<QgsCustomization>( profileFolder + QDir::separator() + QStringLiteral( "QGIS" ) + QDir::separator() + QStringLiteral( "QGISCUSTOMIZATION.xml" ) );
+  if ( !hasCustomization )
+  {
+    customization->setEnabled( false );
+  }
+
+
   //set up splash screen
-  QString splashPath( QgsCustomization::instance()->splashPath() );
+  QString splashPath( customization->splashPath() );
   QPixmap pixmap( splashPath + u"splash.png"_s );
 
   if ( QScreen *screen = QGuiApplication::primaryScreen() )
@@ -1555,11 +1541,7 @@ int main( int argc, char *argv[] )
 
   QgisApp *qgis = new QgisApp( mypSplash, qgisAppOptions, rootProfileFolder, profileName ); // "QgisApp" used to find canonical instance
   qgis->setObjectName( u"QgisApp"_s );
-
-  QgsApplication::connect(
-    &myApp, &QgsApplication::preNotify,
-    QgsCustomization::instance(), &QgsCustomization::preNotify
-  );
+  qgis->setCustomization( std::move( customization ) );
 
   /////////////////////////////////////////////////////////////////////
   // Load a project file if one was specified

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5703,9 +5703,9 @@ void QgisApp::setCustomization( std::unique_ptr<QgsCustomization> customization 
   mCustomization->setQgisApp( this );
 }
 
-const std::unique_ptr<QgsCustomization> &QgisApp::customization() const
+QgsCustomization *QgisApp::customization() const
 {
-  return mCustomization;
+  return mCustomization.get();
 }
 
 QString QgisApp::crsAndFormatAdjustedLayerUri( const QString &uri, const QStringList &supportedCrs, const QStringList &supportedFormats ) const

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5701,8 +5701,11 @@ void QgisApp::setCustomization( std::unique_ptr<QgsCustomization> customization 
 {
   mCustomization = std::move( customization );
   mCustomization->setQgisApp( this );
+}
 
-  mCustomizationDialog.reset();
+const std::unique_ptr<QgsCustomization> &QgisApp::customization() const
+{
+  return mCustomization;
 }
 
 QString QgisApp::crsAndFormatAdjustedLayerUri( const QString &uri, const QStringList &supportedCrs, const QStringList &supportedFormats ) const
@@ -12629,7 +12632,7 @@ void QgisApp::customize()
 
   if ( !mCustomizationDialog )
   {
-    mCustomizationDialog.reset( new QgsCustomizationDialog( mCustomization.get(), this ) );
+    mCustomizationDialog.reset( new QgsCustomizationDialog( this ) );
   }
 
   mCustomizationDialog->show();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -989,9 +989,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void setCustomization( std::unique_ptr<QgsCustomization> customization );
 
     /**
-     * Returns customization
+     * Returns customization. Ownership is not transferred.
      */
-    const std::unique_ptr<QgsCustomization> &customization() const;
+    QgsCustomization *customization() const;
 
   public slots:
     //! save current vector layer
@@ -1364,12 +1364,24 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     */
     void refreshActionFeatureAction();
 
+    /**
+     * Returns menu allowing to show/hide application dock widgets
+     */
     QMenu *panelMenu() { return mPanelMenu; }
 
+    /**
+     * Returns menu allowing to show/hide application tool bars
+     */
     QMenu *toolBarMenu() { return mToolbarMenu; }
 
+    /**
+     * Returns browser widget
+     */
     QgsBrowserDockWidget *browserWidget() { return mBrowserWidget; }
 
+    /**
+     * Returns second instance of the same browser widget
+     */
     QgsBrowserDockWidget *browserWidget2() { return mBrowserWidget2; }
 
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -983,7 +983,15 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     QString getVersionString();
 
+    /**
+     * Sets customization
+     */
     void setCustomization( std::unique_ptr<QgsCustomization> customization );
+
+    /**
+     * Returns customization
+     */
+    const std::unique_ptr<QgsCustomization> &customization() const;
 
   public slots:
     //! save current vector layer

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -181,13 +181,13 @@ class QgsCustomizationDialog;
 #include "qgsmaptoolselect.h"
 #include "qgsmasterlayoutinterface.h"
 #include "qgsmimedatautils.h"
-#include "qobjectuniqueptr.h"
 #include "qgsoptionsutils.h"
 #include "qgsoptionswidgetfactory.h"
 #include "qgspointxy.h"
 #include "qgsrasterminmaxorigin.h"
 #include "qgsrecentprojectsitemsmodel.h"
 #include "qgsvectorlayersaveasdialog.h"
+#include "qobjectuniqueptr.h"
 
 #include <QAbstractSocket>
 #include <QDateTime>

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -165,6 +165,8 @@ class QgsAppGpsSettingsMenu;
 class Qgs3DMapScene;
 class Qgs3DMapCanvas;
 class QgsAppCanvasFiltering;
+class QgsCustomization;
+class QgsCustomizationDialog;
 
 #include "qgsconfig.h"
 #include "ui_qgisapp.h"
@@ -179,6 +181,7 @@ class QgsAppCanvasFiltering;
 #include "qgsmaptoolselect.h"
 #include "qgsmasterlayoutinterface.h"
 #include "qgsmimedatautils.h"
+#include "qobjectuniqueptr.h"
 #include "qgsoptionsutils.h"
 #include "qgsoptionswidgetfactory.h"
 #include "qgspointxy.h"
@@ -980,6 +983,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     QString getVersionString();
 
+    void setCustomization( std::unique_ptr<QgsCustomization> customization );
+
   public slots:
     //! save current vector layer
     QString saveAsFile( QgsMapLayer *layer = nullptr, bool onlySelected = false, bool defaultToAddToMap = true );
@@ -1352,6 +1357,13 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void refreshActionFeatureAction();
 
     QMenu *panelMenu() { return mPanelMenu; }
+
+    QMenu *toolBarMenu() { return mToolbarMenu; }
+
+    QgsBrowserDockWidget *browserWidget() { return mBrowserWidget; }
+
+    QgsBrowserDockWidget *browserWidget2() { return mBrowserWidget2; }
+
 
     void renameView();
 
@@ -2848,6 +2860,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     int mFreezeCount = 0;
 
     QgsAbout *mAboutDialog = nullptr;
+    std::unique_ptr<QgsCustomization> mCustomization;
+    QObjectUniquePtr<QgsCustomizationDialog> mCustomizationDialog;
 
     friend class QgsCanvasRefreshBlocker;
     friend class QgsMapToolsDigitizingTechniqueManager;
@@ -2855,6 +2869,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     friend class TestQgisAppPython;
     friend class TestQgisApp;
     friend class TestQgsProjectExpressions;
+    friend class TestQgsCustomization;
     friend class QgisAppInterface;
     friend class QgsAppScreenShots;
 };

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -242,7 +242,7 @@ qsizetype QgsCustomization::QgsActionItem::qActionIndex() const
   return mQActionIndex;
 }
 
-std::unique_ptr<QgsCustomization::QgsActionItem> QgsCustomization::QgsActionItem::cloneSameType( QgsCustomization::QgsItem *parent ) const
+std::unique_ptr<QgsCustomization::QgsActionItem> QgsCustomization::QgsActionItem::cloneActionItem( QgsCustomization::QgsItem *parent ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsActionItem>( parent );
   clone->copyItemAttributes( this );
@@ -277,7 +277,7 @@ QgsCustomization::QgsMenuItem::QgsMenuItem( const QString &name, const QString &
   : QgsActionItem( name, title, parent )
 {}
 
-std::unique_ptr<QgsCustomization::QgsMenuItem> QgsCustomization::QgsMenuItem::cloneSameType( QgsCustomization::QgsItem *parent ) const
+std::unique_ptr<QgsCustomization::QgsMenuItem> QgsCustomization::QgsMenuItem::cloneMenuItem( QgsCustomization::QgsItem *parent ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsMenuItem>( parent );
   clone->copyItemAttributes( this );
@@ -318,7 +318,7 @@ bool QgsCustomization::QgsToolBarItem::wasVisible() const
   return mWasVisible;
 }
 
-std::unique_ptr<QgsCustomization::QgsToolBarItem> QgsCustomization::QgsToolBarItem::cloneSameType( QgsCustomization::QgsItem *parent ) const
+std::unique_ptr<QgsCustomization::QgsToolBarItem> QgsCustomization::QgsToolBarItem::cloneToolBarItem( QgsCustomization::QgsItem *parent ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsToolBarItem>( parent );
   clone->copyItemAttributes( this );
@@ -358,7 +358,7 @@ QgsCustomization::QgsToolBarsItem::QgsToolBarsItem()
   setTitle( QObject::tr( "ToolBars" ) );
 }
 
-std::unique_ptr<QgsCustomization::QgsToolBarsItem> QgsCustomization::QgsToolBarsItem::cloneSameType( QgsCustomization::QgsItem * ) const
+std::unique_ptr<QgsCustomization::QgsToolBarsItem> QgsCustomization::QgsToolBarsItem::cloneToolBarsItem( QgsCustomization::QgsItem * ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsToolBarsItem>();
   clone->copyItemAttributes( this );
@@ -387,7 +387,7 @@ QgsCustomization::QgsMenusItem::QgsMenusItem()
   setTitle( QObject::tr( "Menus" ) );
 }
 
-std::unique_ptr<QgsCustomization::QgsMenusItem> QgsCustomization::QgsMenusItem::cloneSameType( QgsCustomization::QgsItem * ) const
+std::unique_ptr<QgsCustomization::QgsMenusItem> QgsCustomization::QgsMenusItem::cloneMenusItem( QgsCustomization::QgsItem * ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsMenusItem>();
   clone->copyItemAttributes( this );
@@ -443,7 +443,7 @@ bool QgsCustomization::QgsDockItem::wasVisible() const
   return mWasVisible;
 }
 
-std::unique_ptr<QgsCustomization::QgsDockItem> QgsCustomization::QgsDockItem::cloneSameType( QgsCustomization::QgsItem *parent ) const
+std::unique_ptr<QgsCustomization::QgsDockItem> QgsCustomization::QgsDockItem::cloneDockItem( QgsCustomization::QgsItem *parent ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsDockItem>( parent );
   clone->copyItemAttributes( this );
@@ -460,7 +460,7 @@ QgsCustomization::QgsDocksItem::QgsDocksItem()
   setTitle( QObject::tr( "Docks" ) );
 }
 
-std::unique_ptr<QgsCustomization::QgsDocksItem> QgsCustomization::QgsDocksItem::cloneSameType( QgsCustomization::QgsItem * ) const
+std::unique_ptr<QgsCustomization::QgsDocksItem> QgsCustomization::QgsDocksItem::cloneDocksItem( QgsCustomization::QgsItem * ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsDocksItem>();
   clone->copyItemAttributes( this );
@@ -492,7 +492,7 @@ QgsCustomization::QgsBrowserElementItem::QgsBrowserElementItem( const QString &n
 {
 }
 
-std::unique_ptr<QgsCustomization::QgsBrowserElementItem> QgsCustomization::QgsBrowserElementItem::cloneSameType( QgsCustomization::QgsItem *parent ) const
+std::unique_ptr<QgsCustomization::QgsBrowserElementItem> QgsCustomization::QgsBrowserElementItem::cloneBrowserElementItem( QgsCustomization::QgsItem *parent ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsBrowserElementItem>( parent );
   clone->copyItemAttributes( this );
@@ -514,7 +514,7 @@ QgsCustomization::QgsBrowserElementsItem::QgsBrowserElementsItem()
   setTitle( QObject::tr( "Browser" ) );
 }
 
-std::unique_ptr<QgsCustomization::QgsBrowserElementsItem> QgsCustomization::QgsBrowserElementsItem::cloneSameType( QgsCustomization::QgsItem * ) const
+std::unique_ptr<QgsCustomization::QgsBrowserElementsItem> QgsCustomization::QgsBrowserElementsItem::cloneBrowserElementsItem( QgsCustomization::QgsItem * ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsBrowserElementsItem>();
   clone->copyItemAttributes( this );
@@ -543,7 +543,7 @@ QgsCustomization::QgsStatusBarWidgetItem::QgsStatusBarWidgetItem( QgsItem *paren
 QgsCustomization::QgsStatusBarWidgetItem::QgsStatusBarWidgetItem( const QString &name, QgsItem *parent )
   : QgsItem( name, QString(), parent ) {}
 
-std::unique_ptr<QgsCustomization::QgsStatusBarWidgetItem> QgsCustomization::QgsStatusBarWidgetItem::cloneSameType( QgsCustomization::QgsItem *parent ) const
+std::unique_ptr<QgsCustomization::QgsStatusBarWidgetItem> QgsCustomization::QgsStatusBarWidgetItem::cloneStatusBarWidgetItem( QgsCustomization::QgsItem *parent ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsStatusBarWidgetItem>( parent );
   clone->copyItemAttributes( this );
@@ -564,7 +564,7 @@ QgsCustomization::QgsStatusBarWidgetsItem::QgsStatusBarWidgetsItem()
   setTitle( QObject::tr( "Status Bar" ) );
 }
 
-std::unique_ptr<QgsCustomization::QgsStatusBarWidgetsItem> QgsCustomization::QgsStatusBarWidgetsItem::cloneSameType( QgsCustomization::QgsItem * ) const
+std::unique_ptr<QgsCustomization::QgsStatusBarWidgetsItem> QgsCustomization::QgsStatusBarWidgetsItem::cloneStatusBarWidgetsItem( QgsCustomization::QgsItem * ) const
 {
   auto clone = std::make_unique<QgsCustomization::QgsStatusBarWidgetsItem>();
   clone->copyItemAttributes( this );
@@ -630,11 +630,11 @@ QgsCustomization &QgsCustomization::operator=( const QgsCustomization &other )
   if ( this == &other )
     return *this;
 
-  mBrowserItems = other.mBrowserItems->cloneSameType();
-  mDocks = other.mDocks->cloneSameType();
-  mMenus = other.mMenus->cloneSameType();
-  mStatusBarWidgets = other.mStatusBarWidgets->cloneSameType();
-  mToolBars = other.mToolBars->cloneSameType();
+  mBrowserItems = other.mBrowserItems->cloneBrowserElementsItem();
+  mDocks = other.mDocks->cloneDocksItem();
+  mMenus = other.mMenus->cloneMenusItem();
+  mStatusBarWidgets = other.mStatusBarWidgets->cloneStatusBarWidgetsItem();
+  mToolBars = other.mToolBars->cloneToolBarsItem();
   mEnabled = other.mEnabled;
   mSplashPath = other.mSplashPath;
   mQgisApp = other.mQgisApp;

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -545,7 +545,7 @@ void QgsCustomization::addActions( Item *item, QWidget *widget ) const
   if ( !item || !widget )
     return;
 
-  for ( QgsCustomization::QWidgetIterator::Infos it : QgsCustomization::QWidgetIterator( widget ) )
+  for ( QgsCustomization::QWidgetIterator::Info it : QgsCustomization::QWidgetIterator( widget ) )
   {
     if ( it.name.isEmpty() )
       continue;
@@ -770,7 +770,7 @@ QgsCustomization::QWidgetIterator::QWidgetIterator( QWidget *widget )
 QgsCustomization::QWidgetIterator::Iterator::Iterator( QWidget *ptr, qsizetype idx )
   : idx( idx ), mActions( ptr->actions() ) {}
 
-QgsCustomization::QWidgetIterator::Infos QgsCustomization::QWidgetIterator::Iterator::operator*() const
+QgsCustomization::QWidgetIterator::Info QgsCustomization::QWidgetIterator::Iterator::operator*() const
 {
   if ( idx < 0 || idx >= mActions.count() )
     throw std::out_of_range {
@@ -778,7 +778,7 @@ QgsCustomization::QWidgetIterator::Infos QgsCustomization::QWidgetIterator::Iter
     };
 
   QAction *act = mActions.at( idx );
-  Infos infos;
+  Info infos;
 
   // submenu
   if ( QMenu *menu = act->menu() )
@@ -835,7 +835,7 @@ void QgsCustomization::updateActionVisibility( QgsCustomization::Item *item, QWi
     return;
 
   QSet<QgsCustomization::Item *> treatedChildItems;
-  for ( QgsCustomization::QWidgetIterator::Infos it : QgsCustomization::QWidgetIterator( widget ) )
+  for ( QgsCustomization::QWidgetIterator::Info it : QgsCustomization::QWidgetIterator( widget ) )
   {
     if ( QgsCustomization::Item *childItem = item->getChild( it.name ) )
     {

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -915,16 +915,16 @@ QgsCustomization::QgsQActionsIterator::QgsQActionsIterator( QWidget *widget )
   : mWidget( widget ) {};
 
 QgsCustomization::QgsQActionsIterator::Iterator::Iterator( QWidget *ptr, qsizetype idx )
-  : idx( idx ), mActions( ptr->actions() ) {}
+  : mIdx( idx ), mActions( ptr->actions() ) {}
 
 QgsCustomization::QgsQActionsIterator::Info QgsCustomization::QgsQActionsIterator::Iterator::operator*() const
 {
-  if ( idx < 0 || idx >= mActions.count() )
+  if ( mIdx < 0 || mIdx >= mActions.count() )
     throw std::out_of_range {
       "Action iterator out of range"
     };
 
-  QAction *act = mActions.at( idx );
+  QAction *act = mActions.at( mIdx );
   Info infos;
 
   // submenu
@@ -949,21 +949,22 @@ QgsCustomization::QgsQActionsIterator::Info QgsCustomization::QgsQActionsIterato
   }
 
   infos.action = act;
-  infos.index = idx;
+  infos.index = mIdx;
   return infos;
 }
 
 QgsCustomization::QgsQActionsIterator::Iterator &QgsCustomization::QgsQActionsIterator::Iterator::operator++()
 {
-  idx++;
-  while ( idx < mActions.count() && mActions.at( idx )->isSeparator() )
-    idx++;
+  mIdx++;
+  while ( mIdx < mActions.count() && mActions.at( mIdx )->isSeparator() )
+    mIdx++;
   return *this;
 }
 
 bool QgsCustomization::QgsQActionsIterator::Iterator::operator==( const Iterator &b ) const
 {
-  return idx == b.idx && ( idx < 0 || idx >= mActions.count() || mActions.at( idx ) == b.mActions.at( idx ) );
+  Q_ASSERT( mIdx < 0 || mIdx >= mActions.count() || mActions.at( mIdx ) == b.mActions.at( mIdx ) );
+  return mIdx == b.mIdx;
 }
 
 QgsCustomization::QgsQActionsIterator::Iterator QgsCustomization::QgsQActionsIterator::begin()

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -1079,7 +1079,7 @@ QString QgsCustomization::writeFile( const QString &fileName ) const
   QDomDocument doc( u"Customization"_s );
   QDomElement root = doc.createElement( u"Customization"_s );
   root.setAttribute( u"version"_s, QStringLiteral( CUSTOMIZATION_CURRENT_VERSION ) );
-  root.setAttribute( u"enabled"_s, mEnabled );
+  root.setAttribute( u"enabled"_s, ( mEnabled ? "true" : "false" ) );
 
   if ( !mSplashPath.isEmpty() )
     root.setAttribute( u"splashPath"_s, mSplashPath );

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -154,8 +154,8 @@ unsigned long QgsCustomization::Item::childrenCount() const
 void QgsCustomization::Item::writeXml( QDomDocument &doc, QDomElement &parent ) const
 {
   QDomElement itemElem = doc.createElement( xmlTag() );
-  itemElem.setAttribute( QStringLiteral( "name" ), mName );
-  itemElem.setAttribute( QStringLiteral( "visible" ), mVisible );
+  itemElem.setAttribute( u"name"_s, mName );
+  itemElem.setAttribute( u"visible"_s, mVisible );
 
   for ( const std::unique_ptr<Item> &childItem : mChildItemList )
   {
@@ -167,8 +167,8 @@ void QgsCustomization::Item::writeXml( QDomDocument &doc, QDomElement &parent ) 
 
 QString QgsCustomization::Item::readXml( const QDomElement &elem )
 {
-  mVisible = elem.attribute( QStringLiteral( "visible" ) ) == QStringLiteral( "1" );
-  mName = elem.attribute( QStringLiteral( "name" ) );
+  mVisible = elem.attribute( u"visible"_s ) == "1"_L1;
+  mName = elem.attribute( u"name"_s );
   if ( mName.isEmpty() )
   {
     return QObject::tr( "Invalid XML file : empty name for tag '%1'" ).arg( elem.tagName() );
@@ -181,7 +181,7 @@ QString QgsCustomization::Item::readXml( const QDomElement &elem )
     {
       return QObject::tr( "Invalid XML file : failed to create an item '%1(%2)' as a child of item '%3(%4)'" )
         .arg( childElem.tagName() )
-        .arg( childElem.attribute( QStringLiteral( "name" ) ) )
+        .arg( childElem.attribute( u"name"_s ) )
         .arg( xmlTag() )
         .arg( mName );
     }
@@ -223,7 +223,7 @@ QgsCustomization::Action::Action( const QString &name, const QString &title, Ite
 
 QString QgsCustomization::Action::xmlTag() const
 {
-  return QStringLiteral( "Action" );
+  return u"Action"_s;
 };
 
 void QgsCustomization::Action::setQAction( QAction *qaction, qsizetype qActionIndex )
@@ -252,7 +252,7 @@ std::unique_ptr<QgsCustomization::Item> QgsCustomization::Action::clone( QgsCust
 std::unique_ptr<QgsCustomization::Item> QgsCustomization::Action::createChildItem( const QDomElement &childElem )
 {
   // Action with a menu can have child action
-  if ( childElem.tagName() == QStringLiteral( "Action" ) )
+  if ( childElem.tagName() == "Action"_L1 )
     return std::make_unique<Action>( this );
   else
     return nullptr;
@@ -286,14 +286,14 @@ std::unique_ptr<QgsCustomization::Item> QgsCustomization::Menu::clone( QgsCustom
 
 QString QgsCustomization::Menu::xmlTag() const
 {
-  return QStringLiteral( "Menu" );
+  return u"Menu"_s;
 };
 
 std::unique_ptr<QgsCustomization::Item> QgsCustomization::Menu::createChildItem( const QDomElement &childElem )
 {
-  if ( childElem.tagName() == QStringLiteral( "Action" ) )
+  if ( childElem.tagName() == "Action"_L1 )
     return std::make_unique<QgsCustomization::Action>( this );
-  else if ( childElem.tagName() == QStringLiteral( "Menu" ) )
+  else if ( childElem.tagName() == "Menu"_L1 )
     return std::make_unique<QgsCustomization::Menu>( this );
   else
     return nullptr;
@@ -327,14 +327,14 @@ std::unique_ptr<QgsCustomization::Item> QgsCustomization::ToolBar::clone( QgsCus
 
 QString QgsCustomization::ToolBar::xmlTag() const
 {
-  return QStringLiteral( "ToolBar" );
+  return u"ToolBar"_s;
 };
 
 std::unique_ptr<QgsCustomization::Item> QgsCustomization::ToolBar::createChildItem( const QDomElement &childElem )
 {
-  if ( childElem.tagName() == QStringLiteral( "Action" ) )
+  if ( childElem.tagName() == "Action"_L1 )
     return std::make_unique<Action>( this );
-  if ( childElem.tagName() == QStringLiteral( "Menu" ) )
+  if ( childElem.tagName() == "Menu"_L1 )
     return std::make_unique<Menu>( this );
   else
     return nullptr;
@@ -367,12 +367,12 @@ std::unique_ptr<QgsCustomization::Item> QgsCustomization::ToolBars::clone( QgsCu
 
 QString QgsCustomization::ToolBars::xmlTag() const
 {
-  return QStringLiteral( "ToolBars" );
+  return u"ToolBars"_s;
 };
 
 std::unique_ptr<QgsCustomization::Item> QgsCustomization::ToolBars::createChildItem( const QDomElement &childElem )
 {
-  if ( childElem.tagName() == QStringLiteral( "ToolBar" ) )
+  if ( childElem.tagName() == "ToolBar"_L1 )
     return std::make_unique<ToolBar>( this );
   else
     return nullptr;
@@ -396,12 +396,12 @@ std::unique_ptr<QgsCustomization::Item> QgsCustomization::Menus::clone( QgsCusto
 
 QString QgsCustomization::Menus::xmlTag() const
 {
-  return QStringLiteral( "Menus" );
+  return u"Menus"_s;
 };
 
 std::unique_ptr<QgsCustomization::Item> QgsCustomization::Menus::createChildItem( const QDomElement &childElem )
 {
-  if ( childElem.tagName() == QStringLiteral( "Menu" ) )
+  if ( childElem.tagName() == "Menu"_L1 )
     return std::make_unique<Menu>( this );
   else
     return nullptr;
@@ -421,7 +421,7 @@ QgsCustomization::Dock::Dock( const QString &name, const QString &title, Item *p
 
 QString QgsCustomization::Dock::xmlTag() const
 {
-  return QStringLiteral( "Dock" );
+  return u"Dock"_s;
 };
 
 void QgsCustomization::Dock::copyItemAttributes( const Item *other )
@@ -469,12 +469,12 @@ std::unique_ptr<QgsCustomization::Item> QgsCustomization::Docks::clone( QgsCusto
 
 QString QgsCustomization::Docks::xmlTag() const
 {
-  return QStringLiteral( "Docks" );
+  return u"Docks"_s;
 };
 
 std::unique_ptr<QgsCustomization::Item> QgsCustomization::Docks::createChildItem( const QDomElement &childElem )
 {
-  if ( childElem.tagName() == QStringLiteral( "Dock" ) )
+  if ( childElem.tagName() == "Dock"_L1 )
     return std::make_unique<Dock>( this );
   else
     return nullptr;
@@ -502,7 +502,7 @@ std::unique_ptr<QgsCustomization::Item> QgsCustomization::BrowserItem::clone( Qg
 
 QString QgsCustomization::BrowserItem::xmlTag() const
 {
-  return QStringLiteral( "BrowserItem" );
+  return u"BrowserItem"_s;
 };
 
 ////////////////
@@ -523,12 +523,12 @@ std::unique_ptr<QgsCustomization::Item> QgsCustomization::BrowserItems::clone( Q
 
 QString QgsCustomization::BrowserItems::xmlTag() const
 {
-  return QStringLiteral( "BrowserItems" );
+  return u"BrowserItems"_s;
 };
 
 std::unique_ptr<QgsCustomization::Item> QgsCustomization::BrowserItems::createChildItem( const QDomElement &childElem )
 {
-  if ( childElem.tagName() == QStringLiteral( "BrowserItem" ) )
+  if ( childElem.tagName() == "BrowserItem"_L1 )
     return std::make_unique<BrowserItem>( this );
   else
     return nullptr;
@@ -552,7 +552,7 @@ std::unique_ptr<QgsCustomization::Item> QgsCustomization::StatusBarWidget::clone
 
 QString QgsCustomization::StatusBarWidget::xmlTag() const
 {
-  return QStringLiteral( "StatusBarWidget" );
+  return u"StatusBarWidget"_s;
 };
 
 ////////////////
@@ -573,12 +573,12 @@ std::unique_ptr<QgsCustomization::Item> QgsCustomization::StatusBarWidgets::clon
 
 QString QgsCustomization::StatusBarWidgets::xmlTag() const
 {
-  return QStringLiteral( "StatusBarWidgets" );
+  return u"StatusBarWidgets"_s;
 };
 
 std::unique_ptr<QgsCustomization::Item> QgsCustomization::StatusBarWidgets::createChildItem( const QDomElement &childElem )
 {
-  if ( childElem.tagName() == QStringLiteral( "StatusBarWidget" ) )
+  if ( childElem.tagName() == "StatusBarWidget"_L1 )
     return std::make_unique<StatusBarWidget>( this );
   else
     return nullptr;
@@ -720,7 +720,7 @@ void QgsCustomization::addActions( Item *item, QWidget *widget ) const
       }
       else
       {
-        std::unique_ptr<Action> action = std::make_unique<Action>( it.name, it.title, item );
+        auto action = std::make_unique<Action>( it.name, it.title, item );
         item->addItem( std::move( action ) );
       }
 
@@ -751,7 +751,7 @@ void QgsCustomization::loadApplicationToolBars()
     ToolBar *t = mToolBars->getChild<ToolBar>( name );
     if ( !t )
     {
-      std::unique_ptr<ToolBar> toolBar = std::make_unique<ToolBar>( tb->objectName(), tb->windowTitle(), mToolBars.get() );
+      auto toolBar = std::make_unique<ToolBar>( tb->objectName(), tb->windowTitle(), mToolBars.get() );
       mToolBars->addItem( std::move( toolBar ) );
       t = mToolBars->lastChild<ToolBar>();
     }
@@ -795,7 +795,7 @@ void QgsCustomization::loadApplicationDocks()
     Dock *d = mDocks->getChild<Dock>( name );
     if ( !d )
     {
-      std::unique_ptr<Dock> dock = std::make_unique<Dock>( name, dw->windowTitle(), mDocks.get() );
+      auto dock = std::make_unique<Dock>( name, dw->windowTitle(), mDocks.get() );
       mDocks->addItem( std::move( dock ) );
       d = mDocks->lastChild<Dock>();
     }
@@ -810,16 +810,16 @@ void QgsCustomization::loadApplicationBrowserItems()
   {
     mBrowserItems = std::make_unique<BrowserItems>();
     const QList<QPair<QString, QString>> staticItems = {
-      { QStringLiteral( "special:Home" ), QObject::tr( "Home Folder" ) },
-      { QStringLiteral( "special:ProjectHome" ), QObject::tr( "Project Home Folder" ) },
-      { QStringLiteral( "special:Favorites" ), QObject::tr( "Favorites Folder" ) },
-      { QStringLiteral( "special:Drives" ), QObject::tr( "Drive Folders (e.g. C:\\)" ) },
-      { QStringLiteral( "special:Volumes" ), QObject::tr( "Volume Folder (MacOS only)" ) }
+      { u"special:Home"_s, QObject::tr( "Home Folder" ) },
+      { u"special:ProjectHome"_s, QObject::tr( "Project Home Folder" ) },
+      { u"special:Favorites"_s, QObject::tr( "Favorites Folder" ) },
+      { u"special:Drives"_s, QObject::tr( "Drive Folders (e.g. C:\\)" ) },
+      { u"special:Volumes"_s, QObject::tr( "Volume Folder (MacOS only)" ) }
     };
 
     for ( QPair<QString, QString> staticItem : staticItems )
     {
-      std::unique_ptr<BrowserItem> browserItem = std::make_unique<BrowserItem>( staticItem.first, staticItem.second, mBrowserItems.get() );
+      auto browserItem = std::make_unique<BrowserItem>( staticItem.first, staticItem.second, mBrowserItems.get() );
       mBrowserItems->addItem( std::move( browserItem ) );
     }
   }
@@ -833,7 +833,7 @@ void QgsCustomization::loadApplicationBrowserItems()
     {
       if ( !mBrowserItems->getChild<BrowserItem>( name ) )
       {
-        std::unique_ptr<BrowserItem> browserItem = std::make_unique<BrowserItem>( name, QObject::tr( "Data Item Provider: %1" ).arg( name ), mBrowserItems.get() );
+        auto browserItem = std::make_unique<BrowserItem>( name, QObject::tr( "Data Item Provider: %1" ).arg( name ), mBrowserItems.get() );
         mBrowserItems->addItem( std::move( browserItem ) );
       }
     }
@@ -861,7 +861,7 @@ void QgsCustomization::loadApplicationStatusBarWidgets()
     StatusBarWidget *s = mStatusBarWidgets->getChild<StatusBarWidget>( name );
     if ( !s )
     {
-      std::unique_ptr<StatusBarWidget> statusBarWidget = std::make_unique<StatusBarWidget>( name, mStatusBarWidgets.get() );
+      auto statusBarWidget = std::make_unique<StatusBarWidget>( name, mStatusBarWidgets.get() );
       mStatusBarWidgets->addItem( std::move( statusBarWidget ) );
     }
   }
@@ -1013,7 +1013,7 @@ void QgsCustomization::updateActionVisibility( QgsCustomization::Item *item, QWi
     Action *action = dynamic_cast<Action *>( childItem.get() );
     if ( !action )
     {
-      QgsDebugError( QStringLiteral( "Invalid child type, Action expected" ) );
+      QgsDebugError( u"Invalid child type, Action expected"_s );
       continue;
     }
 
@@ -1081,13 +1081,13 @@ void QgsCustomization::applyToToolBars() const
 
 QString QgsCustomization::writeXML( const QString &fileName ) const
 {
-  QDomDocument doc( QStringLiteral( "Customization" ) );
-  QDomElement root = doc.createElement( QStringLiteral( "Customization" ) );
-  root.setAttribute( QStringLiteral( "version" ), QStringLiteral( CUSTOMIZATION_CURRENT_VERSION ) );
-  root.setAttribute( QStringLiteral( "enabled" ), mEnabled );
+  QDomDocument doc( u"Customization"_s );
+  QDomElement root = doc.createElement( u"Customization"_s );
+  root.setAttribute( u"version"_s, QStringLiteral( CUSTOMIZATION_CURRENT_VERSION ) );
+  root.setAttribute( u"enabled"_s, mEnabled );
 
   if ( !mSplashPath.isEmpty() )
-    root.setAttribute( QStringLiteral( "splashPath" ), mSplashPath );
+    root.setAttribute( u"splashPath"_s, mSplashPath );
 
   doc.appendChild( root );
 
@@ -1125,7 +1125,7 @@ QString QgsCustomization::writeFile( const QString &filePath ) const
 
 QString QgsCustomization::readXml( const QString &fileName )
 {
-  QDomDocument doc( QStringLiteral( "customization" ) );
+  QDomDocument doc( u"customization"_s );
   QFile f( fileName );
   if ( !f.open( QFile::ReadOnly ) )
   {
@@ -1139,31 +1139,31 @@ QString QgsCustomization::readXml( const QString &fileName )
   f.close();
 
   QDomElement docEl = doc.documentElement();
-  if ( docEl.tagName() != QLatin1String( "Customization" ) )
+  if ( docEl.tagName() != "Customization"_L1 )
   {
     return QObject::tr( "Invalid XML file : root tag must be 'Customization'" );
   }
 
-  mEnabled = docEl.attribute( QStringLiteral( "enabled" ) ) == QStringLiteral( "1" );
-  if ( docEl.hasAttribute( QStringLiteral( "splashPath" ) ) )
-    mSplashPath = docEl.attribute( QStringLiteral( "splashPath" ) );
+  mEnabled = docEl.attribute( u"enabled"_s ) == "1"_L1;
+  if ( docEl.hasAttribute( u"splashPath"_s ) )
+    mSplashPath = docEl.attribute( u"splashPath"_s );
 
-  const QString version = docEl.attribute( QStringLiteral( "version" ) );
-  if ( version != QLatin1String( CUSTOMIZATION_CURRENT_VERSION ) && version != QLatin1String( "1" ) )
+  const QString version = docEl.attribute( u"version"_s );
+  if ( version != QLatin1String( CUSTOMIZATION_CURRENT_VERSION ) && version != "1"_L1 )
   {
     return QObject::tr( "Invalid XML file : incorrect version" );
   }
 
   mBrowserItems = std::make_unique<BrowserItems>();
-  mBrowserItems->readXml( docEl.firstChildElement( QStringLiteral( "BrowserItems" ) ) );
+  mBrowserItems->readXml( docEl.firstChildElement( u"BrowserItems"_s ) );
   mDocks = std::make_unique<Docks>();
-  mDocks->readXml( docEl.firstChildElement( QStringLiteral( "Docks" ) ) );
+  mDocks->readXml( docEl.firstChildElement( u"Docks"_s ) );
   mMenus = std::make_unique<Menus>();
-  mMenus->readXml( docEl.firstChildElement( QStringLiteral( "Menus" ) ) );
+  mMenus->readXml( docEl.firstChildElement( u"Menus"_s ) );
   mStatusBarWidgets = std::make_unique<StatusBarWidgets>();
-  mStatusBarWidgets->readXml( docEl.firstChildElement( QStringLiteral( "StatusBarWidgets" ) ) );
+  mStatusBarWidgets->readXml( docEl.firstChildElement( u"StatusBarWidgets"_s ) );
   mToolBars = std::make_unique<ToolBars>();
-  mToolBars->readXml( docEl.firstChildElement( QStringLiteral( "ToolBars" ) ) );
+  mToolBars->readXml( docEl.firstChildElement( u"ToolBars"_s ) );
 
   return QString();
 }
@@ -1184,7 +1184,7 @@ void QgsCustomization::loadOldIniFile( const QString &filePath )
   mEnabled = QSettings().value( "UI/Customization/enabled", false ).toBool();
 
   QSettings settings( filePath, QSettings::IniFormat );
-  mSplashPath = settings.value( QStringLiteral( "/Customization/splashpath" ), QgsApplication::splashPath() ).toString();
+  mSplashPath = settings.value( u"/Customization/splashpath"_s, QgsApplication::splashPath() ).toString();
 
   mBrowserItems = std::make_unique<BrowserItems>();
   mDocks = std::make_unique<Docks>();
@@ -1193,7 +1193,7 @@ void QgsCustomization::loadOldIniFile( const QString &filePath )
   mToolBars = std::make_unique<ToolBars>();
 
   // menus
-  settings.beginGroup( QStringLiteral( "Customization/Menus" ) );
+  settings.beginGroup( u"Customization/Menus"_s );
 
   for ( const QString &key : settings.allKeys() )
   {
@@ -1224,7 +1224,7 @@ void QgsCustomization::loadOldIniFile( const QString &filePath )
   settings.endGroup();
 
   // toolbars
-  settings.beginGroup( QStringLiteral( "Customization/Toolbars" ) );
+  settings.beginGroup( u"Customization/Toolbars"_s );
 
   for ( const QString &key : settings.allKeys() )
   {
@@ -1255,7 +1255,7 @@ void QgsCustomization::loadOldIniFile( const QString &filePath )
   settings.endGroup();
 
   // dock widgets
-  settings.beginGroup( QStringLiteral( "Customization/Docks" ) );
+  settings.beginGroup( u"Customization/Docks"_s );
   for ( const QString &key : settings.allKeys() )
   {
     Item *rootItem = docks().get();
@@ -1280,7 +1280,7 @@ void QgsCustomization::loadOldIniFile( const QString &filePath )
   settings.endGroup();
 
   statusBarWidgets()->setVisible( settings.value( "Customization/StatusBar", true ).toBool() );
-  settings.beginGroup( QStringLiteral( "Customization/StatusBar" ) );
+  settings.beginGroup( u"Customization/StatusBar"_s );
 
   for ( const QString &key : settings.allKeys() )
   {
@@ -1305,7 +1305,7 @@ void QgsCustomization::loadOldIniFile( const QString &filePath )
 
   settings.endGroup();
 
-  settings.beginGroup( QStringLiteral( "Customization/Browser" ) );
+  settings.beginGroup( u"Customization/Browser"_s );
 
   for ( const QString &key : settings.allKeys() )
   {

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -128,6 +128,11 @@ const std::vector<std::unique_ptr<QgsCustomization::Item>> &QgsCustomization::It
   return mChildItemList;
 }
 
+QgsCustomization::Item *QgsCustomization::Item::lastChild() const
+{
+  return mChildItemList.back().get();
+}
+
 
 long QgsCustomization::Item::indexOf( Item *item ) const
 {
@@ -565,8 +570,8 @@ void QgsCustomization::addActions( Item *item, QWidget *widget ) const
       {
         // remove '&' which are used to mark shortcut key
         std::unique_ptr<Action> action = std::make_unique<Action>( it.name, it.title, item );
-        childItem = action.get();
         item->addItem( std::move( action ) );
+        childItem = item->lastChild<Action>();
       }
     }
 
@@ -595,8 +600,8 @@ void QgsCustomization::loadApplicationToolBars()
     if ( !t )
     {
       std::unique_ptr<ToolBar> toolBar = std::make_unique<ToolBar>( tb->objectName(), tb->windowTitle(), mToolBars.get() );
-      t = toolBar.get();
       mToolBars->addItem( std::move( toolBar ) );
+      t = mToolBars->lastChild<ToolBar>();
     }
 
     addActions( t, tb );
@@ -639,8 +644,8 @@ void QgsCustomization::loadApplicationDocks()
     if ( !d )
     {
       std::unique_ptr<Dock> dock = std::make_unique<Dock>( name, dw->windowTitle(), mDocks.get() );
-      d = dock.get();
       mDocks->addItem( std::move( dock ) );
+      d = mDocks->lastChild<Dock>();
     }
 
     d->setWasVisible( dw->isVisible() );

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -289,9 +289,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsActionItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsActionItem> cloneActionItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneActionItem( parent ); };
 
       protected:
         QString xmlTag() const override;
@@ -327,9 +327,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsMenuItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsMenuItem> cloneMenuItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneMenuItem( parent ); };
 
       protected:
         QString xmlTag() const override;
@@ -371,9 +371,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsToolBarItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsToolBarItem> cloneToolBarItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneToolBarItem( parent ); };
 
       protected:
         QString xmlTag() const override;
@@ -399,9 +399,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsToolBarsItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsToolBarsItem> cloneToolBarsItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneToolBarsItem( parent ); };
 
       protected:
         QString xmlTag() const override;
@@ -422,9 +422,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsMenusItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsMenusItem> cloneMenusItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneMenusItem( parent ); };
 
       protected:
         QString xmlTag() const override;
@@ -466,9 +466,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsDockItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsDockItem> cloneDockItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneDockItem( parent ); };
 
       protected:
         QString xmlTag() const override;
@@ -493,9 +493,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsDocksItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsDocksItem> cloneDocksItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneDocksItem( parent ); };
 
       protected:
         QString xmlTag() const override;
@@ -525,9 +525,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsBrowserElementItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsBrowserElementItem> cloneBrowserElementItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneBrowserElementItem( parent ); };
 
       protected:
         QString xmlTag() const override;
@@ -547,9 +547,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsBrowserElementsItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsBrowserElementsItem> cloneBrowserElementsItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneBrowserElementsItem( parent ); };
 
       protected:
         QString xmlTag() const override;
@@ -578,9 +578,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsStatusBarWidgetItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsStatusBarWidgetItem> cloneStatusBarWidgetItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneStatusBarWidgetItem( parent ); };
 
       protected:
         QString xmlTag() const override;
@@ -600,9 +600,9 @@ class APP_EXPORT QgsCustomization
         /**
          * Returns this item clone with \a parent as parent item
          */
-        std::unique_ptr<QgsCustomization::QgsStatusBarWidgetsItem> cloneSameType( QgsCustomization::QgsItem *parent = nullptr ) const;
+        std::unique_ptr<QgsCustomization::QgsStatusBarWidgetsItem> cloneStatusBarWidgetsItem( QgsCustomization::QgsItem *parent = nullptr ) const;
 
-        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneSameType( parent ); };
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneStatusBarWidgetsItem( parent ); };
 
       protected:
         QString xmlTag() const override;

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -154,6 +154,17 @@ class APP_EXPORT QgsCustomization
         Item *getChild( const QString &name ) const;
 
         /**
+         * Return last child item
+         */
+        template<class T>
+        T *lastChild() const { return dynamic_cast<T *>( lastChild() ); }
+
+        /**
+         * Return last child item
+         */
+        Item *lastChild() const;
+
+        /**
          * Returns list of child items
          */
         const std::vector<std::unique_ptr<Item>> &childItemList() const;

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -232,14 +232,14 @@ class APP_EXPORT QgsCustomization
         virtual void copyItemAttributes( const QgsCustomization::Item *other );
 
         QString mName;
+
+      private:
         QString mTitle;
         bool mVisible = true;
         Item *mParent = nullptr;
+        QIcon mIcon;
         QMap<QString, Item *> mChildItems; // for name quick access
         std::vector<std::unique_ptr<Item>> mChildItemList;
-
-      private:
-        QIcon mIcon;
     };
 
     /**
@@ -283,16 +283,7 @@ class APP_EXPORT QgsCustomization
       protected:
         QString xmlTag() const override;
         std::unique_ptr<Item> createChildItem( const QDomElement &childElem ) override;
-
-        void copyItemAttributes( const Item *other ) override
-        {
-          Item::copyItemAttributes( other );
-          if ( const Action *action = dynamic_cast<const Action *>( other ) )
-          {
-            mQAction = action->mQAction;
-            mQActionIndex = action->mQActionIndex;
-          }
-        }
+        void copyItemAttributes( const Item *other ) override;
 
       private:
         QAction *mQAction = nullptr;

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -758,7 +758,7 @@ class APP_EXPORT QgsCustomization
             bool operator==( const Iterator &b ) const;
 
           private:
-            qsizetype idx;
+            qsizetype mIdx;
             QList<QAction *> mActions;
         };
 

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -640,9 +640,9 @@ class APP_EXPORT QgsCustomization
         QWidgetIterator( QWidget *widget );
 
         /**
-         * Iterator informations
+         * Iterator information
          */
-        struct Infos
+        struct Info
         {
             QWidget *widget = nullptr;
             QAction *action = nullptr;
@@ -657,7 +657,7 @@ class APP_EXPORT QgsCustomization
         {
             Iterator( QWidget *ptr, qsizetype idx );
 
-            Infos operator*() const;
+            Info operator*() const;
             Iterator &operator++();
             bool operator==( const Iterator &b ) const;
 
@@ -676,7 +676,7 @@ class APP_EXPORT QgsCustomization
     };
 
     /**
-     * Backward compatiblity method to import old QGIS3 ini file
+     * Backward compatibility method to import old QGIS3 ini file
      */
     void loadOldIniFile( const QString &filePath );
 

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -554,10 +554,10 @@ class APP_EXPORT QgsCustomization
      */
     QString writeFile( const QString &filePath ) const;
 
-  protected:
+  private:
     /**
-   * Add action items as children of \a item for each \a widget actions
-   */
+     * Add action items as children of \a item for each \a widget actions
+     */
     void addActions( Item *item, QWidget *widget ) const;
 
     /**
@@ -626,10 +626,9 @@ class APP_EXPORT QgsCustomization
      */
     QString readXml( const QString &fileName );
 
-  private:
     /**
-   * Helper class to iterate over widget actions
-   */
+     * Helper class to iterate over widget actions
+     */
     class QWidgetIterator
     {
       public:

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -17,163 +17,675 @@
 #ifndef QGSCUSTOMIZATION_H
 #define QGSCUSTOMIZATION_H
 
-#include "ui_qgscustomizationdialogbase.h"
-
 #include "qgis_app.h"
-#include "qgshelp.h"
 
-#include <QDialog>
-#include <QDomNode>
+#include <QDomDocument>
+#include <QIcon>
 
-class QString;
 class QWidget;
-class QTreeWidgetItem;
-class QEvent;
-class QMouseEvent;
-class QSettings;
 class QgsBrowserDockWidget;
+class QDockWidget;
+class QgisApp;
+class QAction;
 
-class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCustomizationDialogBase
+/**
+ * Customization is now read from an XML file so we can later keep track of
+ * action order in menus and tool bars. This XML file is read on a tree
+ * model where every node is an Item. Item is then inherited by any
+ * customizable widget item.
+
+ * read() methods reads the XML file into the model. load() update the
+ * model with the different graphical element and apply() apply the model
+ * to the QGIS main window and the 2 browser widgets.
+ */
+class APP_EXPORT QgsCustomization
 {
-    Q_OBJECT
   public:
-    QgsCustomizationDialog( QWidget *parent, QSettings *settings );
+    /**
+   * Constructor
+   * \param customizationFile file path of the customization. this one used
+   * when calling read() and write()
+   */
+    QgsCustomization( const QString &customizationFile );
 
-    // get item by path
-    QTreeWidgetItem *item( const QString &path, QTreeWidgetItem *widgetItem = nullptr );
+    /**
+     * Destructor
+     */
+    ~QgsCustomization();
 
-    //
+    /**
+     * Set QGIS main window \a qgisApp
+     * Customization model is updated according to main window menus, toolbars, dock widgets ..
+     */
+    void setQgisApp( QgisApp *qgisApp );
 
-    // return current item state for given path
-    bool itemChecked( const QString &path );
-    // set item state for given path
-    void setItemChecked( const QString &path, bool on );
+    /**
+     * Returns TRUE if the customization is currently enabled. If disabled, the customization is not
+     * applied on the application
+     * \see setEnabled()
+     */
+    bool isEnabled() const;
 
-    // recursively save tree item to settings
-    void itemToSettings( const QString &path, QTreeWidgetItem *item, QSettings *settings );
-    // recursively save settings to tree items
-    void settingsToItem( const QString &path, QTreeWidgetItem *item, QSettings *settings );
+    /**
+     * Sets \a enabled state
+     * If disabled, the customization is not applied on the application
+     * \see isEnabled()
+     */
+    void setEnabled( bool enabled );
 
-    // save current tree to settings
-    void treeToSettings( QSettings *settings );
-
-    // restore current tree from settings
-    void settingsToTree( QSettings *settings );
-
-    // switch widget item in tree
-    bool switchWidget( QWidget *widget, QMouseEvent *event );
-
-    // Get path of the widget
-    QString widgetPath( QWidget *widget, const QString &path = QString() );
-
-    void setCatch( bool on );
-    bool catchOn();
-
-  private slots:
-    //void on_btnQgisUser_clicked();
-
-    // Save to settings
-    void ok();
-    void apply();
-
-    void cancel();
-
-    void showHelp();
-
-    // Reset values from settings
-    void reset();
-
-    // Save to settings to file
-    void actionSave_triggered( bool checked );
-
-    // Load settings from file
-    void actionLoad_triggered( bool checked );
-
-    void actionExpandAll_triggered( bool checked );
-    void actionCollapseAll_triggered( bool checked );
-    void actionSelectAll_triggered( bool checked );
-
-    void enableCustomization( bool checked );
-    bool filterItems( const QString &text );
-
-  private:
-    void init();
-    QTreeWidgetItem *createTreeItemWidgets();
-    QTreeWidgetItem *readWidgetsXmlNode( const QDomNode &node );
-    QAction *findAction( QToolButton *toolbutton );
-
-    QString mLastDirSettingsName;
-    QSettings *mSettings = nullptr;
-    QList<QPointer< QWidget > > mSelectedWidgets;
-
-  protected:
-    QMap<QTreeWidgetItem *, bool> mTreeInitialExpand;
-    QMap<QTreeWidgetItem *, bool> mTreeInitialVisible;
-};
-
-class APP_EXPORT QgsCustomization : public QObject
-{
-    Q_OBJECT
-
-  public:
-    enum Status
-    {
-      NotSet = 0,
-      User = 1,   // Set by user
-      Default = 2 // Default customization loaded and set
-    };
-    Q_ENUM( Status )
-
-    //! Returns the instance pointer, creating the object on the first call
-    static QgsCustomization *instance();
-
-    void openDialog( QWidget *parent );
-    static void customizeWidget( QWidget *widget, QEvent *event, QSettings *settings );
-    static void customizeWidget( const QString &path, QWidget *widget, QSettings *settings );
-    static void removeFromLayout( QLayout *layout, QWidget *widget );
-
-    void updateBrowserWidget( QgsBrowserDockWidget *model );
-    void updateMainWindow( QMenu *toolBarMenu, QMenu *panelMenu );
-
-    // make sure to enable/disable before creating QgisApp in order to get it customized (or not)
-    void setEnabled( bool enabled ) { mEnabled = enabled; }
-    bool isEnabled() const { return mEnabled; }
-
-    void setSettings( QSettings *settings ) { mSettings = settings; }
-
-    // Returns the path to the splash screen
+    /**
+     * Returns path to the splash screen
+     */
     QString splashPath() const;
 
-    // Loads and sets default customization
-    void loadDefault();
+    /**
+     * \brief Represents an item tha can be customized in the application
+     */
+    class Item
+    {
+      public:
+        /**
+         * Constructor
+         * \param parent parent Item
+         */
+        Item( Item *parent = nullptr );
 
-    QString statusPath() const { return mStatusPath; }
+        /**
+         * Constructor
+         * \param name name identifier
+         * \param parent parent Item
+         */
+        Item( const QString &name, const QString &title, Item *parent = nullptr );
 
-  public slots:
-    void preNotify( QObject *receiver, QEvent *event, bool *done );
+        /**
+         * Destructor
+         */
+        virtual ~Item();
+
+        /**
+         * Returns name
+         */
+        const QString &name() const;
+
+        /**
+         * Returns title
+         */
+        const QString &title() const;
+
+        /**
+         * Sets \a title
+         */
+        void setTitle( const QString &title );
+
+        /**
+         * Returns Item's parent
+         */
+        Item *parent() const;
+
+        /**
+         * Returns TRUE if the item is visible
+         */
+        bool isVisible() const;
+
+        /**
+         * Sets item visibility to \a isVisible
+         */
+        void setVisible( bool isVisible );
+
+        /**
+         * Adds child item \a item
+         */
+        void addItem( std::unique_ptr<Item> item );
+
+        /**
+         * Return child item at \a index position
+         */
+        Item *getChild( int index ) const;
+
+        /**
+         * Returns child item with has the name \a name, nullptr if not found
+         */
+        template<class T>
+        T *getChild( const QString &name ) const { return dynamic_cast<T *>( getChild( name ) ); }
+
+        /**
+         * Returns child item with has the name \a name, nullptr if not found
+         */
+        Item *getChild( const QString &name ) const;
+
+        /**
+         * Returns list of child items
+         */
+        const std::vector<std::unique_ptr<Item>> &childItemList() const;
+
+        /**
+         * Returns \a item position in child item list, -1 if it doesn't exist
+         */
+        long indexOf( Item *item ) const;
+
+        /**
+         * Returns children count
+         */
+        unsigned long childrenCount() const;
+
+        /**
+         * Sets \a icon
+         */
+        void setIcon( const QIcon &icon );
+
+        /**
+         * Returns icon
+         */
+        virtual QIcon icon() const;
+
+        /**
+         * Writes XML element to document \a doc as a child of the \a parent element
+         */
+        void writeXml( QDomDocument &doc, QDomElement &parent ) const;
+
+        /**
+         * Reads XML information from element \a elem.
+         * Returns error string or an empty string if no error occurred
+         */
+        QString readXml( const QDomElement &elem );
+
+      protected:
+        /**
+         * Returns XML tag
+         */
+        virtual QString xmlTag() const = 0;
+
+        /**
+         * Creates child item from \a childElem element
+         */
+        virtual std::unique_ptr<Item> createChildItem( const QDomElement &childElem );
+
+        QString mName;
+        QString mTitle;
+        bool mVisible = true;
+        Item *mParent = nullptr;
+        QMap<QString, Item *> mChildItems; // for name quick access
+        std::vector<std::unique_ptr<Item>> mChildItemList;
+
+      private:
+        QIcon mIcon;
+    };
+
+    /**
+     * \brief Represents an action
+     */
+    class Action : public Item
+    {
+      public:
+        /**
+         * Constructor
+         * \param parent parent Item
+         */
+        Action( Item *parent );
+
+        /**
+         * Constructor
+         * \param name name identifier
+         * \param title title
+         * \param parent parent Item
+         */
+        Action( const QString &name, const QString &title, Item *parent );
+
+        /**
+         * Associated QAction \a qaction and its index \a actionIndex in the widget holding the action
+         * (Menu, WidgetAction). Used to restore it at the right position if previously removed
+         */
+        void setQAction( QAction *qaction, qsizetype actionIndex );
+
+        /**
+         * Returns associated QAction
+         */
+        QAction *qAction() const;
+
+        /**
+         * Returns actionIndex in the widget holding the action
+         */
+        qsizetype qActionIndex() const;
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<Item> createChildItem( const QDomElement &childElem ) override;
+
+      private:
+        QAction *mQAction = nullptr;
+        qsizetype mQActionIndex = -1;
+    };
+
+    /**
+     * Represent a Menu
+     * Inherits from Action because QMenu are stored within a QAction and we want to keep
+     * track of the menu associated action
+     */
+    class Menu : public Action
+    {
+      public:
+        /**
+         * Constructor
+         * \param parent parent Item
+         */
+        Menu( Item *parent );
+        /**
+         * Constructor
+         * \param name name identifier
+         * \param title title
+         * \param parent parent Item
+         */
+        Menu( const QString &name, const QString &title, Item *parent );
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<Item> createChildItem( const QDomElement &childElem ) override;
+
+      private:
+        QIcon mIcon;
+    };
+
+    /**
+     * Represents a toolbar
+     */
+    class ToolBar : public Item
+    {
+      public:
+        /**
+         * Constructor
+         * \param parent parent Item
+         */
+        ToolBar( Item *parent );
+
+        /**
+         * Constructor
+         * \param name name identifier
+         * \param title title
+         * \param parent parent Item
+         */
+        ToolBar( const QString &name, const QString &title, Item *parent );
+
+        /**
+         * Sets original dock widget visible state
+         * \see wasVisible()
+         */
+        void setWasVisible( const bool &wasVisible );
+
+        /**
+         * Returns original dock widget visible state
+         * \see setWasVisible()
+         */
+        bool wasVisible() const;
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<Item> createChildItem( const QDomElement &childElem ) override;
+
+      private:
+        // used to backup the original visibility state when we change visibility state
+        bool mWasVisible = false;
+    };
+
+    /**
+     * Root item for all ToolBar item
+     */
+    class ToolBars : public Item
+    {
+      public:
+        /**
+         * Constructor
+         */
+        ToolBars();
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<Item> createChildItem( const QDomElement &childElem ) override;
+    };
+
+    /**
+     * Root item for all Menus item
+     */
+    class Menus : public Item
+    {
+      public:
+        /**
+         * Constructor
+         */
+        Menus();
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<Item> createChildItem( const QDomElement &childElem ) override;
+    };
+
+    /**
+     * Represent a Dock
+     */
+    class Dock : public Item
+    {
+      public:
+        /**
+         * Constructor
+         * \param parent parent Item
+         */
+        Dock( Item *parent );
+
+        /**
+         * Constructor
+         * \param name name identifier
+         * \param title title
+         * \param parent parent Item
+         */
+        Dock( const QString &name, const QString &title, Item *parent );
+
+        /**
+         * Sets original dock widget visible state
+         * \see wasVisible()
+         */
+        void setWasVisible( const bool &wasVisible );
+
+        /**
+         * Returns original dock widget visible state
+         * \see setWasVisible()
+         */
+        bool wasVisible() const;
+
+      protected:
+        QString xmlTag() const override;
+        // used to backup the original visibility state when we change visibility state
+        bool mWasVisible = false;
+    };
+
+    /**
+     * Root item for all dock items
+     */
+    class Docks : public Item
+    {
+      public:
+        /**
+         * Constructor
+         */
+        Docks();
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<Item> createChildItem( const QDomElement &childElem ) override;
+    };
+
+    /**
+     * Represent a QgsBrowserDockWidget item
+     */
+    class BrowserItem : public Item
+    {
+      public:
+        /**
+         * Constructor
+         * \param parent parent Item
+         */
+        BrowserItem( Item *parent );
+
+        /**
+         * Constructor
+         * \param name name identifier
+         * \param title title
+         * \param parent parent Item
+         */
+        BrowserItem( const QString &name, const QString &title, Item *parent );
+
+      protected:
+        QString xmlTag() const override;
+    };
+
+    /**
+     * Root item for all browser items
+     */
+    class BrowserItems : public Item
+    {
+      public:
+        /**
+         * Constructor
+         */
+        BrowserItems();
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<Item> createChildItem( const QDomElement &childElem ) override;
+    };
+
+    /**
+     * Represent a QgsStatusBar widget
+     */
+    class StatusBarWidget : public Item
+    {
+      public:
+        /**
+         * Constructor
+         * \param parent parent Item
+         */
+        StatusBarWidget( Item *parent );
+
+        /**
+         * Constructor
+         * \param name name identifier
+         * \param parent parent Item
+         */
+        StatusBarWidget( const QString &name, Item *parent );
+
+      protected:
+        QString xmlTag() const override;
+    };
+
+    /**
+     * Root item for all StatusBarWidget
+     */
+    class StatusBarWidgets : public Item
+    {
+      public:
+        /**
+         * Constructor
+         */
+        StatusBarWidgets();
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<Item> createChildItem( const QDomElement &childElem ) override;
+    };
+
+    /**
+     * Returns browser items to customize QgsBrowserDockWidget content
+     */
+    const std::unique_ptr<QgsCustomization::BrowserItems> &browserItems() const;
+
+    /**
+     * Returns dock items to customize visible QgsDockWidget
+     */
+    const std::unique_ptr<QgsCustomization::Docks> &docks() const;
+
+    /**
+     * Returns menus items to customize QMenu content
+     */
+    const std::unique_ptr<QgsCustomization::Menus> &menus() const;
+
+    /**
+     * Returns status bar items to customize QgsStatusBar displayed widgets
+     */
+    const std::unique_ptr<QgsCustomization::StatusBarWidgets> &statusBarWidgets() const;
+
+    /**
+     * Returns toolbar items to customize QToolBar content
+     */
+    const std::unique_ptr<QgsCustomization::ToolBars> &toolBars() const;
+
+    /**
+     * Apply customization to the application
+     */
+    void apply() const;
+
+    /**
+     * Reads customization file (given at construction time) to update customization content
+     */
+    void read();
+
+    /**
+     * Reads customization file \a filePath to update customization content
+     */
+    QString readFile( const QString &filePath );
+
+    /**
+     * Write customization to file (given at construction time)
+     * Returns error string or an empty string if no error occurred
+     */
+    QString write() const;
+
+    /**
+     * Write customization to \a filePath file
+     * Returns error string or an empty string if no error occurred
+     */
+    QString writeFile( const QString &filePath ) const;
 
   protected:
-    QgsCustomization();
-    ~QgsCustomization() override = default;
-    QgsCustomizationDialog *pDialog = nullptr;
+    /**
+   * Add action items as children of \a item for each \a widget actions
+   */
+    void addActions( Item *item, QWidget *widget ) const;
 
-    bool mEnabled = false;
-    QSettings *mSettings = nullptr;
-    QString mStatusPath;
+    /**
+     * Update customization model with current application customization elements (actins, menus, dockWidgets...)
+     */
+    void load();
 
-    void updateMenu( QMenu *menu, QSettings *settings );
-    void createTreeItemMenus();
-    void createTreeItemToolbars();
-    void createTreeItemDocks();
-    void createTreeItemStatus();
-    void createTreeItemBrowser();
-    void addTreeItemMenu( QTreeWidgetItem *parentItem, const QMenu *menu, const QAction *action = nullptr );
-    void addTreeItemActions( QTreeWidgetItem *parentItem, const QList<QAction *> &actions );
-    QList<QTreeWidgetItem *> mMainWindowItems;
-    QTreeWidgetItem *mBrowserItem = nullptr;
-    friend class QgsCustomizationDialog; // in order to access mMainWindowItems and mBrowserItem
+    /**
+     * Update customization model with current application QgsBrowserDockWidget elements
+     */
+    void loadApplicationBrowserItems();
+
+    /**
+     * Update customization model with current application dock widgets elements
+     */
+    void loadApplicationDocks();
+
+    /**
+     * Update customization model with current application menus elements
+     */
+    void loadApplicationMenus();
+
+    /**
+     * Update customization model with current application QgsStatusBar elements
+     */
+    void loadApplicationStatusBarWidgets();
+
+    /**
+     * Update customization model with current application toolbar elements
+     */
+    void loadApplicationToolBars();
+
+    /**
+     * Apply browser items customization to the application
+     */
+    void applyToBrowserItems() const;
+
+    /**
+     * Apply docks customization to the application
+     */
+    void applyToDocks() const;
+
+    /**
+     * Apply menus customization to the application
+     */
+    void applyToMenus() const;
+
+    /**
+     * Apply status bar customization to the application
+     */
+    void applyToStatusBarWidgets() const;
+
+    /**
+     * Apply toolbar customization to the application
+     */
+    void applyToToolBars() const;
+
+    /**
+     * Writes customization model to XML file \a fileName
+     * Returns error string or an empty string if no error occurred
+     */
+    QString writeXML( const QString &fileName ) const;
+
+    /**
+     * Reads customization model from XML file \a fileName
+     */
+    QString readXml( const QString &fileName );
 
   private:
-    static QgsCustomization *sInstance;
+    /**
+   * Helper class to iterate over widget actions
+   */
+    class QWidgetIterator
+    {
+      public:
+        /**
+         * Constructor
+         * \param widget this class will iterate over the widget actions
+         */
+        QWidgetIterator( QWidget *widget );
+
+        /**
+         * Iterator informations
+         */
+        struct Infos
+        {
+            QWidget *widget = nullptr;
+            QAction *action = nullptr;
+            qsizetype index = -1;
+            QString name;
+            QString title;
+            QIcon icon;
+            bool isMenu = false;
+        };
+
+        struct Iterator
+        {
+            Iterator( QWidget *ptr, qsizetype idx );
+
+            Infos operator*() const;
+            Iterator &operator++();
+            bool operator==( const Iterator &b ) const;
+
+          private:
+            qsizetype idx;
+            QList<QAction *> mActions;
+        };
+
+        Iterator begin();
+        Iterator end();
+
+      private:
+        QWidget *mWidget = nullptr;
+
+        friend class TestQgsCustomization;
+    };
+
+    /**
+     * Backward compatiblity method to import old QGIS3 ini file
+     */
+    void loadOldIniFile( const QString &filePath );
+
+    /**
+     * Update \a widget visibility based on \a item
+     */
+    static void updateActionVisibility( QgsCustomization::Item *item, QWidget *widget );
+
+    std::unique_ptr<BrowserItems> mBrowserItems;
+    std::unique_ptr<Docks> mDocks;
+    std::unique_ptr<Menus> mMenus;
+    std::unique_ptr<StatusBarWidgets> mStatusBarWidgets;
+    std::unique_ptr<ToolBars> mToolBars;
+    bool mEnabled = false;
+    QString mSplashPath;
+
+    QgisApp *mQgisApp = nullptr;
+    QList<QgsBrowserDockWidget *> mBrowserWidgets;
+    QString mCustomizationFile;
+
+    friend class TestQgsCustomization;
 };
 #endif // QGSCUSTOMIZATION_H

--- a/src/app/qgscustomizationdialog.cpp
+++ b/src/app/qgscustomizationdialog.cpp
@@ -39,7 +39,7 @@
 #include <QAbstractItemModelTester>
 #endif
 
-const QgsSettingsEntryString *QgsCustomizationDialog::sSettingLastSaveDir = new QgsSettingsEntryString( QStringLiteral( "last-save-directory" ), sTreeCustomization, QDir::homePath(), QStringLiteral( "Last directory used when saving a customization XML file" ) );
+const QgsSettingsEntryString *QgsCustomizationDialog::sSettingLastSaveDir = new QgsSettingsEntryString( u"last-save-directory"_s, sTreeCustomization, QDir::homePath(), u"Last directory used when saving a customization XML file"_s );
 
 QgsCustomizationDialog::QgsCustomizationModel::QgsCustomizationModel( QgisApp *qgisApp, Mode mode, QObject *parent )
   : QAbstractItemModel( parent )
@@ -299,7 +299,7 @@ const std::unique_ptr<QgsCustomization> &QgsCustomizationDialog::QgsCustomizatio
 void QgsCustomizationDialog::onSaveFile( bool )
 {
   QString fileName = QFileDialog::getSaveFileName( this, tr( "Choose a customization XML file" ), sSettingLastSaveDir->value(), tr( "Customization files (*.xml)" ) );
-  fileName = QgsFileUtils::ensureFileNameHasExtension( fileName, QStringList() << QStringLiteral( "xml" ) );
+  fileName = QgsFileUtils::ensureFileNameHasExtension( fileName, QStringList() << u"xml"_s );
 
   if ( fileName.isEmpty() )
     return;
@@ -371,7 +371,7 @@ void QgsCustomizationDialog::enableCustomization( bool checked )
 
 void QgsCustomizationDialog::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "introduction/qgis_configuration.html#sec-customization" ) );
+  QgsHelp::openHelp( u"introduction/qgis_configuration.html#sec-customization"_s );
 }
 
 void QgsCustomizationDialog::onActionCatchToggled( bool triggered )

--- a/src/app/qgscustomizationdialog.cpp
+++ b/src/app/qgscustomizationdialog.cpp
@@ -184,6 +184,7 @@ void QgsCustomizationDialog::QgsCustomizationModel::init()
 {
   mCustomization = std::make_unique<QgsCustomization>( *mQgisApp->customization() );
   mRootItems.clear();
+  // NOLINTBEGIN(bugprone-branch-clone)
   switch ( mMode )
   {
     case Mode::ActionSelector:
@@ -200,6 +201,7 @@ void QgsCustomizationDialog::QgsCustomizationModel::init()
                  << mCustomization->toolBarsItem();
       break;
   }
+  // NOLINTEND(bugprone-branch-clone)
 }
 
 void QgsCustomizationDialog::QgsCustomizationModel::reset()

--- a/src/app/qgscustomizationdialog.cpp
+++ b/src/app/qgscustomizationdialog.cpp
@@ -68,7 +68,7 @@ class QgsCustomizationDialog::QgsCustomizationModel : public QAbstractItemModel
 
     /**
      * Read new customization model file and reset model
-     * Returns error string. An empty string is returned if no error occured
+     * Returns error string. An empty string is returned if no error occurred
      */
     QString readFile( const QString &filePath );
 

--- a/src/app/qgscustomizationdialog.cpp
+++ b/src/app/qgscustomizationdialog.cpp
@@ -1,0 +1,485 @@
+/***************************************************************************
+    qgscustomizationdialog.cpp
+    ---------------------
+    begin                : 2025/12/16
+    copyright            : (C) 2025 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscustomizationdialog.h"
+
+#include "qgsapplication.h"
+#include "qgsfileutils.h"
+#include "qgsgui.h"
+#include "qgshelp.h"
+#include "qgssettings.h"
+
+#include <QAbstractItemModel>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QPushButton>
+#include <QSortFilterProxyModel>
+#include <QToolButton>
+#include <QWidgetAction>
+#include <qmessagebox.h>
+#include <qnamespace.h>
+
+#include "moc_qgscustomizationdialog.cpp"
+
+const QgsSettingsEntryString *QgsCustomizationDialog::sSettingLastSaveDir = new QgsSettingsEntryString( QStringLiteral( "last-save-directory" ), sTreeCustomization, QDir::homePath(), QStringLiteral( "Last directory used when saving a customization XML file" ) );
+
+class QgsCustomizationDialog::QgsCustomizationModel : public QAbstractItemModel
+{
+  public:
+    enum class Mode
+    {
+      ActionSelector, //!< Use to select actions
+      ItemVisibility  //!< Use to change item visibility
+    };
+
+    QgsCustomizationModel( QgsCustomization *customization, Mode mode, QObject *parent = nullptr );
+    ~QgsCustomizationModel() override = default;
+
+    QVariant data( const QModelIndex &index, int role ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
+    QModelIndex index( int row, int column, const QModelIndex &parent = {} ) const override;
+    QModelIndex parent( const QModelIndex &index ) const override;
+    int rowCount( const QModelIndex &parent = {} ) const override;
+    int columnCount( const QModelIndex &parent = {} ) const override;
+
+    /**
+     * Reset all current modifications
+     */
+    void reset();
+
+    /**
+     * Validate all current modifications
+     */
+    void validate();
+
+    /**
+     * Read new customization model file and reset model
+     * Returns error string. An empty string is returned if no error occured
+     */
+    QString readFile( const QString &filePath );
+
+  private:
+    Mode mMode = Mode::ActionSelector;
+    QgsCustomization *mCustomization = nullptr;
+    QHash<QgsCustomization::Item *, bool> mOldVisibleState;
+    QList<QgsCustomization::Item *> mRootItems;
+};
+
+QgsCustomizationDialog::QgsCustomizationModel::QgsCustomizationModel( QgsCustomization *customization, Mode mode, QObject *parent )
+  : QAbstractItemModel( parent )
+  , mMode( mode )
+  , mCustomization( customization )
+{
+  switch ( mMode )
+  {
+    case Mode::ActionSelector:
+      mRootItems << mCustomization->menus().get()
+                 << mCustomization->toolBars().get();
+      break;
+
+    case Mode::ItemVisibility:
+      mRootItems << mCustomization->browserItems().get()
+                 << mCustomization->docks().get()
+                 << mCustomization->menus().get()
+                 << mCustomization->statusBarWidgets().get()
+                 << mCustomization->toolBars().get();
+  };
+}
+
+QVariant QgsCustomizationDialog::QgsCustomizationModel::data( const QModelIndex &index, int role ) const
+{
+  if ( !index.isValid() || ( role != Qt::DisplayRole && role != Qt::DecorationRole && role != Qt::CheckStateRole ) )
+    return {};
+
+  QgsCustomization::Item *item = static_cast<QgsCustomization::Item *>( index.internalPointer() );
+  switch ( role )
+  {
+    case Qt::DecorationRole:
+      return item && index.column() == 0 ? item->icon() : QVariant {};
+    case Qt::DisplayRole:
+      if ( item )
+      {
+        if ( parent( index ).isValid() )
+          return index.column() == 0 ? QVariant( item->name() ) : QVariant( item->title() );
+        // root items, we display only title
+        else
+          return index.column() == 0 ? QVariant( item->title() ) : QVariant();
+      }
+      else
+        return QVariant {};
+    case Qt::CheckStateRole:
+      return mMode == Mode::ItemVisibility && item && index.parent().isValid() && index.column() == 0 ? ( item->isVisible() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked ) : QVariant {};
+    default:;
+  }
+
+  return QVariant();
+}
+
+bool QgsCustomizationDialog::QgsCustomizationModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  if ( !index.isValid() || role != Qt::CheckStateRole )
+    return false;
+
+  QgsCustomization::Item *item = static_cast<QgsCustomization::Item *>( index.internalPointer() );
+  if ( item )
+  {
+    mOldVisibleState[item] = item->isVisible();
+    item->setVisible( value.value<Qt::CheckState>() == Qt::CheckState::Checked );
+    emit dataChanged( index, index, QList<int>() << Qt::CheckStateRole );
+    return true;
+  }
+
+  return false;
+}
+
+Qt::ItemFlags QgsCustomizationDialog::QgsCustomizationModel::flags( const QModelIndex &index ) const
+{
+  if ( !index.isValid() )
+    return Qt::ItemFlags();
+
+  Qt::ItemFlags flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+
+  if ( mMode == Mode::ItemVisibility && index.parent().isValid() && index.column() == 0 )
+    flags |= Qt::ItemIsUserCheckable;
+
+  return flags;
+}
+
+QVariant QgsCustomizationDialog::QgsCustomizationModel::headerData( int section, Qt::Orientation orientation, int role ) const
+{
+  return role == Qt::DisplayRole && orientation == Qt::Horizontal ? ( section == 0 ? tr( "Object name" ) : tr( "Label" ) ) : QVariant {};
+}
+
+QModelIndex QgsCustomizationDialog::QgsCustomizationModel::index( int row, int column, const QModelIndex &parent ) const
+{
+  if ( !hasIndex( row, column, parent ) )
+    return {};
+
+  // first level, categories title ("Menus" for instance)
+  if ( !parent.isValid() )
+  {
+    return createIndex( row, column, row >= 0 && row < mRootItems.count() ? mRootItems.at( row ) : nullptr );
+  }
+
+  QgsCustomization::Item *item = static_cast<QgsCustomization::Item *>( parent.internalPointer() );
+  return createIndex( row, column, item->getChild( row ) );
+}
+
+QModelIndex QgsCustomizationDialog::QgsCustomizationModel::parent( const QModelIndex &index ) const
+{
+  if ( !index.isValid() )
+    return {};
+
+  QgsCustomization::Item *item = static_cast<QgsCustomization::Item *>( index.internalPointer() );
+  QgsCustomization::Item *parentItem = item ? item->parent() : nullptr;
+  if ( !item || !parentItem )
+    return {};
+
+  QgsCustomization::Item *grandParentItem = parentItem->parent();
+  if ( grandParentItem )
+  {
+    return createIndex( static_cast<int>( grandParentItem->indexOf( parentItem ) ), 0, parentItem );
+  }
+
+  QList<QgsCustomization::Item *>::const_iterator it = std::find( mRootItems.cbegin(), mRootItems.cend(), parentItem );
+  if ( it != mRootItems.cend() )
+    return createIndex( static_cast<int>( std::distance( mRootItems.cbegin(), it ) ), 0, *it );
+
+  return {}; // should never happen
+}
+
+int QgsCustomizationDialog::QgsCustomizationModel::rowCount( const QModelIndex &parent ) const
+{
+  if ( parent.column() > 0 )
+    return 0;
+
+  // first level, categories title ("Menus" for instance)
+  if ( !parent.isValid() )
+  {
+    return static_cast<int>( mRootItems.count() );
+  }
+
+  // second level, categories content (menus item for instance)
+  QgsCustomization::Item *item = static_cast<QgsCustomization::Item *>( parent.internalPointer() );
+  return item ? static_cast<int>( item->childrenCount() ) : 0;
+}
+
+int QgsCustomizationDialog::QgsCustomizationModel::columnCount( const QModelIndex & ) const
+{
+  return 2;
+}
+
+void QgsCustomizationDialog::QgsCustomizationModel::reset()
+{
+  // restore old visible states
+  beginResetModel();
+  for ( auto it = mOldVisibleState.cbegin(); it != mOldVisibleState.cend(); it++ )
+  {
+    it.key()->setVisible( it.value() );
+  }
+
+  mOldVisibleState.clear();
+  endResetModel();
+}
+
+void QgsCustomizationDialog::QgsCustomizationModel::validate()
+{
+  mOldVisibleState.clear();
+}
+
+
+QgsCustomizationDialog::QgsCustomizationDialog( QgsCustomization *customization, QWidget *parent )
+#ifdef Q_OS_MACOS
+  : QMainWindow( parent, Qt::WindowSystemMenuHint ) // Modeless dialog with close button only
+#else
+  : QMainWindow( parent )
+#endif
+  , mCustomization( customization )
+{
+  setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  connect( actionSave, &QAction::triggered, this, &QgsCustomizationDialog::onSaveFile );
+  connect( actionLoad, &QAction::triggered, this, &QgsCustomizationDialog::onLoadFile );
+  connect( actionExpandAll, &QAction::triggered, this, &QgsCustomizationDialog::onExpandAll );
+  connect( actionCollapseAll, &QAction::triggered, this, &QgsCustomizationDialog::onCollapseAll );
+  connect( actionSelectAll, &QAction::triggered, this, &QgsCustomizationDialog::onSelectAll );
+  connect( mCustomizationEnabledCheckBox, &QCheckBox::toggled, this, &QgsCustomizationDialog::enableCustomization );
+  connect( actionCatch, &QAction::triggered, this, &QgsCustomizationDialog::onActionCatchToggled );
+
+  connect( buttonBox->button( QDialogButtonBox::Ok ), &QAbstractButton::clicked, this, &QgsCustomizationDialog::ok );
+  connect( buttonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &QgsCustomizationDialog::apply );
+  connect( buttonBox->button( QDialogButtonBox::Cancel ), &QAbstractButton::clicked, this, &QgsCustomizationDialog::cancel );
+  connect( buttonBox->button( QDialogButtonBox::Reset ), &QAbstractButton::clicked, this, &QgsCustomizationDialog::reset );
+  connect( buttonBox->button( QDialogButtonBox::Help ), &QAbstractButton::clicked, this, &QgsCustomizationDialog::showHelp );
+
+  mItemsVisibilityModel = new QgsCustomizationModel( mCustomization, QgsCustomizationModel::Mode::ItemVisibility, this );
+  QSortFilterProxyModel *proxyModel = new QSortFilterProxyModel( this );
+  proxyModel->sort( 0 );
+  proxyModel->setFilterKeyColumn( 0 );
+  proxyModel->setFilterCaseSensitivity( Qt::CaseSensitivity::CaseInsensitive );
+  proxyModel->setSortCaseSensitivity( Qt::CaseSensitivity::CaseInsensitive );
+
+  proxyModel->setRecursiveFilteringEnabled( true );
+  proxyModel->setSourceModel( mItemsVisibilityModel );
+  mTreeView->setModel( proxyModel );
+  mTreeView->resizeColumnToContents( 0 );
+  mTreeView->header()->resizeSection( 0, 250 );
+  connect( mFilterLe, &QgsFilterLineEdit::valueChanged, proxyModel, &QSortFilterProxyModel::setFilterFixedString );
+
+  mTreeView->setEnabled( false );
+  toolBar->setEnabled( false );
+  mFilterLe->setEnabled( false );
+  mCustomizationEnabledCheckBox->setChecked( mCustomization->isEnabled() );
+}
+
+void QgsCustomizationDialog::reset()
+{
+  mItemsVisibilityModel->reset();
+}
+
+void QgsCustomizationDialog::ok()
+{
+  apply();
+  hide();
+}
+
+void QgsCustomizationDialog::apply()
+{
+  mCustomization->apply();
+
+  const QString error = mCustomization->write();
+  if ( !error.isEmpty() )
+  {
+    QMessageBox::warning( this, tr( "Error writing customization XML file" ), error );
+  }
+
+  mItemsVisibilityModel->validate();
+}
+
+void QgsCustomizationDialog::cancel()
+{
+  reset();
+  hide();
+}
+
+QString QgsCustomizationDialog::QgsCustomizationModel::readFile( const QString &filePath )
+{
+  beginResetModel();
+  QString error = mCustomization->readFile( filePath );
+  endResetModel();
+
+  return error;
+}
+
+void QgsCustomizationDialog::onSaveFile( bool )
+{
+  QString fileName = QFileDialog::getSaveFileName( this, tr( "Choose a customization XML file" ), sSettingLastSaveDir->value(), tr( "Customization files (*.xml)" ) );
+  fileName = QgsFileUtils::ensureFileNameHasExtension( fileName, QStringList() << QStringLiteral( "xml" ) );
+
+  if ( fileName.isEmpty() )
+    return;
+
+  const QString error = mCustomization->writeFile( fileName );
+  if ( !error.isEmpty() )
+  {
+    QMessageBox::warning( this, tr( "Error writing customization XML file" ), error );
+  }
+
+  QFileInfo fileInfo( fileName );
+  sSettingLastSaveDir->setValue( fileInfo.absoluteDir().absolutePath() );
+}
+
+void QgsCustomizationDialog::onLoadFile( bool )
+{
+  QString fileName = QFileDialog::getOpenFileName( this, tr( "Choose a customization XML file" ), sSettingLastSaveDir->value(), tr( "Customization files (*.xml)" ) );
+  if ( fileName.isEmpty() )
+    return;
+
+  QString error = mItemsVisibilityModel->readFile( fileName );
+  if ( !error.isEmpty() )
+  {
+    QMessageBox::warning( this, tr( "Error loading customization XML file" ), error );
+  }
+
+  QFileInfo fileInfo( fileName );
+  sSettingLastSaveDir->setValue( fileInfo.absoluteDir().absolutePath() );
+}
+
+void QgsCustomizationDialog::onExpandAll( bool )
+{
+  mTreeView->expandAll();
+}
+
+void QgsCustomizationDialog::onCollapseAll( bool )
+{
+  mTreeView->collapseAll();
+}
+
+void QgsCustomizationDialog::onSelectAll( bool )
+{
+  // change state recursively
+
+  std::function<void( const QModelIndex & )> selectAll = [this, &selectAll]( const QModelIndex &root ) {
+    if ( mItemsVisibilityModel->data( root, Qt::ItemDataRole::DisplayRole ).value<Qt::CheckState>() == Qt::CheckState::Unchecked )
+    {
+      mItemsVisibilityModel->setData( root, Qt::CheckState::Checked, Qt::ItemDataRole::CheckStateRole );
+    }
+
+    for ( int i = 0; i < mItemsVisibilityModel->rowCount( root ); i++ )
+    {
+      selectAll( mItemsVisibilityModel->index( i, 0, root ) );
+    }
+  };
+
+  selectAll( QModelIndex() );
+}
+
+void QgsCustomizationDialog::enableCustomization( bool checked )
+{
+  mTreeView->setEnabled( checked );
+  toolBar->setEnabled( checked );
+  mFilterLe->setEnabled( checked );
+
+  if ( checked != mCustomization->isEnabled() )
+    mCustomization->setEnabled( checked );
+}
+
+void QgsCustomizationDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "introduction/qgis_configuration.html#sec-customization" ) );
+}
+
+void QgsCustomizationDialog::onActionCatchToggled( bool triggered )
+{
+  if ( triggered )
+    connect( QgsApplication::instance(), &QgsApplication::preNotify, this, &QgsCustomizationDialog::preNotify );
+  else
+    disconnect( QgsApplication::instance(), &QgsApplication::preNotify, this, &QgsCustomizationDialog::preNotify );
+}
+
+QAction *QgsCustomizationDialog::findAction( QToolButton *toolbutton )
+{
+  if ( !toolbutton->parent() )
+    return toolbutton->defaultAction();
+
+  // We need to find the QAction that was returned from the call of "QToolBar::addWidget".
+  // This is a defaultAction in most cases. But when QToolButton is composed of multiple actions,
+  // (e.g. "Select Features by ..." button) we need to go through the parent widget to search for the
+  // parent action name.
+  const QList<QWidgetAction *> tbWidgetActions = toolbutton->parent()->findChildren<QWidgetAction *>( QString(), Qt::FindDirectChildrenOnly );
+  for ( QWidgetAction *act : tbWidgetActions )
+  {
+    QWidget *widget = act->defaultWidget();
+    if ( widget == toolbutton )
+      return act;
+  }
+
+  return toolbutton->defaultAction();
+}
+
+bool QgsCustomizationDialog::selectWidget( QWidget *widget )
+{
+  if ( !actionCatch->isChecked() )
+    return false;
+
+  QString widgetName = widget->objectName();
+  if ( QToolButton *toolbutton = qobject_cast<QToolButton *>( widget ) )
+  {
+    QAction *action = findAction( toolbutton );
+    if ( !action )
+      return false;
+    widgetName = action->objectName();
+  }
+
+  QModelIndexList items = mItemsVisibilityModel->match(
+    mItemsVisibilityModel->index( 4, 0 ),
+    Qt::DisplayRole,
+    widgetName,
+    2,
+    Qt::MatchRecursive
+  );
+
+  if ( items.isEmpty() )
+    return false;
+
+  const QModelIndex currentIndex = static_cast<QSortFilterProxyModel *>( mTreeView->model() )->mapFromSource( items.first() );
+  mTreeView->selectionModel()->setCurrentIndex( currentIndex, QItemSelectionModel::SelectCurrent );
+
+  raise();
+
+  return true;
+}
+
+void QgsCustomizationDialog::preNotify( QObject *receiver, QEvent *event, bool *done )
+{
+  if ( !actionCatch->isChecked() )
+    return;
+
+  if ( !mCustomization )
+    return;
+
+  QWidget *widget = qobject_cast<QWidget *>( receiver );
+  if ( !widget )
+    return;
+
+  // try to select a widget on mouse click
+  if ( event->type() == QEvent::MouseButtonPress )
+  {
+    *done = selectWidget( widget );
+  }
+}

--- a/src/app/qgscustomizationdialog.h
+++ b/src/app/qgscustomizationdialog.h
@@ -17,6 +17,7 @@
 #define QGSCUSTOMIZATIONDIALOG_H
 
 #include "ui_qgscustomizationdialogbase.h"
+
 #include "qgscustomization.h"
 #include "qgssettingstree.h"
 
@@ -69,7 +70,7 @@ class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCus
     void preNotify( QObject *receiver, QEvent *event, bool *done );
 
     /**
-     * Enable "catch" mode, allow to click on the application UI to select action
+     * Enable "catch" mode, allows clicking on the application UI to select action
      */
     void onActionCatchToggled( bool toggled );
 

--- a/src/app/qgscustomizationdialog.h
+++ b/src/app/qgscustomizationdialog.h
@@ -1,0 +1,130 @@
+/***************************************************************************
+    qgscustomizationdialog.h
+    ---------------------
+    begin                : 2025/12/16
+    copyright            : (C) 2025 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCUSTOMIZATIONDIALOG_H
+#define QGSCUSTOMIZATIONDIALOG_H
+
+#include "ui_qgscustomizationdialogbase.h"
+#include "qgscustomization.h"
+#include "qgssettingstree.h"
+
+/**
+ * \ingroup app
+ * \brief Dialog to customize application
+ * \since QGIS 4.0
+*/
+class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCustomizationDialogBase
+{
+    Q_OBJECT
+  public:
+    /**
+     * Constructor
+     * \param customization object to customize the application
+     * \param parent parent widget
+     */
+    QgsCustomizationDialog( QgsCustomization *customization, QWidget *parent );
+
+    static inline QgsSettingsTreeNode *sTreeCustomization = QgsSettingsTree::sTreeApp->createChildNode( QStringLiteral( "customization" ) );
+    static const QgsSettingsEntryString *sSettingLastSaveDir;
+
+  private slots:
+
+    /**
+     * Called whenever user clicks the OK button
+     */
+    void ok();
+
+    /**
+     * Called whenever user clicks the Apply button
+     */
+    void apply();
+
+    /**
+     * Called whenever user clicks the Cancel button
+     */
+    void cancel();
+
+    /**
+     * Called whenever user clicks the Help button
+     */
+    void showHelp();
+
+    /**
+     * Called by QgsApplication::notify() method so we can preempt all the mouse clicks
+     * when the "catch" mode is enabled
+     * see onActionCatchToggled()
+     */
+    void preNotify( QObject *receiver, QEvent *event, bool *done );
+
+    /**
+     * Enable "catch" mode, allow to click on the application UI to select action
+     */
+    void onActionCatchToggled( bool toggled );
+
+    /**
+     * Cancel all current, non applied, modification
+     */
+    void reset();
+
+    /**
+     * Save customization to a file
+     */
+    void onSaveFile( bool checked );
+
+    /**
+     * Load customization to a file
+     */
+    void onLoadFile( bool checked );
+
+    /**
+     * Expand all tree view items
+     */
+    void onExpandAll( bool checked );
+
+    /**
+     * Collapse all tree view items
+     */
+    void onCollapseAll( bool checked );
+
+    /**
+     * Select all tree view items
+     */
+    void onSelectAll( bool checked );
+
+    /**
+     * Enable or disable current customization according to \a cheched boolean
+     */
+    void enableCustomization( bool checked );
+
+  private:
+    /**
+     * find QAction associated to \a toolbutton
+     */
+    QAction *findAction( QToolButton *toolbutton );
+
+    /**
+     * Select item associated to \a widget in tree view
+     */
+    bool selectWidget( QWidget *widget );
+
+    class QgsCustomizationModel;
+
+    QString mLastDirSettingsName;
+
+    QgsCustomization *mCustomization = nullptr;
+    QgsCustomizationModel *mItemsVisibilityModel = nullptr;
+};
+
+#endif

--- a/src/app/qgscustomizationdialog.h
+++ b/src/app/qgscustomizationdialog.h
@@ -180,7 +180,7 @@ class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCus
         Mode mMode = Mode::ActionSelector;
         QgisApp *mQgisApp = nullptr;
         std::unique_ptr<QgsCustomization> mCustomization; // current customization, copy of the application one
-        QList<QgsCustomization::Item *> mRootItems;
+        QList<QgsCustomization::QgsItem *> mRootItems;
     };
 
     QString mLastDirSettingsName;

--- a/src/app/qgscustomizationdialog.h
+++ b/src/app/qgscustomizationdialog.h
@@ -40,7 +40,7 @@ class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCus
      */
     QgsCustomizationDialog( QgisApp *qgisApp );
 
-    static inline QgsSettingsTreeNode *sTreeCustomization = QgsSettingsTree::sTreeApp->createChildNode( QStringLiteral( "customization" ) );
+    static inline QgsSettingsTreeNode *sTreeCustomization = QgsSettingsTree::sTreeApp->createChildNode( u"customization"_s );
     static const QgsSettingsEntryString *sSettingLastSaveDir;
 
   private slots:

--- a/src/gui/qgsbrowserwidget.h
+++ b/src/gui/qgsbrowserwidget.h
@@ -191,6 +191,7 @@ class GUI_EXPORT QgsBrowserWidget : public QgsPanelWidget, private Ui::QgsBrowse
     QStringList mDisabledDataItemsKeys;
 
     friend class QgsBrowserDockWidget;
+    friend class TestQgsCustomization;
 };
 
 #endif // QGSBROWSERWIDGET_H

--- a/src/ui/qgscustomizationdialogbase.ui
+++ b/src/ui/qgscustomizationdialogbase.ui
@@ -7,49 +7,64 @@
     <x>0</x>
     <y>0</y>
     <width>503</width>
-    <height>370</height>
+    <height>658</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Interface Customization</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <layout class="QVBoxLayout" name="verticalLayout_3">
     <item>
-     <widget class="QCheckBox" name="mCustomizationEnabledCheckBox">
-      <property name="text">
-       <string>Enable customization</string>
-      </property>
-     </widget>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QCheckBox" name="mCustomizationEnabledCheckBox">
+        <property name="text">
+         <string>Enable customization</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
     </item>
     <item>
-     <widget class="QgsFilterLineEdit" name="mLeFilter">
-      <property name="placeholderText">
-       <string>Search…</string>
+     <widget class="QSplitter" name="splitter">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
       </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QTreeWidget" name="treeWidget">
-      <property name="selectionBehavior">
-       <enum>QAbstractItemView::SelectItems</enum>
-      </property>
-      <property name="columnCount">
-       <number>2</number>
-      </property>
-      <attribute name="headerVisible">
-       <bool>true</bool>
-      </attribute>
-      <column>
-       <property name="text">
-        <string notr="true">1</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string notr="true">2</string>
-       </property>
-      </column>
+      <widget class="QWidget" name="layoutWidget">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QgsFilterLineEdit" name="mFilterLe">
+          <property name="placeholderText">
+           <string>Search…</string>
+          </property>
+          <property name="showSearchIcon">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTreeView" name="mTreeView">
+          <property name="selectionBehavior">
+           <enum>QAbstractItemView::SelectItems</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </item>
     <item>
@@ -157,6 +172,13 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TESTS
   testqgsadvanceddigitizing.cpp
   testqgsattributetable.cpp
   testqgsapplocatorfilters.cpp
+  testqgscustomization.cpp
   testqgsdecorationscalebar.cpp
   testqgsdwgimportdialog.cpp
   testqgsfieldcalculator.cpp

--- a/tests/src/app/testqgscustomization.cpp
+++ b/tests/src/app/testqgscustomization.cpp
@@ -1,0 +1,564 @@
+/***************************************************************************
+    testqgscustomization.cpp
+    ---------------------
+    begin                : 2025/12/10
+    copyright            : (C) 2025 by Julien Cabieces
+    email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgisapp.h"
+#include "qgsbrowserguimodel.h"
+#include "qgsbrowserwidget.h"
+#include "qgslayertreeview.h"
+#include "qgstest.h"
+#include "qgscustomization.h"
+#include "qgsstatusbar.h"
+#include "qgsbrowserdockwidget.h"
+
+#include <QDockWidget>
+
+class TestQgsCustomization : public QgsTest
+{
+    Q_OBJECT
+
+  public:
+    TestQgsCustomization()
+      : QgsTest( QStringLiteral( "Customization Tests" ) ) {}
+
+  private slots:
+    void initTestCase();    // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init();            // will be called before each testfunction is executed.
+    void cleanup();         // will be called after every testfunction.
+
+    void testLoadApply();
+    void testActionPosition();
+    void testEnabled();
+    void testBackwardCompatiblity();
+
+  private:
+    template<class T>
+    T *getItem( const std::unique_ptr<QgsCustomization> &customization, const QString &path ) const
+    {
+      return dynamic_cast<T *>( getItem( customization, path ) );
+    }
+    QgsCustomization::Item *getItem( const std::unique_ptr<QgsCustomization> &customization, const QString &path ) const;
+
+    template<class T>
+    T *getItem( const QString &path ) const { return dynamic_cast<T *>( getItem( path ) ); }
+    QgsCustomization::Item *getItem( const QString &path ) const
+    {
+      return getItem( mQgisApp->mCustomization, path );
+    }
+
+    static QWidget *findQWidget( const QString &path );
+
+    template<class T>
+    static T *findQWidget( const QString &path )
+    {
+      return dynamic_cast<T *>( findQWidget( path ) );
+    }
+
+    static QAction *findQAction( const QString &path );
+    static long long qactionPosition( const QString &path );
+
+    std::unique_ptr<QgisApp> mQgisApp;
+    std::unique_ptr<QTemporaryFile> mCustomizationFile;
+};
+
+QgsCustomization::Item *TestQgsCustomization::getItem( const std::unique_ptr<QgsCustomization> &customization, const QString &path ) const
+{
+  QStringList pathElems = path.split( "/" );
+  if ( pathElems.isEmpty() )
+    return nullptr;
+
+  const QHash<QString, QgsCustomization::Item *> rootItems = {
+    { "Menus", customization->menus().get() },
+    { "ToolBars", customization->toolBars().get() },
+    { "Docks", customization->docks().get() },
+    { "BrowserItems", customization->browserItems().get() },
+    { "StatusBarWidgets", customization->statusBarWidgets().get() }
+  };
+
+  QgsCustomization::Item *currentItem = nullptr;
+  for ( const QString &pathElem : pathElems )
+  {
+    if ( currentItem )
+    {
+      currentItem = currentItem->getChild( pathElem );
+    }
+    else
+    {
+      currentItem = rootItems.value( pathElem );
+    }
+
+    if ( !currentItem )
+      return nullptr;
+  }
+
+  return currentItem;
+}
+
+QWidget *TestQgsCustomization::findQWidget( const QString &path )
+{
+  QStringList pathElems = path.split( "/" );
+  if ( pathElems.isEmpty() )
+    return nullptr;
+
+  const QHash<QString, QWidget *> rootWidgets = { { "Menus", QgisApp::instance()->menuBar() }, { "ToolBars", QgisApp::instance() }, { "Docks", QgisApp::instance() }, { "StatusBarWidgets", QgisApp::instance()->statusBarIface() } };
+
+  const QString rootElem = pathElems.takeFirst();
+  QWidget *currentWidget = rootWidgets.value( rootElem );
+  if ( !currentWidget )
+    return nullptr;
+
+  for ( const QString &pathElem : pathElems )
+  {
+    if ( dynamic_cast<QToolBar *>( currentWidget )
+         || dynamic_cast<QMenu *>( currentWidget )
+         || dynamic_cast<QMenuBar *>( currentWidget ) )
+    {
+      for ( QgsCustomization::QWidgetIterator::Infos it : QgsCustomization::QWidgetIterator( currentWidget ) )
+      {
+        if ( it.name == pathElem )
+        {
+          currentWidget = it.widget;
+          break;
+        }
+      }
+    }
+    else
+    {
+      QList<QObject *> children = currentWidget->children();
+      QList<QObject *>::const_iterator it = std::find_if( children.cbegin(), children.cend(), [&pathElem]( QObject *obj ) { return dynamic_cast<QWidget *>( obj ) && obj->objectName() == pathElem; } );
+      currentWidget = dynamic_cast<QWidget *>( *it );
+    }
+
+    if ( !currentWidget )
+      return nullptr;
+  }
+
+  return currentWidget;
+}
+
+QAction *TestQgsCustomization::findQAction( const QString &path )
+{
+  QStringList pathElems = path.split( "/" );
+  if ( pathElems.isEmpty() )
+    return nullptr;
+
+  qsizetype lastSlashIndex = path.lastIndexOf( "/" );
+  if ( lastSlashIndex < 0 )
+    return nullptr;
+
+  QWidget *currentWidget = findQWidget( path.first( lastSlashIndex ) );
+  if ( !currentWidget )
+    return nullptr;
+
+  const QString actionName = path.mid( lastSlashIndex + 1 );
+
+  const QList<QAction *> actions = currentWidget->actions();
+  const QList<QAction *>::const_iterator actionIt = std::find_if( actions.cbegin(), actions.cend(), [&actionName]( QAction *action ) { return action->objectName() == actionName; } );
+  return actionIt != actions.cend() ? *actionIt : nullptr;
+}
+
+long long TestQgsCustomization::qactionPosition( const QString &path )
+{
+  qsizetype lastSlashIndex = path.lastIndexOf( "/" );
+  QWidget *currentWidget = findQWidget( path.first( lastSlashIndex ) );
+  if ( !currentWidget )
+    return -1;
+
+  const QString actionName = path.mid( lastSlashIndex + 1 );
+
+  const QList<QAction *> actions = currentWidget->actions();
+  const QList<QAction *>::const_iterator actionIt = std::find_if( actions.cbegin(), actions.cend(), [&actionName]( QAction *action ) { return action->objectName() == actionName; } );
+  return actionIt == actions.cend() ? -1 : std::distance( actions.cbegin(), actionIt );
+}
+
+void TestQgsCustomization::initTestCase()
+{
+}
+
+void TestQgsCustomization::cleanupTestCase()
+{
+}
+
+void TestQgsCustomization::init()
+{
+  mQgisApp = std::make_unique<QgisApp>();
+  mQgisApp->createStatusBar();
+
+  QgsBrowserGuiModel *browserModel = new QgsBrowserGuiModel( this );
+  mQgisApp->mBrowserWidget = new QgsBrowserDockWidget( tr( "Browser" ), browserModel, mQgisApp.get() );
+  mQgisApp->mBrowserWidget->setObjectName( QStringLiteral( "Browser" ) );
+
+
+  // add a test tool bar to test action with menu
+  QToolBar *toolBar = new QToolBar( "testToolBar", mQgisApp.get() );
+  toolBar->setObjectName( "testToolBar" );
+  QToolButton *tb = new QToolButton( toolBar );
+  tb->setPopupMode( QToolButton::MenuButtonPopup );
+  QAction *action = new QAction( "testToolBarMenuAction1" );
+  action->setObjectName( "testToolBarMenuAction1" );
+  tb->addAction( action );
+  tb->setDefaultAction( action );
+  action = new QAction( "testToolBarMenuAction2" );
+  action->setObjectName( "testToolBarMenuAction2" );
+  tb->addAction( action );
+  QAction *tbAction = toolBar->addWidget( tb );
+  tbAction->setObjectName( "testToolBarToolButton" );
+  mQgisApp->addToolBar( toolBar );
+
+  QVERIFY( findQWidget<QDockWidget>( "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
+  findQWidget<QDockWidget>( "Docks/QgsAdvancedDigitizingDockWidgetBase" )->setVisible( true );
+
+  // Random crashes if this is is visible
+  mQgisApp->mLayerTreeView->setVisible( false );
+
+  mQgisApp->show();
+
+  QVERIFY( findQWidget<QMenu>( "Menus/mHelpMenu" ) );
+
+  mCustomizationFile = std::make_unique<QTemporaryFile>();
+  mCustomizationFile->open(); // fileName is not available until open
+  auto customization = std::make_unique<QgsCustomization>( mCustomizationFile->fileName() );
+  mQgisApp->setCustomization( std::move( customization ) );
+}
+
+void TestQgsCustomization::cleanup()
+{
+  mCustomizationFile->close();
+}
+
+void TestQgsCustomization::testLoadApply()
+{
+  mQgisApp->mCustomization->setEnabled( true );
+
+  // Make some modifications to the current customization
+  auto setAllVisible = [this]( bool visible ) {
+    QVERIFY( getItem<QgsCustomization::Menu>( "Menus/mHelpMenu" ) );
+    getItem<QgsCustomization::Menu>( "Menus/mHelpMenu" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" ) );
+    getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::ToolBar>( "ToolBars/mFileToolBar" ) );
+    getItem<QgsCustomization::ToolBar>( "ToolBars/mFileToolBar" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
+    getItem<QgsCustomization::Action>( "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::BrowserItem>( "BrowserItems/special:Home" ) );
+    getItem<QgsCustomization::BrowserItem>( "BrowserItems/special:Home" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::Dock>( "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
+    getItem<QgsCustomization::Dock>( "Docks/QgsAdvancedDigitizingDockWidgetBase" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::StatusBarWidget>( "StatusBarWidgets/LocatorWidget" ) );
+    getItem<QgsCustomization::StatusBarWidget>( "StatusBarWidgets/LocatorWidget" )->setVisible( visible );
+
+    QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
+    getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->setVisible( visible );
+  };
+
+  setAllVisible( false );
+
+  mQgisApp->mCustomization->write();
+
+  // re-read written customization
+  auto customization = std::make_unique<QgsCustomization>( mCustomizationFile->fileName() );
+
+  // test item visiblity
+  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mProjectMenu" ) );
+  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mProjectMenu" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" ) );
+  QVERIFY( !getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionUndo" ) );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionUndo" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionRedo" ) );
+  QVERIFY( !getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionRedo" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mFileToolBar" ) );
+  QVERIFY( !getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mFileToolBar" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mAttributesToolBar" ) );
+  QVERIFY( getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mAttributesToolBar" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddVirtualLayer" ) );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddVirtualLayer" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
+  QVERIFY( !getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/special:Home" ) );
+  QVERIFY( !getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/special:Home" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/GPKG" ) );
+  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/GPKG" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::Dock>( customization, "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
+  QVERIFY( !getItem<QgsCustomization::Dock>( customization, "Docks/QgsAdvancedDigitizingDockWidgetBase" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/mProgressBar" ) );
+  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/mProgressBar" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/LocatorWidget" ) );
+  QVERIFY( !getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/LocatorWidget" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
+  QVERIFY( !getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction2" ) );
+  QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction2" )->isVisible() );
+
+  // test initial situation
+  QVERIFY( findQWidget<QMenu>( "Menus/mHelpMenu" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" )->isVisible() );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRedo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRedo" )->isVisible() );
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" ) );
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" )->isVisible() );
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mFileToolBar" ) );
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mFileToolBar" )->isVisible() );
+  QVERIFY( findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
+  QVERIFY( findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->isVisible() );
+  // QVERIFY( getItem<QgsCustomization::BrowserItem>( "BrowserItems/special:Home" ) );
+  // getItem<QgsCustomization::BrowserItem>( "BrowserItems/special:Home" )->setIsVisible( visible );
+  QVERIFY( findQWidget<QDockWidget>( "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
+  QVERIFY( findQWidget<QDockWidget>( "Docks/QgsAdvancedDigitizingDockWidgetBase" )->isVisible() );
+  QVERIFY( findQWidget<QWidget>( "StatusBarWidgets/LocatorWidget" ) );
+  QVERIFY( findQWidget<QWidget>( "StatusBarWidgets/LocatorWidget" )->isVisible() );
+  QVERIFY( findQAction( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
+  QVERIFY( findQAction( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->isVisible() );
+
+  // apply modification
+  mQgisApp->mCustomization->apply();
+
+  QVERIFY( !findQWidget<QMenu>( "Menus/mHelpMenu" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" )->isVisible() );
+  QVERIFY( !findQAction( "Menus/mEditMenu/mActionRedo" ) );
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" ) );
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" )->isVisible() );
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mFileToolBar" ) );
+  QVERIFY( !findQWidget<QToolBar>( "ToolBars/mFileToolBar" )->isVisible() );
+  QVERIFY( !findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
+  QVERIFY( findQWidget<QDockWidget>( "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
+  QVERIFY( !findQWidget<QDockWidget>( "Docks/QgsAdvancedDigitizingDockWidgetBase" )->isVisible() );
+  QVERIFY( findQWidget<QWidget>( "StatusBarWidgets/LocatorWidget" ) );
+  QVERIFY( !findQWidget<QWidget>( "StatusBarWidgets/LocatorWidget" )->isVisible() );
+  QVERIFY( !findQAction( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
+  mQgisApp->browserWidget()->browserWidget()->mDisabledDataItemsKeys.contains( "special:Home" );
+
+  // go back to initial situation
+  setAllVisible( true );
+
+  mQgisApp->mCustomization->apply();
+
+  QVERIFY( findQWidget<QMenu>( "Menus/mHelpMenu" ) );
+  QVERIFY( !findQWidget<QMenu>( "Menus/mHelpMenu" )->isVisible() );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" )->isVisible() );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRedo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRedo" )->isVisible() );
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" ) );
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" )->isVisible() );
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mFileToolBar" ) );
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mFileToolBar" )->isVisible() );
+  QVERIFY( findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
+  QVERIFY( findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->isVisible() );
+  QVERIFY( !mQgisApp->browserWidget()->browserWidget()->mDisabledDataItemsKeys.contains( "special:Home" ) );
+  QVERIFY( findQWidget<QDockWidget>( "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
+  QVERIFY( findQWidget<QDockWidget>( "Docks/QgsAdvancedDigitizingDockWidgetBase" )->isVisible() );
+  QVERIFY( findQWidget<QWidget>( "StatusBarWidgets/LocatorWidget" ) );
+  QVERIFY( findQWidget<QWidget>( "StatusBarWidgets/LocatorWidget" )->isVisible() );
+  QVERIFY( findQAction( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
+  QVERIFY( findQAction( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->isVisible() );
+}
+
+void TestQgsCustomization::testActionPosition()
+{
+  mQgisApp->mCustomization->setEnabled( true );
+
+  // test initial situation
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" )->isVisible() );
+  long long undoPosition = qactionPosition( "Menus/mEditMenu/mActionUndo" );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRedo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRedo" )->isVisible() );
+  long long redoPosition = qactionPosition( "Menus/mEditMenu/mActionRedo" );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRotatePointSymbols" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRotatePointSymbols" )->isVisible() );
+  long long rotatePosition = qactionPosition( "Menus/mEditMenu/mActionRotatePointSymbols" );
+
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" ) );
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" ) );
+  getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" )->setVisible( false );
+  QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRotatePointSymbols" ) );
+  getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRotatePointSymbols" )->setVisible( false );
+
+  // apply modification
+  mQgisApp->mCustomization->apply();
+
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" )->isVisible() );
+  QVERIFY( !findQAction( "Menus/mEditMenu/mActionRedo" ) );
+  QVERIFY( !findQAction( "Menus/mEditMenu/mActionRotatePointSymbols" ) );
+  // same mActionRedo action than edit menu one must be existing in toolbar
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" ) );
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" )->isVisible() );
+  QCOMPARE( qactionPosition( "Menus/mEditMenu/mActionUndo" ), undoPosition );
+
+  // go back to initial situation
+  QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" ) );
+  getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" )->setVisible( true );
+  QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRotatePointSymbols" ) );
+  getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRotatePointSymbols" )->setVisible( true );
+
+  mQgisApp->mCustomization->apply();
+
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionUndo" )->isVisible() );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRedo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRedo" )->isVisible() );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRotatePointSymbols" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRotatePointSymbols" )->isVisible() );
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" ) );
+  QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" )->isVisible() );
+  QCOMPARE( qactionPosition( "Menus/mEditMenu/mActionUndo" ), undoPosition );
+  QCOMPARE( qactionPosition( "Menus/mEditMenu/mActionRedo" ), redoPosition );
+  QCOMPARE( qactionPosition( "Menus/mEditMenu/mActionRotatePointSymbols" ), rotatePosition );
+
+  // remove mActionRedo and check mActionRotatePointSymbols position is just same as before minus one
+  // (because mActionRedo is missing)
+  QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" ) );
+  getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" )->setVisible( false );
+
+  mQgisApp->mCustomization->apply();
+
+  QVERIFY( !findQAction( "Menus/mEditMenu/mActionRedo" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRotatePointSymbols" ) );
+  QVERIFY( findQAction( "Menus/mEditMenu/mActionRotatePointSymbols" )->isVisible() );
+  QCOMPARE( qactionPosition( "Menus/mEditMenu/mActionRotatePointSymbols" ), rotatePosition - 1 );
+}
+
+void TestQgsCustomization::testEnabled()
+{
+  QVERIFY( getItem<QgsCustomization::Menu>( "Menus/mHelpMenu" ) );
+  getItem<QgsCustomization::Menu>( "Menus/mHelpMenu" )->setVisible( false );
+
+  mQgisApp->mCustomization->write();
+
+  // re-read written customization
+  auto customization = std::make_unique<QgsCustomization>( mCustomizationFile->fileName() );
+  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" ) );
+  QVERIFY( !getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" )->isVisible() );
+  QVERIFY( !customization->isEnabled() );
+
+  QVERIFY( findQWidget<QMenu>( "Menus/mHelpMenu" ) );
+
+  mQgisApp->mCustomization->apply();
+
+  // still visible because we didn't  enabled customization
+  QVERIFY( findQWidget<QMenu>( "Menus/mHelpMenu" ) );
+
+  mQgisApp->mCustomization->setEnabled( true );
+
+  mQgisApp->mCustomization->apply();
+  QVERIFY( !findQWidget<QMenu>( "Menus/mHelpMenu" ) );
+
+  mQgisApp->mCustomization->write();
+
+  // re-read written customization
+  customization = std::make_unique<QgsCustomization>( mCustomizationFile->fileName() );
+  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" ) );
+  QVERIFY( !getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" )->isVisible() );
+  QVERIFY( customization->isEnabled() );
+}
+
+void TestQgsCustomization::testBackwardCompatiblity()
+{
+  QSettings().setValue( "UI/Customization/enabled", true );
+
+  QTemporaryFile iniFile;
+  iniFile.open(); // fileName is not available until open
+  const QString iniFileName = iniFile.fileName();
+
+  {
+    QSettings settings( iniFileName, QSettings::IniFormat );
+
+    settings.setValue( "/Customization/splashpath", "/tmp/splashPath.png" );
+
+    settings.setValue( "Customization/Toolbars/mAnnotationsToolBar/mActionAnnotationdeligne", true );
+    settings.setValue( "Customization/Toolbars/mAnnotationsToolBar/mActionAnnotationdepolygone", false );
+
+    settings.setValue( "Customization/Toolbars/mAttributesToolBar/ActionMeasure", false );
+    settings.setValue( "Customization/Toolbars/mAttributesToolBar/ActionMeasure/mActionMeasure", true );
+    settings.setValue( "Customization/Toolbars/mAttributesToolBar/ActionMeasure/mActionMeasureAngle", false );
+
+    settings.setValue( "Customization/Menus/mEditMenu/mActionCopyFeatures", true );
+    settings.setValue( "Customization/Menus/mEditMenu/mActionCutFeatures", false );
+    settings.setValue( "Customization/Menus/mViewMenu/mMenuMeasure", false );
+    settings.setValue( "Customization/Menus/mViewMenu/mMenuMeasure/mActionMeasure", true );
+    settings.setValue( "Customization/Menus/mViewMenu/mMenuMeasure/mActionMeasureAngle", false );
+
+    settings.setValue( "Customization/Docks/AdvancedDigitizingTools", true );
+    settings.setValue( "Customization/Docks/BookmarksDockWidget", false );
+
+    settings.setValue( "Customization/StatusBar", false );
+    settings.setValue( "Customization/StatusBar/LocatorWidget", true );
+    settings.setValue( "Customization/StatusBar/mCoordsEdit", false );
+
+    settings.setValue( "Customization/Browser/GPKG", true );
+    settings.setValue( "Customization/Browser/MSSQL", false );
+  }
+
+  auto customization = std::make_unique<QgsCustomization>( ( QString() ) );
+  customization->loadOldIniFile( iniFileName );
+
+  QVERIFY( customization->isEnabled() );
+  QCOMPARE( customization->splashPath(), "/tmp/splashPath.png" );
+
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAnnotationsToolBar/mActionAnnotationdeligne" ) );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAnnotationsToolBar/mActionAnnotationdeligne" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAnnotationsToolBar/mActionAnnotationdepolygone" ) );
+  QVERIFY( !getItem<QgsCustomization::Action>( customization, "ToolBars/mAnnotationsToolBar/mActionAnnotationdepolygone" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure" ) );
+  QVERIFY( !getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasure" ) );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasure" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasureAngle" ) );
+  QVERIFY( !getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasureAngle" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionCopyFeatures" ) );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionCopyFeatures" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionCutFeatures" ) );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure" ) );
+  QVERIFY( !getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure/mActionMeasure" ) );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure/mActionMeasure" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure/mActionMeasureAngle" ) );
+  QVERIFY( !getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure/mActionMeasureAngle" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::Dock>( customization, "Docks/AdvancedDigitizingTools" ) );
+  QVERIFY( getItem<QgsCustomization::Dock>( customization, "Docks/AdvancedDigitizingTools" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::Dock>( customization, "Docks/BookmarksDockWidget" ) );
+  QVERIFY( !getItem<QgsCustomization::Dock>( customization, "Docks/BookmarksDockWidget" )->isVisible() );
+
+  QVERIFY( !customization->statusBarWidgets()->isVisible() );
+  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/LocatorWidget" ) );
+  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/LocatorWidget" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/mCoordsEdit" ) );
+  QVERIFY( !getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/mCoordsEdit" )->isVisible() );
+
+  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/GPKG" ) );
+  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/GPKG" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/MSSQL" ) );
+  QVERIFY( !getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/MSSQL" )->isVisible() );
+}
+
+
+QGSTEST_MAIN( TestQgsCustomization )
+#include "testqgscustomization.moc"

--- a/tests/src/app/testqgscustomization.cpp
+++ b/tests/src/app/testqgscustomization.cpp
@@ -14,13 +14,13 @@
  ***************************************************************************/
 
 #include "qgisapp.h"
+#include "qgsbrowserdockwidget.h"
 #include "qgsbrowserguimodel.h"
 #include "qgsbrowserwidget.h"
-#include "qgslayertreeview.h"
-#include "qgstest.h"
 #include "qgscustomization.h"
+#include "qgslayertreeview.h"
 #include "qgsstatusbar.h"
-#include "qgsbrowserdockwidget.h"
+#include "qgstest.h"
 
 #include <QDockWidget>
 
@@ -41,7 +41,7 @@ class TestQgsCustomization : public QgsTest
     void testLoadApply();
     void testActionPosition();
     void testEnabled();
-    void testBackwardCompatiblity();
+    void testBackwardCompatibility();
 
   private:
     template<class T>
@@ -477,7 +477,7 @@ void TestQgsCustomization::testEnabled()
   QVERIFY( customization->isEnabled() );
 }
 
-void TestQgsCustomization::testBackwardCompatiblity()
+void TestQgsCustomization::testBackwardCompatibility()
 {
   QSettings().setValue( "UI/Customization/enabled", true );
 

--- a/tests/src/app/testqgscustomization.cpp
+++ b/tests/src/app/testqgscustomization.cpp
@@ -49,15 +49,15 @@ class TestQgsCustomization : public QgsTest
 
   private:
     template<class T>
-    T *getItem( const std::unique_ptr<QgsCustomization> &customization, const QString &path ) const
+    T *getItem( QgsCustomization *customization, const QString &path ) const
     {
       return dynamic_cast<T *>( getItem( customization, path ) );
     }
-    QgsCustomization::Item *getItem( const std::unique_ptr<QgsCustomization> &customization, const QString &path ) const;
+    QgsCustomization::QgsItem *getItem( QgsCustomization *customization, const QString &path ) const;
 
     template<class T>
     T *getItem( const QString &path ) const { return dynamic_cast<T *>( getItem( path ) ); }
-    QgsCustomization::Item *getItem( const QString &path ) const
+    QgsCustomization::QgsItem *getItem( const QString &path ) const
     {
       return getItem( mQgisApp->customization(), path );
     }
@@ -77,21 +77,21 @@ class TestQgsCustomization : public QgsTest
     std::unique_ptr<QTemporaryFile> mCustomizationFile;
 };
 
-QgsCustomization::Item *TestQgsCustomization::getItem( const std::unique_ptr<QgsCustomization> &customization, const QString &path ) const
+QgsCustomization::QgsItem *TestQgsCustomization::getItem( QgsCustomization *customization, const QString &path ) const
 {
   QStringList pathElems = path.split( "/" );
   if ( pathElems.isEmpty() )
     return nullptr;
 
-  const QHash<QString, QgsCustomization::Item *> rootItems = {
-    { "Menus", customization->menus().get() },
-    { "ToolBars", customization->toolBars().get() },
-    { "Docks", customization->docks().get() },
-    { "BrowserItems", customization->browserItems().get() },
-    { "StatusBarWidgets", customization->statusBarWidgets().get() }
+  const QHash<QString, QgsCustomization::QgsItem *> rootItems = {
+    { "Menus", customization->menusItem() },
+    { "ToolBars", customization->toolBarsItem() },
+    { "Docks", customization->docksItem() },
+    { "BrowserItems", customization->browserElementsItem() },
+    { "StatusBarWidgets", customization->statusBarWidgetsItem() }
   };
 
-  QgsCustomization::Item *currentItem = nullptr;
+  QgsCustomization::QgsItem *currentItem = nullptr;
   for ( const QString &pathElem : pathElems )
   {
     if ( currentItem )
@@ -129,7 +129,7 @@ QWidget *TestQgsCustomization::findQWidget( const QString &path )
          || dynamic_cast<QMenu *>( currentWidget )
          || dynamic_cast<QMenuBar *>( currentWidget ) )
     {
-      for ( QgsCustomization::QWidgetIterator::Info it : QgsCustomization::QWidgetIterator( currentWidget ) )
+      for ( QgsCustomization::QgsQActionsIterator::Info it : QgsCustomization::QgsQActionsIterator( currentWidget ) )
       {
         if ( it.name == pathElem )
         {
@@ -248,23 +248,23 @@ void TestQgsCustomization::testLoadApply()
 
   // Make some modifications to the current customization
   auto setAllVisible = [this]( bool visible ) {
-    QVERIFY( getItem<QgsCustomization::Menu>( "Menus/mHelpMenu" ) );
-    getItem<QgsCustomization::Menu>( "Menus/mHelpMenu" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" ) );
-    getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::ToolBar>( "ToolBars/mFileToolBar" ) );
-    getItem<QgsCustomization::ToolBar>( "ToolBars/mFileToolBar" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
-    getItem<QgsCustomization::Action>( "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::BrowserItem>( "BrowserItems/special:Home" ) );
-    getItem<QgsCustomization::BrowserItem>( "BrowserItems/special:Home" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::Dock>( "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
-    getItem<QgsCustomization::Dock>( "Docks/QgsAdvancedDigitizingDockWidgetBase" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::StatusBarWidget>( "StatusBarWidgets/LocatorWidget" ) );
-    getItem<QgsCustomization::StatusBarWidget>( "StatusBarWidgets/LocatorWidget" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsMenuItem>( "Menus/mHelpMenu" ) );
+    getItem<QgsCustomization::QgsMenuItem>( "Menus/mHelpMenu" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRedo" ) );
+    getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRedo" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsToolBarItem>( "ToolBars/mFileToolBar" ) );
+    getItem<QgsCustomization::QgsToolBarItem>( "ToolBars/mFileToolBar" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsActionItem>( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
+    getItem<QgsCustomization::QgsActionItem>( "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( "BrowserItems/special:Home" ) );
+    getItem<QgsCustomization::QgsBrowserElementItem>( "BrowserItems/special:Home" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsDockItem>( "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
+    getItem<QgsCustomization::QgsDockItem>( "Docks/QgsAdvancedDigitizingDockWidgetBase" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( "StatusBarWidgets/LocatorWidget" ) );
+    getItem<QgsCustomization::QgsStatusBarWidgetItem>( "StatusBarWidgets/LocatorWidget" )->setVisible( visible );
 
-    QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
-    getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
+    getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->setVisible( visible );
   };
 
   setAllVisible( false );
@@ -275,43 +275,43 @@ void TestQgsCustomization::testLoadApply()
   auto customization = std::make_unique<QgsCustomization>( mCustomizationFile->fileName() );
 
   // test item visiblity
-  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mProjectMenu" ) );
-  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mProjectMenu" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" ) );
-  QVERIFY( !getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mProjectMenu" ) );
+  QVERIFY( getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mProjectMenu" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mHelpMenu" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mHelpMenu" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionUndo" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionUndo" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionRedo" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionRedo" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionUndo" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionUndo" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionRedo" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionRedo" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mFileToolBar" ) );
-  QVERIFY( !getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mFileToolBar" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mAttributesToolBar" ) );
-  QVERIFY( getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mAttributesToolBar" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsToolBarItem>( customization.get(), "ToolBars/mFileToolBar" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsToolBarItem>( customization.get(), "ToolBars/mFileToolBar" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsToolBarItem>( customization.get(), "ToolBars/mAttributesToolBar" ) );
+  QVERIFY( getItem<QgsCustomization::QgsToolBarItem>( customization.get(), "ToolBars/mAttributesToolBar" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddVirtualLayer" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddVirtualLayer" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mLayerToolBar/mActionAddVirtualLayer" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mLayerToolBar/mActionAddVirtualLayer" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/special:Home" ) );
-  QVERIFY( !getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/special:Home" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/GPKG" ) );
-  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/GPKG" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/special:Home" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/special:Home" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/GPKG" ) );
+  QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/GPKG" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Dock>( customization, "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
-  QVERIFY( !getItem<QgsCustomization::Dock>( customization, "Docks/QgsAdvancedDigitizingDockWidgetBase" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsDockItem>( customization.get(), "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsDockItem>( customization.get(), "Docks/QgsAdvancedDigitizingDockWidgetBase" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/mProgressBar" ) );
-  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/mProgressBar" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/LocatorWidget" ) );
-  QVERIFY( !getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/LocatorWidget" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/mProgressBar" ) );
+  QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/mProgressBar" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/LocatorWidget" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/LocatorWidget" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction2" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction2" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction2" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction2" )->isVisible() );
 
   // test initial situation
   QVERIFY( findQWidget<QMenu>( "Menus/mHelpMenu" ) );
@@ -396,10 +396,10 @@ void TestQgsCustomization::testActionPosition()
   QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" ) );
   QVERIFY( findQAction( "ToolBars/mDigitizeToolBar/mActionRedo" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" ) );
-  getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" )->setVisible( false );
-  QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRotatePointSymbols" ) );
-  getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRotatePointSymbols" )->setVisible( false );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRedo" ) );
+  getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRedo" )->setVisible( false );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRotatePointSymbols" ) );
+  getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRotatePointSymbols" )->setVisible( false );
 
   // apply modification
   mQgisApp->customization()->apply();
@@ -414,10 +414,10 @@ void TestQgsCustomization::testActionPosition()
   QCOMPARE( qactionPosition( "Menus/mEditMenu/mActionUndo" ), undoPosition );
 
   // go back to initial situation
-  QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" ) );
-  getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" )->setVisible( true );
-  QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRotatePointSymbols" ) );
-  getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRotatePointSymbols" )->setVisible( true );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRedo" ) );
+  getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRedo" )->setVisible( true );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRotatePointSymbols" ) );
+  getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRotatePointSymbols" )->setVisible( true );
 
   mQgisApp->customization()->apply();
 
@@ -435,8 +435,8 @@ void TestQgsCustomization::testActionPosition()
 
   // remove mActionRedo and check mActionRotatePointSymbols position is just same as before minus one
   // (because mActionRedo is missing)
-  QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" ) );
-  getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" )->setVisible( false );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRedo" ) );
+  getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRedo" )->setVisible( false );
 
   mQgisApp->customization()->apply();
 
@@ -448,15 +448,15 @@ void TestQgsCustomization::testActionPosition()
 
 void TestQgsCustomization::testEnabled()
 {
-  QVERIFY( getItem<QgsCustomization::Menu>( "Menus/mHelpMenu" ) );
-  getItem<QgsCustomization::Menu>( "Menus/mHelpMenu" )->setVisible( false );
+  QVERIFY( getItem<QgsCustomization::QgsMenuItem>( "Menus/mHelpMenu" ) );
+  getItem<QgsCustomization::QgsMenuItem>( "Menus/mHelpMenu" )->setVisible( false );
 
   mQgisApp->customization()->write();
 
   // re-read written customization
   auto customization = std::make_unique<QgsCustomization>( mCustomizationFile->fileName() );
-  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" ) );
-  QVERIFY( !getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mHelpMenu" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mHelpMenu" )->isVisible() );
   QVERIFY( !customization->isEnabled() );
 
   QVERIFY( findQWidget<QMenu>( "Menus/mHelpMenu" ) );
@@ -475,8 +475,8 @@ void TestQgsCustomization::testEnabled()
 
   // re-read written customization
   customization = std::make_unique<QgsCustomization>( mCustomizationFile->fileName() );
-  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" ) );
-  QVERIFY( !getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mHelpMenu" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mHelpMenu" )->isVisible() );
   QVERIFY( customization->isEnabled() );
 }
 
@@ -523,43 +523,43 @@ void TestQgsCustomization::testBackwardCompatibility()
   QVERIFY( customization->isEnabled() );
   QCOMPARE( customization->splashPath(), "/tmp/splashPath.png" );
 
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAnnotationsToolBar/mActionAnnotationdeligne" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAnnotationsToolBar/mActionAnnotationdeligne" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAnnotationsToolBar/mActionAnnotationdepolygone" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( customization, "ToolBars/mAnnotationsToolBar/mActionAnnotationdepolygone" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mAnnotationsToolBar/mActionAnnotationdeligne" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mAnnotationsToolBar/mActionAnnotationdeligne" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mAnnotationsToolBar/mActionAnnotationdepolygone" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mAnnotationsToolBar/mActionAnnotationdepolygone" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasure" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasure" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasureAngle" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( customization, "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasureAngle" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mAttributesToolBar/ActionMeasure" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mAttributesToolBar/ActionMeasure" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasure" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasure" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasureAngle" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mAttributesToolBar/ActionMeasure/mActionMeasureAngle" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionCopyFeatures" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionCopyFeatures" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionCutFeatures" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure/mActionMeasure" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure/mActionMeasure" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure/mActionMeasureAngle" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( customization, "Menus/mViewMenu/mMenuMeasure/mActionMeasureAngle" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionCopyFeatures" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionCopyFeatures" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionCutFeatures" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mViewMenu/mMenuMeasure" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mViewMenu/mMenuMeasure" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mViewMenu/mMenuMeasure/mActionMeasure" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mViewMenu/mMenuMeasure/mActionMeasure" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mViewMenu/mMenuMeasure/mActionMeasureAngle" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mViewMenu/mMenuMeasure/mActionMeasureAngle" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Dock>( customization, "Docks/AdvancedDigitizingTools" ) );
-  QVERIFY( getItem<QgsCustomization::Dock>( customization, "Docks/AdvancedDigitizingTools" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Dock>( customization, "Docks/BookmarksDockWidget" ) );
-  QVERIFY( !getItem<QgsCustomization::Dock>( customization, "Docks/BookmarksDockWidget" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsDockItem>( customization.get(), "Docks/AdvancedDigitizingTools" ) );
+  QVERIFY( getItem<QgsCustomization::QgsDockItem>( customization.get(), "Docks/AdvancedDigitizingTools" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsDockItem>( customization.get(), "Docks/BookmarksDockWidget" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsDockItem>( customization.get(), "Docks/BookmarksDockWidget" )->isVisible() );
 
-  QVERIFY( !customization->statusBarWidgets()->isVisible() );
-  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/LocatorWidget" ) );
-  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/LocatorWidget" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/mCoordsEdit" ) );
-  QVERIFY( !getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/mCoordsEdit" )->isVisible() );
+  QVERIFY( !customization->statusBarWidgetsItem()->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/LocatorWidget" ) );
+  QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/LocatorWidget" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/mCoordsEdit" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/mCoordsEdit" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/GPKG" ) );
-  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/GPKG" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/MSSQL" ) );
-  QVERIFY( !getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/MSSQL" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/GPKG" ) );
+  QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/GPKG" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/MSSQL" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/MSSQL" )->isVisible() );
 }
 
 void TestQgsCustomization::testClone()
@@ -568,23 +568,23 @@ void TestQgsCustomization::testClone()
 
   // Make some modifications to the current customization
   auto setAllVisible = [this]( bool visible ) {
-    QVERIFY( getItem<QgsCustomization::Menu>( "Menus/mHelpMenu" ) );
-    getItem<QgsCustomization::Menu>( "Menus/mHelpMenu" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" ) );
-    getItem<QgsCustomization::Action>( "Menus/mEditMenu/mActionRedo" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::ToolBar>( "ToolBars/mFileToolBar" ) );
-    getItem<QgsCustomization::ToolBar>( "ToolBars/mFileToolBar" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
-    getItem<QgsCustomization::Action>( "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::BrowserItem>( "BrowserItems/special:Home" ) );
-    getItem<QgsCustomization::BrowserItem>( "BrowserItems/special:Home" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::Dock>( "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
-    getItem<QgsCustomization::Dock>( "Docks/QgsAdvancedDigitizingDockWidgetBase" )->setVisible( visible );
-    QVERIFY( getItem<QgsCustomization::StatusBarWidget>( "StatusBarWidgets/LocatorWidget" ) );
-    getItem<QgsCustomization::StatusBarWidget>( "StatusBarWidgets/LocatorWidget" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsMenuItem>( "Menus/mHelpMenu" ) );
+    getItem<QgsCustomization::QgsMenuItem>( "Menus/mHelpMenu" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRedo" ) );
+    getItem<QgsCustomization::QgsActionItem>( "Menus/mEditMenu/mActionRedo" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsToolBarItem>( "ToolBars/mFileToolBar" ) );
+    getItem<QgsCustomization::QgsToolBarItem>( "ToolBars/mFileToolBar" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsActionItem>( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
+    getItem<QgsCustomization::QgsActionItem>( "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( "BrowserItems/special:Home" ) );
+    getItem<QgsCustomization::QgsBrowserElementItem>( "BrowserItems/special:Home" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsDockItem>( "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
+    getItem<QgsCustomization::QgsDockItem>( "Docks/QgsAdvancedDigitizingDockWidgetBase" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( "StatusBarWidgets/LocatorWidget" ) );
+    getItem<QgsCustomization::QgsStatusBarWidgetItem>( "StatusBarWidgets/LocatorWidget" )->setVisible( visible );
 
-    QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
-    getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->setVisible( visible );
+    QVERIFY( getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
+    getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->setVisible( visible );
   };
 
   setAllVisible( false );
@@ -593,43 +593,43 @@ void TestQgsCustomization::testClone()
   auto customization = std::make_unique<QgsCustomization>( *mQgisApp->customization() );
 
   // test item visiblity
-  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mProjectMenu" ) );
-  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mProjectMenu" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" ) );
-  QVERIFY( !getItem<QgsCustomization::Menu>( customization, "Menus/mHelpMenu" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mProjectMenu" ) );
+  QVERIFY( getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mProjectMenu" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mHelpMenu" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsMenuItem>( customization.get(), "Menus/mHelpMenu" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionUndo" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionUndo" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionRedo" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( customization, "Menus/mEditMenu/mActionRedo" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionUndo" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionUndo" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionRedo" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( customization.get(), "Menus/mEditMenu/mActionRedo" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mFileToolBar" ) );
-  QVERIFY( !getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mFileToolBar" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mAttributesToolBar" ) );
-  QVERIFY( getItem<QgsCustomization::ToolBar>( customization, "ToolBars/mAttributesToolBar" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsToolBarItem>( customization.get(), "ToolBars/mFileToolBar" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsToolBarItem>( customization.get(), "ToolBars/mFileToolBar" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsToolBarItem>( customization.get(), "ToolBars/mAttributesToolBar" ) );
+  QVERIFY( getItem<QgsCustomization::QgsToolBarItem>( customization.get(), "ToolBars/mAttributesToolBar" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddVirtualLayer" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddVirtualLayer" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( customization, "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mLayerToolBar/mActionAddVirtualLayer" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mLayerToolBar/mActionAddVirtualLayer" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( customization.get(), "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/special:Home" ) );
-  QVERIFY( !getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/special:Home" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/GPKG" ) );
-  QVERIFY( getItem<QgsCustomization::BrowserItem>( customization, "BrowserItems/GPKG" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/special:Home" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/special:Home" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/GPKG" ) );
+  QVERIFY( getItem<QgsCustomization::QgsBrowserElementItem>( customization.get(), "BrowserItems/GPKG" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Dock>( customization, "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
-  QVERIFY( !getItem<QgsCustomization::Dock>( customization, "Docks/QgsAdvancedDigitizingDockWidgetBase" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsDockItem>( customization.get(), "Docks/QgsAdvancedDigitizingDockWidgetBase" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsDockItem>( customization.get(), "Docks/QgsAdvancedDigitizingDockWidgetBase" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/mProgressBar" ) );
-  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/mProgressBar" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/LocatorWidget" ) );
-  QVERIFY( !getItem<QgsCustomization::StatusBarWidget>( customization, "StatusBarWidgets/LocatorWidget" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/mProgressBar" ) );
+  QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/mProgressBar" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/LocatorWidget" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsStatusBarWidgetItem>( customization.get(), "StatusBarWidgets/LocatorWidget" )->isVisible() );
 
-  QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
-  QVERIFY( !getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->isVisible() );
-  QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction2" ) );
-  QVERIFY( getItem<QgsCustomization::Action>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction2" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" ) );
+  QVERIFY( !getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction1" )->isVisible() );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction2" ) );
+  QVERIFY( getItem<QgsCustomization::QgsActionItem>( "ToolBars/testToolBar/testToolBarToolButton/testToolBarMenuAction2" )->isVisible() );
 
   // test initial situation
   QVERIFY( findQWidget<QMenu>( "Menus/mHelpMenu" ) );

--- a/tests/src/app/testqgscustomization.cpp
+++ b/tests/src/app/testqgscustomization.cpp
@@ -32,7 +32,7 @@ class TestQgsCustomization : public QgsTest
 
   public:
     TestQgsCustomization()
-      : QgsTest( QStringLiteral( "Customization Tests" ) ) {}
+      : QgsTest( u"Customization Tests"_s ) {}
 
   private slots:
     void initTestCase();    // will be called before the first testfunction is executed.
@@ -202,7 +202,7 @@ void TestQgsCustomization::init()
 
   QgsBrowserGuiModel *browserModel = new QgsBrowserGuiModel( this );
   mQgisApp->mBrowserWidget = new QgsBrowserDockWidget( tr( "Browser" ), browserModel, mQgisApp.get() );
-  mQgisApp->mBrowserWidget->setObjectName( QStringLiteral( "Browser" ) );
+  mQgisApp->mBrowserWidget->setObjectName( u"Browser"_s );
 
 
   // add a test tool bar to test action with menu
@@ -590,7 +590,7 @@ void TestQgsCustomization::testClone()
   setAllVisible( false );
 
   // copy customization
-  std::unique_ptr<QgsCustomization> customization( new QgsCustomization( *mQgisApp->customization() ) );
+  auto customization = std::make_unique<QgsCustomization>( *mQgisApp->customization() );
 
   // test item visiblity
   QVERIFY( getItem<QgsCustomization::Menu>( customization, "Menus/mProjectMenu" ) );
@@ -728,15 +728,15 @@ void TestQgsCustomization::testModel()
   // Uncheck ToolBars/mLayerToolBar/mActionAddRasterLayer item
   {
     QModelIndex toolBarsIndex = model.index( 4, 0 );
-    QCOMPARE( model.data( toolBarsIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "ToolBars" ) );
+    QCOMPARE( model.data( toolBarsIndex, Qt::ItemDataRole::DisplayRole ), u"ToolBars"_s );
     QModelIndexList items = model.match( model.index( 0, 0, toolBarsIndex ), Qt::DisplayRole, "mLayerToolBar", 1 );
     QCOMPARE( items.count(), 1 );
     QModelIndex layerToolBarIndex = items.first();
-    QCOMPARE( model.data( layerToolBarIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "mLayerToolBar" ) );
+    QCOMPARE( model.data( layerToolBarIndex, Qt::ItemDataRole::DisplayRole ), u"mLayerToolBar"_s );
     items = model.match( model.index( 0, 0, layerToolBarIndex ), Qt::DisplayRole, "mActionAddRasterLayer", 1 );
     QCOMPARE( items.count(), 1 );
     QModelIndex addRasterLayerIndex = items.first();
-    QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "mActionAddRasterLayer" ) );
+    QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::DisplayRole ), u"mActionAddRasterLayer"_s );
 
     model.setData( addRasterLayerIndex, Qt::CheckState::Unchecked, Qt::ItemDataRole::CheckStateRole );
     QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::CheckStateRole ), Qt::CheckState::Unchecked );
@@ -753,15 +753,15 @@ void TestQgsCustomization::testModel()
 
   {
     QModelIndex toolBarsIndex = model.index( 4, 0 );
-    QCOMPARE( model.data( toolBarsIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "ToolBars" ) );
+    QCOMPARE( model.data( toolBarsIndex, Qt::ItemDataRole::DisplayRole ), u"ToolBars"_s );
     QModelIndexList items = model.match( model.index( 0, 0, toolBarsIndex ), Qt::DisplayRole, "mLayerToolBar", 1 );
     QCOMPARE( items.count(), 1 );
     QModelIndex layerToolBarIndex = items.first();
-    QCOMPARE( model.data( layerToolBarIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "mLayerToolBar" ) );
+    QCOMPARE( model.data( layerToolBarIndex, Qt::ItemDataRole::DisplayRole ), u"mLayerToolBar"_s );
     items = model.match( model.index( 0, 0, layerToolBarIndex ), Qt::DisplayRole, "mActionAddRasterLayer", 1 );
     QCOMPARE( items.count(), 1 );
     QModelIndex addRasterLayerIndex = items.first();
-    QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "mActionAddRasterLayer" ) );
+    QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::DisplayRole ), u"mActionAddRasterLayer"_s );
 
     QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::CheckStateRole ), Qt::CheckState::Checked );
   }
@@ -769,15 +769,15 @@ void TestQgsCustomization::testModel()
   // Uncheck ToolBars/mLayerToolBar/mActionAddRasterLayer item
   {
     QModelIndex toolBarsIndex = model.index( 4, 0 );
-    QCOMPARE( model.data( toolBarsIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "ToolBars" ) );
+    QCOMPARE( model.data( toolBarsIndex, Qt::ItemDataRole::DisplayRole ), u"ToolBars"_s );
     QModelIndexList items = model.match( model.index( 0, 0, toolBarsIndex ), Qt::DisplayRole, "mLayerToolBar", 1 );
     QCOMPARE( items.count(), 1 );
     QModelIndex layerToolBarIndex = items.first();
-    QCOMPARE( model.data( layerToolBarIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "mLayerToolBar" ) );
+    QCOMPARE( model.data( layerToolBarIndex, Qt::ItemDataRole::DisplayRole ), u"mLayerToolBar"_s );
     items = model.match( model.index( 0, 0, layerToolBarIndex ), Qt::DisplayRole, "mActionAddRasterLayer", 1 );
     QCOMPARE( items.count(), 1 );
     QModelIndex addRasterLayerIndex = items.first();
-    QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "mActionAddRasterLayer" ) );
+    QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::DisplayRole ), u"mActionAddRasterLayer"_s );
 
     model.setData( addRasterLayerIndex, Qt::CheckState::Unchecked, Qt::ItemDataRole::CheckStateRole );
     QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::CheckStateRole ), Qt::CheckState::Unchecked );
@@ -791,15 +791,15 @@ void TestQgsCustomization::testModel()
 
   {
     QModelIndex toolBarsIndex = model.index( 4, 0 );
-    QCOMPARE( model.data( toolBarsIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "ToolBars" ) );
+    QCOMPARE( model.data( toolBarsIndex, Qt::ItemDataRole::DisplayRole ), u"ToolBars"_s );
     QModelIndexList items = model.match( model.index( 0, 0, toolBarsIndex ), Qt::DisplayRole, "mLayerToolBar", 1 );
     QCOMPARE( items.count(), 1 );
     QModelIndex layerToolBarIndex = items.first();
-    QCOMPARE( model.data( layerToolBarIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "mLayerToolBar" ) );
+    QCOMPARE( model.data( layerToolBarIndex, Qt::ItemDataRole::DisplayRole ), u"mLayerToolBar"_s );
     items = model.match( model.index( 0, 0, layerToolBarIndex ), Qt::DisplayRole, "mActionAddRasterLayer", 1 );
     QCOMPARE( items.count(), 1 );
     QModelIndex addRasterLayerIndex = items.first();
-    QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::DisplayRole ), QStringLiteral( "mActionAddRasterLayer" ) );
+    QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::DisplayRole ), u"mActionAddRasterLayer"_s );
 
     model.setData( addRasterLayerIndex, Qt::CheckState::Unchecked, Qt::ItemDataRole::CheckStateRole );
     QCOMPARE( model.data( addRasterLayerIndex, Qt::ItemDataRole::CheckStateRole ), Qt::CheckState::Unchecked );

--- a/tests/src/app/testqgscustomization.cpp
+++ b/tests/src/app/testqgscustomization.cpp
@@ -125,7 +125,7 @@ QWidget *TestQgsCustomization::findQWidget( const QString &path )
          || dynamic_cast<QMenu *>( currentWidget )
          || dynamic_cast<QMenuBar *>( currentWidget ) )
     {
-      for ( QgsCustomization::QWidgetIterator::Infos it : QgsCustomization::QWidgetIterator( currentWidget ) )
+      for ( QgsCustomization::QWidgetIterator::Info it : QgsCustomization::QWidgetIterator( currentWidget ) )
       {
         if ( it.name == pathElem )
         {


### PR DESCRIPTION
This is a complete rewriting of the customization code and a preliminary work for [#QEP343](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-343-customized-toolbars-and-menus.md)

Customization is now read from an XML file so we can later keep track of action order in menus and tool bars. This XML file is read on a tree model where every node is an Item. Item is then inherited by any customizable widget item.

- read() methods reads the XML file into the model. 
- load() update the model with the different graphical element
- apply() apply the model to the QGIS main window and the 2 browser widgets.

Thanks to this rework, we gain the ability to see our edit live in QGIS.

![customization](https://github.com/user-attachments/assets/0114091c-c502-40dc-bac2-b45d3e873495)

**Funded by Stadt Frankfurt am Main and Oslandia**

