### PR TITLE
enable or disable series buttons depending on the availability of the layer and series (fix #63470)

### DIFF
--- a/src/gui/layout/qgslayoutchartwidget.cpp
+++ b/src/gui/layout/qgslayoutchartwidget.cpp
@@ -68,6 +68,7 @@ QgsLayoutChartWidget::QgsLayoutChartWidget( QgsLayoutItemChart *chartItem )
   connect( mIntersectAtlasCheckBox, &QCheckBox::stateChanged, this, &QgsLayoutChartWidget::mIntersectAtlasCheckBox_stateChanged );
 
   setGuiElementValues();
+  updateButtonsState();
 
   connect( mChartItem, &QgsLayoutObject::changed, this, &QgsLayoutChartWidget::setGuiElementValues );
 }
@@ -237,6 +238,7 @@ void QgsLayoutChartWidget::changeLayer( QgsMapLayer *layer )
   mChartItem->setSourceLayer( vl );
   mChartItem->update();
   mChartItem->endCommand();
+  updateButtonsState();
 }
 
 void QgsLayoutChartWidget::changeSortExpression( const QString &expression, bool )
@@ -343,6 +345,7 @@ void QgsLayoutChartWidget::mAddSeriesPushButton_clicked()
 
   mSeriesListWidget->setCurrentRow( mSeriesListWidget->count() - 1 );
   mSeriesListWidget_currentItemChanged( mSeriesListWidget->currentItem(), nullptr );
+  updateButtonsState();
 }
 
 void QgsLayoutChartWidget::mRemoveSeriesPushButton_clicked()
@@ -368,6 +371,7 @@ void QgsLayoutChartWidget::mRemoveSeriesPushButton_clicked()
   mChartItem->setSeriesList( seriesList );
   mChartItem->endCommand();
   mChartItem->update();
+  updateButtonsState();
 }
 
 void QgsLayoutChartWidget::mSeriesPropertiesButton_clicked()
@@ -456,4 +460,17 @@ void QgsLayoutChartWidget::mIntersectAtlasCheckBox_stateChanged( int state )
   mChartItem->setFilterToAtlasFeature( filterToAtlas );
   mChartItem->endCommand();
   mChartItem->update();
+}
+
+void QgsLayoutChartWidget::updateButtonsState()
+{
+  if ( !mChartItem )
+  {
+    return;
+  }
+
+  const bool enable = qobject_cast<QgsVectorLayer *>( mLayerComboBox->currentLayer() ) != nullptr;
+  mSortCheckBox->setEnabled( enable );
+  mAddSeriesPushButton->setEnabled( enable );
+  mRemoveSeriesPushButton->setEnabled( mSeriesListWidget->count() > 0 );
 }

--- a/src/gui/layout/qgslayoutchartwidget.h
+++ b/src/gui/layout/qgslayoutchartwidget.h
@@ -71,6 +71,9 @@ class GUI_EXPORT QgsLayoutChartWidget : public QgsLayoutItemBaseWidget, private 
     //! Sets the GUI elements to the values of mChartItem
     void setGuiElementValues();
 
+    //! Updates buttons state when selecting a layer or adding/removing series
+    void updateButtonsState();
+
     //! Adds a new item to the series list widget
     QListWidgetItem *addSeriesListItem( const QString &name );
 


### PR DESCRIPTION
## Description

When adding a layout chart item the add/remove series buttons and "sort by" checkbox are enabled even if a chart data source is not set.

They should be enabled only when data source is set or if there are some series defined (for remove series button).

Fixes #63470.