### PR TITLE
fix(LayerStyleWidget): fix memory leak

### DIFF
--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -492,6 +492,7 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
     else
     {
       delete current;
+      current = nullptr;
     }
   }
 

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -489,6 +489,10 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
     {
       mDiagramWidget = widget;
     }
+    else
+    {
+      delete current;
+    }
   }
 
   mWidgetStack->clear();


### PR DESCRIPTION
QgsPanelWidget::takeMainPanel() release ownership of the widget so we need to delete it

I'm pretty sure that the above widget pointers need to be deleted later also, but it's unclear to me how we use these pointers. It seems that we backup them for later reuse to speed up widget creation ( [here](https://github.com/qgis/QGIS/blob/05f3ecee1e829289c32e474148b3bbf6ebca0e4d/src/app/qgslayerstylingwidget.cpp#L549) for instance ) but sometime we [don't](https://github.com/qgis/QGIS/blob/05f3ecee1e829289c32e474148b3bbf6ebca0e4d/src/app/qgslayerstylingwidget.cpp#L587). And sometime, it's not just a backup, we actually use the [pointer](https://github.com/qgis/QGIS/blob/05f3ecee1e829289c32e474148b3bbf6ebca0e4d/src/app/qgslayerstylingwidget.cpp#L427). So this part needs more testing and rewrite.

**Funded by Stadt Frankfurt am Main and Oslandia**
