### PR TITLE
Fix Nominatim URL in batch geocode algorithm help

### DIFF
--- a/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.cpp
+++ b/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.cpp
@@ -58,7 +58,7 @@ QgsBatchNominatimGeocodeAlgorithm *QgsBatchNominatimGeocodeAlgorithm::createInst
 
 QString QgsBatchNominatimGeocodeAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm performs batch geocoding using the <a href=\"#\">Nominatim</a> service against an input layer string field.\n\n"
+  return QObject::tr( "This algorithm performs batch geocoding using the <a href=\"https://nominatim.org/\">Nominatim</a> service against an input layer string field.\n\n"
                       "The output layer will have a point geometry reflecting the geocoded location as well as a number of attributes associated to the geocoded location." );
 }
 

--- a/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.cpp
+++ b/src/analysis/processing/qgsalgorithmbatchnominatimgeocode.cpp
@@ -58,7 +58,7 @@ QgsBatchNominatimGeocodeAlgorithm *QgsBatchNominatimGeocodeAlgorithm::createInst
 
 QString QgsBatchNominatimGeocodeAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm performs batch geocoding using the <a href=\"https://nominatim.org/\">Nominatim</a> service against an input layer string field.\n\n"
+  return QObject::tr( "This algorithm performs batch geocoding using the <a href=\"https://nominatim.qgis.org/\">Nominatim</a> service against an input layer string field.\n\n"
                       "The output layer will have a point geometry reflecting the geocoded location as well as a number of attributes associated to the geocoded location." );
 }
 


### PR DESCRIPTION
## Description
### What I did

- Regarding the processing tool "Batch Nominatim geocoder", the "Nominatim" in the help text was displayed as a link, but the link destination was not set. Therefore, I have added the link destination.

<img width="800" height="663" alt="スクリーンショット 2026-01-05 17 59 26" src="https://github.com/user-attachments/assets/d9813e89-d43e-4d14-addf-5bd06c1febf0" />

### Notes

- I specified `https://nominatim.org/` as the link destination, but please let me know if there is a more appropriate link.