### PR TITLE
Add OAuth support to PostgreSQL provider

### DIFF
--- a/src/auth/oauth2/core/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2method.cpp
@@ -127,9 +127,9 @@ QgsO2 *QgsOAuth2Factory::createO2Private( const QString &authcfg, QgsAuthOAuth2C
 QgsAuthOAuth2Method::QgsAuthOAuth2Method()
 {
   setVersion( 1 );
-  setExpansions( QgsAuthMethod::NetworkRequest | QgsAuthMethod::NetworkReply );
+  setExpansions( QgsAuthMethod::NetworkRequest | QgsAuthMethod::NetworkReply | QgsAuthMethod::DataSourceUri );
   setDataProviders( QStringList() << u"ows"_s << u"wfs"_s // convert to lowercase
-                                  << u"wcs"_s << u"wms"_s );
+                                  << u"wcs"_s << u"wms"_s << u"postgres"_s );
 
   const QStringList cachedirpaths = QStringList()
                                     << QgsAuthOAuth2Config::tokenCacheDirectory()
@@ -336,57 +336,66 @@ bool QgsAuthOAuth2Method::updateNetworkRequest( QNetworkRequest &request, const 
   QUrl url = request.url();
   QUrlQuery query( url );
 
-  switch ( accessmethod )
+  if ( dataprovider == "postgres"_L1 )
   {
-    case QgsAuthOAuth2Config::AccessMethod::Header:
+    // allow easy token "exfiltration" via QNetworkRequest, so that we can do without
+    // a postgres/oauth-specific update* method
+    request.setRawHeader( "Token"_ba, o2->token().toLatin1() );
+  }
+  else
+  {
+    switch ( accessmethod )
     {
-      const QString header = o2->oauth2config()->customHeader().isEmpty() ? QString( O2_HTTP_AUTHORIZATION_HEADER ) : o2->oauth2config()->customHeader();
-      request.setRawHeader( header.toLatin1(), u"Bearer %1"_s.arg( o2->token() ).toLatin1() );
-
-      const QVariantMap extraTokens = o2->oauth2config()->extraTokens();
-      if ( !extraTokens.isEmpty() )
+      case QgsAuthOAuth2Config::AccessMethod::Header:
       {
-        const QVariantMap receivedExtraTokens = o2->extraTokens();
-        const QStringList extraTokenNames = extraTokens.keys();
-        for ( const QString &extraTokenName : extraTokenNames )
+        const QString header = o2->oauth2config()->customHeader().isEmpty() ? QString( O2_HTTP_AUTHORIZATION_HEADER ) : o2->oauth2config()->customHeader();
+        request.setRawHeader( header.toLatin1(), u"Bearer %1"_s.arg( o2->token() ).toLatin1() );
+
+        const QVariantMap extraTokens = o2->oauth2config()->extraTokens();
+        if ( !extraTokens.isEmpty() )
         {
-          if ( receivedExtraTokens.contains( extraTokenName ) )
+          const QVariantMap receivedExtraTokens = o2->extraTokens();
+          const QStringList extraTokenNames = extraTokens.keys();
+          for ( const QString &extraTokenName : extraTokenNames )
           {
-            request.setRawHeader( extraTokens[extraTokenName].toString().replace( '_', '-' ).toLatin1(), receivedExtraTokens[extraTokenName].toString().toLatin1() );
+            if ( receivedExtraTokens.contains( extraTokenName ) )
+            {
+              request.setRawHeader( extraTokens[extraTokenName].toString().replace( '_', '-' ).toLatin1(), receivedExtraTokens[extraTokenName].toString().toLatin1() );
+            }
           }
         }
-      }
 
 #ifdef QGISDEBUG
-      msg = u"Updated request HEADER with access token for authcfg: %1"_s.arg( authcfg );
-      QgsDebugMsgLevel( msg, 2 );
+        msg = u"Updated request HEADER with access token for authcfg: %1"_s.arg( authcfg );
+        QgsDebugMsgLevel( msg, 2 );
 #endif
-      break;
+        break;
+      }
+      case QgsAuthOAuth2Config::AccessMethod::Form:
+        // FIXME: what to do here if the parent request is not POST?
+        //        probably have to skip this until auth system support is moved into QgsNetworkAccessManager
+        msg = u"Update request FAILED for authcfg %1: form POST token update is unsupported"_s.arg( authcfg );
+        QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Warning );
+        break;
+      case QgsAuthOAuth2Config::AccessMethod::Query:
+        if ( !query.hasQueryItem( O2_OAUTH2_ACCESS_TOKEN ) )
+        {
+          query.addQueryItem( O2_OAUTH2_ACCESS_TOKEN, o2->token() );
+          url.setQuery( query );
+          request.setUrl( url );
+#ifdef QGISDEBUG
+          msg = u"Updated request QUERY with access token for authcfg: %1"_s.arg( authcfg );
+#endif
+        }
+        else
+        {
+#ifdef QGISDEBUG
+          msg = u"Updated request QUERY with access token SKIPPED (existing token) for authcfg: %1"_s.arg( authcfg );
+#endif
+        }
+        QgsDebugMsgLevel( msg, 2 );
+        break;
     }
-    case QgsAuthOAuth2Config::AccessMethod::Form:
-      // FIXME: what to do here if the parent request is not POST?
-      //        probably have to skip this until auth system support is moved into QgsNetworkAccessManager
-      msg = u"Update request FAILED for authcfg %1: form POST token update is unsupported"_s.arg( authcfg );
-      QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Warning );
-      break;
-    case QgsAuthOAuth2Config::AccessMethod::Query:
-      if ( !query.hasQueryItem( O2_OAUTH2_ACCESS_TOKEN ) )
-      {
-        query.addQueryItem( O2_OAUTH2_ACCESS_TOKEN, o2->token() );
-        url.setQuery( query );
-        request.setUrl( url );
-#ifdef QGISDEBUG
-        msg = u"Updated request QUERY with access token for authcfg: %1"_s.arg( authcfg );
-#endif
-      }
-      else
-      {
-#ifdef QGISDEBUG
-        msg = u"Updated request QUERY with access token SKIPPED (existing token) for authcfg: %1"_s.arg( authcfg );
-#endif
-      }
-      QgsDebugMsgLevel( msg, 2 );
-      break;
   }
 
   return true;
