### PR TITLE
Charts preserve properties

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsbarchartplot.py
+++ b/python/PyQt6/core/auto_additions/qgsbarchartplot.py
@@ -2,7 +2,7 @@
 try:
     QgsBarChartPlot.create = staticmethod(QgsBarChartPlot.create)
     QgsBarChartPlot.createDataGatherer = staticmethod(QgsBarChartPlot.createDataGatherer)
-    QgsBarChartPlot.__overridden_methods__ = ['type', 'renderContent', 'writeXml', 'readXml']
+    QgsBarChartPlot.__overridden_methods__ = ['type', 'renderContent', 'writeXml', 'readXml', 'initFromPlot']
     QgsBarChartPlot.__group__ = ['plot']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgslinechartplot.py
+++ b/python/PyQt6/core/auto_additions/qgslinechartplot.py
@@ -2,7 +2,7 @@
 try:
     QgsLineChartPlot.create = staticmethod(QgsLineChartPlot.create)
     QgsLineChartPlot.createDataGatherer = staticmethod(QgsLineChartPlot.createDataGatherer)
-    QgsLineChartPlot.__overridden_methods__ = ['type', 'renderContent', 'writeXml', 'readXml']
+    QgsLineChartPlot.__overridden_methods__ = ['type', 'renderContent', 'writeXml', 'readXml', 'initFromPlot']
     QgsLineChartPlot.__group__ = ['plot']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgspiechartplot.py
+++ b/python/PyQt6/core/auto_additions/qgspiechartplot.py
@@ -2,7 +2,7 @@
 try:
     QgsPieChartPlot.create = staticmethod(QgsPieChartPlot.create)
     QgsPieChartPlot.createDataGatherer = staticmethod(QgsPieChartPlot.createDataGatherer)
-    QgsPieChartPlot.__overridden_methods__ = ['type', 'renderContent', 'writeXml', 'readXml']
+    QgsPieChartPlot.__overridden_methods__ = ['type', 'renderContent', 'writeXml', 'readXml', 'initFromPlot']
     QgsPieChartPlot.__group__ = ['plot']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgsplot.py
+++ b/python/PyQt6/core/auto_additions/qgsplot.py
@@ -65,6 +65,11 @@ QgsPlot.DataDefinedProperty.__doc__ = """Data defined properties for different p
 """
 # --
 try:
+    QgsPlotAxis.copyProperties = staticmethod(QgsPlotAxis.copyProperties)
+    QgsPlotAxis.__group__ = ['plot']
+except (NameError, AttributeError):
+    pass
+try:
     QgsPlotDefaultSettings.axisLabelNumericFormat = staticmethod(QgsPlotDefaultSettings.axisLabelNumericFormat)
     QgsPlotDefaultSettings.axisGridMajorSymbol = staticmethod(QgsPlotDefaultSettings.axisGridMajorSymbol)
     QgsPlotDefaultSettings.axisGridMinorSymbol = staticmethod(QgsPlotDefaultSettings.axisGridMinorSymbol)
@@ -80,7 +85,7 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsPlot.__virtual_methods__ = ['type', 'writeXml', 'readXml']
+    QgsPlot.__virtual_methods__ = ['type', 'writeXml', 'readXml', 'initFromPlot']
     QgsPlot.__group__ = ['plot']
 except (NameError, AttributeError):
     pass
@@ -111,9 +116,5 @@ except (NameError, AttributeError):
     pass
 try:
     QgsPlotData.__group__ = ['plot']
-except (NameError, AttributeError):
-    pass
-try:
-    QgsPlotAxis.__group__ = ['plot']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/plot/qgsbarchartplot.sip.in
+++ b/python/PyQt6/core/auto_generated/plot/qgsbarchartplot.sip.in
@@ -67,6 +67,13 @@ Returns a new bar chart.
 Returns a new data gatherer for a given bar chart ``plot``.
 %End
 
+    virtual void initFromPlot( const QgsPlot *plot );
+
+%Docstring
+Initializes properties of this plot from an existing ``plot``,
+transferring all applicable settings.
+%End
+
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/plot/qgslinechartplot.sip.in
+++ b/python/PyQt6/core/auto_generated/plot/qgslinechartplot.sip.in
@@ -82,6 +82,13 @@ Returns a new line chart.
 Returns a new data gatherer for a given line chart ``plot``.
 %End
 
+    virtual void initFromPlot( const QgsPlot *plot );
+
+%Docstring
+Initializes properties of this plot from an existing ``plot``,
+transferring all applicable settings.
+%End
+
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/plot/qgspiechartplot.sip.in
+++ b/python/PyQt6/core/auto_generated/plot/qgspiechartplot.sip.in
@@ -122,6 +122,13 @@ Returns a new pie chart.
 Returns a new data gatherer for a given pie chart ``plot``.
 %End
 
