### PR TITLE
Remove obsolete class QRegExp

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -44,7 +44,6 @@
 #include <QMessageBox>
 #include <QPalette>
 #include <QPushButton>
-#include <QRegExp>
 #include <QRegularExpression>
 #include <QSortFilterProxyModel>
 #include <QStandardItem>

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -35,7 +35,6 @@
 #include <QNetworkRequest>
 #include <QPixmap>
 #include <QPushButton>
-#include <QRegExp>
 #include <QScreen>
 #include <QTextDocument>
 #include <QToolButton>

--- a/src/crssync/main.cpp
+++ b/src/crssync/main.cpp
@@ -15,7 +15,6 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#include "qgsconfig.h"
 
 #include <cpl_error.h>
 #include <iostream>
@@ -24,18 +23,14 @@
 #include "qgsapplication.h"
 #include "qgscoordinatereferencesystem.h"
 
-#include <QRegularExpression>
 #include <QSettings>
 #include <QTemporaryDir>
 
 void CPL_STDCALL showError( CPLErr errClass, int errNo, const char *msg )
 {
   Q_UNUSED( errClass )
-  const QRegularExpression re( QRegularExpression::anchoredPattern( "EPSG PCS/GCS code \\d+ not found in EPSG support files.  Is this a valid\nEPSG coordinate system?" ) );
-  if ( errNo != 6 && !re.match( msg ).hasMatch() )
-  {
-    std::cerr << msg;
-  }
+  Q_UNUSED( errNo )
+  std::cerr << msg;
 }
 
 int main( int argc, char **argv )

