### PR TITLE
Update Pdal_wrench to version 1.4.0

### DIFF
--- a/external/pdal_wrench/alg.hpp
+++ b/external/pdal_wrench/alg.hpp
@@ -116,12 +116,12 @@ struct Translate : public Alg
     std::string assignCrs;
     std::string transformCrs;
     std::string transformCoordOp;
-    std::string outputFormat;  // las / laz / copc
+    std::string outputFormatVpc;  // las / laz / copc
     std::string transformMatrix; // 4x4 matrix as 16 space-separated values
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
 
     std::vector<std::string> tileOutputFiles;
 
@@ -187,11 +187,11 @@ struct Clip : public Alg
     // parameters from the user
     std::string outputFile;
     std::string polygonFile;
-    std::string outputFormat;  // las / laz / copc
+    std::string outputFormatVpc;  // las / laz / copc
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
     pdal::Arg* argPolygon = nullptr;
 
     std::vector<std::string> tileOutputFiles;
@@ -235,14 +235,14 @@ struct Thin : public Alg
     std::string mode;  // "every-nth" or "sample"
     int stepEveryN;  // keep every N-th point
     double stepSample;  // cell size for Poisson sampling
-    std::string outputFormat;  // las / laz / copc
+    std::string outputFormatVpc;  // las / laz / copc
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
     pdal::Arg* argMode = nullptr;
     pdal::Arg* argStepEveryN = nullptr;
     pdal::Arg* argStepSample = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
 
     std::vector<std::string> tileOutputFiles;
 
@@ -342,7 +342,7 @@ struct ClassifyGround : public Alg
 
     // parameters from the user
     std::string outputFile;
-    std::string outputFormat;  // las / laz / copc
+    std::string outputFormatVpc;  // las / laz / copc
 
     double cellSize = 1.0;
     double scalar = 1.25;
@@ -352,7 +352,7 @@ struct ClassifyGround : public Alg
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
     pdal::Arg* argCellSize = nullptr;
 
     pdal::Arg* argScalar = nullptr;
@@ -379,7 +379,7 @@ struct FilterNoise: public Alg
     
     // parameters from the user
     std::string outputFile;
-    std::string outputFormat;  // las / laz / copc
+    std::string outputFormatVpc;  // las / laz / copc
     std::string algorithm = "statistical"; // "statistical" or "radius"
     bool removeNoisePoints = false;
 
@@ -393,7 +393,7 @@ struct FilterNoise: public Alg
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
     pdal::Arg* argAlgorithm = nullptr;
     pdal::Arg* argRemoveNoisePoints = nullptr;
     pdal::Arg* argRadiusMinK = nullptr;
@@ -415,7 +415,7 @@ struct HeightAboveGround : public Alg
     
     // parameters from the user
     std::string outputFile;
-    std::string outputFormat;  // las / laz / copc / vpc
+    std::string outputFormatVpc;  // las / laz / copc
     bool replaceZWithHeightAboveGround = true;
     std::string algorithm = "nn";
 
@@ -428,7 +428,7 @@ struct HeightAboveGround : public Alg
     
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
     pdal::Arg* argReplaceZWithHeightAboveGround = nullptr;
     pdal::Arg* argAlgorithm = nullptr;
 
@@ -440,6 +440,34 @@ struct HeightAboveGround : public Alg
     pdal::Arg* argDelaunayCount = nullptr;
 
     std::vector<std::string> tileOutputFiles;