+    virtual void initFromPlot( const QgsPlot *plot );
+
+%Docstring
+Initializes properties of this plot from an existing ``plot``,
+transferring all applicable settings.
+%End
+
 };
 
 /************************************************************************

--- a/python/PyQt6/core/auto_generated/plot/qgsplot.sip.in
+++ b/python/PyQt6/core/auto_generated/plot/qgsplot.sip.in
@@ -136,6 +136,15 @@ Writes the plot's properties into an XML ``element``.
 Reads the plot's properties from an XML ``element``.
 %End
 
+    virtual void initFromPlot( const QgsPlot *plot );
+%Docstring
+Initializes properties of this plot from an existing ``plot``,
+transferring all applicable settings. Subclasses should override this
+method and call the base class implementation first.
+
+.. versionadded:: 4.0
+%End
+
     static const QgsPropertiesDefinition &propertyDefinitions();
 %Docstring
 Returns the plot property definitions.
@@ -417,6 +426,7 @@ Returns the line symbol used to render the major lines in the axis grid.
 .. seealso:: :py:func:`setGridMajorSymbol`
 %End
 
+
     void setGridMajorSymbol( QgsLineSymbol *symbol /Transfer/ );
 %Docstring
 Sets the ``symbol`` used to render the major lines in the axis grid.
@@ -432,6 +442,7 @@ Returns the line symbol used to render the minor lines in the axis grid.
 
 .. seealso:: :py:func:`setGridMinorSymbol`
 %End
+
 
     void setGridMinorSymbol( QgsLineSymbol *symbol /Transfer/ );
 %Docstring
@@ -518,6 +529,12 @@ Sets the ``placement`` for the axis label suffixes.
 .. versionadded:: 3.32
 %End
 
+    static void copyProperties( const QgsPlotAxis &source, QgsPlotAxis &destination );
+%Docstring
+Copies all properties from ``source`` axis to ``destination`` axis.
+
+.. versionadded:: 4.0
+%End
   private:
     QgsPlotAxis( const QgsPlotAxis &other );
 };
@@ -612,6 +629,14 @@ Returns the margins of the plot area (in millimeters)
 Sets the ``margins`` of the plot area (in millimeters)
 
 .. seealso:: :py:func:`setMargins`
+%End
+
+    void copyCommonProperties( const Qgs2DPlot *other );
+%Docstring
+Copies all Qgs2DPlot-level properties (size, margins, data-defined
+properties) from ``other`` to this plot.
+
+.. versionadded:: 4.0
 %End
 
   protected:
@@ -761,6 +786,7 @@ Returns the fill symbol used to render the background of the chart.
 .. seealso:: :py:func:`setChartBackgroundSymbol`
 %End
 
+
     void setChartBackgroundSymbol( QgsFillSymbol *symbol /Transfer/ );
 %Docstring
 Sets the fill ``symbol`` used to render the background of the chart.
@@ -776,6 +802,7 @@ Returns the symbol used to render the border of the chart.
 
 .. seealso:: :py:func:`setChartBorderSymbol`
 %End
+
 
     void setChartBorderSymbol( QgsFillSymbol *symbol /Transfer/ );
 %Docstring
@@ -794,6 +821,14 @@ Returns whether the X and Y axes are flipped.
     void setFlipAxes( bool flipAxes );
 %Docstring
 Sets whether the X and Y axes are flipped.
+%End
+
+    void copyCommonProperties( const Qgs2DXyPlot *other );
+%Docstring
+Copies all Qgs2DXyPlot-level properties (axis ranges, axes, flip state,
+background and border symbols) from ``other`` to this plot.
+
+.. versionadded:: 4.0
 %End
 
   protected:

--- a/src/core/plot/qgsbarchartplot.cpp
+++ b/src/core/plot/qgsbarchartplot.cpp
@@ -254,3 +254,21 @@ QgsVectorLayerAbstractPlotDataGatherer *QgsBarChartPlot::createDataGatherer( Qgs
 
   return new QgsVectorLayerXyPlotDataGatherer( chart->xAxis().type() );
 }
+
+void QgsBarChartPlot::initFromPlot( const QgsPlot *plot )
+{
+  if ( !plot )
+  {
+    return;
+  }
+
+  if ( const Qgs2DXyPlot *plotXy = dynamic_cast<const Qgs2DXyPlot *>( plot ) )
+  {
+    Qgs2DXyPlot::copyCommonProperties( plotXy );
+  }
+  else if ( const Qgs2DPlot *plotPie = dynamic_cast<const Qgs2DPlot *>( plot ) )
+  {
+
+    Qgs2DPlot::copyCommonProperties( plotPie );
+  }
+}

--- a/src/core/plot/qgsbarchartplot.h
+++ b/src/core/plot/qgsbarchartplot.h
@@ -72,6 +72,12 @@ class CORE_EXPORT QgsBarChartPlot : public Qgs2DXyPlot
     //! Returns a new data gatherer for a given bar chart \a plot.
     static QgsVectorLayerAbstractPlotDataGatherer *createDataGatherer( QgsPlot *plot ) SIP_TRANSFERBACK;
 
+    /**
+     * Initializes properties of this plot from an existing \a plot, transferring all applicable
+     * settings.
+     */
+    void initFromPlot( const QgsPlot *plot ) override;
+
   private:
 
     std::vector<std::unique_ptr<QgsFillSymbol>> mFillSymbols;

--- a/src/core/plot/qgslinechartplot.cpp
+++ b/src/core/plot/qgslinechartplot.cpp
@@ -379,3 +379,21 @@ QgsVectorLayerAbstractPlotDataGatherer *QgsLineChartPlot::createDataGatherer( Qg
 
   return new QgsVectorLayerXyPlotDataGatherer( chart->xAxis().type() );
 }
