### PR TITLE
Topology: fix potential memory leak and remove a deprecated GEOS function in checkGaps

### DIFF
--- a/src/plugins/topology/topolTest.cpp
+++ b/src/plugins/topology/topolTest.cpp
@@ -492,14 +492,7 @@ ErrorList topolTest::checkGaps( QgsVectorLayer *layer1, QgsVectorLayer *layer2, 
     return errorList;
   }
 
-  GEOSGeometry **geomArray = new GEOSGeometry *[geomList.size()];
-  for ( int i = 0; i < geomList.size(); ++i )
-  {
-    geomArray[i] = geomList.at( i );
-  }
-
-  GEOSGeometry *collection = GEOSGeom_createCollection_r( geosctxt, GEOS_MULTIPOLYGON, geomArray, geomList.size() );
-  delete[] geomArray;
+  GEOSGeometry *collection = GEOSGeom_createCollection_r( geosctxt, GEOS_MULTIPOLYGON, geomList.data(), geomList.size() );
 
   if ( !collection )
   {
@@ -1231,10 +1224,7 @@ void topolTest::fillFeatureMap( QgsVectorLayer *layer, const QgsRectangle &exten
   }
   else
   {
-    fit = layer->getFeatures( QgsFeatureRequest()
-                                .setFilterRect( extent )
-                                .setFlags( Qgis::FeatureRequestFlag::ExactIntersect )
-                                .setNoAttributes() );
+    fit = layer->getFeatures( QgsFeatureRequest().setFilterRect( extent ).setFlags( Qgis::FeatureRequestFlag::ExactIntersect ).setNoAttributes() );
   }
 
   QgsFeature f;
@@ -1257,10 +1247,7 @@ void topolTest::fillFeatureList( QgsVectorLayer *layer, const QgsRectangle &exte
   }
   else
   {
-    fit = layer->getFeatures( QgsFeatureRequest()
-                                .setFilterRect( extent )
-                                .setFlags( Qgis::FeatureRequestFlag::ExactIntersect )
-                                .setNoAttributes() );
+    fit = layer->getFeatures( QgsFeatureRequest().setFilterRect( extent ).setFlags( Qgis::FeatureRequestFlag::ExactIntersect ).setNoAttributes() );
   }
 
   QgsFeature f;
@@ -1285,10 +1272,7 @@ QgsSpatialIndex *topolTest::createIndex( QgsVectorLayer *layer, const QgsRectang
   }
   else
   {
-    fit = layer->getFeatures( QgsFeatureRequest()
-                                .setFilterRect( extent )
-                                .setFlags( Qgis::FeatureRequestFlag::ExactIntersect )
-                                .setNoAttributes() );
+    fit = layer->getFeatures( QgsFeatureRequest().setFilterRect( extent ).setFlags( Qgis::FeatureRequestFlag::ExactIntersect ).setNoAttributes() );
   }
 
 


### PR DESCRIPTION
## Description


I'm not toally sure about the mem leak here, but `GEOSUnionCascaded_r` is deprecated since 3.3.0 we must use `GEOSUnaryUnion_r` instead.

@Djedouas @uclaros could you take a look and test it? Thanks.

The topology codebase could be modernized, but it's out of the scope here.