### PR TITLE
[mssql] Fix field order for newly created tables 

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -2215,7 +2215,7 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
         return Qgis::VectorExportResult::ErrorAttributeTypeUnsupported;
       }
 
-      const int newAttributeIndex = attributeClauses.length();
+      const int newAttributeIndex = static_cast< int >( attributeClauses.length() );
       attributeClauses.append( columnDefinition );
       if ( oldToNewAttrIdxMap )
       {

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1338,19 +1338,11 @@ bool QgsMssqlProvider::addAttributes( const QList<QgsField> &attributes )
   attributeClauses.reserve( attributes.size() );
   for ( QList<QgsField>::const_iterator it = attributes.begin(); it != attributes.end(); ++it )
   {
-    QString type = it->typeName();
-    if ( type == "char"_L1 || type == "varchar"_L1 || type == "nvarchar"_L1 )
-    {
-      if ( it->length() > 0 )
-        type = u"%1(%2)"_s.arg( type ).arg( it->length() );
-    }
-    else if ( type == "numeric"_L1 || type == "decimal"_L1 )
-    {
-      if ( it->length() > 0 && it->precision() > 0 )
-        type = u"%1(%2,%3)"_s.arg( type ).arg( it->length() ).arg( it->precision() );
-    }
+    const QString definition = QgsMssqlUtils::columnDefinitionForField( *it );
+    if ( definition.isEmpty() )
+      return false;
 
-    attributeClauses.append( u"[%1] %2"_s.arg( it->name(), type ) );
+    attributeClauses.append( definition );
   }
   statement += attributeClauses.join( ", "_L1 );
 

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1970,68 +1970,6 @@ Qgis::VectorLayerTypeFlags QgsMssqlProvider::vectorLayerTypeFlags() const
   return flags;
 }
 
-bool QgsMssqlProvider::convertField( QgsField &field )
-{
-  QString fieldType = u"nvarchar(max)"_s; //default to string
-  int fieldSize = field.length();
-  int fieldPrec = field.precision();
-  switch ( field.type() )
-  {
-    case QMetaType::Type::LongLong:
-      fieldType = u"bigint"_s;
-      fieldSize = -1;
-      fieldPrec = 0;
-      break;
-
-    case QMetaType::Type::QDateTime:
-      fieldType = u"datetime"_s;
-      fieldPrec = 0;
-      break;
-
-    case QMetaType::Type::QDate:
-      fieldType = u"date"_s;
-      fieldPrec = 0;
-      break;
-
-    case QMetaType::Type::QTime:
-      fieldType = u"time"_s;
-      fieldPrec = 0;
-      break;
-
-    case QMetaType::Type::QString:
-      fieldType = u"nvarchar(max)"_s;
-      fieldPrec = 0;
-      break;
-
-    case QMetaType::Type::Int:
-      fieldType = u"int"_s;
-      fieldSize = -1;
-      fieldPrec = 0;
-      break;
-
-    case QMetaType::Type::Double:
-      if ( fieldSize <= 0 || fieldPrec <= 0 )
-      {
-        fieldType = u"float"_s;
-        fieldSize = -1;
-        fieldPrec = 0;
-      }
-      else
-      {
-        fieldType = u"decimal"_s;
-      }
-      break;
-
-    default:
-      return false;
-  }
-
-  field.setTypeName( fieldType );
-  field.setLength( fieldSize );
-  field.setPrecision( fieldPrec );
-  return true;
-}
-
 void QgsMssqlProvider::mssqlWkbTypeAndDimension( Qgis::WkbType wkbType, QString &geometryType, int &dim )
 {
   const Qgis::WkbType flatType = QgsWkbTypes::flatType( wkbType );
@@ -2237,23 +2175,74 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
     }
   }
 
