### PR TITLE
[server] Run (C++) server filters when HAVE_SERVER_PYTHON_PLUGINS=OFF

### DIFF
--- a/src/server/qgsfilterresponsedecorator.cpp
+++ b/src/server/qgsfilterresponsedecorator.cpp
@@ -28,7 +28,6 @@ QgsFilterResponseDecorator::QgsFilterResponseDecorator( QgsServerFiltersMap filt
 
 void QgsFilterResponseDecorator::start()
 {
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
   QgsServerFiltersMap::const_iterator filtersIterator;
   for ( filtersIterator = mFilters.constBegin(); filtersIterator != mFilters.constEnd(); ++filtersIterator )
   {
@@ -38,12 +37,10 @@ void QgsFilterResponseDecorator::start()
       return;
     }
   }
-#endif
 }
 
 void QgsFilterResponseDecorator::ready()
 {
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
   QgsServerFiltersMap::const_iterator filtersIterator;
   for ( filtersIterator = mFilters.constBegin(); filtersIterator != mFilters.constEnd(); ++filtersIterator )
   {
@@ -53,12 +50,10 @@ void QgsFilterResponseDecorator::ready()
       return;
     }
   }
-#endif
 }
 
 void QgsFilterResponseDecorator::finish()
 {
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
   QgsServerFiltersMap::const_iterator filtersIterator;
   for ( filtersIterator = mFilters.constBegin(); filtersIterator != mFilters.constEnd(); ++filtersIterator )
   {
@@ -69,7 +64,6 @@ void QgsFilterResponseDecorator::finish()
       break;
     }
   }
-#endif
   // Will call internal 'flush'
   mResponse.finish();
 }
@@ -77,7 +71,6 @@ void QgsFilterResponseDecorator::finish()
 
 void QgsFilterResponseDecorator::flush()
 {
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
   QgsServerFiltersMap::const_iterator filtersIterator;
 
   for ( filtersIterator = mFilters.constBegin(); filtersIterator != mFilters.constEnd(); ++filtersIterator )
@@ -88,6 +81,5 @@ void QgsFilterResponseDecorator::flush()
       return;
     }
   }
-#endif
   mResponse.flush();
 }


### PR DESCRIPTION
Because C++ server plugins may still exist and are allowed to run even when python is off.

Fix #64556
