### PR TITLE
expose label suffix to the layout charts properties (fix #63465)

### DIFF
--- a/src/gui/plot/qgsplotwidget.cpp
+++ b/src/gui/plot/qgsplotwidget.cpp
@@ -304,6 +304,12 @@ QgsBarChartPlotWidget::QgsBarChartPlotWidget( QWidget *parent )
     emit widgetChanged();
   } );
 
+  connect( mXAxisLabelSuffix, &QLineEdit::textChanged, this, [this] {
+    if ( mBlockChanges )
+      return;
+    emit widgetChanged();
+  } );
+
   mXAxisLabelsCombo->addItem( tr( "None" ), QVariant::fromValue( Qgis::PlotAxisSuffixPlacement::NoLabels ) );
   mXAxisLabelsCombo->addItem( tr( "Every Value" ), QVariant::fromValue( Qgis::PlotAxisSuffixPlacement::EveryLabel ) );
   mXAxisLabelsCombo->addItem( tr( "First Value" ), QVariant::fromValue( Qgis::PlotAxisSuffixPlacement::FirstLabel ) );
@@ -456,6 +462,7 @@ void QgsBarChartPlotWidget::setPlot( QgsPlot *plot )
   mYAxisNumericFormat.reset( chartPlot->yAxis().numericFormat()->clone() );
 
   mXAxisTypeCombo->setCurrentIndex( mXAxisTypeCombo->findData( QVariant::fromValue( chartPlot->xAxis().type() ) ) );
+  mXAxisLabelSuffix->setText( chartPlot->xAxis().labelSuffix() );
   mXAxisLabelsCombo->setCurrentIndex( mXAxisLabelsCombo->findData( QVariant::fromValue( chartPlot->xAxis().labelSuffixPlacement() ) ) );
 
   mXAxisMajorIntervalSpin->setValue( chartPlot->xAxis().gridIntervalMajor() );
@@ -535,6 +542,7 @@ QgsPlot *QgsBarChartPlotWidget::createPlot()
   chartPlot->yAxis().setNumericFormat( mYAxisNumericFormat.get()->clone() );
 
   chartPlot->xAxis().setType( mXAxisTypeCombo->currentData().value<Qgis::PlotAxisType>() );
+  chartPlot->xAxis().setLabelSuffix( mXAxisLabelSuffix->text() );
   chartPlot->xAxis().setLabelSuffixPlacement( mXAxisLabelsCombo->currentData().value<Qgis::PlotAxisSuffixPlacement>() );
 
   chartPlot->xAxis().setGridIntervalMajor( mXAxisMajorIntervalSpin->value() );
@@ -769,6 +777,12 @@ QgsLineChartPlotWidget::QgsLineChartPlotWidget( QWidget *parent )
     emit widgetChanged();
   } );
 
+  connect( mXAxisLabelSuffix, &QLineEdit::textChanged, this, [this] {
+    if ( mBlockChanges )
+      return;
+    emit widgetChanged();
+  } );
+
   mXAxisLabelsCombo->addItem( tr( "None" ), QVariant::fromValue( Qgis::PlotAxisSuffixPlacement::NoLabels ) );
   mXAxisLabelsCombo->addItem( tr( "Every Value" ), QVariant::fromValue( Qgis::PlotAxisSuffixPlacement::EveryLabel ) );
   mXAxisLabelsCombo->addItem( tr( "First Value" ), QVariant::fromValue( Qgis::PlotAxisSuffixPlacement::FirstLabel ) );
@@ -949,6 +963,7 @@ void QgsLineChartPlotWidget::setPlot( QgsPlot *plot )
   mYAxisLabelFontButton->setTextFormat( chartPlot->yAxis().textFormat() );
 
   mXAxisTypeCombo->setCurrentIndex( mXAxisTypeCombo->findData( QVariant::fromValue( chartPlot->xAxis().type() ) ) );
+  mXAxisLabelSuffix->setText( chartPlot->xAxis().labelSuffix() );
   mXAxisLabelsCombo->setCurrentIndex( mXAxisLabelsCombo->findData( QVariant::fromValue( chartPlot->xAxis().labelSuffixPlacement() ) ) );
 
   mXAxisMajorIntervalSpin->setValue( chartPlot->xAxis().gridIntervalMajor() );
