### PR TITLE
[ui][rasters] Fix broken handling of transparency widget's cell widgets preventing editing

### DIFF
--- a/src/gui/raster/qgsrastertransparencywidget.cpp
+++ b/src/gui/raster/qgsrastertransparencywidget.cpp
@@ -255,30 +255,18 @@ void QgsRasterTransparencyWidget::pbnAddValuesManually_clicked()
 
   tableTransparency->insertRow( tableTransparency->rowCount() );
 
-  int n = 0;
   switch ( mCurrentMode )
   {
     case Mode::SingleBand:
-      n = 2; // set both From and To columns
-      break;
-
-    case Mode::RgbBands:
-      n = 3;
-      break;
-  }
-
-  for ( int i = 0; i < n; i++ )
-  {
-    setTransparencyCell( tableTransparency->rowCount() - 1, i, std::numeric_limits<double>::quiet_NaN() );
-  }
-
-  switch ( mCurrentMode )
-  {
-    case Mode::SingleBand:
+      setTransparencyCell( tableTransparency->rowCount() - 1, static_cast<int>( SingleBandTableColumns::From ), std::numeric_limits<double>::quiet_NaN() );
+      setTransparencyCell( tableTransparency->rowCount() - 1, static_cast<int>( SingleBandTableColumns::To ), std::numeric_limits<double>::quiet_NaN() );
       setTransparencyCell( tableTransparency->rowCount() - 1, static_cast<int>( SingleBandTableColumns::Opacity ), 100 );
       break;
-
     case Mode::RgbBands:
+      setTransparencyCell( tableTransparency->rowCount() - 1, static_cast<int>( RgbBandTableColumns::Red ), std::numeric_limits<double>::quiet_NaN() );
+      setTransparencyCell( tableTransparency->rowCount() - 1, static_cast<int>( RgbBandTableColumns::Green ), std::numeric_limits<double>::quiet_NaN() );
+      setTransparencyCell( tableTransparency->rowCount() - 1, static_cast<int>( RgbBandTableColumns::Blue ), std::numeric_limits<double>::quiet_NaN() );
+      setTransparencyCell( tableTransparency->rowCount() - 1, static_cast<int>( RgbBandTableColumns::Tolerance ), 0 );
       setTransparencyCell( tableTransparency->rowCount() - 1, static_cast<int>( RgbBandTableColumns::Opacity ), 100 );
       break;
   }
