### PR TITLE
[Expressions] Support arithmetic operators on color objects in expressions

### DIFF
--- a/resources/function_help/json/op_asterisk
+++ b/resources/function_help/json/op_asterisk
@@ -2,7 +2,7 @@
   "name": "*",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Multiplication of two values",
+  "description": "Multiplication of two values. When used with a color and a number, multiplies each RGB (or CMYK) component of the color by the number, clamping results to [0, 1]. Color alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"
@@ -16,6 +16,9 @@
   }, {
     "expression": "5 * NULL",
     "returns": "NULL"
+  }, {
+    "expression": "color_rgbf(0.2, 0.4, 0.6) * 2",
+    "returns": "RGBA: 0.40,0.80,1.00,1.00"
   }],
-  "tags": ["multiplication", "values"]
+  "tags": ["multiplication", "values", "color"]
 }

--- a/resources/function_help/json/op_asterisk
+++ b/resources/function_help/json/op_asterisk
@@ -2,7 +2,7 @@
   "name": "*",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Multiplication of two values. When used with a color and a number, multiplies each RGB (or CMYK) component of the color by the number, clamping results to [0, 1]. Color alpha channel is preserved.",
+  "description": "Multiplication of two values.<br><br>When used with two colors, performs component-wise multiplication on all channels including alpha, clamping results to [0, 1]. HSL and HSV colors are operated on in RGB space and converted back to their original color spec.<br><br>When used with a color and a number (in any order), multiplies each color component (excluding alpha) by the number, clamping results to [0, 1]. The alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/resources/function_help/json/op_asterisk
+++ b/resources/function_help/json/op_asterisk
@@ -2,7 +2,7 @@
   "name": "*",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Multiplication of two values.<br><br>When used with two colors, performs component-wise multiplication on all channels including alpha, clamping results to [0, 1]. HSL and HSV colors are operated on in RGB space and converted back to their original color spec.<br><br>When used with a color and a number (in any order), multiplies each color component (excluding alpha) by the number, clamping results to [0, 1]. The alpha channel is preserved.",
+  "description": "Multiplication of two values.<br><br>When used with two colors, performs component-wise multiplication on the color components (not alpha), clamping results to [0, 1]. The alpha channel of the left color is used. HSL and HSV colors are converted to RGB for the operation, and the result is an RGB color. CMYK colors produce a CMYK result.<br><br>When used with a color and a number (in any order), multiplies each color component (excluding alpha) by the number, clamping results to [0, 1]. The alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/resources/function_help/json/op_div
+++ b/resources/function_help/json/op_div
@@ -2,7 +2,7 @@
   "name": "/",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Division of two values. When used with a color and a number, divides each RGB (or CMYK) component of the color by the number, clamping results to [0, 1]. The color must be on the left side. Division by zero returns NULL. Color alpha channel is preserved.",
+  "description": "Division of two values.<br><br>When used with two colors, performs component-wise division on all channels including alpha, clamping results to [0, 1]. HSL and HSV colors are operated on in RGB space and converted back to their original color spec.<br><br>When used with a color and a number, divides each color component (excluding alpha) by the number, clamping results to [0, 1]. The color must be on the left side. Division by zero returns NULL. The alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/resources/function_help/json/op_div
+++ b/resources/function_help/json/op_div
@@ -2,7 +2,7 @@
   "name": "/",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Division of two values.<br><br>When used with two colors, performs component-wise division on all channels including alpha, clamping results to [0, 1]. HSL and HSV colors are operated on in RGB space and converted back to their original color spec.<br><br>When used with a color and a number, divides each color component (excluding alpha) by the number, clamping results to [0, 1]. The color must be on the left side. Division by zero returns NULL. The alpha channel is preserved.",
+  "description": "Division of two values.<br><br>When used with two colors, performs component-wise division on the color components (not alpha), clamping results to [0, 1]. The alpha channel of the left color is used. HSL and HSV colors are converted to RGB for the operation, and the result is an RGB color. CMYK colors produce a CMYK result.<br><br>When used with a color and a number, divides each color component (excluding alpha) by the number, clamping results to [0, 1]. The color must be on the left side. Division by zero returns NULL. The alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/resources/function_help/json/op_div
+++ b/resources/function_help/json/op_div
@@ -2,7 +2,7 @@
   "name": "/",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Division of two values",
+  "description": "Division of two values. When used with a color and a number, divides each RGB (or CMYK) component of the color by the number, clamping results to [0, 1]. The color must be on the left side. Division by zero returns NULL. Color alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"
@@ -16,6 +16,9 @@
   }, {
     "expression": "5 / NULL",
     "returns": "NULL"
+  }, {
+    "expression": "color_rgbf(0.8, 0.6, 0.4) / 2",
+    "returns": "RGBA: 0.40,0.30,0.20,1.00"
   }],
-  "tags": ["division", "values"]
+  "tags": ["division", "values", "color"]
 }

--- a/resources/function_help/json/op_minus
+++ b/resources/function_help/json/op_minus
@@ -2,7 +2,7 @@
   "name": "-",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Subtraction of two values. If one of the values is NULL the result will be NULL.<br><br>When used with two colors, performs component-wise subtraction on all channels including alpha, clamping results to [0, 1]. HSL and HSV colors are operated on in RGB space and converted back to their original color spec.<br><br>When used with a color and a number (in any order), subtracts one from the other per color component (excluding alpha), clamping results to [0, 1]. The alpha channel is preserved.",
+  "description": "Subtraction of two values. If one of the values is NULL the result will be NULL.<br><br>When used with two colors, performs component-wise subtraction on the color components (not alpha), clamping results to [0, 1]. The alpha channel of the left color is used. HSL and HSV colors are converted to RGB for the operation, and the result is an RGB color. CMYK colors produce a CMYK result.<br><br>When used with a color and a number (in any order), subtracts one from the other per color component (excluding alpha), clamping results to [0, 1]. The alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/resources/function_help/json/op_minus
+++ b/resources/function_help/json/op_minus
@@ -2,7 +2,7 @@
   "name": "-",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Subtraction of two values. If one of the values is NULL the result will be NULL.",
+  "description": "Subtraction of two values. If one of the values is NULL the result will be NULL. When used with a color and a number, subtracts the number from each RGB (or CMYK) component of the color, clamping results to [0, 1]. The color must be on the left side. Color alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"
@@ -19,6 +19,9 @@
   }, {
     "expression": "to_datetime('2012-05-05 12:00:00') - to_interval('1 day 2 hours')",
     "returns": "2012-05-04T10:00:00"
+  }, {
+    "expression": "color_rgbf(0.8, 0.6, 0.4) - 0.1",
+    "returns": "RGBA: 0.70,0.50,0.30,1.00"
   }],
-  "tags": ["subtraction", "null", "result", "values"]
+  "tags": ["subtraction", "null", "result", "values", "color"]
 }

--- a/resources/function_help/json/op_minus
+++ b/resources/function_help/json/op_minus
@@ -2,7 +2,7 @@
   "name": "-",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Subtraction of two values. If one of the values is NULL the result will be NULL. When used with a color and a number, subtracts the number from each RGB (or CMYK) component of the color, clamping results to [0, 1]. The color must be on the left side. Color alpha channel is preserved.",
+  "description": "Subtraction of two values. If one of the values is NULL the result will be NULL.<br><br>When used with two colors, performs component-wise subtraction on all channels including alpha, clamping results to [0, 1]. HSL and HSV colors are operated on in RGB space and converted back to their original color spec.<br><br>When used with a color and a number (in any order), subtracts one from the other per color component (excluding alpha), clamping results to [0, 1]. The alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/resources/function_help/json/op_plus
+++ b/resources/function_help/json/op_plus
@@ -2,7 +2,7 @@
   "name": "+",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Addition of two values or concatenation of two strings.<br><br>For numeric and datetime operations if either value is NULL the result will be NULL.<br><br>For string concatenation NULL values from fields are treated as empty strings. Use the || operator instead if NULL propagation for strings is required.<br><br>When used with a color and a number, adds the number to each RGB (or CMYK) component of the color, clamping results to [0, 1]. Color alpha channel is preserved.",
+  "description": "Addition of two values or concatenation of two strings.<br><br>For numeric and datetime operations if either value is NULL the result will be NULL.<br><br>For string concatenation NULL values from fields are treated as empty strings. Use the || operator instead if NULL propagation for strings is required.<br><br>When used with two colors, performs component-wise addition on all channels including alpha, clamping results to [0, 1]. HSL and HSV colors are operated on in RGB space and converted back to their original color spec.<br><br>When used with a color and a number (in any order), adds the number to each color component (excluding alpha), clamping results to [0, 1]. The alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/resources/function_help/json/op_plus
+++ b/resources/function_help/json/op_plus
@@ -2,7 +2,7 @@
   "name": "+",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Addition of two values or concatenation of two strings.<br><br>For numeric and datetime operations if either value is NULL the result will be NULL.<br><br>For string concatenation NULL values from fields are treated as empty strings. Use the || operator instead if NULL propagation for strings is required.",
+  "description": "Addition of two values or concatenation of two strings.<br><br>For numeric and datetime operations if either value is NULL the result will be NULL.<br><br>For string concatenation NULL values from fields are treated as empty strings. Use the || operator instead if NULL propagation for strings is required.<br><br>When used with a color and a number, adds the number to each RGB (or CMYK) component of the color, clamping results to [0, 1]. Color alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"
@@ -28,6 +28,9 @@
   }, {
     "expression": "to_datetime('2020-08-01 12:00:00') + '1 day 2 hours'",
     "returns": "2020-08-02T14:00:00"
+  }, {
+    "expression": "color_rgbf(0.2, 0.4, 0.6) + 0.1",
+    "returns": "RGBA: 0.30,0.50,0.70,1.00"
   }],
-  "tags": ["addition", "null", "result", "values"]
+  "tags": ["addition", "null", "result", "values", "color"]
 }

--- a/resources/function_help/json/op_plus
+++ b/resources/function_help/json/op_plus
@@ -2,7 +2,7 @@
   "name": "+",
   "type": "operator",
   "groups": ["Operators"],
