### PR TITLE
[browser] Add a generic Rename Vector Table action for supported providers

### DIFF
--- a/python/PyQt6/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsdataitem.sip.in
@@ -123,6 +123,26 @@ Create children. Children are not expected to have parent set.
     }
 %End
 
+    int creatorAncestorDepth() const;
+%Docstring
+Returns the hierarchical depth of the item's original creator/source.
+
+This value represents the depth of the item that this object was created
+from. For example, a return value of 1 indicates that the item was
+created by its direct parent. A return value of 2 would indicate it was
+created by its grandparent, etc.
+
+A value of 0 indicates an unknown source, or an item which has not yet
+been added to the hierarchy.
+
+This value indicates the ancestor which must be refreshed in order to
+regenerate an item representing the same object as this item refers to.
+
+.. seealso:: :py:func:`ancestorAtDepth`
+
+.. versionadded:: 4.0
+%End
+
     Qgis::BrowserItemState state() const;
 
     virtual void setState( Qgis::BrowserItemState state );

--- a/python/PyQt6/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsdataitem.sip.in
@@ -463,6 +463,7 @@ Ownership of the returned objects is transferred to the caller.
 .. versionadded:: 3.16
 %End
 
+
   protected:
     virtual void populate( const QVector<QgsDataItem *> &children );
 

--- a/python/PyQt6/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsdataitem.sip.in
@@ -335,6 +335,19 @@ Gets item parent. QgsDataItem maintains its own items hierarchy, it does
 not use QObject hierarchy.
 %End
 
+    QgsDataItem *ancestorAtDepth( int depth ) const;
+%Docstring
+Returns the ancestor item at the specified ``depth``.
+
+If ``depth`` is 1 then this method returns the
+:py:func:`~QgsDataItem.parent` item. A ``depth`` of 2 would return its
+grandparent (e.g. the parent's parent item).
+
+Returns ``None`` if no item exists at the specified depth.
+
+.. versionadded:: 4.0
+%End
+
     void setParent( QgsDataItem *parent );
 %Docstring
 Set item parent and connect / disconnect parent to / from item signals.

--- a/python/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdataitem.sip.in
@@ -123,6 +123,26 @@ Create children. Children are not expected to have parent set.
     }
 %End
 
+    int creatorAncestorDepth() const;
+%Docstring
+Returns the hierarchical depth of the item's original creator/source.
+
+This value represents the depth of the item that this object was created
+from. For example, a return value of 1 indicates that the item was
+created by its direct parent. A return value of 2 would indicate it was
+created by its grandparent, etc.
+
+A value of 0 indicates an unknown source, or an item which has not yet
+been added to the hierarchy.
+
+This value indicates the ancestor which must be refreshed in order to
+regenerate an item representing the same object as this item refers to.
+
+.. seealso:: :py:func:`ancestorAtDepth`
+
+.. versionadded:: 4.0
+%End
+
     Qgis::BrowserItemState state() const;
 
     virtual void setState( Qgis::BrowserItemState state );

--- a/python/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdataitem.sip.in
@@ -463,6 +463,7 @@ Ownership of the returned objects is transferred to the caller.
 .. versionadded:: 3.16
 %End
 
+
   protected:
     virtual void populate( const QVector<QgsDataItem *> &children );
 

--- a/python/core/auto_generated/browser/qgsdataitem.sip.in
+++ b/python/core/auto_generated/browser/qgsdataitem.sip.in
@@ -335,6 +335,19 @@ Gets item parent. QgsDataItem maintains its own items hierarchy, it does
 not use QObject hierarchy.
 %End
 
+    QgsDataItem *ancestorAtDepth( int depth ) const;
+%Docstring
+Returns the ancestor item at the specified ``depth``.
+
+If ``depth`` is 1 then this method returns the
+:py:func:`~QgsDataItem.parent` item. A ``depth`` of 2 would return its
+grandparent (e.g. the parent's parent item).
+
+Returns ``None`` if no item exists at the specified depth.
+
+.. versionadded:: 4.0
+%End
+
     void setParent( QgsDataItem *parent );
 %Docstring
 Set item parent and connect / disconnect parent to / from item signals.

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1883,7 +1883,7 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
 
           std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn2( qgis::down_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( connectionUri, QVariantMap() ) ) );
 
