### PR TITLE
[Customization]  Add processing in user defined menu or toolbar

### DIFF
--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -24,8 +24,10 @@
 #include "qgsbrowserdockwidget.h"
 #include "qgsdataitemprovider.h"
 #include "qgsdataitemproviderregistry.h"
-#include "qgsgui.h"
 #include "qgslogger.h"
+#include "qgsprocessingprovider.h"
+#include "qgsprocessingregistry.h"
+#include "qgspythonrunner.h"
 #include "qgsstatusbar.h"
 
 #include <QAction>
@@ -42,12 +44,40 @@
 #include <QString>
 #include <QToolButton>
 #include <QWidgetAction>
+#include <qbuffer.h>
 
 using namespace Qt::StringLiterals;
 
 #define CUSTOMIZATION_CURRENT_VERSION "1"
 #define USER_MENU_PROPERTY "__usermenu__"
 #define USER_TOOLBAR_PROPERTY "__usertoolbar__"
+
+class QgsProcessingAlgorithmAction : public QAction
+{
+  public:
+    QgsProcessingAlgorithmAction( const QString &processingAlgorithmId, const QIcon &icon, const QString &title, QObject *parent )
+      : QAction( icon, title, parent )
+      , mProcessingAlgorithmId( processingAlgorithmId )
+    {
+      connect( this, &QAction::triggered, this, &QgsProcessingAlgorithmAction::run );
+    }
+
+  public slots:
+
+    void run()
+    {
+      // AlgorithmDialog class exists only as a Python implementation, so we need to run a
+      // Python command to display the associated algorithm dialog
+      const QString command( "import processing; from qgis.utils import iface;"
+                             "dialog = processing.createAlgorithmDialog('%1');\n"
+                             "if dialog: dialog.show()\n"
+                             "else: iface.messageBar().pushMessage( 'Invalid algorithm id : %1', Qgis.MessageLevel.Warning )" );
+      QgsPythonRunner::run( command.arg( mProcessingAlgorithmId ) );
+    }
+
+  private:
+    QString mProcessingAlgorithmId;
+};
 
 QgsCustomization::QgsItem::QgsItem( QgsCustomization::QgsItem *parent )
   : mParent( parent )
