### PR TITLE
[browser] Improve UX when renaming/moving database objects

### DIFF
--- a/python/PyQt6/core/auto_generated/browser/qgsfieldsitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsfieldsitem.sip.in
@@ -82,6 +82,15 @@ Creates and returns a (possibly ``None``) layer from the connection URI
 and schema/table information
 %End
 
+    QgsFields fields() const;
+%Docstring
+Returns the fields contained by the item.
+
+The fields are only populated after the item's children are created.
+
+.. versionadded:: 4.0
+%End
+
     QgsAbstractDatabaseProviderConnection::TableProperty *tableProperty() const;
 %Docstring
 Returns the (possibly ``None``) properties of the table this fields

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1457,8 +1457,15 @@ void QgsFieldItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *men
           const QString itemName { item->name() };
 
           connect( renameFieldAction, &QAction::triggered, fieldsItem, [md, fieldsItem, itemName, context] {
+            const QgsFields existingFields = fieldsItem->fields();
+            QStringList existingFieldNames = existingFields.names();
+            existingFieldNames.removeAll( itemName );
+
             // Confirmation dialog
-            QgsNewNameDialog dlg( tr( "field “%1”" ).arg( itemName ), itemName );
+            QgsNewNameDialog dlg( tr( "field “%1”" ).arg( itemName ), itemName, {}, existingFieldNames );
+            dlg.setOverwriteEnabled( false );
+            dlg.setConflictingNameWarning( tr( "A field with this name already exists." ) );
+
             dlg.setWindowTitle( tr( "Rename Field" ) );
             if ( dlg.exec() != QDialog::Accepted || dlg.name() == itemName )
               return;

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1997,10 +1997,37 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
 
         if ( dlg->exec() == QDialog::Accepted )
         {
+          std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn( qgis::down_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( connectionUri, QVariantMap() ) ) );
+          const QString targetSchema = dlg->selectedSchema();
+          QStringList existingTableNamesInTargetSchema;
+          try
+          {
+            const QList<QgsAbstractDatabaseProviderConnection::TableProperty> existingTablesInTargetSchema = conn->tables( targetSchema );
+            existingTableNamesInTargetSchema.reserve( existingTablesInTargetSchema.size() );
+            for ( const QgsAbstractDatabaseProviderConnection::TableProperty &table : existingTablesInTargetSchema )
+            {
+              existingTableNamesInTargetSchema.append( table.tableName() );
+            }
+          }
+          catch ( QgsProviderConnectionException &ex )
+          {
+            ( void ) ex;
+          }
+          conn.reset();
+
           if ( selectedItems.count() == 1 )
           {
+            const QString tableName = item->name();
+            if ( existingTableNamesInTargetSchema.contains( tableName ) )
+            {
+              if ( context.messageBar() )
+              {
+                context.messageBar()->pushCritical( QString(), tr( "Cannot move %1 to %2: a table with the same name already exists in the schema" ).arg( tableName, targetSchema ) );
+              }
+              return;
+            }
             std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn3( qgis::down_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( connectionUri, QVariantMap() ) ) );
-            bool success = moveTableToSchema( std::move( conn3 ), item->parent()->name(), item->name(), dlg->selectedSchema(), context, true );
+            bool success = moveTableToSchema( std::move( conn3 ), item->parent()->name(), tableName, targetSchema, context, true );
             if ( !success )
               return;
 
@@ -2011,16 +2038,43 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
             if ( !item->parent() || !qobject_cast<QgsDataCollectionItem *>( item->parent()->parent() ) )
               return;
 
-            QgsDataItemGuiProviderUtils::refreshChildWithName( item->parent()->parent(), dlg->selectedSchema() );
+            QgsDataItemGuiProviderUtils::refreshChildWithName( item->parent()->parent(), targetSchema );
           }
           else
           {
             int numberImported = 0;
             QSet<QString> schemasToRefresh;
+
+            QStringList nameClashes;
+            for ( const QgsDataItem *selectedItem : selectedItems )
+            {
+              const QString tableName = selectedItem->name();
+              if ( existingTableNamesInTargetSchema.contains( tableName ) )
+              {
+                nameClashes.append( tableName );
+              }
+            }
+            if ( !nameClashes.isEmpty() )
+            {
+              if ( context.messageBar() )
+              {
+                if ( nameClashes.size() == 1 )
+                {
+                  context.messageBar()->pushCritical( QString(), tr( "Cannot move %1 to %2: a table with the same name already exists in the schema" ).arg( nameClashes.at( 0 ), targetSchema ) );
+                }
+                else
+                {
+                  const QString names = nameClashes.join( tr( ", " ) );
+                  context.messageBar()->pushCritical( QString(), tr( "Cannot move %1 to %2: tables with the same names already exists in the schema" ).arg( names, targetSchema ) );
+                }
+              }
+              return;
+            }
+
             for ( const QgsDataItem *selectedItem : selectedItems )
             {
               std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn3( qgis::down_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( connectionUri, QVariantMap() ) ) );
-              bool success = moveTableToSchema( std::move( conn3 ), selectedItem->parent()->name(), selectedItem->name(), dlg->selectedSchema(), context, false );
+              bool success = moveTableToSchema( std::move( conn3 ), selectedItem->parent()->name(), selectedItem->name(), targetSchema, context, false );
 
               if ( success )
               {
@@ -2039,14 +2093,14 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
               return;
 
             // add target schema to schemas to refresh
-            schemasToRefresh.insert( dlg->selectedSchema() );
+            schemasToRefresh.insert( targetSchema );
 
             for ( const QString &schema : schemasToRefresh )
             {
               QgsDataItemGuiProviderUtils::refreshChildWithName( dbItem, schema );
             }
 
-            notify( tr( "Move Tables" ), tr( "%1 tables moved to schema %2" ).arg( numberImported ).arg( dlg->selectedSchema() ), context, Qgis::MessageLevel::Success );
+            notify( tr( "Move Tables" ), tr( "%1 tables moved to schema %2" ).arg( numberImported ).arg( targetSchema ), context, Qgis::MessageLevel::Success );
           }
         }
       } );