+
+    // impl
+    virtual void addArgs() override;
+    virtual bool checkArgs() override;
+    virtual void preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
+    virtual void finalize(std::vector<std::unique_ptr<PipelineManager>>& pipelines) override;
+};
+
+struct ComparePointClouds : public Alg
+{   
+    ComparePointClouds() { isStreaming = false; }
+
+    // parameters from the user
+    std::string outputFile;
+
+    std::string comparedInputFile;
+    double subsamplingCellSize;  // cell size for Poisson sampling
+    double normalRadius = 2.0;
+    double cylRadius = 2.0;
+    double cylHalflen = 5.0;
+    double regError = 0.0;
+    std::string cylOrientation = "up";
+
+    // args - initialized in addArgs()
+    pdal::Arg* argOutput = nullptr;
+    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argComparedInputFile = nullptr;
+    pdal::Arg* argOrientation = nullptr;
 
     // impl
     virtual void addArgs() override;

--- a/external/pdal_wrench/classify_ground.cpp
+++ b/external/pdal_wrench/classify_ground.cpp
@@ -35,7 +35,7 @@ namespace fs = std::filesystem;
 void ClassifyGround::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormat = &programArgs.add("output-format", "Output format (las/laz/copc)", outputFormat);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc, "copc");
     
     argCellSize = &programArgs.add("cell-size", "Sets the grid cell size in map units. Smaller values give finer detail but may increase noise.", cellSize, 1.0);
     argScalar = &programArgs.add("scalar", "Increases the threshold on steeper slopes. Raise this for rough terrain.", scalar, 1.25);
@@ -52,17 +52,20 @@ bool ClassifyGround::checkArgs()
         return false;
     }
 
-    if (argOutputFormat->set())
+    if (argOutputFormatVpc->set())
     {
-        if (outputFormat != "las" && outputFormat != "laz" && outputFormat != "copc")
+        if (outputFormatVpc != "las" && outputFormatVpc != "laz" && outputFormatVpc != "copc")
         {
-            std::cerr << "unknown output format: " << outputFormat << std::endl;
+            std::cerr << "unknown output format: " << outputFormatVpc << std::endl;
             return false;
         }
     }
-    else
-        outputFormat = "las";  // uncompressed by default
-
+    
+    if ( ends_with(outputFile, ".vpc") && outputFormatVpc == "copc" )
+    {
+        isStreaming = false;
+    }
+    
     return true;
 }
 
@@ -134,14 +137,7 @@ void ClassifyGround::preparePipelines(std::vector<std::unique_ptr<PipelineManage
             ParallelJobInfo tile(ParallelJobInfo::FileBased, BOX2D(), filterExpression, filterBounds);
             tile.inputFilenames.push_back(f.filename);
 
-            // for input file /x/y/z.las that goes to /tmp/hello.vpc,
-            // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fileStem(f.filename);
-
-            if (!ends_with(outputFile, ".vpc"))
-                tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
-            else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
+            tile.outputFilename = tileOutputFileName(outputFile, outputFormatVpc, outputSubdir, f.filename);
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/external/pdal_wrench/clip.cpp
+++ b/external/pdal_wrench/clip.cpp
@@ -34,7 +34,7 @@ namespace fs = std::filesystem;
 void Clip::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormat = &programArgs.add("output-format", "Output format (las/laz/copc)", outputFormat);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc, "copc");
     argPolygon = &programArgs.add("polygon,p", "Input polygon vector file", polygonFile);
 }
 
@@ -51,17 +51,20 @@ bool Clip::checkArgs()
         return false;
     }
 
-    if (argOutputFormat->set())
+    if (argOutputFormatVpc->set())
     {
-        if (outputFormat != "las" && outputFormat != "laz")
+        if (outputFormatVpc != "las" && outputFormatVpc != "laz" && outputFormatVpc != "copc")
         {
-            std::cerr << "unknown output format: " << outputFormat << std::endl;
+            std::cerr << "unknown output format: " << outputFormatVpc << std::endl;
             return false;
         }
     }
-    else
-        outputFormat = "las";  // uncompressed by default
 
+    if ( ends_with(outputFile, ".vpc") && outputFormatVpc == "copc" )
+    {
+        isStreaming = false;
+    }
+    
     return true;
 }
 
