### PR TITLE
Disable unity build for Windows CI build 

### DIFF
--- a/.github/workflows/windows-qt6.yml
+++ b/.github/workflows/windows-qt6.yml
@@ -87,7 +87,7 @@ jobs:
                 -D WITH_SFCGAL=ON \
                 -D ENABLE_TESTS=OFF \
                 -D USE_CCACHE=ON \
-                -D ENABLE_UNITY_BUILDS=ON \
+                -D ENABLE_UNITY_BUILDS=OFF \
                 -D FLEX_EXECUTABLE="${SOURCE_DIR}/win_flex.exe" \
                 -D BISON_EXECUTABLE="${SOURCE_DIR}/win_bison.exe" \
                 -D USE_CCACHE=ON \

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -23,6 +23,7 @@
 
 #include <QDomDocument>
 #include <QIcon>
+#include <QMap>
 
 class QWidget;
 class QgsBrowserDockWidget;

--- a/src/core/qgsapplicationthemeregistry.h
+++ b/src/core/qgsapplicationthemeregistry.h
@@ -20,6 +20,7 @@
 
 #include "qgis_core.h"
 
+#include <QHash>
 #include <QList>
 
 /**


### PR DESCRIPTION
This is now randomly failing for unrelated changes.  Eg from https://github.com/qgis/QGIS/pull/64639 we get:

```
FAILED: [code=4294967295] output/bin/qgis_core.dll src/core/qgis_core.lib 
C:\Windows\system32\cmd.exe /C "cd . && D:\a\_temp\1515681511\cmake-3.31.6-windows-x86_64\bin\cmake.exe -E vs_link_dll --msvc-ver=1944 --intdir=src\core\CMakeFiles\qgis_core.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\qgis_core.rsp  /out:output\bin\qgis_core.dll /implib:src\core\qgis_core.lib /pdb:output\bin\qgis_core.pdb /dll /version:3.99 /machine:x64 /INCREMENTAL:NO && C:\Windows\system32\cmd.exe /C "cd /D D:\a\QGIS\QGIS\build\src\core && "C:\Program Files\PowerShell\7\pwsh.exe" -noprofile -executionpolicy Bypass -file C:/.vcpkg/scripts/buildsystems/msbuild/applocal.ps1 -targetBinary D:/a/QGIS/QGIS/build/output/bin/qgis_core.dll -installedDir D:/a/QGIS/QGIS/build/vcpkg_installed/x64-windows-release/bin -OutVariable out""
LINK: command "C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\qgis_core.rsp /out:output\bin\qgis_core.dll /implib:src\core\qgis_core.lib /pdb:output\bin\qgis_core.pdb /dll /version:3.99 /machine:x64 /INCREMENTAL:NO /MANIFEST:EMBED,ID=2" failed (exit code 1120) with the following output:
   Creating library src\core\qgis_core.lib and object src\core\qgis_core.exp
unity_32_cxx.cxx.obj : error LNK2019: unresolved external symbol "public: int __cdecl QgsOgrLayer::GetExtent(struct OGREnvelope *,bool)" (?GetExtent@QgsOgrLayer@@QEAAHPEAUOGREnvelope@@_N@Z) referenced in function "public: virtual class QgsBox3D __cdecl QgsOgrProvider::extent3D(void)const " (?extent3D@QgsOgrProvider@@UEBA?AVQgsBox3D@@XZ)
unity_32_cxx.cxx.obj : error LNK2019: unresolved external symbol "public: int __cdecl QgsOgrLayer::GetExtent3D(struct OGREnvelope3D *,bool)" (?GetExtent3D@QgsOgrLayer@@QEAAHPEAUOGREnvelope3D@@_N@Z) referenced in function "public: virtual class QgsBox3D __cdecl QgsOgrProvider::extent3D(void)const " (?extent3D@QgsOgrProvider@@UEBA?AVQgsBox3D@@XZ)
unity_32_cxx.cxx.obj : error LNK2019: unresolved external symbol "public: int __cdecl QgsOgrLayer::computeExtent3DSlowly(struct OGREnvelope3D *)" (?computeExtent3DSlowly@QgsOgrLayer@@QEAAHPEAUOGREnvelope3D@@@Z) referenced in function "public: virtual class QgsBox3D __cdecl QgsOgrProvider::extent3D(void)const " (?extent3D@QgsOgrProvider@@UEBA?AVQgsBox3D@@XZ)
output\bin\qgis_core.dll : fatal error LNK1120: 3 unresolved externals
```