### PR TITLE
[vector tiles] Fix handling of nested match property for color values

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -2876,7 +2876,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseValueList( const QVariantList &json,
   }
   else
   {
-    return QgsProperty::fromExpression( parseExpression( json, context ) );
+    return QgsProperty::fromExpression( parseExpression( json, context, type == PropertyType::Color ) );
   }
 }
 
@@ -3503,10 +3503,10 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
     for ( int i = 1; i < expression.size() - 2; i += 2 )
     {
       const QString condition = parseExpression( expression.value( i ).toList(), context );
-      const QString value = parseValue( expression.value( i + 1 ), context );
+      const QString value = parseValue( expression.value( i + 1 ), context, colorExpected );
       caseString += u" WHEN (%1) THEN %2"_s.arg( condition, value );
     }
-    const QString value = parseValue( expression.constLast(), context );
+    const QString value = parseValue( expression.constLast(), context, colorExpected );
     caseString += u" ELSE %1 END"_s.arg( value );
     return caseString;
   }

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -2758,6 +2758,64 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
             "CASE WHEN @vector_tile_zoom >= 14 AND @vector_tile_zoom < 16 THEN color_hsla(color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'hsl_hue'), color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'hsl_saturation'), color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'lightness'), color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'alpha')) WHEN @vector_tile_zoom >= 16 THEN color_hsla(color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'hsl_hue'), color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'hsl_saturation'), color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'lightness'), color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'alpha')) ELSE color_hsla(color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'hsl_hue'), color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'hsl_saturation'), color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'lightness'), color_part(CASE WHEN \"class\" IN ('roof', 'cooling_tower') THEN color_rgba(210,210,214,255) ELSE color_rgba(184,184,188,255) END,'alpha')) END",
         )
 
+    def testComplexLineColor(self):
+        context = QgsMapBoxGlStyleConversionContext()
+
+        style = {
+            "id": "road_fill",
+            "type": "line",
+            "source": "base_v1.0.0",
+            "source-layer": "transportation",
+            "minzoom": 4,
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round",
+                "visibility": "visible",
+            },
+            "paint": {
+                "line-color": [
+                    "match",
+                    ["get", "class"],
+                    [
+                        "motorway",
+                        "trunk",
+                        "motorway_construction",
+                        "trunk_construction",
+                    ],
+                    "rgb(248, 207, 117)",
+                    [
+                        "case",
+                        ["has", "is_route"],
+                        [
+                            "match",
+                            ["get", "is_route"],
+                            [5, 10],
+                            "rgb(250, 182, 158)",
+                            [6, 7, 8],
+                            "rgb(250, 243, 158)",
+                            "rgb(255, 255, 255)",
+                        ],
+                        "rgb(255, 255, 255)",
+                    ],
+                ],
+                "line-width": 10,
+                "line-opacity": 1,
+            },
+        }
+
+        has_renderer, rendererStyle = QgsMapBoxGlStyleConverter.parseLineLayer(
+            style,
+            context,
+        )
+
+        self.assertTrue(has_renderer)
+        dd_props = rendererStyle.symbol()[0].dataDefinedProperties()
+        prop = dd_props.property(QgsSymbolLayer.Property.StrokeColor)
+        self.assertEqual(
+            prop.asExpression(),
+            "CASE WHEN \"class\" IN ('motorway','trunk','motorway_construction','trunk_construction') THEN '#f8cf75' ELSE CASE WHEN (\"is_route\" IS NOT NULL) THEN CASE WHEN \"is_route\" IN (5, 10) THEN color_rgba(250,182,158,255) WHEN \"is_route\" IN (6, 7, 8) THEN color_rgba(250,243,158,255) ELSE color_rgba(255,255,255,255) END ELSE color_rgba(255,255,255,255) END END",
+        )
+
     def testRetrieveSprite(self):
         context = QgsMapBoxGlStyleConversionContext()
         sprite_image_file = (


### PR DESCRIPTION
## Description

Before:

<img width="1030" height="1034" alt="image" src="https://github.com/user-attachments/assets/a7bc95d3-2aae-40ef-b92e-d22f1f39bc3d" />

PR:

<img width="1025" height="1029" alt="image" src="https://github.com/user-attachments/assets/13b8ed7d-1543-4b38-9794-cd2327c94b3e" />

For a moment here I was questioning the styling choice of swisstopo with bright green roads, until I realized QGIS was just parsing it all wrong.