### PR TITLE
Add maptool Circle from 2 Points and Radius.

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -794,6 +794,7 @@
         <file>themes/default/mActionLockExtent.svg</file>
         <file>themes/default/mGeoPackage.svg</file>
         <file>themes/default/mActionCircle2Points.svg</file>
+        <file>themes/default/mActionCircle2PointsRadius.svg</file>
         <file>themes/default/mActionCircle3Points.svg</file>
         <file>themes/default/mActionCircleCenterPoint.svg</file>
         <file>themes/default/mActionEllipseFoci.svg</file>

--- a/images/themes/default/mActionCircle2PointsRadius.svg
+++ b/images/themes/default/mActionCircle2PointsRadius.svg
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="mActionCircle2PointsRadius.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="48.291667"
+     inkscape:cx="11.989646"
+     inkscape:cy="12"
+     inkscape:window-width="3440"
+     inkscape:window-height="1368"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <g
+     id="g6">
+    <circle
+       cx="10"
+       cy="11"
+       fill="none"
+       r="7.430634"
+       stroke="#8cbe8c"
+       stroke-width="3.138732"
+       id="circle1" />
+    <g
+       transform="translate(33)"
+       id="g3">
+      <rect
+         fill="#c4a000"
+         height="11"
+         rx="2.01149"
+         width="11"
+         x="-20"
+         y="13"
+         id="rect1" />
+      <g
+         fill="#fcffff"
+         id="g2">
+        <path
+           d="m-15 14v2.0625c-.537663.111041-1.024662.383291-1.375.78125l-1.78125-1.03125-.5.875 1.78125 1.03125c-.082063.247432-.125.506395-.125.78125s.04294.533818.125.78125l-1.78125 1.03125.5.875 1.78125-1.03125c.352503.40042.832682.670182 1.375.78125v2.0625h1v-2.0625c.537663-.111041 1.024662-.383291 1.375-.78125l1.78125 1.03125.5-.875-1.78125-1.03125c.082063-.247432.125-.506395.125-.78125s-.04294-.533818-.125-.78125l1.78125-1.03125-.5-.875-1.78125 1.03125c-.352503-.40042-.832682-.670182-1.375-.78125v-2.0625zm.5 3.5c.552 0 1 .448 1 1s-.448 1-1 1-1-.448-1-1 .448-1 1-1z"
+           id="path1" />
+        <path
+           d="m-19 19 9-.0096s0 0 0-2c0-2.9904-1-2.9904-4.5-2.9904s-4.5 0-4.5 3z"
+           fill-rule="evenodd"
+           opacity=".3"
+           id="path2" />
+      </g>
+    </g>
+    <g
+       id="g5">
+      <path
+         d="m 11.986982,2.8097134 h 3 v 3 h -3 z"
+         id="path3"
+         style="fill:#bebebe;stroke:#8c8c8c" />
+      <g
+         id="g4">
+        <path
+           d="M 13.718384,4.7869155 9.681776,11.557767"
+           fill="none"
+           stroke-width="2.79394"
+           id="path4-1-3"
+           style="stroke:#8c8c8c" />
+        <path
+           d="M 4.9221745,5.4990019 9.9616651,11.560534"
+           fill="none"
+           stroke-width="2.79394"
+           id="path4-1"
+           style="stroke:#8c8c8c" />
+      </g>
+      <path
+         d="m 3.5413155,3.6596306 h 3 v 3 h -3 z"
+         id="path4"
+         style="fill:#bebebe;stroke:#8c8c8c" />
+    </g>
+  </g>
+</svg>

--- a/python/PyQt6/core/auto_additions/qgscircle.py
+++ b/python/PyQt6/core/auto_additions/qgscircle.py
@@ -4,6 +4,7 @@ try:
     QgsCircle.from3Points = staticmethod(QgsCircle.from3Points)
     QgsCircle.fromCenterDiameter = staticmethod(QgsCircle.fromCenterDiameter)
     QgsCircle.fromCenterPoint = staticmethod(QgsCircle.fromCenterPoint)
+    QgsCircle.from2PointsRadius = staticmethod(QgsCircle.from2PointsRadius)
     QgsCircle.from3Tangents = staticmethod(QgsCircle.from3Tangents)
     QgsCircle.from3TangentsMulti = staticmethod(QgsCircle.from3TangentsMulti)
     QgsCircle.fromExtent = staticmethod(QgsCircle.fromExtent)

--- a/python/PyQt6/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgscircle.sip.in
@@ -90,6 +90,33 @@ between ``center`` and ``pt1``.
 :param pt1: A point on the circle.
 %End
 
