### PR TITLE
[Virtual Point Clouds] Fix RGB renderer not set as default when reading RGB VPC

### DIFF
--- a/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp
+++ b/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp
@@ -583,18 +583,17 @@ QgsPointCloudRenderer *QgsVirtualPointCloudProvider::createRenderer( const QVari
 {
   Q_UNUSED( configuration )
 
-  if ( mAttributes.indexOf( "Red"_L1 ) >= 0 && mAttributes.indexOf( "Green"_L1 ) >= 0 && mAttributes.indexOf( "Blue"_L1 ) >= 0 )
+  if ( mRedMax != std::numeric_limits<double>::lowest() && mGreenMax != std::numeric_limits<double>::lowest() && mBlueMax != std::numeric_limits<double>::lowest() )
   {
     auto renderer = std::make_unique< QgsPointCloudRgbRenderer >();
-    if ( mRedMax == std::numeric_limits<double>::lowest() || mGreenMax == std::numeric_limits<double>::lowest() || mBlueMax == std::numeric_limits<double>::lowest() )
+    const int maxValue = std::max( mBlueMax, std::max( mRedMax, mGreenMax ) );
+
+    if ( maxValue == 0 )
     {
-      const int maxValue = std::max( mBlueMax, std::max( mRedMax, mGreenMax ) );
-
-      if ( maxValue == 0 )
-      {
-        renderer.reset();
-      }
-
+      renderer.reset();
+    }
+    else
+    {
       const int rangeGuess = maxValue > 255 ? 65535 : 255;
 
       if ( rangeGuess > 255 )
@@ -607,16 +606,6 @@ QgsPointCloudRenderer *QgsVirtualPointCloudProvider::createRenderer( const QVari
         renderer->setGreenContrastEnhancement( new QgsContrastEnhancement( contrast ) );
         renderer->setBlueContrastEnhancement( new QgsContrastEnhancement( contrast ) );
       }
-    }
-    else
-    {
-      QgsContrastEnhancement contrast( Qgis::DataType::UInt16 );
-      contrast.setMinimumValue( std::numeric_limits<uint16_t>::lowest() );
-      contrast.setMaximumValue( std::numeric_limits<uint16_t>::max() );
-      contrast.setContrastEnhancementAlgorithm( QgsContrastEnhancement::StretchToMinimumMaximum );
-      renderer->setRedContrastEnhancement( new QgsContrastEnhancement( contrast ) );
-      renderer->setGreenContrastEnhancement( new QgsContrastEnhancement( contrast ) );
-      renderer->setBlueContrastEnhancement( new QgsContrastEnhancement( contrast ) );
     }
 
     if ( renderer )

--- a/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp
+++ b/src/core/providers/vpc/qgsvirtualpointcloudprovider.cpp
@@ -31,6 +31,7 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgspointcloudclassifiedrenderer.h"
 #include "qgspointcloudextentrenderer.h"
+#include "qgspointcloudrgbrenderer.h"
 #include "qgspointcloudsubindex.h"
 #include "qgsproviderregistry.h"
 #include "qgsprovidersublayerdetails.h"
@@ -406,6 +407,21 @@ void QgsVirtualPointCloudProvider::parseFile()
       }
     }
 
+    if ( f["properties"].contains( "pc:statistics" ) )
+    {
+      nlohmann::json pcStats = f["properties"]["pc:statistics"];
+
+      for ( auto pcStat : pcStats )
+      {
+        if ( pcStat["name"] == "Red" )
+          mRedMax = std::max( mRedMax, pcStat[ "maximum" ].get<double>() );
+        if ( pcStat["name"] == "Green" )
+          mGreenMax = std::max( mRedMax, pcStat[ "maximum" ].get<double>() );
+        if ( pcStat["name"] == "Blue" )
+          mBlueMax = std::max( mRedMax, pcStat[ "maximum" ].get<double>() );
+      }
+    }
+
     if ( transform.isValid() && !transform.isShortCircuited() )
     {
       try
@@ -566,6 +582,46 @@ bool QgsVirtualPointCloudProvider::setSubsetString( const QString &subset, bool 
 QgsPointCloudRenderer *QgsVirtualPointCloudProvider::createRenderer( const QVariantMap &configuration ) const
 {
   Q_UNUSED( configuration )
+
+  if ( mAttributes.indexOf( "Red"_L1 ) >= 0 && mAttributes.indexOf( "Green"_L1 ) >= 0 && mAttributes.indexOf( "Blue"_L1 ) >= 0 )
+  {
+    auto renderer = std::make_unique< QgsPointCloudRgbRenderer >();
+    if ( mRedMax == std::numeric_limits<double>::lowest() || mGreenMax == std::numeric_limits<double>::lowest() || mBlueMax == std::numeric_limits<double>::lowest() )
+    {
+      const int maxValue = std::max( mBlueMax, std::max( mRedMax, mGreenMax ) );
+
+      if ( maxValue == 0 )
+      {
+        renderer.reset();
+      }
+
+      const int rangeGuess = maxValue > 255 ? 65535 : 255;
+
+      if ( rangeGuess > 255 )
+      {
+        QgsContrastEnhancement contrast( Qgis::DataType::UnknownDataType );
+        contrast.setMinimumValue( 0 );
+        contrast.setMaximumValue( rangeGuess );
+        contrast.setContrastEnhancementAlgorithm( QgsContrastEnhancement::StretchToMinimumMaximum );
+        renderer->setRedContrastEnhancement( new QgsContrastEnhancement( contrast ) );
+        renderer->setGreenContrastEnhancement( new QgsContrastEnhancement( contrast ) );
+        renderer->setBlueContrastEnhancement( new QgsContrastEnhancement( contrast ) );
+      }
+    }
+    else
+    {
+      QgsContrastEnhancement contrast( Qgis::DataType::UInt16 );
+      contrast.setMinimumValue( std::numeric_limits<uint16_t>::lowest() );
+      contrast.setMaximumValue( std::numeric_limits<uint16_t>::max() );
+      contrast.setContrastEnhancementAlgorithm( QgsContrastEnhancement::StretchToMinimumMaximum );
+      renderer->setRedContrastEnhancement( new QgsContrastEnhancement( contrast ) );
+      renderer->setGreenContrastEnhancement( new QgsContrastEnhancement( contrast ) );
+      renderer->setBlueContrastEnhancement( new QgsContrastEnhancement( contrast ) );
+    }
+
+    if ( renderer )
+      return renderer.release();
+  }
 
   if ( mAttributes.indexOf( "Classification"_L1 ) >= 0 )
   {

--- a/src/core/providers/vpc/qgsvirtualpointcloudprovider.h
+++ b/src/core/providers/vpc/qgsvirtualpointcloudprovider.h
@@ -92,6 +92,10 @@ class CORE_EXPORT QgsVirtualPointCloudProvider: public QgsPointCloudDataProvider
     QgsPointCloudAttributeCollection mAttributes;
     QgsPointCloudIndex mOverview = QgsPointCloudIndex( nullptr );
 
+    double mRedMax = std::numeric_limits<double>::lowest();
+    double mGreenMax = std::numeric_limits<double>::lowest();
+    double mBlueMax = std::numeric_limits<double>::lowest();
+
     QStringList mUriList;
     QgsRectangle mExtent;
     qint64 mPointCount = 0;


### PR DESCRIPTION
If `Red`, `Green` and `Blue` attributes are present in the VPC statistics, we go through all dataset statistics to get the minimum and maximum value for each attribute and default to RGB renderer if the values are present.

This relies on the statistics being present in the VPC.