### PR TITLE
fix incorrect selected feature count when there are non-existent feature IDs (fix #61604)

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsvectorlayerutils.py
+++ b/python/PyQt6/core/auto_additions/qgsvectorlayerutils.py
@@ -34,6 +34,7 @@ try:
     QgsVectorLayerUtils.getFeatureDisplayString = staticmethod(QgsVectorLayerUtils.getFeatureDisplayString)
     QgsVectorLayerUtils.impactsCascadeFeatures = staticmethod(QgsVectorLayerUtils.impactsCascadeFeatures)
     QgsVectorLayerUtils.guessFriendlyIdentifierField = staticmethod(QgsVectorLayerUtils.guessFriendlyIdentifierField)
+    QgsVectorLayerUtils.filterValidFeatureIds = staticmethod(QgsVectorLayerUtils.filterValidFeatureIds)
     QgsVectorLayerUtils.fieldToDataArray = staticmethod(QgsVectorLayerUtils.fieldToDataArray)
     QgsVectorLayerUtils.__group__ = ['vector']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -715,17 +715,15 @@ clearAndSelect flag set.
 :param ids: feature IDs to select
 :param behavior: selection type, allows adding to current selection,
                  removing from selection, etc.
-:param validateIds: if ``True``, filters out invalid feature IDs before
-                    selection. Set to ``False`` (default) for best
-                    performance. Enable validation when calling from
-                    Python or when ID validity is uncertain to avoid
-                    incorrect selection counts.
+:param validateIds: (since QGIS 4.0) if ``True``, filters out invalid
+                    feature IDs before selection. Set to ``False``
+                    (default) for best performance. Enable validation
+                    when calling from Python or when ID validity is
+                    uncertain to avoid incorrect selection counts.
 
 .. seealso:: :py:func:`selectByRect`
 
 .. seealso:: :py:func:`selectByExpression`
-
-.. versionadded:: 3.40
 %End
 
     void modifySelection( const QgsFeatureIds &selectIds, const QgsFeatureIds &deselectIds );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -706,7 +706,7 @@ Selects matching features using an expression.
 .. seealso:: :py:func:`selectByIds`
 %End
 
-    void selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
+    void selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection, bool validateIds = false );
 %Docstring
 Selects matching features using a list of feature IDs. Will emit the
 :py:func:`~QgsVectorLayer.selectionChanged` signal with the
@@ -715,10 +715,17 @@ clearAndSelect flag set.
 :param ids: feature IDs to select
 :param behavior: selection type, allows adding to current selection,
                  removing from selection, etc.
+:param validateIds: if ``True``, filters out invalid feature IDs before
+                    selection. Set to ``False`` (default) for best
+                    performance. Enable validation when calling from
+                    Python or when ID validity is uncertain to avoid
+                    incorrect selection counts.
 
 .. seealso:: :py:func:`selectByRect`
 
 .. seealso:: :py:func:`selectByExpression`
+
+.. versionadded:: 3.40
 %End
 
     void modifySelection( const QgsFeatureIds &selectIds, const QgsFeatureIds &deselectIds );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -457,7 +457,9 @@ first available.
     static QgsFeatureIds filterValidFeatureIds( const QgsVectorLayer *layer, const QgsFeatureIds &featureIds );
 %Docstring
 Filters a set of feature IDs to only include those that exist in the
-layer. This method can be used to validate feature IDs before selection
+layer.
+
+This method can be used to validate feature IDs before selection
 operations to ensure accurate selection counts. It performs a minimal
 query (no geometry or attributes) for efficiency.
 

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -454,6 +454,23 @@ first available.
 .. versionadded:: 3.18
 %End
 
+    static QgsFeatureIds filterValidFeatureIds( const QgsVectorLayer *layer, const QgsFeatureIds &featureIds );
+%Docstring
+Filters a set of feature IDs to only include those that exist in the
+layer. This method can be used to validate feature IDs before selection
+operations to ensure accurate selection counts. It performs a minimal
+query (no geometry or attributes) for efficiency.
+
+:param layer: vector layer to check feature IDs against
+:param featureIds: set of feature IDs to filter
+
+:return: subset of featureIds containing only IDs that exist in the
+         layer
+
+.. seealso:: :py:func:`QgsVectorLayer.selectByIds`
+
+.. versionadded:: 3.40
+%End
 
 
     static QByteArray fieldToDataArray( const QgsFields &fields, const QString &fieldName, QgsFeatureIterator &it, const QVariant &nullValue );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayerutils.sip.in