@@ -1032,6 +1047,7 @@ QgsPlot *QgsLineChartPlotWidget::createPlot()
   chartPlot->yAxis().setTextFormat( mYAxisLabelFontButton->textFormat() );
 
   chartPlot->xAxis().setType( mXAxisTypeCombo->currentData().value<Qgis::PlotAxisType>() );
+  chartPlot->xAxis().setLabelSuffix( mXAxisLabelSuffix->text() );
   chartPlot->xAxis().setLabelSuffixPlacement( mXAxisLabelsCombo->currentData().value<Qgis::PlotAxisSuffixPlacement>() );
 
   chartPlot->xAxis().setGridIntervalMajor( mXAxisMajorIntervalSpin->value() );

--- a/src/gui/plot/qgsplotwidget.cpp
+++ b/src/gui/plot/qgsplotwidget.cpp
@@ -304,7 +304,7 @@ QgsBarChartPlotWidget::QgsBarChartPlotWidget( QWidget *parent )
     emit widgetChanged();
   } );
 
-  connect( mXAxisLabelSuffix, &QLineEdit::textChanged, this, [this] {
+  connect( mXAxisLabelSuffixEdit, &QLineEdit::textChanged, this, [this] {
     if ( mBlockChanges )
       return;
     emit widgetChanged();
@@ -389,6 +389,8 @@ void QgsBarChartPlotWidget::updateXAxisProperties()
 {
   const bool enable = mXAxisTypeCombo->currentData().value<Qgis::PlotAxisType>() == Qgis::PlotAxisType::Interval;
 
+  mXAxisLabelSuffixLabel->setEnabled( enable );
+  mXAxisLabelSuffixEdit->setEnabled( enable );
   mLabelMinXAxis->setEnabled( enable );
   mSpinMinXAxis->setEnabled( enable );
   mDDBtnMinXAxis->setEnabled( enable );
@@ -462,7 +464,7 @@ void QgsBarChartPlotWidget::setPlot( QgsPlot *plot )
   mYAxisNumericFormat.reset( chartPlot->yAxis().numericFormat()->clone() );
 
   mXAxisTypeCombo->setCurrentIndex( mXAxisTypeCombo->findData( QVariant::fromValue( chartPlot->xAxis().type() ) ) );
-  mXAxisLabelSuffix->setText( chartPlot->xAxis().labelSuffix() );
+  mXAxisLabelSuffixEdit->setText( chartPlot->xAxis().labelSuffix() );
   mXAxisLabelsCombo->setCurrentIndex( mXAxisLabelsCombo->findData( QVariant::fromValue( chartPlot->xAxis().labelSuffixPlacement() ) ) );
 
   mXAxisMajorIntervalSpin->setValue( chartPlot->xAxis().gridIntervalMajor() );
@@ -542,7 +544,7 @@ QgsPlot *QgsBarChartPlotWidget::createPlot()
   chartPlot->yAxis().setNumericFormat( mYAxisNumericFormat.get()->clone() );
 
   chartPlot->xAxis().setType( mXAxisTypeCombo->currentData().value<Qgis::PlotAxisType>() );
-  chartPlot->xAxis().setLabelSuffix( mXAxisLabelSuffix->text() );
+  chartPlot->xAxis().setLabelSuffix( mXAxisLabelSuffixEdit->text() );
   chartPlot->xAxis().setLabelSuffixPlacement( mXAxisLabelsCombo->currentData().value<Qgis::PlotAxisSuffixPlacement>() );
 
   chartPlot->xAxis().setGridIntervalMajor( mXAxisMajorIntervalSpin->value() );
@@ -777,7 +779,7 @@ QgsLineChartPlotWidget::QgsLineChartPlotWidget( QWidget *parent )
     emit widgetChanged();
   } );
 
-  connect( mXAxisLabelSuffix, &QLineEdit::textChanged, this, [this] {
+  connect( mXAxisLabelSuffixEdit, &QLineEdit::textChanged, this, [this] {
     if ( mBlockChanges )
       return;
     emit widgetChanged();
@@ -877,6 +879,8 @@ void QgsLineChartPlotWidget::updateXAxisProperties()
 {
   const bool enable = mXAxisTypeCombo->currentData().value<Qgis::PlotAxisType>() == Qgis::PlotAxisType::Interval;
 
+  mXAxisLabelSuffixLabel->setEnabled( enable );
+  mXAxisLabelSuffixEdit->setEnabled( enable );
   mLabelMinXAxis->setEnabled( enable );
   mSpinMinXAxis->setEnabled( enable );
   mDDBtnMinXAxis->setEnabled( enable );
@@ -963,7 +967,7 @@ void QgsLineChartPlotWidget::setPlot( QgsPlot *plot )
   mYAxisLabelFontButton->setTextFormat( chartPlot->yAxis().textFormat() );
 
   mXAxisTypeCombo->setCurrentIndex( mXAxisTypeCombo->findData( QVariant::fromValue( chartPlot->xAxis().type() ) ) );
-  mXAxisLabelSuffix->setText( chartPlot->xAxis().labelSuffix() );
+  mXAxisLabelSuffixEdit->setText( chartPlot->xAxis().labelSuffix() );
   mXAxisLabelsCombo->setCurrentIndex( mXAxisLabelsCombo->findData( QVariant::fromValue( chartPlot->xAxis().labelSuffixPlacement() ) ) );
 
   mXAxisMajorIntervalSpin->setValue( chartPlot->xAxis().gridIntervalMajor() );
@@ -1047,7 +1051,7 @@ QgsPlot *QgsLineChartPlotWidget::createPlot()
   chartPlot->yAxis().setTextFormat( mYAxisLabelFontButton->textFormat() );
 
   chartPlot->xAxis().setType( mXAxisTypeCombo->currentData().value<Qgis::PlotAxisType>() );
-  chartPlot->xAxis().setLabelSuffix( mXAxisLabelSuffix->text() );
+  chartPlot->xAxis().setLabelSuffix( mXAxisLabelSuffixEdit->text() );
   chartPlot->xAxis().setLabelSuffixPlacement( mXAxisLabelsCombo->currentData().value<Qgis::PlotAxisSuffixPlacement>() );
 
   chartPlot->xAxis().setGridIntervalMajor( mXAxisMajorIntervalSpin->value() );

--- a/src/ui/plot/qgsbarchartplotwidgetbase.ui
+++ b/src/ui/plot/qgsbarchartplotwidgetbase.ui
@@ -47,7 +47,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-468</y>
         <width>548</width>
         <height>1215</height>
        </rect>
@@ -251,77 +251,31 @@
           <string>X Axis</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,2,0">
-          <item row="2" column="2">
-           <widget class="QgsDoubleSpinBox" name="mXAxisMajorIntervalSpin">
-            <property name="decimals">
-             <number>6</number>
-            </property>
-            <property name="minimum">
-             <double>0.000001000000000</double>
-            </property>
-            <property name="maximum">
-             <double>999999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="3">
-           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisLabelInterval">
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_10">
             <property name="text">
-             <string>…</string>
+             <string>Label format</string>
             </property>
            </widget>
-          </item>
-          <item row="6" column="0" colspan="2">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>Label interval</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Minor grid lines</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="2">
-           <widget class="QgsDoubleSpinBox" name="mXAxisLabelIntervalSpin">
-            <property name="decimals">
-             <number>6</number>
-            </property>
-            <property name="minimum">
-             <double>0.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>999999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_18">
-            <property name="text">
-             <string>Axis type</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="2" colspan="2">
-           <widget class="QComboBox" name="mXAxisLabelsCombo"/>
-          </item>
-          <item row="2" column="3">
-           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMajorInterval">
-            <property name="text">
-             <string>…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2" colspan="2">
-           <widget class="QComboBox" name="mXAxisTypeCombo"/>
           </item>
           <item row="9" column="0">
            <widget class="QLabel" name="label_28">
             <property name="text">
              <string>Label placement</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="3">
+           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMinorInterval">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
+           <widget class="QLabel" name="mXAxisMinorIntervalLabel">
+            <property name="text">
+             <string>Minor interval</string>
             </property>
            </widget>
           </item>
@@ -338,74 +292,6 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="2" colspan="2">
-           <widget class="QgsSymbolButton" name="mXAxisMinorLinesSymbolButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Change…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2" colspan="2">
-           <widget class="QgsSymbolButton" name="mXAxisMajorLinesSymbolButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Change…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Label font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Minor interval</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Label format</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="3">
-           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMinorInterval">
-            <property name="text">
-             <string>…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Major grid lines</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="2" colspan="2">
-           <widget class="QPushButton" name="mXAxisLabelFormatButton">
-            <property name="text">
-             <string>Customize</string>
-            </property>
-           </widget>
-          </item>
           <item row="4" column="2">
            <widget class="QgsDoubleSpinBox" name="mXAxisMinorIntervalSpin">
             <property name="decimals">
@@ -419,10 +305,124 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Axis type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2" colspan="2">
+           <widget class="QPushButton" name="mXAxisLabelFormatButton">
+            <property name="text">
+             <string>Customize</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMajorInterval">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0" colspan="2">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Label interval</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Label font</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="mXAxisMajorLinesLabel">
+            <property name="text">
+             <string>Major grid lines</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2" colspan="2">
+           <widget class="QgsSymbolButton" name="mXAxisMinorLinesSymbolButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Change…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="3">
+           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisLabelInterval">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="mXAxisMinorLinesLabel">
+            <property name="text">
+             <string>Minor grid lines</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="2" colspan="2">
+           <widget class="QComboBox" name="mXAxisLabelsCombo"/>
+          </item>
+          <item row="6" column="2">
+           <widget class="QgsDoubleSpinBox" name="mXAxisLabelIntervalSpin">
+            <property name="decimals">
+             <number>6</number>
+            </property>
+            <property name="minimum">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>999999999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2" colspan="2">
+           <widget class="QComboBox" name="mXAxisTypeCombo"/>
+          </item>
+          <item row="2" column="2">
+           <widget class="QgsDoubleSpinBox" name="mXAxisMajorIntervalSpin">
+            <property name="decimals">
+             <number>6</number>
+            </property>
+            <property name="minimum">
+             <double>0.000001000000000</double>
+            </property>
+            <property name="maximum">
+             <double>999999999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="mLabelXAxisMajorInterval">
+           <widget class="QLabel" name="mXAxisMajorIntervalLabel">
             <property name="text">
              <string>Major interval</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2" colspan="2">
+           <widget class="QgsSymbolButton" name="mXAxisMajorLinesSymbolButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Change…</string>
             </property>
            </widget>
           </item>

--- a/src/ui/plot/qgsbarchartplotwidgetbase.ui
+++ b/src/ui/plot/qgsbarchartplotwidgetbase.ui
@@ -49,7 +49,7 @@
         <x>0</x>
         <y>0</y>
         <width>548</width>
-        <height>1183</height>
+        <height>1215</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -251,44 +251,7 @@
           <string>X Axis</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,2,0">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_18">
-            <property name="text">
-             <string>Axis type</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2" colspan="2">
-           <widget class="QComboBox" name="mXAxisTypeCombo"/>
-          </item>
-          <item row="5" column="3">
-           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisLabelInterval">
-            <property name="text">
-             <string>…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2" colspan="2">
-           <widget class="QgsSymbolButton" name="mXAxisMajorLinesSymbolButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Change…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="2" colspan="2">
-           <widget class="QPushButton" name="mXAxisLabelFormatButton">
-            <property name="text">
-             <string>Customize</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
+          <item row="2" column="2">
            <widget class="QgsDoubleSpinBox" name="mXAxisMajorIntervalSpin">
             <property name="decimals">
              <number>6</number>
@@ -301,88 +264,28 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="2">
+          <item row="6" column="3">
+           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisLabelInterval">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0" colspan="2">
            <widget class="QLabel" name="label_8">
             <property name="text">
              <string>Label interval</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Label font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="mXAxisMinorLinesLabel">
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_5">
             <property name="text">
              <string>Minor grid lines</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="2" colspan="2">
-           <widget class="QgsFontButton" name="mXAxisLabelFontButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2" colspan="2">
-           <widget class="QgsSymbolButton" name="mXAxisMinorLinesSymbolButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Change…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QgsDoubleSpinBox" name="mXAxisMinorIntervalSpin">
-            <property name="decimals">
-             <number>6</number>
-            </property>
-            <property name="minimum">
-             <double>0.000001000000000</double>
-            </property>
-            <property name="maximum">
-             <double>999999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="mXAxisMajorIntervalLabel">
-            <property name="text">
-             <string>Major interval</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMajorInterval">
-            <property name="text">
-             <string>…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QLabel" name="mXAxisMinorIntervalLabel">
-            <property name="text">
-             <string>Minor interval</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="2">
+          <item row="6" column="2">
            <widget class="QgsDoubleSpinBox" name="mXAxisLabelIntervalSpin">
             <property name="decimals">
              <number>6</number>
@@ -395,28 +298,27 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_10">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_18">
             <property name="text">
-             <string>Label format</string>
+             <string>Axis type</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="3">
-           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMinorInterval">
+          <item row="9" column="2" colspan="2">
+           <widget class="QComboBox" name="mXAxisLabelsCombo"/>
+          </item>
+          <item row="2" column="3">
+           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMajorInterval">
             <property name="text">
              <string>…</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="mXAxisMajorLinesLabel">
-            <property name="text">
-             <string>Major grid lines</string>
-            </property>
-           </widget>
+          <item row="0" column="2" colspan="2">
+           <widget class="QComboBox" name="mXAxisTypeCombo"/>
           </item>
-          <item row="8" column="0">
+          <item row="9" column="0">
            <widget class="QLabel" name="label_28">
             <property name="text">
              <string>Label placement</string>
@@ -424,7 +326,115 @@
            </widget>
           </item>
           <item row="8" column="2" colspan="2">
-           <widget class="QComboBox" name="mXAxisLabelsCombo"/>
+           <widget class="QgsFontButton" name="mXAxisLabelFontButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Font</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2" colspan="2">
+           <widget class="QgsSymbolButton" name="mXAxisMinorLinesSymbolButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Change…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2" colspan="2">
+           <widget class="QgsSymbolButton" name="mXAxisMajorLinesSymbolButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Change…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Label font</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Minor interval</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Label format</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="3">
+           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMinorInterval">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Major grid lines</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2" colspan="2">
+           <widget class="QPushButton" name="mXAxisLabelFormatButton">
+            <property name="text">
+             <string>Customize</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QgsDoubleSpinBox" name="mXAxisMinorIntervalSpin">
+            <property name="decimals">
+             <number>6</number>
+            </property>
+            <property name="minimum">
+             <double>0.000001000000000</double>
+            </property>
+            <property name="maximum">
+             <double>999999999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="mLabelXAxisMajorInterval">
+            <property name="text">
+             <string>Major interval</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="mXAxisLabelSuffixLabel">
+            <property name="text">
+             <string>Axis label suffix</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2" colspan="2">
+           <widget class="QLineEdit" name="mXAxisLabelSuffixEdit"/>
           </item>
          </layout>
         </widget>
@@ -795,6 +805,11 @@
   <tabstop>mDDBtnMinYAxis</tabstop>
   <tabstop>mSpinMaxYAxis</tabstop>
   <tabstop>mDDBtnMaxYAxis</tabstop>
+  <tabstop>mAddSymbolPushButton</tabstop>
+  <tabstop>mRemoveSymbolPushButton</tabstop>
+  <tabstop>mSymbolsList</tabstop>
+  <tabstop>mXAxisTypeCombo</tabstop>
+  <tabstop>mXAxisLabelSuffixEdit</tabstop>
   <tabstop>mXAxisMajorIntervalSpin</tabstop>
   <tabstop>mDDBtnXAxisMajorInterval</tabstop>
   <tabstop>mXAxisMajorLinesSymbolButton</tabstop>

--- a/src/ui/plot/qgslinechartplotwidgetbase.ui
+++ b/src/ui/plot/qgslinechartplotwidgetbase.ui
@@ -49,7 +49,7 @@
         <x>0</x>
         <y>0</y>
         <width>548</width>
-        <height>1183</height>
+        <height>1215</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -251,44 +251,62 @@
           <string>X Axis</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,2,0">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_18">
-            <property name="text">
-             <string>Axis type</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2" colspan="2">
-           <widget class="QComboBox" name="mXAxisTypeCombo"/>
-          </item>
-          <item row="5" column="3">
+          <item row="6" column="3">
            <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisLabelInterval">
             <property name="text">
              <string>…</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="2" colspan="2">
-           <widget class="QgsSymbolButton" name="mXAxisMajorLinesSymbolButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Change…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="2" colspan="2">
+          <item row="7" column="2" colspan="2">
            <widget class="QPushButton" name="mXAxisLabelFormatButton">
             <property name="text">
              <string>Customize</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Major interval</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Major grid lines</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="2" colspan="2">
+           <widget class="QComboBox" name="mXAxisLabelsCombo"/>
+          </item>
+          <item row="6" column="0" colspan="2">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Label interval</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="3">
+           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMinorInterval">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Label format</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2" colspan="2">
+           <widget class="QComboBox" name="mXAxisTypeCombo"/>
+          </item>
+          <item row="2" column="2">
            <widget class="QgsDoubleSpinBox" name="mXAxisMajorIntervalSpin">
             <property name="decimals">
              <number>6</number>
@@ -301,54 +319,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="2">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>Label interval</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Label font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="mXAxisMinorLinesLabel">
-            <property name="text">
-             <string>Minor grid lines</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="2" colspan="2">
-           <widget class="QgsFontButton" name="mXAxisLabelFontButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2" colspan="2">
-           <widget class="QgsSymbolButton" name="mXAxisMinorLinesSymbolButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Change…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
+          <item row="4" column="2">
            <widget class="QgsDoubleSpinBox" name="mXAxisMinorIntervalSpin">
             <property name="decimals">
              <number>6</number>
@@ -361,28 +332,75 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="mXAxisMajorIntervalLabel">
-            <property name="text">
-             <string>Major interval</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
+          <item row="2" column="3">
            <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMajorInterval">
             <property name="text">
              <string>…</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QLabel" name="mXAxisMinorIntervalLabel">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Axis type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="label_28">
+            <property name="text">
+             <string>Label placement</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Label font</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Minor grid lines</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2" colspan="2">
+           <widget class="QgsSymbolButton" name="mXAxisMinorLinesSymbolButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Change…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2" colspan="2">
+           <widget class="QgsSymbolButton" name="mXAxisMajorLinesSymbolButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Change…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
+           <widget class="QLabel" name="label_7">
             <property name="text">
              <string>Minor interval</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="2">
+          <item row="6" column="2">
            <widget class="QgsDoubleSpinBox" name="mXAxisLabelIntervalSpin">
             <property name="decimals">
              <number>6</number>
@@ -395,36 +413,28 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Label format</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMinorInterval">
-            <property name="text">
-             <string>…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="mXAxisMajorLinesLabel">
-            <property name="text">
-             <string>Major grid lines</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="label_28">
-            <property name="text">
-             <string>Label placement</string>
-            </property>
-           </widget>
-          </item>
           <item row="8" column="2" colspan="2">
-           <widget class="QComboBox" name="mXAxisLabelsCombo"/>
+           <widget class="QgsFontButton" name="mXAxisLabelFontButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Font</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="mXAxisLabelSuffixLabel">
+            <property name="text">
+             <string>Axis label suffix</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2" colspan="2">
+           <widget class="QLineEdit" name="mXAxisLabelSuffixEdit"/>
           </item>
          </layout>
         </widget>
@@ -795,6 +805,11 @@
   <tabstop>mDDBtnMinYAxis</tabstop>
   <tabstop>mSpinMaxYAxis</tabstop>
   <tabstop>mDDBtnMaxYAxis</tabstop>
+  <tabstop>mAddSymbolPushButton</tabstop>
+  <tabstop>mRemoveSymbolPushButton</tabstop>
+  <tabstop>mSymbolsList</tabstop>
+  <tabstop>mXAxisTypeCombo</tabstop>
+  <tabstop>mXAxisLabelSuffixEdit</tabstop>
   <tabstop>mXAxisMajorIntervalSpin</tabstop>
   <tabstop>mDDBtnXAxisMajorInterval</tabstop>
   <tabstop>mXAxisMajorLinesSymbolButton</tabstop>

--- a/src/ui/plot/qgslinechartplotwidgetbase.ui
+++ b/src/ui/plot/qgslinechartplotwidgetbase.ui
@@ -47,7 +47,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-468</y>
         <width>548</width>
         <height>1215</height>
        </rect>
@@ -251,37 +251,6 @@
           <string>X Axis</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,2,0">
-          <item row="6" column="3">
-           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisLabelInterval">
-            <property name="text">
-             <string>…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="2" colspan="2">
-           <widget class="QPushButton" name="mXAxisLabelFormatButton">
-            <property name="text">
-             <string>Customize</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Major interval</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Major grid lines</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="2" colspan="2">
-           <widget class="QComboBox" name="mXAxisLabelsCombo"/>
-          </item>
           <item row="6" column="0" colspan="2">
            <widget class="QLabel" name="label_8">
             <property name="text">
@@ -289,8 +258,11 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="3">
-           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMinorInterval">
+          <item row="0" column="2" colspan="2">
+           <widget class="QComboBox" name="mXAxisTypeCombo"/>
+          </item>
+          <item row="2" column="3">
+           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMajorInterval">
             <property name="text">
              <string>…</string>
             </property>
@@ -300,70 +272,6 @@
            <widget class="QLabel" name="label_10">
             <property name="text">
              <string>Label format</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2" colspan="2">
-           <widget class="QComboBox" name="mXAxisTypeCombo"/>
-          </item>
-          <item row="2" column="2">
-           <widget class="QgsDoubleSpinBox" name="mXAxisMajorIntervalSpin">
-            <property name="decimals">
-             <number>6</number>
-            </property>
-            <property name="minimum">
-             <double>0.000001000000000</double>
-            </property>
-            <property name="maximum">
-             <double>999999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QgsDoubleSpinBox" name="mXAxisMinorIntervalSpin">
-            <property name="decimals">
-             <number>6</number>
-            </property>
-            <property name="minimum">
-             <double>0.000001000000000</double>
-            </property>
-            <property name="maximum">
-             <double>999999999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMajorInterval">
-            <property name="text">
-             <string>…</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_18">
-            <property name="text">
-             <string>Axis type</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0">
-           <widget class="QLabel" name="label_28">
-            <property name="text">
-             <string>Label placement</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Label font</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Minor grid lines</string>
             </property>
            </widget>
           </item>
@@ -380,6 +288,29 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="2">
+           <widget class="QgsDoubleSpinBox" name="mXAxisMajorIntervalSpin">
+            <property name="decimals">
+             <number>6</number>
+            </property>
+            <property name="minimum">
+             <double>0.000001000000000</double>
+            </property>
+            <property name="maximum">
+             <double>999999999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="2" colspan="2">
+           <widget class="QComboBox" name="mXAxisLabelsCombo"/>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="label_28">
+            <property name="text">
+             <string>Label placement</string>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="2" colspan="2">
            <widget class="QgsSymbolButton" name="mXAxisMajorLinesSymbolButton">
             <property name="sizePolicy">
@@ -393,10 +324,44 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="2">
+           <widget class="QgsDoubleSpinBox" name="mXAxisMinorIntervalSpin">
+            <property name="decimals">
+             <number>6</number>
+            </property>
+            <property name="minimum">
+             <double>0.000001000000000</double>
+            </property>
+            <property name="maximum">
+             <double>999999999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="3">
+           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisMinorInterval">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="mXAxisMajorLinesLabel">
+            <property name="text">
+             <string>Major grid lines</string>
+            </property>
+           </widget>
+          </item>
           <item row="4" column="0" colspan="2">
-           <widget class="QLabel" name="label_7">
+           <widget class="QLabel" name="mXAxisMinorIntervalLabel">
             <property name="text">
              <string>Minor interval</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Axis type</string>
             </property>
            </widget>
           </item>
@@ -423,6 +388,41 @@
             </property>
             <property name="text">
              <string>Font</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="mXAxisMajorIntervalLabel">
+            <property name="text">
+             <string>Major interval</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2" colspan="2">
+           <widget class="QPushButton" name="mXAxisLabelFormatButton">
+            <property name="text">
+             <string>Customize</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Label font</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="mXAxisMinorLinesLabel">
+            <property name="text">
+             <string>Minor grid lines</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="3">
+           <widget class="QgsPropertyOverrideButton" name="mDDBtnXAxisLabelInterval">
+            <property name="text">
+             <string>…</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
## Description

Layout chart items have "Label placement" property which is responsible for the placement of the axis label suffix. However, this property does nothing as there is no way to set axis label suffix.

This PR adds a new widget (line edit) to the layout chart item properties panel allowing to set  label suffix.

Fixes #63465.