### PR TITLE
[attribute form] Add the ability to preview the attributes form within the vector layer properties dialog

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsvectorlayerutils.py
+++ b/python/PyQt6/core/auto_additions/qgsvectorlayerutils.py
@@ -1,4 +1,15 @@
 # The following has been generated automatically from src/core/vector/qgsvectorlayerutils.h
+# monkey patching scoped based enum
+QgsVectorLayerUtils.FieldIsEditableFlag.IgnoreLayerEditability.__doc__ = "Ignores the vector layer's editable state"
+QgsVectorLayerUtils.FieldIsEditableFlag.__doc__ = """Flags used with the :py:func:`~QgsVectorLayerUtils.fieldIsEditable` function
+
+.. versionadded:: 4.0
+
+* ``IgnoreLayerEditability``: Ignores the vector layer's editable state
+
+"""
+# --
+QgsVectorLayerUtils.FieldIsEditableFlags = lambda flags=0: QgsVectorLayerUtils.FieldIsEditableFlag(flags)
 QgsVectorLayerUtils.IgnoreAuxiliaryLayers = QgsVectorLayerUtils.CascadedFeatureFlag.IgnoreAuxiliaryLayers
 QgsVectorLayerUtils.CascadedFeatureFlags = lambda flags=0: QgsVectorLayerUtils.CascadedFeatureFlag(flags)
 try:

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -77,6 +77,13 @@ Returns attributes
 
     };
 
+    enum class FieldIsEditableFlag /BaseType=IntFlag/
+    {
+      IgnoreLayerEditability,
+    };
+    typedef QFlags<QgsVectorLayerUtils::FieldIsEditableFlag> FieldIsEditableFlags;
+
+
     typedef QList<QgsVectorLayerUtils::QgsFeatureData> QgsFeaturesDataList;
 
     static QgsFeatureIterator getValuesIterator( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok, bool selectedOnly );
@@ -325,12 +332,18 @@ compatibility logic.
 .. versionadded:: 3.4
 %End
 
-    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, bool forceIsEditable = false );
+    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, QgsVectorLayerUtils::FieldIsEditableFlags flags = QgsVectorLayerUtils::FieldIsEditableFlags() );
 %Docstring
-Tests whether a field is editable for a particular ``feature``.
+Tests whether a field is editable for a particular feature.
 
-:return: ``True`` if the field at index ``fieldIndex`` from ``layer`` is
-         editable, ``False`` if the field is read only.
+:param layer: The vector layer
+:param fieldIndex: The field index
+:param feature: The feature
+:param flags: Additional flags modifying the editability check behavior
+              (since QGIS 4.0)
+
+:return: ``True`` if the field is editable, ``False`` if the field is
+         read only.
 
 .. versionadded:: 3.10
 %End

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -325,7 +325,7 @@ compatibility logic.
 .. versionadded:: 3.4
 %End
 
-    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature );
+    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, bool forceIsEditable = false );
 %Docstring
 Tests whether a field is editable for a particular ``feature``.
 

--- a/python/PyQt6/gui/auto_additions/qgsattributeeditorcontext.py
+++ b/python/PyQt6/gui/auto_additions/qgsattributeeditorcontext.py
@@ -6,6 +6,7 @@ QgsAttributeEditorContext.MultiEditMode = QgsAttributeEditorContext.Mode.MultiEd
 QgsAttributeEditorContext.SearchMode = QgsAttributeEditorContext.Mode.SearchMode
 QgsAttributeEditorContext.AggregateSearchMode = QgsAttributeEditorContext.Mode.AggregateSearchMode
 QgsAttributeEditorContext.IdentifyMode = QgsAttributeEditorContext.Mode.IdentifyMode
+QgsAttributeEditorContext.PreviewMode = QgsAttributeEditorContext.Mode.PreviewMode
 QgsAttributeEditorContext.Mode.baseClass = QgsAttributeEditorContext
 QgsAttributeEditorContext.Undefined = QgsAttributeEditorContext.RelationMode.Undefined
 QgsAttributeEditorContext.Multiple = QgsAttributeEditorContext.RelationMode.Multiple

--- a/python/PyQt6/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -35,7 +35,8 @@ showing an embedded form due to relations)
       MultiEditMode,
       SearchMode,
       AggregateSearchMode,
-      IdentifyMode
+      IdentifyMode,
+      PreviewMode
     };
 
     enum RelationMode /BaseType=IntEnum/

--- a/python/core/auto_additions/qgsvectorlayerutils.py
+++ b/python/core/auto_additions/qgsvectorlayerutils.py
@@ -1,4 +1,14 @@
 # The following has been generated automatically from src/core/vector/qgsvectorlayerutils.h
+# monkey patching scoped based enum
+QgsVectorLayerUtils.FieldIsEditableFlag.IgnoreLayerEditability.__doc__ = "Ignores the vector layer's editable state"
+QgsVectorLayerUtils.FieldIsEditableFlag.__doc__ = """Flags used with the :py:func:`~QgsVectorLayerUtils.fieldIsEditable` function
+
+.. versionadded:: 4.0
+
+* ``IgnoreLayerEditability``: Ignores the vector layer's editable state
+
+"""
+# --
 try:
     QgsVectorLayerUtils.getValuesIterator = staticmethod(QgsVectorLayerUtils.getValuesIterator)
     QgsVectorLayerUtils.getValues = staticmethod(QgsVectorLayerUtils.getValues)

--- a/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -77,6 +77,13 @@ Returns attributes
 
     };
 
+    enum class FieldIsEditableFlag
+    {
+      IgnoreLayerEditability,
+    };
+    typedef QFlags<QgsVectorLayerUtils::FieldIsEditableFlag> FieldIsEditableFlags;
+
+
     typedef QList<QgsVectorLayerUtils::QgsFeatureData> QgsFeaturesDataList;
 
     static QgsFeatureIterator getValuesIterator( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok, bool selectedOnly );
