### PR TITLE
Fix availability of Merge and Split Policies when creating and editing Field Domains

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgsfielddomainwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsfielddomainwidget.sip.in
@@ -61,6 +61,13 @@ Sets if name of the field domain is editable.
 .. versionadded:: 4.0
 %End
 
+    void setPoliciesEditable( bool editable );
+%Docstring
+Sets if merge and split policies are editable.
+
+.. versionadded:: 4.0
+%End
+
   signals:
 
     void validityChanged( bool isValid );
@@ -112,6 +119,13 @@ Caller takes ownership of the returned object.
     void setNameEditable( bool editable );
 %Docstring
 Sets if name of the field domain is editable
+
+.. versionadded:: 4.0
+%End
+
+    void setPoliciesEditable( bool editable );
+%Docstring
+Sets if merge and split policies are editable.
 
 .. versionadded:: 4.0
 %End

--- a/python/gui/auto_generated/qgsfielddomainwidget.sip.in
+++ b/python/gui/auto_generated/qgsfielddomainwidget.sip.in
@@ -61,6 +61,13 @@ Sets if name of the field domain is editable.
 .. versionadded:: 4.0
 %End
 
+    void setPoliciesEditable( bool editable );
+%Docstring
+Sets if merge and split policies are editable.
+
+.. versionadded:: 4.0
+%End
+
   signals:
 
     void validityChanged( bool isValid );
@@ -112,6 +119,13 @@ Caller takes ownership of the returned object.
     void setNameEditable( bool editable );
 %Docstring
 Sets if name of the field domain is editable
+
+.. versionadded:: 4.0
+%End
+
+    void setPoliciesEditable( bool editable );
+%Docstring
+Sets if merge and split policies are editable.
 
 .. versionadded:: 4.0
 %End

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2516,6 +2516,9 @@ void QgsFieldDomainItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
       connectionUri = fileItem->path();
     }
 
+    QFileInfo itemFileInfo( item->path() );
+    bool policiesEditable = itemFileInfo.isDir() && item->name().endsWith( u".gdb"_s, Qt::CaseInsensitive );
+
     // Check if domain creation is supported
     QgsProviderMetadata *md { QgsProviderRegistry::instance()->providerMetadata( providerKey ) };
     if ( md )

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2516,8 +2516,18 @@ void QgsFieldDomainItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
       connectionUri = fileItem->path();
     }
 
-    QFileInfo itemFileInfo( item->path() );
-    bool policiesEditable = itemFileInfo.isDir() && item->name().endsWith( u".gdb"_s, Qt::CaseInsensitive );
+    bool policiesEditable = false;
+    QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( providerKey, item->path() );
+    if ( provider->isValid() )
+    {
+      if ( QgsVectorDataProvider *vectorProvider = qobject_cast<QgsVectorDataProvider *>( provider ) )
+      {
+        if ( vectorProvider->storageType() == "OpenFileGDB"_L1 )
+        {
+          policiesEditable = true;
+        }
+      }
+    }
 
     // Check if domain creation is supported
     QgsProviderMetadata *md { QgsProviderRegistry::instance()->providerMetadata( providerKey ) };

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2533,9 +2533,10 @@ void QgsFieldDomainItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
           QMenu *createFieldDomainMenu = new QMenu( tr( "New Field Domain" ), menu );
           menu->addMenu( createFieldDomainMenu );
 
