### PR TITLE
[core] Insure that content cache\'s remote content fetching tasks live on the same thread as the content cache itself

### DIFF
--- a/src/core/qgsabstractcontentcache_p.h
+++ b/src/core/qgsabstractcontentcache_p.h
@@ -149,6 +149,11 @@ QByteArray QgsAbstractContentCache<T>::getContent( const QString &path, const QB
   request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 
   QgsNetworkContentFetcherTask *task = new QgsNetworkContentFetcherTask( request );
+  if ( QThread::currentThread() != thread() )
+  {
+    // Move the network content fetcher task to the content cache thread
+    task->moveToThread( thread() );
+  }
   connect( task, &QgsNetworkContentFetcherTask::fetched, this, [this, task, path, missingContent]
   {
     const QMutexLocker locker( &mMutex );


### PR DESCRIPTION
## Description

This is a proposed fix for https://github.com/qgis/QGIS/issues/65137 -- it doesn't address the underlying issue but the workaround makes sense (to me) here. Moving the task to the content cache's thread to avoid the task threading issue is sensible as  the content fetcher task is implicitly tied to the content cache itself.