### PR TITLE
use expression context from the algorithm context in the Geometry by Expression algorithm (fix #54869)

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/geometry_by_expression_layerref.gml
+++ b/python/plugins/processing/tests/testdata/expected/geometry_by_expression_layerref.gml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ geometry_by_expression_layerref.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1.38955823293173 1.56224899598394</gml:lowerCorner><gml:upperCorner>3.11044176706827 7.06224899598394</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                 
+  <ogr:featureMember>
+    <ogr:geometry_by_expression_layerref gml:id="geometry_by_expression_layerref.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-0.389558232931727 1.56224899598394</gml:lowerCorner><gml:upperCorner>1.61044176706827 3.56224899598394</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="geometry_by_expression_layerref.geom.0"><gml:exterior><gml:LinearRing><gml:posList>-0.389558232931727 1.56224899598394 1.61044176706827 1.56224899598394 1.61044176706827 3.56224899598394 1.11044176706827 3.56224899598394 1.11044176706827 3.06224899598394 -0.389558232931727 3.06224899598394 -0.389558232931727 1.56224899598394</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>polys.0</ogr:fid>
+      <ogr:name>aaaaa</ogr:name>
+      <ogr:intval>33</ogr:intval>
+      <ogr:floatval>44.123456</ogr:floatval>
+    </ogr:geometry_by_expression_layerref>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:geometry_by_expression_layerref gml:id="geometry_by_expression_layerref.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>2.11044176706827 4.06224899598394</gml:lowerCorner><gml:upperCorner>2.61044176706827 5.06224899598394</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="geometry_by_expression_layerref.geom.1"><gml:exterior><gml:LinearRing><gml:posList>2.61044176706827 4.56224899598394 2.11044176706827 5.06224899598394 2.11044176706827 4.06224899598394 2.61044176706827 4.56224899598394</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>polys.1</ogr:fid>
+      <ogr:name>Aaaaa</ogr:name>
+      <ogr:intval>-33</ogr:intval>
+      <ogr:floatval>0</ogr:floatval>
+    </ogr:geometry_by_expression_layerref>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:geometry_by_expression_layerref gml:id="geometry_by_expression_layerref.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>2.61044176706827 3.06224899598394</gml:lowerCorner><gml:upperCorner>3.11044176706827 3.56224899598394</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="geometry_by_expression_layerref.geom.2"><gml:exterior><gml:LinearRing><gml:posList>2.61044176706827 3.06224899598394 3.11044176706827 3.06224899598394 3.11044176706827 3.56224899598394 2.61044176706827 3.56224899598394 2.61044176706827 3.06224899598394</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>polys.2</ogr:fid>
+      <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval>0.123</ogr:floatval>
+    </ogr:geometry_by_expression_layerref>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:geometry_by_expression_layerref gml:id="geometry_by_expression_layerref.3">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1.38955823293173 5.06224899598394</gml:lowerCorner><gml:upperCorner>0.610441767068273 7.06224899598394</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="geometry_by_expression_layerref.geom.3"><gml:exterior><gml:LinearRing><gml:posList>0.610441767068273 5.06224899598394 0.610441767068273 7.06224899598394 -1.38955823293173 7.06224899598394 -1.38955823293173 5.06224899598394 0.610441767068273 5.06224899598394</gml:posList></gml:LinearRing></gml:exterior><gml:interior><gml:LinearRing><gml:posList>0.110441767068273 5.56224899598394 -0.889558232931727 5.56224899598394 -0.889558232931727 6.56224899598394 0.110441767068273 6.56224899598394 0.110441767068273 5.56224899598394</gml:posList></gml:LinearRing></gml:interior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>polys.3</ogr:fid>
+      <ogr:name>ASDF</ogr:name>
+      <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
+    </ogr:geometry_by_expression_layerref>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:geometry_by_expression_layerref gml:id="geometry_by_expression_layerref.4">
+      <ogr:fid>polys.4</ogr:fid>
+      <ogr:name xsi:nil="true"/>
+      <ogr:intval>120</ogr:intval>
+      <ogr:floatval>-100291.43213</ogr:floatval>
+    </ogr:geometry_by_expression_layerref>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:geometry_by_expression_layerref gml:id="geometry_by_expression_layerref.5">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1.38955823293173 3.06224899598394</gml:lowerCorner><gml:upperCorner>1.11044176706827 5.06224899598394</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="geometry_by_expression_layerref.geom.5"><gml:exterior><gml:LinearRing><gml:posList>1.11044176706827 3.56224899598394 0.610441767068273 5.06224899598394 -1.38955823293173 5.06224899598394 -0.389558232931727 3.06224899598394 1.11044176706827 3.06224899598394 1.11044176706827 3.56224899598394</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>polys.5</ogr:fid>
+      <ogr:name>elim</ogr:name>
+      <ogr:intval>2</ogr:intval>
+      <ogr:floatval>3.33</ogr:floatval>
+    </ogr:geometry_by_expression_layerref>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/geometry_by_expression_layerref.xsd
+++ b/python/plugins/processing/tests/testdata/expected/geometry_by_expression_layerref.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="geometry_by_expression_layerref" type="ogr:geometry_by_expression_layerref_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="geometry_by_expression_layerref_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:SurfacePropertyType" nillable="true" minOccurs="0" maxOccurs="1"/> <!-- restricted to Polygon --><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
@@ -703,3 +703,20 @@ tests:
       OUTPUT:
         name: expected/force_ccw_multipolys.gml
         type: vector
+
+  - algorithm: native:geometrybyexpression
+    name: Geometry by expression (using @layer_name)
+    params:
+      EXPRESSION: "scale(\n  geometry:=$geometry, \n  x_scale:=0.5, \n  y_scale:=0.5,\
+        \ \n  center:=centroid(\n    aggregate(layer:=@layer_name, aggregate:='collect',\
+        \ expression:=@geometry)\n  )\n)"
+      INPUT:
+        name: polys.gml|layername=polys2
+        type: vector
+      OUTPUT_GEOMETRY: 0
+      WITH_M: false
+      WITH_Z: false
+    results:
+      OUTPUT:
+        name: expected/geometry_by_expression_layerref.gml
+        type: vector

--- a/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
+++ b/src/analysis/processing/qgsalgorithmgeometrybyexpression.cpp
@@ -131,17 +131,19 @@ bool QgsGeometryByExpressionAlgorithm::prepareAlgorithm( const QVariantMap &para
     return false;
   }
 
-  mExpressionContext = createExpressionContext( parameters, context );
-  mExpression.prepare( &mExpressionContext );
-
   return true;
 }
 
