### PR TITLE
Remove redundant default ports from http/https requests 

### DIFF
--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -306,26 +306,27 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
 {
   const QgsSettings s;
 
-  QNetworkRequest *pReq( const_cast< QNetworkRequest * >( &req ) ); // hack user agent
+  // copy request so we can modify it
+  QNetworkRequest modifiedRequest( req );
 
   QString userAgent = s.value( u"/qgis/networkAndProxy/userAgent"_s, "Mozilla/5.0" ).toString();
   if ( !userAgent.isEmpty() )
     userAgent += ' ';
   userAgent += u"QGIS/%1/%2"_s.arg( Qgis::versionInt() ).arg( QSysInfo::prettyProductName() );
-  pReq->setRawHeader( "User-Agent", userAgent.toLatin1() );
+  modifiedRequest.setRawHeader( "User-Agent", userAgent.toLatin1() );
 
 #ifndef QT_NO_SSL
-  const bool ishttps = pReq->url().scheme().compare( "https"_L1, Qt::CaseInsensitive ) == 0;
+  const bool ishttps = modifiedRequest.url().scheme().compare( "https"_L1, Qt::CaseInsensitive ) == 0;
   if ( ishttps && !QgsApplication::authManager()->isDisabled() )
   {
     QgsDebugMsgLevel( u"Adding trusted CA certs to request"_s, 3 );
-    QSslConfiguration sslconfig( pReq->sslConfiguration() );
+    QSslConfiguration sslconfig( modifiedRequest.sslConfiguration() );
     // Merge trusted CAs with any additional CAs added by the authentication methods
     sslconfig.setCaCertificates( QgsAuthCertUtils::casMerge( QgsApplication::authManager()->trustedCaCertsCache(), sslconfig.caCertificates( ) ) );
     // check for SSL cert custom config
     const QString hostport( u"%1:%2"_s
-                            .arg( pReq->url().host().trimmed() )
-                            .arg( pReq->url().port() != -1 ? pReq->url().port() : 443 ) );
+                            .arg( modifiedRequest.url().host().trimmed() )
+                            .arg( modifiedRequest.url().port() != -1 ? modifiedRequest.url().port() : 443 ) );
     const QgsAuthConfigSslServer servconfig = QgsApplication::authManager()->sslCertCustomConfigByHost( hostport.trimmed() );
     if ( !servconfig.isNull() )
     {
@@ -335,20 +336,20 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
       sslconfig.setPeerVerifyDepth( servconfig.sslPeerVerifyDepth() );
     }
 
-    pReq->setSslConfiguration( sslconfig );
+    modifiedRequest.setSslConfiguration( sslconfig );
   }
 #endif
 
   if ( sMainNAM->mCacheDisabled )
   {
     // if caching is disabled then we override whatever the request actually has set!
-    pReq->setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
-    pReq->setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
+    modifiedRequest.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
+    modifiedRequest.setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
   }
 
   for ( const auto &preprocessor :  sCustomPreprocessors )
   {
-    preprocessor.second( pReq );
+    preprocessor.second( &modifiedRequest );
   }
 
   static QAtomicInt sRequestId = 0;
@@ -362,15 +363,15 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   for ( const auto &preprocessor :  sCustomAdvancedPreprocessors )
   {
     int intOp = static_cast< int >( op );
-    preprocessor.second( pReq, intOp, &content );
+    preprocessor.second( &modifiedRequest, intOp, &content );
     op = static_cast< QNetworkAccessManager::Operation >( intOp );
   }
 
-  emit requestAboutToBeCreated( QgsNetworkRequestParameters( op, req, requestId, content ) );
+  emit requestAboutToBeCreated( QgsNetworkRequestParameters( op, modifiedRequest, requestId, content ) );
   Q_NOWARN_DEPRECATED_PUSH
-  emit requestAboutToBeCreated( op, req, outgoingData );
+  emit requestAboutToBeCreated( op, modifiedRequest, outgoingData );
   Q_NOWARN_DEPRECATED_POP
-  QNetworkReply *reply = QNetworkAccessManager::createRequest( op, req, outgoingData );
+  QNetworkReply *reply = QNetworkAccessManager::createRequest( op, modifiedRequest, outgoingData );
   reply->setProperty( "requestId", requestId );
 
   emit requestCreated( QgsNetworkRequestParameters( op, reply->request(), requestId, content ) );
@@ -385,7 +386,7 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
 
   for ( const auto &replyPreprocessor :  sCustomReplyPreprocessors )
   {
-    replyPreprocessor.second( req, reply );
+    replyPreprocessor.second( modifiedRequest, reply );
   }
 
   // The timer will call abortRequest slot to abort the connection if needed.

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -340,6 +340,20 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   }
 #endif
 
