### PR TITLE
Adding "Field Calculator" menu item to the attribute table header

### DIFF
--- a/python/PyQt6/gui/auto_generated/vector/qgsfieldcalculator.sip.in
+++ b/python/PyQt6/gui/auto_generated/vector/qgsfieldcalculator.sip.in
@@ -31,7 +31,17 @@ Sample usage of the :py:class:`QgsFieldCalculator` class:
 #include "qgsfieldcalculator.h"
 %End
   public:
-    QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = 0 );
+    QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = 0, int fieldIndex = -1 );
+%Docstring
+Constructor for QgsFieldCalculator, with the specified ``parent``
+widget.
+
+The target layer must be specified using the ``vl`` argument.
+
+Since QGIS 4.2, the optional ``fieldIndex`` argument can be used to
+automatically select the existing field with the specified index in the
+dialog.
+%End
 
     int changedAttributeId() const;
 %Docstring

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -1018,22 +1018,44 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
 
   mConfig.update( mLayer->fields() );
   // get layer field index from column name
-  const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( mConfig.mapVisibleColumnToIndex( col ) ).name );
+  int fieldIndex = -1;
+  if ( col != -1 )
+    fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( mConfig.mapVisibleColumnToIndex( col ) ).name );
   const Qgis::FieldOrigin fieldOrigin = mLayer->fields().fieldOrigin( fieldIndex );
 
   mHorizontalHeaderMenu->addSeparator();
+
+  const QgsVectorLayer *vl = mFilterModel->layer();
+  const QgsVectorDataProvider *dataProvider = vl->dataProvider();
+  const Qgis::VectorProviderCapabilities caps = dataProvider->capabilities();
+  const bool layerIsReadOnly { vl->readOnly() };
+  const bool canChangeAttributeValue = !layerIsReadOnly && ( caps & Qgis::VectorProviderCapability::ChangeAttributeValues );
+
   bool fieldCalculatorEnabled = false;
 
-  if ( fieldOrigin == Qgis::FieldOrigin::Provider || fieldOrigin == Qgis::FieldOrigin::Edit )
-    fieldCalculatorEnabled = true;
-
-  if ( fieldOrigin == Qgis::FieldOrigin::Join )
+  switch ( fieldOrigin )
   {
-    int srcFieldIndex;
-    const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
-
-    if ( info && info->isEditable() )
-      fieldCalculatorEnabled = true;
+    case Qgis::FieldOrigin::Provider:
+    case Qgis::FieldOrigin::Edit:
+      fieldCalculatorEnabled = canChangeAttributeValue;
+      break;
+    case Qgis::FieldOrigin::Join:
+    {
+      int srcFieldIndex;
+      const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
+      const QgsVectorLayer *joinedLayer = info->joinLayer();
+      const Qgis::VectorProviderCapabilities joinedCaps = dataProvider->capabilities();
+      const bool joinedLayerIsReadOnly { joinedLayer->readOnly() };
+      const bool joinedLayerCanChangeAttributeValue = !joinedLayerIsReadOnly && ( joinedCaps & Qgis::VectorProviderCapability::ChangeAttributeValues );
+      if ( info && info->isEditable() )
+        fieldCalculatorEnabled = joinedLayerCanChangeAttributeValue;
+      break;
+    }
+    case Qgis::FieldOrigin::Unknown:
+    case Qgis::FieldOrigin::Expression:
+      break;
+    default:
+      break;
   }
 
   QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator…" ), mHorizontalHeaderMenu );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -1044,7 +1044,8 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
       int srcFieldIndex;
       const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
       const QgsVectorLayer *joinedLayer = info->joinLayer();
