### PR TITLE
allow HTML formatting in message log viewer

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -76,6 +76,18 @@ Qgis.Success = Qgis.MessageLevel.Success
 Qgis.NoLevel = Qgis.MessageLevel.NoLevel
 Qgis.MessageLevel.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.MessageType.MessageText.__doc__ = "Text message"
+Qgis.MessageType.MessageHtml.__doc__ = "HTML message"
+Qgis.MessageType.__doc__ = """Type of message
+This will be used both for message log and message bar in application.
+
+* ``MessageText``: Text message
+* ``MessageHtml``: HTML message
+
+"""
+# --
+Qgis.MessageType.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.NetworkRequestFlag.DisableMessageLogging.__doc__ = "If present, indicates that no message logging should be performed when network errors are encountered"
 Qgis.NetworkRequestFlag.__doc__ = """Flags controlling behavior of network requests.
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -75,18 +75,32 @@ Qgis.Critical = Qgis.MessageLevel.Critical
 Qgis.Success = Qgis.MessageLevel.Success
 Qgis.NoLevel = Qgis.MessageLevel.NoLevel
 Qgis.MessageLevel.baseClass = Qgis
+QgsMessageOutput.MessageType = Qgis.StringFormat
 # monkey patching scoped based enum
-Qgis.MessageType.MessageText.__doc__ = "Text message"
-Qgis.MessageType.MessageHtml.__doc__ = "HTML message"
-Qgis.MessageType.__doc__ = """Type of message
-This will be used both for message log and message bar in application.
+QgsMessageOutput.MessageText = Qgis.StringFormat.PlainText
+QgsMessageOutput.MessageType.MessageText = Qgis.StringFormat.PlainText
+QgsMessageOutput.MessageText.is_monkey_patched = True
+QgsMessageOutput.MessageText.__doc__ = "Text message"
+QgsMessageOutput.MessageHtml = Qgis.StringFormat.Html
+QgsMessageOutput.MessageType.MessageHtml = Qgis.StringFormat.Html
+QgsMessageOutput.MessageHtml.is_monkey_patched = True
+QgsMessageOutput.MessageHtml.__doc__ = "HTML message"
+Qgis.StringFormat.__doc__ = """Format of log message
 
-* ``MessageText``: Text message
-* ``MessageHtml``: HTML message
+.. versionadded:: 4.0.
+
+* ``PlainText``: Text message
+
+  Available as ``QgsMessageOutput.MessageText`` in older QGIS releases.
+
+* ``Html``: HTML message
+
+  Available as ``QgsMessageOutput.MessageHtml`` in older QGIS releases.
+
 
 """
 # --
-Qgis.MessageType.baseClass = Qgis
+Qgis.StringFormat.baseClass = Qgis
 # monkey patching scoped based enum
 Qgis.NetworkRequestFlag.DisableMessageLogging.__doc__ = "If present, indicates that no message logging should be performed when network errors are encountered"
 Qgis.NetworkRequestFlag.__doc__ = """Flags controlling behavior of network requests.

--- a/python/PyQt6/core/auto_additions/qgsmessagelog.py
+++ b/python/PyQt6/core/auto_additions/qgsmessagelog.py
@@ -1,8 +1,9 @@
 # The following has been generated automatically from src/core/qgsmessagelog.h
 try:
-    QgsMessageLog.__attribute_docs__ = {'messageReceived': 'Emitted whenever the log receives a message which is not a\n:py:class:`Qgis`.MessageLevel.Info level message and which has the\n``notifyUser`` flag as ``True``.\n\nIf :py:class:`QgsMessageLogNotifyBlocker` objects have been created then\nthis signal may be temporarily suppressed.\n\n.. seealso:: :py:class:`QgsMessageLogNotifyBlocker`\n'}
+    QgsMessageLog.__attribute_docs__ = {'messageReceived': 'Emitted whenever the log receives a message which is not a\n:py:class:`Qgis`.MessageLevel.Info level message and which has the\n``notifyUser`` flag as ``True``.\n\nIf :py:class:`QgsMessageLogNotifyBlocker` objects have been created then\nthis signal may be temporarily suppressed.\n\n.. seealso:: :py:class:`QgsMessageLogNotifyBlocker`\n', 'messageReceivedWithFormat': "Emitted whenever the log receives a ``message``.\n\nThis signal is emitted for all messages received by the log, regardless\nof the ``notifyUser`` flag's value for the message.\n"}
     QgsMessageLog.logMessage = staticmethod(QgsMessageLog.logMessage)
-    QgsMessageLog.__signal_arguments__ = {'messageReceived': ['received: bool']}
+    QgsMessageLog.logMessageWithFormat = staticmethod(QgsMessageLog.logMessageWithFormat)
+    QgsMessageLog.__signal_arguments__ = {'messageReceivedWithFormat': ['message: str', 'tag: str', 'level: Qgis.MessageLevel', ': Qgis.StringFormat'], 'messageReceived': ['received: bool']}
 except (NameError, AttributeError):
     pass
 try:

--- a/python/PyQt6/core/auto_additions/qgsmessagelog.py
+++ b/python/PyQt6/core/auto_additions/qgsmessagelog.py
@@ -2,7 +2,6 @@
 try:
     QgsMessageLog.__attribute_docs__ = {'messageReceived': 'Emitted whenever the log receives a message which is not a\n:py:class:`Qgis`.MessageLevel.Info level message and which has the\n``notifyUser`` flag as ``True``.\n\nIf :py:class:`QgsMessageLogNotifyBlocker` objects have been created then\nthis signal may be temporarily suppressed.\n\n.. seealso:: :py:class:`QgsMessageLogNotifyBlocker`\n', 'messageReceivedWithFormat': "Emitted whenever the log receives a ``message``.\n\nThis signal is emitted for all messages received by the log, regardless\nof the ``notifyUser`` flag's value for the message.\n"}
     QgsMessageLog.logMessage = staticmethod(QgsMessageLog.logMessage)
-    QgsMessageLog.logMessageWithFormat = staticmethod(QgsMessageLog.logMessageWithFormat)
     QgsMessageLog.__signal_arguments__ = {'messageReceivedWithFormat': ['message: str', 'tag: str', 'level: Qgis.MessageLevel', ': Qgis.StringFormat'], 'messageReceived': ['received: bool']}
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -71,47 +71,46 @@ The development version
 
     enum class AuthConfigurationStorageCapability /BaseType=IntFlag/
     {
-        ClearStorage,
+      ClearStorage,
 
-        ReadConfiguration,
-        UpdateConfiguration,
-        DeleteConfiguration,
-        CreateConfiguration,
+      ReadConfiguration,
+      UpdateConfiguration,
+      DeleteConfiguration,
+      CreateConfiguration,
 
-        ReadCertificateIdentity,
-        UpdateCertificateIdentity,
-        DeleteCertificateIdentity,
-        CreateCertificateIdentity,
+      ReadCertificateIdentity,
+      UpdateCertificateIdentity,
+      DeleteCertificateIdentity,
+      CreateCertificateIdentity,
 
-        ReadSslCertificateCustomConfig,
-        UpdateSslCertificateCustomConfig,
-        DeleteSslCertificateCustomConfig,
-        CreateSslCertificateCustomConfig,
+      ReadSslCertificateCustomConfig,
+      UpdateSslCertificateCustomConfig,
+      DeleteSslCertificateCustomConfig,
+      CreateSslCertificateCustomConfig,
 
-        ReadCertificateAuthority,
-        UpdateCertificateAuthority,
-        DeleteCertificateAuthority,
-        CreateCertificateAuthority,
+      ReadCertificateAuthority,
+      UpdateCertificateAuthority,
+      DeleteCertificateAuthority,
+      CreateCertificateAuthority,
 
-        ReadCertificateTrustPolicy,
-        UpdateCertificateTrustPolicy,
-        DeleteCertificateTrustPolicy,
-        CreateCertificateTrustPolicy,
+      ReadCertificateTrustPolicy,
+      UpdateCertificateTrustPolicy,
+      DeleteCertificateTrustPolicy,
+      CreateCertificateTrustPolicy,
 
-        ReadMasterPassword,
-        UpdateMasterPassword,
-        DeleteMasterPassword,
-        CreateMasterPassword,
+      ReadMasterPassword,
+      UpdateMasterPassword,
+      DeleteMasterPassword,
+      CreateMasterPassword,
 
-        ReadSetting,
-        UpdateSetting,
-        DeleteSetting,
-        CreateSetting,
+      ReadSetting,
+      UpdateSetting,
+      DeleteSetting,
+      CreateSetting,
 
     };
 
     typedef QFlags<Qgis::AuthConfigurationStorageCapability> AuthConfigurationStorageCapabilities;
-
 
 
     enum MessageLevel /BaseType=IntEnum/
@@ -131,157 +130,157 @@ The development version
 
     enum class NetworkRequestFlag /BaseType=IntFlag/
     {
-        DisableMessageLogging,
+      DisableMessageLogging,
     };
 
     typedef QFlags<Qgis::NetworkRequestFlag> NetworkRequestFlags;
 
 
     enum class LayerType /BaseType=IntEnum/
-    {
-        Vector,
-               Raster,
-               Plugin,
-               Mesh,
-               VectorTile,
-               Annotation,
-               PointCloud,
-               Group,
-               TiledScene,
+      {
+      Vector,
+      Raster,
+      Plugin,
+      Mesh,
+      VectorTile,
+      Annotation,
+      PointCloud,
+      Group,
+      TiledScene,
     };
 
     enum class LayerFilter /BaseType=IntFlag/
     {
-        RasterLayer,
-        NoGeometry,
-        PointLayer,
-        LineLayer,
-        PolygonLayer,
-        HasGeometry,
-        VectorLayer,
-        PluginLayer,
-        WritableLayer,
-        MeshLayer,
-        VectorTileLayer,
-        PointCloudLayer,
-        AnnotationLayer,
-        TiledSceneLayer,
-        All,
-        SpatialLayer
+      RasterLayer,
+      NoGeometry,
+      PointLayer,
+      LineLayer,
+      PolygonLayer,
+      HasGeometry,
+      VectorLayer,
+      PluginLayer,
+      WritableLayer,
+      MeshLayer,
+      VectorTileLayer,
+      PointCloudLayer,
+      AnnotationLayer,
+      TiledSceneLayer,
+      All,
+      SpatialLayer
     };
     typedef QFlags<Qgis::LayerFilter> LayerFilters;
 
 
     enum class LoadStyleFlag /BaseType=IntFlag/
     {
-        IgnoreMissingStyleErrors,
+      IgnoreMissingStyleErrors,
     };
 
     typedef QFlags<Qgis::LoadStyleFlag> LoadStyleFlags;
 
 
     enum class WkbType /BaseType=IntEnum/
-    {
-        Unknown,
-        Point,
-        LineString,
-        Polygon,
-        Triangle,
-        MultiPoint,
-        MultiLineString,
-        MultiPolygon,
-        GeometryCollection,
-        CircularString,
-        CompoundCurve,
-        CurvePolygon,
-        MultiCurve,
-        MultiSurface,
-        PolyhedralSurface,
-        TIN,
+      {
+      Unknown,
+      Point,
+      LineString,
+      Polygon,
+      Triangle,
+      MultiPoint,
+      MultiLineString,
+      MultiPolygon,
+      GeometryCollection,
+      CircularString,
+      CompoundCurve,
+      CurvePolygon,
+      MultiCurve,
+      MultiSurface,
+      PolyhedralSurface,
+      TIN,
       NurbsCurve,
-        NoGeometry,
-        PointZ,
-        LineStringZ,
-        PolygonZ,
-        TriangleZ,
-        MultiPointZ,
-        MultiLineStringZ,
-        MultiPolygonZ,
-        GeometryCollectionZ,
-        CircularStringZ,
-        CompoundCurveZ,
-        CurvePolygonZ,
-        MultiCurveZ,
-        MultiSurfaceZ,
-        PolyhedralSurfaceZ,
-        TINZ,
+      NoGeometry,
+      PointZ,
+      LineStringZ,
+      PolygonZ,
+      TriangleZ,
+      MultiPointZ,
+      MultiLineStringZ,
+      MultiPolygonZ,
+      GeometryCollectionZ,
+      CircularStringZ,
+      CompoundCurveZ,
+      CurvePolygonZ,
+      MultiCurveZ,
+      MultiSurfaceZ,
+      PolyhedralSurfaceZ,
+      TINZ,
       NurbsCurveZ,
-        PointM,
-        LineStringM,
-        PolygonM,
-        TriangleM,
-        MultiPointM,
-        MultiLineStringM,
-        MultiPolygonM,
-        GeometryCollectionM,
-        CircularStringM,
-        CompoundCurveM,
-        CurvePolygonM,
-        MultiCurveM,
-        MultiSurfaceM,
-        PolyhedralSurfaceM,
-        TINM,
+      PointM,
+      LineStringM,
+      PolygonM,
+      TriangleM,
+      MultiPointM,
+      MultiLineStringM,
+      MultiPolygonM,
+      GeometryCollectionM,
+      CircularStringM,
+      CompoundCurveM,
+      CurvePolygonM,
+      MultiCurveM,
+      MultiSurfaceM,
+      PolyhedralSurfaceM,
+      TINM,
       NurbsCurveM,
-        PointZM,
-        LineStringZM,
-        PolygonZM,
-        MultiPointZM,
-        MultiLineStringZM,
-        MultiPolygonZM,
-        GeometryCollectionZM,
-        CircularStringZM,
-        CompoundCurveZM,
-        CurvePolygonZM,
-        MultiCurveZM,
-        MultiSurfaceZM,
-        PolyhedralSurfaceZM,
-        TINZM,
-        TriangleZM,
+      PointZM,
+      LineStringZM,
+      PolygonZM,
+      MultiPointZM,
+      MultiLineStringZM,
+      MultiPolygonZM,
+      GeometryCollectionZM,
+      CircularStringZM,
+      CompoundCurveZM,
+      CurvePolygonZM,
+      MultiCurveZM,
+      MultiSurfaceZM,
+      PolyhedralSurfaceZM,
+      TINZM,
+      TriangleZM,
       NurbsCurveZM,
-        Point25D,
-        LineString25D,
-        Polygon25D,
-        MultiPoint25D,
-        MultiLineString25D,
-        MultiPolygon25D
+      Point25D,
+      LineString25D,
+      Polygon25D,
+      MultiPoint25D,
+      MultiLineString25D,
+      MultiPolygon25D
     };
 
     enum class GeometryType /BaseType=IntEnum/
-    {
-        Point,
-              Line,
-              Polygon,
-              Unknown,
-              Null,
+      {
+      Point,
+      Line,
+      Polygon,
+      Unknown,
+      Null,
     };
 
     enum class DataType /BaseType=IntEnum/
-    {
-        UnknownDataType,
-        Byte,
-        Int8,
-        UInt16,
-        Int16,
-        UInt32,
-        Int32,
-        Float32,
-        Float64,
-        CInt16,
-        CInt32,
-        CFloat32,
-        CFloat64,
-        ARGB32,
-        ARGB32_Premultiplied
+      {
+      UnknownDataType,
+      Byte,
+      Int8,
+      UInt16,
+      Int16,
+      UInt32,
+      Int32,
+      Float32,
+      Float64,
+      CInt16,
+      CInt32,
+      CFloat32,
+      CFloat64,
+      ARGB32,
+      ARGB32_Premultiplied
     };
 
     enum class CaptureTechnique /BaseType=IntEnum/
@@ -300,19 +299,19 @@ The development version
 
     enum class VectorLayerTypeFlag /BaseType=IntFlag/
     {
-        SqlQuery
+      SqlQuery
     };
     typedef QFlags<Qgis::VectorLayerTypeFlag> VectorLayerTypeFlags;
 
 
     enum class EmbeddedScriptMode /BaseType=IntEnum/
-    {
-        Never,
-        Ask,
-        SessionOnly,
-        Always,
-        NotForThisSession,
-        NeverAsk,
+      {
+      Never,
+      Ask,
+      SessionOnly,
+      Always,
+      NotForThisSession,
+      NeverAsk,
     };
 
     enum class EmbeddedScriptType /BaseType=IntEnum/
@@ -332,14 +331,14 @@ The development version
 
     enum class DataProviderReadFlag /BaseType=IntFlag/
     {
-        TrustDataSource,
-        SkipFeatureCount,
-        LoadDefaultStyle,
-        SkipGetExtent,
-        SkipFullScan,
-        ForceReadOnly,
-        SkipCredentialsRequest,
-        ParallelThreadLoading,
+      TrustDataSource,
+      SkipFeatureCount,
+      LoadDefaultStyle,
+      SkipGetExtent,
+      SkipFullScan,
+      ForceReadOnly,
+      SkipCredentialsRequest,
+      ParallelThreadLoading,
     };
 
     typedef QFlags<Qgis::DataProviderReadFlag> DataProviderReadFlags;
@@ -348,61 +347,61 @@ The development version
 
     enum class VectorProviderCapability /BaseType=IntFlag/
     {
-        NoCapabilities,
-        AddFeatures,
-        DeleteFeatures,
-        ChangeAttributeValues,
-        AddAttributes,
-        DeleteAttributes,
-        CreateSpatialIndex,
-        SelectAtId,
-        ChangeGeometries,
-        SelectEncoding,
-        CreateAttributeIndex,
-        SimplifyGeometries,
-        SimplifyGeometriesWithTopologicalValidation,
-        TransactionSupport,
-        CircularGeometries,
-        ChangeFeatures,
-        RenameAttributes,
-        FastTruncate,
-        ReadLayerMetadata,
-        WriteLayerMetadata,
-        CancelSupport,
-        CreateRenderer,
-        CreateLabeling,
-        ReloadData,
-        FeatureSymbology,
-        EditingCapabilities,
+      NoCapabilities,
+      AddFeatures,
+      DeleteFeatures,
+      ChangeAttributeValues,
+      AddAttributes,
+      DeleteAttributes,
+      CreateSpatialIndex,
+      SelectAtId,
+      ChangeGeometries,
+      SelectEncoding,
+      CreateAttributeIndex,
+      SimplifyGeometries,
+      SimplifyGeometriesWithTopologicalValidation,
+      TransactionSupport,
+      CircularGeometries,
+      ChangeFeatures,
+      RenameAttributes,
+      FastTruncate,
+      ReadLayerMetadata,
+      WriteLayerMetadata,
+      CancelSupport,
+      CreateRenderer,
+      CreateLabeling,
+      ReloadData,
+      FeatureSymbology,
+      EditingCapabilities,
     };
 
     typedef QFlags<Qgis::VectorProviderCapability> VectorProviderCapabilities;
 
 
     enum class FeatureCountState /BaseType=IntEnum/
-    {
-        Uncounted,
-        UnknownCount,
+      {
+      Uncounted,
+      UnknownCount,
     };
 
     enum class SpatialIndexPresence /BaseType=IntEnum/
-    {
-        Unknown,
-        NotPresent,
-        Present,
+      {
+      Unknown,
+      NotPresent,
+      Present,
     };
 
     enum class FeatureAvailability /BaseType=IntEnum/
-    {
-        NoFeaturesAvailable,
-        FeaturesAvailable,
-        FeaturesMaybeAvailable
+      {
+      NoFeaturesAvailable,
+      FeaturesAvailable,
+      FeaturesMaybeAvailable
     };
 
     enum class VectorDataProviderAttributeEditCapability /BaseType=IntFlag/
     {
-        EditAlias,
-        EditComment,
+      EditAlias,
+      EditComment,
     };
 
 
@@ -410,31 +409,31 @@ The development version
 
 
     enum class SymbolType /BaseType=IntEnum/
-    {
-        Marker,
-        Line,
-        Fill,
-        Hybrid
+      {
+      Marker,
+      Line,
+      Fill,
+      Hybrid
     };
 
     enum class ScaleMethod /BaseType=IntEnum/
-    {
-        ScaleArea,
-        ScaleDiameter
+      {
+      ScaleArea,
+      ScaleDiameter
     };
 
     enum class SettingsType /BaseType=IntEnum/
-    {
-        Custom,
-        Variant,
-        String,
-        StringList,
-        VariantMap,
-        Bool,
-        Integer,
-        Double,
-        EnumFlag,
-        Color
+      {
+      Custom,
+      Variant,
+      String,
+      StringList,
+      VariantMap,
+      Bool,
+      Integer,
+      Double,
+      EnumFlag,
+      Color
     };
 
     enum class SettingsTreeNodeType
@@ -446,71 +445,71 @@ The development version
 
     enum class SettingsTreeNodeOption /BaseType=IntFlag/
     {
-        NamedListSelectedItemSetting,
+      NamedListSelectedItemSetting,
     };
 
     typedef QFlags<Qgis::SettingsTreeNodeOption> SettingsTreeNodeOptions;
 
 
     enum class PropertyType /BaseType=IntEnum/
-    {
-        Invalid,
-                Static,
-                Field,
-                Expression,
+      {
+      Invalid,
+      Static,
+      Field,
+      Expression,
     };
 
     enum class SldExportOption /BaseType=IntFlag/
     {
-        NoOptions,
-        Svg,
-        Png,
+      NoOptions,
+      Svg,
+      Png,
     };
     typedef QFlags<Qgis::SldExportOption> SldExportOptions;
 
 
     enum class SldExportVendorExtension /BaseType=IntFlag/
     {
-        NoVendorExtension,
-        GeoServerVendorExtension,
-        DeegreeVendorExtension,
+      NoVendorExtension,
+      GeoServerVendorExtension,
+      DeegreeVendorExtension,
     };
 
 
     enum class SettingsOption /BaseType=IntFlag/
     {
-        SaveFormerValue,
-        SaveEnumFlagAsInt,
+      SaveFormerValue,
+      SaveEnumFlagAsInt,
     };
     typedef QFlags<Qgis::SettingsOption> SettingsOptions;
 
 
     enum class SnappingMode /BaseType=IntEnum/
-    {
-        ActiveLayer,
-        AllLayers,
-        AdvancedConfiguration,
+      {
+      ActiveLayer,
+      AllLayers,
+      AdvancedConfiguration,
     };
 
     enum class SnappingType /BaseType=IntFlag/
     {
-        NoSnap,
-        Vertex,
-        Segment,
-        Area,
-        Centroid,
-        MiddleOfSegment,
-        LineEndpoint,
+      NoSnap,
+      Vertex,
+      Segment,
+      Area,
+      Centroid,
+      MiddleOfSegment,
+      LineEndpoint,
     };
     typedef QFlags<Qgis::SnappingType> SnappingTypes;
 
 
     enum class SymbolRenderHint /BaseType=IntFlag/
     {
-        DynamicRotation,
-        IsSymbolLayerSubSymbol,
-        ForceVectorRendering,
-        ExcludeSymbolBuffers,
+      DynamicRotation,
+      IsSymbolLayerSubSymbol,
+      ForceVectorRendering,
+      ExcludeSymbolBuffers,
     };
     typedef QFlags<Qgis::SymbolRenderHint> SymbolRenderHints;
 
@@ -523,23 +522,23 @@ The development version
 
 
     enum class HorizontalAnchorPoint /BaseType=IntEnum/
-    {
-        Left,
-        Center,
-        Right,
+      {
+      Left,
+      Center,
+      Right,
     };
 
     enum class VerticalAnchorPoint /BaseType=IntEnum/
-    {
-        Top,
-        Center,
-        Bottom,
-        Baseline,
+      {
+      Top,
+      Center,
+      Bottom,
+      Baseline,
     };
 
     enum class FeatureRendererFlag /BaseType=IntFlag/
     {
-        AffectsLabeling,
+      AffectsLabeling,
     };
 
     typedef QFlags<Qgis::FeatureRendererFlag> FeatureRendererFlags;
@@ -547,100 +546,100 @@ The development version
 
     enum class SymbolFlag /BaseType=IntFlag/
     {
-        RendererShouldUseSymbolLevels,
-        AffectsLabeling,
+      RendererShouldUseSymbolLevels,
+      AffectsLabeling,
     };
     typedef QFlags<Qgis::SymbolFlag> SymbolFlags;
 
 
     enum class SymbolPreviewFlag /BaseType=IntFlag/
     {
-        FlagIncludeCrosshairsForMarkerSymbols,
+      FlagIncludeCrosshairsForMarkerSymbols,
     };
     typedef QFlags<Qgis::SymbolPreviewFlag> SymbolPreviewFlags;
 
 
     enum class SymbolLayerFlag /BaseType=IntFlag/
     {
-        DisableFeatureClipping,
-        CanCalculateMaskGeometryPerFeature,
-        AffectsLabeling,
+      DisableFeatureClipping,
+      CanCalculateMaskGeometryPerFeature,
+      AffectsLabeling,
     };
     typedef QFlags<Qgis::SymbolLayerFlag> SymbolLayerFlags;
 
 
     enum class SymbolLayerUserFlag /BaseType=IntFlag/
     {
-        DisableSelectionRecoloring,
+      DisableSelectionRecoloring,
     };
 
     typedef QFlags<Qgis::SymbolLayerUserFlag> SymbolLayerUserFlags;
 
 
     enum class BrowserItemType /BaseType=IntEnum/
-    {
-        Collection,
-        Directory,
-        Layer,
-        Error,
-        Favorites,
-        Project,
-        Custom,
-        Fields,
-        Field,
+      {
+      Collection,
+      Directory,
+      Layer,
+      Error,
+      Favorites,
+      Project,
+      Custom,
+      Fields,
+      Field,
     };
 
     enum class BrowserItemState /BaseType=IntEnum/
-    {
-        NotPopulated,
-        Populating,
-        Populated,
+      {
+      NotPopulated,
+      Populating,
+      Populated,
     };
 
     enum class BrowserItemCapability /BaseType=IntFlag/
     {
-        NoCapabilities,
-        SetCrs,
-        Fertile,
-        Fast,
-        Collapse,
-        Rename,
-        Delete,
-        ItemRepresentsFile,
-        RefreshChildrenWhenItemIsRefreshed,
-        ReadOnly,
+      NoCapabilities,
+      SetCrs,
+      Fertile,
+      Fast,
+      Collapse,
+      Rename,
+      Delete,
+      ItemRepresentsFile,
+      RefreshChildrenWhenItemIsRefreshed,
+      ReadOnly,
     };
     typedef QFlags<Qgis::BrowserItemCapability> BrowserItemCapabilities;
 
 
     enum class DataItemProviderCapability /BaseType=IntFlag/
     {
-        NoCapabilities,
-        Files,
-        Directories,
-        Databases,
-        NetworkSources,
+      NoCapabilities,
+      Files,
+      Directories,
+      Databases,
+      NetworkSources,
     };
 
     typedef QFlags<Qgis::DataItemProviderCapability> DataItemProviderCapabilities;
 
 
     enum class BrowserLayerType /BaseType=IntEnum/
-    {
-        NoType,
-        Vector,
-        Raster,
-        Point,
-        Line,
-        Polygon,
-        TableLayer,
-        Database,
-        Table,
-        Plugin,
-        Mesh,
-        VectorTile,
-        PointCloud,
-        TiledScene,
+      {
+      NoType,
+      Vector,
+      Raster,
+      Point,
+      Line,
+      Polygon,
+      TableLayer,
+      Database,
+      Table,
+      Plugin,
+      Mesh,
+      VectorTile,
+      PointCloud,
+      TiledScene,
     };
 
     enum class BrowserDirectoryMonitoring /BaseType=IntEnum/
@@ -660,25 +659,25 @@ The development version
     };
 
     enum class VectorExportResult /BaseType=IntEnum/
-    {
-        Success,
-        ErrorCreatingDataSource,
-        ErrorCreatingLayer,
-        ErrorAttributeTypeUnsupported,
-        ErrorAttributeCreationFailed,
-        ErrorProjectingFeatures,
-        ErrorFeatureWriteFailed,
-        ErrorInvalidLayer,
-        ErrorInvalidProvider,
-        ErrorProviderUnsupportedFeature,
-        ErrorConnectionFailed,
-        UserCanceled,
+      {
+      Success,
+      ErrorCreatingDataSource,
+      ErrorCreatingLayer,
+      ErrorAttributeTypeUnsupported,
+      ErrorAttributeCreationFailed,
+      ErrorProjectingFeatures,
+      ErrorFeatureWriteFailed,
+      ErrorInvalidLayer,
+      ErrorInvalidProvider,
+      ErrorProviderUnsupportedFeature,
+      ErrorConnectionFailed,
+      UserCanceled,
     };
 
     enum class VectorFileWriterCapability /BaseType=IntFlag/
     {
-        FieldAliases,
-        FieldComments,
+      FieldAliases,
+      FieldComments,
     };
 
     typedef QFlags<Qgis::VectorFileWriterCapability> VectorFileWriterCapabilities;
@@ -686,10 +685,10 @@ The development version
 
     enum class SqlLayerDefinitionCapability /BaseType=IntFlag/
     {
-        SubsetStringFilter,
-        GeometryColumn,
-        PrimaryKeys,
-        UnstableFeatureIds
+      SubsetStringFilter,
+      GeometryColumn,
+      PrimaryKeys,
+      UnstableFeatureIds
     };
     typedef QFlags<Qgis::SqlLayerDefinitionCapability> SqlLayerDefinitionCapabilities;
 
@@ -720,9 +719,9 @@ The development version
     };
 
     enum class ActionStart /BaseType=IntEnum/
-    {
-        Deferred,
-                 Immediate,
+      {
+      Deferred,
+      Immediate,
     };
 
     enum class UnplacedLabelVisibility /BaseType=IntEnum/
@@ -751,16 +750,16 @@ The development version
     };
 
     enum class LabelPlacement /BaseType=IntEnum/
-    {
-        AroundPoint,
-        OverPoint,
-        Line,
-        Curved,
-        Horizontal,
-        Free,
-        OrderedPositionsAroundPoint,
-        PerimeterCurved,
-        OutsidePolygons,
+      {
+      AroundPoint,
+      OverPoint,
+      Line,
+      Curved,
+      Horizontal,
+      Free,
+      OrderedPositionsAroundPoint,
+      PerimeterCurved,
+      OutsidePolygons,
     };
 
     enum class CurvedLabelMode /BaseType=IntEnum/
@@ -772,20 +771,20 @@ The development version
     };
 
     enum class LabelPredefinedPointPosition /BaseType=IntEnum/
-    {
-        TopLeft,
-        TopSlightlyLeft,
-        TopMiddle,
-        TopSlightlyRight,
-        TopRight,
-        MiddleLeft,
-        MiddleRight,
-        BottomLeft,
-        BottomSlightlyLeft,
-        BottomMiddle,
-        BottomSlightlyRight,
-        BottomRight,
-        OverPoint,
+      {
+      TopLeft,
+      TopSlightlyLeft,
+      TopMiddle,
+      TopSlightlyRight,
+      TopRight,
+      MiddleLeft,
+      MiddleRight,
+      BottomLeft,
+      BottomSlightlyLeft,
+      BottomMiddle,
+      BottomSlightlyRight,
+      BottomRight,
+      OverPoint,
     };
 
     enum class MultiPartLabelingBehavior /BaseType=IntEnum/
@@ -796,30 +795,30 @@ The development version
     };
 
     enum class LabelOffsetType /BaseType=IntEnum/
-    {
-        FromPoint,
-        FromSymbolBounds,
+      {
+      FromPoint,
+      FromSymbolBounds,
     };
 
     enum class LabelQuadrantPosition /BaseType=IntEnum/
-    {
-        AboveLeft,
-                  Above,
-                  AboveRight,
-                  Left,
-                  Over,
-                  Right,
-                  BelowLeft,
-                  Below,
-                  BelowRight,
+      {
+      AboveLeft,
+      Above,
+      AboveRight,
+      Left,
+      Over,
+      Right,
+      BelowLeft,
+      Below,
+      BelowRight,
     };
 
     enum class LabelLinePlacementFlag /BaseType=IntFlag/
     {
-        OnLine,
-        AboveLine,
-        BelowLine,
-        MapOrientation,
+      OnLine,
+      AboveLine,
+      BelowLine,
+      MapOrientation,
     };
 
     typedef QFlags<Qgis::LabelLinePlacementFlag> LabelLinePlacementFlags;
@@ -827,44 +826,44 @@ The development version
 
     enum class LabelPolygonPlacementFlag /BaseType=IntFlag/
     {
-        AllowPlacementOutsideOfPolygon,
-        AllowPlacementInsideOfPolygon,
+      AllowPlacementOutsideOfPolygon,
+      AllowPlacementInsideOfPolygon,
     };
 
     typedef QFlags<Qgis::LabelPolygonPlacementFlag> LabelPolygonPlacementFlags;
 
 
     enum class UpsideDownLabelHandling /BaseType=IntEnum/
-    {
-        FlipUpsideDownLabels,
-                             AllowUpsideDownWhenRotationIsDefined,
-                             AlwaysAllowUpsideDown
+      {
+      FlipUpsideDownLabels,
+      AllowUpsideDownWhenRotationIsDefined,
+      AlwaysAllowUpsideDown
     };
 
     enum class LabelMultiLineAlignment /BaseType=IntEnum/
-    {
-        Left,
-        Center,
-        Right,
-        FollowPlacement,
-        Justify,
+      {
+      Left,
+      Center,
+      Right,
+      FollowPlacement,
+      Justify,
     };
 
     enum class FileFilterType /BaseType=IntEnum/
-    {
-        Vector,
-        Raster,
-        Mesh,
-        MeshDataset,
-        PointCloud,
-        VectorTile,
-        TiledScene,
+      {
+      Vector,
+      Raster,
+      Mesh,
+      MeshDataset,
+      PointCloud,
+      VectorTile,
+      TiledScene,
     };
 
     enum class UriCleaningFlag /BaseType=IntFlag/
     {
-        RemoveCredentials,
-        RedactCredentials,
+      RemoveCredentials,
+      RedactCredentials,
     };
 
     typedef QFlags<Qgis::UriCleaningFlag> UriCleaningFlags;
@@ -872,70 +871,70 @@ The development version
 
     enum class SublayerQueryFlag /BaseType=IntFlag/
     {
-        FastScan,
-        ResolveGeometryType,
-        CountFeatures,
-        IncludeSystemTables,
-        OpenLayersToResolveDescriptions,
+      FastScan,
+      ResolveGeometryType,
+      CountFeatures,
+      IncludeSystemTables,
+      OpenLayersToResolveDescriptions,
     };
     typedef QFlags<Qgis::SublayerQueryFlag> SublayerQueryFlags;
 
 
     enum class SublayerFlag /BaseType=IntFlag/
     {
-        SystemTable,
+      SystemTable,
     };
     typedef QFlags<Qgis::SublayerFlag> SublayerFlags;
 
 
     enum class ShaderInterpolationMethod /BaseType=IntEnum/
-    {
-        Linear,
-        Discrete,
-        Exact,
+      {
+      Linear,
+      Discrete,
+      Exact,
     };
 
     enum class ShaderClassificationMethod /BaseType=IntEnum/
-    {
-        Continuous,
-        EqualInterval,
-        Quantile,
+      {
+      Continuous,
+      EqualInterval,
+      Quantile,
     };
 
     enum class RasterPipeInterfaceRole /BaseType=IntEnum/
-    {
-        Unknown,
-        Provider,
-        Renderer,
-        Brightness,
-        Resampler,
-        Projector,
-        Nuller,
-        HueSaturation,
+      {
+      Unknown,
+      Provider,
+      Renderer,
+      Brightness,
+      Resampler,
+      Projector,
+      Nuller,
+      HueSaturation,
     };
 
     enum class RasterResamplingStage /BaseType=IntEnum/
-    {
-        ResampleFilter,
-        Provider,
+      {
+      ResampleFilter,
+      Provider,
     };
 
     enum class RasterResamplingMethod /BaseType=IntEnum/
-    {
-        Nearest,
-        Bilinear,
-        Cubic,
-        CubicSpline,
-        Lanczos,
-        Average,
-        Mode,
-        Gauss
+      {
+      Nearest,
+      Bilinear,
+      Cubic,
+      CubicSpline,
+      Lanczos,
+      Average,
+      Mode,
+      Gauss
     };
 
     enum class RasterRendererFlag /BaseType=IntFlag/
     {
-        InternalLayerOpacityHandling,
-        UseNoDataForOutOfRangePixels,
+      InternalLayerOpacityHandling,
+      UseNoDataForOutOfRangePixels,
     };
 
     typedef QFlags<Qgis::RasterRendererFlag> RasterRendererFlags;
@@ -944,31 +943,31 @@ The development version
 
     enum class RasterRendererCapability /BaseType=IntFlag/
     {
-        UsesMultipleBands,
+      UsesMultipleBands,
     };
 
     typedef QFlags<Qgis::RasterRendererCapability> RasterRendererCapabilities;
 
 
     enum class RasterRangeLimit /BaseType=IntEnum/
-    {
-        NotSet,
-               MinimumMaximum,
-               StdDev,
-               CumulativeCut
+      {
+      NotSet,
+      MinimumMaximum,
+      StdDev,
+      CumulativeCut
     };
 
     enum class RasterRangeExtent /BaseType=IntEnum/
-    {
-        WholeRaster,
-                    FixedCanvas,
-                    UpdatedCanvas,
+      {
+      WholeRaster,
+      FixedCanvas,
+      UpdatedCanvas,
     };
 
     enum class RasterRangeAccuracy /BaseType=IntEnum/
-    {
-        Exact,
-        Estimated,
+      {
+      Exact,
+      Estimated,
     };
 
     enum class RasterAttributeTableFieldUsage /BaseType=IntEnum/
@@ -1001,20 +1000,20 @@ The development version
     };
 
     enum class RasterExportType /BaseType=IntEnum/
-    {
-        Raw,
-        RenderedImage
+      {
+      Raw,
+      RenderedImage
     };
 
     enum class RasterFileWriterResult /BaseType=IntEnum/
-    {
-        Success,
-        SourceProviderError,
-        DestinationProviderError,
-        CreateDatasourceError,
-        WriteError,
-        NoDataConflict,
-        Canceled,
+      {
+      Success,
+      SourceProviderError,
+      DestinationProviderError,
+      CreateDatasourceError,
+      WriteError,
+      NoDataConflict,
+      Canceled,
     };
 
     enum class MeshEditingErrorType /BaseType=IntEnum/
@@ -1043,20 +1042,20 @@ The development version
     };
 
     enum class FieldOrigin /BaseType=IntEnum/
-    {
-        Unknown,
-                Provider,
-                Join,
-                Edit,
-                Expression
+      {
+      Unknown,
+      Provider,
+      Join,
+      Edit,
+      Expression
     };
 
     enum class FieldConfigurationFlag /BaseType=IntFlag/
     {
-        NoFlag,
-        NotSearchable,
-        HideFromWms,
-        HideFromWfs,
+      NoFlag,
+      NotSearchable,
+      HideFromWms,
+      HideFromWfs,
     };
 
     typedef QFlags<Qgis::FieldConfigurationFlag> FieldConfigurationFlags;
@@ -1077,11 +1076,11 @@ The development version
     };
 
     enum class SelectBehavior /BaseType=IntEnum/
-    {
-        SetSelection,
-        AddToSelection,
-        IntersectSelection,
-        RemoveFromSelection,
+      {
+      SetSelection,
+      AddToSelection,
+      IntersectSelection,
+      RemoveFromSelection,
     };
 
     enum class SelectGeometryRelationship /BaseType=IntEnum/
@@ -1092,8 +1091,8 @@ The development version
 
     enum class SelectionFlag /BaseType=IntFlag/
     {
-        SingleFeatureSelection,
-        ToggleSelection,
+      SingleFeatureSelection,
+      ToggleSelection,
     };
 
     typedef QFlags<Qgis::SelectionFlag> SelectionFlags;
@@ -1101,19 +1100,19 @@ The development version
 
 
     enum class VectorEditResult /BaseType=IntEnum/
-    {
-        Success,
-        EmptyGeometry,
-        EditFailed,
-        FetchFeatureFailed,
-        InvalidLayer,
+      {
+      Success,
+      EmptyGeometry,
+      EditFailed,
+      FetchFeatureFailed,
+      InvalidLayer,
     };
 
     enum class VertexMarkerType /BaseType=IntEnum/
-    {
-        SemiTransparentCircle,
-        Cross,
-        NoMarker,
+      {
+      SemiTransparentCircle,
+      Cross,
+      NoMarker,
     };
 
     enum class ContentStatus /BaseType=IntEnum/
@@ -1134,18 +1133,18 @@ The development version
     };
 
     enum class DeviceConnectionStatus /BaseType=IntEnum/
-    {
-        Disconnected,
-        Connecting,
-        Connected,
+      {
+      Disconnected,
+      Connecting,
+      Connected,
     };
 
     enum class GpsFixStatus /BaseType=IntEnum/
-    {
-        NoData,
-        NoFix,
-        Fix2D,
-        Fix3D
+      {
+      NoData,
+      NoFix,
+      Fix2D,
+      Fix3D
     };
 
 
@@ -1185,26 +1184,26 @@ The development version
 
     enum class GpsInformationComponent /BaseType=IntFlag/
     {
-        Location,
-        Altitude,
-        GroundSpeed,
-        Bearing,
-        TotalTrackLength,
-        TrackDistanceFromStart,
-        Pdop,
-        Hdop,
-        Vdop,
-        HorizontalAccuracy,
-        VerticalAccuracy,
-        HvAccuracy,
-        SatellitesUsed,
-        Timestamp,
-        TrackStartTime,
-        TrackEndTime,
-        TrackDistanceSinceLastPoint,
-        TrackTimeSinceLastPoint,
-        GeoidalSeparation,
-        EllipsoidAltitude,
+      Location,
+      Altitude,
+      GroundSpeed,
+      Bearing,
+      TotalTrackLength,
+      TrackDistanceFromStart,
+      Pdop,
+      Hdop,
+      Vdop,
+      HorizontalAccuracy,
+      VerticalAccuracy,
+      HvAccuracy,
+      SatellitesUsed,
+      Timestamp,
+      TrackStartTime,
+      TrackEndTime,
+      TrackDistanceSinceLastPoint,
+      TrackTimeSinceLastPoint,
+      GeoidalSeparation,
+      EllipsoidAltitude,
     };
 
     typedef QFlags<Qgis::GpsInformationComponent> GpsInformationComponents;
@@ -1212,18 +1211,18 @@ The development version
 
     enum class BabelFormatCapability /BaseType=IntFlag/
     {
-        Import,
-        Export,
-        Waypoints,
-        Routes,
-        Tracks,
+      Import,
+      Export,
+      Waypoints,
+      Routes,
+      Tracks,
     };
     typedef QFlags<Qgis::BabelFormatCapability> BabelFormatCapabilities;
 
 
     enum class BabelCommandFlag /BaseType=IntFlag/
     {
-        QuoteFilePaths,
+      QuoteFilePaths,
     };
     typedef QFlags<Qgis::BabelCommandFlag> BabelCommandFlags;
 
@@ -1236,59 +1235,59 @@ The development version
     };
 
     enum class GeometryOperationResult /BaseType=IntEnum/
-    {
-        Success,
-        NothingHappened,
-        InvalidBaseGeometry,
-        InvalidInputGeometryType,
-        SelectionIsEmpty,
-        SelectionIsGreaterThanOne,
-        GeometryEngineError,
-        LayerNotEditable,
-        // Add part issues
-        AddPartSelectedGeometryNotFound,
-        AddPartNotMultiGeometry,
-        // Add ring issues
-        AddRingNotClosed,
-        AddRingNotValid,
-        AddRingCrossesExistingRings,
-        AddRingNotInExistingFeature,
-        // Split features
-        SplitCannotSplitPoint,
-        GeometryTypeHasChanged,
+      {
+      Success,
+      NothingHappened,
+      InvalidBaseGeometry,
+      InvalidInputGeometryType,
+      SelectionIsEmpty,
+      SelectionIsGreaterThanOne,
+      GeometryEngineError,
+      LayerNotEditable,
+      // Add part issues
+      AddPartSelectedGeometryNotFound,
+      AddPartNotMultiGeometry,
+      // Add ring issues
+      AddRingNotClosed,
+      AddRingNotValid,
+      AddRingCrossesExistingRings,
+      AddRingNotInExistingFeature,
+      // Split features
+      SplitCannotSplitPoint,
+      GeometryTypeHasChanged,
     };
 
     enum class GeometryValidityFlag /BaseType=IntFlag/
     {
-        AllowSelfTouchingHoles,
+      AllowSelfTouchingHoles,
     };
     typedef QFlags<Qgis::GeometryValidityFlag> GeometryValidityFlags;
 
 
     enum class GeometryValidationEngine /BaseType=IntEnum/
-    {
-        QgisInternal,
-                     Geos,
+      {
+      QgisInternal,
+      Geos,
     };
 
     enum class BufferSide /BaseType=IntEnum/
-    {
-        Left,
-        Right,
+      {
+      Left,
+      Right,
     };
 
     enum class EndCapStyle /BaseType=IntEnum/
-    {
-        Round,
-        Flat,
-        Square,
+      {
+      Round,
+      Flat,
+      Square,
     };
 
     enum class JoinStyle /BaseType=IntEnum/
-    {
-        Round,
-        Miter,
-        Bevel,
+      {
+      Round,
+      Miter,
+      Bevel,
     };
 
     enum class JoinStyle3D /BaseType=IntEnum/
@@ -1300,8 +1299,8 @@ The development version
 
     enum class GeosCreationFlag /BaseType=IntFlag/
     {
-        RejectOnInvalidSubGeometry,
-        SkipEmptyInteriorRings,
+      RejectOnInvalidSubGeometry,
+      SkipEmptyInteriorRings,
     };
 
     typedef QFlags<Qgis::GeosCreationFlag> GeosCreationFlags;
@@ -1322,30 +1321,30 @@ The development version
 
     enum class FeatureRequestFlag /BaseType=IntFlag/
     {
-        NoFlags,
-        NoGeometry,
-        SubsetOfAttributes,
-        ExactIntersect,
-        IgnoreStaticNodesDuringExpressionCompilation,
-        EmbeddedSymbols,
+      NoFlags,
+      NoGeometry,
+      SubsetOfAttributes,
+      ExactIntersect,
+      IgnoreStaticNodesDuringExpressionCompilation,
+      EmbeddedSymbols,
     };
 
     typedef QFlags<Qgis::FeatureRequestFlag> FeatureRequestFlags;
 
 
     enum class FeatureRequestFilterType /BaseType=IntEnum/
-    {
-        NoFilter,
-                 Fid,
-                 Expression,
-                 Fids
+      {
+      NoFilter,
+      Fid,
+      Expression,
+      Fids
     };
 
     enum class InvalidGeometryCheck /BaseType=IntEnum/
-    {
-        NoCheck,
-        SkipInvalid,
-        AbortOnInvalid,
+      {
+      NoCheck,
+      SkipInvalid,
+      AbortOnInvalid,
     };
 
     enum class SpatialFilterType /BaseType=IntEnum/
@@ -1357,17 +1356,17 @@ The development version
 
     enum class FileOperationFlag /BaseType=IntFlag/
     {
-        IncludeMetadataFile,
-        IncludeStyleFile,
+      IncludeMetadataFile,
+      IncludeStyleFile,
     };
     typedef QFlags<Qgis::FileOperationFlag> FileOperationFlags;
 
 
     enum class MapLayerProperty /BaseType=IntFlag/
     {
-        UsersCannotToggleEditing,
-        IsBasemapLayer,
-        Is3DBasemapLayer,
+      UsersCannotToggleEditing,
+      IsBasemapLayer,
+      Is3DBasemapLayer,
     };
     typedef QFlags<Qgis::MapLayerProperty> MapLayerProperties;
 
@@ -1381,10 +1380,10 @@ The development version
 
     enum class DataProviderFlag /BaseType=IntFlag/
     {
-        IsBasemapSource,
-                        FastExtent2D,
-                        FastExtent3D,
-                        Is3DBasemapSource,
+      IsBasemapSource,
+      FastExtent2D,
+      FastExtent3D,
+      Is3DBasemapSource,
     };
     typedef QFlags<Qgis::DataProviderFlag> DataProviderFlags;
 
@@ -1458,23 +1457,23 @@ The development version
     };
 
     enum class CrsIdentifierType /BaseType=IntEnum/
-    {
-        ShortString,
-        MediumString,
-        FullString,
+      {
+      ShortString,
+      MediumString,
+      FullString,
     };
 
     enum class CrsWktVariant /BaseType=IntEnum/
-    {
-        Wkt1Gdal,
-                 Wkt1Esri,
-                 Wkt2_2015,
-                 Wkt2_2015Simplified,
-                 Wkt2_2019,
-                 Wkt2_2019Simplified,
-                 Preferred,
-                 PreferredSimplified,
-                 PreferredGdal,
+      {
+      Wkt1Gdal,
+      Wkt1Esri,
+      Wkt2_2015,
+      Wkt2_2015Simplified,
+      Wkt2_2019,
+      Wkt2_2019Simplified,
+      Preferred,
+      PreferredSimplified,
+      PreferredGdal,
     };
 
     enum class Axis /BaseType=IntEnum/
@@ -1486,9 +1485,9 @@ The development version
 
     enum class AnnotationItemFlag /BaseType=IntFlag/
     {
-        ScaleDependentBoundingBox,
-        SupportsReferenceScale,
-        SupportsCallouts,
+      ScaleDependentBoundingBox,
+      SupportsReferenceScale,
+      SupportsCallouts,
     };
     typedef QFlags<Qgis::AnnotationItemFlag> AnnotationItemFlags;
 
@@ -1502,7 +1501,7 @@ The development version
 
     enum class AnnotationItemGuiFlag /BaseType=IntFlag/
     {
-        FlagNoCreationTools,
+      FlagNoCreationTools,
     };
     typedef QFlags<Qgis::AnnotationItemGuiFlag> AnnotationItemGuiFlags;
 
@@ -1521,18 +1520,18 @@ The development version
     };
 
     enum class TemporalNavigationMode /BaseType=IntEnum/
-    {
-        Disabled,
-                 Animated,
-                 FixedRange,
-                 Movie,
+      {
+      Disabled,
+      Animated,
+      FixedRange,
+      Movie,
     };
 
     enum class AnimationState /BaseType=IntEnum/
-    {
-        Forward,
-        Reverse,
-        Idle,
+      {
+      Forward,
+      Reverse,
+      Idle,
     };
 
     enum class PlaybackOperation /BaseType=IntEnum/
@@ -1547,13 +1546,13 @@ The development version
     };
 
     enum class VectorTemporalMode /BaseType=IntEnum/
-    {
-        FixedTemporalRange,
-        FeatureDateTimeInstantFromField,
-        FeatureDateTimeStartAndEndFromFields,
-        FeatureDateTimeStartAndDurationFromFields,
-        FeatureDateTimeStartAndEndFromExpressions,
-        RedrawLayerOnly,
+      {
+      FixedTemporalRange,
+      FeatureDateTimeInstantFromField,
+      FeatureDateTimeStartAndEndFromFields,
+      FeatureDateTimeStartAndDurationFromFields,
+      FeatureDateTimeStartAndEndFromExpressions,
+      RedrawLayerOnly,
     };
 
     enum class VectorTemporalLimitMode /BaseType=IntEnum/
@@ -1563,49 +1562,49 @@ The development version
     };
 
     enum class VectorDataProviderTemporalMode /BaseType=IntEnum/
-    {
-        HasFixedTemporalRange,
-        StoresFeatureDateTimeInstantInField,
-        StoresFeatureDateTimeStartAndEndInSeparateFields,
+      {
+      HasFixedTemporalRange,
+      StoresFeatureDateTimeInstantInField,
+      StoresFeatureDateTimeStartAndEndInSeparateFields,
     };
 
     enum class RasterTemporalMode /BaseType=IntEnum/
-    {
-        FixedTemporalRange,
-        TemporalRangeFromDataProvider,
-        RedrawLayerOnly,
-        FixedRangePerBand,
-        RepresentsTemporalValues,
-        FixedDateTime,
+      {
+      FixedTemporalRange,
+      TemporalRangeFromDataProvider,
+      RedrawLayerOnly,
+      FixedRangePerBand,
+      RepresentsTemporalValues,
+      FixedDateTime,
     };
 
     enum class TemporalIntervalMatchMethod /BaseType=IntEnum/
-    {
-        MatchUsingWholeRange,
-        MatchExactUsingStartOfRange,
-        MatchExactUsingEndOfRange,
-        FindClosestMatchToStartOfRange,
-        FindClosestMatchToEndOfRange
+      {
+      MatchUsingWholeRange,
+      MatchExactUsingStartOfRange,
+      MatchExactUsingEndOfRange,
+      FindClosestMatchToStartOfRange,
+      FindClosestMatchToEndOfRange
     };
 
     enum class RasterTemporalCapabilityFlag /BaseType=IntFlag/
     {
-        RequestedTimesMustExactlyMatchAllAvailableTemporalRanges,
+      RequestedTimesMustExactlyMatchAllAvailableTemporalRanges,
     };
 
     typedef QFlags<Qgis::RasterTemporalCapabilityFlag> RasterTemporalCapabilityFlags;
 
 
     enum class TransformDirection /BaseType=IntEnum/
-    {
-        Forward,
-                Reverse
+      {
+      Forward,
+      Reverse
     };
 
     enum class CoordinateTransformationFlag /BaseType=IntFlag/
     {
-        BallparkTransformsAreAppropriate,
-                                         IgnoreImpossibleTransformations,
+      BallparkTransformsAreAppropriate,
+      IgnoreImpossibleTransformations,
     };
 
     typedef QFlags<Qgis::CoordinateTransformationFlag> CoordinateTransformationFlags;
@@ -1620,63 +1619,63 @@ The development version
 
     enum class MapSettingsFlag /BaseType=IntFlag/
     {
-        Antialiasing,
-        DrawEditingInfo,
-        ForceVectorOutput,
-        UseAdvancedEffects,
-        DrawLabeling,
-        UseRenderingOptimization,
-        DrawSelection,
-        DrawSymbolBounds,
-        RenderMapTile,
-        RenderPartialOutput,
-        RenderPreviewJob,
-        RenderBlocking,
-        LosslessImageRendering,
-        Render3DMap,
-        HighQualityImageTransforms,
-        SkipSymbolRendering,
-        ForceRasterMasks,
-        RecordProfile,
-        AlwaysUseGlobalMasks,
+      Antialiasing,
+      DrawEditingInfo,
+      ForceVectorOutput,
+      UseAdvancedEffects,
+      DrawLabeling,
+      UseRenderingOptimization,
+      DrawSelection,
+      DrawSymbolBounds,
+      RenderMapTile,
+      RenderPartialOutput,
+      RenderPreviewJob,
+      RenderBlocking,
+      LosslessImageRendering,
+      Render3DMap,
+      HighQualityImageTransforms,
+      SkipSymbolRendering,
+      ForceRasterMasks,
+      RecordProfile,
+      AlwaysUseGlobalMasks,
     };
     typedef QFlags<Qgis::MapSettingsFlag> MapSettingsFlags;
 
 
     enum class RenderContextFlag /BaseType=IntFlag/
     {
-        DrawEditingInfo,
-        ForceVectorOutput,
-        UseAdvancedEffects,
-        UseRenderingOptimization,
-        DrawSelection,
-        DrawSymbolBounds,
-        RenderMapTile,
-        Antialiasing,
-        RenderPartialOutput,
-        RenderPreviewJob,
-        RenderBlocking,
-        RenderSymbolPreview,
-        LosslessImageRendering,
-        ApplyScalingWorkaroundForTextRendering,
-        Render3DMap,
-        ApplyClipAfterReprojection,
-        RenderingSubSymbol,
-        HighQualityImageTransforms,
-        SkipSymbolRendering,
-        RecordProfile,
-        AlwaysUseGlobalMasks,
-        DisableSymbolClippingToExtent,
-        RenderLayerTree
+      DrawEditingInfo,
+      ForceVectorOutput,
+      UseAdvancedEffects,
+      UseRenderingOptimization,
+      DrawSelection,
+      DrawSymbolBounds,
+      RenderMapTile,
+      Antialiasing,
+      RenderPartialOutput,
+      RenderPreviewJob,
+      RenderBlocking,
+      RenderSymbolPreview,
+      LosslessImageRendering,
+      ApplyScalingWorkaroundForTextRendering,
+      Render3DMap,
+      ApplyClipAfterReprojection,
+      RenderingSubSymbol,
+      HighQualityImageTransforms,
+      SkipSymbolRendering,
+      RecordProfile,
+      AlwaysUseGlobalMasks,
+      DisableSymbolClippingToExtent,
+      RenderLayerTree
     };
     typedef QFlags<Qgis::RenderContextFlag> RenderContextFlags;
 
 
     enum class MapLayerRendererFlag /BaseType=IntFlag/
     {
-        RenderPartialOutputs,
-        RenderPartialOutputOverPreviousCachedImage,
-        AffectsLabeling,
+      RenderPartialOutputs,
+      RenderPartialOutputOverPreviousCachedImage,
+      AffectsLabeling,
     };
 
     typedef QFlags<Qgis::MapLayerRendererFlag> MapLayerRendererFlags;
@@ -1684,7 +1683,7 @@ The development version
 
     enum class PaintEffectFlag /BaseType=IntFlag/
     {
-        RequiresRasterization,
+      RequiresRasterization,
     };
 
     typedef QFlags<Qgis::PaintEffectFlag> PaintEffectFlags;
@@ -1692,74 +1691,74 @@ The development version
 
 
     enum class TextRenderFormat /BaseType=IntEnum/
-    {
-        AlwaysOutlines,
-                       AlwaysText,
-                       PreferText,
+      {
+      AlwaysOutlines,
+      AlwaysText,
+      PreferText,
     };
 
     enum class LabelingFlag /BaseType=IntFlag/
     {
-        UseAllLabels,
-        UsePartialCandidates,
-        // TODO QGIS 5.0: remove
-        RenderOutlineLabels,
-        DrawLabelRectOnly,
-        DrawCandidates,
-        DrawUnplacedLabels,
-        CollectUnplacedLabels,
-        DrawLabelMetrics,
+      UseAllLabels,
+      UsePartialCandidates,
+      // TODO QGIS 5.0: remove
+      RenderOutlineLabels,
+      DrawLabelRectOnly,
+      DrawCandidates,
+      DrawUnplacedLabels,
+      CollectUnplacedLabels,
+      DrawLabelMetrics,
     };
 
     typedef QFlags<Qgis::LabelingFlag> LabelingFlags;
 
 
     enum class LabelPlacementEngineVersion /BaseType=IntEnum/
-    {
-        Version1,
-                 Version2,
+      {
+      Version1,
+      Version2,
     };
 
     enum class TextOrientation /BaseType=IntEnum/
-    {
-        Horizontal,
-                   Vertical,
-                   RotationBased,
+      {
+      Horizontal,
+      Vertical,
+      RotationBased,
     };
 
     enum class TextLayoutMode /BaseType=IntEnum/
-    {
-        Rectangle,
-                  Point,
-                  Labeling,
-                  RectangleCapHeightBased,
-                  RectangleAscentBased,
+      {
+      Rectangle,
+      Point,
+      Labeling,
+      RectangleCapHeightBased,
+      RectangleAscentBased,
     };
 
     enum class TextComponent /BaseType=IntFlag/
     {
-        Text,
-        Buffer,
-        Background,
-        Shadow,
+      Text,
+      Buffer,
+      Background,
+      Shadow,
     };
 
     typedef QFlags<Qgis::TextComponent> TextComponents;
 
 
     enum class TextHorizontalAlignment /BaseType=IntEnum/
-    {
-        Left,
-             Center,
-             Right,
-             Justify,
+      {
+      Left,
+      Center,
+      Right,
+      Justify,
     };
 
     enum class TextVerticalAlignment /BaseType=IntEnum/
-    {
-        Top,
-            VerticalCenter,
-            Bottom,
+      {
+      Top,
+      VerticalCenter,
+      Bottom,
     };
 
     enum class TextCharacterVerticalAlignment /BaseType=IntEnum/
@@ -1771,29 +1770,29 @@ The development version
 
     enum class CurvedTextFlag /BaseType=IntFlag/
     {
-        TruncateStringWhenLineIsTooShort,
-        UseBaselinePlacement,
-        UprightCharactersOnly,
-        ExtendLineToFitText,
+      TruncateStringWhenLineIsTooShort,
+      UseBaselinePlacement,
+      UprightCharactersOnly,
+      ExtendLineToFitText,
     };
 
     typedef QFlags<Qgis::CurvedTextFlag> CurvedTextFlags;
 
 
     enum class VectorSimplificationAlgorithm /BaseType=IntEnum/
-    {
-        Distance,
-        SnapToGrid,
-        Visvalingam,
-        SnappedToGridGlobal,
+      {
+      Distance,
+      SnapToGrid,
+      Visvalingam,
+      SnappedToGridGlobal,
     };
 
     enum class VectorRenderingSimplificationFlag /BaseType=IntFlag/
     {
-        NoSimplification,
-        GeometrySimplification,
-        AntialiasingSimplification,
-        FullSimplification,
+      NoSimplification,
+      GeometrySimplification,
+      AntialiasingSimplification,
+      FullSimplification,
     };
 
     typedef QFlags<Qgis::VectorRenderingSimplificationFlag> VectorRenderingSimplificationFlags;
@@ -1814,73 +1813,73 @@ The development version
     };
 
     enum class VertexType /BaseType=IntEnum/
-    {
-        Segment,
-        Curve,
+      {
+      Segment,
+      Curve,
       ControlPoint,
     };
 
     enum class MarkerShape /BaseType=IntEnum/
-    {
-        Square,
-        Diamond,
-        Pentagon,
-        Hexagon,
-        Triangle,
-        EquilateralTriangle,
-        Star,
-        Arrow,
-        Circle,
-        Cross,
-        CrossFill,
-        Cross2,
-        Line,
-        ArrowHead,
-        ArrowHeadFilled,
-        SemiCircle,
-        ThirdCircle,
-        QuarterCircle,
-        QuarterSquare,
-        HalfSquare,
-        DiagonalHalfSquare,
-        RightHalfTriangle,
-        LeftHalfTriangle,
-        Octagon,
-        SquareWithCorners,
-        AsteriskFill,
-        HalfArc,
-        ThirdArc,
-        QuarterArc,
-        ParallelogramRight,
-        ParallelogramLeft,
-        Trapezoid,
-        Shield,
-        DiamondStar,
-        Heart,
-        Decagon,
-        RoundedSquare,
+      {
+      Square,
+      Diamond,
+      Pentagon,
+      Hexagon,
+      Triangle,
+      EquilateralTriangle,
+      Star,
+      Arrow,
+      Circle,
+      Cross,
+      CrossFill,
+      Cross2,
+      Line,
+      ArrowHead,
+      ArrowHeadFilled,
+      SemiCircle,
+      ThirdCircle,
+      QuarterCircle,
+      QuarterSquare,
+      HalfSquare,
+      DiagonalHalfSquare,
+      RightHalfTriangle,
+      LeftHalfTriangle,
+      Octagon,
+      SquareWithCorners,
+      AsteriskFill,
+      HalfArc,
+      ThirdArc,
+      QuarterArc,
+      ParallelogramRight,
+      ParallelogramLeft,
+      Trapezoid,
+      Shield,
+      DiamondStar,
+      Heart,
+      Decagon,
+      RoundedSquare,
     };
 
     enum class MarkerLinePlacement /BaseType=IntFlag/
     {
-        Interval,
-        Vertex,
-        LastVertex,
-        FirstVertex,
-        CentralPoint,
-        CurvePoint,
-        SegmentCenter,
-        InnerVertices,
+      Interval,
+      Vertex,
+      LastVertex,
+      FirstVertex,
+      CentralPoint,
+      CurvePoint,
+      SegmentCenter,
+      InnerVertices,
     };
     typedef QFlags<Qgis::MarkerLinePlacement> MarkerLinePlacements;
 
 
     enum class LinearReferencingPlacement /BaseType=IntFlag/
     {
-        IntervalCartesian2D,
-        IntervalZ,
-        IntervalM,
-        Vertex,
+      IntervalCartesian2D,
+      IntervalZ,
+      IntervalM,
+      Vertex,
     };
 
     enum class LinearReferencingLabelSource /BaseType=IntEnum/
@@ -1891,35 +1890,35 @@ The development version
     };
 
     enum class GradientColorSource /BaseType=IntEnum/
-    {
-        SimpleTwoColor,
-        ColorRamp,
+      {
+      SimpleTwoColor,
+      ColorRamp,
     };
 
     enum class GradientType /BaseType=IntEnum/
-    {
-        Linear,
-        Radial,
-        Conical,
+      {
+      Linear,
+      Radial,
+      Conical,
     };
 
     enum class SymbolCoordinateReference /BaseType=IntEnum/
-    {
-        Feature,
-        Viewport,
+      {
+      Feature,
+      Viewport,
     };
 
     enum class GradientSpread /BaseType=IntEnum/
-    {
-        Pad,
-        Reflect,
-        Repeat,
+      {
+      Pad,
+      Reflect,
+      Repeat,
     };
 
     enum class PointCountMethod /BaseType=IntEnum/
-    {
-        Absolute,
-                 DensityBased,
+      {
+      Absolute,
+      DensityBased,
     };
 
     enum class MarkerClipMode /BaseType=IntEnum/
@@ -1954,9 +1953,9 @@ The development version
     };
 
     enum class GraduatedMethod /BaseType=IntEnum/
-    {
-        Color,
-              Size,
+      {
+      Color,
+      Size,
     };
 
     enum class PlotAxisSuffixPlacement
@@ -2000,20 +1999,20 @@ The development version
 
 
     enum class Capitalization /BaseType=IntEnum/
-    {
-        MixedCase,
-        AllUppercase,
-        AllLowercase,
-        ForceFirstLetterToCapital,
-        SmallCaps,
-        TitleCase,
-        UpperCamelCase,
-        AllSmallCaps,
+      {
+      MixedCase,
+      AllUppercase,
+      AllLowercase,
+      ForceFirstLetterToCapital,
+      SmallCaps,
+      TitleCase,
+      UpperCamelCase,
+      AllSmallCaps,
     };
 
     enum class TextRendererFlag /BaseType=IntFlag/
     {
-        WrapLines,
+      WrapLines,
     };
     typedef QFlags<Qgis::TextRendererFlag> TextRendererFlags;
 
@@ -2025,10 +2024,10 @@ The development version
     };
 
     enum class AngularDirection /BaseType=IntEnum/
-    {
-        Clockwise,
-        CounterClockwise,
-        NoOrientation,
+      {
+      Clockwise,
+      CounterClockwise,
+      NoOrientation,
     };
 
     enum class RendererUsage /BaseType=IntEnum/
@@ -2040,7 +2039,7 @@ The development version
 
     enum class MapCanvasFlag /BaseType=IntFlag/
     {
-        ShowMainAnnotationLayer,
+      ShowMainAnnotationLayer,
     };
 
     typedef QFlags<Qgis::MapCanvasFlag> MapCanvasFlags;
@@ -2048,8 +2047,8 @@ The development version
 
     enum class ViewSyncModeFlag /BaseType=IntFlag/
     {
-        Sync3DTo2D,
-        Sync2DTo3D,
+      Sync3DTo2D,
+      Sync2DTo3D,
     };
     typedef QFlags<Qgis::ViewSyncModeFlag> ViewSyncModeFlags;
 
@@ -2063,7 +2062,7 @@ The development version
 
     enum class HistoryProviderBackend /BaseType=IntFlag/
     {
-        LocalProfile,
+      LocalProfile,
 //      Project = 1 << 1, //!< QGIS Project  (not yet implemented)
     };
     typedef QFlags<Qgis::HistoryProviderBackend> HistoryProviderBackends;
@@ -2076,28 +2075,28 @@ The development version
     };
 
     enum class ProcessingSourceType /BaseType=IntEnum/
-    {
-        MapLayer,
-        VectorAnyGeometry,
-        VectorPoint,
-        VectorLine,
-        VectorPolygon,
-        Raster,
-        File,
-        Vector,
-        Mesh,
-        Plugin,
-        PointCloud,
-        Annotation,
-        VectorTile,
-        TiledScene
+      {
+      MapLayer,
+      VectorAnyGeometry,
+      VectorPoint,
+      VectorLine,
+      VectorPolygon,
+      Raster,
+      File,
+      Vector,
+      Mesh,
+      Plugin,
+      PointCloud,
+      Annotation,
+      VectorTile,
+      TiledScene
     };
 
 
     enum class ProcessingProviderFlag /BaseType=IntFlag/
     {
-        DeemphasiseSearchResults,
-        CompatibleWithVirtualRaster,
+      DeemphasiseSearchResults,
+      CompatibleWithVirtualRaster,
     };
 
     typedef QFlags<Qgis::ProcessingProviderFlag> ProcessingProviderFlags;
@@ -2105,22 +2104,22 @@ The development version
 
     enum class ProcessingAlgorithmFlag /BaseType=IntFlag/
     {
-        HideFromToolbox,
-        HideFromModeler,
-        SupportsBatch,
-        CanCancel,
-        RequiresMatchingCrs,
-        NoThreading,
-        DisplayNameIsLiteral,
-        SupportsInPlaceEdits,
-        KnownIssues,
-        CustomException,
-        PruneModelBranchesBasedOnAlgorithmResults,
-        SkipGenericModelLogging,
-        NotAvailableInStandaloneTool,
-        RequiresProject,
-        SecurityRisk,
-        Deprecated,
+      HideFromToolbox,
+      HideFromModeler,
+      SupportsBatch,
+      CanCancel,
+      RequiresMatchingCrs,
+      NoThreading,
+      DisplayNameIsLiteral,
+      SupportsInPlaceEdits,
+      KnownIssues,
+      CustomException,
+      PruneModelBranchesBasedOnAlgorithmResults,
+      SkipGenericModelLogging,
+      NotAvailableInStandaloneTool,
+      RequiresProject,
+      SecurityRisk,
+      Deprecated,
     };
 
     typedef QFlags<Qgis::ProcessingAlgorithmFlag> ProcessingAlgorithmFlags;
@@ -2128,25 +2127,25 @@ The development version
 
     enum class ProcessingAlgorithmDocumentationFlag /BaseType=IntFlag/
     {
-        RegeneratesPrimaryKey,
-        RegeneratesPrimaryKeyInSomeScenarios,
-        RespectsEllipsoid,
+      RegeneratesPrimaryKey,
+      RegeneratesPrimaryKeyInSomeScenarios,
+      RespectsEllipsoid,
     };
 
     typedef QFlags<Qgis::ProcessingAlgorithmDocumentationFlag> ProcessingAlgorithmDocumentationFlags;
 
 
     enum class ProcessingPropertyAvailability /BaseType=IntEnum/
-    {
-        NotAvailable,
-        Available,
+      {
+      NotAvailable,
+      Available,
     };
 
     enum class ProcessingLogLevel /BaseType=IntEnum/
-    {
-        DefaultLevel,
-        Verbose,
-        ModelDebug,
+      {
+      DefaultLevel,
+      Verbose,
+      ModelDebug,
     };
 
     enum class ProcessingMode
@@ -2158,8 +2157,8 @@ The development version
 
     enum class ProcessingFeatureSourceDefinitionFlag /BaseType=IntFlag/
     {
-        OverrideDefaultGeometryCheck,
-        CreateIndividualOutputPerInputFeature,
+      OverrideDefaultGeometryCheck,
+      CreateIndividualOutputPerInputFeature,
     };
 
     typedef QFlags<Qgis::ProcessingFeatureSourceDefinitionFlag> ProcessingFeatureSourceDefinitionFlags;
@@ -2167,7 +2166,7 @@ The development version
 
     enum class ProcessingFeatureSourceFlag /BaseType=IntFlag/
     {
-        SkipGeometryValidityChecks,
+      SkipGeometryValidityChecks,
     };
 
     typedef QFlags<Qgis::ProcessingFeatureSourceFlag> ProcessingFeatureSourceFlags;
@@ -2175,7 +2174,7 @@ The development version
 
     enum class ProcessingParameterTypeFlag /BaseType=IntFlag/
     {
-        ExposeToModeler
+      ExposeToModeler
     };
 
     typedef QFlags<Qgis::ProcessingParameterTypeFlag> ProcessingParameterTypeFlags;
@@ -2183,42 +2182,42 @@ The development version
 
     enum class ProcessingParameterFlag /BaseType=IntFlag/
     {
-        Advanced,
-        Hidden,
-        Optional,
-        IsModelOutput,
+      Advanced,
+      Hidden,
+      Optional,
+      IsModelOutput,
     };
 
     typedef QFlags<Qgis::ProcessingParameterFlag> ProcessingParameterFlags;
 
 
     enum class ProcessingFileParameterBehavior /BaseType=IntEnum/
-    {
-        File,
-        Folder,
+      {
+      File,
+      Folder,
     };
 
     enum class ProcessingNumberParameterType /BaseType=IntEnum/
-    {
-        Integer,
-        Double,
+      {
+      Integer,
+      Double,
     };
 
     enum class ProcessingFieldParameterDataType /BaseType=IntEnum/
-    {
-        Any,
-        Numeric,
-        String,
-        DateTime,
-        Binary,
-        Boolean,
+      {
+      Any,
+      Numeric,
+      String,
+      DateTime,
+      Binary,
+      Boolean,
     };
 
     enum class ProcessingDateTimeParameterDataType /BaseType=IntEnum/
-    {
-        DateTime,
-        Date,
-        Time,
+      {
+      DateTime,
+      Date,
+      Time,
     };
 
     enum class ProcessingModelChildParameterSource /BaseType=IntEnum/
@@ -2239,16 +2238,16 @@ The development version
     };
 
     enum class ProcessingTinInputLayerType /BaseType=IntEnum/
-    {
-        Vertices,
-        StructureLines,
-        BreakLines
+      {
+      Vertices,
+      StructureLines,
+      BreakLines
     };
 
     enum class CrsDefinitionFormat /BaseType=IntEnum/
-    {
-        Wkt,
-            Proj,
+      {
+      Wkt,
+      Proj,
     };
 
     enum class FieldDomainSplitPolicy /BaseType=IntEnum/
@@ -2363,17 +2362,17 @@ The development version
 
     enum class ProjectFlag /BaseType=IntFlag/
     {
-        EvaluateDefaultValuesOnProviderSide,
-        TrustStoredLayerStatistics,
-        RememberLayerEditStatusBetweenSessions,
-        RememberAttributeTableWindowsBetweenSessions,
+      EvaluateDefaultValuesOnProviderSide,
+      TrustStoredLayerStatistics,
+      RememberLayerEditStatusBetweenSessions,
+      RememberAttributeTableWindowsBetweenSessions,
     };
     typedef QFlags<Qgis::ProjectFlag> ProjectFlags;
 
 
     enum class PlotToolFlag /BaseType=IntFlag/
     {
-        ShowContextMenu,
+      ShowContextMenu,
     };
     typedef QFlags<Qgis::PlotToolFlag> PlotToolFlags;
 
@@ -2439,9 +2438,9 @@ The development version
 
     enum class ProfileGeneratorFlag /BaseType=IntFlag/
     {
-        RespectsMaximumErrorMapUnit,
-                                    RespectsDistanceRange,
-                                    RespectsElevationRange,
+      RespectsMaximumErrorMapUnit,
+      RespectsDistanceRange,
+      RespectsElevationRange,
     };
     typedef QFlags<Qgis::ProfileGeneratorFlag> ProfileGeneratorFlags;
 
@@ -2454,41 +2453,41 @@ The development version
     };
 
     enum class PointCloudSymbol /BaseType=IntEnum/
-    {
-        Square,
-        Circle,
+      {
+      Square,
+      Circle,
     };
 
     enum class PointCloudDrawOrder /BaseType=IntEnum/
-    {
-        Default,
-        BottomToTop,
-        TopToBottom,
+      {
+      Default,
+      BottomToTop,
+      TopToBottom,
     };
 
     enum class AvoidIntersectionsMode /BaseType=IntEnum/
-    {
-        AllowIntersections,
-        AvoidIntersectionsCurrentLayer,
-        AvoidIntersectionsLayers,
+      {
+      AllowIntersections,
+      AvoidIntersectionsCurrentLayer,
+      AvoidIntersectionsLayers,
     };
 
     enum class ProjectFileFormat /BaseType=IntEnum/
-    {
-        Qgz,
-        Qgs,
+      {
+      Qgz,
+      Qgs,
     };
 
     enum class ProjectReadFlag /BaseType=IntFlag/
     {
-        DontResolveLayers,
-        DontLoadLayouts,
-        TrustLayerMetadata,
-        DontStoreOriginalStyles,
-        DontLoad3DViews,
-        DontLoadProjectStyles,
-        ForceReadOnlyLayers,
-        DontUpgradeAnnotations,
+      DontResolveLayers,
+      DontLoadLayouts,
+      TrustLayerMetadata,
+      DontStoreOriginalStyles,
+      DontLoad3DViews,
+      DontLoadProjectStyles,
+      ForceReadOnlyLayers,
+      DontUpgradeAnnotations,
     };
 
     typedef QFlags<Qgis::ProjectReadFlag> ProjectReadFlags;
@@ -2496,7 +2495,7 @@ The development version
 
     enum class ProjectCapability /BaseType=IntFlag/
     {
-        ProjectStyles,
+      ProjectStyles,
     };
 
     typedef QFlags<Qgis::ProjectCapability> ProjectCapabilities;
@@ -2514,27 +2513,27 @@ The development version
     };
 
     enum class ArcGisRestServiceType /BaseType=IntEnum/
-    {
-        FeatureServer,
-                      MapServer,
-                      ImageServer,
-                      GlobeServer,
-                      GPServer,
-                      GeocodeServer,
-                      Unknown,
-                      SceneServer,
+      {
+      FeatureServer,
+      MapServer,
+      ImageServer,
+      GlobeServer,
+      GPServer,
+      GeocodeServer,
+      Unknown,
+      SceneServer,
     };
 
     enum class RelationshipType /BaseType=IntEnum/
-    {
-        Normal,
-        Generated,
+      {
+      Normal,
+      Generated,
     };
 
     enum class RelationshipStrength /BaseType=IntEnum/
-    {
-        Association,
-        Composition,
+      {
+      Association,
+      Composition,
     };
 
     enum class RelationshipCardinality /BaseType=IntEnum/
@@ -2547,9 +2546,9 @@ The development version
 
     enum class RelationshipCapability /BaseType=IntFlag/
     {
-        MultipleFieldKeys,
-        ForwardPathLabel,
-        BackwardPathLabel,
+      MultipleFieldKeys,
+      ForwardPathLabel,
+      BackwardPathLabel,
     };
 
     typedef QFlags<Qgis::RelationshipCapability> RelationshipCapabilities;
@@ -2586,9 +2585,9 @@ The development version
 
     enum class ScriptLanguageCapability /BaseType=IntFlag/
     {
-        Reformat,
-        CheckSyntax,
-        ToggleComment,
+      Reformat,
+      CheckSyntax,
+      ToggleComment,
     };
 
     typedef QFlags<Qgis::ScriptLanguageCapability> ScriptLanguageCapabilities;
@@ -2603,7 +2602,7 @@ The development version
 
     enum class LayerTreeFilterFlag /BaseType=IntFlag/
     {
-        SkipVisibilityCheck,
+      SkipVisibilityCheck,
     };
 
     typedef QFlags<Qgis::LayerTreeFilterFlag> LayerTreeFilterFlags;
@@ -2611,21 +2610,21 @@ The development version
 
     enum class MapLayerLegendFlag /BaseType=IntFlag/
     {
-        ExcludeByDefault,
+      ExcludeByDefault,
     };
 
     typedef QFlags<Qgis::MapLayerLegendFlag> MapLayerLegendFlags;
 
 
     enum class LegendComponent /BaseType=IntEnum/
-    {
-        Undefined,
-        Hidden,
-        Title,
-        Group,
-        Subgroup,
-        Symbol,
-        SymbolLabel,
+      {
+      Undefined,
+      Hidden,
+      Title,
+      Group,
+      Subgroup,
+      Symbol,
+      SymbolLabel,
     };
 
     enum class LegendSyncMode /BaseType=IntEnum/
@@ -2637,7 +2636,7 @@ The development version
 
     enum class LegendJsonRenderFlag /BaseType=IntFlag/
     {
-        ShowRuleDetails,
+      ShowRuleDetails,
     };
     typedef QFlags<Qgis::LegendJsonRenderFlag> LegendJsonRenderFlags;
 
@@ -2651,10 +2650,10 @@ The development version
 
     enum class MapLayerActionTarget /BaseType=IntFlag/
     {
-        Layer,
-        SingleFeature,
-        MultipleFeatures,
-        AllActions
+      Layer,
+      SingleFeature,
+      MultipleFeatures,
+      AllActions
     };
 
     typedef QFlags<Qgis::MapLayerActionTarget> MapLayerActionTargets;
@@ -2662,23 +2661,23 @@ The development version
 
     enum class MapLayerActionFlag /BaseType=IntFlag/
     {
-        EnabledOnlyWhenEditable,
-        EnableOnlyWhenHasGeometry,
+      EnabledOnlyWhenEditable,
+      EnableOnlyWhenHasGeometry,
     };
 
     typedef QFlags<Qgis::MapLayerActionFlag> MapLayerActionFlags;
 
 
     enum class AttributeActionType /BaseType=IntEnum/
-    {
-        Generic,
-        GenericPython,
-        Mac,
-        Windows,
-        Unix,
-        OpenUrl,
-        SubmitUrlEncoded,
-        SubmitUrlMultipart,
+      {
+      Generic,
+      GenericPython,
+      Mac,
+      Windows,
+      Unix,
+      OpenUrl,
+      SubmitUrlEncoded,
+      SubmitUrlMultipart,
     };
 
     enum class MetadataDateType
@@ -2691,108 +2690,108 @@ The development version
 
 
     enum class RasterColorInterpretation /BaseType=IntEnum/
-    {
-        Undefined,
-        GrayIndex,
-        PaletteIndex,
-        RedBand,
-        GreenBand,
-        BlueBand,
-        AlphaBand,
-        HueBand,
-        SaturationBand,
-        LightnessBand,
-        CyanBand,
-        MagentaBand,
-        YellowBand,
-        BlackBand,
-        YCbCr_YBand,
-        YCbCr_CbBand,
-        YCbCr_CrBand,
-        ContinuousPalette,
+      {
+      Undefined,
+      GrayIndex,
+      PaletteIndex,
+      RedBand,
+      GreenBand,
+      BlueBand,
+      AlphaBand,
+      HueBand,
+      SaturationBand,
+      LightnessBand,
+      CyanBand,
+      MagentaBand,
+      YellowBand,
+      BlackBand,
+      YCbCr_YBand,
+      YCbCr_CbBand,
+      YCbCr_CrBand,
+      ContinuousPalette,
 
-        // Note: values between PanBand and SAR_P_Band match additions done in
-        // GDAL 3.10, except that the numeric values of the constant don't match GDAL ones
+      // Note: values between PanBand and SAR_P_Band match additions done in
+      // GDAL 3.10, except that the numeric values of the constant don't match GDAL ones
 
-        PanBand,
-        CoastalBand,
-        RedEdgeBand,
-        NIRBand,
-        SWIRBand,
-        MWIRBand,
-        LWIRBand,
-        TIRBand,
-        OtherIRBand,
-        SAR_Ka_Band,
-        SAR_K_Band,
-        SAR_Ku_Band,
-        SAR_X_Band,
-        SAR_C_Band,
-        SAR_S_Band,
-        SAR_L_Band,
-        SAR_P_Band,
+      PanBand,
+      CoastalBand,
+      RedEdgeBand,
+      NIRBand,
+      SWIRBand,
+      MWIRBand,
+      LWIRBand,
+      TIRBand,
+      OtherIRBand,
+      SAR_Ka_Band,
+      SAR_K_Band,
+      SAR_Ku_Band,
+      SAR_X_Band,
+      SAR_C_Band,
+      SAR_S_Band,
+      SAR_L_Band,
+      SAR_P_Band,
     };
 
     enum class RasterLayerType /BaseType=IntEnum/
-    {
-        GrayOrUndefined,
-        Palette,
-        MultiBand,
-        SingleBandColorData,
+      {
+      GrayOrUndefined,
+      Palette,
+      MultiBand,
+      SingleBandColorData,
     };
 
     enum class RasterDrawingStyle /BaseType=IntEnum/
-    {
-        Undefined,
-                  SingleBandGray,
-                  SingleBandPseudoColor,
-                  PalettedColor,
-                  PalettedSingleBandGray,
-                  PalettedSingleBandPseudoColor,
-                  PalettedMultiBandColor,
-                  MultiBandSingleBandGray,
-                  MultiBandSingleBandPseudoColor,
-                  MultiBandColor,
-                  SingleBandColorData,
+      {
+      Undefined,
+      SingleBandGray,
+      SingleBandPseudoColor,
+      PalettedColor,
+      PalettedSingleBandGray,
+      PalettedSingleBandPseudoColor,
+      PalettedMultiBandColor,
+      MultiBandSingleBandGray,
+      MultiBandSingleBandPseudoColor,
+      MultiBandColor,
+      SingleBandColorData,
     };
 
     enum class RasterPyramidFormat /BaseType=IntEnum/
-    {
-        GeoTiff,
-        Internal,
-        Erdas
+      {
+      GeoTiff,
+      Internal,
+      Erdas
     };
 
     enum class RasterBuildPyramidOption /BaseType=IntEnum/
-    {
-        No,
-        Yes,
-        CopyExisting
+      {
+      No,
+      Yes,
+      CopyExisting
     };
 
     enum class RasterIdentifyFormat /BaseType=IntFlag/
     {
-        Undefined,
-        Value,
-        Text,
-        Html,
-        Feature,
+      Undefined,
+      Value,
+      Text,
+      Html,
+      Feature,
     };
 
 
     enum class RasterInterfaceCapability /BaseType=IntFlag/
     {
-        NoCapabilities,
-        Size,
-        Create,
-        Remove,
-        BuildPyramids,
-        Identify,
-        IdentifyValue,
-        IdentifyText,
-        IdentifyHtml,
-        IdentifyFeature,
-        Prefetch,
+      NoCapabilities,
+      Size,
+      Create,
+      Remove,
+      BuildPyramids,
+      Identify,
+      IdentifyValue,
+      IdentifyText,
+      IdentifyHtml,
+      IdentifyFeature,
+      Prefetch,
     };
 
     typedef QFlags<Qgis::RasterInterfaceCapability> RasterInterfaceCapabilities;
@@ -2801,15 +2800,15 @@ The development version
 
     enum class RasterProviderCapability /BaseType=IntFlag/
     {
-        NoProviderCapabilities,
-        ReadLayerMetadata,
-        WriteLayerMetadata,
-        ProviderHintBenefitsFromResampling,
-        ProviderHintCanPerformProviderResampling,
-        ReloadData,
-        DpiDependentData,
-        NativeRasterAttributeTable,
-        BuildPyramids,
+      NoProviderCapabilities,
+      ReadLayerMetadata,
+      WriteLayerMetadata,
+      ProviderHintBenefitsFromResampling,
+      ProviderHintCanPerformProviderResampling,
+      ReloadData,
+      DpiDependentData,
+      NativeRasterAttributeTable,
+      BuildPyramids,
     };
 
     typedef QFlags<Qgis::RasterProviderCapability> RasterProviderCapabilities;
@@ -2822,234 +2821,234 @@ The development version
     };
 
     enum class BlendMode /BaseType=IntEnum/
-    {
-        Normal,
-               Lighten,
-               Screen,
-               Dodge,
-               Addition,
-               Darken,
-               Multiply,
-               Burn,
-               Overlay,
-               SoftLight,
-               HardLight,
-               Difference,
-               Subtract,
-               Source,
-               DestinationOver,
-               Clear,
-               Destination,
-               SourceIn,
-               DestinationIn,
-               SourceOut,
-               DestinationOut,
-               SourceAtop,
-               DestinationAtop,
-               Xor,
+      {
+      Normal,
+      Lighten,
+      Screen,
+      Dodge,
+      Addition,
+      Darken,
+      Multiply,
+      Burn,
+      Overlay,
+      SoftLight,
+      HardLight,
+      Difference,
+      Subtract,
+      Source,
+      DestinationOver,
+      Clear,
+      Destination,
+      SourceIn,
+      DestinationIn,
+      SourceOut,
+      DestinationOut,
+      SourceAtop,
+      DestinationAtop,
+      Xor,
     };
 
     enum class SystemOfMeasurement /BaseType=IntEnum/
-    {
-        Unknown,
-        Metric,
-        Imperial,
-        USCS,
+      {
+      Unknown,
+      Metric,
+      Imperial,
+      USCS,
     };
 
     enum class MapToolUnit /BaseType=IntEnum/
-    {
-        Layer,
-              Pixels,
-              Project
+      {
+      Layer,
+      Pixels,
+      Project
     };
 
     enum class UnitType /BaseType=IntEnum/
-    {
-        Distance,
-        Area,
-        Volume,
-        Unknown,
-        Temporal,
+      {
+      Distance,
+      Area,
+      Volume,
+      Unknown,
+      Temporal,
     };
 
     enum class DistanceUnit /BaseType=IntEnum/
-    {
-        Meters,
-               Kilometers,
-               Feet,
-               NauticalMiles,
-               Yards,
-               Miles,
-               Degrees,
-               Centimeters,
-               Millimeters,
-               Inches,
-               ChainsInternational,
-               ChainsBritishBenoit1895A,
-               ChainsBritishBenoit1895B,
-               ChainsBritishSears1922Truncated,
-               ChainsBritishSears1922,
-               ChainsClarkes,
-               ChainsUSSurvey,
-               FeetBritish1865,
-               FeetBritish1936,
-               FeetBritishBenoit1895A,
-               FeetBritishBenoit1895B,
-               FeetBritishSears1922Truncated,
-               FeetBritishSears1922,
-               FeetClarkes,
-               FeetGoldCoast,
-               FeetIndian,
-               FeetIndian1937,
-               FeetIndian1962,
-               FeetIndian1975,
-               FeetUSSurvey,
-               LinksInternational,
-               LinksBritishBenoit1895A,
-               LinksBritishBenoit1895B,
-               LinksBritishSears1922Truncated,
-               LinksBritishSears1922,
-               LinksClarkes,
-               LinksUSSurvey,
-               YardsBritishBenoit1895A,
-               YardsBritishBenoit1895B,
-               YardsBritishSears1922Truncated,
-               YardsBritishSears1922,
-               YardsClarkes,
-               YardsIndian,
-               YardsIndian1937,
-               YardsIndian1962,
-               YardsIndian1975,
-               MilesUSSurvey,
-               Fathoms,
-               MetersGermanLegal,
-               Unknown,
+      {
+      Meters,
+      Kilometers,
+      Feet,
+      NauticalMiles,
+      Yards,
+      Miles,
+      Degrees,
+      Centimeters,
+      Millimeters,
+      Inches,
+      ChainsInternational,
+      ChainsBritishBenoit1895A,
+      ChainsBritishBenoit1895B,
+      ChainsBritishSears1922Truncated,
+      ChainsBritishSears1922,
+      ChainsClarkes,
+      ChainsUSSurvey,
+      FeetBritish1865,
+      FeetBritish1936,
+      FeetBritishBenoit1895A,
+      FeetBritishBenoit1895B,
+      FeetBritishSears1922Truncated,
+      FeetBritishSears1922,
+      FeetClarkes,
+      FeetGoldCoast,
+      FeetIndian,
+      FeetIndian1937,
+      FeetIndian1962,
+      FeetIndian1975,
+      FeetUSSurvey,
+      LinksInternational,
+      LinksBritishBenoit1895A,
+      LinksBritishBenoit1895B,
+      LinksBritishSears1922Truncated,
+      LinksBritishSears1922,
+      LinksClarkes,
+      LinksUSSurvey,
+      YardsBritishBenoit1895A,
+      YardsBritishBenoit1895B,
+      YardsBritishSears1922Truncated,
+      YardsBritishSears1922,
+      YardsClarkes,
+      YardsIndian,
+      YardsIndian1937,
+      YardsIndian1962,
+      YardsIndian1975,
+      MilesUSSurvey,
+      Fathoms,
+      MetersGermanLegal,
+      Unknown,
     };
 
     enum class DistanceUnitType /BaseType=IntEnum/
-    {
-        Standard,
-        Geographic,
-        Unknown,
+      {
+      Standard,
+      Geographic,
+      Unknown,
     };
 
     enum class AreaUnit /BaseType=IntEnum/
-    {
-        SquareMeters,
-                     SquareKilometers,
-                     SquareFeet,
-                     SquareYards,
-                     SquareMiles,
-                     Hectares,
-                     Acres,
-                     SquareNauticalMiles,
-                     SquareDegrees,
-                     SquareCentimeters,
-                     SquareMillimeters,
-                     SquareInches,
-                     Unknown,
+      {
+      SquareMeters,
+      SquareKilometers,
+      SquareFeet,
+      SquareYards,
+      SquareMiles,
+      Hectares,
+      Acres,
+      SquareNauticalMiles,
+      SquareDegrees,
+      SquareCentimeters,
+      SquareMillimeters,
+      SquareInches,
+      Unknown,
     };
 
     enum class VolumeUnit /BaseType=IntEnum/
-    {
-        CubicMeters,
-                    CubicFeet,
-                    CubicYards,
-                    Barrel,
-                    CubicDecimeter,
-                    Liters,
-                    GallonUS,
-                    CubicInch,
-                    CubicCentimeter,
-                    CubicDegrees,
-                    Unknown,
+      {
+      CubicMeters,
+      CubicFeet,
+      CubicYards,
+      Barrel,
+      CubicDecimeter,
+      Liters,
+      GallonUS,
+      CubicInch,
+      CubicCentimeter,
+      CubicDegrees,
+      Unknown,
     };
 
     enum class AngleUnit /BaseType=IntEnum/
-    {
-        Degrees,
-                Radians,
-                Gon,
-                MinutesOfArc,
-                SecondsOfArc,
-                Turn,
-                MilliradiansSI,
-                MilNATO,
-                Unknown,
+      {
+      Degrees,
+      Radians,
+      Gon,
+      MinutesOfArc,
+      SecondsOfArc,
+      Turn,
+      MilliradiansSI,
+      MilNATO,
+      Unknown,
     };
 
     enum class TemporalUnit /BaseType=IntEnum/
-    {
-        Milliseconds,
-                     Seconds,
-                     Minutes,
-                     Hours,
-                     Days,
-                     Weeks,
-                     Months,
-                     Years,
-                     Decades,
-                     Centuries,
-                     IrregularStep,
-                     Unknown
+      {
+      Milliseconds,
+      Seconds,
+      Minutes,
+      Hours,
+      Days,
+      Weeks,
+      Months,
+      Years,
+      Decades,
+      Centuries,
+      IrregularStep,
+      Unknown
     };
 
     enum class RenderUnit /BaseType=IntEnum/
-    {
-        Millimeters,
-                    MapUnits,
-                    Pixels,
-                    Percentage,
-                    Points,
-                    Inches,
-                    Unknown,
-                    MetersInMapUnits,
+      {
+      Millimeters,
+      MapUnits,
+      Pixels,
+      Percentage,
+      Points,
+      Inches,
+      Unknown,
+      MetersInMapUnits,
     };
 
     enum class LayoutUnit /BaseType=IntEnum/
-    {
-        Millimeters,
-                    Centimeters,
-                    Meters,
-                    Inches,
-                    Feet,
-                    Points,
-                    Picas,
-                    Pixels
+      {
+      Millimeters,
+      Centimeters,
+      Meters,
+      Inches,
+      Feet,
+      Points,
+      Picas,
+      Pixels
     };
 
     enum class LayoutUnitType /BaseType=IntEnum/
-    {
-        PaperUnits,
-                   ScreenUnits
+      {
+      PaperUnits,
+      ScreenUnits
     };
 
     enum class LayoutRenderFlag /BaseType=IntFlag/
     {
-        Debug,
-        OutlineOnly,
-        Antialiasing,
-        UseAdvancedEffects,
-        ForceVectorOutput,
-        HideCoverageLayer,
-        DrawSelection,
-        DisableTiledRasterLayerRenders,
-        RenderLabelsByMapLayer,
-        LosslessImageRendering,
-        SynchronousLegendGraphics,
-        AlwaysUseGlobalMasks,
-        LimitCoverageLayerRenderToCurrentFeature,
+      Debug,
+      OutlineOnly,
+      Antialiasing,
+      UseAdvancedEffects,
+      ForceVectorOutput,
+      HideCoverageLayer,
+      DrawSelection,
+      DisableTiledRasterLayerRenders,
+      RenderLabelsByMapLayer,
+      LosslessImageRendering,
+      SynchronousLegendGraphics,
+      AlwaysUseGlobalMasks,
+      LimitCoverageLayerRenderToCurrentFeature,
     };
 
     typedef QFlags<Qgis::LayoutRenderFlag> LayoutRenderFlags;
 
 
     enum class PictureFormat /BaseType=IntEnum/
-    {
-        SVG,
-        Raster,
-        Unknown,
+      {
+      SVG,
+      Raster,
+      Unknown,
     };
 
     enum class ScaleCalculationMethod /BaseType=IntEnum/
@@ -3062,127 +3061,127 @@ The development version
     };
 
     enum class ScaleBarAlignment /BaseType=IntEnum/
-    {
-        Left,
-        Middle,
-        Right,
+      {
+      Left,
+      Middle,
+      Right,
     };
 
     enum class ScaleBarSegmentSizeMode /BaseType=IntEnum/
-    {
-        Fixed,
-        FitWidth
+      {
+      Fixed,
+      FitWidth
     };
 
     enum class ScaleBarDistanceLabelVerticalPlacement /BaseType=IntEnum/
-    {
-        AboveSegment,
-        BelowSegment,
+      {
+      AboveSegment,
+      BelowSegment,
     };
 
     enum class ScaleBarDistanceLabelHorizontalPlacement /BaseType=IntEnum/
-    {
-        CenteredEdge,
-        CenteredSegment,
+      {
+      CenteredEdge,
+      CenteredSegment,
     };
 
 
     enum class MapGridUnit /BaseType=IntEnum/
-    {
-        MapUnits,
-                 Millimeters,
-                 Centimeters,
-                 DynamicPageSizeBased,
+      {
+      MapUnits,
+      Millimeters,
+      Centimeters,
+      DynamicPageSizeBased,
     };
 
     enum class MapGridStyle /BaseType=IntEnum/
-    {
-        Lines,
-        LineCrosses,
-        Markers,
-        FrameAndAnnotationsOnly
+      {
+      Lines,
+      LineCrosses,
+      Markers,
+      FrameAndAnnotationsOnly
     };
 
     enum class MapGridComponentVisibility /BaseType=IntEnum/
-    {
-        ShowAll,
-        LatitudeOnly,
-        LongitudeOnly,
-        HideAll
+      {
+      ShowAll,
+      LatitudeOnly,
+      LongitudeOnly,
+      HideAll
     };
 
     enum class MapGridAnnotationPosition /BaseType=IntEnum/
-    {
-        InsideMapFrame,
-        OutsideMapFrame,
+      {
+      InsideMapFrame,
+      OutsideMapFrame,
     };
 
     enum class MapGridAnnotationDirection /BaseType=IntEnum/
-    {
-        Horizontal,
-        Vertical,
-        VerticalDescending,
-        BoundaryDirection,
-        AboveTick,
-        OnTick,
-        UnderTick,
+      {
+      Horizontal,
+      Vertical,
+      VerticalDescending,
+      BoundaryDirection,
+      AboveTick,
+      OnTick,
+      UnderTick,
     };
 
     enum class MapGridAnnotationFormat /BaseType=IntEnum/
-    {
-        Decimal,
-        DegreeMinute,
-        DegreeMinuteSecond,
-        DecimalWithSuffix,
-        DegreeMinuteNoSuffix,
-        DegreeMinutePadded,
-        DegreeMinuteSecondNoSuffix,
-        DegreeMinuteSecondPadded,
-        CustomFormat
+      {
+      Decimal,
+      DegreeMinute,
+      DegreeMinuteSecond,
+      DecimalWithSuffix,
+      DegreeMinuteNoSuffix,
+      DegreeMinutePadded,
+      DegreeMinuteSecondNoSuffix,
+      DegreeMinuteSecondPadded,
+      CustomFormat
     };
 
     enum class MapGridBorderSide /BaseType=IntEnum/
-    {
-        Left,
-        Right,
-        Bottom,
-        Top,
+      {
+      Left,
+      Right,
+      Bottom,
+      Top,
     };
 
     enum class MapGridFrameStyle /BaseType=IntEnum/
-    {
-        NoFrame,
-        Zebra,
-        InteriorTicks,
-        ExteriorTicks,
-        InteriorExteriorTicks,
-        LineBorder,
-        LineBorderNautical,
-        ZebraNautical,
+      {
+      NoFrame,
+      Zebra,
+      InteriorTicks,
+      ExteriorTicks,
+      InteriorExteriorTicks,
+      LineBorder,
+      LineBorderNautical,
+      ZebraNautical,
     };
 
     enum class MapGridTickLengthMode /BaseType=IntEnum/
-    {
-        OrthogonalTicks,
-        NormalizedTicks,
+      {
+      OrthogonalTicks,
+      NormalizedTicks,
     };
 
 
     enum class MapGridFrameSideFlag /BaseType=IntFlag/
     {
-        Left,
-        Right,
-        Top,
-        Bottom
+      Left,
+      Right,
+      Top,
+      Bottom
     };
 
     typedef QFlags<Qgis::MapGridFrameSideFlag> MapGridFrameSideFlags;
 
 
     enum class MapGridAnnotationType /BaseType=IntEnum/
-    {
-        Longitude,
-        Latitude
+      {
+      Longitude,
+      Latitude
     };
 
     enum class InputControllerType /BaseType=IntEnum/
@@ -3208,28 +3207,28 @@ The development version
 
     enum class DatabaseProviderConnectionCapability2 /BaseType=IntFlag/
     {
-        SetFieldComment,
-        SetFieldAlias,
-        SetTableComment,
-        EditFieldDomain,
-        DeleteFieldDomain,
+      SetFieldComment,
+      SetFieldAlias,
+      SetTableComment,
+      EditFieldDomain,
+      DeleteFieldDomain,
     };
     typedef QFlags<Qgis::DatabaseProviderConnectionCapability2> DatabaseProviderConnectionCapabilities2;
 
 
     enum class DatabaseProviderTableImportCapability /BaseType=IntFlag/
     {
-        SetGeometryColumnName,
-        SetPrimaryKeyName,
+      SetGeometryColumnName,
+      SetPrimaryKeyName,
     };
     typedef QFlags<Qgis::DatabaseProviderTableImportCapability> DatabaseProviderTableImportCapabilities;
 
 
     enum class ProviderStyleStorageCapability /BaseType=IntFlag/
     {
-        SaveToDatabase,
-        LoadFromDatabase,
-        DeleteFromDatabase
+      SaveToDatabase,
+      LoadFromDatabase,
+      DeleteFromDatabase
     };
     typedef QFlags<Qgis::ProviderStyleStorageCapability> ProviderStyleStorageCapabilities;
 
@@ -3242,16 +3241,16 @@ The development version
     };
 
     enum class AttributeEditorType /BaseType=IntEnum/
-    {
-        Container,
-                  Field,
-                  Relation,
-                  QmlElement,
-                  HtmlElement,
-                  Action,
-                  TextElement,
-                  SpacerElement,
-                  Invalid,
+      {
+      Container,
+      Field,
+      Relation,
+      QmlElement,
+      HtmlElement,
+      Action,
+      TextElement,
+      SpacerElement,
+      Invalid,
     };
 
     enum class AttributeEditorContainerType /BaseType=IntEnum/
@@ -3262,25 +3261,25 @@ The development version
     };
 
     enum class AttributeFormLayout /BaseType=IntEnum/
-    {
-        AutoGenerated,
-        DragAndDrop,
-        UiFile
+      {
+      AutoGenerated,
+      DragAndDrop,
+      UiFile
     };
 
     enum class AttributeFormSuppression /BaseType=IntEnum/
-    {
-        Default,
-        On,
-        Off
+      {
+      Default,
+      On,
+      Off
     };
 
     enum class AttributeFormPythonInitCodeSource /BaseType=IntEnum/
-    {
-        NoSource,
-        File,
-        Dialog,
-        Environment
+      {
+      NoSource,
+      File,
+      Dialog,
+      Environment
     };
 
     enum class AttributeFormReuseLastValuePolicy /BaseType=IntEnum/
@@ -3298,15 +3297,15 @@ The development version
     };
 
     enum class FeatureSymbologyExport /BaseType=IntEnum/
-    {
-        NoSymbology,
-        PerFeature,
-        PerSymbolLayer
+      {
+      NoSymbology,
+      PerFeature,
+      PerSymbolLayer
     };
 
     enum class VectorTileProviderFlag /BaseType=IntFlag/
     {
-        AlwaysUseTileMatrixSetFromProvider,
+      AlwaysUseTileMatrixSetFromProvider,
     };
 
     typedef QFlags<Qgis::VectorTileProviderFlag> VectorTileProviderFlags;
@@ -3314,7 +3313,7 @@ The development version
 
     enum class VectorTileProviderCapability /BaseType=IntFlag/
     {
-        ReadLayerMetadata,
+      ReadLayerMetadata,
     };
 
     typedef QFlags<Qgis::VectorTileProviderCapability> VectorTileProviderCapabilities;
@@ -3330,7 +3329,7 @@ The development version
 
     enum class TiledSceneProviderCapability /BaseType=IntFlag/
     {
-        ReadLayerMetadata,
+      ReadLayerMetadata,
     };
 
     typedef QFlags<Qgis::TiledSceneProviderCapability> TiledSceneProviderCapabilities;
@@ -3358,7 +3357,7 @@ The development version
 
     enum class TiledSceneRequestFlag /BaseType=IntFlag/
     {
-        NoHierarchyFetch,
+      NoHierarchyFetch,
     };
 
     typedef QFlags<Qgis::TiledSceneRequestFlag> TiledSceneRequestFlags;
@@ -3366,10 +3365,10 @@ The development version
 
     enum class TiledSceneRendererFlag /BaseType=IntFlag/
     {
-        RequiresTextures,
-        ForceRasterRender,
-        RendersTriangles,
-        RendersLines,
+      RequiresTextures,
+      ForceRasterRender,
+      RendersTriangles,
+      RendersLines,
     };
 
     typedef QFlags<Qgis::TiledSceneRendererFlag> TiledSceneRendererFlags;
@@ -3404,23 +3403,23 @@ The development version
 
     enum class ZonalStatistic /BaseType=IntFlag/
     {
-        Count,
-        Sum,
-        Mean,
-        Median,
-        StDev,
-        Min,
-        Max,
-        Range,
-        Minority,
-        Majority,
-        Variety,
-        Variance,
-        MinimumPoint,
-        MaximumPoint,
-        All,
-        AllNumeric,
-        Default,
+      Count,
+      Sum,
+      Mean,
+      Median,
+      StDev,
+      Min,
+      Max,
+      Range,
+      Minority,
+      Majority,
+      Variety,
+      Variance,
+      MinimumPoint,
+      MaximumPoint,
+      All,
+      AllNumeric,
+      Default,
     };
 
     typedef QFlags<Qgis::ZonalStatistic> ZonalStatistics;
@@ -3438,52 +3437,52 @@ The development version
     };
 
     enum class Aggregate /BaseType=IntEnum/
-    {
-        Count,
-        CountDistinct,
-        CountMissing,
-        Min,
-        Max,
-        Sum,
-        Mean,
-        Median,
-        StDev,
-        StDevSample,
-        Range,
-        Minority,
-        Majority,
-        FirstQuartile,
-        ThirdQuartile,
-        InterQuartileRange,
-        StringMinimumLength,
-        StringMaximumLength,
-        StringConcatenate,
-        GeometryCollect,
-        ArrayAggregate,
-        StringConcatenateUnique
+      {
+      Count,
+      CountDistinct,
+      CountMissing,
+      Min,
+      Max,
+      Sum,
+      Mean,
+      Median,
+      StDev,
+      StDevSample,
+      Range,
+      Minority,
+      Majority,
+      FirstQuartile,
+      ThirdQuartile,
+      InterQuartileRange,
+      StringMinimumLength,
+      StringMaximumLength,
+      StringConcatenate,
+      GeometryCollect,
+      ArrayAggregate,
+      StringConcatenateUnique
     };
 
     enum class Statistic /BaseType=IntFlag/
     {
-        Count,
-        CountMissing,
-        Sum,
-        Mean,
-        Median,
-        StDev,
-        StDevSample,
-        Min,
-        Max,
-        Range,
-        Minority,
-        Majority,
-        Variety,
-        FirstQuartile,
-        ThirdQuartile,
-        InterQuartileRange,
-        First,
-        Last,
-        All
+      Count,
+      CountMissing,
+      Sum,
+      Mean,
+      Median,
+      StDev,
+      StDevSample,
+      Min,
+      Max,
+      Range,
+      Minority,
+      Majority,
+      Variety,
+      FirstQuartile,
+      ThirdQuartile,
+      InterQuartileRange,
+      First,
+      Last,
+      All
     };
 
     typedef QFlags<Qgis::Statistic> Statistics;
@@ -3491,13 +3490,13 @@ The development version
 
     enum class DateTimeStatistic /BaseType=IntFlag/
     {
-        Count,
-        CountDistinct,
-        CountMissing,
-        Min,
-        Max,
-        Range,
-        All,
+      Count,
+      CountDistinct,
+      CountMissing,
+      Min,
+      Max,
+      Range,
+      All,
     };
 
     typedef QFlags<Qgis::DateTimeStatistic> DateTimeStatistics;
@@ -3505,17 +3504,17 @@ The development version
 
     enum class StringStatistic /BaseType=IntFlag/
     {
-        Count,
-        CountDistinct,
-        CountMissing,
-        Min,
-        Max,
-        MinimumLength,
-        MaximumLength,
-        MeanLength,
-        Minority,
-        Majority,
-        All,
+      Count,
+      CountDistinct,
+      CountMissing,
+      Min,
+      Max,
+      MinimumLength,
+      MaximumLength,
+      MeanLength,
+      Minority,
+      Majority,
+      All,
     };
 
     typedef QFlags<Qgis::StringStatistic> StringStatistics;
@@ -3523,15 +3522,15 @@ The development version
 
     enum class RasterBandStatistic /BaseType=IntFlag/
     {
-        NoStatistic,
-        Min,
-        Max,
-        Range,
-        Sum,
-        Mean,
-        StdDev,
-        SumOfSquares,
-        All
+      NoStatistic,
+      Min,
+      Max,
+      Range,
+      Sum,
+      Mean,
+      StdDev,
+      SumOfSquares,
+      All
     };
 
     typedef QFlags<Qgis::RasterBandStatistic> RasterBandStatistics;
@@ -3634,8 +3633,8 @@ The development version
 
     enum class RasterProcessingParameterCapability /BaseType=IntFlag/
     {
-        WmsScale,
-        WmsDpi,
+      WmsScale,
+      WmsDpi,
     };
 
     typedef QFlags<Qgis::RasterProcessingParameterCapability> RasterProcessingParameterCapabilities;
@@ -3652,10 +3651,10 @@ The development version
 
     enum class ExtrusionFace /BaseType=IntFlag/
     {
-        NoFace,
-        Walls,
-        Roof,
-        Floor
+      NoFace,
+      Walls,
+      Roof,
+      Floor
     };
 
     typedef QFlags<Qgis::ExtrusionFace> ExtrusionFaces;
@@ -3663,8 +3662,8 @@ The development version
 
     enum class TriangulationAlgorithm /BaseType=IntFlag/
     {
-        ConstrainedDelaunay,
-        Earcut
+      ConstrainedDelaunay,
+      Earcut
     };
 
     static const double DEFAULT_SEARCH_RADIUS_MM;

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -122,10 +122,10 @@ The development version
       NoLevel,
     };
 
-    enum class MessageType /BaseType=IntEnum/
-    {
-      MessageText,
-      MessageHtml,
+    enum class StringFormat /BaseType=IntEnum/
+      {
+      PlainText,
+      Html,
     };
 
     enum class NetworkRequestFlag /BaseType=IntFlag/

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -71,42 +71,42 @@ The development version
 
     enum class AuthConfigurationStorageCapability /BaseType=IntFlag/
     {
-      ClearStorage,
+        ClearStorage,
 
-      ReadConfiguration,
-      UpdateConfiguration,
-      DeleteConfiguration,
-      CreateConfiguration,
+        ReadConfiguration,
+        UpdateConfiguration,
+        DeleteConfiguration,
+        CreateConfiguration,
 
-      ReadCertificateIdentity,
-      UpdateCertificateIdentity,
-      DeleteCertificateIdentity,
-      CreateCertificateIdentity,
+        ReadCertificateIdentity,
+        UpdateCertificateIdentity,
+        DeleteCertificateIdentity,
+        CreateCertificateIdentity,
 
-      ReadSslCertificateCustomConfig,
-      UpdateSslCertificateCustomConfig,
-      DeleteSslCertificateCustomConfig,
-      CreateSslCertificateCustomConfig,
+        ReadSslCertificateCustomConfig,
+        UpdateSslCertificateCustomConfig,
+        DeleteSslCertificateCustomConfig,
+        CreateSslCertificateCustomConfig,
 
-      ReadCertificateAuthority,
-      UpdateCertificateAuthority,
-      DeleteCertificateAuthority,
-      CreateCertificateAuthority,
+        ReadCertificateAuthority,
+        UpdateCertificateAuthority,
+        DeleteCertificateAuthority,
+        CreateCertificateAuthority,
 
-      ReadCertificateTrustPolicy,
-      UpdateCertificateTrustPolicy,
-      DeleteCertificateTrustPolicy,
-      CreateCertificateTrustPolicy,
+        ReadCertificateTrustPolicy,
+        UpdateCertificateTrustPolicy,
+        DeleteCertificateTrustPolicy,
+        CreateCertificateTrustPolicy,
 
-      ReadMasterPassword,
-      UpdateMasterPassword,
-      DeleteMasterPassword,
-      CreateMasterPassword,
+        ReadMasterPassword,
+        UpdateMasterPassword,
+        DeleteMasterPassword,
+        CreateMasterPassword,
 
-      ReadSetting,
-      UpdateSetting,
-      DeleteSetting,
-      CreateSetting,
+        ReadSetting,
+        UpdateSetting,
+        DeleteSetting,
+        CreateSetting,
 
     };
 
@@ -123,159 +123,165 @@ The development version
       NoLevel,
     };
 
+    enum class MessageType /BaseType=IntEnum/
+    {
+      MessageText,
+      MessageHtml,
+    };
+
     enum class NetworkRequestFlag /BaseType=IntFlag/
     {
-      DisableMessageLogging,
+        DisableMessageLogging,
     };
 
     typedef QFlags<Qgis::NetworkRequestFlag> NetworkRequestFlags;
 
 
     enum class LayerType /BaseType=IntEnum/
-      {
-      Vector,
-      Raster,
-      Plugin,
-      Mesh,
-      VectorTile,
-      Annotation,
-      PointCloud,
-      Group,
-      TiledScene,
+    {
+        Vector,
+               Raster,
+               Plugin,
+               Mesh,
+               VectorTile,
+               Annotation,
+               PointCloud,
+               Group,
+               TiledScene,
     };
 
     enum class LayerFilter /BaseType=IntFlag/
     {
-      RasterLayer,
-      NoGeometry,
-      PointLayer,
-      LineLayer,
-      PolygonLayer,
-      HasGeometry,
-      VectorLayer,
-      PluginLayer,
-      WritableLayer,
-      MeshLayer,
-      VectorTileLayer,
-      PointCloudLayer,
-      AnnotationLayer,
-      TiledSceneLayer,
-      All,
-      SpatialLayer
+        RasterLayer,
+        NoGeometry,
+        PointLayer,
+        LineLayer,
+        PolygonLayer,
+        HasGeometry,
+        VectorLayer,
+        PluginLayer,
+        WritableLayer,
+        MeshLayer,
+        VectorTileLayer,
+        PointCloudLayer,
+        AnnotationLayer,
+        TiledSceneLayer,
+        All,
+        SpatialLayer
     };
     typedef QFlags<Qgis::LayerFilter> LayerFilters;
 
 
     enum class LoadStyleFlag /BaseType=IntFlag/
     {
-      IgnoreMissingStyleErrors,
+        IgnoreMissingStyleErrors,
     };
 
     typedef QFlags<Qgis::LoadStyleFlag> LoadStyleFlags;
 
 
     enum class WkbType /BaseType=IntEnum/
-      {
-      Unknown,
-      Point,
-      LineString,
-      Polygon,
-      Triangle,
-      MultiPoint,
-      MultiLineString,
-      MultiPolygon,
-      GeometryCollection,
-      CircularString,
-      CompoundCurve,
-      CurvePolygon,
-      MultiCurve,
-      MultiSurface,
-      PolyhedralSurface,
-      TIN,
+    {
+        Unknown,
+        Point,
+        LineString,
+        Polygon,
+        Triangle,
+        MultiPoint,
+        MultiLineString,
+        MultiPolygon,
+        GeometryCollection,
+        CircularString,
+        CompoundCurve,
+        CurvePolygon,
+        MultiCurve,
+        MultiSurface,
+        PolyhedralSurface,
+        TIN,
       NurbsCurve,
-      NoGeometry,
-      PointZ,
-      LineStringZ,
-      PolygonZ,
-      TriangleZ,
-      MultiPointZ,
-      MultiLineStringZ,
-      MultiPolygonZ,
-      GeometryCollectionZ,
-      CircularStringZ,
-      CompoundCurveZ,
-      CurvePolygonZ,
-      MultiCurveZ,
-      MultiSurfaceZ,
-      PolyhedralSurfaceZ,
-      TINZ,
+        NoGeometry,
+        PointZ,
+        LineStringZ,
+        PolygonZ,
+        TriangleZ,
+        MultiPointZ,
+        MultiLineStringZ,
+        MultiPolygonZ,
+        GeometryCollectionZ,
+        CircularStringZ,
+        CompoundCurveZ,
+        CurvePolygonZ,
+        MultiCurveZ,
+        MultiSurfaceZ,
+        PolyhedralSurfaceZ,
+        TINZ,
       NurbsCurveZ,
-      PointM,
-      LineStringM,
-      PolygonM,
-      TriangleM,
-      MultiPointM,
-      MultiLineStringM,
-      MultiPolygonM,
-      GeometryCollectionM,
-      CircularStringM,
-      CompoundCurveM,
-      CurvePolygonM,
-      MultiCurveM,
-      MultiSurfaceM,
-      PolyhedralSurfaceM,
-      TINM,
+        PointM,
+        LineStringM,
+        PolygonM,
+        TriangleM,
+        MultiPointM,
+        MultiLineStringM,
+        MultiPolygonM,
+        GeometryCollectionM,
+        CircularStringM,
+        CompoundCurveM,
+        CurvePolygonM,
+        MultiCurveM,
+        MultiSurfaceM,
+        PolyhedralSurfaceM,
+        TINM,
       NurbsCurveM,
-      PointZM,
-      LineStringZM,
-      PolygonZM,
-      MultiPointZM,
-      MultiLineStringZM,
-      MultiPolygonZM,
-      GeometryCollectionZM,
-      CircularStringZM,
-      CompoundCurveZM,
-      CurvePolygonZM,
-      MultiCurveZM,
-      MultiSurfaceZM,
-      PolyhedralSurfaceZM,
-      TINZM,
-      TriangleZM,
+        PointZM,
+        LineStringZM,
+        PolygonZM,
+        MultiPointZM,
+        MultiLineStringZM,
+        MultiPolygonZM,
+        GeometryCollectionZM,
+        CircularStringZM,
+        CompoundCurveZM,
+        CurvePolygonZM,
+        MultiCurveZM,
+        MultiSurfaceZM,
+        PolyhedralSurfaceZM,
+        TINZM,
+        TriangleZM,
       NurbsCurveZM,
-      Point25D,
-      LineString25D,
-      Polygon25D,
-      MultiPoint25D,
-      MultiLineString25D,
-      MultiPolygon25D
+        Point25D,
+        LineString25D,
+        Polygon25D,
+        MultiPoint25D,
+        MultiLineString25D,
+        MultiPolygon25D
     };
 
     enum class GeometryType /BaseType=IntEnum/
-      {
-      Point,
-      Line,
-      Polygon,
-      Unknown,
-      Null,
+    {
+        Point,
+              Line,
+              Polygon,
+              Unknown,
+              Null,
     };
 
     enum class DataType /BaseType=IntEnum/
-      {
-      UnknownDataType,
-      Byte,
-      Int8,
-      UInt16,
-      Int16,
-      UInt32,
-      Int32,
-      Float32,
-      Float64,
-      CInt16,
-      CInt32,
-      CFloat32,
-      CFloat64,
-      ARGB32,
-      ARGB32_Premultiplied
+    {
+        UnknownDataType,
+        Byte,
+        Int8,
+        UInt16,
+        Int16,
+        UInt32,
+        Int32,
+        Float32,
+        Float64,
+        CInt16,
+        CInt32,
+        CFloat32,
+        CFloat64,
+        ARGB32,
+        ARGB32_Premultiplied
     };
 
     enum class CaptureTechnique /BaseType=IntEnum/
@@ -294,19 +300,19 @@ The development version
 
     enum class VectorLayerTypeFlag /BaseType=IntFlag/
     {
-      SqlQuery
+        SqlQuery
     };
     typedef QFlags<Qgis::VectorLayerTypeFlag> VectorLayerTypeFlags;
 
 
     enum class EmbeddedScriptMode /BaseType=IntEnum/
-      {
-      Never,
-      Ask,
-      SessionOnly,
-      Always,
-      NotForThisSession,
-      NeverAsk,
+    {
+        Never,
+        Ask,
+        SessionOnly,
+        Always,
+        NotForThisSession,
+        NeverAsk,
     };
 
     enum class EmbeddedScriptType /BaseType=IntEnum/
@@ -326,14 +332,14 @@ The development version
 
     enum class DataProviderReadFlag /BaseType=IntFlag/
     {
-      TrustDataSource,
-      SkipFeatureCount,
-      LoadDefaultStyle,
-      SkipGetExtent,
-      SkipFullScan,
-      ForceReadOnly,
-      SkipCredentialsRequest,
-      ParallelThreadLoading,
+        TrustDataSource,
+        SkipFeatureCount,
+        LoadDefaultStyle,
+        SkipGetExtent,
+        SkipFullScan,
+        ForceReadOnly,
+        SkipCredentialsRequest,
+        ParallelThreadLoading,
     };
 
     typedef QFlags<Qgis::DataProviderReadFlag> DataProviderReadFlags;
@@ -342,61 +348,61 @@ The development version
 
     enum class VectorProviderCapability /BaseType=IntFlag/
     {
-      NoCapabilities,
-      AddFeatures,
-      DeleteFeatures,
-      ChangeAttributeValues,
-      AddAttributes,
-      DeleteAttributes,
-      CreateSpatialIndex,
-      SelectAtId,
-      ChangeGeometries,
-      SelectEncoding,
-      CreateAttributeIndex,
-      SimplifyGeometries,
-      SimplifyGeometriesWithTopologicalValidation,
-      TransactionSupport,
-      CircularGeometries,
-      ChangeFeatures,
-      RenameAttributes,
-      FastTruncate,
-      ReadLayerMetadata,
-      WriteLayerMetadata,
-      CancelSupport,
-      CreateRenderer,
-      CreateLabeling,
-      ReloadData,
-      FeatureSymbology,
-      EditingCapabilities,
+        NoCapabilities,
+        AddFeatures,
+        DeleteFeatures,
+        ChangeAttributeValues,
+        AddAttributes,
+        DeleteAttributes,
+        CreateSpatialIndex,
+        SelectAtId,
+        ChangeGeometries,
+        SelectEncoding,
+        CreateAttributeIndex,
+        SimplifyGeometries,
+        SimplifyGeometriesWithTopologicalValidation,
+        TransactionSupport,
+        CircularGeometries,
+        ChangeFeatures,
+        RenameAttributes,
+        FastTruncate,
+        ReadLayerMetadata,
+        WriteLayerMetadata,
+        CancelSupport,
+        CreateRenderer,
+        CreateLabeling,
+        ReloadData,
+        FeatureSymbology,
+        EditingCapabilities,
     };
 
     typedef QFlags<Qgis::VectorProviderCapability> VectorProviderCapabilities;
 
 
     enum class FeatureCountState /BaseType=IntEnum/
-      {
-      Uncounted,
-      UnknownCount,
+    {
+        Uncounted,
+        UnknownCount,
     };
 
     enum class SpatialIndexPresence /BaseType=IntEnum/
-      {
-      Unknown,
-      NotPresent,
-      Present,
+    {
+        Unknown,
+        NotPresent,
+        Present,
     };
 
     enum class FeatureAvailability /BaseType=IntEnum/
-      {
-      NoFeaturesAvailable,
-      FeaturesAvailable,
-      FeaturesMaybeAvailable
+    {
+        NoFeaturesAvailable,
+        FeaturesAvailable,
+        FeaturesMaybeAvailable
     };
 
     enum class VectorDataProviderAttributeEditCapability /BaseType=IntFlag/
     {
-      EditAlias,
-      EditComment,
+        EditAlias,
+        EditComment,
     };
 
 
@@ -404,31 +410,31 @@ The development version
 
 
     enum class SymbolType /BaseType=IntEnum/
-      {
-      Marker,
-      Line,
-      Fill,
-      Hybrid
+    {
+        Marker,
+        Line,
+        Fill,
+        Hybrid
     };
 
     enum class ScaleMethod /BaseType=IntEnum/
-      {
-      ScaleArea,
-      ScaleDiameter
+    {
+        ScaleArea,
+        ScaleDiameter
     };
 
     enum class SettingsType /BaseType=IntEnum/
-      {
-      Custom,
-      Variant,
-      String,
-      StringList,
-      VariantMap,
-      Bool,
-      Integer,
-      Double,
-      EnumFlag,
-      Color
+    {
+        Custom,
+        Variant,
+        String,
+        StringList,
+        VariantMap,
+        Bool,
+        Integer,
+        Double,
+        EnumFlag,
+        Color
     };
 
     enum class SettingsTreeNodeType
@@ -440,71 +446,71 @@ The development version
 
     enum class SettingsTreeNodeOption /BaseType=IntFlag/
     {
-      NamedListSelectedItemSetting,
+        NamedListSelectedItemSetting,
     };
 
     typedef QFlags<Qgis::SettingsTreeNodeOption> SettingsTreeNodeOptions;
 
 
     enum class PropertyType /BaseType=IntEnum/
-      {
-      Invalid,
-      Static,
-      Field,
-      Expression,
+    {
+        Invalid,
+                Static,
+                Field,
+                Expression,
     };
 
     enum class SldExportOption /BaseType=IntFlag/
     {
-      NoOptions,
-      Svg,
-      Png,
+        NoOptions,
+        Svg,
+        Png,
     };
     typedef QFlags<Qgis::SldExportOption> SldExportOptions;
 
 
     enum class SldExportVendorExtension /BaseType=IntFlag/
     {
-      NoVendorExtension,
-      GeoServerVendorExtension,
-      DeegreeVendorExtension,
+        NoVendorExtension,
+        GeoServerVendorExtension,
+        DeegreeVendorExtension,
     };
 
 
     enum class SettingsOption /BaseType=IntFlag/
     {
-      SaveFormerValue,
-      SaveEnumFlagAsInt,
+        SaveFormerValue,
+        SaveEnumFlagAsInt,
     };
     typedef QFlags<Qgis::SettingsOption> SettingsOptions;
 
 
     enum class SnappingMode /BaseType=IntEnum/
-      {
-      ActiveLayer,
-      AllLayers,
-      AdvancedConfiguration,
+    {
+        ActiveLayer,
+        AllLayers,
+        AdvancedConfiguration,
     };
 
     enum class SnappingType /BaseType=IntFlag/
     {
-      NoSnap,
-      Vertex,
-      Segment,
-      Area,
-      Centroid,
-      MiddleOfSegment,
-      LineEndpoint,
+        NoSnap,
+        Vertex,
+        Segment,
+        Area,
+        Centroid,
+        MiddleOfSegment,
+        LineEndpoint,
     };
     typedef QFlags<Qgis::SnappingType> SnappingTypes;
 
 
     enum class SymbolRenderHint /BaseType=IntFlag/
     {
-      DynamicRotation,
-      IsSymbolLayerSubSymbol,
-      ForceVectorRendering,
-      ExcludeSymbolBuffers,
+        DynamicRotation,
+        IsSymbolLayerSubSymbol,
+        ForceVectorRendering,
+        ExcludeSymbolBuffers,
     };
     typedef QFlags<Qgis::SymbolRenderHint> SymbolRenderHints;
 
@@ -517,23 +523,23 @@ The development version
 
 
     enum class HorizontalAnchorPoint /BaseType=IntEnum/
-      {
-      Left,
-      Center,
-      Right,
+    {
+        Left,
+        Center,
+        Right,
     };
 
     enum class VerticalAnchorPoint /BaseType=IntEnum/
-      {
-      Top,
-      Center,
-      Bottom,
-      Baseline,
+    {
+        Top,
+        Center,
+        Bottom,
+        Baseline,
     };
 
     enum class FeatureRendererFlag /BaseType=IntFlag/
     {
-      AffectsLabeling,
+        AffectsLabeling,
     };
 
     typedef QFlags<Qgis::FeatureRendererFlag> FeatureRendererFlags;
@@ -541,100 +547,100 @@ The development version
 
     enum class SymbolFlag /BaseType=IntFlag/
     {
-      RendererShouldUseSymbolLevels,
-      AffectsLabeling,
+        RendererShouldUseSymbolLevels,
+        AffectsLabeling,
     };
     typedef QFlags<Qgis::SymbolFlag> SymbolFlags;
 
 
     enum class SymbolPreviewFlag /BaseType=IntFlag/
     {
-      FlagIncludeCrosshairsForMarkerSymbols,
+        FlagIncludeCrosshairsForMarkerSymbols,
     };
     typedef QFlags<Qgis::SymbolPreviewFlag> SymbolPreviewFlags;
 
 
     enum class SymbolLayerFlag /BaseType=IntFlag/
     {
-      DisableFeatureClipping,
-      CanCalculateMaskGeometryPerFeature,
-      AffectsLabeling,
+        DisableFeatureClipping,
+        CanCalculateMaskGeometryPerFeature,
+        AffectsLabeling,
     };
     typedef QFlags<Qgis::SymbolLayerFlag> SymbolLayerFlags;
 
 
     enum class SymbolLayerUserFlag /BaseType=IntFlag/
     {
-      DisableSelectionRecoloring,
+        DisableSelectionRecoloring,
     };
 
     typedef QFlags<Qgis::SymbolLayerUserFlag> SymbolLayerUserFlags;
 
 
     enum class BrowserItemType /BaseType=IntEnum/
-      {
-      Collection,
-      Directory,
-      Layer,
-      Error,
-      Favorites,
-      Project,
-      Custom,
-      Fields,
-      Field,
+    {
+        Collection,
+        Directory,
+        Layer,
+        Error,
+        Favorites,
+        Project,
+        Custom,
+        Fields,
+        Field,
     };
 
     enum class BrowserItemState /BaseType=IntEnum/
-      {
-      NotPopulated,
-      Populating,
-      Populated,
+    {
+        NotPopulated,
+        Populating,
+        Populated,
     };
 
     enum class BrowserItemCapability /BaseType=IntFlag/
     {
-      NoCapabilities,
-      SetCrs,
-      Fertile,
-      Fast,
-      Collapse,
-      Rename,
-      Delete,
-      ItemRepresentsFile,
-      RefreshChildrenWhenItemIsRefreshed,
-      ReadOnly,
+        NoCapabilities,
+        SetCrs,
+        Fertile,
+        Fast,
+        Collapse,
+        Rename,
+        Delete,
+        ItemRepresentsFile,
+        RefreshChildrenWhenItemIsRefreshed,
+        ReadOnly,
     };
     typedef QFlags<Qgis::BrowserItemCapability> BrowserItemCapabilities;
 
 
     enum class DataItemProviderCapability /BaseType=IntFlag/
     {
-      NoCapabilities,
-      Files,
-      Directories,
-      Databases,
-      NetworkSources,
+        NoCapabilities,
+        Files,
+        Directories,
+        Databases,
+        NetworkSources,
     };
 
     typedef QFlags<Qgis::DataItemProviderCapability> DataItemProviderCapabilities;
 
 
     enum class BrowserLayerType /BaseType=IntEnum/
-      {
-      NoType,
-      Vector,
-      Raster,
-      Point,
-      Line,
-      Polygon,
-      TableLayer,
-      Database,
-      Table,
-      Plugin,
-      Mesh,
-      VectorTile,
-      PointCloud,
-      TiledScene,
+    {
+        NoType,
+        Vector,
+        Raster,
+        Point,
+        Line,
+        Polygon,
+        TableLayer,
+        Database,
+        Table,
+        Plugin,
+        Mesh,
+        VectorTile,
+        PointCloud,
+        TiledScene,
     };
 
     enum class BrowserDirectoryMonitoring /BaseType=IntEnum/
@@ -654,25 +660,25 @@ The development version
     };
 
     enum class VectorExportResult /BaseType=IntEnum/
-      {
-      Success,
-      ErrorCreatingDataSource,
-      ErrorCreatingLayer,
-      ErrorAttributeTypeUnsupported,
-      ErrorAttributeCreationFailed,
-      ErrorProjectingFeatures,
-      ErrorFeatureWriteFailed,
-      ErrorInvalidLayer,
-      ErrorInvalidProvider,
-      ErrorProviderUnsupportedFeature,
-      ErrorConnectionFailed,
-      UserCanceled,
+    {
+        Success,
+        ErrorCreatingDataSource,
+        ErrorCreatingLayer,
+        ErrorAttributeTypeUnsupported,
+        ErrorAttributeCreationFailed,
+        ErrorProjectingFeatures,
+        ErrorFeatureWriteFailed,
+        ErrorInvalidLayer,
+        ErrorInvalidProvider,
+        ErrorProviderUnsupportedFeature,
+        ErrorConnectionFailed,
+        UserCanceled,
     };
 
     enum class VectorFileWriterCapability /BaseType=IntFlag/
     {
-      FieldAliases,
-      FieldComments,
+        FieldAliases,
+        FieldComments,
     };
 
     typedef QFlags<Qgis::VectorFileWriterCapability> VectorFileWriterCapabilities;
@@ -680,10 +686,10 @@ The development version
 
     enum class SqlLayerDefinitionCapability /BaseType=IntFlag/
     {
-      SubsetStringFilter,
-      GeometryColumn,
-      PrimaryKeys,
-      UnstableFeatureIds
+        SubsetStringFilter,
+        GeometryColumn,
+        PrimaryKeys,
+        UnstableFeatureIds
     };
     typedef QFlags<Qgis::SqlLayerDefinitionCapability> SqlLayerDefinitionCapabilities;
 
@@ -714,9 +720,9 @@ The development version
     };
 
     enum class ActionStart /BaseType=IntEnum/
-      {
-      Deferred,
-      Immediate,
+    {
+        Deferred,
+                 Immediate,
     };
 
     enum class UnplacedLabelVisibility /BaseType=IntEnum/
@@ -745,16 +751,16 @@ The development version
     };
 
     enum class LabelPlacement /BaseType=IntEnum/
-      {
-      AroundPoint,
-      OverPoint,
-      Line,
-      Curved,
-      Horizontal,
-      Free,
-      OrderedPositionsAroundPoint,
-      PerimeterCurved,
-      OutsidePolygons,
+    {
+        AroundPoint,
+        OverPoint,
+        Line,
+        Curved,
+        Horizontal,
+        Free,
+        OrderedPositionsAroundPoint,
+        PerimeterCurved,
+        OutsidePolygons,
     };
 
     enum class CurvedLabelMode /BaseType=IntEnum/
@@ -766,20 +772,20 @@ The development version
     };
 
     enum class LabelPredefinedPointPosition /BaseType=IntEnum/
-      {
-      TopLeft,
-      TopSlightlyLeft,
-      TopMiddle,
-      TopSlightlyRight,
-      TopRight,
-      MiddleLeft,
-      MiddleRight,
-      BottomLeft,
-      BottomSlightlyLeft,
-      BottomMiddle,
-      BottomSlightlyRight,
-      BottomRight,
-      OverPoint,
+    {
+        TopLeft,
+        TopSlightlyLeft,
+        TopMiddle,
+        TopSlightlyRight,
+        TopRight,
+        MiddleLeft,
+        MiddleRight,
+        BottomLeft,
+        BottomSlightlyLeft,
+        BottomMiddle,
+        BottomSlightlyRight,
+        BottomRight,
+        OverPoint,
     };
 
     enum class MultiPartLabelingBehavior /BaseType=IntEnum/
@@ -790,30 +796,30 @@ The development version
     };
 
     enum class LabelOffsetType /BaseType=IntEnum/
-      {
-      FromPoint,
-      FromSymbolBounds,
+    {
+        FromPoint,
+        FromSymbolBounds,
     };
 
     enum class LabelQuadrantPosition /BaseType=IntEnum/
-      {
-      AboveLeft,
-      Above,
-      AboveRight,
-      Left,
-      Over,
-      Right,
-      BelowLeft,
-      Below,
-      BelowRight,
+    {
+        AboveLeft,
+                  Above,
+                  AboveRight,
+                  Left,
+                  Over,
+                  Right,
+                  BelowLeft,
+                  Below,
+                  BelowRight,
     };
 
     enum class LabelLinePlacementFlag /BaseType=IntFlag/
     {
-      OnLine,
-      AboveLine,
-      BelowLine,
-      MapOrientation,
+        OnLine,
+        AboveLine,
+        BelowLine,
+        MapOrientation,
     };
 
     typedef QFlags<Qgis::LabelLinePlacementFlag> LabelLinePlacementFlags;
@@ -821,44 +827,44 @@ The development version
 
     enum class LabelPolygonPlacementFlag /BaseType=IntFlag/
     {
-      AllowPlacementOutsideOfPolygon,
-      AllowPlacementInsideOfPolygon,
+        AllowPlacementOutsideOfPolygon,
+        AllowPlacementInsideOfPolygon,
     };
 
     typedef QFlags<Qgis::LabelPolygonPlacementFlag> LabelPolygonPlacementFlags;
 
 
     enum class UpsideDownLabelHandling /BaseType=IntEnum/
-      {
-      FlipUpsideDownLabels,
-      AllowUpsideDownWhenRotationIsDefined,
-      AlwaysAllowUpsideDown
+    {
+        FlipUpsideDownLabels,
+                             AllowUpsideDownWhenRotationIsDefined,
+                             AlwaysAllowUpsideDown
     };
 
     enum class LabelMultiLineAlignment /BaseType=IntEnum/
-      {
-      Left,
-      Center,
-      Right,
-      FollowPlacement,
-      Justify,
+    {
+        Left,
+        Center,
+        Right,
+        FollowPlacement,
+        Justify,
     };
 
     enum class FileFilterType /BaseType=IntEnum/
-      {
-      Vector,
-      Raster,
-      Mesh,
-      MeshDataset,
-      PointCloud,
-      VectorTile,
-      TiledScene,
+    {
+        Vector,
+        Raster,
+        Mesh,
+        MeshDataset,
+        PointCloud,
+        VectorTile,
+        TiledScene,
     };
 
     enum class UriCleaningFlag /BaseType=IntFlag/
     {
-      RemoveCredentials,
-      RedactCredentials,
+        RemoveCredentials,
+        RedactCredentials,
     };
 
     typedef QFlags<Qgis::UriCleaningFlag> UriCleaningFlags;
@@ -866,70 +872,70 @@ The development version
 
     enum class SublayerQueryFlag /BaseType=IntFlag/
     {
-      FastScan,
-      ResolveGeometryType,
-      CountFeatures,
-      IncludeSystemTables,
-      OpenLayersToResolveDescriptions,
+        FastScan,
+        ResolveGeometryType,
+        CountFeatures,
+        IncludeSystemTables,
+        OpenLayersToResolveDescriptions,
     };
     typedef QFlags<Qgis::SublayerQueryFlag> SublayerQueryFlags;
 
 
     enum class SublayerFlag /BaseType=IntFlag/
     {
-      SystemTable,
+        SystemTable,
     };
     typedef QFlags<Qgis::SublayerFlag> SublayerFlags;
 
 
     enum class ShaderInterpolationMethod /BaseType=IntEnum/
-      {
-      Linear,
-      Discrete,
-      Exact,
+    {
+        Linear,
+        Discrete,
+        Exact,
     };
 
     enum class ShaderClassificationMethod /BaseType=IntEnum/
-      {
-      Continuous,
-      EqualInterval,
-      Quantile,
+    {
+        Continuous,
+        EqualInterval,
+        Quantile,
     };
 
     enum class RasterPipeInterfaceRole /BaseType=IntEnum/
-      {
-      Unknown,
-      Provider,
-      Renderer,
-      Brightness,
-      Resampler,
-      Projector,
-      Nuller,
-      HueSaturation,
+    {
+        Unknown,
+        Provider,
+        Renderer,
+        Brightness,
+        Resampler,
+        Projector,
+        Nuller,
+        HueSaturation,
     };
 
     enum class RasterResamplingStage /BaseType=IntEnum/
-      {
-      ResampleFilter,
-      Provider,
+    {
+        ResampleFilter,
+        Provider,
     };
 
     enum class RasterResamplingMethod /BaseType=IntEnum/
-      {
-      Nearest,
-      Bilinear,
-      Cubic,
-      CubicSpline,
-      Lanczos,
-      Average,
-      Mode,
-      Gauss
+    {
+        Nearest,
+        Bilinear,
+        Cubic,
+        CubicSpline,
+        Lanczos,
+        Average,
+        Mode,
+        Gauss
     };
 
     enum class RasterRendererFlag /BaseType=IntFlag/
     {
-      InternalLayerOpacityHandling,
-      UseNoDataForOutOfRangePixels,
+        InternalLayerOpacityHandling,
+        UseNoDataForOutOfRangePixels,
     };
 
     typedef QFlags<Qgis::RasterRendererFlag> RasterRendererFlags;
@@ -938,31 +944,31 @@ The development version
 
     enum class RasterRendererCapability /BaseType=IntFlag/
     {
-      UsesMultipleBands,
+        UsesMultipleBands,
     };
 
     typedef QFlags<Qgis::RasterRendererCapability> RasterRendererCapabilities;
 
 
     enum class RasterRangeLimit /BaseType=IntEnum/
-      {
-      NotSet,
-      MinimumMaximum,
-      StdDev,
-      CumulativeCut
+    {
+        NotSet,
+               MinimumMaximum,
+               StdDev,
+               CumulativeCut
     };
 
     enum class RasterRangeExtent /BaseType=IntEnum/
-      {
-      WholeRaster,
-      FixedCanvas,
-      UpdatedCanvas,
+    {
+        WholeRaster,
+                    FixedCanvas,
+                    UpdatedCanvas,
     };
 
     enum class RasterRangeAccuracy /BaseType=IntEnum/
-      {
-      Exact,
-      Estimated,
+    {
+        Exact,
+        Estimated,
     };
 
     enum class RasterAttributeTableFieldUsage /BaseType=IntEnum/
@@ -995,20 +1001,20 @@ The development version
     };
 
     enum class RasterExportType /BaseType=IntEnum/
-      {
-      Raw,
-      RenderedImage
+    {
+        Raw,
+        RenderedImage
     };
 
     enum class RasterFileWriterResult /BaseType=IntEnum/
-      {
-      Success,
-      SourceProviderError,
-      DestinationProviderError,
-      CreateDatasourceError,
-      WriteError,
-      NoDataConflict,
-      Canceled,
+    {
+        Success,
+        SourceProviderError,
+        DestinationProviderError,
+        CreateDatasourceError,
+        WriteError,
+        NoDataConflict,
+        Canceled,
     };
 
     enum class MeshEditingErrorType /BaseType=IntEnum/
@@ -1037,20 +1043,20 @@ The development version
     };
 
     enum class FieldOrigin /BaseType=IntEnum/
-      {
-      Unknown,
-      Provider,
-      Join,
-      Edit,
-      Expression
+    {
+        Unknown,
+                Provider,
+                Join,
+                Edit,
+                Expression
     };
 
     enum class FieldConfigurationFlag /BaseType=IntFlag/
     {
-      NoFlag,
-      NotSearchable,
-      HideFromWms,
-      HideFromWfs,
+        NoFlag,
+        NotSearchable,
+        HideFromWms,
+        HideFromWfs,
     };
 
     typedef QFlags<Qgis::FieldConfigurationFlag> FieldConfigurationFlags;
@@ -1071,11 +1077,11 @@ The development version
     };
 
     enum class SelectBehavior /BaseType=IntEnum/
-      {
-      SetSelection,
-      AddToSelection,
-      IntersectSelection,
-      RemoveFromSelection,
+    {
+        SetSelection,
+        AddToSelection,
+        IntersectSelection,
+        RemoveFromSelection,
     };
 
     enum class SelectGeometryRelationship /BaseType=IntEnum/
@@ -1086,8 +1092,8 @@ The development version
 
     enum class SelectionFlag /BaseType=IntFlag/
     {
-      SingleFeatureSelection,
-      ToggleSelection,
+        SingleFeatureSelection,
+        ToggleSelection,
     };
 
     typedef QFlags<Qgis::SelectionFlag> SelectionFlags;
@@ -1095,19 +1101,19 @@ The development version
 
 
     enum class VectorEditResult /BaseType=IntEnum/
-      {
-      Success,
-      EmptyGeometry,
-      EditFailed,
-      FetchFeatureFailed,
-      InvalidLayer,
+    {
+        Success,
+        EmptyGeometry,
+        EditFailed,
+        FetchFeatureFailed,
+        InvalidLayer,
     };
 
     enum class VertexMarkerType /BaseType=IntEnum/
-      {
-      SemiTransparentCircle,
-      Cross,
-      NoMarker,
+    {
+        SemiTransparentCircle,
+        Cross,
+        NoMarker,
     };
 
     enum class ContentStatus /BaseType=IntEnum/
@@ -1128,18 +1134,18 @@ The development version
     };
 
     enum class DeviceConnectionStatus /BaseType=IntEnum/
-      {
-      Disconnected,
-      Connecting,
-      Connected,
+    {
+        Disconnected,
+        Connecting,
+        Connected,
     };
 
     enum class GpsFixStatus /BaseType=IntEnum/
-      {
-      NoData,
-      NoFix,
-      Fix2D,
-      Fix3D
+    {
+        NoData,
+        NoFix,
+        Fix2D,
+        Fix3D
     };
 
 
@@ -1179,26 +1185,26 @@ The development version
 
     enum class GpsInformationComponent /BaseType=IntFlag/
     {
-      Location,
-      Altitude,
-      GroundSpeed,
-      Bearing,
-      TotalTrackLength,
-      TrackDistanceFromStart,
-      Pdop,
-      Hdop,
-      Vdop,
-      HorizontalAccuracy,
-      VerticalAccuracy,
-      HvAccuracy,
-      SatellitesUsed,
-      Timestamp,
-      TrackStartTime,
-      TrackEndTime,
-      TrackDistanceSinceLastPoint,
-      TrackTimeSinceLastPoint,
-      GeoidalSeparation,
-      EllipsoidAltitude,
+        Location,
+        Altitude,
+        GroundSpeed,
+        Bearing,
+        TotalTrackLength,
+        TrackDistanceFromStart,
+        Pdop,
+        Hdop,
+        Vdop,
+        HorizontalAccuracy,
+        VerticalAccuracy,
+        HvAccuracy,
+        SatellitesUsed,
+        Timestamp,
+        TrackStartTime,
+        TrackEndTime,
+        TrackDistanceSinceLastPoint,
+        TrackTimeSinceLastPoint,
+        GeoidalSeparation,
+        EllipsoidAltitude,
     };
 
     typedef QFlags<Qgis::GpsInformationComponent> GpsInformationComponents;
@@ -1206,18 +1212,18 @@ The development version
 
     enum class BabelFormatCapability /BaseType=IntFlag/
     {
-      Import,
-      Export,
-      Waypoints,
-      Routes,
-      Tracks,
+        Import,
+        Export,
+        Waypoints,
+        Routes,
+        Tracks,
     };
     typedef QFlags<Qgis::BabelFormatCapability> BabelFormatCapabilities;
 
 
     enum class BabelCommandFlag /BaseType=IntFlag/
     {
-      QuoteFilePaths,
+        QuoteFilePaths,
     };
     typedef QFlags<Qgis::BabelCommandFlag> BabelCommandFlags;
 
@@ -1230,59 +1236,59 @@ The development version
     };
 
     enum class GeometryOperationResult /BaseType=IntEnum/
-      {
-      Success,
-      NothingHappened,
-      InvalidBaseGeometry,
-      InvalidInputGeometryType,
-      SelectionIsEmpty,
-      SelectionIsGreaterThanOne,
-      GeometryEngineError,
-      LayerNotEditable,
-      // Add part issues
-      AddPartSelectedGeometryNotFound,
-      AddPartNotMultiGeometry,
-      // Add ring issues
-      AddRingNotClosed,
-      AddRingNotValid,
-      AddRingCrossesExistingRings,
-      AddRingNotInExistingFeature,
-      // Split features
-      SplitCannotSplitPoint,
-      GeometryTypeHasChanged,
+    {
+        Success,
+        NothingHappened,
+        InvalidBaseGeometry,
+        InvalidInputGeometryType,
+        SelectionIsEmpty,
+        SelectionIsGreaterThanOne,
+        GeometryEngineError,
+        LayerNotEditable,
+        // Add part issues
+        AddPartSelectedGeometryNotFound,
+        AddPartNotMultiGeometry,
+        // Add ring issues
+        AddRingNotClosed,
+        AddRingNotValid,
+        AddRingCrossesExistingRings,
+        AddRingNotInExistingFeature,
+        // Split features
+        SplitCannotSplitPoint,
+        GeometryTypeHasChanged,
     };
 
     enum class GeometryValidityFlag /BaseType=IntFlag/
     {
-      AllowSelfTouchingHoles,
+        AllowSelfTouchingHoles,
     };
     typedef QFlags<Qgis::GeometryValidityFlag> GeometryValidityFlags;
 
 
     enum class GeometryValidationEngine /BaseType=IntEnum/
-      {
-      QgisInternal,
-      Geos,
+    {
+        QgisInternal,
+                     Geos,
     };
 
     enum class BufferSide /BaseType=IntEnum/
-      {
-      Left,
-      Right,
+    {
+        Left,
+        Right,
     };
 
     enum class EndCapStyle /BaseType=IntEnum/
-      {
-      Round,
-      Flat,
-      Square,
+    {
+        Round,
+        Flat,
+        Square,
     };
 
     enum class JoinStyle /BaseType=IntEnum/
-      {
-      Round,
-      Miter,
-      Bevel,
+    {
+        Round,
+        Miter,
+        Bevel,
     };
 
     enum class JoinStyle3D /BaseType=IntEnum/
@@ -1294,8 +1300,8 @@ The development version
 
     enum class GeosCreationFlag /BaseType=IntFlag/
     {
-      RejectOnInvalidSubGeometry,
-      SkipEmptyInteriorRings,
+        RejectOnInvalidSubGeometry,
+        SkipEmptyInteriorRings,
     };
 
     typedef QFlags<Qgis::GeosCreationFlag> GeosCreationFlags;
@@ -1316,30 +1322,30 @@ The development version
 
     enum class FeatureRequestFlag /BaseType=IntFlag/
     {
-      NoFlags,
-      NoGeometry,
-      SubsetOfAttributes,
-      ExactIntersect,
-      IgnoreStaticNodesDuringExpressionCompilation,
-      EmbeddedSymbols,
+        NoFlags,
+        NoGeometry,
+        SubsetOfAttributes,
+        ExactIntersect,
+        IgnoreStaticNodesDuringExpressionCompilation,
+        EmbeddedSymbols,
     };
 
     typedef QFlags<Qgis::FeatureRequestFlag> FeatureRequestFlags;
 
 
     enum class FeatureRequestFilterType /BaseType=IntEnum/
-      {
-      NoFilter,
-      Fid,
-      Expression,
-      Fids
+    {
+        NoFilter,
+                 Fid,
+                 Expression,
+                 Fids
     };
 
     enum class InvalidGeometryCheck /BaseType=IntEnum/
-      {
-      NoCheck,
-      SkipInvalid,
-      AbortOnInvalid,
+    {
+        NoCheck,
+        SkipInvalid,
+        AbortOnInvalid,
     };
 
     enum class SpatialFilterType /BaseType=IntEnum/
@@ -1351,17 +1357,17 @@ The development version
 
     enum class FileOperationFlag /BaseType=IntFlag/
     {
-      IncludeMetadataFile,
-      IncludeStyleFile,
+        IncludeMetadataFile,
+        IncludeStyleFile,
     };
     typedef QFlags<Qgis::FileOperationFlag> FileOperationFlags;
 
 
     enum class MapLayerProperty /BaseType=IntFlag/
     {
-      UsersCannotToggleEditing,
-      IsBasemapLayer,
-      Is3DBasemapLayer,
+        UsersCannotToggleEditing,
+        IsBasemapLayer,
+        Is3DBasemapLayer,
     };
     typedef QFlags<Qgis::MapLayerProperty> MapLayerProperties;
 
@@ -1375,10 +1381,10 @@ The development version
 
     enum class DataProviderFlag /BaseType=IntFlag/
     {
-      IsBasemapSource,
-      FastExtent2D,
-      FastExtent3D,
-      Is3DBasemapSource,
+        IsBasemapSource,
+                        FastExtent2D,
+                        FastExtent3D,
+                        Is3DBasemapSource,
     };
     typedef QFlags<Qgis::DataProviderFlag> DataProviderFlags;
 
@@ -1452,23 +1458,23 @@ The development version
     };
 
     enum class CrsIdentifierType /BaseType=IntEnum/
-      {
-      ShortString,
-      MediumString,
-      FullString,
+    {
+        ShortString,
+        MediumString,
+        FullString,
     };
 
     enum class CrsWktVariant /BaseType=IntEnum/
-      {
-      Wkt1Gdal,
-      Wkt1Esri,
-      Wkt2_2015,
-      Wkt2_2015Simplified,
-      Wkt2_2019,
-      Wkt2_2019Simplified,
-      Preferred,
-      PreferredSimplified,
-      PreferredGdal,
+    {
+        Wkt1Gdal,
+                 Wkt1Esri,
+                 Wkt2_2015,
+                 Wkt2_2015Simplified,
+                 Wkt2_2019,
+                 Wkt2_2019Simplified,
+                 Preferred,
+                 PreferredSimplified,
+                 PreferredGdal,
     };
 
     enum class Axis /BaseType=IntEnum/
@@ -1480,9 +1486,9 @@ The development version
 
     enum class AnnotationItemFlag /BaseType=IntFlag/
     {
-      ScaleDependentBoundingBox,
-      SupportsReferenceScale,
-      SupportsCallouts,
+        ScaleDependentBoundingBox,
+        SupportsReferenceScale,
+        SupportsCallouts,
     };
     typedef QFlags<Qgis::AnnotationItemFlag> AnnotationItemFlags;
 
@@ -1496,7 +1502,7 @@ The development version
 
     enum class AnnotationItemGuiFlag /BaseType=IntFlag/
     {
-      FlagNoCreationTools,
+        FlagNoCreationTools,
     };
     typedef QFlags<Qgis::AnnotationItemGuiFlag> AnnotationItemGuiFlags;
 
@@ -1515,18 +1521,18 @@ The development version
     };
 
     enum class TemporalNavigationMode /BaseType=IntEnum/
-      {
-      Disabled,
-      Animated,
-      FixedRange,
-      Movie,
+    {
+        Disabled,
+                 Animated,
+                 FixedRange,
+                 Movie,
     };
 
     enum class AnimationState /BaseType=IntEnum/
-      {
-      Forward,
-      Reverse,
-      Idle,
+    {
+        Forward,
+        Reverse,
+        Idle,
     };
 
     enum class PlaybackOperation /BaseType=IntEnum/
@@ -1541,13 +1547,13 @@ The development version
     };
 
     enum class VectorTemporalMode /BaseType=IntEnum/
-      {
-      FixedTemporalRange,
-      FeatureDateTimeInstantFromField,
-      FeatureDateTimeStartAndEndFromFields,
-      FeatureDateTimeStartAndDurationFromFields,
-      FeatureDateTimeStartAndEndFromExpressions,
-      RedrawLayerOnly,
+    {
+        FixedTemporalRange,
+        FeatureDateTimeInstantFromField,
+        FeatureDateTimeStartAndEndFromFields,
+        FeatureDateTimeStartAndDurationFromFields,
+        FeatureDateTimeStartAndEndFromExpressions,
+        RedrawLayerOnly,
     };
 
     enum class VectorTemporalLimitMode /BaseType=IntEnum/
@@ -1557,49 +1563,49 @@ The development version
     };
 
     enum class VectorDataProviderTemporalMode /BaseType=IntEnum/
-      {
-      HasFixedTemporalRange,
-      StoresFeatureDateTimeInstantInField,
-      StoresFeatureDateTimeStartAndEndInSeparateFields,
+    {
+        HasFixedTemporalRange,
+        StoresFeatureDateTimeInstantInField,
+        StoresFeatureDateTimeStartAndEndInSeparateFields,
     };
 
     enum class RasterTemporalMode /BaseType=IntEnum/
-      {
-      FixedTemporalRange,
-      TemporalRangeFromDataProvider,
-      RedrawLayerOnly,
-      FixedRangePerBand,
-      RepresentsTemporalValues,
-      FixedDateTime,
+    {
+        FixedTemporalRange,
+        TemporalRangeFromDataProvider,
+        RedrawLayerOnly,
+        FixedRangePerBand,
+        RepresentsTemporalValues,
+        FixedDateTime,
     };
 
     enum class TemporalIntervalMatchMethod /BaseType=IntEnum/
-      {
-      MatchUsingWholeRange,
-      MatchExactUsingStartOfRange,
-      MatchExactUsingEndOfRange,
-      FindClosestMatchToStartOfRange,
-      FindClosestMatchToEndOfRange
+    {
+        MatchUsingWholeRange,
+        MatchExactUsingStartOfRange,
+        MatchExactUsingEndOfRange,
+        FindClosestMatchToStartOfRange,
+        FindClosestMatchToEndOfRange
     };
 
     enum class RasterTemporalCapabilityFlag /BaseType=IntFlag/
     {
-      RequestedTimesMustExactlyMatchAllAvailableTemporalRanges,
+        RequestedTimesMustExactlyMatchAllAvailableTemporalRanges,
     };
 
     typedef QFlags<Qgis::RasterTemporalCapabilityFlag> RasterTemporalCapabilityFlags;
 
 
     enum class TransformDirection /BaseType=IntEnum/
-      {
-      Forward,
-      Reverse
+    {
+        Forward,
+                Reverse
     };
 
     enum class CoordinateTransformationFlag /BaseType=IntFlag/
     {
-      BallparkTransformsAreAppropriate,
-      IgnoreImpossibleTransformations,
+        BallparkTransformsAreAppropriate,
+                                         IgnoreImpossibleTransformations,
     };
 
     typedef QFlags<Qgis::CoordinateTransformationFlag> CoordinateTransformationFlags;
@@ -1614,63 +1620,63 @@ The development version
 
     enum class MapSettingsFlag /BaseType=IntFlag/
     {
-      Antialiasing,
-      DrawEditingInfo,
-      ForceVectorOutput,
-      UseAdvancedEffects,
-      DrawLabeling,
-      UseRenderingOptimization,
-      DrawSelection,
-      DrawSymbolBounds,
-      RenderMapTile,
-      RenderPartialOutput,
-      RenderPreviewJob,
-      RenderBlocking,
-      LosslessImageRendering,
-      Render3DMap,
-      HighQualityImageTransforms,
-      SkipSymbolRendering,
-      ForceRasterMasks,
-      RecordProfile,
-      AlwaysUseGlobalMasks,
+        Antialiasing,
+        DrawEditingInfo,
+        ForceVectorOutput,
+        UseAdvancedEffects,
+        DrawLabeling,
+        UseRenderingOptimization,
+        DrawSelection,
+        DrawSymbolBounds,
+        RenderMapTile,
+        RenderPartialOutput,
+        RenderPreviewJob,
+        RenderBlocking,
+        LosslessImageRendering,
+        Render3DMap,
+        HighQualityImageTransforms,
+        SkipSymbolRendering,
+        ForceRasterMasks,
+        RecordProfile,
+        AlwaysUseGlobalMasks,
     };
     typedef QFlags<Qgis::MapSettingsFlag> MapSettingsFlags;
 
 
     enum class RenderContextFlag /BaseType=IntFlag/
     {
-      DrawEditingInfo,
-      ForceVectorOutput,
-      UseAdvancedEffects,
-      UseRenderingOptimization,
-      DrawSelection,
-      DrawSymbolBounds,
-      RenderMapTile,
-      Antialiasing,
-      RenderPartialOutput,
-      RenderPreviewJob,
-      RenderBlocking,
-      RenderSymbolPreview,
-      LosslessImageRendering,
-      ApplyScalingWorkaroundForTextRendering,
-      Render3DMap,
-      ApplyClipAfterReprojection,
-      RenderingSubSymbol,
-      HighQualityImageTransforms,
-      SkipSymbolRendering,
-      RecordProfile,
-      AlwaysUseGlobalMasks,
-      DisableSymbolClippingToExtent,
-      RenderLayerTree
+        DrawEditingInfo,
+        ForceVectorOutput,
+        UseAdvancedEffects,
+        UseRenderingOptimization,
+        DrawSelection,
+        DrawSymbolBounds,
+        RenderMapTile,
+        Antialiasing,
+        RenderPartialOutput,
+        RenderPreviewJob,
+        RenderBlocking,
+        RenderSymbolPreview,
+        LosslessImageRendering,
+        ApplyScalingWorkaroundForTextRendering,
+        Render3DMap,
+        ApplyClipAfterReprojection,
+        RenderingSubSymbol,
+        HighQualityImageTransforms,
+        SkipSymbolRendering,
+        RecordProfile,
+        AlwaysUseGlobalMasks,
+        DisableSymbolClippingToExtent,
+        RenderLayerTree
     };
     typedef QFlags<Qgis::RenderContextFlag> RenderContextFlags;
 
 
     enum class MapLayerRendererFlag /BaseType=IntFlag/
     {
-      RenderPartialOutputs,
-      RenderPartialOutputOverPreviousCachedImage,
-      AffectsLabeling,
+        RenderPartialOutputs,
+        RenderPartialOutputOverPreviousCachedImage,
+        AffectsLabeling,
     };
 
     typedef QFlags<Qgis::MapLayerRendererFlag> MapLayerRendererFlags;
@@ -1678,7 +1684,7 @@ The development version
 
     enum class PaintEffectFlag /BaseType=IntFlag/
     {
-      RequiresRasterization,
+        RequiresRasterization,
     };
 
     typedef QFlags<Qgis::PaintEffectFlag> PaintEffectFlags;
@@ -1686,74 +1692,74 @@ The development version
 
 
     enum class TextRenderFormat /BaseType=IntEnum/
-      {
-      AlwaysOutlines,
-      AlwaysText,
-      PreferText,
+    {
+        AlwaysOutlines,
+                       AlwaysText,
+                       PreferText,
     };
 
     enum class LabelingFlag /BaseType=IntFlag/
     {
-      UseAllLabels,
-      UsePartialCandidates,
-      // TODO QGIS 5.0: remove
-      RenderOutlineLabels,
-      DrawLabelRectOnly,
-      DrawCandidates,
-      DrawUnplacedLabels,
-      CollectUnplacedLabels,
-      DrawLabelMetrics,
+        UseAllLabels,
+        UsePartialCandidates,
+        // TODO QGIS 5.0: remove
+        RenderOutlineLabels,
+        DrawLabelRectOnly,
+        DrawCandidates,
+        DrawUnplacedLabels,
+        CollectUnplacedLabels,
+        DrawLabelMetrics,
     };
 
     typedef QFlags<Qgis::LabelingFlag> LabelingFlags;
 
 
     enum class LabelPlacementEngineVersion /BaseType=IntEnum/
-      {
-      Version1,
-      Version2,
+    {
+        Version1,
+                 Version2,
     };
 
     enum class TextOrientation /BaseType=IntEnum/
-      {
-      Horizontal,
-      Vertical,
-      RotationBased,
+    {
+        Horizontal,
+                   Vertical,
+                   RotationBased,
     };
 
     enum class TextLayoutMode /BaseType=IntEnum/
-      {
-      Rectangle,
-      Point,
-      Labeling,
-      RectangleCapHeightBased,
-      RectangleAscentBased,
+    {
+        Rectangle,
+                  Point,
+                  Labeling,
+                  RectangleCapHeightBased,
+                  RectangleAscentBased,
     };
 
     enum class TextComponent /BaseType=IntFlag/
     {
-      Text,
-      Buffer,
-      Background,
-      Shadow,
+        Text,
+        Buffer,
+        Background,
+        Shadow,
     };
 
     typedef QFlags<Qgis::TextComponent> TextComponents;
 
 
     enum class TextHorizontalAlignment /BaseType=IntEnum/
-      {
-      Left,
-      Center,
-      Right,
-      Justify,
+    {
+        Left,
+             Center,
+             Right,
+             Justify,
     };
 
     enum class TextVerticalAlignment /BaseType=IntEnum/
-      {
-      Top,
-      VerticalCenter,
-      Bottom,
+    {
+        Top,
+            VerticalCenter,
+            Bottom,
     };
 
     enum class TextCharacterVerticalAlignment /BaseType=IntEnum/
@@ -1765,29 +1771,29 @@ The development version
 
     enum class CurvedTextFlag /BaseType=IntFlag/
     {
-      TruncateStringWhenLineIsTooShort,
-      UseBaselinePlacement,
-      UprightCharactersOnly,
-      ExtendLineToFitText,
+        TruncateStringWhenLineIsTooShort,
+        UseBaselinePlacement,
+        UprightCharactersOnly,
+        ExtendLineToFitText,
     };
 
     typedef QFlags<Qgis::CurvedTextFlag> CurvedTextFlags;
 
 
     enum class VectorSimplificationAlgorithm /BaseType=IntEnum/
-      {
-      Distance,
-      SnapToGrid,
-      Visvalingam,
-      SnappedToGridGlobal,
+    {
+        Distance,
+        SnapToGrid,
+        Visvalingam,
+        SnappedToGridGlobal,
     };
 
     enum class VectorRenderingSimplificationFlag /BaseType=IntFlag/
     {
-      NoSimplification,
-      GeometrySimplification,
-      AntialiasingSimplification,
-      FullSimplification,
+        NoSimplification,
+        GeometrySimplification,
+        AntialiasingSimplification,
+        FullSimplification,
     };
 
     typedef QFlags<Qgis::VectorRenderingSimplificationFlag> VectorRenderingSimplificationFlags;
@@ -1808,73 +1814,73 @@ The development version
     };
 
     enum class VertexType /BaseType=IntEnum/
-      {
-      Segment,
-      Curve,
+    {
+        Segment,
+        Curve,
       ControlPoint,
     };
 
     enum class MarkerShape /BaseType=IntEnum/
-      {
-      Square,
-      Diamond,
-      Pentagon,
-      Hexagon,
-      Triangle,
-      EquilateralTriangle,
-      Star,
-      Arrow,
-      Circle,
-      Cross,
-      CrossFill,
-      Cross2,
-      Line,
-      ArrowHead,
-      ArrowHeadFilled,
-      SemiCircle,
-      ThirdCircle,
-      QuarterCircle,
-      QuarterSquare,
-      HalfSquare,
-      DiagonalHalfSquare,
-      RightHalfTriangle,
-      LeftHalfTriangle,
-      Octagon,
-      SquareWithCorners,
-      AsteriskFill,
-      HalfArc,
-      ThirdArc,
-      QuarterArc,
-      ParallelogramRight,
-      ParallelogramLeft,
-      Trapezoid,
-      Shield,
-      DiamondStar,
-      Heart,
-      Decagon,
-      RoundedSquare,
+    {
+        Square,
+        Diamond,
+        Pentagon,
+        Hexagon,
+        Triangle,
+        EquilateralTriangle,
+        Star,
+        Arrow,
+        Circle,
+        Cross,
+        CrossFill,
+        Cross2,
+        Line,
+        ArrowHead,
+        ArrowHeadFilled,
+        SemiCircle,
+        ThirdCircle,
+        QuarterCircle,
+        QuarterSquare,
+        HalfSquare,
+        DiagonalHalfSquare,
+        RightHalfTriangle,
+        LeftHalfTriangle,
+        Octagon,
+        SquareWithCorners,
+        AsteriskFill,
+        HalfArc,
+        ThirdArc,
+        QuarterArc,
+        ParallelogramRight,
+        ParallelogramLeft,
+        Trapezoid,
+        Shield,
+        DiamondStar,
+        Heart,
+        Decagon,
+        RoundedSquare,
     };
 
     enum class MarkerLinePlacement /BaseType=IntFlag/
     {
-      Interval,
-      Vertex,
-      LastVertex,
-      FirstVertex,
-      CentralPoint,
-      CurvePoint,
-      SegmentCenter,
-      InnerVertices,
+        Interval,
+        Vertex,
+        LastVertex,
+        FirstVertex,
+        CentralPoint,
+        CurvePoint,
+        SegmentCenter,
+        InnerVertices,
     };
     typedef QFlags<Qgis::MarkerLinePlacement> MarkerLinePlacements;
 
 
     enum class LinearReferencingPlacement /BaseType=IntFlag/
     {
-      IntervalCartesian2D,
-      IntervalZ,
-      IntervalM,
-      Vertex,
+        IntervalCartesian2D,
+        IntervalZ,
+        IntervalM,
+        Vertex,
     };
 
     enum class LinearReferencingLabelSource /BaseType=IntEnum/
@@ -1885,35 +1891,35 @@ The development version
     };
 
     enum class GradientColorSource /BaseType=IntEnum/
-      {
-      SimpleTwoColor,
-      ColorRamp,
+    {
+        SimpleTwoColor,
+        ColorRamp,
     };
 
     enum class GradientType /BaseType=IntEnum/
-      {
-      Linear,
-      Radial,
-      Conical,
+    {
+        Linear,
+        Radial,
+        Conical,
     };
 
     enum class SymbolCoordinateReference /BaseType=IntEnum/
-      {
-      Feature,
-      Viewport,
+    {
+        Feature,
+        Viewport,
     };
 
     enum class GradientSpread /BaseType=IntEnum/
-      {
-      Pad,
-      Reflect,
-      Repeat,
+    {
+        Pad,
+        Reflect,
+        Repeat,
     };
 
     enum class PointCountMethod /BaseType=IntEnum/
-      {
-      Absolute,
-      DensityBased,
+    {
+        Absolute,
+                 DensityBased,
     };
 
     enum class MarkerClipMode /BaseType=IntEnum/
@@ -1948,9 +1954,9 @@ The development version
     };
 
     enum class GraduatedMethod /BaseType=IntEnum/
-      {
-      Color,
-      Size,
+    {
+        Color,
+              Size,
     };
 
     enum class PlotAxisSuffixPlacement
@@ -1994,20 +2000,20 @@ The development version
 
 
     enum class Capitalization /BaseType=IntEnum/
-      {
-      MixedCase,
-      AllUppercase,
-      AllLowercase,
-      ForceFirstLetterToCapital,
-      SmallCaps,
-      TitleCase,
-      UpperCamelCase,
-      AllSmallCaps,
+    {
+        MixedCase,
+        AllUppercase,
+        AllLowercase,
+        ForceFirstLetterToCapital,
+        SmallCaps,
+        TitleCase,
+        UpperCamelCase,
+        AllSmallCaps,
     };
 
     enum class TextRendererFlag /BaseType=IntFlag/
     {
-      WrapLines,
+        WrapLines,
     };
     typedef QFlags<Qgis::TextRendererFlag> TextRendererFlags;
 
@@ -2019,10 +2025,10 @@ The development version
     };
 
     enum class AngularDirection /BaseType=IntEnum/
-      {
-      Clockwise,
-      CounterClockwise,
-      NoOrientation,
+    {
+        Clockwise,
+        CounterClockwise,
+        NoOrientation,
     };
 
     enum class RendererUsage /BaseType=IntEnum/
@@ -2034,7 +2040,7 @@ The development version
 
     enum class MapCanvasFlag /BaseType=IntFlag/
     {
-      ShowMainAnnotationLayer,
+        ShowMainAnnotationLayer,
     };
 
     typedef QFlags<Qgis::MapCanvasFlag> MapCanvasFlags;
@@ -2042,8 +2048,8 @@ The development version
 
     enum class ViewSyncModeFlag /BaseType=IntFlag/
     {
-      Sync3DTo2D,
-      Sync2DTo3D,
+        Sync3DTo2D,
+        Sync2DTo3D,
     };
     typedef QFlags<Qgis::ViewSyncModeFlag> ViewSyncModeFlags;
 
@@ -2057,7 +2063,7 @@ The development version
 
     enum class HistoryProviderBackend /BaseType=IntFlag/
     {
-      LocalProfile,
+        LocalProfile,
 //      Project = 1 << 1, //!< QGIS Project  (not yet implemented)
     };
     typedef QFlags<Qgis::HistoryProviderBackend> HistoryProviderBackends;
@@ -2070,28 +2076,28 @@ The development version
     };
 
     enum class ProcessingSourceType /BaseType=IntEnum/
-      {
-      MapLayer,
-      VectorAnyGeometry,
-      VectorPoint,
-      VectorLine,
-      VectorPolygon,
-      Raster,
-      File,
-      Vector,
-      Mesh,
-      Plugin,
-      PointCloud,
-      Annotation,
-      VectorTile,
-      TiledScene
+    {
+        MapLayer,
+        VectorAnyGeometry,
+        VectorPoint,
+        VectorLine,
+        VectorPolygon,
+        Raster,
+        File,
+        Vector,
+        Mesh,
+        Plugin,
+        PointCloud,
+        Annotation,
+        VectorTile,
+        TiledScene
     };
 
 
     enum class ProcessingProviderFlag /BaseType=IntFlag/
     {
-      DeemphasiseSearchResults,
-      CompatibleWithVirtualRaster,
+        DeemphasiseSearchResults,
+        CompatibleWithVirtualRaster,
     };
 
     typedef QFlags<Qgis::ProcessingProviderFlag> ProcessingProviderFlags;
@@ -2099,22 +2105,22 @@ The development version
 
     enum class ProcessingAlgorithmFlag /BaseType=IntFlag/
     {
-      HideFromToolbox,
-      HideFromModeler,
-      SupportsBatch,
-      CanCancel,
-      RequiresMatchingCrs,
-      NoThreading,
-      DisplayNameIsLiteral,
-      SupportsInPlaceEdits,
-      KnownIssues,
-      CustomException,
-      PruneModelBranchesBasedOnAlgorithmResults,
-      SkipGenericModelLogging,
-      NotAvailableInStandaloneTool,
-      RequiresProject,
-      SecurityRisk,
-      Deprecated,
+        HideFromToolbox,
+        HideFromModeler,
+        SupportsBatch,
+        CanCancel,
+        RequiresMatchingCrs,
+        NoThreading,
+        DisplayNameIsLiteral,
+        SupportsInPlaceEdits,
+        KnownIssues,
+        CustomException,
+        PruneModelBranchesBasedOnAlgorithmResults,
+        SkipGenericModelLogging,
+        NotAvailableInStandaloneTool,
+        RequiresProject,
+        SecurityRisk,
+        Deprecated,
     };
 
     typedef QFlags<Qgis::ProcessingAlgorithmFlag> ProcessingAlgorithmFlags;
@@ -2122,25 +2128,25 @@ The development version
 
     enum class ProcessingAlgorithmDocumentationFlag /BaseType=IntFlag/
     {
-      RegeneratesPrimaryKey,
-      RegeneratesPrimaryKeyInSomeScenarios,
-      RespectsEllipsoid,
+        RegeneratesPrimaryKey,
+        RegeneratesPrimaryKeyInSomeScenarios,
+        RespectsEllipsoid,
     };
 
     typedef QFlags<Qgis::ProcessingAlgorithmDocumentationFlag> ProcessingAlgorithmDocumentationFlags;
 
 
     enum class ProcessingPropertyAvailability /BaseType=IntEnum/
-      {
-      NotAvailable,
-      Available,
+    {
+        NotAvailable,
+        Available,
     };
 
     enum class ProcessingLogLevel /BaseType=IntEnum/
-      {
-      DefaultLevel,
-      Verbose,
-      ModelDebug,
+    {
+        DefaultLevel,
+        Verbose,
+        ModelDebug,
     };
 
     enum class ProcessingMode
@@ -2152,8 +2158,8 @@ The development version
 
     enum class ProcessingFeatureSourceDefinitionFlag /BaseType=IntFlag/
     {
-      OverrideDefaultGeometryCheck,
-      CreateIndividualOutputPerInputFeature,
+        OverrideDefaultGeometryCheck,
+        CreateIndividualOutputPerInputFeature,
     };
 
     typedef QFlags<Qgis::ProcessingFeatureSourceDefinitionFlag> ProcessingFeatureSourceDefinitionFlags;
@@ -2161,7 +2167,7 @@ The development version
 
     enum class ProcessingFeatureSourceFlag /BaseType=IntFlag/
     {
-      SkipGeometryValidityChecks,
+        SkipGeometryValidityChecks,
     };
 
     typedef QFlags<Qgis::ProcessingFeatureSourceFlag> ProcessingFeatureSourceFlags;
@@ -2169,7 +2175,7 @@ The development version
 
     enum class ProcessingParameterTypeFlag /BaseType=IntFlag/
     {
-      ExposeToModeler
+        ExposeToModeler
     };
 
     typedef QFlags<Qgis::ProcessingParameterTypeFlag> ProcessingParameterTypeFlags;
@@ -2177,42 +2183,42 @@ The development version
 
     enum class ProcessingParameterFlag /BaseType=IntFlag/
     {
-      Advanced,
-      Hidden,
-      Optional,
-      IsModelOutput,
+        Advanced,
+        Hidden,
+        Optional,
+        IsModelOutput,
     };
 
     typedef QFlags<Qgis::ProcessingParameterFlag> ProcessingParameterFlags;
 
 
     enum class ProcessingFileParameterBehavior /BaseType=IntEnum/
-      {
-      File,
-      Folder,
+    {
+        File,
+        Folder,
     };
 
     enum class ProcessingNumberParameterType /BaseType=IntEnum/
-      {
-      Integer,
-      Double,
+    {
+        Integer,
+        Double,
     };
 
     enum class ProcessingFieldParameterDataType /BaseType=IntEnum/
-      {
-      Any,
-      Numeric,
-      String,
-      DateTime,
-      Binary,
-      Boolean,
+    {
+        Any,
+        Numeric,
+        String,
+        DateTime,
+        Binary,
+        Boolean,
     };
 
     enum class ProcessingDateTimeParameterDataType /BaseType=IntEnum/
-      {
-      DateTime,
-      Date,
-      Time,
+    {
+        DateTime,
+        Date,
+        Time,
     };
 
     enum class ProcessingModelChildParameterSource /BaseType=IntEnum/
@@ -2233,16 +2239,16 @@ The development version
     };
 
     enum class ProcessingTinInputLayerType /BaseType=IntEnum/
-      {
-      Vertices,
-      StructureLines,
-      BreakLines
+    {
+        Vertices,
+        StructureLines,
+        BreakLines
     };
 
     enum class CrsDefinitionFormat /BaseType=IntEnum/
-      {
-      Wkt,
-      Proj,
+    {
+        Wkt,
+            Proj,
     };
 
     enum class FieldDomainSplitPolicy /BaseType=IntEnum/
@@ -2357,17 +2363,17 @@ The development version
 
     enum class ProjectFlag /BaseType=IntFlag/
     {
-      EvaluateDefaultValuesOnProviderSide,
-      TrustStoredLayerStatistics,
-      RememberLayerEditStatusBetweenSessions,
-      RememberAttributeTableWindowsBetweenSessions,
+        EvaluateDefaultValuesOnProviderSide,
+        TrustStoredLayerStatistics,
+        RememberLayerEditStatusBetweenSessions,
+        RememberAttributeTableWindowsBetweenSessions,
     };
     typedef QFlags<Qgis::ProjectFlag> ProjectFlags;
 
 
     enum class PlotToolFlag /BaseType=IntFlag/
     {
-      ShowContextMenu,
+        ShowContextMenu,
     };
     typedef QFlags<Qgis::PlotToolFlag> PlotToolFlags;
 
@@ -2433,9 +2439,9 @@ The development version
 
     enum class ProfileGeneratorFlag /BaseType=IntFlag/
     {
-      RespectsMaximumErrorMapUnit,
-      RespectsDistanceRange,
-      RespectsElevationRange,
+        RespectsMaximumErrorMapUnit,
+                                    RespectsDistanceRange,
+                                    RespectsElevationRange,
     };
     typedef QFlags<Qgis::ProfileGeneratorFlag> ProfileGeneratorFlags;
 
@@ -2448,41 +2454,41 @@ The development version
     };
 
     enum class PointCloudSymbol /BaseType=IntEnum/
-      {
-      Square,
-      Circle,
+    {
+        Square,
+        Circle,
     };
 
     enum class PointCloudDrawOrder /BaseType=IntEnum/
-      {
-      Default,
-      BottomToTop,
-      TopToBottom,
+    {
+        Default,
+        BottomToTop,
+        TopToBottom,
     };
 
     enum class AvoidIntersectionsMode /BaseType=IntEnum/
-      {
-      AllowIntersections,
-      AvoidIntersectionsCurrentLayer,
-      AvoidIntersectionsLayers,
+    {
+        AllowIntersections,
+        AvoidIntersectionsCurrentLayer,
+        AvoidIntersectionsLayers,
     };
 
     enum class ProjectFileFormat /BaseType=IntEnum/
-      {
-      Qgz,
-      Qgs,
+    {
+        Qgz,
+        Qgs,
     };
 
     enum class ProjectReadFlag /BaseType=IntFlag/
     {
-      DontResolveLayers,
-      DontLoadLayouts,
-      TrustLayerMetadata,
-      DontStoreOriginalStyles,
-      DontLoad3DViews,
-      DontLoadProjectStyles,
-      ForceReadOnlyLayers,
-      DontUpgradeAnnotations,
+        DontResolveLayers,
+        DontLoadLayouts,
+        TrustLayerMetadata,
+        DontStoreOriginalStyles,
+        DontLoad3DViews,
+        DontLoadProjectStyles,
+        ForceReadOnlyLayers,
+        DontUpgradeAnnotations,
     };
 
     typedef QFlags<Qgis::ProjectReadFlag> ProjectReadFlags;
@@ -2490,7 +2496,7 @@ The development version
 
     enum class ProjectCapability /BaseType=IntFlag/
     {
-      ProjectStyles,
+        ProjectStyles,
     };
 
     typedef QFlags<Qgis::ProjectCapability> ProjectCapabilities;
@@ -2508,27 +2514,27 @@ The development version
     };
 
     enum class ArcGisRestServiceType /BaseType=IntEnum/
-      {
-      FeatureServer,
-      MapServer,
-      ImageServer,
-      GlobeServer,
-      GPServer,
-      GeocodeServer,
-      Unknown,
-      SceneServer,
+    {
+        FeatureServer,
+                      MapServer,
+                      ImageServer,
+                      GlobeServer,
+                      GPServer,
+                      GeocodeServer,
+                      Unknown,
+                      SceneServer,
     };
 
     enum class RelationshipType /BaseType=IntEnum/
-      {
-      Normal,
-      Generated,
+    {
+        Normal,
+        Generated,
     };
 
     enum class RelationshipStrength /BaseType=IntEnum/
-      {
-      Association,
-      Composition,
+    {
+        Association,
+        Composition,
     };
 
     enum class RelationshipCardinality /BaseType=IntEnum/
@@ -2541,9 +2547,9 @@ The development version
 
     enum class RelationshipCapability /BaseType=IntFlag/
     {
-      MultipleFieldKeys,
-      ForwardPathLabel,
-      BackwardPathLabel,
+        MultipleFieldKeys,
+        ForwardPathLabel,
+        BackwardPathLabel,
     };
 
     typedef QFlags<Qgis::RelationshipCapability> RelationshipCapabilities;
@@ -2580,9 +2586,9 @@ The development version
 
     enum class ScriptLanguageCapability /BaseType=IntFlag/
     {
-      Reformat,
-      CheckSyntax,
-      ToggleComment,
+        Reformat,
+        CheckSyntax,
+        ToggleComment,
     };
 
     typedef QFlags<Qgis::ScriptLanguageCapability> ScriptLanguageCapabilities;
@@ -2597,7 +2603,7 @@ The development version
 
     enum class LayerTreeFilterFlag /BaseType=IntFlag/
     {
-      SkipVisibilityCheck,
+        SkipVisibilityCheck,
     };
 
     typedef QFlags<Qgis::LayerTreeFilterFlag> LayerTreeFilterFlags;
@@ -2605,21 +2611,21 @@ The development version
 
     enum class MapLayerLegendFlag /BaseType=IntFlag/
     {
-      ExcludeByDefault,
+        ExcludeByDefault,
     };
 
     typedef QFlags<Qgis::MapLayerLegendFlag> MapLayerLegendFlags;
 
 
     enum class LegendComponent /BaseType=IntEnum/
-      {
-      Undefined,
-      Hidden,
-      Title,
-      Group,
-      Subgroup,
-      Symbol,
-      SymbolLabel,
+    {
+        Undefined,
+        Hidden,
+        Title,
+        Group,
+        Subgroup,
+        Symbol,
+        SymbolLabel,
     };
 
     enum class LegendSyncMode /BaseType=IntEnum/
@@ -2631,7 +2637,7 @@ The development version
 
     enum class LegendJsonRenderFlag /BaseType=IntFlag/
     {
-      ShowRuleDetails,
+        ShowRuleDetails,
     };
     typedef QFlags<Qgis::LegendJsonRenderFlag> LegendJsonRenderFlags;
 
@@ -2645,10 +2651,10 @@ The development version
 
     enum class MapLayerActionTarget /BaseType=IntFlag/
     {
-      Layer,
-      SingleFeature,
-      MultipleFeatures,
-      AllActions
+        Layer,
+        SingleFeature,
+        MultipleFeatures,
+        AllActions
     };
 
     typedef QFlags<Qgis::MapLayerActionTarget> MapLayerActionTargets;
@@ -2656,23 +2662,23 @@ The development version
 
     enum class MapLayerActionFlag /BaseType=IntFlag/
     {
-      EnabledOnlyWhenEditable,
-      EnableOnlyWhenHasGeometry,
+        EnabledOnlyWhenEditable,
+        EnableOnlyWhenHasGeometry,
     };
 
     typedef QFlags<Qgis::MapLayerActionFlag> MapLayerActionFlags;
 
 
     enum class AttributeActionType /BaseType=IntEnum/
-      {
-      Generic,
-      GenericPython,
-      Mac,
-      Windows,
-      Unix,
-      OpenUrl,
-      SubmitUrlEncoded,
-      SubmitUrlMultipart,
+    {
+        Generic,
+        GenericPython,
+        Mac,
+        Windows,
+        Unix,
+        OpenUrl,
+        SubmitUrlEncoded,
+        SubmitUrlMultipart,
     };
 
     enum class MetadataDateType
@@ -2685,108 +2691,108 @@ The development version
 
 
     enum class RasterColorInterpretation /BaseType=IntEnum/
-      {
-      Undefined,
-      GrayIndex,
-      PaletteIndex,
-      RedBand,
-      GreenBand,
-      BlueBand,
-      AlphaBand,
-      HueBand,
-      SaturationBand,
-      LightnessBand,
-      CyanBand,
-      MagentaBand,
-      YellowBand,
-      BlackBand,
-      YCbCr_YBand,
-      YCbCr_CbBand,
-      YCbCr_CrBand,
-      ContinuousPalette,
+    {
+        Undefined,
+        GrayIndex,
+        PaletteIndex,
+        RedBand,
+        GreenBand,
+        BlueBand,
+        AlphaBand,
+        HueBand,
+        SaturationBand,
+        LightnessBand,
+        CyanBand,
+        MagentaBand,
+        YellowBand,
+        BlackBand,
+        YCbCr_YBand,
+        YCbCr_CbBand,
+        YCbCr_CrBand,
+        ContinuousPalette,
 
-      // Note: values between PanBand and SAR_P_Band match additions done in
-      // GDAL 3.10, except that the numeric values of the constant don't match GDAL ones
+        // Note: values between PanBand and SAR_P_Band match additions done in
+        // GDAL 3.10, except that the numeric values of the constant don't match GDAL ones
 
-      PanBand,
-      CoastalBand,
-      RedEdgeBand,
-      NIRBand,
-      SWIRBand,
-      MWIRBand,
-      LWIRBand,
-      TIRBand,
-      OtherIRBand,
-      SAR_Ka_Band,
-      SAR_K_Band,
-      SAR_Ku_Band,
-      SAR_X_Band,
-      SAR_C_Band,
-      SAR_S_Band,
-      SAR_L_Band,
-      SAR_P_Band,
+        PanBand,
+        CoastalBand,
+        RedEdgeBand,
+        NIRBand,
+        SWIRBand,
+        MWIRBand,
+        LWIRBand,
+        TIRBand,
+        OtherIRBand,
+        SAR_Ka_Band,
+        SAR_K_Band,
+        SAR_Ku_Band,
+        SAR_X_Band,
+        SAR_C_Band,
+        SAR_S_Band,
+        SAR_L_Band,
+        SAR_P_Band,
     };
 
     enum class RasterLayerType /BaseType=IntEnum/
-      {
-      GrayOrUndefined,
-      Palette,
-      MultiBand,
-      SingleBandColorData,
+    {
+        GrayOrUndefined,
+        Palette,
+        MultiBand,
+        SingleBandColorData,
     };
 
     enum class RasterDrawingStyle /BaseType=IntEnum/
-      {
-      Undefined,
-      SingleBandGray,
-      SingleBandPseudoColor,
-      PalettedColor,
-      PalettedSingleBandGray,
-      PalettedSingleBandPseudoColor,
-      PalettedMultiBandColor,
-      MultiBandSingleBandGray,
-      MultiBandSingleBandPseudoColor,
-      MultiBandColor,
-      SingleBandColorData,
+    {
+        Undefined,
+                  SingleBandGray,
+                  SingleBandPseudoColor,
+                  PalettedColor,
+                  PalettedSingleBandGray,
+                  PalettedSingleBandPseudoColor,
+                  PalettedMultiBandColor,
+                  MultiBandSingleBandGray,
+                  MultiBandSingleBandPseudoColor,
+                  MultiBandColor,
+                  SingleBandColorData,
     };
 
     enum class RasterPyramidFormat /BaseType=IntEnum/
-      {
-      GeoTiff,
-      Internal,
-      Erdas
+    {
+        GeoTiff,
+        Internal,
+        Erdas
     };
 
     enum class RasterBuildPyramidOption /BaseType=IntEnum/
-      {
-      No,
-      Yes,
-      CopyExisting
+    {
+        No,
+        Yes,
+        CopyExisting
     };
 
     enum class RasterIdentifyFormat /BaseType=IntFlag/
     {
-      Undefined,
-      Value,
-      Text,
-      Html,
-      Feature,
+        Undefined,
+        Value,
+        Text,
+        Html,
+        Feature,
     };
 
 
     enum class RasterInterfaceCapability /BaseType=IntFlag/
     {
-      NoCapabilities,
-      Size,
-      Create,
-      Remove,
-      BuildPyramids,
-      Identify,
-      IdentifyValue,
-      IdentifyText,
-      IdentifyHtml,
-      IdentifyFeature,
-      Prefetch,
+        NoCapabilities,
+        Size,
+        Create,
+        Remove,
+        BuildPyramids,
+        Identify,
+        IdentifyValue,
+        IdentifyText,
+        IdentifyHtml,
+        IdentifyFeature,
+        Prefetch,
     };
 
     typedef QFlags<Qgis::RasterInterfaceCapability> RasterInterfaceCapabilities;
@@ -2795,15 +2801,15 @@ The development version
 
     enum class RasterProviderCapability /BaseType=IntFlag/
     {
-      NoProviderCapabilities,
-      ReadLayerMetadata,
-      WriteLayerMetadata,
-      ProviderHintBenefitsFromResampling,
-      ProviderHintCanPerformProviderResampling,
-      ReloadData,
-      DpiDependentData,
-      NativeRasterAttributeTable,
-      BuildPyramids,
+        NoProviderCapabilities,
+        ReadLayerMetadata,
+        WriteLayerMetadata,
+        ProviderHintBenefitsFromResampling,
+        ProviderHintCanPerformProviderResampling,
+        ReloadData,
+        DpiDependentData,
+        NativeRasterAttributeTable,
+        BuildPyramids,
     };
 
     typedef QFlags<Qgis::RasterProviderCapability> RasterProviderCapabilities;
@@ -2816,234 +2822,234 @@ The development version
     };
 
     enum class BlendMode /BaseType=IntEnum/
-      {
-      Normal,
-      Lighten,
-      Screen,
-      Dodge,
-      Addition,
-      Darken,
-      Multiply,
-      Burn,
-      Overlay,
-      SoftLight,
-      HardLight,
-      Difference,
-      Subtract,
-      Source,
-      DestinationOver,
-      Clear,
-      Destination,
-      SourceIn,
-      DestinationIn,
-      SourceOut,
-      DestinationOut,
-      SourceAtop,
-      DestinationAtop,
-      Xor,
+    {
+        Normal,
+               Lighten,
+               Screen,
+               Dodge,
+               Addition,
+               Darken,
+               Multiply,
+               Burn,
+               Overlay,
+               SoftLight,
+               HardLight,
+               Difference,
+               Subtract,
+               Source,
+               DestinationOver,
+               Clear,
+               Destination,
+               SourceIn,
+               DestinationIn,
+               SourceOut,
+               DestinationOut,
+               SourceAtop,
+               DestinationAtop,
+               Xor,
     };
 
     enum class SystemOfMeasurement /BaseType=IntEnum/
-      {
-      Unknown,
-      Metric,
-      Imperial,
-      USCS,
+    {
+        Unknown,
+        Metric,
+        Imperial,
+        USCS,
     };
 
     enum class MapToolUnit /BaseType=IntEnum/
-      {
-      Layer,
-      Pixels,
-      Project
+    {
+        Layer,
+              Pixels,
+              Project
     };
 
     enum class UnitType /BaseType=IntEnum/
-      {
-      Distance,
-      Area,
-      Volume,
-      Unknown,
-      Temporal,
+    {
+        Distance,
+        Area,
+        Volume,
+        Unknown,
+        Temporal,
     };
 
     enum class DistanceUnit /BaseType=IntEnum/
-      {
-      Meters,
-      Kilometers,
-      Feet,
-      NauticalMiles,
-      Yards,
-      Miles,
-      Degrees,
-      Centimeters,
-      Millimeters,
-      Inches,
-      ChainsInternational,
-      ChainsBritishBenoit1895A,
-      ChainsBritishBenoit1895B,
-      ChainsBritishSears1922Truncated,
-      ChainsBritishSears1922,
-      ChainsClarkes,
-      ChainsUSSurvey,
-      FeetBritish1865,
-      FeetBritish1936,
-      FeetBritishBenoit1895A,
-      FeetBritishBenoit1895B,
-      FeetBritishSears1922Truncated,
-      FeetBritishSears1922,
-      FeetClarkes,
-      FeetGoldCoast,
-      FeetIndian,
-      FeetIndian1937,
-      FeetIndian1962,
-      FeetIndian1975,
-      FeetUSSurvey,
-      LinksInternational,
-      LinksBritishBenoit1895A,
-      LinksBritishBenoit1895B,
-      LinksBritishSears1922Truncated,
-      LinksBritishSears1922,
-      LinksClarkes,
-      LinksUSSurvey,
-      YardsBritishBenoit1895A,
-      YardsBritishBenoit1895B,
-      YardsBritishSears1922Truncated,
-      YardsBritishSears1922,
-      YardsClarkes,
-      YardsIndian,
-      YardsIndian1937,
-      YardsIndian1962,
-      YardsIndian1975,
-      MilesUSSurvey,
-      Fathoms,
-      MetersGermanLegal,
-      Unknown,
+    {
+        Meters,
+               Kilometers,
+               Feet,
+               NauticalMiles,
+               Yards,
+               Miles,
+               Degrees,
+               Centimeters,
+               Millimeters,
+               Inches,
+               ChainsInternational,
+               ChainsBritishBenoit1895A,
+               ChainsBritishBenoit1895B,
+               ChainsBritishSears1922Truncated,
+               ChainsBritishSears1922,
+               ChainsClarkes,
+               ChainsUSSurvey,
+               FeetBritish1865,
+               FeetBritish1936,
+               FeetBritishBenoit1895A,
+               FeetBritishBenoit1895B,
+               FeetBritishSears1922Truncated,
+               FeetBritishSears1922,
+               FeetClarkes,
+               FeetGoldCoast,
+               FeetIndian,
+               FeetIndian1937,
+               FeetIndian1962,
+               FeetIndian1975,
+               FeetUSSurvey,
+               LinksInternational,
+               LinksBritishBenoit1895A,
+               LinksBritishBenoit1895B,
+               LinksBritishSears1922Truncated,
+               LinksBritishSears1922,
+               LinksClarkes,
+               LinksUSSurvey,
+               YardsBritishBenoit1895A,
+               YardsBritishBenoit1895B,
+               YardsBritishSears1922Truncated,
+               YardsBritishSears1922,
+               YardsClarkes,
+               YardsIndian,
+               YardsIndian1937,
+               YardsIndian1962,
+               YardsIndian1975,
+               MilesUSSurvey,
+               Fathoms,
+               MetersGermanLegal,
+               Unknown,
     };
 
     enum class DistanceUnitType /BaseType=IntEnum/
-      {
-      Standard,
-      Geographic,
-      Unknown,
+    {
+        Standard,
+        Geographic,
+        Unknown,
     };
 
     enum class AreaUnit /BaseType=IntEnum/
-      {
-      SquareMeters,
-      SquareKilometers,
-      SquareFeet,
-      SquareYards,
-      SquareMiles,
-      Hectares,
-      Acres,
-      SquareNauticalMiles,
-      SquareDegrees,
-      SquareCentimeters,
-      SquareMillimeters,
-      SquareInches,
-      Unknown,
+    {
+        SquareMeters,
+                     SquareKilometers,
+                     SquareFeet,
+                     SquareYards,
+                     SquareMiles,
+                     Hectares,
+                     Acres,
+                     SquareNauticalMiles,
+                     SquareDegrees,
+                     SquareCentimeters,
+                     SquareMillimeters,
+                     SquareInches,
+                     Unknown,
     };
 
     enum class VolumeUnit /BaseType=IntEnum/
-      {
-      CubicMeters,
-      CubicFeet,
-      CubicYards,
-      Barrel,
-      CubicDecimeter,
-      Liters,
-      GallonUS,
-      CubicInch,
-      CubicCentimeter,
-      CubicDegrees,
-      Unknown,
+    {
+        CubicMeters,
+                    CubicFeet,
+                    CubicYards,
+                    Barrel,
+                    CubicDecimeter,
+                    Liters,
+                    GallonUS,
+                    CubicInch,
+                    CubicCentimeter,
+                    CubicDegrees,
+                    Unknown,
     };
 
     enum class AngleUnit /BaseType=IntEnum/
-      {
-      Degrees,
-      Radians,
-      Gon,
-      MinutesOfArc,
-      SecondsOfArc,
-      Turn,
-      MilliradiansSI,
-      MilNATO,
-      Unknown,
+    {
+        Degrees,
+                Radians,
+                Gon,
+                MinutesOfArc,
+                SecondsOfArc,
+                Turn,
+                MilliradiansSI,
+                MilNATO,
+                Unknown,
     };
 
     enum class TemporalUnit /BaseType=IntEnum/
-      {
-      Milliseconds,
-      Seconds,
-      Minutes,
-      Hours,
-      Days,
-      Weeks,
-      Months,
-      Years,
-      Decades,
-      Centuries,
-      IrregularStep,
-      Unknown
+    {
+        Milliseconds,
+                     Seconds,
+                     Minutes,
+                     Hours,
+                     Days,
+                     Weeks,
+                     Months,
+                     Years,
+                     Decades,
+                     Centuries,
+                     IrregularStep,
+                     Unknown
     };
 
     enum class RenderUnit /BaseType=IntEnum/
-      {
-      Millimeters,
-      MapUnits,
-      Pixels,
-      Percentage,
-      Points,
-      Inches,
-      Unknown,
-      MetersInMapUnits,
+    {
+        Millimeters,
+                    MapUnits,
+                    Pixels,
+                    Percentage,
+                    Points,
+                    Inches,
+                    Unknown,
+                    MetersInMapUnits,
     };
 
     enum class LayoutUnit /BaseType=IntEnum/
-      {
-      Millimeters,
-      Centimeters,
-      Meters,
-      Inches,
-      Feet,
-      Points,
-      Picas,
-      Pixels
+    {
+        Millimeters,
+                    Centimeters,
+                    Meters,
+                    Inches,
+                    Feet,
+                    Points,
+                    Picas,
+                    Pixels
     };
 
     enum class LayoutUnitType /BaseType=IntEnum/
-      {
-      PaperUnits,
-      ScreenUnits
+    {
+        PaperUnits,
+                   ScreenUnits
     };
 
     enum class LayoutRenderFlag /BaseType=IntFlag/
     {
-      Debug,
-      OutlineOnly,
-      Antialiasing,
-      UseAdvancedEffects,
-      ForceVectorOutput,
-      HideCoverageLayer,
-      DrawSelection,
-      DisableTiledRasterLayerRenders,
-      RenderLabelsByMapLayer,
-      LosslessImageRendering,
-      SynchronousLegendGraphics,
-      AlwaysUseGlobalMasks,
-      LimitCoverageLayerRenderToCurrentFeature,
+        Debug,
+        OutlineOnly,
+        Antialiasing,
+        UseAdvancedEffects,
+        ForceVectorOutput,
+        HideCoverageLayer,
+        DrawSelection,
+        DisableTiledRasterLayerRenders,
+        RenderLabelsByMapLayer,
+        LosslessImageRendering,
+        SynchronousLegendGraphics,
+        AlwaysUseGlobalMasks,
+        LimitCoverageLayerRenderToCurrentFeature,
     };
 
     typedef QFlags<Qgis::LayoutRenderFlag> LayoutRenderFlags;
 
 
     enum class PictureFormat /BaseType=IntEnum/
-      {
-      SVG,
-      Raster,
-      Unknown,
+    {
+        SVG,
+        Raster,
+        Unknown,
     };
 
     enum class ScaleCalculationMethod /BaseType=IntEnum/
@@ -3056,127 +3062,127 @@ The development version
     };
 
     enum class ScaleBarAlignment /BaseType=IntEnum/
-      {
-      Left,
-      Middle,
-      Right,
+    {
+        Left,
+        Middle,
+        Right,
     };
 
     enum class ScaleBarSegmentSizeMode /BaseType=IntEnum/
-      {
-      Fixed,
-      FitWidth
+    {
+        Fixed,
+        FitWidth
     };
 
     enum class ScaleBarDistanceLabelVerticalPlacement /BaseType=IntEnum/
-      {
-      AboveSegment,
-      BelowSegment,
+    {
+        AboveSegment,
+        BelowSegment,
     };
 
     enum class ScaleBarDistanceLabelHorizontalPlacement /BaseType=IntEnum/
-      {
-      CenteredEdge,
-      CenteredSegment,
+    {
+        CenteredEdge,
+        CenteredSegment,
     };
 
 
     enum class MapGridUnit /BaseType=IntEnum/
-      {
-      MapUnits,
-      Millimeters,
-      Centimeters,
-      DynamicPageSizeBased,
+    {
+        MapUnits,
+                 Millimeters,
+                 Centimeters,
+                 DynamicPageSizeBased,
     };
 
     enum class MapGridStyle /BaseType=IntEnum/
-      {
-      Lines,
-      LineCrosses,
-      Markers,
-      FrameAndAnnotationsOnly
+    {
+        Lines,
+        LineCrosses,
+        Markers,
+        FrameAndAnnotationsOnly
     };
 
     enum class MapGridComponentVisibility /BaseType=IntEnum/
-      {
-      ShowAll,
-      LatitudeOnly,
-      LongitudeOnly,
-      HideAll
+    {
+        ShowAll,
+        LatitudeOnly,
+        LongitudeOnly,
+        HideAll
     };
 
     enum class MapGridAnnotationPosition /BaseType=IntEnum/
-      {
-      InsideMapFrame,
-      OutsideMapFrame,
+    {
+        InsideMapFrame,
+        OutsideMapFrame,
     };
 
     enum class MapGridAnnotationDirection /BaseType=IntEnum/
-      {
-      Horizontal,
-      Vertical,
-      VerticalDescending,
-      BoundaryDirection,
-      AboveTick,
-      OnTick,
-      UnderTick,
+    {
+        Horizontal,
+        Vertical,
+        VerticalDescending,
+        BoundaryDirection,
+        AboveTick,
+        OnTick,
+        UnderTick,
     };
 
     enum class MapGridAnnotationFormat /BaseType=IntEnum/
-      {
-      Decimal,
-      DegreeMinute,
-      DegreeMinuteSecond,
-      DecimalWithSuffix,
-      DegreeMinuteNoSuffix,
-      DegreeMinutePadded,
-      DegreeMinuteSecondNoSuffix,
-      DegreeMinuteSecondPadded,
-      CustomFormat
+    {
+        Decimal,
+        DegreeMinute,
+        DegreeMinuteSecond,
+        DecimalWithSuffix,
+        DegreeMinuteNoSuffix,
+        DegreeMinutePadded,
+        DegreeMinuteSecondNoSuffix,
+        DegreeMinuteSecondPadded,
+        CustomFormat
     };
 
     enum class MapGridBorderSide /BaseType=IntEnum/
-      {
-      Left,
-      Right,
-      Bottom,
-      Top,
+    {
+        Left,
+        Right,
+        Bottom,
+        Top,
     };
 
     enum class MapGridFrameStyle /BaseType=IntEnum/
-      {
-      NoFrame,
-      Zebra,
-      InteriorTicks,
-      ExteriorTicks,
-      InteriorExteriorTicks,
-      LineBorder,
-      LineBorderNautical,
-      ZebraNautical,
+    {
+        NoFrame,
+        Zebra,
+        InteriorTicks,
+        ExteriorTicks,
+        InteriorExteriorTicks,
+        LineBorder,
+        LineBorderNautical,
+        ZebraNautical,
     };
 
     enum class MapGridTickLengthMode /BaseType=IntEnum/
-      {
-      OrthogonalTicks,
-      NormalizedTicks,
+    {
+        OrthogonalTicks,
+        NormalizedTicks,
     };
 
 
     enum class MapGridFrameSideFlag /BaseType=IntFlag/
     {
-      Left,
-      Right,
-      Top,
-      Bottom
+        Left,
+        Right,
+        Top,
+        Bottom
     };
 
     typedef QFlags<Qgis::MapGridFrameSideFlag> MapGridFrameSideFlags;
 
 
     enum class MapGridAnnotationType /BaseType=IntEnum/
-      {
-      Longitude,
-      Latitude
+    {
+        Longitude,
+        Latitude
     };
 
     enum class InputControllerType /BaseType=IntEnum/
@@ -3202,28 +3208,28 @@ The development version
 
     enum class DatabaseProviderConnectionCapability2 /BaseType=IntFlag/
     {
-      SetFieldComment,
-      SetFieldAlias,
-      SetTableComment,
-      EditFieldDomain,
-      DeleteFieldDomain,
+        SetFieldComment,
+        SetFieldAlias,
+        SetTableComment,
+        EditFieldDomain,
+        DeleteFieldDomain,
     };
     typedef QFlags<Qgis::DatabaseProviderConnectionCapability2> DatabaseProviderConnectionCapabilities2;
 
 
     enum class DatabaseProviderTableImportCapability /BaseType=IntFlag/
     {
-      SetGeometryColumnName,
-      SetPrimaryKeyName,
+        SetGeometryColumnName,
+        SetPrimaryKeyName,
     };
     typedef QFlags<Qgis::DatabaseProviderTableImportCapability> DatabaseProviderTableImportCapabilities;
 
 
     enum class ProviderStyleStorageCapability /BaseType=IntFlag/
     {
-      SaveToDatabase,
-      LoadFromDatabase,
-      DeleteFromDatabase
+        SaveToDatabase,
+        LoadFromDatabase,
+        DeleteFromDatabase
     };
     typedef QFlags<Qgis::ProviderStyleStorageCapability> ProviderStyleStorageCapabilities;
 
@@ -3236,16 +3242,16 @@ The development version
     };
 
     enum class AttributeEditorType /BaseType=IntEnum/
-      {
-      Container,
-      Field,
-      Relation,
-      QmlElement,
-      HtmlElement,
-      Action,
-      TextElement,
-      SpacerElement,
-      Invalid,
+    {
+        Container,
+                  Field,
+                  Relation,
+                  QmlElement,
+                  HtmlElement,
+                  Action,
+                  TextElement,
+                  SpacerElement,
+                  Invalid,
     };
 
     enum class AttributeEditorContainerType /BaseType=IntEnum/
@@ -3256,25 +3262,25 @@ The development version
     };
 
     enum class AttributeFormLayout /BaseType=IntEnum/
-      {
-      AutoGenerated,
-      DragAndDrop,
-      UiFile
+    {
+        AutoGenerated,
+        DragAndDrop,
+        UiFile
     };
 
     enum class AttributeFormSuppression /BaseType=IntEnum/
-      {
-      Default,
-      On,
-      Off
+    {
+        Default,
+        On,
+        Off
     };
 
     enum class AttributeFormPythonInitCodeSource /BaseType=IntEnum/
-      {
-      NoSource,
-      File,
-      Dialog,
-      Environment
+    {
+        NoSource,
+        File,
+        Dialog,
+        Environment
     };
 
     enum class AttributeFormReuseLastValuePolicy /BaseType=IntEnum/
@@ -3292,15 +3298,15 @@ The development version
     };
 
     enum class FeatureSymbologyExport /BaseType=IntEnum/
-      {
-      NoSymbology,
-      PerFeature,
-      PerSymbolLayer
+    {
+        NoSymbology,
+        PerFeature,
+        PerSymbolLayer
     };
 
     enum class VectorTileProviderFlag /BaseType=IntFlag/
     {
-      AlwaysUseTileMatrixSetFromProvider,
+        AlwaysUseTileMatrixSetFromProvider,
     };
 
     typedef QFlags<Qgis::VectorTileProviderFlag> VectorTileProviderFlags;
@@ -3308,7 +3314,7 @@ The development version
 
     enum class VectorTileProviderCapability /BaseType=IntFlag/
     {
-      ReadLayerMetadata,
+        ReadLayerMetadata,
     };
 
     typedef QFlags<Qgis::VectorTileProviderCapability> VectorTileProviderCapabilities;
@@ -3324,7 +3330,7 @@ The development version
 
     enum class TiledSceneProviderCapability /BaseType=IntFlag/
     {
-      ReadLayerMetadata,
+        ReadLayerMetadata,
     };
 
     typedef QFlags<Qgis::TiledSceneProviderCapability> TiledSceneProviderCapabilities;
@@ -3352,7 +3358,7 @@ The development version
 
     enum class TiledSceneRequestFlag /BaseType=IntFlag/
     {
-      NoHierarchyFetch,
+        NoHierarchyFetch,
     };
 
     typedef QFlags<Qgis::TiledSceneRequestFlag> TiledSceneRequestFlags;
@@ -3360,10 +3366,10 @@ The development version
 
     enum class TiledSceneRendererFlag /BaseType=IntFlag/
     {
-      RequiresTextures,
-      ForceRasterRender,
-      RendersTriangles,
-      RendersLines,
+        RequiresTextures,
+        ForceRasterRender,
+        RendersTriangles,
+        RendersLines,
     };
 
     typedef QFlags<Qgis::TiledSceneRendererFlag> TiledSceneRendererFlags;
@@ -3398,23 +3404,23 @@ The development version
 
     enum class ZonalStatistic /BaseType=IntFlag/
     {
-      Count,
-      Sum,
-      Mean,
-      Median,
-      StDev,
-      Min,
-      Max,
-      Range,
-      Minority,
-      Majority,
-      Variety,
-      Variance,
-      MinimumPoint,
-      MaximumPoint,
-      All,
-      AllNumeric,
-      Default,
+        Count,
+        Sum,
+        Mean,
+        Median,
+        StDev,
+        Min,
+        Max,
+        Range,
+        Minority,
+        Majority,
+        Variety,
+        Variance,
+        MinimumPoint,
+        MaximumPoint,
+        All,
+        AllNumeric,
+        Default,
     };
 
     typedef QFlags<Qgis::ZonalStatistic> ZonalStatistics;
@@ -3432,52 +3438,52 @@ The development version
     };
 
     enum class Aggregate /BaseType=IntEnum/
-      {
-      Count,
-      CountDistinct,
-      CountMissing,
-      Min,
-      Max,
-      Sum,
-      Mean,
-      Median,
-      StDev,
-      StDevSample,
-      Range,
-      Minority,
-      Majority,
-      FirstQuartile,
-      ThirdQuartile,
-      InterQuartileRange,
-      StringMinimumLength,
-      StringMaximumLength,
-      StringConcatenate,
-      GeometryCollect,
-      ArrayAggregate,
-      StringConcatenateUnique
+    {
+        Count,
+        CountDistinct,
+        CountMissing,
+        Min,
+        Max,
+        Sum,
+        Mean,
+        Median,
+        StDev,
+        StDevSample,
+        Range,
+        Minority,
+        Majority,
+        FirstQuartile,
+        ThirdQuartile,
+        InterQuartileRange,
+        StringMinimumLength,
+        StringMaximumLength,
+        StringConcatenate,
+        GeometryCollect,
+        ArrayAggregate,
+        StringConcatenateUnique
     };
 
     enum class Statistic /BaseType=IntFlag/
     {
-      Count,
-      CountMissing,
-      Sum,
-      Mean,
-      Median,
-      StDev,
-      StDevSample,
-      Min,
-      Max,
-      Range,
-      Minority,
-      Majority,
-      Variety,
-      FirstQuartile,
-      ThirdQuartile,
-      InterQuartileRange,
-      First,
-      Last,
-      All
+        Count,
+        CountMissing,
+        Sum,
+        Mean,
+        Median,
+        StDev,
+        StDevSample,
+        Min,
+        Max,
+        Range,
+        Minority,
+        Majority,
+        Variety,
+        FirstQuartile,
+        ThirdQuartile,
+        InterQuartileRange,
+        First,
+        Last,
+        All
     };
 
     typedef QFlags<Qgis::Statistic> Statistics;
@@ -3485,13 +3491,13 @@ The development version
 
     enum class DateTimeStatistic /BaseType=IntFlag/
     {
-      Count,
-      CountDistinct,
-      CountMissing,
-      Min,
-      Max,
-      Range,
-      All,
+        Count,
+        CountDistinct,
+        CountMissing,
+        Min,
+        Max,
+        Range,
+        All,
     };
 
     typedef QFlags<Qgis::DateTimeStatistic> DateTimeStatistics;
@@ -3499,17 +3505,17 @@ The development version
 
     enum class StringStatistic /BaseType=IntFlag/
     {
-      Count,
-      CountDistinct,
-      CountMissing,
-      Min,
-      Max,
-      MinimumLength,
-      MaximumLength,
-      MeanLength,
-      Minority,
-      Majority,
-      All,
+        Count,
+        CountDistinct,
+        CountMissing,
+        Min,
+        Max,
+        MinimumLength,
+        MaximumLength,
+        MeanLength,
+        Minority,
+        Majority,
+        All,
     };
 
     typedef QFlags<Qgis::StringStatistic> StringStatistics;
@@ -3517,15 +3523,15 @@ The development version
 
     enum class RasterBandStatistic /BaseType=IntFlag/
     {
-      NoStatistic,
-      Min,
-      Max,
-      Range,
-      Sum,
-      Mean,
-      StdDev,
-      SumOfSquares,
-      All
+        NoStatistic,
+        Min,
+        Max,
+        Range,
+        Sum,
+        Mean,
+        StdDev,
+        SumOfSquares,
+        All
     };
 
     typedef QFlags<Qgis::RasterBandStatistic> RasterBandStatistics;
@@ -3628,8 +3634,8 @@ The development version
 
     enum class RasterProcessingParameterCapability /BaseType=IntFlag/
     {
-      WmsScale,
-      WmsDpi,
+        WmsScale,
+        WmsDpi,
     };
 
     typedef QFlags<Qgis::RasterProcessingParameterCapability> RasterProcessingParameterCapabilities;
@@ -3646,10 +3652,10 @@ The development version
 
     enum class ExtrusionFace /BaseType=IntFlag/
     {
-      NoFace,
-      Walls,
-      Roof,
-      Floor
+        NoFace,
+        Walls,
+        Roof,
+        Floor
     };
 
     typedef QFlags<Qgis::ExtrusionFace> ExtrusionFaces;
@@ -3657,8 +3663,8 @@ The development version
 
     enum class TriangulationAlgorithm /BaseType=IntFlag/
     {
-      ConstrainedDelaunay,
-      Earcut
+        ConstrainedDelaunay,
+        Earcut
     };
 
     static const double DEFAULT_SEARCH_RADIUS_MM;

--- a/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
@@ -44,9 +44,33 @@ should appear in logs silently. Note that log viewer implementations may
 only respect notification hints for certain message levels.
 %End
 
+    static void logMessageWithFormat( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, Qgis::StringFormat format = Qgis::StringFormat::PlainText,
+                                      bool notifyUser = true, const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
+%Docstring
+Adds a ``message`` to the log instance (and creates it if necessary).
+
+If ``notifyUser`` is ``True``, then the message should be brought to the
+user's attention by various UI hints. If it is ``False``, the message
+should appear in logs silently. Note that log viewer implementations may
+only respect notification hints for certain message levels.
+
+.. versionadded:: 4.0
+%End
   signals:
 
-    void messageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level );
+ void messageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level ) /Deprecated="Since 4.0. Use messageReceivedWithFormat() instead."/;
+%Docstring
+Emitted whenever the log receives a ``message``.
+
+This signal is emitted for all messages received by the log, regardless
+of the ``notifyUser`` flag's value for the message.
+
+.. deprecated:: 4.0
+
+   Use :py:func:`~QgsMessageLog.messageReceivedWithFormat` instead.
+%End
+
+    void messageReceivedWithFormat( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::StringFormat );
 %Docstring
 Emitted whenever the log receives a ``message``.
 
@@ -147,6 +171,18 @@ Logs a message to stderr.
 :param message: the message to format
 :param tag: the tag of the message
 :param level: the log level of the message
+%End
+
+    virtual void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::StringFormat format );
+%Docstring
+Logs a message to stderr.
+
+:param message: the message to format
+:param tag: the tag of the message
+:param level: the log level of the message
+:param format: the format of the message (currently ignored)
+
+.. versionadded:: 4.0
 %End
 };
 

--- a/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
@@ -43,9 +43,7 @@ user's attention by various UI hints. If it is ``False``, the message
 should appear in logs silently. Note that log viewer implementations may
 only respect notification hints for certain message levels.
 %End
-
-    static void logMessageWithFormat( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, Qgis::StringFormat format = Qgis::StringFormat::PlainText,
-                                      bool notifyUser = true, const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
+    static void logMessageWithFormat( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, Qgis::StringFormat format = Qgis::StringFormat::PlainText, bool notifyUser = true );
 %Docstring
 Adds a ``message`` to the log instance (and creates it if necessary).
 
@@ -53,6 +51,8 @@ If ``notifyUser`` is ``True``, then the message should be brought to the
 user's attention by various UI hints. If it is ``False``, the message
 should appear in logs silently. Note that log viewer implementations may
 only respect notification hints for certain message levels.
+
+The ``format`` parameter specifies the message format.
 
 .. versionadded:: 4.0
 %End

--- a/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessagelog.sip.in
@@ -34,16 +34,7 @@ accessed through :py:func:`QgsApplication.messageLog()`.
 
 
     static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true,
-                            const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
-%Docstring
-Adds a ``message`` to the log instance (and creates it if necessary).
-
-If ``notifyUser`` is ``True``, then the message should be brought to the
-user's attention by various UI hints. If it is ``False``, the message
-should appear in logs silently. Note that log viewer implementations may
-only respect notification hints for certain message levels.
-%End
-    static void logMessageWithFormat( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, Qgis::StringFormat format = Qgis::StringFormat::PlainText, bool notifyUser = true );
+                            const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE(), Qgis::StringFormat format = Qgis::StringFormat::PlainText );
 %Docstring
 Adds a ``message`` to the log instance (and creates it if necessary).
 
@@ -52,10 +43,9 @@ user's attention by various UI hints. If it is ``False``, the message
 should appear in logs silently. Note that log viewer implementations may
 only respect notification hints for certain message levels.
 
-The ``format`` parameter specifies the message format.
-
-.. versionadded:: 4.0
+The ``format`` parameter specifies the message format (since QGIS 4.0).
 %End
+
   signals:
 
  void messageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level ) /Deprecated="Since 4.0. Use messageReceivedWithFormat() instead."/;

--- a/python/PyQt6/core/auto_generated/qgsmessageoutput.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessageoutput.sip.in
@@ -35,7 +35,7 @@ signal :py:func:`~destroyed` to notify the deletion
 
     virtual ~QgsMessageOutput();
 
-    virtual void setMessage( const QString &message, Qgis::MessageType msgType ) = 0;
+    virtual void setMessage( const QString &message, Qgis::StringFormat format ) = 0;
 %Docstring
 Sets message, it won't be displayed until
 %End
@@ -55,7 +55,7 @@ Sets title for the messages
 display the message to the user and deletes itself
 %End
 
-    static void showMessage( const QString &title, const QString &message, Qgis::MessageType msgType );
+    static void showMessage( const QString &title, const QString &message, Qgis::StringFormat format );
 %Docstring
 Display the blocking message to the user.
 %End
@@ -88,7 +88,7 @@ be the right choice for apps without GUI.
 
     QgsMessageOutputConsole();
 
-    virtual void setMessage( const QString &message, Qgis::MessageType msgType );
+    virtual void setMessage( const QString &message, Qgis::StringFormat format );
 
 
     virtual void appendMessage( const QString &message );

--- a/python/PyQt6/core/auto_generated/qgsmessageoutput.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmessageoutput.sip.in
@@ -33,11 +33,9 @@ signal :py:func:`~destroyed` to notify the deletion
 %End
   public:
 
-    enum MessageType /BaseType=IntEnum/ { MessageText, MessageHtml };
-
     virtual ~QgsMessageOutput();
 
-    virtual void setMessage( const QString &message, MessageType msgType ) = 0;
+    virtual void setMessage( const QString &message, Qgis::MessageType msgType ) = 0;
 %Docstring
 Sets message, it won't be displayed until
 %End
@@ -57,7 +55,7 @@ Sets title for the messages
 display the message to the user and deletes itself
 %End
 
-    static void showMessage( const QString &title, const QString &message, MessageType msgType );
+    static void showMessage( const QString &title, const QString &message, Qgis::MessageType msgType );
 %Docstring
 Display the blocking message to the user.
 %End
@@ -90,7 +88,7 @@ be the right choice for apps without GUI.
 
     QgsMessageOutputConsole();
 
-    virtual void setMessage( const QString &message, MessageType msgType );
+    virtual void setMessage( const QString &message, Qgis::MessageType msgType );
 
 
     virtual void appendMessage( const QString &message );

--- a/python/PyQt6/gui/auto_generated/qgsmessagelogviewer.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmessagelogviewer.sip.in
@@ -29,7 +29,7 @@ to the system's :py:func:`QgsApplication.messageLog()` instance.
 
   public slots:
 
-    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::MessageType type );
 %Docstring
 Logs a ``message`` to the viewer.
 %End

--- a/python/PyQt6/gui/auto_generated/qgsmessagelogviewer.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmessagelogviewer.sip.in
@@ -33,7 +33,7 @@ to the system's :py:func:`QgsApplication.messageLog()` instance.
 %Docstring
 Logs a ``message`` to the viewer.
 
-The ``format`` parameter defined message format (since QGIS 4.0)
+The ``format`` parameter specifies the message format (since QGIS 4.0)
 %End
 
     void showTab( const QString &tag );

--- a/python/PyQt6/gui/auto_generated/qgsmessagelogviewer.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmessagelogviewer.sip.in
@@ -29,9 +29,11 @@ to the system's :py:func:`QgsApplication.messageLog()` instance.
 
   public slots:
 
-    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::StringFormat format = Qgis::StringFormat::PlainText );
 %Docstring
 Logs a ``message`` to the viewer.
+
+The ``format`` parameter defined message format (since QGIS 4.0)
 %End
 
     void showTab( const QString &tag );

--- a/python/PyQt6/gui/auto_generated/qgsmessagelogviewer.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmessagelogviewer.sip.in
@@ -29,7 +29,7 @@ to the system's :py:func:`QgsApplication.messageLog()` instance.
 
   public slots:
 
-    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::MessageType type );
+    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
 %Docstring
 Logs a ``message`` to the viewer.
 %End

--- a/python/PyQt6/gui/auto_generated/qgsmessageviewer.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmessageviewer.sip.in
@@ -22,7 +22,7 @@ A generic message view for displaying QGIS messages.
   public:
     QgsMessageViewer( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, bool deleteOnClose = true );
 
-    virtual void setMessage( const QString &message, Qgis::MessageType msgType );
+    virtual void setMessage( const QString &message, Qgis::StringFormat format );
 
 
     virtual void appendMessage( const QString &message );

--- a/python/PyQt6/gui/auto_generated/qgsmessageviewer.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmessageviewer.sip.in
@@ -22,7 +22,7 @@ A generic message view for displaying QGIS messages.
   public:
     QgsMessageViewer( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, bool deleteOnClose = true );
 
-    virtual void setMessage( const QString &message, MessageType msgType );
+    virtual void setMessage( const QString &message, Qgis::MessageType msgType );
 
 
     virtual void appendMessage( const QString &message );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -1277,7 +1277,7 @@ bool Qgs3DMapScene::exportScene( const Qgs3DMapExportSettings &exportSettings )
     QString message = tr( "The following layers were not exported:" ) + "\n";
     for ( const QString &layerName : notParsedLayers )
       message += layerName + "\n";
-    QgsMessageOutput::showMessage( tr( "3D exporter warning" ), message, QgsMessageOutput::MessageText );
+    QgsMessageOutput::showMessage( tr( "3D exporter warning" ), message, Qgis::StringFormat::PlainText );
   }
 
   return true;

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2340,7 +2340,7 @@ bool QgsDatabaseItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiCo
             {
               QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
               output->setTitle( tr( "Import to database" ) );
-              output->setMessage( tr( "Failed to import some vector layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+              output->setMessage( tr( "Failed to import some vector layers!\n\n" ) + errorMessage, Qgis::StringFormat::PlainText );
               output->showMessage();
             }
           } );
@@ -2358,7 +2358,7 @@ bool QgsDatabaseItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiCo
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( tr( "Import to database" ) );
-    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), Qgis::StringFormat::PlainText );
     output->showMessage();
   }
   if ( hasSubTasks )

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -4064,7 +4064,7 @@ void QgsLayoutDesignerDialog::showWmsPrintingWarning()
   {
     QgsMessageViewer *m = new QgsMessageViewer( this );
     m->setWindowTitle( tr( "Project Contains WMS Layers" ) );
-    m->setMessage( tr( "Some WMS servers (e.g. UMN mapserver) have a limit for the WIDTH and HEIGHT parameter. Printing layers from such servers may exceed this limit. If this is the case, the WMS layer will not be printed" ), QgsMessageOutput::MessageText );
+    m->setMessage( tr( "Some WMS servers (e.g. UMN mapserver) have a limit for the WIDTH and HEIGHT parameter. Printing layers from such servers may exceed this limit. If this is the case, the WMS layer will not be printed" ), Qgis::StringFormat::PlainText );
     m->setCheckBoxText( tr( "Don't show this message again" ) );
     m->setCheckBoxState( Qt::Unchecked );
     m->setCheckBoxVisible( true );
@@ -4107,7 +4107,7 @@ void QgsLayoutDesignerDialog::showRasterizationWarning()
 
   QgsMessageViewer m( this, QgsGuiUtils::ModalDialogFlags, false );
   m.setWindowTitle( tr( "Composition Effects" ) );
-  m.setMessage( tr( "Advanced composition effects such as blend modes or vector layer transparency are enabled in this layout, which cannot be printed as vectors. Printing as a raster is recommended." ), QgsMessageOutput::MessageText );
+  m.setMessage( tr( "Advanced composition effects such as blend modes or vector layer transparency are enabled in this layout, which cannot be printed as vectors. Printing as a raster is recommended." ), Qgis::StringFormat::PlainText );
   m.setCheckBoxText( tr( "Print as raster" ) );
   m.setCheckBoxState( Qt::Checked );
   m.setCheckBoxVisible( true );
@@ -4126,7 +4126,7 @@ void QgsLayoutDesignerDialog::showForceVectorWarning()
 
   QgsMessageViewer m( this, QgsGuiUtils::ModalDialogFlags, false );
   m.setWindowTitle( tr( "Force Vector" ) );
-  m.setMessage( tr( "This layout has the \"Always export as vectors\" option enabled, but the layout contains effects such as blend modes or vector layer transparency, which cannot be printed as vectors. The generated file will differ from the layout contents." ), QgsMessageOutput::MessageText );
+  m.setMessage( tr( "This layout has the \"Always export as vectors\" option enabled, but the layout contains effects such as blend modes or vector layer transparency, which cannot be printed as vectors. The generated file will differ from the layout contents." ), Qgis::StringFormat::PlainText );
   m.setCheckBoxText( tr( "Never show this message again" ) );
   m.setCheckBoxState( Qt::Unchecked );
   m.setCheckBoxVisible( true );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1952,7 +1952,7 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
       connect( detailsButton, &QPushButton::clicked, this, [detailsButton, licenseDetails] {
         QgsMessageViewer *dialog = new QgsMessageViewer( detailsButton );
         dialog->setTitle( tr( "Font License" ) );
-        dialog->setMessage( licenseDetails, QgsMessageOutput::MessageText );
+        dialog->setMessage( licenseDetails, Qgis::StringFormat::PlainText );
         dialog->showMessage();
       } );
       messageWidget->layout()->addWidget( detailsButton );
@@ -1975,7 +1975,7 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
       connect( detailsButton, &QPushButton::clicked, this, [error] {
         QgsMessageViewer *dialog = new QgsMessageViewer( nullptr, QgsGuiUtils::ModalDialogFlags, true );
         dialog->setTitle( tr( "Font Install Failed" ) );
-        dialog->setMessage( error, QgsMessageOutput::MessageText );
+        dialog->setMessage( error, Qgis::StringFormat::PlainText );
         dialog->showMessage();
       } );
       messageWidget->layout()->addWidget( detailsButton );
@@ -2483,7 +2483,7 @@ QList<QgsMapLayer *> QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList
       if ( QgsMessageViewer *dialog = dynamic_cast<QgsMessageViewer *>( QgsMessageOutput::createMessageOutput() ) )
       {
         dialog->setTitle( title );
-        dialog->setMessage( longMessage, QgsMessageOutput::MessageHtml );
+        dialog->setMessage( longMessage, Qgis::StringFormat::Html );
         dialog->showMessage();
       }
     } );

--- a/src/app/qgsappcoordinateoperationhandlers.cpp
+++ b/src/app/qgsappcoordinateoperationhandlers.cpp
@@ -193,7 +193,7 @@ void QgsAppMissingGridHandler::onCoordinateOperationCreationError( const QgsCoor
     // dlg has deleted on close
     QgsMessageOutput *dlg( QgsMessageOutput::createMessageOutput() );
     dlg->setTitle( tr( "No Transformations Available" ) );
-    dlg->setMessage( longMessage, QgsMessageOutput::MessageHtml );
+    dlg->setMessage( longMessage, Qgis::StringFormat::Html );
     dlg->showMessage();
   } );
 
@@ -274,7 +274,7 @@ void QgsAppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateR
     // dlg has deleted on close
     QgsMessageOutput *dlg( QgsMessageOutput::createMessageOutput() );
     dlg->setTitle( tr( "Ballpark Transform Occurred" ) );
-    dlg->setMessage( longMessage, QgsMessageOutput::MessageHtml );
+    dlg->setMessage( longMessage, Qgis::StringFormat::Html );
     dlg->showMessage();
   } );
 
@@ -297,7 +297,7 @@ void QgsAppMissingGridHandler::onDynamicToDynamicWarning( const QgsCoordinateRef
     // dlg has deleted on close
     QgsMessageOutput *dlg( QgsMessageOutput::createMessageOutput() );
     dlg->setTitle( tr( "Unsupported Transformation" ) );
-    dlg->setMessage( longMessage, QgsMessageOutput::MessageHtml );
+    dlg->setMessage( longMessage, Qgis::StringFormat::Html );
     dlg->showMessage();
   } );
 

--- a/src/core/auth/qgsauthmethodregistry.cpp
+++ b/src/core/auth/qgsauthmethodregistry.cpp
@@ -131,7 +131,7 @@ void QgsAuthMethodRegistry::init()
 
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( QObject::tr( "No Authentication Methods" ) );
-    output->setMessage( msg, QgsMessageOutput::MessageText );
+    output->setMessage( msg, Qgis::StringFormat::PlainText );
     output->showMessage();
     return;
   }

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -103,42 +103,42 @@ class CORE_EXPORT Qgis
      */
     enum class AuthConfigurationStorageCapability: int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ClearStorage = 1 << 0, //!< Can clear all configurations from storage
+      ClearStorage = 1 << 0, //!< Can clear all configurations from storage
 
-        ReadConfiguration = 1 << 1, //!< Can read an authentication configuration
-        UpdateConfiguration = 1 << 2, //!< Can update an authentication configuration
-        DeleteConfiguration = 1 << 3, //!< Can deleet an authentication configuration
-        CreateConfiguration = 1 << 4, //!< Can create a new authentication configuration
+      ReadConfiguration = 1 << 1, //!< Can read an authentication configuration
+      UpdateConfiguration = 1 << 2, //!< Can update an authentication configuration
+      DeleteConfiguration = 1 << 3, //!< Can deleet an authentication configuration
+      CreateConfiguration = 1 << 4, //!< Can create a new authentication configuration
 
-        ReadCertificateIdentity = 1 << 5, //!< Can read a certificate identity
-        UpdateCertificateIdentity = 1 << 6, //!< Can update a certificate identity
-        DeleteCertificateIdentity = 1 << 7, //!< Can delete a certificate identity
-        CreateCertificateIdentity = 1 << 8, //!< Can create a new certificate identity
+      ReadCertificateIdentity = 1 << 5, //!< Can read a certificate identity
+      UpdateCertificateIdentity = 1 << 6, //!< Can update a certificate identity
+      DeleteCertificateIdentity = 1 << 7, //!< Can delete a certificate identity
+      CreateCertificateIdentity = 1 << 8, //!< Can create a new certificate identity
 
-        ReadSslCertificateCustomConfig = 1 << 9, //!< Can read a SSL certificate custom config
-        UpdateSslCertificateCustomConfig = 1 << 10, //!< Can update a SSL certificate custom config
-        DeleteSslCertificateCustomConfig = 1 << 11, //!< Can delete a SSL certificate custom config
-        CreateSslCertificateCustomConfig = 1 << 12, //!< Can create a new SSL certificate custom config
+      ReadSslCertificateCustomConfig = 1 << 9, //!< Can read a SSL certificate custom config
+      UpdateSslCertificateCustomConfig = 1 << 10, //!< Can update a SSL certificate custom config
+      DeleteSslCertificateCustomConfig = 1 << 11, //!< Can delete a SSL certificate custom config
+      CreateSslCertificateCustomConfig = 1 << 12, //!< Can create a new SSL certificate custom config
 
-        ReadCertificateAuthority = 1 << 13, //!< Can read a certificate authority
-        UpdateCertificateAuthority = 1 << 14, //!< Can update a certificate authority
-        DeleteCertificateAuthority = 1 << 15, //!< Can delete a certificate authority
-        CreateCertificateAuthority = 1 << 16, //!< Can create a new certificate authority
+      ReadCertificateAuthority = 1 << 13, //!< Can read a certificate authority
+      UpdateCertificateAuthority = 1 << 14, //!< Can update a certificate authority
+      DeleteCertificateAuthority = 1 << 15, //!< Can delete a certificate authority
+      CreateCertificateAuthority = 1 << 16, //!< Can create a new certificate authority
 
-        ReadCertificateTrustPolicy = 1 << 17, //!< Can read a certificate trust policy
-        UpdateCertificateTrustPolicy = 1 << 18, //!< Can update a certificate trust policy
-        DeleteCertificateTrustPolicy = 1 << 19, //!< Can delete a certificate trust policy
-        CreateCertificateTrustPolicy = 1 << 20, //!< Can create a new certificate trust policy
+      ReadCertificateTrustPolicy = 1 << 17, //!< Can read a certificate trust policy
+      UpdateCertificateTrustPolicy = 1 << 18, //!< Can update a certificate trust policy
+      DeleteCertificateTrustPolicy = 1 << 19, //!< Can delete a certificate trust policy
+      CreateCertificateTrustPolicy = 1 << 20, //!< Can create a new certificate trust policy
 
-        ReadMasterPassword = 1 << 21, //!< Can read the master password
-        UpdateMasterPassword = 1 << 22, //!< Can update the master password
-        DeleteMasterPassword = 1 << 23, //!< Can delete the master password
-        CreateMasterPassword = 1 << 24, //!< Can create a new master password
+      ReadMasterPassword = 1 << 21, //!< Can read the master password
+      UpdateMasterPassword = 1 << 22, //!< Can update the master password
+      DeleteMasterPassword = 1 << 23, //!< Can delete the master password
+      CreateMasterPassword = 1 << 24, //!< Can create a new master password
 
-        ReadSetting = 1 << 25, //!< Can read the authentication settings
-        UpdateSetting = 1 << 26, //!< Can update the authentication setting
-        DeleteSetting = 1 << 27, //!< Can delete the authentication setting
-        CreateSetting = 1 << 28, //!< Can create a new authentication setting
+      ReadSetting = 1 << 25, //!< Can read the authentication settings
+      UpdateSetting = 1 << 26, //!< Can update the authentication setting
+      DeleteSetting = 1 << 27, //!< Can delete the authentication setting
+      CreateSetting = 1 << 28, //!< Can create a new authentication setting
 
     };
     Q_ENUM( AuthConfigurationStorageCapability )
@@ -149,7 +149,6 @@ class CORE_EXPORT Qgis
      */
     Q_DECLARE_FLAGS( AuthConfigurationStorageCapabilities, AuthConfigurationStorageCapability )
     Q_FLAG( AuthConfigurationStorageCapabilities )
-
 
     /**
      * \brief Level for messages
@@ -183,7 +182,7 @@ class CORE_EXPORT Qgis
      */
     enum class NetworkRequestFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        DisableMessageLogging = 1 << 0, //!< If present, indicates that no message logging should be performed when network errors are encountered
+      DisableMessageLogging = 1 << 0, //!< If present, indicates that no message logging should be performed when network errors are encountered
     };
     Q_ENUM( NetworkRequestFlag )
 
@@ -201,16 +200,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30. Prior to 3.30 this was available as QgsMapLayerType.
      */
     enum class LayerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMapLayer, LayerType ) : int
-    {
-        Vector SIP_MONKEYPATCH_COMPAT_NAME( VectorLayer ), //!< Vector layer
-               Raster SIP_MONKEYPATCH_COMPAT_NAME( RasterLayer ), //!< Raster layer
-               Plugin SIP_MONKEYPATCH_COMPAT_NAME( PluginLayer ), //!< Plugin based layer
-               Mesh SIP_MONKEYPATCH_COMPAT_NAME( MeshLayer ),    //!< Mesh layer. Added in QGIS 3.2
-               VectorTile SIP_MONKEYPATCH_COMPAT_NAME( VectorTileLayer ), //!< Vector tile layer. Added in QGIS 3.14
-               Annotation SIP_MONKEYPATCH_COMPAT_NAME( AnnotationLayer ), //!< Contains freeform, georeferenced annotations. Added in QGIS 3.16
-               PointCloud SIP_MONKEYPATCH_COMPAT_NAME( PointCloudLayer ), //!< Point cloud layer. Added in QGIS 3.18
-               Group SIP_MONKEYPATCH_COMPAT_NAME( GroupLayer ), //!< Composite group layer. Added in QGIS 3.24
-               TiledScene, //!< Tiled scene layer. Added in QGIS 3.34
+      {
+      Vector SIP_MONKEYPATCH_COMPAT_NAME( VectorLayer ), //!< Vector layer
+      Raster SIP_MONKEYPATCH_COMPAT_NAME( RasterLayer ), //!< Raster layer
+      Plugin SIP_MONKEYPATCH_COMPAT_NAME( PluginLayer ), //!< Plugin based layer
+      Mesh SIP_MONKEYPATCH_COMPAT_NAME( MeshLayer ),    //!< Mesh layer. Added in QGIS 3.2
+      VectorTile SIP_MONKEYPATCH_COMPAT_NAME( VectorTileLayer ), //!< Vector tile layer. Added in QGIS 3.14
+      Annotation SIP_MONKEYPATCH_COMPAT_NAME( AnnotationLayer ), //!< Contains freeform, georeferenced annotations. Added in QGIS 3.16
+      PointCloud SIP_MONKEYPATCH_COMPAT_NAME( PointCloudLayer ), //!< Point cloud layer. Added in QGIS 3.18
+      Group SIP_MONKEYPATCH_COMPAT_NAME( GroupLayer ), //!< Composite group layer. Added in QGIS 3.24
+      TiledScene, //!< Tiled scene layer. Added in QGIS 3.34
     };
     Q_ENUM( LayerType )
 
@@ -221,22 +220,22 @@ class CORE_EXPORT Qgis
      */
     enum class LayerFilter SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMapLayerProxyModel, Filter ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        RasterLayer = 1,
-        NoGeometry = 2,
-        PointLayer = 4,
-        LineLayer = 8,
-        PolygonLayer = 16,
-        HasGeometry = PointLayer | LineLayer | PolygonLayer,
-        VectorLayer = NoGeometry | HasGeometry,
-        PluginLayer = 32,
-        WritableLayer = 64,
-        MeshLayer = 128, //!< QgsMeshLayer \since QGIS 3.6
-        VectorTileLayer = 256, //!< QgsVectorTileLayer \since QGIS 3.14
-        PointCloudLayer = 512, //!< QgsPointCloudLayer \since QGIS 3.18
-        AnnotationLayer = 1024, //!< QgsAnnotationLayer \since QGIS 3.22
-        TiledSceneLayer = 2048, //!< QgsTiledSceneLayer \since QGIS 3.34
-        All = RasterLayer | VectorLayer | PluginLayer | MeshLayer | VectorTileLayer | PointCloudLayer | AnnotationLayer | TiledSceneLayer, //!< All layers
-        SpatialLayer = RasterLayer | HasGeometry | PluginLayer | MeshLayer | VectorTileLayer | PointCloudLayer | AnnotationLayer | TiledSceneLayer //!< All spatial layers. \since QGIS 3.24
+      RasterLayer = 1,
+      NoGeometry = 2,
+      PointLayer = 4,
+      LineLayer = 8,
+      PolygonLayer = 16,
+      HasGeometry = PointLayer | LineLayer | PolygonLayer,
+      VectorLayer = NoGeometry | HasGeometry,
+      PluginLayer = 32,
+      WritableLayer = 64,
+      MeshLayer = 128, //!< QgsMeshLayer \since QGIS 3.6
+      VectorTileLayer = 256, //!< QgsVectorTileLayer \since QGIS 3.14
+      PointCloudLayer = 512, //!< QgsPointCloudLayer \since QGIS 3.18
+      AnnotationLayer = 1024, //!< QgsAnnotationLayer \since QGIS 3.22
+      TiledSceneLayer = 2048, //!< QgsTiledSceneLayer \since QGIS 3.34
+      All = RasterLayer | VectorLayer | PluginLayer | MeshLayer | VectorTileLayer | PointCloudLayer | AnnotationLayer | TiledSceneLayer, //!< All layers
+      SpatialLayer = RasterLayer | HasGeometry | PluginLayer | MeshLayer | VectorTileLayer | PointCloudLayer | AnnotationLayer | TiledSceneLayer //!< All spatial layers. \since QGIS 3.24
     };
     Q_DECLARE_FLAGS( LayerFilters, LayerFilter )
     Q_FLAG( LayerFilters )
@@ -248,7 +247,7 @@ class CORE_EXPORT Qgis
      */
     enum class LoadStyleFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        IgnoreMissingStyleErrors = 1 << 0, //!< If the style is missing, then don't flag it as an error. This flag can be used when the caller is not certain that a style exists, and accordingly a failure to find the style does not indicate an issue with loading the style itself.
+      IgnoreMissingStyleErrors = 1 << 0, //!< If the style is missing, then don't flag it as an error. This flag can be used when the caller is not certain that a style exists, and accordingly a failure to find the style does not indicate an issue with loading the style itself.
     };
     Q_ENUM( LoadStyleFlag )
 
@@ -288,79 +287,79 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class WkbType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsWkbTypes, Type ) : quint32
-    {
-        Unknown =  0, //!< Unknown
-        Point = 1, //!< Point
-        LineString = 2, //!< LineString
-        Polygon = 3, //!< Polygon
-        Triangle = 17, //!< Triangle
-        MultiPoint = 4, //!< MultiPoint
-        MultiLineString = 5, //!< MultiLineString
-        MultiPolygon = 6, //!< MultiPolygon
-        GeometryCollection = 7, //!< GeometryCollection
-        CircularString = 8, //!< CircularString
-        CompoundCurve = 9, //!< CompoundCurve
-        CurvePolygon = 10, //!< CurvePolygon
-        MultiCurve = 11, //!< MultiCurve
-        MultiSurface = 12, //!< MultiSurface
-        PolyhedralSurface = 15, //!< PolyhedralSurface \since QGIS 3.40
-        TIN = 16, //!< TIN \since QGIS 3.40
+      {
+      Unknown =  0, //!< Unknown
+      Point = 1, //!< Point
+      LineString = 2, //!< LineString
+      Polygon = 3, //!< Polygon
+      Triangle = 17, //!< Triangle
+      MultiPoint = 4, //!< MultiPoint
+      MultiLineString = 5, //!< MultiLineString
+      MultiPolygon = 6, //!< MultiPolygon
+      GeometryCollection = 7, //!< GeometryCollection
+      CircularString = 8, //!< CircularString
+      CompoundCurve = 9, //!< CompoundCurve
+      CurvePolygon = 10, //!< CurvePolygon
+      MultiCurve = 11, //!< MultiCurve
+      MultiSurface = 12, //!< MultiSurface
+      PolyhedralSurface = 15, //!< PolyhedralSurface \since QGIS 3.40
+      TIN = 16, //!< TIN \since QGIS 3.40
       NurbsCurve = 21, //!< NurbsCurve \since QGIS 4.0
-        NoGeometry = 100, //!< No geometry
-        PointZ = 1001, //!< PointZ
-        LineStringZ = 1002, //!< LineStringZ
-        PolygonZ = 1003, //!< PolygonZ
-        TriangleZ = 1017, //!< TriangleZ
-        MultiPointZ = 1004, //!< MultiPointZ
-        MultiLineStringZ = 1005, //!< MultiLineStringZ
-        MultiPolygonZ = 1006, //!< MultiPolygonZ
-        GeometryCollectionZ = 1007, //!< GeometryCollectionZ
-        CircularStringZ = 1008, //!< CircularStringZ
-        CompoundCurveZ = 1009, //!< CompoundCurveZ
-        CurvePolygonZ = 1010, //!< CurvePolygonZ
-        MultiCurveZ = 1011, //!< MultiCurveZ
-        MultiSurfaceZ = 1012, //!< MultiSurfaceZ
-        PolyhedralSurfaceZ = 1015, //!< PolyhedralSurfaceZ
-        TINZ = 1016, //!< TINZ
+      NoGeometry = 100, //!< No geometry
+      PointZ = 1001, //!< PointZ
+      LineStringZ = 1002, //!< LineStringZ
+      PolygonZ = 1003, //!< PolygonZ
+      TriangleZ = 1017, //!< TriangleZ
+      MultiPointZ = 1004, //!< MultiPointZ
+      MultiLineStringZ = 1005, //!< MultiLineStringZ
+      MultiPolygonZ = 1006, //!< MultiPolygonZ
+      GeometryCollectionZ = 1007, //!< GeometryCollectionZ
+      CircularStringZ = 1008, //!< CircularStringZ
+      CompoundCurveZ = 1009, //!< CompoundCurveZ
+      CurvePolygonZ = 1010, //!< CurvePolygonZ
+      MultiCurveZ = 1011, //!< MultiCurveZ
+      MultiSurfaceZ = 1012, //!< MultiSurfaceZ
+      PolyhedralSurfaceZ = 1015, //!< PolyhedralSurfaceZ
+      TINZ = 1016, //!< TINZ
       NurbsCurveZ = 1021, //!< NurbsCurveZ \since QGIS 4.0
-        PointM = 2001, //!< PointM
-        LineStringM = 2002, //!< LineStringM
-        PolygonM = 2003, //!< PolygonM
-        TriangleM = 2017, //!< TriangleM
-        MultiPointM = 2004, //!< MultiPointM
-        MultiLineStringM = 2005, //!< MultiLineStringM
-        MultiPolygonM = 2006, //!< MultiPolygonM
-        GeometryCollectionM = 2007, //!< GeometryCollectionM
-        CircularStringM = 2008, //!< CircularStringM
-        CompoundCurveM = 2009, //!< CompoundCurveM
-        CurvePolygonM = 2010, //!< CurvePolygonM
-        MultiCurveM = 2011, //!< MultiCurveM
-        MultiSurfaceM = 2012, //!< MultiSurfaceM
-        PolyhedralSurfaceM = 2015, //!< PolyhedralSurfaceM
-        TINM = 2016, //!< TINM
+      PointM = 2001, //!< PointM
+      LineStringM = 2002, //!< LineStringM
+      PolygonM = 2003, //!< PolygonM
+      TriangleM = 2017, //!< TriangleM
+      MultiPointM = 2004, //!< MultiPointM
+      MultiLineStringM = 2005, //!< MultiLineStringM
+      MultiPolygonM = 2006, //!< MultiPolygonM
+      GeometryCollectionM = 2007, //!< GeometryCollectionM
+      CircularStringM = 2008, //!< CircularStringM
+      CompoundCurveM = 2009, //!< CompoundCurveM
+      CurvePolygonM = 2010, //!< CurvePolygonM
+      MultiCurveM = 2011, //!< MultiCurveM
+      MultiSurfaceM = 2012, //!< MultiSurfaceM
+      PolyhedralSurfaceM = 2015, //!< PolyhedralSurfaceM
+      TINM = 2016, //!< TINM
       NurbsCurveM = 2021, //!< NurbsCurveM \since QGIS 4.0
-        PointZM = 3001, //!< PointZM
-        LineStringZM = 3002, //!< LineStringZM
-        PolygonZM = 3003, //!< PolygonZM
-        MultiPointZM = 3004, //!< MultiPointZM
-        MultiLineStringZM = 3005, //!< MultiLineStringZM
-        MultiPolygonZM = 3006, //!< MultiPolygonZM
-        GeometryCollectionZM = 3007, //!< GeometryCollectionZM
-        CircularStringZM = 3008, //!< CircularStringZM
-        CompoundCurveZM = 3009, //!< CompoundCurveZM
-        CurvePolygonZM = 3010, //!< CurvePolygonZM
-        MultiCurveZM = 3011, //!< MultiCurveZM
-        MultiSurfaceZM = 3012, //!< MultiSurfaceZM
-        PolyhedralSurfaceZM = 3015, //!< PolyhedralSurfaceM
-        TINZM = 3016, //!< TINZM
-        TriangleZM = 3017, //!< TriangleZM
+      PointZM = 3001, //!< PointZM
+      LineStringZM = 3002, //!< LineStringZM
+      PolygonZM = 3003, //!< PolygonZM
+      MultiPointZM = 3004, //!< MultiPointZM
+      MultiLineStringZM = 3005, //!< MultiLineStringZM
+      MultiPolygonZM = 3006, //!< MultiPolygonZM
+      GeometryCollectionZM = 3007, //!< GeometryCollectionZM
+      CircularStringZM = 3008, //!< CircularStringZM
+      CompoundCurveZM = 3009, //!< CompoundCurveZM
+      CurvePolygonZM = 3010, //!< CurvePolygonZM
+      MultiCurveZM = 3011, //!< MultiCurveZM
+      MultiSurfaceZM = 3012, //!< MultiSurfaceZM
+      PolyhedralSurfaceZM = 3015, //!< PolyhedralSurfaceM
+      TINZM = 3016, //!< TINZM
+      TriangleZM = 3017, //!< TriangleZM
       NurbsCurveZM = 3021, //!< NurbsCurveZM \since QGIS 4.0
-        Point25D = 0x80000001, //!< Point25D
-        LineString25D, //!< LineString25D
-        Polygon25D, //!< Polygon25D
-        MultiPoint25D, //!< MultiPoint25D
-        MultiLineString25D, //!< MultiLineString25D
-        MultiPolygon25D //!< MultiPolygon25D
+      Point25D = 0x80000001, //!< Point25D
+      LineString25D, //!< LineString25D
+      Polygon25D, //!< Polygon25D
+      MultiPoint25D, //!< MultiPoint25D
+      MultiLineString25D, //!< MultiLineString25D
+      MultiPolygon25D //!< MultiPolygon25D
     };
     Q_ENUM( WkbType )
 
@@ -373,12 +372,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class GeometryType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsWkbTypes, GeometryType ) : int
-    {
-        Point SIP_MONKEYPATCH_COMPAT_NAME( PointGeometry ), //!< Points
-              Line SIP_MONKEYPATCH_COMPAT_NAME( LineGeometry ), //!< Lines
-              Polygon SIP_MONKEYPATCH_COMPAT_NAME( PolygonGeometry ), //!< Polygons
-              Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownGeometry ), //!< Unknown types
-              Null SIP_MONKEYPATCH_COMPAT_NAME( NullGeometry ), //!< No geometry
+      {
+      Point SIP_MONKEYPATCH_COMPAT_NAME( PointGeometry ), //!< Points
+      Line SIP_MONKEYPATCH_COMPAT_NAME( LineGeometry ), //!< Lines
+      Polygon SIP_MONKEYPATCH_COMPAT_NAME( PolygonGeometry ), //!< Polygons
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownGeometry ), //!< Unknown types
+      Null SIP_MONKEYPATCH_COMPAT_NAME( NullGeometry ), //!< No geometry
     };
     Q_ENUM( GeometryType )
 
@@ -387,22 +386,22 @@ class CORE_EXPORT Qgis
      * This is modified and extended copy of GDALDataType.
      */
     enum class DataType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( Qgis, DataType ) : int
-    {
-        UnknownDataType = 0, //!< Unknown or unspecified type
-        Byte = 1, //!< Eight bit unsigned integer (quint8)
-        Int8 = 14, //!< Eight bit signed integer (qint8) (added in QGIS 3.30)
-        UInt16 = 2, //!< Sixteen bit unsigned integer (quint16)
-        Int16 = 3, //!< Sixteen bit signed integer (qint16)
-        UInt32 = 4, //!< Thirty two bit unsigned integer (quint32)
-        Int32 = 5, //!< Thirty two bit signed integer (qint32)
-        Float32 = 6, //!< Thirty two bit floating point (float)
-        Float64 = 7, //!< Sixty four bit floating point (double)
-        CInt16 = 8, //!< Complex Int16
-        CInt32 = 9, //!< Complex Int32
-        CFloat32 = 10, //!< Complex Float32
-        CFloat64 = 11, //!< Complex Float64
-        ARGB32 = 12, //!< Color, alpha, red, green, blue, 4 bytes the same as QImage::Format_ARGB32
-        ARGB32_Premultiplied = 13 //!< Color, alpha, red, green, blue, 4 bytes  the same as QImage::Format_ARGB32_Premultiplied
+      {
+      UnknownDataType = 0, //!< Unknown or unspecified type
+      Byte = 1, //!< Eight bit unsigned integer (quint8)
+      Int8 = 14, //!< Eight bit signed integer (qint8) (added in QGIS 3.30)
+      UInt16 = 2, //!< Sixteen bit unsigned integer (quint16)
+      Int16 = 3, //!< Sixteen bit signed integer (qint16)
+      UInt32 = 4, //!< Thirty two bit unsigned integer (quint32)
+      Int32 = 5, //!< Thirty two bit signed integer (qint32)
+      Float32 = 6, //!< Thirty two bit floating point (float)
+      Float64 = 7, //!< Sixty four bit floating point (double)
+      CInt16 = 8, //!< Complex Int16
+      CInt32 = 9, //!< Complex Int32
+      CFloat32 = 10, //!< Complex Float32
+      CFloat64 = 11, //!< Complex Float64
+      ARGB32 = 12, //!< Color, alpha, red, green, blue, 4 bytes the same as QImage::Format_ARGB32
+      ARGB32_Premultiplied = 13 //!< Color, alpha, red, green, blue, 4 bytes  the same as QImage::Format_ARGB32_Premultiplied
     };
     Q_ENUM( DataType )
 
@@ -439,7 +438,7 @@ class CORE_EXPORT Qgis
      */
     enum class VectorLayerTypeFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        SqlQuery = 1 << 0 //!< SQL query layer
+      SqlQuery = 1 << 0 //!< SQL query layer
     };
     Q_ENUM( VectorLayerTypeFlag )
     //! Vector layer type flags
@@ -451,13 +450,13 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class EmbeddedScriptMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( Qgis, PythonMacroMode ) : int
-    {
-        Never = 0,              //!< Embedded scripts never run
-        Ask = 1,                //!< User is prompted before running scripts
-        SessionOnly = 2,        //!< Only during this session (only used prior to QGIS 4.0)
-        Always = 3,             //!< Embedded scripts are always run
-        NotForThisSession = 4,  //!< Embedded scripts will not be run for this session (only used prior to QGIS 4.0)
-        NeverAsk = 5,           //!< The user is never prompted, embedded scripts are only run on trusted projects and folders \since QGIS 4.0
+      {
+      Never = 0,              //!< Embedded scripts never run
+      Ask = 1,                //!< User is prompted before running scripts
+      SessionOnly = 2,        //!< Only during this session (only used prior to QGIS 4.0)
+      Always = 3,             //!< Embedded scripts are always run
+      NotForThisSession = 4,  //!< Embedded scripts will not be run for this session (only used prior to QGIS 4.0)
+      NeverAsk = 5,           //!< The user is never prompted, embedded scripts are only run on trusted projects and folders \since QGIS 4.0
     };
     Q_ENUM( EmbeddedScriptMode )
 
@@ -495,14 +494,14 @@ class CORE_EXPORT Qgis
      */
     enum class DataProviderReadFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDataProvider, ReadFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        TrustDataSource SIP_MONKEYPATCH_COMPAT_NAME( FlagTrustDataSource ) = 1 << 0, //!< Trust datasource config (primary key unicity, geometry type and srid, etc). Improves provider load time by skipping expensive checks like primary key unicity, geometry type and srid and by using estimated metadata on data load \since QGIS 3.16
-        SkipFeatureCount = 1 << 1, //!< Make featureCount() return -1 to indicate unknown, and subLayers() to return a unknown feature count as well. Since QGIS 3.18. Only implemented by OGR provider at time of writing.
-        LoadDefaultStyle SIP_MONKEYPATCH_COMPAT_NAME( FlagLoadDefaultStyle ) = 1 << 2, //!< Reset the layer's style to the default for the datasource
-        SkipGetExtent = 1 << 3, //!< Skip the extent from provider
-        SkipFullScan = 1 << 4, //!< Skip expensive full scan on files (i.e. on delimited text) \since QGIS 3.24
-        ForceReadOnly = 1 << 5, //!< Open layer in a read-only mode \since QGIS 3.28
-        SkipCredentialsRequest =  1 << 6, //!< Skip credentials if the provided one are not valid, let the provider be invalid, avoiding to block the thread creating the provider if it is not the main thread \since QGIS 3.32
-        ParallelThreadLoading = 1 << 7, //!< Provider is created in a parallel thread than the one where it will live \since QGIS 3.32.1
+      TrustDataSource SIP_MONKEYPATCH_COMPAT_NAME( FlagTrustDataSource ) = 1 << 0, //!< Trust datasource config (primary key unicity, geometry type and srid, etc). Improves provider load time by skipping expensive checks like primary key unicity, geometry type and srid and by using estimated metadata on data load \since QGIS 3.16
+      SkipFeatureCount = 1 << 1, //!< Make featureCount() return -1 to indicate unknown, and subLayers() to return a unknown feature count as well. Since QGIS 3.18. Only implemented by OGR provider at time of writing.
+      LoadDefaultStyle SIP_MONKEYPATCH_COMPAT_NAME( FlagLoadDefaultStyle ) = 1 << 2, //!< Reset the layer's style to the default for the datasource
+      SkipGetExtent = 1 << 3, //!< Skip the extent from provider
+      SkipFullScan = 1 << 4, //!< Skip expensive full scan on files (i.e. on delimited text) \since QGIS 3.24
+      ForceReadOnly = 1 << 5, //!< Open layer in a read-only mode \since QGIS 3.28
+      SkipCredentialsRequest =  1 << 6, //!< Skip credentials if the provided one are not valid, let the provider be invalid, avoiding to block the thread creating the provider if it is not the main thread \since QGIS 3.32
+      ParallelThreadLoading = 1 << 7, //!< Provider is created in a parallel thread than the one where it will live \since QGIS 3.32.1
     };
     Q_ENUM( DataProviderReadFlag )
 
@@ -527,32 +526,32 @@ class CORE_EXPORT Qgis
      */
     enum class VectorProviderCapability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorDataProvider, Capability ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoCapabilities = 0, //!< Provider has no capabilities
-        AddFeatures = 1, //!< Allows adding features
-        DeleteFeatures = 1 <<  1, //!< Allows deletion of features
-        ChangeAttributeValues = 1 <<  2, //!< Allows modification of attribute values
-        AddAttributes = 1 <<  3, //!< Allows addition of new attributes (fields)
-        DeleteAttributes = 1 <<  4, //!< Allows deletion of attributes (fields)
-        CreateSpatialIndex = 1 <<  6, //!< Allows creation of spatial index
-        SelectAtId = 1 <<  7, //!< Fast access to features using their ID
-        ChangeGeometries = 1 <<  8, //!< Allows modifications of geometries
-        SelectEncoding = 1 << 13, //!< Allows user to select encoding
-        CreateAttributeIndex = 1 << 12, //!< Can create indexes on provider's fields
-        SimplifyGeometries = 1 << 14, //!< Supports simplification of geometries on provider side according to a distance tolerance
-        SimplifyGeometriesWithTopologicalValidation = 1 << 15, //!< Supports topological simplification of geometries on provider side according to a distance tolerance
-        TransactionSupport = 1 << 16, //!< Supports transactions
-        CircularGeometries = 1 << 17, //!< Supports circular geometry types (circularstring, compoundcurve, curvepolygon)
-        ChangeFeatures = 1 << 18, //!< Supports joint updates for attributes and geometry. Providers supporting this should still define ChangeGeometries | ChangeAttributeValues.
-        RenameAttributes = 1 << 19, //!< Supports renaming attributes (fields) \since QGIS 2.16
-        FastTruncate = 1 << 20, //!< Supports fast truncation of the layer (removing all features) \since QGIS 3.0
-        ReadLayerMetadata = 1 << 21, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
-        WriteLayerMetadata = 1 << 22, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
-        CancelSupport = 1 << 23, //!< Supports interruption of pending queries from a separated thread \since QGIS 3.2
-        CreateRenderer = 1 << 24, //!< Provider can create feature renderers using backend-specific formatting information. Since QGIS 3.2. See QgsVectorDataProvider::createRenderer().
-        CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
-        ReloadData = 1 << 26, //!< Provider is able to force reload data
-        FeatureSymbology = 1 << 27, //!< Provider is able retrieve embedded symbology associated with individual features \since QGIS 3.20
-        EditingCapabilities = AddFeatures | DeleteFeatures | ChangeAttributeValues | ChangeGeometries | AddAttributes | DeleteAttributes | RenameAttributes, //!< Bitmask of all editing capabilities
+      NoCapabilities = 0, //!< Provider has no capabilities
+      AddFeatures = 1, //!< Allows adding features
+      DeleteFeatures = 1 <<  1, //!< Allows deletion of features
+      ChangeAttributeValues = 1 <<  2, //!< Allows modification of attribute values
+      AddAttributes = 1 <<  3, //!< Allows addition of new attributes (fields)
+      DeleteAttributes = 1 <<  4, //!< Allows deletion of attributes (fields)
+      CreateSpatialIndex = 1 <<  6, //!< Allows creation of spatial index
+      SelectAtId = 1 <<  7, //!< Fast access to features using their ID
+      ChangeGeometries = 1 <<  8, //!< Allows modifications of geometries
+      SelectEncoding = 1 << 13, //!< Allows user to select encoding
+      CreateAttributeIndex = 1 << 12, //!< Can create indexes on provider's fields
+      SimplifyGeometries = 1 << 14, //!< Supports simplification of geometries on provider side according to a distance tolerance
+      SimplifyGeometriesWithTopologicalValidation = 1 << 15, //!< Supports topological simplification of geometries on provider side according to a distance tolerance
+      TransactionSupport = 1 << 16, //!< Supports transactions
+      CircularGeometries = 1 << 17, //!< Supports circular geometry types (circularstring, compoundcurve, curvepolygon)
+      ChangeFeatures = 1 << 18, //!< Supports joint updates for attributes and geometry. Providers supporting this should still define ChangeGeometries | ChangeAttributeValues.
+      RenameAttributes = 1 << 19, //!< Supports renaming attributes (fields) \since QGIS 2.16
+      FastTruncate = 1 << 20, //!< Supports fast truncation of the layer (removing all features) \since QGIS 3.0
+      ReadLayerMetadata = 1 << 21, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
+      WriteLayerMetadata = 1 << 22, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
+      CancelSupport = 1 << 23, //!< Supports interruption of pending queries from a separated thread \since QGIS 3.2
+      CreateRenderer = 1 << 24, //!< Provider can create feature renderers using backend-specific formatting information. Since QGIS 3.2. See QgsVectorDataProvider::createRenderer().
+      CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
+      ReloadData = 1 << 26, //!< Provider is able to force reload data
+      FeatureSymbology = 1 << 27, //!< Provider is able retrieve embedded symbology associated with individual features \since QGIS 3.20
+      EditingCapabilities = AddFeatures | DeleteFeatures | ChangeAttributeValues | ChangeGeometries | AddAttributes | DeleteAttributes | RenameAttributes, //!< Bitmask of all editing capabilities
     };
     Q_ENUM( VectorProviderCapability )
 
@@ -572,9 +571,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class FeatureCountState SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorDataProvider, FeatureCountState ) : int
-    {
-        Uncounted = -2, //!< Feature count not yet computed
-        UnknownCount = -1, //!< Provider returned an unknown feature count
+      {
+      Uncounted = -2, //!< Feature count not yet computed
+      UnknownCount = -1, //!< Provider returned an unknown feature count
     };
     Q_ENUM( FeatureCountState )
 
@@ -585,10 +584,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class SpatialIndexPresence SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFeatureSource, SpatialIndexPresence ) : int
-    {
-        Unknown SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexUnknown ) = 0, //!< Spatial index presence cannot be determined, index may or may not exist
-        NotPresent SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexNotPresent ) = 1, //!< No spatial index exists for the source
-        Present SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexPresent ) = 2, //!< A valid spatial index exists for the source
+      {
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexUnknown ) = 0, //!< Spatial index presence cannot be determined, index may or may not exist
+      NotPresent SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexNotPresent ) = 1, //!< No spatial index exists for the source
+      Present SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexPresent ) = 2, //!< A valid spatial index exists for the source
     };
     Q_ENUM( SpatialIndexPresence )
 
@@ -604,10 +603,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class FeatureAvailability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFeatureSource, FeatureAvailability ) : int
-    {
-        NoFeaturesAvailable = 0, //!< There are certainly no features available in this source
-        FeaturesAvailable, //!< There is at least one feature available in this source
-        FeaturesMaybeAvailable //!< There may be features available in this source
+      {
+      NoFeaturesAvailable = 0, //!< There are certainly no features available in this source
+      FeaturesAvailable, //!< There is at least one feature available in this source
+      FeaturesMaybeAvailable //!< There may be features available in this source
     };
     Q_ENUM( FeatureAvailability )
 
@@ -618,8 +617,8 @@ class CORE_EXPORT Qgis
      */
     enum class VectorDataProviderAttributeEditCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        EditAlias = 1 << 0, //!< Allows editing aliases
-        EditComment = 1 << 1, //!< Allows editing comments
+      EditAlias = 1 << 0, //!< Allows editing aliases
+      EditComment = 1 << 1, //!< Allows editing comments
     };
 
     Q_ENUM( VectorDataProviderAttributeEditCapability )
@@ -637,11 +636,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class SymbolType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbol, SymbolType ) : int
-    {
-        Marker, //!< Marker symbol
-        Line, //!< Line symbol
-        Fill, //!< Fill symbol
-        Hybrid //!< Hybrid symbol
+      {
+      Marker, //!< Marker symbol
+      Line, //!< Line symbol
+      Fill, //!< Fill symbol
+      Hybrid //!< Hybrid symbol
     };
     Q_ENUM( SymbolType )
 
@@ -651,9 +650,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class ScaleMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbol, ScaleMethod ) : int
-    {
-        ScaleArea,     //!< Calculate scale by the area
-        ScaleDiameter  //!< Calculate scale by the diameter
+      {
+      ScaleArea,     //!< Calculate scale by the area
+      ScaleDiameter  //!< Calculate scale by the diameter
     };
     Q_ENUM( ScaleMethod )
 
@@ -662,17 +661,17 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class SettingsType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSettingsEntryBase, SettingsType ) : int
-    {
-        Custom, //!< Custom implementation
-        Variant, //!< Generic variant
-        String, //!< String
-        StringList, //!< List of strings
-        VariantMap, //!< Map of strings
-        Bool, //!< Boolean
-        Integer, //!< Integer
-        Double, //!< Double precision number
-        EnumFlag, //!< Enum or Flag
-        Color //!< Color
+      {
+      Custom, //!< Custom implementation
+      Variant, //!< Generic variant
+      String, //!< String
+      StringList, //!< List of strings
+      VariantMap, //!< Map of strings
+      Bool, //!< Boolean
+      Integer, //!< Integer
+      Double, //!< Double precision number
+      EnumFlag, //!< Enum or Flag
+      Color //!< Color
     };
     Q_ENUM( SettingsType )
 
@@ -694,7 +693,7 @@ class CORE_EXPORT Qgis
      */
     enum class SettingsTreeNodeOption : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NamedListSelectedItemSetting = 1 << 0, //!< Creates a setting to store which is the current item
+      NamedListSelectedItemSetting = 1 << 0, //!< Creates a setting to store which is the current item
     };
 
     Q_ENUM( SettingsTreeNodeOption )
@@ -709,11 +708,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class PropertyType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProperty, Type ): int
-    {
-        Invalid SIP_MONKEYPATCH_COMPAT_NAME( InvalidProperty ), //!< Invalid (not set) property
-                Static SIP_MONKEYPATCH_COMPAT_NAME( StaticProperty ), //!< Static property
-                Field SIP_MONKEYPATCH_COMPAT_NAME( FieldBasedProperty ), //!< Field based property
-                Expression SIP_MONKEYPATCH_COMPAT_NAME( ExpressionBasedProperty ), //!< Expression based property
+      {
+      Invalid SIP_MONKEYPATCH_COMPAT_NAME( InvalidProperty ), //!< Invalid (not set) property
+      Static SIP_MONKEYPATCH_COMPAT_NAME( StaticProperty ), //!< Static property
+      Field SIP_MONKEYPATCH_COMPAT_NAME( FieldBasedProperty ), //!< Field based property
+      Expression SIP_MONKEYPATCH_COMPAT_NAME( ExpressionBasedProperty ), //!< Expression based property
     };
     Q_ENUM( PropertyType )
 
@@ -724,9 +723,9 @@ class CORE_EXPORT Qgis
      */
     enum class SldExportOption : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoOptions = 0,                      //!< Default SLD export
-        Svg = 1 << 0,                       //!< Export complex styles to separate SVG files for better compatibility with OGC servers
-        Png = 1 << 1,                       //!< Export complex styles to separate PNG files for better compatibility with OGC servers
+      NoOptions = 0,                      //!< Default SLD export
+      Svg = 1 << 0,                       //!< Export complex styles to separate SVG files for better compatibility with OGC servers
+      Png = 1 << 1,                       //!< Export complex styles to separate PNG files for better compatibility with OGC servers
     };
     Q_ENUM( SldExportOption )
     Q_DECLARE_FLAGS( SldExportOptions, SldExportOption )
@@ -739,9 +738,9 @@ class CORE_EXPORT Qgis
      */
     enum class SldExportVendorExtension : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoVendorExtension = 0,             //!< No vendor extensions
-        GeoServerVendorExtension = 1 << 1, //!< Use GeoServer vendor extensions when required
-        DeegreeVendorExtension = 1 << 2,   //!< Use Deegree vendor extensions when required
+      NoVendorExtension = 0,             //!< No vendor extensions
+      GeoServerVendorExtension = 1 << 1, //!< Use GeoServer vendor extensions when required
+      DeegreeVendorExtension = 1 << 2,   //!< Use Deegree vendor extensions when required
     };
     Q_ENUM( SldExportVendorExtension )
 
@@ -752,8 +751,8 @@ class CORE_EXPORT Qgis
      */
     enum class SettingsOption : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        SaveFormerValue = 1 << 1, //!< Save the former value of the settings
-        SaveEnumFlagAsInt = 1 << 2, //!< The enum/flag will be saved as an integer value instead of text
+      SaveFormerValue = 1 << 1, //!< Save the former value of the settings
+      SaveEnumFlagAsInt = 1 << 2, //!< The enum/flag will be saved as an integer value instead of text
     };
     Q_ENUM( SettingsOption )
     Q_DECLARE_FLAGS( SettingsOptions, SettingsOption )
@@ -764,10 +763,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class SnappingMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSnappingConfig, SnappingMode ) : int
-    {
-        ActiveLayer = 1, //!< On the active layer
-        AllLayers = 2, //!< On all vector layers
-        AdvancedConfiguration = 3, //!< On a per layer configuration basis
+      {
+      ActiveLayer = 1, //!< On the active layer
+      AllLayers = 2, //!< On all vector layers
+      AdvancedConfiguration = 3, //!< On a per layer configuration basis
     };
     Q_ENUM( SnappingMode )
 
@@ -777,13 +776,13 @@ class CORE_EXPORT Qgis
      */
     enum class SnappingType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSnappingConfig, SnappingTypes ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoSnap SIP_MONKEYPATCH_COMPAT_NAME( NoSnapFlag ) = 0, //!< No snapping
-        Vertex SIP_MONKEYPATCH_COMPAT_NAME( VertexFlag ) = 1 << 0, //!< On vertices
-        Segment SIP_MONKEYPATCH_COMPAT_NAME( SegmentFlag ) = 1 << 1, //!< On segments
-        Area SIP_MONKEYPATCH_COMPAT_NAME( AreaFlag ) = 1 << 2, //!< On Area
-        Centroid SIP_MONKEYPATCH_COMPAT_NAME( CentroidFlag ) = 1 << 3, //!< On centroid
-        MiddleOfSegment SIP_MONKEYPATCH_COMPAT_NAME( MiddleOfSegmentFlag ) = 1 << 4, //!< On Middle segment
-        LineEndpoint SIP_MONKEYPATCH_COMPAT_NAME( LineEndpointFlag ) = 1 << 5, //!< Start or end points of lines, or first vertex in polygon rings only \since QGIS 3.20
+      NoSnap SIP_MONKEYPATCH_COMPAT_NAME( NoSnapFlag ) = 0, //!< No snapping
+      Vertex SIP_MONKEYPATCH_COMPAT_NAME( VertexFlag ) = 1 << 0, //!< On vertices
+      Segment SIP_MONKEYPATCH_COMPAT_NAME( SegmentFlag ) = 1 << 1, //!< On segments
+      Area SIP_MONKEYPATCH_COMPAT_NAME( AreaFlag ) = 1 << 2, //!< On Area
+      Centroid SIP_MONKEYPATCH_COMPAT_NAME( CentroidFlag ) = 1 << 3, //!< On centroid
+      MiddleOfSegment SIP_MONKEYPATCH_COMPAT_NAME( MiddleOfSegmentFlag ) = 1 << 4, //!< On Middle segment
+      LineEndpoint SIP_MONKEYPATCH_COMPAT_NAME( LineEndpointFlag ) = 1 << 5, //!< Start or end points of lines, or first vertex in polygon rings only \since QGIS 3.20
     };
     Q_ENUM( SnappingType )
     //! Snapping types
@@ -797,10 +796,10 @@ class CORE_EXPORT Qgis
      */
     enum class SymbolRenderHint SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbol, RenderHint ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        DynamicRotation = 1 << 1, //!< Rotation of symbol may be changed during rendering and symbol should not be cached
-        IsSymbolLayerSubSymbol = 1 << 2, //!< Symbol is being rendered as a sub-symbol of a QgsSymbolLayer \since QGIS 3.38
-        ForceVectorRendering = 1 << 3, //!< Symbol must be rendered using vector methods, and optimisations like pre-rendered images must be disabled \since QGIS 3.40
-        ExcludeSymbolBuffers = 1 << 4, //!< Do not render symbol buffers. \since QGIS 3.40
+      DynamicRotation = 1 << 1, //!< Rotation of symbol may be changed during rendering and symbol should not be cached
+      IsSymbolLayerSubSymbol = 1 << 2, //!< Symbol is being rendered as a sub-symbol of a QgsSymbolLayer \since QGIS 3.38
+      ForceVectorRendering = 1 << 3, //!< Symbol must be rendered using vector methods, and optimisations like pre-rendered images must be disabled \since QGIS 3.40
+      ExcludeSymbolBuffers = 1 << 4, //!< Do not render symbol buffers. \since QGIS 3.40
     };
     Q_ENUM( SymbolRenderHint )
     //! Symbol render hints
@@ -827,10 +826,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.44
      */
     enum class HorizontalAnchorPoint SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMarkerSymbolLayer, HorizontalAnchorPoint ) : int
-    {
-        Left, //!< Align to left side of symbol
-        Center SIP_MONKEYPATCH_COMPAT_NAME( HCenter ), //!< Align to horizontal center of symbol
-        Right, //!< Align to right side of symbol
+      {
+      Left, //!< Align to left side of symbol
+      Center SIP_MONKEYPATCH_COMPAT_NAME( HCenter ), //!< Align to horizontal center of symbol
+      Right, //!< Align to right side of symbol
     };
     Q_ENUM( HorizontalAnchorPoint )
 
@@ -841,11 +840,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.44
      */
     enum class VerticalAnchorPoint SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMarkerSymbolLayer, VerticalAnchorPoint ) : int
-    {
-        Top, //!< Align to top of symbol
-        Center SIP_MONKEYPATCH_COMPAT_NAME( VCenter ), //!< Align to vertical center of symbol
-        Bottom, //!< Align to bottom of symbol
-        Baseline, //!< Align to baseline of symbol, e.g. font baseline for font marker symbol layers. Treated as Bottom if no baseline is available for the symbol layer type. \since QGIS 3.44
+      {
+      Top, //!< Align to top of symbol
+      Center SIP_MONKEYPATCH_COMPAT_NAME( VCenter ), //!< Align to vertical center of symbol
+      Bottom, //!< Align to bottom of symbol
+      Baseline, //!< Align to baseline of symbol, e.g. font baseline for font marker symbol layers. Treated as Bottom if no baseline is available for the symbol layer type. \since QGIS 3.44
     };
     Q_ENUM( VerticalAnchorPoint )
 
@@ -856,7 +855,7 @@ class CORE_EXPORT Qgis
      */
     enum class FeatureRendererFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        AffectsLabeling = 1 << 0, //!< If present, indicates that the renderer will participate in the map labeling problem
+      AffectsLabeling = 1 << 0, //!< If present, indicates that the renderer will participate in the map labeling problem
     };
     Q_ENUM( FeatureRendererFlag )
 
@@ -875,8 +874,8 @@ class CORE_EXPORT Qgis
      */
     enum class SymbolFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        RendererShouldUseSymbolLevels = 1 << 0, //!< If present, indicates that a QgsFeatureRenderer using the symbol should use symbol levels for best results
-        AffectsLabeling = 1 << 1, //!< If present, indicates that the symbol will participate in the map labeling problem \since QGIS 3.40
+      RendererShouldUseSymbolLevels = 1 << 0, //!< If present, indicates that a QgsFeatureRenderer using the symbol should use symbol levels for best results
+      AffectsLabeling = 1 << 1, //!< If present, indicates that the symbol will participate in the map labeling problem \since QGIS 3.40
     };
     Q_ENUM( SymbolFlag )
     //! Symbol flags
@@ -890,7 +889,7 @@ class CORE_EXPORT Qgis
      */
     enum class SymbolPreviewFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbol, PreviewFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        FlagIncludeCrosshairsForMarkerSymbols = 1 << 0, //!< Include a crosshairs reference image in the background of marker symbol previews
+      FlagIncludeCrosshairsForMarkerSymbols = 1 << 0, //!< Include a crosshairs reference image in the background of marker symbol previews
     };
     Q_ENUM( SymbolPreviewFlag )
     //! Symbol preview flags
@@ -908,9 +907,9 @@ class CORE_EXPORT Qgis
      */
     enum class SymbolLayerFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        DisableFeatureClipping = 1 << 0, //!< If present, indicates that features should never be clipped to the map extent during rendering
-        CanCalculateMaskGeometryPerFeature = 1 << 1, //!< If present, indicates that mask geometry can safely be calculated per feature for the symbol layer. This avoids using the entire symbol layer's mask geometry for every feature rendered, considerably simplifying vector exports and resulting in much smaller file sizes. \since QGIS 3.38
-        AffectsLabeling = 1 << 2, //!< If present, indicates that the symbol layer will participate in the map labeling problem \since QGIS 3.40
+      DisableFeatureClipping = 1 << 0, //!< If present, indicates that features should never be clipped to the map extent during rendering
+      CanCalculateMaskGeometryPerFeature = 1 << 1, //!< If present, indicates that mask geometry can safely be calculated per feature for the symbol layer. This avoids using the entire symbol layer's mask geometry for every feature rendered, considerably simplifying vector exports and resulting in much smaller file sizes. \since QGIS 3.38
+      AffectsLabeling = 1 << 2, //!< If present, indicates that the symbol layer will participate in the map labeling problem \since QGIS 3.40
     };
     Q_ENUM( SymbolLayerFlag )
     //! Symbol layer flags
@@ -928,7 +927,7 @@ class CORE_EXPORT Qgis
      */
     enum class SymbolLayerUserFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        DisableSelectionRecoloring = 1 << 0, //!< If present, indicates that the symbol layer should not be recolored when rendering selected features
+      DisableSelectionRecoloring = 1 << 0, //!< If present, indicates that the symbol layer should not be recolored when rendering selected features
     };
     Q_ENUM( SymbolLayerUserFlag )
 
@@ -946,16 +945,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class BrowserItemType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDataItem, Type ) : int
-    {
-        Collection, //!< A collection of items
-        Directory, //!< Represents a file directory
-        Layer, //!< Represents a map layer
-        Error, //!< Contains an error message
-        Favorites, //!< Represents a favorite item
-        Project, //!< Represents a QGIS project
-        Custom, //!< Custom item type
-        Fields, //!< Collection of fields
-        Field, //!< Vector layer field
+      {
+      Collection, //!< A collection of items
+      Directory, //!< Represents a file directory
+      Layer, //!< Represents a map layer
+      Error, //!< Contains an error message
+      Favorites, //!< Represents a favorite item
+      Project, //!< Represents a QGIS project
+      Custom, //!< Custom item type
+      Fields, //!< Collection of fields
+      Field, //!< Vector layer field
     };
     Q_ENUM( BrowserItemType )
 
@@ -965,10 +964,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class BrowserItemState SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDataItem, State ) : int
-    {
-        NotPopulated, //!< Children not yet created
-        Populating, //!< Creating children in separate thread (populating or refreshing)
-        Populated, //!< Children created
+      {
+      NotPopulated, //!< Children not yet created
+      Populating, //!< Creating children in separate thread (populating or refreshing)
+      Populated, //!< Children created
     };
     Q_ENUM( BrowserItemState )
 
@@ -979,16 +978,16 @@ class CORE_EXPORT Qgis
      */
     enum class BrowserItemCapability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDataItem, Capability ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoCapabilities = 0, //!< Item has no capabilities
-        SetCrs = 1 << 0, //!< Can set CRS on layer or group of layers. deprecated since QGIS 3.6 -- no longer used by QGIS and will be removed in QGIS 5.0
-        Fertile = 1 << 1, //!< Can create children. Even items without this capability may have children, but cannot create them, it means that children are created by item ancestors.
-        Fast = 1 << 2, //!< CreateChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QgsSettings
-        Collapse = 1 << 3, //!< The collapse/expand status for this items children should be ignored in order to avoid undesired network connections (wms etc.)
-        Rename = 1 << 4, //!< Item can be renamed
-        Delete = 1 << 5, //!< Item can be deleted
-        ItemRepresentsFile = 1 << 6, //!< Item's path() directly represents a file on disk \since QGIS 3.22
-        RefreshChildrenWhenItemIsRefreshed = 1 << 7, //!< When the item is refreshed, all its populated children will also be refreshed in turn \since QGIS 3.26
-        ReadOnly = 1 << 8, //!< Item is read only \since QGIS 3.40
+      NoCapabilities = 0, //!< Item has no capabilities
+      SetCrs = 1 << 0, //!< Can set CRS on layer or group of layers. deprecated since QGIS 3.6 -- no longer used by QGIS and will be removed in QGIS 5.0
+      Fertile = 1 << 1, //!< Can create children. Even items without this capability may have children, but cannot create them, it means that children are created by item ancestors.
+      Fast = 1 << 2, //!< CreateChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QgsSettings
+      Collapse = 1 << 3, //!< The collapse/expand status for this items children should be ignored in order to avoid undesired network connections (wms etc.)
+      Rename = 1 << 4, //!< Item can be renamed
+      Delete = 1 << 5, //!< Item can be deleted
+      ItemRepresentsFile = 1 << 6, //!< Item's path() directly represents a file on disk \since QGIS 3.22
+      RefreshChildrenWhenItemIsRefreshed = 1 << 7, //!< When the item is refreshed, all its populated children will also be refreshed in turn \since QGIS 3.26
+      ReadOnly = 1 << 8, //!< Item is read only \since QGIS 3.40
     };
     Q_ENUM( BrowserItemCapability )
     //! Browser item capabilities
@@ -1004,11 +1003,11 @@ class CORE_EXPORT Qgis
      */
     enum class DataItemProviderCapability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDataProvider, DataCapability ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoCapabilities SIP_MONKEYPATCH_COMPAT_NAME( NoDataCapabilities ) = 0, //!< No capabilities
-        Files SIP_MONKEYPATCH_COMPAT_NAME( File ) = 1, //!< Can provides items which corresponds to files
-        Directories SIP_MONKEYPATCH_COMPAT_NAME( Dir ) = 1 << 1, //!< Can provides items which corresponds to directories
-        Databases SIP_MONKEYPATCH_COMPAT_NAME( Database ) = 1 << 2, //!< Can provides items which corresponds to databases
-        NetworkSources SIP_MONKEYPATCH_COMPAT_NAME( Net ) = 1 << 3, //!< Network/internet source
+      NoCapabilities SIP_MONKEYPATCH_COMPAT_NAME( NoDataCapabilities ) = 0, //!< No capabilities
+      Files SIP_MONKEYPATCH_COMPAT_NAME( File ) = 1, //!< Can provides items which corresponds to files
+      Directories SIP_MONKEYPATCH_COMPAT_NAME( Dir ) = 1 << 1, //!< Can provides items which corresponds to directories
+      Databases SIP_MONKEYPATCH_COMPAT_NAME( Database ) = 1 << 2, //!< Can provides items which corresponds to databases
+      NetworkSources SIP_MONKEYPATCH_COMPAT_NAME( Net ) = 1 << 3, //!< Network/internet source
     };
     Q_ENUM( DataItemProviderCapability )
 
@@ -1028,21 +1027,21 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class BrowserLayerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayerItem, LayerType ) : int
-    {
-        NoType, //!< No type
-        Vector, //!< Generic vector layer
-        Raster, //!< Raster layer
-        Point, //!< Vector point layer
-        Line, //!< Vector line layer
-        Polygon, //!< Vector polygon layer
-        TableLayer, //!< Vector non-spatial layer
-        Database, //!< Database layer
-        Table, //!< Database table
-        Plugin, //!< Plugin based layer
-        Mesh, //!< Mesh layer
-        VectorTile, //!< Vector tile layer
-        PointCloud, //!< Point cloud layer
-        TiledScene, //!< Tiled scene layer \since QGIS 3.34
+      {
+      NoType, //!< No type
+      Vector, //!< Generic vector layer
+      Raster, //!< Raster layer
+      Point, //!< Vector point layer
+      Line, //!< Vector line layer
+      Polygon, //!< Vector polygon layer
+      TableLayer, //!< Vector non-spatial layer
+      Database, //!< Database layer
+      Table, //!< Database table
+      Plugin, //!< Plugin based layer
+      Mesh, //!< Mesh layer
+      VectorTile, //!< Vector tile layer
+      PointCloud, //!< Point cloud layer
+      TiledScene, //!< Tiled scene layer \since QGIS 3.34
     };
     Q_ENUM( BrowserLayerType )
 
@@ -1079,19 +1078,19 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class VectorExportResult SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorLayerExporter, ExportError ) : int
-    {
-        Success SIP_MONKEYPATCH_COMPAT_NAME( NoError ) = 0, //!< No errors were encountered
-        ErrorCreatingDataSource SIP_MONKEYPATCH_COMPAT_NAME( ErrCreateDataSource ), //!< Could not create the destination data source
-        ErrorCreatingLayer SIP_MONKEYPATCH_COMPAT_NAME( ErrCreateLayer ), //!< Could not create destination layer
-        ErrorAttributeTypeUnsupported SIP_MONKEYPATCH_COMPAT_NAME( ErrAttributeTypeUnsupported ), //!< Source layer has an attribute type which could not be handled by destination
-        ErrorAttributeCreationFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrAttributeCreationFailed ), //!< Destination provider was unable to create an attribute
-        ErrorProjectingFeatures SIP_MONKEYPATCH_COMPAT_NAME( ErrProjection ), //!< An error occurred while reprojecting features to destination CRS
-        ErrorFeatureWriteFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrFeatureWriteFailed ), //!< An error occurred while writing a feature to the destination
-        ErrorInvalidLayer SIP_MONKEYPATCH_COMPAT_NAME( ErrInvalidLayer ), //!< Could not access newly created destination layer
-        ErrorInvalidProvider SIP_MONKEYPATCH_COMPAT_NAME( ErrInvalidProvider ), //!< Could not find a matching provider key
-        ErrorProviderUnsupportedFeature SIP_MONKEYPATCH_COMPAT_NAME( ErrProviderUnsupportedFeature ), //!< Provider does not support creation of empty layers
-        ErrorConnectionFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrConnectionFailed ), //!< Could not connect to destination
-        UserCanceled SIP_MONKEYPATCH_COMPAT_NAME( ErrUserCanceled ), //!< User canceled the export
+      {
+      Success SIP_MONKEYPATCH_COMPAT_NAME( NoError ) = 0, //!< No errors were encountered
+      ErrorCreatingDataSource SIP_MONKEYPATCH_COMPAT_NAME( ErrCreateDataSource ), //!< Could not create the destination data source
+      ErrorCreatingLayer SIP_MONKEYPATCH_COMPAT_NAME( ErrCreateLayer ), //!< Could not create destination layer
+      ErrorAttributeTypeUnsupported SIP_MONKEYPATCH_COMPAT_NAME( ErrAttributeTypeUnsupported ), //!< Source layer has an attribute type which could not be handled by destination
+      ErrorAttributeCreationFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrAttributeCreationFailed ), //!< Destination provider was unable to create an attribute
+      ErrorProjectingFeatures SIP_MONKEYPATCH_COMPAT_NAME( ErrProjection ), //!< An error occurred while reprojecting features to destination CRS
+      ErrorFeatureWriteFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrFeatureWriteFailed ), //!< An error occurred while writing a feature to the destination
+      ErrorInvalidLayer SIP_MONKEYPATCH_COMPAT_NAME( ErrInvalidLayer ), //!< Could not access newly created destination layer
+      ErrorInvalidProvider SIP_MONKEYPATCH_COMPAT_NAME( ErrInvalidProvider ), //!< Could not find a matching provider key
+      ErrorProviderUnsupportedFeature SIP_MONKEYPATCH_COMPAT_NAME( ErrProviderUnsupportedFeature ), //!< Provider does not support creation of empty layers
+      ErrorConnectionFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrConnectionFailed ), //!< Could not connect to destination
+      UserCanceled SIP_MONKEYPATCH_COMPAT_NAME( ErrUserCanceled ), //!< User canceled the export
     };
     Q_ENUM( VectorExportResult )
 
@@ -1101,8 +1100,8 @@ class CORE_EXPORT Qgis
      */
     enum class VectorFileWriterCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        FieldAliases = 1 << 0, //!< Writer can support field aliases
-        FieldComments = 1 << 2, //!< Writer can support field comments
+      FieldAliases = 1 << 0, //!< Writer can support field aliases
+      FieldComments = 1 << 2, //!< Writer can support field comments
     };
     Q_ENUM( VectorFileWriterCapability )
 
@@ -1119,10 +1118,10 @@ class CORE_EXPORT Qgis
      */
     enum class SqlLayerDefinitionCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        SubsetStringFilter = 1 << 1,  //!< SQL layer definition supports subset string filter
-        GeometryColumn = 1 << 2,      //!< SQL layer definition supports geometry column
-        PrimaryKeys = 1 << 3,         //!< SQL layer definition supports primary keys
-        UnstableFeatureIds = 1 << 4   //!< SQL layer definition supports disabling select at id
+      SubsetStringFilter = 1 << 1,  //!< SQL layer definition supports subset string filter
+      GeometryColumn = 1 << 2,      //!< SQL layer definition supports geometry column
+      PrimaryKeys = 1 << 3,         //!< SQL layer definition supports primary keys
+      UnstableFeatureIds = 1 << 4   //!< SQL layer definition supports disabling select at id
     };
     Q_ENUM( SqlLayerDefinitionCapability )
     //! SQL layer definition capabilities
@@ -1170,9 +1169,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class ActionStart SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsNetworkContentFetcherRegistry, FetchingMode ) : int
-    {
-        Deferred SIP_MONKEYPATCH_COMPAT_NAME( DownloadLater ), //!< Do not start immediately the action
-                 Immediate SIP_MONKEYPATCH_COMPAT_NAME( DownloadImmediately ), //!< Action will start immediately
+      {
+      Deferred SIP_MONKEYPATCH_COMPAT_NAME( DownloadLater ), //!< Do not start immediately the action
+      Immediate SIP_MONKEYPATCH_COMPAT_NAME( DownloadImmediately ), //!< Action will start immediately
     };
     Q_ENUM( ActionStart )
 
@@ -1233,16 +1232,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class LabelPlacement SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, Placement ) : int
-    {
-        AroundPoint, //!< Arranges candidates in a circle around a point (or centroid of a polygon). Applies to point or polygon layers only.
-        OverPoint, //!< Arranges candidates over a point (or centroid of a polygon), or at a preset offset from the point. Applies to point or polygon layers only.
-        Line, //!< Arranges candidates parallel to a generalised line representing the feature or parallel to a polygon's perimeter. Applies to line or polygon layers only.
-        Curved, //!< Arranges candidates following the curvature of a line feature. Applies to line layers only.
-        Horizontal, //!< Arranges horizontal candidates scattered throughout a polygon feature. Applies to polygon layers only.
-        Free, //!< Arranges candidates scattered throughout a polygon feature. Candidates are rotated to respect the polygon's orientation. Applies to polygon layers only.
-        OrderedPositionsAroundPoint, //!< Candidates are placed in predefined positions around a point. Preference is given to positions with greatest cartographic appeal, e.g., top right, bottom right, etc. Applies to point layers only.
-        PerimeterCurved, //!< Arranges candidates following the curvature of a polygon's boundary. Applies to polygon layers only.
-        OutsidePolygons, //!< Candidates are placed outside of polygon boundaries. Applies to polygon layers only \since QGIS 3.14
+      {
+      AroundPoint, //!< Arranges candidates in a circle around a point (or centroid of a polygon). Applies to point or polygon layers only.
+      OverPoint, //!< Arranges candidates over a point (or centroid of a polygon), or at a preset offset from the point. Applies to point or polygon layers only.
+      Line, //!< Arranges candidates parallel to a generalised line representing the feature or parallel to a polygon's perimeter. Applies to line or polygon layers only.
+      Curved, //!< Arranges candidates following the curvature of a line feature. Applies to line layers only.
+      Horizontal, //!< Arranges horizontal candidates scattered throughout a polygon feature. Applies to polygon layers only.
+      Free, //!< Arranges candidates scattered throughout a polygon feature. Candidates are rotated to respect the polygon's orientation. Applies to polygon layers only.
+      OrderedPositionsAroundPoint, //!< Candidates are placed in predefined positions around a point. Preference is given to positions with greatest cartographic appeal, e.g., top right, bottom right, etc. Applies to point layers only.
+      PerimeterCurved, //!< Arranges candidates following the curvature of a polygon's boundary. Applies to polygon layers only.
+      OutsidePolygons, //!< Candidates are placed outside of polygon boundaries. Applies to polygon layers only \since QGIS 3.14
     };
     Q_ENUM( LabelPlacement )
 
@@ -1268,20 +1267,20 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class LabelPredefinedPointPosition SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, PredefinedPointPosition ) : int
-    {
-        TopLeft, //!< Label on top-left of point
-        TopSlightlyLeft, //!< Label on top of point, slightly left of center
-        TopMiddle, //!< Label directly above point
-        TopSlightlyRight, //!< Label on top of point, slightly right of center
-        TopRight, //!< Label on top-right of point
-        MiddleLeft, //!< Label on left of point
-        MiddleRight, //!< Label on right of point
-        BottomLeft, //!< Label on bottom-left of point
-        BottomSlightlyLeft, //!< Label below point, slightly left of center
-        BottomMiddle, //!< Label directly below point
-        BottomSlightlyRight, //!< Label below point, slightly right of center
-        BottomRight, //!< Label on bottom right of point
-        OverPoint, //!< Label directly centered over point \since QGIS 3.38
+      {
+      TopLeft, //!< Label on top-left of point
+      TopSlightlyLeft, //!< Label on top of point, slightly left of center
+      TopMiddle, //!< Label directly above point
+      TopSlightlyRight, //!< Label on top of point, slightly right of center
+      TopRight, //!< Label on top-right of point
+      MiddleLeft, //!< Label on left of point
+      MiddleRight, //!< Label on right of point
+      BottomLeft, //!< Label on bottom-left of point
+      BottomSlightlyLeft, //!< Label below point, slightly left of center
+      BottomMiddle, //!< Label directly below point
+      BottomSlightlyRight, //!< Label below point, slightly right of center
+      BottomRight, //!< Label on bottom right of point
+      OverPoint, //!< Label directly centered over point \since QGIS 3.38
     };
     Q_ENUM( LabelPredefinedPointPosition )
 
@@ -1307,9 +1306,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class LabelOffsetType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, OffsetType ) : int
-    {
-        FromPoint, //!< Offset distance applies from point geometry
-        FromSymbolBounds, //!< Offset distance applies from rendered symbol bounds
+      {
+      FromPoint, //!< Offset distance applies from point geometry
+      FromSymbolBounds, //!< Offset distance applies from rendered symbol bounds
     };
     Q_ENUM( LabelOffsetType )
 
@@ -1321,16 +1320,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class LabelQuadrantPosition SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, QuadrantPosition ) : int
-    {
-        AboveLeft SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAboveLeft ), //!< Above left
-                  Above SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAbove ), //!< Above center
-                  AboveRight SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAboveRight ), //!< Above right
-                  Left SIP_MONKEYPATCH_COMPAT_NAME( QuadrantLeft ), //!< Left middle
-                  Over SIP_MONKEYPATCH_COMPAT_NAME( QuadrantOver ), //!< Center middle
-                  Right SIP_MONKEYPATCH_COMPAT_NAME( QuadrantRight ), //!< Right middle
-                  BelowLeft SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelowLeft ), //!< Below left
-                  Below SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelow ), //!< Below center
-                  BelowRight SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelowRight ), //!< Below right
+      {
+      AboveLeft SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAboveLeft ), //!< Above left
+      Above SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAbove ), //!< Above center
+      AboveRight SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAboveRight ), //!< Above right
+      Left SIP_MONKEYPATCH_COMPAT_NAME( QuadrantLeft ), //!< Left middle
+      Over SIP_MONKEYPATCH_COMPAT_NAME( QuadrantOver ), //!< Center middle
+      Right SIP_MONKEYPATCH_COMPAT_NAME( QuadrantRight ), //!< Right middle
+      BelowLeft SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelowLeft ), //!< Below left
+      Below SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelow ), //!< Below center
+      BelowRight SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelowRight ), //!< Below right
     };
     Q_ENUM( LabelQuadrantPosition )
 
@@ -1342,10 +1341,10 @@ class CORE_EXPORT Qgis
      */
     enum class LabelLinePlacementFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLabeling, LinePlacementFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        OnLine = 1, //!< Labels can be placed directly over a line feature.
-        AboveLine = 2, //!< Labels can be placed above a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed below the line feature.
-        BelowLine = 4, //!< Labels can be placed below a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed above the line feature.
-        MapOrientation = 8, //!< Signifies that the AboveLine and BelowLine flags should respect the map's orientation rather than the feature's orientation. For example, AboveLine will always result in label's being placed above a line, regardless of the line's direction.
+      OnLine = 1, //!< Labels can be placed directly over a line feature.
+      AboveLine = 2, //!< Labels can be placed above a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed below the line feature.
+      BelowLine = 4, //!< Labels can be placed below a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed above the line feature.
+      MapOrientation = 8, //!< Signifies that the AboveLine and BelowLine flags should respect the map's orientation rather than the feature's orientation. For example, AboveLine will always result in label's being placed above a line, regardless of the line's direction.
     };
     Q_ENUM( LabelLinePlacementFlag )
 
@@ -1367,8 +1366,8 @@ class CORE_EXPORT Qgis
      */
     enum class LabelPolygonPlacementFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLabeling, PolygonPlacementFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        AllowPlacementOutsideOfPolygon = 1 << 0, //!< Labels can be placed outside of a polygon feature
-        AllowPlacementInsideOfPolygon = 1 << 1, //!< Labels can be placed inside a polygon feature
+      AllowPlacementOutsideOfPolygon = 1 << 0, //!< Labels can be placed outside of a polygon feature
+      AllowPlacementInsideOfPolygon = 1 << 1, //!< Labels can be placed inside a polygon feature
     };
     Q_ENUM( LabelPolygonPlacementFlag )
 
@@ -1389,10 +1388,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class UpsideDownLabelHandling SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, UpsideDownLabels ) : int
-    {
-        FlipUpsideDownLabels SIP_MONKEYPATCH_COMPAT_NAME( Upright ), //!< Upside-down labels (90 <= angle < 270) are shown upright
-                             AllowUpsideDownWhenRotationIsDefined SIP_MONKEYPATCH_COMPAT_NAME( ShowDefined ), //!< Show upside down when rotation is layer- or data-defined
-                             AlwaysAllowUpsideDown SIP_MONKEYPATCH_COMPAT_NAME( ShowAll ) //!< Show upside down for all labels, including dynamic ones
+      {
+      FlipUpsideDownLabels SIP_MONKEYPATCH_COMPAT_NAME( Upright ), //!< Upside-down labels (90 <= angle < 270) are shown upright
+      AllowUpsideDownWhenRotationIsDefined SIP_MONKEYPATCH_COMPAT_NAME( ShowDefined ), //!< Show upside down when rotation is layer- or data-defined
+      AlwaysAllowUpsideDown SIP_MONKEYPATCH_COMPAT_NAME( ShowAll ) //!< Show upside down for all labels, including dynamic ones
     };
     Q_ENUM( UpsideDownLabelHandling )
 
@@ -1404,12 +1403,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class LabelMultiLineAlignment SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, MultiLineAlign ) : int
-    {
-        Left SIP_MONKEYPATCH_COMPAT_NAME( MultiLeft ) = 0, //!< Left align
-        Center SIP_MONKEYPATCH_COMPAT_NAME( MultiCenter ), //!< Center align
-        Right SIP_MONKEYPATCH_COMPAT_NAME( MultiRight ), //!< Right align
-        FollowPlacement SIP_MONKEYPATCH_COMPAT_NAME( MultiFollowPlacement ), //!< Alignment follows placement of label, e.g., labels to the left of a feature will be drawn with right alignment
-        Justify SIP_MONKEYPATCH_COMPAT_NAME( MultiJustify ), //!< Justified
+      {
+      Left SIP_MONKEYPATCH_COMPAT_NAME( MultiLeft ) = 0, //!< Left align
+      Center SIP_MONKEYPATCH_COMPAT_NAME( MultiCenter ), //!< Center align
+      Right SIP_MONKEYPATCH_COMPAT_NAME( MultiRight ), //!< Right align
+      FollowPlacement SIP_MONKEYPATCH_COMPAT_NAME( MultiFollowPlacement ), //!< Alignment follows placement of label, e.g., labels to the left of a feature will be drawn with right alignment
+      Justify SIP_MONKEYPATCH_COMPAT_NAME( MultiJustify ), //!< Justified
     };
     Q_ENUM( LabelMultiLineAlignment )
 
@@ -1420,14 +1419,14 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class FileFilterType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProviderMetadata, FilterType ) : int
-    {
-        Vector SIP_MONKEYPATCH_COMPAT_NAME( FilterVector ) = 1, //!< Vector layers
-        Raster SIP_MONKEYPATCH_COMPAT_NAME( FilterRaster ), //!< Raster layers
-        Mesh SIP_MONKEYPATCH_COMPAT_NAME( FilterMesh ), //!< Mesh layers
-        MeshDataset SIP_MONKEYPATCH_COMPAT_NAME( FilterMeshDataset ), //!< Mesh datasets
-        PointCloud SIP_MONKEYPATCH_COMPAT_NAME( FilterPointCloud ), //!< Point clouds \since QGIS 3.18
-        VectorTile, //!< Vector tile layers \since QGIS 3.32
-        TiledScene, //!< Tiled scene layers \since QGIS 3.34
+      {
+      Vector SIP_MONKEYPATCH_COMPAT_NAME( FilterVector ) = 1, //!< Vector layers
+      Raster SIP_MONKEYPATCH_COMPAT_NAME( FilterRaster ), //!< Raster layers
+      Mesh SIP_MONKEYPATCH_COMPAT_NAME( FilterMesh ), //!< Mesh layers
+      MeshDataset SIP_MONKEYPATCH_COMPAT_NAME( FilterMeshDataset ), //!< Mesh datasets
+      PointCloud SIP_MONKEYPATCH_COMPAT_NAME( FilterPointCloud ), //!< Point clouds \since QGIS 3.18
+      VectorTile, //!< Vector tile layers \since QGIS 3.32
+      TiledScene, //!< Tiled scene layers \since QGIS 3.34
     };
     Q_ENUM( FileFilterType )
 
@@ -1438,8 +1437,8 @@ class CORE_EXPORT Qgis
      */
     enum class UriCleaningFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        RemoveCredentials = 1 << 0, //!< Completely remove credentials (eg passwords) from the URI. This flag is not compatible with the RedactCredentials flag.
-        RedactCredentials = 1 << 1, //!< Replace the value of credentials (eg passwords) with 'xxxxxxxx'. This flag is not compatible with the RemoveCredentials flag.
+      RemoveCredentials = 1 << 0, //!< Completely remove credentials (eg passwords) from the URI. This flag is not compatible with the RedactCredentials flag.
+      RedactCredentials = 1 << 1, //!< Replace the value of credentials (eg passwords) with 'xxxxxxxx'. This flag is not compatible with the RemoveCredentials flag.
     };
     Q_ENUM( UriCleaningFlag )
 
@@ -1458,11 +1457,11 @@ class CORE_EXPORT Qgis
      */
     enum class SublayerQueryFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        FastScan = 1 << 0, //!< Indicates that the provider must scan for sublayers using the fastest possible approach -- e.g. by first checking that a uri has an extension which is known to be readable by the provider
-        ResolveGeometryType = 1 << 1, //!< Attempt to resolve the geometry type for vector sublayers
-        CountFeatures = 1 << 2, //!< Count features in vector sublayers
-        IncludeSystemTables = 1 << 3, //!< Include system or internal tables (these are not included by default)
-        OpenLayersToResolveDescriptions = 1 << 4, //!< Attempt to open layers in order to resolve layer descriptions. May be slow and should never be done in a UI blocking call. \since QGIS 4.0
+      FastScan = 1 << 0, //!< Indicates that the provider must scan for sublayers using the fastest possible approach -- e.g. by first checking that a uri has an extension which is known to be readable by the provider
+      ResolveGeometryType = 1 << 1, //!< Attempt to resolve the geometry type for vector sublayers
+      CountFeatures = 1 << 2, //!< Count features in vector sublayers
+      IncludeSystemTables = 1 << 3, //!< Include system or internal tables (these are not included by default)
+      OpenLayersToResolveDescriptions = 1 << 4, //!< Attempt to open layers in order to resolve layer descriptions. May be slow and should never be done in a UI blocking call. \since QGIS 4.0
     };
     //! Sublayer query flags
     Q_DECLARE_FLAGS( SublayerQueryFlags, SublayerQueryFlag )
@@ -1476,7 +1475,7 @@ class CORE_EXPORT Qgis
      */
     enum class SublayerFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        SystemTable = 1 << 0, //!< Sublayer is a system or internal table, which should be hidden by default
+      SystemTable = 1 << 0, //!< Sublayer is a system or internal table, which should be hidden by default
     };
     //! Sublayer flags
     Q_DECLARE_FLAGS( SublayerFlags, SublayerFlag )
@@ -1491,10 +1490,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.38
      */
     enum class ShaderInterpolationMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsColorRampShader, Type ) : int
-    {
-        Linear SIP_MONKEYPATCH_COMPAT_NAME( Interpolated ) = 0, //!< Interpolates the color between two class breaks linearly
-        Discrete = 1, //!< Assigns the color of the higher class for every pixel between two class breaks
-        Exact = 2, //!< Assigns the color of the exact matching value in the color ramp item list
+      {
+      Linear SIP_MONKEYPATCH_COMPAT_NAME( Interpolated ) = 0, //!< Interpolates the color between two class breaks linearly
+      Discrete = 1, //!< Assigns the color of the higher class for every pixel between two class breaks
+      Exact = 2, //!< Assigns the color of the exact matching value in the color ramp item list
     };
     Q_ENUM( ShaderInterpolationMethod )
 
@@ -1506,10 +1505,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.38
      */
     enum class ShaderClassificationMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsColorRampShader, ClassificationMode ) : int
-    {
-        Continuous = 1, //!< Uses breaks from color palette
-        EqualInterval = 2, //!< Uses equal interval
-        Quantile = 3, //!< Uses quantile (i.e. equal pixel) count
+      {
+      Continuous = 1, //!< Uses breaks from color palette
+      EqualInterval = 2, //!< Uses equal interval
+      Quantile = 3, //!< Uses quantile (i.e. equal pixel) count
     };
     Q_ENUM( ShaderClassificationMethod )
 
@@ -1519,15 +1518,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class RasterPipeInterfaceRole SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterPipe, Role ) : int
-    {
-        Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownRole ) = 0, //!< Unknown role
-        Provider SIP_MONKEYPATCH_COMPAT_NAME( ProviderRole ) = 1, //!< Data provider role
-        Renderer SIP_MONKEYPATCH_COMPAT_NAME( RendererRole ) = 2, //!< Raster renderer role
-        Brightness SIP_MONKEYPATCH_COMPAT_NAME( BrightnessRole ) = 3, //!< Brightness filter role
-        Resampler SIP_MONKEYPATCH_COMPAT_NAME( ResamplerRole ) = 4, //!< Resampler role
-        Projector SIP_MONKEYPATCH_COMPAT_NAME( ProjectorRole ) = 5, //!< Projector role
-        Nuller SIP_MONKEYPATCH_COMPAT_NAME( NullerRole ) = 6, //!< Raster nuller role
-        HueSaturation SIP_MONKEYPATCH_COMPAT_NAME( HueSaturationRole ) = 7, //!< Hue/saturation filter role (also applies grayscale/color inversion)
+      {
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownRole ) = 0, //!< Unknown role
+      Provider SIP_MONKEYPATCH_COMPAT_NAME( ProviderRole ) = 1, //!< Data provider role
+      Renderer SIP_MONKEYPATCH_COMPAT_NAME( RendererRole ) = 2, //!< Raster renderer role
+      Brightness SIP_MONKEYPATCH_COMPAT_NAME( BrightnessRole ) = 3, //!< Brightness filter role
+      Resampler SIP_MONKEYPATCH_COMPAT_NAME( ResamplerRole ) = 4, //!< Resampler role
+      Projector SIP_MONKEYPATCH_COMPAT_NAME( ProjectorRole ) = 5, //!< Projector role
+      Nuller SIP_MONKEYPATCH_COMPAT_NAME( NullerRole ) = 6, //!< Raster nuller role
+      HueSaturation SIP_MONKEYPATCH_COMPAT_NAME( HueSaturationRole ) = 7, //!< Hue/saturation filter role (also applies grayscale/color inversion)
     };
     Q_ENUM( RasterPipeInterfaceRole )
 
@@ -1536,9 +1535,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class RasterResamplingStage SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterPipe, ResamplingStage ) : int
-    {
-        ResampleFilter, //!< Resampling occurs in ResamplingFilter
-        Provider, //!< Resampling occurs in Provider
+      {
+      ResampleFilter, //!< Resampling occurs in ResamplingFilter
+      Provider, //!< Resampling occurs in Provider
     };
     Q_ENUM( RasterResamplingStage )
 
@@ -1550,15 +1549,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.42
      */
     enum class RasterResamplingMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterDataProvider, ResamplingMethod ) : int
-    {
-        Nearest, //!< Nearest-neighbour resampling
-        Bilinear, //!< Bilinear (2x2 kernel) resampling
-        Cubic, //!< Cubic Convolution Approximation (4x4 kernel) resampling
-        CubicSpline, //!< Cubic B-Spline Approximation (4x4 kernel)
-        Lanczos, //!< Lanczos windowed sinc interpolation (6x6 kernel)
-        Average, //!< Average resampling
-        Mode, //!< Mode (selects the value which appears most often of all the sampled points)
-        Gauss //!< Gauss blurring
+      {
+      Nearest, //!< Nearest-neighbour resampling
+      Bilinear, //!< Bilinear (2x2 kernel) resampling
+      Cubic, //!< Cubic Convolution Approximation (4x4 kernel) resampling
+      CubicSpline, //!< Cubic B-Spline Approximation (4x4 kernel)
+      Lanczos, //!< Lanczos windowed sinc interpolation (6x6 kernel)
+      Average, //!< Average resampling
+      Mode, //!< Mode (selects the value which appears most often of all the sampled points)
+      Gauss //!< Gauss blurring
     };
     Q_ENUM( RasterResamplingMethod )
 
@@ -1569,8 +1568,8 @@ class CORE_EXPORT Qgis
      */
     enum class RasterRendererFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        InternalLayerOpacityHandling = 1 << 0, //!< The renderer internally handles the raster layer's opacity, so the default layer level opacity handling should not be applied.
-        UseNoDataForOutOfRangePixels = 1 << 1, //!< Out of range pixels (eg those values outside of the rendered map's z range filter) should be set using additional nodata values instead of additional transparency values \since QGIS 3.38
+      InternalLayerOpacityHandling = 1 << 0, //!< The renderer internally handles the raster layer's opacity, so the default layer level opacity handling should not be applied.
+      UseNoDataForOutOfRangePixels = 1 << 1, //!< Out of range pixels (eg those values outside of the rendered map's z range filter) should be set using additional nodata values instead of additional transparency values \since QGIS 3.38
     };
 
     /**
@@ -1590,7 +1589,7 @@ class CORE_EXPORT Qgis
      */
     enum class RasterRendererCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        UsesMultipleBands = 1 << 0, //!< The renderer utilizes multiple raster bands for color data (note that alpha bands are not considered for this capability)
+      UsesMultipleBands = 1 << 0, //!< The renderer utilizes multiple raster bands for color data (note that alpha bands are not considered for this capability)
     };
     Q_ENUM( RasterRendererCapability )
 
@@ -1610,11 +1609,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.42
      */
     enum class RasterRangeLimit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterMinMaxOrigin, Limits ) : int
-    {
-        NotSet SIP_MONKEYPATCH_COMPAT_NAME( None_ ), //!< User defined
-               MinimumMaximum SIP_MONKEYPATCH_COMPAT_NAME( MinMax ), //!< Real min-max values
-               StdDev, //!< Range is [ mean - stdDevFactor() * stddev, mean + stdDevFactor() * stddev ]
-               CumulativeCut //!< Range is [ min + cumulativeCutLower() * (max - min), min + cumulativeCutUpper() * (max - min) ]
+      {
+      NotSet SIP_MONKEYPATCH_COMPAT_NAME( None_ ), //!< User defined
+      MinimumMaximum SIP_MONKEYPATCH_COMPAT_NAME( MinMax ), //!< Real min-max values
+      StdDev, //!< Range is [ mean - stdDevFactor() * stddev, mean + stdDevFactor() * stddev ]
+      CumulativeCut //!< Range is [ min + cumulativeCutLower() * (max - min), min + cumulativeCutUpper() * (max - min) ]
     };
     Q_ENUM( RasterRangeLimit )
 
@@ -1626,10 +1625,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.42
      */
     enum class RasterRangeExtent SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterMinMaxOrigin, Extent ) : int
-    {
-        WholeRaster SIP_MONKEYPATCH_COMPAT_NAME( None_ ), //!< Whole raster is used to compute statistics
-                    FixedCanvas SIP_MONKEYPATCH_COMPAT_NAME( CurrentCanvas ), //!< Current extent of the canvas (at the time of computation) is used to compute statistics
-                    UpdatedCanvas, //!< Constantly updated extent of the canvas is used to compute statistics
+      {
+      WholeRaster SIP_MONKEYPATCH_COMPAT_NAME( None_ ), //!< Whole raster is used to compute statistics
+      FixedCanvas SIP_MONKEYPATCH_COMPAT_NAME( CurrentCanvas ), //!< Current extent of the canvas (at the time of computation) is used to compute statistics
+      UpdatedCanvas, //!< Constantly updated extent of the canvas is used to compute statistics
     };
     Q_ENUM( RasterRangeExtent )
 
@@ -1641,9 +1640,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.42
      */
     enum class RasterRangeAccuracy SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterMinMaxOrigin, StatAccuracy ): int
-    {
-        Exact, //!< Exact statistics
-        Estimated, //!< Approximated statistics
+      {
+      Exact, //!< Exact statistics
+      Estimated, //!< Approximated statistics
     };
     Q_ENUM( RasterRangeAccuracy )
 
@@ -1695,9 +1694,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class RasterExportType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterFileWriter, Mode ) : int
-    {
-        Raw = 0, //!< Raw data
-        RenderedImage SIP_MONKEYPATCH_COMPAT_NAME( Image ) = 1 //!< Rendered image
+      {
+      Raw = 0, //!< Raw data
+      RenderedImage SIP_MONKEYPATCH_COMPAT_NAME( Image ) = 1 //!< Rendered image
     };
     Q_ENUM( RasterExportType )
 
@@ -1708,14 +1707,14 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class RasterFileWriterResult SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterFileWriter, WriterError ) : int
-    {
-        Success SIP_MONKEYPATCH_COMPAT_NAME( NoError ) = 0, //!< Successful export
-        SourceProviderError = 1, //!< Source data provider error
-        DestinationProviderError SIP_MONKEYPATCH_COMPAT_NAME( DestProviderError ) = 2, //!< Destination data provider error
-        CreateDatasourceError = 3, //!< Data source creation error
-        WriteError = 4, //!< Write error
-        NoDataConflict = 5, //!< Internal error if a value used for 'no data' was found in input
-        Canceled SIP_MONKEYPATCH_COMPAT_NAME( WriteCanceled ) = 6, //!< Writing was manually canceled
+      {
+      Success SIP_MONKEYPATCH_COMPAT_NAME( NoError ) = 0, //!< Successful export
+      SourceProviderError = 1, //!< Source data provider error
+      DestinationProviderError SIP_MONKEYPATCH_COMPAT_NAME( DestProviderError ) = 2, //!< Destination data provider error
+      CreateDatasourceError = 3, //!< Data source creation error
+      WriteError = 4, //!< Write error
+      NoDataConflict = 5, //!< Internal error if a value used for 'no data' was found in input
+      Canceled SIP_MONKEYPATCH_COMPAT_NAME( WriteCanceled ) = 6, //!< Writing was manually canceled
     };
     Q_ENUM( RasterFileWriterResult )
 
@@ -1770,12 +1769,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.38
     */
     enum class FieldOrigin SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFields, FieldOrigin ) : int
-    {
-        Unknown SIP_MONKEYPATCH_COMPAT_NAME( OriginUnknown ), //!< The field origin has not been specified
-                Provider SIP_MONKEYPATCH_COMPAT_NAME( OriginProvider ), //!< Field originates from the underlying data provider of the vector layer
-                Join SIP_MONKEYPATCH_COMPAT_NAME( OriginJoin ), //!< Field originates from a joined layer
-                Edit SIP_MONKEYPATCH_COMPAT_NAME( OriginEdit ), //!< Field has been temporarily added in editing mode
-                Expression SIP_MONKEYPATCH_COMPAT_NAME( OriginExpression ) //!< Field is calculated from an expression
+      {
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( OriginUnknown ), //!< The field origin has not been specified
+      Provider SIP_MONKEYPATCH_COMPAT_NAME( OriginProvider ), //!< Field originates from the underlying data provider of the vector layer
+      Join SIP_MONKEYPATCH_COMPAT_NAME( OriginJoin ), //!< Field originates from a joined layer
+      Edit SIP_MONKEYPATCH_COMPAT_NAME( OriginEdit ), //!< Field has been temporarily added in editing mode
+      Expression SIP_MONKEYPATCH_COMPAT_NAME( OriginExpression ) //!< Field is calculated from an expression
     };
     Q_ENUM( FieldOrigin )
 
@@ -1788,10 +1787,10 @@ class CORE_EXPORT Qgis
      */
     enum class FieldConfigurationFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoFlag = 0, //!< No flag is defined
-        NotSearchable = 1 << 1, //!< Defines if the field is searchable (used in the locator search for instance)
-        HideFromWms = 1 << 2, //!< Field is not available if layer is served as WMS from QGIS server
-        HideFromWfs = 1 << 3, //!< Field is not available if layer is served as WFS from QGIS server
+      NoFlag = 0, //!< No flag is defined
+      NotSearchable = 1 << 1, //!< Defines if the field is searchable (used in the locator search for instance)
+      HideFromWms = 1 << 2, //!< Field is not available if layer is served as WMS from QGIS server
+      HideFromWfs = 1 << 3, //!< Field is not available if layer is served as WFS from QGIS server
     };
     Q_ENUM( FieldConfigurationFlag )
 
@@ -1837,11 +1836,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class SelectBehavior SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorLayer, SelectBehavior ) : int
-    {
-        SetSelection, //!< Set selection, removing any existing selection
-        AddToSelection, //!< Add selection to current selection
-        IntersectSelection, //!< Modify current selection to include only select features which match
-        RemoveFromSelection, //!< Remove from current selection
+      {
+      SetSelection, //!< Set selection, removing any existing selection
+      AddToSelection, //!< Add selection to current selection
+      IntersectSelection, //!< Modify current selection to include only select features which match
+      RemoveFromSelection, //!< Remove from current selection
     };
     Q_ENUM( SelectBehavior )
 
@@ -1864,8 +1863,8 @@ class CORE_EXPORT Qgis
      */
     enum class SelectionFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        SingleFeatureSelection = 1 << 0, //!< Select only a single feature, picking the "best" match for the selection geometry
-        ToggleSelection = 1 << 1, //!< Enables a "toggle" selection mode, where previously selected matching features will be deselected and previously deselected features will be selected. This flag works only when the SingleFeatureSelection flag is also set.
+      SingleFeatureSelection = 1 << 0, //!< Select only a single feature, picking the "best" match for the selection geometry
+      ToggleSelection = 1 << 1, //!< Enables a "toggle" selection mode, where previously selected matching features will be deselected and previously deselected features will be selected. This flag works only when the SingleFeatureSelection flag is also set.
     };
 
     /**
@@ -1884,12 +1883,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class VectorEditResult SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorLayer, EditResult ) : int
-    {
-        Success = 0, //!< Edit operation was successful
-        EmptyGeometry = 1, //!< Edit operation resulted in an empty geometry
-        EditFailed = 2, //!< Edit operation failed
-        FetchFeatureFailed = 3, //!< Unable to fetch requested feature
-        InvalidLayer = 4, //!< Edit failed due to invalid layer
+      {
+      Success = 0, //!< Edit operation was successful
+      EmptyGeometry = 1, //!< Edit operation resulted in an empty geometry
+      EditFailed = 2, //!< Edit operation failed
+      FetchFeatureFailed = 3, //!< Unable to fetch requested feature
+      InvalidLayer = 4, //!< Edit failed due to invalid layer
     };
     Q_ENUM( VectorEditResult )
 
@@ -1899,10 +1898,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class VertexMarkerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbolLayerUtils, VertexMarkerType ) : int
-    {
-        SemiTransparentCircle, //!< Semi-transparent circle marker
-        Cross, //!< Cross marker
-        NoMarker, //!< No marker
+      {
+      SemiTransparentCircle, //!< Semi-transparent circle marker
+      Cross, //!< Cross marker
+      NoMarker, //!< No marker
     };
     Q_ENUM( VertexMarkerType )
 
@@ -1940,10 +1939,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class DeviceConnectionStatus SIP_MONKEYPATCH_SCOPEENUM_UNNEST( Qgis, GpsConnectionStatus ) : int
-    {
-        Disconnected, //!< Device is disconnected
-        Connecting, //!< Device is connecting
-        Connected, //!< Device is successfully connected
+      {
+      Disconnected, //!< Device is disconnected
+      Connecting, //!< Device is connecting
+      Connected, //!< Device is successfully connected
     };
     Q_ENUM( DeviceConnectionStatus )
 
@@ -1955,11 +1954,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class GpsFixStatus SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGpsInformation, FixStatus ) : int
-    {
-        NoData, //!< No fix data available
-        NoFix, //!< GPS is not fixed
-        Fix2D, //!< 2D fix
-        Fix3D //!< 3D fix
+      {
+      NoData, //!< No fix data available
+      NoFix, //!< GPS is not fixed
+      Fix2D, //!< 2D fix
+      Fix3D //!< 3D fix
     };
     Q_ENUM( GpsFixStatus );
 
@@ -2023,26 +2022,26 @@ class CORE_EXPORT Qgis
      */
     enum class GpsInformationComponent : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Location = 1 << 0, //!< 2D location (latitude/longitude), as a QgsPointXY value
-        Altitude = 1 << 1, //!< Altitude/elevation above or below the mean sea level
-        GroundSpeed = 1 << 2, //!< Ground speed
-        Bearing = 1 << 3, //!< Bearing measured in degrees clockwise from true north to the direction of travel
-        TotalTrackLength = 1 << 4, //!< Total distance of current GPS track (available from QgsGpsLogger class only)
-        TrackDistanceFromStart = 1 << 5, //!< Direct distance from first vertex in current GPS track to last vertex (available from QgsGpsLogger class only)
-        Pdop = 1 << 6, //!< Dilution of precision
-        Hdop = 1 << 7, //!< Horizontal dilution of precision
-        Vdop = 1 << 8, //!< Vertical dilution of precision
-        HorizontalAccuracy = 1 << 9, //!< Horizontal accuracy in meters
-        VerticalAccuracy = 1 << 10, //!< Vertical accuracy in meters
-        HvAccuracy = 1 << 11, //!< 3D RMS
-        SatellitesUsed = 1 << 12, //!< Count of satellites used in obtaining the fix
-        Timestamp = 1 << 13, //!< Timestamp
-        TrackStartTime = 1 << 14, //!< Timestamp at start of current track (available from QgsGpsLogger class only)
-        TrackEndTime = 1 << 15, //!< Timestamp at end (current point) of current track (available from QgsGpsLogger class only)
-        TrackDistanceSinceLastPoint = 1 << 16, //!< Distance since last recorded location (available from QgsGpsLogger class only)
-        TrackTimeSinceLastPoint = 1 << 17, //!< Time since last recorded location (available from QgsGpsLogger class only)
-        GeoidalSeparation = 1 << 18, //!< Geoidal separation, the difference between the WGS-84 Earth ellipsoid and mean-sea-level (geoid), "-" means mean-sea-level below ellipsoid
-        EllipsoidAltitude = 1 << 19, //!< Altitude/elevation above or below the WGS-84 Earth ellipsoid
+      Location = 1 << 0, //!< 2D location (latitude/longitude), as a QgsPointXY value
+      Altitude = 1 << 1, //!< Altitude/elevation above or below the mean sea level
+      GroundSpeed = 1 << 2, //!< Ground speed
+      Bearing = 1 << 3, //!< Bearing measured in degrees clockwise from true north to the direction of travel
+      TotalTrackLength = 1 << 4, //!< Total distance of current GPS track (available from QgsGpsLogger class only)
+      TrackDistanceFromStart = 1 << 5, //!< Direct distance from first vertex in current GPS track to last vertex (available from QgsGpsLogger class only)
+      Pdop = 1 << 6, //!< Dilution of precision
+      Hdop = 1 << 7, //!< Horizontal dilution of precision
+      Vdop = 1 << 8, //!< Vertical dilution of precision
+      HorizontalAccuracy = 1 << 9, //!< Horizontal accuracy in meters
+      VerticalAccuracy = 1 << 10, //!< Vertical accuracy in meters
+      HvAccuracy = 1 << 11, //!< 3D RMS
+      SatellitesUsed = 1 << 12, //!< Count of satellites used in obtaining the fix
+      Timestamp = 1 << 13, //!< Timestamp
+      TrackStartTime = 1 << 14, //!< Timestamp at start of current track (available from QgsGpsLogger class only)
+      TrackEndTime = 1 << 15, //!< Timestamp at end (current point) of current track (available from QgsGpsLogger class only)
+      TrackDistanceSinceLastPoint = 1 << 16, //!< Distance since last recorded location (available from QgsGpsLogger class only)
+      TrackTimeSinceLastPoint = 1 << 17, //!< Time since last recorded location (available from QgsGpsLogger class only)
+      GeoidalSeparation = 1 << 18, //!< Geoidal separation, the difference between the WGS-84 Earth ellipsoid and mean-sea-level (geoid), "-" means mean-sea-level below ellipsoid
+      EllipsoidAltitude = 1 << 19, //!< Altitude/elevation above or below the WGS-84 Earth ellipsoid
     };
 
     /**
@@ -2061,11 +2060,11 @@ class CORE_EXPORT Qgis
      */
     enum class BabelFormatCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Import = 1 << 0, //!< Format supports importing
-        Export = 1 << 1, //!< Format supports exporting
-        Waypoints = 1 << 2, //!< Format supports waypoints
-        Routes = 1 << 3, //!< Format supports routes
-        Tracks = 1 << 4, //!< Format supports tracks
+      Import = 1 << 0, //!< Format supports importing
+      Export = 1 << 1, //!< Format supports exporting
+      Waypoints = 1 << 2, //!< Format supports waypoints
+      Routes = 1 << 3, //!< Format supports routes
+      Tracks = 1 << 4, //!< Format supports tracks
     };
     //! Babel GPS format capabilities
     Q_DECLARE_FLAGS( BabelFormatCapabilities, BabelFormatCapability )
@@ -2080,7 +2079,7 @@ class CORE_EXPORT Qgis
      */
     enum class BabelCommandFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        QuoteFilePaths = 1 << 0, //!< File paths should be enclosed in quotations and escaped
+      QuoteFilePaths = 1 << 0, //!< File paths should be enclosed in quotations and escaped
     };
     //! Babel command flags
     Q_DECLARE_FLAGS( BabelCommandFlags, BabelCommandFlag )
@@ -2108,26 +2107,26 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class GeometryOperationResult SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, OperationResult ) : int
-    {
-        Success = 0, //!< Operation succeeded
-        NothingHappened = 1000, //!< Nothing happened, without any error
-        InvalidBaseGeometry, //!< The base geometry on which the operation is done is invalid or empty
-        InvalidInputGeometryType, //!< The input geometry (ring, part, split line, etc.) has not the correct geometry type
-        SelectionIsEmpty, //!< No features were selected
-        SelectionIsGreaterThanOne, //!< More than one features were selected
-        GeometryEngineError, //!< Geometry engine misses a method implemented or an error occurred in the geometry engine
-        LayerNotEditable, //!< Cannot edit layer
-        // Add part issues
-        AddPartSelectedGeometryNotFound, //!< The selected geometry cannot be found
-        AddPartNotMultiGeometry, //!< The source geometry is not multi
-        // Add ring issues
-        AddRingNotClosed, //!< The input ring is not closed
-        AddRingNotValid, //!< The input ring is not valid
-        AddRingCrossesExistingRings, //!< The input ring crosses existing rings (it is not disjoint)
-        AddRingNotInExistingFeature, //!< The input ring doesn't have any existing ring to fit into
-        // Split features
-        SplitCannotSplitPoint, //!< Cannot split points
-        GeometryTypeHasChanged, //!< Operation has changed geometry type
+      {
+      Success = 0, //!< Operation succeeded
+      NothingHappened = 1000, //!< Nothing happened, without any error
+      InvalidBaseGeometry, //!< The base geometry on which the operation is done is invalid or empty
+      InvalidInputGeometryType, //!< The input geometry (ring, part, split line, etc.) has not the correct geometry type
+      SelectionIsEmpty, //!< No features were selected
+      SelectionIsGreaterThanOne, //!< More than one features were selected
+      GeometryEngineError, //!< Geometry engine misses a method implemented or an error occurred in the geometry engine
+      LayerNotEditable, //!< Cannot edit layer
+      // Add part issues
+      AddPartSelectedGeometryNotFound, //!< The selected geometry cannot be found
+      AddPartNotMultiGeometry, //!< The source geometry is not multi
+      // Add ring issues
+      AddRingNotClosed, //!< The input ring is not closed
+      AddRingNotValid, //!< The input ring is not valid
+      AddRingCrossesExistingRings, //!< The input ring crosses existing rings (it is not disjoint)
+      AddRingNotInExistingFeature, //!< The input ring doesn't have any existing ring to fit into
+      // Split features
+      SplitCannotSplitPoint, //!< Cannot split points
+      GeometryTypeHasChanged, //!< Operation has changed geometry type
     };
     Q_ENUM( GeometryOperationResult )
 
@@ -2138,7 +2137,7 @@ class CORE_EXPORT Qgis
      */
     enum class GeometryValidityFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, ValidityFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        AllowSelfTouchingHoles SIP_MONKEYPATCH_COMPAT_NAME( FlagAllowSelfTouchingHoles ) = 1 << 0, //!< Indicates that self-touching holes are permitted. OGC validity states that self-touching holes are NOT permitted, whilst other vendor validity checks (e.g. ESRI) permit self-touching holes.
+      AllowSelfTouchingHoles SIP_MONKEYPATCH_COMPAT_NAME( FlagAllowSelfTouchingHoles ) = 1 << 0, //!< Indicates that self-touching holes are permitted. OGC validity states that self-touching holes are NOT permitted, whilst other vendor validity checks (e.g. ESRI) permit self-touching holes.
     };
     //! Geometry validity flags
     Q_DECLARE_FLAGS( GeometryValidityFlags, GeometryValidityFlag ) SIP_MONKEYPATCH_FLAGS_UNNEST( QgsGeometry, ValidityFlags )
@@ -2150,9 +2149,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class GeometryValidationEngine SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, ValidationMethod ) : int
-    {
-        QgisInternal SIP_MONKEYPATCH_COMPAT_NAME( ValidatorQgisInternal ), //!< Use internal QgsGeometryValidator method
-                     Geos SIP_MONKEYPATCH_COMPAT_NAME( ValidatorGeos ), //!< Use GEOS validation methods
+      {
+      QgisInternal SIP_MONKEYPATCH_COMPAT_NAME( ValidatorQgisInternal ), //!< Use internal QgsGeometryValidator method
+      Geos SIP_MONKEYPATCH_COMPAT_NAME( ValidatorGeos ), //!< Use GEOS validation methods
     };
     Q_ENUM( GeometryValidationEngine )
 
@@ -2162,9 +2161,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class BufferSide SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, BufferSide ) : int
-    {
-        Left SIP_MONKEYPATCH_COMPAT_NAME( SideLeft ) = 0, //!< Buffer to left of line
-        Right SIP_MONKEYPATCH_COMPAT_NAME( SideRight ), //!< Buffer to right of line
+      {
+      Left SIP_MONKEYPATCH_COMPAT_NAME( SideLeft ) = 0, //!< Buffer to left of line
+      Right SIP_MONKEYPATCH_COMPAT_NAME( SideRight ), //!< Buffer to right of line
     };
     Q_ENUM( BufferSide )
 
@@ -2174,10 +2173,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class EndCapStyle SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, EndCapStyle ) : int
-    {
-        Round SIP_MONKEYPATCH_COMPAT_NAME( CapRound ) = 1, //!< Round cap
-        Flat SIP_MONKEYPATCH_COMPAT_NAME( CapFlat ), //!< Flat cap (in line with start/end of line)
-        Square SIP_MONKEYPATCH_COMPAT_NAME( CapSquare ), //!< Square cap (extends past start/end of line by buffer distance)
+      {
+      Round SIP_MONKEYPATCH_COMPAT_NAME( CapRound ) = 1, //!< Round cap
+      Flat SIP_MONKEYPATCH_COMPAT_NAME( CapFlat ), //!< Flat cap (in line with start/end of line)
+      Square SIP_MONKEYPATCH_COMPAT_NAME( CapSquare ), //!< Square cap (extends past start/end of line by buffer distance)
     };
     Q_ENUM( EndCapStyle )
 
@@ -2187,10 +2186,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class JoinStyle SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, JoinStyle ) : int
-    {
-        Round SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleRound ) = 1, //!< Use rounded joins
-        Miter SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleMiter ), //!< Use mitered joins
-        Bevel SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleBevel ), //!< Use beveled joins
+      {
+      Round SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleRound ) = 1, //!< Use rounded joins
+      Miter SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleMiter ), //!< Use mitered joins
+      Bevel SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleBevel ), //!< Use beveled joins
     };
     Q_ENUM( JoinStyle )
 
@@ -2214,8 +2213,8 @@ class CORE_EXPORT Qgis
      */
     enum class GeosCreationFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        RejectOnInvalidSubGeometry = 1 << 0,  //!< Don't allow geometries with invalid sub-geometries to be created
-        SkipEmptyInteriorRings = 1 << 1,      //!< Skip any empty polygon interior ring
+      RejectOnInvalidSubGeometry = 1 << 0,  //!< Don't allow geometries with invalid sub-geometries to be created
+      SkipEmptyInteriorRings = 1 << 1,      //!< Skip any empty polygon interior ring
     };
     Q_ENUM( GeosCreationFlag )
 
@@ -2261,12 +2260,12 @@ class CORE_EXPORT Qgis
      */
     enum class FeatureRequestFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFeatureRequest, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoFlags            = 0, //!< No flags are set
-        NoGeometry         = 1,  //!< Geometry is not required. It may still be returned if e.g. required for a filter condition.
-        SubsetOfAttributes = 2,  //!< Fetch only a subset of attributes (setSubsetOfAttributes sets this flag)
-        ExactIntersect     = 4,   //!< Use exact geometry intersection (slower) instead of bounding boxes
-        IgnoreStaticNodesDuringExpressionCompilation = 8, //!< If a feature request uses a filter expression which can be partially precalculated due to static nodes in the expression, setting this flag will prevent these precalculated values from being utilized during compilation of the filter for the backend provider. This flag significantly slows down feature requests and should be used for debugging purposes only. \since QGIS 3.18
-        EmbeddedSymbols    = 16,  //!< Retrieve any embedded feature symbology \since QGIS 3.20
+      NoFlags            = 0, //!< No flags are set
+      NoGeometry         = 1,  //!< Geometry is not required. It may still be returned if e.g. required for a filter condition.
+      SubsetOfAttributes = 2,  //!< Fetch only a subset of attributes (setSubsetOfAttributes sets this flag)
+      ExactIntersect     = 4,   //!< Use exact geometry intersection (slower) instead of bounding boxes
+      IgnoreStaticNodesDuringExpressionCompilation = 8, //!< If a feature request uses a filter expression which can be partially precalculated due to static nodes in the expression, setting this flag will prevent these precalculated values from being utilized during compilation of the filter for the backend provider. This flag significantly slows down feature requests and should be used for debugging purposes only. \since QGIS 3.18
+      EmbeddedSymbols    = 16,  //!< Retrieve any embedded feature symbology \since QGIS 3.20
     };
     Q_ENUM( FeatureRequestFlag )
 
@@ -2288,11 +2287,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class FeatureRequestFilterType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFeatureRequest, FilterType ) : int
-    {
-        NoFilter SIP_MONKEYPATCH_COMPAT_NAME( FilterNone ), //!< No filter is applied
-                 Fid SIP_MONKEYPATCH_COMPAT_NAME( FilterFid ), //!< Filter using feature ID
-                 Expression SIP_MONKEYPATCH_COMPAT_NAME( FilterExpression ), //!< Filter using expression
-                 Fids SIP_MONKEYPATCH_COMPAT_NAME( FilterFids ) //!< Filter using feature IDs
+      {
+      NoFilter SIP_MONKEYPATCH_COMPAT_NAME( FilterNone ), //!< No filter is applied
+      Fid SIP_MONKEYPATCH_COMPAT_NAME( FilterFid ), //!< Filter using feature ID
+      Expression SIP_MONKEYPATCH_COMPAT_NAME( FilterExpression ), //!< Filter using expression
+      Fids SIP_MONKEYPATCH_COMPAT_NAME( FilterFids ) //!< Filter using feature IDs
     };
     Q_ENUM( FeatureRequestFilterType )
 
@@ -2304,10 +2303,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class InvalidGeometryCheck SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFeatureRequest, InvalidGeometryCheck ) : int
-    {
-        NoCheck SIP_MONKEYPATCH_COMPAT_NAME( GeometryNoCheck ) = 0, //!< No invalid geometry checking
-        SkipInvalid SIP_MONKEYPATCH_COMPAT_NAME( GeometrySkipInvalid ) = 1, //!< Skip any features with invalid geometry. This requires a slow geometry validity check for every feature.
-        AbortOnInvalid SIP_MONKEYPATCH_COMPAT_NAME( GeometryAbortOnInvalid ) = 2, //!< Close iterator on encountering any features with invalid geometry. This requires a slow geometry validity check for every feature.
+      {
+      NoCheck SIP_MONKEYPATCH_COMPAT_NAME( GeometryNoCheck ) = 0, //!< No invalid geometry checking
+      SkipInvalid SIP_MONKEYPATCH_COMPAT_NAME( GeometrySkipInvalid ) = 1, //!< Skip any features with invalid geometry. This requires a slow geometry validity check for every feature.
+      AbortOnInvalid SIP_MONKEYPATCH_COMPAT_NAME( GeometryAbortOnInvalid ) = 2, //!< Close iterator on encountering any features with invalid geometry. This requires a slow geometry validity check for every feature.
     };
     Q_ENUM( InvalidGeometryCheck )
 
@@ -2331,8 +2330,8 @@ class CORE_EXPORT Qgis
      */
     enum class FileOperationFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        IncludeMetadataFile = 1 << 0, //!< Indicates that any associated .qmd metadata file should be included with the operation
-        IncludeStyleFile = 1 << 1, //!< Indicates that any associated .qml styling file should be included with the operation
+      IncludeMetadataFile = 1 << 0, //!< Indicates that any associated .qmd metadata file should be included with the operation
+      IncludeStyleFile = 1 << 1, //!< Indicates that any associated .qml styling file should be included with the operation
     };
     //! File operation flags
     Q_DECLARE_FLAGS( FileOperationFlags, FileOperationFlag )
@@ -2346,9 +2345,9 @@ class CORE_EXPORT Qgis
      */
     enum class MapLayerProperty : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        UsersCannotToggleEditing = 1 << 0, //!< Indicates that users are not allowed to toggle editing for this layer. Note that this does not imply that the layer is non-editable (see isEditable(), supportsEditing() ), rather that the editable status of the layer cannot be changed by users manually \since QGIS 3.22
-        IsBasemapLayer = 1 << 1, //!< Layer is considered a 'basemap' layer, and certain properties of the layer should be ignored when calculating project-level properties. For instance, the extent of basemap layers is ignored when calculating the extent of a project, as these layers are typically global and extend outside of a project's area of interest \since QGIS 3.26
-        Is3DBasemapLayer = 1 << 2, //!< Layer is considered a '3D basemap' layer. This flag is similar to IsBasemapLayer, but reserved for layers which contain 3D data \since QGIS 3.44
+      UsersCannotToggleEditing = 1 << 0, //!< Indicates that users are not allowed to toggle editing for this layer. Note that this does not imply that the layer is non-editable (see isEditable(), supportsEditing() ), rather that the editable status of the layer cannot be changed by users manually \since QGIS 3.22
+      IsBasemapLayer = 1 << 1, //!< Layer is considered a 'basemap' layer, and certain properties of the layer should be ignored when calculating project-level properties. For instance, the extent of basemap layers is ignored when calculating the extent of a project, as these layers are typically global and extend outside of a project's area of interest \since QGIS 3.26
+      Is3DBasemapLayer = 1 << 2, //!< Layer is considered a '3D basemap' layer. This flag is similar to IsBasemapLayer, but reserved for layers which contain 3D data \since QGIS 3.44
     };
     //! Map layer properties
     Q_DECLARE_FLAGS( MapLayerProperties, MapLayerProperty )
@@ -2375,10 +2374,10 @@ class CORE_EXPORT Qgis
      */
     enum class DataProviderFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        IsBasemapSource = 1 << 1, //!< Associated source should be considered a 'basemap' layer. See Qgis::MapLayerProperty::IsBasemapLayer.
-                        FastExtent2D = 1 << 2, //!< Provider's 2D extent retrieval via QgsDataProvider::extent() is always guaranteed to be trivial/fast to calculate \since QGIS 3.38
-                        FastExtent3D = 1 << 3, //!< Provider's 3D extent retrieval via QgsDataProvider::extent3D() is always guaranteed to be trivial/fast to calculate \since QGIS 3.38
-                        Is3DBasemapSource = 1 << 4, //!< Associated source should be considered a '3D basemap' layer. See Qgis::MapLayerProperty::Is3DBasemapLayer. \since QGIS 3.44
+      IsBasemapSource = 1 << 1, //!< Associated source should be considered a 'basemap' layer. See Qgis::MapLayerProperty::IsBasemapLayer.
+      FastExtent2D = 1 << 2, //!< Provider's 2D extent retrieval via QgsDataProvider::extent() is always guaranteed to be trivial/fast to calculate \since QGIS 3.38
+      FastExtent3D = 1 << 3, //!< Provider's 3D extent retrieval via QgsDataProvider::extent3D() is always guaranteed to be trivial/fast to calculate \since QGIS 3.38
+      Is3DBasemapSource = 1 << 4, //!< Associated source should be considered a '3D basemap' layer. See Qgis::MapLayerProperty::Is3DBasemapLayer. \since QGIS 3.44
     };
     //! Data provider flags
     Q_DECLARE_FLAGS( DataProviderFlags, DataProviderFlag )
@@ -2483,10 +2482,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class CrsIdentifierType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCoordinateReferenceSystem, IdentifierType ) : int
-    {
-        ShortString, //!< A heavily abbreviated string, for use when a compact representation is required
-        MediumString, //!< A medium-length string, recommended for general purpose use
-        FullString, //!< Full definition -- possibly a very lengthy string, e.g. with no truncation of custom WKT definitions
+      {
+      ShortString, //!< A heavily abbreviated string, for use when a compact representation is required
+      MediumString, //!< A medium-length string, recommended for general purpose use
+      FullString, //!< Full definition -- possibly a very lengthy string, e.g. with no truncation of custom WKT definitions
     };
     Q_ENUM( CrsIdentifierType )
 
@@ -2498,16 +2497,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class CrsWktVariant SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCoordinateReferenceSystem, WktVariant ) : int
-    {
-        Wkt1Gdal SIP_MONKEYPATCH_COMPAT_NAME( WKT1_GDAL ), //!< WKT1 as traditionally output by GDAL, deriving from OGC 01-009. A notable departure from WKT1_GDAL with respect to OGC 01-009 is that in WKT1_GDAL, the unit of the PRIMEM value is always degrees.
-                 Wkt1Esri SIP_MONKEYPATCH_COMPAT_NAME( WKT1_ESRI ), //!< WKT1 as traditionally output by ESRI software, deriving from OGC 99-049.
-                 Wkt2_2015 SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2015 ), //!< Full WKT2 string, conforming to ISO 19162:2015(E) / OGC 12-063r5 with all possible nodes and new keyword names.
-                 Wkt2_2015Simplified SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2015_SIMPLIFIED ), //!< Same as WKT2_2015 with the following exceptions: UNIT keyword used. ID node only on top element. No ORDER element in AXIS element. PRIMEM node omitted if it is Greenwich.  ELLIPSOID.UNIT node omitted if it is UnitOfMeasure::METRE. PARAMETER.UNIT / PRIMEM.UNIT omitted if same as AXIS. AXIS.UNIT omitted and replaced by a common GEODCRS.UNIT if they are all the same on all axis.
-                 Wkt2_2019  SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2019 ), //!< Full WKT2 string, conforming to ISO 19162:2019 / OGC 18-010, with all possible nodes and new keyword names. Non-normative list of differences: WKT2_2019 uses GEOGCRS / BASEGEOGCRS keywords for GeographicCRS.
-                 Wkt2_2019Simplified  SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2019_SIMPLIFIED ), //!< WKT2_2019 with the simplification rule of WKT2_SIMPLIFIED
-                 Preferred SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED ) = Wkt2_2019, //!< Preferred format, matching the most recent WKT ISO standard. Currently an alias to WKT2_2019, but may change in future versions.
-                 PreferredSimplified  SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED_SIMPLIFIED ) = Wkt2_2019Simplified, //!< Preferred simplified format, matching the most recent WKT ISO standard. Currently an alias to WKT2_2019_SIMPLIFIED, but may change in future versions.
-                 PreferredGdal SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED_GDAL ) = Wkt2_2019, //!< Preferred format for conversion of CRS to WKT for use with the GDAL library.
+      {
+      Wkt1Gdal SIP_MONKEYPATCH_COMPAT_NAME( WKT1_GDAL ), //!< WKT1 as traditionally output by GDAL, deriving from OGC 01-009. A notable departure from WKT1_GDAL with respect to OGC 01-009 is that in WKT1_GDAL, the unit of the PRIMEM value is always degrees.
+      Wkt1Esri SIP_MONKEYPATCH_COMPAT_NAME( WKT1_ESRI ), //!< WKT1 as traditionally output by ESRI software, deriving from OGC 99-049.
+      Wkt2_2015 SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2015 ), //!< Full WKT2 string, conforming to ISO 19162:2015(E) / OGC 12-063r5 with all possible nodes and new keyword names.
+      Wkt2_2015Simplified SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2015_SIMPLIFIED ), //!< Same as WKT2_2015 with the following exceptions: UNIT keyword used. ID node only on top element. No ORDER element in AXIS element. PRIMEM node omitted if it is Greenwich.  ELLIPSOID.UNIT node omitted if it is UnitOfMeasure::METRE. PARAMETER.UNIT / PRIMEM.UNIT omitted if same as AXIS. AXIS.UNIT omitted and replaced by a common GEODCRS.UNIT if they are all the same on all axis.
+      Wkt2_2019  SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2019 ), //!< Full WKT2 string, conforming to ISO 19162:2019 / OGC 18-010, with all possible nodes and new keyword names. Non-normative list of differences: WKT2_2019 uses GEOGCRS / BASEGEOGCRS keywords for GeographicCRS.
+      Wkt2_2019Simplified  SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2019_SIMPLIFIED ), //!< WKT2_2019 with the simplification rule of WKT2_SIMPLIFIED
+      Preferred SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED ) = Wkt2_2019, //!< Preferred format, matching the most recent WKT ISO standard. Currently an alias to WKT2_2019, but may change in future versions.
+      PreferredSimplified  SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED_SIMPLIFIED ) = Wkt2_2019Simplified, //!< Preferred simplified format, matching the most recent WKT ISO standard. Currently an alias to WKT2_2019_SIMPLIFIED, but may change in future versions.
+      PreferredGdal SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED_GDAL ) = Wkt2_2019, //!< Preferred format for conversion of CRS to WKT for use with the GDAL library.
     };
     Q_ENUM( CrsWktVariant )
 
@@ -2531,9 +2530,9 @@ class CORE_EXPORT Qgis
      */
     enum class AnnotationItemFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ScaleDependentBoundingBox = 1 << 0, //!< Item's bounding box will vary depending on map scale
-        SupportsReferenceScale = 1 << 1, //!< Item supports reference scale based rendering \since QGIS 3.40
-        SupportsCallouts = 1 << 2, //!< Item supports callouts \since QGIS 3.40
+      ScaleDependentBoundingBox = 1 << 0, //!< Item's bounding box will vary depending on map scale
+      SupportsReferenceScale = 1 << 1, //!< Item supports reference scale based rendering \since QGIS 3.40
+      SupportsCallouts = 1 << 2, //!< Item supports callouts \since QGIS 3.40
     };
     //! Annotation item flags
     Q_DECLARE_FLAGS( AnnotationItemFlags, AnnotationItemFlag )
@@ -2560,7 +2559,7 @@ class CORE_EXPORT Qgis
      */
     enum class AnnotationItemGuiFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        FlagNoCreationTools = 1 << 0,  //!< Do not show item creation tools for the item type
+      FlagNoCreationTools = 1 << 0,  //!< Do not show item creation tools for the item type
     };
     //! Annotation item GUI flags
     Q_DECLARE_FLAGS( AnnotationItemGuiFlags, AnnotationItemGuiFlag )
@@ -2600,11 +2599,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class TemporalNavigationMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTemporalNavigationObject, NavigationMode ) : int
-    {
-        Disabled SIP_MONKEYPATCH_COMPAT_NAME( NavigationOff ), //!< Temporal navigation is disabled
-                 Animated, //!< Temporal navigation relies on frames within a datetime range
-                 FixedRange, //!< Temporal navigation relies on a fixed datetime range
-                 Movie, //!< Movie mode -- behaves like a video player, with a fixed frame duration and no temporal range \since QGIS 3.36
+      {
+      Disabled SIP_MONKEYPATCH_COMPAT_NAME( NavigationOff ), //!< Temporal navigation is disabled
+      Animated, //!< Temporal navigation relies on frames within a datetime range
+      FixedRange, //!< Temporal navigation relies on a fixed datetime range
+      Movie, //!< Movie mode -- behaves like a video player, with a fixed frame duration and no temporal range \since QGIS 3.36
     };
     Q_ENUM( TemporalNavigationMode )
 
@@ -2616,10 +2615,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class AnimationState SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTemporalNavigationObject, AnimationState ) : int
-    {
-        Forward, //!< Animation is playing forward.
-        Reverse, //!< Animation is playing in reverse.
-        Idle, //!< Animation is paused.
+      {
+      Forward, //!< Animation is playing forward.
+      Reverse, //!< Animation is playing in reverse.
+      Idle, //!< Animation is paused.
     };
     Q_ENUM( AnimationState )
 
@@ -2646,13 +2645,13 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class VectorTemporalMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorLayerTemporalProperties, TemporalMode ) : int
-    {
-        FixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ModeFixedTemporalRange ) = 0, //!< Mode when temporal properties have fixed start and end datetimes.
-        FeatureDateTimeInstantFromField SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeInstantFromField ), //!< Mode when features have a datetime instant taken from a single field
-        FeatureDateTimeStartAndEndFromFields SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndEndFromFields ), //!< Mode when features have separate fields for start and end times
-        FeatureDateTimeStartAndDurationFromFields SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndDurationFromFields ), //!< Mode when features have a field for start time and a field for event duration
-        FeatureDateTimeStartAndEndFromExpressions SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndEndFromExpressions ), //!< Mode when features use expressions for start and end times
-        RedrawLayerOnly SIP_MONKEYPATCH_COMPAT_NAME( ModeRedrawLayerOnly ), //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when symbology or rule based renderer expressions depend on the time range.
+      {
+      FixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ModeFixedTemporalRange ) = 0, //!< Mode when temporal properties have fixed start and end datetimes.
+      FeatureDateTimeInstantFromField SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeInstantFromField ), //!< Mode when features have a datetime instant taken from a single field
+      FeatureDateTimeStartAndEndFromFields SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndEndFromFields ), //!< Mode when features have separate fields for start and end times
+      FeatureDateTimeStartAndDurationFromFields SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndDurationFromFields ), //!< Mode when features have a field for start time and a field for event duration
+      FeatureDateTimeStartAndEndFromExpressions SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndEndFromExpressions ), //!< Mode when features use expressions for start and end times
+      RedrawLayerOnly SIP_MONKEYPATCH_COMPAT_NAME( ModeRedrawLayerOnly ), //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when symbology or rule based renderer expressions depend on the time range.
     };
     Q_ENUM( VectorTemporalMode )
 
@@ -2674,10 +2673,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class VectorDataProviderTemporalMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorDataProviderTemporalCapabilities, TemporalMode ) : int
-    {
-        HasFixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ProviderHasFixedTemporalRange ) = 0, //!< Entire dataset from provider has a fixed start and end datetime.
-        StoresFeatureDateTimeInstantInField SIP_MONKEYPATCH_COMPAT_NAME( ProviderStoresFeatureDateTimeInstantInField ), //!< Dataset has feature datetime instants stored in a single field
-        StoresFeatureDateTimeStartAndEndInSeparateFields SIP_MONKEYPATCH_COMPAT_NAME( ProviderStoresFeatureDateTimeStartAndEndInSeparateFields ), //!< Dataset stores feature start and end datetimes in separate fields
+      {
+      HasFixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ProviderHasFixedTemporalRange ) = 0, //!< Entire dataset from provider has a fixed start and end datetime.
+      StoresFeatureDateTimeInstantInField SIP_MONKEYPATCH_COMPAT_NAME( ProviderStoresFeatureDateTimeInstantInField ), //!< Dataset has feature datetime instants stored in a single field
+      StoresFeatureDateTimeStartAndEndInSeparateFields SIP_MONKEYPATCH_COMPAT_NAME( ProviderStoresFeatureDateTimeStartAndEndInSeparateFields ), //!< Dataset stores feature start and end datetimes in separate fields
     };
     Q_ENUM( VectorDataProviderTemporalMode )
 
@@ -2687,13 +2686,13 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class RasterTemporalMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterLayerTemporalProperties, TemporalMode ) : int
-    {
-        FixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ModeFixedTemporalRange ) = 0, //!< Mode when temporal properties have fixed start and end datetimes.
-        TemporalRangeFromDataProvider SIP_MONKEYPATCH_COMPAT_NAME( ModeTemporalRangeFromDataProvider ) = 1, //!< Mode when raster layer delegates temporal range handling to the dataprovider.
-        RedrawLayerOnly SIP_MONKEYPATCH_COMPAT_NAME( ModeRedrawLayerOnly ) = 2, //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when raster symbology expressions depend on the time range. \since QGIS 3.22
-        FixedRangePerBand = 3, //!< Layer has a fixed temporal range per band \since QGIS 3.38
-        RepresentsTemporalValues = 4, //!< Pixel values represent an datetime
-        FixedDateTime = 5, //!< Layer has a fixed date time instant. \since QGIS 3.44
+      {
+      FixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ModeFixedTemporalRange ) = 0, //!< Mode when temporal properties have fixed start and end datetimes.
+      TemporalRangeFromDataProvider SIP_MONKEYPATCH_COMPAT_NAME( ModeTemporalRangeFromDataProvider ) = 1, //!< Mode when raster layer delegates temporal range handling to the dataprovider.
+      RedrawLayerOnly SIP_MONKEYPATCH_COMPAT_NAME( ModeRedrawLayerOnly ) = 2, //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when raster symbology expressions depend on the time range. \since QGIS 3.22
+      FixedRangePerBand = 3, //!< Layer has a fixed temporal range per band \since QGIS 3.38
+      RepresentsTemporalValues = 4, //!< Pixel values represent an datetime
+      FixedDateTime = 5, //!< Layer has a fixed date time instant. \since QGIS 3.44
     };
     Q_ENUM( RasterTemporalMode )
 
@@ -2703,12 +2702,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class TemporalIntervalMatchMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterDataProviderTemporalCapabilities, IntervalHandlingMethod ) : int
-    {
-        MatchUsingWholeRange, //!< Use an exact match to the whole temporal range
-        MatchExactUsingStartOfRange, //!< Match the start of the temporal range to a corresponding layer or band, and only use exact matching results
-        MatchExactUsingEndOfRange, //!< Match the end of the temporal range to a corresponding layer or band, and only use exact matching results
-        FindClosestMatchToStartOfRange, //!< Match the start of the temporal range to the least previous closest datetime.
-        FindClosestMatchToEndOfRange //!< Match the end of the temporal range to the least previous closest datetime.
+      {
+      MatchUsingWholeRange, //!< Use an exact match to the whole temporal range
+      MatchExactUsingStartOfRange, //!< Match the start of the temporal range to a corresponding layer or band, and only use exact matching results
+      MatchExactUsingEndOfRange, //!< Match the end of the temporal range to a corresponding layer or band, and only use exact matching results
+      FindClosestMatchToStartOfRange, //!< Match the start of the temporal range to the least previous closest datetime.
+      FindClosestMatchToEndOfRange //!< Match the end of the temporal range to the least previous closest datetime.
     };
     Q_ENUM( TemporalIntervalMatchMethod )
 
@@ -2719,7 +2718,7 @@ class CORE_EXPORT Qgis
      */
     enum class RasterTemporalCapabilityFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        RequestedTimesMustExactlyMatchAllAvailableTemporalRanges = 1 << 0, //!< If present, indicates that the provider must only request temporal values which are exact matches for the values present in QgsRasterDataProviderTemporalCapabilities::allAvailableTemporalRanges().
+      RequestedTimesMustExactlyMatchAllAvailableTemporalRanges = 1 << 0, //!< If present, indicates that the provider must only request temporal values which are exact matches for the values present in QgsRasterDataProviderTemporalCapabilities::allAvailableTemporalRanges().
     };
     Q_ENUM( RasterTemporalCapabilityFlag )
 
@@ -2737,9 +2736,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class TransformDirection SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCoordinateTransform, TransformDirection ) : int
-    {
-        Forward SIP_MONKEYPATCH_COMPAT_NAME( ForwardTransform ), //!< Forward transform (from source to destination)
-                Reverse SIP_MONKEYPATCH_COMPAT_NAME( ReverseTransform ) //!< Reverse/inverse transform (from destination to source)
+      {
+      Forward SIP_MONKEYPATCH_COMPAT_NAME( ForwardTransform ), //!< Forward transform (from source to destination)
+      Reverse SIP_MONKEYPATCH_COMPAT_NAME( ReverseTransform ) //!< Reverse/inverse transform (from destination to source)
     };
     Q_ENUM( TransformDirection )
 
@@ -2750,8 +2749,8 @@ class CORE_EXPORT Qgis
      */
     enum class CoordinateTransformationFlag  : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        BallparkTransformsAreAppropriate = 1 << 0, //!< Indicates that approximate "ballpark" results are appropriate for this coordinate transform. See QgsCoordinateTransform::setBallparkTransformsAreAppropriate() for further details.
-                                         IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::isTransformationPossible() and QgsCoordinateTransform::isValid().
+      BallparkTransformsAreAppropriate = 1 << 0, //!< Indicates that approximate "ballpark" results are appropriate for this coordinate transform. See QgsCoordinateTransform::setBallparkTransformsAreAppropriate() for further details.
+      IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::isTransformationPossible() and QgsCoordinateTransform::isValid().
     };
     Q_ENUM( CoordinateTransformationFlag )
 
@@ -2783,25 +2782,25 @@ class CORE_EXPORT Qgis
      */
     enum class MapSettingsFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMapSettings, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Antialiasing             = 0x01,  //!< Enable anti-aliasing for map rendering
-        DrawEditingInfo          = 0x02,  //!< Enable drawing of vertex markers for layers in editing mode
-        ForceVectorOutput        = 0x04,  //!< Vector graphics should not be cached and drawn as raster images. \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
-        UseAdvancedEffects       = 0x08,  //!< Enable layer opacity and blending effects \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
-        DrawLabeling             = 0x10,  //!< Enable drawing of labels on top of the map
-        UseRenderingOptimization = 0x20,  //!< Enable vector simplification and other rendering optimizations
-        DrawSelection            = 0x40,  //!< Whether vector selections should be shown in the rendered map
-        DrawSymbolBounds         = 0x80,  //!< Draw bounds of symbols (for debugging/testing)
-        RenderMapTile            = 0x100, //!< Draw map such that there are no problems between adjacent tiles
-        RenderPartialOutput      = 0x200, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
-        RenderPreviewJob         = 0x400, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
-        RenderBlocking           = 0x800, //!< Render and load remote sources in the same thread to ensure rendering remote sources (svg and images). WARNING: this flag must NEVER be used from GUI based applications (like the main QGIS application) or crashes will result. Only for use in external scripts or QGIS server.
-        LosslessImageRendering   = 0x1000, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF). This flag only works with builds based on Qt 5.13 or later.
-        Render3DMap              = 0x2000, //!< Render is for a 3D map
-        HighQualityImageTransforms = 0x4000, //!< Enable high quality image transformations, which results in better appearance of scaled or rotated raster components of a map \since QGIS 3.24
-        SkipSymbolRendering      = 0x8000, //!< Disable symbol rendering while still drawing labels if enabled \since QGIS 3.24
-        ForceRasterMasks         = 0x10000,  //!< Force symbol masking to be applied using a raster method. This is considerably faster when compared to the vector method, but results in a inferior quality output. \since QGIS 3.26.1
-        RecordProfile            = 0x20000, //!< Enable run-time profiling while rendering \since QGIS 3.34
-        AlwaysUseGlobalMasks     = 0x40000, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex vector exports in all current Qt versions. This flag only applies to vector map exports. \since QGIS 3.38
+      Antialiasing             = 0x01,  //!< Enable anti-aliasing for map rendering
+      DrawEditingInfo          = 0x02,  //!< Enable drawing of vertex markers for layers in editing mode
+      ForceVectorOutput        = 0x04,  //!< Vector graphics should not be cached and drawn as raster images. \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
+      UseAdvancedEffects       = 0x08,  //!< Enable layer opacity and blending effects \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
+      DrawLabeling             = 0x10,  //!< Enable drawing of labels on top of the map
+      UseRenderingOptimization = 0x20,  //!< Enable vector simplification and other rendering optimizations
+      DrawSelection            = 0x40,  //!< Whether vector selections should be shown in the rendered map
+      DrawSymbolBounds         = 0x80,  //!< Draw bounds of symbols (for debugging/testing)
+      RenderMapTile            = 0x100, //!< Draw map such that there are no problems between adjacent tiles
+      RenderPartialOutput      = 0x200, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
+      RenderPreviewJob         = 0x400, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
+      RenderBlocking           = 0x800, //!< Render and load remote sources in the same thread to ensure rendering remote sources (svg and images). WARNING: this flag must NEVER be used from GUI based applications (like the main QGIS application) or crashes will result. Only for use in external scripts or QGIS server.
+      LosslessImageRendering   = 0x1000, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF). This flag only works with builds based on Qt 5.13 or later.
+      Render3DMap              = 0x2000, //!< Render is for a 3D map
+      HighQualityImageTransforms = 0x4000, //!< Enable high quality image transformations, which results in better appearance of scaled or rotated raster components of a map \since QGIS 3.24
+      SkipSymbolRendering      = 0x8000, //!< Disable symbol rendering while still drawing labels if enabled \since QGIS 3.24
+      ForceRasterMasks         = 0x10000,  //!< Force symbol masking to be applied using a raster method. This is considerably faster when compared to the vector method, but results in a inferior quality output. \since QGIS 3.26.1
+      RecordProfile            = 0x20000, //!< Enable run-time profiling while rendering \since QGIS 3.34
+      AlwaysUseGlobalMasks     = 0x40000, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex vector exports in all current Qt versions. This flag only applies to vector map exports. \since QGIS 3.38
     };
     //! Map settings flags
     Q_DECLARE_FLAGS( MapSettingsFlags, MapSettingsFlag ) SIP_MONKEYPATCH_FLAGS_UNNEST( QgsMapSettings, Flags )
@@ -2815,29 +2814,29 @@ class CORE_EXPORT Qgis
      */
     enum class RenderContextFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRenderContext, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        DrawEditingInfo          = 0x01,  //!< Enable drawing of vertex markers for layers in editing mode
-        ForceVectorOutput        = 0x02,  //!< Vector graphics should not be cached and drawn as raster images \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
-        UseAdvancedEffects       = 0x04,  //!< Enable layer opacity and blending effects \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
-        UseRenderingOptimization = 0x08,  //!< Enable vector simplification and other rendering optimizations
-        DrawSelection            = 0x10,  //!< Whether vector selections should be shown in the rendered map
-        DrawSymbolBounds         = 0x20,  //!< Draw bounds of symbols (for debugging/testing)
-        RenderMapTile            = 0x40,  //!< Draw map such that there are no problems between adjacent tiles
-        Antialiasing             = 0x80,  //!< Use antialiasing while drawing
-        RenderPartialOutput      = 0x100, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
-        RenderPreviewJob         = 0x200, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
-        RenderBlocking           = 0x400, //!< Render and load remote sources in the same thread to ensure rendering remote sources (svg and images). WARNING: this flag must NEVER be used from GUI based applications (like the main QGIS application) or crashes will result. Only for use in external scripts or QGIS server.
-        RenderSymbolPreview      = 0x800, //!< The render is for a symbol preview only and map based properties may not be available, so care should be taken to handle map unit based sizes in an appropriate way.
-        LosslessImageRendering   = 0x1000, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF). This flag only works with builds based on Qt 5.13 or later.
-        ApplyScalingWorkaroundForTextRendering = 0x2000, //!< Whether a scaling workaround designed to stablise the rendering of small font sizes (or for painters scaled out by a large amount) when rendering text. Generally this is recommended, but it may incur some performance cost.
-        Render3DMap              = 0x4000, //!< Render is for a 3D map
-        ApplyClipAfterReprojection = 0x8000, //!< Feature geometry clipping to mapExtent() must be performed after the geometries are transformed using coordinateTransform(). Usually feature geometry clipping occurs using the extent() in the layer's CRS prior to geometry transformation, but in some cases when extent() could not be accurately calculated it is necessary to clip geometries to mapExtent() AFTER transforming them using coordinateTransform().
-        RenderingSubSymbol       = 0x10000, //!< Set whenever a sub-symbol of a parent symbol is currently being rendered. Can be used during symbol and symbol layer rendering to determine whether the symbol being rendered is a subsymbol. \since QGIS 3.24
-        HighQualityImageTransforms = 0x20000, //!< Enable high quality image transformations, which results in better appearance of scaled or rotated raster components of a map \since QGIS 3.24
-        SkipSymbolRendering      = 0x40000, //!< Disable symbol rendering while still drawing labels if enabled \since QGIS 3.24
-        RecordProfile            = 0x80000, //!< Enable run-time profiling while rendering \since QGIS 3.34
-        AlwaysUseGlobalMasks     = 0x100000, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex vector exports in all current Qt versions. This flag only applies to vector map exports. \since QGIS 3.38
-        DisableSymbolClippingToExtent = 0x200000, //!< Force symbol clipping to map extent to be disabled in all situations. This will result in slower rendering, and should only be used in situations where the feature clipping is always undesirable. \since QGIS 3.40
-        RenderLayerTree = 0x400000        //!< The render is for a layer tree display where map based properties are not available and where avoidance of long rendering freeze is crucial \since QGIS 3.44
+      DrawEditingInfo          = 0x01,  //!< Enable drawing of vertex markers for layers in editing mode
+      ForceVectorOutput        = 0x02,  //!< Vector graphics should not be cached and drawn as raster images \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
+      UseAdvancedEffects       = 0x04,  //!< Enable layer opacity and blending effects \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
+      UseRenderingOptimization = 0x08,  //!< Enable vector simplification and other rendering optimizations
+      DrawSelection            = 0x10,  //!< Whether vector selections should be shown in the rendered map
+      DrawSymbolBounds         = 0x20,  //!< Draw bounds of symbols (for debugging/testing)
+      RenderMapTile            = 0x40,  //!< Draw map such that there are no problems between adjacent tiles
+      Antialiasing             = 0x80,  //!< Use antialiasing while drawing
+      RenderPartialOutput      = 0x100, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
+      RenderPreviewJob         = 0x200, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
+      RenderBlocking           = 0x400, //!< Render and load remote sources in the same thread to ensure rendering remote sources (svg and images). WARNING: this flag must NEVER be used from GUI based applications (like the main QGIS application) or crashes will result. Only for use in external scripts or QGIS server.
+      RenderSymbolPreview      = 0x800, //!< The render is for a symbol preview only and map based properties may not be available, so care should be taken to handle map unit based sizes in an appropriate way.
+      LosslessImageRendering   = 0x1000, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF). This flag only works with builds based on Qt 5.13 or later.
+      ApplyScalingWorkaroundForTextRendering = 0x2000, //!< Whether a scaling workaround designed to stablise the rendering of small font sizes (or for painters scaled out by a large amount) when rendering text. Generally this is recommended, but it may incur some performance cost.
+      Render3DMap              = 0x4000, //!< Render is for a 3D map
+      ApplyClipAfterReprojection = 0x8000, //!< Feature geometry clipping to mapExtent() must be performed after the geometries are transformed using coordinateTransform(). Usually feature geometry clipping occurs using the extent() in the layer's CRS prior to geometry transformation, but in some cases when extent() could not be accurately calculated it is necessary to clip geometries to mapExtent() AFTER transforming them using coordinateTransform().
+      RenderingSubSymbol       = 0x10000, //!< Set whenever a sub-symbol of a parent symbol is currently being rendered. Can be used during symbol and symbol layer rendering to determine whether the symbol being rendered is a subsymbol. \since QGIS 3.24
+      HighQualityImageTransforms = 0x20000, //!< Enable high quality image transformations, which results in better appearance of scaled or rotated raster components of a map \since QGIS 3.24
+      SkipSymbolRendering      = 0x40000, //!< Disable symbol rendering while still drawing labels if enabled \since QGIS 3.24
+      RecordProfile            = 0x80000, //!< Enable run-time profiling while rendering \since QGIS 3.34
+      AlwaysUseGlobalMasks     = 0x100000, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex vector exports in all current Qt versions. This flag only applies to vector map exports. \since QGIS 3.38
+      DisableSymbolClippingToExtent = 0x200000, //!< Force symbol clipping to map extent to be disabled in all situations. This will result in slower rendering, and should only be used in situations where the feature clipping is always undesirable. \since QGIS 3.40
+      RenderLayerTree = 0x400000        //!< The render is for a layer tree display where map based properties are not available and where avoidance of long rendering freeze is crucial \since QGIS 3.44
     };
     //! Render context flags
     Q_DECLARE_FLAGS( RenderContextFlags, RenderContextFlag ) SIP_MONKEYPATCH_FLAGS_UNNEST( QgsRenderContext, Flags )
@@ -2851,9 +2850,9 @@ class CORE_EXPORT Qgis
      */
     enum class MapLayerRendererFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        RenderPartialOutputs = 1 << 0,  //!< The renderer benefits from rendering temporary in-progress preview renders. These are temporary results which will be used for the layer during rendering in-progress compositions, which will differ from the final layer render. They can be used for showing overlays or other information to users which help inform them about what is actually occurring during a slow layer render, but where these overlays and additional content is not wanted in the final layer renders. Another use case is rendering unsorted results as soon as they are available, before doing a final sorted render of the entire layer contents.
-        RenderPartialOutputOverPreviousCachedImage = 1 << 1,//!< When rendering temporary in-progress preview renders, these preview renders can be drawn over any previously cached layer render we have for the same region. This can allow eg a low-resolution zoomed in version of the last map render to be used as a base painting surface to overdraw with incremental preview render outputs. If not set, an empty image will be used as the starting point for the render preview image.
-        AffectsLabeling = 1 << 2, //!< The layer rendering will interact with the map labeling \since QGIS 3.40
+      RenderPartialOutputs = 1 << 0,  //!< The renderer benefits from rendering temporary in-progress preview renders. These are temporary results which will be used for the layer during rendering in-progress compositions, which will differ from the final layer render. They can be used for showing overlays or other information to users which help inform them about what is actually occurring during a slow layer render, but where these overlays and additional content is not wanted in the final layer renders. Another use case is rendering unsorted results as soon as they are available, before doing a final sorted render of the entire layer contents.
+      RenderPartialOutputOverPreviousCachedImage = 1 << 1,//!< When rendering temporary in-progress preview renders, these preview renders can be drawn over any previously cached layer render we have for the same region. This can allow eg a low-resolution zoomed in version of the last map render to be used as a base painting surface to overdraw with incremental preview render outputs. If not set, an empty image will be used as the starting point for the render preview image.
+      AffectsLabeling = 1 << 2, //!< The layer rendering will interact with the map labeling \since QGIS 3.40
     };
     Q_ENUM( MapLayerRendererFlag )
 
@@ -2872,7 +2871,7 @@ class CORE_EXPORT Qgis
      */
     enum class PaintEffectFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        RequiresRasterization = 1 << 0, //!< The effect requires raster-based rendering.
+      RequiresRasterization = 1 << 0, //!< The effect requires raster-based rendering.
     };
     Q_ENUM( PaintEffectFlag )
 
@@ -2892,10 +2891,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class TextRenderFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRenderContext, TextRenderFormat ) : int
-    {
-        AlwaysOutlines SIP_MONKEYPATCH_COMPAT_NAME( TextFormatAlwaysOutlines ), //!< Always render text using path objects (AKA outlines/curves). This setting guarantees the best quality rendering, even when using a raster paint surface (where sub-pixel path based text rendering is superior to sub-pixel text-based rendering). The downside is that text is converted to paths only, so users cannot open created vector outputs for post-processing in other applications and retain text editability.  This setting also guarantees complete compatibility with the full range of formatting options available through QgsTextRenderer and QgsTextFormat, some of which may not be possible to reproduce when using a vector-based paint surface and TextFormatAlwaysText mode. A final benefit to this setting is that vector exports created using text as outlines do not require all users to have the original fonts installed in order to display the text in its original style.
-                       AlwaysText SIP_MONKEYPATCH_COMPAT_NAME( TextFormatAlwaysText ), //!< Always render text as text objects. While this mode preserves text objects as text for post-processing in external vector editing applications, it can result in rendering artifacts or poor quality rendering, depending on the text format settings. Even with raster based paint devices, TextFormatAlwaysText can result in inferior rendering quality to TextFormatAlwaysOutlines. When rendering using TextFormatAlwaysText to a vector based device (e.g. PDF or SVG), care must be taken to ensure that the required fonts are available to users when opening the created files, or default fallback fonts will be used to display the output instead. (Although PDF exports MAY automatically embed some fonts when possible, depending on the user's platform).
-                       PreferText, //!< Render text as text objects, unless doing so results in rendering artifacts or poor quality rendering (depending on text format settings). When rendering using TextFormatAlwaysText to a vector based device (e.g. PDF or SVG), care must be taken to ensure that the required fonts are available to users when opening the created files, or default fallback fonts will be used to display the output instead. (Although PDF exports MAY automatically embed some fonts when possible, depending on the user's platform). \since QGIS 3.40
+      {
+      AlwaysOutlines SIP_MONKEYPATCH_COMPAT_NAME( TextFormatAlwaysOutlines ), //!< Always render text using path objects (AKA outlines/curves). This setting guarantees the best quality rendering, even when using a raster paint surface (where sub-pixel path based text rendering is superior to sub-pixel text-based rendering). The downside is that text is converted to paths only, so users cannot open created vector outputs for post-processing in other applications and retain text editability.  This setting also guarantees complete compatibility with the full range of formatting options available through QgsTextRenderer and QgsTextFormat, some of which may not be possible to reproduce when using a vector-based paint surface and TextFormatAlwaysText mode. A final benefit to this setting is that vector exports created using text as outlines do not require all users to have the original fonts installed in order to display the text in its original style.
+      AlwaysText SIP_MONKEYPATCH_COMPAT_NAME( TextFormatAlwaysText ), //!< Always render text as text objects. While this mode preserves text objects as text for post-processing in external vector editing applications, it can result in rendering artifacts or poor quality rendering, depending on the text format settings. Even with raster based paint devices, TextFormatAlwaysText can result in inferior rendering quality to TextFormatAlwaysOutlines. When rendering using TextFormatAlwaysText to a vector based device (e.g. PDF or SVG), care must be taken to ensure that the required fonts are available to users when opening the created files, or default fallback fonts will be used to display the output instead. (Although PDF exports MAY automatically embed some fonts when possible, depending on the user's platform).
+      PreferText, //!< Render text as text objects, unless doing so results in rendering artifacts or poor quality rendering (depending on text format settings). When rendering using TextFormatAlwaysText to a vector based device (e.g. PDF or SVG), care must be taken to ensure that the required fonts are available to users when opening the created files, or default fallback fonts will be used to display the output instead. (Although PDF exports MAY automatically embed some fonts when possible, depending on the user's platform). \since QGIS 3.40
     };
     Q_ENUM( TextRenderFormat )
 
@@ -2908,15 +2907,15 @@ class CORE_EXPORT Qgis
      */
     enum class LabelingFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLabelingEngineSettings, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        UseAllLabels          = 1 << 1, //!< Whether to draw all labels even if there would be collisions
-        UsePartialCandidates  = 1 << 2, //!< Whether to use also label candidates that are partially outside of the map view
-        // TODO QGIS 5.0: remove
-        RenderOutlineLabels   = 1 << 3, //!< Whether to render labels as text or outlines. Deprecated and of QGIS 3.4.3 - use defaultTextRenderFormat() instead.
-        DrawLabelRectOnly     = 1 << 4, //!< Whether to only draw the label rect and not the actual label text (used for unit tests)
-        DrawCandidates        = 1 << 5, //!< Whether to draw rectangles of generated candidates (good for debugging)
-        DrawUnplacedLabels    = 1 << 6, //!< Whether to render unplaced labels as an indicator/warning for users
-        CollectUnplacedLabels = 1 << 7, //!< Whether unplaced labels should be collected in the labeling results (regardless of whether they are being rendered) \since QGIS 3.20
-        DrawLabelMetrics      = 1 << 8, //!< Whether to render label metric guides (for debugging) \since QGIS 3.30
+      UseAllLabels          = 1 << 1, //!< Whether to draw all labels even if there would be collisions
+      UsePartialCandidates  = 1 << 2, //!< Whether to use also label candidates that are partially outside of the map view
+      // TODO QGIS 5.0: remove
+      RenderOutlineLabels   = 1 << 3, //!< Whether to render labels as text or outlines. Deprecated and of QGIS 3.4.3 - use defaultTextRenderFormat() instead.
+      DrawLabelRectOnly     = 1 << 4, //!< Whether to only draw the label rect and not the actual label text (used for unit tests)
+      DrawCandidates        = 1 << 5, //!< Whether to draw rectangles of generated candidates (good for debugging)
+      DrawUnplacedLabels    = 1 << 6, //!< Whether to render unplaced labels as an indicator/warning for users
+      CollectUnplacedLabels = 1 << 7, //!< Whether unplaced labels should be collected in the labeling results (regardless of whether they are being rendered) \since QGIS 3.20
+      DrawLabelMetrics      = 1 << 8, //!< Whether to render label metric guides (for debugging) \since QGIS 3.30
     };
     Q_ENUM( LabelingFlag )
 
@@ -2938,9 +2937,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class LabelPlacementEngineVersion SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLabelingEngineSettings, PlacementEngineVersion ) : int
-    {
-        Version1 SIP_MONKEYPATCH_COMPAT_NAME( PlacementEngineVersion1 ), //!< Version 1, matches placement from QGIS <= 3.10.1
-                 Version2 SIP_MONKEYPATCH_COMPAT_NAME( PlacementEngineVersion2 ), //!< Version 2 (default for new projects since QGIS 3.12)
+      {
+      Version1 SIP_MONKEYPATCH_COMPAT_NAME( PlacementEngineVersion1 ), //!< Version 1, matches placement from QGIS <= 3.10.1
+      Version2 SIP_MONKEYPATCH_COMPAT_NAME( PlacementEngineVersion2 ), //!< Version 2 (default for new projects since QGIS 3.12)
     };
     Q_ENUM( LabelPlacementEngineVersion )
 
@@ -2952,10 +2951,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class TextOrientation SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextFormat, TextOrientation ) : int
-    {
-        Horizontal SIP_MONKEYPATCH_COMPAT_NAME( HorizontalOrientation ), //!< Horizontally oriented text
-                   Vertical SIP_MONKEYPATCH_COMPAT_NAME( VerticalOrientation ), //!< Vertically oriented text
-                   RotationBased SIP_MONKEYPATCH_COMPAT_NAME( RotationBasedOrientation ), //!< Horizontally or vertically oriented text based on rotation (only available for map labeling)
+      {
+      Horizontal SIP_MONKEYPATCH_COMPAT_NAME( HorizontalOrientation ), //!< Horizontally oriented text
+      Vertical SIP_MONKEYPATCH_COMPAT_NAME( VerticalOrientation ), //!< Vertically oriented text
+      RotationBased SIP_MONKEYPATCH_COMPAT_NAME( RotationBasedOrientation ), //!< Horizontally or vertically oriented text based on rotation (only available for map labeling)
     };
     Q_ENUM( TextOrientation )
 
@@ -2967,12 +2966,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class TextLayoutMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextRenderer, DrawMode ) : int
-    {
-        Rectangle SIP_MONKEYPATCH_COMPAT_NAME( Rect ), //!< Text within rectangle layout mode
-                  Point, //!< Text at point of origin layout mode
-                  Labeling SIP_MONKEYPATCH_COMPAT_NAME( Label ), //!< Labeling-specific layout mode
-                  RectangleCapHeightBased, //!< Similar to Rectangle mode, but uses cap height only when calculating font heights for the first line of text, and cap height + descent for subsequent lines of text \since QGIS 3.30
-                  RectangleAscentBased, //!< Similar to Rectangle mode, but uses ascents only when calculating font and line heights. \since QGIS 3.30
+      {
+      Rectangle SIP_MONKEYPATCH_COMPAT_NAME( Rect ), //!< Text within rectangle layout mode
+      Point, //!< Text at point of origin layout mode
+      Labeling SIP_MONKEYPATCH_COMPAT_NAME( Label ), //!< Labeling-specific layout mode
+      RectangleCapHeightBased, //!< Similar to Rectangle mode, but uses cap height only when calculating font heights for the first line of text, and cap height + descent for subsequent lines of text \since QGIS 3.30
+      RectangleAscentBased, //!< Similar to Rectangle mode, but uses ascents only when calculating font and line heights. \since QGIS 3.30
     };
     Q_ENUM( TextLayoutMode )
 
@@ -2985,10 +2984,10 @@ class CORE_EXPORT Qgis
      */
     enum class TextComponent SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextRenderer, TextPart ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Text = 1 << 0, //!< Text component
-        Buffer = 1 << 1, //!< Buffer component
-        Background = 1 << 2, //!< Background shape
-        Shadow = 1 << 3, //!< Drop shadow
+      Text = 1 << 0, //!< Text component
+      Buffer = 1 << 1, //!< Buffer component
+      Background = 1 << 2, //!< Background shape
+      Shadow = 1 << 3, //!< Drop shadow
     };
     Q_ENUM( TextComponent )
 
@@ -3008,11 +3007,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class TextHorizontalAlignment SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextRenderer, HAlignment ) : int
-    {
-        Left SIP_MONKEYPATCH_COMPAT_NAME( AlignLeft ), //!< Left align
-             Center SIP_MONKEYPATCH_COMPAT_NAME( AlignCenter ), //!< Center align
-             Right SIP_MONKEYPATCH_COMPAT_NAME( AlignRight ), //!< Right align
-             Justify SIP_MONKEYPATCH_COMPAT_NAME( AlignJustify ), //!< Justify align
+      {
+      Left SIP_MONKEYPATCH_COMPAT_NAME( AlignLeft ), //!< Left align
+      Center SIP_MONKEYPATCH_COMPAT_NAME( AlignCenter ), //!< Center align
+      Right SIP_MONKEYPATCH_COMPAT_NAME( AlignRight ), //!< Right align
+      Justify SIP_MONKEYPATCH_COMPAT_NAME( AlignJustify ), //!< Justify align
     };
     Q_ENUM( TextHorizontalAlignment )
 
@@ -3027,10 +3026,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class TextVerticalAlignment SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextRenderer, VAlignment ) : int
-    {
-        Top SIP_MONKEYPATCH_COMPAT_NAME( AlignTop ), //!< Align to top
-            VerticalCenter SIP_MONKEYPATCH_COMPAT_NAME( AlignVCenter ), //!< Center align
-            Bottom SIP_MONKEYPATCH_COMPAT_NAME( AlignBottom ), //!< Align to bottom
+      {
+      Top SIP_MONKEYPATCH_COMPAT_NAME( AlignTop ), //!< Align to top
+      VerticalCenter SIP_MONKEYPATCH_COMPAT_NAME( AlignVCenter ), //!< Center align
+      Bottom SIP_MONKEYPATCH_COMPAT_NAME( AlignBottom ), //!< Align to bottom
     };
     Q_ENUM( TextVerticalAlignment )
 
@@ -3057,10 +3056,10 @@ class CORE_EXPORT Qgis
      */
     enum class CurvedTextFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextRendererUtils, CurvedTextFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        TruncateStringWhenLineIsTooShort = 1 << 0, //!< When a string is too long for the line, truncate characters instead of aborting the placement
-        UseBaselinePlacement = 1 << 1, //!< Generate placement based on the character baselines instead of centers
-        UprightCharactersOnly = 1 << 2, //!< Permit upright characters only. If not present then upside down text placement is permitted.
-        ExtendLineToFitText = 1 << 3, //!< When a string is too long for the line, extend the line's final segment to fit the entire string. \since QGIS 4.0
+      TruncateStringWhenLineIsTooShort = 1 << 0, //!< When a string is too long for the line, truncate characters instead of aborting the placement
+      UseBaselinePlacement = 1 << 1, //!< Generate placement based on the character baselines instead of centers
+      UprightCharactersOnly = 1 << 2, //!< Permit upright characters only. If not present then upside down text placement is permitted.
+      ExtendLineToFitText = 1 << 3, //!< When a string is too long for the line, extend the line's final segment to fit the entire string. \since QGIS 4.0
     };
     Q_ENUM( CurvedTextFlag )
 
@@ -3079,11 +3078,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.38
      */
     enum class VectorSimplificationAlgorithm SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorSimplifyMethod, SimplifyAlgorithm ) : int
-    {
-        Distance = 0, //!< The simplification uses the distance between points to remove duplicate points
-        SnapToGrid = 1, //!< The simplification uses a grid (similar to ST_SnapToGrid) to remove duplicate points
-        Visvalingam = 2, //!< The simplification gives each point in a line an importance weighting, so that least important points are removed first
-        SnappedToGridGlobal = 3, //!< Snap to a global grid based on the tolerance. Good for consistent results for incoming vertices, regardless of their feature
+      {
+      Distance = 0, //!< The simplification uses the distance between points to remove duplicate points
+      SnapToGrid = 1, //!< The simplification uses a grid (similar to ST_SnapToGrid) to remove duplicate points
+      Visvalingam = 2, //!< The simplification gives each point in a line an importance weighting, so that least important points are removed first
+      SnappedToGridGlobal = 3, //!< Snap to a global grid based on the tolerance. Good for consistent results for incoming vertices, regardless of their feature
     };
     Q_ENUM( VectorSimplificationAlgorithm )
 
@@ -3096,10 +3095,10 @@ class CORE_EXPORT Qgis
      */
     enum class VectorRenderingSimplificationFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorSimplifyMethod, SimplifyHint ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoSimplification           = 0, //!< No simplification can be applied
-        GeometrySimplification     = 1, //!< The geometries can be simplified using the current map2pixel context state
-        AntialiasingSimplification = 2, //!< The geometries can be rendered with 'AntiAliasing' disabled because of it is '1-pixel size'
-        FullSimplification         = 3, //!< All simplification hints can be applied ( Geometry + AA-disabling )
+      NoSimplification           = 0, //!< No simplification can be applied
+      GeometrySimplification     = 1, //!< The geometries can be simplified using the current map2pixel context state
+      AntialiasingSimplification = 2, //!< The geometries can be rendered with 'AntiAliasing' disabled because of it is '1-pixel size'
+      FullSimplification         = 3, //!< All simplification hints can be applied ( Geometry + AA-disabling )
     };
     Q_ENUM( VectorRenderingSimplificationFlag )
 
@@ -3144,9 +3143,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class VertexType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVertexId, VertexType ) : int
-    {
-        Segment SIP_MONKEYPATCH_COMPAT_NAME( SegmentVertex ) = 1, //!< The actual start or end point of a segment
-        Curve SIP_MONKEYPATCH_COMPAT_NAME( CurveVertex ) = 2, //!< An intermediate point on a segment defining the curvature of the segment
+      {
+      Segment SIP_MONKEYPATCH_COMPAT_NAME( SegmentVertex ) = 1, //!< The actual start or end point of a segment
+      Curve SIP_MONKEYPATCH_COMPAT_NAME( CurveVertex ) = 2, //!< An intermediate point on a segment defining the curvature of the segment
       ControlPoint SIP_MONKEYPATCH_COMPAT_NAME( ControlPointVertex ) = 3, //!< A NURBS control point (does not lie on the curve) \since QGIS 4.0
     };
     Q_ENUM( VertexType )
@@ -3159,44 +3158,44 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class MarkerShape SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSimpleMarkerSymbolLayerBase, Shape ) : int
-    {
-        Square, //!< Square
-        Diamond, //!< Diamond
-        Pentagon, //!< Pentagon
-        Hexagon, //!< Hexagon
-        Triangle, //!< Triangle
-        EquilateralTriangle, //!< Equilateral triangle
-        Star, //!< Star
-        Arrow, //!< Arrow
-        Circle, //!< Circle
-        Cross, //!< Cross (lines only)
-        CrossFill, //!< Solid filled cross
-        Cross2, //!< Rotated cross (lines only), 'x' shape
-        Line, //!< Vertical line
-        ArrowHead, //!< Right facing arrow head (unfilled, lines only)
-        ArrowHeadFilled, //!< Right facing filled arrow head
-        SemiCircle, //!< Semi circle (top half)
-        ThirdCircle, //!< One third circle (top left third)
-        QuarterCircle, //!< Quarter circle (top left quarter)
-        QuarterSquare, //!< Quarter square (top left quarter)
-        HalfSquare, //!< Half square (left half)
-        DiagonalHalfSquare, //!< Diagonal half square (bottom left half)
-        RightHalfTriangle, //!< Right half of triangle
-        LeftHalfTriangle, //!< Left half of triangle
-        Octagon, //!< Octagon \since QGIS 3.18
-        SquareWithCorners, //!< A square with diagonal corners \since QGIS 3.18
-        AsteriskFill, //!< A filled asterisk shape \since QGIS 3.18
-        HalfArc, //!< A line-only half arc \since QGIS 3.20
-        ThirdArc, //!< A line-only one third arc \since QGIS 3.20
-        QuarterArc, //!< A line-only one quarter arc \since QGIS 3.20
-        ParallelogramRight, //!< Parallelogram that slants right \since QGIS 3.28
-        ParallelogramLeft, //!< Parallelogram that slants left \since QGIS 3.28
-        Trapezoid, //!< Trapezoid \since QGIS 3.28
-        Shield, //!< A shape consisting of a triangle attached to a rectangle \since QGIS 3.28
-        DiamondStar, //!< A 4-sided star \since QGIS 3.28
-        Heart, //!< Heart \since QGIS 3.28
-        Decagon, //!< Decagon \since QGIS 3.28
-        RoundedSquare, //!< A square with rounded corners \since QGIS 3.28
+      {
+      Square, //!< Square
+      Diamond, //!< Diamond
+      Pentagon, //!< Pentagon
+      Hexagon, //!< Hexagon
+      Triangle, //!< Triangle
+      EquilateralTriangle, //!< Equilateral triangle
+      Star, //!< Star
+      Arrow, //!< Arrow
+      Circle, //!< Circle
+      Cross, //!< Cross (lines only)
+      CrossFill, //!< Solid filled cross
+      Cross2, //!< Rotated cross (lines only), 'x' shape
+      Line, //!< Vertical line
+      ArrowHead, //!< Right facing arrow head (unfilled, lines only)
+      ArrowHeadFilled, //!< Right facing filled arrow head
+      SemiCircle, //!< Semi circle (top half)
+      ThirdCircle, //!< One third circle (top left third)
+      QuarterCircle, //!< Quarter circle (top left quarter)
+      QuarterSquare, //!< Quarter square (top left quarter)
+      HalfSquare, //!< Half square (left half)
+      DiagonalHalfSquare, //!< Diagonal half square (bottom left half)
+      RightHalfTriangle, //!< Right half of triangle
+      LeftHalfTriangle, //!< Left half of triangle
+      Octagon, //!< Octagon \since QGIS 3.18
+      SquareWithCorners, //!< A square with diagonal corners \since QGIS 3.18
+      AsteriskFill, //!< A filled asterisk shape \since QGIS 3.18
+      HalfArc, //!< A line-only half arc \since QGIS 3.20
+      ThirdArc, //!< A line-only one third arc \since QGIS 3.20
+      QuarterArc, //!< A line-only one quarter arc \since QGIS 3.20
+      ParallelogramRight, //!< Parallelogram that slants right \since QGIS 3.28
+      ParallelogramLeft, //!< Parallelogram that slants left \since QGIS 3.28
+      Trapezoid, //!< Trapezoid \since QGIS 3.28
+      Shield, //!< A shape consisting of a triangle attached to a rectangle \since QGIS 3.28
+      DiamondStar, //!< A 4-sided star \since QGIS 3.28
+      Heart, //!< Heart \since QGIS 3.28
+      Decagon, //!< Decagon \since QGIS 3.28
+      RoundedSquare, //!< A square with rounded corners \since QGIS 3.28
     };
     Q_ENUM( MarkerShape )
 
@@ -3209,14 +3208,14 @@ class CORE_EXPORT Qgis
      */
     enum class MarkerLinePlacement SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTemplatedLineSymbolLayerBase, Placement ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Interval = 1 << 0, //!< Place symbols at regular intervals
-        Vertex = 1 << 1, //!< Place symbols on every vertex in the line
-        LastVertex = 1 << 2, //!< Place symbols on the last vertex in the line
-        FirstVertex = 1 << 3, //!< Place symbols on the first vertex in the line
-        CentralPoint = 1 << 4, //!< Place symbols at the mid point of the line
-        CurvePoint = 1 << 5, //!< Place symbols at every virtual curve point in the line (used when rendering curved geometry types only)
-        SegmentCenter = 1 << 6, //!< Place symbols at the center of every line segment
-        InnerVertices = 1 << 7, //!< Inner vertices (i.e. all vertices except the first and last vertex) \since QGIS 3.24
+      Interval = 1 << 0, //!< Place symbols at regular intervals
+      Vertex = 1 << 1, //!< Place symbols on every vertex in the line
+      LastVertex = 1 << 2, //!< Place symbols on the last vertex in the line
+      FirstVertex = 1 << 3, //!< Place symbols on the first vertex in the line
+      CentralPoint = 1 << 4, //!< Place symbols at the mid point of the line
+      CurvePoint = 1 << 5, //!< Place symbols at every virtual curve point in the line (used when rendering curved geometry types only)
+      SegmentCenter = 1 << 6, //!< Place symbols at the center of every line segment
+      InnerVertices = 1 << 7, //!< Inner vertices (i.e. all vertices except the first and last vertex) \since QGIS 3.24
     };
     Q_ENUM( MarkerLinePlacement )
     Q_DECLARE_FLAGS( MarkerLinePlacements, MarkerLinePlacement )
@@ -3229,10 +3228,10 @@ class CORE_EXPORT Qgis
      */
     enum class LinearReferencingPlacement : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        IntervalCartesian2D = 1 << 0, //!< Place labels at regular intervals, using Cartesian distance calculations on a 2D plane
-        IntervalZ = 1 << 1, //!< Place labels at regular intervals, linearly interpolated using Z values
-        IntervalM = 1 << 2, //!< Place labels at regular intervals, linearly interpolated using M values
-        Vertex = 1 << 3, //!< Place labels on every vertex in the line
+      IntervalCartesian2D = 1 << 0, //!< Place labels at regular intervals, using Cartesian distance calculations on a 2D plane
+      IntervalZ = 1 << 1, //!< Place labels at regular intervals, linearly interpolated using Z values
+      IntervalM = 1 << 2, //!< Place labels at regular intervals, linearly interpolated using M values
+      Vertex = 1 << 3, //!< Place labels on every vertex in the line
     };
     Q_ENUM( LinearReferencingPlacement )
 
@@ -3257,9 +3256,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class GradientColorSource SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGradientFillSymbolLayer, GradientColorType ) : int
-    {
-        SimpleTwoColor, //!< Simple two color gradient
-        ColorRamp, //!< Gradient color ramp
+      {
+      SimpleTwoColor, //!< Simple two color gradient
+      ColorRamp, //!< Gradient color ramp
     };
     Q_ENUM( GradientColorSource )
 
@@ -3271,10 +3270,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class GradientType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGradientFillSymbolLayer, GradientType ) : int
-    {
-        Linear, //!< Linear gradient
-        Radial, //!< Radial (circular) gradient
-        Conical, //!< Conical (polar) gradient
+      {
+      Linear, //!< Linear gradient
+      Radial, //!< Radial (circular) gradient
+      Conical, //!< Conical (polar) gradient
     };
     Q_ENUM( GradientType )
 
@@ -3286,9 +3285,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class SymbolCoordinateReference SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGradientFillSymbolLayer, GradientCoordinateMode ) : int
-    {
-        Feature, //!< Relative to feature/shape being rendered
-        Viewport, //!< Relative to the whole viewport/output device
+      {
+      Feature, //!< Relative to feature/shape being rendered
+      Viewport, //!< Relative to the whole viewport/output device
     };
     Q_ENUM( SymbolCoordinateReference )
 
@@ -3301,10 +3300,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class GradientSpread SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGradientFillSymbolLayer, GradientSpread ) : int
-    {
-        Pad, //!< Pad out gradient using colors at endpoint of gradient
-        Reflect, //!< Reflect gradient
-        Repeat, //!< Repeat gradient
+      {
+      Pad, //!< Pad out gradient using colors at endpoint of gradient
+      Reflect, //!< Reflect gradient
+      Repeat, //!< Repeat gradient
     };
     Q_ENUM( GradientSpread )
 
@@ -3316,9 +3315,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class PointCountMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRandomMarkerFillSymbolLayer, CountMethod ) : int
-    {
-        Absolute SIP_MONKEYPATCH_COMPAT_NAME( AbsoluteCount ), //!< The point count is used as an absolute count of markers
-                 DensityBased SIP_MONKEYPATCH_COMPAT_NAME( DensityBasedCount ), //!< The point count is part of a marker density count
+      {
+      Absolute SIP_MONKEYPATCH_COMPAT_NAME( AbsoluteCount ), //!< The point count is used as an absolute count of markers
+      DensityBased SIP_MONKEYPATCH_COMPAT_NAME( DensityBasedCount ), //!< The point count is part of a marker density count
     };
     Q_ENUM( PointCountMethod )
 
@@ -3385,9 +3384,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class GraduatedMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGraduatedSymbolRenderer, GraduatedMethod ) : int
-    {
-        Color SIP_MONKEYPATCH_COMPAT_NAME( GraduatedColor ), //!< Alter color of symbols
-              Size SIP_MONKEYPATCH_COMPAT_NAME( GraduatedSize ), //!< Alter size of symbols
+      {
+      Color SIP_MONKEYPATCH_COMPAT_NAME( GraduatedColor ), //!< Alter color of symbols
+      Size SIP_MONKEYPATCH_COMPAT_NAME( GraduatedSize ), //!< Alter size of symbols
     };
     Q_ENUM( GraduatedMethod )
 
@@ -3468,15 +3467,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class Capitalization SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsStringUtils, Capitalization ) : int
-    {
-        MixedCase = 0, //!< Mixed case, ie no change
-        AllUppercase = 1, //!< Convert all characters to uppercase
-        AllLowercase = 2,  //!< Convert all characters to lowercase
-        ForceFirstLetterToCapital = 4, //!< Convert just the first letter of each word to uppercase, leave the rest untouched
-        SmallCaps = 5, //!< Mixed case small caps \since QGIS 3.24
-        TitleCase = 1004, //!< Simple title case conversion - does not fully grammatically parse the text and uses simple rules only. Note that this method does not convert any characters to lowercase, it only uppercases required letters. Callers must ensure that input strings are already lowercased.
-        UpperCamelCase = 1005, //!< Convert the string to upper camel case. Note that this method does not unaccent characters.
-        AllSmallCaps = 1006, //!< Force all characters to small caps \since QGIS 3.24
+      {
+      MixedCase = 0, //!< Mixed case, ie no change
+      AllUppercase = 1, //!< Convert all characters to uppercase
+      AllLowercase = 2,  //!< Convert all characters to lowercase
+      ForceFirstLetterToCapital = 4, //!< Convert just the first letter of each word to uppercase, leave the rest untouched
+      SmallCaps = 5, //!< Mixed case small caps \since QGIS 3.24
+      TitleCase = 1004, //!< Simple title case conversion - does not fully grammatically parse the text and uses simple rules only. Note that this method does not convert any characters to lowercase, it only uppercases required letters. Callers must ensure that input strings are already lowercased.
+      UpperCamelCase = 1005, //!< Convert the string to upper camel case. Note that this method does not unaccent characters.
+      AllSmallCaps = 1006, //!< Force all characters to small caps \since QGIS 3.24
     };
     Q_ENUM( Capitalization )
 
@@ -3487,7 +3486,7 @@ class CORE_EXPORT Qgis
      */
     enum class TextRendererFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        WrapLines = 1 << 0, //!< Automatically wrap long lines of text
+      WrapLines = 1 << 0, //!< Automatically wrap long lines of text
     };
     Q_ENUM( TextRendererFlag )
     Q_DECLARE_FLAGS( TextRendererFlags, TextRendererFlag )
@@ -3511,10 +3510,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class AngularDirection SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCurve, Orientation ) : int
-    {
-        Clockwise, //!< Clockwise direction
-        CounterClockwise, //!< Counter-clockwise direction
-        NoOrientation, //!< Unknown orientation or sentinel value
+      {
+      Clockwise, //!< Clockwise direction
+      CounterClockwise, //!< Counter-clockwise direction
+      NoOrientation, //!< Unknown orientation or sentinel value
     };
     Q_ENUM( AngularDirection )
 
@@ -3538,7 +3537,7 @@ class CORE_EXPORT Qgis
      */
     enum class MapCanvasFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ShowMainAnnotationLayer = 1 << 0, //!< The project's main annotation layer should be rendered in the canvas
+      ShowMainAnnotationLayer = 1 << 0, //!< The project's main annotation layer should be rendered in the canvas
     };
     Q_ENUM( MapCanvasFlag )
 
@@ -3557,8 +3556,8 @@ class CORE_EXPORT Qgis
      */
     enum class ViewSyncModeFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Sync3DTo2D = 1 << 0, //!< Synchronize 3D view camera to the main map canvas extent
-        Sync2DTo3D = 1 << 1, //!< Update the 2D main canvas extent to include the viewed area from the 3D view
+      Sync3DTo2D = 1 << 0, //!< Synchronize 3D view camera to the main map canvas extent
+      Sync2DTo3D = 1 << 1, //!< Update the 2D main canvas extent to include the viewed area from the 3D view
     };
     Q_ENUM( ViewSyncModeFlag )
     Q_DECLARE_FLAGS( ViewSyncModeFlags, ViewSyncModeFlag )
@@ -3583,7 +3582,7 @@ class CORE_EXPORT Qgis
      */
     enum class HistoryProviderBackend : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        LocalProfile = 1 << 0, //!< Local profile
+      LocalProfile = 1 << 0, //!< Local profile
 //      Project = 1 << 1, //!< QGIS Project  (not yet implemented)
     };
     Q_ENUM( HistoryProviderBackend )
@@ -3610,21 +3609,21 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingSourceType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessing, SourceType ) : int
-    {
-        MapLayer SIP_MONKEYPATCH_COMPAT_NAME( TypeMapLayer ) = -2, //!< Any map layer type (raster, vector, mesh, point cloud, annotation or plugin layer)
-        VectorAnyGeometry SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorAnyGeometry ) = -1, //!< Any vector layer with geometry
-        VectorPoint SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorPoint ) = 0, //!< Vector point layers
-        VectorLine SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorLine ) = 1, //!< Vector line layers
-        VectorPolygon SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorPolygon ) = 2, //!< Vector polygon layers
-        Raster SIP_MONKEYPATCH_COMPAT_NAME( TypeRaster ) = 3, //!< Raster layers
-        File SIP_MONKEYPATCH_COMPAT_NAME( TypeFile ) = 4, //!< Files (i.e. non map layer sources, such as text files)
-        Vector SIP_MONKEYPATCH_COMPAT_NAME( TypeVector ) = 5, //!< Tables (i.e. vector layers with or without geometry). When used for a sink this indicates the sink has no geometry.
-        Mesh SIP_MONKEYPATCH_COMPAT_NAME( TypeMesh ) = 6, //!< Mesh layers \since QGIS 3.6
-        Plugin SIP_MONKEYPATCH_COMPAT_NAME( TypePlugin ) = 7, //!< Plugin layers \since QGIS 3.22
-        PointCloud SIP_MONKEYPATCH_COMPAT_NAME( TypePointCloud ) = 8, //!< Point cloud layers \since QGIS 3.22
-        Annotation SIP_MONKEYPATCH_COMPAT_NAME( TypeAnnotation ) = 9, //!< Annotation layers \since QGIS 3.22
-        VectorTile SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorTile ) = 10, //!< Vector tile layers \since QGIS 3.32
-        TiledScene = 11 //!< Tiled scene layers \since QGIS 4.0
+      {
+      MapLayer SIP_MONKEYPATCH_COMPAT_NAME( TypeMapLayer ) = -2, //!< Any map layer type (raster, vector, mesh, point cloud, annotation or plugin layer)
+      VectorAnyGeometry SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorAnyGeometry ) = -1, //!< Any vector layer with geometry
+      VectorPoint SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorPoint ) = 0, //!< Vector point layers
+      VectorLine SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorLine ) = 1, //!< Vector line layers
+      VectorPolygon SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorPolygon ) = 2, //!< Vector polygon layers
+      Raster SIP_MONKEYPATCH_COMPAT_NAME( TypeRaster ) = 3, //!< Raster layers
+      File SIP_MONKEYPATCH_COMPAT_NAME( TypeFile ) = 4, //!< Files (i.e. non map layer sources, such as text files)
+      Vector SIP_MONKEYPATCH_COMPAT_NAME( TypeVector ) = 5, //!< Tables (i.e. vector layers with or without geometry). When used for a sink this indicates the sink has no geometry.
+      Mesh SIP_MONKEYPATCH_COMPAT_NAME( TypeMesh ) = 6, //!< Mesh layers \since QGIS 3.6
+      Plugin SIP_MONKEYPATCH_COMPAT_NAME( TypePlugin ) = 7, //!< Plugin layers \since QGIS 3.22
+      PointCloud SIP_MONKEYPATCH_COMPAT_NAME( TypePointCloud ) = 8, //!< Point cloud layers \since QGIS 3.22
+      Annotation SIP_MONKEYPATCH_COMPAT_NAME( TypeAnnotation ) = 9, //!< Annotation layers \since QGIS 3.22
+      VectorTile SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorTile ) = 10, //!< Vector tile layers \since QGIS 3.32
+      TiledScene = 11 //!< Tiled scene layers \since QGIS 4.0
     };
     Q_ENUM( ProcessingSourceType )
 
@@ -3638,8 +3637,8 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingProviderFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingProvider, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        DeemphasiseSearchResults SIP_MONKEYPATCH_COMPAT_NAME( FlagDeemphasiseSearchResults ) = 1 << 1, //!< Algorithms should be de-emphasised in the search results when searching for algorithms. Use for low-priority providers or those with substantial known issues.
-        CompatibleWithVirtualRaster SIP_MONKEYPATCH_COMPAT_NAME( FlagCompatibleWithVirtualRaster ) = 1 << 2, //!< The processing provider's algorithms can work with QGIS virtualraster data provider \since QGIS 3.36
+      DeemphasiseSearchResults SIP_MONKEYPATCH_COMPAT_NAME( FlagDeemphasiseSearchResults ) = 1 << 1, //!< Algorithms should be de-emphasised in the search results when searching for algorithms. Use for low-priority providers or those with substantial known issues.
+      CompatibleWithVirtualRaster SIP_MONKEYPATCH_COMPAT_NAME( FlagCompatibleWithVirtualRaster ) = 1 << 2, //!< The processing provider's algorithms can work with QGIS virtualraster data provider \since QGIS 3.36
     };
     Q_ENUM( ProcessingProviderFlag );
 
@@ -3662,22 +3661,22 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingAlgorithmFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingAlgorithm, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        HideFromToolbox SIP_MONKEYPATCH_COMPAT_NAME( FlagHideFromToolbox ) = 1 << 1, //!< Algorithm should be hidden from the toolbox
-        HideFromModeler SIP_MONKEYPATCH_COMPAT_NAME( FlagHideFromModeler ) = 1 << 2, //!< Algorithm should be hidden from the modeler
-        SupportsBatch SIP_MONKEYPATCH_COMPAT_NAME( FlagSupportsBatch ) = 1 << 3,  //!< Algorithm supports batch mode
-        CanCancel SIP_MONKEYPATCH_COMPAT_NAME( FlagCanCancel ) = 1 << 4, //!< Algorithm can be canceled
-        RequiresMatchingCrs SIP_MONKEYPATCH_COMPAT_NAME( FlagRequiresMatchingCrs ) = 1 << 5, //!< Algorithm requires that all input layers have matching coordinate reference systems
-        NoThreading SIP_MONKEYPATCH_COMPAT_NAME( FlagNoThreading ) = 1 << 6, //!< Algorithm is not thread safe and cannot be run in a background thread, e.g. for algorithms which manipulate the current project, layer selections, or with external dependencies which are not thread-safe.
-        DisplayNameIsLiteral SIP_MONKEYPATCH_COMPAT_NAME( FlagDisplayNameIsLiteral ) = 1 << 7, //!< Algorithm's display name is a static literal string, and should not be translated or automatically formatted. For use with algorithms named after commands, e.g. GRASS 'v.in.ogr'.
-        SupportsInPlaceEdits SIP_MONKEYPATCH_COMPAT_NAME( FlagSupportsInPlaceEdits ) = 1 << 8, //!< Algorithm supports in-place editing
-        KnownIssues SIP_MONKEYPATCH_COMPAT_NAME( FlagKnownIssues ) = 1 << 9, //!< Algorithm has known issues
-        CustomException SIP_MONKEYPATCH_COMPAT_NAME( FlagCustomException ) = 1 << 10, //!< Algorithm raises custom exception notices, don't use the standard ones
-        PruneModelBranchesBasedOnAlgorithmResults SIP_MONKEYPATCH_COMPAT_NAME( FlagPruneModelBranchesBasedOnAlgorithmResults ) = 1 << 11, //!< Algorithm results will cause remaining model branches to be pruned based on the results of running the algorithm
-        SkipGenericModelLogging SIP_MONKEYPATCH_COMPAT_NAME( FlagSkipGenericModelLogging ) = 1 << 12, //!< When running as part of a model, the generic algorithm setup and results logging should be skipped
-        NotAvailableInStandaloneTool SIP_MONKEYPATCH_COMPAT_NAME( FlagNotAvailableInStandaloneTool ) = 1 << 13, //!< Algorithm should not be available from the standalone "qgis_process" tool. Used to flag algorithms which make no sense outside of the QGIS application, such as "select by..." style algorithms.
-        RequiresProject SIP_MONKEYPATCH_COMPAT_NAME( FlagRequiresProject ) = 1 << 14, //!< The algorithm requires that a valid QgsProject is available from the processing context in order to execute
-        SecurityRisk = 1 << 15, //!< The algorithm represents a potential security risk if executed with untrusted inputs. \since QGIS 3.40
-        Deprecated SIP_MONKEYPATCH_COMPAT_NAME( FlagDeprecated ) = HideFromToolbox | HideFromModeler, //!< Algorithm is deprecated
+      HideFromToolbox SIP_MONKEYPATCH_COMPAT_NAME( FlagHideFromToolbox ) = 1 << 1, //!< Algorithm should be hidden from the toolbox
+      HideFromModeler SIP_MONKEYPATCH_COMPAT_NAME( FlagHideFromModeler ) = 1 << 2, //!< Algorithm should be hidden from the modeler
+      SupportsBatch SIP_MONKEYPATCH_COMPAT_NAME( FlagSupportsBatch ) = 1 << 3,  //!< Algorithm supports batch mode
+      CanCancel SIP_MONKEYPATCH_COMPAT_NAME( FlagCanCancel ) = 1 << 4, //!< Algorithm can be canceled
+      RequiresMatchingCrs SIP_MONKEYPATCH_COMPAT_NAME( FlagRequiresMatchingCrs ) = 1 << 5, //!< Algorithm requires that all input layers have matching coordinate reference systems
+      NoThreading SIP_MONKEYPATCH_COMPAT_NAME( FlagNoThreading ) = 1 << 6, //!< Algorithm is not thread safe and cannot be run in a background thread, e.g. for algorithms which manipulate the current project, layer selections, or with external dependencies which are not thread-safe.
+      DisplayNameIsLiteral SIP_MONKEYPATCH_COMPAT_NAME( FlagDisplayNameIsLiteral ) = 1 << 7, //!< Algorithm's display name is a static literal string, and should not be translated or automatically formatted. For use with algorithms named after commands, e.g. GRASS 'v.in.ogr'.
+      SupportsInPlaceEdits SIP_MONKEYPATCH_COMPAT_NAME( FlagSupportsInPlaceEdits ) = 1 << 8, //!< Algorithm supports in-place editing
+      KnownIssues SIP_MONKEYPATCH_COMPAT_NAME( FlagKnownIssues ) = 1 << 9, //!< Algorithm has known issues
+      CustomException SIP_MONKEYPATCH_COMPAT_NAME( FlagCustomException ) = 1 << 10, //!< Algorithm raises custom exception notices, don't use the standard ones
+      PruneModelBranchesBasedOnAlgorithmResults SIP_MONKEYPATCH_COMPAT_NAME( FlagPruneModelBranchesBasedOnAlgorithmResults ) = 1 << 11, //!< Algorithm results will cause remaining model branches to be pruned based on the results of running the algorithm
+      SkipGenericModelLogging SIP_MONKEYPATCH_COMPAT_NAME( FlagSkipGenericModelLogging ) = 1 << 12, //!< When running as part of a model, the generic algorithm setup and results logging should be skipped
+      NotAvailableInStandaloneTool SIP_MONKEYPATCH_COMPAT_NAME( FlagNotAvailableInStandaloneTool ) = 1 << 13, //!< Algorithm should not be available from the standalone "qgis_process" tool. Used to flag algorithms which make no sense outside of the QGIS application, such as "select by..." style algorithms.
+      RequiresProject SIP_MONKEYPATCH_COMPAT_NAME( FlagRequiresProject ) = 1 << 14, //!< The algorithm requires that a valid QgsProject is available from the processing context in order to execute
+      SecurityRisk = 1 << 15, //!< The algorithm represents a potential security risk if executed with untrusted inputs. \since QGIS 3.40
+      Deprecated SIP_MONKEYPATCH_COMPAT_NAME( FlagDeprecated ) = HideFromToolbox | HideFromModeler, //!< Algorithm is deprecated
     };
     Q_ENUM( ProcessingAlgorithmFlag );
 
@@ -3698,9 +3697,9 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingAlgorithmDocumentationFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        RegeneratesPrimaryKey = 1 << 0, //!< Algorithm always drops any existing primary keys or FID values and regenerates them in outputs
-        RegeneratesPrimaryKeyInSomeScenarios = 1 << 1, //!< Algorithm may drop the existing primary keys or FID values in some scenarios, depending on algorithm inputs and parameters
-        RespectsEllipsoid = 1 << 2, //!< Algorithm respects the context's ellipsoid settings, and uses ellipsoidal based measurements. \since QGIS 4.0
+      RegeneratesPrimaryKey = 1 << 0, //!< Algorithm always drops any existing primary keys or FID values and regenerates them in outputs
+      RegeneratesPrimaryKeyInSomeScenarios = 1 << 1, //!< Algorithm may drop the existing primary keys or FID values in some scenarios, depending on algorithm inputs and parameters
+      RespectsEllipsoid = 1 << 2, //!< Algorithm respects the context's ellipsoid settings, and uses ellipsoidal based measurements. \since QGIS 4.0
     };
     Q_ENUM( ProcessingAlgorithmDocumentationFlag )
 
@@ -3721,9 +3720,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingPropertyAvailability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingAlgorithm, PropertyAvailability ) : int
-    {
-        NotAvailable, //!< Properties are not available
-        Available, //!< Properties are available
+      {
+      NotAvailable, //!< Properties are not available
+      Available, //!< Properties are available
     };
     Q_ENUM( ProcessingPropertyAvailability )
 
@@ -3735,10 +3734,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingLogLevel SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingContext, LogLevel ) : int
-    {
-        DefaultLevel = 0, //!< Default logging level
-        Verbose, //!< Verbose logging
-        ModelDebug, //!< Model debug level logging. Includes verbose logging and other outputs useful for debugging models \since QGIS 3.34
+      {
+      DefaultLevel = 0, //!< Default logging level
+      Verbose, //!< Verbose logging
+      ModelDebug, //!< Model debug level logging. Includes verbose logging and other outputs useful for debugging models \since QGIS 3.34
     };
     Q_ENUM( ProcessingLogLevel )
 
@@ -3766,8 +3765,8 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingFeatureSourceDefinitionFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingFeatureSourceDefinition, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        OverrideDefaultGeometryCheck SIP_MONKEYPATCH_COMPAT_NAME( FlagOverrideDefaultGeometryCheck ) = 1 << 0, //!< If set, the default geometry check method (as dictated by QgsProcessingContext) will be overridden for this source
-        CreateIndividualOutputPerInputFeature SIP_MONKEYPATCH_COMPAT_NAME( FlagCreateIndividualOutputPerInputFeature ) = 1 << 1, //!< If set, every feature processed from this source will be placed into its own individually created output destination. Support for this flag depends on how an algorithm is executed.
+      OverrideDefaultGeometryCheck SIP_MONKEYPATCH_COMPAT_NAME( FlagOverrideDefaultGeometryCheck ) = 1 << 0, //!< If set, the default geometry check method (as dictated by QgsProcessingContext) will be overridden for this source
+      CreateIndividualOutputPerInputFeature SIP_MONKEYPATCH_COMPAT_NAME( FlagCreateIndividualOutputPerInputFeature ) = 1 << 1, //!< If set, every feature processed from this source will be placed into its own individually created output destination. Support for this flag depends on how an algorithm is executed.
     };
     Q_ENUM( ProcessingFeatureSourceDefinitionFlag )
 
@@ -3790,7 +3789,7 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingFeatureSourceFlag SIP_ENUM_BASETYPE( IntFlag ) SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingFeatureSource, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        SkipGeometryValidityChecks SIP_MONKEYPATCH_COMPAT_NAME( FlagSkipGeometryValidityChecks ) = 1 << 1, //!< Invalid geometry checks should always be skipped. This flag can be useful for algorithms which always require invalid geometries, regardless of any user settings (e.g. "repair geometry" type algorithms).
+      SkipGeometryValidityChecks SIP_MONKEYPATCH_COMPAT_NAME( FlagSkipGeometryValidityChecks ) = 1 << 1, //!< Invalid geometry checks should always be skipped. This flag can be useful for algorithms which always require invalid geometries, regardless of any user settings (e.g. "repair geometry" type algorithms).
     };
     Q_ENUM( ProcessingFeatureSourceFlag )
 
@@ -3816,7 +3815,7 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingParameterTypeFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterType, ParameterFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ExposeToModeler = 1 //!< Is this parameter available in the modeler. Is set to on by default.
+      ExposeToModeler = 1 //!< Is this parameter available in the modeler. Is set to on by default.
     };
     Q_ENUM( ProcessingParameterTypeFlag )
 
@@ -3842,10 +3841,10 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingParameterFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterDefinition, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Advanced SIP_MONKEYPATCH_COMPAT_NAME( FlagAdvanced ) = 1 << 1, //!< Parameter is an advanced parameter which should be hidden from users by default
-        Hidden SIP_MONKEYPATCH_COMPAT_NAME( FlagHidden ) = 1 << 2, //!< Parameter is hidden and should not be shown to users
-        Optional SIP_MONKEYPATCH_COMPAT_NAME( FlagOptional ) = 1 << 3, //!< Parameter is optional
-        IsModelOutput SIP_MONKEYPATCH_COMPAT_NAME( FlagIsModelOutput ) = 1 << 4, //!< Destination parameter is final output. The parameter name will be used.
+      Advanced SIP_MONKEYPATCH_COMPAT_NAME( FlagAdvanced ) = 1 << 1, //!< Parameter is an advanced parameter which should be hidden from users by default
+      Hidden SIP_MONKEYPATCH_COMPAT_NAME( FlagHidden ) = 1 << 2, //!< Parameter is hidden and should not be shown to users
+      Optional SIP_MONKEYPATCH_COMPAT_NAME( FlagOptional ) = 1 << 3, //!< Parameter is optional
+      IsModelOutput SIP_MONKEYPATCH_COMPAT_NAME( FlagIsModelOutput ) = 1 << 4, //!< Destination parameter is final output. The parameter name will be used.
     };
     Q_ENUM( ProcessingParameterFlag )
 
@@ -3867,9 +3866,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingFileParameterBehavior SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterFile, Behavior ) : int
-    {
-        File = 0, //!< Parameter is a single file
-        Folder, //!< Parameter is a folder
+      {
+      File = 0, //!< Parameter is a single file
+      Folder, //!< Parameter is a folder
     };
     Q_ENUM( ProcessingFileParameterBehavior )
 
@@ -3881,9 +3880,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingNumberParameterType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterNumber, Type ) : int
-    {
-        Integer, //!< Integer values
-        Double, //!< Double/float values
+      {
+      Integer, //!< Integer values
+      Double, //!< Double/float values
     };
     Q_ENUM( ProcessingNumberParameterType )
 
@@ -3895,13 +3894,13 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingFieldParameterDataType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterField, DataType ) : int
-    {
-        Any = -1, //!< Accepts any field
-        Numeric = 0, //!< Accepts numeric fields
-        String = 1, //!< Accepts string fields
-        DateTime = 2, //!< Accepts datetime fields
-        Binary = 3, //!< Accepts binary fields, since QGIS 3.34
-        Boolean = 4, //!< Accepts boolean fields, since QGIS 3.34
+      {
+      Any = -1, //!< Accepts any field
+      Numeric = 0, //!< Accepts numeric fields
+      String = 1, //!< Accepts string fields
+      DateTime = 2, //!< Accepts datetime fields
+      Binary = 3, //!< Accepts binary fields, since QGIS 3.34
+      Boolean = 4, //!< Accepts boolean fields, since QGIS 3.34
     };
     Q_ENUM( ProcessingFieldParameterDataType )
 
@@ -3913,10 +3912,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingDateTimeParameterDataType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterDateTime, Type ) : int
-    {
-        DateTime, //!< Datetime values
-        Date, //!< Date values
-        Time, //!< Time values
+      {
+      DateTime, //!< Datetime values
+      Date, //!< Date values
+      Time, //!< Time values
     };
     Q_ENUM( ProcessingDateTimeParameterDataType )
 
@@ -3957,10 +3956,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingTinInputLayerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterTinInputLayers, Type ) : int
-    {
-        Vertices, //!< Input that adds only vertices
-        StructureLines, //!< Input that adds add structure lines
-        BreakLines //!< Input that adds vertices and break lines
+      {
+      Vertices, //!< Input that adds only vertices
+      StructureLines, //!< Input that adds add structure lines
+      BreakLines //!< Input that adds vertices and break lines
     };
     Q_ENUM( ProcessingTinInputLayerType )
 
@@ -3970,9 +3969,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class CrsDefinitionFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCoordinateReferenceSystem, Format ) : int
-    {
-        Wkt SIP_MONKEYPATCH_COMPAT_NAME( FormatWkt ), //!< WKT format (always recommended over proj string format)
-            Proj SIP_MONKEYPATCH_COMPAT_NAME( FormatProj ), //!< Proj string format
+      {
+      Wkt SIP_MONKEYPATCH_COMPAT_NAME( FormatWkt ), //!< WKT format (always recommended over proj string format)
+      Proj SIP_MONKEYPATCH_COMPAT_NAME( FormatProj ), //!< Proj string format
     };
     Q_ENUM( CrsDefinitionFormat )
 
@@ -4183,10 +4182,10 @@ class CORE_EXPORT Qgis
      */
     enum class ProjectFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        EvaluateDefaultValuesOnProviderSide = 1 << 0, //!< If set, default values for fields will be evaluated on the provider side when features from the project are created instead of when they are committed.
-        TrustStoredLayerStatistics = 1 << 1, //!< If set, then layer statistics (such as the layer extent) will be read from values stored in the project instead of requesting updated values from the data provider. Additionally, when this flag is set, primary key unicity is not checked for views and materialized views with Postgres provider.
-        RememberLayerEditStatusBetweenSessions = 1 << 2, //!< If set, then any layers set to be editable will be stored in the project and immediately made editable whenever that project is restored
-        RememberAttributeTableWindowsBetweenSessions = 1 << 3, //!< If set, then any open attribute tables will be stored in the project and immediately reopened when the project is restored
+      EvaluateDefaultValuesOnProviderSide = 1 << 0, //!< If set, default values for fields will be evaluated on the provider side when features from the project are created instead of when they are committed.
+      TrustStoredLayerStatistics = 1 << 1, //!< If set, then layer statistics (such as the layer extent) will be read from values stored in the project instead of requesting updated values from the data provider. Additionally, when this flag is set, primary key unicity is not checked for views and materialized views with Postgres provider.
+      RememberLayerEditStatusBetweenSessions = 1 << 2, //!< If set, then any layers set to be editable will be stored in the project and immediately made editable whenever that project is restored
+      RememberAttributeTableWindowsBetweenSessions = 1 << 3, //!< If set, then any open attribute tables will be stored in the project and immediately reopened when the project is restored
     };
     Q_ENUM( ProjectFlag )
     Q_DECLARE_FLAGS( ProjectFlags, ProjectFlag )
@@ -4199,7 +4198,7 @@ class CORE_EXPORT Qgis
      */
     enum class PlotToolFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ShowContextMenu = 1 << 0, //!< Show a context menu when right-clicking with the tool.
+      ShowContextMenu = 1 << 0, //!< Show a context menu when right-clicking with the tool.
     };
     Q_ENUM( PlotToolFlag )
     Q_DECLARE_FLAGS( PlotToolFlags, PlotToolFlag )
@@ -4321,9 +4320,9 @@ class CORE_EXPORT Qgis
      */
     enum class ProfileGeneratorFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        RespectsMaximumErrorMapUnit = 1 << 0, //!< Generated profile respects the QgsProfileGenerationContext::maximumErrorMapUnits() property.
-                                    RespectsDistanceRange = 1 << 1, //!< Generated profile respects the QgsProfileGenerationContext::distanceRange() property.
-                                    RespectsElevationRange = 1 << 2, //!< Generated profile respects the QgsProfileGenerationContext::elevationRange() property.
+      RespectsMaximumErrorMapUnit = 1 << 0, //!< Generated profile respects the QgsProfileGenerationContext::maximumErrorMapUnits() property.
+      RespectsDistanceRange = 1 << 1, //!< Generated profile respects the QgsProfileGenerationContext::distanceRange() property.
+      RespectsElevationRange = 1 << 2, //!< Generated profile respects the QgsProfileGenerationContext::elevationRange() property.
     };
     Q_ENUM( ProfileGeneratorFlag )
     Q_DECLARE_FLAGS( ProfileGeneratorFlags, ProfileGeneratorFlag )
@@ -4348,9 +4347,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class PointCloudSymbol SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPointCloudRenderer, PointSymbol ) : int
-    {
-        Square, //!< Renders points as squares
-        Circle, //!< Renders points as circles
+      {
+      Square, //!< Renders points as squares
+      Circle, //!< Renders points as circles
     };
     Q_ENUM( PointCloudSymbol )
 
@@ -4360,10 +4359,10 @@ class CORE_EXPORT Qgis
      * /since QGIS 3.26
      */
     enum class PointCloudDrawOrder SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPointCloudRenderer, DrawOrder ) : int
-    {
-        Default, //!< Draw points in the order they are stored
-        BottomToTop, //!< Draw points with larger Z values last
-        TopToBottom, //!< Draw points with larger Z values first
+      {
+      Default, //!< Draw points in the order they are stored
+      BottomToTop, //!< Draw points with larger Z values last
+      TopToBottom, //!< Draw points with larger Z values first
     };
     Q_ENUM( PointCloudDrawOrder )
 
@@ -4375,10 +4374,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class AvoidIntersectionsMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProject, AvoidIntersectionsMode ) : int
-    {
-        AllowIntersections, //!< Overlap with any feature allowed when digitizing new features
-        AvoidIntersectionsCurrentLayer, //!< Overlap with features from the active layer when digitizing new features not allowed
-        AvoidIntersectionsLayers, //!< Overlap with features from a specified list of layers when digitizing new features not allowed
+      {
+      AllowIntersections, //!< Overlap with any feature allowed when digitizing new features
+      AvoidIntersectionsCurrentLayer, //!< Overlap with features from the active layer when digitizing new features not allowed
+      AvoidIntersectionsLayers, //!< Overlap with features from a specified list of layers when digitizing new features not allowed
     };
     Q_ENUM( AvoidIntersectionsMode )
 
@@ -4390,9 +4389,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class ProjectFileFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProject, FileFormat ) : int
-    {
-        Qgz, //!< Archive file format, supports auxiliary data
-        Qgs, //!< Project saved in a clear text, does not support auxiliary data
+      {
+      Qgz, //!< Archive file format, supports auxiliary data
+      Qgs, //!< Project saved in a clear text, does not support auxiliary data
     };
     Q_ENUM( ProjectFileFormat )
 
@@ -4405,14 +4404,14 @@ class CORE_EXPORT Qgis
      */
     enum class ProjectReadFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProject, ReadFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        DontResolveLayers SIP_MONKEYPATCH_COMPAT_NAME( FlagDontResolveLayers ) = 1 << 0, //!< Don't resolve layer paths (i.e. don't load any layer content). Dramatically improves project read time if the actual data from the layers is not required.
-        DontLoadLayouts SIP_MONKEYPATCH_COMPAT_NAME( FlagDontLoadLayouts ) = 1 << 1, //!< Don't load print layouts. Improves project read time if layouts are not required, and allows projects to be safely read in background threads (since print layouts are not thread safe).
-        TrustLayerMetadata SIP_MONKEYPATCH_COMPAT_NAME( FlagTrustLayerMetadata ) = 1 << 2, //!< Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server.
-        DontStoreOriginalStyles SIP_MONKEYPATCH_COMPAT_NAME( FlagDontStoreOriginalStyles ) = 1 << 3, //!< Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts.
-        DontLoad3DViews SIP_MONKEYPATCH_COMPAT_NAME( FlagDontLoad3DViews ) = 1 << 4, //!< Skip loading 3D views \since QGIS 3.26
-        DontLoadProjectStyles = 1 << 5, //!< Skip loading project style databases (deprecated -- use ProjectCapability::ProjectStyles flag instead)
-        ForceReadOnlyLayers = 1 << 6, //!< Open layers in a read-only mode. \since QGIS 3.28
-        DontUpgradeAnnotations = 1 << 7, //!< Don't upgrade old annotation items to QgsAnnotationItem \since QGIS 3.40
+      DontResolveLayers SIP_MONKEYPATCH_COMPAT_NAME( FlagDontResolveLayers ) = 1 << 0, //!< Don't resolve layer paths (i.e. don't load any layer content). Dramatically improves project read time if the actual data from the layers is not required.
+      DontLoadLayouts SIP_MONKEYPATCH_COMPAT_NAME( FlagDontLoadLayouts ) = 1 << 1, //!< Don't load print layouts. Improves project read time if layouts are not required, and allows projects to be safely read in background threads (since print layouts are not thread safe).
+      TrustLayerMetadata SIP_MONKEYPATCH_COMPAT_NAME( FlagTrustLayerMetadata ) = 1 << 2, //!< Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server.
+      DontStoreOriginalStyles SIP_MONKEYPATCH_COMPAT_NAME( FlagDontStoreOriginalStyles ) = 1 << 3, //!< Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts.
+      DontLoad3DViews SIP_MONKEYPATCH_COMPAT_NAME( FlagDontLoad3DViews ) = 1 << 4, //!< Skip loading 3D views \since QGIS 3.26
+      DontLoadProjectStyles = 1 << 5, //!< Skip loading project style databases (deprecated -- use ProjectCapability::ProjectStyles flag instead)
+      ForceReadOnlyLayers = 1 << 6, //!< Open layers in a read-only mode. \since QGIS 3.28
+      DontUpgradeAnnotations = 1 << 7, //!< Don't upgrade old annotation items to QgsAnnotationItem \since QGIS 3.40
     };
     Q_ENUM( ProjectReadFlag )
 
@@ -4436,7 +4435,7 @@ class CORE_EXPORT Qgis
      */
     enum class ProjectCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ProjectStyles = 1 << 0, //!< Enable the project embedded style library. Enabling this flag can increase the time required to clear and load projects.
+      ProjectStyles = 1 << 0, //!< Enable the project embedded style library. Enabling this flag can increase the time required to clear and load projects.
     };
     Q_ENUM( ProjectCapability )
 
@@ -4473,15 +4472,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class ArcGisRestServiceType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsArcGisPortalUtils, ItemType ) : int
-    {
-        FeatureServer SIP_MONKEYPATCH_COMPAT_NAME( FeatureService ), //!< FeatureServer
-                      MapServer SIP_MONKEYPATCH_COMPAT_NAME( MapService ), //!< MapServer
-                      ImageServer SIP_MONKEYPATCH_COMPAT_NAME( ImageService ), //!< ImageServer
-                      GlobeServer, //!< GlobeServer
-                      GPServer, //!< GPServer
-                      GeocodeServer, //!< GeocodeServer
-                      Unknown, //!< Other unknown/unsupported type
-                      SceneServer, //!< SceneServer
+      {
+      FeatureServer SIP_MONKEYPATCH_COMPAT_NAME( FeatureService ), //!< FeatureServer
+      MapServer SIP_MONKEYPATCH_COMPAT_NAME( MapService ), //!< MapServer
+      ImageServer SIP_MONKEYPATCH_COMPAT_NAME( ImageService ), //!< ImageServer
+      GlobeServer, //!< GlobeServer
+      GPServer, //!< GPServer
+      GeocodeServer, //!< GeocodeServer
+      Unknown, //!< Other unknown/unsupported type
+      SceneServer, //!< SceneServer
     };
     Q_ENUM( ArcGisRestServiceType )
 
@@ -4493,9 +4492,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class RelationshipType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRelation, RelationType ) : int
-    {
-        Normal, //!< A normal relation
-        Generated, //!< A generated relation is a child of a polymorphic relation
+      {
+      Normal, //!< A normal relation
+      Generated, //!< A generated relation is a child of a polymorphic relation
     };
     Q_ENUM( RelationshipType )
 
@@ -4507,9 +4506,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class RelationshipStrength SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRelation, RelationStrength ) : int
-    {
-        Association, //!< Loose relation, related elements are not part of the parent and a parent copy will not copy any children.
-        Composition, //!< Fix relation, related elements are part of the parent and a parent copy will copy any children or delete of parent will delete children
+      {
+      Association, //!< Loose relation, related elements are not part of the parent and a parent copy will not copy any children.
+      Composition, //!< Fix relation, related elements are part of the parent and a parent copy will copy any children or delete of parent will delete children
     };
     Q_ENUM( RelationshipStrength )
 
@@ -4534,9 +4533,9 @@ class CORE_EXPORT Qgis
      */
     enum class RelationshipCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        MultipleFieldKeys = 1 << 0, //!< Supports multiple field keys (as opposed to a singular field)
-        ForwardPathLabel = 1 << 1, //!< Supports forward path labels
-        BackwardPathLabel = 1 << 2, //!< Supports backward path labels
+      MultipleFieldKeys = 1 << 0, //!< Supports multiple field keys (as opposed to a singular field)
+      ForwardPathLabel = 1 << 1, //!< Supports forward path labels
+      BackwardPathLabel = 1 << 2, //!< Supports backward path labels
     };
     Q_ENUM( RelationshipCapability )
 
@@ -4604,9 +4603,9 @@ class CORE_EXPORT Qgis
      */
     enum class ScriptLanguageCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Reformat = 1 << 0, //!< Language supports automatic code reformatting
-        CheckSyntax = 1 << 1, //!< Language supports syntax checking
-        ToggleComment = 1 << 2, //!< Language supports comment toggling
+      Reformat = 1 << 0, //!< Language supports automatic code reformatting
+      CheckSyntax = 1 << 1, //!< Language supports syntax checking
+      ToggleComment = 1 << 2, //!< Language supports comment toggling
     };
     Q_ENUM( ScriptLanguageCapability )
 
@@ -4638,7 +4637,7 @@ class CORE_EXPORT Qgis
      */
     enum class LayerTreeFilterFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        SkipVisibilityCheck = 1 << 0, //!< If set, the standard visibility check should be skipped
+      SkipVisibilityCheck = 1 << 0, //!< If set, the standard visibility check should be skipped
     };
     Q_ENUM( LayerTreeFilterFlag )
 
@@ -4657,7 +4656,7 @@ class CORE_EXPORT Qgis
      */
     enum class MapLayerLegendFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ExcludeByDefault = 1 << 0, //!< If set, the layer should not be included in legends by default, and must be manually added by a user
+      ExcludeByDefault = 1 << 0, //!< If set, the layer should not be included in legends by default, and must be manually added by a user
     };
     Q_ENUM( MapLayerLegendFlag )
 
@@ -4677,14 +4676,14 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.42
      */
     enum class LegendComponent SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLegendStyle, Style ) : int
-    {
-        Undefined, //!< Should not happen, only if corrupted project file
-        Hidden, //!< Special style, item is hidden including margins around
-        Title, //!< Legend title
-        Group, //!< Legend group title
-        Subgroup, //!< Legend subgroup title
-        Symbol, //!< Symbol icon (excluding label)
-        SymbolLabel, //!< Symbol label (excluding icon)
+      {
+      Undefined, //!< Should not happen, only if corrupted project file
+      Hidden, //!< Special style, item is hidden including margins around
+      Title, //!< Legend title
+      Group, //!< Legend group title
+      Subgroup, //!< Legend subgroup title
+      Symbol, //!< Symbol icon (excluding label)
+      SymbolLabel, //!< Symbol label (excluding icon)
     };
     // !!! WARNING: If adding new values to this enum, make sure you update QgsLegendSettings constructor accordingly!!
     Q_ENUM( LegendComponent )
@@ -4711,7 +4710,7 @@ class CORE_EXPORT Qgis
      */
     enum class LegendJsonRenderFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ShowRuleDetails = 1 << 0, //!< If set, the rule expression of a rule based renderer legend item will be added to the JSON
+      ShowRuleDetails = 1 << 0, //!< If set, the rule expression of a rule based renderer legend item will be added to the JSON
     };
     Q_ENUM( LegendJsonRenderFlag )
     Q_DECLARE_FLAGS( LegendJsonRenderFlags, LegendJsonRenderFlag )
@@ -4741,10 +4740,10 @@ class CORE_EXPORT Qgis
      */
     enum class MapLayerActionTarget : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Layer = 1 << 0, //!< Action targets a complete layer
-        SingleFeature = 1 << 1, //!< Action targets a single feature from a layer
-        MultipleFeatures = 1 << 2, //!< Action targets multiple features from a layer
-        AllActions = Layer | SingleFeature | MultipleFeatures
+      Layer = 1 << 0, //!< Action targets a complete layer
+      SingleFeature = 1 << 1, //!< Action targets a single feature from a layer
+      MultipleFeatures = 1 << 2, //!< Action targets multiple features from a layer
+      AllActions = Layer | SingleFeature | MultipleFeatures
     };
     Q_ENUM( MapLayerActionTarget )
 
@@ -4767,8 +4766,8 @@ class CORE_EXPORT Qgis
      */
     enum class MapLayerActionFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        EnabledOnlyWhenEditable = 1 << 1, //!< Action should be shown only for editable layers
-        EnableOnlyWhenHasGeometry = 1 << 2, //!< Action should be shown only for layers with geometry, \since QGIS 3.42
+      EnabledOnlyWhenEditable = 1 << 1, //!< Action should be shown only for editable layers
+      EnableOnlyWhenHasGeometry = 1 << 2, //!< Action should be shown only for layers with geometry, \since QGIS 3.42
     };
     Q_ENUM( MapLayerActionFlag )
 
@@ -4790,15 +4789,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class AttributeActionType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsAction, ActionType ) : int
-    {
-        Generic, //!< Generic
-        GenericPython, //!< Python
-        Mac, //!< MacOS specific
-        Windows, //!< Windows specific
-        Unix, //!< Unix specific
-        OpenUrl, //!< Open URL action
-        SubmitUrlEncoded, //!< POST data to an URL, using "application/x-www-form-urlencoded" or "application/json" if the body is valid JSON \since QGIS 3.24
-        SubmitUrlMultipart, //!< POST data to an URL using "multipart/form-data"  \since QGIS 3.24
+      {
+      Generic, //!< Generic
+      GenericPython, //!< Python
+      Mac, //!< MacOS specific
+      Windows, //!< Windows specific
+      Unix, //!< Unix specific
+      OpenUrl, //!< Open URL action
+      SubmitUrlEncoded, //!< POST data to an URL, using "application/x-www-form-urlencoded" or "application/json" if the body is valid JSON \since QGIS 3.24
+      SubmitUrlMultipart, //!< POST data to an URL using "multipart/form-data"  \since QGIS 3.24
     };
     Q_ENUM( AttributeActionType )
 
@@ -4827,46 +4826,46 @@ class CORE_EXPORT Qgis
      */
 
     enum class RasterColorInterpretation SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRaster, ColorInterpretation ) : int
-    {
-        Undefined SIP_MONKEYPATCH_COMPAT_NAME( UndefinedColorInterpretation ) = 0, //!< Undefined
-        GrayIndex = 1,          //!< Grayscale
-        PaletteIndex = 2,       //!< Paletted (see associated color table)
-        RedBand = 3,            //!< Red band of RGBA image, or red spectral band [0.62 - 0.69 um]
-        GreenBand = 4,          //!< Green band of RGBA image, or green spectral band [0.51 - 0.60 um]
-        BlueBand = 5,           //!< Blue band of RGBA image, or blue spectral band [0.45 - 0.53 um]
-        AlphaBand = 6,          //!< Alpha (0=transparent, 255=opaque)
-        HueBand = 7,            //!< Hue band of HLS image
-        SaturationBand = 8,     //!< Saturation band of HLS image
-        LightnessBand = 9,      //!< Lightness band of HLS image
-        CyanBand = 10,          //!< Cyan band of CMYK image
-        MagentaBand = 11,       //!< Magenta band of CMYK image
-        YellowBand = 12,        //!< Yellow band of CMYK image, or yellow spectral band [0.58 - 0.62 um]
-        BlackBand = 13,         //!< Black band of CMLY image
-        YCbCr_YBand = 14,       //!< Y Luminance
-        YCbCr_CbBand = 15,      //!< Cb Chroma
-        YCbCr_CrBand = 16,      //!< Cr Chroma
-        ContinuousPalette = 17, //!< Continuous palette, QGIS addition, GRASS
+      {
+      Undefined SIP_MONKEYPATCH_COMPAT_NAME( UndefinedColorInterpretation ) = 0, //!< Undefined
+      GrayIndex = 1,          //!< Grayscale
+      PaletteIndex = 2,       //!< Paletted (see associated color table)
+      RedBand = 3,            //!< Red band of RGBA image, or red spectral band [0.62 - 0.69 um]
+      GreenBand = 4,          //!< Green band of RGBA image, or green spectral band [0.51 - 0.60 um]
+      BlueBand = 5,           //!< Blue band of RGBA image, or blue spectral band [0.45 - 0.53 um]
+      AlphaBand = 6,          //!< Alpha (0=transparent, 255=opaque)
+      HueBand = 7,            //!< Hue band of HLS image
+      SaturationBand = 8,     //!< Saturation band of HLS image
+      LightnessBand = 9,      //!< Lightness band of HLS image
+      CyanBand = 10,          //!< Cyan band of CMYK image
+      MagentaBand = 11,       //!< Magenta band of CMYK image
+      YellowBand = 12,        //!< Yellow band of CMYK image, or yellow spectral band [0.58 - 0.62 um]
+      BlackBand = 13,         //!< Black band of CMLY image
+      YCbCr_YBand = 14,       //!< Y Luminance
+      YCbCr_CbBand = 15,      //!< Cb Chroma
+      YCbCr_CrBand = 16,      //!< Cr Chroma
+      ContinuousPalette = 17, //!< Continuous palette, QGIS addition, GRASS
 
-        // Note: values between PanBand and SAR_P_Band match additions done in
-        // GDAL 3.10, except that the numeric values of the constant don't match GDAL ones
+      // Note: values between PanBand and SAR_P_Band match additions done in
+      // GDAL 3.10, except that the numeric values of the constant don't match GDAL ones
 
-        PanBand = 18,           //!< Panchromatic band [0.40 - 1.00 um] \since QGIS 3.40
-        CoastalBand = 19,       //!< Coastal band [0.40 - 0.45 um] \since QGIS 3.40
-        RedEdgeBand = 20,       //!< Red-edge band [0.69 - 0.79 um] \since QGIS 3.40
-        NIRBand = 21,           //!< Near-InfraRed (NIR) band [0.75 - 1.40 um] \since QGIS 3.40
-        SWIRBand = 22,          //!< Short-Wavelength InfraRed (SWIR) band [1.40 - 3.00 um] \since QGIS 3.40
-        MWIRBand = 23,          //!< Mid-Wavelength InfraRed (MWIR) band [3.00 - 8.00 um] \since QGIS 3.40
-        LWIRBand = 24,          //!< Long-Wavelength InfraRed (LWIR) band [8.00 - 15 um] \since QGIS 3.40
-        TIRBand = 25,           //!< Thermal InfraRed (TIR) band (MWIR or LWIR) [3 - 15 um] \since QGIS 3.40
-        OtherIRBand = 26,       //!< Other infrared band [0.75 - 1000 um] \since QGIS 3.40
-        SAR_Ka_Band = 27,       //!< Synthetic Aperture Radar (SAR) Ka band [0.8 - 1.1 cm / 27 - 40 GHz] \since QGIS 3.40
-        SAR_K_Band = 28,        //!< Synthetic Aperture Radar (SAR) K band [1.1 - 1.7 cm / 18 - 27 GHz] \since QGIS 3.40
-        SAR_Ku_Band = 30,       //!< Synthetic Aperture Radar (SAR) Ku band [1.7 - 2.4 cm / 12 - 18 GHz] \since QGIS 3.40
-        SAR_X_Band = 31,        //!< Synthetic Aperture Radar (SAR) X band [2.4 - 3.8 cm / 8 - 12 GHz] \since QGIS 3.40
-        SAR_C_Band = 32,        //!< Synthetic Aperture Radar (SAR) C band [3.8 - 7.5 cm / 4 - 8 GHz] \since QGIS 3.40
-        SAR_S_Band = 33,        //!< Synthetic Aperture Radar (SAR) S band [7.5 - 15 cm / 2 - 4 GHz] \since QGIS 3.40
-        SAR_L_Band = 34,        //!< Synthetic Aperture Radar (SAR) L band [15 - 30 cm / 1 - 2 GHz] \since QGIS 3.40
-        SAR_P_Band = 35,        //!< Synthetic Aperture Radar (SAR) P band [30 - 100 cm / 0.3 - 1 GHz] \since QGIS 3.40
+      PanBand = 18,           //!< Panchromatic band [0.40 - 1.00 um] \since QGIS 3.40
+      CoastalBand = 19,       //!< Coastal band [0.40 - 0.45 um] \since QGIS 3.40
+      RedEdgeBand = 20,       //!< Red-edge band [0.69 - 0.79 um] \since QGIS 3.40
+      NIRBand = 21,           //!< Near-InfraRed (NIR) band [0.75 - 1.40 um] \since QGIS 3.40
+      SWIRBand = 22,          //!< Short-Wavelength InfraRed (SWIR) band [1.40 - 3.00 um] \since QGIS 3.40
+      MWIRBand = 23,          //!< Mid-Wavelength InfraRed (MWIR) band [3.00 - 8.00 um] \since QGIS 3.40
+      LWIRBand = 24,          //!< Long-Wavelength InfraRed (LWIR) band [8.00 - 15 um] \since QGIS 3.40
+      TIRBand = 25,           //!< Thermal InfraRed (TIR) band (MWIR or LWIR) [3 - 15 um] \since QGIS 3.40
+      OtherIRBand = 26,       //!< Other infrared band [0.75 - 1000 um] \since QGIS 3.40
+      SAR_Ka_Band = 27,       //!< Synthetic Aperture Radar (SAR) Ka band [0.8 - 1.1 cm / 27 - 40 GHz] \since QGIS 3.40
+      SAR_K_Band = 28,        //!< Synthetic Aperture Radar (SAR) K band [1.1 - 1.7 cm / 18 - 27 GHz] \since QGIS 3.40
+      SAR_Ku_Band = 30,       //!< Synthetic Aperture Radar (SAR) Ku band [1.7 - 2.4 cm / 12 - 18 GHz] \since QGIS 3.40
+      SAR_X_Band = 31,        //!< Synthetic Aperture Radar (SAR) X band [2.4 - 3.8 cm / 8 - 12 GHz] \since QGIS 3.40
+      SAR_C_Band = 32,        //!< Synthetic Aperture Radar (SAR) C band [3.8 - 7.5 cm / 4 - 8 GHz] \since QGIS 3.40
+      SAR_S_Band = 33,        //!< Synthetic Aperture Radar (SAR) S band [7.5 - 15 cm / 2 - 4 GHz] \since QGIS 3.40
+      SAR_L_Band = 34,        //!< Synthetic Aperture Radar (SAR) L band [15 - 30 cm / 1 - 2 GHz] \since QGIS 3.40
+      SAR_P_Band = 35,        //!< Synthetic Aperture Radar (SAR) P band [30 - 100 cm / 0.3 - 1 GHz] \since QGIS 3.40
     };
     Q_ENUM( RasterColorInterpretation )
 
@@ -4878,11 +4877,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
     */
     enum class RasterLayerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterLayer, LayerType ) : int
-    {
-        GrayOrUndefined, //!< Gray or undefined
-        Palette, //!< Palette
-        MultiBand SIP_MONKEYPATCH_COMPAT_NAME( Multiband ), //!< Multi band
-        SingleBandColorData SIP_MONKEYPATCH_COMPAT_NAME( ColorLayer ), //!< Single band containing color data
+      {
+      GrayOrUndefined, //!< Gray or undefined
+      Palette, //!< Palette
+      MultiBand SIP_MONKEYPATCH_COMPAT_NAME( Multiband ), //!< Multi band
+      SingleBandColorData SIP_MONKEYPATCH_COMPAT_NAME( ColorLayer ), //!< Single band containing color data
     };
     Q_ENUM( RasterLayerType )
 
@@ -4894,18 +4893,18 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
     */
     enum class RasterDrawingStyle SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRaster, DrawingStyle ) : int
-    {
-        Undefined SIP_MONKEYPATCH_COMPAT_NAME( UndefinedDrawingStyle ),//!< Undefined
-                  SingleBandGray, //!< A single band image drawn as a range of gray colors
-                  SingleBandPseudoColor, //!< A single band image drawn using a pseudocolor algorithm
-                  PalettedColor, //!< A "Palette" image drawn using color table
-                  PalettedSingleBandGray, //!< A "Palette" layer drawn in gray scale
-                  PalettedSingleBandPseudoColor, //!< A "Palette" layerdrawn using a pseudocolor algorithm
-                  PalettedMultiBandColor, //!< Currently not supported
-                  MultiBandSingleBandGray, //!< A layer containing 2 or more bands, but a single band drawn as a range of gray colors
-                  MultiBandSingleBandPseudoColor, //!< A layer containing 2 or more bands, but a single band drawn using a pseudocolor algorithm
-                  MultiBandColor, //!< A layer containing 2 or more bands, mapped to RGB color space. In the case of a multiband with only two bands, one band will be mapped to more than one color.
-                  SingleBandColorData SIP_MONKEYPATCH_COMPAT_NAME( SingleBandColorDataStyle ), //!< ARGB values rendered directly
+      {
+      Undefined SIP_MONKEYPATCH_COMPAT_NAME( UndefinedDrawingStyle ),//!< Undefined
+      SingleBandGray, //!< A single band image drawn as a range of gray colors
+      SingleBandPseudoColor, //!< A single band image drawn using a pseudocolor algorithm
+      PalettedColor, //!< A "Palette" image drawn using color table
+      PalettedSingleBandGray, //!< A "Palette" layer drawn in gray scale
+      PalettedSingleBandPseudoColor, //!< A "Palette" layerdrawn using a pseudocolor algorithm
+      PalettedMultiBandColor, //!< Currently not supported
+      MultiBandSingleBandGray, //!< A layer containing 2 or more bands, but a single band drawn as a range of gray colors
+      MultiBandSingleBandPseudoColor, //!< A layer containing 2 or more bands, but a single band drawn using a pseudocolor algorithm
+      MultiBandColor, //!< A layer containing 2 or more bands, mapped to RGB color space. In the case of a multiband with only two bands, one band will be mapped to more than one color.
+      SingleBandColorData SIP_MONKEYPATCH_COMPAT_NAME( SingleBandColorDataStyle ), //!< ARGB values rendered directly
     };
     Q_ENUM( RasterDrawingStyle )
 
@@ -4917,10 +4916,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class RasterPyramidFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRaster, RasterPyramidsFormat ) : int
-    {
-        GeoTiff SIP_MONKEYPATCH_COMPAT_NAME( PyramidsGTiff ) = 0, //!< Geotiff .ovr (external)
-        Internal SIP_MONKEYPATCH_COMPAT_NAME( PyramidsInternal ) = 1, //!< Internal
-        Erdas SIP_MONKEYPATCH_COMPAT_NAME( PyramidsErdas ) = 2 //!< Erdas Image .aux (external)
+      {
+      GeoTiff SIP_MONKEYPATCH_COMPAT_NAME( PyramidsGTiff ) = 0, //!< Geotiff .ovr (external)
+      Internal SIP_MONKEYPATCH_COMPAT_NAME( PyramidsInternal ) = 1, //!< Internal
+      Erdas SIP_MONKEYPATCH_COMPAT_NAME( PyramidsErdas ) = 2 //!< Erdas Image .aux (external)
     };
     Q_ENUM( RasterPyramidFormat )
 
@@ -4932,10 +4931,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class RasterBuildPyramidOption SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRaster, RasterBuildPyramids ) : int
-    {
-        No SIP_MONKEYPATCH_COMPAT_NAME( PyramidsFlagNo ) = 0, //!< Never
-        Yes SIP_MONKEYPATCH_COMPAT_NAME( PyramidsFlagYes ) = 1, //!< Yes
-        CopyExisting SIP_MONKEYPATCH_COMPAT_NAME( PyramidsCopyExisting ) = 2 //!< Copy existing
+      {
+      No SIP_MONKEYPATCH_COMPAT_NAME( PyramidsFlagNo ) = 0, //!< Never
+      Yes SIP_MONKEYPATCH_COMPAT_NAME( PyramidsFlagYes ) = 1, //!< Yes
+      CopyExisting SIP_MONKEYPATCH_COMPAT_NAME( PyramidsCopyExisting ) = 2 //!< Copy existing
     };
     Q_ENUM( RasterBuildPyramidOption )
 
@@ -4948,11 +4947,11 @@ class CORE_EXPORT Qgis
      */
     enum class RasterIdentifyFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRaster, IdentifyFormat ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Undefined SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatUndefined ) = 0, //!< Undefined
-        Value SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatValue ) = 1, //!< Numerical pixel value
-        Text SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatText ) = 1 << 1, //!< WMS text
-        Html SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatHtml ) = 1 << 2, //!< WMS HTML
-        Feature SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatFeature ) = 1 << 3, //!< WMS GML/JSON -> feature
+      Undefined SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatUndefined ) = 0, //!< Undefined
+      Value SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatValue ) = 1, //!< Numerical pixel value
+      Text SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatText ) = 1 << 1, //!< WMS text
+      Html SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatHtml ) = 1 << 2, //!< WMS HTML
+      Feature SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatFeature ) = 1 << 3, //!< WMS GML/JSON -> feature
     };
     Q_ENUM( RasterIdentifyFormat )
 
@@ -4969,17 +4968,17 @@ class CORE_EXPORT Qgis
      */
     enum class RasterInterfaceCapability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterInterface, Capability ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoCapabilities = 0, //!< No capabilities
-        Size = 1 << 1, //!< Original data source size (and thus resolution) is known, it is not always available, for example for WMS
-        Create = 1 << 2, //!< Create new datasets (Unused and deprecated -- will be removed in QGIS 5)
-        Remove = 1 << 3, //!< Delete datasets (Unused and deprecated -- will be removed in QGIS 5)
-        BuildPyramids = 1 << 4, //!< Supports building of pyramids (overviews) (Deprecated since QGIS 3.38 -- use RasterProviderCapability::BuildPyramids instead)
-        Identify = 1 << 5, //!< At least one identify format supported
-        IdentifyValue = 1 << 6, //!< Numerical values
-        IdentifyText = 1 << 7, //!< WMS text
-        IdentifyHtml = 1 << 8, //!< WMS HTML
-        IdentifyFeature = 1 << 9, //!< WMS GML -> feature
-        Prefetch = 1 << 10, //!< Allow prefetching of out-of-view images
+      NoCapabilities = 0, //!< No capabilities
+      Size = 1 << 1, //!< Original data source size (and thus resolution) is known, it is not always available, for example for WMS
+      Create = 1 << 2, //!< Create new datasets (Unused and deprecated -- will be removed in QGIS 5)
+      Remove = 1 << 3, //!< Delete datasets (Unused and deprecated -- will be removed in QGIS 5)
+      BuildPyramids = 1 << 4, //!< Supports building of pyramids (overviews) (Deprecated since QGIS 3.38 -- use RasterProviderCapability::BuildPyramids instead)
+      Identify = 1 << 5, //!< At least one identify format supported
+      IdentifyValue = 1 << 6, //!< Numerical values
+      IdentifyText = 1 << 7, //!< WMS text
+      IdentifyHtml = 1 << 8, //!< WMS HTML
+      IdentifyFeature = 1 << 9, //!< WMS GML -> feature
+      Prefetch = 1 << 10, //!< Allow prefetching of out-of-view images
     };
     Q_ENUM( RasterInterfaceCapability )
 
@@ -5002,15 +5001,15 @@ class CORE_EXPORT Qgis
      */
     enum class RasterProviderCapability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterDataProvider, ProviderCapability ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoProviderCapabilities = 0, //!< Provider has no capabilities
-        ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
-        WriteLayerMetadata = 1 << 2, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
-        ProviderHintBenefitsFromResampling = 1 << 3, //!< Provider benefits from resampling and should apply user default resampling settings \since QGIS 3.10
-        ProviderHintCanPerformProviderResampling = 1 << 4, //!< Provider can perform resampling (to be opposed to post rendering resampling) \since QGIS 3.16
-        ReloadData = 1 << 5, //!< Is able to force reload data / clear local caches. Since QGIS 3.18, see QgsDataProvider::reloadProviderData()
-        DpiDependentData = 1 << 6, //!< Provider's rendering is dependent on requested pixel size of the viewport \since QGIS 3.20
-        NativeRasterAttributeTable = 1 << 7, //!< Indicates that the provider supports native raster attribute table \since QGIS 3.30
-        BuildPyramids = 1 << 8, //!< Supports building of pyramids (overviews) (since QGIS 3.38 -- this is a replacement for RasterInterfaceCapability::BuildPyramids)
+      NoProviderCapabilities = 0, //!< Provider has no capabilities
+      ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
+      WriteLayerMetadata = 1 << 2, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
+      ProviderHintBenefitsFromResampling = 1 << 3, //!< Provider benefits from resampling and should apply user default resampling settings \since QGIS 3.10
+      ProviderHintCanPerformProviderResampling = 1 << 4, //!< Provider can perform resampling (to be opposed to post rendering resampling) \since QGIS 3.16
+      ReloadData = 1 << 5, //!< Is able to force reload data / clear local caches. Since QGIS 3.18, see QgsDataProvider::reloadProviderData()
+      DpiDependentData = 1 << 6, //!< Provider's rendering is dependent on requested pixel size of the viewport \since QGIS 3.20
+      NativeRasterAttributeTable = 1 << 7, //!< Indicates that the provider supports native raster attribute table \since QGIS 3.30
+      BuildPyramids = 1 << 8, //!< Supports building of pyramids (overviews) (since QGIS 3.38 -- this is a replacement for RasterInterfaceCapability::BuildPyramids)
     };
     Q_ENUM( RasterProviderCapability )
 
@@ -5045,31 +5044,31 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class BlendMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPainting, BlendMode ) : int
-    {
-        Normal SIP_MONKEYPATCH_COMPAT_NAME( BlendNormal ), //!< Normal
-               Lighten SIP_MONKEYPATCH_COMPAT_NAME( BlendLighten ), //!< Lighten
-               Screen SIP_MONKEYPATCH_COMPAT_NAME( BlendScreen ), //!< Screen
-               Dodge SIP_MONKEYPATCH_COMPAT_NAME( BlendDodge ), //!< Dodge
-               Addition SIP_MONKEYPATCH_COMPAT_NAME( BlendAddition ), //!< Addition
-               Darken SIP_MONKEYPATCH_COMPAT_NAME( BlendDarken ), //!< Darken
-               Multiply SIP_MONKEYPATCH_COMPAT_NAME( BlendMultiply ), //!< Multiple
-               Burn SIP_MONKEYPATCH_COMPAT_NAME( BlendBurn ), //!< Burn
-               Overlay SIP_MONKEYPATCH_COMPAT_NAME( BlendOverlay ), //!< Overlay
-               SoftLight SIP_MONKEYPATCH_COMPAT_NAME( BlendSoftLight ), //!< Soft light
-               HardLight SIP_MONKEYPATCH_COMPAT_NAME( BlendHardLight ), //!< Hard light
-               Difference SIP_MONKEYPATCH_COMPAT_NAME( BlendDifference ), //!< Difference
-               Subtract SIP_MONKEYPATCH_COMPAT_NAME( BlendSubtract ), //!< Subtract
-               Source SIP_MONKEYPATCH_COMPAT_NAME( BlendSource ), //!< Source
-               DestinationOver SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationOver ), //!< Destination over
-               Clear SIP_MONKEYPATCH_COMPAT_NAME( BlendClear ), //!< Clear
-               Destination SIP_MONKEYPATCH_COMPAT_NAME( BlendDestination ), //!< Destination
-               SourceIn SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceIn ), //!< Source in
-               DestinationIn SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationIn ), //!< Destination in
-               SourceOut SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceOut ), //!< Source out
-               DestinationOut SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationOut ), //!< Destination out
-               SourceAtop SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceAtop ), //!< Source atop
-               DestinationAtop SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationAtop ), //!< Destination atop
-               Xor SIP_MONKEYPATCH_COMPAT_NAME( BlendXor ), //!< XOR
+      {
+      Normal SIP_MONKEYPATCH_COMPAT_NAME( BlendNormal ), //!< Normal
+      Lighten SIP_MONKEYPATCH_COMPAT_NAME( BlendLighten ), //!< Lighten
+      Screen SIP_MONKEYPATCH_COMPAT_NAME( BlendScreen ), //!< Screen
+      Dodge SIP_MONKEYPATCH_COMPAT_NAME( BlendDodge ), //!< Dodge
+      Addition SIP_MONKEYPATCH_COMPAT_NAME( BlendAddition ), //!< Addition
+      Darken SIP_MONKEYPATCH_COMPAT_NAME( BlendDarken ), //!< Darken
+      Multiply SIP_MONKEYPATCH_COMPAT_NAME( BlendMultiply ), //!< Multiple
+      Burn SIP_MONKEYPATCH_COMPAT_NAME( BlendBurn ), //!< Burn
+      Overlay SIP_MONKEYPATCH_COMPAT_NAME( BlendOverlay ), //!< Overlay
+      SoftLight SIP_MONKEYPATCH_COMPAT_NAME( BlendSoftLight ), //!< Soft light
+      HardLight SIP_MONKEYPATCH_COMPAT_NAME( BlendHardLight ), //!< Hard light
+      Difference SIP_MONKEYPATCH_COMPAT_NAME( BlendDifference ), //!< Difference
+      Subtract SIP_MONKEYPATCH_COMPAT_NAME( BlendSubtract ), //!< Subtract
+      Source SIP_MONKEYPATCH_COMPAT_NAME( BlendSource ), //!< Source
+      DestinationOver SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationOver ), //!< Destination over
+      Clear SIP_MONKEYPATCH_COMPAT_NAME( BlendClear ), //!< Clear
+      Destination SIP_MONKEYPATCH_COMPAT_NAME( BlendDestination ), //!< Destination
+      SourceIn SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceIn ), //!< Source in
+      DestinationIn SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationIn ), //!< Destination in
+      SourceOut SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceOut ), //!< Source out
+      DestinationOut SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationOut ), //!< Destination out
+      SourceAtop SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceAtop ), //!< Source atop
+      DestinationAtop SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationAtop ), //!< Destination atop
+      Xor SIP_MONKEYPATCH_COMPAT_NAME( BlendXor ), //!< XOR
     };
     Q_ENUM( BlendMode )
 
@@ -5081,11 +5080,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class SystemOfMeasurement SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, SystemOfMeasurement ) : int
-    {
-        Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownSystem ) = 0, //!< Unknown system of measurement
-        Metric SIP_MONKEYPATCH_COMPAT_NAME( MetricSystem ), //!< International System of Units (SI)
-        Imperial SIP_MONKEYPATCH_COMPAT_NAME( ImperialSystem ), //!< British Imperial
-        USCS SIP_MONKEYPATCH_COMPAT_NAME( USCSSystem ), //!< United States customary system
+      {
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownSystem ) = 0, //!< Unknown system of measurement
+      Metric SIP_MONKEYPATCH_COMPAT_NAME( MetricSystem ), //!< International System of Units (SI)
+      Imperial SIP_MONKEYPATCH_COMPAT_NAME( ImperialSystem ), //!< British Imperial
+      USCS SIP_MONKEYPATCH_COMPAT_NAME( USCSSystem ), //!< United States customary system
     };
     Q_ENUM( SystemOfMeasurement )
 
@@ -5096,10 +5095,10 @@ class CORE_EXPORT Qgis
     * \since QGIS 3.32
     */
     enum class MapToolUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTolerance, UnitType ) : int
-    {
-        Layer SIP_MONKEYPATCH_COMPAT_NAME( LayerUnits ), //!< Layer unit value
-              Pixels, //!< Pixels unit of tolerance
-              Project  SIP_MONKEYPATCH_COMPAT_NAME( ProjectUnits ) //!< Map (project) units
+      {
+      Layer SIP_MONKEYPATCH_COMPAT_NAME( LayerUnits ), //!< Layer unit value
+      Pixels, //!< Pixels unit of tolerance
+      Project  SIP_MONKEYPATCH_COMPAT_NAME( ProjectUnits ) //!< Map (project) units
     };
     Q_ENUM( MapToolUnit )
 
@@ -5111,12 +5110,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class UnitType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, UnitType ) : int
-    {
-        Distance SIP_MONKEYPATCH_COMPAT_NAME( TypeDistance ) = 0, //!< Distance unit
-        Area SIP_MONKEYPATCH_COMPAT_NAME( TypeArea ), //!< Area unit
-        Volume SIP_MONKEYPATCH_COMPAT_NAME( TypeVolume ), //!< Volume unit
-        Unknown SIP_MONKEYPATCH_COMPAT_NAME( TypeUnknown ), //!< Unknown unit type
-        Temporal SIP_MONKEYPATCH_COMPAT_NAME( TypeTemporal ), //!< Temporal unit
+      {
+      Distance SIP_MONKEYPATCH_COMPAT_NAME( TypeDistance ) = 0, //!< Distance unit
+      Area SIP_MONKEYPATCH_COMPAT_NAME( TypeArea ), //!< Area unit
+      Volume SIP_MONKEYPATCH_COMPAT_NAME( TypeVolume ), //!< Volume unit
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( TypeUnknown ), //!< Unknown unit type
+      Temporal SIP_MONKEYPATCH_COMPAT_NAME( TypeTemporal ), //!< Temporal unit
     };
     Q_ENUM( UnitType )
 
@@ -5128,57 +5127,57 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class DistanceUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, DistanceUnit ) : int
-    {
-        Meters SIP_MONKEYPATCH_COMPAT_NAME( DistanceMeters ), //!< Meters
-               Kilometers SIP_MONKEYPATCH_COMPAT_NAME( DistanceKilometers ), //!< Kilometers
-               Feet SIP_MONKEYPATCH_COMPAT_NAME( DistanceFeet ), //!< Imperial feet
-               NauticalMiles SIP_MONKEYPATCH_COMPAT_NAME( DistanceNauticalMiles ), //!< Nautical miles
-               Yards SIP_MONKEYPATCH_COMPAT_NAME( DistanceYards ), //!< Imperial yards
-               Miles SIP_MONKEYPATCH_COMPAT_NAME( DistanceMiles ), //!< Terrestrial miles
-               Degrees SIP_MONKEYPATCH_COMPAT_NAME( DistanceDegrees ), //!< Degrees, for planar geographic CRS distance measurements
-               Centimeters SIP_MONKEYPATCH_COMPAT_NAME( DistanceCentimeters ), //!< Centimeters
-               Millimeters SIP_MONKEYPATCH_COMPAT_NAME( DistanceMillimeters ), //!< Millimeters
-               Inches, //!< Inches \since QGIS 3.32
-               ChainsInternational, //!< International chains \since QGIS 3.40
-               ChainsBritishBenoit1895A, //!< British chains (Benoit 1895 A) \since QGIS 3.40
-               ChainsBritishBenoit1895B, //!< British chains (Benoit 1895 B) \since QGIS 3.40
-               ChainsBritishSears1922Truncated, //!< British chains (Sears 1922 truncated) \since QGIS 3.40
-               ChainsBritishSears1922, //!< British chains (Sears 1922) \since QGIS 3.40
-               ChainsClarkes, //!< Clarke's chains \since QGIS 3.40
-               ChainsUSSurvey, //!< US Survey chains \since QGIS 3.40
-               FeetBritish1865, //!< British feet (1865) \since QGIS 3.40
-               FeetBritish1936, //!< British feet (1936) \since QGIS 3.40
-               FeetBritishBenoit1895A, //!< British feet (Benoit 1895 A) \since QGIS 3.40
-               FeetBritishBenoit1895B, //!< British feet (Benoit 1895 B) \since QGIS 3.40
-               FeetBritishSears1922Truncated, //!< British feet (Sears 1922 truncated) \since QGIS 3.40
-               FeetBritishSears1922, //!< British feet (Sears 1922) \since QGIS 3.40
-               FeetClarkes, //!< Clarke's feet \since QGIS 3.40
-               FeetGoldCoast, //!< Gold Coast feet \since QGIS 3.40
-               FeetIndian, //!< Indian (geodetic) feet \since QGIS 3.40
-               FeetIndian1937, //!< Indian feet (1937) \since QGIS 3.40
-               FeetIndian1962, //!< Indian feet (1962) \since QGIS 3.40
-               FeetIndian1975, //!< Indian feet (1975) \since QGIS 3.40
-               FeetUSSurvey, //!< US Survey feet \since QGIS 3.40
-               LinksInternational, //!< International links \since QGIS 3.40
-               LinksBritishBenoit1895A, //!< British links (Benoit 1895 A) \since QGIS 3.40
-               LinksBritishBenoit1895B, //!< British links (Benoit 1895 B) \since QGIS 3.40
-               LinksBritishSears1922Truncated, //!< British links (Sears 1922 truncated) \since QGIS 3.40
-               LinksBritishSears1922, //!< British links (Sears 1922) \since QGIS 3.40
-               LinksClarkes, //!< Clarke's links \since QGIS 3.40
-               LinksUSSurvey, //!< US Survey links \since QGIS 3.40
-               YardsBritishBenoit1895A, //!< British yards (Benoit 1895 A) \since QGIS 3.40
-               YardsBritishBenoit1895B, //!< British yards (Benoit 1895 B) \since QGIS 3.40
-               YardsBritishSears1922Truncated, //!< British yards (Sears 1922 truncated) \since QGIS 3.40
-               YardsBritishSears1922, //!< British yards (Sears 1922) \since QGIS 3.40
-               YardsClarkes, //!< Clarke's yards \since QGIS 3.40
-               YardsIndian, //!< Indian yards \since QGIS 3.40
-               YardsIndian1937, //!< Indian yards (1937) \since QGIS 3.40
-               YardsIndian1962, //!< Indian yards (1962) \since QGIS 3.40
-               YardsIndian1975, //!< Indian yards (1975) \since QGIS 3.40
-               MilesUSSurvey, //!< US Survey miles \since QGIS 3.40
-               Fathoms, //!< Fathoms \since QGIS 3.40
-               MetersGermanLegal, //!< German legal meter \since QGIS 3.40
-               Unknown SIP_MONKEYPATCH_COMPAT_NAME( DistanceUnknownUnit ), //!< Unknown distance unit
+      {
+      Meters SIP_MONKEYPATCH_COMPAT_NAME( DistanceMeters ), //!< Meters
+      Kilometers SIP_MONKEYPATCH_COMPAT_NAME( DistanceKilometers ), //!< Kilometers
+      Feet SIP_MONKEYPATCH_COMPAT_NAME( DistanceFeet ), //!< Imperial feet
+      NauticalMiles SIP_MONKEYPATCH_COMPAT_NAME( DistanceNauticalMiles ), //!< Nautical miles
+      Yards SIP_MONKEYPATCH_COMPAT_NAME( DistanceYards ), //!< Imperial yards
+      Miles SIP_MONKEYPATCH_COMPAT_NAME( DistanceMiles ), //!< Terrestrial miles
+      Degrees SIP_MONKEYPATCH_COMPAT_NAME( DistanceDegrees ), //!< Degrees, for planar geographic CRS distance measurements
+      Centimeters SIP_MONKEYPATCH_COMPAT_NAME( DistanceCentimeters ), //!< Centimeters
+      Millimeters SIP_MONKEYPATCH_COMPAT_NAME( DistanceMillimeters ), //!< Millimeters
+      Inches, //!< Inches \since QGIS 3.32
+      ChainsInternational, //!< International chains \since QGIS 3.40
+      ChainsBritishBenoit1895A, //!< British chains (Benoit 1895 A) \since QGIS 3.40
+      ChainsBritishBenoit1895B, //!< British chains (Benoit 1895 B) \since QGIS 3.40
+      ChainsBritishSears1922Truncated, //!< British chains (Sears 1922 truncated) \since QGIS 3.40
+      ChainsBritishSears1922, //!< British chains (Sears 1922) \since QGIS 3.40
+      ChainsClarkes, //!< Clarke's chains \since QGIS 3.40
+      ChainsUSSurvey, //!< US Survey chains \since QGIS 3.40
+      FeetBritish1865, //!< British feet (1865) \since QGIS 3.40
+      FeetBritish1936, //!< British feet (1936) \since QGIS 3.40
+      FeetBritishBenoit1895A, //!< British feet (Benoit 1895 A) \since QGIS 3.40
+      FeetBritishBenoit1895B, //!< British feet (Benoit 1895 B) \since QGIS 3.40
+      FeetBritishSears1922Truncated, //!< British feet (Sears 1922 truncated) \since QGIS 3.40
+      FeetBritishSears1922, //!< British feet (Sears 1922) \since QGIS 3.40
+      FeetClarkes, //!< Clarke's feet \since QGIS 3.40
+      FeetGoldCoast, //!< Gold Coast feet \since QGIS 3.40
+      FeetIndian, //!< Indian (geodetic) feet \since QGIS 3.40
+      FeetIndian1937, //!< Indian feet (1937) \since QGIS 3.40
+      FeetIndian1962, //!< Indian feet (1962) \since QGIS 3.40
+      FeetIndian1975, //!< Indian feet (1975) \since QGIS 3.40
+      FeetUSSurvey, //!< US Survey feet \since QGIS 3.40
+      LinksInternational, //!< International links \since QGIS 3.40
+      LinksBritishBenoit1895A, //!< British links (Benoit 1895 A) \since QGIS 3.40
+      LinksBritishBenoit1895B, //!< British links (Benoit 1895 B) \since QGIS 3.40
+      LinksBritishSears1922Truncated, //!< British links (Sears 1922 truncated) \since QGIS 3.40
+      LinksBritishSears1922, //!< British links (Sears 1922) \since QGIS 3.40
+      LinksClarkes, //!< Clarke's links \since QGIS 3.40
+      LinksUSSurvey, //!< US Survey links \since QGIS 3.40
+      YardsBritishBenoit1895A, //!< British yards (Benoit 1895 A) \since QGIS 3.40
+      YardsBritishBenoit1895B, //!< British yards (Benoit 1895 B) \since QGIS 3.40
+      YardsBritishSears1922Truncated, //!< British yards (Sears 1922 truncated) \since QGIS 3.40
+      YardsBritishSears1922, //!< British yards (Sears 1922) \since QGIS 3.40
+      YardsClarkes, //!< Clarke's yards \since QGIS 3.40
+      YardsIndian, //!< Indian yards \since QGIS 3.40
+      YardsIndian1937, //!< Indian yards (1937) \since QGIS 3.40
+      YardsIndian1962, //!< Indian yards (1962) \since QGIS 3.40
+      YardsIndian1975, //!< Indian yards (1975) \since QGIS 3.40
+      MilesUSSurvey, //!< US Survey miles \since QGIS 3.40
+      Fathoms, //!< Fathoms \since QGIS 3.40
+      MetersGermanLegal, //!< German legal meter \since QGIS 3.40
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( DistanceUnknownUnit ), //!< Unknown distance unit
     };
     Q_ENUM( DistanceUnit )
 
@@ -5190,10 +5189,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class DistanceUnitType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, DistanceUnitType ) : int
-    {
-        Standard, //!< Unit is a standard measurement unit
-        Geographic, //!< Unit is a geographic (e.g., degree based) unit
-        Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownType ),  //!< Unknown unit type
+      {
+      Standard, //!< Unit is a standard measurement unit
+      Geographic, //!< Unit is a geographic (e.g., degree based) unit
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownType ),  //!< Unknown unit type
     };
     Q_ENUM( DistanceUnitType )
 
@@ -5205,20 +5204,20 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class AreaUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, AreaUnit ) : int
-    {
-        SquareMeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMeters ), //!< Square meters
-                     SquareKilometers SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareKilometers ), //!< Square kilometers
-                     SquareFeet SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareFeet ), //!< Square feet
-                     SquareYards SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareYards ), //!< Square yards
-                     SquareMiles SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMiles ), //!< Square miles
-                     Hectares SIP_MONKEYPATCH_COMPAT_NAME( AreaHectares ), //!< Hectares
-                     Acres SIP_MONKEYPATCH_COMPAT_NAME( AreaAcres ), //!< Acres
-                     SquareNauticalMiles SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareNauticalMiles ), //!< Square nautical miles
-                     SquareDegrees SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareDegrees ), //!< Square degrees, for planar geographic CRS area measurements
-                     SquareCentimeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareCentimeters ), //!< Square centimeters
-                     SquareMillimeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMillimeters ), //!< Square millimeters
-                     SquareInches, //!< Square inches \since QGIS 3.32
-                     Unknown SIP_MONKEYPATCH_COMPAT_NAME( AreaUnknownUnit ), //!< Unknown areal unit
+      {
+      SquareMeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMeters ), //!< Square meters
+      SquareKilometers SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareKilometers ), //!< Square kilometers
+      SquareFeet SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareFeet ), //!< Square feet
+      SquareYards SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareYards ), //!< Square yards
+      SquareMiles SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMiles ), //!< Square miles
+      Hectares SIP_MONKEYPATCH_COMPAT_NAME( AreaHectares ), //!< Hectares
+      Acres SIP_MONKEYPATCH_COMPAT_NAME( AreaAcres ), //!< Acres
+      SquareNauticalMiles SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareNauticalMiles ), //!< Square nautical miles
+      SquareDegrees SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareDegrees ), //!< Square degrees, for planar geographic CRS area measurements
+      SquareCentimeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareCentimeters ), //!< Square centimeters
+      SquareMillimeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMillimeters ), //!< Square millimeters
+      SquareInches, //!< Square inches \since QGIS 3.32
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( AreaUnknownUnit ), //!< Unknown areal unit
     };
     Q_ENUM( AreaUnit )
 
@@ -5230,18 +5229,18 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class VolumeUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, VolumeUnit ) : int
-    {
-        CubicMeters SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicMeters ), //!< Cubic meters
-                    CubicFeet SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicFeet ), //!< Cubic feet
-                    CubicYards SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicYards ), //!< Cubic yards
-                    Barrel SIP_MONKEYPATCH_COMPAT_NAME( VolumeBarrel ), //!< Barrels
-                    CubicDecimeter SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicDecimeter ), //!< Cubic decimeters
-                    Liters SIP_MONKEYPATCH_COMPAT_NAME( VolumeLiters ), //!< Litres
-                    GallonUS SIP_MONKEYPATCH_COMPAT_NAME( VolumeGallonUS ), //!< US Gallons
-                    CubicInch SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicInch ), //!< Cubic inches
-                    CubicCentimeter SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicCentimeter ), //!< Cubic Centimeters
-                    CubicDegrees SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicDegrees ), //!< Cubic degrees, for planar geographic CRS volume measurements
-                    Unknown SIP_MONKEYPATCH_COMPAT_NAME( VolumeUnknownUnit ), //!< Unknown volume unit
+      {
+      CubicMeters SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicMeters ), //!< Cubic meters
+      CubicFeet SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicFeet ), //!< Cubic feet
+      CubicYards SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicYards ), //!< Cubic yards
+      Barrel SIP_MONKEYPATCH_COMPAT_NAME( VolumeBarrel ), //!< Barrels
+      CubicDecimeter SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicDecimeter ), //!< Cubic decimeters
+      Liters SIP_MONKEYPATCH_COMPAT_NAME( VolumeLiters ), //!< Litres
+      GallonUS SIP_MONKEYPATCH_COMPAT_NAME( VolumeGallonUS ), //!< US Gallons
+      CubicInch SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicInch ), //!< Cubic inches
+      CubicCentimeter SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicCentimeter ), //!< Cubic Centimeters
+      CubicDegrees SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicDegrees ), //!< Cubic degrees, for planar geographic CRS volume measurements
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( VolumeUnknownUnit ), //!< Unknown volume unit
     };
     Q_ENUM( VolumeUnit )
 
@@ -5253,16 +5252,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class AngleUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, AngleUnit ) : int
-    {
-        Degrees SIP_MONKEYPATCH_COMPAT_NAME( AngleDegrees ), //!< Degrees
-                Radians SIP_MONKEYPATCH_COMPAT_NAME( AngleRadians ), //!< Square kilometers
-                Gon SIP_MONKEYPATCH_COMPAT_NAME( AngleGon ), //!< Gon/gradian
-                MinutesOfArc SIP_MONKEYPATCH_COMPAT_NAME( AngleMinutesOfArc ), //!< Minutes of arc
-                SecondsOfArc SIP_MONKEYPATCH_COMPAT_NAME( AngleSecondsOfArc ), //!< Seconds of arc
-                Turn SIP_MONKEYPATCH_COMPAT_NAME( AngleTurn ), //!< Turn/revolutions
-                MilliradiansSI SIP_MONKEYPATCH_COMPAT_NAME( AngleMilliradiansSI ), //!< Angular milliradians (SI definition, 1/1000 of radian)
-                MilNATO SIP_MONKEYPATCH_COMPAT_NAME( AngleMilNATO ), //!< Angular mil (NATO definition, 6400 mil = 2PI radians)
-                Unknown SIP_MONKEYPATCH_COMPAT_NAME( AngleUnknownUnit ), //!< Unknown angle unit
+      {
+      Degrees SIP_MONKEYPATCH_COMPAT_NAME( AngleDegrees ), //!< Degrees
+      Radians SIP_MONKEYPATCH_COMPAT_NAME( AngleRadians ), //!< Square kilometers
+      Gon SIP_MONKEYPATCH_COMPAT_NAME( AngleGon ), //!< Gon/gradian
+      MinutesOfArc SIP_MONKEYPATCH_COMPAT_NAME( AngleMinutesOfArc ), //!< Minutes of arc
+      SecondsOfArc SIP_MONKEYPATCH_COMPAT_NAME( AngleSecondsOfArc ), //!< Seconds of arc
+      Turn SIP_MONKEYPATCH_COMPAT_NAME( AngleTurn ), //!< Turn/revolutions
+      MilliradiansSI SIP_MONKEYPATCH_COMPAT_NAME( AngleMilliradiansSI ), //!< Angular milliradians (SI definition, 1/1000 of radian)
+      MilNATO SIP_MONKEYPATCH_COMPAT_NAME( AngleMilNATO ), //!< Angular mil (NATO definition, 6400 mil = 2PI radians)
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( AngleUnknownUnit ), //!< Unknown angle unit
     };
     Q_ENUM( AngleUnit )
 
@@ -5274,19 +5273,19 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class TemporalUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, TemporalUnit ) : int
-    {
-        Milliseconds SIP_MONKEYPATCH_COMPAT_NAME( TemporalMilliseconds ), //!< Milliseconds
-                     Seconds SIP_MONKEYPATCH_COMPAT_NAME( TemporalSeconds ), //!< Seconds
-                     Minutes SIP_MONKEYPATCH_COMPAT_NAME( TemporalMinutes ), //!< Minutes
-                     Hours SIP_MONKEYPATCH_COMPAT_NAME( TemporalHours ), //!< Hours
-                     Days SIP_MONKEYPATCH_COMPAT_NAME( TemporalDays ), //!< Days
-                     Weeks SIP_MONKEYPATCH_COMPAT_NAME( TemporalWeeks ), //!< Weeks
-                     Months SIP_MONKEYPATCH_COMPAT_NAME( TemporalMonths ),  //!< Months
-                     Years SIP_MONKEYPATCH_COMPAT_NAME( TemporalYears ), //!< Years
-                     Decades SIP_MONKEYPATCH_COMPAT_NAME( TemporalDecades ), //!< Decades
-                     Centuries SIP_MONKEYPATCH_COMPAT_NAME( TemporalCenturies ), //!< Centuries
-                     IrregularStep SIP_MONKEYPATCH_COMPAT_NAME( TemporalIrregularStep ), //!< Special 'irregular step' time unit, used for temporal data which uses irregular, non-real-world unit steps \since QGIS 3.20
-                     Unknown SIP_MONKEYPATCH_COMPAT_NAME( TemporalUnknownUnit ) //!< Unknown time unit
+      {
+      Milliseconds SIP_MONKEYPATCH_COMPAT_NAME( TemporalMilliseconds ), //!< Milliseconds
+      Seconds SIP_MONKEYPATCH_COMPAT_NAME( TemporalSeconds ), //!< Seconds
+      Minutes SIP_MONKEYPATCH_COMPAT_NAME( TemporalMinutes ), //!< Minutes
+      Hours SIP_MONKEYPATCH_COMPAT_NAME( TemporalHours ), //!< Hours
+      Days SIP_MONKEYPATCH_COMPAT_NAME( TemporalDays ), //!< Days
+      Weeks SIP_MONKEYPATCH_COMPAT_NAME( TemporalWeeks ), //!< Weeks
+      Months SIP_MONKEYPATCH_COMPAT_NAME( TemporalMonths ),  //!< Months
+      Years SIP_MONKEYPATCH_COMPAT_NAME( TemporalYears ), //!< Years
+      Decades SIP_MONKEYPATCH_COMPAT_NAME( TemporalDecades ), //!< Decades
+      Centuries SIP_MONKEYPATCH_COMPAT_NAME( TemporalCenturies ), //!< Centuries
+      IrregularStep SIP_MONKEYPATCH_COMPAT_NAME( TemporalIrregularStep ), //!< Special 'irregular step' time unit, used for temporal data which uses irregular, non-real-world unit steps \since QGIS 3.20
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( TemporalUnknownUnit ) //!< Unknown time unit
     };
     Q_ENUM( TemporalUnit )
 
@@ -5298,15 +5297,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class RenderUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, RenderUnit ) : int
-    {
-        Millimeters SIP_MONKEYPATCH_COMPAT_NAME( RenderMillimeters ), //!< Millimeters
-                    MapUnits SIP_MONKEYPATCH_COMPAT_NAME( RenderMapUnits ), //!< Map units
-                    Pixels SIP_MONKEYPATCH_COMPAT_NAME( RenderPixels ), //!< Pixels
-                    Percentage SIP_MONKEYPATCH_COMPAT_NAME( RenderPercentage ), //!< Percentage of another measurement (e.g., canvas size, feature size)
-                    Points SIP_MONKEYPATCH_COMPAT_NAME( RenderPoints ), //!< Points (e.g., for font sizes)
-                    Inches SIP_MONKEYPATCH_COMPAT_NAME( RenderInches ), //!< Inches
-                    Unknown SIP_MONKEYPATCH_COMPAT_NAME( RenderUnknownUnit ), //!< Mixed or unknown units
-                    MetersInMapUnits SIP_MONKEYPATCH_COMPAT_NAME( RenderMetersInMapUnits ), //!< Meters value as Map units
+      {
+      Millimeters SIP_MONKEYPATCH_COMPAT_NAME( RenderMillimeters ), //!< Millimeters
+      MapUnits SIP_MONKEYPATCH_COMPAT_NAME( RenderMapUnits ), //!< Map units
+      Pixels SIP_MONKEYPATCH_COMPAT_NAME( RenderPixels ), //!< Pixels
+      Percentage SIP_MONKEYPATCH_COMPAT_NAME( RenderPercentage ), //!< Percentage of another measurement (e.g., canvas size, feature size)
+      Points SIP_MONKEYPATCH_COMPAT_NAME( RenderPoints ), //!< Points (e.g., for font sizes)
+      Inches SIP_MONKEYPATCH_COMPAT_NAME( RenderInches ), //!< Inches
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( RenderUnknownUnit ), //!< Mixed or unknown units
+      MetersInMapUnits SIP_MONKEYPATCH_COMPAT_NAME( RenderMetersInMapUnits ), //!< Meters value as Map units
     };
     Q_ENUM( RenderUnit )
 
@@ -5318,15 +5317,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class LayoutUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, LayoutUnit ) : int
-    {
-        Millimeters SIP_MONKEYPATCH_COMPAT_NAME( LayoutMillimeters ), //!< Millimeters
-                    Centimeters SIP_MONKEYPATCH_COMPAT_NAME( LayoutCentimeters ), //!< Centimeters
-                    Meters SIP_MONKEYPATCH_COMPAT_NAME( LayoutMeters ), //!< Meters
-                    Inches SIP_MONKEYPATCH_COMPAT_NAME( LayoutInches ), //!< Inches
-                    Feet SIP_MONKEYPATCH_COMPAT_NAME( LayoutFeet ), //!< Feet
-                    Points SIP_MONKEYPATCH_COMPAT_NAME( LayoutPoints ), //!< Typographic points
-                    Picas SIP_MONKEYPATCH_COMPAT_NAME( LayoutPicas ), //!< Typographic picas
-                    Pixels SIP_MONKEYPATCH_COMPAT_NAME( LayoutPixels ) //!< Pixels
+      {
+      Millimeters SIP_MONKEYPATCH_COMPAT_NAME( LayoutMillimeters ), //!< Millimeters
+      Centimeters SIP_MONKEYPATCH_COMPAT_NAME( LayoutCentimeters ), //!< Centimeters
+      Meters SIP_MONKEYPATCH_COMPAT_NAME( LayoutMeters ), //!< Meters
+      Inches SIP_MONKEYPATCH_COMPAT_NAME( LayoutInches ), //!< Inches
+      Feet SIP_MONKEYPATCH_COMPAT_NAME( LayoutFeet ), //!< Feet
+      Points SIP_MONKEYPATCH_COMPAT_NAME( LayoutPoints ), //!< Typographic points
+      Picas SIP_MONKEYPATCH_COMPAT_NAME( LayoutPicas ), //!< Typographic picas
+      Pixels SIP_MONKEYPATCH_COMPAT_NAME( LayoutPixels ) //!< Pixels
     };
     Q_ENUM( LayoutUnit )
 
@@ -5338,9 +5337,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class LayoutUnitType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, LayoutUnitType ) : int
-    {
-        PaperUnits SIP_MONKEYPATCH_COMPAT_NAME( LayoutPaperUnits ), //!< Unit is a paper based measurement unit
-                   ScreenUnits SIP_MONKEYPATCH_COMPAT_NAME( LayoutScreenUnits ) //!< Unit is a screen based measurement unit
+      {
+      PaperUnits SIP_MONKEYPATCH_COMPAT_NAME( LayoutPaperUnits ), //!< Unit is a paper based measurement unit
+      ScreenUnits SIP_MONKEYPATCH_COMPAT_NAME( LayoutScreenUnits ) //!< Unit is a screen based measurement unit
     };
     Q_ENUM( LayoutUnitType )
 
@@ -5353,19 +5352,19 @@ class CORE_EXPORT Qgis
     */
     enum class LayoutRenderFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutRenderContext, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Debug SIP_MONKEYPATCH_COMPAT_NAME( FlagDebug ) = 1 << 1,  //!< Debug/testing mode, items are drawn as solid rectangles.
-        OutlineOnly SIP_MONKEYPATCH_COMPAT_NAME( FlagOutlineOnly ) = 1 << 2, //!< Render items as outlines only.
-        Antialiasing SIP_MONKEYPATCH_COMPAT_NAME( FlagAntialiasing ) = 1 << 3, //!< Use antialiasing when drawing items.
-        UseAdvancedEffects SIP_MONKEYPATCH_COMPAT_NAME( FlagUseAdvancedEffects ) = 1 << 4, //!< Enable advanced effects such as blend modes. \deprecated QGIS 3.44. Use rasterizedRenderingPolicy() instead.
-        ForceVectorOutput SIP_MONKEYPATCH_COMPAT_NAME( FlagForceVectorOutput ) = 1 << 5, //!< Force output in vector format where possible, even if items require rasterization to keep their correct appearance. \deprecated QGIS 3.44. Use rasterizedRenderingPolicy() instead.
-        HideCoverageLayer SIP_MONKEYPATCH_COMPAT_NAME( FlagHideCoverageLayer ) = 1 << 6, //!< Hide coverage layer in outputs
-        DrawSelection SIP_MONKEYPATCH_COMPAT_NAME( FlagDrawSelection ) = 1 << 7, //!< Draw selection
-        DisableTiledRasterLayerRenders SIP_MONKEYPATCH_COMPAT_NAME( FlagDisableTiledRasterLayerRenders ) = 1 << 8, //!< If set, then raster layers will not be drawn as separate tiles. This may improve the appearance in exported files, at the cost of much higher memory usage during exports.
-        RenderLabelsByMapLayer SIP_MONKEYPATCH_COMPAT_NAME( FlagRenderLabelsByMapLayer ) = 1 << 9, //!< When rendering map items to multi-layered exports, render labels belonging to different layers into separate export layers
-        LosslessImageRendering SIP_MONKEYPATCH_COMPAT_NAME( FlagLosslessImageRendering ) = 1 << 10, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF).
-        SynchronousLegendGraphics SIP_MONKEYPATCH_COMPAT_NAME( FlagSynchronousLegendGraphics ) = 1 << 11, //!< Query legend graphics synchronously.
-        AlwaysUseGlobalMasks SIP_MONKEYPATCH_COMPAT_NAME( FlagAlwaysUseGlobalMasks ) = 1 << 12, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex layout exports in all current Qt versions. This flag only applies to vector layout exports. \since QGIS 3.38
-        LimitCoverageLayerRenderToCurrentFeature = 1 << 13, //!< Limit coverage layer rendering to the current atlas feature. \since QGIS 4.0
+      Debug SIP_MONKEYPATCH_COMPAT_NAME( FlagDebug ) = 1 << 1,  //!< Debug/testing mode, items are drawn as solid rectangles.
+      OutlineOnly SIP_MONKEYPATCH_COMPAT_NAME( FlagOutlineOnly ) = 1 << 2, //!< Render items as outlines only.
+      Antialiasing SIP_MONKEYPATCH_COMPAT_NAME( FlagAntialiasing ) = 1 << 3, //!< Use antialiasing when drawing items.
+      UseAdvancedEffects SIP_MONKEYPATCH_COMPAT_NAME( FlagUseAdvancedEffects ) = 1 << 4, //!< Enable advanced effects such as blend modes. \deprecated QGIS 3.44. Use rasterizedRenderingPolicy() instead.
+      ForceVectorOutput SIP_MONKEYPATCH_COMPAT_NAME( FlagForceVectorOutput ) = 1 << 5, //!< Force output in vector format where possible, even if items require rasterization to keep their correct appearance. \deprecated QGIS 3.44. Use rasterizedRenderingPolicy() instead.
+      HideCoverageLayer SIP_MONKEYPATCH_COMPAT_NAME( FlagHideCoverageLayer ) = 1 << 6, //!< Hide coverage layer in outputs
+      DrawSelection SIP_MONKEYPATCH_COMPAT_NAME( FlagDrawSelection ) = 1 << 7, //!< Draw selection
+      DisableTiledRasterLayerRenders SIP_MONKEYPATCH_COMPAT_NAME( FlagDisableTiledRasterLayerRenders ) = 1 << 8, //!< If set, then raster layers will not be drawn as separate tiles. This may improve the appearance in exported files, at the cost of much higher memory usage during exports.
+      RenderLabelsByMapLayer SIP_MONKEYPATCH_COMPAT_NAME( FlagRenderLabelsByMapLayer ) = 1 << 9, //!< When rendering map items to multi-layered exports, render labels belonging to different layers into separate export layers
+      LosslessImageRendering SIP_MONKEYPATCH_COMPAT_NAME( FlagLosslessImageRendering ) = 1 << 10, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF).
+      SynchronousLegendGraphics SIP_MONKEYPATCH_COMPAT_NAME( FlagSynchronousLegendGraphics ) = 1 << 11, //!< Query legend graphics synchronously.
+      AlwaysUseGlobalMasks SIP_MONKEYPATCH_COMPAT_NAME( FlagAlwaysUseGlobalMasks ) = 1 << 12, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex layout exports in all current Qt versions. This flag only applies to vector layout exports. \since QGIS 3.38
+      LimitCoverageLayerRenderToCurrentFeature = 1 << 13, //!< Limit coverage layer rendering to the current atlas feature. \since QGIS 4.0
     };
     Q_ENUM( LayoutRenderFlag )
 
@@ -5387,10 +5386,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class PictureFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemPicture, Format ) : int
-    {
-        SVG SIP_MONKEYPATCH_COMPAT_NAME( FormatSVG ) = 0, //!< SVG image
-        Raster SIP_MONKEYPATCH_COMPAT_NAME( FormatRaster ), //!< Raster image
-        Unknown SIP_MONKEYPATCH_COMPAT_NAME( FormatUnknown ), //!< Invalid or unknown image type
+      {
+      SVG SIP_MONKEYPATCH_COMPAT_NAME( FormatSVG ) = 0, //!< SVG image
+      Raster SIP_MONKEYPATCH_COMPAT_NAME( FormatRaster ), //!< Raster image
+      Unknown SIP_MONKEYPATCH_COMPAT_NAME( FormatUnknown ), //!< Invalid or unknown image type
     };
     Q_ENUM( PictureFormat )
 
@@ -5417,10 +5416,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class ScaleBarAlignment SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsScaleBarSettings, Alignment ) : int
-    {
-        Left SIP_MONKEYPATCH_COMPAT_NAME( AlignLeft ) = 0, //!< Left aligned
-        Middle SIP_MONKEYPATCH_COMPAT_NAME( AlignMiddle ), //!< Center aligned
-        Right SIP_MONKEYPATCH_COMPAT_NAME( AlignRight ), //!< Right aligned
+      {
+      Left SIP_MONKEYPATCH_COMPAT_NAME( AlignLeft ) = 0, //!< Left aligned
+      Middle SIP_MONKEYPATCH_COMPAT_NAME( AlignMiddle ), //!< Center aligned
+      Right SIP_MONKEYPATCH_COMPAT_NAME( AlignRight ), //!< Right aligned
     };
     Q_ENUM( ScaleBarAlignment )
 
@@ -5432,9 +5431,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class ScaleBarSegmentSizeMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsScaleBarSettings, SegmentSizeMode ) : int
-    {
-        Fixed SIP_MONKEYPATCH_COMPAT_NAME( SegmentSizeFixed ) = 0, //!< Scale bar segment size is fixed to a map unit
-        FitWidth SIP_MONKEYPATCH_COMPAT_NAME( SegmentSizeFitWidth ) = 1 //!< Scale bar segment size is calculated to fit a size range
+      {
+      Fixed SIP_MONKEYPATCH_COMPAT_NAME( SegmentSizeFixed ) = 0, //!< Scale bar segment size is fixed to a map unit
+      FitWidth SIP_MONKEYPATCH_COMPAT_NAME( SegmentSizeFitWidth ) = 1 //!< Scale bar segment size is calculated to fit a size range
     };
     Q_ENUM( ScaleBarSegmentSizeMode )
 
@@ -5446,9 +5445,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class ScaleBarDistanceLabelVerticalPlacement SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsScaleBarSettings, LabelVerticalPlacement ) : int
-    {
-        AboveSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelAboveSegment ) = 0, //!< Labels are drawn above the scalebar
-        BelowSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelBelowSegment ), //!< Labels are drawn below the scalebar
+      {
+      AboveSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelAboveSegment ) = 0, //!< Labels are drawn above the scalebar
+      BelowSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelBelowSegment ), //!< Labels are drawn below the scalebar
     };
     Q_ENUM( ScaleBarDistanceLabelVerticalPlacement )
 
@@ -5460,9 +5459,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class ScaleBarDistanceLabelHorizontalPlacement SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsScaleBarSettings, LabelHorizontalPlacement ) : int
-    {
-        CenteredEdge SIP_MONKEYPATCH_COMPAT_NAME( LabelCenteredEdge ) = 0, //!< Labels are drawn centered relative to segment's edge
-        CenteredSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelCenteredSegment ), //!< Labels are drawn centered relative to segment
+      {
+      CenteredEdge SIP_MONKEYPATCH_COMPAT_NAME( LabelCenteredEdge ) = 0, //!< Labels are drawn centered relative to segment's edge
+      CenteredSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelCenteredSegment ), //!< Labels are drawn centered relative to segment
     };
     Q_ENUM( ScaleBarDistanceLabelHorizontalPlacement )
 
@@ -5475,11 +5474,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, GridUnit ) : int
-    {
-        MapUnits SIP_MONKEYPATCH_COMPAT_NAME( MapUnit ), //!< Grid units follow map units
-                 Millimeters SIP_MONKEYPATCH_COMPAT_NAME( MM ), //!< Grid units in millimeters
-                 Centimeters SIP_MONKEYPATCH_COMPAT_NAME( CM ), //!< Grid units in centimeters
-                 DynamicPageSizeBased, //!< Dynamically sized, based on a on-page size range
+      {
+      MapUnits SIP_MONKEYPATCH_COMPAT_NAME( MapUnit ), //!< Grid units follow map units
+      Millimeters SIP_MONKEYPATCH_COMPAT_NAME( MM ), //!< Grid units in millimeters
+      Centimeters SIP_MONKEYPATCH_COMPAT_NAME( CM ), //!< Grid units in centimeters
+      DynamicPageSizeBased, //!< Dynamically sized, based on a on-page size range
     };
     Q_ENUM( MapGridUnit )
 
@@ -5491,11 +5490,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridStyle SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, GridStyle ) : int
-    {
-        Lines SIP_MONKEYPATCH_COMPAT_NAME( Solid ) = 0, //!< Draw lines for grid
-        LineCrosses SIP_MONKEYPATCH_COMPAT_NAME( Cross ), //!< Draw line crosses at intersections of grid lines
-        Markers, //!< Draw markers at intersections of grid lines
-        FrameAndAnnotationsOnly SIP_MONKEYPATCH_COMPAT_NAME( FrameAnnotationsOnly ) //!< No grid lines over the map, only draw frame and annotations
+      {
+      Lines SIP_MONKEYPATCH_COMPAT_NAME( Solid ) = 0, //!< Draw lines for grid
+      LineCrosses SIP_MONKEYPATCH_COMPAT_NAME( Cross ), //!< Draw line crosses at intersections of grid lines
+      Markers, //!< Draw markers at intersections of grid lines
+      FrameAndAnnotationsOnly SIP_MONKEYPATCH_COMPAT_NAME( FrameAnnotationsOnly ) //!< No grid lines over the map, only draw frame and annotations
     };
     Q_ENUM( MapGridStyle )
 
@@ -5507,11 +5506,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridComponentVisibility SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, DisplayMode ) : int
-    {
-        ShowAll = 0, //!< Show both latitude and longitude annotations/divisions
-        LatitudeOnly, //!< Show latitude/y annotations/divisions only
-        LongitudeOnly, //!< Show longitude/x annotations/divisions only
-        HideAll //!< No annotations
+      {
+      ShowAll = 0, //!< Show both latitude and longitude annotations/divisions
+      LatitudeOnly, //!< Show latitude/y annotations/divisions only
+      LongitudeOnly, //!< Show longitude/x annotations/divisions only
+      HideAll //!< No annotations
     };
     Q_ENUM( MapGridComponentVisibility )
 
@@ -5523,9 +5522,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridAnnotationPosition SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, AnnotationPosition ) : int
-    {
-        InsideMapFrame = 0, //!< Draw annotations inside the map frame
-        OutsideMapFrame, //!< Draw annotations outside the map frame
+      {
+      InsideMapFrame = 0, //!< Draw annotations inside the map frame
+      OutsideMapFrame, //!< Draw annotations outside the map frame
     };
     Q_ENUM( MapGridAnnotationPosition )
 
@@ -5537,14 +5536,14 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridAnnotationDirection SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, AnnotationDirection ) : int
-    {
-        Horizontal = 0, //!< Draw annotations horizontally
-        Vertical, //!< Draw annotations vertically, ascending
-        VerticalDescending, //!< Draw annotations vertically, descending
-        BoundaryDirection, //!< Annotations follow the boundary direction
-        AboveTick, //!< Draw annotations parallel to tick (above the line)
-        OnTick, //!< Draw annotations parallel to tick (on the line)
-        UnderTick, //!< Draw annotations parallel to tick (under the line)
+      {
+      Horizontal = 0, //!< Draw annotations horizontally
+      Vertical, //!< Draw annotations vertically, ascending
+      VerticalDescending, //!< Draw annotations vertically, descending
+      BoundaryDirection, //!< Annotations follow the boundary direction
+      AboveTick, //!< Draw annotations parallel to tick (above the line)
+      OnTick, //!< Draw annotations parallel to tick (on the line)
+      UnderTick, //!< Draw annotations parallel to tick (under the line)
     };
     Q_ENUM( MapGridAnnotationDirection )
 
@@ -5556,16 +5555,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridAnnotationFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, AnnotationFormat ) : int
-    {
-        Decimal = 0, //!< Decimal degrees, use - for S/W coordinates
-        DegreeMinute, //!< Degree/minutes, use NSEW suffix
-        DegreeMinuteSecond, //!< Degree/minutes/seconds, use NSEW suffix
-        DecimalWithSuffix, //!< Decimal degrees, use NSEW suffix
-        DegreeMinuteNoSuffix, //!< Degree/minutes, use - for S/W coordinates
-        DegreeMinutePadded, //!< Degree/minutes, with minutes using leading zeros where required
-        DegreeMinuteSecondNoSuffix, //!< Degree/minutes/seconds, use - for S/W coordinates
-        DegreeMinuteSecondPadded, //!< Degree/minutes/seconds, with minutes using leading zeros where required
-        CustomFormat //!< Custom expression-based format
+      {
+      Decimal = 0, //!< Decimal degrees, use - for S/W coordinates
+      DegreeMinute, //!< Degree/minutes, use NSEW suffix
+      DegreeMinuteSecond, //!< Degree/minutes/seconds, use NSEW suffix
+      DecimalWithSuffix, //!< Decimal degrees, use NSEW suffix
+      DegreeMinuteNoSuffix, //!< Degree/minutes, use - for S/W coordinates
+      DegreeMinutePadded, //!< Degree/minutes, with minutes using leading zeros where required
+      DegreeMinuteSecondNoSuffix, //!< Degree/minutes/seconds, use - for S/W coordinates
+      DegreeMinuteSecondPadded, //!< Degree/minutes/seconds, with minutes using leading zeros where required
+      CustomFormat //!< Custom expression-based format
     };
     Q_ENUM( MapGridAnnotationFormat )
 
@@ -5577,11 +5576,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridBorderSide SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, BorderSide ) : int
-    {
-        Left, //!< Left border
-        Right, //!< Right border
-        Bottom, //!< Bottom border
-        Top, //!< Top border
+      {
+      Left, //!< Left border
+      Right, //!< Right border
+      Bottom, //!< Bottom border
+      Top, //!< Top border
     };
     Q_ENUM( MapGridBorderSide )
 
@@ -5593,15 +5592,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridFrameStyle SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, FrameStyle ) : int
-    {
-        NoFrame = 0, //!< Disable grid frame
-        Zebra, //!< Black/white pattern
-        InteriorTicks,  //!< Tick markers drawn inside map frame
-        ExteriorTicks,  //!< Tick markers drawn outside map frame
-        InteriorExteriorTicks, //!< Tick markers drawn both inside and outside the map frame
-        LineBorder, //!< Simple solid line frame
-        LineBorderNautical, //!< Simple solid line frame, with nautical style diagonals on corners
-        ZebraNautical, //!< Black/white pattern, with nautical style diagonals on corners
+      {
+      NoFrame = 0, //!< Disable grid frame
+      Zebra, //!< Black/white pattern
+      InteriorTicks,  //!< Tick markers drawn inside map frame
+      ExteriorTicks,  //!< Tick markers drawn outside map frame
+      InteriorExteriorTicks, //!< Tick markers drawn both inside and outside the map frame
+      LineBorder, //!< Simple solid line frame
+      LineBorderNautical, //!< Simple solid line frame, with nautical style diagonals on corners
+      ZebraNautical, //!< Black/white pattern, with nautical style diagonals on corners
     };
     Q_ENUM( MapGridFrameStyle )
 
@@ -5613,9 +5612,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridTickLengthMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, TickLengthMode ) : int
-    {
-        OrthogonalTicks = 0, //!< Align ticks orthogonaly
-        NormalizedTicks, //!< Constant tick lengths
+      {
+      OrthogonalTicks = 0, //!< Align ticks orthogonaly
+      NormalizedTicks, //!< Constant tick lengths
     };
     Q_ENUM( MapGridTickLengthMode )
 
@@ -5629,10 +5628,10 @@ class CORE_EXPORT Qgis
      */
     enum class MapGridFrameSideFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, FrameSideFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Left SIP_MONKEYPATCH_COMPAT_NAME( FrameLeft ) = 0x01, //!< Left side of map
-        Right SIP_MONKEYPATCH_COMPAT_NAME( FrameRight ) = 0x02, //!< Right side of map
-        Top SIP_MONKEYPATCH_COMPAT_NAME( FrameTop ) = 0x04, //!< Top side of map
-        Bottom SIP_MONKEYPATCH_COMPAT_NAME( FrameBottom ) = 0x08 //!< Bottom side of map
+      Left SIP_MONKEYPATCH_COMPAT_NAME( FrameLeft ) = 0x01, //!< Left side of map
+      Right SIP_MONKEYPATCH_COMPAT_NAME( FrameRight ) = 0x02, //!< Right side of map
+      Top SIP_MONKEYPATCH_COMPAT_NAME( FrameTop ) = 0x04, //!< Top side of map
+      Bottom SIP_MONKEYPATCH_COMPAT_NAME( FrameBottom ) = 0x08 //!< Bottom side of map
     };
     Q_ENUM( MapGridFrameSideFlag )
 
@@ -5654,9 +5653,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridAnnotationType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, AnnotationCoordinate ) : int
-    {
-        Longitude = 0, //!< Coordinate is a longitude value
-        Latitude //!< Coordinate is a latitude value
+      {
+      Longitude = 0, //!< Coordinate is a longitude value
+      Latitude //!< Coordinate is a latitude value
     };
     Q_ENUM( MapGridAnnotationType )
 
@@ -5700,11 +5699,11 @@ class CORE_EXPORT Qgis
      */
     enum class DatabaseProviderConnectionCapability2 : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        SetFieldComment = 1 << 0, //!< Can set comments for fields via setFieldComment()
-        SetFieldAlias = 1 << 1, //!< Can set aliases for fields via setFieldAlias()
-        SetTableComment = 1 << 2, //!< Can set comments for tables via setTableComment() \since QGIS 3.44
-        EditFieldDomain = 1 << 3,   //!< Can edit existing field domain \since QGIS 4.0
-        DeleteFieldDomain = 1 << 4, //!< Can delete existing field domain \since QGIS 4.0
+      SetFieldComment = 1 << 0, //!< Can set comments for fields via setFieldComment()
+      SetFieldAlias = 1 << 1, //!< Can set aliases for fields via setFieldAlias()
+      SetTableComment = 1 << 2, //!< Can set comments for tables via setTableComment() \since QGIS 3.44
+      EditFieldDomain = 1 << 3,   //!< Can edit existing field domain \since QGIS 4.0
+      DeleteFieldDomain = 1 << 4, //!< Can delete existing field domain \since QGIS 4.0
     };
     Q_ENUM( DatabaseProviderConnectionCapability2 )
     Q_DECLARE_FLAGS( DatabaseProviderConnectionCapabilities2, DatabaseProviderConnectionCapability2 )
@@ -5717,8 +5716,8 @@ class CORE_EXPORT Qgis
      */
     enum class DatabaseProviderTableImportCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        SetGeometryColumnName = 1 << 0, //!< Can set the name of the geometry column
-        SetPrimaryKeyName = 1 << 1, //!< Can set the name of the primary key column
+      SetGeometryColumnName = 1 << 0, //!< Can set the name of the geometry column
+      SetPrimaryKeyName = 1 << 1, //!< Can set the name of the primary key column
     };
     Q_ENUM( DatabaseProviderTableImportCapability )
     Q_DECLARE_FLAGS( DatabaseProviderTableImportCapabilities, DatabaseProviderTableImportCapability )
@@ -5731,9 +5730,9 @@ class CORE_EXPORT Qgis
      */
     enum class ProviderStyleStorageCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        SaveToDatabase = 1 << 1,
-        LoadFromDatabase = 1 << 2,
-        DeleteFromDatabase = 1 << 3
+      SaveToDatabase = 1 << 1,
+      LoadFromDatabase = 1 << 2,
+      DeleteFromDatabase = 1 << 3
     };
     Q_ENUM( ProviderStyleStorageCapability );
     Q_DECLARE_FLAGS( ProviderStyleStorageCapabilities, ProviderStyleStorageCapability )
@@ -5760,16 +5759,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class AttributeEditorType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsAttributeEditorElement, AttributeEditorType ) : int
-    {
-        Container SIP_MONKEYPATCH_COMPAT_NAME( AeTypeContainer ), //!< A container
-                  Field SIP_MONKEYPATCH_COMPAT_NAME( AeTypeField ), //!< A field
-                  Relation SIP_MONKEYPATCH_COMPAT_NAME( AeTypeRelation ), //!< A relation
-                  QmlElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeQmlElement ), //!< A QML element
-                  HtmlElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeHtmlElement ), //!< A HTML element
-                  Action SIP_MONKEYPATCH_COMPAT_NAME( AeTypeAction ), //!< A layer action element \since QGIS 3.22
-                  TextElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeTextElement ), //!< A text element \since QGIS 3.30
-                  SpacerElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeSpacerElement ), //!< A spacer element \since QGIS 3.30
-                  Invalid SIP_MONKEYPATCH_COMPAT_NAME( AeTypeInvalid ), //!< Invalid
+      {
+      Container SIP_MONKEYPATCH_COMPAT_NAME( AeTypeContainer ), //!< A container
+      Field SIP_MONKEYPATCH_COMPAT_NAME( AeTypeField ), //!< A field
+      Relation SIP_MONKEYPATCH_COMPAT_NAME( AeTypeRelation ), //!< A relation
+      QmlElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeQmlElement ), //!< A QML element
+      HtmlElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeHtmlElement ), //!< A HTML element
+      Action SIP_MONKEYPATCH_COMPAT_NAME( AeTypeAction ), //!< A layer action element \since QGIS 3.22
+      TextElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeTextElement ), //!< A text element \since QGIS 3.30
+      SpacerElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeSpacerElement ), //!< A spacer element \since QGIS 3.30
+      Invalid SIP_MONKEYPATCH_COMPAT_NAME( AeTypeInvalid ), //!< Invalid
     };
     Q_ENUM( AttributeEditorType )
 
@@ -5794,10 +5793,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class AttributeFormLayout SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsEditFormConfig, EditorLayout ) : int
-    {
-        AutoGenerated SIP_MONKEYPATCH_COMPAT_NAME( GeneratedLayout ) = 0, //!< Autogenerate a simple tabular layout for the form
-        DragAndDrop SIP_MONKEYPATCH_COMPAT_NAME( TabLayout ) = 1, //!< "Drag and drop" layout. Needs to be configured.
-        UiFile SIP_MONKEYPATCH_COMPAT_NAME( UiFileLayout ) = 2 //!< Load a .ui file for the layout. Needs to be configured.
+      {
+      AutoGenerated SIP_MONKEYPATCH_COMPAT_NAME( GeneratedLayout ) = 0, //!< Autogenerate a simple tabular layout for the form
+      DragAndDrop SIP_MONKEYPATCH_COMPAT_NAME( TabLayout ) = 1, //!< "Drag and drop" layout. Needs to be configured.
+      UiFile SIP_MONKEYPATCH_COMPAT_NAME( UiFileLayout ) = 2 //!< Load a .ui file for the layout. Needs to be configured.
     };
     Q_ENUM( AttributeFormLayout )
 
@@ -5809,10 +5808,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class AttributeFormSuppression SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsEditFormConfig, FeatureFormSuppress ) : int
-    {
-        Default SIP_MONKEYPATCH_COMPAT_NAME( SuppressDefault ) = 0, //!< Use the application-wide setting.
-        On SIP_MONKEYPATCH_COMPAT_NAME( SuppressOn ) = 1, //!< Always suppress feature form.
-        Off SIP_MONKEYPATCH_COMPAT_NAME( SuppressOff ) = 2 //!< Never suppress feature form.
+      {
+      Default SIP_MONKEYPATCH_COMPAT_NAME( SuppressDefault ) = 0, //!< Use the application-wide setting.
+      On SIP_MONKEYPATCH_COMPAT_NAME( SuppressOn ) = 1, //!< Always suppress feature form.
+      Off SIP_MONKEYPATCH_COMPAT_NAME( SuppressOff ) = 2 //!< Never suppress feature form.
     };
     Q_ENUM( AttributeFormSuppression )
 
@@ -5824,11 +5823,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class AttributeFormPythonInitCodeSource SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsEditFormConfig, PythonInitCodeSource ) : int
-    {
-        NoSource SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceNone ) = 0, //!< Do not use Python code at all
-        File SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceFile ) = 1, //!< Load the Python code from an external file
-        Dialog SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceDialog ) = 2, //!< Use the Python code provided in the dialog
-        Environment SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceEnvironment ) = 3 //!< Use the Python code available in the Python environment
+      {
+      NoSource SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceNone ) = 0, //!< Do not use Python code at all
+      File SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceFile ) = 1, //!< Load the Python code from an external file
+      Dialog SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceDialog ) = 2, //!< Use the Python code provided in the dialog
+      Environment SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceEnvironment ) = 3 //!< Use the Python code available in the Python environment
     };
     Q_ENUM( AttributeFormPythonInitCodeSource )
 
@@ -5866,10 +5865,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class FeatureSymbologyExport SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorFileWriter, SymbologyExport ) : int
-    {
-        NoSymbology = 0, //!< Export only data
-        PerFeature SIP_MONKEYPATCH_COMPAT_NAME( FeatureSymbology ), //!< Keeps the number of features and export symbology per feature
-        PerSymbolLayer SIP_MONKEYPATCH_COMPAT_NAME( SymbolLayerSymbology ) //!< Exports one feature per symbol layer (considering symbol levels)
+      {
+      NoSymbology = 0, //!< Export only data
+      PerFeature SIP_MONKEYPATCH_COMPAT_NAME( FeatureSymbology ), //!< Keeps the number of features and export symbology per feature
+      PerSymbolLayer SIP_MONKEYPATCH_COMPAT_NAME( SymbolLayerSymbology ) //!< Exports one feature per symbol layer (considering symbol levels)
     };
     Q_ENUM( FeatureSymbologyExport )
 
@@ -5880,7 +5879,7 @@ class CORE_EXPORT Qgis
      */
     enum class VectorTileProviderFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        AlwaysUseTileMatrixSetFromProvider = 1 << 1, //!< Vector tile layer must always use the tile matrix set from the data provider, and should never store, restore or override the definition of this matrix set.
+      AlwaysUseTileMatrixSetFromProvider = 1 << 1, //!< Vector tile layer must always use the tile matrix set from the data provider, and should never store, restore or override the definition of this matrix set.
     };
     Q_ENUM( VectorTileProviderFlag )
 
@@ -5898,7 +5897,7 @@ class CORE_EXPORT Qgis
      */
     enum class VectorTileProviderCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. See QgsDataProvider::layerMetadata()
+      ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. See QgsDataProvider::layerMetadata()
     };
     Q_ENUM( VectorTileProviderCapability )
 
@@ -5931,7 +5930,7 @@ class CORE_EXPORT Qgis
      */
     enum class TiledSceneProviderCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. See QgsDataProvider::layerMetadata()
+      ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. See QgsDataProvider::layerMetadata()
     };
     Q_ENUM( TiledSceneProviderCapability )
 
@@ -5991,7 +5990,7 @@ class CORE_EXPORT Qgis
      */
     enum class TiledSceneRequestFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoHierarchyFetch = 1 << 0,  //!< Do not allow hierarchy fetching when hierarchy is not currently available. Avoids network requests, but may result in an incomplete tile set. If set, then callers will need to manually perform hierarchy fetches as required.
+      NoHierarchyFetch = 1 << 0,  //!< Do not allow hierarchy fetching when hierarchy is not currently available. Avoids network requests, but may result in an incomplete tile set. If set, then callers will need to manually perform hierarchy fetches as required.
     };
     Q_ENUM( TiledSceneRequestFlag )
 
@@ -6010,10 +6009,10 @@ class CORE_EXPORT Qgis
      */
     enum class TiledSceneRendererFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        RequiresTextures = 1 << 0,  //!< Renderer requires textures
-        ForceRasterRender = 1 << 1, //!< Layer should always be rendered as a raster image
-        RendersTriangles = 1 << 2, //!< Renderer can render triangle primitives
-        RendersLines = 1 << 3, //!< Renderer can render line primitives
+      RequiresTextures = 1 << 0,  //!< Renderer requires textures
+      ForceRasterRender = 1 << 1, //!< Layer should always be rendered as a raster image
+      RendersTriangles = 1 << 2, //!< Renderer can render triangle primitives
+      RendersLines = 1 << 3, //!< Renderer can render line primitives
     };
     Q_ENUM( TiledSceneRendererFlag )
 
@@ -6073,23 +6072,23 @@ class CORE_EXPORT Qgis
      */
     enum class ZonalStatistic : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Count = 1 << 0,  //!< Pixel count
-        Sum = 1 << 1,  //!< Sum of pixel values
-        Mean = 1 << 2,  //!< Mean of pixel values
-        Median = 1 << 3, //!< Median of pixel values
-        StDev = 1 << 4, //!< Standard deviation of pixel values
-        Min = 1 << 5,  //!< Min of pixel values
-        Max = 1 << 6,  //!< Max of pixel values
-        Range = 1 << 7, //!< Range of pixel values (max - min)
-        Minority = 1 << 8, //!< Minority of pixel values
-        Majority = 1 << 9, //!< Majority of pixel values
-        Variety = 1 << 10, //!< Variety (count of distinct) pixel values
-        Variance = 1 << 11, //!< Variance of pixel values
-        MinimumPoint = 1 << 12, //!< Pixel centroid for minimum pixel value \since QGIS 3.42
-        MaximumPoint = 1 << 13, //!< Pixel centroid for maximum pixel value \since QGIS 3.42
-        All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All statistics. For QGIS 3.x this includes ONLY numeric statistics, but for 4.0 this will be extended to included non-numeric statistics. Consider using AllNumeric instead.
-        AllNumeric = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All numeric statistics \since QGIS 3.42
-        Default = Count | Sum | Mean, //!< Default statistics
+      Count = 1 << 0,  //!< Pixel count
+      Sum = 1 << 1,  //!< Sum of pixel values
+      Mean = 1 << 2,  //!< Mean of pixel values
+      Median = 1 << 3, //!< Median of pixel values
+      StDev = 1 << 4, //!< Standard deviation of pixel values
+      Min = 1 << 5,  //!< Min of pixel values
+      Max = 1 << 6,  //!< Max of pixel values
+      Range = 1 << 7, //!< Range of pixel values (max - min)
+      Minority = 1 << 8, //!< Minority of pixel values
+      Majority = 1 << 9, //!< Majority of pixel values
+      Variety = 1 << 10, //!< Variety (count of distinct) pixel values
+      Variance = 1 << 11, //!< Variance of pixel values
+      MinimumPoint = 1 << 12, //!< Pixel centroid for minimum pixel value \since QGIS 3.42
+      MaximumPoint = 1 << 13, //!< Pixel centroid for maximum pixel value \since QGIS 3.42
+      All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All statistics. For QGIS 3.x this includes ONLY numeric statistics, but for 4.0 this will be extended to included non-numeric statistics. Consider using AllNumeric instead.
+      AllNumeric = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All numeric statistics \since QGIS 3.42
+      Default = Count | Sum | Mean, //!< Default statistics
     };
     Q_ENUM( ZonalStatistic )
 
@@ -6125,29 +6124,29 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36. Prior to 3.36 this was available as QgsAggregateCalculator::Aggregate.
      */
     enum class Aggregate SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsAggregateCalculator, Aggregate ) : int
-    {
-        Count, //!< Count
-        CountDistinct, //!< Number of distinct values
-        CountMissing, //!< Number of missing (null) values
-        Min, //!< Min of values
-        Max, //!< Max of values
-        Sum, //!< Sum of values
-        Mean, //!< Mean of values (numeric fields only)
-        Median, //!< Median of values (numeric fields only)
-        StDev, //!< Standard deviation of values (numeric fields only)
-        StDevSample,//!< Sample standard deviation of values (numeric fields only)
-        Range, //!< Range of values (max - min) (numeric and datetime fields only)
-        Minority, //!< Minority of values
-        Majority, //!< Majority of values
-        FirstQuartile, //!< First quartile (numeric fields only)
-        ThirdQuartile, //!< Third quartile (numeric fields only)
-        InterQuartileRange, //!< Inter quartile range (IQR) (numeric fields only)
-        StringMinimumLength, //!< Minimum length of string (string fields only)
-        StringMaximumLength, //!< Maximum length of string (string fields only)
-        StringConcatenate, //!< Concatenate values with a joining string (string fields only). Specify the delimiter using setDelimiter().
-        GeometryCollect, //!< Create a multipart geometry from aggregated geometries
-        ArrayAggregate, //!< Create an array of values
-        StringConcatenateUnique //!< Concatenate unique values with a joining string (string fields only). Specify the delimiter using setDelimiter().
+      {
+      Count, //!< Count
+      CountDistinct, //!< Number of distinct values
+      CountMissing, //!< Number of missing (null) values
+      Min, //!< Min of values
+      Max, //!< Max of values
+      Sum, //!< Sum of values
+      Mean, //!< Mean of values (numeric fields only)
+      Median, //!< Median of values (numeric fields only)
+      StDev, //!< Standard deviation of values (numeric fields only)
+      StDevSample,//!< Sample standard deviation of values (numeric fields only)
+      Range, //!< Range of values (max - min) (numeric and datetime fields only)
+      Minority, //!< Minority of values
+      Majority, //!< Majority of values
+      FirstQuartile, //!< First quartile (numeric fields only)
+      ThirdQuartile, //!< Third quartile (numeric fields only)
+      InterQuartileRange, //!< Inter quartile range (IQR) (numeric fields only)
+      StringMinimumLength, //!< Minimum length of string (string fields only)
+      StringMaximumLength, //!< Maximum length of string (string fields only)
+      StringConcatenate, //!< Concatenate values with a joining string (string fields only). Specify the delimiter using setDelimiter().
+      GeometryCollect, //!< Create a multipart geometry from aggregated geometries
+      ArrayAggregate, //!< Create an array of values
+      StringConcatenateUnique //!< Concatenate unique values with a joining string (string fields only). Specify the delimiter using setDelimiter().
     };
     Q_ENUM( Aggregate )
 
@@ -6158,25 +6157,25 @@ class CORE_EXPORT Qgis
      */
     enum class Statistic SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsStatisticalSummary, Statistic ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Count = 1 << 0,  //!< Count
-        CountMissing = 1 << 15, //!< Number of missing (null) values
-        Sum = 1 << 1,  //!< Sum of values
-        Mean = 1 << 2,  //!< Mean of values
-        Median = 1 << 3, //!< Median of values
-        StDev = 1 << 4, //!< Standard deviation of values
-        StDevSample = 1 << 5, //!< Sample standard deviation of values
-        Min = 1 << 6,  //!< Min of values
-        Max = 1 << 7,  //!< Max of values
-        Range = 1 << 8, //!< Range of values (max - min)
-        Minority = 1 << 9, //!< Minority of values
-        Majority = 1 << 10, //!< Majority of values
-        Variety = 1 << 11, //!< Variety (count of distinct) values
-        FirstQuartile = 1 << 12, //!< First quartile
-        ThirdQuartile = 1 << 13, //!< Third quartile
-        InterQuartileRange = 1 << 14, //!< Inter quartile range (IQR)
-        First = 1 << 16, //!< First value \since QGIS 3.6
-        Last = 1 << 17, //!< Last value \since QGIS 3.6
-        All = Count | CountMissing | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | FirstQuartile | ThirdQuartile | InterQuartileRange | First | Last //!< All statistics
+      Count = 1 << 0,  //!< Count
+      CountMissing = 1 << 15, //!< Number of missing (null) values
+      Sum = 1 << 1,  //!< Sum of values
+      Mean = 1 << 2,  //!< Mean of values
+      Median = 1 << 3, //!< Median of values
+      StDev = 1 << 4, //!< Standard deviation of values
+      StDevSample = 1 << 5, //!< Sample standard deviation of values
+      Min = 1 << 6,  //!< Min of values
+      Max = 1 << 7,  //!< Max of values
+      Range = 1 << 8, //!< Range of values (max - min)
+      Minority = 1 << 9, //!< Minority of values
+      Majority = 1 << 10, //!< Majority of values
+      Variety = 1 << 11, //!< Variety (count of distinct) values
+      FirstQuartile = 1 << 12, //!< First quartile
+      ThirdQuartile = 1 << 13, //!< Third quartile
+      InterQuartileRange = 1 << 14, //!< Inter quartile range (IQR)
+      First = 1 << 16, //!< First value \since QGIS 3.6
+      Last = 1 << 17, //!< Last value \since QGIS 3.6
+      All = Count | CountMissing | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | FirstQuartile | ThirdQuartile | InterQuartileRange | First | Last //!< All statistics
     };
     Q_ENUM( Statistic )
 
@@ -6195,13 +6194,13 @@ class CORE_EXPORT Qgis
      */
     enum class DateTimeStatistic SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDateTimeStatisticalSummary, Statistic ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Count = 1,  //!< Count
-        CountDistinct = 2,  //!< Number of distinct datetime values
-        CountMissing = 4,  //!< Number of missing (null) values
-        Min = 8, //!< Minimum (earliest) datetime value
-        Max = 16, //!< Maximum (latest) datetime value
-        Range = 32, //!< Interval between earliest and latest datetime value
-        All = Count | CountDistinct | CountMissing | Min | Max | Range, //!< All statistics
+      Count = 1,  //!< Count
+      CountDistinct = 2,  //!< Number of distinct datetime values
+      CountMissing = 4,  //!< Number of missing (null) values
+      Min = 8, //!< Minimum (earliest) datetime value
+      Max = 16, //!< Maximum (latest) datetime value
+      Range = 32, //!< Interval between earliest and latest datetime value
+      All = Count | CountDistinct | CountMissing | Min | Max | Range, //!< All statistics
     };
     Q_ENUM( DateTimeStatistic )
 
@@ -6220,17 +6219,17 @@ class CORE_EXPORT Qgis
      */
     enum class StringStatistic SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsStringStatisticalSummary, Statistic ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        Count = 1,  //!< Count
-        CountDistinct = 2,  //!< Number of distinct string values
-        CountMissing = 4,  //!< Number of missing (null) values
-        Min = 8, //!< Minimum string value
-        Max = 16, //!< Maximum string value
-        MinimumLength = 32, //!< Minimum length of string
-        MaximumLength = 64, //!< Maximum length of string
-        MeanLength = 128, //!< Mean length of strings
-        Minority = 256, //!< Minority of strings
-        Majority = 512, //!< Majority of strings
-        All = Count | CountDistinct | CountMissing | Min | Max | MinimumLength | MaximumLength | MeanLength | Minority | Majority, //!< All statistics
+      Count = 1,  //!< Count
+      CountDistinct = 2,  //!< Number of distinct string values
+      CountMissing = 4,  //!< Number of missing (null) values
+      Min = 8, //!< Minimum string value
+      Max = 16, //!< Maximum string value
+      MinimumLength = 32, //!< Minimum length of string
+      MaximumLength = 64, //!< Maximum length of string
+      MeanLength = 128, //!< Mean length of strings
+      Minority = 256, //!< Minority of strings
+      Majority = 512, //!< Majority of strings
+      All = Count | CountDistinct | CountMissing | Min | Max | MinimumLength | MaximumLength | MeanLength | Minority | Majority, //!< All statistics
     };
     Q_ENUM( StringStatistic )
 
@@ -6249,15 +6248,15 @@ class CORE_EXPORT Qgis
      */
     enum class RasterBandStatistic SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterBandStats, Stats ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoStatistic = 0, //!< No statistic
-        Min = 1, //!< Minimum
-        Max = 1 << 1, //!< Maximum
-        Range = 1 << 2, //!< Range
-        Sum = 1 << 3, //!< Sum
-        Mean = 1 << 4, //!< Mean
-        StdDev = 1 << 5, //!< Standard deviation
-        SumOfSquares = 1 << 6, //!< Sum of squares
-        All = Min | Max | Range | Sum | Mean | StdDev | SumOfSquares //!< All available statistics
+      NoStatistic = 0, //!< No statistic
+      Min = 1, //!< Minimum
+      Max = 1 << 1, //!< Maximum
+      Range = 1 << 2, //!< Range
+      Sum = 1 << 3, //!< Sum
+      Mean = 1 << 4, //!< Mean
+      StdDev = 1 << 5, //!< Standard deviation
+      SumOfSquares = 1 << 6, //!< Sum of squares
+      All = Min | Max | Range | Sum | Mean | StdDev | SumOfSquares //!< All available statistics
     };
     Q_ENUM( RasterBandStatistic )
 
@@ -6433,8 +6432,8 @@ class CORE_EXPORT Qgis
      */
     enum class RasterProcessingParameterCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        WmsScale = 1 << 0, //!< The parameter supports a reference scale for WMS source layers
-        WmsDpi = 1 << 1,   //!< The parameter supports a server resolution for WMS source layers
+      WmsScale = 1 << 0, //!< The parameter supports a reference scale for WMS source layers
+      WmsDpi = 1 << 1,   //!< The parameter supports a server resolution for WMS source layers
     };
     Q_ENUM( RasterProcessingParameterCapability )
 
@@ -6466,10 +6465,10 @@ class CORE_EXPORT Qgis
      */
     enum class ExtrusionFace : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        NoFace = 0,
-        Walls = 1 << 0,
-        Roof = 1 << 1,
-        Floor = 1 << 2
+      NoFace = 0,
+      Walls = 1 << 0,
+      Roof = 1 << 1,
+      Floor = 1 << 2
     };
     Q_ENUM( ExtrusionFace )
 
@@ -6486,8 +6485,8 @@ class CORE_EXPORT Qgis
      */
     enum class TriangulationAlgorithm : int SIP_ENUM_BASETYPE( IntFlag )
     {
-        ConstrainedDelaunay = 0,
-        Earcut = 1 << 0
+      ConstrainedDelaunay = 0,
+      Earcut = 1 << 0
     };
     Q_ENUM( TriangulationAlgorithm )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -103,42 +103,42 @@ class CORE_EXPORT Qgis
      */
     enum class AuthConfigurationStorageCapability: int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ClearStorage = 1 << 0, //!< Can clear all configurations from storage
+        ClearStorage = 1 << 0, //!< Can clear all configurations from storage
 
-      ReadConfiguration = 1 << 1, //!< Can read an authentication configuration
-      UpdateConfiguration = 1 << 2, //!< Can update an authentication configuration
-      DeleteConfiguration = 1 << 3, //!< Can deleet an authentication configuration
-      CreateConfiguration = 1 << 4, //!< Can create a new authentication configuration
+        ReadConfiguration = 1 << 1, //!< Can read an authentication configuration
+        UpdateConfiguration = 1 << 2, //!< Can update an authentication configuration
+        DeleteConfiguration = 1 << 3, //!< Can deleet an authentication configuration
+        CreateConfiguration = 1 << 4, //!< Can create a new authentication configuration
 
-      ReadCertificateIdentity = 1 << 5, //!< Can read a certificate identity
-      UpdateCertificateIdentity = 1 << 6, //!< Can update a certificate identity
-      DeleteCertificateIdentity = 1 << 7, //!< Can delete a certificate identity
-      CreateCertificateIdentity = 1 << 8, //!< Can create a new certificate identity
+        ReadCertificateIdentity = 1 << 5, //!< Can read a certificate identity
+        UpdateCertificateIdentity = 1 << 6, //!< Can update a certificate identity
+        DeleteCertificateIdentity = 1 << 7, //!< Can delete a certificate identity
+        CreateCertificateIdentity = 1 << 8, //!< Can create a new certificate identity
 
-      ReadSslCertificateCustomConfig = 1 << 9, //!< Can read a SSL certificate custom config
-      UpdateSslCertificateCustomConfig = 1 << 10, //!< Can update a SSL certificate custom config
-      DeleteSslCertificateCustomConfig = 1 << 11, //!< Can delete a SSL certificate custom config
-      CreateSslCertificateCustomConfig = 1 << 12, //!< Can create a new SSL certificate custom config
+        ReadSslCertificateCustomConfig = 1 << 9, //!< Can read a SSL certificate custom config
+        UpdateSslCertificateCustomConfig = 1 << 10, //!< Can update a SSL certificate custom config
+        DeleteSslCertificateCustomConfig = 1 << 11, //!< Can delete a SSL certificate custom config
+        CreateSslCertificateCustomConfig = 1 << 12, //!< Can create a new SSL certificate custom config
 
-      ReadCertificateAuthority = 1 << 13, //!< Can read a certificate authority
-      UpdateCertificateAuthority = 1 << 14, //!< Can update a certificate authority
-      DeleteCertificateAuthority = 1 << 15, //!< Can delete a certificate authority
-      CreateCertificateAuthority = 1 << 16, //!< Can create a new certificate authority
+        ReadCertificateAuthority = 1 << 13, //!< Can read a certificate authority
+        UpdateCertificateAuthority = 1 << 14, //!< Can update a certificate authority
+        DeleteCertificateAuthority = 1 << 15, //!< Can delete a certificate authority
+        CreateCertificateAuthority = 1 << 16, //!< Can create a new certificate authority
 
-      ReadCertificateTrustPolicy = 1 << 17, //!< Can read a certificate trust policy
-      UpdateCertificateTrustPolicy = 1 << 18, //!< Can update a certificate trust policy
-      DeleteCertificateTrustPolicy = 1 << 19, //!< Can delete a certificate trust policy
-      CreateCertificateTrustPolicy = 1 << 20, //!< Can create a new certificate trust policy
+        ReadCertificateTrustPolicy = 1 << 17, //!< Can read a certificate trust policy
+        UpdateCertificateTrustPolicy = 1 << 18, //!< Can update a certificate trust policy
+        DeleteCertificateTrustPolicy = 1 << 19, //!< Can delete a certificate trust policy
+        CreateCertificateTrustPolicy = 1 << 20, //!< Can create a new certificate trust policy
 
-      ReadMasterPassword = 1 << 21, //!< Can read the master password
-      UpdateMasterPassword = 1 << 22, //!< Can update the master password
-      DeleteMasterPassword = 1 << 23, //!< Can delete the master password
-      CreateMasterPassword = 1 << 24, //!< Can create a new master password
+        ReadMasterPassword = 1 << 21, //!< Can read the master password
+        UpdateMasterPassword = 1 << 22, //!< Can update the master password
+        DeleteMasterPassword = 1 << 23, //!< Can delete the master password
+        CreateMasterPassword = 1 << 24, //!< Can create a new master password
 
-      ReadSetting = 1 << 25, //!< Can read the authentication settings
-      UpdateSetting = 1 << 26, //!< Can update the authentication setting
-      DeleteSetting = 1 << 27, //!< Can delete the authentication setting
-      CreateSetting = 1 << 28, //!< Can create a new authentication setting
+        ReadSetting = 1 << 25, //!< Can read the authentication settings
+        UpdateSetting = 1 << 26, //!< Can update the authentication setting
+        DeleteSetting = 1 << 27, //!< Can delete the authentication setting
+        CreateSetting = 1 << 28, //!< Can create a new authentication setting
 
     };
     Q_ENUM( AuthConfigurationStorageCapability )
@@ -166,13 +166,24 @@ class CORE_EXPORT Qgis
     Q_ENUM( MessageLevel )
 
     /**
+     * \brief Type of message
+     * This will be used both for message log and message bar in application.
+     */
+    enum class MessageType : int
+    {
+      MessageText = 0, //!< Text message
+      MessageHtml = 1, //!< HTML message
+    };
+    Q_ENUM( MessageType )
+
+    /**
      * \brief Flags controlling behavior of network requests.
      *
      * \since QGIS 4.0
      */
     enum class NetworkRequestFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      DisableMessageLogging = 1 << 0, //!< If present, indicates that no message logging should be performed when network errors are encountered
+        DisableMessageLogging = 1 << 0, //!< If present, indicates that no message logging should be performed when network errors are encountered
     };
     Q_ENUM( NetworkRequestFlag )
 
@@ -190,16 +201,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30. Prior to 3.30 this was available as QgsMapLayerType.
      */
     enum class LayerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMapLayer, LayerType ) : int
-      {
-      Vector SIP_MONKEYPATCH_COMPAT_NAME( VectorLayer ), //!< Vector layer
-      Raster SIP_MONKEYPATCH_COMPAT_NAME( RasterLayer ), //!< Raster layer
-      Plugin SIP_MONKEYPATCH_COMPAT_NAME( PluginLayer ), //!< Plugin based layer
-      Mesh SIP_MONKEYPATCH_COMPAT_NAME( MeshLayer ),    //!< Mesh layer. Added in QGIS 3.2
-      VectorTile SIP_MONKEYPATCH_COMPAT_NAME( VectorTileLayer ), //!< Vector tile layer. Added in QGIS 3.14
-      Annotation SIP_MONKEYPATCH_COMPAT_NAME( AnnotationLayer ), //!< Contains freeform, georeferenced annotations. Added in QGIS 3.16
-      PointCloud SIP_MONKEYPATCH_COMPAT_NAME( PointCloudLayer ), //!< Point cloud layer. Added in QGIS 3.18
-      Group SIP_MONKEYPATCH_COMPAT_NAME( GroupLayer ), //!< Composite group layer. Added in QGIS 3.24
-      TiledScene, //!< Tiled scene layer. Added in QGIS 3.34
+    {
+        Vector SIP_MONKEYPATCH_COMPAT_NAME( VectorLayer ), //!< Vector layer
+               Raster SIP_MONKEYPATCH_COMPAT_NAME( RasterLayer ), //!< Raster layer
+               Plugin SIP_MONKEYPATCH_COMPAT_NAME( PluginLayer ), //!< Plugin based layer
+               Mesh SIP_MONKEYPATCH_COMPAT_NAME( MeshLayer ),    //!< Mesh layer. Added in QGIS 3.2
+               VectorTile SIP_MONKEYPATCH_COMPAT_NAME( VectorTileLayer ), //!< Vector tile layer. Added in QGIS 3.14
+               Annotation SIP_MONKEYPATCH_COMPAT_NAME( AnnotationLayer ), //!< Contains freeform, georeferenced annotations. Added in QGIS 3.16
+               PointCloud SIP_MONKEYPATCH_COMPAT_NAME( PointCloudLayer ), //!< Point cloud layer. Added in QGIS 3.18
+               Group SIP_MONKEYPATCH_COMPAT_NAME( GroupLayer ), //!< Composite group layer. Added in QGIS 3.24
+               TiledScene, //!< Tiled scene layer. Added in QGIS 3.34
     };
     Q_ENUM( LayerType )
 
@@ -210,22 +221,22 @@ class CORE_EXPORT Qgis
      */
     enum class LayerFilter SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMapLayerProxyModel, Filter ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      RasterLayer = 1,
-      NoGeometry = 2,
-      PointLayer = 4,
-      LineLayer = 8,
-      PolygonLayer = 16,
-      HasGeometry = PointLayer | LineLayer | PolygonLayer,
-      VectorLayer = NoGeometry | HasGeometry,
-      PluginLayer = 32,
-      WritableLayer = 64,
-      MeshLayer = 128, //!< QgsMeshLayer \since QGIS 3.6
-      VectorTileLayer = 256, //!< QgsVectorTileLayer \since QGIS 3.14
-      PointCloudLayer = 512, //!< QgsPointCloudLayer \since QGIS 3.18
-      AnnotationLayer = 1024, //!< QgsAnnotationLayer \since QGIS 3.22
-      TiledSceneLayer = 2048, //!< QgsTiledSceneLayer \since QGIS 3.34
-      All = RasterLayer | VectorLayer | PluginLayer | MeshLayer | VectorTileLayer | PointCloudLayer | AnnotationLayer | TiledSceneLayer, //!< All layers
-      SpatialLayer = RasterLayer | HasGeometry | PluginLayer | MeshLayer | VectorTileLayer | PointCloudLayer | AnnotationLayer | TiledSceneLayer //!< All spatial layers. \since QGIS 3.24
+        RasterLayer = 1,
+        NoGeometry = 2,
+        PointLayer = 4,
+        LineLayer = 8,
+        PolygonLayer = 16,
+        HasGeometry = PointLayer | LineLayer | PolygonLayer,
+        VectorLayer = NoGeometry | HasGeometry,
+        PluginLayer = 32,
+        WritableLayer = 64,
+        MeshLayer = 128, //!< QgsMeshLayer \since QGIS 3.6
+        VectorTileLayer = 256, //!< QgsVectorTileLayer \since QGIS 3.14
+        PointCloudLayer = 512, //!< QgsPointCloudLayer \since QGIS 3.18
+        AnnotationLayer = 1024, //!< QgsAnnotationLayer \since QGIS 3.22
+        TiledSceneLayer = 2048, //!< QgsTiledSceneLayer \since QGIS 3.34
+        All = RasterLayer | VectorLayer | PluginLayer | MeshLayer | VectorTileLayer | PointCloudLayer | AnnotationLayer | TiledSceneLayer, //!< All layers
+        SpatialLayer = RasterLayer | HasGeometry | PluginLayer | MeshLayer | VectorTileLayer | PointCloudLayer | AnnotationLayer | TiledSceneLayer //!< All spatial layers. \since QGIS 3.24
     };
     Q_DECLARE_FLAGS( LayerFilters, LayerFilter )
     Q_FLAG( LayerFilters )
@@ -237,7 +248,7 @@ class CORE_EXPORT Qgis
      */
     enum class LoadStyleFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      IgnoreMissingStyleErrors = 1 << 0, //!< If the style is missing, then don't flag it as an error. This flag can be used when the caller is not certain that a style exists, and accordingly a failure to find the style does not indicate an issue with loading the style itself.
+        IgnoreMissingStyleErrors = 1 << 0, //!< If the style is missing, then don't flag it as an error. This flag can be used when the caller is not certain that a style exists, and accordingly a failure to find the style does not indicate an issue with loading the style itself.
     };
     Q_ENUM( LoadStyleFlag )
 
@@ -277,79 +288,79 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class WkbType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsWkbTypes, Type ) : quint32
-      {
-      Unknown =  0, //!< Unknown
-      Point = 1, //!< Point
-      LineString = 2, //!< LineString
-      Polygon = 3, //!< Polygon
-      Triangle = 17, //!< Triangle
-      MultiPoint = 4, //!< MultiPoint
-      MultiLineString = 5, //!< MultiLineString
-      MultiPolygon = 6, //!< MultiPolygon
-      GeometryCollection = 7, //!< GeometryCollection
-      CircularString = 8, //!< CircularString
-      CompoundCurve = 9, //!< CompoundCurve
-      CurvePolygon = 10, //!< CurvePolygon
-      MultiCurve = 11, //!< MultiCurve
-      MultiSurface = 12, //!< MultiSurface
-      PolyhedralSurface = 15, //!< PolyhedralSurface \since QGIS 3.40
-      TIN = 16, //!< TIN \since QGIS 3.40
+    {
+        Unknown =  0, //!< Unknown
+        Point = 1, //!< Point
+        LineString = 2, //!< LineString
+        Polygon = 3, //!< Polygon
+        Triangle = 17, //!< Triangle
+        MultiPoint = 4, //!< MultiPoint
+        MultiLineString = 5, //!< MultiLineString
+        MultiPolygon = 6, //!< MultiPolygon
+        GeometryCollection = 7, //!< GeometryCollection
+        CircularString = 8, //!< CircularString
+        CompoundCurve = 9, //!< CompoundCurve
+        CurvePolygon = 10, //!< CurvePolygon
+        MultiCurve = 11, //!< MultiCurve
+        MultiSurface = 12, //!< MultiSurface
+        PolyhedralSurface = 15, //!< PolyhedralSurface \since QGIS 3.40
+        TIN = 16, //!< TIN \since QGIS 3.40
       NurbsCurve = 21, //!< NurbsCurve \since QGIS 4.0
-      NoGeometry = 100, //!< No geometry
-      PointZ = 1001, //!< PointZ
-      LineStringZ = 1002, //!< LineStringZ
-      PolygonZ = 1003, //!< PolygonZ
-      TriangleZ = 1017, //!< TriangleZ
-      MultiPointZ = 1004, //!< MultiPointZ
-      MultiLineStringZ = 1005, //!< MultiLineStringZ
-      MultiPolygonZ = 1006, //!< MultiPolygonZ
-      GeometryCollectionZ = 1007, //!< GeometryCollectionZ
-      CircularStringZ = 1008, //!< CircularStringZ
-      CompoundCurveZ = 1009, //!< CompoundCurveZ
-      CurvePolygonZ = 1010, //!< CurvePolygonZ
-      MultiCurveZ = 1011, //!< MultiCurveZ
-      MultiSurfaceZ = 1012, //!< MultiSurfaceZ
-      PolyhedralSurfaceZ = 1015, //!< PolyhedralSurfaceZ
-      TINZ = 1016, //!< TINZ
+        NoGeometry = 100, //!< No geometry
+        PointZ = 1001, //!< PointZ
+        LineStringZ = 1002, //!< LineStringZ
+        PolygonZ = 1003, //!< PolygonZ
+        TriangleZ = 1017, //!< TriangleZ
+        MultiPointZ = 1004, //!< MultiPointZ
+        MultiLineStringZ = 1005, //!< MultiLineStringZ
+        MultiPolygonZ = 1006, //!< MultiPolygonZ
+        GeometryCollectionZ = 1007, //!< GeometryCollectionZ
+        CircularStringZ = 1008, //!< CircularStringZ
+        CompoundCurveZ = 1009, //!< CompoundCurveZ
+        CurvePolygonZ = 1010, //!< CurvePolygonZ
+        MultiCurveZ = 1011, //!< MultiCurveZ
+        MultiSurfaceZ = 1012, //!< MultiSurfaceZ
+        PolyhedralSurfaceZ = 1015, //!< PolyhedralSurfaceZ
+        TINZ = 1016, //!< TINZ
       NurbsCurveZ = 1021, //!< NurbsCurveZ \since QGIS 4.0
-      PointM = 2001, //!< PointM
-      LineStringM = 2002, //!< LineStringM
-      PolygonM = 2003, //!< PolygonM
-      TriangleM = 2017, //!< TriangleM
-      MultiPointM = 2004, //!< MultiPointM
-      MultiLineStringM = 2005, //!< MultiLineStringM
-      MultiPolygonM = 2006, //!< MultiPolygonM
-      GeometryCollectionM = 2007, //!< GeometryCollectionM
-      CircularStringM = 2008, //!< CircularStringM
-      CompoundCurveM = 2009, //!< CompoundCurveM
-      CurvePolygonM = 2010, //!< CurvePolygonM
-      MultiCurveM = 2011, //!< MultiCurveM
-      MultiSurfaceM = 2012, //!< MultiSurfaceM
-      PolyhedralSurfaceM = 2015, //!< PolyhedralSurfaceM
-      TINM = 2016, //!< TINM
+        PointM = 2001, //!< PointM
+        LineStringM = 2002, //!< LineStringM
+        PolygonM = 2003, //!< PolygonM
+        TriangleM = 2017, //!< TriangleM
+        MultiPointM = 2004, //!< MultiPointM
+        MultiLineStringM = 2005, //!< MultiLineStringM
+        MultiPolygonM = 2006, //!< MultiPolygonM
+        GeometryCollectionM = 2007, //!< GeometryCollectionM
+        CircularStringM = 2008, //!< CircularStringM
+        CompoundCurveM = 2009, //!< CompoundCurveM
+        CurvePolygonM = 2010, //!< CurvePolygonM
+        MultiCurveM = 2011, //!< MultiCurveM
+        MultiSurfaceM = 2012, //!< MultiSurfaceM
+        PolyhedralSurfaceM = 2015, //!< PolyhedralSurfaceM
+        TINM = 2016, //!< TINM
       NurbsCurveM = 2021, //!< NurbsCurveM \since QGIS 4.0
-      PointZM = 3001, //!< PointZM
-      LineStringZM = 3002, //!< LineStringZM
-      PolygonZM = 3003, //!< PolygonZM
-      MultiPointZM = 3004, //!< MultiPointZM
-      MultiLineStringZM = 3005, //!< MultiLineStringZM
-      MultiPolygonZM = 3006, //!< MultiPolygonZM
-      GeometryCollectionZM = 3007, //!< GeometryCollectionZM
-      CircularStringZM = 3008, //!< CircularStringZM
-      CompoundCurveZM = 3009, //!< CompoundCurveZM
-      CurvePolygonZM = 3010, //!< CurvePolygonZM
-      MultiCurveZM = 3011, //!< MultiCurveZM
-      MultiSurfaceZM = 3012, //!< MultiSurfaceZM
-      PolyhedralSurfaceZM = 3015, //!< PolyhedralSurfaceM
-      TINZM = 3016, //!< TINZM
-      TriangleZM = 3017, //!< TriangleZM
+        PointZM = 3001, //!< PointZM
+        LineStringZM = 3002, //!< LineStringZM
+        PolygonZM = 3003, //!< PolygonZM
+        MultiPointZM = 3004, //!< MultiPointZM
+        MultiLineStringZM = 3005, //!< MultiLineStringZM
+        MultiPolygonZM = 3006, //!< MultiPolygonZM
+        GeometryCollectionZM = 3007, //!< GeometryCollectionZM
+        CircularStringZM = 3008, //!< CircularStringZM
+        CompoundCurveZM = 3009, //!< CompoundCurveZM
+        CurvePolygonZM = 3010, //!< CurvePolygonZM
+        MultiCurveZM = 3011, //!< MultiCurveZM
+        MultiSurfaceZM = 3012, //!< MultiSurfaceZM
+        PolyhedralSurfaceZM = 3015, //!< PolyhedralSurfaceM
+        TINZM = 3016, //!< TINZM
+        TriangleZM = 3017, //!< TriangleZM
       NurbsCurveZM = 3021, //!< NurbsCurveZM \since QGIS 4.0
-      Point25D = 0x80000001, //!< Point25D
-      LineString25D, //!< LineString25D
-      Polygon25D, //!< Polygon25D
-      MultiPoint25D, //!< MultiPoint25D
-      MultiLineString25D, //!< MultiLineString25D
-      MultiPolygon25D //!< MultiPolygon25D
+        Point25D = 0x80000001, //!< Point25D
+        LineString25D, //!< LineString25D
+        Polygon25D, //!< Polygon25D
+        MultiPoint25D, //!< MultiPoint25D
+        MultiLineString25D, //!< MultiLineString25D
+        MultiPolygon25D //!< MultiPolygon25D
     };
     Q_ENUM( WkbType )
 
@@ -362,12 +373,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class GeometryType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsWkbTypes, GeometryType ) : int
-      {
-      Point SIP_MONKEYPATCH_COMPAT_NAME( PointGeometry ), //!< Points
-      Line SIP_MONKEYPATCH_COMPAT_NAME( LineGeometry ), //!< Lines
-      Polygon SIP_MONKEYPATCH_COMPAT_NAME( PolygonGeometry ), //!< Polygons
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownGeometry ), //!< Unknown types
-      Null SIP_MONKEYPATCH_COMPAT_NAME( NullGeometry ), //!< No geometry
+    {
+        Point SIP_MONKEYPATCH_COMPAT_NAME( PointGeometry ), //!< Points
+              Line SIP_MONKEYPATCH_COMPAT_NAME( LineGeometry ), //!< Lines
+              Polygon SIP_MONKEYPATCH_COMPAT_NAME( PolygonGeometry ), //!< Polygons
+              Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownGeometry ), //!< Unknown types
+              Null SIP_MONKEYPATCH_COMPAT_NAME( NullGeometry ), //!< No geometry
     };
     Q_ENUM( GeometryType )
 
@@ -376,22 +387,22 @@ class CORE_EXPORT Qgis
      * This is modified and extended copy of GDALDataType.
      */
     enum class DataType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( Qgis, DataType ) : int
-      {
-      UnknownDataType = 0, //!< Unknown or unspecified type
-      Byte = 1, //!< Eight bit unsigned integer (quint8)
-      Int8 = 14, //!< Eight bit signed integer (qint8) (added in QGIS 3.30)
-      UInt16 = 2, //!< Sixteen bit unsigned integer (quint16)
-      Int16 = 3, //!< Sixteen bit signed integer (qint16)
-      UInt32 = 4, //!< Thirty two bit unsigned integer (quint32)
-      Int32 = 5, //!< Thirty two bit signed integer (qint32)
-      Float32 = 6, //!< Thirty two bit floating point (float)
-      Float64 = 7, //!< Sixty four bit floating point (double)
-      CInt16 = 8, //!< Complex Int16
-      CInt32 = 9, //!< Complex Int32
-      CFloat32 = 10, //!< Complex Float32
-      CFloat64 = 11, //!< Complex Float64
-      ARGB32 = 12, //!< Color, alpha, red, green, blue, 4 bytes the same as QImage::Format_ARGB32
-      ARGB32_Premultiplied = 13 //!< Color, alpha, red, green, blue, 4 bytes  the same as QImage::Format_ARGB32_Premultiplied
+    {
+        UnknownDataType = 0, //!< Unknown or unspecified type
+        Byte = 1, //!< Eight bit unsigned integer (quint8)
+        Int8 = 14, //!< Eight bit signed integer (qint8) (added in QGIS 3.30)
+        UInt16 = 2, //!< Sixteen bit unsigned integer (quint16)
+        Int16 = 3, //!< Sixteen bit signed integer (qint16)
+        UInt32 = 4, //!< Thirty two bit unsigned integer (quint32)
+        Int32 = 5, //!< Thirty two bit signed integer (qint32)
+        Float32 = 6, //!< Thirty two bit floating point (float)
+        Float64 = 7, //!< Sixty four bit floating point (double)
+        CInt16 = 8, //!< Complex Int16
+        CInt32 = 9, //!< Complex Int32
+        CFloat32 = 10, //!< Complex Float32
+        CFloat64 = 11, //!< Complex Float64
+        ARGB32 = 12, //!< Color, alpha, red, green, blue, 4 bytes the same as QImage::Format_ARGB32
+        ARGB32_Premultiplied = 13 //!< Color, alpha, red, green, blue, 4 bytes  the same as QImage::Format_ARGB32_Premultiplied
     };
     Q_ENUM( DataType )
 
@@ -428,7 +439,7 @@ class CORE_EXPORT Qgis
      */
     enum class VectorLayerTypeFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      SqlQuery = 1 << 0 //!< SQL query layer
+        SqlQuery = 1 << 0 //!< SQL query layer
     };
     Q_ENUM( VectorLayerTypeFlag )
     //! Vector layer type flags
@@ -440,13 +451,13 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class EmbeddedScriptMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( Qgis, PythonMacroMode ) : int
-      {
-      Never = 0,              //!< Embedded scripts never run
-      Ask = 1,                //!< User is prompted before running scripts
-      SessionOnly = 2,        //!< Only during this session (only used prior to QGIS 4.0)
-      Always = 3,             //!< Embedded scripts are always run
-      NotForThisSession = 4,  //!< Embedded scripts will not be run for this session (only used prior to QGIS 4.0)
-      NeverAsk = 5,           //!< The user is never prompted, embedded scripts are only run on trusted projects and folders \since QGIS 4.0
+    {
+        Never = 0,              //!< Embedded scripts never run
+        Ask = 1,                //!< User is prompted before running scripts
+        SessionOnly = 2,        //!< Only during this session (only used prior to QGIS 4.0)
+        Always = 3,             //!< Embedded scripts are always run
+        NotForThisSession = 4,  //!< Embedded scripts will not be run for this session (only used prior to QGIS 4.0)
+        NeverAsk = 5,           //!< The user is never prompted, embedded scripts are only run on trusted projects and folders \since QGIS 4.0
     };
     Q_ENUM( EmbeddedScriptMode )
 
@@ -484,14 +495,14 @@ class CORE_EXPORT Qgis
      */
     enum class DataProviderReadFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDataProvider, ReadFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      TrustDataSource SIP_MONKEYPATCH_COMPAT_NAME( FlagTrustDataSource ) = 1 << 0, //!< Trust datasource config (primary key unicity, geometry type and srid, etc). Improves provider load time by skipping expensive checks like primary key unicity, geometry type and srid and by using estimated metadata on data load \since QGIS 3.16
-      SkipFeatureCount = 1 << 1, //!< Make featureCount() return -1 to indicate unknown, and subLayers() to return a unknown feature count as well. Since QGIS 3.18. Only implemented by OGR provider at time of writing.
-      LoadDefaultStyle SIP_MONKEYPATCH_COMPAT_NAME( FlagLoadDefaultStyle ) = 1 << 2, //!< Reset the layer's style to the default for the datasource
-      SkipGetExtent = 1 << 3, //!< Skip the extent from provider
-      SkipFullScan = 1 << 4, //!< Skip expensive full scan on files (i.e. on delimited text) \since QGIS 3.24
-      ForceReadOnly = 1 << 5, //!< Open layer in a read-only mode \since QGIS 3.28
-      SkipCredentialsRequest =  1 << 6, //!< Skip credentials if the provided one are not valid, let the provider be invalid, avoiding to block the thread creating the provider if it is not the main thread \since QGIS 3.32
-      ParallelThreadLoading = 1 << 7, //!< Provider is created in a parallel thread than the one where it will live \since QGIS 3.32.1
+        TrustDataSource SIP_MONKEYPATCH_COMPAT_NAME( FlagTrustDataSource ) = 1 << 0, //!< Trust datasource config (primary key unicity, geometry type and srid, etc). Improves provider load time by skipping expensive checks like primary key unicity, geometry type and srid and by using estimated metadata on data load \since QGIS 3.16
+        SkipFeatureCount = 1 << 1, //!< Make featureCount() return -1 to indicate unknown, and subLayers() to return a unknown feature count as well. Since QGIS 3.18. Only implemented by OGR provider at time of writing.
+        LoadDefaultStyle SIP_MONKEYPATCH_COMPAT_NAME( FlagLoadDefaultStyle ) = 1 << 2, //!< Reset the layer's style to the default for the datasource
+        SkipGetExtent = 1 << 3, //!< Skip the extent from provider
+        SkipFullScan = 1 << 4, //!< Skip expensive full scan on files (i.e. on delimited text) \since QGIS 3.24
+        ForceReadOnly = 1 << 5, //!< Open layer in a read-only mode \since QGIS 3.28
+        SkipCredentialsRequest =  1 << 6, //!< Skip credentials if the provided one are not valid, let the provider be invalid, avoiding to block the thread creating the provider if it is not the main thread \since QGIS 3.32
+        ParallelThreadLoading = 1 << 7, //!< Provider is created in a parallel thread than the one where it will live \since QGIS 3.32.1
     };
     Q_ENUM( DataProviderReadFlag )
 
@@ -516,32 +527,32 @@ class CORE_EXPORT Qgis
      */
     enum class VectorProviderCapability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorDataProvider, Capability ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoCapabilities = 0, //!< Provider has no capabilities
-      AddFeatures = 1, //!< Allows adding features
-      DeleteFeatures = 1 <<  1, //!< Allows deletion of features
-      ChangeAttributeValues = 1 <<  2, //!< Allows modification of attribute values
-      AddAttributes = 1 <<  3, //!< Allows addition of new attributes (fields)
-      DeleteAttributes = 1 <<  4, //!< Allows deletion of attributes (fields)
-      CreateSpatialIndex = 1 <<  6, //!< Allows creation of spatial index
-      SelectAtId = 1 <<  7, //!< Fast access to features using their ID
-      ChangeGeometries = 1 <<  8, //!< Allows modifications of geometries
-      SelectEncoding = 1 << 13, //!< Allows user to select encoding
-      CreateAttributeIndex = 1 << 12, //!< Can create indexes on provider's fields
-      SimplifyGeometries = 1 << 14, //!< Supports simplification of geometries on provider side according to a distance tolerance
-      SimplifyGeometriesWithTopologicalValidation = 1 << 15, //!< Supports topological simplification of geometries on provider side according to a distance tolerance
-      TransactionSupport = 1 << 16, //!< Supports transactions
-      CircularGeometries = 1 << 17, //!< Supports circular geometry types (circularstring, compoundcurve, curvepolygon)
-      ChangeFeatures = 1 << 18, //!< Supports joint updates for attributes and geometry. Providers supporting this should still define ChangeGeometries | ChangeAttributeValues.
-      RenameAttributes = 1 << 19, //!< Supports renaming attributes (fields) \since QGIS 2.16
-      FastTruncate = 1 << 20, //!< Supports fast truncation of the layer (removing all features) \since QGIS 3.0
-      ReadLayerMetadata = 1 << 21, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
-      WriteLayerMetadata = 1 << 22, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
-      CancelSupport = 1 << 23, //!< Supports interruption of pending queries from a separated thread \since QGIS 3.2
-      CreateRenderer = 1 << 24, //!< Provider can create feature renderers using backend-specific formatting information. Since QGIS 3.2. See QgsVectorDataProvider::createRenderer().
-      CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
-      ReloadData = 1 << 26, //!< Provider is able to force reload data
-      FeatureSymbology = 1 << 27, //!< Provider is able retrieve embedded symbology associated with individual features \since QGIS 3.20
-      EditingCapabilities = AddFeatures | DeleteFeatures | ChangeAttributeValues | ChangeGeometries | AddAttributes | DeleteAttributes | RenameAttributes, //!< Bitmask of all editing capabilities
+        NoCapabilities = 0, //!< Provider has no capabilities
+        AddFeatures = 1, //!< Allows adding features
+        DeleteFeatures = 1 <<  1, //!< Allows deletion of features
+        ChangeAttributeValues = 1 <<  2, //!< Allows modification of attribute values
+        AddAttributes = 1 <<  3, //!< Allows addition of new attributes (fields)
+        DeleteAttributes = 1 <<  4, //!< Allows deletion of attributes (fields)
+        CreateSpatialIndex = 1 <<  6, //!< Allows creation of spatial index
+        SelectAtId = 1 <<  7, //!< Fast access to features using their ID
+        ChangeGeometries = 1 <<  8, //!< Allows modifications of geometries
+        SelectEncoding = 1 << 13, //!< Allows user to select encoding
+        CreateAttributeIndex = 1 << 12, //!< Can create indexes on provider's fields
+        SimplifyGeometries = 1 << 14, //!< Supports simplification of geometries on provider side according to a distance tolerance
+        SimplifyGeometriesWithTopologicalValidation = 1 << 15, //!< Supports topological simplification of geometries on provider side according to a distance tolerance
+        TransactionSupport = 1 << 16, //!< Supports transactions
+        CircularGeometries = 1 << 17, //!< Supports circular geometry types (circularstring, compoundcurve, curvepolygon)
+        ChangeFeatures = 1 << 18, //!< Supports joint updates for attributes and geometry. Providers supporting this should still define ChangeGeometries | ChangeAttributeValues.
+        RenameAttributes = 1 << 19, //!< Supports renaming attributes (fields) \since QGIS 2.16
+        FastTruncate = 1 << 20, //!< Supports fast truncation of the layer (removing all features) \since QGIS 3.0
+        ReadLayerMetadata = 1 << 21, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
+        WriteLayerMetadata = 1 << 22, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
+        CancelSupport = 1 << 23, //!< Supports interruption of pending queries from a separated thread \since QGIS 3.2
+        CreateRenderer = 1 << 24, //!< Provider can create feature renderers using backend-specific formatting information. Since QGIS 3.2. See QgsVectorDataProvider::createRenderer().
+        CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
+        ReloadData = 1 << 26, //!< Provider is able to force reload data
+        FeatureSymbology = 1 << 27, //!< Provider is able retrieve embedded symbology associated with individual features \since QGIS 3.20
+        EditingCapabilities = AddFeatures | DeleteFeatures | ChangeAttributeValues | ChangeGeometries | AddAttributes | DeleteAttributes | RenameAttributes, //!< Bitmask of all editing capabilities
     };
     Q_ENUM( VectorProviderCapability )
 
@@ -561,9 +572,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class FeatureCountState SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorDataProvider, FeatureCountState ) : int
-      {
-      Uncounted = -2, //!< Feature count not yet computed
-      UnknownCount = -1, //!< Provider returned an unknown feature count
+    {
+        Uncounted = -2, //!< Feature count not yet computed
+        UnknownCount = -1, //!< Provider returned an unknown feature count
     };
     Q_ENUM( FeatureCountState )
 
@@ -574,10 +585,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class SpatialIndexPresence SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFeatureSource, SpatialIndexPresence ) : int
-      {
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexUnknown ) = 0, //!< Spatial index presence cannot be determined, index may or may not exist
-      NotPresent SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexNotPresent ) = 1, //!< No spatial index exists for the source
-      Present SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexPresent ) = 2, //!< A valid spatial index exists for the source
+    {
+        Unknown SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexUnknown ) = 0, //!< Spatial index presence cannot be determined, index may or may not exist
+        NotPresent SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexNotPresent ) = 1, //!< No spatial index exists for the source
+        Present SIP_MONKEYPATCH_COMPAT_NAME( SpatialIndexPresent ) = 2, //!< A valid spatial index exists for the source
     };
     Q_ENUM( SpatialIndexPresence )
 
@@ -593,10 +604,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class FeatureAvailability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFeatureSource, FeatureAvailability ) : int
-      {
-      NoFeaturesAvailable = 0, //!< There are certainly no features available in this source
-      FeaturesAvailable, //!< There is at least one feature available in this source
-      FeaturesMaybeAvailable //!< There may be features available in this source
+    {
+        NoFeaturesAvailable = 0, //!< There are certainly no features available in this source
+        FeaturesAvailable, //!< There is at least one feature available in this source
+        FeaturesMaybeAvailable //!< There may be features available in this source
     };
     Q_ENUM( FeatureAvailability )
 
@@ -607,8 +618,8 @@ class CORE_EXPORT Qgis
      */
     enum class VectorDataProviderAttributeEditCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      EditAlias = 1 << 0, //!< Allows editing aliases
-      EditComment = 1 << 1, //!< Allows editing comments
+        EditAlias = 1 << 0, //!< Allows editing aliases
+        EditComment = 1 << 1, //!< Allows editing comments
     };
 
     Q_ENUM( VectorDataProviderAttributeEditCapability )
@@ -626,11 +637,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class SymbolType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbol, SymbolType ) : int
-      {
-      Marker, //!< Marker symbol
-      Line, //!< Line symbol
-      Fill, //!< Fill symbol
-      Hybrid //!< Hybrid symbol
+    {
+        Marker, //!< Marker symbol
+        Line, //!< Line symbol
+        Fill, //!< Fill symbol
+        Hybrid //!< Hybrid symbol
     };
     Q_ENUM( SymbolType )
 
@@ -640,9 +651,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class ScaleMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbol, ScaleMethod ) : int
-      {
-      ScaleArea,     //!< Calculate scale by the area
-      ScaleDiameter  //!< Calculate scale by the diameter
+    {
+        ScaleArea,     //!< Calculate scale by the area
+        ScaleDiameter  //!< Calculate scale by the diameter
     };
     Q_ENUM( ScaleMethod )
 
@@ -651,17 +662,17 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class SettingsType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSettingsEntryBase, SettingsType ) : int
-      {
-      Custom, //!< Custom implementation
-      Variant, //!< Generic variant
-      String, //!< String
-      StringList, //!< List of strings
-      VariantMap, //!< Map of strings
-      Bool, //!< Boolean
-      Integer, //!< Integer
-      Double, //!< Double precision number
-      EnumFlag, //!< Enum or Flag
-      Color //!< Color
+    {
+        Custom, //!< Custom implementation
+        Variant, //!< Generic variant
+        String, //!< String
+        StringList, //!< List of strings
+        VariantMap, //!< Map of strings
+        Bool, //!< Boolean
+        Integer, //!< Integer
+        Double, //!< Double precision number
+        EnumFlag, //!< Enum or Flag
+        Color //!< Color
     };
     Q_ENUM( SettingsType )
 
@@ -683,7 +694,7 @@ class CORE_EXPORT Qgis
      */
     enum class SettingsTreeNodeOption : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NamedListSelectedItemSetting = 1 << 0, //!< Creates a setting to store which is the current item
+        NamedListSelectedItemSetting = 1 << 0, //!< Creates a setting to store which is the current item
     };
 
     Q_ENUM( SettingsTreeNodeOption )
@@ -698,11 +709,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class PropertyType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProperty, Type ): int
-      {
-      Invalid SIP_MONKEYPATCH_COMPAT_NAME( InvalidProperty ), //!< Invalid (not set) property
-      Static SIP_MONKEYPATCH_COMPAT_NAME( StaticProperty ), //!< Static property
-      Field SIP_MONKEYPATCH_COMPAT_NAME( FieldBasedProperty ), //!< Field based property
-      Expression SIP_MONKEYPATCH_COMPAT_NAME( ExpressionBasedProperty ), //!< Expression based property
+    {
+        Invalid SIP_MONKEYPATCH_COMPAT_NAME( InvalidProperty ), //!< Invalid (not set) property
+                Static SIP_MONKEYPATCH_COMPAT_NAME( StaticProperty ), //!< Static property
+                Field SIP_MONKEYPATCH_COMPAT_NAME( FieldBasedProperty ), //!< Field based property
+                Expression SIP_MONKEYPATCH_COMPAT_NAME( ExpressionBasedProperty ), //!< Expression based property
     };
     Q_ENUM( PropertyType )
 
@@ -713,9 +724,9 @@ class CORE_EXPORT Qgis
      */
     enum class SldExportOption : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoOptions = 0,                      //!< Default SLD export
-      Svg = 1 << 0,                       //!< Export complex styles to separate SVG files for better compatibility with OGC servers
-      Png = 1 << 1,                       //!< Export complex styles to separate PNG files for better compatibility with OGC servers
+        NoOptions = 0,                      //!< Default SLD export
+        Svg = 1 << 0,                       //!< Export complex styles to separate SVG files for better compatibility with OGC servers
+        Png = 1 << 1,                       //!< Export complex styles to separate PNG files for better compatibility with OGC servers
     };
     Q_ENUM( SldExportOption )
     Q_DECLARE_FLAGS( SldExportOptions, SldExportOption )
@@ -728,9 +739,9 @@ class CORE_EXPORT Qgis
      */
     enum class SldExportVendorExtension : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoVendorExtension = 0,             //!< No vendor extensions
-      GeoServerVendorExtension = 1 << 1, //!< Use GeoServer vendor extensions when required
-      DeegreeVendorExtension = 1 << 2,   //!< Use Deegree vendor extensions when required
+        NoVendorExtension = 0,             //!< No vendor extensions
+        GeoServerVendorExtension = 1 << 1, //!< Use GeoServer vendor extensions when required
+        DeegreeVendorExtension = 1 << 2,   //!< Use Deegree vendor extensions when required
     };
     Q_ENUM( SldExportVendorExtension )
 
@@ -741,8 +752,8 @@ class CORE_EXPORT Qgis
      */
     enum class SettingsOption : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      SaveFormerValue = 1 << 1, //!< Save the former value of the settings
-      SaveEnumFlagAsInt = 1 << 2, //!< The enum/flag will be saved as an integer value instead of text
+        SaveFormerValue = 1 << 1, //!< Save the former value of the settings
+        SaveEnumFlagAsInt = 1 << 2, //!< The enum/flag will be saved as an integer value instead of text
     };
     Q_ENUM( SettingsOption )
     Q_DECLARE_FLAGS( SettingsOptions, SettingsOption )
@@ -753,10 +764,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class SnappingMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSnappingConfig, SnappingMode ) : int
-      {
-      ActiveLayer = 1, //!< On the active layer
-      AllLayers = 2, //!< On all vector layers
-      AdvancedConfiguration = 3, //!< On a per layer configuration basis
+    {
+        ActiveLayer = 1, //!< On the active layer
+        AllLayers = 2, //!< On all vector layers
+        AdvancedConfiguration = 3, //!< On a per layer configuration basis
     };
     Q_ENUM( SnappingMode )
 
@@ -766,13 +777,13 @@ class CORE_EXPORT Qgis
      */
     enum class SnappingType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSnappingConfig, SnappingTypes ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoSnap SIP_MONKEYPATCH_COMPAT_NAME( NoSnapFlag ) = 0, //!< No snapping
-      Vertex SIP_MONKEYPATCH_COMPAT_NAME( VertexFlag ) = 1 << 0, //!< On vertices
-      Segment SIP_MONKEYPATCH_COMPAT_NAME( SegmentFlag ) = 1 << 1, //!< On segments
-      Area SIP_MONKEYPATCH_COMPAT_NAME( AreaFlag ) = 1 << 2, //!< On Area
-      Centroid SIP_MONKEYPATCH_COMPAT_NAME( CentroidFlag ) = 1 << 3, //!< On centroid
-      MiddleOfSegment SIP_MONKEYPATCH_COMPAT_NAME( MiddleOfSegmentFlag ) = 1 << 4, //!< On Middle segment
-      LineEndpoint SIP_MONKEYPATCH_COMPAT_NAME( LineEndpointFlag ) = 1 << 5, //!< Start or end points of lines, or first vertex in polygon rings only \since QGIS 3.20
+        NoSnap SIP_MONKEYPATCH_COMPAT_NAME( NoSnapFlag ) = 0, //!< No snapping
+        Vertex SIP_MONKEYPATCH_COMPAT_NAME( VertexFlag ) = 1 << 0, //!< On vertices
+        Segment SIP_MONKEYPATCH_COMPAT_NAME( SegmentFlag ) = 1 << 1, //!< On segments
+        Area SIP_MONKEYPATCH_COMPAT_NAME( AreaFlag ) = 1 << 2, //!< On Area
+        Centroid SIP_MONKEYPATCH_COMPAT_NAME( CentroidFlag ) = 1 << 3, //!< On centroid
+        MiddleOfSegment SIP_MONKEYPATCH_COMPAT_NAME( MiddleOfSegmentFlag ) = 1 << 4, //!< On Middle segment
+        LineEndpoint SIP_MONKEYPATCH_COMPAT_NAME( LineEndpointFlag ) = 1 << 5, //!< Start or end points of lines, or first vertex in polygon rings only \since QGIS 3.20
     };
     Q_ENUM( SnappingType )
     //! Snapping types
@@ -786,10 +797,10 @@ class CORE_EXPORT Qgis
      */
     enum class SymbolRenderHint SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbol, RenderHint ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      DynamicRotation = 1 << 1, //!< Rotation of symbol may be changed during rendering and symbol should not be cached
-      IsSymbolLayerSubSymbol = 1 << 2, //!< Symbol is being rendered as a sub-symbol of a QgsSymbolLayer \since QGIS 3.38
-      ForceVectorRendering = 1 << 3, //!< Symbol must be rendered using vector methods, and optimisations like pre-rendered images must be disabled \since QGIS 3.40
-      ExcludeSymbolBuffers = 1 << 4, //!< Do not render symbol buffers. \since QGIS 3.40
+        DynamicRotation = 1 << 1, //!< Rotation of symbol may be changed during rendering and symbol should not be cached
+        IsSymbolLayerSubSymbol = 1 << 2, //!< Symbol is being rendered as a sub-symbol of a QgsSymbolLayer \since QGIS 3.38
+        ForceVectorRendering = 1 << 3, //!< Symbol must be rendered using vector methods, and optimisations like pre-rendered images must be disabled \since QGIS 3.40
+        ExcludeSymbolBuffers = 1 << 4, //!< Do not render symbol buffers. \since QGIS 3.40
     };
     Q_ENUM( SymbolRenderHint )
     //! Symbol render hints
@@ -816,10 +827,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.44
      */
     enum class HorizontalAnchorPoint SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMarkerSymbolLayer, HorizontalAnchorPoint ) : int
-      {
-      Left, //!< Align to left side of symbol
-      Center SIP_MONKEYPATCH_COMPAT_NAME( HCenter ), //!< Align to horizontal center of symbol
-      Right, //!< Align to right side of symbol
+    {
+        Left, //!< Align to left side of symbol
+        Center SIP_MONKEYPATCH_COMPAT_NAME( HCenter ), //!< Align to horizontal center of symbol
+        Right, //!< Align to right side of symbol
     };
     Q_ENUM( HorizontalAnchorPoint )
 
@@ -830,11 +841,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.44
      */
     enum class VerticalAnchorPoint SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMarkerSymbolLayer, VerticalAnchorPoint ) : int
-      {
-      Top, //!< Align to top of symbol
-      Center SIP_MONKEYPATCH_COMPAT_NAME( VCenter ), //!< Align to vertical center of symbol
-      Bottom, //!< Align to bottom of symbol
-      Baseline, //!< Align to baseline of symbol, e.g. font baseline for font marker symbol layers. Treated as Bottom if no baseline is available for the symbol layer type. \since QGIS 3.44
+    {
+        Top, //!< Align to top of symbol
+        Center SIP_MONKEYPATCH_COMPAT_NAME( VCenter ), //!< Align to vertical center of symbol
+        Bottom, //!< Align to bottom of symbol
+        Baseline, //!< Align to baseline of symbol, e.g. font baseline for font marker symbol layers. Treated as Bottom if no baseline is available for the symbol layer type. \since QGIS 3.44
     };
     Q_ENUM( VerticalAnchorPoint )
 
@@ -845,7 +856,7 @@ class CORE_EXPORT Qgis
      */
     enum class FeatureRendererFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      AffectsLabeling = 1 << 0, //!< If present, indicates that the renderer will participate in the map labeling problem
+        AffectsLabeling = 1 << 0, //!< If present, indicates that the renderer will participate in the map labeling problem
     };
     Q_ENUM( FeatureRendererFlag )
 
@@ -864,8 +875,8 @@ class CORE_EXPORT Qgis
      */
     enum class SymbolFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      RendererShouldUseSymbolLevels = 1 << 0, //!< If present, indicates that a QgsFeatureRenderer using the symbol should use symbol levels for best results
-      AffectsLabeling = 1 << 1, //!< If present, indicates that the symbol will participate in the map labeling problem \since QGIS 3.40
+        RendererShouldUseSymbolLevels = 1 << 0, //!< If present, indicates that a QgsFeatureRenderer using the symbol should use symbol levels for best results
+        AffectsLabeling = 1 << 1, //!< If present, indicates that the symbol will participate in the map labeling problem \since QGIS 3.40
     };
     Q_ENUM( SymbolFlag )
     //! Symbol flags
@@ -879,7 +890,7 @@ class CORE_EXPORT Qgis
      */
     enum class SymbolPreviewFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbol, PreviewFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      FlagIncludeCrosshairsForMarkerSymbols = 1 << 0, //!< Include a crosshairs reference image in the background of marker symbol previews
+        FlagIncludeCrosshairsForMarkerSymbols = 1 << 0, //!< Include a crosshairs reference image in the background of marker symbol previews
     };
     Q_ENUM( SymbolPreviewFlag )
     //! Symbol preview flags
@@ -897,9 +908,9 @@ class CORE_EXPORT Qgis
      */
     enum class SymbolLayerFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      DisableFeatureClipping = 1 << 0, //!< If present, indicates that features should never be clipped to the map extent during rendering
-      CanCalculateMaskGeometryPerFeature = 1 << 1, //!< If present, indicates that mask geometry can safely be calculated per feature for the symbol layer. This avoids using the entire symbol layer's mask geometry for every feature rendered, considerably simplifying vector exports and resulting in much smaller file sizes. \since QGIS 3.38
-      AffectsLabeling = 1 << 2, //!< If present, indicates that the symbol layer will participate in the map labeling problem \since QGIS 3.40
+        DisableFeatureClipping = 1 << 0, //!< If present, indicates that features should never be clipped to the map extent during rendering
+        CanCalculateMaskGeometryPerFeature = 1 << 1, //!< If present, indicates that mask geometry can safely be calculated per feature for the symbol layer. This avoids using the entire symbol layer's mask geometry for every feature rendered, considerably simplifying vector exports and resulting in much smaller file sizes. \since QGIS 3.38
+        AffectsLabeling = 1 << 2, //!< If present, indicates that the symbol layer will participate in the map labeling problem \since QGIS 3.40
     };
     Q_ENUM( SymbolLayerFlag )
     //! Symbol layer flags
@@ -917,7 +928,7 @@ class CORE_EXPORT Qgis
      */
     enum class SymbolLayerUserFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      DisableSelectionRecoloring = 1 << 0, //!< If present, indicates that the symbol layer should not be recolored when rendering selected features
+        DisableSelectionRecoloring = 1 << 0, //!< If present, indicates that the symbol layer should not be recolored when rendering selected features
     };
     Q_ENUM( SymbolLayerUserFlag )
 
@@ -935,16 +946,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class BrowserItemType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDataItem, Type ) : int
-      {
-      Collection, //!< A collection of items
-      Directory, //!< Represents a file directory
-      Layer, //!< Represents a map layer
-      Error, //!< Contains an error message
-      Favorites, //!< Represents a favorite item
-      Project, //!< Represents a QGIS project
-      Custom, //!< Custom item type
-      Fields, //!< Collection of fields
-      Field, //!< Vector layer field
+    {
+        Collection, //!< A collection of items
+        Directory, //!< Represents a file directory
+        Layer, //!< Represents a map layer
+        Error, //!< Contains an error message
+        Favorites, //!< Represents a favorite item
+        Project, //!< Represents a QGIS project
+        Custom, //!< Custom item type
+        Fields, //!< Collection of fields
+        Field, //!< Vector layer field
     };
     Q_ENUM( BrowserItemType )
 
@@ -954,10 +965,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class BrowserItemState SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDataItem, State ) : int
-      {
-      NotPopulated, //!< Children not yet created
-      Populating, //!< Creating children in separate thread (populating or refreshing)
-      Populated, //!< Children created
+    {
+        NotPopulated, //!< Children not yet created
+        Populating, //!< Creating children in separate thread (populating or refreshing)
+        Populated, //!< Children created
     };
     Q_ENUM( BrowserItemState )
 
@@ -968,16 +979,16 @@ class CORE_EXPORT Qgis
      */
     enum class BrowserItemCapability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDataItem, Capability ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoCapabilities = 0, //!< Item has no capabilities
-      SetCrs = 1 << 0, //!< Can set CRS on layer or group of layers. deprecated since QGIS 3.6 -- no longer used by QGIS and will be removed in QGIS 5.0
-      Fertile = 1 << 1, //!< Can create children. Even items without this capability may have children, but cannot create them, it means that children are created by item ancestors.
-      Fast = 1 << 2, //!< CreateChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QgsSettings
-      Collapse = 1 << 3, //!< The collapse/expand status for this items children should be ignored in order to avoid undesired network connections (wms etc.)
-      Rename = 1 << 4, //!< Item can be renamed
-      Delete = 1 << 5, //!< Item can be deleted
-      ItemRepresentsFile = 1 << 6, //!< Item's path() directly represents a file on disk \since QGIS 3.22
-      RefreshChildrenWhenItemIsRefreshed = 1 << 7, //!< When the item is refreshed, all its populated children will also be refreshed in turn \since QGIS 3.26
-      ReadOnly = 1 << 8, //!< Item is read only \since QGIS 3.40
+        NoCapabilities = 0, //!< Item has no capabilities
+        SetCrs = 1 << 0, //!< Can set CRS on layer or group of layers. deprecated since QGIS 3.6 -- no longer used by QGIS and will be removed in QGIS 5.0
+        Fertile = 1 << 1, //!< Can create children. Even items without this capability may have children, but cannot create them, it means that children are created by item ancestors.
+        Fast = 1 << 2, //!< CreateChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QgsSettings
+        Collapse = 1 << 3, //!< The collapse/expand status for this items children should be ignored in order to avoid undesired network connections (wms etc.)
+        Rename = 1 << 4, //!< Item can be renamed
+        Delete = 1 << 5, //!< Item can be deleted
+        ItemRepresentsFile = 1 << 6, //!< Item's path() directly represents a file on disk \since QGIS 3.22
+        RefreshChildrenWhenItemIsRefreshed = 1 << 7, //!< When the item is refreshed, all its populated children will also be refreshed in turn \since QGIS 3.26
+        ReadOnly = 1 << 8, //!< Item is read only \since QGIS 3.40
     };
     Q_ENUM( BrowserItemCapability )
     //! Browser item capabilities
@@ -993,11 +1004,11 @@ class CORE_EXPORT Qgis
      */
     enum class DataItemProviderCapability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDataProvider, DataCapability ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoCapabilities SIP_MONKEYPATCH_COMPAT_NAME( NoDataCapabilities ) = 0, //!< No capabilities
-      Files SIP_MONKEYPATCH_COMPAT_NAME( File ) = 1, //!< Can provides items which corresponds to files
-      Directories SIP_MONKEYPATCH_COMPAT_NAME( Dir ) = 1 << 1, //!< Can provides items which corresponds to directories
-      Databases SIP_MONKEYPATCH_COMPAT_NAME( Database ) = 1 << 2, //!< Can provides items which corresponds to databases
-      NetworkSources SIP_MONKEYPATCH_COMPAT_NAME( Net ) = 1 << 3, //!< Network/internet source
+        NoCapabilities SIP_MONKEYPATCH_COMPAT_NAME( NoDataCapabilities ) = 0, //!< No capabilities
+        Files SIP_MONKEYPATCH_COMPAT_NAME( File ) = 1, //!< Can provides items which corresponds to files
+        Directories SIP_MONKEYPATCH_COMPAT_NAME( Dir ) = 1 << 1, //!< Can provides items which corresponds to directories
+        Databases SIP_MONKEYPATCH_COMPAT_NAME( Database ) = 1 << 2, //!< Can provides items which corresponds to databases
+        NetworkSources SIP_MONKEYPATCH_COMPAT_NAME( Net ) = 1 << 3, //!< Network/internet source
     };
     Q_ENUM( DataItemProviderCapability )
 
@@ -1017,21 +1028,21 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class BrowserLayerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayerItem, LayerType ) : int
-      {
-      NoType, //!< No type
-      Vector, //!< Generic vector layer
-      Raster, //!< Raster layer
-      Point, //!< Vector point layer
-      Line, //!< Vector line layer
-      Polygon, //!< Vector polygon layer
-      TableLayer, //!< Vector non-spatial layer
-      Database, //!< Database layer
-      Table, //!< Database table
-      Plugin, //!< Plugin based layer
-      Mesh, //!< Mesh layer
-      VectorTile, //!< Vector tile layer
-      PointCloud, //!< Point cloud layer
-      TiledScene, //!< Tiled scene layer \since QGIS 3.34
+    {
+        NoType, //!< No type
+        Vector, //!< Generic vector layer
+        Raster, //!< Raster layer
+        Point, //!< Vector point layer
+        Line, //!< Vector line layer
+        Polygon, //!< Vector polygon layer
+        TableLayer, //!< Vector non-spatial layer
+        Database, //!< Database layer
+        Table, //!< Database table
+        Plugin, //!< Plugin based layer
+        Mesh, //!< Mesh layer
+        VectorTile, //!< Vector tile layer
+        PointCloud, //!< Point cloud layer
+        TiledScene, //!< Tiled scene layer \since QGIS 3.34
     };
     Q_ENUM( BrowserLayerType )
 
@@ -1068,19 +1079,19 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.20
      */
     enum class VectorExportResult SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorLayerExporter, ExportError ) : int
-      {
-      Success SIP_MONKEYPATCH_COMPAT_NAME( NoError ) = 0, //!< No errors were encountered
-      ErrorCreatingDataSource SIP_MONKEYPATCH_COMPAT_NAME( ErrCreateDataSource ), //!< Could not create the destination data source
-      ErrorCreatingLayer SIP_MONKEYPATCH_COMPAT_NAME( ErrCreateLayer ), //!< Could not create destination layer
-      ErrorAttributeTypeUnsupported SIP_MONKEYPATCH_COMPAT_NAME( ErrAttributeTypeUnsupported ), //!< Source layer has an attribute type which could not be handled by destination
-      ErrorAttributeCreationFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrAttributeCreationFailed ), //!< Destination provider was unable to create an attribute
-      ErrorProjectingFeatures SIP_MONKEYPATCH_COMPAT_NAME( ErrProjection ), //!< An error occurred while reprojecting features to destination CRS
-      ErrorFeatureWriteFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrFeatureWriteFailed ), //!< An error occurred while writing a feature to the destination
-      ErrorInvalidLayer SIP_MONKEYPATCH_COMPAT_NAME( ErrInvalidLayer ), //!< Could not access newly created destination layer
-      ErrorInvalidProvider SIP_MONKEYPATCH_COMPAT_NAME( ErrInvalidProvider ), //!< Could not find a matching provider key
-      ErrorProviderUnsupportedFeature SIP_MONKEYPATCH_COMPAT_NAME( ErrProviderUnsupportedFeature ), //!< Provider does not support creation of empty layers
-      ErrorConnectionFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrConnectionFailed ), //!< Could not connect to destination
-      UserCanceled SIP_MONKEYPATCH_COMPAT_NAME( ErrUserCanceled ), //!< User canceled the export
+    {
+        Success SIP_MONKEYPATCH_COMPAT_NAME( NoError ) = 0, //!< No errors were encountered
+        ErrorCreatingDataSource SIP_MONKEYPATCH_COMPAT_NAME( ErrCreateDataSource ), //!< Could not create the destination data source
+        ErrorCreatingLayer SIP_MONKEYPATCH_COMPAT_NAME( ErrCreateLayer ), //!< Could not create destination layer
+        ErrorAttributeTypeUnsupported SIP_MONKEYPATCH_COMPAT_NAME( ErrAttributeTypeUnsupported ), //!< Source layer has an attribute type which could not be handled by destination
+        ErrorAttributeCreationFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrAttributeCreationFailed ), //!< Destination provider was unable to create an attribute
+        ErrorProjectingFeatures SIP_MONKEYPATCH_COMPAT_NAME( ErrProjection ), //!< An error occurred while reprojecting features to destination CRS
+        ErrorFeatureWriteFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrFeatureWriteFailed ), //!< An error occurred while writing a feature to the destination
+        ErrorInvalidLayer SIP_MONKEYPATCH_COMPAT_NAME( ErrInvalidLayer ), //!< Could not access newly created destination layer
+        ErrorInvalidProvider SIP_MONKEYPATCH_COMPAT_NAME( ErrInvalidProvider ), //!< Could not find a matching provider key
+        ErrorProviderUnsupportedFeature SIP_MONKEYPATCH_COMPAT_NAME( ErrProviderUnsupportedFeature ), //!< Provider does not support creation of empty layers
+        ErrorConnectionFailed SIP_MONKEYPATCH_COMPAT_NAME( ErrConnectionFailed ), //!< Could not connect to destination
+        UserCanceled SIP_MONKEYPATCH_COMPAT_NAME( ErrUserCanceled ), //!< User canceled the export
     };
     Q_ENUM( VectorExportResult )
 
@@ -1090,8 +1101,8 @@ class CORE_EXPORT Qgis
      */
     enum class VectorFileWriterCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      FieldAliases = 1 << 0, //!< Writer can support field aliases
-      FieldComments = 1 << 2, //!< Writer can support field comments
+        FieldAliases = 1 << 0, //!< Writer can support field aliases
+        FieldComments = 1 << 2, //!< Writer can support field comments
     };
     Q_ENUM( VectorFileWriterCapability )
 
@@ -1108,10 +1119,10 @@ class CORE_EXPORT Qgis
      */
     enum class SqlLayerDefinitionCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      SubsetStringFilter = 1 << 1,  //!< SQL layer definition supports subset string filter
-      GeometryColumn = 1 << 2,      //!< SQL layer definition supports geometry column
-      PrimaryKeys = 1 << 3,         //!< SQL layer definition supports primary keys
-      UnstableFeatureIds = 1 << 4   //!< SQL layer definition supports disabling select at id
+        SubsetStringFilter = 1 << 1,  //!< SQL layer definition supports subset string filter
+        GeometryColumn = 1 << 2,      //!< SQL layer definition supports geometry column
+        PrimaryKeys = 1 << 3,         //!< SQL layer definition supports primary keys
+        UnstableFeatureIds = 1 << 4   //!< SQL layer definition supports disabling select at id
     };
     Q_ENUM( SqlLayerDefinitionCapability )
     //! SQL layer definition capabilities
@@ -1159,9 +1170,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class ActionStart SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsNetworkContentFetcherRegistry, FetchingMode ) : int
-      {
-      Deferred SIP_MONKEYPATCH_COMPAT_NAME( DownloadLater ), //!< Do not start immediately the action
-      Immediate SIP_MONKEYPATCH_COMPAT_NAME( DownloadImmediately ), //!< Action will start immediately
+    {
+        Deferred SIP_MONKEYPATCH_COMPAT_NAME( DownloadLater ), //!< Do not start immediately the action
+                 Immediate SIP_MONKEYPATCH_COMPAT_NAME( DownloadImmediately ), //!< Action will start immediately
     };
     Q_ENUM( ActionStart )
 
@@ -1222,16 +1233,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class LabelPlacement SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, Placement ) : int
-      {
-      AroundPoint, //!< Arranges candidates in a circle around a point (or centroid of a polygon). Applies to point or polygon layers only.
-      OverPoint, //!< Arranges candidates over a point (or centroid of a polygon), or at a preset offset from the point. Applies to point or polygon layers only.
-      Line, //!< Arranges candidates parallel to a generalised line representing the feature or parallel to a polygon's perimeter. Applies to line or polygon layers only.
-      Curved, //!< Arranges candidates following the curvature of a line feature. Applies to line layers only.
-      Horizontal, //!< Arranges horizontal candidates scattered throughout a polygon feature. Applies to polygon layers only.
-      Free, //!< Arranges candidates scattered throughout a polygon feature. Candidates are rotated to respect the polygon's orientation. Applies to polygon layers only.
-      OrderedPositionsAroundPoint, //!< Candidates are placed in predefined positions around a point. Preference is given to positions with greatest cartographic appeal, e.g., top right, bottom right, etc. Applies to point layers only.
-      PerimeterCurved, //!< Arranges candidates following the curvature of a polygon's boundary. Applies to polygon layers only.
-      OutsidePolygons, //!< Candidates are placed outside of polygon boundaries. Applies to polygon layers only \since QGIS 3.14
+    {
+        AroundPoint, //!< Arranges candidates in a circle around a point (or centroid of a polygon). Applies to point or polygon layers only.
+        OverPoint, //!< Arranges candidates over a point (or centroid of a polygon), or at a preset offset from the point. Applies to point or polygon layers only.
+        Line, //!< Arranges candidates parallel to a generalised line representing the feature or parallel to a polygon's perimeter. Applies to line or polygon layers only.
+        Curved, //!< Arranges candidates following the curvature of a line feature. Applies to line layers only.
+        Horizontal, //!< Arranges horizontal candidates scattered throughout a polygon feature. Applies to polygon layers only.
+        Free, //!< Arranges candidates scattered throughout a polygon feature. Candidates are rotated to respect the polygon's orientation. Applies to polygon layers only.
+        OrderedPositionsAroundPoint, //!< Candidates are placed in predefined positions around a point. Preference is given to positions with greatest cartographic appeal, e.g., top right, bottom right, etc. Applies to point layers only.
+        PerimeterCurved, //!< Arranges candidates following the curvature of a polygon's boundary. Applies to polygon layers only.
+        OutsidePolygons, //!< Candidates are placed outside of polygon boundaries. Applies to polygon layers only \since QGIS 3.14
     };
     Q_ENUM( LabelPlacement )
 
@@ -1257,20 +1268,20 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class LabelPredefinedPointPosition SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, PredefinedPointPosition ) : int
-      {
-      TopLeft, //!< Label on top-left of point
-      TopSlightlyLeft, //!< Label on top of point, slightly left of center
-      TopMiddle, //!< Label directly above point
-      TopSlightlyRight, //!< Label on top of point, slightly right of center
-      TopRight, //!< Label on top-right of point
-      MiddleLeft, //!< Label on left of point
-      MiddleRight, //!< Label on right of point
-      BottomLeft, //!< Label on bottom-left of point
-      BottomSlightlyLeft, //!< Label below point, slightly left of center
-      BottomMiddle, //!< Label directly below point
-      BottomSlightlyRight, //!< Label below point, slightly right of center
-      BottomRight, //!< Label on bottom right of point
-      OverPoint, //!< Label directly centered over point \since QGIS 3.38
+    {
+        TopLeft, //!< Label on top-left of point
+        TopSlightlyLeft, //!< Label on top of point, slightly left of center
+        TopMiddle, //!< Label directly above point
+        TopSlightlyRight, //!< Label on top of point, slightly right of center
+        TopRight, //!< Label on top-right of point
+        MiddleLeft, //!< Label on left of point
+        MiddleRight, //!< Label on right of point
+        BottomLeft, //!< Label on bottom-left of point
+        BottomSlightlyLeft, //!< Label below point, slightly left of center
+        BottomMiddle, //!< Label directly below point
+        BottomSlightlyRight, //!< Label below point, slightly right of center
+        BottomRight, //!< Label on bottom right of point
+        OverPoint, //!< Label directly centered over point \since QGIS 3.38
     };
     Q_ENUM( LabelPredefinedPointPosition )
 
@@ -1296,9 +1307,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class LabelOffsetType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, OffsetType ) : int
-      {
-      FromPoint, //!< Offset distance applies from point geometry
-      FromSymbolBounds, //!< Offset distance applies from rendered symbol bounds
+    {
+        FromPoint, //!< Offset distance applies from point geometry
+        FromSymbolBounds, //!< Offset distance applies from rendered symbol bounds
     };
     Q_ENUM( LabelOffsetType )
 
@@ -1310,16 +1321,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class LabelQuadrantPosition SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, QuadrantPosition ) : int
-      {
-      AboveLeft SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAboveLeft ), //!< Above left
-      Above SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAbove ), //!< Above center
-      AboveRight SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAboveRight ), //!< Above right
-      Left SIP_MONKEYPATCH_COMPAT_NAME( QuadrantLeft ), //!< Left middle
-      Over SIP_MONKEYPATCH_COMPAT_NAME( QuadrantOver ), //!< Center middle
-      Right SIP_MONKEYPATCH_COMPAT_NAME( QuadrantRight ), //!< Right middle
-      BelowLeft SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelowLeft ), //!< Below left
-      Below SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelow ), //!< Below center
-      BelowRight SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelowRight ), //!< Below right
+    {
+        AboveLeft SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAboveLeft ), //!< Above left
+                  Above SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAbove ), //!< Above center
+                  AboveRight SIP_MONKEYPATCH_COMPAT_NAME( QuadrantAboveRight ), //!< Above right
+                  Left SIP_MONKEYPATCH_COMPAT_NAME( QuadrantLeft ), //!< Left middle
+                  Over SIP_MONKEYPATCH_COMPAT_NAME( QuadrantOver ), //!< Center middle
+                  Right SIP_MONKEYPATCH_COMPAT_NAME( QuadrantRight ), //!< Right middle
+                  BelowLeft SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelowLeft ), //!< Below left
+                  Below SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelow ), //!< Below center
+                  BelowRight SIP_MONKEYPATCH_COMPAT_NAME( QuadrantBelowRight ), //!< Below right
     };
     Q_ENUM( LabelQuadrantPosition )
 
@@ -1331,10 +1342,10 @@ class CORE_EXPORT Qgis
      */
     enum class LabelLinePlacementFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLabeling, LinePlacementFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      OnLine = 1, //!< Labels can be placed directly over a line feature.
-      AboveLine = 2, //!< Labels can be placed above a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed below the line feature.
-      BelowLine = 4, //!< Labels can be placed below a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed above the line feature.
-      MapOrientation = 8, //!< Signifies that the AboveLine and BelowLine flags should respect the map's orientation rather than the feature's orientation. For example, AboveLine will always result in label's being placed above a line, regardless of the line's direction.
+        OnLine = 1, //!< Labels can be placed directly over a line feature.
+        AboveLine = 2, //!< Labels can be placed above a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed below the line feature.
+        BelowLine = 4, //!< Labels can be placed below a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed above the line feature.
+        MapOrientation = 8, //!< Signifies that the AboveLine and BelowLine flags should respect the map's orientation rather than the feature's orientation. For example, AboveLine will always result in label's being placed above a line, regardless of the line's direction.
     };
     Q_ENUM( LabelLinePlacementFlag )
 
@@ -1356,8 +1367,8 @@ class CORE_EXPORT Qgis
      */
     enum class LabelPolygonPlacementFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLabeling, PolygonPlacementFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      AllowPlacementOutsideOfPolygon = 1 << 0, //!< Labels can be placed outside of a polygon feature
-      AllowPlacementInsideOfPolygon = 1 << 1, //!< Labels can be placed inside a polygon feature
+        AllowPlacementOutsideOfPolygon = 1 << 0, //!< Labels can be placed outside of a polygon feature
+        AllowPlacementInsideOfPolygon = 1 << 1, //!< Labels can be placed inside a polygon feature
     };
     Q_ENUM( LabelPolygonPlacementFlag )
 
@@ -1378,10 +1389,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class UpsideDownLabelHandling SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, UpsideDownLabels ) : int
-      {
-      FlipUpsideDownLabels SIP_MONKEYPATCH_COMPAT_NAME( Upright ), //!< Upside-down labels (90 <= angle < 270) are shown upright
-      AllowUpsideDownWhenRotationIsDefined SIP_MONKEYPATCH_COMPAT_NAME( ShowDefined ), //!< Show upside down when rotation is layer- or data-defined
-      AlwaysAllowUpsideDown SIP_MONKEYPATCH_COMPAT_NAME( ShowAll ) //!< Show upside down for all labels, including dynamic ones
+    {
+        FlipUpsideDownLabels SIP_MONKEYPATCH_COMPAT_NAME( Upright ), //!< Upside-down labels (90 <= angle < 270) are shown upright
+                             AllowUpsideDownWhenRotationIsDefined SIP_MONKEYPATCH_COMPAT_NAME( ShowDefined ), //!< Show upside down when rotation is layer- or data-defined
+                             AlwaysAllowUpsideDown SIP_MONKEYPATCH_COMPAT_NAME( ShowAll ) //!< Show upside down for all labels, including dynamic ones
     };
     Q_ENUM( UpsideDownLabelHandling )
 
@@ -1393,12 +1404,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class LabelMultiLineAlignment SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPalLayerSettings, MultiLineAlign ) : int
-      {
-      Left SIP_MONKEYPATCH_COMPAT_NAME( MultiLeft ) = 0, //!< Left align
-      Center SIP_MONKEYPATCH_COMPAT_NAME( MultiCenter ), //!< Center align
-      Right SIP_MONKEYPATCH_COMPAT_NAME( MultiRight ), //!< Right align
-      FollowPlacement SIP_MONKEYPATCH_COMPAT_NAME( MultiFollowPlacement ), //!< Alignment follows placement of label, e.g., labels to the left of a feature will be drawn with right alignment
-      Justify SIP_MONKEYPATCH_COMPAT_NAME( MultiJustify ), //!< Justified
+    {
+        Left SIP_MONKEYPATCH_COMPAT_NAME( MultiLeft ) = 0, //!< Left align
+        Center SIP_MONKEYPATCH_COMPAT_NAME( MultiCenter ), //!< Center align
+        Right SIP_MONKEYPATCH_COMPAT_NAME( MultiRight ), //!< Right align
+        FollowPlacement SIP_MONKEYPATCH_COMPAT_NAME( MultiFollowPlacement ), //!< Alignment follows placement of label, e.g., labels to the left of a feature will be drawn with right alignment
+        Justify SIP_MONKEYPATCH_COMPAT_NAME( MultiJustify ), //!< Justified
     };
     Q_ENUM( LabelMultiLineAlignment )
 
@@ -1409,14 +1420,14 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class FileFilterType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProviderMetadata, FilterType ) : int
-      {
-      Vector SIP_MONKEYPATCH_COMPAT_NAME( FilterVector ) = 1, //!< Vector layers
-      Raster SIP_MONKEYPATCH_COMPAT_NAME( FilterRaster ), //!< Raster layers
-      Mesh SIP_MONKEYPATCH_COMPAT_NAME( FilterMesh ), //!< Mesh layers
-      MeshDataset SIP_MONKEYPATCH_COMPAT_NAME( FilterMeshDataset ), //!< Mesh datasets
-      PointCloud SIP_MONKEYPATCH_COMPAT_NAME( FilterPointCloud ), //!< Point clouds \since QGIS 3.18
-      VectorTile, //!< Vector tile layers \since QGIS 3.32
-      TiledScene, //!< Tiled scene layers \since QGIS 3.34
+    {
+        Vector SIP_MONKEYPATCH_COMPAT_NAME( FilterVector ) = 1, //!< Vector layers
+        Raster SIP_MONKEYPATCH_COMPAT_NAME( FilterRaster ), //!< Raster layers
+        Mesh SIP_MONKEYPATCH_COMPAT_NAME( FilterMesh ), //!< Mesh layers
+        MeshDataset SIP_MONKEYPATCH_COMPAT_NAME( FilterMeshDataset ), //!< Mesh datasets
+        PointCloud SIP_MONKEYPATCH_COMPAT_NAME( FilterPointCloud ), //!< Point clouds \since QGIS 3.18
+        VectorTile, //!< Vector tile layers \since QGIS 3.32
+        TiledScene, //!< Tiled scene layers \since QGIS 3.34
     };
     Q_ENUM( FileFilterType )
 
@@ -1427,8 +1438,8 @@ class CORE_EXPORT Qgis
      */
     enum class UriCleaningFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      RemoveCredentials = 1 << 0, //!< Completely remove credentials (eg passwords) from the URI. This flag is not compatible with the RedactCredentials flag.
-      RedactCredentials = 1 << 1, //!< Replace the value of credentials (eg passwords) with 'xxxxxxxx'. This flag is not compatible with the RemoveCredentials flag.
+        RemoveCredentials = 1 << 0, //!< Completely remove credentials (eg passwords) from the URI. This flag is not compatible with the RedactCredentials flag.
+        RedactCredentials = 1 << 1, //!< Replace the value of credentials (eg passwords) with 'xxxxxxxx'. This flag is not compatible with the RemoveCredentials flag.
     };
     Q_ENUM( UriCleaningFlag )
 
@@ -1447,11 +1458,11 @@ class CORE_EXPORT Qgis
      */
     enum class SublayerQueryFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      FastScan = 1 << 0, //!< Indicates that the provider must scan for sublayers using the fastest possible approach -- e.g. by first checking that a uri has an extension which is known to be readable by the provider
-      ResolveGeometryType = 1 << 1, //!< Attempt to resolve the geometry type for vector sublayers
-      CountFeatures = 1 << 2, //!< Count features in vector sublayers
-      IncludeSystemTables = 1 << 3, //!< Include system or internal tables (these are not included by default)
-      OpenLayersToResolveDescriptions = 1 << 4, //!< Attempt to open layers in order to resolve layer descriptions. May be slow and should never be done in a UI blocking call. \since QGIS 4.0
+        FastScan = 1 << 0, //!< Indicates that the provider must scan for sublayers using the fastest possible approach -- e.g. by first checking that a uri has an extension which is known to be readable by the provider
+        ResolveGeometryType = 1 << 1, //!< Attempt to resolve the geometry type for vector sublayers
+        CountFeatures = 1 << 2, //!< Count features in vector sublayers
+        IncludeSystemTables = 1 << 3, //!< Include system or internal tables (these are not included by default)
+        OpenLayersToResolveDescriptions = 1 << 4, //!< Attempt to open layers in order to resolve layer descriptions. May be slow and should never be done in a UI blocking call. \since QGIS 4.0
     };
     //! Sublayer query flags
     Q_DECLARE_FLAGS( SublayerQueryFlags, SublayerQueryFlag )
@@ -1465,7 +1476,7 @@ class CORE_EXPORT Qgis
      */
     enum class SublayerFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      SystemTable = 1 << 0, //!< Sublayer is a system or internal table, which should be hidden by default
+        SystemTable = 1 << 0, //!< Sublayer is a system or internal table, which should be hidden by default
     };
     //! Sublayer flags
     Q_DECLARE_FLAGS( SublayerFlags, SublayerFlag )
@@ -1480,10 +1491,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.38
      */
     enum class ShaderInterpolationMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsColorRampShader, Type ) : int
-      {
-      Linear SIP_MONKEYPATCH_COMPAT_NAME( Interpolated ) = 0, //!< Interpolates the color between two class breaks linearly
-      Discrete = 1, //!< Assigns the color of the higher class for every pixel between two class breaks
-      Exact = 2, //!< Assigns the color of the exact matching value in the color ramp item list
+    {
+        Linear SIP_MONKEYPATCH_COMPAT_NAME( Interpolated ) = 0, //!< Interpolates the color between two class breaks linearly
+        Discrete = 1, //!< Assigns the color of the higher class for every pixel between two class breaks
+        Exact = 2, //!< Assigns the color of the exact matching value in the color ramp item list
     };
     Q_ENUM( ShaderInterpolationMethod )
 
@@ -1495,10 +1506,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.38
      */
     enum class ShaderClassificationMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsColorRampShader, ClassificationMode ) : int
-      {
-      Continuous = 1, //!< Uses breaks from color palette
-      EqualInterval = 2, //!< Uses equal interval
-      Quantile = 3, //!< Uses quantile (i.e. equal pixel) count
+    {
+        Continuous = 1, //!< Uses breaks from color palette
+        EqualInterval = 2, //!< Uses equal interval
+        Quantile = 3, //!< Uses quantile (i.e. equal pixel) count
     };
     Q_ENUM( ShaderClassificationMethod )
 
@@ -1508,15 +1519,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class RasterPipeInterfaceRole SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterPipe, Role ) : int
-      {
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownRole ) = 0, //!< Unknown role
-      Provider SIP_MONKEYPATCH_COMPAT_NAME( ProviderRole ) = 1, //!< Data provider role
-      Renderer SIP_MONKEYPATCH_COMPAT_NAME( RendererRole ) = 2, //!< Raster renderer role
-      Brightness SIP_MONKEYPATCH_COMPAT_NAME( BrightnessRole ) = 3, //!< Brightness filter role
-      Resampler SIP_MONKEYPATCH_COMPAT_NAME( ResamplerRole ) = 4, //!< Resampler role
-      Projector SIP_MONKEYPATCH_COMPAT_NAME( ProjectorRole ) = 5, //!< Projector role
-      Nuller SIP_MONKEYPATCH_COMPAT_NAME( NullerRole ) = 6, //!< Raster nuller role
-      HueSaturation SIP_MONKEYPATCH_COMPAT_NAME( HueSaturationRole ) = 7, //!< Hue/saturation filter role (also applies grayscale/color inversion)
+    {
+        Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownRole ) = 0, //!< Unknown role
+        Provider SIP_MONKEYPATCH_COMPAT_NAME( ProviderRole ) = 1, //!< Data provider role
+        Renderer SIP_MONKEYPATCH_COMPAT_NAME( RendererRole ) = 2, //!< Raster renderer role
+        Brightness SIP_MONKEYPATCH_COMPAT_NAME( BrightnessRole ) = 3, //!< Brightness filter role
+        Resampler SIP_MONKEYPATCH_COMPAT_NAME( ResamplerRole ) = 4, //!< Resampler role
+        Projector SIP_MONKEYPATCH_COMPAT_NAME( ProjectorRole ) = 5, //!< Projector role
+        Nuller SIP_MONKEYPATCH_COMPAT_NAME( NullerRole ) = 6, //!< Raster nuller role
+        HueSaturation SIP_MONKEYPATCH_COMPAT_NAME( HueSaturationRole ) = 7, //!< Hue/saturation filter role (also applies grayscale/color inversion)
     };
     Q_ENUM( RasterPipeInterfaceRole )
 
@@ -1525,9 +1536,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class RasterResamplingStage SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterPipe, ResamplingStage ) : int
-      {
-      ResampleFilter, //!< Resampling occurs in ResamplingFilter
-      Provider, //!< Resampling occurs in Provider
+    {
+        ResampleFilter, //!< Resampling occurs in ResamplingFilter
+        Provider, //!< Resampling occurs in Provider
     };
     Q_ENUM( RasterResamplingStage )
 
@@ -1539,15 +1550,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.42
      */
     enum class RasterResamplingMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterDataProvider, ResamplingMethod ) : int
-      {
-      Nearest, //!< Nearest-neighbour resampling
-      Bilinear, //!< Bilinear (2x2 kernel) resampling
-      Cubic, //!< Cubic Convolution Approximation (4x4 kernel) resampling
-      CubicSpline, //!< Cubic B-Spline Approximation (4x4 kernel)
-      Lanczos, //!< Lanczos windowed sinc interpolation (6x6 kernel)
-      Average, //!< Average resampling
-      Mode, //!< Mode (selects the value which appears most often of all the sampled points)
-      Gauss //!< Gauss blurring
+    {
+        Nearest, //!< Nearest-neighbour resampling
+        Bilinear, //!< Bilinear (2x2 kernel) resampling
+        Cubic, //!< Cubic Convolution Approximation (4x4 kernel) resampling
+        CubicSpline, //!< Cubic B-Spline Approximation (4x4 kernel)
+        Lanczos, //!< Lanczos windowed sinc interpolation (6x6 kernel)
+        Average, //!< Average resampling
+        Mode, //!< Mode (selects the value which appears most often of all the sampled points)
+        Gauss //!< Gauss blurring
     };
     Q_ENUM( RasterResamplingMethod )
 
@@ -1558,8 +1569,8 @@ class CORE_EXPORT Qgis
      */
     enum class RasterRendererFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      InternalLayerOpacityHandling = 1 << 0, //!< The renderer internally handles the raster layer's opacity, so the default layer level opacity handling should not be applied.
-      UseNoDataForOutOfRangePixels = 1 << 1, //!< Out of range pixels (eg those values outside of the rendered map's z range filter) should be set using additional nodata values instead of additional transparency values \since QGIS 3.38
+        InternalLayerOpacityHandling = 1 << 0, //!< The renderer internally handles the raster layer's opacity, so the default layer level opacity handling should not be applied.
+        UseNoDataForOutOfRangePixels = 1 << 1, //!< Out of range pixels (eg those values outside of the rendered map's z range filter) should be set using additional nodata values instead of additional transparency values \since QGIS 3.38
     };
 
     /**
@@ -1579,7 +1590,7 @@ class CORE_EXPORT Qgis
      */
     enum class RasterRendererCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      UsesMultipleBands = 1 << 0, //!< The renderer utilizes multiple raster bands for color data (note that alpha bands are not considered for this capability)
+        UsesMultipleBands = 1 << 0, //!< The renderer utilizes multiple raster bands for color data (note that alpha bands are not considered for this capability)
     };
     Q_ENUM( RasterRendererCapability )
 
@@ -1599,11 +1610,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.42
      */
     enum class RasterRangeLimit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterMinMaxOrigin, Limits ) : int
-      {
-      NotSet SIP_MONKEYPATCH_COMPAT_NAME( None_ ), //!< User defined
-      MinimumMaximum SIP_MONKEYPATCH_COMPAT_NAME( MinMax ), //!< Real min-max values
-      StdDev, //!< Range is [ mean - stdDevFactor() * stddev, mean + stdDevFactor() * stddev ]
-      CumulativeCut //!< Range is [ min + cumulativeCutLower() * (max - min), min + cumulativeCutUpper() * (max - min) ]
+    {
+        NotSet SIP_MONKEYPATCH_COMPAT_NAME( None_ ), //!< User defined
+               MinimumMaximum SIP_MONKEYPATCH_COMPAT_NAME( MinMax ), //!< Real min-max values
+               StdDev, //!< Range is [ mean - stdDevFactor() * stddev, mean + stdDevFactor() * stddev ]
+               CumulativeCut //!< Range is [ min + cumulativeCutLower() * (max - min), min + cumulativeCutUpper() * (max - min) ]
     };
     Q_ENUM( RasterRangeLimit )
 
@@ -1615,10 +1626,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.42
      */
     enum class RasterRangeExtent SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterMinMaxOrigin, Extent ) : int
-      {
-      WholeRaster SIP_MONKEYPATCH_COMPAT_NAME( None_ ), //!< Whole raster is used to compute statistics
-      FixedCanvas SIP_MONKEYPATCH_COMPAT_NAME( CurrentCanvas ), //!< Current extent of the canvas (at the time of computation) is used to compute statistics
-      UpdatedCanvas, //!< Constantly updated extent of the canvas is used to compute statistics
+    {
+        WholeRaster SIP_MONKEYPATCH_COMPAT_NAME( None_ ), //!< Whole raster is used to compute statistics
+                    FixedCanvas SIP_MONKEYPATCH_COMPAT_NAME( CurrentCanvas ), //!< Current extent of the canvas (at the time of computation) is used to compute statistics
+                    UpdatedCanvas, //!< Constantly updated extent of the canvas is used to compute statistics
     };
     Q_ENUM( RasterRangeExtent )
 
@@ -1630,9 +1641,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.42
      */
     enum class RasterRangeAccuracy SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterMinMaxOrigin, StatAccuracy ): int
-      {
-      Exact, //!< Exact statistics
-      Estimated, //!< Approximated statistics
+    {
+        Exact, //!< Exact statistics
+        Estimated, //!< Approximated statistics
     };
     Q_ENUM( RasterRangeAccuracy )
 
@@ -1684,9 +1695,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class RasterExportType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterFileWriter, Mode ) : int
-      {
-      Raw = 0, //!< Raw data
-      RenderedImage SIP_MONKEYPATCH_COMPAT_NAME( Image ) = 1 //!< Rendered image
+    {
+        Raw = 0, //!< Raw data
+        RenderedImage SIP_MONKEYPATCH_COMPAT_NAME( Image ) = 1 //!< Rendered image
     };
     Q_ENUM( RasterExportType )
 
@@ -1697,14 +1708,14 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class RasterFileWriterResult SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterFileWriter, WriterError ) : int
-      {
-      Success SIP_MONKEYPATCH_COMPAT_NAME( NoError ) = 0, //!< Successful export
-      SourceProviderError = 1, //!< Source data provider error
-      DestinationProviderError SIP_MONKEYPATCH_COMPAT_NAME( DestProviderError ) = 2, //!< Destination data provider error
-      CreateDatasourceError = 3, //!< Data source creation error
-      WriteError = 4, //!< Write error
-      NoDataConflict = 5, //!< Internal error if a value used for 'no data' was found in input
-      Canceled SIP_MONKEYPATCH_COMPAT_NAME( WriteCanceled ) = 6, //!< Writing was manually canceled
+    {
+        Success SIP_MONKEYPATCH_COMPAT_NAME( NoError ) = 0, //!< Successful export
+        SourceProviderError = 1, //!< Source data provider error
+        DestinationProviderError SIP_MONKEYPATCH_COMPAT_NAME( DestProviderError ) = 2, //!< Destination data provider error
+        CreateDatasourceError = 3, //!< Data source creation error
+        WriteError = 4, //!< Write error
+        NoDataConflict = 5, //!< Internal error if a value used for 'no data' was found in input
+        Canceled SIP_MONKEYPATCH_COMPAT_NAME( WriteCanceled ) = 6, //!< Writing was manually canceled
     };
     Q_ENUM( RasterFileWriterResult )
 
@@ -1759,12 +1770,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.38
     */
     enum class FieldOrigin SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFields, FieldOrigin ) : int
-      {
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( OriginUnknown ), //!< The field origin has not been specified
-      Provider SIP_MONKEYPATCH_COMPAT_NAME( OriginProvider ), //!< Field originates from the underlying data provider of the vector layer
-      Join SIP_MONKEYPATCH_COMPAT_NAME( OriginJoin ), //!< Field originates from a joined layer
-      Edit SIP_MONKEYPATCH_COMPAT_NAME( OriginEdit ), //!< Field has been temporarily added in editing mode
-      Expression SIP_MONKEYPATCH_COMPAT_NAME( OriginExpression ) //!< Field is calculated from an expression
+    {
+        Unknown SIP_MONKEYPATCH_COMPAT_NAME( OriginUnknown ), //!< The field origin has not been specified
+                Provider SIP_MONKEYPATCH_COMPAT_NAME( OriginProvider ), //!< Field originates from the underlying data provider of the vector layer
+                Join SIP_MONKEYPATCH_COMPAT_NAME( OriginJoin ), //!< Field originates from a joined layer
+                Edit SIP_MONKEYPATCH_COMPAT_NAME( OriginEdit ), //!< Field has been temporarily added in editing mode
+                Expression SIP_MONKEYPATCH_COMPAT_NAME( OriginExpression ) //!< Field is calculated from an expression
     };
     Q_ENUM( FieldOrigin )
 
@@ -1777,10 +1788,10 @@ class CORE_EXPORT Qgis
      */
     enum class FieldConfigurationFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoFlag = 0, //!< No flag is defined
-      NotSearchable = 1 << 1, //!< Defines if the field is searchable (used in the locator search for instance)
-      HideFromWms = 1 << 2, //!< Field is not available if layer is served as WMS from QGIS server
-      HideFromWfs = 1 << 3, //!< Field is not available if layer is served as WFS from QGIS server
+        NoFlag = 0, //!< No flag is defined
+        NotSearchable = 1 << 1, //!< Defines if the field is searchable (used in the locator search for instance)
+        HideFromWms = 1 << 2, //!< Field is not available if layer is served as WMS from QGIS server
+        HideFromWfs = 1 << 3, //!< Field is not available if layer is served as WFS from QGIS server
     };
     Q_ENUM( FieldConfigurationFlag )
 
@@ -1826,11 +1837,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class SelectBehavior SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorLayer, SelectBehavior ) : int
-      {
-      SetSelection, //!< Set selection, removing any existing selection
-      AddToSelection, //!< Add selection to current selection
-      IntersectSelection, //!< Modify current selection to include only select features which match
-      RemoveFromSelection, //!< Remove from current selection
+    {
+        SetSelection, //!< Set selection, removing any existing selection
+        AddToSelection, //!< Add selection to current selection
+        IntersectSelection, //!< Modify current selection to include only select features which match
+        RemoveFromSelection, //!< Remove from current selection
     };
     Q_ENUM( SelectBehavior )
 
@@ -1853,8 +1864,8 @@ class CORE_EXPORT Qgis
      */
     enum class SelectionFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      SingleFeatureSelection = 1 << 0, //!< Select only a single feature, picking the "best" match for the selection geometry
-      ToggleSelection = 1 << 1, //!< Enables a "toggle" selection mode, where previously selected matching features will be deselected and previously deselected features will be selected. This flag works only when the SingleFeatureSelection flag is also set.
+        SingleFeatureSelection = 1 << 0, //!< Select only a single feature, picking the "best" match for the selection geometry
+        ToggleSelection = 1 << 1, //!< Enables a "toggle" selection mode, where previously selected matching features will be deselected and previously deselected features will be selected. This flag works only when the SingleFeatureSelection flag is also set.
     };
 
     /**
@@ -1873,12 +1884,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class VectorEditResult SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorLayer, EditResult ) : int
-      {
-      Success = 0, //!< Edit operation was successful
-      EmptyGeometry = 1, //!< Edit operation resulted in an empty geometry
-      EditFailed = 2, //!< Edit operation failed
-      FetchFeatureFailed = 3, //!< Unable to fetch requested feature
-      InvalidLayer = 4, //!< Edit failed due to invalid layer
+    {
+        Success = 0, //!< Edit operation was successful
+        EmptyGeometry = 1, //!< Edit operation resulted in an empty geometry
+        EditFailed = 2, //!< Edit operation failed
+        FetchFeatureFailed = 3, //!< Unable to fetch requested feature
+        InvalidLayer = 4, //!< Edit failed due to invalid layer
     };
     Q_ENUM( VectorEditResult )
 
@@ -1888,10 +1899,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class VertexMarkerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSymbolLayerUtils, VertexMarkerType ) : int
-      {
-      SemiTransparentCircle, //!< Semi-transparent circle marker
-      Cross, //!< Cross marker
-      NoMarker, //!< No marker
+    {
+        SemiTransparentCircle, //!< Semi-transparent circle marker
+        Cross, //!< Cross marker
+        NoMarker, //!< No marker
     };
     Q_ENUM( VertexMarkerType )
 
@@ -1929,10 +1940,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class DeviceConnectionStatus SIP_MONKEYPATCH_SCOPEENUM_UNNEST( Qgis, GpsConnectionStatus ) : int
-      {
-      Disconnected, //!< Device is disconnected
-      Connecting, //!< Device is connecting
-      Connected, //!< Device is successfully connected
+    {
+        Disconnected, //!< Device is disconnected
+        Connecting, //!< Device is connecting
+        Connected, //!< Device is successfully connected
     };
     Q_ENUM( DeviceConnectionStatus )
 
@@ -1944,11 +1955,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class GpsFixStatus SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGpsInformation, FixStatus ) : int
-      {
-      NoData, //!< No fix data available
-      NoFix, //!< GPS is not fixed
-      Fix2D, //!< 2D fix
-      Fix3D //!< 3D fix
+    {
+        NoData, //!< No fix data available
+        NoFix, //!< GPS is not fixed
+        Fix2D, //!< 2D fix
+        Fix3D //!< 3D fix
     };
     Q_ENUM( GpsFixStatus );
 
@@ -2012,26 +2023,26 @@ class CORE_EXPORT Qgis
      */
     enum class GpsInformationComponent : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Location = 1 << 0, //!< 2D location (latitude/longitude), as a QgsPointXY value
-      Altitude = 1 << 1, //!< Altitude/elevation above or below the mean sea level
-      GroundSpeed = 1 << 2, //!< Ground speed
-      Bearing = 1 << 3, //!< Bearing measured in degrees clockwise from true north to the direction of travel
-      TotalTrackLength = 1 << 4, //!< Total distance of current GPS track (available from QgsGpsLogger class only)
-      TrackDistanceFromStart = 1 << 5, //!< Direct distance from first vertex in current GPS track to last vertex (available from QgsGpsLogger class only)
-      Pdop = 1 << 6, //!< Dilution of precision
-      Hdop = 1 << 7, //!< Horizontal dilution of precision
-      Vdop = 1 << 8, //!< Vertical dilution of precision
-      HorizontalAccuracy = 1 << 9, //!< Horizontal accuracy in meters
-      VerticalAccuracy = 1 << 10, //!< Vertical accuracy in meters
-      HvAccuracy = 1 << 11, //!< 3D RMS
-      SatellitesUsed = 1 << 12, //!< Count of satellites used in obtaining the fix
-      Timestamp = 1 << 13, //!< Timestamp
-      TrackStartTime = 1 << 14, //!< Timestamp at start of current track (available from QgsGpsLogger class only)
-      TrackEndTime = 1 << 15, //!< Timestamp at end (current point) of current track (available from QgsGpsLogger class only)
-      TrackDistanceSinceLastPoint = 1 << 16, //!< Distance since last recorded location (available from QgsGpsLogger class only)
-      TrackTimeSinceLastPoint = 1 << 17, //!< Time since last recorded location (available from QgsGpsLogger class only)
-      GeoidalSeparation = 1 << 18, //!< Geoidal separation, the difference between the WGS-84 Earth ellipsoid and mean-sea-level (geoid), "-" means mean-sea-level below ellipsoid
-      EllipsoidAltitude = 1 << 19, //!< Altitude/elevation above or below the WGS-84 Earth ellipsoid
+        Location = 1 << 0, //!< 2D location (latitude/longitude), as a QgsPointXY value
+        Altitude = 1 << 1, //!< Altitude/elevation above or below the mean sea level
+        GroundSpeed = 1 << 2, //!< Ground speed
+        Bearing = 1 << 3, //!< Bearing measured in degrees clockwise from true north to the direction of travel
+        TotalTrackLength = 1 << 4, //!< Total distance of current GPS track (available from QgsGpsLogger class only)
+        TrackDistanceFromStart = 1 << 5, //!< Direct distance from first vertex in current GPS track to last vertex (available from QgsGpsLogger class only)
+        Pdop = 1 << 6, //!< Dilution of precision
+        Hdop = 1 << 7, //!< Horizontal dilution of precision
+        Vdop = 1 << 8, //!< Vertical dilution of precision
+        HorizontalAccuracy = 1 << 9, //!< Horizontal accuracy in meters
+        VerticalAccuracy = 1 << 10, //!< Vertical accuracy in meters
+        HvAccuracy = 1 << 11, //!< 3D RMS
+        SatellitesUsed = 1 << 12, //!< Count of satellites used in obtaining the fix
+        Timestamp = 1 << 13, //!< Timestamp
+        TrackStartTime = 1 << 14, //!< Timestamp at start of current track (available from QgsGpsLogger class only)
+        TrackEndTime = 1 << 15, //!< Timestamp at end (current point) of current track (available from QgsGpsLogger class only)
+        TrackDistanceSinceLastPoint = 1 << 16, //!< Distance since last recorded location (available from QgsGpsLogger class only)
+        TrackTimeSinceLastPoint = 1 << 17, //!< Time since last recorded location (available from QgsGpsLogger class only)
+        GeoidalSeparation = 1 << 18, //!< Geoidal separation, the difference between the WGS-84 Earth ellipsoid and mean-sea-level (geoid), "-" means mean-sea-level below ellipsoid
+        EllipsoidAltitude = 1 << 19, //!< Altitude/elevation above or below the WGS-84 Earth ellipsoid
     };
 
     /**
@@ -2050,11 +2061,11 @@ class CORE_EXPORT Qgis
      */
     enum class BabelFormatCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Import = 1 << 0, //!< Format supports importing
-      Export = 1 << 1, //!< Format supports exporting
-      Waypoints = 1 << 2, //!< Format supports waypoints
-      Routes = 1 << 3, //!< Format supports routes
-      Tracks = 1 << 4, //!< Format supports tracks
+        Import = 1 << 0, //!< Format supports importing
+        Export = 1 << 1, //!< Format supports exporting
+        Waypoints = 1 << 2, //!< Format supports waypoints
+        Routes = 1 << 3, //!< Format supports routes
+        Tracks = 1 << 4, //!< Format supports tracks
     };
     //! Babel GPS format capabilities
     Q_DECLARE_FLAGS( BabelFormatCapabilities, BabelFormatCapability )
@@ -2069,7 +2080,7 @@ class CORE_EXPORT Qgis
      */
     enum class BabelCommandFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      QuoteFilePaths = 1 << 0, //!< File paths should be enclosed in quotations and escaped
+        QuoteFilePaths = 1 << 0, //!< File paths should be enclosed in quotations and escaped
     };
     //! Babel command flags
     Q_DECLARE_FLAGS( BabelCommandFlags, BabelCommandFlag )
@@ -2097,26 +2108,26 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class GeometryOperationResult SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, OperationResult ) : int
-      {
-      Success = 0, //!< Operation succeeded
-      NothingHappened = 1000, //!< Nothing happened, without any error
-      InvalidBaseGeometry, //!< The base geometry on which the operation is done is invalid or empty
-      InvalidInputGeometryType, //!< The input geometry (ring, part, split line, etc.) has not the correct geometry type
-      SelectionIsEmpty, //!< No features were selected
-      SelectionIsGreaterThanOne, //!< More than one features were selected
-      GeometryEngineError, //!< Geometry engine misses a method implemented or an error occurred in the geometry engine
-      LayerNotEditable, //!< Cannot edit layer
-      // Add part issues
-      AddPartSelectedGeometryNotFound, //!< The selected geometry cannot be found
-      AddPartNotMultiGeometry, //!< The source geometry is not multi
-      // Add ring issues
-      AddRingNotClosed, //!< The input ring is not closed
-      AddRingNotValid, //!< The input ring is not valid
-      AddRingCrossesExistingRings, //!< The input ring crosses existing rings (it is not disjoint)
-      AddRingNotInExistingFeature, //!< The input ring doesn't have any existing ring to fit into
-      // Split features
-      SplitCannotSplitPoint, //!< Cannot split points
-      GeometryTypeHasChanged, //!< Operation has changed geometry type
+    {
+        Success = 0, //!< Operation succeeded
+        NothingHappened = 1000, //!< Nothing happened, without any error
+        InvalidBaseGeometry, //!< The base geometry on which the operation is done is invalid or empty
+        InvalidInputGeometryType, //!< The input geometry (ring, part, split line, etc.) has not the correct geometry type
+        SelectionIsEmpty, //!< No features were selected
+        SelectionIsGreaterThanOne, //!< More than one features were selected
+        GeometryEngineError, //!< Geometry engine misses a method implemented or an error occurred in the geometry engine
+        LayerNotEditable, //!< Cannot edit layer
+        // Add part issues
+        AddPartSelectedGeometryNotFound, //!< The selected geometry cannot be found
+        AddPartNotMultiGeometry, //!< The source geometry is not multi
+        // Add ring issues
+        AddRingNotClosed, //!< The input ring is not closed
+        AddRingNotValid, //!< The input ring is not valid
+        AddRingCrossesExistingRings, //!< The input ring crosses existing rings (it is not disjoint)
+        AddRingNotInExistingFeature, //!< The input ring doesn't have any existing ring to fit into
+        // Split features
+        SplitCannotSplitPoint, //!< Cannot split points
+        GeometryTypeHasChanged, //!< Operation has changed geometry type
     };
     Q_ENUM( GeometryOperationResult )
 
@@ -2127,7 +2138,7 @@ class CORE_EXPORT Qgis
      */
     enum class GeometryValidityFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, ValidityFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      AllowSelfTouchingHoles SIP_MONKEYPATCH_COMPAT_NAME( FlagAllowSelfTouchingHoles ) = 1 << 0, //!< Indicates that self-touching holes are permitted. OGC validity states that self-touching holes are NOT permitted, whilst other vendor validity checks (e.g. ESRI) permit self-touching holes.
+        AllowSelfTouchingHoles SIP_MONKEYPATCH_COMPAT_NAME( FlagAllowSelfTouchingHoles ) = 1 << 0, //!< Indicates that self-touching holes are permitted. OGC validity states that self-touching holes are NOT permitted, whilst other vendor validity checks (e.g. ESRI) permit self-touching holes.
     };
     //! Geometry validity flags
     Q_DECLARE_FLAGS( GeometryValidityFlags, GeometryValidityFlag ) SIP_MONKEYPATCH_FLAGS_UNNEST( QgsGeometry, ValidityFlags )
@@ -2139,9 +2150,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class GeometryValidationEngine SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, ValidationMethod ) : int
-      {
-      QgisInternal SIP_MONKEYPATCH_COMPAT_NAME( ValidatorQgisInternal ), //!< Use internal QgsGeometryValidator method
-      Geos SIP_MONKEYPATCH_COMPAT_NAME( ValidatorGeos ), //!< Use GEOS validation methods
+    {
+        QgisInternal SIP_MONKEYPATCH_COMPAT_NAME( ValidatorQgisInternal ), //!< Use internal QgsGeometryValidator method
+                     Geos SIP_MONKEYPATCH_COMPAT_NAME( ValidatorGeos ), //!< Use GEOS validation methods
     };
     Q_ENUM( GeometryValidationEngine )
 
@@ -2151,9 +2162,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class BufferSide SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, BufferSide ) : int
-      {
-      Left SIP_MONKEYPATCH_COMPAT_NAME( SideLeft ) = 0, //!< Buffer to left of line
-      Right SIP_MONKEYPATCH_COMPAT_NAME( SideRight ), //!< Buffer to right of line
+    {
+        Left SIP_MONKEYPATCH_COMPAT_NAME( SideLeft ) = 0, //!< Buffer to left of line
+        Right SIP_MONKEYPATCH_COMPAT_NAME( SideRight ), //!< Buffer to right of line
     };
     Q_ENUM( BufferSide )
 
@@ -2163,10 +2174,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class EndCapStyle SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, EndCapStyle ) : int
-      {
-      Round SIP_MONKEYPATCH_COMPAT_NAME( CapRound ) = 1, //!< Round cap
-      Flat SIP_MONKEYPATCH_COMPAT_NAME( CapFlat ), //!< Flat cap (in line with start/end of line)
-      Square SIP_MONKEYPATCH_COMPAT_NAME( CapSquare ), //!< Square cap (extends past start/end of line by buffer distance)
+    {
+        Round SIP_MONKEYPATCH_COMPAT_NAME( CapRound ) = 1, //!< Round cap
+        Flat SIP_MONKEYPATCH_COMPAT_NAME( CapFlat ), //!< Flat cap (in line with start/end of line)
+        Square SIP_MONKEYPATCH_COMPAT_NAME( CapSquare ), //!< Square cap (extends past start/end of line by buffer distance)
     };
     Q_ENUM( EndCapStyle )
 
@@ -2176,10 +2187,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class JoinStyle SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGeometry, JoinStyle ) : int
-      {
-      Round SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleRound ) = 1, //!< Use rounded joins
-      Miter SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleMiter ), //!< Use mitered joins
-      Bevel SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleBevel ), //!< Use beveled joins
+    {
+        Round SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleRound ) = 1, //!< Use rounded joins
+        Miter SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleMiter ), //!< Use mitered joins
+        Bevel SIP_MONKEYPATCH_COMPAT_NAME( JoinStyleBevel ), //!< Use beveled joins
     };
     Q_ENUM( JoinStyle )
 
@@ -2203,8 +2214,8 @@ class CORE_EXPORT Qgis
      */
     enum class GeosCreationFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      RejectOnInvalidSubGeometry = 1 << 0,  //!< Don't allow geometries with invalid sub-geometries to be created
-      SkipEmptyInteriorRings = 1 << 1,      //!< Skip any empty polygon interior ring
+        RejectOnInvalidSubGeometry = 1 << 0,  //!< Don't allow geometries with invalid sub-geometries to be created
+        SkipEmptyInteriorRings = 1 << 1,      //!< Skip any empty polygon interior ring
     };
     Q_ENUM( GeosCreationFlag )
 
@@ -2250,12 +2261,12 @@ class CORE_EXPORT Qgis
      */
     enum class FeatureRequestFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFeatureRequest, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoFlags            = 0, //!< No flags are set
-      NoGeometry         = 1,  //!< Geometry is not required. It may still be returned if e.g. required for a filter condition.
-      SubsetOfAttributes = 2,  //!< Fetch only a subset of attributes (setSubsetOfAttributes sets this flag)
-      ExactIntersect     = 4,   //!< Use exact geometry intersection (slower) instead of bounding boxes
-      IgnoreStaticNodesDuringExpressionCompilation = 8, //!< If a feature request uses a filter expression which can be partially precalculated due to static nodes in the expression, setting this flag will prevent these precalculated values from being utilized during compilation of the filter for the backend provider. This flag significantly slows down feature requests and should be used for debugging purposes only. \since QGIS 3.18
-      EmbeddedSymbols    = 16,  //!< Retrieve any embedded feature symbology \since QGIS 3.20
+        NoFlags            = 0, //!< No flags are set
+        NoGeometry         = 1,  //!< Geometry is not required. It may still be returned if e.g. required for a filter condition.
+        SubsetOfAttributes = 2,  //!< Fetch only a subset of attributes (setSubsetOfAttributes sets this flag)
+        ExactIntersect     = 4,   //!< Use exact geometry intersection (slower) instead of bounding boxes
+        IgnoreStaticNodesDuringExpressionCompilation = 8, //!< If a feature request uses a filter expression which can be partially precalculated due to static nodes in the expression, setting this flag will prevent these precalculated values from being utilized during compilation of the filter for the backend provider. This flag significantly slows down feature requests and should be used for debugging purposes only. \since QGIS 3.18
+        EmbeddedSymbols    = 16,  //!< Retrieve any embedded feature symbology \since QGIS 3.20
     };
     Q_ENUM( FeatureRequestFlag )
 
@@ -2277,11 +2288,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class FeatureRequestFilterType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFeatureRequest, FilterType ) : int
-      {
-      NoFilter SIP_MONKEYPATCH_COMPAT_NAME( FilterNone ), //!< No filter is applied
-      Fid SIP_MONKEYPATCH_COMPAT_NAME( FilterFid ), //!< Filter using feature ID
-      Expression SIP_MONKEYPATCH_COMPAT_NAME( FilterExpression ), //!< Filter using expression
-      Fids SIP_MONKEYPATCH_COMPAT_NAME( FilterFids ) //!< Filter using feature IDs
+    {
+        NoFilter SIP_MONKEYPATCH_COMPAT_NAME( FilterNone ), //!< No filter is applied
+                 Fid SIP_MONKEYPATCH_COMPAT_NAME( FilterFid ), //!< Filter using feature ID
+                 Expression SIP_MONKEYPATCH_COMPAT_NAME( FilterExpression ), //!< Filter using expression
+                 Fids SIP_MONKEYPATCH_COMPAT_NAME( FilterFids ) //!< Filter using feature IDs
     };
     Q_ENUM( FeatureRequestFilterType )
 
@@ -2293,10 +2304,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class InvalidGeometryCheck SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsFeatureRequest, InvalidGeometryCheck ) : int
-      {
-      NoCheck SIP_MONKEYPATCH_COMPAT_NAME( GeometryNoCheck ) = 0, //!< No invalid geometry checking
-      SkipInvalid SIP_MONKEYPATCH_COMPAT_NAME( GeometrySkipInvalid ) = 1, //!< Skip any features with invalid geometry. This requires a slow geometry validity check for every feature.
-      AbortOnInvalid SIP_MONKEYPATCH_COMPAT_NAME( GeometryAbortOnInvalid ) = 2, //!< Close iterator on encountering any features with invalid geometry. This requires a slow geometry validity check for every feature.
+    {
+        NoCheck SIP_MONKEYPATCH_COMPAT_NAME( GeometryNoCheck ) = 0, //!< No invalid geometry checking
+        SkipInvalid SIP_MONKEYPATCH_COMPAT_NAME( GeometrySkipInvalid ) = 1, //!< Skip any features with invalid geometry. This requires a slow geometry validity check for every feature.
+        AbortOnInvalid SIP_MONKEYPATCH_COMPAT_NAME( GeometryAbortOnInvalid ) = 2, //!< Close iterator on encountering any features with invalid geometry. This requires a slow geometry validity check for every feature.
     };
     Q_ENUM( InvalidGeometryCheck )
 
@@ -2320,8 +2331,8 @@ class CORE_EXPORT Qgis
      */
     enum class FileOperationFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      IncludeMetadataFile = 1 << 0, //!< Indicates that any associated .qmd metadata file should be included with the operation
-      IncludeStyleFile = 1 << 1, //!< Indicates that any associated .qml styling file should be included with the operation
+        IncludeMetadataFile = 1 << 0, //!< Indicates that any associated .qmd metadata file should be included with the operation
+        IncludeStyleFile = 1 << 1, //!< Indicates that any associated .qml styling file should be included with the operation
     };
     //! File operation flags
     Q_DECLARE_FLAGS( FileOperationFlags, FileOperationFlag )
@@ -2335,9 +2346,9 @@ class CORE_EXPORT Qgis
      */
     enum class MapLayerProperty : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      UsersCannotToggleEditing = 1 << 0, //!< Indicates that users are not allowed to toggle editing for this layer. Note that this does not imply that the layer is non-editable (see isEditable(), supportsEditing() ), rather that the editable status of the layer cannot be changed by users manually \since QGIS 3.22
-      IsBasemapLayer = 1 << 1, //!< Layer is considered a 'basemap' layer, and certain properties of the layer should be ignored when calculating project-level properties. For instance, the extent of basemap layers is ignored when calculating the extent of a project, as these layers are typically global and extend outside of a project's area of interest \since QGIS 3.26
-      Is3DBasemapLayer = 1 << 2, //!< Layer is considered a '3D basemap' layer. This flag is similar to IsBasemapLayer, but reserved for layers which contain 3D data \since QGIS 3.44
+        UsersCannotToggleEditing = 1 << 0, //!< Indicates that users are not allowed to toggle editing for this layer. Note that this does not imply that the layer is non-editable (see isEditable(), supportsEditing() ), rather that the editable status of the layer cannot be changed by users manually \since QGIS 3.22
+        IsBasemapLayer = 1 << 1, //!< Layer is considered a 'basemap' layer, and certain properties of the layer should be ignored when calculating project-level properties. For instance, the extent of basemap layers is ignored when calculating the extent of a project, as these layers are typically global and extend outside of a project's area of interest \since QGIS 3.26
+        Is3DBasemapLayer = 1 << 2, //!< Layer is considered a '3D basemap' layer. This flag is similar to IsBasemapLayer, but reserved for layers which contain 3D data \since QGIS 3.44
     };
     //! Map layer properties
     Q_DECLARE_FLAGS( MapLayerProperties, MapLayerProperty )
@@ -2364,10 +2375,10 @@ class CORE_EXPORT Qgis
      */
     enum class DataProviderFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      IsBasemapSource = 1 << 1, //!< Associated source should be considered a 'basemap' layer. See Qgis::MapLayerProperty::IsBasemapLayer.
-      FastExtent2D = 1 << 2, //!< Provider's 2D extent retrieval via QgsDataProvider::extent() is always guaranteed to be trivial/fast to calculate \since QGIS 3.38
-      FastExtent3D = 1 << 3, //!< Provider's 3D extent retrieval via QgsDataProvider::extent3D() is always guaranteed to be trivial/fast to calculate \since QGIS 3.38
-      Is3DBasemapSource = 1 << 4, //!< Associated source should be considered a '3D basemap' layer. See Qgis::MapLayerProperty::Is3DBasemapLayer. \since QGIS 3.44
+        IsBasemapSource = 1 << 1, //!< Associated source should be considered a 'basemap' layer. See Qgis::MapLayerProperty::IsBasemapLayer.
+                        FastExtent2D = 1 << 2, //!< Provider's 2D extent retrieval via QgsDataProvider::extent() is always guaranteed to be trivial/fast to calculate \since QGIS 3.38
+                        FastExtent3D = 1 << 3, //!< Provider's 3D extent retrieval via QgsDataProvider::extent3D() is always guaranteed to be trivial/fast to calculate \since QGIS 3.38
+                        Is3DBasemapSource = 1 << 4, //!< Associated source should be considered a '3D basemap' layer. See Qgis::MapLayerProperty::Is3DBasemapLayer. \since QGIS 3.44
     };
     //! Data provider flags
     Q_DECLARE_FLAGS( DataProviderFlags, DataProviderFlag )
@@ -2472,10 +2483,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class CrsIdentifierType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCoordinateReferenceSystem, IdentifierType ) : int
-      {
-      ShortString, //!< A heavily abbreviated string, for use when a compact representation is required
-      MediumString, //!< A medium-length string, recommended for general purpose use
-      FullString, //!< Full definition -- possibly a very lengthy string, e.g. with no truncation of custom WKT definitions
+    {
+        ShortString, //!< A heavily abbreviated string, for use when a compact representation is required
+        MediumString, //!< A medium-length string, recommended for general purpose use
+        FullString, //!< Full definition -- possibly a very lengthy string, e.g. with no truncation of custom WKT definitions
     };
     Q_ENUM( CrsIdentifierType )
 
@@ -2487,16 +2498,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class CrsWktVariant SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCoordinateReferenceSystem, WktVariant ) : int
-      {
-      Wkt1Gdal SIP_MONKEYPATCH_COMPAT_NAME( WKT1_GDAL ), //!< WKT1 as traditionally output by GDAL, deriving from OGC 01-009. A notable departure from WKT1_GDAL with respect to OGC 01-009 is that in WKT1_GDAL, the unit of the PRIMEM value is always degrees.
-      Wkt1Esri SIP_MONKEYPATCH_COMPAT_NAME( WKT1_ESRI ), //!< WKT1 as traditionally output by ESRI software, deriving from OGC 99-049.
-      Wkt2_2015 SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2015 ), //!< Full WKT2 string, conforming to ISO 19162:2015(E) / OGC 12-063r5 with all possible nodes and new keyword names.
-      Wkt2_2015Simplified SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2015_SIMPLIFIED ), //!< Same as WKT2_2015 with the following exceptions: UNIT keyword used. ID node only on top element. No ORDER element in AXIS element. PRIMEM node omitted if it is Greenwich.  ELLIPSOID.UNIT node omitted if it is UnitOfMeasure::METRE. PARAMETER.UNIT / PRIMEM.UNIT omitted if same as AXIS. AXIS.UNIT omitted and replaced by a common GEODCRS.UNIT if they are all the same on all axis.
-      Wkt2_2019  SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2019 ), //!< Full WKT2 string, conforming to ISO 19162:2019 / OGC 18-010, with all possible nodes and new keyword names. Non-normative list of differences: WKT2_2019 uses GEOGCRS / BASEGEOGCRS keywords for GeographicCRS.
-      Wkt2_2019Simplified  SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2019_SIMPLIFIED ), //!< WKT2_2019 with the simplification rule of WKT2_SIMPLIFIED
-      Preferred SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED ) = Wkt2_2019, //!< Preferred format, matching the most recent WKT ISO standard. Currently an alias to WKT2_2019, but may change in future versions.
-      PreferredSimplified  SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED_SIMPLIFIED ) = Wkt2_2019Simplified, //!< Preferred simplified format, matching the most recent WKT ISO standard. Currently an alias to WKT2_2019_SIMPLIFIED, but may change in future versions.
-      PreferredGdal SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED_GDAL ) = Wkt2_2019, //!< Preferred format for conversion of CRS to WKT for use with the GDAL library.
+    {
+        Wkt1Gdal SIP_MONKEYPATCH_COMPAT_NAME( WKT1_GDAL ), //!< WKT1 as traditionally output by GDAL, deriving from OGC 01-009. A notable departure from WKT1_GDAL with respect to OGC 01-009 is that in WKT1_GDAL, the unit of the PRIMEM value is always degrees.
+                 Wkt1Esri SIP_MONKEYPATCH_COMPAT_NAME( WKT1_ESRI ), //!< WKT1 as traditionally output by ESRI software, deriving from OGC 99-049.
+                 Wkt2_2015 SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2015 ), //!< Full WKT2 string, conforming to ISO 19162:2015(E) / OGC 12-063r5 with all possible nodes and new keyword names.
+                 Wkt2_2015Simplified SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2015_SIMPLIFIED ), //!< Same as WKT2_2015 with the following exceptions: UNIT keyword used. ID node only on top element. No ORDER element in AXIS element. PRIMEM node omitted if it is Greenwich.  ELLIPSOID.UNIT node omitted if it is UnitOfMeasure::METRE. PARAMETER.UNIT / PRIMEM.UNIT omitted if same as AXIS. AXIS.UNIT omitted and replaced by a common GEODCRS.UNIT if they are all the same on all axis.
+                 Wkt2_2019  SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2019 ), //!< Full WKT2 string, conforming to ISO 19162:2019 / OGC 18-010, with all possible nodes and new keyword names. Non-normative list of differences: WKT2_2019 uses GEOGCRS / BASEGEOGCRS keywords for GeographicCRS.
+                 Wkt2_2019Simplified  SIP_MONKEYPATCH_COMPAT_NAME( WKT2_2019_SIMPLIFIED ), //!< WKT2_2019 with the simplification rule of WKT2_SIMPLIFIED
+                 Preferred SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED ) = Wkt2_2019, //!< Preferred format, matching the most recent WKT ISO standard. Currently an alias to WKT2_2019, but may change in future versions.
+                 PreferredSimplified  SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED_SIMPLIFIED ) = Wkt2_2019Simplified, //!< Preferred simplified format, matching the most recent WKT ISO standard. Currently an alias to WKT2_2019_SIMPLIFIED, but may change in future versions.
+                 PreferredGdal SIP_MONKEYPATCH_COMPAT_NAME( WKT_PREFERRED_GDAL ) = Wkt2_2019, //!< Preferred format for conversion of CRS to WKT for use with the GDAL library.
     };
     Q_ENUM( CrsWktVariant )
 
@@ -2520,9 +2531,9 @@ class CORE_EXPORT Qgis
      */
     enum class AnnotationItemFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ScaleDependentBoundingBox = 1 << 0, //!< Item's bounding box will vary depending on map scale
-      SupportsReferenceScale = 1 << 1, //!< Item supports reference scale based rendering \since QGIS 3.40
-      SupportsCallouts = 1 << 2, //!< Item supports callouts \since QGIS 3.40
+        ScaleDependentBoundingBox = 1 << 0, //!< Item's bounding box will vary depending on map scale
+        SupportsReferenceScale = 1 << 1, //!< Item supports reference scale based rendering \since QGIS 3.40
+        SupportsCallouts = 1 << 2, //!< Item supports callouts \since QGIS 3.40
     };
     //! Annotation item flags
     Q_DECLARE_FLAGS( AnnotationItemFlags, AnnotationItemFlag )
@@ -2549,7 +2560,7 @@ class CORE_EXPORT Qgis
      */
     enum class AnnotationItemGuiFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      FlagNoCreationTools = 1 << 0,  //!< Do not show item creation tools for the item type
+        FlagNoCreationTools = 1 << 0,  //!< Do not show item creation tools for the item type
     };
     //! Annotation item GUI flags
     Q_DECLARE_FLAGS( AnnotationItemGuiFlags, AnnotationItemGuiFlag )
@@ -2589,11 +2600,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class TemporalNavigationMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTemporalNavigationObject, NavigationMode ) : int
-      {
-      Disabled SIP_MONKEYPATCH_COMPAT_NAME( NavigationOff ), //!< Temporal navigation is disabled
-      Animated, //!< Temporal navigation relies on frames within a datetime range
-      FixedRange, //!< Temporal navigation relies on a fixed datetime range
-      Movie, //!< Movie mode -- behaves like a video player, with a fixed frame duration and no temporal range \since QGIS 3.36
+    {
+        Disabled SIP_MONKEYPATCH_COMPAT_NAME( NavigationOff ), //!< Temporal navigation is disabled
+                 Animated, //!< Temporal navigation relies on frames within a datetime range
+                 FixedRange, //!< Temporal navigation relies on a fixed datetime range
+                 Movie, //!< Movie mode -- behaves like a video player, with a fixed frame duration and no temporal range \since QGIS 3.36
     };
     Q_ENUM( TemporalNavigationMode )
 
@@ -2605,10 +2616,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class AnimationState SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTemporalNavigationObject, AnimationState ) : int
-      {
-      Forward, //!< Animation is playing forward.
-      Reverse, //!< Animation is playing in reverse.
-      Idle, //!< Animation is paused.
+    {
+        Forward, //!< Animation is playing forward.
+        Reverse, //!< Animation is playing in reverse.
+        Idle, //!< Animation is paused.
     };
     Q_ENUM( AnimationState )
 
@@ -2635,13 +2646,13 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class VectorTemporalMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorLayerTemporalProperties, TemporalMode ) : int
-      {
-      FixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ModeFixedTemporalRange ) = 0, //!< Mode when temporal properties have fixed start and end datetimes.
-      FeatureDateTimeInstantFromField SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeInstantFromField ), //!< Mode when features have a datetime instant taken from a single field
-      FeatureDateTimeStartAndEndFromFields SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndEndFromFields ), //!< Mode when features have separate fields for start and end times
-      FeatureDateTimeStartAndDurationFromFields SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndDurationFromFields ), //!< Mode when features have a field for start time and a field for event duration
-      FeatureDateTimeStartAndEndFromExpressions SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndEndFromExpressions ), //!< Mode when features use expressions for start and end times
-      RedrawLayerOnly SIP_MONKEYPATCH_COMPAT_NAME( ModeRedrawLayerOnly ), //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when symbology or rule based renderer expressions depend on the time range.
+    {
+        FixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ModeFixedTemporalRange ) = 0, //!< Mode when temporal properties have fixed start and end datetimes.
+        FeatureDateTimeInstantFromField SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeInstantFromField ), //!< Mode when features have a datetime instant taken from a single field
+        FeatureDateTimeStartAndEndFromFields SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndEndFromFields ), //!< Mode when features have separate fields for start and end times
+        FeatureDateTimeStartAndDurationFromFields SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndDurationFromFields ), //!< Mode when features have a field for start time and a field for event duration
+        FeatureDateTimeStartAndEndFromExpressions SIP_MONKEYPATCH_COMPAT_NAME( ModeFeatureDateTimeStartAndEndFromExpressions ), //!< Mode when features use expressions for start and end times
+        RedrawLayerOnly SIP_MONKEYPATCH_COMPAT_NAME( ModeRedrawLayerOnly ), //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when symbology or rule based renderer expressions depend on the time range.
     };
     Q_ENUM( VectorTemporalMode )
 
@@ -2663,10 +2674,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class VectorDataProviderTemporalMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorDataProviderTemporalCapabilities, TemporalMode ) : int
-      {
-      HasFixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ProviderHasFixedTemporalRange ) = 0, //!< Entire dataset from provider has a fixed start and end datetime.
-      StoresFeatureDateTimeInstantInField SIP_MONKEYPATCH_COMPAT_NAME( ProviderStoresFeatureDateTimeInstantInField ), //!< Dataset has feature datetime instants stored in a single field
-      StoresFeatureDateTimeStartAndEndInSeparateFields SIP_MONKEYPATCH_COMPAT_NAME( ProviderStoresFeatureDateTimeStartAndEndInSeparateFields ), //!< Dataset stores feature start and end datetimes in separate fields
+    {
+        HasFixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ProviderHasFixedTemporalRange ) = 0, //!< Entire dataset from provider has a fixed start and end datetime.
+        StoresFeatureDateTimeInstantInField SIP_MONKEYPATCH_COMPAT_NAME( ProviderStoresFeatureDateTimeInstantInField ), //!< Dataset has feature datetime instants stored in a single field
+        StoresFeatureDateTimeStartAndEndInSeparateFields SIP_MONKEYPATCH_COMPAT_NAME( ProviderStoresFeatureDateTimeStartAndEndInSeparateFields ), //!< Dataset stores feature start and end datetimes in separate fields
     };
     Q_ENUM( VectorDataProviderTemporalMode )
 
@@ -2676,13 +2687,13 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class RasterTemporalMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterLayerTemporalProperties, TemporalMode ) : int
-      {
-      FixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ModeFixedTemporalRange ) = 0, //!< Mode when temporal properties have fixed start and end datetimes.
-      TemporalRangeFromDataProvider SIP_MONKEYPATCH_COMPAT_NAME( ModeTemporalRangeFromDataProvider ) = 1, //!< Mode when raster layer delegates temporal range handling to the dataprovider.
-      RedrawLayerOnly SIP_MONKEYPATCH_COMPAT_NAME( ModeRedrawLayerOnly ) = 2, //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when raster symbology expressions depend on the time range. \since QGIS 3.22
-      FixedRangePerBand = 3, //!< Layer has a fixed temporal range per band \since QGIS 3.38
-      RepresentsTemporalValues = 4, //!< Pixel values represent an datetime
-      FixedDateTime = 5, //!< Layer has a fixed date time instant. \since QGIS 3.44
+    {
+        FixedTemporalRange SIP_MONKEYPATCH_COMPAT_NAME( ModeFixedTemporalRange ) = 0, //!< Mode when temporal properties have fixed start and end datetimes.
+        TemporalRangeFromDataProvider SIP_MONKEYPATCH_COMPAT_NAME( ModeTemporalRangeFromDataProvider ) = 1, //!< Mode when raster layer delegates temporal range handling to the dataprovider.
+        RedrawLayerOnly SIP_MONKEYPATCH_COMPAT_NAME( ModeRedrawLayerOnly ) = 2, //!< Redraw the layer when temporal range changes, but don't apply any filtering. Useful when raster symbology expressions depend on the time range. \since QGIS 3.22
+        FixedRangePerBand = 3, //!< Layer has a fixed temporal range per band \since QGIS 3.38
+        RepresentsTemporalValues = 4, //!< Pixel values represent an datetime
+        FixedDateTime = 5, //!< Layer has a fixed date time instant. \since QGIS 3.44
     };
     Q_ENUM( RasterTemporalMode )
 
@@ -2692,12 +2703,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class TemporalIntervalMatchMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterDataProviderTemporalCapabilities, IntervalHandlingMethod ) : int
-      {
-      MatchUsingWholeRange, //!< Use an exact match to the whole temporal range
-      MatchExactUsingStartOfRange, //!< Match the start of the temporal range to a corresponding layer or band, and only use exact matching results
-      MatchExactUsingEndOfRange, //!< Match the end of the temporal range to a corresponding layer or band, and only use exact matching results
-      FindClosestMatchToStartOfRange, //!< Match the start of the temporal range to the least previous closest datetime.
-      FindClosestMatchToEndOfRange //!< Match the end of the temporal range to the least previous closest datetime.
+    {
+        MatchUsingWholeRange, //!< Use an exact match to the whole temporal range
+        MatchExactUsingStartOfRange, //!< Match the start of the temporal range to a corresponding layer or band, and only use exact matching results
+        MatchExactUsingEndOfRange, //!< Match the end of the temporal range to a corresponding layer or band, and only use exact matching results
+        FindClosestMatchToStartOfRange, //!< Match the start of the temporal range to the least previous closest datetime.
+        FindClosestMatchToEndOfRange //!< Match the end of the temporal range to the least previous closest datetime.
     };
     Q_ENUM( TemporalIntervalMatchMethod )
 
@@ -2708,7 +2719,7 @@ class CORE_EXPORT Qgis
      */
     enum class RasterTemporalCapabilityFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      RequestedTimesMustExactlyMatchAllAvailableTemporalRanges = 1 << 0, //!< If present, indicates that the provider must only request temporal values which are exact matches for the values present in QgsRasterDataProviderTemporalCapabilities::allAvailableTemporalRanges().
+        RequestedTimesMustExactlyMatchAllAvailableTemporalRanges = 1 << 0, //!< If present, indicates that the provider must only request temporal values which are exact matches for the values present in QgsRasterDataProviderTemporalCapabilities::allAvailableTemporalRanges().
     };
     Q_ENUM( RasterTemporalCapabilityFlag )
 
@@ -2726,9 +2737,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class TransformDirection SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCoordinateTransform, TransformDirection ) : int
-      {
-      Forward SIP_MONKEYPATCH_COMPAT_NAME( ForwardTransform ), //!< Forward transform (from source to destination)
-      Reverse SIP_MONKEYPATCH_COMPAT_NAME( ReverseTransform ) //!< Reverse/inverse transform (from destination to source)
+    {
+        Forward SIP_MONKEYPATCH_COMPAT_NAME( ForwardTransform ), //!< Forward transform (from source to destination)
+                Reverse SIP_MONKEYPATCH_COMPAT_NAME( ReverseTransform ) //!< Reverse/inverse transform (from destination to source)
     };
     Q_ENUM( TransformDirection )
 
@@ -2739,8 +2750,8 @@ class CORE_EXPORT Qgis
      */
     enum class CoordinateTransformationFlag  : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      BallparkTransformsAreAppropriate = 1 << 0, //!< Indicates that approximate "ballpark" results are appropriate for this coordinate transform. See QgsCoordinateTransform::setBallparkTransformsAreAppropriate() for further details.
-      IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::isTransformationPossible() and QgsCoordinateTransform::isValid().
+        BallparkTransformsAreAppropriate = 1 << 0, //!< Indicates that approximate "ballpark" results are appropriate for this coordinate transform. See QgsCoordinateTransform::setBallparkTransformsAreAppropriate() for further details.
+                                         IgnoreImpossibleTransformations = 1 << 1, //!< Indicates that impossible transformations (such as those which attempt to transform between two different celestial bodies) should be silently handled and marked as invalid. See QgsCoordinateTransform::isTransformationPossible() and QgsCoordinateTransform::isValid().
     };
     Q_ENUM( CoordinateTransformationFlag )
 
@@ -2772,25 +2783,25 @@ class CORE_EXPORT Qgis
      */
     enum class MapSettingsFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMapSettings, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Antialiasing             = 0x01,  //!< Enable anti-aliasing for map rendering
-      DrawEditingInfo          = 0x02,  //!< Enable drawing of vertex markers for layers in editing mode
-      ForceVectorOutput        = 0x04,  //!< Vector graphics should not be cached and drawn as raster images. \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
-      UseAdvancedEffects       = 0x08,  //!< Enable layer opacity and blending effects \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
-      DrawLabeling             = 0x10,  //!< Enable drawing of labels on top of the map
-      UseRenderingOptimization = 0x20,  //!< Enable vector simplification and other rendering optimizations
-      DrawSelection            = 0x40,  //!< Whether vector selections should be shown in the rendered map
-      DrawSymbolBounds         = 0x80,  //!< Draw bounds of symbols (for debugging/testing)
-      RenderMapTile            = 0x100, //!< Draw map such that there are no problems between adjacent tiles
-      RenderPartialOutput      = 0x200, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
-      RenderPreviewJob         = 0x400, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
-      RenderBlocking           = 0x800, //!< Render and load remote sources in the same thread to ensure rendering remote sources (svg and images). WARNING: this flag must NEVER be used from GUI based applications (like the main QGIS application) or crashes will result. Only for use in external scripts or QGIS server.
-      LosslessImageRendering   = 0x1000, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF). This flag only works with builds based on Qt 5.13 or later.
-      Render3DMap              = 0x2000, //!< Render is for a 3D map
-      HighQualityImageTransforms = 0x4000, //!< Enable high quality image transformations, which results in better appearance of scaled or rotated raster components of a map \since QGIS 3.24
-      SkipSymbolRendering      = 0x8000, //!< Disable symbol rendering while still drawing labels if enabled \since QGIS 3.24
-      ForceRasterMasks         = 0x10000,  //!< Force symbol masking to be applied using a raster method. This is considerably faster when compared to the vector method, but results in a inferior quality output. \since QGIS 3.26.1
-      RecordProfile            = 0x20000, //!< Enable run-time profiling while rendering \since QGIS 3.34
-      AlwaysUseGlobalMasks     = 0x40000, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex vector exports in all current Qt versions. This flag only applies to vector map exports. \since QGIS 3.38
+        Antialiasing             = 0x01,  //!< Enable anti-aliasing for map rendering
+        DrawEditingInfo          = 0x02,  //!< Enable drawing of vertex markers for layers in editing mode
+        ForceVectorOutput        = 0x04,  //!< Vector graphics should not be cached and drawn as raster images. \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
+        UseAdvancedEffects       = 0x08,  //!< Enable layer opacity and blending effects \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
+        DrawLabeling             = 0x10,  //!< Enable drawing of labels on top of the map
+        UseRenderingOptimization = 0x20,  //!< Enable vector simplification and other rendering optimizations
+        DrawSelection            = 0x40,  //!< Whether vector selections should be shown in the rendered map
+        DrawSymbolBounds         = 0x80,  //!< Draw bounds of symbols (for debugging/testing)
+        RenderMapTile            = 0x100, //!< Draw map such that there are no problems between adjacent tiles
+        RenderPartialOutput      = 0x200, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
+        RenderPreviewJob         = 0x400, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
+        RenderBlocking           = 0x800, //!< Render and load remote sources in the same thread to ensure rendering remote sources (svg and images). WARNING: this flag must NEVER be used from GUI based applications (like the main QGIS application) or crashes will result. Only for use in external scripts or QGIS server.
+        LosslessImageRendering   = 0x1000, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF). This flag only works with builds based on Qt 5.13 or later.
+        Render3DMap              = 0x2000, //!< Render is for a 3D map
+        HighQualityImageTransforms = 0x4000, //!< Enable high quality image transformations, which results in better appearance of scaled or rotated raster components of a map \since QGIS 3.24
+        SkipSymbolRendering      = 0x8000, //!< Disable symbol rendering while still drawing labels if enabled \since QGIS 3.24
+        ForceRasterMasks         = 0x10000,  //!< Force symbol masking to be applied using a raster method. This is considerably faster when compared to the vector method, but results in a inferior quality output. \since QGIS 3.26.1
+        RecordProfile            = 0x20000, //!< Enable run-time profiling while rendering \since QGIS 3.34
+        AlwaysUseGlobalMasks     = 0x40000, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex vector exports in all current Qt versions. This flag only applies to vector map exports. \since QGIS 3.38
     };
     //! Map settings flags
     Q_DECLARE_FLAGS( MapSettingsFlags, MapSettingsFlag ) SIP_MONKEYPATCH_FLAGS_UNNEST( QgsMapSettings, Flags )
@@ -2804,29 +2815,29 @@ class CORE_EXPORT Qgis
      */
     enum class RenderContextFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRenderContext, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      DrawEditingInfo          = 0x01,  //!< Enable drawing of vertex markers for layers in editing mode
-      ForceVectorOutput        = 0x02,  //!< Vector graphics should not be cached and drawn as raster images \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
-      UseAdvancedEffects       = 0x04,  //!< Enable layer opacity and blending effects \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
-      UseRenderingOptimization = 0x08,  //!< Enable vector simplification and other rendering optimizations
-      DrawSelection            = 0x10,  //!< Whether vector selections should be shown in the rendered map
-      DrawSymbolBounds         = 0x20,  //!< Draw bounds of symbols (for debugging/testing)
-      RenderMapTile            = 0x40,  //!< Draw map such that there are no problems between adjacent tiles
-      Antialiasing             = 0x80,  //!< Use antialiasing while drawing
-      RenderPartialOutput      = 0x100, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
-      RenderPreviewJob         = 0x200, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
-      RenderBlocking           = 0x400, //!< Render and load remote sources in the same thread to ensure rendering remote sources (svg and images). WARNING: this flag must NEVER be used from GUI based applications (like the main QGIS application) or crashes will result. Only for use in external scripts or QGIS server.
-      RenderSymbolPreview      = 0x800, //!< The render is for a symbol preview only and map based properties may not be available, so care should be taken to handle map unit based sizes in an appropriate way.
-      LosslessImageRendering   = 0x1000, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF). This flag only works with builds based on Qt 5.13 or later.
-      ApplyScalingWorkaroundForTextRendering = 0x2000, //!< Whether a scaling workaround designed to stablise the rendering of small font sizes (or for painters scaled out by a large amount) when rendering text. Generally this is recommended, but it may incur some performance cost.
-      Render3DMap              = 0x4000, //!< Render is for a 3D map
-      ApplyClipAfterReprojection = 0x8000, //!< Feature geometry clipping to mapExtent() must be performed after the geometries are transformed using coordinateTransform(). Usually feature geometry clipping occurs using the extent() in the layer's CRS prior to geometry transformation, but in some cases when extent() could not be accurately calculated it is necessary to clip geometries to mapExtent() AFTER transforming them using coordinateTransform().
-      RenderingSubSymbol       = 0x10000, //!< Set whenever a sub-symbol of a parent symbol is currently being rendered. Can be used during symbol and symbol layer rendering to determine whether the symbol being rendered is a subsymbol. \since QGIS 3.24
-      HighQualityImageTransforms = 0x20000, //!< Enable high quality image transformations, which results in better appearance of scaled or rotated raster components of a map \since QGIS 3.24
-      SkipSymbolRendering      = 0x40000, //!< Disable symbol rendering while still drawing labels if enabled \since QGIS 3.24
-      RecordProfile            = 0x80000, //!< Enable run-time profiling while rendering \since QGIS 3.34
-      AlwaysUseGlobalMasks     = 0x100000, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex vector exports in all current Qt versions. This flag only applies to vector map exports. \since QGIS 3.38
-      DisableSymbolClippingToExtent = 0x200000, //!< Force symbol clipping to map extent to be disabled in all situations. This will result in slower rendering, and should only be used in situations where the feature clipping is always undesirable. \since QGIS 3.40
-      RenderLayerTree = 0x400000        //!< The render is for a layer tree display where map based properties are not available and where avoidance of long rendering freeze is crucial \since QGIS 3.44
+        DrawEditingInfo          = 0x01,  //!< Enable drawing of vertex markers for layers in editing mode
+        ForceVectorOutput        = 0x02,  //!< Vector graphics should not be cached and drawn as raster images \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
+        UseAdvancedEffects       = 0x04,  //!< Enable layer opacity and blending effects \deprecated QGIS 3.44. Use Qgis::RasterizedRenderingPolicy instead.
+        UseRenderingOptimization = 0x08,  //!< Enable vector simplification and other rendering optimizations
+        DrawSelection            = 0x10,  //!< Whether vector selections should be shown in the rendered map
+        DrawSymbolBounds         = 0x20,  //!< Draw bounds of symbols (for debugging/testing)
+        RenderMapTile            = 0x40,  //!< Draw map such that there are no problems between adjacent tiles
+        Antialiasing             = 0x80,  //!< Use antialiasing while drawing
+        RenderPartialOutput      = 0x100, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
+        RenderPreviewJob         = 0x200, //!< Render is a 'canvas preview' render, and shortcuts should be taken to ensure fast rendering
+        RenderBlocking           = 0x400, //!< Render and load remote sources in the same thread to ensure rendering remote sources (svg and images). WARNING: this flag must NEVER be used from GUI based applications (like the main QGIS application) or crashes will result. Only for use in external scripts or QGIS server.
+        RenderSymbolPreview      = 0x800, //!< The render is for a symbol preview only and map based properties may not be available, so care should be taken to handle map unit based sizes in an appropriate way.
+        LosslessImageRendering   = 0x1000, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF). This flag only works with builds based on Qt 5.13 or later.
+        ApplyScalingWorkaroundForTextRendering = 0x2000, //!< Whether a scaling workaround designed to stablise the rendering of small font sizes (or for painters scaled out by a large amount) when rendering text. Generally this is recommended, but it may incur some performance cost.
+        Render3DMap              = 0x4000, //!< Render is for a 3D map
+        ApplyClipAfterReprojection = 0x8000, //!< Feature geometry clipping to mapExtent() must be performed after the geometries are transformed using coordinateTransform(). Usually feature geometry clipping occurs using the extent() in the layer's CRS prior to geometry transformation, but in some cases when extent() could not be accurately calculated it is necessary to clip geometries to mapExtent() AFTER transforming them using coordinateTransform().
+        RenderingSubSymbol       = 0x10000, //!< Set whenever a sub-symbol of a parent symbol is currently being rendered. Can be used during symbol and symbol layer rendering to determine whether the symbol being rendered is a subsymbol. \since QGIS 3.24
+        HighQualityImageTransforms = 0x20000, //!< Enable high quality image transformations, which results in better appearance of scaled or rotated raster components of a map \since QGIS 3.24
+        SkipSymbolRendering      = 0x40000, //!< Disable symbol rendering while still drawing labels if enabled \since QGIS 3.24
+        RecordProfile            = 0x80000, //!< Enable run-time profiling while rendering \since QGIS 3.34
+        AlwaysUseGlobalMasks     = 0x100000, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex vector exports in all current Qt versions. This flag only applies to vector map exports. \since QGIS 3.38
+        DisableSymbolClippingToExtent = 0x200000, //!< Force symbol clipping to map extent to be disabled in all situations. This will result in slower rendering, and should only be used in situations where the feature clipping is always undesirable. \since QGIS 3.40
+        RenderLayerTree = 0x400000        //!< The render is for a layer tree display where map based properties are not available and where avoidance of long rendering freeze is crucial \since QGIS 3.44
     };
     //! Render context flags
     Q_DECLARE_FLAGS( RenderContextFlags, RenderContextFlag ) SIP_MONKEYPATCH_FLAGS_UNNEST( QgsRenderContext, Flags )
@@ -2840,9 +2851,9 @@ class CORE_EXPORT Qgis
      */
     enum class MapLayerRendererFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      RenderPartialOutputs = 1 << 0,  //!< The renderer benefits from rendering temporary in-progress preview renders. These are temporary results which will be used for the layer during rendering in-progress compositions, which will differ from the final layer render. They can be used for showing overlays or other information to users which help inform them about what is actually occurring during a slow layer render, but where these overlays and additional content is not wanted in the final layer renders. Another use case is rendering unsorted results as soon as they are available, before doing a final sorted render of the entire layer contents.
-      RenderPartialOutputOverPreviousCachedImage = 1 << 1,//!< When rendering temporary in-progress preview renders, these preview renders can be drawn over any previously cached layer render we have for the same region. This can allow eg a low-resolution zoomed in version of the last map render to be used as a base painting surface to overdraw with incremental preview render outputs. If not set, an empty image will be used as the starting point for the render preview image.
-      AffectsLabeling = 1 << 2, //!< The layer rendering will interact with the map labeling \since QGIS 3.40
+        RenderPartialOutputs = 1 << 0,  //!< The renderer benefits from rendering temporary in-progress preview renders. These are temporary results which will be used for the layer during rendering in-progress compositions, which will differ from the final layer render. They can be used for showing overlays or other information to users which help inform them about what is actually occurring during a slow layer render, but where these overlays and additional content is not wanted in the final layer renders. Another use case is rendering unsorted results as soon as they are available, before doing a final sorted render of the entire layer contents.
+        RenderPartialOutputOverPreviousCachedImage = 1 << 1,//!< When rendering temporary in-progress preview renders, these preview renders can be drawn over any previously cached layer render we have for the same region. This can allow eg a low-resolution zoomed in version of the last map render to be used as a base painting surface to overdraw with incremental preview render outputs. If not set, an empty image will be used as the starting point for the render preview image.
+        AffectsLabeling = 1 << 2, //!< The layer rendering will interact with the map labeling \since QGIS 3.40
     };
     Q_ENUM( MapLayerRendererFlag )
 
@@ -2861,7 +2872,7 @@ class CORE_EXPORT Qgis
      */
     enum class PaintEffectFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      RequiresRasterization = 1 << 0, //!< The effect requires raster-based rendering.
+        RequiresRasterization = 1 << 0, //!< The effect requires raster-based rendering.
     };
     Q_ENUM( PaintEffectFlag )
 
@@ -2881,10 +2892,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class TextRenderFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRenderContext, TextRenderFormat ) : int
-      {
-      AlwaysOutlines SIP_MONKEYPATCH_COMPAT_NAME( TextFormatAlwaysOutlines ), //!< Always render text using path objects (AKA outlines/curves). This setting guarantees the best quality rendering, even when using a raster paint surface (where sub-pixel path based text rendering is superior to sub-pixel text-based rendering). The downside is that text is converted to paths only, so users cannot open created vector outputs for post-processing in other applications and retain text editability.  This setting also guarantees complete compatibility with the full range of formatting options available through QgsTextRenderer and QgsTextFormat, some of which may not be possible to reproduce when using a vector-based paint surface and TextFormatAlwaysText mode. A final benefit to this setting is that vector exports created using text as outlines do not require all users to have the original fonts installed in order to display the text in its original style.
-      AlwaysText SIP_MONKEYPATCH_COMPAT_NAME( TextFormatAlwaysText ), //!< Always render text as text objects. While this mode preserves text objects as text for post-processing in external vector editing applications, it can result in rendering artifacts or poor quality rendering, depending on the text format settings. Even with raster based paint devices, TextFormatAlwaysText can result in inferior rendering quality to TextFormatAlwaysOutlines. When rendering using TextFormatAlwaysText to a vector based device (e.g. PDF or SVG), care must be taken to ensure that the required fonts are available to users when opening the created files, or default fallback fonts will be used to display the output instead. (Although PDF exports MAY automatically embed some fonts when possible, depending on the user's platform).
-      PreferText, //!< Render text as text objects, unless doing so results in rendering artifacts or poor quality rendering (depending on text format settings). When rendering using TextFormatAlwaysText to a vector based device (e.g. PDF or SVG), care must be taken to ensure that the required fonts are available to users when opening the created files, or default fallback fonts will be used to display the output instead. (Although PDF exports MAY automatically embed some fonts when possible, depending on the user's platform). \since QGIS 3.40
+    {
+        AlwaysOutlines SIP_MONKEYPATCH_COMPAT_NAME( TextFormatAlwaysOutlines ), //!< Always render text using path objects (AKA outlines/curves). This setting guarantees the best quality rendering, even when using a raster paint surface (where sub-pixel path based text rendering is superior to sub-pixel text-based rendering). The downside is that text is converted to paths only, so users cannot open created vector outputs for post-processing in other applications and retain text editability.  This setting also guarantees complete compatibility with the full range of formatting options available through QgsTextRenderer and QgsTextFormat, some of which may not be possible to reproduce when using a vector-based paint surface and TextFormatAlwaysText mode. A final benefit to this setting is that vector exports created using text as outlines do not require all users to have the original fonts installed in order to display the text in its original style.
+                       AlwaysText SIP_MONKEYPATCH_COMPAT_NAME( TextFormatAlwaysText ), //!< Always render text as text objects. While this mode preserves text objects as text for post-processing in external vector editing applications, it can result in rendering artifacts or poor quality rendering, depending on the text format settings. Even with raster based paint devices, TextFormatAlwaysText can result in inferior rendering quality to TextFormatAlwaysOutlines. When rendering using TextFormatAlwaysText to a vector based device (e.g. PDF or SVG), care must be taken to ensure that the required fonts are available to users when opening the created files, or default fallback fonts will be used to display the output instead. (Although PDF exports MAY automatically embed some fonts when possible, depending on the user's platform).
+                       PreferText, //!< Render text as text objects, unless doing so results in rendering artifacts or poor quality rendering (depending on text format settings). When rendering using TextFormatAlwaysText to a vector based device (e.g. PDF or SVG), care must be taken to ensure that the required fonts are available to users when opening the created files, or default fallback fonts will be used to display the output instead. (Although PDF exports MAY automatically embed some fonts when possible, depending on the user's platform). \since QGIS 3.40
     };
     Q_ENUM( TextRenderFormat )
 
@@ -2897,15 +2908,15 @@ class CORE_EXPORT Qgis
      */
     enum class LabelingFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLabelingEngineSettings, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      UseAllLabels          = 1 << 1, //!< Whether to draw all labels even if there would be collisions
-      UsePartialCandidates  = 1 << 2, //!< Whether to use also label candidates that are partially outside of the map view
-      // TODO QGIS 5.0: remove
-      RenderOutlineLabels   = 1 << 3, //!< Whether to render labels as text or outlines. Deprecated and of QGIS 3.4.3 - use defaultTextRenderFormat() instead.
-      DrawLabelRectOnly     = 1 << 4, //!< Whether to only draw the label rect and not the actual label text (used for unit tests)
-      DrawCandidates        = 1 << 5, //!< Whether to draw rectangles of generated candidates (good for debugging)
-      DrawUnplacedLabels    = 1 << 6, //!< Whether to render unplaced labels as an indicator/warning for users
-      CollectUnplacedLabels = 1 << 7, //!< Whether unplaced labels should be collected in the labeling results (regardless of whether they are being rendered) \since QGIS 3.20
-      DrawLabelMetrics      = 1 << 8, //!< Whether to render label metric guides (for debugging) \since QGIS 3.30
+        UseAllLabels          = 1 << 1, //!< Whether to draw all labels even if there would be collisions
+        UsePartialCandidates  = 1 << 2, //!< Whether to use also label candidates that are partially outside of the map view
+        // TODO QGIS 5.0: remove
+        RenderOutlineLabels   = 1 << 3, //!< Whether to render labels as text or outlines. Deprecated and of QGIS 3.4.3 - use defaultTextRenderFormat() instead.
+        DrawLabelRectOnly     = 1 << 4, //!< Whether to only draw the label rect and not the actual label text (used for unit tests)
+        DrawCandidates        = 1 << 5, //!< Whether to draw rectangles of generated candidates (good for debugging)
+        DrawUnplacedLabels    = 1 << 6, //!< Whether to render unplaced labels as an indicator/warning for users
+        CollectUnplacedLabels = 1 << 7, //!< Whether unplaced labels should be collected in the labeling results (regardless of whether they are being rendered) \since QGIS 3.20
+        DrawLabelMetrics      = 1 << 8, //!< Whether to render label metric guides (for debugging) \since QGIS 3.30
     };
     Q_ENUM( LabelingFlag )
 
@@ -2927,9 +2938,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class LabelPlacementEngineVersion SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLabelingEngineSettings, PlacementEngineVersion ) : int
-      {
-      Version1 SIP_MONKEYPATCH_COMPAT_NAME( PlacementEngineVersion1 ), //!< Version 1, matches placement from QGIS <= 3.10.1
-      Version2 SIP_MONKEYPATCH_COMPAT_NAME( PlacementEngineVersion2 ), //!< Version 2 (default for new projects since QGIS 3.12)
+    {
+        Version1 SIP_MONKEYPATCH_COMPAT_NAME( PlacementEngineVersion1 ), //!< Version 1, matches placement from QGIS <= 3.10.1
+                 Version2 SIP_MONKEYPATCH_COMPAT_NAME( PlacementEngineVersion2 ), //!< Version 2 (default for new projects since QGIS 3.12)
     };
     Q_ENUM( LabelPlacementEngineVersion )
 
@@ -2941,10 +2952,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class TextOrientation SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextFormat, TextOrientation ) : int
-      {
-      Horizontal SIP_MONKEYPATCH_COMPAT_NAME( HorizontalOrientation ), //!< Horizontally oriented text
-      Vertical SIP_MONKEYPATCH_COMPAT_NAME( VerticalOrientation ), //!< Vertically oriented text
-      RotationBased SIP_MONKEYPATCH_COMPAT_NAME( RotationBasedOrientation ), //!< Horizontally or vertically oriented text based on rotation (only available for map labeling)
+    {
+        Horizontal SIP_MONKEYPATCH_COMPAT_NAME( HorizontalOrientation ), //!< Horizontally oriented text
+                   Vertical SIP_MONKEYPATCH_COMPAT_NAME( VerticalOrientation ), //!< Vertically oriented text
+                   RotationBased SIP_MONKEYPATCH_COMPAT_NAME( RotationBasedOrientation ), //!< Horizontally or vertically oriented text based on rotation (only available for map labeling)
     };
     Q_ENUM( TextOrientation )
 
@@ -2956,12 +2967,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class TextLayoutMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextRenderer, DrawMode ) : int
-      {
-      Rectangle SIP_MONKEYPATCH_COMPAT_NAME( Rect ), //!< Text within rectangle layout mode
-      Point, //!< Text at point of origin layout mode
-      Labeling SIP_MONKEYPATCH_COMPAT_NAME( Label ), //!< Labeling-specific layout mode
-      RectangleCapHeightBased, //!< Similar to Rectangle mode, but uses cap height only when calculating font heights for the first line of text, and cap height + descent for subsequent lines of text \since QGIS 3.30
-      RectangleAscentBased, //!< Similar to Rectangle mode, but uses ascents only when calculating font and line heights. \since QGIS 3.30
+    {
+        Rectangle SIP_MONKEYPATCH_COMPAT_NAME( Rect ), //!< Text within rectangle layout mode
+                  Point, //!< Text at point of origin layout mode
+                  Labeling SIP_MONKEYPATCH_COMPAT_NAME( Label ), //!< Labeling-specific layout mode
+                  RectangleCapHeightBased, //!< Similar to Rectangle mode, but uses cap height only when calculating font heights for the first line of text, and cap height + descent for subsequent lines of text \since QGIS 3.30
+                  RectangleAscentBased, //!< Similar to Rectangle mode, but uses ascents only when calculating font and line heights. \since QGIS 3.30
     };
     Q_ENUM( TextLayoutMode )
 
@@ -2974,10 +2985,10 @@ class CORE_EXPORT Qgis
      */
     enum class TextComponent SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextRenderer, TextPart ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Text = 1 << 0, //!< Text component
-      Buffer = 1 << 1, //!< Buffer component
-      Background = 1 << 2, //!< Background shape
-      Shadow = 1 << 3, //!< Drop shadow
+        Text = 1 << 0, //!< Text component
+        Buffer = 1 << 1, //!< Buffer component
+        Background = 1 << 2, //!< Background shape
+        Shadow = 1 << 3, //!< Drop shadow
     };
     Q_ENUM( TextComponent )
 
@@ -2997,11 +3008,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class TextHorizontalAlignment SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextRenderer, HAlignment ) : int
-      {
-      Left SIP_MONKEYPATCH_COMPAT_NAME( AlignLeft ), //!< Left align
-      Center SIP_MONKEYPATCH_COMPAT_NAME( AlignCenter ), //!< Center align
-      Right SIP_MONKEYPATCH_COMPAT_NAME( AlignRight ), //!< Right align
-      Justify SIP_MONKEYPATCH_COMPAT_NAME( AlignJustify ), //!< Justify align
+    {
+        Left SIP_MONKEYPATCH_COMPAT_NAME( AlignLeft ), //!< Left align
+             Center SIP_MONKEYPATCH_COMPAT_NAME( AlignCenter ), //!< Center align
+             Right SIP_MONKEYPATCH_COMPAT_NAME( AlignRight ), //!< Right align
+             Justify SIP_MONKEYPATCH_COMPAT_NAME( AlignJustify ), //!< Justify align
     };
     Q_ENUM( TextHorizontalAlignment )
 
@@ -3016,10 +3027,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class TextVerticalAlignment SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextRenderer, VAlignment ) : int
-      {
-      Top SIP_MONKEYPATCH_COMPAT_NAME( AlignTop ), //!< Align to top
-      VerticalCenter SIP_MONKEYPATCH_COMPAT_NAME( AlignVCenter ), //!< Center align
-      Bottom SIP_MONKEYPATCH_COMPAT_NAME( AlignBottom ), //!< Align to bottom
+    {
+        Top SIP_MONKEYPATCH_COMPAT_NAME( AlignTop ), //!< Align to top
+            VerticalCenter SIP_MONKEYPATCH_COMPAT_NAME( AlignVCenter ), //!< Center align
+            Bottom SIP_MONKEYPATCH_COMPAT_NAME( AlignBottom ), //!< Align to bottom
     };
     Q_ENUM( TextVerticalAlignment )
 
@@ -3046,10 +3057,10 @@ class CORE_EXPORT Qgis
      */
     enum class CurvedTextFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTextRendererUtils, CurvedTextFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      TruncateStringWhenLineIsTooShort = 1 << 0, //!< When a string is too long for the line, truncate characters instead of aborting the placement
-      UseBaselinePlacement = 1 << 1, //!< Generate placement based on the character baselines instead of centers
-      UprightCharactersOnly = 1 << 2, //!< Permit upright characters only. If not present then upside down text placement is permitted.
-      ExtendLineToFitText = 1 << 3, //!< When a string is too long for the line, extend the line's final segment to fit the entire string. \since QGIS 4.0
+        TruncateStringWhenLineIsTooShort = 1 << 0, //!< When a string is too long for the line, truncate characters instead of aborting the placement
+        UseBaselinePlacement = 1 << 1, //!< Generate placement based on the character baselines instead of centers
+        UprightCharactersOnly = 1 << 2, //!< Permit upright characters only. If not present then upside down text placement is permitted.
+        ExtendLineToFitText = 1 << 3, //!< When a string is too long for the line, extend the line's final segment to fit the entire string. \since QGIS 4.0
     };
     Q_ENUM( CurvedTextFlag )
 
@@ -3068,11 +3079,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.38
      */
     enum class VectorSimplificationAlgorithm SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorSimplifyMethod, SimplifyAlgorithm ) : int
-      {
-      Distance = 0, //!< The simplification uses the distance between points to remove duplicate points
-      SnapToGrid = 1, //!< The simplification uses a grid (similar to ST_SnapToGrid) to remove duplicate points
-      Visvalingam = 2, //!< The simplification gives each point in a line an importance weighting, so that least important points are removed first
-      SnappedToGridGlobal = 3, //!< Snap to a global grid based on the tolerance. Good for consistent results for incoming vertices, regardless of their feature
+    {
+        Distance = 0, //!< The simplification uses the distance between points to remove duplicate points
+        SnapToGrid = 1, //!< The simplification uses a grid (similar to ST_SnapToGrid) to remove duplicate points
+        Visvalingam = 2, //!< The simplification gives each point in a line an importance weighting, so that least important points are removed first
+        SnappedToGridGlobal = 3, //!< Snap to a global grid based on the tolerance. Good for consistent results for incoming vertices, regardless of their feature
     };
     Q_ENUM( VectorSimplificationAlgorithm )
 
@@ -3085,10 +3096,10 @@ class CORE_EXPORT Qgis
      */
     enum class VectorRenderingSimplificationFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorSimplifyMethod, SimplifyHint ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoSimplification           = 0, //!< No simplification can be applied
-      GeometrySimplification     = 1, //!< The geometries can be simplified using the current map2pixel context state
-      AntialiasingSimplification = 2, //!< The geometries can be rendered with 'AntiAliasing' disabled because of it is '1-pixel size'
-      FullSimplification         = 3, //!< All simplification hints can be applied ( Geometry + AA-disabling )
+        NoSimplification           = 0, //!< No simplification can be applied
+        GeometrySimplification     = 1, //!< The geometries can be simplified using the current map2pixel context state
+        AntialiasingSimplification = 2, //!< The geometries can be rendered with 'AntiAliasing' disabled because of it is '1-pixel size'
+        FullSimplification         = 3, //!< All simplification hints can be applied ( Geometry + AA-disabling )
     };
     Q_ENUM( VectorRenderingSimplificationFlag )
 
@@ -3133,9 +3144,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.22
      */
     enum class VertexType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVertexId, VertexType ) : int
-      {
-      Segment SIP_MONKEYPATCH_COMPAT_NAME( SegmentVertex ) = 1, //!< The actual start or end point of a segment
-      Curve SIP_MONKEYPATCH_COMPAT_NAME( CurveVertex ) = 2, //!< An intermediate point on a segment defining the curvature of the segment
+    {
+        Segment SIP_MONKEYPATCH_COMPAT_NAME( SegmentVertex ) = 1, //!< The actual start or end point of a segment
+        Curve SIP_MONKEYPATCH_COMPAT_NAME( CurveVertex ) = 2, //!< An intermediate point on a segment defining the curvature of the segment
       ControlPoint SIP_MONKEYPATCH_COMPAT_NAME( ControlPointVertex ) = 3, //!< A NURBS control point (does not lie on the curve) \since QGIS 4.0
     };
     Q_ENUM( VertexType )
@@ -3148,44 +3159,44 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class MarkerShape SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsSimpleMarkerSymbolLayerBase, Shape ) : int
-      {
-      Square, //!< Square
-      Diamond, //!< Diamond
-      Pentagon, //!< Pentagon
-      Hexagon, //!< Hexagon
-      Triangle, //!< Triangle
-      EquilateralTriangle, //!< Equilateral triangle
-      Star, //!< Star
-      Arrow, //!< Arrow
-      Circle, //!< Circle
-      Cross, //!< Cross (lines only)
-      CrossFill, //!< Solid filled cross
-      Cross2, //!< Rotated cross (lines only), 'x' shape
-      Line, //!< Vertical line
-      ArrowHead, //!< Right facing arrow head (unfilled, lines only)
-      ArrowHeadFilled, //!< Right facing filled arrow head
-      SemiCircle, //!< Semi circle (top half)
-      ThirdCircle, //!< One third circle (top left third)
-      QuarterCircle, //!< Quarter circle (top left quarter)
-      QuarterSquare, //!< Quarter square (top left quarter)
-      HalfSquare, //!< Half square (left half)
-      DiagonalHalfSquare, //!< Diagonal half square (bottom left half)
-      RightHalfTriangle, //!< Right half of triangle
-      LeftHalfTriangle, //!< Left half of triangle
-      Octagon, //!< Octagon \since QGIS 3.18
-      SquareWithCorners, //!< A square with diagonal corners \since QGIS 3.18
-      AsteriskFill, //!< A filled asterisk shape \since QGIS 3.18
-      HalfArc, //!< A line-only half arc \since QGIS 3.20
-      ThirdArc, //!< A line-only one third arc \since QGIS 3.20
-      QuarterArc, //!< A line-only one quarter arc \since QGIS 3.20
-      ParallelogramRight, //!< Parallelogram that slants right \since QGIS 3.28
-      ParallelogramLeft, //!< Parallelogram that slants left \since QGIS 3.28
-      Trapezoid, //!< Trapezoid \since QGIS 3.28
-      Shield, //!< A shape consisting of a triangle attached to a rectangle \since QGIS 3.28
-      DiamondStar, //!< A 4-sided star \since QGIS 3.28
-      Heart, //!< Heart \since QGIS 3.28
-      Decagon, //!< Decagon \since QGIS 3.28
-      RoundedSquare, //!< A square with rounded corners \since QGIS 3.28
+    {
+        Square, //!< Square
+        Diamond, //!< Diamond
+        Pentagon, //!< Pentagon
+        Hexagon, //!< Hexagon
+        Triangle, //!< Triangle
+        EquilateralTriangle, //!< Equilateral triangle
+        Star, //!< Star
+        Arrow, //!< Arrow
+        Circle, //!< Circle
+        Cross, //!< Cross (lines only)
+        CrossFill, //!< Solid filled cross
+        Cross2, //!< Rotated cross (lines only), 'x' shape
+        Line, //!< Vertical line
+        ArrowHead, //!< Right facing arrow head (unfilled, lines only)
+        ArrowHeadFilled, //!< Right facing filled arrow head
+        SemiCircle, //!< Semi circle (top half)
+        ThirdCircle, //!< One third circle (top left third)
+        QuarterCircle, //!< Quarter circle (top left quarter)
+        QuarterSquare, //!< Quarter square (top left quarter)
+        HalfSquare, //!< Half square (left half)
+        DiagonalHalfSquare, //!< Diagonal half square (bottom left half)
+        RightHalfTriangle, //!< Right half of triangle
+        LeftHalfTriangle, //!< Left half of triangle
+        Octagon, //!< Octagon \since QGIS 3.18
+        SquareWithCorners, //!< A square with diagonal corners \since QGIS 3.18
+        AsteriskFill, //!< A filled asterisk shape \since QGIS 3.18
+        HalfArc, //!< A line-only half arc \since QGIS 3.20
+        ThirdArc, //!< A line-only one third arc \since QGIS 3.20
+        QuarterArc, //!< A line-only one quarter arc \since QGIS 3.20
+        ParallelogramRight, //!< Parallelogram that slants right \since QGIS 3.28
+        ParallelogramLeft, //!< Parallelogram that slants left \since QGIS 3.28
+        Trapezoid, //!< Trapezoid \since QGIS 3.28
+        Shield, //!< A shape consisting of a triangle attached to a rectangle \since QGIS 3.28
+        DiamondStar, //!< A 4-sided star \since QGIS 3.28
+        Heart, //!< Heart \since QGIS 3.28
+        Decagon, //!< Decagon \since QGIS 3.28
+        RoundedSquare, //!< A square with rounded corners \since QGIS 3.28
     };
     Q_ENUM( MarkerShape )
 
@@ -3198,14 +3209,14 @@ class CORE_EXPORT Qgis
      */
     enum class MarkerLinePlacement SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTemplatedLineSymbolLayerBase, Placement ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Interval = 1 << 0, //!< Place symbols at regular intervals
-      Vertex = 1 << 1, //!< Place symbols on every vertex in the line
-      LastVertex = 1 << 2, //!< Place symbols on the last vertex in the line
-      FirstVertex = 1 << 3, //!< Place symbols on the first vertex in the line
-      CentralPoint = 1 << 4, //!< Place symbols at the mid point of the line
-      CurvePoint = 1 << 5, //!< Place symbols at every virtual curve point in the line (used when rendering curved geometry types only)
-      SegmentCenter = 1 << 6, //!< Place symbols at the center of every line segment
-      InnerVertices = 1 << 7, //!< Inner vertices (i.e. all vertices except the first and last vertex) \since QGIS 3.24
+        Interval = 1 << 0, //!< Place symbols at regular intervals
+        Vertex = 1 << 1, //!< Place symbols on every vertex in the line
+        LastVertex = 1 << 2, //!< Place symbols on the last vertex in the line
+        FirstVertex = 1 << 3, //!< Place symbols on the first vertex in the line
+        CentralPoint = 1 << 4, //!< Place symbols at the mid point of the line
+        CurvePoint = 1 << 5, //!< Place symbols at every virtual curve point in the line (used when rendering curved geometry types only)
+        SegmentCenter = 1 << 6, //!< Place symbols at the center of every line segment
+        InnerVertices = 1 << 7, //!< Inner vertices (i.e. all vertices except the first and last vertex) \since QGIS 3.24
     };
     Q_ENUM( MarkerLinePlacement )
     Q_DECLARE_FLAGS( MarkerLinePlacements, MarkerLinePlacement )
@@ -3218,10 +3229,10 @@ class CORE_EXPORT Qgis
      */
     enum class LinearReferencingPlacement : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      IntervalCartesian2D = 1 << 0, //!< Place labels at regular intervals, using Cartesian distance calculations on a 2D plane
-      IntervalZ = 1 << 1, //!< Place labels at regular intervals, linearly interpolated using Z values
-      IntervalM = 1 << 2, //!< Place labels at regular intervals, linearly interpolated using M values
-      Vertex = 1 << 3, //!< Place labels on every vertex in the line
+        IntervalCartesian2D = 1 << 0, //!< Place labels at regular intervals, using Cartesian distance calculations on a 2D plane
+        IntervalZ = 1 << 1, //!< Place labels at regular intervals, linearly interpolated using Z values
+        IntervalM = 1 << 2, //!< Place labels at regular intervals, linearly interpolated using M values
+        Vertex = 1 << 3, //!< Place labels on every vertex in the line
     };
     Q_ENUM( LinearReferencingPlacement )
 
@@ -3246,9 +3257,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class GradientColorSource SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGradientFillSymbolLayer, GradientColorType ) : int
-      {
-      SimpleTwoColor, //!< Simple two color gradient
-      ColorRamp, //!< Gradient color ramp
+    {
+        SimpleTwoColor, //!< Simple two color gradient
+        ColorRamp, //!< Gradient color ramp
     };
     Q_ENUM( GradientColorSource )
 
@@ -3260,10 +3271,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class GradientType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGradientFillSymbolLayer, GradientType ) : int
-      {
-      Linear, //!< Linear gradient
-      Radial, //!< Radial (circular) gradient
-      Conical, //!< Conical (polar) gradient
+    {
+        Linear, //!< Linear gradient
+        Radial, //!< Radial (circular) gradient
+        Conical, //!< Conical (polar) gradient
     };
     Q_ENUM( GradientType )
 
@@ -3275,9 +3286,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class SymbolCoordinateReference SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGradientFillSymbolLayer, GradientCoordinateMode ) : int
-      {
-      Feature, //!< Relative to feature/shape being rendered
-      Viewport, //!< Relative to the whole viewport/output device
+    {
+        Feature, //!< Relative to feature/shape being rendered
+        Viewport, //!< Relative to the whole viewport/output device
     };
     Q_ENUM( SymbolCoordinateReference )
 
@@ -3290,10 +3301,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class GradientSpread SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGradientFillSymbolLayer, GradientSpread ) : int
-      {
-      Pad, //!< Pad out gradient using colors at endpoint of gradient
-      Reflect, //!< Reflect gradient
-      Repeat, //!< Repeat gradient
+    {
+        Pad, //!< Pad out gradient using colors at endpoint of gradient
+        Reflect, //!< Reflect gradient
+        Repeat, //!< Repeat gradient
     };
     Q_ENUM( GradientSpread )
 
@@ -3305,9 +3316,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class PointCountMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRandomMarkerFillSymbolLayer, CountMethod ) : int
-      {
-      Absolute SIP_MONKEYPATCH_COMPAT_NAME( AbsoluteCount ), //!< The point count is used as an absolute count of markers
-      DensityBased SIP_MONKEYPATCH_COMPAT_NAME( DensityBasedCount ), //!< The point count is part of a marker density count
+    {
+        Absolute SIP_MONKEYPATCH_COMPAT_NAME( AbsoluteCount ), //!< The point count is used as an absolute count of markers
+                 DensityBased SIP_MONKEYPATCH_COMPAT_NAME( DensityBasedCount ), //!< The point count is part of a marker density count
     };
     Q_ENUM( PointCountMethod )
 
@@ -3374,9 +3385,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class GraduatedMethod SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsGraduatedSymbolRenderer, GraduatedMethod ) : int
-      {
-      Color SIP_MONKEYPATCH_COMPAT_NAME( GraduatedColor ), //!< Alter color of symbols
-      Size SIP_MONKEYPATCH_COMPAT_NAME( GraduatedSize ), //!< Alter size of symbols
+    {
+        Color SIP_MONKEYPATCH_COMPAT_NAME( GraduatedColor ), //!< Alter color of symbols
+              Size SIP_MONKEYPATCH_COMPAT_NAME( GraduatedSize ), //!< Alter size of symbols
     };
     Q_ENUM( GraduatedMethod )
 
@@ -3457,15 +3468,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class Capitalization SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsStringUtils, Capitalization ) : int
-      {
-      MixedCase = 0, //!< Mixed case, ie no change
-      AllUppercase = 1, //!< Convert all characters to uppercase
-      AllLowercase = 2,  //!< Convert all characters to lowercase
-      ForceFirstLetterToCapital = 4, //!< Convert just the first letter of each word to uppercase, leave the rest untouched
-      SmallCaps = 5, //!< Mixed case small caps \since QGIS 3.24
-      TitleCase = 1004, //!< Simple title case conversion - does not fully grammatically parse the text and uses simple rules only. Note that this method does not convert any characters to lowercase, it only uppercases required letters. Callers must ensure that input strings are already lowercased.
-      UpperCamelCase = 1005, //!< Convert the string to upper camel case. Note that this method does not unaccent characters.
-      AllSmallCaps = 1006, //!< Force all characters to small caps \since QGIS 3.24
+    {
+        MixedCase = 0, //!< Mixed case, ie no change
+        AllUppercase = 1, //!< Convert all characters to uppercase
+        AllLowercase = 2,  //!< Convert all characters to lowercase
+        ForceFirstLetterToCapital = 4, //!< Convert just the first letter of each word to uppercase, leave the rest untouched
+        SmallCaps = 5, //!< Mixed case small caps \since QGIS 3.24
+        TitleCase = 1004, //!< Simple title case conversion - does not fully grammatically parse the text and uses simple rules only. Note that this method does not convert any characters to lowercase, it only uppercases required letters. Callers must ensure that input strings are already lowercased.
+        UpperCamelCase = 1005, //!< Convert the string to upper camel case. Note that this method does not unaccent characters.
+        AllSmallCaps = 1006, //!< Force all characters to small caps \since QGIS 3.24
     };
     Q_ENUM( Capitalization )
 
@@ -3476,7 +3487,7 @@ class CORE_EXPORT Qgis
      */
     enum class TextRendererFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      WrapLines = 1 << 0, //!< Automatically wrap long lines of text
+        WrapLines = 1 << 0, //!< Automatically wrap long lines of text
     };
     Q_ENUM( TextRendererFlag )
     Q_DECLARE_FLAGS( TextRendererFlags, TextRendererFlag )
@@ -3500,10 +3511,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class AngularDirection SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCurve, Orientation ) : int
-      {
-      Clockwise, //!< Clockwise direction
-      CounterClockwise, //!< Counter-clockwise direction
-      NoOrientation, //!< Unknown orientation or sentinel value
+    {
+        Clockwise, //!< Clockwise direction
+        CounterClockwise, //!< Counter-clockwise direction
+        NoOrientation, //!< Unknown orientation or sentinel value
     };
     Q_ENUM( AngularDirection )
 
@@ -3527,7 +3538,7 @@ class CORE_EXPORT Qgis
      */
     enum class MapCanvasFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ShowMainAnnotationLayer = 1 << 0, //!< The project's main annotation layer should be rendered in the canvas
+        ShowMainAnnotationLayer = 1 << 0, //!< The project's main annotation layer should be rendered in the canvas
     };
     Q_ENUM( MapCanvasFlag )
 
@@ -3546,8 +3557,8 @@ class CORE_EXPORT Qgis
      */
     enum class ViewSyncModeFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Sync3DTo2D = 1 << 0, //!< Synchronize 3D view camera to the main map canvas extent
-      Sync2DTo3D = 1 << 1, //!< Update the 2D main canvas extent to include the viewed area from the 3D view
+        Sync3DTo2D = 1 << 0, //!< Synchronize 3D view camera to the main map canvas extent
+        Sync2DTo3D = 1 << 1, //!< Update the 2D main canvas extent to include the viewed area from the 3D view
     };
     Q_ENUM( ViewSyncModeFlag )
     Q_DECLARE_FLAGS( ViewSyncModeFlags, ViewSyncModeFlag )
@@ -3572,7 +3583,7 @@ class CORE_EXPORT Qgis
      */
     enum class HistoryProviderBackend : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      LocalProfile = 1 << 0, //!< Local profile
+        LocalProfile = 1 << 0, //!< Local profile
 //      Project = 1 << 1, //!< QGIS Project  (not yet implemented)
     };
     Q_ENUM( HistoryProviderBackend )
@@ -3599,21 +3610,21 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingSourceType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessing, SourceType ) : int
-      {
-      MapLayer SIP_MONKEYPATCH_COMPAT_NAME( TypeMapLayer ) = -2, //!< Any map layer type (raster, vector, mesh, point cloud, annotation or plugin layer)
-      VectorAnyGeometry SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorAnyGeometry ) = -1, //!< Any vector layer with geometry
-      VectorPoint SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorPoint ) = 0, //!< Vector point layers
-      VectorLine SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorLine ) = 1, //!< Vector line layers
-      VectorPolygon SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorPolygon ) = 2, //!< Vector polygon layers
-      Raster SIP_MONKEYPATCH_COMPAT_NAME( TypeRaster ) = 3, //!< Raster layers
-      File SIP_MONKEYPATCH_COMPAT_NAME( TypeFile ) = 4, //!< Files (i.e. non map layer sources, such as text files)
-      Vector SIP_MONKEYPATCH_COMPAT_NAME( TypeVector ) = 5, //!< Tables (i.e. vector layers with or without geometry). When used for a sink this indicates the sink has no geometry.
-      Mesh SIP_MONKEYPATCH_COMPAT_NAME( TypeMesh ) = 6, //!< Mesh layers \since QGIS 3.6
-      Plugin SIP_MONKEYPATCH_COMPAT_NAME( TypePlugin ) = 7, //!< Plugin layers \since QGIS 3.22
-      PointCloud SIP_MONKEYPATCH_COMPAT_NAME( TypePointCloud ) = 8, //!< Point cloud layers \since QGIS 3.22
-      Annotation SIP_MONKEYPATCH_COMPAT_NAME( TypeAnnotation ) = 9, //!< Annotation layers \since QGIS 3.22
-      VectorTile SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorTile ) = 10, //!< Vector tile layers \since QGIS 3.32
-      TiledScene = 11 //!< Tiled scene layers \since QGIS 4.0
+    {
+        MapLayer SIP_MONKEYPATCH_COMPAT_NAME( TypeMapLayer ) = -2, //!< Any map layer type (raster, vector, mesh, point cloud, annotation or plugin layer)
+        VectorAnyGeometry SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorAnyGeometry ) = -1, //!< Any vector layer with geometry
+        VectorPoint SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorPoint ) = 0, //!< Vector point layers
+        VectorLine SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorLine ) = 1, //!< Vector line layers
+        VectorPolygon SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorPolygon ) = 2, //!< Vector polygon layers
+        Raster SIP_MONKEYPATCH_COMPAT_NAME( TypeRaster ) = 3, //!< Raster layers
+        File SIP_MONKEYPATCH_COMPAT_NAME( TypeFile ) = 4, //!< Files (i.e. non map layer sources, such as text files)
+        Vector SIP_MONKEYPATCH_COMPAT_NAME( TypeVector ) = 5, //!< Tables (i.e. vector layers with or without geometry). When used for a sink this indicates the sink has no geometry.
+        Mesh SIP_MONKEYPATCH_COMPAT_NAME( TypeMesh ) = 6, //!< Mesh layers \since QGIS 3.6
+        Plugin SIP_MONKEYPATCH_COMPAT_NAME( TypePlugin ) = 7, //!< Plugin layers \since QGIS 3.22
+        PointCloud SIP_MONKEYPATCH_COMPAT_NAME( TypePointCloud ) = 8, //!< Point cloud layers \since QGIS 3.22
+        Annotation SIP_MONKEYPATCH_COMPAT_NAME( TypeAnnotation ) = 9, //!< Annotation layers \since QGIS 3.22
+        VectorTile SIP_MONKEYPATCH_COMPAT_NAME( TypeVectorTile ) = 10, //!< Vector tile layers \since QGIS 3.32
+        TiledScene = 11 //!< Tiled scene layers \since QGIS 4.0
     };
     Q_ENUM( ProcessingSourceType )
 
@@ -3627,8 +3638,8 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingProviderFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingProvider, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      DeemphasiseSearchResults SIP_MONKEYPATCH_COMPAT_NAME( FlagDeemphasiseSearchResults ) = 1 << 1, //!< Algorithms should be de-emphasised in the search results when searching for algorithms. Use for low-priority providers or those with substantial known issues.
-      CompatibleWithVirtualRaster SIP_MONKEYPATCH_COMPAT_NAME( FlagCompatibleWithVirtualRaster ) = 1 << 2, //!< The processing provider's algorithms can work with QGIS virtualraster data provider \since QGIS 3.36
+        DeemphasiseSearchResults SIP_MONKEYPATCH_COMPAT_NAME( FlagDeemphasiseSearchResults ) = 1 << 1, //!< Algorithms should be de-emphasised in the search results when searching for algorithms. Use for low-priority providers or those with substantial known issues.
+        CompatibleWithVirtualRaster SIP_MONKEYPATCH_COMPAT_NAME( FlagCompatibleWithVirtualRaster ) = 1 << 2, //!< The processing provider's algorithms can work with QGIS virtualraster data provider \since QGIS 3.36
     };
     Q_ENUM( ProcessingProviderFlag );
 
@@ -3651,22 +3662,22 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingAlgorithmFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingAlgorithm, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      HideFromToolbox SIP_MONKEYPATCH_COMPAT_NAME( FlagHideFromToolbox ) = 1 << 1, //!< Algorithm should be hidden from the toolbox
-      HideFromModeler SIP_MONKEYPATCH_COMPAT_NAME( FlagHideFromModeler ) = 1 << 2, //!< Algorithm should be hidden from the modeler
-      SupportsBatch SIP_MONKEYPATCH_COMPAT_NAME( FlagSupportsBatch ) = 1 << 3,  //!< Algorithm supports batch mode
-      CanCancel SIP_MONKEYPATCH_COMPAT_NAME( FlagCanCancel ) = 1 << 4, //!< Algorithm can be canceled
-      RequiresMatchingCrs SIP_MONKEYPATCH_COMPAT_NAME( FlagRequiresMatchingCrs ) = 1 << 5, //!< Algorithm requires that all input layers have matching coordinate reference systems
-      NoThreading SIP_MONKEYPATCH_COMPAT_NAME( FlagNoThreading ) = 1 << 6, //!< Algorithm is not thread safe and cannot be run in a background thread, e.g. for algorithms which manipulate the current project, layer selections, or with external dependencies which are not thread-safe.
-      DisplayNameIsLiteral SIP_MONKEYPATCH_COMPAT_NAME( FlagDisplayNameIsLiteral ) = 1 << 7, //!< Algorithm's display name is a static literal string, and should not be translated or automatically formatted. For use with algorithms named after commands, e.g. GRASS 'v.in.ogr'.
-      SupportsInPlaceEdits SIP_MONKEYPATCH_COMPAT_NAME( FlagSupportsInPlaceEdits ) = 1 << 8, //!< Algorithm supports in-place editing
-      KnownIssues SIP_MONKEYPATCH_COMPAT_NAME( FlagKnownIssues ) = 1 << 9, //!< Algorithm has known issues
-      CustomException SIP_MONKEYPATCH_COMPAT_NAME( FlagCustomException ) = 1 << 10, //!< Algorithm raises custom exception notices, don't use the standard ones
-      PruneModelBranchesBasedOnAlgorithmResults SIP_MONKEYPATCH_COMPAT_NAME( FlagPruneModelBranchesBasedOnAlgorithmResults ) = 1 << 11, //!< Algorithm results will cause remaining model branches to be pruned based on the results of running the algorithm
-      SkipGenericModelLogging SIP_MONKEYPATCH_COMPAT_NAME( FlagSkipGenericModelLogging ) = 1 << 12, //!< When running as part of a model, the generic algorithm setup and results logging should be skipped
-      NotAvailableInStandaloneTool SIP_MONKEYPATCH_COMPAT_NAME( FlagNotAvailableInStandaloneTool ) = 1 << 13, //!< Algorithm should not be available from the standalone "qgis_process" tool. Used to flag algorithms which make no sense outside of the QGIS application, such as "select by..." style algorithms.
-      RequiresProject SIP_MONKEYPATCH_COMPAT_NAME( FlagRequiresProject ) = 1 << 14, //!< The algorithm requires that a valid QgsProject is available from the processing context in order to execute
-      SecurityRisk = 1 << 15, //!< The algorithm represents a potential security risk if executed with untrusted inputs. \since QGIS 3.40
-      Deprecated SIP_MONKEYPATCH_COMPAT_NAME( FlagDeprecated ) = HideFromToolbox | HideFromModeler, //!< Algorithm is deprecated
+        HideFromToolbox SIP_MONKEYPATCH_COMPAT_NAME( FlagHideFromToolbox ) = 1 << 1, //!< Algorithm should be hidden from the toolbox
+        HideFromModeler SIP_MONKEYPATCH_COMPAT_NAME( FlagHideFromModeler ) = 1 << 2, //!< Algorithm should be hidden from the modeler
+        SupportsBatch SIP_MONKEYPATCH_COMPAT_NAME( FlagSupportsBatch ) = 1 << 3,  //!< Algorithm supports batch mode
+        CanCancel SIP_MONKEYPATCH_COMPAT_NAME( FlagCanCancel ) = 1 << 4, //!< Algorithm can be canceled
+        RequiresMatchingCrs SIP_MONKEYPATCH_COMPAT_NAME( FlagRequiresMatchingCrs ) = 1 << 5, //!< Algorithm requires that all input layers have matching coordinate reference systems
+        NoThreading SIP_MONKEYPATCH_COMPAT_NAME( FlagNoThreading ) = 1 << 6, //!< Algorithm is not thread safe and cannot be run in a background thread, e.g. for algorithms which manipulate the current project, layer selections, or with external dependencies which are not thread-safe.
+        DisplayNameIsLiteral SIP_MONKEYPATCH_COMPAT_NAME( FlagDisplayNameIsLiteral ) = 1 << 7, //!< Algorithm's display name is a static literal string, and should not be translated or automatically formatted. For use with algorithms named after commands, e.g. GRASS 'v.in.ogr'.
+        SupportsInPlaceEdits SIP_MONKEYPATCH_COMPAT_NAME( FlagSupportsInPlaceEdits ) = 1 << 8, //!< Algorithm supports in-place editing
+        KnownIssues SIP_MONKEYPATCH_COMPAT_NAME( FlagKnownIssues ) = 1 << 9, //!< Algorithm has known issues
+        CustomException SIP_MONKEYPATCH_COMPAT_NAME( FlagCustomException ) = 1 << 10, //!< Algorithm raises custom exception notices, don't use the standard ones
+        PruneModelBranchesBasedOnAlgorithmResults SIP_MONKEYPATCH_COMPAT_NAME( FlagPruneModelBranchesBasedOnAlgorithmResults ) = 1 << 11, //!< Algorithm results will cause remaining model branches to be pruned based on the results of running the algorithm
+        SkipGenericModelLogging SIP_MONKEYPATCH_COMPAT_NAME( FlagSkipGenericModelLogging ) = 1 << 12, //!< When running as part of a model, the generic algorithm setup and results logging should be skipped
+        NotAvailableInStandaloneTool SIP_MONKEYPATCH_COMPAT_NAME( FlagNotAvailableInStandaloneTool ) = 1 << 13, //!< Algorithm should not be available from the standalone "qgis_process" tool. Used to flag algorithms which make no sense outside of the QGIS application, such as "select by..." style algorithms.
+        RequiresProject SIP_MONKEYPATCH_COMPAT_NAME( FlagRequiresProject ) = 1 << 14, //!< The algorithm requires that a valid QgsProject is available from the processing context in order to execute
+        SecurityRisk = 1 << 15, //!< The algorithm represents a potential security risk if executed with untrusted inputs. \since QGIS 3.40
+        Deprecated SIP_MONKEYPATCH_COMPAT_NAME( FlagDeprecated ) = HideFromToolbox | HideFromModeler, //!< Algorithm is deprecated
     };
     Q_ENUM( ProcessingAlgorithmFlag );
 
@@ -3687,9 +3698,9 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingAlgorithmDocumentationFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      RegeneratesPrimaryKey = 1 << 0, //!< Algorithm always drops any existing primary keys or FID values and regenerates them in outputs
-      RegeneratesPrimaryKeyInSomeScenarios = 1 << 1, //!< Algorithm may drop the existing primary keys or FID values in some scenarios, depending on algorithm inputs and parameters
-      RespectsEllipsoid = 1 << 2, //!< Algorithm respects the context's ellipsoid settings, and uses ellipsoidal based measurements. \since QGIS 4.0
+        RegeneratesPrimaryKey = 1 << 0, //!< Algorithm always drops any existing primary keys or FID values and regenerates them in outputs
+        RegeneratesPrimaryKeyInSomeScenarios = 1 << 1, //!< Algorithm may drop the existing primary keys or FID values in some scenarios, depending on algorithm inputs and parameters
+        RespectsEllipsoid = 1 << 2, //!< Algorithm respects the context's ellipsoid settings, and uses ellipsoidal based measurements. \since QGIS 4.0
     };
     Q_ENUM( ProcessingAlgorithmDocumentationFlag )
 
@@ -3710,9 +3721,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingPropertyAvailability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingAlgorithm, PropertyAvailability ) : int
-      {
-      NotAvailable, //!< Properties are not available
-      Available, //!< Properties are available
+    {
+        NotAvailable, //!< Properties are not available
+        Available, //!< Properties are available
     };
     Q_ENUM( ProcessingPropertyAvailability )
 
@@ -3724,10 +3735,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingLogLevel SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingContext, LogLevel ) : int
-      {
-      DefaultLevel = 0, //!< Default logging level
-      Verbose, //!< Verbose logging
-      ModelDebug, //!< Model debug level logging. Includes verbose logging and other outputs useful for debugging models \since QGIS 3.34
+    {
+        DefaultLevel = 0, //!< Default logging level
+        Verbose, //!< Verbose logging
+        ModelDebug, //!< Model debug level logging. Includes verbose logging and other outputs useful for debugging models \since QGIS 3.34
     };
     Q_ENUM( ProcessingLogLevel )
 
@@ -3755,8 +3766,8 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingFeatureSourceDefinitionFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingFeatureSourceDefinition, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      OverrideDefaultGeometryCheck SIP_MONKEYPATCH_COMPAT_NAME( FlagOverrideDefaultGeometryCheck ) = 1 << 0, //!< If set, the default geometry check method (as dictated by QgsProcessingContext) will be overridden for this source
-      CreateIndividualOutputPerInputFeature SIP_MONKEYPATCH_COMPAT_NAME( FlagCreateIndividualOutputPerInputFeature ) = 1 << 1, //!< If set, every feature processed from this source will be placed into its own individually created output destination. Support for this flag depends on how an algorithm is executed.
+        OverrideDefaultGeometryCheck SIP_MONKEYPATCH_COMPAT_NAME( FlagOverrideDefaultGeometryCheck ) = 1 << 0, //!< If set, the default geometry check method (as dictated by QgsProcessingContext) will be overridden for this source
+        CreateIndividualOutputPerInputFeature SIP_MONKEYPATCH_COMPAT_NAME( FlagCreateIndividualOutputPerInputFeature ) = 1 << 1, //!< If set, every feature processed from this source will be placed into its own individually created output destination. Support for this flag depends on how an algorithm is executed.
     };
     Q_ENUM( ProcessingFeatureSourceDefinitionFlag )
 
@@ -3779,7 +3790,7 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingFeatureSourceFlag SIP_ENUM_BASETYPE( IntFlag ) SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingFeatureSource, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      SkipGeometryValidityChecks SIP_MONKEYPATCH_COMPAT_NAME( FlagSkipGeometryValidityChecks ) = 1 << 1, //!< Invalid geometry checks should always be skipped. This flag can be useful for algorithms which always require invalid geometries, regardless of any user settings (e.g. "repair geometry" type algorithms).
+        SkipGeometryValidityChecks SIP_MONKEYPATCH_COMPAT_NAME( FlagSkipGeometryValidityChecks ) = 1 << 1, //!< Invalid geometry checks should always be skipped. This flag can be useful for algorithms which always require invalid geometries, regardless of any user settings (e.g. "repair geometry" type algorithms).
     };
     Q_ENUM( ProcessingFeatureSourceFlag )
 
@@ -3805,7 +3816,7 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingParameterTypeFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterType, ParameterFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ExposeToModeler = 1 //!< Is this parameter available in the modeler. Is set to on by default.
+        ExposeToModeler = 1 //!< Is this parameter available in the modeler. Is set to on by default.
     };
     Q_ENUM( ProcessingParameterTypeFlag )
 
@@ -3831,10 +3842,10 @@ class CORE_EXPORT Qgis
      */
     enum class ProcessingParameterFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterDefinition, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Advanced SIP_MONKEYPATCH_COMPAT_NAME( FlagAdvanced ) = 1 << 1, //!< Parameter is an advanced parameter which should be hidden from users by default
-      Hidden SIP_MONKEYPATCH_COMPAT_NAME( FlagHidden ) = 1 << 2, //!< Parameter is hidden and should not be shown to users
-      Optional SIP_MONKEYPATCH_COMPAT_NAME( FlagOptional ) = 1 << 3, //!< Parameter is optional
-      IsModelOutput SIP_MONKEYPATCH_COMPAT_NAME( FlagIsModelOutput ) = 1 << 4, //!< Destination parameter is final output. The parameter name will be used.
+        Advanced SIP_MONKEYPATCH_COMPAT_NAME( FlagAdvanced ) = 1 << 1, //!< Parameter is an advanced parameter which should be hidden from users by default
+        Hidden SIP_MONKEYPATCH_COMPAT_NAME( FlagHidden ) = 1 << 2, //!< Parameter is hidden and should not be shown to users
+        Optional SIP_MONKEYPATCH_COMPAT_NAME( FlagOptional ) = 1 << 3, //!< Parameter is optional
+        IsModelOutput SIP_MONKEYPATCH_COMPAT_NAME( FlagIsModelOutput ) = 1 << 4, //!< Destination parameter is final output. The parameter name will be used.
     };
     Q_ENUM( ProcessingParameterFlag )
 
@@ -3856,9 +3867,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingFileParameterBehavior SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterFile, Behavior ) : int
-      {
-      File = 0, //!< Parameter is a single file
-      Folder, //!< Parameter is a folder
+    {
+        File = 0, //!< Parameter is a single file
+        Folder, //!< Parameter is a folder
     };
     Q_ENUM( ProcessingFileParameterBehavior )
 
@@ -3870,9 +3881,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingNumberParameterType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterNumber, Type ) : int
-      {
-      Integer, //!< Integer values
-      Double, //!< Double/float values
+    {
+        Integer, //!< Integer values
+        Double, //!< Double/float values
     };
     Q_ENUM( ProcessingNumberParameterType )
 
@@ -3884,13 +3895,13 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingFieldParameterDataType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterField, DataType ) : int
-      {
-      Any = -1, //!< Accepts any field
-      Numeric = 0, //!< Accepts numeric fields
-      String = 1, //!< Accepts string fields
-      DateTime = 2, //!< Accepts datetime fields
-      Binary = 3, //!< Accepts binary fields, since QGIS 3.34
-      Boolean = 4, //!< Accepts boolean fields, since QGIS 3.34
+    {
+        Any = -1, //!< Accepts any field
+        Numeric = 0, //!< Accepts numeric fields
+        String = 1, //!< Accepts string fields
+        DateTime = 2, //!< Accepts datetime fields
+        Binary = 3, //!< Accepts binary fields, since QGIS 3.34
+        Boolean = 4, //!< Accepts boolean fields, since QGIS 3.34
     };
     Q_ENUM( ProcessingFieldParameterDataType )
 
@@ -3902,10 +3913,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingDateTimeParameterDataType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterDateTime, Type ) : int
-      {
-      DateTime, //!< Datetime values
-      Date, //!< Date values
-      Time, //!< Time values
+    {
+        DateTime, //!< Datetime values
+        Date, //!< Date values
+        Time, //!< Time values
     };
     Q_ENUM( ProcessingDateTimeParameterDataType )
 
@@ -3946,10 +3957,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36
      */
     enum class ProcessingTinInputLayerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProcessingParameterTinInputLayers, Type ) : int
-      {
-      Vertices, //!< Input that adds only vertices
-      StructureLines, //!< Input that adds add structure lines
-      BreakLines //!< Input that adds vertices and break lines
+    {
+        Vertices, //!< Input that adds only vertices
+        StructureLines, //!< Input that adds add structure lines
+        BreakLines //!< Input that adds vertices and break lines
     };
     Q_ENUM( ProcessingTinInputLayerType )
 
@@ -3959,9 +3970,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.24
      */
     enum class CrsDefinitionFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsCoordinateReferenceSystem, Format ) : int
-      {
-      Wkt SIP_MONKEYPATCH_COMPAT_NAME( FormatWkt ), //!< WKT format (always recommended over proj string format)
-      Proj SIP_MONKEYPATCH_COMPAT_NAME( FormatProj ), //!< Proj string format
+    {
+        Wkt SIP_MONKEYPATCH_COMPAT_NAME( FormatWkt ), //!< WKT format (always recommended over proj string format)
+            Proj SIP_MONKEYPATCH_COMPAT_NAME( FormatProj ), //!< Proj string format
     };
     Q_ENUM( CrsDefinitionFormat )
 
@@ -4172,10 +4183,10 @@ class CORE_EXPORT Qgis
      */
     enum class ProjectFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      EvaluateDefaultValuesOnProviderSide = 1 << 0, //!< If set, default values for fields will be evaluated on the provider side when features from the project are created instead of when they are committed.
-      TrustStoredLayerStatistics = 1 << 1, //!< If set, then layer statistics (such as the layer extent) will be read from values stored in the project instead of requesting updated values from the data provider. Additionally, when this flag is set, primary key unicity is not checked for views and materialized views with Postgres provider.
-      RememberLayerEditStatusBetweenSessions = 1 << 2, //!< If set, then any layers set to be editable will be stored in the project and immediately made editable whenever that project is restored
-      RememberAttributeTableWindowsBetweenSessions = 1 << 3, //!< If set, then any open attribute tables will be stored in the project and immediately reopened when the project is restored
+        EvaluateDefaultValuesOnProviderSide = 1 << 0, //!< If set, default values for fields will be evaluated on the provider side when features from the project are created instead of when they are committed.
+        TrustStoredLayerStatistics = 1 << 1, //!< If set, then layer statistics (such as the layer extent) will be read from values stored in the project instead of requesting updated values from the data provider. Additionally, when this flag is set, primary key unicity is not checked for views and materialized views with Postgres provider.
+        RememberLayerEditStatusBetweenSessions = 1 << 2, //!< If set, then any layers set to be editable will be stored in the project and immediately made editable whenever that project is restored
+        RememberAttributeTableWindowsBetweenSessions = 1 << 3, //!< If set, then any open attribute tables will be stored in the project and immediately reopened when the project is restored
     };
     Q_ENUM( ProjectFlag )
     Q_DECLARE_FLAGS( ProjectFlags, ProjectFlag )
@@ -4188,7 +4199,7 @@ class CORE_EXPORT Qgis
      */
     enum class PlotToolFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ShowContextMenu = 1 << 0, //!< Show a context menu when right-clicking with the tool.
+        ShowContextMenu = 1 << 0, //!< Show a context menu when right-clicking with the tool.
     };
     Q_ENUM( PlotToolFlag )
     Q_DECLARE_FLAGS( PlotToolFlags, PlotToolFlag )
@@ -4310,9 +4321,9 @@ class CORE_EXPORT Qgis
      */
     enum class ProfileGeneratorFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      RespectsMaximumErrorMapUnit = 1 << 0, //!< Generated profile respects the QgsProfileGenerationContext::maximumErrorMapUnits() property.
-      RespectsDistanceRange = 1 << 1, //!< Generated profile respects the QgsProfileGenerationContext::distanceRange() property.
-      RespectsElevationRange = 1 << 2, //!< Generated profile respects the QgsProfileGenerationContext::elevationRange() property.
+        RespectsMaximumErrorMapUnit = 1 << 0, //!< Generated profile respects the QgsProfileGenerationContext::maximumErrorMapUnits() property.
+                                    RespectsDistanceRange = 1 << 1, //!< Generated profile respects the QgsProfileGenerationContext::distanceRange() property.
+                                    RespectsElevationRange = 1 << 2, //!< Generated profile respects the QgsProfileGenerationContext::elevationRange() property.
     };
     Q_ENUM( ProfileGeneratorFlag )
     Q_DECLARE_FLAGS( ProfileGeneratorFlags, ProfileGeneratorFlag )
@@ -4337,9 +4348,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class PointCloudSymbol SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPointCloudRenderer, PointSymbol ) : int
-      {
-      Square, //!< Renders points as squares
-      Circle, //!< Renders points as circles
+    {
+        Square, //!< Renders points as squares
+        Circle, //!< Renders points as circles
     };
     Q_ENUM( PointCloudSymbol )
 
@@ -4349,10 +4360,10 @@ class CORE_EXPORT Qgis
      * /since QGIS 3.26
      */
     enum class PointCloudDrawOrder SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPointCloudRenderer, DrawOrder ) : int
-      {
-      Default, //!< Draw points in the order they are stored
-      BottomToTop, //!< Draw points with larger Z values last
-      TopToBottom, //!< Draw points with larger Z values first
+    {
+        Default, //!< Draw points in the order they are stored
+        BottomToTop, //!< Draw points with larger Z values last
+        TopToBottom, //!< Draw points with larger Z values first
     };
     Q_ENUM( PointCloudDrawOrder )
 
@@ -4364,10 +4375,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class AvoidIntersectionsMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProject, AvoidIntersectionsMode ) : int
-      {
-      AllowIntersections, //!< Overlap with any feature allowed when digitizing new features
-      AvoidIntersectionsCurrentLayer, //!< Overlap with features from the active layer when digitizing new features not allowed
-      AvoidIntersectionsLayers, //!< Overlap with features from a specified list of layers when digitizing new features not allowed
+    {
+        AllowIntersections, //!< Overlap with any feature allowed when digitizing new features
+        AvoidIntersectionsCurrentLayer, //!< Overlap with features from the active layer when digitizing new features not allowed
+        AvoidIntersectionsLayers, //!< Overlap with features from a specified list of layers when digitizing new features not allowed
     };
     Q_ENUM( AvoidIntersectionsMode )
 
@@ -4379,9 +4390,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.26
      */
     enum class ProjectFileFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProject, FileFormat ) : int
-      {
-      Qgz, //!< Archive file format, supports auxiliary data
-      Qgs, //!< Project saved in a clear text, does not support auxiliary data
+    {
+        Qgz, //!< Archive file format, supports auxiliary data
+        Qgs, //!< Project saved in a clear text, does not support auxiliary data
     };
     Q_ENUM( ProjectFileFormat )
 
@@ -4394,14 +4405,14 @@ class CORE_EXPORT Qgis
      */
     enum class ProjectReadFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsProject, ReadFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      DontResolveLayers SIP_MONKEYPATCH_COMPAT_NAME( FlagDontResolveLayers ) = 1 << 0, //!< Don't resolve layer paths (i.e. don't load any layer content). Dramatically improves project read time if the actual data from the layers is not required.
-      DontLoadLayouts SIP_MONKEYPATCH_COMPAT_NAME( FlagDontLoadLayouts ) = 1 << 1, //!< Don't load print layouts. Improves project read time if layouts are not required, and allows projects to be safely read in background threads (since print layouts are not thread safe).
-      TrustLayerMetadata SIP_MONKEYPATCH_COMPAT_NAME( FlagTrustLayerMetadata ) = 1 << 2, //!< Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server.
-      DontStoreOriginalStyles SIP_MONKEYPATCH_COMPAT_NAME( FlagDontStoreOriginalStyles ) = 1 << 3, //!< Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts.
-      DontLoad3DViews SIP_MONKEYPATCH_COMPAT_NAME( FlagDontLoad3DViews ) = 1 << 4, //!< Skip loading 3D views \since QGIS 3.26
-      DontLoadProjectStyles = 1 << 5, //!< Skip loading project style databases (deprecated -- use ProjectCapability::ProjectStyles flag instead)
-      ForceReadOnlyLayers = 1 << 6, //!< Open layers in a read-only mode. \since QGIS 3.28
-      DontUpgradeAnnotations = 1 << 7, //!< Don't upgrade old annotation items to QgsAnnotationItem \since QGIS 3.40
+        DontResolveLayers SIP_MONKEYPATCH_COMPAT_NAME( FlagDontResolveLayers ) = 1 << 0, //!< Don't resolve layer paths (i.e. don't load any layer content). Dramatically improves project read time if the actual data from the layers is not required.
+        DontLoadLayouts SIP_MONKEYPATCH_COMPAT_NAME( FlagDontLoadLayouts ) = 1 << 1, //!< Don't load print layouts. Improves project read time if layouts are not required, and allows projects to be safely read in background threads (since print layouts are not thread safe).
+        TrustLayerMetadata SIP_MONKEYPATCH_COMPAT_NAME( FlagTrustLayerMetadata ) = 1 << 2, //!< Trust layer metadata. Improves project read time. Do not use it if layers' extent is not fixed during the project's use by QGIS and QGIS Server.
+        DontStoreOriginalStyles SIP_MONKEYPATCH_COMPAT_NAME( FlagDontStoreOriginalStyles ) = 1 << 3, //!< Skip the initial XML style storage for layers. Useful for minimising project load times in non-interactive contexts.
+        DontLoad3DViews SIP_MONKEYPATCH_COMPAT_NAME( FlagDontLoad3DViews ) = 1 << 4, //!< Skip loading 3D views \since QGIS 3.26
+        DontLoadProjectStyles = 1 << 5, //!< Skip loading project style databases (deprecated -- use ProjectCapability::ProjectStyles flag instead)
+        ForceReadOnlyLayers = 1 << 6, //!< Open layers in a read-only mode. \since QGIS 3.28
+        DontUpgradeAnnotations = 1 << 7, //!< Don't upgrade old annotation items to QgsAnnotationItem \since QGIS 3.40
     };
     Q_ENUM( ProjectReadFlag )
 
@@ -4425,7 +4436,7 @@ class CORE_EXPORT Qgis
      */
     enum class ProjectCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ProjectStyles = 1 << 0, //!< Enable the project embedded style library. Enabling this flag can increase the time required to clear and load projects.
+        ProjectStyles = 1 << 0, //!< Enable the project embedded style library. Enabling this flag can increase the time required to clear and load projects.
     };
     Q_ENUM( ProjectCapability )
 
@@ -4462,15 +4473,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class ArcGisRestServiceType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsArcGisPortalUtils, ItemType ) : int
-      {
-      FeatureServer SIP_MONKEYPATCH_COMPAT_NAME( FeatureService ), //!< FeatureServer
-      MapServer SIP_MONKEYPATCH_COMPAT_NAME( MapService ), //!< MapServer
-      ImageServer SIP_MONKEYPATCH_COMPAT_NAME( ImageService ), //!< ImageServer
-      GlobeServer, //!< GlobeServer
-      GPServer, //!< GPServer
-      GeocodeServer, //!< GeocodeServer
-      Unknown, //!< Other unknown/unsupported type
-      SceneServer, //!< SceneServer
+    {
+        FeatureServer SIP_MONKEYPATCH_COMPAT_NAME( FeatureService ), //!< FeatureServer
+                      MapServer SIP_MONKEYPATCH_COMPAT_NAME( MapService ), //!< MapServer
+                      ImageServer SIP_MONKEYPATCH_COMPAT_NAME( ImageService ), //!< ImageServer
+                      GlobeServer, //!< GlobeServer
+                      GPServer, //!< GPServer
+                      GeocodeServer, //!< GeocodeServer
+                      Unknown, //!< Other unknown/unsupported type
+                      SceneServer, //!< SceneServer
     };
     Q_ENUM( ArcGisRestServiceType )
 
@@ -4482,9 +4493,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class RelationshipType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRelation, RelationType ) : int
-      {
-      Normal, //!< A normal relation
-      Generated, //!< A generated relation is a child of a polymorphic relation
+    {
+        Normal, //!< A normal relation
+        Generated, //!< A generated relation is a child of a polymorphic relation
     };
     Q_ENUM( RelationshipType )
 
@@ -4496,9 +4507,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.28
      */
     enum class RelationshipStrength SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRelation, RelationStrength ) : int
-      {
-      Association, //!< Loose relation, related elements are not part of the parent and a parent copy will not copy any children.
-      Composition, //!< Fix relation, related elements are part of the parent and a parent copy will copy any children or delete of parent will delete children
+    {
+        Association, //!< Loose relation, related elements are not part of the parent and a parent copy will not copy any children.
+        Composition, //!< Fix relation, related elements are part of the parent and a parent copy will copy any children or delete of parent will delete children
     };
     Q_ENUM( RelationshipStrength )
 
@@ -4523,9 +4534,9 @@ class CORE_EXPORT Qgis
      */
     enum class RelationshipCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      MultipleFieldKeys = 1 << 0, //!< Supports multiple field keys (as opposed to a singular field)
-      ForwardPathLabel = 1 << 1, //!< Supports forward path labels
-      BackwardPathLabel = 1 << 2, //!< Supports backward path labels
+        MultipleFieldKeys = 1 << 0, //!< Supports multiple field keys (as opposed to a singular field)
+        ForwardPathLabel = 1 << 1, //!< Supports forward path labels
+        BackwardPathLabel = 1 << 2, //!< Supports backward path labels
     };
     Q_ENUM( RelationshipCapability )
 
@@ -4593,9 +4604,9 @@ class CORE_EXPORT Qgis
      */
     enum class ScriptLanguageCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Reformat = 1 << 0, //!< Language supports automatic code reformatting
-      CheckSyntax = 1 << 1, //!< Language supports syntax checking
-      ToggleComment = 1 << 2, //!< Language supports comment toggling
+        Reformat = 1 << 0, //!< Language supports automatic code reformatting
+        CheckSyntax = 1 << 1, //!< Language supports syntax checking
+        ToggleComment = 1 << 2, //!< Language supports comment toggling
     };
     Q_ENUM( ScriptLanguageCapability )
 
@@ -4627,7 +4638,7 @@ class CORE_EXPORT Qgis
      */
     enum class LayerTreeFilterFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      SkipVisibilityCheck = 1 << 0, //!< If set, the standard visibility check should be skipped
+        SkipVisibilityCheck = 1 << 0, //!< If set, the standard visibility check should be skipped
     };
     Q_ENUM( LayerTreeFilterFlag )
 
@@ -4646,7 +4657,7 @@ class CORE_EXPORT Qgis
      */
     enum class MapLayerLegendFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ExcludeByDefault = 1 << 0, //!< If set, the layer should not be included in legends by default, and must be manually added by a user
+        ExcludeByDefault = 1 << 0, //!< If set, the layer should not be included in legends by default, and must be manually added by a user
     };
     Q_ENUM( MapLayerLegendFlag )
 
@@ -4666,14 +4677,14 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.42
      */
     enum class LegendComponent SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLegendStyle, Style ) : int
-      {
-      Undefined, //!< Should not happen, only if corrupted project file
-      Hidden, //!< Special style, item is hidden including margins around
-      Title, //!< Legend title
-      Group, //!< Legend group title
-      Subgroup, //!< Legend subgroup title
-      Symbol, //!< Symbol icon (excluding label)
-      SymbolLabel, //!< Symbol label (excluding icon)
+    {
+        Undefined, //!< Should not happen, only if corrupted project file
+        Hidden, //!< Special style, item is hidden including margins around
+        Title, //!< Legend title
+        Group, //!< Legend group title
+        Subgroup, //!< Legend subgroup title
+        Symbol, //!< Symbol icon (excluding label)
+        SymbolLabel, //!< Symbol label (excluding icon)
     };
     // !!! WARNING: If adding new values to this enum, make sure you update QgsLegendSettings constructor accordingly!!
     Q_ENUM( LegendComponent )
@@ -4700,7 +4711,7 @@ class CORE_EXPORT Qgis
      */
     enum class LegendJsonRenderFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ShowRuleDetails = 1 << 0, //!< If set, the rule expression of a rule based renderer legend item will be added to the JSON
+        ShowRuleDetails = 1 << 0, //!< If set, the rule expression of a rule based renderer legend item will be added to the JSON
     };
     Q_ENUM( LegendJsonRenderFlag )
     Q_DECLARE_FLAGS( LegendJsonRenderFlags, LegendJsonRenderFlag )
@@ -4730,10 +4741,10 @@ class CORE_EXPORT Qgis
      */
     enum class MapLayerActionTarget : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Layer = 1 << 0, //!< Action targets a complete layer
-      SingleFeature = 1 << 1, //!< Action targets a single feature from a layer
-      MultipleFeatures = 1 << 2, //!< Action targets multiple features from a layer
-      AllActions = Layer | SingleFeature | MultipleFeatures
+        Layer = 1 << 0, //!< Action targets a complete layer
+        SingleFeature = 1 << 1, //!< Action targets a single feature from a layer
+        MultipleFeatures = 1 << 2, //!< Action targets multiple features from a layer
+        AllActions = Layer | SingleFeature | MultipleFeatures
     };
     Q_ENUM( MapLayerActionTarget )
 
@@ -4756,8 +4767,8 @@ class CORE_EXPORT Qgis
      */
     enum class MapLayerActionFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      EnabledOnlyWhenEditable = 1 << 1, //!< Action should be shown only for editable layers
-      EnableOnlyWhenHasGeometry = 1 << 2, //!< Action should be shown only for layers with geometry, \since QGIS 3.42
+        EnabledOnlyWhenEditable = 1 << 1, //!< Action should be shown only for editable layers
+        EnableOnlyWhenHasGeometry = 1 << 2, //!< Action should be shown only for layers with geometry, \since QGIS 3.42
     };
     Q_ENUM( MapLayerActionFlag )
 
@@ -4779,15 +4790,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class AttributeActionType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsAction, ActionType ) : int
-      {
-      Generic, //!< Generic
-      GenericPython, //!< Python
-      Mac, //!< MacOS specific
-      Windows, //!< Windows specific
-      Unix, //!< Unix specific
-      OpenUrl, //!< Open URL action
-      SubmitUrlEncoded, //!< POST data to an URL, using "application/x-www-form-urlencoded" or "application/json" if the body is valid JSON \since QGIS 3.24
-      SubmitUrlMultipart, //!< POST data to an URL using "multipart/form-data"  \since QGIS 3.24
+    {
+        Generic, //!< Generic
+        GenericPython, //!< Python
+        Mac, //!< MacOS specific
+        Windows, //!< Windows specific
+        Unix, //!< Unix specific
+        OpenUrl, //!< Open URL action
+        SubmitUrlEncoded, //!< POST data to an URL, using "application/x-www-form-urlencoded" or "application/json" if the body is valid JSON \since QGIS 3.24
+        SubmitUrlMultipart, //!< POST data to an URL using "multipart/form-data"  \since QGIS 3.24
     };
     Q_ENUM( AttributeActionType )
 
@@ -4816,46 +4827,46 @@ class CORE_EXPORT Qgis
      */
 
     enum class RasterColorInterpretation SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRaster, ColorInterpretation ) : int
-      {
-      Undefined SIP_MONKEYPATCH_COMPAT_NAME( UndefinedColorInterpretation ) = 0, //!< Undefined
-      GrayIndex = 1,          //!< Grayscale
-      PaletteIndex = 2,       //!< Paletted (see associated color table)
-      RedBand = 3,            //!< Red band of RGBA image, or red spectral band [0.62 - 0.69 um]
-      GreenBand = 4,          //!< Green band of RGBA image, or green spectral band [0.51 - 0.60 um]
-      BlueBand = 5,           //!< Blue band of RGBA image, or blue spectral band [0.45 - 0.53 um]
-      AlphaBand = 6,          //!< Alpha (0=transparent, 255=opaque)
-      HueBand = 7,            //!< Hue band of HLS image
-      SaturationBand = 8,     //!< Saturation band of HLS image
-      LightnessBand = 9,      //!< Lightness band of HLS image
-      CyanBand = 10,          //!< Cyan band of CMYK image
-      MagentaBand = 11,       //!< Magenta band of CMYK image
-      YellowBand = 12,        //!< Yellow band of CMYK image, or yellow spectral band [0.58 - 0.62 um]
-      BlackBand = 13,         //!< Black band of CMLY image
-      YCbCr_YBand = 14,       //!< Y Luminance
-      YCbCr_CbBand = 15,      //!< Cb Chroma
-      YCbCr_CrBand = 16,      //!< Cr Chroma
-      ContinuousPalette = 17, //!< Continuous palette, QGIS addition, GRASS
+    {
+        Undefined SIP_MONKEYPATCH_COMPAT_NAME( UndefinedColorInterpretation ) = 0, //!< Undefined
+        GrayIndex = 1,          //!< Grayscale
+        PaletteIndex = 2,       //!< Paletted (see associated color table)
+        RedBand = 3,            //!< Red band of RGBA image, or red spectral band [0.62 - 0.69 um]
+        GreenBand = 4,          //!< Green band of RGBA image, or green spectral band [0.51 - 0.60 um]
+        BlueBand = 5,           //!< Blue band of RGBA image, or blue spectral band [0.45 - 0.53 um]
+        AlphaBand = 6,          //!< Alpha (0=transparent, 255=opaque)
+        HueBand = 7,            //!< Hue band of HLS image
+        SaturationBand = 8,     //!< Saturation band of HLS image
+        LightnessBand = 9,      //!< Lightness band of HLS image
+        CyanBand = 10,          //!< Cyan band of CMYK image
+        MagentaBand = 11,       //!< Magenta band of CMYK image
+        YellowBand = 12,        //!< Yellow band of CMYK image, or yellow spectral band [0.58 - 0.62 um]
+        BlackBand = 13,         //!< Black band of CMLY image
+        YCbCr_YBand = 14,       //!< Y Luminance
+        YCbCr_CbBand = 15,      //!< Cb Chroma
+        YCbCr_CrBand = 16,      //!< Cr Chroma
+        ContinuousPalette = 17, //!< Continuous palette, QGIS addition, GRASS
 
-      // Note: values between PanBand and SAR_P_Band match additions done in
-      // GDAL 3.10, except that the numeric values of the constant don't match GDAL ones
+        // Note: values between PanBand and SAR_P_Band match additions done in
+        // GDAL 3.10, except that the numeric values of the constant don't match GDAL ones
 
-      PanBand = 18,           //!< Panchromatic band [0.40 - 1.00 um] \since QGIS 3.40
-      CoastalBand = 19,       //!< Coastal band [0.40 - 0.45 um] \since QGIS 3.40
-      RedEdgeBand = 20,       //!< Red-edge band [0.69 - 0.79 um] \since QGIS 3.40
-      NIRBand = 21,           //!< Near-InfraRed (NIR) band [0.75 - 1.40 um] \since QGIS 3.40
-      SWIRBand = 22,          //!< Short-Wavelength InfraRed (SWIR) band [1.40 - 3.00 um] \since QGIS 3.40
-      MWIRBand = 23,          //!< Mid-Wavelength InfraRed (MWIR) band [3.00 - 8.00 um] \since QGIS 3.40
-      LWIRBand = 24,          //!< Long-Wavelength InfraRed (LWIR) band [8.00 - 15 um] \since QGIS 3.40
-      TIRBand = 25,           //!< Thermal InfraRed (TIR) band (MWIR or LWIR) [3 - 15 um] \since QGIS 3.40
-      OtherIRBand = 26,       //!< Other infrared band [0.75 - 1000 um] \since QGIS 3.40
-      SAR_Ka_Band = 27,       //!< Synthetic Aperture Radar (SAR) Ka band [0.8 - 1.1 cm / 27 - 40 GHz] \since QGIS 3.40
-      SAR_K_Band = 28,        //!< Synthetic Aperture Radar (SAR) K band [1.1 - 1.7 cm / 18 - 27 GHz] \since QGIS 3.40
-      SAR_Ku_Band = 30,       //!< Synthetic Aperture Radar (SAR) Ku band [1.7 - 2.4 cm / 12 - 18 GHz] \since QGIS 3.40
-      SAR_X_Band = 31,        //!< Synthetic Aperture Radar (SAR) X band [2.4 - 3.8 cm / 8 - 12 GHz] \since QGIS 3.40
-      SAR_C_Band = 32,        //!< Synthetic Aperture Radar (SAR) C band [3.8 - 7.5 cm / 4 - 8 GHz] \since QGIS 3.40
-      SAR_S_Band = 33,        //!< Synthetic Aperture Radar (SAR) S band [7.5 - 15 cm / 2 - 4 GHz] \since QGIS 3.40
-      SAR_L_Band = 34,        //!< Synthetic Aperture Radar (SAR) L band [15 - 30 cm / 1 - 2 GHz] \since QGIS 3.40
-      SAR_P_Band = 35,        //!< Synthetic Aperture Radar (SAR) P band [30 - 100 cm / 0.3 - 1 GHz] \since QGIS 3.40
+        PanBand = 18,           //!< Panchromatic band [0.40 - 1.00 um] \since QGIS 3.40
+        CoastalBand = 19,       //!< Coastal band [0.40 - 0.45 um] \since QGIS 3.40
+        RedEdgeBand = 20,       //!< Red-edge band [0.69 - 0.79 um] \since QGIS 3.40
+        NIRBand = 21,           //!< Near-InfraRed (NIR) band [0.75 - 1.40 um] \since QGIS 3.40
+        SWIRBand = 22,          //!< Short-Wavelength InfraRed (SWIR) band [1.40 - 3.00 um] \since QGIS 3.40
+        MWIRBand = 23,          //!< Mid-Wavelength InfraRed (MWIR) band [3.00 - 8.00 um] \since QGIS 3.40
+        LWIRBand = 24,          //!< Long-Wavelength InfraRed (LWIR) band [8.00 - 15 um] \since QGIS 3.40
+        TIRBand = 25,           //!< Thermal InfraRed (TIR) band (MWIR or LWIR) [3 - 15 um] \since QGIS 3.40
+        OtherIRBand = 26,       //!< Other infrared band [0.75 - 1000 um] \since QGIS 3.40
+        SAR_Ka_Band = 27,       //!< Synthetic Aperture Radar (SAR) Ka band [0.8 - 1.1 cm / 27 - 40 GHz] \since QGIS 3.40
+        SAR_K_Band = 28,        //!< Synthetic Aperture Radar (SAR) K band [1.1 - 1.7 cm / 18 - 27 GHz] \since QGIS 3.40
+        SAR_Ku_Band = 30,       //!< Synthetic Aperture Radar (SAR) Ku band [1.7 - 2.4 cm / 12 - 18 GHz] \since QGIS 3.40
+        SAR_X_Band = 31,        //!< Synthetic Aperture Radar (SAR) X band [2.4 - 3.8 cm / 8 - 12 GHz] \since QGIS 3.40
+        SAR_C_Band = 32,        //!< Synthetic Aperture Radar (SAR) C band [3.8 - 7.5 cm / 4 - 8 GHz] \since QGIS 3.40
+        SAR_S_Band = 33,        //!< Synthetic Aperture Radar (SAR) S band [7.5 - 15 cm / 2 - 4 GHz] \since QGIS 3.40
+        SAR_L_Band = 34,        //!< Synthetic Aperture Radar (SAR) L band [15 - 30 cm / 1 - 2 GHz] \since QGIS 3.40
+        SAR_P_Band = 35,        //!< Synthetic Aperture Radar (SAR) P band [30 - 100 cm / 0.3 - 1 GHz] \since QGIS 3.40
     };
     Q_ENUM( RasterColorInterpretation )
 
@@ -4867,11 +4878,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
     */
     enum class RasterLayerType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterLayer, LayerType ) : int
-      {
-      GrayOrUndefined, //!< Gray or undefined
-      Palette, //!< Palette
-      MultiBand SIP_MONKEYPATCH_COMPAT_NAME( Multiband ), //!< Multi band
-      SingleBandColorData SIP_MONKEYPATCH_COMPAT_NAME( ColorLayer ), //!< Single band containing color data
+    {
+        GrayOrUndefined, //!< Gray or undefined
+        Palette, //!< Palette
+        MultiBand SIP_MONKEYPATCH_COMPAT_NAME( Multiband ), //!< Multi band
+        SingleBandColorData SIP_MONKEYPATCH_COMPAT_NAME( ColorLayer ), //!< Single band containing color data
     };
     Q_ENUM( RasterLayerType )
 
@@ -4883,18 +4894,18 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
     */
     enum class RasterDrawingStyle SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRaster, DrawingStyle ) : int
-      {
-      Undefined SIP_MONKEYPATCH_COMPAT_NAME( UndefinedDrawingStyle ),//!< Undefined
-      SingleBandGray, //!< A single band image drawn as a range of gray colors
-      SingleBandPseudoColor, //!< A single band image drawn using a pseudocolor algorithm
-      PalettedColor, //!< A "Palette" image drawn using color table
-      PalettedSingleBandGray, //!< A "Palette" layer drawn in gray scale
-      PalettedSingleBandPseudoColor, //!< A "Palette" layerdrawn using a pseudocolor algorithm
-      PalettedMultiBandColor, //!< Currently not supported
-      MultiBandSingleBandGray, //!< A layer containing 2 or more bands, but a single band drawn as a range of gray colors
-      MultiBandSingleBandPseudoColor, //!< A layer containing 2 or more bands, but a single band drawn using a pseudocolor algorithm
-      MultiBandColor, //!< A layer containing 2 or more bands, mapped to RGB color space. In the case of a multiband with only two bands, one band will be mapped to more than one color.
-      SingleBandColorData SIP_MONKEYPATCH_COMPAT_NAME( SingleBandColorDataStyle ), //!< ARGB values rendered directly
+    {
+        Undefined SIP_MONKEYPATCH_COMPAT_NAME( UndefinedDrawingStyle ),//!< Undefined
+                  SingleBandGray, //!< A single band image drawn as a range of gray colors
+                  SingleBandPseudoColor, //!< A single band image drawn using a pseudocolor algorithm
+                  PalettedColor, //!< A "Palette" image drawn using color table
+                  PalettedSingleBandGray, //!< A "Palette" layer drawn in gray scale
+                  PalettedSingleBandPseudoColor, //!< A "Palette" layerdrawn using a pseudocolor algorithm
+                  PalettedMultiBandColor, //!< Currently not supported
+                  MultiBandSingleBandGray, //!< A layer containing 2 or more bands, but a single band drawn as a range of gray colors
+                  MultiBandSingleBandPseudoColor, //!< A layer containing 2 or more bands, but a single band drawn using a pseudocolor algorithm
+                  MultiBandColor, //!< A layer containing 2 or more bands, mapped to RGB color space. In the case of a multiband with only two bands, one band will be mapped to more than one color.
+                  SingleBandColorData SIP_MONKEYPATCH_COMPAT_NAME( SingleBandColorDataStyle ), //!< ARGB values rendered directly
     };
     Q_ENUM( RasterDrawingStyle )
 
@@ -4906,10 +4917,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class RasterPyramidFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRaster, RasterPyramidsFormat ) : int
-      {
-      GeoTiff SIP_MONKEYPATCH_COMPAT_NAME( PyramidsGTiff ) = 0, //!< Geotiff .ovr (external)
-      Internal SIP_MONKEYPATCH_COMPAT_NAME( PyramidsInternal ) = 1, //!< Internal
-      Erdas SIP_MONKEYPATCH_COMPAT_NAME( PyramidsErdas ) = 2 //!< Erdas Image .aux (external)
+    {
+        GeoTiff SIP_MONKEYPATCH_COMPAT_NAME( PyramidsGTiff ) = 0, //!< Geotiff .ovr (external)
+        Internal SIP_MONKEYPATCH_COMPAT_NAME( PyramidsInternal ) = 1, //!< Internal
+        Erdas SIP_MONKEYPATCH_COMPAT_NAME( PyramidsErdas ) = 2 //!< Erdas Image .aux (external)
     };
     Q_ENUM( RasterPyramidFormat )
 
@@ -4921,10 +4932,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class RasterBuildPyramidOption SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRaster, RasterBuildPyramids ) : int
-      {
-      No SIP_MONKEYPATCH_COMPAT_NAME( PyramidsFlagNo ) = 0, //!< Never
-      Yes SIP_MONKEYPATCH_COMPAT_NAME( PyramidsFlagYes ) = 1, //!< Yes
-      CopyExisting SIP_MONKEYPATCH_COMPAT_NAME( PyramidsCopyExisting ) = 2 //!< Copy existing
+    {
+        No SIP_MONKEYPATCH_COMPAT_NAME( PyramidsFlagNo ) = 0, //!< Never
+        Yes SIP_MONKEYPATCH_COMPAT_NAME( PyramidsFlagYes ) = 1, //!< Yes
+        CopyExisting SIP_MONKEYPATCH_COMPAT_NAME( PyramidsCopyExisting ) = 2 //!< Copy existing
     };
     Q_ENUM( RasterBuildPyramidOption )
 
@@ -4937,11 +4948,11 @@ class CORE_EXPORT Qgis
      */
     enum class RasterIdentifyFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRaster, IdentifyFormat ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Undefined SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatUndefined ) = 0, //!< Undefined
-      Value SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatValue ) = 1, //!< Numerical pixel value
-      Text SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatText ) = 1 << 1, //!< WMS text
-      Html SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatHtml ) = 1 << 2, //!< WMS HTML
-      Feature SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatFeature ) = 1 << 3, //!< WMS GML/JSON -> feature
+        Undefined SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatUndefined ) = 0, //!< Undefined
+        Value SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatValue ) = 1, //!< Numerical pixel value
+        Text SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatText ) = 1 << 1, //!< WMS text
+        Html SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatHtml ) = 1 << 2, //!< WMS HTML
+        Feature SIP_MONKEYPATCH_COMPAT_NAME( IdentifyFormatFeature ) = 1 << 3, //!< WMS GML/JSON -> feature
     };
     Q_ENUM( RasterIdentifyFormat )
 
@@ -4958,17 +4969,17 @@ class CORE_EXPORT Qgis
      */
     enum class RasterInterfaceCapability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterInterface, Capability ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoCapabilities = 0, //!< No capabilities
-      Size = 1 << 1, //!< Original data source size (and thus resolution) is known, it is not always available, for example for WMS
-      Create = 1 << 2, //!< Create new datasets (Unused and deprecated -- will be removed in QGIS 5)
-      Remove = 1 << 3, //!< Delete datasets (Unused and deprecated -- will be removed in QGIS 5)
-      BuildPyramids = 1 << 4, //!< Supports building of pyramids (overviews) (Deprecated since QGIS 3.38 -- use RasterProviderCapability::BuildPyramids instead)
-      Identify = 1 << 5, //!< At least one identify format supported
-      IdentifyValue = 1 << 6, //!< Numerical values
-      IdentifyText = 1 << 7, //!< WMS text
-      IdentifyHtml = 1 << 8, //!< WMS HTML
-      IdentifyFeature = 1 << 9, //!< WMS GML -> feature
-      Prefetch = 1 << 10, //!< Allow prefetching of out-of-view images
+        NoCapabilities = 0, //!< No capabilities
+        Size = 1 << 1, //!< Original data source size (and thus resolution) is known, it is not always available, for example for WMS
+        Create = 1 << 2, //!< Create new datasets (Unused and deprecated -- will be removed in QGIS 5)
+        Remove = 1 << 3, //!< Delete datasets (Unused and deprecated -- will be removed in QGIS 5)
+        BuildPyramids = 1 << 4, //!< Supports building of pyramids (overviews) (Deprecated since QGIS 3.38 -- use RasterProviderCapability::BuildPyramids instead)
+        Identify = 1 << 5, //!< At least one identify format supported
+        IdentifyValue = 1 << 6, //!< Numerical values
+        IdentifyText = 1 << 7, //!< WMS text
+        IdentifyHtml = 1 << 8, //!< WMS HTML
+        IdentifyFeature = 1 << 9, //!< WMS GML -> feature
+        Prefetch = 1 << 10, //!< Allow prefetching of out-of-view images
     };
     Q_ENUM( RasterInterfaceCapability )
 
@@ -4991,15 +5002,15 @@ class CORE_EXPORT Qgis
      */
     enum class RasterProviderCapability SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterDataProvider, ProviderCapability ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoProviderCapabilities = 0, //!< Provider has no capabilities
-      ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
-      WriteLayerMetadata = 1 << 2, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
-      ProviderHintBenefitsFromResampling = 1 << 3, //!< Provider benefits from resampling and should apply user default resampling settings \since QGIS 3.10
-      ProviderHintCanPerformProviderResampling = 1 << 4, //!< Provider can perform resampling (to be opposed to post rendering resampling) \since QGIS 3.16
-      ReloadData = 1 << 5, //!< Is able to force reload data / clear local caches. Since QGIS 3.18, see QgsDataProvider::reloadProviderData()
-      DpiDependentData = 1 << 6, //!< Provider's rendering is dependent on requested pixel size of the viewport \since QGIS 3.20
-      NativeRasterAttributeTable = 1 << 7, //!< Indicates that the provider supports native raster attribute table \since QGIS 3.30
-      BuildPyramids = 1 << 8, //!< Supports building of pyramids (overviews) (since QGIS 3.38 -- this is a replacement for RasterInterfaceCapability::BuildPyramids)
+        NoProviderCapabilities = 0, //!< Provider has no capabilities
+        ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
+        WriteLayerMetadata = 1 << 2, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
+        ProviderHintBenefitsFromResampling = 1 << 3, //!< Provider benefits from resampling and should apply user default resampling settings \since QGIS 3.10
+        ProviderHintCanPerformProviderResampling = 1 << 4, //!< Provider can perform resampling (to be opposed to post rendering resampling) \since QGIS 3.16
+        ReloadData = 1 << 5, //!< Is able to force reload data / clear local caches. Since QGIS 3.18, see QgsDataProvider::reloadProviderData()
+        DpiDependentData = 1 << 6, //!< Provider's rendering is dependent on requested pixel size of the viewport \since QGIS 3.20
+        NativeRasterAttributeTable = 1 << 7, //!< Indicates that the provider supports native raster attribute table \since QGIS 3.30
+        BuildPyramids = 1 << 8, //!< Supports building of pyramids (overviews) (since QGIS 3.38 -- this is a replacement for RasterInterfaceCapability::BuildPyramids)
     };
     Q_ENUM( RasterProviderCapability )
 
@@ -5034,31 +5045,31 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class BlendMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsPainting, BlendMode ) : int
-      {
-      Normal SIP_MONKEYPATCH_COMPAT_NAME( BlendNormal ), //!< Normal
-      Lighten SIP_MONKEYPATCH_COMPAT_NAME( BlendLighten ), //!< Lighten
-      Screen SIP_MONKEYPATCH_COMPAT_NAME( BlendScreen ), //!< Screen
-      Dodge SIP_MONKEYPATCH_COMPAT_NAME( BlendDodge ), //!< Dodge
-      Addition SIP_MONKEYPATCH_COMPAT_NAME( BlendAddition ), //!< Addition
-      Darken SIP_MONKEYPATCH_COMPAT_NAME( BlendDarken ), //!< Darken
-      Multiply SIP_MONKEYPATCH_COMPAT_NAME( BlendMultiply ), //!< Multiple
-      Burn SIP_MONKEYPATCH_COMPAT_NAME( BlendBurn ), //!< Burn
-      Overlay SIP_MONKEYPATCH_COMPAT_NAME( BlendOverlay ), //!< Overlay
-      SoftLight SIP_MONKEYPATCH_COMPAT_NAME( BlendSoftLight ), //!< Soft light
-      HardLight SIP_MONKEYPATCH_COMPAT_NAME( BlendHardLight ), //!< Hard light
-      Difference SIP_MONKEYPATCH_COMPAT_NAME( BlendDifference ), //!< Difference
-      Subtract SIP_MONKEYPATCH_COMPAT_NAME( BlendSubtract ), //!< Subtract
-      Source SIP_MONKEYPATCH_COMPAT_NAME( BlendSource ), //!< Source
-      DestinationOver SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationOver ), //!< Destination over
-      Clear SIP_MONKEYPATCH_COMPAT_NAME( BlendClear ), //!< Clear
-      Destination SIP_MONKEYPATCH_COMPAT_NAME( BlendDestination ), //!< Destination
-      SourceIn SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceIn ), //!< Source in
-      DestinationIn SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationIn ), //!< Destination in
-      SourceOut SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceOut ), //!< Source out
-      DestinationOut SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationOut ), //!< Destination out
-      SourceAtop SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceAtop ), //!< Source atop
-      DestinationAtop SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationAtop ), //!< Destination atop
-      Xor SIP_MONKEYPATCH_COMPAT_NAME( BlendXor ), //!< XOR
+    {
+        Normal SIP_MONKEYPATCH_COMPAT_NAME( BlendNormal ), //!< Normal
+               Lighten SIP_MONKEYPATCH_COMPAT_NAME( BlendLighten ), //!< Lighten
+               Screen SIP_MONKEYPATCH_COMPAT_NAME( BlendScreen ), //!< Screen
+               Dodge SIP_MONKEYPATCH_COMPAT_NAME( BlendDodge ), //!< Dodge
+               Addition SIP_MONKEYPATCH_COMPAT_NAME( BlendAddition ), //!< Addition
+               Darken SIP_MONKEYPATCH_COMPAT_NAME( BlendDarken ), //!< Darken
+               Multiply SIP_MONKEYPATCH_COMPAT_NAME( BlendMultiply ), //!< Multiple
+               Burn SIP_MONKEYPATCH_COMPAT_NAME( BlendBurn ), //!< Burn
+               Overlay SIP_MONKEYPATCH_COMPAT_NAME( BlendOverlay ), //!< Overlay
+               SoftLight SIP_MONKEYPATCH_COMPAT_NAME( BlendSoftLight ), //!< Soft light
+               HardLight SIP_MONKEYPATCH_COMPAT_NAME( BlendHardLight ), //!< Hard light
+               Difference SIP_MONKEYPATCH_COMPAT_NAME( BlendDifference ), //!< Difference
+               Subtract SIP_MONKEYPATCH_COMPAT_NAME( BlendSubtract ), //!< Subtract
+               Source SIP_MONKEYPATCH_COMPAT_NAME( BlendSource ), //!< Source
+               DestinationOver SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationOver ), //!< Destination over
+               Clear SIP_MONKEYPATCH_COMPAT_NAME( BlendClear ), //!< Clear
+               Destination SIP_MONKEYPATCH_COMPAT_NAME( BlendDestination ), //!< Destination
+               SourceIn SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceIn ), //!< Source in
+               DestinationIn SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationIn ), //!< Destination in
+               SourceOut SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceOut ), //!< Source out
+               DestinationOut SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationOut ), //!< Destination out
+               SourceAtop SIP_MONKEYPATCH_COMPAT_NAME( BlendSourceAtop ), //!< Source atop
+               DestinationAtop SIP_MONKEYPATCH_COMPAT_NAME( BlendDestinationAtop ), //!< Destination atop
+               Xor SIP_MONKEYPATCH_COMPAT_NAME( BlendXor ), //!< XOR
     };
     Q_ENUM( BlendMode )
 
@@ -5070,11 +5081,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class SystemOfMeasurement SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, SystemOfMeasurement ) : int
-      {
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownSystem ) = 0, //!< Unknown system of measurement
-      Metric SIP_MONKEYPATCH_COMPAT_NAME( MetricSystem ), //!< International System of Units (SI)
-      Imperial SIP_MONKEYPATCH_COMPAT_NAME( ImperialSystem ), //!< British Imperial
-      USCS SIP_MONKEYPATCH_COMPAT_NAME( USCSSystem ), //!< United States customary system
+    {
+        Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownSystem ) = 0, //!< Unknown system of measurement
+        Metric SIP_MONKEYPATCH_COMPAT_NAME( MetricSystem ), //!< International System of Units (SI)
+        Imperial SIP_MONKEYPATCH_COMPAT_NAME( ImperialSystem ), //!< British Imperial
+        USCS SIP_MONKEYPATCH_COMPAT_NAME( USCSSystem ), //!< United States customary system
     };
     Q_ENUM( SystemOfMeasurement )
 
@@ -5085,10 +5096,10 @@ class CORE_EXPORT Qgis
     * \since QGIS 3.32
     */
     enum class MapToolUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsTolerance, UnitType ) : int
-      {
-      Layer SIP_MONKEYPATCH_COMPAT_NAME( LayerUnits ), //!< Layer unit value
-      Pixels, //!< Pixels unit of tolerance
-      Project  SIP_MONKEYPATCH_COMPAT_NAME( ProjectUnits ) //!< Map (project) units
+    {
+        Layer SIP_MONKEYPATCH_COMPAT_NAME( LayerUnits ), //!< Layer unit value
+              Pixels, //!< Pixels unit of tolerance
+              Project  SIP_MONKEYPATCH_COMPAT_NAME( ProjectUnits ) //!< Map (project) units
     };
     Q_ENUM( MapToolUnit )
 
@@ -5100,12 +5111,12 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class UnitType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, UnitType ) : int
-      {
-      Distance SIP_MONKEYPATCH_COMPAT_NAME( TypeDistance ) = 0, //!< Distance unit
-      Area SIP_MONKEYPATCH_COMPAT_NAME( TypeArea ), //!< Area unit
-      Volume SIP_MONKEYPATCH_COMPAT_NAME( TypeVolume ), //!< Volume unit
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( TypeUnknown ), //!< Unknown unit type
-      Temporal SIP_MONKEYPATCH_COMPAT_NAME( TypeTemporal ), //!< Temporal unit
+    {
+        Distance SIP_MONKEYPATCH_COMPAT_NAME( TypeDistance ) = 0, //!< Distance unit
+        Area SIP_MONKEYPATCH_COMPAT_NAME( TypeArea ), //!< Area unit
+        Volume SIP_MONKEYPATCH_COMPAT_NAME( TypeVolume ), //!< Volume unit
+        Unknown SIP_MONKEYPATCH_COMPAT_NAME( TypeUnknown ), //!< Unknown unit type
+        Temporal SIP_MONKEYPATCH_COMPAT_NAME( TypeTemporal ), //!< Temporal unit
     };
     Q_ENUM( UnitType )
 
@@ -5117,57 +5128,57 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class DistanceUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, DistanceUnit ) : int
-      {
-      Meters SIP_MONKEYPATCH_COMPAT_NAME( DistanceMeters ), //!< Meters
-      Kilometers SIP_MONKEYPATCH_COMPAT_NAME( DistanceKilometers ), //!< Kilometers
-      Feet SIP_MONKEYPATCH_COMPAT_NAME( DistanceFeet ), //!< Imperial feet
-      NauticalMiles SIP_MONKEYPATCH_COMPAT_NAME( DistanceNauticalMiles ), //!< Nautical miles
-      Yards SIP_MONKEYPATCH_COMPAT_NAME( DistanceYards ), //!< Imperial yards
-      Miles SIP_MONKEYPATCH_COMPAT_NAME( DistanceMiles ), //!< Terrestrial miles
-      Degrees SIP_MONKEYPATCH_COMPAT_NAME( DistanceDegrees ), //!< Degrees, for planar geographic CRS distance measurements
-      Centimeters SIP_MONKEYPATCH_COMPAT_NAME( DistanceCentimeters ), //!< Centimeters
-      Millimeters SIP_MONKEYPATCH_COMPAT_NAME( DistanceMillimeters ), //!< Millimeters
-      Inches, //!< Inches \since QGIS 3.32
-      ChainsInternational, //!< International chains \since QGIS 3.40
-      ChainsBritishBenoit1895A, //!< British chains (Benoit 1895 A) \since QGIS 3.40
-      ChainsBritishBenoit1895B, //!< British chains (Benoit 1895 B) \since QGIS 3.40
-      ChainsBritishSears1922Truncated, //!< British chains (Sears 1922 truncated) \since QGIS 3.40
-      ChainsBritishSears1922, //!< British chains (Sears 1922) \since QGIS 3.40
-      ChainsClarkes, //!< Clarke's chains \since QGIS 3.40
-      ChainsUSSurvey, //!< US Survey chains \since QGIS 3.40
-      FeetBritish1865, //!< British feet (1865) \since QGIS 3.40
-      FeetBritish1936, //!< British feet (1936) \since QGIS 3.40
-      FeetBritishBenoit1895A, //!< British feet (Benoit 1895 A) \since QGIS 3.40
-      FeetBritishBenoit1895B, //!< British feet (Benoit 1895 B) \since QGIS 3.40
-      FeetBritishSears1922Truncated, //!< British feet (Sears 1922 truncated) \since QGIS 3.40
-      FeetBritishSears1922, //!< British feet (Sears 1922) \since QGIS 3.40
-      FeetClarkes, //!< Clarke's feet \since QGIS 3.40
-      FeetGoldCoast, //!< Gold Coast feet \since QGIS 3.40
-      FeetIndian, //!< Indian (geodetic) feet \since QGIS 3.40
-      FeetIndian1937, //!< Indian feet (1937) \since QGIS 3.40
-      FeetIndian1962, //!< Indian feet (1962) \since QGIS 3.40
-      FeetIndian1975, //!< Indian feet (1975) \since QGIS 3.40
-      FeetUSSurvey, //!< US Survey feet \since QGIS 3.40
-      LinksInternational, //!< International links \since QGIS 3.40
-      LinksBritishBenoit1895A, //!< British links (Benoit 1895 A) \since QGIS 3.40
-      LinksBritishBenoit1895B, //!< British links (Benoit 1895 B) \since QGIS 3.40
-      LinksBritishSears1922Truncated, //!< British links (Sears 1922 truncated) \since QGIS 3.40
-      LinksBritishSears1922, //!< British links (Sears 1922) \since QGIS 3.40
-      LinksClarkes, //!< Clarke's links \since QGIS 3.40
-      LinksUSSurvey, //!< US Survey links \since QGIS 3.40
-      YardsBritishBenoit1895A, //!< British yards (Benoit 1895 A) \since QGIS 3.40
-      YardsBritishBenoit1895B, //!< British yards (Benoit 1895 B) \since QGIS 3.40
-      YardsBritishSears1922Truncated, //!< British yards (Sears 1922 truncated) \since QGIS 3.40
-      YardsBritishSears1922, //!< British yards (Sears 1922) \since QGIS 3.40
-      YardsClarkes, //!< Clarke's yards \since QGIS 3.40
-      YardsIndian, //!< Indian yards \since QGIS 3.40
-      YardsIndian1937, //!< Indian yards (1937) \since QGIS 3.40
-      YardsIndian1962, //!< Indian yards (1962) \since QGIS 3.40
-      YardsIndian1975, //!< Indian yards (1975) \since QGIS 3.40
-      MilesUSSurvey, //!< US Survey miles \since QGIS 3.40
-      Fathoms, //!< Fathoms \since QGIS 3.40
-      MetersGermanLegal, //!< German legal meter \since QGIS 3.40
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( DistanceUnknownUnit ), //!< Unknown distance unit
+    {
+        Meters SIP_MONKEYPATCH_COMPAT_NAME( DistanceMeters ), //!< Meters
+               Kilometers SIP_MONKEYPATCH_COMPAT_NAME( DistanceKilometers ), //!< Kilometers
+               Feet SIP_MONKEYPATCH_COMPAT_NAME( DistanceFeet ), //!< Imperial feet
+               NauticalMiles SIP_MONKEYPATCH_COMPAT_NAME( DistanceNauticalMiles ), //!< Nautical miles
+               Yards SIP_MONKEYPATCH_COMPAT_NAME( DistanceYards ), //!< Imperial yards
+               Miles SIP_MONKEYPATCH_COMPAT_NAME( DistanceMiles ), //!< Terrestrial miles
+               Degrees SIP_MONKEYPATCH_COMPAT_NAME( DistanceDegrees ), //!< Degrees, for planar geographic CRS distance measurements
+               Centimeters SIP_MONKEYPATCH_COMPAT_NAME( DistanceCentimeters ), //!< Centimeters
+               Millimeters SIP_MONKEYPATCH_COMPAT_NAME( DistanceMillimeters ), //!< Millimeters
+               Inches, //!< Inches \since QGIS 3.32
+               ChainsInternational, //!< International chains \since QGIS 3.40
+               ChainsBritishBenoit1895A, //!< British chains (Benoit 1895 A) \since QGIS 3.40
+               ChainsBritishBenoit1895B, //!< British chains (Benoit 1895 B) \since QGIS 3.40
+               ChainsBritishSears1922Truncated, //!< British chains (Sears 1922 truncated) \since QGIS 3.40
+               ChainsBritishSears1922, //!< British chains (Sears 1922) \since QGIS 3.40
+               ChainsClarkes, //!< Clarke's chains \since QGIS 3.40
+               ChainsUSSurvey, //!< US Survey chains \since QGIS 3.40
+               FeetBritish1865, //!< British feet (1865) \since QGIS 3.40
+               FeetBritish1936, //!< British feet (1936) \since QGIS 3.40
+               FeetBritishBenoit1895A, //!< British feet (Benoit 1895 A) \since QGIS 3.40
+               FeetBritishBenoit1895B, //!< British feet (Benoit 1895 B) \since QGIS 3.40
+               FeetBritishSears1922Truncated, //!< British feet (Sears 1922 truncated) \since QGIS 3.40
+               FeetBritishSears1922, //!< British feet (Sears 1922) \since QGIS 3.40
+               FeetClarkes, //!< Clarke's feet \since QGIS 3.40
+               FeetGoldCoast, //!< Gold Coast feet \since QGIS 3.40
+               FeetIndian, //!< Indian (geodetic) feet \since QGIS 3.40
+               FeetIndian1937, //!< Indian feet (1937) \since QGIS 3.40
+               FeetIndian1962, //!< Indian feet (1962) \since QGIS 3.40
+               FeetIndian1975, //!< Indian feet (1975) \since QGIS 3.40
+               FeetUSSurvey, //!< US Survey feet \since QGIS 3.40
+               LinksInternational, //!< International links \since QGIS 3.40
+               LinksBritishBenoit1895A, //!< British links (Benoit 1895 A) \since QGIS 3.40
+               LinksBritishBenoit1895B, //!< British links (Benoit 1895 B) \since QGIS 3.40
+               LinksBritishSears1922Truncated, //!< British links (Sears 1922 truncated) \since QGIS 3.40
+               LinksBritishSears1922, //!< British links (Sears 1922) \since QGIS 3.40
+               LinksClarkes, //!< Clarke's links \since QGIS 3.40
+               LinksUSSurvey, //!< US Survey links \since QGIS 3.40
+               YardsBritishBenoit1895A, //!< British yards (Benoit 1895 A) \since QGIS 3.40
+               YardsBritishBenoit1895B, //!< British yards (Benoit 1895 B) \since QGIS 3.40
+               YardsBritishSears1922Truncated, //!< British yards (Sears 1922 truncated) \since QGIS 3.40
+               YardsBritishSears1922, //!< British yards (Sears 1922) \since QGIS 3.40
+               YardsClarkes, //!< Clarke's yards \since QGIS 3.40
+               YardsIndian, //!< Indian yards \since QGIS 3.40
+               YardsIndian1937, //!< Indian yards (1937) \since QGIS 3.40
+               YardsIndian1962, //!< Indian yards (1962) \since QGIS 3.40
+               YardsIndian1975, //!< Indian yards (1975) \since QGIS 3.40
+               MilesUSSurvey, //!< US Survey miles \since QGIS 3.40
+               Fathoms, //!< Fathoms \since QGIS 3.40
+               MetersGermanLegal, //!< German legal meter \since QGIS 3.40
+               Unknown SIP_MONKEYPATCH_COMPAT_NAME( DistanceUnknownUnit ), //!< Unknown distance unit
     };
     Q_ENUM( DistanceUnit )
 
@@ -5179,10 +5190,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class DistanceUnitType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, DistanceUnitType ) : int
-      {
-      Standard, //!< Unit is a standard measurement unit
-      Geographic, //!< Unit is a geographic (e.g., degree based) unit
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownType ),  //!< Unknown unit type
+    {
+        Standard, //!< Unit is a standard measurement unit
+        Geographic, //!< Unit is a geographic (e.g., degree based) unit
+        Unknown SIP_MONKEYPATCH_COMPAT_NAME( UnknownType ),  //!< Unknown unit type
     };
     Q_ENUM( DistanceUnitType )
 
@@ -5194,20 +5205,20 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class AreaUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, AreaUnit ) : int
-      {
-      SquareMeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMeters ), //!< Square meters
-      SquareKilometers SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareKilometers ), //!< Square kilometers
-      SquareFeet SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareFeet ), //!< Square feet
-      SquareYards SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareYards ), //!< Square yards
-      SquareMiles SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMiles ), //!< Square miles
-      Hectares SIP_MONKEYPATCH_COMPAT_NAME( AreaHectares ), //!< Hectares
-      Acres SIP_MONKEYPATCH_COMPAT_NAME( AreaAcres ), //!< Acres
-      SquareNauticalMiles SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareNauticalMiles ), //!< Square nautical miles
-      SquareDegrees SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareDegrees ), //!< Square degrees, for planar geographic CRS area measurements
-      SquareCentimeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareCentimeters ), //!< Square centimeters
-      SquareMillimeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMillimeters ), //!< Square millimeters
-      SquareInches, //!< Square inches \since QGIS 3.32
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( AreaUnknownUnit ), //!< Unknown areal unit
+    {
+        SquareMeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMeters ), //!< Square meters
+                     SquareKilometers SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareKilometers ), //!< Square kilometers
+                     SquareFeet SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareFeet ), //!< Square feet
+                     SquareYards SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareYards ), //!< Square yards
+                     SquareMiles SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMiles ), //!< Square miles
+                     Hectares SIP_MONKEYPATCH_COMPAT_NAME( AreaHectares ), //!< Hectares
+                     Acres SIP_MONKEYPATCH_COMPAT_NAME( AreaAcres ), //!< Acres
+                     SquareNauticalMiles SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareNauticalMiles ), //!< Square nautical miles
+                     SquareDegrees SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareDegrees ), //!< Square degrees, for planar geographic CRS area measurements
+                     SquareCentimeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareCentimeters ), //!< Square centimeters
+                     SquareMillimeters SIP_MONKEYPATCH_COMPAT_NAME( AreaSquareMillimeters ), //!< Square millimeters
+                     SquareInches, //!< Square inches \since QGIS 3.32
+                     Unknown SIP_MONKEYPATCH_COMPAT_NAME( AreaUnknownUnit ), //!< Unknown areal unit
     };
     Q_ENUM( AreaUnit )
 
@@ -5219,18 +5230,18 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class VolumeUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, VolumeUnit ) : int
-      {
-      CubicMeters SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicMeters ), //!< Cubic meters
-      CubicFeet SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicFeet ), //!< Cubic feet
-      CubicYards SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicYards ), //!< Cubic yards
-      Barrel SIP_MONKEYPATCH_COMPAT_NAME( VolumeBarrel ), //!< Barrels
-      CubicDecimeter SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicDecimeter ), //!< Cubic decimeters
-      Liters SIP_MONKEYPATCH_COMPAT_NAME( VolumeLiters ), //!< Litres
-      GallonUS SIP_MONKEYPATCH_COMPAT_NAME( VolumeGallonUS ), //!< US Gallons
-      CubicInch SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicInch ), //!< Cubic inches
-      CubicCentimeter SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicCentimeter ), //!< Cubic Centimeters
-      CubicDegrees SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicDegrees ), //!< Cubic degrees, for planar geographic CRS volume measurements
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( VolumeUnknownUnit ), //!< Unknown volume unit
+    {
+        CubicMeters SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicMeters ), //!< Cubic meters
+                    CubicFeet SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicFeet ), //!< Cubic feet
+                    CubicYards SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicYards ), //!< Cubic yards
+                    Barrel SIP_MONKEYPATCH_COMPAT_NAME( VolumeBarrel ), //!< Barrels
+                    CubicDecimeter SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicDecimeter ), //!< Cubic decimeters
+                    Liters SIP_MONKEYPATCH_COMPAT_NAME( VolumeLiters ), //!< Litres
+                    GallonUS SIP_MONKEYPATCH_COMPAT_NAME( VolumeGallonUS ), //!< US Gallons
+                    CubicInch SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicInch ), //!< Cubic inches
+                    CubicCentimeter SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicCentimeter ), //!< Cubic Centimeters
+                    CubicDegrees SIP_MONKEYPATCH_COMPAT_NAME( VolumeCubicDegrees ), //!< Cubic degrees, for planar geographic CRS volume measurements
+                    Unknown SIP_MONKEYPATCH_COMPAT_NAME( VolumeUnknownUnit ), //!< Unknown volume unit
     };
     Q_ENUM( VolumeUnit )
 
@@ -5242,16 +5253,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class AngleUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, AngleUnit ) : int
-      {
-      Degrees SIP_MONKEYPATCH_COMPAT_NAME( AngleDegrees ), //!< Degrees
-      Radians SIP_MONKEYPATCH_COMPAT_NAME( AngleRadians ), //!< Square kilometers
-      Gon SIP_MONKEYPATCH_COMPAT_NAME( AngleGon ), //!< Gon/gradian
-      MinutesOfArc SIP_MONKEYPATCH_COMPAT_NAME( AngleMinutesOfArc ), //!< Minutes of arc
-      SecondsOfArc SIP_MONKEYPATCH_COMPAT_NAME( AngleSecondsOfArc ), //!< Seconds of arc
-      Turn SIP_MONKEYPATCH_COMPAT_NAME( AngleTurn ), //!< Turn/revolutions
-      MilliradiansSI SIP_MONKEYPATCH_COMPAT_NAME( AngleMilliradiansSI ), //!< Angular milliradians (SI definition, 1/1000 of radian)
-      MilNATO SIP_MONKEYPATCH_COMPAT_NAME( AngleMilNATO ), //!< Angular mil (NATO definition, 6400 mil = 2PI radians)
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( AngleUnknownUnit ), //!< Unknown angle unit
+    {
+        Degrees SIP_MONKEYPATCH_COMPAT_NAME( AngleDegrees ), //!< Degrees
+                Radians SIP_MONKEYPATCH_COMPAT_NAME( AngleRadians ), //!< Square kilometers
+                Gon SIP_MONKEYPATCH_COMPAT_NAME( AngleGon ), //!< Gon/gradian
+                MinutesOfArc SIP_MONKEYPATCH_COMPAT_NAME( AngleMinutesOfArc ), //!< Minutes of arc
+                SecondsOfArc SIP_MONKEYPATCH_COMPAT_NAME( AngleSecondsOfArc ), //!< Seconds of arc
+                Turn SIP_MONKEYPATCH_COMPAT_NAME( AngleTurn ), //!< Turn/revolutions
+                MilliradiansSI SIP_MONKEYPATCH_COMPAT_NAME( AngleMilliradiansSI ), //!< Angular milliradians (SI definition, 1/1000 of radian)
+                MilNATO SIP_MONKEYPATCH_COMPAT_NAME( AngleMilNATO ), //!< Angular mil (NATO definition, 6400 mil = 2PI radians)
+                Unknown SIP_MONKEYPATCH_COMPAT_NAME( AngleUnknownUnit ), //!< Unknown angle unit
     };
     Q_ENUM( AngleUnit )
 
@@ -5263,19 +5274,19 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class TemporalUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, TemporalUnit ) : int
-      {
-      Milliseconds SIP_MONKEYPATCH_COMPAT_NAME( TemporalMilliseconds ), //!< Milliseconds
-      Seconds SIP_MONKEYPATCH_COMPAT_NAME( TemporalSeconds ), //!< Seconds
-      Minutes SIP_MONKEYPATCH_COMPAT_NAME( TemporalMinutes ), //!< Minutes
-      Hours SIP_MONKEYPATCH_COMPAT_NAME( TemporalHours ), //!< Hours
-      Days SIP_MONKEYPATCH_COMPAT_NAME( TemporalDays ), //!< Days
-      Weeks SIP_MONKEYPATCH_COMPAT_NAME( TemporalWeeks ), //!< Weeks
-      Months SIP_MONKEYPATCH_COMPAT_NAME( TemporalMonths ),  //!< Months
-      Years SIP_MONKEYPATCH_COMPAT_NAME( TemporalYears ), //!< Years
-      Decades SIP_MONKEYPATCH_COMPAT_NAME( TemporalDecades ), //!< Decades
-      Centuries SIP_MONKEYPATCH_COMPAT_NAME( TemporalCenturies ), //!< Centuries
-      IrregularStep SIP_MONKEYPATCH_COMPAT_NAME( TemporalIrregularStep ), //!< Special 'irregular step' time unit, used for temporal data which uses irregular, non-real-world unit steps \since QGIS 3.20
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( TemporalUnknownUnit ) //!< Unknown time unit
+    {
+        Milliseconds SIP_MONKEYPATCH_COMPAT_NAME( TemporalMilliseconds ), //!< Milliseconds
+                     Seconds SIP_MONKEYPATCH_COMPAT_NAME( TemporalSeconds ), //!< Seconds
+                     Minutes SIP_MONKEYPATCH_COMPAT_NAME( TemporalMinutes ), //!< Minutes
+                     Hours SIP_MONKEYPATCH_COMPAT_NAME( TemporalHours ), //!< Hours
+                     Days SIP_MONKEYPATCH_COMPAT_NAME( TemporalDays ), //!< Days
+                     Weeks SIP_MONKEYPATCH_COMPAT_NAME( TemporalWeeks ), //!< Weeks
+                     Months SIP_MONKEYPATCH_COMPAT_NAME( TemporalMonths ),  //!< Months
+                     Years SIP_MONKEYPATCH_COMPAT_NAME( TemporalYears ), //!< Years
+                     Decades SIP_MONKEYPATCH_COMPAT_NAME( TemporalDecades ), //!< Decades
+                     Centuries SIP_MONKEYPATCH_COMPAT_NAME( TemporalCenturies ), //!< Centuries
+                     IrregularStep SIP_MONKEYPATCH_COMPAT_NAME( TemporalIrregularStep ), //!< Special 'irregular step' time unit, used for temporal data which uses irregular, non-real-world unit steps \since QGIS 3.20
+                     Unknown SIP_MONKEYPATCH_COMPAT_NAME( TemporalUnknownUnit ) //!< Unknown time unit
     };
     Q_ENUM( TemporalUnit )
 
@@ -5287,15 +5298,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class RenderUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, RenderUnit ) : int
-      {
-      Millimeters SIP_MONKEYPATCH_COMPAT_NAME( RenderMillimeters ), //!< Millimeters
-      MapUnits SIP_MONKEYPATCH_COMPAT_NAME( RenderMapUnits ), //!< Map units
-      Pixels SIP_MONKEYPATCH_COMPAT_NAME( RenderPixels ), //!< Pixels
-      Percentage SIP_MONKEYPATCH_COMPAT_NAME( RenderPercentage ), //!< Percentage of another measurement (e.g., canvas size, feature size)
-      Points SIP_MONKEYPATCH_COMPAT_NAME( RenderPoints ), //!< Points (e.g., for font sizes)
-      Inches SIP_MONKEYPATCH_COMPAT_NAME( RenderInches ), //!< Inches
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( RenderUnknownUnit ), //!< Mixed or unknown units
-      MetersInMapUnits SIP_MONKEYPATCH_COMPAT_NAME( RenderMetersInMapUnits ), //!< Meters value as Map units
+    {
+        Millimeters SIP_MONKEYPATCH_COMPAT_NAME( RenderMillimeters ), //!< Millimeters
+                    MapUnits SIP_MONKEYPATCH_COMPAT_NAME( RenderMapUnits ), //!< Map units
+                    Pixels SIP_MONKEYPATCH_COMPAT_NAME( RenderPixels ), //!< Pixels
+                    Percentage SIP_MONKEYPATCH_COMPAT_NAME( RenderPercentage ), //!< Percentage of another measurement (e.g., canvas size, feature size)
+                    Points SIP_MONKEYPATCH_COMPAT_NAME( RenderPoints ), //!< Points (e.g., for font sizes)
+                    Inches SIP_MONKEYPATCH_COMPAT_NAME( RenderInches ), //!< Inches
+                    Unknown SIP_MONKEYPATCH_COMPAT_NAME( RenderUnknownUnit ), //!< Mixed or unknown units
+                    MetersInMapUnits SIP_MONKEYPATCH_COMPAT_NAME( RenderMetersInMapUnits ), //!< Meters value as Map units
     };
     Q_ENUM( RenderUnit )
 
@@ -5307,15 +5318,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class LayoutUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, LayoutUnit ) : int
-      {
-      Millimeters SIP_MONKEYPATCH_COMPAT_NAME( LayoutMillimeters ), //!< Millimeters
-      Centimeters SIP_MONKEYPATCH_COMPAT_NAME( LayoutCentimeters ), //!< Centimeters
-      Meters SIP_MONKEYPATCH_COMPAT_NAME( LayoutMeters ), //!< Meters
-      Inches SIP_MONKEYPATCH_COMPAT_NAME( LayoutInches ), //!< Inches
-      Feet SIP_MONKEYPATCH_COMPAT_NAME( LayoutFeet ), //!< Feet
-      Points SIP_MONKEYPATCH_COMPAT_NAME( LayoutPoints ), //!< Typographic points
-      Picas SIP_MONKEYPATCH_COMPAT_NAME( LayoutPicas ), //!< Typographic picas
-      Pixels SIP_MONKEYPATCH_COMPAT_NAME( LayoutPixels ) //!< Pixels
+    {
+        Millimeters SIP_MONKEYPATCH_COMPAT_NAME( LayoutMillimeters ), //!< Millimeters
+                    Centimeters SIP_MONKEYPATCH_COMPAT_NAME( LayoutCentimeters ), //!< Centimeters
+                    Meters SIP_MONKEYPATCH_COMPAT_NAME( LayoutMeters ), //!< Meters
+                    Inches SIP_MONKEYPATCH_COMPAT_NAME( LayoutInches ), //!< Inches
+                    Feet SIP_MONKEYPATCH_COMPAT_NAME( LayoutFeet ), //!< Feet
+                    Points SIP_MONKEYPATCH_COMPAT_NAME( LayoutPoints ), //!< Typographic points
+                    Picas SIP_MONKEYPATCH_COMPAT_NAME( LayoutPicas ), //!< Typographic picas
+                    Pixels SIP_MONKEYPATCH_COMPAT_NAME( LayoutPixels ) //!< Pixels
     };
     Q_ENUM( LayoutUnit )
 
@@ -5327,9 +5338,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.30
      */
     enum class LayoutUnitType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsUnitTypes, LayoutUnitType ) : int
-      {
-      PaperUnits SIP_MONKEYPATCH_COMPAT_NAME( LayoutPaperUnits ), //!< Unit is a paper based measurement unit
-      ScreenUnits SIP_MONKEYPATCH_COMPAT_NAME( LayoutScreenUnits ) //!< Unit is a screen based measurement unit
+    {
+        PaperUnits SIP_MONKEYPATCH_COMPAT_NAME( LayoutPaperUnits ), //!< Unit is a paper based measurement unit
+                   ScreenUnits SIP_MONKEYPATCH_COMPAT_NAME( LayoutScreenUnits ) //!< Unit is a screen based measurement unit
     };
     Q_ENUM( LayoutUnitType )
 
@@ -5342,19 +5353,19 @@ class CORE_EXPORT Qgis
     */
     enum class LayoutRenderFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutRenderContext, Flag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Debug SIP_MONKEYPATCH_COMPAT_NAME( FlagDebug ) = 1 << 1,  //!< Debug/testing mode, items are drawn as solid rectangles.
-      OutlineOnly SIP_MONKEYPATCH_COMPAT_NAME( FlagOutlineOnly ) = 1 << 2, //!< Render items as outlines only.
-      Antialiasing SIP_MONKEYPATCH_COMPAT_NAME( FlagAntialiasing ) = 1 << 3, //!< Use antialiasing when drawing items.
-      UseAdvancedEffects SIP_MONKEYPATCH_COMPAT_NAME( FlagUseAdvancedEffects ) = 1 << 4, //!< Enable advanced effects such as blend modes. \deprecated QGIS 3.44. Use rasterizedRenderingPolicy() instead.
-      ForceVectorOutput SIP_MONKEYPATCH_COMPAT_NAME( FlagForceVectorOutput ) = 1 << 5, //!< Force output in vector format where possible, even if items require rasterization to keep their correct appearance. \deprecated QGIS 3.44. Use rasterizedRenderingPolicy() instead.
-      HideCoverageLayer SIP_MONKEYPATCH_COMPAT_NAME( FlagHideCoverageLayer ) = 1 << 6, //!< Hide coverage layer in outputs
-      DrawSelection SIP_MONKEYPATCH_COMPAT_NAME( FlagDrawSelection ) = 1 << 7, //!< Draw selection
-      DisableTiledRasterLayerRenders SIP_MONKEYPATCH_COMPAT_NAME( FlagDisableTiledRasterLayerRenders ) = 1 << 8, //!< If set, then raster layers will not be drawn as separate tiles. This may improve the appearance in exported files, at the cost of much higher memory usage during exports.
-      RenderLabelsByMapLayer SIP_MONKEYPATCH_COMPAT_NAME( FlagRenderLabelsByMapLayer ) = 1 << 9, //!< When rendering map items to multi-layered exports, render labels belonging to different layers into separate export layers
-      LosslessImageRendering SIP_MONKEYPATCH_COMPAT_NAME( FlagLosslessImageRendering ) = 1 << 10, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF).
-      SynchronousLegendGraphics SIP_MONKEYPATCH_COMPAT_NAME( FlagSynchronousLegendGraphics ) = 1 << 11, //!< Query legend graphics synchronously.
-      AlwaysUseGlobalMasks SIP_MONKEYPATCH_COMPAT_NAME( FlagAlwaysUseGlobalMasks ) = 1 << 12, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex layout exports in all current Qt versions. This flag only applies to vector layout exports. \since QGIS 3.38
-      LimitCoverageLayerRenderToCurrentFeature = 1 << 13, //!< Limit coverage layer rendering to the current atlas feature. \since QGIS 4.0
+        Debug SIP_MONKEYPATCH_COMPAT_NAME( FlagDebug ) = 1 << 1,  //!< Debug/testing mode, items are drawn as solid rectangles.
+        OutlineOnly SIP_MONKEYPATCH_COMPAT_NAME( FlagOutlineOnly ) = 1 << 2, //!< Render items as outlines only.
+        Antialiasing SIP_MONKEYPATCH_COMPAT_NAME( FlagAntialiasing ) = 1 << 3, //!< Use antialiasing when drawing items.
+        UseAdvancedEffects SIP_MONKEYPATCH_COMPAT_NAME( FlagUseAdvancedEffects ) = 1 << 4, //!< Enable advanced effects such as blend modes. \deprecated QGIS 3.44. Use rasterizedRenderingPolicy() instead.
+        ForceVectorOutput SIP_MONKEYPATCH_COMPAT_NAME( FlagForceVectorOutput ) = 1 << 5, //!< Force output in vector format where possible, even if items require rasterization to keep their correct appearance. \deprecated QGIS 3.44. Use rasterizedRenderingPolicy() instead.
+        HideCoverageLayer SIP_MONKEYPATCH_COMPAT_NAME( FlagHideCoverageLayer ) = 1 << 6, //!< Hide coverage layer in outputs
+        DrawSelection SIP_MONKEYPATCH_COMPAT_NAME( FlagDrawSelection ) = 1 << 7, //!< Draw selection
+        DisableTiledRasterLayerRenders SIP_MONKEYPATCH_COMPAT_NAME( FlagDisableTiledRasterLayerRenders ) = 1 << 8, //!< If set, then raster layers will not be drawn as separate tiles. This may improve the appearance in exported files, at the cost of much higher memory usage during exports.
+        RenderLabelsByMapLayer SIP_MONKEYPATCH_COMPAT_NAME( FlagRenderLabelsByMapLayer ) = 1 << 9, //!< When rendering map items to multi-layered exports, render labels belonging to different layers into separate export layers
+        LosslessImageRendering SIP_MONKEYPATCH_COMPAT_NAME( FlagLosslessImageRendering ) = 1 << 10, //!< Render images losslessly whenever possible, instead of the default lossy jpeg rendering used for some destination devices (e.g. PDF).
+        SynchronousLegendGraphics SIP_MONKEYPATCH_COMPAT_NAME( FlagSynchronousLegendGraphics ) = 1 << 11, //!< Query legend graphics synchronously.
+        AlwaysUseGlobalMasks SIP_MONKEYPATCH_COMPAT_NAME( FlagAlwaysUseGlobalMasks ) = 1 << 12, //!< When applying clipping paths for selective masking, always use global ("entire map") paths, instead of calculating local clipping paths per rendered feature. This results in considerably more complex layout exports in all current Qt versions. This flag only applies to vector layout exports. \since QGIS 3.38
+        LimitCoverageLayerRenderToCurrentFeature = 1 << 13, //!< Limit coverage layer rendering to the current atlas feature. \since QGIS 4.0
     };
     Q_ENUM( LayoutRenderFlag )
 
@@ -5376,10 +5387,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class PictureFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemPicture, Format ) : int
-      {
-      SVG SIP_MONKEYPATCH_COMPAT_NAME( FormatSVG ) = 0, //!< SVG image
-      Raster SIP_MONKEYPATCH_COMPAT_NAME( FormatRaster ), //!< Raster image
-      Unknown SIP_MONKEYPATCH_COMPAT_NAME( FormatUnknown ), //!< Invalid or unknown image type
+    {
+        SVG SIP_MONKEYPATCH_COMPAT_NAME( FormatSVG ) = 0, //!< SVG image
+        Raster SIP_MONKEYPATCH_COMPAT_NAME( FormatRaster ), //!< Raster image
+        Unknown SIP_MONKEYPATCH_COMPAT_NAME( FormatUnknown ), //!< Invalid or unknown image type
     };
     Q_ENUM( PictureFormat )
 
@@ -5406,10 +5417,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class ScaleBarAlignment SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsScaleBarSettings, Alignment ) : int
-      {
-      Left SIP_MONKEYPATCH_COMPAT_NAME( AlignLeft ) = 0, //!< Left aligned
-      Middle SIP_MONKEYPATCH_COMPAT_NAME( AlignMiddle ), //!< Center aligned
-      Right SIP_MONKEYPATCH_COMPAT_NAME( AlignRight ), //!< Right aligned
+    {
+        Left SIP_MONKEYPATCH_COMPAT_NAME( AlignLeft ) = 0, //!< Left aligned
+        Middle SIP_MONKEYPATCH_COMPAT_NAME( AlignMiddle ), //!< Center aligned
+        Right SIP_MONKEYPATCH_COMPAT_NAME( AlignRight ), //!< Right aligned
     };
     Q_ENUM( ScaleBarAlignment )
 
@@ -5421,9 +5432,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class ScaleBarSegmentSizeMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsScaleBarSettings, SegmentSizeMode ) : int
-      {
-      Fixed SIP_MONKEYPATCH_COMPAT_NAME( SegmentSizeFixed ) = 0, //!< Scale bar segment size is fixed to a map unit
-      FitWidth SIP_MONKEYPATCH_COMPAT_NAME( SegmentSizeFitWidth ) = 1 //!< Scale bar segment size is calculated to fit a size range
+    {
+        Fixed SIP_MONKEYPATCH_COMPAT_NAME( SegmentSizeFixed ) = 0, //!< Scale bar segment size is fixed to a map unit
+        FitWidth SIP_MONKEYPATCH_COMPAT_NAME( SegmentSizeFitWidth ) = 1 //!< Scale bar segment size is calculated to fit a size range
     };
     Q_ENUM( ScaleBarSegmentSizeMode )
 
@@ -5435,9 +5446,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class ScaleBarDistanceLabelVerticalPlacement SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsScaleBarSettings, LabelVerticalPlacement ) : int
-      {
-      AboveSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelAboveSegment ) = 0, //!< Labels are drawn above the scalebar
-      BelowSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelBelowSegment ), //!< Labels are drawn below the scalebar
+    {
+        AboveSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelAboveSegment ) = 0, //!< Labels are drawn above the scalebar
+        BelowSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelBelowSegment ), //!< Labels are drawn below the scalebar
     };
     Q_ENUM( ScaleBarDistanceLabelVerticalPlacement )
 
@@ -5449,9 +5460,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.40
      */
     enum class ScaleBarDistanceLabelHorizontalPlacement SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsScaleBarSettings, LabelHorizontalPlacement ) : int
-      {
-      CenteredEdge SIP_MONKEYPATCH_COMPAT_NAME( LabelCenteredEdge ) = 0, //!< Labels are drawn centered relative to segment's edge
-      CenteredSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelCenteredSegment ), //!< Labels are drawn centered relative to segment
+    {
+        CenteredEdge SIP_MONKEYPATCH_COMPAT_NAME( LabelCenteredEdge ) = 0, //!< Labels are drawn centered relative to segment's edge
+        CenteredSegment SIP_MONKEYPATCH_COMPAT_NAME( LabelCenteredSegment ), //!< Labels are drawn centered relative to segment
     };
     Q_ENUM( ScaleBarDistanceLabelHorizontalPlacement )
 
@@ -5464,11 +5475,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridUnit SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, GridUnit ) : int
-      {
-      MapUnits SIP_MONKEYPATCH_COMPAT_NAME( MapUnit ), //!< Grid units follow map units
-      Millimeters SIP_MONKEYPATCH_COMPAT_NAME( MM ), //!< Grid units in millimeters
-      Centimeters SIP_MONKEYPATCH_COMPAT_NAME( CM ), //!< Grid units in centimeters
-      DynamicPageSizeBased, //!< Dynamically sized, based on a on-page size range
+    {
+        MapUnits SIP_MONKEYPATCH_COMPAT_NAME( MapUnit ), //!< Grid units follow map units
+                 Millimeters SIP_MONKEYPATCH_COMPAT_NAME( MM ), //!< Grid units in millimeters
+                 Centimeters SIP_MONKEYPATCH_COMPAT_NAME( CM ), //!< Grid units in centimeters
+                 DynamicPageSizeBased, //!< Dynamically sized, based on a on-page size range
     };
     Q_ENUM( MapGridUnit )
 
@@ -5480,11 +5491,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridStyle SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, GridStyle ) : int
-      {
-      Lines SIP_MONKEYPATCH_COMPAT_NAME( Solid ) = 0, //!< Draw lines for grid
-      LineCrosses SIP_MONKEYPATCH_COMPAT_NAME( Cross ), //!< Draw line crosses at intersections of grid lines
-      Markers, //!< Draw markers at intersections of grid lines
-      FrameAndAnnotationsOnly SIP_MONKEYPATCH_COMPAT_NAME( FrameAnnotationsOnly ) //!< No grid lines over the map, only draw frame and annotations
+    {
+        Lines SIP_MONKEYPATCH_COMPAT_NAME( Solid ) = 0, //!< Draw lines for grid
+        LineCrosses SIP_MONKEYPATCH_COMPAT_NAME( Cross ), //!< Draw line crosses at intersections of grid lines
+        Markers, //!< Draw markers at intersections of grid lines
+        FrameAndAnnotationsOnly SIP_MONKEYPATCH_COMPAT_NAME( FrameAnnotationsOnly ) //!< No grid lines over the map, only draw frame and annotations
     };
     Q_ENUM( MapGridStyle )
 
@@ -5496,11 +5507,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridComponentVisibility SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, DisplayMode ) : int
-      {
-      ShowAll = 0, //!< Show both latitude and longitude annotations/divisions
-      LatitudeOnly, //!< Show latitude/y annotations/divisions only
-      LongitudeOnly, //!< Show longitude/x annotations/divisions only
-      HideAll //!< No annotations
+    {
+        ShowAll = 0, //!< Show both latitude and longitude annotations/divisions
+        LatitudeOnly, //!< Show latitude/y annotations/divisions only
+        LongitudeOnly, //!< Show longitude/x annotations/divisions only
+        HideAll //!< No annotations
     };
     Q_ENUM( MapGridComponentVisibility )
 
@@ -5512,9 +5523,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridAnnotationPosition SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, AnnotationPosition ) : int
-      {
-      InsideMapFrame = 0, //!< Draw annotations inside the map frame
-      OutsideMapFrame, //!< Draw annotations outside the map frame
+    {
+        InsideMapFrame = 0, //!< Draw annotations inside the map frame
+        OutsideMapFrame, //!< Draw annotations outside the map frame
     };
     Q_ENUM( MapGridAnnotationPosition )
 
@@ -5526,14 +5537,14 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridAnnotationDirection SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, AnnotationDirection ) : int
-      {
-      Horizontal = 0, //!< Draw annotations horizontally
-      Vertical, //!< Draw annotations vertically, ascending
-      VerticalDescending, //!< Draw annotations vertically, descending
-      BoundaryDirection, //!< Annotations follow the boundary direction
-      AboveTick, //!< Draw annotations parallel to tick (above the line)
-      OnTick, //!< Draw annotations parallel to tick (on the line)
-      UnderTick, //!< Draw annotations parallel to tick (under the line)
+    {
+        Horizontal = 0, //!< Draw annotations horizontally
+        Vertical, //!< Draw annotations vertically, ascending
+        VerticalDescending, //!< Draw annotations vertically, descending
+        BoundaryDirection, //!< Annotations follow the boundary direction
+        AboveTick, //!< Draw annotations parallel to tick (above the line)
+        OnTick, //!< Draw annotations parallel to tick (on the line)
+        UnderTick, //!< Draw annotations parallel to tick (under the line)
     };
     Q_ENUM( MapGridAnnotationDirection )
 
@@ -5545,16 +5556,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridAnnotationFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, AnnotationFormat ) : int
-      {
-      Decimal = 0, //!< Decimal degrees, use - for S/W coordinates
-      DegreeMinute, //!< Degree/minutes, use NSEW suffix
-      DegreeMinuteSecond, //!< Degree/minutes/seconds, use NSEW suffix
-      DecimalWithSuffix, //!< Decimal degrees, use NSEW suffix
-      DegreeMinuteNoSuffix, //!< Degree/minutes, use - for S/W coordinates
-      DegreeMinutePadded, //!< Degree/minutes, with minutes using leading zeros where required
-      DegreeMinuteSecondNoSuffix, //!< Degree/minutes/seconds, use - for S/W coordinates
-      DegreeMinuteSecondPadded, //!< Degree/minutes/seconds, with minutes using leading zeros where required
-      CustomFormat //!< Custom expression-based format
+    {
+        Decimal = 0, //!< Decimal degrees, use - for S/W coordinates
+        DegreeMinute, //!< Degree/minutes, use NSEW suffix
+        DegreeMinuteSecond, //!< Degree/minutes/seconds, use NSEW suffix
+        DecimalWithSuffix, //!< Decimal degrees, use NSEW suffix
+        DegreeMinuteNoSuffix, //!< Degree/minutes, use - for S/W coordinates
+        DegreeMinutePadded, //!< Degree/minutes, with minutes using leading zeros where required
+        DegreeMinuteSecondNoSuffix, //!< Degree/minutes/seconds, use - for S/W coordinates
+        DegreeMinuteSecondPadded, //!< Degree/minutes/seconds, with minutes using leading zeros where required
+        CustomFormat //!< Custom expression-based format
     };
     Q_ENUM( MapGridAnnotationFormat )
 
@@ -5566,11 +5577,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridBorderSide SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, BorderSide ) : int
-      {
-      Left, //!< Left border
-      Right, //!< Right border
-      Bottom, //!< Bottom border
-      Top, //!< Top border
+    {
+        Left, //!< Left border
+        Right, //!< Right border
+        Bottom, //!< Bottom border
+        Top, //!< Top border
     };
     Q_ENUM( MapGridBorderSide )
 
@@ -5582,15 +5593,15 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridFrameStyle SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, FrameStyle ) : int
-      {
-      NoFrame = 0, //!< Disable grid frame
-      Zebra, //!< Black/white pattern
-      InteriorTicks,  //!< Tick markers drawn inside map frame
-      ExteriorTicks,  //!< Tick markers drawn outside map frame
-      InteriorExteriorTicks, //!< Tick markers drawn both inside and outside the map frame
-      LineBorder, //!< Simple solid line frame
-      LineBorderNautical, //!< Simple solid line frame, with nautical style diagonals on corners
-      ZebraNautical, //!< Black/white pattern, with nautical style diagonals on corners
+    {
+        NoFrame = 0, //!< Disable grid frame
+        Zebra, //!< Black/white pattern
+        InteriorTicks,  //!< Tick markers drawn inside map frame
+        ExteriorTicks,  //!< Tick markers drawn outside map frame
+        InteriorExteriorTicks, //!< Tick markers drawn both inside and outside the map frame
+        LineBorder, //!< Simple solid line frame
+        LineBorderNautical, //!< Simple solid line frame, with nautical style diagonals on corners
+        ZebraNautical, //!< Black/white pattern, with nautical style diagonals on corners
     };
     Q_ENUM( MapGridFrameStyle )
 
@@ -5602,9 +5613,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridTickLengthMode SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, TickLengthMode ) : int
-      {
-      OrthogonalTicks = 0, //!< Align ticks orthogonaly
-      NormalizedTicks, //!< Constant tick lengths
+    {
+        OrthogonalTicks = 0, //!< Align ticks orthogonaly
+        NormalizedTicks, //!< Constant tick lengths
     };
     Q_ENUM( MapGridTickLengthMode )
 
@@ -5618,10 +5629,10 @@ class CORE_EXPORT Qgis
      */
     enum class MapGridFrameSideFlag SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, FrameSideFlag ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Left SIP_MONKEYPATCH_COMPAT_NAME( FrameLeft ) = 0x01, //!< Left side of map
-      Right SIP_MONKEYPATCH_COMPAT_NAME( FrameRight ) = 0x02, //!< Right side of map
-      Top SIP_MONKEYPATCH_COMPAT_NAME( FrameTop ) = 0x04, //!< Top side of map
-      Bottom SIP_MONKEYPATCH_COMPAT_NAME( FrameBottom ) = 0x08 //!< Bottom side of map
+        Left SIP_MONKEYPATCH_COMPAT_NAME( FrameLeft ) = 0x01, //!< Left side of map
+        Right SIP_MONKEYPATCH_COMPAT_NAME( FrameRight ) = 0x02, //!< Right side of map
+        Top SIP_MONKEYPATCH_COMPAT_NAME( FrameTop ) = 0x04, //!< Top side of map
+        Bottom SIP_MONKEYPATCH_COMPAT_NAME( FrameBottom ) = 0x08 //!< Bottom side of map
     };
     Q_ENUM( MapGridFrameSideFlag )
 
@@ -5643,9 +5654,9 @@ class CORE_EXPORT Qgis
      * \since QGIS 4.0
      */
     enum class MapGridAnnotationType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsLayoutItemMapGrid, AnnotationCoordinate ) : int
-      {
-      Longitude = 0, //!< Coordinate is a longitude value
-      Latitude //!< Coordinate is a latitude value
+    {
+        Longitude = 0, //!< Coordinate is a longitude value
+        Latitude //!< Coordinate is a latitude value
     };
     Q_ENUM( MapGridAnnotationType )
 
@@ -5689,11 +5700,11 @@ class CORE_EXPORT Qgis
      */
     enum class DatabaseProviderConnectionCapability2 : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      SetFieldComment = 1 << 0, //!< Can set comments for fields via setFieldComment()
-      SetFieldAlias = 1 << 1, //!< Can set aliases for fields via setFieldAlias()
-      SetTableComment = 1 << 2, //!< Can set comments for tables via setTableComment() \since QGIS 3.44
-      EditFieldDomain = 1 << 3,   //!< Can edit existing field domain \since QGIS 4.0
-      DeleteFieldDomain = 1 << 4, //!< Can delete existing field domain \since QGIS 4.0
+        SetFieldComment = 1 << 0, //!< Can set comments for fields via setFieldComment()
+        SetFieldAlias = 1 << 1, //!< Can set aliases for fields via setFieldAlias()
+        SetTableComment = 1 << 2, //!< Can set comments for tables via setTableComment() \since QGIS 3.44
+        EditFieldDomain = 1 << 3,   //!< Can edit existing field domain \since QGIS 4.0
+        DeleteFieldDomain = 1 << 4, //!< Can delete existing field domain \since QGIS 4.0
     };
     Q_ENUM( DatabaseProviderConnectionCapability2 )
     Q_DECLARE_FLAGS( DatabaseProviderConnectionCapabilities2, DatabaseProviderConnectionCapability2 )
@@ -5706,8 +5717,8 @@ class CORE_EXPORT Qgis
      */
     enum class DatabaseProviderTableImportCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      SetGeometryColumnName = 1 << 0, //!< Can set the name of the geometry column
-      SetPrimaryKeyName = 1 << 1, //!< Can set the name of the primary key column
+        SetGeometryColumnName = 1 << 0, //!< Can set the name of the geometry column
+        SetPrimaryKeyName = 1 << 1, //!< Can set the name of the primary key column
     };
     Q_ENUM( DatabaseProviderTableImportCapability )
     Q_DECLARE_FLAGS( DatabaseProviderTableImportCapabilities, DatabaseProviderTableImportCapability )
@@ -5720,9 +5731,9 @@ class CORE_EXPORT Qgis
      */
     enum class ProviderStyleStorageCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      SaveToDatabase = 1 << 1,
-      LoadFromDatabase = 1 << 2,
-      DeleteFromDatabase = 1 << 3
+        SaveToDatabase = 1 << 1,
+        LoadFromDatabase = 1 << 2,
+        DeleteFromDatabase = 1 << 3
     };
     Q_ENUM( ProviderStyleStorageCapability );
     Q_DECLARE_FLAGS( ProviderStyleStorageCapabilities, ProviderStyleStorageCapability )
@@ -5749,16 +5760,16 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class AttributeEditorType SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsAttributeEditorElement, AttributeEditorType ) : int
-      {
-      Container SIP_MONKEYPATCH_COMPAT_NAME( AeTypeContainer ), //!< A container
-      Field SIP_MONKEYPATCH_COMPAT_NAME( AeTypeField ), //!< A field
-      Relation SIP_MONKEYPATCH_COMPAT_NAME( AeTypeRelation ), //!< A relation
-      QmlElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeQmlElement ), //!< A QML element
-      HtmlElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeHtmlElement ), //!< A HTML element
-      Action SIP_MONKEYPATCH_COMPAT_NAME( AeTypeAction ), //!< A layer action element \since QGIS 3.22
-      TextElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeTextElement ), //!< A text element \since QGIS 3.30
-      SpacerElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeSpacerElement ), //!< A spacer element \since QGIS 3.30
-      Invalid SIP_MONKEYPATCH_COMPAT_NAME( AeTypeInvalid ), //!< Invalid
+    {
+        Container SIP_MONKEYPATCH_COMPAT_NAME( AeTypeContainer ), //!< A container
+                  Field SIP_MONKEYPATCH_COMPAT_NAME( AeTypeField ), //!< A field
+                  Relation SIP_MONKEYPATCH_COMPAT_NAME( AeTypeRelation ), //!< A relation
+                  QmlElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeQmlElement ), //!< A QML element
+                  HtmlElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeHtmlElement ), //!< A HTML element
+                  Action SIP_MONKEYPATCH_COMPAT_NAME( AeTypeAction ), //!< A layer action element \since QGIS 3.22
+                  TextElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeTextElement ), //!< A text element \since QGIS 3.30
+                  SpacerElement SIP_MONKEYPATCH_COMPAT_NAME( AeTypeSpacerElement ), //!< A spacer element \since QGIS 3.30
+                  Invalid SIP_MONKEYPATCH_COMPAT_NAME( AeTypeInvalid ), //!< Invalid
     };
     Q_ENUM( AttributeEditorType )
 
@@ -5783,10 +5794,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class AttributeFormLayout SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsEditFormConfig, EditorLayout ) : int
-      {
-      AutoGenerated SIP_MONKEYPATCH_COMPAT_NAME( GeneratedLayout ) = 0, //!< Autogenerate a simple tabular layout for the form
-      DragAndDrop SIP_MONKEYPATCH_COMPAT_NAME( TabLayout ) = 1, //!< "Drag and drop" layout. Needs to be configured.
-      UiFile SIP_MONKEYPATCH_COMPAT_NAME( UiFileLayout ) = 2 //!< Load a .ui file for the layout. Needs to be configured.
+    {
+        AutoGenerated SIP_MONKEYPATCH_COMPAT_NAME( GeneratedLayout ) = 0, //!< Autogenerate a simple tabular layout for the form
+        DragAndDrop SIP_MONKEYPATCH_COMPAT_NAME( TabLayout ) = 1, //!< "Drag and drop" layout. Needs to be configured.
+        UiFile SIP_MONKEYPATCH_COMPAT_NAME( UiFileLayout ) = 2 //!< Load a .ui file for the layout. Needs to be configured.
     };
     Q_ENUM( AttributeFormLayout )
 
@@ -5798,10 +5809,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class AttributeFormSuppression SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsEditFormConfig, FeatureFormSuppress ) : int
-      {
-      Default SIP_MONKEYPATCH_COMPAT_NAME( SuppressDefault ) = 0, //!< Use the application-wide setting.
-      On SIP_MONKEYPATCH_COMPAT_NAME( SuppressOn ) = 1, //!< Always suppress feature form.
-      Off SIP_MONKEYPATCH_COMPAT_NAME( SuppressOff ) = 2 //!< Never suppress feature form.
+    {
+        Default SIP_MONKEYPATCH_COMPAT_NAME( SuppressDefault ) = 0, //!< Use the application-wide setting.
+        On SIP_MONKEYPATCH_COMPAT_NAME( SuppressOn ) = 1, //!< Always suppress feature form.
+        Off SIP_MONKEYPATCH_COMPAT_NAME( SuppressOff ) = 2 //!< Never suppress feature form.
     };
     Q_ENUM( AttributeFormSuppression )
 
@@ -5813,11 +5824,11 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class AttributeFormPythonInitCodeSource SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsEditFormConfig, PythonInitCodeSource ) : int
-      {
-      NoSource SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceNone ) = 0, //!< Do not use Python code at all
-      File SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceFile ) = 1, //!< Load the Python code from an external file
-      Dialog SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceDialog ) = 2, //!< Use the Python code provided in the dialog
-      Environment SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceEnvironment ) = 3 //!< Use the Python code available in the Python environment
+    {
+        NoSource SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceNone ) = 0, //!< Do not use Python code at all
+        File SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceFile ) = 1, //!< Load the Python code from an external file
+        Dialog SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceDialog ) = 2, //!< Use the Python code provided in the dialog
+        Environment SIP_MONKEYPATCH_COMPAT_NAME( CodeSourceEnvironment ) = 3 //!< Use the Python code available in the Python environment
     };
     Q_ENUM( AttributeFormPythonInitCodeSource )
 
@@ -5855,10 +5866,10 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.32
      */
     enum class FeatureSymbologyExport SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsVectorFileWriter, SymbologyExport ) : int
-      {
-      NoSymbology = 0, //!< Export only data
-      PerFeature SIP_MONKEYPATCH_COMPAT_NAME( FeatureSymbology ), //!< Keeps the number of features and export symbology per feature
-      PerSymbolLayer SIP_MONKEYPATCH_COMPAT_NAME( SymbolLayerSymbology ) //!< Exports one feature per symbol layer (considering symbol levels)
+    {
+        NoSymbology = 0, //!< Export only data
+        PerFeature SIP_MONKEYPATCH_COMPAT_NAME( FeatureSymbology ), //!< Keeps the number of features and export symbology per feature
+        PerSymbolLayer SIP_MONKEYPATCH_COMPAT_NAME( SymbolLayerSymbology ) //!< Exports one feature per symbol layer (considering symbol levels)
     };
     Q_ENUM( FeatureSymbologyExport )
 
@@ -5869,7 +5880,7 @@ class CORE_EXPORT Qgis
      */
     enum class VectorTileProviderFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      AlwaysUseTileMatrixSetFromProvider = 1 << 1, //!< Vector tile layer must always use the tile matrix set from the data provider, and should never store, restore or override the definition of this matrix set.
+        AlwaysUseTileMatrixSetFromProvider = 1 << 1, //!< Vector tile layer must always use the tile matrix set from the data provider, and should never store, restore or override the definition of this matrix set.
     };
     Q_ENUM( VectorTileProviderFlag )
 
@@ -5887,7 +5898,7 @@ class CORE_EXPORT Qgis
      */
     enum class VectorTileProviderCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. See QgsDataProvider::layerMetadata()
+        ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. See QgsDataProvider::layerMetadata()
     };
     Q_ENUM( VectorTileProviderCapability )
 
@@ -5920,7 +5931,7 @@ class CORE_EXPORT Qgis
      */
     enum class TiledSceneProviderCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. See QgsDataProvider::layerMetadata()
+        ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. See QgsDataProvider::layerMetadata()
     };
     Q_ENUM( TiledSceneProviderCapability )
 
@@ -5980,7 +5991,7 @@ class CORE_EXPORT Qgis
      */
     enum class TiledSceneRequestFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoHierarchyFetch = 1 << 0,  //!< Do not allow hierarchy fetching when hierarchy is not currently available. Avoids network requests, but may result in an incomplete tile set. If set, then callers will need to manually perform hierarchy fetches as required.
+        NoHierarchyFetch = 1 << 0,  //!< Do not allow hierarchy fetching when hierarchy is not currently available. Avoids network requests, but may result in an incomplete tile set. If set, then callers will need to manually perform hierarchy fetches as required.
     };
     Q_ENUM( TiledSceneRequestFlag )
 
@@ -5999,10 +6010,10 @@ class CORE_EXPORT Qgis
      */
     enum class TiledSceneRendererFlag : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      RequiresTextures = 1 << 0,  //!< Renderer requires textures
-      ForceRasterRender = 1 << 1, //!< Layer should always be rendered as a raster image
-      RendersTriangles = 1 << 2, //!< Renderer can render triangle primitives
-      RendersLines = 1 << 3, //!< Renderer can render line primitives
+        RequiresTextures = 1 << 0,  //!< Renderer requires textures
+        ForceRasterRender = 1 << 1, //!< Layer should always be rendered as a raster image
+        RendersTriangles = 1 << 2, //!< Renderer can render triangle primitives
+        RendersLines = 1 << 3, //!< Renderer can render line primitives
     };
     Q_ENUM( TiledSceneRendererFlag )
 
@@ -6062,23 +6073,23 @@ class CORE_EXPORT Qgis
      */
     enum class ZonalStatistic : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Count = 1 << 0,  //!< Pixel count
-      Sum = 1 << 1,  //!< Sum of pixel values
-      Mean = 1 << 2,  //!< Mean of pixel values
-      Median = 1 << 3, //!< Median of pixel values
-      StDev = 1 << 4, //!< Standard deviation of pixel values
-      Min = 1 << 5,  //!< Min of pixel values
-      Max = 1 << 6,  //!< Max of pixel values
-      Range = 1 << 7, //!< Range of pixel values (max - min)
-      Minority = 1 << 8, //!< Minority of pixel values
-      Majority = 1 << 9, //!< Majority of pixel values
-      Variety = 1 << 10, //!< Variety (count of distinct) pixel values
-      Variance = 1 << 11, //!< Variance of pixel values
-      MinimumPoint = 1 << 12, //!< Pixel centroid for minimum pixel value \since QGIS 3.42
-      MaximumPoint = 1 << 13, //!< Pixel centroid for maximum pixel value \since QGIS 3.42
-      All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All statistics. For QGIS 3.x this includes ONLY numeric statistics, but for 4.0 this will be extended to included non-numeric statistics. Consider using AllNumeric instead.
-      AllNumeric = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All numeric statistics \since QGIS 3.42
-      Default = Count | Sum | Mean, //!< Default statistics
+        Count = 1 << 0,  //!< Pixel count
+        Sum = 1 << 1,  //!< Sum of pixel values
+        Mean = 1 << 2,  //!< Mean of pixel values
+        Median = 1 << 3, //!< Median of pixel values
+        StDev = 1 << 4, //!< Standard deviation of pixel values
+        Min = 1 << 5,  //!< Min of pixel values
+        Max = 1 << 6,  //!< Max of pixel values
+        Range = 1 << 7, //!< Range of pixel values (max - min)
+        Minority = 1 << 8, //!< Minority of pixel values
+        Majority = 1 << 9, //!< Majority of pixel values
+        Variety = 1 << 10, //!< Variety (count of distinct) pixel values
+        Variance = 1 << 11, //!< Variance of pixel values
+        MinimumPoint = 1 << 12, //!< Pixel centroid for minimum pixel value \since QGIS 3.42
+        MaximumPoint = 1 << 13, //!< Pixel centroid for maximum pixel value \since QGIS 3.42
+        All = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All statistics. For QGIS 3.x this includes ONLY numeric statistics, but for 4.0 this will be extended to included non-numeric statistics. Consider using AllNumeric instead.
+        AllNumeric = Count | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | Variance, //!< All numeric statistics \since QGIS 3.42
+        Default = Count | Sum | Mean, //!< Default statistics
     };
     Q_ENUM( ZonalStatistic )
 
@@ -6114,29 +6125,29 @@ class CORE_EXPORT Qgis
      * \since QGIS 3.36. Prior to 3.36 this was available as QgsAggregateCalculator::Aggregate.
      */
     enum class Aggregate SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsAggregateCalculator, Aggregate ) : int
-      {
-      Count, //!< Count
-      CountDistinct, //!< Number of distinct values
-      CountMissing, //!< Number of missing (null) values
-      Min, //!< Min of values
-      Max, //!< Max of values
-      Sum, //!< Sum of values
-      Mean, //!< Mean of values (numeric fields only)
-      Median, //!< Median of values (numeric fields only)
-      StDev, //!< Standard deviation of values (numeric fields only)
-      StDevSample,//!< Sample standard deviation of values (numeric fields only)
-      Range, //!< Range of values (max - min) (numeric and datetime fields only)
-      Minority, //!< Minority of values
-      Majority, //!< Majority of values
-      FirstQuartile, //!< First quartile (numeric fields only)
-      ThirdQuartile, //!< Third quartile (numeric fields only)
-      InterQuartileRange, //!< Inter quartile range (IQR) (numeric fields only)
-      StringMinimumLength, //!< Minimum length of string (string fields only)
-      StringMaximumLength, //!< Maximum length of string (string fields only)
-      StringConcatenate, //!< Concatenate values with a joining string (string fields only). Specify the delimiter using setDelimiter().
-      GeometryCollect, //!< Create a multipart geometry from aggregated geometries
-      ArrayAggregate, //!< Create an array of values
-      StringConcatenateUnique //!< Concatenate unique values with a joining string (string fields only). Specify the delimiter using setDelimiter().
+    {
+        Count, //!< Count
+        CountDistinct, //!< Number of distinct values
+        CountMissing, //!< Number of missing (null) values
+        Min, //!< Min of values
+        Max, //!< Max of values
+        Sum, //!< Sum of values
+        Mean, //!< Mean of values (numeric fields only)
+        Median, //!< Median of values (numeric fields only)
+        StDev, //!< Standard deviation of values (numeric fields only)
+        StDevSample,//!< Sample standard deviation of values (numeric fields only)
+        Range, //!< Range of values (max - min) (numeric and datetime fields only)
+        Minority, //!< Minority of values
+        Majority, //!< Majority of values
+        FirstQuartile, //!< First quartile (numeric fields only)
+        ThirdQuartile, //!< Third quartile (numeric fields only)
+        InterQuartileRange, //!< Inter quartile range (IQR) (numeric fields only)
+        StringMinimumLength, //!< Minimum length of string (string fields only)
+        StringMaximumLength, //!< Maximum length of string (string fields only)
+        StringConcatenate, //!< Concatenate values with a joining string (string fields only). Specify the delimiter using setDelimiter().
+        GeometryCollect, //!< Create a multipart geometry from aggregated geometries
+        ArrayAggregate, //!< Create an array of values
+        StringConcatenateUnique //!< Concatenate unique values with a joining string (string fields only). Specify the delimiter using setDelimiter().
     };
     Q_ENUM( Aggregate )
 
@@ -6147,25 +6158,25 @@ class CORE_EXPORT Qgis
      */
     enum class Statistic SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsStatisticalSummary, Statistic ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Count = 1 << 0,  //!< Count
-      CountMissing = 1 << 15, //!< Number of missing (null) values
-      Sum = 1 << 1,  //!< Sum of values
-      Mean = 1 << 2,  //!< Mean of values
-      Median = 1 << 3, //!< Median of values
-      StDev = 1 << 4, //!< Standard deviation of values
-      StDevSample = 1 << 5, //!< Sample standard deviation of values
-      Min = 1 << 6,  //!< Min of values
-      Max = 1 << 7,  //!< Max of values
-      Range = 1 << 8, //!< Range of values (max - min)
-      Minority = 1 << 9, //!< Minority of values
-      Majority = 1 << 10, //!< Majority of values
-      Variety = 1 << 11, //!< Variety (count of distinct) values
-      FirstQuartile = 1 << 12, //!< First quartile
-      ThirdQuartile = 1 << 13, //!< Third quartile
-      InterQuartileRange = 1 << 14, //!< Inter quartile range (IQR)
-      First = 1 << 16, //!< First value \since QGIS 3.6
-      Last = 1 << 17, //!< Last value \since QGIS 3.6
-      All = Count | CountMissing | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | FirstQuartile | ThirdQuartile | InterQuartileRange | First | Last //!< All statistics
+        Count = 1 << 0,  //!< Count
+        CountMissing = 1 << 15, //!< Number of missing (null) values
+        Sum = 1 << 1,  //!< Sum of values
+        Mean = 1 << 2,  //!< Mean of values
+        Median = 1 << 3, //!< Median of values
+        StDev = 1 << 4, //!< Standard deviation of values
+        StDevSample = 1 << 5, //!< Sample standard deviation of values
+        Min = 1 << 6,  //!< Min of values
+        Max = 1 << 7,  //!< Max of values
+        Range = 1 << 8, //!< Range of values (max - min)
+        Minority = 1 << 9, //!< Minority of values
+        Majority = 1 << 10, //!< Majority of values
+        Variety = 1 << 11, //!< Variety (count of distinct) values
+        FirstQuartile = 1 << 12, //!< First quartile
+        ThirdQuartile = 1 << 13, //!< Third quartile
+        InterQuartileRange = 1 << 14, //!< Inter quartile range (IQR)
+        First = 1 << 16, //!< First value \since QGIS 3.6
+        Last = 1 << 17, //!< Last value \since QGIS 3.6
+        All = Count | CountMissing | Sum | Mean | Median | StDev | Max | Min | Range | Minority | Majority | Variety | FirstQuartile | ThirdQuartile | InterQuartileRange | First | Last //!< All statistics
     };
     Q_ENUM( Statistic )
 
@@ -6184,13 +6195,13 @@ class CORE_EXPORT Qgis
      */
     enum class DateTimeStatistic SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsDateTimeStatisticalSummary, Statistic ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Count = 1,  //!< Count
-      CountDistinct = 2,  //!< Number of distinct datetime values
-      CountMissing = 4,  //!< Number of missing (null) values
-      Min = 8, //!< Minimum (earliest) datetime value
-      Max = 16, //!< Maximum (latest) datetime value
-      Range = 32, //!< Interval between earliest and latest datetime value
-      All = Count | CountDistinct | CountMissing | Min | Max | Range, //!< All statistics
+        Count = 1,  //!< Count
+        CountDistinct = 2,  //!< Number of distinct datetime values
+        CountMissing = 4,  //!< Number of missing (null) values
+        Min = 8, //!< Minimum (earliest) datetime value
+        Max = 16, //!< Maximum (latest) datetime value
+        Range = 32, //!< Interval between earliest and latest datetime value
+        All = Count | CountDistinct | CountMissing | Min | Max | Range, //!< All statistics
     };
     Q_ENUM( DateTimeStatistic )
 
@@ -6209,17 +6220,17 @@ class CORE_EXPORT Qgis
      */
     enum class StringStatistic SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsStringStatisticalSummary, Statistic ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Count = 1,  //!< Count
-      CountDistinct = 2,  //!< Number of distinct string values
-      CountMissing = 4,  //!< Number of missing (null) values
-      Min = 8, //!< Minimum string value
-      Max = 16, //!< Maximum string value
-      MinimumLength = 32, //!< Minimum length of string
-      MaximumLength = 64, //!< Maximum length of string
-      MeanLength = 128, //!< Mean length of strings
-      Minority = 256, //!< Minority of strings
-      Majority = 512, //!< Majority of strings
-      All = Count | CountDistinct | CountMissing | Min | Max | MinimumLength | MaximumLength | MeanLength | Minority | Majority, //!< All statistics
+        Count = 1,  //!< Count
+        CountDistinct = 2,  //!< Number of distinct string values
+        CountMissing = 4,  //!< Number of missing (null) values
+        Min = 8, //!< Minimum string value
+        Max = 16, //!< Maximum string value
+        MinimumLength = 32, //!< Minimum length of string
+        MaximumLength = 64, //!< Maximum length of string
+        MeanLength = 128, //!< Mean length of strings
+        Minority = 256, //!< Minority of strings
+        Majority = 512, //!< Majority of strings
+        All = Count | CountDistinct | CountMissing | Min | Max | MinimumLength | MaximumLength | MeanLength | Minority | Majority, //!< All statistics
     };
     Q_ENUM( StringStatistic )
 
@@ -6238,15 +6249,15 @@ class CORE_EXPORT Qgis
      */
     enum class RasterBandStatistic SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsRasterBandStats, Stats ) : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoStatistic = 0, //!< No statistic
-      Min = 1, //!< Minimum
-      Max = 1 << 1, //!< Maximum
-      Range = 1 << 2, //!< Range
-      Sum = 1 << 3, //!< Sum
-      Mean = 1 << 4, //!< Mean
-      StdDev = 1 << 5, //!< Standard deviation
-      SumOfSquares = 1 << 6, //!< Sum of squares
-      All = Min | Max | Range | Sum | Mean | StdDev | SumOfSquares //!< All available statistics
+        NoStatistic = 0, //!< No statistic
+        Min = 1, //!< Minimum
+        Max = 1 << 1, //!< Maximum
+        Range = 1 << 2, //!< Range
+        Sum = 1 << 3, //!< Sum
+        Mean = 1 << 4, //!< Mean
+        StdDev = 1 << 5, //!< Standard deviation
+        SumOfSquares = 1 << 6, //!< Sum of squares
+        All = Min | Max | Range | Sum | Mean | StdDev | SumOfSquares //!< All available statistics
     };
     Q_ENUM( RasterBandStatistic )
 
@@ -6422,8 +6433,8 @@ class CORE_EXPORT Qgis
      */
     enum class RasterProcessingParameterCapability : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      WmsScale = 1 << 0, //!< The parameter supports a reference scale for WMS source layers
-      WmsDpi = 1 << 1,   //!< The parameter supports a server resolution for WMS source layers
+        WmsScale = 1 << 0, //!< The parameter supports a reference scale for WMS source layers
+        WmsDpi = 1 << 1,   //!< The parameter supports a server resolution for WMS source layers
     };
     Q_ENUM( RasterProcessingParameterCapability )
 
@@ -6455,10 +6466,10 @@ class CORE_EXPORT Qgis
      */
     enum class ExtrusionFace : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      NoFace = 0,
-      Walls = 1 << 0,
-      Roof = 1 << 1,
-      Floor = 1 << 2
+        NoFace = 0,
+        Walls = 1 << 0,
+        Roof = 1 << 1,
+        Floor = 1 << 2
     };
     Q_ENUM( ExtrusionFace )
 
@@ -6475,8 +6486,8 @@ class CORE_EXPORT Qgis
      */
     enum class TriangulationAlgorithm : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      ConstrainedDelaunay = 0,
-      Earcut = 1 << 0
+        ConstrainedDelaunay = 0,
+        Earcut = 1 << 0
     };
     Q_ENUM( TriangulationAlgorithm )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -165,15 +165,16 @@ class CORE_EXPORT Qgis
     Q_ENUM( MessageLevel )
 
     /**
-     * \brief Type of message
-     * This will be used both for message log and message bar in application.
+     * \brief Format of log message
+     *
+     * \since QGIS 4.0. Prior to QGIS 4.0 this was available as QgsMessageOutput.MessageType
      */
-    enum class MessageType : int
-    {
-      MessageText = 0, //!< Text message
-      MessageHtml = 1, //!< HTML message
+    enum class StringFormat SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsMessageOutput, MessageType ) : int
+      {
+      PlainText SIP_MONKEYPATCH_COMPAT_NAME( MessageText ), //!< Text message
+      Html SIP_MONKEYPATCH_COMPAT_NAME( MessageHtml ), //!< HTML message
     };
-    Q_ENUM( MessageType )
+    Q_ENUM( StringFormat )
 
     /**
      * \brief Flags controlling behavior of network requests.

--- a/src/core/qgsmessagelog.cpp
+++ b/src/core/qgsmessagelog.cpp
@@ -33,34 +33,7 @@ using namespace Qt::StringLiterals;
 class QgsMessageLogConsole;
 
 void QgsMessageLog::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, bool notifyUser,
-                                const char *file, const char *function, int line )
-{
-#ifndef QGISDEBUG
-  Q_UNUSED( file )
-  Q_UNUSED( function )
-  Q_UNUSED( line )
-#endif
-  switch ( level )
-  {
-    case Qgis::MessageLevel::Info:
-    case Qgis::MessageLevel::Success:
-    case Qgis::MessageLevel::NoLevel:
-      QgsDebugMsgLevelLoc( u"%1 %2[%3] %4"_s.arg( QDateTime::currentDateTime().toString( Qt::ISODate ), tag ).arg( static_cast< int >( level ) ).arg( message ),
-                           1, file, function, line );
-      break;
-
-    case Qgis::MessageLevel::Warning:
-    case Qgis::MessageLevel::Critical:
-      QgsDebugErrorLoc( u"%1 %2[%3] %4"_s.arg( QDateTime::currentDateTime().toString( Qt::ISODate ), tag ).arg( static_cast< int >( level ) ).arg( message ),
-                        file, function, line );
-      break;
-  }
-
-  QgsApplication::messageLog()->emitMessage( message, tag, level, notifyUser, Qgis::StringFormat::PlainText );
-}
-
-void QgsMessageLog::logMessageWithFormat( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::StringFormat format, bool notifyUser,
-    const char *file, const char *function, int line )
+                                const char *file, const char *function, int line, Qgis::StringFormat format )
 {
 #ifndef QGISDEBUG
   Q_UNUSED( file )

--- a/src/core/qgsmessagelog.cpp
+++ b/src/core/qgsmessagelog.cpp
@@ -88,7 +88,6 @@ void QgsMessageLog::logMessageWithFormat( const QString &message, const QString 
 
 void QgsMessageLog::emitMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, bool notifyUser, Qgis::StringFormat format )
 {
-  emit messageReceived( message, tag, level );
   emit messageReceivedWithFormat( message, tag, level, format );
   if ( level != Qgis::MessageLevel::Info && notifyUser && mAdviseBlockCount == 0 )
   {

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -59,22 +59,12 @@ class CORE_EXPORT QgsMessageLog : public QObject
      * If \a notifyUser is TRUE, then the message should be brought to the user's attention by various UI hints.
      * If it is FALSE, the message should appear in logs silently. Note that log viewer implementations may
      * only respect notification hints for certain message levels.
+     *
+     * The \a format parameter specifies the message format (since QGIS 4.0).
      */
     static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true,
-                            const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
-    /**
-     * Adds a \a message to the log instance (and creates it if necessary).
-     *
-     * If \a notifyUser is TRUE, then the message should be brought to the user's attention by various UI hints.
-     * If it is FALSE, the message should appear in logs silently. Note that log viewer implementations may
-     * only respect notification hints for certain message levels.
-     *
-     * The \a format parameter specifies the message format.
-     *
-     * \since QGIS 4.0
-     */
-    static void logMessageWithFormat( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, Qgis::StringFormat format = Qgis::StringFormat::PlainText,
-                                      bool notifyUser = true, const char *file SIP_PYARGREMOVE = __builtin_FILE(), const char *function SIP_PYARGREMOVE = __builtin_FUNCTION(), int line SIP_PYARGREMOVE = __builtin_LINE() );
+                            const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE(), Qgis::StringFormat format = Qgis::StringFormat::PlainText );
+
   signals:
 
     /**

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -62,7 +62,6 @@ class CORE_EXPORT QgsMessageLog : public QObject
      */
     static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true,
                             const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
-
     /**
      * Adds a \a message to the log instance (and creates it if necessary).
      *
@@ -70,10 +69,12 @@ class CORE_EXPORT QgsMessageLog : public QObject
      * If it is FALSE, the message should appear in logs silently. Note that log viewer implementations may
      * only respect notification hints for certain message levels.
      *
+     * The \a format parameter specifies the message format.
+     *
      * \since QGIS 4.0
      */
     static void logMessageWithFormat( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, Qgis::StringFormat format = Qgis::StringFormat::PlainText,
-                                      bool notifyUser = true, const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
+                                      bool notifyUser = true, const char *file SIP_PYARGREMOVE = __builtin_FILE(), const char *function SIP_PYARGREMOVE = __builtin_FUNCTION(), int line SIP_PYARGREMOVE = __builtin_LINE() );
   signals:
 
     /**

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -63,6 +63,17 @@ class CORE_EXPORT QgsMessageLog : public QObject
     static void logMessage( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, bool notifyUser = true,
                             const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
 
+    /**
+     * Adds a \a message to the log instance (and creates it if necessary).
+     *
+     * If \a notifyUser is TRUE, then the message should be brought to the user's attention by various UI hints.
+     * If it is FALSE, the message should appear in logs silently. Note that log viewer implementations may
+     * only respect notification hints for certain message levels.
+     *
+     * \since QGIS 4.0
+     */
+    static void logMessageWithFormat( const QString &message, const QString &tag = QString(), Qgis::MessageLevel level = Qgis::MessageLevel::Warning, Qgis::StringFormat format = Qgis::StringFormat::PlainText,
+                                      bool notifyUser = true, const char *file = __builtin_FILE(), const char *function = __builtin_FUNCTION(), int line = __builtin_LINE() );
   signals:
 
     /**
@@ -70,8 +81,18 @@ class CORE_EXPORT QgsMessageLog : public QObject
      *
      * This signal is emitted for all messages received by the log, regardless of the \a notifyUser flag's
      * value for the message.
+     *
+     * \deprecated QGIS 4.0. Use messageReceivedWithFormat() instead.
      */
-    void messageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level );
+    Q_DECL_DEPRECATED void messageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level ) SIP_DEPRECATED;
+
+    /**
+     * Emitted whenever the log receives a \a message.
+     *
+     * This signal is emitted for all messages received by the log, regardless of the \a notifyUser flag's
+     * value for the message.
+     */
+    void messageReceivedWithFormat( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::StringFormat );
 
     //TODO QGIS 5.0 - remove received argument
 
@@ -87,7 +108,7 @@ class CORE_EXPORT QgsMessageLog : public QObject
 
   private:
 
-    void emitMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, bool notifyUser = true );
+    void emitMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, bool notifyUser = true, Qgis::StringFormat format = Qgis::StringFormat::PlainText );
 
     int mAdviseBlockCount = 0;
 
@@ -171,6 +192,18 @@ class CORE_EXPORT QgsMessageLogConsole : public QObject
      * \param level the log level of the message
      */
     virtual void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+
+    /**
+     * Logs a message to stderr.
+     *
+     * \param message the message to format
+     * \param tag the tag of the message
+     * \param level the log level of the message
+     * \param format the format of the message (currently ignored)
+     *
+     * \since QGIS 4.0
+     */
+    virtual void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::StringFormat format );
 };
 
 #endif

--- a/src/core/qgsmessageoutput.cpp
+++ b/src/core/qgsmessageoutput.cpp
@@ -44,7 +44,7 @@ QgsMessageOutput *QgsMessageOutput::createMessageOutput()
   return mMessageOutputCreator();
 }
 
-void QgsMessageOutput::showMessage( const QString &title, const QString &message, MessageType msgType )
+void QgsMessageOutput::showMessage( const QString &title, const QString &message, Qgis::MessageType msgType )
 {
   QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
   output->setTitle( title );
@@ -55,7 +55,7 @@ void QgsMessageOutput::showMessage( const QString &title, const QString &message
 ////////////////////////////////
 // QgsMessageOutputConsole
 
-void QgsMessageOutputConsole::setMessage( const QString &message, MessageType msgType )
+void QgsMessageOutputConsole::setMessage( const QString &message, Qgis::MessageType msgType )
 {
   mMessage = message;
   mMsgType = msgType;
@@ -68,14 +68,7 @@ void QgsMessageOutputConsole::appendMessage( const QString &message )
 
 void QgsMessageOutputConsole::showMessage( bool )
 {
-  if ( mMsgType == MessageHtml )
-  {
-    mMessage.replace( "<br>"_L1, "\n"_L1 );
-    mMessage.replace( "&nbsp;"_L1, " "_L1 );
-    const thread_local QRegularExpression tagRX( u"</?[^>]+>"_s );
-    mMessage.replace( tagRX, QString() );
-  }
-  QgsMessageLog::logMessage( mMessage, mTitle.isNull() ? QObject::tr( "Console" ) : mTitle );
+  QgsMessageLog::logMessage( mMessage, mTitle.isNull() ? QObject::tr( "Console" ) : mTitle, Qgis::MessageLevel::Info, mMsgType );
   emit destroyed();
   delete this;
 }

--- a/src/core/qgsmessageoutput.cpp
+++ b/src/core/qgsmessageoutput.cpp
@@ -68,6 +68,13 @@ void QgsMessageOutputConsole::appendMessage( const QString &message )
 
 void QgsMessageOutputConsole::showMessage( bool )
 {
+  if ( mFormat == Qgis::StringFormat::Html )
+  {
+    mMessage.replace( "<br>"_L1, "\n"_L1 );
+    mMessage.replace( "&nbsp;"_L1, " "_L1 );
+    const thread_local QRegularExpression tagRX( u"</?[^>]+>"_s );
+    mMessage.replace( tagRX, QString() );
+  }
   QgsMessageLog::logMessage( mMessage, mTitle.isNull() ? QObject::tr( "Console" ) : mTitle );
   emit destroyed();
   delete this;

--- a/src/core/qgsmessageoutput.cpp
+++ b/src/core/qgsmessageoutput.cpp
@@ -44,21 +44,21 @@ QgsMessageOutput *QgsMessageOutput::createMessageOutput()
   return mMessageOutputCreator();
 }
 
-void QgsMessageOutput::showMessage( const QString &title, const QString &message, Qgis::MessageType msgType )
+void QgsMessageOutput::showMessage( const QString &title, const QString &message, Qgis::StringFormat format )
 {
   QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
   output->setTitle( title );
-  output->setMessage( message, msgType );
+  output->setMessage( message, format );
   output->showMessage();
 }
 
 ////////////////////////////////
 // QgsMessageOutputConsole
 
-void QgsMessageOutputConsole::setMessage( const QString &message, Qgis::MessageType msgType )
+void QgsMessageOutputConsole::setMessage( const QString &message, Qgis::StringFormat format )
 {
   mMessage = message;
-  mMsgType = msgType;
+  mFormat = format;
 }
 
 void QgsMessageOutputConsole::appendMessage( const QString &message )
@@ -68,7 +68,7 @@ void QgsMessageOutputConsole::appendMessage( const QString &message )
 
 void QgsMessageOutputConsole::showMessage( bool )
 {
-  QgsMessageLog::logMessage( mMessage, mTitle.isNull() ? QObject::tr( "Console" ) : mTitle, Qgis::MessageLevel::Info, mMsgType );
+  QgsMessageLog::logMessage( mMessage, mTitle.isNull() ? QObject::tr( "Console" ) : mTitle );
   emit destroyed();
   delete this;
 }

--- a/src/core/qgsmessageoutput.h
+++ b/src/core/qgsmessageoutput.h
@@ -44,13 +44,10 @@ class CORE_EXPORT QgsMessageOutput
 {
   public:
 
-    //! message can be in plain text or in html format
-    enum MessageType { MessageText, MessageHtml };
-
     virtual ~QgsMessageOutput() = default;
 
     //! Sets message, it won't be displayed until
-    virtual void setMessage( const QString &message, MessageType msgType ) = 0;
+    virtual void setMessage( const QString &message, Qgis::MessageType msgType ) = 0;
 
     //! message to be appended to the current text
     virtual void appendMessage( const QString &message ) = 0;
@@ -64,7 +61,7 @@ class CORE_EXPORT QgsMessageOutput
     /**
      * Display the blocking message to the user.
      */
-    static void showMessage( const QString &title, const QString &message, MessageType msgType );
+    static void showMessage( const QString &title, const QString &message, Qgis::MessageType msgType );
 
     // TODO: implementation where Python class could be passed
 
@@ -102,7 +99,7 @@ class CORE_EXPORT QgsMessageOutputConsole : public QObject, public QgsMessageOut
 
     QgsMessageOutputConsole() = default;
 
-    void setMessage( const QString &message, MessageType msgType ) override;
+    void setMessage( const QString &message, Qgis::MessageType msgType ) override;
 
     void appendMessage( const QString &message ) override;
 
@@ -124,7 +121,7 @@ class CORE_EXPORT QgsMessageOutputConsole : public QObject, public QgsMessageOut
     //! stores current title
     QString mTitle;
 
-    MessageType mMsgType = MessageText;
+    Qgis::MessageType mMsgType = Qgis::MessageType::MessageText;
 };
 
 #endif

--- a/src/core/qgsmessageoutput.h
+++ b/src/core/qgsmessageoutput.h
@@ -47,7 +47,7 @@ class CORE_EXPORT QgsMessageOutput
     virtual ~QgsMessageOutput() = default;
 
     //! Sets message, it won't be displayed until
-    virtual void setMessage( const QString &message, Qgis::MessageType msgType ) = 0;
+    virtual void setMessage( const QString &message, Qgis::StringFormat format ) = 0;
 
     //! message to be appended to the current text
     virtual void appendMessage( const QString &message ) = 0;
@@ -61,7 +61,7 @@ class CORE_EXPORT QgsMessageOutput
     /**
      * Display the blocking message to the user.
      */
-    static void showMessage( const QString &title, const QString &message, Qgis::MessageType msgType );
+    static void showMessage( const QString &title, const QString &message, Qgis::StringFormat format );
 
     // TODO: implementation where Python class could be passed
 
@@ -99,7 +99,7 @@ class CORE_EXPORT QgsMessageOutputConsole : public QObject, public QgsMessageOut
 
     QgsMessageOutputConsole() = default;
 
-    void setMessage( const QString &message, Qgis::MessageType msgType ) override;
+    void setMessage( const QString &message, Qgis::StringFormat format ) override;
 
     void appendMessage( const QString &message ) override;
 
@@ -121,7 +121,7 @@ class CORE_EXPORT QgsMessageOutputConsole : public QObject, public QgsMessageOut
     //! stores current title
     QString mTitle;
 
-    Qgis::MessageType mMsgType = Qgis::MessageType::MessageText;
+    Qgis::StringFormat mFormat = Qgis::StringFormat::PlainText;
 };
 
 #endif

--- a/src/core/qgsmessageoutput.h
+++ b/src/core/qgsmessageoutput.h
@@ -17,6 +17,7 @@
 #ifndef QGSMESSAGEOUTPUT_H
 #define QGSMESSAGEOUTPUT_H
 
+#include "qgis.h"
 #include "qgis_core.h"
 #include "qgis_sip.h"
 

--- a/src/core/qgsrunprocess.cpp
+++ b/src/core/qgsrunprocess.cpp
@@ -64,7 +64,7 @@ QgsRunProcess::QgsRunProcess( const QString &action, bool capture )
     // It will delete itself when the dialog box is closed.
     mOutput = QgsMessageOutput::createMessageOutput();
     mOutput->setTitle( action );
-    mOutput->setMessage( tr( "<b>Starting %1…</b>" ).arg( action ), QgsMessageOutput::MessageHtml );
+    mOutput->setMessage( tr( "<b>Starting %1…</b>" ).arg( action ), Qgis::StringFormat::Html );
     mOutput->showMessage( false ); // non-blocking
 
     // get notification of delete if it's derived from QObject
@@ -166,7 +166,7 @@ void QgsRunProcess::processError( QProcess::ProcessError err )
   if ( err == QProcess::FailedToStart )
   {
     QgsMessageOutput *output = mOutput ? mOutput : QgsMessageOutput::createMessageOutput();
-    output->setMessage( tr( "Unable to run command %1" ).arg( mCommand ), QgsMessageOutput::MessageText );
+    output->setMessage( tr( "Unable to run command %1" ).arg( mCommand ), Qgis::StringFormat::PlainText );
     // Didn't work, so no need to hang around
     die();
   }

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -1245,7 +1245,7 @@ void QgsModelDesignerDialog::validate()
       }
       longMessage += "</ul>"_L1;
 
-      dialog->setMessage( longMessage, QgsMessageOutput::MessageHtml );
+      dialog->setMessage( longMessage, Qgis::StringFormat::Html );
       dialog->showMessage();
     } );
     messageWidget->layout()->addWidget( detailsButton );

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -612,7 +612,7 @@ void QgsModelGraphicsScene::showWarning( const QString &shortMessage, const QStr
   connect( detailsButton, &QPushButton::clicked, detailsButton, [detailsButton, title, longMessage] {
     QgsMessageViewer *dialog = new QgsMessageViewer( detailsButton );
     dialog->setTitle( title );
-    dialog->setMessage( longMessage, QgsMessageOutput::MessageHtml );
+    dialog->setMessage( longMessage, Qgis::StringFormat::Html );
     dialog->showMessage();
   } );
   messageWidget->layout()->addWidget( detailsButton );

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -553,7 +553,7 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
               {
                 QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
                 output->setTitle( tr( "Import to GeoPackage database" ) );
-                output->setMessage( tr( "Failed to import some vector layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+                output->setMessage( tr( "Failed to import some vector layers!\n\n" ) + errorMessage, Qgis::StringFormat::PlainText );
                 output->showMessage();
               }
             } );
@@ -575,7 +575,7 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
               {
                 QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
                 output->setTitle( tr( "Import to GeoPackage database" ) );
-                output->setMessage( tr( "Failed to import some raster layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+                output->setMessage( tr( "Failed to import some raster layers!\n\n" ) + errorMessage, Qgis::StringFormat::PlainText );
                 output->showMessage();
               }
               // Always try to delete the imported raster, in case the gpkg has been left
@@ -598,7 +598,7 @@ bool QgsGeoPackageItemGuiProvider::handleDropGeopackage( QgsGeoPackageCollection
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( tr( "Import to GeoPackage database" ) );
-    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), Qgis::StringFormat::PlainText );
     output->showMessage();
   }
   if ( hasSubTasks )

--- a/src/gui/qgsdataitemguiproviderutils.cpp
+++ b/src/gui/qgsdataitemguiproviderutils.cpp
@@ -96,7 +96,7 @@ bool QgsDataItemGuiProviderUtils::handleDropUriForConnection( std::unique_ptr<Qg
     QObject::connect( detailsButton, &QPushButton::clicked, detailsButton, [longTitle, error] {
       QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
       output->setTitle( longTitle );
-      output->setMessage( error, QgsMessageOutput::MessageText );
+      output->setMessage( error, Qgis::StringFormat::PlainText );
       output->showMessage();
     } );
     item->layout()->addWidget( detailsButton );
@@ -176,7 +176,7 @@ void QgsDataItemGuiProviderUtils::handleImportVectorLayerForConnection( std::uni
     QObject::connect( detailsButton, &QPushButton::clicked, detailsButton, [longTitle, error] {
       QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
       output->setTitle( longTitle );
-      output->setMessage( error, QgsMessageOutput::MessageText );
+      output->setMessage( error, Qgis::StringFormat::PlainText );
       output->showMessage();
     } );
     item->layout()->addWidget( detailsButton );

--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -109,7 +109,7 @@ void QgsMessageLogViewer::reject()
 {
 }
 
-void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::MessageType type )
+void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level )
 {
   constexpr int MESSAGE_COUNT_LIMIT = 10000;
   // Avoid logging too many messages, which might blow memory.
@@ -174,15 +174,7 @@ void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag
 
   const QString prefix = u"<font color=\"%1\">%2 &nbsp;&nbsp;&nbsp; %3 &nbsp;&nbsp;&nbsp;</font>"_s
                            .arg( color.name(), QDateTime::currentDateTime().toString( Qt::ISODate ), levelString );
-
-  if ( msgType == Qgis::MessageType::MessageHtml )
-  {
-    cleanedMessage = message;
-  }
-  else
-  {
-    cleanedMessage = message.toHtmlEscaped();
-  }
+  QString cleanedMessage = message.toHtmlEscaped();
   if ( mMessageLoggedCount == MESSAGE_COUNT_LIMIT )
     cleanedMessage = tr( "Message log truncated" );
 

--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -42,7 +42,7 @@ QgsMessageLogViewer::QgsMessageLogViewer( QWidget *parent, Qt::WindowFlags fl )
 {
   setupUi( this );
 
-  connect( QgsApplication::messageLog(), static_cast<void ( QgsMessageLog::* )( const QString &, const QString &, Qgis::MessageLevel )>( &QgsMessageLog::messageReceived ), this, static_cast<void ( QgsMessageLogViewer::* )( const QString &, const QString &, Qgis::MessageLevel )>( &QgsMessageLogViewer::logMessage ) );
+  connect( QgsApplication::messageLog(), static_cast<void ( QgsMessageLog::* )( const QString &, const QString &, Qgis::MessageLevel, Qgis::StringFormat )>( &QgsMessageLog::messageReceivedWithFormat ), this, static_cast<void ( QgsMessageLogViewer::* )( const QString &, const QString &, Qgis::MessageLevel, Qgis::StringFormat )>( &QgsMessageLogViewer::logMessage ) );
 
   connect( tabWidget, &QTabWidget::tabCloseRequested, this, &QgsMessageLogViewer::closeTab );
 
@@ -109,7 +109,7 @@ void QgsMessageLogViewer::reject()
 {
 }
 
-void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level )
+void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::StringFormat format )
 {
   constexpr int MESSAGE_COUNT_LIMIT = 10000;
   // Avoid logging too many messages, which might blow memory.
@@ -174,7 +174,16 @@ void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag
 
   const QString prefix = u"<font color=\"%1\">%2 &nbsp;&nbsp;&nbsp; %3 &nbsp;&nbsp;&nbsp;</font>"_s
                            .arg( color.name(), QDateTime::currentDateTime().toString( Qt::ISODate ), levelString );
-  QString cleanedMessage = message.toHtmlEscaped();
+  QString cleanedMessage;
+  switch ( format )
+  {
+    case Qgis::StringFormat::PlainText:
+      cleanedMessage = message.toHtmlEscaped();
+      break;
+    case Qgis::StringFormat::Html:
+      cleanedMessage = message;
+      break;
+  }
   if ( mMessageLoggedCount == MESSAGE_COUNT_LIMIT )
     cleanedMessage = tr( "Message log truncated" );
 

--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -109,7 +109,7 @@ void QgsMessageLogViewer::reject()
 {
 }
 
-void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level )
+void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::MessageType type )
 {
   constexpr int MESSAGE_COUNT_LIMIT = 10000;
   // Avoid logging too many messages, which might blow memory.
@@ -174,7 +174,15 @@ void QgsMessageLogViewer::logMessage( const QString &message, const QString &tag
 
   const QString prefix = u"<font color=\"%1\">%2 &nbsp;&nbsp;&nbsp; %3 &nbsp;&nbsp;&nbsp;</font>"_s
                            .arg( color.name(), QDateTime::currentDateTime().toString( Qt::ISODate ), levelString );
-  QString cleanedMessage = message.toHtmlEscaped();
+
+  if ( msgType == Qgis::MessageType::MessageHtml )
+  {
+    cleanedMessage = message;
+  }
+  else
+  {
+    cleanedMessage = message.toHtmlEscaped();
+  }
   if ( mMessageLoggedCount == MESSAGE_COUNT_LIMIT )
     cleanedMessage = tr( "Message log truncated" );
 

--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -49,7 +49,7 @@ class GUI_EXPORT QgsMessageLogViewer : public QDialog, private Ui::QgsMessageLog
     /**
      * Logs a \a message to the viewer.
      *
-     * The \a format parameter defined message format (since QGIS 4.0)
+     * The \a format parameter specifies the message format (since QGIS 4.0)
      */
     void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::StringFormat format = Qgis::StringFormat::PlainText );
 

--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -48,8 +48,10 @@ class GUI_EXPORT QgsMessageLogViewer : public QDialog, private Ui::QgsMessageLog
 
     /**
      * Logs a \a message to the viewer.
+     *
+     * The \a format parameter defined message format (since QGIS 4.0)
      */
-    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::StringFormat format = Qgis::StringFormat::PlainText );
 
     /**
      * Activates the tab whose title matches the given \a tag, if any.

--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -49,7 +49,7 @@ class GUI_EXPORT QgsMessageLogViewer : public QDialog, private Ui::QgsMessageLog
     /**
      * Logs a \a message to the viewer.
      */
-    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::MessageType type );
 
     /**
      * Activates the tab whose title matches the given \a tag, if any.

--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -49,7 +49,7 @@ class GUI_EXPORT QgsMessageLogViewer : public QDialog, private Ui::QgsMessageLog
     /**
      * Logs a \a message to the viewer.
      */
-    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::MessageType type );
+    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
 
     /**
      * Activates the tab whose title matches the given \a tag, if any.

--- a/src/gui/qgsmessageviewer.cpp
+++ b/src/gui/qgsmessageviewer.cpp
@@ -57,9 +57,9 @@ void QgsMessageViewer::appendMessage( const QString &msg )
 }
 
 
-void QgsMessageViewer::setMessage( const QString &message, MessageType msgType )
+void QgsMessageViewer::setMessage( const QString &message, Qgis::MessageType msgType )
 {
-  if ( msgType == MessageHtml )
+  if ( msgType == Qgis::MessageType::MessageHtml )
     setMessageAsHtml( message );
   else
     setMessageAsPlainText( message );

--- a/src/gui/qgsmessageviewer.cpp
+++ b/src/gui/qgsmessageviewer.cpp
@@ -57,12 +57,17 @@ void QgsMessageViewer::appendMessage( const QString &msg )
 }
 
 
-void QgsMessageViewer::setMessage( const QString &message, Qgis::MessageType msgType )
+void QgsMessageViewer::setMessage( const QString &message, Qgis::StringFormat format )
 {
-  if ( msgType == Qgis::MessageType::MessageHtml )
-    setMessageAsHtml( message );
-  else
-    setMessageAsPlainText( message );
+  switch ( format )
+  {
+    case Qgis::StringFormat::PlainText:
+      setMessageAsPlainText( message );
+      break;
+    case Qgis::StringFormat::Html:
+      setMessageAsHtml( message );
+      break;
+  };
 }
 
 void QgsMessageViewer::showMessage( bool blocking )

--- a/src/gui/qgsmessageviewer.h
+++ b/src/gui/qgsmessageviewer.h
@@ -35,7 +35,7 @@ class GUI_EXPORT QgsMessageViewer : public QDialog, public QgsMessageOutput, pri
   public:
     QgsMessageViewer( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, bool deleteOnClose = true );
 
-    void setMessage( const QString &message, Qgis::MessageType msgType ) override;
+    void setMessage( const QString &message, Qgis::StringFormat format ) override;
 
     void appendMessage( const QString &message ) override;
 

--- a/src/gui/qgsmessageviewer.h
+++ b/src/gui/qgsmessageviewer.h
@@ -35,7 +35,7 @@ class GUI_EXPORT QgsMessageViewer : public QDialog, public QgsMessageOutput, pri
   public:
     QgsMessageViewer( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, bool deleteOnClose = true );
 
-    void setMessage( const QString &message, MessageType msgType ) override;
+    void setMessage( const QString &message, Qgis::MessageType msgType ) override;
 
     void appendMessage( const QString &message ) override;
 

--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -259,7 +259,7 @@ int QgsProcessingExec::run( const QStringList &args, Qgis::ProcessingLogLevel lo
 {
   mFlags = flags;
 
-  QObject::connect( QgsApplication::messageLog(), static_cast<void ( QgsMessageLog::* )( const QString &message, const QString &tag, Qgis::MessageLevel level )>( &QgsMessageLog::messageReceived ), QgsApplication::instance(), []( const QString &message, const QString &, Qgis::MessageLevel level ) {
+  QObject::connect( QgsApplication::messageLog(), static_cast<void ( QgsMessageLog::* )( const QString &message, const QString &tag, Qgis::MessageLevel level, Qgis::StringFormat )>( &QgsMessageLog::messageReceivedWithFormat ), QgsApplication::instance(), []( const QString &message, const QString &, Qgis::MessageLevel level, Qgis::StringFormat ) {
     if ( level == Qgis::MessageLevel::Critical )
     {
       if ( !message.contains( "DeprecationWarning:"_L1 ) )

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -1192,7 +1192,7 @@ void QgsDelimitedTextProvider::reportErrors( const QStringList &messages, bool s
     {
       QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
       output->setTitle( tr( "Delimited text file errors" ) );
-      output->setMessage( tr( "Errors in file %1" ).arg( mFile->fileName() ), QgsMessageOutput::MessageText );
+      output->setMessage( tr( "Errors in file %1" ).arg( mFile->fileName() ), Qgis::StringFormat::PlainText );
       const auto constMessages = messages;
       for ( const QString &message : constMessages )
       {

--- a/src/providers/grass/qgsgrassprovidermodule.cpp
+++ b/src/providers/grass/qgsgrassprovidermodule.cpp
@@ -215,7 +215,7 @@ void QgsGrassItemActions::renameGrassObject()
     QgsDebugMsgLevel( obj.name() + " exists -> delete", 2 );
     if ( !QgsGrass::deleteObject( obj ) )
     {
-      QgsMessageOutput::showMessage( errorTitle, QObject::tr( "Cannot delete %1" ).arg( obj.name() ), QgsMessageOutput::MessageText );
+      QgsMessageOutput::showMessage( errorTitle, QObject::tr( "Cannot delete %1" ).arg( obj.name() ), Qgis::StringFormat::PlainText );
       return;
     }
   }
@@ -226,7 +226,7 @@ void QgsGrassItemActions::renameGrassObject()
   }
   catch ( QgsGrass::Exception &e )
   {
-    QgsMessageOutput::showMessage( errorTitle, QObject::tr( "Cannot rename %1 to %2" ).arg( mGrassObject.name(), obj.name() ) + "\n" + e.what(), QgsMessageOutput::MessageText );
+    QgsMessageOutput::showMessage( errorTitle, QObject::tr( "Cannot rename %1 to %2" ).arg( mGrassObject.name(), obj.name() ) + "\n" + e.what(), Qgis::StringFormat::PlainText );
   }
 }
 
@@ -925,7 +925,7 @@ bool QgsGrassMapsetItem::handleDrop( const QMimeData *data, Qt::DropAction )
 
   if ( !errors.isEmpty() )
   {
-    QgsMessageOutput::showMessage( tr( "Import to GRASS mapset" ), tr( "Failed to import some layers!\n\n" ) + errors.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
+    QgsMessageOutput::showMessage( tr( "Import to GRASS mapset" ), tr( "Failed to import some layers!\n\n" ) + errors.join( QLatin1Char( '\n' ) ), Qgis::StringFormat::PlainText );
   }
 
   return true;
@@ -937,7 +937,7 @@ void QgsGrassMapsetItem::onImportFinished( QgsGrassImport *import )
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( tr( "Import to GRASS mapset failed" ) );
-    output->setMessage( tr( "Failed to import %1 to %2: %3" ).arg( import->srcDescription(), import->grassObject().mapsetPath(), import->error() ), QgsMessageOutput::MessageText );
+    output->setMessage( tr( "Failed to import %1 to %2: %3" ).arg( import->srcDescription(), import->grassObject().mapsetPath(), import->error() ), Qgis::StringFormat::PlainText );
     output->showMessage();
   }
 

--- a/src/providers/hana/qgshanadataitemguiprovider.cpp
+++ b/src/providers/hana/qgshanadataitemguiprovider.cpp
@@ -440,7 +440,7 @@ bool QgsHanaDataItemGuiProvider::handleDrop( QgsHanaConnectionItem *connectionIt
           {
             QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
             output->setTitle( tr( "Import to SAP HANA database" ) );
-            output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+            output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, Qgis::StringFormat::PlainText );
             output->showMessage();
           }
           if ( connectionItemPointer )
@@ -466,7 +466,7 @@ bool QgsHanaDataItemGuiProvider::handleDrop( QgsHanaConnectionItem *connectionIt
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( tr( "Import to SAP HANA database" ) );
-    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), Qgis::StringFormat::PlainText );
     output->showMessage();
   }
 

--- a/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
+++ b/src/providers/mssql/qgsmssqldataitemguiprovider.cpp
@@ -358,7 +358,7 @@ bool QgsMssqlDataItemGuiProvider::handleDrop( QgsMssqlConnectionItem *connection
         {
           QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
           output->setTitle( tr( "Import to MS SQL Server database" ) );
-          output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+          output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, Qgis::StringFormat::PlainText );
           output->showMessage();
         }
         if ( connectionItemPointer )
@@ -383,7 +383,7 @@ bool QgsMssqlDataItemGuiProvider::handleDrop( QgsMssqlConnectionItem *connection
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( tr( "Import to MS SQL Server database" ) );
-    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), Qgis::StringFormat::PlainText );
     output->showMessage();
   }
 

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -396,7 +396,7 @@ bool QgsOracleConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction 
         {
           QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
           output->setTitle( tr( "Import to Oracle database" ) );
-          output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+          output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, Qgis::StringFormat::PlainText );
           output->showMessage();
         }
         if ( state() == Qgis::BrowserItemState::Populated )
@@ -418,7 +418,7 @@ bool QgsOracleConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction 
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( tr( "Import to Oracle database" ) );
-    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( '\n' ), QgsMessageOutput::MessageText );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( '\n' ), Qgis::StringFormat::PlainText );
     output->showMessage();
   }
 

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -783,7 +783,7 @@ bool QgsPostgresDataItemGuiProvider::handleDrop( QgsPGConnectionItem *connection
         {
           QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
           output->setTitle( tr( "Import to PostgreSQL database" ) );
-          output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+          output->setMessage( tr( "Failed to import some layers!\n\n" ) + errorMessage, Qgis::StringFormat::PlainText );
           output->showMessage();
         }
         if ( connectionItemPointer )
@@ -803,7 +803,7 @@ bool QgsPostgresDataItemGuiProvider::handleDrop( QgsPGConnectionItem *connection
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( tr( "Import to PostgreSQL database" ) );
-    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), Qgis::StringFormat::PlainText );
     output->showMessage();
   }
 

--- a/src/providers/spatialite/qgsspatialitedataitemguiprovider.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitemguiprovider.cpp
@@ -214,7 +214,7 @@ bool QgsSpatiaLiteDataItemGuiProvider::handleDropConnectionItem( QgsSLConnection
         {
           QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
           output->setTitle( tr( "Import to SpatiaLite database" ) );
-          output->setMessage( tr( "Failed to import layer!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+          output->setMessage( tr( "Failed to import layer!\n\n" ) + errorMessage, Qgis::StringFormat::PlainText );
           output->showMessage();
         }
         connItem->refresh();
@@ -233,7 +233,7 @@ bool QgsSpatiaLiteDataItemGuiProvider::handleDropConnectionItem( QgsSLConnection
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( tr( "Import to SpatiaLite database" ) );
-    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), QgsMessageOutput::MessageText );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QLatin1Char( '\n' ) ), Qgis::StringFormat::PlainText );
     output->showMessage();
   }
 

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -1293,7 +1293,7 @@ void QgsWcsCapabilities::showMessageBox( const QString &title, const QString &te
 {
   QgsMessageOutput *message = QgsMessageOutput::createMessageOutput();
   message->setTitle( title );
-  message->setMessage( text, QgsMessageOutput::MessageText );
+  message->setMessage( text, Qgis::StringFormat::PlainText );
   message->showMessage();
 }
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3975,7 +3975,7 @@ void QgsWmsProvider::showMessageBox( const QString &title, const QString &text )
 {
   QgsMessageOutput *message = QgsMessageOutput::createMessageOutput();
   message->setTitle( title );
-  message->setMessage( text, QgsMessageOutput::MessageText );
+  message->setMessage( text, Qgis::StringFormat::PlainText );
   message->showMessage();
 }
 

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -138,7 +138,7 @@ _ssr = StartupScriptRunner()
     {
       QgsMessageOutput *msg = QgsMessageOutput::createMessageOutput();
       msg->setTitle( QObject::tr( "Python error" ) );
-      msg->setMessage( QObject::tr( "The extra plugin path '%1' does not exist!" ).arg( p ), QgsMessageOutput::MessageText );
+      msg->setMessage( QObject::tr( "The extra plugin path '%1' does not exist!" ).arg( p ), Qgis::StringFormat::PlainText );
       msg->showMessage();
     }
 #ifdef Q_OS_WIN
@@ -470,7 +470,7 @@ bool QgsPythonUtilsImpl::runString( const QString &command, QString msgOnError, 
   qDebug() << str;
   QgsMessageOutput *msg = QgsMessageOutput::createMessageOutput();
   msg->setTitle( QObject::tr( "Python error" ) );
-  msg->setMessage( str, QgsMessageOutput::MessageHtml );
+  msg->setMessage( str, Qgis::StringFormat::Html );
   msg->showMessage();
 
   return res;
@@ -528,7 +528,7 @@ bool QgsPythonUtilsImpl::runFile( const QString &filename, const QString &messag
 
   QgsMessageOutput *msg = QgsMessageOutput::createMessageOutput();
   msg->setTitle( QObject::tr( "Python error" ) );
-  msg->setMessage( str, QgsMessageOutput::MessageHtml );
+  msg->setMessage( str, Qgis::StringFormat::Html );
   msg->showMessage();
 
   return false;
@@ -596,7 +596,7 @@ bool QgsPythonUtilsImpl::setArgv( const QStringList &arguments, const QString &m
 
   QgsMessageOutput *msg = QgsMessageOutput::createMessageOutput();
   msg->setTitle( QObject::tr( "Python error" ) );
-  msg->setMessage( str, QgsMessageOutput::MessageHtml );
+  msg->setMessage( str, Qgis::StringFormat::Html );
   msg->showMessage();
 
   return false;

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -90,13 +90,15 @@ class MessageLogger(QObject):
         self.tag = tag
 
     def __enter__(self):
-        QgsApplication.messageLog().messageReceived.connect(self.logMessage)
+        QgsApplication.messageLog().messageReceivedWithFormat.connect(self.logMessage)
         return self
 
     def __exit__(self, type, value, traceback):
-        QgsApplication.messageLog().messageReceived.disconnect(self.logMessage)
+        QgsApplication.messageLog().messageReceivedWithFormat.disconnect(
+            self.logMessage
+        )
 
-    def logMessage(self, msg, tag, level):
+    def logMessage(self, msg, tag, level, format):
         if tag == self.tag or not self.tag:
             self.log.append(msg.encode("UTF-8"))
 

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -129,13 +129,15 @@ class MessageLogger(QObject):
         self.tag = tag
 
     def __enter__(self):
-        QgsApplication.messageLog().messageReceived.connect(self.logMessage)
+        QgsApplication.messageLog().messageReceivedWithFormat.connect(self.logMessage)
         return self
 
     def __exit__(self, type, value, traceback):
-        QgsApplication.messageLog().messageReceived.disconnect(self.logMessage)
+        QgsApplication.messageLog().messageReceivedWithFormat.disconnect(
+            self.logMessage
+        )
 
-    def logMessage(self, msg, tag, level):
+    def logMessage(self, msg, tag, level, format):
         if tag == self.tag or not self.tag:
             self.log.append(str(msg))
 

--- a/tests/src/python/test_qgsmessagelog.py
+++ b/tests/src/python/test_qgsmessagelog.py
@@ -32,12 +32,15 @@ class TestQgsMessageLog(QgisTestCase):
         app_log = QgsApplication.messageLog()
 
         # signals should be emitted by application log
-        app_spy = QSignalSpy(app_log.messageReceivedWithType)
+        app_spy = QSignalSpy(app_log.messageReceivedWithFormat)
         app_spy_received = QSignalSpy(app_log.messageReceived[bool])
 
         QgsMessageLog.logMessage("test", "tag", Qgis.MessageLevel.Info, notifyUser=True)
         self.assertEqual(len(app_spy), 1)
-        self.assertEqual(app_spy[-1], ["test", "tag", Qgis.MessageLevel.Info])
+        self.assertEqual(
+            app_spy[-1],
+            ["test", "tag", Qgis.MessageLevel.Info, Qgis.StringFormat.PlainText],
+        )
         # info message, so messageReceived(bool) should not be emitted
         self.assertEqual(len(app_spy_received), 0)
 
@@ -45,7 +48,10 @@ class TestQgsMessageLog(QgisTestCase):
             "test", "tag", Qgis.MessageLevel.Warning, notifyUser=True
         )
         self.assertEqual(len(app_spy), 2)
-        self.assertEqual(app_spy[-1], ["test", "tag", Qgis.MessageLevel.Warning])
+        self.assertEqual(
+            app_spy[-1],
+            ["test", "tag", Qgis.MessageLevel.Warning, Qgis.StringFormat.PlainText],
+        )
         # warning message, so messageReceived(bool) should be emitted
         self.assertEqual(len(app_spy_received), 1)
 
@@ -59,14 +65,17 @@ class TestQgsMessageLog(QgisTestCase):
     def testBlocker(self):
         app_log = QgsApplication.messageLog()
 
-        spy = QSignalSpy(app_log.messageReceivedWithType)
+        spy = QSignalSpy(app_log.messageReceivedWithFormat)
         spy_received = QSignalSpy(app_log.messageReceived[bool])
 
         QgsMessageLog.logMessage(
             "test", "tag", Qgis.MessageLevel.Warning, notifyUser=True
         )
         self.assertEqual(len(spy), 1)
-        self.assertEqual(spy[-1], ["test", "tag", Qgis.MessageLevel.Warning])
+        self.assertEqual(
+            spy[-1],
+            ["test", "tag", Qgis.MessageLevel.Warning, Qgis.StringFormat.PlainText],
+        )
         self.assertEqual(len(spy_received), 1)
 
         # block notifications

--- a/tests/src/python/test_qgsmessagelog.py
+++ b/tests/src/python/test_qgsmessagelog.py
@@ -32,7 +32,7 @@ class TestQgsMessageLog(QgisTestCase):
         app_log = QgsApplication.messageLog()
 
         # signals should be emitted by application log
-        app_spy = QSignalSpy(app_log.messageReceived)
+        app_spy = QSignalSpy(app_log.messageReceivedWithType)
         app_spy_received = QSignalSpy(app_log.messageReceived[bool])
 
         QgsMessageLog.logMessage("test", "tag", Qgis.MessageLevel.Info, notifyUser=True)
@@ -59,7 +59,7 @@ class TestQgsMessageLog(QgisTestCase):
     def testBlocker(self):
         app_log = QgsApplication.messageLog()
 
-        spy = QSignalSpy(app_log.messageReceived)
+        spy = QSignalSpy(app_log.messageReceivedWithType)
         spy_received = QSignalSpy(app_log.messageReceived[bool])
 
         QgsMessageLog.logMessage(


### PR DESCRIPTION
## Description

Introduces HTML rendering support in the QgsMessageLogViewer, allowing developers and plugin authors to display rich-text log messages (bold, colored, or formatted text) directly in the QGIS “Log Messages” panel via new  `logMessageWithFormat()`  method.

Supersedes #64489 and #63756.