### PR TITLE
do not prepare already prepared expressions in the Refactor fields algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmrefactorfields.cpp
+++ b/src/analysis/processing/qgsalgorithmrefactorfields.cpp
@@ -172,6 +172,7 @@ QgsFeatureList QgsRefactorFieldsAlgorithm::processFeature( const QgsFeature &fea
       if ( it->isValid() )
         it->prepare( &mExpressionContext );
     }
+    mExpressionsPrepared = true;
   }
 
   QgsAttributes attributes;


### PR DESCRIPTION
## Description

Refactor fields algorithm prepares expression(s) on every `processFeature()` call even if they were prepared before. This happens because `mExpressionsPrepared` flag was not used (probably due to oversight).