### PR TITLE
[Virtual Point Clouds] Add combobox to adjust the switching between rendering overview only and sub index rendering

### DIFF
--- a/python/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
@@ -121,6 +121,20 @@ Returns the renderer behavior when zoomed out
 .. versionadded:: 3.42
 %End
 
+    void setZoomOutMultiplier( double multiplier );
+%Docstring
+Sets the zoom out multiplier for zoomed out rendering of the overview
+
+.. versionadded:: 4.0
+%End
+
+    double zoomOutMultiplier() const;
+%Docstring
+Returns the zoom out multiplier for zoomed out rendering of the overview
+
+.. versionadded:: 4.0
+%End
+
   private:
     QgsPointCloudLayer3DRenderer( const QgsPointCloudLayer3DRenderer & );
     QgsPointCloudLayer3DRenderer &operator=( const QgsPointCloudLayer3DRenderer & );

--- a/python/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
@@ -121,16 +121,16 @@ Returns the renderer behavior when zoomed out
 .. versionadded:: 3.42
 %End
 
-    void setZoomOutMultiplier( double multiplier );
+    void setOverviewSwitchingScale( double scale );
 %Docstring
-Sets the zoom out multiplier for zoomed out rendering of the overview
+Sets the overview switching scale
 
 .. versionadded:: 4.0
 %End
 
-    double zoomOutMultiplier() const;
+    double overviewSwitchingScale() const;
 %Docstring
-Returns the zoom out multiplier for zoomed out rendering of the overview
+Returns the overview switching scale
 
 .. versionadded:: 4.0
 %End

--- a/python/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
@@ -125,6 +125,10 @@ Returns the renderer behavior when zoomed out
 %Docstring
 Sets the overview switching scale
 
+Used to determine when point clouds switch from rendering bounding boxes
+to displaying full point data. The value is compared against screen
+space error (SSE) calculated from camera distance and node size.
+
 .. versionadded:: 4.0
 %End
 

--- a/python/PyQt6/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
@@ -121,6 +121,20 @@ Returns the renderer behavior when zoomed out
 .. versionadded:: 3.42
 %End
 
+    void setZoomOutMultiplier( double multiplier );
+%Docstring
+Sets the zoom out multiplier for zoomed out rendering of the overview
+
+.. versionadded:: 4.0
+%End
+
+    double zoomOutMultiplier() const;
+%Docstring
+Returns the zoom out multiplier for zoomed out rendering of the overview
+
+.. versionadded:: 4.0
+%End
+
   private:
     QgsPointCloudLayer3DRenderer( const QgsPointCloudLayer3DRenderer & );
     QgsPointCloudLayer3DRenderer &operator=( const QgsPointCloudLayer3DRenderer & );

--- a/python/PyQt6/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
@@ -121,16 +121,16 @@ Returns the renderer behavior when zoomed out
 .. versionadded:: 3.42
 %End
 
-    void setZoomOutMultiplier( double multiplier );
+    void setOverviewSwitchingScale( double scale );
 %Docstring
-Sets the zoom out multiplier for zoomed out rendering of the overview
+Sets the overview switching scale
 
 .. versionadded:: 4.0
 %End
 
-    double zoomOutMultiplier() const;
+    double overviewSwitchingScale() const;
 %Docstring
-Returns the zoom out multiplier for zoomed out rendering of the overview
+Returns the overview switching scale
 
 .. versionadded:: 4.0
 %End

--- a/python/PyQt6/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgspointcloudlayer3drenderer.sip.in
@@ -125,6 +125,10 @@ Returns the renderer behavior when zoomed out
 %Docstring
 Sets the overview switching scale
 
+Used to determine when point clouds switch from rendering bounding boxes
+to displaying full point data. The value is compared against screen
+space error (SSE) calculated from camera distance and node size.
+
 .. versionadded:: 4.0
 %End
 

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -629,6 +629,12 @@ Returns the renderer behavior when zoomed out
 %Docstring
 Sets the overview switching scale
 
+Point clouds whose extents intersect the map extent are considered
+visible. When zoomed out beyond the overview switching scale (render
+extent exceeds average point cloud dimensions by the scale factor), and
+overview zoom-out behavior is enabled, the overview is rendered instead
+of an individual point cloud.
+
 .. versionadded:: 4.0
 %End
 

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -625,16 +625,16 @@ Returns the renderer behavior when zoomed out
 .. versionadded:: 3.42
 %End
 
-    void setZoomOutMultiplier( const double value );
+    void setOverviewSwitchingScale( const double value );
 %Docstring
-Sets the zoom out multiplier for overview rendering
+Sets the overview switching scale
 
 .. versionadded:: 4.0
 %End
 
-    double zoomOutMultiplier() const;
+    double overviewSwitchingScale() const;
 %Docstring
-Returns the zoom out multiplier for overview rendering
+Returns the overview switching scale
 
 .. versionadded:: 4.0
 %End

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -625,6 +625,20 @@ Returns the renderer behavior when zoomed out
 .. versionadded:: 3.42
 %End
 
+    void setZoomOutMultiplier( const double value );
+%Docstring
+Sets the zoom out multiplier for overview rendering
+
+.. versionadded:: 4.0
+%End
+
+    double zoomOutMultiplier() const;
+%Docstring
+Returns the zoom out multiplier for overview rendering
+
+.. versionadded:: 4.0
+%End
+
   protected:
 
     static void pointXY( QgsPointCloudRenderContext &context, const char *ptr, int i, double &x, double &y );

--- a/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -629,6 +629,12 @@ Returns the renderer behavior when zoomed out
 %Docstring
 Sets the overview switching scale
 
+Point clouds whose extents intersect the map extent are considered
+visible. When zoomed out beyond the overview switching scale (render
+extent exceeds average point cloud dimensions by the scale factor), and
+overview zoom-out behavior is enabled, the overview is rendered instead
+of an individual point cloud.
+
 .. versionadded:: 4.0
 %End
 

--- a/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -625,16 +625,16 @@ Returns the renderer behavior when zoomed out
 .. versionadded:: 3.42
 %End
 
-    void setZoomOutMultiplier( const double value );
+    void setOverviewSwitchingScale( const double value );
 %Docstring
-Sets the zoom out multiplier for overview rendering
+Sets the overview switching scale
 
 .. versionadded:: 4.0
 %End
 
-    double zoomOutMultiplier() const;
+    double overviewSwitchingScale() const;
 %Docstring
-Returns the zoom out multiplier for overview rendering
+Returns the overview switching scale
 
 .. versionadded:: 4.0
 %End

--- a/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
+++ b/python/core/auto_generated/pointcloud/qgspointcloudrenderer.sip.in
@@ -625,6 +625,20 @@ Returns the renderer behavior when zoomed out
 .. versionadded:: 3.42
 %End
 
+    void setZoomOutMultiplier( const double value );
+%Docstring
+Sets the zoom out multiplier for overview rendering
+
+.. versionadded:: 4.0
+%End
+
+    double zoomOutMultiplier() const;
+%Docstring
+Returns the zoom out multiplier for overview rendering
+
+.. versionadded:: 4.0
+%End
+
   protected:
 
     static void pointXY( QgsPointCloudRenderContext &context, const char *ptr, int i, double &x, double &y );

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -147,6 +147,7 @@ QgsPointCloudLayer3DRenderer *QgsPointCloudLayer3DRenderer::clone() const
   r->setMaximumScreenError( mMaximumScreenError );
   r->setShowBoundingBoxes( mShowBoundingBoxes );
   r->setZoomOutBehavior( mZoomOutBehavior );
