### PR TITLE
[Postgres] Fix name suggestions when batch importing projects to DB

### DIFF
--- a/src/providers/postgres/qgspostgresimportprojectdialog.cpp
+++ b/src/providers/postgres/qgspostgresimportprojectdialog.cpp
@@ -171,7 +171,7 @@ QSet<QString> QgsPostgresImportProjectDialog::projectNamesInSchema()
 
 QString QgsPostgresImportProjectDialog::prepareProjectName( const QString &fullFilePath )
 {
-  QString projectName = createUniqueProjectName( QFileInfo( fullFilePath ).baseName() );
+  const QString projectName = createUniqueProjectName( QFileInfo( fullFilePath ).completeBaseName() );
 
   mExistingProjectNames.insert( projectName );
   return projectName;

--- a/src/providers/postgres/qgspostgresimportprojectdialog.cpp
+++ b/src/providers/postgres/qgspostgresimportprojectdialog.cpp
@@ -175,7 +175,7 @@ QString QgsPostgresImportProjectDialog::prepareProjectName( const QString &fullF
   project.read( fullFilePath );
   QString projectName = project.title().isEmpty() ? project.baseName() : project.title();
 
-  projectName = createUniqueProjectName( projectName );
+  QString projectName = createUniqueProjectName( project.baseName() );
 
   mExistingProjectNames.insert( projectName );
   return projectName;

--- a/src/providers/postgres/qgspostgresimportprojectdialog.cpp
+++ b/src/providers/postgres/qgspostgresimportprojectdialog.cpp
@@ -172,8 +172,7 @@ QSet<QString> QgsPostgresImportProjectDialog::projectNamesInSchema()
 QString QgsPostgresImportProjectDialog::prepareProjectName( const QString &fullFilePath )
 {
   QgsProject project;
-  project.read( fullFilePath );
-  QString projectName = project.title().isEmpty() ? project.baseName() : project.title();
+  project.read( fullFilePath, Qgis::ProjectReadFlag::DontResolveLayers | Qgis::ProjectReadFlag::DontLoadLayouts | Qgis::ProjectReadFlag::DontLoad3DViews | Qgis::ProjectReadFlag::TrustLayerMetadata );
 
   QString projectName = createUniqueProjectName( project.baseName() );
 

--- a/src/providers/postgres/qgspostgresimportprojectdialog.cpp
+++ b/src/providers/postgres/qgspostgresimportprojectdialog.cpp
@@ -171,10 +171,7 @@ QSet<QString> QgsPostgresImportProjectDialog::projectNamesInSchema()
 
 QString QgsPostgresImportProjectDialog::prepareProjectName( const QString &fullFilePath )
 {
-  QgsProject project;
-  project.read( fullFilePath, Qgis::ProjectReadFlag::DontResolveLayers | Qgis::ProjectReadFlag::DontLoadLayouts | Qgis::ProjectReadFlag::DontLoad3DViews | Qgis::ProjectReadFlag::TrustLayerMetadata );
-
-  QString projectName = createUniqueProjectName( project.baseName() );
+  QString projectName = createUniqueProjectName( QFileInfo( fullFilePath ).baseName() );
 
   mExistingProjectNames.insert( projectName );
   return projectName;


### PR DESCRIPTION
## Description

When batch importing projects to Postgre DB suggest names based on `QFileInfo.baseName()`. That makes things much faster as projects do not need to read at all. 