### PR TITLE
Add transientGeometryChanged signal to QgsMapToolAdvancedDigitizing

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgsmaptooladvanceddigitizing.py
+++ b/python/PyQt6/gui/auto_additions/qgsmaptooladvanceddigitizing.py
@@ -1,7 +1,9 @@
 # The following has been generated automatically from src/gui/maptools/qgsmaptooladvanceddigitizing.h
 try:
+    QgsMapToolAdvancedDigitizing.__attribute_docs__ = {'transientGeometryChanged': "Emitted whenever the ``geometry`` associated with the tool is changed,\nincluding transient (i.e. non-finalized, hover state) changes.\n\nConnections to this signal should take care to check the CRS of\n``geometry``, as it may be either in the canvas CRS or an associated\nlayer's CRS.\n\n.. versionadded:: 4.0\n"}
     QgsMapToolAdvancedDigitizing.__virtual_methods__ = ['layer', 'cadCanvasPressEvent', 'cadCanvasReleaseEvent', 'cadCanvasMoveEvent']
     QgsMapToolAdvancedDigitizing.__overridden_methods__ = ['canvasPressEvent', 'canvasReleaseEvent', 'canvasMoveEvent', 'activate', 'deactivate']
+    QgsMapToolAdvancedDigitizing.__signal_arguments__ = {'transientGeometryChanged': ['geometry: QgsReferencedGeometry']}
     QgsMapToolAdvancedDigitizing.__group__ = ['maptools']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_generated/maptools/qgsmaptooladvanceddigitizing.sip.in
+++ b/python/PyQt6/gui/auto_generated/maptools/qgsmaptooladvanceddigitizing.sip.in
@@ -217,6 +217,20 @@ occur in the layer's CRS.
 .. versionadded:: 3.4
 %End
 
+  signals:
+
+    void transientGeometryChanged( const QgsReferencedGeometry &geometry );
+%Docstring
+Emitted whenever the ``geometry`` associated with the tool is changed,
+including transient (i.e. non-finalized, hover state) changes.
+
+Connections to this signal should take care to check the CRS of
+``geometry``, as it may be either in the canvas CRS or an associated
+layer's CRS.
+
+.. versionadded:: 4.0
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_additions/qgsmaptooladvanceddigitizing.py
+++ b/python/gui/auto_additions/qgsmaptooladvanceddigitizing.py
@@ -1,7 +1,9 @@
 # The following has been generated automatically from src/gui/maptools/qgsmaptooladvanceddigitizing.h
 try:
+    QgsMapToolAdvancedDigitizing.__attribute_docs__ = {'transientGeometryChanged': "Emitted whenever the ``geometry`` associated with the tool is changed,\nincluding transient (i.e. non-finalized, hover state) changes.\n\nConnections to this signal should take care to check the CRS of\n``geometry``, as it may be either in the canvas CRS or an associated\nlayer's CRS.\n\n.. versionadded:: 4.0\n"}
     QgsMapToolAdvancedDigitizing.__virtual_methods__ = ['layer', 'cadCanvasPressEvent', 'cadCanvasReleaseEvent', 'cadCanvasMoveEvent']
     QgsMapToolAdvancedDigitizing.__overridden_methods__ = ['canvasPressEvent', 'canvasReleaseEvent', 'canvasMoveEvent', 'activate', 'deactivate']
+    QgsMapToolAdvancedDigitizing.__signal_arguments__ = {'transientGeometryChanged': ['geometry: QgsReferencedGeometry']}
     QgsMapToolAdvancedDigitizing.__group__ = ['maptools']
 except (NameError, AttributeError):
     pass

--- a/python/gui/auto_generated/maptools/qgsmaptooladvanceddigitizing.sip.in
+++ b/python/gui/auto_generated/maptools/qgsmaptooladvanceddigitizing.sip.in
@@ -217,6 +217,20 @@ occur in the layer's CRS.
 .. versionadded:: 3.4
 %End
 
