### PR TITLE
Fix elevation profile missing VPC subindexes if a straight line is drawn

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -381,11 +381,10 @@ bool QgsPointCloudLayerProfileGeneratorBase::collectData( QgsGeos &curve, const 
     indexes.append( mIndex );
 
   // Gather all relevant sub-indexes
-  const QgsRectangle profileCurveBbox = mProfileCurve->boundingBox();
   for ( const QgsPointCloudSubIndex &subidx : mSubIndexes )
   {
     QgsPointCloudIndex index = subidx.index();
-    if ( index && index.isValid() && subidx.polygonBounds().intersects( profileCurveBbox ) )
+    if ( index && index.isValid() && curve.intersects( subidx.polygonBounds().constGet() ) )
       indexes.append( subidx.index() );
   }
 

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -376,21 +376,6 @@ bool QgsPointCloudLayerProfileGeneratorBase::collectData( QgsGeos &curve, const 
 {
   maxErrorInLayerCoordinates = 0;
 
-  QVector<QgsPointCloudIndex> indexes;
-  if ( mIndex && mIndex.isValid() )
-    indexes.append( mIndex );
-
-  // Gather all relevant sub-indexes
-  for ( const QgsPointCloudSubIndex &subidx : mSubIndexes )
-  {
-    QgsPointCloudIndex index = subidx.index();
-    if ( index && index.isValid() && curve.intersects( subidx.polygonBounds().constGet() ) )
-      indexes.append( subidx.index() );
-  }
-
-  if ( indexes.empty() )
-    return false;
-
   std::unique_ptr< QgsAbstractGeometry > searchGeometryInLayerCrs;
   searchGeometryInLayerCrs.reset( curve.buffer( mTolerance, 8, Qgis::EndCapStyle::Flat, Qgis::JoinStyle::Round, 2 ) );
   mLayerToTargetTransform = QgsCoordinateTransform( mSourceCrs, mTargetCrs, mTransformContext );
@@ -405,12 +390,27 @@ bool QgsPointCloudLayerProfileGeneratorBase::collectData( QgsGeos &curve, const 
     return false;
   }
 
-  if ( mFeedback->isCanceled() )
-    return false;
-
   mSearchGeometryInLayerCrsGeometryEngine = std::make_unique< QgsGeos >( searchGeometryInLayerCrs.get() );
   mSearchGeometryInLayerCrsGeometryEngine->prepareGeometry();
   const QgsRectangle maxSearchExtentInLayerCrs = searchGeometryInLayerCrs->boundingBox();
+
+  QVector<QgsPointCloudIndex> indexes;
+  if ( mIndex && mIndex.isValid() )
+    indexes.append( mIndex );
+
+  // Gather all relevant sub-indexes
+  for ( const QgsPointCloudSubIndex &subidx : mSubIndexes )
+  {
+    QgsPointCloudIndex index = subidx.index();
+    if ( index && index.isValid() && mSearchGeometryInLayerCrsGeometryEngine->intersects( subidx.polygonBounds().constGet() ) )
+      indexes.append( subidx.index() );
+  }
+
+  if ( indexes.empty() )
+    return false;
+
+  if ( mFeedback->isCanceled() )
+    return false;
 
   QgsPointCloudRequest request;
   QgsPointCloudAttributeCollection attributes;


### PR DESCRIPTION
A wise man said a straight line doesn't exist in nature, but a stupid one managed to create it in Python.

<img width="890" height="565" alt="Screenshot_20260305_124028" src="https://github.com/user-attachments/assets/cf59ad25-5b27-400e-a33a-513f5b868341" />

This fixes an issue with the elevation profile missing VPC subindexes if the curve was a straight line on either X or Y axis.

The previous behavior was to check the intersection of the bounding box of the curve (a QgsRectangle) with the subindex bounds, but the intersection would fail if the curve was a straight line on either X or Y (xMin == xMax or yMin == yMax) because its bounds would produce an invalid rectangle.

Edit:

2 additional related fixes:
- buffered curve is used when checking for subindex intersection
- curve is transformed into proper CRS before usage, so we don't miss points when the layer and map CRS do not match