@@ -432,7 +462,11 @@ QgsCustomization::QgsUserMenuItem::QgsUserMenuItem( const QString &name, const Q
 QgsCustomization::QgsItem::ItemCapability QgsCustomization::QgsUserMenuItem::capabilities() const
 {
   return static_cast<ItemCapability>(
-    static_cast<int>( ItemCapability::AddActionRefChild ) | static_cast<int>( ItemCapability::AddUserMenuChild ) | static_cast<int>( ItemCapability::Rename ) | static_cast<int>( ItemCapability::Delete )
+    static_cast<int>( ItemCapability::AddActionRefChild )
+    | static_cast<int>( ItemCapability::AddUserMenuChild )
+    | static_cast<int>( ItemCapability::AddProcessingAlgorithmRefChild )
+    | static_cast<int>( ItemCapability::Rename )
+    | static_cast<int>( ItemCapability::Delete )
   );
 }
 
@@ -462,6 +496,8 @@ std::unique_ptr<QgsCustomization::QgsItem> QgsCustomization::QgsUserMenuItem::cr
 {
   if ( childElem.tagName() == "ActionRef"_L1 )
     return std::make_unique<QgsActionRefItem>( this );
+  else if ( childElem.tagName() == "ProcessingAlgorithmRef"_L1 )
+    return std::make_unique<QgsProcessingAlgorithmRefItem>( this );
   else if ( childElem.tagName() == "UserMenu"_L1 )
     return std::make_unique<QgsUserMenuItem>( this );
   else
@@ -555,13 +591,20 @@ std::unique_ptr<QgsCustomization::QgsItem> QgsCustomization::QgsUserToolBarItem:
 {
   if ( childElem.tagName() == "ActionRef"_L1 )
     return std::make_unique<QgsActionRefItem>( this );
+  else if ( childElem.tagName() == "ProcessingAlgorithmRef"_L1 )
+    return std::make_unique<QgsProcessingAlgorithmRefItem>( this );
   else
     return nullptr;
 }
 
 QgsCustomization::QgsItem::ItemCapability QgsCustomization::QgsUserToolBarItem::capabilities() const
 {
-  return static_cast<ItemCapability>( static_cast<int>( ItemCapability::AddActionRefChild ) | static_cast<int>( ItemCapability::Rename ) | static_cast<int>( ItemCapability::Delete ) );
+  return static_cast<ItemCapability>(
+    static_cast<int>( ItemCapability::AddActionRefChild )
+    | static_cast<int>( ItemCapability::AddProcessingAlgorithmRefChild )
+    | static_cast<int>( ItemCapability::Rename )
+    | static_cast<int>( ItemCapability::Delete )
+  );
 }
 
 ////////////////
@@ -812,6 +855,202 @@ std::unique_ptr<QgsCustomization::QgsItem> QgsCustomization::QgsStatusBarWidgets
 
 ////////////////
 
+QgsCustomization::QgsProcessingProviderItem::QgsProcessingProviderItem( QgsItem *parent )
+  : QgsItem( parent )
+{}
+
+QgsCustomization::QgsProcessingProviderItem::QgsProcessingProviderItem( const QString &name, const QString &title, QgsItem *parent )
+  : QgsItem( name, title, parent ) {}
+
+std::unique_ptr<QgsCustomization::QgsProcessingProviderItem> QgsCustomization::QgsProcessingProviderItem::cloneProcessingProviderItem( QgsCustomization::QgsItem *parent ) const
+{
+  auto clone = std::make_unique<QgsCustomization::QgsProcessingProviderItem>( parent );
+  clone->copyItemAttributes( this );
+  return clone;
+}
+
+QString QgsCustomization::QgsProcessingProviderItem::xmlTag() const
+{
+  return u"ProcessingProvider"_s;
+};
+
+std::unique_ptr<QgsCustomization::QgsItem> QgsCustomization::QgsProcessingProviderItem::createChildItem( const QDomElement &childElem )
+{
+  if ( childElem.tagName() == "ProcessingGroup"_L1 )
+    return std::make_unique<QgsProcessingGroupItem>( this );
+  else
+    return nullptr;
+}
+
+////////////////
+
+QgsCustomization::QgsProcessingGroupItem::QgsProcessingGroupItem( QgsItem *parent )
+  : QgsItem( parent )
+{}
+
+QgsCustomization::QgsProcessingGroupItem::QgsProcessingGroupItem( const QString &name, const QString &title, QgsItem *parent )
+  : QgsItem( name, title, parent ) {}
+
+std::unique_ptr<QgsCustomization::QgsProcessingGroupItem> QgsCustomization::QgsProcessingGroupItem::cloneProcessingGroupItem( QgsCustomization::QgsItem *parent ) const
+{
+  auto clone = std::make_unique<QgsCustomization::QgsProcessingGroupItem>( parent );
+  clone->copyItemAttributes( this );
+  return clone;
+}
+
+QString QgsCustomization::QgsProcessingGroupItem::xmlTag() const
+{
+  return u"ProcessingGroup"_s;
+};
+
+
+std::unique_ptr<QgsCustomization::QgsItem> QgsCustomization::QgsProcessingGroupItem::createChildItem( const QDomElement &childElem )
+{
+  if ( childElem.tagName() == "ProcessingAlgorithm"_L1 )
+    return std::make_unique<QgsProcessingAlgorithmItem>( this );
+  else
+    return nullptr;
+}
+
+////////////////
+
+QgsCustomization::QgsProcessingAlgorithmItem::QgsProcessingAlgorithmItem( QgsItem *parent )
+  : QgsItem( parent )
+{}
+
+QgsCustomization::QgsProcessingAlgorithmItem::QgsProcessingAlgorithmItem( const QString &name, const QString &title, QgsItem *parent )
+  : QgsItem( name, title, parent ) {}
+
+std::unique_ptr<QgsCustomization::QgsProcessingAlgorithmItem> QgsCustomization::QgsProcessingAlgorithmItem::cloneProcessingAlgorithmItem( QgsCustomization::QgsItem *parent ) const
+{
+  auto clone = std::make_unique<QgsCustomization::QgsProcessingAlgorithmItem>( parent );
+  clone->copyItemAttributes( this );
+  return clone;
+}
+
+QString QgsCustomization::QgsProcessingAlgorithmItem::xmlTag() const
+{
+  return u"ProcessingAlgorithm"_s;
+};
+
+QgsCustomization::QgsItem::ItemCapability QgsCustomization::QgsProcessingAlgorithmItem::capabilities() const
+{
+  return ItemCapability::Drag;
+}
+
+////////////////
+
+QgsCustomization::QgsProcessingAlgorithmRefItem::QgsProcessingAlgorithmRefItem( QgsItem *parent )
+  : QgsItem( parent )
+{}
+
+QgsCustomization::QgsProcessingAlgorithmRefItem::QgsProcessingAlgorithmRefItem( const QString &id, const QString &name, const QString &title, QgsItem *parent )
+  : QgsItem( name, title, parent )
+  , mId( id )
+{}
+
+const QString &QgsCustomization::QgsProcessingAlgorithmRefItem::id() const
+{
+  return mId;
+}
+
+std::unique_ptr<QgsCustomization::QgsProcessingAlgorithmRefItem> QgsCustomization::QgsProcessingAlgorithmRefItem::cloneProcessingAlgorithmItem( QgsCustomization::QgsItem *parent ) const
+{
+  auto clone = std::make_unique<QgsCustomization::QgsProcessingAlgorithmRefItem>( parent );
+  clone->copyItemAttributes( this );
+  return clone;
+}
+
+QString QgsCustomization::QgsProcessingAlgorithmRefItem::xmlTag() const
+{
+  return u"ProcessingAlgorithmRef"_s;
+};
+
+QgsCustomization::QgsItem::ItemCapability QgsCustomization::QgsProcessingAlgorithmRefItem::capabilities() const
+{
+  return ItemCapability::Delete;
+}
+
+void QgsCustomization::QgsProcessingAlgorithmRefItem::writeXmlItem( QDomElement &elem ) const
+{
+  elem.setAttribute( u"id"_s, id() );
+  elem.setAttribute( u"title"_s, title() );
+
+  const QIcon lIcon = icon();
+  if ( !lIcon.isNull() )
+  {
+    // We have no idea what would be the best size to store, it depends on the widget that would
+    // display it. So let's use a classic size 32x32
+    const QPixmap pixmap = lIcon.pixmap( QSize( 32, 32 ) );
+    QByteArray byteArray;
+    QBuffer buffer( &byteArray );
+    if ( pixmap.save( &buffer, "PNG" ) )
+    {
+      const QString base64 = QString::fromLatin1( byteArray.toBase64() );
+      elem.setAttribute( u"icon"_s, base64 );
+    }
+    else
+    {
+      QgsDebugError( "Fail to save icon in base 64" );
+    }
+  }
+};
+
+void QgsCustomization::QgsProcessingAlgorithmRefItem::readXmlItem( const QDomElement &elem )
+{
+  setTitle( elem.attribute( u"title"_s ) );
+  mId = elem.attribute( u"id"_s );
+
+  const QString base64 = elem.attribute( u"icon"_s );
+  if ( !base64.isEmpty() )
+  {
+    QPixmap pixmap;
+    pixmap.loadFromData( QByteArray::fromBase64( base64.toLatin1() ) );
+    setIcon( pixmap );
+  }
+};
+
+void QgsCustomization::QgsProcessingAlgorithmRefItem::copyItemAttributes( const QgsItem *other )
+{
+  QgsItem::copyItemAttributes( other );
+  if ( const QgsProcessingAlgorithmRefItem *processingAlgorithmRefItem = dynamic_cast<const QgsProcessingAlgorithmRefItem *>( other ) )
+  {
+    mId = processingAlgorithmRefItem->mId;
+  }
+}
+
+
+////////////////
+
+QgsCustomization::QgsProcessingProvidersItem::QgsProcessingProvidersItem()
+  : QgsItem()
+{
+  mName = "ProcessingProviders";
+  setTitle( QObject::tr( "Processing Providers" ) );
+}
+
+std::unique_ptr<QgsCustomization::QgsProcessingProvidersItem> QgsCustomization::QgsProcessingProvidersItem::cloneProcessingProvidersItem( QgsCustomization::QgsItem * ) const
+{
+  auto clone = std::make_unique<QgsCustomization::QgsProcessingProvidersItem>();
+  clone->copyItemAttributes( this );
+  return clone;
+}
+
+QString QgsCustomization::QgsProcessingProvidersItem::xmlTag() const
+{
+  return u"ProcessingProviders"_s;
+};
+
+std::unique_ptr<QgsCustomization::QgsItem> QgsCustomization::QgsProcessingProvidersItem::createChildItem( const QDomElement &childElem )
+{
+  if ( childElem.tagName() == "ProcessingProvider"_L1 )
+    return std::make_unique<QgsProcessingProviderItem>( this );
+  else
+    return nullptr;
+}
+
+////////////////
+
 QgsCustomization::QgsCustomization( const QString &customizationFile )
   : mCustomizationFile( customizationFile )
 {
@@ -861,6 +1100,7 @@ QgsCustomization &QgsCustomization::operator=( const QgsCustomization &other )
   mMenus = other.mMenus->cloneMenusItem();
   mStatusBarWidgets = other.mStatusBarWidgets->cloneStatusBarWidgetsItem();
   mToolBars = other.mToolBars->cloneToolBarsItem();
+  mProcessingProviders = other.mProcessingProviders->cloneProcessingProvidersItem();
   mEnabled = other.mEnabled;
   mSplashPath = other.mSplashPath;
   mQgisApp = other.mQgisApp;
@@ -876,6 +1116,7 @@ void QgsCustomization::load()
   loadApplicationMenus();
   loadApplicationStatusBarWidgets();
   loadApplicationToolBars();
+  loadProcessingProviders();
 }
 
 bool QgsCustomization::isEnabled() const
@@ -916,6 +1157,11 @@ QgsCustomization::QgsStatusBarWidgetsItem *QgsCustomization::statusBarWidgetsIte
 QgsCustomization::QgsToolBarsItem *QgsCustomization::toolBarsItem() const
 {
   return mToolBars.get();
+}
+
+QgsCustomization::QgsProcessingProvidersItem *QgsCustomization::processingProvidersItem() const
+{
+  return mProcessingProviders.get();
 }
 
 void QgsCustomization::addActions( QgsItem *item, QWidget *widget ) const
@@ -977,6 +1223,40 @@ void QgsCustomization::loadApplicationToolBars()
 
     addActions( t, tb );
     t->setWasVisible( tb->isVisible() );
+  }
+}
+
+void QgsCustomization::loadProcessingProviders()
+{
+  if ( !mProcessingProviders )
+  {
+    mProcessingProviders = std::make_unique<QgsProcessingProvidersItem>();
+  }
+
+  if ( !QgsApplication::processingRegistry() )
+    return;
+
+  for ( QgsProcessingProvider *provider : QgsApplication::processingRegistry()->providers() )
+  {
+    auto providerItem = std::make_unique<QgsProcessingProviderItem>( provider->id(), provider->name(), mProcessingProviders.get() );
+    providerItem->setIcon( provider->icon() );
+    for ( const QgsProcessingAlgorithm *algorithm : provider->algorithms() )
+    {
+      const QString groupId = algorithm->groupId();
+      QgsProcessingGroupItem *group = providerItem->getChild<QgsProcessingGroupItem>( groupId );
+      if ( !group )
+      {
+        auto g = std::make_unique<QgsProcessingGroupItem>( groupId, algorithm->group(), providerItem.get() );
+        providerItem->addChild( std::move( g ) );
+        group = providerItem->lastChild<QgsProcessingGroupItem>();
+      }
+
+      auto processingItem = std::make_unique<QgsProcessingAlgorithmItem>( algorithm->id(), algorithm->displayName(), group );
+      processingItem->setIcon( algorithm->icon() );
+      group->addChild( std::move( processingItem ) );
+    }
+
+    mProcessingProviders->addChild( std::move( providerItem ) );
   }
 }
 