@@ -588,9 +597,22 @@ void QgsAuthOAuth2Method::onAuthCode()
 
 bool QgsAuthOAuth2Method::updateDataSourceUriItems( QStringList &connectionItems, const QString &authcfg, const QString &dataprovider )
 {
-  Q_UNUSED( connectionItems )
-  Q_UNUSED( authcfg )
-  Q_UNUSED( dataprovider )
+  if ( dataprovider == "postgres"_L1 )
+  {
+    QgsAuthOAuth2Config *config = getOAuth2Bundle( authcfg, true )->oauth2config();
+
+    connectionItems << u"oauth_issuer=%1"_s.arg( QUrl( config->requestUrl() ).toString( QUrl::RemovePath ) )
+                    << u"oauth_client_id=%1"_s.arg( config->clientId() );
+
+    if ( !config->clientSecret().isEmpty() )
+    {
+      connectionItems << u"oauth_client_secret=%1"_s.arg( config->clientSecret() );
+    }
+    if ( !config->scope().isEmpty() )
+    {
+      connectionItems << u"oauth_scope=%1"_s.arg( config->scope().replace( ' '_L1, u"%20"_s ) );
+    }
+  }
 
   return true;
 }

--- a/src/providers/postgres/CMakeLists.txt
+++ b/src/providers/postgres/CMakeLists.txt
@@ -5,6 +5,7 @@ set(PG_SRCS
   qgspostgresutils.cpp
   qgspostgresprovider.cpp
   qgspostgresconn.cpp
+  qgspostgresconnoauthhandler.cpp
   qgspostgresconnpool.cpp
   qgspostgresdataitems.cpp
   qgspostgresfeatureiterator.cpp
@@ -87,6 +88,7 @@ set(PGRASTER_SRCS
   raster/qgspostgresrastershareddata.cpp
   raster/qgspostgresrasterutils.cpp
   qgspostgresconn.cpp
+  qgspostgresconnoauthhandler.cpp
   qgspostgresconnpool.cpp
   qgspostgresprovidermetadatautils.cpp
 )

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -22,6 +22,7 @@
 #include <nlohmann/json.hpp>
 
 #include "qgsapplication.h"
+#include "qgsauthmanager.h"
 #include "qgscredentials.h"
 #include "qgsdatasourceuri.h"
 #include "qgsdbquerylog.h"
@@ -29,6 +30,7 @@
 #include "qgsjsonutils.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
+#include "qgspostgresconnoauthhandler.h"
 #include "qgspostgresconnpool.h"
 #include "qgspostgresstringutils.h"
 #include "qgssettings.h"
@@ -49,6 +51,11 @@
 #else
 #include <netinet/in.h>
 #endif
+
+extern "C"
+{
+#include <pg_config.h>
+}
 
 const int PG_DEFAULT_TIMEOUT = 30;
 
@@ -303,8 +310,30 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
   };
   addDefaultTimeoutAndClientEncoding( expandedConnectionInfo );
 
