### PR TITLE
remove backward compatibility settings migration code

### DIFF
--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -53,6 +53,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   // copy values from old keys to new keys and delete the old ones
   // for backward compatibility, old keys are recreated when the registry gets deleted
 
+  // TODO: remove in QGIS 4.4 (after LTR 4.2)
+
   // single settings - added in 3.30
   QgsIdentifyResultsDialog::settingHideNullValues->copyValueFromKey( u"Map/hideNullValues"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
@@ -65,15 +67,4 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
 }
 
 QgsSettingsRegistryApp::~QgsSettingsRegistryApp()
-{
-  // TODO QGIS 5.0: Remove
-  // backward compatibility for settings
-  QgsIdentifyResultsDialog::settingHideNullValues->copyValueToKeyIfChanged( u"Map/hideNullValues"_s );
-  QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueToKeyIfChanged( u"plugins/automatically-check-for-updates"_s );
-  QgsPluginManager::settingsAllowExperimental->copyValueToKeyIfChanged( u"app/plugin_installer/allowExperimental"_s );
-  QgsPluginManager::settingsAllowDeprecated->copyValueToKeyIfChanged( u"app/plugin_installer/allowDeprecated"_s );
-  QgsPluginManager::settingsCheckOnStartLastDate->copyValueFromKey( u"app/plugin_installer/checkOnStartLastDate"_s, true );
-  QgsPluginManager::settingsSeenPlugins->copyValueFromKey( u"app/plugin_installer/seen_plugins"_s, true );
-  QgsPluginManager::settingsLastZipDirectory->copyValueFromKey( u"app/plugin_installer/lastZipDirectory"_s, true );
-  QgsPluginManager::settingsShowInstallFromZipWarning->copyValueFromKey( u"app/plugin_installer/showInstallFromZipWarning"_s, true );
-}
+{}

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -172,21 +172,23 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   // copy values from old keys to new keys and delete the old ones
   // for backward compatibility, old keys are recreated when the registry gets deleted
 
+  // TODO: remove in QGIS 4.4 (after LTR 4.2)
+
   // single settings - added in 3.30
-  QgsLayout::settingsSearchPathForTemplates->copyValueFromKey( u"core/Layout/searchPathsForTemplates"_s );
+  QgsLayout::settingsSearchPathForTemplates->copyValueFromKey( u"core/Layout/searchPathsForTemplates"_s, true );
 
-  QgsProcessing::settingsPreferFilenameAsLayerName->copyValueFromKey( u"Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME"_s );
-  QgsProcessing::settingsTempPath->copyValueFromKey( u"Processing/Configuration/TEMP_PATH2"_s );
+  QgsProcessing::settingsPreferFilenameAsLayerName->copyValueFromKey( u"Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME"_s, true );
+  QgsProcessing::settingsTempPath->copyValueFromKey( u"Processing/Configuration/TEMP_PATH2"_s, true );
 
-  QgsNetworkAccessManager::settingsNetworkTimeout->copyValueFromKey( u"qgis/networkAndProxy/networkTimeout"_s );
+  QgsNetworkAccessManager::settingsNetworkTimeout->copyValueFromKey( u"qgis/networkAndProxy/networkTimeout"_s, true );
 
-  settingsLayerTreeShowFeatureCountForNewLayers->copyValueFromKey( u"core/layer-tree/show_feature_count_for_new_layers"_s );
+  settingsLayerTreeShowFeatureCountForNewLayers->copyValueFromKey( u"core/layer-tree/show_feature_count_for_new_layers"_s, true );
 
 #if defined( HAVE_QTSERIALPORT )
-  QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( u"core/gps/stop_bits"_s );
-  QgsGpsDetector::settingsGpsFlowControl->copyValueFromKey( u"core/gps/flow_control"_s );
-  QgsGpsDetector::settingsGpsDataBits->copyValueFromKey( u"core/gps/data_bits"_s );
-  QgsGpsDetector::settingsGpsParity->copyValueFromKey( u"core/gps/parity"_s );
+  QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( u"core/gps/stop_bits"_s, true );
+  QgsGpsDetector::settingsGpsFlowControl->copyValueFromKey( u"core/gps/flow_control"_s, true );
+  QgsGpsDetector::settingsGpsDataBits->copyValueFromKey( u"core/gps/data_bits"_s, true );
+  QgsGpsDetector::settingsGpsParity->copyValueFromKey( u"core/gps/parity"_s, true );
 #endif
 
   QgsRasterLayer::settingsRasterDefaultOversampling->copyValueFromKey( u"Raster/defaultOversampling"_s, true );
