### PR TITLE
add missed headers widget to the new WMS connection dialog (fix #63972)

### DIFF
--- a/src/providers/wms/qgswmsnewconnection.cpp
+++ b/src/providers/wms/qgswmsnewconnection.cpp
@@ -29,8 +29,8 @@
 
 using namespace Qt::StringLiterals;
 
-QgsWmsNewConnection::QgsWmsNewConnection( QWidget *parent, const QString &connName )
-  : QgsNewHttpConnection( parent, QgsNewHttpConnection::ConnectionWms, u"WMS"_s, connName )
+QgsWmsNewConnection::QgsWmsNewConnection( QWidget *parent, const QString &connName, QgsNewHttpConnection::Flags flags )
+  : QgsNewHttpConnection( parent, QgsNewHttpConnection::ConnectionWms, u"WMS"_s, connName, flags )
 {
   connect( wmsFormatDetectButton(), &QPushButton::clicked, this, &QgsWmsNewConnection::detectFormat );
   initWmsSpecificSettings();

--- a/src/providers/wms/qgswmsnewconnection.h
+++ b/src/providers/wms/qgswmsnewconnection.h
@@ -23,7 +23,7 @@ class QgsWmsNewConnection : public QgsNewHttpConnection
 {
     Q_OBJECT
   public:
-    QgsWmsNewConnection( QWidget *parent = nullptr, const QString &connName = QString() );
+    QgsWmsNewConnection( QWidget *parent = nullptr, const QString &connName = QString(), QgsNewHttpConnection::Flags flags = QgsNewHttpConnection::Flags() );
 
   private slots:
 

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -188,7 +188,7 @@ void QgsWMSSourceSelect::updateFormatButtons( const QStringList &availableFormat
 void QgsWMSSourceSelect::refresh()
 {
   // Reload WMS connections and update the GUI
-  QgsDebugMsgLevel( u"Refreshing WMS connections ..."_s, 2 );
+  QgsDebugMsgLevel( u"Refreshing WMS connections..."_s, 2 );
   populateConnectionList();
 }
 
@@ -209,7 +209,7 @@ void QgsWMSSourceSelect::populateConnectionList()
 
 void QgsWMSSourceSelect::btnNew_clicked()
 {
-  auto nc = new QgsWmsNewConnection( this );
+  auto nc = new QgsWmsNewConnection( this, QString(), QgsNewHttpConnection::FlagShowHttpSettings );
   nc->setAttribute( Qt::WA_DeleteOnClose );
 
   // For testability, do not use exec()
@@ -222,7 +222,7 @@ void QgsWMSSourceSelect::btnNew_clicked()
 
 void QgsWMSSourceSelect::btnEdit_clicked()
 {
-  auto nc = std::make_unique<QgsWmsNewConnection>( this, cmbConnections->currentText() );
+  auto nc = std::make_unique<QgsWmsNewConnection>( this, cmbConnections->currentText(), QgsNewHttpConnection::FlagShowHttpSettings );
 
   if ( nc->exec() )
   {


### PR DESCRIPTION
## Description

Add `flags` argument to the `QgsWmsNewConnection` constructor so we can enable of the HTTP headers widget. 

Fixes #63972.