### PR TITLE
Fix QGIS Server service URL calculation when X-Forwarded-Proto header has multiple values

### DIFF
--- a/src/server/qgsfcgiserverrequest.cpp
+++ b/src/server/qgsfcgiserverrequest.cpp
@@ -118,12 +118,13 @@ QgsFcgiServerRequest::QgsFcgiServerRequest()
   {
     const QString headerName = QgsStringUtils::capitalize(
                                  QString( headerKey ).replace( '_'_L1, ' '_L1 ), Qgis::Capitalization::TitleCase
-    )
-                                 .replace( ' '_L1, '-'_L1 );
+                               )
+                               .replace( ' '_L1, '-'_L1 );
     const char *result = getenv( u"HTTP_%1"_s.arg( headerKey ).toStdString().c_str() );
     if ( result && strlen( result ) > 0 )
     {
       setHeader( headerName, result );
+      QgsMessageLog::logMessage( u"HTTP HEADER %1: %2"_s.arg( headerName ).arg( QString( result ) ), u"Server"_s, Qgis::MessageLevel::Info );
     }
   }
 
@@ -162,8 +163,8 @@ void QgsFcgiServerRequest::fillUrl( QUrl &url ) const
   if ( url.scheme().isEmpty() )
   {
     QString( getenv( "HTTPS" ) ).compare( "on"_L1, Qt::CaseInsensitive ) == 0
-      ? url.setScheme( u"https"_s )
-      : url.setScheme( u"http"_s );
+    ? url.setScheme( u"https"_s )
+    : url.setScheme( u"http"_s );
   }
 }
 
@@ -232,7 +233,8 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url ) const
 {
   QgsMessageLog::logMessage( u"******************** New request ***************"_s, u"Server"_s, Qgis::MessageLevel::Info );
 
-  const QStringList envVars {
+  const QStringList envVars
+  {
     u"SERVER_NAME"_s,
     u"REQUEST_URI"_s,
     u"SCRIPT_NAME"_s,
@@ -271,14 +273,6 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url ) const
     }
   }
 
-  qDebug() << "Headers:";
-  qDebug() << "------------------------------------------------";
-  const QMap<QString, QString> &hdrs = headers();
-  for ( auto it = hdrs.constBegin(); it != hdrs.constEnd(); it++ )
-  {
-    qDebug() << it.key() << ": " << it.value();
-    QgsMessageLog::logMessage( u"HTTP HEADER %1: %2"_s.arg( it.key() ).arg( QString( it.value() ) ), u"Server"_s, Qgis::MessageLevel::Info );
-  }
 }
 
 QString QgsFcgiServerRequest::header( const QString &name ) const

--- a/src/server/qgsfcgiserverrequest.cpp
+++ b/src/server/qgsfcgiserverrequest.cpp
@@ -118,8 +118,8 @@ QgsFcgiServerRequest::QgsFcgiServerRequest()
   {
     const QString headerName = QgsStringUtils::capitalize(
                                  QString( headerKey ).replace( '_'_L1, ' '_L1 ), Qgis::Capitalization::TitleCase
-                               )
-                               .replace( ' '_L1, '-'_L1 );
+    )
+                                 .replace( ' '_L1, '-'_L1 );
     const char *result = getenv( u"HTTP_%1"_s.arg( headerKey ).toStdString().c_str() );
     if ( result && strlen( result ) > 0 )
     {
@@ -163,8 +163,8 @@ void QgsFcgiServerRequest::fillUrl( QUrl &url ) const
   if ( url.scheme().isEmpty() )
   {
     QString( getenv( "HTTPS" ) ).compare( "on"_L1, Qt::CaseInsensitive ) == 0
-    ? url.setScheme( u"https"_s )
-    : url.setScheme( u"http"_s );
+      ? url.setScheme( u"https"_s )
+      : url.setScheme( u"http"_s );
   }
 }
 
@@ -233,8 +233,7 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url ) const
 {
   QgsMessageLog::logMessage( u"******************** New request ***************"_s, u"Server"_s, Qgis::MessageLevel::Info );
 
-  const QStringList envVars
-  {
+  const QStringList envVars {
     u"SERVER_NAME"_s,
     u"REQUEST_URI"_s,
     u"SCRIPT_NAME"_s,
@@ -272,7 +271,6 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url ) const
       QgsMessageLog::logMessage( u"%1: %2"_s.arg( envVar ).arg( QString( getenv( envVar.toStdString().c_str() ) ) ), u"Server"_s, Qgis::MessageLevel::Info );
     }
   }
-
 }
 
 QString QgsFcgiServerRequest::header( const QString &name ) const

