### PR TITLE
[Expression] Remove owned functions before delete

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -9886,6 +9886,15 @@ bool QgsExpression::unregisterFunction( const QString &name )
 
 void QgsExpression::cleanRegisteredFunctions()
 {
+  for ( QgsExpressionFunction *func : *sOwnedFunctions() )
+  {
+    sBuiltinFunctions()->removeAll( func->name() );
+    for ( QString alias : func->aliases() )
+      sBuiltinFunctions()->removeAll( alias );
+
+    sFunctions()->removeAll( func );
+  }
+
   qDeleteAll( *sOwnedFunctions() );
   sOwnedFunctions()->clear();
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -9890,8 +9890,10 @@ void QgsExpression::cleanRegisteredFunctions()
   for ( QgsExpressionFunction *func : std::as_const( ownedFunctions ) )
   {
     sBuiltinFunctions()->removeAll( func->name() );
-    for ( QString alias : func->aliases() )
+    for ( const QString &alias : func->aliases() )
+    {
       sBuiltinFunctions()->removeAll( alias );
+    }
 
     sFunctions()->removeAll( func );
   }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -9886,7 +9886,8 @@ bool QgsExpression::unregisterFunction( const QString &name )
 
 void QgsExpression::cleanRegisteredFunctions()
 {
-  for ( QgsExpressionFunction *func : *sOwnedFunctions() )
+  const QList<QgsExpressionFunction *> &ownedFunctions = *sOwnedFunctions();
+  for ( QgsExpressionFunction *func : std::as_const( ownedFunctions ) )
   {
     sBuiltinFunctions()->removeAll( func->name() );
     for ( QString alias : func->aliases() )
@@ -10238,4 +10239,3 @@ void QgsWithVariableExpressionFunction::appendTemporaryVariable( const QgsExpres
   QgsExpressionContext *updatedContext = const_cast<QgsExpressionContext *>( context );
   updatedContext->appendScope( scope );
 }
-


### PR DESCRIPTION
Any owned function exists in sFunctions list so we have to remove it from the sFunctions list. If not, when deleting/recreating QgisApp (in tests for instance), cleanRegisteredFunctions() is called and let with dangling expression functions pointer.

Needed in #64325

**Funded by Stadt Frankfurt am Main and Oslandia**