@@ -471,7 +471,7 @@ query (no geometry or attributes) for efficiency.
 
 .. seealso:: :py:func:`QgsVectorLayer.selectByIds`
 
-.. versionadded:: 3.40
+.. versionadded:: 4.0
 %End
 
 

--- a/python/PyQt6/gui/auto_generated/qgscolorbutton.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgscolorbutton.sip.in
@@ -31,7 +31,7 @@ from the screen, and selecting colors from color swatch grids.
       sipType = NULL;
 %End
   public:
-    enum Behavior /BaseType=IntEnum/
+    enum Behavior
     {
       ShowDialog,
       SignalOnly

--- a/python/PyQt6/gui/auto_generated/qgscolorbutton.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgscolorbutton.sip.in
@@ -31,7 +31,7 @@ from the screen, and selecting colors from color swatch grids.
       sipType = NULL;
 %End
   public:
-    enum Behavior
+    enum Behavior /BaseType=IntEnum/
     {
       ShowDialog,
       SignalOnly

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -640,28 +640,35 @@ void QgsVectorLayer::selectByExpression( const QString &expression, Qgis::Select
   selectByIds( newSelection );
 }
 
-void QgsVectorLayer::selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior )
+void QgsVectorLayer::selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior, bool validateIds )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  // Opt-in validation: filter invalid IDs if requested
+  QgsFeatureIds idsToSelect = ids;
+  if ( validateIds )
+  {
+    idsToSelect = QgsVectorLayerUtils::filterValidFeatureIds( this, ids );
+  }
 
   QgsFeatureIds newSelection;
 
   switch ( behavior )
   {
     case Qgis::SelectBehavior::SetSelection:
-      newSelection = ids;
+      newSelection = idsToSelect;
       break;
 
     case Qgis::SelectBehavior::AddToSelection:
-      newSelection = mSelectedFeatureIds + ids;
+      newSelection = mSelectedFeatureIds + idsToSelect;
       break;
 
     case Qgis::SelectBehavior::RemoveFromSelection:
-      newSelection = mSelectedFeatureIds - ids;
+      newSelection = mSelectedFeatureIds - idsToSelect;
       break;
 
     case Qgis::SelectBehavior::IntersectSelection:
-      newSelection = mSelectedFeatureIds.intersect( ids );
+      newSelection = mSelectedFeatureIds.intersect( idsToSelect );
       break;
   }
 

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -827,10 +827,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param ids feature IDs to select
      * \param behavior selection type, allows adding to current selection, removing
      * from selection, etc.
+     * \param validateIds if TRUE, filters out invalid feature IDs before selection.
+     * Set to FALSE (default) for best performance. Enable validation when calling
+     * from Python or when ID validity is uncertain to avoid incorrect selection counts.
      * \see selectByRect()
      * \see selectByExpression()
+     * \since QGIS 3.40 (validateIds parameter)
      */
-    Q_INVOKABLE void selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
+    Q_INVOKABLE void selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection, bool validateIds = false );
 
     /**
      * Modifies the current selection on this layer

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -827,12 +827,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param ids feature IDs to select
      * \param behavior selection type, allows adding to current selection, removing
      * from selection, etc.
-     * \param validateIds if TRUE, filters out invalid feature IDs before selection.
-     * Set to FALSE (default) for best performance. Enable validation when calling
-     * from Python or when ID validity is uncertain to avoid incorrect selection counts.
+     * \param validateIds (since QGIS 4.0) if set to TRUE, filters out invalid feature IDs before selection.
+     * Leave as FALSE (default) for best performance. Enable validation when calling
+     * from Python or when no-valid IDs may be present in the list to avoid incorrect selection counts.
      * \see selectByRect()
      * \see selectByExpression()
-     * \since QGIS 3.40 (validateIds parameter)
      */
     Q_INVOKABLE void selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection, bool validateIds = false );
 

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -827,12 +827,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param ids feature IDs to select
      * \param behavior selection type, allows adding to current selection, removing
      * from selection, etc.
