### PR TITLE
qgsvectorlayer3drendererwidget: Fix layer update in singlesymbol

### DIFF
--- a/src/app/3d/qgssymbol3dwidget.cpp
+++ b/src/app/3d/qgssymbol3dwidget.cpp
@@ -35,6 +35,9 @@ QgsSymbol3DWidget::QgsSymbol3DWidget( QgsVectorLayer *layer, QWidget *parent )
   : QWidget( parent )
   , mLayer( layer )
 {
+  // If layer is null, the widget cannot be created.
+  Q_ASSERT( mLayer );
+
   widgetUnsupported = new QLabel( tr( "Sorry, this symbol is not supported." ), this );
 
   widgetStack = new QStackedWidget( this );
@@ -66,6 +69,9 @@ std::unique_ptr<QgsAbstract3DSymbol> QgsSymbol3DWidget::symbol()
 
 void QgsSymbol3DWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorLayer *vlayer )
 {
+  // If layer is null, the widget cannot be updated.
+  Q_ASSERT( vlayer );
+
   mLayer = vlayer;
   mStyleWidget->setLayerType( mLayer->geometryType() );
 

--- a/src/app/3d/qgssymbol3dwidget.h
+++ b/src/app/3d/qgssymbol3dwidget.h
@@ -46,7 +46,7 @@ class QgsSymbol3DWidget : public QWidget
     //! Returns a new symbol instance or NULLPTR
     std::unique_ptr<QgsAbstract3DSymbol> symbol();
 
-    //! Sets symbol (does not take ownership)
+    //! Sets symbol and layer (does not take ownership)
     void setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorLayer *vlayer );
 
   signals:

--- a/src/app/3d/qgsvectorlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.cpp
@@ -63,17 +63,19 @@ void QgsSingleSymbol3DRendererWidget::setLayer( QgsVectorLayer *layer )
   // If layer is null, the widget cannot be updated.
   Q_ASSERT( layer );
 
-  QgsAbstract3DRenderer *r = layer->renderer3D();
+  mLayer = layer;
+
+  QgsAbstract3DRenderer *r = mLayer->renderer3D();
   if ( r && r->type() == "vector"_L1 )
   {
     QgsVectorLayer3DRenderer *vectorRenderer = static_cast<QgsVectorLayer3DRenderer *>( r );
-    widgetSymbol->setSymbol( vectorRenderer->symbol(), layer );
+    widgetSymbol->setSymbol( vectorRenderer->symbol(), mLayer );
   }
   else
   {
-    const std::unique_ptr<QgsAbstract3DSymbol> sym( QgsApplication::symbol3DRegistry()->defaultSymbolForGeometryType( layer->geometryType() ) );
-    sym->setDefaultPropertiesFromLayer( layer );
-    widgetSymbol->setSymbol( sym.get(), layer );
+    const std::unique_ptr<QgsAbstract3DSymbol> sym( QgsApplication::symbol3DRegistry()->defaultSymbolForGeometryType( mLayer->geometryType() ) );
+    sym->setDefaultPropertiesFromLayer( mLayer );
+    widgetSymbol->setSymbol( sym.get(), mLayer );
   }
 }
 

--- a/src/app/3d/qgsvectorlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.cpp
@@ -37,6 +37,9 @@ QgsSingleSymbol3DRendererWidget::QgsSingleSymbol3DRendererWidget( QgsVectorLayer
   : QWidget( parent )
   , mLayer( layer )
 {
+  // If layer is null, the widget cannot be created.
+  Q_ASSERT( mLayer );
+
   QVBoxLayout *scrollLayout = new QVBoxLayout();
   scrollLayout->setContentsMargins( 0, 0, 0, 0 );
 
@@ -57,6 +60,9 @@ QgsSingleSymbol3DRendererWidget::QgsSingleSymbol3DRendererWidget( QgsVectorLayer
 
 void QgsSingleSymbol3DRendererWidget::setLayer( QgsVectorLayer *layer )
 {
+  // If layer is null, the widget cannot be updated.
+  Q_ASSERT( layer );
+
   QgsAbstract3DRenderer *r = layer->renderer3D();
   if ( r && r->type() == "vector"_L1 )
   {


### PR DESCRIPTION
## Description

- `QgsSingleSymbol3DRendererWidget::setLayer` was not updating its attribute `mLayer`.
- also add assert of the related widgets. They cannot be created if the layer if the layer is null.

**Funded by Stadt Frankfurt am Main and Oslandia**