### PR TITLE
[feature] Add concat_ws expression function

### DIFF
--- a/resources/function_help/json/concat_ws
+++ b/resources/function_help/json/concat_ws
@@ -1,0 +1,26 @@
+{
+  "name": "concat_ws",
+  "type": "function",
+  "groups": ["String"],
+  "description": "Concatenate all but first arguments with separators into a single string. The first parameter is used as a separator. NULL arguments are ignored.",
+  "variableLenArguments": true,
+  "arguments": [{
+    "arg": "separator",
+    "description": "seperator to use when concatenating non-null values"
+  }, {
+    "arg": "string",
+    "syntaxOnly": true
+  }, {
+    "arg": "string2",
+    "syntaxOnly": true
+  }, {
+    "arg": "string",
+    "descOnly": true,
+    "description": "a string value"
+  }],
+  "examples": [{
+    "expression": "concat_ws(',', 'abcde', 2, NULL, 22)",
+    "returns": "'abcde,2,22'"
+  }],
+  "tags": ["empty", "converted", "numbers", "concatenates", "null", "strings", "several", "other", "values", "separator", "join"]
+}

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2721,6 +2721,30 @@ static QVariant fcnConcat( const QVariantList &values, const QgsExpressionContex
   return concat;
 }
 
+static QVariant fcnConcatWs( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  if ( values.length() < 2 )
+  {
+    parent->setEvalErrorString( QObject::tr( "Function concat_ws requires at least 2 arguments" ) );
+    return QVariant();
+  }
+
+  const QString separator = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
+
+  QStringList stringValues;
+  stringValues.reserve( values.size() - 1 );
+  for ( int i = 1; i < values.size(); ++i )
+  {
+    const QVariant value = values.at( i );
+    if ( !QgsVariantUtils::isNull( value ) )
+    {
+      stringValues.append( QgsExpressionUtils::getStringValue( value, parent ) );
+    }
+  }
+
+  return stringValues.join( separator );
+}
+
 static QVariant fcnStrpos( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString string = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
@@ -9312,6 +9336,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
            true
          )
       << new QgsStaticExpressionFunction( u"concat"_s, -1, fcnConcat, u"String"_s, QString(), false, QSet<QString>(), false, QStringList(), true )
+      << new QgsStaticExpressionFunction( u"concat_ws"_s, -1, fcnConcatWs, u"String"_s, QString(), false, QSet<QString>(), false, QStringList(), true )
       << new QgsStaticExpressionFunction( u"strpos"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"haystack"_s ) << QgsExpressionFunction::Parameter( u"needle"_s ), fcnStrpos, u"String"_s )
       << new QgsStaticExpressionFunction( u"left"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"string"_s ) << QgsExpressionFunction::Parameter( u"length"_s ), fcnLeft, u"String"_s )
       << new QgsStaticExpressionFunction( u"right"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"string"_s ) << QgsExpressionFunction::Parameter( u"length"_s ), fcnRight, u"String"_s )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1964,6 +1964,13 @@ class TestQgsExpression : public QObject
       QTest::newRow( "concat" ) << "concat('a', 'b', 'c', 'd')" << false << QVariant( "abcd" );
       QTest::newRow( "concat function single" ) << "concat('a')" << false << QVariant( "a" );
       QTest::newRow( "concat function with NULL" ) << "concat(NULL,'a','b')" << false << QVariant( "ab" );
+      QTest::newRow( "concat_ws no args" ) << "concat_ws()" << true << QVariant();
+      QTest::newRow( "concat_ws one arg" ) << "concat_ws(' ')" << true << QVariant();
+      QTest::newRow( "concat_ws comma" ) << "concat_ws(',', 'b', NULL, 'd')" << false << QVariant( "b,d" );
+      QTest::newRow( "concat_ws comma multichar" ) << "concat_ws(', ', 'b', NULL, 'd', 'efg', NULL, 'hij')" << false << QVariant( "b, d, efg, hij" );
+      QTest::newRow( "concat_ws all NULL" ) << "concat_ws(',', NULL, NULL, NULL)" << false << QVariant( "" );
+      QTest::newRow( "concat_ws function single" ) << "concat_ws(',', 'a')" << false << QVariant( "a" );
+      QTest::newRow( "concat_ws function with NULL" ) << "concat_ws(NULL,'a','b')" << false << QVariant( "ab" );
       QTest::newRow( "array_to_string" ) << "array_to_string(array(1,2,3),',')" << false << QVariant( "1,2,3" );
       QTest::newRow( "array_to_string with custom empty value" ) << "array_to_string(array(1,'',3),',','*')" << false << QVariant( "1,*,3" );
       QTest::newRow( "array_to_string fail passing non-array" ) << "array_to_string('non-array',',')" << true << QVariant();


### PR DESCRIPTION
Concatenate all but first arguments with separators. The first parameter is used as a separator.
NULL arguments are ignored.
