### PR TITLE
Core: ensure initial filter is pre-selected in Processing file widgets

### DIFF
--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -29,6 +29,7 @@
 #include "qgsprocessingwidgetwrapper.h"
 #include "qgsproviderregistry.h"
 #include "qgssettings.h"
+#include "qgsstringutils.h"
 #include "qgsvectorlayer.h"
 #include "qgswmsutils.h"
 
@@ -760,7 +761,8 @@ void QgsProcessingMapLayerComboBox::selectFromFile()
   else
     filter = QObject::tr( "All files (*.*)" );
 
-  const QString filename = QFileDialog::getOpenFileName( this, tr( "Select File" ), path, filter );
+  QString selectedFilter = filter.split( u";;"_s ).at( 0 );
+  const QString filename = QFileDialog::getOpenFileName( this, tr( "Select File" ), path, filter, &selectedFilter );
   if ( filename.isEmpty() )
     return;
 

--- a/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
+++ b/src/gui/processing/qgsprocessingmultipleselectiondialog.cpp
@@ -29,6 +29,7 @@
 #include "qgsproject.h"
 #include "qgsrasterlayer.h"
 #include "qgssettings.h"
+#include "qgsstringutils.h"
 #include "qgstiledscenelayer.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectortilelayer.h"
@@ -358,7 +359,8 @@ void QgsProcessingMultipleInputPanelWidget::addFiles()
   else
     filter = QObject::tr( "All files (*.*)" );
 
-  const QStringList filenames = QFileDialog::getOpenFileNames( this, tr( "Select File(s)" ), path, filter );
+  QString selectedFilter = filter.split( u";;"_s ).at( 0 );
+  const QStringList filenames = QFileDialog::getOpenFileNames( this, tr( "Select File(s)" ), path, filter, &selectedFilter );
   if ( filenames.empty() )
     return;
 


### PR DESCRIPTION
In this PR I have ensured that the correct file format (like GeoPackage) is automatically selected when a user opens a file dialog in the Processing toolbox it migrates the logic from deprecated Python wrappers to the modern C++ core components
Changes
Updated QgsProcessingMapLayerComboBox to pass the initial filter to the file dialog updated QgsProcessingMultipleSelectionDialog to handle pre-selection for multiple file inputs used QStringLiteral and proper pointer signatures to match QGIS core coding standards
<img width="986" height="225" alt="Screenshot 2026-01-30 at 12 06 07 AM" src="https://github.com/user-attachments/assets/3d91e92a-fae0-49bb-b775-e2aa1f8bc042" />
<img width="1076" height="726" alt="Screenshot 2026-01-30 at 12 09 22 AM" src="https://github.com/user-attachments/assets/69da3281-ea21-4968-bf07-bf5c430658ea" />
<img width="1882" height="1064" alt="Screenshot 2026-01-28 at 9 35 18 PM" src="https://github.com/user-attachments/assets/8920fa0f-f2d2-43aa-9225-25aa083c46f8" />
