### PR TITLE
Pre-select initial file filter in core C++ widgets

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -252,12 +252,9 @@ class WidgetWrapper(QgsAbstractProcessingParameterWidgetWrapper):
         else:
             path = ""
 
-        # TODO: should use selectedFilter argument for default file format
+        file_filter = self.parameterDefinition().createFileFilter()
         filename, selected_filter = QFileDialog.getOpenFileName(
-            self.widget,
-            self.tr("Select File"),
-            path,
-            self.parameterDefinition().createFileFilter(),
+            self.widget, self.tr("Select File"), path, file_filter, file_filter
         )
         if filename:
             settings.setValue(
@@ -690,7 +687,7 @@ class FileWidgetWrapper(WidgetWrapper):
             filter = self.tr("All files (*.*)")
 
         filename, selected_filter = QFileDialog.getOpenFileName(
-            self.widget, self.tr("Select File"), path, filter
+            self.widget, self.tr("Select File"), path, filter, filter
         )
         if filename:
             self.combo.setEditText(filename)

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -252,9 +252,12 @@ class WidgetWrapper(QgsAbstractProcessingParameterWidgetWrapper):
         else:
             path = ""
 
-        file_filter = self.parameterDefinition().createFileFilter()
+        # TODO: should use selectedFilter argument for default file format
         filename, selected_filter = QFileDialog.getOpenFileName(
-            self.widget, self.tr("Select File"), path, file_filter, file_filter
+            self.widget,
+            self.tr("Select File"),
+            path,
+            self.parameterDefinition().createFileFilter(),
         )
         if filename:
             settings.setValue(
@@ -686,8 +689,13 @@ class FileWidgetWrapper(WidgetWrapper):
         else:
             filter = self.tr("All files (*.*)")
 
+        file_filter = self.parameterDefinition().createFileFilter()
         filename, selected_filter = QFileDialog.getOpenFileName(
-            self.widget, self.tr("Select File"), path, filter, filter
+            self.widget,
+            self.tr("Select File"),
+            path,
+            file_filter,
+            file_filter.split(";;")[0],
         )
         if filename:
             self.combo.setEditText(filename)

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -757,7 +757,9 @@ void QgsProcessingMapLayerComboBox::selectFromFile()
   else
     filter = QObject::tr( "All files (*.*)" );
 
-  const QString filename = QFileDialog::getOpenFileName( this, tr( "Select File" ), path, filter );
+  QString selectedFilter = filter.split( QStringLiteral( ";;" ) ).at( 0 );
+
+  const QString filename = QFileDialog::getOpenFileName( this, tr( "Select File" ), path, filter, &selectedFilter );
   if ( filename.isEmpty() )
     return;
 

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -349,7 +349,9 @@ void QgsProcessingMultipleInputPanelWidget::addFiles()
   else
     filter = QObject::tr( "All files (*.*)" );
 
-  const QStringList filenames = QFileDialog::getOpenFileNames( this, tr( "Select File(s)" ), path, filter );
+  QString selectedFilter = filter.split( QStringLiteral( ";;" ) ).at( 0 );
+
+  const QStringList filenames = QFileDialog::getOpenFileNames( this, tr( "Select File(s)" ), path, filter, &selectedFilter );
   if ( filenames.empty() )
     return;
 


### PR DESCRIPTION
in this PR I have ensured that the correct file format (like GeoPackage) is automatically selected when a user opens a file dialog in the Processing toolbox it migrates the logic from deprecated Python wrappers to the modern C++ core components
Changes
Updated QgsProcessingMapLayerComboBox to pass the initial filter to the file dialog updated QgsProcessingMultipleSelectionDialog to handle pre-selection for multiple file inputs used QStringLiteral and proper pointer signatures to match QGIS core coding standards
<img width="986" height="225" alt="Screenshot 2026-01-30 at 12 06 07 AM" src="https://github.com/user-attachments/assets/f115e210-1c35-4b1d-8566-2698654a28fa" />
<img width="1076" height="726" alt="Screenshot 2026-01-30 at 12 09 22 AM" src="https://github.com/user-attachments/assets/b5b268e5-46de-4200-b547-1019661438b1" />
<img width="1882" height="1064" alt="Screenshot 2026-01-28 at 9 35 18 PM" src="https://github.com/user-attachments/assets/a3e13ff1-0120-4a56-8168-4c0fcd5976dd" />
