### PR TITLE
Fix model changes lost when cancelling save in Model Designer

### DIFF
--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -407,12 +407,15 @@ QgsModelDesignerDialog::~QgsModelDesignerDialog()
 
 void QgsModelDesignerDialog::closeEvent( QCloseEvent *event )
 {
-  if ( !saveModel( false ) )
+  if ( checkForUnsavedChanges() )
   {
-    event->ignore();
-    return;
+    if ( !saveModel( false ) )
+    {
+      event->ignore();
+      return;
+    }
   }
-
+  
   QMainWindow::closeEvent( event );
 }
 void QgsModelDesignerDialog::beginUndoCommand( const QString &text, const QString &id, QgsModelUndoCommand::CommandOperation operation )

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -407,12 +407,14 @@ QgsModelDesignerDialog::~QgsModelDesignerDialog()
 
 void QgsModelDesignerDialog::closeEvent( QCloseEvent *event )
 {
-  if ( checkForUnsavedChanges() )
-    event->accept();
-  else
+  if ( !saveModel( false ) )
+  {
     event->ignore();
-}
+    return;
+  }
 
+  QMainWindow::closeEvent( event );
+}
 void QgsModelDesignerDialog::beginUndoCommand( const QString &text, const QString &id, QgsModelUndoCommand::CommandOperation operation )
 {
   if ( mBlockUndoCommands || !mUndoStack )


### PR DESCRIPTION
This PR fixes an issue in the Model Designer where model changes could be lost when the user cancels the save dialog while closing the window. Previously, when closing the Model Designer, the save dialog could appear and if the user clicked Cancel, the window could still close and changes would be lost and this  updae ensures that when saveModel(false) returns false (user cancels), the close event is ignored and the Model Designer remains open.
To sort out this issue :
1. Open Model Designer
2. Modify a model
3. Close the window
4. Click Cancel in the save dialog
Expected behavior:
The Model Designer should remain open and changes should not be lost.
This Fixes #47282