### PR TITLE
[RAT] Missing error message in warning dialog

### DIFF
--- a/src/gui/raster/qgsloadrasterattributetabledialog.cpp
+++ b/src/gui/raster/qgsloadrasterattributetabledialog.cpp
@@ -98,7 +98,7 @@ void QgsLoadRasterAttributeTableDialog::accept()
     {
       if ( !rat->isValid( &errorMessage ) )
       {
-        switch ( QMessageBox::warning( nullptr, tr( "Invalid Raster Attribute Table" ), tr( "The raster attribute table is not valid:\n%1\nLoad anyway?" ), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel ) )
+        switch ( QMessageBox::warning( nullptr, tr( "Invalid Raster Attribute Table" ), tr( "The raster attribute table is not valid:\n%1\nLoad anyway?" ).arg( errorMessage ), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel ) )
         {
           case QMessageBox::Cancel:
             return;


### PR DESCRIPTION
The idea is to fix this, when trying to load attribute table from an existing vat.dbf file
<img width="416" height="402" alt="image" src="https://github.com/user-attachments/assets/c6d27858-a8ac-4b6b-8578-627f893a7715" />
