### PR TITLE
When migrating QGIS 3 profiles, don't copy contents of symlinks

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsfileutils.py
+++ b/python/PyQt6/core/auto_additions/qgsfileutils.py
@@ -1,4 +1,18 @@
 # The following has been generated automatically from src/core/qgsfileutils.h
+# monkey patching scoped based enum
+QgsFileUtils.CopyFlag.NoSymLinks.__doc__ = "If present, indicates that symbolic links should be skipped during the copy"
+QgsFileUtils.CopyFlag.__doc__ = """Flags controlling behavior of file copy operations.
+
+.. versionadded:: 4.0.1
+
+* ``NoSymLinks``: If present, indicates that symbolic links should be skipped during the copy
+
+"""
+# --
+QgsFileUtils.CopyFlag.baseClass = QgsFileUtils
+QgsFileUtils.CopyFlags = lambda flags=0: QgsFileUtils.CopyFlag(flags)
+QgsFileUtils.CopyFlags.baseClass = QgsFileUtils
+CopyFlags = QgsFileUtils  # dirty hack since SIP seems to introduce the flags in module
 try:
     QgsFileUtils.representFileSize = staticmethod(QgsFileUtils.representFileSize)
     QgsFileUtils.extensionsFromFilter = staticmethod(QgsFileUtils.extensionsFromFilter)

--- a/python/PyQt6/core/auto_generated/qgsfileutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfileutils.sip.in
@@ -20,6 +20,9 @@ Contains utilities for working with files.
 #include "qgsfileutils.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
     static QString representFileSize( qint64 bytes );
 %Docstring
 Returns the human size from bytes
@@ -233,7 +236,16 @@ already exist is found.
 
 .. versionadded:: 3.30
 %End
-    static bool copyDirectory( const QString &source, const QString &destination );
+
+    enum class CopyFlag /BaseType=IntFlag/
+    {
+      NoSymLinks,
+    };
+
+    typedef QFlags<QgsFileUtils::CopyFlag> CopyFlags;
+
+
+    static bool copyDirectory( const QString &source, const QString &destination, QgsFileUtils::CopyFlags flags = QgsFileUtils::CopyFlags() );
 %Docstring
 Recursively copies a whole directory.
 
@@ -243,6 +255,9 @@ were copied.
 .. note::
 
    If an error occurs while copying a file, this method still attempts to copy all remaining files and folders.
+
+Since QGIS 4.0.1 the ``flags`` argument can be used to specify flags
+controlling the behavior of the copy operation.
 
 .. versionadded:: 4.0
 %End
@@ -258,6 +273,9 @@ Replacement is case-sensitive.
 .. versionadded:: 4.0
 %End
 };
+
+QFlags<QgsFileUtils::CopyFlag> operator|(QgsFileUtils::CopyFlag f1, QFlags<QgsFileUtils::CopyFlag> f2);
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/app/qgsversionmigration.cpp
+++ b/src/app/qgsversionmigration.cpp
@@ -377,7 +377,7 @@ QgsError Qgs3To4Migration::runMigration( const QString &oldProfilePath, const QS
   newProfileDir.remove( u"symbology-style.db"_s );
 
   QgsError errors;
-  QgsFileUtils::copyDirectory( oldProfilePath, newProfilePath );
+  QgsFileUtils::copyDirectory( oldProfilePath, newProfilePath, QgsFileUtils::CopyFlag::NoSymLinks );
 
   newProfileDir.remove( u"QGIS/QGIS4.ini"_s );
   newProfileDir.rename( u"QGIS/QGIS3.ini"_s, u"QGIS/QGIS4.ini"_s );

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -29,6 +29,8 @@
 #include <QSet>
 #include <QString>
 
+#include "moc_qgsfileutils.cpp"
+
 using namespace Qt::StringLiterals;
 
 #ifdef Q_OS_UNIX
@@ -633,7 +635,7 @@ QString QgsFileUtils::uniquePath( const QString &path )
   return uniquePath;
 }
 