-     * \param validateIds if TRUE, filters out invalid feature IDs before
+     * \param validateIds (since QGIS 4.0) if TRUE, filters out invalid feature IDs before
      * selection. Set to FALSE (default) for best performance. Enable validation when calling from
      * Python or when ID validity is uncertain to avoid incorrect selection counts.
      * \see selectByRect()
      * \see selectByExpression()
-     * \since QGIS 3.40
      */
     Q_INVOKABLE void selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection, bool validateIds = false );
 

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -827,11 +827,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param ids feature IDs to select
      * \param behavior selection type, allows adding to current selection, removing
      * from selection, etc.
-     * \param validateIds (since QGIS 4.0) if set to TRUE, filters out invalid feature IDs before selection.
-     * Leave as FALSE (default) for best performance. Enable validation when calling
-     * from Python or when no-valid IDs may be present in the list to avoid incorrect selection counts.
+     * \param validateIds if TRUE, filters out invalid feature IDs before
+     * selection. Set to FALSE (default) for best performance. Enable validation when calling from
+     * Python or when ID validity is uncertain to avoid incorrect selection counts.
      * \see selectByRect()
      * \see selectByExpression()
+     * \since QGIS 3.40
      */
     Q_INVOKABLE void selectByIds( const QgsFeatureIds &ids, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection, bool validateIds = false );
 

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -1653,7 +1653,7 @@ QgsFeatureIds QgsVectorLayerUtils::filterValidFeatureIds( const QgsVectorLayer *
     return QgsFeatureIds();
 
   if ( featureIds.isEmpty() )
-    return featureIds;
+    return QgsFeatureIds();
 
   // build up an optimised feature request
   QgsFeatureRequest request;

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -1646,3 +1646,27 @@ QByteArray QgsVectorLayerUtils::fieldToDataArray( const QgsFields &fields, const
 
   return res;
 }
+
+QgsFeatureIds QgsVectorLayerUtils::filterValidFeatureIds( const QgsVectorLayer *layer, const QgsFeatureIds &featureIds )
+{
+  if ( !layer || featureIds.isEmpty() )
+    return featureIds;
+
+  // build up an optimised feature request
+  QgsFeatureRequest request;
+  request.setFilterFids( featureIds );
+  request.setNoAttributes();
+  request.setFlags( Qgis::FeatureRequestFlag::NoGeometry );
+
+  QgsFeatureIds validIds;
+  validIds.reserve( featureIds.size() );
+
+  QgsFeature feat;
+  QgsFeatureIterator it = layer->getFeatures( request );
+  while ( it.nextFeature( feat ) )
+  {
+    validIds.insert( feat.id() );
+  }
+
+  return validIds;
+}

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -1649,7 +1649,10 @@ QByteArray QgsVectorLayerUtils::fieldToDataArray( const QgsFields &fields, const
 
 QgsFeatureIds QgsVectorLayerUtils::filterValidFeatureIds( const QgsVectorLayer *layer, const QgsFeatureIds &featureIds )
 {
-  if ( !layer || featureIds.isEmpty() )
+  if ( !layer )
+    return QgsFeatureIds();
+
+  if ( featureIds.isEmpty() )
     return featureIds;
 
   // build up an optimised feature request

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -508,7 +508,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      * \param featureIds set of feature IDs to filter
      * \returns subset of featureIds containing only IDs that exist in the layer
      * \see QgsVectorLayer::selectByIds()
-     * \since QGIS 4.0
+     * \since QGIS 3.40
      */
     static QgsFeatureIds filterValidFeatureIds( const QgsVectorLayer *layer, const QgsFeatureIds &featureIds );
 

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -501,13 +501,14 @@ class CORE_EXPORT QgsVectorLayerUtils
 
     /**
      * Filters a set of feature IDs to only include those that exist in the layer.
+     *
      * This method can be used to validate feature IDs before selection operations to ensure
      * accurate selection counts. It performs a minimal query (no geometry or attributes) for efficiency.
      * \param layer vector layer to check feature IDs against
      * \param featureIds set of feature IDs to filter
      * \returns subset of featureIds containing only IDs that exist in the layer
      * \see QgsVectorLayer::selectByIds()
-     * \since QGIS 3.40
+     * \since QGIS 4.0
      */
     static QgsFeatureIds filterValidFeatureIds( const QgsVectorLayer *layer, const QgsFeatureIds &featureIds );
 

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -499,6 +499,17 @@ class CORE_EXPORT QgsVectorLayerUtils
     static QString guessFriendlyIdentifierField( const QgsFields &fields );
 #endif
 
+    /**
+     * Filters a set of feature IDs to only include those that exist in the layer.
+     * This method can be used to validate feature IDs before selection operations to ensure
+     * accurate selection counts. It performs a minimal query (no geometry or attributes) for efficiency.
+     * \param layer vector layer to check feature IDs against
+     * \param featureIds set of feature IDs to filter
+     * \returns subset of featureIds containing only IDs that exist in the layer
+     * \see QgsVectorLayer::selectByIds()
+     * \since QGIS 3.40
+     */
+    static QgsFeatureIds filterValidFeatureIds( const QgsVectorLayer *layer, const QgsFeatureIds &featureIds );
 
 #ifndef SIP_RUN
     /**

--- a/src/core/vector/qgsvectorlayerutils.h
+++ b/src/core/vector/qgsvectorlayerutils.h
@@ -508,7 +508,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      * \param featureIds set of feature IDs to filter
      * \returns subset of featureIds containing only IDs that exist in the layer
      * \see QgsVectorLayer::selectByIds()
-     * \since QGIS 3.40
+     * \since QGIS 4.0
      */
     static QgsFeatureIds filterValidFeatureIds( const QgsVectorLayer *layer, const QgsFeatureIds &featureIds );
 

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -80,6 +80,7 @@ class TestQgsVectorLayer : public QgsTest
     void testFieldExpression();
     void testFieldAggregateExpression();
     void testAddFeatureExtentUpdated();
+    void testSelectByIdsValidation();
 };
 
 void TestQgsVectorLayer::initTestCase()
@@ -540,6 +541,65 @@ void TestQgsVectorLayer::testAddFeatureExtentUpdated()
   QCOMPARE( spyDeleted.at( 0 ).at( 0 ), QVariant( lineF1.id() ) );
 
   delete layerLine;
+}
+
+void TestQgsVectorLayer::testSelectByIdsValidation()
+{
+  std::unique_ptr<QgsVectorLayer> layer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?field=id:integer" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+  QVERIFY( layer->isValid() );
+
+  QgsFeature f1( layer->fields() );
+  f1.setAttribute( 0, 1 );
+  QgsFeature f2( layer->fields() );
+  f2.setAttribute( 0, 2 );
+  QgsFeature f3( layer->fields() );
+  f3.setAttribute( 0, 3 );
+  QgsFeature f4( layer->fields() );
+  f4.setAttribute( 0, 4 );
+  QgsFeature f5( layer->fields() );
+  f5.setAttribute( 0, 5 );
+
+  layer->dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 << f3 << f4 << f5 );
+  QCOMPARE( layer->featureCount(), 5L );
+
+  QgsFeatureIds testIds = { 1, 2, 99, 100, 3 };
+  layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, false );
+  QCOMPARE( layer->selectedFeatureCount(), 5 );
+  QCOMPARE( layer->selectedFeatureIds().size(), 3 );
+  QVERIFY( layer->selectedFeatureIds().contains( 1 ) );
+  QVERIFY( layer->selectedFeatureIds().contains( 2 ) );
+  QVERIFY( layer->selectedFeatureIds().contains( 3 ) );
+
+  layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, true );
+  QCOMPARE( layer->selectedFeatureCount(), 3 );
+  QCOMPARE( layer->selectedFeatureIds().size(), 3 );
+  QVERIFY( layer->selectedFeatureIds().contains( 1 ) );
+  QVERIFY( layer->selectedFeatureIds().contains( 2 ) );
+  QVERIFY( layer->selectedFeatureIds().contains( 3 ) );
+
+  testIds = { 99, 100, 200 };
+  layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, true );
+  QCOMPARE( layer->selectedFeatureCount(), 0 );
+  QVERIFY( layer->selectedFeatureIds().isEmpty() );
+
+
+  testIds = { 1, 2, 3, 4, 5 };
+  layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, true );
+  QCOMPARE( layer->selectedFeatureCount(), 5 );
+  QCOMPARE( layer->selectedFeatureIds().size(), 5 );
+
+
+  testIds = { 1, 2 };
+  layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, true );
+  QCOMPARE( layer->selectedFeatureCount(), 2 );
+
+  testIds = { 3, 99 };
+  layer->selectByIds( testIds, Qgis::SelectBehavior::AddToSelection, true );
+  QCOMPARE( layer->selectedFeatureCount(), 3 ); // Should have 1, 2, 3
+  QVERIFY( layer->selectedFeatureIds().contains( 1 ) );
+  QVERIFY( layer->selectedFeatureIds().contains( 2 ) );
+  QVERIFY( layer->selectedFeatureIds().contains( 3 ) );
+  QVERIFY( !layer->selectedFeatureIds().contains( 99 ) );
 }
 
 

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -565,17 +565,13 @@ void TestQgsVectorLayer::testSelectByIdsValidation()
   QgsFeatureIds testIds = { 1, 2, 99, 100, 3 };
   layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, false );
   QCOMPARE( layer->selectedFeatureCount(), 5 );