+  signals:
+
+    void transientGeometryChanged( const QgsReferencedGeometry &geometry );
+%Docstring
+Emitted whenever the ``geometry`` associated with the tool is changed,
+including transient (i.e. non-finalized, hover state) changes.
+
+Connections to this signal should take care to check the CRS of
+``geometry``, as it may be either in the canvas CRS or an associated
+layer's CRS.
+
+.. versionadded:: 4.0
+%End
+
 };
 
 /************************************************************************

--- a/src/app/maptools/qgsmaptoolshapecircle2points.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircle2points.cpp
@@ -83,5 +83,10 @@ void QgsMapToolShapeCircle2Points::cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsM
     return;
 
   mCircle = QgsCircle::from2Points( mPoints.at( 0 ), mParentTool->mapPoint( *e ) );
-  mTempRubberBand->setGeometry( mCircle.toCircularString( true ) );
+  const QgsGeometry newGeometry( mCircle.toCircularString( true ) );
+  if ( !newGeometry.isEmpty() )
+  {
+    mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+    setTransientGeometry( newGeometry );
+  }
 }

--- a/src/app/maptools/qgsmaptoolshapecircle2tangentspoint.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircle2tangentspoint.cpp
@@ -144,8 +144,7 @@ void QgsMapToolShapeCircle2TangentsPoint::cadCanvasMoveEvent( QgsMapMouseEvent *
       mTempRubberBand->show();
     }
   }
-
-  if ( mPoints.size() == 4 && !mCenters.isEmpty() )
+  else if ( mPoints.size() == 4 && !mCenters.isEmpty() )
   {
     QgsPoint center = QgsPoint( mCenters.at( 0 ) );
     const double currentDist = mapPoint.distanceSquared( center );
@@ -157,7 +156,12 @@ void QgsMapToolShapeCircle2TangentsPoint::cadCanvasMoveEvent( QgsMapMouseEvent *
     }
 
     mCircle = QgsCircle( center, mRadius );
-    mTempRubberBand->setGeometry( mCircle.toCircularString( true ) );
+    const QgsGeometry newGeometry( mCircle.toCircularString( true ) );
+    if ( !newGeometry.isEmpty() )
+    {
+      mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+      setTransientGeometry( newGeometry );
+    }
   }
 }
 

--- a/src/app/maptools/qgsmaptoolshapecircle3points.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircle3points.cpp
@@ -98,7 +98,12 @@ void QgsMapToolShapeCircle3Points::cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsM
     case 2:
     {
       mCircle = QgsCircle::from3Points( mPoints.at( 0 ), mPoints.at( 1 ), mParentTool->mapPoint( *e ) );
-      mTempRubberBand->setGeometry( mCircle.toCircularString( true ) );
+      const QgsGeometry newGeometry( mCircle.toCircularString( true ) );
+      if ( !newGeometry.isEmpty() )
+      {
+        mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+        setTransientGeometry( newGeometry );
+      }
     }
     break;
     default:

--- a/src/app/maptools/qgsmaptoolshapecircle3tangents.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircle3tangents.cpp
@@ -145,8 +145,13 @@ void QgsMapToolShapeCircle3Tangents::cadCanvasMoveEvent( QgsMapMouseEvent *e, Qg
     {
       const QgsPoint pos = getFirstPointOnParallels( mPoints.at( 0 ), mPoints.at( 1 ), mPosPoints.at( 0 ), mPoints.at( 2 ), mPoints.at( 3 ), mPosPoints.at( 1 ), QgsPoint( p1 ), QgsPoint( p2 ) );
       mCircle = QgsCircle::from3Tangents( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), mPoints.at( 3 ), QgsPoint( p1 ), QgsPoint( p2 ), 1E-8, pos );
-      mTempRubberBand->setGeometry( mCircle.toLineString() );
-      mTempRubberBand->show();
+      const QgsGeometry newGeometry( mCircle.toLineString() );
+      if ( !newGeometry.isEmpty() )
+      {
+        mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+        setTransientGeometry( newGeometry );
+        mTempRubberBand->show();
+      }
     }
     else
     {

--- a/src/app/maptools/qgsmaptoolshapecirclecenterpoint.cpp
+++ b/src/app/maptools/qgsmaptoolshapecirclecenterpoint.cpp
@@ -89,6 +89,11 @@ void QgsMapToolShapeCircleCenterPoint::cadCanvasMoveEvent( QgsMapMouseEvent *e, 
   if ( mTempRubberBand && !mPoints.isEmpty() )
   {
     mCircle = QgsCircle::fromCenterPoint( mPoints.at( 0 ), point );
-    mTempRubberBand->setGeometry( mCircle.toCircularString( true ) );
+    const QgsGeometry newGeometry( mCircle.toCircularString( true ) );
+    if ( !newGeometry.isEmpty() )
+    {
+      mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+      setTransientGeometry( newGeometry );
+    }
   }
 }

--- a/src/app/maptools/qgsmaptoolshapeellipsecenter2points.cpp
+++ b/src/app/maptools/qgsmaptoolshapeellipsecenter2points.cpp
@@ -102,7 +102,12 @@ void QgsMapToolShapeEllipseCenter2Points::cadCanvasMoveEvent( QgsMapMouseEvent *
       case 2:
       {
         mEllipse = QgsEllipse::fromCenter2Points( mPoints.at( 0 ), mPoints.at( 1 ), point );
-        mTempRubberBand->setGeometry( mEllipse.toPolygon( segments() ) );
+        const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
+        if ( !newGeometry.isEmpty() )
+        {
+          mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+          setTransientGeometry( newGeometry );
+        }
       }
       break;
       default:

--- a/src/app/maptools/qgsmaptoolshapeellipsecenterpoint.cpp
+++ b/src/app/maptools/qgsmaptoolshapeellipsecenterpoint.cpp
@@ -89,6 +89,11 @@ void QgsMapToolShapeEllipseCenterPoint::cadCanvasMoveEvent( QgsMapMouseEvent *e,
   if ( mTempRubberBand )
   {
     mEllipse = QgsEllipse::fromCenterPoint( mPoints.at( 0 ), point );
-    mTempRubberBand->setGeometry( mEllipse.toPolygon( segments() ) );
+    const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
+    if ( !newGeometry.isEmpty() )
+    {
+      mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+      setTransientGeometry( newGeometry );
+    }
   }
 }

--- a/src/app/maptools/qgsmaptoolshapeellipseextent.cpp
+++ b/src/app/maptools/qgsmaptoolshapeellipseextent.cpp
@@ -101,7 +101,12 @@ void QgsMapToolShapeEllipseExtent::cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsM
         if ( qgsDoubleNear( mParentTool->canvas()->rotation(), 0.0 ) )
         {
           mEllipse = QgsEllipse::fromExtent( mPoints.at( 0 ), point );
-          mTempRubberBand->setGeometry( mEllipse.toPolygon( segments() ) );
+          const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
+          if ( !newGeometry.isEmpty() )
+          {
+            mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+            setTransientGeometry( newGeometry );
+          }
         }
         else
         {
@@ -109,7 +114,12 @@ void QgsMapToolShapeEllipseExtent::cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsM
           const double angle = mPoints.at( 0 ).azimuth( point );
 
           mEllipse = QgsEllipse::fromExtent( mPoints.at( 0 ), mPoints.at( 0 ).project( dist, angle ) );
-          mTempRubberBand->setGeometry( mEllipse.toPolygon( segments() ) );
+          const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
+          if ( !newGeometry.isEmpty() )
+          {
+            mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+            setTransientGeometry( newGeometry );
+          }
         }
       }
       break;

--- a/src/app/maptools/qgsmaptoolshapeellipsefoci.cpp
+++ b/src/app/maptools/qgsmaptoolshapeellipsefoci.cpp
@@ -108,7 +108,12 @@ void QgsMapToolShapeEllipseFoci::cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsMap
       case 2:
       {
         mEllipse = QgsEllipse::fromFoci( mPoints.at( 0 ), mPoints.at( 1 ), point );
-        mTempRubberBand->setGeometry( mEllipse.toPolygon() );
+        const QgsGeometry newGeometry( mEllipse.toPolygon() );
+        if ( !newGeometry.isEmpty() )
+        {
+          mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+          setTransientGeometry( newGeometry );
+        }
       }
       break;
       default:

--- a/src/app/maptools/qgsmaptoolshaperectangle3points.cpp
+++ b/src/app/maptools/qgsmaptoolshaperectangle3points.cpp
@@ -165,7 +165,12 @@ void QgsMapToolShapeRectangle3Points::cadCanvasMoveEvent( QgsMapMouseEvent *e, Q
             mRectangle = QgsQuadrilateral::rectangleFrom3Points( mPoints.at( 0 ), mPoints.at( 1 ), point, QgsQuadrilateral::Projected );
             break;
         }
-        mTempRubberBand->setGeometry( mRectangle.toPolygon() );
+        const QgsGeometry newGeometry( mRectangle.toPolygon() );
+        if ( !newGeometry.isEmpty() )
+        {
+          mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+          setTransientGeometry( newGeometry );
+        }
       }
       break;
       default:

--- a/src/app/maptools/qgsmaptoolshaperectanglecenter.cpp
+++ b/src/app/maptools/qgsmaptoolshaperectanglecenter.cpp
@@ -99,7 +99,12 @@ void QgsMapToolShapeRectangleCenter::cadCanvasMoveEvent( QgsMapMouseEvent *e, Qg
         const double angle = mPoints.at( 0 ).azimuth( point );
 
         mRectangle = QgsQuadrilateral::rectangleFromExtent( mPoints.at( 0 ).project( -dist, angle ), mPoints.at( 0 ).project( dist, angle ) );
-        mTempRubberBand->setGeometry( mRectangle.toPolygon() );
+        const QgsGeometry newGeometry( mRectangle.toPolygon() );
+        if ( !newGeometry.isEmpty() )
+        {
+          mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+          setTransientGeometry( newGeometry );
+        }
       }
       break;
       default:

--- a/src/app/maptools/qgsmaptoolshaperectangleextent.cpp
+++ b/src/app/maptools/qgsmaptoolshaperectangleextent.cpp
@@ -98,7 +98,12 @@ void QgsMapToolShapeRectangleExtent::cadCanvasMoveEvent( QgsMapMouseEvent *e, Qg
         const double angle = mPoints.at( 0 ).azimuth( point );
 
         mRectangle = QgsQuadrilateral::rectangleFromExtent( mPoints.at( 0 ), mPoints.at( 0 ).project( dist, angle ) );
-        mTempRubberBand->setGeometry( mRectangle.toPolygon() );
+        const QgsGeometry newGeometry( mRectangle.toPolygon() );
+        if ( !newGeometry.isEmpty() )
+        {
+          mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+          setTransientGeometry( newGeometry );
+        }
       }
       break;
       default:

--- a/src/app/maptools/qgsmaptoolshaperegularpolygon2points.cpp
+++ b/src/app/maptools/qgsmaptoolshaperegularpolygon2points.cpp
@@ -100,6 +100,11 @@ void QgsMapToolShapeRegularPolygon2Points::cadCanvasMoveEvent( QgsMapMouseEvent 
   if ( mTempRubberBand && !mPoints.isEmpty() )
   {
     mRegularPolygon = QgsRegularPolygon( mPoints.at( 0 ), point, mNumberSidesSpinBox->value() );
-    mTempRubberBand->setGeometry( mRegularPolygon.toPolygon() );
+    const QgsGeometry newGeometry( mRegularPolygon.toPolygon() );
+    if ( !newGeometry.isEmpty() )
+    {
+      mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+      setTransientGeometry( newGeometry );
+    }
   }
 }

--- a/src/app/maptools/qgsmaptoolshaperegularpolygoncentercorner.cpp
+++ b/src/app/maptools/qgsmaptoolshaperegularpolygoncentercorner.cpp
@@ -98,6 +98,11 @@ void QgsMapToolShapeRegularPolygonCenterCorner::cadCanvasMoveEvent( QgsMapMouseE
   {
     const QgsRegularPolygon::ConstructionOption option = QgsRegularPolygon::InscribedCircle;
     mRegularPolygon = QgsRegularPolygon( mPoints.at( 0 ), point, mNumberSidesSpinBox->value(), option );
-    mTempRubberBand->setGeometry( mRegularPolygon.toPolygon() );
+    const QgsGeometry newGeometry( mRegularPolygon.toPolygon() );
+    if ( !newGeometry.isEmpty() )
+    {
+      mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+      setTransientGeometry( newGeometry );
+    }
   }
 }

--- a/src/app/maptools/qgsmaptoolshaperegularpolygoncenterpoint.cpp
+++ b/src/app/maptools/qgsmaptoolshaperegularpolygoncenterpoint.cpp
@@ -100,6 +100,11 @@ void QgsMapToolShapeRegularPolygonCenterPoint::cadCanvasMoveEvent( QgsMapMouseEv
   {
     const QgsRegularPolygon::ConstructionOption option = QgsRegularPolygon::CircumscribedCircle;
     mRegularPolygon = QgsRegularPolygon( mPoints.at( 0 ), point, mNumberSidesSpinBox->value(), option );
-    mTempRubberBand->setGeometry( mRegularPolygon.toPolygon() );
+    const QgsGeometry newGeometry( mRegularPolygon.toPolygon() );
+    if ( !newGeometry.isEmpty() )
+    {
+      mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+      setTransientGeometry( newGeometry );
+    }
   }
 }

--- a/src/gui/maptools/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/maptools/qgsmaptooladvanceddigitizing.h
@@ -21,6 +21,7 @@
 
 #include "qgis_gui.h"
 #include "qgsmaptooledit.h"
+#include "qgsreferencedgeometry.h"
 
 class QgsMapMouseEvent;
 class QgsAdvancedDigitizingDockWidget;
@@ -198,6 +199,23 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
      * \since QGIS 3.4
      */
     void setSnapToLayerGridEnabled( bool snapToLayerGridEnabled );