@@ -1264,7 +1544,8 @@ QAction *QgsCustomization::findQAction( const QString &path )
   return actionIt != actions.cend() ? *actionIt : nullptr;
 }
 
-template<class WidgetType> void QgsCustomization::updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget )
+template<class WidgetType>
+void QgsCustomization::updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget ) const
 {
   // clear all user menu
   const QList<QAction *> widgetActions = parentWidget->actions();
@@ -1276,9 +1557,6 @@ template<class WidgetType> void QgsCustomization::updateMenuActionVisibility( Qg
       parentWidget->removeAction( action );
     }
   }
-
-  // update non-user menu visibility
-  updateActionVisibility( parentItem, parentWidget );
 
   // add user menu
   for ( const std::unique_ptr<QgsCustomization::QgsItem> &childItem : parentItem->childItemList() )
@@ -1295,17 +1573,13 @@ template<class WidgetType> void QgsCustomization::updateMenuActionVisibility( Qg
 
       updateMenuActionVisibility( userMenu, menu );
     }
-    else if ( QgsCustomization::QgsActionRefItem *actionRef = dynamic_cast<QgsCustomization::QgsActionRefItem *>( childItem.get() ) )
-    {
-      if ( QAction *action = findQAction( actionRef->actionRefPath() ) )
-      {
-        parentWidget->addAction( action );
-      }
-    }
   }
+
+  // update non-user menu visibility
+  updateActionVisibility( parentItem, parentWidget );
 }
 