-          auto createDomain = [context, itemWeakPointer = QPointer<QgsDataItem>( item ), md, connectionUri]( Qgis::FieldDomainType type ) {
+          auto createDomain = [context, itemWeakPointer = QPointer<QgsDataItem>( item ), md, connectionUri, policiesEditable]( Qgis::FieldDomainType type ) {
             QgsFieldDomainDialog dialog( type, QgisApp::instance() );
             dialog.setWindowTitle( tr( "New Field Domain" ) );
+            dialog.setPoliciesEditable( policiesEditable );
             if ( dialog.exec() )
             {
               std::unique_ptr<QgsFieldDomain> newDomain( dialog.createFieldDomain() );
@@ -2598,11 +2599,12 @@ void QgsFieldDomainItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
             QAction *editFieldDomainAction = new QAction( QObject::tr( "Edit Field Domain…" ), menu );
             menu->addAction( editFieldDomainAction );
 
-            connect( editFieldDomainAction, &QAction::triggered, this, [context, item, md, connectionUri, fieldDomainLambda = std::move( fieldDomain )] {
+            connect( editFieldDomainAction, &QAction::triggered, this, [context, item, md, connectionUri, policiesEditable, fieldDomainLambda = std::move( fieldDomain )] {
               QgsFieldDomainDialog dialog( fieldDomainLambda->type(), QgisApp::instance() );
               dialog.setWindowTitle( tr( "Edit Field Domain" ) );
               dialog.setFieldDomain( fieldDomainLambda.get() );
               dialog.setNameEditable( false );
+              dialog.setPoliciesEditable( policiesEditable );
 
               if ( dialog.exec() )
               {

--- a/src/gui/qgsfielddomainwidget.cpp
+++ b/src/gui/qgsfielddomainwidget.cpp
@@ -88,6 +88,12 @@ void QgsFieldDomainWidget::setNameEditable( bool editable )
   mNameEdit->setEnabled( editable );
 }
 
+void QgsFieldDomainWidget::setPoliciesEditable( bool editable )
+{
+  mComboSplitPolicy->setEnabled( editable );
+  mComboMergePolicy->setEnabled( editable );
+}
+
 QgsFieldDomain *QgsRangeDomainWidget::createFieldDomain( const QString &name, const QString &description, QMetaType::Type fieldType ) const
 {
   return new QgsRangeFieldDomain( name, description, fieldType, mMinSpinBox->value(), mMinInclusiveCheckBox->isChecked(), mMaxSpinBox->value(), mMaxInclusiveCheckBox->isChecked() );
@@ -122,6 +128,11 @@ void QgsGlobDomainWidget::setFieldDomain( const QgsFieldDomain *domain )
 void QgsFieldDomainDialog::setNameEditable( bool editable )
 {
   mWidget->setNameEditable( editable );
+}
+
+void QgsFieldDomainDialog::setPoliciesEditable( bool editable )
+{
+  mWidget->setPoliciesEditable( editable );
 }
 
 QgsFieldDomain *QgsGlobDomainWidget::createFieldDomain( const QString &name, const QString &description, QMetaType::Type fieldType ) const

--- a/src/gui/qgsfielddomainwidget.h
+++ b/src/gui/qgsfielddomainwidget.h
@@ -249,6 +249,13 @@ class GUI_EXPORT QgsFieldDomainWidget : public QWidget, private Ui_QgsFieldDomai
      */
     void setNameEditable( bool editable );
 
+    /**
+     * Sets if merge and split policies are editable.
+     *
+     * \since QGIS 4.0
+     */
+    void setPoliciesEditable( bool editable );
+
   signals:
 
     /**
@@ -301,6 +308,13 @@ class GUI_EXPORT QgsFieldDomainDialog : public QDialog
      * \since QGIS 4.0
      */
     void setNameEditable( bool editable );
+
+    /**
+     * Sets if merge and split policies are editable.
+     *
+     * \since QGIS 4.0
+     */
+    void setPoliciesEditable( bool editable );
 
   public slots:
 


### PR DESCRIPTION
## Description

Fixes the issue with Split and Merge Policies being editable even for provides that do not support it (GPKG). It should be only available for OpenFileGDB. Otherwise it confuses users (see the linked issue).

@rouault Would the check here be sufficient or do you think that something more elaborate is necessary? I based it on your suggestion to handle this in the GUI, but I am not completely sure that this check is enough.

Fixes: #64240
