### PR TITLE
Force tasks to have affinity with task manager thread 

### DIFF
--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -447,6 +447,18 @@ long QgsTaskManager::addTaskPrivate( QgsTask *task, QgsTaskList dependencies, bo
   if ( !task )
     return 0;
 
+  // task MUST have affinity with task manager thread (by original design of QgsTaskManager). Otherwise
+  // there's potentially NO event loop associated with the thread the task is running in, and all qobject
+  // connections or invokeMethod related logic will fail (see https://github.com/qgis/QGIS/issues/65137)
+  if ( task->thread() != this->thread() )
+  {
+    QgsDebugMsgLevel( u"Task \"%1\" created in background thread, pushing to main thread"_s.arg( task->description() ), 1 );
+    if ( !task->moveToThread( this->thread() ) )
+    {
+      QgsDebugError( u"Failed to move task \"%1\" from background thread to task manager thread"_s.arg( task->description() ) );
+    }
+  }
+
   if ( !mInitialized )
   {
     mInitialized = true;

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -273,7 +273,7 @@ void QgsTask::setProgress( double progress )
 void QgsTask::completed()
 {
   mStatus = Complete;
-  QMetaObject::invokeMethod( this, "processSubTasksForCompletion" );
+  QMetaObject::invokeMethod( this, &QgsTask::processSubTasksForCompletion );
 }
 
 void QgsTask::processSubTasksForCompletion()
@@ -359,7 +359,7 @@ void QgsTask::processSubTasksForHold()
 void QgsTask::terminated()
 {
   mStatus = Terminated;
-  QMetaObject::invokeMethod( this, "processSubTasksForTermination" );
+  QMetaObject::invokeMethod( this, &QgsTask::processSubTasksForTermination );
 }
 
 

--- a/tests/src/core/testqgstaskmanager.cpp
+++ b/tests/src/core/testqgstaskmanager.cpp
@@ -357,6 +357,7 @@ class TestQgsTaskManager : public QObject
     void scopedProxyTask();
     void hiddenTask();
     void testQgsTaskWithSerialSubTasks();
+    void taskCreatedInBackgroundThread();
 };
 
 void TestQgsTaskManager::initTestCase()
@@ -1788,6 +1789,49 @@ void TestQgsTaskManager::testQgsTaskWithSerialSubTasks()
   QVERIFY( task->runCalled );
 
   taskWithSerialSubTasks->cancel();
+}
+
+class BackgroundTaskCreator : public QRunnable
+{
+  public:
+    BackgroundTaskCreator( QgsTaskManager *manager, std::atomic<QgsTask *> *createdTask )
+      : mManager( manager )
+      , mCreatedTask( createdTask )
+    {
+    }
+
+    void run() override
+    {
+      // force creation of a task in a thread WITHOUT an event loop
+      SuccessTask *task = new SuccessTask( u"background_created_task"_s );
+      mCreatedTask->store( task );
+      mManager->addTask( task );
+    }
+
+  private:
+    QgsTaskManager *mManager = nullptr;
+    std::atomic<QgsTask *> *mCreatedTask = nullptr;
+};
+
+void TestQgsTaskManager::taskCreatedInBackgroundThread()
+{
+  QgsTaskManager manager;
+  std::atomic<QgsTask *> task = nullptr;
+  BackgroundTaskCreator *creator = new BackgroundTaskCreator( &manager, &task );
+
+  // wait for task to be created and added to our manager
+  QSignalSpy spy( &manager, &QgsTaskManager::taskAdded );
+  QThreadPool::globalInstance()->start( creator );
+  spy.wait();
+
+  QElapsedTimer timer;
+  timer.start();
+  while ( task.load()->status() != QgsTask::Complete && timer.elapsed() < 5000 )
+  {
+    QCoreApplication::processEvents();
+  }
+
+  QCOMPARE( task.load()->status(), QgsTask::Complete );
 }
 
 QGSTEST_MAIN( TestQgsTaskManager )


### PR DESCRIPTION
Alternative to https://github.com/qgis/QGIS/pull/65139

The tasks MUST have affinity with task manager thread (by the original design of QgsTaskManager).

Otherwise there's potentially NO event loop associated with the thread the task is running in, and all qobject connections or invokeMethod related logic will fail

Fixes https://github.com/qgis/QGIS/issues/65137