### PR TITLE
improve how Processing algorithms from unloaded provider are shown in the history

### DIFF
--- a/src/gui/processing/qgsprocessinghistoryprovider.cpp
+++ b/src/gui/processing/qgsprocessinghistoryprovider.cpp
@@ -387,7 +387,7 @@ class ProcessingHistoryRootNode : public ProcessingHistoryBaseNode
       {
         case Qt::DisplayRole:
         {
-          const QString algName = mAlgorithmInformation.displayName;
+          const QString algName = mAlgorithmInformation.displayName.isEmpty() ? mAlgorithmId : mAlgorithmInformation.displayName;
           if ( !mDescription.isEmpty() )
             return u"[%1] %2 - %3"_s.arg( mEntry.timestamp.toString( u"yyyy-MM-dd hh:mm"_s ), algName, mDescription );
           else
@@ -396,7 +396,7 @@ class ProcessingHistoryRootNode : public ProcessingHistoryBaseNode
 
         case Qt::DecorationRole:
         {
-          return mAlgorithmInformation.icon;
+          return mAlgorithmInformation.icon.isNull() ? QgsApplication::getThemeIcon( u"processingAlgorithm.svg"_s ) : mAlgorithmInformation.icon;
         }
 
         default:


### PR DESCRIPTION
## Description

If Processing provider is unloaded, history entries for its algorithms appear without an icon and algorithm name making it difficult to find entries and making the whole history look inconsistent.

<img width="938" height="585" alt="before" src="https://github.com/user-attachments/assets/d80765e8-1339-4c90-a918-da7beedfb1d3" />

If we can't obtain algorithm details from the registry, fallback to use generic algorithm icon and algorithm ID instead of the algorithm name.

<img width="938" height="587" alt="after" src="https://github.com/user-attachments/assets/0067faac-7adf-40ad-bd03-57c2e55ade9f" />