+  if ( modifiedRequest.url().port() != -1 )
+  {
+    QUrl requestUrl = modifiedRequest.url();
+    const QString scheme = requestUrl.scheme();
+    const bool isDefaultPort = ( scheme == "http"_L1 && requestUrl.port() == 80 )
+                               || ( scheme == "https"_L1 && requestUrl.port() == 443 );
+    if ( isDefaultPort )
+    {
+      QgsDebugMsgLevel( u"Removing explicit default port %2 from url %1"_s.arg( requestUrl.port( ) ).arg( requestUrl.toString() ), 2 );
+      requestUrl.setPort( -1 );
+      modifiedRequest.setUrl( requestUrl );
+    }
+  }
+
   if ( sMainNAM->mCacheDisabled )
   {
     // if caching is disabled then we override whatever the request actually has set!

--- a/tests/src/python/test_qgsnetworkaccessmanager.py
+++ b/tests/src/python/test_qgsnetworkaccessmanager.py
@@ -188,7 +188,7 @@ class TestQgsNetworkAccessManager(QgisTestCase):
             "http://testhost.com:8080/qgis_local_server/index.html",
         )
 
-        # HTTPS request with redundant default port 80
+        # HTTPS request with redundant default port 443
         request = QNetworkRequest(
             QUrl("https://testhost.com:443/qgis_local_server/index.html")
         )

--- a/tests/src/python/test_qgsnetworkaccessmanager.py
+++ b/tests/src/python/test_qgsnetworkaccessmanager.py
@@ -21,7 +21,7 @@ from qgis.core import (
     QgsNetworkAccessManager,
 )
 from qgis.PyQt.QtCore import QUrl
-from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
+from qgis.PyQt.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.testing import QgisTestCase, start_app
 from utilities import unitTestDataPath
@@ -145,6 +145,83 @@ class TestQgsNetworkAccessManager(QgisTestCase):
         # no longer exists, so a key error should be raised
         with self.assertRaises(KeyError):
             QgsNetworkAccessManager.removeReplyPreprocessor(_id)
+
+    def test_default_port_removal(self):
+        """
+        Test removal of redundant default ports from hosts
+
+        See https://github.com/qgis/QGIS/issues/29475
+        """
+
+        # HTTP request with redundant default port 80
+        request = QNetworkRequest(
+            QUrl("http://testhost.com:80/qgis_local_server/index.html")
+        )
+        self.assertEqual(
+            request.url().toString(),
+            "http://testhost.com:80/qgis_local_server/index.html",
+        )
+
+        reply = QgsNetworkAccessManager.instance().createRequest(
+            QNetworkAccessManager.Operation.GetOperation, request, None
+        )
+        # default port should be removed in actual used request
+        self.assertEqual(
+            reply.request().url().toString(),
+            "http://testhost.com/qgis_local_server/index.html",
+        )
+
+        # HTTP request with non-default port 8080
+        request = QNetworkRequest(
+            QUrl("http://testhost.com:8080/qgis_local_server/index.html")
+        )
+        self.assertEqual(
+            request.url().toString(),
+            "http://testhost.com:8080/qgis_local_server/index.html",
+        )
+
+        reply = QgsNetworkAccessManager.instance().createRequest(
+            QNetworkAccessManager.Operation.GetOperation, request, None
+        )
+        self.assertEqual(
+            reply.request().url().toString(),
+            "http://testhost.com:8080/qgis_local_server/index.html",
+        )
+
+        # HTTPS request with redundant default port 80
+        request = QNetworkRequest(
+            QUrl("https://testhost.com:443/qgis_local_server/index.html")
+        )
+        self.assertEqual(
+            request.url().toString(),
+            "https://testhost.com:443/qgis_local_server/index.html",
+        )
+
+        reply = QgsNetworkAccessManager.instance().createRequest(
+            QNetworkAccessManager.Operation.GetOperation, request, None
+        )
+        # default port should be removed in actual used request
+        self.assertEqual(
+            reply.request().url().toString(),
+            "https://testhost.com/qgis_local_server/index.html",
+        )
+
+        # HTTPS request with non-default port 8080
+        request = QNetworkRequest(
+            QUrl("https://testhost.com:8080/qgis_local_server/index.html")
+        )
+        self.assertEqual(
+            request.url().toString(),
+            "https://testhost.com:8080/qgis_local_server/index.html",
+        )
+
+        reply = QgsNetworkAccessManager.instance().createRequest(
+            QNetworkAccessManager.Operation.GetOperation, request, None
+        )
+        self.assertEqual(
+            reply.request().url().toString(),
+            "https://testhost.com:8080/qgis_local_server/index.html",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When creating requests, if an explicit port number is present for the url which matches the default port for that scheme, remove
it.

Fixes https://github.com/qgis/QGIS/issues/29475

Likely also fixes https://github.com/qgis/QGIS/issues/29197, but that service is no longer available to test with.

Funded by République et canton de Genève