+  r->setZoomOutMultiplier( mZoomOutMultiplier );
   return r;
 }
 
@@ -183,11 +184,12 @@ void QgsPointCloudLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWri
 
   QDomDocument doc = elem.ownerDocument();
 
-  elem.setAttribute( u"layer"_s, mLayerRef.layerId );
+  elem.setAttribute( u"layer"_s ), mLayerRef.layerId );
   elem.setAttribute( u"max-screen-error"_s, maximumScreenError() );
-  elem.setAttribute( u"show-bounding-boxes"_s, showBoundingBoxes() ? u"1"_s : u"0"_s );
+  elem.setAttribute( u"show-bounding-boxes"_s, showBoundingBoxes() ? u"1"_s : u"0"_s ) );
   elem.setAttribute( u"point-budget"_s, mPointBudget );
   elem.setAttribute( u"zoom-out-behavior"_s, qgsEnumValueToKey( mZoomOutBehavior ) );
+  elem.setAttribute( u"zoom-out-multiplier"_s, mZoomOutMultiplier );
 
   QDomElement elemSymbol = doc.createElement( u"symbol"_s );
   if ( mSymbol )
@@ -209,6 +211,7 @@ void QgsPointCloudLayer3DRenderer::readXml( const QDomElement &elem, const QgsRe
   mMaximumScreenError = elem.attribute( u"max-screen-error"_s, u"3.0"_s ).toDouble();
   mPointBudget = elem.attribute( u"point-budget"_s, u"5000000"_s ).toInt();
   mZoomOutBehavior = qgsEnumKeyToValue( elem.attribute( u"zoom-out-behavior"_s ), Qgis::PointCloudZoomOutRenderBehavior::RenderExtents );
+  mZoomOutMultiplier = elem.attribute( u"zoom-out-multiplier"_s, u"1.0"_s ).toDouble();
 
   if ( symbolType == "single-color"_L1 )
     mSymbol = std::make_unique<QgsSingleColorPointCloud3DSymbol>();

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -147,7 +147,7 @@ QgsPointCloudLayer3DRenderer *QgsPointCloudLayer3DRenderer::clone() const
   r->setMaximumScreenError( mMaximumScreenError );
   r->setShowBoundingBoxes( mShowBoundingBoxes );
   r->setZoomOutBehavior( mZoomOutBehavior );
-  r->setZoomOutMultiplier( mZoomOutMultiplier );
+  r->setOverviewSwitchingScale( mOverviewSwitchingScale );
   return r;
 }
 
@@ -189,7 +189,7 @@ void QgsPointCloudLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWri
   elem.setAttribute( u"show-bounding-boxes"_s, showBoundingBoxes() ? u"1"_s : u"0"_s );
   elem.setAttribute( u"point-budget"_s, mPointBudget );
   elem.setAttribute( u"zoom-out-behavior"_s, qgsEnumValueToKey( mZoomOutBehavior ) );
-  elem.setAttribute( u"zoom-out-multiplier"_s, mZoomOutMultiplier );
+  elem.setAttribute( u"overview-switching-scale"_s, mOverviewSwitchingScale );
 
   QDomElement elemSymbol = doc.createElement( u"symbol"_s );
   if ( mSymbol )
@@ -211,7 +211,7 @@ void QgsPointCloudLayer3DRenderer::readXml( const QDomElement &elem, const QgsRe
   mMaximumScreenError = elem.attribute( u"max-screen-error"_s, u"3.0"_s ).toDouble();
   mPointBudget = elem.attribute( u"point-budget"_s, u"5000000"_s ).toInt();
   mZoomOutBehavior = qgsEnumKeyToValue( elem.attribute( u"zoom-out-behavior"_s ), Qgis::PointCloudZoomOutRenderBehavior::RenderExtents );
-  mZoomOutMultiplier = elem.attribute( u"zoom-out-multiplier"_s, u"1.0"_s ).toDouble();
+  mOverviewSwitchingScale = elem.attribute( u"overview-switching-scale"_s, u"1.0"_s ).toDouble();
 
   if ( symbolType == "single-color"_L1 )
     mSymbol = std::make_unique<QgsSingleColorPointCloud3DSymbol>();

--- a/src/3d/qgspointcloudlayer3drenderer.cpp
+++ b/src/3d/qgspointcloudlayer3drenderer.cpp
@@ -184,9 +184,9 @@ void QgsPointCloudLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWri
 
   QDomDocument doc = elem.ownerDocument();
 
-  elem.setAttribute( u"layer"_s ), mLayerRef.layerId );
+  elem.setAttribute( u"layer"_s, mLayerRef.layerId );
   elem.setAttribute( u"max-screen-error"_s, maximumScreenError() );
-  elem.setAttribute( u"show-bounding-boxes"_s, showBoundingBoxes() ? u"1"_s : u"0"_s ) );
+  elem.setAttribute( u"show-bounding-boxes"_s, showBoundingBoxes() ? u"1"_s : u"0"_s );
   elem.setAttribute( u"point-budget"_s, mPointBudget );
   elem.setAttribute( u"zoom-out-behavior"_s, qgsEnumValueToKey( mZoomOutBehavior ) );
   elem.setAttribute( u"zoom-out-multiplier"_s, mZoomOutMultiplier );

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -317,6 +317,11 @@ class _3D_EXPORT QgsPointCloudLayer3DRenderer : public QgsAbstractPointCloud3DRe
 
     /**
       * Sets the overview switching scale
+      *
+      * Used to determine when point clouds
+      * switch from rendering bounding boxes to displaying full point data.
+      * The value is compared against screen space error (SSE) calculated from
+      * camera distance and node size.
       * \since QGIS 4.0
       */
     void setOverviewSwitchingScale( double scale ) { mOverviewSwitchingScale = scale; }

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -316,16 +316,16 @@ class _3D_EXPORT QgsPointCloudLayer3DRenderer : public QgsAbstractPointCloud3DRe
     Qgis::PointCloudZoomOutRenderBehavior zoomOutBehavior() const { return mZoomOutBehavior; }
 
     /**
-      * Sets the zoom out multiplier for zoomed out rendering of the overview
+      * Sets the overview switching scale
       * \since QGIS 4.0
       */
-    void setZoomOutMultiplier( double multiplier ) { mZoomOutMultiplier = multiplier; }
+    void setOverviewSwitchingScale( double scale ) { mOverviewSwitchingScale = scale; }
 
     /**
-      * Returns the zoom out multiplier for zoomed out rendering of the overview
+      * Returns the overview switching scale
       * \since QGIS 4.0
       */
-    double zoomOutMultiplier() const { return mZoomOutMultiplier; }
+    double overviewSwitchingScale() const { return mOverviewSwitchingScale; }
 
   private:
     QgsMapLayerRef mLayerRef; //!< Layer used to extract mesh data from
@@ -334,7 +334,7 @@ class _3D_EXPORT QgsPointCloudLayer3DRenderer : public QgsAbstractPointCloud3DRe
     bool mShowBoundingBoxes = false;
     int mPointBudget = 5000000;
     Qgis::PointCloudZoomOutRenderBehavior mZoomOutBehavior = Qgis::PointCloudZoomOutRenderBehavior::RenderExtents;
-    double mZoomOutMultiplier = 1.0;
+    double mOverviewSwitchingScale = 1.0;
 
   private:
 #ifdef SIP_RUN

