### PR TITLE
Fix several double-word and grammar typos in core headers

### DIFF
--- a/python/PyQt6/core/auto_generated/callouts/qgscallout.sip.in
+++ b/python/PyQt6/core/auto_generated/callouts/qgscallout.sip.in
@@ -294,7 +294,7 @@ information about how a callout is being rendered.
 
     bool enabled() const;
 %Docstring
-Returns ``True`` if the the callout is enabled.
+Returns ``True`` if the callout is enabled.
 
 .. seealso:: :py:func:`setEnabled`
 %End

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -384,7 +384,7 @@ test performed by :py:func:`~QgsGeometry.isGeosEqual`.
 Compares the geometry with another geometry using GEOS.
 
 This method performs a slow, topological check, where geometries are
-considered equal if all of the their component edges overlap. E.g. lines
+considered equal if all of their component edges overlap. E.g. lines
 with the same vertex locations but opposite direction will be considered
 equal by this method.
 

--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -171,7 +171,7 @@ connect to and access the data.
 
     bool addDatasets( const QString &path, const QDateTime &defaultReferenceTime = QDateTime() );
 %Docstring
-Adds datasets to the mesh from file with ``path``. Use the the time
+Adds datasets to the mesh from file with ``path``. Use the time
 ``defaultReferenceTime`` as reference time is not provided in the file
 
 :param path: the path to the datasets file

--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -715,7 +715,7 @@ Remove the given ``key`` from the specified ``scope``.
 
     QStringList entryList( const QString &scope, const QString &key ) const;
 %Docstring
-Returns a list of child keys with values which exist within the the
+Returns a list of child keys with values which exist within the
 specified ``scope`` and ``key``.
 
 This method does not return keys that contain other keys. See
@@ -730,7 +730,7 @@ keys.
     QStringList subkeyList( const QString &scope, const QString &key ) const;
 %Docstring
 Returns a list of child keys which contain other keys that exist within
-the the specified ``scope`` and ``key``.
+the specified ``scope`` and ``key``.
 
 This method only returns keys with keys, it will not return keys that
 contain only values. See :py:func:`~QgsProject.entryList` to retrieve

--- a/python/PyQt6/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -614,7 +614,7 @@ only, such as ".aux.xml" files or ".shp.xml" files, or the
 cloud sources.
 
 This method tests whether any of the registered providers return
-``True`` for the their :py:func:`QgsProviderMetadata.uriIsBlocklisted()`
+``True`` for their :py:func:`QgsProviderMetadata.uriIsBlocklisted()`
 implementation for the specified URI.
 
 .. versionadded:: 3.18

--- a/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -277,14 +277,14 @@ Set to -1 if no limit is desired.
 
     QString filter() const;
 %Docstring
-Returns the the string filter to filter expanded child entities by.
+Returns the string filter to filter expanded child entities by.
 
 .. seealso:: :py:func:`setFilter`
 %End
 
     void setFilter( const QString &filter );
 %Docstring
-Returns the the string ``filter`` to filter expanded child entities by.
+Returns the string ``filter`` to filter expanded child entities by.
 
 .. seealso:: :py:func:`filter`
 %End

--- a/python/PyQt6/core/auto_generated/qgsapplication.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsapplication.sip.in
@@ -151,7 +151,7 @@ Sets the FileOpen event receiver
 %Docstring
 Set the active theme to the specified theme. The theme name should be a
 single word e.g. 'default','classic'. The theme search path usually will
-be pkgDataPath + "/themes/" + themName + "/" but plugin writers etc can
+be pkgDataPath + "/themes/" + themeName + "/" but plugin writers etc can
 use :py:func:`~QgsApplication.themeName` as a basis for searching for
 resources in their own datastores e.g. a Qt4 resource bundle.
 
@@ -173,7 +173,7 @@ Calculate the application pkg path
 %Docstring
 Set the active theme to the specified theme. The theme name should be a
 single word e.g. 'default','classic'. The theme search path usually will
-be pkgDataPath + "/themes/" + themName + "/" but plugin writers etc can
+be pkgDataPath + "/themes/" + themeName + "/" but plugin writers etc can
 use this method as a basis for searching for resources in their own
 datastores e.g. a Qt4 resource bundle.
 %End

