### PR TITLE
Fix vertextool for NURBS

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -429,11 +429,13 @@ void QgsVertexTool::addDragNurbsBand( QgsVectorLayer *layer, const QgsNurbsCurve
   if ( !nurbs || nurbs->controlPoints().isEmpty() )
     return;
 
+  const std::uintptr_t nurbsId = reinterpret_cast<quintptr>( nurbs );
+
   // Check if a band already exists for this NURBS curve
   NurbsBand *existingBand = nullptr;
   for ( NurbsBand &band : mDragNurbsBands )
   {
-    if ( band.nurbs == nurbs )
+    if ( band.id == nurbsId )
     {
       existingBand = &band;
       break;
@@ -456,7 +458,7 @@ void QgsVertexTool::addDragNurbsBand( QgsVectorLayer *layer, const QgsNurbsCurve
     QVector<QgsPointXY> mapControlPoints = transformNurbsControlPointsToMap( layer, nurbs->controlPoints() );
 
     NurbsBand band;
-    band.nurbs = nurbs;
+    band.id = nurbsId;
     band.curveBand.reset( createRubberBand( Qgis::GeometryType::Line, true ) );
     band.controlBand.reset( createRubberBand( Qgis::GeometryType::Line, true ) );
     applyNurbsControlPolygonStyle( band.controlBand.data() );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -457,9 +457,9 @@ void QgsVertexTool::addDragNurbsBand( QgsVectorLayer *layer, const QgsNurbsCurve
 
     NurbsBand band;
     band.nurbs = nurbs;
-    band.curveBand = createRubberBand( Qgis::GeometryType::Line, true );
-    band.controlBand = createRubberBand( Qgis::GeometryType::Line, true );
-    applyNurbsControlPolygonStyle( band.controlBand );
+    band.curveBand.reset( createRubberBand( Qgis::GeometryType::Line, true ) );
+    band.controlBand.reset( createRubberBand( Qgis::GeometryType::Line, true ) );
+    applyNurbsControlPolygonStyle( band.controlBand.data() );
 
     band.controlPoints = std::move( mapControlPoints );
     band.degree = nurbs->degree();
@@ -475,7 +475,7 @@ void QgsVertexTool::addDragNurbsBand( QgsVectorLayer *layer, const QgsNurbsCurve
 
     band.updateRubberBand( mapPoint );
 
-    mDragNurbsBands << band;
+    mDragNurbsBands.emplace_back( std::move( band ) );
   }
 }
 
@@ -493,11 +493,6 @@ void QgsVertexTool::clearDragBands()
     delete b.band;
   mDragCircularBands.clear();
 
-  for ( const NurbsBand &band : std::as_const( mDragNurbsBands ) )
-  {
-    delete band.curveBand;
-    delete band.controlBand;
-  }
   mDragNurbsBands.clear();
 
   mBezierMarker->setVisible( false );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1447,36 +1447,39 @@ void QgsVertexTool::updateFeatureBand( const QgsPointLocator::Match &m )
 
     QgsGeometry geom = cachedGeometry( m.layer(), m.featureId() );
 
-    // Check if this is a NURBS curve
-    const QgsNurbsCurve *nurbs = QgsNurbsUtils::extractNurbsCurve( geom.constGet() );
-
-    if ( nurbs && !nurbs->controlPoints().isEmpty() )
+    if ( QgsNurbsUtils::containsNurbsCurve( geom.constGet() ) )
     {
-      QVector<QgsPointXY> mapPoints = transformNurbsControlPointsToMap( m.layer(), nurbs->controlPoints() );
+      // Check if this is a NURBS curve
+      const QgsNurbsCurve *nurbs = QgsNurbsUtils::extractNurbsCurve( geom.constGet() );
 
-      if ( nurbs->isPolyBezier() )
+      if ( nurbs && !nurbs->controlPoints().isEmpty() )
       {
-        // Poly-Bézier mode: visualize with anchors/handles
-        QgsBezierData bezierData = QgsBezierData::fromPolyBezierControlPoints( mapPoints, nurbs->degree() );
-        mBezierMarker->updateFromData( bezierData );
-        mBezierMarker->setVisible( true );
-        mBezierMarker->setHandlesVisible( true );
+        QVector<QgsPointXY> mapPoints = transformNurbsControlPointsToMap( m.layer(), nurbs->controlPoints() );
 
-        mNurbsControlPolygonBand->setVisible( false );
-        mFeatureBandMarkers->setVisible( false );
-      }
-      else
-      {
-        // CAD mode: show control polygon
-        mBezierMarker->setVisible( false );
+        if ( nurbs->isPolyBezier() )
+        {
+          // Poly-Bézier mode: visualize with anchors/handles
+          QgsBezierData bezierData = QgsBezierData::fromPolyBezierControlPoints( mapPoints, nurbs->degree() );
+          mBezierMarker->updateFromData( bezierData );
+          mBezierMarker->setVisible( true );
+          mBezierMarker->setHandlesVisible( true );
 
-        mNurbsControlPolygonBand->reset( Qgis::GeometryType::Line );
-        for ( const QgsPointXY &pt : mapPoints )
-          mNurbsControlPolygonBand->addPoint( pt );
-        mNurbsControlPolygonBand->setVisible( true );
+          mNurbsControlPolygonBand->setVisible( false );
+          mFeatureBandMarkers->setVisible( false );
+        }
+        else
+        {
+          // CAD mode: show control polygon
+          mBezierMarker->setVisible( false );
 
-        mFeatureBandMarkers->setToGeometry( geometryToMultiPoint( geom ), m.layer() );
-        mFeatureBandMarkers->setVisible( true );
+          mNurbsControlPolygonBand->reset( Qgis::GeometryType::Line );
+          for ( const QgsPointXY &pt : mapPoints )
+            mNurbsControlPolygonBand->addPoint( pt );
+          mNurbsControlPolygonBand->setVisible( true );
+
+          mFeatureBandMarkers->setToGeometry( geometryToMultiPoint( geom ), m.layer() );
+          mFeatureBandMarkers->setVisible( true );
+        }
       }
     }
     else

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2050,7 +2050,7 @@ void QgsVertexTool::stopDragging()
 
 QgsPoint QgsVertexTool::matchToLayerPoint( const QgsVectorLayer *destLayer, const QgsPointXY &mapPoint, const QgsPointLocator::Match *match )
 {
-  if ( match->layer() )
+  if ( match && match->layer() )
   {
     switch ( match->type() )
     {

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -338,7 +338,6 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
      */
     QVector<QgsPointXY> transformNurbsControlPointsToMap( QgsVectorLayer *layer, const QgsPointSequence &controlPoints );
 
-  private:
     QgsVertexEditor *vertexEditor();
 
     // members used for temporary highlight of stuff

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -16,6 +16,7 @@
 #ifndef QGSVERTEXTOOL_H
 #define QGSVERTEXTOOL_H
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -412,7 +413,7 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     //! structure to keep information about a rubber band used for dragging of a NURBS curve \since QGIS 4.0
     struct NurbsBand
     {
-        const QgsNurbsCurve *nurbs = nullptr;        //!< NURBS curve pointer for identification
+        std::uintptr_t id;                           //!< NURBS curve identifier
         QObjectUniquePtr<QgsRubberBand> curveBand;   //!< Evaluated NURBS curve visualization
         QObjectUniquePtr<QgsRubberBand> controlBand; //!< Control polygon
         QVector<QgsPointXY> controlPoints;           //!< Control points in map coordinates

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -17,6 +17,7 @@
 #define QGSVERTEXTOOL_H
 
 #include <memory>
+#include <vector>
 
 #include "qgis_app.h"
 #include "qgsbeziermarker.h"
@@ -411,15 +412,15 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     //! structure to keep information about a rubber band used for dragging of a NURBS curve \since QGIS 4.0
     struct NurbsBand
     {
-        const QgsNurbsCurve *nurbs = nullptr; //!< NURBS curve pointer for identification
-        QgsRubberBand *curveBand = nullptr;   //!< Evaluated NURBS curve visualization
-        QgsRubberBand *controlBand = nullptr; //!< Control polygon
-        QVector<QgsPointXY> controlPoints;    //!< Control points in map coordinates
-        QVector<int> movingIndices;           //!< Indices of control points being dragged
-        QVector<QgsVector> offsets;           //!< Offset vectors from mouse cursor to each moving control point
-        int degree = 3;                       //!< NURBS curve degree
-        QVector<double> knots;                //!< Knot vector
-        QVector<double> weights;              //!< Weight vector for rational curves
+        const QgsNurbsCurve *nurbs = nullptr;        //!< NURBS curve pointer for identification
+        QObjectUniquePtr<QgsRubberBand> curveBand;   //!< Evaluated NURBS curve visualization
+        QObjectUniquePtr<QgsRubberBand> controlBand; //!< Control polygon
+        QVector<QgsPointXY> controlPoints;           //!< Control points in map coordinates
+        QVector<int> movingIndices;                  //!< Indices of control points being dragged
+        QVector<QgsVector> offsets;                  //!< Offset vectors from mouse cursor to each moving control point
+        int degree = 3;                              //!< NURBS curve degree
+        QVector<double> knots;                       //!< Knot vector
+        QVector<double> weights;                     //!< Weight vector for rational curves
 
         //! Update geometry of the rubber bands on the current mouse cursor position (in map units)
         void updateRubberBand( const QgsPointXY &mapPoint );
@@ -438,7 +439,7 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     //! list of active rubber bands for circular segments
     QList<CircularBand> mDragCircularBands;
     //! list of active rubber bands for NURBS curves \since QGIS 4.0
-    QList<NurbsBand> mDragNurbsBands;
+    std::vector<NurbsBand> mDragNurbsBands;
 
     //! rubber band for displaying NURBS control polygon in edit mode \since QGIS 4.0
     QObjectUniquePtr<QgsRubberBand> mNurbsControlPolygonBand;

--- a/src/core/geometry/qgsnurbscurve.cpp
+++ b/src/core/geometry/qgsnurbscurve.cpp
@@ -1492,7 +1492,15 @@ bool QgsNurbsCurve::moveVertex( QgsVertexId position, const QgsPoint &newPos )
   if ( idx < 0 || idx >= mControlPoints.size() )
     return false;
 
-  mControlPoints[idx] = newPos;
+  mControlPoints[idx].setX( newPos.x() );
+  mControlPoints[idx].setY( newPos.y() );
+
+  if ( is3D() && newPos.is3D() )
+    mControlPoints[idx].setZ( newPos.z() );
+
+  if ( isMeasure() && newPos.isMeasure() )
+    mControlPoints[idx].setM( newPos.m() );
+
   clearCache();
   return true;
 }

--- a/src/gui/maptools/qgsbezierdata.cpp
+++ b/src/gui/maptools/qgsbezierdata.cpp
@@ -375,4 +375,48 @@ QgsBezierData QgsBezierData::fromPolyBezierControlPoints( const QVector<QgsPoint
   return fromPolyBezierControlPoints( points, degree );
 }
 
+void QgsBezierData::calculateSymmetricHandles( QVector<QgsPoint> &controlPoints, int anchorIndex, const QgsPoint &mousePosition )
+{
+  if ( anchorIndex < 0 || anchorIndex >= controlPoints.size() )
+    return;
+
+  QgsPoint *handleFollow = nullptr;
+  if ( anchorIndex + 1 < controlPoints.size() )
+    handleFollow = &controlPoints[anchorIndex + 1];
+
+  QgsPoint *handleOpposite = nullptr;
+  if ( anchorIndex - 1 >= 0 )
+    handleOpposite = &controlPoints[anchorIndex - 1];
+
+  calculateSymmetricHandles( controlPoints.at( anchorIndex ), mousePosition, handleFollow, handleOpposite );
+}
+
+void QgsBezierData::calculateSymmetricHandles( const QgsPoint &anchor, const QgsPoint &mousePosition, QgsPoint *handleFollow, QgsPoint *handleOpposite )
+{
+  // Calculate vector from anchor to mouse
+  const double dx = mousePosition.x() - anchor.x();
+  const double dy = mousePosition.y() - anchor.y();
+
+  if ( handleFollow )
+  {
+    handleFollow->setX( anchor.x() + dx );
+    handleFollow->setY( anchor.y() + dy );
+  }
+
+  if ( handleOpposite )
+  {
+    handleOpposite->setX( anchor.x() - dx );
+    handleOpposite->setY( anchor.y() - dy );
+  }
+}
+
+void QgsBezierData::calculateSymmetricHandles( int anchorIndex, const QgsPoint &mousePosition )
+{
+  if ( anchorIndex < 0 || anchorIndex >= mData.count() )
+    return;
+
+  QgsAnchorWithHandles &awh = mData[anchorIndex];
+  calculateSymmetricHandles( awh.anchor, mousePosition, &awh.rightHandle, &awh.leftHandle );
+}
+
 ///@endcond PRIVATE

--- a/src/gui/maptools/qgsbezierdata.cpp
+++ b/src/gui/maptools/qgsbezierdata.cpp
@@ -199,9 +199,13 @@ std::unique_ptr<QgsNurbsCurve> QgsBezierData::asNurbsCurve( int degree ) const
     for ( int j = 1; j < degree; ++j )
     {
       if ( j == 1 )
+      {
         ctrlPts.append( mData[i].rightHandle );
+      }
       else if ( j == degree - 1 )
+      {
         ctrlPts.append( mData[i + 1].leftHandle );
+      }
       else
       {
         // degree > 3, we don't have intermediate handles.

--- a/src/gui/maptools/qgsbezierdata.cpp
+++ b/src/gui/maptools/qgsbezierdata.cpp
@@ -183,31 +183,41 @@ QgsPointSequence QgsBezierData::interpolateLine() const
   return result;
 }
 
-std::unique_ptr<QgsNurbsCurve> QgsBezierData::asNurbsCurve() const
+std::unique_ptr<QgsNurbsCurve> QgsBezierData::asNurbsCurve( int degree ) const
 {
   const int anchorCount = mData.count();
-  if ( anchorCount < 2 )
+  if ( anchorCount < 2 || degree < 1 )
     return nullptr;
 
-  // Build control points: anchor, handle_right, handle_left, anchor, ...
-  // A piecewise cubic Bézier with n anchors has n-1 segments
-  // Total control points: 1 + 3*(n-1) = 3n-2
+  // Build control points
   QVector<QgsPoint> ctrlPts;
+  ctrlPts.reserve( 1 + ( anchorCount - 1 ) * degree );
   ctrlPts.append( mData[0].anchor );
 
   for ( int i = 0; i < anchorCount - 1; ++i )
   {
-    ctrlPts.append( mData[i].rightHandle );
-    ctrlPts.append( mData[i + 1].leftHandle );
+    for ( int j = 1; j < degree; ++j )
+    {
+      if ( j == 1 )
+        ctrlPts.append( mData[i].rightHandle );
+      else if ( j == degree - 1 )
+        ctrlPts.append( mData[i + 1].leftHandle );
+      else
+      {
+        // degree > 3, we don't have intermediate handles.
+        // We'll just repeat the right handle as a fallback.
+        ctrlPts.append( mData[i].rightHandle );
+      }
+    }
     ctrlPts.append( mData[i + 1].anchor );
   }
 
-  QVector<double> knots = QgsNurbsCurve::generateKnotsForBezierConversion( anchorCount );
+  QVector<double> knots = QgsNurbsCurve::generateKnotsForBezierConversion( anchorCount, degree );
 
   // Uniform weights (non-rational B-spline)
   QVector<double> weights( ctrlPts.count(), 1.0 );
 
-  return std::make_unique<QgsNurbsCurve>( ctrlPts, 3, knots, weights );
+  return std::make_unique<QgsNurbsCurve>( ctrlPts, degree, knots, weights );
 }
 
 void QgsBezierData::clear()
@@ -309,6 +319,60 @@ int QgsBezierData::findClosestSegment( const QgsPoint &point, double tolerance )
   }
 
   return closestSegment;
+}
+
+QgsBezierData QgsBezierData::fromPolyBezierControlPoints( const QVector<QgsPoint> &controlPoints, int degree )
+{
+  QgsBezierData data;
+
+  if ( degree < 1 )
+    return data;
+
+  const int n = controlPoints.size();
+  if ( n < degree + 1 || ( n - 1 ) % degree != 0 )
+    return data;
+
+  const int numAnchors = ( n - 1 ) / degree + 1;
+
+  for ( int i = 0; i < numAnchors; ++i )
+  {
+    const int anchorIndex = i * degree;
+    if ( anchorIndex >= n )
+      break;
+
+    const QgsPoint &anchor = controlPoints[anchorIndex];
+    QgsPoint leftHandle = anchor;
+    QgsPoint rightHandle = anchor;
+
+    if ( i > 0 )
+    {
+      const int leftIndex = anchorIndex - 1;
+      if ( leftIndex < n )
+        leftHandle = controlPoints[leftIndex];
+    }
+
+    if ( i < numAnchors - 1 )
+    {
+      const int rightIndex = anchorIndex + 1;
+      if ( rightIndex < n )
+        rightHandle = controlPoints[rightIndex];
+    }
+
+    data.addAnchor( anchor );
+    data.moveHandle( i * 2, leftHandle );
+    data.moveHandle( i * 2 + 1, rightHandle );
+  }
+
+  return data;
+}
+
+QgsBezierData QgsBezierData::fromPolyBezierControlPoints( const QVector<QgsPointXY> &controlPoints, int degree )
+{
+  QVector<QgsPoint> points;
+  points.reserve( controlPoints.size() );
+  for ( const QgsPointXY &pt : controlPoints )
+    points.append( QgsPoint( pt ) );
+  return fromPolyBezierControlPoints( points, degree );
 }
 
 ///@endcond PRIVATE

--- a/src/gui/maptools/qgsbezierdata.h
+++ b/src/gui/maptools/qgsbezierdata.h
@@ -26,7 +26,6 @@
 
 class QgsNurbsCurve;
 
-
 ///@cond PRIVATE
 
 /**

--- a/src/gui/maptools/qgsbezierdata.h
+++ b/src/gui/maptools/qgsbezierdata.h
@@ -161,7 +161,7 @@ class GUI_EXPORT QgsBezierData
 
     /**
      * Converts the Poly-Bézier data to a QgsNurbsCurve.
-     * The resulting curve is a piecewise Bézier of degree \a degree represented as NURBS.
+     * The resulting curve is a piecewise Bézier of \a degree represented as NURBS.
      * \param degree The degree of the Bézier segments (defaults to 3 for cubic).
      * \returns new QgsNurbsCurve. Returns nullptr if less than 2 anchors or degree < 1.
      */

--- a/src/gui/maptools/qgsbezierdata.h
+++ b/src/gui/maptools/qgsbezierdata.h
@@ -162,10 +162,38 @@ class GUI_EXPORT QgsBezierData
 
     /**
      * Converts the Poly-Bézier data to a QgsNurbsCurve.
-     * The resulting curve is a piecewise cubic Bézier represented as NURBS.
-     * \returns new QgsNurbsCurve. Returns nullptr if less than 2 anchors.
+     * The resulting curve is a piecewise Bézier of degree \a degree represented as NURBS.
+     * \param degree The degree of the Bézier segments (defaults to 3 for cubic).
+     * \returns new QgsNurbsCurve. Returns nullptr if less than 2 anchors or degree < 1.
      */
-    std::unique_ptr<QgsNurbsCurve> asNurbsCurve() const;
+    std::unique_ptr<QgsNurbsCurve> asNurbsCurve( int degree = 3 ) const;
+
+    /**
+     * Creates QgsBezierData from a poly-Bézier NURBS curve control points.
+     *
+     * Converts NURBS control point layout (anchor, handle, ..., handle, anchor, ...)
+     * to QgsBezierData structure (anchors with left/right handles).
+     *
+     * \param controlPoints Control points from a poly-Bézier NURBS curve
+     *                      (must have d*k+1 points where k is the number of segments and d is the degree)
+     * \param degree The degree of the Bézier segments (defaults to 3 for cubic).
+     * \returns QgsBezierData with anchors and handles extracted
+     * \since QGIS 4.0
+     */
+    static QgsBezierData fromPolyBezierControlPoints( const QVector<QgsPoint> &controlPoints, int degree = 3 );
+
+    /**
+     * Creates QgsBezierData from a poly-Bézier NURBS curve control points.
+     *
+     * Overload that accepts 2D points.
+     *
+     * \param controlPoints Control points from a poly-Bézier NURBS curve
+     *                      (must have d*k+1 points where k is the number of segments and d is the degree)
+     * \param degree The degree of the Bézier segments (defaults to 3 for cubic).
+     * \returns QgsBezierData with anchors and handles extracted
+     * \since QGIS 4.0
+     */
+    static QgsBezierData fromPolyBezierControlPoints( const QVector<QgsPointXY> &controlPoints, int degree = 3 );
 
     //! Clears all data
     void clear();

--- a/src/gui/maptools/qgsbezierdata.h
+++ b/src/gui/maptools/qgsbezierdata.h
@@ -195,6 +195,38 @@ class GUI_EXPORT QgsBezierData
      */
     static QgsBezierData fromPolyBezierControlPoints( const QVector<QgsPointXY> &controlPoints, int degree = 3 );
 
+    /**
+     * Calculates and updates the symmetric handle positions when dragging a Poly-Bézier anchor.
+     *
+     * \param controlPoints The list of control points to update.
+     * \param anchorIndex The index of the anchor being dragged.
+     * \param mousePosition The position of the mouse cursor (defining the direction/length of handles relative to anchor).
+     * \since QGIS 4.0
+     */
+    static void calculateSymmetricHandles( QVector<QgsPoint> &controlPoints, int anchorIndex, const QgsPoint &mousePosition );
+
+    /**
+     * Calculates and updates the symmetric handle positions for a single anchor.
+     *
+     * \param anchor The anchor point (center).
+     * \param mousePosition The new position for the handle that follows the mouse.
+     * \param handleFollow The handle that will be moved to \a mousePosition.
+     * \param handleOpposite The handle that will be moved to the symmetric opposite position.
+     * \since QGIS 4.0
+     */
+    static void calculateSymmetricHandles( const QgsPoint &anchor, const QgsPoint &mousePosition, QgsPoint *handleFollow, QgsPoint *handleOpposite );
+
+    /**
+     * Updates the handles of the anchor at \a anchorIndex symmetrically.
+     * The right handle will follow \a mousePosition, and the left handle will
+     * be placed in the opposite direction.
+     *
+     * \param anchorIndex The index of the anchor to update.
+     * \param mousePosition The new position for the right handle.
+     * \since QGIS 4.0
+     */
+    void calculateSymmetricHandles( int anchorIndex, const QgsPoint &mousePosition );
+
     //! Clears all data
     void clear();
 

--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -687,16 +687,7 @@ void QgsMapToolCapture::cadCanvasMoveEvent( QgsMapMouseEvent *e )
       else if ( mBezierDragAnchorIndex >= 0 )
       {
         // Creating new anchor: update both handles symmetrically
-        const QgsPoint &anchor = mBezierData->anchor( mBezierDragAnchorIndex );
-        const int leftHandleIdx = mBezierDragAnchorIndex * 2;
-        const int rightHandleIdx = mBezierDragAnchorIndex * 2 + 1;
-
-        // Right handle follows mouse
-        mBezierData->moveHandle( rightHandleIdx, mapPoint );
-
-        // Left handle goes opposite direction: anchor - (mouse - anchor) = 2*anchor - mouse
-        const QgsPoint leftHandle( anchor.x() * 2 - mapPoint.x(), anchor.y() * 2 - mapPoint.y() );
-        mBezierData->moveHandle( leftHandleIdx, leftHandle );
+        mBezierData->calculateSymmetricHandles( mBezierDragAnchorIndex, mapPoint );
       }
 
       // Update visualization


### PR DESCRIPTION
## Description

Fix vertextool for NURBS

- Differentiates NURBS and poly-bezier (redisplays handles/anchors)
- Can move control points (and so handles/anchors)
- Can Alt+drag anchors
- Fix Z/M in moveVertex
- refacto/improvements in qgsbezierdata

https://github.com/user-attachments/assets/004fca4f-065a-486e-a345-fb5549343be7

Limitation : 

- Can't add point at begin/end : I'm still working on it. I almost have something functional for nurbs “cad,” but for bézier, I'm not yet satisfied.