### PR TITLE
[layouts] Add missing expression context when editing chart series

### DIFF
--- a/src/gui/layout/qgslayoutchartseriesdetailswidget.h
+++ b/src/gui/layout/qgslayoutchartseriesdetailswidget.h
@@ -32,7 +32,7 @@
  * \brief A widget for editing series details for a layout chart item.
  * \since QGIS 4.0
 */
-class GUI_EXPORT QgsLayoutChartSeriesDetailsWidget : public QgsPanelWidget, private Ui::QgsLayoutChartSeriesDetailsWidgetBase
+class GUI_EXPORT QgsLayoutChartSeriesDetailsWidget : public QgsPanelWidget, public QgsExpressionContextGenerator, private Ui::QgsLayoutChartSeriesDetailsWidgetBase
 {
     Q_OBJECT
 
@@ -58,12 +58,22 @@ class GUI_EXPORT QgsLayoutChartSeriesDetailsWidget : public QgsPanelWidget, priv
     //! Returns the filter expression
     QString filterExpression() const;
 
+    /**
+     * Register an expression context generator class that will be used to retrieve
+     * an expression context for configuration widgets when required.
+     */
+    void registerExpressionContextGenerator( QgsExpressionContextGenerator *generator );
+
+    QgsExpressionContext createExpressionContext() const override;
+
   private slots:
     void mFilterButton_clicked();
 
   private:
     QPointer<QgsVectorLayer> mVectorLayer;
     int mIndex = 0;
+
+    QgsExpressionContextGenerator *mExpressionContextGenerator = nullptr;
 };
 
 #endif // QGSLAYOUTCHARTSERIESDETAILSWIDGET_H

--- a/src/gui/layout/qgslayoutchartwidget.cpp
+++ b/src/gui/layout/qgslayoutchartwidget.cpp
@@ -372,6 +372,7 @@ void QgsLayoutChartWidget::mSeriesPropertiesButton_clicked()
   }
 
   QgsLayoutChartSeriesDetailsWidget *widget = new QgsLayoutChartSeriesDetailsWidget( mChartItem->sourceLayer(), idx, seriesList[idx], this );
+  widget->registerExpressionContextGenerator( mChartItem );
   widget->setPanelTitle( tr( "Series Details" ) );
   connect( widget, &QgsPanelWidget::widgetChanged, this, [this, widget]() {
     if ( !mChartItem )


### PR DESCRIPTION
## Description

Tittle says it all. The PR adds missing expression context (such as atlas, layout variables, etc.) when editing a layout chart item series.

<img width="697" height="475" alt="image" src="https://github.com/user-attachments/assets/a545d90f-4932-4a54-bf0f-15948d0b0a61" />
