### PR TITLE
[ui][attribute form] When relation editor widgets are children of parent containers…

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1853,6 +1853,18 @@ void QgsAttributeForm::init()
               layout->setRowStretch( row, widgDef->verticalStretch() );
               addSpacer = false;
             }
+            else
+            {
+              if ( widgetInfo.expandingNeeded )
+              {
+                addSpacer = false;
+                widgetInfo.widget->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Expanding );
+              }
+              else
+              {
+                widgetInfo.widget->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Maximum );
+              }
+            }
 
             if ( containerDef->visibilityExpression().enabled() || containerDef->collapsedExpression().enabled() )
             {
@@ -1871,6 +1883,18 @@ void QgsAttributeForm::init()
             {
               layout->setRowStretch( row, widgDef->verticalStretch() );
               addSpacer = false;
+            }
+            else
+            {
+              if ( widgetInfo.expandingNeeded )
+              {
+                addSpacer = false;
+                widgetInfo.widget->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Expanding );
+              }
+              else
+              {
+                widgetInfo.widget->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Maximum );
+              }
             }
             if ( widgDef->horizontalStretch() > 0 && widgDef->horizontalStretch() > layout->columnStretch( column + 1 ) )
             {
@@ -1895,7 +1919,6 @@ void QgsAttributeForm::init()
             }
 
             QWidget *tabPage = new QWidget( tabWidget );
-
             tabWidget->addTab( tabPage, widgDef->name() );
             tabWidget->setTabStyle( tabWidget->tabBar()->count() - 1, widgDef->labelStyle() );
 
@@ -1907,6 +1930,11 @@ void QgsAttributeForm::init()
             tabPage->setLayout( tabPageLayout );
 
             WidgetInfo widgetInfo = createWidgetFromDef( widgDef, tabPage, mLayer, mContext );
+            if ( widgetInfo.expandingNeeded )
+            {
+              addSpacer = false;
+              widgetInfo.widget->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Expanding );
+            }
             tabPageLayout->addWidget( widgetInfo.widget );
             break;
           }
@@ -2716,6 +2744,17 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
           {
             registerContainerInformation( new ContainerInformation( widgetInfo.widget, containerDef->visibilityExpression().enabled() ? containerDef->visibilityExpression().data() : QgsExpression(), containerDef->collapsed(), containerDef->collapsedExpression().enabled() ? containerDef->collapsedExpression().data() : QgsExpression() ) );
           }
+          if ( childDef->verticalStretch() == 0 )
+          {
+            if ( widgetInfo.expandingNeeded )
+            {
+              widgetInfo.widget->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Expanding );
+            }
+            else
+            {
+              widgetInfo.widget->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Maximum );
+            }
+          }
         }
 
         // column containing the actual widget, not the label
@@ -2838,6 +2877,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
       newWidgetInfo.labelText = QString();
       newWidgetInfo.labelOnTop = true;
       newWidgetInfo.showLabel = widgetDef->showLabel();
+      newWidgetInfo.expandingNeeded |= !addSpacer;
       break;
     }
 

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -408,6 +408,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     struct WidgetInfo
     {
         QWidget *widget = nullptr;
+        bool expandingNeeded = false;
         QString labelText;
         QString toolTip;
         QString hint;


### PR DESCRIPTION
… make sure they are taking as much space as possible

This fixes an unfortunate GUI layout issue where tons of available space is not being used to expand the relation editor widget area _when_ embedded into drag and drop form containers.

Before (left) vs. PR (right):

<img width="926" height="582" alt="image" src="https://github.com/user-attachments/assets/93e94d6b-c219-470c-9436-770d079e064d" />

Same goes for the multiline edit widget:

<img width="873" height="484" alt="image" src="https://github.com/user-attachments/assets/9b40b5fe-e6f5-4290-a8d3-94d602401d1b" />

Fixes https://github.com/qgis/QGIS/issues/55817