### PR TITLE
[pg][raster] Fix stats calculation when extent is specified

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsrasterlayerutils.py
+++ b/python/PyQt6/core/auto_additions/qgsrasterlayerutils.py
@@ -2,6 +2,7 @@
 try:
     QgsRasterLayerUtils.renderedBandForElevationAndTemporalRange = staticmethod(QgsRasterLayerUtils.renderedBandForElevationAndTemporalRange)
     QgsRasterLayerUtils.computeMinMax = staticmethod(QgsRasterLayerUtils.computeMinMax)
+    QgsRasterLayerUtils.alignRasterExtent = staticmethod(QgsRasterLayerUtils.alignRasterExtent)
     QgsRasterLayerUtils.__group__ = ['raster']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterlayerutils.sip.in
@@ -59,6 +59,18 @@ according to MinMaxOrigin parameters ``mmo`` and ``extent``.
 .. versionadded:: 4.0
 %End
 
+    static QgsRectangle alignRasterExtent( const QgsRectangle &extent, const QgsPointXY &origin, double pixelSizeX, double pixelSizeY );
+%Docstring
+Returns a new extent that includes the given ``extent`` with corners
+coordinates aligned to the pixel grid defined by the ``origin`` and
+``pixelSizeX`` and ``pixelSizeY`` arguments.
+
+The resulting extent will be expanded if necessary to ensure that its
+corners fall on pixel boundaries defined by the origin and pixel sizes.
+
+.. versionadded:: 4.0
+%End
+
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterlayerutils.sip.in
@@ -68,6 +68,9 @@ coordinates aligned to the pixel grid defined by the ``origin`` and
 The resulting extent will be expanded if necessary to ensure that its
 corners fall on pixel boundaries defined by the origin and pixel sizes.
 
+:return: The aligned extent or the original extent if pixel sizes are
+         zero (to avoid division by zero) or if the extent is empty.
+
 .. versionadded:: 4.0
 %End
 

--- a/src/core/raster/qgsrasterlayerutils.cpp
+++ b/src/core/raster/qgsrasterlayerutils.cpp
@@ -283,3 +283,14 @@ void QgsRasterLayerUtils::computeMinMax( QgsRasterDataProvider *provider,
   }
   QgsDebugMsgLevel( u"band = %1 min = %2 max = %3"_s.arg( band ).arg( min ).arg( max ), 4 );
 }
+
+QgsRectangle QgsRasterLayerUtils::alignRasterExtent( const QgsRectangle &extent, const QgsPointXY &origin, double pixelSizeX, double pixelSizeY )
+{
+  // This may be negative to indicate inverted NS axis: make sure to use absolute value for calculations
+  const double absPixelSizeY { std::abs( pixelSizeY ) };
+  const double minX { origin.x() + std::floor( ( extent.xMinimum() - origin.x() ) / pixelSizeX ) *pixelSizeX };
+  const double minY { origin.y() + std::floor( ( extent.yMinimum() - origin.y() ) / absPixelSizeY ) *absPixelSizeY };
+  const double maxX { origin.x() + std::ceil( ( extent.xMaximum() - origin.x() ) / pixelSizeX ) *pixelSizeX };
+  const double maxY { origin.y() + std::ceil( ( extent.yMaximum() - origin.y() ) / absPixelSizeY ) *absPixelSizeY };
+  return QgsRectangle( minX, minY, maxX, maxY );
+}

