### PR TITLE
3d scene export: Add an option to disable terrain export

### DIFF
--- a/python/3d/auto_generated/qgs3dmapexportsettings.sip.in
+++ b/python/3d/auto_generated/qgs3dmapexportsettings.sip.in
@@ -62,6 +62,17 @@ Returns the terrain texture resolution
 Returns the scale of the exported model
 %End
 
+    bool terrainExportEnabled() const;
+%Docstring
+Returns whether terrain export is enabled. It terrain export is
+disabled, the terrain resolution and terrain texture resolution
+parameters have no effect.
+
+.. seealso:: :py:func:`setTerrainExportEnabled`
+
+.. versionadded:: 4.0
+%End
+
     void setSceneName( const QString &sceneName );
 %Docstring
 Sets the scene name
@@ -93,6 +104,15 @@ Sets the terrain texture resolution
     void setScale( float scale );
 %Docstring
 Sets the scale of exported model
+%End
+
+    void setTerrainExportEnabled( bool enabled );
+%Docstring
+Sets whether terrain export is enabled.
+
+.. seealso:: :py:func:`terrainExportEnabled`
+
+.. versionadded:: 4.0
 %End
 
 };

--- a/python/PyQt6/3d/auto_generated/qgs3dmapexportsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapexportsettings.sip.in
@@ -62,6 +62,17 @@ Returns the terrain texture resolution
 Returns the scale of the exported model
 %End
 
+    bool terrainExportEnabled() const;
+%Docstring
+Returns whether terrain export is enabled. It terrain export is
+disabled, the terrain resolution and terrain texture resolution
+parameters have no effect.
+
+.. seealso:: :py:func:`setTerrainExportEnabled`
+
+.. versionadded:: 4.0
+%End
+
     void setSceneName( const QString &sceneName );
 %Docstring
 Sets the scene name
@@ -93,6 +104,15 @@ Sets the terrain texture resolution
     void setScale( float scale );
 %Docstring
 Sets the scale of exported model
+%End
+
+    void setTerrainExportEnabled( bool enabled );
+%Docstring
+Sets whether terrain export is enabled.
+
+.. seealso:: :py:func:`terrainExportEnabled`
+
+.. versionadded:: 4.0
 %End
 
 };

--- a/src/3d/qgs3dmapexportsettings.h
+++ b/src/3d/qgs3dmapexportsettings.h
@@ -53,6 +53,16 @@ class _3D_EXPORT Qgs3DMapExportSettings
     //! Returns the scale of the exported model
     float scale() const { return mScale; }
 
+    /**
+     * Returns whether terrain export is enabled.
+     * It terrain export is disabled, the terrain resolution and terrain texture resolution
+     * parameters have no effect.
+     *
+     * \see setTerrainExportEnabled()
+     * \since QGIS 4.0
+     */
+    bool terrainExportEnabled() const { return mTerrainExportEnabled; }
+
     //! Sets the scene name
     void setSceneName( const QString &sceneName ) { mSceneName = sceneName; }
     //! Sets the scene's .obj file folder path
@@ -70,6 +80,14 @@ class _3D_EXPORT Qgs3DMapExportSettings
     //! Sets the scale of exported model
     void setScale( float scale ) { mScale = scale; }
 
+    /**
+     * Sets whether terrain export is enabled.
+     *
+     * \see terrainExportEnabled()
+     * \since QGIS 4.0
+     */
+    void setTerrainExportEnabled( bool enabled ) { mTerrainExportEnabled = enabled; }
+
   private:
     QString mSceneName = QString( "Scene" );
     QString mSceneFolderPath = QDir::homePath();
@@ -79,6 +97,7 @@ class _3D_EXPORT Qgs3DMapExportSettings
     bool mExportTextures = false;
     int mTerrainTextureResolution = 512;
     float mScale = 1.0f;
+    bool mTerrainExportEnabled = true;
 };
 
 #endif // QGS3DMAPEXPORTSETTINGS_H

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -1133,6 +1133,7 @@ bool Qgs3DMapScene::exportScene( const Qgs3DMapExportSettings &exportSettings )
   exporter.setExportTextures( exportSettings.exportTextures() );
   exporter.setTerrainTextureResolution( exportSettings.terrainTextureResolution() );
   exporter.setScale( exportSettings.scale() );
