### PR TITLE
Support bbox-epsg-XXXX placeholders in XYZ tile URLs

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1668,6 +1668,20 @@ void QgsWmsProvider::createTileRequestsXYZ( const QgsWmtsTileMatrix *tm, const Q
     ++i;
     QString turl( url );
 
+    // Add bbox placeholder resolution for WMS services using XYZ tiling with bbox parameters
+    static const QRegularExpression bboxRegex( R"(\{bbox-epsg-\d+\})", QRegularExpression::CaseInsensitiveOption );
+    if ( turl.contains( bboxRegex ) )
+    {
+      QgsRectangle tileRect = tm->tileRect( tile.col, tile.row );
+      QString bboxStr = QString( "%1,%2,%3,%4" )
+                          .arg( tileRect.xMinimum(), 0, 'f', 6 )
+                          .arg( tileRect.yMinimum(), 0, 'f', 6 )
+                          .arg( tileRect.xMaximum(), 0, 'f', 6 )
+                          .arg( tileRect.yMaximum(), 0, 'f', 6 );
+
+      turl.replace( bboxRegex, bboxStr );
+    }
+
     if ( turl.contains( "{q}"_L1 ) ) // used in Bing maps
       turl.replace( "{q}"_L1, _tile2quadkey( tile.col, tile.row, z ) );
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1669,9 +1669,22 @@ void QgsWmsProvider::createTileRequestsXYZ( const QgsWmtsTileMatrix *tm, const Q
     QString turl( url );
 
     // Add bbox placeholder resolution for WMS services using XYZ tiling with bbox parameters
-    static const QRegularExpression bboxRegex( R"(\{bbox-epsg-\d+\})", QRegularExpression::CaseInsensitiveOption );
-    if ( turl.contains( bboxRegex ) )
+    static const QRegularExpression bboxRegex( R"(\{bbox-epsg-(\d+)\})", QRegularExpression::CaseInsensitiveOption );
+    QRegularExpressionMatch bboxMatch = bboxRegex.match( turl );
+    if ( bboxMatch.hasMatch() )
     {
+      QString epsgCode = bboxMatch.captured( 1 );
+      QString currentEpsg = mImageCrs.mid( mImageCrs.lastIndexOf( ':' ) + 1 );
+      if ( currentEpsg != epsgCode )
+      {
+        QgsMessageLog::logMessage(
+          tr( "Warning: Bbox placeholder EPSG:%1 does not match current CRS %2" )
+            .arg( epsgCode, mImageCrs ),
+          tr( "WMS" ),
+          Qgis::MessageLevel::Warning
+        );
+      }
+
       QgsRectangle tileRect = tm->tileRect( tile.col, tile.row );
       QString bboxStr = QString( "%1,%2,%3,%4" )
                           .arg( tileRect.xMinimum(), 0, 'f', 6 )


### PR DESCRIPTION
## Description

Previously {bbox-epsg-XXXX} placeholders wouldn't be handled in XYZ tile requests. The url would just include the placeholder instead of the actual bbox values, thus the request would fail.

The placeholder is now replaced, if the url contains it.

Closes #61040 

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
