### PR TITLE
[qt6][editor widgets] Fix range editor widget's slider not working with Qt6 builds

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsdial.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsdial.sip.in
@@ -29,8 +29,36 @@ Constructor for QgsDial
 %End
 
     void setMinimum( const QVariant &min );
+%Docstring
+Sets the dial range's minimum value.
+%End
+
+    QVariant minimum() const;
+%Docstring
+Returns the dial range's minimum value.
+
+.. versionadded:: 4.0
+%End
     void setMaximum( const QVariant &max );
+%Docstring
+Sets the dial range's maximum value.
+%End
+
+    QVariant maximum() const;
+%Docstring
+Returns the dial range's maximum value.
+
+.. versionadded:: 4.0
+%End
     void setSingleStep( const QVariant &step );
+%Docstring
+Sets the dial's single step value.
+%End
+
+    QVariant singleStep() const;
+%Docstring
+Returns the dial's single step value.
+%End
     void setValue( const QVariant &value );
     QVariant variantValue() const;
 

--- a/python/PyQt6/gui/auto_generated/qgsslider.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsslider.sip.in
@@ -32,8 +32,36 @@ Constructor for QgsSlider
 %End
 
     void setMinimum( const QVariant &min );
+%Docstring
+Sets the slider range's minimum value.
+%End
+
+    QVariant minimum() const;
+%Docstring
+Returns the slider range's minimum value.
+
+.. versionadded:: 4.0
+%End
     void setMaximum( const QVariant &max );
+%Docstring
+Sets the slider range's maximum value.
+%End
+
+    QVariant maximum() const;
+%Docstring
+Returns the slider range's maximum value.
+
+.. versionadded:: 4.0
+%End
     void setSingleStep( const QVariant &step );
+%Docstring
+Sets the slider's single step value.
+%End
+
+    QVariant singleStep() const;
+%Docstring
+Returns the slider's single step value.
+%End
     void setValue( const QVariant &value );
     QVariant variantValue() const;
 

--- a/python/gui/auto_generated/qgsdial.sip.in
+++ b/python/gui/auto_generated/qgsdial.sip.in
@@ -29,8 +29,36 @@ Constructor for QgsDial
 %End
 
     void setMinimum( const QVariant &min );
+%Docstring
+Sets the dial range's minimum value.
+%End
+
+    QVariant minimum() const;
+%Docstring
+Returns the dial range's minimum value.
+
+.. versionadded:: 4.0
+%End
     void setMaximum( const QVariant &max );
+%Docstring
+Sets the dial range's maximum value.
+%End
+
+    QVariant maximum() const;
+%Docstring
+Returns the dial range's maximum value.
+
+.. versionadded:: 4.0
+%End
     void setSingleStep( const QVariant &step );
+%Docstring
+Sets the dial's single step value.
+%End
+
+    QVariant singleStep() const;
+%Docstring
+Returns the dial's single step value.
+%End
     void setValue( const QVariant &value );
     QVariant variantValue() const;
 

--- a/python/gui/auto_generated/qgsslider.sip.in
+++ b/python/gui/auto_generated/qgsslider.sip.in
@@ -32,8 +32,36 @@ Constructor for QgsSlider
 %End
 
     void setMinimum( const QVariant &min );
+%Docstring
+Sets the slider range's minimum value.
+%End
+
+    QVariant minimum() const;
+%Docstring
+Returns the slider range's minimum value.
+
+.. versionadded:: 4.0
+%End
     void setMaximum( const QVariant &max );
+%Docstring
+Sets the slider range's maximum value.
+%End
+
+    QVariant maximum() const;
+%Docstring
+Returns the slider range's maximum value.
+
+.. versionadded:: 4.0
+%End
     void setSingleStep( const QVariant &step );
+%Docstring
+Sets the slider's single step value.
+%End
+
+    QVariant singleStep() const;
+%Docstring
+Returns the slider's single step value.
+%End
     void setValue( const QVariant &value );
     QVariant variantValue() const;
 

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -100,6 +100,16 @@ static void setupIntEditor( const QVariant &min, const QVariant &max, const QVar
   QObject::connect( slider, qOverload<int>( &T::valueChanged ), wrapper, &QgsRangeWidgetWrapper::emitValueChanged );
 }
 
