### PR TITLE
use Ctrl+: shortcut for Toggle Comment action on Windows (fix #63429)

### DIFF
--- a/src/gui/qgsshortcutsmanager.cpp
+++ b/src/gui/qgsshortcutsmanager.cpp
@@ -45,7 +45,12 @@ QgsShortcutsManager::QgsShortcutsManager( QObject *parent, const QString &settin
     registerAction( action, sequence, section );
     mCommonActions.insert( static_cast< int >( commonAction ), action );
   };
+
+#ifdef Q_OS_WIN
+  registerCommonAction( CommonAction::CodeToggleComment, QgsApplication::getThemeIcon( u"console/iconCommentEditorConsole.svg"_s, QgsApplication::palette().color( QPalette::ColorRole::WindowText ) ), tr( "Toggle Comment" ), tr( "Toggle comment" ), u"Ctrl+:"_s, u"mEditorToggleComment"_s, u"Editor"_s );
+#else
   registerCommonAction( CommonAction::CodeToggleComment, QgsApplication::getThemeIcon( u"console/iconCommentEditorConsole.svg"_s, QgsApplication::palette().color( QPalette::ColorRole::WindowText ) ), tr( "Toggle Comment" ), tr( "Toggle comment" ), u"Ctrl+/"_s, u"mEditorToggleComment"_s, u"Editor"_s );
+#endif
   registerCommonAction( CommonAction::CodeReformat, QgsApplication::getThemeIcon( u"console/iconFormatCode.svg"_s ), tr( "Reformat Code" ), tr( "Reformat code" ), u"Ctrl+Alt+F"_s, u"mEditorReformatCode"_s, u"Editor"_s );
   registerCommonAction( CommonAction::CodeRunScript, QgsApplication::getThemeIcon( u"mActionStart.svg"_s ), tr( "Run Script" ), tr( "Run entire script" ), u"Ctrl+Shift+E"_s, u"mEditorRunScript"_s, u"Editor"_s );
   registerCommonAction( CommonAction::CodeRunSelection, QgsApplication::getThemeIcon( u"mActionRunSelected.svg"_s ), tr( "Run Selection" ), tr( "Run selected part of script" ), u"Ctrl+E"_s, u"mEditorRunSelection"_s, u"Editor"_s );

--- a/tests/src/python/test_qgscodeeditorpython.py
+++ b/tests/src/python/test_qgscodeeditorpython.py
@@ -11,6 +11,7 @@ __date__ = "31/03/2023"
 __copyright__ = "Copyright 2023, The QGIS Project"
 
 
+import os
 from qgis.PyQt.QtCore import QCoreApplication, Qt
 from qgis.PyQt.QtTest import QTest
 from qgis.core import QgsSettings
@@ -182,25 +183,38 @@ class TestQgsCodeEditorPython(QgisTestCase):
 
         # Check single line comment
         editor.setText("#Hello World")
-        QTest.keyClick(editor, "/", Qt.KeyboardModifier.ControlModifier)
+        if os.name == "nt":
+            QTest.keyClick(editor, ":", Qt.KeyboardModifier.ControlModifier)
+        else:
+            QTest.keyClick(editor, "/", Qt.KeyboardModifier.ControlModifier)
         self.assertEqual(editor.text(), "Hello World")
-        QTest.keyClick(editor, "/", Qt.KeyboardModifier.ControlModifier)
+        if os.name == "nt":
+            QTest.keyClick(editor, ":", Qt.KeyboardModifier.ControlModifier)
+        else:
+            QTest.keyClick(editor, "/", Qt.KeyboardModifier.ControlModifier)
         self.assertEqual(editor.text(), "# Hello World")
 
         # Check multiline comment
         editor.setText("Hello\nQGIS\nWorld")
         editor.setSelection(0, 0, 1, 4)
-        QTest.keyClick(editor, "/", Qt.KeyboardModifier.ControlModifier)
+
+        # on Windows Ctrl+/ does not work, so we stick with original Ctrl+:
+        # see https://github.com/qgis/QGIS/issues/63429
+        toggle_comment_key = "/"
+        if os.name == "nt":
+            toggle_comment_key = ":"
+
+        QTest.keyClick(editor, toggle_comment_key, Qt.KeyboardModifier.ControlModifier)
         self.assertEqual(editor.text(), "# Hello\n# QGIS\nWorld")
-        QTest.keyClick(editor, "/", Qt.KeyboardModifier.ControlModifier)
+        QTest.keyClick(editor, toggle_comment_key, Qt.KeyboardModifier.ControlModifier)
         self.assertEqual(editor.text(), "Hello\nQGIS\nWorld")
 
         # Check multiline comment with already commented lines
         editor.setText("Hello\n# QGIS\nWorld")
         editor.setSelection(0, 0, 2, 4)
-        QTest.keyClick(editor, "/", Qt.KeyboardModifier.ControlModifier)
+        QTest.keyClick(editor, toggle_comment_key, Qt.KeyboardModifier.ControlModifier)
         self.assertEqual(editor.text(), "# Hello\n# # QGIS\n# World")
-        QTest.keyClick(editor, "/", Qt.KeyboardModifier.ControlModifier)
+        QTest.keyClick(editor, toggle_comment_key, Qt.KeyboardModifier.ControlModifier)
         self.assertEqual(editor.text(), "Hello\n# QGIS\nWorld")
 
 

--- a/tests/src/python/test_qgsshortcutsmanager.py
+++ b/tests/src/python/test_qgsshortcutsmanager.py
@@ -10,6 +10,7 @@ __author__ = "Nyall Dawson"
 __date__ = "28/05/2016"
 __copyright__ = "Copyright 2016, The QGIS Project"
 
+import os
 from typing import List
 
 from qgis.PyQt.QtCore import QCoreApplication, QObject, QEvent
@@ -508,9 +509,19 @@ class TestQgsShortcutsManager(QgisTestCase):
             == QgsShortcutsManager.CommonAction.CodeToggleComment.value
         ][0]
         self.assertEqual(toggle_code_comment_action.text(), "Toggle Comment")