--- a/src/server/qgsfcgiserverrequest.cpp
+++ b/src/server/qgsfcgiserverrequest.cpp
@@ -277,6 +277,7 @@ void QgsFcgiServerRequest::printRequestInfos( const QUrl &url ) const
   for ( auto it = hdrs.constBegin(); it != hdrs.constEnd(); it++ )
   {
     qDebug() << it.key() << ": " << it.value();
+    QgsMessageLog::logMessage( u"HTTP HEADER %1: %2"_s.arg( it.key() ).arg( QString( it.value() ) ), u"Server"_s, Qgis::MessageLevel::Info );
   }
 }
 

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -422,7 +422,15 @@ QString QgsServerProjectUtils::serviceUrl( const QString &service, const QgsServ
   QUrl urlQUrl = request.baseUrl();
   if ( !proto.isEmpty() )
   {
-    urlQUrl.setScheme( proto );
+    QStringList forwardProto = proto.split( ','_L1 );
+    if ( forwardProto.length() > 0 )
+    {
+      urlQUrl.setScheme( forwardProto[0] );
+    }
+    else
+    {
+      urlQUrl.setScheme( proto );
+    }
   }
 
   if ( !host.isEmpty() )

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -491,7 +491,15 @@ QString QgsServerSettings::serviceUrl( const QString &service ) const
 
   if ( result.isEmpty() )
   {
-    result = value( QgsServerSettingsEnv::QGIS_SERVER_SERVICE_URL ).toString();
+    if ( getenv( "QGIS_SERVER_SERVICE_URL" ) )
+    {
+      result = getenv( "QGIS_SERVER_SERVICE_URL" );
+      QgsMessageLog::logMessage( u"Using QGIS_SERVER_SERVICE_URL from environment: %1"_s.arg( result ), u"Server"_s, Qgis::MessageLevel::Info );
+    }
+    else
+    {
+      result = value( QgsServerSettingsEnv::QGIS_SERVER_SERVICE_URL ).toString();
+    }
   }
 
   return result;

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -494,7 +494,6 @@ QString QgsServerSettings::serviceUrl( const QString &service ) const
     if ( getenv( "QGIS_SERVER_SERVICE_URL" ) )
     {
       result = getenv( "QGIS_SERVER_SERVICE_URL" );
-      QgsMessageLog::logMessage( u"Using QGIS_SERVER_SERVICE_URL from environment: %1"_s.arg( result ), u"Server"_s, Qgis::MessageLevel::Info );
     }
     else
     {


### PR DESCRIPTION
## Description

This PR does 3 different (little) things. For each feature, there is only one piece of code changed. Comments are welcome regarding each feature.

<del>There are 3 more formatting changes in this PR. They were produced by `scripts/astyle.sh`.</del>

I was still using `scripts/astyle.sh` on files outside `src/core`. So sorry! I've updated the PR using `clang-format` for files under `src/server`.

### 1. Fix #64940

Support for protocol list in X-Forwarded-Proto header. Now it is possible to receive a X-Forwarded-Proto header like: `X-Forwarded-Proto: https, https, HTTPS`.

### 2. Read QGIS_SERVER_SERVICE_URL environment variable in every request

Only the QGIS_PROJECT_FILE file is read on every request. This variable can be set in a rewrite rule, for example, for every request. Other environment variables are read only when the server starts.

This PR also reads QGIS_SERVER_SERVICE_URL environment variable in every request, giving more flexibility  to set it, when headers are not enough. This PR was motivated by this limitation: when the service URL is not being properly computed, we must provide a way to force it.

For example, with this PR we can define something like this on Apache (example with mod_rewrite):

```apache
RewriteRule ^/postgresql/(.*)/(.*)/(.*)/cgi-bin/qgis_mapserv.fcgi /cgi-bin/qgis_mapserv.fcgi [NC,PT,E=QGIS_SERVER_SERVICE_URL:https://%{HTTP_HOST}/postgresql/$1/$2/$3/cgi-bin/qgis_mapserv.fcgi,E=QGIS_PROJECT_FILE:postgresql:?service=$1&sslmode=disable&schema=$2&project=$3]
```

This rewrite rule defines two environment variables on every request:
* QGIS_SERVER_SERVICE_URL
* QGIS_PROJECT_FILE

For a request like this: `https://osgeo.local/postgresql/5363_carttop1_coimbra_20250401/public/testewfs/cgi-bin/qgis_mapserv.fcgi`, the variables will be defined as:
* QGIS_SERVER_SERVICE_URL: https://osgeo.local/postgresql/5363_carttop1_coimbra_20250401/public/testewfs/cgi-bin/qgis_mapserv.fcgi
* QGIS_PROJECT_FILE: postgresql:?service=5363_carttop1_coimbra_20250401&sslmode=disable&schema=public&project=testewfs

If we change the project being served, both QGIS_SERVER_SERVICE_URL and QGIS_PROJECT_FILE are set automatically.

### 3. Log headers 

Before this PR, headers could be logged only on a debug version. On a quality/production environment, it is not easy to compile and run a debug version to check the atual headers received.

This PR removes the header logging on debug versions and make it happen on release versions, depending on QGIS_SERVER_LOG_LEVEL variable.


