### PR TITLE
[annotations] Add a new annotation item rotation operation and make use of it

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsannotationitemeditoperation.py
+++ b/python/PyQt6/core/auto_additions/qgsannotationitemeditoperation.py
@@ -4,12 +4,17 @@ QgsAbstractAnnotationItemEditOperation.Type.MoveNode.__doc__ = "Move a node"
 QgsAbstractAnnotationItemEditOperation.Type.DeleteNode.__doc__ = "Delete a node"
 QgsAbstractAnnotationItemEditOperation.Type.AddNode.__doc__ = "Add a node"
 QgsAbstractAnnotationItemEditOperation.Type.TranslateItem.__doc__ = "Translate (move) an item"
+QgsAbstractAnnotationItemEditOperation.Type.RotateItem.__doc__ = "Rotate an item \n.. versionadded:: 4.0"
 QgsAbstractAnnotationItemEditOperation.Type.__doc__ = """Operation type
 
 * ``MoveNode``: Move a node
 * ``DeleteNode``: Delete a node
 * ``AddNode``: Add a node
 * ``TranslateItem``: Translate (move) an item
+* ``RotateItem``: Rotate an item
+
+  .. versionadded:: 4.0
+
 
 """
 # --
@@ -36,6 +41,11 @@ except (NameError, AttributeError):
 try:
     QgsAnnotationItemEditOperationTranslateItem.__overridden_methods__ = ['type']
     QgsAnnotationItemEditOperationTranslateItem.__group__ = ['annotations']
+except (NameError, AttributeError):
+    pass
+try:
+    QgsAnnotationItemEditOperationRotateItem.__overridden_methods__ = ['type']
+    QgsAnnotationItemEditOperationRotateItem.__group__ = ['annotations']
 except (NameError, AttributeError):
     pass
 try:

--- a/python/PyQt6/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
+++ b/python/PyQt6/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
@@ -75,6 +75,7 @@ Abstract base class for annotation item edit operations.
       DeleteNode,
       AddNode,
       TranslateItem,
+      RotateItem,
     };
 
     QgsAbstractAnnotationItemEditOperation( const QString &itemId );
@@ -305,6 +306,37 @@ Returns the y-axis translation, in pixels.
 %End
 
 };
+
+
+class QgsAnnotationItemEditOperationRotateItem : QgsAbstractAnnotationItemEditOperation
+{
+%Docstring(signature="appended")
+Annotation item edit operation consisting of rotating an item.
+
+.. versionadded:: 4.0
+%End
+
+%TypeHeaderCode
+#include "qgsannotationitemeditoperation.h"
+%End
+  public:
+
+    QgsAnnotationItemEditOperationRotateItem( const QString &itemId, double angle );
+%Docstring
+Constructor for QgsAnnotationItemEditOperationRotateItem, where the node
+with the specified ``id`` and rotation ``angle`` (in degrees)
+%End
+
+    virtual Type type() const;
+
+
+    double angle() const;
+%Docstring
+Returns the rotation angle value (in degrees).
+%End
+
+};
+
 
 class QgsAnnotationItemEditOperationTransientResults
 {

--- a/python/PyQt6/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
+++ b/python/PyQt6/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
@@ -323,8 +323,8 @@ Annotation item edit operation consisting of rotating an item.
 
     QgsAnnotationItemEditOperationRotateItem( const QString &itemId, double angle );
 %Docstring
-Constructor for QgsAnnotationItemEditOperationRotateItem, where the node
-with the specified ``id`` and rotation ``angle`` (in degrees)
+Constructor for QgsAnnotationItemEditOperationRotateItem, where the item
+with the specified ``itemId`` and rotation ``angle`` (in degrees)
 %End
 
     virtual Type type() const;

--- a/python/PyQt6/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
+++ b/python/PyQt6/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
@@ -332,7 +332,7 @@ with the specified ``itemId`` and rotation ``angle`` (in degrees)
 
     double angle() const;
 %Docstring
-Returns the rotation angle value (in degrees).
+Returns the rotation angle value (in degrees clockwise).
 %End
 
 };

