### PR TITLE
[MapToolCapture] When undoing, remove whole curve only when it has more than 2 vertices

### DIFF
--- a/src/gui/maptools/qgsmaptoolcapture.cpp
+++ b/src/gui/maptools/qgsmaptoolcapture.cpp
@@ -1228,7 +1228,10 @@ void QgsMapToolCapture::undo( bool isAutoRepeat )
     const QgsCoordinateTransform ct = mCanvas->mapSettings().layerTransform( layer() );
     if ( ct.isValid() && !ct.isShortCircuited() )
     {
-      mCaptureCurve.removeCurve( mCaptureCurve.nCurves() - 1 );
+      const int previousCurveIndex = mCaptureCurve.nCurves() - 1;
+      const QgsCurve *curve = mCaptureCurve.curveAt( previousCurveIndex );
+      if ( curve && curve->numPoints() > 2 )
+        mCaptureCurve.removeCurve( previousCurveIndex );
     }
     if ( mCaptureCurve.numPoints() == 2 && mCaptureCurve.nCurves() == 1 )
     {


### PR DESCRIPTION
Fixes #58813.

With https://github.com/qgis/QGIS/pull/51943, if the layer has a different CRS than the project, if you're digitizing with a curve the curve will get transformed into a line with interpolated vertices, which is why [when undoing the entire curve gets deleted in case of different CRS's](https://github.com/qgis/QGIS/blob/a624b45c2eaf6d2d21aad46f8e975267afbb3904/src/gui/maptools/qgsmaptoolcapture.cpp#L1227). However, when undoing digitized straight segments this causes the bug described in the issue.

Fix the bug by deleting the entire last curve only if actually contains a transformed curve (has more than 2 vertexes).