-        self.assertEqual(toggle_code_comment_action.shortcut().toString(), "Ctrl+/")
+
+        # on Windows Ctrl+/ does not work, so we stick with original Ctrl+:
+        # see https://github.com/qgis/QGIS/issues/63429
+        toggle_comment_shortcut = "Ctrl+/"
+        if os.name == "nt":
+            toggle_comment_shortcut = "Ctrl+:"
+
         self.assertEqual(
-            toggle_code_comment_action.toolTip(), "<b>Toggle comment</b> (Ctrl+/)"
+            toggle_code_comment_action.shortcut().toString(), toggle_comment_shortcut
+        )
+        self.assertEqual(
+            toggle_code_comment_action.toolTip(),
+            f"<b>Toggle comment</b> ({toggle_comment_shortcut})",
         )
 
         self.assertEqual(
@@ -523,7 +534,7 @@ class TestQgsShortcutsManager(QgisTestCase):
             s.sequenceForCommonAction(
                 QgsShortcutsManager.CommonAction.CodeToggleComment
             ).toString(),
-            "Ctrl+/",
+            toggle_comment_shortcut,
         )
 
         # link an action to a common action
@@ -552,9 +563,12 @@ class TestQgsShortcutsManager(QgisTestCase):
             my_toggle_comment_action, QgsShortcutsManager.CommonAction.CodeToggleComment
         )
         self.assertEqual(my_toggle_comment_action.text(), "Toggle Comment")
-        self.assertEqual(my_toggle_comment_action.shortcut().toString(), "Ctrl+/")
         self.assertEqual(
-            my_toggle_comment_action.toolTip(), "<b>Toggle comment</b> (Ctrl+/)"
+            my_toggle_comment_action.shortcut().toString(), toggle_comment_shortcut
+        )
+        self.assertEqual(
+            my_toggle_comment_action.toolTip(),
+            f"<b>Toggle comment</b> ({toggle_comment_shortcut})",
         )
 
         # change shortcut
@@ -563,7 +577,9 @@ class TestQgsShortcutsManager(QgisTestCase):
         self.assertEqual(my_reformat_action1.toolTip(), "<b>Reformat code</b> (B)")
         self.assertEqual(my_reformat_action2.shortcut().toString(), "B")
         self.assertEqual(my_reformat_action2.toolTip(), "<b>Reformat code</b> (B)")
-        self.assertEqual(my_toggle_comment_action.shortcut().toString(), "Ctrl+/")
+        self.assertEqual(
+            my_toggle_comment_action.shortcut().toString(), toggle_comment_shortcut
+        )
 
         self.assertEqual(
             s.sequenceForCommonAction(
@@ -575,7 +591,7 @@ class TestQgsShortcutsManager(QgisTestCase):
             s.sequenceForCommonAction(
                 QgsShortcutsManager.CommonAction.CodeToggleComment
             ).toString(),
-            "Ctrl+/",
+            toggle_comment_shortcut,
         )
 
         s.setKeySequence(toggle_code_comment_action, "C")


### PR DESCRIPTION
## Description

The `Ctrl+/` shortcut seems does not work on Windows. Restore original `Ctrl+:` shortcut for the Toggle Comment action in the code editor for Windows and use `Ctrl+/` on all other platforms.

Fixes #63429.