### PR TITLE
Don't immediately validate child algorithms in models

### DIFF
--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -378,22 +378,6 @@ class ModelerDialog(QgsModelDesignerDialog):
             self.repaintModel()
             self.endUndoCommand()
 
-            res, errors = self.model().validateChildAlgorithm(id)
-            if not res:
-                self.view().scene().showWarning(
-                    QCoreApplication.translate(
-                        "ModelerDialog", "Algorithm “{}” is invalid"
-                    ).format(alg.description()),
-                    self.tr("Algorithm is Invalid"),
-                    QCoreApplication.translate(
-                        "ModelerDialog",
-                        '<div style="color:palette(window-text);"><p>The “{}” algorithm is invalid, because:</p><ul><li>{}</li></ul></div>',
-                    ).format(alg.description(), "</li><li>".join(errors)),
-                    level=Qgis.MessageLevel.Warning,
-                )
-            else:
-                self.view().scene().messageBar().clearWidgets()
-
     def getPositionForAlgorithmItem(self):
         MARGIN = 20
         BOX_WIDTH = 200

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -221,22 +221,6 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
         self.requestModelRepaint.emit()
         self.changed.emit()
 
-        res, errors = self.model().validateChildAlgorithm(alg.childId())
-        if not res:
-            self.scene().showWarning(
-                QCoreApplication.translate(
-                    "ModelerGraphicItem", "Algorithm “{}” is invalid"
-                ).format(alg.description()),
-                self.tr("Algorithm is Invalid"),
-                QCoreApplication.translate(
-                    "ModelerGraphicItem",
-                    "<p>The “{}” algorithm is invalid, because:</p><ul><li>{}</li></ul>",
-                ).format(alg.description(), "</li><li>".join(errors)),
-                level=Qgis.MessageLevel.Warning,
-            )
-        else:
-            self.scene().messageBar().clearWidgets()
-
     def editComponent(self):
         self.edit()
 


### PR DESCRIPTION
Now that we're moving toward interactive connections of components, it's no longer such an expected situation when a child algorithm is (temporarily) made invalid.

Eg if you disconnect an existing connection, and haven't yet reconnected that input to a different output.

In these situations the message bar warnings which show when that child algorithm is in a (temporary!) invalid state are just noise and get in the way.

We still:

1. Show these warnings when manually validating the model
2. Validate and warn when attempting to RUN the model
3. Show invalid child algorithms in the "Red" state