@@ -196,46 +198,10 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   pal::Pal::settingsRenderingLabelCandidatesLimitLines->copyValueFromKey( u"core/rendering/label_candidates_limit_lines"_s, true );
   pal::Pal::settingsRenderingLabelCandidatesLimitPolygons->copyValueFromKey( u"core/rendering/label_candidates_limit_polygons"_s, true );
 
-  // handle bad migration - Fix profiles for old QGIS versions (restore the Map/scales key on windows)
-  // TODO: Remove this from QGIS 3.36
-  // PR Link: https://github.com/qgis/QGIS/pull/52580
-  if ( settings->contains( u"Map/scales"_s ) )
-  {
-    const QStringList oldScales = settings->value( u"Map/scales"_s ).toStringList();
-    if ( !oldScales.isEmpty() && !oldScales.at( 0 ).isEmpty() )
-      settings->setValue( u"Map/scales"_s, oldScales.join( ',' ) );
-    else
-      settings->setValue( u"Map/scales"_s, Qgis::defaultProjectScales() );
-  }
-
-  // migrate only one way for map scales
-  if ( !settingsMapScales->exists() )
-  {
-    // Handle bad migration. Prefer map/scales over Map/scales
-    // TODO: Discard this part starting from QGIS 3.36
-    const QStringList oldScales = settings->value( u"map/scales"_s ).toStringList();
-    if ( !oldScales.isEmpty() && !oldScales.at( 0 ).isEmpty() )
-    {
-      // If migration has failed before (QGIS < 3.30.2), all scales might be
-      // concatenated in the first element of the list
-      QStringList actualScales;
-      for ( const QString &element : oldScales )
-      {
-        actualScales << element.split( "," );
-      }
-      settingsMapScales->setValue( actualScales );
-    }
-    // TODO: keep only this part of the migration starting from QGIS 3.36
-    else if ( settings->contains( u"Map/scales"_s ) )
-    {
-      settingsMapScales->setValue( settings->value( u"Map/scales"_s ).toString().split( ',' ) );
-    }
-  }
-
   // digitizing settings - added in 3.30
   {
-    settingsDigitizingLineColor->copyValueFromKeys( u"qgis/digitizing/line_color_red"_s, u"qgis/digitizing/line_color_green"_s, u"qgis/digitizing/line_color_blue"_s, u"qgis/digitizing/line_color_alpha"_s );
-    settingsDigitizingFillColor->copyValueFromKeys( u"qgis/digitizing/fill_color_red"_s, u"qgis/digitizing/fill_color_green"_s, u"qgis/digitizing/fill_color_blue"_s, u"qgis/digitizing/fill_color_alpha"_s );
+    settingsDigitizingLineColor->copyValueFromKeys( u"qgis/digitizing/line_color_red"_s, u"qgis/digitizing/line_color_green"_s, u"qgis/digitizing/line_color_blue"_s, u"qgis/digitizing/line_color_alpha"_s, true );
+    settingsDigitizingFillColor->copyValueFromKeys( u"qgis/digitizing/fill_color_red"_s, u"qgis/digitizing/fill_color_green"_s, u"qgis/digitizing/fill_color_blue"_s, u"qgis/digitizing/fill_color_alpha"_s, true );
 
     const QList<const QgsSettingsEntryBase *> settings = QgsSettingsTree::sTreeDigitizing->childrenSettings();
     for ( const QgsSettingsEntryBase *setting : settings )
@@ -251,7 +217,7 @@ void QgsSettingsRegistryCore::migrateOldSettings()
       {
         name.replace( '-', '_' );
       }
-      setting->copyValueFromKey( QString( "qgis/digitizing/%1" ).arg( name ) );
+      setting->copyValueFromKey( QString( "qgis/digitizing/%1" ).arg( name ), true );
     }
   }
 
@@ -421,218 +387,5 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   QgsSettings::releaseFlush();
 }
 
