### PR TITLE
Processing file dialog fix

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -692,7 +692,7 @@ class FileWidgetWrapper(WidgetWrapper):
             filter = self.tr("All files (*.*)")
 
         filename, selected_filter = QFileDialog.getOpenFileName(
-            self.widget, self.tr("Select File"), path, filter
+            self.widget, self.tr("Select File"), path, filter, filter
         )
         if filename:
             self.combo.setEditText(filename)

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -7,12 +7,12 @@
     Email                : arnaud dot morvan at camptocamp dot com
                            volayaf at gmail dot com
 ***************************************************************************
-*                                                                         *
-*   This program is free software; you can redistribute it and/or modify  *
-*   it under the terms of the GNU General Public License as published by  *
-*   the Free Software Foundation; either version 2 of the License, or     *
-*   (at your option) any later version.                                   *
-*                                                                         *
+* *
+* This program is free software; you can redistribute it and/or modify  *
+* it under the terms of the GNU General Public License as published by  *
+* the Free Software Foundation; either version 2 of the License, or     *
+* (at your option) any later version.                                   *
+* *
 ***************************************************************************
 """
 
@@ -252,12 +252,14 @@ class WidgetWrapper(QgsAbstractProcessingParameterWidgetWrapper):
         else:
             path = ""
 
-        # TODO: should use selectedFilter argument for default file format
+        # Set the default file format from the parameter definition
+        file_filter = self.parameterDefinition().createFileFilter()
         filename, selected_filter = QFileDialog.getOpenFileName(
             self.widget,
             self.tr("Select File"),
             path,
-            self.parameterDefinition().createFileFilter(),
+            file_filter,
+            file_filter
         )
         if filename:
             settings.setValue(
@@ -1481,7 +1483,7 @@ class MeshWidgetWrapper(MapLayerWidgetWrapper):
             self.widgetValueHasChanged.emit(self)
 
 
-class EnumWidgetWrapper(WidgetWrapper):
+class EnumWidgetWrapper(EnumWidgetWrapper):
     NOT_SELECTED = "[Not selected]"
 
     def __init__(self, *args, **kwargs):
@@ -1524,7 +1526,7 @@ class EnumWidgetWrapper(WidgetWrapper):
                 self.parameterDefinition().flags()
                 & QgsProcessingParameterDefinition.Flag.FlagOptional
             ):
-                self.combobox.addItem(self.NOT_SELECTED, self.NOT_SET_OPTION)
+                self.combobox.addItem(self.NOT_SET, self.NOT_SET_OPTION)
             for i, option in enumerate(self.parameterDefinition().options()):
                 self.combobox.addItem(option, i)
             values = self.dialog.getAvailableValuesOfType(QgsProcessingParameterEnum)

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -255,11 +255,7 @@ class WidgetWrapper(QgsAbstractProcessingParameterWidgetWrapper):
         # Set the default file format from the parameter definition
         file_filter = self.parameterDefinition().createFileFilter()
         filename, selected_filter = QFileDialog.getOpenFileName(
-            self.widget,
-            self.tr("Select File"),
-            path,
-            file_filter,
-            file_filter
+            self.widget, self.tr("Select File"), path, file_filter, file_filter
         )
         if filename:
             settings.setValue(

--- a/src/core/diagram/qgshistogramdiagram.cpp
+++ b/src/core/diagram/qgshistogramdiagram.cpp
@@ -145,13 +145,13 @@ QSizeF QgsHistogramDiagram::diagramSize( const QgsAttributes &attributes, const 
   {
     case QgsDiagramSettings::Up:
     case QgsDiagramSettings::Down:
-      mScaleFactor = maxValue / s.size.height();
+      mScaleFactor = s.size.height() / maxValue;
       size.scale( s.barWidth * s.categoryColors.size() + spacing * std::max( 0, static_cast<int>( s.categoryAttributes.size() ) - 1 ), s.size.height(), Qt::IgnoreAspectRatio );
       break;
 
     case QgsDiagramSettings::Right:
     case QgsDiagramSettings::Left:
-      mScaleFactor = maxValue / s.size.width();
+      mScaleFactor = s.size.width() / maxValue;
       size.scale( s.size.width(), s.barWidth * s.categoryColors.size() + spacing * std::max( 0, static_cast<int>( s.categoryAttributes.size() ) - 1 ), Qt::IgnoreAspectRatio );
       break;
   }


### PR DESCRIPTION
Uses file_filter as the initialFilter in QFileDialog.getOpenFileName.
Removes an outdated TODO comment.
Applies consistent logic to both WidgetWrapper and FileWidgetWrapper.