### PR TITLE
fix layout of the preview area in the form Text Widget (fix #63961)

### DIFF
--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -681,9 +681,9 @@ void QgsAttributesFormLayoutView::onItemDoubleClicked( const QModelIndex &index 
       expressionWidgetBox->layout()->addWidget( editExpressionButton );
       layout->addWidget( text );
       QScrollArea *textPreviewBox = new QgsScrollArea();
-      textPreviewBox->setLayout( new QGridLayout );
+      textPreviewBox->setWidgetResizable( true );
       textPreviewBox->setMinimumWidth( 200 );
-      textPreviewBox->layout()->addWidget( textWrapper->widget() );
+      textPreviewBox->setWidget( textWrapper->widget() );
       //emit to load preview for the first time
       emit text->textChanged();
       textSplitter->addWidget( textPreviewBox );


### PR DESCRIPTION
## Description

As preview is a `QLabel` we should add it directly to the scroll area, if it is added via a layout, the scroll area treats it like a fixed UI.

Fixes #63961.