### PR TITLE
Clarify Polyline vs MultiLineString behavior in PyQGIS documentation

### DIFF
--- a/doc/modules.dox
+++ b/doc/modules.dox
@@ -44,4 +44,3 @@ The QgsQuick library is built on top of the CORE library and Qt Quick/QML framew
 */
 
 
-

--- a/doc/modules.dox
+++ b/doc/modules.dox
@@ -44,3 +44,4 @@ The QgsQuick library is built on top of the CORE library and Qt Quick/QML framew
 */
 
 
+

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -173,6 +173,36 @@ class CORE_EXPORT QgsGeometryParameters
  * methods for working with geodesic calculations and spatial operations on geometries,
  * and should be used whenever calculations which account for the curvature of the Earth (or any other celestial body)
  * are required.
+  *
+ * \note Polyline vs MultiLineString behavior
+ *
+ * In the QGIS API and PyQGIS, there is an important distinction between
+ * geometry construction methods and vector layer geometry types which
+ * can be confusing.
+ *
+ * A Polyline represents a single-part line geometry composed of one
+ * continuous sequence of vertices. Geometry construction methods such as
+ * fromPolyline() or fromPolylineXY() create single-part line geometries.
+ *
+ * A MultiLineString represents a multipart line geometry composed of
+ * multiple independent line parts. When creating a vector layer intended
+ * to store line features, QGIS requires the geometry type to be specified
+ * as MultiLineString.
+ *
+ * Even when a geometry consists of a single line part, QGIS may silently
+ * promote a single-part polyline to a multipart geometry when adding it
+ * to a layer. No error or warning is raised in this case.
+ *
+ * When working with line geometries in PyQGIS, it is therefore recommended
+ * to explicitly handle both single-part and multipart geometries.
+ *
+ * \code{.py}
+ * geom = feature.geometry()
+ * if geom.isMultipart():
+ *     lines = geom.asMultiPolyline()
+ * else:
+ *     line = geom.asPolyline()
+ * \endcode
  */
 class CORE_EXPORT QgsGeometry
 {

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -204,7 +204,6 @@ class CORE_EXPORT QgsGeometryParameters
  *     line = geom.asPolyline()
  * \endcode
  */
-
 class CORE_EXPORT QgsGeometry
 {
     Q_GADGET

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -173,7 +173,7 @@ class CORE_EXPORT QgsGeometryParameters
  * methods for working with geodesic calculations and spatial operations on geometries,
  * and should be used whenever calculations which account for the curvature of the Earth (or any other celestial body)
  * are required.
-  *
+ *
  * \note Polyline vs MultiLineString behavior
  *
  * In the QGIS API and PyQGIS, there is an important distinction between
@@ -204,6 +204,7 @@ class CORE_EXPORT QgsGeometryParameters
  *     line = geom.asPolyline()
  * \endcode
  */
+
 class CORE_EXPORT QgsGeometry
 {
     Q_GADGET

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -196,13 +196,13 @@ class CORE_EXPORT QgsGeometryParameters
  * When working with line geometries in PyQGIS, it is therefore recommended
  * to explicitly handle both single-part and multipart geometries.
  *
- * \code{.py}
- * geom = feature.geometry()
- * if geom.isMultipart():
- *     lines = geom.asMultiPolyline()
- * else:
- *     line = geom.asPolyline()
- * \endcode
+ \code{.py}
+ geom = feature.geometry()
+ if geom.isMultipart():
+     lines = geom.asMultiPolyline()
+ else:
+     line = geom.asPolyline()
+ \endcode
  */
 class CORE_EXPORT QgsGeometry
 {


### PR DESCRIPTION
This PR adds documentation clarifying the difference between Polyline and
MultiLineString geometries in PyQGIS, explaining the distinction between
geometry construction methods and vector layer geometry types and why
single-part polylines may be promoted to multipart geometries when added
to layers.
fixes #57348 
