### PR TITLE
Fix missing QgsProcessingException and other exceptions in type stubs

### DIFF
--- a/python/core/__init__.py.in
+++ b/python/core/__init__.py.in
@@ -23,6 +23,19 @@ __copyright__ = '(C) 2014, Nathan Woodrow'
 
 import typing as _typing
 
+if _typing.TYPE_CHECKING:
+    # Exception classes that SIP doesn't export to stub files properly
+    # These are available at runtime from qgis._core but need explicit
+    # type hints for IDE support (see issue #63592)
+    from qgis._core import (
+        QgsException,
+        QgsCsException,
+        QgsProcessingException,
+        QgsProviderConnectionException,
+        QgsNotSupportedException,
+        QgsSettingsException,
+    )
+
 from qgis.PyQt.QtCore import NULL
 from qgis.PyQt.QtCore import Qt as _Qt
 from qgis.PyQt.QtCore import QMetaType as _QMetaType


### PR DESCRIPTION
fixes #63592.

- QgsProcessingException was missing from IDE autocomplete
- Other exception classes had the same issue
- These exceptions work at runtime but lack type information
- TYPE_CHECKING block provides IDE support without runtime impact

This fix:
- Adds explicit type hints for all SIP exception classes
- Protected by TYPE_CHECKING to avoid runtime overhead
- 100% backwards compatible
- Improves IDE support for PyQGIS developers

## Summary

This PR fixes missing exception classes in QGIS Python type stubs, improving IDE autocomplete and type checking support for PyQGIS developers. The fix addresses `QgsProcessingException` and other SIP exception classes that exist at runtime but are missing from the autogenerated `.pyi` stub files.

### User-Reported Issue

Users reported that IDEs (PyCharm, VS Code with Pylance) show false errors when importing `QgsProcessingException`:

```python
from qgis.core import QgsProcessingException  # IDE shows error, but code works
```

The exception is documented in the API docs:  
https://qgis.org/pyqgis/3.44/core/QgsProcessingException.html

### Root Cause

1. QGIS uses SIP to generate Python bindings from C++ code
2. SIP automatically generates `.pyi` stub files for IDE type checking
3. Exception classes are defined as `%Exception` in SIP (special handling)
4. SIP's stub generator doesn't export these exception types to `.pyi` files
5. At runtime, exceptions work fine (imported via `from qgis._core import *`)
6. IDEs see only the stub files, not runtime behavior

**Affected Exception Classes:**
- `QgsProcessingException`
- `QgsCsException`
- `QgsProviderConnectionException`
- `QgsNotSupportedException`
- `QgsSettingsException`
- `QgsException`