-  QCOMPARE( layer->selectedFeatureIds().size(), 3 );
-  QVERIFY( layer->selectedFeatureIds().contains( 1 ) );
-  QVERIFY( layer->selectedFeatureIds().contains( 2 ) );
-  QVERIFY( layer->selectedFeatureIds().contains( 3 ) );
+  QCOMPARE( layer->selectedFeatureIds().size(), 5 );
+  QCOMPARE( layer->selectedFeatureIds(), testIds );
 
   layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, true );
   QCOMPARE( layer->selectedFeatureCount(), 3 );
   QCOMPARE( layer->selectedFeatureIds().size(), 3 );
-  QVERIFY( layer->selectedFeatureIds().contains( 1 ) );
-  QVERIFY( layer->selectedFeatureIds().contains( 2 ) );
-  QVERIFY( layer->selectedFeatureIds().contains( 3 ) );
+  QCOMPARE( layer->selectedFeatureIds(), QgsFeatureIds() << 1 << 2 << 3 );
 
   testIds = { 99, 100, 200 };
   layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, true );
@@ -586,18 +582,17 @@ void TestQgsVectorLayer::testSelectByIdsValidation()
   layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, true );
   QCOMPARE( layer->selectedFeatureCount(), 5 );
   QCOMPARE( layer->selectedFeatureIds().size(), 5 );