@@ -98,26 +101,7 @@ bool loadPolygons(const std::string &polygonFile, pdal::Options& crop_opts, BOX2
                 fullEnvelope = envelope;
             else
                 fullEnvelope.Merge(envelope);
-
-            char* wkt_ptr = nullptr;
-            OGR_G_ExportToWkt(hGeometry, &wkt_ptr);
-            const std::string wkt(wkt_ptr);
-            CPLFree(wkt_ptr);
-
-            SpatialReference pdalSrs;
-            if ( OGRSpatialReferenceH srs = OGR_G_GetSpatialReference(hGeometry) )
-            {
-                char *srsWkt_ptr = nullptr;
-                const OGRErr err = OSRExportToWkt(srs, &srsWkt_ptr);
-                if ( err== OGRERR_NONE )
-                {
-                  const std::string srsWkt = std::string(srsWkt_ptr);
-                  pdalSrs = SpatialReference( srsWkt );
-                }
-                CPLFree(srsWkt_ptr);
-            }
-
-            crop_opts.add(pdal::Option("polygon", pdal::Polygon(wkt, pdalSrs)));
+            crop_opts.add(pdal::Option("polygon", pdal::Polygon(hGeometry)));
         }
         OGR_F_Destroy( hFeature );
     }
@@ -206,15 +190,7 @@ void Clip::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipel
             ParallelJobInfo tile(ParallelJobInfo::FileBased, BOX2D(), filterExpression, filterBounds);
             tile.inputFilenames.push_back(f.filename);
 