-  "description": "Addition of two values or concatenation of two strings.<br><br>For numeric and datetime operations if either value is NULL the result will be NULL.<br><br>For string concatenation NULL values from fields are treated as empty strings. Use the || operator instead if NULL propagation for strings is required.<br><br>When used with two colors, performs component-wise addition on all channels including alpha, clamping results to [0, 1]. HSL and HSV colors are operated on in RGB space and converted back to their original color spec.<br><br>When used with a color and a number (in any order), adds the number to each color component (excluding alpha), clamping results to [0, 1]. The alpha channel is preserved.",
+  "description": "Addition of two values or concatenation of two strings.<br><br>For numeric and datetime operations if either value is NULL the result will be NULL.<br><br>For string concatenation NULL values from fields are treated as empty strings. Use the || operator instead if NULL propagation for strings is required.<br><br>When used with two colors, performs component-wise addition on the color components (not alpha), clamping results to [0, 1]. The alpha channel of the left color is used. HSL and HSV colors are converted to RGB for the operation, and the result is an RGB color. CMYK colors produce a CMYK result.<br><br>When used with a color and a number (in any order), adds the number to each color component (excluding alpha), clamping results to [0, 1]. The alpha channel is preserved.",
   "arguments": [{
     "arg": "a",
     "description": "value"

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -497,44 +497,34 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
           return QVariant();
         }
 
-        int r, g, b, a;
-
-        switch ( mOp )
+        switch ( color.spec() )
         {
-          case boPlus:
-            r = std::clamp( static_cast<int>( std::round( color.red() + value ) ), 0, 255 );
-            g = std::clamp( static_cast<int>( std::round( color.green() + value ) ), 0, 255 );
-            b = std::clamp( static_cast<int>( std::round( color.blue() + value ) ), 0, 255 );
-            a = std::clamp( static_cast<int>( std::round( color.alpha() + value ) ), 0, 255 );
-            break;
-
-          case boMinus:
-            r = std::clamp( static_cast<int>( std::round( color.red() - value ) ), 0, 255 );
-            g = std::clamp( static_cast<int>( std::round( color.green() - value ) ), 0, 255 );
-            b = std::clamp( static_cast<int>( std::round( color.blue() - value ) ), 0, 255 );
-            a = std::clamp( static_cast<int>( std::round( color.alpha() - value ) ), 0, 255 );
-            break;
-
-          case boMul:
-            r = std::clamp( static_cast<int>( std::round( color.red() * value ) ), 0, 255 );
-            g = std::clamp( static_cast<int>( std::round( color.green() * value ) ), 0, 255 );
-            b = std::clamp( static_cast<int>( std::round( color.blue() * value ) ), 0, 255 );
-            a = std::clamp( static_cast<int>( std::round( color.alpha() * value ) ), 0, 255 );
-            break;
-
-          case boDiv:
-            r = std::clamp( static_cast<int>( std::round( color.red() / value ) ), 0, 255 );
-            g = std::clamp( static_cast<int>( std::round( color.green() / value ) ), 0, 255 );
-            b = std::clamp( static_cast<int>( std::round( color.blue() / value ) ), 0, 255 );
-            a = std::clamp( static_cast<int>( std::round( color.alpha() / value ) ), 0, 255 );
-            break;
-
+          case QColor::Cmyk:
+          {
+            int c, m, y, k, a;
+            color.getCmyk( &c, &m, &y, &k, &a );
+            return QColor::fromCmyk(
+                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( c ), value ) ) ), 0, 255 ),
+                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( m ), value ) ) ), 0, 255 ),
+                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( y ), value ) ) ), 0, 255 ),
+                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( k ), value ) ) ), 0, 255 ),
+                     a
+                   );
+          }
+          case QColor::Rgb:
+          {
+            int r, g, b, a;
+            color.getRgb( &r, &g, &b, &a );
+            return QColor::fromRgb(
+                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( r ), value ) ) ), 0, 255 ),
+                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( g ), value ) ) ), 0, 255 ),
+                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( b ), value ) ) ), 0, 255 ),
+                     a
+                   );
+          }
           default:
             return QVariant();
         }
-
-        QColor result( r, g, b, a );
-        return QVariant( result );
       }
       else
       {

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -473,6 +473,58 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         ENSURE_NO_EVAL_ERROR
         return QgsInterval( datetime1 - datetime2 );
       }
+      else if ( ( mOp == boPlus || mOp == boMinus || mOp == boMul || mOp == boDiv ) && vL.userType() == QMetaType::Type::QColor && vR.userType() == QMetaType::Type::QColor )
+      {
+        bool isQColor = false;
+        const QColor colorL = QgsExpressionUtils::getColorValue( vL, parent, isQColor );
+        ENSURE_NO_EVAL_ERROR
+        const QColor colorR = QgsExpressionUtils::getColorValue( vR, parent, isQColor );
+        ENSURE_NO_EVAL_ERROR
+
+        switch ( colorL.spec() )
+        {
+          case QColor::Cmyk:
+          {
+            float lc, lm, ly, lk, la, rc, rm, ry, rk, ra;
+            colorL.getCmykF( &lc, &lm, &ly, &lk, &la );
+            colorR.getCmykF( &rc, &rm, &ry, &rk, &ra );
+            return QColor::fromCmykF(
+              static_cast<float>( std::clamp( computeDouble( lc, rc ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( lm, rm ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( ly, ry ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( lk, rk ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( la, ra ), 0.0, 1.0 ) )
+            );
+          }
+          case QColor::Hsl:
+          case QColor::Hsv:
+          case QColor::Rgb:
+          case QColor::ExtendedRgb:
+          {
+            QColor::Spec originSpec = colorL.spec();
+            float lr, lg, lb, la, rr, rg, rb, ra;
+            colorL.getRgbF( &lr, &lg, &lb, &la );
+            colorR.getRgbF( &rr, &rg, &rb, &ra );
+            QColor result = QColor::fromRgbF(
+              static_cast<float>( std::clamp( computeDouble( lr, rr ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( lg, rg ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( lb, rb ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( la, ra ), 0.0, 1.0 ) )
+            );
+            switch ( originSpec )
+            {
+              case QColor::Hsl:
+                return result.toHsl();
+              case QColor::Hsv:
+                return result.toHsv();
+              default:
+                return result;
+            }
+          }
+          default:
+            return QVariant();
+        }
+      }
       else if ( ( mOp == boPlus || mOp == boMinus || mOp == boMul || mOp == boDiv )
                 && ( ( ( vL.userType() == QMetaType::Type::QColor ) && QgsExpressionUtils::isDoubleSafe( vR ) ) || ( ( vR.userType() == QMetaType::Type::QColor ) && QgsExpressionUtils::isDoubleSafe( vL ) ) ) )
       {
@@ -489,10 +541,10 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
           return QVariant();
         }
 
-        // it doesn't make sense to support these operations with color element on the right
-        if ( !colorLeft && ( mOp == boPlus || mOp == boMinus || mOp == boDiv ) )
+        // let's not divide with color
+        if ( !colorLeft && mOp == boDiv )
         {
-          parent->setEvalErrorString( tr( "Can't perform /, +, - with a color value on the right" ) );
+          parent->setEvalErrorString( tr( "Can't perform / with a color value on the right" ) );
           return QVariant();
         }
 
@@ -502,11 +554,15 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
           {
             float c, m, y, k, a;
             color.getCmykF( &c, &m, &y, &k, &a );
+            const double dc = static_cast<double>( c );
+            const double dm = static_cast<double>( m );
+            const double dy = static_cast<double>( y );
+            const double dk = static_cast<double>( k );
             return QColor::fromCmykF(
-              static_cast<float>( std::clamp( computeDouble( static_cast<double>( c ), value ), 0.0, 1.0 ) ),
-              static_cast<float>( std::clamp( computeDouble( static_cast<double>( m ), value ), 0.0, 1.0 ) ),
-              static_cast<float>( std::clamp( computeDouble( static_cast<double>( y ), value ), 0.0, 1.0 ) ),
-              static_cast<float>( std::clamp( computeDouble( static_cast<double>( k ), value ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( colorLeft ? dc : value, colorLeft ? value : dc ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( colorLeft ? dm : value, colorLeft ? value : dm ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( colorLeft ? dy : value, colorLeft ? value : dy ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( colorLeft ? dk : value, colorLeft ? value : dk ), 0.0, 1.0 ) ),
               a
             );
           }
@@ -518,10 +574,13 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
             QColor::Spec originSpec = color.spec();
             float r, g, b, a;
             color.getRgbF( &r, &g, &b, &a );
+            const double dr = static_cast<double>( r );
+            const double dg = static_cast<double>( g );
+            const double db = static_cast<double>( b );
             QColor result = QColor::fromRgbF(
-              static_cast<float>( std::clamp( computeDouble( static_cast<double>( r ), value ), 0.0, 1.0 ) ),
-              static_cast<float>( std::clamp( computeDouble( static_cast<double>( g ), value ), 0.0, 1.0 ) ),
-              static_cast<float>( std::clamp( computeDouble( static_cast<double>( b ), value ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( colorLeft ? dr : value, colorLeft ? value : dr ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( colorLeft ? dg : value, colorLeft ? value : dg ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( colorLeft ? db : value, colorLeft ? value : db ), 0.0, 1.0 ) ),
               a
             );
             switch ( originSpec )

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -501,26 +501,39 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         {
           case QColor::Cmyk:
           {
-            int c, m, y, k, a;
-            color.getCmyk( &c, &m, &y, &k, &a );
-            return QColor::fromCmyk(
-                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( c ), value ) ) ), 0, 255 ),
-                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( m ), value ) ) ), 0, 255 ),
-                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( y ), value ) ) ), 0, 255 ),
-                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( k ), value ) ) ), 0, 255 ),
+            float c, m, y, k, a;
+            color.getCmykF( &c, &m, &y, &k, &a );
+            return QColor::fromCmykF(
+                     static_cast<float>( std::clamp( computeDouble( static_cast<double>( c ), value ), 0.0, 1.0 ) ),
+                     static_cast<float>( std::clamp( computeDouble( static_cast<double>( m ), value ), 0.0, 1.0 ) ),
+                     static_cast<float>( std::clamp( computeDouble( static_cast<double>( y ), value ), 0.0, 1.0 ) ),
+                     static_cast<float>( std::clamp( computeDouble( static_cast<double>( k ), value ), 0.0, 1.0 ) ),
                      a
                    );
           }
+          case QColor::Hsl:
+          case QColor::Hsv:
           case QColor::Rgb:
+          case QColor::ExtendedRgb:  // color_rgbf constructor clamps it to 0-1, so we do the same here
           {
-            int r, g, b, a;
-            color.getRgb( &r, &g, &b, &a );
-            return QColor::fromRgb(
-                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( r ), value ) ) ), 0, 255 ),
-                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( g ), value ) ) ), 0, 255 ),
-                     std::clamp( static_cast<int>( std::round( computeDouble( static_cast<double>( b ), value ) ) ), 0, 255 ),
-                     a
-                   );
+            QColor::Spec originSpec = color.spec();
+            float r, g, b, a;
+            color.getRgbF( &r, &g, &b, &a );
+            QColor result = QColor::fromRgbF(
+                              static_cast<float>( std::clamp( computeDouble( static_cast<double>( r ), value ), 0.0, 1.0 ) ),
+                              static_cast<float>( std::clamp( computeDouble( static_cast<double>( g ), value ), 0.0, 1.0 ) ),
+                              static_cast<float>( std::clamp( computeDouble( static_cast<double>( b ), value ), 0.0, 1.0 ) ),
+                              a
+                            );
+            switch ( originSpec )
+            {
+              case QColor::Hsl:
+                return result.toHsl();
+              case QColor::Hsv:
+                return result.toHsv();
+              default:
+                return result;
+            }
           }
           default:
             return QVariant();

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -20,6 +20,7 @@
 #include "qgsstringutils.h"
 #include "qgsvariantutils.h"
 
+#include <QColor>
 #include <QDate>
 #include <QDateTime>
 #include <QRegularExpression>
@@ -471,6 +472,69 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         QDateTime datetime2 = QgsExpressionUtils::getDateTimeValue( vR, parent );
         ENSURE_NO_EVAL_ERROR
         return QgsInterval( datetime1 - datetime2 );