+  QCOMPARE( layer->selectedFeatureIds(), testIds );
 
   testIds = { 1, 2 };
   layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, true );
   QCOMPARE( layer->selectedFeatureCount(), 2 );
+  QCOMPARE( layer->selectedFeatureIds(), testIds );
 
   testIds = { 3, 99 };
   layer->selectByIds( testIds, Qgis::SelectBehavior::AddToSelection, true );
   QCOMPARE( layer->selectedFeatureCount(), 3 ); // Should have 1, 2, 3
-  QVERIFY( layer->selectedFeatureIds().contains( 1 ) );
-  QVERIFY( layer->selectedFeatureIds().contains( 2 ) );
-  QVERIFY( layer->selectedFeatureIds().contains( 3 ) );
-  QVERIFY( !layer->selectedFeatureIds().contains( 99 ) );
+  QCOMPARE( layer->selectedFeatureIds(), QgsFeatureIds() << 1 << 2 << 3 );
 }
 
 QGSTEST_MAIN( TestQgsVectorLayer )

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -545,7 +545,7 @@ void TestQgsVectorLayer::testAddFeatureExtentUpdated()
 
 void TestQgsVectorLayer::testSelectByIdsValidation()
 {
-  std::unique_ptr<QgsVectorLayer> layer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?field=id:integer" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+  auto layer = std::make_unique<QgsVectorLayer>( u"Point?field=id:integer"_s, u"test"_s, u"memory"_s );
   QVERIFY( layer->isValid() );
 
   QgsFeature f1( layer->fields() );
@@ -582,12 +582,10 @@ void TestQgsVectorLayer::testSelectByIdsValidation()
   QCOMPARE( layer->selectedFeatureCount(), 0 );
   QVERIFY( layer->selectedFeatureIds().isEmpty() );
 
-
   testIds = { 1, 2, 3, 4, 5 };
   layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, true );
   QCOMPARE( layer->selectedFeatureCount(), 5 );
   QCOMPARE( layer->selectedFeatureIds().size(), 5 );