-void QgsCustomization::updateActionVisibility( QgsCustomization::QgsItem *item, QWidget *widget )
+void QgsCustomization::updateActionVisibility( QgsCustomization::QgsItem *item, QWidget *widget ) const
 {
   if ( !item || !widget )
     return;
@@ -1339,10 +1613,7 @@ void QgsCustomization::updateActionVisibility( QgsCustomization::QgsItem *item, 
   {
     QgsActionItem *action = dynamic_cast<QgsActionItem *>( childItem.get() );
     if ( !action )
-    {
-      QgsDebugError( u"Invalid child type, Action expected"_s );
       continue;
-    }
 
     if ( !action->isVisible() )
       nbRemoved++;
@@ -1354,6 +1625,26 @@ void QgsCustomization::updateActionVisibility( QgsCustomization::QgsItem *item, 
         widget->insertAction( widget->actions().at( index ), action->qAction() );
       else
         widget->addAction( action->qAction() );
+    }
+  }
+
+  for ( const std::unique_ptr<QgsItem> &childItem : item->childItemList() )
+  {
+    if ( !childItem->isVisible() )
+      continue;
+
+    if ( auto *actionRef = dynamic_cast<QgsCustomization::QgsActionRefItem *>( childItem.get() ) )
+    {
+      if ( QAction *action = findQAction( actionRef->actionRefPath() ) )
+      {
+        widget->addAction( action );
+      }
+    }
+    else if ( auto *processingAlgorithmRef = dynamic_cast<QgsCustomization::QgsProcessingAlgorithmRefItem *>( childItem.get() ) )
+    {
+      QgsProcessingAlgorithmAction *action = new QgsProcessingAlgorithmAction( processingAlgorithmRef->id(), processingAlgorithmRef->icon(), processingAlgorithmRef->title(), widget );
+      action->setObjectName( processingAlgorithmRef->name() );
+      widget->addAction( action );
     }
   }
 }
@@ -1727,6 +2018,11 @@ QString QgsCustomization::uniqueToolBarName() const
 QString QgsCustomization::uniqueActionName( const QString &originalActionName ) const
 {
   return uniqueItemName( u"ActionRef_"_s + originalActionName + "_" );
+}
+
+QString QgsCustomization::uniqueProcessingAlgorithmName( const QString &originalProcessingAlgorithmName ) const
+{
+  return uniqueItemName( u"ProcessingAlgorithmRef_"_s + originalProcessingAlgorithmName + "_" );
 }
 
 QgsCustomization::QgsItem *QgsCustomization::getItem( const QString &path ) const

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -25,6 +25,7 @@
 #include "qgsdataitemprovider.h"
 #include "qgsdataitemproviderregistry.h"
 #include "qgslogger.h"
+#include "qgsprocessingalgorithm.h"
 #include "qgsprocessingprovider.h"
 #include "qgsprocessingregistry.h"
 #include "qgspythonrunner.h"
@@ -68,10 +69,12 @@ class QgsProcessingAlgorithmAction : public QAction
     {
       // AlgorithmDialog class exists only as a Python implementation, so we need to run a
       // Python command to display the associated algorithm dialog
-      const QString command( "import processing; from qgis.utils import iface;"
-                             "dialog = processing.createAlgorithmDialog('%1');\n"
-                             "if dialog: dialog.show()\n"
-                             "else: iface.messageBar().pushMessage( 'Invalid algorithm id : %1', Qgis.MessageLevel.Warning )" );
+      const QString command(
+        "import processing; from qgis.utils import iface;"
+        "dialog = processing.createAlgorithmDialog('%1');\n"
+        "if dialog: dialog.show()\n"
+        "else: iface.messageBar().pushMessage( 'Invalid algorithm id : %1', Qgis.MessageLevel.Warning )"
+      );
       QgsPythonRunner::run( command.arg( mProcessingAlgorithmId ) );
     }
 
@@ -860,7 +863,8 @@ QgsCustomization::QgsProcessingProviderItem::QgsProcessingProviderItem( QgsItem 
 {}
 
 QgsCustomization::QgsProcessingProviderItem::QgsProcessingProviderItem( const QString &name, const QString &title, QgsItem *parent )
-  : QgsItem( name, title, parent ) {}
+  : QgsItem( name, title, parent )
+{}
 
 std::unique_ptr<QgsCustomization::QgsProcessingProviderItem> QgsCustomization::QgsProcessingProviderItem::cloneProcessingProviderItem( QgsCustomization::QgsItem *parent ) const
 {
@@ -889,7 +893,8 @@ QgsCustomization::QgsProcessingGroupItem::QgsProcessingGroupItem( QgsItem *paren
 {}
 
 QgsCustomization::QgsProcessingGroupItem::QgsProcessingGroupItem( const QString &name, const QString &title, QgsItem *parent )
-  : QgsItem( name, title, parent ) {}
+  : QgsItem( name, title, parent )
+{}
 
 std::unique_ptr<QgsCustomization::QgsProcessingGroupItem> QgsCustomization::QgsProcessingGroupItem::cloneProcessingGroupItem( QgsCustomization::QgsItem *parent ) const
 {
@@ -919,7 +924,8 @@ QgsCustomization::QgsProcessingAlgorithmItem::QgsProcessingAlgorithmItem( QgsIte
 {}
 
 QgsCustomization::QgsProcessingAlgorithmItem::QgsProcessingAlgorithmItem( const QString &name, const QString &title, QgsItem *parent )
-  : QgsItem( name, title, parent ) {}
+  : QgsItem( name, title, parent )
+{}
 
 std::unique_ptr<QgsCustomization::QgsProcessingAlgorithmItem> QgsCustomization::QgsProcessingAlgorithmItem::cloneProcessingAlgorithmItem( QgsCustomization::QgsItem *parent ) const
 {
@@ -975,39 +981,12 @@ void QgsCustomization::QgsProcessingAlgorithmRefItem::writeXmlItem( QDomElement 
 {
   elem.setAttribute( u"id"_s, id() );
   elem.setAttribute( u"title"_s, title() );
-
-  const QIcon lIcon = icon();
-  if ( !lIcon.isNull() )
-  {
-    // We have no idea what would be the best size to store, it depends on the widget that would
-    // display it. So let's use a classic size 32x32
-    const QPixmap pixmap = lIcon.pixmap( QSize( 32, 32 ) );
-    QByteArray byteArray;
-    QBuffer buffer( &byteArray );
-    if ( pixmap.save( &buffer, "PNG" ) )
-    {
-      const QString base64 = QString::fromLatin1( byteArray.toBase64() );
-      elem.setAttribute( u"icon"_s, base64 );
-    }
-    else
-    {
-      QgsDebugError( "Fail to save icon in base 64" );
-    }
-  }
 };
 
 void QgsCustomization::QgsProcessingAlgorithmRefItem::readXmlItem( const QDomElement &elem )
 {
   setTitle( elem.attribute( u"title"_s ) );
   mId = elem.attribute( u"id"_s );
-
-  const QString base64 = elem.attribute( u"icon"_s );
-  if ( !base64.isEmpty() )
-  {
-    QPixmap pixmap;
-    pixmap.loadFromData( QByteArray::fromBase64( base64.toLatin1() ) );
-    setIcon( pixmap );
-  }
 };
 
 void QgsCustomization::QgsProcessingAlgorithmRefItem::copyItemAttributes( const QgsItem *other )
@@ -1073,6 +1052,11 @@ void QgsCustomization::setQgisApp( QgisApp *qgisApp )
   mQgisApp = qgisApp;
   if ( newApp )
     load();
+
+  // We need to search for algorithm icon once algorithm have been registered in the application
+  // (not at customization object creation)
+  loadProcessingAlgorithmItemIcons( mToolBars.get() );
+  loadProcessingAlgorithmItemIcons( mMenus.get() );
 
   apply();
 }
@@ -1544,8 +1528,7 @@ QAction *QgsCustomization::findQAction( const QString &path )
   return actionIt != actions.cend() ? *actionIt : nullptr;
 }
 
-template<class WidgetType>
-void QgsCustomization::updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget ) const
+template<class WidgetType> void QgsCustomization::updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget ) const
 {
   // clear all user menu
   const QList<QAction *> widgetActions = parentWidget->actions();
@@ -1728,6 +1711,22 @@ void QgsCustomization::applyToToolBars() const
   }
 }
 
+void QgsCustomization::loadProcessingAlgorithmItemIcons( QgsItem *rootItem )
+{
+  if ( QgsCustomization::QgsProcessingAlgorithmRefItem *algorithmRefItem = dynamic_cast<QgsCustomization::QgsProcessingAlgorithmRefItem *>( rootItem ) )
+  {
+    const QgsProcessingAlgorithm *alg = QgsApplication::processingRegistry()->algorithmById( algorithmRefItem->id() );
+    if ( alg )
+    {
+      algorithmRefItem->setIcon( alg->icon() );
+    }
+  }
+
+  for ( const std::unique_ptr<QgsItem> &childItem : rootItem->childItemList() )
+  {
+    loadProcessingAlgorithmItemIcons( childItem.get() );
+  }
+}
 
 QString QgsCustomization::writeFile( const QString &fileName ) const
 {

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -45,7 +45,7 @@
 #include <QString>
 #include <QToolButton>
 #include <QWidgetAction>
-#include <qbuffer.h>
+#include <QBuffer>
 
 using namespace Qt::StringLiterals;
 

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -33,6 +33,7 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QBuffer>
 #include <QDir>
 #include <QDockWidget>
 #include <QDomDocument>
@@ -45,7 +46,6 @@
 #include <QString>
 #include <QToolButton>
 #include <QWidgetAction>
-#include <QBuffer>
 
 using namespace Qt::StringLiterals;
 

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -239,13 +239,14 @@ class APP_EXPORT QgsCustomization
          */
         enum class ItemCapability : int
         {
-          None = 0,                     //! No capability
-          AddUserMenuChild = 1 << 0,    //! Support adding UserMenu item as child
-          AddActionRefChild = 1 << 1,   //! Support adding ActionRef as child
-          AddUserToolBarChild = 1 << 2, //! Support adding UserToolBar as child
-          Rename = 1 << 3,              //! Support renaming
-          Delete = 1 << 4,              //! Support delete
-          Drag = 1 << 5                 //! Support dragging for later droping
+          None = 0,                                //! No capability
+          AddUserMenuChild = 1 << 0,               //! Support adding QgsUserMenuItem item as child
+          AddActionRefChild = 1 << 1,              //! Support adding QgsActionRefItem as child
+          AddUserToolBarChild = 1 << 2,            //! Support adding QgsUserToolBarItem as child
+          AddProcessingAlgorithmRefChild = 1 << 3, //! Support adding QgsProcessingAlgorithmRefItem as child. \since QGIS 4.2
+          Rename = 1 << 4,                         //! Support renaming
+          Delete = 1 << 5,                         //! Support delete
+          Drag = 1 << 6                            //! Support dragging for later droping
         };
 
         /**
@@ -354,6 +355,9 @@ class APP_EXPORT QgsCustomization
         qsizetype mQActionIndex = -1;
     };
 
+    /**
+     * Represent a reference to an existing action item
+     */
     class QgsActionRefItem : public QgsActionItem
     {
       public:
@@ -746,6 +750,172 @@ class APP_EXPORT QgsCustomization
     };
 
     /**
+     * Represent a processing provider
+     */
+    class QgsProcessingProviderItem : public QgsItem
+    {
+      public:
+        /**
+         * Constructor
+         */
+        QgsProcessingProviderItem( QgsItem *parent );
+
+        /**
+         * Constructor
+         * \param name name identifier
+         * \param title title
+         * \param parent parent Item
+         */
+        QgsProcessingProviderItem( const QString &name, const QString &title, QgsItem *parent );
+
+        /**
+         * Returns this item clone with \a parent as parent item
+         */
+        std::unique_ptr<QgsCustomization::QgsProcessingProviderItem> cloneProcessingProviderItem( QgsCustomization::QgsItem *parent = nullptr ) const;
+
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneProcessingProviderItem( parent ); };
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<QgsItem> createChildItem( const QDomElement &childElem ) override;
+    };
+
+    /**
+     * Represent a processing algorithm group
+     */
+    class QgsProcessingGroupItem : public QgsItem
+    {
+      public:
+        /**
+         * Constructor
+         */
+        QgsProcessingGroupItem( QgsItem *parent );
+
+        /**
+         * Constructor
+         * \param name name identifier
+         * \param title title
+         * \param parent parent Item
+         */
+        QgsProcessingGroupItem( const QString &name, const QString &title, QgsItem *parent );
+
+        /**
+         * Returns this item clone with \a parent as parent item
+         */
+        std::unique_ptr<QgsCustomization::QgsProcessingGroupItem> cloneProcessingGroupItem( QgsCustomization::QgsItem *parent = nullptr ) const;
+
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneProcessingGroupItem( parent ); };
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<QgsItem> createChildItem( const QDomElement &childElem ) override;
+    };
+
+    /**
+     * Represent a processing algorithm
+     *
+     * \since QGIS 4.2
+     */
+    class QgsProcessingAlgorithmItem : public QgsItem
+    {
+      public:
+        /**
+         * Constructor
+         */
+        QgsProcessingAlgorithmItem( QgsItem *parent );
+
+        /**
+         * Constructor
+         * \param name name identifier
+         * \param title title
+         * \param parent parent Item
+         */
+        QgsProcessingAlgorithmItem( const QString &name, const QString &title, QgsItem *parent );
+
+        /**
+         * Returns this item clone with \a parent as parent item
+         */
+        std::unique_ptr<QgsCustomization::QgsProcessingAlgorithmItem> cloneProcessingAlgorithmItem( QgsCustomization::QgsItem *parent = nullptr ) const;
+
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneProcessingAlgorithmItem( parent ); };
+
+      protected:
+        QString xmlTag() const override;
+        ItemCapability capabilities() const override;
+
+        QString mId;
+    };
+
+    /**
+     * Represent a reference to an existing processing algorithm item
+     *
+     * \since QGIS 4.2
+     */
+    class QgsProcessingAlgorithmRefItem : public QgsItem
+    {
+      public:
+        /**
+         * Constructor
+         */
+        QgsProcessingAlgorithmRefItem( QgsItem *parent );
+
+        /**
+         * Constructor
+         * \param id algorithm id, \see QgsProcessingRegistry::algorithmById()
+         * \param name name identifier
+         * \param title title
+         * \param parent parent Item
+         */
+        QgsProcessingAlgorithmRefItem( const QString &id, const QString &name, const QString &title, QgsItem *parent );
+
+        /**
+         * Returns algorithm id, \see QgsProcessingRegistry::algorithmById()
+         */
+        const QString &id() const;
+
+        /**
+         * Returns this item clone with \a parent as parent item
+         */
+        std::unique_ptr<QgsCustomization::QgsProcessingAlgorithmRefItem> cloneProcessingAlgorithmItem( QgsCustomization::QgsItem *parent = nullptr ) const;
+
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneProcessingAlgorithmItem( parent ); };
+
+      protected:
+        QString xmlTag() const override;
+        ItemCapability capabilities() const override;
+        void writeXmlItem( QDomElement &elem ) const override;
+        void readXmlItem( const QDomElement &elem ) override;
+        void copyItemAttributes( const QgsItem *other ) override;
+
+        QString mId;
+    };
+
+    /**
+     * Root item for all Processing providers
+     *
+     * \since QGIS 4.2
+     */
+    class QgsProcessingProvidersItem : public QgsItem
+    {
+      public:
+        /**
+         * Constructor
+         */
+        QgsProcessingProvidersItem();
+
+        /**
+         * Returns this item clone with \a parent as parent item
+         */
+        std::unique_ptr<QgsCustomization::QgsProcessingProvidersItem> cloneProcessingProvidersItem( QgsCustomization::QgsItem *parent = nullptr ) const;
+
+        std::unique_ptr<QgsCustomization::QgsItem> clone( QgsCustomization::QgsItem *parent = nullptr ) const override { return cloneProcessingProvidersItem( parent ); };
+
+      protected:
+        QString xmlTag() const override;
+        std::unique_ptr<QgsItem> createChildItem( const QDomElement &childElem ) override;
+    };
+
+    /**
      * Returns browser items to customize QgsBrowserDockWidget content
      */
     QgsCustomization::QgsBrowserElementsItem *browserElementsItem() const;
