### PR TITLE
fix wrong feature count returned by Query Builder for Spatialite layer

### DIFF
--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -614,8 +614,13 @@ QgsSpatiaLiteProvider::QgsSpatiaLiteProvider( QString const &uri, const Provider
   setNativeTypes( QgsSpatiaLiteConnection::nativeTypes() );
 
   // Update extent and feature count
-  if ( !mSubsetString.isEmpty() )
-    getTableSummary();
+  if ( !mSubsetString.isEmpty() && !getTableSummary() )
+  {
+    mNumberFeatures = 0;
+    QgsDebugError( u"Invalid SpatiaLite layer"_s );
+    closeDb();
+    return;
+  }
 
   mValid = true;
 }

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -545,7 +545,7 @@ QgsSpatiaLiteProvider::QgsSpatiaLiteProvider( QString const &uri, const Provider
     }
 
     // if DB has Z geometry we do NOT use the v.4.0 AbstractInterface as it does not retrieve Z extent data
-    if ( lyr->GeometryType == GAIA_XY_Z || lyr->GeometryType == GAIA_XY_Z_M )
+    if ( lyr->Dimensions == GAIA_XY_Z || lyr->Dimensions == GAIA_XY_Z_M )
     {
       if ( !getTableSummary() ) // gets the extent and feature count
       {

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -437,6 +437,7 @@ void QgsSpatiaLiteSourceSelect::setSql( const QModelIndex &index )
 
   if ( !vlayer->isValid() )
   {
+    QMessageBox::critical( this, tr( "SpatiaLite Error" ), tr( "Error when creating a layer. Check message log for more details." ) );
     delete vlayer;
     return;
   }

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -157,7 +157,7 @@ void QgsSpatiaLiteSourceSelect::populateConnectionList()
   for ( const QString &name : list )
   {
     // retrieving the SQLite DB name and full path
-    const QString text = name + tr( "@" ) + QgsSpatiaLiteConnection::connectionPath( name );
+    const QString text = name + '@' + QgsSpatiaLiteConnection::connectionPath( name );
     cmbConnections->addItem( text );
   }
   setConnectionListPosition();
@@ -481,15 +481,13 @@ void QgsSpatiaLiteSourceSelect::setConnectionListPosition()
 {
   const QgsSettings settings;
   // If possible, set the item currently displayed database
-  QString toSelect = settings.value( u"SpatiaLite/connections/selected"_s ).toString();
+  QString name = settings.value( u"SpatiaLite/connections/selected"_s ).toString();
 
-  toSelect += '@' + settings.value( "/SpatiaLite/connections/" + toSelect + "/sqlitepath" ).toString();
-
-  cmbConnections->setCurrentIndex( cmbConnections->findText( toSelect ) );
+  cmbConnections->setCurrentIndex( cmbConnections->findText( name ) );
 
   if ( cmbConnections->currentIndex() < 0 )
   {
-    if ( toSelect.isNull() )
+    if ( name.isEmpty() )
       cmbConnections->setCurrentIndex( 0 );
     else
       cmbConnections->setCurrentIndex( cmbConnections->count() - 1 );

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -481,7 +481,7 @@ void QgsSpatiaLiteSourceSelect::setConnectionListPosition()
 {
   const QgsSettings settings;
   // If possible, set the item currently displayed database
-  QString name = settings.value( u"SpatiaLite/connections/selected"_s ).toString();
+  const QString name = settings.value( u"SpatiaLite/connections/selected"_s ).toString();
 
   cmbConnections->setCurrentIndex( cmbConnections->findText( name ) );
 

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -2470,6 +2470,20 @@ class TestQgsSpatialiteProvider(QgisTestCase, ProviderTestCase):
             self.assertIn("name2", field_names)
             self.assertNotIn("name1", field_names)
 
+    def test_invalid_subset_string(self):
+        """Check that constructing a vector layer with the incorrect subset
+        string will result in an invalid layer.
+        Related to GH #64282.
+        """
+        testPath = f"dbname={self.dbname} table='test_filter' (geometry) key='id'"
+        table_name = "test_filter"
+        subset_string = f"SELECT * FROM {table_name} WHERE name REGEXP '^i';"
+        # unvalid subset string should result in an invalid layer
+        uri = QgsDataSourceUri(f"dbname={self.dbname}")
+        uri.setDataSource("", table_name, "geometry", subset_string, "")
+        layer = QgsVectorLayer(uri.uri(), "subset layer", "spatialite")
+        self.assertFalse(layer.isValid())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

When user manually adds an incorrect subset string to the  "SQL" column in the SpatiaLite connection dialog and then opens Query Builder and clicks on the "Test" button QGIS wrongly reports that all layer features match filter. This happens because:

1.  `getTableSummaryAbstractInterface()` does not take into account subset string when retrieving feature count
2.  we ignore return value from `getTableSummary()` when this method is called at the end of the provider initialization to update layer extent and feature count.

Proposed fix checks the return value of the last call to `getTableSummary()` and if it fails flags the layer data source as invalid SpatiaLite layer.  To improve UX, SpatiaLite connection dialog now shows a message box when user tries to open a Query Builder for invalid layer (e.g. layer with incorrect subset string entered manually in the SQL column).

I also fixed a few other issues found along the way:
 -  fix detection of Z/M coordinates when using the v.4.0 AbstractInterface code path. Previously this check was using `GeometryType` property which does not report presence or absence of the Z/M coordinates (as per [metatables.c](https://www.gaia-gis.it/fossil/libspatialite/file?name=src/spatialite/metatables.c)). Instead it should check the `Dimensions` property.
 - correctly restore last used connection and show it in the connections list

Fixes #64282.
