### PR TITLE
qgssfcgalengine: Use source_location to replace __FUNCTION__ macros

### DIFF
--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -59,12 +59,12 @@ sfcgal::shared_prim sfcgal::make_shared_prim( sfcgal::primitive *prim )
 }
 #endif
 
-bool sfcgal::ErrorHandler::hasSucceedOrStack( QString *errorMsg, const char *fromFile, const char *fromFunc, int fromLine )
+bool sfcgal::ErrorHandler::hasSucceedOrStack( QString *errorMsg, const std::source_location &location )
 {
   bool succeed = isTextEmpty();
   if ( !succeed )
   {
-    addText( "relaying error from: ", fromFile, fromFunc, fromLine );
+    addText( "relaying error from: ", location );
     if ( errorMsg )
     {
       errorMsg->append( errorMessages.first() );
@@ -82,7 +82,7 @@ int sfcgal::errorCallback( const char *fmt, ... )
   vsnprintf( buffer, sizeof buffer, fmt, ap );
   va_end( ap );
 
-  sfcgal::errorHandler()->addText( u"SFCGAL error occurred: %1"_s.arg( buffer ), __FILE__, __FUNCTION__, __LINE__ );
+  sfcgal::errorHandler()->addText( u"SFCGAL error occurred: %1"_s.arg( buffer ) );
 
   return static_cast<int>( strlen( buffer ) );
 }
@@ -96,7 +96,7 @@ int sfcgal::warningCallback( const char *fmt, ... )
   vsnprintf( buffer, sizeof buffer, fmt, ap );
   va_end( ap );
 
-  sfcgal::errorHandler()->addText( u"SFCGAL warning occurred: %1"_s.arg( buffer ), __FILE__, __FUNCTION__, __LINE__ );
+  sfcgal::errorHandler()->addText( u"SFCGAL warning occurred: %1"_s.arg( buffer ) );
 
   return static_cast<int>( strlen( buffer ) );
 }
@@ -132,9 +132,12 @@ bool sfcgal::ErrorHandler::isTextEmpty() const
   return errorMessages.isEmpty();
 }
 
-void sfcgal::ErrorHandler::addText( const QString &msg, const char *fromFile, const char *fromFunc, int fromLine )
+void sfcgal::ErrorHandler::addText( const QString &msg, const std::source_location &location )
 {
-  QString txt = QString( "%2 (%3:%4) %1" ).arg( msg ).arg( fromFunc ).arg( fromFile ).arg( fromLine );
+  QString txt = QString( "%2 (%3:%4) %1" ).arg( msg ) //
+                .arg( QString::fromStdString( location.function_name() ) ) //
+                .arg( QString::fromStdString( location.file_name() ) ) //
+                .arg( location.line() );
 
   errorMessages.push_front( txt );
 }
@@ -300,8 +303,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsSfcgalEngine::toAbstractGeometry( const 
     Qgis::WkbType sfcgalType = QgsSfcgalEngine::wkbType( geom );
     sfcgal::errorHandler()->addText( u"WKB contains unmanaged geometry type (WKB:%1 / SFCGAL:%2"_s //
                                      .arg( static_cast<int>( wkbPtr.readHeader() ) )                          //
-                                     .arg( static_cast<int>( sfcgalType ) ),
-                                     __FILE__, __FUNCTION__, __LINE__ );
+                                     .arg( static_cast<int>( sfcgalType ) ) );
   }
 
   return out;
@@ -425,8 +427,7 @@ Qgis::WkbType QgsSfcgalEngine::wkbType( const sfcgal::geometry *geom, QString *e
   if ( qgisType >= Qgis::WkbType::Unknown && qgisType <= Qgis::WkbType::TriangleZM )
     return qgisType;
 
-  sfcgal::errorHandler()->addText( u"WKB type '%1' is not known from QGIS"_s.arg( wkbType ), //
-                                   __FILE__, __FUNCTION__, __LINE__ );
+  sfcgal::errorHandler()->addText( u"WKB type '%1' is not known from QGIS"_s.arg( wkbType ) );
   return Qgis::WkbType::Unknown;
 }
 

--- a/src/core/geometry/qgssfcgalengine.h
+++ b/src/core/geometry/qgssfcgalengine.h
@@ -42,34 +42,34 @@ class QgsSfcgalGeometry;
 #define SFCGAL_VERSION SFCGAL_MAKE_VERSION( SFCGAL_VERSION_MAJOR_INT, SFCGAL_VERSION_MINOR_INT, SFCGAL_VERSION_PATCH_INT )
 
 /// check if \a ptr is not null else add stacktrace entry and return the \a defaultObj
