### PR TITLE
use EPSG:4326 when exporting vector to GPX, KML and GeoJSON with RFC7946=YES (fix  #16404)

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -764,11 +764,10 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
         layerOptionsLayout->addRow( control.first, control.second );
       }
 
-      // for GeoiJSON we need to track changes of the RFC7946 option to update CRS accordingly
+      // for GeoJSON we need to track changes of the RFC7946 option to update CRS accordingly
       if ( sFormat == "GeoJSON"_L1 )
       {
-        QComboBox *cmbRfc7946 = mLayerOptionsGroupBox->findChild<QComboBox *>( "RFC7946"_L1 );
-        if ( cmbRfc7946 )
+        if ( QComboBox *cmbRfc7946 = mLayerOptionsGroupBox->findChild<QComboBox *>( "RFC7946"_L1 ) )
         {
           connect( cmbRfc7946, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsVectorLayerSaveAsDialog::setCrsForFormat );
         }

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -730,7 +730,7 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
 
   typedef QPair<QLabel *, QWidget *> LabelControlPair;
 
-  if ( QgsVectorFileWriter::driverMetadata( format(), driverMetaData ) )
+  if ( QgsVectorFileWriter::driverMetadata( sFormat, driverMetaData ) )
   {
     if ( !driverMetaData.driverOptions.empty() )
     {
@@ -761,6 +761,16 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
       for ( LabelControlPair control : constControls )
       {
         layerOptionsLayout->addRow( control.first, control.second );
+      }
+
+      // for GeoiJSON we need to track changes of the RFC7946 option to update CRS accordingly
+      if ( sFormat == "GeoJSON"_L1 )
+      {
+        QComboBox *cmbRfc7946 = mLayerOptionsGroupBox->findChild<QComboBox *>( "RFC7946"_L1 );
+        if ( cmbRfc7946 )
+        {
+          connect( cmbRfc7946, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsVectorLayerSaveAsDialog::setCrsForFormat );
+        }
       }
     }
     else
@@ -807,6 +817,9 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
       mAddToCanvas->setEnabled( true );
     }
   }
+
+  // update CRS selector based on the selected format and layer creation options
+  setCrsForFormat();
 }
 
 void QgsVectorLayerSaveAsDialog::mUseAliasesForExportedName_stateChanged( int state )
@@ -1357,4 +1370,33 @@ void QgsVectorLayerSaveAsDialog::mDeselectAllAttributes_clicked()
 void QgsVectorLayerSaveAsDialog::showHelp()
 {
   QgsHelp::openHelp( u"managing_data_source/create_layers.html#creating-new-layers-from-an-existing-layer"_s );
+}
+
+void QgsVectorLayerSaveAsDialog::setCrsForFormat()
+{
+  const QString outputFormat = format();
+
+  bool force4326 = ( outputFormat == "KML"_L1 || outputFormat == "LIBKML"_L1 || outputFormat == "GPX"_L1 );
+
+  // GeoJSON with RFC7946=YES should use EPSG:4326
+  if ( outputFormat == "GeoJSON"_L1 )
+  {
+    QComboBox *cmb = mLayerOptionsGroupBox->findChild<QComboBox *>( u"RFC7946"_s );
+    if ( cmb && cmb->currentText() == "YES"_L1 )
+    {
+      force4326 = true;
+    }
+  }
+
+  if ( force4326 )
+  {
+    mCrsSelector->setEnabled( false );
+    whileBlocking( mCrsSelector )->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
+    mSelectedCrs = QgsCoordinateReferenceSystem( u"EPSG:4326"_s );
+    mExtentGroupBox->setOutputCrs( mSelectedCrs );
+  }
+  else
+  {
+    mCrsSelector->setEnabled( true );
+  }
 }

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -181,6 +181,7 @@ void QgsVectorLayerSaveAsDialog::setup()
     "Select the coordinate reference system for the vector file. "
     "The data points will be transformed from the layer coordinate reference system."
   ) );
+  mUserDefinedCrs = mSelectedCrs;
 
   mEncodingComboBox->setCurrentIndex( idx );
   mFormatComboBox_currentIndexChanged( mFormatComboBox->currentIndex() );
@@ -1001,7 +1002,15 @@ void QgsVectorLayerSaveAsDialog::mAttributeTable_itemChanged( QTableWidgetItem *
 
 void QgsVectorLayerSaveAsDialog::mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs )
 {
+  if ( mCrsDefinedByFormat )
+  {
+    // this should never happen as CRS selector should be disabled, but let's be safe and
+    // avoid overwriting user defined CRS with the CRS required by the output format
+    return;
+  }
+
   mSelectedCrs = crs;
+  mUserDefinedCrs = crs;
   mExtentGroupBox->setOutputCrs( mSelectedCrs );
 }
 