+      }
+      else if ( ( mOp == boPlus || mOp == boMinus || mOp == boMul || mOp == boDiv ) &&
+                ( ( ( vL.userType() == QMetaType::Type::QColor ) && QgsExpressionUtils::isDoubleSafe( vR ) ) ||
+                  ( ( vR.userType() == QMetaType::Type::QColor ) && QgsExpressionUtils::isDoubleSafe( vL ) ) ) )
+      {
+        const bool colorLeft = vL.userType() == QMetaType::Type::QColor;
+        bool isQColor = false;
+        const QColor color = QgsExpressionUtils::getColorValue( colorLeft ? vL : vR, parent, isQColor );
+        ENSURE_NO_EVAL_ERROR
+
+        const double value = QgsExpressionUtils::getDoubleValue( colorLeft ? vR : vL, parent );
+        ENSURE_NO_EVAL_ERROR
+
+        if ( mOp == boDiv && value == 0.0 )
+        {
+          return QVariant();
+        }
+
+        // it doesn't make sense to support these operations with color element on the right
+        if ( !colorLeft && ( mOp == boPlus || mOp == boMinus || mOp == boDiv ) )
+        {
+          parent->setEvalErrorString( tr( "Can't perform /, +, - with Color on the right" ) );
+          return QVariant();
+        }
+
+        int r, g, b, a;
+
+        switch ( mOp )
+        {
+          case boPlus:
+            r = std::clamp( static_cast<int>( std::round( color.red() + value ) ), 0, 255 );
+            g = std::clamp( static_cast<int>( std::round( color.green() + value ) ), 0, 255 );
+            b = std::clamp( static_cast<int>( std::round( color.blue() + value ) ), 0, 255 );
+            a = std::clamp( static_cast<int>( std::round( color.alpha() + value ) ), 0, 255 );
+            break;
+
+          case boMinus:
+            r = std::clamp( static_cast<int>( std::round( color.red() - value ) ), 0, 255 );
+            g = std::clamp( static_cast<int>( std::round( color.green() - value ) ), 0, 255 );
+            b = std::clamp( static_cast<int>( std::round( color.blue() - value ) ), 0, 255 );
+            a = std::clamp( static_cast<int>( std::round( color.alpha() - value ) ), 0, 255 );
+            break;
+
+          case boMul:
+            r = std::clamp( static_cast<int>( std::round( color.red() * value ) ), 0, 255 );
+            g = std::clamp( static_cast<int>( std::round( color.green() * value ) ), 0, 255 );
+            b = std::clamp( static_cast<int>( std::round( color.blue() * value ) ), 0, 255 );
+            a = std::clamp( static_cast<int>( std::round( color.alpha() * value ) ), 0, 255 );
+            break;
+
+          case boDiv:
+            r = std::clamp( static_cast<int>( std::round( color.red() / value ) ), 0, 255 );
+            g = std::clamp( static_cast<int>( std::round( color.green() / value ) ), 0, 255 );
+            b = std::clamp( static_cast<int>( std::round( color.blue() / value ) ), 0, 255 );
+            a = std::clamp( static_cast<int>( std::round( color.alpha() / value ) ), 0, 255 );
+            break;
+
+          default:
+            return QVariant();
+        }
+
+        QColor result( r, g, b, a );
+        return QVariant( result );
       }
       else
       {

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -473,9 +473,8 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         ENSURE_NO_EVAL_ERROR
         return QgsInterval( datetime1 - datetime2 );
       }
