### PR TITLE
Unaccent layers, bookmarks, actions, layouts and settings in locator and processing toolbox search

### DIFF
--- a/src/app/locator/qgsactionlocatorfilter.cpp
+++ b/src/app/locator/qgsactionlocatorfilter.cpp
@@ -17,6 +17,8 @@
 
 #include "qgsactionlocatorfilter.h"
 
+#include "qgsstringutils.h"
+
 #include <QAction>
 #include <QMenu>
 #include <QRegularExpression>
@@ -108,7 +110,7 @@ void QgsActionLocatorFilter::searchActions( const QString &string, QWidget *pare
     result.displayString = searchText;
     result.setUserData( QVariant::fromValue( action ) );
     result.icon = action->icon();
-    result.score = fuzzyScore( result.displayString, string );
+    result.score = fuzzyScore( QgsStringUtils::unaccent( result.displayString ), QgsStringUtils::unaccent( string ) );
 
     if ( result.score > 0 )
     {

--- a/src/app/locator/qgsbookmarklocatorfilter.cpp
+++ b/src/app/locator/qgsbookmarklocatorfilter.cpp
@@ -20,6 +20,7 @@
 #include "qgisapp.h"
 #include "qgsapplication.h"
 #include "qgsfeedback.h"
+#include "qgsstringutils.h"
 
 #include "moc_qgsbookmarklocatorfilter.cpp"
 
@@ -59,7 +60,7 @@ void QgsBookmarkLocatorFilter::fetchResults( const QString &string, const QgsLoc
       continue;
     }
 
-    result.score = fuzzyScore( result.displayString, string );
+    result.score = fuzzyScore( QgsStringUtils::unaccent( result.displayString ), QgsStringUtils::unaccent( string ) );
 
     if ( result.score > 0 )
       emit resultFetched( result );

--- a/src/app/locator/qgslayertreelocatorfilter.cpp
+++ b/src/app/locator/qgslayertreelocatorfilter.cpp
@@ -21,6 +21,7 @@
 #include "qgsiconutils.h"
 #include "qgslayertree.h"
 #include "qgsproject.h"
+#include "qgsstringutils.h"
 
 #include "moc_qgslayertreelocatorfilter.cpp"
 
@@ -55,7 +56,7 @@ void QgsLayerTreeLocatorFilter::fetchResults( const QString &string, const QgsLo
       continue;
     }
 
-    result.score = fuzzyScore( result.displayString, string );
+    result.score = fuzzyScore( QgsStringUtils::unaccent( result.displayString ), QgsStringUtils::unaccent( string ) );
 
     if ( result.score > 0 )
       emit resultFetched( result );

--- a/src/app/locator/qgslayoutlocatorfilter.cpp
+++ b/src/app/locator/qgslayoutlocatorfilter.cpp
@@ -21,6 +21,7 @@
 #include "qgslayoutmanager.h"
 #include "qgsmasterlayoutinterface.h"
 #include "qgsproject.h"
+#include "qgsstringutils.h"
 
 #include "moc_qgslayoutlocatorfilter.cpp"
 
@@ -52,7 +53,7 @@ void QgsLayoutLocatorFilter::fetchResults( const QString &string, const QgsLocat
       continue;
     }
 
-    result.score = fuzzyScore( result.displayString, string );
+    result.score = fuzzyScore( QgsStringUtils::unaccent( result.displayString ), QgsStringUtils::unaccent( string ) );
 
     if ( result.score > 0 )
       emit resultFetched( result );

--- a/src/app/locator/qgssettingslocatorfilter.cpp
+++ b/src/app/locator/qgssettingslocatorfilter.cpp
@@ -18,6 +18,7 @@
 #include "qgssettingslocatorfilter.h"
 
 #include "qgisapp.h"
+#include "qgsstringutils.h"
 
 #include "moc_qgssettingslocatorfilter.cpp"
 
@@ -70,7 +71,7 @@ void QgsSettingsLocatorFilter::fetchResults( const QString &string, const QgsLoc
       continue;
     }
 
-    result.score = fuzzyScore( result.displayString, string );
+    result.score = fuzzyScore( QgsStringUtils::unaccent( result.displayString ), QgsStringUtils::unaccent( string ) );
 
     if ( result.score > 0 )
       emit resultFetched( result );

--- a/src/gui/processing/qgsprocessingtoolboxmodel.cpp
+++ b/src/gui/processing/qgsprocessingtoolboxmodel.cpp
@@ -21,6 +21,7 @@
 #include "qgsprocessingfavoritealgorithmmanager.h"
 #include "qgsprocessingrecentalgorithmlog.h"
 #include "qgsprocessingregistry.h"
+#include "qgsstringutils.h"
 #include "qgsvectorlayer.h"
 
 #include <QMimeData>
@@ -899,9 +900,10 @@ bool QgsProcessingToolboxProxyModel::filterAcceptsRow( int sourceRow, const QMod
       for ( const QString &part : partsToMatch )
       {
         bool found = false;
+        const QString unaccentedPart = QgsStringUtils::unaccent( part );
         for ( const QString &partToSearch : std::as_const( partsToSearch ) )
         {
-          if ( partToSearch.contains( part, Qt::CaseInsensitive ) )
+          if ( QgsStringUtils::unaccent( partToSearch ).contains( unaccentedPart, Qt::CaseInsensitive ) )
           {
             found = true;
             break;
@@ -954,9 +956,10 @@ bool QgsProcessingToolboxProxyModel::filterAcceptsRow( int sourceRow, const QMod
       for ( const QString &part : partsToMatch )
       {
         bool found = false;
+        const QString unaccentedPart = QgsStringUtils::unaccent( part );
         for ( const QString &partToSearch : std::as_const( partsToSearch ) )
         {
-          if ( partToSearch.contains( part, Qt::CaseInsensitive ) )
+          if ( QgsStringUtils::unaccent( partToSearch ).contains( unaccentedPart, Qt::CaseInsensitive ) )
           {
             found = true;
             break;


### PR DESCRIPTION
Use the unaccent function to improve locator and search more easily for layer names, layouts and bookmarks.

Unaccent also now works for the search in the processing toolbox.

E.g. from now on if a user searches for "creme" the locator will match a layer named "crème", and vice versa.

I tested all by hand (except the locator actions filter as I got lazy). Sometimes the CI fails but unrelated. I don't know if the processing toolbox search should have come in another pull request, I just added it here.

Fixes https://github.com/qgis/QGIS/issues/39475