### PR TITLE
Improve 3D map view "Invert vertical axis" setting.

### DIFF
--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -48,16 +48,30 @@ Sets the camera movement speed
 
     Qgis::VerticalAxisInversion verticalAxisInversion() const;
 %Docstring
-Returns the vertical axis inversion behavior.
+Returns the vertical axis inversion behavior for walk mode.
 
 .. versionadded:: 3.18
 %End
 
     void setVerticalAxisInversion( Qgis::VerticalAxisInversion inversion );
 %Docstring
-Sets the vertical axis ``inversion`` behavior.
+Sets the vertical axis ``inversion`` behavior for walk mode.
 
 .. versionadded:: 3.18
+%End
+
+    bool verticalAxisInversionTerrain() const;
+%Docstring
+Returns the vertical axis inversion behavior for terrain mode.
+
+.. versionadded:: 4.2
+%End
+
+    void setVerticalAxisInversionTerrain( bool inversion );
+%Docstring
+Sets the vertical axis ``inversion`` behavior for terrain mode.
+
+.. versionadded:: 4.2
 %End
 
     void frameTriggered( float dt );

--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -48,14 +48,14 @@ Sets the camera movement speed
 
     Qgis::VerticalAxisInversionFlags verticalAxisInversion() const;
 %Docstring
-Returns the vertical axis inversion behavior for walk mode.
+Returns the vertical axis inversion behavior.
 
 .. versionadded:: 3.18
 %End
 
     void setVerticalAxisInversion( Qgis::VerticalAxisInversionFlags inversion );
 %Docstring
-Sets the vertical axis ``inversion`` behavior for walk mode.
+Sets the vertical axis ``inversion`` behavior.
 
 .. versionadded:: 3.18
 %End

--- a/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgscameracontroller.sip.in
@@ -46,32 +46,18 @@ Sets the camera movement speed
 .. versionadded:: 3.18
 %End
 
-    Qgis::VerticalAxisInversion verticalAxisInversion() const;
+    Qgis::VerticalAxisInversionFlags verticalAxisInversion() const;
 %Docstring
 Returns the vertical axis inversion behavior for walk mode.
 
 .. versionadded:: 3.18
 %End
 
-    void setVerticalAxisInversion( Qgis::VerticalAxisInversion inversion );
+    void setVerticalAxisInversion( Qgis::VerticalAxisInversionFlags inversion );
 %Docstring
 Sets the vertical axis ``inversion`` behavior for walk mode.
 
 .. versionadded:: 3.18
-%End
-
-    bool verticalAxisInversionTerrain() const;
-%Docstring
-Returns the vertical axis inversion behavior for terrain mode.
-
-.. versionadded:: 4.2
-%End
-
-    void setVerticalAxisInversionTerrain( bool inversion );
-%Docstring
-Sets the vertical axis ``inversion`` behavior for terrain mode.
-
-.. versionadded:: 4.2
 %End
 
     void frameTriggered( float dt );

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -7928,20 +7928,29 @@ Qgis.SceneMode.__doc__ = """The 3D scene mode used in 3D map views.
 # --
 Qgis.SceneMode.baseClass = Qgis
 # monkey patching scoped based enum
-Qgis.VerticalAxisInversion.Never.__doc__ = "Never invert vertical axis movements"
-Qgis.VerticalAxisInversion.WhenDragging.__doc__ = "Invert vertical axis movements when dragging in first person modes"
-Qgis.VerticalAxisInversion.Always.__doc__ = "Always invert vertical axis movements"
-Qgis.VerticalAxisInversion.__doc__ = """Vertical axis inversion options for 3D views.
+Qgis.VerticalAxisInversion.InFlyWhenDragging.__doc__ = ""
+Qgis.VerticalAxisInversion.InFlyWhenCaptured.__doc__ = ""
+Qgis.VerticalAxisInversion.InTerrain.__doc__ = ""
+Qgis.VerticalAxisInversion.Never.__doc__ = ""
+Qgis.VerticalAxisInversion.WhenDragging.__doc__ = ""
+Qgis.VerticalAxisInversion.Always.__doc__ = ""
+Qgis.VerticalAxisInversion.__doc__ = """When in terrain navigation
 
-.. versionadded:: 3.30
+.. versionadded:: 4.2
 
-* ``Never``: Never invert vertical axis movements
-* ``WhenDragging``: Invert vertical axis movements when dragging in first person modes
-* ``Always``: Always invert vertical axis movements
+* ``InFlyWhenDragging``: 
+* ``InFlyWhenCaptured``: 
+* ``InTerrain``: 
+* ``Never``: 
+* ``WhenDragging``: 
+* ``Always``: 
 
 """
 # --
 Qgis.VerticalAxisInversion.baseClass = Qgis