-            // for input file /x/y/z.las that goes to /tmp/hello.vpc,
-            // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fileStem(f.filename);
-            
-            // if the output is not VPC  las file format is forced to avoid time spent on compression, files will be later merged into single output and removed anyways
-            if (!ends_with(outputFile, ".vpc"))
-                tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
-            else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
+            tile.outputFilename = tileOutputFileName(outputFile, outputFormatVpc, outputSubdir, f.filename);
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/external/pdal_wrench/compare.cpp
+++ b/external/pdal_wrench/compare.cpp
@@ -1,0 +1,184 @@
+/*****************************************************************************
+ *   Copyright (c) 2026, Lutra Consulting Ltd. and Hobu, Inc.                *
+ *                                                                           *
+ *   All rights reserved.                                                    *
+ *                                                                           *
+ *   This program is free software; you can redistribute it and/or modify    *
+ *   it under the terms of the GNU General Public License as published by    *
+ *   the Free Software Foundation; either version 3 of the License, or       *
+ *   (at your option) any later version.                                     *
+ *                                                                           *
+ ****************************************************************************/
+
+#include <filesystem>
+#include <iostream>
+#include <thread>
+
+#include <pdal/PipelineManager.hpp>
+#include <pdal/Polygon.hpp>
+#include <pdal/Stage.hpp>
+#include <pdal/pdal_types.hpp>
+#include <pdal/util/ProgramArgs.hpp>
+
+#include <gdal_utils.h>
+
+#include "alg.hpp"
+#include "utils.hpp"
+#include "vpc.hpp"
+
+using namespace pdal;
+
+void ComparePointClouds::addArgs() 
+{
+  argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
+  argComparedInputFile = &programArgs.add("input-compare", "Point cloud file to compare against input", comparedInputFile);
+  
+  programArgs.add("subsampling-cell-size", "Minimum spacing between points", subsamplingCellSize, 0.0);
+
+  programArgs.add( "normal-radius", "Radius of the sphere around each core point that defines the neighbors from which normals are calculated.", normalRadius, 2.0);
+  programArgs.add("cyl-radius", "Radius of the cylinder inside of which points are searched for when calculating change", cylRadius, 2.0);
+  programArgs.add("cyl-halflen", "The half-length of the cylinder of neighbors used for calculating change", cylHalflen, 5.0);
+  programArgs.add("reg-error", "Registration error", regError, 0.0);
+  argOrientation = &programArgs.add( "cyl-orientation", "Which direction to orient the cylinder/normal vector used for comparison between the two point clouds. (up, origin, none)", cylOrientation, "up");
+}
+
+bool ComparePointClouds::checkArgs() 
+{
+
+  if (ends_with(inputFile, ".vpc")) {
+    std::cerr << "input cannot be a VPC file" << std::endl;
+    return false;
+  }
+
+  if (ends_with(comparedInputFile, ".vpc")) {
+    std::cerr << "compared input cannot be a VPC file" << std::endl;
+    return false;
+  }
+
+  if (!argOutput->set()) {
+    std::cerr << "missing output" << std::endl;
+    return false;
+  }
+
+  if (!argComparedInputFile->set()) {
+    std::cerr << "missing compared input file" << std::endl;
+    return false;
+  }
+
+  if (argOrientation->set()) {
+    if (cylOrientation != "up" && cylOrientation != "origin" &&
+        cylOrientation != "none") {
+      std::cerr << "unknown orientation: " << cylOrientation << std::endl;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile, std::string compareFile, double subsamplingCellSize, double normalRadius, double cylRadius, double cylHalflen, double regError, std::string cylOrientation)
+{
+  std::unique_ptr<PipelineManager> manager(new PipelineManager);
+
+  Stage &reader1 = makeReader(manager.get(), tile->inputFilenames[0]);
+  Stage *last = &reader1;
+
+  // filtering
+  if (!tile->filterBounds.empty())
+  {
+      Options filter_opts;
+      filter_opts.add(pdal::Option("bounds", tile->filterBounds));
+
+      if (readerSupportsBounds(reader1))
+      {
+          // Reader of the format can do the filtering - use that whenever possible!
+          reader1.addOptions(filter_opts);
+      }
+      else
+      {
+          // Reader can't do the filtering - do it with a filter
+          last = &manager->makeFilter("filters.crop", *last, filter_opts);
+      }
+  }
+
+  if (!tile->filterExpression.empty())
+  {
+      Options filter_opts;
+      filter_opts.add(pdal::Option("expression", tile->filterExpression));
+      last = &manager->makeFilter("filters.expression", *last, filter_opts);
+  }     
+  
+  Stage *reader1FilteredCropped = last;
+
+  Stage &reader2 = makeReader(manager.get(), compareFile);
+  last = &reader2;
+
+  // filtering
+  if (!tile->filterBounds.empty())
+  {
+      Options filter_opts;
+      filter_opts.add(pdal::Option("bounds", tile->filterBounds));
+
+      if (readerSupportsBounds(reader2))
+      {
+          // Reader of the format can do the filtering - use that whenever possible!
+          reader2.addOptions(filter_opts);
+      }
+      else
+      {
+          // Reader can't do the filtering - do it with a filter
+          last = &manager->makeFilter("filters.crop", *last, filter_opts);
+      }
+  }
+
+  if (!tile->filterExpression.empty())
+  {
+      Options filter_opts;
+      filter_opts.add(pdal::Option("expression", tile->filterExpression));
+      last = &manager->makeFilter("filters.expression", *last, filter_opts);
+  }
+  Stage *reader2FilteredCropped = last;
+
+  Stage *corePoints = nullptr;
+  if (subsamplingCellSize != 0.0)
+  {
+    pdal::Options sample_opts;
+    sample_opts.add(pdal::Option("cell", subsamplingCellSize));
+    corePoints = &manager->makeFilter("filters.sample", *reader1FilteredCropped, sample_opts);
+  }
+  else
+  {
+    corePoints = reader1FilteredCropped;
+  }
+
+  Options compare_opts;
+  compare_opts.add(pdal::Option("normal_radius", normalRadius));
+  compare_opts.add(pdal::Option("cyl_radius", cylRadius));
+  compare_opts.add(pdal::Option("cyl_halflen", cylHalflen));
+  compare_opts.add(pdal::Option("reg_error", regError));
+  compare_opts.add(pdal::Option("orientation", cylOrientation));
+
+  Stage *filterM3c2 = &manager->makeFilter("filters.m3c2", compare_opts);
+
+  // inputs to M3C2 filter are origin file, compared file and core points (in order)
+  filterM3c2->setInput(*reader1FilteredCropped);
+  filterM3c2->setInput(*reader2FilteredCropped);
+  filterM3c2->setInput(*corePoints);
+  
+  makeWriter(manager.get(), tile->outputFilename, filterM3c2);
+
+  return manager;
+}
+
+void ComparePointClouds::preparePipelines(std::vector<std::unique_ptr<PipelineManager>> &pipelines)
+{
+  ParallelJobInfo tile(ParallelJobInfo::Single, BOX2D(), filterExpression,
+                       filterBounds);
+  tile.inputFilenames.push_back(inputFile);
+  tile.outputFilename = outputFile;
+  pipelines.push_back(pipeline(&tile, comparedInputFile, subsamplingCellSize, normalRadius, cylRadius, cylHalflen, regError, cylOrientation));
+}
+
+void ComparePointClouds::finalize( std::vector<std::unique_ptr<PipelineManager>> &)
+{
+}

--- a/external/pdal_wrench/height_above_ground.cpp
+++ b/external/pdal_wrench/height_above_ground.cpp
@@ -35,7 +35,7 @@ namespace fs = std::filesystem;
 void HeightAboveGround::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormat = &programArgs.add("output-format", "Output format (las/laz/copc)", outputFormat);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc, "copc");
     argAlgorithm = &programArgs.add("algorithm", "Height Above Ground algorithm to use: nn (Nearest Neighbor) or delaunay (Delaunay).", algorithm, "nn");
     argReplaceZWithHeightAboveGround = &programArgs.add("replace-z", "Replace Z dimension with height above ground (true/false).", replaceZWithHeightAboveGround, true);
 
@@ -55,17 +55,20 @@ bool HeightAboveGround::checkArgs()
         return false;
     }
 
