### PR TITLE
[Postgres] Fix missing overwrite info when renaming project

### DIFF
--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -928,17 +928,17 @@ void QgsPostgresDataItemGuiProvider::exportProjectToFile( QgsPGProjectItem *proj
 
 void QgsPostgresDataItemGuiProvider::renameProject( QgsPGProjectItem *projectItem, QgsDataItemGuiContext context )
 {
-  QgsNewNameDialog dlg( tr( "project “%1”" ).arg( projectItem->name() ), projectItem->name() );
-  dlg.setWindowTitle( tr( "Rename Project" ) );
-  if ( dlg.exec() != QDialog::Accepted || dlg.name() == projectItem->name() )
-    return;
-
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( projectItem->postgresProjectUri().connInfo, false );
   if ( !conn )
   {
     notify( tr( "Rename Project" ), tr( "Unable to rename project." ), context, Qgis::MessageLevel::Warning );
     return;
   }
+
+  QgsNewNameDialog dlg( tr( "project “%1”" ).arg( projectItem->name() ), projectItem->name(), QStringList(), QgsPostgresUtils::projectNamesInSchema( conn, projectItem->schemaName() ) );
+  dlg.setWindowTitle( tr( "Rename Project" ) );
+  if ( dlg.exec() != QDialog::Accepted || dlg.name() == projectItem->name() )
+    return;
 
   const QString newUri = projectItem->uriWithNewName( dlg.name() );
 

--- a/src/providers/postgres/qgspostgresutils.cpp
+++ b/src/providers/postgres/qgspostgresutils.cpp
@@ -838,3 +838,30 @@ bool QgsPostgresUtils::moveProjectVersions( QgsPostgresConn *conn, const QString
 
   return true;
 }
+
+QStringList QgsPostgresUtils::projectNamesInSchema( QgsPostgresConn *conn, const QString &schema )
+{
+  QStringList projects;
+
+  if ( !QgsPostgresUtils::projectsTableExists( conn, schema ) )
+  {
+    return projects;
+  }
+
+  const QString sql = u"SELECT name FROM %1.qgis_projects"_s
+                        .arg( QgsPostgresConn::quotedIdentifier( schema ) );
+
+  QgsPostgresResult res( conn->PQexec( sql ) );
+  if ( res.PQresultStatus() != PGRES_TUPLES_OK )
+  {
+    return projects;
+  }
+
+  const int rows = res.PQntuples();
+  for ( int i = 0; i < rows; ++i )
+  {
+    projects << res.PQgetvalue( i, 0 );
+  }
+
+  return projects;
+}

--- a/src/providers/postgres/qgspostgresutils.h
+++ b/src/providers/postgres/qgspostgresutils.h
@@ -207,6 +207,13 @@ class QgsPostgresUtils
      * \since QGIS 4.0
      */
     static bool moveProjectVersions( QgsPostgresConn *conn, const QString &originalSchema, const QString &project, const QString &targetSchema );
+
+    /**
+     * List projects in the specified \a schema
+     *
+     * \since QGIS 4.0
+     */
+    static QStringList projectNamesInSchema( QgsPostgresConn *conn, const QString &schema );
 };
 
 #endif


### PR DESCRIPTION
## Description

When renaming QGIS project in PosgreSQL DB the user was not informed about overwrite.  This prefills QgsNewNameDialog with existing project names, so that Overwrite button shows up.

Fixes #64839