### PR TITLE
Line-Symbol-Templates for simple- and marker-line with arrowheads

### DIFF
--- a/resources/symbology-style.xml
+++ b/resources/symbology-style.xml
@@ -5699,7 +5699,7 @@
         </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="arrowheads markerline" tags="Showcase" type="line">
+    <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="arrowheads markerline" tags="Showcase" type="line" addedVersion="40000">
       <data_defined_properties>
         <Option type="Map">
           <Option name="name" type="QString" value=""/>
@@ -5707,7 +5707,7 @@
           <Option name="type" type="QString" value="collection"/>
         </Option>
       </data_defined_properties>
-      <layer class="MarkerLine" enabled="1" id="{25de20f2-ce9d-44a2-899c-ba5269c71207}" locked="0" pass="0">
+      <layer class="MarkerLine" enabled="1" id="{aba62713-b196-47cb-ab5e-4fed49f61d6b}" locked="0" pass="0">
         <Option type="Map">
           <Option name="average_angle_length" type="QString" value="4"/>
           <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
@@ -5717,26 +5717,42 @@
           <Option name="interval_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           <Option name="interval_unit" type="QString" value="MM"/>
           <Option name="offset" type="QString" value="0"/>
-          <Option name="offset_along_line" type="QString" value="0"/>
+          <Option name="offset_along_line" type="QString" value="1.5"/>
           <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           <Option name="offset_along_line_unit" type="QString" value="MM"/>
           <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           <Option name="offset_unit" type="QString" value="MM"/>
           <Option name="place_on_every_part" type="bool" value="false"/>
-          <Option name="placements" type="QString" value="Interval|LastVertex"/>
+          <Option name="placements" type="QString" value="Interval"/>
           <Option name="ring_filter" type="QString" value="0"/>
           <Option name="rotate" type="QString" value="1"/>
-          <Option name="trim_distance_end" type="QString" value="5"/>
+          <Option name="trim_distance_end" type="QString" value="4"/>
           <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-          <Option name="trim_distance_start" type="QString" value="8"/>
+          <Option name="trim_distance_start" type="QString" value="4"/>
           <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           <Option name="trim_distance_start_unit" type="QString" value="MM"/>
         </Option>
         <data_defined_properties>
           <Option type="Map">
             <Option name="name" type="QString" value=""/>
-            <Option name="properties"/>
+            <Option name="properties" type="Map">
+              <Option name="interval" type="Map">
+                <Option name="active" type="bool" value="true"/>
+                <Option name="expression" type="QString" value="with_variable(&#xa;    'mililength',&#xa;&#x9;-- length of the symbol in milimeters considering the trims&#xa;    (length(geometry(@feature)) * 1000/ @map_scale)-8, &#xa;    case &#xa;        when (@mililength % 4) > 2 -- bigger than the half&#xa;&#x9;&#x9;then &#xa;&#x9;&#x9;&#x9;4 + -- caps need to be enlarged&#xa;&#x9;&#x9;&#x9;(&#xa;&#x9;&#x9;&#x9;((@mililength % 4) - 3) -- minus 3 (size of a block) because we need the space for a last block&#xa;&#x9;&#x9;&#x9;/ &#xa;&#x9;&#x9;&#x9;(round(@mililength / 4) - 1)&#xa;&#x9;&#x9;&#x9;) -- minus 1 because with rounding up we have a cap to much&#xa;        else  -- smaller than the half&#xa;&#x9;&#x9;&#x9;4 - -- caps need to be diminished&#xa;&#x9;&#x9;&#x9;(&#xa;&#x9;&#x9;&#x9;(3 - (@mililength % 4)) -- divide from 3 (size of a block) because it's what we need to dismish to have space for the block&#xa;&#x9;&#x9;&#x9;/ &#xa;&#x9;&#x9;&#x9;(round(@mililength / 4)) -- no minus because we are rounding down&#xa;&#x9;&#x9;&#x9;)&#xa;    end&#xa;)"/>
+                <Option name="type" type="int" value="3"/>
+              </Option>
+              <Option name="trimEnd" type="Map">
+                <Option name="active" type="bool" value="false"/>
+                <Option name="expression" type="QString" value="(($length/@map_scale*1000)-9)%6/2+4.5"/>
+                <Option name="type" type="int" value="3"/>
+              </Option>
+              <Option name="trimStart" type="Map">
+                <Option name="active" type="bool" value="false"/>
+                <Option name="expression" type="QString" value="(($length/@map_scale*1000))%6/2+4.5"/>
+                <Option name="type" type="int" value="3"/>
+              </Option>
+            </Option>
             <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
