### PR TITLE
fix comparison method in the QgsCoordinateReferenceSystemProxyModel

### DIFF
--- a/src/gui/proj/qgscoordinatereferencesystemmodel.cpp
+++ b/src/gui/proj/qgscoordinatereferencesystemmodel.cpp
@@ -756,7 +756,7 @@ bool QgsCoordinateReferenceSystemProxyModel::lessThan( const QModelIndex &left, 
   {
     // both are groups -- ensure USER group comes last, and CUSTOM group comes first
     const QString leftGroupId = sourceModel()->data( left, static_cast<int>( QgsCoordinateReferenceSystemModel::CustomRole::GroupId ) ).toString();
-    const QString rightGroupId = sourceModel()->data( left, static_cast<int>( QgsCoordinateReferenceSystemModel::CustomRole::GroupId ) ).toString();
+    const QString rightGroupId = sourceModel()->data( right, static_cast<int>( QgsCoordinateReferenceSystemModel::CustomRole::GroupId ) ).toString();
     if ( leftGroupId == "USER"_L1 )
       return false;
     if ( rightGroupId == "USER"_L1 )


### PR DESCRIPTION
## Description

Fixes use of the  same model index as left and right index in the `lessThan()` method.

Resurrects #64454.