### PR TITLE
[afs] Use linear geometries if service doesn't support curved geometry updates

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -83,7 +83,7 @@ Converts an ESRI REST field ``type`` to a QVariant type.
 Converts an ESRI REST geometry ``type`` to a WKB type.
 %End
 
-    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 );
+    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, bool allowCurves = true, QgsCoordinateReferenceSystem *crs /Out/ = 0 );
 %Docstring
 Converts an ESRI REST ``geometry`` JSON definition to a
 :py:class:`QgsAbstractGeometry`.
@@ -94,6 +94,8 @@ Caller takes ownership of the returned object.
 :param esriGeometryType: ESRI geometry type string
 :param hasM: set to ``True`` to if geometry includes M values
 :param hasZ: set to ``True`` to if geometry includes Z values
+:param allowCurves: controls whether the returned geometry can be a
+                    curved geometry type (since QGIS 4.0)
 
 :return: - converted geometry
          - crs: the parsed geometry CRS

--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -83,7 +83,7 @@ Converts an ESRI REST field ``type`` to a QVariant type.
 Converts an ESRI REST geometry ``type`` to a WKB type.
 %End
 
-    static QgsAbstractGeometry *convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 ) /Factory/;
+    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 );
 %Docstring
 Converts an ESRI REST ``geometry`` JSON definition to a
 :py:class:`QgsAbstractGeometry`.
@@ -105,14 +105,14 @@ Converts a spatial reference JSON definition to a
 :py:class:`QgsCoordinateReferenceSystem` value.
 %End
 
-    static QgsSymbol *convertSymbol( const QVariantMap &definition ) /Factory/;
+    static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition );
 %Docstring
 Converts a symbol JSON ``definition`` to a :py:class:`QgsSymbol`.
 
 Caller takes ownership of the returned symbol.
 %End
 
-    static QgsFeatureRenderer *convertRenderer( const QVariantMap &rendererData ) /Factory/;
+    static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData );
 %Docstring
 Converts renderer JSON ``data`` to an equivalent
 :py:class:`QgsFeatureRenderer`.
@@ -120,7 +120,7 @@ Converts renderer JSON ``data`` to an equivalent
 Caller takes ownership of the returned renderer.
 %End
 