--- a/python/PyQt6/core/auto_generated/qgscacheindex.sip.in
+++ b/python/PyQt6/core/auto_generated/qgscacheindex.sip.in
@@ -39,7 +39,7 @@ clear all cache information in here.
 
     virtual void requestCompleted( const QgsFeatureRequest &featureRequest, const QgsFeatureIds &fids );
 %Docstring
-Implement this method to update the the indices, in case you need
+Implement this method to update the indices, in case you need
 information contained by the request to properly index. (E.g. spatial
 index) Does nothing by default
 

--- a/python/PyQt6/core/auto_generated/textrenderer/qgsfontmanager.sip.in
+++ b/python/PyQt6/core/auto_generated/textrenderer/qgsfontmanager.sip.in
@@ -205,7 +205,7 @@ font is installed and available for use.
 
     void enableFontDownloadsForSession();
 %Docstring
-Enables font downloads the the current QGIS session.
+Enables font downloads the current QGIS session.
 
 .. warning::
 

--- a/python/core/auto_generated/callouts/qgscallout.sip.in
+++ b/python/core/auto_generated/callouts/qgscallout.sip.in
@@ -294,7 +294,7 @@ information about how a callout is being rendered.
 
     bool enabled() const;
 %Docstring
-Returns ``True`` if the the callout is enabled.
+Returns ``True`` if the callout is enabled.
 
 .. seealso:: :py:func:`setEnabled`
 %End

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -384,7 +384,7 @@ test performed by :py:func:`~QgsGeometry.isGeosEqual`.
 Compares the geometry with another geometry using GEOS.
 
 This method performs a slow, topological check, where geometries are
-considered equal if all of the their component edges overlap. E.g. lines
+considered equal if all of their component edges overlap. E.g. lines
 with the same vertex locations but opposite direction will be considered
 equal by this method.
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -171,7 +171,7 @@ connect to and access the data.
 
     bool addDatasets( const QString &path, const QDateTime &defaultReferenceTime = QDateTime() );
 %Docstring
-Adds datasets to the mesh from file with ``path``. Use the the time
+Adds datasets to the mesh from file with ``path``. Use the time
 ``defaultReferenceTime`` as reference time is not provided in the file
 
 :param path: the path to the datasets file

--- a/python/core/auto_generated/project/qgsproject.sip.in
+++ b/python/core/auto_generated/project/qgsproject.sip.in
@@ -715,7 +715,7 @@ Remove the given ``key`` from the specified ``scope``.
 
     QStringList entryList( const QString &scope, const QString &key ) const;
 %Docstring
-Returns a list of child keys with values which exist within the the
+Returns a list of child keys with values which exist within the
 specified ``scope`` and ``key``.
 
 This method does not return keys that contain other keys. See
@@ -730,7 +730,7 @@ keys.
     QStringList subkeyList( const QString &scope, const QString &key ) const;
 %Docstring
 Returns a list of child keys which contain other keys that exist within
-the the specified ``scope`` and ``key``.
+the specified ``scope`` and ``key``.
 
 This method only returns keys with keys, it will not return keys that
 contain only values. See :py:func:`~QgsProject.entryList` to retrieve

--- a/python/core/auto_generated/providers/qgsproviderregistry.sip.in
+++ b/python/core/auto_generated/providers/qgsproviderregistry.sip.in
@@ -614,7 +614,7 @@ only, such as ".aux.xml" files or ".shp.xml" files, or the
 cloud sources.
 
 This method tests whether any of the registered providers return
-``True`` for the their :py:func:`QgsProviderMetadata.uriIsBlocklisted()`
+``True`` for their :py:func:`QgsProviderMetadata.uriIsBlocklisted()`
 implementation for the specified URI.
 
 .. versionadded:: 3.18

--- a/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
+++ b/python/core/auto_generated/providers/sensorthings/qgssensorthingsutils.sip.in
@@ -277,14 +277,14 @@ Set to -1 if no limit is desired.
 
     QString filter() const;
 %Docstring
-Returns the the string filter to filter expanded child entities by.
+Returns the string filter to filter expanded child entities by.
 
 .. seealso:: :py:func:`setFilter`
 %End
 
     void setFilter( const QString &filter );
 %Docstring