-
 
   testIds = { 1, 2 };
   layer->selectByIds( testIds, Qgis::SelectBehavior::SetSelection, true );
@@ -601,7 +599,6 @@ void TestQgsVectorLayer::testSelectByIdsValidation()
   QVERIFY( layer->selectedFeatureIds().contains( 3 ) );
   QVERIFY( !layer->selectedFeatureIds().contains( 99 ) );
 }
-
 
 QGSTEST_MAIN( TestQgsVectorLayer )
 #include "testqgsvectorlayer.moc"

--- a/tests/src/core/testqgsvectorlayerutils.cpp
+++ b/tests/src/core/testqgsvectorlayerutils.cpp
@@ -146,8 +146,6 @@ void TestQgsVectorLayerUtils::testGetFeatureSource()
   thread2->quit();
 }
 
-}
-
 void TestQgsVectorLayerUtils::testGetValues()
 {
   const QString pointFileName = mTestDataDir + "points.shp";
@@ -547,7 +545,7 @@ void TestQgsVectorLayerUtils::testObjectsMaskedByLabels()
 
 void TestQgsVectorLayerUtils::testFilterValidFeatureIds()
 {
-  std::unique_ptr<QgsVectorLayer> layer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?field=id:integer" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+  auto layer = std::make_unique<QgsVectorLayer>( u"Point?field=id:integer"_s, u"test"_s, u"memory"_s );
   QVERIFY( layer->isValid() );
 
   QgsFeature f1( layer->fields() );

--- a/tests/src/core/testqgsvectorlayerutils.cpp
+++ b/tests/src/core/testqgsvectorlayerutils.cpp
@@ -50,6 +50,7 @@ class TestQgsVectorLayerUtils : public QObject
     void testUniqueValues();
     void testObjectsMaskedBySymbolLayers();
     void testObjectsMaskedByLabels();
+    void testFilterValidFeatureIds();
 
   private:
     QString mTestDataDir;
@@ -540,6 +541,64 @@ void TestQgsVectorLayerUtils::testObjectsMaskedByLabels()
 
   labelResult = QgsVectorLayerUtils::collectObjectsMaskedByLabelsFromLayer( maskingLayer.get(), sets, allLayers );
   QVERIFY( labelResult.isEmpty() );
+}
+
+void TestQgsVectorLayerUtils::testFilterValidFeatureIds()
+{
+  std::unique_ptr<QgsVectorLayer> layer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?field=id:integer" ), QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+  QVERIFY( layer->isValid() );
+
+  QgsFeature f1( layer->fields() );
+  f1.setAttribute( 0, 1 );
+  QgsFeature f2( layer->fields() );
+  f2.setAttribute( 0, 2 );
+  QgsFeature f3( layer->fields() );
+  f3.setAttribute( 0, 3 );
+  QgsFeature f4( layer->fields() );
+  f4.setAttribute( 0, 4 );
+  QgsFeature f5( layer->fields() );
+  f5.setAttribute( 0, 5 );
+
+  layer->dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 << f3 << f4 << f5 );
+  QCOMPARE( layer->featureCount(), 5L );
+
+  QgsFeatureIds testIds = { 1, 2, 3 };
+  QgsFeatureIds result = QgsVectorLayerUtils::filterValidFeatureIds( nullptr, testIds );
+  QVERIFY( result.isEmpty() );
+
+  result = QgsVectorLayerUtils::filterValidFeatureIds( layer.get(), QgsFeatureIds() );
+  QVERIFY( result.isEmpty() );
+
+  testIds = { 1, 2, 3, 4, 5 };
+  result = QgsVectorLayerUtils::filterValidFeatureIds( layer.get(), testIds );
+  QCOMPARE( result.size(), 5 );
+  QVERIFY( result.contains( 1 ) );
+  QVERIFY( result.contains( 2 ) );
+  QVERIFY( result.contains( 3 ) );
+  QVERIFY( result.contains( 4 ) );
+  QVERIFY( result.contains( 5 ) );
+
+  testIds = { 1, 2, 99, 100, 3, 200 };
+  result = QgsVectorLayerUtils::filterValidFeatureIds( layer.get(), testIds );
+  QCOMPARE( result.size(), 3 );
+  QVERIFY( result.contains( 1 ) );
+  QVERIFY( result.contains( 2 ) );
+  QVERIFY( result.contains( 3 ) );
+  QVERIFY( !result.contains( 99 ) );
+  QVERIFY( !result.contains( 100 ) );
+  QVERIFY( !result.contains( 200 ) );
+
+  testIds = { 99, 100, 200 };
+  result = QgsVectorLayerUtils::filterValidFeatureIds( layer.get(), testIds );
+  QVERIFY( result.isEmpty() );
+
+  testIds = { -1, 1, 2, -5 };
+  result = QgsVectorLayerUtils::filterValidFeatureIds( layer.get(), testIds );
+  QCOMPARE( result.size(), 2 );
+  QVERIFY( result.contains( 1 ) );
+  QVERIFY( result.contains( 2 ) );
+  QVERIFY( !result.contains( -1 ) );
+  QVERIFY( !result.contains( -5 ) );
 }
 
 QGSTEST_MAIN( TestQgsVectorLayerUtils )