+
+  signals:
+
+    //NOTE -- we use QgsReferencedGeometry here, as we'd like to defer the transformation of geometry to a particular
+    //desired destination CRS (eg layer CRS or map canvas CRS) as the caller's responsibility. That's because we don't want
+    //to waste cycles doing that transformation with every mouse move, when potentially NOTHING is even connected to this signal!
+    //By using QgsReferencedGeometry we allows the emitters to just use the geometries they've already calculated for the rubber
+    //bands, regardless of what CRS they are in
+    /**
+     * Emitted whenever the \a geometry associated with the tool is changed, including transient (i.e. non-finalized, hover state) changes.
+     *
+     * Connections to this signal should take care to check the CRS of \a geometry, as it may be either in the
+     * canvas CRS or an associated layer's CRS.
+     *
+     * \since QGIS 4.0
+     */
+    void transientGeometryChanged( const QgsReferencedGeometry &geometry );
 
   private slots:
 

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -556,6 +556,7 @@ void QgsMapToolCapture::cadCanvasMoveEvent( QgsMapMouseEvent *e )
         mAllowAddingStreamingPoints = true;
         addVertex( mapPoint );
         mAllowAddingStreamingPoints = false;
+        emit transientGeometryChanged( QgsReferencedGeometry( QgsGeometry( mCaptureCurve.clone() ), targetCrs ) );
       }
       else if ( tracingEnabled() && mCaptureCurve.numPoints() != 0 )
       {

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -429,6 +429,8 @@ void QgsMapToolCapture::resetRubberBand()
 
 void QgsMapToolCapture::setCurrentShapeMapToolIsActivated( bool activated )
 {
+  // suppress false positive clang tidy warning
+  // NOLINTBEGIN(bugprone-branch-clone)
   if ( activated )
   {
     connect( mCurrentShapeMapTool, &QgsMapToolShapeAbstract::transientGeometryChanged, this, &QgsMapToolAdvancedDigitizing::transientGeometryChanged );
@@ -439,6 +441,7 @@ void QgsMapToolCapture::setCurrentShapeMapToolIsActivated( bool activated )
     disconnect( mCurrentShapeMapTool, &QgsMapToolShapeAbstract::transientGeometryChanged, this, &QgsMapToolAdvancedDigitizing::transientGeometryChanged );
     mCurrentShapeMapTool->deactivate();
   }
+  // NOLINTEND(bugprone-branch-clone)
 }
 
 QgsRubberBand *QgsMapToolCapture::takeRubberBand()

--- a/src/gui/maptools/qgsmaptoolcapture.h
+++ b/src/gui/maptools/qgsmaptoolcapture.h
@@ -389,6 +389,8 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     //! Reset the
     void resetRubberBand();
 
+    void setCurrentShapeMapToolIsActivated( bool activated );
+
     //! The capture mode in which this tool operates
     CaptureMode mCaptureMode;
 

--- a/src/gui/maptools/qgsmaptoolshapeabstract.cpp
+++ b/src/gui/maptools/qgsmaptoolshapeabstract.cpp
@@ -18,6 +18,7 @@
 #include "qgsmaptoolshapeabstract.h"
 
 #include "qgsgeometryrubberband.h"
+#include "qgsmapcanvas.h"
 
 #include <QKeyEvent>
 
@@ -55,4 +56,9 @@ void QgsMapToolShapeAbstract::undo()
     clean();
   else if ( mPoints.count() > 1 )
     mPoints.removeLast();
+}
+
+void QgsMapToolShapeAbstract::setTransientGeometry( const QgsGeometry &geometry )
+{
+  emit transientGeometryChanged( QgsReferencedGeometry( geometry, mParentTool->canvas()->mapSettings().destinationCrs() ) );
 }

