### PR TITLE
Advanced Digitiser: remove Ctrl modifier from X/Y/Z lock shortcuts

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1997,7 +1997,6 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
     case Qt::Key_X:
     {
       // modifier+x ONLY caught for ShortcutOverride events...
-      // Use Alt+X only (not Ctrl+X) to avoid conflict with the standard "Cut" shortcut
       if ( type == QEvent::ShortcutOverride && e->modifiers() == Qt::AltModifier )
       {
         mXConstraint->toggleLocked();
@@ -2028,7 +2027,6 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
     case Qt::Key_Y:
     {
       // modifier+y ONLY caught for ShortcutOverride events...
-      // Use Alt+Y only (not Ctrl+Y) to avoid conflict with the standard "Redo" shortcut
       if ( type == QEvent::ShortcutOverride && e->modifiers() == Qt::AltModifier )
       {
         mYConstraint->toggleLocked();

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -301,17 +301,17 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
 
   mRelativeXButton->setToolTip( "<b>" + tr( "Toggles relative x to previous node" ) + "</b><br>(" + tr( "press Shift + x for quick access" ) + ")" );
   mXLineEdit->setToolTip( "<b>" + tr( "X coordinate" ) + "</b><br>(" + tr( "press x for quick access" ) + ")" );
-  mLockXButton->setToolTip( "<b>" + tr( "Lock x coordinate" ) + "</b><br>(" + tr( "press Ctrl + x for quick access" ) + ")" );
+  mLockXButton->setToolTip( "<b>" + tr( "Lock x coordinate" ) + "</b><br>(" + tr( "press Alt + x for quick access" ) + ")" );
   mRepeatingLockXButton->setToolTip( "<b>" + tr( "Continuously lock x coordinate" ) + "</b>" );
 
   mRelativeYButton->setToolTip( "<b>" + tr( "Toggles relative y to previous node" ) + "</b><br>(" + tr( "press Shift + y for quick access" ) + ")" );
   mYLineEdit->setToolTip( "<b>" + tr( "Y coordinate" ) + "</b><br>(" + tr( "press y for quick access" ) + ")" );
-  mLockYButton->setToolTip( "<b>" + tr( "Lock y coordinate" ) + "</b><br>(" + tr( "press Ctrl + y for quick access" ) + ")" );
+  mLockYButton->setToolTip( "<b>" + tr( "Lock y coordinate" ) + "</b><br>(" + tr( "press Alt + y for quick access" ) + ")" );
   mRepeatingLockYButton->setToolTip( "<b>" + tr( "Continuously lock y coordinate" ) + "</b>" );
 
   mRelativeZButton->setToolTip( "<b>" + tr( "Toggles relative z to previous node" ) + "</b><br>(" + tr( "press Shift + z for quick access" ) + ")" );
   mZLineEdit->setToolTip( "<b>" + tr( "Z coordinate" ) + "</b><br>(" + tr( "press z for quick access" ) + ")" );
-  mLockZButton->setToolTip( "<b>" + tr( "Lock z coordinate" ) + "</b><br>(" + tr( "press Ctrl + z for quick access" ) + ")" );
+  mLockZButton->setToolTip( "<b>" + tr( "Lock z coordinate" ) + "</b><br>(" + tr( "press Alt + z for quick access" ) + ")" );
   mRepeatingLockZButton->setToolTip( "<b>" + tr( "Continuously lock z coordinate" ) + "</b>" );
 
   mRelativeMButton->setToolTip( "<b>" + tr( "Toggles relative m to previous node" ) + "</b><br>(" + tr( "press Shift + m for quick access" ) + ")" );
@@ -1997,7 +1997,8 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
     case Qt::Key_X:
     {
       // modifier+x ONLY caught for ShortcutOverride events...
-      if ( type == QEvent::ShortcutOverride && ( e->modifiers() == Qt::AltModifier || e->modifiers() == Qt::ControlModifier ) )
+      // Use Alt+X only (not Ctrl+X) to avoid conflict with the standard "Cut" shortcut
+      if ( type == QEvent::ShortcutOverride && e->modifiers() == Qt::AltModifier )
       {
         mXConstraint->toggleLocked();
         emit lockXChanged( mXConstraint->isLocked() );
@@ -2027,7 +2028,8 @@ bool QgsAdvancedDigitizingDockWidget::filterKeyPress( QKeyEvent *e )
     case Qt::Key_Y:
     {
       // modifier+y ONLY caught for ShortcutOverride events...
-      if ( type == QEvent::ShortcutOverride && ( e->modifiers() == Qt::AltModifier || e->modifiers() == Qt::ControlModifier ) )
+      // Use Alt+Y only (not Ctrl+Y) to avoid conflict with the standard "Redo" shortcut
+      if ( type == QEvent::ShortcutOverride && e->modifiers() == Qt::AltModifier )
       {
         mYConstraint->toggleLocked();
         emit lockYChanged( mYConstraint->isLocked() );


### PR DESCRIPTION
## Description
- Removes `Ctrl` as a modifier for locking X/Y/Z coordinates in the advanced sketcher dock widget, leaving only `Alt+X/Y/Z`
- Restores standard `Ctrl+X` (cut) and `Ctrl+Y` (redo) behavior when editing coordinate text fields. `Ctrl+Z` was never bound so this brings it inline with existing behavior
- Updates tooltips to reflect the `Alt`-only shortcut

Fixes https://github.com/qgis/QGIS/issues/64558