### PR TITLE
Group filtering options in Layout Chart item properties

### DIFF
--- a/src/ui/layout/qgslayoutchartwidgetbase.ui
+++ b/src/ui/layout/qgslayoutchartwidgetbase.ui
@@ -230,26 +230,14 @@
             </property>
            </widget>
           </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QgsCollapsibleGroupBoxBasic" name="featureFilteringGroupBox">
-         <property name="title">
-          <string>Feature Filtering</string>
-         </property>
-         <property name="collapsed" stdset="0">
-          <bool>false</bool>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
+          <item row="5" column="0" colspan="3">
            <widget class="QCheckBox" name="mFilterOnlyVisibleFeaturesCheckBox">
             <property name="text">
              <string>Use only features visible within a map</string>
             </property>
            </widget>
           </item>
-          <item>
+          <item row="6" column="0" colspan="3">
            <layout class="QHBoxLayout" name="linkedMapLayout">
             <item>
              <widget class="QLabel" name="mLinkedMapLabel">
@@ -266,7 +254,7 @@
             </item>
            </layout>
           </item>
-          <item>
+          <item row="7" column="0" colspan="3">
            <widget class="QCheckBox" name="mIntersectAtlasCheckBox">
             <property name="text">
              <string>Use only features intersecting atlas feature</string>

--- a/src/ui/layout/qgslayoutchartwidgetbase.ui
+++ b/src/ui/layout/qgslayoutchartwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>542</width>
-    <height>889</height>
+    <height>682</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -61,15 +61,15 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>358</width>
-        <height>681</height>
+        <width>542</width>
+        <height>660</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
        <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="mainPropertiesGroupBox">
          <property name="focusPolicy">
-          <enum>Qt::StrongFocus</enum>
+          <enum>Qt::FocusPolicy::StrongFocus</enum>
          </property>
          <property name="title">
           <string>Main Properties</string>
@@ -114,7 +114,7 @@
        <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="dataSourceGroupBox">
          <property name="focusPolicy">
-          <enum>Qt::StrongFocus</enum>
+          <enum>Qt::FocusPolicy::StrongFocus</enum>
          </property>
          <property name="title">
           <string>Data Source</string>
@@ -125,7 +125,7 @@
          <property name="collapsed" stdset="0">
           <bool>false</bool>
          </property>
-         <layout class="QGridLayout" name="dataSourceLayout" columnstretch="0,1">
+         <layout class="QGridLayout" name="dataSourceLayout" columnstretch="0,1,0">
           <item row="0" column="0">
            <widget class="QLabel" name="layerLabel">
             <property name="text">
@@ -137,7 +137,7 @@
            </widget>
           </item>
           <item row="0" column="1" colspan="2">
-           <widget class="QgsMapLayerComboBox" name="mLayerComboBox">
+           <widget class="QgsMapLayerComboBox" name="mLayerComboBox" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -171,7 +171,7 @@
              <string>…</string>
             </property>
             <property name="arrowType">
-             <enum>Qt::UpArrow</enum>
+             <enum>Qt::ArrowType::UpArrow</enum>
             </property>
            </widget>
           </item>
@@ -233,35 +233,47 @@
          </layout>
         </widget>
        </item>
-       <item row="5" column="0" colspan="3">
-        <widget class="QCheckBox" name="mFilterOnlyVisibleFeaturesCheckBox">
-         <property name="text">
-          <string>Use only features visible within a map</string>
+       <item>
+        <widget class="QgsCollapsibleGroupBoxBasic" name="featureFilteringGroupBox">
+         <property name="title">
+          <string>Feature Filtering</string>
          </property>
-        </widget>
-       </item>
-       <item row="6" column="0" colspan="3">
-        <layout class="QHBoxLayout" name="linkedMapLayout">
-         <item>
-          <widget class="QLabel" name="mLinkedMapLabel">
-           <property name="text">
-            <string>Linked map</string>
-           </property>
-           <property name="buddy">
-            <cstring>mLinkedMapComboBox</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QgsLayoutItemComboBox" name="mLinkedMapComboBox"/>
-         </item>
-        </layout>
-       </item>
-       <item row="7" column="0" colspan="3">
-        <widget class="QCheckBox" name="mIntersectAtlasCheckBox">
-         <property name="text">
-          <string>Use only features intersecting atlas feature</string>
+         <property name="collapsed" stdset="0">
+          <bool>false</bool>
          </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QCheckBox" name="mFilterOnlyVisibleFeaturesCheckBox">
+            <property name="text">
+             <string>Use only features visible within a map</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="linkedMapLayout">
+            <item>
+             <widget class="QLabel" name="mLinkedMapLabel">
+              <property name="text">
+               <string>Linked map</string>
+              </property>
+              <property name="buddy">
+               <cstring>mLinkedMapComboBox</cstring>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsLayoutItemComboBox" name="mLinkedMapComboBox"/>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="mIntersectAtlasCheckBox">
+            <property name="text">
+             <string>Use only features intersecting atlas feature</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>
@@ -273,25 +285,9 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -311,9 +307,12 @@
    <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QWidget</extends>
+   <header>qgsmaplayercombobox.h</header>
+  </customwidget>
  </customwidgets>
- <tabstops>
- </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Instead of this
<img width="425" height="498" alt="image" src="https://github.com/user-attachments/assets/f6b9a185-28c7-41f4-94a9-683714cf6a61" />
Let's do  this
<img width="450" height="498" alt="image" src="https://github.com/user-attachments/assets/c5930330-f6bd-4f43-93cb-dbfab45f2373" />
