### PR TITLE
[themes] Fix tooltip text color unreadable with night mapping under Qt6

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -39,6 +39,7 @@ QToolTip
 {
     border: 1px solid #222;
     background: @itembackground;
+    color: @text;
 }
 
 QMenuBar {

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -38,6 +38,7 @@ QWebView, QTextBrowser
 QToolTip
 {
     border: 1px solid #222;
+    color: @text;
 }
 
 QMenuBar {


### PR DESCRIPTION
## Description

Simple but important themes fix for 4.0.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