-    if (argOutputFormat->set())
+    if (argOutputFormatVpc->set())
     {
-        if (outputFormat != "las" && outputFormat != "laz" && outputFormat != "copc")
+        if (outputFormatVpc != "las" && outputFormatVpc != "laz" && outputFormatVpc != "copc")
         {
-            std::cerr << "unknown output format: " << outputFormat << std::endl;
+            std::cerr << "unknown output format: " << outputFormatVpc << std::endl;
             return false;
         }
     }
-    else
-        outputFormat = "las";  // uncompressed by default
 
+    if ( ends_with(outputFile, ".vpc") && outputFormatVpc == "copc" )
+    {
+        isStreaming = false;
+    }
+    
     if (!argAlgorithm->set())
     {
         std::cerr << "missing algorithm" << std::endl;
@@ -193,14 +196,7 @@ void HeightAboveGround::preparePipelines(std::vector<std::unique_ptr<PipelineMan
             ParallelJobInfo tile(ParallelJobInfo::FileBased, BOX2D(), filterExpression, filterBounds);
             tile.inputFilenames.push_back(f.filename);
 
-            // for input file /x/y/z.las that goes to /tmp/hello.vpc,
-            // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fileStem(f.filename);
-
-            if (!ends_with(outputFile, ".vpc"))
-                tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
-            else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
+            tile.outputFilename = tileOutputFileName(outputFile, outputFormatVpc, outputSubdir, f.filename);
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/external/pdal_wrench/main.cpp
+++ b/external/pdal_wrench/main.cpp
@@ -21,6 +21,7 @@ TODO:
 
 #include <pdal/util/FileUtils.hpp>
 #include <pdal/pdal_config.hpp>
+#include <pdal/pdal_features.hpp>
 
 #include "gdal_version.h"
 
@@ -29,7 +30,7 @@ TODO:
 
 extern int runTile(std::vector<std::string> arglist);  // tile/tile.cpp
 
-std::string WRENCH_VERSION = "1.3.0";
+std::string WRENCH_VERSION = "1.4.0";
 
 void printUsage()
 {
@@ -42,6 +43,10 @@ void printUsage()
     std::cout << "   build_vpc              Creates a virtual point cloud" << std::endl;
     std::cout << "   classify_ground        Classify ground points" << std::endl;
     std::cout << "   clip                   Outputs only points that are inside of the clipping polygons" << std::endl;
+// TODO this check can be removed once PDAL 2.10 is widely used    
+#if PDAL_VERSION_MAJOR > 2 || ( PDAL_VERSION_MAJOR == 2 && PDAL_VERSION_MINOR >= 10 )
+    std::cout << "   compare                Compares two point clouds for differences" << std::endl;
+#endif    
     std::cout << "   density                Exports a raster where each cell contains number of points" << std::endl;
     std::cout << "   filter_noise           Classify noise points" << std::endl;
     std::cout << "   height_above_ground    Calculates height above ground for each point" << std::endl;
@@ -154,6 +159,14 @@ int main(int argc, char* argv[])
         ClassifyGround classifyGround;
         runAlg(args, classifyGround);
     }
+// TODO this check can be removed once PDAL 2.10 is is widely used    
+#if PDAL_VERSION_MAJOR > 2 || ( PDAL_VERSION_MAJOR == 2 && PDAL_VERSION_MINOR >= 10 )
+    else if (cmd == "compare")
+    {
+        ComparePointClouds comparison;
+        runAlg(args, comparison);
+    }
+#endif    
     else
     {
         std::cerr << "unknown command: " << cmd << std::endl;

--- a/external/pdal_wrench/thin.cpp
+++ b/external/pdal_wrench/thin.cpp
@@ -37,7 +37,7 @@ namespace fs = std::filesystem;
 void Thin::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormat = &programArgs.add("output-format", "Output format (las/laz/copc)", outputFormat);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc, "copc");
     argMode = &programArgs.add("mode", " 'every-nth' or 'sample' - either to keep every N-th point or to keep points based on their distance", mode);
     argStepEveryN = &programArgs.add("step-every-nth", "Keep every N-th point", stepEveryN);
     argStepSample = &programArgs.add("step-sample", "Minimum spacing between points", stepSample);
@@ -78,17 +78,20 @@ bool Thin::checkArgs()
         return false;
     }
 
-    if (argOutputFormat->set())
+    if (argOutputFormatVpc->set())
     {
-        if (outputFormat != "las" && outputFormat != "laz")
+        if (outputFormatVpc != "las" && outputFormatVpc != "laz" && outputFormatVpc != "copc")
         {
-            std::cerr << "unknown output format: " << outputFormat << std::endl;
+            std::cerr << "unknown output format: " << outputFormatVpc << std::endl;
             return false;
         }
     }
-    else
-        outputFormat = "las";  // uncompressed by default
 
+    if ( ends_with(outputFile, ".vpc") && outputFormatVpc == "copc" )
+    {
+        isStreaming = false;
+    }
+    
     return true;
 }
 