@@ -325,12 +332,18 @@ compatibility logic.
 .. versionadded:: 3.4
 %End
 
-    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, bool forceIsEditable = false );
+    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, QgsVectorLayerUtils::FieldIsEditableFlags flags = QgsVectorLayerUtils::FieldIsEditableFlags() );
 %Docstring
-Tests whether a field is editable for a particular ``feature``.
+Tests whether a field is editable for a particular feature.
 
-:return: ``True`` if the field at index ``fieldIndex`` from ``layer`` is
-         editable, ``False`` if the field is read only.
+:param layer: The vector layer
+:param fieldIndex: The field index
+:param feature: The feature
+:param flags: Additional flags modifying the editability check behavior
+              (since QGIS 4.0)
+
+:return: ``True`` if the field is editable, ``False`` if the field is
+         read only.
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -325,7 +325,7 @@ compatibility logic.
 .. versionadded:: 3.4
 %End
 
-    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature );
+    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, bool forceIsEditable = false );
 %Docstring
 Tests whether a field is editable for a particular ``feature``.
 

--- a/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -35,7 +35,8 @@ showing an embedded form due to relations)
       MultiEditMode,
       SearchMode,
       AggregateSearchMode,
-      IdentifyMode
+      IdentifyMode,
+      PreviewMode
     };
 
     enum RelationMode

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -956,9 +956,9 @@ QgsAttributeMap QgsVectorLayerUtils::QgsFeatureData::attributes() const
   return mAttributes;
 }
 
-bool _fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature )
+bool _fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, bool forceIsEditable )
 {
-  return layer->isEditable() &&
+  return ( layer->isEditable() || forceIsEditable ) &&
          !layer->editFormConfig().readOnly( fieldIndex ) &&
          // Provider permissions
          layer->dataProvider() &&
@@ -1016,7 +1016,7 @@ bool QgsVectorLayerUtils::fieldEditabilityDependsOnFeature( const QgsVectorLayer
   }
 }
 
-bool QgsVectorLayerUtils::fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature )
+bool QgsVectorLayerUtils::fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, bool forceIsEditable )
 {
   if ( layer->fields().fieldOrigin( fieldIndex ) == Qgis::FieldOrigin::Join )
   {
@@ -1034,10 +1034,10 @@ bool QgsVectorLayerUtils::fieldIsEditable( const QgsVectorLayer *layer, int fiel
         return false;
     }
 
-    return _fieldIsEditable( info->joinLayer(), srcFieldIndex, feature );
+    return _fieldIsEditable( info->joinLayer(), srcFieldIndex, feature, false );
   }
-  else
-    return _fieldIsEditable( layer, fieldIndex, feature );
+
+  return _fieldIsEditable( layer, fieldIndex, feature, forceIsEditable );
 }
 
 

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -956,9 +956,9 @@ QgsAttributeMap QgsVectorLayerUtils::QgsFeatureData::attributes() const
   return mAttributes;
 }
 
-bool _fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, bool forceIsEditable )
+bool _fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, QgsVectorLayerUtils::FieldIsEditableFlags flags = QgsVectorLayerUtils::FieldIsEditableFlags() )
 {
-  return ( layer->isEditable() || forceIsEditable ) &&
+  return ( layer->isEditable() || ( flags & QgsVectorLayerUtils::FieldIsEditableFlag::IgnoreLayerEditability ) ) &&
          !layer->editFormConfig().readOnly( fieldIndex ) &&
          // Provider permissions
          layer->dataProvider() &&
@@ -1016,7 +1016,7 @@ bool QgsVectorLayerUtils::fieldEditabilityDependsOnFeature( const QgsVectorLayer
   }
 }
 
-bool QgsVectorLayerUtils::fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, bool forceIsEditable )
+bool QgsVectorLayerUtils::fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, QgsVectorLayerUtils::FieldIsEditableFlags flags )
 {
   if ( layer->fields().fieldOrigin( fieldIndex ) == Qgis::FieldOrigin::Join )
   {
@@ -1034,10 +1034,10 @@ bool QgsVectorLayerUtils::fieldIsEditable( const QgsVectorLayer *layer, int fiel
         return false;
     }
 
-    return _fieldIsEditable( info->joinLayer(), srcFieldIndex, feature, false );
+    return _fieldIsEditable( info->joinLayer(), srcFieldIndex, feature );
   }
 
-  return _fieldIsEditable( layer, fieldIndex, feature, forceIsEditable );
+  return _fieldIsEditable( layer, fieldIndex, feature, flags );
 }
 
 

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -956,7 +956,7 @@ QgsAttributeMap QgsVectorLayerUtils::QgsFeatureData::attributes() const
   return mAttributes;
 }
 
-bool _fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, QgsVectorLayerUtils::FieldIsEditableFlags flags = QgsVectorLayerUtils::FieldIsEditableFlags() )
+bool fieldIsEditablePrivate( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, QgsVectorLayerUtils::FieldIsEditableFlags flags = QgsVectorLayerUtils::FieldIsEditableFlags() )
 {
   return ( layer->isEditable() || ( flags & QgsVectorLayerUtils::FieldIsEditableFlag::IgnoreLayerEditability ) ) &&
          !layer->editFormConfig().readOnly( fieldIndex ) &&
@@ -1034,10 +1034,10 @@ bool QgsVectorLayerUtils::fieldIsEditable( const QgsVectorLayer *layer, int fiel
         return false;
     }
 
-    return _fieldIsEditable( info->joinLayer(), srcFieldIndex, feature );
+    return fieldIsEditablePrivate( info->joinLayer(), srcFieldIndex, feature );
   }
 
