### PR TITLE
Fix saving unsaved project into Postgre DB

### DIFF
--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -1141,6 +1141,8 @@ void QgsPostgresDataItemGuiProvider::saveCurrentProject( QgsPGSchemaItem *schema
   pgProjectUri.schemaName = schemaItem->name();
   pgProjectUri.projectName = project->title().isEmpty() ? project->baseName() : project->title();
 
+  const QString previousTitle = project->title();
+
   if ( pgProjectUri.projectName.isEmpty() )
   {
     bool ok;
@@ -1148,6 +1150,7 @@ void QgsPostgresDataItemGuiProvider::saveCurrentProject( QgsPGSchemaItem *schema
     if ( ok && !projectName.isEmpty() )
     {
       pgProjectUri.projectName = projectName;
+      project->setTitle( projectName );
     }
     else
     {
@@ -1173,7 +1176,7 @@ void QgsPostgresDataItemGuiProvider::saveCurrentProject( QgsPGSchemaItem *schema
     notify( tr( "Save Project" ), tr( "Project “%1” exist in the database. Overwriting it." ).arg( pgProjectUri.projectName ), context, Qgis::MessageLevel::Info );
   }
 
-  QString previousFileName = project->fileName();
+  const QString previousFileName = project->fileName();
   project->setFileName( projectUri );
 
   // write project to the database
@@ -1183,6 +1186,7 @@ void QgsPostgresDataItemGuiProvider::saveCurrentProject( QgsPGSchemaItem *schema
     notify( tr( "Save Project" ), tr( "Unable to save project “%1” to “%2”." ).arg( project->title(), schemaItem->name() ), context, Qgis::MessageLevel::Warning );
     conn->unref();
     project->setFileName( previousFileName );
+    project->setTitle( previousTitle );
     return;
   }
 

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -1173,21 +1173,20 @@ void QgsPostgresDataItemGuiProvider::saveCurrentProject( QgsPGSchemaItem *schema
     notify( tr( "Save Project" ), tr( "Project “%1” exist in the database. Overwriting it." ).arg( pgProjectUri.projectName ), context, Qgis::MessageLevel::Info );
   }
 
-  // read the project, set title and new filename
-  QgsProject savedProject;
-  savedProject.read( project->fileName() );
-  savedProject.setFileName( projectUri );
+  QString previousFileName = project->fileName();
+  project->setFileName( projectUri );
 
   // write project to the database
-  const bool success = savedProject.write();
+  const bool success = project->write();
   if ( !success )
   {
-    notify( tr( "Save Project" ), tr( "Unable to save project “%1” to “%2”." ).arg( savedProject.title(), schemaItem->name() ), context, Qgis::MessageLevel::Warning );
+    notify( tr( "Save Project" ), tr( "Unable to save project “%1” to “%2”." ).arg( project->title(), schemaItem->name() ), context, Qgis::MessageLevel::Warning );
     conn->unref();
+    project->setFileName( previousFileName );
     return;
   }
 
-  notify( tr( "Save Project" ), tr( "Project “%1” saved to schema “%2”." ).arg( savedProject.title(), schemaItem->name() ), context, Qgis::MessageLevel::Info );
+  notify( tr( "Save Project" ), tr( "Project “%1” saved to schema “%2”." ).arg( project->title(), schemaItem->name() ), context, Qgis::MessageLevel::Info );
 
   // refresh
   schemaItem->refresh();


### PR DESCRIPTION
## Description

If project was not saved yet it could not be saved into Postgre DB. Try updating filename to DB location, if it cannot be saved there, reuse previous location. Previously the project was loaded from filename, but that does not work if file is not saved yet - ends with empty project.

Fixes #64412 

Funded by: Ocean Winds