### PR TITLE
Reorder tabstops in advanced digitizing Floater dialog

### DIFF
--- a/src/ui/qgsadvanceddigitizingfloaterbase.ui
+++ b/src/ui/qgsadvanceddigitizingfloaterbase.ui
@@ -351,16 +351,17 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>mXLineEdit</tabstop>
   <tabstop>mDistanceLineEdit</tabstop>
   <tabstop>mAngleLineEdit</tabstop>
-  <tabstop>mBearingLineEdit</tabstop>
+  <tabstop>mXLineEdit</tabstop>
   <tabstop>mYLineEdit</tabstop>
   <tabstop>mZLineEdit</tabstop>
   <tabstop>mMLineEdit</tabstop>
+  <tabstop>mBearingLineEdit</tabstop>
   <tabstop>mCommonAngleSnappingLineEdit</tabstop>
   <tabstop>mTotalAreaLineEdit</tabstop>
   <tabstop>mTotalLengthLineEdit</tabstop>
+  <tabstop>mWeightLineEdit</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
Fixes #65172 (I didn't notice it was in a *.ui file)
Question: What do you think about sorting the items here, providing the editable ones before the non editable ones (list to be confirmed - see #65173) ? I think this would result in moving up the Weight entry, but above what?

