### PR TITLE
Add some missing Qt::StringLiterals namespace

### DIFF
--- a/src/app/georeferencer/qgsgeorefdelegates.cpp
+++ b/src/app/georeferencer/qgsgeorefdelegates.cpp
@@ -27,6 +27,8 @@
 
 #include "moc_qgsgeorefdelegates.cpp"
 
+using namespace Qt::StringLiterals;
+
 // ------------------------- QgsDmsAndDdDelegate --------------------------- //
 QgsDmsAndDdDelegate::QgsDmsAndDdDelegate( QWidget *parent )
   : QStyledItemDelegate( parent )

--- a/src/app/pluginmanager/qgspluginsortfilterproxymodel.cpp
+++ b/src/app/pluginmanager/qgspluginsortfilterproxymodel.cpp
@@ -18,6 +18,8 @@
 
 #include "moc_qgspluginsortfilterproxymodel.cpp"
 
+using namespace Qt::StringLiterals;
+
 QgsPluginSortFilterProxyModel::QgsPluginSortFilterProxyModel( QObject *parent )
   : QSortFilterProxyModel( parent )
 {


### PR DESCRIPTION
## Description

This seems to fix some windows vcpkg CI issues. See for example: https://github.com/qgis/QGIS/actions/runs/21176580805/job/60906980313?pr=64569