### PR TITLE
fix: build with oracle support on qt-6.10

### DIFF
--- a/src/providers/oracle/ocispatial/CMakeLists.txt
+++ b/src/providers/oracle/ocispatial/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(qsqlocispatial SHARED ${QSQLOCISPATIAL_SRC})
 target_link_libraries(qsqlocispatial
   ${QT_VERSION_BASE}::Core
   ${QT_VERSION_BASE}::Sql
+  ${QT_VERSION_BASE}::SqlPrivate
   ${OCI_LIBRARY}
 )
 


### PR DESCRIPTION
Compilation with oracle support on qt-6.10 fails
```FAILED: [code=1] src/providers/oracle/ocispatial/CMakeFiles/qsqlocispatial.dir/qsql_ocispatial.cpp.o 
/usr/bin/x86_64-pc-linux-gnu-g++ -DQT_CORE_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_DEPRECATED_WARNINGS -DQT_PLUGIN -DQT_SHARED -DQT_SQL_LIB -DQ
T_USE_QSTRINGBUILDER -DSIP_VERSION=0x060e00 -Dqsqlocispatial_EXPORTS -I/var/tmp/portage/sci-geosciences/qgis-3.44.6/work/qgis-3.44.6_build/src/provider
s/oracle/ocispatial/qsqlocispatial_autogen/include -I/var/tmp/portage/sci-geosciences/qgis-3.44.6/work/qgis-3.44.6_build -isystem /usr/lib64/oracle/cli
ent/rdbms/public -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6 -isystem /usr/lib64/qt6/mkspecs/linux-g++ -isystem /usr/include/qt6/QtSql  
-march=native -O2 -pipe -fno-strict-aliasing -std=gnu++17 -fPIC -fvisibility=hidden -mno-direct-extern-access -MD -MT src/providers/oracle/ocispatial/C
MakeFiles/qsqlocispatial.dir/qsql_ocispatial.cpp.o -MF src/providers/oracle/ocispatial/CMakeFiles/qsqlocispatial.dir/qsql_ocispatial.cpp.o.d -o src/pro
viders/oracle/ocispatial/CMakeFiles/qsqlocispatial.dir/qsql_ocispatial.cpp.o -c /var/tmp/portage/sci-geosciences/qgis-3.44.6/work/qgis-3.44.6/src/provi
ders/oracle/ocispatial/qsql_ocispatial.cpp
/var/tmp/portage/sci-geosciences/qgis-3.44.6/work/qgis-3.44.6/src/providers/oracle/ocispatial/qsql_ocispatial.cpp:72:10: fatal error: QtSql/private/qsqlcachedresult_p.h: No such file or directory
   72 | #include <QtSql/private/qsqlcachedresult_p.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```
