### PR TITLE
Fix WMS-T layer loading via Data Source Manager

### DIFF
--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -1115,7 +1115,10 @@ void QgsWMSSourceSelect::collectDimensions( QStringList &layers, QgsDataSourceUr
       if ( uri.param( "type"_L1 ) == "wmst"_L1 )
       {
         uri.setParam( "temporalSource"_L1, "provider"_L1 );
-        uri.setParam( "allowTemporalUpdates"_L1, "true"_L1 );
+        if ( uri.param( "allowTemporalUpdates"_L1 ) != "true"_L1 )
+        {
+          uri.setParam( "allowTemporalUpdates"_L1, "true"_L1 );
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

Currently, when loading a WMS-T layer through the **Data Source Manager**, the `allowTemporalUpdates` parameter is set/inserted twice. This results in an image being successfully requested when adding the layer once,  but requests after that fail. The image currently stays the same, even though the temporal slider is moved.

Setting the parameter only once make sure, WMS-T temporal controls will now work again, when a layer is loaded via the **Data Source Manager**. 

Partially fixes #64099

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
