### PR TITLE
Add digitizing support for TIN and PolyhedralSurface geometries

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsgeometry.py
+++ b/python/PyQt6/core/auto_additions/qgsgeometry.py
@@ -12,6 +12,7 @@ try:
     QgsGeometry.fromRect = staticmethod(QgsGeometry.fromRect)
     QgsGeometry.fromBox3D = staticmethod(QgsGeometry.fromBox3D)
     QgsGeometry.collectGeometry = staticmethod(QgsGeometry.collectGeometry)
+    QgsGeometry.collectTinPatches = staticmethod(QgsGeometry.collectTinPatches)
     QgsGeometry.createWedgeBuffer = staticmethod(QgsGeometry.createWedgeBuffer)
     QgsGeometry.createWedgeBufferFromAngles = staticmethod(QgsGeometry.createWedgeBufferFromAngles)
     QgsGeometry.unaryUnion = staticmethod(QgsGeometry.unaryUnion)

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2329,7 +2329,7 @@ Exports the geometry to a GeoJSON string.
 %End
 
 
-    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true ) const;
+    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true, QString *errorMessage /Out/ = 0 ) const;
 %Docstring
 Attempts to coerce this geometry into the specified destination
 ``type``.

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -288,6 +288,30 @@ surface geometry.
 Creates a new multipart geometry from a list of QgsGeometry objects
 %End
 
+    static QgsGeometry collectTinPatches( const QVector<QgsGeometry> &geometries );
+%Docstring
+Collects all patches from a list of TIN or Triangle geometries into a
+single TIN geometry.
+
+This method iterates through the input ``geometries`` and extracts all
+triangle patches, combining them into a single
+:py:class:`QgsTriangulatedSurface`. Input geometries can be either
+:py:class:`QgsTriangulatedSurface` (TIN) or :py:class:`QgsTriangle`
+objects. Other geometry types are ignored.
+
+The resulting TIN will preserve Z and M values if present in the first
+valid input geometry.
+
+:param geometries: list of input geometries (should be TIN or Triangle
+                   types)
+
+:return: a QgsGeometry containing a QgsTriangulatedSurface with all
+         collected patches, or a null geometry if no valid TIN/Triangle
+         geometries were found
+
+.. versionadded:: 4.0
+%End
+
     static QgsGeometry createWedgeBuffer( const QgsPoint &center, double azimuth, double angularWidth, double outerRadius, double innerRadius = 0 );
 %Docstring
 Creates a wedge shaped buffer from a ``center`` point.
@@ -2894,8 +2918,7 @@ The coordinates at which the error is located and should be visualized.
 
         SIP_PYOBJECT __repr__();
 %MethodCode
-        QString str
-          = QStringLiteral( "<QgsGeometry.Error: %1>" ).arg( sipCpp->what() );
+        QString str = QStringLiteral( "<QgsGeometry.Error: %1>" ).arg( sipCpp->what() );
         sipRes = PyUnicode_FromString( str.toUtf8().data() );
 %End
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2329,7 +2329,7 @@ Exports the geometry to a GeoJSON string.
 %End
 
 
-    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true, QString *errorMessage /Out/ = 0 ) const;
+    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true ) const;
 %Docstring
 Attempts to coerce this geometry into the specified destination
 ``type``.
@@ -2364,6 +2364,12 @@ geometries to points. By default duplicated nodes are ignored.
    of geometries instead of the geometry family (point/line/polygon), and tries more exhaustively
    to coerce geometries to the desired ``type``. It also correctly maintains curves and z/m values
    wherever appropriate.
+
+.. note::
+
+   If an error occurs during conversion (e.g., attempting to convert a polygon with
+   non-triangular vertices to a Triangle or TIN geometry), an empty vector will be returned and the
+   error message can be retrieved by calling :py:func:`~QgsGeometry.lastError` on the returned geometry.
 
 .. versionadded:: 3.14
 %End

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -41,7 +41,6 @@ Encapsulates parameters under which a geometry operation is performed.
 #include "qgsgeometry.h"
 %End
   public:
-
     double gridSize() const;
 %Docstring
 Returns the grid size which will be used to snap vertices of a geometry.
@@ -105,7 +104,6 @@ as the point, line, polygon, curve or other geometry subclasses.
     static const QMetaObject staticMetaObject;
 
   public:
-
     QgsGeometry() /HoldGIL/;
 
     QgsGeometry( const QgsGeometry & );
@@ -290,8 +288,7 @@ surface geometry.
 Creates a new multipart geometry from a list of QgsGeometry objects
 %End
 
-    static QgsGeometry createWedgeBuffer( const QgsPoint &center, double azimuth, double angularWidth,
-                                          double outerRadius, double innerRadius = 0 );
+    static QgsGeometry createWedgeBuffer( const QgsPoint &center, double azimuth, double angularWidth, double outerRadius, double innerRadius = 0 );
 %Docstring
 Creates a wedge shaped buffer from a ``center`` point.
 
@@ -310,8 +307,7 @@ Polygon geometry.
 .. versionadded:: 3.2
 %End
 
-    static QgsGeometry createWedgeBufferFromAngles( const QgsPoint &center, double startAngle, double endAngle,
-        double outerRadius, double innerRadius = 0 );
+    static QgsGeometry createWedgeBufferFromAngles( const QgsPoint &center, double startAngle, double endAngle, double outerRadius, double innerRadius = 0 );
 %Docstring
 Creates a wedge shaped buffer from a ``center`` point.
 
