### PR TITLE
Feature/add point by deflection angle

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsgeometryutils.py
+++ b/python/PyQt6/core/auto_additions/qgsgeometryutils.py
@@ -13,6 +13,7 @@ try:
     QgsGeometryUtils.circleCircleInnerTangents = staticmethod(QgsGeometryUtils.circleCircleInnerTangents)
     QgsGeometryUtils.projectPointOnSegment = staticmethod(QgsGeometryUtils.projectPointOnSegment)
     QgsGeometryUtils.leftOfLine = staticmethod(QgsGeometryUtils.leftOfLine)
+    QgsGeometryUtils.pointByDeflectionAngle = staticmethod(QgsGeometryUtils.pointByDeflectionAngle)
     QgsGeometryUtils.interpolatePointOnArc = staticmethod(QgsGeometryUtils.interpolatePointOnArc)
     QgsGeometryUtils.segmentMidPoint = staticmethod(QgsGeometryUtils.segmentMidPoint)
     QgsGeometryUtils.segmentMidPointFromCenter = staticmethod(QgsGeometryUtils.segmentMidPointFromCenter)

--- a/python/PyQt6/core/auto_additions/qgsgeometryutils_base.py
+++ b/python/PyQt6/core/auto_additions/qgsgeometryutils_base.py
@@ -37,6 +37,7 @@ try:
     QgsGeometryUtilsBase.segmentIntersection = staticmethod(QgsGeometryUtilsBase.segmentIntersection)
     QgsGeometryUtilsBase.project = staticmethod(QgsGeometryUtilsBase.project)
     QgsGeometryUtilsBase.azimuth = staticmethod(QgsGeometryUtilsBase.azimuth)
+    QgsGeometryUtilsBase.pointByDeflectionAngle = staticmethod(QgsGeometryUtilsBase.pointByDeflectionAngle)
     QgsGeometryUtilsBase.__group__ = ['geometry']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -204,6 +204,44 @@ segment) and the result is undefined.
 Returns a point a specified ``distance`` toward a second point.
 %End
 
+    static QgsPoint pointByDeflectionAngle( const QgsPoint &basePoint, const QgsPoint &directionPoint,
+                                            double deflectionAngle, double distance ) /HoldGIL/;
+%Docstring
+Calculates a point by applying a deflection angle from an initial
+direction.
+
+Given a ``basePoint`` and a ``directionPoint`` that defines the initial
+bearing, this method calculates a new point at the specified
+``distance`` from the base point, deflected by ``deflectionAngle`` from
+the initial direction.
+
+The deflection angle is measured from the initial bearing:
+
+- Positive values deflect clockwise (to the right)
+- Negative values deflect counter-clockwise (to the left)
+
+This is commonly used in surveying for traverse calculations where
+angles are measured as deflections from the previous course direction.
+
+Any Z or M values from the ``basePoint`` will be preserved in the
+returned point.
+
+:param basePoint: the base point (instrument position)
+:param directionPoint: the direction point (backsight), defines the
+                       initial bearing
+:param deflectionAngle: deflection angle in radians (positive =
+                        clockwise/right)
+:param distance: distance to the new point
+
+:return: the calculated point
+
+.. seealso:: :py:func:`pointOnLineWithDistance`
+
+.. seealso:: :py:func:`QgsGeometryUtilsBase.pointByDeflectionAngle`
+
+.. versionadded:: 4.0
+%End
+
     static QgsPoint interpolatePointOnArc( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, double distance ) /HoldGIL/;
 %Docstring
 Interpolates a point on an arc defined by three points, ``pt1``, ``pt2``

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
@@ -618,6 +618,44 @@ Calculates Cartesian azimuth between points (``x1``, ``y1``) and
 .. versionadded:: 3.34
 %End
 
