### PR TITLE
Fix: + operator NULL propagation in string concatenation

### DIFF
--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -402,9 +402,11 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
     case boPlus:
       if ( vL.userType() == QMetaType::Type::QString && vR.userType() == QMetaType::Type::QString )
       {
-        QString sL = QgsExpressionUtils::isNull( vL ) ? QString() : QgsExpressionUtils::getStringValue( vL, parent );
+        if ( QgsExpressionUtils::isNull( vL ) || QgsExpressionUtils::isNull( vR ) )
+          return QVariant();
+        QString sL = QgsExpressionUtils::getStringValue( vL, parent );
         ENSURE_NO_EVAL_ERROR
-        QString sR = QgsExpressionUtils::isNull( vR ) ? QString() : QgsExpressionUtils::getStringValue( vR, parent );
+        QString sR = QgsExpressionUtils::getStringValue( vR, parent );
         ENSURE_NO_EVAL_ERROR
         return QVariant( sL + sR );
       }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1075,6 +1075,7 @@ class TestQgsExpression : public QObject
 
       // concatenation
       QTest::newRow( "concat with plus" ) << "'a' + 'b'" << false << QVariant( "ab" );
+      QTest::newRow( "plus string with null" ) << "'a' + null" << false << QVariant();
       QTest::newRow( "concat" ) << "'a' || 'b'" << false << QVariant( "ab" );
       QTest::newRow( "concat with int" ) << "'a' || 1" << false << QVariant( "a1" );
       QTest::newRow( "concat with int" ) << "2 || 'b'" << false << QVariant( "2b" );
@@ -5813,6 +5814,24 @@ class TestQgsExpression : public QObject
       res = exp.evaluate( &context );
       QCOMPARE( static_cast<QMetaType::Type>( res.userType() ), QMetaType::Type::QString );
       QCOMPARE( res.toString(), u"test"_s );
+    }
+
+    void testPlusNULLAttributeValue()
+    {
+      // Test that + operator propagates NULL from field values
+      // https://github.com/qgis/QGIS/issues/64634
+
+      QgsFields fields;
+      fields.append( QgsField( u"notes"_s, QMetaType::Type::QString ) );
+
+      QgsFeature f;
+      f.initAttributes( 1 );
+      f.setAttribute( 0, QVariant() ); // NULL
+
+      QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f, fields );
+      QgsExpression exp( u"' - ' + notes"_s );
+      QVariant res = exp.evaluate( &context );
+      QVERIFY( res.isNull() ); // Should be NULL, not " - "
     }
 
     void testIsFieldEqualityExpression_data()


### PR DESCRIPTION
Fixes #64634

## Bug
```
' - ' + NULL_field  →  ' - '   (wrong)
' - ' || NULL_field →  NULL    (correct)
```

## Fix
NULL check before concatenation, matching `||` pattern:
```cpp
if ( QgsExpressionUtils::isNull( vL ) || QgsExpressionUtils::isNull( vR ) )
  return QVariant();
```

## Tests
- `'a' + null` → NULL
- `' - ' + [NULL field]` → NULL

## Note
Behavior change: `+` now propagates NULL instead of silently converting to empty string.