### PR TITLE
[app] Use _wputenv_s on Windows to avoid issues with non ASCII chars when setting custom environment variables

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1464,7 +1464,7 @@ int main( int argc, char *argv[] )
         if ( systemEnvVars.contains( envVarName ) && envVarApply == "unset"_L1 )
         {
 #ifdef Q_OS_WIN
-          putenv( QString( "%1=" ).arg( envVarName ).toUtf8().constData() );
+          _wputenv_s( envVarName.toStdWString().c_str(), L"" );
 #else
           unsetenv( envVarName.toUtf8().constData() );
 #endif
@@ -1473,7 +1473,7 @@ int main( int argc, char *argv[] )
         {
 #ifdef Q_OS_WIN
           if ( envVarApply != "undefined" || !getenv( envVarName.toUtf8().constData() ) )
-            putenv( QString( "%1=%2" ).arg( envVarName ).arg( envVarValue ).toUtf8().constData() );
+            _wputenv_s( envVarName.toStdWString().c_str(), envVarValue.toStdWString().c_str() );
 #else
           setenv( envVarName.toUtf8().constData(), envVarValue.toUtf8().constData(), envVarApply == "undefined"_L1 ? 0 : 1 );
 #endif


### PR DESCRIPTION
## Description

Fixes #65151 replacing the `putenv` function with the corresponding wide-character version `_wputenv_s` which is needed on Windows systems to correctly handle non ASCII characters in environment variable's name and value for Overwrite, Append, Prepend, Unset modes in Settings → Options → System → Environment.

Before:

<img width="548" height="351" alt="image" src="https://github.com/user-attachments/assets/7156c970-a7b3-43d7-b30e-31ac3f1e9cdf" />
<img width="723" height="184" alt="image" src="https://github.com/user-attachments/assets/cc375e95-9c9a-405a-b013-0a7723ed1ff1" />
<img width="304" height="317" alt="image" src="https://github.com/user-attachments/assets/aebd1873-ea50-4073-a952-6d6b8625d9c4" />

After:
<img width="541" height="349" alt="image" src="https://github.com/user-attachments/assets/67674c99-cbc5-482c-a574-a1ff507422ce" />
<img width="720" height="172" alt="image" src="https://github.com/user-attachments/assets/01483899-8971-41b1-93b5-406e46fd2fc7" />
<img width="324" height="333" alt="image" src="https://github.com/user-attachments/assets/83c11afd-3ac6-4538-98f0-601ddd67701f" />



## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
