### PR TITLE
Fix decimal font size load from SLD style

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -5634,7 +5634,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
   }
 
   QString fontFamily = u"Sans-Serif"_s;
-  int fontPointSize = 10;
+  double fontPointSize = 10;
   Qgis::RenderUnit fontUnitSize = Qgis::RenderUnit::Points;
   int fontWeight = -1;
   bool fontItalic = false;
@@ -5660,7 +5660,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
       else if ( it.key() == "font-size"_L1 )
       {
         bool ok;
-        int fontSize = it.value().toInt( &ok );
+        double fontSize = it.value().toDouble( &ok );
         if ( ok )
         {
           fontPointSize = fontSize;
@@ -5680,7 +5680,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
   }
 
   QgsTextFormat format;
-  QFont font( fontFamily, fontPointSize, fontWeight, fontItalic );
+  QFont font( fontFamily, 1, fontWeight, fontItalic );
   font.setUnderline( fontUnderline );
   format.setFont( font );
   format.setSize( fontPointSize );

--- a/tests/src/python/test_qgssymbollayer_readsld.py
+++ b/tests/src/python/test_qgssymbollayer_readsld.py
@@ -505,6 +505,19 @@ class TestQgsSymbolLayerReadSld(QgisTestCase):
         self.assertEqual(settings.yOffset, 0)
         self.assertEqual(settings.offsetUnits, QgsUnitTypes.RenderUnit.RenderPixels)
 
+    def test_read_font_decimal(self):
+        layer = createLayerWithOnePoint()
+        mFilePath = os.path.join(
+            TEST_DATA_DIR, "symbol_layer/external_sld/decimal_font_size.sld"
+        )
+        layer.loadSldStyle(mFilePath)
+
+        settings = layer.labeling().settings()
+        format = settings.format()
+
+        self.assertEqual(format.size(), 13.5)
+        self.assertEqual(format.sizeUnit(), QgsUnitTypes.RenderUnit.RenderPixels)
+
     def test_read_circle(self):
         """Test wellknown name circle polygon fill"""
 

--- a/tests/testdata/symbol_layer/external_sld/decimal_font_size.sld
+++ b/tests/testdata/symbol_layer/external_sld/decimal_font_size.sld
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" version="1.1.0" xmlns:se="http://www.opengis.net/se">
+ <NamedLayer>
+  <se:Name>font_decimal</se:Name>
+  <UserStyle>
+   <se:Name>font_decimal</se:Name>
+   <se:FeatureTypeStyle>
+    <se:Rule>
+     <se:Name>Single symbol</se:Name>
+     <se:PointSymbolizer>
+      <se:Graphic>
+       <se:Mark>
+        <se:WellKnownName>circle</se:WellKnownName>
+        <se:Fill>
+          <se:SvgParameter name="fill">#000000</se:SvgParameter>
+        </se:Fill>
+       </se:Mark>
+      </se:Graphic>
+     </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+     <se:TextSymbolizer>
+      <se:Label>
+        <ogc:PropertyName>fldtxt</ogc:PropertyName>
+      </se:Label>
+      <se:Font>
+        <se:SvgParameter name="font-size">13.5</se:SvgParameter>
+      </se:Font>
+      <se:Fill>
+       <se:SvgParameter name="fill">#000000</se:SvgParameter>
+      </se:Fill>
+     </se:TextSymbolizer>
+    </se:Rule>
+   </se:FeatureTypeStyle>
+  </UserStyle>
+ </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
## Fix decimal font size load from SLD style

SLD style correctly saves **decimal** font size, but does not load it. After loading, it's always set to 10.

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
