### PR TITLE
respect dock/dialog setting when opening the attribute table

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -296,11 +296,10 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   // info from table to application
   connect( this, &QgsAttributeTableDialog::saveEdits, this, [] { QgisApp::instance()->saveEdits(); } );
 
-  QgsDockableWidgetHelper::OpeningMode openingMode = QgsDockableWidgetHelper::OpeningMode::RespectSetting;
+  QgsDockableWidgetHelper::OpeningMode openingMode = QgsAttributeTableDialog::settingsAttributeTableDefaultDocked->value() ? QgsDockableWidgetHelper::OpeningMode::ForceDocked : QgsDockableWidgetHelper::OpeningMode::ForceDialog;
   if ( initiallyDocked )
     openingMode = *initiallyDocked ? QgsDockableWidgetHelper::OpeningMode::ForceDocked : QgsDockableWidgetHelper::OpeningMode::ForceDialog;
-  bool defaultDocked = QgsAttributeTableDialog::settingsAttributeTableDefaultDocked->value();
-  mDockableWidgetHelper = new QgsDockableWidgetHelper( windowTitle(), this, QgisApp::instance(), u"attribute-table"_s, QStringList(), openingMode, defaultDocked, Qt::BottomDockWidgetArea );
+  mDockableWidgetHelper = new QgsDockableWidgetHelper( windowTitle(), this, QgisApp::instance(), u"attribute-table"_s, QStringList(), openingMode, false, Qt::BottomDockWidgetArea );
   toggleShortcuts( !mDockableWidgetHelper->isDocked() );
   connect( mDockableWidgetHelper, &QgsDockableWidgetHelper::closed, this, [this]() {
     close();

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -62,7 +62,7 @@
 
 using namespace Qt::StringLiterals;
 
-const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAttributeTableDefaultDocked = new QgsSettingsEntryBool( u"attribute-table-default-docked"_s, QgsSettingsTree::sTreeAttributeTable, true, u"If true, attribute tables will be docked by default."_s );
+const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAttributeTableDefaultDocked = new QgsSettingsEntryBool( u"attribute-table-default-docked"_s, QgsSettingsTree::sTreeAttributeTable, false, u"If true, attribute tables will be docked by default."_s );
 
 const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAutosizeAttributeTable = new QgsSettingsEntryBool( u"autosize-attribute-table"_s, QgsSettingsTree::sTreeAttributeTable, false );
 

--- a/src/app/qgsversionmigration.cpp
+++ b/src/app/qgsversionmigration.cpp
@@ -16,6 +16,7 @@
 #include "qgsversionmigration.h"
 
 #include "qgsapplication.h"
+#include "qgsattributetabledialog.h"
 #include "qgsfileutils.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
@@ -386,6 +387,12 @@ QgsError Qgs3To4Migration::runMigration( const QString &oldProfilePath, const QS
 
   QgsSettings newSettings;
   newSettings.setValue( u"migration/migrated_from_3"_s, true );
+
+  if ( newSettings.value( u"qgis/dockAttributeTable"_s, false ).toBool() )
+  {
+    QgsAttributeTableDialog::settingsAttributeTableDefaultDocked->setValue( true );
+    newSettings.remove( u"qgis/dockAttributeTable"_s );
+  }
 
   return errors;
 }


### PR DESCRIPTION
take 2 for #62416

with this, it will always respect the setting (except in initiallyDocked is provided)