-  return _fieldIsEditable( layer, fieldIndex, feature, flags );
+  return fieldIsEditablePrivate( layer, fieldIndex, feature, flags );
 }
 
 

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -331,7 +331,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      *
      * \since QGIS 3.10
      */
-    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature );
+    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, bool forceIsEditable = false );
 
     /**
      * Returns TRUE if the field at index \a fieldIndex from \a layer

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -109,6 +109,16 @@ class CORE_EXPORT QgsVectorLayerUtils
         QgsAttributeMap mAttributes;
     };
 
+    /**
+     * Flags used with the fieldIsEditable() function
+     * \since QGIS 4.0
+     */
+    enum class FieldIsEditableFlag : int SIP_ENUM_BASETYPE( IntFlag )
+    {
+      IgnoreLayerEditability = 1 << 0, //!< Ignores the vector layer's editable state
+    };
+    Q_DECLARE_FLAGS( FieldIsEditableFlags, FieldIsEditableFlag )
+
     // SIP does not like "using", use legacy typedef
     //! Alias for list of QgsFeatureData
     typedef QList<QgsVectorLayerUtils::QgsFeatureData> QgsFeaturesDataList;
@@ -324,14 +334,18 @@ class CORE_EXPORT QgsVectorLayerUtils
     static QgsFeatureList makeFeaturesCompatible( const QgsFeatureList &features, const QgsVectorLayer *layer, QgsFeatureSink::SinkFlags sinkFlags = QgsFeatureSink::SinkFlags() );
 
     /**
-     * Tests whether a field is editable for a particular \a feature.
+     * Tests whether a field is editable for a particular feature.
      *
-     * \returns TRUE if the field at index \a fieldIndex from \a layer
-     * is editable, FALSE if the field is read only.
+     * \param layer The vector layer
+     * \param fieldIndex The field index
+     * \param feature The feature
+     * \param flags Additional flags modifying the editability check behavior (since QGIS 4.0)
+     *
+     * \returns TRUE if the field is editable, FALSE if the field is read only.
      *
      * \since QGIS 3.10
      */
