### PR TITLE
[feature] Allow copying/pasting all styles from a layer to another

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10481,9 +10481,7 @@ QgsVectorLayer *QgisApp::pasteAsNewMemoryVector( const QString &layerName )
 
 void QgisApp::copyStyle( QgsMapLayer *sourceLayer, QgsMapLayer::StyleCategories categories )
 {
-  QgsMapLayer *selectionLayer = sourceLayer ? sourceLayer : activeLayer();
-
-  if ( selectionLayer )
+  if ( QgsMapLayer *selectionLayer = sourceLayer ? sourceLayer : activeLayer() )
   {
     QString errorMsg;
     QDomDocument doc( u"qgis"_s );
@@ -10503,10 +10501,52 @@ void QgisApp::copyStyle( QgsMapLayer *sourceLayer, QgsMapLayer::StyleCategories 
   }
 }
 
+void QgisApp::copyAllStyles( QgsMapLayer *sourceLayer )
+{
+  if ( QgsMapLayer *selectionLayer = sourceLayer ? sourceLayer : activeLayer() )
+  {
+    QString errorMsg;
+    QDomDocument tempDoc( u"qgis"_s );
+    QgsReadWriteContext context;
+
+    // QgsMapLayerStyleManager does not store current style, so export that first
+    selectionLayer->exportNamedStyle( tempDoc, errorMsg, context );
+    if ( !errorMsg.isEmpty() )
+    {
+      visibleMessageBar()->pushMessage( tr( "Cannot copy styles" ), errorMsg, Qgis::MessageLevel::Critical );
+      return;
+    }
+
+    QDomImplementation DomImplementation;
+    const QDomDocumentType documentType = DomImplementation.createDocumentType( u"qgisLayerStyles"_s, u"http://mrcc.com/qgis.dtd"_s, u"SYSTEM"_s );
+    QDomDocument doc( documentType );
+
+    QDomElement rootNode = doc.createElement( u"qgisLayerStyles"_s );
+
+    QDomElement styleElem = doc.createElement( u"defaultStyle"_s );
+    QDomNode currentStyleNode = doc.importNode( tempDoc.documentElement(), true );
+    styleElem.appendChild( currentStyleNode );
+    rootNode.appendChild( styleElem );
+
+    // export other styles
+    QgsMapLayerStyleManager *mgr = selectionLayer->styleManager();
+    QDomElement stylesElem = doc.createElement( u"styles"_s );
+    mgr->writeXml( stylesElem );
+
+    rootNode.appendChild( stylesElem );
+    doc.appendChild( rootNode );
+
+    // Copies data in text form as well, so the XML can be pasted into a text editor
+    clipboard()->setData( QStringLiteral( QGSCLIPBOARD_STYLES_MIME ), doc.toByteArray(), doc.toString() );
+
+    // Enables the paste menu element
+    mActionPasteStyle->setEnabled( true );
+  }
+}
+
 void QgisApp::pasteStyle( QgsMapLayer *destinationLayer, QgsMapLayer::StyleCategories categories )
 {
-  QgsMapLayer *selectionLayer = destinationLayer ? destinationLayer : activeLayer();
-  if ( selectionLayer )
+  if ( QgsMapLayer *selectionLayer = destinationLayer ? destinationLayer : activeLayer() )
   {
     if ( clipboard()->hasFormat( QStringLiteral( QGSCLIPBOARD_STYLE_MIME ) ) )
     {
@@ -10530,6 +10570,51 @@ void QgisApp::pasteStyle( QgsMapLayer *destinationLayer, QgsMapLayer::StyleCateg
       if ( !selectionLayer->importNamedStyle( doc, errorMsg, categories ) )
       {
         visibleMessageBar()->pushMessage( tr( "Cannot paste style" ), errorMsg, Qgis::MessageLevel::Critical );
+        return;
+      }
+
+      mLayerTreeView->refreshLayerSymbology( selectionLayer->id() );
+      selectionLayer->triggerRepaint();
+      QgsProject::instance()->setDirty( true );
+    }
+  }
+}
+
+void QgisApp::pasteAllStyles( QgsMapLayer *destinationLayer )
+{
+  if ( QgsMapLayer *selectionLayer = destinationLayer ? destinationLayer : activeLayer() )
+  {
+    if ( clipboard()->hasFormat( QStringLiteral( QGSCLIPBOARD_STYLES_MIME ) ) )
+    {
+      QDomImplementation DomImplementation;
+      const QDomDocumentType documentType = DomImplementation.createDocumentType( u"qgisLayerStyles"_s, u"http://mrcc.com/qgis.dtd"_s, u"SYSTEM"_s );
+      QDomDocument doc( documentType );
+
+      QString errorMsg;
+      int errorLine, errorColumn;
+      if ( !doc.setContent( clipboard()->data( QStringLiteral( QGSCLIPBOARD_STYLES_MIME ) ), false, &errorMsg, &errorLine, &errorColumn ) )
+      {
+        visibleMessageBar()->pushMessage( tr( "Cannot parse styles" ), errorMsg, Qgis::MessageLevel::Critical );
+        return;
+      }
+
+      const QDomElement rootElement { doc.firstChildElement( u"qgisLayerStyles"_s ).firstChildElement( u"defaultStyle"_s ).firstChildElement( u"qgis"_s ) };
+      const Qgis::LayerType styleOriginType { qgsEnumKeyToValue( rootElement.attribute( u"layerType"_s ), Qgis::LayerType::Vector ) };
+      if ( selectionLayer->type() != styleOriginType )
+      {
+        visibleMessageBar()->pushMessage( tr( "Cannot paste styles to layer '%1' because the type doesn't match (%2 → %3)" ).arg( selectionLayer->name(), QgsMapLayerUtils::layerTypeToString( styleOriginType ), QgsMapLayerUtils::layerTypeToString( selectionLayer->type() ) ), errorMsg, Qgis::MessageLevel::Warning );
+        return;
+      }
+
+      QgsMapLayerStyleManager *mgr = selectionLayer->styleManager();
+      mgr->readXml( doc.firstChildElement( u"qgisLayerStyles"_s ).firstChildElement( u"styles"_s ) );
+
+      QDomDocument currentStyleDoc( u"qgis"_s );
+      QDomNode importedNode = currentStyleDoc.importNode( rootElement, true );
+      currentStyleDoc.appendChild( importedNode );
+      if ( !selectionLayer->importNamedStyle( currentStyleDoc, errorMsg ) )
+      {
+        visibleMessageBar()->pushMessage( tr( "Cannot paste styles" ), errorMsg, Qgis::MessageLevel::Critical );
         return;
       }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1128,6 +1128,13 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * \param categories The style categories to copy
      */
     void copyStyle( QgsMapLayer *sourceLayer = nullptr, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
+
+    /**
+     * Copies all styles from a map layer.
+     * \param sourceLayer The layer where the style will be taken from (defaults to the active layer on the legend)
+     */
+    void copyAllStyles( QgsMapLayer *sourceLayer = nullptr );
+
     //! pastes style on the clipboard to the active layer
 
     /**
@@ -1135,6 +1142,14 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * \param categories The style categories to copy
      */
     void pasteStyle( QgsMapLayer *destinationLayer = nullptr, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );
+
+    /**
+     * Pastes all copied styles from a map layer.
+     *
+     * \param destinationLayer The layer that the clipboard styles will be pasted to (defaults to the active layer on the legend)
+     */
+    void pasteAllStyles( QgsMapLayer *destinationLayer = nullptr );
+
     //! copies group or layer on the clipboard
     void copyLayer();
     //! pastes group or layer from the clipboard to layer tree

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -713,10 +713,12 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           menuStyleManager->setTitle( tr( "Styles (%1)" ).arg( mgr->styles().count() ) );
         }
 
+        const QString copyCurrentStyleString = mgr->styles().count() > 1 ? tr( "Copy Current Style" ) : tr( "Copy Style" );
+
         QgisApp *app = QgisApp::instance();
         if ( layer->type() == Qgis::LayerType::Vector || layer->type() == Qgis::LayerType::Raster )
         {
-          QMenu *copyStyleMenu = menuStyleManager->addMenu( tr( "Copy Style" ) );
+          QMenu *copyStyleMenu = menuStyleManager->addMenu( copyCurrentStyleString );
           copyStyleMenu->setToolTipsVisible( true );
           QgsMapLayerStyleCategoriesModel *model = new QgsMapLayerStyleCategoriesModel( layer->type(), copyStyleMenu );
           model->setShowAllCategories( true );
@@ -752,7 +754,11 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         }
         else
         {
-          menuStyleManager->addAction( tr( "Copy Style" ), app, [app] { app->copyStyle(); } );
+          menuStyleManager->addAction( copyCurrentStyleString, app, [app] { app->copyStyle(); } );
+        }
+        if ( mgr->styles().count() > 1 )
+        {
+          menuStyleManager->addAction( tr( "Copy All Styles" ), app, [app] { app->copyAllStyles(); } );
         }
 
         if ( layer && app->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
@@ -814,6 +820,10 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           {
             menuStyleManager->addAction( tr( "Paste Style" ), app, [app] { app->pasteStyle(); } );
           }
+        }
+        else if ( layer && app->clipboard()->hasFormat( QGSCLIPBOARD_STYLES_MIME ) )
+        {
+          menuStyleManager->addAction( tr( "Paste All Styles" ), app, [app] { app->pasteAllStyles(); } );
         }
 
         menuStyleManager->addSeparator()->setObjectName( "MenuStyleSeparator"_L1 );

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -57,6 +57,7 @@ typedef QMap<QString, QgsPalLayerSettings > QgsLabelSettingsMap;
  * Constants used to describe copy-paste MIME types
  */
 #define QGSCLIPBOARD_STYLE_MIME "application/qgis.style"
+#define QGSCLIPBOARD_STYLES_MIME "application/qgis.styles"
 
 /**
  * \ingroup core

--- a/tests/src/app/testqgisapp.cpp
+++ b/tests/src/app/testqgisapp.cpp
@@ -15,10 +15,15 @@
 #include <gdal.h>
 
 #include "qgisapp.h"
+#include "qgsclipboard.h"
+#include "qgsfillsymbol.h"
 #include "qgsmaplayerlegend.h"
 #include "qgsmaplayerstore.h"
+#include "qgsmaplayerstylemanager.h"
 #include "qgsproject.h"
 #include "qgsrasterlayer.h"
+#include "qgssinglesymbolrenderer.h"
+#include "qgsstyle.h"
 #include "qgstest.h"
 
 #include <QApplication>
@@ -41,6 +46,7 @@ class TestQgisApp : public QObject
     void cleanup();         // will be called after every testfunction.
     //! Test for issue GH #63346
     void pasteRasterStyleCategory();
+    void copyPasteMultipleStyles();
 
   public slots:
     void addVectorLayerShp();
@@ -235,6 +241,51 @@ void TestQgisApp::pasteRasterStyleCategory()
   // Paste style to raster 2
   mQgisApp->pasteStyle( &rl2, QgsMapLayer::StyleCategory::Legend );
   QVERIFY( !rl2.legend()->flags().testFlag( Qgis::MapLayerLegendFlag::ExcludeByDefault ) );
+}
+
+void TestQgisApp::copyPasteMultipleStyles()
+{
+  auto sourceLayer = std::make_unique< QgsVectorLayer >( u"Polygon?crs=EPSG:4326"_s, u"polygons"_s, u"memory"_s );
+  auto destLayer = std::make_unique< QgsVectorLayer >( u"Polygon?crs=EPSG:4326"_s, u"polygons"_s, u"memory"_s );
+
+  sourceLayer->setRenderer( new QgsSingleSymbolRenderer( QgsFillSymbol::createSimple( { { "color", "#110011" } } ).release() ) );
+  sourceLayer->styleManager()->addStyleFromLayer( u"second style"_s );
+  sourceLayer->styleManager()->setCurrentStyle( u"second style"_s );
+  sourceLayer->setRenderer( new QgsSingleSymbolRenderer( QgsFillSymbol::createSimple( { { "color", "#220022" } } ).release() ) );
+  sourceLayer->styleManager()->addStyleFromLayer( u"third style"_s );
+  sourceLayer->styleManager()->setCurrentStyle( u"third style"_s );
+  sourceLayer->setRenderer( new QgsSingleSymbolRenderer( QgsFillSymbol::createSimple( { { "color", "#330033" } } ).release() ) );
+  QCOMPARE( sourceLayer->styleManager()->currentStyle(), u"third style"_s );
+
+  destLayer->setRenderer( new QgsSingleSymbolRenderer( QgsFillSymbol::createSimple( { { "color", "#ff0000" } } ).release() ) );
+
+  // copy all styles
+  mQgisApp->copyAllStyles( sourceLayer.get() );
+  QVERIFY( mQgisApp->clipboard()->hasFormat( QStringLiteral( QGSCLIPBOARD_STYLES_MIME ) ) );
+
+  mQgisApp->pasteAllStyles( destLayer.get() );
+  QCOMPARE( destLayer->styleManager()->styles().count(), 3 );
+  QVERIFY( destLayer->styleManager()->styles().contains( u"default" ) );
+  QVERIFY( destLayer->styleManager()->styles().contains( u"second style" ) );
+  QVERIFY( destLayer->styleManager()->styles().contains( u"third style" ) );
+
+  QCOMPARE( destLayer->styleManager()->currentStyle(), u"third style"_s );
+  QCOMPARE( dynamic_cast< QgsSingleSymbolRenderer *>( destLayer->renderer() )->symbol()->symbolLayer( 0 )->color().name(), u"#330033"_s );
+
+  destLayer->styleManager()->setCurrentStyle( u"second style"_s );
+  QCOMPARE( dynamic_cast< QgsSingleSymbolRenderer *>( destLayer->renderer() )->symbol()->symbolLayer( 0 )->color().name(), u"#220022"_s );
+
+  destLayer->styleManager()->setCurrentStyle( u"default"_s );
+  QCOMPARE( dynamic_cast< QgsSingleSymbolRenderer *>( destLayer->renderer() )->symbol()->symbolLayer( 0 )->color().name(), u"#110011"_s );
+
+  // make sure pasting styles onto layer with multiple existing styles clears those
+  // copy two styles from dest layer back to source layer, the missing one should be removed
+  destLayer->styleManager()->removeStyle( u"second style"_s );
+  mQgisApp->copyAllStyles( destLayer.get() );
+  mQgisApp->pasteAllStyles( sourceLayer.get() );
+  QCOMPARE( sourceLayer->styleManager()->styles().count(), 2 );
+  QVERIFY( sourceLayer->styleManager()->styles().contains( u"default" ) );
+  QVERIFY( sourceLayer->styleManager()->styles().contains( u"third style" ) );
 }
 
 


### PR DESCRIPTION
When a layer has multiple styles, the layer tree context menu now contains a new "Copy All Styles" action. Triggering this will copy the definition of ALL the layer's styles to the clipboard.

Users can then right click another layer and "Paste All Styles" in order to paste copies of ALL the original's layers styles.

Makes it much less frustrating to copy all the styles from a layer to another -- previously this would involve manually switching the source layer between every existing style, copying each and pasting one-by-one.

Sponsored by City of Canning