-          QgsNewNameDialog dlg( tr( "Table %2.%3" ).arg( schema, tableName ), tableName );
+          QgsNewNameDialog dlg( tr( "Table %1.%2" ).arg( schema, tableName ), tableName );
           dlg.setWindowTitle( tr( "Rename Table" ) );
           if ( dlg.exec() != QDialog::Accepted || dlg.name() == tableName )
             return;

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1856,7 +1856,72 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
     }
 
     // Move to schema should not be available for connections and schemata
-    const bool isTable = qobject_cast<QgsLayerItem *>( item );
+    QgsLayerItem *layerItem = qobject_cast<QgsLayerItem *>( item );
+    const bool isTable = static_cast< bool >( layerItem );
+    if ( selectedItems.size() == 1 && layerItem && layerItem->mapLayerType() == Qgis::LayerType::Vector && conn && conn->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::RenameVectorTable ) )
+    {
+      // some providers implement their own Rename Table action, with provider-specific logic.
+      // Until we can make the generic method flexible enough to handle that logic, hide the generic
+      // action from these providers so we don't get two different Rename actions.
+
+      const bool providerImplementsRename = layerItem->providerKey() == "postgresraster"_L1 || layerItem->providerKey() == u"postgres"_s
+                                            || qobject_cast< QgsGeoPackageVectorLayerItem * >( layerItem );
+      if ( !providerImplementsRename )
+      {
+        QAction *renameTableAction = new QAction( tr( "Rename Table…" ), menu );
+        const QString connectionUri = conn->uri();
+        const QString providerKey = conn->providerKey();
+        const QString schema = item->parent()->name();
+        const QString tableName = item->name();
+
+        QPointer< QgsLayerItem > layerItem( qobject_cast<QgsLayerItem *>( item ) );
+
+        connect( renameTableAction, &QAction::triggered, renameTableAction, [providerKey, connectionUri, schema, tableName, context, layerItem = std::move( layerItem )] {
+          QgsProviderMetadata *md { QgsProviderRegistry::instance()->providerMetadata( providerKey ) };
+          if ( !md )
+            return;
+
+          std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn2( qgis::down_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( connectionUri, QVariantMap() ) ) );
+
+          QgsNewNameDialog dlg( tr( "Table %2.%3" ).arg( schema, tableName ), tableName );
+          dlg.setWindowTitle( tr( "Rename Table" ) );
+          if ( dlg.exec() != QDialog::Accepted || dlg.name() == tableName )
+            return;
+
+          QString errCause;
+          try
+          {
+            conn2->renameVectorTable( schema, tableName, dlg.name() );
+          }
+          catch ( QgsProviderConnectionException &ex )
+          {
+            errCause = ex.what();
+          }
+
+          if ( !errCause.isEmpty() )
+          {
+            notify( tr( "Cannot rename table" ), errCause, context, Qgis::MessageLevel::Critical );
+          }
+          else if ( context.messageBar() )
+          {
+            context.messageBar()->pushMessage( tr( "Renamed table to %1" ).arg( dlg.name() ), Qgis::MessageLevel::Success );
+          }
+
+          if ( layerItem )
+          {
+            // it's not always the direct parent responsible for creating layer items -- ensure we refresh
+            // the correct ancestor to get the newly renamed table showing
+            if ( QgsDataItem *itemToRefresh = layerItem->ancestorAtDepth( layerItem->creatorAncestorDepth() ) )
+            {
+              itemToRefresh->refresh();
+            }
+          }
+        } );
+
+        QgsDataItemGuiProviderUtils::addToSubMenu( menu, renameTableAction, tr( "Manage" ) );
+      }
+    }
+
     if ( isTable && conn && conn->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::MoveTableToSchema ) )
     {
       const QString connectionUri = conn->uri();

--- a/src/core/browser/qgsdataitem.cpp
+++ b/src/core/browser/qgsdataitem.cpp
@@ -190,6 +190,11 @@ QVector<QgsDataItem *> QgsDataItem::createChildren()
   return QVector<QgsDataItem *>();
 }
 