-    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, bool forceIsEditable = false );
+    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature, QgsVectorLayerUtils::FieldIsEditableFlags flags = QgsVectorLayerUtils::FieldIsEditableFlags() );
 
     /**
      * Returns TRUE if the field at index \a fieldIndex from \a layer

--- a/src/gui/qgsattributeeditorcontext.h
+++ b/src/gui/qgsattributeeditorcontext.h
@@ -53,7 +53,8 @@ class GUI_EXPORT QgsAttributeEditorContext
       MultiEditMode,       //!< Multi edit mode, for editing fields of multiple features at once
       SearchMode,          //!< Form values are used for searching/filtering the layer
       AggregateSearchMode, //!< Form is in aggregate search mode, show each widget in this mode
-      IdentifyMode         //!< Identify the feature
+      IdentifyMode,        //!< Identify the feature
+      PreviewMode          //!< Preview mode, for previewing attribute configurations \since QGIS 4.0
     };
     Q_ENUM( Mode )
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -217,7 +217,7 @@ void QgsAttributeForm::setMode( QgsAttributeEditorContext::Mode mode )
     w->setContext( newContext );
   }
 
-  auto toggleRelationWidgetsVisibility = [this]( bool relationWidgetsVisible ) {
+  auto setRelationWidgetsVisible = [this]( bool relationWidgetsVisible ) {
     for ( QgsAttributeFormRelationEditorWidget *w : findChildren<QgsAttributeFormRelationEditorWidget *>() )
     {
       w->setVisible( relationWidgetsVisible );
@@ -227,53 +227,53 @@ void QgsAttributeForm::setMode( QgsAttributeEditorContext::Mode mode )
   switch ( mode )
   {
     case QgsAttributeEditorContext::SingleEditMode:
-      toggleRelationWidgetsVisibility( true );
+      setRelationWidgetsVisible( true );
       setFeature( mFeature );
       mSearchButtonBox->setVisible( false );
       break;
 
     case QgsAttributeEditorContext::AddFeatureMode:
-      toggleRelationWidgetsVisibility( true );
+      setRelationWidgetsVisible( true );
       synchronizeState();
       mSearchButtonBox->setVisible( false );
       break;
 
     case QgsAttributeEditorContext::FixAttributeMode:
-      toggleRelationWidgetsVisibility( true );
+      setRelationWidgetsVisible( true );
       synchronizeState();
       mSearchButtonBox->setVisible( false );
       break;
 
     case QgsAttributeEditorContext::MultiEditMode:
-      toggleRelationWidgetsVisibility( true );
+      setRelationWidgetsVisible( true );
       resetMultiEdit( false );
       synchronizeState();
       mSearchButtonBox->setVisible( false );
       break;
 
     case QgsAttributeEditorContext::SearchMode:
-      toggleRelationWidgetsVisibility( true );
+      setRelationWidgetsVisible( true );
       mSearchButtonBox->setVisible( true );
       synchronizeState();
       hideButtonBox();
       break;
 
     case QgsAttributeEditorContext::AggregateSearchMode:
-      toggleRelationWidgetsVisibility( false );
+      setRelationWidgetsVisible( false );
       mSearchButtonBox->setVisible( false );
       synchronizeState();
       hideButtonBox();
       break;
 
     case QgsAttributeEditorContext::IdentifyMode:
-      toggleRelationWidgetsVisibility( true );
+      setRelationWidgetsVisible( true );
       setFeature( mFeature );
       synchronizeState();
       mSearchButtonBox->setVisible( false );
       break;
 
     case QgsAttributeEditorContext::PreviewMode:
-      toggleRelationWidgetsVisibility( false );
+      setRelationWidgetsVisible( false );
       synchronizeState();
       mSearchButtonBox->setVisible( false );
       break;

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -203,6 +203,10 @@ void QgsAttributeForm::setMode( QgsAttributeEditorContext::Mode mode )
       case QgsAttributeEditorContext::IdentifyMode:
         w->setMode( QgsAttributeFormWidget::DefaultMode );
         break;
+
+      case QgsAttributeEditorContext::PreviewMode:
+        w->setMode( QgsAttributeFormWidget::DefaultMode );
+        break;
     }
   }
   //update all form editor widget modes to match
@@ -213,7 +217,7 @@ void QgsAttributeForm::setMode( QgsAttributeEditorContext::Mode mode )
     w->setContext( newContext );
   }
 
-  bool relationWidgetsVisible = ( mMode != QgsAttributeEditorContext::AggregateSearchMode );
+  bool relationWidgetsVisible = ( mMode != QgsAttributeEditorContext::AggregateSearchMode && mMode != QgsAttributeEditorContext::PreviewMode );
   for ( QgsAttributeFormRelationEditorWidget *w : findChildren<QgsAttributeFormRelationEditorWidget *>() )
   {
     w->setVisible( relationWidgetsVisible );
@@ -256,6 +260,11 @@ void QgsAttributeForm::setMode( QgsAttributeEditorContext::Mode mode )
 
     case QgsAttributeEditorContext::IdentifyMode:
       setFeature( mFeature );
+      synchronizeState();
+      mSearchButtonBox->setVisible( false );
+      break;
+
+    case QgsAttributeEditorContext::PreviewMode:
       synchronizeState();
       mSearchButtonBox->setVisible( false );
       break;
@@ -308,6 +317,7 @@ void QgsAttributeForm::setFeature( const QgsFeature &feature )
     case QgsAttributeEditorContext::IdentifyMode:
     case QgsAttributeEditorContext::AddFeatureMode:
     case QgsAttributeEditorContext::FixAttributeMode:
+    case QgsAttributeEditorContext::PreviewMode:
     {
       resetValues();
 
@@ -569,9 +579,10 @@ void QgsAttributeForm::updateValuesDependenciesDefaultValues( const int originId
   if ( !mDefaultValueDependencies.contains( originIdx ) )
     return;
 
-  if ( !mFeature.isValid()
-       && mMode != QgsAttributeEditorContext::AddFeatureMode )
+  if ( !mFeature.isValid() && ( mMode != QgsAttributeEditorContext::AddFeatureMode || mMode != QgsAttributeEditorContext::PreviewMode ) )
+  {
     return;
+  }
 
   // create updated Feature
   QgsFeature updatedFeature = getUpdatedFeature();
@@ -918,6 +929,9 @@ bool QgsAttributeForm::saveWithDetails( QString *error )
     case QgsAttributeEditorContext::SearchMode:
     case QgsAttributeEditorContext::AggregateSearchMode:
       break;
+
+    case QgsAttributeEditorContext::PreviewMode:
+      return true;
   }
 
   mIsSaving = true;
@@ -943,6 +957,9 @@ bool QgsAttributeForm::saveWithDetails( QString *error )
 
     case QgsAttributeEditorContext::MultiEditMode:
       success = saveMultiEdits();
+      break;
+
+    case QgsAttributeEditorContext::PreviewMode:
       break;
   }
 
@@ -1070,6 +1087,7 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
     case QgsAttributeEditorContext::IdentifyMode:
     case QgsAttributeEditorContext::AddFeatureMode:
     case QgsAttributeEditorContext::FixAttributeMode:
+    case QgsAttributeEditorContext::PreviewMode:
     {
       Q_NOWARN_DEPRECATED_PUSH
       emit attributeChanged( eww->field().name(), value );
@@ -1587,10 +1605,11 @@ bool QgsAttributeForm::needsGeometry() const
 
 void QgsAttributeForm::synchronizeState()
 {
-  bool isEditable = ( mFeature.isValid()
-                      || mMode == QgsAttributeEditorContext::AddFeatureMode
-                      || mMode == QgsAttributeEditorContext::MultiEditMode )
-                    && mLayer->isEditable();
+  bool isEditable = ( ( mFeature.isValid()
+                        || mMode == QgsAttributeEditorContext::AddFeatureMode
+                        || mMode == QgsAttributeEditorContext::MultiEditMode )
+                      && mLayer->isEditable() )
+                    || mMode == QgsAttributeEditorContext::PreviewMode;
 
   for ( QgsWidgetWrapper *ww : std::as_const( mWidgets ) )
   {
@@ -1600,7 +1619,9 @@ void QgsAttributeForm::synchronizeState()
       const QList<QgsAttributeFormEditorWidget *> formWidgets = mFormEditorWidgets.values( eww->fieldIdx() );
 
       for ( QgsAttributeFormEditorWidget *formWidget : formWidgets )
+      {
         formWidget->setConstraintResultVisible( isEditable );
+      }
 
       eww->setConstraintResultVisible( isEditable );
 
@@ -1659,7 +1680,9 @@ void QgsAttributeForm::synchronizeState()
   // change OK button status
   QPushButton *okButton = mButtonBox->button( QDialogButtonBox::Ok );
   if ( okButton )
+  {
     okButton->setEnabled( isEditable );
+  }
 }
 
 void QgsAttributeForm::init()
@@ -2992,6 +3015,7 @@ void QgsAttributeForm::layerSelectionChanged()
     case QgsAttributeEditorContext::FixAttributeMode:
     case QgsAttributeEditorContext::SearchMode:
     case QgsAttributeEditorContext::AggregateSearchMode:
+    case QgsAttributeEditorContext::PreviewMode:
       break;
 
     case QgsAttributeEditorContext::MultiEditMode:
@@ -3223,7 +3247,7 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
 
 bool QgsAttributeForm::fieldIsEditable( int fieldIndex ) const
 {
-  return QgsVectorLayerUtils::fieldIsEditable( mLayer, fieldIndex, mFeature );
+  return QgsVectorLayerUtils::fieldIsEditable( mLayer, fieldIndex, mFeature, mMode == QgsAttributeEditorContext::PreviewMode );
 }
 
 void QgsAttributeForm::updateFieldDependencies()

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -1389,8 +1389,28 @@ void QgsAttributesFormProperties::previewForm()
 
   auto projectDirtyBlocker = std::make_unique<QgsProjectDirtyBlocker>( QgsProject::instance() );
 
+
+  QgsFields fields;
+  QList<QPair<QgsField, QString>> expressionFields;
+
+  for ( int i = 0; i < mLayer->fields().size(); i++ )
+  {
+    if ( mLayer->fields().fieldOrigin( i ) == Qgis::FieldOrigin::Expression )
+    {
+      expressionFields << qMakePair( mLayer->fields().at( i ), mLayer->expressionField( i ) );
+    }
+    else
+    {
+      fields.append( mLayer->fields().at( i ) );
+    }
+  }
+
   std::unique_ptr<QgsVectorLayer> vlayer;
-  vlayer.reset( QgsMemoryProviderUtils::createMemoryLayer( "preview"_L1, mLayer->fields(), mLayer->wkbType(), mLayer->crs() ) );
+  vlayer.reset( QgsMemoryProviderUtils::createMemoryLayer( "preview"_L1, fields, mLayer->wkbType(), mLayer->crs() ) );
+  for ( const QPair<QgsField, QString> &expressionField : expressionFields )
+  {
+    vlayer->addExpressionField( expressionField.second, expressionField.first );
+  }
 
   mSourceFieldsProperties->applyToLayer( vlayer.get() );
   applyToLayer( vlayer.get() );

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -1407,7 +1407,7 @@ void QgsAttributesFormProperties::previewForm()
 
   std::unique_ptr<QgsVectorLayer> vlayer;
   vlayer.reset( QgsMemoryProviderUtils::createMemoryLayer( "preview"_L1, fields, mLayer->wkbType(), mLayer->crs() ) );
-  for ( const QPair<QgsField, QString> &expressionField : expressionFields )
+  for ( const QPair<QgsField, QString> &expressionField : std::as_const( expressionFields ) )
   {
     vlayer->addExpressionField( expressionField.second, expressionField.first );
   }

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -31,8 +31,9 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgsfieldcombobox.h"
 #include "qgsgui.h"
+#include "qgsmemoryproviderutils.h"
 #include "qgssettingsregistrycore.h"
-#include "qgsvectorlayerproperties.h"
+#include "qgssourcefieldsproperties.h"
 #include "qgsvectorlayerutils.h"
 #include "qgsxmlutils.h"
 
@@ -44,10 +45,10 @@
 
 const QgsSettingsEntryBool *QgsAttributesFormProperties::settingShowAliases = new QgsSettingsEntryBool( u"show-aliases"_s, sTreeAttributesForm, false, u"Whether to show aliases (true) or names (false) in both the Available Widgets and the Form Layout panels."_s );
 
-QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent, QgsVectorLayerProperties *vectorLayerProperties )
+QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent, QgsSourceFieldsProperties *sourceFieldsProperties )
   : QWidget( parent )
   , mLayer( layer )
-  , mVectorLayerProperties( vectorLayerProperties )
+  , mSourceFieldsProperties( sourceFieldsProperties )
 {
   if ( !layer )
     return;
@@ -147,7 +148,7 @@ QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer,
   // show an eventual horizontal scrollbar in the right-hand side panel
   splitter->setSizes( { widget->minimumSizeHint().width(), 600 } );
 
-  if ( mVectorLayerProperties )
+  if ( mSourceFieldsProperties )
   {
     connect( mFormPreviewButton, &QAbstractButton::clicked, this, &QgsAttributesFormProperties::previewForm );
   }
@@ -809,9 +810,14 @@ void QgsAttributesFormProperties::store()
 void QgsAttributesFormProperties::apply()
 {
   mBlockUpdates++;
-  store();
+  applyToLayer( mLayer );
+  mBlockUpdates--;
+}
 
-  QgsEditFormConfig editFormConfig = mLayer->editFormConfig();
+void QgsAttributesFormProperties::applyToLayer( QgsVectorLayer *layer )
+{
+  store();
+  QgsEditFormConfig editFormConfig = layer->editFormConfig();
 
   const QModelIndex fieldContainer = mAvailableWidgetsModel->fieldContainer();
   QModelIndex index;
@@ -822,7 +828,7 @@ void QgsAttributesFormProperties::apply()
     const QgsAttributesFormData::FieldConfig cfg = index.data( QgsAttributesFormModel::ItemFieldConfigRole ).value<QgsAttributesFormData::FieldConfig>();
 
     const QString fieldName = index.data( QgsAttributesFormModel::ItemNameRole ).toString();
-    const int idx = mLayer->fields().indexOf( fieldName );
+    const int idx = layer->fields().indexOf( fieldName );
 
     //continue in case field does not exist anymore
     if ( idx < 0 )
@@ -837,41 +843,41 @@ void QgsAttributesFormProperties::apply()
       editFormConfig.setDataDefinedFieldProperties( fieldName, cfg.mDataDefinedProperties );
     }
 
-    mLayer->setEditorWidgetSetup( idx, QgsEditorWidgetSetup( cfg.mEditorWidgetType, cfg.mEditorWidgetConfig ) );
+    layer->setEditorWidgetSetup( idx, QgsEditorWidgetSetup( cfg.mEditorWidgetType, cfg.mEditorWidgetConfig ) );
 
     const QgsFieldConstraints constraints = cfg.mFieldConstraints;
-    mLayer->setConstraintExpression( idx, constraints.constraintExpression(), constraints.constraintDescription() );
+    layer->setConstraintExpression( idx, constraints.constraintExpression(), constraints.constraintDescription() );
     if ( constraints.constraints() & QgsFieldConstraints::ConstraintNotNull )
     {
-      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintNotNull, constraints.constraintStrength( QgsFieldConstraints::ConstraintNotNull ) );
+      layer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintNotNull, constraints.constraintStrength( QgsFieldConstraints::ConstraintNotNull ) );
     }
     else
     {
-      mLayer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintNotNull );
+      layer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintNotNull );
     }
     if ( constraints.constraints() & QgsFieldConstraints::ConstraintUnique )
     {
-      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintUnique, constraints.constraintStrength( QgsFieldConstraints::ConstraintUnique ) );
+      layer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintUnique, constraints.constraintStrength( QgsFieldConstraints::ConstraintUnique ) );
     }
     else
     {
-      mLayer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintUnique );
+      layer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintUnique );
     }
     if ( constraints.constraints() & QgsFieldConstraints::ConstraintExpression )
     {
-      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintExpression, constraints.constraintStrength( QgsFieldConstraints::ConstraintExpression ) );
+      layer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintExpression, constraints.constraintStrength( QgsFieldConstraints::ConstraintExpression ) );
     }
     else
     {
-      mLayer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintExpression );
+      layer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintExpression );
     }
 
-    mLayer->setFieldAlias( idx, cfg.mAlias );
-    mLayer->setFieldSplitPolicy( idx, cfg.mSplitPolicy );
-    mLayer->setFieldDuplicatePolicy( idx, cfg.mDuplicatePolicy );
-    mLayer->setFieldMergePolicy( idx, cfg.mMergePolicy );
+    layer->setFieldAlias( idx, cfg.mAlias );
+    layer->setFieldSplitPolicy( idx, cfg.mSplitPolicy );
+    layer->setFieldDuplicatePolicy( idx, cfg.mDuplicatePolicy );
+    layer->setFieldMergePolicy( idx, cfg.mMergePolicy );
 
-    mLayer->setDefaultValueDefinition( idx, QgsDefaultValue( cfg.mDefaultValueExpression, cfg.mApplyDefaultValueOnUpdate ) );
+    layer->setDefaultValueDefinition( idx, QgsDefaultValue( cfg.mDefaultValueExpression, cfg.mApplyDefaultValueOnUpdate ) );
   }
 
   // // tabs and groups
@@ -921,10 +927,8 @@ void QgsAttributesFormProperties::apply()
     }
   }
 
-  mLayer->setEditFormConfig( editFormConfig );
-  mBlockUpdates--;
+  layer->setEditFormConfig( editFormConfig );
 }
-
 
 void QgsAttributesFormProperties::updatedFields()
 {
@@ -1378,27 +1382,23 @@ void QgsAttributesFormProperties::setFormLayoutIndicatorProvidersEnabled( bool e
 
 void QgsAttributesFormProperties::previewForm()
 {
-  if ( !mVectorLayerProperties )
+  if ( !mSourceFieldsProperties )
   {
     return;
   }
 
   auto projectDirtyBlocker = std::make_unique<QgsProjectDirtyBlocker>( QgsProject::instance() );
 
-  QgsReadWriteContext readWriteContext;
-  readWriteContext.setPathResolver( QgsProject::instance()->pathResolver() );
-  QDomDocument layerDocument;
-  QDomElement layerElement = layerDocument.createElement( "maplayer"_L1 );
-  mLayer->writeLayerXml( layerElement, layerDocument, readWriteContext );
+  std::unique_ptr<QgsVectorLayer> vlayer;
+  vlayer.reset( QgsMemoryProviderUtils::createMemoryLayer( "preview"_L1, mLayer->fields(), mLayer->wkbType(), mLayer->crs() ) );
 
-  mVectorLayerProperties->apply();
+  mSourceFieldsProperties->applyToLayer( vlayer.get() );
+  applyToLayer( vlayer.get() );
 
-  QgsFeature feature = QgsVectorLayerUtils::createFeature( mLayer );
-  QgsAttributeDialog form( mLayer, &feature, false, this, true );
+  QgsFeature feature = QgsVectorLayerUtils::createFeature( vlayer.get() );
+  QgsAttributeDialog form( vlayer.get(), &feature, false, this, true );
   form.setMode( QgsAttributeEditorContext::PreviewMode );
   form.exec();
-
-  mLayer->readLayerXml( layerElement, readWriteContext );
 
   projectDirtyBlocker.reset();
 }

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -1383,6 +1383,8 @@ void QgsAttributesFormProperties::previewForm()
     return;
   }
 
+  auto projectDirtyBlocker = std::make_unique<QgsProjectDirtyBlocker>( QgsProject::instance() );
+
   QgsReadWriteContext readWriteContext;
   readWriteContext.setPathResolver( QgsProject::instance()->pathResolver() );
   QDomDocument layerDocument;
@@ -1397,4 +1399,6 @@ void QgsAttributesFormProperties::previewForm()
   form.exec();
 
   mLayer->readLayerXml( layerElement, readWriteContext );
+
+  projectDirtyBlocker.reset();
 }

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -68,6 +68,12 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     static inline QgsSettingsTreeNode *sTreeAttributesForm = QgsSettingsTree::sTreeApp->createChildNode( u"attributes-form"_s );
     static const QgsSettingsEntryBool *settingShowAliases;
 
+    /**
+     * The QgsAttributesFormProperties constructor.
+     * \param layer The vector layer being configured
+     * \param parent The parent QObject
+     * \param vectorLayerProperties The vector layer properties dialog, an optional parameter used to generate preview forms (since QGIS 4.0)
+     */
     explicit QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent = nullptr, QgsVectorLayerProperties *vectorLayerProperties = nullptr );
 
     void init();

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -51,7 +51,7 @@ class QgsAttributeWidgetEdit;
 class QgsAttributesFormBaseView;
 class QgsFieldConstraintIndicatorProvider;
 class QgsFieldDefaultValueIndicatorProvider;
