### PR TITLE
disable unnecessary settings for X axis when it has categorical type (fix #63463)

### DIFF
--- a/src/gui/plot/qgsplotwidget.cpp
+++ b/src/gui/plot/qgsplotwidget.cpp
@@ -383,16 +383,22 @@ void QgsBarChartPlotWidget::updateXAxisProperties()
 {
   const bool enable = mXAxisTypeCombo->currentData().value<Qgis::PlotAxisType>() == Qgis::PlotAxisType::Interval;
 
+  mLabelMinXAxis->setEnabled( enable );
   mSpinMinXAxis->setEnabled( enable );
   mDDBtnMinXAxis->setEnabled( enable );
+  mLabelMaxXAxis->setEnabled( enable );
   mSpinMaxXAxis->setEnabled( enable );
   mDDBtnMaxXAxis->setEnabled( enable );
 
+  mXAxisMajorIntervalLabel->setEnabled( enable );
   mXAxisMajorIntervalSpin->setEnabled( enable );
   mDDBtnXAxisMajorInterval->setEnabled( enable );
+  mXAxisMajorLinesLabel->setEnabled( enable );
   mXAxisMajorLinesSymbolButton->setEnabled( enable );
+  mXAxisMinorIntervalLabel->setEnabled( enable );
   mXAxisMinorIntervalSpin->setEnabled( enable );
   mDDBtnXAxisMinorInterval->setEnabled( enable );
+  mXAxisMinorLinesLabel->setEnabled( enable );
   mXAxisMinorLinesSymbolButton->setEnabled( enable );
 }
 
@@ -857,16 +863,22 @@ void QgsLineChartPlotWidget::updateXAxisProperties()
 {
   const bool enable = mXAxisTypeCombo->currentData().value<Qgis::PlotAxisType>() == Qgis::PlotAxisType::Interval;
 
+  mLabelMinXAxis->setEnabled( enable );
   mSpinMinXAxis->setEnabled( enable );
   mDDBtnMinXAxis->setEnabled( enable );
+  mLabelMaxXAxis->setEnabled( enable );
   mSpinMaxXAxis->setEnabled( enable );
   mDDBtnMaxXAxis->setEnabled( enable );
 
+  mXAxisMajorIntervalLabel->setEnabled( enable );
   mXAxisMajorIntervalSpin->setEnabled( enable );
   mDDBtnXAxisMajorInterval->setEnabled( enable );
+  mXAxisMajorLinesLabel->setEnabled( enable );
   mXAxisMajorLinesSymbolButton->setEnabled( enable );
+  mXAxisMinorIntervalLabel->setEnabled( enable );
   mXAxisMinorIntervalSpin->setEnabled( enable );
   mDDBtnXAxisMinorInterval->setEnabled( enable );
+  mXAxisMinorLinesLabel->setEnabled( enable );
   mXAxisMinorLinesSymbolButton->setEnabled( enable );
 }
 

--- a/src/gui/plot/qgsplotwidget.cpp
+++ b/src/gui/plot/qgsplotwidget.cpp
@@ -98,7 +98,6 @@ void QgsPlotWidget::updateProperty()
   emit widgetChanged();
 }
 
