### PR TITLE
show message if algorithm can not be executed from the Processing history because of the missed provider (fix #63757)

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgsprocessinghistoryprovider.py
+++ b/python/PyQt6/gui/auto_additions/qgsprocessinghistoryprovider.py
@@ -1,8 +1,8 @@
 # The following has been generated automatically from src/gui/processing/qgsprocessinghistoryprovider.h
 try:
-    QgsProcessingHistoryProvider.__attribute_docs__ = {'executePython': 'Emitted when the provider needs to execute python ``commands`` in the\nProcessing context.\n\n.. versionadded:: 3.32\n', 'createTest': 'Emitted when the provider needs to create a Processing test with the\ngiven python ``command``.\n\n.. versionadded:: 3.32\n'}
+    QgsProcessingHistoryProvider.__attribute_docs__ = {'executePython': 'Emitted when the provider needs to execute python ``commands`` in the\nProcessing context.\n\n.. versionadded:: 3.32\n', 'createTest': 'Emitted when the provider needs to create a Processing test with the\ngiven python ``command``.\n\n.. versionadded:: 3.32\n', 'showMessage': 'Emitted when the provider needs to display a ``message``.\n\n.. versionadded:: 4.0\n'}
     QgsProcessingHistoryProvider.__overridden_methods__ = ['id', 'createNodeForEntry', 'updateNodeForEntry']
-    QgsProcessingHistoryProvider.__signal_arguments__ = {'executePython': ['commands: str'], 'createTest': ['command: str']}
+    QgsProcessingHistoryProvider.__signal_arguments__ = {'executePython': ['commands: str'], 'createTest': ['command: str'], 'showMessage': ['message: str']}
     QgsProcessingHistoryProvider.__group__ = ['processing']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessinghistoryprovider.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessinghistoryprovider.sip.in
@@ -56,6 +56,13 @@ given python ``command``.
 .. versionadded:: 3.32
 %End
 
+    void showMessage( const QString &message );
+%Docstring
+Emitted when the provider needs to display a ``message``.
+
+.. versionadded:: 4.0
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_additions/qgsprocessinghistoryprovider.py
+++ b/python/gui/auto_additions/qgsprocessinghistoryprovider.py
@@ -1,8 +1,8 @@
 # The following has been generated automatically from src/gui/processing/qgsprocessinghistoryprovider.h
 try:
-    QgsProcessingHistoryProvider.__attribute_docs__ = {'executePython': 'Emitted when the provider needs to execute python ``commands`` in the\nProcessing context.\n\n.. versionadded:: 3.32\n', 'createTest': 'Emitted when the provider needs to create a Processing test with the\ngiven python ``command``.\n\n.. versionadded:: 3.32\n'}
+    QgsProcessingHistoryProvider.__attribute_docs__ = {'executePython': 'Emitted when the provider needs to execute python ``commands`` in the\nProcessing context.\n\n.. versionadded:: 3.32\n', 'createTest': 'Emitted when the provider needs to create a Processing test with the\ngiven python ``command``.\n\n.. versionadded:: 3.32\n', 'showMessage': 'Emitted when the provider needs to display a ``message``.\n\n.. versionadded:: 4.0\n'}
     QgsProcessingHistoryProvider.__overridden_methods__ = ['id', 'createNodeForEntry', 'updateNodeForEntry']
-    QgsProcessingHistoryProvider.__signal_arguments__ = {'executePython': ['commands: str'], 'createTest': ['command: str']}
+    QgsProcessingHistoryProvider.__signal_arguments__ = {'executePython': ['commands: str'], 'createTest': ['command: str'], 'showMessage': ['message: str']}
     QgsProcessingHistoryProvider.__group__ = ['processing']
 except (NameError, AttributeError):
     pass

--- a/python/gui/auto_generated/processing/qgsprocessinghistoryprovider.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessinghistoryprovider.sip.in
@@ -56,6 +56,13 @@ given python ``command``.
 .. versionadded:: 3.32
 %End
 
+    void showMessage( const QString &message );
+%Docstring
+Emitted when the provider needs to display a ``message``.
+
+.. versionadded:: 4.0
+%End
+
 };
 
 /************************************************************************

--- a/src/gui/processing/qgsprocessinghistoryprovider.cpp
+++ b/src/gui/processing/qgsprocessinghistoryprovider.cpp
@@ -114,6 +114,12 @@ class ProcessingHistoryBaseNode : public QgsHistoryEntryGroup
       if ( mPythonCommand.isEmpty() )
         return true;
 
+      if ( !QgsApplication::processingRegistry()->algorithmById( mAlgorithmId ) )
+      {
+        mProvider->emitShowMessage( QObject::tr( "Could not find algorithm '%1'. Check if corresponding algorithm provider is enabled." ).arg( mAlgorithmId ) );
+        return true;
+      }
+
       QString execAlgorithmDialogCommand = mPythonCommand;
       execAlgorithmDialogCommand.replace( "processing.run("_L1, "processing.execAlgorithmDialog("_L1 );
 
@@ -443,4 +449,9 @@ void QgsProcessingHistoryProvider::emitExecute( const QString &commands )
 void QgsProcessingHistoryProvider::emitCreateTest( const QString &command )
 {
   emit createTest( command );
+}
+
+void QgsProcessingHistoryProvider::emitShowMessage( const QString &message )
+{
+  emit showMessage( message );
 }

--- a/src/gui/processing/qgsprocessinghistoryprovider.h
+++ b/src/gui/processing/qgsprocessinghistoryprovider.h
@@ -61,11 +61,22 @@ class GUI_EXPORT QgsProcessingHistoryProvider : public QgsAbstractHistoryProvide
      */
     void createTest( const QString &command );
 
