### PR TITLE
prevent crash in the Download vector tiles algorithm when tiles can not be downloaded (fix #64791)

### DIFF
--- a/src/analysis/processing/qgsalgorithmdownloadvectortiles.cpp
+++ b/src/analysis/processing/qgsalgorithmdownloadvectortiles.cpp
@@ -204,9 +204,7 @@ QVariantMap QgsDownloadVectorTilesAlgorithm::processAlgorithm( const QVariantMap
 
       // TODO: at the moment, it handles single source only of tiles
       // takes the first one
-      const QByteArray data = rawTile.data.first();
-
-      if ( !data.isEmpty() )
+      if ( const QByteArray data = !rawTile.data.isEmpty() ? rawTile.data.first() : QByteArray(); !data.isEmpty() )
       {
         QByteArray gzipTileData;
         QgsZipUtils::encodeGzip( data, gzipTileData );


### PR DESCRIPTION
## Description

When downloading tiles at the edge of the tile layer some tiles may not exists and will return 404 error when downloading them. In that case we will end up with an empty map in the `QgsVectorTileRawData`  and attempt to access the first element of the map will result in crash.

Fixes #64791.