### PR TITLE
Processing file dialog fix

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -252,12 +252,9 @@ class WidgetWrapper(QgsAbstractProcessingParameterWidgetWrapper):
         else:
             path = ""
 
-        # TODO: should use selectedFilter argument for default file format
+        file_filter = self.parameterDefinition().createFileFilter()
         filename, selected_filter = QFileDialog.getOpenFileName(
-            self.widget,
-            self.tr("Select File"),
-            path,
-            self.parameterDefinition().createFileFilter(),
+            self.widget, self.tr("Select File"), path, file_filter, file_filter
         )
         if filename:
             settings.setValue(
@@ -690,7 +687,7 @@ class FileWidgetWrapper(WidgetWrapper):
             filter = self.tr("All files (*.*)")
 
         filename, selected_filter = QFileDialog.getOpenFileName(
-            self.widget, self.tr("Select File"), path, filter
+            self.widget, self.tr("Select File"), path, filter, filter
         )
         if filename:
             self.combo.setEditText(filename)

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -252,9 +252,12 @@ class WidgetWrapper(QgsAbstractProcessingParameterWidgetWrapper):
         else:
             path = ""
 
-        file_filter = self.parameterDefinition().createFileFilter()
+        # TODO: should use selectedFilter argument for default file format
         filename, selected_filter = QFileDialog.getOpenFileName(
-            self.widget, self.tr("Select File"), path, file_filter, file_filter
+            self.widget,
+            self.tr("Select File"),
+            path,
+            self.parameterDefinition().createFileFilter(),
         )
         if filename:
             settings.setValue(
@@ -686,8 +689,13 @@ class FileWidgetWrapper(WidgetWrapper):
         else:
             filter = self.tr("All files (*.*)")
 
+        file_filter = self.parameterDefinition().createFileFilter()
         filename, selected_filter = QFileDialog.getOpenFileName(
-            self.widget, self.tr("Select File"), path, filter, filter
+            self.widget,
+            self.tr("Select File"),
+            path,
+            file_filter,
+            file_filter.split(";;")[0],
         )
         if filename:
             self.combo.setEditText(filename)


### PR DESCRIPTION
Uses file_filter as the initialFilter in QFileDialog.getOpenFileName.
Removes an outdated TODO comment.
Applies consistent logic to both WidgetWrapper and FileWidgetWrapper.
<img width="1061" height="689" alt="Screenshot 2026-01-27 at 9 37 14 PM" src="https://github.com/user-attachments/assets/7ce5f250-7563-424d-9291-20bfc6f38b2a" />
