### PR TITLE
Skip moving faces validity checks if a single vertex is selected

### DIFF
--- a/python/PyQt6/core/auto_generated/mesh/qgsmeshspatialindex.sip.in
+++ b/python/PyQt6/core/auto_generated/mesh/qgsmeshspatialindex.sip.in
@@ -70,6 +70,10 @@ specified ``rectangle``.
 
    The intersection test is performed based on the face bounding boxes only, so it is necessary
    to manually test the returned faces for exact geometry intersection when required.
+
+.. note::
+
+   Since QGIS 4.0, an empty list is returned if the specified ``rectangle`` is null.
 %End
 
     QList<int> nearestNeighbor( const QgsPointXY &point, int neighbors ) const;

--- a/src/app/mesh/qgsmaptooleditmeshframe.cpp
+++ b/src/app/mesh/qgsmaptooleditmeshframe.cpp
@@ -1208,7 +1208,7 @@ void QgsMapToolEditMeshFrame::moveSelection( const QgsPointXY &destinationPoint 
   // we test only the faces that are deformed on the border, moving and not deformed faces are tested later
   mIsMovingAllowed = mCurrentEditor->canBeTransformed( qgis::setToList( borderMovingFace ), transformFunction );
 
-  if ( mIsMovingAllowed )
+  if ( mIsMovingAllowed && !movingFacesGeometry.isEmpty() )
   {
     //to finish test if the polygons formed by the moving faces contains something else
     const QList<int> &faceIndexesIntersect = mCurrentLayer->triangularMesh()->nativeFaceIndexForRectangle( movingFacesGeometry.boundingBox() );

--- a/src/core/mesh/qgsmeshspatialindex.cpp
+++ b/src/core/mesh/qgsmeshspatialindex.cpp
@@ -389,6 +389,9 @@ QgsMeshSpatialIndex &QgsMeshSpatialIndex::operator=( QgsMeshSpatialIndex &&other
 QList<int> QgsMeshSpatialIndex::intersects( const QgsRectangle &rect ) const
 {
   QList<int> list;
+  if ( rect.isNull() )
+    return list;
+
   QgisMeshVisitor visitor( list );
 
   const SpatialIndex::Region r = QgsSpatialIndexUtils::rectangleToRegion( rect );

--- a/src/core/mesh/qgsmeshspatialindex.h
+++ b/src/core/mesh/qgsmeshspatialindex.h
@@ -81,6 +81,7 @@ class CORE_EXPORT QgsMeshSpatialIndex
      *
      * \note The intersection test is performed based on the face bounding boxes only, so it is necessary
      * to manually test the returned faces for exact geometry intersection when required.
+     * \note Since QGIS 4.0, an empty list is returned if the specified \a rectangle is null.
      */
     QList<int> intersects( const QgsRectangle &rectangle ) const;
 


### PR DESCRIPTION
## AI disclosure

Claude helps me to write debug output in order to diagnose the issue and identify where the bottleneck occurred. I'm not very familiar with C++, debug output, etc.
The fix is quite trivial in the end.

## What's the issue ?

Closes https://github.com/qgis/QGIS/issues/56897

When a single vertex is selected, `movingFacesGeometry` is empty and `mCurrentLayer->triangularMesh()->nativeFaceIndexForRectangle()` returns ALL faces. This causes a huge slowdown in the case of big meshes.
Furthermore, checks on moving faces are useless if a single vertex is selected; `canBeTransformed` already performs all necessary checks.

Before:

> moveSelection: vertices= 1 borderFaces= 6 edges= 0 ms canBeTransformed= 0 ms postChecks= 688 ms total= 689 ms allowed= true

After:

> moveSelection: vertices= 1 borderFaces= 6 edges= 0 ms canBeTransformed= 0 ms postChecks= 0 ms total= 0 ms allowed= true	

postChecks involved 380 000 faces to be checked for nothing