### PR TITLE
add merge tag for aggregate algorithm so that it shows up when searching for it

### DIFF
--- a/src/analysis/processing/qgsalgorithmaggregate.cpp
+++ b/src/analysis/processing/qgsalgorithmaggregate.cpp
@@ -57,7 +57,7 @@ Qgis::ProcessingAlgorithmDocumentationFlags QgsAggregateAlgorithm::documentation
 
 QStringList QgsAggregateAlgorithm::tags() const
 {
-  return QObject::tr( "attributes,sum,mean,collect,dissolve,statistics" ).split( ',' );
+  return QObject::tr( "attributes,sum,mean,collect,dissolve,statistics,merge" ).split( ',' );
 }
 
 QString QgsAggregateAlgorithm::group() const


### PR DESCRIPTION
I searched for it last week using ``merge`` as search parameter as I wanted to present how a polygon layer can be merged by aggregating the attributes but I couldn't find it. It took some time until I got right the right search term.