### PR TITLE
Cleanup grid annotation drawing

### DIFF
--- a/src/core/layout/qgslayoutitemmapgrid.cpp
+++ b/src/core/layout/qgslayoutitemmapgrid.cpp
@@ -1365,7 +1365,7 @@ void QgsLayoutItemMapGrid::drawCoordinateAnnotation( QgsRenderContext &context, 
     return;
 
   const Qgis::MapGridBorderSide frameBorder = annot.border;
-  double textWidth = QgsTextRenderer::textWidth( context, mAnnotationFormat, QStringList() << annotationString ) / context.convertToPainterUnits( 1, Qgis::RenderUnit::Millimeters );
+  double textWidth = QgsTextRenderer::textWidth( context, mAnnotationFormat, annotationString.split( '\n' ) ) / context.convertToPainterUnits( 1, Qgis::RenderUnit::Millimeters );
   if ( extension )
     textWidth *= 1.1; // little bit of extra padding when we are calculating the bounding rect, to account for antialiasing
 

--- a/src/core/layout/qgslayoutitemmapgrid.cpp
+++ b/src/core/layout/qgslayoutitemmapgrid.cpp
@@ -1437,7 +1437,7 @@ void QgsLayoutItemMapGrid::drawCoordinateAnnotation( QgsRenderContext &context, 
     distanceToFrameMM /= QVector2D::dotProduct( vector, normalVector );
   }
 
-  const QVector2D annotationPositionMM = annot.position + distanceToFrameMM * vector;
+  const QVector2D annotationPositionMM = annot.position + static_cast< float >( distanceToFrameMM ) * vector;
 
   const bool outside = ( anotPos == Qgis::MapGridAnnotationPosition::OutsideMapFrame );
 

--- a/src/core/layout/qgslayoutitemmapgrid.cpp
+++ b/src/core/layout/qgslayoutitemmapgrid.cpp
@@ -1391,9 +1391,18 @@ void QgsLayoutItemMapGrid::drawCoordinateAnnotation( QgsRenderContext &context, 
 
   const double textWidthMM = textWidthPainterUnits * painterUnitsToMM ;
 
-  //relevant for annotations is the height of digits
-  const double textHeightPainterUnits = extension ? QgsTextRenderer::textHeight( context, mAnnotationFormat, QChar(), true )
-                                        : QgsTextRenderer::textHeight( context, mAnnotationFormat, '0', false );
+  double textHeightPainterUnits = 0;
+  if ( extension || doc.size() > 1 )
+  {
+    textHeightPainterUnits = sizePainterUnits.height();
+  }
+  else
+  {
+    // special logic for single line annotations -- using fixed digit height only.
+    // kept for pixel-perfect compatibility with existing renders prior to proper support for
+    // multi-line annotation labels
+    textHeightPainterUnits = QgsTextRenderer::textHeight( context, mAnnotationFormat, '0', false );
+  }
   const double textHeightMM = textHeightPainterUnits * painterUnitsToMM;
 
 


### PR DESCRIPTION
- Fix some remaining issues when using multiline labels (especially with mixed format annotation strings)
- Rename variables to make it clear which are in millimeters and which are in painter units, and rename ambiguously named variables for clarity