--- a/src/crssync/main.cpp
+++ b/src/crssync/main.cpp
@@ -24,15 +24,15 @@
 #include "qgsapplication.h"
 #include "qgscoordinatereferencesystem.h"
 
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QSettings>
 #include <QTemporaryDir>
 
 void CPL_STDCALL showError( CPLErr errClass, int errNo, const char *msg )
 {
   Q_UNUSED( errClass )
-  const QRegExp re( "EPSG PCS/GCS code \\d+ not found in EPSG support files.  Is this a valid\nEPSG coordinate system?" );
-  if ( errNo != 6 && !re.exactMatch( msg ) )
+  const QRegularExpression re( QRegularExpression::anchoredPattern( "EPSG PCS/GCS code \\d+ not found in EPSG support files.  Is this a valid\nEPSG coordinate system?" ) );
+  if ( errNo != 6 && !re.match( msg ).hasMatch() )
   {
     std::cerr << msg;
   }

--- a/src/plugins/grass/qgsgrassnewmapset.cpp
+++ b/src/plugins/grass/qgsgrassnewmapset.cpp
@@ -35,7 +35,6 @@
 #include <QCloseEvent>
 #include <QFileDialog>
 #include <QMessageBox>
-#include <QRegExp>
 #include <QRegularExpression>
 #include <QRegularExpressionValidator>
 #include <QTextStream>

--- a/src/providers/grass/qgsgrass.cpp
+++ b/src/providers/grass/qgsgrass.cpp
@@ -56,7 +56,7 @@
 #include <QHash>
 #include <QTextCodec>
 #include <QElapsedTimer>
-#include <QRegExp>
+#include <QRegularExpression>
 
 extern "C"
 {
@@ -119,13 +119,14 @@ bool QgsGrassObject::setFromUri( const QString &uri )
     QString path = fi.canonicalFilePath();
     QgsDebugMsgLevel( "path = " + path, 2 );
     // /gisdbase_path/location/mapset/cellhd/raster_map
-    QRegExp rx( "(.*)/([^/]*)/([^/]*)/cellhd/([^/]*)", Qt::CaseInsensitive );
-    if ( rx.indexIn( path ) > -1 )
+    const thread_local QRegularExpression cellhdExpression( "(.*)/([^/]*)/([^/]*)/cellhd/([^/]*)", QRegularExpression::CaseInsensitiveOption );
+    const QRegularExpressionMatch match = cellhdExpression.match( path );
+    if ( match.hasMatch() )
     {
-      mGisdbase = rx.cap( 1 );
-      mLocation = rx.cap( 2 );
-      mMapset = rx.cap( 3 );
-      mName = rx.cap( 4 );
+      mGisdbase = match.captured( 1 );
+      mLocation = match.captured( 2 );
+      mMapset = match.captured( 3 );
+      mName = match.captured( 4 );
       mType = Raster;
       return QgsGrass::isLocation( mGisdbase + "/" + mLocation );
     }
@@ -139,12 +140,13 @@ bool QgsGrassObject::setFromUri( const QString &uri )
     if ( dir.cdUp() )    // .../mapset/
     {
       QString path = dir.canonicalPath();
-      QRegExp rx( "(.*)/([^/]*)/([^/]*)" );
-      if ( rx.indexIn( path ) > -1 )
+      const thread_local QRegularExpression pathExpression( "(.*)/([^/]*)/([^/]*)" );
+      const QRegularExpressionMatch match = pathExpression.match( path );
+      if ( match.hasMatch() )
       {
-        mGisdbase = rx.cap( 1 );
-        mLocation = rx.cap( 2 );
-        mMapset = rx.cap( 3 );
+        mGisdbase = match.captured( 1 );
+        mLocation = match.captured( 2 );
+        mMapset = match.captured( 3 );
         mName = fi.dir().dirName();
         mType = Vector;
         QgsDebugMsgLevel( "parsed : " + toString(), 2 );
@@ -2853,15 +2855,15 @@ QgsGrass::ModuleOutput QgsGrass::parseModuleOutput( const QString &input, QStrin
   QgsDebugMsgLevel( "ascii = " + ascii, 2 );
 #endif
 
-  QRegExp rxpercent( "GRASS_INFO_PERCENT: (\\d+)" );
-  QRegExp rxmessage( "GRASS_INFO_MESSAGE\\(\\d+,\\d+\\): (.*)" );
-  QRegExp rxwarning( "GRASS_INFO_WARNING\\(\\d+,\\d+\\): (.*)" );
-  QRegExp rxerror( "GRASS_INFO_ERROR\\(\\d+,\\d+\\): (.*)" );
-  QRegExp rxend( "GRASS_INFO_END\\(\\d+,\\d+\\)" );
+  const thread_local QRegularExpression rxpercent( "GRASS_INFO_PERCENT: (\\d+)" );
+  const thread_local QRegularExpression rxmessage( "GRASS_INFO_MESSAGE\\(\\d+,\\d+\\): (.*)" );
+  const thread_local QRegularExpression rxwarning( "GRASS_INFO_WARNING\\(\\d+,\\d+\\): (.*)" );
+  const thread_local QRegularExpression rxerror( "GRASS_INFO_ERROR\\(\\d+,\\d+\\): (.*)" );
+  const thread_local QRegularExpression rxend( "GRASS_INFO_END\\(\\d+,\\d+\\)" );
   // GRASS added G_progress() which does not support GRASS_MESSAGE_FORMAT=gui
   // and it is printing fprintf(stderr, "%10ld\b\b\b\b\b\b\b\b\b\b", n);
   // Ticket created https://trac.osgeo.org/grass/ticket/2751
-  QRegExp rxprogress( " +(\\d+)\\b\\b\\b\\b\\b\\b\\b\\b\\b\\b" );
+  const thread_local QRegularExpression rxprogress( " +(\\d+)\\b\\b\\b\\b\\b\\b\\b\\b\\b\\b" );
 
   // We return simple messages in html non formatted, monospace text should be set on widget
   // where it is used because output may be formatted assuming fixed width font
@@ -2869,38 +2871,38 @@ QgsGrass::ModuleOutput QgsGrass::parseModuleOutput( const QString &input, QStrin
   {
     return OutputNone;
   }
-  else if ( rxpercent.indexIn( input ) != -1 )
+  else if ( const QRegularExpressionMatch match = rxpercent.match( input ); match.hasMatch() )
   {
-    value = rxpercent.cap( 1 ).toInt();
+    value = match.capturedView( 1 ).toInt();
     return OutputPercent;
   }
-  else if ( rxmessage.indexIn( input ) != -1 )
+  else if ( const QRegularExpressionMatch match = rxmessage.match( input ); match.hasMatch() )
   {
-    text = rxmessage.cap( 1 );
+    text = match.captured( 1 );
     html = text;
     return OutputMessage;
   }
-  else if ( rxwarning.indexIn( input ) != -1 )
+  else if ( const QRegularExpressionMatch match = rxwarning.match( input ); match.hasMatch() )
   {
-    text = rxwarning.cap( 1 );
+    text = match.captured( 1 );
     QString img = QgsApplication::pkgDataPath() + "/themes/default/grass/grass_module_warning.png";
     html = "<img src=\"" + img + "\">" + text;
     return OutputWarning;
   }
-  else if ( rxerror.indexIn( input ) != -1 )
+  else if ( const QRegularExpressionMatch match = rxerror.match( input ); match.hasMatch() )
   {
-    text = rxerror.cap( 1 );
+    text = match.captured( 1 );
     QString img = QgsApplication::pkgDataPath() + "/themes/default/grass/grass_module_error.png";
     html = "<img src=\"" + img + "\">" + text;
     return OutputError;
   }
-  else if ( rxend.indexIn( input ) != -1 )
+  else if ( const QRegularExpressionMatch match = rxend.match( input ); match.hasMatch() )
   {
     return OutputNone;
   }
-  else if ( rxprogress.indexIn( input ) != -1 )
+  else if ( const QRegularExpressionMatch match = rxprogress.match( input ); match.hasMatch() )
   {
-    value = rxprogress.cap( 1 ).toInt();
+    value = match.capturedView( 1 ).toInt();
     return OutputProgress;
   }
   else // some plain text which cannot be parsed


### PR DESCRIPTION
`QRegExp` was superseeded by `QRegularExpression` in Qt 5, and moved to the Qt 5 Compatibility module in Qt 6.

This PR replaces the last usages of `QRegExp` by `QRegularExpression`. There are some differences in pattern handling between the two, however nothing which affected the patterns in question AFAICT.