### PR TITLE
[qt6][attribute form] Fix constraints styling not updated when running QGIS against Qt 6.9

### DIFF
--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -129,6 +129,10 @@ void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()
         break;
     }
   }
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 9, 0 ) && QT_VERSION < QT_VERSION_CHECK( 6, 10, 0 )
+  widget()->style()->unpolish( widget() );
+  widget()->style()->polish( widget() );
+#endif
 }
 
 bool QgsEditorWidgetWrapper::setFormFeatureAttribute( const QString &attributeName, const QVariant &attributeValue )


### PR DESCRIPTION
## Description

Building against Qt 6.9 (AFAIK ubuntu 25.04, 25.10, and possibly 26.04), QGIS fails to update the constraint styling of attribute form editor widgets when going from a hard/soft fail state to valid state. This PR fixes it by manually restyling the widget using (un)polish( widget ).