### PR TITLE
Sort the list of available plugins in the About page

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5656,7 +5656,9 @@ QString QgisApp::getVersionString()
   if ( mPythonUtils && mPythonUtils->isEnabled() )
   {
     versionString += QStringLiteral( "<td colspan=\"2\">&nbsp;</td></tr><tr><td colspan=\"2\"><b>%1</b></td>" ).arg( tr( "Active Python plugins" ) );
-    const QStringList activePlugins = mPythonUtils->listActivePlugins();
+    QStringList pluginsList = mPythonUtils->listActivePlugins();
+    pluginsList.sort();
+    const QStringList activePlugins = pluginsList;
     for ( const QString &plugin : activePlugins )
     {
       const QString version = mPythonUtils->getPluginMetadata( plugin, QStringLiteral( "version" ) );


### PR DESCRIPTION
Outputs
<img width="442" height="184" alt="image" src="https://github.com/user-attachments/assets/6eaa1588-adff-49a5-bf4a-4b54bb70c2eb" />
The idea is to avoid a hard to read list as [follows](https://github.com/qgis/QGIS/issues/64374#issue-3757445167)
<img width="459" height="835" alt="image" src="https://github.com/user-attachments/assets/98ff5271-1b70-4b58-a2bc-551278bc41f6" />
