### PR TITLE
[GeoPdfExport] Avoid map theme contaminate non-map-them items

### DIFF
--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1993,6 +1993,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::handleLayeredExport( const QL
           layoutItemLayerIdx++;
         }
         layerDetails.mapLayerId.clear();
+        layerDetails.mapTheme.clear();
         Q_NOWARN_DEPRECATED_PUSH
         mLayout->renderContext().setCurrentExportLayer( -1 );
         Q_NOWARN_DEPRECATED_POP

--- a/tests/src/core/testqgslayoutexporter.cpp
+++ b/tests/src/core/testqgslayoutexporter.cpp
@@ -45,6 +45,7 @@ class TestQgsLayoutExporter : public QgsTest
     void cleanup();
     void testHandleLayeredExport();
     void testHandleLayeredExportCustomGroups();
+    void testHandleLayeredExportMapTheme();
 };
 
 void TestQgsLayoutExporter::initTestCase()
@@ -515,6 +516,143 @@ void TestQgsLayoutExporter::testHandleLayeredExportCustomGroups()
 
   qDeleteAll( items );
 }
+
+void TestQgsLayoutExporter::testHandleLayeredExportMapTheme()
+{
+  QgsProject p;
+  QgsLayout l( &p );
+  l.renderContext().setExportThemes( { "Theme One", "Theme Two" } );
+  QgsLayoutExporter exporter( &l );
+
+  QList<unsigned int> layerIds;
+  QStringList layerNames;
+  QStringList mapLayerIds;
+  QStringList groupNames;
+  QStringList mapThemes;
+  QgsLayout *layout = &l;
+  auto exportFunc = [&layerIds, &layerNames, &mapLayerIds, &groupNames, &mapThemes, layout]( unsigned int layerId, const QgsLayoutItem::ExportLayerDetail &layerDetail ) -> QgsLayoutExporter::ExportResult {
+    layerIds << layerId;
+    layerNames << layerDetail.name;
+    mapLayerIds << layerDetail.mapLayerId;
+    groupNames << layerDetail.groupName;
+    mapThemes << layerDetail.mapTheme;
+    QImage im( 512, 512, QImage::Format_ARGB32_Premultiplied );
+    QPainter p( &im );
+    layout->render( &p );
+    p.end();
+
+    return QgsLayoutExporter::Success;
+  };
+  auto getExportGroupNameFunc = []( QgsLayoutItem *item ) -> QString {
+    return item->customProperty( u"pdfExportGroup"_s ).toString();
+  };
+
+  QList<QGraphicsItem *> items;
+  QStringList expectedGroupNames;
+  QgsLayoutExporter::ExportResult res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QVERIFY( layerIds.isEmpty() );
+  QVERIFY( layerNames.isEmpty() );
+  QVERIFY( groupNames.isEmpty() );
+  QVERIFY( mapLayerIds.isEmpty() );
+  QVERIFY( mapThemes.isEmpty() );
+
+  QgsLayoutItemPage *page = new QgsLayoutItemPage( &l );
+  items << page;
+  expectedGroupNames << QString();
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList<unsigned int>() << 1 );
+  QCOMPARE( layerNames, QStringList() << u"Page"_s );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() );
+  QCOMPARE( mapThemes, QStringList() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+  mapThemes.clear();
+
+  QgsLayoutItemLabel *label = new QgsLayoutItemLabel( &l );
+  items << label;
+  expectedGroupNames << QString();
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList<unsigned int>() << 1 << 2 );
+  QCOMPARE( layerNames, QStringList() << u"Page"_s << u"Label"_s );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() );
+  QCOMPARE( mapThemes, QStringList() << QString() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+  mapThemes.clear();
+
+  QgsLayoutItemShape *shape = new QgsLayoutItemShape( &l );
+  items << shape;
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList<unsigned int>() << 1 << 2 );
+  QCOMPARE( layerNames, QStringList() << u"Page"_s << u"Label, Shape"_s );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() );
+  QCOMPARE( mapThemes, QStringList() << QString() << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+  mapThemes.clear();
+
+  // with an item which has sublayers
+  QgsVectorLayer *linesLayer = new QgsVectorLayer( TEST_DATA_DIR + u"/lines.shp"_s, u"lines"_s, u"ogr"_s );
+  QVERIFY( linesLayer->isValid() );
+
+  p.addMapLayer( linesLayer );
+
+  QgsLayoutItemMap *map = new QgsLayoutItemMap( &l );
+  map->attemptSetSceneRect( QRectF( 20, 20, 200, 100 ) );
+  map->setFrameEnabled( false );
+  map->setBackgroundEnabled( false );
+  map->setCrs( linesLayer->crs() );
+  map->zoomToExtent( linesLayer->extent() );
+  map->setLayers( QList<QgsMapLayer *>() << linesLayer );
+
+  items << map;
+  expectedGroupNames << QString() << QString();
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList<unsigned int>() << 1 << 2 << 3 << 4 );
+  QCOMPARE( layerNames, QStringList() << u"Page"_s << u"Label, Shape"_s << u"Map 1 (Theme One): lines"_s << u"Map 1 (Theme Two): lines"_s );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << linesLayer->id() << linesLayer->id() );
+  QCOMPARE( mapThemes, QStringList() << QString() << QString() << u"Theme One"_s << u"Theme Two"_s );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+  mapThemes.clear();
+
+  QgsLayoutItemLabel *label4 = new QgsLayoutItemLabel( &l );
+  items << label4;
+  label4->setCustomProperty( u"pdfExportGroup"_s, u"more labels"_s );
+  expectedGroupNames << u"more labels"_s;
+  res = exporter.handleLayeredExport( items, exportFunc, getExportGroupNameFunc );
+  QCOMPARE( res, QgsLayoutExporter::Success );
+  QCOMPARE( layerIds, QList<unsigned int>() << 1 << 2 << 3 << 4 << 5 );
+  QCOMPARE( layerNames, QStringList() << u"Page"_s << u"Label, Shape"_s << u"Map 1 (Theme One): lines"_s << u"Map 1 (Theme Two): lines"_s << u"Label"_s );
+  QCOMPARE( groupNames, expectedGroupNames );
+  QCOMPARE( mapLayerIds, QStringList() << QString() << QString() << linesLayer->id() << linesLayer->id() << QString() );
+  QCOMPARE( mapThemes, QStringList() << QString() << QString() << u"Theme One"_s << u"Theme Two"_s << QString() );
+  layerIds.clear();
+  layerNames.clear();
+  groupNames.clear();
+  mapLayerIds.clear();
+  mapThemes.clear();
+
+  qDeleteAll( items );
+}
+
 
 QGSTEST_MAIN( TestQgsLayoutExporter )
 #include "testqgslayoutexporter.moc"


### PR DESCRIPTION
As for mapLayerId, mapTheme needs to be cleared. If not, following element (like picture) would be considering in the theme while there are not.

Reported directly to me by @nicogodet

@nicogodet you'll need this one and #63580 to have a fully GeoPdfExport with themes.

**Funded by QGIS.org bug fix program**