### PR TITLE
Mac: defer FileOpen events until initialization completes

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2647,7 +2647,14 @@ bool QgisApp::event( QEvent *event )
   {
     // handle FileOpen event (double clicking a file icon in Mac OS X Finder)
     QFileOpenEvent *foe = static_cast<QFileOpenEvent *>( event );
-    openFile( foe->file() );
+    if ( !mInitializationHasCompleted )
+    {
+      mDeferredFileOpenPaths << foe->file();
+    }
+    else
+    {
+      openFile( foe->file() );
+    }
     done = true;
   }
   else if ( event->type() == QEvent::Gesture )
@@ -16955,6 +16962,15 @@ void QgisApp::authMessageLog( const QString &message, const QString &authtag, Qg
 
 void QgisApp::completeInitialization()
 {
+  mInitializationHasCompleted = true;
+
+  const QStringList deferredFileOpenPaths = mDeferredFileOpenPaths;
+  mDeferredFileOpenPaths.clear();
+  for ( const QString &path : deferredFileOpenPaths )
+  {
+    openFile( path );
+  }
+
   emit initializationCompleted();
 }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2591,6 +2591,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Keep track of whether ongoing dataset(s) is/are being dropped through the table of contents
     bool mLayerTreeDrop = false;
 
+    bool mInitializationHasCompleted = false;
+    QStringList mDeferredFileOpenPaths;
+
     //! Helper class that connects layer tree with map canvas
     QgsLayerTreeMapCanvasBridge *mLayerTreeCanvasBridge = nullptr;
     //! Table of contents (legend) to order layers of the map


### PR DESCRIPTION
Fixes #45809

Also addresses #46340 (closed as wontfix; appears to share the same root cause).
Related: https://github.com/NewGraphEnvironment/dff-2022/issues/106

## Description
On macOS, opening a .qgs/.qgz project via Finder/LaunchServices can trigger a FileOpen event before QgisApp initialization completes. This results in the project opening at 0,0 (“Null Island”) instead of restoring the last saved extent. Using "File --> Open" or loading a recent project does not result in this bug appearing. 

This PR defers handling of FileOpen events until initialization has completed by queueing early FileOpen paths and processing them during completeInitialization().

## Testing
- Built QGIS locally on macOS (arm64).
- Reproduced failure mode without the change (project opens at 0,0 / “Null Island”).
- Verified fix by opening the same .qgz via LaunchServices (`open -n -a QGIS.app <project.qgz>`) and confirming it restores the last saved extent.