### PR TITLE
Fix warning message NamedTemporaryFile not closed

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -357,7 +357,9 @@ class Editor(QgsCodeEditorPython):
         self.console_widget.show_editor_action.setChecked(False)
 
     def createTempFile(self):
-        name = tempfile.NamedTemporaryFile(delete=False).name
+        f = tempfile.NamedTemporaryFile(delete=False)
+        name = f.name
+        f.close()
         # Need to use newline='' to avoid adding extra \r characters on Windows
         with open(name, "w", encoding="utf-8", newline="") as f:
             f.write(self.text())

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -357,12 +357,12 @@ class Editor(QgsCodeEditorPython):
         self.console_widget.show_editor_action.setChecked(False)
 
     def createTempFile(self):
-        f = tempfile.NamedTemporaryFile(delete=False)
-        name = f.name
-        f.close()
         # Need to use newline='' to avoid adding extra \r characters on Windows
-        with open(name, "w", encoding="utf-8", newline="") as f:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", newline="", delete=False
+        ) as f:
             f.write(self.text())
+            name = f.name
         return name
 
     def runScriptCode(self):

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -215,7 +215,10 @@ class PythonInterpreter(QgsCodeInterpreter, code.InteractiveInterpreter):
                 res = (self.sub_process.stdout + self.sub_process.stderr).strip()
 
                 # Use a temporary file to communicate the result to the inner interpreter
-                tmp = Path(NamedTemporaryFile(delete=False).name)
+                f = NamedTemporaryFile(delete=False)
+                name = f.name
+                f.close()
+                tmp = Path(name)
                 tmp.write_text(res, encoding="utf-8")
                 self.runsource(
                     f'{varname} = Path("{tmp}").read_text(encoding="utf-8").split("\\n")'

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -215,11 +215,10 @@ class PythonInterpreter(QgsCodeInterpreter, code.InteractiveInterpreter):
                 res = (self.sub_process.stdout + self.sub_process.stderr).strip()
 
                 # Use a temporary file to communicate the result to the inner interpreter
-                f = NamedTemporaryFile(delete=False)
-                name = f.name
-                f.close()
+                with NamedTemporaryFile(encoding="utf-8", mode="w", delete=False) as f:
+                    name = f.name
+                    f.write(res)
                 tmp = Path(name)
-                tmp.write_text(res, encoding="utf-8")
                 self.runsource(
                     f'{varname} = Path("{tmp}").read_text(encoding="utf-8").split("\\n")'
                 )


### PR DESCRIPTION
After experimenting with some Python code using the Python console in QGIS, I noticed a bunch of warnings in the terminal window after running the code.


```
buildDebug/python/core/build/_core/sip_corepart24.cpp:44342 : (meth_QgsMessageLog_logMessage) [102313ms] 2026-03-04T18:31:37 Python warning[1] warning:/usr/lib64/python3.14/tempfile.py:484: ResourceWarning: Implicitly cleaning up <_TemporaryFileWrapper file=<_io.BufferedRandom name='/tmp/tmpex570qow'>>
  _warnings.warn(self.warn_message, ResourceWarning)

traceback:  File "/home/viperminiq/dev/QGISbuilds/add-elevation-profile-vpc-test/buildDebug/output/python/console/console.py", line 643, in runScriptEditor
    self.tabEditorWidget.currentWidget().runScriptCode()
  File "/home/viperminiq/dev/QGISbuilds/add-elevation-profile-vpc-test/buildDebug/output/python/console/console_editor.py", line 384, in runScriptCode
    filename = self.createTempFile()
  File "/home/viperminiq/dev/QGISbuilds/add-elevation-profile-vpc-test/buildDebug/output/python/console/console_editor.py", line 360, in createTempFile
    name = tempfile.NamedTemporaryFile(delete=False).name
  File "/usr/lib64/python3.14/tempfile.py", line 484, in __del__
    _warnings.warn(self.warn_message, ResourceWarning)
```

To prevent the warnings, we close `NamedTemporaryFile` after getting the filename.