-Returns the the string ``filter`` to filter expanded child entities by.
+Returns the string ``filter`` to filter expanded child entities by.
 
 .. seealso:: :py:func:`filter`
 %End

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -151,7 +151,7 @@ Sets the FileOpen event receiver
 %Docstring
 Set the active theme to the specified theme. The theme name should be a
 single word e.g. 'default','classic'. The theme search path usually will
-be pkgDataPath + "/themes/" + themName + "/" but plugin writers etc can
+be pkgDataPath + "/themes/" + themeName + "/" but plugin writers etc can
 use :py:func:`~QgsApplication.themeName` as a basis for searching for
 resources in their own datastores e.g. a Qt4 resource bundle.
 
@@ -173,7 +173,7 @@ Calculate the application pkg path
 %Docstring
 Set the active theme to the specified theme. The theme name should be a
 single word e.g. 'default','classic'. The theme search path usually will
-be pkgDataPath + "/themes/" + themName + "/" but plugin writers etc can
+be pkgDataPath + "/themes/" + themeName + "/" but plugin writers etc can
 use this method as a basis for searching for resources in their own
 datastores e.g. a Qt4 resource bundle.
 %End

--- a/python/core/auto_generated/qgscacheindex.sip.in
+++ b/python/core/auto_generated/qgscacheindex.sip.in
@@ -39,7 +39,7 @@ clear all cache information in here.
 
     virtual void requestCompleted( const QgsFeatureRequest &featureRequest, const QgsFeatureIds &fids );
 %Docstring
-Implement this method to update the the indices, in case you need
+Implement this method to update the indices, in case you need
 information contained by the request to properly index. (E.g. spatial
 index) Does nothing by default
 

--- a/python/core/auto_generated/textrenderer/qgsfontmanager.sip.in
+++ b/python/core/auto_generated/textrenderer/qgsfontmanager.sip.in
@@ -205,7 +205,7 @@ font is installed and available for use.
 
     void enableFontDownloadsForSession();
 %Docstring
-Enables font downloads the the current QGIS session.
+Enables font downloads the current QGIS session.
 
 .. warning::
 

--- a/src/core/callouts/qgscallout.h
+++ b/src/core/callouts/qgscallout.h
@@ -317,7 +317,7 @@ class CORE_EXPORT QgsCallout
     void render( QgsRenderContext &context, const QRectF &rect, const double angle, const QgsGeometry &anchor, QgsCalloutContext &calloutContext );
 
     /**
-     * Returns TRUE if the the callout is enabled.
+     * Returns TRUE if the callout is enabled.
      * \see setEnabled()
      */
     bool enabled() const { return mEnabled; }

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -433,7 +433,7 @@ class CORE_EXPORT QgsGeometry
      * Compares the geometry with another geometry using GEOS.
      *
      * This method performs a slow, topological check, where geometries
