### PR TITLE
qgsbillboardgeometry: Add missing Qt::StringLiterals namespace

### DIFF
--- a/src/3d/symbols/qgsbillboardgeometry.cpp
+++ b/src/3d/symbols/qgsbillboardgeometry.cpp
@@ -21,6 +21,8 @@
 
 #include "moc_qgsbillboardgeometry.cpp"
 
+using namespace Qt::StringLiterals;
+
 QgsBillboardGeometry::QgsBillboardGeometry( Qt3DCore::QNode *parent )
   : QGeometry( parent )
   , mVertexBuffer( new Qt3DCore::QBuffer( this ) )


### PR DESCRIPTION
## Description

qgsbillboardgeometry: Add missing Qt::StringLiterals namespace

This seems to fix an issue on windows vcpkg ci. See for example: https://github.com/qgis/QGIS/actions/runs/21077011437/job/60621340218?pr=64569