+    static void pointByDeflectionAngle( double x1, double y1, double x2, double y2,
+                                        double deflectionAngle, double distance,
+                                        double &resultX /Out/, double &resultY /Out/ ) /HoldGIL/;
+%Docstring
+Calculates a point by applying a deflection angle from an initial
+direction.
+
+Given a base point (``x1``, ``y1``) and a direction point (``x2``,
+``y2``) that defines the initial bearing, this method calculates a new
+point at the specified ``distance`` from the base point, deflected by
+``deflectionAngle`` from the initial direction.
+
+The deflection angle is measured from the initial bearing:
+
+- Positive values deflect clockwise (to the right)
+- Negative values deflect counter-clockwise (to the left)
+
+This is commonly used in surveying for traverse calculations where
+angles are measured as deflections from the previous course direction.
+
+:param x1: x-coordinate of the base point (instrument position)
+:param y1: y-coordinate of the base point (instrument position)
+:param x2: x-coordinate of the direction point (backsight)
+:param y2: y-coordinate of the direction point (backsight)
+:param deflectionAngle: deflection angle in radians (positive =
+                        clockwise/right)
+:param distance: distance to the new point
+
+.. seealso:: :py:func:`project`
+
+.. seealso:: :py:func:`lineAngle`
+
+:return: - resultX: x-coordinate of the calculated point
+         - resultY: y-coordinate of the calculated point
+
+.. versionadded:: 4.0
+%End
+
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_additions/qgsgeometryutils.py
+++ b/python/core/auto_additions/qgsgeometryutils.py
@@ -13,6 +13,7 @@ try:
     QgsGeometryUtils.circleCircleInnerTangents = staticmethod(QgsGeometryUtils.circleCircleInnerTangents)
     QgsGeometryUtils.projectPointOnSegment = staticmethod(QgsGeometryUtils.projectPointOnSegment)
     QgsGeometryUtils.leftOfLine = staticmethod(QgsGeometryUtils.leftOfLine)
+    QgsGeometryUtils.pointByDeflectionAngle = staticmethod(QgsGeometryUtils.pointByDeflectionAngle)
     QgsGeometryUtils.interpolatePointOnArc = staticmethod(QgsGeometryUtils.interpolatePointOnArc)
     QgsGeometryUtils.segmentMidPoint = staticmethod(QgsGeometryUtils.segmentMidPoint)
     QgsGeometryUtils.segmentMidPointFromCenter = staticmethod(QgsGeometryUtils.segmentMidPointFromCenter)

--- a/python/core/auto_additions/qgsgeometryutils_base.py
+++ b/python/core/auto_additions/qgsgeometryutils_base.py
@@ -37,6 +37,7 @@ try:
     QgsGeometryUtilsBase.segmentIntersection = staticmethod(QgsGeometryUtilsBase.segmentIntersection)
     QgsGeometryUtilsBase.project = staticmethod(QgsGeometryUtilsBase.project)
     QgsGeometryUtilsBase.azimuth = staticmethod(QgsGeometryUtilsBase.azimuth)
+    QgsGeometryUtilsBase.pointByDeflectionAngle = staticmethod(QgsGeometryUtilsBase.pointByDeflectionAngle)
     QgsGeometryUtilsBase.__group__ = ['geometry']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -204,6 +204,44 @@ segment) and the result is undefined.
 Returns a point a specified ``distance`` toward a second point.
 %End
 
+    static QgsPoint pointByDeflectionAngle( const QgsPoint &basePoint, const QgsPoint &directionPoint,
+                                            double deflectionAngle, double distance ) /HoldGIL/;
+%Docstring
+Calculates a point by applying a deflection angle from an initial
+direction.
+
+Given a ``basePoint`` and a ``directionPoint`` that defines the initial
+bearing, this method calculates a new point at the specified
+``distance`` from the base point, deflected by ``deflectionAngle`` from
+the initial direction.
+
+The deflection angle is measured from the initial bearing:
+
+- Positive values deflect clockwise (to the right)
+- Negative values deflect counter-clockwise (to the left)
+
+This is commonly used in surveying for traverse calculations where
+angles are measured as deflections from the previous course direction.
+
+Any Z or M values from the ``basePoint`` will be preserved in the
+returned point.
+
+:param basePoint: the base point (instrument position)
+:param directionPoint: the direction point (backsight), defines the
+                       initial bearing
+:param deflectionAngle: deflection angle in radians (positive =
+                        clockwise/right)
+:param distance: distance to the new point
+
+:return: the calculated point
+
+.. seealso:: :py:func:`pointOnLineWithDistance`
+
+.. seealso:: :py:func:`QgsGeometryUtilsBase.pointByDeflectionAngle`
+
+.. versionadded:: 4.0
+%End
+
     static QgsPoint interpolatePointOnArc( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, double distance ) /HoldGIL/;
 %Docstring
 Interpolates a point on an arc defined by three points, ``pt1``, ``pt2``

--- a/python/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils_base.sip.in
@@ -618,6 +618,44 @@ Calculates Cartesian azimuth between points (``x1``, ``y1``) and
 .. versionadded:: 3.34
 %End
 
