### PR TITLE
[Elevation profile][3D] Display elevation profile curve in 3D

### DIFF
--- a/python/PyQt6/core/auto_additions/qgselevationprofile.py
+++ b/python/PyQt6/core/auto_additions/qgselevationprofile.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/elevation/qgselevationprofile.h
 try:
-    QgsElevationProfile.__attribute_docs__ = {'nameChanged': 'Emitted when the profile is renamed.\n\n.. seealso:: :py:func:`name`\n\n.. seealso:: :py:func:`setName`\n', 'useProjectLayerTreeChanged': 'Emitted when the use project layer tree property is changed.\n\n.. seealso:: :py:func:`setUseProjectLayerTree`\n'}
-    QgsElevationProfile.__signal_arguments__ = {'nameChanged': ['newName: str'], 'useProjectLayerTreeChanged': ['useProjectTree: bool']}
+    QgsElevationProfile.__attribute_docs__ = {'nameChanged': 'Emitted when the profile is renamed.\n\n.. seealso:: :py:func:`name`\n\n.. seealso:: :py:func:`setName`\n', 'useProjectLayerTreeChanged': 'Emitted when the use project layer tree property is changed.\n\n.. seealso:: :py:func:`setUseProjectLayerTree`\n', 'profileCurveChanged': 'Emitted when the profile curve is changed.\n\n.. seealso:: :py:func:`profileCurve`\n\n.. seealso:: :py:func:`setProfileCurve`\n\n.. versionadded:: 4.2\n', 'toleranceChanged': 'Emitted when the profile tolerance is changed.\n\n.. seealso:: :py:func:`tolerance`\n\n.. seealso:: :py:func:`setTolerance`\n\n.. versionadded:: 4.2\n'}
+    QgsElevationProfile.__signal_arguments__ = {'nameChanged': ['newName: str'], 'useProjectLayerTreeChanged': ['useProjectTree: bool'], 'toleranceChanged': ['tolerance: float']}
     QgsElevationProfile.__group__ = ['elevation']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/elevation/qgselevationprofile.sip.in
+++ b/python/PyQt6/core/auto_generated/elevation/qgselevationprofile.sip.in
@@ -248,6 +248,28 @@ Emitted when the use project layer tree property is changed.
 .. seealso:: :py:func:`setUseProjectLayerTree`
 %End
 
