### PR TITLE
qgsogrutils: Fix ogrGeometryToQgsGeometry for 3d/m wkb case

### DIFF
--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -1065,7 +1065,7 @@ QgsGeometry QgsOgrUtils::ogrGeometryToQgsGeometry( OGRGeometryH geom )
   // get the wkb representation
   int memorySize = OGR_G_WkbSize( geom );
   unsigned char *wkb = new unsigned char[memorySize];
-  OGR_G_ExportToWkb( geom, static_cast<OGRwkbByteOrder>( QgsApplication::endian() ), wkb );
+  OGR_G_ExportToIsoWkb( geom, static_cast<OGRwkbByteOrder>( QgsApplication::endian() ), wkb );
 
   QgsGeometry g;
   g.fromWkb( wkb, memorySize );

--- a/tests/src/core/testqgsogrutils.cpp
+++ b/tests/src/core/testqgsogrutils.cpp
@@ -211,6 +211,14 @@ void TestQgsOgrUtils::ogrGeometryToQgsGeometry()
   geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
   QCOMPARE( geom.asWkt( 3 ), u"PolyhedralSurface Z (((0.2 0 0, 1 0 0, 1 1 0, 0 1 0, 0.2 0 0)))"_s );
   OGR_G_DestroyGeometry( ogrGeom );
+  ogrGeom = nullptr;
+
+  wkt = QByteArray( "TIN Z (((0 0 0, 1.2 0 0, 0 1 0, 0 0 0)),((1 0 0, 1 1 0, 0 1 0, 1 0 0)))" );
+  wktChar = wkt.data();
+  OGR_G_CreateFromWkt( &wktChar, nullptr, &ogrGeom );
+  geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
+  QCOMPARE( geom.asWkt( 3 ), u"TIN Z (((0 0 0, 1.2 0 0, 0 1 0, 0 0 0)),((1 0 0, 1 1 0, 0 1 0, 1 0 0)))"_s );
+  OGR_G_DestroyGeometry( ogrGeom );
 }
 
 void TestQgsOgrUtils::ogrGeometryToQgsGeometry2_data()
@@ -241,6 +249,12 @@ void TestQgsOgrUtils::ogrGeometryToQgsGeometry2_data()
   QTest::newRow( "polyhedralsurfacez2" ) << u"PolyhedralSurface Z (((0 0 0, 1 0 0, 0 1 0, 0 0 0)),((0 0 0, 0 1 0, 0 0 1, 0 0 0)))"_s << static_cast<int>( Qgis::WkbType::PolyhedralSurfaceZ );
   QTest::newRow( "polyhedralsurfacem" ) << u"PolyhedralSurface M (((0.2 0 1, 1 0 1, 1 1 1, 0 1 1, 0.2 0 1)))"_s << static_cast<int>( Qgis::WkbType::PolyhedralSurfaceM );
   QTest::newRow( "polyhedralsurfacezm" ) << u"PolyhedralSurface ZM (((0.2 0 0 1, 1 0 0 1, 1 1 0 1, 0 1 0 1, 0.2 0 0 1)))"_s << static_cast<int>( Qgis::WkbType::PolyhedralSurfaceZM );
+
+  QTest::newRow( "tin" ) << u"TIN (((0 0, 1.1 0, 0 1, 0 0)))"_s << static_cast<int>( Qgis::WkbType::TIN );
+  QTest::newRow( "tinz" ) << u"TIN Z (((0 0 0, 1.1 0 0, 0 1 0, 0 0 0)))"_s << static_cast<int>( Qgis::WkbType::TINZ );
+  QTest::newRow( "tinz2" ) << u"TIN Z (((0 0 0, 1.1 0 0, 0 1 0, 0 0 0)),((1 0 0, 1 1 0, 0 1.2 0, 1 0 0)))"_s << static_cast<int>( Qgis::WkbType::TINZ );
+  QTest::newRow( "tinm" ) << u"TIN M (((0 0 1, 1 0 1, 0 1.1 1, 0 0 1)))"_s << static_cast<int>( Qgis::WkbType::TINM );
+  QTest::newRow( "tinzm" ) << u"TIN ZM (((0 0 0 1, 1 0 0 1, 0 1.1 0 1, 0 0 0 1)))"_s << static_cast<int>( Qgis::WkbType::TINZM );
 }
 
 void TestQgsOgrUtils::ogrGeometryToQgsGeometry2()

