### PR TITLE
python/PyQt6/core/additions/qgsfunction.py: restore lost edits

### DIFF
--- a/python/PyQt6/core/additions/qgsfunction.py
+++ b/python/PyQt6/core/additions/qgsfunction.py
@@ -111,7 +111,7 @@ def register_function(
     The function signature may contain special parameters (in any order at the end of the signature):
 
     - feature: the QgsFeature related to the current evaluation
-    - parent: the QgsExpressionFunction parent
+    - parent: the QgsExpression parent
     - context: the QgsExpressionContext related to the current evaluation
 
     If those parameters are present in the function signature, they will be automatically passed to the function,
@@ -192,7 +192,7 @@ def qgsfunction(args="auto", group: str = "custom", **kwargs):
     The decorated function signature may contain special parameters (in any order at the end of the signature):
 
     - ``feature``: the QgsFeature related to the current evaluation
-    - ``parent``: the QgsExpressionFunction parent
+    - ``parent``: the QgsExpression parent
     - ``context``: the QgsExpressionContext related to the current evaluation
 
     If those parameters are present in the function signature, they will be automatically passed to the function,
@@ -296,7 +296,7 @@ def qgsfunction(args="auto", group: str = "custom", **kwargs):
 
     This registers a function called "display_field" in the "custom" group.
     This expression requires an unique parameter: ``fieldname``. ``feature`` is automatically passed to the function.
-    ``parent`` is the QgsExpressionFunction parent, and can be used to raise an error.
+    ``parent`` is the QgsExpression parent, and can be used to raise an error.
 
     .. code-block:: text
 


### PR DESCRIPTION
Restore lost edits done in python/core/additions/qgsfunction.py per PR#63341 as raised in https://github.com/qgis/QGIS/pull/64880#issuecomment-3894552163

CC @ValentinBuira 

With that change the diff in the core/additions directory between PyQt6  and ./ before its removal is:
```
diff -Nur ../python/PyQt6/core/additions/qgsfeature.py ../../tmp/python/core/additions/qgsfeature.py
--- ../python/PyQt6/core/additions/qgsfeature.py	2026-02-12 03:22:16.614075563 +0100
+++ ../../tmp/python/core/additions/qgsfeature.py	2026-02-13 04:08:55.156857095 +0100
@@ -15,11 +15,15 @@
 ***************************************************************************
 """
 
+from PyQt5.QtCore import QVariant
+
 
 def _mapping_feature(feature):
     geom = feature.geometry()
-    fields = [field.name() for field in feature.fields()]
-    properties = dict(list(zip(fields, feature.attributes())))
+    properties = {
+        k: None if (v is None or (isinstance(v, QVariant) and v.isNull())) else v
+        for k, v in feature.attributeMap().items()
+    }
     return {
         "type": "Feature",
         "properties": properties,
diff -Nur ../python/PyQt6/core/additions/qgssettingsentry.py ../../tmp/python/core/additions/qgssettingsentry.py
--- ../python/PyQt6/core/additions/qgssettingsentry.py	2026-02-12 03:22:16.615075566 +0100
+++ ../../tmp/python/core/additions/qgssettingsentry.py	2026-02-13 04:08:55.156857095 +0100
@@ -16,7 +16,6 @@
 """
 
 from .metaenum import metaEnumFromValue
-from enum import IntFlag, Flag
 from qgis.core import (
     QgsSettings,
     QgsSettingsTree,
@@ -54,14 +53,18 @@
         # TODO QGIS 5: rename pluginName arg to parent and key to name
 
         self.options = options
-        self.__enum_class = defaultValue.__class__
-
-        if issubclass(self.__enum_class, (IntFlag, Flag)):
-            defaultValueStr = "|".join(
-                [e.name for e in self.__enum_class if defaultValue & e]
+        defaultValueStr = ""
+        self.__metaEnum = metaEnumFromValue(defaultValue)
+        if self.__metaEnum is None or not self.__metaEnum.isValid():
+            QgsLogger.debug(
+                f"Invalid metaenum. Enum/Flag probably misses Q_ENUM/Q_FLAG declaration. Settings key: '{self.key()}'"
             )
         else:
-            defaultValueStr = defaultValue.name
+            if self.__metaEnum.isFlag():
+                defaultValueStr = self.__metaEnum.valueToKeys(defaultValue)
+            else:
+                defaultValueStr = self.__metaEnum.valueToKey(defaultValue)
+            self.__enumFlagClass = defaultValue.__class__
 
         if type(pluginName) is str:
             parent = QgsSettingsTree.createPluginTreeNode(pluginName)
@@ -69,6 +72,9 @@
             parent = pluginName
         super().__init__(key, parent, defaultValueStr, description, options)
 
+    def metaEnum(self):
+        return self.__metaEnum
+
     def typeId(self):
         """
         Defines a custom id since this class has not the same API as the cpp implementation
@@ -81,29 +87,14 @@
 
         :param dynamicKeyPart: argument specifies the dynamic part of the settings key.
         """
-        v = QgsSettings().value(self.key(dynamicKeyPart), self.defaultValue())
-        if issubclass(self.__enum_class, (IntFlag, Flag)):
-            if isinstance(v, str):
-                flag_val = self.__enum_class(0)
-                for part in v.split("|"):
-                    try:
-                        flag_val |= getattr(self.__enum_class, part)
-                    except AttributeError:
-                        QgsLogger.debug(f"Invalid enum/flag key/s '{v}'.")
-                        return -1
-                return flag_val
-            elif isinstance(v, int):
-                return self.__enum_class(v)
-        else:
-            if isinstance(v, str):
-                try:
-                    flag_val = getattr(self.__enum_class, v)
-                except AttributeError:
-                    QgsLogger.debug(f"Invalid enum/flag key/s '{v}'.")
-                    return -1
-                return flag_val
-            elif isinstance(v, int):
-                return self.__enum_class(v)
+        if self.__metaEnum.isFlag():
+            return QgsSettings().flagValue(
+                self.key(dynamicKeyPart), self.defaultValue()
+            )
+        else:
+            return QgsSettings().enumValue(
+                self.key(dynamicKeyPart), self.defaultValue()
+            )
 
     def valueWithDefaultOverride(self, defaultValueOverride, dynamicKeyPart=None):
         """
@@ -125,25 +116,27 @@
         """
         Get settings default value.
         """
+
+        if self.__metaEnum is None or not self.__metaEnum.isValid():
+            QgsLogger.debug(
+                f"Invalid metaenum. Enum/Flag probably misses Q_ENUM/Q_FLAG declaration. Settings key: '{self.key()}'"
+            )
+            return -1
+
         defaultValueString = self.defaultValueAsVariant()
+        if self.__metaEnum.isFlag():
+            (defaultValue, ok) = self.__metaEnum.keysToValue(defaultValueString)
+        else:
+            (defaultValue, ok) = self.__metaEnum.keyToValue(defaultValueString)
+        if not ok:
+            QgsLogger.debug(
+                f"Invalid enum/flag key/s '{self.defaultValueAsVariant()}'."
+            )
+            return -1
 
-        if issubclass(self.__enum_class, (IntFlag, Flag)):
-            flag_val = self.__enum_class(0)
-            for part in defaultValueString.split("|"):
-                try:
-                    flag_val |= getattr(self.__enum_class, part)
-                except AttributeError:
-                    QgsLogger.debug(f"Invalid enum/flag key/s '{part}'.")
-                    return -1
-            return flag_val
-        else:
-            try:
-                return getattr(self.__enum_class, defaultValueString)
-            except AttributeError:
-                QgsLogger.debug(
-                    f"Invalid enum/flag key/s '{self.defaultValueAsVariant()}'."
-                )
-                return -1
+        # cast to the enum class
+        defaultValue = self.__enumFlagClass(defaultValue)
+        return defaultValue
 
     def setValue(self, value, dynamicKeyPart: (list, str) = None):
         """
@@ -152,23 +145,23 @@
         :param value: the value to set for the setting.
         :param dynamicKeyPart: argument specifies the dynamic part of the settings key (a single one a string, or several as a list)
         """
+
+        if self.__metaEnum is None or not self.__metaEnum.isValid():
+            QgsLogger.debug(
+                f"Invalid metaenum. Enum/Flag probably misses Q_ENUM/Q_FLAG declaration. Settings key: '{self.key()}'"
+            )
+            return False
+
         if self.options & Qgis.SettingsOption.SaveEnumFlagAsInt:
-            enum_flag_key = value.value
+            enum_flag_key = int(value)
         else:
-            if issubclass(self.__enum_class, (IntFlag, Flag)):
-                enum_flag_key = "|".join(
-                    [e.name for e in self.__enum_class if value & e]
-                )
+            if self.__metaEnum.isFlag():
+                enum_flag_key = self.__metaEnum.valueToKeys(value)
             else:
-                if isinstance(value, int):
-                    try:
-                        enum_flag_key = [
-                            e.name for e in self.__enum_class if value == e.value
-                        ][0]
-                    except IndexError:
-                        return False
-                else:
-                    enum_flag_key = value.name
+                enum_flag_key = self.__metaEnum.valueToKey(value)
+            if not enum_flag_key:
+                QgsLogger.debug(f"Invalid enum/flag value '{value}'.")
+                return False
 
         if type(dynamicKeyPart) is str:
             dynamicKeyPart = [dynamicKeyPart]
diff -Nur ../python/PyQt6/core/additions/qgssettings.py ../../tmp/python/core/additions/qgssettings.py
--- ../python/PyQt6/core/additions/qgssettings.py	2026-02-12 03:22:16.615075566 +0100
+++ ../../tmp/python/core/additions/qgssettings.py	2026-02-13 04:08:55.156857095 +0100
@@ -101,18 +101,38 @@
     :param flagDefaultValue: the default value as a flag value
     :param section: optional section
     :return: the setting value
+
+     .. note::  The flag needs to be declared with Q_FLAG (not Q_FLAGS).
+
     """
 
-    default_value_str = "|".join(
-        [e.name for e in flagDefaultValue.__class__ if flagDefaultValue & e]
+    # There is an issue in SIP, flags.__class__ does not return the proper class
+    # (e.g. Filters instead of Qgis.LayerFilters)
+    # dirty hack to get the parent class
+    __import__(flagDefaultValue.__module__)
+    baseClass = None
+    exec(
+        "baseClass={module}.{flag_class}".format(
+            module=flagDefaultValue.__module__.replace("_", ""),
+            flag_class=flagDefaultValue.__class__.__name__,
+        )
     )
-    str_val = self.value(key, default_value_str, str, section)
 
-    flag_val = flagDefaultValue.__class__(0)
-    for part in str_val.split("|"):
-        try:
-            flag_val |= getattr(flagDefaultValue.__class__, part)
-        except AttributeError:
-            return flagDefaultValue
+    meta_enum = metaEnumFromValue(flagDefaultValue, baseClass)
+    if meta_enum is None or not meta_enum.isValid():
+        # this should not happen
+        raise ValueError(
+            f"could not get the meta enum for given enum default value (type: {type(flagDefaultValue)})"
+        )
+
+    str_val = self.value(key, meta_enum.valueToKeys(flagDefaultValue), str, section)
+    # need a new meta enum as QgsSettings.value is making a copy and leads to seg fault (probably a PyQt issue)
+    meta_enum_2 = metaEnumFromValue(flagDefaultValue)
+    (flag_val, ok) = meta_enum_2.keysToValue(str_val)
+
+    if not ok:
+        flag_val = flagDefaultValue
+    else:
+        flag_val = flagDefaultValue.__class__(flag_val)
 
     return flag_val
```

At first sight it seems to be Qt5 specifics but I might be wrong