--- a/python/core/auto_additions/qgsannotationitemeditoperation.py
+++ b/python/core/auto_additions/qgsannotationitemeditoperation.py
@@ -4,12 +4,17 @@ QgsAbstractAnnotationItemEditOperation.Type.MoveNode.__doc__ = "Move a node"
 QgsAbstractAnnotationItemEditOperation.Type.DeleteNode.__doc__ = "Delete a node"
 QgsAbstractAnnotationItemEditOperation.Type.AddNode.__doc__ = "Add a node"
 QgsAbstractAnnotationItemEditOperation.Type.TranslateItem.__doc__ = "Translate (move) an item"
+QgsAbstractAnnotationItemEditOperation.Type.RotateItem.__doc__ = "Rotate an item \n.. versionadded:: 4.0"
 QgsAbstractAnnotationItemEditOperation.Type.__doc__ = """Operation type
 
 * ``MoveNode``: Move a node
 * ``DeleteNode``: Delete a node
 * ``AddNode``: Add a node
 * ``TranslateItem``: Translate (move) an item
+* ``RotateItem``: Rotate an item
+
+  .. versionadded:: 4.0
+
 
 """
 # --
@@ -36,6 +41,11 @@ except (NameError, AttributeError):
 try:
     QgsAnnotationItemEditOperationTranslateItem.__overridden_methods__ = ['type']
     QgsAnnotationItemEditOperationTranslateItem.__group__ = ['annotations']
+except (NameError, AttributeError):
+    pass
+try:
+    QgsAnnotationItemEditOperationRotateItem.__overridden_methods__ = ['type']
+    QgsAnnotationItemEditOperationRotateItem.__group__ = ['annotations']
 except (NameError, AttributeError):
     pass
 try:

--- a/python/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
@@ -75,6 +75,7 @@ Abstract base class for annotation item edit operations.
       DeleteNode,
       AddNode,
       TranslateItem,
+      RotateItem,
     };
 
     QgsAbstractAnnotationItemEditOperation( const QString &itemId );
@@ -305,6 +306,37 @@ Returns the y-axis translation, in pixels.
 %End
 
 };
+
+
+class QgsAnnotationItemEditOperationRotateItem : QgsAbstractAnnotationItemEditOperation
+{
+%Docstring(signature="appended")
+Annotation item edit operation consisting of rotating an item.
+
+.. versionadded:: 4.0
+%End
+
+%TypeHeaderCode
+#include "qgsannotationitemeditoperation.h"
+%End
+  public:
+
+    QgsAnnotationItemEditOperationRotateItem( const QString &itemId, double angle );
+%Docstring
+Constructor for QgsAnnotationItemEditOperationRotateItem, where the node
+with the specified ``id`` and rotation ``angle`` (in degrees)
+%End
+
+    virtual Type type() const;
+
+
+    double angle() const;
+%Docstring
+Returns the rotation angle value (in degrees).
+%End
+
+};
+
 
 class QgsAnnotationItemEditOperationTransientResults
 {

--- a/python/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
@@ -323,8 +323,8 @@ Annotation item edit operation consisting of rotating an item.
 
     QgsAnnotationItemEditOperationRotateItem( const QString &itemId, double angle );
 %Docstring
-Constructor for QgsAnnotationItemEditOperationRotateItem, where the node
-with the specified ``id`` and rotation ``angle`` (in degrees)
+Constructor for QgsAnnotationItemEditOperationRotateItem, where the item
+with the specified ``itemId`` and rotation ``angle`` (in degrees)
 %End
 
     virtual Type type() const;

--- a/python/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationitemeditoperation.sip.in
@@ -332,7 +332,7 @@ with the specified ``itemId`` and rotation ``angle`` (in degrees)
 
     double angle() const;
 %Docstring
-Returns the rotation angle value (in degrees).
+Returns the rotation angle value (in degrees clockwise).
 %End
 
 };

--- a/src/core/annotations/qgsannotationitemeditoperation.cpp
+++ b/src/core/annotations/qgsannotationitemeditoperation.cpp
@@ -112,6 +112,22 @@ QgsAbstractAnnotationItemEditOperation::Type QgsAnnotationItemEditOperationTrans
 
 
 //
+// QgsAnnotationItemEditOperationRotateItem
+//
+
+QgsAnnotationItemEditOperationRotateItem::QgsAnnotationItemEditOperationRotateItem( const QString &itemId, double angle )
+  : QgsAbstractAnnotationItemEditOperation( itemId )
+  , mAngle( angle )
+{
+}
+
+QgsAbstractAnnotationItemEditOperation::Type QgsAnnotationItemEditOperationRotateItem::type() const
+{
+  return Type::RotateItem;
+}
+
+
+//
 // QgsAnnotationItemEditOperationAddNode
 //
 

