### PR TITLE
Support loading assets from STAC collections

### DIFF
--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -58,8 +58,17 @@ bool QgsStacAssetItem::hasDragEnabled() const
 
 QgsMimeDataUtils::UriList QgsStacAssetItem::mimeUris() const
 {
-  QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( parent() );
-  const QString authcfg = itemItem->stacController()->authCfg();
+  QgsStacController *controller = nullptr;
+  if ( QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( parent() ) )
+  {
+    controller = itemItem->stacController();
+  }
+  else if ( QgsStacCatalogItem *catalogItem = qobject_cast<QgsStacCatalogItem *>( parent() ) )
+  {
+    controller = catalogItem->stacController();
+  }
+
+  const QString authcfg = controller ? controller->authCfg() : QString();
 
   QgsMimeDataUtils::Uri uri;
   QUrl url( mStacAsset->href() );
@@ -453,6 +462,19 @@ QVector<QgsDataItem *> QgsStacCatalogItem::createChildren()
     else
     {
       // todo: should handle other links?
+    }
+  }
+
+  if ( mIsCollection )
+  {
+    if ( QgsStacCollection *collection = dynamic_cast<QgsStacCollection *>( mStacCatalog.get() ) )
+    {
+      const QMap<QString, QgsStacAsset> assets = collection->assets();
+      for ( auto it = assets.constBegin(); it != assets.constEnd(); ++it )
+      {
+        QgsStacAssetItem *assetItem = new QgsStacAssetItem( this, it.key(), &it.value() );
+        contents.append( assetItem );
+      }
     }
   }
 

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -56,17 +56,23 @@ bool QgsStacAssetItem::hasDragEnabled() const
   return mStacAsset->isCloudOptimized();
 }
 
+QgsStacController *QgsStacAssetItem::stacController() const
+{
+  if ( const QgsStacItemItem *itemItem = qobject_cast<const QgsStacItemItem *>( parent() ) )
+  {
+    return itemItem->stacController();
+  }
+  else if ( const QgsStacCatalogItem *catalogItem = qobject_cast<const QgsStacCatalogItem *>( parent() ) )
+  {
+    return catalogItem->stacController();
+  }
+  Q_ASSERT( false );
+  return nullptr;
+}
+
 QgsMimeDataUtils::UriList QgsStacAssetItem::mimeUris() const
 {
-  QgsStacController *controller = nullptr;
-  if ( QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( parent() ) )
-  {
-    controller = itemItem->stacController();
-  }
-  else if ( QgsStacCatalogItem *catalogItem = qobject_cast<QgsStacCatalogItem *>( parent() ) )
-  {
-    controller = catalogItem->stacController();
-  }
+  QgsStacController *controller = stacController();
 
   const QString authcfg = controller ? controller->authCfg() : QString();
 

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -470,16 +470,13 @@ QVector<QgsDataItem *> QgsStacCatalogItem::createChildren()
     }
   }
 
-  if ( mIsCollection )
+  if ( QgsStacCollection *collection = qobject_cast<QgsStacCollection *>( mStacCatalog.get() ) )
   {
-    if ( QgsStacCollection *collection = dynamic_cast<QgsStacCollection *>( mStacCatalog.get() ) )
+    const QMap<QString, QgsStacAsset> assets = collection->assets();
+    for ( auto it = assets.constBegin(); it != assets.constEnd(); ++it )
     {
-      const QMap<QString, QgsStacAsset> assets = collection->assets();
-      for ( auto it = assets.constBegin(); it != assets.constEnd(); ++it )
-      {
-        QgsStacAssetItem *assetItem = new QgsStacAssetItem( this, it.key(), &it.value() );
-        contents.append( assetItem );
-      }
+      QgsStacAssetItem *assetItem = new QgsStacAssetItem( this, it.key(), &it.value() );
+      contents.append( assetItem );
     }
   }
 

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -470,7 +470,7 @@ QVector<QgsDataItem *> QgsStacCatalogItem::createChildren()
     }
   }
 
