### PR TITLE
Avoid module wide `QtConcurrent` imports

### DIFF
--- a/src/3d/qgsannotationlayerchunkloader_p.cpp
+++ b/src/3d/qgsannotationlayerchunkloader_p.cpp
@@ -41,8 +41,9 @@
 #include "qgstextureatlasgenerator.h"
 
 #include <QString>
+#include <QTimer>
 #include <Qt3DCore/QTransform>
-#include <QtConcurrent>
+#include <QtConcurrentRun>
 
 #include "moc_qgsannotationlayerchunkloader_p.cpp"
 

--- a/src/3d/qgspointcloudlayerchunkloader_p.cpp
+++ b/src/3d/qgspointcloudlayerchunkloader_p.cpp
@@ -38,7 +38,7 @@
 #include <Qt3DRender/QGraphicsApiFilter>
 #include <Qt3DRender/QShaderProgram>
 #include <Qt3DRender/QTechnique>
-#include <QtConcurrent>
+#include <QtConcurrentRun>
 
 #include "moc_qgspointcloudlayerchunkloader_p.cpp"
 

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -32,7 +32,7 @@
 
 #include <QString>
 #include <Qt3DCore/QTransform>
-#include <QtConcurrent>
+#include <QtConcurrentRun>
 
 #include "moc_qgsrulebasedchunkloader_p.cpp"
 

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -39,7 +39,7 @@
 
 #include <QString>
 #include <Qt3DCore/QTransform>
