### PR TITLE
Fix data-defined stroke style not using default for NULL values

### DIFF
--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -769,9 +769,8 @@ void QgsSimpleLineSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderContext
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::StrokeStyle ) )
   {
     context.setOriginalValueVariable( QgsSymbolLayerUtils::encodePenStyle( mPenStyle ) );
-    QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::Property::StrokeStyle, context.renderContext().expressionContext() );
-    if ( !QgsVariantUtils::isNull( exprVal ) )
-      pen.setStyle( QgsSymbolLayerUtils::decodePenStyle( exprVal.toString() ) );
+    const QString lineStyleString = mDataDefinedProperties.valueAsString( QgsSymbolLayer::Property::StrokeStyle, context.renderContext().expressionContext(), QgsSymbolLayerUtils::encodePenStyle( mPenStyle ) );
+    pen.setStyle( QgsSymbolLayerUtils::decodePenStyle( lineStyleString ) );
   }
 
   //join style


### PR DESCRIPTION
Hi all.

For a line layer, If I use data defined override based on some fields for "stroke width" or "color", if the corresponding columns/fields are NULL then the default "stroke width"/"color" get taken into account.

This currently works different for StrokeStyle as it doesn't have a fallback to the default StrokeStyle and it messes up things by inheriting the style from first/other? feature instead of using the default.

StrokeWidth handles this correctly IMHO by using valueAsDouble with a default parameter:
``
  valueAsDouble( Property::StrokeWidth, ..., mWidth )
``
StrokeStyle was using value() + a null check without falling back to the default
``
  QVariant exprVal = value( Property::StrokeStyle, ... );
  if ( !isNull( exprVal ) )
    pen.setStyle( decode( exprVal ) );
``
Now uses valueAsString() with the encoded default, like in StrokeWidth.

I actually noticed this from time to time while teaching but I never got to investigate further as I worked around it by using conditional expressions to return the default.

It may be that the current behavior is somehow a feature and I don't understand it.

This is how it works before the fix, notice the line above changes style depending if the line below is in the map canvas  or not:

[Screencast_20260118_144413.webm](https://github.com/user-attachments/assets/f1e9e846-ed87-4937-baad-d8e1b6007ebb)

This is after the fix:
![Screencast_20260118_151806](https://github.com/user-attachments/assets/13e9fa3d-ab3d-4060-8fd5-a1eb161c9ddb)

There are many more properties to visit, but I thought of getting feedback first.

Thank you for looking into this.

I'm also attaching a project so that everyone can easily replicate.
I tested only with master today but I noticed this in LTR's.

[bug.zip](https://github.com/user-attachments/files/24695884/bug.zip)

 