-  if ( QgsStacCollection *collection = qobject_cast<QgsStacCollection *>( mStacCatalog.get() ) )
+  if ( QgsStacCollection *collection = dynamic_cast<QgsStacCollection *>( mStacCatalog.get() ) )
   {
     const QMap<QString, QgsStacAsset> assets = collection->assets();
     for ( auto it = assets.constBegin(); it != assets.constEnd(); ++it )

--- a/src/core/stac/qgsstacdataitems.cpp
+++ b/src/core/stac/qgsstacdataitems.cpp
@@ -58,13 +58,12 @@ bool QgsStacAssetItem::hasDragEnabled() const
 
 QgsStacController *QgsStacAssetItem::stacController() const
 {
-  if ( const QgsStacItemItem *itemItem = qobject_cast<const QgsStacItemItem *>( parent() ) )
+  const QgsDataItem *item = this;
+  while ( item )
   {
-    return itemItem->stacController();
-  }
-  else if ( const QgsStacCatalogItem *catalogItem = qobject_cast<const QgsStacCatalogItem *>( parent() ) )
-  {
-    return catalogItem->stacController();
+    if ( const QgsStacConnectionItem *ci = qobject_cast<const QgsStacConnectionItem *>( item ) )
+      return ci->controller();
+    item = item->parent();
   }
   Q_ASSERT( false );
   return nullptr;

--- a/src/core/stac/qgsstacdataitems.h
+++ b/src/core/stac/qgsstacdataitems.h
@@ -47,6 +47,7 @@ class CORE_EXPORT QgsStacAssetItem : public QgsDataItem
     QVariant sortKey() const override { return QStringLiteral( "4 %1" ).arg( mName ); }
     void updateToolTip();
     const QgsStacAsset *stacAsset() const { return mStacAsset; }
+    QgsStacController *stacController() const;
 
   private:
     const QgsStacAsset *mStacAsset;

--- a/src/gui/stac/qgsstacdataitemguiprovider.cpp
+++ b/src/gui/stac/qgsstacdataitemguiprovider.cpp
@@ -241,7 +241,7 @@ void QgsStacDataItemGuiProvider::downloadAssets( QgsDataItem *item, QgsDataItemG
   if ( itemItem )
   {
     dialog.setStacItem( itemItem->stacItem() );
-    authcfg = itemItem->stacController()->authCfg()
+    authcfg = itemItem->stacController()->authCfg();
   }
   else if ( assetItem )
   {

--- a/src/gui/stac/qgsstacdataitemguiprovider.cpp
+++ b/src/gui/stac/qgsstacdataitemguiprovider.cpp
@@ -212,8 +212,14 @@ void QgsStacDataItemGuiProvider::showDetails( QgsDataItem *item )
   }
   else if ( assetItem )
   {
-    QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( assetItem->parent() );
-    authcfg = itemItem->stacController()->authCfg();
+    if ( QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( assetItem->parent() ) )
+    {
+      authcfg = itemItem->stacController()->authCfg();
+    }
+    else if ( QgsStacCatalogItem *catalogItem = qobject_cast<QgsStacCatalogItem *>( assetItem->parent() ) )
+    {
+      authcfg = catalogItem->stacController()->authCfg();
+    }
     d.setContentFromStacAsset( assetItem->name(), assetItem->stacAsset() );
   }
   d.setAuthcfg( authcfg );
@@ -236,11 +242,21 @@ void QgsStacDataItemGuiProvider::downloadAssets( QgsDataItem *item, QgsDataItemG
   }
   else if ( assetItem )
   {
-    itemItem = qobject_cast<QgsStacItemItem *>( assetItem->parent() );
+    if ( QgsStacItemItem *parentItem = qobject_cast<QgsStacItemItem *>( assetItem->parent() ) )
+    {
+      dialog.setAuthCfg( parentItem->stacController()->authCfg() );
+    }
+    else if ( QgsStacCatalogItem *parentCatalog = qobject_cast<QgsStacCatalogItem *>( assetItem->parent() ) )
+    {
+      dialog.setAuthCfg( parentCatalog->stacController()->authCfg() );
+    }
     dialog.addStacAsset( assetItem->name(), assetItem->stacAsset() );
   }
   dialog.setMessageBar( context.messageBar() );
-  dialog.setAuthCfg( itemItem->stacController()->authCfg() );
+  if ( itemItem )
+  {
+    dialog.setAuthCfg( itemItem->stacController()->authCfg() );
+  }
   dialog.exec();
 }
 

--- a/src/gui/stac/qgsstacdataitemguiprovider.cpp
+++ b/src/gui/stac/qgsstacdataitemguiprovider.cpp
@@ -229,6 +229,8 @@ void QgsStacDataItemGuiProvider::showDetails( QgsDataItem *item )
 
 void QgsStacDataItemGuiProvider::downloadAssets( QgsDataItem *item, QgsDataItemGuiContext context )
 {
+  QString authcfg;
+
   QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( item );
   QgsStacAssetItem *assetItem = qobject_cast<QgsStacAssetItem *>( item );
 
@@ -239,24 +241,22 @@ void QgsStacDataItemGuiProvider::downloadAssets( QgsDataItem *item, QgsDataItemG
   if ( itemItem )
   {
     dialog.setStacItem( itemItem->stacItem() );
+    authcfg = itemItem->stacController()->authCfg()
   }
   else if ( assetItem )
   {
     if ( QgsStacItemItem *parentItem = qobject_cast<QgsStacItemItem *>( assetItem->parent() ) )
     {
-      dialog.setAuthCfg( parentItem->stacController()->authCfg() );
+      authcfg = parentItem->stacController()->authCfg();
     }
     else if ( QgsStacCatalogItem *parentCatalog = qobject_cast<QgsStacCatalogItem *>( assetItem->parent() ) )
     {
-      dialog.setAuthCfg( parentCatalog->stacController()->authCfg() );
+      authcfg = parentCatalog->stacController()->authCfg();
     }
     dialog.addStacAsset( assetItem->name(), assetItem->stacAsset() );
   }
   dialog.setMessageBar( context.messageBar() );
-  if ( itemItem )
-  {
-    dialog.setAuthCfg( itemItem->stacController()->authCfg() );
-  }
+  dialog.setAuthCfg( authcfg );
   dialog.exec();
 }
 

--- a/src/gui/stac/qgsstacdataitemguiprovider.cpp
+++ b/src/gui/stac/qgsstacdataitemguiprovider.cpp
@@ -212,14 +212,7 @@ void QgsStacDataItemGuiProvider::showDetails( QgsDataItem *item )
   }
   else if ( assetItem )
   {
-    if ( QgsStacItemItem *itemItem = qobject_cast<QgsStacItemItem *>( assetItem->parent() ) )
-    {
-      authcfg = itemItem->stacController()->authCfg();
-    }
-    else if ( QgsStacCatalogItem *catalogItem = qobject_cast<QgsStacCatalogItem *>( assetItem->parent() ) )
-    {
-      authcfg = catalogItem->stacController()->authCfg();
-    }
+    authcfg = assetItem->stacController()->authCfg();
     d.setContentFromStacAsset( assetItem->name(), assetItem->stacAsset() );
   }
   d.setAuthcfg( authcfg );
@@ -245,14 +238,7 @@ void QgsStacDataItemGuiProvider::downloadAssets( QgsDataItem *item, QgsDataItemG
   }
   else if ( assetItem )
   {
-    if ( QgsStacItemItem *parentItem = qobject_cast<QgsStacItemItem *>( assetItem->parent() ) )
-    {
-      authcfg = parentItem->stacController()->authCfg();
-    }
-    else if ( QgsStacCatalogItem *parentCatalog = qobject_cast<QgsStacCatalogItem *>( assetItem->parent() ) )
-    {
-      authcfg = parentCatalog->stacController()->authCfg();
-    }
+    authcfg = assetItem->stacController()->authCfg();
     dialog.addStacAsset( assetItem->name(), assetItem->stacAsset() );
   }
   dialog.setMessageBar( context.messageBar() );

--- a/tests/src/core/testqgsstac.cpp
+++ b/tests/src/core/testqgsstac.cpp
@@ -162,7 +162,6 @@ void TestQgsStac::testParseLocalCollection()
   QCOMPARE( asset.uri().layerType, QStringLiteral( "vector" ) );
   QVERIFY( asset.isDownloadable() );
   QVERIFY( asset.isCloudOptimized() );
-
 }
 
 void TestQgsStac::testParseLocalItem()

--- a/tests/src/core/testqgsstac.cpp
+++ b/tests/src/core/testqgsstac.cpp
@@ -25,7 +25,6 @@
 #include "qgsstaccontroller.h"
 #include "qgsstacitem.h"
 #include "qgsstacitemcollection.h"
-#include "qgsstacdataitems.h"
 #include "qgstest.h"
 
 #include <QObject>
@@ -287,7 +286,6 @@ void TestQgsStac::testParseLocalCollections()
   QCOMPARE( col->links().size(), 3 );
   QCOMPARE( col->stacExtensions().size(), 0 );
 }
