### PR TITLE
Add missing QgsProcessingException to Python SIP stubs

### DIFF
--- a/python/core/qgsexception.sip
+++ b/python/core/qgsexception.sip
@@ -1,3 +1,13 @@
+class QgsProcessingException : QgsException
+{
+%TypeHeaderCode
+#include "qgsexception.h"
+%End
+
+public:
+    QgsProcessingException(const QString &message);
+};
+
 %Exception QgsCsException(SIP_Exception) /PyName=QgsCsException/
 {
 %TypeHeaderCode


### PR DESCRIPTION
### Summary
adds the missing sip exception block for `QgsProcessingException` so it is correctly exported in the generated `qgis._core.pyi` Python stubs.

### Issue
`QgsProcessingException` exists in C++ and is widely used, but it is not included in the sip generated Python stubs, causing IDEs to report it as unresolved.

### Fix
added the missing `%Exception QgsProcessingException` definition to `python/core/qgsexception.sip`.

### Notes
1)Documentation / stub-generation only
2)No changes to C++ or runtime behavior
3)CI will regenerate the updated `.pyi` files automatically
