### PR TITLE
Fix: Avoid the exponential form in search filter expressions

### DIFF
--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
@@ -76,7 +76,7 @@ void QgsDefaultSearchWidgetWrapper::setExpression( const QString &expression )
       const double doubleValue = QgsDoubleValidator::toDouble( exp, &ok );
       if ( ok )
       {
-        exp = QString::number( doubleValue );
+        exp = QString::number( doubleValue, 'f', QLocale::FloatingPointShortest );
       }
     }
     str = u"%1 %2 '%3'"_s

--- a/tests/src/python/test_qgssearchwidgetwrapper.py
+++ b/tests/src/python/test_qgssearchwidgetwrapper.py
@@ -269,6 +269,11 @@ class PyQgsDefaultSearchWidgetWrapper(QgisTestCase):
             w.expression(),
             "\"fldint\" = '10000'",
         )
+        line_edit.setText("10,000,000")
+        self.assertEqual(
+            w.expression(),
+            "\"fldint\" = '10000000'",
+        )
 
         w = QgsDefaultSearchWidgetWrapper(layer, 1)
         w.initWidget(parent)
@@ -294,6 +299,11 @@ class PyQgsDefaultSearchWidgetWrapper(QgisTestCase):
         self.assertEqual(
             w.expression(),
             "\"flddouble\" = '10000.5'",
+        )
+        line_edit.setText("10,000.5555555555")
+        self.assertEqual(
+            w.expression(),
+            "\"flddouble\" = '10000.5555555555'",
         )
 
 


### PR DESCRIPTION
Avoid the scientific notation (exponential form) for large values in search filter expressions. 

This fixes #64682