--- a/src/3d/qgspointcloudlayer3drenderer.h
+++ b/src/3d/qgspointcloudlayer3drenderer.h
@@ -315,6 +315,18 @@ class _3D_EXPORT QgsPointCloudLayer3DRenderer : public QgsAbstractPointCloud3DRe
       */
     Qgis::PointCloudZoomOutRenderBehavior zoomOutBehavior() const { return mZoomOutBehavior; }
 
+    /**
+      * Sets the zoom out multiplier for zoomed out rendering of the overview
+      * \since QGIS 4.0
+      */
+    void setZoomOutMultiplier( double multiplier ) { mZoomOutMultiplier = multiplier; }
+
+    /**
+      * Returns the zoom out multiplier for zoomed out rendering of the overview
+      * \since QGIS 4.0
+      */
+    double zoomOutMultiplier() const { return mZoomOutMultiplier; }
+
   private:
     QgsMapLayerRef mLayerRef; //!< Layer used to extract mesh data from
     std::unique_ptr<QgsPointCloud3DSymbol> mSymbol;
@@ -322,6 +334,7 @@ class _3D_EXPORT QgsPointCloudLayer3DRenderer : public QgsAbstractPointCloud3DRe
     bool mShowBoundingBoxes = false;
     int mPointBudget = 5000000;
     Qgis::PointCloudZoomOutRenderBehavior mZoomOutBehavior = Qgis::PointCloudZoomOutRenderBehavior::RenderExtents;
+    double mZoomOutMultiplier = 1.0;
 
   private:
 #ifdef SIP_RUN