-QgsFeatureList QgsGeometryByExpressionAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &, QgsProcessingFeedback * )
+QgsFeatureList QgsGeometryByExpressionAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
+  if ( !mExpressionPrepared )
+  {
+    mExpression.prepare( &context.expressionContext() );
+    mExpressionPrepared = true;
+  }
+
   QgsFeature feature = f;
-  mExpressionContext.setFeature( feature );
-  const QVariant value = mExpression.evaluate( &mExpressionContext );
+  const QVariant value = mExpression.evaluate( &context.expressionContext() );
 
   if ( mExpression.hasEvalError() )
   {

--- a/src/analysis/processing/qgsalgorithmgeometrybyexpression.h
+++ b/src/analysis/processing/qgsalgorithmgeometrybyexpression.h
@@ -61,7 +61,7 @@ class QgsGeometryByExpressionAlgorithm : public QgsProcessingFeatureBasedAlgorit
   private:
     Qgis::WkbType mWkbType = Qgis::WkbType::Unknown;
     QgsExpression mExpression;
-    QgsExpressionContext mExpressionContext;
+    bool mExpressionPrepared = false;
 };
 
 ///@endcond PRIVATE


### PR DESCRIPTION
## Description

Fix missing layer scope in the Geometry by Expression Processing algorithm. Rely on the logic implemented in the `QgsProcessingFeatureBasedAlgorithm` instead of initializing expression context manually. 

Fixes #54869.
Supersedes #64134.