### PR TITLE
Remove redundant default ports from http/https requests (backport)

### DIFF
--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -336,6 +336,20 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   }
 #endif
 
+  if ( modifiedRequest.url().port() != -1 )
+  {
+    QUrl requestUrl = modifiedRequest.url();
+    const QString scheme = requestUrl.scheme();
+    const bool isDefaultPort = ( scheme == QLatin1String( "http" ) && requestUrl.port() == 80 )
+                               || ( scheme == QLatin1String( "https" ) && requestUrl.port() == 443 );
+    if ( isDefaultPort )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "Removing explicit default port %2 from url %1" ).arg( requestUrl.port( ) ).arg( requestUrl.toString() ), 2 );
+      requestUrl.setPort( -1 );
+      modifiedRequest.setUrl( requestUrl );
+    }
+  }
+
   if ( sMainNAM->mCacheDisabled )
   {
     // if caching is disabled then we override whatever the request actually has set!

--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -302,26 +302,27 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
 {
   const QgsSettings s;
 
-  QNetworkRequest *pReq( const_cast< QNetworkRequest * >( &req ) ); // hack user agent
+  // copy request so we can modify it
+  QNetworkRequest modifiedRequest( req );
 
   QString userAgent = s.value( QStringLiteral( "/qgis/networkAndProxy/userAgent" ), "Mozilla/5.0" ).toString();
   if ( !userAgent.isEmpty() )
     userAgent += ' ';
   userAgent += QStringLiteral( "QGIS/%1/%2" ).arg( Qgis::versionInt() ).arg( QSysInfo::prettyProductName() );
-  pReq->setRawHeader( "User-Agent", userAgent.toLatin1() );
+  modifiedRequest.setRawHeader( "User-Agent", userAgent.toLatin1() );
 
 #ifndef QT_NO_SSL
-  const bool ishttps = pReq->url().scheme().compare( QLatin1String( "https" ), Qt::CaseInsensitive ) == 0;
+  const bool ishttps = modifiedRequest.url().scheme().compare( QLatin1String( "https" ), Qt::CaseInsensitive ) == 0;
   if ( ishttps && !QgsApplication::authManager()->isDisabled() )
   {
     QgsDebugMsgLevel( QStringLiteral( "Adding trusted CA certs to request" ), 3 );
-    QSslConfiguration sslconfig( pReq->sslConfiguration() );
+    QSslConfiguration sslconfig( modifiedRequest.sslConfiguration() );
     // Merge trusted CAs with any additional CAs added by the authentication methods
     sslconfig.setCaCertificates( QgsAuthCertUtils::casMerge( QgsApplication::authManager()->trustedCaCertsCache(), sslconfig.caCertificates( ) ) );
     // check for SSL cert custom config
     const QString hostport( QStringLiteral( "%1:%2" )
-                            .arg( pReq->url().host().trimmed() )
-                            .arg( pReq->url().port() != -1 ? pReq->url().port() : 443 ) );
+                            .arg( modifiedRequest.url().host().trimmed() )
+                            .arg( modifiedRequest.url().port() != -1 ? modifiedRequest.url().port() : 443 ) );
     const QgsAuthConfigSslServer servconfig = QgsApplication::authManager()->sslCertCustomConfigByHost( hostport.trimmed() );
     if ( !servconfig.isNull() )
     {
@@ -331,20 +332,20 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
       sslconfig.setPeerVerifyDepth( servconfig.sslPeerVerifyDepth() );
     }
 
-    pReq->setSslConfiguration( sslconfig );
+    modifiedRequest.setSslConfiguration( sslconfig );
   }
 #endif
 
   if ( sMainNAM->mCacheDisabled )
   {
     // if caching is disabled then we override whatever the request actually has set!
-    pReq->setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
-    pReq->setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
+    modifiedRequest.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
+    modifiedRequest.setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
   }
 
   for ( const auto &preprocessor :  sCustomPreprocessors )
   {
-    preprocessor.second( pReq );
+    preprocessor.second( &modifiedRequest );
   }
 
   static QAtomicInt sRequestId = 0;
@@ -358,15 +359,15 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   for ( const auto &preprocessor :  sCustomAdvancedPreprocessors )
   {
     int intOp = static_cast< int >( op );
-    preprocessor.second( pReq, intOp, &content );
+    preprocessor.second( &modifiedRequest, intOp, &content );
     op = static_cast< QNetworkAccessManager::Operation >( intOp );
   }
 
-  emit requestAboutToBeCreated( QgsNetworkRequestParameters( op, req, requestId, content ) );
+  emit requestAboutToBeCreated( QgsNetworkRequestParameters( op, modifiedRequest, requestId, content ) );
   Q_NOWARN_DEPRECATED_PUSH
-  emit requestAboutToBeCreated( op, req, outgoingData );
+  emit requestAboutToBeCreated( op, modifiedRequest, outgoingData );
   Q_NOWARN_DEPRECATED_POP
-  QNetworkReply *reply = QNetworkAccessManager::createRequest( op, req, outgoingData );
+  QNetworkReply *reply = QNetworkAccessManager::createRequest( op, modifiedRequest, outgoingData );
   reply->setProperty( "requestId", requestId );
 
   emit requestCreated( QgsNetworkRequestParameters( op, reply->request(), requestId, content ) );
@@ -381,7 +382,7 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
 
   for ( const auto &replyPreprocessor :  sCustomReplyPreprocessors )
   {
-    replyPreprocessor.second( req, reply );
+    replyPreprocessor.second( modifiedRequest, reply );
   }
 
   // The timer will call abortRequest slot to abort the connection if needed.

--- a/tests/src/python/test_qgsnetworkaccessmanager.py
+++ b/tests/src/python/test_qgsnetworkaccessmanager.py
@@ -16,7 +16,7 @@ import socketserver
 import threading
 from functools import partial
 
-from qgis.PyQt.QtCore import QUrl
+from qgis.PyQt.QtCore import QCoreApplication, QEvent, QUrl
 from qgis.PyQt.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
@@ -172,6 +172,8 @@ class TestQgsNetworkAccessManager(QgisTestCase):
             reply.request().url().toString(),
             "http://testhost.com/qgis_local_server/index.html",
         )