--- a/src/3d/qgsvirtualpointcloudentity_p.cpp
+++ b/src/3d/qgsvirtualpointcloudentity_p.cpp
@@ -141,7 +141,7 @@ void QgsVirtualPointCloudEntity::handleSceneUpdate( const SceneContext &sceneCon
   const QVector<QgsPointCloudSubIndex> subIndexes = provider()->subIndexes();
 
   const QgsPointCloudLayer3DRenderer *rendererBehavior = dynamic_cast<QgsPointCloudLayer3DRenderer *>( mLayer->renderer3D() );
-  const double zoomOutMultiplier = rendererBehavior ? rendererBehavior->zoomOutMultiplier() : 1;
+  const double overviewSwitchingScale = rendererBehavior ? rendererBehavior->overviewSwitchingScale() : 1;
   qsizetype subIndexesRendered = 0;
 
   for ( int i = 0; i < subIndexes.size(); ++i )
@@ -168,7 +168,7 @@ void QgsVirtualPointCloudEntity::handleSceneUpdate( const SceneContext &sceneCon
     constexpr float THRESHOLD = .2;
 
     QgsBox3D scaledBox = box3D;
-    scaledBox.scale( zoomOutMultiplier );
+    scaledBox.scale( overviewSwitchingScale );
     const bool zoomedOut = !scaledBox.contains( cameraPosMapCoords.x(), cameraPosMapCoords.y(), cameraPosMapCoords.z() );
 
     if ( zoomedOut )

--- a/src/3d/qgsvirtualpointcloudentity_p.cpp
+++ b/src/3d/qgsvirtualpointcloudentity_p.cpp
@@ -194,7 +194,7 @@ void QgsVirtualPointCloudEntity::handleSceneUpdate( const SceneContext &sceneCon
   if ( provider()->overview() && rendererBehavior && ( rendererBehavior->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverview || rendererBehavior->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverviewAndExtents ) )
   {
     // no need to render the overview if all sub indexes are shown
-    if ( subIndexesRendered == mChunkedEntitiesMap.size() )
+    if ( !mChunkedEntitiesMap.isEmpty() && subIndexesRendered == mChunkedEntitiesMap.size() )
       mOverviewEntity->setEnabled( false );
     else
       mOverviewEntity->setEnabled( true );

--- a/src/3d/qgsvirtualpointcloudentity_p.cpp
+++ b/src/3d/qgsvirtualpointcloudentity_p.cpp
@@ -165,11 +165,11 @@ void QgsVirtualPointCloudEntity::handleSceneUpdate( const SceneContext &sceneCon
     const float epsilon = static_cast<float>( std::min( box3D.width(), box3D.height() ) ) / SPAN;
     const float distance = static_cast<float>( box3D.distanceTo( cameraPosMapCoords ) );
     const float sse = Qgs3DUtils::screenSpaceError( epsilon, distance, sceneContext.screenSizePx, sceneContext.cameraFov );
-    const float THRESHOLD = .2 / overviewSwitchingScale;
+    const double THRESHOLD = 0.2 / overviewSwitchingScale;
 
     // always display as bbox for the initial temporary camera pos (0, 0, 0)
     // then once the camera changes we display as bbox depending on screen space error
-    const bool displayAsBbox = sceneContext.cameraPos.isNull() || sse < THRESHOLD;
+    const bool displayAsBbox = sceneContext.cameraPos.isNull() || sse < static_cast<float>( THRESHOLD );
     if ( !displayAsBbox )
     {
       subIndexesRendered += 1;

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -712,7 +712,7 @@ Qgis::PointCloudZoomOutRenderBehavior QgsPointCloud3DSymbolWidget::zoomOutBehavi
 
 void QgsPointCloud3DSymbolWidget::setZoomOutMultiplier( double multiplier )
 {
-  int idx = 0;
+  size_t idx = 0;
   for ( size_t i = 0; i < mZoomOutScale.size(); ++i )
   {
     if ( multiplier <= mZoomOutScale[i] )

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -152,24 +152,22 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
       {
         mZoomOutOptions->addItem( tr( "Show Overview Only" ), QVariant::fromValue( Qgis::PointCloudZoomOutRenderBehavior::RenderOverview ) );
         mZoomOutOptions->addItem( tr( "Show Extents Over Overview" ), QVariant::fromValue( Qgis::PointCloudZoomOutRenderBehavior::RenderOverviewAndExtents ) );
+
+        for ( auto it = mOverviewSwitchingScaleMap.constBegin(); it != mOverviewSwitchingScaleMap.constEnd(); ++it )
+        {
+          mOverviewSwitchingScale->addItem( it.value(), it.key() );
+        }
+        setOverviewSwitchingScale( 1.0 );
       }
     }
     else
     {
       mZoomOutOptions->setEnabled( false );
-      mZoomOutMultiplier->setEnabled( false );
+      mOverviewSwitchingScale->setEnabled( false );
     }
 
-    whileBlocking( mZoomOutMultiplier )->setRange( 0, static_cast<int>( mZoomOutScale.size() - 1 ) );
-    mZoomOutMultiplier->setSingleStep( 1 );
-    mZoomOutMultiplier->setPageStep( 1 );
-    mZoomOutMultiplier->setTickInterval( 1 );
-    mZoomOutMultiplier->setTickPosition( QSlider::TicksBelow );
-
-    setZoomOutMultiplier( mZoomOutScale[mZoomOutScale.size() / 2] );
-
     connect( mZoomOutOptions, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
-    connect( mZoomOutMultiplier, &QSlider::valueChanged, this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
+    connect( mOverviewSwitchingScale, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
   }
   else
   {
@@ -710,25 +708,14 @@ Qgis::PointCloudZoomOutRenderBehavior QgsPointCloud3DSymbolWidget::zoomOutBehavi
   return mZoomOutOptions->currentData().value<Qgis::PointCloudZoomOutRenderBehavior>();
 }
 
-void QgsPointCloud3DSymbolWidget::setZoomOutMultiplier( double multiplier )
+void QgsPointCloud3DSymbolWidget::setOverviewSwitchingScale( double scale )
 {
-  size_t idx = 0;
-  for ( size_t i = 0; i < mZoomOutScale.size(); ++i )
-  {
-    if ( multiplier <= mZoomOutScale[i] )
-    {
-      idx = i;
-      break;
-    }
-  }
-
-  whileBlocking( mZoomOutMultiplier )->setValue( idx );
+  mOverviewSwitchingScale->setCurrentIndex( mOverviewSwitchingScale->findData( scale ) );
 }
 
-double QgsPointCloud3DSymbolWidget::zoomOutMultiplier() const
+double QgsPointCloud3DSymbolWidget::overviewSwitchingScale() const
 {
-  const int idx = std::clamp( mZoomOutMultiplier->value(), 0, static_cast<int>( mZoomOutScale.size() ) - 1 );
-  return mZoomOutScale[idx];
+  return mOverviewSwitchingScaleMap.key( mOverviewSwitchingScale->currentText() );
 }
 
 void QgsPointCloud3DSymbolWidget::connectChildPanels( QgsPanelWidget *parent )

--- a/src/app/3d/qgspointcloud3dsymbolwidget.cpp
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.cpp
@@ -157,9 +157,19 @@ QgsPointCloud3DSymbolWidget::QgsPointCloud3DSymbolWidget( QgsPointCloudLayer *la
     else
     {
       mZoomOutOptions->setEnabled( false );
+      mZoomOutMultiplier->setEnabled( false );
     }
 
+    whileBlocking( mZoomOutMultiplier )->setRange( 0, static_cast<int>( mZoomOutScale.size() - 1 ) );
+    mZoomOutMultiplier->setSingleStep( 1 );
+    mZoomOutMultiplier->setPageStep( 1 );
+    mZoomOutMultiplier->setTickInterval( 1 );
+    mZoomOutMultiplier->setTickPosition( QSlider::TicksBelow );
+
+    setZoomOutMultiplier( mZoomOutScale[mZoomOutScale.size() / 2] );
+
     connect( mZoomOutOptions, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
+    connect( mZoomOutMultiplier, &QSlider::valueChanged, this, &QgsPointCloud3DSymbolWidget::emitChangedSignal );
   }
   else
   {
@@ -698,6 +708,27 @@ void QgsPointCloud3DSymbolWidget::setZoomOutBehavior( const Qgis::PointCloudZoom
 Qgis::PointCloudZoomOutRenderBehavior QgsPointCloud3DSymbolWidget::zoomOutBehavior() const
 {
   return mZoomOutOptions->currentData().value<Qgis::PointCloudZoomOutRenderBehavior>();
+}
+
+void QgsPointCloud3DSymbolWidget::setZoomOutMultiplier( double multiplier )
+{
+  int idx = 0;
+  for ( size_t i = 0; i < mZoomOutScale.size(); ++i )
+  {
+    if ( multiplier <= mZoomOutScale[i] )
+    {
+      idx = i;
+      break;
+    }
+  }
+
+  whileBlocking( mZoomOutMultiplier )->setValue( idx );
+}
+
+double QgsPointCloud3DSymbolWidget::zoomOutMultiplier() const
+{
+  const int idx = std::clamp( mZoomOutMultiplier->value(), 0, static_cast<int>( mZoomOutScale.size() ) - 1 );
+  return mZoomOutScale[idx];
 }
 
 void QgsPointCloud3DSymbolWidget::connectChildPanels( QgsPanelWidget *parent )

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -49,6 +49,9 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setZoomOutBehavior( Qgis::PointCloudZoomOutRenderBehavior zoomOutBehavior );
     Qgis::PointCloudZoomOutRenderBehavior zoomOutBehavior() const;
 
+    void setZoomOutMultiplier( double threshold );
+    double zoomOutMultiplier() const;
+
     void connectChildPanels( QgsPanelWidget *parent );
 
   private slots:
@@ -77,6 +80,8 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setColorRampMinMax( double min, double max );
 
   private:
+    const std::array<double, 7> mZoomOutScale = { 0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0 };
+
     int mBlockChangedSignals = 0;
     int mDisableMinMaxWidgetRefresh = 0;
     QgsPointCloudClassifiedRendererWidget *mClassifiedRendererWidget = nullptr;

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -80,6 +80,7 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setColorRampMinMax( double min, double max );
 
   private:
+    // for 2D rendering, see values in qgspointcloudrendererpropertieswidget.h
     const QMap<double, QString> mOverviewSwitchingScaleMap {
       { 5.0, "Much earlier" },
       { 2.0, "Earlier" },

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -49,8 +49,8 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setZoomOutBehavior( Qgis::PointCloudZoomOutRenderBehavior zoomOutBehavior );
     Qgis::PointCloudZoomOutRenderBehavior zoomOutBehavior() const;
 
-    void setZoomOutMultiplier( double threshold );
-    double zoomOutMultiplier() const;
+    void setOverviewSwitchingScale( double scale );
+    double overviewSwitchingScale() const;
 
     void connectChildPanels( QgsPanelWidget *parent );
 
@@ -80,7 +80,12 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setColorRampMinMax( double min, double max );
 
   private:
-    const std::array<double, 8> mZoomOutScale = { 0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0 };
+    const QMap<double, QString> mOverviewSwitchingScaleMap {
+      { 5.0, "Much earlier" },
+      { 2.0, "Earlier" },
+      { 1.0, "Normal" },
+      { 0.5, "Later" }
+    };
 
     int mBlockChangedSignals = 0;
     int mDisableMinMaxWidgetRefresh = 0;

--- a/src/app/3d/qgspointcloud3dsymbolwidget.h
+++ b/src/app/3d/qgspointcloud3dsymbolwidget.h
@@ -80,7 +80,7 @@ class QgsPointCloud3DSymbolWidget : public QWidget, private Ui::QgsPointCloud3DS
     void setColorRampMinMax( double min, double max );
 
   private:
-    const std::array<double, 7> mZoomOutScale = { 0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0 };
+    const std::array<double, 8> mZoomOutScale = { 0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0 };
 
     int mBlockChangedSignals = 0;
     int mDisableMinMaxWidgetRefresh = 0;

--- a/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
@@ -65,7 +65,7 @@ QgsPointCloudLayer3DRenderer *QgsPointCloudLayer3DRendererWidget::renderer()
   renderer->setMaximumScreenError( mWidgetPointCloudSymbol->maximumScreenError() );
   renderer->setShowBoundingBoxes( mWidgetPointCloudSymbol->showBoundingBoxes() );
   renderer->setZoomOutBehavior( mWidgetPointCloudSymbol->zoomOutBehavior() );
-  renderer->setZoomOutMultiplier( mWidgetPointCloudSymbol->zoomOutMultiplier() );
+  renderer->setOverviewSwitchingScale( mWidgetPointCloudSymbol->overviewSwitchingScale() );
   return renderer;
 }
 

--- a/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
+++ b/src/app/3d/qgspointcloudlayer3drendererwidget.cpp
@@ -65,6 +65,7 @@ QgsPointCloudLayer3DRenderer *QgsPointCloudLayer3DRendererWidget::renderer()
   renderer->setMaximumScreenError( mWidgetPointCloudSymbol->maximumScreenError() );
   renderer->setShowBoundingBoxes( mWidgetPointCloudSymbol->showBoundingBoxes() );
   renderer->setZoomOutBehavior( mWidgetPointCloudSymbol->zoomOutBehavior() );
+  renderer->setZoomOutMultiplier( mWidgetPointCloudSymbol->zoomOutMultiplier() );
   return renderer;
 }
 

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -987,9 +987,14 @@ void QgsPointCloudLayer::loadIndexesForRenderContext( QgsRenderContext &renderer
         if ( subIndex.at( i ).index() )
           continue;
 
+
+        const double zoomOutMultiplier = mRenderer ? mRenderer->zoomOutMultiplier() : 1.0;
+        const double widthThreshold = vpcProvider->averageSubIndexWidth()  * zoomOutMultiplier;
+        const double heightThreshold = vpcProvider->averageSubIndexHeight() * zoomOutMultiplier;
+
         if ( subIndex.at( i ).extent().intersects( renderExtent ) &&
-             ( renderExtent.width() < vpcProvider->averageSubIndexWidth() ||
-               renderExtent.height() < vpcProvider->averageSubIndexHeight() ) )
+             ( renderExtent.width() < widthThreshold ||
+               renderExtent.height() < heightThreshold ) )
         {
           mDataProvider->loadSubIndex( i );
         }

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -987,10 +987,9 @@ void QgsPointCloudLayer::loadIndexesForRenderContext( QgsRenderContext &renderer
         if ( subIndex.at( i ).index() )
           continue;
 
-
-        const double zoomOutMultiplier = mRenderer ? mRenderer->zoomOutMultiplier() : 1.0;
-        const double widthThreshold = vpcProvider->averageSubIndexWidth()  * zoomOutMultiplier;
-        const double heightThreshold = vpcProvider->averageSubIndexHeight() * zoomOutMultiplier;
+        const double overviewSwitchingScale = mRenderer ? mRenderer->overviewSwitchingScale() : 1.0;
+        const double widthThreshold = vpcProvider->averageSubIndexWidth()  * overviewSwitchingScale;
+        const double heightThreshold = vpcProvider->averageSubIndexHeight() * overviewSwitchingScale;
 
         if ( subIndex.at( i ).extent().intersects( renderExtent ) &&
              ( renderExtent.width() < widthThreshold ||

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -216,9 +216,9 @@ bool QgsPointCloudLayerRenderer::render()
         visibleIndexes.append( si );
       }
     }
-    const double zoomOutMultiplier = mRenderer->zoomOutMultiplier();
-    const bool zoomedOut = renderExtent.width() > mAverageSubIndexWidth * zoomOutMultiplier ||
-                           renderExtent.height() > mAverageSubIndexHeight * zoomOutMultiplier;
+    const double overviewSwitchingScale = mRenderer->overviewSwitchingScale();
+    const bool zoomedOut = renderExtent.width() > mAverageSubIndexWidth * overviewSwitchingScale ||
+                           renderExtent.height() > mAverageSubIndexHeight * overviewSwitchingScale;
     // if the overview of virtual point cloud exists, and we are zoomed out, we render just overview
     if ( mOverviewIndex && mOverviewIndex->isValid() && zoomedOut &&
          mRenderer->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverview )

--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -216,8 +216,9 @@ bool QgsPointCloudLayerRenderer::render()
         visibleIndexes.append( si );
       }
     }
-    const bool zoomedOut = renderExtent.width() > mAverageSubIndexWidth ||
-                           renderExtent.height() > mAverageSubIndexHeight;
+    const double zoomOutMultiplier = mRenderer->zoomOutMultiplier();
+    const bool zoomedOut = renderExtent.width() > mAverageSubIndexWidth * zoomOutMultiplier ||
+                           renderExtent.height() > mAverageSubIndexHeight * zoomOutMultiplier;
     // if the overview of virtual point cloud exists, and we are zoomed out, we render just overview
     if ( mOverviewIndex && mOverviewIndex->isValid() && zoomedOut &&
          mRenderer->zoomOutBehavior() == Qgis::PointCloudZoomOutRenderBehavior::RenderOverview )

--- a/src/core/pointcloud/qgspointcloudrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudrenderer.cpp
@@ -153,6 +153,11 @@ void QgsPointCloudRenderer::setMaximumScreenError( double error )
   mMaximumScreenError = error;
 }
 
+void QgsPointCloudRenderer::setZoomOutMultiplier( double value )
+{
+  mZoomOutMultiplier = value;
+}
+
 Qgis::RenderUnit QgsPointCloudRenderer::maximumScreenErrorUnit() const
 {
   return mMaximumScreenErrorUnit;
@@ -221,6 +226,7 @@ void QgsPointCloudRenderer::copyCommonProperties( QgsPointCloudRenderer *destina
   destination->setShowLabels( mShowLabels );
   destination->setLabelTextFormat( mLabelTextFormat );
   destination->setZoomOutBehavior( mZoomOutBehavior );
+  destination->setZoomOutMultiplier( mZoomOutMultiplier );
 }
 
 void QgsPointCloudRenderer::restoreCommonProperties( const QDomElement &element, const QgsReadWriteContext &context )
@@ -246,6 +252,7 @@ void QgsPointCloudRenderer::restoreCommonProperties( const QDomElement &element,
     mLabelTextFormat.readXml( element.firstChildElement( u"text-style"_s ), context );
   }
   mZoomOutBehavior = qgsEnumKeyToValue( element.attribute( u"zoomOutBehavior"_s ), Qgis::PointCloudZoomOutRenderBehavior::RenderExtents );
+  mZoomOutMultiplier = element.attribute( u"zoomOutMultiplier"_s, u"1.0"_s ).toDouble();
 }
 
 void QgsPointCloudRenderer::saveCommonProperties( QDomElement &element, const QgsReadWriteContext &context ) const
@@ -272,7 +279,10 @@ void QgsPointCloudRenderer::saveCommonProperties( QDomElement &element, const Qg
     element.appendChild( mLabelTextFormat.writeXml( doc, context ) );
   }
   if ( mZoomOutBehavior != Qgis::PointCloudZoomOutRenderBehavior::RenderExtents )
+  {
     element.setAttribute( u"zoomOutBehavior"_s, qgsEnumValueToKey( mZoomOutBehavior ) );
+    element.setAttribute( u"zoomOutMultiplier"_s, qgsDoubleToString( mZoomOutMultiplier ) );
+  }
 }
 
 Qgis::PointCloudSymbol QgsPointCloudRenderer::pointSymbol() const

--- a/src/core/pointcloud/qgspointcloudrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudrenderer.cpp
@@ -153,9 +153,9 @@ void QgsPointCloudRenderer::setMaximumScreenError( double error )
   mMaximumScreenError = error;
 }
 
-void QgsPointCloudRenderer::setZoomOutMultiplier( double value )
+void QgsPointCloudRenderer::setOverviewSwitchingScale( double scale )
 {
-  mZoomOutMultiplier = value;
+  mOverviewSwitchingScale = scale;
 }
 
 Qgis::RenderUnit QgsPointCloudRenderer::maximumScreenErrorUnit() const
@@ -226,7 +226,7 @@ void QgsPointCloudRenderer::copyCommonProperties( QgsPointCloudRenderer *destina
   destination->setShowLabels( mShowLabels );
   destination->setLabelTextFormat( mLabelTextFormat );
   destination->setZoomOutBehavior( mZoomOutBehavior );
-  destination->setZoomOutMultiplier( mZoomOutMultiplier );
+  destination->setOverviewSwitchingScale( mOverviewSwitchingScale );
 }
 
 void QgsPointCloudRenderer::restoreCommonProperties( const QDomElement &element, const QgsReadWriteContext &context )
@@ -252,7 +252,7 @@ void QgsPointCloudRenderer::restoreCommonProperties( const QDomElement &element,
     mLabelTextFormat.readXml( element.firstChildElement( u"text-style"_s ), context );
   }
   mZoomOutBehavior = qgsEnumKeyToValue( element.attribute( u"zoomOutBehavior"_s ), Qgis::PointCloudZoomOutRenderBehavior::RenderExtents );
-  mZoomOutMultiplier = element.attribute( u"zoomOutMultiplier"_s, u"1.0"_s ).toDouble();
+  mOverviewSwitchingScale = element.attribute( u"overviewSwitchingScale"_s, u"1.0"_s ).toDouble();
 }
 
 void QgsPointCloudRenderer::saveCommonProperties( QDomElement &element, const QgsReadWriteContext &context ) const
@@ -281,7 +281,7 @@ void QgsPointCloudRenderer::saveCommonProperties( QDomElement &element, const Qg
   if ( mZoomOutBehavior != Qgis::PointCloudZoomOutRenderBehavior::RenderExtents )
   {
     element.setAttribute( u"zoomOutBehavior"_s, qgsEnumValueToKey( mZoomOutBehavior ) );
-    element.setAttribute( u"zoomOutMultiplier"_s, qgsDoubleToString( mZoomOutMultiplier ) );
+    element.setAttribute( u"overviewSwitchingScale"_s, qgsDoubleToString( mOverviewSwitchingScale ) );
   }
 }
 

--- a/src/core/pointcloud/qgspointcloudrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrenderer.h
@@ -712,6 +712,18 @@ class CORE_EXPORT QgsPointCloudRenderer
      */
     Qgis::PointCloudZoomOutRenderBehavior zoomOutBehavior() const { return mZoomOutBehavior; }
 
+    /**
+     * Sets the zoom out multiplier for overview rendering
+     * \since QGIS 4.0
+     */
+    void setZoomOutMultiplier( const double value );
+
+    /**
+      * Returns the zoom out multiplier for overview rendering
+      * \since QGIS 4.0
+      */
+    double zoomOutMultiplier() const { return mZoomOutMultiplier; }
+
   protected:
 
     /**
@@ -855,6 +867,7 @@ class CORE_EXPORT QgsPointCloudRenderer
     QgsTextFormat mLabelTextFormat;
 
     Qgis::PointCloudZoomOutRenderBehavior mZoomOutBehavior = Qgis::PointCloudZoomOutRenderBehavior::RenderExtents;
+    double mZoomOutMultiplier = 1.0;
 };
 
 #endif // QGSPOINTCLOUDRENDERER_H

--- a/src/core/pointcloud/qgspointcloudrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrenderer.h
@@ -714,6 +714,11 @@ class CORE_EXPORT QgsPointCloudRenderer
 
     /**
       * Sets the overview switching scale
+      *
+      * Point clouds whose extents intersect the map extent are considered visible.
+      * When zoomed out beyond the overview switching scale (render extent exceeds average
+      * point cloud dimensions by the scale factor), and overview zoom-out behavior is enabled,
+      * the overview is rendered instead of an individual point cloud.
       * \since QGIS 4.0
       */
     void setOverviewSwitchingScale( const double value );

--- a/src/core/pointcloud/qgspointcloudrenderer.h
+++ b/src/core/pointcloud/qgspointcloudrenderer.h
@@ -713,16 +713,16 @@ class CORE_EXPORT QgsPointCloudRenderer
     Qgis::PointCloudZoomOutRenderBehavior zoomOutBehavior() const { return mZoomOutBehavior; }
 
     /**
-     * Sets the zoom out multiplier for overview rendering
-     * \since QGIS 4.0
-     */
-    void setZoomOutMultiplier( const double value );
-
-    /**
-      * Returns the zoom out multiplier for overview rendering
+      * Sets the overview switching scale
       * \since QGIS 4.0
       */
-    double zoomOutMultiplier() const { return mZoomOutMultiplier; }
+    void setOverviewSwitchingScale( const double value );
+
+    /**
+      * Returns the overview switching scale
+      * \since QGIS 4.0
+      */
+    double overviewSwitchingScale() const { return mOverviewSwitchingScale; }
 
   protected:
 
@@ -867,7 +867,7 @@ class CORE_EXPORT QgsPointCloudRenderer
     QgsTextFormat mLabelTextFormat;
 
     Qgis::PointCloudZoomOutRenderBehavior mZoomOutBehavior = Qgis::PointCloudZoomOutRenderBehavior::RenderExtents;
-    double mZoomOutMultiplier = 1.0;
+    double mOverviewSwitchingScale = 1.0;
 };
 
 #endif // QGSPOINTCLOUDRENDERER_H

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
@@ -148,6 +148,16 @@ QgsPointCloudRendererPropertiesWidget::QgsPointCloudRendererPropertiesWidget( Qg
       mZoomOutOptions->setEnabled( false );
     }
 
+    whileBlocking( mZoomOutMultiplier )->setRange( 0, static_cast<int>( mZoomOutScale.size() - 1 ) );
+    mZoomOutMultiplier->setSingleStep( 1 );
+    mZoomOutMultiplier->setPageStep( 1 );
+    mZoomOutMultiplier->setTickInterval( 1 );
+    mZoomOutMultiplier->setTickPosition( QSlider::TicksBelow );
+
+    setZoomOutMultiplier( mZoomOutScale[mZoomOutScale.size() / 2] );
+
+    connect( mZoomOutMultiplier, &QSlider::valueChanged, this, &QgsPointCloudRendererPropertiesWidget::emitWidgetChanged );
+
     connect( mZoomOutOptions, qOverload<int>( &QComboBox::currentIndexChanged ), this, [this]( int ) {
       switch ( mZoomOutOptions->currentData().value<Qgis::PointCloudZoomOutRenderBehavior>() )
       {
@@ -217,6 +227,7 @@ void QgsPointCloudRendererPropertiesWidget::syncToLayer( QgsMapLayer *layer )
 
     mMaxErrorSpinBox->setValue( mLayer->renderer()->maximumScreenError() );
     mMaxErrorUnitWidget->setUnit( mLayer->renderer()->maximumScreenErrorUnit() );
+    mZoomOutMultiplier->setValue( mLayer->renderer()->zoomOutMultiplier() );
 
     mTriangulateGroupBox->setChecked( mLayer->renderer()->renderAsTriangles() );
     mHorizontalTriangleCheckBox->setChecked( mLayer->renderer()->horizontalTriangleFilter() );
@@ -285,6 +296,8 @@ void QgsPointCloudRendererPropertiesWidget::apply()
   mLayer->renderer()->setShowLabels( mLabels->isChecked() );
   mLayer->renderer()->setLabelTextFormat( mLabelOptions->textFormat() );
   mLayer->renderer()->setZoomOutBehavior( mZoomOutOptions->currentData().value<Qgis::PointCloudZoomOutRenderBehavior>() );
+
+  mLayer->renderer()->setZoomOutMultiplier( zoomOutMultiplier() );
 }
 
 void QgsPointCloudRendererPropertiesWidget::rendererChanged()
@@ -358,4 +371,25 @@ void QgsPointCloudRendererPropertiesWidget::emitWidgetChanged()
 {
   if ( !mBlockChangedSignal )
     emit widgetChanged();
+}
+
+void QgsPointCloudRendererPropertiesWidget::setZoomOutMultiplier( double threshold )
+{
+  int idx = 0;
+  for ( size_t i = 0; i < mZoomOutScale.size(); ++i )
+  {
+    if ( threshold <= mZoomOutScale[i] )
+    {
+      idx = i;
+      break;
+    }
+  }
+
+  whileBlocking( mZoomOutMultiplier )->setValue( idx );
+}
+
+double QgsPointCloudRendererPropertiesWidget::zoomOutMultiplier() const
+{
+  const int idx = std::clamp( mZoomOutMultiplier->value(), 0, static_cast<int>( mZoomOutScale.size() ) - 1 );
+  return mZoomOutScale[idx];
 }

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.cpp
@@ -227,7 +227,7 @@ void QgsPointCloudRendererPropertiesWidget::syncToLayer( QgsMapLayer *layer )
 
     mMaxErrorSpinBox->setValue( mLayer->renderer()->maximumScreenError() );
     mMaxErrorUnitWidget->setUnit( mLayer->renderer()->maximumScreenErrorUnit() );
-    mZoomOutMultiplier->setValue( mLayer->renderer()->zoomOutMultiplier() );
+    setZoomOutMultiplier( mLayer->renderer()->zoomOutMultiplier() );
 
     mTriangulateGroupBox->setChecked( mLayer->renderer()->renderAsTriangles() );
     mHorizontalTriangleCheckBox->setChecked( mLayer->renderer()->horizontalTriangleFilter() );
@@ -373,12 +373,12 @@ void QgsPointCloudRendererPropertiesWidget::emitWidgetChanged()
     emit widgetChanged();
 }
 
-void QgsPointCloudRendererPropertiesWidget::setZoomOutMultiplier( double threshold )
+void QgsPointCloudRendererPropertiesWidget::setZoomOutMultiplier( double multiplier )
 {
-  int idx = 0;
+  size_t idx = 0;
   for ( size_t i = 0; i < mZoomOutScale.size(); ++i )
   {
-    if ( threshold <= mZoomOutScale[i] )
+    if ( multiplier <= mZoomOutScale[i] )
     {
       idx = i;
       break;

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.h
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.h
@@ -65,6 +65,10 @@ class GUI_EXPORT QgsPointCloudRendererPropertiesWidget : public QgsMapLayerConfi
 
   private:
     static void initRendererWidgetFunctions();
+    void setZoomOutMultiplier( double threshold );
+    double zoomOutMultiplier() const;
+
+    const std::array<double, 7> mZoomOutScale = { 0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0 };
 
     QgsPointCloudLayer *mLayer = nullptr;
     QgsStyle *mStyle = nullptr;

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.h
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.h
@@ -64,11 +64,16 @@ class GUI_EXPORT QgsPointCloudRendererPropertiesWidget : public QgsMapLayerConfi
     void emitWidgetChanged();
 
   private:
-    static void initRendererWidgetFunctions();
-    void setZoomOutMultiplier( double multiplier );
-    double zoomOutMultiplier() const;
+    const QMap<double, QString> mOverviewSwitchingScaleMap {
+      { 5.0, "Much earlier" },
+      { 2.0, "Earlier" },
+      { 1.0, "Normal" },
+      { 0.5, "Later" }
+    };
 
-    const std::array<double, 8> mZoomOutScale = { 0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0 };
+    static void initRendererWidgetFunctions();
+    void setOverviewSwitchingScale( double scale );
+    double overviewSwitchingScale() const;
 
     QgsPointCloudLayer *mLayer = nullptr;
     QgsStyle *mStyle = nullptr;

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.h
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.h
@@ -65,10 +65,10 @@ class GUI_EXPORT QgsPointCloudRendererPropertiesWidget : public QgsMapLayerConfi
 
   private:
     static void initRendererWidgetFunctions();
-    void setZoomOutMultiplier( double threshold );
+    void setZoomOutMultiplier( double multiplier );
     double zoomOutMultiplier() const;
 
-    const std::array<double, 7> mZoomOutScale = { 0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0 };
+    const std::array<double, 8> mZoomOutScale = { 0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0 };
 
     QgsPointCloudLayer *mLayer = nullptr;
     QgsStyle *mStyle = nullptr;

--- a/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.h
+++ b/src/gui/pointcloud/qgspointcloudrendererpropertieswidget.h
@@ -64,6 +64,7 @@ class GUI_EXPORT QgsPointCloudRendererPropertiesWidget : public QgsMapLayerConfi
     void emitWidgetChanged();
 
   private:
+    // for 3D rendering, see values in qgspointcloud3dsymbolwidget.h
     const QMap<double, QString> mOverviewSwitchingScaleMap {
       { 5.0, "Much earlier" },
       { 2.0, "Earlier" },

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -207,7 +207,7 @@
          <item row="1" column="0">
           <widget class="QLabel" name="label">
            <property name="text">
-            <string>Zoomed out treshold:</string>
+            <string>Level of Detail:</string>
            </property>
           </widget>
          </item>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -212,7 +212,15 @@
           <widget class="QComboBox" name="mZoomOutOptions"/>
          </item>
          <item row="1" column="1" colspan="2">
-          <widget class="QComboBox" name="mOverviewSwitchingScale"/>
+          <widget class="QComboBox" name="mOverviewSwitchingScale">
+           <property name="toolTip">
+            <string>Sets the screen space error threshold at which detailed 3D point cloud tiles are rendered instead of their bounding boxes.
+
+Normal means tiles switch to detailed rendering once they occupy a noticeable portion of the screen.
+
+Select Earlier to load detailed tiles at a greater distance (zoomed out), or Later to switch only when zoomed in very close.</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -194,14 +194,28 @@
          <bool>false</bool>
         </property>
         <layout class="QGridLayout" name="gridLayout_5">
-         <item row="0" column="1" colspan="2">
-          <widget class="QComboBox" name="mZoomOutOptions"/>
-         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="label_4">
            <property name="text">
             <string>When zoomed out</string>
            </property>
+          </widget>
+         </item>
+         <item row="0" column="1" colspan="2">
+          <widget class="QComboBox" name="mZoomOutOptions"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Zoomed out treshold:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSlider" name="mZoomOutMultiplier">
+            <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+            </property>
           </widget>
          </item>
         </layout>
@@ -233,7 +247,7 @@
           <string>See 2D Symbology settings</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignCenter</set>
+          <set>Qt::AlignmentFlag::AlignCenter</set>
          </property>
         </widget>
        </item>
@@ -263,7 +277,7 @@
        <item row="1" column="1">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -417,7 +431,7 @@ enhancement</string>
             <string>Min</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -433,7 +447,7 @@ enhancement</string>
             <string>Max</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -459,7 +473,7 @@ enhancement</string>
             <string>Min</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -475,7 +489,7 @@ enhancement</string>
             <string>Max</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -494,7 +508,7 @@ enhancement</string>
             <string>Min</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -510,7 +524,7 @@ enhancement</string>
             <string>Max</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -543,7 +557,7 @@ enhancement</string>
             <string>Blue band</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -573,7 +587,7 @@ enhancement</string>
             <string>Green band</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -589,7 +603,7 @@ enhancement</string>
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -629,15 +643,15 @@ enhancement</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>

--- a/src/ui/3d/qgspointcloud3dsymbolwidget.ui
+++ b/src/ui/3d/qgspointcloud3dsymbolwidget.ui
@@ -194,6 +194,13 @@
          <bool>false</bool>
         </property>
         <layout class="QGridLayout" name="gridLayout_5">
+         <item row="1" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Overview switching scale</string>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="label_4">
            <property name="text">
@@ -204,19 +211,8 @@
          <item row="0" column="1" colspan="2">
           <widget class="QComboBox" name="mZoomOutOptions"/>
          </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Level of Detail:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QSlider" name="mZoomOutMultiplier">
-            <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-            </property>
-          </widget>
+         <item row="1" column="1" colspan="2">
+          <widget class="QComboBox" name="mOverviewSwitchingScale"/>
          </item>
         </layout>
        </widget>

--- a/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
@@ -108,7 +108,7 @@
              </size>
             </property>
             <property name="focusPolicy">
-             <enum>Qt::StrongFocus</enum>
+             <enum>Qt::FocusPolicy::StrongFocus</enum>
             </property>
            </widget>
           </item>
@@ -181,10 +181,34 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>When zoomed out</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QgsFontButton" name="mLabelOptions">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Zoomed out treshold:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QComboBox" name="mZoomOutOptions"/>
+          </item>
           <item row="1" column="1">
            <spacer name="horizontalSpacer">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -194,23 +218,6 @@
             </property>
            </spacer>
           </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QComboBox" name="mZoomOutOptions"/>
-          </item>
-          <item row="1" column="2">
-           <widget class="QgsFontButton" name="mLabelOptions">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>When zoomed out</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="0">
            <widget class="QCheckBox" name="mLabels">
             <property name="text">
@@ -218,6 +225,13 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="1" colspan="2">
+            <widget class="QSlider" name="mZoomOutMultiplier">
+              <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+            </widget>
+            </item>
          </layout>
         </widget>
        </item>
@@ -262,7 +276,7 @@
              </size>
             </property>
             <property name="focusPolicy">
-             <enum>Qt::StrongFocus</enum>
+             <enum>Qt::FocusPolicy::StrongFocus</enum>
             </property>
            </widget>
           </item>
@@ -279,7 +293,7 @@
           <item row="2" column="1" colspan="3">
            <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
             <property name="focusPolicy">
-             <enum>Qt::StrongFocus</enum>
+             <enum>Qt::FocusPolicy::StrongFocus</enum>
             </property>
            </widget>
           </item>

--- a/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
@@ -198,7 +198,7 @@
           <item row="2" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Zoomed out treshold:</string>
+             <string>Level of Detail:</string>
             </property>
            </widget>
           </item>

--- a/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
@@ -226,7 +226,15 @@
            </widget>
           </item>
           <item row="2" column="1" colspan="2">
-           <widget class="QComboBox" name="mOverviewSwitchingScale"/>
+           <widget class="QComboBox" name="mOverviewSwitchingScale">
+            <property name="toolTip">
+             <string>Sets the zoom level at which the individual point cloud files will get rendered instead of the overview or their extents.
+
+Normal means roughly when the point cloud extent no longer fits the map extent.
+
+Select Earlier to switch at a smaller scale (zoomed out) or Later to switch at a larger scale (zoomed in). </string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
@@ -181,29 +181,12 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_3">
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="mLabels">
             <property name="text">
-             <string>When zoomed out</string>
+             <string>Show tile labels</string>
             </property>
            </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QgsFontButton" name="mLabelOptions">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Level of Detail:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QComboBox" name="mZoomOutOptions"/>
           </item>
           <item row="1" column="1">
            <spacer name="horizontalSpacer">
@@ -218,20 +201,33 @@
             </property>
            </spacer>
           </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="mLabels">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Show tile labels</string>
+             <string>When zoomed out</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QComboBox" name="mZoomOutOptions"/>
+          </item>
+          <item row="1" column="2">
+           <widget class="QgsFontButton" name="mLabelOptions">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Overview switching scale</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1" colspan="2">
-            <widget class="QSlider" name="mZoomOutMultiplier">
-              <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-            </widget>
-            </item>
+           <widget class="QComboBox" name="mOverviewSwitchingScale"/>
+          </item>
          </layout>
         </widget>
        </item>

--- a/tests/src/3d/testqgspointcloud3drendering.cpp
+++ b/tests/src/3d/testqgspointcloud3drendering.cpp
@@ -603,6 +603,7 @@ void TestQgsPointCloud3DRendering::testPointCloud3DOverview()
   QgsPointCloudLayer3DRenderer *renderer = new QgsPointCloudLayer3DRenderer();
   renderer->setSymbol( symbol );
   renderer->setZoomOutBehavior( Qgis::PointCloudZoomOutRenderBehavior::RenderOverview );
+  renderer->setZoomOutMultiplier( 16.0 );
   mVpcLayer->setRenderer3D( renderer );
 
   scene->cameraController()->resetView( 120 );

--- a/tests/src/3d/testqgspointcloud3drendering.cpp
+++ b/tests/src/3d/testqgspointcloud3drendering.cpp
@@ -603,7 +603,6 @@ void TestQgsPointCloud3DRendering::testPointCloud3DOverview()
   QgsPointCloudLayer3DRenderer *renderer = new QgsPointCloudLayer3DRenderer();
   renderer->setSymbol( symbol );
   renderer->setZoomOutBehavior( Qgis::PointCloudZoomOutRenderBehavior::RenderOverview );
-  renderer->setOverviewSwitchingScale( 16.0 );
   mVpcLayer->setRenderer3D( renderer );
 
   scene->cameraController()->resetView( 120 );

--- a/tests/src/3d/testqgspointcloud3drendering.cpp
+++ b/tests/src/3d/testqgspointcloud3drendering.cpp
@@ -603,7 +603,7 @@ void TestQgsPointCloud3DRendering::testPointCloud3DOverview()
   QgsPointCloudLayer3DRenderer *renderer = new QgsPointCloudLayer3DRenderer();
   renderer->setSymbol( symbol );
   renderer->setZoomOutBehavior( Qgis::PointCloudZoomOutRenderBehavior::RenderOverview );
-  renderer->setZoomOutMultiplier( 16.0 );
+  renderer->setOverviewSwitchingScale( 16.0 );
   mVpcLayer->setRenderer3D( renderer );
 
   scene->cameraController()->resetView( 120 );


### PR DESCRIPTION
This PR adds a combobox that controls the point of switching between rendering overview only and rendering a sub index of the VPC.

Users are presented with 4 options (adding the actual value of the option in the brackets, it is subject to change based on the feedback once in the wild): Later (0.5), Normal (1.0), Earlier (2.0), Much earlier (5.0).

On 2D map canvas, if the average extent width of the sub indexes multiplied by the value from the combobox is higher than the viewable map canvas, a sub index is loaded, otherwise overview only gets rendered.

For the 3D Map, we calculate the screen space error (SSE) - https://github.com/qgis/QGIS/blob/de30659865a24d0855eed8850675ab0181ee19c0/src/3d/qgs3dutils.cpp#L881-L905 and compare it against the fixed value of 0.2 divided by the combobox value.

One change is that when all the sub indexes are shown in the 3D Map, we disable overview rendering to save resources.

[Screencast_20260130_102919.webm](https://github.com/user-attachments/assets/cf1740b9-ae6e-4b40-b385-bc8bd36cbca0)

