### PR TITLE
Fix SLPK loading

### DIFF
--- a/src/core/tiledscene/qgsesrii3sdataprovider.cpp
+++ b/src/core/tiledscene/qgsesrii3sdataprovider.cpp
@@ -714,7 +714,8 @@ QgsEsriI3SDataProvider::QgsEsriI3SDataProvider( const QString &uri,
   , mShared( std::make_shared< QgsEsriI3SDataProviderSharedData >() )
 {
   QgsDataSourceUri dataSource( dataSourceUri() );
-  QString sourcePath = dataSource.param( u"url"_s );
+  const QString url = dataSource.param( u"url"_s );
+  QString sourcePath = QUrl::fromPercentEncoding( url.toUtf8() );
 
   if ( sourcePath.isEmpty() )
   {


### PR DESCRIPTION
When the `uri` string reaches the provider, it is percent encoded, meaning the forward slashes are replaced with `%2`. This is OK for loading the files from the web, but not when loading local files.

Easy fix is to get the string `fromPercentEncoding`.

This was introduced with #62446