+
+void QgsLineChartPlot::initFromPlot( const QgsPlot *plot )
+{
+  if ( !plot )
+  {
+    return;
+  }
+
+  if ( const Qgs2DXyPlot *plotXy = dynamic_cast<const Qgs2DXyPlot *>( plot ) )
+  {
+    Qgs2DXyPlot::copyCommonProperties( plotXy );
+  }
+  else if ( const Qgs2DPlot *plotPie = dynamic_cast<const Qgs2DPlot *>( plot ) )
+  {
+
+    Qgs2DPlot::copyCommonProperties( plotPie );
+  }
+}

--- a/src/core/plot/qgslinechartplot.h
+++ b/src/core/plot/qgslinechartplot.h
@@ -88,6 +88,12 @@ class CORE_EXPORT QgsLineChartPlot : public Qgs2DXyPlot
     //! Returns a new data gatherer for a given line chart \a plot.
     static QgsVectorLayerAbstractPlotDataGatherer *createDataGatherer( QgsPlot *plot ) SIP_TRANSFERBACK;
 
+    /**
+     * Initializes properties of this plot from an existing \a plot, transferring all applicable
+     * settings.
+     */
+    void initFromPlot( const QgsPlot *plot ) override;
+
   private:
 
     std::vector<std::unique_ptr<QgsMarkerSymbol>> mMarkerSymbols;

--- a/src/core/plot/qgspiechartplot.cpp
+++ b/src/core/plot/qgspiechartplot.cpp
@@ -445,3 +445,17 @@ void QgsPieChartPlot::setLabelType( Qgis::PieChartLabelType type )
 {
   mLabelType = type;
 }
+
+void QgsPieChartPlot::initFromPlot( const QgsPlot *plot )
+{
+  if ( !plot )
+  {
+    return;
+  }
+
+  // pie charts do not have axis, so we transfer only settings related to the chart area
+  if ( const Qgs2DPlot *plot2D = dynamic_cast<const Qgs2DPlot *>( plot ) )
+  {
+    Qgs2DPlot::copyCommonProperties( plot2D );
+  }
+}

--- a/src/core/plot/qgspiechartplot.h
+++ b/src/core/plot/qgspiechartplot.h
@@ -129,6 +129,12 @@ class CORE_EXPORT QgsPieChartPlot : public Qgs2DPlot
     //! Returns a new data gatherer for a given pie chart \a plot.
     static QgsVectorLayerAbstractPlotDataGatherer *createDataGatherer( QgsPlot *plot ) SIP_TRANSFERBACK;
 
+    /**
+     * Initializes properties of this plot from an existing \a plot, transferring all applicable
+     * settings.
+     */
+    void initFromPlot( const QgsPlot *plot ) override;
+
   private:
 
     std::vector<std::unique_ptr<QgsFillSymbol>> mFillSymbols;

--- a/src/core/plot/qgsplot.cpp
+++ b/src/core/plot/qgsplot.cpp
@@ -91,7 +91,17 @@ const QgsPropertiesDefinition &QgsPlot::propertyDefinitions()
   return sPropertyDefinitions;
 }
 
+void QgsPlot::initFromPlot( const QgsPlot *plot )
+{
+  if ( !plot )
+    return;
+  setDataDefinedProperties( plot->dataDefinedProperties() );
+}
+
+
+//
 // QgsPlotAxis
+//
 
 QgsPlotAxis::QgsPlotAxis()
 {
@@ -200,12 +210,22 @@ QgsLineSymbol *QgsPlotAxis::gridMajorSymbol()
   return mGridMajorSymbol.get();
 }
 
+const QgsLineSymbol *QgsPlotAxis::gridMajorSymbol() const
+{
+  return mGridMajorSymbol.get();
+}
+
 void QgsPlotAxis::setGridMajorSymbol( QgsLineSymbol *symbol )
 {
   mGridMajorSymbol.reset( symbol );
 }
 
 QgsLineSymbol *QgsPlotAxis::gridMinorSymbol()
+{
+  return mGridMinorSymbol.get();
+}
+
+const QgsLineSymbol *QgsPlotAxis::gridMinorSymbol() const
 {
   return mGridMinorSymbol.get();
 }
@@ -223,6 +243,23 @@ QgsTextFormat QgsPlotAxis::textFormat() const
 void QgsPlotAxis::setTextFormat( const QgsTextFormat &format )
 {
   mLabelTextFormat = format;
+}
+
+void QgsPlotAxis::copyProperties( const QgsPlotAxis &source, QgsPlotAxis &dest )
+{
+  dest.setType( source.type() );
+  dest.setGridIntervalMinor( source.gridIntervalMinor() );
+  dest.setGridIntervalMajor( source.gridIntervalMajor() );
+  dest.setLabelInterval( source.labelInterval() );
+  dest.setLabelSuffix( source.labelSuffix() );
+  dest.setLabelSuffixPlacement( source.labelSuffixPlacement() );
+  dest.setTextFormat( source.textFormat() );
+  if ( source.numericFormat() )
+    dest.setNumericFormat( source.numericFormat()->clone() );
+  if ( source.gridMajorSymbol() )
+    dest.setGridMajorSymbol( source.gridMajorSymbol()->clone() );
+  if ( source.gridMinorSymbol() )
+    dest.setGridMinorSymbol( source.gridMinorSymbol()->clone() );
 }
 
 
