### PR TITLE
[3D] Move the "Disable Cross Section" action to the bottom of the menu

### DIFF
--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -280,8 +280,6 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
 
   mActionSetClippingPlanes = mCrossSectionMenu->addAction( QgsApplication::getThemeIcon( u"mActionEditCut.svg"_s ), tr( "Cross Section Tool" ), this, &Qgs3DMapCanvasWidget::setClippingPlanesOn2DCanvas );
   mActionSetClippingPlanes->setCheckable( true );
-  mActionDisableClippingPlanes = mCrossSectionMenu->addAction( QgsApplication::getThemeIcon( u"mActionEditCutDisabled.svg"_s ), tr( "Disable Cross Section" ), this, &Qgs3DMapCanvasWidget::disableCrossSection );
-  mActionDisableClippingPlanes->setDisabled( true );
 
   mClippingToleranceAction = new Qgs3DMapClippingToleranceWidgetSettingsAction( mCrossSectionMenu );
   connect( mClippingToleranceAction->toleranceSpinBox(), qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( double value ) {
@@ -309,6 +307,10 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
 
   mCrossSectionMenu->addAction( mActionNudgeLeft );
   mCrossSectionMenu->addAction( mActionNudgeRight );
+
+  mCrossSectionMenu->addSeparator();
+  mActionDisableClippingPlanes = mCrossSectionMenu->addAction( QgsApplication::getThemeIcon( u"mActionEditCutDisabled.svg"_s ), tr( "Disable Cross Section" ), this, &Qgs3DMapCanvasWidget::disableCrossSection );
+  mActionDisableClippingPlanes->setDisabled( true );
 
   // Effects Menu
   mEffectsMenu = new QMenu( this );


### PR DESCRIPTION
allowing to group all the actions/settings that draw/edit the cross section, and separate them from the destructive action

Currently the menu looks like this (there are missing icons in the screenshot - see #64829)
<img width="232" height="161" alt="image" src="https://github.com/user-attachments/assets/7a13f568-c44b-4846-a377-bd86d1c5ad53" />
This PR proposes to send the "disable cross section" entry to the end, after a horizontal separator.

BTW, is it a disable action or a delete? The cross section tool seems to have a checkbox at the left but checking/unchecking it doesn't seem to change anything in the 3D view and using the "disable..." tool just erases the cross section. No way to get it back afaict. _PS: my build is two weeks old in the case it is an already fixed issue_