+    void profileCurveChanged();
+%Docstring
+Emitted when the profile curve is changed.
+
+.. seealso:: :py:func:`profileCurve`
+
+.. seealso:: :py:func:`setProfileCurve`
+
+.. versionadded:: 4.2
+%End
+
+    void toleranceChanged( double tolerance );
+%Docstring
+Emitted when the profile tolerance is changed.
+
+.. seealso:: :py:func:`tolerance`
+
+.. seealso:: :py:func:`setTolerance`
+
+.. versionadded:: 4.2
+%End
+
 };
 
 /************************************************************************

--- a/python/PyQt6/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
+++ b/python/PyQt6/gui/auto_generated/elevation/qgselevationprofilecanvas.sip.in
@@ -206,6 +206,17 @@ Returns the elevation range currently visible in the plot.
 .. seealso:: :py:func:`setVisiblePlotRange`
 %End
 
+    QgsDoubleRange dataElevationRange() const;
+%Docstring
+Returns elevation range of the computed profile results.
+
+Calculated from data, not from visible extent.
+
+.. seealso:: :py:func:`visibleElevationRange`
+
+.. versionadded:: 4.2
+%End
+
 
     void render( QgsRenderContext &context, double width, double height, const Qgs2DXyPlot &plotSettings );
 %Docstring

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -35,11 +35,15 @@
 #include "qgsapplication.h"
 #include "qgscameracontroller.h"
 #include "qgscrosssection.h"
+#include "qgscurve.h"
 #include "qgsdockablewidgethelper.h"
+#include "qgselevationprofile.h"
 #include "qgsflatterrainsettings.h"
+#include "qgsframegraph.h"
 #include "qgsgui.h"
 #include "qgshelp.h"
 #include "qgsidentifyresultsdialog.h"
+#include "qgslinestring.h"
 #include "qgsmap3dexportwidget.h"
 #include "qgsmapcanvas.h"
 #include "qgsmapthemecollection.h"
@@ -50,10 +54,14 @@
 #include "qgspointcloudlayer.h"
 #include "qgspointcloudlayer3drenderer.h"
 #include "qgspointcloudquerybuilder.h"
+#include "qgspolygon.h"
+#include "qgsprofilepoint.h"
 #include "qgsrubberband.h"
+#include "qgsrubberband3d.h"
 #include "qgssettings.h"
 #include "qgssettingstree.h"
 #include "qgsshortcutsmanager.h"
+#include "qgswindow3dengine.h"
 
 #include <QAction>
 #include <QActionGroup>
@@ -1379,6 +1387,270 @@ void Qgs3DMapCanvasWidget::updateCheckedActionsFromMapSettings( const Qgs3DMapSe
   whileBlocking( mActionSync3DNavTo2D )->setChecked( mapSettings->viewSyncMode().testFlag( Qgis::ViewSyncModeFlag::Sync3DTo2D ) );
   whileBlocking( mShowFrustumPolygon )->setChecked( mapSettings->viewFrustumVisualizationEnabled() );
   whileBlocking( mActionShow2DMapOverlay )->setChecked( mapSettings->is2DMapOverlayEnabled() );
+}
+
+void Qgs3DMapCanvasWidget::onProfileDestroyed( QObject *obj )
+{
+  if ( QgsElevationProfile *profile = static_cast<QgsElevationProfile *>( obj ) )
+    mElevationProfileData.erase( profile );
+}
+
+void Qgs3DMapCanvasWidget::updateProfileCursorPosition( QgsElevationProfile *profile, const QgsPointXY &mapPoint, const QgsProfilePoint &profilePoint )
+{
+  if ( !mCanvas || !mElevationProfileData.contains( profile ) )
+    return;
+
+  ElevationProfileData &data = mElevationProfileData[profile];
+
+  QgsCurve *curve = profile->profileCurve();
+  if ( mapPoint.isEmpty() || profilePoint.isEmpty() || !curve )
+  {
+    data.cursorLineRubberBand.reset();
+    data.cursorPolygonRubberBand.reset();
+    return;
+  }
+
+  if ( !data.cursorLineRubberBand )
+  {
+    data.cursorLineRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Line );
+    data.cursorLineRubberBand->setColor( QColor( 0, 0, 0, 200 ) );
+    data.cursorLineRubberBand->setWidth( 3 );
+    data.cursorLineRubberBand->setMarkersEnabled( false );
+  }
+
+  QgsGeometry cursorGeom( new QgsLineString( QVector<QgsPoint> {
+    QgsPoint( mapPoint.x(), mapPoint.y(), data.zMin ),
+    QgsPoint( mapPoint.x(), mapPoint.y(), data.zMax ),
+  } ) );
+  data.cursorLineRubberBand->setGeometry( cursorGeom );
+
+  std::unique_ptr<QgsPoint> p0( curve->interpolatePoint( profilePoint.distance() ) );
+  std::unique_ptr<QgsPoint> p1( curve->interpolatePoint( curve->length() ) );
+
+  if ( !p0 || !p1 )
+  {
+    data.cursorLineRubberBand.reset();
+    data.cursorPolygonRubberBand.reset();
+    return;
+  }
+
+  double dx = p1->x() - p0->x();
+  double dy = p1->y() - p0->y();
+
+  const double length = std::sqrt( dx * dx + dy * dy );
+
+  dx /= length;
+  dy /= length;
+
+  const double tolerance = profile->tolerance();
+  const double normalX = -dy * tolerance;
+  const double normalY = dx * tolerance;
+
+  const double x = mapPoint.x();
+  const double y = mapPoint.y();
+
+  QgsGeometry polyGeom( new QgsPolygon( new QgsLineString( QVector<QgsPoint> {
+    QgsPoint( x + normalX, y + normalY, data.zMin ),
+    QgsPoint( x - normalX, y - normalY, data.zMin ),
+    QgsPoint( x - normalX, y - normalY, data.zMax ),
+    QgsPoint( x + normalX, y + normalY, data.zMax ),
+    QgsPoint( x + normalX, y + normalY, data.zMin ),
+  } ) ) );
+
+  if ( !data.cursorPolygonRubberBand )
+  {
+    data.cursorPolygonRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Polygon );
+    data.cursorPolygonRubberBand->setColor( QColor( 50, 50, 50, 100 ) );
+    data.cursorPolygonRubberBand->setWidth( 0 );
+    data.cursorPolygonRubberBand->setMarkersEnabled( false );
+  }
+
+  data.cursorPolygonRubberBand->setGeometry( polyGeom );
+}
+
+void Qgs3DMapCanvasWidget::setProfileData( QgsElevationProfile *profile, double zMin, double zMax )
+{
+  // only when the generation of the profile finishes, we get zMin and zMax
+  // however, rasters and point clouds trigger profile generation on every elevation profile canvas move/zoom
+  // so Z values of the profile curve in 3D can fluctuate when dealing with those formats and zooming/moving in elevation canvas
+  if ( !profile )
+    return;
+
+  if ( mElevationProfileData.contains( profile ) )
+  {
+    ElevationProfileData &data = mElevationProfileData[profile];
+    data.zMin = zMin;
+    data.zMax = zMax;
+    updateProfileRubberBands( profile );
+    return;
+  }
+
+  ElevationProfileData profileData;
+  profileData.zMin = zMin;
+  profileData.zMax = zMax;
+  mElevationProfileData[profile] = std::move( profileData );
+
+  connect( profile, &QgsElevationProfile::profileCurveChanged, this, [this, profile] { updateProfileRubberBands( profile ); } );
+  connect( profile, &QgsElevationProfile::toleranceChanged, this, [this, profile] { updateProfileRubberBands( profile ); } );
+  connect( profile, &QObject::destroyed, this, &Qgs3DMapCanvasWidget::onProfileDestroyed );
+
+  updateProfileRubberBands( profile );
+}
+
+void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profile )
+{
+  if ( !mCanvas || !mElevationProfileData.contains( profile ) )
+    return;
+
+  ElevationProfileData &data = mElevationProfileData[profile];
+
+  QgsCurve *curve = profile->profileCurve();
+  if ( !curve )
+  {
+    data.rubberBandZMin.reset();
+    data.rubberBandZMax.reset();
+    data.rubberBandSideLines.clear();
+    return;
+  }
+
+  const double tolerance = profile->tolerance();
+  QgsGeometry curveGeom( curve->clone() );
+
+  QgsGeometry rubberBandGeom;
+  Qgis::GeometryType geomType;
+  if ( tolerance > 0 )
+  {
+    rubberBandGeom = curveGeom.buffer( tolerance, 8, Qgis::EndCapStyle::Flat, Qgis::JoinStyle::Round, 2 );
+    geomType = Qgis::GeometryType::Polygon;
+  }
+  else
+  {
+    rubberBandGeom = curveGeom;
+    geomType = Qgis::GeometryType::Line;
+  }
+
+  if ( data.geomType != geomType )
+  {
+    data.rubberBandZMin.reset();
+    data.rubberBandZMax.reset();
+    data.rubberBandSideLines.clear();
+    data.geomType = geomType;
+  }
+
+  if ( !data.rubberBandZMin )
+  {
+    data.rubberBandZMin = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), geomType );
+    data.rubberBandZMin->setColor( QColor( 200, 200, 200, 200 ) );
+    data.rubberBandZMin->setOutlineColor( QColor( 200, 200, 200, 200 ) );
+    data.rubberBandZMin->setWidth( 3 );
+    data.rubberBandZMin->setMarkersEnabled( false );
+    data.rubberBandZMin->setFillEnabled( false );
+  }
+
+  if ( !data.rubberBandZMax )
+  {
+    data.rubberBandZMax = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), geomType );
+    data.rubberBandZMax->setColor( QColor( 200, 200, 200, 200 ) );
+    data.rubberBandZMax->setOutlineColor( QColor( 200, 200, 200, 200 ) );
+    data.rubberBandZMax->setWidth( 3 );
+    data.rubberBandZMax->setMarkersEnabled( false );
+    data.rubberBandZMax->setFillEnabled( false );
+  }
+
+  QgsGeometry geomZMin = rubberBandGeom;
+  QgsGeometry geomZMax = rubberBandGeom;
+
+  QgsAbstractGeometry *gZMin = geomZMin.get();
+  gZMin->addZValue( data.zMin );
+
+  QgsAbstractGeometry *gZMax = geomZMax.get();
+  gZMax->addZValue( data.zMax );
+
+  data.rubberBandZMin->setGeometry( geomZMin );
+  data.rubberBandZMax->setGeometry( geomZMax );
+
+  QVector<QgsPointXY> sidePoints; // used to construct vertical lines at the sides of the bottom/top polygons
+  if ( tolerance > 0 )
+  {
+    const int numCurvePoints = curve->numPoints();
+
+    // vertical lines at the beggining
+    QgsPoint pt1 = curve->vertexAt( QgsVertexId( 0, 0, 0 ) );
+    QgsPoint pt2 = curve->vertexAt( QgsVertexId( 0, 0, 1 ) );
+
+    double x, y;
+    QgsGeometryUtilsBase::perpendicularOffsetPointAlongSegment( pt1.x(), pt1.y(), pt2.x(), pt2.y(), 0.0, tolerance, &x, &y );
+    sidePoints.append( QgsPointXY( x, y ) );
+
+    QgsGeometryUtilsBase::perpendicularOffsetPointAlongSegment( pt1.x(), pt1.y(), pt2.x(), pt2.y(), 0.0, -tolerance, &x, &y );
+    sidePoints.append( QgsPointXY( x, y ) );
+
+    // we want only one vertical line at the arch middle point (where the curve bends, if curve is made out of multiple lines)
+    for ( int i = 1; i < numCurvePoints - 1; i++ )
+    {
+      const QgsPoint vertexPrevious = curve->vertexAt( QgsVertexId( 0, 0, i - 1 ) );
+      const QgsPoint vertexMiddle = curve->vertexAt( QgsVertexId( 0, 0, i ) );
+      const QgsPoint vertexNext = curve->vertexAt( QgsVertexId( 0, 0, i + 1 ) );
+
+      const double anglePreviousMiddle = QgsGeometryUtilsBase::lineAngle( vertexPrevious.x(), vertexPrevious.y(), vertexMiddle.x(), vertexMiddle.y() );
+      const double angleMiddleNext = QgsGeometryUtilsBase::lineAngle( vertexMiddle.x(), vertexMiddle.y(), vertexNext.x(), vertexNext.y() );
+
+      const double averageAngle = QgsGeometryUtilsBase::averageAngle( anglePreviousMiddle, angleMiddleNext ) - M_PI_2;
+      const double dx = std::sin( averageAngle );
+      const double dy = std::cos( averageAngle );
+
+      const double turnAngle = QgsGeometryUtilsBase::normalizedAngle( angleMiddleNext - anglePreviousMiddle );
+      const double angleHalf = turnAngle < M_PI ? turnAngle * 0.5 : ( 2.0 * M_PI - turnAngle ) * 0.5;
+
+      const double miter = tolerance / std::cos( angleHalf );
+
+      const double left = turnAngle < M_PI ? tolerance : miter;
+      const double right = turnAngle < M_PI ? miter : tolerance;
+
+      sidePoints.append( QgsPointXY( vertexMiddle.x() + dx * left, vertexMiddle.y() + dy * left ) );
+      sidePoints.append( QgsPointXY( vertexMiddle.x() - dx * right, vertexMiddle.y() - dy * right ) );
+    }
+
+    // vertical lines at the end
+    pt1 = curve->vertexAt( QgsVertexId( 0, 0, numCurvePoints - 2 ) );
+    pt2 = curve->vertexAt( QgsVertexId( 0, 0, numCurvePoints - 1 ) );
+
+    QgsGeometryUtilsBase::perpendicularOffsetPointAlongSegment( pt1.x(), pt1.y(), pt2.x(), pt2.y(), 1.0, tolerance, &x, &y );
+    sidePoints.append( QgsPointXY( x, y ) );
+
+    QgsGeometryUtilsBase::perpendicularOffsetPointAlongSegment( pt1.x(), pt1.y(), pt2.x(), pt2.y(), 1.0, -tolerance, &x, &y );
+    sidePoints.append( QgsPointXY( x, y ) );
+  }
+  else // not a polygon, so we just construct vertical lines at each vertex of the curve
+  {
+    for ( auto vertex = rubberBandGeom.vertices_begin(); vertex != rubberBandGeom.vertices_end(); vertex++ )
+    {
+      sidePoints.append( QgsPointXY( ( *vertex ).x(), ( *vertex ).y() ) );
+    }
+  }
+
+  data.rubberBandSideLines.resize( sidePoints.size() );
+
+  // construct vertical lines from zMin to zMax
+  for ( qsizetype i = 0; i < sidePoints.size(); i++ )
+  {
+    const QgsPointXY &point = sidePoints[i];
+
+    QgsGeometry lineGeom( new QgsLineString( QVector<QgsPoint> {
+      QgsPoint( point.x(), point.y(), data.zMin ),
+      QgsPoint( point.x(), point.y(), data.zMax ),
+    } ) );
+
+    if ( !data.rubberBandSideLines[i] )
+    {
+      data.rubberBandSideLines[i] = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Line );
+      data.rubberBandSideLines[i]->setColor( QColor( 200, 200, 200, 150 ) );
+      data.rubberBandSideLines[i]->setWidth( 3 );
+      data.rubberBandSideLines[i]->setMarkersEnabled( false );
+    }
+
+    data.rubberBandSideLines[i]->setGeometry( lineGeom );
+  }
 }
 
 //

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1533,7 +1533,7 @@ void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profil
   }
   else
   {
-    rubberBandGeom = curveGeom;
+    rubberBandGeom = QgsGeometry( curve->curveToLine() );
     geomType = Qgis::GeometryType::Line;
   }
 

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1389,12 +1389,6 @@ void Qgs3DMapCanvasWidget::updateCheckedActionsFromMapSettings( const Qgs3DMapSe
   whileBlocking( mActionShow2DMapOverlay )->setChecked( mapSettings->is2DMapOverlayEnabled() );
 }
 
-void Qgs3DMapCanvasWidget::onProfileDestroyed( QObject *obj )
-{
-  if ( QgsElevationProfile *profile = static_cast<QgsElevationProfile *>( obj ) )
-    mElevationProfileData.erase( profile );
-}
-
 void Qgs3DMapCanvasWidget::updateProfileCursorPosition( QgsElevationProfile *profile, const QgsPointXY &mapPoint, const QgsProfilePoint &profilePoint )
 {
   if ( !mCanvas || !mElevationProfileData.contains( profile ) )
@@ -1418,10 +1412,12 @@ void Qgs3DMapCanvasWidget::updateProfileCursorPosition( QgsElevationProfile *pro
     data.cursorLineRubberBand->setMarkersEnabled( false );
   }
 
-  QgsGeometry cursorGeom( new QgsLineString( QVector<QgsPoint> {
-    QgsPoint( mapPoint.x(), mapPoint.y(), data.zMin ),
-    QgsPoint( mapPoint.x(), mapPoint.y(), data.zMax ),
-  } ) );
+  QgsGeometry cursorGeom( new QgsLineString(
+    QVector<QgsPoint> {
+      QgsPoint( mapPoint.x(), mapPoint.y(), data.zMin ),
+      QgsPoint( mapPoint.x(), mapPoint.y(), data.zMax ),
+    }
+  ) );
   data.cursorLineRubberBand->setGeometry( cursorGeom );
 
   // we need to properly rotate the curve depending on where it is
@@ -1457,13 +1453,15 @@ void Qgs3DMapCanvasWidget::updateProfileCursorPosition( QgsElevationProfile *pro
   const double x = mapPoint.x();
   const double y = mapPoint.y();
 
-  QgsGeometry polyGeom( new QgsPolygon( new QgsLineString( QVector<QgsPoint> {
-    QgsPoint( x + normalX, y + normalY, data.zMin ),
-    QgsPoint( x - normalX, y - normalY, data.zMin ),
-    QgsPoint( x - normalX, y - normalY, data.zMax ),
-    QgsPoint( x + normalX, y + normalY, data.zMax ),
-    QgsPoint( x + normalX, y + normalY, data.zMin ),
-  } ) ) );
+  QgsGeometry polyGeom( new QgsPolygon( new QgsLineString(
+    QVector<QgsPoint> {
+      QgsPoint( x + normalX, y + normalY, data.zMin ),
+      QgsPoint( x - normalX, y - normalY, data.zMin ),
+      QgsPoint( x - normalX, y - normalY, data.zMax ),
+      QgsPoint( x + normalX, y + normalY, data.zMax ),
+      QgsPoint( x + normalX, y + normalY, data.zMin ),
+    }
+  ) ) );
 
   if ( !data.cursorPolygonRubberBand )
   {
@@ -1498,11 +1496,26 @@ void Qgs3DMapCanvasWidget::setProfileData( QgsElevationProfile *profile, double 
   profileData.zMax = zMax;
   mElevationProfileData[profile] = std::move( profileData );
 
-  connect( profile, &QgsElevationProfile::profileCurveChanged, this, [this, profile] { updateProfileRubberBands( profile ); } );
-  connect( profile, &QgsElevationProfile::toleranceChanged, this, [this, profile] { updateProfileRubberBands( profile ); } );
-  connect( profile, &QObject::destroyed, this, &Qgs3DMapCanvasWidget::onProfileDestroyed );
+  connect( profile, &QObject::destroyed, this, [this, profile] { mElevationProfileData.erase( profile ); } );
 
   updateProfileRubberBands( profile );
+}
+
+void Qgs3DMapCanvasWidget::removeProfileData( QgsElevationProfile *profile )
+{
+  hideProfileRubberBands( profile );
+  mElevationProfileData.erase( profile );
+}
+
+void Qgs3DMapCanvasWidget::hideProfileRubberBands( QgsElevationProfile *profile )
+{
+  if ( mElevationProfileData.contains( profile ) )
+  {
+    ElevationProfileData &data = mElevationProfileData[profile];
+    data.rubberBandZMin.reset();
+    data.rubberBandZMax.reset();
+    data.rubberBandSideLines.clear();
+  }
 }
 
 void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profile )
@@ -1644,10 +1657,12 @@ void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profil
   {
     const QgsPointXY &point = sidePoints[i];
 
-    QgsGeometry lineGeom( new QgsLineString( QVector<QgsPoint> {
-      QgsPoint( point.x(), point.y(), data.zMin ),
-      QgsPoint( point.x(), point.y(), data.zMax ),
-    } ) );
+    QgsGeometry lineGeom( new QgsLineString(
+      QVector<QgsPoint> {
+        QgsPoint( point.x(), point.y(), data.zMin ),
+        QgsPoint( point.x(), point.y(), data.zMax ),
+      }
+    ) );
 
     if ( !data.rubberBandSideLines[i] )
     {

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1424,8 +1424,16 @@ void Qgs3DMapCanvasWidget::updateProfileCursorPosition( QgsElevationProfile *pro
   } ) );
   data.cursorLineRubberBand->setGeometry( cursorGeom );
 
-  std::unique_ptr<QgsPoint> p0( curve->interpolatePoint( profilePoint.distance() ) );
-  std::unique_ptr<QgsPoint> p1( curve->interpolatePoint( curve->length() ) );
+  // we need to properly rotate the curve depending on where it is
+  const double curveLength = curve->length();
+  const double offset = std::min( 0.1, curveLength * 0.001 );
+  const double profilePointDistance = profilePoint.distance();
+
+  const double d0 = std::max( 0.0, profilePointDistance - offset );
+  const double d1 = std::min( curveLength, profilePointDistance + offset );
+
+  std::unique_ptr<QgsPoint> p0( curve->interpolatePoint( d0 ) );
+  std::unique_ptr<QgsPoint> p1( curve->interpolatePoint( d1 ) );
 
   if ( !p0 || !p1 )
   {

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1526,6 +1526,9 @@ void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profil
   ElevationProfileData &data = mElevationProfileData[profile];
 
   QgsCurve *curve = profile->profileCurve();
+  if ( curve )
+    ( void ) curve->removeDuplicateNodes();
+
   if ( !curve )
   {
     data.rubberBandZMin.reset();
@@ -1606,24 +1609,23 @@ void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profil
     QgsGeometryUtilsBase::perpendicularOffsetPointAlongSegment( pt1.x(), pt1.y(), pt2.x(), pt2.y(), 0.0, -tolerance, &x, &y );
     sidePoints.append( QgsPointXY( x, y ) );
 
-    // we want only one vertical line at the arch middle point (where the curve bends, if curve is made out of multiple lines)
+    // we want only one vertical line at the arc middle point (where the curve bends, if the curve is made out of multiple segments)
     for ( int i = 1; i < numCurvePoints - 1; i++ )
     {
       const QgsPoint vertexPrevious = curve->vertexAt( QgsVertexId( 0, 0, i - 1 ) );
       const QgsPoint vertexMiddle = curve->vertexAt( QgsVertexId( 0, 0, i ) );
       const QgsPoint vertexNext = curve->vertexAt( QgsVertexId( 0, 0, i + 1 ) );
 
-      const double anglePreviousMiddle = QgsGeometryUtilsBase::lineAngle( vertexPrevious.x(), vertexPrevious.y(), vertexMiddle.x(), vertexMiddle.y() );
-      const double angleMiddleNext = QgsGeometryUtilsBase::lineAngle( vertexMiddle.x(), vertexMiddle.y(), vertexNext.x(), vertexNext.y() );
-
-      const double averageAngle = QgsGeometryUtilsBase::averageAngle( anglePreviousMiddle, angleMiddleNext ) - M_PI_2;
+      const double averageAngle = QgsGeometryUtilsBase::averageAngle( vertexPrevious.x(), vertexPrevious.y(), vertexMiddle.x(), vertexMiddle.y(), vertexNext.x(), vertexNext.y() ) - M_PI_2;
       const double dx = std::sin( averageAngle );
       const double dy = std::cos( averageAngle );
 
-      const double turnAngle = QgsGeometryUtilsBase::normalizedAngle( angleMiddleNext - anglePreviousMiddle );
+      const double angleBetweenPoints = QgsGeometryUtilsBase::angleBetweenThreePoints( vertexPrevious.x(), vertexPrevious.y(), vertexMiddle.x(), vertexMiddle.y(), vertexNext.x(), vertexNext.y() );
+      const double turnAngle = QgsGeometryUtilsBase::normalizedAngle( angleBetweenPoints - M_PI );
       const double angleHalf = turnAngle < M_PI ? turnAngle * 0.5 : ( 2.0 * M_PI - turnAngle ) * 0.5;
 
-      const double miter = tolerance / std::cos( angleHalf );
+      const double cosAngleHalf = std::cos( angleHalf );
+      const double miter = std::abs( cosAngleHalf ) > 1e-10 ? tolerance / cosAngleHalf : tolerance;
 
       const double left = turnAngle < M_PI ? tolerance : miter;
       const double right = turnAngle < M_PI ? miter : tolerance;

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1526,9 +1526,6 @@ void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profil
   ElevationProfileData &data = mElevationProfileData[profile];
 
   QgsCurve *curve = profile->profileCurve();
-  if ( curve )
-    ( void ) curve->removeDuplicateNodes();
-
   if ( !curve )
   {
     data.rubberBandZMin.reset();
@@ -1615,6 +1612,9 @@ void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profil
       const QgsPoint vertexPrevious = curve->vertexAt( QgsVertexId( 0, 0, i - 1 ) );
       const QgsPoint vertexMiddle = curve->vertexAt( QgsVertexId( 0, 0, i ) );
       const QgsPoint vertexNext = curve->vertexAt( QgsVertexId( 0, 0, i + 1 ) );
+
+      if ( vertexMiddle == vertexPrevious || vertexMiddle == vertexNext )
+        continue;
 
       const double averageAngle = QgsGeometryUtilsBase::averageAngle( vertexPrevious.x(), vertexPrevious.y(), vertexMiddle.x(), vertexMiddle.y(), vertexNext.x(), vertexNext.y() ) - M_PI_2;
       const double dx = std::sin( averageAngle );

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1447,19 +1447,19 @@ void Qgs3DMapCanvasWidget::updateProfileCursorPosition( QgsElevationProfile *pro
   dy /= length;
 
   const double tolerance = profile->tolerance();
-  const double normalX = -dy * tolerance;
-  const double normalY = dx * tolerance;
+  const double nX = -dy * tolerance;
+  const double nY = dx * tolerance;
 
   const double x = mapPoint.x();
   const double y = mapPoint.y();
 
   QgsGeometry polyGeom( new QgsPolygon( new QgsLineString(
     QVector<QgsPoint> {
-      QgsPoint( x + normalX, y + normalY, data.zMin ),
-      QgsPoint( x - normalX, y - normalY, data.zMin ),
-      QgsPoint( x - normalX, y - normalY, data.zMax ),
-      QgsPoint( x + normalX, y + normalY, data.zMax ),
-      QgsPoint( x + normalX, y + normalY, data.zMin ),
+      QgsPoint( x + nX, y + nY, data.zMin ),
+      QgsPoint( x - nX, y - nY, data.zMin ),
+      QgsPoint( x - nX, y - nY, data.zMax ),
+      QgsPoint( x + nX, y + nY, data.zMax ),
+      QgsPoint( x + nX, y + nY, data.zMin ),
     }
   ) ) );
 
@@ -1595,7 +1595,7 @@ void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profil
   {
     const int numCurvePoints = curve->numPoints();
 
-    // vertical lines at the beggining
+    // vertical lines at the beginning
     QgsPoint pt1 = curve->vertexAt( QgsVertexId( 0, 0, 0 ) );
     QgsPoint pt2 = curve->vertexAt( QgsVertexId( 0, 0, 1 ) );
 

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -50,11 +50,14 @@ class QgsMapCanvas;
 class QgsDockableWidgetHelper;
 class QgsMessageBar;
 class QgsRubberBand;
+class QgsRubberBand3D;
 class QgsDoubleSpinBox;
 class Qgs3DMapClippingToleranceWidgetSettingsAction;
 class QgsSettingsEntryDouble;
 class QgsSettingsEntryBool;
 class QgsGeometry;
+class QgsElevationProfile;
+class QgsProfilePoint;
 
 //! Helper validator for classification classes
 class ClassValidator : public QValidator
@@ -110,6 +113,10 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
 
     void nudgeCurve( Qgis::BufferSide side );
 
+    void setProfileData( QgsElevationProfile *profile, double zMin, double zMax );
+
+    void updateProfileCursorPosition( QgsElevationProfile *profile, const QgsPointXY &mapPoint, const QgsProfilePoint &profilePoint );
+
   private slots:
     void resetView();
     void configure();
@@ -158,6 +165,8 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     void setClippingTolerance( double tolerance );
     void lockCrossSectionTolerance( bool enabled );
     void updateClippingRubberBand();
+    void updateProfileRubberBands( QgsElevationProfile *profile );
+    void onProfileDestroyed( QObject *profile );
 
     QString mCanvasName;
     Qgs3DMapCanvas *mCanvas = nullptr;
@@ -233,6 +242,20 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     Qgs3DMapClippingToleranceWidgetSettingsAction *mClippingToleranceAction = nullptr;
 
     QMenu *mToolbarMenu = nullptr;
+
+    struct ElevationProfileData
+    {
+        std::unique_ptr<QgsRubberBand3D> rubberBandZMin;
+        std::unique_ptr<QgsRubberBand3D> rubberBandZMax;
+        std::vector<std::unique_ptr<QgsRubberBand3D>> rubberBandSideLines;
+        std::unique_ptr<QgsRubberBand3D> cursorLineRubberBand;
+        std::unique_ptr<QgsRubberBand3D> cursorPolygonRubberBand;
+        Qgis::GeometryType geomType = Qgis::GeometryType::Line; // used for rubberBandZMin and ZMax
+        double zMin = 0;
+        double zMax = 0;
+    };
+
+    std::unordered_map<QgsElevationProfile *, ElevationProfileData> mElevationProfileData;
 };
 
 class Qgs3DMapClippingToleranceWidgetSettingsAction : public QWidgetAction

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -115,6 +115,8 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
 
     void setProfileData( QgsElevationProfile *profile, double zMin, double zMax );
 
+    void removeProfileData( QgsElevationProfile *profile );
+
     void updateProfileCursorPosition( QgsElevationProfile *profile, const QgsPointXY &mapPoint, const QgsProfilePoint &profilePoint );
 
   private slots:
@@ -166,7 +168,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     void lockCrossSectionTolerance( bool enabled );
     void updateClippingRubberBand();
     void updateProfileRubberBands( QgsElevationProfile *profile );
-    void onProfileDestroyed( QObject *profile );
+    void hideProfileRubberBands( QgsElevationProfile *profile );
 
     QString mCanvasName;
     Qgs3DMapCanvas *mCanvas = nullptr;

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -82,7 +82,6 @@ using namespace Qt::StringLiterals;
 
 const QgsSettingsEntryDouble *QgsElevationProfileWidget::settingTolerance
   = new QgsSettingsEntryDouble( u"tolerance"_s, QgsSettingsTree::sTreeElevationProfile, 0.1, u"Tolerance distance for elevation profile plots"_s, Qgis::SettingsOptions(), 0 );
-
 const QgsSettingsEntryBool *QgsElevationProfileWidget::settingShowLayerTree
   = new QgsSettingsEntryBool( u"show-layer-tree"_s, QgsSettingsTree::sTreeElevationProfile, true, u"Whether the layer tree should be shown for elevation profile plots"_s );
 const QgsSettingsEntryBool *QgsElevationProfileWidget::settingLockAxis
@@ -95,6 +94,9 @@ const QgsSettingsEntryBool *QgsElevationProfileWidget::settingShowSubsections
   = new QgsSettingsEntryBool( u"show-sub-sections"_s, QgsSettingsTree::sTreeElevationProfile, false, u"Whether to display subsections"_s );
 const QgsSettingsEntryBool *QgsElevationProfileWidget::settingShowScaleRatioInToolbar
   = new QgsSettingsEntryBool( u"show-scale-ratio-in-toolbar"_s, QgsSettingsTree::sTreeElevationProfile, false, u"If true, the scale ratio widget will be moved to the toolbar instead of the options menu"_s );
+const QgsSettingsEntryBool *QgsElevationProfileWidget::settingShowCurveIn3D
+  = new QgsSettingsEntryBool( u"show-curve-3d"_s, QgsSettingsTree::sTreeElevationProfile, false, u"Whether to display curve in 3D map"_s );
+
 //
 // QgsElevationProfileLayersDialog
 //
@@ -466,6 +468,29 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
   connect( mShowSubsectionsAction, &QAction::triggered, this, &QgsElevationProfileWidget::showSubsectionsTriggered );
   mOptionsMenu->addAction( mShowSubsectionsAction );
 
+#ifdef HAVE_3D
+  mShowCurveIn3DAction = new QAction( tr( "Show Curve in 3D" ), this );
+  mShowCurveIn3DAction->setCheckable( true );
+  mShowCurveIn3DAction->setChecked( settingShowCurveIn3D->value() );
+  connect( mShowCurveIn3DAction, &QAction::triggered, this, &QgsElevationProfileWidget::updateCurveIn3D );
+  mOptionsMenu->addAction( mShowCurveIn3DAction );
+
+  connect( mProfile, &QgsElevationProfile::profileCurveChanged, this, [this] {
+    if ( mShowCurveIn3DAction->isChecked() )
+    {
+      const QgsDoubleRange elevationRange = mCanvas->dataElevationRange();
+      emit profileDataChanged( mProfile, elevationRange.lower(), elevationRange.upper() );
+    }
+  } );
+  connect( mProfile, &QgsElevationProfile::toleranceChanged, this, [this] {
+    if ( mShowCurveIn3DAction->isChecked() )
+    {
+      const QgsDoubleRange elevationRange = mCanvas->dataElevationRange();
+      emit profileDataChanged( mProfile, elevationRange.lower(), elevationRange.upper() );
+    }
+  } );
+#endif
+
   // Edit Subsections Symbology action
   mSubsectionsSymbologyAction = new QAction( tr( "Subsections Symbology…" ), this );
   mSubsectionsSymbologyAction->setEnabled( settingShowSubsections->value() );
@@ -526,7 +551,11 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
   QToolButton *toggleButton = mDockableWidgetHelper->createDockUndockToolButton();
   toggleButton->setToolTip( tr( "Dock Elevation Profile View" ) );
   toolBar->addWidget( toggleButton );
-  connect( mDockableWidgetHelper, &QgsDockableWidgetHelper::closed, this, [this]() { close(); } );
+  connect( mDockableWidgetHelper, &QgsDockableWidgetHelper::closed, this, [this]() {
+    if ( mProfile && mShowCurveIn3DAction && mShowCurveIn3DAction->isChecked() )
+      emit profileDataRemoved( mProfile );
+    close();
+  } );
 
   if ( settingShowScaleRatioInToolbar->value() )
   {
@@ -906,11 +935,7 @@ void QgsElevationProfileWidget::onTotalPendingJobsCountChanged( int count )
     mLastJobTimeSeconds = mLastJobTime.elapsed() / 1000.0;
     mProgressPendingJobs->setVisible( false );
 
-    if ( mProfile )
-    {
-      const QgsDoubleRange elevationRange = mCanvas->dataElevationRange();
-      emit profileDataChanged( mProfile, elevationRange.lower(), elevationRange.upper() );
-    }
+    updateCurveIn3D();
   }
 }
 
@@ -1306,6 +1331,29 @@ void QgsElevationProfileWidget::editSubsectionsSymbology()
       mProfile->setSubsectionsSymbol( mSubsectionsSymbol->clone() );
     }
     showSubsectionsTriggered();
+  }
+}
+
+void QgsElevationProfileWidget::updateCurveIn3D()
+{
+  if ( !mShowCurveIn3DAction )
+    return;
+
+  const bool showCurveIn3D = mShowCurveIn3DAction->isChecked();
+
+  settingShowCurveIn3D->setValue( showCurveIn3D );
+
+  if ( !mProfile )
+    return;
+
+  if ( showCurveIn3D )
+  {
+    const QgsDoubleRange elevationRange = mCanvas->dataElevationRange();
+    emit profileDataChanged( mProfile, elevationRange.lower(), elevationRange.upper() );
+  }
+  else
+  {
+    emit profileDataRemoved( mProfile );
   }
 }
 

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -905,6 +905,12 @@ void QgsElevationProfileWidget::onTotalPendingJobsCountChanged( int count )
     mJobProgressBarTimer.stop();
     mLastJobTimeSeconds = mLastJobTime.elapsed() / 1000.0;
     mProgressPendingJobs->setVisible( false );
+
+    if ( mProfile )
+    {
+      const QgsDoubleRange elevationRange = mCanvas->dataElevationRange();
+      emit profileDataChanged( mProfile, elevationRange.lower(), elevationRange.upper() );
+    }
   }
 }
 
@@ -944,11 +950,13 @@ void QgsElevationProfileWidget::onCanvasPointHovered( const QgsPointXY &, const 
   if ( mapPoint.isEmpty() )
   {
     mMapPointRubberBand->hide();
+    emit profileCursorMoved( mProfile, QgsPointXY(), profilePoint );
   }
   else
   {
     mMapPointRubberBand->setToGeometry( mapPoint );
     mMapPointRubberBand->show();
+    emit profileCursorMoved( mProfile, QgsPointXY( mapPoint.asPoint() ), profilePoint );
   }
 }
 

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -469,7 +469,7 @@ QgsElevationProfileWidget::QgsElevationProfileWidget( QgsElevationProfile *profi
   mOptionsMenu->addAction( mShowSubsectionsAction );
 
 #ifdef HAVE_3D
-  mShowCurveIn3DAction = new QAction( tr( "Show Curve in 3D" ), this );
+  mShowCurveIn3DAction = new QAction( tr( "Show Profile in 3D Views" ), this );
   mShowCurveIn3DAction->setCheckable( true );
   mShowCurveIn3DAction->setChecked( settingShowCurveIn3D->value() );
   connect( mShowCurveIn3DAction, &QAction::triggered, this, &QgsElevationProfileWidget::updateCurveIn3D );

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -123,6 +123,8 @@ class APP_EXPORT QgsElevationProfileWidget : public QWidget
 
   signals:
     void toggleDockModeRequested( bool docked );
+    void profileDataChanged( QgsElevationProfile *profile, double zMin, double zMax );
+    void profileCursorMoved( QgsElevationProfile *profile, const QgsPointXY &mapPoint, const QgsProfilePoint &profilePoint );
 
   private slots:
     void addLayers();

--- a/src/app/elevation/qgselevationprofilewidget.h
+++ b/src/app/elevation/qgselevationprofilewidget.h
@@ -101,6 +101,7 @@ class APP_EXPORT QgsElevationProfileWidget : public QWidget
     static const QgsSettingsEntryColor *settingBackgroundColor;
     static const QgsSettingsEntryBool *settingShowSubsections;
     static const QgsSettingsEntryBool *settingShowScaleRatioInToolbar;
+    static const QgsSettingsEntryBool *settingShowCurveIn3D;
 
     QgsElevationProfileWidget( QgsElevationProfile *profile, QgsMapCanvas *canvas );
     ~QgsElevationProfileWidget() override;
@@ -124,7 +125,11 @@ class APP_EXPORT QgsElevationProfileWidget : public QWidget
   signals:
     void toggleDockModeRequested( bool docked );
     void profileDataChanged( QgsElevationProfile *profile, double zMin, double zMax );
+    void profileDataRemoved( QgsElevationProfile *profile );
     void profileCursorMoved( QgsElevationProfile *profile, const QgsPointXY &mapPoint, const QgsProfilePoint &profilePoint );
+
+  public slots:
+    void updateCurveIn3D();
 
   private slots:
     void addLayers();
@@ -174,6 +179,7 @@ class APP_EXPORT QgsElevationProfileWidget : public QWidget
     QAction *mRenameProfileAction = nullptr;
     QAction *mLockRatioAction = nullptr;
     QAction *mShowSubsectionsAction = nullptr;
+    QAction *mShowCurveIn3DAction = nullptr;
     QAction *mSubsectionsSymbologyAction = nullptr;
     QAction *mSyncLayerTreeAction = nullptr;
     QAction *mActionAddGroup = nullptr;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13426,7 +13426,9 @@ Qgs3DMapCanvasWidget *QgisApp::createNew3DMapCanvasDock( const QString &name, bo
   for ( QgsElevationProfileWidget *profileWidget : std::as_const( mElevationProfileWidgets ) )
   {
     connect( profileWidget, &QgsElevationProfileWidget::profileDataChanged, widget, &Qgs3DMapCanvasWidget::setProfileData );
+    connect( profileWidget, &QgsElevationProfileWidget::profileDataRemoved, widget, &Qgs3DMapCanvasWidget::removeProfileData );
     connect( profileWidget, &QgsElevationProfileWidget::profileCursorMoved, widget, &Qgs3DMapCanvasWidget::updateProfileCursorPosition );
+    profileWidget->updateCurveIn3D();
   }
 
   return widget;
@@ -13473,6 +13475,7 @@ QgsElevationProfileWidget *QgisApp::openElevationProfile( QgsElevationProfile *p
   for ( Qgs3DMapCanvasWidget *canvasWidget : std::as_const( mOpen3DMapViews ) )
   {
     connect( widget, &QgsElevationProfileWidget::profileDataChanged, canvasWidget, &Qgs3DMapCanvasWidget::setProfileData );
+    connect( widget, &QgsElevationProfileWidget::profileDataRemoved, canvasWidget, &Qgs3DMapCanvasWidget::removeProfileData );
     connect( widget, &QgsElevationProfileWidget::profileCursorMoved, canvasWidget, &Qgs3DMapCanvasWidget::updateProfileCursorPosition );
   }
 #endif

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13423,6 +13423,12 @@ Qgs3DMapCanvasWidget *QgisApp::createNew3DMapCanvasDock( const QString &name, bo
   widget->setMainCanvas( mMapCanvas );
   widget->mapCanvas3D()->setTemporalController( mTemporalControllerWidget->temporalController() );
 
+  for ( QgsElevationProfileWidget *profileWidget : std::as_const( mElevationProfileWidgets ) )
+  {
+    connect( profileWidget, &QgsElevationProfileWidget::profileDataChanged, widget, &Qgs3DMapCanvasWidget::setProfileData );
+    connect( profileWidget, &QgsElevationProfileWidget::profileCursorMoved, widget, &Qgs3DMapCanvasWidget::updateProfileCursorPosition );
+  }
+
   return widget;
 #else
   Q_UNUSED( name );
@@ -13461,6 +13467,15 @@ QgsElevationProfileWidget *QgisApp::openElevationProfile( QgsElevationProfile *p
   QgsElevationProfileWidget *widget = new QgsElevationProfileWidget( profile, mMapCanvas );
 
   connect( widget, &QgsElevationProfileWidget::destroyed, this, [this, widget] { mElevationProfileWidgets.remove( widget ); } );
+
+#ifdef HAVE_3D
+  // Connect the new elevation profile widget's signals to all open 3D map views
+  for ( Qgs3DMapCanvasWidget *canvasWidget : std::as_const( mOpen3DMapViews ) )
+  {
+    connect( widget, &QgsElevationProfileWidget::profileDataChanged, canvasWidget, &Qgs3DMapCanvasWidget::setProfileData );
+    connect( widget, &QgsElevationProfileWidget::profileCursorMoved, canvasWidget, &Qgs3DMapCanvasWidget::updateProfileCursorPosition );
+  }
+#endif
 
   mElevationProfileWidgets.insert( widget );
 

--- a/src/core/elevation/qgselevationprofile.cpp
+++ b/src/core/elevation/qgselevationprofile.cpp
@@ -174,6 +174,7 @@ void QgsElevationProfile::setProfileCurve( QgsCurve *curve )
     return;
   mProfileCurve.reset( curve );
   dirtyProject();
+  emit profileCurveChanged();
 }
 
 QgsCurve *QgsElevationProfile::profileCurve() const
@@ -188,6 +189,7 @@ void QgsElevationProfile::setTolerance( double tolerance )
 
   mTolerance = tolerance;
   dirtyProject();
+  emit toleranceChanged( mTolerance );
 }
 
 double QgsElevationProfile::tolerance() const

--- a/src/core/elevation/qgselevationprofile.h
+++ b/src/core/elevation/qgselevationprofile.h
@@ -251,6 +251,26 @@ class CORE_EXPORT QgsElevationProfile : public QObject
      */
     void useProjectLayerTreeChanged( bool useProjectTree );
 