@@ -352,9 +389,21 @@ void Qgs2DPlot::applyDataDefinedProperties( QgsRenderContext &context, QgsMargin
   }
 }
 
+void Qgs2DPlot::copyCommonProperties( const Qgs2DPlot *other )
+{
+  if ( !other )
+  {
+    return;
+  }
+
+  setDataDefinedProperties( other->dataDefinedProperties() );
+  setSize( other->size() );
+  setMargins( other->margins() );
+}
+
 
 //
-// Qgs2DPlot
+// Qgs2DXyPlot
 //
 
 Qgs2DXyPlot::Qgs2DXyPlot()
@@ -1110,12 +1159,22 @@ QgsFillSymbol *Qgs2DXyPlot::chartBackgroundSymbol()
   return mChartBackgroundSymbol.get();
 }
 
+const QgsFillSymbol *Qgs2DXyPlot::chartBackgroundSymbol() const
+{
+  return mChartBackgroundSymbol.get();
+}
+
 void Qgs2DXyPlot::setChartBackgroundSymbol( QgsFillSymbol *symbol )
 {
   mChartBackgroundSymbol.reset( symbol );
 }
 
 QgsFillSymbol *Qgs2DXyPlot::chartBorderSymbol()
+{
+  return mChartBorderSymbol.get();
+}
+
+const QgsFillSymbol *Qgs2DXyPlot::chartBorderSymbol() const
 {
   return mChartBorderSymbol.get();
 }
@@ -1238,6 +1297,34 @@ void Qgs2DXyPlot::applyDataDefinedProperties( QgsRenderContext &context, double 
     }
   }
 }
+
+void Qgs2DXyPlot::copyCommonProperties( const Qgs2DXyPlot *other )
+{
+  if ( !other )
+  {
+    return;
+  }
+
+  Qgs2DPlot::copyCommonProperties( other );
+  setXMinimum( other->xMinimum() );
+  setXMaximum( other->xMaximum() );
+  setYMinimum( other->yMinimum() );
+  setYMaximum( other->yMaximum() );
+  setFlipAxes( other->flipAxes() );
+
+  QgsPlotAxis::copyProperties( other->xAxis(), mXAxis );
+  QgsPlotAxis::copyProperties( other->yAxis(), mYAxis );
+
+  if ( other->chartBackgroundSymbol() )
+  {
+    setChartBackgroundSymbol( other->chartBackgroundSymbol()->clone() );
+  }
+  if ( other->chartBorderSymbol() )
+  {
+    setChartBorderSymbol( other->chartBorderSymbol()->clone() );
+  }
+}
+
 
 //
 // QgsPlotDefaultSettings

--- a/src/core/plot/qgsplot.h
+++ b/src/core/plot/qgsplot.h
@@ -161,6 +161,13 @@ class CORE_EXPORT QgsPlot
     virtual bool readXml( const QDomElement &element, const QgsReadWriteContext &context );
 
     /**
+     * Initializes properties of this plot from an existing \a plot, transferring all applicable
+     * settings. Subclasses should override this method and call the base class implementation first.
+     * \since QGIS 4.0
+     */
+    virtual void initFromPlot( const QgsPlot *plot );
+
+    /**
      * Returns the plot property definitions.
      */
     static const QgsPropertiesDefinition &propertyDefinitions();
@@ -431,6 +438,15 @@ class CORE_EXPORT QgsPlotAxis
     QgsLineSymbol *gridMajorSymbol();
 
     /**
+     * Returns the line symbol used to render the major lines in the axis grid.
+     *
+     * \see setGridMajorSymbol()
+     * \note not available in Python bindings
+     * \since QGIS 4.0
+     */
+    const QgsLineSymbol *gridMajorSymbol() const SIP_SKIP;
+
+    /**
      * Sets the \a symbol used to render the major lines in the axis grid.
      *
      * Ownership of \a symbol is transferred to the plot.
@@ -445,6 +461,15 @@ class CORE_EXPORT QgsPlotAxis
      * \see setGridMinorSymbol()
      */
     QgsLineSymbol *gridMinorSymbol();
+
+    /**
+     * Returns the line symbol used to render the major lines in the axis grid.
+     *
+     * \see setGridMinorSymbol()
+     * \note not available in Python bindings
+     * \since QGIS 4.0
+     */
+    const QgsLineSymbol *gridMinorSymbol() const SIP_SKIP;
 
     /**
      * Sets the \a symbol used to render the minor lines in the axis grid.
@@ -525,6 +550,12 @@ class CORE_EXPORT QgsPlotAxis
      */
     void setLabelSuffixPlacement( Qgis::PlotAxisSuffixPlacement placement );
 
+    /**
+     * Copies all properties from \a source axis to \a destination axis.
+     *
+     * \since QGIS 4.0
+     */
+    static void copyProperties( const QgsPlotAxis &source, QgsPlotAxis &destination );
   private:
 
 #ifdef SIP_RUN
@@ -628,6 +659,12 @@ class CORE_EXPORT Qgs2DPlot : public QgsPlot
      * \see setMargins()
      */
     void setMargins( const QgsMargins &margins );
+
+    /**
+     * Copies all Qgs2DPlot-level properties (size, margins, data-defined properties) from \a other to this plot.
+     * \since QGIS 4.0
+     */
+    void copyCommonProperties( const Qgs2DPlot *other );
 
   protected:
 
