### PR TITLE
Avoid protected inheritance for classes exposed to sip

### DIFF
--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshadvancedediting.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshadvancedediting.sip.in
@@ -9,7 +9,7 @@
 
 
 
-class QgsMeshAdvancedEditing : protected QgsTopologicalMesh::Changes /Abstract/
+class QgsMeshAdvancedEditing : QgsTopologicalMesh::Changes /Abstract/
 {
 %Docstring(signature="appended")
 Abstract class that can be derived to implement advanced editing on

--- a/python/PyQt6/gui/auto_generated/callouts/qgscalloutwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/callouts/qgscalloutwidget.sip.in
@@ -8,7 +8,7 @@
 
 
 
-class QgsCalloutWidget : QWidget, protected QgsExpressionContextGenerator
+class QgsCalloutWidget : QWidget, QgsExpressionContextGenerator
 {
 %Docstring(signature="appended")
 Base class for widgets which allow control over the properties of

--- a/python/PyQt6/gui/auto_generated/labeling/qgslabelsettingswidgetbase.sip.in
+++ b/python/PyQt6/gui/auto_generated/labeling/qgslabelsettingswidgetbase.sip.in
@@ -10,7 +10,7 @@
 
 
 
-class QgsLabelSettingsWidgetBase : QgsPanelWidget, protected QgsExpressionContextGenerator
+class QgsLabelSettingsWidgetBase : QgsPanelWidget, QgsExpressionContextGenerator
 {
 %Docstring(signature="appended")
 Base class for widgets which allow customization of label engine

--- a/python/PyQt6/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
@@ -13,7 +13,7 @@
 template<T>
 class QgsMapToolEditBlankSegments;
 
-class QgsSymbolLayerWidget : QWidget, protected QgsExpressionContextGenerator
+class QgsSymbolLayerWidget : QWidget, QgsExpressionContextGenerator
 {
 %Docstring(signature="appended")
 Abstract base class for widgets used to configure

--- a/python/core/auto_generated/mesh/qgsmeshadvancedediting.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshadvancedediting.sip.in
@@ -9,7 +9,7 @@
 
 
 
-class QgsMeshAdvancedEditing : protected QgsTopologicalMesh::Changes /Abstract/
+class QgsMeshAdvancedEditing : QgsTopologicalMesh::Changes /Abstract/
 {
 %Docstring(signature="appended")
 Abstract class that can be derived to implement advanced editing on

--- a/python/gui/auto_generated/callouts/qgscalloutwidget.sip.in
+++ b/python/gui/auto_generated/callouts/qgscalloutwidget.sip.in
@@ -8,7 +8,7 @@
 
 
 
-class QgsCalloutWidget : QWidget, protected QgsExpressionContextGenerator
+class QgsCalloutWidget : QWidget, QgsExpressionContextGenerator
 {
 %Docstring(signature="appended")
 Base class for widgets which allow control over the properties of

--- a/python/gui/auto_generated/labeling/qgslabelsettingswidgetbase.sip.in
+++ b/python/gui/auto_generated/labeling/qgslabelsettingswidgetbase.sip.in
@@ -10,7 +10,7 @@
 
 
 
-class QgsLabelSettingsWidgetBase : QgsPanelWidget, protected QgsExpressionContextGenerator
+class QgsLabelSettingsWidgetBase : QgsPanelWidget, QgsExpressionContextGenerator
 {
 %Docstring(signature="appended")
 Base class for widgets which allow customization of label engine

--- a/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
@@ -13,7 +13,7 @@
 template<T>
 class QgsMapToolEditBlankSegments;
 
-class QgsSymbolLayerWidget : QWidget, protected QgsExpressionContextGenerator
+class QgsSymbolLayerWidget : QWidget, QgsExpressionContextGenerator
 {
 %Docstring(signature="appended")
 Abstract base class for widgets used to configure

--- a/src/core/mesh/qgsmeshadvancedediting.h
+++ b/src/core/mesh/qgsmeshadvancedediting.h
@@ -35,7 +35,7 @@ class QgsExpressionContext;
  *
  * \since QGIS 3.22
  */
-class CORE_EXPORT QgsMeshAdvancedEditing : protected QgsTopologicalMesh::Changes SIP_ABSTRACT
+class CORE_EXPORT QgsMeshAdvancedEditing : public QgsTopologicalMesh::Changes SIP_ABSTRACT
 {
   public:
 

--- a/src/gui/callouts/qgscalloutwidget.h
+++ b/src/gui/callouts/qgscalloutwidget.h
@@ -30,7 +30,7 @@
  * \brief Base class for widgets which allow control over the properties of callouts.
  * \since QGIS 3.10
  */
-class GUI_EXPORT QgsCalloutWidget : public QWidget, protected QgsExpressionContextGenerator
+class GUI_EXPORT QgsCalloutWidget : public QWidget, public QgsExpressionContextGenerator
 {
     Q_OBJECT
 

--- a/src/gui/labeling/qgslabelsettingswidgetbase.h
+++ b/src/gui/labeling/qgslabelsettingswidgetbase.h
@@ -35,7 +35,7 @@ class QgsPropertyOverrideButton;
  * \brief Base class for widgets which allow customization of label engine properties, such as label placement settings.
  * \since QGIS 3.12
  */
-class GUI_EXPORT QgsLabelSettingsWidgetBase : public QgsPanelWidget, protected QgsExpressionContextGenerator
+class GUI_EXPORT QgsLabelSettingsWidgetBase : public QgsPanelWidget, public QgsExpressionContextGenerator
 {
     Q_OBJECT
 

--- a/src/gui/layertree/qgslayertreeembeddedconfigwidget.h
+++ b/src/gui/layertree/qgslayertreeembeddedconfigwidget.h
@@ -28,7 +28,7 @@ class QgsMapLayer;
  * \class QgsLayerTreeEmbeddedConfigWidget
  * \brief A widget to configure layer tree embedded widgets for a particular map layer.
  */
-class GUI_EXPORT QgsLayerTreeEmbeddedConfigWidget : public QWidget, protected Ui::QgsLayerTreeEmbeddedConfigWidgetBase
+class GUI_EXPORT QgsLayerTreeEmbeddedConfigWidget : public QWidget, private Ui::QgsLayerTreeEmbeddedConfigWidgetBase
 {
     Q_OBJECT
   public:

--- a/src/gui/providers/qgsabstractdbsourceselect.h
+++ b/src/gui/providers/qgsabstractdbsourceselect.h
@@ -32,7 +32,7 @@ class QItemDelegate;
  * \brief Base class for database source widget selectors.
  * \since QGIS 3.24
  */
-class GUI_EXPORT QgsAbstractDbSourceSelect : public QgsAbstractDataSourceWidget, protected Ui::QgsDbSourceSelectBase
+class GUI_EXPORT QgsAbstractDbSourceSelect : public QgsAbstractDataSourceWidget, public Ui::QgsDbSourceSelectBase
 {
     Q_OBJECT
   public:

--- a/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
+++ b/src/gui/providers/sensorthings/qgssensorthingssourcewidget.h
@@ -129,7 +129,7 @@ class QgsSensorThingsRemoveExpansionDelegate : public QStyledItemDelegate SIP_SK
 };
 
 
-class QgsSensorThingsSourceWidget : public QgsProviderSourceWidget, protected Ui::QgsSensorThingsSourceWidgetBase
+class QgsSensorThingsSourceWidget : public QgsProviderSourceWidget, private Ui::QgsSensorThingsSourceWidgetBase
 {
     Q_OBJECT
 

--- a/src/gui/providers/sensorthings/qgssensorthingssubseteditor.h
+++ b/src/gui/providers/sensorthings/qgssensorthingssubseteditor.h
@@ -33,7 +33,7 @@ class QgsFieldProxyModel;
 ///@cond PRIVATE
 #define SIP_NO_FILE
 
-class QgsSensorThingsSubsetEditor : public QgsSubsetStringEditorInterface, protected Ui::QgsSensorThingsSubsetEditorBase
+class QgsSensorThingsSubsetEditor : public QgsSubsetStringEditorInterface, private Ui::QgsSensorThingsSubsetEditorBase
 {
     Q_OBJECT
 

--- a/src/gui/qgsowssourceselect.h
+++ b/src/gui/qgsowssourceselect.h
@@ -50,7 +50,7 @@ class QgsOWSSourceWidget;
  * The user can then connect and add
  * layers from the WCS server to the map canvas.
  */
-class GUI_EXPORT QgsOWSSourceSelect : public QgsAbstractDataSourceWidget, protected Ui::QgsOWSSourceSelectBase
+class GUI_EXPORT QgsOWSSourceSelect : public QgsAbstractDataSourceWidget, public Ui::QgsOWSSourceSelectBase
 {
     Q_OBJECT
 

--- a/src/gui/qgsrichtexteditor.h
+++ b/src/gui/qgsrichtexteditor.h
@@ -57,7 +57,7 @@ class QgsCodeEditorHTML;
  *
  * \since QGIS 3.20
  */
-class GUI_EXPORT QgsRichTextEditor : public QWidget, protected Ui::QgsRichTextEditorBase
+class GUI_EXPORT QgsRichTextEditor : public QWidget, private Ui::QgsRichTextEditorBase
 {
     Q_OBJECT
   public:

--- a/src/gui/qgstablewidgetbase.h
+++ b/src/gui/qgstablewidgetbase.h
@@ -31,7 +31,7 @@
  * Child classes must call init(QAbstractTableModel*) from their constructor.
  *
  */
-class GUI_EXPORT QgsTableWidgetBase : public QWidget, protected Ui::QgsTableWidgetUiBase
+class GUI_EXPORT QgsTableWidgetBase : public QWidget, public Ui::QgsTableWidgetUiBase
 {
     Q_OBJECT
   public:

--- a/src/gui/qgstextformatwidget.h
+++ b/src/gui/qgstextformatwidget.h
@@ -48,7 +48,7 @@ class QgsCharacterSelectorDialog;
  *
  */
 
-class GUI_EXPORT QgsTextFormatWidget : public QWidget, public QgsExpressionContextGenerator, protected Ui::QgsTextFormatWidgetBase
+class GUI_EXPORT QgsTextFormatWidget : public QWidget, public QgsExpressionContextGenerator, public Ui::QgsTextFormatWidgetBase
 {
     Q_OBJECT
     Q_PROPERTY( QgsTextFormat format READ format )

--- a/src/gui/raster/qgscolorrampshaderwidget.h
+++ b/src/gui/raster/qgscolorrampshaderwidget.h
@@ -46,7 +46,7 @@ class QgsLocaleAwareNumericLineEditDelegate;
  *
  * \since QGIS 3.4
  */
-class GUI_EXPORT QgsColorRampShaderWidget : public QWidget, protected Ui::QgsColorRampShaderWidgetBase
+class GUI_EXPORT QgsColorRampShaderWidget : public QWidget, private Ui::QgsColorRampShaderWidgetBase
 {
     Q_OBJECT
 

--- a/src/gui/symbology/qgs25drendererwidget.h
+++ b/src/gui/symbology/qgs25drendererwidget.h
@@ -29,7 +29,7 @@ class Qgs25DRenderer;
  * \class Qgs25DRendererWidget
  * \brief A widget for configuring a Qgs25DRenderer.
  */
-class GUI_EXPORT Qgs25DRendererWidget : public QgsRendererWidget, protected Ui::Qgs25DRendererWidgetBase
+class GUI_EXPORT Qgs25DRendererWidget : public QgsRendererWidget, private Ui::Qgs25DRendererWidgetBase
 {
     Q_OBJECT
 

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -38,7 +38,7 @@ class GUI_EXPORT QgsMapToolEditBlankSegments;
  * \class QgsSymbolLayerWidget
  * \brief Abstract base class for widgets used to configure QgsSymbolLayer classes.
  */
-class GUI_EXPORT QgsSymbolLayerWidget : public QWidget, protected QgsExpressionContextGenerator
+class GUI_EXPORT QgsSymbolLayerWidget : public QWidget, public QgsExpressionContextGenerator
 {
     Q_OBJECT
 

--- a/src/gui/vector/qgsattributesformview.h
+++ b/src/gui/vector/qgsattributesformview.h
@@ -33,7 +33,7 @@ class QgsAttributesFormTreeViewIndicator;
  * \ingroup gui
  * \since QGIS 3.44
  */
-class GUI_EXPORT QgsAttributesFormBaseView : public QTreeView, protected QgsExpressionContextGenerator
+class GUI_EXPORT QgsAttributesFormBaseView : public QTreeView, public QgsExpressionContextGenerator
 {
     Q_OBJECT
 


### PR DESCRIPTION
Support for these are deprecated in sip, and is marked for removal in sip 7