-class QgsVectorLayerProperties;
+class QgsSourceFieldsProperties;
 
 /**
  * \brief Creates panels to configure attributes forms.
@@ -72,9 +72,9 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
      * The QgsAttributesFormProperties constructor.
      * \param layer The vector layer being configured
      * \param parent The parent QObject
-     * \param vectorLayerProperties The vector layer properties dialog, an optional parameter used to generate preview forms (since QGIS 4.0)
+     * \param sourceFieldsProperties The source fields properties widget, an optional parameter used to generate preview forms (since QGIS 4.0)
      */
-    explicit QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent = nullptr, QgsVectorLayerProperties *vectorLayerProperties = nullptr );
+    explicit QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent = nullptr, QgsSourceFieldsProperties *sourceFieldsProperties = nullptr );
 
     void init();
 
@@ -118,7 +118,6 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     void updateButtons();
 
     QgsVectorLayer *mLayer = nullptr;
-    QgsVectorLayerProperties *mVectorLayerProperties = nullptr;
 
     QgsAttributesFormBaseView *mAvailableWidgetsView = nullptr;
     QgsAttributesFormBaseView *mFormLayoutView = nullptr;
@@ -188,6 +187,8 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     void setAvailableWidgetsIndicatorProvidersEnabled( bool enabled );
     void setFormLayoutIndicatorProvidersEnabled( bool enabled );
 