@@ -786,6 +823,13 @@ class CORE_EXPORT Qgs2DXyPlot : public Qgs2DPlot
     QgsFillSymbol *chartBackgroundSymbol();
 
     /**
+     * Returns the fill symbol used to render the background of the chart.
+     * \see setChartBackgroundSymbol()
+     * \note not available in Python bindings
+     */
+    const QgsFillSymbol *chartBackgroundSymbol() const SIP_SKIP;
+
+    /**
      * Sets the fill \a symbol used to render the background of the chart.
      *
      * Ownership of \a symbol is transferred to the plot.
@@ -800,6 +844,14 @@ class CORE_EXPORT Qgs2DXyPlot : public Qgs2DPlot
      * \see setChartBorderSymbol()
      */
     QgsFillSymbol *chartBorderSymbol();
+
+    /**
+     * Returns the symbol used to render the border of the chart.
+     *
+     * \see setChartBorderSymbol()
+     * \note not available in Python bindings
+     */
+    const QgsFillSymbol *chartBorderSymbol() const SIP_SKIP;
 
     /**
      * Sets the \a symbol used to render the border of the chart.
@@ -819,6 +871,13 @@ class CORE_EXPORT Qgs2DXyPlot : public Qgs2DPlot
      * Sets whether the X and Y axes are flipped.
      */
     void setFlipAxes( bool flipAxes );
+
+    /**
+     * Copies all Qgs2DXyPlot-level properties (axis ranges, axes, flip state, background and border symbols)
+     * from \a other to this plot.
+     * \since QGIS 4.0
+     */
+    void copyCommonProperties( const Qgs2DXyPlot *other );
 
   protected:
 

--- a/src/gui/layout/qgslayoutchartwidget.cpp
+++ b/src/gui/layout/qgslayoutchartwidget.cpp
@@ -173,28 +173,13 @@ void QgsLayoutChartWidget::mChartTypeComboBox_currentIndexChanged( int )
     return;
   }
 
+  QgsPlot *oldPlot = mChartItem->plot();
   QgsPlot *newPlot = QgsApplication::instance()->plotRegistry()->createPlot( plotType );
+  // copy relevant properties from the old plot
+  newPlot->initFromPlot( oldPlot );
   Qgs2DXyPlot *newPlot2DXy = dynamic_cast<Qgs2DXyPlot *>( newPlot );
   if ( newPlot2DXy )
   {
-    Qgs2DXyPlot *oldPlot2DXy = dynamic_cast<Qgs2DXyPlot *>( mChartItem->plot() );
-    if ( oldPlot2DXy )
-    {
-      // Transfer a few basic details for a nicer UX
-      newPlot2DXy->setXMinimum( oldPlot2DXy->xMinimum() );
-      newPlot2DXy->setXMaximum( oldPlot2DXy->xMaximum() );
-      newPlot2DXy->setYMinimum( oldPlot2DXy->yMinimum() );
-      newPlot2DXy->setYMaximum( oldPlot2DXy->yMaximum() );
-
-      newPlot2DXy->xAxis().setType( oldPlot2DXy->xAxis().type() );
-      newPlot2DXy->xAxis().setGridIntervalMajor( oldPlot2DXy->xAxis().gridIntervalMajor() );
-      newPlot2DXy->xAxis().setGridIntervalMinor( oldPlot2DXy->xAxis().gridIntervalMinor() );
-      newPlot2DXy->xAxis().setLabelInterval( oldPlot2DXy->xAxis().labelInterval() );
-
-      newPlot2DXy->yAxis().setGridIntervalMajor( oldPlot2DXy->yAxis().gridIntervalMajor() );
-      newPlot2DXy->yAxis().setGridIntervalMinor( oldPlot2DXy->yAxis().gridIntervalMinor() );
-      newPlot2DXy->yAxis().setLabelInterval( oldPlot2DXy->yAxis().labelInterval() );
-    }
     mFlipAxesCheckBox->setEnabled( true );
     mFlipAxesCheckBox->setChecked( newPlot2DXy->flipAxes() );
   }