+  QStringList attributeClauses;
+  attributeClauses.reserve( fields.size() + 1 );
+  if ( oldToNewAttrIdxMap )
+    oldToNewAttrIdxMap->clear();
+
+  const QString pkColumnDefinition = u"[%1] [int] IDENTITY(1,1) NOT NULL"_s.arg( primaryKey );
+  attributeClauses << pkColumnDefinition;
+
+  const bool skipConvertFields = options && options->value( u"skipConvertFields"_s, false ).toBool();
+  if ( fields.size() > 0 )
+  {
+    for ( int originalFieldIndex = 0; originalFieldIndex < fields.size(); ++originalFieldIndex )
+    {
+      const QgsField field = fields.at( originalFieldIndex );
+      if ( field.name() == geometryColumn )
+      {
+        // Found a field with the same name of the geometry column. Skip it!
+
+        // TODO -- this should probably be reported to the user, or cause the table creation to fail??
+        QgsDebugError( u"Field %1 skipped as it collides with geometry column name"_s.arg( field.name() ) );
+        continue;
+      }
+      else if ( field.name() == primaryKey )
+      {
+        if ( oldToNewAttrIdxMap )
+        {
+          oldToNewAttrIdxMap->insert( originalFieldIndex, 0 );
+        }
+        continue;
+      }
+
+      const QString columnDefinition = QgsMssqlUtils::columnDefinitionForField( field, !skipConvertFields );
+      if ( columnDefinition.isEmpty() )
+      {
+        if ( errorMessage )
+          *errorMessage = QObject::tr( "Unsupported type for field %1" ).arg( field.name() );
+
+        return Qgis::VectorExportResult::ErrorAttributeTypeUnsupported;
+      }
+
+      const int newAttributeIndex = attributeClauses.length();
+      attributeClauses.append( columnDefinition );
+      if ( oldToNewAttrIdxMap )
+      {
+        oldToNewAttrIdxMap->insert( originalFieldIndex, newAttributeIndex );
+      }
+    }
+  }
+
+  const QString columnDefinitions = attributeClauses.join( ", "_L1 );
+
   if ( !geometryColumn.isEmpty() )
   {
     sql = QStringLiteral( "IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[%1].[%2]') AND type in (N'U')) DROP TABLE [%1].[%2]\n"
-                          "CREATE TABLE [%1].[%2]([%3] [int] IDENTITY(1,1) NOT NULL, [%4] [geometry] NULL CONSTRAINT [PK_%2] PRIMARY KEY CLUSTERED ( [%3] ASC ))\n"
+                          "CREATE TABLE [%1].[%2](%9, [%4] [geometry] NULL CONSTRAINT [PK_%2] PRIMARY KEY CLUSTERED ( [%3] ASC ))\n"
                           "DELETE FROM geometry_columns WHERE f_table_schema = '%1' AND f_table_name = '%2'\n"
                           "INSERT INTO [geometry_columns] ([f_table_catalog], [f_table_schema],[f_table_name], "
                           "[f_geometry_column],[coord_dimension],[srid],[geometry_type]) VALUES ('%5', '%1', '%2', '%4', %6, %7, '%8')" )
-            .arg( schemaName, tableName, primaryKey, geometryColumn, dbName, QString::number( dim ), QString::number( srid ), geometryType );
+            .arg( schemaName, tableName, primaryKey, geometryColumn, dbName, QString::number( dim ), QString::number( srid ), geometryType, columnDefinitions );
   }
   else
   {
     //geometryless table
     sql = QStringLiteral( "IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[%1].[%2]') AND type in (N'U')) DROP TABLE [%1].[%2]\n"
-                          "CREATE TABLE [%1].[%2]([%3] [int] IDENTITY(1,1) NOT NULL CONSTRAINT [PK_%2] PRIMARY KEY CLUSTERED ( [%3] ASC ))\n"
+                          "CREATE TABLE [%1].[%2](%4 CONSTRAINT [PK_%2] PRIMARY KEY CLUSTERED ( [%3] ASC ))\n"
                           "DELETE FROM geometry_columns WHERE f_table_schema = '%1' AND f_table_name = '%2'\n"
     )
-            .arg( schemaName, tableName, primaryKey );
+            .arg( schemaName, tableName, primaryKey, columnDefinitions );
   }
 
   logWrapper = std::make_unique<QgsDatabaseQueryLogWrapper>( sql, uri, u"mssql"_s, u"QgsMssqlProvider"_s, QGS_QUERY_LOG_ORIGIN );
@@ -2284,58 +2273,6 @@ Qgis::VectorExportResult QgsMssqlProvider::createEmptyLayer( const QString &uri,
     return Qgis::VectorExportResult::ErrorInvalidLayer;
   }
 