-      const Qgis::VectorProviderCapabilities joinedCaps = dataProvider->capabilities();
+      const QgsVectorDataProvider *joinedDataProvider = joinedLayer->dataProvider();
+      const Qgis::VectorProviderCapabilities joinedCaps = joinedDataProvider->capabilities();
       const bool joinedLayerIsReadOnly { joinedLayer->readOnly() };
       const bool joinedLayerCanChangeAttributeValue = !joinedLayerIsReadOnly && ( joinedCaps & Qgis::VectorProviderCapability::ChangeAttributeValues );
       if ( info && info->isEditable() )

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -23,6 +23,7 @@
 #include "qgsexpressionbuilderdialog.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeaturelistmodel.h"
+#include "qgsfieldcalculator.h"
 #include "qgsfieldconditionalformatwidget.h"
 #include "qgsgui.h"
 #include "qgsifeatureselectionmanager.h"
@@ -37,6 +38,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayercache.h"
 #include "qgsvectorlayereditbuffer.h"
+#include "qgsvectorlayerjoinbuffer.h"
 
 #include <QClipboard>
 #include <QDialog>
@@ -1014,6 +1016,33 @@ void QgsDualView::showViewHeaderMenu( QPoint point )
   connect( sort, &QAction::triggered, this, [this]() { modifySort(); } );
   mHorizontalHeaderMenu->addAction( sort );
 
+  mConfig.update( mLayer->fields() );
+  // get layer field index from column name
+  const int fieldIndex = mLayer->fields().indexFromName( mConfig.columns().at( mConfig.mapVisibleColumnToIndex( col ) ).name );
+  const Qgis::FieldOrigin fieldOrigin = mLayer->fields().fieldOrigin( fieldIndex );
+
+  mHorizontalHeaderMenu->addSeparator();
+  bool fieldCalculatorEnabled = false;
+
+  if ( fieldOrigin == Qgis::FieldOrigin::Provider || fieldOrigin == Qgis::FieldOrigin::Edit )
+    fieldCalculatorEnabled = true;
+
+  if ( fieldOrigin == Qgis::FieldOrigin::Join )
+  {
+    int srcFieldIndex;
+    const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
+
+    if ( info && info->isEditable() )
+      fieldCalculatorEnabled = true;
+  }
+
+  QAction *fieldCalculator = new QAction( tr( "Open &Field Calculator…" ), mHorizontalHeaderMenu );
+  connect( fieldCalculator, &QAction::triggered, this, &QgsDualView::fieldCalculator );
+  fieldCalculator->setData( fieldIndex );
+  mHorizontalHeaderMenu->addAction( fieldCalculator );
+
+  fieldCalculator->setEnabled( fieldCalculatorEnabled );
+
   mHorizontalHeaderMenu->popup( mTableView->horizontalHeader()->mapToGlobal( point ) );
 }
 
@@ -1053,6 +1082,21 @@ void QgsDualView::hideColumn()
   {
     config.setColumnHidden( sourceCol, true );
     setAttributeTableConfig( config );
+  }
+}
+
+void QgsDualView::fieldCalculator()
+{
+  QAction *action = qobject_cast<QAction *>( sender() );
+  const int fieldIndex = action->data().toInt();
+  mConfig.update( mLayer->fields() );
+  QgsFieldCalculator calc( mLayer, this, fieldIndex );
+  if ( calc.exec() == QDialog::Accepted )
+  {
+    int col = mMasterModel->fieldCol( calc.changedAttributeId() );
+
+    if ( col >= 0 )
+      mMasterModel->reload( mMasterModel->index( 0, col ), mMasterModel->index( mMasterModel->rowCount() - 1, col ) );
   }
 }
 

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -351,6 +351,8 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     void hideColumn();
 
+    void fieldCalculator();
+
     void resizeColumn();
 
     void resizeAllColumns();

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -137,15 +137,9 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent, con
     mUpdateExistingGroupBox->setCheckable( false );
   }
 