--- a/src/core/annotations/qgsannotationitemeditoperation.h
+++ b/src/core/annotations/qgsannotationitemeditoperation.h
@@ -327,7 +327,7 @@ class CORE_EXPORT QgsAnnotationItemEditOperationRotateItem : public QgsAbstractA
     Type type() const override;
 
     /**
-     * Returns the rotation angle value (in degrees).
+     * Returns the rotation angle value (in degrees clockwise).
      */
     double angle() const { return mAngle; }
 

--- a/src/core/annotations/qgsannotationitemeditoperation.h
+++ b/src/core/annotations/qgsannotationitemeditoperation.h
@@ -89,6 +89,7 @@ class CORE_EXPORT QgsAbstractAnnotationItemEditOperation
       DeleteNode, //!< Delete a node
       AddNode, //!< Add a node
       TranslateItem, //!< Translate (move) an item
+      RotateItem, //!< Rotate an item \since QGIS 4.0
     };
 
     /**
@@ -306,6 +307,36 @@ class CORE_EXPORT QgsAnnotationItemEditOperationTranslateItem : public QgsAbstra
     double mTranslatePixelsY = 0;
 
 };
+
+
+/**
+ * \ingroup core
+ * \brief Annotation item edit operation consisting of rotating an item.
+ * \since QGIS 4.0
+ */
+class CORE_EXPORT QgsAnnotationItemEditOperationRotateItem : public QgsAbstractAnnotationItemEditOperation
+{
+  public:
+
+    /**
+     * Constructor for QgsAnnotationItemEditOperationRotateItem, where the node with the specified \a id and rotation
+     * \a angle (in degrees)
+     */
+    QgsAnnotationItemEditOperationRotateItem( const QString &itemId, double angle );
+
+    Type type() const override;
+
+    /**
+     * Returns the rotation angle value (in degrees).
+     */
+    double angle() const { return mAngle; }
+
+  private:
+
+    double mAngle = 0;
+
+};
+
 
 /**
  * \ingroup core

--- a/src/core/annotations/qgsannotationitemeditoperation.h
+++ b/src/core/annotations/qgsannotationitemeditoperation.h
@@ -319,7 +319,7 @@ class CORE_EXPORT QgsAnnotationItemEditOperationRotateItem : public QgsAbstractA
   public:
 
     /**
-     * Constructor for QgsAnnotationItemEditOperationRotateItem, where the node with the specified \a id and rotation
+     * Constructor for QgsAnnotationItemEditOperationRotateItem, where the item with the specified \a itemId and rotation
      * \a angle (in degrees)
      */
     QgsAnnotationItemEditOperationRotateItem( const QString &itemId, double angle );

--- a/src/core/annotations/qgsannotationlineitem.cpp
+++ b/src/core/annotations/qgsannotationlineitem.cpp
@@ -134,6 +134,17 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationLineItem::applyEditV2( QgsA
       mCurve->transform( transform );
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
+
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
+    {
+      QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
+      QgsPoint center = mCurve->centroid();
+      QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
+      transform.rotate( -rotateOperation->angle() );
+      transform.translate( -center.x(), -center.y() );
+      mCurve->transform( transform );
+      return Qgis::AnnotationItemEditOperationResult::Success;
+    }
   }
 
   return Qgis::AnnotationItemEditOperationResult::Invalid;
@@ -159,6 +170,18 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationLineItem::transient
       QgsAnnotationItemEditOperationTranslateItem *moveOperation = qgis::down_cast< QgsAnnotationItemEditOperationTranslateItem * >( operation );
       const QTransform transform = QTransform::fromTranslate( moveOperation->translationX(), moveOperation->translationY() );
       std::unique_ptr< QgsCurve > modifiedCurve( mCurve->clone() );
+      modifiedCurve->transform( transform );
+      return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( std::move( modifiedCurve ) ) );
+    }
+
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
+    {
+      QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
+      std::unique_ptr< QgsCurve > modifiedCurve( mCurve->clone() );
+      QgsPoint center = modifiedCurve->centroid();
+      QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
+      transform.rotate( -rotateOperation->angle() );
+      transform.translate( -center.x(), -center.y() );
       modifiedCurve->transform( transform );
       return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( std::move( modifiedCurve ) ) );
     }