@@ -769,6 +939,14 @@ class APP_EXPORT QgsCustomization
      * Returns toolbar items to customize QToolBar content
      */
     QgsCustomization::QgsToolBarsItem *toolBarsItem() const;
+
+    /**
+     * Returns processing provider items, so user can create action that trigger processing
+     * algorithm in user defined menu or toolbars
+     *
+     * \since QGIS 4.2
+     */
+    QgsCustomization::QgsProcessingProvidersItem *processingProvidersItem() const;
 
     /**
      * Apply customization to the application
@@ -812,6 +990,13 @@ class APP_EXPORT QgsCustomization
      * Returns an action unique name within the entire application
      */
     QString uniqueActionName( const QString &originalActionName ) const;
+
+    /**
+     * Returns a processing algorithm unique name within the entire application
+     *
+     * \since QGIS 4.2
+     */
+    QString uniqueProcessingAlgorithmName( const QString &originalProcessingAlgorithmName ) const;
 
     /**
      * Returns customization item according to its \a path. \a path is a '/' separated list of
@@ -862,6 +1047,13 @@ class APP_EXPORT QgsCustomization
      * Update customization model with current application toolbar elements
      */
     void loadApplicationToolBars();
+
+    /**
+     * Update customization model with current application processing elements
+     *
+     * \since QGIS 4.2
+     */
+    void loadProcessingProviders();
 
     /**
      * Apply browser items customization to the application
@@ -944,12 +1136,13 @@ class APP_EXPORT QgsCustomization
     /**
      * Update action \a widget visibility based on \a item
      */
-    static void updateActionVisibility( QgsCustomization::QgsItem *item, QWidget *widget );
+    void updateActionVisibility( QgsCustomization::QgsItem *item, QWidget *widget ) const;
 
     /**
      * Update menu \a widget visibility based on \a item
      */
-    template<class WidgetType> static void updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget );
+    template<class WidgetType>
+    void updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget ) const;
 
     /**
      * Returns QWidget corresponding to \a path. Path is a '/' separated list of
@@ -971,6 +1164,7 @@ class APP_EXPORT QgsCustomization
     std::unique_ptr<QgsMenusItem> mMenus;
     std::unique_ptr<QgsStatusBarWidgetsItem> mStatusBarWidgets;
     std::unique_ptr<QgsToolBarsItem> mToolBars;
+    std::unique_ptr<QgsProcessingProvidersItem> mProcessingProviders;
     bool mEnabled = false;
     QString mSplashPath;
 

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -842,8 +842,6 @@ class APP_EXPORT QgsCustomization
       protected:
         QString xmlTag() const override;
         ItemCapability capabilities() const override;
-
-        QString mId;
     };
 
     /**
@@ -1081,6 +1079,12 @@ class APP_EXPORT QgsCustomization
     void applyToToolBars() const;
 
     /**
+     * Find recursively \a rootItem QgsProcessingAlgorithmRefItem children and set their icon
+     * using referenced algorithm one.
+     */
+    void loadProcessingAlgorithmItemIcons( QgsItem *rootItem );
+
+    /**
      * Helper class to iterate over widget actions
      */
     class QgsQActionsIterator
@@ -1141,8 +1145,7 @@ class APP_EXPORT QgsCustomization
     /**
      * Update menu \a widget visibility based on \a item
      */
-    template<class WidgetType>
-    void updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget ) const;
+    template<class WidgetType> void updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget ) const;
 
     /**
      * Returns QWidget corresponding to \a path. Path is a '/' separated list of

--- a/src/app/qgscustomizationdialog.cpp
+++ b/src/app/qgscustomizationdialog.cpp
@@ -227,9 +227,7 @@ void QgsCustomizationDialog::QgsCustomizationModel::init()
   switch ( mMode )
   {
     case Mode::ActionSelector:
-      mRootItems << mCustomization->menusItem()
-                 << mCustomization->toolBarsItem()
-                 << mCustomization->processingProvidersItem();
+      mRootItems << mCustomization->menusItem() << mCustomization->toolBarsItem() << mCustomization->processingProvidersItem();
       break;
 
     case Mode::ItemVisibility:
@@ -413,7 +411,8 @@ bool QgsCustomizationDialog::QgsCustomizationModel::canDropMimeData( const QMime
          // Try to see if we can workaround thin in dragEnterEvent
          // uncomment the following lines when fixed
          /* && item && item->hasCapability( QgsCustomization::Item::ItemCapability::UserMenuChild ) */
-         && data && ( data->hasFormat( ACTIONPATHS_MIMEDATA_NAME ) || data->hasFormat( PROCESSING_ALGORITHM_IDS_MIMEDATA_NAME ) );
+         && data
+         && ( data->hasFormat( ACTIONPATHS_MIMEDATA_NAME ) || data->hasFormat( PROCESSING_ALGORITHM_IDS_MIMEDATA_NAME ) );
 }
 
 bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int, const QModelIndex &parent )
