### PR TITLE
Docs: fix various spelling typos

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -173,7 +173,7 @@ class ANALYSIS_EXPORT QgsGeometryCheck
      */
     enum Flag SIP_ENUM_BASETYPE( IntFlag )
     {
-      AvailableInValidation = 1 << 1 //!< This geometry check should be available in layer validation on the vector layer peroperties
+      AvailableInValidation = 1 << 1 //!< This geometry check should be available in layer validation on the vector layer properties
     };
     Q_DECLARE_FLAGS( Flags, Flag )
     Q_FLAG( Flags )

--- a/src/providers/mssql/qgsmssqlnewconnection.h
+++ b/src/providers/mssql/qgsmssqlnewconnection.h
@@ -26,7 +26,7 @@
 
 class QgsMssqlDatabase;
 
-//! Class that reprents a model to display available schemas on a database and choose which will be displayed in QGIS
+//! Class that represents a model to display available schemas on a database and choose which will be displayed in QGIS
 class SchemaModel : public QAbstractListModel
 {
     Q_OBJECT

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -413,7 +413,7 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
     // Set the request handler into the interface for plugins to manipulate it
     sServerInterface->setRequestHandler( &requestHandler );
 
-    // Initialize configfilepath so that is is available
+    // Initialize configfilepath so that it is available
     // before calling plugin methods
     // Note that plugins may still change that value using
     // setConfigFilePath() interface method


### PR DESCRIPTION
nano +416 src/server/qgsserver.cpp
# Change "is is" to "it is"
nano +101 src/core/symbology/qgsrulebasedrendererwidget.h
# Change "bindungs" to "bindings"
nano +176 src/analysis/vector/geometry_checker/qgsgeometrycheck.h
# Change "peroperties" to "properties"
nano +29 src/providers/mssql/qgsmssqlnewconnection.h
# Change "reprents" to "represents"