--- a/src/core/annotations/qgsannotationlineitem.cpp
+++ b/src/core/annotations/qgsannotationlineitem.cpp
@@ -138,7 +138,7 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationLineItem::applyEditV2( QgsA
     case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
     {
       QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
-      QgsPoint center = mCurve->centroid();
+      QgsPointXY center = mCurve->boundingBox().center();
       QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
       transform.rotate( -rotateOperation->angle() );
       transform.translate( -center.x(), -center.y() );
@@ -178,7 +178,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationLineItem::transient
     {
       QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
       std::unique_ptr< QgsCurve > modifiedCurve( mCurve->clone() );
-      QgsPoint center = modifiedCurve->centroid();
+      QgsPointXY center = modifiedCurve->boundingBox().center();
       QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
       transform.rotate( -rotateOperation->angle() );
       transform.translate( -center.x(), -center.y() );

--- a/src/core/annotations/qgsannotationlinetextitem.cpp
+++ b/src/core/annotations/qgsannotationlinetextitem.cpp
@@ -157,6 +157,17 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationLineTextItem::applyEditV2( 
       mCurve->transform( transform );
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
+
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
+    {
+      QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
+      QgsPoint center = mCurve->centroid();
+      QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
+      transform.rotate( -rotateOperation->angle() );
+      transform.translate( -center.x(), -center.y() );
+      mCurve->transform( transform );
+      return Qgis::AnnotationItemEditOperationResult::Success;
+    }
   }
 
   return Qgis::AnnotationItemEditOperationResult::Invalid;
@@ -182,6 +193,18 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationLineTextItem::trans
       QgsAnnotationItemEditOperationTranslateItem *moveOperation = qgis::down_cast< QgsAnnotationItemEditOperationTranslateItem * >( operation );
       const QTransform transform = QTransform::fromTranslate( moveOperation->translationX(), moveOperation->translationY() );
       std::unique_ptr< QgsCurve > modifiedCurve( mCurve->clone() );
+      modifiedCurve->transform( transform );
+      return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( std::move( modifiedCurve ) ) );
+    }
+
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
+    {
+      QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
+      std::unique_ptr< QgsCurve > modifiedCurve( mCurve->clone() );
+      QgsPoint center = modifiedCurve->centroid();
+      QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
+      transform.rotate( -rotateOperation->angle() );
+      transform.translate( -center.x(), -center.y() );
       modifiedCurve->transform( transform );
       return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( std::move( modifiedCurve ) ) );
     }

