### PR TITLE
Fix decodeUri path when layers loaded by dragging a folder

### DIFF
--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -149,8 +149,7 @@ class PyQgsOGRProvider(QgisTestCase):
     def test_querySublayers_directory_returns_file_paths(self):
         """Ensure directory scans do not yield directory-only URIs (see GH #64850)."""
 
-        tmp_dir = tempfile.mkdtemp()
-        try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             src_dir = os.path.join(TEST_DATA_DIR, "3d")
             base = "buildings"
             for ext in (".shp", ".dbf", ".shx", ".prj", ".qpj"):
@@ -164,8 +163,6 @@ class PyQgsOGRProvider(QgisTestCase):
             for sl in sublayers:
                 parts = metadata.decodeUri(sl.uri())
                 self.assertTrue(os.path.isfile(parts["path"]))
-        finally:
-            shutil.rmtree(tmp_dir, True)
 
     def testUpdateMode(self):
 


### PR DESCRIPTION
Fixes #64850

When OGR is asked to query sublayers for a *plain* directory (i.e. not an OGR-supported directory dataset like .gdb), GDAL may treat the directory itself as a dataset. This results in layer URIs whose path component is the directory only, so providerMetadata.decodeUri() loses the actual file path.

This PR changes QgsOgrProviderMetadata::querySublayers() to, for plain directories, iterate files one level deep and call querySublayers() per file. This preserves real file paths in the generated URIs and makes decodeUri() return the expected file path.

Includes a Python unit test ensuring decodeUri(path) points to a file when querying sublayers for a directory.

Notes:
- intentionally non-recursive (one directory level)
- excludes VSI paths and OGR directory datasets