### PR TITLE
Harmonize some PDAL algorithms output name

### DIFF
--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilternoiseradius.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilternoiseradius.cpp
@@ -103,7 +103,15 @@ QStringList QgsPdalFilterNoiseRadiusAlgorithm::createArgumentLists( const QVaria
     removeNoisePoints = "true";
   }
 
-  QStringList args = { u"filter_noise"_s, u"--input=%1"_s.arg( layer->source() ), u"--output=%1"_s.arg( outputFile ), u"--algorithm=radius"_s, u"--remove-noise-points=%1"_s.arg( removeNoisePoints ), u"--radius-min-k=%1"_s.arg( minK ), u"--radius-radius=%1"_s.arg( radius ) };
+  QStringList args = {
+    u"filter_noise"_s,
+    u"--input=%1"_s.arg( layer->source() ),
+    u"--output=%1"_s.arg( outputFile ),
+    u"--algorithm=radius"_s,
+    u"--remove-noise-points=%1"_s.arg( removeNoisePoints ),
+    u"--radius-min-k=%1"_s.arg( minK ),
+    u"--radius-radius=%1"_s.arg( radius )
+  };
 
   applyVpcOutputFormatParameter( outputFile, args, parameters, context, feedback );
   applyCommonParameters( args, layer->crs(), parameters, context );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilternoiseradius.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilternoiseradius.cpp
@@ -78,7 +78,7 @@ void QgsPdalFilterNoiseRadiusAlgorithm::initAlgorithm( const QVariantMap & )
 
   createVpcOutputFormatParameter();
 
-  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Filtered (radius algorithm)" ) ) );
+  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Filtered noise (radius)" ) ) );
 }
 
 QStringList QgsPdalFilterNoiseRadiusAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilternoiseradius.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilternoiseradius.cpp
@@ -78,7 +78,7 @@ void QgsPdalFilterNoiseRadiusAlgorithm::initAlgorithm( const QVariantMap & )
 
   createVpcOutputFormatParameter();
 
-  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Filtered noise (radius)" ) ) );
+  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Filtered noise" ) ) );
 }
 
 QStringList QgsPdalFilterNoiseRadiusAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilternoisestatistical.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilternoisestatistical.cpp
@@ -55,7 +55,10 @@ QString QgsPdalFilterNoiseStatisticalAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm filters noise in a point cloud using a statistical outlier removal algorithm." )
          + u"\n\n"_s
-         + QObject::tr( "For each point, the algorithm computes the mean distance to its K nearest neighbors. Points whose mean distance exceeds a threshold (mean distance + multiplier × standard deviation) are classified as noise." );
+         + QObject::tr(
+           "For each point, the algorithm computes the mean distance to its K nearest neighbors. Points whose mean distance exceeds a threshold (mean distance + multiplier × standard deviation) are "
+           "classified as noise."
+         );
 }
 
 QString QgsPdalFilterNoiseStatisticalAlgorithm::shortDescription() const
@@ -103,7 +106,15 @@ QStringList QgsPdalFilterNoiseStatisticalAlgorithm::createArgumentLists( const Q
     removeNoisePoints = "true";
   }
 
-  QStringList args = { u"filter_noise"_s, u"--input=%1"_s.arg( layer->source() ), u"--output=%1"_s.arg( outputFile ), u"--algorithm=statistical"_s, u"--remove-noise-points=%1"_s.arg( removeNoisePoints ), u"--statistical-mean-k=%1"_s.arg( meanK ), u"--statistical-multiplier=%1"_s.arg( multiplier ) };
+  QStringList args = {
+    u"filter_noise"_s,
+    u"--input=%1"_s.arg( layer->source() ),
+    u"--output=%1"_s.arg( outputFile ),
+    u"--algorithm=statistical"_s,
+    u"--remove-noise-points=%1"_s.arg( removeNoisePoints ),
+    u"--statistical-mean-k=%1"_s.arg( meanK ),
+    u"--statistical-multiplier=%1"_s.arg( multiplier )
+  };
 
   applyVpcOutputFormatParameter( outputFile, args, parameters, context, feedback );
   applyCommonParameters( args, layer->crs(), parameters, context );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilternoisestatistical.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilternoisestatistical.cpp
@@ -81,7 +81,7 @@ void QgsPdalFilterNoiseStatisticalAlgorithm::initAlgorithm( const QVariantMap & 
 
   createVpcOutputFormatParameter();
 
-  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Filtered noise (statistical)" ) ) );
+  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Filtered noise" ) ) );
 }
 
 QStringList QgsPdalFilterNoiseStatisticalAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )

--- a/src/analysis/processing/pdal/qgsalgorithmpdalfilternoisestatistical.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalfilternoisestatistical.cpp
@@ -81,7 +81,7 @@ void QgsPdalFilterNoiseStatisticalAlgorithm::initAlgorithm( const QVariantMap & 
 
   createVpcOutputFormatParameter();
 
-  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Filtered (statistical algorithm)" ) ) );
+  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Filtered noise (statistical)" ) ) );
 }
 
 QStringList QgsPdalFilterNoiseStatisticalAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )

