### PR TITLE
Fix #64702: RAT Pixel Count always 0

### DIFF
--- a/python/PyQt6/core/auto_generated/raster/qgsrasterattributetable.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterattributetable.sip.in
@@ -508,6 +508,36 @@ raster band from which the attribute table was created.
          - bandNumber: band number
 %End
 
+    bool updatePixelCounts( QgsRasterDataProvider *provider, int bandNumber, QString *errorMessage /Out/ = 0, QgsRasterBlockFeedback *feedback = 0 );
+%Docstring
+Updates the PixelCount column values by scanning the raster data.
+
+This method iterates through all pixels in the raster and counts how
+many belong to each class defined in the Raster Attribute Table.
+
+For thematic RATs (discrete values): pixels are matched exactly to
+MinMax values. For athematic RATs (value ranges): pixels are matched to
+[Min, Max) ranges.
+
+:param provider: the raster data provider to read from
+:param bandNumber: the band number (1-indexed)
+:param feedback: optional feedback object for progress reporting and
+                 cancellation
+
+:return: - ``True`` on success, ``False`` on error or cancellation
+         - errorMessage: will be set if an error occurs
+
+.. note::
+
+   This operation can be slow for large rasters as it requires reading all pixels.
+
+.. note::
+
+   The RAT must have a PixelCount column (use :py:func:`~QgsRasterAttributeTable.insertField` to add one first).
+
+.. versionadded:: 3.44
+%End
+
 
 
     static QHash<int, QgsRasterAttributeTable::UsageInformation> usageInformationInt( ) /PyName=usageInformation/;

--- a/python/core/auto_generated/raster/qgsrasterattributetable.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterattributetable.sip.in
@@ -508,6 +508,36 @@ raster band from which the attribute table was created.
          - bandNumber: band number
 %End
 
+    bool updatePixelCounts( QgsRasterDataProvider *provider, int bandNumber, QString *errorMessage /Out/ = 0, QgsRasterBlockFeedback *feedback = 0 );
+%Docstring
+Updates the PixelCount column values by scanning the raster data.
+
+This method iterates through all pixels in the raster and counts how
+many belong to each class defined in the Raster Attribute Table.
+
+For thematic RATs (discrete values): pixels are matched exactly to
+MinMax values. For athematic RATs (value ranges): pixels are matched to
+[Min, Max) ranges.
+
+:param provider: the raster data provider to read from
+:param bandNumber: the band number (1-indexed)
+:param feedback: optional feedback object for progress reporting and
+                 cancellation
+
+:return: - ``True`` on success, ``False`` on error or cancellation
+         - errorMessage: will be set if an error occurs
+
+.. note::
+
+   This operation can be slow for large rasters as it requires reading all pixels.
+
+.. note::
+
+   The RAT must have a PixelCount column (use :py:func:`~QgsRasterAttributeTable.insertField` to add one first).
+
+.. versionadded:: 3.44
+%End
+
 
 
     static QHash<int, QgsRasterAttributeTable::UsageInformation> usageInformationInt( ) /PyName=usageInformation/;

--- a/src/core/raster/qgsrasterattributetable.h
+++ b/src/core/raster/qgsrasterattributetable.h
@@ -27,9 +27,10 @@
 #include <QLinearGradient>
 #include <QObject>
 
+class QgsRasterBlockFeedback;
+class QgsRasterDataProvider;
 class QgsRasterLayer;
 class QgsRasterRenderer;
-class QgsRasterDataProvider;
 
 /**
  * \ingroup core
@@ -439,6 +440,28 @@ class CORE_EXPORT QgsRasterAttributeTable
      * \returns NULLPTR in case of errors or unsupported renderer.
      */
     static QgsRasterAttributeTable *createFromRaster( QgsRasterLayer *rasterLayer, int *bandNumber SIP_OUT = nullptr ) SIP_FACTORY;
+
+    /**
+     * Updates the PixelCount column values by scanning the raster data.
+     *
+     * This method iterates through all pixels in the raster and counts how many
+     * belong to each class defined in the Raster Attribute Table.
+     *
+     * For thematic RATs (discrete values): pixels are matched exactly to MinMax values.
+     * For athematic RATs (value ranges): pixels are matched to [Min, Max) ranges.
+     *
+     * \param provider the raster data provider to read from
+     * \param bandNumber the band number (1-indexed)
+     * \param errorMessage will be set if an error occurs
+     * \param feedback optional feedback object for progress reporting and cancellation
+     * \returns TRUE on success, FALSE on error or cancellation
+     *
+     * \note This operation can be slow for large rasters as it requires reading all pixels.
+     * \note The RAT must have a PixelCount column (use insertField() to add one first).
+     *
+     * \since QGIS 3.44
+     */
+    bool updatePixelCounts( QgsRasterDataProvider *provider, int bandNumber, QString *errorMessage SIP_OUT = nullptr, QgsRasterBlockFeedback *feedback = nullptr );
 
     /**
      * Returns information about supported Raster Attribute Table usages.

--- a/src/gui/raster/qgsrasterattributetablewidget.h
+++ b/src/gui/raster/qgsrasterattributetablewidget.h
@@ -173,6 +173,7 @@ class GUI_EXPORT QgsRasterAttributeTableWidget : public QgsPanelWidget, private 
     void removeColumn();
     void addRow();
     void removeRow();
+    void updatePixelCount();
     void bandChanged( const int index );
     void notify( const QString &title, const QString &message, Qgis::MessageLevel level = Qgis::MessageLevel::Info );
     void setDelegates();
@@ -191,6 +192,7 @@ class GUI_EXPORT QgsRasterAttributeTableWidget : public QgsPanelWidget, private 
     QAction *mActionAddRow = nullptr;
     QAction *mActionRemoveRow = nullptr;
     QAction *mActionSaveChanges = nullptr;
+    QAction *mActionUpdatePixelCount = nullptr;
 
     QgsMessageBar *mMessageBar = nullptr;
     QSortFilterProxyModel *mProxyModel = nullptr;


### PR DESCRIPTION
## Problem

Adding a "Pixel Count" column to a Raster Attribute Table shows all zeros instead of actual pixel counts per class.

## Solution

Add `QgsRasterAttributeTable::updatePixelCounts()` method and toolbar button.

**Design choice:** User-triggered scan (not automatic) because large rasters are slow to scan.

## Changes

**Core** (`qgsrasterattributetable.cpp/h`)
- `updatePixelCounts(provider, band, errorMessage, feedback)` - scans raster, counts pixels per class
- Handles thematic (exact value) and athematic (range) RATs
- Progress reporting and cancellation support

**GUI** (`qgsrasterattributetablewidget.cpp/h`)
- "Update Pixel Count" toolbar button (refresh icon)
- Warning dialog, progress bar, cancel support
- Enabled only when editing + PixelCount column exists

**Bindings** - SIP annotations for PyQGIS

**Tests** - `testUpdatePixelCounts`, `testUpdatePixelCountsNoColumn`

## Test checklist

- [ ] Create RAT from symbology, add PixelCount column
- [ ] Enable editing → click "Update Pixel Count"
- [ ] Verify counts match raster values
- [ ] Cancel mid-scan → verify graceful abort
- [ ] PyQGIS: `rat.updatePixelCounts(provider, 1)`

## Known limitations

**Float thematic RATs** (rare): Hash lookup on non-integer MinMax values (e.g., 1.5, 2.7) may miss matches due to floating-point precision. Use athematic (range-based) RATs for float data instead. Most thematic rasters are integer-typed, so this rarely applies.

Fixes #64702
