### PR TITLE
tests: Work around gcc12 bug with c++20 edge cases

### DIFF
--- a/tests/src/core/geometry/testqgsgeometrycollection.cpp
+++ b/tests/src/core/geometry/testqgsgeometrycollection.cpp
@@ -195,8 +195,8 @@ void TestQgsGeometryCollection::geometryCollection()
   QVERIFY( !( emptyCollection == c11 ) );
   QVERIFY( emptyCollection != c11 );
   QgsPoint notCollection;
-  QVERIFY( !( emptyCollection == notCollection ) );
-  QVERIFY( emptyCollection != notCollection );
+  QVERIFY( !( ( const QgsAbstractGeometry& ) emptyCollection == notCollection ) );
+  QVERIFY( ( const QgsAbstractGeometry& ) emptyCollection != notCollection );
   QgsMultiPoint mp;
   QgsMultiLineString ml;
   QVERIFY( mp != ml );

--- a/tests/src/core/geometry/testqgslinestring.cpp
+++ b/tests/src/core/geometry/testqgslinestring.cpp
@@ -953,8 +953,8 @@ void TestQgsLineString::equality()
   QVERIFY( ls6 != QgsCircularString() );
 
   QgsPoint p1;
-  QVERIFY( !( ls6 == p1 ) );
-  QVERIFY( ls6 != p1 );
+  QVERIFY( !( ( const QgsAbstractGeometry& ) ls6 == p1 ) );
+  QVERIFY( ( const QgsAbstractGeometry& ) ls6 != p1 );
   QVERIFY( ls6 == ls6 );
 }
 

--- a/tests/src/core/geometry/testqgspoint.cpp
+++ b/tests/src/core/geometry/testqgspoint.cpp
@@ -372,9 +372,17 @@ void TestQgsPoint::equality()
 
   QVERIFY( QgsPoint( Qgis::WkbType::Point, 2 / 3.0, 1 / 3.0 ) != QgsPoint( Qgis::WkbType::PointZ, 2 / 3.0, 1 / 3.0 ) );
 
+  /*
+   * gcc12 throws an "ambiguous overload" error when there are
+   * multiple possible choices due to inheritance.  Downcast pt1 to
+   * reduce the search space.  This problem does not occur in actual
+   * code -- only in tests.  Accept a workaround because the point is
+   * to test the code, not verify that the compiler is pedantically
+   * correct.
+   */
   QgsLineString ls;
-  QVERIFY( pt1 != ls );
-  QVERIFY( !( pt1 == ls ) );
+  QVERIFY( ( const QgsAbstractGeometry& ) pt1 != ls );
+  QVERIFY( !( ( const QgsAbstractGeometry& ) pt1 == ls ) );
 }
 
 void TestQgsPoint::operators()

--- a/tests/src/core/geometry/testqgspolygon.cpp
+++ b/tests/src/core/geometry/testqgspolygon.cpp
@@ -267,8 +267,8 @@ void TestQgsPolygon::equality()
   QVERIFY( !( pl1 != pl2 ) );
 
   QgsLineString ls;
-  QVERIFY( pl1 != ls );
-  QVERIFY( !( pl1 == ls ) );
+  QVERIFY( ( const QgsAbstractGeometry& ) pl1 != ls );
+  QVERIFY( !( ( const QgsAbstractGeometry& ) pl1 == ls ) );
 }
 
 void TestQgsPolygon::clone()


### PR DESCRIPTION
There are multiple tests that, with gcc 12, get an ambiguous overload error, with the basic problem being multiple inheritance paths. Somehow, c++20 requires that this work, and gcc 13 accepts the code. (clang 15 also rejects this code, and clang 16 is ok).

Because the point is to test qgis, not compiler conformance, and because this overload pattern does not appear in the codebase (it would error if it did), downcast one side of the comparison to the base class to avoid the error.  Analysis and fix suggestion are due to Even Rouault.

With this change, the code compiles (NetBSD 10 amd64 with gcc12 and qt6), but I am not quite set up to run tests.   (I'm watching CI and tweaking.)

This does not need backporting to 3.44, which builds with gcc 10.