### PR TITLE
Make clear that the credential dialog comes from QGIS

### DIFF
--- a/src/gui/qgscredentialdialog.cpp
+++ b/src/gui/qgscredentialdialog.cpp
@@ -106,7 +106,7 @@ QgsCredentialDialog::QgsCredentialDialog( QWidget *parent, Qt::WindowFlags fl )
   } );
 
   leMasterPass->setPlaceholderText( tr( "Required" ) );
-  chkbxPasswordHelperEnable->setText( tr( "Store/update the master password in your %1" )
+  chkbxPasswordHelperEnable->setText( tr( "Store/update the master password in your QGIS %1" )
                                         .arg( QgsAuthManager::passwordHelperDisplayName() ) );
   leUsername->setFocus();
 }

--- a/src/gui/qgscredentialdialog.cpp
+++ b/src/gui/qgscredentialdialog.cpp
@@ -198,7 +198,7 @@ void QgsCredentialDialog::requestCredentialsMasterPassword( QString *password, b
   mIgnoreButton->hide();
   leMasterPass->setFocus();
 
-  const QString titletxt( stored ? tr( "Enter CURRENT master authentication password" ) : tr( "Set NEW master authentication password" ) );
+  const QString titletxt( stored ? tr( "Enter CURRENT master authentication password for QGIS" ) : tr( "Set NEW master authentication password for QGIS" ) );
   lblPasswordTitle->setText( titletxt );
 
   chkbxPasswordHelperEnable->setChecked( QgsApplication::authManager()->passwordHelperEnabled() );

--- a/src/ui/qgscredentialdialog.ui
+++ b/src/ui/qgscredentialdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Enter Credentials</string>
+   <string>Enter QGIS Credentials</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">


### PR DESCRIPTION
## Description

Fixes feature request #64281

Add the word "QGIS" to several text elements of the UI. This should ensure that our dialog doesn't look like phishing.

## Questions:

- Do I need to do anything to allow translations to be done properly?
- Do UI text changes like in this PR require new unit tests?
- How am I supposed to test that the UI looks right with these changes? How do I reach the dialog boxes shown in #64281?
