### PR TITLE
[raster][rat] COG: suggest IGNORE_COG_LAYOUT_BREAK=YES

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -4515,11 +4515,16 @@ bool QgsGdalProvider::setEditable( bool enabled )
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,8,0)
   // Check if this is a GTiff with COG layout because otherwise it won't open in update mode.
-  if ( mDriverName == "GTiff"_L1 && GDALGetMetadataItem( mGdalBaseDataset, "LAYOUT", "IMAGE_STRUCTURE" ) == "COG"_L1 && !dataSourceUri().contains( "IGNORE_COG_LAYOUT_BREAK=YES"_L1, Qt::CaseSensitivity::CaseInsensitive ) )
+  if ( mDriverName == "GTiff"_L1 )
   {
-    QString msg = u"Cannot reopen GDAL dataset %1 in update mode because it would possibly break COG layout,\nset the open option IGNORE_COG_LAYOUT_BREAK=YES to override."_s.arg( dataSourceUri() );
-    appendError( ERRMSG( msg ) );
-    return false;
+    const char *layout = GDALGetMetadataItem( mGdalBaseDataset, "LAYOUT", "IMAGE_STRUCTURE" );
+    if ( layout && EQUAL( layout, "COG" ) &&
+         !dataSourceUri().contains( "IGNORE_COG_LAYOUT_BREAK=YES"_L1, Qt::CaseSensitivity::CaseInsensitive ) )
+    {
+      QString msg = u"Cannot reopen GDAL dataset %1 in update mode because it would possibly break COG layout,\nset the open option IGNORE_COG_LAYOUT_BREAK=YES to override."_s.arg( dataSourceUri() );
+      appendError( ERRMSG( msg ) );
+      return false;
+    }
   }
 #endif
 

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -44,7 +44,7 @@ void QgsRasterDataProvider::setUseSourceNoDataValue( int bandNo, bool use )
 
   if ( mUseSrcNoDataValue.size() < bandNo )
   {
-    for ( int i = mUseSrcNoDataValue.size(); i < bandNo; i++ )
+    for ( qsizetype i = mUseSrcNoDataValue.size(); i < bandNo; i++ )
     {
       mUseSrcNoDataValue.append( false );
     }
@@ -1002,7 +1002,8 @@ QgsRasterDataProvider::VirtualRasterParameters QgsRasterDataProvider::decodeVirt
   }
   components.formula = query.queryItemValue( u"formula"_s );
 
-  for ( const auto &item : query.queryItems() )
+  const QList<std::pair<QString, QString> > &queryItems { query.queryItems() };
+  for ( const auto &item : std::as_const( queryItems ) )
   {
     if ( !( item.first.mid( item.first.indexOf( ':' ), -1 ) == ":uri"_L1 ) )
     {

--- a/tests/src/python/test_qgsrasterattributetable.py
+++ b/tests/src/python/test_qgsrasterattributetable.py
@@ -1602,8 +1602,8 @@ class TestQgsRasterAttributeTable(QgisTestCase):
     def test_COG_layout(self):
         # Create a 2x2 cog raster using GDAL
         tif_path = os.path.join(self.temp_path, "cog_layout.tif")
-        driver = gdal.GetDriverByName("COG")
-        dataset = driver.Create(tif_path, 2, 2, 1, gdal.GDT_Byte)
+        driver = gdal.GetDriverByName("MEM")
+        dataset = driver.Create("cog_layout.tif", 2, 2, 1, gdal.GDT_Byte)
         # Set CRS and geotransform to avoid warnings when opening the raster in QGIS
         dataset.SetGeoTransform((0, 1, 0, 0, 0, -1))
         srs = osr.SpatialReference()
@@ -1612,6 +1612,12 @@ class TestQgsRasterAttributeTable(QgisTestCase):
         dataset.GetRasterBand(1).Fill(0)
         dataset.GetRasterBand(1).FlushCache()
         dataset.FlushCache()
+
+        gdal.GetDriverByName("COG").CreateCopy(
+            tif_path,
+            dataset,
+        )
+
         dataset = None
 
         raster = QgsRasterLayer(tif_path)


### PR DESCRIPTION
Fixes #65040

Suggest to set IGNORE_COG_LAYOUT_BREAK=YES when
an internal RAT cannot be saved (and more in general when a request to open in RW mode is made on a COG).
