### PR TITLE
Docs: clarify QgsLogger initialization via logFile()

### DIFF
--- a/src/core/qgslogger.h
+++ b/src/core/qgslogger.h
@@ -156,7 +156,15 @@ class CORE_EXPORT QgsLogger
     /**
      * Reads the environment variable QGIS_LOG_FILE. Returns an empty string if the variable is not set,
      * otherwise returns a file name for writing log messages to.
+     * Returns the log file path used by QgsLogger.
+     *
+     * Calling this method initializes the logging system by reading the
+     * environment variables QGIS_LOG_FILE, QGIS_DEBUG, and QGIS_DEBUG_FILE.
+     *
+     * This method must be called before any call to logMessageToFile(),
+     * otherwise messages will not be written to the log file.
     */
+
     static QString logFile();
 
   private:


### PR DESCRIPTION
This PR clarifies the documented behavior of QgsLogger::logFile().

Calling logFile() initializes the logging system by reading the
QGIS_LOG_FILE, QGIS_DEBUG, and QGIS_DEBUG_FILE environment variables.
If this initialization step is skipped, logMessageToFile() will not
write messages to the log file.

This change is documentation-only and does not modify runtime behavior.

Fixes #62982
