### PR TITLE
[annotations] Implement click-click item dragging for the annotation selection tool

### DIFF
--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -130,21 +130,33 @@ void QgsMapToolSelectAnnotation::cadCanvasMoveEvent( QgsMapMouseEvent *event )
 
   if ( event->buttons() == Qt::NoButton )
   {
-    if ( mMouseHandles->sceneBoundingRect().contains( scenePos ) )
+    if ( mMouseHandles->isDragging() )
     {
-      QGraphicsSceneHoverEvent forwardedEvent( QEvent::GraphicsSceneHoverMove );
+      QGraphicsSceneMouseEvent forwardedEvent( QEvent::GraphicsSceneMouseMove );
       forwardedEvent.setPos( mMouseHandles->mapFromScene( scenePos ) );
       forwardedEvent.setScenePos( scenePos );
-      mMouseHandles->hoverMoveEvent( &forwardedEvent );
-      mHoveringMouseHandles = true;
+      forwardedEvent.setLastScenePos( mLastScenePos );
+      forwardedEvent.setButton( Qt::LeftButton );
+      mMouseHandles->mouseMoveEvent( &forwardedEvent );
     }
-    else if ( mHoveringMouseHandles )
+    else
     {
-      QGraphicsSceneHoverEvent forwardedEvent( QEvent::GraphicsSceneHoverLeave );
-      forwardedEvent.setPos( mMouseHandles->mapFromScene( scenePos ) );
-      forwardedEvent.setScenePos( scenePos );
-      mMouseHandles->hoverMoveEvent( &forwardedEvent );
-      mHoveringMouseHandles = false;
+      if ( mMouseHandles->sceneBoundingRect().contains( scenePos ) )
+      {
+        QGraphicsSceneHoverEvent forwardedEvent( QEvent::GraphicsSceneHoverMove );
+        forwardedEvent.setPos( mMouseHandles->mapFromScene( scenePos ) );
+        forwardedEvent.setScenePos( scenePos );
+        mMouseHandles->hoverMoveEvent( &forwardedEvent );
+        mHoveringMouseHandles = true;
+      }
+      else if ( mHoveringMouseHandles )
+      {
+        QGraphicsSceneHoverEvent forwardedEvent( QEvent::GraphicsSceneHoverLeave );
+        forwardedEvent.setPos( mMouseHandles->mapFromScene( scenePos ) );
+        forwardedEvent.setScenePos( scenePos );
+        mMouseHandles->hoverMoveEvent( &forwardedEvent );
+        mHoveringMouseHandles = false;
+      }
     }
   }
   else if ( event->buttons() == Qt::LeftButton )

--- a/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
@@ -48,7 +48,7 @@ QgsMapToolSelectAnnotationMouseHandles::QgsMapToolSelectAnnotationMouseHandles( 
   mCanvas->scene()->addItem( this );
 
   setRotationEnabled( true );
-  setClickClickEnabled( true );
+  setCadMouseDigitizingModeEnabled( true );
 }
 
 void QgsMapToolSelectAnnotationMouseHandles::paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget )

--- a/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotationmousehandles.cpp
@@ -48,6 +48,7 @@ QgsMapToolSelectAnnotationMouseHandles::QgsMapToolSelectAnnotationMouseHandles( 
   mCanvas->scene()->addItem( this );
 
   setRotationEnabled( true );
+  setClickClickEnabled( true );
 }
 
 void QgsMapToolSelectAnnotationMouseHandles::paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget )

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -63,6 +63,16 @@ void QgsGraphicsViewMouseHandles::setRotationEnabled( bool enable )
   update();
 }
 
+void QgsGraphicsViewMouseHandles::setClickClickEnabled( bool enable )
+{
+  if ( mClickClickEnabled == enable )
+  {
+    return;
+  }
+
+  mClickClickEnabled = enable;
+}
+
 void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHandles, bool showStaticBoundingBoxes, bool showTemporaryBoundingBoxes, const QStyleOptionGraphicsItem *, QWidget * )
 {
   if ( !showHandles )
@@ -622,6 +632,11 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
     return;
   }
 
+  if ( mIsDragging || mIsResizing || mIsRotating )
+  {
+    return;
+  }
+
   //save current cursor position
   mMouseMoveStartPos = event->lastScenePos();
   //save current item geometry
@@ -670,6 +685,11 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
     case Qgis::MouseHandlesAction::SelectItem:
     case Qgis::MouseHandlesAction::NoAction:
       break;
+  }
+
+  if ( mIsDragging )
+  {
+    mIsDragStarting = true;
   }
 }
 
@@ -728,6 +748,12 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
     return;
   }
 
+  if ( mIsDragStarting )
+  {
+    mIsDragStarting = false;
+    return;
+  }
+
   // Mouse may have been grabbed from the QgsLayoutViewSelectTool, so we need to release it explicitly
   // otherwise, hover events will not be received
   if ( mView->scene()->mouseGrabberItem() == this )
@@ -739,8 +765,8 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
   double diffX = mouseMoveStopPoint.x() - mMouseMoveStartPos.x();
   double diffY = mouseMoveStopPoint.y() - mMouseMoveStartPos.y();
 
-  //it was only a click
-  if ( std::fabs( diffX ) < std::numeric_limits<double>::min() && std::fabs( diffY ) < std::numeric_limits<double>::min() )
+  const bool isClick = std::fabs( diffX ) < std::numeric_limits<double>::min() && std::fabs( diffY ) < std::numeric_limits<double>::min();
+  if ( isClick )
   {
     mIsDragging = false;
     mIsResizing = false;
@@ -858,6 +884,7 @@ void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *e
   mCurrentMouseMoveAction = Qgis::MouseHandlesAction::MoveItem;
   //redraw handles
   resetTransform();
+  update();
   updateHandles();
   //reset status bar message
   resetStatusBar();

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -632,7 +632,7 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
     return;
   }
 