@@ -163,14 +166,7 @@ void Thin::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipel
             ParallelJobInfo tile(ParallelJobInfo::FileBased, BOX2D(), filterExpression, filterBounds);
             tile.inputFilenames.push_back(f.filename);
 
-            // for input file /x/y/z.las that goes to /tmp/hello.vpc,
-            // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fileStem(f.filename);
-
-            if (!ends_with(outputFile, ".vpc"))
-                tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
-            else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
+            tile.outputFilename = tileOutputFileName(outputFile, outputFormatVpc, outputSubdir, f.filename);
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/external/pdal_wrench/tile/tile.cpp
+++ b/external/pdal_wrench/tile/tile.cpp
@@ -442,7 +442,7 @@ void addArgs(pdal::ProgramArgs& programArgs, BaseInfo::Options& options, pdal::A
     programArgs.add("input-file-list", "Read input files from a text file", options.inputFileList);
     programArgs.add("length,l", "Tile length", options.tileLength, 1000.);
     tempArg = &(programArgs.add("temp_dir", "Temp directory", options.tempDir));
-    programArgs.add("output-format", "Output format (las/laz)", options.outputFormat);
+    programArgs.add("vpc-output-format", "Output format (las/laz/copc)", options.outputFormat);
 
     // for debugging
     programArgs.add("preserve_temp_dir", "Do not remove the temp directory before and after processing (for debugging)",

--- a/external/pdal_wrench/utils.cpp
+++ b/external/pdal_wrench/utils.cpp
@@ -356,3 +356,31 @@ void buildOutput(std::string outputFile, std::vector<std::string> &tileOutputFil
         removeFiles(tileOutputFiles, true);
     }
 }
+
+std::string tileOutputFileName(const std::string &outputFile, const std::string &outputFormat, const fs::path &outputSubdir, const std::string &tileFilename)
+{
+    assert(outputFormat == "las" || outputFormat == "laz" || outputFormat == "copc");
+
+    const fs::path inputBasename = fileStem(tileFilename);
+
+    // construct full output file name for the tile without extension
+    const std::string fullFileNameWithoutExt = (outputSubdir / inputBasename).string();
+
+    // output is not a VPC, it will be merged later into a single file,
+    // use las to avoid zipping the file, it will be removed after merging
+    if (!ends_with(outputFile, ".vpc"))
+    {
+        return fullFileNameWithoutExt + ".las";
+    }
+
+    // output is VPC, use specified output format
+    std::string ext = outputFormat;
+
+    // change extension for copc, user inputed copc as format, but copc.laz is needed as extension
+    if (outputFormat == "copc")
+    {
+        ext = "copc.laz";
+    }
+
+    return fullFileNameWithoutExt + "." + ext;
+}

--- a/external/pdal_wrench/utils.hpp
+++ b/external/pdal_wrench/utils.hpp
@@ -14,7 +14,9 @@
 
 #include <pdal/PipelineManager.hpp>
 #include <mutex>
+#include <filesystem>
 
+namespace fs = std::filesystem;
 using namespace pdal;
 
 // tiling scheme containing tileCountX x tileCountY square tiles of tileSize x tileSize,
@@ -275,3 +277,7 @@ pdal::Stage &makeWriter(pdal::PipelineManager *manager, const std::string &outpu
  */
 void buildOutput(std::string outputFile, std::vector<std::string> &tileOutputFiles);
 
+/**
+ * Generate tile output file name based on outputFile and outputFormat.
+ */
+std::string tileOutputFileName(const std::string &outputFile, const std::string &outputFormat, const fs::path &outputSubdir, const std::string &tileFilename);

--- a/src/providers/pdal/CMakeLists.txt
+++ b/src/providers/pdal/CMakeLists.txt
@@ -170,6 +170,7 @@ set(PDAL_WRENCH_SRCS
   ${CMAKE_SOURCE_DIR}/external/pdal_wrench/classify_ground.cpp
   ${CMAKE_SOURCE_DIR}/external/pdal_wrench/filter_noise.cpp
   ${CMAKE_SOURCE_DIR}/external/pdal_wrench/height_above_ground.cpp
+  ${CMAKE_SOURCE_DIR}/external/pdal_wrench/compare.cpp
 
   ${CMAKE_SOURCE_DIR}/external/pdal_wrench/tile/tile.cpp
   ${CMAKE_SOURCE_DIR}/external/pdal_wrench/tile/BufferCache.cpp


### PR DESCRIPTION
## Description

Update pdal_wrench to the latest version. Improves handling of VPC files in operations, allows to specify type of stored data, if operation output is VPC. Adds new algorithm to compare point clouds (only available if compiled agains PDAL version >= 2.10).

Release notes [https://github.com/PDAL/wrench/releases/tag/v1.4.0](https://github.com/PDAL/wrench/releases/tag/v1.4.0)
