### PR TITLE
Improve help of concat function and || and + operators

### DIFF
--- a/resources/function_help/json/concat
+++ b/resources/function_help/json/concat
@@ -2,7 +2,7 @@
   "name": "concat",
   "type": "function",
   "groups": ["String"],
-  "description": "Concatenates several strings to one. NULL values are converted to empty strings. Other values (like numbers) are converted to strings.<br><br>See also: the <b>||</b> operator, which also concatenates strings but propagates NULL values according to the SQL-standard (if any operand is NULL, the result is NULL).<br><br>Use <b>concat()</b> when you want NULLs treated as empty strings, or <b>||</b> when NULL should make the entire result NULL.",
+  "description": "Concatenates several values to a single string. NULL values are converted to empty strings. Other values (like numbers) are converted to strings.<br><br>See the <b>||</b> function for a different behavior.",
   "variableLenArguments": true,
   "arguments": [{
     "arg": "string1",

--- a/resources/function_help/json/concat
+++ b/resources/function_help/json/concat
@@ -2,7 +2,7 @@
   "name": "concat",
   "type": "function",
   "groups": ["String"],
-  "description": "Concatenates several strings to one. NULL values are converted to empty strings. Other values (like numbers) are converted to strings.",
+  "description": "Concatenates several strings to one. NULL values are converted to empty strings. Other values (like numbers) are converted to strings.<br><br>See also: the <b>||</b> operator, which also concatenates strings but propagates NULL values according to the SQL-standard (if any operand is NULL, the result is NULL).<br><br>Use <b>concat()</b> when you want NULLs treated as empty strings, or <b>||</b> when NULL should make the entire result NULL.",
   "variableLenArguments": true,
   "arguments": [{
     "arg": "string1",
@@ -28,6 +28,5 @@
     "expression": "concat('The Wall', NULL)",
     "returns": "'The Wall'"
   }],
-  "notes": "See also: the || operator, which also concatenates strings but propagates NULL values according to the SQL-standard (i.e., if any operand is NULL, the result is NULL). Use concat() when you want NULLs treated as empty strings, or || when NULL should make the entire result NULL.",
   "tags": ["empty", "converted", "numbers", "concatenates", "null", "strings", "several", "other", "values"]
 }

--- a/resources/function_help/json/concat
+++ b/resources/function_help/json/concat
@@ -28,5 +28,6 @@
     "expression": "concat('The Wall', NULL)",
     "returns": "'The Wall'"
   }],
+  "notes": "See also: the || operator, which also concatenates strings but propagates NULL values according to the SQL-standard (i.e., if any operand is NULL, the result is NULL). Use concat() when you want NULLs treated as empty strings, or || when NULL should make the entire result NULL.",
   "tags": ["empty", "converted", "numbers", "concatenates", "null", "strings", "several", "other", "values"]
 }

--- a/resources/function_help/json/concat
+++ b/resources/function_help/json/concat
@@ -2,7 +2,7 @@
   "name": "concat",
   "type": "function",
   "groups": ["String"],
-  "description": "Concatenates several values to a single string. NULL values are converted to empty strings. Other values (like numbers) are converted to strings.<br><br>See the <b>||</b> function for a different behavior.",
+  "description": "Concatenates several values to a single string. NULL values are converted to empty strings. Other values (like numbers) are converted to strings.<br><br>See the <b>||</b> function for an alternative concatenation behavior.",
   "variableLenArguments": true,
   "arguments": [{
     "arg": "string1",

--- a/resources/function_help/json/op_concat
+++ b/resources/function_help/json/op_concat
@@ -2,7 +2,7 @@
   "name": "||",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Joins two values together into a string.<br><br>If one of the values is NULL the result will be NULL. See the CONCAT function for a different behavior.",
+  "description": "Joins two values together into a string.<br><br>If one of the values is NULL the result will be NULL. See the <b>concat</b> function for a different behavior.",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/resources/function_help/json/op_concat
+++ b/resources/function_help/json/op_concat
@@ -2,7 +2,7 @@
   "name": "||",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Joins two values together into a string.<br><br>If one of the values is NULL the result will be NULL. See the <b>concat</b> function for a different behavior.",
+  "description": "Joins two values together into a string.<br><br>If one of the values is NULL the result will be NULL. See the <b>concat</b> function for an alternative concatenation behavior.",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/resources/function_help/json/op_plus
+++ b/resources/function_help/json/op_plus
@@ -2,7 +2,7 @@
   "name": "+",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Addition of two values. If one of the values is NULL the result will be NULL.",
+  "description": "Addition of two values. If one of the values is NULL the result will be NULL.<br><br><b>Can also concatenate strings, but NULL handling may be unreliable in that context so WE STRONGLY RECOMMEND AGAINST IT</b>. We recommend to use for string concatenation the <b>||</b> operator (propagates NULL) or the <b>concat</b> function (treats NULL as empty string).",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/resources/function_help/json/op_plus
+++ b/resources/function_help/json/op_plus
@@ -2,7 +2,7 @@
   "name": "+",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Addition of two values. If one of the values is NULL the result will be NULL.<br><br><b>Can also concatenate strings, but NULL handling may be unreliable in that context so WE STRONGLY RECOMMEND AGAINST IT</b>. We recommend to use for string concatenation the <b>||</b> operator (propagates NULL) or the <b>concat</b> function (treats NULL as empty string).",
+  "description": "Addition of two values or concatenation of two strings.<br><br>For numeric and datetime operations, if either value is NULL the result will be NULL.<br><br>For string concatenation, NULL values from fields are treated as empty strings. Use the || operator instead if you want NULL propagation for strings.",
   "arguments": [{
     "arg": "a",
     "description": "value"
@@ -16,6 +16,12 @@
   }, {
     "expression": "5 + NULL",
     "returns": "NULL"
+  }, {
+    "expression": "'5' + NULL",
+    "returns": "NULL"
+  }, {
+    "expression": "'5' + \"name\"",
+    "returns": "'5' (if value in \"name\" field is NULL) or a concatenation of the two strings"
   }, {
     "expression": "'QGIS ' + 'ROCKS'",
     "returns": "'QGIS ROCKS'"

--- a/resources/function_help/json/op_plus
+++ b/resources/function_help/json/op_plus
@@ -2,7 +2,7 @@
   "name": "+",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Addition of two values or concatenation of two strings.<br><br>For numeric and datetime operations, if either value is NULL the result will be NULL.<br><br>For string concatenation, NULL values from fields are treated as empty strings. Use the || operator instead if you want NULL propagation for strings.",
+  "description": "Addition of two values or concatenation of two strings.<br><br>For numeric and datetime operations if either value is NULL the result will be NULL.<br><br>For string concatenation NULL values from fields are treated as empty strings. Use the || operator instead if NULL propagation for strings is required.",
   "arguments": [{
     "arg": "a",
     "description": "value"


### PR DESCRIPTION
fixes https://github.com/qgis/QGIS/issues/64634 by documenting how it should be done

See also https://github.com/qgis/QGIS/pull/1947

This is how they look, any improve suggestions are opened:

<img width="746" height="629" alt="image" src="https://github.com/user-attachments/assets/e07b1099-065b-4ebf-9fbc-8d9f02617065" />

<img width="746" height="629" alt="image" src="https://github.com/user-attachments/assets/cbe2aefc-9268-48ff-8bbd-ff72229ab49c" />

<img width="746" height="629" alt="image" src="https://github.com/user-attachments/assets/59e857ea-cb18-4b81-96a9-43cf206a8146" />