+    /**
+     * Emitted when the profile curve is changed.
+     *
+     * \see profileCurve()
+     * \see setProfileCurve()
+     *
+     * \since QGIS 4.2
+     */
+    void profileCurveChanged();
+
+    /**
+     * Emitted when the profile tolerance is changed.
+     *
+     * \see tolerance()
+     * \see setTolerance()
+     *
+     * \since QGIS 4.2
+     */
+    void toleranceChanged( double tolerance );
+
   private slots:
 
     void dirtyProject();

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -1440,6 +1440,13 @@ QgsDoubleRange QgsElevationProfileCanvas::visibleElevationRange() const
   return QgsDoubleRange( mPlotItem->yMinimum(), mPlotItem->yMaximum() );
 }
 
+QgsDoubleRange QgsElevationProfileCanvas::dataElevationRange() const
+{
+  if ( mCurrentJob )
+    return mCurrentJob->zRange();
+  return QgsDoubleRange();
+}
+
 const Qgs2DXyPlot &QgsElevationProfileCanvas::plot() const
 {
   return *mPlotItem;

--- a/src/gui/elevation/qgselevationprofilecanvas.h
+++ b/src/gui/elevation/qgselevationprofilecanvas.h
@@ -205,6 +205,16 @@ class GUI_EXPORT QgsElevationProfileCanvas : public QgsPlotCanvas
     QgsDoubleRange visibleElevationRange() const;
 
     /**
+     * Returns elevation range of the computed profile results.
+     *
+     * Calculated from data, not from visible extent.
+     *
+     * \see visibleElevationRange()
+     * \since QGIS 4.2
+     */
+    QgsDoubleRange dataElevationRange() const;
+
+    /**
      * Returns a reference to the 2D plot used by the widget.
      *
      * \note Not available in Python bindings


### PR DESCRIPTION
This PR enables the display of the elevation profile curve in 3D.

Curve is got from the elevation profile and Z values are set from the calculated min and max Z values of the data that is within the curve.

Polygon and line rubberbands follow the cursor to display over what position in the elevation profile the user is currently hovering over.

[target.webm](https://github.com/user-attachments/assets/d71b36a5-f25a-4a91-bdcd-846c7c9d3e34)

<img width="3183" height="1742" alt="Screenshot_20260218_104645" src="https://github.com/user-attachments/assets/18715570-4f7f-45b3-87bb-13c9f3550118" />

<img width="1181" height="549" alt="Screenshot_20260320_104034" src="https://github.com/user-attachments/assets/fccd6c69-4da7-4d5b-b4f4-5539e0b3eb12" />


