### PR TITLE
Fix virtual raster provider copy constructor memory leak

### DIFF
--- a/src/providers/virtualraster/qgsvirtualrasterprovider.cpp
+++ b/src/providers/virtualraster/qgsvirtualrasterprovider.cpp
@@ -132,6 +132,7 @@ QgsVirtualRasterProvider::QgsVirtualRasterProvider( const QgsVirtualRasterProvid
   for ( const auto &it : other.mRasterLayers )
   {
     QgsRasterLayer *rcProvidedLayer = it->clone();
+    mRasterLayers << rcProvidedLayer;
     for ( int j = 0; j < rcProvidedLayer->bandCount(); ++j )
     {
       QgsRasterCalculatorEntry entry;

--- a/src/providers/virtualraster/qgsvirtualrasterprovider.cpp
+++ b/src/providers/virtualraster/qgsvirtualrasterprovider.cpp
@@ -95,7 +95,7 @@ QgsVirtualRasterProvider::QgsVirtualRasterProvider( const QString &uri, const Qg
       continue;
     }
 
-    //this var is not useful right now except for the copy constructor
+    // mRasterLayers owns the layer lifetime, freed in the destructor
     mRasterLayers << rProvidedLayer;
 
     for ( int j = 0; j < rProvidedLayer->bandCount(); ++j )


### PR DESCRIPTION
Follow-up to #64785 — fixes #64559

Cloned `QgsRasterLayer` objects in the copy constructor were never added to `mRasterLayers`, so the destructor never freed them. Each `clone()` call from the rendering pipeline leaked all source layers.

One-line fix: `mRasterLayers << rcProvidedLayer;`