@@ -1388,15 +1397,19 @@ void QgsVectorLayerSaveAsDialog::setCrsForFormat()
     }
   }
 
-  if ( force4326 )
+  if ( force4326 && !mCrsDefinedByFormat )
   {
+    mUserDefinedCrs = mCrsSelector->crs();
+    mCrsDefinedByFormat = true;
     mCrsSelector->setEnabled( false );
-    whileBlocking( mCrsSelector )->setCrs( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ) );
     mSelectedCrs = QgsCoordinateReferenceSystem( u"EPSG:4326"_s );
+    whileBlocking( mCrsSelector )->setCrs( mSelectedCrs );
     mExtentGroupBox->setOutputCrs( mSelectedCrs );
   }
-  else
+  else if ( !force4326 && mCrsDefinedByFormat )
   {
+    mCrsDefinedByFormat = false;
     mCrsSelector->setEnabled( true );
+    mCrsSelector->setCrs( mUserDefinedCrs );
   }
 }

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -265,6 +265,7 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     void mUseAliasesForExportedName_stateChanged( int state );
     void mReplaceRawFieldValues_stateChanged( int state );
     void mAttributeTable_itemChanged( QTableWidgetItem *item );
+    void setCrsForFormat();
 
   private:
     enum class ColumnIndex : int

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -283,6 +283,7 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
 
     QgsRectangle mLayerExtent;
     QgsCoordinateReferenceSystem mLayerCrs;
+    QgsCoordinateReferenceSystem mUserDefinedCrs;
     QgsVectorLayer *mLayer = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsVectorFileWriter::ActionOnExistingFile mActionOnExistingFile;
@@ -291,6 +292,7 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     bool mAddToCanvasStateOnOpenCompatibleDriver = true;
     QHash<QString, QPair<bool, std::optional<bool>>> mFieldsState;
     QString mPreviousFormat;
+    bool mCrsDefinedByFormat = false;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsVectorLayerSaveAsDialog::Options )

--- a/tests/src/app/testqgsvectorlayersaveasdialog.cpp
+++ b/tests/src/app/testqgsvectorlayersaveasdialog.cpp
@@ -15,12 +15,14 @@
 #include "ogr/qgsvectorlayersaveasdialog.h"
 #include "qgisapp.h"
 #include "qgsapplication.h"
+#include "qgscollapsiblegroupbox.h"
 #include "qgseditorwidgetregistry.h"
 #include "qgsfeature.h"
 #include "qgsgeometry.h"
 #include "qgsgui.h"
 #include "qgsmapcanvas.h"
 #include "qgsproject.h"
+#include "qgsprojectionselectionwidget.h"
 #include "qgstest.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
@@ -47,6 +49,7 @@ class TestQgsVectorLayerSaveAsDialog : public QObject
 
     void testAttributesAsDisplayedValues();
     void testFieldSelectionPreservedOnFormatChange();
+    void testSetCrsDependingOnFormat();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -223,6 +226,63 @@ void TestQgsVectorLayerSaveAsDialog::testFieldSelectionPreservedOnFormatChange()
   QCOMPARE( mAttributeTable->item( 2, 0 )->checkState(), Qt::Checked );
   QCOMPARE( mAttributeTable->item( 2, 3 )->checkState(), Qt::Unchecked );
   QCOMPARE( mReplaceRawFieldValues->checkState(), Qt::Unchecked );