+        reply.deleteLater()
+        QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
 
         # HTTP request with non-default port 8080
         request = QNetworkRequest(
@@ -189,6 +191,8 @@ class TestQgsNetworkAccessManager(QgisTestCase):
             reply.request().url().toString(),
             "http://testhost.com:8080/qgis_local_server/index.html",
         )
+        reply.deleteLater()
+        QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
 
         # HTTPS request with redundant default port 443
         request = QNetworkRequest(
@@ -207,6 +211,8 @@ class TestQgsNetworkAccessManager(QgisTestCase):
             reply.request().url().toString(),
             "https://testhost.com/qgis_local_server/index.html",
         )
+        reply.deleteLater()
+        QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
 
         # HTTPS request with non-default port 8080
         request = QNetworkRequest(
@@ -224,6 +230,8 @@ class TestQgsNetworkAccessManager(QgisTestCase):
             reply.request().url().toString(),
             "https://testhost.com:8080/qgis_local_server/index.html",
         )
+        reply.deleteLater()
+        QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsnetworkaccessmanager.py
+++ b/tests/src/python/test_qgsnetworkaccessmanager.py
@@ -17,7 +17,7 @@ import threading
 from functools import partial
 
 from qgis.PyQt.QtCore import QUrl
-from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
+from qgis.PyQt.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.core import (
     QgsNetworkAccessManager,
@@ -147,6 +147,83 @@ class TestQgsNetworkAccessManager(QgisTestCase):
         # no longer exists, so a key error should be raised
         with self.assertRaises(KeyError):
             QgsNetworkAccessManager.removeReplyPreprocessor(_id)
+
+    def test_default_port_removal(self):
+        """
+        Test removal of redundant default ports from hosts
+
+        See https://github.com/qgis/QGIS/issues/29475
+        """
+
+        # HTTP request with redundant default port 80
+        request = QNetworkRequest(
+            QUrl("http://testhost.com:80/qgis_local_server/index.html")
+        )
+        self.assertEqual(
+            request.url().toString(),
+            "http://testhost.com:80/qgis_local_server/index.html",
+        )
+
+        reply = QgsNetworkAccessManager.instance().createRequest(
+            QNetworkAccessManager.Operation.GetOperation, request, None
+        )
+        # default port should be removed in actual used request
+        self.assertEqual(
+            reply.request().url().toString(),
+            "http://testhost.com/qgis_local_server/index.html",
+        )
+
+        # HTTP request with non-default port 8080
+        request = QNetworkRequest(
+            QUrl("http://testhost.com:8080/qgis_local_server/index.html")
+        )
+        self.assertEqual(
+            request.url().toString(),
+            "http://testhost.com:8080/qgis_local_server/index.html",
+        )
+
+        reply = QgsNetworkAccessManager.instance().createRequest(
+            QNetworkAccessManager.Operation.GetOperation, request, None
+        )
+        self.assertEqual(
+            reply.request().url().toString(),
+            "http://testhost.com:8080/qgis_local_server/index.html",
+        )
+
+        # HTTPS request with redundant default port 80
+        request = QNetworkRequest(
+            QUrl("https://testhost.com:443/qgis_local_server/index.html")
+        )
+        self.assertEqual(
+            request.url().toString(),
+            "https://testhost.com:443/qgis_local_server/index.html",
+        )
+
+        reply = QgsNetworkAccessManager.instance().createRequest(
+            QNetworkAccessManager.Operation.GetOperation, request, None
+        )
+        # default port should be removed in actual used request
+        self.assertEqual(
+            reply.request().url().toString(),
+            "https://testhost.com/qgis_local_server/index.html",
+        )
+
+        # HTTPS request with non-default port 8080
+        request = QNetworkRequest(
+            QUrl("https://testhost.com:8080/qgis_local_server/index.html")
+        )
+        self.assertEqual(
+            request.url().toString(),
+            "https://testhost.com:8080/qgis_local_server/index.html",
+        )
+
+        reply = QgsNetworkAccessManager.instance().createRequest(
+            QNetworkAccessManager.Operation.GetOperation, request, None
+        )
+        self.assertEqual(
+            reply.request().url().toString(),
+            "https://testhost.com:8080/qgis_local_server/index.html",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsnetworkaccessmanager.py
+++ b/tests/src/python/test_qgsnetworkaccessmanager.py
@@ -190,7 +190,7 @@ class TestQgsNetworkAccessManager(QgisTestCase):
             "http://testhost.com:8080/qgis_local_server/index.html",
         )
 
-        # HTTPS request with redundant default port 80
+        # HTTPS request with redundant default port 443
         request = QNetworkRequest(
             QUrl("https://testhost.com:443/qgis_local_server/index.html")
         )


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/65163, with test fix from https://github.com/qgis/QGIS/pull/65200