--- a/tests/src/core/testqgsogrutils.cpp
+++ b/tests/src/core/testqgsogrutils.cpp
@@ -203,6 +203,14 @@ void TestQgsOgrUtils::ogrGeometryToQgsGeometry()
   geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
   QCOMPARE( geom.asWkt( 3 ), u"MultiPoint ZM ((1.1 2.2 3 4),(3.3 4.4 4 5))"_s );
   OGR_G_DestroyGeometry( ogrGeom );
+  ogrGeom = nullptr;
+
+  wkt = QByteArray( "POLYHEDRALSURFACE Z (((0.2 0 0, 1 0 0, 1 1 0, 0 1 0, 0.2 0 0)))" );
+  wktChar = wkt.data();
+  OGR_G_CreateFromWkt( &wktChar, nullptr, &ogrGeom );
+  geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
+  QCOMPARE( geom.asWkt( 3 ), u"PolyhedralSurface Z (((0.2 0 0, 1 0 0, 1 1 0, 0 1 0, 0.2 0 0)))"_s );
+  OGR_G_DestroyGeometry( ogrGeom );
 }
 
 void TestQgsOgrUtils::ogrGeometryToQgsGeometry2_data()
@@ -227,6 +235,12 @@ void TestQgsOgrUtils::ogrGeometryToQgsGeometry2_data()
   QTest::newRow( "linestring" ) << u"MultiLineString Z ((1.1 2.2 3, 3.3 4.4 6),(5 5 3, 6 6 1))"_s << static_cast<int>( Qgis::WkbType::MultiLineStringZ );
   QTest::newRow( "linestring" ) << u"MultiLineString M ((1.1 2.2 4, 3.3 4.4 7),(5 5 4, 6 6 2))"_s << static_cast<int>( Qgis::WkbType::MultiLineStringM );
   QTest::newRow( "linestring" ) << u"MultiLineString ZM ((1.1 2.2 4 5, 3.3 4.4 8 9),(5 5 7 1, 6 6 2 3))"_s << static_cast<int>( Qgis::WkbType::MultiLineStringZM );
+
+  QTest::newRow( "polyhedralsurface" ) << u"PolyhedralSurface (((0.2 0, 1 0, 1 1, 0 1, 0.2 0)))"_s << static_cast<int>( Qgis::WkbType::PolyhedralSurface );
+  QTest::newRow( "polyhedralsurfacez" ) << u"PolyhedralSurface Z (((0.2 0 0, 1 0 0, 1 1 0, 0 1 0, 0.2 0 0)))"_s << static_cast<int>( Qgis::WkbType::PolyhedralSurfaceZ );
+  QTest::newRow( "polyhedralsurfacez2" ) << u"PolyhedralSurface Z (((0 0 0, 1 0 0, 0 1 0, 0 0 0)),((0 0 0, 0 1 0, 0 0 1, 0 0 0)))"_s << static_cast<int>( Qgis::WkbType::PolyhedralSurfaceZ );
+  QTest::newRow( "polyhedralsurfacem" ) << u"PolyhedralSurface M (((0.2 0 1, 1 0 1, 1 1 1, 0 1 1, 0.2 0 1)))"_s << static_cast<int>( Qgis::WkbType::PolyhedralSurfaceM );
+  QTest::newRow( "polyhedralsurfacezm" ) << u"PolyhedralSurface ZM (((0.2 0 0 1, 1 0 0 1, 1 1 0 1, 0 1 0 1, 0.2 0 0 1)))"_s << static_cast<int>( Qgis::WkbType::PolyhedralSurfaceZM );
 }
 
 void TestQgsOgrUtils::ogrGeometryToQgsGeometry2()


### PR DESCRIPTION
## Description

`OGR_G_ExportToWkb` returns wkb types with bit 31 set to 1  (0x80000000) for 3d geometries. However, QGIS uses the OGC/ISO standard which uses the `+1000` encoding for 3d types.

This issue can be reproduced when import 3d polyhedralsurface for
example. This is fixed by using `OGR_G_ExportToIsoWkb` instead.

