### PR TITLE
[browser] Fix refreshing ArcGIS REST services just uses cached response 

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisportalutils.sip.in
@@ -25,7 +25,7 @@ Utility functions for working with ArcGIS REST services.
 %End
   public:
 
-    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0, const QString &urlPrefix = QString() );
+    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0, const QString &urlPrefix = QString(), bool forceRefresh = false );
 %Docstring
 Retrieves JSON user info for the specified user name.
 
@@ -40,6 +40,9 @@ details will be retrieved
 :param requestHeaders: optional additional request headers
 :param feedback: optional feedback argument for cancellation support
 :param urlPrefix: http web proxy url prefix
+:param forceRefresh: if ``False`` then previously cached replies may be
+                     used for the request. If it is set to ``True`` then
+                     a new query is always performed. (since QGIS 4.0)
 
 :return: - JSON user info
          - errorTitle: title summary of any encountered errors
@@ -74,7 +77,7 @@ details will be retrieved
    Use the version with :py:class:`QgsHttpHeaders` instead.
 %End
 
-    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0, const QString &urlPrefix = QString() );
+    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0, const QString &urlPrefix = QString(), bool forceRefresh = false );
 %Docstring
 Retrieves JSON definitions for all groups which the specified user name
 is a member of.
@@ -90,6 +93,9 @@ details will be retrieved
 :param requestHeaders: optional additional request headers
 :param feedback: optional feedback argument for cancellation support
 :param urlPrefix: http web proxy url prefix
+:param forceRefresh: if ``False`` then previously cached replies may be
+                     used for the request. If it is set to ``True`` then
+                     a new query is always performed. (since QGIS 4.0)
 
 :return: - a list of JSON group info
          - errorTitle: title summary of any encountered errors
@@ -124,7 +130,7 @@ details will be retrieved
    Use the version with :py:class:`QgsHttpHeaders` instead.
 %End
 
-    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(),  QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString() );
+    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(),  QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString(), bool forceRefresh = false );
 %Docstring
 Retrieves JSON definitions for all items which belong the the specified
 ``groupId``.
@@ -138,6 +144,9 @@ Retrieves JSON definitions for all items which belong the the specified
 :param pageSize: number of results to retrieve for each request. Maximum
                  value is 100.
 :param urlPrefix: http web proxy url prefix
+:param forceRefresh: if ``False`` then previously cached replies may be
+                     used for the request. If it is set to ``True`` then
+                     a new query is always performed. (since QGIS 4.0)
 
 :return: - a list of JSON item info for all items within the group
          - errorTitle: title summary of any encountered errors
@@ -172,7 +181,7 @@ Retrieves JSON definitions for all items which belong the the specified
 
     static QVariantList retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg,
         const QList< int > &itemTypes,
-        QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString() );
+        QString &errorTitle /Out/, QString &errorText /Out/, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = 0, int pageSize = 100, const QString &urlPrefix = QString(), bool forceRefresh = false );
 %Docstring
 Retrieves JSON definitions for all items which belong the the specified
 ``groupId``.
@@ -188,6 +197,9 @@ Retrieves JSON definitions for all items which belong the the specified
 :param pageSize: number of results to retrieve for each request. Maximum
                  value is 100.
 :param urlPrefix: http web proxy url prefix
+:param forceRefresh: if ``False`` then previously cached replies may be
+                     used for the request. If it is set to ``True`` then
+                     a new query is always performed. (since QGIS 4.0)
 
 :return: - a list of JSON item info for all items within the group
          - errorTitle: title summary of any encountered errors

--- a/src/core/providers/arcgis/qgsarcgisportalutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisportalutils.cpp
@@ -23,7 +23,7 @@
 
 using namespace Qt::StringLiterals;
 
-QVariantMap QgsArcGisPortalUtils::retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, const QString &urlPrefix )
+QVariantMap QgsArcGisPortalUtils::retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, const QString &urlPrefix, bool forceRefresh )
 {
   QString endPoint = communityUrl;
   if ( endPoint.endsWith( '/' ) )
@@ -39,7 +39,7 @@ QVariantMap QgsArcGisPortalUtils::retrieveUserInfo( const QString &communityUrl,
   query.addQueryItem( u"f"_s, u"json"_s );
   queryUrl.setQuery( query );
 
-  return QgsArcGisRestQueryUtils::queryServiceJSON( queryUrl, authcfg, errorTitle, errorText, requestHeaders, feedback, urlPrefix );
+  return QgsArcGisRestQueryUtils::queryServiceJSON( queryUrl, authcfg, errorTitle, errorText, requestHeaders, feedback, urlPrefix, forceRefresh );
 }
 
 QVariantMap QgsArcGisPortalUtils::retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QMap< QString, QVariant > &requestHeaders, QgsFeedback *feedback, const QString &urlPrefix )
