### PR TITLE
Fix incorrect path value when constructing QgsDataProvider

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -2517,7 +2517,7 @@ void QgsFieldDomainItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
     }
 
     bool policiesEditable = false;
-    QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( providerKey, item->path() );
+    QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( providerKey, connectionUri );
     if ( provider->isValid() )
     {
       if ( QgsVectorDataProvider *vectorProvider = qobject_cast<QgsVectorDataProvider *>( provider ) )


### PR DESCRIPTION
## Description

`QgsFieldDomainsItem` and `QgsFieldDomainItem` cannot use `item->path()` to construct the provider, as they contain domain name in that, which means the provider is not constructed properly. `connectionUri` variable needs to used there.

Fixes issue mentioned by @agiudiceandrea  in #64849
