### PR TITLE
Fix: Make read-only measurement fields non-editable in Advanced Digit…

### DIFF
--- a/src/gui/qgsadvanceddigitizingfloater.cpp
+++ b/src/gui/qgsadvanceddigitizingfloater.cpp
@@ -36,7 +36,24 @@ QgsAdvancedDigitizingFloater::QgsAdvancedDigitizingFloater( QgsMapCanvas *canvas
   , mCadDockWidget( cadDockWidget )
 {
   setupUi( this );
+  //Disable editing and focus for read-only measurement fields
+  mTotalAreaLineEdit->setReadOnly( true );
+  mTotalAreaLineEdit->setFocusPolicy( Qt::NoFocus );
+  mTotalLengthLineEdit->setReadOnly( true );
+  mTotalLengthLineEdit->setFocusPolicy( Qt::NoFocus );
+  mBearingLineEdit->setReadOnly( true );
+  mBearingLineEdit->setFocusPolicy( Qt::NoFocus );
+  mCommonAngleSnappingLineEdit->setReadOnly( true );
+  mCommonAngleSnappingLineEdit->setFocusPolicy( Qt::NoFocus );
 
+  //Tab order: Only editable fields should be tabbable
+  setTabOrder( mDistanceLineEdit, mAngleLineEdit );
+  setTabOrder( mAngleLineEdit, mXLineEdit );
+  setTabOrder( mXLineEdit, mYLineEdit );
+  setTabOrder( mYLineEdit, mZLineEdit );
+  setTabOrder( mZLineEdit, mMLineEdit );
+  setTabOrder( mMLineEdit, mWeightLineEdit );
+  
   setAttribute( Qt::WA_TransparentForMouseEvents );
   adjustSize();
 

--- a/src/ui/qgsadvanceddigitizingfloaterbase.ui
+++ b/src/ui/qgsadvanceddigitizingfloaterbase.ui
@@ -123,12 +123,6 @@
      <property name="frame">
       <bool>false</bool>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::NoFocus</enum>
-     </property>
     </widget>
    </item>
    <item row="5" column="0" colspan="2">
@@ -208,12 +202,6 @@
      <property name="frame">
       <bool>false</bool>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::NoFocus</enum>
-     </property>
     </widget>
    </item>
    <item row="3" column="3">
@@ -259,12 +247,6 @@
     <widget class="QLineEdit" name="mBearingLineEdit">
      <property name="frame">
       <bool>false</bool>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::NoFocus</enum>
      </property>
     </widget>
    </item>
@@ -324,12 +306,6 @@
      </property>
      <property name="frame">
       <bool>false</bool>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::NoFocus</enum>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsadvanceddigitizingfloaterbase.ui
+++ b/src/ui/qgsadvanceddigitizingfloaterbase.ui
@@ -123,6 +123,12 @@
      <property name="frame">
       <bool>false</bool>
      </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
     </widget>
    </item>
    <item row="5" column="0" colspan="2">
@@ -202,6 +208,12 @@
      <property name="frame">
       <bool>false</bool>
      </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
     </widget>
    </item>
    <item row="3" column="3">
@@ -247,6 +259,12 @@
     <widget class="QLineEdit" name="mBearingLineEdit">
      <property name="frame">
       <bool>false</bool>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
      </property>
     </widget>
    </item>
@@ -307,6 +325,12 @@
      <property name="frame">
       <bool>false</bool>
      </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
     </widget>
    </item>
    <item row="5" column="3">
@@ -351,17 +375,12 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>mDistanceLineEdit</tabstop>
-  <tabstop>mAngleLineEdit</tabstop>
-  <tabstop>mXLineEdit</tabstop>
-  <tabstop>mYLineEdit</tabstop>
-  <tabstop>mZLineEdit</tabstop>
-  <tabstop>mMLineEdit</tabstop>
-  <tabstop>mBearingLineEdit</tabstop>
-  <tabstop>mCommonAngleSnappingLineEdit</tabstop>
-  <tabstop>mTotalAreaLineEdit</tabstop>
-  <tabstop>mTotalLengthLineEdit</tabstop>
-  <tabstop>mWeightLineEdit</tabstop>
+   <tabstop>mXLineEdit</tabstop>
+   <tabstop>mDistanceLineEdit</tabstop>
+   <tabstop>mAngleLineEdit</tabstop>
+   <tabstop>mYLineEdit</tabstop>
+   <tabstop>mZLineEdit</tabstop>
+   <tabstop>mMLineEdit</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsadvanceddigitizingfloaterbase.ui
+++ b/src/ui/qgsadvanceddigitizingfloaterbase.ui
@@ -351,12 +351,17 @@
   </layout>
  </widget>
  <tabstops>
-   <tabstop>mXLineEdit</tabstop>
    <tabstop>mDistanceLineEdit</tabstop>
    <tabstop>mAngleLineEdit</tabstop>
+   <tabstop>mXLineEdit</tabstop>
    <tabstop>mYLineEdit</tabstop>
    <tabstop>mZLineEdit</tabstop>
    <tabstop>mMLineEdit</tabstop>
+   <tabstop>mBearingLineEdit</tabstop>
+   <tabstop>mCommonAngleSnappingLineEdit</tabstop>
+   <tabstop>mTotalAreaLineEdit</tabstop>
+   <tabstop>mTotalLengthLineEdit</tabstop>
+   <tabstop>mWeightLineEdit</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
This commit fixes issue #65173 by preventing user interaction with display-only fields in the Advanced Digitizing Floater.

Changes applied:
1) mTotalAreaLineEdit set to read-only and non-focusable
2) mTotalLengthLineEdit set to read-only and non-focusable
3) mBearingLineEdit set to read-only and non-focusable
4) mCommonAngleSnappingLineEdit set to read-only and non-focusable
5) Removed these widgets from the tab order in the .ui file
6) No behavioral or structural changes beyond restricting editability