@@ -47,9 +47,9 @@ QVariantMap QgsArcGisPortalUtils::retrieveUserInfo( const QString &communityUrl,
   return QgsArcGisPortalUtils::retrieveUserInfo( communityUrl, user, authcfg, errorTitle, errorText, QgsHttpHeaders( requestHeaders ), feedback, urlPrefix );
 }
 
-QVariantList QgsArcGisPortalUtils::retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, const QString &urlPrefix )
+QVariantList QgsArcGisPortalUtils::retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, const QString &urlPrefix, bool forceRefresh )
 {
-  const QVariantMap info = retrieveUserInfo( communityUrl, user, authcfg, errorTitle, errorText, requestHeaders, feedback, urlPrefix );
+  const QVariantMap info = retrieveUserInfo( communityUrl, user, authcfg, errorTitle, errorText, requestHeaders, feedback, urlPrefix, forceRefresh );
   return info.value( u"groups"_s ).toList();
 }
 
@@ -58,7 +58,7 @@ QVariantList QgsArcGisPortalUtils::retrieveUserGroups( const QString &communityU
   return QgsArcGisPortalUtils::retrieveUserGroups( communityUrl, user, authcfg, errorTitle, errorText, QgsHttpHeaders( requestHeaders ), feedback, urlPrefix );
 }
 
-QVariantList QgsArcGisPortalUtils::retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, int pageSize, const QString &urlPrefix )
+QVariantList QgsArcGisPortalUtils::retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, int pageSize, const QString &urlPrefix, bool forceRefresh )
 {
   QString endPoint = contentUrl;
   if ( endPoint.endsWith( '/' ) )
@@ -78,7 +78,7 @@ QVariantList QgsArcGisPortalUtils::retrieveGroupContent( const QString &contentU
     query.addQueryItem( u"num"_s, QString::number( pageSize ) );
     queryUrl.setQuery( query );
 
-    const QVariantMap response = QgsArcGisRestQueryUtils::queryServiceJSON( queryUrl, authcfg, errorTitle, errorText, requestHeaders, feedback, urlPrefix );
+    const QVariantMap response = QgsArcGisRestQueryUtils::queryServiceJSON( queryUrl, authcfg, errorTitle, errorText, requestHeaders, feedback, urlPrefix, forceRefresh );
     if ( !errorText.isEmpty() )
       return QVariantList();
 
@@ -100,9 +100,9 @@ QVariantList QgsArcGisPortalUtils::retrieveGroupContent( const QString &contentU
   return QgsArcGisPortalUtils::retrieveGroupContent( contentUrl, groupId, authcfg, errorTitle, errorText, QgsHttpHeaders( requestHeaders ), feedback, pageSize, urlPrefix );
 }
 
-QVariantList QgsArcGisPortalUtils::retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg, const QList<int> &itemTypes, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, int pageSize, const QString &urlPrefix )
+QVariantList QgsArcGisPortalUtils::retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg, const QList<int> &itemTypes, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, int pageSize, const QString &urlPrefix, bool forceRefresh )
 {
-  const QVariantList items = retrieveGroupContent( contentUrl, groupId, authcfg, errorTitle, errorText, requestHeaders, feedback, pageSize, urlPrefix );
+  const QVariantList items = retrieveGroupContent( contentUrl, groupId, authcfg, errorTitle, errorText, requestHeaders, feedback, pageSize, urlPrefix, forceRefresh );
 
   // filter results to desired types
   QVariantList result;

--- a/src/core/providers/arcgis/qgsarcgisportalutils.h
+++ b/src/core/providers/arcgis/qgsarcgisportalutils.h
@@ -51,11 +51,12 @@ class CORE_EXPORT QgsArcGisPortalUtils
      * \param requestHeaders optional additional request headers
      * \param feedback optional feedback argument for cancellation support
      * \param urlPrefix http web proxy url prefix
+     * \param forceRefresh if FALSE then previously cached replies may be used for the request. If it is set to TRUE then a new query is always performed. (since QGIS 4.0)
      *
      * \returns JSON user info
      * \since QGIS 3.24
      */
-    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, const QString &urlPrefix = QString() );
+    static QVariantMap retrieveUserInfo( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, const QString &urlPrefix = QString(), bool forceRefresh = false );
 
     /**
      * Retrieves JSON user info for the specified user name. Only to avoid API break.
@@ -89,11 +90,11 @@ class CORE_EXPORT QgsArcGisPortalUtils
      * \param requestHeaders optional additional request headers
      * \param feedback optional feedback argument for cancellation support
      * \param urlPrefix http web proxy url prefix
-     *
+     * \param forceRefresh if FALSE then previously cached replies may be used for the request. If it is set to TRUE then a new query is always performed. (since QGIS 4.0)
      * \returns a list of JSON group info
      * \since QGIS 3.24
      */