+  exporter.setTerrainExportEnabled( exportSettings.terrainExportEnabled() );
 
   for ( auto it = mLayerEntities.constBegin(); it != mLayerEntities.constEnd(); ++it )
   {

--- a/src/3d/qgs3dsceneexporter.cpp
+++ b/src/3d/qgs3dsceneexporter.cpp
@@ -254,7 +254,7 @@ void Qgs3DSceneExporter::processEntityMaterial( Qt3DCore::QEntity *entity, Qgs3D
 void Qgs3DSceneExporter::parseTerrain( QgsTerrainEntity *terrain, const QString &layerName )
 {
   Qgs3DMapSettings *settings = terrain->mapSettings();
-  if ( !settings->terrainRenderingEnabled() )
+  if ( !settings->terrainRenderingEnabled() || !mTerrainExportEnabled )
     return;
 
   QgsChunkNode *node = terrain->rootNode();

--- a/src/3d/qgs3dsceneexporter.h
+++ b/src/3d/qgs3dsceneexporter.h
@@ -112,6 +112,24 @@ class _3D_EXPORT Qgs3DSceneExporter : public Qt3DCore::QEntity
     //! Returns the scale of the exported 3D model
     float scale() const { return mScale; }
 
+    /**
+     * Returns whether terrain export is enabled.
+     * It terrain export is disabled, the terrain resolution and terrain texture resolution
+     * parameters have no effect.
+     *
+     * \see setTerrainExportEnabled()
+     * \since QGIS 4.0
+     */
+    bool terrainExportEnabled() const { return mTerrainExportEnabled; }
+
+    /**
+     * Sets whether terrain export is enabled.
+     *
+     * \see terrainExportEnabled()
+     * \since QGIS 4.0
+     */
+    void setTerrainExportEnabled( bool enabled ) { mTerrainExportEnabled = enabled; }
+
   private:
     //! Constructs Qgs3DExportObject from instanced point geometry
     QVector<Qgs3DExportObject *> processInstancedPointGeometry( Qt3DCore::QEntity *entity, const QString &objectNamePrefix );
@@ -152,6 +170,7 @@ class _3D_EXPORT Qgs3DSceneExporter : public Qt3DCore::QEntity
     bool mExportTextures = false;
     int mTerrainTextureResolution = 512;
     float mScale = 1.0f;
+    bool mTerrainExportEnabled = true;
 
     QSet<QgsFeatureId> mExportedFeatureIds;
 

--- a/src/3d/terrain/qgsdemterraingenerator.cpp
+++ b/src/3d/terrain/qgsdemterraingenerator.cpp
@@ -116,3 +116,8 @@ void QgsDemTerrainGenerator::updateGenerator()
     mIsValid = false;
   }
 }
+
+QgsTerrainGenerator::Capabilities QgsDemTerrainGenerator::capabilities() const
+{
+  return QgsTerrainGenerator::Capability::SupportsTileResolution;
+}

--- a/src/3d/terrain/qgsdemterraingenerator.h
+++ b/src/3d/terrain/qgsdemterraingenerator.h
@@ -79,6 +79,8 @@ class _3D_EXPORT QgsDemTerrainGenerator : public QgsTerrainGenerator
 
     QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const override SIP_FACTORY;
 
+    QgsTerrainGenerator::Capabilities capabilities() const override;
+
   private:
     void updateGenerator();
 

--- a/src/3d/terrain/qgsonlineterraingenerator.cpp
+++ b/src/3d/terrain/qgsonlineterraingenerator.cpp
@@ -96,3 +96,8 @@ void QgsOnlineTerrainGenerator::updateGenerator()
 
   mHeightMapGenerator = std::make_unique<QgsDemHeightMapGenerator>( nullptr, mTerrainTilingScheme, mResolution, mTransformContext );
 }
+
+QgsTerrainGenerator::Capabilities QgsOnlineTerrainGenerator::capabilities() const
+{
+  return QgsTerrainGenerator::Capability::SupportsTileResolution;
+}

--- a/src/3d/terrain/qgsonlineterraingenerator.h
+++ b/src/3d/terrain/qgsonlineterraingenerator.h
@@ -72,6 +72,8 @@ class _3D_EXPORT QgsOnlineTerrainGenerator : public QgsTerrainGenerator
 
     QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const override SIP_FACTORY;
 