+template<class T>
+static void setupVariantEditor( const QVariant &min, const QVariant &max, const QVariant &step, T *slider, QgsRangeWidgetWrapper *wrapper )
+{
+  // must use a template function because those methods are overloaded and not inherited by some classes
+  slider->setMinimum( min.isValid() ? min.toInt() : std::numeric_limits<int>::lowest() );
+  slider->setMaximum( max.isValid() ? max.toInt() : std::numeric_limits<int>::max() );
+  slider->setSingleStep( step.isValid() ? step.toInt() : 1 );
+  QObject::connect( slider, qOverload<const QVariant &>( &T::valueChanged ), wrapper, &QgsRangeWidgetWrapper::emitValueChanged );
+}
+
 void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
 {
   mDoubleSpinBox = qobject_cast<QDoubleSpinBox *>( editor );
@@ -195,9 +205,9 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
     ( void ) field().convertCompatible( max );
     ( void ) field().convertCompatible( step );
     if ( mQgsDial )
-      setupIntEditor<QDial>( min, max, step, mQgsDial, this );
+      setupVariantEditor( min, max, step, mQgsDial, this );
     else if ( mQgsSlider )
-      setupIntEditor<QSlider>( min, max, step, mQgsSlider, this );
+      setupVariantEditor( min, max, step, mQgsSlider, this );
     else if ( mDial )
       setupIntEditor( min, max, step, mDial, this );
     else if ( mSlider )

--- a/src/gui/qgsdial.h
+++ b/src/gui/qgsdial.h
@@ -41,9 +41,38 @@ class GUI_EXPORT QgsDial : public QDial
      */
     QgsDial( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
+    /**
+     * Sets the dial range's minimum value.
+     */
     void setMinimum( const QVariant &min );
+
+    /**
+     * Returns the dial range's minimum value.
+     * \since QGIS 4.0
+     */
+    QVariant minimum() const { return mMin; };
+
+    /**
+     * Sets the dial range's maximum value.
+     */
     void setMaximum( const QVariant &max );
+
+    /**
+     * Returns the dial range's maximum value.
+     * \since QGIS 4.0
+     */
+    QVariant maximum() const { return mMax; };
+
+    /**
+     * Sets the dial's single step value.
+     */
     void setSingleStep( const QVariant &step );
+
+    /**
+     * Returns the dial's single step value.
+     */
+    QVariant singleStep() const { return mStep; };
+
     void setValue( const QVariant &value );
     QVariant variantValue() const;
 

--- a/src/gui/qgsslider.h
+++ b/src/gui/qgsslider.h
@@ -41,9 +41,38 @@ class GUI_EXPORT QgsSlider : public QSlider
     //! Constructor for QgsSlider
     QgsSlider( Qt::Orientation orientation, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
+    /**
+     * Sets the slider range's minimum value.
+     */
     void setMinimum( const QVariant &min );
+
+    /**
+     * Returns the slider range's minimum value.
+     * \since QGIS 4.0
+     */
+    QVariant minimum() const { return mMin; };
+
+    /**
+     * Sets the slider range's maximum value.
+     */
     void setMaximum( const QVariant &max );
+
+    /**
+     * Returns the slider range's maximum value.
+     * \since QGIS 4.0
+     */
+    QVariant maximum() const { return mMax; };
+
+    /**
+     * Sets the slider's single step value.
+     */
     void setSingleStep( const QVariant &step );
+
+    /**
+     * Returns the slider's single step value.
+     */
+    QVariant singleStep() const { return mStep; };
+
     void setValue( const QVariant &value );
     QVariant variantValue() const;
 

--- a/tests/src/gui/testqgsrangewidgetwrapper.cpp
+++ b/tests/src/gui/testqgsrangewidgetwrapper.cpp
@@ -19,11 +19,13 @@
 
 #include "qgsapplication.h"
 #include "qgsdataprovider.h"
+#include "qgsdial.h"
 #include "qgsdoublespinbox.h"
 #include "qgsfilterlineedit.h"
 #include "qgslogger.h"
 #include "qgsrangeconfigdlg.h"
 #include "qgsrangewidgetwrapper.h"
+#include "qgsslider.h"
 #include "qgsspinbox.h"
 #include "qgstest.h"
 #include "qgsvectorlayer.h"
@@ -55,12 +57,15 @@ class TestQgsRangeWidgetWrapper : public QObject
     void test_negativeIntegers(); // see GH issue #32149
     void test_focus();
     void testLongLong();
+    void testSlider();
+    void testDial();
 
   private:
     std::unique_ptr<QgsRangeWidgetWrapper> widget0; // For field 0
     std::unique_ptr<QgsRangeWidgetWrapper> widget1; // For field 1
     std::unique_ptr<QgsRangeWidgetWrapper> widget2; // For field 2
     std::unique_ptr<QgsRangeWidgetWrapper> widget3; // For field 3
+    std::unique_ptr<QgsRangeWidgetWrapper> widget4; // For field 4
     std::unique_ptr<QgsVectorLayer> vl;
 };
 
@@ -97,6 +102,7 @@ void TestQgsRangeWidgetWrapper::init()
   // simple int
   fields.append( QgsField( "simplenumber", QMetaType::Type::Int ) );
   fields.append( QgsField( "longlong", QMetaType::Type::LongLong ) );
+  fields.append( QgsField( "longlongtwo", QMetaType::Type::LongLong ) );
   vl->dataProvider()->addAttributes( fields );
   vl->updateFields();
   QVERIFY( vl.get() );
@@ -128,6 +134,7 @@ void TestQgsRangeWidgetWrapper::init()
   widget1 = std::make_unique<QgsRangeWidgetWrapper>( vl.get(), 1, nullptr, nullptr );
   widget2 = std::make_unique<QgsRangeWidgetWrapper>( vl.get(), 2, nullptr, nullptr );
   widget3 = std::make_unique<QgsRangeWidgetWrapper>( vl.get(), 3, nullptr, nullptr );
+  widget4 = std::make_unique<QgsRangeWidgetWrapper>( vl.get(), 4, nullptr, nullptr );
   QVERIFY( widget1.get() );
 }
 
@@ -540,6 +547,42 @@ void TestQgsRangeWidgetWrapper::testLongLong()
 
   // wrapper value must be a long long type, not double
   QCOMPARE( wrapper->value(), 1234567890123LL );
+}
+
+void TestQgsRangeWidgetWrapper::testSlider()
+{
+  QVariantMap cfg;
+  cfg.insert( u"Style"_s, u"Slider"_s );
+  cfg.insert( u"Min"_s, 10 );
+  cfg.insert( u"Max"_s, 20 );
+  cfg.insert( u"Step"_s, 5 );
+  widget4->setConfig( cfg );
+
+  QgsSlider *slider = qobject_cast<QgsSlider *>( widget4->createWidget( nullptr ) );
+  QVERIFY( slider );
+  widget4->initWidget( slider );
+
+  QCOMPARE( slider->minimum(), 10 );
+  QCOMPARE( slider->maximum(), 20 );
+  QCOMPARE( slider->singleStep(), 5 );
+}
+
+void TestQgsRangeWidgetWrapper::testDial()
+{
+  QVariantMap cfg;
+  cfg.insert( u"Style"_s, u"Dial"_s );
+  cfg.insert( u"Min"_s, 10 );
+  cfg.insert( u"Max"_s, 20 );
+  cfg.insert( u"Step"_s, 5 );
+  widget4->setConfig( cfg );
+
+  QgsDial *dial = qobject_cast<QgsDial *>( widget4->createWidget( nullptr ) );
+  QVERIFY( dial );
+  widget4->initWidget( dial );
+
+  QCOMPARE( dial->minimum(), 10 );
+  QCOMPARE( dial->maximum(), 20 );
+  QCOMPARE( dial->singleStep(), 5 );
 }
 
 QGSTEST_MAIN( TestQgsRangeWidgetWrapper )


### PR DESCRIPTION
## Description

Glad this one got caught before QGIS 4.0 was released.

I'm not sure why this ever worked TBH, but here we are, a fix to the range editor widget's slider - and dial - simply not working with Qt6 builds.