### PR TITLE
[themes] Fix border color for disabled datetime edits for dark themes

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -154,6 +154,7 @@ QAbstractSpinBox::drop-down:hover {
 }
 QAbstractSpinBox::drop-down:disabled {
     background-color: transparent !important;
+    border-color: @itemdarkbackground;
 }
 
 /* ==================================================================================== */

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -146,6 +146,7 @@ QAbstractSpinBox::drop-down:hover {
 }
 QAbstractSpinBox::drop-down:disabled {
     background-color: transparent !important;
+    border-color: @itemdarkbackground;
 }
 /* ==================================================================================== */
 /* CALENDAR                                                                             */


### PR DESCRIPTION
This PR fixes for the border color of the drop-down button of `QgsDateTimeEdit` widgets when they are disabled to match the overall appearance of the dark themes.

Before:
<img width="204" height="50" alt="datetimeedit_before_2" src="https://github.com/user-attachments/assets/339be5ab-9761-4d3d-b9aa-f7e50e37d6ae" />

After:
<img width="204" height="50" alt="datetimeedit_after_2" src="https://github.com/user-attachments/assets/6730468b-9d26-48a0-94e0-4825e714646a" />

The same changes have been applied to the Blend of Gray theme. They can be backported.