-// TODO QGIS 5.0: Remove
 void QgsSettingsRegistryCore::backwardCompatibility()
-{
-  // This method triggers a ton of QgsSettings constructions and destructions, which is very expensive
-  // as it involves writing new values to the underlying ini files.
-  // Accordingly we place a hold on constructing new QgsSettings objects for the duration of the method,
-  // so that only a single QgsSettings object is created and destroyed at the end of this method.
-  QgsSettings::holdFlush();
-  auto settings = QgsSettings::get();
-
-  // CAREFUL! There's a mix of copyValueToKeyIfChanged and copyValueToKey used here.
-  // copyValueToKeyIfChanged should be used if copyValueFromKey did NOT have the removeSettingAtKey argument set to True
-  // in migrateOldSettings
-
-  // single settings - added in 3.30
-  QgsLayout::settingsSearchPathForTemplates->copyValueToKeyIfChanged( u"core/Layout/searchPathsForTemplates"_s );
-
-  QgsProcessing::settingsPreferFilenameAsLayerName->copyValueToKeyIfChanged( u"Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME"_s );
-  QgsProcessing::settingsTempPath->copyValueToKeyIfChanged( u"Processing/Configuration/TEMP_PATH2"_s );
-
-  QgsNetworkAccessManager::settingsNetworkTimeout->copyValueToKeyIfChanged( u"qgis/networkAndProxy/networkTimeout"_s );
-
-  settingsLayerTreeShowFeatureCountForNewLayers->copyValueToKeyIfChanged( u"core/layer-tree/show_feature_count_for_new_layers"_s );
-
-#if defined( HAVE_QTSERIALPORT )
-  QgsGpsDetector::settingsGpsStopBits->copyValueToKeyIfChanged( u"core/gps/stop_bits"_s );
-  QgsGpsDetector::settingsGpsFlowControl->copyValueToKeyIfChanged( u"core/gps/flow_control"_s );
-  QgsGpsDetector::settingsGpsDataBits->copyValueToKeyIfChanged( u"core/gps/data_bits"_s );
-  QgsGpsDetector::settingsGpsParity->copyValueToKeyIfChanged( u"core/gps/parity"_s );
-#endif
-
-  QgsRasterLayer::settingsRasterDefaultOversampling->copyValueToKey( u"Raster/defaultOversampling"_s );
-  QgsRasterLayer::settingsRasterDefaultEarlyResampling->copyValueToKey( u"Raster/defaultEarlyResampling"_s );
-
-  pal::Pal::settingsRenderingLabelCandidatesLimitPoints->copyValueToKey( u"core/rendering/label_candidates_limit_points"_s );
-  pal::Pal::settingsRenderingLabelCandidatesLimitLines->copyValueToKey( u"core/rendering/label_candidates_limit_lines"_s );
-  pal::Pal::settingsRenderingLabelCandidatesLimitPolygons->copyValueToKey( u"core/rendering/label_candidates_limit_polygons"_s );
-
-  // digitizing settings - added in 3.30
-  {
-    if ( settingsDigitizingLineColor->hasChanged() )
-      settingsDigitizingLineColor->copyValueToKeys( u"qgis/digitizing/line_color_red"_s, u"qgis/digitizing/line_color_green"_s, u"qgis/digitizing/line_color_blue"_s, u"qgis/digitizing/line_color_alpha"_s );
-    if ( settingsDigitizingFillColor->hasChanged() )
-      settingsDigitizingFillColor->copyValueToKeys( u"qgis/digitizing/fill_color_red"_s, u"qgis/digitizing/fill_color_green"_s, u"qgis/digitizing/fill_color_blue"_s, u"qgis/digitizing/fill_color_alpha"_s );
-
-    const QList<const QgsSettingsEntryBase *> settings = QgsSettingsTree::sTreeDigitizing->childrenSettings();
-    for ( const QgsSettingsEntryBase *setting : settings )
-    {
-      QString name = setting->name();
-      if ( name == settingsDigitizingLineColor->name() || name == settingsDigitizingFillColor->name() )
-        continue;
-      if ( name == settingsDigitizingReuseLastValues->name() )
-      {
-        name = u"reuseLastValues"_s;
-      }
-      else
-      {
-        name.replace( '-', '_' );
-      }
-      setting->copyValueToKeyIfChanged( QString( "qgis/digitizing/%1" ).arg( name ) );
-    }
-  }
-
-  // locator filters - added in 3.30
-  {
-    const QStringList filters = QgsLocator::sTreeLocatorFilters->items();
-    for ( const QString &filter : filters )
-    {
-      QgsLocator::settingsLocatorFilterEnabled->copyValueToKey( u"gui/locator_filters/enabled_%1"_s, { filter } );
-      QgsLocator::settingsLocatorFilterDefault->copyValueToKey( u"gui/locator_filters/default_%1"_s, { filter } );
-      QgsLocator::settingsLocatorFilterPrefix->copyValueToKey( u"gui/locator_filters/prefix_%1"_s, { filter } );
-    }
-  }
-
-  // OWS connections settings - added in 3.30
-  {
-    const QStringList services = { u"WMS"_s, u"WFS"_s, u"WCS"_s };
-    for ( const QString &service : services )
-    {
-      const QStringList connections = QgsOwsConnection::sTreeOwsConnections->items( { service.toLower() } );
-      if ( connections.count() == 0 )
-        continue;
-
-      for ( const QString &connection : connections )
-      {
-        QgsOwsConnection::settingsUrl->copyValueToKey( u"qgis/connections-%1/%2/url"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsVersion->copyValueToKey( u"qgis/connections-%1/%2/version"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsIgnoreGetMapURI->copyValueToKey( u"qgis/connections-%1/%2/ignoreGetMapURI"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsIgnoreGetFeatureInfoURI->copyValueToKey( u"qgis/connections-%1/%2/ignoreGetFeatureInfoURI"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsSmoothPixmapTransform->copyValueToKey( u"qgis/connections-%1/%2/smoothPixmapTransform"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsReportedLayerExtents->copyValueToKey( u"qgis/connections-%1/%2/reportedLayerExtents"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsDpiMode->copyValueToKey( u"qgis/connections-%1/%2/dpiMode"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsTilePixelRatio->copyValueToKey( u"qgis/connections-%1/%2/tilePixelRatio"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsMaxNumFeatures->copyValueToKey( u"qgis/connections-%1/%2/maxnumfeatures"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsPagesize->copyValueToKey( u"qgis/connections-%1/%2/pagesize"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsPagingEnabled->copyValueToKey( u"qgis/connections-%1/%2/pagingenabled"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsPreferCoordinatesForWfsT11->copyValueToKey( u"qgis/connections-%1/%2/preferCoordinatesForWfsT11"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsIgnoreAxisOrientation->copyValueToKey( u"qgis/connections-%1/%2/ignoreAxisOrientation"_s, { service.toLower(), connection } );
-        QgsOwsConnection::settingsInvertAxisOrientation->copyValueToKey( u"qgis/connections-%1/%2/invertAxisOrientation"_s, { service.toLower(), connection } );
-
-        if ( QgsOwsConnection::settingsHeaders->exists( { service.toLower(), connection } ) )
-        {
-          Q_NOWARN_DEPRECATED_PUSH
-          const QgsHttpHeaders headers = QgsHttpHeaders( QgsOwsConnection::settingsHeaders->value( { service.toLower(), connection } ) );
-          settings->beginGroup( u"qgis/connections-%1/%2"_s.arg( service.toLower(), connection ) );
-          headers.updateSettings( *settings );
-          settings->endGroup();
-          Q_NOWARN_DEPRECATED_POP
-        }
-
-        QgsOwsConnection::settingsUsername->copyValueToKey( u"qgis/connections/%1/%2/username"_s.arg( service, connection ), { service.toLower(), connection } );
-        QgsOwsConnection::settingsPassword->copyValueToKey( u"qgis/connections/%1/%2/password"_s.arg( service, connection ), { service.toLower(), connection } );
-        QgsOwsConnection::settingsAuthCfg->copyValueToKey( u"qgis/connections/%1/%2/authcfg"_s.arg( service, connection ), { service.toLower(), connection } );
-      }
-    }
-  }
-
-  // Vector tile - added in 3.30
-  {
-    const QStringList connections = QgsVectorTileProviderConnection::sTreeConnectionVectorTile->items();
-
-    for ( const QString &connection : connections )
-    {
-      // do not overwrite already set setting
-      QgsVectorTileProviderConnection::settingsUrl->copyValueToKey( u"qgis/connections-vector-tile/%1/url"_s, { connection } );
-      QgsVectorTileProviderConnection::settingsZmin->copyValueToKey( u"qgis/connections-vector-tile/%1/zmin"_s, { connection } );
-      QgsVectorTileProviderConnection::settingsZmax->copyValueToKey( u"qgis/connections-vector-tile/%1/zmax"_s, { connection } );
-      QgsVectorTileProviderConnection::settingsAuthcfg->copyValueToKey( u"qgis/connections-vector-tile/%1/authcfg"_s, { connection } );
-      QgsVectorTileProviderConnection::settingsUsername->copyValueToKey( u"qgis/connections-vector-tile/%1/username"_s, { connection } );
-      QgsVectorTileProviderConnection::settingsPassword->copyValueToKey( u"qgis/connections-vector-tile/%1/password"_s, { connection } );
-      QgsVectorTileProviderConnection::settingsStyleUrl->copyValueToKey( u"qgis/connections-vector-tile/%1/styleUrl"_s, { connection } );
-      QgsVectorTileProviderConnection::settingsServiceType->copyValueToKey( u"qgis/connections-vector-tile/%1/serviceType"_s, { connection } );
-
-      if ( QgsVectorTileProviderConnection::settingsHeaders->exists( connection ) )
-      {
-        Q_NOWARN_DEPRECATED_PUSH const QgsHttpHeaders headers = QgsHttpHeaders( QgsVectorTileProviderConnection::settingsHeaders->value( connection ) );
-        settings->beginGroup( u"qgis/connections-vector-tile/%1"_s.arg( connection ) );
-        headers.updateSettings( *settings );
-        settings->endGroup();
-        Q_NOWARN_DEPRECATED_POP
-      }
-    }
-  }
-
-  // xyz - added in 3.30
-  {
-    const QStringList connections = QgsXyzConnectionSettings::sTreeXyzConnections->items();
-    for ( const QString &connection : connections )
-    {
-      QgsXyzConnectionSettings::settingsUrl->copyValueToKey( u"qgis/connections-xyz/%1/url"_s, { connection } );
-      QgsXyzConnectionSettings::settingsZmin->copyValueToKey( u"qgis/connections-xyz/%1/zmin"_s, { connection } );
-      QgsXyzConnectionSettings::settingsZmax->copyValueToKey( u"qgis/connections-xyz/%1/zmax"_s, { connection } );
-      QgsXyzConnectionSettings::settingsAuthcfg->copyValueToKey( u"qgis/connections-xyz/%1/authcfg"_s, { connection } );
-      QgsXyzConnectionSettings::settingsUsername->copyValueToKey( u"qgis/connections-xyz/%1/username"_s, { connection } );
-      QgsXyzConnectionSettings::settingsPassword->copyValueToKey( u"qgis/connections-xyz/%1/password"_s, { connection } );
-      QgsXyzConnectionSettings::settingsTilePixelRatio->copyValueToKey( u"qgis/connections-xyz/%1/tilePixelRatio"_s, { connection } );
-      QgsXyzConnectionSettings::settingsHidden->copyValueToKey( u"qgis/connections-xyz/%1/hidden"_s, { connection } );
-      QgsXyzConnectionSettings::settingsInterpretation->copyValueToKey( u"qgis/connections-xyz/%1/interpretation"_s, { connection } );
-
-      if ( QgsXyzConnectionSettings::settingsHeaders->exists( connection ) )
-      {
-        Q_NOWARN_DEPRECATED_PUSH
-        const QgsHttpHeaders headers = QgsHttpHeaders( QgsXyzConnectionSettings::settingsHeaders->value( connection ) );
-        settings->beginGroup( u"qgis/connections-xyz/%1"_s.arg( connection ) );
-        headers.updateSettings( *settings );
-        settings->endGroup();
-        Q_NOWARN_DEPRECATED_POP
-      }
-    }
-  }
-
-  // Arcgis - added in 3.30
-  {
-    const QStringList connections = QgsArcGisConnectionSettings::sTreeConnectionArcgis->items();
-    for ( const QString &connection : connections )
-    {
-      // do not overwrite already set setting
-      QgsArcGisConnectionSettings::settingsUrl->copyValueToKey( u"qgis/connections-arcgisfeatureserver/%1/url"_s, { connection } );
-      QgsArcGisConnectionSettings::settingsAuthcfg->copyValueToKey( u"qgis/ARCGISFEATURESERVER/%1/authcfg"_s, { connection } );
-      QgsArcGisConnectionSettings::settingsUsername->copyValueToKey( u"qgis/ARCGISFEATURESERVER/%1/username"_s, { connection } );
-      QgsArcGisConnectionSettings::settingsPassword->copyValueToKey( u"qgis/ARCGISFEATURESERVER/%1/password"_s, { connection } );
-      QgsArcGisConnectionSettings::settingsContentEndpoint->copyValueToKey( u"qgis/connections-arcgisfeatureserver/%1/content_endpoint"_s, { connection } );
-      QgsArcGisConnectionSettings::settingsCommunityEndpoint->copyValueToKey( u"qgis/connections-arcgisfeatureserver/%1/community_endpoint"_s, { connection } );
-      if ( QgsArcGisConnectionSettings::settingsHeaders->exists( connection ) )
-      {
-        if ( QgsArcGisConnectionSettings::settingsHeaders->exists( connection ) )
-        {
-          Q_NOWARN_DEPRECATED_PUSH
-          const QgsHttpHeaders headers = QgsHttpHeaders( QgsArcGisConnectionSettings::settingsHeaders->value( connection ) );
-          settings->beginGroup( u"qgis/connections-arcgisfeatureserver/%1"_s.arg( connection ) );
-          headers.updateSettings( *settings );
-          settings->endGroup();
-          Q_NOWARN_DEPRECATED_POP
-        }
-      }
-    }
-  }
-
-  // babel devices settings - added in 3.30
-  {
-    const QStringList devices = QgsBabelFormatRegistry::sTreeBabelDevices->items();
-    settings->setValue( u"/Plugin-GPS/devices/deviceList"_s, devices );
-    for ( const QString &device : devices )
-    {
-      QgsBabelFormatRegistry::settingsBabelWptDownload->copyValueToKey( u"/Plugin-GPS/devices/%1/wptdownload"_s, { device } );
-      QgsBabelFormatRegistry::settingsBabelWptUpload->copyValueToKey( u"/Plugin-GPS/devices/%1/wptupload"_s, { device } );
-      QgsBabelFormatRegistry::settingsBabelRteDownload->copyValueToKey( u"/Plugin-GPS/devices/%1/rtedownload"_s, { device } );
-      QgsBabelFormatRegistry::settingsBabelRteUpload->copyValueToKey( u"/Plugin-GPS/devices/%1/rteupload"_s, { device } );
-      QgsBabelFormatRegistry::settingsBabelTrkDownload->copyValueToKey( u"/Plugin-GPS/devices/%1/trkdownload"_s, { device } );
-      QgsBabelFormatRegistry::settingsBabelTrkUpload->copyValueToKey( u"/Plugin-GPS/devices/%1/trkupload"_s, { device } );
-    }
-  }
-
-  QgsSettings::releaseFlush();
-}
+{}

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -32,6 +32,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   // copy values from old keys to new keys and delete the old ones
   // for backward compatibility, old keys are recreated when the registry gets deleted
 
+  // TODO: remove in QGIS 4.4 (after LTR 4.2)
+
   // single settings - added in 3.30
   settingsRespectScreenDPI->copyValueFromKey( u"gui/qgis/respect_screen_dpi"_s, {}, true );
 
@@ -43,8 +45,4 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
 }
 
 QgsSettingsRegistryGui::~QgsSettingsRegistryGui()
-{
-  // TODO QGIS 5.0: Remove
-  // backward compatibility for settings
-  settingsRespectScreenDPI->copyValueToKeyIfChanged( u"gui/qgis/respect_screen_dpi"_s );
-}
+{}


### PR DESCRIPTION
This removes backward compatibility for settings.

I would let the forward code enabled until 4.2: 
* in case someone jumps from 3.30 to 4.2
* bust mostly because copyValueFromKey is deleting the old key, so it automatically cleans the profile.