### PR TITLE
[CheckSpell] Set correct dir for spelling.dat file

### DIFF
--- a/scripts/pre_commit/spell_check/check_spelling.sh
+++ b/scripts/pre_commit/spell_check/check_spelling.sh
@@ -201,13 +201,13 @@ for I in $(seq -f '%02g' 0  $((SPLIT-1)) ) ; do
         # also make error small case and escape special chars: () |
         ERRORSMALLCASE=$(echo ${ERRORNOCOLOR,,} |${GP}sed -r 's/\(/\\(/g' | ${GP}sed -r 's/\)/\\)/g' | ${GP}sed -r 's/\|/\\|/g' )
         if [[ ! "${ERRORSMALLCASE}" =~ $IGNORECASE_INWORD ]]; then
-         if [[ -n $(ag --noaffinity --nonumbers --case-sensitive "^${ERRORSMALLCASE:1:-1}${ERRORSMALLCASE: -1}?:" scripts/spell_check/spelling.dat) ]]; then
+         if [[ -n $(ag --noaffinity --nonumbers --case-sensitive "^${ERRORSMALLCASE:1:-1}${ERRORSMALLCASE: -1}?:" ${DIR}/spelling.dat) ]]; then
            PREVCHAR=${ERROR::1}
            # remove first character
            ERRORSMALLCASE=${ERRORSMALLCASE#?}
            ERROR=${ERROR#?}
          fi
-         if [[ -n $(ag --noaffinity --nonumbers --case-sensitive "^${ERRORSMALLCASE::-1}:" scripts/spell_check/spelling.dat) ]]; then
+         if [[ -n $(ag --noaffinity --nonumbers --case-sensitive "^${ERRORSMALLCASE::-1}:" ${DIR}/spelling.dat) ]]; then
            NEXTCHAR=${ERROR:${#ERROR}-1:1}
            # remove last character
            ERRORSMALLCASE=${ERRORSMALLCASE::-1}


### PR DESCRIPTION
To avoid those error messages

> ERR: Error stat()ing: scripts/spell_check/spelling.dat
> ERR: Error opening directory scripts/spell_check/spelling.dat: No such file or directory
> ERR: Error stat()ing: scripts/spell_check/spelling.dat
> ERR: Error opening directory scripts/spell_check/spelling.dat: No such file or directory
> 