-bool QgsFileUtils::copyDirectory( const QString &source, const QString &destination )
+bool QgsFileUtils::copyDirectory( const QString &source, const QString &destination, CopyFlags flags )
 {
   QDir sourceDir( source );
   if ( !sourceDir.exists() )
@@ -653,7 +655,13 @@ bool QgsFileUtils::copyDirectory( const QString &source, const QString &destinat
   }
 
   bool copiedAll = true;
-  const QStringList files = sourceDir.entryList( QDir::Files );
+
+  QDir::Filters fileFilters = QDir::Files;
+  if ( flags & CopyFlag::NoSymLinks )
+  {
+    fileFilters |= QDir::NoSymLinks;
+  }
+  const QStringList files = sourceDir.entryList( fileFilters );
   for ( const QString &file : files )
   {
     const QString srcFileName = sourceDir.filePath( file );
@@ -664,12 +672,18 @@ bool QgsFileUtils::copyDirectory( const QString &source, const QString &destinat
       copiedAll = false;
     }
   }
-  const QStringList dirs = sourceDir.entryList( QDir::AllDirs | QDir::NoDotAndDotDot );
+
+  QDir::Filters dirFilters = QDir::AllDirs | QDir::NoDotAndDotDot;
+  if ( flags & CopyFlag::NoSymLinks )
+  {
+    dirFilters |= QDir::NoSymLinks;
+  }
+  const QStringList dirs = sourceDir.entryList( dirFilters );
   for ( const QString &dir : dirs )
   {
     const QString srcDirName = sourceDir.filePath( dir );
     const QString destDirName = destDir.filePath( dir );
-    if ( !copyDirectory( srcDirName, destDirName ) )
+    if ( !copyDirectory( srcDirName, destDirName, flags ) )
     {
       copiedAll = false;
     }

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -31,6 +31,8 @@
  */
 class CORE_EXPORT QgsFileUtils
 {
+    Q_GADGET
+
   public:
     /**
      * Returns the human size from bytes
@@ -237,6 +239,26 @@ class CORE_EXPORT QgsFileUtils
      * \since QGIS 3.30
      */
     static QString uniquePath( const QString &path );
+
+    /**
+     * Flags controlling behavior of file copy operations.
+     *
+     * \since QGIS 4.0.1
+     */
+    enum class CopyFlag : int SIP_ENUM_BASETYPE( IntFlag )
+    {
+      NoSymLinks = 1 << 0, //!< If present, indicates that symbolic links should be skipped during the copy
+    };
+    Q_ENUM( CopyFlag )
+
+    /**
+     * Flags controlling behavior of file copy operations.
+     *
+     * \since QGIS 4.0.1
+     */
+    Q_DECLARE_FLAGS( CopyFlags, CopyFlag )
+    Q_FLAG( CopyFlags )
+
     /**
      * Recursively copies a whole directory.
      *
@@ -244,9 +266,12 @@ class CORE_EXPORT QgsFileUtils
      *
      * \note If an error occurs while copying a file, this method still attempts to copy all remaining files and folders.
      *
+     * Since QGIS 4.0.1 the \a flags argument can be used to specify flags controlling the
+     * behavior of the copy operation.
+     *
      * \since QGIS 4.0
      */
-    static bool copyDirectory( const QString &source, const QString &destination );
+    static bool copyDirectory( const QString &source, const QString &destination, QgsFileUtils::CopyFlags flags = QgsFileUtils::CopyFlags() );
 
     /**
      * Replaces all occurrences of a given string in a file.
@@ -259,5 +284,7 @@ class CORE_EXPORT QgsFileUtils
      */
     static bool replaceTextInFile( const QString &path, const QString &searchString, const QString &replacement );
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFileUtils::CopyFlags )
 
 #endif // QGSFILEUTILS_H


### PR DESCRIPTION
So eg if a user profile contains a symlink to a plugin directory,
don't make a full copy of that symlinked directory into the
QGIS 4 user profile. Instead just skip it and let the user manually
migrate that part of their profile.

Fixes issues when migrating (NON STANDARD) profile setups, especially
for plugin development environments.