### PR TITLE
[tests] GdalAlgorithmsRasterTest: Rely on mocked WMS instead of online WMS server

### DIFF
--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -84,6 +84,7 @@ from processing.algs.gdal.slope import slope
 from processing.algs.gdal.translate import translate
 from processing.algs.gdal.viewshed import viewshed
 from processing.algs.gdal.warp import warp
+from processing.tests.TestData import wms_layer_1_3_0_frankfurt
 
 testDataPath = os.path.join(os.path.dirname(__file__), "testdata")
 
@@ -746,7 +747,18 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
             )
 
             # TEST: WMS layer and no scale, therefore NO XML
-            wms_source = "wms://contextualWMSLegend=0&crs=EPSG:25832&dpiMode=7&featureCount=10&format=image/png&layers=bplan_stadtkarte&styles&tilePixelRatio=0&url=https://planas.frankfurt.de/mapproxy/bplan_stadtkarte/service"
+            wms_layer = wms_layer_1_3_0_frankfurt("clipbyext_no_scale", "EPSG:25832")
+            self.assertTrue(wms_layer.isValid())
+            wms_source = wms_layer.publicSource()
+
+            # Setup a project to allow processing to find the WMS layer
+            project = QgsProject()
+            project.setFileName(os.path.join(outdir, "clip_by_extent_tests.qgs"))
+            project.addMapLayer(wms_layer)
+            self.assertEqual(project.count(), 1)
+
+            context.setProject(project)
+
             command = alg.getConsoleCommands(
                 {
                     "INPUT": QgsProcessingRasterLayerDefinition(wms_source),
@@ -767,7 +779,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
             #  '45.78',
             #  '-of',
             #  'JPEG',
-            #  '"contextualWMSLegend=0&crs=EPSG:25832&dpiMode=7&featureCount=10&format=image/png&layers=bplan_stadtkarte&styles&tilePixelRatio=0&url=https://planas.frankfurt.de/mapproxy/bplan_stadtkarte/service"',
+            #  '"crs=EPSG:25832&layers=bplan_stadtkarte&styles&url=file:///tmp/tmpstqn8v1p/clipbyext_no_scale_fake_qgis_http_endpoint_SERVICE=WMS_REQUEST=GetCapabilities"',
             #  '/tmp/tmpd0s9gnal/check.jpg']
             self.assertEqual(len(parts), 9)
 
@@ -1125,7 +1137,18 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
             )
 
             # TEST: WMS layer and no scale, therefore NO XML
-            wms_source = "wms://contextualWMSLegend=0&crs=EPSG:25832&dpiMode=7&featureCount=10&format=image/png&layers=bplan_stadtkarte&styles&tilePixelRatio=0&url=https://planas.frankfurt.de/mapproxy/bplan_stadtkarte/service"
+            wms_layer = wms_layer_1_3_0_frankfurt("clipbymask_no_scale", "EPSG:25832")
+            self.assertTrue(wms_layer.isValid())
+            wms_source = wms_layer.publicSource()
+
+            # Setup a project to allow processing to find the WMS layer
+            project = QgsProject()
+            project.setFileName(os.path.join(outdir, "clip_by_mask_tests.qgs"))
+            project.addMapLayer(wms_layer)
+            self.assertEqual(project.count(), 1)
+
+            context.setProject(project)
+
             command = alg.getConsoleCommands(
                 {
                     "INPUT": QgsProcessingRasterLayerDefinition(wms_source),
@@ -1143,7 +1166,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
             #  '-overwrite -of JPEG -cutline '
             #  '/docs/dev/QGIS-QT/QGIS/python/plugins/processing/tests/testdata/polys.gml '
             #  '-cl polys2 -crop_to_cutline '
-            #  '"contextualWMSLegend=0&crs=EPSG:25832&dpiMode=7&featureCount=10&format=image/png&layers=bplan_stadtkarte&styles&tilePixelRatio=0&url=https://planas.frankfurt.de/mapproxy/bplan_stadtkarte/service" '
+            #  '"crs=EPSG:25832&layers=bplan_stadtkarte&styles&url=file:///tmp/tmpstqn8v1p/clipbymask_no_scale_fake_qgis_http_endpoint_SERVICE=WMS_REQUEST=GetCapabilities" '
             #  '/tmp/tmpu8tqyhux/check.jpg']
 
             self.assertEqual(len(parts), 10)

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -749,15 +749,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
             # TEST: WMS layer and no scale, therefore NO XML
             wms_layer = wms_layer_1_3_0_frankfurt("clipbyext_no_scale", "EPSG:25832")
             self.assertTrue(wms_layer.isValid())
-            wms_source = wms_layer.publicSource()
-
-            # Setup a project to allow processing to find the WMS layer
-            project = QgsProject()
-            project.setFileName(os.path.join(outdir, "clip_by_extent_tests.qgs"))
-            project.addMapLayer(wms_layer)
-            self.assertEqual(project.count(), 1)
-
-            context.setProject(project)
+            wms_source = "wms://" + wms_layer.publicSource()
 
             command = alg.getConsoleCommands(
                 {
@@ -1139,15 +1131,7 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
             # TEST: WMS layer and no scale, therefore NO XML
             wms_layer = wms_layer_1_3_0_frankfurt("clipbymask_no_scale", "EPSG:25832")
             self.assertTrue(wms_layer.isValid())
-            wms_source = wms_layer.publicSource()
-
-            # Setup a project to allow processing to find the WMS layer
-            project = QgsProject()
-            project.setFileName(os.path.join(outdir, "clip_by_mask_tests.qgs"))
-            project.addMapLayer(wms_layer)
-            self.assertEqual(project.count(), 1)
-
-            context.setProject(project)
+            wms_source = "wms://" + wms_layer.publicSource()
 
             command = alg.getConsoleCommands(
                 {


### PR DESCRIPTION
The remote WMS server is sometimes down.

For instance, see: https://github.com/qgis/QGIS/actions/runs/20148634279/job/57840738873#step:13:1056

_Note: this PR is not touching any existent behavior, it just switches from a remote WMS server to a mocked one for improving CI._

References https://github.com/qgis/QGIS/pull/62937#issuecomment-3644310998

---

Reviving #64308 
