### PR TITLE
Fix QgsGeometry::deleteVertex docstring

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -801,12 +801,15 @@ not correspond to a valid vertex on this geometry
 Deletes the vertex at the given position number and item (first number
 is index 0)
 
+For Point geometries, this clears the geometry. For MultiPoint
+geometries, this removes the point geometry at the specified index. For
+other geometry types, this removes the vertex at the specified index. If
+the removal of the vertex would result in an invalid geometry (e.g. a
+LineString with less than 2 vertices), the geometry is cleared instead.
+
 :return: ``False`` if atVertex does not correspond to a valid vertex on
-         this geometry (including if this geometry is a Point), or if
-         the number of remaining vertices in the linestring would be
-         less than two. It is up to the caller to distinguish between
-         these error conditions. (Or maybe we add another method to this
-         object to help make the distinction?)
+         this geometry or if the geometry is null, ``True`` if the
+         vertex was successfully deleted or the geometry was cleared.
 %End
 
     bool toggleCircularAtVertex( int atVertex );

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -801,12 +801,15 @@ not correspond to a valid vertex on this geometry
 Deletes the vertex at the given position number and item (first number
 is index 0)
 
+For Point geometries, this clears the geometry. For MultiPoint
+geometries, this removes the point geometry at the specified index. For
+other geometry types, this removes the vertex at the specified index. If
+the removal of the vertex would result in an invalid geometry (e.g. a
+LineString with less than 2 vertices), the geometry is cleared instead.
+
 :return: ``False`` if atVertex does not correspond to a valid vertex on
-         this geometry (including if this geometry is a Point), or if
-         the number of remaining vertices in the linestring would be
-         less than two. It is up to the caller to distinguish between
-         these error conditions. (Or maybe we add another method to this
-         object to help make the distinction?)
+         this geometry or if the geometry is null, ``True`` if the
+         vertex was successfully deleted or the geometry was cleared.
 %End
 
     bool toggleCircularAtVertex( int atVertex );

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -849,15 +849,16 @@ class CORE_EXPORT QgsGeometry
     bool moveVertex( const QgsPoint &p, int atVertex );
 
     /**
-     * Deletes the vertex at the given position number and item
-     * (first number is index 0)
-     * \returns FALSE if atVertex does not correspond to a valid vertex
-     * on this geometry (including if this geometry is a Point),
-     * or if the number of remaining vertices in the linestring
-     * would be less than two.
-     * It is up to the caller to distinguish between
-     * these error conditions.  (Or maybe we add another method to this
-     * object to help make the distinction?)
+     * Deletes the vertex at the given position number and item (first number is index 0)
+     *
+     * For Point geometries, this clears the geometry.
+     * For MultiPoint geometries, this removes the point geometry at the specified index.
+     * For other geometry types, this removes the vertex at the specified index.
+     * If the removal of the vertex would result in an invalid geometry (e.g. a LineString with less than 2 vertices),
+     * the geometry is cleared instead.
+     *
+     * \returns FALSE if atVertex does not correspond to a valid vertex on this geometry or if the geometry is null,
+     * TRUE if the vertex was successfully deleted or the geometry was cleared.
      */
     bool deleteVertex( int atVertex );
 


### PR DESCRIPTION
The previous docstring was not correct. 
In fact, geometry is cleared if a linestring ends up with less than 2 points or a polygon ends up with less than 3. `deleteVertex` method of each geometry type handles such cases and geometries are cleared within those methods. In such cases, TRUE is returned.