-  if ( fieldIndex != -1 )
-  {
-    mNewFieldGroupBox->setEnabled( false );
-    mUpdateExistingGroupBox->setEnabled( true );
-  }
-
   if ( mUpdateExistingGroupBox->isEnabled() )
   {
-    mUpdateExistingGroupBox->setChecked( !mNewFieldGroupBox->isEnabled() );
+    mUpdateExistingGroupBox->setChecked( !mNewFieldGroupBox->isEnabled() || ( mUpdateExistingGroupBox->isEnabled() && fieldIndex != -1 ) );
   }
   else
   {

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -48,7 +48,7 @@ constexpr int FTC_MINPREC_IDX = 4;
 constexpr int FTC_MAXPREC_IDX = 5;
 constexpr int FTC_SUBTYPE_IDX = 6;
 
-QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
+QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent, const int fieldIndex )
   : QDialog( parent )
   , mVectorLayer( vl )
   , mAttributeId( -1 )
@@ -79,7 +79,7 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
   expContext.lastScope()->addVariable( QgsExpressionContextScope::StaticVariable( u"row_number"_s, 1, true ) );
   expContext.setHighlightedVariables( QStringList() << u"row_number"_s );
 
-  populateFields();
+  populateFields( fieldIndex );
   populateOutputFieldTypes();
 
   connect( builder, &QgsExpressionBuilderWidget::expressionParsed, this, &QgsFieldCalculator::setDialogButtonState );
@@ -135,6 +135,12 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
     mNewFieldGroupBox->setToolTip( tr( "Not available for layer" ) );
     mUpdateExistingGroupBox->setChecked( true );
     mUpdateExistingGroupBox->setCheckable( false );
+  }
+
+  if ( fieldIndex != -1 )
+  {
+    mNewFieldGroupBox->setEnabled( false );
+    mUpdateExistingGroupBox->setEnabled( true );
   }
 
   if ( mUpdateExistingGroupBox->isEnabled() )
@@ -524,7 +530,7 @@ void QgsFieldCalculator::mExistingFieldComboBox_currentIndexChanged( const int i
   setDialogButtonState();
 }
 
-void QgsFieldCalculator::populateFields()
+void QgsFieldCalculator::populateFields( int fieldIndex )
 {
   if ( !mVectorLayer )
     return;
@@ -576,7 +582,7 @@ void QgsFieldCalculator::populateFields()
     font.setItalic( true );
     mExistingFieldComboBox->setItemData( mExistingFieldComboBox->count() - 1, font, Qt::FontRole );
   }
-  mExistingFieldComboBox->setCurrentIndex( -1 );
+  mExistingFieldComboBox->setCurrentIndex( fieldIndex );
 }
 
 void QgsFieldCalculator::setDialogButtonState()

--- a/src/gui/vector/qgsfieldcalculator.h
+++ b/src/gui/vector/qgsfieldcalculator.h
@@ -45,7 +45,15 @@ class GUI_EXPORT QgsFieldCalculator : public QDialog, private Ui::QgsFieldCalcul
 {
     Q_OBJECT
   public:
-    QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = nullptr );
+    /**
+     * Constructor for QgsFieldCalculator, with the specified \a parent widget.
+     *
+     * The target layer must be specified using the \a vl argument.
+     *
+     * Since QGIS 4.2, the optional \a fieldIndex argument can be used to automatically
+     * select the existing field with the specified index in the dialog.
+     */
+    QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent = nullptr, int fieldIndex = -1 );
 
     /**
      * \brief Returns the field index of the field for which new attribute values were calculated.
@@ -77,7 +85,7 @@ class GUI_EXPORT QgsFieldCalculator : public QDialog, private Ui::QgsFieldCalcul
     //! default constructor forbidden
     QgsFieldCalculator();
     //! Inserts existing fields into the combo box
-    void populateFields();
+    void populateFields( int fieldIndex );
     //! Inserts the types supported by the provider into the combo box
     void populateOutputFieldTypes();
 


### PR DESCRIPTION
## Description

Added a new "Field Calculator" menu item in the popup appearing when right clicking in the header of a column in a vector layer's attribute table. The Field Calculator window opens having the "Update existing field" checkbox checked and the corresponding field already selected in the combo box.

