### PR TITLE
Fix logic error in QgsCoordinateReferenceSystemProxyModel sorting

### DIFF
--- a/src/core/diagram/qgshistogramdiagram.cpp
+++ b/src/core/diagram/qgshistogramdiagram.cpp
@@ -145,13 +145,13 @@ QSizeF QgsHistogramDiagram::diagramSize( const QgsAttributes &attributes, const 
   {
     case QgsDiagramSettings::Up:
     case QgsDiagramSettings::Down:
-      mScaleFactor = maxValue / s.size.height();
+      mScaleFactor = s.size.height() / maxValue;
       size.scale( s.barWidth * s.categoryColors.size() + spacing * std::max( 0, static_cast<int>( s.categoryAttributes.size() ) - 1 ), s.size.height(), Qt::IgnoreAspectRatio );
       break;
 
     case QgsDiagramSettings::Right:
     case QgsDiagramSettings::Left:
-      mScaleFactor = maxValue / s.size.width();
+      mScaleFactor = s.size.width() / maxValue;
       size.scale( s.size.width(), s.barWidth * s.categoryColors.size() + spacing * std::max( 0, static_cast<int>( s.categoryAttributes.size() ) - 1 ), Qt::IgnoreAspectRatio );
       break;
   }

--- a/src/gui/proj/qgscoordinatereferencesystemmodel.cpp
+++ b/src/gui/proj/qgscoordinatereferencesystemmodel.cpp
@@ -753,10 +753,12 @@ bool QgsCoordinateReferenceSystemProxyModel::lessThan( const QModelIndex &left, 
   const QString rightStr = sourceModel()->data( right ).toString().toLower();
 
   if ( leftType == QgsCoordinateReferenceSystemModelNode::NodeGroup )
-  {
+{
     // both are groups -- ensure USER group comes last, and CUSTOM group comes first
     const QString leftGroupId = sourceModel()->data( left, static_cast<int>( QgsCoordinateReferenceSystemModel::CustomRole::GroupId ) ).toString();
-    const QString rightGroupId = sourceModel()->data( left, static_cast<int>( QgsCoordinateReferenceSystemModel::CustomRole::GroupId ) ).toString();
+    // FIX: Change 'left' to 'right' below
+    const QString rightGroupId = sourceModel()->data( right, static_cast<int>( QgsCoordinateReferenceSystemModel::CustomRole::GroupId ) ).toString();
+    
     if ( leftGroupId == QLatin1String( "USER" ) )
       return false;
     if ( rightGroupId == QLatin1String( "USER" ) )
@@ -767,7 +769,6 @@ bool QgsCoordinateReferenceSystemProxyModel::lessThan( const QModelIndex &left, 
     if ( rightGroupId == QLatin1String( "CUSTOM" ) )
       return false;
   }
-
   // default sort is alphabetical order
   return QString::localeAwareCompare( leftStr, rightStr ) < 0;
 }


### PR DESCRIPTION
i have fixed a regression in the CRS selection tree where groups were not sorting correctly. I identified a logic error in lessThan where the rightGroupId was being incorrectly assigned using the left model index instead of the right index.