+    static QVector<QgsCircle> from2PointsRadius( const QgsPoint &pt1, const QgsPoint &pt2, double radius, const QgsPoint &pos = QgsPoint() ) /HoldGIL/;
+%Docstring
+Constructs circles passing through 2 points with a given ``radius``.
+
+This method returns 0, 1 or 2 circles depending on the geometric
+configuration:
+
+- 0 circles: if the radius is smaller than half the distance between the
+  points
+- 1 circle: if the radius equals half the distance (diameter case)
+- 2 circles: if the radius is larger than half the distance
+
+When ``pos`` is specified and valid, only the circle whose center is
+closest to ``pos`` is returned.
+
+Z and M values are transferred from the input points to the circle
+center. The azimuth always takes the default value.
+
+:param pt1: First point on the circle.
+:param pt2: Second point on the circle.
+:param radius: The radius of the circle (must be positive).
+:param pos: Optional point to select the nearest circle center.
+
+:return: Vector containing 0, 1 or 2 circles.
+
+.. versionadded:: 4.0
+%End
 
     static QgsCircle from3Tangents( const QgsPoint &pt1_tg1, const QgsPoint &pt2_tg1, const QgsPoint &pt1_tg2, const QgsPoint &pt2_tg2, const QgsPoint &pt1_tg3, const QgsPoint &pt2_tg3, double epsilon = 1E-8, const QgsPoint &pos = QgsPoint() ) /HoldGIL/;
 %Docstring

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -239,6 +239,7 @@ set(QGIS_APP_SRCS
   maptools/qgsmaptoolshaperegularpolygonabstract.cpp
 
   maptools/qgsmaptoolshapecircle2points.cpp
+  maptools/qgsmaptoolshapecircle2pointsradius.cpp
   maptools/qgsmaptoolshapecircle2tangentspoint.cpp
   maptools/qgsmaptoolshapecircle3points.cpp
   maptools/qgsmaptoolshapecircle3tangents.cpp

--- a/src/app/maptools/qgsmaptoolshapecircle2pointsradius.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircle2pointsradius.cpp
@@ -21,6 +21,7 @@
 #include "qgsdoublespinbox.h"
 #include "qgsgeometryrubberband.h"
 #include "qgslinestring.h"
+#include "qgsmapcanvas.h"
 #include "qgsmapmouseevent.h"
 #include "qgsmaptoolcapture.h"
 #include "qgsmessagebar.h"
@@ -286,8 +287,24 @@ void QgsMapToolShapeCircle2PointsRadius::createRadiusSpinBox()
   }
   else
   {
-    mRadiusSpinBox->setValue( 1.0 );
-    mRadius = 1.0;
+    // Default radius: half of the smallest canvas dimension, rounded to lower multiple of 10
+    QgsMapCanvas *canvas = mParentTool->canvas();
+    const QgsRectangle extent = canvas->extent();
+    double defaultRadius = std::min( extent.width(), extent.height() ) / 2.0;
+
+    if ( defaultRadius >= 10.0 )
+    {
+      // Round down to nearest multiple of 10
+      defaultRadius = std::floor( defaultRadius / 10.0 ) * 10.0;
+    }
+    else
+    {
+      // Between 0 and 10: round to nearest integer, minimum 1
+      defaultRadius = std::max( 1.0, std::round( defaultRadius ) );
+    }
+
+    mRadiusSpinBox->setValue( defaultRadius );
+    mRadius = defaultRadius;
   }
   QgisApp::instance()->addUserInputWidget( mRadiusSpinBox );
   mRadiusSpinBox->setFocus( Qt::TabFocusReason );

--- a/src/app/maptools/qgsmaptoolshapecircle2pointsradius.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircle2pointsradius.cpp
@@ -349,6 +349,7 @@ void QgsMapToolShapeCircle2PointsRadius::clean()
   mCenters.clear();
   deleteSegmentRubberBand();
   deleteRadiusSpinBox();
+  mRadius = 0.0; // Reset to recalculate default based on current canvas extent
   QgsMapToolShapeCircleAbstract::clean();
 }
 

