### PR TITLE
[browser] Improve UX when renaming/moving database objects

### DIFF
--- a/python/PyQt6/core/auto_generated/browser/qgsfieldsitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsfieldsitem.sip.in
@@ -82,6 +82,15 @@ Creates and returns a (possibly ``None``) layer from the connection URI
 and schema/table information
 %End
 
+    QgsFields fields() const;
+%Docstring
+Returns the fields contained by the item.
+
+The fields are only populated after the item's children are created.
+
+.. versionadded:: 4.0
+%End
+
     QgsAbstractDatabaseProviderConnection::TableProperty *tableProperty() const;
 %Docstring
 Returns the (possibly ``None``) properties of the table this fields

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1466,8 +1466,15 @@ void QgsFieldItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *men
               return;
             }
 
+            const QgsFields existingFields = fieldsItem->fields();
+            QStringList existingFieldNames = existingFields.names();
+            existingFieldNames.removeAll( itemName );
+
             // Confirmation dialog
-            QgsNewNameDialog dlg( tr( "field “%1”" ).arg( itemName ), itemName );
+            QgsNewNameDialog dlg( tr( "field “%1”" ).arg( itemName ), itemName, {}, existingFieldNames );
+            dlg.setOverwriteEnabled( false );
+            dlg.setConflictingNameWarning( tr( "A field with this name already exists." ) );
+
             dlg.setWindowTitle( tr( "Rename Field" ) );
             if ( dlg.exec() != QDialog::Accepted || dlg.name() == itemName )
               return;

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -1911,8 +1911,28 @@ void QgsDatabaseItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *
 
           std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn2( qgis::down_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( connectionUri, QVariantMap() ) ) );
 
-          QgsNewNameDialog dlg( tr( "Table %1.%2" ).arg( schema, tableName ), tableName );
+          QStringList existingTableNames;
+          try
+          {
+            const QList<QgsAbstractDatabaseProviderConnection::TableProperty> existingTables = conn2->tables( schema );
+            existingTableNames.reserve( existingTables.size() );
+            for ( const QgsAbstractDatabaseProviderConnection::TableProperty &table : existingTables )
+            {
+              if ( table.tableName() != tableName )
+              {
+                existingTableNames.append( table.tableName() );
+              }
+            }
+          }
+          catch ( QgsProviderConnectionException &ex )
+          {
+            ( void ) ex;
+          }
+
+          QgsNewNameDialog dlg( tr( "Table %1.%2" ).arg( schema, tableName ), tableName, {}, existingTableNames );
           dlg.setWindowTitle( tr( "Rename Table" ) );
+          dlg.setOverwriteEnabled( false );
+          dlg.setConflictingNameWarning( tr( "A table with this name already exists." ) );
           if ( dlg.exec() != QDialog::Accepted || dlg.name() == tableName )
             return;
 

--- a/src/core/browser/qgsfieldsitem.cpp
+++ b/src/core/browser/qgsfieldsitem.cpp
@@ -81,8 +81,8 @@ QVector<QgsDataItem *> QgsFieldsItem::createChildren()
       if ( conn )
       {
         int i = 0;
-        const QgsFields constFields { conn->fields( mSchema, mTableName ) };
-        for ( const auto &f : constFields )
+        mFields = conn->fields( mSchema, mTableName );
+        for ( const QgsField &f : mFields )
         {
           QgsFieldItem *fieldItem { new QgsFieldItem( this, f ) };
           fieldItem->setSortKey( i++ );
@@ -138,6 +138,11 @@ QgsVectorLayer *QgsFieldsItem::layer()
     QgsDebugError( u"Error getting metadata for provider %1"_s.arg( providerKey() ) );
   }
   return nullptr;
+}
+
+QgsFields QgsFieldsItem::fields() const
+{
+  return mFields;
 }
 
 QgsAbstractDatabaseProviderConnection::TableProperty *QgsFieldsItem::tableProperty() const

--- a/src/core/browser/qgsfieldsitem.h
+++ b/src/core/browser/qgsfieldsitem.h
@@ -94,6 +94,15 @@ class CORE_EXPORT QgsFieldsItem : public QgsDataItem
     QgsVectorLayer *layer() SIP_FACTORY;
 
     /**
+     * Returns the fields contained by the item.
+     *
+     * The fields are only populated after the item's children are created.
+     *
+     * \since QGIS 4.0
+     */
+    QgsFields fields() const;
+
+    /**
      * Returns the (possibly NULLPTR) properties of the table this fields belong to.
      * \since QGIS 3.16
      */
@@ -113,7 +122,7 @@ class CORE_EXPORT QgsFieldsItem : public QgsDataItem
     QString mConnectionUri;
     bool mCanRename = false;
     std::unique_ptr<QgsAbstractDatabaseProviderConnection::TableProperty> mTableProperty;
-
+    QgsFields mFields;
 };
 
 

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -274,6 +274,7 @@ void QgsGeoPackageItemGuiProvider::renameVectorLayer( const QString &uri, const 
   dlg.setRegularExpression( QStringLiteral( R"re([^|]+)re" ) );
 
   dlg.setOverwriteEnabled( false );
+  dlg.setConflictingNameWarning( tr( "A table with this name already exists." ) );
 
   if ( dlg.exec() != dlg.Accepted || dlg.name().isEmpty() || dlg.name() == layerName )
     return;


### PR DESCRIPTION
(re-opens https://github.com/qgis/QGIS/pull/64978)

Don't allow renaming fields to duplicate names
Don't allow renaming tables to duplicate names
Show more user-friendly message when attempting to move schema and duplicate names exist in the target schema