@@ -5748,24 +5764,24 @@
               <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
-          <layer class="SimpleMarker" enabled="1" id="{25e0d9fd-bdac-440f-862c-e91d01593ed2}" locked="0" pass="0">
+          <layer class="SimpleMarker" enabled="1" id="{127e2e3c-e7e9-40b8-97b6-171956080769}" locked="0" pass="0">
             <Option type="Map">
               <Option name="angle" type="QString" value="0"/>
               <Option name="cap_style" type="QString" value="square"/>
               <Option name="color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
               <Option name="horizontal_anchor_point" type="QString" value="1"/>
               <Option name="joinstyle" type="QString" value="bevel"/>
-              <Option name="name" type="QString" value="half_square"/>
+              <Option name="name" type="QString" value="line"/>
               <Option name="offset" type="QString" value="0,0"/>
               <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
               <Option name="offset_unit" type="QString" value="MM"/>
-              <Option name="outline_color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="outline_color" type="QString" value="45,186,176,255,rgb:0.1764706,0.7294118,0.6901961,1"/>
               <Option name="outline_style" type="QString" value="solid"/>
-              <Option name="outline_width" type="QString" value="0"/>
+              <Option name="outline_width" type="QString" value="3"/>
               <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
               <Option name="outline_width_unit" type="QString" value="MM"/>
               <Option name="scale_method" type="QString" value="diameter"/>
-              <Option name="size" type="QString" value="6"/>
+              <Option name="size" type="QString" value="3"/>
               <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
               <Option name="size_unit" type="QString" value="MM"/>
               <Option name="vertical_anchor_point" type="QString" value="1"/>
@@ -5780,7 +5796,7 @@
           </layer>
         </symbol>
       </layer>
-      <layer class="MarkerLine" enabled="1" id="{f87706cf-d234-4401-9a24-36614afef9cd}" locked="0" pass="0">
+      <layer class="MarkerLine" enabled="1" id="{edfbc5f3-e2bd-40d7-a140-85b71a7fc658}" locked="0" pass="0">
         <Option type="Map">
           <Option name="average_angle_length" type="QString" value="4"/>
           <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
@@ -5821,18 +5837,18 @@
               <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
-          <layer class="SimpleMarker" enabled="1" id="{2b36f1a4-f402-4869-94a3-8b2d11833465}" locked="0" pass="0">
+          <layer class="SimpleMarker" enabled="1" id="{0a6e7293-ca21-4b78-8e9f-9ebeaa59d3b6}" locked="0" pass="0">
             <Option type="Map">
               <Option name="angle" type="QString" value="0"/>
               <Option name="cap_style" type="QString" value="square"/>
-              <Option name="color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="color" type="QString" value="45,186,176,255,rgb:0.1764706,0.7294118,0.6901961,1"/>
               <Option name="horizontal_anchor_point" type="QString" value="1"/>
               <Option name="joinstyle" type="QString" value="bevel"/>
               <Option name="name" type="QString" value="filled_arrowhead"/>
               <Option name="offset" type="QString" value="0,0"/>
               <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
               <Option name="offset_unit" type="QString" value="MM"/>
-              <Option name="outline_color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="outline_color" type="QString" value="45,186,176,255,rgb:0.1764706,0.7294118,0.6901961,1"/>
               <Option name="outline_style" type="QString" value="solid"/>
               <Option name="outline_width" type="QString" value="0"/>
               <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
