### PR TITLE
remove GroupedDragging for docks

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1028,7 +1028,7 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
 
   mScreenHelper = new QgsScreenHelper( this );
 
-  setDockOptions( dockOptions() | QMainWindow::GroupedDragging );
+  setDockOptions( dockOptions() );
 
   QgsDockableWidgetHelper::sAddTabifiedDockWidgetFunction = []( Qt::DockWidgetArea dockArea, QDockWidget *dock, const QStringList &tabSiblings, bool raiseTab ) {
     QgisApp::instance()->addTabifiedDockWidget( dockArea, dock, tabSiblings, raiseTab );


### PR DESCRIPTION
fixes #62416

* the crash in #62416 was not directly introduced by #60245 but rather revealed.
* it's the default mode from dialog to dock that revealed this crash. But reverting that change would make no sense if we keep the default setting (which was not working until recently https://github.com/qgis/QGIS/pull/64954)

Further down an explanation of the crash (produced by Claude LLM).

If we consider this non fixable (which I am not certain), I see 3 options:
1. Revert the default to dialog + remove the setting for the default mode
2. Automatically switch to a dialog as long as the dock isn't docked anymore (so do not authorize `Qt::NoDockWidgetArea`)
3. Disable groupped dragging

I am personnaly in favor of the latter: it's the simplest and safest, and also I was always confused by this behavior and would expect only 1 dock to be dragged.

But I'd like to hear your opinion :)


**************

### Why `GroupedDragging` causes the crash (LLM generated)

When `QMainWindow::GroupedDragging` is enabled (as in `qgisapp.cpp` line 1031), Qt allows **floating** `QDockWidget`s to be dragged over each other and merged into a **`QDockWidgetGroupWindow`** — an internal Qt container that hosts multiple dock widgets in a tab bar.

Here's the sequence that crashes:

1. **Two attribute table docks are floating.** Each is a `QgsDockWidget` (subclass of `QDockWidget`) created by `QgsDockableWidgetHelper::toggleDockMode(true)`.

5. **User drags dock A over dock B.** Qt's `QMainWindowLayout::hover()` detects the overlap and creates a `QDockWidgetGroupWindow` to group them. This triggers `QDockWidgetGroupWindow::restore()`, which internally builds a `QDockAreaLayoutInfo` to manage the tab layout.

6. **Qt's internal layout code iterates dock items** via `QDockAreaLayoutInfo::isEmpty()` → `QDockAreaLayoutItem::skip()`. This code assumes dock widgets are properly registered in the main window's internal layout structures. But floating dock widgets that were **never truly docked** in the main window (or were added/removed dynamically) may have **stale or missing entries** in `QMainWindowLayout`'s internal `QDockAreaLayout`.

7. **The `QDockAreaLayoutItem` references a dangling/invalid widget pointer** — either because the dock widget was already removed from the layout, or because the `QDockWidgetGroupWindow`'s internal state is inconsistent (e.g., it tries to access a dock widget's `QDockWidgetLayout` that has already been partially torn down). This causes the access violation in `QDockAreaLayoutItem::skip()`.

8. **For the `QTabBar::mouseReleaseEvent` crash**: once the docks are grouped into a `QDockWidgetGroupWindow`, releasing the mouse triggers `QTabBar::mouseReleaseEvent`. If during the grouping process the `QgsDockWidget::closeEvent` fires (Qt may hide/close/reparent widgets during regrouping), the `closed()` signal chain causes `WA_DeleteOnClose` → synchronous destruction of the `QgsAttributeTableDialog` → destruction of the dock widget **while the `QTabBar` is still processing the mouse event** on a tab that referenced the now-destroyed dock.

In short: Qt's `GroupedDragging` + `QDockWidgetGroupWindow` machinery assumes dock widgets have stable lifetimes and properly initialized internal layout state. QGIS's attribute table docks violate both assumptions — they can be destroyed mid-event, and they're dynamically created floating docks that Qt's layout bookkeeping doesn't properly track.

