### PR TITLE
Make Processing algorithm template not crash from child algorithm

### DIFF
--- a/python/plugins/processing/script/ScriptTemplate.py
+++ b/python/plugins/processing/script/ScriptTemplate.py
@@ -200,6 +200,7 @@ class ExampleProcessingAlgorithm(QgsProcessingAlgorithm):
                 },
                 context=context,
                 feedback=feedback,
+                is_child_algorithm=True,
             )["OUTPUT"]
 
         # Return the results of the algorithm. In this case our only result is


### PR DESCRIPTION
The built-in example `QgsProcessingAlgorithm` (Create New Script from Template...") does not mark its optional child algorithm with `is_child_algorithm=True`.

This crashes QGIS.