-     * are considered equal if all of the their component edges overlap. E.g.
+     * are considered equal if all of their component edges overlap. E.g.
      * lines with the same vertex locations but opposite direction will be
      * considered equal by this method.
      *

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -201,7 +201,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer, public QgsAbstractProfileSo
     QString loadDefaultStyle( bool &resultFlag SIP_OUT ) final;
 
     /**
-     * Adds datasets to the mesh from file with \a path. Use the the time \a defaultReferenceTime as reference time is not provided in the file
+     * Adds datasets to the mesh from file with \a path. Use the time \a defaultReferenceTime as reference time is not provided in the file
      *
      * \param path the path to the datasets file
      * \param defaultReferenceTime reference time used if not provided in the file

--- a/src/core/mesh/qgsmeshlayerutils.h
+++ b/src/core/mesh/qgsmeshlayerutils.h
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsMeshLayerUtils
      * \brief Returns N vector/scalar values from the index from the dataset
      *
      * See QgsMeshLayerUtils::datasetValuesCount() to determine maximum number of values to be requested
-     * See QgsMeshLayerUtils::datasetValuesType() to see the the type of values the function returns
+     * See QgsMeshLayerUtils::datasetValuesType() to see the type of values the function returns
      * See QgsMeshDatasetGroupMetadata::isVector() to check if the returned value is vector or scalar
      *
      * \since QGIS 3.12

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -680,7 +680,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     bool removeEntry( const QString &scope, const QString &key );
 
     /**
-     * Returns a list of child keys with values which exist within the the specified \a scope and \a key.
+     * Returns a list of child keys with values which exist within the specified \a scope and \a key.
      *
      * This method does not return keys that contain other keys. See subkeyList() to retrieve keys
      * which contain other keys.
@@ -690,7 +690,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QStringList entryList( const QString &scope, const QString &key ) const;
 
     /**
-     * Returns a list of child keys which contain other keys that exist within the the specified \a scope and \a key.
+     * Returns a list of child keys which contain other keys that exist within the specified \a scope and \a key.
      *
      * This method only returns keys with keys, it will not return keys that contain only values. See
      * entryList() to retrieve keys with values.

--- a/src/core/providers/qgsproviderregistry.h
+++ b/src/core/providers/qgsproviderregistry.h
@@ -598,7 +598,7 @@ class CORE_EXPORT QgsProviderRegistry
      * for URIs which are known to be sidecar files only, such as ".aux.xml" files or ".shp.xml" files,
      * or the "ept-build.json" files which sit alongside Entwine "ept.json" point cloud sources.
      *
-     * This method tests whether any of the registered providers return TRUE for the their
+     * This method tests whether any of the registered providers return TRUE for their
      * QgsProviderMetadata::uriIsBlocklisted() implementation for the specified URI.
      *
      * \since QGIS 3.18

--- a/src/core/providers/sensorthings/qgssensorthingsutils.h
+++ b/src/core/providers/sensorthings/qgssensorthingsutils.h
@@ -274,14 +274,14 @@ class CORE_EXPORT QgsSensorThingsExpansionDefinition
     void setLimit( int limit );
 
     /**
-     * Returns the the string filter to filter expanded child entities by.
+     * Returns the string filter to filter expanded child entities by.
      *
      * \see setFilter()
      */
     QString filter() const;
 
     /**
-     * Returns the the string \a filter to filter expanded child entities by.
+     * Returns the string \a filter to filter expanded child entities by.
      *
      * \see filter()
      */

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -243,7 +243,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     /**
      * Set the active theme to the specified theme.
      * The theme name should be a single word e.g. 'default','classic'.
-     * The theme search path usually will be pkgDataPath + "/themes/" + themName + "/"
+     * The theme search path usually will be pkgDataPath + "/themes/" + themeName + "/"
      * but plugin writers etc can use themeName() as a basis for searching
      * for resources in their own datastores e.g. a Qt4 resource bundle.
      * \note A basic test will be carried out to ensure the theme search path
@@ -261,7 +261,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     /**
      * Set the active theme to the specified theme.
      * The theme name should be a single word e.g. 'default','classic'.
-     * The theme search path usually will be pkgDataPath + "/themes/" + themName + "/"
+     * The theme search path usually will be pkgDataPath + "/themes/" + themeName + "/"
      * but plugin writers etc can use this method as a basis for searching
      * for resources in their own datastores e.g. a Qt4 resource bundle.
      */

--- a/src/core/qgscacheindex.h
+++ b/src/core/qgscacheindex.h
@@ -47,7 +47,7 @@ class CORE_EXPORT QgsAbstractCacheIndex
 
     /**
      * \brief
-     * Implement this method to update the the indices, in case you need information contained by the request
+     * Implement this method to update the indices, in case you need information contained by the request
      * to properly index. (E.g. spatial index)
      * Does nothing by default
      *

--- a/src/core/textrenderer/qgsfontmanager.h
+++ b/src/core/textrenderer/qgsfontmanager.h
@@ -249,7 +249,7 @@ class CORE_EXPORT QgsFontManager : public QObject
     bool tryToDownloadFontFamily( const QString &family, QString &matchedFamily SIP_OUT );
 
     /**
-     * Enables font downloads the the current QGIS session.
+     * Enables font downloads the current QGIS session.
      *
      * \warning Ensure that the QgsApplication is fully initialized before calling this method.
      */


### PR DESCRIPTION
I have fixed several small spelling and grammar mistakes found in the core API header files.
Changes included
Fixed "the the" to "the" in multiple files.
Corrected "of the their" to "of their" in qgsgeometry.h.
Fixed "for the their" to "for their" in qgsproviderregistry.h.