### PR TITLE
Change expression from string_to_array to array_to_string in overlay_touches example

### DIFF
--- a/resources/function_help/json/overlay_touches
+++ b/resources/function_help/json/overlay_touches
@@ -34,7 +34,7 @@
     "expression": "overlay_touches('regions', name)",
     "returns": "an array of names, for the regions touched by the current feature"
   }, {
-    "expression": "string_to_array(overlay_touches('regions', name))",
+    "expression": "array_to_string(overlay_touches('regions', name))",
     "returns": "a string as a comma separated list of names, for the regions touched by the current feature"
   }, {
     "expression": "array_sort(overlay_touches(layer:='regions', expression:=\"name\", filter:= population > 10000))",


### PR DESCRIPTION
## Description

### Problem
In the function documentation file resources/function_help/json/overlay_touches, there is an error in one of the example definitions (line 37).
The example uses the string_to_array() function when it should use array_to_string().
Error Details:

Line 37 (INCORRECT):
```json
"expression": "string_to_array(overlay_touches('regions', name))",
"returns": "a string as a comma separated list of names, for the regions touched by the current feature"
```
Why This Is an Error:

- The function `overlay_touches('regions', name)` returns an ARRAY of values (region names)
- To convert an array to a comma-separated string, you need to use `array_to_string()`
- The function `string_to_array()` does the opposite: it converts a string into an array

Inconsistency with Other Examples:
All other examples in the same `overlay_touches` function and in related overlay functions (`overlay_contains`,` overlay_crosses`, `overlay_disjoint`, etc.) correctly use array_to_string() to convert array results to strings.

Solution
Line 37 (CORRECT):
```json
"expression": "array_to_string(overlay_touches('regions', name))",
"returns": "a string as a comma separated list of names, for the regions touched by the current feature"
```
Modified File:

`resources/function_help/json/overlay_touches`

Change Type:

- Documentation/examples correction
- No impact on source code

Testing:
This modification only affects the JSON documentation that provides contextual help to users. The `overlay_touches` function itself has not been modified, but the example now correctly reflects how to use this function with the proper type conversion functions.