@@ -5853,7 +5869,7 @@
           </layer>
         </symbol>
       </layer>
-      <layer class="MarkerLine" enabled="1" id="{dbcfb525-c380-4dba-98cc-780bd2217324}" locked="0" pass="0">
+      <layer class="MarkerLine" enabled="1" id="{67274c51-f7ff-455d-a909-ef99096d6089}" locked="0" pass="0">
         <Option type="Map">
           <Option name="average_angle_length" type="QString" value="4"/>
           <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
@@ -5894,18 +5910,18 @@
               <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
-          <layer class="SimpleMarker" enabled="1" id="{4f57fdb1-30c8-4c51-b5d1-0887f6740336}" locked="0" pass="0">
+          <layer class="SimpleMarker" enabled="1" id="{6b52df22-f538-4b96-b091-56882f7976f7}" locked="0" pass="0">
             <Option type="Map">
               <Option name="angle" type="QString" value="180"/>
               <Option name="cap_style" type="QString" value="square"/>
-              <Option name="color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="color" type="QString" value="45,186,176,255,rgb:0.1764706,0.7294118,0.6901961,1"/>
               <Option name="horizontal_anchor_point" type="QString" value="1"/>
               <Option name="joinstyle" type="QString" value="bevel"/>
               <Option name="name" type="QString" value="filled_arrowhead"/>
               <Option name="offset" type="QString" value="0,0"/>
               <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
               <Option name="offset_unit" type="QString" value="MM"/>
-              <Option name="outline_color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="outline_color" type="QString" value="45,186,176,255,rgb:0.1764706,0.7294118,0.6901961,1"/>
               <Option name="outline_style" type="QString" value="solid"/>
               <Option name="outline_width" type="QString" value="0"/>
               <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
@@ -5927,7 +5943,7 @@
         </symbol>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="arrowheads simpleline" tags="Showcase" type="line">
+    <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="arrowheads simpleline" tags="Showcase" type="line" addedVersion="40000">
       <data_defined_properties>
         <Option type="Map">
           <Option name="name" type="QString" value=""/>

--- a/resources/symbology-style.xml
+++ b/resources/symbology-style.xml
@@ -5742,16 +5742,6 @@
                 <Option name="type" type="int" value="1"/>
                 <Option name="val" type="QString" value=""/>
               </Option>
-              <Option name="trimEnd" type="Map">
-                <Option name="active" type="bool" value="false"/>
-                <Option name="expression" type="QString" value="(($length/@map_scale*1000)-9)%6/2+4.5"/>
-                <Option name="type" type="int" value="3"/>
-              </Option>
-              <Option name="trimStart" type="Map">
-                <Option name="active" type="bool" value="false"/>
-                <Option name="expression" type="QString" value="(($length/@map_scale*1000))%6/2+4.5"/>
-                <Option name="type" type="int" value="3"/>
-              </Option>
             </Option>
             <Option name="type" type="QString" value="collection"/>
           </Option>

--- a/resources/symbology-style.xml
+++ b/resources/symbology-style.xml
@@ -5699,6 +5699,427 @@
         </data_defined_properties>
       </layer>
     </symbol>