--- a/tests/src/python/test_qgsplot.py
+++ b/tests/src/python/test_qgsplot.py
@@ -21,10 +21,12 @@ from qgis.core import (
     QgsFontUtils,
     QgsLineChartPlot,
     QgsLineSymbol,
+    QgsMargins,
     QgsMarkerSymbol,
     QgsPalLayerSettings,
     QgsPieChartPlot,
     QgsPlot,
+    QgsPlotAxis,
     QgsPlotData,
     QgsPlotRenderContext,
     QgsPresetSchemeColorRamp,
@@ -1667,6 +1669,365 @@ class TestQgsPlot(QgisTestCase):
         assert self.image_check(
             "pie_chart_plot_value_labels", "pie_chart_plot_value_labels", im
         )
+
+    def test_copy_axis_properties(self):
+        source_axis = QgsPlotAxis()
+        source_axis.setType(Qgis.PlotAxisType.Categorical)
+        source_axis.setGridIntervalMajor(5)
+        source_axis.setGridIntervalMinor(1)
+        source_axis.setLabelInterval(2.5)
+        source_axis.setLabelSuffix("km")
+        source_axis.setLabelSuffixPlacement(Qgis.PlotAxisSuffixPlacement.LastLabel)
+
+        text_format = QgsTextFormat()
+        text_format.setSize(14)
+        text_format.setColor(QColor(255, 0, 0))
+        source_axis.setTextFormat(text_format)
+
+        number_format = QgsBasicNumericFormat()
+        number_format.setNumberDecimalPlaces(3)
+        number_format.setShowTrailingZeros(True)
+        source_axis.setNumericFormat(number_format)
+
+        major_grid_symbol = QgsLineSymbol.createSimple(
+            {"outline_color": "#112233", "outline_width": 2}
+        )
+        source_axis.setGridMajorSymbol(major_grid_symbol)
+
+        minor_grid_symbol = QgsLineSymbol.createSimple(
+            {"outline_color": "#33221", "outline_width": 0.75}
+        )
+        source_axis.setGridMinorSymbol(minor_grid_symbol)
+
+        dest_axis = QgsPlotAxis()
+        QgsPlotAxis.copyProperties(source_axis, dest_axis)
+
+        self.assertEqual(dest_axis.type(), source_axis.type())
+        self.assertEqual(dest_axis.gridIntervalMajor(), source_axis.gridIntervalMajor())
+        self.assertEqual(dest_axis.gridIntervalMinor(), source_axis.gridIntervalMinor())
+        self.assertEqual(dest_axis.labelInterval(), source_axis.labelInterval())
+        self.assertEqual(dest_axis.labelSuffix(), source_axis.labelSuffix())
+        self.assertEqual(
+            dest_axis.labelSuffixPlacement(), source_axis.labelSuffixPlacement()
+        )
+        self.assertAlmostEqual(
+            dest_axis.textFormat().size(), source_axis.textFormat().size()
+        )
+        self.assertEqual(
+            dest_axis.textFormat().color().name(),
+            source_axis.textFormat().color().name(),
+        )
+        self.assertEqual(
+            dest_axis.numericFormat().numberDecimalPlaces(),
+            source_axis.numericFormat().numberDecimalPlaces(),
+        )
+        self.assertTrue(dest_axis.numericFormat().showTrailingZeros())
+        self.assertEqual(
+            dest_axis.gridMajorSymbol().color().name(),
+            source_axis.gridMajorSymbol().color().name(),
+        )
+        self.assertEqual(
+            dest_axis.gridMinorSymbol().color().name(),
+            source_axis.gridMinorSymbol().color().name(),
+        )
+
+        source_axis.setLabelSuffix("miles")
+        source_axis.setGridIntervalMinor(99)
+        self.assertEqual(dest_axis.labelSuffix(), "km")
+        self.assertEqual(dest_axis.gridIntervalMinor(), 1)
+
+    def _create_2dxyplot(self, type="bar"):
+        """Creates a fully configured Qgs2DXyPlot plot (bar or line)"""
+        plot = None
+        if type == "bar":
+            plot = QgsBarChartPlot()
+        elif type == "line":
+            plot = QgsBarChartPlot()
+
+        plot.setSize(QSizeF(500, 400))
+        plot.setMargins(QgsMargins(2, 4, 6, 8))
+        plot.setXMinimum(-10)
+        plot.setXMaximum(10)
+        plot.setYMinimum(0)
+        plot.setYMaximum(100)
+        plot.setFlipAxes(True)
+
+        plot.xAxis().setType(Qgis.PlotAxisType.Interval)
+        plot.xAxis().setGridIntervalMajor(5)
+        plot.xAxis().setGridIntervalMinor(1)
+        plot.xAxis().setLabelInterval(5)
+        plot.xAxis().setLabelSuffix("m")
+        plot.xAxis().setLabelSuffixPlacement(Qgis.PlotAxisSuffixPlacement.LastLabel)
+
+        grid_major_symbol = QgsLineSymbol.createSimple(
+            {"outline_color": "#aaaaaa", "outline_width": 1}
+        )
+        plot.xAxis().setGridMajorSymbol(grid_major_symbol)
+        grid_minor_symbol = QgsLineSymbol.createSimple(
+            {"outline_color": "#bbbbbb", "outline_width": 0.5}
+        )
+        plot.xAxis().setGridMinorSymbol(grid_minor_symbol)
+        text_format = QgsTextFormat()
+        text_format.setColor(QColor(1, 2, 3))
+        plot.xAxis().setTextFormat(text_format)
+        number_format = QgsBasicNumericFormat()
+        number_format.setNumberDecimalPlaces(1)
+        plot.xAxis().setNumericFormat(number_format)
+
+        plot.yAxis().setGridIntervalMajor(20)
+        plot.yAxis().setGridIntervalMinor(10)
+        plot.yAxis().setLabelInterval(20)
+        plot.yAxis().setLabelSuffix("%")
+        grid_major_symbol = QgsLineSymbol.createSimple(
+            {"outline_color": "#cccccc", "outline_width": 1}
+        )
+        plot.yAxis().setGridMajorSymbol(grid_major_symbol)
+        grid_minor_symbol = QgsLineSymbol.createSimple(
+            {"outline_color": "#dddddd", "outline_width": 0.5}
+        )
+        plot.yAxis().setGridMinorSymbol(grid_minor_symbol)
+        text_format = QgsTextFormat()
+        text_format.setColor(QColor(4, 5, 6))
+        plot.yAxis().setTextFormat(text_format)
+
+        background_symbol = QgsFillSymbol.createSimple(
+            {"color": "#eeeeee", "outline_style": "no"}
+        )
+        plot.setChartBackgroundSymbol(background_symbol)
+        border_symbol = QgsFillSymbol.createSimple(
+            {
+                "outline_color": "#ffffff",
+                "style": "no",
+                "outline_style": "solid",
+                "outline_width": 1,
+            }
+        )
+        plot.setChartBorderSymbol(border_symbol)
+
+        plot.setDataDefinedProperty(
+            QgsPlot.DataDefinedProperty.YAxisMaximum, QgsProperty.fromValue(50.5)
+        )
+
+        return plot
+
+    def _create_2dplot(self):
+        """Creates a fully configured Qgs2DPlot (pie)"""
+        plot = QgsPieChartPlot()
+
+        plot.setSize(QSizeF(500, 400))
+        plot.setMargins(QgsMargins(2, 4, 6, 8))
+
+        text_format = QgsTextFormat()
+        text_format.setColor(QColor(3, 2, 1))
+        plot.setTextFormat(text_format)
+        number_format = QgsBasicNumericFormat()
+        number_format.setNumberDecimalPlaces(1)
+        plot.setNumericFormat(number_format)
+        plot.setLabelType(Qgis.PieChartLabelType.Categories)
+
+        plot.setDataDefinedProperty(
+            QgsPlot.DataDefinedProperty.MarginLeft, QgsProperty.fromValue(10.2)
+        )
+
+        return plot
+
+    def _check_2dplot_properties(self, new_plot, old_plot):
+        """Checks that Qgs2DPlot properties are copied from old_plot to new_plot"""
+        self.assertEqual(new_plot.size(), old_plot.size())
+        self.assertAlmostEqual(new_plot.margins().left(), old_plot.margins().left())
+        self.assertAlmostEqual(new_plot.margins().top(), old_plot.margins().top())
+        self.assertAlmostEqual(new_plot.margins().right(), old_plot.margins().right())
+        self.assertAlmostEqual(new_plot.margins().bottom(), old_plot.margins().bottom())
+
+        self.assertEqual(
+            new_plot.dataDefinedProperties().isActive(
+                QgsPlot.DataDefinedProperty.MarginLeft
+            ),
+            old_plot.dataDefinedProperties().isActive(
+                QgsPlot.DataDefinedProperty.MarginLeft
+            ),
+        )
+        self.assertEqual(
+            new_plot.dataDefinedProperties()
+            .property(QgsPlot.DataDefinedProperty.MarginLeft)
+            .staticValue(),
+            old_plot.dataDefinedProperties()
+            .property(QgsPlot.DataDefinedProperty.MarginLeft)
+            .staticValue(),
+        )
+
+    def _check_2dxyplot_properties(self, new_plot, old_plot):
+        """Checks that Qgs2DXyPlot properties are copied from old_plot to new_plot"""
+        self.assertEqual(new_plot.size(), old_plot.size())
+        self.assertEqual(new_plot.xMinimum(), old_plot.xMinimum())
+        self.assertEqual(new_plot.xMaximum(), old_plot.xMaximum())
+        self.assertEqual(new_plot.yMinimum(), old_plot.yMinimum())
+        self.assertEqual(new_plot.yMaximum(), old_plot.yMaximum())
+        self.assertTrue(new_plot.flipAxes(), old_plot.flipAxes())
+
+        self.assertEqual(new_plot.xAxis().type(), old_plot.xAxis().type())
+        self.assertEqual(
+            new_plot.xAxis().gridIntervalMajor(), old_plot.xAxis().gridIntervalMajor()
+        )
+        self.assertEqual(
+            new_plot.xAxis().gridIntervalMinor(), old_plot.xAxis().gridIntervalMinor()
+        )
+        self.assertEqual(
+            new_plot.xAxis().labelInterval(), old_plot.xAxis().labelInterval()
+        )
+        self.assertEqual(new_plot.xAxis().labelSuffix(), old_plot.xAxis().labelSuffix())
+        self.assertEqual(
+            new_plot.xAxis().labelSuffixPlacement(),
+            old_plot.xAxis().labelSuffixPlacement(),
+        )
+        self.assertEqual(
+            new_plot.xAxis().gridMajorSymbol().color().name(),
+            old_plot.xAxis().gridMajorSymbol().color().name(),
+        )
+        self.assertEqual(
+            new_plot.xAxis().gridMinorSymbol().color().name(),
+            old_plot.xAxis().gridMinorSymbol().color().name(),
+        )
+        self.assertEqual(
+            new_plot.xAxis().textFormat().color().name(),
+            old_plot.xAxis().textFormat().color().name(),
+        )
+        self.assertEqual(
+            new_plot.xAxis().numericFormat().numberDecimalPlaces(),
+            new_plot.xAxis().numericFormat().numberDecimalPlaces(),
+        )
+
+        self.assertEqual(
+            new_plot.yAxis().gridIntervalMajor(), old_plot.yAxis().gridIntervalMajor()
+        )
+        self.assertEqual(
+            new_plot.yAxis().gridIntervalMinor(), old_plot.yAxis().gridIntervalMinor()
+        )
+        self.assertEqual(
+            new_plot.yAxis().labelInterval(), old_plot.yAxis().labelInterval()
+        )
+        self.assertEqual(new_plot.yAxis().labelSuffix(), old_plot.yAxis().labelSuffix())
+        self.assertEqual(
+            new_plot.yAxis().labelSuffixPlacement(),
+            old_plot.yAxis().labelSuffixPlacement(),
+        )
+        self.assertEqual(
+            new_plot.yAxis().gridMajorSymbol().color().name(),
+            old_plot.yAxis().gridMajorSymbol().color().name(),
+        )
+        self.assertEqual(
+            new_plot.yAxis().gridMinorSymbol().color().name(),
+            old_plot.yAxis().gridMinorSymbol().color().name(),
+        )
+        self.assertEqual(
+            new_plot.yAxis().textFormat().color().name(),
+            old_plot.yAxis().textFormat().color().name(),
+        )
+        self.assertEqual(
+            new_plot.yAxis().numericFormat().numberDecimalPlaces(),
+            new_plot.yAxis().numericFormat().numberDecimalPlaces(),
+        )
+
+        self.assertEqual(
+            new_plot.chartBackgroundSymbol().color().name(),
+            old_plot.chartBackgroundSymbol().color().name(),
+        )
+        self.assertEqual(
+            new_plot.chartBorderSymbol().color().name(),
+            old_plot.chartBorderSymbol().color().name(),
+        )
+
+        self.assertEqual(
+            new_plot.dataDefinedProperties().isActive(
+                QgsPlot.DataDefinedProperty.YAxisMaximum
+            ),
+            old_plot.dataDefinedProperties().isActive(
+                QgsPlot.DataDefinedProperty.YAxisMaximum
+            ),
+        )
+        self.assertEqual(
+            new_plot.dataDefinedProperties()
+            .property(QgsPlot.DataDefinedProperty.YAxisMaximum)
+            .staticValue(),
+            old_plot.dataDefinedProperties()
+            .property(QgsPlot.DataDefinedProperty.YAxisMaximum)
+            .staticValue(),
+        )
+
+    def test_init_line_plot(self):
+        # from bar plot
+        bar_plot = self._create_2dxyplot("bar")
+
+        line_plot = QgsLineChartPlot()
+        line_plot.initFromPlot(bar_plot)
+        self._check_2dplot_properties(line_plot, bar_plot)
+        self._check_2dxyplot_properties(line_plot, bar_plot)
+
+        # from pie plot
+        pie_plot = self._create_2dplot()
+
+        line_plot = QgsLineChartPlot()
+        # store properties specific to line chart plot to confirm they won't be touched
+        x_axis_major_interval = line_plot.xAxis().gridIntervalMajor()
+        x_axis_text_format = line_plot.xAxis().textFormat()
+        y_axis_text_format = line_plot.yAxis().textFormat()
+
+        line_plot.initFromPlot(pie_plot)
+        self._check_2dplot_properties(line_plot, pie_plot)
+        self.assertEqual(line_plot.xAxis().gridIntervalMajor(), x_axis_major_interval)
+        self.assertEqual(
+            line_plot.xAxis().textFormat().color().name(),
+            x_axis_text_format.color().name(),
+        )
+        self.assertEqual(
+            line_plot.yAxis().textFormat().color().name(),
+            y_axis_text_format.color().name(),
+        )
+
+    def test_init_bar_plot(self):
+        # from line plot
+        line_plot = self._create_2dxyplot("line")
+
+        bar_plot = QgsBarChartPlot()
+        bar_plot.initFromPlot(line_plot)
+        self._check_2dplot_properties(bar_plot, line_plot)
+        self._check_2dxyplot_properties(bar_plot, line_plot)
+
+        # from pie plot
+        pie_plot = self._create_2dplot()
+
+        bar_plot = QgsBarChartPlot()
+        # store properties specific to line chart plot to confirm they won't be touched
+        x_axis_major_interval = bar_plot.xAxis().gridIntervalMajor()
+        x_axis_text_format = bar_plot.xAxis().textFormat()
+        y_axis_text_format = bar_plot.yAxis().textFormat()
+
+        bar_plot.initFromPlot(pie_plot)
+        self._check_2dplot_properties(bar_plot, pie_plot)
+        self.assertEqual(bar_plot.xAxis().gridIntervalMajor(), x_axis_major_interval)
+        self.assertEqual(
+            bar_plot.xAxis().textFormat().color().name(),
+            x_axis_text_format.color().name(),
+        )
+        self.assertEqual(
+            bar_plot.yAxis().textFormat().color().name(),
+            y_axis_text_format.color().name(),
+        )
+
+    def test_init_pie_plot(self):
+        # from bar plot
+        bar_plot = self._create_2dxyplot("bar")
+
+        pie_plot = QgsPieChartPlot()
+        pie_plot.initFromPlot(bar_plot)
+        self._check_2dplot_properties(pie_plot, bar_plot)
+
+        # from line plot
+        line_plot = self._create_2dxyplot("line")
+
+        pie_plot = QgsPieChartPlot()
+        pie_plot.initFromPlot(line_plot)
+        self._check_2dplot_properties(pie_plot, line_plot)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

When a chart item is added to layout, changed chart properties are lost when switching to another chart type even if the new chart type has the same set of properties (e.g. major/minor grid intervals, text and numeric formats, etc.). 

Fixes #63464.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.