--- a/src/gui/maptools/qgsmaptoolshapeabstract.h
+++ b/src/gui/maptools/qgsmaptoolshapeabstract.h
@@ -22,6 +22,7 @@
 #include "qgis_gui.h"
 #include "qgsabstractgeometry.h"
 #include "qgsmaptoolcapture.h"
+#include "qgsreferencedgeometry.h"
 
 #include <QIcon>
 #include <QString>
@@ -103,10 +104,31 @@ class GUI_EXPORT QgsMapToolShapeAbstract
     //! Called to undo last action (last point added)
     virtual void undo();
 
+  signals:
+
+    /**
+     * Emitted whenever the \a geometry associated with the tool is changed, including transient (i.e. non-finalized, hover state) changes.
+     *
+     * \since QGIS 4.0
+     */
+    void transientGeometryChanged( const QgsReferencedGeometry &geometry );
+
   private:
     QString mId;
 
   protected:
+    /**
+     * Sets the current \a geometry, including transient (i.e. non-finalized, hover state) changes.
+     *
+     * Subclasses should call this during their cadCanvasMoveEvent() implementations, whenever the transient
+     * geometry changes as a result of a mouse move.
+     *
+     * \a geometry should be in the current map canvas CRS.
+     *
+     * \since QGIS 4.0
+     */
+    void setTransientGeometry( const QgsGeometry &geometry );
+
     QgsMapToolCapture *mParentTool = nullptr;
 
     //! points (in map coordinates)

