### PR TITLE
xprocessing: remove deprecated OPTIONS param from GridNearestNeighbor …

### DIFF
--- a/python/plugins/processing/algs/gdal/GridNearestNeighbor.py
+++ b/python/plugins/processing/algs/gdal/GridNearestNeighbor.py
@@ -48,7 +48,6 @@ class GridNearestNeighbor(GdalAlgorithm):
     RADIUS_2 = "RADIUS_2"
     ANGLE = "ANGLE"
     NODATA = "NODATA"
-    OPTIONS = "OPTIONS"
     CREATION_OPTIONS = "CREATION_OPTIONS"
     EXTRA = "EXTRA"
     DATA_TYPE = "DATA_TYPE"
@@ -262,9 +261,7 @@ class GridNearestNeighbor(GdalAlgorithm):
             arguments.extend(input_details.open_options_as_arguments())
 
         options = self.parameterAsString(parameters, self.CREATION_OPTIONS, context)
-        # handle backwards compatibility parameter OPTIONS
-        if self.OPTIONS in parameters and parameters[self.OPTIONS] not in (None, ""):
-            options = self.parameterAsString(parameters, self.OPTIONS, context)
+
         if options:
             arguments.extend(GdalUtils.parseCreationOptions(options))
 


### PR DESCRIPTION
processing: remove deprecated OPTIONS parameter from GridNearestNeighbor (QGIS 5 cleanup)

## Description

This PR removes the legacy `OPTIONS` parameter from the GridNearestNeighbor algorithm.

Context:
- Marked with `# TODO QGIS 5: remove parameter and related logic`
- Deprecated in favor of `CREATION_OPTIONS`
- No functional or UI changes
- Internal cleanup aligned with QGIS 5 transition

No documentation impact.
No backport required.

Reference: the parameter is already annotated with `# TODO QGIS 5: remove parameter and related logic` in the source.