--- a/tests/src/core/testqgsvectorlayerutils.cpp
+++ b/tests/src/core/testqgsvectorlayerutils.cpp
@@ -572,21 +572,12 @@ void TestQgsVectorLayerUtils::testFilterValidFeatureIds()
   testIds = { 1, 2, 3, 4, 5 };
   result = QgsVectorLayerUtils::filterValidFeatureIds( layer.get(), testIds );
   QCOMPARE( result.size(), 5 );
-  QVERIFY( result.contains( 1 ) );
-  QVERIFY( result.contains( 2 ) );
-  QVERIFY( result.contains( 3 ) );
-  QVERIFY( result.contains( 4 ) );
-  QVERIFY( result.contains( 5 ) );
+  QCOMPARE( result, testIds );
 
   testIds = { 1, 2, 99, 100, 3, 200 };
   result = QgsVectorLayerUtils::filterValidFeatureIds( layer.get(), testIds );
   QCOMPARE( result.size(), 3 );
-  QVERIFY( result.contains( 1 ) );
-  QVERIFY( result.contains( 2 ) );
-  QVERIFY( result.contains( 3 ) );
-  QVERIFY( !result.contains( 99 ) );
-  QVERIFY( !result.contains( 100 ) );
-  QVERIFY( !result.contains( 200 ) );
+  QCOMPARE( result, QgsFeatureIds() << 1 << 2 << 3 );
 
   testIds = { 99, 100, 200 };
   result = QgsVectorLayerUtils::filterValidFeatureIds( layer.get(), testIds );
@@ -595,10 +586,7 @@ void TestQgsVectorLayerUtils::testFilterValidFeatureIds()
   testIds = { -1, 1, 2, -5 };
   result = QgsVectorLayerUtils::filterValidFeatureIds( layer.get(), testIds );
   QCOMPARE( result.size(), 2 );
-  QVERIFY( result.contains( 1 ) );
-  QVERIFY( result.contains( 2 ) );
-  QVERIFY( !result.contains( -1 ) );
-  QVERIFY( !result.contains( -5 ) );
+  QCOMPARE( result, QgsFeatureIds() << 1 << 2 );
 }
 
 QGSTEST_MAIN( TestQgsVectorLayerUtils )

--- a/tests/src/core/testqgsvectorlayerutils.cpp
+++ b/tests/src/core/testqgsvectorlayerutils.cpp
@@ -146,6 +146,8 @@ void TestQgsVectorLayerUtils::testGetFeatureSource()
   thread2->quit();
 }
 
+}
+
 void TestQgsVectorLayerUtils::testGetValues()
 {
   const QString pointFileName = mTestDataDir + "points.shp";


### PR DESCRIPTION
## Description

The `selectByIds()` method does not check if passed feature IDs are valid. This may result in an incorrect feature count.

This PR introduces a new argument `validateId` (set to `false` by default) to allow opt-in validation of the feature IDs before selecting/counting features. 

Supersedes #63789.
Fixes #61604.