### PR TITLE
[afs] Use linear geometries if service doesn't support curved geometry updates (backport)

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -84,7 +84,7 @@ Converts an ESRI REST field ``type`` to a QVariant type.
 Converts an ESRI REST geometry ``type`` to a WKB type.
 %End
 
-    static QgsAbstractGeometry *convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 ) /Factory/;
+    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 );
 %Docstring
 Converts an ESRI REST ``geometry`` JSON definition to a
 :py:class:`QgsAbstractGeometry`.
@@ -106,14 +106,14 @@ Converts a spatial reference JSON definition to a
 :py:class:`QgsCoordinateReferenceSystem` value.
 %End
 
-    static QgsSymbol *convertSymbol( const QVariantMap &definition ) /Factory/;
+    static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition );
 %Docstring
 Converts a symbol JSON ``definition`` to a :py:class:`QgsSymbol`.
 
 Caller takes ownership of the returned symbol.
 %End
 
-    static QgsFeatureRenderer *convertRenderer( const QVariantMap &rendererData ) /Factory/;
+    static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData );
 %Docstring
 Converts renderer JSON ``data`` to an equivalent
 :py:class:`QgsFeatureRenderer`.
@@ -121,7 +121,7 @@ Converts renderer JSON ``data`` to an equivalent
 Caller takes ownership of the returned renderer.
 %End
 
-    static QgsAbstractVectorLayerLabeling *convertLabeling( const QVariantList &data ) /Factory/;
+    static std::unique_ptr< QgsAbstractVectorLayerLabeling > convertLabeling( const QVariantList &data );
 %Docstring
 Converts labeling JSON ``data`` to an equivalent QGIS vector labeling.
 

--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -84,7 +84,7 @@ Converts an ESRI REST field ``type`` to a QVariant type.
 Converts an ESRI REST geometry ``type`` to a WKB type.
 %End
 
-    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 );
+    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, bool allowCurves = true, QgsCoordinateReferenceSystem *crs /Out/ = 0 );
 %Docstring
 Converts an ESRI REST ``geometry`` JSON definition to a
 :py:class:`QgsAbstractGeometry`.
@@ -95,6 +95,8 @@ Caller takes ownership of the returned object.
 :param esriGeometryType: ESRI geometry type string
 :param hasM: set to ``True`` to if geometry includes M values
 :param hasZ: set to ``True`` to if geometry includes Z values
+:param allowCurves: controls whether the returned geometry can be a
+                    curved geometry type (since QGIS 4.0)
 
 :return: - converted geometry
          - crs: the parsed geometry CRS

--- a/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -84,7 +84,7 @@ Converts an ESRI REST field ``type`` to a QVariant type.
 Converts an ESRI REST geometry ``type`` to a WKB type.
 %End
 
-    static QgsAbstractGeometry *convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 ) /Factory/;
+    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 );
 %Docstring
 Converts an ESRI REST ``geometry`` JSON definition to a
 :py:class:`QgsAbstractGeometry`.
@@ -106,14 +106,14 @@ Converts a spatial reference JSON definition to a
 :py:class:`QgsCoordinateReferenceSystem` value.
 %End
 
-    static QgsSymbol *convertSymbol( const QVariantMap &definition ) /Factory/;
+    static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition );
 %Docstring
 Converts a symbol JSON ``definition`` to a :py:class:`QgsSymbol`.
 
 Caller takes ownership of the returned symbol.
 %End
 
-    static QgsFeatureRenderer *convertRenderer( const QVariantMap &rendererData ) /Factory/;
+    static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData );
 %Docstring
 Converts renderer JSON ``data`` to an equivalent
 :py:class:`QgsFeatureRenderer`.
@@ -121,7 +121,7 @@ Converts renderer JSON ``data`` to an equivalent
 Caller takes ownership of the returned renderer.
 %End
 
-    static QgsAbstractVectorLayerLabeling *convertLabeling( const QVariantList &data ) /Factory/;
+    static std::unique_ptr< QgsAbstractVectorLayerLabeling > convertLabeling( const QVariantList &data );
 %Docstring
 Converts labeling JSON ``data`` to an equivalent QGIS vector labeling.
 

--- a/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -84,7 +84,7 @@ Converts an ESRI REST field ``type`` to a QVariant type.
 Converts an ESRI REST geometry ``type`` to a WKB type.
 %End
 
-    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs /Out/ = 0 );
+    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, bool allowCurves = true, QgsCoordinateReferenceSystem *crs /Out/ = 0 );
 %Docstring
 Converts an ESRI REST ``geometry`` JSON definition to a
 :py:class:`QgsAbstractGeometry`.
@@ -95,6 +95,8 @@ Caller takes ownership of the returned object.
 :param esriGeometryType: ESRI geometry type string
 :param hasM: set to ``True`` to if geometry includes M values
 :param hasZ: set to ``True`` to if geometry includes Z values
