### PR TITLE
qgssfcgalengine: Only define SFCGAL_VERSION_NUM when not available

### DIFF
--- a/src/core/geometry/qgssfcgalengine.h
+++ b/src/core/geometry/qgssfcgalengine.h
@@ -37,9 +37,15 @@ class QgsGeometry;
 class QgsSfcgalGeometry;
 
 /// compute SFCGAL integer version from major, minor and patch number
+/// This is not available before SFCGAL version 2.3.
+#ifndef SFCGAL_MAKE_VERSION
 #define SFCGAL_MAKE_VERSION( major, minor, patch ) ( ( major ) * 10000 + ( minor ) * 100 + ( patch ) )
+#endif
 /// compute current SFCGAL integer version
+/// This is not available before SFCGAL version 2.3.
+#ifndef SFCGAL_VERSION_NUM
 #define SFCGAL_VERSION_NUM SFCGAL_MAKE_VERSION( SFCGAL_VERSION_MAJOR_INT, SFCGAL_VERSION_MINOR_INT, SFCGAL_VERSION_PATCH_INT )
+#endif
 
 /// check if \a ptr is not null else add stacktrace entry and return the \a defaultObj
 #define CHECK_NOT_NULL( ptr, defaultObj )                                              \


### PR DESCRIPTION
## Description

`SFCGAL_MAKE_VERSION` and `SFCGAL_VERSION_NUM` macros have been available since SFCGAL 2.3. In that case, these macros don't need to be redefined.

See: https://gitlab.com/sfcgal/SFCGAL/-/merge_requests/654

This is a follow-up of https://github.com/qgis/QGIS/pull/64494