-
 QgsBarChartPlotWidget::QgsBarChartPlotWidget( QWidget *parent )
   : QgsPlotWidget( parent )
 {
@@ -298,6 +297,7 @@ QgsBarChartPlotWidget::QgsBarChartPlotWidget( QWidget *parent )
 
   mXAxisTypeCombo->addItem( tr( "Interval" ), QVariant::fromValue( Qgis::PlotAxisType::Interval ) );
   mXAxisTypeCombo->addItem( tr( "Categorical" ), QVariant::fromValue( Qgis::PlotAxisType::Categorical ) );
+  connect( mXAxisTypeCombo, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsBarChartPlotWidget::updateXAxisProperties );
   connect( mXAxisTypeCombo, qOverload<int>( &QComboBox::currentIndexChanged ), this, [this]( int ) {
     if ( mBlockChanges )
       return;
@@ -377,6 +377,23 @@ void QgsBarChartPlotWidget::mRemoveSymbolPushButton_clicked()
   mSymbolsList->removeRow( mSymbolsList->row( item ) );
 
   emit widgetChanged();
+}
+
+void QgsBarChartPlotWidget::updateXAxisProperties()
+{
+  const bool enable = mXAxisTypeCombo->currentData().value<Qgis::PlotAxisType>() == Qgis::PlotAxisType::Interval;
+
+  mSpinMinXAxis->setEnabled( enable );
+  mDDBtnMinXAxis->setEnabled( enable );
+  mSpinMaxXAxis->setEnabled( enable );
+  mDDBtnMaxXAxis->setEnabled( enable );
+
+  mXAxisMajorIntervalSpin->setEnabled( enable );
+  mDDBtnXAxisMajorInterval->setEnabled( enable );
+  mXAxisMajorLinesSymbolButton->setEnabled( enable );
+  mXAxisMinorIntervalSpin->setEnabled( enable );
+  mDDBtnXAxisMinorInterval->setEnabled( enable );
+  mXAxisMinorLinesSymbolButton->setEnabled( enable );
 }
 
 void QgsBarChartPlotWidget::setPlot( QgsPlot *plot )
@@ -476,7 +493,6 @@ void QgsBarChartPlotWidget::setPlot( QgsPlot *plot )
 
   mBlockChanges--;
 }
-
 
 QgsPlot *QgsBarChartPlotWidget::createPlot()
 {
@@ -740,6 +756,7 @@ QgsLineChartPlotWidget::QgsLineChartPlotWidget( QWidget *parent )
 
   mXAxisTypeCombo->addItem( tr( "Interval" ), QVariant::fromValue( Qgis::PlotAxisType::Interval ) );
   mXAxisTypeCombo->addItem( tr( "Categorical" ), QVariant::fromValue( Qgis::PlotAxisType::Categorical ) );
+  connect( mXAxisTypeCombo, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsLineChartPlotWidget::updateXAxisProperties );
   connect( mXAxisTypeCombo, qOverload<int>( &QComboBox::currentIndexChanged ), this, [this]( int ) {
     if ( mBlockChanges )
       return;
@@ -834,6 +851,23 @@ void QgsLineChartPlotWidget::mRemoveSymbolPushButton_clicked()
   mSymbolsList->removeRow( mSymbolsList->row( item ) );
 
   emit widgetChanged();
+}
+
+void QgsLineChartPlotWidget::updateXAxisProperties()
+{
+  const bool enable = mXAxisTypeCombo->currentData().value<Qgis::PlotAxisType>() == Qgis::PlotAxisType::Interval;
+
+  mSpinMinXAxis->setEnabled( enable );
+  mDDBtnMinXAxis->setEnabled( enable );
+  mSpinMaxXAxis->setEnabled( enable );
+  mDDBtnMaxXAxis->setEnabled( enable );
+
+  mXAxisMajorIntervalSpin->setEnabled( enable );
+  mDDBtnXAxisMajorInterval->setEnabled( enable );
+  mXAxisMajorLinesSymbolButton->setEnabled( enable );
+  mXAxisMinorIntervalSpin->setEnabled( enable );
+  mDDBtnXAxisMinorInterval->setEnabled( enable );
+  mXAxisMinorLinesSymbolButton->setEnabled( enable );
 }
 
 void QgsLineChartPlotWidget::setPlot( QgsPlot *plot )
@@ -946,7 +980,6 @@ void QgsLineChartPlotWidget::setPlot( QgsPlot *plot )
 
   mBlockChanges--;
 }
-
 
 QgsPlot *QgsLineChartPlotWidget::createPlot()
 {

--- a/src/gui/plot/qgsplotwidget.h
+++ b/src/gui/plot/qgsplotwidget.h
@@ -119,6 +119,8 @@ class GUI_EXPORT QgsBarChartPlotWidget : public QgsPlotWidget, private Ui::QgsBa
   private slots:
     void mAddSymbolPushButton_clicked();
     void mRemoveSymbolPushButton_clicked();
+    //! Updates enabled/disabled state of the X axis controls depending on the axis type
+    void updateXAxisProperties();
 
   private:
     int mBlockChanges = 0;
@@ -162,6 +164,8 @@ class GUI_EXPORT QgsLineChartPlotWidget : public QgsPlotWidget, private Ui::QgsL
   private slots:
     void mAddSymbolPushButton_clicked();
     void mRemoveSymbolPushButton_clicked();
+    //! Updates enabled/disabled state of the X axis controls depending on the axis type
+    void updateXAxisProperties();
 
   private:
     int mBlockChanges = 0;

--- a/src/ui/plot/qgsbarchartplotwidgetbase.ui
+++ b/src/ui/plot/qgsbarchartplotwidgetbase.ui
@@ -38,7 +38,7 @@
    <item>
     <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::Shape::StyledPanel</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -47,9 +47,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-127</y>
+        <y>0</y>
         <width>548</width>
-        <height>1515</height>
+        <height>1183</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -178,9 +178,6 @@
        </item>
        <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="groupSymbolsList">
-         <property name="title">
-          <string>Symbols list</string>
-         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
            <horstretch>0</horstretch>
@@ -192,6 +189,9 @@
            <width>16777215</width>
            <height>320</height>
           </size>
+         </property>
+         <property name="title">
+          <string>Symbols list</string>
          </property>
          <layout class="QVBoxLayout" name="verticalBoxLayout">
           <item>
@@ -316,7 +316,7 @@
            </widget>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="label_5">
+           <widget class="QLabel" name="mXAxisMinorLinesLabel">
             <property name="text">
              <string>Minor grid lines</string>
             </property>
@@ -362,7 +362,7 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_6">
+           <widget class="QLabel" name="mXAxisMajorIntervalLabel">
             <property name="text">
              <string>Major interval</string>
             </property>
@@ -376,7 +376,7 @@
            </widget>
           </item>
           <item row="3" column="0" colspan="2">
-           <widget class="QLabel" name="label_7">
+           <widget class="QLabel" name="mXAxisMinorIntervalLabel">
             <property name="text">
              <string>Minor interval</string>
             </property>
@@ -410,7 +410,7 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="mXAxisMajorLinesLabel">
             <property name="text">
              <string>Major grid lines</string>
             </property>

--- a/src/ui/plot/qgslinechartplotwidgetbase.ui
+++ b/src/ui/plot/qgslinechartplotwidgetbase.ui
@@ -38,7 +38,7 @@
    <item>
     <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::Shape::StyledPanel</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -47,9 +47,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-127</y>
+        <y>0</y>
         <width>548</width>
-        <height>1515</height>
+        <height>1183</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -178,9 +178,6 @@
        </item>
        <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="symbolsListGroupBox">
-         <property name="title">
-          <string>Symbols list</string>
-         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
            <horstretch>0</horstretch>
@@ -192,6 +189,9 @@
            <width>16777215</width>
            <height>320</height>
           </size>
+         </property>
+         <property name="title">
+          <string>Symbols list</string>
          </property>
          <layout class="QVBoxLayout" name="verticalBoxLayout">
           <item>
@@ -316,7 +316,7 @@
            </widget>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="label_5">
+           <widget class="QLabel" name="mXAxisMinorLinesLabel">
             <property name="text">
              <string>Minor grid lines</string>
             </property>
@@ -362,7 +362,7 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_6">
+           <widget class="QLabel" name="mXAxisMajorIntervalLabel">
             <property name="text">
              <string>Major interval</string>
             </property>
@@ -376,7 +376,7 @@
            </widget>
           </item>
           <item row="3" column="0" colspan="2">
-           <widget class="QLabel" name="label_7">
+           <widget class="QLabel" name="mXAxisMinorIntervalLabel">
             <property name="text">
              <string>Minor interval</string>
             </property>
@@ -410,7 +410,7 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="mXAxisMajorLinesLabel">
             <property name="text">
              <string>Major grid lines</string>
             </property>


### PR DESCRIPTION
## Description

When X axis in the chart layout item set to "Categorical" disable widgets that do not make sense in that mode:
 - X axis chart range (minimum and maximum) widgets
 - major/minor grid lines widgets
 - major/minor intervals 

Fixes #63463.