+    <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="arrowheads markerline" tags="Showcase" type="line">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="MarkerLine" enabled="1" id="{25de20f2-ce9d-44a2-899c-ba5269c71207}" locked="0" pass="0">
+        <Option type="Map">
+          <Option name="average_angle_length" type="QString" value="4"/>
+          <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="average_angle_unit" type="QString" value="MM"/>
+          <Option name="blank_segments_unit" type="QString" value="MapUnit"/>
+          <Option name="interval" type="QString" value="6"/>
+          <Option name="interval_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="interval_unit" type="QString" value="MM"/>
+          <Option name="offset" type="QString" value="0"/>
+          <Option name="offset_along_line" type="QString" value="0"/>
+          <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_along_line_unit" type="QString" value="MM"/>
+          <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_unit" type="QString" value="MM"/>
+          <Option name="place_on_every_part" type="bool" value="false"/>
+          <Option name="placements" type="QString" value="Interval|LastVertex"/>
+          <Option name="ring_filter" type="QString" value="0"/>
+          <Option name="rotate" type="QString" value="1"/>
+          <Option name="trim_distance_end" type="QString" value="5"/>
+          <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+          <Option name="trim_distance_start" type="QString" value="8"/>
+          <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+        </Option>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="@arrowheads markerline@0" type="marker">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleMarker" enabled="1" id="{25e0d9fd-bdac-440f-862c-e91d01593ed2}" locked="0" pass="0">
+            <Option type="Map">
+              <Option name="angle" type="QString" value="0"/>
+              <Option name="cap_style" type="QString" value="square"/>
+              <Option name="color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="horizontal_anchor_point" type="QString" value="1"/>
+              <Option name="joinstyle" type="QString" value="bevel"/>
+              <Option name="name" type="QString" value="half_square"/>
+              <Option name="offset" type="QString" value="0,0"/>
+              <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="offset_unit" type="QString" value="MM"/>
+              <Option name="outline_color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="outline_style" type="QString" value="solid"/>
+              <Option name="outline_width" type="QString" value="0"/>
+              <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="outline_width_unit" type="QString" value="MM"/>
+              <Option name="scale_method" type="QString" value="diameter"/>
+              <Option name="size" type="QString" value="6"/>
+              <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="size_unit" type="QString" value="MM"/>
+              <Option name="vertical_anchor_point" type="QString" value="1"/>
+            </Option>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+      <layer class="MarkerLine" enabled="1" id="{f87706cf-d234-4401-9a24-36614afef9cd}" locked="0" pass="0">
+        <Option type="Map">
+          <Option name="average_angle_length" type="QString" value="4"/>
+          <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="average_angle_unit" type="QString" value="MM"/>
+          <Option name="blank_segments_unit" type="QString" value="MapUnit"/>
+          <Option name="interval" type="QString" value="3"/>
+          <Option name="interval_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="interval_unit" type="QString" value="MM"/>
+          <Option name="offset" type="QString" value="0"/>
+          <Option name="offset_along_line" type="QString" value="0"/>
+          <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_along_line_unit" type="QString" value="MM"/>
+          <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_unit" type="QString" value="MM"/>
+          <Option name="place_on_every_part" type="bool" value="false"/>
+          <Option name="placements" type="QString" value="LastVertex"/>
+          <Option name="ring_filter" type="QString" value="0"/>
+          <Option name="rotate" type="QString" value="1"/>
+          <Option name="trim_distance_end" type="QString" value="0"/>
+          <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+          <Option name="trim_distance_start" type="QString" value="0"/>
+          <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+        </Option>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="@arrowheads markerline@1" type="marker">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleMarker" enabled="1" id="{2b36f1a4-f402-4869-94a3-8b2d11833465}" locked="0" pass="0">
+            <Option type="Map">
+              <Option name="angle" type="QString" value="0"/>
+              <Option name="cap_style" type="QString" value="square"/>
+              <Option name="color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="horizontal_anchor_point" type="QString" value="1"/>
+              <Option name="joinstyle" type="QString" value="bevel"/>
+              <Option name="name" type="QString" value="filled_arrowhead"/>
+              <Option name="offset" type="QString" value="0,0"/>
+              <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="offset_unit" type="QString" value="MM"/>
+              <Option name="outline_color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="outline_style" type="QString" value="solid"/>
+              <Option name="outline_width" type="QString" value="0"/>
+              <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="outline_width_unit" type="QString" value="MM"/>
+              <Option name="scale_method" type="QString" value="diameter"/>
+              <Option name="size" type="QString" value="6"/>
+              <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="size_unit" type="QString" value="MM"/>
+              <Option name="vertical_anchor_point" type="QString" value="1"/>
+            </Option>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+      <layer class="MarkerLine" enabled="1" id="{dbcfb525-c380-4dba-98cc-780bd2217324}" locked="0" pass="0">
+        <Option type="Map">
+          <Option name="average_angle_length" type="QString" value="4"/>
+          <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="average_angle_unit" type="QString" value="MM"/>
+          <Option name="blank_segments_unit" type="QString" value="MapUnit"/>
+          <Option name="interval" type="QString" value="3"/>
+          <Option name="interval_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="interval_unit" type="QString" value="MM"/>
+          <Option name="offset" type="QString" value="0"/>
+          <Option name="offset_along_line" type="QString" value="0"/>
+          <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_along_line_unit" type="QString" value="MM"/>
+          <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_unit" type="QString" value="MM"/>
+          <Option name="place_on_every_part" type="bool" value="false"/>
+          <Option name="placements" type="QString" value="FirstVertex"/>
+          <Option name="ring_filter" type="QString" value="0"/>
+          <Option name="rotate" type="QString" value="1"/>
+          <Option name="trim_distance_end" type="QString" value="0"/>
+          <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+          <Option name="trim_distance_start" type="QString" value="0"/>
+          <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+        </Option>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="@arrowheads markerline@2" type="marker">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleMarker" enabled="1" id="{4f57fdb1-30c8-4c51-b5d1-0887f6740336}" locked="0" pass="0">
+            <Option type="Map">
+              <Option name="angle" type="QString" value="180"/>
+              <Option name="cap_style" type="QString" value="square"/>
+              <Option name="color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="horizontal_anchor_point" type="QString" value="1"/>
+              <Option name="joinstyle" type="QString" value="bevel"/>
+              <Option name="name" type="QString" value="filled_arrowhead"/>
+              <Option name="offset" type="QString" value="0,0"/>
+              <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="offset_unit" type="QString" value="MM"/>
+              <Option name="outline_color" type="QString" value="46,120,125,255,rgb:0.1803922,0.4705882,0.4901961,1"/>
+              <Option name="outline_style" type="QString" value="solid"/>
+              <Option name="outline_width" type="QString" value="0"/>
+              <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="outline_width_unit" type="QString" value="MM"/>
+              <Option name="scale_method" type="QString" value="diameter"/>
+              <Option name="size" type="QString" value="6"/>
+              <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="size_unit" type="QString" value="MM"/>
+              <Option name="vertical_anchor_point" type="QString" value="1"/>
+            </Option>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+    </symbol>
+    <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="arrowheads simpleline" tags="Showcase" type="line">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="SimpleLine" enabled="1" id="{f5aa1446-bce2-4c02-b8db-9f9daa7bf046}" locked="0" pass="0">
+        <Option type="Map">
+          <Option name="align_dash_pattern" type="QString" value="1"/>
+          <Option name="capstyle" type="QString" value="square"/>
+          <Option name="customdash" type="QString" value="1;2"/>
+          <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="customdash_unit" type="QString" value="MM"/>
+          <Option name="dash_pattern_offset" type="QString" value="0"/>
+          <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+          <Option name="draw_inside_polygon" type="QString" value="0"/>
+          <Option name="joinstyle" type="QString" value="bevel"/>
+          <Option name="line_color" type="QString" value="113,79,125,255,rgb:0.4420386,0.3087053,0.4905013,1"/>
+          <Option name="line_style" type="QString" value="dash"/>
+          <Option name="line_width" type="QString" value="1"/>
+          <Option name="line_width_unit" type="QString" value="MM"/>
+          <Option name="offset" type="QString" value="0"/>
+          <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_unit" type="QString" value="MM"/>
+          <Option name="ring_filter" type="QString" value="0"/>
+          <Option name="trim_distance_end" type="QString" value="3"/>
+          <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+          <Option name="trim_distance_start" type="QString" value="3"/>
+          <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+          <Option name="tweak_dash_pattern_on_corners" type="QString" value="1"/>
+          <Option name="use_custom_dash" type="QString" value="1"/>
+          <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        </Option>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer class="MarkerLine" enabled="1" id="{bd939dec-b155-4090-b1c1-cac15db9e7f7}" locked="0" pass="0">
+        <Option type="Map">
+          <Option name="average_angle_length" type="QString" value="4"/>
+          <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="average_angle_unit" type="QString" value="MM"/>
+          <Option name="blank_segments_unit" type="QString" value="MapUnit"/>
+          <Option name="interval" type="QString" value="3"/>
+          <Option name="interval_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="interval_unit" type="QString" value="MM"/>
+          <Option name="offset" type="QString" value="0"/>
+          <Option name="offset_along_line" type="QString" value="0"/>
+          <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_along_line_unit" type="QString" value="MM"/>
+          <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_unit" type="QString" value="MM"/>
+          <Option name="place_on_every_part" type="bool" value="false"/>
+          <Option name="placements" type="QString" value="FirstVertex"/>
+          <Option name="ring_filter" type="QString" value="0"/>
+          <Option name="rotate" type="QString" value="1"/>
+          <Option name="trim_distance_end" type="QString" value="0"/>
+          <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+          <Option name="trim_distance_start" type="QString" value="0"/>
+          <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+        </Option>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="@arrowheads simpleline@1" type="marker">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleMarker" enabled="1" id="{a0bb63cc-3583-411f-a02f-db64f9cd73b3}" locked="0" pass="0">
+            <Option type="Map">
+              <Option name="angle" type="QString" value="270"/>
+              <Option name="cap_style" type="QString" value="square"/>
+              <Option name="color" type="QString" value="113,79,125,255,rgb:0.4420386,0.3087053,0.4905013,1"/>
+              <Option name="horizontal_anchor_point" type="QString" value="1"/>
+              <Option name="joinstyle" type="QString" value="bevel"/>
+              <Option name="name" type="QString" value="triangle"/>
+              <Option name="offset" type="QString" value="0,0"/>
+              <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="offset_unit" type="QString" value="MM"/>
+              <Option name="outline_color" type="QString" value="55,126,184,255,rgb:0.2156863,0.4941176,0.7215686,1"/>
+              <Option name="outline_style" type="QString" value="solid"/>
+              <Option name="outline_width" type="QString" value="0"/>
+              <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="outline_width_unit" type="QString" value="MM"/>
+              <Option name="scale_method" type="QString" value="diameter"/>
+              <Option name="size" type="QString" value="3"/>
+              <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="size_unit" type="QString" value="MM"/>
+              <Option name="vertical_anchor_point" type="QString" value="1"/>
+            </Option>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+      <layer class="MarkerLine" enabled="1" id="{13fcea2e-98f3-4757-a064-a3a343d219aa}" locked="0" pass="0">
+        <Option type="Map">
+          <Option name="average_angle_length" type="QString" value="4"/>
+          <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="average_angle_unit" type="QString" value="MM"/>
+          <Option name="blank_segments_unit" type="QString" value="MapUnit"/>
+          <Option name="interval" type="QString" value="3"/>
+          <Option name="interval_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="interval_unit" type="QString" value="MM"/>
+          <Option name="offset" type="QString" value="0"/>
+          <Option name="offset_along_line" type="QString" value="0"/>
+          <Option name="offset_along_line_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_along_line_unit" type="QString" value="MM"/>
+          <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offset_unit" type="QString" value="MM"/>
+          <Option name="place_on_every_part" type="bool" value="false"/>
+          <Option name="placements" type="QString" value="LastVertex"/>
+          <Option name="ring_filter" type="QString" value="0"/>
+          <Option name="rotate" type="QString" value="1"/>
+          <Option name="trim_distance_end" type="QString" value="0"/>
+          <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+          <Option name="trim_distance_start" type="QString" value="0"/>
+          <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+        </Option>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="@arrowheads simpleline@2" type="marker">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleMarker" enabled="1" id="{57a97150-c685-4d3b-a0ef-49543707fd47}" locked="0" pass="0">
+            <Option type="Map">
+              <Option name="angle" type="QString" value="90"/>
+              <Option name="cap_style" type="QString" value="square"/>
+              <Option name="color" type="QString" value="113,79,125,255,rgb:0.4420386,0.3087053,0.4905013,1"/>
+              <Option name="horizontal_anchor_point" type="QString" value="1"/>
+              <Option name="joinstyle" type="QString" value="bevel"/>
+              <Option name="name" type="QString" value="triangle"/>
+              <Option name="offset" type="QString" value="0,0"/>
+              <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="offset_unit" type="QString" value="MM"/>
+              <Option name="outline_color" type="QString" value="55,126,184,255,rgb:0.2156863,0.4941176,0.7215686,1"/>
+              <Option name="outline_style" type="QString" value="solid"/>
+              <Option name="outline_width" type="QString" value="0"/>
+              <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="outline_width_unit" type="QString" value="MM"/>
+              <Option name="scale_method" type="QString" value="diameter"/>
+              <Option name="size" type="QString" value="3"/>
+              <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option name="size_unit" type="QString" value="MM"/>
+              <Option name="vertical_anchor_point" type="QString" value="1"/>
+            </Option>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+    </symbol>    
   </symbols>
   <colorramps>
     <colorramp favorite="1" name="Blues" type="gradient" addedVersion="30000">