--- a/src/core/annotations/qgsannotationlinetextitem.cpp
+++ b/src/core/annotations/qgsannotationlinetextitem.cpp
@@ -161,7 +161,7 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationLineTextItem::applyEditV2( 
     case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
     {
       QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
-      QgsPoint center = mCurve->centroid();
+      QgsPointXY center = mCurve->boundingBox().center();
       QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
       transform.rotate( -rotateOperation->angle() );
       transform.translate( -center.x(), -center.y() );
@@ -201,7 +201,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationLineTextItem::trans
     {
       QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
       std::unique_ptr< QgsCurve > modifiedCurve( mCurve->clone() );
-      QgsPoint center = modifiedCurve->centroid();
+      QgsPointXY center = modifiedCurve->boundingBox().center();
       QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
       transform.rotate( -rotateOperation->angle() );
       transform.translate( -center.x(), -center.y() );

--- a/src/core/annotations/qgsannotationmarkeritem.cpp
+++ b/src/core/annotations/qgsannotationmarkeritem.cpp
@@ -106,6 +106,17 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationMarkerItem::applyEditV2( Qg
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
+    {
+      QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
+      if ( mSymbol )
+      {
+        mSymbol->setAngle( mSymbol->angle() + rotateOperation->angle() );
+        return Qgis::AnnotationItemEditOperationResult::Success;
+      }
+      break;
+    }
+
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;
   }
@@ -129,6 +140,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationMarkerItem::transie
       return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( new QgsPoint( mPoint.x() + moveOperation->translationX(), mPoint.y() + moveOperation->translationY() ) ) );
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
     case QgsAbstractAnnotationItemEditOperation::Type::DeleteNode:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;

--- a/src/core/annotations/qgsannotationmarkeritem.cpp
+++ b/src/core/annotations/qgsannotationmarkeritem.cpp
@@ -111,7 +111,7 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationMarkerItem::applyEditV2( Qg
       QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
       if ( mSymbol )
       {
-        mSymbol->setAngle( mSymbol->angle() + rotateOperation->angle() );
+        mSymbol->setAngle( std::fmod( mSymbol->angle() + rotateOperation->angle(), 360.0 ) );
         return Qgis::AnnotationItemEditOperationResult::Success;
       }
       break;

--- a/src/core/annotations/qgsannotationpointtextitem.cpp
+++ b/src/core/annotations/qgsannotationpointtextitem.cpp
@@ -273,6 +273,13 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationPointTextItem::applyEditV2(
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
+    {
+      QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
+      mAngle += rotateOperation->angle();
+      return Qgis::AnnotationItemEditOperationResult::Success;
+    }
+
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;
   }
@@ -296,6 +303,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationPointTextItem::tran
       return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( new QgsPoint( mPoint.x() + moveOperation->translationX(), mPoint.y() + moveOperation->translationY() ) ) );
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
     case QgsAbstractAnnotationItemEditOperation::Type::DeleteNode:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;

--- a/src/core/annotations/qgsannotationpointtextitem.cpp
+++ b/src/core/annotations/qgsannotationpointtextitem.cpp
@@ -276,7 +276,7 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationPointTextItem::applyEditV2(
     case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
     {
       QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
-      mAngle += rotateOperation->angle();
+      mAngle = std::fmod( mAngle + rotateOperation->angle(), 360.0 );
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
 

--- a/src/core/annotations/qgsannotationpolygonitem.cpp
+++ b/src/core/annotations/qgsannotationpolygonitem.cpp
@@ -168,7 +168,7 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationPolygonItem::applyEditV2( Q
     case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
     {
       QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
-      QgsPoint center = mPolygon->centroid();
+      QgsPointXY center = mPolygon->boundingBox().center();
       QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
       transform.rotate( -rotateOperation->angle() );
       transform.translate( -center.x(), -center.y() );
@@ -208,7 +208,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationPolygonItem::transi
     {
       QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
       std::unique_ptr< QgsCurvePolygon > modifiedPolygon( mPolygon->clone() );
-      QgsPoint center = modifiedPolygon->centroid();
+      QgsPointXY center = modifiedPolygon->boundingBox().center();
       QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
       transform.rotate( -rotateOperation->angle() );
       transform.translate( -center.x(), -center.y() );

--- a/src/core/annotations/qgsannotationpolygonitem.cpp
+++ b/src/core/annotations/qgsannotationpolygonitem.cpp
@@ -164,6 +164,17 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationPolygonItem::applyEditV2( Q
       mPolygon->transform( transform );
       return Qgis::AnnotationItemEditOperationResult::Success;
     }
+
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
+    {
+      QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
+      QgsPoint center = mPolygon->centroid();
+      QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
+      transform.rotate( -rotateOperation->angle() );
+      transform.translate( -center.x(), -center.y() );
+      mPolygon->transform( transform );
+      return Qgis::AnnotationItemEditOperationResult::Success;
+    }
   }
 
   return Qgis::AnnotationItemEditOperationResult::Invalid;
@@ -189,6 +200,18 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationPolygonItem::transi
       QgsAnnotationItemEditOperationTranslateItem *moveOperation = qgis::down_cast< QgsAnnotationItemEditOperationTranslateItem * >( operation );
       const QTransform transform = QTransform::fromTranslate( moveOperation->translationX(), moveOperation->translationY() );
       std::unique_ptr< QgsCurvePolygon > modifiedPolygon( mPolygon->clone() );
+      modifiedPolygon->transform( transform );
+      return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( std::move( modifiedPolygon ) ) );
+    }
+
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
+    {
+      QgsAnnotationItemEditOperationRotateItem *rotateOperation = qgis::down_cast< QgsAnnotationItemEditOperationRotateItem * >( operation );
+      std::unique_ptr< QgsCurvePolygon > modifiedPolygon( mPolygon->clone() );
+      QgsPoint center = modifiedPolygon->centroid();
+      QTransform transform = QTransform::fromTranslate( center.x(), center.y() );
+      transform.rotate( -rotateOperation->angle() );
+      transform.translate( -center.x(), -center.y() );
       modifiedPolygon->transform( transform );
       return new QgsAnnotationItemEditOperationTransientResults( QgsGeometry( std::move( modifiedPolygon ) ) );
     }

--- a/src/core/annotations/qgsannotationrectitem.cpp
+++ b/src/core/annotations/qgsannotationrectitem.cpp
@@ -348,6 +348,7 @@ Qgis::AnnotationItemEditOperationResult QgsAnnotationRectItem::applyEditV2( QgsA
 
     case QgsAbstractAnnotationItemEditOperation::Type::DeleteNode:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
       break;
   }
   return Qgis::AnnotationItemEditOperationResult::Invalid;
@@ -488,6 +489,7 @@ QgsAnnotationItemEditOperationTransientResults *QgsAnnotationRectItem::transient
       break;
     }
 
+    case QgsAbstractAnnotationItemEditOperation::Type::RotateItem:
     case QgsAbstractAnnotationItemEditOperation::Type::DeleteNode:
     case QgsAbstractAnnotationItemEditOperation::Type::AddNode:
       break;

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -93,7 +93,6 @@ QgsMapToolSelectAnnotation::QgsMapToolSelectAnnotation( QgsMapCanvas *canvas, Qg
   : QgsAnnotationMapTool( canvas, cadDockWidget )
 {
   connect( QgsMapToolSelectAnnotation::canvas(), &QgsMapCanvas::mapCanvasRefreshed, this, &QgsMapToolSelectAnnotation::onCanvasRefreshed );
-  connect( this, &QgsMapToolSelectAnnotation::selectedItemsChanged, this, &QgsMapToolSelectAnnotation::updateSelectedItem );
 
   setAdvancedDigitizingAllowed( false );
 }
@@ -309,6 +308,7 @@ void QgsMapToolSelectAnnotation::keyPressEvent( QKeyEvent *event )
       }
     }
     emit selectedItemsChanged();
+    updateSelectedItem();
     event->ignore();
     return;
   }
@@ -324,6 +324,7 @@ void QgsMapToolSelectAnnotation::keyPressEvent( QKeyEvent *event )
       mSelectedItems.pop_back();
     }
     emit selectedItemsChanged();
