### PR TITLE
[fix] Clip raster by extent/mask algorithms (avoid encoded URL inside the XML description file)

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -691,20 +691,19 @@ class GdalUtils:
                  An additional returned value provides callers with more details on an eventual write error.
         """
         # Prepare data
-        uri = layer.publicSource()
         version = QgsWmsUtils.wmsVersion(layer)
-        source = QgsProviderRegistry.instance().decodeUri("wms", uri)
-        base_url = source.get("url", "")
+        source = QgsDataSourceUri()
+        source.setEncodedUri(layer.publicSource())
+
+        base_url = source.param("url")
         crs_obj = layer.crs()
         crs_string = GdalUtils.gdal_crs_string(crs_obj)
-        image_format = source.get("format", "")
+        image_format = source.param("format")
         service = {"SERVICE": "WMS"}
-        sublayers = source["layers"] if "layers" in source and source["layers"] else []
-        if isinstance(sublayers, str):
-            sublayers = [sublayers]  # If only one layer, it is given as string
-        styles = source["styles"] if "styles" in source and source["styles"] else []
-        if isinstance(styles, str):
-            styles = [styles]  # If only one style, it is given as string
+        sublayers = source.params("layers")
+        styles = [
+            style for style in source.params("styles") if style
+        ]  # Avoid empty strings
 
         # Set up XML doc
         def add_text_element(doc, base_element, element_name, element_text):


### PR DESCRIPTION
Rationale:

`provider_metadata.decodeUri()` has changed in master (!!!), as well as `layer.publicSource()` for WMS layers (they now return encoded URLs). See e.g., comment at https://github.com/qgis/QGIS/issues/55318#issuecomment-3917239315

That means the XML description file used by the aforementioned algorithms, gets an encoded URL (e.g., `https%3A%2F%2Fplanas.frankfurt.de%2Fwms%2Fbebauungsplaene_rv_flaechennutzung`) and also an encoded FORMAT parameter (e.g., `image%2Fpng` ), **breaking** the XML interpretation.

Solution:

Rely on `QgsDataSourceUri()` instead of `provider_metadata.decodeUri()` for constructing a XML description file for WMS layers. `QgsDataSourceUri()` keeps behaving as expected, that is, returning decoded params, like URL.

---------

Funded by [City of Frankfurt – Stadtplanungsamt](https://www.stadtplanungsamt-frankfurt.de/about_us_5645.html).