--- a/resources/symbology-style.xml
+++ b/resources/symbology-style.xml
@@ -5737,11 +5737,6 @@
           <Option type="Map">
             <Option name="name" type="QString" value=""/>
             <Option name="properties" type="Map">
-              <Option name="interval" type="Map">
-                <Option name="active" type="bool" value="false"/>
-                <Option name="type" type="int" value="1"/>
-                <Option name="val" type="QString" value=""/>
-              </Option>
             </Option>
             <Option name="type" type="QString" value="collection"/>
           </Option>

--- a/resources/symbology-style.xml
+++ b/resources/symbology-style.xml
@@ -5707,13 +5707,13 @@
           <Option name="type" type="QString" value="collection"/>
         </Option>
       </data_defined_properties>
-      <layer class="MarkerLine" enabled="1" id="{aba62713-b196-47cb-ab5e-4fed49f61d6b}" locked="0" pass="0">
+      <layer class="MarkerLine" enabled="1" id="{831dae49-75b1-4c14-b55c-57b7add8424f}" locked="0" pass="0">
         <Option type="Map">
           <Option name="average_angle_length" type="QString" value="4"/>
           <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           <Option name="average_angle_unit" type="QString" value="MM"/>
           <Option name="blank_segments_unit" type="QString" value="MapUnit"/>
