### PR TITLE
Adjust description of equals and overlay-* expression functions

### DIFF
--- a/resources/function_help/json/equals
+++ b/resources/function_help/json/equals
@@ -14,6 +14,9 @@
     "expression": "equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'POINT( 0 0 )' ) )",
     "returns": "TRUE"
   }, {
+    "expression": "equals( geom_from_wkt( 'POINT( 0 0 )' ), geom_from_wkt( 'MULTIPOINT( ( 0 0 ) )' ) )",
+    "returns": "FALSE"
+  }, {
     "expression": "equals( geom_from_wkt( 'LINESTRING( 0 0, 1 1 )' ), geom_from_wkt( 'LINESTRING( 0 0, 1 1 )' ) )",
     "returns": "TRUE"
   }, {

--- a/resources/function_help/json/overlay_contains
+++ b/resources/function_help/json/overlay_contains
@@ -2,7 +2,7 @@
   "name": "overlay_contains",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature spatially contains at least one feature from a target layer, or an array of expression-based results for the features in the target layer contained in the current feature.<br><br>Read more on the underlying GEOS \"Contains\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Contains.html'>ST_Contains</a> function.",
+  "description": "Returns whether the current feature spatially contains at least one feature from a target layer, or returns an array of expression-based results for the features in the target layer contained in the current feature.<br><br>Read more on the underlying GEOS \"Contains\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Contains.html'>ST_Contains</a> function.",
   "arguments": [{
     "arg": "layer",
     "description": "the layer whose overlay is checked"

--- a/resources/function_help/json/overlay_crosses
+++ b/resources/function_help/json/overlay_crosses
@@ -2,7 +2,7 @@
   "name": "overlay_crosses",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature spatially crosses at least one feature from a target layer, or an array of expression-based results for the features in the target layer crossed by the current feature.<br><br>Read more on the underlying GEOS \"Crosses\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Crosses.html'>ST_Crosses</a> function.",
+  "description": "Returns whether the current feature spatially crosses at least one feature from a target layer, or returns an array of expression-based results for the features in the target layer crossed by the current feature.<br><br>Read more on the underlying GEOS \"Crosses\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Crosses.html'>ST_Crosses</a> function.",
   "arguments": [{
     "arg": "layer",
     "description": "the layer whose overlay is checked"

--- a/resources/function_help/json/overlay_disjoint
+++ b/resources/function_help/json/overlay_disjoint
@@ -2,7 +2,7 @@
   "name": "overlay_disjoint",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature is spatially disjoint from all the features of a target layer, or an array of expression-based results for the features in the target layer that are disjoint from the current feature.<br><br>Read more on the underlying GEOS \"Disjoint\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Disjoint.html'>ST_Disjoint</a> function.",
+  "description": "Returns whether the current feature is spatially disjoint from all the features of a target layer, or returns an array of expression-based results for the features in the target layer that are disjoint from the current feature.<br><br>Read more on the underlying GEOS \"Disjoint\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Disjoint.html'>ST_Disjoint</a> function.",
   "arguments": [{
     "arg": "layer",
     "description": "the layer whose overlay is checked"

--- a/resources/function_help/json/overlay_equals
+++ b/resources/function_help/json/overlay_equals
@@ -2,7 +2,7 @@
   "name": "overlay_equals",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature's geometry is exactly equal to at least one feature's geometry from a target layer, or an array of expression-based results for the features in the target layer whose geometry is exactly equal to the current feature's geometry. Note that the order of vertices matters.",
+  "description": "Returns whether the current feature's geometry is exactly equal to at least one feature's geometry from a target layer, or returns an array of expression-based results for the features in the target layer whose geometry is exactly equal to the current feature's geometry. Note that the order of vertices matters.",
   "arguments": [{
     "arg": "layer",
     "description": "the layer whose overlay is checked"

--- a/resources/function_help/json/overlay_equals
+++ b/resources/function_help/json/overlay_equals
@@ -2,7 +2,7 @@
   "name": "overlay_equals",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature is exactly equal to at least one feature from a target layer, or an array of expression-based results for the features in the target layer that are exactly equal to the current feature. Note that the order of vertices matters.",
+  "description": "Returns whether the current feature's geometry is exactly equal to at least one feature's geometry from a target layer, or an array of expression-based results for the features in the target layer whose geometry is exactly equal to the current feature's geometry. Note that the order of vertices matters.",
   "arguments": [{
     "arg": "layer",
     "description": "the layer whose overlay is checked"
@@ -26,10 +26,10 @@
   }],
   "examples": [{
     "expression": "overlay_equals('regions')",
-    "returns": "TRUE if the current feature is exactly equal to a region"
+    "returns": "TRUE if the current feature's geometry is exactly the same as the geometry of a region"
   }, {
     "expression": "overlay_equals('regions', filter:= population > 10000)",
-    "returns": "TRUE if the current feature is exactly equal to a region with a population greater than 10000"
+    "returns": "TRUE if the current feature's geometry is exactly the same as the geometry of a region whose population is greater than 10000"
   }, {
     "expression": "overlay_equals('regions', name)",
     "returns": "an array of names, for the regions exactly equal to the current feature"
@@ -43,5 +43,6 @@
     "expression": "overlay_equals(layer:='regions', expression:= geom_to_wkt(@geometry), limit:=2)",
     "returns": "an array of geometries (in WKT), for up to two regions exactly equal to the current feature"
   }],
+  "notes": "This function requires exact equality of geometries, meaning that the geometries 'LINESTRING( 0 0, 1 1 )' and 'LINESTRING( 1 1, 0 0 )' are different.",
   "tags": ["predicate", "current", "equals", "equal", "target", "array", "exactly", "described", "underlying", "features"]
 }

--- a/resources/function_help/json/overlay_intersects
+++ b/resources/function_help/json/overlay_intersects
@@ -2,7 +2,7 @@
   "name": "overlay_intersects",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature spatially intersects at least one feature from a target layer, or an array of expression-based results for the features in the target layer intersected by the current feature.<br><br>Read more on the underlying GEOS \"Intersects\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Intersects.html'>ST_Intersects</a> function.",
+  "description": "Returns whether the current feature spatially intersects at least one feature from a target layer, or returns an array of expression-based results for the features in the target layer intersected by the current feature.<br><br>Read more on the underlying GEOS \"Intersects\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Intersects.html'>ST_Intersects</a> function.",
   "arguments": [
     {
       "arg": "layer",

--- a/resources/function_help/json/overlay_nearest
+++ b/resources/function_help/json/overlay_nearest
@@ -2,7 +2,7 @@
   "name": "overlay_nearest",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature has feature(s) from a target layer within a given distance, or an array of expression-based results for the features in the target layer within a distance from the current feature.<br><br>Note: This function can be slow and consume a lot of memory for large layers.",
+  "description": "Returns whether the current feature has feature(s) from a target layer within a given distance, or returns an array of expression-based results for the features in the target layer within a distance from the current feature.<br><br>Note: This function can be slow and consume a lot of memory for large layers.",
   "arguments": [{
     "arg": "layer",
     "description": "the target layer"

--- a/resources/function_help/json/overlay_touches
+++ b/resources/function_help/json/overlay_touches
@@ -2,7 +2,7 @@
   "name": "overlay_touches",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns whether the current feature spatially touches at least one feature from a target layer, or an array of expression-based results for the features in the target layer touched by the current feature.<br><br>Read more on the underlying GEOS \"Touches\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Touches.html'>ST_Touches</a> function.",
+  "description": "Returns whether the current feature spatially touches at least one feature from a target layer, or returns an array of expression-based results for the features in the target layer touched by the current feature.<br><br>Read more on the underlying GEOS \"Touches\" predicate, as described in PostGIS <a href='https://postgis.net/docs/ST_Touches.html'>ST_Touches</a> function.",
   "arguments": [{
     "arg": "layer",
     "description": "the layer whose overlay is checked"

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -4329,6 +4329,7 @@ class TestQgsExpression : public QObject
       QTest::newRow( "Disjoint" ) << "disjoint( $geometry, geomFromWKT('LINESTRING ( 2 0, 0 2 )') )" << QgsGeometry::fromPointXY( point ) << false << QVariant( 1 );
       QTest::newRow( "No Equals point" ) << "equals( $geometry, geomFromWKT('POINT( 1 0 )') )" << QgsGeometry::fromPointXY( point ) << false << QVariant( 0 );
       QTest::newRow( "Equals point" ) << "equals( $geometry, geomFromWKT('POINT( 0 0 )') )" << QgsGeometry::fromPointXY( point ) << false << QVariant( 1 );
+      QTest::newRow( "No Equals multipoint" ) << "equals( $geometry, geomFromWKT('MULTIPOINT( ( 0 0 ) )') )" << QgsGeometry::fromPointXY( point ) << false << QVariant( 0 );
       QTest::newRow( "No Equals line" ) << "equals( $geometry, geomFromWKT('LINESTRING( 10 10, 0 0 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 0 );
       QTest::newRow( "Equals line" ) << "equals( $geometry, geomFromWKT('LINESTRING( 0 0, 10 10 )') )" << QgsGeometry::fromPolylineXY( line ) << false << QVariant( 1 );
       QTest::newRow( "No Equals polygon" ) << "equals( $geometry, geomFromWKT('POLYGON(( 0 0, 10 0, 10 10, 0 0 ))') )" << QgsGeometry::fromPolygonXY( polygon ) << false << QVariant( 0 );


### PR DESCRIPTION
This is a follow-up to #64627 and #64641 based on review/discussion in docs repo:
- Add a multipoint example to the equals function
- Insist on geometry equality in overlay_equals function
- Repeat 'returns' in the help for clarification