+    static void pointByDeflectionAngle( double x1, double y1, double x2, double y2,
+                                        double deflectionAngle, double distance,
+                                        double &resultX /Out/, double &resultY /Out/ ) /HoldGIL/;
+%Docstring
+Calculates a point by applying a deflection angle from an initial
+direction.
+
+Given a base point (``x1``, ``y1``) and a direction point (``x2``,
+``y2``) that defines the initial bearing, this method calculates a new
+point at the specified ``distance`` from the base point, deflected by
+``deflectionAngle`` from the initial direction.
+
+The deflection angle is measured from the initial bearing:
+
+- Positive values deflect clockwise (to the right)
+- Negative values deflect counter-clockwise (to the left)
+
+This is commonly used in surveying for traverse calculations where
+angles are measured as deflections from the previous course direction.
+
+:param x1: x-coordinate of the base point (instrument position)
+:param y1: y-coordinate of the base point (instrument position)
+:param x2: x-coordinate of the direction point (backsight)
+:param y2: y-coordinate of the direction point (backsight)
+:param deflectionAngle: deflection angle in radians (positive =
+                        clockwise/right)
+:param distance: distance to the new point
+
+.. seealso:: :py:func:`project`
+
+.. seealso:: :py:func:`lineAngle`
+
+:return: - resultX: x-coordinate of the calculated point
+         - resultY: y-coordinate of the calculated point
+
+.. versionadded:: 4.0
+%End
+
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -512,6 +512,30 @@ QgsPoint QgsGeometryUtils::pointOnLineWithDistance( const QgsPoint &startPoint, 
   return QgsPoint( x, y );
 }
 
