### PR TITLE
Fix: regression in dependent layer reload for WFS/OAPIF providers

### DIFF
--- a/editors/QtCreator/templates/wizards/qgis/qgis_test/file.cpp
+++ b/editors/QtCreator/templates/wizards/qgis/qgis_test/file.cpp
@@ -37,25 +37,33 @@ private slots:
   // Add your test methods here
 };
 
-void % { CN }
+void %
+{
+  CN
+}
 ::initTestCase()
-{
-}
+{}
 
-void % { CN }
+void %
+{
+  CN
+}
 ::cleanupTestCase()
-{
-}
+{}
 
-void % { CN }
+void %
+{
+  CN
+}
 ::init()
-{
-}
+{}
 
-void % { CN }
-::cleanup()
+void %
 {
+  CN
 }
+::cleanup()
+{}
 
 QGSTEST_MAIN( % { CN } )
 #include "%{JS: Cpp.classToFileName('%{Class}', '.moc')}"

--- a/editors/QtCreator/templates/wizards/qgis/qgis_test/file.cpp
+++ b/editors/QtCreator/templates/wizards/qgis/qgis_test/file.cpp
@@ -37,33 +37,25 @@ private slots:
   // Add your test methods here
 };
 
-void %
-{
-  CN
-}
+void % { CN }
 ::initTestCase()
-{}
-
-void %
 {
-  CN
 }
+
+void % { CN }
 ::cleanupTestCase()
-{}
-
-void %
 {
-  CN
 }
+
+void % { CN }
 ::init()
-{}
-
-void %
 {
-  CN
 }
+
+void % { CN }
 ::cleanup()
-{}
+{
+}
 
 QGSTEST_MAIN( % { CN } )
 #include "%{JS: Cpp.classToFileName('%{Class}', '.moc')}"

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -1026,7 +1026,7 @@ QgsVectorDataProvider.FeatureSymbology.is_monkey_patched = True
 QgsVectorDataProvider.FeatureSymbology.__doc__ = "Provider is able retrieve embedded symbology associated with individual features \n.. versionadded:: 3.20"
 QgsVectorDataProvider.CacheData = Qgis.VectorProviderCapability.CacheData
 QgsVectorDataProvider.CacheData.is_monkey_patched = True
-QgsVectorDataProvider.CacheData.__doc__ = "Provider caches source data and should force provider data reloads when dependent layers are committed \n.. versionadded:: 3.99"
+QgsVectorDataProvider.CacheData.__doc__ = "Provider caches source data and should force provider data reloads when dependent layers are committed \n.. versionadded:: 4.2"
 QgsVectorDataProvider.EditingCapabilities = Qgis.VectorProviderCapability.EditingCapabilities
 QgsVectorDataProvider.EditingCapabilities.is_monkey_patched = True
 QgsVectorDataProvider.EditingCapabilities.__doc__ = "Bitmask of all editing capabilities"
@@ -1077,7 +1077,7 @@ Qgis.VectorProviderCapability.__doc__ = """Vector data provider capabilities.
 
 * ``CacheData``: Provider caches source data and should force provider data reloads when dependent layers are committed
 
-  .. versionadded:: 3.99
+  .. versionadded:: 4.2
 
 * ``EditingCapabilities``: Bitmask of all editing capabilities
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -1024,6 +1024,9 @@ QgsVectorDataProvider.ReloadData.__doc__ = "Provider is able to force reload dat
 QgsVectorDataProvider.FeatureSymbology = Qgis.VectorProviderCapability.FeatureSymbology
 QgsVectorDataProvider.FeatureSymbology.is_monkey_patched = True
 QgsVectorDataProvider.FeatureSymbology.__doc__ = "Provider is able retrieve embedded symbology associated with individual features \n.. versionadded:: 3.20"
+QgsVectorDataProvider.CacheData = Qgis.VectorProviderCapability.CacheData
+QgsVectorDataProvider.CacheData.is_monkey_patched = True
+QgsVectorDataProvider.CacheData.__doc__ = "Provider caches source data and should force provider data reloads when dependent layers are committed \n.. versionadded:: 3.99"
 QgsVectorDataProvider.EditingCapabilities = Qgis.VectorProviderCapability.EditingCapabilities
 QgsVectorDataProvider.EditingCapabilities.is_monkey_patched = True
 QgsVectorDataProvider.EditingCapabilities.__doc__ = "Bitmask of all editing capabilities"
@@ -1071,6 +1074,10 @@ Qgis.VectorProviderCapability.__doc__ = """Vector data provider capabilities.
 * ``FeatureSymbology``: Provider is able retrieve embedded symbology associated with individual features
 
   .. versionadded:: 3.20