+    QgsTerrainGenerator::Capabilities capabilities() const override;
+
   private:
     void updateGenerator();
 

--- a/src/3d/terrain/qgsterraingenerator.cpp
+++ b/src/3d/terrain/qgsterraingenerator.cpp
@@ -80,3 +80,8 @@ bool QgsTerrainGenerator::isValid() const
 {
   return mIsValid;
 }
+
+QgsTerrainGenerator::Capabilities QgsTerrainGenerator::capabilities() const
+{
+  return QgsTerrainGenerator::Capability::NoCapabilities;
+}

--- a/src/3d/terrain/qgsterraingenerator.h
+++ b/src/3d/terrain/qgsterraingenerator.h
@@ -59,6 +59,28 @@ class _3D_EXPORT QgsTerrainGenerator : public QgsQuadtreeChunkLoaderFactory
       QuantizedMesh, //!< Terrain is built from quantized mesh tiles
     };
 
+    /**
+     * Specific capabilities of the terrain generator
+     *
+     * \since QGIS 4.0
+     */
+    enum class Capability : int
+    {
+      NoCapabilities = 1 << 0,         //!< No specific capabilities
+      SupportsTileResolution = 1 << 1, //!< Supports tile resolution
+    };
+
+    Q_ENUM( Capability )
+    Q_DECLARE_FLAGS( Capabilities, Capability )
+    Q_FLAG( Capabilities )
+
+    /**
+     * Returns flags containing the supported capabilities
+     *
+     * \since QGIS.4.0
+     */
+    virtual QgsTerrainGenerator::Capabilities capabilities() const;
+
     //! Sets terrain entity for the generator (does not transfer ownership)
     virtual void setTerrain( QgsTerrainEntity *t ) { mTerrain = t; }
 

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -818,7 +818,7 @@ void Qgs3DMapCanvasWidget::configure()
 
 void Qgs3DMapCanvasWidget::exportScene()
 {
-  QDialog dlg;
+  QDialog dlg( this );
   dlg.setWindowTitle( tr( "Export 3D Scene" ) );
   dlg.setObjectName( u"3DSceneExportDialog"_s );
   QgsGui::enableAutoGeometryRestore( &dlg );

--- a/src/app/3d/qgsmap3dexportwidget.cpp
+++ b/src/app/3d/qgsmap3dexportwidget.cpp
@@ -72,6 +72,8 @@ void QgsMap3DExportWidget::loadSettings()
   // Do not enable terrain options if terrain rendering is disabled
   if ( mScene->mapSettings()->terrainRenderingEnabled() )
   {
+    ui->terrainGroup->setEnabled( true );
+    ui->terrainGroup->setChecked( true );
     ui->terrainTextureResolutionLabel->setEnabled( true );
     ui->terrainTextureResolutionSpinBox->setEnabled( true );
 
@@ -91,12 +93,9 @@ void QgsMap3DExportWidget::loadSettings()
   }
   else
   {
-    ui->terrainResolutionLabel->setEnabled( false );
-    ui->terrainResolutionSpinBox->setEnabled( false );
-    ui->terrainResolutionSpinBox->setToolTip( tr( "Enable terrain rendering to use this option." ) );
-    ui->terrainTextureResolutionLabel->setEnabled( false );
-    ui->terrainTextureResolutionSpinBox->setEnabled( false );
-    ui->terrainTextureResolutionSpinBox->setToolTip( tr( "Enable terrain rendering to use this option." ) );
+    ui->terrainGroup->setEnabled( false );
+    ui->terrainGroup->setChecked( false );
+    ui->terrainGroup->setToolTip( tr( "Enable terrain rendering to use this option." ) );
   }
 }
 
@@ -110,6 +109,7 @@ void QgsMap3DExportWidget::settingsChanged()
   mExportSettings->setExportTextures( ui->exportTexturesCheckBox->isChecked() );
   mExportSettings->setTerrainTextureResolution( ui->terrainTextureResolutionSpinBox->value() );
   mExportSettings->setScale( ui->scaleSpinBox->value() );
+  mExportSettings->setTerrainExportEnabled( ui->terrainGroup->isEnabled() && ui->terrainGroup->isChecked() );
 }
 
 bool QgsMap3DExportWidget::exportScene()

