### PR TITLE
[mssql] Add Rename Table action in browser

### DIFF
--- a/src/providers/mssql/qgsmssqlconnection.h
+++ b/src/providers/mssql/qgsmssqlconnection.h
@@ -190,6 +190,11 @@ class QgsMssqlConnection
     static bool truncateTable( const QString &uri, QString *errorMessage );
 
     /**
+     * Renames the table referenced by \a uri to \a newName.
+     */
+    static bool renameTable( const QString &uri, const QString &newName, QString *errorMessage );
+
+    /**
      * Creates a new schema under connection specified by \a uri.
      */
     static bool createSchema( const QString &uri, const QString &schemaName, QString *errorMessage );

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -253,7 +253,7 @@ void QgsMssqlDataItemGuiProvider::renameLayer( QgsMssqlLayerItem *layerItem, Qgs
 {
   const QgsMssqlLayerProperty &layerInfo = layerItem->layerInfo();
 
-  QgsNewNameDialog dlg( tr( "Table %2.%3" ).arg( layerInfo.schemaName, layerInfo.tableName ), layerInfo.tableName );
+  QgsNewNameDialog dlg( tr( "Table %1.%2" ).arg( layerInfo.schemaName, layerInfo.tableName ), layerInfo.tableName );
   dlg.setWindowTitle( tr( "Rename Table" ) );
   if ( dlg.exec() != QDialog::Accepted || dlg.name() == layerInfo.tableName )
     return;

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.h
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.h
@@ -40,6 +40,7 @@ class QgsMssqlDataItemGuiProvider : public QObject, public QgsDataItemGuiProvide
     static void editConnection( QgsDataItem *item );
     static void duplicateConnection( QgsDataItem *item );
     static void createSchema( QgsMssqlConnectionItem *connItem );
+    static void renameLayer( QgsMssqlLayerItem *layerItem, QgsDataItemGuiContext context );
     static void truncateTable( QgsMssqlLayerItem *layerItem );
     static void saveConnections();
     static void loadConnections( QgsDataItem *item );


### PR DESCRIPTION
Allows renaming SQL Server tables.

I originally attempted to change the existing "Rename Table" actions (present for postrgres, hana, geopackage) to a generic Rename action based on the connection capabilities (see https://github.com/nyalldawson/QGIS/commit/c7ccc697fc43e342788c72386199ba7e5531f1b6), but this approach hit a roadblock in that:

1. The postgres rename table action does a lot more than just rename vector tables (it can eg rename views and raster layers). We don't have generic connection capabilities to handle those yet.
2. There's provider-specific browser refreshing logic required here. Specifically, to refresh a schema's table list for mssql we actually need to refresh at the connection level, since the connection item populates both schemas and tables at once. This differs from eg postgres provider, which requires a refresh at the schema level only. I really don't want to pollute the core abstract database connection class with specifically browser/GUI related flags like "requires grand parent refresh after renaming tables". 

Given these issues, I've opted for a (not so nice) implementation in the mssql browser GUI class alone, mimicing the existing implementations in the postgres/hana/geopackage provider gui classes. 