### PR TITLE
The password is partially shown in the layer properties if there is a space 

### DIFF
--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -240,7 +240,14 @@ QString QgsDataSourceUri::removePassword( const QString &aUri, bool hide )
   QString safeName( aUri );
   if ( aUri.contains( " password="_L1 ) )
   {
-    regexp.setPattern( u" password=.* "_s );
+    if ( aUri.contains( " password='"_L1 ) )
+    {
+      regexp.setPattern( u" password='[^']*' "_s );
+    }
+    else
+    {
+      regexp.setPattern( u" password=.* "_s );
+    }
 
     if ( hide )
     {

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -816,6 +816,12 @@ void TestQgsDataSourceUri::checkRemovePassword()
 
   const QString uri2 = QgsDataSourceUri::removePassword( u"postgresql://user@127.0.0.1:5432?dbname=test"_s );
   QCOMPARE( uri2, u"postgresql://user@127.0.0.1:5432?dbname=test"_s );
+
+  const QString uri3 = QgsDataSourceUri::removePassword( u"dbname='geodata' host=localhost port=5432 user='jgr' password='s Hertogenbosch 2023' srid=4326 table=\"Rocha\".\"pocos_gebox_005\" (rast)"_s );
+  QCOMPARE( uri3, u"dbname='geodata' host=localhost port=5432 user='jgr' srid=4326 table=\"Rocha\".\"pocos_gebox_005\" (rast)"_s );
+
+  const QString uri4 = QgsDataSourceUri::removePassword( u"dbname='geodata' host=localhost port=5432 user='jgr' password='s Hertogenbosch 2023' srid=4326 table=\"Rocha\".\"pocos_gebox_005\" (rast)"_s, true );
+  QCOMPARE( uri4, u"dbname='geodata' host=localhost port=5432 user='jgr' password=XXXXXXXX srid=4326 table=\"Rocha\".\"pocos_gebox_005\" (rast)"_s );
 }
 
 void TestQgsDataSourceUri::checkUnicodeUri()


### PR DESCRIPTION
## Description

This PR enhances the method we use to hide the password. It adds a new regular expression to capture everything between quotes, after `password=`, if there are quotes.

Fix #64630 

## Validating

The following code can be used to test and validate this PR.

Password with spaces:

```python
uri = QgsDataSourceUri()
print( uri.removePassword( "dbname='geodata' host=localhost port=5432 user='jgr' password='Hertogenbosch 2023' srid=4326 table=\"Rocha\".\"pocos_gebox_005\" (rast)" ) ) 

dbname='geodata' host=localhost port=5432 user='jgr' srid=4326 table="Rocha"."pocos_gebox_005" (rast)
```

Password with multiple spaces:

```python
uri = QgsDataSourceUri()
print( uri.removePassword( "dbname='geodata' host=localhost port=5432 user='jgr' password='s Hertogenbosch2023' srid=4326 table=\"Rocha\".\"pocos_gebox_005\" (rast)" ) ) 

dbname='geodata' host=localhost port=5432 user='jgr' srid=4326 table="Rocha"."pocos_gebox_005" (rast)
```

Password without spaces (keep the old behavior):

```python
uri = QgsDataSourceUri()
print( uri.removePassword( "dbname='geodata' host=localhost port=5432 user='jgr' password='Hertogenbosch2023' srid=4326 table=\"Rocha\".\"pocos_gebox_005\" (rast)" ) ) 

dbname='geodata' host=localhost port=5432 user='jgr' srid=4326 table="Rocha"."pocos_gebox_005" (rast)
```

Masking the password:

```python
uri = QgsDataSourceUri()
print( uri.removePassword( "dbname='geodata' host=localhost port=5432 user='jgr' password='s Hertogenbosch2023' srid=4326 table=\"Rocha\".\"pocos_gebox_005\" (rast)", True ) ) 

dbname='geodata' host=localhost port=5432 user='jgr' password=XXXXXXXX srid=4326 table="Rocha"."pocos_gebox_005" (rast)
```

