### PR TITLE
[Plugins] Follow-up to #65146 – clean up the supportsQt6 tag

### DIFF
--- a/python/plugins/MetaSearch/metadata.txt
+++ b/python/plugins/MetaSearch/metadata.txt
@@ -5,7 +5,6 @@ about=MetaSearch is a QGIS plugin to interact with metadata catalog services, su
 category=Web
 version=0.3.6
 qgisMinimumVersion=4.0
-supportsQt6=yes
 icon=images/MetaSearch.svg
 author=Tom Kralidis
 email=tomkralidis@gmail.com

--- a/python/plugins/db_manager/metadata.txt
+++ b/python/plugins/db_manager/metadata.txt
@@ -4,7 +4,6 @@ description=Manage your databases within QGIS
 category=Database
 version=0.1.20
 qgisMinimumVersion=4.0
-supportsQt6=yes
 
 author=Giuseppe Sucameli
 email=brush.tyler@gmail.com

--- a/python/plugins/grassprovider/metadata.txt
+++ b/python/plugins/grassprovider/metadata.txt
@@ -5,7 +5,6 @@ about=Exposes selected GRASS GIS algorithms and tools for use within the QGIS Pr
 category=Analysis
 version=2.12.99
 qgisMinimumVersion=4.0
-supportsQt6=yes
 
 icon=:/images/themes/default/providerGrass.svg
 

--- a/python/plugins/processing/metadata.txt
+++ b/python/plugins/processing/metadata.txt
@@ -5,7 +5,6 @@ about=Spatial data processing framework for QGIS
 category=Analysis
 version=2.12.99
 qgisMinimumVersion=4.0
-supportsQt6=yes
 author=Victor Olaya
 
 icon=:/images/themes/default/processingAlgorithm.svg

--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -39,7 +39,6 @@ from qgis.core import (
 )
 from qgis.gui import QgsGui
 from qgis.PyQt.QtCore import (
-    QT_VERSION_STR,
     QByteArray,
     QCoreApplication,
     QDate,
@@ -664,9 +663,6 @@ class Repositories(QObject):
                         .text()
                         .strip()
                     )
-                    supports_qt6 = pluginNodes.item(i).firstChildElement(
-                        "supports_qt6"
-                    ).text().strip().upper() in ["TRUE", "YES"]
                     if not qgisMaximumVersion:
                         qgisMaximumVersion = qgisMinimumVersion[0] + ".99"
                     # if compatible, add the plugin to the list
@@ -835,18 +831,7 @@ class Plugins(QObject):
         if os.path.exists(metadataFile):
             version = normalizeVersion(pluginMetadata("version"))
 
-        qt_version = int(QT_VERSION_STR.split(".")[0])
-        supports_qt6 = pluginMetadata("supportsQt6").strip().upper() in ("TRUE", "YES")
-        if (
-            qt_version == 6
-            and not supports_qt6
-            and "QGIS_DISABLE_SUPPORTS_QT6_CHECK" not in os.environ
-        ):
-            error = "incompatible"
-            errorDetails = QCoreApplication.translate(
-                "QgsPluginInstaller", "Plugin does not support Qt6 versions of QGIS"
-            )
-        elif version:
+        if version:
             qgisMinimumVersion = pluginMetadata("qgisMinimumVersion").strip()
             if not qgisMinimumVersion:
                 qgisMinimumVersion = "0"

--- a/src/app/qgspluginregistry.cpp
+++ b/src/app/qgspluginregistry.cpp
@@ -731,14 +731,6 @@ bool QgsPluginRegistry::checkPythonPlugin( const QString &packageName )
 bool QgsPluginRegistry::isPythonPluginCompatible( const QString &packageName ) const
 {
 #ifdef WITH_BINDINGS
-  const QString supportsQt6 = mPythonUtils->getPluginMetadata( packageName, u"supportsQt6"_s ).trimmed();
-  if ( supportsQt6.compare( "YES"_L1, Qt::CaseInsensitive ) != 0 && supportsQt6.compare( "TRUE"_L1, Qt::CaseInsensitive ) != 0 )
-  {
-    if ( !getenv( "QGIS_DISABLE_SUPPORTS_QT6_CHECK" ) )
-    {
-      return false;
-    }
-  }
   const QString minVersion = mPythonUtils->getPluginMetadata( packageName, u"qgisMinimumVersion"_s );
   // try to read qgisMaximumVersion. Note checkQgisVersion can cope with "__error__" value.
   const QString maxVersion = mPythonUtils->getPluginMetadata( packageName, u"qgisMaximumVersion"_s );


### PR DESCRIPTION
This PR continues the work started in #65146.

While #65146 fixed the incorrect automatic bumping of qgisMaximumVersion from 3.99 to 4.99, this PR performs the related cleanup:

1. Stop checking the supportsQt6 tag in the plugin installer.
2. Drop the supportsQt6 tag from internal plugins.

Please note that the plugins website still requires the `supportsQt6` tag for QGIS 4–compatible plugins (see ongoing work by Lova: https://github.com/qgis/QGIS-Plugins-Website/issues/249) thus we cannot remove it from installable plugins yet. However, it should be cleaned up on the installer side before the 4.0 release.

Once this PR and the related webapp changes are merged, supportsQt6 will no longer be handled and plugin authors won't need to (and shouldn't) include it.

Cc: @Xpirix @rouault @agiudiceandrea 