-    static QgsAbstractVectorLayerLabeling *convertLabeling( const QVariantList &data ) /Factory/;
+    static std::unique_ptr< QgsAbstractVectorLayerLabeling > convertLabeling( const QVariantList &data );
 %Docstring
 Converts labeling JSON ``data`` to an equivalent QGIS vector labeling.
 

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -127,7 +127,7 @@ Qgis::WkbType QgsArcGisRestUtils::convertGeometryType( const QString &esriGeomet
 
 std::unique_ptr< QgsPoint > QgsArcGisRestUtils::convertPoint( const QVariantList &coordList, Qgis::WkbType pointType )
 {
-  int nCoords = coordList.size();
+  const int nCoords = static_cast< int >( coordList.size() );
   if ( nCoords < 2 )
     return nullptr;
   bool xok = false, yok = false;
@@ -148,7 +148,7 @@ std::unique_ptr< QgsCircularString > QgsArcGisRestUtils::convertCircularString( 
   const QVariantList coordsList = curveData[u"c"_s].toList();
   if ( coordsList.isEmpty() )
     return nullptr;
-  const int coordsListSize = coordsList.size();
+  const int coordsListSize = static_cast< int >( coordsList.size() );
 
   QVector<QgsPoint> points;
   points.reserve( coordsListSize + 1 );
@@ -183,7 +183,7 @@ std::unique_ptr< QgsCurve > QgsArcGisRestUtils::convertCompoundCurve( const QVar
   QVector< double > lineY;
   QVector< double > lineZ;
   QVector< double > lineM;
-  int maxCurveListSize = curvesList.size();
+  const int maxCurveListSize = static_cast< int >( curvesList.size() );
   lineX.resize( maxCurveListSize );
   lineY.resize( maxCurveListSize );
 
@@ -209,7 +209,7 @@ std::unique_ptr< QgsCurve > QgsArcGisRestUtils::convertCompoundCurve( const QVar
     if ( curveData.userType() == QMetaType::Type::QVariantList )
     {
       const QVariantList coordList = curveData.toList();
-      const int nCoords = coordList.size();
+      const int nCoords = static_cast< int >( coordList.size() );
       if ( nCoords < 2 )
         return nullptr;
 
@@ -325,7 +325,7 @@ std::unique_ptr<QgsLineString> QgsArcGisRestUtils::convertLineString( const QVar
   QVector< double > lineY;
   QVector< double > lineZ;
   QVector< double > lineM;
-  int maxCurveListSize = curvesList.size();
+  const int maxCurveListSize = static_cast< int >( curvesList.size() );
   lineX.resize( maxCurveListSize );
   lineY.resize( maxCurveListSize );
 
@@ -350,7 +350,7 @@ std::unique_ptr<QgsLineString> QgsArcGisRestUtils::convertLineString( const QVar
     if ( curveData.userType() == QMetaType::Type::QVariantList )
     {
       const QVariantList coordList = curveData.toList();
-      const int nCoords = coordList.size();
+      const int nCoords = static_cast< int >( coordList.size() );
       if ( nCoords < 2 )
         return nullptr;
 
@@ -411,7 +411,7 @@ std::unique_ptr< QgsMultiPoint > QgsArcGisRestUtils::convertMultiPoint( const QV
   const QVariantList coordsList = geometryData[u"points"_s].toList();
 
   auto multiPoint = std::make_unique< QgsMultiPoint >();
-  multiPoint->reserve( coordsList.size() );
+  multiPoint->reserve( static_cast< int >( coordsList.size() ) );
   for ( const QVariant &coordData : coordsList )
   {
     const QVariantList coordList = coordData.toList();
@@ -448,7 +448,7 @@ std::unique_ptr< QgsMultiCurve > QgsArcGisRestUtils::convertGeometryPolyline( co
   if ( pathsList.isEmpty() )
     return nullptr;
   std::unique_ptr< QgsMultiCurve > multiCurve = allowCurves ? std::make_unique< QgsMultiCurve >() : std::make_unique< QgsMultiLineString >();
-  multiCurve->reserve( pathsList.size() );
+  multiCurve->reserve( static_cast< int >( pathsList.size() ) );
   for ( const QVariant &pathData : std::as_const( pathsList ) )
   {
     std::unique_ptr< QgsCurve > curve = allowCurves ? convertCompoundCurve( pathData.toList(), pointType ) : convertLineString( pathData.toList(), pointType );
@@ -473,7 +473,7 @@ std::unique_ptr< QgsMultiSurface > QgsArcGisRestUtils::convertGeometryPolygon( c
     return nullptr;
 
   QList< QgsCurve * > curves;
-  for ( int i = 0, n = ringsList.size(); i < n; ++i )
+  for ( int i = 0, n = static_cast< int >( ringsList.size() ); i < n; ++i )
   {
     std::unique_ptr< QgsCurve > curve = allowCurves ? convertCompoundCurve( ringsList[i].toList(), pointType ) : convertLineString( ringsList[i].toList(), pointType );
     if ( !curve )
@@ -496,7 +496,7 @@ std::unique_ptr< QgsMultiSurface > QgsArcGisRestUtils::convertGeometryPolygon( c
   }
 
   std::sort( curves.begin(), curves.end(), []( const QgsCurve * a, const QgsCurve * b )->bool{ double a_area = 0.0; double b_area = 0.0; a->sumUpArea( a_area ); b->sumUpArea( b_area ); return std::abs( a_area ) > std::abs( b_area ); } );
-  result->reserve( curves.size() );
+  result->reserve( static_cast< int >( curves.size() ) );
   while ( !curves.isEmpty() )
   {
     QgsCurve *exterior = curves.takeFirst();

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -139,7 +139,7 @@ class CORE_EXPORT QgsArcGisRestUtils
      *
      * \returns converted geometry
      */
-    static QgsAbstractGeometry *convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs SIP_OUT = nullptr ) SIP_FACTORY;
+    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs SIP_OUT = nullptr );
 
     /**
      * Converts a spatial reference JSON definition to a QgsCoordinateReferenceSystem value.
@@ -151,21 +151,21 @@ class CORE_EXPORT QgsArcGisRestUtils
      *
      * Caller takes ownership of the returned symbol.
      */
-    static QgsSymbol *convertSymbol( const QVariantMap &definition ) SIP_FACTORY;
+    static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition );
 
     /**
      * Converts renderer JSON \a data to an equivalent QgsFeatureRenderer.
      *
      * Caller takes ownership of the returned renderer.
      */
-    static QgsFeatureRenderer *convertRenderer( const QVariantMap &rendererData ) SIP_FACTORY;
+    static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData );
 
     /**
      * Converts labeling JSON \a data to an equivalent QGIS vector labeling.
      *
      * Caller takes ownership of the returned object.
      */
-    static QgsAbstractVectorLayerLabeling *convertLabeling( const QVariantList &data ) SIP_FACTORY;
+    static std::unique_ptr< QgsAbstractVectorLayerLabeling > convertLabeling( const QVariantList &data );
 
     /**
      * Converts an ESRI labeling expression to a QGIS expression string.

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -135,11 +135,12 @@ class CORE_EXPORT QgsArcGisRestUtils
      * \param esriGeometryType ESRI geometry type string
      * \param hasM set to TRUE to if geometry includes M values
      * \param hasZ set to TRUE to if geometry includes Z values
+     * \param allowCurves controls whether the returned geometry can be a curved geometry type (since QGIS 4.0)
      * \param crs if specified will be set to the parsed geometry CRS
      *
      * \returns converted geometry
      */
-    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs SIP_OUT = nullptr );
+    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, bool allowCurves = true, QgsCoordinateReferenceSystem *crs SIP_OUT = nullptr );
 
     /**
      * Converts a spatial reference JSON definition to a QgsCoordinateReferenceSystem value.
@@ -288,7 +289,12 @@ class CORE_EXPORT QgsArcGisRestUtils
     /**
      * Converts a compound curve JSON \a list to a geometry object of the specified \a type.
      */
-    static std::unique_ptr< QgsCompoundCurve > convertCompoundCurve( const QVariantList &list, Qgis::WkbType type );
+    static std::unique_ptr< QgsCurve > convertCompoundCurve( const QVariantList &list, Qgis::WkbType type );
+
+    /**
+     * Converts a line string JSON \a list to a geometry object of the specified \a type.
+     */
+    static std::unique_ptr< QgsLineString > convertLineString( const QVariantList &list, Qgis::WkbType type );
 
     /**
      * Converts point \a data to a point object of the specified \a type.
@@ -302,13 +308,17 @@ class CORE_EXPORT QgsArcGisRestUtils
 
     /**
      * Converts polyline \a data to a curve object of the specified \a type.
+     *
+     *The \a allowCurves argument controls whether the returned geometry can be a curved geometry type.
      */
-    static std::unique_ptr< QgsMultiCurve > convertGeometryPolyline( const QVariantMap &data, Qgis::WkbType pointType );
+    static std::unique_ptr< QgsMultiCurve > convertGeometryPolyline( const QVariantMap &data, Qgis::WkbType pointType, bool allowCurves );
 
     /**
      * Converts polygon \a data to a polygon object of the specified \a type.
+     *
+     * The \a allowCurves argument controls whether the returned geometry can be a curved geometry type.
      */
-    static std::unique_ptr< QgsMultiSurface > convertGeometryPolygon( const QVariantMap &data, Qgis::WkbType pointType );
+    static std::unique_ptr< QgsMultiSurface > convertGeometryPolygon( const QVariantMap &data, Qgis::WkbType pointType, bool allowCurves );
 
     /**
      * Converts envelope \a data to a polygon object.

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -29,8 +29,10 @@
 #include "qgsfeedback.h"
 #include "qgslogger.h"
 #include "qgsreadwritelocker.h"
+#include "qgsrenderer.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsvariantutils.h"
+#include "qgsvectorlayerlabeling.h"
 
 #include <QString>
 
@@ -760,12 +762,12 @@ void QgsAfsProvider::reloadProviderData()
 
 QgsFeatureRenderer *QgsAfsProvider::createRenderer( const QVariantMap & ) const
 {
-  return QgsArcGisRestUtils::convertRenderer( mRendererDataMap );
+  return QgsArcGisRestUtils::convertRenderer( mRendererDataMap ).release();
 }
 
 QgsAbstractVectorLayerLabeling *QgsAfsProvider::createLabeling( const QVariantMap & ) const
 {
-  return QgsArcGisRestUtils::convertLabeling( mLabelingDataList );
+  return QgsArcGisRestUtils::convertLabeling( mLabelingDataList ).release();
 }
 
 bool QgsAfsProvider::renderInPreview( const QgsDataProvider::PreviewContext & )

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -106,7 +106,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QVariantMap mRendererDataMap;
     QVariantList mLabelingDataList;
     QgsHttpHeaders mRequestHeaders;
-    bool mServerSupportsCurves = false;
+    bool mServerSupportsCurvedUpdates = false;
     QString mAdminUrl;
     QVariantMap mAdminData;
     QStringList mAdminCapabilityStrings;

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -283,7 +283,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
 
     // Set geometry
     const QVariantMap geometryData = featureData[u"geometry"_s].toMap();
-    std::unique_ptr<QgsAbstractGeometry> geometry( QgsArcGisRestUtils::convertGeometry( geometryData, queryData[u"geometryType"_s].toString(), QgsWkbTypes::hasM( mGeometryType ), QgsWkbTypes::hasZ( mGeometryType ) ) );
+    std::unique_ptr<QgsAbstractGeometry> geometry( QgsArcGisRestUtils::convertGeometry( geometryData, queryData[u"geometryType"_s].toString(), QgsWkbTypes::hasM( mGeometryType ), QgsWkbTypes::hasZ( mGeometryType ), QgsWkbTypes::isCurvedType( mGeometryType ) ) );
     // Above might return 0, which is OK since in theory empty geometries are allowed
     if ( geometry )
       feature.setGeometry( QgsGeometry( std::move( geometry ) ) );

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -911,7 +911,7 @@ QgsRasterIdentifyResult QgsAmsProvider::identify( const QgsPointXY &point, Qgis:
         featureAttributes.append( it.value().toString() );
       }
       QgsCoordinateReferenceSystem crs;
-      std::unique_ptr<QgsAbstractGeometry> geometry( QgsArcGisRestUtils::convertGeometry( resultMap[u"geometry"_s].toMap(), resultMap[u"geometryType"_s].toString(), false, false, &crs ) );
+      std::unique_ptr<QgsAbstractGeometry> geometry( QgsArcGisRestUtils::convertGeometry( resultMap[u"geometry"_s].toMap(), resultMap[u"geometryType"_s].toString(), false, false, true, &crs ) );
       QgsFeature feature( fields );
       feature.setGeometry( QgsGeometry( std::move( geometry ) ) );
       feature.setAttributes( featureAttributes );

--- a/tests/src/core/testqgsarcgisrestutils.cpp
+++ b/tests/src/core/testqgsarcgisrestutils.cpp
@@ -169,9 +169,14 @@ void TestQgsArcGisRestUtils::testParseEsriGeometryPolygon()
                                      "]"
                                      "}" );
   QCOMPARE( map[u"rings"_s].isValid(), true );
-  std::unique_ptr<QgsMultiSurface> geometry = QgsArcGisRestUtils::convertGeometryPolygon( map, Qgis::WkbType::Point );
+  std::unique_ptr<QgsMultiSurface> geometry = QgsArcGisRestUtils::convertGeometryPolygon( map, Qgis::WkbType::Point, true );
   QVERIFY( geometry.get() );
   QCOMPARE( geometry->asWkt(), u"MultiSurface (CurvePolygon (CompoundCurve ((0 0, 10 0, 10 10, 0 10, 0 0)),CompoundCurve ((3 3, 9 3, 6 9, 3 3))),CurvePolygon (CompoundCurve ((12 0, 13 0, 13 10, 12 10, 12 0))))"_s );
+
+  // force straight geometry type
+  geometry = QgsArcGisRestUtils::convertGeometryPolygon( map, Qgis::WkbType::Point, false );
+  QVERIFY( geometry.get() );
+  QCOMPARE( geometry->asWkt(), u"MultiPolygon (((0 0, 10 0, 10 10, 0 10, 0 0),(3 3, 9 3, 6 9, 3 3)),((12 0, 13 0, 13 10, 12 10, 12 0)))"_s );
 }
 
 void TestQgsArcGisRestUtils::testParseEsriFillStyle()
@@ -707,7 +712,7 @@ QVariantMap TestQgsArcGisRestUtils::jsonStringToMap( const QString &string ) con
 void TestQgsArcGisRestUtils::testParseCompoundCurve()
 {
   const QVariantMap map = jsonStringToMap( "{\"curvePaths\": [[[6,3],[5,3],{\"c\": [[3,3],[1,4]]}]]}" );
-  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::Point ) );
+  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::Point, true ) );
   QVERIFY( curve );
   QCOMPARE( curve->asWkt(), u"MultiCurve (CompoundCurve ((6 3, 5 3),CircularString (5 3, 1 4, 3 3)))"_s );
 }
@@ -715,33 +720,53 @@ void TestQgsArcGisRestUtils::testParseCompoundCurve()
 void TestQgsArcGisRestUtils::testParsePolyline()
 {
   const QVariantMap map = jsonStringToMap( "{\"paths\": [[[6,3],[5,3]]]}" );
-  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::Point ) );
+  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::Point, true ) );
   QVERIFY( curve );
   QCOMPARE( curve->asWkt(), u"MultiCurve (CompoundCurve ((6 3, 5 3)))"_s );
+
+  // force straight geometry type
+  curve = QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::Point, false );
+  QVERIFY( curve );
+  QCOMPARE( curve->asWkt(), u"MultiLineString ((6 3, 5 3))"_s );
 }
 
 void TestQgsArcGisRestUtils::testParsePolylineZ()
 {
   const QVariantMap map = jsonStringToMap( "{\"paths\": [[[6,3,1],[5,3,2]]]}" );
-  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZ ) );
+  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZ, true ) );
   QVERIFY( curve );
   QCOMPARE( curve->asWkt(), u"MultiCurve Z (CompoundCurve Z ((6 3 1, 5 3 2)))"_s );
+
+  // force straight geometry type
+  curve = QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZ, false );
+  QVERIFY( curve );
+  QCOMPARE( curve->asWkt(), u"MultiLineString Z ((6 3 1, 5 3 2))"_s );
 }
 
 void TestQgsArcGisRestUtils::testParsePolylineM()
 {
   const QVariantMap map = jsonStringToMap( "{\"paths\": [[[6,3,1],[5,3,2]]]}" );
-  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointM ) );
+  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointM, true ) );
   QVERIFY( curve );
   QCOMPARE( curve->asWkt(), u"MultiCurve M (CompoundCurve M ((6 3 1, 5 3 2)))"_s );
+
+  // force straight geometry type
+  curve = QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointM, false );
+  QVERIFY( curve );
+  QCOMPARE( curve->asWkt(), u"MultiLineString M ((6 3 1, 5 3 2))"_s );
 }
 
 void TestQgsArcGisRestUtils::testParsePolylineZM()
 {
   const QVariantMap map = jsonStringToMap( "{\"paths\": [[[6,3,1,11],[5,3,2,12]]]}" );
-  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZM ) );
+  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZM, true ) );
   QVERIFY( curve );
   QCOMPARE( curve->asWkt(), u"MultiCurve ZM (CompoundCurve ZM ((6 3 1 11, 5 3 2 12)))"_s );
+
+  // force straight geometry type
+  curve = QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZM, false );
+  QVERIFY( curve );
+  QCOMPARE( curve->asWkt(), u"MultiLineString ZM ((6 3 1 11, 5 3 2 12))"_s );
 }
 
 QGSTEST_MAIN( TestQgsArcGisRestUtils )


### PR DESCRIPTION
The actual JSON geometry objects don't explicitly state if a geometry is curved type or not so we were previously always returning the curved geometry types.

This can break feature updates though, because if the service doesn't support curved geometries then we need to make sure the feature's geometry is a straight geometry.

Now we force use of linear geometry values when the service does not advertised curved geometry support.

Fixes edits to layers fail when service doesn't support curved geometry types (#55620)

Funded by République et canton de Genève