### PR TITLE
Use ubuntu repo version of doxygen

### DIFF
--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -15,9 +15,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DOXYGEN_VERSION: 1.9.8
-
 jobs:
   documentation_checks:
     runs-on: ubuntu-latest
@@ -30,8 +27,7 @@ jobs:
           python-version: '3.13'
       - name: Install requirements
         run: |
-          wget https://www.doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
-          tar -xzf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
+          sudo apt install -y doxygen
           python -m pip install --upgrade pip
           pip install autopep8 nose2 mock termcolor
       - name: Make
@@ -39,7 +35,7 @@ jobs:
           mkdir build
           cd build
           cmake -DUSE_CCACHE=OFF -DWITH_CORE=OFF -DWITH_APIDOC=ON -DWITH_ASTYLE=ON -DENABLE_TESTS=ON \
-                -DWITH_DOT=NO -DWERROR=ON -DDOXYGEN_EXECUTABLE=../doxygen-${DOXYGEN_VERSION}/bin/doxygen ..
+                -DWITH_DOT=NO -DWERROR=ON ..
           make -j3 apidoc
       - name: Run Tests
         run: cd build && ctest -V -R PyQgsDocCoverage


### PR DESCRIPTION
Avoids CI errors when downloads from doxygen.nl fail

This was originally done to get access to a newer doxygen vs what was available in the ubuntu repos, but now we have 1.9.8 in the repo anyway.