### PR TITLE
appstream: Provide a vcs-browser url

### DIFF
--- a/linux/org.qgis.qgis.appdata.xml.in
+++ b/linux/org.qgis.qgis.appdata.xml.in
@@ -17,6 +17,7 @@
 
   <metadata_license>CC-BY-3.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
+  <url type="vcs-browser">https://github.com/qgis/QGIS/</url>
   <url type="bugtracker">https://github.com/qgis/QGIS/issues</url>
   <url type="donation">https://qgis.org/funding/donate/</url>
   <url type="faq">https://qgis.org/resources/support/faq/</url>


### PR DESCRIPTION
It's a warning on flathub and probably good to have on its own.