-#define CHECK_NOT_NULL( ptr, defaultObj )                                                                                \
-  if ( !( ptr ) )                                                                                                        \
-  {                                                                                                                      \
-    sfcgal::errorHandler()->addText( QString( "Null pointer for '%1'" ).arg( #ptr ), __FILE__, __FUNCTION__, __LINE__ ); \
-    return ( defaultObj );                                                                                               \
+#define CHECK_NOT_NULL( ptr, defaultObj )                                              \
+  if ( !( ptr ) )                                                                      \
+  {                                                                                    \
+    sfcgal::errorHandler()->addText( QString( "Null pointer for '%1'" ).arg( #ptr ) ); \
+    return ( defaultObj );                                                             \
   }
 
 /// check if no error has been caught else add stacktrace entry and return the \a defaultObj
-#define CHECK_SUCCESS( errorMsg, defaultObj )                                                         \
-  if ( !sfcgal::errorHandler()->hasSucceedOrStack( ( errorMsg ), __FILE__, __FUNCTION__, __LINE__ ) ) \
-  {                                                                                                   \
-    return ( defaultObj );                                                                            \
+#define CHECK_SUCCESS( errorMsg, defaultObj )                       \
+  if ( !sfcgal::errorHandler()->hasSucceedOrStack( ( errorMsg ) ) ) \
+  {                                                                 \
+    return ( defaultObj );                                          \
   }
 
 /// check if no error has been caught else add stacktrace entry, log the stacktrace and return the \a defaultObj
-#define CHECK_SUCCESS_LOG( errorMsg, defaultObj )                                                     \
-  if ( !sfcgal::errorHandler()->hasSucceedOrStack( ( errorMsg ), __FILE__, __FUNCTION__, __LINE__ ) ) \
-  {                                                                                                   \
-    QgsDebugError( sfcgal::errorHandler()->getFullText() );                                           \
-    return ( defaultObj );                                                                            \
+#define CHECK_SUCCESS_LOG( errorMsg, defaultObj )                   \
+  if ( !sfcgal::errorHandler()->hasSucceedOrStack( ( errorMsg ) ) ) \
+  {                                                                 \
+    QgsDebugError( sfcgal::errorHandler()->getFullText() );         \
+    return ( defaultObj );                                          \
   }
 
 /// check if no error has been caught else add stacktrace entry, log the stacktrace and throw an exception
-#define THROW_ON_ERROR(errorMsg) \
-  if ( !sfcgal::errorHandler()->hasSucceedOrStack( ( errorMsg ), __FILE__, __FUNCTION__, __LINE__ ) ) \
-  {                                                                                                   \
-    QgsDebugError( sfcgal::errorHandler()->getFullText() );                                           \
-    throw QgsSfcgalException( sfcgal::errorHandler()->getFullText() );                                \
+#define THROW_ON_ERROR(errorMsg)                                       \
+  if ( !sfcgal::errorHandler()->hasSucceedOrStack( ( errorMsg ) ) )    \
+  {                                                                    \
+    QgsDebugError( sfcgal::errorHandler()->getFullText() );            \
+    throw QgsSfcgalException( sfcgal::errorHandler()->getFullText() ); \
   }
 
 
@@ -176,7 +176,7 @@ namespace sfcgal
       * - a stacktrace entry is added with caller location
       * - \a errorMsg will be updated with failure messages
       */
-      bool hasSucceedOrStack( QString *errorMsg = nullptr, const char *fromFile = nullptr, const char *fromFunc = nullptr, int fromLine = 0 );
+      bool hasSucceedOrStack( QString *errorMsg = nullptr, const std::source_location &location = std::source_location::current() );
 
       /**
        * Clears failure messages and also clear \a errorMsg content if not null.
@@ -193,7 +193,7 @@ namespace sfcgal
       QString getFullText() const;
 
       //! Adds \a msg to the failure message list.
-      void addText( const QString &msg, const char *fromFile = nullptr, const char *fromFunc = nullptr, int fromLine = 0 );
+      void addText( const QString &msg, const std::source_location &location = std::source_location::current() );
 
     private:
       QStringList errorMessages;

--- a/src/core/geometry/qgssfcgalengine.h
+++ b/src/core/geometry/qgssfcgalengine.h
@@ -31,7 +31,7 @@
 #include "qgspoint.h"
 #include "qgsvector3d.h"
 
-#include <QtGui/qmatrix4x4.h>
+#include <QMatrix4x4>
 
 class QgsGeometry;
 class QgsSfcgalGeometry;


### PR DESCRIPTION
## Description

`__FILE__`, `__FUNCTION__`, `__LINE__` are used by QgsSfcgalEngine to
display debug and error messages. With C++20, these macro can be
replaced by using `source_location`.

This was first introduced in c3ee47a378731a8432c1423ddd754fb7df59865b
but reverted by aedccc2838321854f36c1ea7eb92f3564a868adb because this
broke the Qt5 sip compiler.

With Qt6 being mandatory, this can now be safely applied.