### PR TITLE
Fix WMTS-T layers temporal capabilities resourceURL selection

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -2309,7 +2309,15 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
 
       if ( resourceType == "tile"_L1 )
       {
-        tileLayer.getTileURLs.insert( format, tmpl );
+        if ( tmpl.contains( u"{TIME}"_s, Qt::CaseInsensitive ) )
+        {
+          tileLayer.getTileURLs.insert( format, tmpl );
+        }
+        else if ( !tileLayer.getTileURLs.contains( format ) )
+        {
+          // Only use non-temporal URL if no URL exists yet for this format
+          tileLayer.getTileURLs.insert( format, tmpl );
+        }
       }
       else if ( resourceType == "FeatureInfo"_L1 )
       {

--- a/tests/src/providers/testqgswmscapabilities.cpp
+++ b/tests/src/providers/testqgswmscapabilities.cpp
@@ -534,6 +534,7 @@ class TestQgsWmsCapabilities : public QObject
               <TileMatrixSetLink>
                   <TileMatrixSet>g</TileMatrixSet>
               </TileMatrixSetLink>
+              <ResourceURL format="image/png" resourceType="tile" template="https:\/\/landscapes-mapserver.tern.org.au/mapcache/wmts/1.0.0/ETaScaled/default/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
               <ResourceURL format="image/png" resourceType="tile" template="https:\/\/landscapes-mapserver.tern.org.au/mapcache/wmts/1.0.0/ETaScaled/default/{time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
           </Layer>
           <TileMatrixSet>
@@ -574,6 +575,11 @@ class TestQgsWmsCapabilities : public QObject
       QCOMPARE( tileLayer.temporalInterval, QgsInterval( 1, Qgis::TemporalUnit::IrregularStep ) );
       QCOMPARE( tileLayer.temporalCapabilityFlags, Qgis::RasterTemporalCapabilityFlag::RequestedTimesMustExactlyMatchAllAvailableTemporalRanges );
       QCOMPARE( tileLayer.defaultTimeDimensionValue, u"current"_s );
+
+      // Verify the temporal URL (with {TIME}) was selected
+      QVERIFY( tileLayer.getTileURLs.contains( "image/png" ) );
+      QString selectedUrl = tileLayer.getTileURLs.value( "image/png" );
+      QVERIFY( selectedUrl.toLower().contains( "{time}" ) );
     }
 
     void wmtsTimeDimensionValue_data()


### PR DESCRIPTION
## Description

In WMTS-T the capabilities can contain multiple `resourceURLs`, e.g:
```xml
<ResourceURL template="https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MERRA2_2m_Air_Temperature_Monthly/default/{Time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" format="image/png" resourceType="tile"/>
<ResourceURL template="https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MERRA2_2m_Air_Temperature_Monthly/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" format="image/png" resourceType="tile"/>
<ResourceURL template="https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MERRA2_2m_Air_Temperature_Monthly/default/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" format="image/png" resourceType="tile"/>
```

QGIS will currently select the last url encountered, in this case with the `{TIME}` parameter already being set to `default`. This results in the temporal controller not fetching new tiles when the slider is moved. The same image will keep being displayed, it doesn't change.

This PR makes sure `resourceURL`s with a `{TIME}` parameter will be preferred, resulting in the temporal controller working correctly again. It now displays the correct image, respective of the set point in time.

Try this WMTS-T (It's quite slow): https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/1.0.0/WMTSCapabilities.xml

Closes #54043.

https://github.com/user-attachments/assets/4e86f0a4-a92b-4d07-8c43-ea29db84ffd8


## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
