### PR TITLE
nix: fix loading of spatialite extension in DB Manager

### DIFF
--- a/nix/spatialite-path.patch
+++ b/nix/spatialite-path.patch
@@ -1,0 +1,14 @@
+diff --git a/python/utils.py b/python/utils.py
+index 1234567890..abcdef1234 100644
+--- a/python/utils.py
++++ b/python/utils.py
+@@ -938,6 +938,7 @@ def spatialite_connect(*args, **kwargs):
+     con = sqlite3.dbapi2.connect(*args, **kwargs)
+     con.enable_load_extension(True)
+     cur = con.cursor()
+     libs = [
++        ("@spatialiteLib@", "sqlite3_modspatialite_init"),
+         # SpatiaLite >= 4.2 and Sqlite >= 3.7.17, should work on all platforms
+         ("mod_spatialite", "sqlite3_modspatialite_init"),
+         # SpatiaLite >= 4.2 and Sqlite < 3.7.17 (Travis)
+         ("mod_spatialite.so", "sqlite3_modspatialite_init"),

--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -192,6 +192,9 @@ stdenv.mkDerivation
       pyQt6PackageDir = "${py.pkgs.pyqt6}/${py.pkgs.python.sitePackages}";
       qsciPackageDir = "${py.pkgs.qscintilla-qt6}/${py.pkgs.python.sitePackages}";
     })
+    (replaceVars ./spatialite-path.patch {
+      spatialiteLib = "${libspatialite}/lib/mod_spatialite.so";
+    })
   ];
 
   # Add path to Qt platform plugins


### PR DESCRIPTION
## Description

SQLite's load_extension() cannot find mod_spatialite.so in the Nix store
using standard library search paths. This commit adds a patch that
injects the full Nix store path to libspatialite as the first entry in
the extension search list, ensuring the db_manager plugin and other
spatialite-dependent features work correctly.

Tested in Python console: 

```python
from qgis.utils import spatialite_connect; conn = spatialite_connect(':memory:'); cur = conn.cursor(); cur.execute("SELECT spatialite_version()"); print(f"✓ SpatiaLite
  version: {cur.fetchone()[0]}")

<sqlite3.Cursor object at 0x7f4b5001f2c0>
✓ SpatiaLite version: 5.1.0
```

Run QGIS from this PR

```bash
nix run github:imincik/QGIS/fix-spatialite-loading#qgis
```

Closes #64268


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
