### PR TITLE
QgsVectorFileWriter.writeAsVectorFormat(): fix writing into a GeoPackage…

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -791,6 +791,7 @@ not exist yet in the layer
 
 
 
+
   private:
     QgsVectorFileWriter( const QgsVectorFileWriter &rh );
 };

--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -791,6 +791,7 @@ not exist yet in the layer
 
 
 
+
   private:
     QgsVectorFileWriter( const QgsVectorFileWriter &rh );
 };

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -353,8 +353,6 @@ void QgsVectorFileWriter::init( QString vectorFileName,
     options[ datasourceOptions.size()] = nullptr;
   }
 
-  mAttrIdxToOgrIdx.remove( 0 );
-
   // create the data source
   if ( action == CreateOrOverwriteFile )
     mDS.reset( OGR_Dr_CreateDataSource( poDriver, vectorFileName.toUtf8().constData(), options ) );
@@ -567,7 +565,8 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   QgsDebugMsgLevel( "creating " + QString::number( fields.size() ) + " fields", 2 );
 
   mFields = fields;
-  mAttrIdxToOgrIdx.clear();
+  mAttrIdxToProviderIdx.clear();
+  mAttrIdxToOgrLayerIdx.clear();
   QSet<int> existingIdxs;
 
   mFieldValueConverter = fieldValueConverter;
@@ -631,7 +630,8 @@ void QgsVectorFileWriter::init( QString vectorFileName,
           int ogrIdx = OGR_FD_GetFieldIndex( defn, mCodec->fromUnicode( attrField.name() ) );
           if ( ogrIdx >= 0 )
           {
-            mAttrIdxToOgrIdx.insert( fldIdx, ogrIdx );
+            mAttrIdxToProviderIdx.insert( fldIdx, ogrIdx );
+            mAttrIdxToOgrLayerIdx.insert( fldIdx, ogrIdx );
             continue;
           }
         }
@@ -1011,6 +1011,9 @@ void QgsVectorFileWriter::init( QString vectorFileName,
           }
         }
 
+        existingIdxs.insert( ogrIdx );
+        mAttrIdxToOgrLayerIdx.insert( fldIdx, ogrIdx );
+
         if ( promoteFidColumnToAttribute )
         {
           if ( ogrFidColumnName.compare( attrField.name(), Qt::CaseInsensitive ) == 0 )
@@ -1025,8 +1028,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
           }
         }
 
-        existingIdxs.insert( ogrIdx );
-        mAttrIdxToOgrIdx.insert( fldIdx, ogrIdx );
+        mAttrIdxToProviderIdx.insert( fldIdx, ogrIdx );
       }
     }
     break;
@@ -1039,7 +1041,10 @@ void QgsVectorFileWriter::init( QString vectorFileName,
         QString name( attrField.name() );
         int ogrIdx = OGR_FD_GetFieldIndex( defn, mCodec->fromUnicode( name ) );
         if ( ogrIdx >= 0 )
-          mAttrIdxToOgrIdx.insert( fldIdx, ogrIdx );
+        {
+          mAttrIdxToProviderIdx.insert( fldIdx, ogrIdx );
+          mAttrIdxToOgrLayerIdx.insert( fldIdx, ogrIdx );
+        }
       }
     }
     break;
@@ -1052,7 +1057,10 @@ void QgsVectorFileWriter::init( QString vectorFileName,
     int fidIdx = fields.lookupField( u"FID"_s );
 
     if ( fidIdx >= 0 )
-      mAttrIdxToOgrIdx.remove( fidIdx );
+    {
+      mAttrIdxToProviderIdx.remove( fidIdx );
+      mAttrIdxToOgrLayerIdx.remove( fidIdx );
+    }
   }
 
   QgsDebugMsgLevel( u"Done creating fields"_s, 2 );
@@ -2837,7 +2845,7 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
   gdal::ogr_feature_unique_ptr poFeature( OGR_F_Create( OGR_L_GetLayerDefn( mLayer ) ) );
 
   // attribute handling