+int QgsDataItem::creatorAncestorDepth() const
+{
+  return mCreatorAncestorDepth;
+}
+
 void QgsDataItem::populate( bool foreground )
 {
   if ( state() == Qgis::BrowserItemState::Populated || state() == Qgis::BrowserItemState::Populating )
@@ -268,10 +273,22 @@ void QgsDataItem::populate( const QVector<QgsDataItem *> &children )
 {
   QgsDebugMsgLevel( "mPath = " + mPath, 3 );
 
+  std::function< void( QgsDataItem *, int ) > setChildAncestorDepthRecursive;
+  setChildAncestorDepthRecursive = [&setChildAncestorDepthRecursive]( QgsDataItem * child, int depth )
+  {
+    child->mCreatorAncestorDepth = depth;
+    const QVector< QgsDataItem * > children = child->children();
+    for ( QgsDataItem *nextChild : children )
+    {
+      setChildAncestorDepthRecursive( nextChild, depth + 1 );
+    }
+  };
+
   for ( QgsDataItem *child : children )
   {
     if ( !child ) // should not happen
       continue;
+    setChildAncestorDepthRecursive( child, 1 );
     // update after thread finished -> refresh
     addChildItem( child, true );
   }

--- a/src/core/browser/qgsdataitem.cpp
+++ b/src/core/browser/qgsdataitem.cpp
@@ -499,6 +499,20 @@ int QgsDataItem::findItem( QVector<QgsDataItem *> items, QgsDataItem *item )
   return -1;
 }
 
+QgsDataItem *QgsDataItem::ancestorAtDepth( int depth ) const
+{
+  if ( depth < 0 )
+    return nullptr;
+
+  QgsDataItem *result = const_cast< QgsDataItem * >( this );
+  while ( result && depth > 0 )
+  {
+    depth--;
+    result = result->parent();
+  }
+  return result;
+}
+
 bool QgsDataItem::equal( const QgsDataItem *other )
 {
   return ( metaObject()->className() == other->metaObject()->className() &&

--- a/src/core/browser/qgsdataitem.h
+++ b/src/core/browser/qgsdataitem.h
@@ -472,6 +472,13 @@ class CORE_EXPORT QgsDataItem : public QObject
      */
     virtual QgsAbstractDatabaseProviderConnection *databaseConnection() const SIP_FACTORY;
 
+    // TODO should be private, but MSSQL data item provider is badly behaved and needs to
+    // manually manipulate this!
+    /**
+     * Creator ancestor depth.
+     */
+    SIP_SKIP int mCreatorAncestorDepth = 0;
+
   protected:
     virtual void populate( const QVector<QgsDataItem *> &children );
 
@@ -623,8 +630,6 @@ class CORE_EXPORT QgsDataItem : public QObject
     // Set to true if object has to be deleted when possible (nothing running in threads)
     bool mDeferredDelete = false;
     std::unique_ptr<QFutureWatcher<QVector<QgsDataItem *> >> mFutureWatcher;
-
-    int mCreatorAncestorDepth = 0;
 
     // number of items currently in loading (populating) state
     static QgsAnimatedIcon *sPopulatingIcon;

--- a/src/core/browser/qgsdataitem.h
+++ b/src/core/browser/qgsdataitem.h
@@ -350,6 +350,18 @@ class CORE_EXPORT QgsDataItem : public QObject
     QgsDataItem *parent() const { return mParent; }
 
     /**
+     * Returns the ancestor item at the specified \a depth.
+     *
+     * If \a depth is 1 then this method returns the parent() item. A \a depth
+     * of 2 would return its grandparent (e.g. the parent's parent item).
+     *
+     * Returns NULLPTR if no item exists at the specified depth.
+     *
+     * \since QGIS 4.0
+     */
+    QgsDataItem *ancestorAtDepth( int depth ) const;
+
+    /**
      * Set item parent and connect / disconnect parent to / from item signals.
      * It does not add itself to parents children (mChildren)
     */

--- a/src/core/browser/qgsdataitem.h
+++ b/src/core/browser/qgsdataitem.h
@@ -147,6 +147,25 @@ class CORE_EXPORT QgsDataItem : public QObject
     SIP_END
 #endif
 
+    /**
+     * Returns the hierarchical depth of the item's original creator/source.
+     *
+     * This value represents the depth of the item that this object was created
+     * from. For example, a return value of 1 indicates that the item was created by its
+     * direct parent. A return value of 2 would indicate it was created by its
+     * grandparent, etc.
+     *
+     * A value of 0 indicates an unknown source, or an item which has not yet
+     * been added to the hierarchy.
+     *
+     * This value indicates the ancestor which must be refreshed in order to
+     * regenerate an item representing the same object as this item refers to.
+     *
+     * \see ancestorAtDepth()
+     * \since QGIS 4.0
+     */
+    int creatorAncestorDepth() const;
+
     Qgis::BrowserItemState state() const;
 
     /**
@@ -604,6 +623,9 @@ class CORE_EXPORT QgsDataItem : public QObject
     // Set to true if object has to be deleted when possible (nothing running in threads)
     bool mDeferredDelete = false;
     std::unique_ptr<QFutureWatcher<QVector<QgsDataItem *> >> mFutureWatcher;
+
+    int mCreatorAncestorDepth = 0;
+
     // number of items currently in loading (populating) state
     static QgsAnimatedIcon *sPopulatingIcon;
 };

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -56,8 +56,6 @@ void QgsGeoPackageItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu
     // (We only show the rename action when the user has a single layer selected -- it doesn't work on multi-layers at once)
     if ( selectedItems.size() == 1 && layerItem->capabilities2() & Qgis::BrowserItemCapability::Rename )
     {
-      QMenu *manageLayerMenu = new QMenu( tr( "Manage" ), menu );
-
       QAction *actionRenameLayer = new QAction( tr( "Rename Layer “%1”…" ).arg( layerItem->name() ), menu );
       const QString uri = layerItem->uri();
       const QString providerKey = layerItem->providerKey();
@@ -66,9 +64,8 @@ void QgsGeoPackageItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu
       connect( actionRenameLayer, &QAction::triggered, this, [this, uri, providerKey, tableNames, itemPointer, context] {
         renameVectorLayer( uri, providerKey, tableNames, itemPointer, context );
       } );
-      manageLayerMenu->addAction( actionRenameLayer );
 
-      menu->addMenu( manageLayerMenu );
+      QgsDataItemGuiProviderUtils::addToSubMenu( menu, actionRenameLayer, tr( "Manage" ) );
     }
   }
 

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -110,21 +110,6 @@ void QgsHanaDataItemGuiProvider::populateContextMenu(
 
     menu->addMenu( maintainMenu );
   }
-
-  if ( QgsHanaLayerItem *layerItem = qobject_cast<QgsHanaLayerItem *>( item ) )
-  {
-    const QgsHanaLayerProperty &layerInfo = layerItem->layerInfo();
-    if ( !layerInfo.isView )
-    {
-      QMenu *maintainMenu = new QMenu( tr( "Table Operations" ), menu );
-
-      QAction *actionRenameLayer = new QAction( tr( "Rename Table…" ), this );
-      connect( actionRenameLayer, &QAction::triggered, this, [layerItem, context] { renameLayer( layerItem, context ); } );
-      maintainMenu->addAction( actionRenameLayer );
-
-      menu->addMenu( maintainMenu );
-    }
-  }
 }
 
 bool QgsHanaDataItemGuiProvider::deleteLayer( QgsLayerItem *item, QgsDataItemGuiContext context )
@@ -365,39 +350,6 @@ void QgsHanaDataItemGuiProvider::renameSchema( QgsHanaSchemaItem *schemaItem, Qg
   else
   {
     notify( caption, tr( "Unable to rename schema '%1'\n%2" ).arg( schemaName, errorMsg ), context, Qgis::MessageLevel::Warning );
-  }
-}
-
-void QgsHanaDataItemGuiProvider::renameLayer( QgsHanaLayerItem *layerItem, QgsDataItemGuiContext context )
-{
-  const QgsHanaLayerProperty &layerInfo = layerItem->layerInfo();
-  const QString caption = tr( "Rename Table" );
-  QgsNewNameDialog dlg( tr( "table '%1.%2'" ).arg( layerInfo.schemaName, layerInfo.tableName ), layerInfo.tableName );
-  dlg.setWindowTitle( caption );
-  if ( dlg.exec() != QDialog::Accepted || dlg.name() == layerInfo.tableName )
-    return;
-
-  const QString newLayerName = dlg.name();
-  QString errorMsg;
-  try
-  {
-    const QgsHanaProviderConnection providerConn( layerItem->uri(), {} );
-    providerConn.renameVectorTable( layerInfo.schemaName, layerInfo.tableName, newLayerName );
-  }
-  catch ( const QgsProviderConnectionException &ex )
-  {
-    errorMsg = ex.what();
-  }
-
-  if ( errorMsg.isEmpty() )
-  {
-    notify( caption, tr( "'%1' renamed successfully to '%2'." ).arg( layerInfo.tableName, newLayerName ), context, Qgis::MessageLevel::Success );
-    if ( layerItem->parent() )
-      layerItem->parent()->refresh();
-  }
-  else
-  {
-    notify( caption, tr( "Unable to rename '%1'\n%2" ).arg( layerInfo.tableName, errorMsg ), context, Qgis::MessageLevel::Warning );
   }
 }
 

--- a/src/providers/hana/qgshanadataitemguiprovider.h
+++ b/src/providers/hana/qgshanadataitemguiprovider.h
@@ -47,7 +47,6 @@ class QgsHanaDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void createSchema( QgsDataItem *item, QgsDataItemGuiContext context );
     static void deleteSchema( QgsHanaSchemaItem *schemaItem, QgsDataItemGuiContext context );
     static void renameSchema( QgsHanaSchemaItem *schemaItem, QgsDataItemGuiContext context );
-    static void renameLayer( QgsHanaLayerItem *layerItem, QgsDataItemGuiContext context );
 
     bool handleDrop( QgsHanaConnectionItem *connectionItem, const QMimeData *data, const QString &toSchema, QgsDataItemGuiContext context );
     bool handleDropUri( QgsHanaConnectionItem *connectionItem, const QgsMimeDataUtils::Uri &sourceUri, const QString &toSchema, QgsDataItemGuiContext context );

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -303,6 +303,11 @@ QVector<QgsDataItem *> QgsMssqlConnectionItem::createChildren()
     setAsPopulated();
   }
 
+  for ( QgsDataItem *child : std::as_const( children ) )
+  {
+    setChildAncestorDepthRecursive( child, 1 );
+  }
+
   return children;
 }
 
@@ -314,6 +319,16 @@ void QgsMssqlConnectionItem::setAsPopulated()
     child->setState( Qgis::BrowserItemState::Populated );
   }
   setState( Qgis::BrowserItemState::Populated );
+}
+
+void QgsMssqlConnectionItem::setChildAncestorDepthRecursive( QgsDataItem *child, int depth )
+{
+  child->mCreatorAncestorDepth = depth;
+  const QVector< QgsDataItem * > children = child->children();
+  for ( QgsDataItem *nextChild : children )
+  {
+    setChildAncestorDepthRecursive( nextChild, depth + 1 );
+  }
 }
 
 void QgsMssqlConnectionItem::setAllowGeometrylessTables( const bool allow )
@@ -506,6 +521,7 @@ QgsMssqlLayerItem *QgsMssqlSchemaItem::addLayer( const QgsMssqlLayerProperty &la
 
   QgsMssqlLayerItem *layerItem = new QgsMssqlLayerItem( this, layerProperty.tableName, mPath + '/' + layerProperty.tableName, layerType, layerProperty );
   layerItem->setToolTip( tip );
+  layerItem->mCreatorAncestorDepth = 2;
   if ( refresh )
     addChildItem( layerItem, true );
   else

--- a/src/providers/mssql/qgsmssqldataitems.h
+++ b/src/providers/mssql/qgsmssqldataitems.h
@@ -85,6 +85,7 @@ class QgsMssqlConnectionItem : public QgsDataCollectionItem
     void setAsPopulated();
 
   private:
+    void setChildAncestorDepthRecursive( QgsDataItem *child, int depth );
     QString mConnectionUri;
     QString mService;
     QString mHost;

--- a/tests/src/python/test_qgsdataitem.py
+++ b/tests/src/python/test_qgsdataitem.py
@@ -76,6 +76,15 @@ class TestQgsDataItem(QgisTestCase):
         greatgrandchild = grandchild2.children()[0]
         self.assertEqual([c.name() for c in child2.children()], ["grandchild3"])
 
+        # test ancestor methods
+        self.assertEqual(root_item.creatorAncestorDepth(), 0)
+        self.assertEqual(child1.creatorAncestorDepth(), 1)
+        self.assertEqual(child2.creatorAncestorDepth(), 1)
+        self.assertEqual(child3.creatorAncestorDepth(), 1)
+        self.assertEqual(grandchild1.creatorAncestorDepth(), 2)
+        self.assertEqual(grandchild2.creatorAncestorDepth(), 2)
+        self.assertEqual(greatgrandchild.creatorAncestorDepth(), 3)
+
         self.assertEqual(root_item.ancestorAtDepth(-1), None)
         self.assertEqual(root_item.ancestorAtDepth(0), root_item)
         self.assertEqual(root_item.ancestorAtDepth(1), None)

--- a/tests/src/python/test_qgsdataitem.py
+++ b/tests/src/python/test_qgsdataitem.py
@@ -13,7 +13,7 @@ __copyright__ = "Copyright 2020, The QGIS Project"
 
 import os
 
-from qgis.core import QgsDataCollectionItem, QgsDirectoryItem
+from qgis.core import QgsDataCollectionItem, QgsDirectoryItem, QgsDataItem, Qgis
 import unittest
 from qgis.testing import start_app, QgisTestCase
 
@@ -22,7 +22,97 @@ from utilities import unitTestDataPath
 app = start_app()
 
 
+class DummyDataItem(QgsDataItem):
+
+    def __init__(self):
+        QgsDataItem.__init__(self, Qgis.BrowserItemType.Custom, None, "dummy", "dummy")
+        self.setCapabilities(
+            Qgis.BrowserItemCapability.Fast | Qgis.BrowserItemCapability.Fertile
+        )
+
+    def createChildren(self):
+        child1 = QgsDataItem(Qgis.BrowserItemType.Custom, None, "child1", "child1")
+        child1.addChildItem(
+            QgsDataItem(Qgis.BrowserItemType.Custom, None, "grandchild1", "grandchild1")
+        )
+        grandchild2 = QgsDataItem(
+            Qgis.BrowserItemType.Custom, None, "grandchild2", "grandchild2"
+        )
+        grandchild2.addChildItem(
+            QgsDataItem(
+                Qgis.BrowserItemType.Custom,
+                None,
+                "greatgrandchild1",
+                "greatgrandchild1",
+            )
+        )
+        child1.addChildItem(grandchild2)
+        child2 = QgsDataItem(Qgis.BrowserItemType.Custom, None, "child2", "child2")
+        child2.addChildItem(
+            QgsDataItem(Qgis.BrowserItemType.Custom, None, "grandchild3", "grandchild3")
+        )
+        child3 = QgsDataItem(Qgis.BrowserItemType.Custom, None, "child3", "child3")
+
+        return [child1, child2, child3]
+
+
 class TestQgsDataItem(QgisTestCase):
+
+    def test_ancestors(self):
+        root_item = DummyDataItem()
+        root_item.populate()
+        # check that item is fully populated
+        self.assertEqual(
+            [c.name() for c in root_item.children()], ["child1", "child2", "child3"]
+        )
+        child1, child2, child3 = root_item.children()
+        self.assertEqual(
+            [c.name() for c in child1.children()], ["grandchild1", "grandchild2"]
+        )
+        grandchild1, grandchild2 = child1.children()
+        self.assertEqual(
+            [c.name() for c in grandchild2.children()], ["greatgrandchild1"]
+        )
+        greatgrandchild = grandchild2.children()[0]
+        self.assertEqual([c.name() for c in child2.children()], ["grandchild3"])
+
+        self.assertEqual(root_item.ancestorAtDepth(-1), None)
+        self.assertEqual(root_item.ancestorAtDepth(0), root_item)
+        self.assertEqual(root_item.ancestorAtDepth(1), None)
+
+        self.assertEqual(child1.ancestorAtDepth(-1), None)
+        self.assertEqual(child1.ancestorAtDepth(0), child1)
+        self.assertEqual(child1.ancestorAtDepth(1), root_item)
+        self.assertEqual(child1.ancestorAtDepth(2), None)
+
+        self.assertEqual(child2.ancestorAtDepth(-1), None)
+        self.assertEqual(child2.ancestorAtDepth(0), child2)
+        self.assertEqual(child2.ancestorAtDepth(1), root_item)
+        self.assertEqual(child2.ancestorAtDepth(2), None)
+
+        self.assertEqual(child3.ancestorAtDepth(-1), None)
+        self.assertEqual(child3.ancestorAtDepth(0), child3)
+        self.assertEqual(child3.ancestorAtDepth(1), root_item)
+        self.assertEqual(child3.ancestorAtDepth(2), None)
+
+        self.assertEqual(grandchild1.ancestorAtDepth(-1), None)
+        self.assertEqual(grandchild1.ancestorAtDepth(0), grandchild1)
+        self.assertEqual(grandchild1.ancestorAtDepth(1), child1)
+        self.assertEqual(grandchild1.ancestorAtDepth(2), root_item)
+        self.assertEqual(grandchild1.ancestorAtDepth(3), None)
+
+        self.assertEqual(grandchild2.ancestorAtDepth(-1), None)
+        self.assertEqual(grandchild2.ancestorAtDepth(0), grandchild2)
+        self.assertEqual(grandchild2.ancestorAtDepth(1), child1)
+        self.assertEqual(grandchild2.ancestorAtDepth(2), root_item)
+        self.assertEqual(grandchild2.ancestorAtDepth(3), None)
+
+        self.assertEqual(greatgrandchild.ancestorAtDepth(-1), None)
+        self.assertEqual(greatgrandchild.ancestorAtDepth(0), greatgrandchild)
+        self.assertEqual(greatgrandchild.ancestorAtDepth(1), grandchild2)
+        self.assertEqual(greatgrandchild.ancestorAtDepth(2), child1)
+        self.assertEqual(greatgrandchild.ancestorAtDepth(3), root_item)
+        self.assertEqual(greatgrandchild.ancestorAtDepth(4), None)
 
     def test_databaseConnection(self):
 


### PR DESCRIPTION
Alternative to https://github.com/qgis/QGIS/pull/64552.

Adds required API so that the correct parent item is refreshed after a rename, in order to correctly re-populate mssql connections with the updated table names. Also adds manual blocklisting of providers which would otherwise show duplicate Rename actions, due to provider-specific logic living in their existing Rename Table actions.

Sponsored by City of Canning