-  // add fields to the layer
-  if ( oldToNewAttrIdxMap )
-    oldToNewAttrIdxMap->clear();
-
-  if ( fields.size() > 0 )
-  {
-    const QgsFields providerFields = provider->fields();
-    int offset = providerFields.size();
-
-    // get the list of fields
-    QList<QgsField> flist;
-    for ( int originalFieldIndex = 0, n = fields.size(); originalFieldIndex < n; ++originalFieldIndex )
-    {
-      QgsField field = fields.at( originalFieldIndex );
-      if ( field.name() == geometryColumn )
-      {
-        // Found a field with the same name of the geometry column. Skip it!
-        continue;
-      }
-
-      const int providerIndex = providerFields.lookupField( field.name() );
-
-      if ( providerIndex >= 0 )
-      {
-        // we've already created this field (i.e. it was set in the CREATE TABLE statement), so
-        // we don't need to re-add it now
-        if ( oldToNewAttrIdxMap )
-          oldToNewAttrIdxMap->insert( originalFieldIndex, providerIndex );
-        continue;
-      }
-
-      if ( !( options && options->value( u"skipConvertFields"_s, false ).toBool() ) && !convertField( field ) )
-      {
-        if ( errorMessage )
-          *errorMessage = QObject::tr( "Unsupported type for field %1" ).arg( field.name() );
-
-        return Qgis::VectorExportResult::ErrorAttributeTypeUnsupported;
-      }
-
-      flist.append( field );
-      if ( oldToNewAttrIdxMap )
-        oldToNewAttrIdxMap->insert( originalFieldIndex, offset++ );
-    }
-
-    if ( !provider->addAttributes( flist ) )
-    {
-      if ( errorMessage )
-        *errorMessage = QObject::tr( "Creation of fields failed" );
-
-      return Qgis::VectorExportResult::ErrorAttributeCreationFailed;
-    }
-  }
   return Qgis::VectorExportResult::Success;
 }
 

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -123,9 +123,6 @@ class QgsMssqlProvider final : public QgsVectorDataProvider
 
     bool createAttributeIndex( int field ) override;
 
-    //! Convert a QgsField to work with MSSQL
-    static bool convertField( QgsField &field );
-
     // Parse type name and num coordinates as stored in geometry_columns table and returns normalized (M, Z or ZM) type name
     static QString typeFromMetadata( const QString &typeName, int numCoords );
 

--- a/src/providers/mssql/qgsmssqlutils.cpp
+++ b/src/providers/mssql/qgsmssqlutils.cpp
@@ -167,10 +167,10 @@ Qgis::WkbType QgsMssqlUtils::wkbTypeFromGeometryType( const QString &type )
   return QgsWkbTypes::parseType( type.toUpper() );
 }
 