-    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, const QString &urlPrefix = QString() );
+    static QVariantList retrieveUserGroups( const QString &communityUrl, const QString &user, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, const QString &urlPrefix = QString(), bool forceRefresh = false );
 
     /**
      * Retrieves JSON definitions for all groups which the specified user name is a member of. Only to avoid API break.
@@ -126,11 +127,12 @@ class CORE_EXPORT QgsArcGisPortalUtils
      * \param feedback optional feedback argument for cancellation support
      * \param pageSize number of results to retrieve for each request. Maximum value is 100.
      * \param urlPrefix http web proxy url prefix
+     * \param forceRefresh if FALSE then previously cached replies may be used for the request. If it is set to TRUE then a new query is always performed. (since QGIS 4.0)
      *
      * \returns a list of JSON item info for all items within the group
      * \since QGIS 3.24
      */
-    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(),  QgsFeedback *feedback = nullptr, int pageSize = 100, const QString &urlPrefix = QString() );
+    static QVariantList retrieveGroupContent( const QString &contentUrl, const QString &groupId, const QString &authcfg, QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(),  QgsFeedback *feedback = nullptr, int pageSize = 100, const QString &urlPrefix = QString(), bool forceRefresh = false );
 
     /**
      * Retrieves JSON definitions for all items which belong the the specified \a groupId. Only to avoid API break.
@@ -163,13 +165,14 @@ class CORE_EXPORT QgsArcGisPortalUtils
      * \param feedback optional feedback argument for cancellation support
      * \param pageSize number of results to retrieve for each request. Maximum value is 100.
      * \param urlPrefix http web proxy url prefix
+     * \param forceRefresh if FALSE then previously cached replies may be used for the request. If it is set to TRUE then a new query is always performed. (since QGIS 4.0)
      *
      * \returns a list of JSON item info for all items within the group
      * \since QGIS 3.24
      */
     static QVariantList retrieveGroupItemsOfType( const QString &contentUrl, const QString &groupId, const QString &authcfg,
         const QList< int > &itemTypes,
-        QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, int pageSize = 100, const QString &urlPrefix = QString() );
+        QString &errorTitle SIP_OUT, QString &errorText SIP_OUT, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, int pageSize = 100, const QString &urlPrefix = QString(), bool forceRefresh = false );
 
     /**
      * Retrieves JSON definitions for all items which belong the the specified \a groupId. Only to avoid API break.

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -38,14 +38,14 @@
 
 using namespace Qt::StringLiterals;
 
-QVariantMap QgsArcGisRestQueryUtils::getServiceInfo( const QString &baseurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, const QString &urlPrefix )
+QVariantMap QgsArcGisRestQueryUtils::getServiceInfo( const QString &baseurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, const QString &urlPrefix, bool forceRefresh )
 {
   // http://sampleserver5.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer?f=json
   QUrl queryUrl( baseurl );
   QUrlQuery query( queryUrl );
   query.addQueryItem( u"f"_s, u"json"_s );
   queryUrl.setQuery( query );
-  return queryServiceJSON( queryUrl, authcfg, errorTitle, errorText, requestHeaders, nullptr, urlPrefix );
+  return queryServiceJSON( queryUrl, authcfg, errorTitle, errorText, requestHeaders, nullptr, urlPrefix, forceRefresh );
 }
 
 QVariantMap QgsArcGisRestQueryUtils::getLayerInfo( const QString &layerurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, const QString &urlPrefix )
@@ -174,7 +174,7 @@ QList<quint32> QgsArcGisRestQueryUtils::getObjectIdsByExtent( const QString &lay
   return ids;
 }
 
-QByteArray QgsArcGisRestQueryUtils::queryService( const QUrl &u, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, QString *contentType, const QString &urlPrefix )
+QByteArray QgsArcGisRestQueryUtils::queryService( const QUrl &u, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, QString *contentType, const QString &urlPrefix, bool forceRefresh )
 {
   QUrl url = parseUrl( u );
 
@@ -187,7 +187,7 @@ QByteArray QgsArcGisRestQueryUtils::queryService( const QUrl &u, const QString &
 
   QgsBlockingNetworkRequest networkRequest;
   networkRequest.setAuthCfg( authcfg );
-  const QgsBlockingNetworkRequest::ErrorCode error = networkRequest.get( request, false, feedback );
+  const QgsBlockingNetworkRequest::ErrorCode error = networkRequest.get( request, forceRefresh, feedback );
 
   if ( feedback && feedback->isCanceled() )
     return QByteArray();
@@ -217,9 +217,9 @@ QByteArray QgsArcGisRestQueryUtils::queryService( const QUrl &u, const QString &
   return content.content();
 }
 
-QVariantMap QgsArcGisRestQueryUtils::queryServiceJSON( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, const QString &urlPrefix )
+QVariantMap QgsArcGisRestQueryUtils::queryServiceJSON( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, QgsFeedback *feedback, const QString &urlPrefix, bool forceRefresh )
 {
-  const QByteArray reply = queryService( url, authcfg, errorTitle, errorText, requestHeaders, feedback, nullptr, urlPrefix );
+  const QByteArray reply = queryService( url, authcfg, errorTitle, errorText, requestHeaders, feedback, nullptr, urlPrefix, forceRefresh );
   if ( !errorTitle.isEmpty() )
   {
     return QVariantMap();

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -53,7 +53,7 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
     /**
      * Retrieves JSON service info for the specified base URL.
      */
