### PR TITLE
[3D] fix two memory leaks in QgsRuleBased3DRendererWidget

### DIFF
--- a/src/app/3d/qgsrulebased3drendererwidget.cpp
+++ b/src/app/3d/qgsrulebased3drendererwidget.cpp
@@ -62,11 +62,6 @@ QgsRuleBased3DRendererWidget::QgsRuleBased3DRendererWidget( QWidget *parent )
   connect( mDeleteAction, &QAction::triggered, this, &QgsRuleBased3DRendererWidget::removeRule );
 }
 
-QgsRuleBased3DRendererWidget::~QgsRuleBased3DRendererWidget()
-{
-  delete mRootRule;
-}
-
 void QgsRuleBased3DRendererWidget::setLayer( QgsVectorLayer *layer )
 {
   mLayer = layer;
@@ -75,15 +70,15 @@ void QgsRuleBased3DRendererWidget::setLayer( QgsVectorLayer *layer )
   if ( r && r->type() == "rulebased"_L1 )
   {
     QgsRuleBased3DRenderer *ruleRenderer = static_cast<QgsRuleBased3DRenderer *>( r );
-    mRootRule = ruleRenderer->rootRule()->clone();
+    mRootRule.reset( ruleRenderer->rootRule()->clone() );
   }
   else
   {
     // TODO: handle the special case when switching from single symbol renderer
-    mRootRule = new QgsRuleBased3DRenderer::Rule( nullptr );
+    mRootRule = std::make_unique<QgsRuleBased3DRenderer::Rule>( nullptr );
   }
 
-  mModel.reset( new QgsRuleBased3DRendererModel( mRootRule ) );
+  mModel.reset( new QgsRuleBased3DRendererModel( mRootRule.get() ) );
   viewRules->setModel( mModel );
 
   connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsRuleBased3DRendererWidget::widgetChanged );

--- a/src/app/3d/qgsrulebased3drendererwidget.cpp
+++ b/src/app/3d/qgsrulebased3drendererwidget.cpp
@@ -83,7 +83,7 @@ void QgsRuleBased3DRendererWidget::setLayer( QgsVectorLayer *layer )
     mRootRule = new QgsRuleBased3DRenderer::Rule( nullptr );
   }
 
-  mModel = new QgsRuleBased3DRendererModel( mRootRule );
+  mModel.reset( new QgsRuleBased3DRendererModel( mRootRule ) );
   viewRules->setModel( mModel );
 
   connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsRuleBased3DRendererWidget::widgetChanged );

--- a/src/app/3d/qgsrulebased3drendererwidget.h
+++ b/src/app/3d/qgsrulebased3drendererwidget.h
@@ -84,12 +84,11 @@ class QgsRuleBased3DRendererWidget : public QgsPanelWidget, private Ui::QgsRuleB
 
   public:
     QgsRuleBased3DRendererWidget( QWidget *parent = nullptr );
-    ~QgsRuleBased3DRendererWidget() override;
 
     //! load renderer from the layer
     void setLayer( QgsVectorLayer *layer );
     //! no transfer of ownership
-    QgsRuleBased3DRenderer::Rule *rootRule() { return mRootRule; }
+    QgsRuleBased3DRenderer::Rule *rootRule() { return mRootRule.get(); }
 
     void setDockMode( bool dockMode ) override;
 
@@ -111,7 +110,7 @@ class QgsRuleBased3DRendererWidget : public QgsPanelWidget, private Ui::QgsRuleB
   private:
     QgsVectorLayer *mLayer = nullptr;
 
-    QgsRuleBased3DRenderer::Rule *mRootRule = nullptr;
+    std::unique_ptr<QgsRuleBased3DRenderer::Rule> mRootRule = nullptr;
     QObjectUniquePtr<QgsRuleBased3DRendererModel> mModel = nullptr;
 
     QAction *mCopyAction = nullptr;

--- a/src/app/3d/qgsrulebased3drendererwidget.h
+++ b/src/app/3d/qgsrulebased3drendererwidget.h
@@ -22,6 +22,7 @@
 
 #include "qgspanelwidget.h"
 #include "qgsrulebased3drenderer.h"
+#include "qobjectuniqueptr.h"
 
 #include <QWidget>
 
@@ -111,7 +112,7 @@ class QgsRuleBased3DRendererWidget : public QgsPanelWidget, private Ui::QgsRuleB
     QgsVectorLayer *mLayer = nullptr;
 
     QgsRuleBased3DRenderer::Rule *mRootRule = nullptr;
-    QgsRuleBased3DRendererModel *mModel = nullptr;
+    QObjectUniquePtr<QgsRuleBased3DRendererModel> mModel = nullptr;
 
     QAction *mCopyAction = nullptr;
     QAction *mPasteAction = nullptr;


### PR DESCRIPTION
## Description

`QgsRuleBased3DRendererWidget::setLayer` recreates a new root rule and a new model on each call without deleting the previous ones. Fix those leaks by using `std::unique_ptr` and `QObjectUniquePtr`.

**Funded by Stadt Frankfurt am Main and Oslandia**