-          <Option name="interval" type="QString" value="6"/>
+          <Option name="interval" type="QString" value="4"/>
           <Option name="interval_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           <Option name="interval_unit" type="QString" value="MM"/>
           <Option name="offset" type="QString" value="0"/>
@@ -5723,7 +5723,7 @@
           <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           <Option name="offset_unit" type="QString" value="MM"/>
           <Option name="place_on_every_part" type="bool" value="false"/>
-          <Option name="placements" type="QString" value="Interval"/>
+          <Option name="placements" type="QString" value="Interval|LastVertex"/>
           <Option name="ring_filter" type="QString" value="0"/>
           <Option name="rotate" type="QString" value="1"/>
           <Option name="trim_distance_end" type="QString" value="4"/>
@@ -5738,9 +5738,9 @@
             <Option name="name" type="QString" value=""/>
             <Option name="properties" type="Map">
               <Option name="interval" type="Map">
-                <Option name="active" type="bool" value="true"/>
-                <Option name="expression" type="QString" value="with_variable(&#xa;    'mililength',&#xa;&#x9;-- length of the symbol in milimeters considering the trims&#xa;    (length(geometry(@feature)) * 1000/ @map_scale)-8, &#xa;    case &#xa;        when (@mililength % 4) > 2 -- bigger than the half&#xa;&#x9;&#x9;then &#xa;&#x9;&#x9;&#x9;4 + -- caps need to be enlarged&#xa;&#x9;&#x9;&#x9;(&#xa;&#x9;&#x9;&#x9;((@mililength % 4) - 3) -- minus 3 (size of a block) because we need the space for a last block&#xa;&#x9;&#x9;&#x9;/ &#xa;&#x9;&#x9;&#x9;(round(@mililength / 4) - 1)&#xa;&#x9;&#x9;&#x9;) -- minus 1 because with rounding up we have a cap to much&#xa;        else  -- smaller than the half&#xa;&#x9;&#x9;&#x9;4 - -- caps need to be diminished&#xa;&#x9;&#x9;&#x9;(&#xa;&#x9;&#x9;&#x9;(3 - (@mililength % 4)) -- divide from 3 (size of a block) because it's what we need to dismish to have space for the block&#xa;&#x9;&#x9;&#x9;/ &#xa;&#x9;&#x9;&#x9;(round(@mililength / 4)) -- no minus because we are rounding down&#xa;&#x9;&#x9;&#x9;)&#xa;    end&#xa;)"/>
-                <Option name="type" type="int" value="3"/>
+                <Option name="active" type="bool" value="false"/>
+                <Option name="type" type="int" value="1"/>
+                <Option name="val" type="QString" value=""/>
               </Option>
               <Option name="trimEnd" type="Map">
                 <Option name="active" type="bool" value="false"/>