+  bool isOAuth = false;
+  if ( !mUri.authConfigId().isEmpty() )
+  {
+    QgsAuthMethod *method = QgsApplication::authManager()->configAuthMethod( mUri.authConfigId() );
+    QStringList items;
+    if ( method->key() == "OAuth2"_L1 && method->updateDataSourceUriItems( items, mUri.authConfigId(), u"postgres"_s ) )
+    {
+#if PG_MAJORVERSION_NUM >= 18
+      isOAuth = true;
+      expandedConnectionInfo += u" %1"_s.arg( items.join( " " ) );
+#else
+      QgsMessageLog::logMessage(
+        tr( "OAuth authentication requires PostgreSQL 18, this QGIS is built using the PostgreSQL client library version %1.%2, falling back to basic authentication" ).arg( PG_MAJORVERSION_NUM ).arg( PG_MINORVERSION_NUM ),
+        tr( "PostGIS" )
+      );
+#endif
+    }
+  }
+
   auto logWrapper = std::make_unique<QgsDatabaseQueryLogWrapper>( u"libpq::PQconnectdb()"_s, expandedConnectionInfo.toUtf8(), u"postgres"_s, u"QgsPostgresConn"_s, QGS_QUERY_LOG_ORIGIN_PG_CON );
-  mConn = PQconnectdb( expandedConnectionInfo.toUtf8() );
+  {
+    const auto auth = QgsPostgresConnOAuthHandler( mUri.authConfigId() );
+    mConn = PQconnectdb( expandedConnectionInfo.toUtf8() );
+  }
 
   // remove temporary cert/key/CA if they exist
   QgsDataSourceUri expandedUri( expandedConnectionInfo );
@@ -343,7 +372,7 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
   }
 
   // check the connection status
