### PR TITLE
[GUI] processing: fix master regression when selecting raster output filename in translated application

### DIFF
--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -7155,6 +7155,9 @@ QString QgsProcessingParameterRasterDestination::createFileFilter() const
 {
   QStringList filters;
   const QList<QPair<QString, QString>> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
+  // Note: the returned filter list MUST be in the same order as the output
+  // of supportedOutputRasterLayerFormatAndExtensions(), otherwise
+  // QgsProcessingLayerOutputDestinationWidget::selectFile() will misbehave.
   for ( const QPair<QString, QString> &formatAndExt : std::as_const( formatAndExtensions ) )
   {
     QString format = formatAndExt.first;

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -475,10 +475,18 @@ void QgsProcessingLayerOutputDestinationWidget::selectFile()
     mUseRemapping = false;
     if ( mParameter->type() == QgsProcessingParameterRasterDestination::typeName() )
     {
-      int spacePos = static_cast<int>( lastFilter.indexOf( ' ' ) );
-      if ( spacePos > 0 )
+      const QgsProcessingParameterRasterDestination *rasterParam = static_cast<const QgsProcessingParameterRasterDestination *>( mParameter );
+      const QList<QPair<QString, QString>> formatAndExtensions = rasterParam->supportedOutputRasterLayerFormatAndExtensions();
+      Q_ASSERT( formatAndExtensions.size() + 1 == filters.size() ); // filters have one more entry for all files
+      int idxFilter = 0;
+      for ( const QString &f : filters )
       {
-        mFormat = lastFilter.left( spacePos );
+        if ( f == lastFilter )
+        {
+          mFormat = formatAndExtensions[idxFilter].first;
+          break;
+        }
+        ++idxFilter;
       }
     }
     filename = QgsFileUtils::addExtensionFromFilter( filename, lastFilter );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -8520,6 +8520,15 @@ void TestQgsProcessing::parameterRasterOut()
   QVERIFY( !def->createFileFilter().contains( u"*.2dm"_s ) );
   QVERIFY( def->createFileFilter().contains( u"*.*"_s ) );
 
+  const QStringList filters = def->createFileFilter().split( u";;"_s );
+  const QList<QPair<QString, QString>> formatAndExtensions = def->supportedOutputRasterLayerFormatAndExtensions();
+  QCOMPARE( filters.size(), formatAndExtensions.size() + 1 ); // filters have one more entry for all files
+  for ( qsizetype i = 0; i < formatAndExtensions.size(); ++i )
+  {
+    QVERIFY( filters[i].contains( formatAndExtensions[i].first.toUpper() ) );
+    QVERIFY( filters[i].contains( formatAndExtensions[i].second ) );
+  }
+
   QVariantMap params;
   params.insert( "non_optional", "test.tif" );
   QCOMPARE( QgsProcessingParameters::parameterAsOutputLayer( def.get(), params, context ), u"test.tif"_s );


### PR DESCRIPTION
Fixes #64804 , regression introduced in https://github.com/qgis/QGIS/pull/64226

Avoid making assumption on the values of filters and rely instead on QgsProcessingParameterRasterDestination::supportedOutputRasterLayerFormatAndExtensions()
