### PR TITLE
restore paste functionality in Python Console (fix #64070)

### DIFF
--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -347,6 +347,7 @@ class ShellScintilla(QgsCodeEditorPython):
         self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord("Z") + ctrl)
         self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord("Y") + ctrl)
         self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord("L") + ctrl + shift)
+        self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord("V") + ctrl)
 
         # New QShortcut = ctrl+space/ctrl+alt+space for Autocomplete
         self.newShortcutCSS = QShortcut(
@@ -389,7 +390,6 @@ class ShellScintilla(QgsCodeEditorPython):
         self.console_widget.callWidgetMessageBar(msgText)
 
     def keyPressEvent(self, e):
-
         if (
             e.modifiers()
             & (Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.MetaModifier)
@@ -401,6 +401,17 @@ class ShellScintilla(QgsCodeEditorPython):
                 self._interpreter.sub_process.kill()
                 self._interpreter.sub_process = None
                 self.updatePrompt()
+            return
+        elif (
+            e.modifiers()
+            & (Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.MetaModifier)
+            and e.key() == Qt.Key.Key_V
+        ) or (
+            e.modifiers() & Qt.KeyboardModifier.ShiftModifier
+            and e.key() == Qt.Key.Key_Insert
+        ):
+            self.paste()
+            e.accept()
             return
 
         # update the live history


### PR DESCRIPTION
## Description

Disable native paste functionality as it does not handle multiline text. Instead use existing custom logic restoring behavior and functionality of older QGIS versions.

Fixes #64070.