### PR TITLE
[Virtual Point Clouds] Expose data provider to Python

### DIFF
--- a/python/PyQt6/core/auto_additions/qgspointclouddataprovider.py
+++ b/python/PyQt6/core/auto_additions/qgspointclouddataprovider.py
@@ -15,7 +15,7 @@ try:
     QgsPointCloudDataProvider.translatedLasClassificationCodes = staticmethod(QgsPointCloudDataProvider.translatedLasClassificationCodes)
     QgsPointCloudDataProvider.dataFormatIds = staticmethod(QgsPointCloudDataProvider.dataFormatIds)
     QgsPointCloudDataProvider.translatedDataFormatIds = staticmethod(QgsPointCloudDataProvider.translatedDataFormatIds)
-    QgsPointCloudDataProvider.__virtual_methods__ = ['capabilities', 'index', 'polygonBounds', 'originalMetadata', 'createRenderer']
+    QgsPointCloudDataProvider.__virtual_methods__ = ['capabilities', 'index', 'subIndexes', 'loadSubIndex', 'polygonBounds', 'originalMetadata', 'createRenderer']
     QgsPointCloudDataProvider.__abstract_methods__ = ['attributes', 'loadIndex', 'generateIndex', 'indexingState', 'pointCount']
     QgsPointCloudDataProvider.__overridden_methods__ = ['supportsSubsetString', 'subsetStringDialect', 'subsetStringHelpUrl', 'subsetString', 'setSubsetString']
     QgsPointCloudDataProvider.__signal_arguments__ = {'indexGenerationStateChanged': ['state: QgsPointCloudDataProvider.PointCloudIndexGenerationState']}

--- a/python/PyQt6/core/auto_additions/qgspointcloudsubindex.py
+++ b/python/PyQt6/core/auto_additions/qgspointcloudsubindex.py
@@ -1,0 +1,5 @@
+# The following has been generated automatically from src/core/pointcloud/qgspointcloudsubindex.h
+try:
+    QgsPointCloudSubIndex.__group__ = ['pointcloud']
+except (NameError, AttributeError):
+    pass

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
@@ -133,7 +133,33 @@ Returns the point cloud index associated with the provider.
 Can be None (e.g. the index is being created)
 %End
 
+    virtual QVector<QgsPointCloudSubIndex> subIndexes();
+%Docstring
+Returns a list of sub indexes available if the provider supports
+multiple indexes, empty list otherwise.
 
+The sub indexes contain a pointer to the individual indexes which may be
+None if not yet loaded.
+
+.. note::
+
+   Not available in Python bindings
+
+.. versionadded:: 3.32
+%End
+
+    virtual void loadSubIndex( int n );
+%Docstring
+Triggers loading of the point cloud index for the ``n`` th sub index
+
+Only applies to providers that support multiple indexes
+
+.. note::
+
+   Not available in Python bindings
+
+.. versionadded:: 3.32
+%End
 
     bool hasValidIndex() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointclouddataprovider.sip.in
@@ -141,11 +141,7 @@ multiple indexes, empty list otherwise.
 The sub indexes contain a pointer to the individual indexes which may be
 None if not yet loaded.
 
-.. note::
-
-   Not available in Python bindings
-
-.. versionadded:: 3.32
+.. versionadded:: 4.0
 %End
 
     virtual void loadSubIndex( int n );
@@ -154,11 +150,7 @@ Triggers loading of the point cloud index for the ``n`` th sub index
 
 Only applies to providers that support multiple indexes
 
-.. note::
-
-   Not available in Python bindings
-
-.. versionadded:: 3.32
+.. versionadded:: 4.0
 %End
 
     bool hasValidIndex() const;

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudlayer.sip.in
@@ -295,6 +295,15 @@ otherwise the index is fetched from the data provider.
 .. versionadded:: 3.42
 %End
 
