### PR TITLE
warn user if concave hull can not be computed (fix #63868)

### DIFF
--- a/src/analysis/processing/qgsalgorithmconcavehull.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehull.cpp
@@ -87,7 +87,7 @@ bool QgsConcaveHullAlgorithm::prepareAlgorithm( const QVariantMap &parameters, Q
   if ( mSource->featureCount() < 3 )
     throw QgsProcessingException( QObject::tr( "Input layer should contain at least 3 points." ) );
 
-  mStep = mSource->featureCount() > 0 ? 50.0 / mSource->featureCount() : 1;
+  mStep = mSource->featureCount() > 0 ? 50.0 / static_cast<double>( mSource->featureCount() ) : 1;
 
   mPercentage = parameterAsDouble( parameters, u"ALPHA"_s, context );
   mAllowHoles = parameterAsBool( parameters, u"HOLES"_s, context );
@@ -129,7 +129,7 @@ void QgsConcaveHullAlgorithm::concaveHullGeos( std::unique_ptr<QgsFeatureSink> &
     if ( feedback->isCanceled() )
       return;
 
-    feedback->setProgress( i * mStep );
+    feedback->setProgress( static_cast<double>( i ) * mStep );
 
     if ( !f.hasGeometry() )
       continue;
@@ -150,10 +150,15 @@ void QgsConcaveHullAlgorithm::concaveHullGeos( std::unique_ptr<QgsFeatureSink> &
   }
   const QgsGeometry concaveHull = allPoints.concaveHull( mPercentage, mAllowHoles );
 
+  if ( concaveHull.isNull() )
+  {
+    feedback->reportError( concaveHull.lastError() );
+  }
+
   if ( mSplitMultipart && concaveHull.isMultipart() )
   {
     QVector<QgsGeometry> collection = concaveHull.asGeometryCollection();
-    mStep = collection.length() > 0 ? 50.0 / collection.length() : 1;
+    mStep = collection.length() > 0 ? 50.0 / static_cast<double>( collection.length() ) : 1;
     for ( int i = 0; i < collection.length(); i++ )
     {
       if ( feedback->isCanceled() )
@@ -228,7 +233,7 @@ void QgsConcaveHullAlgorithm::concaveHullQgis( std::unique_ptr<QgsFeatureSink> &
   QVector<double> length;
   QMap<long, double> edges;
   long i = 0;
-  double step = layer->featureCount() > 0 ? 100.0 / layer->featureCount() : 1;
+  double step = layer->featureCount() > 0 ? 100.0 / static_cast<double>( layer->featureCount() ) : 1;
   QgsFeatureIterator it = layer->getFeatures( QgsFeatureRequest().setNoAttributes() );
   QgsFeature f;
   while ( it.nextFeature( f ) )
@@ -237,7 +242,7 @@ void QgsConcaveHullAlgorithm::concaveHullQgis( std::unique_ptr<QgsFeatureSink> &
     if ( feedback->isCanceled() )
       return;
 
-    multiStepFeedback.setProgress( i * step );
+    multiStepFeedback.setProgress( static_cast<double>( i ) * step );
 
     if ( !f.hasGeometry() )
       continue;
@@ -255,7 +260,7 @@ void QgsConcaveHullAlgorithm::concaveHullQgis( std::unique_ptr<QgsFeatureSink> &
   feedback->setProgressText( QObject::tr( "Removing features…" ) );
   multiStepFeedback.setCurrentStep( 3 );
   i = 0;
-  step = edges.size() > 0 ? 100.0 / edges.size() : 1;
+  step = edges.size() > 0 ? 100.0 / static_cast<double>( edges.size() ) : 1;
   QgsFeatureIds toDelete;
   QMap<long, double>::iterator edgesIt = edges.begin();
   while ( edgesIt != edges.end() )
@@ -270,7 +275,7 @@ void QgsConcaveHullAlgorithm::concaveHullQgis( std::unique_ptr<QgsFeatureSink> &
 
     ++edgesIt;
     i++;
-    multiStepFeedback.setProgress( i * step );
+    multiStepFeedback.setProgress( static_cast<double>( i ) * step );
   }
   layer->dataProvider()->deleteFeatures( toDelete );
 
@@ -305,7 +310,7 @@ void QgsConcaveHullAlgorithm::concaveHullQgis( std::unique_ptr<QgsFeatureSink> &
   if ( mSplitMultipart && concaveHull.isMultipart() )
   {
     const QVector<QgsGeometry> collection = concaveHull.asGeometryCollection();
-    step = collection.length() > 0 ? 50.0 / collection.length() : 1;
+    step = collection.length() > 0 ? 50.0 / static_cast<double>( collection.length() ) : 1;
     for ( int i = 0; i < collection.length(); i++ )
     {
       if ( feedback->isCanceled() )

--- a/src/analysis/processing/qgsalgorithmconcavehull.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehull.cpp
@@ -150,7 +150,7 @@ void QgsConcaveHullAlgorithm::concaveHullGeos( std::unique_ptr<QgsFeatureSink> &
   }
   const QgsGeometry concaveHull = allPoints.concaveHull( mPercentage, mAllowHoles );
 
-  if ( concaveHull.isNull() )
+  if ( concaveHull.isNull() && !concaveHull.lastError().isEmpty() )
   {
     feedback->reportError( concaveHull.lastError() );
   }

--- a/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
@@ -118,7 +118,7 @@ QgsFeatureList QgsConcaveHullByFeatureAlgorithm::processFeature( const QgsFeatur
     else
     {
       outputGeometry = f.geometry().concaveHull( mPercentage, mAllowHoles );
-      if ( outputGeometry.isNull() )
+      if ( outputGeometry.isNull() && !outputGeometry.lastError().isEmpty() )
         feedback->reportError( outputGeometry.lastError() );
       f.setGeometry( outputGeometry );
     }


### PR DESCRIPTION
## Description

Report error if concave hull can not be computed in the Processing "Concave hull" algorithm.

Fixes #63868.