+    updateSelectedItem();
     event->ignore();
   }
   else if ( event->key() == Qt::Key_Left
@@ -465,6 +466,7 @@ void QgsMapToolSelectAnnotation::setSelectedItemsFromRect( const QgsRectangle &m
     }
   }
   emit selectedItemsChanged();
+  updateSelectedItem();
 }
 
 void QgsMapToolSelectAnnotation::setSelectedItemFromPoint( const QgsPointXY &mapPoint, bool toggleSelection )
@@ -519,6 +521,7 @@ void QgsMapToolSelectAnnotation::setSelectedItemFromPoint( const QgsPointXY &map
     mSelectedItems.back()->updateBoundingBox( closestItem->boundingBox() );
   }
   emit selectedItemsChanged();
+  updateSelectedItem();
 }
 
 void QgsMapToolSelectAnnotation::updateSelectedItem()
@@ -545,6 +548,7 @@ void QgsMapToolSelectAnnotation::clearSelectedItems()
   if ( hadSelection )
   {
     emit selectedItemsChanged();
+    updateSelectedItem();
   }
 }
 

--- a/tests/src/python/test_qgsannotationitemeditoperation.py
+++ b/tests/src/python/test_qgsannotationitemeditoperation.py
@@ -16,6 +16,7 @@ from qgis.core import (
     QgsAnnotationItemEditOperationAddNode,
     QgsAnnotationItemEditOperationDeleteNode,
     QgsAnnotationItemEditOperationMoveNode,
+    QgsAnnotationItemEditOperationRotateItem,
     QgsAnnotationItemEditOperationTranslateItem,
     QgsPoint,
     QgsVertexId,
@@ -58,6 +59,11 @@ class TestQgsAnnotationItemEditOperation(QgisTestCase):
         self.assertEqual(operation.itemId(), "item id")
         self.assertEqual(operation.translationX(), 6)
         self.assertEqual(operation.translationY(), 7)
+
+    def test_rotate_operation(self):
+        operation = QgsAnnotationItemEditOperationRotateItem("item id", 45)
+        self.assertEqual(operation.itemId(), "item id")
+        self.assertEqual(operation.angle(), 45)
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsannotationlineitem.py
+++ b/tests/src/python/test_qgsannotationlineitem.py
@@ -21,6 +21,7 @@ from qgis.core import (
     QgsAnnotationItemEditOperationAddNode,
     QgsAnnotationItemEditOperationDeleteNode,
     QgsAnnotationItemEditOperationMoveNode,
+    QgsAnnotationItemEditOperationRotateItem,
     QgsAnnotationItemEditOperationTranslateItem,
     QgsAnnotationItemNode,
     QgsAnnotationLineItem,
@@ -116,6 +117,27 @@ class TestQgsAnnotationLineItem(QgisTestCase):
         self.assertEqual(
             item.geometry().asWkt(), "LineString (112 213, 114 213, 114 215)"
         )
+
+    def test_rotate_operation(self):
+        item = QgsAnnotationLineItem(
+            QgsLineString(
+                [
+                    QgsPoint(0, 0),
+                    QgsPoint(5, 10),
+                    QgsPoint(10, 0),
+                ]
+            )
+        )
+        self.assertEqual(item.geometry().asWkt(), "LineString (0 0, 5 10, 10 0)")
+
+        self.assertEqual(
+            item.applyEditV2(
+                QgsAnnotationItemEditOperationRotateItem("", 90),
+                QgsAnnotationItemEditContext(),
+            ),
+            Qgis.AnnotationItemEditOperationResult.Success,
+        )
+        self.assertEqual(item.geometry().asWkt(), "LineString (0 10, 10 5, 0 0)")
 
     def test_apply_move_node_edit(self):
         item = QgsAnnotationLineItem(

--- a/tests/src/python/test_qgsannotationlinetextitem.py
+++ b/tests/src/python/test_qgsannotationlinetextitem.py
@@ -21,6 +21,7 @@ from qgis.core import (
     QgsAnnotationItemEditOperationAddNode,
     QgsAnnotationItemEditOperationDeleteNode,
     QgsAnnotationItemEditOperationMoveNode,
+    QgsAnnotationItemEditOperationRotateItem,
     QgsAnnotationItemEditOperationTranslateItem,
     QgsAnnotationItemNode,
     QgsAnnotationLineTextItem,
@@ -128,6 +129,28 @@ class TestQgsAnnotationLineTextItem(QgisTestCase):
         self.assertEqual(
             item.geometry().asWkt(1), "LineString (112 213, 113 213.1, 114 213)"
         )
+
+    def test_rotate_operation(self):
+        item = QgsAnnotationLineTextItem(
+            "my text",
+            QgsLineString(
+                [
+                    QgsPoint(0, 0),
+                    QgsPoint(5, 10),
+                    QgsPoint(10, 0),
+                ]
+            ),
+        )
+        self.assertEqual(item.geometry().asWkt(), "LineString (0 0, 5 10, 10 0)")
+
+        self.assertEqual(
+            item.applyEditV2(
+                QgsAnnotationItemEditOperationRotateItem("", 90),
+                QgsAnnotationItemEditContext(),
+            ),
+            Qgis.AnnotationItemEditOperationResult.Success,
+        )
+        self.assertEqual(item.geometry().asWkt(), "LineString (0 10, 10 5, 0 0)")
 
     def test_apply_move_node_edit(self):
         item = QgsAnnotationLineTextItem(

--- a/tests/src/python/test_qgsannotationmarkeritem.py
+++ b/tests/src/python/test_qgsannotationmarkeritem.py
@@ -21,6 +21,7 @@ from qgis.core import (
     QgsAnnotationItemEditOperationAddNode,
     QgsAnnotationItemEditOperationDeleteNode,
     QgsAnnotationItemEditOperationMoveNode,
+    QgsAnnotationItemEditOperationRotateItem,
     QgsAnnotationItemEditOperationTranslateItem,
     QgsAnnotationItemNode,
     QgsAnnotationMarkerItem,
@@ -98,6 +99,19 @@ class TestQgsAnnotationMarkerItem(QgisTestCase):
             Qgis.AnnotationItemEditOperationResult.Success,
         )
         self.assertEqual(item.geometry().asWkt(), "POINT(112 213)")
+
+    def test_rotate_operation(self):
+        item = QgsAnnotationMarkerItem(QgsPoint(12, 13))
+        self.assertEqual(item.symbol().angle(), 0)
+
+        self.assertEqual(
+            item.applyEditV2(
+                QgsAnnotationItemEditOperationRotateItem("", 90),
+                QgsAnnotationItemEditContext(),
+            ),
+            Qgis.AnnotationItemEditOperationResult.Success,
+        )
+        self.assertEqual(item.symbol().angle(), 90)
 
     def test_apply_move_node_edit(self):
         item = QgsAnnotationMarkerItem(QgsPoint(12, 13))

--- a/tests/src/python/test_qgsannotationpointtextitem.py
+++ b/tests/src/python/test_qgsannotationpointtextitem.py
@@ -21,6 +21,7 @@ from qgis.core import (
     QgsAnnotationItemEditOperationAddNode,
     QgsAnnotationItemEditOperationDeleteNode,
     QgsAnnotationItemEditOperationMoveNode,
+    QgsAnnotationItemEditOperationRotateItem,
     QgsAnnotationItemEditOperationTranslateItem,
     QgsAnnotationItemNode,
     QgsAnnotationPointTextItem,
@@ -120,6 +121,19 @@ class TestQgsAnnotationPointTextItem(QgisTestCase):
             Qgis.AnnotationItemEditOperationResult.Success,
         )
         self.assertEqual(item.point().asWkt(), "POINT(112 213)")
+
+    def test_rotate_operation(self):
+        item = QgsAnnotationPointTextItem("my text", QgsPointXY(12, 13))
+        self.assertEqual(item.angle(), 0)
+
+        self.assertEqual(
+            item.applyEditV2(
+                QgsAnnotationItemEditOperationRotateItem("", 90),
+                QgsAnnotationItemEditContext(),
+            ),
+            Qgis.AnnotationItemEditOperationResult.Success,
+        )
+        self.assertEqual(item.angle(), 90)
 
     def test_apply_move_node_edit(self):
         item = QgsAnnotationPointTextItem("my text", QgsPointXY(12, 13))

--- a/tests/src/python/test_qgsannotationpolygonitem.py
+++ b/tests/src/python/test_qgsannotationpolygonitem.py
@@ -21,6 +21,7 @@ from qgis.core import (
     QgsAnnotationItemEditOperationAddNode,
     QgsAnnotationItemEditOperationDeleteNode,
     QgsAnnotationItemEditOperationMoveNode,
+    QgsAnnotationItemEditOperationRotateItem,
     QgsAnnotationItemEditOperationTranslateItem,
     QgsAnnotationItemNode,
     QgsAnnotationPolygonItem,
@@ -383,6 +384,35 @@ class TestQgsAnnotationPolygonItem(QgisTestCase):
         self.assertEqual(
             res.representativeGeometry().asWkt(),
             "Polygon ((112 213, 114 213, 114 215, 112 213))",
+        )
+
+    def test_rotate_operation(self):
+        item = QgsAnnotationPolygonItem(
+            QgsPolygon(
+                QgsLineString(
+                    [
+                        QgsPoint(0, 0),
+                        QgsPoint(10, 0),
+                        QgsPoint(10, 10),
+                        QgsPoint(0, 10),
+                        QgsPoint(0, 0),
+                    ]
+                )
+            )
+        )
+        self.assertEqual(
+            item.geometry().asWkt(), "Polygon ((0 0, 10 0, 10 10, 0 10, 0 0))"
+        )
+
+        self.assertEqual(
+            item.applyEditV2(
+                QgsAnnotationItemEditOperationRotateItem("", 90),
+                QgsAnnotationItemEditContext(),
+            ),
+            Qgis.AnnotationItemEditOperationResult.Success,
+        )
+        self.assertEqual(
+            item.geometry().asWkt(), "Polygon ((0 10, 0 0, 10 0, 10 10, 0 10))"
         )
 
     def testReadWriteXml(self):


### PR DESCRIPTION
## Description

This PR adds a new rotate operation for annotation items, and implements rotation behavior for:
- polygon item
- line item
- marker item (nice example of operation's usefulness as we're rotating the symbol here)
- text on point
- text on line

Two rectangle-based items (such as text in a box) do not support rotation. We could eventually add support for these (e.g. rotated annotation images would be cool). But for now this PR unlocks the items that have a preestablished notion of rotation.

@nyalldawson , as discussed in the initial PR.