### PR TITLE
Always check pointer initialized inside if initializer

### DIFF
--- a/src/app/devtools/querylogger/qgsappquerylogger.cpp
+++ b/src/app/devtools/querylogger/qgsappquerylogger.cpp
@@ -294,7 +294,7 @@ bool QgsDatabaseQueryLoggerProxyModel::filterAcceptsRow( int source_row, const Q
       }
       for ( int i = 0; i < request->childCount(); i++ )
       {
-        if ( QgsDevToolsModelValueNode *valueNode = static_cast<QgsDevToolsModelValueNode *>( request->childAt( i ) ); valueNode->value().contains( mFilterString, Qt::CaseInsensitive ) )
+        if ( QgsDevToolsModelValueNode *valueNode = static_cast<QgsDevToolsModelValueNode *>( request->childAt( i ) ); valueNode && valueNode->value().contains( mFilterString, Qt::CaseInsensitive ) )
         {
           return true;
         }

--- a/src/app/devtools/querylogger/qgsappquerylogger.cpp
+++ b/src/app/devtools/querylogger/qgsappquerylogger.cpp
@@ -294,7 +294,8 @@ bool QgsDatabaseQueryLoggerProxyModel::filterAcceptsRow( int source_row, const Q
       }
       for ( int i = 0; i < request->childCount(); i++ )
       {
-        if ( QgsDevToolsModelValueNode *valueNode = static_cast<QgsDevToolsModelValueNode *>( request->childAt( i ) ); valueNode && valueNode->value().contains( mFilterString, Qt::CaseInsensitive ) )
+        QgsDevToolsModelValueNode *valueNode = static_cast<QgsDevToolsModelValueNode *>( request->childAt( i ) );
+        if ( valueNode && valueNode->value().contains( mFilterString, Qt::CaseInsensitive ) )
         {
           return true;
         }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -1897,7 +1897,7 @@ bool QgsMeshLayer::readSymbology( const QDomNode &node, QString &errorMessage,
     QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Legend" ) );
 
     const QDomElement legendElem = node.firstChildElement( u"legend"_s );
-    if ( QgsMapLayerLegend *l = legend(); !legendElem.isNull() )
+    if ( QgsMapLayerLegend *l = legend(); l && !legendElem.isNull() )
     {
       l->readXml( legendElem, context );
     }

--- a/src/core/pointcloud/qgspointcloudlayer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayer.cpp
@@ -246,7 +246,7 @@ bool QgsPointCloudLayer::readSymbology( const QDomNode &node, QString &errorMess
     QgsReadWriteContextCategoryPopper p = context.enterCategory( tr( "Legend" ) );
 
     const QDomElement legendElem = node.firstChildElement( u"legend"_s );
-    if ( QgsMapLayerLegend *l = legend(); !legendElem.isNull() )
+    if ( QgsMapLayerLegend *l = legend(); l && !legendElem.isNull() )
     {
       l->readXml( legendElem, context );
     }

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -6021,7 +6021,7 @@ QString QgsVectorLayer::htmlMetadata() const
     }
 
     // geom column name
-    if ( const QgsVectorDataProvider *provider = dataProvider(); !provider->geometryColumnName().isEmpty() )
+    if ( const QgsVectorDataProvider *provider = dataProvider(); provider && !provider->geometryColumnName().isEmpty() )
     {
       myMetadata += u"<tr><td class=\"highlight\">"_s + tr( "Geometry column" ) + u"</td><td>"_s + provider->geometryColumnName() + u"</td></tr>\n"_s;
     }


### PR DESCRIPTION
## Description
This should fix an unreported crash, when trying to load a point cloud or mesh layer that have a default style, ie .qml sidecar file with the same name.

When using the c++17 `if ( init; condition )` idiom with a pointer in the init part, it is a _very_ easy mistake to make (see also https://github.com/qgis/QGIS-Enhancement-Proposals/pull/346/changes#r2307575991).


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