+
+* ``CacheData``: Provider caches source data and should force provider data reloads when dependent layers are committed
+
+  .. versionadded:: 3.99
 
 * ``EditingCapabilities``: Bitmask of all editing capabilities
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -368,6 +368,7 @@ The development version
       CreateLabeling,
       ReloadData,
       FeatureSymbology,
+      CacheData,
       EditingCapabilities,
     };
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -548,7 +548,7 @@ int QgisEvent = QEvent::User + 1;
       CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
       ReloadData = 1 << 26, //!< Provider is able to force reload data
       FeatureSymbology = 1 << 27, //!< Provider is able retrieve embedded symbology associated with individual features \since QGIS 3.20
-      CacheData = 1 << 28, //!< Provider caches source data and should force provider data reloads when dependent layers are committed \since QGIS 3.99
+      CacheData = 1 << 28, //!< Provider caches source data and should force provider data reloads when dependent layers are committed \since QGIS 4.2
       EditingCapabilities = AddFeatures | DeleteFeatures | ChangeAttributeValues | ChangeGeometries | AddAttributes | DeleteAttributes | RenameAttributes, //!< Bitmask of all editing capabilities
     };
     Q_ENUM( VectorProviderCapability )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -548,6 +548,7 @@ int QgisEvent = QEvent::User + 1;
       CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
       ReloadData = 1 << 26, //!< Provider is able to force reload data
       FeatureSymbology = 1 << 27, //!< Provider is able retrieve embedded symbology associated with individual features \since QGIS 3.20
+      CacheData = 1 << 28, //!< Provider caches source data and should force provider data reloads when dependent layers are committed \since QGIS 3.99
       EditingCapabilities = AddFeatures | DeleteFeatures | ChangeAttributeValues | ChangeGeometries | AddAttributes | DeleteAttributes | RenameAttributes, //!< Bitmask of all editing capabilities
     };
     Q_ENUM( VectorProviderCapability )

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -6283,6 +6283,16 @@ void QgsVectorLayer::emitDataChanged()
   mDataChangedFired = false;
 }
 
+void QgsVectorLayer::onDependencyAfterCommitChanges()
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  if ( mDataProvider && mDataProvider->capabilities().testFlag( Qgis::VectorProviderCapability::CacheData ) )
+    mDataProvider->reloadData();
+  else
+    emitDataChanged();
+}
+
 bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
@@ -6310,8 +6320,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
       disconnect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
       disconnect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
       disconnect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-      disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::emitDataChanged );
-      disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
+      disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::onDependencyAfterCommitChanges );
     }
   }
 
@@ -6335,10 +6344,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
       connect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
       connect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
       connect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-      if ( providerType() == QStringLiteral("WFS") || providerType() == QStringLiteral("OAPIF") )
-        connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::emitDataChanged );
-      else
-        connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
+      connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::onDependencyAfterCommitChanges );
     }
   }
 

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -6311,6 +6311,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
       disconnect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
       disconnect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
       disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::emitDataChanged );
+      disconnect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
     }
   }
 
@@ -6334,7 +6335,10 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
       connect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
       connect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
       connect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
-      connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::emitDataChanged );
+      if ( providerType() == QStringLiteral("WFS") || providerType() == QStringLiteral("OAPIF") )
+        connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::emitDataChanged );
+      else
+        connect( lyr, &QgsVectorLayer::afterCommitChanges, this, &QgsVectorLayer::reload );
     }
   }
 

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2832,6 +2832,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
     void onRelationsLoaded();
     void onSymbolsCounted();
     void onDirtyTransaction( const QString &sql, const QString &name );
+    void onDependencyAfterCommitChanges();
     void emitDataChanged();
 
   private:

--- a/src/providers/wfs/oapif/qgsoapifprovider.cpp
+++ b/src/providers/wfs/oapif/qgsoapifprovider.cpp
@@ -544,7 +544,7 @@ bool QgsOapifProvider::isValid() const
 
 void QgsOapifProvider::computeCapabilities( const QgsOapifItemsRequest &itemsRequest )
 {
-  mCapabilities = Qgis::VectorProviderCapability::SelectAtId | Qgis::VectorProviderCapability::ReadLayerMetadata | Qgis::VectorProviderCapability::ReloadData;
+  mCapabilities = Qgis::VectorProviderCapability::SelectAtId | Qgis::VectorProviderCapability::ReadLayerMetadata | Qgis::VectorProviderCapability::ReloadData | Qgis::VectorProviderCapability::CacheData;
 
   // Determine edition capabilities: create (POST on /items),
   // update (PUT on /items/some_id) and delete (DELETE on /items/some_id)

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1759,7 +1759,7 @@ QStringList QgsWFSProvider::insertedFeatureIds( const QDomDocument &serverRespon
 
 bool QgsWFSProvider::getCapabilities()
 {
-  mCapabilities = Qgis::VectorProviderCapability::SelectAtId | Qgis::VectorProviderCapability::ReloadData;
+  mCapabilities = Qgis::VectorProviderCapability::SelectAtId | Qgis::VectorProviderCapability::ReloadData | Qgis::VectorProviderCapability::CacheData;
 
   if ( mShared->mCaps.version.isEmpty() )
   {

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -10,7 +10,9 @@ __author__ = "Hugo Mercier"
 __date__ = "12/07/2016"
 __copyright__ = "Copyright 2016, The QGIS Project"
 
+import hashlib
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -35,6 +37,24 @@ from qgis.utils import spatialite_connect
 
 # Convenience instances in case you may need them
 start_app()
+
+
+def sanitize(endpoint, x):
+    if len(endpoint + x) > 256:
+        # print('Before: ' + endpoint + x)
+        x = x.replace("/", "_").encode()
+        ret = endpoint + hashlib.md5(x).hexdigest()
+        # print('After:  ' + ret)
+        return ret
+    ret = endpoint + x.replace("?", "_").replace("&", "_").replace("<", "_").replace(
+        ">", "_"
+    ).replace('"', "_").replace("'", "_").replace(" ", "_").replace(":", "_").replace(
+        "/", "_"
+    ).replace(
+        "\n", "_"
+    )
+    # print('Sanitize: ' + x)
+    return ret
 
 
 class TestLayerDependencies(QgisTestCase):
@@ -83,8 +103,71 @@ class TestLayerDependencies(QgisTestCase):
             f"dbname='{fn}' table=\"node2\" (geom) sql=", "_points2", "spatialite"
         )
         assert self.pointsLayer2.isValid()
+
+        self.basetestpath = tempfile.mkdtemp().replace("\\", "/")
+        endpoint = self.basetestpath + "/fake_qgis_http_endpoint_cache_data_dependency"
+
+        with open(
+            sanitize(
+                endpoint,
+                "?SERVICE=WFS?REQUEST=GetCapabilities?ACCEPTVERSIONS=2.0.0,1.1.0,1.0.0",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+<wfs:WFS_Capabilities version="2.0.0" xmlns="http://www.opengis.net/wfs/2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://schemas.opengis.net/gml/3.2" xmlns:fes="http://www.opengis.net/fes/2.0">
+  <FeatureTypeList>
+    <FeatureType>
+      <Name>my:typename</Name>
+      <Title>Title</Title>
+      <Abstract>Abstract</Abstract>
+      <DefaultCRS>urn:ogc:def:crs:EPSG::4326</DefaultCRS>
+      <WGS84BoundingBox>
+        <LowerCorner>-71.123 66.33</LowerCorner>
+        <UpperCorner>-65.32 78.3</UpperCorner>
+      </WGS84BoundingBox>
+    </FeatureType>
+  </FeatureTypeList>
+</wfs:WFS_Capabilities>"""
+            )
+
+        with open(
+            sanitize(
+                endpoint,
+                "?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename&TYPENAME=my:typename",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+<xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
+  <xsd:import namespace="http://www.opengis.net/gml/3.2"/>
+  <xsd:complexType name="typenameType">
+    <xsd:complexContent>
+      <xsd:extension base="gml:AbstractFeatureType">
+        <xsd:sequence>
+          <xsd:element maxOccurs="1" minOccurs="0" name="pk" nillable="true" type="xsd:long"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="geometryProperty" nillable="true" type="gml:PointPropertyType"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="typename" substitutionGroup="gml:_Feature" type="my:typenameType"/>
+</xsd:schema>"""
+            )
+
+        self.cachedLayer = QgsVectorLayer(
+            "url='http://"
+            + endpoint
+            + "' typename='my:typename' skipInitialGetFeature='true'",
+            "cache_data_dependent",
+            "WFS",
+        )
+        assert self.cachedLayer.isValid()
+
         QgsProject.instance().addMapLayers(
-            [self.pointsLayer, self.linesLayer, self.pointsLayer2]
+            [self.pointsLayer, self.linesLayer, self.pointsLayer2, self.cachedLayer]
         )
 
         # save the project file
@@ -98,7 +181,7 @@ class TestLayerDependencies(QgisTestCase):
     def tearDown(self):
         """Run after each test."""
         QgsProject.instance().clear()
-        pass
+        shutil.rmtree(self.basetestpath, True)
 
     def test_resetSnappingIndex(self):
         self.pointsLayer.setDependencies([])
@@ -383,6 +466,32 @@ class TestLayerDependencies(QgisTestCase):
 
         self.pointsLayer.setDependencies([])
         self.pointsLayer2.setDependencies([])
+
+    def test_cache_data_dependency_triggers_provider_reload(self):
+        self.assertTrue(
+            self.cachedLayer.dataProvider().capabilities()
+            & Qgis.VectorProviderCapability.CacheData
+        )
+
+        self.assertTrue(
+            self.cachedLayer.setDependencies([QgsMapLayerDependency(self.linesLayer.id())])
+        )
+
+        spy_cached_provider_data_changed = QSignalSpy(
+            self.cachedLayer.dataProvider().dataChanged
+        )
+
+        f = QgsFeature(self.linesLayer.fields())
+        f.setId(5)
+        geom = QgsGeometry.fromWkt("LINESTRING(0.2 0.2,0.3 0.3)")
+        f.setGeometry(geom)
+        self.linesLayer.startEditing()
+        self.linesLayer.addFeatures([f])
+        self.assertTrue(self.linesLayer.commitChanges())
+
+        self.assertEqual(len(spy_cached_provider_data_changed), 1)
+
+        self.cachedLayer.setDependencies([])
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -50,9 +50,7 @@ def sanitize(endpoint, x):
         ">", "_"
     ).replace('"', "_").replace("'", "_").replace(" ", "_").replace(":", "_").replace(
         "/", "_"
-    ).replace(
-        "\n", "_"
-    )
+    ).replace("\n", "_")
     # print('Sanitize: ' + x)
     return ret
 
@@ -474,7 +472,9 @@ class TestLayerDependencies(QgisTestCase):
         )
 
         self.assertTrue(
-            self.cachedLayer.setDependencies([QgsMapLayerDependency(self.linesLayer.id())])
+            self.cachedLayer.setDependencies(
+                [QgsMapLayerDependency(self.linesLayer.id())]
+            )
         )
 
         spy_cached_provider_data_changed = QSignalSpy(

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -1451,7 +1451,8 @@ class TestPyQgsWFSProvider(QgisTestCase, ProviderTestCase):
             | QgsVectorDataProvider.Capability.ChangeGeometries
             | QgsVectorDataProvider.Capability.DeleteFeatures
             | QgsVectorDataProvider.Capability.SelectAtId
-            | QgsVectorDataProvider.Capability.ReloadData,
+            | QgsVectorDataProvider.Capability.ReloadData
+            | QgsVectorDataProvider.Capability.CacheData,
         )
 
         (ret, _) = vl.dataProvider().addFeatures([QgsFeature()])
@@ -7352,7 +7353,8 @@ Can't recognize service requested.
             | QgsVectorDataProvider.Capability.ChangeGeometries
             | QgsVectorDataProvider.Capability.DeleteFeatures
             | QgsVectorDataProvider.Capability.SelectAtId
-            | QgsVectorDataProvider.Capability.ReloadData,
+            | QgsVectorDataProvider.Capability.ReloadData
+            | QgsVectorDataProvider.Capability.CacheData,
         )
 
         # Transaction response failure (no modifications)


### PR DESCRIPTION
## Description

Since QGIS 3.44, `QgsVectorLayer::setDependencies` no longer works correctly with the WFS provider. This regression was introduced by PR #58528, which changed the dependent layer behavior when the source layer emits `afterCommitChanges`.

Previously (up to 3.40), dependent layers performed a `reload()` on this signal. PR #58528 changed this to `emitDataChanged()` to avoid side effects discussed in that PR. However, WFS requires `reload()` to actually refresh data.

This fix adds a conditional: WFS and OAPIF providers restore the `reload()` behavior, while other providers keep using `emitDataChanged()`.