### PR TITLE
Add Qt Tools to Mac App Bundle

### DIFF
--- a/cmake/VcpkgInstallDeps.cmake
+++ b/cmake/VcpkgInstallDeps.cmake
@@ -155,3 +155,37 @@ if(NOT MSVC AND NOT EMSCRIPTEN)
     DESTINATION "${QGIS_BIN_SUBDIR}")
 endif()
 
+if(WITH_CUSTOM_WIDGETS)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    install(CODE [[
+      function(fixup_qt_app APP_PACKAGE EXECUTABLE)
+        find_program(CMAKE_INSTALL_NAME_TOOL NAMES install_name_tool HINTS ${_CMAKE_TOOLCHAIN_LOCATION})
+        execute_process(COMMAND ${CMAKE_INSTALL_NAME_TOOL} "-rpath" "@loader_path/../../../../../../lib" "@loader_path/../../../Frameworks" "${APP_PACKAGE}/Contents/MacOS/${EXECUTABLE}")
+        file(WRITE "${APP_PACKAGE}/Contents/MacOS/qt.conf"
+          "[Paths]"
+          "\n"
+          "Plugins = ../../../PlugIns"
+        )
+      endfunction()
+    ]])
+    install(DIRECTORY "${VCPKG_BASE_DIR}/tools/qttools/bin/Designer.app" 
+      DESTINATION "${QGIS_BIN_SUBDIR}" 
+      FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+    install(CODE
+      "fixup_qt_app(\"\${CMAKE_INSTALL_PREFIX}/${QGIS_BIN_SUBDIR}/Designer.app\" \"Designer\")"
+    )
+    install(DIRECTORY "${VCPKG_BASE_DIR}/tools/qttools/bin/Linguist.app" 
+      DESTINATION "${QGIS_BIN_SUBDIR}" 
+      FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+    install(CODE
+      "fixup_qt_app(\"\${CMAKE_INSTALL_PREFIX}/${QGIS_BIN_SUBDIR}/Linguist.app\" \"Linguist\")"
+    )
+    install(DIRECTORY "${VCPKG_BASE_DIR}/tools/qttools/bin/pixeltool.app"
+      DESTINATION "${QGIS_BIN_SUBDIR}"
+      FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        WORLD_READ WORLD_EXECUTE GROUP_READ GROUP_EXECUTE)
+    install(CODE
+      "fixup_qt_app(\"\${CMAKE_INSTALL_PREFIX}/${QGIS_BIN_SUBDIR}/pixeltool.app\" \"pixeltool\")"
+    )
+  endif()
+endif()


### PR DESCRIPTION
## Description

This PR modifies the cmake build process for the "bundle" target to add the Qt tools Designer, Linguist, and pixeltool to the QGIS Mac app bundle and then fix up the `rpath` and plugin directories so that they run and, in the case of Designer, pickup the QGIS custom widgets. The apps are added to the bundle only if QGIS is configured to build the custom widgets (i.e., if `WITH_CUSTOM_WIDGETS` is set). These apps are useful for plugin developers who may not have a full Qt Creator install and still want to be able to use Qt's tools for laying out dialogs and creating language files. And they have long been bundled in the 3.x Mac bundles, so this PR maintains existing functionality.