### PR TITLE
Fix warning on release builds without OpenCL

### DIFF
--- a/python/PyQt6/analysis/auto_additions/qgsrastercalculator.py
+++ b/python/PyQt6/analysis/auto_additions/qgsrastercalculator.py
@@ -26,7 +26,7 @@ QgsRasterCalculator.CalculationError.is_monkey_patched = True
 QgsRasterCalculator.CalculationError.__doc__ = "Error occurred while performing calculation"
 QgsRasterCalculator.OpenCLKernelBuildError = QgsRasterCalculator.Result.OpenCLKernelBuildError
 QgsRasterCalculator.OpenCLKernelBuildError.is_monkey_patched = True
-QgsRasterCalculator.OpenCLKernelBuildError.__doc__ = "Error building OpenCL kernel"
+QgsRasterCalculator.OpenCLKernelBuildError.__doc__ = "Error building OpenCL kernel. \n.. versionadded:: 4.0"
 QgsRasterCalculator.Result.__doc__ = """Result of the calculation
 
 * ``Success``: Calculation successful
@@ -37,7 +37,10 @@ QgsRasterCalculator.Result.__doc__ = """Result of the calculation
 * ``MemoryError``: Error allocating memory for result
 * ``BandError``: Invalid band number for input
 * ``CalculationError``: Error occurred while performing calculation
-* ``OpenCLKernelBuildError``: Error building OpenCL kernel
+* ``OpenCLKernelBuildError``: Error building OpenCL kernel.
+
+  .. versionadded:: 4.0
+
 
 """
 # --

--- a/python/analysis/auto_additions/qgsrastercalculator.py
+++ b/python/analysis/auto_additions/qgsrastercalculator.py
@@ -26,7 +26,7 @@ QgsRasterCalculator.CalculationError.is_monkey_patched = True
 QgsRasterCalculator.CalculationError.__doc__ = "Error occurred while performing calculation"
 QgsRasterCalculator.OpenCLKernelBuildError = QgsRasterCalculator.Result.OpenCLKernelBuildError
 QgsRasterCalculator.OpenCLKernelBuildError.is_monkey_patched = True
-QgsRasterCalculator.OpenCLKernelBuildError.__doc__ = "Error building OpenCL kernel"
+QgsRasterCalculator.OpenCLKernelBuildError.__doc__ = "Error building OpenCL kernel. \n.. versionadded:: 4.0"
 QgsRasterCalculator.Result.__doc__ = """Result of the calculation
 
 * ``Success``: Calculation successful
@@ -37,7 +37,10 @@ QgsRasterCalculator.Result.__doc__ = """Result of the calculation
 * ``MemoryError``: Error allocating memory for result
 * ``BandError``: Invalid band number for input
 * ``CalculationError``: Error occurred while performing calculation
-* ``OpenCLKernelBuildError``: Error building OpenCL kernel
+* ``OpenCLKernelBuildError``: Error building OpenCL kernel.
+
+  .. versionadded:: 4.0
+
 
 """
 # --

--- a/src/analysis/raster/qgsrastercalculator.h
+++ b/src/analysis/raster/qgsrastercalculator.h
@@ -87,7 +87,7 @@ class ANALYSIS_EXPORT QgsRasterCalculator
       MemoryError = 5,           //!< Error allocating memory for result
       BandError = 6,             //!< Invalid band number for input
       CalculationError = 7,      //!< Error occurred while performing calculation
-      OpenCLKernelBuildError = 8 //!< Error building OpenCL kernel
+      OpenCLKernelBuildError = 8 //!< Error building OpenCL kernel. \since QGIS 4.0
     };
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6332,11 +6332,9 @@ void QgisApp::showRasterCalculator()
       case QgsRasterCalculator::Result::CalculationError:
         visibleMessageBar()->pushMessage( tr( "Raster calculator" ), tr( "An error occurred while performing the calculation." ), Qgis::MessageLevel::Critical );
         break;
-#ifdef HAVE_OPENCL
       case QgsRasterCalculator::Result::OpenCLKernelBuildError:
         visibleMessageBar()->pushMessage( tr( "Raster calculator" ), tr( "An error occurred while performing the calculation using OpenCL. See OpenCL log messages for details." ), Qgis::MessageLevel::Critical );
         break;
-#endif
     }
     p.hide();
   }


### PR DESCRIPTION
The enum value is unconditionally defined, so if we don't handle it for builds without OpenCL we'll get a warning.