--- a/src/core/browser/qgsfieldsitem.cpp
+++ b/src/core/browser/qgsfieldsitem.cpp
@@ -81,8 +81,8 @@ QVector<QgsDataItem *> QgsFieldsItem::createChildren()
       if ( conn )
       {
         int i = 0;
-        const QgsFields constFields { conn->fields( mSchema, mTableName ) };
-        for ( const auto &f : constFields )
+        mFields = conn->fields( mSchema, mTableName );
+        for ( const QgsField &f : mFields )
         {
           QgsFieldItem *fieldItem { new QgsFieldItem( this, f ) };
           fieldItem->setSortKey( i++ );
@@ -138,6 +138,11 @@ QgsVectorLayer *QgsFieldsItem::layer()
     QgsDebugError( u"Error getting metadata for provider %1"_s.arg( providerKey() ) );
   }
   return nullptr;
+}
+
+QgsFields QgsFieldsItem::fields() const
+{
+  return mFields;
 }
 
 QgsAbstractDatabaseProviderConnection::TableProperty *QgsFieldsItem::tableProperty() const

--- a/src/core/browser/qgsfieldsitem.h
+++ b/src/core/browser/qgsfieldsitem.h
@@ -94,6 +94,15 @@ class CORE_EXPORT QgsFieldsItem : public QgsDataItem
     QgsVectorLayer *layer() SIP_FACTORY;
 
     /**
+     * Returns the fields contained by the item.
+     *
+     * The fields are only populated after the item's children are created.
+     *
+     * \since QGIS 4.0
+     */
+    QgsFields fields() const;
+
+    /**
      * Returns the (possibly NULLPTR) properties of the table this fields belong to.
      * \since QGIS 3.16
      */
@@ -113,7 +122,7 @@ class CORE_EXPORT QgsFieldsItem : public QgsDataItem
     QString mConnectionUri;
     bool mCanRename = false;
     std::unique_ptr<QgsAbstractDatabaseProviderConnection::TableProperty> mTableProperty;
-
+    QgsFields mFields;
 };
 
 

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -274,6 +274,7 @@ void QgsGeoPackageItemGuiProvider::renameVectorLayer( const QString &uri, const 
   dlg.setRegularExpression( QStringLiteral( R"re([^|]+)re" ) );
 
   dlg.setOverwriteEnabled( false );
+  dlg.setConflictingNameWarning( tr( "A table with this name already exists." ) );
 
   if ( dlg.exec() != dlg.Accepted || dlg.name().isEmpty() || dlg.name() == layerName )
     return;


### PR DESCRIPTION
- Don't allow renaming fields to duplicate names
- Don't allow renaming tables to duplicate names
- Show more user-friendly message when attempting to move schema and duplicate names exist in the target schema