-    static QVariantMap getServiceInfo( const QString &baseurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), const QString &urlPrefix = QString() );
+    static QVariantMap getServiceInfo( const QString &baseurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), const QString &urlPrefix = QString(), bool forceRefresh = false );
 
     /**
      * Retrieves JSON layer info for the specified layer URL.
@@ -110,12 +110,11 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
     /**
      * Performs a blocking request to a URL and returns the retrieved data.
      */
-    static QByteArray queryService( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, QString *contentType = nullptr, const QString &urlPrefix = QString() );
-
+    static QByteArray queryService( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, QString *contentType = nullptr, const QString &urlPrefix = QString(), bool forceRefresh = false );
     /**
      * Performs a blocking request to a URL and returns the retrieved JSON content.
      */
-    static QVariantMap queryServiceJSON( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, const QString &urlPrefix = QString() );
+    static QVariantMap queryServiceJSON( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(), QgsFeedback *feedback = nullptr, const QString &urlPrefix = QString(), bool forceRefresh = false );
 
     /**
      * Calls the specified \a visitor function on all folder items found within the given service data.

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.h
@@ -56,6 +56,10 @@ class QgsArcGisRestConnectionItem : public QgsDataCollectionItem
     Q_OBJECT
   public:
     QgsArcGisRestConnectionItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &connectionName );
+
+    using QgsDataCollectionItem::refresh;
+    void refresh() override;
+
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
     QString url() const;
@@ -64,6 +68,7 @@ class QgsArcGisRestConnectionItem : public QgsDataCollectionItem
     QString mConnName;
     QString mPortalCommunityEndpoint;
     QString mPortalContentEndpoint;
+    bool mForceRefresh = false;
 };
 
 /**
@@ -77,7 +82,7 @@ class QgsArcGisPortalGroupsItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisPortalGroupsItem( QgsDataItem *parent, const QString &path, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, const QString &communityEndpoint, const QString &contentEndpoint );
+    QgsArcGisPortalGroupsItem( QgsDataItem *parent, const QString &path, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, const QString &communityEndpoint, const QString &contentEndpoint, bool forceRefresh );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
@@ -87,6 +92,7 @@ class QgsArcGisPortalGroupsItem : public QgsDataCollectionItem
     QString mUrlPrefix;
     QString mPortalCommunityEndpoint;
     QString mPortalContentEndpoint;
+    bool mForceRefresh = false;
 };
 
 /**
@@ -99,7 +105,7 @@ class QgsArcGisPortalGroupItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisPortalGroupItem( QgsDataItem *parent, const QString &groupId, const QString &name, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, const QString &communityEndpoint, const QString &contentEndpoint );
+    QgsArcGisPortalGroupItem( QgsDataItem *parent, const QString &groupId, const QString &name, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, const QString &communityEndpoint, const QString &contentEndpoint, bool forceRefresh );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
@@ -110,6 +116,7 @@ class QgsArcGisPortalGroupItem : public QgsDataCollectionItem
     QString mUrlPrefix;
     QString mPortalCommunityEndpoint;
     QString mPortalContentEndpoint;
+    bool mForceRefresh = false;
 };
 
 
@@ -124,7 +131,7 @@ class QgsArcGisRestServicesItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisRestServicesItem( QgsDataItem *parent, const QString &url, const QString &path, const QString &authcfg, const QgsHttpHeaders &headers, const QString urlPrefix );
+    QgsArcGisRestServicesItem( QgsDataItem *parent, const QString &url, const QString &path, const QString &authcfg, const QgsHttpHeaders &headers, const QString urlPrefix, bool forceRefresh );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
@@ -135,6 +142,7 @@ class QgsArcGisRestServicesItem : public QgsDataCollectionItem
     QString mUrlPrefix;
     QString mPortalCommunityEndpoint;
     QString mPortalContentEndpoint;
+    bool mForceRefresh = false;
 };
 
 /**
@@ -147,7 +155,7 @@ class QgsArcGisRestFolderItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisRestFolderItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix );
+    QgsArcGisRestFolderItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, bool forceRefresh );
     void setSupportedFormats( const QString &formats );
 
     QVector<QgsDataItem *> createChildren() override;
@@ -160,6 +168,7 @@ class QgsArcGisRestFolderItem : public QgsDataCollectionItem
     QgsHttpHeaders mHeaders;
     QString mUrlPrefix;
     QString mSupportedFormats;
+    bool mForceRefresh = false;
 };
 
 
@@ -173,7 +182,7 @@ class QgsArcGisFeatureServiceItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisFeatureServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix );
+    QgsArcGisFeatureServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, bool forceRefresh );
     void setSupportedFormats( const QString &formats );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
@@ -185,6 +194,7 @@ class QgsArcGisFeatureServiceItem : public QgsDataCollectionItem
     QgsHttpHeaders mHeaders;
     QString mUrlPrefix;
     QString mSupportedFormats;
+    bool mForceRefresh = false;
 };
 
 /**
@@ -197,7 +207,7 @@ class QgsArcGisMapServiceItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisMapServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, Qgis::ArcGisRestServiceType serviceType );
+    QgsArcGisMapServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, Qgis::ArcGisRestServiceType serviceType, bool forceRefresh );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
@@ -208,6 +218,7 @@ class QgsArcGisMapServiceItem : public QgsDataCollectionItem
     QgsHttpHeaders mHeaders;
     QString mUrlPrefix;
     Qgis::ArcGisRestServiceType mServiceType = Qgis::ArcGisRestServiceType::Unknown;
+    bool mForceRefresh = false;
 };
 
 /**
@@ -220,7 +231,7 @@ class QgsArcGisSceneServiceItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsArcGisSceneServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix );
+    QgsArcGisSceneServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, bool forceRefresh );
     void setSupportedFormats( const QString &formats );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
@@ -232,6 +243,7 @@ class QgsArcGisSceneServiceItem : public QgsDataCollectionItem
     QgsHttpHeaders mHeaders;
     QString mUrlPrefix;
     QString mSupportedFormats;
+    bool mForceRefresh = false;
 };
 
 /**


### PR DESCRIPTION
This fix follows the same behavior as the WMS provider implements - the initial population of the connection's children MAY use
cached responses, but as soon as the user manually triggers a refresh on the connection item, the population will force a network retrieval ignoring any local cached response.

Fixes https://github.com/qgis/QGIS/issues/63010

Funded by République et canton de Genève