-  if ( mIsDragging || mIsResizing || mIsRotating )
+  if ( mClickClickEnabled && ( mIsDragging || mIsResizing || mIsRotating ) )
   {
     return;
   }
@@ -687,7 +687,7 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
       break;
   }
 
-  if ( mIsDragging )
+  if ( mClickClickEnabled && mIsDragging )
   {
     mIsDragStarting = true;
   }

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -63,14 +63,14 @@ void QgsGraphicsViewMouseHandles::setRotationEnabled( bool enable )
   update();
 }
 
-void QgsGraphicsViewMouseHandles::setClickClickEnabled( bool enable )
+void QgsGraphicsViewMouseHandles::setCadMouseDigitizingModeEnabled( bool enable )
 {
-  if ( mClickClickEnabled == enable )
+  if ( mCadMouseDigitizingMode == enable )
   {
     return;
   }
 
-  mClickClickEnabled = enable;
+  mCadMouseDigitizingMode = enable;
 }
 
 void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHandles, bool showStaticBoundingBoxes, bool showTemporaryBoundingBoxes, const QStyleOptionGraphicsItem *, QWidget * )
@@ -632,7 +632,7 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
     return;
   }
 
-  if ( mClickClickEnabled && ( mIsDragging || mIsResizing || mIsRotating ) )
+  if ( mCadMouseDigitizingMode && ( mIsDragging || mIsResizing || mIsRotating ) )
   {
     return;
   }
@@ -687,7 +687,7 @@ void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *eve
       break;
   }
 
-  if ( mClickClickEnabled && mIsDragging )
+  if ( mCadMouseDigitizingMode && mIsDragging )
   {
     mIsDragStarting = true;
   }

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -110,13 +110,13 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     void setRotationEnabled( bool enable );
 
     /**
-     * Sets whether moving of items happens when dragging while holding the
-     * mouse's left button is held down or by mouse clicking once, dragging,
-     * then mouse clicking again.
+     * Sets to TRUE for item dragging behavior to require a mouse click,
+     * mouse movement, then a second mouse click to confirm the dragging
+     * operation.
      *
      * \since QGIS 4.0
      */
-    void setClickClickEnabled( bool enable );
+    void setCadMouseDigitizingModeEnabled( bool enable );
 
   public slots:
 
@@ -247,7 +247,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
 
     QRectF mResizeRect;
 
-    bool mClickClickEnabled = false;
+    bool mCadMouseDigitizingMode = false;
 
     bool mRotationEnabled = false;
     //! Center point around which rotation occurs

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -109,6 +109,15 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
      */
     void setRotationEnabled( bool enable );
 
+    /**
+     * Sets whether moving of items happens when dragging while holding the
+     * mouse's left button is held down or by mouse clicking once, dragging,
+     * then mouse clicking again.
+     *
+     * \since QGIS 4.0
+     */
+    void setClickClickEnabled( bool enable );
+
   public slots:
 
     //! Redraws handles when selected item size changes
@@ -238,6 +247,8 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
 
     QRectF mResizeRect;
 
+    bool mClickClickEnabled = false;
+
     bool mRotationEnabled = false;
     //! Center point around which rotation occurs
     QPointF mRotationCenter;
@@ -254,8 +265,11 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles : public QObject, public QGraphicsR
     Qgis::MouseHandlesAction mCurrentMouseMoveAction = Qgis::MouseHandlesAction::NoAction;
     bool mDoubleClickInProgress = false;
 
+
     //! True if user is currently dragging items
     bool mIsDragging = false;
+    //! True if user is starting to drag items in click-click behavior
+    bool mIsDragStarting = false;
     //! True is user is currently resizing items
     bool mIsResizing = false;
     //! True is user is currently rotating items

--- a/tests/src/app/testqgsmaptoolselectannotation.cpp
+++ b/tests/src/app/testqgsmaptoolselectannotation.cpp
@@ -282,12 +282,12 @@ void TestQgsMapToolSelectAnnotation::testMoveItem()
   QCOMPARE( spy.at( 0 ).at( 1 ).toString(), i1id );
 
   // a mouse press on the item will start moving the item
-  utils.mousePress( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
 
   // move mouse and click to end item move
   utils.mouseMove( 4.5, 4.5, Qt::LeftButton );
   utils.mouseMove( 4.5, 4.5, Qt::LeftButton );
-  utils.mouseRelease( 4.5, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 4.5, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
   while ( !canvas.isDrawing() )
   {
     QgsApplication::processEvents();
@@ -300,10 +300,10 @@ void TestQgsMapToolSelectAnnotation::testMoveItem()
 
   // start a new move
   utils.mouseMove( 4.6, 4.5 );
-  utils.mousePress( 4.6, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 4.6, 4.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
   utils.mouseMove( 1.5, 1.5, Qt::LeftButton );
   utils.mouseMove( 1.5, 1.5, Qt::LeftButton );
-  utils.mouseRelease( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 1.5, 1.5, Qt::LeftButton, Qt::KeyboardModifiers(), true );
   while ( !canvas.isDrawing() )
   {
     QgsApplication::processEvents();


### PR DESCRIPTION
## Description

As promised, here's the tweak that add click-click behavior to the annotation selection tool.

@nyalldawson , I'm in _dire_ need of a better function name than setClickClickEnabled :)