+    QVector<QgsPointCloudSubIndex> subIndexes() const;
+%Docstring
+Returns point cloud indexes associated with the layer (only if the layer
+has a virtual point cloud data provider). If the layer is editable,
+:py:class:`QgsPointCloudEditingIndexes` are returned, otherwise the
+indexes are fetched from the data provider.
+
+.. versionadded:: 4.0
+%End
 
     bool isVpc() const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudsubindex.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudsubindex.sip.in
@@ -1,0 +1,82 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/pointcloud/qgspointcloudsubindex.h                          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/
+
+
+
+
+
+
+
+
+class QgsPointCloudSubIndex
+{
+%Docstring(signature="appended")
+Represents an individual index and metadata for the virtual point cloud
+data provider.
+
+The index is initially ``None`` until the virtual point cloud data
+provider explicitly loads the uri.
+
+.. versionadded:: 3.32
+%End
+
+%TypeHeaderCode
+#include "qgspointcloudsubindex.h"
+%End
+  public:
+    QgsPointCloudSubIndex( const QString &uri, const QgsGeometry &geometry, const QgsRectangle &extent, const QgsDoubleRange &zRange, qint64 count );
+%Docstring
+Constructor
+%End
+
+    QgsPointCloudIndex index() const;
+%Docstring
+Returns the point cloud index. May be ``None`` if not loaded.
+%End
+
+    void setIndex( QgsPointCloudIndex index );
+%Docstring
+Sets the point cloud index to ``index``.
+%End
+
+    QString uri() const;
+%Docstring
+Returns the uri for this sub index
+%End
+
+    QgsRectangle extent() const;
+%Docstring
+Returns the extent for this sub index in the index's crs coordinates.
+%End
+
+    QgsDoubleRange zRange() const;
+%Docstring
+Returns the elevation range for this sub index hoping it's in meters.
+%End
+
+    QgsGeometry polygonBounds() const;
+%Docstring
+Returns the bounds of the sub index in the index's crs coordinates as a
+multi polygon geometry. This can be the same as the extent or a more
+detailed geometry like a convex hull if available.
+%End
+
+    qint64 pointCount() const;
+%Docstring
+The number of points contained in the index.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/pointcloud/qgspointcloudsubindex.h                          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/

--- a/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudsubindex.sip.in
+++ b/python/PyQt6/core/auto_generated/pointcloud/qgspointcloudsubindex.sip.in
@@ -22,7 +22,7 @@ data provider.
 The index is initially ``None`` until the virtual point cloud data
 provider explicitly loads the uri.
 
-.. versionadded:: 3.32
+.. versionadded:: 4.0
 %End
 
 %TypeHeaderCode

--- a/python/PyQt6/core/auto_generated/providers/vpc/qgsvirtualpointcloudprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/vpc/qgsvirtualpointcloudprovider.sip.in
@@ -1,0 +1,146 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/providers/vpc/qgsvirtualpointcloudprovider.h                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/
+
+
+
+
+
+
+
+class QgsVirtualPointCloudProvider: QgsPointCloudDataProvider
+{
+%Docstring(signature="appended")
+Provides access to virtual point cloud (VPC) data sources.
+
+This provider handles virtual point cloud files referencing multiple
+input point clouds and exposes them as a single point cloud layer.
+
+.. versionadded:: 4.0
+%End
+
+%TypeHeaderCode
+#include "qgsvirtualpointcloudprovider.h"
+%End
+  public:
+    QgsVirtualPointCloudProvider( const QString &uri,
+                                  const QgsDataProvider::ProviderOptions &providerOptions,
+                                  Qgis::DataProviderReadFlags flags = Qgis::DataProviderReadFlags() );
+
+    ~QgsVirtualPointCloudProvider();
+
+    virtual Qgis::DataProviderFlags flags() const;
+
+    virtual QgsPointCloudDataProvider::Capabilities capabilities() const;
+
+    virtual QgsCoordinateReferenceSystem crs() const;
+
+
+    virtual QgsRectangle extent() const;
+
+    virtual QgsPointCloudAttributeCollection attributes() const;
+
+    virtual bool isValid() const;
+
+    virtual QString name() const;
+
+    virtual QString description() const;
+
+    virtual QgsPointCloudIndex index() const;
+
+    virtual qint64 pointCount() const;
+
+    virtual QVariantMap originalMetadata() const;
+
+    virtual void loadIndex( );
+
+    virtual void generateIndex( );
+
+    virtual PointCloudIndexGenerationState indexingState( );
+    virtual QgsGeometry polygonBounds() const;
+
+    virtual QVector<QgsPointCloudSubIndex> subIndexes();
+    virtual void loadSubIndex( int i );
+
+    virtual bool setSubsetString( const QString &subset, bool updateFeatureCount = false );
+
+    virtual QgsPointCloudRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const /Factory/;
+
+
+    QgsPointCloudIndex overview() const;
+%Docstring
+Returns pointer to the overview index. May be ``None`` if it doesn't
+exist.
+
+.. versionadded:: 3.42
+%End
+
+    double averageSubIndexWidth() const;
+%Docstring
+Returns the calculated average width of point clouds.
+
+.. note::
+
+   We use this value to calculate when to switch between overview and point clouds
+
+.. versionadded:: 3.42
+%End
+
+    double averageSubIndexHeight() const;
+%Docstring
+Returns the calculated average height of point clouds.
+
+.. note::
+
+   We use this value to calculate when to switch between overview and point clouds
+
+.. versionadded:: 3.42
+%End
+
+  signals:
+    void subIndexLoaded( int i );
+
+};
+
+class QgsVirtualPointCloudProviderMetadata : QgsProviderMetadata
+{
+%TypeHeaderCode
+#include "qgsvirtualpointcloudprovider.h"
+%End
+  public:
+    QgsVirtualPointCloudProviderMetadata();
+    virtual QIcon icon() const;
+
+    virtual QgsProviderMetadata::ProviderMetadataCapabilities capabilities() const;
+
+    virtual QgsVirtualPointCloudProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, Qgis::DataProviderReadFlags flags = Qgis::DataProviderReadFlags() );
+
+    virtual QList< QgsProviderSublayerDetails > querySublayers( const QString &uri, Qgis::SublayerQueryFlags flags = Qgis::SublayerQueryFlags(), QgsFeedback *feedback = 0 ) const;
+
+    virtual int priorityForUri( const QString &uri ) const;
+
+    virtual QList< Qgis::LayerType > validLayerTypesForUri( const QString &uri ) const;
+
+    virtual QString encodeUri( const QVariantMap &parts ) const;
+
+    virtual QVariantMap decodeUri( const QString &uri ) const;
+
+    virtual QString filters( Qgis::FileFilterType type );
+
+    virtual ProviderCapabilities providerCapabilities() const;
+
+    virtual QList< Qgis::LayerType > supportedLayerTypes() const;
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/providers/vpc/qgsvirtualpointcloudprovider.h                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.py again   *
+ ************************************************************************/

--- a/python/PyQt6/core/core_auto.sip
+++ b/python/PyQt6/core/core_auto.sip
@@ -537,6 +537,7 @@
 %Include auto_generated/pointcloud/qgspointcloudlayer.sip
 %Include auto_generated/pointcloud/qgspointcloudlayerelevationproperties.sip
 %Include auto_generated/pointcloud/qgspointcloudindex.sip
+%Include auto_generated/pointcloud/qgspointcloudsubindex.sip
 %Include auto_generated/pointcloud/qgspointclouddataprovider.sip
 %Include auto_generated/pointcloud/qgspointcloudrenderer.sip
 %Include auto_generated/pointcloud/qgspointcloudrendererregistry.sip

--- a/src/core/pointcloud/qgspointclouddataprovider.h
+++ b/src/core/pointcloud/qgspointclouddataprovider.h
@@ -163,8 +163,7 @@ class CORE_EXPORT QgsPointCloudDataProvider: public QgsDataProvider
      *
      * The sub indexes contain a pointer to the individual indexes which may be nullptr if not yet loaded.
      *
-     * \note Not available in Python bindings
-     * \since QGIS 3.32
+     * \since QGIS 4.0
      */
     virtual QVector<QgsPointCloudSubIndex> subIndexes() { return QVector<QgsPointCloudSubIndex>(); }
 
@@ -173,8 +172,7 @@ class CORE_EXPORT QgsPointCloudDataProvider: public QgsDataProvider
      *
      * Only applies to providers that support multiple indexes
      *
-     * \note Not available in Python bindings
-     * \since QGIS 3.32
+     * \since QGIS 4.0
      */
     virtual void loadSubIndex( int n ) { Q_UNUSED( n ) return; }
 

--- a/src/core/pointcloud/qgspointclouddataprovider.h
+++ b/src/core/pointcloud/qgspointclouddataprovider.h
@@ -166,7 +166,7 @@ class CORE_EXPORT QgsPointCloudDataProvider: public QgsDataProvider
      * \note Not available in Python bindings
      * \since QGIS 3.32
      */
-    virtual QVector<QgsPointCloudSubIndex> subIndexes() SIP_SKIP { return QVector<QgsPointCloudSubIndex>(); }
+    virtual QVector<QgsPointCloudSubIndex> subIndexes() { return QVector<QgsPointCloudSubIndex>(); }
 
     /**
      * Triggers loading of the point cloud index for the \a n th sub index
@@ -176,7 +176,7 @@ class CORE_EXPORT QgsPointCloudDataProvider: public QgsDataProvider
      * \note Not available in Python bindings
      * \since QGIS 3.32
      */
-    virtual void loadSubIndex( int n ) SIP_SKIP { Q_UNUSED( n ) return; }
+    virtual void loadSubIndex( int n ) { Q_UNUSED( n ) return; }
 
     /**
      * Returns whether provider has index which is valid

--- a/src/core/pointcloud/qgspointcloudlayer.h
+++ b/src/core/pointcloud/qgspointcloudlayer.h
@@ -355,7 +355,7 @@ class CORE_EXPORT QgsPointCloudLayer : public QgsMapLayer, public QgsAbstractPro
      *
      * \since QGIS 4.0
      */
-    QVector<QgsPointCloudSubIndex> subIndexes() const SIP_SKIP;
+    QVector<QgsPointCloudSubIndex> subIndexes() const;
 
     /**
      * Returns whether the layer has a virtual point cloud data provider or not.

--- a/src/core/pointcloud/qgspointcloudsubindex.h
+++ b/src/core/pointcloud/qgspointcloudsubindex.h
@@ -27,7 +27,6 @@
 #include <QString>
 
 ///@cond PRIVATE
-#define SIP_NO_FILE
 
 
 /**
@@ -37,7 +36,7 @@
  *
  * \since QGIS 3.32
  */
-class QgsPointCloudSubIndex
+class CORE_EXPORT QgsPointCloudSubIndex
 {
   public:
     //! Constructor

--- a/src/core/pointcloud/qgspointcloudsubindex.h
+++ b/src/core/pointcloud/qgspointcloudsubindex.h
@@ -34,7 +34,7 @@
  *
  * The index is initially NULLPTR until the virtual point cloud data provider explicitly loads the uri.
  *
- * \since QGIS 3.32
+ * \since QGIS 4.0
  */
 class CORE_EXPORT QgsPointCloudSubIndex
 {


### PR DESCRIPTION
This PR exposes virtual point cloud provider to Pyhon.
API is considered experimental and changes are possible at any time.

However, we can now experiment with VPCs and prototype using Python.
This also enables us to write tests in Python for VPCs.