+QgsPoint QgsGeometryUtils::pointByDeflectionAngle( const QgsPoint &basePoint, const QgsPoint &directionPoint,
+    double deflectionAngle, double distance )
+{
+  double resultX, resultY;
+  QgsGeometryUtilsBase::pointByDeflectionAngle( basePoint.x(), basePoint.y(),
+      directionPoint.x(), directionPoint.y(),
+      deflectionAngle, distance,
+      resultX, resultY );
+
+  // Create result point preserving Z and M from basePoint
+  QgsPoint result( resultX, resultY );
+  if ( basePoint.is3D() )
+  {
+    result.convertTo( QgsWkbTypes::addZ( result.wkbType() ) );
+    result.setZ( basePoint.z() );
+  }
+  if ( basePoint.isMeasure() )
+  {
+    result.convertTo( QgsWkbTypes::addM( result.wkbType() ) );
+    result.setM( basePoint.m() );
+  }
+  return result;
+}
+
 
 QgsPoint QgsGeometryUtils::interpolatePointOnArc( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, double distance )
 {

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -226,6 +226,37 @@ class CORE_EXPORT QgsGeometryUtils
     static QgsPoint pointOnLineWithDistance( const QgsPoint &startPoint, const QgsPoint &directionPoint, double distance ) SIP_HOLDGIL;
 
     /**
+     * Calculates a point by applying a deflection angle from an initial direction.
+     *
+     * Given a \a basePoint and a \a directionPoint that defines the initial bearing,
+     * this method calculates a new point at the specified \a distance from the base point,
+     * deflected by \a deflectionAngle from the initial direction.
+     *
+     * The deflection angle is measured from the initial bearing:
+     *
+     * - Positive values deflect clockwise (to the right)
+     * - Negative values deflect counter-clockwise (to the left)
+     *
+     * This is commonly used in surveying for traverse calculations where angles are
+     * measured as deflections from the previous course direction.
+     *
+     * Any Z or M values from the \a basePoint will be preserved in the returned point.
+     *
+     * \param basePoint the base point (instrument position)
+     * \param directionPoint the direction point (backsight), defines the initial bearing
+     * \param deflectionAngle deflection angle in radians (positive = clockwise/right)
+     * \param distance distance to the new point
+     * \returns the calculated point
+     *
+     * \see pointOnLineWithDistance()
+     * \see QgsGeometryUtilsBase::pointByDeflectionAngle()
+     *
+     * \since QGIS 4.0
+     */
+    static QgsPoint pointByDeflectionAngle( const QgsPoint &basePoint, const QgsPoint &directionPoint,
+                                            double deflectionAngle, double distance ) SIP_HOLDGIL;
+
+    /**
      * Interpolates a point on an arc defined by three points, \a pt1, \a pt2 and \a pt3. The arc will be
      * interpolated by the specified \a distance from \a pt1.
      *

--- a/src/core/geometry/qgsgeometryutils_base.cpp
+++ b/src/core/geometry/qgsgeometryutils_base.cpp
@@ -770,6 +770,26 @@ double QgsGeometryUtilsBase::azimuth( double x1, double y1, double x2, double y2
   return ( std::atan2( dx, dy ) * 180.0 / M_PI );
 }
 
+void QgsGeometryUtilsBase::pointByDeflectionAngle( double x1, double y1, double x2, double y2,
+    double deflectionAngle, double distance,
+    double &resultX, double &resultY )
+{
+  // Calculate the initial bearing from base point to direction point
+  // lineAngle returns angle in radians, clockwise from north
+  const double initialBearing = lineAngle( x1, y1, x2, y2 );
+
+  // Add deflection angle to get the new bearing
+  // Positive deflection = clockwise (right turn)
+  const double newBearing = normalizedAngle( initialBearing + deflectionAngle );
+
+  // Convert bearing (radians from north) to azimuth (degrees from north) for project()
+  const double azimuthDegrees = newBearing * 180.0 / M_PI;
+
+  // Project the point using the 2D version (inclination = 90 degrees)
+  double resultZ;
+  project( x1, y1, std::numeric_limits<double>::quiet_NaN(), distance, azimuthDegrees, 90.0, resultX, resultY, resultZ );
+}
+
 bool QgsGeometryUtilsBase::angleBisector( double aX, double aY, double bX, double bY, double cX, double cY, double dX, double dY,
     double &pointX, double &pointY, double &angle )
 {

--- a/src/core/geometry/qgsgeometryutils_base.h
+++ b/src/core/geometry/qgsgeometryutils_base.h
@@ -525,6 +525,39 @@ class CORE_EXPORT QgsGeometryUtilsBase
      */
     static double azimuth( double x1, double y1, double x2, double y2 ) SIP_HOLDGIL;
 
+    /**
+     * Calculates a point by applying a deflection angle from an initial direction.
+     *
+     * Given a base point (\a x1, \a y1) and a direction point (\a x2, \a y2) that defines
+     * the initial bearing, this method calculates a new point at the specified \a distance
+     * from the base point, deflected by \a deflectionAngle from the initial direction.
+     *
+     * The deflection angle is measured from the initial bearing:
+     *
+     * - Positive values deflect clockwise (to the right)
+     * - Negative values deflect counter-clockwise (to the left)
+     *
+     * This is commonly used in surveying for traverse calculations where angles are
+     * measured as deflections from the previous course direction.
+     *
+     * \param x1 x-coordinate of the base point (instrument position)
+     * \param y1 y-coordinate of the base point (instrument position)
+     * \param x2 x-coordinate of the direction point (backsight)
+     * \param y2 y-coordinate of the direction point (backsight)
+     * \param deflectionAngle deflection angle in radians (positive = clockwise/right)
+     * \param distance distance to the new point
+     * \param resultX x-coordinate of the calculated point
+     * \param resultY y-coordinate of the calculated point
+     *
+     * \see project()
+     * \see lineAngle()
+     *
+     * \since QGIS 4.0
+     */
+    static void pointByDeflectionAngle( double x1, double y1, double x2, double y2,
+                                        double deflectionAngle, double distance,
+                                        double &resultX SIP_OUT, double &resultY SIP_OUT ) SIP_HOLDGIL;
+
 #ifndef SIP_RUN
 
     /**

--- a/tests/src/core/geometry/testqgsgeometryutils.cpp
+++ b/tests/src/core/geometry/testqgsgeometryutils.cpp
@@ -2069,7 +2069,7 @@ void TestQgsGeometryUtils::testCheckWeaklyFor3DPlane()
 
 void TestQgsGeometryUtils::testPointByDeflectionAngle()
 {
-  const double tolerance = 1e-4;
+  const double tolerance = 1e-8;
 
   // Test 1: No deflection, continue north
   {

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -116,6 +116,7 @@ ADD_PYTHON_TEST(PyQgsGeometryGeneratorSymbolLayer test_qgsgeometrygeneratorsymbo
 ADD_PYTHON_TEST(PyQgsGeometryPaintDevice test_qgsgeometrypaintdevice.py)
 ADD_PYTHON_TEST(PyQgsGeometryTest test_qgsgeometry.py)
 ADD_PYTHON_TEST(PyQgsGeometryValidator test_qgsgeometryvalidator.py)
+ADD_PYTHON_TEST(PyQgsGeometryUtils test_qgsgeometryutils.py)
 ADD_PYTHON_TEST(PyQgsGoogleMapsGeocoder test_qgsgooglemapsgeocoder.py)
 ADD_PYTHON_TEST(PyQgsGpsLogger test_qgsgpslogger.py)
 ADD_PYTHON_TEST(PyQgsGpxProvider test_provider_gpx.py)

--- a/tests/src/python/test_qgsgeometryutils.py
+++ b/tests/src/python/test_qgsgeometryutils.py
@@ -1,0 +1,78 @@
+"""QGIS Unit tests for QgsGeometryUtils.
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+
+__author__ = "Loïc Bartoletti"
+__date__ = "January 2026"
+__copyright__ = "Copyright 2026, The QGIS Project"
+
+import math
+from qgis.core import (
+    QgsGeometryUtils,
+    QgsPoint,
+)
+from qgis.testing import unittest
+
+
+class TestQgsGeometryUtils(unittest.TestCase):
+
+    def test_point_by_deflection_angle(self):
+        """Test pointByDeflectionAngle function"""
+        # Test 1: No deflection, continue north
+        base = QgsPoint(0, 0)
+        direction = QgsPoint(0, 10)
+        result = QgsGeometryUtils.pointByDeflectionAngle(base, direction, 0.0, 5.0)
+        self.assertAlmostEqual(result.x(), 0.0, places=8)
+        self.assertAlmostEqual(result.y(), 5.0, places=8)
+
+        # Test 2: 90 degree right deflection (pi/2 radians)
+        result = QgsGeometryUtils.pointByDeflectionAngle(
+            base, direction, math.pi / 2, 5.0
+        )
+        self.assertAlmostEqual(result.x(), 5.0, places=8)
+        self.assertAlmostEqual(result.y(), 0.0, places=8)
+
+        # Test 3: 90 degree left deflection (-pi/2 radians)
+        result = QgsGeometryUtils.pointByDeflectionAngle(
+            base, direction, -math.pi / 2, 5.0
+        )
+        self.assertAlmostEqual(result.x(), -5.0, places=8)
+        self.assertAlmostEqual(result.y(), 0.0, places=8)
+
+        # Test 4: 180 degree deflection (pi radians)
+        result = QgsGeometryUtils.pointByDeflectionAngle(base, direction, math.pi, 5.0)
+        self.assertAlmostEqual(result.x(), 0.0, places=8)
+        self.assertAlmostEqual(result.y(), -5.0, places=8)
+
+        # Test 5: Preserve Z value from basePoint
+        base_z = QgsPoint(0, 0, 100)  # PointZ
+        result = QgsGeometryUtils.pointByDeflectionAngle(base_z, direction, 0.0, 5.0)
+        self.assertTrue(result.is3D())
+        self.assertAlmostEqual(result.z(), 100.0, places=8)
+
+        # Test 6: Non-origin base point
+        base_offset = QgsPoint(10, 10)
+        direction_offset = QgsPoint(10, 20)
+        result = QgsGeometryUtils.pointByDeflectionAngle(
+            base_offset, direction_offset, 0.0, 5.0
+        )
+        self.assertAlmostEqual(result.x(), 10.0, places=8)
+        self.assertAlmostEqual(result.y(), 15.0, places=8)
+
+        # Test 7: Diagonal direction with 45 degree deflection
+        direction_ne = QgsPoint(10, 10)  # NE direction (45 deg from north)
+        result = QgsGeometryUtils.pointByDeflectionAngle(
+            base, direction_ne, math.pi / 4, math.sqrt(2.0)
+        )
+        # 45 deg (NE) + 45 deg right = 90 deg = East
+        # East direction with distance sqrt(2) gives (sqrt(2), 0)
+        self.assertAlmostEqual(result.x(), math.sqrt(2.0), places=8)
+        self.assertAlmostEqual(result.y(), 0.0, places=8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add a new static function that calculates a point given a base point,
a direction point, a deflection angle, and a distance. The deflection
angle is measured from the initial direction (base to direction point)
with positive angles turning right (clockwise) and negative angles
turning left (counter-clockwise).

Used in CAD and Surveying

cc @jmarsac