-      else if ( ( mOp == boPlus || mOp == boMinus || mOp == boMul || mOp == boDiv ) &&
-                ( ( ( vL.userType() == QMetaType::Type::QColor ) && QgsExpressionUtils::isDoubleSafe( vR ) ) ||
-                  ( ( vR.userType() == QMetaType::Type::QColor ) && QgsExpressionUtils::isDoubleSafe( vL ) ) ) )
+      else if ( ( mOp == boPlus || mOp == boMinus || mOp == boMul || mOp == boDiv )
+                && ( ( ( vL.userType() == QMetaType::Type::QColor ) && QgsExpressionUtils::isDoubleSafe( vR ) ) || ( ( vR.userType() == QMetaType::Type::QColor ) && QgsExpressionUtils::isDoubleSafe( vL ) ) ) )
       {
         const bool colorLeft = vL.userType() == QMetaType::Type::QColor;
         bool isQColor = false;
@@ -493,7 +492,7 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         // it doesn't make sense to support these operations with color element on the right
         if ( !colorLeft && ( mOp == boPlus || mOp == boMinus || mOp == boDiv ) )
         {
-          parent->setEvalErrorString( tr( "Can't perform /, +, - with Color on the right" ) );
+          parent->setEvalErrorString( tr( "Can't perform /, +, - with a color value on the right" ) );
           return QVariant();
         }
 
@@ -504,27 +503,27 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
             float c, m, y, k, a;
             color.getCmykF( &c, &m, &y, &k, &a );
             return QColor::fromCmykF(
-                     static_cast<float>( std::clamp( computeDouble( static_cast<double>( c ), value ), 0.0, 1.0 ) ),
-                     static_cast<float>( std::clamp( computeDouble( static_cast<double>( m ), value ), 0.0, 1.0 ) ),
-                     static_cast<float>( std::clamp( computeDouble( static_cast<double>( y ), value ), 0.0, 1.0 ) ),
-                     static_cast<float>( std::clamp( computeDouble( static_cast<double>( k ), value ), 0.0, 1.0 ) ),
-                     a
-                   );
+              static_cast<float>( std::clamp( computeDouble( static_cast<double>( c ), value ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( static_cast<double>( m ), value ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( static_cast<double>( y ), value ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( static_cast<double>( k ), value ), 0.0, 1.0 ) ),
+              a
+            );
           }
           case QColor::Hsl:
           case QColor::Hsv:
           case QColor::Rgb:
-          case QColor::ExtendedRgb:  // color_rgbf constructor clamps it to 0-1, so we do the same here
+          case QColor::ExtendedRgb: // color_rgbf constructor clamps it to 0-1, so we do the same here
           {
             QColor::Spec originSpec = color.spec();
             float r, g, b, a;
             color.getRgbF( &r, &g, &b, &a );
             QColor result = QColor::fromRgbF(
-                              static_cast<float>( std::clamp( computeDouble( static_cast<double>( r ), value ), 0.0, 1.0 ) ),
-                              static_cast<float>( std::clamp( computeDouble( static_cast<double>( g ), value ), 0.0, 1.0 ) ),
-                              static_cast<float>( std::clamp( computeDouble( static_cast<double>( b ), value ), 0.0, 1.0 ) ),
-                              a
-                            );
+              static_cast<float>( std::clamp( computeDouble( static_cast<double>( r ), value ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( static_cast<double>( g ), value ), 0.0, 1.0 ) ),
+              static_cast<float>( std::clamp( computeDouble( static_cast<double>( b ), value ), 0.0, 1.0 ) ),
+              a
+            );
             switch ( originSpec )
             {
               case QColor::Hsl:

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -481,10 +481,25 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         const QColor colorR = QgsExpressionUtils::getColorValue( vR, parent, isQColor );
         ENSURE_NO_EVAL_ERROR
 
-        switch ( colorL.spec() )
+        if ( !colorL.isValid() || !colorR.isValid() )
+        {
+          parent->setEvalErrorString( tr( "Cannot perform operation on invalid color" ) );
+          return QVariant();
+        }
+
+        QColor::Spec colorLSpec = colorL.spec();
+        QColor::Spec colorRSpec = colorR.spec();
+
+        switch ( colorLSpec )
         {
           case QColor::Cmyk:
           {
+            if ( colorRSpec != QColor::Cmyk )
+            {
+              parent->setEvalErrorString( tr( "Cannot combine a CMYK color with a non-CMYK color" ) );
+              return QVariant();
+            }
+
             float lc, lm, ly, lk, la, rc, rm, ry, rk, ra;
             colorL.getCmykF( &lc, &lm, &ly, &lk, &la );
             colorR.getCmykF( &rc, &rm, &ry, &rk, &ra );
@@ -493,7 +508,7 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
               static_cast<float>( std::clamp( computeDouble( lm, rm ), 0.0, 1.0 ) ),
               static_cast<float>( std::clamp( computeDouble( ly, ry ), 0.0, 1.0 ) ),
               static_cast<float>( std::clamp( computeDouble( lk, rk ), 0.0, 1.0 ) ),
-              static_cast<float>( std::clamp( computeDouble( la, ra ), 0.0, 1.0 ) )
+              la
             );
           }
           case QColor::Hsl:
@@ -501,25 +516,18 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
           case QColor::Rgb:
           case QColor::ExtendedRgb:
           {
-            QColor::Spec originSpec = colorL.spec();
+            if ( colorRSpec == QColor::Cmyk )
+            {
+              parent->setEvalErrorString( tr( "Cannot combine a non-CMYK color with a CMYK color" ) );
+              return QVariant();
+            }
+
             float lr, lg, lb, la, rr, rg, rb, ra;
             colorL.getRgbF( &lr, &lg, &lb, &la );
             colorR.getRgbF( &rr, &rg, &rb, &ra );
-            QColor result = QColor::fromRgbF(
-              static_cast<float>( std::clamp( computeDouble( lr, rr ), 0.0, 1.0 ) ),
-              static_cast<float>( std::clamp( computeDouble( lg, rg ), 0.0, 1.0 ) ),
-              static_cast<float>( std::clamp( computeDouble( lb, rb ), 0.0, 1.0 ) ),
-              static_cast<float>( std::clamp( computeDouble( la, ra ), 0.0, 1.0 ) )
-            );
-            switch ( originSpec )
-            {
-              case QColor::Hsl:
-                return result.toHsl();
-              case QColor::Hsv:
-                return result.toHsv();
-              default:
-                return result;
-            }
+            QColor result = QColor::
+              fromRgbF( static_cast<float>( std::clamp( computeDouble( lr, rr ), 0.0, 1.0 ) ), static_cast<float>( std::clamp( computeDouble( lg, rg ), 0.0, 1.0 ) ), static_cast<float>( std::clamp( computeDouble( lb, rb ), 0.0, 1.0 ) ), la );
+            return result;
           }
           default:
             return QVariant();
@@ -532,6 +540,12 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
         bool isQColor = false;
         const QColor color = QgsExpressionUtils::getColorValue( colorLeft ? vL : vR, parent, isQColor );
         ENSURE_NO_EVAL_ERROR
+
+        if ( !color.isValid() )
+        {
+          parent->setEvalErrorString( tr( "Cannot perform operation on invalid color" ) );
+          return QVariant();
+        }
 
         const double value = QgsExpressionUtils::getDoubleValue( colorLeft ? vR : vL, parent );
         ENSURE_NO_EVAL_ERROR
@@ -558,6 +572,7 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
             const double dm = static_cast<double>( m );
             const double dy = static_cast<double>( y );
             const double dk = static_cast<double>( k );
+
             return QColor::fromCmykF(
               static_cast<float>( std::clamp( computeDouble( colorLeft ? dc : value, colorLeft ? value : dc ), 0.0, 1.0 ) ),
               static_cast<float>( std::clamp( computeDouble( colorLeft ? dm : value, colorLeft ? value : dm ), 0.0, 1.0 ) ),
@@ -571,27 +586,18 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
           case QColor::Rgb:
           case QColor::ExtendedRgb: // color_rgbf constructor clamps it to 0-1, so we do the same here
           {
-            QColor::Spec originSpec = color.spec();
             float r, g, b, a;
             color.getRgbF( &r, &g, &b, &a );
             const double dr = static_cast<double>( r );
             const double dg = static_cast<double>( g );
             const double db = static_cast<double>( b );
-            QColor result = QColor::fromRgbF(
+
+            return QColor::fromRgbF(
               static_cast<float>( std::clamp( computeDouble( colorLeft ? dr : value, colorLeft ? value : dr ), 0.0, 1.0 ) ),
               static_cast<float>( std::clamp( computeDouble( colorLeft ? dg : value, colorLeft ? value : dg ), 0.0, 1.0 ) ),
               static_cast<float>( std::clamp( computeDouble( colorLeft ? db : value, colorLeft ? value : db ), 0.0, 1.0 ) ),
               a
             );
-            switch ( originSpec )
-            {
-              case QColor::Hsl:
-                return result.toHsl();
-              case QColor::Hsv:
-                return result.toHsv();
-              default:
-                return result;
-            }
           }
           default:
             return QVariant();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2546,6 +2546,27 @@ class TestQgsExpression : public QObject
       QTest::newRow( "color hsva float" ) << "color_hsvf(0.5,0.9012,0,0.8034)" << false << QVariant( QColor::fromHsvF( 0.5f, 0.9012, 0, 0.8034 ) );
       QTest::newRow( "color hsv invalid float" ) << "color_hsvf(1.5,0.1,0,0)" << false << QVariant( QColor::fromHsvF( 1, 0.1, 0, 0 ) );
 
+      // Color addition
+      QTest::newRow( "color add int" ) << "color_rgbf(0.4,0.6,0.8) + 50" << false << QVariant( QColor( 152, 203, 254, 255 ) );
+      QTest::newRow( "color add float" ) << "color_rgbf(0.4,0.6,0.8) + 10.5" << false << QVariant( QColor( 113, 164, 215, 255 ) );
+      QTest::newRow( "color add overflow" ) << "color_rgbf(0.8,0.8,0.8) + 100" << false << QVariant( QColor( 255, 255, 255, 255 ) );
+
+      // Color subtraction
+      QTest::newRow( "color subtract int" ) << "color_rgbf(0.4,0.6,0.8) - 50" << false << QVariant( QColor( 52, 103, 154, 205 ) );
+      QTest::newRow( "color subtract float" ) << "color_rgbf(0.4,0.6,0.8) - 10.5" << false << QVariant( QColor( 92, 143, 194, 245 ) );
+      QTest::newRow( "color subtract underflow" ) << "color_rgbf(0.2,0.2,0.2) - 100" << false << QVariant( QColor( 0, 0, 0, 155 ) );
+
+      // Color multiplication
+      QTest::newRow( "color multiply int" ) << "color_rgbf(0.4,0.6,0.8) * 2" << false << QVariant( QColor( 204, 255, 255, 255 ) );
+      QTest::newRow( "color multiply float" ) << "color_rgbf(0.4,0.6,0.8) * 0.5" << false << QVariant( QColor( 51, 77, 102, 128 ) );
+      QTest::newRow( "color multiply zero" ) << "color_rgbf(0.4,0.6,0.8) * 0" << false << QVariant( QColor( 0, 0, 0, 0 ) );
+      QTest::newRow( "color multiply negative" ) << "color_rgbf(0.4,0.6,0.8) * -1" << false << QVariant( QColor( 0, 0, 0, 0 ) );
+
+      // Color division
+      QTest::newRow( "color divide int" ) << "color_rgbf(0.4,0.6,0.8) / 2" << false << QVariant( QColor( 51, 77, 102, 128 ) );
+      QTest::newRow( "color divide float" ) << "color_rgbf(0.4,0.6,0.8) / 0.5" << false << QVariant( QColor( 204, 255, 255, 255 ) );
+      QTest::newRow( "color divide zero" ) << "color_rgbf(0.4,0.6,0.8) / 0" << false << QVariant();
+
       // Precedence and associativity
       QTest::newRow( "multiplication first" ) << "1+2*3" << false << QVariant( 7 );
       QTest::newRow( "brackets first" ) << "(1+2)*(3+4)" << false << QVariant( 21 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2547,46 +2547,76 @@ class TestQgsExpression : public QObject
       QTest::newRow( "color hsv invalid float" ) << "color_hsvf(1.5,0.1,0,0)" << false << QVariant( QColor::fromHsvF( 1, 0.1, 0, 0 ) );
 
       // RGB color addition
-      QTest::newRow( "color rgb add int" ) << "color_rgbf(0.4,0.6,0.8,0.4) + 50" << false << QVariant( QColor( 152, 203, 254, 102 ) );
-      QTest::newRow( "color rgb add float" ) << "color_rgbf(0.4,0.6,0.8) + 10.5" << false << QVariant( QColor( 113, 164, 215, 255 ) );
-      QTest::newRow( "color rgb add overflow" ) << "color_rgbf(0.8,0.8,0.8) + 100" << false << QVariant( QColor( 255, 255, 255, 255 ) );
+      QTest::newRow( "color add float" ) << "color_rgbf(0.4,0.6,0.8) + 0.1" << false << QVariant( QColor::fromRgbF( 0.5, 0.7, 0.9, 1.0 ) );
+      QTest::newRow( "color add overflow" ) << "color_rgbf(0.8,0.8,0.8) + 1" << false << QVariant( QColor::fromRgbF( 1.0, 1.0, 1.0, 1.0 ) );
 
       // RGB color subtraction
-      QTest::newRow( "color rgb subtract int" ) << "color_rgbf(0.4,0.6,0.8,0.4) - 50" << false << QVariant( QColor( 52, 103, 154, 102 ) );
-      QTest::newRow( "color rgb subtract float" ) << "color_rgbf(0.4,0.6,0.8) - 10.5" << false << QVariant( QColor( 92, 143, 194, 255 ) );
-      QTest::newRow( "color rgb subtract underflow" ) << "color_rgbf(0.2,0.2,0.2) - 100" << false << QVariant( QColor( 0, 0, 0, 255 ) );
+      QTest::newRow( "color subtract float" ) << "color_rgbf(0.4,0.6,0.8) - 0.1" << false << QVariant( QColor::fromRgbF( 0.3, 0.5, 0.7, 1.0 ) );
+      QTest::newRow( "color subtract underflow" ) << "color_rgbf(0.2,0.2,0.2) - 1" << false << QVariant( QColor::fromRgbF( 0.0, 0.0, 0.0, 1.0 ) );
 
       // RGB color multiplication
-      QTest::newRow( "color rgb ultiply int" ) << "color_rgbf(0.4,0.6,0.8,0.4) * 2" << false << QVariant( QColor( 204, 255, 255, 102 ) );
-      QTest::newRow( "color rgb multiply float" ) << "color_rgbf(0.4,0.6,0.8) * 0.5" << false << QVariant( QColor( 51, 77, 102, 255 ) );
-      QTest::newRow( "color rgb multiply zero" ) << "color_rgbf(0.4,0.6,0.8) * 0" << false << QVariant( QColor( 0, 0, 0, 255 ) );
-      QTest::newRow( "color rgb multiply negative" ) << "color_rgbf(0.4,0.6,0.8) * -1" << false << QVariant( QColor( 0, 0, 0, 255 ) );
+      QTest::newRow( "color multiply int" ) << "color_rgbf(0.4,0.6,0.8,0.4) * 2" << false << QVariant( QColor::fromRgbF( 0.8, 1.0, 1.0, 0.4 ) );
+      QTest::newRow( "color multiply float" ) << "color_rgbf(0.4,0.6,0.8) * 0.5" << false << QVariant( QColor::fromRgbF( 0.2, 0.3, 0.4, 1.0 ) );
+      QTest::newRow( "color multiply zero" ) << "color_rgbf(0.4,0.6,0.8) * 0" << false << QVariant( QColor::fromRgbF( 0.0, 0.0, 0.0, 1.0 ) );
+      QTest::newRow( "color multiply negative" ) << "color_rgbf(0.4,0.6,0.8) * -1" << false << QVariant( QColor::fromRgbF( 0.0, 0.0, 0.0, 1.0 ) );
 
       // RGB color division
-      QTest::newRow( "color rgb divide int" ) << "color_rgbf(0.4,0.6,0.8,0.4) / 2" << false << QVariant( QColor( 51, 77, 102, 102 ) );
-      QTest::newRow( "color rgb divide float" ) << "color_rgbf(0.4,0.6,0.8) / 0.5" << false << QVariant( QColor( 204, 255, 255, 255 ) );
-      QTest::newRow( "color rgb divide zero" ) << "color_rgbf(0.4,0.6,0.8) / 0" << false << QVariant();
+      QTest::newRow( "color divide int" ) << "color_rgbf(0.4,0.6,0.8,0.4) / 2" << false << QVariant( QColor::fromRgbF( 0.2, 0.3, 0.4, 0.4 ) );
+      QTest::newRow( "color divide float" ) << "color_rgbf(0.4,0.6,0.8) / 0.5" << false << QVariant( QColor::fromRgbF( 0.8, 1.0, 1.0, 1.0 ) );
+      QTest::newRow( "color divide zero" ) << "color_rgbf(0.4,0.6,0.8) / 0" << false << QVariant();
 
       // CMYK color addition
-      QTest::newRow( "color cmyk add int" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.4) + 50" << false << QVariant( QColor::fromCmyk( 152, 203, 254, 101, 102 ) );
-      QTest::newRow( "color cmyk add float" ) << "color_cmykf(0.4,0.6,0.8,0.2) + 10.5" << false << QVariant( QColor::fromCmyk( 113, 164, 215, 62, 255 ) );
-      QTest::newRow( "color cmyk add overflow" ) << "color_cmykf(0.8,0.8,0.8,0.8) + 100" << false << QVariant( QColor::fromCmyk( 255, 255, 255, 255, 255 ) );
+      QTest::newRow( "cmyk color add float" ) << "color_cmykf(0.4,0.6,0.8,0.2) + 0.1" << false << QVariant( QColor::fromCmykF( 0.5, 0.7, 0.9, 0.3, 1.0 ) );
+      QTest::newRow( "cmyk color add overflow" ) << "color_cmykf(0.8,0.8,0.8,0.8) + 1" << false << QVariant( QColor::fromCmykF( 1.0, 1.0, 1.0, 1.0, 1.0 ) );
 
       // CMYK color subtraction
-      QTest::newRow( "color cmyk subtract int" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.4) - 50" << false << QVariant( QColor::fromCmyk( 52, 103, 154, 1, 102 ) );
-      QTest::newRow( "color cmyk subtract float" ) << "color_cmykf(0.4,0.6,0.8,0.2) - 10.5" << false << QVariant( QColor::fromCmyk( 92, 143, 194, 41, 255 ) );
-      QTest::newRow( "color cmyk subtract underflow" ) << "color_cmykf(0.2,0.2,0.2,0.2) - 100" << false << QVariant( QColor::fromCmyk( 0, 0, 0, 0, 255 ) );
+      QTest::newRow( "cmyk color subtract float" ) << "color_cmykf(0.4,0.6,0.8,0.2) - 0.1" << false << QVariant( QColor::fromCmykF( 0.3, 0.5, 0.7, 0.1, 1.0 ) );
+      QTest::newRow( "cmyk color subtract underflow" ) << "color_cmykf(0.2,0.2,0.2,0.2) - 1" << false << QVariant( QColor::fromCmykF( 0.0, 0.0, 0.0, 0.0, 1.0 ) );
 
       // CMYK color multiplication
-      QTest::newRow( "color cmyk multiply int" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.4) * 2" << false << QVariant( QColor::fromCmyk( 204, 255, 255, 102, 102 ) );
-      QTest::newRow( "color cmyk multiply float" ) << "color_cmykf(0.4,0.6,0.8,0.2) * 0.5" << false << QVariant( QColor::fromCmyk( 51, 77, 102, 26, 255 ) );
-      QTest::newRow( "color cmyk multiply zero" ) << "color_cmykf(0.4,0.6,0.8,0.2) * 0" << false << QVariant( QColor::fromCmyk( 0, 0, 0, 0, 255 ) );
-      QTest::newRow( "color cmyk multiply negative" ) << "color_cmykf(0.4,0.6,0.8,0.2) * -1" << false << QVariant( QColor::fromCmyk( 0, 0, 0, 0, 255 ) );
+      QTest::newRow( "cmyk color multiply int" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.4) * 2" << false << QVariant( QColor::fromCmykF( 0.8, 1.0, 1.0, 0.4, 0.4 ) );
+      QTest::newRow( "cmyk color multiply float" ) << "color_cmykf(0.4,0.6,0.8,0.2) * 0.5" << false << QVariant( QColor::fromCmykF( 0.2, 0.3, 0.4, 0.1, 1.0 ) );
+      QTest::newRow( "cmyk color multiply zero" ) << "color_cmykf(0.4,0.6,0.8,0.2) * 0" << false << QVariant( QColor::fromCmykF( 0.0, 0.0, 0.0, 0.0, 1.0 ) );
+      QTest::newRow( "cmyk color multiply negative" ) << "color_cmykf(0.4,0.6,0.8,0.2) * -1" << false << QVariant( QColor::fromCmykF( 0.0, 0.0, 0.0, 0.0, 1.0 ) );
 
       // CMYK color division
-      QTest::newRow( "color cmyk divide int" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.4) / 2" << false << QVariant( QColor::fromCmyk( 51, 77, 102, 26, 102 ) );
-      QTest::newRow( "color cmyk divide float" ) << "color_cmykf(0.4,0.6,0.8,0.2) / 0.5" << false << QVariant( QColor::fromCmyk( 204, 255, 255, 102, 255 ) );
-      QTest::newRow( "color cmyk divide zero" ) << "color_cmykf(0.4,0.6,0.8,0.2) / 0" << false << QVariant();
+      QTest::newRow( "cmyk color divide int" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.4) / 2" << false << QVariant( QColor::fromCmykF( 0.2, 0.3, 0.4, 0.1, 0.4 ) );
+      QTest::newRow( "cmyk color divide float" ) << "color_cmykf(0.4,0.6,0.8,0.2) / 0.5" << false << QVariant( QColor::fromCmykF( 0.8, 1.0, 1.0, 0.4, 1.0 ) );
+      QTest::newRow( "cmyk color divide zero" ) << "color_cmykf(0.4,0.6,0.8,0.2) / 0" << false << QVariant();
+
+      // HSL color addition
+      QTest::newRow( "hsl color add" ) << "color_hslf(0,0,0.5) + 0.2" << false << QVariant( QColor::fromHslF( -1, 0, 0.7, 1.0 ) );
+      QTest::newRow( "hsl color add 2" ) << "color_hslf(0.75,0.5,0.5) + 0.3" << false << QVariant( QColor::fromHslF( 0.7592, 1.0, 0.775, 1.0 ) );
+      QTest::newRow( "hsl color add overflow" ) << "color_hslf(0,0,0.8) + 0.5" << false << QVariant( QColor::fromHslF( -1, 0, 1.0, 1.0 ) );
+
+      // HSL color subtraction
+      QTest::newRow( "hsl color subtract" ) << "color_hslf(0,0,0.5) - 0.2" << false << QVariant( QColor::fromHslF( -1, 0, 0.3, 1.0 ) );
+      QTest::newRow( "hsl color subtract 2" ) << "color_hslf(0.75,0.5,0.5) - 0.3" << false << QVariant( QColor::fromHslF( 0.7408, 1.0, 0.225, 1.0 ) );
+      QTest::newRow( "hsl color subtract underflow" ) << "color_hslf(0,0,0.2) - 0.5" << false << QVariant( QColor::fromHslF( -1, 0, 0, 1.0 ) );
+
+      // HSL color multiplication
+      QTest::newRow( "hsl color multiply" ) << "color_hslf(0,0,0.5) * 0.5" << false << QVariant( QColor::fromHslF( -1, 0, 0.25, 1.0 ) );
+      QTest::newRow( "hsl color multiply overflow" ) << "color_hslf(0,0,0.5) * 3" << false << QVariant( QColor::fromHslF( -1, 0, 1.0, 1.0 ) );
+
+      // HSL color division
+      QTest::newRow( "hsl color divide" ) << "color_hslf(0,0,0.8) / 2" << false << QVariant( QColor::fromHslF( -1, 0, 0.4, 1.0 ) );
+      QTest::newRow( "hsl color divide zero" ) << "color_hslf(0,0,0.5) / 0" << false << QVariant();
+
+      // HSV color addition
+      QTest::newRow( "hsv color add" ) << "color_hsvf(0,0,0.5) + 0.2" << false << QVariant( QColor::fromHsvF( -1, 0, 0.7, 1.0 ) );
+      QTest::newRow( "hsv color add overflow" ) << "color_hsvf(0,0,0.8) + 0.5" << false << QVariant( QColor::fromHsvF( -1, 0, 1.0, 1.0 ) );
+
+      // HSV color subtraction
+      QTest::newRow( "hsv color subtract" ) << "color_hsvf(0,0,0.5) - 0.2" << false << QVariant( QColor::fromHsvF( -1, 0, 0.3, 1.0 ) );
+      QTest::newRow( "hsv color subtract underflow" ) << "color_hsvf(0,0,0.2) - 0.5" << false << QVariant( QColor::fromHsvF( -1, 0, 0, 1.0 ) );
+
+      // HSV color multiplication
+      QTest::newRow( "hsv color multiply" ) << "color_hsvf(0,0,0.5) * 0.5" << false << QVariant( QColor::fromHsvF( -1, 0, 0.25, 1.0 ) );
+      QTest::newRow( "hsv color multiply overflow" ) << "color_hsvf(0,0,0.5) * 3" << false << QVariant( QColor::fromHsvF( -1, 0, 1.0, 1.0 ) );
+
+      // HSV color division
+      QTest::newRow( "hsv color divide" ) << "color_hsvf(0,0,0.8) / 2" << false << QVariant( QColor::fromHsvF( -1, 0, 0.4, 1.0 ) );
+      QTest::newRow( "hsv color divide zero" ) << "color_hsvf(0,0,0.5) / 0" << false << QVariant();
 
       // Precedence and associativity
       QTest::newRow( "multiplication first" ) << "1+2*3" << false << QVariant( 7 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2546,26 +2546,47 @@ class TestQgsExpression : public QObject
       QTest::newRow( "color hsva float" ) << "color_hsvf(0.5,0.9012,0,0.8034)" << false << QVariant( QColor::fromHsvF( 0.5f, 0.9012, 0, 0.8034 ) );
       QTest::newRow( "color hsv invalid float" ) << "color_hsvf(1.5,0.1,0,0)" << false << QVariant( QColor::fromHsvF( 1, 0.1, 0, 0 ) );
 
-      // Color addition
-      QTest::newRow( "color add int" ) << "color_rgbf(0.4,0.6,0.8) + 50" << false << QVariant( QColor( 152, 203, 254, 255 ) );
-      QTest::newRow( "color add float" ) << "color_rgbf(0.4,0.6,0.8) + 10.5" << false << QVariant( QColor( 113, 164, 215, 255 ) );
-      QTest::newRow( "color add overflow" ) << "color_rgbf(0.8,0.8,0.8) + 100" << false << QVariant( QColor( 255, 255, 255, 255 ) );
+      // RGB color addition
+      QTest::newRow( "color rgb add int" ) << "color_rgbf(0.4,0.6,0.8,0.4) + 50" << false << QVariant( QColor( 152, 203, 254, 102 ) );
+      QTest::newRow( "color rgb add float" ) << "color_rgbf(0.4,0.6,0.8) + 10.5" << false << QVariant( QColor( 113, 164, 215, 255 ) );
+      QTest::newRow( "color rgb add overflow" ) << "color_rgbf(0.8,0.8,0.8) + 100" << false << QVariant( QColor( 255, 255, 255, 255 ) );
 
-      // Color subtraction
-      QTest::newRow( "color subtract int" ) << "color_rgbf(0.4,0.6,0.8) - 50" << false << QVariant( QColor( 52, 103, 154, 205 ) );
-      QTest::newRow( "color subtract float" ) << "color_rgbf(0.4,0.6,0.8) - 10.5" << false << QVariant( QColor( 92, 143, 194, 245 ) );
-      QTest::newRow( "color subtract underflow" ) << "color_rgbf(0.2,0.2,0.2) - 100" << false << QVariant( QColor( 0, 0, 0, 155 ) );
+      // RGB color subtraction
+      QTest::newRow( "color rgb subtract int" ) << "color_rgbf(0.4,0.6,0.8,0.4) - 50" << false << QVariant( QColor( 52, 103, 154, 102 ) );
+      QTest::newRow( "color rgb subtract float" ) << "color_rgbf(0.4,0.6,0.8) - 10.5" << false << QVariant( QColor( 92, 143, 194, 255 ) );
+      QTest::newRow( "color rgb subtract underflow" ) << "color_rgbf(0.2,0.2,0.2) - 100" << false << QVariant( QColor( 0, 0, 0, 255 ) );
 
-      // Color multiplication
-      QTest::newRow( "color multiply int" ) << "color_rgbf(0.4,0.6,0.8) * 2" << false << QVariant( QColor( 204, 255, 255, 255 ) );
-      QTest::newRow( "color multiply float" ) << "color_rgbf(0.4,0.6,0.8) * 0.5" << false << QVariant( QColor( 51, 77, 102, 128 ) );
-      QTest::newRow( "color multiply zero" ) << "color_rgbf(0.4,0.6,0.8) * 0" << false << QVariant( QColor( 0, 0, 0, 0 ) );
-      QTest::newRow( "color multiply negative" ) << "color_rgbf(0.4,0.6,0.8) * -1" << false << QVariant( QColor( 0, 0, 0, 0 ) );
+      // RGB color multiplication
+      QTest::newRow( "color rgb ultiply int" ) << "color_rgbf(0.4,0.6,0.8,0.4) * 2" << false << QVariant( QColor( 204, 255, 255, 102 ) );
+      QTest::newRow( "color rgb multiply float" ) << "color_rgbf(0.4,0.6,0.8) * 0.5" << false << QVariant( QColor( 51, 77, 102, 255 ) );
+      QTest::newRow( "color rgb multiply zero" ) << "color_rgbf(0.4,0.6,0.8) * 0" << false << QVariant( QColor( 0, 0, 0, 255 ) );
+      QTest::newRow( "color rgb multiply negative" ) << "color_rgbf(0.4,0.6,0.8) * -1" << false << QVariant( QColor( 0, 0, 0, 255 ) );
 
-      // Color division
-      QTest::newRow( "color divide int" ) << "color_rgbf(0.4,0.6,0.8) / 2" << false << QVariant( QColor( 51, 77, 102, 128 ) );
-      QTest::newRow( "color divide float" ) << "color_rgbf(0.4,0.6,0.8) / 0.5" << false << QVariant( QColor( 204, 255, 255, 255 ) );
-      QTest::newRow( "color divide zero" ) << "color_rgbf(0.4,0.6,0.8) / 0" << false << QVariant();
+      // RGB color division
+      QTest::newRow( "color rgb divide int" ) << "color_rgbf(0.4,0.6,0.8,0.4) / 2" << false << QVariant( QColor( 51, 77, 102, 102 ) );
+      QTest::newRow( "color rgb divide float" ) << "color_rgbf(0.4,0.6,0.8) / 0.5" << false << QVariant( QColor( 204, 255, 255, 255 ) );
+      QTest::newRow( "color rgb divide zero" ) << "color_rgbf(0.4,0.6,0.8) / 0" << false << QVariant();
+
+      // CMYK color addition
+      QTest::newRow( "color cmyk add int" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.4) + 50" << false << QVariant( QColor::fromCmyk( 152, 203, 254, 101, 102 ) );
+      QTest::newRow( "color cmyk add float" ) << "color_cmykf(0.4,0.6,0.8,0.2) + 10.5" << false << QVariant( QColor::fromCmyk( 113, 164, 215, 62, 255 ) );
+      QTest::newRow( "color cmyk add overflow" ) << "color_cmykf(0.8,0.8,0.8,0.8) + 100" << false << QVariant( QColor::fromCmyk( 255, 255, 255, 255, 255 ) );
+
+      // CMYK color subtraction
+      QTest::newRow( "color cmyk subtract int" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.4) - 50" << false << QVariant( QColor::fromCmyk( 52, 103, 154, 1, 102 ) );
+      QTest::newRow( "color cmyk subtract float" ) << "color_cmykf(0.4,0.6,0.8,0.2) - 10.5" << false << QVariant( QColor::fromCmyk( 92, 143, 194, 41, 255 ) );
+      QTest::newRow( "color cmyk subtract underflow" ) << "color_cmykf(0.2,0.2,0.2,0.2) - 100" << false << QVariant( QColor::fromCmyk( 0, 0, 0, 0, 255 ) );
+
+      // CMYK color multiplication
+      QTest::newRow( "color cmyk multiply int" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.4) * 2" << false << QVariant( QColor::fromCmyk( 204, 255, 255, 102, 102 ) );
+      QTest::newRow( "color cmyk multiply float" ) << "color_cmykf(0.4,0.6,0.8,0.2) * 0.5" << false << QVariant( QColor::fromCmyk( 51, 77, 102, 26, 255 ) );
+      QTest::newRow( "color cmyk multiply zero" ) << "color_cmykf(0.4,0.6,0.8,0.2) * 0" << false << QVariant( QColor::fromCmyk( 0, 0, 0, 0, 255 ) );
+      QTest::newRow( "color cmyk multiply negative" ) << "color_cmykf(0.4,0.6,0.8,0.2) * -1" << false << QVariant( QColor::fromCmyk( 0, 0, 0, 0, 255 ) );
+
+      // CMYK color division
+      QTest::newRow( "color cmyk divide int" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.4) / 2" << false << QVariant( QColor::fromCmyk( 51, 77, 102, 26, 102 ) );
+      QTest::newRow( "color cmyk divide float" ) << "color_cmykf(0.4,0.6,0.8,0.2) / 0.5" << false << QVariant( QColor::fromCmyk( 204, 255, 255, 102, 255 ) );
+      QTest::newRow( "color cmyk divide zero" ) << "color_cmykf(0.4,0.6,0.8,0.2) / 0" << false << QVariant();
 
       // Precedence and associativity
       QTest::newRow( "multiplication first" ) << "1+2*3" << false << QVariant( 7 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2618,6 +2618,58 @@ class TestQgsExpression : public QObject
       QTest::newRow( "hsv color divide" ) << "color_hsvf(0,0,0.8) / 2" << false << QVariant( QColor::fromHsvF( -1, 0, 0.4, 1.0 ) );
       QTest::newRow( "hsv color divide zero" ) << "color_hsvf(0,0,0.5) / 0" << false << QVariant();
 
+      // float + color
+      QTest::newRow( "float plus rgb color" ) << "0.1 + color_rgbf(0.4,0.6,0.8)" << false << QVariant( QColor::fromRgbF( 0.5, 0.7, 0.9, 1.0 ) );
+      QTest::newRow( "float plus rgb color overflow" ) << "1 + color_rgbf(0.8,0.8,0.8)" << false << QVariant( QColor::fromRgbF( 1.0, 1.0, 1.0, 1.0 ) );
+      QTest::newRow( "float plus cmyk color" ) << "0.1 + color_cmykf(0.4,0.6,0.8,0.2)" << false << QVariant( QColor::fromCmykF( 0.5, 0.7, 0.9, 0.3, 1.0 ) );
+      QTest::newRow( "float plus hsl color" ) << "0.2 + color_hslf(0,0,0.5)" << false << QVariant( QColor::fromHslF( -1, 0, 0.7, 1.0 ) );
+      QTest::newRow( "float plus hsv color" ) << "0.2 + color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.7, 1.0 ) );
+
+      // float - color
+      QTest::newRow( "float minus rgb color" ) << "1.0 - color_rgbf(0.4,0.6,0.8)" << false << QVariant( QColor::fromRgbF( 0.6, 0.4, 0.2, 1.0 ) );
+      QTest::newRow( "float minus rgb color underflow" ) << "0.5 - color_rgbf(0.4,0.6,0.8)" << false << QVariant( QColor::fromRgbF( 0.1, 0.0, 0.0, 1.0 ) );
+      QTest::newRow( "float minus cmyk color" ) << "1.0 - color_cmykf(0.4,0.6,0.8,0.2)" << false << QVariant( QColor::fromCmykF( 0.6, 0.4, 0.2, 0.8, 1.0 ) );
+      QTest::newRow( "float minus cmyk color underflow" ) << "0.5 - color_cmykf(0.4,0.6,0.8,0.2)" << false << QVariant( QColor::fromCmykF( 0.1, 0.0, 0.0, 0.3, 1.0 ) );
+      QTest::newRow( "float minus hsl color" ) << "0.8 - color_hslf(0,0,0.5)" << false << QVariant( QColor::fromHslF( -1, 0, 0.3, 1.0 ) );
+      QTest::newRow( "float minus hsv color" ) << "0.8 - color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.3, 1.0 ) );
+
+      // float divided by color
+      QTest::newRow( "float divide color error" ) << "1.0 / color_rgbf(0.4,0.6,0.8)" << true << QVariant();
+
+      // RGB color + RGB color
+      QTest::newRow( "rgb color add color" ) << "color_rgbf(0.4,0.6,0.8) + color_rgbf(0.1,0.2,0.1)" << false << QVariant( QColor::fromRgbF( 0.5, 0.8, 0.9, 1.0 ) );
+      QTest::newRow( "rgb color add color overflow" ) << "color_rgbf(0.8,0.8,0.8) + color_rgbf(0.5,0.5,0.5)" << false << QVariant( QColor::fromRgbF( 1.0, 1.0, 1.0, 1.0 ) );
+      QTest::newRow( "rgb color add color alpha combined" ) << "color_rgbf(0.4,0.6,0.8,0.5) + color_rgbf(0.1,0.2,0.1,0.9)" << false << QVariant( QColor::fromRgbF( 0.5, 0.8, 0.9, 1.0 ) );
+      QTest::newRow( "rgb color subtract color" ) << "color_rgbf(0.4,0.6,0.8) - color_rgbf(0.1,0.1,0.3)" << false << QVariant( QColor::fromRgbF( 0.3, 0.5, 0.5, 0.0 ) );
+      QTest::newRow( "rgb color subtract color underflow" ) << "color_rgbf(0.1,0.1,0.1) - color_rgbf(0.5,0.5,0.5)" << false << QVariant( QColor::fromRgbF( 0.0, 0.0, 0.0, 0.0 ) );
+      QTest::newRow( "rgb color multiply color" ) << "color_rgbf(0.4,0.6,0.8) * color_rgbf(0.5,0.5,0.5)" << false << QVariant( QColor::fromRgbF( 0.2, 0.3, 0.4, 1.0 ) );
+      QTest::newRow( "rgb color divide color" ) << "color_rgbf(0.4,0.6,0.8) / color_rgbf(0.5,0.5,0.5)" << false << QVariant( QColor::fromRgbF( 0.8, 1.0, 1.0, 1.0 ) );
+
+      // CMYK color + CMYK color
+      QTest::newRow( "cmyk color add color" ) << "color_cmykf(0.4,0.6,0.8,0.2) + color_cmykf(0.1,0.1,0.1,0.1)" << false << QVariant( QColor::fromCmykF( 0.5, 0.7, 0.9, 0.3, 1.0 ) );
+      QTest::newRow( "cmyk color add color overflow" ) << "color_cmykf(0.8,0.8,0.8,0.8) + color_cmykf(0.5,0.5,0.5,0.5)" << false << QVariant( QColor::fromCmykF( 1.0, 1.0, 1.0, 1.0, 1.0 ) );
+      QTest::newRow( "cmyk color add color alpha combined" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.5) + color_cmykf(0.1,0.1,0.1,0.1,0.9)" << false << QVariant( QColor::fromCmykF( 0.5, 0.7, 0.9, 0.3, 1.0 ) );
+      QTest::newRow( "cmyk color subtract color" ) << "color_cmykf(0.4,0.6,0.8,0.2) - color_cmykf(0.1,0.1,0.3,0.1)" << false << QVariant( QColor::fromCmykF( 0.3, 0.5, 0.5, 0.1, 0.0 ) );
+      QTest::newRow( "cmyk color subtract color underflow" ) << "color_cmykf(0.1,0.1,0.1,0.1) - color_cmykf(0.5,0.5,0.5,0.5)" << false << QVariant( QColor::fromCmykF( 0.0, 0.0, 0.0, 0.0, 0.0 ) );
+      QTest::newRow( "cmyk color multiply color" ) << "color_cmykf(0.4,0.6,0.8,0.2) * color_cmykf(0.5,0.5,0.5,0.5)" << false << QVariant( QColor::fromCmykF( 0.2, 0.3, 0.4, 0.1, 1.0 ) );
+      QTest::newRow( "cmyk color divide color" ) << "color_cmykf(0.4,0.6,0.8,0.2) / color_cmykf(0.5,0.5,0.5,0.5)" << false << QVariant( QColor::fromCmykF( 0.8, 1.0, 1.0, 0.4, 1.0 ) );
+
+      // HSL color + HSL color
+      QTest::newRow( "hsl color add color" ) << "color_hslf(0,0,0.5) + color_hslf(0,0,0.2)" << false << QVariant( QColor::fromHslF( -1, 0, 0.7, 1.0 ) );
+      QTest::newRow( "hsl color add color overflow" ) << "color_hslf(0,0,0.8) + color_hslf(0,0,0.5)" << false << QVariant( QColor::fromHslF( -1, 0, 1.0, 1.0 ) );
+      QTest::newRow( "hsl color subtract color" ) << "color_hslf(0,0,0.7) - color_hslf(0,0,0.2)" << false << QVariant( QColor::fromHslF( -1, 0, 0.5, 0.0 ) );
+      QTest::newRow( "hsl color subtract color underflow" ) << "color_hslf(0,0,0.1) - color_hslf(0,0,0.5)" << false << QVariant( QColor::fromHslF( -1, 0, 0.0, 0.0 ) );
+      QTest::newRow( "hsl color multiply color" ) << "color_hslf(0,0,0.5) * color_hslf(0,0,0.6)" << false << QVariant( QColor::fromHslF( -1, 0, 0.3, 1.0 ) );
+      QTest::newRow( "hsl color divide color" ) << "color_hslf(0,0,0.8) / color_hslf(0,0,0.4)" << false << QVariant( QColor::fromHslF( -1, 0, 1.0, 1.0 ) );
+
+      // HSV color + HSV color
+      QTest::newRow( "hsv color add color" ) << "color_hsvf(0,0,0.5) + color_hsvf(0,0,0.2)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.7, 1.0 ) );
+      QTest::newRow( "hsv color add color overflow" ) << "color_hsvf(0,0,0.8) + color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromHsvF( -1, 0, 1.0, 1.0 ) );
+      QTest::newRow( "hsv color subtract color" ) << "color_hsvf(0,0,0.7) - color_hsvf(0,0,0.2)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.5, 0.0 ) );
+      QTest::newRow( "hsv color subtract color underflow" ) << "color_hsvf(0,0,0.1) - color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.0, 0.0 ) );
+      QTest::newRow( "hsv color multiply color" ) << "color_hsvf(0,0,0.5) * color_hsvf(0,0,0.6)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.3, 1.0 ) );
+      QTest::newRow( "hsv color divide color" ) << "color_hsvf(0,0,0.8) / color_hsvf(0,0,0.4)" << false << QVariant( QColor::fromHsvF( -1, 0, 1.0, 1.0 ) );
+
       // Precedence and associativity
       QTest::newRow( "multiplication first" ) << "1+2*3" << false << QVariant( 7 );
       QTest::newRow( "brackets first" ) << "(1+2)*(3+4)" << false << QVariant( 21 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2585,53 +2585,53 @@ class TestQgsExpression : public QObject
       QTest::newRow( "cmyk color divide zero" ) << "color_cmykf(0.4,0.6,0.8,0.2) / 0" << false << QVariant();
 
       // HSL color addition
-      QTest::newRow( "hsl color add" ) << "color_hslf(0,0,0.5) + 0.2" << false << QVariant( QColor::fromHslF( -1, 0, 0.7, 1.0 ) );
-      QTest::newRow( "hsl color add 2" ) << "color_hslf(0.75,0.5,0.5) + 0.3" << false << QVariant( QColor::fromHslF( 0.7592, 1.0, 0.775, 1.0 ) );
-      QTest::newRow( "hsl color add overflow" ) << "color_hslf(0,0,0.8) + 0.5" << false << QVariant( QColor::fromHslF( -1, 0, 1.0, 1.0 ) );
+      QTest::newRow( "hsl color add" ) << "color_hslf(0,0,0.5) + 0.2" << false << QVariant( QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
+      QTest::newRow( "hsl color add 2" ) << "color_hslf(0.75,0.5,0.5) + 0.3" << false << QVariant( QColor::fromRgbF( 0.8f, 0.55f, 1.0f, 1.0f ) );
+      QTest::newRow( "hsl color add overflow" ) << "color_hslf(0,0,0.8) + 0.5" << false << QVariant( QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) );
 
       // HSL color subtraction
-      QTest::newRow( "hsl color subtract" ) << "color_hslf(0,0,0.5) - 0.2" << false << QVariant( QColor::fromHslF( -1, 0, 0.3, 1.0 ) );
-      QTest::newRow( "hsl color subtract 2" ) << "color_hslf(0.75,0.5,0.5) - 0.3" << false << QVariant( QColor::fromHslF( 0.7408, 1.0, 0.225, 1.0 ) );
-      QTest::newRow( "hsl color subtract underflow" ) << "color_hslf(0,0,0.2) - 0.5" << false << QVariant( QColor::fromHslF( -1, 0, 0, 1.0 ) );
+      QTest::newRow( "hsl color subtract" ) << "color_hslf(0,0,0.5) - 0.2" << false << QVariant( QColor::fromRgbF( 0.3f, 0.3f, 0.3f, 1.0f ) );
+      QTest::newRow( "hsl color subtract 2" ) << "color_hslf(0.75,0.5,0.5) - 0.3" << false << QVariant( QColor::fromRgbF( 0.2f, 0.0f, 0.45f, 1.0f ) );
+      QTest::newRow( "hsl color subtract underflow" ) << "color_hslf(0,0,0.2) - 0.5" << false << QVariant( QColor::fromRgbF( 0.0f, 0.0f, 0.0f, 1.0f ) );
 
       // HSL color multiplication
-      QTest::newRow( "hsl color multiply" ) << "color_hslf(0,0,0.5) * 0.5" << false << QVariant( QColor::fromHslF( -1, 0, 0.25, 1.0 ) );
-      QTest::newRow( "hsl color multiply overflow" ) << "color_hslf(0,0,0.5) * 3" << false << QVariant( QColor::fromHslF( -1, 0, 1.0, 1.0 ) );
+      QTest::newRow( "hsl color multiply" ) << "color_hslf(0,0,0.5) * 0.5" << false << QVariant( QColor::fromRgbF( 0.25f, 0.25f, 0.25f, 1.0f ) );
+      QTest::newRow( "hsl color multiply overflow" ) << "color_hslf(0,0,0.5) * 3" << false << QVariant( QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) );
 
       // HSL color division
-      QTest::newRow( "hsl color divide" ) << "color_hslf(0,0,0.8) / 2" << false << QVariant( QColor::fromHslF( -1, 0, 0.4, 1.0 ) );
+      QTest::newRow( "hsl color divide" ) << "color_hslf(0,0,0.8) / 2" << false << QVariant( QColor::fromRgbF( 0.4f, 0.4f, 0.4f, 1.0f ) );
       QTest::newRow( "hsl color divide zero" ) << "color_hslf(0,0,0.5) / 0" << false << QVariant();
 
       // HSV color addition
-      QTest::newRow( "hsv color add" ) << "color_hsvf(0,0,0.5) + 0.2" << false << QVariant( QColor::fromHsvF( -1, 0, 0.7, 1.0 ) );
-      QTest::newRow( "hsv color add overflow" ) << "color_hsvf(0,0,0.8) + 0.5" << false << QVariant( QColor::fromHsvF( -1, 0, 1.0, 1.0 ) );
+      QTest::newRow( "hsv color add" ) << "color_hsvf(0,0,0.5) + 0.2" << false << QVariant( QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
+      QTest::newRow( "hsv color add overflow" ) << "color_hsvf(0,0,0.8) + 0.5" << false << QVariant( QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) );
 
       // HSV color subtraction
-      QTest::newRow( "hsv color subtract" ) << "color_hsvf(0,0,0.5) - 0.2" << false << QVariant( QColor::fromHsvF( -1, 0, 0.3, 1.0 ) );
-      QTest::newRow( "hsv color subtract underflow" ) << "color_hsvf(0,0,0.2) - 0.5" << false << QVariant( QColor::fromHsvF( -1, 0, 0, 1.0 ) );
+      QTest::newRow( "hsv color subtract" ) << "color_hsvf(0,0,0.5) - 0.2" << false << QVariant( QColor::fromRgbF( 0.3f, 0.3f, 0.3f, 1.0f ) );
+      QTest::newRow( "hsv color subtract underflow" ) << "color_hsvf(0,0,0.2) - 0.5" << false << QVariant( QColor::fromRgbF( 0.0f, 0.0f, 0.0f, 1.0f ) );
 
       // HSV color multiplication
-      QTest::newRow( "hsv color multiply" ) << "color_hsvf(0,0,0.5) * 0.5" << false << QVariant( QColor::fromHsvF( -1, 0, 0.25, 1.0 ) );
-      QTest::newRow( "hsv color multiply overflow" ) << "color_hsvf(0,0,0.5) * 3" << false << QVariant( QColor::fromHsvF( -1, 0, 1.0, 1.0 ) );
+      QTest::newRow( "hsv color multiply" ) << "color_hsvf(0,0,0.5) * 0.5" << false << QVariant( QColor::fromRgbF( 0.25f, 0.25f, 0.25f, 1.0f ) );
+      QTest::newRow( "hsv color multiply overflow" ) << "color_hsvf(0,0,0.5) * 3" << false << QVariant( QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) );
 
       // HSV color division
-      QTest::newRow( "hsv color divide" ) << "color_hsvf(0,0,0.8) / 2" << false << QVariant( QColor::fromHsvF( -1, 0, 0.4, 1.0 ) );
+      QTest::newRow( "hsv color divide" ) << "color_hsvf(0,0,0.8) / 2" << false << QVariant( QColor::fromRgbF( 0.4f, 0.4f, 0.4f, 1.0f ) );
       QTest::newRow( "hsv color divide zero" ) << "color_hsvf(0,0,0.5) / 0" << false << QVariant();
 
       // float + color
       QTest::newRow( "float plus rgb color" ) << "0.1 + color_rgbf(0.4,0.6,0.8)" << false << QVariant( QColor::fromRgbF( 0.5, 0.7, 0.9, 1.0 ) );
       QTest::newRow( "float plus rgb color overflow" ) << "1 + color_rgbf(0.8,0.8,0.8)" << false << QVariant( QColor::fromRgbF( 1.0, 1.0, 1.0, 1.0 ) );
       QTest::newRow( "float plus cmyk color" ) << "0.1 + color_cmykf(0.4,0.6,0.8,0.2)" << false << QVariant( QColor::fromCmykF( 0.5, 0.7, 0.9, 0.3, 1.0 ) );
-      QTest::newRow( "float plus hsl color" ) << "0.2 + color_hslf(0,0,0.5)" << false << QVariant( QColor::fromHslF( -1, 0, 0.7, 1.0 ) );
-      QTest::newRow( "float plus hsv color" ) << "0.2 + color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.7, 1.0 ) );
+      QTest::newRow( "float plus hsl color" ) << "0.2 + color_hslf(0,0,0.5)" << false << QVariant( QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
+      QTest::newRow( "float plus hsv color" ) << "0.2 + color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
 
       // float - color
       QTest::newRow( "float minus rgb color" ) << "1.0 - color_rgbf(0.4,0.6,0.8)" << false << QVariant( QColor::fromRgbF( 0.6, 0.4, 0.2, 1.0 ) );
       QTest::newRow( "float minus rgb color underflow" ) << "0.5 - color_rgbf(0.4,0.6,0.8)" << false << QVariant( QColor::fromRgbF( 0.1, 0.0, 0.0, 1.0 ) );
       QTest::newRow( "float minus cmyk color" ) << "1.0 - color_cmykf(0.4,0.6,0.8,0.2)" << false << QVariant( QColor::fromCmykF( 0.6, 0.4, 0.2, 0.8, 1.0 ) );
       QTest::newRow( "float minus cmyk color underflow" ) << "0.5 - color_cmykf(0.4,0.6,0.8,0.2)" << false << QVariant( QColor::fromCmykF( 0.1, 0.0, 0.0, 0.3, 1.0 ) );
-      QTest::newRow( "float minus hsl color" ) << "0.8 - color_hslf(0,0,0.5)" << false << QVariant( QColor::fromHslF( -1, 0, 0.3, 1.0 ) );
-      QTest::newRow( "float minus hsv color" ) << "0.8 - color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.3, 1.0 ) );
+      QTest::newRow( "float minus hsl color" ) << "0.8 - color_hslf(0,0,0.5)" << false << QVariant( QColor::fromRgbF( 0.3f, 0.3f, 0.3f, 1.0f ) );
+      QTest::newRow( "float minus hsv color" ) << "0.8 - color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromRgbF( 0.3f, 0.3f, 0.3f, 1.0f ) );
 
       // float divided by color
       QTest::newRow( "float divide color error" ) << "1.0 / color_rgbf(0.4,0.6,0.8)" << true << QVariant();
@@ -2639,36 +2639,36 @@ class TestQgsExpression : public QObject
       // RGB color + RGB color
       QTest::newRow( "rgb color add color" ) << "color_rgbf(0.4,0.6,0.8) + color_rgbf(0.1,0.2,0.1)" << false << QVariant( QColor::fromRgbF( 0.5, 0.8, 0.9, 1.0 ) );
       QTest::newRow( "rgb color add color overflow" ) << "color_rgbf(0.8,0.8,0.8) + color_rgbf(0.5,0.5,0.5)" << false << QVariant( QColor::fromRgbF( 1.0, 1.0, 1.0, 1.0 ) );
-      QTest::newRow( "rgb color add color alpha combined" ) << "color_rgbf(0.4,0.6,0.8,0.5) + color_rgbf(0.1,0.2,0.1,0.9)" << false << QVariant( QColor::fromRgbF( 0.5, 0.8, 0.9, 1.0 ) );
-      QTest::newRow( "rgb color subtract color" ) << "color_rgbf(0.4,0.6,0.8) - color_rgbf(0.1,0.1,0.3)" << false << QVariant( QColor::fromRgbF( 0.3, 0.5, 0.5, 0.0 ) );
-      QTest::newRow( "rgb color subtract color underflow" ) << "color_rgbf(0.1,0.1,0.1) - color_rgbf(0.5,0.5,0.5)" << false << QVariant( QColor::fromRgbF( 0.0, 0.0, 0.0, 0.0 ) );
+      QTest::newRow( "rgb color add color alpha" ) << "color_rgbf(0.4,0.6,0.8,0.5) + color_rgbf(0.1,0.2,0.1,0.9)" << false << QVariant( QColor::fromRgbF( 0.5, 0.8, 0.9, 0.5 ) );
+      QTest::newRow( "rgb color subtract color" ) << "color_rgbf(0.4,0.6,0.8) - color_rgbf(0.1,0.1,0.3)" << false << QVariant( QColor::fromRgbF( 0.3, 0.5, 0.5, 1.0 ) );
+      QTest::newRow( "rgb color subtract color underflow" ) << "color_rgbf(0.1,0.1,0.1) - color_rgbf(0.5,0.5,0.5)" << false << QVariant( QColor::fromRgbF( 0.0, 0.0, 0.0, 1.0 ) );
       QTest::newRow( "rgb color multiply color" ) << "color_rgbf(0.4,0.6,0.8) * color_rgbf(0.5,0.5,0.5)" << false << QVariant( QColor::fromRgbF( 0.2, 0.3, 0.4, 1.0 ) );
       QTest::newRow( "rgb color divide color" ) << "color_rgbf(0.4,0.6,0.8) / color_rgbf(0.5,0.5,0.5)" << false << QVariant( QColor::fromRgbF( 0.8, 1.0, 1.0, 1.0 ) );
 
       // CMYK color + CMYK color
       QTest::newRow( "cmyk color add color" ) << "color_cmykf(0.4,0.6,0.8,0.2) + color_cmykf(0.1,0.1,0.1,0.1)" << false << QVariant( QColor::fromCmykF( 0.5, 0.7, 0.9, 0.3, 1.0 ) );
       QTest::newRow( "cmyk color add color overflow" ) << "color_cmykf(0.8,0.8,0.8,0.8) + color_cmykf(0.5,0.5,0.5,0.5)" << false << QVariant( QColor::fromCmykF( 1.0, 1.0, 1.0, 1.0, 1.0 ) );
-      QTest::newRow( "cmyk color add color alpha combined" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.5) + color_cmykf(0.1,0.1,0.1,0.1,0.9)" << false << QVariant( QColor::fromCmykF( 0.5, 0.7, 0.9, 0.3, 1.0 ) );
-      QTest::newRow( "cmyk color subtract color" ) << "color_cmykf(0.4,0.6,0.8,0.2) - color_cmykf(0.1,0.1,0.3,0.1)" << false << QVariant( QColor::fromCmykF( 0.3, 0.5, 0.5, 0.1, 0.0 ) );
-      QTest::newRow( "cmyk color subtract color underflow" ) << "color_cmykf(0.1,0.1,0.1,0.1) - color_cmykf(0.5,0.5,0.5,0.5)" << false << QVariant( QColor::fromCmykF( 0.0, 0.0, 0.0, 0.0, 0.0 ) );
+      QTest::newRow( "cmyk color add color alpha" ) << "color_cmykf(0.4,0.6,0.8,0.2,0.5) + color_cmykf(0.1,0.1,0.1,0.1,0.9)" << false << QVariant( QColor::fromCmykF( 0.5, 0.7, 0.9, 0.3, 0.5 ) );
+      QTest::newRow( "cmyk color subtract color" ) << "color_cmykf(0.4,0.6,0.8,0.2) - color_cmykf(0.1,0.1,0.3,0.1)" << false << QVariant( QColor::fromCmykF( 0.3, 0.5, 0.5, 0.1, 1.0 ) );
+      QTest::newRow( "cmyk color subtract color underflow" ) << "color_cmykf(0.1,0.1,0.1,0.1) - color_cmykf(0.5,0.5,0.5,0.5)" << false << QVariant( QColor::fromCmykF( 0.0, 0.0, 0.0, 0.0, 1.0 ) );
       QTest::newRow( "cmyk color multiply color" ) << "color_cmykf(0.4,0.6,0.8,0.2) * color_cmykf(0.5,0.5,0.5,0.5)" << false << QVariant( QColor::fromCmykF( 0.2, 0.3, 0.4, 0.1, 1.0 ) );
       QTest::newRow( "cmyk color divide color" ) << "color_cmykf(0.4,0.6,0.8,0.2) / color_cmykf(0.5,0.5,0.5,0.5)" << false << QVariant( QColor::fromCmykF( 0.8, 1.0, 1.0, 0.4, 1.0 ) );
 
       // HSL color + HSL color
-      QTest::newRow( "hsl color add color" ) << "color_hslf(0,0,0.5) + color_hslf(0,0,0.2)" << false << QVariant( QColor::fromHslF( -1, 0, 0.7, 1.0 ) );
-      QTest::newRow( "hsl color add color overflow" ) << "color_hslf(0,0,0.8) + color_hslf(0,0,0.5)" << false << QVariant( QColor::fromHslF( -1, 0, 1.0, 1.0 ) );
-      QTest::newRow( "hsl color subtract color" ) << "color_hslf(0,0,0.7) - color_hslf(0,0,0.2)" << false << QVariant( QColor::fromHslF( -1, 0, 0.5, 0.0 ) );
-      QTest::newRow( "hsl color subtract color underflow" ) << "color_hslf(0,0,0.1) - color_hslf(0,0,0.5)" << false << QVariant( QColor::fromHslF( -1, 0, 0.0, 0.0 ) );
-      QTest::newRow( "hsl color multiply color" ) << "color_hslf(0,0,0.5) * color_hslf(0,0,0.6)" << false << QVariant( QColor::fromHslF( -1, 0, 0.3, 1.0 ) );
-      QTest::newRow( "hsl color divide color" ) << "color_hslf(0,0,0.8) / color_hslf(0,0,0.4)" << false << QVariant( QColor::fromHslF( -1, 0, 1.0, 1.0 ) );
+      QTest::newRow( "hsl color add color" ) << "color_hslf(0,0,0.5) + color_hslf(0,0,0.2)" << false << QVariant( QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
+      QTest::newRow( "hsl color add color overflow" ) << "color_hslf(0,0,0.8) + color_hslf(0,0,0.5)" << false << QVariant( QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) );
+      QTest::newRow( "hsl color subtract color" ) << "color_hslf(0,0,0.7) - color_hslf(0,0,0.2)" << false << QVariant( QColor::fromRgbF( 0.5f, 0.5f, 0.5f, 1.0f ) );
+      QTest::newRow( "hsl color subtract color underflow" ) << "color_hslf(0,0,0.1) - color_hslf(0,0,0.5)" << false << QVariant( QColor::fromRgbF( 0.0f, 0.0f, 0.0f, 1.0f ) );
+      QTest::newRow( "hsl color multiply color" ) << "color_hslf(0,0,0.5) * color_hslf(0,0,0.6)" << false << QVariant( QColor::fromRgbF( 0.3f, 0.3f, 0.3f, 1.0f ) );
+      QTest::newRow( "hsl color divide color" ) << "color_hslf(0,0,0.8) / color_hslf(0,0,0.4)" << false << QVariant( QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) );
 
       // HSV color + HSV color
-      QTest::newRow( "hsv color add color" ) << "color_hsvf(0,0,0.5) + color_hsvf(0,0,0.2)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.7, 1.0 ) );
-      QTest::newRow( "hsv color add color overflow" ) << "color_hsvf(0,0,0.8) + color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromHsvF( -1, 0, 1.0, 1.0 ) );
-      QTest::newRow( "hsv color subtract color" ) << "color_hsvf(0,0,0.7) - color_hsvf(0,0,0.2)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.5, 0.0 ) );
-      QTest::newRow( "hsv color subtract color underflow" ) << "color_hsvf(0,0,0.1) - color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.0, 0.0 ) );
-      QTest::newRow( "hsv color multiply color" ) << "color_hsvf(0,0,0.5) * color_hsvf(0,0,0.6)" << false << QVariant( QColor::fromHsvF( -1, 0, 0.3, 1.0 ) );
-      QTest::newRow( "hsv color divide color" ) << "color_hsvf(0,0,0.8) / color_hsvf(0,0,0.4)" << false << QVariant( QColor::fromHsvF( -1, 0, 1.0, 1.0 ) );
+      QTest::newRow( "hsv color add color" ) << "color_hsvf(0,0,0.5) + color_hsvf(0,0,0.2)" << false << QVariant( QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
+      QTest::newRow( "hsv color add color overflow" ) << "color_hsvf(0,0,0.8) + color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) );
+      QTest::newRow( "hsv color subtract color" ) << "color_hsvf(0,0,0.7) - color_hsvf(0,0,0.2)" << false << QVariant( QColor::fromRgbF( 0.5f, 0.5f, 0.5f, 1.0f ) );
+      QTest::newRow( "hsv color subtract color underflow" ) << "color_hsvf(0,0,0.1) - color_hsvf(0,0,0.5)" << false << QVariant( QColor::fromRgbF( 0.0f, 0.0f, 0.0f, 1.0f ) );
+      QTest::newRow( "hsv color multiply color" ) << "color_hsvf(0,0,0.5) * color_hsvf(0,0,0.6)" << false << QVariant( QColor::fromRgbF( 0.3f, 0.3f, 0.3f, 1.0f ) );
+      QTest::newRow( "hsv color divide color" ) << "color_hsvf(0,0,0.8) / color_hsvf(0,0,0.4)" << false << QVariant( QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) );
 
       // Precedence and associativity
       QTest::newRow( "multiplication first" ) << "1+2*3" << false << QVariant( 7 );


### PR DESCRIPTION
This PR adds support for modifying color objects (not strings!) in expressions.

Color is split into its basic components, and the operation is applied to them using the provided value.
For example, `color_rgbf(0.4,0.6,0.8) + 0.2` yields `RGBA: 0.6,0.8,1.0,1.0`.

Only multiplication is supported with color on either end with a numeric value, for all others,  color element needs to be on the left. 

The user doesn't need to handle "difficult" color component extractions and perform arithmetic operations on them if they want to produce a color.

An few examples based on #64889 for usage:

Base:
<img width="1933" height="1263" alt="Screenshot_20260211_165848" src="https://github.com/user-attachments/assets/b743cf6a-90aa-4550-80e4-975c186fa315" />

@point_color / 1.5
<img width="1933" height="1263" alt="Screenshot_20260211_170028" src="https://github.com/user-attachments/assets/c31462f0-27fa-47d4-850e-3ba236ba059d" />

(Attribute by ramp)
@point_color * scale_linear( @NumberOfReturns, 0, 8, 0.5, 1 )
<img width="1933" height="1263" alt="Screenshot_20260211_170820" src="https://github.com/user-attachments/assets/97a41669-c5fe-4dba-aa42-442fcedf9155" />