### PR TITLE
Add ellipse maptool from 4 points and from Center 3 points

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -794,8 +794,10 @@
         <file>themes/default/mActionCircle2Points.svg</file>
         <file>themes/default/mActionCircle3Points.svg</file>
         <file>themes/default/mActionCircleCenterPoint.svg</file>
+        <file>themes/default/mActionEllipse4Points.svg</file>
         <file>themes/default/mActionEllipseFoci.svg</file>
         <file>themes/default/mActionEllipseCenter2Points.svg</file>
+        <file>themes/default/mActionEllipseCenter3Points.svg</file>
         <file>themes/default/mActionEllipseCenterPoint.svg</file>
         <file>themes/default/mActionEllipseExtent.svg</file>
         <file>themes/default/mActionRectangleExtent.svg</file>

--- a/images/themes/default/mActionEllipse4Points.svg
+++ b/images/themes/default/mActionEllipse4Points.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="mActionEllipse4Points.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="48.291667"
+     inkscape:cx="11.989646"
+     inkscape:cy="12"
+     inkscape:window-width="3440"
+     inkscape:window-height="1368"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <g
+     id="g8">
+    <ellipse
+       cx="5.6722555"
+       cy="14.812654"
+       fill="none"
+       rx="7.724184"
+       ry="4.724184"
+       stroke="#8cbe8c"
+       stroke-width="2.55163"
+       id="ellipse1"
+       transform="rotate(-22.793251)" />
+    <g
+       id="g7">
+      <path
+         d="M 0.71476417,14.044782 3.4804907,12.88256 4.6427116,15.648287 1.8769852,16.810508 Z"
+         id="path1"
+         style="fill:#bebebe;stroke:#8c8c8c" />
+      <path
+         d="m 14.411556,6.2502362 2.765727,-1.1622216 1.162221,2.7657266 -2.765727,1.162221 z"
+         id="path2"
+         style="fill:#bebebe;stroke:#8c8c8c" />
+      <path
+         d="m 7.5933983,15.797898 2.7657267,-1.162222 1.162221,2.765727 -2.7657267,1.162221 z"
+         id="path2-0"
+         style="fill:#bebebe;stroke:#8c8c8c" />
+      <path
+         d="M 6.9153834,6.3403384 9.6811096,5.1781174 10.843331,7.9438444 8.0776046,9.1060653 Z"
+         id="path3"
+         style="fill:#bebebe;stroke:#8c8c8c" />
+    </g>
+    <g
+       transform="translate(33)"
+       id="g6">
+      <rect
+         fill="#c4a000"
+         height="11"
+         rx="2.01149"
+         width="11"
+         x="-20"
+         y="13"
+         id="rect4" />
+      <g
+         fill="#fcffff"
+         id="g5">
+        <path
+           d="m-15 14v2.0625c-.537663.111041-1.024662.383291-1.375.78125l-1.78125-1.03125-.5.875 1.78125 1.03125c-.082063.247432-.125.506395-.125.78125s.04294.533818.125.78125l-1.78125 1.03125.5.875 1.78125-1.03125c.352503.40042.832682.670182 1.375.78125v2.0625h1v-2.0625c.537663-.111041 1.024662-.383291 1.375-.78125l1.78125 1.03125.5-.875-1.78125-1.03125c.082063-.247432.125-.506395.125-.78125s-.04294-.533818-.125-.78125l1.78125-1.03125-.5-.875-1.78125 1.03125c-.352503-.40042-.832682-.670182-1.375-.78125v-2.0625zm.5 3.5c.552 0 1 .448 1 1s-.448 1-1 1-1-.448-1-1 .448-1 1-1z"
+           id="path4" />
+        <path
+           d="m-19 19 9-.0096s0 0 0-2c0-2.9904-1-2.9904-4.5-2.9904s-4.5 0-4.5 3z"
+           fill-rule="evenodd"
+           opacity=".3"
+           id="path5" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/images/themes/default/mActionEllipseCenter3Points.svg
+++ b/images/themes/default/mActionEllipseCenter3Points.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="mActionEllipseCenter3Points.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="48.291667"
+     inkscape:cx="11.989646"
+     inkscape:cy="12"
+     inkscape:window-width="3440"
+     inkscape:window-height="1368"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <g
+     id="g8">
+    <ellipse
+       cx="5.6722555"
+       cy="14.812654"
+       fill="none"
+       rx="7.724184"
+       ry="4.724184"
+       stroke="#8cbe8c"
+       stroke-width="2.55163"
+       id="ellipse1"
+       transform="rotate(-22.793251)" />
+    <g
+       id="g7">
+      <path
+         d="M 0.71476417,14.044782 3.4804907,12.88256 4.6427116,15.648287 1.8769852,16.810508 Z"
+         id="path1"
+         style="fill:#bebebe;stroke:#8c8c8c" />
+      <path
+         d="M 8.716992,10.329615 11.482719,9.1673934 12.64494,11.93312 9.879213,13.095341 Z"
+         id="path2"
+         style="fill:#bebebe;stroke:#8c8c8c" />
+      <path
+         d="M 6.9153834,6.3403384 9.6811096,5.1781174 10.843331,7.9438444 8.0776046,9.1060653 Z"
+         id="path3"
+         style="fill:#bebebe;stroke:#8c8c8c" />
+      <path
+         d="m 16.326789,9.8790014 2.765727,-1.162221 1.162221,2.7657266 -2.765726,1.162221 z"
+         id="path3-0"
+         style="fill:#bebebe;stroke:#8c8c8c" />
+    </g>
+    <g
+       transform="translate(33)"
+       id="g6">
+      <rect
+         fill="#c4a000"
+         height="11"
+         rx="2.01149"
+         width="11"
+         x="-20"
+         y="13"
+         id="rect4" />
+      <g
+         fill="#fcffff"
+         id="g5">
+        <path
+           d="m-15 14v2.0625c-.537663.111041-1.024662.383291-1.375.78125l-1.78125-1.03125-.5.875 1.78125 1.03125c-.082063.247432-.125.506395-.125.78125s.04294.533818.125.78125l-1.78125 1.03125.5.875 1.78125-1.03125c.352503.40042.832682.670182 1.375.78125v2.0625h1v-2.0625c.537663-.111041 1.024662-.383291 1.375-.78125l1.78125 1.03125.5-.875-1.78125-1.03125c.082063-.247432.125-.506395.125-.78125s-.04294-.533818-.125-.78125l1.78125-1.03125-.5-.875-1.78125 1.03125c-.352503-.40042-.832682-.670182-1.375-.78125v-2.0625zm.5 3.5c.552 0 1 .448 1 1s-.448 1-1 1-1-.448-1-1 .448-1 1-1z"
+           id="path4" />
+        <path
+           d="m-19 19 9-.0096s0 0 0-2c0-2.9904-1-2.9904-4.5-2.9904s-4.5 0-4.5 3z"
+           fill-rule="evenodd"
+           opacity=".3"
+           id="path5" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/python/PyQt6/core/auto_additions/qgsellipse.py
+++ b/python/PyQt6/core/auto_additions/qgsellipse.py
@@ -4,6 +4,8 @@ try:
     QgsEllipse.fromExtent = staticmethod(QgsEllipse.fromExtent)
     QgsEllipse.fromCenterPoint = staticmethod(QgsEllipse.fromCenterPoint)
     QgsEllipse.fromCenter2Points = staticmethod(QgsEllipse.fromCenter2Points)