-
 
 void TestQgsStac::testFetchStacObjectAsync()
 {

--- a/tests/src/core/testqgsstac.cpp
+++ b/tests/src/core/testqgsstac.cpp
@@ -25,6 +25,7 @@
 #include "qgsstaccontroller.h"
 #include "qgsstacitem.h"
 #include "qgsstacitemcollection.h"
+#include "qgsstacdataitems.h"
 #include "qgstest.h"
 
 #include <QObject>
@@ -154,6 +155,15 @@ void TestQgsStac::testParseLocalCollection()
   QVariantMap sum( col->summaries() );
   QCOMPARE( sum.size(), 9 );
   QCOMPARE( sum.value( QStringLiteral( "platform" ) ).toStringList(), QStringList() << QLatin1String( "cool_sat1" ) << QLatin1String( "cool_sat2" ) );
+
+  QCOMPARE( col->assets().size(), 1 );
+
+  QgsStacAsset asset = col->assets().value( QStringLiteral( "geoparquet-file" ), QgsStacAsset( {}, {}, {}, {}, {} ) );
+  QCOMPARE( asset.formatName(), QStringLiteral( "Parquet" ) );
+  QCOMPARE( asset.uri().layerType, QStringLiteral( "vector" ) );
+  QVERIFY( asset.isDownloadable() );
+  QVERIFY( asset.isCloudOptimized() );
+
 }
 
 void TestQgsStac::testParseLocalItem()
