### PR TITLE
Fix missing feedback to on in-place algorithm executed via locator

### DIFF
--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -258,5 +258,13 @@ class InPlaceAlgorithmLocatorFilter(QgsLocatorFilter):
         else:
             feedback = MessageBarProgress(algname=alg.displayName())
             parameters = {}
-            execute_in_place(alg, parameters, feedback=feedback)
+            ok, results = execute_in_place(alg, parameters, feedback=feedback)
+            if ok:
+                iface.messageBar().pushSuccess(
+                    "",
+                    self.tr(
+                        "{algname} completed. %n feature(s) processed.",
+                        n=results["__count"],
+                    ).format(algname=alg.displayName()),
+                )
             feedback.close()


### PR DESCRIPTION
When executing an in-place algorithm via locator that does suppress the dialog (because all required parameters - namely layer) is fulfilled, it should give a feedback in the message bar (aligned to the behavior, when starting it from the algorithm toolbox).

<img width="664" height="100" alt="image" src="https://github.com/user-attachments/assets/2bad9916-109f-47c2-8961-2854e3efad44" />

*Financed by the Canton of Solothurn*