+Qgis.VerticalAxisInversionFlags = lambda flags=0: Qgis.VerticalAxisInversion(flags)
+Qgis.VerticalAxisInversionFlags.baseClass = Qgis
+VerticalAxisInversionFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
 Qgis.Export3DSceneFormat.Obj.__doc__ = "Wavefront OBJ format."
 Qgis.Export3DSceneFormat.StlAscii.__doc__ = "STL ascii format."

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -7928,19 +7928,28 @@ Qgis.SceneMode.__doc__ = """The 3D scene mode used in 3D map views.
 # --
 Qgis.SceneMode.baseClass = Qgis
 # monkey patching scoped based enum
-Qgis.VerticalAxisInversion.InFlyWhenDragging.__doc__ = ""
-Qgis.VerticalAxisInversion.InFlyWhenCaptured.__doc__ = ""
-Qgis.VerticalAxisInversion.InTerrain.__doc__ = ""
+Qgis.VerticalAxisInversion.WhenRotatingDragging.__doc__ = "When rotating camera around self with mouse captured \n.. versionadded:: 4.2"
+Qgis.VerticalAxisInversion.WhenRotatingCaptured.__doc__ = "When rotating camera around self with mouse button pressed \n.. versionadded:: 4.2"
+Qgis.VerticalAxisInversion.WhenPivoting.__doc__ = "When pivoting camera around point in terrain \n.. versionadded:: 4.2"
 Qgis.VerticalAxisInversion.Never.__doc__ = ""
 Qgis.VerticalAxisInversion.WhenDragging.__doc__ = ""
 Qgis.VerticalAxisInversion.Always.__doc__ = ""
-Qgis.VerticalAxisInversion.__doc__ = """When in terrain navigation
+Qgis.VerticalAxisInversion.__doc__ = """Vertical axis inversion options for 3D views.
 
-.. versionadded:: 4.2
+.. versionadded:: 3.30
 
-* ``InFlyWhenDragging``: 
-* ``InFlyWhenCaptured``: 
-* ``InTerrain``: 
+* ``WhenRotatingDragging``: When rotating camera around self with mouse captured
+
+  .. versionadded:: 4.2
+
+* ``WhenRotatingCaptured``: When rotating camera around self with mouse button pressed
+
+  .. versionadded:: 4.2
+
+* ``WhenPivoting``: When pivoting camera around point in terrain
+
+  .. versionadded:: 4.2
+
 * ``Never``: 
 * ``WhenDragging``: 
 * ``Always``: 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2500,12 +2500,23 @@ The development version
       Globe
     };
 
-    enum class VerticalAxisInversion /BaseType=IntEnum/
+    enum class VerticalAxisInversion /BaseType=IntFlag/
     {
+      InFlyWhenDragging,
+      InFlyWhenCaptured,
+      InTerrain,
+
+      // Legacy aliases for old flying-only enum:
+
+      //! Never invert vertical axis movements
       Never,
+      //! Invert vertical axis movements when dragging in first person modes
       WhenDragging,
+      //! Always invert vertical axis movements
       Always,
     };
+    typedef QFlags<Qgis::VerticalAxisInversion> VerticalAxisInversionFlags;
+
 
     enum class Export3DSceneFormat /BaseType=IntEnum/
     {
@@ -4006,6 +4017,8 @@ QFlags<Qgis::MapSettingsFlag> operator|(Qgis::MapSettingsFlag f1, QFlags<Qgis::M
 QFlags<Qgis::MarkerLinePlacement> operator|(Qgis::MarkerLinePlacement f1, QFlags<Qgis::MarkerLinePlacement> f2);
 
 QFlags<Qgis::PlotToolFlag> operator|(Qgis::PlotToolFlag f1, QFlags<Qgis::PlotToolFlag> f2);
+
+QFlags<Qgis::VerticalAxisInversion> operator|(Qgis::VerticalAxisInversion f1, QFlags<Qgis::VerticalAxisInversion> f2);
 
 QFlags<Qgis::ProfileGeneratorFlag> operator|(Qgis::ProfileGeneratorFlag f1, QFlags<Qgis::ProfileGeneratorFlag> f2);
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2502,17 +2502,14 @@ The development version
 
     enum class VerticalAxisInversion /BaseType=IntFlag/
     {
-      InFlyWhenDragging,
-      InFlyWhenCaptured,
-      InTerrain,
+      WhenRotatingDragging,
+      WhenRotatingCaptured,
+      WhenPivoting,
 
       // Legacy aliases for old flying-only enum:
 
-      //! Never invert vertical axis movements
       Never,
-      //! Invert vertical axis movements when dragging in first person modes
       WhenDragging,
-      //! Always invert vertical axis movements
       Always,
     };
     typedef QFlags<Qgis::VerticalAxisInversion> VerticalAxisInversionFlags;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -579,6 +579,17 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
     float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
 
+    switch ( mVerticalAxisInversion )
+    {
+      case Qgis::VerticalAxisInversion::Always:
+      case Qgis::VerticalAxisInversion::WhenDragging:
+        pitchDiff *= -1;
+        break;
+
+      case Qgis::VerticalAxisInversion::Never:
+        break;
+    }
+
     if ( !mDepthBufferIsReady )
       return;
 
@@ -766,8 +777,19 @@ void QgsCameraController::onPositionChangedGlobeTerrainNavigation( Qt3DInput::QM
     setMouseParameters( MouseOperation::RotationCenter, mMousePos );
 
     const float scale = static_cast<float>( std::max( mScene->engine()->size().width(), mScene->engine()->size().height() ) );
-    const float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
+    float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
     const float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
+
+    switch ( mVerticalAxisInversion )
+    {
+      case Qgis::VerticalAxisInversion::Always:
+      case Qgis::VerticalAxisInversion::WhenDragging:
+        pitchDiff *= -1;
+        break;
+
+      case Qgis::VerticalAxisInversion::Never:
+        break;
+    }
 
     mCameraPose.setPitchAngle( mRotationPitch + pitchDiff );
     mCameraPose.setHeadingAngle( mRotationYaw + yawDiff );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -576,7 +576,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     setMouseParameters( MouseOperation::RotationCenter, mMousePos );
 
     float scale = static_cast<float>( std::max( mScene->engine()->size().width(), mScene->engine()->size().height() ) );
-    float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
+    float pitchDiff = -180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
     float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
 
     if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::WhenPivoting )
@@ -604,7 +604,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
   {
     setMouseParameters( MouseOperation::RotationCamera );
     // rotate/tilt using mouse (camera stays at one position as it rotates)
-    float diffPitch = 0.2f * static_cast<float>( dy );
+    float diffPitch = -0.2f * static_cast<float>( dy );
     const float diffYaw = -0.2f * dx;
     if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::WhenRotatingDragging )
       diffPitch *= -1.0f;
@@ -771,7 +771,7 @@ void QgsCameraController::onPositionChangedGlobeTerrainNavigation( Qt3DInput::QM
     setMouseParameters( MouseOperation::RotationCenter, mMousePos );
 
     const float scale = static_cast<float>( std::max( mScene->engine()->size().width(), mScene->engine()->size().height() ) );
-    float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
+    float pitchDiff = -180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
     const float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
 
     if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::WhenPivoting )
@@ -1293,6 +1293,7 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
       float diffPitch = -0.2f * dy;
       if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::WhenRotatingDragging )
         diffPitch *= -1;
+
       const float diffYaw = -0.2f * dx;
       rotateCamera( diffPitch, diffYaw );
     }

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -102,14 +102,9 @@ void QgsCameraController::setCameraMovementSpeed( double movementSpeed )
   emit cameraMovementSpeedChanged( mCameraMovementSpeed );
 }
 
-void QgsCameraController::setVerticalAxisInversion( Qgis::VerticalAxisInversion inversion )
+void QgsCameraController::setVerticalAxisInversion( Qgis::VerticalAxisInversionFlags inversion )
 {
-  mVerticalAxisInversionFlyMode = inversion;
-}
-
-void QgsCameraController::setVerticalAxisInversionTerrain( bool inversion )
-{
-  mVerticalAxisInversionTerrainMode = inversion;
+  mVerticalAxisInversion = inversion;
 }
 
 void QgsCameraController::rotateCamera( float diffPitch, float diffHeading )
@@ -584,7 +579,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
     float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
 
-    if ( mVerticalAxisInversionTerrainMode )
+    if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::InTerrain )
       pitchDiff *= -1;
 
     if ( !mDepthBufferIsReady )
@@ -777,7 +772,7 @@ void QgsCameraController::onPositionChangedGlobeTerrainNavigation( Qt3DInput::QM
     float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
     const float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
 
-    if ( mVerticalAxisInversionTerrainMode )
+    if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::InTerrain )
       pitchDiff *= -1;
 
     mCameraPose.setPitchAngle( mRotationPitch + pitchDiff );
@@ -1285,16 +1280,8 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     if ( mCaptureFpsMouseMovements )
     {
       float diffPitch = -0.2f * dy;
-      switch ( mVerticalAxisInversionFlyMode )
-      {
-        case Qgis::VerticalAxisInversion::Always:
-          diffPitch *= -1;
-          break;
-
-        case Qgis::VerticalAxisInversion::WhenDragging:
-        case Qgis::VerticalAxisInversion::Never:
-          break;
-      }
+      if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::InFlyWhenCaptured )
+        diffPitch *= -1;
 
       const float diffYaw = -0.2f * dx;
       rotateCamera( diffPitch, diffYaw );
@@ -1302,16 +1289,8 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     else if ( mouse->buttons() & Qt::LeftButton )
     {
       float diffPitch = -0.2f * dy;
-      switch ( mVerticalAxisInversionFlyMode )
-      {
-        case Qgis::VerticalAxisInversion::Always:
-        case Qgis::VerticalAxisInversion::WhenDragging:
-          diffPitch *= -1;
-          break;
-
-        case Qgis::VerticalAxisInversion::Never:
-          break;
-      }
+      if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::InFlyWhenDragging )
+        diffPitch *= -1;
       const float diffYaw = -0.2f * dx;
       rotateCamera( diffPitch, diffYaw );
     }

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -579,7 +579,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
     float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
 
-    if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::InTerrain )
+    if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::WhenPivoting )
       pitchDiff *= -1;
 
     if ( !mDepthBufferIsReady )
@@ -604,8 +604,10 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
   {
     setMouseParameters( MouseOperation::RotationCamera );
     // rotate/tilt using mouse (camera stays at one position as it rotates)
-    const float diffPitch = 0.2f * dy;
+    float diffPitch = 0.2f * dy;
     const float diffYaw = -0.2f * dx;
+    if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::WhenRotatingDragging )
+      diffPitch *= -1.0f;
     rotateCamera( diffPitch, diffYaw );
   }
   else if ( hasLeftButton && !hasShift && !hasCtrl )
@@ -772,7 +774,7 @@ void QgsCameraController::onPositionChangedGlobeTerrainNavigation( Qt3DInput::QM
     float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
     const float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
 
-    if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::InTerrain )
+    if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::WhenPivoting )
       pitchDiff *= -1;
 
     mCameraPose.setPitchAngle( mRotationPitch + pitchDiff );
@@ -1280,7 +1282,7 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     if ( mCaptureFpsMouseMovements )
     {
       float diffPitch = -0.2f * dy;
-      if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::InFlyWhenCaptured )
+      if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::WhenRotatingCaptured )
         diffPitch *= -1;
 
       const float diffYaw = -0.2f * dx;
@@ -1289,7 +1291,7 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     else if ( mouse->buttons() & Qt::LeftButton )
     {
       float diffPitch = -0.2f * dy;
-      if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::InFlyWhenDragging )
+      if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::WhenRotatingDragging )
         diffPitch *= -1;
       const float diffYaw = -0.2f * dx;
       rotateCamera( diffPitch, diffYaw );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -604,7 +604,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
   {
     setMouseParameters( MouseOperation::RotationCamera );
     // rotate/tilt using mouse (camera stays at one position as it rotates)
-    float diffPitch = 0.2f * dy;
+    float diffPitch = 0.2f * static_cast<float>( dy );
     const float diffYaw = -0.2f * dx;
     if ( mVerticalAxisInversion & Qgis::VerticalAxisInversion::WhenRotatingDragging )
       diffPitch *= -1.0f;

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -104,7 +104,12 @@ void QgsCameraController::setCameraMovementSpeed( double movementSpeed )
 
 void QgsCameraController::setVerticalAxisInversion( Qgis::VerticalAxisInversion inversion )
 {
-  mVerticalAxisInversion = inversion;
+  mVerticalAxisInversionFlyMode = inversion;
+}
+
+void QgsCameraController::setVerticalAxisInversionTerrain( bool inversion )
+{
+  mVerticalAxisInversionTerrainMode = inversion;
 }
 
 void QgsCameraController::rotateCamera( float diffPitch, float diffHeading )
@@ -579,16 +584,8 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
     float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
 
-    switch ( mVerticalAxisInversion )
-    {
-      case Qgis::VerticalAxisInversion::Always:
-      case Qgis::VerticalAxisInversion::WhenDragging:
-        pitchDiff *= -1;
-        break;
-
-      case Qgis::VerticalAxisInversion::Never:
-        break;
-    }
+    if ( mVerticalAxisInversionTerrainMode )
+      pitchDiff *= -1;
 
     if ( !mDepthBufferIsReady )
       return;
@@ -780,16 +777,8 @@ void QgsCameraController::onPositionChangedGlobeTerrainNavigation( Qt3DInput::QM
     float pitchDiff = 180.0f * static_cast<float>( mouse->y() - mClickPoint.y() ) / scale;
     const float yawDiff = -180.0f * static_cast<float>( mouse->x() - mClickPoint.x() ) / scale;
 
-    switch ( mVerticalAxisInversion )
-    {
-      case Qgis::VerticalAxisInversion::Always:
-      case Qgis::VerticalAxisInversion::WhenDragging:
-        pitchDiff *= -1;
-        break;
-
-      case Qgis::VerticalAxisInversion::Never:
-        break;
-    }
+    if ( mVerticalAxisInversionTerrainMode )
+      pitchDiff *= -1;
 
     mCameraPose.setPitchAngle( mRotationPitch + pitchDiff );
     mCameraPose.setHeadingAngle( mRotationYaw + yawDiff );
@@ -1296,7 +1285,7 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     if ( mCaptureFpsMouseMovements )
     {
       float diffPitch = -0.2f * dy;
-      switch ( mVerticalAxisInversion )
+      switch ( mVerticalAxisInversionFlyMode )
       {
         case Qgis::VerticalAxisInversion::Always:
           diffPitch *= -1;
@@ -1313,7 +1302,7 @@ void QgsCameraController::onPositionChangedFlyNavigation( Qt3DInput::QMouseEvent
     else if ( mouse->buttons() & Qt::LeftButton )
     {
       float diffPitch = -0.2f * dy;
-      switch ( mVerticalAxisInversion )
+      switch ( mVerticalAxisInversionFlyMode )
       {
         case Qgis::VerticalAxisInversion::Always:
         case Qgis::VerticalAxisInversion::WhenDragging:

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -96,16 +96,28 @@ class _3D_EXPORT QgsCameraController : public QObject
     void setCameraMovementSpeed( double movementSpeed );
 
     /**
-     * Returns the vertical axis inversion behavior.
+     * Returns the vertical axis inversion behavior for walk mode.
      * \since QGIS 3.18
      */
-    Qgis::VerticalAxisInversion verticalAxisInversion() const { return mVerticalAxisInversion; }
+    Qgis::VerticalAxisInversion verticalAxisInversion() const { return mVerticalAxisInversionFlyMode; }
 
     /**
-     * Sets the vertical axis \a inversion behavior.
+     * Sets the vertical axis \a inversion behavior for walk mode.
      * \since QGIS 3.18
      */
     void setVerticalAxisInversion( Qgis::VerticalAxisInversion inversion );
+
+    /**
+     * Returns the vertical axis inversion behavior for terrain mode.
+     * \since QGIS 4.2
+     */
+    bool verticalAxisInversionTerrain() const { return mVerticalAxisInversionTerrainMode; }
+
+    /**
+     * Sets the vertical axis \a inversion behavior for terrain mode.
+     * \since QGIS 4.2
+     */
+    void setVerticalAxisInversionTerrain( bool inversion );
 
     //! Called internally from 3D scene when a new frame is generated. Updates camera according to keyboard/mouse input
     void frameTriggered( float dt );
@@ -499,7 +511,8 @@ class _3D_EXPORT QgsCameraController : public QObject
     Qt3DInput::QKeyboardHandler *mKeyboardHandler = nullptr;
     bool mInputHandlersEnabled = true;
     Qgis::NavigationMode mCameraNavigationMode = Qgis::NavigationMode::TerrainBased;
-    Qgis::VerticalAxisInversion mVerticalAxisInversion = Qgis::VerticalAxisInversion::WhenDragging;
+    Qgis::VerticalAxisInversion mVerticalAxisInversionFlyMode = Qgis::VerticalAxisInversion::WhenDragging;
+    bool mVerticalAxisInversionTerrainMode = false;
     double mCameraMovementSpeed = 5.0;
 
     QSet<int> mDepressedKeys;

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -96,13 +96,13 @@ class _3D_EXPORT QgsCameraController : public QObject
     void setCameraMovementSpeed( double movementSpeed );
 
     /**
-     * Returns the vertical axis inversion behavior for walk mode.
+     * Returns the vertical axis inversion behavior.
      * \since QGIS 3.18
      */
     Qgis::VerticalAxisInversionFlags verticalAxisInversion() const { return mVerticalAxisInversion; }
 
     /**
-     * Sets the vertical axis \a inversion behavior for walk mode.
+     * Sets the vertical axis \a inversion behavior.
      * \since QGIS 3.18
      */
     void setVerticalAxisInversion( Qgis::VerticalAxisInversionFlags inversion );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -499,7 +499,7 @@ class _3D_EXPORT QgsCameraController : public QObject
     Qt3DInput::QKeyboardHandler *mKeyboardHandler = nullptr;
     bool mInputHandlersEnabled = true;
     Qgis::NavigationMode mCameraNavigationMode = Qgis::NavigationMode::TerrainBased;
-    Qgis::VerticalAxisInversionFlags mVerticalAxisInversion = Qgis::VerticalAxisInversion::WhenDragging;
+    Qgis::VerticalAxisInversionFlags mVerticalAxisInversion = Qgis::VerticalAxisInversion::WhenPivoting | Qgis::VerticalAxisInversion::WhenRotatingDragging;
     double mCameraMovementSpeed = 5.0;
 
     QSet<int> mDepressedKeys;

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -99,25 +99,13 @@ class _3D_EXPORT QgsCameraController : public QObject
      * Returns the vertical axis inversion behavior for walk mode.
      * \since QGIS 3.18
      */
-    Qgis::VerticalAxisInversion verticalAxisInversion() const { return mVerticalAxisInversionFlyMode; }
+    Qgis::VerticalAxisInversionFlags verticalAxisInversion() const { return mVerticalAxisInversion; }
 
     /**
      * Sets the vertical axis \a inversion behavior for walk mode.
      * \since QGIS 3.18
      */
-    void setVerticalAxisInversion( Qgis::VerticalAxisInversion inversion );
-
-    /**
-     * Returns the vertical axis inversion behavior for terrain mode.
-     * \since QGIS 4.2
-     */
-    bool verticalAxisInversionTerrain() const { return mVerticalAxisInversionTerrainMode; }
-
-    /**
-     * Sets the vertical axis \a inversion behavior for terrain mode.
-     * \since QGIS 4.2
-     */
-    void setVerticalAxisInversionTerrain( bool inversion );
+    void setVerticalAxisInversion( Qgis::VerticalAxisInversionFlags inversion );
 
     //! Called internally from 3D scene when a new frame is generated. Updates camera according to keyboard/mouse input
     void frameTriggered( float dt );
@@ -511,8 +499,7 @@ class _3D_EXPORT QgsCameraController : public QObject
     Qt3DInput::QKeyboardHandler *mKeyboardHandler = nullptr;
     bool mInputHandlersEnabled = true;
     Qgis::NavigationMode mCameraNavigationMode = Qgis::NavigationMode::TerrainBased;
-    Qgis::VerticalAxisInversion mVerticalAxisInversionFlyMode = Qgis::VerticalAxisInversion::WhenDragging;
-    bool mVerticalAxisInversionTerrainMode = false;
+    Qgis::VerticalAxisInversionFlags mVerticalAxisInversion = Qgis::VerticalAxisInversion::WhenDragging;
     double mCameraMovementSpeed = 5.0;
 
     QSet<int> mDepressedKeys;

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -16,10 +16,10 @@
 #include "qgs3doptions.h"
 
 #include "qgis.h"
+#include "qgisapp.h"
 #include "qgs3d.h"
 #include "qgs3dmapcanvas.h"
 #include "qgs3dmapcanvaswidget.h"
-#include "qgisapp.h"
 #include "qgsapplication.h"
 #include "qgscameracontroller.h"
 #include "qgssettings.h"
@@ -75,6 +75,9 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   const Qgis::VerticalAxisInversion axisInversion = settings.enumValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenDragging, QgsSettings::App );
   mInvertVerticalAxisCombo->setCurrentIndex( mInvertVerticalAxisCombo->findData( QVariant::fromValue( axisInversion ) ) );
 
+  const bool axisInversionTerrain = settings.value( u"map3d/axisInversionTerrain"_s, false, QgsSettings::App ).value<bool>();
+  mInvertVerticalAxisTerrainCombo->setCurrentIndex( axisInversionTerrain );
+
   const Qt3DRender::QCameraLens::ProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qt3DRender::QCameraLens::PerspectiveProjection, QgsSettings::App );
   cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( static_cast<int>( defaultProjection ) ) );
 
@@ -112,6 +115,11 @@ void Qgs3DOptionsWidget::apply()
 
   Qgis::VerticalAxisInversion axisInversion = mInvertVerticalAxisCombo->currentData().value<Qgis::VerticalAxisInversion>();
   settings.setEnumValue( u"map3d/axisInversion"_s, axisInversion, QgsSettings::App );
+
+  // Index 0 (false) is "No", index 1 (true) "Yes"
+  bool axisInversionTerrain = mInvertVerticalAxisTerrainCombo->currentIndex();
+  settings.setValue( u"map3d/axisInversionTerrain"_s, axisInversionTerrain, QgsSettings::App );
+
   // Apply axis inversion setting to existing map views
   for ( Qgs3DMapCanvas *canvas : QgisApp::instance()->mapCanvases3D() )
   {
@@ -119,6 +127,7 @@ void Qgs3DOptionsWidget::apply()
     if ( !cameraController )
       continue;
     cameraController->setVerticalAxisInversion( axisInversion );
+    cameraController->setVerticalAxisInversionTerrain( axisInversionTerrain );
   }
 }
 

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -17,7 +17,11 @@
 
 #include "qgis.h"
 #include "qgs3d.h"
+#include "qgs3dmapcanvas.h"
+#include "qgs3dmapcanvaswidget.h"
+#include "qgisapp.h"
 #include "qgsapplication.h"
+#include "qgscameracontroller.h"
 #include "qgssettings.h"
 #include "qgssettingsentryenumflag.h"
 
@@ -96,7 +100,6 @@ void Qgs3DOptionsWidget::apply()
 {
   QgsSettings settings;
   settings.setEnumValue( u"map3d/defaultNavigation"_s, mCameraNavigationModeCombo->currentData().value<Qgis::NavigationMode>(), QgsSettings::App );
-  settings.setEnumValue( u"map3d/axisInversion"_s, mInvertVerticalAxisCombo->currentData().value<Qgis::VerticalAxisInversion>(), QgsSettings::App );
   settings.setValue( u"map3d/defaultProjection"_s, static_cast<Qt3DRender::QCameraLens::ProjectionType>( cboCameraProjectionType->currentData().toInt() ), QgsSettings::App );
   settings.setValue( u"map3d/defaultMovementSpeed"_s, mCameraMovementSpeed->value(), QgsSettings::App );
   settings.setValue( u"map3d/defaultFieldOfView"_s, spinCameraFieldOfView->value(), QgsSettings::App );
@@ -106,6 +109,20 @@ void Qgs3DOptionsWidget::apply()
   Qgs3D::settingMsaaEnabled->setValue( mMSAA->isChecked() );
   Qgs3D::settingTextureFilterQuality->setValue( mTextureFilterQualityCombo->currentData().value< Qgis::TextureFilterQuality >() );
   Qgs3D::settingShadowQuality->setValue( mShadowQualityCombo->currentData().value< Qgis::ShadowQuality >() );
+
+  auto axisInversion = mInvertVerticalAxisCombo->currentData().value<Qgis::VerticalAxisInversion>();
+  settings.setEnumValue( u"map3d/axisInversion"_s, axisInversion, QgsSettings::App );
+  // Apply axis inversion setting to existing map views
+  for ( auto view : QgisApp::instance()->get3DMapViews() )
+  {
+    Qgs3DMapCanvas *canvas = view->mapCanvas3D();
+    if ( !canvas )
+      continue;
+    QgsCameraController *cameraController = canvas->cameraController();
+    if ( !cameraController )
+      continue;
+    cameraController->setVerticalAxisInversion( axisInversion );
+  }
 }
 
 

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -19,7 +19,6 @@
 #include "qgisapp.h"
 #include "qgs3d.h"
 #include "qgs3dmapcanvas.h"
-#include "qgs3dmapcanvaswidget.h"
 #include "qgsapplication.h"
 #include "qgscameracontroller.h"
 #include "qgssettings.h"
@@ -49,9 +48,10 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   cboCameraProjectionType->addItem( tr( "Perspective Projection" ), Qt3DRender::QCameraLens::PerspectiveProjection );
   cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), Qt3DRender::QCameraLens::OrthographicProjection );
 
-  mVerticalAxisInversionComboBox->addItem( tr( "In walk mode (when captured)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::InFlyWhenCaptured ) );
-  mVerticalAxisInversionComboBox->addItem( tr( "In walk mode (when dragging)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::InFlyWhenDragging ) );
-  mVerticalAxisInversionComboBox->addItem( tr( "In terrain mode" ), QVariant::fromValue( Qgis::VerticalAxisInversion::InTerrain ) );
+  mVerticalAxisInversionComboBox->setDefaultText( tr( "Do not invert" ) );
+  mVerticalAxisInversionComboBox->addItem( tr( "When rotating (mouse captured)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenRotatingCaptured ) );
+  mVerticalAxisInversionComboBox->addItem( tr( "When rotating (when dragging)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenRotatingDragging ) );
+  mVerticalAxisInversionComboBox->addItem( tr( "When pivoting around terrain" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenPivoting ) );
 
   mTextureFilterQualityCombo->addItem( tr( "Off (Trilinear)" ), QVariant::fromValue( Qgis::TextureFilterQuality::Trilinear ) );
   mTextureFilterQualityCombo->addItem( tr( "2×" ), QVariant::fromValue( Qgis::TextureFilterQuality::Anisotropic2x ) );
@@ -72,10 +72,10 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   const Qgis::NavigationMode defaultNavMode = settings.enumValue( u"map3d/defaultNavigation"_s, Qgis::NavigationMode::TerrainBased, QgsSettings::App );
   mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( QVariant::fromValue( defaultNavMode ) ) );
 
-  const Qgis::VerticalAxisInversionFlags axisInversion = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::InFlyWhenDragging, QgsSettings::App );
-  mVerticalAxisInversionComboBox->setItemCheckState( 0, ( axisInversion & Qgis::VerticalAxisInversion::InFlyWhenCaptured ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
-  mVerticalAxisInversionComboBox->setItemCheckState( 1, ( axisInversion & Qgis::VerticalAxisInversion::InFlyWhenDragging ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
-  mVerticalAxisInversionComboBox->setItemCheckState( 2, ( axisInversion & Qgis::VerticalAxisInversion::InTerrain ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
+  const Qgis::VerticalAxisInversionFlags axisInversion = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenRotatingDragging, QgsSettings::App );
+  mVerticalAxisInversionComboBox->setItemCheckState( 0, ( axisInversion & Qgis::VerticalAxisInversion::WhenRotatingCaptured ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
+  mVerticalAxisInversionComboBox->setItemCheckState( 1, ( axisInversion & Qgis::VerticalAxisInversion::WhenRotatingDragging ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
+  mVerticalAxisInversionComboBox->setItemCheckState( 2, ( axisInversion & Qgis::VerticalAxisInversion::WhenPivoting ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
 
   const Qt3DRender::QCameraLens::ProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qt3DRender::QCameraLens::PerspectiveProjection, QgsSettings::App );
   cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( static_cast<int>( defaultProjection ) ) );
@@ -113,7 +113,7 @@ void Qgs3DOptionsWidget::apply()
   Qgs3D::settingShadowQuality->setValue( mShadowQualityCombo->currentData().value< Qgis::ShadowQuality >() );
 
   Qgis::VerticalAxisInversionFlags axisInversion;
-  for ( auto flag : mVerticalAxisInversionComboBox->checkedItemsData() )
+  for ( QVariant flag : mVerticalAxisInversionComboBox->checkedItemsData() )
     axisInversion.setFlag( flag.value<Qgis::VerticalAxisInversion>() );
 
   settings.setFlagValue( u"map3d/axisInversion"_s, axisInversion, QgsSettings::App );
@@ -121,10 +121,8 @@ void Qgs3DOptionsWidget::apply()
   // Apply axis inversion setting to existing map views
   for ( Qgs3DMapCanvas *canvas : QgisApp::instance()->mapCanvases3D() )
   {
-    QgsCameraController *cameraController = canvas->cameraController();
-    if ( !cameraController )
-      continue;
-    cameraController->setVerticalAxisInversion( axisInversion );
+    if ( QgsCameraController *cameraController = canvas->cameraController() )
+      cameraController->setVerticalAxisInversion( axisInversion );
   }
 }
 

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -50,7 +50,7 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
 
   mVerticalAxisInversionComboBox->setDefaultText( tr( "Do not invert" ) );
   mVerticalAxisInversionComboBox->addItem( tr( "When rotating (mouse captured)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenRotatingCaptured ) );
-  mVerticalAxisInversionComboBox->addItem( tr( "When rotating (when dragging)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenRotatingDragging ) );
+  mVerticalAxisInversionComboBox->addItem( tr( "When rotating (while dragging)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenRotatingDragging ) );
   mVerticalAxisInversionComboBox->addItem( tr( "When pivoting around terrain" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenPivoting ) );
 
   mTextureFilterQualityCombo->addItem( tr( "Off (Trilinear)" ), QVariant::fromValue( Qgis::TextureFilterQuality::Trilinear ) );
@@ -72,8 +72,7 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   const Qgis::NavigationMode defaultNavMode = settings.enumValue( u"map3d/defaultNavigation"_s, Qgis::NavigationMode::TerrainBased, QgsSettings::App );
   mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( QVariant::fromValue( defaultNavMode ) ) );
 
-  const Qgis::VerticalAxisInversionFlags axisInversion
-    = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenPivoting | Qgis::VerticalAxisInversion::WhenRotatingDragging, QgsSettings::App );
+  const Qgis::VerticalAxisInversionFlags axisInversion = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversionFlags(), QgsSettings::App );
   mVerticalAxisInversionComboBox->setItemCheckState( 0, ( axisInversion & Qgis::VerticalAxisInversion::WhenRotatingCaptured ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
   mVerticalAxisInversionComboBox->setItemCheckState( 1, ( axisInversion & Qgis::VerticalAxisInversion::WhenRotatingDragging ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
   mVerticalAxisInversionComboBox->setItemCheckState( 2, ( axisInversion & Qgis::VerticalAxisInversion::WhenPivoting ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -72,7 +72,8 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   const Qgis::NavigationMode defaultNavMode = settings.enumValue( u"map3d/defaultNavigation"_s, Qgis::NavigationMode::TerrainBased, QgsSettings::App );
   mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( QVariant::fromValue( defaultNavMode ) ) );
 
-  const Qgis::VerticalAxisInversionFlags axisInversion = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenRotatingDragging, QgsSettings::App );
+  const Qgis::VerticalAxisInversionFlags axisInversion
+    = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenPivoting | Qgis::VerticalAxisInversion::WhenRotatingDragging, QgsSettings::App );
   mVerticalAxisInversionComboBox->setItemCheckState( 0, ( axisInversion & Qgis::VerticalAxisInversion::WhenRotatingCaptured ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
   mVerticalAxisInversionComboBox->setItemCheckState( 1, ( axisInversion & Qgis::VerticalAxisInversion::WhenRotatingDragging ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
   mVerticalAxisInversionComboBox->setItemCheckState( 2, ( axisInversion & Qgis::VerticalAxisInversion::WhenPivoting ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -110,14 +110,11 @@ void Qgs3DOptionsWidget::apply()
   Qgs3D::settingTextureFilterQuality->setValue( mTextureFilterQualityCombo->currentData().value< Qgis::TextureFilterQuality >() );
   Qgs3D::settingShadowQuality->setValue( mShadowQualityCombo->currentData().value< Qgis::ShadowQuality >() );
 
-  auto axisInversion = mInvertVerticalAxisCombo->currentData().value<Qgis::VerticalAxisInversion>();
+  Qgis::VerticalAxisInversion axisInversion = mInvertVerticalAxisCombo->currentData().value<Qgis::VerticalAxisInversion>();
   settings.setEnumValue( u"map3d/axisInversion"_s, axisInversion, QgsSettings::App );
   // Apply axis inversion setting to existing map views
-  for ( auto view : QgisApp::instance()->get3DMapViews() )
+  for ( Qgs3DMapCanvas *canvas : QgisApp::instance()->mapCanvases3D() )
   {
-    Qgs3DMapCanvas *canvas = view->mapCanvas3D();
-    if ( !canvas )
-      continue;
     QgsCameraController *cameraController = canvas->cameraController();
     if ( !cameraController )
       continue;

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -49,9 +49,9 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   cboCameraProjectionType->addItem( tr( "Perspective Projection" ), Qt3DRender::QCameraLens::PerspectiveProjection );
   cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), Qt3DRender::QCameraLens::OrthographicProjection );
 
-  mInvertVerticalAxisCombo->addItem( tr( "Never" ), QVariant::fromValue( Qgis::VerticalAxisInversion::Never ) );
-  mInvertVerticalAxisCombo->addItem( tr( "Only When Dragging" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenDragging ) );
-  mInvertVerticalAxisCombo->addItem( tr( "Always" ), QVariant::fromValue( Qgis::VerticalAxisInversion::Always ) );
+  mVerticalAxisInversionComboBox->addItem( tr( "In walk mode (when captured)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::InFlyWhenCaptured ) );
+  mVerticalAxisInversionComboBox->addItem( tr( "In walk mode (when dragging)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::InFlyWhenDragging ) );
+  mVerticalAxisInversionComboBox->addItem( tr( "In terrain mode" ), QVariant::fromValue( Qgis::VerticalAxisInversion::InTerrain ) );
 
   mTextureFilterQualityCombo->addItem( tr( "Off (Trilinear)" ), QVariant::fromValue( Qgis::TextureFilterQuality::Trilinear ) );
   mTextureFilterQualityCombo->addItem( tr( "2×" ), QVariant::fromValue( Qgis::TextureFilterQuality::Anisotropic2x ) );
@@ -72,11 +72,10 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   const Qgis::NavigationMode defaultNavMode = settings.enumValue( u"map3d/defaultNavigation"_s, Qgis::NavigationMode::TerrainBased, QgsSettings::App );
   mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( QVariant::fromValue( defaultNavMode ) ) );
 
-  const Qgis::VerticalAxisInversion axisInversion = settings.enumValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenDragging, QgsSettings::App );
-  mInvertVerticalAxisCombo->setCurrentIndex( mInvertVerticalAxisCombo->findData( QVariant::fromValue( axisInversion ) ) );
-
-  const bool axisInversionTerrain = settings.value( u"map3d/axisInversionTerrain"_s, false, QgsSettings::App ).value<bool>();
-  mInvertVerticalAxisTerrainCombo->setCurrentIndex( axisInversionTerrain );
+  const Qgis::VerticalAxisInversionFlags axisInversion = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::InFlyWhenDragging, QgsSettings::App );
+  mVerticalAxisInversionComboBox->setItemCheckState( 0, ( axisInversion & Qgis::VerticalAxisInversion::InFlyWhenCaptured ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
+  mVerticalAxisInversionComboBox->setItemCheckState( 1, ( axisInversion & Qgis::VerticalAxisInversion::InFlyWhenDragging ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
+  mVerticalAxisInversionComboBox->setItemCheckState( 2, ( axisInversion & Qgis::VerticalAxisInversion::InTerrain ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
 
   const Qt3DRender::QCameraLens::ProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qt3DRender::QCameraLens::PerspectiveProjection, QgsSettings::App );
   cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( static_cast<int>( defaultProjection ) ) );
@@ -113,12 +112,11 @@ void Qgs3DOptionsWidget::apply()
   Qgs3D::settingTextureFilterQuality->setValue( mTextureFilterQualityCombo->currentData().value< Qgis::TextureFilterQuality >() );
   Qgs3D::settingShadowQuality->setValue( mShadowQualityCombo->currentData().value< Qgis::ShadowQuality >() );
 
-  Qgis::VerticalAxisInversion axisInversion = mInvertVerticalAxisCombo->currentData().value<Qgis::VerticalAxisInversion>();
-  settings.setEnumValue( u"map3d/axisInversion"_s, axisInversion, QgsSettings::App );
+  Qgis::VerticalAxisInversionFlags axisInversion;
+  for ( auto flag : mVerticalAxisInversionComboBox->checkedItemsData() )
+    axisInversion.setFlag( flag.value<Qgis::VerticalAxisInversion>() );
 
-  // Index 0 (false) is "No", index 1 (true) "Yes"
-  bool axisInversionTerrain = mInvertVerticalAxisTerrainCombo->currentIndex();
-  settings.setValue( u"map3d/axisInversionTerrain"_s, axisInversionTerrain, QgsSettings::App );
+  settings.setFlagValue( u"map3d/axisInversion"_s, axisInversion, QgsSettings::App );
 
   // Apply axis inversion setting to existing map views
   for ( Qgs3DMapCanvas *canvas : QgisApp::instance()->mapCanvases3D() )
@@ -127,7 +125,6 @@ void Qgs3DOptionsWidget::apply()
     if ( !cameraController )
       continue;
     cameraController->setVerticalAxisInversion( axisInversion );
-    cameraController->setVerticalAxisInversionTerrain( axisInversionTerrain );
   }
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13687,8 +13687,7 @@ Qgs3DMapCanvas *QgisApp::createNewMapCanvas3D( const QString &name, Qgis::SceneM
 
     if ( QgsCameraController *cameraController = canvasWidget->mapCanvas3D()->cameraController() )
     {
-      const Qgis::VerticalAxisInversionFlags axisInversion
-        = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenPivoting | Qgis::VerticalAxisInversion::WhenRotatingDragging, QgsSettings::App );
+      const Qgis::VerticalAxisInversionFlags axisInversion = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversionFlags(), QgsSettings::App );
       cameraController->setVerticalAxisInversion( axisInversion );
     }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13687,7 +13687,8 @@ Qgs3DMapCanvas *QgisApp::createNewMapCanvas3D( const QString &name, Qgis::SceneM
 
     if ( QgsCameraController *cameraController = canvasWidget->mapCanvas3D()->cameraController() )
     {
-      const Qgis::VerticalAxisInversionFlags axisInversion = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenDragging, QgsSettings::App );
+      const Qgis::VerticalAxisInversionFlags axisInversion
+        = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenPivoting | Qgis::VerticalAxisInversion::WhenRotatingDragging, QgsSettings::App );
       cameraController->setVerticalAxisInversion( axisInversion );
     }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13687,10 +13687,8 @@ Qgs3DMapCanvas *QgisApp::createNewMapCanvas3D( const QString &name, Qgis::SceneM
 
     if ( QgsCameraController *cameraController = canvasWidget->mapCanvas3D()->cameraController() )
     {
-      const Qgis::VerticalAxisInversion axisInversion = settings.enumValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenDragging, QgsSettings::App );
-      const bool axisInversionTerrain = settings.value( u"map3d/axisInversionTerrain"_s, false, QgsSettings::App ).value<bool>();
+      const Qgis::VerticalAxisInversionFlags axisInversion = settings.flagValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenDragging, QgsSettings::App );
       cameraController->setVerticalAxisInversion( axisInversion );
-      cameraController->setVerticalAxisInversionTerrain( axisInversionTerrain );
     }
 
     QDomImplementation DomImplementation;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13685,9 +13685,13 @@ Qgs3DMapCanvas *QgisApp::createNewMapCanvas3D( const QString &name, Qgis::SceneM
       }
     }
 
-    const Qgis::VerticalAxisInversion axisInversion = settings.enumValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenDragging, QgsSettings::App );
-    if ( canvasWidget->mapCanvas3D()->cameraController() )
-      canvasWidget->mapCanvas3D()->cameraController()->setVerticalAxisInversion( axisInversion );
+    if ( QgsCameraController *cameraController = canvasWidget->mapCanvas3D()->cameraController() )
+    {
+      const Qgis::VerticalAxisInversion axisInversion = settings.enumValue( u"map3d/axisInversion"_s, Qgis::VerticalAxisInversion::WhenDragging, QgsSettings::App );
+      const bool axisInversionTerrain = settings.value( u"map3d/axisInversionTerrain"_s, false, QgsSettings::App ).value<bool>();
+      cameraController->setVerticalAxisInversion( axisInversion );
+      cameraController->setVerticalAxisInversionTerrain( axisInversionTerrain );
+    }
 
     QDomImplementation DomImplementation;
     QDomDocumentType documentType = DomImplementation.createDocumentType( u"qgis"_s, u"http://mrcc.com/qgis.dtd"_s, u"SYSTEM"_s );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4472,9 +4472,9 @@ int QgisEvent = QEvent::User + 1;
 
       // Legacy aliases for old flying-only enum:
 
-      Never = 0,                                            //<! Never invert vertical axis movements \deprecated QGIS 4.2
-      WhenDragging = WhenRotatingDragging,                  //<! Invert vertical axis movements when dragging in first person modes \deprecated QGIS 4.2
-      Always = WhenRotatingDragging | WhenRotatingCaptured, //<! Always invert vertical axis movements \deprecated QGIS 4.2
+      Never = WhenRotatingDragging | WhenRotatingCaptured | WhenPivoting, //<! Never invert vertical axis movements \deprecated QGIS 4.2
+      WhenDragging = WhenRotatingCaptured | WhenPivoting,                 //<! Invert vertical axis movements when dragging in first person modes \deprecated QGIS 4.2
+      Always = WhenPivoting,                                              //<! Always invert vertical axis movements \deprecated QGIS 4.2
     };
     Q_ENUM( VerticalAxisInversion )
     Q_DECLARE_FLAGS( VerticalAxisInversionFlags, VerticalAxisInversion )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4464,13 +4464,36 @@ int QgisEvent = QEvent::User + 1;
      *
      * \since QGIS 3.30
      */
-    enum class VerticalAxisInversion : int
+    enum class VerticalAxisInversion : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      Never,        //!< Never invert vertical axis movements
-      WhenDragging, //!< Invert vertical axis movements when dragging in first person modes
-      Always,       //!< Always invert vertical axis movements
+      /**
+       * When dragging with mouse button held in fly navigation
+       * \since QGIS 4.2
+       */
+      InFlyWhenDragging = 1 << 0,
+      /**
+       * When moving captured mouse in fly navigation
+       * \since QGIS 4.2
+       */
+      InFlyWhenCaptured = 1 << 1,
+      /**
+       * When in terrain navigation
+       * \since QGIS 4.2
+       */
+      InTerrain = 1 << 2,
+
+      // Legacy aliases for old flying-only enum:
+
+      //! Never invert vertical axis movements
+      Never = 0,
+      //! Invert vertical axis movements when dragging in first person modes
+      WhenDragging = InFlyWhenDragging,
+      //! Always invert vertical axis movements
+      Always = InFlyWhenDragging | InFlyWhenCaptured,
     };
     Q_ENUM( VerticalAxisInversion )
+    Q_DECLARE_FLAGS( VerticalAxisInversionFlags, VerticalAxisInversion )
+    Q_FLAG( VerticalAxisInversionFlags )
 
     /**
      * The file format used when exporting a 3D scene.
@@ -7006,6 +7029,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::LoadStyleFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapSettingsFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MarkerLinePlacements )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::PlotToolFlags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::VerticalAxisInversionFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ProfileGeneratorFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ProjectCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ProjectReadFlags )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4466,30 +4466,15 @@ int QgisEvent = QEvent::User + 1;
      */
     enum class VerticalAxisInversion : int SIP_ENUM_BASETYPE( IntFlag )
     {
-      /**
-       * When dragging with mouse button held in fly navigation
-       * \since QGIS 4.2
-       */
-      InFlyWhenDragging = 1 << 0,
-      /**
-       * When moving captured mouse in fly navigation
-       * \since QGIS 4.2
-       */
-      InFlyWhenCaptured = 1 << 1,
-      /**
-       * When in terrain navigation
-       * \since QGIS 4.2
-       */
-      InTerrain = 1 << 2,
+      WhenRotatingDragging = 1 << 0, //!< When rotating camera around self with mouse captured \since QGIS 4.2
+      WhenRotatingCaptured = 1 << 1, //!< When rotating camera around self with mouse button pressed \since QGIS 4.2
+      WhenPivoting = 1 << 2,         //!< When pivoting camera around point in terrain \since QGIS 4.2
 
       // Legacy aliases for old flying-only enum:
 
-      //! Never invert vertical axis movements
-      Never = 0,
-      //! Invert vertical axis movements when dragging in first person modes
-      WhenDragging = InFlyWhenDragging,
-      //! Always invert vertical axis movements
-      Always = InFlyWhenDragging | InFlyWhenCaptured,
+      Never = 0,                                            //<! Never invert vertical axis movements \deprecated QGIS 4.2
+      WhenDragging = WhenRotatingDragging,                  //<! Invert vertical axis movements when dragging in first person modes \deprecated QGIS 4.2
+      Always = WhenRotatingDragging | WhenRotatingCaptured, //<! Always invert vertical axis movements \deprecated QGIS 4.2
     };
     Q_ENUM( VerticalAxisInversion )
     Q_DECLARE_FLAGS( VerticalAxisInversionFlags, VerticalAxisInversion )

--- a/src/core/settings/qgssettings.h
+++ b/src/core/settings/qgssettings.h
@@ -349,7 +349,7 @@ class CORE_EXPORT QgsSettings : public QObject
       if ( metaEnum.isValid() )
       {
         // read as string
-        QByteArray ba = value( key, metaEnum.valueToKeys( static_cast< const int >( defaultValue ) ) ).toString().toUtf8();
+        QByteArray ba = value( key, metaEnum.valueToKeys( static_cast< const int >( defaultValue ) ), section ).toString().toUtf8();
         const char *vs = ba.data();
         v = static_cast<T>( metaEnum.keysToValue( vs, &ok ) );
       }

--- a/src/ui/3d/qgs3doptionsbase.ui
+++ b/src/ui/3d/qgs3doptionsbase.ui
@@ -69,6 +69,39 @@
            <string>Default Camera Settings</string>
           </property>
           <layout class="QGridLayout" name="gridLayout">
+           <item row="3" column="1" colspan="2">
+            <widget class="QComboBox" name="mCameraNavigationModeCombo"/>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="labelMovementSpeed">
+             <property name="text">
+              <string>Movement speed</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1" colspan="2">
+            <widget class="QgsDoubleSpinBox" name="mCameraMovementSpeed">
+             <property name="minimum">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>5.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="labelInvertVerticalAxis">
+             <property name="text">
+              <string>Invert vertical axis</string>
+             </property>
+             <property name="textFormat">
+              <enum>Qt::TextFormat::RichText</enum>
+             </property>
+            </widget>
+           </item>
            <item row="1" column="1" colspan="2">
             <widget class="QComboBox" name="cboCameraProjectionType"/>
            </item>
@@ -103,59 +136,8 @@
              </property>
             </widget>
            </item>
-           <item row="3" column="1" colspan="2">
-            <widget class="QComboBox" name="mCameraNavigationModeCombo"/>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="labelMovementSpeed">
-             <property name="text">
-              <string>Movement speed</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1" colspan="2">
-            <widget class="QgsDoubleSpinBox" name="mCameraMovementSpeed">
-             <property name="minimum">
-              <double>0.010000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>1.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>5.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="labelInvertVerticalAxis">
-             <property name="text">
-              <string>Invert vertical axis (walk mode)</string>
-             </property>
-            </widget>
-           </item>
            <item row="5" column="1" colspan="2">
-            <widget class="QComboBox" name="mInvertVerticalAxisCombo"/>
-           </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="labelInvertVerticalAxisTerrain">
-             <property name="text">
-              <string>Invert vertical axis (terrain based)</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="1" colspan="2">
-            <widget class="QComboBox" name="mInvertVerticalAxisTerrainCombo">
-             <item>
-              <property name="text">
-               <string>No</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Yes</string>
-              </property>
-             </item>
-            </widget>
+            <widget class="QgsCheckableComboBox" name="mVerticalAxisInversionComboBox"/>
            </item>
           </layout>
          </widget>
@@ -268,6 +250,11 @@
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsCheckableComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgscheckablecombobox.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
@@ -275,8 +262,6 @@
   <tabstop>spinCameraFieldOfView</tabstop>
   <tabstop>mCameraNavigationModeCombo</tabstop>
   <tabstop>mCameraMovementSpeed</tabstop>
-  <tabstop>mInvertVerticalAxisCombo</tabstop>
-  <tabstop>mInvertVerticalAxisTerrainCombo</tabstop>
   <tabstop>mGpuMemoryLimit</tabstop>
   <tabstop>mTextureFilterQualityCombo</tabstop>
   <tabstop>mShadowQualityCombo</tabstop>

--- a/src/ui/3d/qgs3doptionsbase.ui
+++ b/src/ui/3d/qgs3doptionsbase.ui
@@ -63,6 +63,103 @@
         <property name="bottomMargin">
          <number>0</number>
         </property>
+        <item row="0" column="0">
+         <widget class="QGroupBox" name="cameraTerrain">
+          <property name="title">
+           <string>Default Camera Settings</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="1" column="1" colspan="2">
+            <widget class="QComboBox" name="cboCameraProjectionType"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="labelCameraProjectionType">
+             <property name="text">
+              <string>Projection type</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="labelFieldofView">
+             <property name="text">
+              <string>Field of View</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1" colspan="2">
+            <widget class="QgsSpinBox" name="spinCameraFieldOfView">
+             <property name="suffix">
+              <string>°</string>
+             </property>
+             <property name="maximum">
+              <number>180</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="labelCameraNavigationMode">
+             <property name="text">
+              <string>Navigation mode</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1" colspan="2">
+            <widget class="QComboBox" name="mCameraNavigationModeCombo"/>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="labelMovementSpeed">
+             <property name="text">
+              <string>Movement speed</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1" colspan="2">
+            <widget class="QgsDoubleSpinBox" name="mCameraMovementSpeed">
+             <property name="minimum">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>5.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="labelInvertVerticalAxis">
+             <property name="text">
+              <string>Invert vertical axis (walk mode)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1" colspan="2">
+            <widget class="QComboBox" name="mInvertVerticalAxisCombo"/>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="labelInvertVerticalAxisTerrain">
+             <property name="text">
+              <string>Invert vertical axis (terrain based)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1" colspan="2">
+            <widget class="QComboBox" name="mInvertVerticalAxisTerrainCombo">
+             <item>
+              <property name="text">
+               <string>No</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Yes</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
         <item row="1" column="0">
          <widget class="QGroupBox" name="groupBox">
           <property name="title">
@@ -97,19 +194,6 @@
            </item>
           </layout>
          </widget>
-        </item>
-        <item row="3" column="0">
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
         </item>
         <item row="2" column="0">
          <widget class="QGroupBox" name="groupBox_2">
@@ -147,81 +231,18 @@
           </layout>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QGroupBox" name="cameraTerrain">
-          <property name="title">
-           <string>Default Camera Settings</string>
+        <item row="3" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Orientation::Vertical</enum>
           </property>
-          <layout class="QGridLayout" name="gridLayout" columnstretch="1,2">
-           <item row="0" column="0">
-            <widget class="QLabel" name="labelCameraProjectionType">
-             <property name="text">
-              <string>Projection type</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QComboBox" name="cboCameraProjectionType"/>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="labelFieldofView">
-             <property name="text">
-              <string>Field of View</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QgsSpinBox" name="spinCameraFieldOfView">
-             <property name="suffix">
-              <string>°</string>
-             </property>
-             <property name="maximum">
-              <number>180</number>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="labelCameraNavigationMode">
-             <property name="text">
-              <string>Navigation mode</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QComboBox" name="mCameraNavigationModeCombo"/>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="labelMovementSpeed">
-             <property name="text">
-              <string>Movement speed</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QgsDoubleSpinBox" name="mCameraMovementSpeed">
-             <property name="minimum">
-              <double>0.010000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>1.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>5.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="labelCameraNavigationMode_2">
-             <property name="text">
-              <string>Invert vertical axis</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QComboBox" name="mInvertVerticalAxisCombo"/>
-           </item>
-          </layout>
-         </widget>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </widget>
@@ -255,6 +276,7 @@
   <tabstop>mCameraNavigationModeCombo</tabstop>
   <tabstop>mCameraMovementSpeed</tabstop>
   <tabstop>mInvertVerticalAxisCombo</tabstop>
+  <tabstop>mInvertVerticalAxisTerrainCombo</tabstop>
   <tabstop>mGpuMemoryLimit</tabstop>
   <tabstop>mTextureFilterQualityCombo</tabstop>
   <tabstop>mShadowQualityCombo</tabstop>

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -309,6 +309,7 @@ void TestQgs3DCameraController::testRotationCenter()
 
   // look from the top
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 0 ), 2500, 0, 0 );
+  scene->cameraController()->setVerticalAxisInversion( Qgis::VerticalAxisInversion::Never );
   QVector3D initialCamViewCenter = scene->cameraController()->camera()->viewCenter();
   QVector3D initialCamPosition = scene->cameraController()->camera()->position();
   float initialPitch = scene->cameraController()->pitch();
@@ -384,6 +385,7 @@ void TestQgs3DCameraController::testRotationCamera()
 
   // look from the top
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 0 ), 2500, 0, 0 );
+  scene->cameraController()->setVerticalAxisInversion( Qgis::VerticalAxisInversion::Never );
   QVector3D initialCamViewCenter = scene->cameraController()->camera()->viewCenter();
   QVector3D initialCamPosition = scene->cameraController()->camera()->position();
   float initialPitch = scene->cameraController()->pitch();
@@ -460,6 +462,7 @@ void TestQgs3DCameraController::testRotationCenterZoomWheelRotationCenter()
 
   // look from the top
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 0 ), 2500, 0, 0 );
+  scene->cameraController()->setVerticalAxisInversion( Qgis::VerticalAxisInversion::Never );
   waitForNearPlane( engine, scene, 1000 );
 
   QVector3D initialCamViewCenter = scene->cameraController()->camera()->viewCenter();
@@ -603,6 +606,7 @@ void TestQgs3DCameraController::testTranslateRotationCenterTranslate()
 
   // look from the top
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 0 ), 2500, 0, 0 );
+  scene->cameraController()->setVerticalAxisInversion( Qgis::VerticalAxisInversion::Never );
   waitForNearPlane( engine, scene, 1000 );
 
   QVector3D initialCamViewCenter = scene->cameraController()->camera()->viewCenter();
@@ -882,6 +886,7 @@ void TestQgs3DCameraController::testTranslateRotationCameraTranslate()
 
   // look from the top
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 0 ), 2500, 0, 0 );
+  scene->cameraController()->setVerticalAxisInversion( Qgis::VerticalAxisInversion::Never );
   QVector3D initialCamViewCenter = scene->cameraController()->camera()->viewCenter();
   QVector3D initialCamPosition = scene->cameraController()->camera()->position();
   float initialPitch = scene->cameraController()->pitch();
@@ -1023,6 +1028,7 @@ void TestQgs3DCameraController::testRotationCenterRotationCameraRotationCenter()
 
   // look from the top
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 0 ), 2500, 0, 0 );
+  scene->cameraController()->setVerticalAxisInversion( Qgis::VerticalAxisInversion::Never );
   QVector3D initialCamViewCenter = scene->cameraController()->camera()->viewCenter();
   QVector3D initialCamPosition = scene->cameraController()->camera()->position();
   float initialPitch = scene->cameraController()->pitch();
@@ -1291,6 +1297,7 @@ void TestQgs3DCameraController::testOrthographic()
 
   // look from the top
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 0 ), 2500, 0, 0 );
+  scene->cameraController()->setVerticalAxisInversion( Qgis::VerticalAxisInversion::Never );
 
   Qgs3DUtils::waitForEntitiesLoaded( scene );
   Qgs3DUtils::waitForFrame( engine, scene );


### PR DESCRIPTION
## Description

~This PR does two things to make the existing "Invert vertical axis" setting usable:~
- ~It allows the setting to be changed per view, like all the other settings.~
- ~It extends it from just "walk" navigation to "terrain" navigation.~

~The setting still uses the existing `VerticalAxisInversion` enum, with its somewhat cryptic `Never`/`Always`/`WhenDragging` options that don't translate exactly to terrain navigation. Maybe having two separate settings for walk mode and terrain mode would be best, but it would (possibly needlessly) complicate the code further.~

~This does mean a switch in default behaviour, because the default value of this option is "when dragging" (unchanged from before).~

~This PR now adds a new global option for inverting vertical inputs for terrain navigation, while leaving the existing setting only for walk navigation. It also changes the settings dialog to also apply the settings to existing 3D views, in addition to setting the persistent option.~

This PR now refactors the Y inversion setting for 3D views into a QFlag-based setting, with an independent bit for each scenario (walk mode dragging, walk mode mouse captured, terrain mode). This setting can be edited globally in a checkbox-based-combobox.

The C++ interface for setting inverted Y preferences is changed, but the Python interface is compatible from a duck-typing perspective (as compatible as adding new cases to the enum).

**Settings dialog**:
<img width="781" height="539" alt="qgis_y_inversion" src="https://github.com/user-attachments/assets/9ec5696a-085c-4301-9868-2fde58e4561e" />



<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