@@ -430,9 +429,7 @@ bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeData( const QMimeDat
 bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeDataActions( const QMimeData *data, int row, const QModelIndex &parent )
 {
   QgsCustomization::QgsItem *item = parent.isValid() ? static_cast<QgsCustomization::QgsItem *>( parent.internalPointer() ) : nullptr;
-  if ( !item || !data
-       || !item->hasCapability( QgsCustomization::QgsItem::ItemCapability::AddActionRefChild )
-       || !data->hasFormat( ACTIONPATHS_MIMEDATA_NAME ) )
+  if ( !item || !data || !item->hasCapability( QgsCustomization::QgsItem::ItemCapability::AddActionRefChild ) || !data->hasFormat( ACTIONPATHS_MIMEDATA_NAME ) )
     return false;
 
   QDataStream dataStreamRead( data->data( ACTIONPATHS_MIMEDATA_NAME ) );
@@ -473,7 +470,8 @@ bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeDataProcessingAlgori
 {
   QgsCustomization::QgsItem *item = parent.isValid() ? static_cast<QgsCustomization::QgsItem *>( parent.internalPointer() ) : nullptr;
   if ( !QgsApplication::processingRegistry()
-       || !item || !data
+       || !item
+       || !data
        || !item->hasCapability( QgsCustomization::QgsItem::ItemCapability::AddProcessingAlgorithmRefChild )
        || !data->hasFormat( PROCESSING_ALGORITHM_IDS_MIMEDATA_NAME ) )
     return false;
@@ -501,7 +499,8 @@ bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeDataProcessingAlgori
   beginInsertRows( parent, row, row + static_cast<int>( processingAlgorithms.count() ) - 1 );
   for ( const QgsProcessingAlgorithm *processingAlgorithm : std::as_const( processingAlgorithms ) )
   {
-    auto processingAlgorithmRef = std::make_unique<QgsCustomization::QgsProcessingAlgorithmRefItem>( processingAlgorithm->id(), mCustomization->uniqueProcessingAlgorithmName( processingAlgorithm->name() ), processingAlgorithm->displayName(), item );
+    auto processingAlgorithmRef = std::make_unique<
+      QgsCustomization::QgsProcessingAlgorithmRefItem>( processingAlgorithm->id(), mCustomization->uniqueProcessingAlgorithmName( processingAlgorithm->name() ), processingAlgorithm->displayName(), item );
     processingAlgorithmRef->setIcon( processingAlgorithm->icon() );
     item->insertChild( row, std::move( processingAlgorithmRef ) );
   }

--- a/src/app/qgscustomizationdialog.cpp
+++ b/src/app/qgscustomizationdialog.cpp
@@ -21,6 +21,8 @@
 #include "qgsfileutils.h"
 #include "qgsgui.h"
 #include "qgshelp.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsprocessingregistry.h"
 #include "qgssettings.h"
 
 #include <QAbstractItemModel>
@@ -48,7 +50,8 @@ constexpr int TOOLBAR_ROW = 4;
 const QgsSettingsEntryString *QgsCustomizationDialog::sSettingLastSaveDir
   = new QgsSettingsEntryString( u"last-save-directory"_s, sTreeCustomization, QDir::homePath(), u"Last directory used when saving a customization XML file"_s );
 
-#define ACTIONPATHS_MIMEDATA_NAME "application/qgis.customization.actionpaths"
+#define ACTIONPATHS_MIMEDATA_NAME u"application/qgis.customization.actionpaths"_s
+#define PROCESSING_ALGORITHM_IDS_MIMEDATA_NAME u"application/qgis.customization.processingalgorithmsids"_s
 
 QgsCustomizationDialog::QgsCustomizationModel::QgsCustomizationModel( QgisApp *qgisApp, Mode mode, QObject *parent )
   : QAbstractItemModel( parent )
@@ -224,7 +227,9 @@ void QgsCustomizationDialog::QgsCustomizationModel::init()
   switch ( mMode )
   {
     case Mode::ActionSelector:
-      mRootItems << mCustomization->menusItem() << mCustomization->toolBarsItem();
+      mRootItems << mCustomization->menusItem()
+                 << mCustomization->toolBarsItem()
+                 << mCustomization->processingProvidersItem();
       break;
 
     case Mode::ItemVisibility:
@@ -356,6 +361,7 @@ QMimeData *QgsCustomizationDialog::QgsCustomizationModel::mimeData( const QModel
 
 
   QStringList strActionPaths;
+  QStringList strProcessingAlgorithmIds;
   QSet<int> rows;
   for ( const QModelIndex &index : indexes )
   {
@@ -366,15 +372,33 @@ QMimeData *QgsCustomizationDialog::QgsCustomizationModel::mimeData( const QModel
     rows << index.row();
 
     QgsCustomization::QgsItem *item = index.isValid() ? static_cast<QgsCustomization::QgsItem *>( index.internalPointer() ) : nullptr;
-    if ( QgsCustomization::QgsActionItem *action = dynamic_cast<QgsCustomization::QgsActionItem *>( item ) )
+    if ( auto *action = dynamic_cast<QgsCustomization::QgsActionItem *>( item ) )
+    {
       strActionPaths << action->path();
+    }
+    else if ( auto *processingAlgorithmId = dynamic_cast<QgsCustomization::QgsProcessingAlgorithmItem *>( item ) )
+    {
+      strProcessingAlgorithmIds << processingAlgorithmId->name();
+    }
   }
 
-  QByteArray actionPaths;
-  QDataStream dataStreamWrite( &actionPaths, QIODevice::WriteOnly );
-  dataStreamWrite << strActionPaths;
+  if ( !strActionPaths.isEmpty() )
+  {
+    QByteArray actionPaths;
+    QDataStream dataStreamWrite( &actionPaths, QIODevice::WriteOnly );
+    dataStreamWrite << strActionPaths;
 
-  mimeData->setData( QStringLiteral( ACTIONPATHS_MIMEDATA_NAME ), actionPaths );
+    mimeData->setData( ACTIONPATHS_MIMEDATA_NAME, actionPaths );
+  }
+
+  if ( !strProcessingAlgorithmIds.isEmpty() )
+  {
+    QByteArray actionPaths;
+    QDataStream dataStreamWrite( &actionPaths, QIODevice::WriteOnly );
+    dataStreamWrite << strProcessingAlgorithmIds;
+
+    mimeData->setData( PROCESSING_ALGORITHM_IDS_MIMEDATA_NAME, actionPaths );
+  }
 
   return mimeData;
 }
@@ -389,8 +413,7 @@ bool QgsCustomizationDialog::QgsCustomizationModel::canDropMimeData( const QMime
          // Try to see if we can workaround thin in dragEnterEvent
          // uncomment the following lines when fixed
          /* && item && item->hasCapability( QgsCustomization::Item::ItemCapability::UserMenuChild ) */
-         && data
-         && data->hasFormat( QStringLiteral( ACTIONPATHS_MIMEDATA_NAME ) );
+         && data && ( data->hasFormat( ACTIONPATHS_MIMEDATA_NAME ) || data->hasFormat( PROCESSING_ALGORITHM_IDS_MIMEDATA_NAME ) );
 }
 
 bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int, const QModelIndex &parent )
@@ -401,11 +424,18 @@ bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeData( const QMimeDat
   if ( row == -1 )
     row = rowCount( parent ); // if dropped directly onto group item, insert at last position
 
+  return dropMimeDataActions( data, row, parent ) || dropMimeDataProcessingAlgorithms( data, row, parent );
+}
+
+bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeDataActions( const QMimeData *data, int row, const QModelIndex &parent )
+{
   QgsCustomization::QgsItem *item = parent.isValid() ? static_cast<QgsCustomization::QgsItem *>( parent.internalPointer() ) : nullptr;
-  if ( !item || !item->hasCapability( QgsCustomization::QgsItem::ItemCapability::AddActionRefChild ) || !data || !data->hasFormat( QStringLiteral( ACTIONPATHS_MIMEDATA_NAME ) ) )
+  if ( !item || !data
+       || !item->hasCapability( QgsCustomization::QgsItem::ItemCapability::AddActionRefChild )
+       || !data->hasFormat( ACTIONPATHS_MIMEDATA_NAME ) )
     return false;
 
-  QDataStream dataStreamRead( data->data( QStringLiteral( ACTIONPATHS_MIMEDATA_NAME ) ) );
+  QDataStream dataStreamRead( data->data( ACTIONPATHS_MIMEDATA_NAME ) );
   QStringList actionPaths;
   dataStreamRead >> actionPaths;
 
@@ -426,7 +456,7 @@ bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeData( const QMimeDat
     return false;
 
   beginInsertRows( parent, row, row + static_cast<int>( actions.count() ) - 1 );
-  for ( QPair<QgsCustomization::QgsActionItem *, QString> actionAndPath : actions )
+  for ( QPair<QgsCustomization::QgsActionItem *, QString> actionAndPath : std::as_const( actions ) )
   {
     QgsCustomization::QgsActionItem *action = actionAndPath.first;
     auto actionRef = std::make_unique<QgsCustomization::QgsActionRefItem>( mCustomization->uniqueActionName( action->name() ), action->title(), actionAndPath.second, item );
@@ -438,6 +468,52 @@ bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeData( const QMimeDat
 
   return true;
 }
+
+bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeDataProcessingAlgorithms( const QMimeData *data, int row, const QModelIndex &parent )
+{
+  QgsCustomization::QgsItem *item = parent.isValid() ? static_cast<QgsCustomization::QgsItem *>( parent.internalPointer() ) : nullptr;
+  if ( !QgsApplication::processingRegistry()
+       || !item || !data
+       || !item->hasCapability( QgsCustomization::QgsItem::ItemCapability::AddProcessingAlgorithmRefChild )
+       || !data->hasFormat( PROCESSING_ALGORITHM_IDS_MIMEDATA_NAME ) )
+    return false;
+
+  QDataStream dataStreamRead( data->data( PROCESSING_ALGORITHM_IDS_MIMEDATA_NAME ) );
+  QStringList processingAlgorithmIds;
+  dataStreamRead >> processingAlgorithmIds;
+
+  QList<const QgsProcessingAlgorithm *> processingAlgorithms;
+  for ( QString processingAlgorithmId : std::as_const( processingAlgorithmIds ) )
+  {
+    const QgsProcessingAlgorithm *processingAlgorithm = QgsApplication::processingRegistry()->algorithmById( processingAlgorithmId );
+    if ( !processingAlgorithm )
+    {
+      QgsDebugError( u"Invalid processing algorithm id '%1'"_s.arg( processingAlgorithmId ) );
+      continue;
+    }
+
+    processingAlgorithms << processingAlgorithm;
+  }
+
+  if ( processingAlgorithms.isEmpty() )
+    return false;
+
+  if ( row == -1 )
+    row = 0; // if dropped directly onto group item, insert at first position
+
+  beginInsertRows( parent, row, row + static_cast<int>( processingAlgorithms.count() ) - 1 );
+  for ( const QgsProcessingAlgorithm *processingAlgorithm : std::as_const( processingAlgorithms ) )
+  {
+    auto processingAlgorithmRef = std::make_unique<QgsCustomization::QgsProcessingAlgorithmRefItem>( processingAlgorithm->id(), mCustomization->uniqueProcessingAlgorithmName( processingAlgorithm->name() ), processingAlgorithm->displayName(), item );
+    processingAlgorithmRef->setIcon( processingAlgorithm->icon() );
+    item->insertChild( row, std::move( processingAlgorithmRef ) );
+  }
+
+  endInsertRows();
+
+  return true;
+}
+
 
 ////////////////
 

--- a/src/app/qgscustomizationdialog.cpp
+++ b/src/app/qgscustomizationdialog.cpp
@@ -498,9 +498,6 @@ bool QgsCustomizationDialog::QgsCustomizationModel::dropMimeDataProcessingAlgori
   if ( processingAlgorithms.isEmpty() )
     return false;
 
-  if ( row == -1 )
-    row = 0; // if dropped directly onto group item, insert at first position
-
   beginInsertRows( parent, row, row + static_cast<int>( processingAlgorithms.count() ) - 1 );
   for ( const QgsProcessingAlgorithm *processingAlgorithm : std::as_const( processingAlgorithms ) )
   {

--- a/src/app/qgscustomizationdialog.h
+++ b/src/app/qgscustomizationdialog.h
@@ -234,6 +234,18 @@ class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCus
         const std::unique_ptr<QgsCustomization> &customization() const;
 
       private:
+        /**
+         * Called whenever user drop some mime \a data representing a QgsActionItem on
+         * \a parent at \a row position
+         */
+        bool dropMimeDataActions( const QMimeData *data, int row, const QModelIndex &parent );
+
+        /**
+         * Called whenever user drop some mime \a data representing a QgsProcessingAlgorithmItem on
+         * \a parent at \a row position
+         */
+        bool dropMimeDataProcessingAlgorithms( const QMimeData *data, int row, const QModelIndex &parent );
+
         Mode mMode = Mode::ActionSelector;
         QgisApp *mQgisApp = nullptr;
         std::unique_ptr<QgsCustomization> mCustomization; // current customization, copy of the application one

--- a/tests/src/app/testqgscustomization.cpp
+++ b/tests/src/app/testqgscustomization.cpp
@@ -20,6 +20,8 @@
 #include "qgscustomization.h"
 #include "qgscustomizationdialog.h"
 #include "qgslayertreeview.h"
+#include "qgsnativealgorithms.h"
+#include "qgsprocessingregistry.h"
 #include "qgstest.h"
 
 #include <QAbstractItemModelTester>
@@ -50,6 +52,7 @@ class TestQgsCustomization : public QgsTest
     void testBackwardCompatibility();
     void testClone();
     void testModel();
+    void testModelProcessing();
 
   private:
     template<class T> T *getItem( QgsCustomization *customization, const QString &path ) const { return dynamic_cast<T *>( getItem( customization, path ) ); }
@@ -112,7 +115,9 @@ long long TestQgsCustomization::qactionPosition( const QString &path )
 }
 
 void TestQgsCustomization::initTestCase()
-{}
+{
+  QgsApplication::processingRegistry()->addProvider( new QgsNativeAlgorithms( QgsApplication::processingRegistry() ) );
+}
 
 void TestQgsCustomization::cleanupTestCase()
 {}
@@ -128,7 +133,6 @@ void TestQgsCustomization::init()
   QgsBrowserGuiModel *browserModel = new QgsBrowserGuiModel( this );
   mQgisApp->mBrowserWidget = new QgsBrowserDockWidget( tr( "Browser" ), browserModel, mQgisApp.get() );
   mQgisApp->mBrowserWidget->setObjectName( u"Browser"_s );
-
 
   // add a test tool bar to test action with menu
   QToolBar *toolBar = new QToolBar( "testToolBar", mQgisApp.get() );
@@ -798,6 +802,127 @@ void TestQgsCustomization::testModel()
     QVERIFY( !findQWidget( "ToolBars/UserToolBar_1" ) );
     actions = findQActions( mQgisApp->toolBarMenu(), u"UserToolBar_1"_s );
     QCOMPARE( actions.count(), 0 );
+  }
+}
+
+void TestQgsCustomization::testModelProcessing()
+{
+  mQgisApp->customization()->setEnabled( true );
+
+  QgsCustomizationDialog::QgsCustomizationModel model( mQgisApp.get(), QgsCustomizationDialog::QgsCustomizationModel::Mode::ItemVisibility );
+  QAbstractItemModelTester modelTester( &model, QAbstractItemModelTester::FailureReportingMode::Fatal );
+
+  QCOMPARE( model.rowCount(), 5 );
+
+  QgsCustomizationDialog::QgsCustomizationModel modelActionSelector( mQgisApp.get(), QgsCustomizationDialog::QgsCustomizationModel::Mode::ActionSelector );
+  QAbstractItemModelTester modelActionSelectorTester( &modelActionSelector, QAbstractItemModelTester::FailureReportingMode::Fatal );
+
+  const QModelIndexList bufferActionIndexes = modelActionSelector.match( modelActionSelector.index( 0, 0 ), Qt::ItemDataRole::DisplayRole, u"native:buffer"_s, -1, Qt::MatchRecursive | Qt::MatchFixedString );
+  QCOMPARE( bufferActionIndexes.count(), 1 );
+
+  std::unique_ptr<QMimeData> mimeData( modelActionSelector.mimeData( bufferActionIndexes ) );
+  QVERIFY( mimeData );
+
+  // add user menu and drop a processing algorithm action
+  {
+    const QModelIndex menusIndex = model.index( 2, 0 );
+    QCOMPARE( model.data( menusIndex, Qt::ItemDataRole::DisplayRole ), u"Menus"_s );
+
+    QModelIndex newMenuItemIndex = model.addUserItem( menusIndex );
+    QCOMPARE( model.data( newMenuItemIndex, Qt::ItemDataRole::DisplayRole ), u"UserMenu_1"_s );
+
+    model.apply();
+    QVERIFY( getItem<QgsCustomization::QgsUserMenuItem>( "Menus/UserMenu_1" ) );
+    QVERIFY( findQWidget( "Menus/UserMenu_1" ) );
+
+    QVERIFY( modelActionSelector.canDropMimeData( mimeData.get(), Qt::DropAction::LinkAction, 0, 0, newMenuItemIndex ) );
+
+    QCOMPARE( model.rowCount( newMenuItemIndex ), 0 );
+    QVERIFY( modelActionSelector.dropMimeData( mimeData.get(), Qt::DropAction::LinkAction, 0, 0, newMenuItemIndex ) );
+    QCOMPARE( model.rowCount( newMenuItemIndex ), 1 );
+
+    QModelIndex actionIndex = model.index( 0, 0, newMenuItemIndex );
+    QCOMPARE( model.data( actionIndex, Qt::ItemDataRole::DisplayRole ), u"ProcessingAlgorithmRef_buffer_1"_s );
+    QCOMPARE( model.data( model.index( 0, 1, newMenuItemIndex ), Qt::ItemDataRole::DisplayRole ), u"Buffer"_s );
+    QVERIFY( !model.data( actionIndex, Qt::ItemDataRole::DecorationRole ).value<QIcon>().isNull() );
+
+    QVERIFY( getItem<QgsCustomization::QgsUserMenuItem>( "Menus/UserMenu_1" ) );
+    QCOMPARE( getItem<QgsCustomization::QgsUserMenuItem>( "Menus/UserMenu_1" )->childrenCount(), 0 );
+
+    model.apply();
+    QVERIFY( getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1" ) );
+    QVERIFY( getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1" )->isVisible() );
+    QVERIFY( findQAction( u"Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1"_s ) );
+
+    model.setData( actionIndex, Qt::CheckState::Unchecked, Qt::ItemDataRole::CheckStateRole );
+    QCOMPARE( model.data( actionIndex, Qt::ItemDataRole::CheckStateRole ), Qt::CheckState::Unchecked );
+    model.apply();
+    QVERIFY( getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1" ) );
+    QVERIFY( !getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1" )->isVisible() );
+    QVERIFY( !findQAction( u"Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1"_s ) );
+
+    model.setData( actionIndex, Qt::CheckState::Checked, Qt::ItemDataRole::CheckStateRole );
+    QCOMPARE( model.data( actionIndex, Qt::ItemDataRole::CheckStateRole ), Qt::CheckState::Checked );
+    model.apply();
+    QVERIFY( getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1" ) );
+    QVERIFY( getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1" )->isVisible() );
+    QVERIFY( findQAction( u"Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1"_s ) );
+
+    model.deleteUserItems( QList<QModelIndex>() << actionIndex );
+    model.apply();
+    QVERIFY( !getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1" ) );
+    QVERIFY( !findQAction( u"Menus/UserMenu_1/ProcessingAlgorithmRef_buffer_1"_s ) );
+  }
+
+  // add user ToolBar and drop a processing algorithm action
+  {
+    const QModelIndex toolBarsIndex = model.index( 4, 0 );
+    QCOMPARE( model.data( toolBarsIndex, Qt::ItemDataRole::DisplayRole ), u"ToolBars"_s );
+
+    QModelIndex newToolBarItemIndex = model.addUserItem( toolBarsIndex );
+    QCOMPARE( model.data( newToolBarItemIndex, Qt::ItemDataRole::DisplayRole ), u"UserToolBar_1"_s );
+
+    model.apply();
+    QVERIFY( getItem<QgsCustomization::QgsUserToolBarItem>( "ToolBars/UserToolBar_1" ) );
+    QVERIFY( findQWidget( "ToolBars/UserToolBar_1" ) );
+
+    QVERIFY( modelActionSelector.canDropMimeData( mimeData.get(), Qt::DropAction::LinkAction, 0, 0, newToolBarItemIndex ) );
+
+    QCOMPARE( model.rowCount( newToolBarItemIndex ), 0 );
+    QVERIFY( modelActionSelector.dropMimeData( mimeData.get(), Qt::DropAction::LinkAction, 0, 0, newToolBarItemIndex ) );
+    QCOMPARE( model.rowCount( newToolBarItemIndex ), 1 );
+
+    QModelIndex actionIndex = model.index( 0, 0, newToolBarItemIndex );
+    QCOMPARE( model.data( actionIndex, Qt::ItemDataRole::DisplayRole ), u"ProcessingAlgorithmRef_buffer_1"_s );
+    QCOMPARE( model.data( model.index( 0, 1, newToolBarItemIndex ), Qt::ItemDataRole::DisplayRole ), u"Buffer"_s );
+    QVERIFY( !model.data( actionIndex, Qt::ItemDataRole::DecorationRole ).value<QIcon>().isNull() );
+
+    QVERIFY( getItem<QgsCustomization::QgsUserToolBarItem>( "ToolBars/UserToolBar_1" ) );
+    QCOMPARE( getItem<QgsCustomization::QgsUserToolBarItem>( "ToolBars/UserToolBar_1" )->childrenCount(), 0 );
+
+    model.apply();
+    QVERIFY( getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1" ) );
+    QVERIFY( getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1" )->isVisible() );
+    QVERIFY( findQAction( u"ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1"_s ) );
+
+    model.setData( actionIndex, Qt::CheckState::Unchecked, Qt::ItemDataRole::CheckStateRole );
+    QCOMPARE( model.data( actionIndex, Qt::ItemDataRole::CheckStateRole ), Qt::CheckState::Unchecked );
+    model.apply();
+    QVERIFY( getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1" ) );
+    QVERIFY( !getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1" )->isVisible() );
+    QVERIFY( !findQAction( u"ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1"_s ) );
+
+    model.setData( actionIndex, Qt::CheckState::Checked, Qt::ItemDataRole::CheckStateRole );
+    QCOMPARE( model.data( actionIndex, Qt::ItemDataRole::CheckStateRole ), Qt::CheckState::Checked );
+    model.apply();
+    QVERIFY( getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1" ) );
+    QVERIFY( getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1" )->isVisible() );
+    QVERIFY( findQAction( u"ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1"_s ) );
+
+    model.deleteUserItems( QList<QModelIndex>() << actionIndex );
+    model.apply();
+    QVERIFY( !getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1" ) );
+    QVERIFY( !findQAction( u"ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1"_s ) );
   }
 }
 


### PR DESCRIPTION
Implement the possibility to add processing algorithm action in user
defined menu or toolbar. When triggered, those actions would open a
dialog to parametrize and execute the associated processing.

![processing](https://github.com/user-attachments/assets/df80ab0b-4755-4e3e-8def-b91d96b0520d)

AlgorithmDialog is a Python implementation from the processing module,
so we use QgsPythonRunner to trigger the opening of the dialog.

include #64912 and #64900

**Funded by Stadt Frankfurt am Main and Oslandia**