### PR TITLE
[3D] Add camera controls dialog to control the 3D camera in map coordinates

### DIFF
--- a/src/app/3d/qgs3dcameracontrolswidget.cpp
+++ b/src/app/3d/qgs3dcameracontrolswidget.cpp
@@ -1,0 +1,111 @@
+/***************************************************************************
+  qgs3dcameracontrolswidget.cpp
+  --------------------------------------
+  Date                 : February 2026
+  Copyright            : (C) 2026 by Dominik Cindrić
+  Email                : viper dot miniq at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgs3dcameracontrolswidget.h"
+
+#include "qgis.h"
+#include "qgs3dmapcanvas.h"
+#include "qgs3dmapscene.h"
+#include "qgs3dutils.h"
+#include "qgscameracontroller.h"
+#include "qgscoordinatereferencesystem.h"
+
+#include <QString>
+
+#include "moc_qgs3dcameracontrolswidget.cpp"
+
+using namespace Qt::StringLiterals;
+
+Qgs3DCameraControlsWidget::Qgs3DCameraControlsWidget( Qgs3DMapCanvas *canvas, QWidget *parent )
+  : QWidget( parent )
+  , m3DMapCanvas( canvas )
+{
+  setupUi( this );
+
+  connect( mCameraX, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double ) {
+    updateCameraLookingAt();
+  } );
+
+  connect( mCameraY, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double ) {
+    updateCameraLookingAt();
+  } );
+
+  connect( mCameraZ, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double ) {
+    updateCameraLookingAt();
+  } );
+
+  connect( mCameraPitch, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double value ) {
+    QgsCameraPose pose = m3DMapCanvas->cameraController()->cameraPose();
+    pose.setPitchAngle( value );
+    m3DMapCanvas->cameraController()->setCameraPose( pose );
+  } );
+
+  connect( mCameraHeading, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double value ) {
+    QgsCameraPose pose = m3DMapCanvas->cameraController()->cameraPose();
+    pose.setHeadingAngle( value );
+    m3DMapCanvas->cameraController()->setCameraPose( pose );
+  } );
+
+  connect( mCameraDistanceFromCenterPoint, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double value ) {
+    QgsCameraPose pose = m3DMapCanvas->cameraController()->cameraPose();
+    pose.setDistanceFromCenterPoint( value );
+    m3DMapCanvas->cameraController()->setCameraPose( pose );
+  } );
+
+  mCameraX->setRange( std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() );
+  mCameraY->setRange( std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() );
+  mCameraZ->setRange( std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() );
+  mCameraPitch->setRange( 0.0, 180.0 );
+  mCameraHeading->setRange( std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() );
+  mCameraDistanceFromCenterPoint->setRange( std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() );
+
+  setCRSInfo();
+  updateFromCamera();
+}
+
+void Qgs3DCameraControlsWidget::updateCameraLookingAt()
+{
+  QgsVector3D mapLookingAt( mCameraX->value(), mCameraY->value(), mCameraX->value() );
+  QgsVector3D worldLookingAt = m3DMapCanvas->mapSettings()->mapToWorldCoordinates( mapLookingAt );
+  worldLookingAt.setZ( mCameraZ->value() );
+
+  m3DMapCanvas->cameraController()->setLookingAtPoint(
+    worldLookingAt,
+    m3DMapCanvas->cameraController()->distance(),
+    m3DMapCanvas->cameraController()->pitch(),
+    m3DMapCanvas->cameraController()->yaw()
+  );
+}
+
+void Qgs3DCameraControlsWidget::updateFromCamera() const
+{
+  QgsCameraPose pose = m3DMapCanvas->cameraController()->cameraPose();
+  QgsVector3D mapCoords = m3DMapCanvas->mapSettings()->worldToMapCoordinates( pose.centerPoint() );
+
+  whileBlocking( mCameraX )->setValue( mapCoords.x() );
+  whileBlocking( mCameraY )->setValue( mapCoords.y() );
+  whileBlocking( mCameraZ )->setValue( mapCoords.z() );
+
+  whileBlocking( mCameraPitch )->setValue( pose.pitchAngle() );
+  whileBlocking( mCameraHeading )->setValue( pose.headingAngle() );
+  whileBlocking( mCameraDistanceFromCenterPoint )->setValue( pose.distanceFromCenterPoint() );
+}
+
+void Qgs3DCameraControlsWidget::setCRSInfo() const
+{
+  QgsCoordinateReferenceSystem crs = m3DMapCanvas->mapSettings()->crs();
+  labelCRS->setText( tr( "Coordinates in 3D map CRS" ) + u" (%1)"_s.arg( crs.userFriendlyIdentifier( Qgis::CrsIdentifierType::ShortString ) ) );
+  labelCRS->setToolTip( crs.userFriendlyIdentifier( Qgis::CrsIdentifierType::MediumString ) );
+}

--- a/src/app/3d/qgs3dcameracontrolswidget.cpp
+++ b/src/app/3d/qgs3dcameracontrolswidget.cpp
@@ -21,8 +21,12 @@
 #include "qgs3dutils.h"
 #include "qgscameracontroller.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgslayoututils.h"
+#include "qgssettings.h"
 
+#include <QPushButton>
 #include <QString>
+#include <QTimer>
 
 #include "moc_qgs3dcameracontrolswidget.cpp"
 
@@ -34,41 +38,24 @@ Qgs3DCameraControlsWidget::Qgs3DCameraControlsWidget( Qgs3DMapCanvas *canvas, QW
 {
   setupUi( this );
 
-  connect( mCameraX, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double ) {
-    updateCameraLookingAt();
-  } );
+  mAutoApplyTimer = new QTimer( this );
+  mAutoApplyTimer->setSingleShot( true );
+  connect( mAutoApplyTimer, &QTimer::timeout, this, &Qgs3DCameraControlsWidget::applySettings );
 
-  connect( mCameraY, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double ) {
-    updateCameraLookingAt();
-  } );
+  connect( mButtonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &Qgs3DCameraControlsWidget::applySettings );
+  connect( mLiveApplyCheck, &QCheckBox::toggled, this, &Qgs3DCameraControlsWidget::liveApplyToggled );
 
-  connect( mCameraZ, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double ) {
-    updateCameraLookingAt();
-  } );
-
-  connect( mCameraPitch, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double value ) {
-    QgsCameraPose pose = m3DMapCanvas->cameraController()->cameraPose();
-    pose.setPitchAngle( value );
-    m3DMapCanvas->cameraController()->setCameraPose( pose );
-  } );
-
-  connect( mCameraHeading, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double value ) {
-    QgsCameraPose pose = m3DMapCanvas->cameraController()->cameraPose();
-    pose.setHeadingAngle( value );
-    m3DMapCanvas->cameraController()->setCameraPose( pose );
-  } );
-
-  connect( mCameraDistanceFromCenterPoint, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, [this]( const double value ) {
-    QgsCameraPose pose = m3DMapCanvas->cameraController()->cameraPose();
-    pose.setDistanceFromCenterPoint( value );
-    m3DMapCanvas->cameraController()->setCameraPose( pose );
-  } );
+  QgsSettings settings;
+  mLiveApplyCheck->setChecked( settings.value( u"UI/3DCameraControlsLiveUpdate"_s, true ).toBool() );
+  mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( !mLiveApplyCheck->isChecked() );
+  if ( mLiveApplyCheck->isChecked() )
+    connectLiveUpdates();
 
   mCameraX->setRange( std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() );
   mCameraY->setRange( std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() );
   mCameraZ->setRange( std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() );
   mCameraPitch->setRange( 0.0, 180.0 );
-  mCameraHeading->setRange( std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() );
+  mCameraHeading->setRange( 0.0, 360.0 );
   mCameraDistanceFromCenterPoint->setRange( std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() );
 
   setCRSInfo();
@@ -98,8 +85,8 @@ void Qgs3DCameraControlsWidget::updateFromCamera() const
   whileBlocking( mCameraY )->setValue( mapCoords.y() );
   whileBlocking( mCameraZ )->setValue( mapCoords.z() );
 
-  whileBlocking( mCameraPitch )->setValue( pose.pitchAngle() );
-  whileBlocking( mCameraHeading )->setValue( pose.headingAngle() );
+  whileBlocking( mCameraPitch )->setValue( QgsLayoutUtils::normalizedAngle( pose.pitchAngle() ) );
+  whileBlocking( mCameraHeading )->setValue( QgsLayoutUtils::normalizedAngle( pose.headingAngle() ) );
   whileBlocking( mCameraDistanceFromCenterPoint )->setValue( pose.distanceFromCenterPoint() );
 }
 
@@ -108,4 +95,56 @@ void Qgs3DCameraControlsWidget::setCRSInfo() const
   QgsCoordinateReferenceSystem crs = m3DMapCanvas->mapSettings()->crs();
   labelCRS->setText( tr( "Coordinates in 3D map CRS" ) + u" (%1)"_s.arg( crs.userFriendlyIdentifier( Qgis::CrsIdentifierType::ShortString ) ) );
   labelCRS->setToolTip( crs.userFriendlyIdentifier( Qgis::CrsIdentifierType::MediumString ) );
+}
+
+void Qgs3DCameraControlsWidget::autoApply()
+{
+  mAutoApplyTimer->start( 100 );
+}
+
+void Qgs3DCameraControlsWidget::liveApplyToggled( const bool liveUpdateEnabled )
+{
+  QgsSettings settings;
+  settings.setValue( u"UI/3DCameraControlsLiveUpdate"_s, liveUpdateEnabled );
+  mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( !liveUpdateEnabled );
+  if ( liveUpdateEnabled )
+  {
+    connectLiveUpdates();
+    applySettings();
+  }
+  else
+  {
+    disconnectLiveUpdates();
+  }
+}
+
+void Qgs3DCameraControlsWidget::connectLiveUpdates()
+{
+  connect( mCameraX, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+  connect( mCameraY, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+  connect( mCameraZ, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+  connect( mCameraPitch, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+  connect( mCameraHeading, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+  connect( mCameraDistanceFromCenterPoint, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+}
+
+void Qgs3DCameraControlsWidget::disconnectLiveUpdates()
+{
+  disconnect( mCameraX, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+  disconnect( mCameraY, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+  disconnect( mCameraZ, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+  disconnect( mCameraPitch, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+  disconnect( mCameraHeading, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+  disconnect( mCameraDistanceFromCenterPoint, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &Qgs3DCameraControlsWidget::autoApply );
+}
+
+void Qgs3DCameraControlsWidget::applySettings()
+{
+  updateCameraLookingAt();
+
+  QgsCameraPose pose = m3DMapCanvas->cameraController()->cameraPose();
+  pose.setPitchAngle( mCameraPitch->value() );
+  pose.setHeadingAngle( mCameraHeading->value() );
+  pose.setDistanceFromCenterPoint( mCameraDistanceFromCenterPoint->value() );
+  m3DMapCanvas->cameraController()->setCameraPose( pose );
 }

--- a/src/app/3d/qgs3dcameracontrolswidget.cpp
+++ b/src/app/3d/qgs3dcameracontrolswidget.cpp
@@ -143,8 +143,8 @@ void Qgs3DCameraControlsWidget::applySettings()
   updateCameraLookingAt();
 
   QgsCameraPose pose = m3DMapCanvas->cameraController()->cameraPose();
-  pose.setPitchAngle( mCameraPitch->value() );
-  pose.setHeadingAngle( mCameraHeading->value() );
-  pose.setDistanceFromCenterPoint( mCameraDistanceFromCenterPoint->value() );
+  pose.setPitchAngle( static_cast< float >( mCameraPitch->value() ) );
+  pose.setHeadingAngle( static_cast< float >( mCameraHeading->value() ) );
+  pose.setDistanceFromCenterPoint( static_cast< float >( mCameraDistanceFromCenterPoint->value() ) );
   m3DMapCanvas->cameraController()->setCameraPose( pose );
 }

--- a/src/app/3d/qgs3dcameracontrolswidget.cpp
+++ b/src/app/3d/qgs3dcameracontrolswidget.cpp
@@ -22,7 +22,7 @@
 #include "qgscameracontroller.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgslayoututils.h"
-#include "qgssettings.h"
+#include "qgssettingstree.h"
 
 #include <QPushButton>
 #include <QString>
@@ -31,6 +31,8 @@
 #include "moc_qgs3dcameracontrolswidget.cpp"
 
 using namespace Qt::StringLiterals;
+
+const QgsSettingsEntryBool *Qgs3DCameraControlsWidget::setting3DCameraControlsLiveUpdate = new QgsSettingsEntryBool( u"camera-controls-live-update"_s, QgsSettingsTree::sTree3DMap, true, u"Whether the 3D map is dynamically updated while camera controls are edited"_s );
 
 Qgs3DCameraControlsWidget::Qgs3DCameraControlsWidget( Qgs3DMapCanvas *canvas, QWidget *parent )
   : QWidget( parent )
@@ -45,8 +47,7 @@ Qgs3DCameraControlsWidget::Qgs3DCameraControlsWidget( Qgs3DMapCanvas *canvas, QW
   connect( mButtonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &Qgs3DCameraControlsWidget::applySettings );
   connect( mLiveApplyCheck, &QCheckBox::toggled, this, &Qgs3DCameraControlsWidget::liveApplyToggled );
 
-  QgsSettings settings;
-  mLiveApplyCheck->setChecked( settings.value( u"UI/3DCameraControlsLiveUpdate"_s, true ).toBool() );
+  mLiveApplyCheck->setChecked( setting3DCameraControlsLiveUpdate->value() );
   mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( !mLiveApplyCheck->isChecked() );
   if ( mLiveApplyCheck->isChecked() )
     connectLiveUpdates();
@@ -104,8 +105,7 @@ void Qgs3DCameraControlsWidget::autoApply()
 
 void Qgs3DCameraControlsWidget::liveApplyToggled( const bool liveUpdateEnabled )
 {
-  QgsSettings settings;
-  settings.setValue( u"UI/3DCameraControlsLiveUpdate"_s, liveUpdateEnabled );
+  setting3DCameraControlsLiveUpdate->setValue( liveUpdateEnabled );
   mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( !liveUpdateEnabled );
   if ( liveUpdateEnabled )
   {

--- a/src/app/3d/qgs3dcameracontrolswidget.h
+++ b/src/app/3d/qgs3dcameracontrolswidget.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+  qgs3dcameracontrolswidget.h
+  --------------------------------------
+  Date                 : February 2026
+  Copyright            : (C) 2026 by Dominik Cindrić
+  Email                : viper dot miniq at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGS3DCAMERACONTROLSWIDGET_H
+#define QGS3DCAMERACONTROLSWIDGET_H
+
+class QStandardItemModel;
+class Qgs3DMapCanvas;
+
+#include "ui_qgs3dcameracontrolswidget.h"
+
+#include "qgis_app.h"
+#include "qgs3dmapsettings.h"
+
+class APP_EXPORT Qgs3DCameraControlsWidget : public QWidget, Ui::Qgs3DCameraControlsWidget
+{
+    Q_OBJECT
+  public:
+    explicit Qgs3DCameraControlsWidget( Qgs3DMapCanvas *canvas, QWidget *parent = nullptr );
+
+  public slots:
+    void updateFromCamera() const;
+
+  private:
+    void setCRSInfo() const;
+    void updateCameraLookingAt();
+
+    Qgs3DMapCanvas *m3DMapCanvas = nullptr;
+};
+
+#endif // QGS3DCAMERACONTROLSWIDGET_H

--- a/src/app/3d/qgs3dcameracontrolswidget.h
+++ b/src/app/3d/qgs3dcameracontrolswidget.h
@@ -18,6 +18,7 @@
 
 class QStandardItemModel;
 class Qgs3DMapCanvas;
+class QgsSettingsEntryBool;
 
 #include "ui_qgs3dcameracontrolswidget.h"
 
@@ -28,6 +29,8 @@ class APP_EXPORT Qgs3DCameraControlsWidget : public QWidget, Ui::Qgs3DCameraCont
 {
     Q_OBJECT
   public:
+    static const QgsSettingsEntryBool *setting3DCameraControlsLiveUpdate;
+
     explicit Qgs3DCameraControlsWidget( Qgs3DMapCanvas *canvas, QWidget *parent = nullptr );
 
   public slots:

--- a/src/app/3d/qgs3dcameracontrolswidget.h
+++ b/src/app/3d/qgs3dcameracontrolswidget.h
@@ -33,11 +33,19 @@ class APP_EXPORT Qgs3DCameraControlsWidget : public QWidget, Ui::Qgs3DCameraCont
   public slots:
     void updateFromCamera() const;
 
+  private slots:
+    void autoApply();
+    void applySettings();
+    void liveApplyToggled( bool liveUpdateEnabled );
+
   private:
     void setCRSInfo() const;
     void updateCameraLookingAt();
+    void connectLiveUpdates();
+    void disconnectLiveUpdates();
 
     Qgs3DMapCanvas *m3DMapCanvas = nullptr;
+    QTimer *mAutoApplyTimer = nullptr;
 };
 
 #endif // QGS3DCAMERACONTROLSWIDGET_H

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -82,6 +82,7 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
   mToolbarMenu->setObjectName( u"mToolbarMenu"_s );
 
   QToolBar *toolBar = new QToolBar( this );
+  toolBar->setIconSize( QgisApp::instance()->iconSize( isDocked ) );
 
   QAction *actionCameraControl = toolBar->addAction( QIcon( QgsApplication::iconPath( "mActionPan.svg" ) ), tr( "Camera Control" ), this, &Qgs3DMapCanvasWidget::cameraControl );
   actionCameraControl->setCheckable( true );

--- a/src/app/3d/qgs3dmapcanvaswidget.h
+++ b/src/app/3d/qgs3dmapcanvaswidget.h
@@ -113,6 +113,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
   private slots:
     void resetView();
     void configure();
+    void configureCamera();
     void saveAsImage();
     void toggleAnimations();
     void cameraControl();
@@ -190,6 +191,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QAction *mActionSync3DNavTo2D = nullptr;
     QAction *mShowFrustumPolygon = nullptr;
     QAction *mActionShow2DMapOverlay = nullptr;
+    QAction *mActionOpenCameraControlsWidget = nullptr;
     QAction *mActionAnim = nullptr;
     QAction *mActionExport = nullptr;
     QAction *mActionMapThemes = nullptr;
@@ -211,6 +213,7 @@ class APP_EXPORT Qgs3DMapCanvasWidget : public QWidget
     QObjectUniquePtr<QgsRubberBand> mViewFrustumHighlight;
     QObjectUniquePtr<QgsRubberBand> mViewExtentHighlight;
     QPointer<QDialog> mConfigureDialog;
+    QPointer<QDialog> mCameraControlsDialog;
     QgsMessageBar *mMessageBar = nullptr;
     bool mGpuMemoryLimitReachedReported = false;
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -395,6 +395,7 @@ if (WITH_3D)
     3d/qgs3dviewsmanagerdialog.cpp
     3d/qgs3ddebugwidget.cpp
     3d/qgsmaptoolclippingplanes.cpp
+    3d/qgs3dcameracontrolswidget.cpp
   )
 endif()
 

--- a/src/ui/3d/qgs3dcameracontrolswidget.ui
+++ b/src/ui/3d/qgs3dcameracontrolswidget.ui
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Qgs3DCameraControlsWidget</class>
+ <widget class="QWidget" name="Qgs3DCameraControlsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>426</width>
+    <height>305</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0">
+    <widget class="QLabel" name="labelZ">
+     <property name="text">
+      <string>Looking at Z:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraPitch"/>
+   </item>
+   <item row="2" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraY"/>
+   </item>
+   <item row="5" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraHeading"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="labelPitch">
+     <property name="text">
+      <string>Pitch:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="labelX">
+     <property name="text">
+      <string>Looking at X:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="labelY">
+     <property name="text">
+      <string>Looking at Y:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraZ"/>
+   </item>
+   <item row="6" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraDistanceFromCenterPoint"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraX"/>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="labelCRS">
+     <property name="text">
+      <string>Coordinates in 3D Map CRS (EPSG: #CODE)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="labelHeading">
+     <property name="text">
+      <string>Heading:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="labelDistanceFromCenterPoint">
+     <property name="text">
+      <string>Distance from center point:</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/3d/qgs3dcameracontrolswidget.ui
+++ b/src/ui/3d/qgs3dcameracontrolswidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">Camera Controls</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="3" column="1">

--- a/src/ui/3d/qgs3dcameracontrolswidget.ui
+++ b/src/ui/3d/qgs3dcameracontrolswidget.ui
@@ -7,40 +7,20 @@
     <x>0</x>
     <y>0</y>
     <width>426</width>
-    <height>305</height>
+    <height>316</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
-    <widget class="QLabel" name="labelZ">
+   <item row="3" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraZ"/>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="labelDistanceFromCenterPoint">
      <property name="text">
-      <string>Looking at Z:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QDoubleSpinBox" name="mCameraPitch"/>
-   </item>
-   <item row="2" column="1">
-    <widget class="QDoubleSpinBox" name="mCameraY"/>
-   </item>
-   <item row="5" column="1">
-    <widget class="QDoubleSpinBox" name="mCameraHeading"/>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="labelPitch">
-     <property name="text">
-      <string>Pitch:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="labelX">
-     <property name="text">
-      <string>Looking at X:</string>
+      <string>Distance from center:</string>
      </property>
     </widget>
    </item>
@@ -51,14 +31,84 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QDoubleSpinBox" name="mCameraZ"/>
+   <item row="7" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraHeading">
+     <property name="suffix">
+      <string>°</string>
+     </property>
+     <property name="decimals">
+      <number>0</number>
+     </property>
+    </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QDoubleSpinBox" name="mCameraDistanceFromCenterPoint"/>
+   <item row="2" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraY"/>
    </item>
    <item row="1" column="1">
     <widget class="QDoubleSpinBox" name="mCameraX"/>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mLiveApplyCheck">
+       <property name="toolTip">
+        <string>If checked, the map canvas will automatically update whenever an option has been changed without the requirement to click Apply</string>
+       </property>
+       <property name="text">
+        <string>Live update</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="autoRepeat">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="mButtonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::StandardButton::Apply</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="6" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraPitch">
+     <property name="suffix">
+      <string>°</string>
+     </property>
+     <property name="decimals">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="labelZ">
+     <property name="text">
+      <string>Looking at Z:</string>
+     </property>
+    </widget>
    </item>
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="labelCRS">
@@ -67,7 +117,17 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="5" column="1">
+    <widget class="QDoubleSpinBox" name="mCameraDistanceFromCenterPoint"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="labelX">
+     <property name="text">
+      <string>Looking at X:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
     <widget class="QLabel" name="labelHeading">
      <property name="text">
       <string>Heading:</string>
@@ -75,9 +135,9 @@
     </widget>
    </item>
    <item row="6" column="0">
-    <widget class="QLabel" name="labelDistanceFromCenterPoint">
+    <widget class="QLabel" name="labelPitch">
      <property name="text">
-      <string>Distance from center point:</string>
+      <string>Pitch:</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This PR adds a dialog to control the camera looking at XYZ in 3D map CRS coordinates, as well as setting pitch and heading angles and distance from the center point.

~~No set button, camera updates on value change.~~

Dialog gets a `Live update` button that mimics the behavior of the Layer Styling panel.
When set, user changed settings are automatically reflected in the 3D map (there is a 100ms timer for this). 

This does not affect the values updating from the 3D map. 
When a user moves the camera, the values are updated in realtime, regardless of the `Live update` checkbox. 

<img width="2139" height="1485" alt="Screenshot_20260319_094951" src="https://github.com/user-attachments/assets/cb9bb1b7-ecd0-4bb7-8300-b199aeaed65d" />