@@ -5764,7 +5764,7 @@
               <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
-          <layer class="SimpleMarker" enabled="1" id="{127e2e3c-e7e9-40b8-97b6-171956080769}" locked="0" pass="0">
+          <layer class="SimpleMarker" enabled="1" id="{031f8913-1f43-482e-9417-91dbef181097}" locked="0" pass="0">
             <Option type="Map">
               <Option name="angle" type="QString" value="0"/>
               <Option name="cap_style" type="QString" value="square"/>
@@ -5796,7 +5796,7 @@
           </layer>
         </symbol>
       </layer>
-      <layer class="MarkerLine" enabled="1" id="{edfbc5f3-e2bd-40d7-a140-85b71a7fc658}" locked="0" pass="0">
+      <layer class="MarkerLine" enabled="1" id="{9374afef-3e13-4a06-bd9d-4278060d9e3b}" locked="0" pass="0">
         <Option type="Map">
           <Option name="average_angle_length" type="QString" value="4"/>
           <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
@@ -5837,7 +5837,7 @@
               <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
-          <layer class="SimpleMarker" enabled="1" id="{0a6e7293-ca21-4b78-8e9f-9ebeaa59d3b6}" locked="0" pass="0">
+          <layer class="SimpleMarker" enabled="1" id="{b880697e-7f35-4f1f-b4a9-dce6dde79083}" locked="0" pass="0">
             <Option type="Map">
               <Option name="angle" type="QString" value="0"/>
               <Option name="cap_style" type="QString" value="square"/>
@@ -5869,7 +5869,7 @@
           </layer>
         </symbol>
       </layer>
-      <layer class="MarkerLine" enabled="1" id="{67274c51-f7ff-455d-a909-ef99096d6089}" locked="0" pass="0">
+      <layer class="MarkerLine" enabled="1" id="{21b57150-c74b-4bd1-94de-2288564125c3}" locked="0" pass="0">
         <Option type="Map">
           <Option name="average_angle_length" type="QString" value="4"/>
           <Option name="average_angle_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
@@ -5910,7 +5910,7 @@
               <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
-          <layer class="SimpleMarker" enabled="1" id="{6b52df22-f538-4b96-b091-56882f7976f7}" locked="0" pass="0">
+          <layer class="SimpleMarker" enabled="1" id="{e692a677-2711-4e46-a51a-ec92ea7056c7}" locked="0" pass="0">
             <Option type="Map">
               <Option name="angle" type="QString" value="180"/>
               <Option name="cap_style" type="QString" value="square"/>


### PR DESCRIPTION
Simple line with arrowheads and marker line with arrowheads in the category "Showcase".

https://github.com/user-attachments/assets/33990ef5-c47c-45f3-a195-9bcbed89a306

**This PR depends on #64548 because the use of the trim option on marker lines.**