-  if ( PQstatus() != CONNECTION_OK )
+  if ( PQstatus() != CONNECTION_OK && !isOAuth )
   {
     QString username = mUri.username();
     QString password = mUri.password();

--- a/src/providers/postgres/qgspostgresconnoauthhandler.cpp
+++ b/src/providers/postgres/qgspostgresconnoauthhandler.cpp
@@ -1,0 +1,115 @@
+/***************************************************************************
+  qgspostgresconnoauthhandler.cpp
+
+ ---------------------
+ begin                : 27.12.2025
+ copyright            : (C) 2025 by Jan Dalheimer
+ email                : jan@dalheimer.de
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspostgresconnoauthhandler.h"
+
+#include <mutex>
+
+#include "qgsapplication.h"
+#include "qgsauthmanager.h"
+#include "qgsauthmethod.h"
+#include "qgslogger.h"
+#include "qgsmessagelog.h"
+
+extern "C"
+{
+#include <libpq-fe.h>
+#include <pg_config.h>
+}
+
+#ifdef _WIN32
+#define SOCKTYPE uintptr_t /* avoids depending on winsock2.h for SOCKET */
+#else
+#define SOCKTYPE int
+#endif
+
+#if PG_MAJORVERSION_NUM >= 18
+std::once_flag postgresInitFlag;
+int postgresAuthDataHook( PGauthData type, PGconn *conn, void *data )
+{
+  if ( type != PQAUTHDATA_OAUTH_BEARER_TOKEN )
+  {
+    return -1;
+  }
+
+  PGoauthBearerRequest *request = static_cast<PGoauthBearerRequest *>( data );
+
+  if ( !QgsPostgresConnOAuthHandler::currentlyInScope() )
+  {
+    // might happen when connecting from outside of QgsPostgresConn, such as from psycopg in Python
+    // in practice the connection will likely fail, but at least we won't make anything worse/more confusing this way
+    return PQdefaultAuthDataHook( type, conn, data );
+  }
+
+  const QString authcfg = QgsPostgresConnOAuthHandler::currentAuthCfg();
+  QgsAuthMethod *method = QgsApplication::authManager()->configAuthMethod( authcfg );
+  if ( method && method->key() == "OAuth2"_L1 )
+  {
+    QNetworkRequest req;
+    // this _is_ a blocking call, however since it does run an event loop (so that the UI
+    // stays responsive, in case the connection is established from the main thread) and
+    // we never actually use the ability in libpq to connect asynchronously (at least not
+    // in QgsPostgresConn) we should be fine to keep this as a blocking call
+    const bool success = method->updateNetworkRequest( req, authcfg, u"postgres"_s );
+    if ( success )
+    {
+      const QByteArray token = req.rawHeader( "Token"_ba );
+      char *tokenStr = new char[token.size() + 1];
+      strncpy( tokenStr, token.constData(), token.size() + 1 );
+      request->token = tokenStr;
+      // libpq does not deallocate the token for us
+      request->cleanup = []( PGconn *, PGoauthBearerRequest *request ) { delete static_cast<const char *>( request->token ); };
+      return 1;
+    }
+    else
+    {
+      QgsLogger::warning( u"PostgreSQL: OAuth flow failed"_s );
+      return -1;
+    }
+  }
+  else
+  {
+    QgsMessageLog::logMessage( QgsPostgresConnOAuthHandler::tr( "PostgreSQL server request OAuth authentication, however connection in QGIS is not configured to use OAuth" ), QgsPostgresConnOAuthHandler::tr( "PostGIS" ) );
+    return -1;
+  }
+  // Success is indicated by returning an integer greater than zero.
+  return 1;
+}
+#endif
+
+thread_local QString QgsPostgresConnOAuthHandler::sAuthCfg;
+thread_local bool QgsPostgresConnOAuthHandler::sInScope = false;
+QgsPostgresConnOAuthHandler::QgsPostgresConnOAuthHandler( const QString &authcfg )
+{
+#if PG_MAJORVERSION_NUM >= 18
+  std::call_once( postgresInitFlag, []() {
+    PQsetAuthDataHook( postgresAuthDataHook );
+  } );
+#endif
+
+  if ( sInScope )
+  {
+    QgsLogger::warning( u"starting second postgres connection attempt while previous is not yet finished"_s );
+  }
+  sAuthCfg = authcfg;
+  sInScope = true;
+}
+
+QgsPostgresConnOAuthHandler::~QgsPostgresConnOAuthHandler()
+{
+  sAuthCfg = QString();
+  sInScope = false;
+}

--- a/src/providers/postgres/qgspostgresconnoauthhandler.h
+++ b/src/providers/postgres/qgspostgresconnoauthhandler.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+  qgspostgresconnoauthhandler.h
+
+ ---------------------
+ begin                : 27.12.2025
+ copyright            : (C) 2025 by Jan Dalheimer
+ email                : jan@dalheimer.de
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <QCoreApplication>
+#include <QString>
+
+/**
+ * Allows passing information about the authcfg to be used for a new database
+ * connection to the handler called by libpq.
+ *
+ * This is mostly a workaround since the PQconnect* functions do not allow
+ * passing any form of user data (which could otherwise have been used to pass
+ * the authcfg).
+ *
+ * It works by storing the current authcfg in a thread_local variable, which
+ * can then be retrieved by the handler called by libpq. The code flow from
+ * PQconnectdb to the handler is synchronous, so by using a thread_local
+ * variable this workaround should be fully safe against race conditions.
+ *
+ * An alternative approach would have been to use PQconnectStart in
+ * QgsPostgresConn, then storing information about the authcfg for the returned
+ * PGconn* somewhere where the handler (which is called after PQconnectStart
+ * has returned) could retrieve it. However, that would require replicating
+ * the functionality of pqConnectDBComplete which is a non-public function of
+ * libpq, so unless QgsPostgresConn is rewritten to use a non-blocking approach
+ * we can use this workaround.
+ *
+ * This is a RAII-style class, the only public interface is creation of an
+ * instance of this class. During the life time of that instance the given
+ * authcfg is used by the OAuth handler.
+ */
+class QgsPostgresConnOAuthHandler
+{
+    Q_DECLARE_TR_FUNCTIONS( QgsPostgresConnOAuthHandler );
+
+  public:
+    explicit QgsPostgresConnOAuthHandler( const QString &authcfg );
+    ~QgsPostgresConnOAuthHandler();
+
+    static QString currentAuthCfg() { return sAuthCfg; }
+    static bool currentlyInScope() { return sInScope; }
+
+  private:
+    thread_local static QString sAuthCfg;
+    thread_local static bool sInScope;
+};


### PR DESCRIPTION
## Description

This PR adds support for using OAuth authentication on PostgreSQL connections, as [introduced in PostgreSQL 18](https://www.postgresql.org/docs/current/auth-oauth.html).

The UI-changes are minimal, just that OAuth is available as an authentication method on PostgreSQL connections.

Given that this is still a very new feature in PostgreSQL, there is still relatively limited information available, and no other in-the-wild client implementations (that I've been able to find) to look at.

### Implementation details

The interface provided by libpq is intended to be non-blocking, however I've implemented it as a blocking operation for two reasons:

* QGIS doesn't actually need it to be non-blocking (`QgsPostgresConn` uses the blocking variant of the `PQconnect*` function)
* A non-blocking implementation would have been significantly more complex, and also platform dependent (the built-in flow in libpq/psql has separate implementations for Linux and BSD, and doesn't support Windows)

I haven't found any drawbacks during my testing, though it's of course possible that doing it blocking violates some assumption in libpq that may manifest as a bug later on. I've tried commenting the implementation quite extensively.

For non-`QgsPostgresConn`-connections (such as from `psycopg` or `QSqlDatabase`) we fallback to the default flow provided by libpq (which in practice will likely fail, but at least we don't make anything worse for those cases).

## Testing

I've tested these changes against Zitadel (IdP) and PostgreSQL 18.1 (as well as 17 do confirm that that still works), though any OAuth-compatible IdP should work.

I've used the dummy validator available here: https://github.com/sevensolutions/postgres18-oauth-playground/blob/main/README.md.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