--- a/src/app/maptools/qgsmaptoolshapecircle2pointsradius.cpp
+++ b/src/app/maptools/qgsmaptoolshapecircle2pointsradius.cpp
@@ -1,0 +1,363 @@
+/***************************************************************************
+    qgsmaptoolshapecircle2pointsradius.cpp  -  map tool for adding circle
+    from 2 points and a radius
+    ---------------------
+    begin                : January 2026
+    copyright            : (C) 2026 by Loïc Bartoletti
+    email                : lituus at free dot fr
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaptoolshapecircle2pointsradius.h"
+
+#include "qgisapp.h"
+#include "qgsapplication.h"
+#include "qgsdoublespinbox.h"
+#include "qgsgeometryrubberband.h"
+#include "qgslinestring.h"
+#include "qgsmapmouseevent.h"
+#include "qgsmaptoolcapture.h"
+#include "qgsmessagebar.h"
+
+#include <QString>
+
+#include "moc_qgsmaptoolshapecircle2pointsradius.cpp"
+
+using namespace Qt::StringLiterals;
+
+QString QgsMapToolShapeCircle2PointsRadiusMetadata::id() const
+{
+  return QgsMapToolShapeCircle2PointsRadiusMetadata::TOOL_ID;
+}
+
+QString QgsMapToolShapeCircle2PointsRadiusMetadata::name() const
+{
+  return QObject::tr( "Circle from 2 points and a radius" );
+}
+
+QIcon QgsMapToolShapeCircle2PointsRadiusMetadata::icon() const
+{
+  return QgsApplication::getThemeIcon( u"/mActionCircle2PointsRadius.svg"_s );
+}
+
+QgsMapToolShapeAbstract::ShapeCategory QgsMapToolShapeCircle2PointsRadiusMetadata::category() const
+{
+  return QgsMapToolShapeAbstract::ShapeCategory::Circle;
+}
+
+QgsMapToolShapeAbstract *QgsMapToolShapeCircle2PointsRadiusMetadata::factory( QgsMapToolCapture *parentTool ) const
+{
+  return new QgsMapToolShapeCircle2PointsRadius( parentTool );
+}
+
+QgsMapToolShapeCircle2PointsRadius::QgsMapToolShapeCircle2PointsRadius( QgsMapToolCapture *parentTool )
+  : QgsMapToolShapeCircleAbstract( QgsMapToolShapeCircle2PointsRadiusMetadata::TOOL_ID, parentTool )
+{
+}
+
+QgsMapToolShapeCircle2PointsRadius::~QgsMapToolShapeCircle2PointsRadius()
+{
+  clearCenterRubberBands();
+  deleteSegmentRubberBand();
+  deleteRadiusSpinBox();
+}
+
+bool QgsMapToolShapeCircle2PointsRadius::cadCanvasReleaseEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode )
+{
+  const QgsPoint point = mParentTool->mapPoint( *e );
+
+  if ( e->button() == Qt::LeftButton )
+  {
+    // State 0: No points yet - add first point and show spinbox
+    if ( mPoints.isEmpty() )
+    {
+      mPoints.append( point );
+
+      // Create the spinbox after first point is set
+      createRadiusSpinBox();
+
+      if ( !mTempRubberBand )
+      {
+        Qgis::GeometryType type = mode == QgsMapToolCapture::CapturePolygon ? Qgis::GeometryType::Polygon : Qgis::GeometryType::Line;
+        mTempRubberBand = mParentTool->createGeometryRubberBand( type, true );
+        mTempRubberBand->show();
+      }
+    }
+    // State 1: First point set - add second point
+    else if ( mPoints.size() == 1 )
+    {
+      const double distance = mPoints.at( 0 ).distance( point );
+      const double minRadius = distance / 2.0;
+
+      if ( mRadius < minRadius )
+      {
+        QgisApp::instance()->messageBar()->pushMessage(
+          tr( "Error" ),
+          tr( "Creating a circle of radius %1 requires a radius of at least %2 (distance between points is %3)." )
+            .arg( mRadius, 0, 'f', 2 )
+            .arg( minRadius, 0, 'f', 2 )
+            .arg( distance, 0, 'f', 2 ),
+          Qgis::MessageLevel::Warning
+        );
+        return false;
+      }
+
+      mPoints.append( point );
+      updateCenters( mPoints.at( 0 ), mPoints.at( 1 ) );
+
+      // If only one center possible (diameter case), finish directly
+      if ( mCenters.size() == 1 )
+      {
+        mCircle = QgsCircle( mCenters.at( 0 ), mRadius );
+        addCircleToParentTool();
+        return true;
+      }
+    }
+    // State 2: Two points set, multiple centers - select center
+    else if ( mPoints.size() == 2 && mCenters.size() == 2 )
+    {
+      // Find the nearest center to the click position
+      const double dist1 = point.distanceSquared( mCenters.at( 0 ) );
+      const double dist2 = point.distanceSquared( mCenters.at( 1 ) );
+
+      QgsPoint selectedCenter = ( dist1 <= dist2 ) ? mCenters.at( 0 ) : mCenters.at( 1 );
+      mCircle = QgsCircle( selectedCenter, mRadius );
+      addCircleToParentTool();
+      return true;
+    }
+  }
+  else if ( e->button() == Qt::RightButton )
+  {
+    // If we have 2 points and a valid circle, finish with the current preview
+    if ( mPoints.size() == 2 && !mCircle.isEmpty() )
+    {
+      addCircleToParentTool();
+      return true;
+    }
+    // Otherwise cancel
+    clean();
+    return true;
+  }
+
+  return false;
+}
+
+void QgsMapToolShapeCircle2PointsRadius::cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode )
+{
+  Q_UNUSED( mode )
+
+  const QgsPoint mapPoint = mParentTool->mapPoint( *e );
+
+  // State 0: No points yet - nothing to preview
+  if ( mPoints.isEmpty() )
+  {
+    return;
+  }
+
+  // State 1: First point set - preview circle and show both centers
+  if ( mPoints.size() == 1 )
+  {
+    // Always show the segment between point 1 and current mouse position
+    updateSegmentRubberBand( mPoints.at( 0 ), mapPoint );
+
+    const double distance = mPoints.at( 0 ).distance( mapPoint );
+    const double minRadius = distance / 2.0;
+
+    // Check if radius is sufficient
+    if ( mRadius < minRadius )
+    {
+      // Clear circle preview and centers when radius is insufficient
+      clearCenterRubberBands();
+      mCenters.clear();
+      if ( mTempRubberBand )
+      {
+        mTempRubberBand->hide();
+      }
+      return;
+    }
+
+    updateCenters( mPoints.at( 0 ), mapPoint );
+
+    if ( mCenters.isEmpty() )
+      return;
+
+    // Select the center closest to mouse for preview
+    QgsPoint selectedCenter = mCenters.at( 0 );
+    if ( mCenters.size() == 2 )
+    {
+      const double dist1 = mapPoint.distanceSquared( mCenters.at( 0 ) );
+      const double dist2 = mapPoint.distanceSquared( mCenters.at( 1 ) );
+      if ( dist2 < dist1 )
+        selectedCenter = mCenters.at( 1 );
+    }
+
+    mCircle = QgsCircle( selectedCenter, mRadius );
+    const QgsGeometry newGeometry( mCircle.toCircularString( true ) );
+    if ( !newGeometry.isEmpty() && mTempRubberBand )
+    {
+      mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+      mTempRubberBand->show();
+      setTransientGeometry( newGeometry );
+    }
+  }
+  // State 2: Two points set - select center with mouse
+  else if ( mPoints.size() == 2 && mCenters.size() == 2 )
+  {
+    // Select the center closest to mouse for preview
+    const double dist1 = mapPoint.distanceSquared( mCenters.at( 0 ) );
+    const double dist2 = mapPoint.distanceSquared( mCenters.at( 1 ) );
+    QgsPoint selectedCenter = ( dist1 <= dist2 ) ? mCenters.at( 0 ) : mCenters.at( 1 );
+
+    mCircle = QgsCircle( selectedCenter, mRadius );
+    const QgsGeometry newGeometry( mCircle.toCircularString( true ) );
+    if ( !newGeometry.isEmpty() && mTempRubberBand )
+    {
+      mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+      setTransientGeometry( newGeometry );
+    }
+  }
+}
+
+void QgsMapToolShapeCircle2PointsRadius::updateCenters( const QgsPoint &pt1, const QgsPoint &pt2 )
+{
+  clearCenterRubberBands();
+  mCenters.clear();
+
+  QVector<QgsCircle> circles = QgsCircle::from2PointsRadius( pt1, pt2, mRadius );
+
+  for ( const QgsCircle &circle : circles )
+  {
+    mCenters.append( circle.center() );
+
+    // Create a rubber band to show this center
+    std::unique_ptr<QgsGeometryRubberBand> rb( mParentTool->createGeometryRubberBand( Qgis::GeometryType::Point, true ) );
+    rb->setGeometry( new QgsPoint( circle.center() ) );
+    rb->show();
+    mCenterRubberBands.append( rb.release() );
+  }
+}
+
+void QgsMapToolShapeCircle2PointsRadius::clearCenterRubberBands()
+{
+  qDeleteAll( mCenterRubberBands );
+  mCenterRubberBands.clear();
+}
+
+void QgsMapToolShapeCircle2PointsRadius::updateSegmentRubberBand( const QgsPoint &pt1, const QgsPoint &pt2 )
+{
+  if ( !mSegmentRubberBand )
+  {
+    mSegmentRubberBand = mParentTool->createGeometryRubberBand( Qgis::GeometryType::Line, true );
+  }
+
+  auto line = std::make_unique<QgsLineString>();
+  line->addVertex( pt1 );
+  line->addVertex( pt2 );
+  mSegmentRubberBand->setGeometry( line.release() );
+  mSegmentRubberBand->show();
+}
+
+void QgsMapToolShapeCircle2PointsRadius::deleteSegmentRubberBand()
+{
+  if ( mSegmentRubberBand )
+  {
+    delete mSegmentRubberBand;
+    mSegmentRubberBand = nullptr;
+  }
+}
+
+void QgsMapToolShapeCircle2PointsRadius::createRadiusSpinBox()
+{
+  deleteRadiusSpinBox();
+  mRadiusSpinBox = new QgsDoubleSpinBox();
+  mRadiusSpinBox->setMaximum( 99999999 );
+  mRadiusSpinBox->setMinimum( 0.0001 );
+  mRadiusSpinBox->setDecimals( 6 );
+  mRadiusSpinBox->setPrefix( tr( "Radius: " ) );
+  if ( mRadius > 0 )
+  {
+    mRadiusSpinBox->setValue( mRadius );
+  }
+  else
+  {
+    mRadiusSpinBox->setValue( 1.0 );
+    mRadius = 1.0;
+  }
+  QgisApp::instance()->addUserInputWidget( mRadiusSpinBox );
+  mRadiusSpinBox->setFocus( Qt::TabFocusReason );
+  QObject::connect( mRadiusSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &QgsMapToolShapeCircle2PointsRadius::radiusSpinBoxChanged );
+}
+
+void QgsMapToolShapeCircle2PointsRadius::deleteRadiusSpinBox()
+{
+  if ( mRadiusSpinBox )
+  {
+    delete mRadiusSpinBox;
+    mRadiusSpinBox = nullptr;
+  }
+}
+
+void QgsMapToolShapeCircle2PointsRadius::radiusSpinBoxChanged( double radius )
+{
+  mRadius = radius;
+
+  // If we have two points, update the centers with the new radius
+  if ( mPoints.size() == 2 )
+  {
+    updateCenters( mPoints.at( 0 ), mPoints.at( 1 ) );
+
+    // Update the circle preview if we have centers
+    if ( !mCenters.isEmpty() && mTempRubberBand )
+    {
+      mCircle = QgsCircle( mCenters.at( 0 ), mRadius );
+      const QgsGeometry newGeometry( mCircle.toCircularString( true ) );
+      if ( !newGeometry.isEmpty() )
+      {
+        mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+        setTransientGeometry( newGeometry );
+      }
+    }
+  }
+}
+
+void QgsMapToolShapeCircle2PointsRadius::clean()
+{
+  clearCenterRubberBands();
+  mCenters.clear();
+  deleteSegmentRubberBand();
+  deleteRadiusSpinBox();
+  QgsMapToolShapeCircleAbstract::clean();
+}
+
+void QgsMapToolShapeCircle2PointsRadius::undo()
+{
+  // State 2 (2 points): go back to State 1 (1 point)
+  if ( mPoints.size() == 2 )
+  {
+    mPoints.removeLast();
+    clearCenterRubberBands();
+    mCenters.clear();
+    mCircle = QgsCircle();
+
+    // Hide the circle preview but keep the temp rubber band
+    if ( mTempRubberBand )
+    {
+      mTempRubberBand->hide();
+    }
+
+    // Delete the segment rubber band - it will be recreated on next mouse move
+    // to show the segment from point 1 to mouse position
+    deleteSegmentRubberBand();
+  }
+  // State 1 (1 point): go back to State 0 (clean)
+  else if ( mPoints.size() == 1 )
+  {
+    clean();
+  }
+}

--- a/src/app/maptools/qgsmaptoolshapecircle2pointsradius.h
+++ b/src/app/maptools/qgsmaptoolshapecircle2pointsradius.h
@@ -1,0 +1,94 @@
+/***************************************************************************
+    qgsmaptoolshapecircle2pointsradius.h  -  map tool for adding circle
+    from 2 points and a radius
+    ---------------------
+    begin                : January 2026
+    copyright            : (C) 2026 by Loïc Bartoletti
+    email                : lituus at free dot fr
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLSHAPECIRCLE2POINTSRADIUS_H
+#define QGSMAPTOOLSHAPECIRCLE2POINTSRADIUS_H
+
+#include "qgis_app.h"
+#include "qgsmaptoolshapecircleabstract.h"
+#include "qgsmaptoolshaperegistry.h"
+
+#include <QString>
+
+using namespace Qt::StringLiterals;
+
+class QDoubleSpinBox;
+class QgsGeometryRubberBand;
+
+class APP_EXPORT QgsMapToolShapeCircle2PointsRadiusMetadata : public QgsMapToolShapeMetadata
+{
+  public:
+    QgsMapToolShapeCircle2PointsRadiusMetadata()
+      : QgsMapToolShapeMetadata()
+    {}
+
+    static const inline QString TOOL_ID = u"circle-from-2-points-radius"_s;
+
+    QString id() const override;
+    QString name() const override;
+    QIcon icon() const override;
+    QgsMapToolShapeAbstract::ShapeCategory category() const override;
+    QgsMapToolShapeAbstract *factory( QgsMapToolCapture *parentTool ) const override;
+};
+
+class APP_EXPORT QgsMapToolShapeCircle2PointsRadius : public QgsMapToolShapeCircleAbstract
+{
+    Q_OBJECT
+
+  public:
+    QgsMapToolShapeCircle2PointsRadius( QgsMapToolCapture *parentTool );
+    ~QgsMapToolShapeCircle2PointsRadius() override;
+
+    bool cadCanvasReleaseEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode ) override;
+    void cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode ) override;
+
+    void clean() override;
+    void undo() override;
+
+  public slots:
+    void radiusSpinBoxChanged( double radius );
+
+  private:
+    //! (re-)create the spin box to enter the radius of the circle
+    void createRadiusSpinBox();
+    //! delete the spin box to enter the radius of the circle, if it exists
+    void deleteRadiusSpinBox();
+
+    //! Update the possible centers and rubber bands
+    void updateCenters( const QgsPoint &pt1, const QgsPoint &pt2 );
+    //! Clear center rubber bands
+    void clearCenterRubberBands();
+
+    //! Update the segment rubber band between two points
+    void updateSegmentRubberBand( const QgsPoint &pt1, const QgsPoint &pt2 );
+    //! Delete the segment rubber band
+    void deleteSegmentRubberBand();
+
+    QDoubleSpinBox *mRadiusSpinBox = nullptr;
+
+    double mRadius = 0.0;
+
+    //! Possible centers for the circle
+    QVector<QgsPoint> mCenters;
+
+    //! Rubber bands to display possible centers
+    QVector<QgsGeometryRubberBand *> mCenterRubberBands;
+
+    //! Rubber band to display segment between two points
+    QgsGeometryRubberBand *mSegmentRubberBand = nullptr;
+};
+
+#endif // QGSMAPTOOLSHAPECIRCLE2POINTSRADIUS_H

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -499,6 +499,7 @@ using namespace Qt::StringLiterals;
 #include "qgsmaptoolshaperegistry.h"
 #include "qgsmaptoolshapecircularstringradius.h"
 #include "qgsmaptoolshapecircle2points.h"
+#include "qgsmaptoolshapecircle2pointsradius.h"
 #include "qgsmaptoolshapecircle3points.h"
 #include "qgsmaptoolshapecircle3tangents.h"
 #include "qgsmaptoolshapecircle2tangentspoint.h"
@@ -1227,6 +1228,7 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
 
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeCircularStringRadiusMetadata() );
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeCircle2PointsMetadata() );
+  QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeCircle2PointsRadiusMetadata() );
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeCircle3PointsMetadata() );
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeCircle3TangentsMetadata() );
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeCircle2TangentsPointMetadata() );

--- a/src/core/geometry/qgscircle.h
+++ b/src/core/geometry/qgscircle.h
@@ -101,6 +101,30 @@ class CORE_EXPORT QgsCircle : public QgsEllipse
      */
     static QgsCircle fromCenterPoint( const QgsPoint &center, const QgsPoint &pt1 ) SIP_HOLDGIL; // cppcheck-suppress duplInheritedMember
 
