### PR TITLE
fix(dbmanager): fix using session_role parameter en dbmanager plugin

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/plugin.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugin.py
@@ -97,8 +97,9 @@ class PostGisDBPlugin(DBPlugin):
             "username",
             "password",
             "authcfg",
+            "session_role",
         ]
-        service, host, port, database, username, password, authcfg = (
+        service, host, port, database, username, password, authcfg, session_role = (
             settings.value(x, "", type=str) for x in settingsList
         )
 
@@ -121,6 +122,7 @@ class PostGisDBPlugin(DBPlugin):
             )
 
         uri.setUseEstimatedMetadata(useEstimatedMetadata)
+        uri.setParam("session_role", session_role)
 
         try:
             return self.connectToUri(uri)


### PR DESCRIPTION
## Description

Actualy you can use `Session ROLE` parameter in Posgresql Connection, however, this parameter is not used by the plugin db_manager.

This PR fix the plugin to use the `Session ROLE` parameter

## AI tool usage

No AI tool has been used here.

This fix was funded by "Les agences de l'eau"
<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