+    QgsEllipse.from4Points = staticmethod(QgsEllipse.from4Points)
+    QgsEllipse.fromCenter3Points = staticmethod(QgsEllipse.fromCenter3Points)
     QgsEllipse.__virtual_methods__ = ['isEmpty', 'setSemiMajorAxis', 'setSemiMinorAxis', 'focusDistance', 'foci', 'eccentricity', 'area', 'perimeter', 'quadrant', 'points', 'toPolygon', 'toLineString', 'orientedBoundingBox', 'boundingBox', 'toString']
     QgsEllipse.__group__ = ['geometry']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/geometry/qgsellipse.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsellipse.sip.in
@@ -99,6 +99,65 @@ and is retrieved from the first 3D point amongst ``ptc``, ``pt1`` and
 :param pt2: Second point.
 %End
 
+    static QgsEllipse from4Points( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, const QgsPoint &pt4 ) /HoldGIL/;
+%Docstring
+Constructs an ellipse from 4 points.
+
+The ellipse will have axes aligned to the X and Y axes. The 4 points
+must lie on the ellipse and define a unique axis-aligned ellipse.
+
+Z dimension is supported and is retrieved from the first 3D point
+amongst the input points. M value is retrieved from the first point with
+M amongst the input points.
+
+If the 4 points do not define a valid ellipse (e.g., collinear points,
+points forming a hyperbola, or insufficient points), an empty ellipse is
+returned.
+
+:param pt1: First point on the ellipse.
+:param pt2: Second point on the ellipse.
+:param pt3: Third point on the ellipse.
+:param pt4: Fourth point on the ellipse.
+
+:return: The constructed ellipse, or an empty ellipse if the points do
+         not define a valid ellipse.
+
+.. note::
+
+   This method produces only axis-aligned ellipses (azimuth is always 90 degrees).
+
+.. versionadded:: 4.0
+%End
+
+    static QgsEllipse fromCenter3Points( const QgsPoint &center, const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3 ) /HoldGIL/;
+%Docstring
+Constructs an ellipse from a center point and 3 points on the ellipse.
+
+Unlike :py:func:`~QgsEllipse.from4Points`, this method can produce
+ellipses with any orientation.
+
+Z dimension is supported and is retrieved from the first 3D point
+amongst the input points. M value is retrieved from the first point with
+M amongst the input points.
+
+If ``pt2`` and ``pt3`` are identical (within tolerance), the method will
+construct an axis-aligned ellipse using only 2 points.
+
+If the points do not define a valid ellipse (e.g., a point coincides
+with the center, points are collinear through the center, or the
+resulting shape is not an ellipse), an empty ellipse is returned.
+
+:param center: The center point of the ellipse.
+:param pt1: First point on the ellipse.
+:param pt2: Second point on the ellipse.
+:param pt3: Third point on the ellipse.
+
+:return: The constructed ellipse, or an empty ellipse if the points do
+         not define a valid ellipse.
+
+.. versionadded:: 4.0
+%End
+
     virtual bool operator ==( const QgsEllipse &elp ) const;
     virtual bool operator !=( const QgsEllipse &elp ) const;
 

--- a/python/core/auto_additions/qgsellipse.py
+++ b/python/core/auto_additions/qgsellipse.py
@@ -4,6 +4,8 @@ try:
     QgsEllipse.fromExtent = staticmethod(QgsEllipse.fromExtent)
     QgsEllipse.fromCenterPoint = staticmethod(QgsEllipse.fromCenterPoint)
     QgsEllipse.fromCenter2Points = staticmethod(QgsEllipse.fromCenter2Points)
+    QgsEllipse.from4Points = staticmethod(QgsEllipse.from4Points)
+    QgsEllipse.fromCenter3Points = staticmethod(QgsEllipse.fromCenter3Points)
     QgsEllipse.__virtual_methods__ = ['isEmpty', 'setSemiMajorAxis', 'setSemiMinorAxis', 'focusDistance', 'foci', 'eccentricity', 'area', 'perimeter', 'quadrant', 'points', 'toPolygon', 'toLineString', 'orientedBoundingBox', 'boundingBox', 'toString']
     QgsEllipse.__group__ = ['geometry']
 except (NameError, AttributeError):

--- a/python/core/auto_generated/geometry/qgsellipse.sip.in
+++ b/python/core/auto_generated/geometry/qgsellipse.sip.in
@@ -99,6 +99,65 @@ and is retrieved from the first 3D point amongst ``ptc``, ``pt1`` and
 :param pt2: Second point.
 %End
 