+}
+
+void TestQgsVectorLayerSaveAsDialog::testSetCrsDependingOnFormat()
+{
+  //create a temporary layer
+  auto tempLayer = std::make_unique<QgsVectorLayer>( u"Point?crs=EPSG:3857&field=id:int&field=name:string"_s, u"vl"_s, u"memory"_s );
+  QVERIFY( tempLayer->isValid() );
+
+  const QgsVectorLayerSaveAsDialog d( tempLayer.get() );
+
+  QComboBox *mFormatComboBox = d.findChild<QComboBox *>( u"mFormatComboBox"_s );
+  QgsProjectionSelectionWidget *mCrsSelector = d.findChild<QgsProjectionSelectionWidget *>( u"mCrsSelector"_s );
+  QgsCollapsibleGroupBox *mLayerOptionsGroupBox = d.findChild<QgsCollapsibleGroupBox *>( u"mLayerOptionsGroupBox"_s );
+
+  const QgsCoordinateReferenceSystem wgs84 = QgsCoordinateReferenceSystem( u"EPSG:4326"_s );
+  const QgsCoordinateReferenceSystem pseudoMercator = QgsCoordinateReferenceSystem( u"EPSG:3857"_s );
+
+  QCOMPARE( mCrsSelector->crs(), QgsCoordinateReferenceSystem( u"EPSG:3857"_s ) );
+
+  // set format to KML, CRS selector should be disabled and set to EPSG:4326
+  mFormatComboBox->setCurrentIndex( mFormatComboBox->findData( u"KML"_s ) );
+  QCOMPARE( mCrsSelector->isEnabled(), false );
+  QCOMPARE( mCrsSelector->crs(), wgs84 );
+  QCOMPARE( d.crs(), wgs84 );
+
+  mFormatComboBox->setCurrentIndex( mFormatComboBox->findData( u"GeoPackage"_s ) );
+  QCOMPARE( mCrsSelector->isEnabled(), true );
+  mCrsSelector->setCrs( pseudoMercator );
+  QCOMPARE( mCrsSelector->crs(), pseudoMercator );
+
+  // set format to GPX, CRS selector should be disabled and set to EPSG:4326
+  mFormatComboBox->setCurrentIndex( mFormatComboBox->findData( u"GPX"_s ) );
+  QCOMPARE( mCrsSelector->isEnabled(), false );
+  QCOMPARE( mCrsSelector->crs(), wgs84 );
+  QCOMPARE( d.crs(), wgs84 );
+
+  mFormatComboBox->setCurrentIndex( mFormatComboBox->findData( u"GeoPackage"_s ) );
+  QCOMPARE( mCrsSelector->isEnabled(), true );
+  mCrsSelector->setCrs( pseudoMercator );
+  QCOMPARE( mCrsSelector->crs(), pseudoMercator );
+
+  // set format to GeoJSON, CRS selector should be enabled
+  mFormatComboBox->setCurrentIndex( mFormatComboBox->findData( u"GeoJSON"_s ) );
+  QCOMPARE( mCrsSelector->isEnabled(), true );
+  QCOMPARE( mCrsSelector->crs(), pseudoMercator );
+  QCOMPARE( d.crs(), pseudoMercator );
+
+  // enable RFC7946 ooption, CRS selector should be disabled and set to EPSG:4326
+  QComboBox *cmbRfc7946 = mLayerOptionsGroupBox->findChild<QComboBox *>( u"RFC7946"_s );
+  QVERIFY( cmbRfc7946 );
+  cmbRfc7946->setCurrentIndex( cmbRfc7946->findText( "YES"_L1 ) );
+  QCOMPARE( mCrsSelector->isEnabled(), false );
+  QCOMPARE( mCrsSelector->crs(), wgs84 );
+  QCOMPARE( d.crs(), wgs84 );
+
+  mFormatComboBox->setCurrentIndex( mFormatComboBox->findData( u"GeoPackage"_s ) );
+  QCOMPARE( mCrsSelector->isEnabled(), true );
 }
 
 QGSTEST_MAIN( TestQgsVectorLayerSaveAsDialog )

--- a/tests/src/app/testqgsvectorlayersaveasdialog.cpp
+++ b/tests/src/app/testqgsvectorlayersaveasdialog.cpp
@@ -253,7 +253,6 @@ void TestQgsVectorLayerSaveAsDialog::testSetCrsDependingOnFormat()
 
   mFormatComboBox->setCurrentIndex( mFormatComboBox->findData( u"GeoPackage"_s ) );
   QCOMPARE( mCrsSelector->isEnabled(), true );
-  mCrsSelector->setCrs( pseudoMercator );
   QCOMPARE( mCrsSelector->crs(), pseudoMercator );
 
   // set format to GPX, CRS selector should be disabled and set to EPSG:4326
@@ -264,7 +263,6 @@ void TestQgsVectorLayerSaveAsDialog::testSetCrsDependingOnFormat()
 
   mFormatComboBox->setCurrentIndex( mFormatComboBox->findData( u"GeoPackage"_s ) );
   QCOMPARE( mCrsSelector->isEnabled(), true );
-  mCrsSelector->setCrs( pseudoMercator );
   QCOMPARE( mCrsSelector->crs(), pseudoMercator );
 
   // set format to GeoJSON, CRS selector should be enabled
@@ -283,6 +281,8 @@ void TestQgsVectorLayerSaveAsDialog::testSetCrsDependingOnFormat()
 
   mFormatComboBox->setCurrentIndex( mFormatComboBox->findData( u"GeoPackage"_s ) );
   QCOMPARE( mCrsSelector->isEnabled(), true );
+  QCOMPARE( mCrsSelector->crs(), pseudoMercator );
+  QCOMPARE( d.crs(), pseudoMercator );
 }
 
 QGSTEST_MAIN( TestQgsVectorLayerSaveAsDialog )


### PR DESCRIPTION
## Description

When exporting vector layer to GPX, KML and GeoJSON with RFC7946=YES use EPSG:4326 as output CRS and disable CRS selector. Switching back to a format which does not require specific CRS will restore previously selected CRS.

Fixes #16404.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.