### PR TITLE
[fix] Handle identical points in QgsCrossSection

### DIFF
--- a/src/3d/qgscrosssection.cpp
+++ b/src/3d/qgscrosssection.cpp
@@ -28,6 +28,9 @@ QgsCrossSection::QgsCrossSection( const QgsPoint &p1, const QgsPoint &p2, double
 
 QgsGeometry QgsCrossSection::asGeometry( const QgsCoordinateTransform *ct ) const
 {
+  if ( !isValid() )
+    return QgsGeometry();
+
   QgsVector vec( mEndPoint - mStartPoint );
   vec = vec.normalized().perpVector();
 
@@ -74,6 +77,9 @@ void QgsCrossSection::nudgeRight( double distance )
 
 void QgsCrossSection::nudge( double distance )
 {
+  if ( !isValid() )
+    return;
+
   QgsVector vec( mEndPoint - mStartPoint );
   vec = vec.normalized().perpVector();
 

--- a/src/app/3d/qgsmaptoolclippingplanes.cpp
+++ b/src/app/3d/qgsmaptoolclippingplanes.cpp
@@ -177,8 +177,19 @@ void QgsMapToolClippingPlanes::canvasReleaseEvent( QgsMapMouseEvent *e )
       {
         mRubberBandLines->addPoint( point );
         mRubberBandLines->addPoint( point );
+        mRubberBandPoints->addPoint( point );
       }
-      mRubberBandPoints->addPoint( point );
+      else
+      {
+        QgsPointXY previousPoint = *mRubberBandPoints->getPoint( 0, 0 );
+        if ( previousPoint == point )
+        {
+          clear();
+          emit messageEmitted( tr( "Cross section cannot be defined by identical points, please select a new one!" ), Qgis::MessageLevel::Info );
+        }
+        else
+          mRubberBandPoints->addPoint( point );
+      }
     }
   }
   else if ( e->button() == Qt::RightButton )

--- a/src/app/3d/qgsmaptoolclippingplanes.cpp
+++ b/src/app/3d/qgsmaptoolclippingplanes.cpp
@@ -117,6 +117,9 @@ void QgsMapToolClippingPlanes::canvasReleaseEvent( QgsMapMouseEvent *e )
   if ( e->button() == Qt::LeftButton )
   {
     const QgsPointXY point = toMapCoordinates( e->pos() );
+    if ( mRubberBandPoints->numberOfVertices() > 0 && *mRubberBandPoints->getPoint( 0, mRubberBandPoints->numberOfVertices() - 1 ) == point )
+      return;
+
     if ( mRubberBandPoints->numberOfVertices() == 1 && !mToleranceLocked )
     {
       QgsPointXY pt0 = *mRubberBandPoints->getPoint( 0, 0 );
@@ -177,19 +180,8 @@ void QgsMapToolClippingPlanes::canvasReleaseEvent( QgsMapMouseEvent *e )
       {
         mRubberBandLines->addPoint( point );
         mRubberBandLines->addPoint( point );
-        mRubberBandPoints->addPoint( point );
       }
-      else
-      {
-        QgsPointXY previousPoint = *mRubberBandPoints->getPoint( 0, 0 );
-        if ( previousPoint == point )
-        {
-          clear();
-          emit messageEmitted( tr( "Cross section cannot be defined by identical points, please select a new one!" ), Qgis::MessageLevel::Info );
-        }
-        else
-          mRubberBandPoints->addPoint( point );
-      }
+      mRubberBandPoints->addPoint( point );
     }
   }
   else if ( e->button() == Qt::RightButton )


### PR DESCRIPTION
We do not attempt calculation on an invalid object.
Map tool also checks for identical points, if they are found, it silently fails and let's the user continue selecting a point.