-  for ( QMap<int, int>::const_iterator it = mAttrIdxToOgrIdx.constBegin(); it != mAttrIdxToOgrIdx.constEnd(); ++it )
+  for ( QMap<int, int>::const_iterator it = mAttrIdxToOgrLayerIdx.constBegin(); it != mAttrIdxToOgrLayerIdx.constEnd(); ++it )
   {
     int fldIdx = it.key();
     int ogrField = it.value();
@@ -3307,12 +3315,12 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
 
 void QgsVectorFileWriter::resetMap( const QgsAttributeList &attributes )
 {
-  QMap<int, int> omap( mAttrIdxToOgrIdx );
-  mAttrIdxToOgrIdx.clear();
+  QMap<int, int> omap( mAttrIdxToOgrLayerIdx );
+  mAttrIdxToOgrLayerIdx.clear();
   for ( int i = 0; i < attributes.size(); i++ )
   {
     if ( omap.find( i ) != omap.end() )
-      mAttrIdxToOgrIdx.insert( attributes[i], omap[i] );
+      mAttrIdxToOgrLayerIdx.insert( attributes[i], omap[i] );
   }
 }
 

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -899,7 +899,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      *
      * \since QGIS 3.44
      */
-    QMap<int, int> sourceFieldIndexToWriterFieldIndex() const { return mAttrIdxToOgrIdx; }
+    QMap<int, int> sourceFieldIndexToWriterFieldIndex() const { return mAttrIdxToProviderIdx; }
 
     //! Close opened shapefile for writing
     ~QgsVectorFileWriter() override;
@@ -1001,8 +1001,12 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     //! Geometry type which is being used
     Qgis::WkbType mWkbType;
 
-    //! Map attribute indizes to OGR field indexes
-    QMap<int, int> mAttrIdxToOgrIdx;
+    //! Map attribute indices to OGR provider field indexes such as they are *after* the OGR provider has been created
+    // In particular for a GeoPackage file, a field with the FID column is always put in first position.
+    QMap<int, int> mAttrIdxToProviderIdx;
+
+    //! Map attribute indices to OGR layer field indexes such as they are on the current mLayer instance
+    QMap<int, int> mAttrIdxToOgrLayerIdx;
 
     Qgis::FeatureSymbologyExport mSymbologyExport = Qgis::FeatureSymbologyExport::NoSymbology;
 

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -2207,6 +2207,41 @@ class TestQgsVectorFileWriter(QgisTestCase):
                 },
             )
 
+    def test_write_gpkg_fid_not_first_writeAsVectorFormat(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dest_file_name = (
+                Path(temp_dir)
+                / "test_write_gpkg_fid_not_first_writeAsVectorFormat.gpkg"
+            ).as_posix()
+
+            srcLayer = QgsVectorLayer(
+                "Point?crs=epsg:4326&field=FID_1:integer&field=FID_2:integer",
+                "NewLayer",
+                "Memory",
+            )
+            fet = QgsFeature()
+            fet.setAttributes([1, 100])
+            pr = srcLayer.dataProvider()
+            pr.addFeatures([fet])
+            opts = QgsVectorFileWriter.SaveVectorOptions()
+            opts.driverName = "GPKG"
+            opts.layerName = srcLayer.name()
+            opts.layerOptions = ["FID=FID_2"]
+            QgsVectorFileWriter.writeAsVectorFormatV3(
+                srcLayer,
+                dest_file_name,
+                QgsProject.instance().transformContext(),
+                opts,
+            )
+
+            layer = QgsVectorLayer(dest_file_name)
+            self.assertTrue(layer.isValid())
+            layer_fields = layer.fields()
+            self.assertEqual([f.name() for f in layer_fields], ["FID_2", "FID_1"])
+            features = [f for f in layer.getFeatures()]
+            self.assertEqual(features[0][0], 100)
+            self.assertEqual(features[0][1], 1)
+
     def test_write_shp_fid_first(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             dest_file_name = Path(temp_dir) / "test_fid_first.shp"


### PR DESCRIPTION
… file with FID column name equal to a non-first source field

Fixes #63320 and regression of #61459