+    /**
+     * Emitted when the provider needs to display a \a message.
+     *
+     * \since QGIS 4.0
+     */
+    void showMessage( const QString &message );
+
   private:
     //! Executes some python commands
     void emitExecute( const QString &commands );
 
+    //! Creates a test for a python commands
     void emitCreateTest( const QString &command );
+
+    //! Shows a message to user
+    void emitShowMessage( const QString &message );
 
     //! Returns the path to the old log file
     QString oldLogPath() const;

--- a/src/gui/processing/qgsprocessinghistorywidget.cpp
+++ b/src/gui/processing/qgsprocessinghistorywidget.cpp
@@ -21,6 +21,7 @@
 #include "qgshistoryentry.h"
 #include "qgshistoryproviderregistry.h"
 #include "qgshistorywidget.h"
+#include "qgsprocessinghistoryprovider.h"
 
 #include <QDialogButtonBox>
 #include <QFileDialog>
@@ -97,6 +98,10 @@ QgsProcessingHistoryDialog::QgsProcessingHistoryDialog( QWidget *parent )
   setWindowTitle( tr( "Processing History" ) );
 
   QVBoxLayout *vl = new QVBoxLayout();
+
+  mMessageBar = new QgsMessageBar();
+  vl->addWidget( mMessageBar );
+
   mWidget = new QgsProcessingHistoryWidget();
   vl->addWidget( mWidget, 1 );
 
@@ -114,6 +119,8 @@ QgsProcessingHistoryDialog::QgsProcessingHistoryDialog( QWidget *parent )
   connect( saveButton, &QPushButton::clicked, mWidget, &QgsProcessingHistoryWidget::saveLog );
   connect( mButtonBox->button( QDialogButtonBox::Help ), &QPushButton::clicked, mWidget, &QgsProcessingHistoryWidget::openHelp );
   connect( mButtonBox->button( QDialogButtonBox::Close ), &QPushButton::clicked, mWidget, [this]() { close(); } );
+  auto *provider = qgis::down_cast<QgsProcessingHistoryProvider *>( QgsGui::historyProviderRegistry()->providerById( u"processing"_s ) );
+  connect( provider, &QgsProcessingHistoryProvider::showMessage, mMessageBar, [this]( const QString &message ) { mMessageBar->pushMessage( message, Qgis::MessageLevel::Warning ); } );
 
   vl->addWidget( mButtonBox );
 

--- a/src/gui/processing/qgsprocessinghistorywidget.h
+++ b/src/gui/processing/qgsprocessinghistorywidget.h
@@ -18,6 +18,7 @@
 
 #include "qgis.h"
 #include "qgis_gui.h"
+#include "qgsmessagebar.h"
 #include "qgspanelwidget.h"
 
 #include <QDialog>
@@ -80,6 +81,7 @@ class GUI_EXPORT QgsProcessingHistoryDialog : public QDialog
   private:
     QgsProcessingHistoryWidget *mWidget = nullptr;
     QDialogButtonBox *mButtonBox = nullptr;
+    QgsMessageBar *mMessageBar = nullptr;
 };
 
 #endif // QGSPROCESSINGHISTORYWIDGET_H


### PR DESCRIPTION
## Description

If Processing provider was removed/deactivated, re-running algorithm from that provider from the Processing History dialog will silently fail.

This PR adds a message bar to the Processing History dialog and when user tries to re-run unavailable algorithm, they will get a message "Could not find algorithm X. Check if corresponding algorithm provider is enabled."

<img width="940" height="587" alt="message" src="https://github.com/user-attachments/assets/1d84d86f-51c0-413a-a79f-69c72615008c" />

Fixes #63757.