--- a/tests/src/app/testqgsmaptoolellipse.cpp
+++ b/tests/src/app/testqgsmaptoolellipse.cpp
@@ -29,6 +29,8 @@
 #include "qgsvectorlayer.h"
 #include "testqgsmaptoolutils.h"
 
+#include <QSignalSpy>
+
 class TestQgsMapToolEllipse : public QObject
 {
     Q_OBJECT
@@ -47,6 +49,11 @@ class TestQgsMapToolEllipse : public QObject
     void testEllipseFromCenterAnd2PointsNotEnoughPoints();
     void testEllipseFromExtentNotEnoughPoints();
     void testEllipseFromFociNotEnoughPoints();
+
+    void testTransientGeometrySignalCenterPoint();
+    void testTransientGeometrySignalCenter2Points();
+    void testTransientGeometrySignalExtent();
+    void testTransientGeometrySignalFoci();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -561,6 +568,104 @@ void TestQgsMapToolEllipse::testEllipseFromFociNotEnoughPoints()
   layer->rollBack();
 }
 
+void TestQgsMapToolEllipse::testTransientGeometrySignalCenterPoint()
+{
+  QgsVectorLayer *layer = mVectorLayerMap["XY"].get();
+  mCanvas->setCurrentLayer( layer );
+  layer->startEditing();
+
+  resetMapTool( new QgsMapToolShapeEllipseCenterPointMetadata() );
+
+  TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
+  QSignalSpy spy( mMapTool, &QgsMapToolCapture::transientGeometryChanged );
+
+  utils.mouseClick( 0, 0, Qt::LeftButton );
+  utils.mouseMove( 2, 1 );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ).left( 142 ), u"Polygon ((2 0, 2 -0.1, 2 -0.1, 2 -0.2, 1.9 -0.3, 1.9 -0.3, 1.8 -0.4, 1.8 -0.4, 1.7 -0.5, 1.7 -0.6, 1.6 -0.6, 1.5 -0.7, 1.4 -0.7, 1.3 -0.8, 1.2"_s );
+
+  utils.mouseMove( 2, 2 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ).left( 142 ), u"Polygon ((2 0, 2 -0.1, 2 -0.3, 2 -0.4, 1.9 -0.5, 1.9 -0.6, 1.8 -0.8, 1.8 -0.9, 1.7 -1, 1.7 -1.1, 1.6 -1.2, 1.5 -1.3, 1.4 -1.4, 1.3 -1.5, 1.2 -"_s );
+
+  utils.mouseClick( 2, 1, Qt::RightButton );
+  layer->rollBack();
+}
+
+void TestQgsMapToolEllipse::testTransientGeometrySignalCenter2Points()
+{
+  QgsVectorLayer *layer = mVectorLayerMap["XY"].get();
+  mCanvas->setCurrentLayer( layer );
+  layer->startEditing();
+
+  resetMapTool( new QgsMapToolShapeEllipseCenter2PointsMetadata() );
+
+  TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
+  QSignalSpy spy( mMapTool, &QgsMapToolCapture::transientGeometryChanged );
+
+  utils.mouseClick( 0, 0, Qt::LeftButton );
+  utils.mouseClick( 2, 0, Qt::LeftButton );
+  utils.mouseMove( 3, 1 );
+
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ).left( 142 ), u"Polygon ((2 0, 2 -0.1, 2 -0.2, 2 -0.3, 1.9 -0.4, 1.9 -0.5, 1.8 -0.5, 1.8 -0.6, 1.7 -0.7, 1.7 -0.8, 1.6 -0.9, 1.5 -0.9, 1.4 -1, 1.3 -1.1, 1.2 -"_s );
+
+  utils.mouseMove( 3, 2 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ).left( 142 ), u"Polygon ((0 -2.2, -0.1 -2.2, -0.3 -2.2, -0.4 -2.2, -0.5 -2.2, -0.6 -2.1, -0.8 -2.1, -0.9 -2, -1 -1.9, -1.1 -1.9, -1.2 -1.8, -1.3 -1.7, -1.4 -1"_s );
+
+  utils.mouseClick( 0, 1, Qt::RightButton );
+  layer->rollBack();
+}
+
+void TestQgsMapToolEllipse::testTransientGeometrySignalExtent()
+{
+  QgsVectorLayer *layer = mVectorLayerMap["XY"].get();
+  mCanvas->setCurrentLayer( layer );
+  layer->startEditing();
+
+  resetMapTool( new QgsMapToolShapeEllipseExtentMetadata() );
+
+  TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
+  QSignalSpy spy( mMapTool, &QgsMapToolCapture::transientGeometryChanged );
+
+  utils.mouseClick( 0, 0, Qt::LeftButton );
+  utils.mouseMove( 4, 2 );
+
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ).left( 142 ), u"Polygon ((4 1, 4 0.9, 4 0.9, 4 0.8, 3.9 0.7, 3.9 0.7, 3.8 0.6, 3.8 0.6, 3.7 0.5, 3.7 0.4, 3.6 0.4, 3.5 0.3, 3.4 0.3, 3.3 0.2, 3.2 0.2, 3.1 0.2"_s );
+
+  utils.mouseMove( 3, 2 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ).left( 142 ), u"Polygon ((3 1, 3 0.9, 3 0.9, 3 0.8, 2.9 0.7, 2.9 0.7, 2.9 0.6, 2.8 0.6, 2.8 0.5, 2.7 0.4, 2.7 0.4, 2.6 0.3, 2.6 0.3, 2.5 0.2, 2.4 0.2, 2.3 0.2"_s );
+
+  utils.mouseClick( 4, 2, Qt::RightButton );
+  layer->rollBack();
+}
+
+void TestQgsMapToolEllipse::testTransientGeometrySignalFoci()
+{
+  QgsVectorLayer *layer = mVectorLayerMap["XY"].get();
+  mCanvas->setCurrentLayer( layer );
+  layer->startEditing();
+
+  resetMapTool( new QgsMapToolShapeEllipseFociMetadata() );
+
+  TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
+  QSignalSpy spy( mMapTool, &QgsMapToolCapture::transientGeometryChanged );
+  utils.mouseClick( 0, 0, Qt::LeftButton );
+  utils.mouseClick( 4, 0, Qt::LeftButton );
+  utils.mouseMove( 2, 3 );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ).left( 142 ), u"Polygon ((5.6 0, 5.6 -0.5, 5.4 -1, 5.1 -1.5, 4.8 -1.9, 4.3 -2.3, 3.8 -2.6, 3.2 -2.8, 2.6 -3, 2 -3, 1.4 -3, 0.8 -2.8, 0.2 -2.6, -0.3 -2.3, -0.8"_s );
+
+  utils.mouseMove( 3, 2 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ).left( 142 ), u"Polygon ((4.9 0, 4.9 -0.4, 4.7 -0.7, 4.5 -1.1, 4.2 -1.4, 3.9 -1.6, 3.5 -1.8, 3 -2, 2.5 -2.1, 2 -2.1, 1.5 -2.1, 1 -2, 0.5 -1.8, 0.1 -1.6, -0.2 "_s );
+
+  utils.mouseClick( 2, 3, Qt::RightButton );
+  layer->rollBack();
+}
 
 QGSTEST_MAIN( TestQgsMapToolEllipse )
 #include "testqgsmaptoolellipse.moc"