@@ -277,6 +287,7 @@ void TestQgsStac::testParseLocalCollections()
   QCOMPARE( col->links().size(), 3 );
   QCOMPARE( col->stacExtensions().size(), 0 );
 }
+
 
 void TestQgsStac::testFetchStacObjectAsync()
 {

--- a/tests/src/core/testqgsstac.cpp
+++ b/tests/src/core/testqgsstac.cpp
@@ -136,7 +136,6 @@ void TestQgsStac::testParseLocalCollection()
   QCOMPARE( col->providers().size(), 1 );
   QCOMPARE( col->stacExtensions().size(), 3 );
   QCOMPARE( col->license(), QLatin1String( "CC-BY-4.0" ) );
-  QVERIFY( col->assets().isEmpty() );
 
   // extent
   QgsStacExtent ext( col->extent() );

--- a/tests/testdata/stac/collection.json
+++ b/tests/testdata/stac/collection.json
@@ -108,5 +108,15 @@
       "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0/examples/collection.json",
       "type": "application/json"
     }
-  ]
+  ],
+  "assets": {
+    "geoparquet-file": {
+      "href": "https://github.com/opengeospatial/geoparquet/raw/refs/heads/main/examples/example.parquet",
+      "title": "GeoParquet File",
+      "type": "application/vnd.apache.parquet",
+      "roles": [
+        "data"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Description

STAC catalogs that contain vector assets such as parquet files, generally store the parquet files off the `collection.json` rather than `item.json` 

An example of this style would be Field boundaries (fiboa)  https://data.source.coop/fiboa/ai4sf/stac/collection.json

These assets are currently hidden as only assets attached to STAC items are shown in the STAC browser

This change finds assets on STAC collections and enables the same click and drag behaviour to load them into the current view as assets stored on STAC items.