### PR TITLE
[mvt] Support gzipped tiles in QgsVectorTileMVTDecoder

### DIFF
--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -65,7 +65,7 @@ bool QgsVectorTileMVTDecoder::decode( const QgsVectorTileRawData &rawTileData )
     }
 
     vector_tile::Tile tile;
-    if ( !tile.ParseFromArray( pbf.constData(), pbf.count() ) )
+    if ( !tile.ParseFromArray( pbf.constData(), static_cast<int>( pbf.size() ) ) )
       return false;
 
     for ( int layerNum = 0; layerNum < tile.layers_size(); ++layerNum )


### PR DESCRIPTION
While testing some demo local data (PBF files), I could not render them and discovered they were gzipped.

I am not 100% sure if it's the best place to put this, I am hesitating with [QgsVectorTileLoader::tileReplyFinished](https://github.com/qgis/QGIS/blob/fddeb8c7bdfad72c9334cf78c37eb078ba4cea18/src/core/vectortile/qgsvectortileloader.cpp#L111)