--- a/tests/src/app/testqgsmaptoolregularpolygon.cpp
+++ b/tests/src/app/testqgsmaptoolregularpolygon.cpp
@@ -26,6 +26,8 @@
 #include "qgsvectorlayer.h"
 #include "testqgsmaptoolutils.h"
 
+#include <QSignalSpy>
+
 class TestQgsMapToolRegularPolygon : public QObject
 {
     Q_OBJECT
@@ -47,6 +49,9 @@ class TestQgsMapToolRegularPolygon : public QObject
     void testRegularPolygonFromCenterAndCorner();
     void testRegularPolygonFromCenterAndCornerWithDeletedVertex();
     void testRegularPolygonFromCenterAndCornerNotEnoughPoints();
+    void testTransientGeometrySignal2Points();
+    void testTransientGeometrySignalCenterPoint();
+    void testTransientGeometrySignalCenterCorner();
 
   private:
     void resetMapTool( QgsMapToolShapeMetadata *metadata );
@@ -314,6 +319,75 @@ void TestQgsMapToolRegularPolygon::testRegularPolygonFromCenterAndCornerNotEnoug
   mLayer->rollBack();
 }
 
+void TestQgsMapToolRegularPolygon::testTransientGeometrySignal2Points()
+{
+  mLayer->startEditing();
+
+  QgsMapToolShapeRegularPolygon2PointsMetadata md;
+  resetMapTool( &md );
+
+  TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
+  QSignalSpy spy( mMapTool, &QgsMapToolCapture::transientGeometryChanged );
+
+  utils.mouseClick( 0, 0, Qt::LeftButton );
+  utils.mouseMove( 2, 1 );
+
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ), u"Polygon Z ((0 0 0, 2 1 0, 3.9 -0.2 0, 3.7 -2.5 0, 1.7 -3.5 0, -0.1 -2.2 0, 0 0 0))"_s );
+
+  utils.mouseMove( 3, 2 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ), u"Polygon Z ((0 0 0, 3 2 0, 6.2 0.4 0, 6.5 -3.2 0, 3.5 -5.2 0, 0.2 -3.6 0, 0 0 0))"_s );
+
+  utils.mouseClick( 2, 1, Qt::RightButton );
+  mLayer->rollBack();
+}
+
+void TestQgsMapToolRegularPolygon::testTransientGeometrySignalCenterPoint()
+{
+  mLayer->startEditing();
+
+  QgsMapToolShapeRegularPolygonCenterPointMetadata md;
+  resetMapTool( &md );
+
+  TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
+  QSignalSpy spy( mMapTool, &QgsMapToolCapture::transientGeometryChanged );
+
+  utils.mouseClick( 0, 0, Qt::LeftButton );
+  utils.mouseMove( 2, 1 );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ), u"Polygon Z ((1.4 2.2 0, 2.6 -0.2 0, 1.2 -2.3 0, -1.4 -2.2 0, -2.6 0.2 0, -1.2 2.3 0, 1.4 2.2 0))"_s );
+
+  utils.mouseMove( 3, 2 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ), u"Polygon Z ((1.8 3.7 0, 4.2 0.3 0, 2.3 -3.5 0, -1.8 -3.7 0, -4.2 -0.3 0, -2.3 3.5 0, 1.8 3.7 0))"_s );
+
+  utils.mouseClick( 2, 1, Qt::RightButton );
+  mLayer->rollBack();
+}
+
+void TestQgsMapToolRegularPolygon::testTransientGeometrySignalCenterCorner()
+{
+  mLayer->startEditing();
+
+  QgsMapToolShapeRegularPolygonCenterCornerMetadata md;
+  resetMapTool( &md );
+
+  TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
+  QSignalSpy spy( mMapTool, &QgsMapToolCapture::transientGeometryChanged );
+  utils.mouseClick( 0, 0, Qt::LeftButton );
+  utils.mouseMove( 2, 1 );
+
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.at( 0 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ), u"Polygon Z ((2 1 0, 1.9 -1.2 0, -0.1 -2.2 0, -2 -1 0, -1.9 1.2 0, 0.1 2.2 0, 2 1 0))"_s );
+
+  utils.mouseMove( 3, 2 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.at( 1 ).at( 0 ).value< QgsReferencedGeometry >().asWkt( 1 ), u"Polygon Z ((3 2 0, 3.2 -1.6 0, 0.2 -3.6 0, -3 -2 0, -3.2 1.6 0, -0.2 3.6 0, 3 2 0))"_s );
+
+  utils.mouseClick( 2, 1, Qt::RightButton );
+  mLayer->rollBack();
+}
 
 QGSTEST_MAIN( TestQgsMapToolRegularPolygon )
 #include "testqgsmaptoolregularpolygon.moc"

