### PR TITLE
[espressions] Fix overlay_equals description

### DIFF
--- a/resources/function_help/json/overlay_equals
+++ b/resources/function_help/json/overlay_equals
@@ -2,7 +2,7 @@
   "name": "overlay_equals",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature spatially equals to at least one feature from a target layer, or an array of expression-based results for the features in the target layer that are spatially equal to the current feature.<br><br>Read more on the underlying GEOS \"Equals\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Equals.html'>ST_Equals</a> function.",
+  "description": "Returns whether the current feature is exactly equal to at least one feature from a target layer, or an array of expression-based results for the features in the target layer that are exactly equal to the current feature. Note that the order of vertices matters.",
   "arguments": [{
     "arg": "layer",
     "description": "the layer whose overlay is checked"
@@ -26,22 +26,22 @@
   }],
   "examples": [{
     "expression": "overlay_equals('regions')",
-    "returns": "TRUE if the current feature is spatially equal to a region"
+    "returns": "TRUE if the current feature is exactly equal to a region"
   }, {
     "expression": "overlay_equals('regions', filter:= population > 10000)",
-    "returns": "TRUE if the current feature is spatially equal to a region with a population greater than 10000"
+    "returns": "TRUE if the current feature is exactly equal to a region with a population greater than 10000"
   }, {
     "expression": "overlay_equals('regions', name)",
-    "returns": "an array of names, for the regions spatially equal to the current feature"
+    "returns": "an array of names, for the regions exactly equal to the current feature"
   }, {
     "expression": "array_to_string(overlay_equals('regions', name))",
-    "returns": "a string as a comma separated list of names, for the regions spatially equal to the current feature"
+    "returns": "a string as a comma separated list of names, for the regions exactly equal to the current feature"
   }, {
     "expression": "array_sort(overlay_equals(layer:='regions', expression:=\"name\", filter:= population > 10000))",
-    "returns": "an ordered array of names, for the regions spatially equal to the current feature and with a population greater than 10000"
+    "returns": "an ordered array of names, for the regions exactly equal to the current feature and with a population greater than 10000"
   }, {
     "expression": "overlay_equals(layer:='regions', expression:= geom_to_wkt(@geometry), limit:=2)",
-    "returns": "an array of geometries (in WKT), for up to two regions spatially equal to the current feature"
+    "returns": "an array of geometries (in WKT), for up to two regions exactly equal to the current feature"
   }],
-  "tags": ["predicate", "current", "equals", "equal", "target", "array", "geos", "st_equals", "described", "underlying", "features"]
+  "tags": ["predicate", "current", "equals", "equal", "target", "array", "exactly", "described", "underlying", "features"]
 }

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -187,6 +187,8 @@ void TestQgsOverlayExpression::testOverlay_data()
 
   QTest::newRow( "equals no match" ) << "overlay_equals('rectangles')" << "POLYGON((-156 46, -149 46, -148 37, -156 46))" << false;
   QTest::newRow( "equals no match [cached]" ) << "overlay_equals('rectangles',cache:=true)" << "POLYGON((-156 46, -149 46, -148 37, -156 46))" << false;
+  QTest::newRow( "equals no match different vertices order" ) << "overlay_equals('rectangles')" << "POLYGON((-160 50, -160 35, -145 35, -145 50, -160 50))" << false;
+  QTest::newRow( "equals no match different vertices order [cached]" ) << "overlay_equals('rectangles',cache:=true)" << "POLYGON((-160 50, -160 35, -145 35, -145 50, -160 50))" << false;
 
   QTest::newRow( "disjoint" ) << "overlay_disjoint('rectangles')" << "LINESTRING(-155 15, -122 55, -84 4)" << true;
   QTest::newRow( "disjoint [cached]" ) << "overlay_disjoint('rectangles',cache:=true)" << "LINESTRING(-155 15, -122 55, -84 4)" << true;


### PR DESCRIPTION
## Description

The `overlay_equals` expression function description (since https://github.com/qgis/QGIS/issues/39097) is incorrect: it wrongly states that the behaviour of such function is based on the <<underlying GEOS “Equals” predicate, as described in PostGIS [ST_Equals](https://postgis.net/docs/ST_Equals.html) function>>, while it's actually based on `QgsGeometry:equals` which behaves differently from GEOS “Equals” and PostGIS ST_Equals. The description would have been correct if `overlay_equals` had been based on `QgsGeometry:isGeosEqual` instead of `QgsGeometry:equals`.

This PR just fixes such description (see discussion in https://github.com/qgis/QGIS/pull/64627#discussion_r2709763396 and https://github.com/qgis/QGIS/pull/64627#discussion_r2710415994) in order for it to reflect the actual behaviour of the function and also adds a test that explicitly tests the relevant aspect of the actual behaviour.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
