### PR TITLE
Themes can specify color groups and fix theme loading order

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1254,6 +1254,9 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
   addDockWidget( Qt::LeftDockWidgetArea, mVertexEditorDock );
   mVertexEditorDock->hide();
 
+  // ordering here is important - icons created before this call will not be overridden by themes
+  functionProfile( &QgisApp::readSettings, this, u"Read settings"_s );
+
   mMapTools = std::make_unique<QgsAppMapTools>( mMapCanvas, mAdvancedDigitizingDockWidget );
   mDigitizingTechniqueManager = new QgsMapToolsDigitizingTechniqueManager( this );
 
@@ -1713,8 +1716,6 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
     delete mActionShowPythonDialog;
     mActionShowPythonDialog = nullptr;
   }
-
-  functionProfile( &QgisApp::readSettings, this, u"Read theme settings"_s );
 
   // Update recent project list (as possible custom project storages are now registered by plugins)
   mSplash->showMessage( tr( "Updating recent project paths" ), Qt::AlignHCenter | Qt::AlignBottom, splashTextColor );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1146,13 +1146,20 @@ void QgsApplication::setUITheme( const QString &themeName )
     QTextStream in( &palettefile );
     while ( !in.atEnd() )
     {
-      QString line = in.readLine();
-      QStringList parts = line.split( ':' );
+      const QString line = in.readLine();
+      const QStringList parts = line.split( ' ' )[0].split( ':' );
       if ( parts.count() == 2 )
       {
-        int role = parts.at( 0 ).trimmed().toInt();
-        QColor color = QgsSymbolLayerUtils::decodeColor( parts.at( 1 ).trimmed() );
+        const int role = parts.at( 0 ).trimmed().toInt();
+        const QColor color = QgsSymbolLayerUtils::decodeColor( parts.at( 1 ).trimmed() );
         pal.setColor( static_cast< QPalette::ColorRole >( role ), color );
+      }
+      else if ( parts.count() == 3 )
+      {
+        const int role = parts.at( 0 ).trimmed().toInt();
+        const int group = parts.at( 1 ).trimmed().toInt();
+        const QColor color = QgsSymbolLayerUtils::decodeColor( parts.at( 2 ).trimmed() );
+        pal.setColor( static_cast< QPalette::ColorGroup >( group ), static_cast< QPalette::ColorRole >( role ), color );
       }
     }
     palettefile.close();


### PR DESCRIPTION
Two theme related changes:

* `palette.txt` can specify [color groups](https://doc.qt.io/qt-6/qpalette.html#ColorGroup-enum)
* Theme settings are read slightly earlier during initialization (ensures that icons overridden by themes are properly loaded)

This was originally part of #64495, but I've opened this separate PR for the C++ changes to separate the functionality from the theme discussion.