### PR TITLE
Fix 3D Map crashing with Virtual Point Clouds

### DIFF
--- a/src/3d/qgsvirtualpointcloudentity_p.cpp
+++ b/src/3d/qgsvirtualpointcloudentity_p.cpp
@@ -58,7 +58,7 @@ QgsVirtualPointCloudEntity::QgsVirtualPointCloudEntity(
     createChunkedEntityForSubIndex( i );
   }
 
-  if ( provider()->overview() )
+  if ( provider()->overview() && provider()->overview().isValid() )
   {
     mOverviewEntity = new QgsPointCloudLayerChunkedEntity(
       mapSettings(),
@@ -166,7 +166,7 @@ void QgsVirtualPointCloudEntity::handleSceneUpdate( const SceneContext &sceneCon
   updateBboxEntity();
 
   const QgsPointCloudLayer3DRenderer *rendererBehavior = dynamic_cast<QgsPointCloudLayer3DRenderer *>( mLayer->renderer3D() );
-  if ( provider()->overview() && rendererBehavior && ( rendererBehavior->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverview || rendererBehavior->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverviewAndExtents ) )
+  if ( mOverviewEntity && provider()->overview() && rendererBehavior && ( rendererBehavior->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverview || rendererBehavior->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverviewAndExtents ) )
   {
     mOverviewEntity->handleSceneUpdate( sceneContext );
   }


### PR DESCRIPTION
The crash happens when the symbology changes with the map open and the overview entity is requested to do a scene update.

If `mOverviewEntity` wasn't set at the start, it remains a `nullptr` at the point of the update call. 