### PR TITLE
QgsPointXY add operator< and remove PointComparer from TopolygChecker

### DIFF
--- a/python/PyQt6/core/auto_additions/qgspointxy.py
+++ b/python/PyQt6/core/auto_additions/qgspointxy.py
@@ -1,0 +1,6 @@
+# The following has been generated automatically from src/core/qgspointxy.h
+try:
+    QgsPointXY.__attribute_docs__ = {'mY': 'y coordinate', 'mIsEmpty': 'is point empty?'}
+    QgsPointXY.__annotations__ = {'mY': float, 'mIsEmpty': bool}
+except (NameError, AttributeError):
+    pass

--- a/python/PyQt6/core/auto_generated/qgspointxy.sip.in
+++ b/python/PyQt6/core/auto_generated/qgspointxy.sip.in
@@ -242,6 +242,8 @@ distance comparison
 Multiply x and y by the given value
 %End
 
+    bool operator<( const QgsPointXY &other ) const /HoldGIL/;
+
 
     QgsVector operator-( const QgsPointXY &p ) const;
 

--- a/python/core/auto_additions/qgspointxy.py
+++ b/python/core/auto_additions/qgspointxy.py
@@ -1,0 +1,6 @@
+# The following has been generated automatically from src/core/qgspointxy.h
+try:
+    QgsPointXY.__attribute_docs__ = {'mY': 'y coordinate', 'mIsEmpty': 'is point empty?'}
+    QgsPointXY.__annotations__ = {'mY': float, 'mIsEmpty': bool}
+except (NameError, AttributeError):
+    pass

--- a/python/core/auto_generated/qgspointxy.sip.in
+++ b/python/core/auto_generated/qgspointxy.sip.in
@@ -242,6 +242,8 @@ distance comparison
 Multiply x and y by the given value
 %End
 
+    bool operator<( const QgsPointXY &other ) const /HoldGIL/;
+
 
     QgsVector operator-( const QgsPointXY &p ) const;
 

--- a/src/core/qgspointxy.h
+++ b/src/core/qgspointxy.h
@@ -301,6 +301,34 @@ class CORE_EXPORT QgsPointXY
       mY *= scalar;
     }
 
+    /**
+     * Compares if this point is less than other point
+     * \param other point to compare with
+     *
+     * Points are ordered first by x coordinate, then by y coordinate.
+     *
+     * \since QGIS 4.0
+     */
+    bool operator<( const QgsPointXY &other ) const SIP_HOLDGIL
+    {
+      constexpr double epsilon = 1E-8;
+
+      // Handle empty points: empty points are "less than" non-empty points
+      if ( isEmpty() && !other.isEmpty() )
+        return true;
+      if ( !isEmpty() && other.isEmpty() )
+        return false;
+      if ( isEmpty() && other.isEmpty() )
+        return false;
+
+      if ( mX < other.mX - epsilon )
+        return true;
+      if ( mX > other.mX + epsilon )
+        return false;
+
+      return mY < other.mY - epsilon;
+    }
+
     QgsPointXY &operator=( const QgsPointXY &other ) SIP_HOLDGIL
     {
       if ( &other != this )

--- a/src/plugins/topology/topolTest.cpp
+++ b/src/plugins/topology/topolTest.cpp
@@ -115,7 +115,7 @@ ErrorList topolTest::checkDanglingLines( QgsVectorLayer *layer1, QgsVectorLayer 
   QgsPointXY startPoint;
   QgsPointXY endPoint;
 
-  std::multimap<QgsPointXY, QgsFeatureId, PointComparer> endVerticesMap;
+  std::multimap<QgsPointXY, QgsFeatureId> endVerticesMap;
 
   for ( it = mFeatureList1.begin(); it != mFeatureList1.end(); ++it )
   {
@@ -165,7 +165,7 @@ ErrorList topolTest::checkDanglingLines( QgsVectorLayer *layer1, QgsVectorLayer 
   const QgsGeometry canvasExtentPoly = QgsGeometry::fromRect( qgsInterface->mapCanvas()->extent() );
 
 
-  for ( std::multimap<QgsPointXY, QgsFeatureId, PointComparer>::iterator pointIt = endVerticesMap.begin(), end = endVerticesMap.end(); pointIt != end; pointIt = endVerticesMap.upper_bound( pointIt->first ) )
+  for ( std::multimap<QgsPointXY, QgsFeatureId>::iterator pointIt = endVerticesMap.begin(), end = endVerticesMap.end(); pointIt != end; pointIt = endVerticesMap.upper_bound( pointIt->first ) )
   {
     const QgsPointXY p = pointIt->first;
     const QgsFeatureId k = pointIt->second;
@@ -580,7 +580,7 @@ ErrorList topolTest::checkPseudos( QgsVectorLayer *layer1, QgsVectorLayer *layer
   QgsPointXY startPoint;
   QgsPointXY endPoint;
 
-  std::multimap<QgsPointXY, QgsFeatureId, PointComparer> endVerticesMap;
+  std::multimap<QgsPointXY, QgsFeatureId> endVerticesMap;
 
   for ( it = mFeatureList1.begin(); it != mFeatureList1.end(); ++it )
   {
@@ -631,7 +631,7 @@ ErrorList topolTest::checkPseudos( QgsVectorLayer *layer1, QgsVectorLayer *layer
   const QgsGeometry canvasExtentPoly = QgsGeometry::fromRect( qgsInterface->mapCanvas()->extent() );
 
 
-  for ( std::multimap<QgsPointXY, QgsFeatureId, PointComparer>::iterator pointIt = endVerticesMap.begin(), end = endVerticesMap.end(); pointIt != end; pointIt = endVerticesMap.upper_bound( pointIt->first ) )
+  for ( std::multimap<QgsPointXY, QgsFeatureId>::iterator pointIt = endVerticesMap.begin(), end = endVerticesMap.end(); pointIt != end; pointIt = endVerticesMap.upper_bound( pointIt->first ) )
   {
     const QgsPointXY p = pointIt->first;
     const QgsFeatureId k = pointIt->second;

--- a/src/plugins/topology/topolTest.h
+++ b/src/plugins/topology/topolTest.h
@@ -70,29 +70,6 @@ class TopologyRule
     {}
 };
 
-/**
- * helper class to pass as comparator to map,set etc..
-  */
-class PointComparer
-{
-  public:
-    bool operator()( const QgsPointXY &p1, const QgsPointXY &p2 ) const
-    {
-      if ( p1.x() < p2.x() )
-      {
-        return true;
-      }
-
-      if ( p1.x() == p2.x() && p1.y() < p2.y() )
-      {
-        return true;
-      }
-
-      return false;
-    }
-};
-
-
 class topolTest : public QObject
 {
     Q_OBJECT


### PR DESCRIPTION
## Description

 Add `operator< ` to QgsPointXY with corresponding tests and remove the old custom comparator PointComparer from topology plugin.

@Djedouas @uclaros could you take a look and test it? Thanks.