+:param allowCurves: controls whether the returned geometry can be a
+                    curved geometry type (since QGIS 4.0)
 
 :return: - converted geometry
          - crs: the parsed geometry CRS

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -122,7 +122,7 @@ Qgis::WkbType QgsArcGisRestUtils::convertGeometryType( const QString &esriGeomet
 
 std::unique_ptr< QgsPoint > QgsArcGisRestUtils::convertPoint( const QVariantList &coordList, Qgis::WkbType pointType )
 {
-  int nCoords = coordList.size();
+  const int nCoords = static_cast< int >( coordList.size() );
   if ( nCoords < 2 )
     return nullptr;
   bool xok = false, yok = false;
@@ -143,7 +143,7 @@ std::unique_ptr< QgsCircularString > QgsArcGisRestUtils::convertCircularString( 
   const QVariantList coordsList = curveData[QStringLiteral( "c" )].toList();
   if ( coordsList.isEmpty() )
     return nullptr;
-  const int coordsListSize = coordsList.size();
+  const int coordsListSize = static_cast< int >( coordsList.size() );
 
   QVector<QgsPoint> points;
   points.reserve( coordsListSize + 1 );
@@ -178,7 +178,7 @@ std::unique_ptr< QgsCurve > QgsArcGisRestUtils::convertCompoundCurve( const QVar
   QVector< double > lineY;
   QVector< double > lineZ;
   QVector< double > lineM;
-  int maxCurveListSize = curvesList.size();
+  const int maxCurveListSize = static_cast< int >( curvesList.size() );
   lineX.resize( maxCurveListSize );
   lineY.resize( maxCurveListSize );
 
@@ -204,7 +204,7 @@ std::unique_ptr< QgsCurve > QgsArcGisRestUtils::convertCompoundCurve( const QVar
     if ( curveData.userType() == QMetaType::Type::QVariantList )
     {
       const QVariantList coordList = curveData.toList();
-      const int nCoords = coordList.size();
+      const int nCoords = static_cast< int >( coordList.size() );
       if ( nCoords < 2 )
         return nullptr;
 
@@ -320,7 +320,7 @@ std::unique_ptr<QgsLineString> QgsArcGisRestUtils::convertLineString( const QVar
   QVector< double > lineY;
   QVector< double > lineZ;
   QVector< double > lineM;
-  int maxCurveListSize = curvesList.size();
+  const int maxCurveListSize = static_cast< int >( curvesList.size() );
   lineX.resize( maxCurveListSize );
   lineY.resize( maxCurveListSize );
 
@@ -345,7 +345,7 @@ std::unique_ptr<QgsLineString> QgsArcGisRestUtils::convertLineString( const QVar
     if ( curveData.userType() == QMetaType::Type::QVariantList )
     {
       const QVariantList coordList = curveData.toList();
-      const int nCoords = coordList.size();
+      const int nCoords = static_cast< int >( coordList.size() );
       if ( nCoords < 2 )
         return nullptr;
 
@@ -406,7 +406,7 @@ std::unique_ptr< QgsMultiPoint > QgsArcGisRestUtils::convertMultiPoint( const QV
   const QVariantList coordsList = geometryData[QStringLiteral( "points" )].toList();
 
   auto multiPoint = std::make_unique< QgsMultiPoint >();
-  multiPoint->reserve( coordsList.size() );
+  multiPoint->reserve( static_cast< int >( coordsList.size() ) );
   for ( const QVariant &coordData : coordsList )
   {
     const QVariantList coordList = coordData.toList();
@@ -443,7 +443,7 @@ std::unique_ptr< QgsMultiCurve > QgsArcGisRestUtils::convertGeometryPolyline( co
   if ( pathsList.isEmpty() )
     return nullptr;
   std::unique_ptr< QgsMultiCurve > multiCurve = allowCurves ? std::make_unique< QgsMultiCurve >() : std::make_unique< QgsMultiLineString >();
-  multiCurve->reserve( pathsList.size() );
+  multiCurve->reserve( static_cast< int >( pathsList.size() ) );
   for ( const QVariant &pathData : std::as_const( pathsList ) )
   {
     std::unique_ptr< QgsCurve > curve = allowCurves ? convertCompoundCurve( pathData.toList(), pointType ) : convertLineString( pathData.toList(), pointType );
@@ -468,7 +468,7 @@ std::unique_ptr< QgsMultiSurface > QgsArcGisRestUtils::convertGeometryPolygon( c
     return nullptr;
 
   QList< QgsCurve * > curves;
-  for ( int i = 0, n = ringsList.size(); i < n; ++i )
+  for ( int i = 0, n = static_cast< int >( ringsList.size() ); i < n; ++i )
   {
     std::unique_ptr< QgsCurve > curve = allowCurves ? convertCompoundCurve( ringsList[i].toList(), pointType ) : convertLineString( ringsList[i].toList(), pointType );
     if ( !curve )
@@ -491,7 +491,7 @@ std::unique_ptr< QgsMultiSurface > QgsArcGisRestUtils::convertGeometryPolygon( c
   }
 
   std::sort( curves.begin(), curves.end(), []( const QgsCurve * a, const QgsCurve * b )->bool{ double a_area = 0.0; double b_area = 0.0; a->sumUpArea( a_area ); b->sumUpArea( b_area ); return std::abs( a_area ) > std::abs( b_area ); } );
-  result->reserve( curves.size() );
+  result->reserve( static_cast< int >( curves.size() ) );
   while ( !curves.isEmpty() )
   {
     QgsCurve *exterior = curves.takeFirst();

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -471,7 +471,7 @@ std::unique_ptr< QgsPolygon > QgsArcGisRestUtils::convertEnvelope( const QVarian
   return poly;
 }
 
-QgsAbstractGeometry *QgsArcGisRestUtils::convertGeometry( const QVariantMap &geometryData, const QString &esriGeometryType, bool readM, bool readZ, QgsCoordinateReferenceSystem *crs )
+std::unique_ptr< QgsAbstractGeometry > QgsArcGisRestUtils::convertGeometry( const QVariantMap &geometryData, const QString &esriGeometryType, bool readM, bool readZ, QgsCoordinateReferenceSystem *crs )
 {
   Qgis::WkbType pointType = QgsWkbTypes::zmType( Qgis::WkbType::Point, readZ, readM );
   if ( crs )
@@ -483,15 +483,15 @@ QgsAbstractGeometry *QgsArcGisRestUtils::convertGeometry( const QVariantMap &geo
   if ( esriGeometryType == QLatin1String( "esriGeometryNull" ) )
     return nullptr;
   else if ( esriGeometryType == QLatin1String( "esriGeometryPoint" ) )
-    return convertGeometryPoint( geometryData, pointType ).release();
+    return convertGeometryPoint( geometryData, pointType );
   else if ( esriGeometryType == QLatin1String( "esriGeometryMultipoint" ) )
-    return convertMultiPoint( geometryData, pointType ).release();
+    return convertMultiPoint( geometryData, pointType );
   else if ( esriGeometryType == QLatin1String( "esriGeometryPolyline" ) )
-    return convertGeometryPolyline( geometryData, pointType ).release();
+    return convertGeometryPolyline( geometryData, pointType );
   else if ( esriGeometryType == QLatin1String( "esriGeometryPolygon" ) )
-    return convertGeometryPolygon( geometryData, pointType ).release();
+    return convertGeometryPolygon( geometryData, pointType );
   else if ( esriGeometryType == QLatin1String( "esriGeometryEnvelope" ) )
-    return convertEnvelope( geometryData ).release();
+    return convertEnvelope( geometryData );
   // Unsupported (either by qgis, or format unspecified by the specification)
   //  esriGeometryCircularArc
   //  esriGeometryEllipticArc
@@ -544,36 +544,36 @@ QgsCoordinateReferenceSystem QgsArcGisRestUtils::convertSpatialReference( const 
   return crs;
 }
 
-QgsSymbol *QgsArcGisRestUtils::convertSymbol( const QVariantMap &symbolData )
+std::unique_ptr< QgsSymbol > QgsArcGisRestUtils::convertSymbol( const QVariantMap &symbolData )
 {
   const QString type = symbolData.value( QStringLiteral( "type" ) ).toString();
   if ( type == QLatin1String( "esriSMS" ) )
   {
     // marker symbol
-    return parseEsriMarkerSymbolJson( symbolData ).release();
+    return parseEsriMarkerSymbolJson( symbolData );
   }
   else if ( type == QLatin1String( "esriSLS" ) )
   {
     // line symbol
-    return parseEsriLineSymbolJson( symbolData ).release();
+    return parseEsriLineSymbolJson( symbolData );
   }
   else if ( type == QLatin1String( "esriSFS" ) )
   {
     // fill symbol
-    return parseEsriFillSymbolJson( symbolData ).release();
+    return parseEsriFillSymbolJson( symbolData );
   }
   else if ( type == QLatin1String( "esriPFS" ) )
   {
-    return parseEsriPictureFillSymbolJson( symbolData ).release();
+    return parseEsriPictureFillSymbolJson( symbolData );
   }
   else if ( type == QLatin1String( "esriPMS" ) )
   {
     // picture marker
-    return parseEsriPictureMarkerSymbolJson( symbolData ).release();
+    return parseEsriPictureMarkerSymbolJson( symbolData );
   }
   else if ( type == QLatin1String( "esriTS" ) )
   {
-    return parseEsriTextMarkerSymbolJson( symbolData ).release();
+    return parseEsriTextMarkerSymbolJson( symbolData );
   }
   return nullptr;
 }
@@ -834,7 +834,7 @@ std::unique_ptr<QgsMarkerSymbol> QgsArcGisRestUtils::parseEsriTextMarkerSymbolJs
   return symbol;
 }
 
-QgsAbstractVectorLayerLabeling *QgsArcGisRestUtils::convertLabeling( const QVariantList &labelingData )
+std::unique_ptr<QgsAbstractVectorLayerLabeling > QgsArcGisRestUtils::convertLabeling( const QVariantList &labelingData )
 {
   if ( labelingData.empty() )
     return nullptr;
@@ -966,10 +966,10 @@ QgsAbstractVectorLayerLabeling *QgsArcGisRestUtils::convertLabeling( const QVari
     root->appendChild( child );
   }
 
-  return new QgsRuleBasedLabeling( root );
+  return std::make_unique< QgsRuleBasedLabeling >( root );
 }
 
-QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rendererData )
+std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const QVariantMap &rendererData )
 {
   const QString type = rendererData.value( QStringLiteral( "type" ) ).toString();
   if ( type == QLatin1String( "simple" ) )
@@ -977,7 +977,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
     const QVariantMap symbolProps = rendererData.value( QStringLiteral( "symbol" ) ).toMap();
     std::unique_ptr< QgsSymbol > symbol( convertSymbol( symbolProps ) );
     if ( symbol )
-      return new QgsSingleSymbolRenderer( symbol.release() );
+      return std::make_unique< QgsSingleSymbolRenderer >( symbol.release() );
     else
       return nullptr;
   }
@@ -1027,7 +1027,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
     if ( categoryList.empty() )
       return nullptr;
 
-    return new QgsCategorizedSymbolRenderer( attribute, categoryList );
+    return std::make_unique< QgsCategorizedSymbolRenderer >( attribute, categoryList );
   }
   else if ( type == QLatin1String( "classBreaks" ) )
   {
@@ -1107,9 +1107,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
           symbol->symbolLayer( layer )->setDataDefinedProperty( QgsSymbolLayer::Property::FillColor, colorProperty );
         }
 
-        auto singleSymbolRenderer = std::make_unique< QgsSingleSymbolRenderer >( symbol.release() );
-
-        return singleSymbolRenderer.release();
+        return  std::make_unique< QgsSingleSymbolRenderer >( symbol.release() );
       }
       else
       {
@@ -1181,7 +1179,7 @@ QgsFeatureRenderer *QgsArcGisRestUtils::convertRenderer( const QVariantMap &rend
       graduatedRenderer->addClass( range );
     }
 
-    return graduatedRenderer.release();
+    return graduatedRenderer;
   }
   else if ( type == QLatin1String( "heatmap" ) )
   {

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -169,7 +169,7 @@ std::unique_ptr< QgsCircularString > QgsArcGisRestUtils::convertCircularString( 
   return curve;
 }
 
-std::unique_ptr< QgsCompoundCurve > QgsArcGisRestUtils::convertCompoundCurve( const QVariantList &curvesList, Qgis::WkbType pointType )
+std::unique_ptr< QgsCurve > QgsArcGisRestUtils::convertCompoundCurve( const QVariantList &curvesList, Qgis::WkbType pointType )
 {
   // [[6,3],[5,3],{"b":[[3,2],[6,1],[2,4]]},[1,2],{"c": [[3,3],[1,4]]}]
   auto compoundCurve = std::make_unique< QgsCompoundCurve >();
@@ -312,6 +312,81 @@ std::unique_ptr< QgsCompoundCurve > QgsArcGisRestUtils::convertCompoundCurve( co
   return compoundCurve;
 }
 
+std::unique_ptr<QgsLineString> QgsArcGisRestUtils::convertLineString( const QVariantList &curvesList, Qgis::WkbType pointType )
+{
+  auto linestring = std::make_unique< QgsLineString >();
+
+  QVector< double > lineX;
+  QVector< double > lineY;
+  QVector< double > lineZ;
+  QVector< double > lineM;
+  int maxCurveListSize = curvesList.size();
+  lineX.resize( maxCurveListSize );
+  lineY.resize( maxCurveListSize );
+
+  const bool hasZ = QgsWkbTypes::hasZ( pointType );
+  if ( hasZ )
+    lineZ.resize( maxCurveListSize );
+  const bool hasM = QgsWkbTypes::hasM( pointType );
+  if ( hasM )
+    lineM.resize( maxCurveListSize );
+
+  double *outLineX = lineX.data();
+  double *outLineY = lineY.data();
+  double *outLineZ = lineZ.data();
+  double *outLineM = lineM.data();
+
+  bool xok = false;
+  bool yok = false;
+
+  int actualLineSize = 0;
+  for ( const QVariant &curveData : curvesList )
+  {
+    if ( curveData.userType() == QMetaType::Type::QVariantList )
+    {
+      const QVariantList coordList = curveData.toList();
+      const int nCoords = coordList.size();
+      if ( nCoords < 2 )
+        return nullptr;
+
+      const double x = coordList[0].toDouble( &xok );
+      const double y = coordList[1].toDouble( &yok );
+      if ( !xok || !yok )
+        return nullptr;
+
+      actualLineSize++;
+      *outLineX++ = x;
+      *outLineY++ = y;
+      if ( hasZ )
+      {
+        *outLineZ++ = nCoords >= 3 ? coordList[2].toDouble() : std::numeric_limits< double >::quiet_NaN();
+      }
+
+      if ( hasM )
+      {
+        // if point has just M but not Z, then the point dimension list will only have X, Y, M, otherwise it will have X, Y, Z, M
+        *outLineM++ = ( ( hasZ && nCoords >= 4 ) || ( !hasZ && nCoords >= 3 ) ) ? coordList[ hasZ ? 3 : 2].toDouble() : std::numeric_limits< double >::quiet_NaN();
+      }
+    }
+    else
+    {
+      QgsDebugError( QStringLiteral( "Found unexpected value when parsing ESRI json line string. Expected list, got %1" ).arg( curveData.metaType().name() ) );
+      return nullptr;
+    }
+  }
+
+  if ( actualLineSize == 0 )
+    return nullptr;
+
+  lineX.resize( actualLineSize );
+  lineY.resize( actualLineSize );
+  if ( hasZ )
+    lineZ.resize( actualLineSize );
+  if ( hasM )
+    lineM.resize( actualLineSize );
+  return std::make_unique< QgsLineString>( lineX, lineY, lineZ, lineM );
+}
+
 std::unique_ptr< QgsPoint > QgsArcGisRestUtils::convertGeometryPoint( const QVariantMap &geometryData, Qgis::WkbType pointType )
 {
   // {"x" : <x>, "y" : <y>, "z" : <z>, "m" : <m>}
@@ -357,7 +432,7 @@ std::unique_ptr< QgsMultiPoint > QgsArcGisRestUtils::convertMultiPoint( const QV
   return multiPoint;
 }
 
-std::unique_ptr< QgsMultiCurve > QgsArcGisRestUtils::convertGeometryPolyline( const QVariantMap &geometryData, Qgis::WkbType pointType )
+std::unique_ptr< QgsMultiCurve > QgsArcGisRestUtils::convertGeometryPolyline( const QVariantMap &geometryData, Qgis::WkbType pointType, bool allowCurves )
 {
   // {"curvePaths": [[[0,0], {"c": [[3,3],[1,4]]} ]]}
   QVariantList pathsList;
@@ -367,11 +442,11 @@ std::unique_ptr< QgsMultiCurve > QgsArcGisRestUtils::convertGeometryPolyline( co
     pathsList = geometryData[QStringLiteral( "curvePaths" )].toList();
   if ( pathsList.isEmpty() )
     return nullptr;
-  auto multiCurve = std::make_unique< QgsMultiCurve >();
+  std::unique_ptr< QgsMultiCurve > multiCurve = allowCurves ? std::make_unique< QgsMultiCurve >() : std::make_unique< QgsMultiLineString >();
   multiCurve->reserve( pathsList.size() );
   for ( const QVariant &pathData : std::as_const( pathsList ) )
   {
-    std::unique_ptr< QgsCompoundCurve > curve = convertCompoundCurve( pathData.toList(), pointType );
+    std::unique_ptr< QgsCurve > curve = allowCurves ? convertCompoundCurve( pathData.toList(), pointType ) : convertLineString( pathData.toList(), pointType );
     if ( !curve )
     {
       return nullptr;
@@ -381,7 +456,7 @@ std::unique_ptr< QgsMultiCurve > QgsArcGisRestUtils::convertGeometryPolyline( co
   return multiCurve;
 }
 
-std::unique_ptr< QgsMultiSurface > QgsArcGisRestUtils::convertGeometryPolygon( const QVariantMap &geometryData, Qgis::WkbType pointType )
+std::unique_ptr< QgsMultiSurface > QgsArcGisRestUtils::convertGeometryPolygon( const QVariantMap &geometryData, Qgis::WkbType pointType, bool allowCurves )
 {
   // {"curveRings": [[[0,0], {"c": [[3,3],[1,4]]} ]]}
   QVariantList ringsList;
@@ -392,10 +467,10 @@ std::unique_ptr< QgsMultiSurface > QgsArcGisRestUtils::convertGeometryPolygon( c
   if ( ringsList.isEmpty() )
     return nullptr;
 
-  QList< QgsCompoundCurve * > curves;
+  QList< QgsCurve * > curves;
   for ( int i = 0, n = ringsList.size(); i < n; ++i )
   {
-    std::unique_ptr< QgsCompoundCurve > curve = convertCompoundCurve( ringsList[i].toList(), pointType );
+    std::unique_ptr< QgsCurve > curve = allowCurves ? convertCompoundCurve( ringsList[i].toList(), pointType ) : convertLineString( ringsList[i].toList(), pointType );
     if ( !curve )
     {
       continue;
@@ -405,30 +480,30 @@ std::unique_ptr< QgsMultiSurface > QgsArcGisRestUtils::convertGeometryPolygon( c
   if ( curves.count() == 0 )
     return nullptr;
 
-  auto result = std::make_unique< QgsMultiSurface >();
+  std::unique_ptr< QgsMultiSurface > result = allowCurves ? std::make_unique< QgsMultiSurface >() : std::make_unique< QgsMultiPolygon >();
   if ( curves.count() == 1 )
   {
     // shortcut for exterior ring only
-    auto newPolygon = std::make_unique< QgsCurvePolygon >();
+    std::unique_ptr< QgsCurvePolygon > newPolygon = allowCurves ? std::make_unique< QgsCurvePolygon >() : std::make_unique< QgsPolygon >();
     newPolygon->setExteriorRing( curves.takeAt( 0 ) );
     result->addGeometry( newPolygon.release() );
     return result;
   }
 
-  std::sort( curves.begin(), curves.end(), []( const QgsCompoundCurve * a, const QgsCompoundCurve * b )->bool{ double a_area = 0.0; double b_area = 0.0; a->sumUpArea( a_area ); b->sumUpArea( b_area ); return std::abs( a_area ) > std::abs( b_area ); } );
+  std::sort( curves.begin(), curves.end(), []( const QgsCurve * a, const QgsCurve * b )->bool{ double a_area = 0.0; double b_area = 0.0; a->sumUpArea( a_area ); b->sumUpArea( b_area ); return std::abs( a_area ) > std::abs( b_area ); } );
   result->reserve( curves.size() );
   while ( !curves.isEmpty() )
   {
-    QgsCompoundCurve *exterior = curves.takeFirst();
-    QgsCurvePolygon *newPolygon = new QgsCurvePolygon();
+    QgsCurve *exterior = curves.takeFirst();
+    QgsCurvePolygon *newPolygon = allowCurves ? new QgsCurvePolygon() : new QgsPolygon();
     newPolygon->setExteriorRing( exterior );
     std::unique_ptr<QgsGeometryEngine> engine( QgsGeometry::createGeometryEngine( newPolygon ) );
     engine->prepareGeometry();
 
-    QMutableListIterator< QgsCompoundCurve * > it( curves );
+    QMutableListIterator< QgsCurve * > it( curves );
     while ( it.hasNext() )
     {
-      QgsCompoundCurve *curve = it.next();
+      QgsCurve *curve = it.next();
       QgsRectangle boundingBox = newPolygon->boundingBox();
       if ( boundingBox.intersects( curve->boundingBox() ) )
       {
@@ -471,7 +546,7 @@ std::unique_ptr< QgsPolygon > QgsArcGisRestUtils::convertEnvelope( const QVarian
   return poly;
 }
 
-std::unique_ptr< QgsAbstractGeometry > QgsArcGisRestUtils::convertGeometry( const QVariantMap &geometryData, const QString &esriGeometryType, bool readM, bool readZ, QgsCoordinateReferenceSystem *crs )
+std::unique_ptr< QgsAbstractGeometry > QgsArcGisRestUtils::convertGeometry( const QVariantMap &geometryData, const QString &esriGeometryType, bool readM, bool readZ, bool allowCurves, QgsCoordinateReferenceSystem *crs )
 {
   Qgis::WkbType pointType = QgsWkbTypes::zmType( Qgis::WkbType::Point, readZ, readM );
   if ( crs )
@@ -487,9 +562,9 @@ std::unique_ptr< QgsAbstractGeometry > QgsArcGisRestUtils::convertGeometry( cons
   else if ( esriGeometryType == QLatin1String( "esriGeometryMultipoint" ) )
     return convertMultiPoint( geometryData, pointType );
   else if ( esriGeometryType == QLatin1String( "esriGeometryPolyline" ) )
-    return convertGeometryPolyline( geometryData, pointType );
+    return convertGeometryPolyline( geometryData, pointType, allowCurves );
   else if ( esriGeometryType == QLatin1String( "esriGeometryPolygon" ) )
-    return convertGeometryPolygon( geometryData, pointType );
+    return convertGeometryPolygon( geometryData, pointType, allowCurves );
   else if ( esriGeometryType == QLatin1String( "esriGeometryEnvelope" ) )
     return convertEnvelope( geometryData );
   // Unsupported (either by qgis, or format unspecified by the specification)

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -370,7 +370,7 @@ std::unique_ptr<QgsLineString> QgsArcGisRestUtils::convertLineString( const QVar
     }
     else
     {
-      QgsDebugError( QStringLiteral( "Found unexpected value when parsing ESRI json line string. Expected list, got %1" ).arg( curveData.metaType().name() ) );
+      QgsDebugError( QStringLiteral( "Found unexpected value when parsing ESRI json line string. Expected list, got %1" ).arg( QMetaType::typeName( curveData.userType() ) ) );
       return nullptr;
     }
   }

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -140,7 +140,7 @@ class CORE_EXPORT QgsArcGisRestUtils
      *
      * \returns converted geometry
      */
-    static QgsAbstractGeometry *convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs SIP_OUT = nullptr ) SIP_FACTORY;
+    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs SIP_OUT = nullptr );
 
     /**
      * Converts a spatial reference JSON definition to a QgsCoordinateReferenceSystem value.
@@ -152,21 +152,21 @@ class CORE_EXPORT QgsArcGisRestUtils
      *
      * Caller takes ownership of the returned symbol.
      */
-    static QgsSymbol *convertSymbol( const QVariantMap &definition ) SIP_FACTORY;
+    static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition );
 
     /**
      * Converts renderer JSON \a data to an equivalent QgsFeatureRenderer.
      *
      * Caller takes ownership of the returned renderer.
      */
-    static QgsFeatureRenderer *convertRenderer( const QVariantMap &rendererData ) SIP_FACTORY;
+    static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData );
 
     /**
      * Converts labeling JSON \a data to an equivalent QGIS vector labeling.
      *
      * Caller takes ownership of the returned object.
      */
-    static QgsAbstractVectorLayerLabeling *convertLabeling( const QVariantList &data ) SIP_FACTORY;
+    static std::unique_ptr< QgsAbstractVectorLayerLabeling > convertLabeling( const QVariantList &data );
 
     /**
      * Converts an ESRI labeling expression to a QGIS expression string.

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -136,11 +136,12 @@ class CORE_EXPORT QgsArcGisRestUtils
      * \param esriGeometryType ESRI geometry type string
      * \param hasM set to TRUE to if geometry includes M values
      * \param hasZ set to TRUE to if geometry includes Z values
+     * \param allowCurves controls whether the returned geometry can be a curved geometry type (since QGIS 4.0)
      * \param crs if specified will be set to the parsed geometry CRS
      *
      * \returns converted geometry
      */
-    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, QgsCoordinateReferenceSystem *crs SIP_OUT = nullptr );
+    static std::unique_ptr< QgsAbstractGeometry > convertGeometry( const QVariantMap &geometry, const QString &esriGeometryType, bool hasM, bool hasZ, bool allowCurves = true, QgsCoordinateReferenceSystem *crs SIP_OUT = nullptr );
 
     /**
      * Converts a spatial reference JSON definition to a QgsCoordinateReferenceSystem value.
@@ -289,7 +290,12 @@ class CORE_EXPORT QgsArcGisRestUtils
     /**
      * Converts a compound curve JSON \a list to a geometry object of the specified \a type.
      */
-    static std::unique_ptr< QgsCompoundCurve > convertCompoundCurve( const QVariantList &list, Qgis::WkbType type );
+    static std::unique_ptr< QgsCurve > convertCompoundCurve( const QVariantList &list, Qgis::WkbType type );
+
+    /**
+     * Converts a line string JSON \a list to a geometry object of the specified \a type.
+     */
+    static std::unique_ptr< QgsLineString > convertLineString( const QVariantList &list, Qgis::WkbType type );
 
     /**
      * Converts point \a data to a point object of the specified \a type.
@@ -303,13 +309,17 @@ class CORE_EXPORT QgsArcGisRestUtils
 
     /**
      * Converts polyline \a data to a curve object of the specified \a type.
+     *
+     *The \a allowCurves argument controls whether the returned geometry can be a curved geometry type.
      */
-    static std::unique_ptr< QgsMultiCurve > convertGeometryPolyline( const QVariantMap &data, Qgis::WkbType pointType );
+    static std::unique_ptr< QgsMultiCurve > convertGeometryPolyline( const QVariantMap &data, Qgis::WkbType pointType, bool allowCurves );
 
     /**
      * Converts polygon \a data to a polygon object of the specified \a type.
+     *
+     * The \a allowCurves argument controls whether the returned geometry can be a curved geometry type.
      */
-    static std::unique_ptr< QgsMultiSurface > convertGeometryPolygon( const QVariantMap &data, Qgis::WkbType pointType );
+    static std::unique_ptr< QgsMultiSurface > convertGeometryPolygon( const QVariantMap &data, Qgis::WkbType pointType, bool allowCurves );
 
     /**
      * Converts envelope \a data to a polygon object.

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -25,10 +25,12 @@
 #include "qgslogger.h"
 #include "qgsdataitemprovider.h"
 #include "qgsapplication.h"
+#include "qgsrenderer.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsfeedback.h"
 #include "qgsreadwritelocker.h"
 #include "qgsvariantutils.h"
+#include "qgsvectorlayerlabeling.h"
 
 
 QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &options, Qgis::DataProviderReadFlags flags )
@@ -753,12 +755,12 @@ void QgsAfsProvider::reloadProviderData()
 
 QgsFeatureRenderer *QgsAfsProvider::createRenderer( const QVariantMap & ) const
 {
-  return QgsArcGisRestUtils::convertRenderer( mRendererDataMap );
+  return QgsArcGisRestUtils::convertRenderer( mRendererDataMap ).release();
 }
 
 QgsAbstractVectorLayerLabeling *QgsAfsProvider::createLabeling( const QVariantMap & ) const
 {
-  return QgsArcGisRestUtils::convertLabeling( mLabelingDataList );
+  return QgsArcGisRestUtils::convertLabeling( mLabelingDataList ).release();
 }
 
 bool QgsAfsProvider::renderInPreview( const QgsDataProvider::PreviewContext & )

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -87,8 +87,9 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
     }
   }
 
-  mServerSupportsCurves = layerData.value( QStringLiteral( "allowTrueCurvesUpdates" ), false ).toBool();
+  mServerSupportsCurvedUpdates = layerData.value( QStringLiteral( "allowTrueCurvesUpdates" ), false ).toBool();
 
+  const bool useCurvedTypes = mServerSupportsCurvedUpdates || !mCapabilityStrings.contains( QLatin1String( "update" ), Qt::CaseInsensitive );
   if ( !isTable )
   {
     // Set extent
@@ -230,6 +231,11 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
     const bool hasM = layerData[QStringLiteral( "hasM" )].toBool();
     const bool hasZ = layerData[QStringLiteral( "hasZ" )].toBool();
     mSharedData->mGeometryType = QgsArcGisRestUtils::convertGeometryType( layerData[QStringLiteral( "geometryType" )].toString() );
+    if ( useCurvedTypes )
+      mSharedData->mGeometryType = QgsWkbTypes::curveType( mSharedData->mGeometryType );
+    else
+      mSharedData->mGeometryType = QgsWkbTypes::linearType( mSharedData->mGeometryType );
+
     if ( mSharedData->mGeometryType == Qgis::WkbType::Unknown )
     {
       if ( layerData.value( QStringLiteral( "serviceDataType" ) ).toString().startsWith( QLatin1String( "esriImageService" ) ) )
@@ -614,7 +620,7 @@ Qgis::VectorProviderCapabilities QgsAfsProvider::capabilities() const
     c = c | Qgis::VectorProviderCapability::CreateLabeling;
   }
 
-  if ( mServerSupportsCurves )
+  if ( mServerSupportsCurvedUpdates )
     c |= Qgis::VectorProviderCapability::CircularGeometries;
 
   if ( mCapabilityStrings.contains( QLatin1String( "delete" ), Qt::CaseInsensitive ) )

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -101,7 +101,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QVariantMap mRendererDataMap;
     QVariantList mLabelingDataList;
     QgsHttpHeaders mRequestHeaders;
-    bool mServerSupportsCurves = false;
+    bool mServerSupportsCurvedUpdates = false;
     QString mAdminUrl;
     QVariantMap mAdminData;
     QStringList mAdminCapabilityStrings;

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -279,7 +279,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
 
     // Set geometry
     const QVariantMap geometryData = featureData[QStringLiteral( "geometry" )].toMap();
-    std::unique_ptr<QgsAbstractGeometry> geometry( QgsArcGisRestUtils::convertGeometry( geometryData, queryData[QStringLiteral( "geometryType" )].toString(), QgsWkbTypes::hasM( mGeometryType ), QgsWkbTypes::hasZ( mGeometryType ) ) );
+    std::unique_ptr<QgsAbstractGeometry> geometry( QgsArcGisRestUtils::convertGeometry( geometryData, queryData[QStringLiteral( "geometryType" )].toString(), QgsWkbTypes::hasM( mGeometryType ), QgsWkbTypes::hasZ( mGeometryType ), QgsWkbTypes::isCurvedType( mGeometryType ) ) );
     // Above might return 0, which is OK since in theory empty geometries are allowed
     if ( geometry )
       feature.setGeometry( QgsGeometry( std::move( geometry ) ) );

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -905,7 +905,7 @@ QgsRasterIdentifyResult QgsAmsProvider::identify( const QgsPointXY &point, Qgis:
         featureAttributes.append( it.value().toString() );
       }
       QgsCoordinateReferenceSystem crs;
-      std::unique_ptr<QgsAbstractGeometry> geometry( QgsArcGisRestUtils::convertGeometry( resultMap[QStringLiteral( "geometry" )].toMap(), resultMap[QStringLiteral( "geometryType" )].toString(), false, false, &crs ) );
+      std::unique_ptr<QgsAbstractGeometry> geometry( QgsArcGisRestUtils::convertGeometry( resultMap[QStringLiteral( "geometry" )].toMap(), resultMap[QStringLiteral( "geometryType" )].toString(), false, false, true, &crs ) );
       QgsFeature feature( fields );
       feature.setGeometry( QgsGeometry( std::move( geometry ) ) );
       feature.setAttributes( featureAttributes );

--- a/tests/src/core/testqgsarcgisrestutils.cpp
+++ b/tests/src/core/testqgsarcgisrestutils.cpp
@@ -166,9 +166,14 @@ void TestQgsArcGisRestUtils::testParseEsriGeometryPolygon()
                                      "]"
                                      "}" );
   QCOMPARE( map[QStringLiteral( "rings" )].isValid(), true );
-  std::unique_ptr<QgsMultiSurface> geometry = QgsArcGisRestUtils::convertGeometryPolygon( map, Qgis::WkbType::Point );
+  std::unique_ptr<QgsMultiSurface> geometry = QgsArcGisRestUtils::convertGeometryPolygon( map, Qgis::WkbType::Point, true );
   QVERIFY( geometry.get() );
   QCOMPARE( geometry->asWkt(), QStringLiteral( "MultiSurface (CurvePolygon (CompoundCurve ((0 0, 10 0, 10 10, 0 10, 0 0)),CompoundCurve ((3 3, 9 3, 6 9, 3 3))),CurvePolygon (CompoundCurve ((12 0, 13 0, 13 10, 12 10, 12 0))))" ) );
+
+  // force straight geometry type
+  geometry = QgsArcGisRestUtils::convertGeometryPolygon( map, Qgis::WkbType::Point, false );
+  QVERIFY( geometry.get() );
+  QCOMPARE( geometry->asWkt(), QStringLiteral( "MultiPolygon (((0 0, 10 0, 10 10, 0 10, 0 0),(3 3, 9 3, 6 9, 3 3)),((12 0, 13 0, 13 10, 12 10, 12 0)))" ) );
 }
 
 void TestQgsArcGisRestUtils::testParseEsriFillStyle()
@@ -704,7 +709,7 @@ QVariantMap TestQgsArcGisRestUtils::jsonStringToMap( const QString &string ) con
 void TestQgsArcGisRestUtils::testParseCompoundCurve()
 {
   const QVariantMap map = jsonStringToMap( "{\"curvePaths\": [[[6,3],[5,3],{\"c\": [[3,3],[1,4]]}]]}" );
-  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::Point ) );
+  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::Point, true ) );
   QVERIFY( curve );
   QCOMPARE( curve->asWkt(), QStringLiteral( "MultiCurve (CompoundCurve ((6 3, 5 3),CircularString (5 3, 1 4, 3 3)))" ) );
 }
@@ -712,33 +717,53 @@ void TestQgsArcGisRestUtils::testParseCompoundCurve()
 void TestQgsArcGisRestUtils::testParsePolyline()
 {
   const QVariantMap map = jsonStringToMap( "{\"paths\": [[[6,3],[5,3]]]}" );
-  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::Point ) );
+  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::Point, true ) );
   QVERIFY( curve );
   QCOMPARE( curve->asWkt(), QStringLiteral( "MultiCurve (CompoundCurve ((6 3, 5 3)))" ) );
+
+  // force straight geometry type
+  curve = QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::Point, false );
+  QVERIFY( curve );
+  QCOMPARE( curve->asWkt(), QStringLiteral( "MultiLineString ((6 3, 5 3))" ) );
 }
 
 void TestQgsArcGisRestUtils::testParsePolylineZ()
 {
   const QVariantMap map = jsonStringToMap( "{\"paths\": [[[6,3,1],[5,3,2]]]}" );
-  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZ ) );
+  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZ, true ) );
   QVERIFY( curve );
   QCOMPARE( curve->asWkt(), QStringLiteral( "MultiCurve Z (CompoundCurve Z ((6 3 1, 5 3 2)))" ) );
+
+  // force straight geometry type
+  curve = QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZ, false );
+  QVERIFY( curve );
+  QCOMPARE( curve->asWkt(), QStringLiteral( "MultiLineString Z ((6 3 1, 5 3 2))" ) );
 }
 
 void TestQgsArcGisRestUtils::testParsePolylineM()
 {
   const QVariantMap map = jsonStringToMap( "{\"paths\": [[[6,3,1],[5,3,2]]]}" );
-  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointM ) );
+  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointM, true ) );
   QVERIFY( curve );
   QCOMPARE( curve->asWkt(), QStringLiteral( "MultiCurve M (CompoundCurve M ((6 3 1, 5 3 2)))" ) );
+
+  // force straight geometry type
+  curve = QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointM, false );
+  QVERIFY( curve );
+  QCOMPARE( curve->asWkt(), QStringLiteral( "MultiLineString M ((6 3 1, 5 3 2))" ) );
 }
 
 void TestQgsArcGisRestUtils::testParsePolylineZM()
 {
   const QVariantMap map = jsonStringToMap( "{\"paths\": [[[6,3,1,11],[5,3,2,12]]]}" );
-  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZM ) );
+  std::unique_ptr<QgsMultiCurve> curve( QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZM, true ) );
   QVERIFY( curve );
   QCOMPARE( curve->asWkt(), QStringLiteral( "MultiCurve ZM (CompoundCurve ZM ((6 3 1 11, 5 3 2 12)))" ) );
+
+  // force straight geometry type
+  curve = QgsArcGisRestUtils::convertGeometryPolyline( map, Qgis::WkbType::PointZM, false );
+  QVERIFY( curve );
+  QCOMPARE( curve->asWkt(), QStringLiteral( "MultiLineString ZM ((6 3 1 11, 5 3 2 12))" ) );
 }
 
 QGSTEST_MAIN( TestQgsArcGisRestUtils )

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -1030,6 +1030,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
                 | QgsVectorDataProvider.Capability.AddFeatures
             ),
         )
+        self.assertEqual(vl.wkbType(), Qgis.WkbType.Point)
         # update capability
         endpoint = self.basetestpath + "/delete_fake_qgis_http_endpoint"
         with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
@@ -1074,7 +1075,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
             f.write(
                 b"""
                     {"currentVersion":10.22,"id":1,"name":"QGIS Test","allowTrueCurvesUpdates":true,"type":"Feature Layer","description":
-                    "QGIS Provider Test Layer","geometryType":"esriGeometryPoint","copyrightText":"not copyright","parentLayer":{"id":2,"name":"QGIS Tests"},"subLayers":[],
+                    "QGIS Provider Test Layer","geometryType":"esriGeometryPolyline","copyrightText":"not copyright","parentLayer":{"id":2,"name":"QGIS Tests"},"subLayers":[],
                     "minScale":72225,"maxScale":0,
                     "defaultVisibility":true,
                     "extent":{"xmin":-71.123,"ymin":66.33,"xmax":-65.32,"ymax":78.3,
@@ -1093,6 +1094,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
             "arcgisfeatureserver",
         )
         self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), Qgis.WkbType.MultiCurve)
         self.assertEqual(
             vl.dataProvider().capabilities(),
             QgsVectorDataProvider.Capabilities(
@@ -1102,6 +1104,43 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
                 | QgsVectorDataProvider.Capability.ChangeAttributeValues
                 | QgsVectorDataProvider.Capability.ChangeFeatures
                 | QgsVectorDataProvider.Capability.CircularGeometries
+                | QgsVectorDataProvider.Capability.ChangeGeometries
+            ),
+        )
+
+        # polyline type, updates allowed, no curve support
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""
+                    {"currentVersion":10.22,"id":1,"name":"QGIS Test","allowTrueCurvesUpdates":false,"type":"Feature Layer","description":
+                    "QGIS Provider Test Layer","geometryType":"esriGeometryPolyline","copyrightText":"not copyright","parentLayer":{"id":2,"name":"QGIS Tests"},"subLayers":[],
+                    "minScale":72225,"maxScale":0,
+                    "defaultVisibility":true,
+                    "extent":{"xmin":-71.123,"ymin":66.33,"xmax":-65.32,"ymax":78.3,
+                    "spatialReference":{"wkid":4326,"latestWkid":4326}},
+                    "hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText",
+                    "displayField":"LABEL","typeIdField":null,
+                    "fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null}],
+                    "relationships":[],"canModifyLayer":false,"canScaleSymbols":false,"hasLabels":false,
+                    "capabilities":"Map,Query,Data,Update","maxRecordCount":1000,"supportsStatistics":true,
+                    "supportsAdvancedQueries":true,"supportedQueryFormats":"JSON, AMF",
+                    "ownershipBasedAccessControlForFeatures":{"allowOthersToQuery":true},"useStandardizedQueries":true}"""
+            )
+        vl = QgsVectorLayer(
+            "url='http://" + endpoint + "' crs='epsg:4326'",
+            "test",
+            "arcgisfeatureserver",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), Qgis.WkbType.MultiLineString)
+        self.assertEqual(
+            vl.dataProvider().capabilities(),
+            QgsVectorDataProvider.Capabilities(
+                QgsVectorDataProvider.Capability.SelectAtId
+                | QgsVectorDataProvider.Capability.ReadLayerMetadata
+                | QgsVectorDataProvider.Capability.ReloadData
+                | QgsVectorDataProvider.Capability.ChangeAttributeValues
+                | QgsVectorDataProvider.Capability.ChangeFeatures
                 | QgsVectorDataProvider.Capability.ChangeGeometries
             ),
         )
@@ -1270,6 +1309,385 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
 
         f = vl.getFeature(0)
         self.assertTrue(f.isValid())
+
+    def testLineStringNoCurvedSupport(self):
+        """Test linestring features when service doesn't support curves"""
+
+        endpoint = self.basetestpath + "/ls_no_curve_fake_qgis_http_endpoint"
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""
+        {"currentVersion":10.22,"id":1,"name":"QGIS Test","type":"Feature Layer","description":
+        "QGIS Provider Test Layer.\n","geometryType":"esriGeometryPolyline","copyrightText":"","parentLayer":{"id":0,"name":"QGIS Tests"},"subLayers":[],
+        "minScale":72225,"maxScale":0,
+        "defaultVisibility":true,
+        "extent":{"xmin":-71.123,"ymin":66.33,"xmax":-65.32,"ymax":78.3,
+        "spatialReference":{"wkid":4326,"latestWkid":4326}},
+        "hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText",
+        "displayField":"LABEL","typeIdField":null,
+        "fields":[{"name":"OBJECTID1","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},
+        {"name":"pk","type":"esriFieldTypeInteger","alias":"pk","domain":null},
+        {"name":"cnt","type":"esriFieldTypeInteger","alias":"cnt","domain":null}],
+        "relationships":[],"canModifyLayer":false,"canScaleSymbols":false,"hasLabels":false,
+        "capabilities":"Map,Query,Data,Update","maxRecordCount":1000,"supportsStatistics":true,
+        "supportsAdvancedQueries":true,"supportedQueryFormats":"JSON, AMF",
+        "ownershipBasedAccessControlForFeatures":{"allowOthersToQuery":true},"useStandardizedQueries":true}"""
+            )
+
+        with open(
+            self.sanitize_local_url(
+                endpoint, "/query?f=json_where=1=1&returnIdsOnly=true"
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+        {
+         "objectIdFieldName": "OBJECTID1",
+         "objectIds": [
+          5
+         ]
+        }
+        """
+            )
+
+        with open(
+            self.sanitize_local_url(
+                endpoint,
+                "/query?f=json&objectIds=5&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+        {
+         "displayFieldName": "LABEL",
+         "geometryType": "esriGeometryPolyline",
+         "spatialReference": {
+          "wkid": 4326,
+          "latestWkid": 4326
+         },
+         "fields":[{"name":"OBJECTID1","type":"esriFieldTypeOID","alias":"OBJECTID1","domain":null},
+          {"name":"pk","type":"esriFieldTypeInteger","alias":"pk","domain":null},
+          {"name":"cnt","type":"esriFieldTypeInteger","alias":"cnt","domain":null},
+          {"name":"Shape","type":"esriFieldTypeGeometry","alias":"Shape","domain":null}],
+         "features": [
+          {
+           "attributes": {
+            "OBJECTID1": 5,
+            "pk": 5,
+            "cnt": -200,
+            "name": null
+           },
+           "geometry": {
+           "paths": [[[-71.123,78.23],[-70.123, 75.23]]]
+           }
+          }
+         ]
+        }"""
+            )
+
+        # Create test layer
+        vl = QgsVectorLayer(
+            "url='http://" + endpoint + "' crs='epsg:4326'",
+            "test",
+            "arcgisfeatureserver",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), Qgis.WkbType.MultiLineString)
+
+        f = vl.getFeature(0)
+        self.assertTrue(f.isValid())
+        self.assertEqual(
+            f.geometry().asWkt(3), "MultiLineString ((-71.123 78.23, -70.123 75.23))"
+        )
+
+    def testLineStringCurvedSupport(self):
+        """Test linestring features when service DOES support curves"""
+
+        endpoint = self.basetestpath + "/ls_curve_fake_qgis_http_endpoint"
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""
+        {"currentVersion":10.22,"id":1,"name":"QGIS Test","allowTrueCurvesUpdates":true,"type":"Feature Layer","description":
+        "QGIS Provider Test Layer.\n","geometryType":"esriGeometryPolyline","copyrightText":"","parentLayer":{"id":0,"name":"QGIS Tests"},"subLayers":[],
+        "minScale":72225,"maxScale":0,
+        "defaultVisibility":true,
+        "extent":{"xmin":-71.123,"ymin":66.33,"xmax":-65.32,"ymax":78.3,
+        "spatialReference":{"wkid":4326,"latestWkid":4326}},
+        "hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText",
+        "displayField":"LABEL","typeIdField":null,
+        "fields":[{"name":"OBJECTID1","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},
+        {"name":"pk","type":"esriFieldTypeInteger","alias":"pk","domain":null},
+        {"name":"cnt","type":"esriFieldTypeInteger","alias":"cnt","domain":null}],
+        "relationships":[],"canModifyLayer":false,"canScaleSymbols":false,"hasLabels":false,
+        "capabilities":"Map,Query,Data,Update","maxRecordCount":1000,"supportsStatistics":true,
+        "supportsAdvancedQueries":true,"supportedQueryFormats":"JSON, AMF",
+        "ownershipBasedAccessControlForFeatures":{"allowOthersToQuery":true},"useStandardizedQueries":true}"""
+            )
+
+        with open(
+            self.sanitize_local_url(
+                endpoint, "/query?f=json_where=1=1&returnIdsOnly=true"
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+        {
+         "objectIdFieldName": "OBJECTID1",
+         "objectIds": [
+          5
+         ]
+        }
+        """
+            )
+
+        with open(
+            self.sanitize_local_url(
+                endpoint,
+                "/query?f=json&objectIds=5&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+        {
+         "displayFieldName": "LABEL",
+         "geometryType": "esriGeometryPolyline",
+         "spatialReference": {
+          "wkid": 4326,
+          "latestWkid": 4326
+         },
+         "fields":[{"name":"OBJECTID1","type":"esriFieldTypeOID","alias":"OBJECTID1","domain":null},
+          {"name":"pk","type":"esriFieldTypeInteger","alias":"pk","domain":null},
+          {"name":"cnt","type":"esriFieldTypeInteger","alias":"cnt","domain":null},
+          {"name":"Shape","type":"esriFieldTypeGeometry","alias":"Shape","domain":null}],
+         "features": [
+          {
+           "attributes": {
+            "OBJECTID1": 5,
+            "pk": 5,
+            "cnt": -200,
+            "name": null
+           },
+           "geometry": {
+           "paths": [[[-71.123,78.23],[-70.123, 75.23]]]
+           }
+          }
+         ]
+        }"""
+            )
+
+        # Create test layer
+        vl = QgsVectorLayer(
+            "url='http://" + endpoint + "' crs='epsg:4326'",
+            "test",
+            "arcgisfeatureserver",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), Qgis.WkbType.MultiCurve)
+
+        f = vl.getFeature(0)
+        self.assertTrue(f.isValid())
+        self.assertEqual(
+            f.geometry().asWkt(3),
+            "MultiCurve (CompoundCurve ((-71.123 78.23, -70.123 75.23)))",
+        )
+
+    def testLPolygonNoCurvedSupport(self):
+        """Test polygon features when service doesn't support curves"""
+
+        endpoint = self.basetestpath + "/poly_no_curve_fake_qgis_http_endpoint"
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""
+        {"currentVersion":10.22,"id":1,"name":"QGIS Test","type":"Feature Layer","description":
+        "QGIS Provider Test Layer.\n","geometryType":"esriGeometryPolygon","copyrightText":"","parentLayer":{"id":0,"name":"QGIS Tests"},"subLayers":[],
+        "minScale":72225,"maxScale":0,
+        "defaultVisibility":true,
+        "extent":{"xmin":-71.123,"ymin":66.33,"xmax":-65.32,"ymax":78.3,
+        "spatialReference":{"wkid":4326,"latestWkid":4326}},
+        "hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText",
+        "displayField":"LABEL","typeIdField":null,
+        "fields":[{"name":"OBJECTID1","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},
+        {"name":"pk","type":"esriFieldTypeInteger","alias":"pk","domain":null},
+        {"name":"cnt","type":"esriFieldTypeInteger","alias":"cnt","domain":null}],
+        "relationships":[],"canModifyLayer":false,"canScaleSymbols":false,"hasLabels":false,
+        "capabilities":"Map,Query,Data,Update","maxRecordCount":1000,"supportsStatistics":true,
+        "supportsAdvancedQueries":true,"supportedQueryFormats":"JSON, AMF",
+        "ownershipBasedAccessControlForFeatures":{"allowOthersToQuery":true},"useStandardizedQueries":true}"""
+            )
+
+        with open(
+            self.sanitize_local_url(
+                endpoint, "/query?f=json_where=1=1&returnIdsOnly=true"
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+        {
+         "objectIdFieldName": "OBJECTID1",
+         "objectIds": [
+          5
+         ]
+        }
+        """
+            )
+
+        with open(
+            self.sanitize_local_url(
+                endpoint,
+                "/query?f=json&objectIds=5&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+        {
+         "displayFieldName": "LABEL",
+         "geometryType": "esriGeometryPolygon",
+         "spatialReference": {
+          "wkid": 4326,
+          "latestWkid": 4326
+         },
+         "fields":[{"name":"OBJECTID1","type":"esriFieldTypeOID","alias":"OBJECTID1","domain":null},
+          {"name":"pk","type":"esriFieldTypeInteger","alias":"pk","domain":null},
+          {"name":"cnt","type":"esriFieldTypeInteger","alias":"cnt","domain":null},
+          {"name":"Shape","type":"esriFieldTypeGeometry","alias":"Shape","domain":null}],
+         "features": [
+          {
+           "attributes": {
+            "OBJECTID1": 5,
+            "pk": 5,
+            "cnt": -200,
+            "name": null
+           },
+           "geometry": {
+           "rings": [
+                                     [[12,0],[13,0],[13,10],[12,10],[12,0]],
+                                     [[3,3],[9,3],[6,9],[3,3]],
+                                     [[0,0],[10,0],[10,10],[0,10],[0,0]]
+                                     ]
+           }
+          }
+         ]
+        }"""
+            )
+
+        # Create test layer
+        vl = QgsVectorLayer(
+            "url='http://" + endpoint + "' crs='epsg:4326'",
+            "test",
+            "arcgisfeatureserver",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), Qgis.WkbType.MultiPolygon)
+
+        f = vl.getFeature(0)
+        self.assertTrue(f.isValid())
+        self.assertEqual(
+            f.geometry().asWkt(3),
+            "MultiPolygon (((0 0, 10 0, 10 10, 0 10, 0 0),(3 3, 9 3, 6 9, 3 3)),((12 0, 13 0, 13 10, 12 10, 12 0)))",
+        )
+
+    def testLPolygonCurvedSupport(self):
+        """Test polygon features when service DOES support curves"""
+
+        endpoint = self.basetestpath + "/poly_curve_fake_qgis_http_endpoint"
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""
+        {"currentVersion":10.22,"id":1,"name":"QGIS Test","allowTrueCurvesUpdates":true,"type":"Feature Layer","description":
+        "QGIS Provider Test Layer.\n","geometryType":"esriGeometryPolygon","copyrightText":"","parentLayer":{"id":0,"name":"QGIS Tests"},"subLayers":[],
+        "minScale":72225,"maxScale":0,
+        "defaultVisibility":true,
+        "extent":{"xmin":-71.123,"ymin":66.33,"xmax":-65.32,"ymax":78.3,
+        "spatialReference":{"wkid":4326,"latestWkid":4326}},
+        "hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText",
+        "displayField":"LABEL","typeIdField":null,
+        "fields":[{"name":"OBJECTID1","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},
+        {"name":"pk","type":"esriFieldTypeInteger","alias":"pk","domain":null},
+        {"name":"cnt","type":"esriFieldTypeInteger","alias":"cnt","domain":null}],
+        "relationships":[],"canModifyLayer":false,"canScaleSymbols":false,"hasLabels":false,
+        "capabilities":"Map,Query,Data,Update","maxRecordCount":1000,"supportsStatistics":true,
+        "supportsAdvancedQueries":true,"supportedQueryFormats":"JSON, AMF",
+        "ownershipBasedAccessControlForFeatures":{"allowOthersToQuery":true},"useStandardizedQueries":true}"""
+            )
+
+        with open(
+            self.sanitize_local_url(
+                endpoint, "/query?f=json_where=1=1&returnIdsOnly=true"
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+        {
+         "objectIdFieldName": "OBJECTID1",
+         "objectIds": [
+          5
+         ]
+        }
+        """
+            )
+
+        with open(
+            self.sanitize_local_url(
+                endpoint,
+                "/query?f=json&objectIds=5&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
+            ),
+            "wb",
+        ) as f:
+            f.write(
+                b"""
+        {
+         "displayFieldName": "LABEL",
+         "geometryType": "esriGeometryPolygon",
+         "spatialReference": {
+          "wkid": 4326,
+          "latestWkid": 4326
+         },
+         "fields":[{"name":"OBJECTID1","type":"esriFieldTypeOID","alias":"OBJECTID1","domain":null},
+          {"name":"pk","type":"esriFieldTypeInteger","alias":"pk","domain":null},
+          {"name":"cnt","type":"esriFieldTypeInteger","alias":"cnt","domain":null},
+          {"name":"Shape","type":"esriFieldTypeGeometry","alias":"Shape","domain":null}],
+         "features": [
+          {
+           "attributes": {
+            "OBJECTID1": 5,
+            "pk": 5,
+            "cnt": -200,
+            "name": null
+           },
+           "geometry": {
+           "rings": [
+                                     [[12,0],[13,0],[13,10],[12,10],[12,0]],
+                                     [[3,3],[9,3],[6,9],[3,3]],
+                                     [[0,0],[10,0],[10,10],[0,10],[0,0]]
+                                     ]
+           }
+          }
+         ]
+        }"""
+            )
+
+        # Create test layer
+        vl = QgsVectorLayer(
+            "url='http://" + endpoint + "' crs='epsg:4326'",
+            "test",
+            "arcgisfeatureserver",
+        )
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.wkbType(), Qgis.WkbType.MultiSurface)
+
+        f = vl.getFeature(0)
+        self.assertTrue(f.isValid())
+        self.assertEqual(
+            f.geometry().asWkt(3),
+            "MultiSurface (CurvePolygon (CompoundCurve ((0 0, 10 0, 10 10, 0 10, 0 0)),CompoundCurve ((3 3, 9 3, 6 9, 3 3))),CurvePolygon (CompoundCurve ((12 0, 13 0, 13 10, 12 10, 12 0))))",
+        )
 
     def testNoCrs(self):
         """Test retrieval of features in their original service CRS"""


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/65094