### PR TITLE
Fix model designer view shifts by a pixel whenever changes are made

### DIFF
--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -511,13 +511,10 @@ void QgsModelGraphicsView::friendlySetSceneRect()
 
   QRectF modelSceneRect = modelScene()->sceneRect();
   QRectF viewSceneRect = sceneRect();
-
-  QRectF visibleRect = mapToScene( viewport()->rect() ).boundingRect();
-
-  viewSceneRect.setLeft( std::min( modelSceneRect.left(), visibleRect.left() ) );
-  viewSceneRect.setRight( std::max( modelSceneRect.right(), visibleRect.right() ) );
-  viewSceneRect.setTop( std::min( modelSceneRect.top(), visibleRect.top() ) );
-  viewSceneRect.setBottom( std::max( modelSceneRect.bottom(), visibleRect.bottom() ) );
+  viewSceneRect.setLeft( std::min( modelSceneRect.left(), viewSceneRect.left() ) );
+  viewSceneRect.setRight( std::max( modelSceneRect.right(), viewSceneRect.right() ) );
+  viewSceneRect.setTop( std::min( modelSceneRect.top(), viewSceneRect.top() ) );
+  viewSceneRect.setBottom( std::max( modelSceneRect.bottom(), viewSceneRect.bottom() ) );
 
   mBlockScrollbarSignals++;
   setSceneRect( viewSceneRect );

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -511,10 +511,13 @@ void QgsModelGraphicsView::friendlySetSceneRect()
 
   QRectF modelSceneRect = modelScene()->sceneRect();
   QRectF viewSceneRect = sceneRect();
-  viewSceneRect.setLeft( std::min( modelSceneRect.left(), viewSceneRect.left() ) );
-  viewSceneRect.setRight( std::max( modelSceneRect.right(), viewSceneRect.right() ) );
-  viewSceneRect.setTop( std::min( modelSceneRect.top(), viewSceneRect.top() ) );
-  viewSceneRect.setBottom( std::max( modelSceneRect.bottom(), viewSceneRect.bottom() ) );
+
+  QRectF visibleRect = mapToScene( viewport()->rect() ).boundingRect();
+
+  viewSceneRect.setLeft( std::min( modelSceneRect.left(), visibleRect.left() ) );
+  viewSceneRect.setRight( std::max( modelSceneRect.right(), visibleRect.right() ) );
+  viewSceneRect.setTop( std::min( modelSceneRect.top(), visibleRect.top() ) );
+  viewSceneRect.setBottom( std::max( modelSceneRect.bottom(), visibleRect.bottom() ) );
 
   mBlockScrollbarSignals++;
   setSceneRect( viewSceneRect );


### PR DESCRIPTION
Followup https://github.com/qgis/QGIS/pull/61793

QGraphicsView::sceneRect() gives us the visible area of the scene in the view already, so we don't need to go through the `mapToScene( viewport()->rect() )` pathway to get this. That pathway was resulting in small rounding issues which caused the scene to shift by a pixel each time the model was changed.

(Note that previously we were retrieving sceneRect() but doing nothing with it)