### PR TITLE
Enhance error message with server response content

### DIFF
--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -733,7 +733,7 @@ void QgsBaseNetworkRequest::replyFinished()
       }
       else if ( !replyContent.isEmpty() )
       {
-        mErrorMessage += tr( "\nserver response: %1" ).arg( replyContent );
+        mErrorMessage += tr( "\nServer response: %1" ).arg( replyContent );
       }
       mErrorCode = QgsBaseNetworkRequest::ServerExceptionError;
       logMessageIfEnabled();

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -731,6 +731,10 @@ void QgsBaseNetworkRequest::replyFinished()
                             .arg( exception.attribute( QStringLiteral( "exceptionCode" ), tr( "missing" ) ), exception.firstChildElement( QStringLiteral( "ExceptionText" ) ).text() );
         }
       }
+      else if ( !replyContent.isEmpty() )
+      {
+        mErrorMessage += tr( "\nserver response: %1" ).arg( replyContent );
+      }
       mErrorCode = QgsBaseNetworkRequest::ServerExceptionError;
       logMessageIfEnabled();
       mResponse.clear();


### PR DESCRIPTION
Add server response to error message for exceptions.

We have some information which is available in the server response. This allow displaying it:

<img width="998" height="416" alt="image" src="https://github.com/user-attachments/assets/ebaba835-f041-4298-968d-3455ea12ff6e" />
