### PR TITLE
[Virtual Point Clouds] Fix 3D Map rendering issues

### DIFF
--- a/src/3d/qgsvirtualpointcloudentity_p.cpp
+++ b/src/3d/qgsvirtualpointcloudentity_p.cpp
@@ -87,6 +87,15 @@ QgsVirtualPointCloudEntity::QgsVirtualPointCloudEntity(
   connect( provider(), &QgsVirtualPointCloudProvider::subIndexLoaded, this, &QgsVirtualPointCloudEntity::createChunkedEntityForSubIndex );
 }
 
+QgsVirtualPointCloudEntity::~QgsVirtualPointCloudEntity()
+{
+  qDeleteAll( mChunkedEntitiesMap );
+  mChunkedEntitiesMap.clear();
+
+  delete mOverviewEntity;
+  mOverviewEntity = nullptr;
+}
+
 QList<QgsChunkedEntity *> QgsVirtualPointCloudEntity::chunkedEntities() const
 {
   return mChunkedEntitiesMap.values();

--- a/src/3d/qgsvirtualpointcloudentity_p.h
+++ b/src/3d/qgsvirtualpointcloudentity_p.h
@@ -59,6 +59,9 @@ class QgsVirtualPointCloudEntity : public Qgs3DMapSceneEntity
     //! Constructs
     QgsVirtualPointCloudEntity( Qgs3DMapSettings *map, QgsPointCloudLayer *layer, const QgsCoordinateTransform &coordinateTransform, QgsPointCloud3DSymbol *symbol, float maxScreenError, bool showBoundingBoxes, double zValueScale, double zValueOffset, int pointBudget );
 
+    //! Destructs
+    ~QgsVirtualPointCloudEntity() override;
+
     //! This is called when the camera moves. It's responsible for loading new indexes and decides if subindex will be rendered as bbox or chunked entity.
     void handleSceneUpdate( const SceneContext &sceneContext ) override;
 


### PR DESCRIPTION
fixes: #61312

Let's delete the created entities before exiting.

Additional Qt6 related fixes (unreported):
ticking the `Show bounding box` while the 3D Map was open would crash QGIS.
changing the `When zoomed out` option would crash QGIS.
turning off or on any attribute in the symbology widget would crash QGIS.

[Screencast_20251217_140637.webm](https://github.com/user-attachments/assets/7455112b-9d37-403b-987e-d7aa422376ca)