+    void applyToLayer( QgsVectorLayer *layer );
+
     QgsAttributesAvailableWidgetsModel *mAvailableWidgetsModel = nullptr;
     QgsAttributesFormLayoutModel *mFormLayoutModel = nullptr;
     QgsAttributesFormProxyModel *mAvailableWidgetsProxyModel = nullptr;
@@ -211,6 +212,8 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     QgsFieldDefaultValueIndicatorProvider *mDefaultValueIndicatorProviderAvailableWidgets = nullptr;
     QgsFieldConstraintIndicatorProvider *mConstraintIndicatorProviderFormLayout = nullptr;
     QgsFieldDefaultValueIndicatorProvider *mDefaultValueIndicatorProviderFormLayout = nullptr;
+
+    QgsSourceFieldsProperties *mSourceFieldsProperties = nullptr;
 
     friend class TestQgsAttributesFormProperties;
 };

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -51,6 +51,7 @@ class QgsAttributeWidgetEdit;
 class QgsAttributesFormBaseView;
 class QgsFieldConstraintIndicatorProvider;
 class QgsFieldDefaultValueIndicatorProvider;
+class QgsVectorLayerProperties;
 
 /**
  * \brief Creates panels to configure attributes forms.
@@ -67,7 +68,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     static inline QgsSettingsTreeNode *sTreeAttributesForm = QgsSettingsTree::sTreeApp->createChildNode( u"attributes-form"_s );
     static const QgsSettingsEntryBool *settingShowAliases;
 
-    explicit QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent = nullptr );
+    explicit QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent = nullptr, QgsVectorLayerProperties *vectorLayerProperties = nullptr );
 
     void init();
 
@@ -111,6 +112,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     void updateButtons();
 
     QgsVectorLayer *mLayer = nullptr;
+    QgsVectorLayerProperties *mVectorLayerProperties = nullptr;
 
     QgsAttributesFormBaseView *mAvailableWidgetsView = nullptr;
     QgsAttributesFormBaseView *mFormLayoutView = nullptr;
@@ -143,6 +145,8 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, public QgsExpress
     void updatedFields();
 
     void updateFilteredItems( const QString &filterText );
+
+    void previewForm();
 
   private:
     //! this will clean the right panel

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -293,10 +293,15 @@ bool QgsSourceFieldsProperties::addAttribute( const QgsField &field )
 
 void QgsSourceFieldsProperties::apply()
 {
+  applyToLayer( mLayer );
+}
+
+void QgsSourceFieldsProperties::applyToLayer( QgsVectorLayer *layer )
+{
   for ( int i = 0; i < mFieldsList->rowCount(); i++ )
   {
     const int idx = mFieldsList->item( i, AttrIdCol )->data( Qt::DisplayRole ).toInt();
-    Qgis::FieldConfigurationFlags flags = mLayer->fieldConfigurationFlags( idx );
+    Qgis::FieldConfigurationFlags flags = layer->fieldConfigurationFlags( idx );
 
     QgsCheckableComboBox *cb = qobject_cast<QgsCheckableComboBox *>( mFieldsList->cellWidget( i, AttrConfigurationFlagsCol ) );
     if ( cb )
@@ -309,7 +314,7 @@ void QgsSourceFieldsProperties::apply()
         const bool active = model->data( index, Qt::CheckStateRole ).value<Qt::CheckState>() == Qt::Checked ? true : false;
         flags.setFlag( flag, active );
       }
-      mLayer->setFieldConfigurationFlags( idx, flags );
+      layer->setFieldConfigurationFlags( idx, flags );
     }
   }
 }

--- a/src/gui/vector/qgssourcefieldsproperties.h
+++ b/src/gui/vector/qgssourcefieldsproperties.h
@@ -113,6 +113,10 @@ class GUI_EXPORT QgsSourceFieldsProperties : public QWidget, private Ui_QgsSourc
 
     void attributesListCellChanged( int row, int column );
     void attributesListCellPressed( int row, int column );
+
+    void applyToLayer( QgsVectorLayer *layer );
+
+    friend class QgsAttributesFormProperties;
 };
 
 #endif // QGSSOURCEFIELDSPROPERTIES_H

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -227,7 +227,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
 
   connect( mSourceFieldsPropertiesDialog, &QgsSourceFieldsProperties::toggleEditing, this, static_cast<void ( QgsVectorLayerProperties::* )()>( &QgsVectorLayerProperties::toggleEditing ) );
 
-  mAttributesFormPropertiesDialog = new QgsAttributesFormProperties( mLayer, mAttributesFormFrame );
+  mAttributesFormPropertiesDialog = new QgsAttributesFormProperties( mLayer, mAttributesFormFrame, this );
   mAttributesFormPropertiesDialog->layout()->setContentsMargins( 0, 0, 0, 0 );
   mAttributesFormFrame->setLayout( new QVBoxLayout( mAttributesFormFrame ) );
   mAttributesFormFrame->layout()->setContentsMargins( 0, 0, 0, 0 );

--- a/src/gui/vector/qgsvectorlayerproperties.cpp
+++ b/src/gui/vector/qgsvectorlayerproperties.cpp
@@ -227,7 +227,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
 
   connect( mSourceFieldsPropertiesDialog, &QgsSourceFieldsProperties::toggleEditing, this, static_cast<void ( QgsVectorLayerProperties::* )()>( &QgsVectorLayerProperties::toggleEditing ) );
 
-  mAttributesFormPropertiesDialog = new QgsAttributesFormProperties( mLayer, mAttributesFormFrame, this );
+  mAttributesFormPropertiesDialog = new QgsAttributesFormProperties( mLayer, mAttributesFormFrame, mSourceFieldsPropertiesDialog );
   mAttributesFormPropertiesDialog->layout()->setContentsMargins( 0, 0, 0, 0 );
   mAttributesFormFrame->setLayout( new QVBoxLayout( mAttributesFormFrame ) );
   mAttributesFormFrame->layout()->setContentsMargins( 0, 0, 0, 0 );

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -222,6 +222,7 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
   private slots:
     void openPanel( QgsPanelWidget *panel );
 
+    friend class QgsAttributesFormProperties;
     friend class QgsAppScreenShots;
     friend class TestQgsLayerPropertiesDialogs;
 };

--- a/src/gui/vector/qgsvectorlayerproperties.h
+++ b/src/gui/vector/qgsvectorlayerproperties.h
@@ -222,7 +222,6 @@ class GUI_EXPORT QgsVectorLayerProperties : public QgsLayerPropertiesDialog, pri
   private slots:
     void openPanel( QgsPanelWidget *panel );
 
-    friend class QgsAttributesFormProperties;
     friend class QgsAppScreenShots;
     friend class TestQgsLayerPropertiesDialogs;
 };

--- a/src/ui/qgsattributesformproperties.ui
+++ b/src/ui/qgsattributesformproperties.ui
@@ -329,6 +329,13 @@ Use this function to add extra logic to your forms.</string>
          </item>
         </layout>
        </item>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="mFormPreviewButton">
+         <property name="text">
+          <string>Preview Attributes Form</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QgsScrollArea" name="scrollArea_2">

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -1212,6 +1212,27 @@ class TestQgsVectorLayerUtils(QgisTestCase):
             b"333333/@\x9a\x99\x99\x99\x99\x99\xd9?\x00\x00\x00\x00\x008\x8f\xc0",
         )
 
+    def test_field_is_editable(self):
+        layer = QgsVectorLayer(
+            "Point?field=fldtxt:string&field=fldint:integer&field=fldlong:int8&field=flddouble:double",
+            "points",
+            "memory",
+        )
+        self.assertTrue(layer.isValid())
+
+        feature = QgsVectorLayerUtils.createFeature(layer)
+
+        self.assertFalse(layer.isEditable())
+        self.assertFalse(QgsVectorLayerUtils.fieldIsEditable(layer, 0, feature))
+        self.assertTrue(
+            QgsVectorLayerUtils.fieldIsEditable(
+                layer,
+                0,
+                feature,
+                QgsVectorLayerUtils.FieldIsEditableFlag.IgnoreLayerEditability,
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

This PR adds the ability to preview an attributes form while configuring it within the vector layer properties dialog. Here's we're the preview button is located:

<img width="1216" height="929" alt="image" src="https://github.com/user-attachments/assets/3e99ad72-64bd-49cb-9ce2-c381e62835ef" />

This will fit in quite nicely with the series of improvements we're going to ship with QGIS 4.0 on the attributes form configuration front. Massive UX wins :)

Since attribute form configuration is _all over the place_ in our API at the moment (i.e., some of it is attached to QgsField, some of it attached to the QgsVectorLayer, etc.), ~~the only way to properly preview the form is to apply all changes in the vector layer properties dialog. The code does so by saving the XML state of the vector layer, applying the changes, showing the preview form, and immediately restoring the saved XML state so users can still _cancel_ the vector layer properties dialog.~~ (An alternative solution that doesn't involve doing that was pushed)

Also, due to the necessity to apply all vector layer properties changes, I'm passing on the QgsVectorLayerProperties widget down to the QgsAttributesFormProperties panel so it can trigger the properties dialog's apply() function. We could also go down a signal connection there but I thought a direct call was better. Open to discuss that :)