### PR TITLE
Fix: ensure Chinese translation files load correctly (fixes #65042)

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -563,7 +563,6 @@ void QgsApplication::init( QString profileFolder )
   ABISYM( mInitialized ) = true;
 }
 
-
 void QgsApplication::installTranslators()
 {
   // Remove translators if any are already installed
@@ -588,14 +587,25 @@ void QgsApplication::installTranslators()
 
   if ( *sTranslation() != "C"_L1 )
   {
+    const QLocale loc( *sTranslation() );
+    QString qgisLocale = *sTranslation();
+    // Normalizes Chinese locale (zh-CN/TW/HK) tags to 
+    // BCP-47 style (zh-Hans/Hant) to ensure QGIS translations load correctly.
+    if ( loc.language() == QLocale::Chinese )
+    {
+      qgisLocale = ( loc.script() == QLocale::TraditionalChineseScript ) ? u"zh-Hant"_s : u"zh-Hans"_s;
+      QgsDebugMsgLevel( u"qgis locale tag: %1 (original: %2)"_s
+                    .arg( qgisLocale, *sTranslation() ), 2 );
+    }
+
     mQgisTranslator = std::make_unique<QTranslator>( this );
-    if ( mQgisTranslator->load( u"qgis_"_s + *sTranslation(), i18nPath() ) )
+    if ( mQgisTranslator->load( u"qgis_"_s + qgisLocale, i18nPath() ) )
     {
       installTranslator( mQgisTranslator.get() );
     }
     else
     {
-      QgsDebugMsgLevel( u"loading of qgis translation failed %1/qgis_%2"_s.arg( i18nPath(), *sTranslation() ), 2 );
+      QgsDebugMsgLevel( u"loading of qgis translation failed %1/qgis_%2"_s.arg( i18nPath(), qgisLocale ), 2 );
     }
 
     /* Translation file for Qt.
@@ -609,8 +619,10 @@ void QgsApplication::installTranslators()
     qtTranslationsPath = prefix + qtTranslationsPath.mid( QLibraryInfo::location( QLibraryInfo::PrefixPath ).length() );
 #endif
 
+    // Leverages QLocale in QTranslator::load() for Qt translations to improve matching reliability 
+    // and support standard Qt translation fallback mechanisms.
     mQtTranslator = std::make_unique<QTranslator>( this );
-    if ( mQtTranslator->load( u"qt_"_s + *sTranslation(), qtTranslationsPath ) )
+    if ( mQtTranslator->load( loc, u"qt"_s, u"_"_s, qtTranslationsPath ) )
     {
       installTranslator( mQtTranslator.get() );
     }
@@ -620,7 +632,7 @@ void QgsApplication::installTranslators()
     }
 
     mQtBaseTranslator = std::make_unique<QTranslator>( this );
-    if ( mQtBaseTranslator->load( u"qtbase_"_s + *sTranslation(), qtTranslationsPath ) )
+    if ( mQtBaseTranslator->load( loc, u"qtbase"_s, u"_"_s, qtTranslationsPath ) )
     {
       installTranslator( mQtBaseTranslator.get() );
     }

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -563,6 +563,7 @@ void QgsApplication::init( QString profileFolder )
   ABISYM( mInitialized ) = true;
 }
 
+
 void QgsApplication::installTranslators()
 {
   // Remove translators if any are already installed
@@ -589,13 +590,13 @@ void QgsApplication::installTranslators()
   {
     const QLocale loc( *sTranslation() );
     QString qgisLocale = *sTranslation();
-    // Normalizes Chinese locale (zh-CN/TW/HK) tags to 
+    // Normalizes Chinese locale (zh-CN/TW/HK) tags to
     // BCP-47 style (zh-Hans/Hant) to ensure QGIS translations load correctly.
     if ( loc.language() == QLocale::Chinese )
     {
       qgisLocale = ( loc.script() == QLocale::TraditionalChineseScript ) ? u"zh-Hant"_s : u"zh-Hans"_s;
       QgsDebugMsgLevel( u"qgis locale tag: %1 (original: %2)"_s
-                    .arg( qgisLocale, *sTranslation() ), 2 );
+                        .arg( qgisLocale, *sTranslation() ), 2 );
     }
 
     mQgisTranslator = std::make_unique<QTranslator>( this );
@@ -619,7 +620,7 @@ void QgsApplication::installTranslators()
     qtTranslationsPath = prefix + qtTranslationsPath.mid( QLibraryInfo::location( QLibraryInfo::PrefixPath ).length() );
 #endif
 
-    // Leverages QLocale in QTranslator::load() for Qt translations to improve matching reliability 
+    // Leverages QLocale in QTranslator::load() for Qt translations to improve matching reliability
     // and support standard Qt translation fallback mechanisms.
     mQtTranslator = std::make_unique<QTranslator>( this );
     if ( mQtTranslator->load( loc, u"qt"_s, u"_"_s, qtTranslationsPath ) )


### PR DESCRIPTION
## Description

### Problem:
Currently, there is a mismatch in how QGIS and Qt handle locale identifiers in Chinese environments, leading to incomplete UI translations:
- QGIS translation files follow BCP-47 tags (e.g., zh-Hans, zh-Hant).
- Qt system translations often follow POSIX-style naming (e.g., zh_CN, zh_TW).

This results in a conflict where either QGIS strings are translated or Qt standard dialogs are translated, but rarely both correctly.

### Fix:
This PR harmonizes the loading process in QgsApplication::installTranslators():
- Normalization: Explicitly maps Chinese locales to BCP-47 style (zh-Hans/Hant) before loading qgis_*.qm files.
- Optimization: Leverages the QLocale-based overload of QTranslator::load() for qt_ and qtbase_ translations, allowing Qt to handle its preferred POSIX-style filenames automatically.

Fixes #65042

## AI tool usage

 - [x] AI tool(s) (Gemini) supported my development of this PR. Used for technical terminology translation and PR description formatting.