### PR TITLE
Remove superfluous std::sort from atlas generation

### DIFF
--- a/src/3d/qgstextureatlasgenerator.cpp
+++ b/src/3d/qgstextureatlasgenerator.cpp
@@ -125,7 +125,6 @@ QgsTextureAtlas QgsTextureAtlasGenerator::createFromRects( const QVector<QRect> 
 {
   std::vector< QgsTextureRect > rects;
   rects.reserve( rectangles.size() );
-  int index = 0;
   for ( const QRect &rect : rectangles )
   {
     rects.emplace_back( QgsTextureRect( rectpack2D::rect_xywh( 0, 0, rect.width(), rect.height() ) ) );
@@ -137,7 +136,6 @@ QgsTextureAtlas QgsTextureAtlasGenerator::createFromImages( const QVector<QImage
 {
   std::vector< QgsTextureRect > rects;
   rects.reserve( images.size() );
-  int index = 0;
   for ( const QImage &image : images )
   {
     rects.emplace_back( QgsTextureRect( rectpack2D::rect_xywh( 0, 0, image.width(), image.height() ), image ) );

--- a/src/3d/qgstextureatlasgenerator.cpp
+++ b/src/3d/qgstextureatlasgenerator.cpp
@@ -182,12 +182,6 @@ QgsTextureAtlas QgsTextureAtlasGenerator::generateAtlas( std::vector< QgsTexture
   if ( !result )
     return QgsTextureAtlas();
 
-  // rectpack2D::find_best_packing will have rearranged rects. Sort it back to the original order
-  // so that we can retrieve the results by their original indices.
-  std::sort( rects.begin(), rects.end(), []( const QgsTextureRect &a, const QgsTextureRect &b ) {
-    return a.id < b.id;
-  } );
-
   QgsTextureAtlas res;
   res.mRects = std::move( rects );
   res.mAtlasSize = QSize( resultSize.w, resultSize.h );

--- a/src/3d/qgstextureatlasgenerator.cpp
+++ b/src/3d/qgstextureatlasgenerator.cpp
@@ -27,9 +27,8 @@
 class QgsTextureRect
 {
   public:
-    QgsTextureRect( const rectpack2D::rect_xywh &rect, int id, const QImage &image = QImage() )
+    QgsTextureRect( const rectpack2D::rect_xywh &rect, const QImage &image = QImage() )
       : rect( rect )
-      , id( id )
       , image( image )
     {
     }
@@ -50,7 +49,6 @@ class QgsTextureRect
     }
 
     rectpack2D::rect_xywh rect;
-    int id = 0;
     QImage image;
 };
 
@@ -130,7 +128,7 @@ QgsTextureAtlas QgsTextureAtlasGenerator::createFromRects( const QVector<QRect> 
   int index = 0;
   for ( const QRect &rect : rectangles )
   {
-    rects.emplace_back( QgsTextureRect( rectpack2D::rect_xywh( 0, 0, rect.width(), rect.height() ), index++ ) );
+    rects.emplace_back( QgsTextureRect( rectpack2D::rect_xywh( 0, 0, rect.width(), rect.height() ) ) );
   }
   return generateAtlas( std::move( rects ), maxSide );
 }
@@ -142,7 +140,7 @@ QgsTextureAtlas QgsTextureAtlasGenerator::createFromImages( const QVector<QImage
   int index = 0;
   for ( const QImage &image : images )
   {
-    rects.emplace_back( QgsTextureRect( rectpack2D::rect_xywh( 0, 0, image.width(), image.height() ), index++, image ) );
+    rects.emplace_back( QgsTextureRect( rectpack2D::rect_xywh( 0, 0, image.width(), image.height() ), image ) );
   }
   return generateAtlas( std::move( rects ), maxSide );
 }


### PR DESCRIPTION
## Description

The `rectpack2D::find_best_packing` function does *not* in fact alter the input container's order.  
This is the only place the actual `subjects` argument is referenced in the `rectpack2D::find_best_packing` definition:

```cpp
			auto& initial_pointers = orders[0];
			initial_pointers.clear();

			for (auto& s : subjects) {
				auto& r = s.get_rect();

				if (r.area() > 0) {
					initial_pointers.emplace_back(std::addressof(r));
				}
			}
```

The library allocates its own order arrays for each comparator, and manipulates these arrays, not the input container.
Since the input `std::vector< QgsTextureRect > rects` in `generateAtlas` is already generated using `index++` for every subsequent element, there seems to be no need to ever sort these elements.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
