### PR TITLE
Core: ensure initial filter is pre-selected in Processing file widgets

### DIFF
--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -38,11 +38,14 @@
 #include <QFileDialog>
 #include <QHBoxLayout>
 #include <QMenu>
+#include <QString>
 #include <QToolButton>
 #include <QUrl>
 #include <QVBoxLayout>
 
 #include "moc_qgsprocessingmaplayercombobox.cpp"
+
+using namespace Qt::StringLiterals;
 
 ///@cond PRIVATE
 
@@ -62,7 +65,7 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
   if ( mParameter->type() == QgsProcessingParameterFeatureSource::typeName() && type == Qgis::ProcessingMode::Standard )
   {
     mIterateButton = new QToolButton();
-    mIterateButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mIconIterate.svg" ) ) );
+    mIterateButton->setIcon( QgsApplication::getThemeIcon( u"mIconIterate.svg"_s ) );
     mIterateButton->setToolTip( tr( "Iterate over this layer, creating a separate output for every feature in the layer" ) );
     mIterateButton->setCheckable( true );
     mIterateButton->setAutoRaise( true );
@@ -78,7 +81,7 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
   if ( mParameter->type() == QgsProcessingParameterFeatureSource::typeName() )
   {
     mSettingsButton = new QToolButton();
-    mSettingsButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionOptions.svg" ) ) );
+    mSettingsButton->setIcon( QgsApplication::getThemeIcon( u"mActionOptions.svg"_s ) );
     mSettingsButton->setToolTip( tr( "Advanced options" ) );
 
     // button width is 1.25 * icon size, height 1.1 * icon size. But we round to ensure even pixel sizes for equal margins
@@ -93,7 +96,7 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
   else if ( mParameter->type() == QgsProcessingParameterRasterLayer::typeName() )
   {
     mSettingsButton = new QToolButton();
-    mSettingsButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionOptions.svg" ) ) );
+    mSettingsButton->setIcon( QgsApplication::getThemeIcon( u"mActionOptions.svg"_s ) );
     mSettingsButton->setToolTip( tr( "Advanced options" ) );
     mSettingsButton->setEnabled( false ); // Only WMS layers will access raster advanced options for now
 
@@ -213,7 +216,7 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
   }
 
   QgsSettings settings;
-  if ( settings.value( QStringLiteral( "Processing/Configuration/SHOW_CRS_DEF" ), true ).toBool() )
+  if ( settings.value( u"Processing/Configuration/SHOW_CRS_DEF"_s, true ).toBool() )
     mCombo->setShowCrs( true );
 
   if ( filters )
@@ -223,7 +226,7 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
   // see https://github.com/qgis/QGIS/issues/55890
   if ( mayBeRaster && ( !mParameter->provider() || !mParameter->provider()->flags().testFlag( Qgis::ProcessingProviderFlag::CompatibleWithVirtualRaster ) ) )
   {
-    mCombo->setExcludedProviders( mCombo->excludedProviders() << QStringLiteral( "virtualraster" ) );
+    mCombo->setExcludedProviders( mCombo->excludedProviders() << u"virtualraster"_s );
   }
 
   if ( mParameter->flags() & Qgis::ProcessingParameterFlag::Optional )
@@ -473,7 +476,7 @@ QString QgsProcessingMapLayerComboBox::compatibleUriFromMimeData( const QMimeDat
   {
     if ( ( mParameter->type() == QgsProcessingParameterFeatureSource::typeName()
            || mParameter->type() == QgsProcessingParameterVectorLayer::typeName() )
-         && u.layerType == QLatin1String( "vector" ) )
+         && u.layerType == "vector"_L1 )
     {
       QList<int> dataTypes = mParameter->type() == QgsProcessingParameterFeatureSource::typeName() ? static_cast<QgsProcessingParameterFeatureSource *>( mParameter.get() )->dataTypes()
                                                                                                    : ( mParameter->type() == QgsProcessingParameterVectorLayer::typeName() ? static_cast<QgsProcessingParameterVectorLayer *>( mParameter.get() )->dataTypes()
@@ -506,13 +509,13 @@ QString QgsProcessingMapLayerComboBox::compatibleUriFromMimeData( const QMimeDat
           break;
       }
       if ( acceptable )
-        return u.providerKey != QLatin1String( "ogr" ) ? QgsProcessingUtils::encodeProviderKeyAndUri( u.providerKey, u.uri ) : u.uri;
+        return u.providerKey != "ogr"_L1 ? QgsProcessingUtils::encodeProviderKeyAndUri( u.providerKey, u.uri ) : u.uri;
     }
     else if ( mParameter->type() == QgsProcessingParameterRasterLayer::typeName()
-              && u.layerType == QLatin1String( "raster" ) && u.providerKey == QLatin1String( "gdal" ) )
+              && u.layerType == "raster"_L1 && u.providerKey == "gdal"_L1 )
       return u.uri;
     else if ( mParameter->type() == QgsProcessingParameterMeshLayer::typeName()
-              && u.layerType == QLatin1String( "mesh" ) && u.providerKey == QLatin1String( "mdal" ) )
+              && u.layerType == "mesh"_L1 && u.providerKey == "mdal"_L1 )
       return u.uri;
     else if ( mParameter->type() == QgsProcessingParameterMapLayer::typeName() )
     {
@@ -522,7 +525,7 @@ QString QgsProcessingMapLayerComboBox::compatibleUriFromMimeData( const QMimeDat
         return u.uri;
       }
 
-      if ( u.layerType == QLatin1String( "vector" ) && u.providerKey == QLatin1String( "ogr" ) )
+      if ( u.layerType == "vector"_L1 && u.providerKey == "ogr"_L1 )
       {
         switch ( QgsWkbTypes::geometryType( u.wkbType ) )
         {
@@ -548,10 +551,10 @@ QString QgsProcessingMapLayerComboBox::compatibleUriFromMimeData( const QMimeDat
             return u.uri;
         }
       }
-      else if ( u.layerType == QLatin1String( "raster" ) && u.providerKey == QLatin1String( "gdal" )
+      else if ( u.layerType == "raster"_L1 && u.providerKey == "gdal"_L1
                 && dataTypes.contains( static_cast<int>( Qgis::ProcessingSourceType::Raster ) ) )
         return u.uri;
-      else if ( u.layerType == QLatin1String( "mesh" ) && u.providerKey == QLatin1String( "mdal" )
+      else if ( u.layerType == "mesh"_L1 && u.providerKey == "mdal"_L1
                 && dataTypes.contains( static_cast<int>( Qgis::ProcessingSourceType::Mesh ) ) )
         return u.uri;
     }
@@ -748,8 +751,8 @@ void QgsProcessingMapLayerComboBox::selectFromFile()
     path = initialValue;
   else if ( QFileInfo::exists( QFileInfo( initialValue ).path() ) && QFileInfo( initialValue ).path() != '.' )
     path = QFileInfo( initialValue ).path();
-  else if ( settings.contains( QStringLiteral( "/Processing/LastInputPath" ) ) )
-    path = settings.value( QStringLiteral( "/Processing/LastInputPath" ) ).toString();
+  else if ( settings.contains( u"/Processing/LastInputPath"_s ) )
+    path = settings.value( u"/Processing/LastInputPath"_s ).toString();
 
   QString filter;
   if ( const QgsFileFilterGenerator *generator = dynamic_cast<const QgsFileFilterGenerator *>( mParameter.get() ) )
@@ -757,11 +760,12 @@ void QgsProcessingMapLayerComboBox::selectFromFile()
   else
     filter = QObject::tr( "All files (*.*)" );
 
-  const QString filename = QFileDialog::getOpenFileName( this, tr( "Select File" ), path, filter );
+  QString selectedFilter = filter.split( QStringLiteral( ";;" ) ).at( 0 );
+  const QString filename = QFileDialog::getOpenFileName( this, tr( "Select File" ), path, filter, &selectedFilter );
   if ( filename.isEmpty() )
     return;
 
-  settings.setValue( QStringLiteral( "/Processing/LastInputPath" ), QFileInfo( filename ).path() );
+  settings.setValue( u"/Processing/LastInputPath"_s, QFileInfo( filename ).path() );
   QgsProcessingContext context;
   setValue( filename, context );
 }
@@ -782,7 +786,7 @@ void QgsProcessingMapLayerComboBox::browseForLayer()
       QgsProcessingContext context;
       if ( widget->uri().uri.isEmpty() )
         setValue( QVariant(), context );
-      else if ( widget->uri().providerKey == QLatin1String( "ogr" ) )
+      else if ( widget->uri().providerKey == "ogr"_L1 )
         setValue( widget->uri().uri, context );
       else
         setValue( QgsProcessingUtils::encodeProviderKeyAndUri( widget->uri().providerKey, widget->uri().uri ), context );

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -19,6 +19,8 @@
 #include "qgsannotationlayer.h"
 #include "qgsfileutils.h"
 #include "qgsgui.h"
+#include "qgsguiutils.h"
+#include "qgsiconutils.h"
 #include "qgsmaplayerfactory.h"
 #include "qgsmeshlayer.h"
 #include "qgsmimedatautils.h"
@@ -38,9 +40,12 @@
 #include <QPushButton>
 #include <QStandardItem>
 #include <QStandardItemModel>
+#include <QString>
 #include <QToolButton>
 
 #include "moc_qgsprocessingmultipleselectiondialog.cpp"
+
+using namespace Qt::StringLiterals;
 
 ///@cond NOT_STABLE
 
@@ -60,6 +65,10 @@ QgsProcessingMultipleSelectionPanelWidget::QgsProcessingMultipleSelectionPanelWi
   mSelectionList->setSelectionBehavior( QAbstractItemView::SelectRows );
   mSelectionList->setSelectionMode( QAbstractItemView::ExtendedSelection );
   mSelectionList->setDragDropMode( QAbstractItemView::InternalMove );
+  mSelectionList->setIconSize( QSize( QgsGuiUtils::scaleIconSize( 16 ), QgsGuiUtils::scaleIconSize( 16 ) ) );
+
+  mModel = new QStandardItemModel( this );
+  mSelectionList->setModel( mModel );
 
   mButtonSelectAll = new QPushButton( tr( "Select All" ) );
   mButtonBox->addButton( mButtonSelectAll, QDialogButtonBox::ActionRole );
@@ -179,8 +188,6 @@ QList<QStandardItem *> QgsProcessingMultipleSelectionPanelWidget::currentItems()
 
 void QgsProcessingMultipleSelectionPanelWidget::populateList( const QVariantList &availableOptions, const QVariantList &selectedOptions )
 {
-  mModel = new QStandardItemModel( this );
-
   QVariantList remainingOptions = availableOptions;
 
   // we add selected options first, keeping the existing order of options
@@ -198,8 +205,6 @@ void QgsProcessingMultipleSelectionPanelWidget::populateList( const QVariantList
   {
     addOption( option, mValueFormatter( option ), false );
   }
-
-  mSelectionList->setModel( mModel );
 }
 
 QList<int> QgsProcessingMultipleSelectionPanelWidget::existingMapLayerFromMimeData( const QMimeData *data ) const
@@ -260,7 +265,7 @@ void QgsProcessingMultipleSelectionPanelWidget::dropEvent( QDropEvent *event )
   }
 }
 
-void QgsProcessingMultipleSelectionPanelWidget::addOption( const QVariant &value, const QString &title, bool selected, bool updateExistingTitle )
+void QgsProcessingMultipleSelectionPanelWidget::addOption( const QVariant &value, const QString &title, bool selected, bool updateExistingTitle, QIcon icon )
 {
   // don't add duplicate options
   for ( int i = 0; i < mModel->rowCount(); ++i )
@@ -278,6 +283,8 @@ void QgsProcessingMultipleSelectionPanelWidget::addOption( const QVariant &value
   item->setCheckState( selected ? Qt::Checked : Qt::Unchecked );
   item->setCheckable( true );
   item->setDropEnabled( false );
+  if ( !icon.isNull() )
+    item->setData( icon, Qt::DecorationRole );
   mModel->appendRow( item.release() );
 }
 
@@ -326,6 +333,8 @@ QgsProcessingMultipleInputPanelWidget::QgsProcessingMultipleInputPanelWidget( co
   connect( addDirButton, &QPushButton::clicked, this, &QgsProcessingMultipleInputPanelWidget::addDirectory );
   buttonBox()->addButton( addDirButton, QDialogButtonBox::ActionRole );
   setAcceptDrops( true );
+
+  // Populate "layers" from model sources
   for ( const QgsProcessingModelChildParameterSource &source : modelSources )
   {
     addOption( QVariant::fromValue( source ), source.friendlyIdentifier( model ), false, true );
@@ -341,7 +350,7 @@ void QgsProcessingMultipleInputPanelWidget::setProject( QgsProject *project )
 void QgsProcessingMultipleInputPanelWidget::addFiles()
 {
   QgsSettings settings;
-  QString path = settings.value( QStringLiteral( "/Processing/LastInputPath" ), QDir::homePath() ).toString();
+  QString path = settings.value( u"/Processing/LastInputPath"_s, QDir::homePath() ).toString();
 
   QString filter;
   if ( const QgsFileFilterGenerator *generator = dynamic_cast<const QgsFileFilterGenerator *>( mParameter ) )
@@ -349,11 +358,12 @@ void QgsProcessingMultipleInputPanelWidget::addFiles()
   else
     filter = QObject::tr( "All files (*.*)" );
 
-  const QStringList filenames = QFileDialog::getOpenFileNames( this, tr( "Select File(s)" ), path, filter );
+  QString selectedFilter = filter.split( QStringLiteral( ";;" ) ).at( 0 );
+  const QStringList filenames = QFileDialog::getOpenFileNames( this, tr( "Select File(s)" ), path, filter, &selectedFilter );
   if ( filenames.empty() )
     return;
 
-  settings.setValue( QStringLiteral( "/Processing/LastInputPath" ), QFileInfo( filenames.at( 0 ) ).path() );
+  settings.setValue( u"/Processing/LastInputPath"_s, QFileInfo( filenames.at( 0 ) ).path() );
 
   for ( const QString &file : filenames )
   {
@@ -366,13 +376,13 @@ void QgsProcessingMultipleInputPanelWidget::addFiles()
 void QgsProcessingMultipleInputPanelWidget::addDirectory()
 {
   QgsSettings settings;
-  const QString path = settings.value( QStringLiteral( "/Processing/LastInputPath" ), QDir::homePath() ).toString();
+  const QString path = settings.value( u"/Processing/LastInputPath"_s, QDir::homePath() ).toString();
 
   const QString dir = QFileDialog::getExistingDirectory( this, tr( "Select Directory" ), path );
   if ( dir.isEmpty() )
     return;
 
-  settings.setValue( QStringLiteral( "/Processing/LastInputPath" ), dir );
+  settings.setValue( u"/Processing/LastInputPath"_s, dir );
 
   QStringList nameFilters;
   if ( const QgsFileFilterGenerator *generator = dynamic_cast<const QgsFileFilterGenerator *>( mParameter ) )
@@ -380,9 +390,9 @@ void QgsProcessingMultipleInputPanelWidget::addDirectory()
     const QStringList extensions = QgsFileUtils::extensionsFromFilter( generator->createFileFilter() );
     for ( const QString &extension : extensions )
     {
-      nameFilters << QStringLiteral( "*.%1" ).arg( extension );
-      nameFilters << QStringLiteral( "*.%1" ).arg( extension.toUpper() );
-      nameFilters << QStringLiteral( "*.%1" ).arg( extension.toLower() );
+      nameFilters << u"*.%1"_s.arg( extension );
+      nameFilters << u"*.%1"_s.arg( extension.toUpper() );
+      nameFilters << u"*.%1"_s.arg( extension.toLower() );
     }
   }
 
@@ -390,15 +400,15 @@ void QgsProcessingMultipleInputPanelWidget::addDirectory()
   while ( it.hasNext() )
   {
     const QString fullPath = it.next();
-    if ( fullPath.endsWith( QLatin1String( ".dbf" ), Qt::CaseInsensitive ) )
+    if ( fullPath.endsWith( ".dbf"_L1, Qt::CaseInsensitive ) )
     {
-      if ( QFileInfo::exists( QStringLiteral( "%1.shp" ).arg( fullPath.chopped( 4 ) ) ) || QFileInfo::exists( QStringLiteral( "%1.SHP" ).arg( fullPath.chopped( 4 ) ) ) )
+      if ( QFileInfo::exists( u"%1.shp"_s.arg( fullPath.chopped( 4 ) ) ) || QFileInfo::exists( u"%1.SHP"_s.arg( fullPath.chopped( 4 ) ) ) )
       {
         // Skip DBFs that are sidecar files to a Shapefile
         continue;
       }
     }
-    else if ( fullPath.endsWith( QLatin1String( ".aux.xml" ), Qt::CaseInsensitive ) || fullPath.endsWith( QLatin1String( ".shp.xml" ), Qt::CaseInsensitive ) )
+    else if ( fullPath.endsWith( ".aux.xml"_L1, Qt::CaseInsensitive ) || fullPath.endsWith( ".shp.xml"_L1, Qt::CaseInsensitive ) )
     {
       // Skip XMLs that are sidecar files  to datasets
       continue;
@@ -495,13 +505,13 @@ QStringList QgsProcessingMultipleInputPanelWidget::compatibleUrisFromMimeData( c
           break;
       }
       if ( acceptable )
-        res.append( u.providerKey != QLatin1String( "ogr" ) ? QgsProcessingUtils::encodeProviderKeyAndUri( u.providerKey, u.uri ) : u.uri );
+        res.append( u.providerKey != "ogr"_L1 ? QgsProcessingUtils::encodeProviderKeyAndUri( u.providerKey, u.uri ) : u.uri );
     }
     else if ( ( parameter->layerType() == Qgis::ProcessingSourceType::MapLayer || parameter->layerType() == Qgis::ProcessingSourceType::Raster )
-              && u.layerType == QgsMapLayerFactory::typeToString( Qgis::LayerType::Raster ) && u.providerKey == QLatin1String( "gdal" ) )
+              && u.layerType == QgsMapLayerFactory::typeToString( Qgis::LayerType::Raster ) && u.providerKey == "gdal"_L1 )
       res.append( u.uri );
     else if ( ( parameter->layerType() == Qgis::ProcessingSourceType::MapLayer || parameter->layerType() == Qgis::ProcessingSourceType::Mesh )
-              && u.layerType == QgsMapLayerFactory::typeToString( Qgis::LayerType::Mesh ) && u.providerKey == QLatin1String( "mdal" ) )
+              && u.layerType == QgsMapLayerFactory::typeToString( Qgis::LayerType::Mesh ) && u.providerKey == "mdal"_L1 )
       res.append( u.uri );
     else if ( ( parameter->layerType() == Qgis::ProcessingSourceType::MapLayer || parameter->layerType() == Qgis::ProcessingSourceType::PointCloud )
               && u.layerType == QgsMapLayerFactory::typeToString( Qgis::LayerType::PointCloud ) )
@@ -625,32 +635,35 @@ void QgsProcessingMultipleInputPanelWidget::populateFromProject( QgsProject *pro
   auto addLayer = [&]( const QgsMapLayer *layer ) {
     const QString authid = layer->crs().authid();
     QString title;
-    if ( settings.value( QStringLiteral( "Processing/Configuration/SHOW_CRS_DEF" ), true ).toBool() && !authid.isEmpty() )
-      title = QStringLiteral( "%1 [%2]" ).arg( layer->name(), authid );
+    if ( settings.value( u"Processing/Configuration/SHOW_CRS_DEF"_s, true ).toBool() && !authid.isEmpty() )
+      title = u"%1 [%2]"_s.arg( layer->name(), authid );
     else
       title = layer->name();
 
+    QIcon icon = QgsIconUtils::iconForLayer( layer );
 
     QString id = layer->id();
     if ( layer == project->mainAnnotationLayer() )
-      id = QStringLiteral( "main" );
+      id = u"main"_s;
 
     for ( int i = 0; i < mModel->rowCount(); ++i )
     {
-      // try to match project layers to current layers
+      // try to match project layers to current layers, also assign its icon if found
       if ( mModel->item( i )->data( Qt::UserRole ) == layer->id() )
       {
         id = layer->id();
+        mModel->item( i )->setData( QgsIconUtils::iconForLayer( layer ), Qt::DecorationRole );
         break;
       }
       else if ( mModel->item( i )->data( Qt::UserRole ) == layer->source() )
       {
         id = layer->source();
+        mModel->item( i )->setData( QgsIconUtils::iconForLayer( layer ), Qt::DecorationRole );
         break;
       }
     }
 
-    addOption( id, title, false, true );
+    addOption( id, title, false, true, icon );
   };
 
   switch ( mParameter->layerType() )
@@ -805,7 +818,7 @@ QgsProcessingMultipleInputDialog::QgsProcessingMultipleInputDialog( const QgsPro
 {
   setWindowTitle( tr( "Multiple Selection" ) );
   QVBoxLayout *vLayout = new QVBoxLayout();
-  mWidget = new QgsProcessingMultipleInputPanelWidget( parameter, selectedOptions, modelSources, model );
+  mWidget = new QgsProcessingMultipleInputPanelWidget( parameter, selectedOptions, modelSources, model, nullptr );
   vLayout->addWidget( mWidget );
   mWidget->buttonBox()->addButton( QDialogButtonBox::Cancel );
   connect( mWidget->buttonBox(), &QDialogButtonBox::accepted, this, &QDialog::accept );


### PR DESCRIPTION
In this PR I have ensured that the correct file format (like GeoPackage) is automatically selected when a user opens a file dialog in the Processing toolbox it migrates the logic from deprecated Python wrappers to the modern C++ core components
Changes
Updated QgsProcessingMapLayerComboBox to pass the initial filter to the file dialog updated QgsProcessingMultipleSelectionDialog to handle pre-selection for multiple file inputs used QStringLiteral and proper pointer signatures to match QGIS core coding standards
<img width="986" height="225" alt="Screenshot 2026-01-30 at 12 06 07 AM" src="https://github.com/user-attachments/assets/332da3cc-cacd-43b7-b80a-8f73d0120cea" />
<img width="1076" height="726" alt="Screenshot 2026-01-30 at 12 09 22 AM" src="https://github.com/user-attachments/assets/461cc480-129b-4e31-a8a9-993e2977d283" />
<img width="1882" height="1064" alt="Screenshot 2026-01-28 at 9 35 18 PM" src="https://github.com/user-attachments/assets/4a3c6508-53f6-466c-b6ba-c433d446b315" />
