### PR TITLE
change order of proxy factory check

### DIFF
--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -78,13 +78,13 @@ class QgsNetworkProxyFactory : public QNetworkProxyFactory
       const auto constProxyFactories = nam->proxyFactories();
       for ( QNetworkProxyFactory *f : constProxyFactories )
       {
-        QList<QNetworkProxy> systemproxies = QNetworkProxyFactory::systemProxyForQuery( query );
-        if ( !systemproxies.isEmpty() )
-          return systemproxies;
-
         QList<QNetworkProxy> proxies = f->queryProxy( query );
         if ( !proxies.isEmpty() )
           return proxies;
+        
+        QList<QNetworkProxy> systemproxies = QNetworkProxyFactory::systemProxyForQuery( query );
+        if ( !systemproxies.isEmpty() )
+          return systemproxies;
       }
 
       // no proxies from the proxy factory list check for excludes


### PR DESCRIPTION
Update qgsnetworkaccessmanager.cpp to return existing custom proxy factories before returning the system proxy. This makes the use of custom proxies possible if a system proxy is set.

see issue https://github.com/qgis/QGIS/issues/65045