### PR TITLE
Polyl-Bézier maptool

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -293,6 +293,7 @@
         <file>themes/default/mActionDeselectAll.svg</file>
         <file>themes/default/mActionDeselectActiveLayer.svg</file>
         <file>themes/default/mActionDigitizeShape.svg</file>
+        <file>themes/default/mActionDigitizeWithBezier.svg</file>
         <file>themes/default/mActionDigitizeWithCurve.svg</file>
         <file>themes/default/mActionDigitizeWithNURBS.svg</file>
         <file>themes/default/mActionDigitizeWithSegment.svg</file>

--- a/images/themes/default/mActionDigitizeWithBezier.svg
+++ b/images/themes/default/mActionDigitizeWithBezier.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg3811"
+   sodipodi:docname="mActionDigitizeWithBezier.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata3817">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3815" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3440"
+     inkscape:window-height="1368"
+     id="namedview3813"
+     showgrid="false"
+     inkscape:zoom="20.108349"
+     inkscape:cx="-0.54703646"
+     inkscape:cy="12.556973"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3811"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <path
+     style="fill:none;stroke:#8cbe8c;stroke-width:1.4;stroke-dasharray:2.8, 1.4;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 11.488723,20.409226 19.443703,7.4399022"
+     id="path1"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#8cbe8c;stroke-width:1.4;stroke-dasharray:2.8, 1.4;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 4.4972358,13.097443 10.241889,8.6017896 10.761376,2.0676119"
+     id="path1-0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:none;stroke:#8cbe8c;stroke-width:0.736981;stroke-dasharray:1.47397, 0.736981;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 1.4530381,17.122305 4.4797717,6.639241"
+     id="path1-8"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#8cbe8c;stroke-width:0.736981;stroke-dasharray:1.47397, 0.736981;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 17.808153,0.46014719 22.287925,7.0993882"
+     id="path1-8-4"
+     sodipodi:nodetypes="cc" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3799"
+     d="m 8.8522662,7.075214 h 2.9999998 v 3 H 8.8522662 Z"
+     style="fill:#bebebe;stroke:#8c8c8c" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3801"
+     d="m 13.202853,11.9542 h 3 v 3 h -3 z"
+     style="fill:#bebebe;stroke:#8c8c8c" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3803"
+     d="m 2.5,19.5 h 3 v 3 h -3 z"
+     style="fill:#bebebe;stroke:#8c8c8c" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3799-0"
+     d="m 18.245959,1.9086212 h 3 v 2.9999996 h -3 z"
+     style="fill:#bebebe;stroke:#8c8c8c" />
+  <path
+     style="fill:none;stroke:#be8c8c;stroke-width:0.4;stroke-dasharray:0.8,0.4;stroke-opacity:1;stroke-dashoffset:0"
+     d="M 4.0281775,21.085769 C 7.4780885,15.738727 21.104217,15.626896 10.940729,9.2001586 8.0908905,7.3981034 19.593851,3.3816799 19.593851,3.3816799"
+     id="path2"
+     sodipodi:nodetypes="csc" />
+</svg>

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -762,11 +762,13 @@ Qgis.CaptureTechnique.__doc__ = """Capture technique.
 Qgis.CaptureTechnique.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.NurbsMode.ControlPoints.__doc__ = "Direct control points mode - the curve is attracted to control points but does not pass through them"
+Qgis.NurbsMode.PolyBezier.__doc__ = "Poly-Bézier mode (vector graphics style) - anchors with tangent handles, the curve passes through anchor points"
 Qgis.NurbsMode.__doc__ = """NURBS digitizing mode.
 
 .. versionadded:: 4.0
 
 * ``ControlPoints``: Direct control points mode - the curve is attracted to control points but does not pass through them
+* ``PolyBezier``: Poly-Bézier mode (vector graphics style) - anchors with tangent handles, the curve passes through anchor points
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -743,7 +743,8 @@ Qgis.CaptureTechnique.StraightSegments.__doc__ = "Default capture mode - capture
 Qgis.CaptureTechnique.CircularString.__doc__ = "Capture in circular strings"
 Qgis.CaptureTechnique.Streaming.__doc__ = "Streaming points digitizing mode (points are automatically added as the mouse cursor moves)."
 Qgis.CaptureTechnique.Shape.__doc__ = "Digitize shapes."
-Qgis.CaptureTechnique.NurbsCurve.__doc__ = "Digitizes NURBS curves with control points. \n.. versionadded:: 4.0"
+Qgis.CaptureTechnique.PolyBezier.__doc__ = "Digitizes poly-Bézier curves with anchors and tangent handles (curve passes through anchor points). \n.. versionadded:: 4.0"
+Qgis.CaptureTechnique.NurbsCurve.__doc__ = "Digitizes NURBS curves with control points (curve is attracted to but does not pass through control points). \n.. versionadded:: 4.0"
 Qgis.CaptureTechnique.__doc__ = """Capture technique.
 
 .. versionadded:: 3.26
@@ -752,7 +753,11 @@ Qgis.CaptureTechnique.__doc__ = """Capture technique.
 * ``CircularString``: Capture in circular strings
 * ``Streaming``: Streaming points digitizing mode (points are automatically added as the mouse cursor moves).
 * ``Shape``: Digitize shapes.
-* ``NurbsCurve``: Digitizes NURBS curves with control points.
+* ``PolyBezier``: Digitizes poly-Bézier curves with anchors and tangent handles (curve passes through anchor points).
+
+  .. versionadded:: 4.0
+
+* ``NurbsCurve``: Digitizes NURBS curves with control points (curve is attracted to but does not pass through control points).
 
   .. versionadded:: 4.0
 
@@ -760,19 +765,6 @@ Qgis.CaptureTechnique.__doc__ = """Capture technique.
 """
 # --
 Qgis.CaptureTechnique.baseClass = Qgis
