### PR TITLE
preserve fields selection when changing format in the Save Features Layer As dialog (fix #32192)

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -286,6 +286,8 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     Options mOptions = Option::AllOptions;
     QString mDefaultOutputLayerNameFromInputLayerName;
     bool mAddToCanvasStateOnOpenCompatibleDriver = true;
+    QHash<QString, QPair<bool, std::optional<bool>>> mFieldsState;
+    QString mPreviousFormat;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsVectorLayerSaveAsDialog::Options )


### PR DESCRIPTION
## Description

In the "Save Features As" dialog changing output file format leads to the complete rebuild of the field list in the "Select fields to export and their export options" and as a result any changes to the exported fields and their options are lost.

This PR adds logic to store information about exported fields and their options before rebuilding the list and correctly restores user selection.

Fixes #32192.


## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.