--- a/tests/src/gui/testqgsmaptoolcapture.cpp
+++ b/tests/src/gui/testqgsmaptoolcapture.cpp
@@ -471,8 +471,7 @@ void TestQgsMapToolCapture::testTransientGeometrySignalTracingPolygon()
   snappingUtils->locatorForLayer( layer )->init();
   canvas.setSnappingUtils( snappingUtils );
 
-  QgsMapCanvasTracer *tracer = new QgsMapCanvasTracer( &canvas );
-  ( void ) tracer;
+  auto tracer = std::make_unique< QgsMapCanvasTracer >( &canvas );
   QgsAdvancedDigitizingDockWidget cadDock( &canvas );
   QgsMapToolCapture tool( &canvas, &cadDock, QgsMapToolCapture::CapturePolygon );
   canvas.setMapTool( &tool );

--- a/tests/src/gui/testqgsmaptoolcapture.cpp
+++ b/tests/src/gui/testqgsmaptoolcapture.cpp
@@ -419,8 +419,8 @@ void TestQgsMapToolCapture::testTransientGeometrySignalTracing()
   snappingUtils->locatorForLayer( layer )->init();
   canvas.setSnappingUtils( snappingUtils );
 
-  QgsMapCanvasTracer *tracer = new QgsMapCanvasTracer( &canvas );
-  ( void ) tracer;
+  auto tracer = std::make_unique< QgsMapCanvasTracer >( &canvas );
+
   QgsAdvancedDigitizingDockWidget cadDock( &canvas );
   QgsMapToolCapture tool( &canvas, &cadDock, QgsMapToolCapture::CaptureLine );
   canvas.setMapTool( &tool );


### PR DESCRIPTION
Adds a means for listening to in-progress changes to a digitized geometry before that change is committed (eg including temporary mouse hover states)

Must be emitted by individual QgsMapToolAdvancedDigitizing subclasses during mouse move events. (Here I've implemented it for the QgsMapToolCapture class)