### PR TITLE
QgsProcessingAlgorithm::parameterAsOutputRasterFormat(): do not cause it to load a temporary output

### DIFF
--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -822,7 +822,13 @@ QString QgsProcessingAlgorithm::parameterAsOutputRasterFormat( const QVariantMap
   QString outputFormat = parameterAsOutputFormat( parameters, name, context );
   if ( outputFormat.isEmpty() )
   {
-    QString outputFile = parameterAsOutputLayer( parameters, name, context );
+    const QgsProcessingParameterDefinition *definition = parameterDefinition( name );
+    QVariant val;
+    if ( definition )
+    {
+      val = parameters.value( definition->name() );
+    }
+    QString outputFile = QgsProcessingParameters::parameterAsOutputLayer( definition, val, context, /* testOnly = */ true );
     if ( !outputFile.isEmpty() )
     {
       const QFileInfo fi( outputFile );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -256,6 +256,15 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
       parameters.insert( u"raster2"_s, u"test.bmp"_s );
       QgsProcessingContext context;
       QCOMPARE( parameterAsOutputRasterFormat( parameters, u"raster2"_s, context ), u"BMP"_s );
+
+      // test that parameterAsOutputRasterFormat() does not cause a temporary
+      // output to be loaded
+      QgsProject p;
+      QgsProcessingOutputLayerDefinition fs( QgsProcessing::TEMPORARY_OUTPUT );
+      fs.destinationProject = &p;
+      parameters.insert( u"raster2"_s, QVariant::fromValue( fs ) );
+      QCOMPARE( parameterAsOutputRasterFormat( parameters, u"raster2"_s, context ), u"GTiff"_s );
+      QCOMPARE( context.layersToLoadOnCompletion().size(), 0 );
     }
 
     void runOutputChecks()


### PR DESCRIPTION
master only

Fixes https://github.com/qgis/QGIS/pull/64226#issuecomment-3716769869 Fix regression introduced per https://github.com/qgis/QGIS/pull/64226
