### PR TITLE
Fix data-defined custom dash pattern not using default for NULL values

### DIFF
--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -730,18 +730,14 @@ void QgsSimpleLineSymbolLayer::applyDataDefinedSymbology( QgsSymbolRenderContext
 
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::CustomDash ) )
   {
+    const QString customDashString = mDataDefinedProperties.valueAsString( QgsSymbolLayer::Property::CustomDash, context.renderContext().expressionContext(), QgsSymbolLayerUtils::encodeRealVector( mCustomDashVector ) );
+    const QStringList dashList = customDashString.split( ';' );
     QVector<qreal> dashVector;
-    QVariant exprVal = mDataDefinedProperties.value( QgsSymbolLayer::Property::CustomDash, context.renderContext().expressionContext() );
-    if ( !QgsVariantUtils::isNull( exprVal ) )
+    for ( const QString &dash : dashList )
     {
-      QStringList dashList = exprVal.toString().split( ';' );
-      QStringList::const_iterator dashIt = dashList.constBegin();
-      for ( ; dashIt != dashList.constEnd(); ++dashIt )
-      {
-        dashVector.push_back( context.renderContext().convertToPainterUnits( dashIt->toDouble(), mCustomDashPatternUnit, mCustomDashPatternMapUnitScale ) / dashWidthDiv );
-      }
-      pen.setDashPattern( dashVector );
+      dashVector.push_back( context.renderContext().convertToPainterUnits( dash.toDouble(), mCustomDashPatternUnit, mCustomDashPatternMapUnitScale ) / dashWidthDiv );
     }
+    pen.setDashPattern( dashVector );
   }
   else if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::StrokeWidth ) && mUseCustomDashPattern )
   {


### PR DESCRIPTION
Use valueAsString() with the encoded default parameter so that when the expression returns NULL, the default custom dash pattern is used instead of being skipped.

Before the fix:
[Screencast_20260122_125641.webm](https://github.com/user-attachments/assets/ec58e70b-3493-4719-a458-5323ebc1e066)


After
[Screencast_20260122_130037.webm](https://github.com/user-attachments/assets/a9a20f5c-03a9-4127-9f53-e575af96a744)