--- a/src/app/3d/qgsmap3dexportwidget.cpp
+++ b/src/app/3d/qgsmap3dexportwidget.cpp
@@ -72,10 +72,22 @@ void QgsMap3DExportWidget::loadSettings()
   // Do not enable terrain options if terrain rendering is disabled
   if ( mScene->mapSettings()->terrainRenderingEnabled() )
   {
-    ui->terrainResolutionLabel->setEnabled( true );
-    ui->terrainResolutionSpinBox->setEnabled( true );
     ui->terrainTextureResolutionLabel->setEnabled( true );
     ui->terrainTextureResolutionSpinBox->setEnabled( true );
+
+    // Only Dem and Online types handle terrain resolution
+    const QgsTerrainGenerator *terrainGenerator = mScene->mapSettings()->terrainGenerator();
+    if ( terrainGenerator->type() == QgsTerrainGenerator::Dem || terrainGenerator->type() == QgsTerrainGenerator::Online )
+    {
+      ui->terrainResolutionLabel->setEnabled( true );
+      ui->terrainResolutionSpinBox->setEnabled( true );
+    }
+    else
+    {
+      ui->terrainResolutionLabel->setEnabled( false );
+      ui->terrainResolutionSpinBox->setEnabled( false );
+      ui->terrainResolutionSpinBox->setToolTip( tr( "This option is unavailable for the %1 terrain type." ).arg( terrainGenerator->typeToString( terrainGenerator->type() ) ) );
+    }
   }
   else
   {

--- a/src/app/3d/qgsmap3dexportwidget.cpp
+++ b/src/app/3d/qgsmap3dexportwidget.cpp
@@ -79,7 +79,7 @@ void QgsMap3DExportWidget::loadSettings()
 
     // Only Dem and Online types handle terrain resolution
     const QgsTerrainGenerator *terrainGenerator = mScene->mapSettings()->terrainGenerator();
-    if ( terrainGenerator->type() == QgsTerrainGenerator::Dem || terrainGenerator->type() == QgsTerrainGenerator::Online )
+    if ( terrainGenerator->capabilities().testFlag( QgsTerrainGenerator::Capability::SupportsTileResolution ) )
     {
       ui->terrainResolutionLabel->setEnabled( true );
       ui->terrainResolutionSpinBox->setEnabled( true );

--- a/src/app/3d/qgsmap3dexportwidget.cpp
+++ b/src/app/3d/qgsmap3dexportwidget.cpp
@@ -19,6 +19,7 @@
 #include "qgis.h"
 #include "qgs3dmapexportsettings.h"
 #include "qgs3dmapscene.h"
+#include "qgs3dmapsettings.h"
 #include "qgssettings.h"
 
 #include <QFileDialog>
@@ -67,6 +68,24 @@ void QgsMap3DExportWidget::loadSettings()
   ui->exportNormalsCheckBox->setChecked( mExportSettings->exportNormals() );
   ui->exportTexturesCheckBox->setChecked( mExportSettings->exportTextures() );
   ui->scaleSpinBox->setValue( mExportSettings->scale() );
+
+  // Do not enable terrain options if terrain rendering is disabled
+  if ( mScene->mapSettings()->terrainRenderingEnabled() )
+  {
+    ui->terrainResolutionLabel->setEnabled( true );
+    ui->terrainResolutionSpinBox->setEnabled( true );
+    ui->terrainTextureResolutionLabel->setEnabled( true );
+    ui->terrainTextureResolutionSpinBox->setEnabled( true );
+  }
+  else
+  {
+    ui->terrainResolutionLabel->setEnabled( false );
+    ui->terrainResolutionSpinBox->setEnabled( false );
+    ui->terrainResolutionSpinBox->setToolTip( tr( "Enable terrain rendering to use this option." ) );
+    ui->terrainTextureResolutionLabel->setEnabled( false );
+    ui->terrainTextureResolutionSpinBox->setEnabled( false );
+    ui->terrainTextureResolutionSpinBox->setToolTip( tr( "Enable terrain rendering to use this option." ) );
+  }
 }
 
 void QgsMap3DExportWidget::settingsChanged()

--- a/src/ui/3d/map3dexportwidget.ui
+++ b/src/ui/3d/map3dexportwidget.ui
@@ -53,7 +53,7 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="terrainTextureResolutionLabel">
        <property name="text">
         <string>Terrain texture resolution</string>
        </property>
@@ -116,7 +116,7 @@
       </widget>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="terrainResolutionLabel">
        <property name="text">
         <string>Terrain resolution</string>
        </property>

--- a/src/ui/3d/map3dexportwidget.ui
+++ b/src/ui/3d/map3dexportwidget.ui
@@ -25,20 +25,7 @@
    </property>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
-     <item row="3" column="1" colspan="2">
-      <widget class="QgsSpinBox" name="terrainTextureResolutionSpinBox">
-       <property name="minimum">
-        <number>16</number>
-       </property>
-       <property name="maximum">
-        <number>4096</number>
-       </property>
-       <property name="value">
-        <number>512</number>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0" colspan="3">
+     <item row="3" column="0" colspan="3">
       <widget class="QCheckBox" name="smoothEdgesCheckBox">
        <property name="text">
         <string>Smooth edges</string>
@@ -52,13 +39,6 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="terrainTextureResolutionLabel">
-       <property name="text">
-        <string>Terrain texture resolution</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="sceneNameLabel">
        <property name="text">
@@ -69,7 +49,7 @@
      <item row="1" column="1" colspan="2">
       <widget class="QgsFileWidget" name="selectFolderWidget" native="true"/>
      </item>
-     <item row="8" column="1">
+     <item row="8" column="0">
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -82,27 +62,14 @@
        </property>
       </spacer>
      </item>
-     <item row="7" column="0" colspan="3">
+     <item row="5" column="0" colspan="3">
       <widget class="QCheckBox" name="exportTexturesCheckBox">
        <property name="text">
         <string>Export textures</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1" colspan="2">
-      <widget class="QgsSpinBox" name="terrainResolutionSpinBox">
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>4096</number>
-       </property>
-       <property name="value">
-        <number>1</number>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0" colspan="3">
+     <item row="4" column="0" colspan="3">
       <widget class="QCheckBox" name="exportNormalsCheckBox">
        <property name="text">
         <string>Export normals</string>
@@ -115,17 +82,10 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="terrainResolutionLabel">
-       <property name="text">
-        <string>Terrain resolution</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="1" colspan="2">
       <widget class="QLineEdit" name="sceneNameLineEdit"/>
      </item>
-     <item row="4" column="1" colspan="2">
+     <item row="2" column="1" colspan="2">
       <widget class="QgsDoubleSpinBox" name="scaleSpinBox">
        <property name="minimum">
         <double>0.100000000000000</double>
@@ -138,11 +98,82 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Model scale</string>
        </property>
+      </widget>
+     </item>
+     <item row="6" column="0" colspan="3">
+      <spacer name="fixedSpacer12">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint">
+        <size>
+         <width>20</width>
+         <height>12</height>
+        </size>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+      </spacer>
+     </item>
+     <item row="7" column="0" colspan="3">
+      <widget class="QGroupBox" name="terrainGroup">
+       <property name="title">
+         <string>Export Terrain</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="terrainLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="terrainTextureResolutionLabel">
+          <property name="text">
+           <string>Terrain texture resolution</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QgsSpinBox" name="terrainTextureResolutionSpinBox">
+          <property name="minimum">
+           <number>16</number>
+          </property>
+          <property name="maximum">
+           <number>4096</number>
+          </property>
+          <property name="value">
+           <number>512</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="terrainResolutionLabel">
+          <property name="text">
+           <string>Terrain resolution</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1" colspan="2">
+         <widget class="QgsSpinBox" name="terrainResolutionSpinBox">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>4096</number>
+          </property>
+          <property name="value">
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
## Description

This adds an option to enable or disable terrain export

This also fixes 2 issues on the current user interface: 
- terrain options are always activated, even when terrain rendering is disabled
- the `terrain resolution` option is only relevant for DTM or online terrain. It must be disabled for other terrain types

## Updated dialog

<img width="1038" height="650" alt="Capture d’écran du 2026-01-08 18-27-45" src="https://github.com/user-attachments/assets/b411c62a-fe2e-45a3-b95e-6d77084b14b5" />

**Funded by Stadt Frankfurt am Main**