### PR TITLE
[mssql] Automatically retrieve geometry SRID if not specified in provider uri

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -79,8 +79,6 @@ QgsMssqlProvider::QgsMssqlProvider( const QString &uri, const ProviderOptions &o
 {
   if ( !mUri.srid().isEmpty() )
     mSRId = mUri.srid().toInt();
-  else
-    mSRId = -1;
 
   mWkbType = mUri.wkbType();
 
@@ -163,7 +161,7 @@ QgsMssqlProvider::QgsMssqlProvider( const QString &uri, const ProviderOptions &o
 
     if ( !mIsQuery )
     {
-      if ( mSRId < 0 || mWkbType == Qgis::WkbType::Unknown || mGeometryColName.isEmpty() )
+      if ( mSRId <= 0 || mWkbType == Qgis::WkbType::Unknown || mGeometryColName.isEmpty() )
       {
         loadMetadata();
       }
@@ -232,7 +230,7 @@ QgsMssqlProvider::QgsMssqlProvider( const QString &uri, const ProviderOptions &o
       {
         // table contains no geometries
         mWkbType = Qgis::WkbType::NoGeometry;
-        mSRId = 0;
+        mSRId = -1;
       }
     }
   }
@@ -272,7 +270,7 @@ QgsFeatureIterator QgsMssqlProvider::getFeatures( const QgsFeatureRequest &reque
 
 void QgsMssqlProvider::loadMetadata()
 {
-  mSRId = 0;
+  mSRId = -1;
   mWkbType = Qgis::WkbType::Unknown;
 
   QSqlQuery query = createQuery();

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -163,7 +163,7 @@ QgsMssqlProvider::QgsMssqlProvider( const QString &uri, const ProviderOptions &o
     {
       if ( mSRId <= 0 || mWkbType == Qgis::WkbType::Unknown || mGeometryColName.isEmpty() )
       {
-        loadMetadata();
+        loadMetadataFromGeometryColumnsTable();
       }
       else
       {
@@ -268,7 +268,7 @@ QgsFeatureIterator QgsMssqlProvider::getFeatures( const QgsFeatureRequest &reque
   return QgsFeatureIterator( new QgsMssqlFeatureIterator( new QgsMssqlFeatureSource( this ), true, request ) );
 }
 
-void QgsMssqlProvider::loadMetadata()
+void QgsMssqlProvider::loadMetadataFromGeometryColumnsTable()
 {
   mSRId = -1;
   mWkbType = Qgis::WkbType::Unknown;

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -717,7 +717,7 @@ void QgsMssqlProvider::UpdateStatistics( bool estimate ) const
       return;
   }
 
-  if ( !mIsQuery )
+  if ( !mIsQuery && mSRId > 0 )
   {
     // Get the extents from the spatial index table to speed up load times.
     // We have to use max() and min() because you can have more then one index but the biggest area is what we want to use.
@@ -746,6 +746,15 @@ void QgsMssqlProvider::UpdateStatistics( bool estimate ) const
 
   // If we can't find the extents in the spatial index table just do what we normally do.
   bool readAllGeography = false;
+  QString sridColumns;
+  if ( mSRId <= 0 )
+  {
+    // piggy-back unknown SRId retrieval onto extent calculation, using min(Srid) and max(Srid) to get single scalar values
+    // since the extent query will only return a SINGLE row. That's enough to tell us whether there's a single distinct
+    // srid in use
+    sridColumns = u", min(%1.STSrid), max(%1.STSrid)"_s.arg( QgsMssqlUtils::quotedIdentifier( mGeometryColName ) );
+  }
+
   if ( estimate )
   {
     if ( mGeometryColType == "geometry"_L1 )
@@ -754,6 +763,9 @@ void QgsMssqlProvider::UpdateStatistics( bool estimate ) const
         statement = u"select min(%1.STPointN(1).STX), min(%1.STPointN(1).STY), max(%1.STPointN(1).STX), max(%1.STPointN(1).STY)"_s.arg( QgsMssqlUtils::quotedIdentifier( mGeometryColName ) );
       else
         statement = u"select min(case when (%1.STIsValid() = 1) THEN %1.STPointN(1).STX else NULL end), min(case when (%1.STIsValid() = 1) THEN %1.STPointN(1).STY else NULL end), max(case when (%1.STIsValid() = 1) THEN %1.STPointN(1).STX else NULL end), max(case when (%1.STIsValid() = 1) THEN %1.STPointN(1).STY else NULL end)"_s.arg( QgsMssqlUtils::quotedIdentifier( mGeometryColName ) );
+
+      if ( !sridColumns.isEmpty() )
+        statement += sridColumns;
     }
     else
     {
@@ -775,6 +787,8 @@ void QgsMssqlProvider::UpdateStatistics( bool estimate ) const
         statement = u"select min(%1.STEnvelope().STPointN(1).STX), min(%1.STEnvelope().STPointN(1).STY), max(%1.STEnvelope().STPointN(3).STX), max(%1.STEnvelope().STPointN(3).STY)"_s.arg( QgsMssqlUtils::quotedIdentifier( mGeometryColName ) );
       else
         statement = u"select min(case when (%1.STIsValid() = 1) THEN %1.STEnvelope().STPointN(1).STX  else NULL end), min(case when (%1.STIsValid() = 1) THEN %1.STEnvelope().STPointN(1).STY else NULL end), max(case when (%1.STIsValid() = 1) THEN %1.STEnvelope().STPointN(3).STX else NULL end), max(case when (%1.STIsValid() = 1) THEN %1.STEnvelope().STPointN(3).STY else NULL end)"_s.arg( QgsMssqlUtils::quotedIdentifier( mGeometryColName ) );
+      if ( !sridColumns.isEmpty() )
+        statement += sridColumns;
     }
     else
     {
@@ -815,16 +829,43 @@ void QgsMssqlProvider::UpdateStatistics( bool estimate ) const
 
     // See https://docs.microsoft.com/en-us/previous-versions/software-testing/cc441928(v=msdn.10)
     const QString sampleFilter = QString( "(ABS(CAST((BINARY_CHECKSUM(%1)) as int)) % 100) = 42" ).arg( cols );
+    const int sampleFilterCol = sridColumns.isEmpty() ? 4 : 6;
 
     const QString statementSample = statement + ( mSqlWhereClause.isEmpty() ? " WHERE " : " AND " ) + sampleFilter;
 
-    if ( LoggedExec( query, statementSample ) && query.next() && !QgsVariantUtils::isNull( query.value( 0 ) ) && query.value( 4 ).toInt() >= minSampleCount )
+    if ( LoggedExec( query, statementSample ) && query.next() )
     {
-      mExtent.setXMinimum( query.value( 0 ).toDouble() );
-      mExtent.setYMinimum( query.value( 1 ).toDouble() );
-      mExtent.setXMaximum( query.value( 2 ).toDouble() );
-      mExtent.setYMaximum( query.value( 3 ).toDouble() );
-      return;
+      const int sampleCount = query.value( sampleFilterCol ).toInt();
+      if ( sampleCount < minSampleCount )
+      {
+        QgsDebugMsgLevel( u"Could not use estimated statistics for %1.%2: sample count %3 is too low"_s.arg( QgsMssqlUtils::quotedIdentifier( mSchemaName ), QgsMssqlUtils::quotedIdentifier( mTableName ) ).arg( sampleCount ), 2 );
+      }
+      if ( !QgsVariantUtils::isNull( query.value( 0 ) ) && sampleCount >= minSampleCount )
+      {
+        mExtent.setXMinimum( query.value( 0 ).toDouble() );
+        mExtent.setYMinimum( query.value( 1 ).toDouble() );
+        mExtent.setXMaximum( query.value( 2 ).toDouble() );
+        mExtent.setYMaximum( query.value( 3 ).toDouble() );
+
+        if ( mSRId <= 0 )
+        {
+          QSet< int > srIdExtrema;
+          if ( !QgsVariantUtils::isNull( query.value( 4 ) ) )
+            srIdExtrema.insert( query.value( 4 ).toInt() );
+          if ( !QgsVariantUtils::isNull( query.value( 5 ) ) )
+            srIdExtrema.insert( query.value( 5 ).toInt() );
+          if ( srIdExtrema.size() == 1 )
+          {
+            mSRId = *srIdExtrema.constBegin();
+          }
+          else
+          {
+            QgsDebugError( u"Could not determine srid for %1.%2: found multiple IDs"_s.arg( QgsMssqlUtils::quotedIdentifier( mSchemaName ), QgsMssqlUtils::quotedIdentifier( mTableName ) ) );
+          }
+        }
+
+        return;
+      }
     }
   }
 
@@ -854,6 +895,24 @@ void QgsMssqlProvider::UpdateStatistics( bool estimate ) const
       mExtent.setXMaximum( query.value( 2 ).toDouble() );
       mExtent.setYMaximum( query.value( 3 ).toDouble() );
     }
+
+    if ( mSRId <= 0 )
+    {
+      QSet< int > srIdExtrema;
+      if ( !QgsVariantUtils::isNull( query.value( 4 ) ) )
+        srIdExtrema.insert( query.value( 4 ).toInt() );
+      if ( !QgsVariantUtils::isNull( query.value( 5 ) ) )
+        srIdExtrema.insert( query.value( 5 ).toInt() );
+      if ( srIdExtrema.size() == 1 )
+      {
+        mSRId = *srIdExtrema.constBegin();
+      }
+      else
+      {
+        QgsDebugError( u"Could not determine srid for %1.%2: found multiple IDs"_s.arg( QgsMssqlUtils::quotedIdentifier( mSchemaName ), QgsMssqlUtils::quotedIdentifier( mTableName ) ) );
+      }
+    }
+
     return;
   }
 

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -201,7 +201,7 @@ class QgsMssqlProvider final : public QgsVectorDataProvider
      */
     QList<int> mPrimaryKeyAttrs;
 
-    mutable long mSRId;
+    mutable long mSRId = -1;
     QString mGeometryColName;
     QString mGeometryColType;
 

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -162,7 +162,7 @@ class QgsMssqlProvider final : public QgsVectorDataProvider
   protected:
     //! Loads fields from input file to member attributeFields
     void loadFields();
-    void loadMetadata();
+    void loadMetadataFromGeometryColumnsTable();
 
   private:
     bool execLogged( QSqlQuery &qry, const QString &sql, const QString &queryOrigin = QString() ) const;

--- a/tests/src/python/test_provider_mssql.py
+++ b/tests/src/python/test_provider_mssql.py
@@ -1672,6 +1672,69 @@ class TestPyQgsMssqlProvider(QgisTestCase, MssqlProviderTestBase):
         )
         self.assertFalse(QgsVectorLayerUtils.validateAttribute(vl, f, 2)[0])
 
+    def test_retrieve_geom_column(self):
+        """
+        Test creating provider with no explicit geometry column name specified
+        """
+        vl = QgsVectorLayer(
+            self.dbconn
+            + ' sslmode=disable key=\'pk\' type=POINT table="qgis_test"."someData" sql=',
+            "test",
+            "mssql",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.dataProvider().geometryColumnName(), "geom")
+        self.assertEqual(vl.dataProvider().crs().authid(), "EPSG:4326")
+        self.assertEqual(
+            {f["pk"]: f.geometry().asWkt(1) for f in vl.dataProvider().getFeatures()},
+            {
+                1: "Point (-70.3 66.3)",
+                2: "Point (-68.2 70.8)",
+                3: "",
+                4: "Point (-65.3 78.3)",
+                5: "Point (-71.1 78.2)",
+            },
+        )
+
+    def test_retrieve_geom_column_estimate(self):
+        """
+        Test creating provider with no explicit geometry column name specified
+        """
+        vl = QgsVectorLayer(
+            self.dbconn
+            + ' sslmode=disable key=\'pk\' type=POLYGON table="qgis_test"."invalid_polys" estimatedmetadata="true" sql=',
+            "test",
+            "mssql",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.dataProvider().geometryColumnName(), "ogr_geometry")
+        self.assertEqual(vl.dataProvider().crs().authid(), "EPSG:4167")
+
+    def test_retrieve_geom_column_and_pk(self):
+        """
+        Test creating provider with no explicit geometry column name or pk specified
+        """
+        vl = QgsVectorLayer(
+            self.dbconn
+            + ' sslmode=disable type=POINT table="qgis_test"."someData" sql=',
+            "test",
+            "mssql",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.dataProvider().geometryColumnName(), "geom")
+        self.assertEqual(vl.dataProvider().crs().authid(), "EPSG:4326")
+        self.assertEqual(vl.dataProvider().pkAttributeIndexes(), [0])
+        self.assertEqual(
+            {f["pk"]: f.geometry().asWkt(1) for f in vl.dataProvider().getFeatures()},
+            {
+                1: "Point (-70.3 66.3)",
+                2: "Point (-68.2 70.8)",
+                3: "",
+                4: "Point (-65.3 78.3)",
+                5: "Point (-71.1 78.2)",
+            },
+        )
+
 
 class TestPyQgsMssqlProviderQuery(QgisTestCase, MssqlProviderTestBase):
 


### PR DESCRIPTION
Allows creation of mssql layer URIs when the geometry column srid is not known in advance (similar to what's possible for e.g. postgres provider)