### PR TITLE
Remove obsolete class QLinkedList

### DIFF
--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -46,8 +46,6 @@
 #include "qgstextlabelfeature.h"
 #include "qgstextrendererutils.h"
 
-#include <QLinkedList>
-
 using namespace pal;
 
 FeaturePart::FeaturePart( QgsLabelFeature *feat, const GEOSGeometry *geom )
@@ -1809,7 +1807,7 @@ std::size_t FeaturePart::createCandidatesForPolygon( std::vector< std::unique_pt
   if ( pal->isCanceled() )
     return 0;
 
-  QLinkedList<PointSet *> shapes_final = splitPolygons( mapShape, labelWidth, labelHeight );
+  QVector<PointSet *> shapes_final = splitPolygons( mapShape, labelWidth, labelHeight );
 #if 0
   QgsDebugMsgLevel( u"PAL split polygons resulted in:"_s, 2 );
   for ( PointSet *ps : shapes_final )

--- a/src/core/pal/layer.h
+++ b/src/core/pal/layer.h
@@ -42,7 +42,6 @@
 #include "qgslabelobstaclesettings.h"
 
 #include <QHash>
-#include <QLinkedList>
 #include <QMutex>
 
 class QgsLabelFeature;

--- a/src/core/pal/pointset.cpp
+++ b/src/core/pal/pointset.cpp
@@ -294,7 +294,7 @@ bool PointSet::containsLabelCandidate( double x, double y, double width, double 
   return GeomFunction::containsCandidate( preparedGeom(), x, y, width, height, alpha );
 }
 
-QLinkedList<PointSet *> PointSet::splitPolygons( PointSet *inputShape, double labelWidth, double labelHeight )
+QVector<PointSet *> PointSet::splitPolygons( PointSet *inputShape, double labelWidth, double labelHeight )
 {
   int j;
 
@@ -309,9 +309,9 @@ QLinkedList<PointSet *> PointSet::splitPolygons( PointSet *inputShape, double la
 
   const double labelArea = labelWidth * labelHeight;
 
-  QLinkedList<PointSet *> inputShapes;
+  QVector<PointSet *> inputShapes;
   inputShapes.push_back( inputShape );
-  QLinkedList<PointSet *> outputShapes;
+  QVector<PointSet *> outputShapes;
 
   while ( !inputShapes.isEmpty() )
   {

--- a/src/core/pal/pointset.h
+++ b/src/core/pal/pointset.h
@@ -43,8 +43,6 @@
 #include "qgsgeos.h"
 #include "qgsrectangle.h"
 
-#include <QLinkedList>
-
 namespace pal
 {
 
@@ -126,7 +124,7 @@ namespace pal
        *
        * \warning this code is completely unreadable and cannot be understood by mortals
        */
-      static QLinkedList<PointSet *> splitPolygons( PointSet *inputShape, double labelWidth, double labelHeight );
+      static QVector<PointSet *> splitPolygons( PointSet *inputShape, double labelWidth, double labelHeight );
 
       /**
        * Extends linestrings by the specified amount at the start and end of the line,

--- a/src/core/pal/problem.cpp
+++ b/src/core/pal/problem.cpp
@@ -284,8 +284,8 @@ inline std::unique_ptr<Chain> Problem::chain( int seed )
 
   const int max_degree = pal->mEjChainDeg;
 
-  QLinkedList<ElemTrans *> currentChain;
-  QLinkedList<int> conflicts;
+  QVector<ElemTrans *> currentChain;
+  QVector<int> conflicts;
 
   std::vector< int > tmpsol( mSol.activeLabelIds );
 
@@ -331,8 +331,7 @@ inline std::unique_ptr<Chain> Problem::chain( int seed )
                 const int feat = lp2->getProblemFeatureId();
 
                 // is there any cycles ?
-                QLinkedList< ElemTrans * >::iterator cur;
-                for ( cur = currentChain.begin(); cur != currentChain.end(); ++cur )
+                for ( auto cur = currentChain.begin(); cur != currentChain.end(); ++cur )
                 {
                   if ( ( *cur )->feat == feat )
                   {
@@ -369,7 +368,7 @@ inline std::unique_ptr<Chain> Problem::chain( int seed )
                 retainedChain->degree = currentChain.size() + 1;
                 retainedChain->feat.resize( retainedChain->degree );
                 retainedChain->label.resize( retainedChain->degree );
-                QLinkedList<ElemTrans *>::iterator current = currentChain.begin();
+                QVector<ElemTrans *>::iterator current = currentChain.begin();
                 ElemTrans *move = nullptr;
                 int j = 0;
                 while ( current != currentChain.end() )
@@ -408,7 +407,7 @@ inline std::unique_ptr<Chain> Problem::chain( int seed )
               newChain->degree = currentChain.size() + 1 + conflicts.size();
               newChain->feat.resize( newChain->degree );
               newChain->label.resize( newChain->degree );
-              QLinkedList<ElemTrans *>::iterator current = currentChain.begin();
+              QVector<ElemTrans *>::iterator current = currentChain.begin();
               ElemTrans *move = nullptr;
               int j = 0;
 
@@ -466,7 +465,7 @@ inline std::unique_ptr<Chain> Problem::chain( int seed )
               retainedChain->degree = currentChain.size() + 1;
               retainedChain->feat.resize( retainedChain->degree );
               retainedChain->label.resize( retainedChain->degree );
-              QLinkedList<ElemTrans *>::iterator current = currentChain.begin();
+              QVector<ElemTrans *>::iterator current = currentChain.begin();
               ElemTrans *move = nullptr;
               int j = 0;
               while ( current != currentChain.end() )

--- a/src/core/pal/util.cpp
+++ b/src/core/pal/util.cpp
@@ -29,27 +29,25 @@
 
 #include "util.h"
 
-#include <cfloat>
-
 #include "qgsgeos.h"
 #include "qgslogger.h"
 
-QLinkedList<const GEOSGeometry *> *pal::Util::unmulti( const GEOSGeometry *the_geom )
+std::optional<QVector<const GEOSGeometry *>> pal::Util::unmulti( const GEOSGeometry *the_geom )
 {
-  QLinkedList<const GEOSGeometry *> *queue = new QLinkedList<const GEOSGeometry *>;
-  QLinkedList<const GEOSGeometry *> *final_queue = new QLinkedList<const GEOSGeometry *>;
+  QVector<const GEOSGeometry *> queue;
+  QVector<const GEOSGeometry *> final_queue;
 
   const GEOSGeometry *geom = nullptr;
 
-  queue->append( the_geom );
+  queue.append( the_geom );
   int nGeom;
   int i;
 
   GEOSContextHandle_t geosctxt = QgsGeosContext::get();
 
-  while ( !queue->isEmpty() )
+  while ( !queue.isEmpty() )
   {
-    geom = queue->takeFirst();
+    geom = queue.takeFirst();
     const int type = GEOSGeomTypeId_r( geosctxt, geom );
     switch ( type )
     {
@@ -60,22 +58,19 @@ QLinkedList<const GEOSGeometry *> *pal::Util::unmulti( const GEOSGeometry *the_g
         nGeom = GEOSGetNumGeometries_r( geosctxt, geom );
         for ( i = 0; i < nGeom; i++ )
         {
-          queue->append( GEOSGetGeometryN_r( geosctxt, geom, i ) );
+          queue.append( GEOSGetGeometryN_r( geosctxt, geom, i ) );
         }
         break;
       case GEOS_POINT:
       case GEOS_LINESTRING:
       case GEOS_POLYGON:
-        final_queue->append( geom );
+        final_queue.append( geom );
         break;
       default:
         QgsDebugError( u"unexpected geometry type:%1"_s.arg( type ) );
-        delete final_queue;
-        delete queue;
-        return nullptr;
+        return {};
     }
   }
-  delete queue;
 
   return final_queue;
 }

--- a/src/core/pal/util.h
+++ b/src/core/pal/util.h
@@ -36,8 +36,7 @@
 #include <memory>
 #include <vector>
 
-#include <QLinkedList>
-#include <QList>
+#include <QVector>
 
 typedef struct GEOSGeom_t GEOSGeometry;
 
@@ -90,8 +89,7 @@ namespace pal
   class Util
   {
     public:
-
-      static QLinkedList<const GEOSGeometry *> *unmulti( const GEOSGeometry *the_geom );
+      static std::optional<QVector<const GEOSGeometry *>> unmulti( const GEOSGeometry *the_geom );
   };
 
 

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -33,7 +33,6 @@
 #include "qgsvectorlayerfeatureiterator.h"
 #include "qgswkbptr.h"
 
-#include <QLinkedListIterator>
 #include <QtConcurrent>
 
 #include "moc_qgspointlocator.cpp"
@@ -66,7 +65,10 @@ static const double POINT_LOC_EPSILON = 1e-12;
 class QgsPointLocator_Stream : public IDataStream
 {
   public:
-    explicit QgsPointLocator_Stream( const QLinkedList<RTree::Data *> &dataList )
+    /**
+     * \brief Construct a QgsPointLocator_Stream
+     */
+    explicit QgsPointLocator_Stream( const QVector<RTree::Data *> &dataList )
       : mDataList( dataList )
       , mIt( mDataList )
     { }
@@ -78,8 +80,8 @@ class QgsPointLocator_Stream : public IDataStream
     void rewind() override { Q_ASSERT( false && "not available" ); }
 
   private:
-    QLinkedList<RTree::Data *> mDataList;
-    QLinkedListIterator<RTree::Data *> mIt;
+    QVector<RTree::Data *> mDataList;
+    QVectorIterator<RTree::Data *> mIt;
 };
 
 
@@ -1046,7 +1048,7 @@ bool QgsPointLocator::rebuildIndex( int maxFeaturesToIndex )
 
   destroyIndex();
 
-  QLinkedList<RTree::Data *> dataList;
+  QVector<RTree::Data *> dataList;
   QgsFeature f;
 
   QgsFeatureRequest request;


### PR DESCRIPTION
`QLinkedList` was made obsolete in Qt 5, and moved to the Qt 5 Compatibility module in Qt 6.

This PR replaces usage of `QLinkedList` by `QVector` (no usage of the class actually required the semantics of a true linked list).