@@ -734,19 +722,27 @@ void QgsRasterTransparencyWidget::setupTransparencyTable( int nBands )
   {
     mCurrentMode = Mode::RgbBands;
     tableTransparency->setColumnCount( static_cast<int>( RgbBandTableColumns::ColumnCount ) );
+    tableTransparency->horizontalHeader()->setSectionResizeMode( static_cast<int>( RgbBandTableColumns::Red ), QHeaderView::Stretch );
+    tableTransparency->horizontalHeader()->setSectionResizeMode( static_cast<int>( RgbBandTableColumns::Green ), QHeaderView::Stretch );
+    tableTransparency->horizontalHeader()->setSectionResizeMode( static_cast<int>( RgbBandTableColumns::Blue ), QHeaderView::Stretch );
+    tableTransparency->horizontalHeader()->setSectionResizeMode( static_cast<int>( RgbBandTableColumns::Tolerance ), QHeaderView::Stretch );
+    tableTransparency->horizontalHeader()->setSectionResizeMode( static_cast<int>( RgbBandTableColumns::Opacity ), QHeaderView::Stretch );
     tableTransparency->setHorizontalHeaderItem( static_cast<int>( RgbBandTableColumns::Red ), new QTableWidgetItem( tr( "Red" ) ) );
     tableTransparency->setHorizontalHeaderItem( static_cast<int>( RgbBandTableColumns::Green ), new QTableWidgetItem( tr( "Green" ) ) );
     tableTransparency->setHorizontalHeaderItem( static_cast<int>( RgbBandTableColumns::Blue ), new QTableWidgetItem( tr( "Blue" ) ) );
     tableTransparency->setHorizontalHeaderItem( static_cast<int>( RgbBandTableColumns::Tolerance ), new QTableWidgetItem( tr( "Tolerance" ) ) );
-    tableTransparency->setHorizontalHeaderItem( static_cast<int>( RgbBandTableColumns::Opacity ), new QTableWidgetItem( tr( "Percent Transparent" ) ) );
+    tableTransparency->setHorizontalHeaderItem( static_cast<int>( RgbBandTableColumns::Opacity ), new QTableWidgetItem( tr( "Opacity [%]" ) ) );
   }
   else //1 band
   {
     mCurrentMode = Mode::SingleBand;
     tableTransparency->setColumnCount( static_cast<int>( SingleBandTableColumns::ColumnCount ) );
+    tableTransparency->horizontalHeader()->setSectionResizeMode( static_cast<int>( SingleBandTableColumns::From ), QHeaderView::Stretch );
+    tableTransparency->horizontalHeader()->setSectionResizeMode( static_cast<int>( SingleBandTableColumns::To ), QHeaderView::Stretch );
+    tableTransparency->horizontalHeader()->setSectionResizeMode( static_cast<int>( SingleBandTableColumns::Opacity ), QHeaderView::Stretch );
     tableTransparency->setHorizontalHeaderItem( static_cast<int>( SingleBandTableColumns::From ), new QTableWidgetItem( tr( "From" ) ) );
     tableTransparency->setHorizontalHeaderItem( static_cast<int>( SingleBandTableColumns::To ), new QTableWidgetItem( tr( "To" ) ) );
-    tableTransparency->setHorizontalHeaderItem( static_cast<int>( SingleBandTableColumns::Opacity ), new QTableWidgetItem( tr( "Percent Transparent" ) ) );
+    tableTransparency->setHorizontalHeaderItem( static_cast<int>( SingleBandTableColumns::Opacity ), new QTableWidgetItem( tr( "Opacity [%]" ) ) );
   }
 }
 
@@ -758,9 +754,11 @@ void QgsRasterTransparencyWidget::setTransparencyCell( int row, int column, doub
     return;
 
   QLineEdit *lineEdit = new QLineEdit();
-  lineEdit->setFrame( false ); // frame looks bad in table
+  // frame looks bad in table
+  lineEdit->setFrame( false );
   // Without margins row selection is not displayed (important for delete row)
   lineEdit->setContentsMargins( 1, 1, 1, 1 );
+  lineEdit->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
 
   if ( column == tableTransparency->columnCount() - 1 )
   {
@@ -797,7 +795,6 @@ void QgsRasterTransparencyWidget::setTransparencyCell( int row, int column, doub
     connect( lineEdit, &QLineEdit::textEdited, this, &QgsPanelWidget::widgetChanged );
   }
   tableTransparency->setCellWidget( row, column, lineEdit );
-  adjustTransparencyCellWidth( row, column );
 
   if ( mCurrentMode == Mode::SingleBand && ( column == static_cast<int>( SingleBandTableColumns::From ) || column == static_cast<int>( SingleBandTableColumns::To ) ) )
   {

--- a/src/ui/raster/qgsrastertransparencywidget.ui
+++ b/src/ui/raster/qgsrastertransparencywidget.ui
@@ -353,10 +353,7 @@
          <bool>true</bool>
         </property>
         <property name="selectionMode">
-         <enum>QAbstractItemView::SingleSelection</enum>
-        </property>
-        <property name="selectionBehavior">
-         <enum>QAbstractItemView::SelectRows</enum>
+         <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
         </property>
         <property name="showGrid">
          <bool>false</bool>


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/64545 whereas manually adding the _first_ transparency row to the raster transparency table widget would make it nearly impossible to edit the tolerance field.

This appears to be very old code, and for some reason the line edit widgets used as cell widgets were set to fixed size instead of expanding / contracting based on the available space. This has been fixed.

While at it, I've also fixed an issue whereas when adding a manual transparency row, the tolerance column would not get a line edit widget, allowing for random characters to be added.

