### PR TITLE
Fix Arrow symbol layer data-defined properties not using defaults for NULL

### DIFF
--- a/src/core/symbology/qgsarrowsymbollayer.cpp
+++ b/src/core/symbology/qgsarrowsymbollayer.cpp
@@ -661,6 +661,8 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   bool ok;
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::ArrowWidth ) )
   {
+    mScaledArrowWidth = context.renderContext().convertToPainterUnits( arrowWidth(), arrowWidthUnit(), arrowWidthUnitScale() );
+    context.setOriginalValueVariable( arrowWidth() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::Property::ArrowWidth, context.renderContext().expressionContext() );
     if ( !QgsVariantUtils::isNull( exprVal ) )
     {
@@ -673,6 +675,7 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   }
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::ArrowStartWidth ) )
   {
+    mScaledArrowStartWidth = context.renderContext().convertToPainterUnits( arrowStartWidth(), arrowStartWidthUnit(), arrowStartWidthUnitScale() );
     context.setOriginalValueVariable( arrowStartWidth() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::Property::ArrowStartWidth, context.renderContext().expressionContext() );
     if ( !QgsVariantUtils::isNull( exprVal ) )
@@ -686,6 +689,7 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   }
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::ArrowHeadLength ) )
   {
+    mScaledHeadLength = context.renderContext().convertToPainterUnits( headLength(), headLengthUnit(), headLengthUnitScale() );
     context.setOriginalValueVariable( headLength() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::Property::ArrowHeadLength, context.renderContext().expressionContext() );
     if ( !QgsVariantUtils::isNull( exprVal ) )
@@ -699,6 +703,7 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   }
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::ArrowHeadThickness ) )
   {
+    mScaledHeadThickness = context.renderContext().convertToPainterUnits( headThickness(), headThicknessUnit(), headThicknessUnitScale() );
     context.setOriginalValueVariable( headThickness() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::Property::ArrowHeadThickness, context.renderContext().expressionContext() );
     if ( !QgsVariantUtils::isNull( exprVal ) )
@@ -712,17 +717,22 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
   }
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::Offset ) )
   {
+    mScaledOffset = context.renderContext().convertToPainterUnits( offset(), offsetUnit(), offsetMapUnitScale() );
     context.setOriginalValueVariable( offset() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::Property::Offset, context.renderContext().expressionContext() );
-    const double w = exprVal.toDouble( &ok );
-    if ( ok )
+    if ( !QgsVariantUtils::isNull( exprVal ) )
     {
-      mScaledOffset = context.renderContext().convertToPainterUnits( w, offsetUnit(), offsetMapUnitScale() );
+      const double w = exprVal.toDouble( &ok );
+      if ( ok )
+      {
+        mScaledOffset = context.renderContext().convertToPainterUnits( w, offsetUnit(), offsetMapUnitScale() );
+      }
     }
   }
 
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::ArrowHeadType ) )
   {
+    mComputedHeadType = headType();
     context.setOriginalValueVariable( headType() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::Property::ArrowHeadType, context.renderContext().expressionContext() );
     if ( !QgsVariantUtils::isNull( exprVal ) )
@@ -737,6 +747,7 @@ void QgsArrowSymbolLayer::_resolveDataDefined( QgsSymbolRenderContext &context )
 
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::ArrowType ) )
   {
+    mComputedArrowType = arrowType();
     context.setOriginalValueVariable( arrowType() );
     exprVal = mDataDefinedProperties.value( QgsSymbolLayer::Property::ArrowType, context.renderContext().expressionContext() );
     if ( !QgsVariantUtils::isNull( exprVal ) )


### PR DESCRIPTION
Reset data-defined properties values to their defaults at the start of each property check in _resolveDataDefined() so that we use the default value when an expression returns NULL.

Should be backported.

Added missing isNull check for Offset property that otherwise would convert NULL -> 0.0

The problem can be seen in this screen record, I manually tested every data defined property of the Arrow symbol layer:
[Screencast_20260124_095920.webm](https://github.com/user-attachments/assets/741ec336-20ee-43a5-999f-f23b252b8e05)


<img width="502" height="563" alt="image" src="https://github.com/user-attachments/assets/b65b38e0-2f38-4a44-90b6-4fa8707230b4" />

One thing that I haven't figured it out and it's in the screencast,  the Offset property (which should be double) shows an incorrect **expected format** in the UI, `string of doubles 'x,y' or array of doubles [x, y]` insted of `double [≥ 0.0]`.

It seems `Property::Offset` is defined globally in `QgsSymbolLayer` with `QgsPropertyDefinition::Offset` type, which is designed for point symbol x,y offsets and the Arrow symbol  layer reuses this property for some reason, and I don't know if this is a wanted behavior or not.

In the case that this is a bug and not wanted for some reason, maybe a new property `Property::ArrowOffset` or alike should be made. Thoughts?
<img width="1226" height="727" alt="image" src="https://github.com/user-attachments/assets/60cf874b-bfec-4024-bb75-f8556cd50bac" />


Here's a project where you can easily replicate:
[bug.zip](https://github.com/user-attachments/files/24864199/bug.zip)