+    static QgsEllipse from4Points( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, const QgsPoint &pt4 ) /HoldGIL/;
+%Docstring
+Constructs an ellipse from 4 points.
+
+The ellipse will have axes aligned to the X and Y axes. The 4 points
+must lie on the ellipse and define a unique axis-aligned ellipse.
+
+Z dimension is supported and is retrieved from the first 3D point
+amongst the input points. M value is retrieved from the first point with
+M amongst the input points.
+
+If the 4 points do not define a valid ellipse (e.g., collinear points,
+points forming a hyperbola, or insufficient points), an empty ellipse is
+returned.
+
+:param pt1: First point on the ellipse.
+:param pt2: Second point on the ellipse.
+:param pt3: Third point on the ellipse.
+:param pt4: Fourth point on the ellipse.
+
+:return: The constructed ellipse, or an empty ellipse if the points do
+         not define a valid ellipse.
+
+.. note::
+
+   This method produces only axis-aligned ellipses (azimuth is always 90 degrees).
+
+.. versionadded:: 4.0
+%End
+
+    static QgsEllipse fromCenter3Points( const QgsPoint &center, const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3 ) /HoldGIL/;
+%Docstring
+Constructs an ellipse from a center point and 3 points on the ellipse.
+
+Unlike :py:func:`~QgsEllipse.from4Points`, this method can produce
+ellipses with any orientation.
+
+Z dimension is supported and is retrieved from the first 3D point
+amongst the input points. M value is retrieved from the first point with
+M amongst the input points.
+
+If ``pt2`` and ``pt3`` are identical (within tolerance), the method will
+construct an axis-aligned ellipse using only 2 points.
+
+If the points do not define a valid ellipse (e.g., a point coincides
+with the center, points are collinear through the center, or the
+resulting shape is not an ellipse), an empty ellipse is returned.
+
+:param center: The center point of the ellipse.
+:param pt1: First point on the ellipse.
+:param pt2: Second point on the ellipse.
+:param pt3: Third point on the ellipse.
+
+:return: The constructed ellipse, or an empty ellipse if the points do
+         not define a valid ellipse.
+
+.. versionadded:: 4.0
+%End
+
     virtual bool operator ==( const QgsEllipse &elp ) const;
     virtual bool operator !=( const QgsEllipse &elp ) const;
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -244,7 +244,9 @@ set(QGIS_APP_SRCS
   maptools/qgsmaptoolshapecircle3tangents.cpp
   maptools/qgsmaptoolshapecirclecenterpoint.cpp
   maptools/qgsmaptoolshapecircularstringradius.cpp
+  maptools/qgsmaptoolshapeellipse4points.cpp
   maptools/qgsmaptoolshapeellipsecenter2points.cpp
+  maptools/qgsmaptoolshapeellipsecenter3points.cpp
   maptools/qgsmaptoolshapeellipsecenterpoint.cpp
   maptools/qgsmaptoolshapeellipseextent.cpp
   maptools/qgsmaptoolshapeellipsefoci.cpp

--- a/src/app/maptools/qgsmaptoolshapeellipse4points.cpp
+++ b/src/app/maptools/qgsmaptoolshapeellipse4points.cpp
@@ -1,0 +1,133 @@
+/***************************************************************************
+    qgsmaptoolshapeellipse4points.cpp  -  map tool for adding ellipse
+    from 4 points
+    ---------------------
+    begin                : December 2025
+    copyright            : (C) 2025 by Loïc Bartoletti
+    email                : lituus at free dot fr
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaptoolshapeellipse4points.h"
+
+#include <memory>
+
+#include "qgsapplication.h"
+#include "qgscircle.h"
+#include "qgsgeometryrubberband.h"
+#include "qgslinestring.h"
+#include "qgsmapmouseevent.h"
+#include "qgsmaptoolcapture.h"
+#include "qgspoint.h"
+
+#include "moc_qgsmaptoolshapeellipse4points.cpp"
+
+const QString QgsMapToolShapeEllipse4PointsMetadata::TOOL_ID = u"ellipse-from-4-points"_s;
+
+QString QgsMapToolShapeEllipse4PointsMetadata::id() const
+{
+  return QgsMapToolShapeEllipse4PointsMetadata::TOOL_ID;
+}
+
+QString QgsMapToolShapeEllipse4PointsMetadata::name() const
+{
+  return QObject::tr( "Ellipse from 4 Points" );
+}
+
+QIcon QgsMapToolShapeEllipse4PointsMetadata::icon() const
+{
+  return QgsApplication::getThemeIcon( u"/mActionEllipse4Points.svg"_s );
+}
+
+QgsMapToolShapeAbstract::ShapeCategory QgsMapToolShapeEllipse4PointsMetadata::category() const
+{
+  return QgsMapToolShapeAbstract::ShapeCategory::Ellipse;
+}
+
+QgsMapToolShapeAbstract *QgsMapToolShapeEllipse4PointsMetadata::factory( QgsMapToolCapture *parentTool ) const
+{
+  return new QgsMapToolShapeEllipse4Points( parentTool );
+}
+
+bool QgsMapToolShapeEllipse4Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode )
+{
+  const QgsPoint point = mParentTool->mapPoint( *e );
+
+  if ( e->button() == Qt::LeftButton )
+  {
+    if ( mPoints.size() < 3 )
+      mPoints.append( point );
+
+    if ( !mTempRubberBand )
+    {
+      Qgis::GeometryType type = mode == QgsMapToolCapture::CapturePolygon ? Qgis::GeometryType::Polygon : Qgis::GeometryType::Line;
+      mTempRubberBand = mParentTool->createGeometryRubberBand( type, true );
+      mTempRubberBand->show();
+    }
+  }
+  else if ( e->button() == Qt::RightButton )
+  {
+    if ( mEllipse.isEmpty() )
+      return false;
+
+    addEllipseToParentTool();
+    return true;
+  }
+
+  return false;
+}
+
+void QgsMapToolShapeEllipse4Points::cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode )
+{
+  Q_UNUSED( mode )
+
+  const QgsPoint point = mParentTool->mapPoint( *e );
+
+  if ( mTempRubberBand )
+  {
+    switch ( mPoints.size() )
+    {
+      case 1:
+      {
+        // Show line from first to current point
+        auto line = std::make_unique<QgsLineString>();
+        line->addVertex( mPoints.at( 0 ) );
+        line->addVertex( point );
+        mTempRubberBand->setGeometry( line.release() );
+      }
+      break;
+      case 2:
+      {
+        // Show circle through 3 points as preview
+        const QgsCircle circle = QgsCircle::from3Points( mPoints.at( 0 ), mPoints.at( 1 ), point );
+        const QgsGeometry newGeometry( circle.toPolygon( segments() ) );
+        if ( !newGeometry.isEmpty() )
+        {
+          mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+          setTransientGeometry( newGeometry );
+        }
+      }
+      break;
+      case 3:
+      {
+        // Show actual ellipse from 4 points
+        mEllipse = QgsEllipse::from4Points( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), point );
+        const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
+        if ( !newGeometry.isEmpty() )
+        {
+          mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+          setTransientGeometry( newGeometry );
+        }
+      }
+      break;
+      default:
+        break;
+    }
+  }
+}

--- a/src/app/maptools/qgsmaptoolshapeellipse4points.cpp
+++ b/src/app/maptools/qgsmaptoolshapeellipse4points.cpp
@@ -117,10 +117,15 @@ void QgsMapToolShapeEllipse4Points::cadCanvasMoveEvent( QgsMapMouseEvent *e, Qgs
       case 3:
       {
         // Show actual ellipse from 4 points
-        mEllipse = QgsEllipse::from4Points( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), point );
-        const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
-        if ( !newGeometry.isEmpty() )
+        const QgsEllipse ellipse = QgsEllipse::from4Points( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), point );
+        if ( !ellipse.isEmpty() )
         {
+          mEllipse = ellipse;
+        }
+        // Show the ellipse (either new valid one, or last valid one)
+        if ( !mEllipse.isEmpty() )
+        {
+          const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
           mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
           setTransientGeometry( newGeometry );
         }

--- a/src/app/maptools/qgsmaptoolshapeellipse4points.h
+++ b/src/app/maptools/qgsmaptoolshapeellipse4points.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+    qgsmaptoolshapeellipse4points.h  -  map tool for adding ellipse
+    from 4 points
+    ---------------------
+    begin                : December 2025
+    copyright            : (C) 2025 by Loïc Bartoletti
+    email                : lituus at free dot fr
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLSHAPEELLIPSE4POINTS_H
+#define QGSMAPTOOLSHAPEELLIPSE4POINTS_H
+
+#include "qgis_app.h"
+#include "qgsmaptoolshapeellipseabstract.h"
+#include "qgsmaptoolshaperegistry.h"
+
+class APP_EXPORT QgsMapToolShapeEllipse4PointsMetadata : public QgsMapToolShapeMetadata
+{
+  public:
+    QgsMapToolShapeEllipse4PointsMetadata()
+      : QgsMapToolShapeMetadata()
+    {}
+
+    static const QString TOOL_ID;
+
+    QString id() const override;
+    QString name() const override;
+    QIcon icon() const override;
+    QgsMapToolShapeAbstract::ShapeCategory category() const override;
+    QgsMapToolShapeAbstract *factory( QgsMapToolCapture *parentTool ) const override;
+};
+
+class APP_EXPORT QgsMapToolShapeEllipse4Points : public QgsMapToolShapeEllipseAbstract
+{
+    Q_OBJECT
+
+  public:
+    QgsMapToolShapeEllipse4Points( QgsMapToolCapture *parentTool )
+      : QgsMapToolShapeEllipseAbstract( QgsMapToolShapeEllipse4PointsMetadata::TOOL_ID, parentTool )
+    {}
+
+    bool cadCanvasReleaseEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode ) override;
+    void cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode ) override;
+};
+
+#endif // QGSMAPTOOLSHAPEELLIPSE4POINTS_H

--- a/src/app/maptools/qgsmaptoolshapeellipsecenter3points.cpp
+++ b/src/app/maptools/qgsmaptoolshapeellipsecenter3points.cpp
@@ -1,0 +1,133 @@
+/***************************************************************************
+    qgsmaptoolshapeellipsecenter3points.cpp  -  map tool for adding ellipse
+    from center and 3 points
+    ---------------------
+    begin                : December 2025
+    copyright            : (C) 2025 by Loïc Bartoletti
+    email                : lituus at free dot fr
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaptoolshapeellipsecenter3points.h"
+
+#include <memory>
+
+#include "qgsapplication.h"
+#include "qgscircle.h"
+#include "qgsgeometryrubberband.h"
+#include "qgslinestring.h"
+#include "qgsmapmouseevent.h"
+#include "qgsmaptoolcapture.h"
+#include "qgspoint.h"
+
+#include "moc_qgsmaptoolshapeellipsecenter3points.cpp"
+
+const QString QgsMapToolShapeEllipseCenter3PointsMetadata::TOOL_ID = u"ellipse-center-3-points"_s;
+
+QString QgsMapToolShapeEllipseCenter3PointsMetadata::id() const
+{
+  return QgsMapToolShapeEllipseCenter3PointsMetadata::TOOL_ID;
+}
+
+QString QgsMapToolShapeEllipseCenter3PointsMetadata::name() const
+{
+  return QObject::tr( "Ellipse from Center and 3 Points" );
+}
+
+QIcon QgsMapToolShapeEllipseCenter3PointsMetadata::icon() const
+{
+  return QgsApplication::getThemeIcon( u"/mActionEllipseCenter3Points.svg"_s );
+}
+
+QgsMapToolShapeAbstract::ShapeCategory QgsMapToolShapeEllipseCenter3PointsMetadata::category() const
+{
+  return QgsMapToolShapeAbstract::ShapeCategory::Ellipse;
+}
+
+QgsMapToolShapeAbstract *QgsMapToolShapeEllipseCenter3PointsMetadata::factory( QgsMapToolCapture *parentTool ) const
+{
+  return new QgsMapToolShapeEllipseCenter3Points( parentTool );
+}
+
+bool QgsMapToolShapeEllipseCenter3Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode )
+{
+  const QgsPoint point = mParentTool->mapPoint( *e );
+
+  if ( e->button() == Qt::LeftButton )
+  {
+    if ( mPoints.size() < 3 )
+      mPoints.append( point );
+
+    if ( !mTempRubberBand )
+    {
+      Qgis::GeometryType type = mode == QgsMapToolCapture::CapturePolygon ? Qgis::GeometryType::Polygon : Qgis::GeometryType::Line;
+      mTempRubberBand = mParentTool->createGeometryRubberBand( type, true );
+      mTempRubberBand->show();
+    }
+  }
+  else if ( e->button() == Qt::RightButton )
+  {
+    if ( mEllipse.isEmpty() )
+      return false;
+
+    addEllipseToParentTool();
+    return true;
+  }
+
+  return false;
+}
+
+void QgsMapToolShapeEllipseCenter3Points::cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode )
+{
+  Q_UNUSED( mode )
+
+  const QgsPoint point = mParentTool->mapPoint( *e );
+
+  if ( mTempRubberBand )
+  {
+    switch ( mPoints.size() )
+    {
+      case 1:
+      {
+        // Show line from center to first point
+        auto line = std::make_unique<QgsLineString>();
+        line->addVertex( mPoints.at( 0 ) );
+        line->addVertex( point );
+        mTempRubberBand->setGeometry( line.release() );
+      }
+      break;
+      case 2:
+      {
+        // Show ellipse preview from center + 2 points
+        mEllipse = QgsEllipse::fromCenter2Points( mPoints.at( 0 ), mPoints.at( 1 ), point );
+        const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
+        if ( !newGeometry.isEmpty() )
+        {
+          mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+          setTransientGeometry( newGeometry );
+        }
+      }
+      break;
+      case 3:
+      {
+        // Show ellipse from center + 3 points
+        mEllipse = QgsEllipse::fromCenter3Points( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), point );
+        const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
+        if ( !newGeometry.isEmpty() )
+        {
+          mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
+          setTransientGeometry( newGeometry );
+        }
+      }
+      break;
+      default:
+        break;
+    }
+  }
+}

--- a/src/app/maptools/qgsmaptoolshapeellipsecenter3points.cpp
+++ b/src/app/maptools/qgsmaptoolshapeellipsecenter3points.cpp
@@ -117,10 +117,15 @@ void QgsMapToolShapeEllipseCenter3Points::cadCanvasMoveEvent( QgsMapMouseEvent *
       case 3:
       {
         // Show ellipse from center + 3 points
-        mEllipse = QgsEllipse::fromCenter3Points( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), point );
-        const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
-        if ( !newGeometry.isEmpty() )
+        const QgsEllipse ellipse = QgsEllipse::fromCenter3Points( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), point );
+        if ( !ellipse.isEmpty() )
         {
+          mEllipse = ellipse;
+        }
+        // Show the ellipse (either new valid one, or last valid one)
+        if ( !mEllipse.isEmpty() )
+        {
+          const QgsGeometry newGeometry( mEllipse.toPolygon( segments() ) );
           mTempRubberBand->setGeometry( newGeometry.constGet()->clone() );
           setTransientGeometry( newGeometry );
         }

--- a/src/app/maptools/qgsmaptoolshapeellipsecenter3points.h
+++ b/src/app/maptools/qgsmaptoolshapeellipsecenter3points.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+    qgsmaptoolshapeellipsecenter3points.h  -  map tool for adding ellipse
+    from center and 3 points
+    ---------------------
+    begin                : December 2025
+    copyright            : (C) 2025 by Loïc Bartoletti
+    email                : lituus at free dot fr
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLSHAPEELLIPSECENTER3POINTS_H
+#define QGSMAPTOOLSHAPEELLIPSECENTER3POINTS_H
+
+#include "qgis_app.h"
+#include "qgsmaptoolshapeellipseabstract.h"
+#include "qgsmaptoolshaperegistry.h"
+
+class APP_EXPORT QgsMapToolShapeEllipseCenter3PointsMetadata : public QgsMapToolShapeMetadata
+{
+  public:
+    QgsMapToolShapeEllipseCenter3PointsMetadata()
+      : QgsMapToolShapeMetadata()
+    {}
+
+    static const QString TOOL_ID;
+
+    QString id() const override;
+    QString name() const override;
+    QIcon icon() const override;
+    QgsMapToolShapeAbstract::ShapeCategory category() const override;
+    QgsMapToolShapeAbstract *factory( QgsMapToolCapture *parentTool ) const override;
+};
+
+class APP_EXPORT QgsMapToolShapeEllipseCenter3Points : public QgsMapToolShapeEllipseAbstract
+{
+    Q_OBJECT
+
+  public:
+    QgsMapToolShapeEllipseCenter3Points( QgsMapToolCapture *parentTool )
+      : QgsMapToolShapeEllipseAbstract( QgsMapToolShapeEllipseCenter3PointsMetadata::TOOL_ID, parentTool )
+    {}
+
+    bool cadCanvasReleaseEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode ) override;
+    void cadCanvasMoveEvent( QgsMapMouseEvent *e, QgsMapToolCapture::CaptureMode mode ) override;
+};
+
+#endif // QGSMAPTOOLSHAPEELLIPSECENTER3POINTS_H

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -498,7 +498,9 @@
 #include "qgsmaptoolshapecircle3tangents.h"
 #include "qgsmaptoolshapecircle2tangentspoint.h"
 #include "qgsmaptoolshapecirclecenterpoint.h"
+#include "qgsmaptoolshapeellipse4points.h"
 #include "qgsmaptoolshapeellipsecenter2points.h"
+#include "qgsmaptoolshapeellipsecenter3points.h"
 #include "qgsmaptoolshapeellipsecenterpoint.h"
 #include "qgsmaptoolshapeellipseextent.h"
 #include "qgsmaptoolshapeellipsefoci.h"
@@ -1262,7 +1264,9 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeCircle3TangentsMetadata() );
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeCircle2TangentsPointMetadata() );
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeCircleCenterPointMetadata() );
+  QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeEllipse4PointsMetadata() );
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeEllipseCenter2PointsMetadata() );
+  QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeEllipseCenter3PointsMetadata() );
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeEllipseCenterPointMetadata() );
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeEllipseExtentMetadata() );
   QgsGui::mapToolShapeRegistry()->addMapTool( new QgsMapToolShapeEllipseFociMetadata() );

--- a/src/core/geometry/qgsellipse.cpp
+++ b/src/core/geometry/qgsellipse.cpp
@@ -31,8 +31,7 @@ void QgsEllipse::normalizeAxis()
   if ( mSemiMajorAxis < mSemiMinorAxis )
   {
     std::swap( mSemiMajorAxis, mSemiMinorAxis );
-    mAzimuth = 180.0 / M_PI *
-               QgsGeometryUtilsBase::normalizedAngle( M_PI / 180.0 * ( mAzimuth + 90 ) );
+    mAzimuth = 180.0 / M_PI * QgsGeometryUtilsBase::normalizedAngle( M_PI / 180.0 * ( mAzimuth + 90 ) );
   }
 }
 
@@ -102,24 +101,396 @@ QgsEllipse QgsEllipse::fromCenter2Points( const QgsPoint &center, const QgsPoint
   return QgsEllipse( centerPt, axis_a, axis_b, azimuth );
 }
 
-bool QgsEllipse::operator ==( const QgsEllipse &elp ) const
+QgsEllipse QgsEllipse::from4Points( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, const QgsPoint &pt4 )
 {
-  return ( ( mCenter == elp.mCenter ) &&
-           qgsDoubleNear( mSemiMajorAxis, elp.mSemiMajorAxis, 1E-8 ) &&
-           qgsDoubleNear( mSemiMinorAxis, elp.mSemiMinorAxis, 1E-8 ) &&
-           qgsDoubleNear( mAzimuth, elp.mAzimuth, 1E-8 )
-         );
+  // Algorithm based on LibreCAD's RS_Ellipse::createFrom4P()
+  // Solves the linear system for axis-aligned ellipse: A*x² + B*x + C*y² + D*y = 1
+
+  constexpr double tolerance = 1e-10;
+
+  // Normalize coordinates to improve numerical stability
+  // Translate to centroid and scale by characteristic length
+  const double cx = ( pt1.x() + pt2.x() + pt3.x() + pt4.x() ) / 4.0;
+  const double cy = ( pt1.y() + pt2.y() + pt3.y() + pt4.y() ) / 4.0;
+
+  // Compute relative vectors from centroid
+  const std::array<QgsVector, 4> relativeVectors =
+  {
+    QgsVector( pt1.x() - cx, pt1.y() - cy ),
+    QgsVector( pt2.x() - cx, pt2.y() - cy ),
+    QgsVector( pt3.x() - cx, pt3.y() - cy ),
+    QgsVector( pt4.x() - cx, pt4.y() - cy )
+  };
+
+  // Compute scale as max distance from centroid
+  double scale = 0.0;
+  for ( const QgsVector &v : relativeVectors )
+  {
+    scale = std::max( scale, v.length() );
+  }
+
+  if ( scale < tolerance )
+    return QgsEllipse(); // All points coincident
+
+  const double invScale = 1.0 / scale;
+
+  // Build the 4x4 augmented matrix [M|b] where M*coeffs = b
+  // Each row: [x², x, y², y | 1] with normalized coordinates
+  double matrix[4][5];
+
+  for ( int i = 0; i < 4; ++i )
+  {
+    const double x = relativeVectors[i].x() * invScale;
+    const double y = relativeVectors[i].y() * invScale;
+    matrix[i][0] = x * x;
+    matrix[i][1] = x;
+    matrix[i][2] = y * y;
+    matrix[i][3] = y;
+    matrix[i][4] = 1.0;
+  }
+
+  // Gaussian elimination with partial pivoting
+  for ( int col = 0; col < 4; ++col )
+  {
+    // Find pivot
+    int maxRow = col;
+    double maxVal = std::fabs( matrix[col][col] );
+    for ( int row = col + 1; row < 4; ++row )
+    {
+      if ( std::fabs( matrix[row][col] ) > maxVal )
+      {
+        maxVal = std::fabs( matrix[row][col] );
+        maxRow = row;
+      }
+    }
+
+    // Swap rows
+    if ( maxRow != col )
+    {
+      for ( int k = 0; k < 5; ++k )
+        std::swap( matrix[col][k], matrix[maxRow][k] );
+    }
+
+    // Check for singular matrix
+    if ( std::fabs( matrix[col][col] ) < tolerance )
+      return QgsEllipse();
+
+    // Eliminate column
+    for ( int row = col + 1; row < 4; ++row )
+    {
+      const double factor = matrix[row][col] / matrix[col][col];
+      for ( int k = col; k < 5; ++k )
+        matrix[row][k] -= factor * matrix[col][k];
+    }
+  }
+
+  // Back substitution
+  double coeffs[4];
+  for ( int i = 3; i >= 0; --i )
+  {
+    coeffs[i] = matrix[i][4];
+    for ( int j = i + 1; j < 4; ++j )
+      coeffs[i] -= matrix[i][j] * coeffs[j];
+    if ( std::fabs( matrix[i][i] ) < tolerance )
+      return QgsEllipse();
+    coeffs[i] /= matrix[i][i];
+  }
+
+  const double A = coeffs[0]; // coefficient of x²
+  const double B = coeffs[1]; // coefficient of x
+  const double C = coeffs[2]; // coefficient of y²
+  const double D = coeffs[3]; // coefficient of y
+
+  // Validate ellipse conditions
+  // For a valid ellipse: A > 0, C > 0, and discriminant d > 0
+  if ( std::fabs( A ) < tolerance || std::fabs( C ) < tolerance )
+    return QgsEllipse();
+
+  const double d = 1.0 + 0.25 * ( B * B / A + D * D / C );
+
+  if ( d / A < tolerance || d / C < tolerance )
+    return QgsEllipse();
+
+  // Extract ellipse parameters in normalized coordinates
+  const double centerXNorm = -0.5 * B / A;
+  const double centerYNorm = -0.5 * D / C;
+  const double semiAxisXNorm = std::sqrt( d / A );
+  const double semiAxisYNorm = std::sqrt( d / C );
+
+  // Transform back to original coordinates
+  const double centerX = centerXNorm * scale + cx;
+  const double centerY = centerYNorm * scale + cy;
+  const double semiAxisX = semiAxisXNorm * scale;
+  const double semiAxisY = semiAxisYNorm * scale;
+
+  QgsPoint center( centerX, centerY );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << pt1 << pt2 << pt3 << pt4, center );
+
+  // Azimuth is 90° for axis-aligned ellipse (major axis along X or Y)
+  return QgsEllipse( center, semiAxisX, semiAxisY, 90.0 );
 }
 
-bool QgsEllipse::operator !=( const QgsEllipse &elp ) const
+QgsEllipse QgsEllipse::fromCenter3Points( const QgsPoint &center, const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3 )
+{
+  // Algorithm based on LibreCAD's RS_Ellipse::createFromCenter3Points() and createFromQuadratic()
+  // Solves the quadratic form: a*x² + b*x*y + c*y² = 1
+  // where (x,y) are coordinates relative to the center
+
+  constexpr double tolerance = 1e-10;
+
+  // Compute relative vectors from center
+  const QgsVector vp1( pt1.x() - center.x(), pt1.y() - center.y() );
+  const QgsVector vp2( pt2.x() - center.x(), pt2.y() - center.y() );
+  const QgsVector vp3( pt3.x() - center.x(), pt3.y() - center.y() );
+
+  // Distances from center (before normalization)
+  const double r1 = vp1.length();
+  const double r2 = vp2.length();
+  const double r3 = vp3.length();
+
+  // Check if any point is at the center
+  if ( r1 < tolerance || r2 < tolerance || r3 < tolerance )
+    return QgsEllipse();
+
+  // Compute scale for normalization (max distance from center)
+  const double scale = std::max( { r1, r2, r3 } );
+  const double invScale = 1.0 / scale;
+
+  // Normalize vectors for numerical stability
+  const QgsVector vp1Norm = vp1 * invScale;
+  const QgsVector vp2Norm = vp2 * invScale;
+  const QgsVector vp3Norm = vp3 * invScale;
+
+  // Normalized distances squared
+  const double r1sq = vp1Norm.lengthSquared();
+  const double r2sq = vp2Norm.lengthSquared();
+  const double r3sq = vp3Norm.lengthSquared();
+
+  // Check if pt2 and pt3 are identical (2-point case)
+  const double dist23sq = ( vp3Norm - vp2Norm ).lengthSquared();
+  const bool twoPointCase = dist23sq < tolerance;
+
+  double a, b, c; // Quadratic form coefficients
+
+  if ( twoPointCase )
+  {
+    // 2-point case: axis-aligned ellipse
+    // Solve: a*x² + c*y² = 1 (b = 0)
+    // System: vp1x²*a + vp1y²*c = 1
+    //         vp2x²*a + vp2y²*c = 1
+
+    const double vp1x2 = vp1Norm.x() * vp1Norm.x();
+    const double vp1y2 = vp1Norm.y() * vp1Norm.y();
+    const double vp2x2 = vp2Norm.x() * vp2Norm.x();
+    const double vp2y2 = vp2Norm.y() * vp2Norm.y();
+
+    const double det = vp1x2 * vp2y2 - vp2x2 * vp1y2;
+    if ( std::fabs( det ) < tolerance )
+      return QgsEllipse();
+
+    a = ( vp2y2 - vp1y2 ) / det;
+    c = ( vp1x2 - vp2x2 ) / det;
+
+    if ( a < tolerance || c < tolerance )
+      return QgsEllipse();
+
+    // Semi-axes in normalized coordinates, then scale back
+    const double semiAxisX = scale / std::sqrt( a );
+    const double semiAxisY = scale / std::sqrt( c );
+
+    QgsPoint centerPt( center );
+    QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << center << pt1 << pt2 << pt3, centerPt );
+
+    return QgsEllipse( centerPt, semiAxisX, semiAxisY, 90.0 );
+  }
+
+  // Check if all 3 points are equidistant from center (circle case)
+  // Use relative tolerance for robustness
+  const double maxRsq = std::max( { r1sq, r2sq, r3sq } );
+  if ( std::fabs( r1sq - r2sq ) < tolerance * maxRsq && std::fabs( r1sq - r3sq ) < tolerance * maxRsq )
+  {
+    // Points are on a circle - use original (non-normalized) radius
+    const double radius = r1 * scale; // r1 is normalized, scale back
+
+    QgsPoint centerPt( center );
+    QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << center << pt1 << pt2 << pt3, centerPt );
+
+    return QgsEllipse( centerPt, radius, radius, 0.0 );
+  }
+
+  // Check if pt1 and pt3 are antipodal (opposite through center)
+  // This happens when vp1 ≈ -vp3, making rows 1 and 3 of the matrix identical
+  const QgsVector sumVp13 = vp1Norm + vp3Norm;
+  const bool antipodal13 = std::fabs( sumVp13.x() ) < tolerance && std::fabs( sumVp13.y() ) < tolerance;
+
+  if ( antipodal13 && std::fabs( r1sq - r3sq ) < tolerance * maxRsq )
+  {
+    // pt1 and pt3 define a diameter, pt2 is a third point
+    // The semi-axis along pt1 direction has length r1 (original distance)
+    // We need to find the semi-axis perpendicular to it
+
+    // Direction of pt1 from center (this is one axis of the ellipse)
+    const double angle1 = vp1Norm.angle();
+
+    // Project pt2 onto the perpendicular axis
+    const double cosAngle1 = std::cos( angle1 );
+    const double sinAngle1 = std::sin( angle1 );
+
+    // pt2 in rotated coordinates (aligned with pt1 axis)
+    const double pt2AlongAxis = vp2Norm.x() * cosAngle1 + vp2Norm.y() * sinAngle1;
+    const double pt2PerpAxis = -vp2Norm.x() * sinAngle1 + vp2Norm.y() * cosAngle1;
+
+    // For ellipse: (pt2AlongAxis / a)² + (pt2PerpAxis / b)² = 1
+    // where a = normalized r1 = sqrt(r1sq), solve for b (normalized)
+    const double aNorm = std::sqrt( r1sq ); // normalized semi-axis along pt1
+    const double alongRatio = pt2AlongAxis / aNorm;
+    const double perpSq = pt2PerpAxis * pt2PerpAxis;
+
+    if ( alongRatio * alongRatio >= 1.0 - tolerance || perpSq < tolerance )
+      return QgsEllipse(); // pt2 not strictly inside or on wrong position
+
+    const double bSqNorm = perpSq / ( 1.0 - alongRatio * alongRatio );
+    if ( bSqNorm < tolerance )
+      return QgsEllipse();
+
+    // Scale back to original coordinates
+    // r1 is the original (non-normalized) distance to pt1
+    const double semiAxis1 = r1; // original distance, not r1*scale!
+    const double semiAxis2 = std::sqrt( bSqNorm ) * scale;
+
+    // Convert angle to QGIS azimuth (from north, clockwise)
+    double azimuth = 90.0 - angle1 * 180.0 / M_PI;
+    azimuth = 180.0 / M_PI * QgsGeometryUtilsBase::normalizedAngle( M_PI / 180.0 * azimuth );
+
+    QgsPoint centerPt( center );
+    QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << center << pt1 << pt2 << pt3, centerPt );
+
+    return QgsEllipse( centerPt, semiAxis1, semiAxis2, azimuth );
+  }
+
+  // 3-point case: general ellipse with possible rotation
+  // Solve: a*x² + b*x*y + c*y² = 1
+  // Direct 3x3 system (exact solution when 3 points define unique ellipse)
+
+  const double m00 = vp1Norm.x() * vp1Norm.x(), m01 = vp1Norm.x() * vp1Norm.y(), m02 = vp1Norm.y() * vp1Norm.y();
+  const double m10 = vp2Norm.x() * vp2Norm.x(), m11 = vp2Norm.x() * vp2Norm.y(), m12 = vp2Norm.y() * vp2Norm.y();
+  const double m20 = vp3Norm.x() * vp3Norm.x(), m21 = vp3Norm.x() * vp3Norm.y(), m22 = vp3Norm.y() * vp3Norm.y();
+
+  // Build augmented matrix for Gaussian elimination
+  double matrix[3][4] =
+  {
+    { m00, m01, m02, 1.0 },
+    { m10, m11, m12, 1.0 },
+    { m20, m21, m22, 1.0 }
+  };
+
+  // Gaussian elimination with partial pivoting
+  for ( int col = 0; col < 3; ++col )
+  {
+    int maxRow = col;
+    double maxVal = std::fabs( matrix[col][col] );
+    for ( int row = col + 1; row < 3; ++row )
+    {
+      if ( std::fabs( matrix[row][col] ) > maxVal )
+      {
+        maxVal = std::fabs( matrix[row][col] );
+        maxRow = row;
+      }
+    }
+
+    if ( maxRow != col )
+    {
+      for ( int k = 0; k < 4; ++k )
+        std::swap( matrix[col][k], matrix[maxRow][k] );
+    }
+
+    if ( std::fabs( matrix[col][col] ) < tolerance )
+      return QgsEllipse(); // Singular matrix - points don't define valid ellipse
+
+    for ( int row = col + 1; row < 3; ++row )
+    {
+      const double factor = matrix[row][col] / matrix[col][col];
+      for ( int k = col; k < 4; ++k )
+        matrix[row][k] -= factor * matrix[col][k];
+    }
+  }
+
+  // Back substitution
+  if ( std::fabs( matrix[2][2] ) < tolerance || std::fabs( matrix[1][1] ) < tolerance )
+    return QgsEllipse();
+
+  c = matrix[2][3] / matrix[2][2];
+  b = ( matrix[1][3] - matrix[1][2] * c ) / matrix[1][1];
+  a = ( matrix[0][3] - matrix[0][1] * b - matrix[0][2] * c ) / matrix[0][0];
+
+  // Convert quadratic form to ellipse parameters using eigenvalue decomposition #spellOk
+  // Matrix: | a    b/2 |
+  //         | b/2  c   |
+  // Eigenvalues: λ = (a+c ± sqrt((a-c)² + b²)) / 2
+
+  const double d = a - c;
+  const double s = std::hypot( d, b );
+
+  // For a valid ellipse, both eigenvalues must be positive
+  // This requires: s < a + c
+  if ( s >= a + c - tolerance )
+    return QgsEllipse();
+
+  const double lambda1 = 0.5 * ( a + c - s ); // smaller eigenvalue
+  const double lambda2 = 0.5 * ( a + c + s ); // larger eigenvalue
+
+  if ( lambda1 < tolerance || lambda2 < tolerance )
+    return QgsEllipse();
+
+  // Semi-axes from eigenvalues (in normalized coordinates), then scale back
+  const double semiMajor = scale / std::sqrt( lambda1 );
+  const double semiMinor = scale / std::sqrt( lambda2 );
+
+  // Compute azimuth from eigenvector
+  // For eigenvalue (a+c-s)/2, eigenvector is:
+  // if a >= c: (-b, d+s)
+  // if a < c:  (s-d, -b)
+  // Angle of vector (x, y) is atan2(y, x)
+  double azimuth;
+  if ( std::fabs( b ) < tolerance )
+  {
+    // Axis-aligned case
+    azimuth = ( a <= c ) ? 90.0 : 0.0;
+  }
+  else if ( a >= c )
+  {
+    // Eigenvector (-b, d+s), angle = atan2(d+s, -b)
+    azimuth = std::atan2( d + s, -b );
+    azimuth = 90.0 - azimuth * 180.0 / M_PI;
+  }
+  else
+  {
+    // Eigenvector (s-d, -b), angle = atan2(-b, s-d)
+    azimuth = std::atan2( -b, s - d );
+    azimuth = 90.0 - azimuth * 180.0 / M_PI;
+  }
+
+  azimuth = 180.0 / M_PI * QgsGeometryUtilsBase::normalizedAngle( M_PI / 180.0 * azimuth );
+
+  QgsPoint centerPt( center );
+  QgsGeometryUtils::transferFirstZOrMValueToPoint( QgsPointSequence() << center << pt1 << pt2 << pt3, centerPt );
+
+  return QgsEllipse( centerPt, semiMajor, semiMinor, azimuth );
+}
+
+bool QgsEllipse::operator==( const QgsEllipse &elp ) const
+{
+  return ( ( mCenter == elp.mCenter ) && qgsDoubleNear( mSemiMajorAxis, elp.mSemiMajorAxis, 1E-8 ) && qgsDoubleNear( mSemiMinorAxis, elp.mSemiMinorAxis, 1E-8 ) && qgsDoubleNear( mAzimuth, elp.mAzimuth, 1E-8 ) );
+}
+
+bool QgsEllipse::operator!=( const QgsEllipse &elp ) const
 {
   return !operator==( elp );
 }
 
 bool QgsEllipse::isEmpty() const
 {
-  return ( qgsDoubleNear( mSemiMajorAxis, 0.0, 1E-8 ) ||
-           qgsDoubleNear( mSemiMinorAxis, 0.0, 1E-8 ) );
+  return ( qgsDoubleNear( mSemiMajorAxis, 0.0, 1E-8 ) || qgsDoubleNear( mSemiMinorAxis, 0.0, 1E-8 ) );
 }
 
 void QgsEllipse::setSemiMajorAxis( const double axis_a )
@@ -135,8 +506,7 @@ void QgsEllipse::setSemiMinorAxis( const double axis_b )
 
 void QgsEllipse::setAzimuth( const double azimuth )
 {
-  mAzimuth = 180.0 / M_PI *
-             QgsGeometryUtilsBase::normalizedAngle( M_PI / 180.0 * azimuth );
+  mAzimuth = 180.0 / M_PI * QgsGeometryUtilsBase::normalizedAngle( M_PI / 180.0 * azimuth );
 }
 
 double QgsEllipse::focusDistance() const
@@ -201,9 +571,7 @@ QgsPointSequence QgsEllipse::points( unsigned int segments ) const
   pts.reserve( x.size() );
   for ( int i = 0; i < x.size(); ++i )
   {
-    pts.append( QgsPoint( x[i], y[i],
-                          hasZ ? z[i] : std::numeric_limits< double >::quiet_NaN(),
-                          hasM ? m[i] : std::numeric_limits< double >::quiet_NaN() ) );
+    pts.append( QgsPoint( x[i], y[i], hasZ ? z[i] : std::numeric_limits< double >::quiet_NaN(), hasM ? m[i] : std::numeric_limits< double >::quiet_NaN() ) );
   }
   return pts;
 }
@@ -245,12 +613,10 @@ void QgsEllipse::pointsInternal( unsigned int segments, QVector<double> &x, QVec
   const double sinAzimuth = std::sin( azimuth );
   for ( double it : t )
   {
-    const double cosT{ std::cos( it ) };
-    const double sinT{ std::sin( it ) };
-    *xOut++ = centerX + mSemiMajorAxis * cosT * cosAzimuth -
-              mSemiMinorAxis * sinT * sinAzimuth;
-    *yOut++ = centerY + mSemiMajorAxis * cosT * sinAzimuth +
-              mSemiMinorAxis * sinT * cosAzimuth;
+    const double cosT { std::cos( it ) };
+    const double sinT { std::sin( it ) };
+    *xOut++ = centerX + mSemiMajorAxis * cosT * cosAzimuth - mSemiMinorAxis * sinT * sinAzimuth;
+    *yOut++ = centerY + mSemiMajorAxis * cosT * sinAzimuth + mSemiMinorAxis * sinT * cosAzimuth;
     if ( zOut )
       *zOut++ = centerZ;
     if ( mOut )

--- a/src/core/geometry/qgsellipse.h
+++ b/src/core/geometry/qgsellipse.h
@@ -106,6 +106,55 @@ class CORE_EXPORT QgsEllipse
      */
     static QgsEllipse fromCenter2Points( const QgsPoint &ptc, const QgsPoint &pt1, const QgsPoint &pt2 ) SIP_HOLDGIL;
 
+    /**
+     * Constructs an ellipse from 4 points.
+     *
+     * The ellipse will have axes aligned to the X and Y axes.
+     * The 4 points must lie on the ellipse and define a unique axis-aligned ellipse.
+     *
+     * Z dimension is supported and is retrieved from the first 3D point amongst the input points.
+     * M value is retrieved from the first point with M amongst the input points.
+     *
+     * If the 4 points do not define a valid ellipse (e.g., collinear points, points forming
+     * a hyperbola, or insufficient points), an empty ellipse is returned.
+     *
+     * \param pt1 First point on the ellipse.
+     * \param pt2 Second point on the ellipse.
+     * \param pt3 Third point on the ellipse.
+     * \param pt4 Fourth point on the ellipse.
+     * \return The constructed ellipse, or an empty ellipse if the points do not define a valid ellipse.
+     *
+     * \note This method produces only axis-aligned ellipses (azimuth is always 90 degrees).
+     *
+     * \since QGIS 4.0
+     */
+    static QgsEllipse from4Points( const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3, const QgsPoint &pt4 ) SIP_HOLDGIL;
+
+    /**
+     * Constructs an ellipse from a center point and 3 points on the ellipse.
+     *
+     * Unlike from4Points(), this method can produce ellipses with any orientation.
+     *
+     * Z dimension is supported and is retrieved from the first 3D point amongst the input points.
+     * M value is retrieved from the first point with M amongst the input points.
+     *
+     * If \a pt2 and \a pt3 are identical (within tolerance), the method will construct
+     * an axis-aligned ellipse using only 2 points.
+     *
+     * If the points do not define a valid ellipse (e.g., a point coincides with the center,
+     * points are collinear through the center, or the resulting shape is not an ellipse),
+     * an empty ellipse is returned.
+     *
+     * \param center The center point of the ellipse.
+     * \param pt1 First point on the ellipse.
+     * \param pt2 Second point on the ellipse.
+     * \param pt3 Third point on the ellipse.
+     * \return The constructed ellipse, or an empty ellipse if the points do not define a valid ellipse.
+     *
+     * \since QGIS 4.0
+     */
+    static QgsEllipse fromCenter3Points( const QgsPoint &center, const QgsPoint &pt1, const QgsPoint &pt2, const QgsPoint &pt3 ) SIP_HOLDGIL;
+
     virtual bool operator ==( const QgsEllipse &elp ) const;
     virtual bool operator !=( const QgsEllipse &elp ) const;
 


### PR DESCRIPTION
## Description

Months (maybe years) ago, I started to adapt these two LibreCAD algorithms in QGIS. 
They may not be the most useful (but they are undoubtedly the most complicated, especially center and 3 points), but I'm clearing out my PR stock.

@ptitjano may I ask you to review my math, please :pray: 

A few precisions: this is not a direct port, as it uses dedicated QGIS methods, a different orientation (north = 0, clockwise), Z/M support, and some robustness improvements (pivot) due to numerical issues with our coordinate system.

For the map tools, there is nothing in particular to report, except that I have adopted the LibreCAD logic of retaining the last valid geometry. Since these two algorithms often tend to produce empty results, this prevents the rubberband from disappearing too often.


Example:

### Ellipse by 4 points

https://github.com/user-attachments/assets/ad2bbfba-039e-4fe1-84b7-5c5da310000f


### Ellipse by Center and 3 points

https://github.com/user-attachments/assets/0594d325-fb0b-49f1-936f-820cb4d8093b

PS: I open the PR with app and core, but I can split it later (core vs app or by method). This allows me to show what it will be used for.