### PR TITLE
Fix export to File Geodatabase when there is no 64bit int field selected (Fix #64905)

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -329,9 +329,10 @@ void QgsVectorLayerSaveAsDialog::accept()
     }
     if ( targetAll )
     {
-      for ( int i = 0; i < mLayer->fields().size(); ++i )
+      const QgsAttributeList attributesSelected = selectedAttributes();
+      for ( int i = 0; i < attributesSelected.size(); ++i )
       {
-        QgsField fld = mLayer->fields().at( i );
+        QgsField fld = mLayer->fields().at( attributesSelected.at( i ) );
         if ( fld.type() == QMetaType::Type::LongLong )
         {
           if ( QMessageBox::question( this, tr( "Save Vector Layer As" ), tr( "The layer contains at least one 64-bit integer field, which, with the current settings, can only be exported as a Real field. It could be exported as a 64-bit integer field if the TARGET_ARCGIS_VERSION layer option is set to ARCGIS_PRO_3_2_OR_LATER. Do you want to continue and export it as a Real field?" ) ) != QMessageBox::Yes )
@@ -346,9 +347,10 @@ void QgsVectorLayerSaveAsDialog::accept()
   else if ( format() == "FileGDB"_L1 )
   {
     // The FileGDB driver based on the ESRI SDK doesn't support 64-bit integers
-    for ( int i = 0; i < mLayer->fields().size(); ++i )
+    const QgsAttributeList attributesSelected = selectedAttributes();
+    for ( int i = 0; i < attributesSelected.size(); ++i )
     {
-      QgsField fld = mLayer->fields().at( i );
+      QgsField fld = mLayer->fields().at( attributesSelected.at( i ) );
       if ( fld.type() == QMetaType::Type::LongLong )
       {
         if ( QMessageBox::question( this, tr( "Save Vector Layer As" ), tr( "The layer contains at least one 64-bit integer field, which cannot be exported as such when using this output driver. 64-bit integer fields could be supported by selecting the %1 format and setting its TARGET_ARCGIS_VERSION layer option to ARCGIS_PRO_3_2_OR_LATER. Do you want to continue and export it as a Real field?" ).arg( tr( "ESRI File Geodatabase" ) ) ) != QMessageBox::Yes )


### PR DESCRIPTION
## Description

Fixes an issue exporting a layer having one or more Integer 64 field to the File Geodatabase format: the warning "The layer contains at least one 64-bit integer field, which, with the current settings, can only be exported as a Real field..." appears even if all the Integer 64 fields are not selected for exporting.

Fixes #64905.

Before:

https://github.com/user-attachments/assets/194e71ff-b5f0-4a04-a348-7bdf84a84943

After:

https://github.com/user-attachments/assets/e7b4bc91-727f-4d8e-9431-d92ac758f68f


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
