### PR TITLE
fix: add install of landingpage webapp resources

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -71,7 +71,6 @@ if (WITH_SERVER_LANDINGPAGE_WEBAPP)
   endif()
   ")
   add_custom_command(
-    POST_BUILD
     OUTPUT ${LANDINGPAGE_OUTPUT_PATH}/landingpage.stamp
     DEPENDS ${LANDINGPAGE_SOURCE_FILES}
     COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -79,6 +78,18 @@ if (WITH_SERVER_LANDINGPAGE_WEBAPP)
     ${LANDINGPAGE_OUTPUT_PATH}/
     COMMAND ${CMAKE_COMMAND} -E touch ${LANDINGPAGE_OUTPUT_PATH}/landingpage.stamp
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/yarn_commands.cmake
+  )
+
+  # see outputDir in: resources/server/src/landingpage/vue.config.js
+  cmake_path(
+    APPEND LANDINGPAGE_OUTPUT_PATH
+    "../../api/ogc/static/landingpage"
+    OUTPUT_VARIABLE LANDINGPAGE_YARN_OUTPUTDIR
+  )
+
+  install(
+    DIRECTORY ${LANDINGPAGE_YARN_OUTPUTDIR}
+    DESTINATION ${QGIS_DATA_DIR}/resources/server/api/ogc/static
   )
 endif()
 


### PR DESCRIPTION
## Description

### Goal
This PR aim to provide a fix to issue #55462 by the adding install of the landingpage resource files built with yarn.

### Changes
Previously, when building with WITH_SERVER_LANDINGPAGE_WEBAPP, the landingpage webapp resources were copied to the build directory and thereafter built from there using the commands in the yarn_command.cmake. The resources needed for the webapp was thus available in the build output directory, but, they were never installed. This PR adds install of the directory "../../api/ogc/static/landingpage" created by yarn build.

In addition, the POST_BUILD was removed from:
` add_custom_command(
    POST_BUILD`, as this was not correctly written add_custom_command, and thus confusing. 


### Additional Note
Note that landingpage webapp source files in server/src/landingpage are also installed in a previous step when WITH_SERVER.

### Tested
This patch was tested in build on rockylinux 10.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
