### PR TITLE
Label field domain policies as in attributes form dialog

### DIFF
--- a/src/ui/qgsfielddomainwidgetbase.ui
+++ b/src/ui/qgsfielddomainwidgetbase.ui
@@ -48,7 +48,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Split policy</string>
+         <string>When splitting features</string>
         </property>
        </widget>
       </item>
@@ -58,7 +58,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Merge policy</string>
+         <string>When merging features</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
"Policies" is already the name of the group box so no need to repeat for each, but let's clarify in the individual name what it is about, and rely on names we already use for the same topic, in attributes form.