-QString QgsMssqlUtils::columnDefinitionForField( const QgsField &field )
+QString QgsMssqlUtils::columnDefinitionForField( const QgsField &field, bool ignoreTypeString )
 {
   QString type = field.typeName();
-  if ( type.isEmpty() )
+  if ( ignoreTypeString || type.isEmpty() )
   {
     switch ( field.type() )
     {

--- a/src/providers/mssql/qgsmssqlutils.cpp
+++ b/src/providers/mssql/qgsmssqlutils.cpp
@@ -183,7 +183,14 @@ QString QgsMssqlUtils::columnDefinitionForField( const QgsField &field )
         break;
 
       case QMetaType::Type::Double:
-        type = u"numeric"_s;
+        if ( field.length() <= 0 || field.precision() <= 0 )
+        {
+          type = u"float"_s;
+        }
+        else
+        {
+          type = u"numeric"_s;
+        }
         break;
 
       case QMetaType::Type::QDate:

--- a/src/providers/mssql/qgsmssqlutils.h
+++ b/src/providers/mssql/qgsmssqlutils.h
@@ -53,6 +53,11 @@ class QgsMssqlUtils
      * Converts the string values from .STGeometryType() to a QGIS WKB type.
      */
     static Qgis::WkbType wkbTypeFromGeometryType( const QString &type );
+
+    /**
+     * Returns the Transect-SQL column definition for a QGIS \a field definition.
+     */
+    static QString columnDefinitionForField( const QgsField &field );
 };
 
 

--- a/src/providers/mssql/qgsmssqlutils.h
+++ b/src/providers/mssql/qgsmssqlutils.h
@@ -56,8 +56,11 @@ class QgsMssqlUtils
 
     /**
      * Returns the Transect-SQL column definition for a QGIS \a field definition.
+     *
+     * If \a ignoreTypeString is TRUE then the native type string from \a field will be ignored, and
+     * only the QVariant metatype considered.
      */
-    static QString columnDefinitionForField( const QgsField &field );
+    static QString columnDefinitionForField( const QgsField &field, bool ignoreTypeString = false );
 };
 
 

--- a/tests/src/providers/testqgsmssqlprovider.cpp
+++ b/tests/src/providers/testqgsmssqlprovider.cpp
@@ -526,10 +526,12 @@ void TestQgsMssqlProvider::testEmptyLayer()
 
   uri.setKeyColumn( u"my_pk"_s );
 
-  QCOMPARE(
-    metadata->createEmptyLayer( uri.uri(), fields, Qgis::WkbType::Point, QgsCoordinateReferenceSystem( "EPSG:3111" ), true, oldToNewAttrIdxMap, errorMessage, {}, createdUri ),
-    Qgis::VectorExportResult::Success
-  );
+  Qgis::VectorExportResult res = metadata->createEmptyLayer( uri.uri(), fields, Qgis::WkbType::Point, QgsCoordinateReferenceSystem( "EPSG:3111" ), true, oldToNewAttrIdxMap, errorMessage, {}, createdUri );
+  if ( !errorMessage.isEmpty() )
+  {
+    QgsDebugError( errorMessage );
+  }
+  QCOMPARE( res, Qgis::VectorExportResult::Success );
 
   auto vl = std::make_unique< QgsVectorLayer >( createdUri, "test", "mssql" );
   QVERIFY( vl->isValid() );
@@ -553,10 +555,12 @@ void TestQgsMssqlProvider::testEmptyLayer()
   // creating a brand new primary key
   uri.setKeyColumn( u"my_new_pk"_s );
 
-  QCOMPARE(
-    metadata->createEmptyLayer( uri.uri(), fields, Qgis::WkbType::Point, QgsCoordinateReferenceSystem( "EPSG:3111" ), true, oldToNewAttrIdxMap, errorMessage, {}, createdUri ),
-    Qgis::VectorExportResult::Success
-  );
+  res = metadata->createEmptyLayer( uri.uri(), fields, Qgis::WkbType::Point, QgsCoordinateReferenceSystem( "EPSG:3111" ), true, oldToNewAttrIdxMap, errorMessage, {}, createdUri );
+  if ( !errorMessage.isEmpty() )
+  {
+    QgsDebugError( errorMessage );
+  }
+  QCOMPARE( res, Qgis::VectorExportResult::Success );
 
   vl = std::make_unique< QgsVectorLayer >( createdUri, "test", "mssql" );
   QVERIFY( vl->isValid() );

--- a/tests/src/providers/testqgsmssqlprovider.cpp
+++ b/tests/src/providers/testqgsmssqlprovider.cpp
@@ -601,7 +601,10 @@ void TestQgsMssqlProvider::testColumnDefinitionForField_data()
     << "[age] int";
   QTest::newRow( "auto_numeric" )
     << QgsField( "score", QMetaType::Type::Double )
-    << "[score] numeric";
+    << "[score] float";
+  QTest::newRow( "auto_numeric_with_precision" )
+    << QgsField( "score", QMetaType::Type::Double, QString(), 20, 8 )
+    << "[score] numeric(20,8)";
   QTest::newRow( "auto_date" )
     << QgsField( "dob", QMetaType::Type::QDate )
     << "[dob] date";
@@ -650,6 +653,10 @@ void TestQgsMssqlProvider::testColumnDefinitionForField_data()
   QTest::newRow( "fmt_decimal_no_len" )
     << QgsField( "val2", QMetaType::Type::Double, "decimal", 0, 5 )
     << "[val2] decimal";
+
+  QTest::newRow( "decimal_with_scale" )
+    << QgsField( "rate", QMetaType::Type::Double, "decimal", 18, 6 )
+    << "[rate] decimal(18,6)";
 
   // unhandled variant type
   QTest::newRow( "unhandled_variant" )

--- a/tests/src/providers/testqgsmssqlprovider.cpp
+++ b/tests/src/providers/testqgsmssqlprovider.cpp
@@ -590,91 +590,154 @@ void TestQgsMssqlProvider::testEmptyLayer()
 void TestQgsMssqlProvider::testColumnDefinitionForField_data()
 {
   QTest::addColumn<QgsField>( "field" );
+  QTest::addColumn<bool>( "ignoreTypeString" );
   QTest::addColumn<QString>( "definition" );
 
   // using automatic type mapping (i.e. no explicit SQL server column type)
   QTest::newRow( "auto_bigint" )
     << QgsField( "id", QMetaType::Type::LongLong )
+    << false
     << "[id] bigint";
   QTest::newRow( "auto_int" )
     << QgsField( "age", QMetaType::Type::Int )
+    << false
     << "[age] int";
   QTest::newRow( "auto_numeric" )
     << QgsField( "score", QMetaType::Type::Double )
+    << false
     << "[score] float";
   QTest::newRow( "auto_numeric_with_precision" )
     << QgsField( "score", QMetaType::Type::Double, QString(), 20, 8 )
+    << false
     << "[score] numeric(20,8)";
   QTest::newRow( "auto_date" )
     << QgsField( "dob", QMetaType::Type::QDate )
+    << false
     << "[dob] date";
   QTest::newRow( "auto_time" )
     << QgsField( "alarm", QMetaType::Type::QTime )
+    << false
     << "[alarm] time";
   QTest::newRow( "auto_datetime" )
     << QgsField( "created_at", QMetaType::Type::QDateTime )
+    << false
     << "[created_at] datetime";
   QTest::newRow( "auto_string_with_length" )
     << QgsField( "name", QMetaType::Type::QString, QString(), 50 )
+    << false
     << "[name] nvarchar(50)";
   QTest::newRow( "auto_string_unlimited" )
     << QgsField( "notes", QMetaType::Type::QString, QString(), 0 )
+    << false
     << "[notes] nvarchar(max)";
 
   // with explicit SQL Server column type names
   QTest::newRow( "explicit_int" )
     << QgsField( "count", QMetaType::Type::Int, "int" )
+    << false
     << "[count] int";
-  QTest::newRow( "explicit_geometry" )
-    << QgsField( "geom", QMetaType::Type::UnknownType, "geometry" )
-    << "[geom] geometry";
   QTest::newRow( "fmt_varchar_len" )
     << QgsField( "code", QMetaType::Type::QString, "varchar", 10 )
+    << false
     << "[code] varchar(10)";
   QTest::newRow( "fmt_nvarchar_len" )
     << QgsField( "label", QMetaType::Type::QString, "nvarchar", 255 )
+    << false
     << "[label] nvarchar(255)";
   QTest::newRow( "fmt_char_len" )
     << QgsField( "flag", QMetaType::Type::QString, "char", 1 )
+    << false
     << "[flag] char(1)";
   QTest::newRow( "fmt_varchar_no_len" )
     << QgsField( "raw", QMetaType::Type::QString, "varchar", 0 )
+    << false
     << "[raw] varchar";
 
   QTest::newRow( "fmt_numeric_full" )
     << QgsField( "cost", QMetaType::Type::Double, "numeric", 10, 2 )
+    << false
     << "[cost] numeric(10,2)";
   QTest::newRow( "fmt_decimal_full" )
     << QgsField( "ratio", QMetaType::Type::Double, "decimal", 18, 6 )
+    << false
     << "[ratio] decimal(18,6)";
   QTest::newRow( "fmt_numeric_no_prec" )
     << QgsField( "val", QMetaType::Type::Double, "numeric", 10, 0 )
+    << false
     << "[val] numeric";
   QTest::newRow( "fmt_decimal_no_len" )
     << QgsField( "val2", QMetaType::Type::Double, "decimal", 0, 5 )
+    << false
     << "[val2] decimal";
 
   QTest::newRow( "decimal_with_scale" )
     << QgsField( "rate", QMetaType::Type::Double, "decimal", 18, 6 )
+    << false
     << "[rate] decimal(18,6)";
+
+
+  // with explicit SQL Server column type names, but ignoreTypeString set
+  QTest::newRow( "explicit_int_ignore_type_string" )
+    << QgsField( "count", QMetaType::Type::Int, "int" )
+    << true
+    << "[count] int";
+  QTest::newRow( "fmt_varchar_len_ignore_type_string" )
+    << QgsField( "code", QMetaType::Type::QString, "varchar", 10 )
+    << true
+    << "[code] nvarchar(10)";
+  QTest::newRow( "fmt_nvarchar_len_ignore_type_string" )
+    << QgsField( "label", QMetaType::Type::QString, "nvarchar", 255 )
+    << true
+    << "[label] nvarchar(255)";
+  QTest::newRow( "fmt_char_len_ignore_type_string" )
+    << QgsField( "flag", QMetaType::Type::QString, "char", 1 )
+    << true
+    << "[flag] nvarchar(1)";
+  QTest::newRow( "fmt_varchar_no_len_ignore_type_string" )
+    << QgsField( "raw", QMetaType::Type::QString, "varchar", 0 )
+    << true
+    << "[raw] nvarchar(max)";
+  QTest::newRow( "fmt_numeric_full_ignore_type_string" )
+    << QgsField( "cost", QMetaType::Type::Double, "numeric", 10, 2 )
+    << true
+    << "[cost] numeric(10,2)";
+  QTest::newRow( "fmt_decimal_full_ignore_type_string" )
+    << QgsField( "ratio", QMetaType::Type::Double, "decimal", 18, 6 )
+    << true
+    << "[ratio] numeric(18,6)";
+  QTest::newRow( "fmt_numeric_no_prec_ignore_type_string" )
+    << QgsField( "val", QMetaType::Type::Double, "numeric", 10, 0 )
+    << true
+    << "[val] float";
+  QTest::newRow( "fmt_decimal_no_len_ignore_type_string" )
+    << QgsField( "val2", QMetaType::Type::Double, "decimal", 0, 5 )
+    << true
+    << "[val2] float";
+  QTest::newRow( "decimal_with_scale_ignore_type_string" )
+    << QgsField( "rate", QMetaType::Type::Double, "decimal", 18, 6 )
+    << true
+    << "[rate] numeric(18,6)";
 
   // unhandled variant type
   QTest::newRow( "unhandled_variant" )
     << QgsField( "bad_col", QMetaType::Type::QVariantMap )
+    << false
     << QString();
 
   // field name escaping
   QTest::newRow( "name_escaping" )
     << QgsField( "complex[field name]", QMetaType::Type::QString )
+    << false
     << "[complex[field name]]] nvarchar(max)";
 }
 
 void TestQgsMssqlProvider::testColumnDefinitionForField()
 {
   QFETCH( QgsField, field );
+  QFETCH( bool, ignoreTypeString );
   QFETCH( QString, definition );
 
-  QCOMPARE( QgsMssqlUtils::columnDefinitionForField( field ), definition );
+  QCOMPARE( QgsMssqlUtils::columnDefinitionForField( field, ignoreTypeString ), definition );
 }
 
 QGSTEST_MAIN( TestQgsMssqlProvider )

--- a/tests/src/providers/testqgsmssqlprovider.cpp
+++ b/tests/src/providers/testqgsmssqlprovider.cpp
@@ -555,6 +555,14 @@ void TestQgsMssqlProvider::testEmptyLayer()
   QCOMPARE( oldToNewAttrIdxMap.value( 1 ), 0 );
   QCOMPARE( oldToNewAttrIdxMap.value( 2 ), 2 );
 
+  // confirm that geometry field is LAST in table definition
+  QList<QList<QVariant> > columnNames = conn->execSql( u"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'empty_layer' AND TABLE_SCHEMA = 'qgis_test' ORDER BY ORDINAL_POSITION;"_s ).rows();
+  QCOMPARE( columnNames.size(), 4 );
+  QCOMPARE( columnNames.at( 0 ).at( 0 ), u"my_pk"_s );
+  QCOMPARE( columnNames.at( 1 ).at( 0 ), u"some_string"_s );
+  QCOMPARE( columnNames.at( 2 ).at( 0 ), u"some_real"_s );
+  QCOMPARE( columnNames.at( 3 ).at( 0 ), u"geom"_s );
+
   // creating a brand new primary key
   uri.setKeyColumn( u"my_new_pk"_s );
 
@@ -585,6 +593,14 @@ void TestQgsMssqlProvider::testEmptyLayer()
   QCOMPARE( oldToNewAttrIdxMap.value( 0 ), 1 );
   QCOMPARE( oldToNewAttrIdxMap.value( 1 ), 2 );
   QCOMPARE( oldToNewAttrIdxMap.value( 2 ), 3 );
+
+  columnNames = conn->execSql( u"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'empty_layer' AND TABLE_SCHEMA = 'qgis_test' ORDER BY ORDINAL_POSITION;"_s ).rows();
+  QCOMPARE( columnNames.size(), 5 );
+  QCOMPARE( columnNames.at( 0 ).at( 0 ), u"my_new_pk"_s );
+  QCOMPARE( columnNames.at( 1 ).at( 0 ), u"some_string"_s );
+  QCOMPARE( columnNames.at( 2 ).at( 0 ), u"my_pk"_s );
+  QCOMPARE( columnNames.at( 3 ).at( 0 ), u"some_real"_s );
+  QCOMPARE( columnNames.at( 4 ).at( 0 ), u"geom"_s );
 }
 
 void TestQgsMssqlProvider::testColumnDefinitionForField_data()


### PR DESCRIPTION
Instead of always inserting the geometry column in the MIDDLE of the table's fields, ensure it is always the last column to match the behavior of other data providers.

Also makes creation of new tables more efficient, by avoiding multiple queries to create an empty table and then add fields and using a single query instead.

Sponsored by City of Canning