--- a/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundnearestneighbour.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundnearestneighbour.cpp
@@ -81,7 +81,7 @@ void QgsPdalHeightAboveGroundNearestNeighbourAlgorithm::initAlgorithm( const QVa
 
   createVpcOutputFormatParameter();
 
-  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Height above ground (nearest neighbour)" ) ) );
+  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Height above ground" ) ) );
 }
 
 QStringList QgsPdalHeightAboveGroundNearestNeighbourAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
@@ -106,7 +106,15 @@ QStringList QgsPdalHeightAboveGroundNearestNeighbourAlgorithm::createArgumentLis
     replaceZ = "true";
   }
 
-  QStringList args = { u"height_above_ground"_s, u"--input=%1"_s.arg( layer->source() ), u"--output=%1"_s.arg( outputFile ), u"--algorithm=nn"_s, u"--replace-z=%1"_s.arg( replaceZ ), u"--nn-count=%1"_s.arg( count ), u"--nn-max-distance=%1"_s.arg( maxDistance ) };
+  QStringList args = {
+    u"height_above_ground"_s,
+    u"--input=%1"_s.arg( layer->source() ),
+    u"--output=%1"_s.arg( outputFile ),
+    u"--algorithm=nn"_s,
+    u"--replace-z=%1"_s.arg( replaceZ ),
+    u"--nn-count=%1"_s.arg( count ),
+    u"--nn-max-distance=%1"_s.arg( maxDistance )
+  };
 
   applyVpcOutputFormatParameter( outputFile, args, parameters, context, feedback );
   applyCommonParameters( args, layer->crs(), parameters, context );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundtriangulation.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundtriangulation.cpp
@@ -55,7 +55,10 @@ QString QgsPdalHeightAboveGroundTriangulationAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm calculates the height of points above the ground surface in a point cloud using a Delaunay triangulation algorithm." )
          + u"\n\n"_s
-         + QObject::tr( "The algorithm uses ground-classified points (classification value 2) to create a triangulated irregular network (TIN) from specified number of neighbors, then computes the height above this surface for all points." )
+         + QObject::tr(
+           "The algorithm uses ground-classified points (classification value 2) to create a triangulated irregular network (TIN) from specified number of neighbors, then computes the height above "
+           "this surface for all points."
+         )
          + u"\n\n"_s
          + QObject::tr( "The output adds a HeightAboveGround dimension to the point cloud. If 'Replace Z values' is enabled, the Z coordinate will be replaced with the height above ground value." );
 }
@@ -102,7 +105,8 @@ QStringList QgsPdalHeightAboveGroundTriangulationAlgorithm::createArgumentLists(
     replaceZ = "true";
   }
 
-  QStringList args = { u"height_above_ground"_s, u"--input=%1"_s.arg( layer->source() ), u"--output=%1"_s.arg( outputFile ), u"--algorithm=delaunay"_s, u"--replace-z=%1"_s.arg( replaceZ ), u"--delaunay-count=%1"_s.arg( count ) };
+  QStringList args
+    = { u"height_above_ground"_s, u"--input=%1"_s.arg( layer->source() ), u"--output=%1"_s.arg( outputFile ), u"--algorithm=delaunay"_s, u"--replace-z=%1"_s.arg( replaceZ ), u"--delaunay-count=%1"_s.arg( count ) };
 
   applyVpcOutputFormatParameter( outputFile, args, parameters, context, feedback );
   applyCommonParameters( args, layer->crs(), parameters, context );

--- a/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundtriangulation.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundtriangulation.cpp
@@ -81,7 +81,7 @@ void QgsPdalHeightAboveGroundTriangulationAlgorithm::initAlgorithm( const QVaria
 
   createVpcOutputFormatParameter();
 
-  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Height above ground (delaunay algorithm)" ) ) );
+  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Height above ground (using triangulation)" ) ) );
 }
 
 QStringList QgsPdalHeightAboveGroundTriangulationAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )

--- a/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundtriangulation.cpp
+++ b/src/analysis/processing/pdal/qgsalgorithmpdalheightabovegroundtriangulation.cpp
@@ -81,7 +81,7 @@ void QgsPdalHeightAboveGroundTriangulationAlgorithm::initAlgorithm( const QVaria
 
   createVpcOutputFormatParameter();
 
-  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Height above ground (using triangulation)" ) ) );
+  addParameter( new QgsProcessingParameterPointCloudDestination( u"OUTPUT"_s, QObject::tr( "Height above ground" ) ) );
 }
 
 QStringList QgsPdalHeightAboveGroundTriangulationAlgorithm::createArgumentLists( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )


### PR DESCRIPTION
The algs names have been [renamed during the review](https://github.com/qgis/QGIS/pull/64343#issuecomment-3755329115) so I think these output names went overseen. The idea is to provide a simpler and meaningful name to the algs output, consistent with the existing algs:
| PDAL Algorithm | current output name | Suggested output name |
------------|---|---|
|Filter noise | Filtered (statistical algorithm) | Filtered noise (statistical)|
|Filter noise (using radius) | Filtered (radius algorithm) | Filtered noise (radius). *maybe should I keep the `using`?*|
|Height above ground | Height above ground (nearest neighbour) | **should this be kept as is or renamed into `Height above ground` to match the algorithm?**
|Height above ground (using triangulation) | Height above ground (delaunay algorithm) | Height above ground (using triangulation)