### PR TITLE
Add include to fix QGIS build with Qt 6.8.3 on my machine

### DIFF
--- a/src/providers/wfs/qgsxmlschemaanalyzer.cpp
+++ b/src/providers/wfs/qgsxmlschemaanalyzer.cpp
@@ -37,6 +37,7 @@
 #include <QDialog>
 #include <QDir>
 #include <QMessageBox>
+#include <QPushButton>
 #include <QStandardPaths>
 #include <QTimer>
 #include <QUrlQuery>


### PR DESCRIPTION
Without this #include, I keep getting this compilation error :man_shrugging: 
```
/home/martin/qgis/git-master/src/providers/wfs/qgsxmlschemaanalyzer.cpp: In static member function ‘static bool QgsXmlSchemaAnalyzer::readAttributesFromSchemaWithGMLAS(const QString&, QgsBackgroundCachedSharedData*, const QByteArray&, const QString&, QString&, QgsFields&, Qgis::WkbType&, bool&, QString&, bool&)’:
/home/martin/qgis/git-master/src/providers/wfs/qgsxmlschemaanalyzer.cpp:326:39: error: invalid use of incomplete type ‘class QAbstractButton’
  326 |     box->button( QMessageBox::Cancel )->setEnabled( false );
      |                                       ^~
In file included from /home/martin/Qt/6.8.3/gcc_64/include/QtWidgets/qmessagebox.h:9,
                 from /home/martin/Qt/6.8.3/gcc_64/include/QtWidgets/QMessageBox:1,
                 from /home/martin/qgis/git-master/src/providers/wfs/qgsxmlschemaanalyzer.cpp:39:
/home/martin/Qt/6.8.3/gcc_64/include/QtWidgets/qdialogbuttonbox.h:15:7: note: forward declaration of ‘class QAbstractButton’
   15 | class QAbstractButton;
      |       ^~~~~~~~~~~~~~~
```