-#include <QtConcurrent>
+#include <QtConcurrentRun>
 
 #include "moc_qgsvectorlayerchunkloader_p.cpp"
 

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -150,7 +150,7 @@ void QgsDemTerrainTileLoader::onHeightMapReady( int jobId, const QByteArray &hei
 
 #include "qgsrasterlayer.h"
 #include "qgsrasterprojector.h"
-#include <QtConcurrent/QtConcurrentRun>
+#include <QtConcurrentRun>
 #include <QFutureWatcher>
 #include <memory>
 #include "qgsterraindownloader.h"

--- a/src/3d/terrain/qgsdemterraintileloader_p.h
+++ b/src/3d/terrain/qgsdemterraintileloader_p.h
@@ -38,7 +38,6 @@
 #include <QElapsedTimer>
 #include <QFutureWatcher>
 #include <QMutex>
-#include <QtConcurrent/QtConcurrentRun>
 
 class QgsRasterDataProvider;
 class QgsRasterLayer;

--- a/src/3d/terrain/qgsquantizedmeshterraingenerator.cpp
+++ b/src/3d/terrain/qgsquantizedmeshterraingenerator.cpp
@@ -47,7 +47,6 @@
 #include <QPhongMaterial>
 #include <QString>
 #include <QTextureMaterial>
-#include <QtConcurrentRun>
 #include <QtGlobal>
 
 #include "moc_qgsquantizedmeshterraingenerator.cpp"

--- a/src/analysis/processing/qgsalgorithmrasterize.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterize.cpp
@@ -36,7 +36,7 @@
 #include "qgsrasterfilewriter.h"
 
 #include <QString>
-#include <QtConcurrent>
+#include <QtConcurrentRun>
 
 using namespace Qt::StringLiterals;
 

--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -32,7 +32,7 @@ email                : matthias@opengis.ch
 
 #include <QFutureWatcher>
 #include <QString>
-#include <QtConcurrent>
+#include <QtConcurrentMap>
 
 #include "moc_qgsgeometryvalidationservice.cpp"
 

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -43,7 +43,7 @@ email                : jpalmer at linz dot govt dot nz
 #include <QApplication>
 #include <QMouseEvent>
 #include <QString>
-#include <QtConcurrent>
+#include <QtConcurrentRun>
 
 #include "moc_qgsmaptoolselectutils.cpp"
 

--- a/src/core/browser/qgsbrowsermodel.cpp
+++ b/src/core/browser/qgsbrowsermodel.cpp
@@ -35,7 +35,6 @@
 #include <QString>
 #include <QStyle>
 #include <QUrl>
-#include <QtConcurrentMap>
 
 #include "moc_qgsbrowsermodel.cpp"
 

--- a/src/core/browser/qgsdataitem.cpp
+++ b/src/core/browser/qgsdataitem.cpp
@@ -47,7 +47,6 @@
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 #include <QVector>
-#include <QtConcurrentMap>
 #include <QtConcurrentRun>
 
 #include "moc_qgsdataitem.cpp"

--- a/src/core/elevation/qgsprofilerenderer.cpp
+++ b/src/core/elevation/qgsprofilerenderer.cpp
@@ -23,7 +23,6 @@
 #include "qgsprofilesnapping.h"
 
 #include <QtConcurrentMap>
-#include <QtConcurrentRun>
 
 #include "moc_qgsprofilerenderer.cpp"
 

--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -23,8 +23,8 @@
 #include "qgsmessagelog.h"
 #include "qgssettingsentryimpl.h"
 
+#include <QCoreApplication>
 #include <QString>
-#include <QtConcurrent>
 
 #include "moc_qgslocator.cpp"
 

--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -53,7 +53,6 @@
 #include <QPicture>
 #include <QString>
 #include <QTimer>
-#include <QtConcurrentMap>
 
 #include "moc_qgsmaprendererjob.cpp"
 

--- a/src/core/pointcloud/qgspointclouddataprovider.cpp
+++ b/src/core/pointcloud/qgspointclouddataprovider.cpp
@@ -30,7 +30,7 @@
 
 #include <QDebug>
 #include <QString>
-#include <QtConcurrent/QtConcurrentMap>
+#include <QtConcurrentMap>
 #include <QtMath>
 
 #include "moc_qgspointclouddataprovider.cpp"

--- a/src/core/pointcloud/qgspointcloudstatscalculationtask.cpp
+++ b/src/core/pointcloud/qgspointcloudstatscalculationtask.cpp
@@ -20,8 +20,6 @@
 #include "qgspointcloudindex.h"
 #include "qgspointcloudrenderer.h"
 
-#include <QtConcurrent/QtConcurrent>
-
 #include "moc_qgspointcloudstatscalculationtask.cpp"
 
 ///@cond PRIVATE

--- a/src/core/pointcloud/qgspointcloudstatscalculator.cpp
+++ b/src/core/pointcloud/qgspointcloudstatscalculator.cpp
@@ -28,7 +28,7 @@
 
 #include <QQueue>
 #include <QString>
-#include <QtConcurrent/QtConcurrentMap>
+#include <QtConcurrentMap>
 
 #include "moc_qgspointcloudstatscalculator.cpp"
 

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -34,7 +34,6 @@
 #include "qgswkbptr.h"
 
 #include <QString>
-#include <QtConcurrent>
 
 #include "moc_qgspointlocator.cpp"
 

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -24,7 +24,6 @@
 
 #include <QStack>
 #include <QString>
-#include <QtConcurrentRun>
 
 #include "moc_qgstaskmanager.cpp"
 

--- a/src/gui/qgsqueryresultwidget.cpp
+++ b/src/gui/qgsqueryresultwidget.cpp
@@ -41,8 +41,10 @@
 #include <QFileDialog>
 #include <QInputDialog>
 #include <QMessageBox>
+#include <QMimeData>
 #include <QShortcut>
 #include <QString>
+#include <QtConcurrentRun>
 
 #include "moc_qgsqueryresultwidget.cpp"
 

--- a/src/gui/qgsqueryresultwidget.h
+++ b/src/gui/qgsqueryresultwidget.h
@@ -27,12 +27,12 @@
 #include "qgssettingstree.h"
 
 #include <QDialog>
+#include <QFutureWatcher>
 #include <QMainWindow>
 #include <QString>
 #include <QStyledItemDelegate>
 #include <QThread>
 #include <QWidget>
-#include <QtConcurrent>
 
 using namespace Qt::StringLiterals;
 

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -38,7 +38,6 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QString>
-#include <QtConcurrentMap>
 
 #include "moc_qgsgeometrycheckersetuptab.cpp"
 

--- a/src/providers/wfs/qgsbasenetworkrequest.cpp
+++ b/src/providers/wfs/qgsbasenetworkrequest.cpp
@@ -30,7 +30,7 @@
 #include <QFuture>
 #include <QNetworkCacheMetaData>
 #include <QString>
-#include <QtConcurrent>
+#include <QUrlQuery>
 
 #include "moc_qgsbasenetworkrequest.cpp"
 

--- a/tests/code_layout/test_qt_imports.sh
+++ b/tests/code_layout/test_qt_imports.sh
@@ -67,6 +67,9 @@ HINTS[15]="Avoid module-wide import of QtWidgets, which results in all Qt Widget
 IMPORTS[16]="#include <QtWidgets/QtWidgets>"
 HINTS[16]="Avoid module-wide import of QtWidgets, which results in all Qt Widget headers being imported."
 
+IMPORTS[17]="#include <QtConcurrent>"
+HINTS[17]="Avoid module-wide import of QtConcurrent, which results in QtCore being imported. Include only the required header, eg. <QtConcurrentRun>, <QtConcurrentMap> etc."
+
 RES=
 DIR=$(git rev-parse --show-toplevel)
 

--- a/tests/src/core/testqgscredentials.cpp
+++ b/tests/src/core/testqgscredentials.cpp
@@ -17,7 +17,7 @@
 
 #include <QObject>
 #include <QString>
-#include <QtConcurrent>
+#include <QtConcurrentMap>
 
 using namespace Qt::StringLiterals;
 

--- a/tests/src/core/testqgsgdalcloudconnection.cpp
+++ b/tests/src/core/testqgsgdalcloudconnection.cpp
@@ -18,7 +18,6 @@
 
 #include <QObject>
 #include <QString>
-#include <QtConcurrent>
 
 using namespace Qt::StringLiterals;
 

--- a/tests/src/core/testqgsimagecache.cpp
+++ b/tests/src/core/testqgsimagecache.cpp
@@ -31,7 +31,7 @@
 #include <QSignalSpy>
 #include <QString>
 #include <QStringList>
-#include <QtConcurrent>
+#include <QtConcurrentMap>
 
 using namespace Qt::StringLiterals;
 

--- a/tests/src/core/testqgsoverlayexpression.cpp
+++ b/tests/src/core/testqgsoverlayexpression.cpp
@@ -17,7 +17,6 @@
 
 #include <QObject>
 #include <QString>
-#include <QtConcurrentMap>
 
 using namespace Qt::StringLiterals;
 

--- a/tests/src/core/testqgsprojutils.cpp
+++ b/tests/src/core/testqgsprojutils.cpp
@@ -25,7 +25,7 @@ using namespace Qt::StringLiterals;
 
 //header for class being tested
 #include "qgsprojutils.h"
-#include <QtConcurrent>
+#include <QtConcurrentMap>
 
 class TestQgsProjUtils : public QObject
 {

--- a/tests/src/core/testqgssensorthingsconnection.cpp
+++ b/tests/src/core/testqgssensorthingsconnection.cpp
@@ -18,7 +18,6 @@
 
 #include <QObject>
 #include <QString>
-#include <QtConcurrent>
 
 using namespace Qt::StringLiterals;
 

--- a/tests/src/core/testqgssvgcache.cpp
+++ b/tests/src/core/testqgssvgcache.cpp
@@ -26,7 +26,7 @@
 #include <QPicture>
 #include <QString>
 #include <QStringList>
-#include <QtConcurrent>
+#include <QtConcurrentMap>
 
 using namespace Qt::StringLiterals;
 

--- a/tests/src/core/testqgstiledsceneconnection.cpp
+++ b/tests/src/core/testqgstiledsceneconnection.cpp
@@ -18,7 +18,6 @@
 
 #include <QObject>
 #include <QString>
-#include <QtConcurrent>
 
 using namespace Qt::StringLiterals;
 


### PR DESCRIPTION
## Description
Including `<QtConcurrent>` results in including the whole `<QtCore>` module, with an impact on build time.

This used to not be clear in previous versions of the documentation, however it is now [clearly stated](https://doc.qt.io/qt-6/qtconcurrentrun.html#optimize-includes) that the preferred way is to include only the required header (`QtConcurrentRun`, `QtConcurrentMap` etc)

This shaved a ~2% off my local build time (clean/uncached), which while not huge is also not insignificant.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
