### PR TITLE
Fix WMS LegendGraphic default style

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -409,15 +409,15 @@ QString QgsWmsProvider::getLegendGraphicUrl() const
         // QGIS wants the default style, but GetCapabilities doesn't give us a
         // way to know what is the default style. So we look for the onlineResource
         // only if there is a single style available or if there is a style called "default".
-        if ( l.style.size() == 1 )
+        const QgsWmsStyleProperty *s = searchStyle( l.style, u"default"_s );
+        if ( s )
         {
-          url = pickLegend( l.style[0] );
+          url = pickLegend( *s );
         }
         else
         {
-          const QgsWmsStyleProperty *s = searchStyle( l.style, u"default"_s );
-          if ( s )
-            url = pickLegend( *s );
+          // If no default style was found, use the first one
+          url = pickLegend( l.style[0] );
         }
       }
       break;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -406,9 +406,7 @@ QString QgsWmsProvider::getLegendGraphicUrl() const
       }
       else
       {
-        // QGIS wants the default style, but GetCapabilities doesn't give us a
-        // way to know what is the default style. So we look for the onlineResource
-        // only if there is a single style available or if there is a style called "default".
+        // Look for a default style
         const QgsWmsStyleProperty *s = searchStyle( l.style, u"default"_s );
         if ( s )
         {

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -412,7 +412,7 @@ QString QgsWmsProvider::getLegendGraphicUrl() const
         {
           url = pickLegend( *s );
         }
-        else
+        else if ( !l.style.empty() )
         {
           // If no default style was found, use the first one
           url = pickLegend( l.style[0] );

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -146,8 +146,8 @@ void TestQgsWmsProvider::legendGraphicsWithoutStyleWithDefault()
 void TestQgsWmsProvider::legendGraphicsWithoutStyleWithoutDefault()
 {
   QgsWmsProvider provider( u"http://localhost:8380/mapserv?xxx&layers=agri_zones&styles=&format=image/jpg"_s, QgsDataProvider::ProviderOptions(), mCapabilities );
-  //two style, cannot guess default => use the WMS GetLegendGraphics
-  QCOMPARE( provider.getLegendGraphicUrl(), QString( "http://localhost:8380/mapserv?" ) );
+  // two styles, use the first one by default to avoid not showing any legend at all
+  QCOMPARE( provider.getLegendGraphicUrl(), QString( "http://www.example.com/yt.png?" ) );
 }
 
 void TestQgsWmsProvider::queryItemsWithNullValue()


### PR DESCRIPTION
## Description

Use the first available style of WMS layer legend graphics if no default style was found, to avoid loading none at all.  

Closes #63754 

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