@@ -1111,8 +1107,7 @@ Example:
       if ( PyList_Check( a0 ) && PyList_GET_SIZE( a0 ) )
       {
         PyObject *p0 = PyList_GetItem( a0, 0 );
-        if ( sipCanConvertToType( p0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-             sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+        if ( sipCanConvertToType( p0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
         {
           QVector<QgsGeometry> newGeometries;
           QVector<QgsPointXY> topologyTestPoints;
@@ -1134,8 +1129,7 @@ Example:
           sipReleaseType( splitLine, sipType_QVector_0100QgsPointXY, state );
         }
 
-        else if ( sipCanConvertToType( p0, sipType_QgsPoint, SIP_NOT_NONE ) &&
-                  sipCanConvertToType( a0, sipType_QVector_0100QgsPoint, SIP_NOT_NONE ) )
+        else if ( sipCanConvertToType( p0, sipType_QgsPoint, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0100QgsPoint, SIP_NOT_NONE ) )
         {
           QVector<QgsGeometry> newGeometries;
           QVector<QgsPoint> topologyTestPoints;
@@ -1170,7 +1164,7 @@ Example:
     }
 %End
 
-    Qgis::GeometryOperationResult splitGeometry( const QgsCurve *curve,  QVector<QgsGeometry> &newGeometries /Out/, bool preserveCircular, bool topological, QgsPointSequence &topologyTestPoints /Out/, bool splitFeature = true );
+    Qgis::GeometryOperationResult splitGeometry( const QgsCurve *curve, QVector<QgsGeometry> &newGeometries /Out/, bool preserveCircular, bool topological, QgsPointSequence &topologyTestPoints /Out/, bool splitFeature = true );
 %Docstring
 Splits this geometry according to a given curve.
 
@@ -1391,11 +1385,7 @@ will be generated.
 .. versionadded:: 3.24
 %End
 
-    QgsGeometry applyDashPattern( const QVector< double > &pattern,
-                                  Qgis::DashPatternLineEndingRule startRule = Qgis::DashPatternLineEndingRule::NoRule,
-                                  Qgis::DashPatternLineEndingRule endRule = Qgis::DashPatternLineEndingRule::NoRule,
-                                  Qgis::DashPatternSizeAdjustment adjustment = Qgis::DashPatternSizeAdjustment::ScaleBothDashAndGap,
-                                  double patternOffset = 0 ) const;
+    QgsGeometry applyDashPattern( const QVector< double > &pattern, Qgis::DashPatternLineEndingRule startRule = Qgis::DashPatternLineEndingRule::NoRule, Qgis::DashPatternLineEndingRule endRule = Qgis::DashPatternLineEndingRule::NoRule, Qgis::DashPatternSizeAdjustment adjustment = Qgis::DashPatternSizeAdjustment::ScaleBothDashAndGap, double patternOffset = 0 ) const;
 %Docstring
 Applies a dash pattern to a geometry, returning a MultiLineString
 geometry which is the input geometry stroked along each line/ring with
@@ -1629,9 +1619,7 @@ Returns an offset line at a given distance and side from an input line.
                    (JoinStyleMiter only)
 %End
 
-    QgsGeometry singleSidedBuffer( double distance, int segments, Qgis::BufferSide side,
-                                   Qgis::JoinStyle joinStyle = Qgis::JoinStyle::Round,
-                                   double miterLimit = 2.0 ) const;
+    QgsGeometry singleSidedBuffer( double distance, int segments, Qgis::BufferSide side, Qgis::JoinStyle joinStyle = Qgis::JoinStyle::Round, double miterLimit = 2.0 ) const;
 %Docstring
 Returns a single sided buffer for a (multi)line geometry. The buffer is
 only applied to one side of the line.
@@ -2358,6 +2346,8 @@ the specified type. E.g.
 - curved geometries will be segmented if ``type`` is non-curved.
 - multi geometries will be converted to a list of single geometries
 - single geometries will be upgraded to multi geometries
+- PolyhedralSurface/TIN will be converted to multi polygon
+- multipolygon, polygon and triangle will be converted to TIN
 - z or m values will be added or dropped as required.
 
 Since QGIS 3.24, the parameters ``defaultZ`` and ``defaultM`` control
@@ -2898,7 +2888,8 @@ The coordinates at which the error is located and should be visualized.
 
         SIP_PYOBJECT __repr__();
 %MethodCode
-        QString str = QStringLiteral( "<QgsGeometry.Error: %1>" ).arg( sipCpp->what() );
+        QString str
+          = QStringLiteral( "<QgsGeometry.Error: %1>" ).arg( sipCpp->what() );
         sipRes = PyUnicode_FromString( str.toUtf8().data() );
 %End
 
@@ -3093,18 +3084,14 @@ should match.
       int state1;
       int sipIsErr = 0;
 
-      if ( PyList_Check( a0 ) && PyList_Check( a1 ) &&
-           PyList_GET_SIZE( a0 ) && PyList_GET_SIZE( a1 ) )
+      if ( PyList_Check( a0 ) && PyList_Check( a1 ) && PyList_GET_SIZE( a0 ) && PyList_GET_SIZE( a1 ) )
       {
         PyObject *o0 = PyList_GetItem( a0, 0 );
         PyObject *o1 = PyList_GetItem( a1, 0 );
         if ( o0 && o1 )
         {
           // compare polyline - polyline
-          if ( sipCanConvertToType( o0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-               sipCanConvertToType( o1, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-               sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
-               sipCanConvertToType( a1, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+          if ( sipCanConvertToType( o0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( o1, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
           {
             QgsPolylineXY *p0;
             QgsPolylineXY *p1;
@@ -3117,18 +3104,14 @@ should match.
             sipReleaseType( p0, sipType_QVector_0100QgsPointXY, state0 );
             sipReleaseType( p1, sipType_QVector_0100QgsPointXY, state1 );
           }
-          else if ( PyList_Check( o0 ) && PyList_Check( o1 ) &&
-                    PyList_GET_SIZE( o0 ) && PyList_GET_SIZE( o1 ) )
+          else if ( PyList_Check( o0 ) && PyList_Check( o1 ) && PyList_GET_SIZE( o0 ) && PyList_GET_SIZE( o1 ) )
           {
             PyObject *oo0 = PyList_GetItem( o0, 0 );
             PyObject *oo1 = PyList_GetItem( o1, 0 );
             if ( oo0 && oo1 )
             {
               // compare polygon - polygon
-              if ( sipCanConvertToType( oo0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                   sipCanConvertToType( oo1, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                   sipCanConvertToType( a0, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
-                   sipCanConvertToType( a1, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+              if ( sipCanConvertToType( oo0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( oo1, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
               {
                 QgsPolygonXY *p0;
                 QgsPolygonXY *p1;
@@ -3141,18 +3124,14 @@ should match.
                 sipReleaseType( p0, sipType_QVector_0600QVector_0100QgsPointXY, state0 );
                 sipReleaseType( p1, sipType_QVector_0600QVector_0100QgsPointXY, state1 );
               }
-              else if ( PyList_Check( oo0 ) && PyList_Check( oo1 ) &&
-                        PyList_GET_SIZE( oo0 ) && PyList_GET_SIZE( oo1 ) )
+              else if ( PyList_Check( oo0 ) && PyList_Check( oo1 ) && PyList_GET_SIZE( oo0 ) && PyList_GET_SIZE( oo1 ) )
               {
                 PyObject *ooo0 = PyList_GetItem( oo0, 0 );
                 PyObject *ooo1 = PyList_GetItem( oo1, 0 );
                 if ( ooo0 && ooo1 )
                 {
                   // compare multipolygon - multipolygon
-                  if ( sipCanConvertToType( ooo0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                       sipCanConvertToType( ooo1, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                       sipCanConvertToType( a0, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
-                       sipCanConvertToType( a1, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+                  if ( sipCanConvertToType( ooo0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( ooo1, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
                   {
                     QgsMultiPolygonXY *p0;
                     QgsMultiPolygonXY *p1;
@@ -3174,8 +3153,7 @@ should match.
     }
 %End
 
-    QgsGeometry smooth( unsigned int iterations = 1, double offset = 0.25,
-                        double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
+    QgsGeometry smooth( unsigned int iterations = 1, double offset = 0.25, double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 %Docstring
 Smooths a geometry by rounding off corners using the Chaikin algorithm.
 This operation roughly doubles the number of vertices in a geometry.

--- a/python/core/auto_additions/qgsgeometry.py
+++ b/python/core/auto_additions/qgsgeometry.py
@@ -12,6 +12,7 @@ try:
     QgsGeometry.fromRect = staticmethod(QgsGeometry.fromRect)
     QgsGeometry.fromBox3D = staticmethod(QgsGeometry.fromBox3D)
     QgsGeometry.collectGeometry = staticmethod(QgsGeometry.collectGeometry)
+    QgsGeometry.collectTinPatches = staticmethod(QgsGeometry.collectTinPatches)
     QgsGeometry.createWedgeBuffer = staticmethod(QgsGeometry.createWedgeBuffer)
     QgsGeometry.createWedgeBufferFromAngles = staticmethod(QgsGeometry.createWedgeBufferFromAngles)
     QgsGeometry.unaryUnion = staticmethod(QgsGeometry.unaryUnion)

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2329,7 +2329,7 @@ Exports the geometry to a GeoJSON string.
 %End
 
 
-    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true ) const;
+    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true, QString *errorMessage /Out/ = 0 ) const;
 %Docstring
 Attempts to coerce this geometry into the specified destination
 ``type``.

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -288,6 +288,30 @@ surface geometry.
 Creates a new multipart geometry from a list of QgsGeometry objects
 %End
 
+    static QgsGeometry collectTinPatches( const QVector<QgsGeometry> &geometries );
+%Docstring
+Collects all patches from a list of TIN or Triangle geometries into a
+single TIN geometry.
+
+This method iterates through the input ``geometries`` and extracts all
+triangle patches, combining them into a single
+:py:class:`QgsTriangulatedSurface`. Input geometries can be either
+:py:class:`QgsTriangulatedSurface` (TIN) or :py:class:`QgsTriangle`
+objects. Other geometry types are ignored.
+
+The resulting TIN will preserve Z and M values if present in the first
+valid input geometry.
+
+:param geometries: list of input geometries (should be TIN or Triangle
+                   types)
+
+:return: a QgsGeometry containing a QgsTriangulatedSurface with all
+         collected patches, or a null geometry if no valid TIN/Triangle
+         geometries were found
+
+.. versionadded:: 4.0
+%End
+
     static QgsGeometry createWedgeBuffer( const QgsPoint &center, double azimuth, double angularWidth, double outerRadius, double innerRadius = 0 );
 %Docstring
 Creates a wedge shaped buffer from a ``center`` point.
@@ -2894,8 +2918,7 @@ The coordinates at which the error is located and should be visualized.
 
         SIP_PYOBJECT __repr__();
 %MethodCode
-        QString str
-          = QStringLiteral( "<QgsGeometry.Error: %1>" ).arg( sipCpp->what() );
+        QString str = QStringLiteral( "<QgsGeometry.Error: %1>" ).arg( sipCpp->what() );
         sipRes = PyUnicode_FromString( str.toUtf8().data() );
 %End
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2329,7 +2329,7 @@ Exports the geometry to a GeoJSON string.
 %End
 
 
-    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true, QString *errorMessage /Out/ = 0 ) const;
+    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true ) const;
 %Docstring
 Attempts to coerce this geometry into the specified destination
 ``type``.
@@ -2364,6 +2364,12 @@ geometries to points. By default duplicated nodes are ignored.
    of geometries instead of the geometry family (point/line/polygon), and tries more exhaustively
    to coerce geometries to the desired ``type``. It also correctly maintains curves and z/m values
    wherever appropriate.
+
+.. note::
+
+   If an error occurs during conversion (e.g., attempting to convert a polygon with
+   non-triangular vertices to a Triangle or TIN geometry), an empty vector will be returned and the
+   error message can be retrieved by calling :py:func:`~QgsGeometry.lastError` on the returned geometry.
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -41,7 +41,6 @@ Encapsulates parameters under which a geometry operation is performed.
 #include "qgsgeometry.h"
 %End
   public:
-
     double gridSize() const;
 %Docstring
 Returns the grid size which will be used to snap vertices of a geometry.
@@ -105,7 +104,6 @@ as the point, line, polygon, curve or other geometry subclasses.
     static const QMetaObject staticMetaObject;
 
   public:
-
     QgsGeometry() /HoldGIL/;
 
     QgsGeometry( const QgsGeometry & );
@@ -290,8 +288,7 @@ surface geometry.
 Creates a new multipart geometry from a list of QgsGeometry objects
 %End
 
-    static QgsGeometry createWedgeBuffer( const QgsPoint &center, double azimuth, double angularWidth,
-                                          double outerRadius, double innerRadius = 0 );
+    static QgsGeometry createWedgeBuffer( const QgsPoint &center, double azimuth, double angularWidth, double outerRadius, double innerRadius = 0 );
 %Docstring
 Creates a wedge shaped buffer from a ``center`` point.
 
@@ -310,8 +307,7 @@ Polygon geometry.
 .. versionadded:: 3.2
 %End
 
-    static QgsGeometry createWedgeBufferFromAngles( const QgsPoint &center, double startAngle, double endAngle,
-        double outerRadius, double innerRadius = 0 );
+    static QgsGeometry createWedgeBufferFromAngles( const QgsPoint &center, double startAngle, double endAngle, double outerRadius, double innerRadius = 0 );
 %Docstring
 Creates a wedge shaped buffer from a ``center`` point.
 
@@ -1111,8 +1107,7 @@ Example:
       if ( PyList_Check( a0 ) && PyList_GET_SIZE( a0 ) )
       {
         PyObject *p0 = PyList_GetItem( a0, 0 );
-        if ( sipCanConvertToType( p0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-             sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+        if ( sipCanConvertToType( p0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
         {
           QVector<QgsGeometry> newGeometries;
           QVector<QgsPointXY> topologyTestPoints;
@@ -1134,8 +1129,7 @@ Example:
           sipReleaseType( splitLine, sipType_QVector_0100QgsPointXY, state );
         }
 
-        else if ( sipCanConvertToType( p0, sipType_QgsPoint, SIP_NOT_NONE ) &&
-                  sipCanConvertToType( a0, sipType_QVector_0100QgsPoint, SIP_NOT_NONE ) )
+        else if ( sipCanConvertToType( p0, sipType_QgsPoint, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0100QgsPoint, SIP_NOT_NONE ) )
         {
           QVector<QgsGeometry> newGeometries;
           QVector<QgsPoint> topologyTestPoints;
@@ -1170,7 +1164,7 @@ Example:
     }
 %End
 
-    Qgis::GeometryOperationResult splitGeometry( const QgsCurve *curve,  QVector<QgsGeometry> &newGeometries /Out/, bool preserveCircular, bool topological, QgsPointSequence &topologyTestPoints /Out/, bool splitFeature = true );
+    Qgis::GeometryOperationResult splitGeometry( const QgsCurve *curve, QVector<QgsGeometry> &newGeometries /Out/, bool preserveCircular, bool topological, QgsPointSequence &topologyTestPoints /Out/, bool splitFeature = true );
 %Docstring
 Splits this geometry according to a given curve.
 
@@ -1391,11 +1385,7 @@ will be generated.
 .. versionadded:: 3.24
 %End
 
-    QgsGeometry applyDashPattern( const QVector< double > &pattern,
-                                  Qgis::DashPatternLineEndingRule startRule = Qgis::DashPatternLineEndingRule::NoRule,
-                                  Qgis::DashPatternLineEndingRule endRule = Qgis::DashPatternLineEndingRule::NoRule,
-                                  Qgis::DashPatternSizeAdjustment adjustment = Qgis::DashPatternSizeAdjustment::ScaleBothDashAndGap,
-                                  double patternOffset = 0 ) const;
+    QgsGeometry applyDashPattern( const QVector< double > &pattern, Qgis::DashPatternLineEndingRule startRule = Qgis::DashPatternLineEndingRule::NoRule, Qgis::DashPatternLineEndingRule endRule = Qgis::DashPatternLineEndingRule::NoRule, Qgis::DashPatternSizeAdjustment adjustment = Qgis::DashPatternSizeAdjustment::ScaleBothDashAndGap, double patternOffset = 0 ) const;
 %Docstring
 Applies a dash pattern to a geometry, returning a MultiLineString
 geometry which is the input geometry stroked along each line/ring with
@@ -1629,9 +1619,7 @@ Returns an offset line at a given distance and side from an input line.
                    (JoinStyleMiter only)
 %End
 
-    QgsGeometry singleSidedBuffer( double distance, int segments, Qgis::BufferSide side,
-                                   Qgis::JoinStyle joinStyle = Qgis::JoinStyle::Round,
-                                   double miterLimit = 2.0 ) const;
+    QgsGeometry singleSidedBuffer( double distance, int segments, Qgis::BufferSide side, Qgis::JoinStyle joinStyle = Qgis::JoinStyle::Round, double miterLimit = 2.0 ) const;
 %Docstring
 Returns a single sided buffer for a (multi)line geometry. The buffer is
 only applied to one side of the line.
@@ -2358,6 +2346,8 @@ the specified type. E.g.
 - curved geometries will be segmented if ``type`` is non-curved.
 - multi geometries will be converted to a list of single geometries
 - single geometries will be upgraded to multi geometries
+- PolyhedralSurface/TIN will be converted to multi polygon
+- multipolygon, polygon and triangle will be converted to TIN
 - z or m values will be added or dropped as required.
 
 Since QGIS 3.24, the parameters ``defaultZ`` and ``defaultM`` control
@@ -2898,7 +2888,8 @@ The coordinates at which the error is located and should be visualized.
 
         SIP_PYOBJECT __repr__();
 %MethodCode
-        QString str = QStringLiteral( "<QgsGeometry.Error: %1>" ).arg( sipCpp->what() );
+        QString str
+          = QStringLiteral( "<QgsGeometry.Error: %1>" ).arg( sipCpp->what() );
         sipRes = PyUnicode_FromString( str.toUtf8().data() );
 %End
 
@@ -3093,18 +3084,14 @@ should match.
       int state1;
       int sipIsErr = 0;
 
-      if ( PyList_Check( a0 ) && PyList_Check( a1 ) &&
-           PyList_GET_SIZE( a0 ) && PyList_GET_SIZE( a1 ) )
+      if ( PyList_Check( a0 ) && PyList_Check( a1 ) && PyList_GET_SIZE( a0 ) && PyList_GET_SIZE( a1 ) )
       {
         PyObject *o0 = PyList_GetItem( a0, 0 );
         PyObject *o1 = PyList_GetItem( a1, 0 );
         if ( o0 && o1 )
         {
           // compare polyline - polyline
-          if ( sipCanConvertToType( o0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-               sipCanConvertToType( o1, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-               sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
-               sipCanConvertToType( a1, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+          if ( sipCanConvertToType( o0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( o1, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
           {
             QgsPolylineXY *p0;
             QgsPolylineXY *p1;
@@ -3117,18 +3104,14 @@ should match.
             sipReleaseType( p0, sipType_QVector_0100QgsPointXY, state0 );
             sipReleaseType( p1, sipType_QVector_0100QgsPointXY, state1 );
           }
-          else if ( PyList_Check( o0 ) && PyList_Check( o1 ) &&
-                    PyList_GET_SIZE( o0 ) && PyList_GET_SIZE( o1 ) )
+          else if ( PyList_Check( o0 ) && PyList_Check( o1 ) && PyList_GET_SIZE( o0 ) && PyList_GET_SIZE( o1 ) )
           {
             PyObject *oo0 = PyList_GetItem( o0, 0 );
             PyObject *oo1 = PyList_GetItem( o1, 0 );
             if ( oo0 && oo1 )
             {
               // compare polygon - polygon
-              if ( sipCanConvertToType( oo0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                   sipCanConvertToType( oo1, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                   sipCanConvertToType( a0, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
-                   sipCanConvertToType( a1, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+              if ( sipCanConvertToType( oo0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( oo1, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
               {
                 QgsPolygonXY *p0;
                 QgsPolygonXY *p1;
@@ -3141,18 +3124,14 @@ should match.
                 sipReleaseType( p0, sipType_QVector_0600QVector_0100QgsPointXY, state0 );
                 sipReleaseType( p1, sipType_QVector_0600QVector_0100QgsPointXY, state1 );
               }
-              else if ( PyList_Check( oo0 ) && PyList_Check( oo1 ) &&
-                        PyList_GET_SIZE( oo0 ) && PyList_GET_SIZE( oo1 ) )
+              else if ( PyList_Check( oo0 ) && PyList_Check( oo1 ) && PyList_GET_SIZE( oo0 ) && PyList_GET_SIZE( oo1 ) )
               {
                 PyObject *ooo0 = PyList_GetItem( oo0, 0 );
                 PyObject *ooo1 = PyList_GetItem( oo1, 0 );
                 if ( ooo0 && ooo1 )
                 {
                   // compare multipolygon - multipolygon
-                  if ( sipCanConvertToType( ooo0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                       sipCanConvertToType( ooo1, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                       sipCanConvertToType( a0, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
-                       sipCanConvertToType( a1, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+                  if ( sipCanConvertToType( ooo0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( ooo1, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
                   {
                     QgsMultiPolygonXY *p0;
                     QgsMultiPolygonXY *p1;
@@ -3174,8 +3153,7 @@ should match.
     }
 %End
 
-    QgsGeometry smooth( unsigned int iterations = 1, double offset = 0.25,
-                        double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
+    QgsGeometry smooth( unsigned int iterations = 1, double offset = 0.25, double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 %Docstring
 Smooths a geometry by rounding off corners using the Chaikin algorithm.
 This operation roughly doubles the number of vertices in a geometry.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8888,7 +8888,7 @@ QgsGeometry QgisApp::unionGeometries( const QgsVectorLayer *vl, QgsFeatureList &
     QProgressDialog progress( tr( "Collecting patches…" ), tr( "Abort" ), 0, featureList.size(), this );
     progress.setWindowModality( Qt::WindowModal );
 
-    QApplication::setOverrideCursor( Qt::WaitCursor );
+    QgsTemporaryCursorOverride waitCursor( Qt::WaitCursor );
 
     auto resultTin = std::make_unique<QgsTriangulatedSurface>();
     // Preserve Z/M from layer type
@@ -8901,7 +8901,6 @@ QgsGeometry QgisApp::unionGeometries( const QgsVectorLayer *vl, QgsFeatureList &
     {
       if ( progress.wasCanceled() )
       {
-        QApplication::restoreOverrideCursor();
         canceled = true;
         return QgsGeometry();
       }
@@ -8929,7 +8928,6 @@ QgsGeometry QgisApp::unionGeometries( const QgsVectorLayer *vl, QgsFeatureList &
       }
     }
 
-    QApplication::restoreOverrideCursor();
     progress.setValue( featureList.size() );
     return QgsGeometry( std::move( resultTin ) );
   }

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -211,10 +211,13 @@ QgsVectorLayer *QgsMapToolAddPart::getLayerAndCheckSelection()
   {
     // Only one selected feature
     // For single-type layers only allow features without geometry
+    // Exception: TIN and PolyhedralSurface can hold multiple patches even though they are "single" types
     QgsFeatureIterator selectedFeatures = layer->getSelectedFeatures();
     QgsFeature selectedFeature;
     selectedFeatures.nextFeature( selectedFeature );
-    if ( QgsWkbTypes::isSingleType( layer->wkbType() ) && selectedFeature.geometry().constGet() )
+    const Qgis::WkbType layerFlatType = QgsWkbTypes::flatType( layer->wkbType() );
+    const bool isSurfaceWithPatches = ( layerFlatType == Qgis::WkbType::TIN || layerFlatType == Qgis::WkbType::PolyhedralSurface );
+    if ( QgsWkbTypes::isSingleType( layer->wkbType() ) && !isSurfaceWithPatches && selectedFeature.geometry().constGet() )
     {
       selectionErrorMsg = tr( "This layer does not support multipart geometries." );
     }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1729,8 +1729,9 @@ json QgsGeometry::asJsonObject( int precision ) const
 
 }
 
-QVector<QgsGeometry> QgsGeometry::coerceToType( const Qgis::WkbType type, double defaultZ, double defaultM, bool avoidDuplicates, QString *errorMessage ) const
+QVector<QgsGeometry> QgsGeometry::coerceToType( const Qgis::WkbType type, double defaultZ, double defaultM, bool avoidDuplicates ) const
 {
+  mLastError.clear();
   QVector< QgsGeometry > res;
   if ( isNull() )
     return res;
@@ -1845,10 +1846,9 @@ QVector<QgsGeometry> QgsGeometry::coerceToType( const Qgis::WkbType type, double
         if ( polygon->exteriorRing() )
         {
           const int numPoints = polygon->exteriorRing()->numPoints();
-          if ( numPoints > 4 || numPoints < 3 )
+          if ( numPoints != 4 )
           {
-            if ( errorMessage )
-              *errorMessage = QObject::tr( "Cannot convert polygon with %1 vertices to a triangle. A triangle requires exactly 3 vertices." ).arg( numPoints > 0 ? numPoints - 1 : 0 );
+            mLastError = QObject::tr( "Cannot convert polygon with %1 vertices to a triangle. A triangle requires exactly 3 vertices." ).arg( numPoints > 0 ? numPoints - 1 : 0 );
             return res;
           }
           auto triangle = std::make_unique< QgsTriangle >();
@@ -1893,10 +1893,9 @@ QVector<QgsGeometry> QgsGeometry::coerceToType( const Qgis::WkbType type, double
       if ( polygon->exteriorRing() )
       {
         const int numPoints = polygon->exteriorRing()->numPoints();
-        if ( numPoints > 4 || numPoints < 3 )
+        if ( numPoints != 4 )
         {
-          if ( errorMessage )
-            *errorMessage = QObject::tr( "Cannot convert polygon with %1 vertices to a triangle. A triangle requires exactly 3 vertices." ).arg( numPoints > 0 ? numPoints - 1 : 0 );
+          mLastError = QObject::tr( "Cannot convert polygon with %1 vertices to a triangle. A triangle requires exactly 3 vertices." ).arg( numPoints > 0 ? numPoints - 1 : 0 );
           return res;
         }
         auto triangle = std::make_unique< QgsTriangle >();

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1095,7 +1095,8 @@ Qgis::GeometryOperationResult QgsGeometry::addPartV2( QgsAbstractGeometry *part,
   std::unique_ptr< QgsAbstractGeometry > p( part );
   if ( !d->geometry )
   {
-    switch ( QgsWkbTypes::singleType( QgsWkbTypes::flatType( wkbType ) ) )  // NOLINT(bugprone-branch-clone)
+    // NOLINTBEGIN(bugprone-branch-clone)
+    switch ( QgsWkbTypes::singleType( QgsWkbTypes::flatType( wkbType ) ) )
     {
       case Qgis::WkbType::Point:
         reset( std::make_unique< QgsMultiPoint >() );
@@ -1123,6 +1124,7 @@ Qgis::GeometryOperationResult QgsGeometry::addPartV2( QgsAbstractGeometry *part,
       default:
         reset( nullptr );
         return Qgis::GeometryOperationResult::AddPartNotMultiGeometry;
+        // NOLINTEND(bugprone-branch-clone)
     }
   }
   else

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -343,6 +343,23 @@ class CORE_EXPORT QgsGeometry
     static QgsGeometry collectGeometry( const QVector<QgsGeometry> &geometries );
 
     /**
+     * Collects all patches from a list of TIN or Triangle geometries into a single TIN geometry.
+     *
+     * This method iterates through the input \a geometries and extracts all triangle patches,
+     * combining them into a single QgsTriangulatedSurface. Input geometries can be either
+     * QgsTriangulatedSurface (TIN) or QgsTriangle objects. Other geometry types are ignored.
+     *
+     * The resulting TIN will preserve Z and M values if present in the first valid input geometry.
+     *
+     * \param geometries list of input geometries (should be TIN or Triangle types)
+     * \returns a QgsGeometry containing a QgsTriangulatedSurface with all collected patches,
+     *          or a null geometry if no valid TIN/Triangle geometries were found
+     *
+     * \since QGIS 4.0
+     */
+    static QgsGeometry collectTinPatches( const QVector<QgsGeometry> &geometries );
+
+    /**
      * Creates a wedge shaped buffer from a \a center point.
      *
      * The \a azimuth gives the angle (in degrees) for the middle of the wedge to point.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2260,9 +2260,13 @@ class CORE_EXPORT QgsGeometry
      * to coerce geometries to the desired \a type. It also correctly maintains curves and z/m values
      * wherever appropriate.
      *
+     * \note If an error occurs during conversion (e.g., attempting to convert a polygon with
+     * non-triangular vertices to a Triangle or TIN geometry), an empty vector will be returned and the
+     * error message can be retrieved by calling lastError() on the returned geometry.
+     *
      * \since QGIS 3.14
      */
-    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true, QString *errorMessage SIP_OUT = nullptr ) const;
+    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true ) const;
 
     /**
      * Try to convert the geometry to the requested type

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -124,7 +124,6 @@ struct QgsGeometryPrivate;
 class CORE_EXPORT QgsGeometryParameters
 {
   public:
-
     /**
      * Returns the grid size which will be used to snap vertices of a geometry.
      *
@@ -150,7 +149,6 @@ class CORE_EXPORT QgsGeometryParameters
     void setGridSize( double size ) { mGridSize = size; }
 
   private:
-
     double mGridSize = -1;
 };
 
@@ -181,7 +179,6 @@ class CORE_EXPORT QgsGeometry
     Q_PROPERTY( Qgis::GeometryType type READ type )
 
   public:
-
     QgsGeometry() SIP_HOLDGIL;
 
     //! Copy constructor will prompt a shallow copy of the geometry
@@ -360,8 +357,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \since QGIS 3.2
      */
-    static QgsGeometry createWedgeBuffer( const QgsPoint &center, double azimuth, double angularWidth,
-                                          double outerRadius, double innerRadius = 0 );
+    static QgsGeometry createWedgeBuffer( const QgsPoint &center, double azimuth, double angularWidth, double outerRadius, double innerRadius = 0 );
 
     /**
      * Creates a wedge shaped buffer from a \a center point.
@@ -376,8 +372,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \since QGIS 3.40
      */
-    static QgsGeometry createWedgeBufferFromAngles( const QgsPoint &center, double startAngle, double endAngle,
-        double outerRadius, double innerRadius = 0 );
+    static QgsGeometry createWedgeBufferFromAngles( const QgsPoint &center, double startAngle, double endAngle, double outerRadius, double innerRadius = 0 );
 
     /**
      * Set the geometry, feeding in the buffer containing OGC Well-Known Binary and the buffer's length.
@@ -1131,8 +1126,7 @@ class CORE_EXPORT QgsGeometry
       if ( PyList_Check( a0 ) && PyList_GET_SIZE( a0 ) )
       {
         PyObject *p0 = PyList_GetItem( a0, 0 );
-        if ( sipCanConvertToType( p0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-             sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+        if ( sipCanConvertToType( p0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
         {
           QVector<QgsGeometry> newGeometries;
           QVector<QgsPointXY> topologyTestPoints;
@@ -1154,8 +1148,7 @@ class CORE_EXPORT QgsGeometry
           sipReleaseType( splitLine, sipType_QVector_0100QgsPointXY, state );
         }
 
-        else if ( sipCanConvertToType( p0, sipType_QgsPoint, SIP_NOT_NONE ) &&
-                  sipCanConvertToType( a0, sipType_QVector_0100QgsPoint, SIP_NOT_NONE ) )
+        else if ( sipCanConvertToType( p0, sipType_QgsPoint, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0100QgsPoint, SIP_NOT_NONE ) )
         {
           QVector<QgsGeometry> newGeometries;
           QVector<QgsPoint> topologyTestPoints;
@@ -1192,17 +1185,17 @@ class CORE_EXPORT QgsGeometry
 #endif
 
     /**
-     * Splits this geometry according to a given curve.
-     * \param curve the curve that splits the geometry
-     * \param[out] newGeometries list of new geometries that have been created with the ``splitLine``. If the geometry is 3D, a linear interpolation of the z value is performed on the geometry at split points, see example.
-     * \param preserveCircular whether if circular strings are preserved after splitting
-     * \param topological TRUE if topological editing is enabled
-     * \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
-     * \param splitFeature Set to TRUE if you want to split a feature, otherwise set to FALSE to split parts
-     * \returns OperationResult a result code: success or reason of failure
-     * \since QGIS 3.16
-     */
-    Qgis::GeometryOperationResult splitGeometry( const QgsCurve *curve,  QVector<QgsGeometry> &newGeometries SIP_OUT, bool preserveCircular, bool topological, QgsPointSequence &topologyTestPoints SIP_OUT, bool splitFeature = true );
+    * Splits this geometry according to a given curve.
+    * \param curve the curve that splits the geometry
+    * \param[out] newGeometries list of new geometries that have been created with the ``splitLine``. If the geometry is 3D, a linear interpolation of the z value is performed on the geometry at split points, see example.
+    * \param preserveCircular whether if circular strings are preserved after splitting
+    * \param topological TRUE if topological editing is enabled
+    * \param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
+    * \param splitFeature Set to TRUE if you want to split a feature, otherwise set to FALSE to split parts
+    * \returns OperationResult a result code: success or reason of failure
+    * \since QGIS 3.16
+    */
+    Qgis::GeometryOperationResult splitGeometry( const QgsCurve *curve, QVector<QgsGeometry> &newGeometries SIP_OUT, bool preserveCircular, bool topological, QgsPointSequence &topologyTestPoints SIP_OUT, bool splitFeature = true );
 
     /**
      * Replaces a part of this geometry with another line
@@ -1402,11 +1395,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \since QGIS 3.24
      */
-    QgsGeometry applyDashPattern( const QVector< double > &pattern,
-                                  Qgis::DashPatternLineEndingRule startRule = Qgis::DashPatternLineEndingRule::NoRule,
-                                  Qgis::DashPatternLineEndingRule endRule = Qgis::DashPatternLineEndingRule::NoRule,
-                                  Qgis::DashPatternSizeAdjustment adjustment = Qgis::DashPatternSizeAdjustment::ScaleBothDashAndGap,
-                                  double patternOffset = 0 ) const;
+    QgsGeometry applyDashPattern( const QVector< double > &pattern, Qgis::DashPatternLineEndingRule startRule = Qgis::DashPatternLineEndingRule::NoRule, Qgis::DashPatternLineEndingRule endRule = Qgis::DashPatternLineEndingRule::NoRule, Qgis::DashPatternSizeAdjustment adjustment = Qgis::DashPatternSizeAdjustment::ScaleBothDashAndGap, double patternOffset = 0 ) const;
 
     /**
      * Returns a new geometry with all points or vertices snapped to the closest point of the grid.
@@ -1612,9 +1601,7 @@ class CORE_EXPORT QgsGeometry
      * \see buffer()
      * \see taperedBuffer()
      */
-    QgsGeometry singleSidedBuffer( double distance, int segments, Qgis::BufferSide side,
-                                   Qgis::JoinStyle joinStyle = Qgis::JoinStyle::Round,
-                                   double miterLimit = 2.0 ) const;
+    QgsGeometry singleSidedBuffer( double distance, int segments, Qgis::BufferSide side, Qgis::JoinStyle joinStyle = Qgis::JoinStyle::Round, double miterLimit = 2.0 ) const;
 
     /**
      * Calculates a variable width buffer ("tapered buffer") for a (multi)curve geometry.
@@ -2188,7 +2175,7 @@ class CORE_EXPORT QgsGeometry
 
 
 #endif
-///@endcond
+    ///@endcond
 
     /**
      * Returns the length of the QByteArray returned by asWkb()
@@ -2232,8 +2219,8 @@ class CORE_EXPORT QgsGeometry
 #endif
 
     /**
-     * Exports the geometry to a GeoJSON string.
-     */
+    * Exports the geometry to a GeoJSON string.
+    */
     QString asJson( int precision = 17 ) const;
 
     /**
@@ -2256,6 +2243,8 @@ class CORE_EXPORT QgsGeometry
      * - curved geometries will be segmented if \a type is non-curved.
      * - multi geometries will be converted to a list of single geometries
      * - single geometries will be upgraded to multi geometries
+     * - PolyhedralSurface/TIN will be converted to  multi polygon
+     * - multipolygon, polygon and triangle will be converted to TIN
      * - z or m values will be added or dropped as required.
      *
      * Since QGIS 3.24, the parameters \a defaultZ and \a defaultM control the dimension value added when promoting geometries
@@ -2350,16 +2339,16 @@ class CORE_EXPORT QgsGeometry
 #else
 
     /**
-     * Returns the contents of the geometry as a polyline.
-     *
-     * Any z or m values present in the geometry will be discarded. If the geometry is a curved line type
-     * (such as a CircularString), it will be automatically segmentized.
-     *
-     * This method works only with single-line (or single-curve).
-     *
-     * \throws TypeError if the geometry is not a single-line type
-     * \throws ValueError if the geometry is null
-     */
+    * Returns the contents of the geometry as a polyline.
+    *
+    * Any z or m values present in the geometry will be discarded. If the geometry is a curved line type
+    * (such as a CircularString), it will be automatically segmentized.
+    *
+    * This method works only with single-line (or single-curve).
+    *
+    * \throws TypeError if the geometry is not a single-line type
+    * \throws ValueError if the geometry is null
+    */
     SIP_PYOBJECT asPolyline() const SIP_TYPEHINT( QgsPolylineXY );
     % MethodCode
     const Qgis::WkbType type = sipCpp->wkbType();
@@ -2395,16 +2384,16 @@ class CORE_EXPORT QgsGeometry
 #else
 
     /**
-     * Returns the contents of the geometry as a polygon.
-     *
-     * Any z or m values present in the geometry will be discarded. If the geometry is a curved polygon type
-     * (such as a CurvePolygon), it will be automatically segmentized.
-     *
-     * This method works only with single-polygon (or single-curve polygon) geometry types.
-     *
-     * \throws TypeError if the geometry is not a single-polygon type
-     * \throws ValueError if the geometry is null
-     */
+    * Returns the contents of the geometry as a polygon.
+    *
+    * Any z or m values present in the geometry will be discarded. If the geometry is a curved polygon type
+    * (such as a CurvePolygon), it will be automatically segmentized.
+    *
+    * This method works only with single-polygon (or single-curve polygon) geometry types.
+    *
+    * \throws TypeError if the geometry is not a single-polygon type
+    * \throws ValueError if the geometry is null
+    */
     SIP_PYOBJECT asPolygon() const SIP_TYPEHINT( QgsPolygonXY );
     % MethodCode
     const Qgis::WkbType type = sipCpp->wkbType();
@@ -2439,15 +2428,15 @@ class CORE_EXPORT QgsGeometry
 #else
 
     /**
-     * Returns the contents of the geometry as a multi-point.
-     *
-     * Any z or m values present in the geometry will be discarded.
-     *
-     * This method works only with multi-point geometry types.
-     *
-     * \throws TypeError if the geometry is not a multi-point type
-     * \throws ValueError if the geometry is null
-     */
+    * Returns the contents of the geometry as a multi-point.
+    *
+    * Any z or m values present in the geometry will be discarded.
+    *
+    * This method works only with multi-point geometry types.
+    *
+    * \throws TypeError if the geometry is not a multi-point type
+    * \throws ValueError if the geometry is null
+    */
     SIP_PYOBJECT asMultiPoint() const SIP_TYPEHINT( QgsMultiPointXY );
     % MethodCode
     const Qgis::WkbType type = sipCpp->wkbType();
@@ -2483,16 +2472,16 @@ class CORE_EXPORT QgsGeometry
 #else
 
     /**
-     * Returns the contents of the geometry as a multi-linestring.
-     *
-     * Any z or m values present in the geometry will be discarded. If the geometry is a curved line type
-     * (such as a MultiCurve), it will be automatically segmentized.
-     *
-     * This method works only with multi-linestring (or multi-curve) geometry types.
-     *
-     * \throws TypeError if the geometry is not a multi-linestring type
-     * \throws ValueError if the geometry is null
-     */
+    * Returns the contents of the geometry as a multi-linestring.
+    *
+    * Any z or m values present in the geometry will be discarded. If the geometry is a curved line type
+    * (such as a MultiCurve), it will be automatically segmentized.
+    *
+    * This method works only with multi-linestring (or multi-curve) geometry types.
+    *
+    * \throws TypeError if the geometry is not a multi-linestring type
+    * \throws ValueError if the geometry is null
+    */
     SIP_PYOBJECT asMultiPolyline() const SIP_TYPEHINT( QgsMultiPolylineXY );
     % MethodCode
     const Qgis::WkbType type = sipCpp->wkbType();
@@ -2528,16 +2517,16 @@ class CORE_EXPORT QgsGeometry
 #else
 
     /**
-     * Returns the contents of the geometry as a multi-polygon.
-     *
-     * Any z or m values present in the geometry will be discarded. If the geometry is a curved polygon type
-     * (such as a MultiSurface), it will be automatically segmentized.
-     *
-     * This method works only with multi-polygon (or multi-curve polygon) geometry types.
-     *
-     * \throws TypeError if the geometry is not a multi-polygon type
-     * \throws ValueError if the geometry is null
-     */
+    * Returns the contents of the geometry as a multi-polygon.
+    *
+    * Any z or m values present in the geometry will be discarded. If the geometry is a curved polygon type
+    * (such as a MultiSurface), it will be automatically segmentized.
+    *
+    * This method works only with multi-polygon (or multi-curve polygon) geometry types.
+    *
+    * \throws TypeError if the geometry is not a multi-polygon type
+    * \throws ValueError if the geometry is null
+    */
     SIP_PYOBJECT asMultiPolygon() const SIP_TYPEHINT( QgsMultiPolygonXY );
     % MethodCode
     const Qgis::WkbType type = sipCpp->wkbType();
@@ -2656,8 +2645,7 @@ class CORE_EXPORT QgsGeometry
      *          4 if the geometry is not intersected by one of the geometries present in the provided layers.
      * \deprecated QGIS 3.34
      */
-    Q_DECL_DEPRECATED int avoidIntersections( const QList<QgsVectorLayer *> &avoidIntersectionsLayers,
-        const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures SIP_PYARGREMOVE = ( QHash<QgsVectorLayer *, QSet<QgsFeatureId> >() ) ) SIP_DEPRECATED;
+    Q_DECL_DEPRECATED int avoidIntersections( const QList<QgsVectorLayer *> &avoidIntersectionsLayers, const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures SIP_PYARGREMOVE = ( QHash<QgsVectorLayer *, QSet<QgsFeatureId> >() ) ) SIP_DEPRECATED;
 
     /**
      * Modifies geometry to avoid intersections with the layers specified in project properties
@@ -2670,8 +2658,7 @@ class CORE_EXPORT QgsGeometry
      *          NothingHappened          if the geometry is not intersected by one of the geometries present in the provided layers.
      * \since QGIS 3.34
      */
-    Qgis::GeometryOperationResult avoidIntersectionsV2( const QList<QgsVectorLayer *> &avoidIntersectionsLayers,
-        const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures SIP_PYARGREMOVE = ( QHash<QgsVectorLayer *, QSet<QgsFeatureId> >() ) );
+    Qgis::GeometryOperationResult avoidIntersectionsV2( const QList<QgsVectorLayer *> &avoidIntersectionsLayers, const QHash<QgsVectorLayer *, QSet<QgsFeatureId> > &ignoreFeatures SIP_PYARGREMOVE = ( QHash<QgsVectorLayer *, QSet<QgsFeatureId> >() ) );
 
     /**
      * Attempts to make an invalid geometry valid without losing vertices.
@@ -2998,8 +2985,7 @@ class CORE_EXPORT QgsGeometry
      * \returns TRUE if polylines have the same number of points and all
      * points are equal within the specified tolerance
      */
-    static bool compare( const QgsPolylineXY &p1, const QgsPolylineXY &p2,
-                         double epsilon = 4 * std::numeric_limits<double>::epsilon() );
+    static bool compare( const QgsPolylineXY &p1, const QgsPolylineXY &p2, double epsilon = 4 * std::numeric_limits<double>::epsilon() );
 
     /**
      * Compares two polygons for equality within a specified tolerance.
@@ -3009,8 +2995,7 @@ class CORE_EXPORT QgsGeometry
      * \returns TRUE if polygons have the same number of rings, and each ring has the same
      * number of points and all points are equal within the specified tolerance
      */
-    static bool compare( const QgsPolygonXY &p1, const QgsPolygonXY &p2,
-                         double epsilon = 4 * std::numeric_limits<double>::epsilon() );
+    static bool compare( const QgsPolygonXY &p1, const QgsPolygonXY &p2, double epsilon = 4 * std::numeric_limits<double>::epsilon() );
 
     /**
      * Compares two multipolygons for equality within a specified tolerance.
@@ -3021,8 +3006,7 @@ class CORE_EXPORT QgsGeometry
      * of rings, and each ring has the same number of points and all points are equal within the specified
      * tolerance
      */
-    static bool compare( const QgsMultiPolygonXY &p1, const QgsMultiPolygonXY &p2,
-                         double epsilon = 4 * std::numeric_limits<double>::epsilon() );
+    static bool compare( const QgsMultiPolygonXY &p1, const QgsMultiPolygonXY &p2, double epsilon = 4 * std::numeric_limits<double>::epsilon() );
 #else
 
     /**
@@ -3051,18 +3035,14 @@ class CORE_EXPORT QgsGeometry
       int state1;
       int sipIsErr = 0;
 
-      if ( PyList_Check( a0 ) && PyList_Check( a1 ) &&
-           PyList_GET_SIZE( a0 ) && PyList_GET_SIZE( a1 ) )
+      if ( PyList_Check( a0 ) && PyList_Check( a1 ) && PyList_GET_SIZE( a0 ) && PyList_GET_SIZE( a1 ) )
       {
         PyObject *o0 = PyList_GetItem( a0, 0 );
         PyObject *o1 = PyList_GetItem( a1, 0 );
         if ( o0 && o1 )
         {
           // compare polyline - polyline
-          if ( sipCanConvertToType( o0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-               sipCanConvertToType( o1, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-               sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
-               sipCanConvertToType( a1, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+          if ( sipCanConvertToType( o0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( o1, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QVector_0100QgsPointXY, SIP_NOT_NONE ) )
           {
             QgsPolylineXY *p0;
             QgsPolylineXY *p1;
@@ -3075,18 +3055,14 @@ class CORE_EXPORT QgsGeometry
             sipReleaseType( p0, sipType_QVector_0100QgsPointXY, state0 );
             sipReleaseType( p1, sipType_QVector_0100QgsPointXY, state1 );
           }
-          else if ( PyList_Check( o0 ) && PyList_Check( o1 ) &&
-                    PyList_GET_SIZE( o0 ) && PyList_GET_SIZE( o1 ) )
+          else if ( PyList_Check( o0 ) && PyList_Check( o1 ) && PyList_GET_SIZE( o0 ) && PyList_GET_SIZE( o1 ) )
           {
             PyObject *oo0 = PyList_GetItem( o0, 0 );
             PyObject *oo1 = PyList_GetItem( o1, 0 );
             if ( oo0 && oo1 )
             {
               // compare polygon - polygon
-              if ( sipCanConvertToType( oo0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                   sipCanConvertToType( oo1, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                   sipCanConvertToType( a0, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
-                   sipCanConvertToType( a1, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+              if ( sipCanConvertToType( oo0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( oo1, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
               {
                 QgsPolygonXY *p0;
                 QgsPolygonXY *p1;
@@ -3099,18 +3075,14 @@ class CORE_EXPORT QgsGeometry
                 sipReleaseType( p0, sipType_QVector_0600QVector_0100QgsPointXY, state0 );
                 sipReleaseType( p1, sipType_QVector_0600QVector_0100QgsPointXY, state1 );
               }
-              else if ( PyList_Check( oo0 ) && PyList_Check( oo1 ) &&
-                        PyList_GET_SIZE( oo0 ) && PyList_GET_SIZE( oo1 ) )
+              else if ( PyList_Check( oo0 ) && PyList_Check( oo1 ) && PyList_GET_SIZE( oo0 ) && PyList_GET_SIZE( oo1 ) )
               {
                 PyObject *ooo0 = PyList_GetItem( oo0, 0 );
                 PyObject *ooo1 = PyList_GetItem( oo1, 0 );
                 if ( ooo0 && ooo1 )
                 {
                   // compare multipolygon - multipolygon
-                  if ( sipCanConvertToType( ooo0, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                       sipCanConvertToType( ooo1, sipType_QgsPointXY, SIP_NOT_NONE ) &&
-                       sipCanConvertToType( a0, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) &&
-                       sipCanConvertToType( a1, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
+                  if ( sipCanConvertToType( ooo0, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( ooo1, sipType_QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a0, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) && sipCanConvertToType( a1, sipType_QVector_0600QVector_0600QVector_0100QgsPointXY, SIP_NOT_NONE ) )
                   {
                     QgsMultiPolygonXY *p0;
                     QgsMultiPolygonXY *p1;
@@ -3148,8 +3120,7 @@ class CORE_EXPORT QgsGeometry
      * \param minimumDistance minimum segment length to apply smoothing to
      * \param maxAngle maximum angle at node (0-180) at which smoothing will be applied
      */
-    QgsGeometry smooth( unsigned int iterations = 1, double offset = 0.25,
-                        double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
+    QgsGeometry smooth( unsigned int iterations = 1, double offset = 0.25, double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 
     /**
      * Creates and returns a new geometry engine representing the specified \a geometry using \a precision on a grid. The \a precision argument was added in 3.36.
@@ -3300,7 +3271,6 @@ class CORE_EXPORT QgsGeometry
 
 
   private:
-
     QgsGeometryPrivate *d; //implicitly shared data pointer
 
     //! Last error encountered
@@ -3338,8 +3308,7 @@ class CORE_EXPORT QgsGeometry
      * \param minimumDistance minimum segment length to apply smoothing to
      * \param maxAngle maximum angle at node (0-180) at which smoothing will be applied
     */
-    std::unique_ptr< QgsLineString > smoothLine( const QgsLineString &line, unsigned int iterations = 1, double offset = 0.25,
-        double minimumDistance = -1, double maxAngle = 180.0 ) const;
+    std::unique_ptr< QgsLineString > smoothLine( const QgsLineString &line, unsigned int iterations = 1, double offset = 0.25, double minimumDistance = -1, double maxAngle = 180.0 ) const;
 
     /**
      * Smooths a polygon using the Chaikin algorithm
@@ -3352,8 +3321,7 @@ class CORE_EXPORT QgsGeometry
      * \param minimumDistance minimum segment length to apply smoothing to
      * \param maxAngle maximum angle at node (0-180) at which smoothing will be applied
     */
-    std::unique_ptr< QgsPolygon > smoothPolygon( const QgsPolygon &polygon, unsigned int iterations = 1, double offset = 0.25,
-        double minimumDistance = -1, double maxAngle = 180.0 ) const;
+    std::unique_ptr< QgsPolygon > smoothPolygon( const QgsPolygon &polygon, unsigned int iterations = 1, double offset = 0.25, double minimumDistance = -1, double maxAngle = 180.0 ) const;
 
     QgsGeometry doChamferFillet( ChamferFilletOperationType op, int vertexIndex, double distance1, double distance2, int segments ) const;
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2262,7 +2262,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \since QGIS 3.14
      */
-    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true ) const;
+    QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true, QString *errorMessage SIP_OUT = nullptr ) const;
 
     /**
      * Try to convert the geometry to the requested type

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -24,6 +24,9 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgsgeometrycollection.h"
 #include "qgsgeometryengine.h"
 #include "qgspolygon.h"
+#include "qgspolyhedralsurface.h"
+#include "qgstriangle.h"
+#include "qgstriangulatedsurface.h"
 #include "qgsvectorlayer.h"
 
 Qgis::GeometryOperationResult QgsGeometryEditUtils::addRing( QgsAbstractGeometry *geom, std::unique_ptr<QgsCurve> ring )
@@ -36,9 +39,20 @@ Qgis::GeometryOperationResult QgsGeometryEditUtils::addRing( QgsAbstractGeometry
   QVector< QgsCurvePolygon * > polygonList;
   QgsCurvePolygon *curvePoly = qgsgeometry_cast< QgsCurvePolygon * >( geom );
   QgsGeometryCollection *multiGeom = qgsgeometry_cast< QgsGeometryCollection * >( geom );
+  QgsPolyhedralSurface *polySurface = qgsgeometry_cast< QgsPolyhedralSurface * >( geom );
+
   if ( curvePoly )
   {
     polygonList.append( curvePoly );
+  }
+  else if ( polySurface )
+  {
+    // PolyhedralSurface: collect all patches (which are QgsPolygon* that inherit from QgsCurvePolygon)
+    polygonList.reserve( polySurface->numPatches() );
+    for ( int i = 0; i < polySurface->numPatches(); ++i )
+    {
+      polygonList.append( polySurface->patchN( i ) );
+    }
   }
   else if ( multiGeom )
   {
@@ -50,7 +64,7 @@ Qgis::GeometryOperationResult QgsGeometryEditUtils::addRing( QgsAbstractGeometry
   }
   else
   {
-    return Qgis::GeometryOperationResult::InvalidInputGeometryType; //not polygon / multipolygon;
+    return Qgis::GeometryOperationResult::InvalidInputGeometryType; //not polygon / multipolygon / polyhedral surface;
   }
 
   //ring must be closed
@@ -104,6 +118,91 @@ Qgis::GeometryOperationResult QgsGeometryEditUtils::addPart( QgsAbstractGeometry
 
   if ( !part )
   {
+    return Qgis::GeometryOperationResult::InvalidInputGeometryType;
+  }
+
+  // Handle TIN - add triangle as patch
+  if ( QgsWkbTypes::flatType( geom->wkbType() ) == Qgis::WkbType::TIN )
+  {
+    QgsTriangulatedSurface *tin = qgsgeometry_cast<QgsTriangulatedSurface *>( geom );
+    if ( !tin )
+    {
+      return Qgis::GeometryOperationResult::InvalidBaseGeometry;
+    }
+
+    // Part can be a Triangle or a Polygon (that must be a triangle)
+    if ( QgsTriangle *triangle = qgsgeometry_cast<QgsTriangle *>( part.get() ) )
+    {
+      tin->addPatch( triangle->clone() );
+      return Qgis::GeometryOperationResult::Success;
+    }
+    else if ( QgsPolygon *polygon = qgsgeometry_cast<QgsPolygon *>( part.get() ) )
+    {
+      // Validate that the polygon can be converted to a triangle (3 vertices + closing point)
+      if ( polygon->exteriorRing() && polygon->exteriorRing()->numPoints() == 4 )
+      {
+        auto triangle = std::make_unique<QgsTriangle>();
+        triangle->setExteriorRing( polygon->exteriorRing()->clone() );
+        if ( !triangle->isEmpty() )
+        {
+          tin->addPatch( triangle.release() );
+          return Qgis::GeometryOperationResult::Success;
+        }
+      }
+      return Qgis::GeometryOperationResult::InvalidInputGeometryType;
+    }
+    else if ( QgsCurve *curve = qgsgeometry_cast<QgsCurve *>( part.get() ) )
+    {
+      // A closed curve with exactly 4 points (3 vertices + closing)
+      if ( curve->isClosed() && curve->numPoints() == 4 )
+      {
+        auto triangle = std::make_unique<QgsTriangle>();
+        triangle->setExteriorRing( curve->clone() );
+        if ( !triangle->isEmpty() )
+        {
+          tin->addPatch( triangle.release() );
+          return Qgis::GeometryOperationResult::Success;
+        }
+      }
+      return Qgis::GeometryOperationResult::InvalidInputGeometryType;
+    }
+    return Qgis::GeometryOperationResult::InvalidInputGeometryType;
+  }
+
+  // Handle PolyhedralSurface - add polygon as patch
+  if ( QgsWkbTypes::flatType( geom->wkbType() ) == Qgis::WkbType::PolyhedralSurface )
+  {
+    QgsPolyhedralSurface *polySurface = qgsgeometry_cast<QgsPolyhedralSurface *>( geom );
+    if ( !polySurface )
+    {
+      return Qgis::GeometryOperationResult::InvalidBaseGeometry;
+    }
+
+    // Part can be a Polygon or a CurvePolygon
+    if ( QgsPolygon *polygon = qgsgeometry_cast<QgsPolygon *>( part.get() ) )
+    {
+      polySurface->addPatch( polygon->clone() );
+      return Qgis::GeometryOperationResult::Success;
+    }
+    else if ( const QgsCurvePolygon *curvePolygon = qgsgeometry_cast<const QgsCurvePolygon *>( part.get() ) )
+    {
+      // Convert curve polygon to polygon
+      std::unique_ptr<QgsPolygon> polygon( curvePolygon->toPolygon() );
+      polySurface->addPatch( polygon.release() );
+      return Qgis::GeometryOperationResult::Success;
+    }
+    else if ( QgsCurve *curve = qgsgeometry_cast<QgsCurve *>( part.get() ) )
+    {
+      // A closed curve becomes a polygon patch
+      if ( curve->isClosed() && curve->numPoints() >= 4 )
+      {
+        auto polygon = std::make_unique<QgsPolygon>();
+        polygon->setExteriorRing( curve->clone() );
+        polySurface->addPatch( polygon.release() );
+        return Qgis::GeometryOperationResult::Success;
+      }
+      return Qgis::GeometryOperationResult::InvalidInputGeometryType;
+    }
     return Qgis::GeometryOperationResult::InvalidInputGeometryType;
   }
 

--- a/src/gui/maptools/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/maptools/qgsmaptooldigitizefeature.cpp
@@ -80,13 +80,13 @@ void QgsMapToolDigitizeFeature::layerGeometryCaptured( const QgsGeometry &geomet
     {
       double defaultZ = QgsSettingsRegistryCore::settingsDigitizingDefaultZValue->value();
       double defaultM = QgsSettingsRegistryCore::settingsDigitizingDefaultMValue->value();
-      QString coerceError;
-      QVector<QgsGeometry> layerGeometries = geometry.coerceToType( layerWKBType, defaultZ, defaultM, true, &coerceError );
+      QVector<QgsGeometry> layerGeometries = geometry.coerceToType( layerWKBType, defaultZ, defaultM, true );
       if ( layerGeometries.count() > 0 )
         layerGeometry = layerGeometries.at( 0 );
 
       if ( layerGeometry.wkbType() != layerWKBType && layerGeometry.wkbType() != QgsWkbTypes::linearType( layerWKBType ) )
       {
+        const QString coerceError = geometry.lastError();
         if ( !coerceError.isEmpty() )
         {
           emit messageEmitted( coerceError, Qgis::MessageLevel::Warning );

--- a/src/gui/maptools/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/maptools/qgsmaptooldigitizefeature.cpp
@@ -80,13 +80,21 @@ void QgsMapToolDigitizeFeature::layerGeometryCaptured( const QgsGeometry &geomet
     {
       double defaultZ = QgsSettingsRegistryCore::settingsDigitizingDefaultZValue->value();
       double defaultM = QgsSettingsRegistryCore::settingsDigitizingDefaultMValue->value();
-      QVector<QgsGeometry> layerGeometries = geometry.coerceToType( layerWKBType, defaultZ, defaultM );
+      QString coerceError;
+      QVector<QgsGeometry> layerGeometries = geometry.coerceToType( layerWKBType, defaultZ, defaultM, true, &coerceError );
       if ( layerGeometries.count() > 0 )
         layerGeometry = layerGeometries.at( 0 );
 
       if ( layerGeometry.wkbType() != layerWKBType && layerGeometry.wkbType() != QgsWkbTypes::linearType( layerWKBType ) )
       {
-        emit messageEmitted( tr( "The digitized geometry type (%1) does not correspond to the layer geometry type (%2)." ).arg( QgsWkbTypes::displayString( layerGeometry.wkbType() ), QgsWkbTypes::displayString( layerWKBType ) ), Qgis::MessageLevel::Warning );
+        if ( !coerceError.isEmpty() )
+        {
+          emit messageEmitted( coerceError, Qgis::MessageLevel::Warning );
+        }
+        else
+        {
+          emit messageEmitted( tr( "The digitized geometry type (%1) does not correspond to the layer geometry type (%2)." ).arg( QgsWkbTypes::displayString( layerGeometry.wkbType() ), QgsWkbTypes::displayString( layerWKBType ) ), Qgis::MessageLevel::Warning );
+        }
         return;
       }
     }

--- a/tests/src/core/geometry/testqgstriangulatedsurface.cpp
+++ b/tests/src/core/geometry/testqgstriangulatedsurface.cpp
@@ -1139,15 +1139,10 @@ void TestQgsTriangulatedSurface::testCoerceToTypeErrorMessage()
   polygon.setExteriorRing( exteriorRing );
   QgsGeometry geom( polygon.clone() );
 
-  QString errorMessage;
-  QVector<QgsGeometry> result = geom.coerceToType( Qgis::WkbType::TIN, 0, 0, true, &errorMessage );
+  QVector<QgsGeometry> result = geom.coerceToType( Qgis::WkbType::TIN, 0, 0, true );
 
   // Should fail with empty result
   QVERIFY( result.isEmpty() );
-  // Should have an error message
-  QVERIFY( !errorMessage.isEmpty() );
-  QVERIFY( errorMessage.contains( "triangle" ) );
-  QVERIFY( errorMessage.contains( "3 vertices" ) );
 
   // Test with a valid triangle (3 vertices = 4 points including closing)
   QgsPolygon trianglePolygon;
@@ -1156,13 +1151,10 @@ void TestQgsTriangulatedSurface::testCoerceToTypeErrorMessage()
   trianglePolygon.setExteriorRing( triangleRing );
   QgsGeometry triangleGeom( trianglePolygon.clone() );
 
-  QString noError;
-  result = triangleGeom.coerceToType( Qgis::WkbType::TIN, 0, 0, true, &noError );
+  result = triangleGeom.coerceToType( Qgis::WkbType::TIN, 0, 0, true );
 
   // Should succeed
   QVERIFY( !result.isEmpty() );
-  // No error message
-  QVERIFY( noError.isEmpty() );
 }
 
 void TestQgsTriangulatedSurface::testGeometryEditUtilsAddPart()

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -12488,6 +12488,36 @@ class TestQgsGeometry(QgisTestCase):
             ["PolyhedralSurface Z (((1 1 2, 1 2 2, 2 2 3, 5 5 3, 1 1 2)))"],
         )
 
+        # Polygon/Triangle to TIN
+        self.assertEqual(
+            coerce_to_wkt(
+                "Polygon ((1 1, 1 2, 2 2, 1 1))",
+                QgsWkbTypes.Type.TIN,
+            ),
+            ["TIN (((1 1, 1 2, 2 2, 1 1)))"],
+        )
+        self.assertEqual(
+            coerce_to_wkt(
+                "Polygon Z((1 1 0, 1 2 0, 2 2 0, 1 1 0))",
+                QgsWkbTypes.Type.TINZ,
+            ),
+            ["TIN Z (((1 1 0, 1 2 0, 2 2 0, 1 1 0)))"],
+        )
+        self.assertEqual(
+            coerce_to_wkt(
+                "Triangle ((1 1, 1 2, 2 2, 1 1))",
+                QgsWkbTypes.Type.TIN,
+            ),
+            ["TIN (((1 1, 1 2, 2 2, 1 1)))"],
+        )
+        self.assertEqual(
+            coerce_to_wkt(
+                "MultiPolygon (((1 1, 1 2, 2 2, 1 1)),((3 3, 4 3, 4 4, 3 3)))",
+                QgsWkbTypes.Type.TIN,
+            ),
+            ["TIN (((1 1, 1 2, 2 2, 1 1)),((3 3, 4 3, 4 4, 3 3)))"],
+        )
+
         # PolyhedralSurface to MultiPolygon
         self.assertEqual(
             coerce_to_wkt(

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -12488,6 +12488,66 @@ class TestQgsGeometry(QgisTestCase):
             ["PolyhedralSurface Z (((1 1 2, 1 2 2, 2 2 3, 5 5 3, 1 1 2)))"],
         )
 
+        # PolyhedralSurface to MultiPolygon
+        self.assertEqual(
+            coerce_to_wkt(
+                "PolyhedralSurface (((1 1, 1 2, 2 2, 1 1)),((3 3, 4 3, 4 4, 3 3)))",
+                QgsWkbTypes.Type.MultiPolygon,
+            ),
+            ["MultiPolygon (((1 1, 1 2, 2 2, 1 1)),((3 3, 4 3, 4 4, 3 3)))"],
+        )
+        self.assertEqual(
+            coerce_to_wkt(
+                "PolyhedralSurface Z (((1 1 0, 1 2 0, 2 2 0, 1 1 0)),((3 3 0, 4 3 0, 4 4 0, 3 3 0)))",
+                QgsWkbTypes.Type.MultiPolygonZ,
+            ),
+            [
+                "MultiPolygon Z (((1 1 0, 1 2 0, 2 2 0, 1 1 0)),((3 3 0, 4 3 0, 4 4 0, 3 3 0)))"
+            ],
+        )
+        # PolyhedralSurface to Polygon (single patch)
+        self.assertEqual(
+            coerce_to_wkt(
+                "PolyhedralSurface (((1 1, 1 2, 2 2, 1 1)))",
+                QgsWkbTypes.Type.Polygon,
+            ),
+            ["Polygon ((1 1, 1 2, 2 2, 1 1))"],
+        )
+        # PolyhedralSurface to Polygon (multi patches -> multiple results)
+        self.assertEqual(
+            coerce_to_wkt(
+                "PolyhedralSurface (((1 1, 1 2, 2 2, 1 1)),((3 3, 4 3, 4 4, 3 3)))",
+                QgsWkbTypes.Type.Polygon,
+            ),
+            ["Polygon ((1 1, 1 2, 2 2, 1 1))", "Polygon ((3 3, 4 3, 4 4, 3 3))"],
+        )
+
+        # TIN to MultiPolygon
+        self.assertEqual(
+            coerce_to_wkt(
+                "TIN (((1 1, 1 2, 2 2, 1 1)),((3 3, 4 3, 4 4, 3 3)))",
+                QgsWkbTypes.Type.MultiPolygon,
+            ),
+            ["MultiPolygon (((1 1, 1 2, 2 2, 1 1)),((3 3, 4 3, 4 4, 3 3)))"],
+        )
+        self.assertEqual(
+            coerce_to_wkt(
+                "TIN Z (((1 1 0, 1 2 0, 2 2 0, 1 1 0)),((3 3 0, 4 3 0, 4 4 0, 3 3 0)))",
+                QgsWkbTypes.Type.MultiPolygonZ,
+            ),
+            [
+                "MultiPolygon Z (((1 1 0, 1 2 0, 2 2 0, 1 1 0)),((3 3 0, 4 3 0, 4 4 0, 3 3 0)))"
+            ],
+        )
+        # TIN to Polygon (single patch)
+        self.assertEqual(
+            coerce_to_wkt(
+                "TIN (((1 1, 1 2, 2 2, 1 1)))",
+                QgsWkbTypes.Type.Polygon,
+            ),
+            ["Polygon ((1 1, 1 2, 2 2, 1 1))"],
+        )
+
         # GeometryCollection of Point to MultiPoint
         self.assertEqual(
             coerce_to_wkt(


### PR DESCRIPTION
## Description

  This PR adds initial digitizing support for TIN (Triangulated Irregular Network) and PolyhedralSurface geometry types.

  These geometry types can now be edited using existing digitizing tools:

- Save "polygon"/"multipolygon" inside TIN/PHS
- Add Part: Add new patches (triangles for TIN, polygons for PolyhedralSurface) to existing features
- Add Ring: Add interior rings to patches within a PolyhedralSurface
- Merge Features: Combine multiple TIN or PolyhedralSurface features into one
- Digitizing: When digitizing on a TIN layer, users are warned if the drawn polygon is not a valid triangle
- Vertex editing: Z/M values can now be edited on PolyhedralSurface vertices

###  Notes

  This is a first step toward full digitizing support for these geometry types. The current implementation adapts existing digitizing tools to respect the constraints of TIN and PolyhedralSurface geometries (but not "surface" since it's not yet well supported)
  (e.g., TIN patches must be triangles, surfaces can hold multiple patches without requiring a "Multi" type).

  Further digitizing improvements may be added in future versions.

Sponsored by Stadt Frankfurt am Main / Oslandia