+    /**
+     * Constructs circles passing through 2 points with a given \a radius.
+     *
+     * This method returns 0, 1 or 2 circles depending on the geometric configuration:
+     *
+     * - 0 circles: if the radius is smaller than half the distance between the points
+     * - 1 circle: if the radius equals half the distance (diameter case)
+     * - 2 circles: if the radius is larger than half the distance
+     *
+     * When \a pos is specified and valid, only the circle whose center is closest
+     * to \a pos is returned.
+     *
+     * Z and M values are transferred from the input points to the circle center.
+     * The azimuth always takes the default value.
+     *
+     * \param pt1 First point on the circle.
+     * \param pt2 Second point on the circle.
+     * \param radius The radius of the circle (must be positive).
+     * \param pos Optional point to select the nearest circle center.
+     * \return Vector containing 0, 1 or 2 circles.
+     *
+     * \since QGIS 4.0
+     */
+    static QVector<QgsCircle> from2PointsRadius( const QgsPoint &pt1, const QgsPoint &pt2, double radius, const QgsPoint &pos = QgsPoint() ) SIP_HOLDGIL;
 
     /**
      * Constructs a circle by 3 tangents on the circle (aka inscribed circle of a triangle).

--- a/tests/src/core/geometry/testqgscircle.cpp
+++ b/tests/src/core/geometry/testqgscircle.cpp
@@ -28,6 +28,7 @@ class TestQgsCircle : public QObject
   private slots:
     void constructor();
     void from2Points();
+    void from2PointsRadius();
     void fromExtent();
     void from3Points();
     void fromCenterDiameter();
@@ -522,6 +523,88 @@ void TestQgsCircle::asGML()
   // asGML2
   QString expectedGML2( u"<LineString xmlns=\"gml\"><coordinates xmlns=\"gml\" cs=\",\" ts=\" \">1,4 1.05,4 1.1,4 1.16,4 1.21,3.99 1.26,3.99 1.31,3.98 1.37,3.98 1.42,3.97 1.47,3.96 1.52,3.95 1.57,3.94 1.62,3.93 1.67,3.92 1.73,3.91 1.78,3.9 1.83,3.88 1.88,3.87 1.93,3.85 1.98,3.84 2.03,3.82 2.08,3.8 2.12,3.78 2.17,3.76 2.22,3.74 2.27,3.72 2.32,3.7 2.36,3.67 2.41,3.65 2.45,3.62 2.5,3.6 2.55,3.57 2.59,3.54 2.63,3.52 2.68,3.49 2.72,3.46 2.76,3.43 2.81,3.4 2.85,3.36 2.89,3.33 2.93,3.3 2.97,3.26 3.01,3.23 3.05,3.19 3.08,3.16 3.12,3.12 3.16,3.08 3.19,3.05 3.23,3.01 3.26,2.97 3.3,2.93 3.33,2.89 3.36,2.85 3.4,2.81 3.43,2.76 3.46,2.72 3.49,2.68 3.52,2.63 3.54,2.59 3.57,2.55 3.6,2.5 3.62,2.45 3.65,2.41 3.67,2.36 3.7,2.32 3.72,2.27 3.74,2.22 3.76,2.17 3.78,2.12 3.8,2.08 3.82,2.03 3.84,1.98 3.85,1.93 3.87,1.88 3.88,1.83 3.9,1.78 3.91,1.73 3.92,1.67 3.93,1.62 3.94,1.57 3.95,1.52 3.96,1.47 3.97,1.42 3.98,1.37 3.98,1.31 3.99,1.26 3.99,1.21 4,1.16 4,1.1 4,1.05 4,1 4,0.95 4,0.9 4,0.84 3.99,0.79 3.99,0.74 3.98,0.69 3.98,0.63 3.97,0.58 3.96,0.53 3.95,0.48 3.94,0.43 3.93,0.38 3.92,0.33 3.91,0.27 3.9,0.22 3.88,0.17 3.87,0.12 3.85,0.07 3.84,0.02 3.82,-0.03 3.8,-0.08 3.78,-0.12 3.76,-0.17 3.74,-0.22 3.72,-0.27 3.7,-0.32 3.67,-0.36 3.65,-0.41 3.62,-0.45 3.6,-0.5 3.57,-0.55 3.54,-0.59 3.52,-0.63 3.49,-0.68 3.46,-0.72 3.43,-0.76 3.4,-0.81 3.36,-0.85 3.33,-0.89 3.3,-0.93 3.26,-0.97 3.23,-1.01 3.19,-1.05 3.16,-1.08 3.12,-1.12 3.08,-1.16 3.05,-1.19 3.01,-1.23 2.97,-1.26 2.93,-1.3 2.89,-1.33 2.85,-1.36 2.81,-1.4 2.76,-1.43 2.72,-1.46 2.68,-1.49 2.63,-1.52 2.59,-1.54 2.55,-1.57 2.5,-1.6 2.45,-1.62 2.41,-1.65 2.36,-1.67 2.32,-1.7 2.27,-1.72 2.22,-1.74 2.17,-1.76 2.12,-1.78 2.08,-1.8 2.03,-1.82 1.98,-1.84 1.93,-1.85 1.88,-1.87 1.83,-1.88 1.78,-1.9 1.73,-1.91 1.67,-1.92 1.62,-1.93 1.57,-1.94 1.52,-1.95 1.47,-1.96 1.42,-1.97 1.37,-1.98 1.31,-1.98 1.26,-1.99 1.21,-1.99 1.16,-2 1.1,-2 1.05,-2 1,-2 0.95,-2 0.9,-2 0.84,-2 0.79,-1.99 0.74,-1.99 0.69,-1.98 0.63,-1.98 0.58,-1.97 0.53,-1.96 0.48,-1.95 0.43,-1.94 0.38,-1.93 0.33,-1.92 0.27,-1.91 0.22,-1.9 0.17,-1.88 0.12,-1.87 0.07,-1.85 0.02,-1.84 -0.03,-1.82 -0.08,-1.8 -0.12,-1.78 -0.17,-1.76 -0.22,-1.74 -0.27,-1.72 -0.32,-1.7 -0.36,-1.67 -0.41,-1.65 -0.45,-1.62 -0.5,-1.6 -0.55,-1.57 -0.59,-1.54 -0.63,-1.52 -0.68,-1.49 -0.72,-1.46 -0.76,-1.43 -0.81,-1.4 -0.85,-1.36 -0.89,-1.33 -0.93,-1.3 -0.97,-1.26 -1.01,-1.23 -1.05,-1.19 -1.08,-1.16 -1.12,-1.12 -1.16,-1.08 -1.19,-1.05 -1.23,-1.01 -1.26,-0.97 -1.3,-0.93 -1.33,-0.89 -1.36,-0.85 -1.4,-0.81 -1.43,-0.76 -1.46,-0.72 -1.49,-0.68 -1.52,-0.63 -1.54,-0.59 -1.57,-0.55 -1.6,-0.5 -1.62,-0.45 -1.65,-0.41 -1.67,-0.36 -1.7,-0.32 -1.72,-0.27 -1.74,-0.22 -1.76,-0.17 -1.78,-0.12 -1.8,-0.08 -1.82,-0.03 -1.84,0.02 -1.85,0.07 -1.87,0.12 -1.88,0.17 -1.9,0.22 -1.91,0.27 -1.92,0.33 -1.93,0.38 -1.94,0.43 -1.95,0.48 -1.96,0.53 -1.97,0.58 -1.98,0.63 -1.98,0.69 -1.99,0.74 -1.99,0.79 -2,0.84 -2,0.9 -2,0.95 -2,1 -2,1.05 -2,1.1 -2,1.16 -1.99,1.21 -1.99,1.26 -1.98,1.31 -1.98,1.37 -1.97,1.42 -1.96,1.47 -1.95,1.52 -1.94,1.57 -1.93,1.62 -1.92,1.67 -1.91,1.73 -1.9,1.78 -1.88,1.83 -1.87,1.88 -1.85,1.93 -1.84,1.98 -1.82,2.03 -1.8,2.08 -1.78,2.12 -1.76,2.17 -1.74,2.22 -1.72,2.27 -1.7,2.32 -1.67,2.36 -1.65,2.41 -1.62,2.45 -1.6,2.5 -1.57,2.55 -1.54,2.59 -1.52,2.63 -1.49,2.68 -1.46,2.72 -1.43,2.76 -1.4,2.81 -1.36,2.85 -1.33,2.89 -1.3,2.93 -1.26,2.97 -1.23,3.01 -1.19,3.05 -1.16,3.08 -1.12,3.12 -1.08,3.16 -1.05,3.19 -1.01,3.23 -0.97,3.26 -0.93,3.3 -0.89,3.33 -0.85,3.36 -0.81,3.4 -0.76,3.43 -0.72,3.46 -0.68,3.49 -0.63,3.52 -0.59,3.54 -0.55,3.57 -0.5,3.6 -0.45,3.62 -0.41,3.65 -0.36,3.67 -0.32,3.7 -0.27,3.72 -0.22,3.74 -0.17,3.76 -0.12,3.78 -0.08,3.8 -0.03,3.82 0.02,3.84 0.07,3.85 0.12,3.87 0.17,3.88 0.22,3.9 0.27,3.91 0.33,3.92 0.38,3.93 0.43,3.94 0.48,3.95 0.53,3.96 0.58,3.97 0.63,3.98 0.69,3.98 0.74,3.99 0.79,3.99 0.84,4 0.9,4 0.95,4 1,4</coordinates></LineString>"_s );
   QGSCOMPAREGML( elemToString( exportCircle.asGml2( doc, 2 ) ), expectedGML2 );
+}
+
+void TestQgsCircle::from2PointsRadius()
+{
+  QVector<QgsCircle> circles;
+
+  // Test 1: Radius too small - no solution
+  circles = QgsCircle::from2PointsRadius( QgsPoint( 0, 0 ), QgsPoint( 10, 0 ), 2 );
+  QVERIFY( circles.isEmpty() );
+
+  // Test 2: Negative radius - no solution
+  circles = QgsCircle::from2PointsRadius( QgsPoint( 0, 0 ), QgsPoint( 4, 0 ), -5 );
+  QVERIFY( circles.isEmpty() );
+
+  // Test 3: Zero radius - no solution
+  circles = QgsCircle::from2PointsRadius( QgsPoint( 0, 0 ), QgsPoint( 4, 0 ), 0 );
+  QVERIFY( circles.isEmpty() );
+
+  // Test 4: Diameter case - exactly 1 solution
+  // P1=(0,0), P2=(4,0), R=2 -> center at (2,0)
+  circles = QgsCircle::from2PointsRadius( QgsPoint( 0, 0 ), QgsPoint( 4, 0 ), 2 );
+  QCOMPARE( circles.count(), 1 );
+  QGSCOMPARENEARPOINT( circles.at( 0 ).center(), QgsPoint( 2, 0 ), 0.0001 );
+  QGSCOMPARENEAR( circles.at( 0 ).radius(), 2.0, 0.0001 );
+
+  // Test 5: Two solutions case
+  // P1=(0,0), P2=(4,0), R=3 -> centers at (2, sqrt(5)) and (2, -sqrt(5))
+  const double expectedH = std::sqrt( 9.0 - 4.0 ); // sqrt(R² - d²) = sqrt(9 - 4) = sqrt(5)
+  circles = QgsCircle::from2PointsRadius( QgsPoint( 0, 0 ), QgsPoint( 4, 0 ), 3 );
+  QCOMPARE( circles.count(), 2 );
+
+  // First center should be at (2, sqrt(5))
+  QGSCOMPARENEARPOINT( circles.at( 0 ).center(), QgsPoint( 2, expectedH ), 0.0001 );
+  QGSCOMPARENEAR( circles.at( 0 ).radius(), 3.0, 0.0001 );
+
+  // Second center should be at (2, -sqrt(5))
+  QGSCOMPARENEARPOINT( circles.at( 1 ).center(), QgsPoint( 2, -expectedH ), 0.0001 );
+  QGSCOMPARENEAR( circles.at( 1 ).radius(), 3.0, 0.0001 );
+
+  // Test 6: Selection by position - returns nearest
+  // With pos near the upper center
+  circles = QgsCircle::from2PointsRadius( QgsPoint( 0, 0 ), QgsPoint( 4, 0 ), 3, QgsPoint( 2, 5 ) );
+  QCOMPARE( circles.count(), 1 );
+  QGSCOMPARENEARPOINT( circles.at( 0 ).center(), QgsPoint( 2, expectedH ), 0.0001 );
+
+  // With pos near the lower center
+  circles = QgsCircle::from2PointsRadius( QgsPoint( 0, 0 ), QgsPoint( 4, 0 ), 3, QgsPoint( 2, -5 ) );
+  QCOMPARE( circles.count(), 1 );
+  QGSCOMPARENEARPOINT( circles.at( 0 ).center(), QgsPoint( 2, -expectedH ), 0.0001 );
+
+  // Test 7: Vertical line case
+  // P1=(0,0), P2=(0,6), R=5 -> centers at (4, 3) and (-4, 3)
+  const double expectedHVert = std::sqrt( 25.0 - 9.0 ); // sqrt(25 - 9) = 4
+  circles = QgsCircle::from2PointsRadius( QgsPoint( 0, 0 ), QgsPoint( 0, 6 ), 5 );
+  QCOMPARE( circles.count(), 2 );
+  QGSCOMPARENEARPOINT( circles.at( 0 ).center(), QgsPoint( -expectedHVert, 3 ), 0.0001 );
+  QGSCOMPARENEARPOINT( circles.at( 1 ).center(), QgsPoint( expectedHVert, 3 ), 0.0001 );
+
+  // Test 8: Z value transfer
+  circles = QgsCircle::from2PointsRadius( QgsPoint( 0, 0, 10 ), QgsPoint( 4, 0, 20 ), 2 );
+  QCOMPARE( circles.count(), 1 );
+  QVERIFY( circles.at( 0 ).center().is3D() );
+  QGSCOMPARENEAR( circles.at( 0 ).center().z(), 10.0, 0.0001 );
+
+  // Test 9: M value transfer
+  circles = QgsCircle::from2PointsRadius( QgsPoint( Qgis::WkbType::PointM, 0, 0, 0, 100 ), QgsPoint( Qgis::WkbType::PointM, 4, 0, 0, 200 ), 2 );
+  QCOMPARE( circles.count(), 1 );
+  QVERIFY( circles.at( 0 ).center().isMeasure() );
+  QGSCOMPARENEAR( circles.at( 0 ).center().m(), 100.0, 0.0001 );
+
+  // Test 10: Diagonal line case
+  // P1=(0,0), P2=(4,4), R=4 -> verify circles pass through both points
+  circles = QgsCircle::from2PointsRadius( QgsPoint( 0, 0 ), QgsPoint( 4, 4 ), 4 );
+  QCOMPARE( circles.count(), 2 );
+  // Verify both circles have correct radius
+  QGSCOMPARENEAR( circles.at( 0 ).radius(), 4.0, 0.0001 );
+  QGSCOMPARENEAR( circles.at( 1 ).radius(), 4.0, 0.0001 );
+  // Verify distance from center to points equals radius
+  QGSCOMPARENEAR( circles.at( 0 ).center().distance( QgsPoint( 0, 0 ) ), 4.0, 0.0001 );
+  QGSCOMPARENEAR( circles.at( 0 ).center().distance( QgsPoint( 4, 4 ) ), 4.0, 0.0001 );
+  QGSCOMPARENEAR( circles.at( 1 ).center().distance( QgsPoint( 0, 0 ) ), 4.0, 0.0001 );
+  QGSCOMPARENEAR( circles.at( 1 ).center().distance( QgsPoint( 4, 4 ) ), 4.0, 0.0001 );
 }
 
 QGSTEST_MAIN( TestQgsCircle )


### PR DESCRIPTION
## Description

This method returns 0, 1 or 2 circles depending on the geometric
configuration:

- 0 circles: if the radius is smaller than half the distance between the
  points
- 1 circle: if the radius equals half the distance (diameter case)
- 2 circles: if the radius is larger than half the distance

Example:

https://github.com/user-attachments/assets/82a14b2a-bef0-417b-81ff-5cd286e9dffd


This method is inspired by LibreCAD.

PS: I'm not sure about the value "1" as default in mRadiusSpinBox. Maybe 10? 5?