### PR TITLE
[annotations][ui] Insure that subpanels are all closed when switching to a new annotation

### DIFF
--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -841,16 +841,28 @@ void QgsLayerStylingWidget::setCurrentPage( QgsLayerStylingWidget::Page page )
 
 void QgsLayerStylingWidget::setAnnotationItem( QgsAnnotationLayer *layer, const QString &itemId, bool multipleItems )
 {
-  mContext.setAnnotationId( itemId );
+  const bool matchingPreviousItem = layer == mCurrentLayer && mContext.annotationId() == itemId;
+  if ( !matchingPreviousItem )
+  {
+    mContext.setAnnotationId( itemId );
+    if ( layer )
+    {
+      setLayer( layer );
+    }
+  }
+
   if ( layer )
   {
-    setLayer( layer );
     mStackedWidget->setCurrentIndex( mLayerPage );
   }
 
   if ( QgsAnnotationItemPropertiesWidget *configWidget = qobject_cast<QgsAnnotationItemPropertiesWidget *>( mWidgetStack->mainPanel() ) )
   {
-    configWidget->setMapLayerConfigWidgetContext( mContext );
+    if ( !matchingPreviousItem )
+    {
+      mWidgetStack->acceptAllPanels();
+      configWidget->setMapLayerConfigWidgetContext( mContext );
+    }
 
     if ( itemId.isEmpty() )
     {


### PR DESCRIPTION
## Description

Fixes https://github.com/qgis/QGIS/issues/60924 and in doing so provides a massive UX relief when editing multiple annotations :)

