### PR TITLE
Fix: QGIS generates invalid dxf file when encoding does not work with layer name(s)

### DIFF
--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -36,6 +36,8 @@
 
 class QgsLayerTreeGroup;
 class QgsLayerTreeNode;
+class QTextCodec;
+class QgsMessageBarItem;
 
 class FieldSelectorDelegate : public QItemDelegate
 {
@@ -145,12 +147,17 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     void showHelp();
 
   private:
+    bool validateEncodingForLayerNames();
+    void showEncodingWarning( const QString &message, const QStringList &details );
+    void clearEncodingWarning();
+
     void cleanGroup( QgsLayerTreeNode *node );
     QgsLayerTree *mLayerTreeGroup = nullptr;
     FieldSelectorDelegate *mFieldSelectorDelegate = nullptr;
     QgsVectorLayerAndAttributeModel *mModel = nullptr;
     QgsDxfExportLayerTreeView *mTreeView = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
+    QgsMessageBarItem *mEncodingWarningItem = nullptr;
 
     QgsCoordinateReferenceSystem mCRS;
 };


### PR DESCRIPTION
## Description

When exporting to dxf, any glyph that the selected codec cannot represent is silently replaced with ? by QgsDxfExport::writeToFile before it ever reaches the DXF file. This character is invalid for layer names in AutoCad:
see [docs](http://docs.autodesk.com/ACD/2010/ENU/AutoCAD%202010%20User%20Documentation/index.html?url=WS1a9193826455f5ffa23ce210c4a30acaf-7345.htm,topicNumber=d0e41665)

This PR blocks the export dialog "ok" button until the user has chosen an encoding which is compatible with the layer names in the project, or until the user changes the layer names to something compatible with the encoding.

Without this check QGIS can generate an invalid dxf file.

The change has been tested by compiling and running on linux. Screenshots show an example of the warning. Notice an invalid codec is chosen for the em-dash character in the layer names.

<img width="788" height="868" alt="Screenshot_20260118_134524" src="https://github.com/user-attachments/assets/e9fdcd43-93bc-4214-801a-fb3dd7f71475" />
<img width="792" height="867" alt="Screenshot_20260118_134541" src="https://github.com/user-attachments/assets/b7fe7255-4697-45fd-9669-8f7cd4fe0dac" />