-# monkey patching scoped based enum
-Qgis.NurbsMode.ControlPoints.__doc__ = "Direct control points mode - the curve is attracted to control points but does not pass through them"
-Qgis.NurbsMode.PolyBezier.__doc__ = "Poly-Bézier mode (vector graphics style) - anchors with tangent handles, the curve passes through anchor points"
-Qgis.NurbsMode.__doc__ = """NURBS digitizing mode.
-
-.. versionadded:: 4.0
-
-* ``ControlPoints``: Direct control points mode - the curve is attracted to control points but does not pass through them
-* ``PolyBezier``: Poly-Bézier mode (vector graphics style) - anchors with tangent handles, the curve passes through anchor points
-
-"""
-# --
-Qgis.NurbsMode.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.VectorLayerTypeFlag.SqlQuery.__doc__ = "SQL query layer"
 Qgis.VectorLayerTypeFlag.__doc__ = """Vector layer type flags.

--- a/python/PyQt6/core/auto_additions/qgsnurbscurve.py
+++ b/python/PyQt6/core/auto_additions/qgsnurbscurve.py
@@ -1,6 +1,7 @@
 # The following has been generated automatically from src/core/geometry/qgsnurbscurve.h
 try:
     QgsNurbsCurve.generateUniformKnots = staticmethod(QgsNurbsCurve.generateUniformKnots)
+    QgsNurbsCurve.generateKnotsForBezierConversion = staticmethod(QgsNurbsCurve.generateKnotsForBezierConversion)
     QgsNurbsCurve.__overridden_methods__ = ['clone', 'isClosed', 'isClosed2D', 'curveToLine', 'draw', 'drawAsPolygon', 'endPoint', 'equals', 'indexOf', 'interpolatePoint', 'numPoints', 'pointAt', 'points', 'reversed', 'scroll', 'startPoint', 'sumUpArea', 'sumUpArea3D', 'xAt', 'yAt', 'zAt', 'mAt', 'asQPolygonF', 'addToPainterPath', 'curveSubstring', 'length', 'segmentLength', 'distanceBetweenVertices', 'snappedToGrid', 'simplifyByDistance', 'removeDuplicateNodes', 'vertexAngle', 'swapXy', 'transform', 'createEmptyWithSameType', 'closestSegment', 'boundingBox', 'boundingBox3D', 'moveVertex', 'insertVertex', 'wkbSize', 'asWkb', 'asWkt', 'asGml2', 'asGml3', 'asKml', 'dimension', 'isEmpty', 'clear', 'boundingBoxIntersects', 'centroid', 'addZValue', 'addMValue', 'dropZValue', 'dropMValue', 'deleteVertex', 'fromWkb', 'fromWkt', 'fuzzyEqual', 'fuzzyDistanceEqual', 'geometryType', 'hasCurvedSegments', 'partCount', 'toCurveType', 'vertexAt', 'vertexCount', 'vertexNumberFromVertexId', 'isValid', 'clearCache', 'compareToSameClass', 'calculateBoundingBox3D']
     QgsNurbsCurve.__group__ = ['geometry']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/geometry/qgsnurbscurve.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsnurbscurve.sip.in
@@ -94,11 +94,21 @@ NURBS).
 Returns ``True`` if this curve is rational (has non-uniform weights).
 %End
 
+
     bool isPolyBezier() const /HoldGIL/;
 %Docstring
-Returns ``True`` if this curve represents a poly-Bézier curve. A
-poly-Bézier is a degree 3 NURBS with (n-1) divisible by 3, where n is
-the number of control points.
+Returns ``True`` if this curve represents a poly-Bézier curve structure.
+
+A poly-Bézier is a piecewise Bézier curve with C0 continuity (positional
+continuity only) used for editing. It requires:
+
+- Control points: (controlPointCount - 1) % degree == 0
+- Knot vector with multiplicity 'degree' at internal junctions
+- Can have 1 or more segments (like MultiPolygon can have 1+ polygons)
+
+Works for any degree ≥ 1. Note that a single-segment poly-Bézier will
+also return ``True`` for :py:func:`~QgsNurbsCurve.isBezier` (degree =
+n-1 condition).
 %End
 
     virtual bool isClosed() const /HoldGIL/;

--- a/python/PyQt6/core/auto_generated/geometry/qgsnurbscurve.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsnurbscurve.sip.in
@@ -382,6 +382,18 @@ repeated (degree+1)] where s = nAnchors - 1 (number of segments)
 .. versionadded:: 4.0
 %End
 
+    bool isAnchorVertex( int localIndex ) const /HoldGIL/;
+%Docstring
+Returns ``True`` if the control point at localIndex is an anchor vertex
+in a poly-Bézier curve. Anchor vertices are at positions 0, degree,
+2*degree, etc.
+
+:param localIndex: the control point index to check
+
+:return: ``True`` if this is an anchor vertex, ``False`` otherwise
+
+.. versionadded:: 4.0
+%End
 
 
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsnurbscurve.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsnurbscurve.sip.in
@@ -366,6 +366,27 @@ with:
 .. versionadded:: 4.0
 %End
 
+    static QVector<double> generateKnotsForBezierConversion( int nAnchors );
+%Docstring
+Generates a knot vector for converting piecewise cubic Bézier curves to
+NURBS.
+
+This creates a knot vector with multiplicity 3 at junctions for C0
+continuity, suitable for representing a sequence of cubic Bézier
+segments as a single NURBS curve. For n anchors (n-1 cubic Bézier
+segments), this generates the appropriate knot vector with degree 3.
+
+Format: [0,0,0,0, 1,1,1, 2,2,2, ..., n-1,n-1,n-1,n-1] Total knots: 4 +
+3*(n-2) + 4 = 3n + 2
+
+:param nAnchors: number of anchor points (defines n-1 cubic Bézier
+                 segments)
+
+:return: the generated knot vector
+
+.. versionadded:: 4.0
+%End
+
 
 
   protected:

--- a/python/PyQt6/core/auto_generated/geometry/qgsnurbscurve.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsnurbscurve.sip.in
@@ -366,26 +366,22 @@ with:
 .. versionadded:: 4.0
 %End
 
-    static QVector<double> generateKnotsForBezierConversion( int nAnchors );
+    static QVector<double> generateKnotsForBezierConversion( int nAnchors, int degree = 3 );
 %Docstring
-Generates a knot vector for converting piecewise cubic Bézier curves to
-NURBS.
+Generates a knot vector for converting piecewise Bézier curves to NURBS.
 
-This creates a knot vector with multiplicity 3 at junctions for C0
-continuity, suitable for representing a sequence of cubic Bézier
-segments as a single NURBS curve. For n anchors (n-1 cubic Bézier
-segments), this generates the appropriate knot vector with degree 3.
+Creates a knot vector with multiplicity 'degree' at junctions for C0
+continuity. Format: [0 repeated (degree+1), 1 repeated degree, ..., s
+repeated (degree+1)] where s = nAnchors - 1 (number of segments)
 
-Format: [0,0,0,0, 1,1,1, 2,2,2, ..., n-1,n-1,n-1,n-1] Total knots: 4 +
-3*(n-2) + 4 = 3n + 2
+:param nAnchors: number of anchor points (must be >= 2)
+:param degree: degree of the curve (must be >= 1), defaults to 3 (cubic)
 
-:param nAnchors: number of anchor points (defines n-1 cubic Bézier
-                 segments)
-
-:return: the generated knot vector
+:return: the generated knot vector, or empty if invalid parameters
 
 .. versionadded:: 4.0
 %End
+
 
 
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -290,6 +290,7 @@ The development version
     enum class NurbsMode /BaseType=IntEnum/
     {
       ControlPoints,
+      PolyBezier,
     };
 
     enum class VectorLayerTypeFlag /BaseType=IntFlag/

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -284,14 +284,10 @@ The development version
       CircularString,
       Streaming,
       Shape,
+      PolyBezier,
       NurbsCurve,
     };
 
-    enum class NurbsMode /BaseType=IntEnum/
-    {
-      ControlPoints,
-      PolyBezier,
-    };
 
     enum class VectorLayerTypeFlag /BaseType=IntFlag/
     {

--- a/python/PyQt6/gui/auto_additions/qgsmaptoolcapture.py
+++ b/python/PyQt6/gui/auto_additions/qgsmaptoolcapture.py
@@ -19,7 +19,7 @@ QgsMapToolCapture.Capability.__and__ = lambda flag1, flag2: _force_int(flag1) & 
 QgsMapToolCapture.Capability.__or__ = lambda flag1, flag2: QgsMapToolCapture.Capability(_force_int(flag1) | _force_int(flag2))
 try:
     QgsMapToolCapture.__virtual_methods__ = ['capabilities', 'supportsTechnique', 'geometryCaptured', 'pointCaptured', 'lineCaptured', 'polygonCaptured']
-    QgsMapToolCapture.__overridden_methods__ = ['activate', 'deactivate', 'cadCanvasMoveEvent', 'cadCanvasReleaseEvent', 'keyPressEvent', 'keyReleaseEvent', 'wheelEvent', 'clean']
+    QgsMapToolCapture.__overridden_methods__ = ['activate', 'deactivate', 'cadCanvasPressEvent', 'cadCanvasMoveEvent', 'cadCanvasReleaseEvent', 'keyPressEvent', 'keyReleaseEvent', 'wheelEvent', 'clean']
     QgsMapToolCapture.__group__ = ['maptools']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_generated/maptools/qgsmaptoolcapture.sip.in
+++ b/python/PyQt6/gui/auto_generated/maptools/qgsmaptoolcapture.sip.in
@@ -13,6 +13,7 @@
 
 
 
+
 class QgsMapToolCapture : QgsMapToolAdvancedDigitizing
 {
 %Docstring(signature="appended")
@@ -115,6 +116,8 @@ Gets the capture curve
 %Docstring
 Returns a list of matches for each point on the captureCurve.
 %End
+
+    virtual void cadCanvasPressEvent( QgsMapMouseEvent *e );
 
     virtual void cadCanvasMoveEvent( QgsMapMouseEvent *e );
 

--- a/src/app/elevation/qgsmaptoolprofilecurve.cpp
+++ b/src/app/elevation/qgsmaptoolprofilecurve.cpp
@@ -46,6 +46,7 @@ bool QgsMapToolProfileCurve::supportsTechnique( Qgis::CaptureTechnique technique
     case Qgis::CaptureTechnique::StraightSegments:
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Streaming:
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       return true;
 

--- a/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.cpp
+++ b/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.cpp
@@ -30,6 +30,8 @@
 
 #include <QAction>
 #include <QActionGroup>
+#include <QGridLayout>
+#include <QLabel>
 #include <QMenu>
 #include <QString>
 #include <QToolButton>
@@ -408,33 +410,39 @@ void QgsMapToolsDigitizingTechniqueManager::enableDigitizingTechniqueActions( bo
 
 void QgsMapToolsDigitizingTechniqueManager::createNurbsDegreeWidget()
 {
-  if ( mNurbsDegreeSpinBox )
+  if ( mNurbsDegreeWidget )
     return;
 
-  mNurbsDegreeSpinBox = new QgsSpinBox( QgisApp::instance() );
-  mNurbsDegreeSpinBox->setMinimum( 1 );
-  mNurbsDegreeSpinBox->setMaximum( 8 );
-  mNurbsDegreeSpinBox->setPrefix( tr( "NURBS Degree: " ) );
-  mNurbsDegreeSpinBox->setValue( QgsSettingsRegistryCore::settingsDigitizingNurbsDegree->value() );
-  mNurbsDegreeSpinBox->setClearValue( 3 );
+  QGridLayout *gLayout = new QGridLayout();
+  gLayout->setContentsMargins( 3, 2, 3, 2 );
 
-  connect( mNurbsDegreeSpinBox, qOverload<int>( &QSpinBox::valueChanged ), this, []( int value ) {
+  QgsSpinBox *spinBox = new QgsSpinBox();
+  spinBox->setMinimum( 1 );
+  spinBox->setMaximum( 8 );
+  spinBox->setValue( QgsSettingsRegistryCore::settingsDigitizingNurbsDegree->value() );
+  spinBox->setClearValue( 3 );
+
+  QLabel *label = new QLabel( tr( "NURBS Degree" ) );
+  gLayout->addWidget( label, 1, 0 );
+  gLayout->addWidget( spinBox, 1, 1 );
+  connect( spinBox, qOverload<int>( &QSpinBox::valueChanged ), this, []( int value ) {
     QgsSettingsRegistryCore::settingsDigitizingNurbsDegree->setValue( value );
   } );
 
-  QgisApp::instance()->addUserInputWidget( mNurbsDegreeSpinBox );
-  mNurbsDegreeSpinBox->setFocus( Qt::TabFocusReason );
+  mNurbsDegreeWidget = new QWidget( QgisApp::instance() );
+  mNurbsDegreeWidget->setLayout( gLayout );
+
+  QgisApp::instance()->addUserInputWidget( mNurbsDegreeWidget );
+  spinBox->setFocus( Qt::TabFocusReason );
 }
 
 void QgsMapToolsDigitizingTechniqueManager::deleteNurbsDegreeWidget()
 {
-  if ( mNurbsDegreeSpinBox )
+  if ( mNurbsDegreeWidget )
   {
-    disconnect( mNurbsDegreeSpinBox, nullptr, this, nullptr );
-    mNurbsDegreeSpinBox->releaseKeyboard();
-    mNurbsDegreeSpinBox->deleteLater();
+    mNurbsDegreeWidget->deleteLater();
   }
-  mNurbsDegreeSpinBox = nullptr;
+  mNurbsDegreeWidget = nullptr;
 }
 
 //

--- a/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.cpp
+++ b/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.cpp
@@ -82,11 +82,6 @@ void QgsMapToolsDigitizingTechniqueManager::setupToolBars()
     actionGroup->addAction( it.value() );
   }
 
-  digitizeMenu->addAction( QgisApp::instance()->mActionDigitizeWithBezier );
-  digitizeMenu->addAction( QgisApp::instance()->mActionDigitizeWithNurbs );
-  actionGroup->addAction( QgisApp::instance()->mActionDigitizeWithBezier );
-  actionGroup->addAction( QgisApp::instance()->mActionDigitizeWithNurbs );
-
   QgisApp::instance()->mActionStreamDigitize->setShortcut( tr( "R", "Keyboard shortcut: toggle stream digitizing" ) );
   connect( digitizeMenu, &QMenu::triggered, this, [this]( QAction *action ) {
     Qgis::CaptureTechnique technique = mTechniqueActions.key( action, Qgis::CaptureTechnique::StraightSegments );

--- a/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.cpp
+++ b/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.cpp
@@ -397,6 +397,7 @@ QgsNurbsDigitizingSettingsAction::QgsNurbsDigitizingSettingsAction( QWidget *par
 
   // Mode ComboBox
   mNurbsModeComboBox = new QComboBox();
+  mNurbsModeComboBox->addItem( tr( "Poly-Bézier" ), static_cast<int>( Qgis::NurbsMode::PolyBezier ) );
   mNurbsModeComboBox->addItem( tr( "Control Points" ), static_cast<int>( Qgis::NurbsMode::ControlPoints ) );
 
   // Set current index based on saved setting

--- a/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.h
+++ b/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.h
@@ -91,7 +91,7 @@ class APP_EXPORT QgsMapToolsDigitizingTechniqueManager : public QObject
     QgsStreamDigitizingSettingsAction *mStreamDigitizingSettingsAction = nullptr;
 
     //! User input widget for NURBS degree setting
-    QgsSpinBox *mNurbsDegreeSpinBox = nullptr;
+    QPointer< QWidget > mNurbsDegreeWidget;
 };
 
 #endif // QGSMAPTOOLSDIGITIZINGTECHNIQUEMANAGER_H

--- a/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.h
+++ b/src/app/maptools/qgsmaptoolsdigitizingtechniquemanager.h
@@ -48,26 +48,6 @@ class APP_EXPORT QgsStreamDigitizingSettingsAction : public QWidgetAction
     QgsSpinBox *mStreamToleranceSpinBox = nullptr;
 };
 
-class QComboBox;
-class QLabel;
-
-class APP_EXPORT QgsNurbsDigitizingSettingsAction : public QWidgetAction
-{
-    Q_OBJECT
-
-  public:
-    QgsNurbsDigitizingSettingsAction( QWidget *parent = nullptr );
-    ~QgsNurbsDigitizingSettingsAction() override;
-
-  private slots:
-    void updateDegreeEnabled( int modeIndex );
-
-  private:
-    QComboBox *mNurbsModeComboBox = nullptr;
-    QgsSpinBox *mNurbsDegreeSpinBox = nullptr;
-    QLabel *mNurbsDegreeLabel = nullptr;
-};
-
 class APP_EXPORT QgsMapToolsDigitizingTechniqueManager : public QObject
 {
     Q_OBJECT
@@ -98,6 +78,9 @@ class APP_EXPORT QgsMapToolsDigitizingTechniqueManager : public QObject
 
     void updateDigitizeModeButton( const Qgis::CaptureTechnique technique );
 
+    void createNurbsDegreeWidget();
+    void deleteNurbsDegreeWidget();
+
     QMap<Qgis::CaptureTechnique, QAction *> mTechniqueActions;
     QHash<QString, QAction *> mShapeActions;
     QMap<QgsMapToolShapeAbstract::ShapeCategory, QToolButton *> mShapeCategoryButtons;
@@ -106,7 +89,9 @@ class APP_EXPORT QgsMapToolsDigitizingTechniqueManager : public QObject
 
     QToolButton *mDigitizeModeToolButton = nullptr;
     QgsStreamDigitizingSettingsAction *mStreamDigitizingSettingsAction = nullptr;
-    QgsNurbsDigitizingSettingsAction *mNurbsDigitizingSettingsAction = nullptr;
+
+    //! User input widget for NURBS degree setting
+    QgsSpinBox *mNurbsDegreeSpinBox = nullptr;
 };
 
 #endif // QGSMAPTOOLSDIGITIZINGTECHNIQUEMANAGER_H

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -52,6 +52,7 @@ bool QgsMapToolAddPart::supportsTechnique( Qgis::CaptureTechnique technique ) co
 
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Shape:
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       return mode() != QgsMapToolCapture::CapturePoint;
   }

--- a/src/app/qgsmaptooladdring.cpp
+++ b/src/app/qgsmaptooladdring.cpp
@@ -49,6 +49,7 @@ bool QgsMapToolAddRing::supportsTechnique( Qgis::CaptureTechnique technique ) co
     case Qgis::CaptureTechnique::Streaming:
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Shape:
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       return true;
   }

--- a/src/app/qgsmaptoolfillring.cpp
+++ b/src/app/qgsmaptoolfillring.cpp
@@ -46,6 +46,7 @@ bool QgsMapToolFillRing::supportsTechnique( Qgis::CaptureTechnique technique ) c
     case Qgis::CaptureTechnique::Streaming:
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Shape:
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       return true;
   }

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -85,6 +85,7 @@ bool QgsMapToolReshape::supportsTechnique( Qgis::CaptureTechnique technique ) co
     case Qgis::CaptureTechnique::StraightSegments:
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Streaming:
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       return true;
 

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -85,11 +85,11 @@ bool QgsMapToolReshape::supportsTechnique( Qgis::CaptureTechnique technique ) co
     case Qgis::CaptureTechnique::StraightSegments:
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Streaming:
-    case Qgis::CaptureTechnique::PolyBezier:
-    case Qgis::CaptureTechnique::NurbsCurve:
       return true;
 
     case Qgis::CaptureTechnique::Shape:
+    case Qgis::CaptureTechnique::PolyBezier:
+    case Qgis::CaptureTechnique::NurbsCurve:
       return false;
   }
   return false;

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -39,6 +39,7 @@ bool QgsMapToolSplitFeatures::supportsTechnique( Qgis::CaptureTechnique techniqu
     case Qgis::CaptureTechnique::StraightSegments:
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Streaming:
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       return true;
 

--- a/src/app/qgsmaptoolsplitparts.cpp
+++ b/src/app/qgsmaptoolsplitparts.cpp
@@ -42,6 +42,7 @@ bool QgsMapToolSplitParts::supportsTechnique( Qgis::CaptureTechnique technique )
 
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Shape:
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       return false;
   }

--- a/src/core/geometry/qgsnurbscurve.cpp
+++ b/src/core/geometry/qgsnurbscurve.cpp
@@ -654,31 +654,31 @@ QVector<double> QgsNurbsCurve::generateUniformKnots( int numControlPoints, int d
   return knots;
 }
 
-QVector<double> QgsNurbsCurve::generateKnotsForBezierConversion( int nAnchors )
+QVector<double> QgsNurbsCurve::generateKnotsForBezierConversion( int nAnchors, int degree )
 {
-  if ( nAnchors < 2 )
+  if ( nAnchors < 2 || degree < 1 )
     return QVector<double>();
 
-  // For n anchors, we have n-1 cubic Bézier segments
-  // Total knots: 4 + 3*(n-2) + 4 = 3n + 2
-  const int totalKnots = 3 * nAnchors + 2;
+  const int segmentCount = nAnchors - 1;
+  const int totalKnots = degree * nAnchors + degree + 1;
+
   QVector<double> knots;
   knots.reserve( totalKnots );
 
-  // First 4 knots are 0
-  for ( int i = 0; i < 4; ++i )
+  // Clamping start: (degree + 1) knots at 0
+  for ( int i = 0; i < degree + 1; ++i )
     knots.append( 0.0 );
 
-  // Interior knots with multiplicity 3
-  for ( int i = 1; i < nAnchors - 1; ++i )
+  // Interior: multiplicity 'degree' at each junction
+  for ( int segmentIndex = 1; segmentIndex < segmentCount; ++segmentIndex )
   {
-    for ( int j = 0; j < 3; ++j )
-      knots.append( static_cast<double>( i ) );
+    for ( int j = 0; j < degree; ++j )
+      knots.append( static_cast<double>( segmentIndex ) );
   }
 
-  // Last 4 knots are n-1
-  for ( int i = 0; i < 4; ++i )
-    knots.append( static_cast<double>( nAnchors - 1 ) );
+  // Clamping end: (degree + 1) knots at segmentCount
+  for ( int i = 0; i < degree + 1; ++i )
+    knots.append( static_cast<double>( segmentCount ) );
 
   return knots;
 }

--- a/src/core/geometry/qgsnurbscurve.cpp
+++ b/src/core/geometry/qgsnurbscurve.cpp
@@ -1787,3 +1787,11 @@ bool QgsNurbsCurve::setWeight( int index, double weight )
   clearCache();
   return true;
 }
+
+bool QgsNurbsCurve::isAnchorVertex( int localIndex ) const
+{
+  if ( !isPolyBezier() || localIndex < 0 || localIndex >= mControlPoints.size() )
+    return false;
+
+  return ( localIndex % mDegree ) == 0;
+}

--- a/src/core/geometry/qgsnurbscurve.cpp
+++ b/src/core/geometry/qgsnurbscurve.cpp
@@ -654,6 +654,35 @@ QVector<double> QgsNurbsCurve::generateUniformKnots( int numControlPoints, int d
   return knots;
 }
 
+QVector<double> QgsNurbsCurve::generateKnotsForBezierConversion( int nAnchors )
+{
+  if ( nAnchors < 2 )
+    return QVector<double>();
+
+  // For n anchors, we have n-1 cubic Bézier segments
+  // Total knots: 4 + 3*(n-2) + 4 = 3n + 2
+  const int totalKnots = 3 * nAnchors + 2;
+  QVector<double> knots;
+  knots.reserve( totalKnots );
+
+  // First 4 knots are 0
+  for ( int i = 0; i < 4; ++i )
+    knots.append( 0.0 );
+
+  // Interior knots with multiplicity 3
+  for ( int i = 1; i < nAnchors - 1; ++i )
+  {
+    for ( int j = 0; j < 3; ++j )
+      knots.append( static_cast<double>( i ) );
+  }
+
+  // Last 4 knots are n-1
+  for ( int i = 0; i < 4; ++i )
+    knots.append( static_cast<double>( nAnchors - 1 ) );
+
+  return knots;
+}
+
 void QgsNurbsCurve::generateUniformKnots()
 {
   mKnots = generateUniformKnots( mControlPoints.size(), mDegree );

--- a/src/core/geometry/qgsnurbscurve.cpp
+++ b/src/core/geometry/qgsnurbscurve.cpp
@@ -119,8 +119,55 @@ bool QgsNurbsCurve::isRational() const
 
 bool QgsNurbsCurve::isPolyBezier() const
 {
-  const int n = mControlPoints.size();
-  return mDegree == 3 && n >= 4 && ( n - 1 ) % 3 == 0;
+  const int controlPointCount = mControlPoints.size();
+  const int degree = mDegree;
+
+  // Basic requirements: degree >= 1, at least degree+1 points,
+  // and the number of control points must satisfy (controlPointCount - 1) % degree == 0.
+  if ( degree < 1 || controlPointCount < degree + 1 || ( controlPointCount - 1 ) % degree != 0 )
+    return false;
+
+  const int segmentCount = ( controlPointCount - 1 ) / degree;
+  const int expectedKnotCount = controlPointCount + degree + 1;
+
+  if ( mKnots.size() != expectedKnotCount )
+    return false;
+
+  // 1. Check that the knot vector is non-decreasing
+  for ( int i = 1; i < expectedKnotCount; ++i )
+  {
+    if ( mKnots[i] < mKnots[i - 1] && !qgsDoubleNear( mKnots[i], mKnots[i - 1] ) )
+      return false;
+  }
+
+  // 2. Check clamping: first degree+1 knots must be 0.0
+  for ( int i = 0; i < degree + 1; ++i )
+  {
+    if ( !qgsDoubleNear( mKnots[i], 0.0 ) )
+      return false;
+  }
+
+  // 3. Check clamping: last degree+1 knots must be equal to the number of segments
+  const double lastKnotValue = static_cast<double>( segmentCount );
+  for ( int i = expectedKnotCount - ( degree + 1 ); i < expectedKnotCount; ++i )
+  {
+    if ( !qgsDoubleNear( mKnots[i], lastKnotValue ) )
+      return false;
+  }
+
+  // 4. Check interior knots: multiplicity 'degree' at each integer junction
+  for ( int segmentIndex = 1; segmentIndex < segmentCount; ++segmentIndex )
+  {
+    const double knotValue = static_cast<double>( segmentIndex );
+    const int startIndex = ( degree + 1 ) + ( segmentIndex - 1 ) * degree;
+    for ( int j = 0; j < degree; ++j )
+    {
+      if ( !qgsDoubleNear( mKnots[startIndex + j], knotValue ) )
+        return false;
+    }
+  }
+
+  return true;
 }
 
 /**

--- a/src/core/geometry/qgsnurbscurve.h
+++ b/src/core/geometry/qgsnurbscurve.h
@@ -340,6 +340,23 @@ class CORE_EXPORT QgsNurbsCurve : public QgsCurve
     static QVector<double> generateUniformKnots( int numControlPoints, int degree );
 
     /**
+     * Generates a knot vector for converting piecewise cubic Bézier curves to NURBS.
+     *
+     * This creates a knot vector with multiplicity 3 at junctions for C0 continuity,
+     * suitable for representing a sequence of cubic Bézier segments as a single NURBS curve.
+     * For n anchors (n-1 cubic Bézier segments), this generates the appropriate knot vector
+     * with degree 3.
+     *
+     * Format: [0,0,0,0, 1,1,1, 2,2,2, ..., n-1,n-1,n-1,n-1]
+     * Total knots: 4 + 3*(n-2) + 4 = 3n + 2
+     *
+     * \param nAnchors number of anchor points (defines n-1 cubic Bézier segments)
+     * \returns the generated knot vector
+     * \since QGIS 4.0
+     */
+    static QVector<double> generateKnotsForBezierConversion( int nAnchors );
+
+    /**
      * Cast the \a geom to a QgsNurbsCurve.
      * Should be used by qgsgeometry_cast<QgsNurbsCurve *>( geometry ).
      * \note Not available in Python.

--- a/src/core/geometry/qgsnurbscurve.h
+++ b/src/core/geometry/qgsnurbscurve.h
@@ -353,6 +353,15 @@ class CORE_EXPORT QgsNurbsCurve : public QgsCurve
      */
     static QVector<double> generateKnotsForBezierConversion( int nAnchors, int degree = 3 );
 
+    /**
+     * Returns TRUE if the control point at localIndex is an anchor vertex
+     * in a poly-Bézier curve. Anchor vertices are at positions 0, degree, 2*degree, etc.
+     *
+     * \param localIndex the control point index to check
+     * \returns TRUE if this is an anchor vertex, FALSE otherwise
+     * \since QGIS 4.0
+     */
+    bool isAnchorVertex( int localIndex ) const SIP_HOLDGIL;
 
     /**
      * Cast the \a geom to a QgsNurbsCurve.

--- a/src/core/geometry/qgsnurbscurve.h
+++ b/src/core/geometry/qgsnurbscurve.h
@@ -108,10 +108,19 @@ class CORE_EXPORT QgsNurbsCurve : public QgsCurve
      */
     bool isRational() const SIP_HOLDGIL;
 
+
     /**
-     * Returns TRUE if this curve represents a poly-Bézier curve.
-     * A poly-Bézier is a degree 3 NURBS with (n-1) divisible by 3,
-     * where n is the number of control points.
+     * Returns TRUE if this curve represents a poly-Bézier curve structure.
+     *
+     * A poly-Bézier is a piecewise Bézier curve with C0 continuity
+     * (positional continuity only) used for editing. It requires:
+     *
+     * - Control points: (controlPointCount - 1) % degree == 0
+     * - Knot vector with multiplicity 'degree' at internal junctions
+     * - Can have 1 or more segments (like MultiPolygon can have 1+ polygons)
+     *
+     * Works for any degree ≥ 1. Note that a single-segment poly-Bézier
+     * will also return TRUE for isBezier() (degree = n-1 condition).
      */
     bool isPolyBezier() const SIP_HOLDGIL;
 

--- a/src/core/geometry/qgsnurbscurve.h
+++ b/src/core/geometry/qgsnurbscurve.h
@@ -340,21 +340,19 @@ class CORE_EXPORT QgsNurbsCurve : public QgsCurve
     static QVector<double> generateUniformKnots( int numControlPoints, int degree );
 
     /**
-     * Generates a knot vector for converting piecewise cubic Bézier curves to NURBS.
+     * Generates a knot vector for converting piecewise Bézier curves to NURBS.
      *
-     * This creates a knot vector with multiplicity 3 at junctions for C0 continuity,
-     * suitable for representing a sequence of cubic Bézier segments as a single NURBS curve.
-     * For n anchors (n-1 cubic Bézier segments), this generates the appropriate knot vector
-     * with degree 3.
+     * Creates a knot vector with multiplicity 'degree' at junctions for C0 continuity.
+     * Format: [0 repeated (degree+1), 1 repeated degree, ..., s repeated (degree+1)]
+     * where s = nAnchors - 1 (number of segments)
      *
-     * Format: [0,0,0,0, 1,1,1, 2,2,2, ..., n-1,n-1,n-1,n-1]
-     * Total knots: 4 + 3*(n-2) + 4 = 3n + 2
-     *
-     * \param nAnchors number of anchor points (defines n-1 cubic Bézier segments)
-     * \returns the generated knot vector
+     * \param nAnchors number of anchor points (must be >= 2)
+     * \param degree degree of the curve (must be >= 1), defaults to 3 (cubic)
+     * \returns the generated knot vector, or empty if invalid parameters
      * \since QGIS 4.0
      */
-    static QVector<double> generateKnotsForBezierConversion( int nAnchors );
+    static QVector<double> generateKnotsForBezierConversion( int nAnchors, int degree = 3 );
+
 
     /**
      * Cast the \a geom to a QgsNurbsCurve.

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -418,6 +418,7 @@ class CORE_EXPORT Qgis
     enum class NurbsMode : int
     {
       ControlPoints, //!< Direct control points mode - the curve is attracted to control points but does not pass through them
+      PolyBezier, //!< Poly-Bézier mode (vector graphics style) - anchors with tangent handles, the curve passes through anchor points
     };
     Q_ENUM( NurbsMode )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -406,21 +406,11 @@ class CORE_EXPORT Qgis
       CircularString, //!< Capture in circular strings
       Streaming, //!< Streaming points digitizing mode (points are automatically added as the mouse cursor moves).
       Shape, //!< Digitize shapes.
-      NurbsCurve, //!< Digitizes NURBS curves with control points. \since QGIS 4.0
+      PolyBezier, //!< Digitizes poly-Bézier curves with anchors and tangent handles (curve passes through anchor points). \since QGIS 4.0
+      NurbsCurve, //!< Digitizes NURBS curves with control points (curve is attracted to but does not pass through control points). \since QGIS 4.0
     };
     Q_ENUM( CaptureTechnique )
 
-    /**
-     * NURBS digitizing mode.
-     *
-     * \since QGIS 4.0
-     */
-    enum class NurbsMode : int
-    {
-      ControlPoints, //!< Direct control points mode - the curve is attracted to control points but does not pass through them
-      PolyBezier, //!< Poly-Bézier mode (vector graphics style) - anchors with tangent handles, the curve passes through anchor points
-    };
-    Q_ENUM( NurbsMode )
 
     /**
      * Vector layer type flags.

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -52,8 +52,6 @@ const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsDigitizingStream
 
 const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsDigitizingNurbsDegree = new QgsSettingsEntryInteger( u"nurbs-degree"_s, QgsSettingsTree::sTreeDigitizing, 3 );
 
-const QgsSettingsEntryEnumFlag<Qgis::NurbsMode> *QgsSettingsRegistryCore::settingsDigitizingNurbsMode = new QgsSettingsEntryEnumFlag<Qgis::NurbsMode>( u"nurbs-mode"_s, QgsSettingsTree::sTreeDigitizing, Qgis::NurbsMode::ControlPoints );
-
 const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsDigitizingLineWidth = new QgsSettingsEntryInteger( u"line-width"_s, QgsSettingsTree::sTreeDigitizing, 1 );
 
 const QgsSettingsEntryColor *QgsSettingsRegistryCore::settingsDigitizingLineColor = new QgsSettingsEntryColor( u"line-color"_s, QgsSettingsTree::sTreeDigitizing, QColor( 255, 0, 0, 200 ) );

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -58,12 +58,6 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
      */
     static const QgsSettingsEntryInteger *settingsDigitizingNurbsDegree;
 
-    /**
-     * Settings entry digitizing NURBS mode
-     * \since QGIS 4.0
-     */
-    static const QgsSettingsEntryEnumFlag<Qgis::NurbsMode> *settingsDigitizingNurbsMode;
-
     //! Settings entry digitizing line width
     static const QgsSettingsEntryInteger *settingsDigitizingLineWidth;
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -361,6 +361,10 @@ set(QGIS_GUI_SRCS
   maptools/qgsmaptoolcapturelayergeometry.cpp
   maptools/qgsmaptoolcapturerubberband.cpp
   maptools/qgsmaptooldigitizefeature.cpp
+
+  maptools/qgsbezierdata.cpp
+  maptools/qgsbeziermarker.cpp
+
   maptools/qgsmaptooledit.cpp
   maptools/qgsmaptooleditblanksegments.cpp
   maptools/qgsmaptoolemitpoint.cpp
@@ -1375,6 +1379,8 @@ set(QGIS_GUI_HDRS
   maptools/qgsmaptoolcapture.h
   maptools/qgsmaptoolcapturelayergeometry.h
   maptools/qgsmaptoolcapturerubberband.h
+  maptools/qgsbezierdata.h
+  maptools/qgsbeziermarker.h
   maptools/qgsmaptooldigitizefeature.h
   maptools/qgsmaptooledit.h
   maptools/qgsmaptooleditblanksegments.h

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -88,6 +88,7 @@ bool QgsMapToolCaptureAnnotationItem::supportsTechnique( Qgis::CaptureTechnique 
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Streaming:
     case Qgis::CaptureTechnique::Shape:
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       return true;
   }

--- a/src/gui/maptools/qgsbezierdata.cpp
+++ b/src/gui/maptools/qgsbezierdata.cpp
@@ -202,26 +202,7 @@ std::unique_ptr<QgsNurbsCurve> QgsBezierData::asNurbsCurve() const
     ctrlPts.append( mData[i + 1].anchor );
   }
 
-  // Build knot vector with multiplicity 3 at junctions for C0 continuity
-  // Format: [0,0,0,0, 1,1,1, 2,2,2, ..., n-1,n-1,n-1,n-1]
-  // Total knots: 4 + 3*(n-2) + 4 = 3n + 2
-  // Actually for n-1 segments with degree 3: ctrlPts.count() + 4 = 3n-2+4 = 3n+2
-  QVector<double> knots;
-
-  // First 4 knots are 0
-  for ( int i = 0; i < 4; ++i )
-    knots.append( 0.0 );
-
-  // Interior knots with multiplicity 3
-  for ( int i = 1; i < n - 1; ++i )
-  {
-    for ( int j = 0; j < 3; ++j )
-      knots.append( static_cast<double>( i ) );
-  }
-
-  // Last 4 knots are n-1
-  for ( int i = 0; i < 4; ++i )
-    knots.append( static_cast<double>( n - 1 ) );
+  QVector<double> knots = QgsNurbsCurve::generateKnotsForBezierConversion( n );
 
   // Uniform weights (non-rational B-spline)
   QVector<double> weights( ctrlPts.count(), 1.0 );

--- a/src/gui/maptools/qgsbezierdata.cpp
+++ b/src/gui/maptools/qgsbezierdata.cpp
@@ -3,6 +3,7 @@
     ---------------------
     begin                : December 2025
     copyright            : (C) 2025 by Loïc Bartoletti
+                           Adapted from BezierEditing plugin work by Takayuki Mizutani
     email                : loic dot bartoletti at oslandia dot com
  ***************************************************************************
  *                                                                         *

--- a/src/gui/maptools/qgsbezierdata.cpp
+++ b/src/gui/maptools/qgsbezierdata.cpp
@@ -185,8 +185,8 @@ QgsPointSequence QgsBezierData::interpolateLine() const
 
 std::unique_ptr<QgsNurbsCurve> QgsBezierData::asNurbsCurve() const
 {
-  const int n = mData.count();
-  if ( n < 2 )
+  const int anchorCount = mData.count();
+  if ( anchorCount < 2 )
     return nullptr;
 
   // Build control points: anchor, handle_right, handle_left, anchor, ...
@@ -195,14 +195,14 @@ std::unique_ptr<QgsNurbsCurve> QgsBezierData::asNurbsCurve() const
   QVector<QgsPoint> ctrlPts;
   ctrlPts.append( mData[0].anchor );
 
-  for ( int i = 0; i < n - 1; ++i )
+  for ( int i = 0; i < anchorCount - 1; ++i )
   {
     ctrlPts.append( mData[i].rightHandle );
     ctrlPts.append( mData[i + 1].leftHandle );
     ctrlPts.append( mData[i + 1].anchor );
   }
 
-  QVector<double> knots = QgsNurbsCurve::generateKnotsForBezierConversion( n );
+  QVector<double> knots = QgsNurbsCurve::generateKnotsForBezierConversion( anchorCount );
 
   // Uniform weights (non-rational B-spline)
   QVector<double> weights( ctrlPts.count(), 1.0 );

--- a/src/gui/maptools/qgsbezierdata.cpp
+++ b/src/gui/maptools/qgsbezierdata.cpp
@@ -25,100 +25,100 @@
 
 const QgsAnchorWithHandles QgsBezierData::sInvalidAnchor;
 
-void QgsBezierData::addAnchor( const QgsPoint &pt )
+void QgsBezierData::addAnchor( const QgsPoint &point )
 {
-  mData.append( QgsAnchorWithHandles( pt ) );
+  mData.append( QgsAnchorWithHandles( point ) );
 }
 
-void QgsBezierData::moveAnchor( int idx, const QgsPoint &pt )
+void QgsBezierData::moveAnchor( int index, const QgsPoint &point )
 {
-  if ( idx < 0 || idx >= mData.count() )
+  if ( index < 0 || index >= mData.count() )
     return;
 
-  QgsAnchorWithHandles &data = mData[idx];
+  QgsAnchorWithHandles &data = mData[index];
 
   // Calculate offset
-  const double dx = pt.x() - data.anchor.x();
-  const double dy = pt.y() - data.anchor.y();
-  const double dz = pt.is3D() ? ( pt.z() - data.anchor.z() ) : 0.0;
+  const double dx = point.x() - data.anchor.x();
+  const double dy = point.y() - data.anchor.y();
+  const double dz = point.is3D() ? ( point.z() - data.anchor.z() ) : 0.0;
 
   // Move anchor
-  data.anchor = pt;
+  data.anchor = point;
 
   // Move both handles relatively
   data.leftHandle.setX( data.leftHandle.x() + dx );
   data.leftHandle.setY( data.leftHandle.y() + dy );
-  if ( pt.is3D() )
+  if ( point.is3D() )
     data.leftHandle.setZ( data.leftHandle.z() + dz );
 
   data.rightHandle.setX( data.rightHandle.x() + dx );
   data.rightHandle.setY( data.rightHandle.y() + dy );
-  if ( pt.is3D() )
+  if ( point.is3D() )
     data.rightHandle.setZ( data.rightHandle.z() + dz );
 }
 
-void QgsBezierData::moveHandle( int idx, const QgsPoint &pt )
+void QgsBezierData::moveHandle( int index, const QgsPoint &point )
 {
-  const int anchorIdx = idx / 2;
-  if ( anchorIdx < 0 || anchorIdx >= mData.count() )
+  const int anchorIndex = index / 2;
+  if ( anchorIndex < 0 || anchorIndex >= mData.count() )
     return;
 
-  if ( idx % 2 == 0 )
-    mData[anchorIdx].leftHandle = pt;
+  if ( index % 2 == 0 )
+    mData[anchorIndex].leftHandle = point;
   else
-    mData[anchorIdx].rightHandle = pt;
+    mData[anchorIndex].rightHandle = point;
 }
 
-void QgsBezierData::insertAnchor( int segmentIdx, const QgsPoint &pt )
+void QgsBezierData::insertAnchor( int segmentIndex, const QgsPoint &point )
 {
-  if ( segmentIdx < 0 || segmentIdx > mData.count() )
+  if ( segmentIndex < 0 || segmentIndex > mData.count() )
     return;
 
-  mData.insert( segmentIdx, QgsAnchorWithHandles( pt ) );
+  mData.insert( segmentIndex, QgsAnchorWithHandles( point ) );
 }
 
-void QgsBezierData::deleteAnchor( int idx )
+void QgsBezierData::deleteAnchor( int index )
 {
-  if ( idx < 0 || idx >= mData.count() )
+  if ( index < 0 || index >= mData.count() )
     return;
 
-  mData.removeAt( idx );
+  mData.removeAt( index );
 }
 
-void QgsBezierData::retractHandle( int idx )
+void QgsBezierData::retractHandle( int index )
 {
-  const int anchorIdx = idx / 2;
-  if ( anchorIdx < 0 || anchorIdx >= mData.count() )
+  const int anchorIndex = index / 2;
+  if ( anchorIndex < 0 || anchorIndex >= mData.count() )
     return;
 
-  if ( idx % 2 == 0 )
-    mData[anchorIdx].leftHandle = mData[anchorIdx].anchor;
+  if ( index % 2 == 0 )
+    mData[anchorIndex].leftHandle = mData[anchorIndex].anchor;
   else
-    mData[anchorIdx].rightHandle = mData[anchorIdx].anchor;
+    mData[anchorIndex].rightHandle = mData[anchorIndex].anchor;
 }
 
-void QgsBezierData::extendHandle( int idx, const QgsPoint &pt )
+void QgsBezierData::extendHandle( int index, const QgsPoint &point )
 {
-  moveHandle( idx, pt );
+  moveHandle( index, point );
 }
 
-QgsPoint QgsBezierData::anchor( int idx ) const
+QgsPoint QgsBezierData::anchor( int index ) const
 {
-  if ( idx < 0 || idx >= mData.count() )
+  if ( index < 0 || index >= mData.count() )
     return QgsPoint();
-  return mData[idx].anchor;
+  return mData[index].anchor;
 }
 
-QgsPoint QgsBezierData::handle( int idx ) const
+QgsPoint QgsBezierData::handle( int index ) const
 {
-  const int anchorIdx = idx / 2;
-  if ( anchorIdx < 0 || anchorIdx >= mData.count() )
+  const int anchorIndex = index / 2;
+  if ( anchorIndex < 0 || anchorIndex >= mData.count() )
     return QgsPoint();
 
-  if ( idx % 2 == 0 )
-    return mData[anchorIdx].leftHandle;
+  if ( index % 2 == 0 )
+    return mData[anchorIndex].leftHandle;
   else
-    return mData[anchorIdx].rightHandle;
+    return mData[anchorIndex].rightHandle;
 }
 
 QVector<QgsPoint> QgsBezierData::anchors() const
@@ -142,11 +142,11 @@ QVector<QgsPoint> QgsBezierData::handles() const
   return result;
 }
 
-const QgsAnchorWithHandles &QgsBezierData::anchorWithHandles( int idx ) const
+const QgsAnchorWithHandles &QgsBezierData::anchorWithHandles( int index ) const
 {
-  if ( idx < 0 || idx >= mData.count() )
+  if ( index < 0 || index >= mData.count() )
     return sInvalidAnchor;
-  return mData[idx];
+  return mData[index];
 }
 
 QgsPointSequence QgsBezierData::interpolate() const
@@ -215,30 +215,30 @@ void QgsBezierData::clear()
   mData.clear();
 }
 
-int QgsBezierData::findClosestAnchor( const QgsPoint &pt, double tolerance ) const
+int QgsBezierData::findClosestAnchor( const QgsPoint &point, double tolerance ) const
 {
-  int closestIdx = -1;
-  double minDistSq = tolerance * tolerance;
+  int closestIndex = -1;
+  double minDistanceSquared = tolerance * tolerance;
 
   for ( int i = 0; i < mData.count(); ++i )
   {
-    const double dx = mData[i].anchor.x() - pt.x();
-    const double dy = mData[i].anchor.y() - pt.y();
-    const double distSq = dx * dx + dy * dy;
-    if ( distSq < minDistSq )
+    const double dx = mData[i].anchor.x() - point.x();
+    const double dy = mData[i].anchor.y() - point.y();
+    const double distanceSquared = dx * dx + dy * dy;
+    if ( distanceSquared < minDistanceSquared )
     {
-      minDistSq = distSq;
-      closestIdx = i;
+      minDistanceSquared = distanceSquared;
+      closestIndex = i;
     }
   }
 
-  return closestIdx;
+  return closestIndex;
 }
 
-int QgsBezierData::findClosestHandle( const QgsPoint &pt, double tolerance ) const
+int QgsBezierData::findClosestHandle( const QgsPoint &point, double tolerance ) const
 {
-  int closestIdx = -1;
-  double minDistSq = tolerance * tolerance;
+  int closestIndex = -1;
+  double minDistanceSquared = tolerance * tolerance;
 
   for ( int i = 0; i < mData.count(); ++i )
   {
@@ -247,40 +247,40 @@ int QgsBezierData::findClosestHandle( const QgsPoint &pt, double tolerance ) con
     // Check left handle (index 2*i)
     if ( !qgsDoubleNear( awh.leftHandle.x(), awh.anchor.x() ) || !qgsDoubleNear( awh.leftHandle.y(), awh.anchor.y() ) )
     {
-      const double dx = awh.leftHandle.x() - pt.x();
-      const double dy = awh.leftHandle.y() - pt.y();
-      const double distSq = dx * dx + dy * dy;
-      if ( distSq < minDistSq )
+      const double dx = awh.leftHandle.x() - point.x();
+      const double dy = awh.leftHandle.y() - point.y();
+      const double distanceSquared = dx * dx + dy * dy;
+      if ( distanceSquared < minDistanceSquared )
       {
-        minDistSq = distSq;
-        closestIdx = i * 2;
+        minDistanceSquared = distanceSquared;
+        closestIndex = i * 2;
       }
     }
 
     // Check right handle (index 2*i+1)
     if ( !qgsDoubleNear( awh.rightHandle.x(), awh.anchor.x() ) || !qgsDoubleNear( awh.rightHandle.y(), awh.anchor.y() ) )
     {
-      const double dx = awh.rightHandle.x() - pt.x();
-      const double dy = awh.rightHandle.y() - pt.y();
-      const double distSq = dx * dx + dy * dy;
-      if ( distSq < minDistSq )
+      const double dx = awh.rightHandle.x() - point.x();
+      const double dy = awh.rightHandle.y() - point.y();
+      const double distanceSquared = dx * dx + dy * dy;
+      if ( distanceSquared < minDistanceSquared )
       {
-        minDistSq = distSq;
-        closestIdx = i * 2 + 1;
+        minDistanceSquared = distanceSquared;
+        closestIndex = i * 2 + 1;
       }
     }
   }
 
-  return closestIdx;
+  return closestIndex;
 }
 
-int QgsBezierData::findClosestSegment( const QgsPoint &pt, double tolerance ) const
+int QgsBezierData::findClosestSegment( const QgsPoint &point, double tolerance ) const
 {
   if ( mData.count() < 2 )
     return -1;
 
   int closestSegment = -1;
-  double minDistSq = tolerance * tolerance;
+  double minDistanceSquared = tolerance * tolerance;
 
   // Check each segment
   for ( int i = 0; i < mData.count() - 1; ++i )
@@ -296,13 +296,13 @@ int QgsBezierData::findClosestSegment( const QgsPoint &pt, double tolerance ) co
       const double t = static_cast<double>( j ) / INTERPOLATION_POINTS;
       const QgsPoint curvePoint = QgsGeometryUtils::interpolatePointOnCubicBezier( p0, p1, p2, p3, t );
 
-      const double dx = curvePoint.x() - pt.x();
-      const double dy = curvePoint.y() - pt.y();
-      const double distSq = dx * dx + dy * dy;
+      const double dx = curvePoint.x() - point.x();
+      const double dy = curvePoint.y() - point.y();
+      const double distanceSquared = dx * dx + dy * dy;
 
-      if ( distSq < minDistSq )
+      if ( distanceSquared < minDistanceSquared )
       {
-        minDistSq = distSq;
+        minDistanceSquared = distanceSquared;
         closestSegment = i;
       }
     }

--- a/src/gui/maptools/qgsbezierdata.cpp
+++ b/src/gui/maptools/qgsbezierdata.cpp
@@ -1,0 +1,332 @@
+/***************************************************************************
+    qgsbezierdata.cpp  -  Data structure for Poly-Bézier curve digitizing
+    ---------------------
+    begin                : December 2025
+    copyright            : (C) 2025 by Loïc Bartoletti
+    email                : loic dot bartoletti at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsbezierdata.h"
+
+#include <cmath>
+
+#include "qgsgeometryutils.h"
+#include "qgsnurbscurve.h"
+
+///@cond PRIVATE
+
+const QgsAnchorWithHandles QgsBezierData::sInvalidAnchor;
+
+void QgsBezierData::addAnchor( const QgsPoint &pt )
+{
+  mData.append( QgsAnchorWithHandles( pt ) );
+}
+
+void QgsBezierData::moveAnchor( int idx, const QgsPoint &pt )
+{
+  if ( idx < 0 || idx >= mData.count() )
+    return;
+
+  QgsAnchorWithHandles &data = mData[idx];
+
+  // Calculate offset
+  const double dx = pt.x() - data.anchor.x();
+  const double dy = pt.y() - data.anchor.y();
+  const double dz = pt.is3D() ? ( pt.z() - data.anchor.z() ) : 0.0;
+
+  // Move anchor
+  data.anchor = pt;
+
+  // Move both handles relatively
+  data.leftHandle.setX( data.leftHandle.x() + dx );
+  data.leftHandle.setY( data.leftHandle.y() + dy );
+  if ( pt.is3D() )
+    data.leftHandle.setZ( data.leftHandle.z() + dz );
+
+  data.rightHandle.setX( data.rightHandle.x() + dx );
+  data.rightHandle.setY( data.rightHandle.y() + dy );
+  if ( pt.is3D() )
+    data.rightHandle.setZ( data.rightHandle.z() + dz );
+}
+
+void QgsBezierData::moveHandle( int idx, const QgsPoint &pt )
+{
+  const int anchorIdx = idx / 2;
+  if ( anchorIdx < 0 || anchorIdx >= mData.count() )
+    return;
+
+  if ( idx % 2 == 0 )
+    mData[anchorIdx].leftHandle = pt;
+  else
+    mData[anchorIdx].rightHandle = pt;
+}
+
+void QgsBezierData::insertAnchor( int segmentIdx, const QgsPoint &pt )
+{
+  if ( segmentIdx < 0 || segmentIdx > mData.count() )
+    return;
+
+  mData.insert( segmentIdx, QgsAnchorWithHandles( pt ) );
+}
+
+void QgsBezierData::deleteAnchor( int idx )
+{
+  if ( idx < 0 || idx >= mData.count() )
+    return;
+
+  mData.removeAt( idx );
+}
+
+void QgsBezierData::retractHandle( int idx )
+{
+  const int anchorIdx = idx / 2;
+  if ( anchorIdx < 0 || anchorIdx >= mData.count() )
+    return;
+
+  if ( idx % 2 == 0 )
+    mData[anchorIdx].leftHandle = mData[anchorIdx].anchor;
+  else
+    mData[anchorIdx].rightHandle = mData[anchorIdx].anchor;
+}
+
+void QgsBezierData::extendHandle( int idx, const QgsPoint &pt )
+{
+  moveHandle( idx, pt );
+}
+
+QgsPoint QgsBezierData::anchor( int idx ) const
+{
+  if ( idx < 0 || idx >= mData.count() )
+    return QgsPoint();
+  return mData[idx].anchor;
+}
+
+QgsPoint QgsBezierData::handle( int idx ) const
+{
+  const int anchorIdx = idx / 2;
+  if ( anchorIdx < 0 || anchorIdx >= mData.count() )
+    return QgsPoint();
+
+  if ( idx % 2 == 0 )
+    return mData[anchorIdx].leftHandle;
+  else
+    return mData[anchorIdx].rightHandle;
+}
+
+QVector<QgsPoint> QgsBezierData::anchors() const
+{
+  QVector<QgsPoint> result;
+  result.reserve( mData.count() );
+  for ( const QgsAnchorWithHandles &awh : mData )
+    result.append( awh.anchor );
+  return result;
+}
+
+QVector<QgsPoint> QgsBezierData::handles() const
+{
+  QVector<QgsPoint> result;
+  result.reserve( mData.count() * 2 );
+  for ( const QgsAnchorWithHandles &awh : mData )
+  {
+    result.append( awh.leftHandle );
+    result.append( awh.rightHandle );
+  }
+  return result;
+}
+
+const QgsAnchorWithHandles &QgsBezierData::anchorWithHandles( int idx ) const
+{
+  if ( idx < 0 || idx >= mData.count() )
+    return sInvalidAnchor;
+  return mData[idx];
+}
+
+QgsPointSequence QgsBezierData::interpolate() const
+{
+  QgsPointSequence result;
+
+  if ( mData.count() < 2 )
+  {
+    // Not enough anchors for a curve, just return anchors
+    for ( const QgsAnchorWithHandles &awh : mData )
+      result.append( awh.anchor );
+    return result;
+  }
+
+  // Add first anchor
+  result.append( mData.first().anchor );
+
+  // For each segment between consecutive anchors
+  for ( int i = 0; i < mData.count() - 1; ++i )
+  {
+    const QgsPoint &p0 = mData[i].anchor;
+    const QgsPoint &p1 = mData[i].rightHandle;
+    const QgsPoint &p2 = mData[i + 1].leftHandle;
+    const QgsPoint &p3 = mData[i + 1].anchor;
+
+    // Interpolate the segment
+    for ( int j = 1; j <= INTERPOLATION_POINTS; ++j )
+    {
+      const double t = static_cast<double>( j ) / INTERPOLATION_POINTS;
+      result.append( QgsGeometryUtils::interpolatePointOnCubicBezier( p0, p1, p2, p3, t ) );
+    }
+  }
+
+  return result;
+}
+
+std::unique_ptr<QgsNurbsCurve> QgsBezierData::asNurbsCurve() const
+{
+  const int n = mData.count();
+  if ( n < 2 )
+    return nullptr;
+
+  // Build control points: anchor, handle_right, handle_left, anchor, ...
+  // A piecewise cubic Bézier with n anchors has n-1 segments
+  // Total control points: 1 + 3*(n-1) = 3n-2
+  QVector<QgsPoint> ctrlPts;
+  ctrlPts.append( mData[0].anchor );
+
+  for ( int i = 0; i < n - 1; ++i )
+  {
+    ctrlPts.append( mData[i].rightHandle );
+    ctrlPts.append( mData[i + 1].leftHandle );
+    ctrlPts.append( mData[i + 1].anchor );
+  }
+
+  // Build knot vector with multiplicity 3 at junctions for C0 continuity
+  // Format: [0,0,0,0, 1,1,1, 2,2,2, ..., n-1,n-1,n-1,n-1]
+  // Total knots: 4 + 3*(n-2) + 4 = 3n + 2
+  // Actually for n-1 segments with degree 3: ctrlPts.count() + 4 = 3n-2+4 = 3n+2
+  QVector<double> knots;
+
+  // First 4 knots are 0
+  for ( int i = 0; i < 4; ++i )
+    knots.append( 0.0 );
+
+  // Interior knots with multiplicity 3
+  for ( int i = 1; i < n - 1; ++i )
+  {
+    for ( int j = 0; j < 3; ++j )
+      knots.append( static_cast<double>( i ) );
+  }
+
+  // Last 4 knots are n-1
+  for ( int i = 0; i < 4; ++i )
+    knots.append( static_cast<double>( n - 1 ) );
+
+  // Uniform weights (non-rational B-spline)
+  QVector<double> weights( ctrlPts.count(), 1.0 );
+
+  return std::make_unique<QgsNurbsCurve>( ctrlPts, 3, knots, weights );
+}
+
+void QgsBezierData::clear()
+{
+  mData.clear();
+}
+
+int QgsBezierData::findClosestAnchor( const QgsPoint &pt, double tolerance ) const
+{
+  int closestIdx = -1;
+  double minDistSq = tolerance * tolerance;
+
+  for ( int i = 0; i < mData.count(); ++i )
+  {
+    const double dx = mData[i].anchor.x() - pt.x();
+    const double dy = mData[i].anchor.y() - pt.y();
+    const double distSq = dx * dx + dy * dy;
+    if ( distSq < minDistSq )
+    {
+      minDistSq = distSq;
+      closestIdx = i;
+    }
+  }
+
+  return closestIdx;
+}
+
+int QgsBezierData::findClosestHandle( const QgsPoint &pt, double tolerance ) const
+{
+  int closestIdx = -1;
+  double minDistSq = tolerance * tolerance;
+
+  for ( int i = 0; i < mData.count(); ++i )
+  {
+    const QgsAnchorWithHandles &awh = mData[i];
+
+    // Check left handle (index 2*i)
+    if ( !qgsDoubleNear( awh.leftHandle.x(), awh.anchor.x() ) || !qgsDoubleNear( awh.leftHandle.y(), awh.anchor.y() ) )
+    {
+      const double dx = awh.leftHandle.x() - pt.x();
+      const double dy = awh.leftHandle.y() - pt.y();
+      const double distSq = dx * dx + dy * dy;
+      if ( distSq < minDistSq )
+      {
+        minDistSq = distSq;
+        closestIdx = i * 2;
+      }
+    }
+
+    // Check right handle (index 2*i+1)
+    if ( !qgsDoubleNear( awh.rightHandle.x(), awh.anchor.x() ) || !qgsDoubleNear( awh.rightHandle.y(), awh.anchor.y() ) )
+    {
+      const double dx = awh.rightHandle.x() - pt.x();
+      const double dy = awh.rightHandle.y() - pt.y();
+      const double distSq = dx * dx + dy * dy;
+      if ( distSq < minDistSq )
+      {
+        minDistSq = distSq;
+        closestIdx = i * 2 + 1;
+      }
+    }
+  }
+
+  return closestIdx;
+}
+
+int QgsBezierData::findClosestSegment( const QgsPoint &pt, double tolerance ) const
+{
+  if ( mData.count() < 2 )
+    return -1;
+
+  int closestSegment = -1;
+  double minDistSq = tolerance * tolerance;
+
+  // Check each segment
+  for ( int i = 0; i < mData.count() - 1; ++i )
+  {
+    const QgsPoint &p0 = mData[i].anchor;
+    const QgsPoint &p1 = mData[i].rightHandle;
+    const QgsPoint &p2 = mData[i + 1].leftHandle;
+    const QgsPoint &p3 = mData[i + 1].anchor;
+
+    // Sample the curve and find minimum distance
+    for ( int j = 0; j <= INTERPOLATION_POINTS; ++j )
+    {
+      const double t = static_cast<double>( j ) / INTERPOLATION_POINTS;
+      const QgsPoint curvePoint = QgsGeometryUtils::interpolatePointOnCubicBezier( p0, p1, p2, p3, t );
+
+      const double dx = curvePoint.x() - pt.x();
+      const double dy = curvePoint.y() - pt.y();
+      const double distSq = dx * dx + dy * dy;
+
+      if ( distSq < minDistSq )
+      {
+        minDistSq = distSq;
+        closestSegment = i;
+      }
+    }
+  }
+
+  return closestSegment;
+}
+
+///@endcond PRIVATE

--- a/src/gui/maptools/qgsbezierdata.cpp
+++ b/src/gui/maptools/qgsbezierdata.cpp
@@ -149,7 +149,7 @@ const QgsAnchorWithHandles &QgsBezierData::anchorWithHandles( int index ) const
   return mData[index];
 }
 
-QgsPointSequence QgsBezierData::interpolate() const
+QgsPointSequence QgsBezierData::interpolateLine() const
 {
   QgsPointSequence result;
 

--- a/src/gui/maptools/qgsbezierdata.h
+++ b/src/gui/maptools/qgsbezierdata.h
@@ -53,8 +53,8 @@ struct GUI_EXPORT QgsAnchorWithHandles
       : anchor( point ), leftHandle( point ), rightHandle( point ) {}
 
     //! Constructor with all points specified
-    QgsAnchorWithHandles( const QgsPoint &a, const QgsPoint &left, const QgsPoint &right )
-      : anchor( a ), leftHandle( left ), rightHandle( right ) {}
+    QgsAnchorWithHandles( const QgsPoint &point, const QgsPoint &left, const QgsPoint &right )
+      : anchor( point ), leftHandle( left ), rightHandle( right ) {}
 };
 
 /**
@@ -87,7 +87,7 @@ class GUI_EXPORT QgsBezierData
     void addAnchor( const QgsPoint &point );
 
     /**
-     * Moves the anchor at index \a index to the new position \a pt.
+     * Moves the anchor at index \a index to the new position \a point.
      * Handles are moved relative to the anchor.
      * \param index anchor index (0-based)
      * \param point new position
@@ -95,7 +95,7 @@ class GUI_EXPORT QgsBezierData
     void moveAnchor( int index, const QgsPoint &point );
 
     /**
-     * Moves the handle at index \a index to the new position \a pt.
+     * Moves the handle at index \a index to the new position \a point.
      * \param index handle index (0-based, 2 handles per anchor)
      * \param point new position
      */

--- a/src/gui/maptools/qgsbezierdata.h
+++ b/src/gui/maptools/qgsbezierdata.h
@@ -157,7 +157,7 @@ class GUI_EXPORT QgsBezierData
      * Returns the interpolated points of the curve for visualization.
      * Uses cubic Bézier interpolation between anchor points.
      */
-    QgsPointSequence interpolate() const;
+    QgsPointSequence interpolateLine() const;
 
     /**
      * Converts the Poly-Bézier data to a QgsNurbsCurve.

--- a/src/gui/maptools/qgsbezierdata.h
+++ b/src/gui/maptools/qgsbezierdata.h
@@ -3,6 +3,7 @@
     ---------------------
     begin                : December 2025
     copyright            : (C) 2025 by Loïc Bartoletti
+                           Adapted from BezierEditing plugin work by Takayuki Mizutani
     email                : loic dot bartoletti at oslandia dot com
  ***************************************************************************
  *                                                                         *

--- a/src/gui/maptools/qgsbezierdata.h
+++ b/src/gui/maptools/qgsbezierdata.h
@@ -1,0 +1,205 @@
+/***************************************************************************
+    qgsbezierdata.h  -  Data structure for Poly-Bézier curve digitizing
+    ---------------------
+    begin                : December 2025
+    copyright            : (C) 2025 by Loïc Bartoletti
+    email                : loic dot bartoletti at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSBEZIERDATA_H
+#define QGSBEZIERDATA_H
+
+#include <memory>
+
+#include "qgis_gui.h"
+#include "qgspoint.h"
+
+class QgsNurbsCurve;
+
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+
+/**
+ * \brief Structure representing an anchor point with its two control handles.
+ *
+ * Each anchor has:
+ *
+ * - anchor: the point where the curve passes through
+ * - leftHandle: controls the incoming tangent (from previous segment)
+ * - rightHandle: controls the outgoing tangent (to next segment)
+ *
+ * \since QGIS 4.0
+ */
+struct GUI_EXPORT QgsAnchorWithHandles
+{
+    QgsPoint anchor;      //!< Anchor point (curve passes through this)
+    QgsPoint leftHandle;  //!< Left handle (controls incoming tangent)
+    QgsPoint rightHandle; //!< Right handle (controls outgoing tangent)
+
+    //! Constructor with anchor at origin, handles retracted
+    QgsAnchorWithHandles() = default;
+
+    //! Constructor with anchor position, handles retracted at anchor
+    explicit QgsAnchorWithHandles( const QgsPoint &pt )
+      : anchor( pt ), leftHandle( pt ), rightHandle( pt ) {}
+
+    //! Constructor with all points specified
+    QgsAnchorWithHandles( const QgsPoint &a, const QgsPoint &left, const QgsPoint &right )
+      : anchor( a ), leftHandle( left ), rightHandle( right ) {}
+};
+
+/**
+ * \brief Data structure for managing Poly-Bézier curve during digitizing.
+ *
+ * This class stores anchor points (where the curve passes through) and
+ * handle points (tangent control points, 2 per anchor).
+ *
+ * Handle indexing:
+ *
+ * - Handle index 2*i is the "left" handle of anchor i (controls incoming tangent)
+ * - Handle index 2*i+1 is the "right" handle of anchor i (controls outgoing tangent)
+ *
+ * \since QGIS 4.0
+ */
+class GUI_EXPORT QgsBezierData
+{
+  public:
+    //! Default constructor
+    QgsBezierData() = default;
+
+    //! Number of interpolated points per Bézier segment for visualization
+    static constexpr int INTERPOLATION_POINTS = 32;
+
+    /**
+     * Adds an anchor point at the given position.
+     * Both handles are initially placed at the anchor position.
+     * \param pt anchor point position
+     */
+    void addAnchor( const QgsPoint &pt );
+
+    /**
+     * Moves the anchor at index \a idx to the new position \a pt.
+     * Handles are moved relative to the anchor.
+     * \param idx anchor index (0-based)
+     * \param pt new position
+     */
+    void moveAnchor( int idx, const QgsPoint &pt );
+
+    /**
+     * Moves the handle at index \a idx to the new position \a pt.
+     * \param idx handle index (0-based, 2 handles per anchor)
+     * \param pt new position
+     */
+    void moveHandle( int idx, const QgsPoint &pt );
+
+    /**
+     * Inserts a new anchor point at the given segment.
+     * \param segmentIdx segment index where to insert (0 = before first segment)
+     * \param pt anchor position
+     */
+    void insertAnchor( int segmentIdx, const QgsPoint &pt );
+
+    /**
+     * Deletes the anchor at index \a idx and its associated handles.
+     * \param idx anchor index to delete
+     */
+    void deleteAnchor( int idx );
+
+    /**
+     * Retracts (collapses) the handle at index \a idx to its anchor position.
+     * \param idx handle index
+     */
+    void retractHandle( int idx );
+
+    /**
+     * Extends (expands) the handle at index \a idx from its anchor.
+     * Used when a handle is initially at the anchor position.
+     * \param idx handle index
+     * \param pt new handle position
+     */
+    void extendHandle( int idx, const QgsPoint &pt );
+
+    //! Returns the number of anchor points
+    int anchorCount() const { return mData.count(); }
+
+    //! Returns the number of handles (always 2 * anchorCount)
+    int handleCount() const { return mData.count() * 2; }
+
+    //! Returns the anchor at index \a idx
+    QgsPoint anchor( int idx ) const;
+
+    //! Returns the handle at index \a idx
+    QgsPoint handle( int idx ) const;
+
+    //! Returns all anchors (extracted from mData)
+    QVector<QgsPoint> anchors() const;
+
+    //! Returns all handles (extracted from mData, 2 per anchor)
+    QVector<QgsPoint> handles() const;
+
+    /**
+     * Returns the anchor with its handles at index \a idx.
+     * \param idx anchor index (0-based)
+     * \returns QgsAnchorWithHandles structure, or default if index is invalid
+     */
+    const QgsAnchorWithHandles &anchorWithHandles( int idx ) const;
+
+    /**
+     * Returns the interpolated points of the curve for visualization.
+     * Uses cubic Bézier interpolation between anchor points.
+     */
+    QgsPointSequence interpolate() const;
+
+    /**
+     * Converts the Poly-Bézier data to a QgsNurbsCurve.
+     * The resulting curve is a piecewise cubic Bézier represented as NURBS.
+     * \returns new QgsNurbsCurve. Returns nullptr if less than 2 anchors.
+     */
+    std::unique_ptr<QgsNurbsCurve> asNurbsCurve() const;
+
+    //! Clears all data
+    void clear();
+
+    //! Returns TRUE if there are no anchors
+    bool isEmpty() const { return mData.isEmpty(); }
+
+    /**
+     * Finds the closest anchor to the given point within tolerance.
+     * \param pt point to search from
+     * \param tolerance search tolerance
+     * \returns anchor index or -1 if not found
+     */
+    int findClosestAnchor( const QgsPoint &pt, double tolerance ) const;
+
+    /**
+     * Finds the closest handle to the given point within tolerance.
+     * \param pt point to search from
+     * \param tolerance search tolerance
+     * \returns handle index or -1 if not found
+     */
+    int findClosestHandle( const QgsPoint &pt, double tolerance ) const;
+
+    /**
+     * Finds the closest segment to the given point within tolerance.
+     * \param pt point to search from
+     * \param tolerance search tolerance
+     * \returns segment index or -1 if not found
+     */
+    int findClosestSegment( const QgsPoint &pt, double tolerance ) const;
+
+  private:
+    QVector<QgsAnchorWithHandles> mData;              //!< Anchor points with their handles (guarantees consistency)
+    static const QgsAnchorWithHandles sInvalidAnchor; //!< Invalid anchor for out-of-bounds access
+};
+
+///@endcond PRIVATE
+
+#endif // QGSBEZIERDATA_H

--- a/src/gui/maptools/qgsbezierdata.h
+++ b/src/gui/maptools/qgsbezierdata.h
@@ -49,8 +49,8 @@ struct GUI_EXPORT QgsAnchorWithHandles
     QgsAnchorWithHandles() = default;
 
     //! Constructor with anchor position, handles retracted at anchor
-    explicit QgsAnchorWithHandles( const QgsPoint &pt )
-      : anchor( pt ), leftHandle( pt ), rightHandle( pt ) {}
+    explicit QgsAnchorWithHandles( const QgsPoint &point )
+      : anchor( point ), leftHandle( point ), rightHandle( point ) {}
 
     //! Constructor with all points specified
     QgsAnchorWithHandles( const QgsPoint &a, const QgsPoint &left, const QgsPoint &right )
@@ -82,51 +82,51 @@ class GUI_EXPORT QgsBezierData
     /**
      * Adds an anchor point at the given position.
      * Both handles are initially placed at the anchor position.
-     * \param pt anchor point position
+     * \param point anchor point position
      */
-    void addAnchor( const QgsPoint &pt );
+    void addAnchor( const QgsPoint &point );
 
     /**
-     * Moves the anchor at index \a idx to the new position \a pt.
+     * Moves the anchor at index \a index to the new position \a pt.
      * Handles are moved relative to the anchor.
-     * \param idx anchor index (0-based)
-     * \param pt new position
+     * \param index anchor index (0-based)
+     * \param point new position
      */
-    void moveAnchor( int idx, const QgsPoint &pt );
+    void moveAnchor( int index, const QgsPoint &point );
 
     /**
-     * Moves the handle at index \a idx to the new position \a pt.
-     * \param idx handle index (0-based, 2 handles per anchor)
-     * \param pt new position
+     * Moves the handle at index \a index to the new position \a pt.
+     * \param index handle index (0-based, 2 handles per anchor)
+     * \param point new position
      */
-    void moveHandle( int idx, const QgsPoint &pt );
+    void moveHandle( int index, const QgsPoint &point );
 
     /**
      * Inserts a new anchor point at the given segment.
-     * \param segmentIdx segment index where to insert (0 = before first segment)
-     * \param pt anchor position
+     * \param segmentIndex segment index where to insert (0 = before first segment)
+     * \param point anchor position
      */
-    void insertAnchor( int segmentIdx, const QgsPoint &pt );
+    void insertAnchor( int segmentIndex, const QgsPoint &point );
 
     /**
-     * Deletes the anchor at index \a idx and its associated handles.
-     * \param idx anchor index to delete
+     * Deletes the anchor at index \a index and its associated handles.
+     * \param index anchor index to delete
      */
-    void deleteAnchor( int idx );
+    void deleteAnchor( int index );
 
     /**
-     * Retracts (collapses) the handle at index \a idx to its anchor position.
-     * \param idx handle index
+     * Retracts (collapses) the handle at index \a index to its anchor position.
+     * \param index handle index
      */
-    void retractHandle( int idx );
+    void retractHandle( int index );
 
     /**
-     * Extends (expands) the handle at index \a idx from its anchor.
+     * Extends (expands) the handle at index \a index from its anchor.
      * Used when a handle is initially at the anchor position.
-     * \param idx handle index
-     * \param pt new handle position
+     * \param index handle index
+     * \param point new handle position
      */
-    void extendHandle( int idx, const QgsPoint &pt );
+    void extendHandle( int index, const QgsPoint &point );
 
     //! Returns the number of anchor points
     int anchorCount() const { return mData.count(); }
@@ -134,11 +134,11 @@ class GUI_EXPORT QgsBezierData
     //! Returns the number of handles (always 2 * anchorCount)
     int handleCount() const { return mData.count() * 2; }
 
-    //! Returns the anchor at index \a idx
-    QgsPoint anchor( int idx ) const;
+    //! Returns the anchor at index \a index
+    QgsPoint anchor( int index ) const;
 
-    //! Returns the handle at index \a idx
-    QgsPoint handle( int idx ) const;
+    //! Returns the handle at index \a index
+    QgsPoint handle( int index ) const;
 
     //! Returns all anchors (extracted from mData)
     QVector<QgsPoint> anchors() const;
@@ -147,11 +147,11 @@ class GUI_EXPORT QgsBezierData
     QVector<QgsPoint> handles() const;
 
     /**
-     * Returns the anchor with its handles at index \a idx.
-     * \param idx anchor index (0-based)
+     * Returns the anchor with its handles at index \a index.
+     * \param index anchor index (0-based)
      * \returns QgsAnchorWithHandles structure, or default if index is invalid
      */
-    const QgsAnchorWithHandles &anchorWithHandles( int idx ) const;
+    const QgsAnchorWithHandles &anchorWithHandles( int index ) const;
 
     /**
      * Returns the interpolated points of the curve for visualization.
@@ -174,27 +174,27 @@ class GUI_EXPORT QgsBezierData
 
     /**
      * Finds the closest anchor to the given point within tolerance.
-     * \param pt point to search from
+     * \param point point to search from
      * \param tolerance search tolerance
      * \returns anchor index or -1 if not found
      */
-    int findClosestAnchor( const QgsPoint &pt, double tolerance ) const;
+    int findClosestAnchor( const QgsPoint &point, double tolerance ) const;
 
     /**
      * Finds the closest handle to the given point within tolerance.
-     * \param pt point to search from
+     * \param point point to search from
      * \param tolerance search tolerance
      * \returns handle index or -1 if not found
      */
-    int findClosestHandle( const QgsPoint &pt, double tolerance ) const;
+    int findClosestHandle( const QgsPoint &point, double tolerance ) const;
 
     /**
      * Finds the closest segment to the given point within tolerance.
-     * \param pt point to search from
+     * \param point point to search from
      * \param tolerance search tolerance
      * \returns segment index or -1 if not found
      */
-    int findClosestSegment( const QgsPoint &pt, double tolerance ) const;
+    int findClosestSegment( const QgsPoint &point, double tolerance ) const;
 
   private:
     QVector<QgsAnchorWithHandles> mData;              //!< Anchor points with their handles (guarantees consistency)

--- a/src/gui/maptools/qgsbeziermarker.cpp
+++ b/src/gui/maptools/qgsbeziermarker.cpp
@@ -1,0 +1,278 @@
+/***************************************************************************
+    qgsbeziermarker.cpp  -  Visualization for Poly-Bézier curve digitizing
+    ---------------------
+    begin                : December 2025
+    copyright            : (C) 2025 by Loïc Bartoletti
+    email                : loic dot bartoletti at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+///@cond PRIVATE
+
+#include "qgsbeziermarker.h"
+
+#include "qgsmapcanvas.h"
+#include "qgsrubberband.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingsregistrycore.h"
+#include "qgsvertexmarker.h"
+
+QgsBezierMarker::QgsBezierMarker( QgsMapCanvas *canvas, QObject *parent )
+  : QObject( parent )
+  , mCanvas( canvas )
+  , mCurveRubberBand( std::make_unique<QgsRubberBand>( canvas, Qgis::GeometryType::Line ) )
+{
+  mCurveRubberBand->setColor( QgsSettingsRegistryCore::settingsDigitizingLineColor->value() );
+  mCurveRubberBand->setWidth( QgsSettingsRegistryCore::settingsDigitizingLineWidth->value() );
+}
+
+QgsBezierMarker::~QgsBezierMarker() = default;
+
+std::unique_ptr<QgsVertexMarker> QgsBezierMarker::createAnchorMarker()
+{
+  auto marker = std::make_unique<QgsVertexMarker>( mCanvas );
+  marker->setIconType( QgsVertexMarker::ICON_BOX );
+  marker->setIconSize( 10 );
+  const QColor snapColor = QgsSettingsRegistryCore::settingsDigitizingSnapColor->value();
+  marker->setColor( snapColor );
+  QColor fillColor = snapColor;
+  fillColor.setAlpha( 100 );
+  marker->setFillColor( fillColor );
+  marker->setPenWidth( 2 );
+  return marker;
+}
+
+std::unique_ptr<QgsVertexMarker> QgsBezierMarker::createHandleMarker()
+{
+  auto marker = std::make_unique<QgsVertexMarker>( mCanvas );
+  marker->setIconType( QgsVertexMarker::ICON_CIRCLE );
+  marker->setIconSize( 8 );
+  QColor lineColor = QgsSettingsRegistryCore::settingsDigitizingLineColor->value();
+  int h, s, v, a;
+  lineColor.getHsv( &h, &s, &v, &a );
+  QColor handleColor = QColor::fromHsv( ( h + 120 ) % 360, s, v, a );
+  marker->setColor( handleColor );
+  QColor fillColor = handleColor;
+  fillColor.setAlpha( 100 );
+  marker->setFillColor( fillColor );
+  marker->setPenWidth( 2 );
+  return marker;
+}
+
+std::unique_ptr<QgsRubberBand> QgsBezierMarker::createHandleLine()
+{
+  auto rb = std::make_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Line );
+  QColor lineColor = QgsSettingsRegistryCore::settingsDigitizingLineColor->value();
+  lineColor.setAlpha( 150 );
+  rb->setColor( lineColor );
+  rb->setWidth( 1 );
+  rb->setLineStyle( Qt::DashLine );
+  return rb;
+}
+
+void QgsBezierMarker::updateFromData( const QgsBezierData &data )
+{
+  updateAnchorMarkers( data );
+  updateHandleMarkers( data );
+  updateHandleLines( data );
+  updateCurve( data );
+}
+
+void QgsBezierMarker::updateCurve( const QgsBezierData &data )
+{
+  mCurveRubberBand->reset( Qgis::GeometryType::Line );
+
+  if ( data.anchorCount() < 1 )
+    return;
+
+  QgsPointSequence points = data.interpolate();
+
+  for ( const QgsPoint &pt : std::as_const( points ) )
+  {
+    mCurveRubberBand->addPoint( QgsPointXY( pt ) );
+  }
+
+  mCurveRubberBand->setVisible( mVisible );
+}
+
+void QgsBezierMarker::updateAnchorMarkers( const QgsBezierData &data )
+{
+  while ( static_cast<int>( mAnchorMarkers.size() ) < data.anchorCount() )
+  {
+    mAnchorMarkers.push_back( createAnchorMarker() );
+  }
+  while ( static_cast<int>( mAnchorMarkers.size() ) > data.anchorCount() )
+  {
+    mAnchorMarkers.pop_back();
+  }
+
+  const QColor snapColor = QgsSettingsRegistryCore::settingsDigitizingSnapColor->value();
+  QColor snapFillColor = snapColor;
+  snapFillColor.setAlpha( 100 );
+
+  for ( int i = 0; i < data.anchorCount(); ++i )
+  {
+    const QgsPoint &anchor = data.anchor( i );
+    mAnchorMarkers[i]->setCenter( QgsPointXY( anchor ) );
+    mAnchorMarkers[i]->setVisible( mVisible );
+
+    if ( i == mHighlightedAnchor )
+    {
+      const QColor selColor = mCanvas->selectionColor();
+      mAnchorMarkers[i]->setColor( selColor );
+      QColor selFillColor = selColor;
+      selFillColor.setAlpha( 150 );
+      mAnchorMarkers[i]->setFillColor( selFillColor );
+    }
+    else
+    {
+      mAnchorMarkers[i]->setColor( snapColor );
+      mAnchorMarkers[i]->setFillColor( snapFillColor );
+    }
+  }
+}
+
+void QgsBezierMarker::updateHandleMarkers( const QgsBezierData &data )
+{
+  while ( static_cast<int>( mHandleMarkers.size() ) < data.handleCount() )
+  {
+    mHandleMarkers.push_back( createHandleMarker() );
+  }
+  while ( static_cast<int>( mHandleMarkers.size() ) > data.handleCount() )
+  {
+    mHandleMarkers.pop_back();
+  }
+
+  QColor lineColor = QgsSettingsRegistryCore::settingsDigitizingLineColor->value();
+  int h, s, v, a;
+  lineColor.getHsv( &h, &s, &v, &a );
+  QColor handleColor = QColor::fromHsv( ( h + 120 ) % 360, s, v, a );
+  QColor handleFillColor = handleColor;
+  handleFillColor.setAlpha( 100 );
+
+  for ( int i = 0; i < data.handleCount(); ++i )
+  {
+    const QgsPoint &handle = data.handle( i );
+    const int anchorIdx = i / 2;
+    if ( anchorIdx >= data.anchorCount() )
+    {
+      mHandleMarkers[i]->setVisible( false );
+      continue;
+    }
+    const QgsPoint &anchor = data.anchor( anchorIdx );
+
+    const bool isRetracted = qgsDoubleNear( handle.x(), anchor.x() ) && qgsDoubleNear( handle.y(), anchor.y() );
+
+    mHandleMarkers[i]->setCenter( QgsPointXY( handle ) );
+    mHandleMarkers[i]->setVisible( mVisible && mHandlesVisible && !isRetracted );
+
+    if ( i == mHighlightedHandle )
+    {
+      const QColor selColor = mCanvas->selectionColor();
+      mHandleMarkers[i]->setColor( selColor );
+      QColor selFillColor = selColor;
+      selFillColor.setAlpha( 150 );
+      mHandleMarkers[i]->setFillColor( selFillColor );
+    }
+    else
+    {
+      mHandleMarkers[i]->setColor( handleColor );
+      mHandleMarkers[i]->setFillColor( handleFillColor );
+    }
+  }
+}
+
+void QgsBezierMarker::updateHandleLines( const QgsBezierData &data )
+{
+  while ( static_cast<int>( mHandleLines.size() ) < data.handleCount() )
+  {
+    mHandleLines.push_back( createHandleLine() );
+  }
+  while ( static_cast<int>( mHandleLines.size() ) > data.handleCount() )
+  {
+    mHandleLines.pop_back();
+  }
+
+  for ( int i = 0; i < data.handleCount(); ++i )
+  {
+    mHandleLines[i]->reset( Qgis::GeometryType::Line );
+
+    const QgsPoint &handle = data.handle( i );
+    const int anchorIdx = i / 2;
+    if ( anchorIdx >= data.anchorCount() )
+    {
+      mHandleLines[i]->setVisible( false );
+      continue;
+    }
+    const QgsPoint &anchor = data.anchor( anchorIdx );
+
+    const bool isRetracted = qgsDoubleNear( handle.x(), anchor.x() ) && qgsDoubleNear( handle.y(), anchor.y() );
+
+    if ( !isRetracted && mVisible && mHandlesVisible )
+    {
+      mHandleLines[i]->addPoint( QgsPointXY( anchor ) );
+      mHandleLines[i]->addPoint( QgsPointXY( handle ) );
+      mHandleLines[i]->setVisible( true );
+    }
+  }
+}
+
+void QgsBezierMarker::setVisible( bool visible )
+{
+  mVisible = visible;
+
+  for ( const auto &marker : mAnchorMarkers )
+    marker->setVisible( visible );
+
+  for ( const auto &marker : mHandleMarkers )
+    marker->setVisible( visible && mHandlesVisible );
+
+  for ( const auto &rb : mHandleLines )
+    rb->setVisible( visible && mHandlesVisible );
+
+  mCurveRubberBand->setVisible( visible );
+}
+
+void QgsBezierMarker::setHandlesVisible( bool visible )
+{
+  mHandlesVisible = visible;
+
+  for ( const auto &marker : mHandleMarkers )
+    marker->setVisible( mVisible && visible );
+
+  for ( const auto &rb : mHandleLines )
+    rb->setVisible( mVisible && visible );
+}
+
+void QgsBezierMarker::clear()
+{
+  mAnchorMarkers.clear();
+  mHandleMarkers.clear();
+  mHandleLines.clear();
+
+  if ( mCurveRubberBand )
+    mCurveRubberBand->reset( Qgis::GeometryType::Line );
+
+  mHighlightedAnchor = -1;
+  mHighlightedHandle = -1;
+}
+
+void QgsBezierMarker::setHighlightedAnchor( int idx )
+{
+  mHighlightedAnchor = idx;
+}
+
+void QgsBezierMarker::setHighlightedHandle( int idx )
+{
+  mHighlightedHandle = idx;
+}
+
+///@endcond PRIVATE
+
+#include "moc_qgsbeziermarker.cpp"

--- a/src/gui/maptools/qgsbeziermarker.cpp
+++ b/src/gui/maptools/qgsbeziermarker.cpp
@@ -210,6 +210,13 @@ void QgsBezierMarker::updateHandleLines( const QgsBezierData &data )
   {
     mHandleLines[i]->reset( Qgis::GeometryType::Line );
 
+    // Reapply style properties after reset
+    QColor lineColor = QgsSettingsRegistryCore::settingsDigitizingLineColor->value();
+    lineColor.setAlpha( MarkerConfig::HandleLineAlpha );
+    mHandleLines[i]->setColor( lineColor );
+    mHandleLines[i]->setWidth( MarkerConfig::HandleLineWidth );
+    mHandleLines[i]->setLineStyle( Qt::DashLine );
+
     const QgsPoint &handle = data.handle( i );
     const int anchorIndex = i / 2;
     if ( anchorIndex >= data.anchorCount() )
@@ -221,11 +228,10 @@ void QgsBezierMarker::updateHandleLines( const QgsBezierData &data )
 
     const bool isRetracted = qgsDoubleNear( handle.x(), anchor.x() ) && qgsDoubleNear( handle.y(), anchor.y() );
 
-    if ( !isRetracted && mVisible && mHandlesVisible )
+    if ( !isRetracted )
     {
       mHandleLines[i]->addPoint( QgsPointXY( anchor ) );
       mHandleLines[i]->addPoint( QgsPointXY( handle ) );
-      mHandleLines[i]->setVisible( true );
     }
   }
 }
@@ -241,7 +247,12 @@ void QgsBezierMarker::setVisible( bool visible )
     marker->setVisible( visible && mHandlesVisible );
 
   for ( const auto &rb : mHandleLines )
-    rb->setVisible( visible && mHandlesVisible );
+  {
+    if ( rb->numberOfVertices() > 0 )
+      rb->setVisible( visible && mHandlesVisible );
+    else
+      rb->setVisible( false );
+  }
 
   mCurveRubberBand->setVisible( visible );
 }
@@ -254,7 +265,12 @@ void QgsBezierMarker::setHandlesVisible( bool visible )
     marker->setVisible( mVisible && visible );
 
   for ( const auto &rb : mHandleLines )
-    rb->setVisible( mVisible && visible );
+  {
+    if ( rb->numberOfVertices() > 0 )
+      rb->setVisible( mVisible && visible );
+    else
+      rb->setVisible( false );
+  }
 }
 
 void QgsBezierMarker::clear()

--- a/src/gui/maptools/qgsbeziermarker.cpp
+++ b/src/gui/maptools/qgsbeziermarker.cpp
@@ -3,6 +3,7 @@
     ---------------------
     begin                : December 2025
     copyright            : (C) 2025 by Loïc Bartoletti
+                           Adapted from BezierEditing plugin work by Takayuki Mizutani
     email                : loic dot bartoletti at oslandia dot com
  ***************************************************************************
  *                                                                         *

--- a/src/gui/maptools/qgsbeziermarker.cpp
+++ b/src/gui/maptools/qgsbeziermarker.cpp
@@ -166,13 +166,13 @@ void QgsBezierMarker::updateHandleMarkers( const QgsBezierData &data )
   for ( int i = 0; i < data.handleCount(); ++i )
   {
     const QgsPoint &handle = data.handle( i );
-    const int anchorIdx = i / 2;
-    if ( anchorIdx >= data.anchorCount() )
+    const int anchorIndex = i / 2;
+    if ( anchorIndex >= data.anchorCount() )
     {
       mHandleMarkers[i]->setVisible( false );
       continue;
     }
-    const QgsPoint &anchor = data.anchor( anchorIdx );
+    const QgsPoint &anchor = data.anchor( anchorIndex );
 
     const bool isRetracted = qgsDoubleNear( handle.x(), anchor.x() ) && qgsDoubleNear( handle.y(), anchor.y() );
 
@@ -211,13 +211,13 @@ void QgsBezierMarker::updateHandleLines( const QgsBezierData &data )
     mHandleLines[i]->reset( Qgis::GeometryType::Line );
 
     const QgsPoint &handle = data.handle( i );
-    const int anchorIdx = i / 2;
-    if ( anchorIdx >= data.anchorCount() )
+    const int anchorIndex = i / 2;
+    if ( anchorIndex >= data.anchorCount() )
     {
       mHandleLines[i]->setVisible( false );
       continue;
     }
-    const QgsPoint &anchor = data.anchor( anchorIdx );
+    const QgsPoint &anchor = data.anchor( anchorIndex );
 
     const bool isRetracted = qgsDoubleNear( handle.x(), anchor.x() ) && qgsDoubleNear( handle.y(), anchor.y() );
 

--- a/src/gui/maptools/qgsbeziermarker.cpp
+++ b/src/gui/maptools/qgsbeziermarker.cpp
@@ -39,13 +39,13 @@ std::unique_ptr<QgsVertexMarker> QgsBezierMarker::createAnchorMarker()
 {
   auto marker = std::make_unique<QgsVertexMarker>( mCanvas );
   marker->setIconType( QgsVertexMarker::ICON_BOX );
-  marker->setIconSize( 10 );
+  marker->setIconSize( MarkerConfig::AnchorMarkerSize );
   const QColor snapColor = QgsSettingsRegistryCore::settingsDigitizingSnapColor->value();
   marker->setColor( snapColor );
   QColor fillColor = snapColor;
-  fillColor.setAlpha( 100 );
+  fillColor.setAlpha( MarkerConfig::FillAlpha );
   marker->setFillColor( fillColor );
-  marker->setPenWidth( 2 );
+  marker->setPenWidth( MarkerConfig::MarkerPenWidth );
   return marker;
 }
 
@@ -53,16 +53,16 @@ std::unique_ptr<QgsVertexMarker> QgsBezierMarker::createHandleMarker()
 {
   auto marker = std::make_unique<QgsVertexMarker>( mCanvas );
   marker->setIconType( QgsVertexMarker::ICON_CIRCLE );
-  marker->setIconSize( 8 );
+  marker->setIconSize( MarkerConfig::HandleMarkerSize );
   QColor lineColor = QgsSettingsRegistryCore::settingsDigitizingLineColor->value();
   int h, s, v, a;
   lineColor.getHsv( &h, &s, &v, &a );
   QColor handleColor = QColor::fromHsv( ( h + 120 ) % 360, s, v, a );
   marker->setColor( handleColor );
   QColor fillColor = handleColor;
-  fillColor.setAlpha( 100 );
+  fillColor.setAlpha( MarkerConfig::FillAlpha );
   marker->setFillColor( fillColor );
-  marker->setPenWidth( 2 );
+  marker->setPenWidth( MarkerConfig::MarkerPenWidth );
   return marker;
 }
 
@@ -70,9 +70,9 @@ std::unique_ptr<QgsRubberBand> QgsBezierMarker::createHandleLine()
 {
   auto rb = std::make_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Line );
   QColor lineColor = QgsSettingsRegistryCore::settingsDigitizingLineColor->value();
-  lineColor.setAlpha( 150 );
+  lineColor.setAlpha( MarkerConfig::HandleLineAlpha );
   rb->setColor( lineColor );
-  rb->setWidth( 1 );
+  rb->setWidth( MarkerConfig::HandleLineWidth );
   rb->setLineStyle( Qt::DashLine );
   return rb;
 }
@@ -128,7 +128,7 @@ void QgsBezierMarker::updateAnchorMarkers( const QgsBezierData &data )
       const QColor selColor = mCanvas->selectionColor();
       mAnchorMarkers[i]->setColor( selColor );
       QColor selFillColor = selColor;
-      selFillColor.setAlpha( 150 );
+      selFillColor.setAlpha( MarkerConfig::SelectionAlpha );
       mAnchorMarkers[i]->setFillColor( selFillColor );
     }
     else
@@ -178,7 +178,7 @@ void QgsBezierMarker::updateHandleMarkers( const QgsBezierData &data )
       const QColor selColor = mCanvas->selectionColor();
       mHandleMarkers[i]->setColor( selColor );
       QColor selFillColor = selColor;
-      selFillColor.setAlpha( 150 );
+      selFillColor.setAlpha( MarkerConfig::SelectionAlpha );
       mHandleMarkers[i]->setFillColor( selFillColor );
     }
     else

--- a/src/gui/maptools/qgsbeziermarker.cpp
+++ b/src/gui/maptools/qgsbeziermarker.cpp
@@ -96,7 +96,7 @@ void QgsBezierMarker::updateCurve( const QgsBezierData &data )
   if ( data.anchorCount() < 1 )
     return;
 
-  QgsPointSequence points = data.interpolate();
+  QgsPointSequence points = data.interpolateLine();
 
   for ( const QgsPoint &pt : std::as_const( points ) )
   {

--- a/src/gui/maptools/qgsbeziermarker.h
+++ b/src/gui/maptools/qgsbeziermarker.h
@@ -47,6 +47,20 @@ class GUI_EXPORT QgsBezierMarker : public QObject
 
   public:
     /**
+     * Configuration constants for marker appearance.
+     */
+    struct MarkerConfig
+    {
+        static constexpr int AnchorMarkerSize = 10;
+        static constexpr int HandleMarkerSize = 8;
+        static constexpr int MarkerPenWidth = 2;
+        static constexpr int HandleLineWidth = 1;
+        static constexpr int FillAlpha = 100;
+        static constexpr int HandleLineAlpha = 150;
+        static constexpr int SelectionAlpha = 150;
+    };
+
+    /**
      * Constructor.
      * \param canvas the map canvas for rendering
      * \param parent parent object

--- a/src/gui/maptools/qgsbeziermarker.h
+++ b/src/gui/maptools/qgsbeziermarker.h
@@ -22,6 +22,7 @@
 
 #include "qgis_gui.h"
 #include "qgsbezierdata.h"
+#include "qobjectuniqueptr.h"
 
 #include <QObject>
 
@@ -112,10 +113,10 @@ class GUI_EXPORT QgsBezierMarker : public QObject
   private:
     QgsMapCanvas *mCanvas = nullptr;
 
-    std::vector<std::unique_ptr<QgsVertexMarker>> mAnchorMarkers;
-    std::vector<std::unique_ptr<QgsVertexMarker>> mHandleMarkers;
-    std::vector<std::unique_ptr<QgsRubberBand>> mHandleLines;
-    std::unique_ptr<QgsRubberBand> mCurveRubberBand;
+    std::vector<QgsVertexMarker *> mAnchorMarkers;
+    std::vector<QgsVertexMarker *> mHandleMarkers;
+    std::vector<QObjectUniquePtr<QgsRubberBand>> mHandleLines;
+    QObjectUniquePtr<QgsRubberBand> mCurveRubberBand;
 
     int mHighlightedAnchor = -1;
     int mHighlightedHandle = -1;
@@ -124,13 +125,13 @@ class GUI_EXPORT QgsBezierMarker : public QObject
     bool mHandlesVisible = true;
 
     //! Creates a new anchor marker
-    std::unique_ptr<QgsVertexMarker> createAnchorMarker();
+    QgsVertexMarker *createAnchorMarker();
 
     //! Creates a new handle marker
-    std::unique_ptr<QgsVertexMarker> createHandleMarker();
+    QgsVertexMarker *createHandleMarker();
 
     //! Creates a new handle line rubber band
-    std::unique_ptr<QgsRubberBand> createHandleLine();
+    QObjectUniquePtr<QgsRubberBand> createHandleLine();
 
     //! Updates anchor markers
     void updateAnchorMarkers( const QgsBezierData &data );

--- a/src/gui/maptools/qgsbeziermarker.h
+++ b/src/gui/maptools/qgsbeziermarker.h
@@ -3,6 +3,7 @@
     ---------------------
     begin                : December 2025
     copyright            : (C) 2025 by Loïc Bartoletti
+                           Adapted from BezierEditing plugin work by Takayuki Mizutani
     email                : loic dot bartoletti at oslandia dot com
  ***************************************************************************
  *                                                                         *

--- a/src/gui/maptools/qgsbeziermarker.h
+++ b/src/gui/maptools/qgsbeziermarker.h
@@ -1,0 +1,132 @@
+/***************************************************************************
+    qgsbeziermarker.h  -  Visualization for Poly-Bézier curve digitizing
+    ---------------------
+    begin                : December 2025
+    copyright            : (C) 2025 by Loïc Bartoletti
+    email                : loic dot bartoletti at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSBEZIERMARKER_H
+#define QGSBEZIERMARKER_H
+
+#include <memory>
+#include <vector>
+
+#include "qgis_gui.h"
+#include "qgsbezierdata.h"
+
+#include <QObject>
+
+class QgsMapCanvas;
+class QgsRubberBand;
+class QgsVertexMarker;
+
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+
+/**
+ * \brief Visualization class for Poly-Bézier curve during digitizing.
+ *
+ * This class manages the visual representation of anchors, handles,
+ * handle lines, and the curve itself on the map canvas.
+ *
+ * \since QGIS 4.0
+ */
+class GUI_EXPORT QgsBezierMarker : public QObject
+{
+    Q_OBJECT
+
+  public:
+    /**
+     * Constructor.
+     * \param canvas the map canvas for rendering
+     * \param parent parent object
+     */
+    explicit QgsBezierMarker( QgsMapCanvas *canvas, QObject *parent = nullptr );
+
+    //! Destructor
+    ~QgsBezierMarker() override;
+
+    /**
+     * Updates the visualization from the given Bézier data.
+     * \param data the Bézier curve data
+     */
+    void updateFromData( const QgsBezierData &data );
+
+    /**
+     * Updates the curve visualization only (optimization for mouse move).
+     * \param data the Bézier curve data
+     */
+    void updateCurve( const QgsBezierData &data );
+
+    /**
+     * Sets visibility of all markers.
+     * \param visible whether markers should be visible
+     */
+    void setVisible( bool visible );
+
+    /**
+     * Sets visibility of handles.
+     * \param visible whether handles should be visible
+     */
+    void setHandlesVisible( bool visible );
+
+    //! Clears all markers
+    void clear();
+
+    /**
+     * Highlights an anchor.
+     * \param idx anchor index (-1 for none)
+     */
+    void setHighlightedAnchor( int idx );
+
+    /**
+     * Highlights a handle.
+     * \param idx handle index (-1 for none)
+     */
+    void setHighlightedHandle( int idx );
+
+  private:
+    QgsMapCanvas *mCanvas = nullptr;
+
+    std::vector<std::unique_ptr<QgsVertexMarker>> mAnchorMarkers;
+    std::vector<std::unique_ptr<QgsVertexMarker>> mHandleMarkers;
+    std::vector<std::unique_ptr<QgsRubberBand>> mHandleLines;
+    std::unique_ptr<QgsRubberBand> mCurveRubberBand;
+
+    int mHighlightedAnchor = -1;
+    int mHighlightedHandle = -1;
+
+    bool mVisible = true;
+    bool mHandlesVisible = true;
+
+    //! Creates a new anchor marker
+    std::unique_ptr<QgsVertexMarker> createAnchorMarker();
+
+    //! Creates a new handle marker
+    std::unique_ptr<QgsVertexMarker> createHandleMarker();
+
+    //! Creates a new handle line rubber band
+    std::unique_ptr<QgsRubberBand> createHandleLine();
+
+    //! Updates anchor markers
+    void updateAnchorMarkers( const QgsBezierData &data );
+
+    //! Updates handle markers
+    void updateHandleMarkers( const QgsBezierData &data );
+
+    //! Updates handle lines
+    void updateHandleLines( const QgsBezierData &data );
+};
+
+///@endcond PRIVATE
+
+#endif // QGSBEZIERMARKER_H

--- a/src/gui/maptools/qgsbeziermarker.h
+++ b/src/gui/maptools/qgsbeziermarker.h
@@ -68,7 +68,6 @@ class GUI_EXPORT QgsBezierMarker : public QObject
      */
     explicit QgsBezierMarker( QgsMapCanvas *canvas, QObject *parent = nullptr );
 
-    //! Destructor
     ~QgsBezierMarker() override;
 
     /**

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -561,8 +561,7 @@ void QgsMapToolCapture::cadCanvasPressEvent( QgsMapMouseEvent *e )
       if ( !mBezierMarker )
         mBezierMarker = std::make_unique<QgsBezierMarker>( mCanvas );
 
-      // Calculate tolerance in map units (10 pixels)
-      const double tolerance = mCanvas->mapUnitsPerPixel() * 10;
+      const double tolerance = searchRadiusMU( mCanvas );
 
       // Reset drag indices
       mBezierDragAnchorIndex = -1;

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -654,6 +654,28 @@ void QgsMapToolCapture::cadCanvasMoveEvent( QgsMapMouseEvent *e )
     // Poly-Bézier mode handling
     const QgsPoint mapPoint = QgsPoint( point );
 
+    // Check if we are hovering over a handle or anchor to change cursor
+    if ( mBezierData )
+    {
+      const double tolerance = searchRadiusMU( mCanvas );
+
+      // Check if mouse is near any handle
+      const int handleIdx = mBezierData->findClosestHandle( mapPoint, tolerance );
+      // Check if mouse is near any anchor
+      const int anchorIdx = mBezierData->findClosestAnchor( mapPoint, tolerance );
+
+      if ( handleIdx >= 0 || anchorIdx >= 0 )
+      {
+        // Change cursor to hand pointer when hovering over a handle or anchor
+        setCursor( Qt::PointingHandCursor );
+      }
+      else
+      {
+        // Reset cursor to the default CapturePoint
+        setCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::CapturePoint ) );
+      }
+    }
+
     if ( mBezierDragging && mBezierData )
     {
       if ( mBezierDragHandleIndex >= 0 )

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -1853,7 +1853,7 @@ void QgsMapToolCapture::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           std::unique_ptr<QgsNurbsCurve> nurbsCurve = mBezierData->asNurbsCurve();
           if ( nurbsCurve )
           {
-            // Transform to layer coordinates
+            // Transform to layer coordinates if a layer is present
             QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer() );
             if ( vlayer )
             {
@@ -1871,45 +1871,45 @@ void QgsMapToolCapture::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
                   return;
                 }
               }
-
-              std::unique_ptr<QgsCurve> curveToAdd;
-
-              // Close for polygon if needed
-              if ( mode() == CapturePolygon && !nurbsCurve->isClosed() )
-              {
-                // For polygon, wrap in compound curve and add closing segment
-                auto compound = std::make_unique<QgsCompoundCurve>();
-                compound->addCurve( nurbsCurve.release() );
-                // Add closing line segment from end to start
-                auto closingSegment = std::make_unique<QgsLineString>();
-                closingSegment->addVertex( compound->endPoint() );
-                closingSegment->addVertex( compound->startPoint() );
-                compound->addCurve( closingSegment.release() );
-                curveToAdd = std::move( compound );
-              }
-              else
-              {
-                curveToAdd.reset( nurbsCurve.release() );
-              }
-              QgsGeometry g;
-
-              if ( mode() == CaptureLine )
-              {
-                g = QgsGeometry( curveToAdd->clone() );
-                geometryCaptured( g );
-                lineCaptured( curveToAdd.release() );
-              }
-              else // CapturePolygon
-              {
-                auto poly = std::make_unique<QgsCurvePolygon>();
-                poly->setExteriorRing( curveToAdd.release() );
-                g = QgsGeometry( poly->clone() );
-                geometryCaptured( g );
-                polygonCaptured( poly.get() );
-              }
-
-              digitizingFinished = true;
             }
+
+            std::unique_ptr<QgsCurve> curveToAdd;
+
+            // Close for polygon if needed
+            if ( mode() == CapturePolygon && !nurbsCurve->isClosed() )
+            {
+              // For polygon, wrap in compound curve and add closing segment
+              auto compound = std::make_unique<QgsCompoundCurve>();
+              compound->addCurve( nurbsCurve.release() );
+              // Add closing line segment from end to start
+              auto closingSegment = std::make_unique<QgsLineString>();
+              closingSegment->addVertex( compound->endPoint() );
+              closingSegment->addVertex( compound->startPoint() );
+              compound->addCurve( closingSegment.release() );
+              curveToAdd = std::move( compound );
+            }
+            else
+            {
+              curveToAdd.reset( nurbsCurve.release() );
+            }
+            QgsGeometry g;
+
+            if ( mode() == CaptureLine )
+            {
+              g = QgsGeometry( curveToAdd->clone() );
+              geometryCaptured( g );
+              lineCaptured( curveToAdd.release() );
+            }
+            else // CapturePolygon
+            {
+              auto poly = std::make_unique<QgsCurvePolygon>();
+              poly->setExteriorRing( curveToAdd.release() );
+              g = QgsGeometry( poly->clone() );
+              geometryCaptured( g );
+              polygonCaptured( poly.get() );
+            }
+
+            digitizingFinished = true;
           }
         }
 

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -512,13 +512,6 @@ void QgsMapToolCapture::setCurrentCaptureTechnique( Qgis::CaptureTechnique techn
 
   mCurrentCaptureTechnique = technique;
 
-  // Emit help message for Poly-Bézier mode
-  if ( technique == Qgis::CaptureTechnique::NurbsCurve
-       && QgsSettingsRegistryCore::settingsDigitizingNurbsMode->value() == Qgis::NurbsMode::PolyBezier )
-  {
-    emit messageEmitted( tr( "Bézier editing: click and drag to add anchor with symmetric handles, click on handle/anchor to edit, Alt+click on anchor to extend handles, right-click to finish" ), Qgis::MessageLevel::Info );
-  }
-
   if ( technique == Qgis::CaptureTechnique::Shape && mCurrentShapeMapTool && isActive() )
   {
     clean();
@@ -584,7 +577,6 @@ void QgsMapToolCapture::cadCanvasPressEvent( QgsMapMouseEvent *e )
         mBezierDragHandleIndex = handleIdx;
         mBezierDragging = true;
         mBezierMarker->setHighlightedHandle( handleIdx );
-        emit messageEmitted( tr( "Bézier editing: drag to move handle, release to confirm" ), Qgis::MessageLevel::Info );
         return;
       }
 
@@ -598,7 +590,6 @@ void QgsMapToolCapture::cadCanvasPressEvent( QgsMapMouseEvent *e )
           mBezierDragAnchorIndex = anchorIdx;
           mBezierDragging = true;
           mBezierMarker->setHighlightedAnchor( anchorIdx );
-          emit messageEmitted( tr( "Bézier editing: drag to extend handles symmetrically, release to confirm" ), Qgis::MessageLevel::Info );
         }
         else
         {
@@ -606,7 +597,6 @@ void QgsMapToolCapture::cadCanvasPressEvent( QgsMapMouseEvent *e )
           mBezierMoveAnchorIndex = anchorIdx;
           mBezierDragging = true;
           mBezierMarker->setHighlightedAnchor( anchorIdx );
-          emit messageEmitted( tr( "Bézier editing: drag to move anchor, release to confirm" ), Qgis::MessageLevel::Info );
         }
         return;
       }
@@ -615,7 +605,6 @@ void QgsMapToolCapture::cadCanvasPressEvent( QgsMapMouseEvent *e )
       mBezierData->addAnchor( mapPoint );
       mBezierDragAnchorIndex = mBezierData->anchorCount() - 1;
       mBezierDragging = true;
-      emit messageEmitted( tr( "Bézier editing: drag to define handles, release to confirm anchor" ), Qgis::MessageLevel::Info );
 
       // Update visualization
       mBezierMarker->updateFromData( *mBezierData );
@@ -1835,8 +1824,6 @@ void QgsMapToolCapture::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           mBezierMarker->updateFromData( *mBezierData );
         }
 
-        // Emit help message reminder
-        emit messageEmitted( tr( "Bézier editing: click and drag to add anchor, click on handle/anchor to edit, Alt+click to extend handles, right-click to finish" ), Qgis::MessageLevel::Info );
         return;
       }
       else if ( e->button() == Qt::RightButton )

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -121,6 +121,7 @@ bool QgsMapToolCapture::supportsTechnique( Qgis::CaptureTechnique technique ) co
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Streaming:
     case Qgis::CaptureTechnique::Shape:
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       return false;
   }
@@ -502,6 +503,7 @@ void QgsMapToolCapture::setCurrentCaptureTechnique( Qgis::CaptureTechnique techn
     case Qgis::CaptureTechnique::Shape:
       mLineDigitizingType = Qgis::WkbType::LineString;
       break;
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       mLineDigitizingType = Qgis::WkbType::NurbsCurve;
       break;
@@ -547,8 +549,7 @@ void QgsMapToolCapture::setCurrentShapeMapTool( const QgsMapToolShapeMetadata *s
 void QgsMapToolCapture::cadCanvasPressEvent( QgsMapMouseEvent *e )
 {
   // Poly-Bézier mode: handle press to add anchor and start drag
-  if ( mCurrentCaptureTechnique == Qgis::CaptureTechnique::NurbsCurve
-       && QgsSettingsRegistryCore::settingsDigitizingNurbsMode->value() == Qgis::NurbsMode::PolyBezier
+  if ( mCurrentCaptureTechnique == Qgis::CaptureTechnique::PolyBezier
        && ( mode() == CaptureLine || mode() == CapturePolygon ) )
   {
     if ( e->button() == Qt::LeftButton )
@@ -648,8 +649,7 @@ void QgsMapToolCapture::cadCanvasMoveEvent( QgsMapMouseEvent *e )
       return;
     }
   }
-  else if ( mCurrentCaptureTechnique == Qgis::CaptureTechnique::NurbsCurve
-            && QgsSettingsRegistryCore::settingsDigitizingNurbsMode->value() == Qgis::NurbsMode::PolyBezier )
+  else if ( mCurrentCaptureTechnique == Qgis::CaptureTechnique::PolyBezier )
   {
     // Poly-Bézier mode handling
     const QgsPoint mapPoint = QgsPoint( point );
@@ -1164,8 +1164,7 @@ void QgsMapToolCapture::undo( bool isAutoRepeat )
   // Handle Poly-Bézier mode: delete the last anchor with its handles
   // This must be checked before the standard size() check since Poly-Bézier
   // doesn't use mCaptureCurve during capture
-  if ( mCurrentCaptureTechnique == Qgis::CaptureTechnique::NurbsCurve
-       && QgsSettingsRegistryCore::settingsDigitizingNurbsMode->value() == Qgis::NurbsMode::PolyBezier
+  if ( mCurrentCaptureTechnique == Qgis::CaptureTechnique::PolyBezier
        && mBezierData && mBezierData->anchorCount() > 0 )
   {
     mBezierData->deleteAnchor( mBezierData->anchorCount() - 1 );
@@ -1826,8 +1825,7 @@ void QgsMapToolCapture::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     QVector<double> nurbsWeights;
 
     // Poly-Bézier mode handling
-    if ( mCurrentCaptureTechnique == Qgis::CaptureTechnique::NurbsCurve
-         && QgsSettingsRegistryCore::settingsDigitizingNurbsMode->value() == Qgis::NurbsMode::PolyBezier )
+    if ( mCurrentCaptureTechnique == Qgis::CaptureTechnique::PolyBezier )
     {
       if ( e->button() == Qt::LeftButton )
       {

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -699,7 +699,7 @@ void QgsMapToolCapture::cadCanvasMoveEvent( QgsMapMouseEvent *e )
 
       mBezierMarker->updateCurve( previewData );
 
-      QgsPointSequence points = previewData.interpolate();
+      QgsPointSequence points = previewData.interpolateLine();
 
       if ( !mTempRubberBand )
       {
@@ -1713,7 +1713,7 @@ void QgsMapToolCapture::updateExtraSnapLayer()
       }
 
       // Add interpolated curve points for snapping to the curve itself
-      const QgsPointSequence interpolated = mBezierData->interpolate();
+      const QgsPointSequence interpolated = mBezierData->interpolateLine();
       for ( const QgsPoint &pt : interpolated )
       {
         lineForSnap->addVertex( pt );

--- a/src/gui/maptools/qgsmaptoolcapture.h
+++ b/src/gui/maptools/qgsmaptoolcapture.h
@@ -17,6 +17,8 @@
 #define QGSMAPTOOLCAPTURE_H
 
 
+#include <memory>
+
 #include "qgis_gui.h"
 #include "qgscompoundcurve.h"
 #include "qgsgeometry.h"
@@ -38,6 +40,8 @@ class QgsMapToolCaptureRubberBand;
 class QgsCurvePolygon;
 class QgsMapToolShapeAbstract;
 class QgsMapToolShapeMetadata;
+class QgsBezierData;
+class QgsBezierMarker;
 
 
 /**
@@ -140,6 +144,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      */
     QList<QgsPointLocator::Match> snappingMatches() const;
 
+    void cadCanvasPressEvent( QgsMapMouseEvent *e ) override;
     void cadCanvasMoveEvent( QgsMapMouseEvent *e ) override;
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
 
@@ -465,6 +470,19 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     bool mStartNewCurve = false;
 
     bool mIgnoreSubsequentAutoRepeatUndo = false;
+
+    //! Data structure for Poly-Bézier curve digitizing (anchors and handles)
+    std::unique_ptr<QgsBezierData> mBezierData;
+    //! Visualization for Poly-Bézier curve digitizing
+    std::unique_ptr<QgsBezierMarker> mBezierMarker;
+    //! TRUE if user is currently dragging
+    bool mBezierDragging = false;
+    //! Index of the anchor being dragged for new anchor handle definition (-1 if not)
+    int mBezierDragAnchorIndex = -1;
+    //! Index of the handle being dragged independently (-1 if not)
+    int mBezierDragHandleIndex = -1;
+    //! Index of the anchor being moved (-1 if not)
+    int mBezierMoveAnchorIndex = -1;
 
     //! Flag for NURBS weight editing mode (activated with W key)
     bool mWeightEditMode = false;

--- a/src/gui/maptools/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/maptools/qgsmaptooldigitizefeature.cpp
@@ -54,6 +54,7 @@ bool QgsMapToolDigitizeFeature::supportsTechnique( Qgis::CaptureTechnique techni
     case Qgis::CaptureTechnique::CircularString:
     case Qgis::CaptureTechnique::Streaming:
     case Qgis::CaptureTechnique::Shape:
+    case Qgis::CaptureTechnique::PolyBezier:
     case Qgis::CaptureTechnique::NurbsCurve:
       return mode() != QgsMapToolCapture::CapturePoint;
   }

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -3388,6 +3388,21 @@ Shows placeholders for labels which could not be placed, e.g. due to overlaps wi
     <string>Digitize Shape</string>
    </property>
   </action>
+  <action name="mActionDigitizeWithBezier">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionDigitizeWithBezier.svg</normaloff>:/images/themes/default/mActionDigitizeWithBezier.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Digitize with Bézier Curve</string>
+   </property>
+   <property name="toolTip">
+    <string>Digitizes NURBS curves with Bézier (handles and anchors)</string>
+   </property>
+  </action>
   <action name="mActionDigitizeWithNurbs">
    <property name="checkable">
     <bool>true</bool>

--- a/tests/src/app/testqgsmaptoolnurbs.cpp
+++ b/tests/src/app/testqgsmaptoolnurbs.cpp
@@ -53,7 +53,7 @@ class TestQgsMapToolNurbs : public QObject
     QgsMapCanvas *mCanvas = nullptr;
     std::unique_ptr<QgsVectorLayer> mLineLayer;
 
-    void resetMapTool( Qgis::NurbsMode mode );
+    void resetMapTool( Qgis::CaptureTechnique technique );
 };
 
 void TestQgsMapToolNurbs::initTestCase()
@@ -84,11 +84,10 @@ void TestQgsMapToolNurbs::cleanupTestCase()
   QgsApplication::exitQgis();
 }
 
-void TestQgsMapToolNurbs::resetMapTool( Qgis::NurbsMode mode )
+void TestQgsMapToolNurbs::resetMapTool( Qgis::CaptureTechnique technique )
 {
   mMapTool->clean();
-  mMapTool->setCurrentCaptureTechnique( Qgis::CaptureTechnique::NurbsCurve );
-  QgsSettingsRegistryCore::settingsDigitizingNurbsMode->setValue( mode );
+  mMapTool->setCurrentCaptureTechnique( technique );
   QgsSettingsRegistryCore::settingsDigitizingNurbsDegree->setValue( 3 );
 }
 
@@ -97,7 +96,7 @@ void TestQgsMapToolNurbs::testNurbsControlPointsMode()
   mLineLayer->startEditing();
   mLineLayer->dataProvider()->truncate();
 
-  resetMapTool( Qgis::NurbsMode::ControlPoints );
+  resetMapTool( Qgis::CaptureTechnique::NurbsCurve );
 
   TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
 
@@ -127,7 +126,7 @@ void TestQgsMapToolNurbs::testNurbsPolyBezierMode()
   mLineLayer->startEditing();
   mLineLayer->dataProvider()->truncate();
 
-  resetMapTool( Qgis::NurbsMode::PolyBezier );
+  resetMapTool( Qgis::CaptureTechnique::PolyBezier );
 
   TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
 
@@ -157,7 +156,7 @@ void TestQgsMapToolNurbs::testNurbsControlPointsNotEnoughPoints()
   mLineLayer->dataProvider()->truncate();
   const long long count = mLineLayer->featureCount();
 
-  resetMapTool( Qgis::NurbsMode::ControlPoints );
+  resetMapTool( Qgis::CaptureTechnique::NurbsCurve );
 
   TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
 
@@ -179,7 +178,7 @@ void TestQgsMapToolNurbs::testNurbsPolyBezierNotEnoughPoints()
   mLineLayer->dataProvider()->truncate();
   const long long count = mLineLayer->featureCount();
 
-  resetMapTool( Qgis::NurbsMode::PolyBezier );
+  resetMapTool( Qgis::CaptureTechnique::PolyBezier );
 
   TestQgsMapToolAdvancedDigitizingUtils utils( mMapTool );
 

--- a/tests/src/core/geometry/testqgsnurbscurve.cpp
+++ b/tests/src/core/geometry/testqgsnurbscurve.cpp
@@ -76,6 +76,7 @@ class TestQgsNurbsCurve : public QObject
     void isValidTests();
     void weightAccessTests();
     void evaluateInvalidNurbs();
+    void generateKnotsForBezierConversion();
 };
 
 void TestQgsNurbsCurve::emptyConstructor()
@@ -845,6 +846,49 @@ void TestQgsNurbsCurve::evaluateInvalidNurbs()
 
   QgsPoint result = invalidCurve.evaluate( 0.5 );
   QVERIFY( result.isEmpty() );
+}
+
+void TestQgsNurbsCurve::generateKnotsForBezierConversion()
+{
+  // Test with insufficient anchors
+  QVector<double> knots = QgsNurbsCurve::generateKnotsForBezierConversion( 1 );
+  QVERIFY( knots.isEmpty() );
+
+  knots = QgsNurbsCurve::generateKnotsForBezierConversion( 0 );
+  QVERIFY( knots.isEmpty() );
+
+  // Test with 2 anchors (1 cubic Bézier segment)
+  // Expected: [0,0,0,0, 1,1,1,1] (8 knots total: 4 + 4)
+  knots = QgsNurbsCurve::generateKnotsForBezierConversion( 2 );
+  QCOMPARE( knots.size(), 8 );
+  for ( int i = 0; i < 4; ++i )
+    QCOMPARE( knots[i], 0.0 );
+  for ( int i = 4; i < 8; ++i )
+    QCOMPARE( knots[i], 1.0 );
+
+  // Test with 3 anchors (2 cubic Bézier segments)
+  // Expected: [0,0,0,0, 1,1,1, 2,2,2,2] (11 knots total: 4 + 3 + 4)
+  knots = QgsNurbsCurve::generateKnotsForBezierConversion( 3 );
+  QCOMPARE( knots.size(), 11 );
+  for ( int i = 0; i < 4; ++i )
+    QCOMPARE( knots[i], 0.0 );
+  for ( int i = 4; i < 7; ++i )
+    QCOMPARE( knots[i], 1.0 );
+  for ( int i = 7; i < 11; ++i )
+    QCOMPARE( knots[i], 2.0 );
+
+  // Test with 4 anchors (3 cubic Bézier segments)
+  // Expected: [0,0,0,0, 1,1,1, 2,2,2, 3,3,3,3] (14 knots total: 4 + 3 + 3 + 4)
+  knots = QgsNurbsCurve::generateKnotsForBezierConversion( 4 );
+  QCOMPARE( knots.size(), 14 );
+  for ( int i = 0; i < 4; ++i )
+    QCOMPARE( knots[i], 0.0 );
+  for ( int i = 4; i < 7; ++i )
+    QCOMPARE( knots[i], 1.0 );
+  for ( int i = 7; i < 10; ++i )
+    QCOMPARE( knots[i], 2.0 );
+  for ( int i = 10; i < 14; ++i )
+    QCOMPARE( knots[i], 3.0 );
 }
 
 QGSTEST_MAIN( TestQgsNurbsCurve )

--- a/tests/src/core/geometry/testqgsnurbscurve.cpp
+++ b/tests/src/core/geometry/testqgsnurbscurve.cpp
@@ -77,6 +77,7 @@ class TestQgsNurbsCurve : public QObject
     void weightAccessTests();
     void evaluateInvalidNurbs();
     void generateKnotsForBezierConversion();
+    void isAnchorVertex();
 };
 
 void TestQgsNurbsCurve::emptyConstructor()
@@ -889,6 +890,35 @@ void TestQgsNurbsCurve::generateKnotsForBezierConversion()
     QCOMPARE( knots[i], 2.0 );
   for ( int i = 10; i < 14; ++i )
     QCOMPARE( knots[i], 3.0 );
+}
+
+void TestQgsNurbsCurve::isAnchorVertex()
+{
+  // Test with degree 3 (cubic) - segments of 4 points (3 intervals), anchors every 3 points (0, 3, 6, ...)
+  QgsNurbsCurve cubic;
+  cubic.setDegree( 3 );
+  cubic.setControlPoints( { QgsPoint( 0, 0 ), QgsPoint( 1, 1 ), QgsPoint( 2, 1 ), QgsPoint( 3, 0 ), QgsPoint( 4, -1 ), QgsPoint( 5, -1 ), QgsPoint( 6, 0 ) } );
+  cubic.setKnots( { 0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2 } );
+
+  QVERIFY( cubic.isAnchorVertex( 0 ) );
+  QVERIFY( !cubic.isAnchorVertex( 1 ) );
+  QVERIFY( !cubic.isAnchorVertex( 2 ) );
+  QVERIFY( cubic.isAnchorVertex( 3 ) );
+  QVERIFY( !cubic.isAnchorVertex( 4 ) );
+  QVERIFY( !cubic.isAnchorVertex( 5 ) );
+  QVERIFY( cubic.isAnchorVertex( 6 ) );
+
+  // Out of bounds
+  QVERIFY( !cubic.isAnchorVertex( 7 ) );
+  QVERIFY( !cubic.isAnchorVertex( -1 ) );
+
+  // Test with a curve that is NOT a Poly-Bezier
+  QgsNurbsCurve standard;
+  standard.setDegree( 2 );
+  standard.setControlPoints( { QgsPoint( 0, 0 ), QgsPoint( 1, 1 ), QgsPoint( 2, 0 ) } );
+  // Invalid knots for Poly-Bezier (must have multiplicity degree at internal knots)
+  standard.setKnots( { 0, 0, 0.5, 1, 1 } );
+  QVERIFY( !standard.isAnchorVertex( 0 ) );
 }
 
 QGSTEST_MAIN( TestQgsNurbsCurve )

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TESTS
   testqgsadvanceddigitizingdockwidget.cpp
   testqgsadvanceddigitizingtoolsregistry.cpp
   testqgsannotationitemguiregistry.cpp
+  testqgsbezierdata.cpp
   testqgsmaptoolzoom.cpp
   testqgsmaptooledit.cpp
   testqgscategorizedrendererwidget.cpp

--- a/tests/src/gui/testqgsbezierdata.cpp
+++ b/tests/src/gui/testqgsbezierdata.cpp
@@ -1,0 +1,234 @@
+/***************************************************************************
+    testqgsbezierdata.cpp
+     --------------------------------------
+    Date                 : December 2025
+    Copyright            : (C) 2025 Loïc Bartoletti
+    Email                : loic dot bartoletti at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <memory>
+
+#include "qgsapplication.h"
+#include "qgsbezierdata.h"
+#include "qgsnurbscurve.h"
+#include "qgstest.h"
+
+#include <QTest>
+
+class TestQgsBezierData : public QObject
+{
+    Q_OBJECT
+
+  public:
+    TestQgsBezierData() = default;
+
+  private slots:
+    void initTestCase();
+    void cleanupTestCase();
+    void init();
+    void cleanup();
+
+    void testConstructor();
+    void testAddAnchor();
+    void testMoveAnchor();
+    void testMoveHandle();
+    void testInsertAnchor();
+    void testDeleteAnchor();
+    void testRetractHandle();
+    void testExtendHandle();
+    void testFindClosestAnchor();
+    void testFindClosestHandle();
+    void testInterpolate();
+    void testAsNurbsCurve();
+    void testClear();
+};
+
+void TestQgsBezierData::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsBezierData::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsBezierData::init()
+{
+}
+
+void TestQgsBezierData::cleanup()
+{
+}
+
+void TestQgsBezierData::testConstructor()
+{
+  QgsBezierData data;
+  QVERIFY( data.isEmpty() );
+  QCOMPARE( data.anchorCount(), 0 );
+  QCOMPARE( data.handleCount(), 0 );
+}
+
+void TestQgsBezierData::testAddAnchor()
+{
+  QgsBezierData data;
+
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  QCOMPARE( data.anchorCount(), 1 );
+  QCOMPARE( data.handleCount(), 2 );
+  QCOMPARE( data.anchor( 0 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( data.handle( 0 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( data.handle( 1 ), QgsPoint( 0, 0 ) );
+
+  data.addAnchor( QgsPoint( 10, 0 ) );
+  QCOMPARE( data.anchorCount(), 2 );
+  QCOMPARE( data.handleCount(), 4 );
+  QCOMPARE( data.anchor( 1 ), QgsPoint( 10, 0 ) );
+}
+
+void TestQgsBezierData::testMoveAnchor()
+{
+  QgsBezierData data;
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  data.moveHandle( 1, QgsPoint( 3, 3 ) );
+
+  data.moveAnchor( 0, QgsPoint( 5, 5 ) );
+  QCOMPARE( data.anchor( 0 ), QgsPoint( 5, 5 ) );
+  QCOMPARE( data.handle( 1 ), QgsPoint( 8, 8 ) );
+}
+
+void TestQgsBezierData::testMoveHandle()
+{
+  QgsBezierData data;
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  data.addAnchor( QgsPoint( 10, 0 ) );
+
+  data.moveHandle( 1, QgsPoint( 3, 3 ) );
+  QCOMPARE( data.handle( 1 ), QgsPoint( 3, 3 ) );
+  QCOMPARE( data.handle( 0 ), QgsPoint( 0, 0 ) );
+}
+
+void TestQgsBezierData::testInsertAnchor()
+{
+  QgsBezierData data;
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  data.addAnchor( QgsPoint( 20, 0 ) );
+
+  data.insertAnchor( 1, QgsPoint( 10, 5 ) );
+  QCOMPARE( data.anchorCount(), 3 );
+  QCOMPARE( data.anchor( 0 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( data.anchor( 1 ), QgsPoint( 10, 5 ) );
+  QCOMPARE( data.anchor( 2 ), QgsPoint( 20, 0 ) );
+}
+
+void TestQgsBezierData::testDeleteAnchor()
+{
+  QgsBezierData data;
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  data.addAnchor( QgsPoint( 10, 0 ) );
+  data.addAnchor( QgsPoint( 20, 0 ) );
+
+  data.deleteAnchor( 1 );
+  QCOMPARE( data.anchorCount(), 2 );
+  QCOMPARE( data.anchor( 0 ), QgsPoint( 0, 0 ) );
+  QCOMPARE( data.anchor( 1 ), QgsPoint( 20, 0 ) );
+}
+
+void TestQgsBezierData::testRetractHandle()
+{
+  QgsBezierData data;
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  data.moveHandle( 1, QgsPoint( 5, 5 ) );
+  QCOMPARE( data.handle( 1 ), QgsPoint( 5, 5 ) );
+
+  data.retractHandle( 1 );
+  QCOMPARE( data.handle( 1 ), QgsPoint( 0, 0 ) );
+}
+
+void TestQgsBezierData::testExtendHandle()
+{
+  QgsBezierData data;
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  QCOMPARE( data.handle( 1 ), QgsPoint( 0, 0 ) );
+
+  data.extendHandle( 1, QgsPoint( 5, 5 ) );
+  QCOMPARE( data.handle( 1 ), QgsPoint( 5, 5 ) );
+}
+
+void TestQgsBezierData::testFindClosestAnchor()
+{
+  QgsBezierData data;
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  data.addAnchor( QgsPoint( 10, 0 ) );
+  data.addAnchor( QgsPoint( 20, 0 ) );
+
+  QCOMPARE( data.findClosestAnchor( QgsPoint( 0.5, 0 ), 1.0 ), 0 );
+  QCOMPARE( data.findClosestAnchor( QgsPoint( 9.5, 0 ), 1.0 ), 1 );
+  QCOMPARE( data.findClosestAnchor( QgsPoint( 100, 100 ), 1.0 ), -1 );
+}
+
+void TestQgsBezierData::testFindClosestHandle()
+{
+  QgsBezierData data;
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  data.moveHandle( 1, QgsPoint( 5, 5 ) );
+
+  QCOMPARE( data.findClosestHandle( QgsPoint( 4.5, 4.5 ), 1.0 ), 1 );
+  QCOMPARE( data.findClosestHandle( QgsPoint( 100, 100 ), 1.0 ), -1 );
+}
+
+void TestQgsBezierData::testInterpolate()
+{
+  QgsBezierData data;
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  data.addAnchor( QgsPoint( 10, 10 ) );
+
+  QgsPointSequence points = data.interpolate();
+  QVERIFY( !points.isEmpty() );
+  QCOMPARE( points.first(), QgsPoint( 0, 0 ) );
+  QCOMPARE( points.last(), QgsPoint( 10, 10 ) );
+}
+
+void TestQgsBezierData::testAsNurbsCurve()
+{
+  QgsBezierData data;
+  QVERIFY( data.asNurbsCurve() == nullptr );
+
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  QVERIFY( data.asNurbsCurve() == nullptr );
+
+  data.addAnchor( QgsPoint( 10, 10 ) );
+  data.moveHandle( 1, QgsPoint( 3, 3 ) );
+  data.moveHandle( 2, QgsPoint( 7, 7 ) );
+
+  std::unique_ptr<QgsNurbsCurve> nurbs( data.asNurbsCurve() );
+  QVERIFY( nurbs != nullptr );
+  QCOMPARE( nurbs->degree(), 3 );
+  QCOMPARE( nurbs->controlPoints().size(), 4 );
+  QCOMPARE( nurbs->startPoint(), QgsPoint( 0, 0 ) );
+  QCOMPARE( nurbs->endPoint(), QgsPoint( 10, 10 ) );
+}
+
+void TestQgsBezierData::testClear()
+{
+  QgsBezierData data;
+  data.addAnchor( QgsPoint( 0, 0 ) );
+  data.addAnchor( QgsPoint( 10, 0 ) );
+  QVERIFY( !data.isEmpty() );
+
+  data.clear();
+  QVERIFY( data.isEmpty() );
+  QCOMPARE( data.anchorCount(), 0 );
+  QCOMPARE( data.handleCount(), 0 );
+}
+
+QGSTEST_MAIN( TestQgsBezierData )
+#include "testqgsbezierdata.moc"

--- a/tests/src/gui/testqgsbezierdata.cpp
+++ b/tests/src/gui/testqgsbezierdata.cpp
@@ -191,7 +191,7 @@ void TestQgsBezierData::testInterpolate()
   data.addAnchor( QgsPoint( 0, 0 ) );
   data.addAnchor( QgsPoint( 10, 10 ) );
 
-  QgsPointSequence points = data.interpolate();
+  QgsPointSequence points = data.interpolateLine();
   QVERIFY( !points.isEmpty() );
   QCOMPARE( points.first(), QgsPoint( 0, 0 ) );
   QCOMPARE( points.last(), QgsPoint( 10, 10 ) );


### PR DESCRIPTION
## Description

This PR follows up on the GUI part for the NURBS curve with a "poly-bézier" / "freeform" curve mode, using anchors and handles.
This mode comes more from the "graphical and illustration world", which may be suitable for beautiful drawings (less technical than ControlPoint).
It adds two classes for managing Bézier data adapted from BezierEditing plugin, which are reused in the map tool.

You have to click+drag, to add point with handle. One can "reinit" handles using alt+click on a point.

Some notes:
- I hardcoded values for the colors, not thinking it was useful to expose and modify them. I've added a calculation (cf QColor::fromHsv) for getting a complementary color. I don't know if it's the best choice, but I like how it looks on my screen :)
- ~~There is a message to help the user; after consideration, I'm not sure if it's the best UX @nirvn @m-kuhn~~
- INTERPOLATION_POINTS is also hardcoded to 32, but it could be roughly a 4 * quadrant segments setting; a good value is, IMHO, between 32 and 64. Do we expose this setting? Do we leave it at 32 or do we make it a "4* setting"?

Example:

https://github.com/user-attachments/assets/c15767d1-c601-48a7-93c9-388db7254960

Sponsored by Stadt Frankfurt am Main and Oslandia