--- a/src/core/raster/qgsrasterlayerutils.cpp
+++ b/src/core/raster/qgsrasterlayerutils.cpp
@@ -287,7 +287,7 @@ void QgsRasterLayerUtils::computeMinMax( QgsRasterDataProvider *provider,
 QgsRectangle QgsRasterLayerUtils::alignRasterExtent( const QgsRectangle &extent, const QgsPointXY &origin, double pixelSizeX, double pixelSizeY )
 {
   // Return original extent if pixel sizes are zero (to avoid division by zero) or if the extent is empty
-  if ( pixelSizeX == 0.0 || pixelSizeY == 0.0 || extent.isEmpty() )
+  if ( qgsDoubleNear( pixelSizeX, 0.0 ) || qgsDoubleNear( pixelSizeY, 0.0 ) || extent.isEmpty() )
   {
     return extent;
   }

--- a/src/core/raster/qgsrasterlayerutils.cpp
+++ b/src/core/raster/qgsrasterlayerutils.cpp
@@ -286,7 +286,12 @@ void QgsRasterLayerUtils::computeMinMax( QgsRasterDataProvider *provider,
 
 QgsRectangle QgsRasterLayerUtils::alignRasterExtent( const QgsRectangle &extent, const QgsPointXY &origin, double pixelSizeX, double pixelSizeY )
 {
-  // This may be negative to indicate inverted NS axis: make sure to use absolute value for calculations
+  // Return original extent if pixel sizes are zero (to avoid division by zero) or if the extent is empty
+  if ( pixelSizeX == 0.0 || pixelSizeY == 0.0 || extent.isEmpty() )
+  {
+    return extent;
+  }
+  // Y pixel size may be negative to indicate inverted NS axis: use absolute value for calculations
   const double absPixelSizeY { std::abs( pixelSizeY ) };
   const double minX { origin.x() + std::floor( ( extent.xMinimum() - origin.x() ) / pixelSizeX ) *pixelSizeX };
   const double minY { origin.y() + std::floor( ( extent.yMinimum() - origin.y() ) / absPixelSizeY ) *absPixelSizeY };

--- a/src/core/raster/qgsrasterlayerutils.h
+++ b/src/core/raster/qgsrasterlayerutils.h
@@ -20,6 +20,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgspointxy.h"
 #include "qgsrange.h"
 
 class QgsRasterLayer;
@@ -70,6 +71,16 @@ class CORE_EXPORT QgsRasterLayerUtils
                                int sampleSize,
                                double &min SIP_OUT,
                                double &max SIP_OUT );
+
+    /**
+     * Returns a new extent that includes the given \a extent with corners coordinates
+     * aligned to the pixel grid defined by the \a origin and \a pixelSizeX and \a pixelSizeY arguments.
+     *
+     * The resulting extent will be expanded if necessary to ensure that its corners fall on pixel boundaries defined by the origin and pixel sizes.
+     *
+     * \since QGIS 4.0
+     */
+    static QgsRectangle alignRasterExtent( const QgsRectangle &extent, const QgsPointXY &origin, double pixelSizeX, double pixelSizeY );
 
 };
 

--- a/src/core/raster/qgsrasterlayerutils.h
+++ b/src/core/raster/qgsrasterlayerutils.h
@@ -78,6 +78,8 @@ class CORE_EXPORT QgsRasterLayerUtils
      *
      * The resulting extent will be expanded if necessary to ensure that its corners fall on pixel boundaries defined by the origin and pixel sizes.
      *
+     * \returns The aligned extent or the original extent if pixel sizes are zero (to avoid division by zero) or if the extent is empty.
+     *
      * \since QGIS 4.0
      */
     static QgsRectangle alignRasterExtent( const QgsRectangle &extent, const QgsPointXY &origin, double pixelSizeX, double pixelSizeY );

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -2335,7 +2335,7 @@ QgsRasterBandStats QgsPostgresRasterProvider::bandStatistics( int bandNo, Qgis::
     queryHeight = std::ceil( extent.height() / std::abs( mScaleY ) );
   }
 
-  const double pixelsRatio { static_cast<double>( sampleSize ) / ( queryWidth * queryHeight ) };
+  const double pixelsRatio { sampleSize / static_cast<double>( queryWidth * queryHeight ) };
   double statsRatio { pixelsRatio };
 
   // Decide if overviews can be used here

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -25,6 +25,7 @@
 #include "qgspostgresprovidermetadatautils.h"
 #include "qgspostgresutils.h"
 #include "qgsraster.h"
+#include "qgsrasterlayerutils.h"
 #include "qgsrectangle.h"
 #include "qgsstringutils.h"
 
@@ -2361,10 +2362,7 @@ QgsRasterBandStats QgsPostgresRasterProvider::bandStatistics( int bandNo, Qgis::
   QgsRectangle extentExpanded { extent };
   if ( !extent.isNull() )
   {
-    extentExpanded.setXMinimum( mExtent.xMinimum() + std::floor( ( extentExpanded.xMinimum() - mExtent.xMinimum() ) / mScaleX ) * mScaleX );
-    extentExpanded.setXMaximum( mExtent.xMinimum() + std::ceil( ( extentExpanded.xMaximum() - mExtent.xMinimum() ) / mScaleX ) * mScaleX );
-    extentExpanded.setYMinimum( mExtent.yMinimum() + std::floor( ( extentExpanded.yMinimum() - mExtent.yMinimum() ) / std::abs( mScaleY ) ) * std::abs( mScaleY ) );
-    extentExpanded.setYMaximum( mExtent.yMinimum() + std::ceil( ( extentExpanded.yMaximum() - mExtent.yMinimum() ) / std::abs( mScaleY ) ) * std::abs( mScaleY ) );
+    extentExpanded = QgsRasterLayerUtils::alignRasterExtent( extent, QgsPointXY( mExtent.xMinimum(), mExtent.yMinimum() ), mScaleX, mScaleY );
   }
 
   // Query the backend

--- a/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
+++ b/src/providers/postgres/raster/qgspostgresrasterprovider.cpp
@@ -2359,11 +2359,7 @@ QgsRasterBandStats QgsPostgresRasterProvider::bandStatistics( int bandNo, Qgis::
   }
 
   // Make sure the extent is aligned to the grid created by the raster, otherwise we might end up with wrong statistics for small rasters or small areas
-  QgsRectangle extentExpanded { extent };
-  if ( !extent.isNull() )
-  {
-    extentExpanded = QgsRasterLayerUtils::alignRasterExtent( extent, QgsPointXY( mExtent.xMinimum(), mExtent.yMinimum() ), mScaleX, mScaleY );
-  }
+  const QgsRectangle extentExpanded { QgsRasterLayerUtils::alignRasterExtent( extent, QgsPointXY( mExtent.xMinimum(), mExtent.yMinimum() ), mScaleX, mScaleY ) };
 
   // Query the backend
   const QString extentSql { extentExpanded.isNull() ? QString() : u"ST_GeomFromText( %1, %2 )"_s.arg( quotedValue( extentExpanded.asWktPolygon() ) ).arg( mCrs.postgisSrid() ) };
@@ -2393,8 +2389,6 @@ QgsRasterBandStats QgsPostgresRasterProvider::bandStatistics( int bandNo, Qgis::
             .arg( std::max<double>( 0, std::min<double>( 1, statsRatio ) ) )
             .arg( tableToQuery, where );
   }
-
-  qDebug() << "Stat sql is: " << sql;
 
   QgsPostgresResult result( connectionRO()->PQexec( sql ) );
 

--- a/tests/src/python/test_provider_postgresraster.py
+++ b/tests/src/python/test_provider_postgresraster.py
@@ -1222,6 +1222,23 @@ class TestPyQgsPostgresRasterProvider(QgisTestCase):
         self.assertNotEqual(stats.maximumValue, small_stats.maximumValue)
         self.assertEqual(int(small_stats.minimumValue), 184)
 
+        # Sample at the center: 2430681.52N, 4080113.42E
+        center_extent = QgsRectangle(4080113, 2430681, 4080113 + 1, 2430681 + 1)
+        center_stats = self.source.bandStatistics(
+            1, Qgis.RasterBandStatistic.All, center_extent
+        )
+        self.assertEqual(int(center_stats.minimumValue), 184)
+
+        # Test extent with known values
+        extent = QgsRectangle.fromWkt(
+            "Polygon ((4080086.82537919469177723 2430669.50382143305614591, 4080117.48640771303325891 2430669.50382143305614591, 4080117.48640771303325891 2430687.6613536006771028, 4080086.82537919469177723 2430687.6613536006771028, 4080086.82537919469177723 2430669.50382143305614591))"
+        )
+        expected_min = 168.894287109375
+        expected_max = 200.4803466796875
+        stats = self.source.bandStatistics(1, Qgis.RasterBandStatistic.All, extent)
+        self.assertAlmostEqual(stats.minimumValue, expected_min, 6)
+        self.assertAlmostEqual(stats.maximumValue, expected_max, 6)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_provider_postgresraster.py
+++ b/tests/src/python/test_provider_postgresraster.py
@@ -1205,6 +1205,23 @@ class TestPyQgsPostgresRasterProvider(QgisTestCase):
         self.assertEqual(desclist, ["default test style"])
         self.assertFalse(errmsg)
 
+    def test_ExtentStatistics(self):
+        """Test extent statistics issue GH #64917"""
+
+        stats = self.source.bandStatistics(1)
+        min_val = stats.minimumValue
+        max_val = stats.maximumValue
+        self.assertEqual(int(min_val), 136)
+
+        extent = self.source.extent()
+        extent.grow(-60)
+        small_stats = self.source.bandStatistics(
+            1, Qgis.RasterBandStatistic.All, extent
+        )
+        self.assertNotEqual(stats.minimumValue, small_stats.minimumValue)
+        self.assertNotEqual(stats.maximumValue, small_stats.maximumValue)
+        self.assertEqual(int(small_stats.minimumValue), 184)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgsrasterlayerutils.py
+++ b/tests/src/python/test_qgsrasterlayerutils.py
@@ -13,8 +13,10 @@ from qgis.core import (
     Qgis,
     QgsDateTimeRange,
     QgsDoubleRange,
+    QgsPointXY,
     QgsRasterLayer,
     QgsRasterLayerUtils,
+    QgsRectangle,
 )
 from qgis.PyQt.QtCore import QDate, QDateTime, QTime
 from qgis.testing import QgisTestCase, start_app
@@ -335,6 +337,49 @@ class TestQgsRasterLayerUtils(QgisTestCase):
         )
         self.assertEqual(band, -1)
         self.assertFalse(matched)
+
+    def test_alignRasterExtent(self):
+
+        # nominal case
+        grid_origin = QgsPointXY(100, 200)
+        xres = 10
+        yres = 20
+        extent = QgsRectangle(209, 419, 301, 601)
+        aligned = QgsRasterLayerUtils.alignRasterExtent(extent, grid_origin, xres, yres)
+        self.assertEqual(aligned, QgsRectangle(200, 400, 310, 620))
+
+        # test with extent already aligned
+        extent = QgsRectangle(200, 400, 310, 620)
+        aligned = QgsRasterLayerUtils.alignRasterExtent(extent, grid_origin, xres, yres)
+        self.assertEqual(aligned, extent)
+
+        # test with negative coordinates
+        grid_origin = QgsPointXY(-100, -200)
+        extent = QgsRectangle(-91, -179, -81, -161)
+        aligned = QgsRasterLayerUtils.alignRasterExtent(extent, grid_origin, xres, yres)
+        self.assertEqual(aligned, QgsRectangle(-100, -180, -80, -160))
+
+        # test with out of bounds extent
+        grid_origin = QgsPointXY(0, 0)
+        extent = QgsRectangle(-15, -25, 15, 25)
+        aligned = QgsRasterLayerUtils.alignRasterExtent(extent, grid_origin, xres, yres)
+        self.assertEqual(aligned, QgsRectangle(-20, -40, 20, 40))
+
+        # test with zero resolution (should return original extent)
+        grid_origin = QgsPointXY(0, 0)
+        xres = 0
+        yres = 0
+        extent = QgsRectangle(10, 20, 30, 40)
+        aligned = QgsRasterLayerUtils.alignRasterExtent(extent, grid_origin, xres, yres)
+        self.assertEqual(aligned, extent)
+
+        # test with empty extent
+        grid_origin = QgsPointXY(0, 0)
+        xres = 10
+        yres = 10
+        extent = QgsRectangle()
+        aligned = QgsRasterLayerUtils.alignRasterExtent(extent, grid_origin, xres, yres)
+        self.assertEqual(aligned, QgsRectangle())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #64917

An issue still remains:: there are small differences in the stats between GDAL and PG raster, I will do some more research but I suspect that the values reported by PG raster are correct and GDAL results (or more precisely: QGIS results got through GDAL) are not.
