### PR TITLE
Migrate some settings to new API

### DIFF
--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -28,6 +28,7 @@
 #include "qgspoint.h"
 #include "qgsraycastcontext.h"
 #include "qgsrubberband3d.h"
+#include "qgssettingsregistrygui.h"
 #include "qgswindow3dengine.h"
 
 #include <QKeyEvent>
@@ -109,13 +110,8 @@ void Qgs3DMapToolMeasureLine::updateSettings()
 {
   if ( mRubberBand )
   {
-    const QgsSettings settings;
-    const int myRed = settings.value( u"qgis/default_measure_color_red"_s, 222 ).toInt();
-    const int myGreen = settings.value( u"qgis/default_measure_color_green"_s, 155 ).toInt();
-    const int myBlue = settings.value( u"qgis/default_measure_color_blue"_s, 67 ).toInt();
-
     mRubberBand->setWidth( 3 );
-    mRubberBand->setColor( QColor( myRed, myGreen, myBlue ) );
+    mRubberBand->setColor( QgsSettingsRegistryGui::settingsDefaultMeasureColor->value() );
   }
 }
 

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -28,6 +28,7 @@
 #include "qgspoint.h"
 #include "qgsraycastcontext.h"
 #include "qgsrubberband3d.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrygui.h"
 #include "qgswindow3dengine.h"
 

--- a/src/app/3d/qgs3dmaptoolpointcloudchangeattributepaintbrush.cpp
+++ b/src/app/3d/qgs3dmaptoolpointcloudchangeattributepaintbrush.cpp
@@ -25,6 +25,7 @@
 #include "qgsguiutils.h"
 #include "qgslinestring.h"
 #include "qgsrubberband3d.h"
+#include "qgssettingsregistrygui.h"
 #include "qgswindow3dengine.h"
 
 #include <QString>
@@ -147,8 +148,7 @@ void Qgs3DMapToolPointCloudChangeAttributePaintbrush::mouseWheelEvent( QWheelEve
 
   // Change the selection circle size. Moving the wheel forward (away) from the user makes
   // the circle smaller
-  const QgsSettings settings;
-  const bool reverseZoom = settings.value( u"qgis/reverse_wheel_zoom"_s, false ).toBool();
+  const bool reverseZoom = QgsSettingsRegistryGui::settingsReverseWheelZoom->value();
   const bool shrink = reverseZoom ? event->angleDelta().y() > 0 : event->angleDelta().y() < 0;
 
   // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps

--- a/src/app/3d/qgs3dmaptoolpointcloudchangeattributepaintbrush.cpp
+++ b/src/app/3d/qgs3dmaptoolpointcloudchangeattributepaintbrush.cpp
@@ -25,6 +25,7 @@
 #include "qgsguiutils.h"
 #include "qgslinestring.h"
 #include "qgsrubberband3d.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrygui.h"
 #include "qgswindow3dengine.h"
 

--- a/src/app/3d/qgs3dmeasuredialog.cpp
+++ b/src/app/3d/qgs3dmeasuredialog.cpp
@@ -178,11 +178,10 @@ void Qgs3DMeasureDialog::closeEvent( QCloseEvent *e )
 
 void Qgs3DMeasureDialog::updateSettings()
 {
-  const QgsSettings settings;
-
   mDecimalPlaces = QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->value();
   mMapDistanceUnit = mTool->canvas()->mapSettings()->crs().mapUnits();
-  mDisplayedDistanceUnit = QgsUnitTypes::decodeDistanceUnit( settings.value( u"qgis/measure/displayunits"_s, QgsUnitTypes::encodeUnit( Qgis::DistanceUnit::Unknown ) ).toString() );
+  const QString displayUnitsStr = QgsSettingsRegistryCore::settingsMeasureDisplayUnits->value();
+  mDisplayedDistanceUnit = displayUnitsStr.isEmpty() ? Qgis::DistanceUnit::Unknown : QgsUnitTypes::decodeDistanceUnit( displayUnitsStr );
   setupTableHeader();
   mUnitsCombo->setCurrentIndex( mUnitsCombo->findData( static_cast<int>( mDisplayedDistanceUnit ) ) );
 }

--- a/src/app/3d/qgs3dmeasuredialog.cpp
+++ b/src/app/3d/qgs3dmeasuredialog.cpp
@@ -20,6 +20,7 @@
 #include "qgs3dmapsettings.h"
 #include "qgs3dmaptoolmeasureline.h"
 #include "qgshelp.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsunittypes.h"
 

--- a/src/app/3d/qgs3dmeasuredialog.cpp
+++ b/src/app/3d/qgs3dmeasuredialog.cpp
@@ -202,7 +202,7 @@ double Qgs3DMeasureDialog::convertLength( double length, Qgis::DistanceUnit toUn
 QString Qgs3DMeasureDialog::formatDistance( double distance ) const
 {
   const QgsSettings settings;
-  const bool baseUnit = settings.value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
+  const bool baseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
   return QgsUnitTypes::formatDistance( distance, mDecimalPlaces, mDisplayedDistanceUnit, baseUnit );
 }
 

--- a/src/app/3d/qgs3dmeasuredialog.cpp
+++ b/src/app/3d/qgs3dmeasuredialog.cpp
@@ -20,6 +20,7 @@
 #include "qgs3dmapsettings.h"
 #include "qgs3dmaptoolmeasureline.h"
 #include "qgshelp.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsunittypes.h"
 
 #include <QCloseEvent>
@@ -179,7 +180,7 @@ void Qgs3DMeasureDialog::updateSettings()
 {
   const QgsSettings settings;
 
-  mDecimalPlaces = settings.value( u"qgis/measure/decimalplaces"_s, "3" ).toInt();
+  mDecimalPlaces = QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->value();
   mMapDistanceUnit = mTool->canvas()->mapSettings()->crs().mapUnits();
   mDisplayedDistanceUnit = QgsUnitTypes::decodeDistanceUnit( settings.value( u"qgis/measure/displayunits"_s, QgsUnitTypes::encodeUnit( Qgis::DistanceUnit::Unknown ) ).toString() );
   setupTableHeader();

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -66,6 +66,7 @@
 #include "qgsrasterlayer.h"
 #include "qgsrelationshipsitem.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgssourceselectprovider.h"
 #include "qgssourceselectproviderregistry.h"
 #include "qgsstylemanagerdialog.h"
@@ -354,7 +355,7 @@ void QgsAppDirectoryItemGuiProvider::populateContextMenu( QgsDataItem *item, QMe
   QAction *fastScanAction = new QAction( tr( "Fast Scan this Directory" ), scanningMenu );
   connect( fastScanAction, &QAction::triggered, this, [this, directoryItem] { toggleFastScan( directoryItem ); } );
   fastScanAction->setCheckable( true );
-  fastScanAction->setChecked( settings.value( u"qgis/scanItemsFastScanUris"_s, QStringList() ).toStringList().contains( item->path() ) );
+  fastScanAction->setChecked( QgsSettingsRegistryCore::settingsScanItemsFastScanUris->value().contains( item->path() ) );
 
   scanningMenu->addAction( fastScanAction );
   menu->addMenu( scanningMenu );
@@ -441,8 +442,7 @@ void QgsAppDirectoryItemGuiProvider::hideDirectory( QgsDirectoryItem *item )
 
 void QgsAppDirectoryItemGuiProvider::toggleFastScan( QgsDirectoryItem *item )
 {
-  QgsSettings settings;
-  QStringList fastScanDirs = settings.value( u"qgis/scanItemsFastScanUris"_s, QStringList() ).toStringList();
+  QStringList fastScanDirs = QgsSettingsRegistryCore::settingsScanItemsFastScanUris->value();
   int idx = fastScanDirs.indexOf( item->path() );
   if ( idx != -1 )
   {
@@ -452,7 +452,7 @@ void QgsAppDirectoryItemGuiProvider::toggleFastScan( QgsDirectoryItem *item )
   {
     fastScanDirs << item->path();
   }
-  settings.setValue( u"qgis/scanItemsFastScanUris"_s, fastScanDirs );
+  QgsSettingsRegistryCore::settingsScanItemsFastScanUris->setValue( fastScanDirs );
 }
 
 void QgsAppDirectoryItemGuiProvider::toggleMonitor( QgsDirectoryItem *item )

--- a/src/app/elevation/qgselevationprofiletoolmeasure.cpp
+++ b/src/app/elevation/qgselevationprofiletoolmeasure.cpp
@@ -22,6 +22,7 @@
 #include "qgsguiutils.h"
 #include "qgsplotmouseevent.h"
 #include "qgsproject.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgssettingsregistrygui.h"
 #include "qgsunittypes.h"

--- a/src/app/elevation/qgselevationprofiletoolmeasure.cpp
+++ b/src/app/elevation/qgselevationprofiletoolmeasure.cpp
@@ -23,6 +23,7 @@
 #include "qgsplotmouseevent.h"
 #include "qgsproject.h"
 #include "qgssettingsregistrycore.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsunittypes.h"
 
 #include <QGraphicsLineItem>
@@ -134,11 +135,8 @@ QgsElevationProfileToolMeasure::QgsElevationProfileToolMeasure( QgsElevationProf
   QPen pen;
   pen.setWidthF( QgsGuiUtils::scaleIconSize( 2 ) );
   pen.setCosmetic( true );
-  QgsSettings settings;
-  const int red = settings.value( u"qgis/default_measure_color_red"_s, 222 ).toInt();
-  const int green = settings.value( u"qgis/default_measure_color_green"_s, 155 ).toInt();
-  const int blue = settings.value( u"qgis/default_measure_color_blue"_s, 67 ).toInt();
-  pen.setColor( QColor( red, green, blue, 100 ) );
+  const QColor measureColor = QgsSettingsRegistryGui::settingsDefaultMeasureColor->value();
+  pen.setColor( QColor( measureColor.red(), measureColor.green(), measureColor.blue(), 100 ) );
   mRubberBand->setPen( pen );
 
   mRubberBand->hide();

--- a/src/app/elevation/qgselevationprofiletoolmeasure.cpp
+++ b/src/app/elevation/qgselevationprofiletoolmeasure.cpp
@@ -22,6 +22,7 @@
 #include "qgsguiutils.h"
 #include "qgsplotmouseevent.h"
 #include "qgsproject.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsunittypes.h"
 
 #include <QGraphicsLineItem>
@@ -98,7 +99,7 @@ void QgsProfileMeasureResultsDialog::setMeasures( double total, double distance,
     distanceUnit = projectUnit;
   }
 
-  int decimals = settings.value( u"qgis/measure/decimalplaces"_s, 3 ).toInt();
+  int decimals = QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->value();
   if ( distanceUnit == Qgis::DistanceUnit::Degrees && distance < 1 )
   {
     // special handling for degrees - because we can't use smaller units (eg m->mm), we need to make sure there's

--- a/src/app/elevation/qgselevationprofiletoolmeasure.cpp
+++ b/src/app/elevation/qgselevationprofiletoolmeasure.cpp
@@ -86,7 +86,7 @@ void QgsProfileMeasureResultsDialog::setMeasures( double total, double distance,
 
   // the distance delta HAS units!
   const QgsSettings settings;
-  const bool baseUnit = settings.value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
+  const bool baseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
 
   Qgis::DistanceUnit distanceUnit = mCrs.mapUnits();
   const Qgis::DistanceUnit projectUnit = QgsProject::instance()->distanceUnits();

--- a/src/app/gps/qgsgpscanvasbridge.cpp
+++ b/src/app/gps/qgsgpscanvasbridge.cpp
@@ -29,6 +29,7 @@
 #include "qgsprojectdisplaysettings.h"
 #include "qgssettingsentryenumflag.h"
 #include "qgssettingsentryimpl.h"
+#include "qgssettingsregistrycore.h"
 #include "qgssettingstree.h"
 #include "qgsstatusbar.h"
 #include "qgssymbollayerutils.h"
@@ -437,7 +438,7 @@ void QgsGpsCanvasBridge::updateGpsDistanceStatusMessage( bool forceDisplay )
     const double distance
       = mDistanceCalculator.convertLengthMeasurement( mDistanceCalculator.measureLine( QVector<QgsPointXY>() << mLastCursorPosWgs84 << mLastGpsPosition ), QgsProject::instance()->distanceUnits() );
     const double bearing = 180 * mDistanceCalculator.bearing( mLastGpsPosition, mLastCursorPosWgs84 ) / M_PI;
-    const int distanceDecimalPlaces = QgsSettings().value( u"qgis/measure/decimalplaces"_s, "3" ).toInt();
+    const int distanceDecimalPlaces = QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->value();
     const QString distanceString = QgsDistanceArea::formatDistance( distance, distanceDecimalPlaces, QgsProject::instance()->distanceUnits() );
     const QString bearingString = mBearingNumericFormat->formatDouble( bearing, QgsNumericFormatContext() );
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -305,7 +305,7 @@ void QgsGpsInformationWidget::updateTrackInformation()
   const double directTrackLength = mDigitizing->trackDistanceFromStart();
 
   const QgsSettings settings;
-  const bool keepBaseUnit = settings.value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
+  const bool keepBaseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
   const int decimalPlaces = settings.value( u"qgis/measure/decimalplaces"_s, 3 ).toInt();
 
   if ( totalTrackLength > 0 )

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -27,6 +27,7 @@
 #include "qgspointxy.h"
 #include "qgsproject.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsstatusbar.h"
 
 #include <QString>
@@ -306,7 +307,7 @@ void QgsGpsInformationWidget::updateTrackInformation()
 
   const QgsSettings settings;
   const bool keepBaseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
-  const int decimalPlaces = settings.value( u"qgis/measure/decimalplaces"_s, 3 ).toInt();
+  const int decimalPlaces = QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->value();
 
   if ( totalTrackLength > 0 )
   {

--- a/src/app/gps/qgsgpstoolbar.cpp
+++ b/src/app/gps/qgsgpstoolbar.cpp
@@ -30,6 +30,7 @@
 #include "qgsproject.h"
 #include "qgsprojectgpssettings.h"
 #include "qgssettingsentryenumflag.h"
+#include "qgssettingsregistrycore.h"
 #include "qgssettingstree.h"
 #include "qgsunittypes.h"
 
@@ -281,7 +282,7 @@ void QgsGpsToolBar::updateLocationLabel()
 
               const QgsSettings settings;
               const bool keepBaseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
-              const int decimalPlaces = settings.value( u"qgis/measure/decimalplaces"_s, 3 ).toInt();
+              const int decimalPlaces = QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->value();
 
               if ( measurement > 0 )
                 parts << mDigitizing->distanceArea().formatDistance( measurement, decimalPlaces, mDigitizing->distanceArea().lengthUnits(), keepBaseUnit );

--- a/src/app/gps/qgsgpstoolbar.cpp
+++ b/src/app/gps/qgsgpstoolbar.cpp
@@ -280,7 +280,7 @@ void QgsGpsToolBar::updateLocationLabel()
               const double measurement = component == Qgis::GpsInformationComponent::TotalTrackLength ? mDigitizing->totalTrackLength() : mDigitizing->trackDistanceFromStart();
 
               const QgsSettings settings;
-              const bool keepBaseUnit = settings.value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
+              const bool keepBaseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
               const int decimalPlaces = settings.value( u"qgis/measure/decimalplaces"_s, 3 ).toInt();
 
               if ( measurement > 0 )

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -879,7 +879,7 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addSublayers( const QList<QgsProviderS
   {
     // Respect if user don't want the new group of layers visible.
     QgsSettings settings;
-    const bool newLayersVisible = settings.value( u"/qgis/new_layers_visible"_s, true ).toBool();
+    const bool newLayersVisible = QgsSettingsRegistryGui::settingsNewLayersVisible->value();
     if ( !newLayersVisible )
       group->setItemVisibilityCheckedRecursive( newLayersVisible );
   }

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -33,6 +33,8 @@
 #include "qgsprojectelevationproperties.h"
 #include "qgsprojecttimesettings.h"
 #include "qgsrasterlayerproperties.h"
+#include "qgssettingsentryenumflag.h"
+#include "qgssettingsregistrycore.h"
 #include "qgssettingsregistrygui.h"
 #include "qgsterrainprovider.h"
 #include "qgstiledscenelayerproperties.h"

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -33,6 +33,7 @@
 #include "qgsprojectelevationproperties.h"
 #include "qgsprojecttimesettings.h"
 #include "qgsrasterlayerproperties.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsterrainprovider.h"
 #include "qgstiledscenelayerproperties.h"
 #include "qgsvectorlayerproperties.h"
@@ -431,7 +432,7 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addOgrVectorLayers( const QStringList 
       baseName = QgsProviderUtils::suggestLayerNameFromFilePath( uri );
     }
 
-    if ( settings.value( u"qgis/formatLayerName"_s, false ).toBool() )
+    if ( QgsSettingsRegistryGui::settingsFormatLayerName->value() )
     {
       baseName = QgsMapLayer::formatLayerName( baseName );
     }
@@ -585,7 +586,7 @@ template<typename L> L *QgsAppLayerHandling::addLayer( const QString &uri, const
 
   QString base( baseName );
 
-  if ( settings.value( u"qgis/formatLayerName"_s, false ).toBool() )
+  if ( QgsSettingsRegistryGui::settingsFormatLayerName->value() )
   {
     base = QgsMapLayer::formatLayerName( base );
   }
@@ -687,7 +688,7 @@ bool QgsAppLayerHandling::askUserForZipItemLayers( const QString &path, const QL
     QgsSettings settings;
 
     QString base = QgsProviderUtils::suggestLayerNameFromFilePath( path );
-    if ( settings.value( u"qgis/formatLayerName"_s, false ).toBool() )
+    if ( QgsSettingsRegistryGui::settingsFormatLayerName->value() )
     {
       base = QgsMapLayer::formatLayerName( base );
     }
@@ -786,7 +787,7 @@ QList<QgsMapLayer *> QgsAppLayerHandling::addSublayers( const QList<QgsProviderS
   }
 
   QgsSettings settings;
-  const bool formatLayerNames = settings.value( u"qgis/formatLayerName"_s, false ).toBool();
+  const bool formatLayerNames = QgsSettingsRegistryGui::settingsFormatLayerName->value();
 
   // if we aren't adding to a group, we need to add the layers in reverse order so that they maintain the correct
   // order in the layer tree!
@@ -1043,7 +1044,7 @@ QList<QgsMapLayer *> QgsAppLayerHandling::openLayer( const QString &fileName, bo
       QgsSettings settings;
 
       QString base = QgsProviderUtils::suggestLayerNameFromFilePath( fileName );
-      if ( settings.value( u"qgis/formatLayerName"_s, false ).toBool() )
+      if ( QgsSettingsRegistryGui::settingsFormatLayerName->value() )
       {
         base = QgsMapLayer::formatLayerName( base );
       }
@@ -1387,7 +1388,7 @@ template<typename T> QList<T *> QgsAppLayerHandling::addLayerPrivate( Qgis::Laye
 
   QgsCanvasRefreshBlocker refreshBlocker;
 
-  QString baseName = settings.value( u"qgis/formatLayerName"_s, false ).toBool() ? QgsMapLayer::formatLayerName( name ) : name;
+  QString baseName = QgsSettingsRegistryGui::settingsFormatLayerName->value() ? QgsMapLayer::formatLayerName( name ) : name;
 
   // if the layer needs authentication, ensure the master password is set
   const thread_local QRegularExpression rx( "authcfg=([a-z]|[A-Z]|[0-9]){7}" );
@@ -1478,7 +1479,7 @@ template<typename T> QList<T *> QgsAppLayerHandling::addLayerPrivate( Qgis::Laye
       if ( !layers.isEmpty() )
       {
         QString base( baseName );
-        if ( settings.value( u"qgis/formatLayerName"_s, false ).toBool() )
+        if ( QgsSettingsRegistryGui::settingsFormatLayerName->value() )
         {
           base = QgsMapLayer::formatLayerName( base );
         }
@@ -1500,7 +1501,7 @@ template<typename T> QList<T *> QgsAppLayerHandling::addLayerPrivate( Qgis::Laye
     if ( !result.isEmpty() )
     {
       QString base( baseName );
-      if ( settings.value( u"qgis/formatLayerName"_s, false ).toBool() )
+      if ( QgsSettingsRegistryGui::settingsFormatLayerName->value() )
       {
         base = QgsMapLayer::formatLayerName( base );
       }

--- a/src/app/layers/qgsapplayerhandling.cpp
+++ b/src/app/layers/qgsapplayerhandling.cpp
@@ -1259,7 +1259,7 @@ void QgsAppLayerHandling::openLayerDefinition( const QString &filename, const Qg
       context.setProjectTranslator( QgsProject::instance() );
 
       QgsSettings settings;
-      Qgis::LayerTreeInsertionMethod insertionMethod = settings.enumValue( u"/qgis/layerTreeInsertionMethod"_s, Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup );
+      Qgis::LayerTreeInsertionMethod insertionMethod = QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod->value();
       loaded = QgsLayerDefinition::loadLayerDefinition( doc, QgsProject::instance(), QgsProject::instance()->layerTreeRoot(), errorMessage, context, insertionMethod, insertPoint );
     }
   }

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -674,7 +674,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   bool baseUnit = mSettings->value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
   mKeepBaseUnitCheckBox->setChecked( baseUnit );
 
-  mPlanimetricMeasurementsComboBox->setChecked( mSettings->value( u"measure/planimetric"_s, false, QgsSettings::Core ).toBool() );
+  mPlanimetricMeasurementsComboBox->setChecked( QgsSettingsRegistryCore::settingsMeasurePlanimetric->value() );
 
   // set the measure tool copy settings
   connect( mSeparatorOther, &QRadioButton::toggled, mSeparatorCustom, &QLineEdit::setEnabled );
@@ -1748,7 +1748,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( u"/projections/crsAccuracyIndicator"_s, mCrsAccuracyIndicatorCheck->isChecked(), QgsSettings::App );
 
   //measurement settings
-  mSettings->setValue( u"measure/planimetric"_s, mPlanimetricMeasurementsComboBox->isChecked(), QgsSettings::Core );
+  QgsSettingsRegistryCore::settingsMeasurePlanimetric->setValue( mPlanimetricMeasurementsComboBox->isChecked() );
 
   Qgis::DistanceUnit distanceUnit = static_cast<Qgis::DistanceUnit>( mDistanceUnitsComboBox->currentData().toInt() );
   mSettings->setValue( u"/qgis/measure/displayunits"_s, QgsUnitTypes::encodeUnit( distanceUnit ) );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -628,7 +628,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mDistanceUnitsComboBox->addItem( tr( "Map Units" ), static_cast<int>( Qgis::DistanceUnit::Unknown ) );
 
   bool ok = false;
-  Qgis::DistanceUnit distanceUnits = QgsUnitTypes::decodeDistanceUnit( mSettings->value( u"/qgis/measure/displayunits"_s ).toString(), &ok );
+  Qgis::DistanceUnit distanceUnits = QgsUnitTypes::decodeDistanceUnit( QgsSettingsRegistryCore::settingsMeasureDisplayUnits->value(), &ok );
   if ( !ok )
     distanceUnits = Qgis::DistanceUnit::Meters;
   mDistanceUnitsComboBox->setCurrentIndex( mDistanceUnitsComboBox->findData( static_cast<int>( distanceUnits ) ) );
@@ -1751,7 +1751,7 @@ void QgsOptions::saveOptions()
   QgsSettingsRegistryCore::settingsMeasurePlanimetric->setValue( mPlanimetricMeasurementsComboBox->isChecked() );
 
   Qgis::DistanceUnit distanceUnit = static_cast<Qgis::DistanceUnit>( mDistanceUnitsComboBox->currentData().toInt() );
-  mSettings->setValue( u"/qgis/measure/displayunits"_s, QgsUnitTypes::encodeUnit( distanceUnit ) );
+  QgsSettingsRegistryCore::settingsMeasureDisplayUnits->setValue( QgsUnitTypes::encodeUnit( distanceUnit ) );
 
   Qgis::AreaUnit areaUnit = static_cast<Qgis::AreaUnit>( mAreaUnitsComboBox->currentData().toInt() );
   mSettings->setValue( u"/qgis/measure/areaunits"_s, QgsUnitTypes::encodeUnit( areaUnit ) );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -796,11 +796,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mRespectScreenDpiCheckBox->setChecked( QgsSettingsRegistryGui::settingsRespectScreenDPI->value() );
 
   //set the color for selections
-  int red = mSettings->value( u"/qgis/default_selection_color_red"_s, 255 ).toInt();
-  int green = mSettings->value( u"/qgis/default_selection_color_green"_s, 255 ).toInt();
-  int blue = mSettings->value( u"/qgis/default_selection_color_blue"_s, 0 ).toInt();
-  int alpha = mSettings->value( u"/qgis/default_selection_color_alpha"_s, 255 ).toInt();
-  pbnSelectionColor->setColor( QColor( red, green, blue, alpha ) );
+  pbnSelectionColor->setColor( QgsSettingsRegistryCore::settingsDefaultSelectionColor->value() );
   pbnSelectionColor->setColorDialogTitle( tr( "Set Selection Color" ) );
   pbnSelectionColor->setAllowOpacity( true );
   pbnSelectionColor->setContext( u"gui"_s );
@@ -1779,10 +1775,7 @@ void QgsOptions::saveOptions()
 
   //set the color for selections
   QColor myColor = pbnSelectionColor->color();
-  mSettings->setValue( u"/qgis/default_selection_color_red"_s, myColor.red() );
-  mSettings->setValue( u"/qgis/default_selection_color_green"_s, myColor.green() );
-  mSettings->setValue( u"/qgis/default_selection_color_blue"_s, myColor.blue() );
-  mSettings->setValue( u"/qgis/default_selection_color_alpha"_s, myColor.alpha() );
+  QgsSettingsRegistryCore::settingsDefaultSelectionColor->setValue( myColor );
 
   //set the default color for canvas background
   myColor = pbnCanvasColor->color();

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -753,7 +753,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   }
   whileBlocking( cmbUITheme )->setCurrentIndex( cmbUITheme->findText( theme, Qt::MatchFixedString ) );
 
-  mNativeColorDialogsChkBx->setChecked( mSettings->value( u"/qgis/native_color_dialogs"_s, false ).toBool() );
+  mNativeColorDialogsChkBx->setChecked( QgsSettingsRegistryGui::settingsNativeColorDialogs->value() );
 
   cbxLegendClassifiers->setChecked( mSettings->value( u"/qgis/showLegendClassifiers"_s, false ).toBool() );
   mShowFeatureCountByDefaultCheckBox->setChecked( QgsSettingsRegistryCore::settingsLayerTreeShowFeatureCountForNewLayers->value() );
@@ -1719,7 +1719,7 @@ void QgsOptions::saveOptions()
 
   QgsSettingsRegistryGui::settingsMessageTimeout->setValue( mMessageTimeoutSpnBx->value() );
 
-  mSettings->setValue( u"/qgis/native_color_dialogs"_s, mNativeColorDialogsChkBx->isChecked() );
+  QgsSettingsRegistryGui::settingsNativeColorDialogs->setValue( mNativeColorDialogsChkBx->isChecked() );
 
   //check behavior so default projection when new layer is added with no
   //projection defined...

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -671,7 +671,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mDecimalPlacesSpinBox->setValue( decimalPlaces );
 
   // set if base unit of measure tool should be changed
-  bool baseUnit = mSettings->value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
+  bool baseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
   mKeepBaseUnitCheckBox->setChecked( baseUnit );
 
   mPlanimetricMeasurementsComboBox->setChecked( QgsSettingsRegistryCore::settingsMeasurePlanimetric->value() );
@@ -1763,7 +1763,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( u"/qgis/measure/decimalplaces"_s, decimalPlaces );
 
   bool baseUnit = mKeepBaseUnitCheckBox->isChecked();
-  mSettings->setValue( u"/qgis/measure/keepbaseunit"_s, baseUnit );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( baseUnit );
 
   QgsMeasureDialog::settingClipboardHeader->setValue( mIncludeHeader->isChecked() );
   QgsMeasureDialog::settingClipboardAlwaysUseDecimalPoint->setValue( mAlwaysUseDecimalPoint->isChecked() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -1670,7 +1670,7 @@ void QgsOptions::saveOptions()
   QgisApp::instance()->setMapTipsDelay( mMapTipsDelaySpinBox->value() );
 
   mSettings->setValue( u"/qgis/legendDoubleClickAction"_s, cmbLegendDoubleClickAction->currentIndex() );
-  mSettings->setEnumValue( u"/qgis/layerTreeInsertionMethod"_s, mLayerTreeInsertionMethod->currentData().value<Qgis::LayerTreeInsertionMethod>() );
+  QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod->setValue( mLayerTreeInsertionMethod->currentData().value<Qgis::LayerTreeInsertionMethod>() );
 
   // project
   mSettings->setValue( u"/qgis/projOpenAtLaunch"_s, mProjectOnLaunchCmbBx->currentIndex() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -740,7 +740,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mFontFamilyRadioCustom->blockSignals( false );
   mFontFamilyComboBox->blockSignals( false );
 
-  mMessageTimeoutSpnBx->setValue( mSettings->value( u"/qgis/messageTimeout"_s, 5 ).toInt() );
+  mMessageTimeoutSpnBx->setValue( QgsSettingsRegistryGui::settingsMessageTimeout->value() );
   mMessageTimeoutSpnBx->setClearValue( 5 );
 
   QString name = mSettings->value( u"/qgis/style"_s ).toString();
@@ -1717,7 +1717,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( u"/qgis/style"_s, cmbStyle->currentText() );
   mSettings->setValue( u"/qgis/toolbarIconSize"_s, cmbIconSize->currentText() );
 
-  mSettings->setValue( u"/qgis/messageTimeout"_s, mMessageTimeoutSpnBx->value() );
+  QgsSettingsRegistryGui::settingsMessageTimeout->setValue( mMessageTimeoutSpnBx->value() );
 
   mSettings->setValue( u"/qgis/native_color_dialogs"_s, mNativeColorDialogsChkBx->isChecked() );
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -547,7 +547,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   // cmbScanZipInBrowser->addItem( tr( "Passthru" ) );     // 1 - removed
   cmbScanZipInBrowser->addItem( tr( "Basic Scan" ), QVariant( "basic" ) );
   cmbScanZipInBrowser->addItem( tr( "Full Scan" ), QVariant( "full" ) );
-  index = cmbScanZipInBrowser->findData( mSettings->value( u"/qgis/scanZipInBrowser2"_s, QString() ) );
+  index = cmbScanZipInBrowser->findData( QgsSettingsRegistryCore::settingsScanZipInBrowser->value() );
   if ( index == -1 )
     index = 1;
   cmbScanZipInBrowser->setCurrentIndex( index );
@@ -1652,7 +1652,7 @@ void QgsOptions::saveOptions()
   mSettings->setEnumValue( u"/qgis/promptForSublayers"_s, static_cast<Qgis::SublayerPromptMode>( cmbPromptSublayers->currentData().toInt() ) );
 
   mSettings->setValue( u"/qgis/scanItemsInBrowser2"_s, cmbScanItemsInBrowser->currentData().toString() );
-  mSettings->setValue( u"/qgis/scanZipInBrowser2"_s, cmbScanZipInBrowser->currentData().toString() );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( cmbScanZipInBrowser->currentData().toString() );
   mSettings->setValue( u"/qgis/monitorDirectoriesInBrowser"_s, mCheckMonitorDirectories->isChecked() );
 
   mSettings->setValue( u"/qgis/mainSnappingWidgetMode"_s, mSnappingMainDialogComboBox->currentData() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -813,10 +813,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   pbnCanvasColor->setDefaultColor( Qt::white );
 
   // set the default color for the measure tool
-  red = mSettings->value( u"/qgis/default_measure_color_red"_s, 222 ).toInt();
-  green = mSettings->value( u"/qgis/default_measure_color_green"_s, 155 ).toInt();
-  blue = mSettings->value( u"/qgis/default_measure_color_blue"_s, 67 ).toInt();
-  pbnMeasureColor->setColor( QColor( red, green, blue ) );
+  pbnMeasureColor->setColor( QgsSettingsRegistryGui::settingsDefaultMeasureColor->value() );
   pbnMeasureColor->setColorDialogTitle( tr( "Set Measuring Tool Color" ) );
   pbnMeasureColor->setContext( u"gui"_s );
   pbnMeasureColor->setDefaultColor( QColor( 222, 155, 67 ) );
@@ -1793,9 +1790,7 @@ void QgsOptions::saveOptions()
 
   //set the default color for the measure tool
   myColor = pbnMeasureColor->color();
-  mSettings->setValue( u"/qgis/default_measure_color_red"_s, myColor.red() );
-  mSettings->setValue( u"/qgis/default_measure_color_green"_s, myColor.green() );
-  mSettings->setValue( u"/qgis/default_measure_color_blue"_s, myColor.blue() );
+  QgsSettingsRegistryGui::settingsDefaultMeasureColor->setValue( myColor );
 
   QgsSettingsRegistryGui::settingsZoomFactor->setValue( zoomFactorValue() );
   QgsSettingsRegistryGui::settingsReverseWheelZoom->setValue( reverseWheelZoom->isChecked() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -807,10 +807,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   pbnSelectionColor->setDefaultColor( QColor( 255, 255, 0, 255 ) );
 
   //set the default color for canvas background
-  red = mSettings->value( u"/qgis/default_canvas_color_red"_s, 255 ).toInt();
-  green = mSettings->value( u"/qgis/default_canvas_color_green"_s, 255 ).toInt();
-  blue = mSettings->value( u"/qgis/default_canvas_color_blue"_s, 255 ).toInt();
-  pbnCanvasColor->setColor( QColor( red, green, blue ) );
+  pbnCanvasColor->setColor( QgsSettingsRegistryCore::settingsDefaultCanvasColor->value() );
   pbnCanvasColor->setColorDialogTitle( tr( "Set Canvas Color" ) );
   pbnCanvasColor->setContext( u"gui"_s );
   pbnCanvasColor->setDefaultColor( Qt::white );
@@ -1792,9 +1789,7 @@ void QgsOptions::saveOptions()
 
   //set the default color for canvas background
   myColor = pbnCanvasColor->color();
-  mSettings->setValue( u"/qgis/default_canvas_color_red"_s, myColor.red() );
-  mSettings->setValue( u"/qgis/default_canvas_color_green"_s, myColor.green() );
-  mSettings->setValue( u"/qgis/default_canvas_color_blue"_s, myColor.blue() );
+  QgsSettingsRegistryCore::settingsDefaultCanvasColor->setValue( myColor );
 
   //set the default color for the measure tool
   myColor = pbnMeasureColor->color();

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -887,7 +887,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   setZoomFactorValue();
   spinZoomFactor->setClearValue( 200 );
-  reverseWheelZoom->setChecked( mSettings->value( u"/qgis/reverse_wheel_zoom"_s, false ).toBool() );
+  reverseWheelZoom->setChecked( QgsSettingsRegistryGui::settingsReverseWheelZoom->value() );
 
   // predefined scales for scale combobox
   const QStringList scalePaths = QgsSettingsRegistryCore::settingsMapScales->value();
@@ -1802,8 +1802,8 @@ void QgsOptions::saveOptions()
   mSettings->setValue( u"/qgis/default_measure_color_green"_s, myColor.green() );
   mSettings->setValue( u"/qgis/default_measure_color_blue"_s, myColor.blue() );
 
-  mSettings->setValue( u"/qgis/zoom_factor"_s, zoomFactorValue() );
-  mSettings->setValue( u"/qgis/reverse_wheel_zoom"_s, reverseWheelZoom->isChecked() );
+  QgsSettingsRegistryGui::settingsZoomFactor->setValue( zoomFactorValue() );
+  QgsSettingsRegistryGui::settingsReverseWheelZoom->setValue( reverseWheelZoom->isChecked() );
 
   //digitizing
   QgsSettingsRegistryCore::settingsDigitizingLineWidth->setValue( mLineWidthSpinBox->value() );
@@ -2842,13 +2842,13 @@ double QgsOptions::zoomFactorValue()
 void QgsOptions::setZoomFactorValue()
 {
   // Set the percent value for zoom factor spin box. This function is for converting the decimal zoom factor value in the qgis setting to the percent zoom factor value.
-  if ( mSettings->value( u"/qgis/zoom_factor"_s, 2 ).toDouble() <= 1.01 )
+  if ( QgsSettingsRegistryGui::settingsZoomFactor->value() <= 1.01 )
   {
     spinZoomFactor->setValue( spinZoomFactor->minimum() );
   }
   else
   {
-    int percentValue = mSettings->value( u"/qgis/zoom_factor"_s, 2 ).toDouble() * 100;
+    int percentValue = QgsSettingsRegistryGui::settingsZoomFactor->value() * 100;
     spinZoomFactor->setValue( percentValue );
   }
 }

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -665,7 +665,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mAngleUnitsComboBox->setCurrentIndex( mAngleUnitsComboBox->findData( static_cast<int>( unit ) ) );
 
   // set decimal places of the measure tool
-  int decimalPlaces = mSettings->value( u"/qgis/measure/decimalplaces"_s, 3 ).toInt();
+  int decimalPlaces = QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->value();
   mDecimalPlacesSpinBox->setClearValue( 3 );
   mDecimalPlacesSpinBox->setRange( 0, 12 );
   mDecimalPlacesSpinBox->setValue( decimalPlaces );
@@ -1760,7 +1760,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( u"/qgis/measure/angleunits"_s, QgsUnitTypes::encodeUnit( angleUnit ) );
 
   int decimalPlaces = mDecimalPlacesSpinBox->value();
-  mSettings->setValue( u"/qgis/measure/decimalplaces"_s, decimalPlaces );
+  QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->setValue( decimalPlaces );
 
   bool baseUnit = mKeepBaseUnitCheckBox->isChecked();
   QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( baseUnit );

--- a/src/app/options/qgsrenderingoptions.cpp
+++ b/src/app/options/qgsrenderingoptions.cpp
@@ -19,6 +19,7 @@
 #include "qgsguiutils.h"
 #include "qgssettings.h"
 #include "qgssettingsregistrycore.h"
+#include "qgssettingsregistrygui.h"
 
 #include <QString>
 #include <QThread>
@@ -59,7 +60,7 @@ QgsRenderingOptionsWidget::QgsRenderingOptionsWidget( QWidget *parent )
   doubleSpinBoxMagnifierDefault->setValue( magnifierVal );
   doubleSpinBoxMagnifierDefault->setClearValue( 100 );
 
-  chkAntiAliasing->setChecked( settings.value( u"/qgis/enable_anti_aliasing"_s, true ).toBool() );
+  chkAntiAliasing->setChecked( QgsSettingsRegistryGui::settingsEnableAntiAliasing->value() );
 }
 
 QString QgsRenderingOptionsWidget::helpKey() const
@@ -81,7 +82,7 @@ void QgsRenderingOptionsWidget::apply()
   // magnification
   settings.setValue( u"/qgis/magnifier_factor_default"_s, doubleSpinBoxMagnifierDefault->value() / 100 );
 
-  settings.setValue( u"/qgis/enable_anti_aliasing"_s, chkAntiAliasing->isChecked() );
+  QgsSettingsRegistryGui::settingsEnableAntiAliasing->setValue( chkAntiAliasing->isChecked() );
 }
 
 

--- a/src/app/options/qgsrenderingoptions.cpp
+++ b/src/app/options/qgsrenderingoptions.cpp
@@ -37,7 +37,7 @@ QgsRenderingOptionsWidget::QgsRenderingOptionsWidget( QWidget *parent )
   setupUi( this );
 
   QgsSettings settings;
-  chkAddedVisibility->setChecked( settings.value( u"/qgis/new_layers_visible"_s, true ).toBool() );
+  chkAddedVisibility->setChecked( QgsSettingsRegistryGui::settingsNewLayersVisible->value() );
 
   spinMaxThreads->setRange( 1, QThread::idealThreadCount() );
   spinMaxThreads->setClearValue( 1, tr( "All Available (%1)" ).arg( QThread::idealThreadCount() ) );
@@ -70,7 +70,7 @@ QString QgsRenderingOptionsWidget::helpKey() const
 void QgsRenderingOptionsWidget::apply()
 {
   QgsSettings settings;
-  settings.setValue( u"/qgis/new_layers_visible"_s, chkAddedVisibility->isChecked() );
+  QgsSettingsRegistryGui::settingsNewLayersVisible->setValue( chkAddedVisibility->isChecked() );
 
   const int maxThreads = spinMaxThreads->value() == spinMaxThreads->clearValue() ? -1 : spinMaxThreads->value();
   QgsApplication::setMaxThreads( maxThreads );

--- a/src/app/options/qgsrenderingoptions.cpp
+++ b/src/app/options/qgsrenderingoptions.cpp
@@ -47,7 +47,7 @@ QgsRenderingOptionsWidget::QgsRenderingOptionsWidget( QWidget *parent )
   else
     spinMaxThreads->clear();
 
-  spinMapUpdateInterval->setValue( settings.value( u"/qgis/map_update_interval"_s, 250 ).toInt() );
+  spinMapUpdateInterval->setValue( QgsSettingsRegistryGui::settingsMapUpdateInterval->value() );
   spinMapUpdateInterval->setClearValue( 250 );
 
   double magnifierMin = 100 * QgsGuiUtils::CANVAS_MAGNIFICATION_MIN;
@@ -77,7 +77,7 @@ void QgsRenderingOptionsWidget::apply()
   QgsApplication::setMaxThreads( maxThreads );
   settings.setValue( u"/qgis/max_threads"_s, maxThreads );
 
-  settings.setValue( u"/qgis/map_update_interval"_s, spinMapUpdateInterval->value() );
+  QgsSettingsRegistryGui::settingsMapUpdateInterval->setValue( spinMapUpdateInterval->value() );
 
   // magnification
   settings.setValue( u"/qgis/magnifier_factor_default"_s, doubleSpinBoxMagnifierDefault->value() / 100 );

--- a/src/app/options/qgsrenderingoptions.cpp
+++ b/src/app/options/qgsrenderingoptions.cpp
@@ -52,7 +52,7 @@ QgsRenderingOptionsWidget::QgsRenderingOptionsWidget( QWidget *parent )
 
   double magnifierMin = 100 * QgsGuiUtils::CANVAS_MAGNIFICATION_MIN;
   double magnifierMax = 100 * QgsGuiUtils::CANVAS_MAGNIFICATION_MAX;
-  double magnifierVal = 100 * settings.value( u"/qgis/magnifier_factor_default"_s, 1.0 ).toDouble();
+  double magnifierVal = 100 * QgsSettingsRegistryGui::settingsMagnifierFactorDefault->value();
   doubleSpinBoxMagnifierDefault->setRange( magnifierMin, magnifierMax );
   doubleSpinBoxMagnifierDefault->setSingleStep( 50 );
   doubleSpinBoxMagnifierDefault->setDecimals( 0 );
@@ -80,7 +80,7 @@ void QgsRenderingOptionsWidget::apply()
   QgsSettingsRegistryGui::settingsMapUpdateInterval->setValue( spinMapUpdateInterval->value() );
 
   // magnification
-  settings.setValue( u"/qgis/magnifier_factor_default"_s, doubleSpinBoxMagnifierDefault->value() / 100 );
+  QgsSettingsRegistryGui::settingsMagnifierFactorDefault->setValue( doubleSpinBoxMagnifierDefault->value() / 100 );
 
   QgsSettingsRegistryGui::settingsEnableAntiAliasing->setValue( chkAntiAliasing->isChecked() );
 }

--- a/src/app/options/qgsvectorrenderingoptions.cpp
+++ b/src/app/options/qgsvectorrenderingoptions.cpp
@@ -19,6 +19,7 @@
 #include "qgsapplication.h"
 #include "qgssettings.h"
 #include "qgssettingsentryenumflag.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsvectorlayer.h"
 
 #include <QString>
@@ -49,14 +50,14 @@ QgsVectorRenderingOptionsWidget::QgsVectorRenderingOptionsWidget( QWidget *paren
   //segmentation tolerance type
   mToleranceTypeComboBox->addItem( tr( "Maximum Angle" ), QgsAbstractGeometry::MaximumAngle );
   mToleranceTypeComboBox->addItem( tr( "Maximum Difference" ), QgsAbstractGeometry::MaximumDifference );
-  QgsAbstractGeometry::SegmentationToleranceType toleranceType = settings.enumValue( u"/qgis/segmentationToleranceType"_s, QgsAbstractGeometry::MaximumAngle );
+  QgsAbstractGeometry::SegmentationToleranceType toleranceType = QgsSettingsRegistryGui::settingsSegmentationToleranceType->value();
   int toleranceTypeIndex = mToleranceTypeComboBox->findData( toleranceType );
   if ( toleranceTypeIndex != -1 )
   {
     mToleranceTypeComboBox->setCurrentIndex( toleranceTypeIndex );
   }
 
-  double tolerance = settings.value( u"/qgis/segmentationTolerance"_s, "0.01745" ).toDouble();
+  double tolerance = QgsSettingsRegistryGui::settingsSegmentationTolerance->value();
   if ( toleranceType == QgsAbstractGeometry::MaximumAngle )
   {
     tolerance = tolerance * 180.0 / M_PI; //value shown to the user is degree, not rad
@@ -101,13 +102,13 @@ void QgsVectorRenderingOptionsWidget::apply()
 
   //curve segmentation
   QgsAbstractGeometry::SegmentationToleranceType segmentationType = ( QgsAbstractGeometry::SegmentationToleranceType ) mToleranceTypeComboBox->currentData().toInt();
-  settings.setEnumValue( u"/qgis/segmentationToleranceType"_s, segmentationType );
+  QgsSettingsRegistryGui::settingsSegmentationToleranceType->setValue( segmentationType );
   double segmentationTolerance = mSegmentationToleranceSpinBox->value();
   if ( segmentationType == QgsAbstractGeometry::MaximumAngle )
   {
     segmentationTolerance = segmentationTolerance / 180.0 * M_PI; //user sets angle tolerance in degrees, internal classes need value in rad
   }
-  settings.setValue( u"/qgis/segmentationTolerance"_s, segmentationTolerance );
+  QgsSettingsRegistryGui::settingsSegmentationTolerance->setValue( segmentationTolerance );
 }
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2908,7 +2908,7 @@ void QgisApp::applyDefaultSettingsToCanvas( QgsMapCanvas *canvas )
   canvas->setWheelFactor( zoomFactor );
   canvas->setCachingEnabled( settings.value( u"qgis/enable_render_caching"_s, true ).toBool() );
   canvas->setParallelRenderingEnabled( settings.value( u"qgis/parallel_rendering"_s, true ).toBool() );
-  canvas->setMapUpdateInterval( settings.value( u"qgis/map_update_interval"_s, 250 ).toInt() );
+  canvas->setMapUpdateInterval( QgsSettingsRegistryGui::settingsMapUpdateInterval->value() );
   canvas->setSegmentationTolerance( settings.value( u"qgis/segmentationTolerance"_s, "0.01745" ).toDouble() );
   canvas->setSegmentationToleranceType( QgsAbstractGeometry::SegmentationToleranceType( settings.enumValue( u"qgis/segmentationToleranceType"_s, QgsAbstractGeometry::MaximumAngle ) ) );
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1099,10 +1099,7 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
   mMapCanvas->mapSettings().setFlag( Qgis::MapSettingsFlag::RecordProfile );
 
   // set canvas color right away
-  int myRed = settings.value( u"qgis/default_canvas_color_red"_s, 255 ).toInt();
-  int myGreen = settings.value( u"qgis/default_canvas_color_green"_s, 255 ).toInt();
-  int myBlue = settings.value( u"qgis/default_canvas_color_blue"_s, 255 ).toInt();
-  mMapCanvas->setCanvasColor( QColor( myRed, myGreen, myBlue ) );
+  mMapCanvas->setCanvasColor( QgsSettingsRegistryCore::settingsDefaultCanvasColor->value() );
 
   // set project linked to main canvas
   mMapCanvas->setProject( QgsProject::instance() );
@@ -4619,11 +4616,7 @@ void QgisApp::createOverview()
   mOverviewCanvas = new QgsMapOverviewCanvas( nullptr, mMapCanvas );
 
   //set canvas color to default
-  QgsSettings settings;
-  int red = settings.value( u"qgis/default_canvas_color_red"_s, 255 ).toInt();
-  int green = settings.value( u"qgis/default_canvas_color_green"_s, 255 ).toInt();
-  int blue = settings.value( u"qgis/default_canvas_color_blue"_s, 255 ).toInt();
-  mOverviewCanvas->setBackgroundColor( QColor( red, green, blue ) );
+  mOverviewCanvas->setBackgroundColor( QgsSettingsRegistryCore::settingsDefaultCanvasColor->value() );
 
   mOverviewMapCursor = new QCursor( Qt::OpenHandCursor );
   mOverviewCanvas->setCursor( *mOverviewMapCursor );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4053,7 +4053,7 @@ void QgisApp::createStatusBar()
   connect( mMapCanvas, &QgsMapCanvas::scaleLockChanged, mMagnifierWidget, &QgsStatusBarMagnifierWidget::updateScaleLock );
   connect( mMagnifierWidget, &QgsStatusBarMagnifierWidget::magnificationChanged, mMapCanvas, [this]( double factor ) { mMapCanvas->setMagnificationFactor( factor ); } );
   connect( mMagnifierWidget, &QgsStatusBarMagnifierWidget::scaleLockChanged, mMapCanvas, &QgsMapCanvas::setScaleLocked );
-  mMagnifierWidget->updateMagnification( QSettings().value( u"/qgis/magnifier_factor_default"_s, 1.0 ).toDouble() );
+  mMagnifierWidget->updateMagnification( QgsSettingsRegistryGui::settingsMagnifierFactorDefault->value() );
   mStatusBar->addPermanentWidget( mMagnifierWidget, 0 );
 
   // add a widget to show/set current rotation
@@ -12809,7 +12809,7 @@ void QgisApp::showOptionsDialog( QWidget *parent, const QString &currentPage, in
     }
 #endif
 
-    double factor = mySettings.value( u"qgis/magnifier_factor_default"_s, 1.0 ).toDouble();
+    double factor = QgsSettingsRegistryGui::settingsMagnifierFactorDefault->value();
     mMagnifierWidget->setDefaultFactor( factor );
     mMagnifierWidget->updateMagnification( factor );
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -83,6 +83,7 @@ using namespace Qt::StringLiterals;
 #include "qgsmaplayerutils.h"
 #include "qgsscreenhelper.h"
 #include "qgssettingsregistrycore.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsapplication.h"
 #include "qgslayerstylingwidget.h"
@@ -2903,7 +2904,7 @@ void QgisApp::applyDefaultSettingsToCanvas( QgsMapCanvas *canvas )
 {
   QgsSettings settings;
   canvas->enableAntiAliasing( settings.value( u"qgis/enable_anti_aliasing"_s, true ).toBool() );
-  double zoomFactor = settings.value( u"qgis/zoom_factor"_s, 2 ).toDouble();
+  double zoomFactor = QgsSettingsRegistryGui::settingsZoomFactor->value();
   canvas->setWheelFactor( zoomFactor );
   canvas->setCachingEnabled( settings.value( u"qgis/enable_render_caching"_s, true ).toBool() );
   canvas->setParallelRenderingEnabled( settings.value( u"qgis/parallel_rendering"_s, true ).toBool() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5937,7 +5937,7 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
   // set project CRS
   const QgsCoordinateReferenceSystem srs = QgsCoordinateReferenceSystem( settings.value( u"/projections/defaultProjectCrs"_s, Qgis::geographicCrsAuthId(), QgsSettings::App ).toString() );
   // write the projections _proj string_ to project settings
-  const bool planimetric = settings.value( u"measure/planimetric"_s, true, QgsSettings::Core ).toBool();
+  const bool planimetric = QgsSettingsRegistryCore::settingsMeasurePlanimetric->value();
   prj->setCrs( srs, !planimetric ); // If the default ellipsoid is not planimetric, set it from the default crs
   if ( planimetric )
     prj->setEllipsoid( Qgis::geoNone() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14809,7 +14809,7 @@ void QgisApp::showPanMessage( double distance, Qgis::DistanceUnit unit, double b
     return;
 
   const double distanceInProjectUnits = distance * QgsUnitTypes::fromUnitToUnitFactor( unit, QgsProject::instance()->distanceUnits() );
-  const int distanceDecimalPlaces = QgsSettings().value( u"qgis/measure/decimalplaces"_s, 3 ).toInt();
+  const int distanceDecimalPlaces = QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->value();
   const QString distanceString = QgsDistanceArea::formatDistance( distanceInProjectUnits, distanceDecimalPlaces, QgsProject::instance()->distanceUnits() );
   const QString bearingString = mBearingNumericFormat->formatDouble( bearing, QgsNumericFormatContext() );
   mStatusBar->showMessage( tr( "Pan distance %1 (%2)" ).arg( distanceString, bearingString ), 2000 );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5918,7 +5918,7 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
 
   QgsProject *prj = QgsProject::instance();
   prj->layerTreeRegistryBridge()->setNewLayersVisible( settings.value( u"qgis/new_layers_visible"_s, true ).toBool() );
-  prj->layerTreeRegistryBridge()->setLayerInsertionMethod( settings.enumValue( u"qgis/layerTreeInsertionMethod"_s, Qgis::LayerTreeInsertionMethod::AboveInsertionPoint ) );
+  prj->layerTreeRegistryBridge()->setLayerInsertionMethod( QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod->value() );
 
   //set the canvas to the default project background color
   mOverviewCanvas->setBackgroundColor( prj->backgroundColor() );
@@ -10667,7 +10667,7 @@ void QgisApp::pasteLayer()
     }
 
     QgsSettings settings;
-    Qgis::LayerTreeInsertionMethod insertionMethod = settings.enumValue( u"/qgis/layerTreeInsertionMethod"_s, Qgis::LayerTreeInsertionMethod::OptimalInInsertionGroup );
+    Qgis::LayerTreeInsertionMethod insertionMethod = QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod->value();
     QgsLayerTreeRegistryBridge::InsertionPoint insertionPoint = layerTreeInsertionPoint();
     bool loaded = QgsLayerDefinition::loadLayerDefinition( doc, QgsProject::instance(), root, errorMessage, readWriteContext, insertionMethod, &insertionPoint );
 
@@ -12765,7 +12765,7 @@ void QgisApp::showOptionsDialog( QWidget *parent, const QString &currentPage, in
   if ( optionsDialog->exec() )
   {
     QgsProject::instance()->layerTreeRegistryBridge()->setNewLayersVisible( mySettings.value( u"qgis/new_layers_visible"_s, true ).toBool() );
-    QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionMethod( mySettings.enumValue( u"qgis/layerTreeInsertionMethod"_s, Qgis::LayerTreeInsertionMethod::AboveInsertionPoint ) );
+    QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionMethod( QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod->value() );
 
     setupLayerTreeViewFromSettings();
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2903,7 +2903,7 @@ void QgisApp::applyProjectSettingsToCanvas( QgsMapCanvas *canvas )
 void QgisApp::applyDefaultSettingsToCanvas( QgsMapCanvas *canvas )
 {
   QgsSettings settings;
-  canvas->enableAntiAliasing( settings.value( u"qgis/enable_anti_aliasing"_s, true ).toBool() );
+  canvas->enableAntiAliasing( QgsSettingsRegistryGui::settingsEnableAntiAliasing->value() );
   double zoomFactor = QgsSettingsRegistryGui::settingsZoomFactor->value();
   canvas->setWheelFactor( zoomFactor );
   canvas->setCachingEnabled( settings.value( u"qgis/enable_render_caching"_s, true ).toBool() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2909,7 +2909,7 @@ void QgisApp::applyDefaultSettingsToCanvas( QgsMapCanvas *canvas )
   canvas->setCachingEnabled( settings.value( u"qgis/enable_render_caching"_s, true ).toBool() );
   canvas->setParallelRenderingEnabled( settings.value( u"qgis/parallel_rendering"_s, true ).toBool() );
   canvas->setMapUpdateInterval( QgsSettingsRegistryGui::settingsMapUpdateInterval->value() );
-  canvas->setSegmentationTolerance( settings.value( u"qgis/segmentationTolerance"_s, "0.01745" ).toDouble() );
+  canvas->setSegmentationTolerance( QgsSettingsRegistryGui::settingsSegmentationTolerance->value() );
   canvas->setSegmentationToleranceType( QgsAbstractGeometry::SegmentationToleranceType( settings.enumValue( u"qgis/segmentationToleranceType"_s, QgsAbstractGeometry::MaximumAngle ) ) );
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5917,7 +5917,7 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
   closeProject();
 
   QgsProject *prj = QgsProject::instance();
-  prj->layerTreeRegistryBridge()->setNewLayersVisible( settings.value( u"qgis/new_layers_visible"_s, true ).toBool() );
+  prj->layerTreeRegistryBridge()->setNewLayersVisible( QgsSettingsRegistryGui::settingsNewLayersVisible->value() );
   prj->layerTreeRegistryBridge()->setLayerInsertionMethod( QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod->value() );
 
   //set the canvas to the default project background color
@@ -12764,7 +12764,7 @@ void QgisApp::showOptionsDialog( QWidget *parent, const QString &currentPage, in
 
   if ( optionsDialog->exec() )
   {
-    QgsProject::instance()->layerTreeRegistryBridge()->setNewLayersVisible( mySettings.value( u"qgis/new_layers_visible"_s, true ).toBool() );
+    QgsProject::instance()->layerTreeRegistryBridge()->setNewLayersVisible( QgsSettingsRegistryGui::settingsNewLayersVisible->value() );
     QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionMethod( QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod->value() );
 
     setupLayerTreeViewFromSettings();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -83,6 +83,7 @@ using namespace Qt::StringLiterals;
 #include "qgsmaplayerutils.h"
 #include "qgsscreenhelper.h"
 #include "qgssettingsregistrycore.h"
+#include "qgssettingsentryenumflag.h"
 #include "qgssettingsregistrygui.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsapplication.h"
@@ -2907,7 +2908,7 @@ void QgisApp::applyDefaultSettingsToCanvas( QgsMapCanvas *canvas )
   canvas->setParallelRenderingEnabled( settings.value( u"qgis/parallel_rendering"_s, true ).toBool() );
   canvas->setMapUpdateInterval( QgsSettingsRegistryGui::settingsMapUpdateInterval->value() );
   canvas->setSegmentationTolerance( QgsSettingsRegistryGui::settingsSegmentationTolerance->value() );
-  canvas->setSegmentationToleranceType( QgsAbstractGeometry::SegmentationToleranceType( settings.enumValue( u"qgis/segmentationToleranceType"_s, QgsAbstractGeometry::MaximumAngle ) ) );
+  canvas->setSegmentationToleranceType( QgsSettingsRegistryGui::settingsSegmentationToleranceType->value() );
 }
 
 void QgisApp::readSettings()

--- a/src/app/qgsanimationexportdialog.cpp
+++ b/src/app/qgsanimationexportdialog.cpp
@@ -22,6 +22,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsmapdecoration.h"
 #include "qgsprojecttimesettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrygui.h"
 #include "qgstemporalnavigationobject.h"
 #include "qgstemporalutils.h"

--- a/src/app/qgsanimationexportdialog.cpp
+++ b/src/app/qgsanimationexportdialog.cpp
@@ -22,6 +22,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsmapdecoration.h"
 #include "qgsprojecttimesettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgstemporalnavigationobject.h"
 #include "qgstemporalutils.h"
 #include "qgsunittypes.h"
@@ -245,8 +246,8 @@ void QgsAnimationExportDialog::applyMapSettings( QgsMapSettings &mapSettings )
 {
   const QgsSettings settings;
 
-  mapSettings.setFlag( Qgis::MapSettingsFlag::Antialiasing, settings.value( u"qgis/enable_anti_aliasing"_s, true ).toBool() );
-  mapSettings.setFlag( Qgis::MapSettingsFlag::HighQualityImageTransforms, settings.value( u"qgis/enable_anti_aliasing"_s, true ).toBool() );
+  mapSettings.setFlag( Qgis::MapSettingsFlag::Antialiasing, QgsSettingsRegistryGui::settingsEnableAntiAliasing->value() );
+  mapSettings.setFlag( Qgis::MapSettingsFlag::HighQualityImageTransforms, QgsSettingsRegistryGui::settingsEnableAntiAliasing->value() );
   mapSettings.setFlag( Qgis::MapSettingsFlag::DrawEditingInfo, false );
   mapSettings.setFlag( Qgis::MapSettingsFlag::DrawSelection, false );
   mapSettings.setSelectionColor( mMapCanvas->mapSettings().selectionColor() );

--- a/src/app/qgsdisplayangle.cpp
+++ b/src/app/qgsdisplayangle.cpp
@@ -24,6 +24,7 @@
 #include "qgsproject.h"
 #include "qgsprojectdisplaysettings.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsunittypes.h"
 
 #include <QString>
@@ -45,7 +46,7 @@ void QgsDisplayAngle::setAngleInRadians( double value )
 
   const QgsSettings settings;
   const Qgis::AngleUnit unit = QgsUnitTypes::decodeAngleUnit( settings.value( u"qgis/measure/angleunits"_s, QgsUnitTypes::encodeUnit( Qgis::AngleUnit::Degrees ) ).toString() );
-  const int decimals = settings.value( u"qgis/measure/decimalplaces"_s, 3 ).toInt();
+  const int decimals = QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->value();
   mAngleLineEdit->setText( QgsUnitTypes::formatAngle( mValue * QgsUnitTypes::fromUnitToUnitFactor( Qgis::AngleUnit::Radians, unit ), decimals, unit ) );
 }
 

--- a/src/app/qgsdisplayangle.cpp
+++ b/src/app/qgsdisplayangle.cpp
@@ -24,6 +24,7 @@
 #include "qgsproject.h"
 #include "qgsprojectdisplaysettings.h"
 #include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsunittypes.h"
 

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -31,6 +31,7 @@
 #include "qgsrubberband.h"
 #include "qgsscalecombobox.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsvectorlayer.h"
 #include "qgsvertexmarker.h"
 
@@ -616,7 +617,7 @@ QgsMapSettingsAction::QgsMapSettingsAction( QWidget *parent )
   const QgsSettings settings;
   const int minimumFactor = 100 * QgsGuiUtils::CANVAS_MAGNIFICATION_MIN;
   const int maximumFactor = 100 * QgsGuiUtils::CANVAS_MAGNIFICATION_MAX;
-  const int defaultFactor = 100 * settings.value( u"/qgis/magnifier_factor_default"_s, 1.0 ).toDouble();
+  const int defaultFactor = 100 * QgsSettingsRegistryGui::settingsMagnifierFactorDefault->value();
 
   mMagnifierWidget = new QgsDoubleSpinBox();
   mMagnifierWidget->setSuffix( u"%"_s );

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -38,6 +38,7 @@
 #include "qgsproject.h"
 #include "qgsscalecalculator.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 
 #include <QCheckBox>
 #include <QClipboard>
@@ -358,8 +359,8 @@ void QgsMapSaveDialog::applyMapSettings( QgsMapSettings &mapSettings )
       break;
 
     case Image:
-      mapSettings.setFlag( Qgis::MapSettingsFlag::Antialiasing, settings.value( u"qgis/enable_anti_aliasing"_s, true ).toBool() );
-      mapSettings.setFlag( Qgis::MapSettingsFlag::HighQualityImageTransforms, settings.value( u"qgis/enable_anti_aliasing"_s, true ).toBool() );
+      mapSettings.setFlag( Qgis::MapSettingsFlag::Antialiasing, QgsSettingsRegistryGui::settingsEnableAntiAliasing->value() );
+      mapSettings.setFlag( Qgis::MapSettingsFlag::HighQualityImageTransforms, QgsSettingsRegistryGui::settingsEnableAntiAliasing->value() );
       break;
   }
 

--- a/src/app/qgsmaptoolmeasureangle.cpp
+++ b/src/app/qgsmaptoolmeasureangle.cpp
@@ -25,6 +25,7 @@
 #include "qgsproject.h"
 #include "qgsrubberband.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgssnapindicator.h"
 
 #include <QString>
@@ -187,11 +188,8 @@ void QgsMapToolMeasureAngle::createRubberBand()
   delete mRubberBand;
   mRubberBand = new QgsRubberBand( mCanvas, Qgis::GeometryType::Line );
 
-  const QgsSettings settings;
-  const int myRed = settings.value( u"qgis/default_measure_color_red"_s, 180 ).toInt();
-  const int myGreen = settings.value( u"qgis/default_measure_color_green"_s, 180 ).toInt();
-  const int myBlue = settings.value( u"qgis/default_measure_color_blue"_s, 180 ).toInt();
-  mRubberBand->setColor( QColor( myRed, myGreen, myBlue, 100 ) );
+  const QColor measureColor = QgsSettingsRegistryGui::settingsDefaultMeasureColor->value();
+  mRubberBand->setColor( QColor( measureColor.red(), measureColor.green(), measureColor.blue(), 100 ) );
   mRubberBand->setWidth( 3 );
 }
 

--- a/src/app/qgsmaptoolmeasureangle.cpp
+++ b/src/app/qgsmaptoolmeasureangle.cpp
@@ -24,7 +24,7 @@
 #include "qgsmapmouseevent.h"
 #include "qgsproject.h"
 #include "qgsrubberband.h"
-#include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrygui.h"
 #include "qgssnapindicator.h"
 

--- a/src/app/qgsmaptoolmeasurebearing.cpp
+++ b/src/app/qgsmaptoolmeasurebearing.cpp
@@ -23,7 +23,7 @@
 #include "qgsmapmouseevent.h"
 #include "qgsproject.h"
 #include "qgsrubberband.h"
-#include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrygui.h"
 #include "qgssnapindicator.h"
 

--- a/src/app/qgsmaptoolmeasurebearing.cpp
+++ b/src/app/qgsmaptoolmeasurebearing.cpp
@@ -24,6 +24,7 @@
 #include "qgsproject.h"
 #include "qgsrubberband.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgssnapindicator.h"
 
 #include <QString>
@@ -165,11 +166,8 @@ void QgsMapToolMeasureBearing::createRubberBand()
   delete mRubberBand;
   mRubberBand = new QgsRubberBand( mCanvas, Qgis::GeometryType::Line );
 
-  const QgsSettings settings;
-  const int myRed = settings.value( u"qgis/default_measure_color_red"_s, 180 ).toInt();
-  const int myGreen = settings.value( u"qgis/default_measure_color_green"_s, 180 ).toInt();
-  const int myBlue = settings.value( u"qgis/default_measure_color_blue"_s, 180 ).toInt();
-  mRubberBand->setColor( QColor( myRed, myGreen, myBlue, 100 ) );
+  const QColor measureColor = QgsSettingsRegistryGui::settingsDefaultMeasureColor->value();
+  mRubberBand->setColor( QColor( measureColor.red(), measureColor.green(), measureColor.blue(), 100 ) );
   mRubberBand->setWidth( 3 );
 }
 

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -445,7 +445,7 @@ void QgsMeasureDialog::saveWindowLocation()
 QString QgsMeasureDialog::formatDistance( double distance, bool convertUnits ) const
 {
   const QgsSettings settings;
-  const bool baseUnit = settings.value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
+  const bool baseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
 
   if ( convertUnits )
     distance = convertLength( distance, mDistanceUnits );

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -26,6 +26,7 @@
 #include "qgsproject.h"
 #include "qgssettings.h"
 #include "qgssettingsentryimpl.h"
+#include "qgssettingsregistrycore.h"
 #include "qgssettingstree.h"
 #include "qgsunittypes.h"
 
@@ -161,7 +162,7 @@ void QgsMeasureDialog::updateSettings()
 {
   const QgsSettings settings;
 
-  mDecimalPlaces = settings.value( u"qgis/measure/decimalplaces"_s, 3 ).toInt();
+  mDecimalPlaces = QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->value();
   mCanvasUnits = mCanvas->mapUnits();
 
   // Configure QgsDistanceArea

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -24,6 +24,7 @@
 #include "qgsproject.h"
 #include "qgsrubberband.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgssnapindicator.h"
 
 #include <QMessageBox>
@@ -126,16 +127,12 @@ void QgsMeasureTool::restart()
 
 void QgsMeasureTool::updateSettings()
 {
-  const QgsSettings settings;
-
-  const int myRed = settings.value( u"qgis/default_measure_color_red"_s, 222 ).toInt();
-  const int myGreen = settings.value( u"qgis/default_measure_color_green"_s, 155 ).toInt();
-  const int myBlue = settings.value( u"qgis/default_measure_color_blue"_s, 67 ).toInt();
-  mRubberBand->setColor( QColor( myRed, myGreen, myBlue, 100 ) );
+  const QColor measureColor = QgsSettingsRegistryGui::settingsDefaultMeasureColor->value();
+  mRubberBand->setColor( QColor( measureColor.red(), measureColor.green(), measureColor.blue(), 100 ) );
   mRubberBand->setWidth( 3 );
   mRubberBandPoints->setIcon( QgsRubberBand::ICON_CIRCLE );
   mRubberBandPoints->setIconSize( 10 );
-  mRubberBandPoints->setColor( QColor( myRed, myGreen, myBlue, 150 ) );
+  mRubberBandPoints->setColor( QColor( measureColor.red(), measureColor.green(), measureColor.blue(), 150 ) );
 
   // Reproject the points to the new destination CoordinateReferenceSystem
   if ( mRubberBand->size() > 0 && mDestinationCrs != mCanvas->mapSettings().destinationCrs() && mCanvas->mapSettings().destinationCrs().isValid() )

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -23,7 +23,7 @@
 #include "qgsmessagelog.h"
 #include "qgsproject.h"
 #include "qgsrubberband.h"
-#include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrygui.h"
 #include "qgssnapindicator.h"
 

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -75,6 +75,7 @@ using namespace Qt::StringLiterals;
 #include "qgsprojecttimesettings.h"
 #include "qgstemporalutils.h"
 #include "qgsstylemanagerdialog.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsfileutils.h"
 
 //qt includes
@@ -478,10 +479,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   pbnSelectionColor->setAllowOpacity( true );
 
   //get the color for map canvas background and set button color accordingly (default white)
-  myRedInt = settings.value( u"qgis/default_canvas_color_red"_s, 255 ).toInt();
-  myGreenInt = settings.value( u"qgis/default_canvas_color_green"_s, 255 ).toInt();
-  myBlueInt = settings.value( u"qgis/default_canvas_color_blue"_s, 255 ).toInt();
-  QColor defaultCanvasColor = QColor( myRedInt, myGreenInt, myBlueInt );
+  QColor defaultCanvasColor = QgsSettingsRegistryCore::settingsDefaultCanvasColor->value();
 
   pbnCanvasColor->setContext( u"gui"_s );
   pbnCanvasColor->setColor( QgsProject::instance()->backgroundColor() );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -466,11 +466,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mScaleMethodWidget->setScaleMethod( QgsProject::instance()->scaleMethod() );
 
   //get the color selections and set the button color accordingly
-  int myRedInt = settings.value( u"qgis/default_selection_color_red"_s, 255 ).toInt();
-  int myGreenInt = settings.value( u"qgis/default_selection_color_green"_s, 255 ).toInt();
-  int myBlueInt = settings.value( u"qgis/default_selection_color_blue"_s, 0 ).toInt();
-  int myAlphaInt = settings.value( u"qgis/default_selection_color_alpha"_s, 255 ).toInt();
-  QColor defaultSelectionColor = QColor( myRedInt, myGreenInt, myBlueInt, myAlphaInt );
+  QColor defaultSelectionColor = QgsSettingsRegistryCore::settingsDefaultSelectionColor->value();
 
   pbnSelectionColor->setContext( u"gui"_s );
   pbnSelectionColor->setColor( QgsProject::instance()->selectionColor() );

--- a/src/app/qgsstatusbarmagnifierwidget.cpp
+++ b/src/app/qgsstatusbarmagnifierwidget.cpp
@@ -20,6 +20,7 @@
 #include "qgsdoublespinbox.h"
 #include "qgsguiutils.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 
 #include <QFont>
 #include <QHBoxLayout>
@@ -37,7 +38,7 @@ QgsStatusBarMagnifierWidget::QgsStatusBarMagnifierWidget( QWidget *parent )
   const QgsSettings settings;
   const int minimumFactor = 100 * QgsGuiUtils::CANVAS_MAGNIFICATION_MIN;
   const int maximumFactor = 100 * QgsGuiUtils::CANVAS_MAGNIFICATION_MAX;
-  const int defaultFactor = 100 * settings.value( u"qgis/magnifier_factor_default"_s, 1.0 ).toDouble();
+  const int defaultFactor = 100 * QgsSettingsRegistryGui::settingsMagnifierFactorDefault->value();
 
   // label
   mLabel = new QLabel();

--- a/src/app/qgstemplateprojectsmodel.cpp
+++ b/src/app/qgstemplateprojectsmodel.cpp
@@ -21,6 +21,7 @@
 #include "qgsapplication.h"
 #include "qgsproject.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsziputils.h"
 
 #include <QApplication>
@@ -53,11 +54,7 @@ QgsTemplateProjectsModel::QgsTemplateProjectsModel( QObject *parent )
 
   setColumnCount( 1 );
 
-  const QgsSettings settings;
-  const int red = settings.value( u"qgis/default_canvas_color_red"_s, 255 ).toInt();
-  const int green = settings.value( u"qgis/default_canvas_color_green"_s, 255 ).toInt();
-  const int blue = settings.value( u"qgis/default_canvas_color_blue"_s, 255 ).toInt();
-  const QColor canvasColor( red, green, blue );
+  const QColor canvasColor = QgsSettingsRegistryCore::settingsDefaultCanvasColor->value();
 
   QStandardItem *emptyProjectItem = new QStandardItem();
   emptyProjectItem->setData( false, static_cast<int>( CustomRole::WritableRole ) );
@@ -119,11 +116,7 @@ void QgsTemplateProjectsModel::scanDirectory( const QString &path )
   }
 
   // Use default canvas color when preview image is missing
-  const QgsSettings settings;
-  const int red = settings.value( u"qgis/default_canvas_color_red"_s, 255 ).toInt();
-  const int green = settings.value( u"qgis/default_canvas_color_green"_s, 255 ).toInt();
-  const int blue = settings.value( u"qgis/default_canvas_color_blue"_s, 255 ).toInt();
-  const QColor canvasColor( red, green, blue );
+  const QColor canvasColor = QgsSettingsRegistryCore::settingsDefaultCanvasColor->value();
 
   // Refill with templates from this directory
   for ( const QFileInfo &file : files )

--- a/src/core/browser/qgsfilebaseddataitemprovider.cpp
+++ b/src/core/browser/qgsfilebaseddataitemprovider.cpp
@@ -28,6 +28,7 @@
 #include "qgsproviderutils.h"
 #include "qgsrelationshipsitem.h"
 #include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsstyle.h"
 

--- a/src/core/browser/qgsfilebaseddataitemprovider.cpp
+++ b/src/core/browser/qgsfilebaseddataitemprovider.cpp
@@ -28,6 +28,7 @@
 #include "qgsproviderutils.h"
 #include "qgsrelationshipsitem.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsstyle.h"
 
 #include <QString>
@@ -622,7 +623,7 @@ QgsDataItem *QgsFileBasedDataItemProvider::createDataItemForPathPrivate(
 
   // should we fast scan only?
   if ( ( settings.value( u"qgis/scanItemsInBrowser2"_s, "extension" ).toString() == "extension"_L1 )
-       || ( parentItem && settings.value( u"qgis/scanItemsFastScanUris"_s, QStringList() ).toStringList().contains( parentItem->path() ) ) )
+       || ( parentItem && QgsSettingsRegistryCore::settingsScanItemsFastScanUris->value().contains( parentItem->path() ) ) )
   {
     queryFlags |= Qgis::SublayerQueryFlag::FastScan;
   }

--- a/src/core/browser/qgszipitem.cpp
+++ b/src/core/browser/qgszipitem.cpp
@@ -26,6 +26,7 @@
 #include "qgsdataitemproviderregistry.h"
 #include "qgsgdalutils.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 
 #include <QFileInfo>
 #include <QString>
@@ -93,8 +94,7 @@ QVector<QgsDataItem *> QgsZipItem::createChildren()
 {
   QVector<QgsDataItem *> children;
   QString tmpPath;
-  const QgsSettings settings;
-  const QString scanZipSetting = settings.value( u"qgis/scanZipInBrowser2"_s, "basic" ).toString();
+  const QString scanZipSetting = QgsSettingsRegistryCore::settingsScanZipInBrowser->value();
 
   mZipFileList.clear();
 
@@ -163,8 +163,7 @@ QgsDataItem *QgsZipItem::itemFromPath( QgsDataItem *parent, const QString &path,
 
 QgsDataItem *QgsZipItem::itemFromPath( QgsDataItem *parent, const QString &filePath, const QString &name, const QString &path )
 {
-  const QgsSettings settings;
-  const QString scanZipSetting = settings.value( u"qgis/scanZipInBrowser2"_s, "basic" ).toString();
+  const QString scanZipSetting = QgsSettingsRegistryCore::settingsScanZipInBrowser->value();
   QStringList zipFileList;
   const QString vsiPrefix = QgsGdalUtils::vsiPrefixForPath( filePath );
   bool populated = false;
@@ -218,8 +217,7 @@ QStringList QgsZipItem::getZipFileList()
     return mZipFileList;
 
   QString tmpPath;
-  const QgsSettings settings;
-  const QString scanZipSetting = settings.value( u"qgis/scanZipInBrowser2"_s, "basic" ).toString();
+  const QString scanZipSetting = QgsSettingsRegistryCore::settingsScanZipInBrowser->value();
 
   QgsDebugMsgLevel( u"mFilePath = %1 name= %2 scanZipSetting= %3 vsiPrefix= %4"_s.arg( mFilePath, name(), scanZipSetting, mVsiPrefix ), 3 );
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1326,14 +1326,11 @@ void QgsProject::clear()
   const bool defaultRelativePaths = mSettings.value( u"/qgis/defaultProjectPathsRelative"_s, true ).toBool();
   setFilePathStorage( defaultRelativePaths ? Qgis::FilePathType::Relative : Qgis::FilePathType::Absolute );
 
-  int red = mSettings.value( u"qgis/default_canvas_color_red"_s, 255 ).toInt();
-  int green = mSettings.value( u"qgis/default_canvas_color_green"_s, 255 ).toInt();
-  int blue = mSettings.value( u"qgis/default_canvas_color_blue"_s, 255 ).toInt();
-  setBackgroundColor( QColor( red, green, blue ) );
+  setBackgroundColor( QgsSettingsRegistryCore::settingsDefaultCanvasColor->value() );
 
-  red = mSettings.value( u"qgis/default_selection_color_red"_s, 255 ).toInt();
-  green = mSettings.value( u"qgis/default_selection_color_green"_s, 255 ).toInt();
-  blue = mSettings.value( u"qgis/default_selection_color_blue"_s, 0 ).toInt();
+  int red = mSettings.value( u"qgis/default_selection_color_red"_s, 255 ).toInt();
+  int green = mSettings.value( u"qgis/default_selection_color_green"_s, 255 ).toInt();
+  int blue = mSettings.value( u"qgis/default_selection_color_blue"_s, 0 ).toInt();
   const int alpha = mSettings.value( u"qgis/default_selection_color_alpha"_s, 255 ).toInt();
   setSelectionColor( QColor( red, green, blue, alpha ) );
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1268,7 +1268,7 @@ void QgsProject::clear()
 
   //fallback to QGIS default measurement unit
   bool ok = false;
-  const Qgis::DistanceUnit distanceUnit = QgsUnitTypes::decodeDistanceUnit( mSettings.value( u"/qgis/measure/displayunits"_s ).toString(), &ok );
+  const Qgis::DistanceUnit distanceUnit = QgsUnitTypes::decodeDistanceUnit( QgsSettingsRegistryCore::settingsMeasureDisplayUnits->value(), &ok );
   setDistanceUnits( ok ? distanceUnit : Qgis::DistanceUnit::Meters );
   ok = false;
   const Qgis::AreaUnit areaUnits = QgsUnitTypes::decodeAreaUnit( mSettings.value( u"/qgis/measure/areaunits"_s ).toString(), &ok );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1328,11 +1328,7 @@ void QgsProject::clear()
 
   setBackgroundColor( QgsSettingsRegistryCore::settingsDefaultCanvasColor->value() );
 
-  int red = mSettings.value( u"qgis/default_selection_color_red"_s, 255 ).toInt();
-  int green = mSettings.value( u"qgis/default_selection_color_green"_s, 255 ).toInt();
-  int blue = mSettings.value( u"qgis/default_selection_color_blue"_s, 0 ).toInt();
-  const int alpha = mSettings.value( u"qgis/default_selection_color_alpha"_s, 255 ).toInt();
-  setSelectionColor( QColor( red, green, blue, alpha ) );
+  setSelectionColor( QgsSettingsRegistryCore::settingsDefaultSelectionColor->value() );
 
   mSnappingConfig.clearIndividualLayerSettings();
 

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -44,6 +44,7 @@ using namespace Qt::StringLiterals;
 #include "qgsrasterpyramid.h"
 #include "qgspointxy.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsprovidersublayerdetails.h"
 #include "qgsproviderutils.h"
@@ -3002,8 +3003,7 @@ void buildSupportedRasterFileFilterAndExtensions( QString &fileFiltersString, QS
   fileFiltersString = filters.join( ";;"_L1 ) + ";;";
 
   // VSIFileHandler (see qgsogrprovider.cpp) - second
-  QgsSettings settings;
-  if ( settings.value( u"qgis/scanZipInBrowser2"_s, "basic" ).toString() != "no"_L1 )
+  if ( QgsSettingsRegistryCore::settingsScanZipInBrowser->value() != "no"_L1 )
   {
     fileFiltersString.prepend( createFileFilter_( QObject::tr( "GDAL/OGR VSIFileHandler" ), u"*.zip *.gz *.tar *.tar.gz *.tgz"_s ) );
     extensions << u"zip"_s << u"gz"_s << u"tar"_s << u"tar.gz"_s << u"tgz"_s;

--- a/src/core/providers/ogr/qgsogrproviderutils.cpp
+++ b/src/core/providers/ogr/qgsogrproviderutils.cpp
@@ -30,6 +30,7 @@ email                : nyall dot dawson at gmail dot com
 #include "qgsproviderregistry.h"
 #include "qgsprovidersublayerdetails.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgssqlstatement.h"
 #include "qgsvariantutils.h"
 #include "qgsvectorfilewriter.h"
@@ -617,8 +618,7 @@ QString createFilters( const QString &type )
     //   see http://trac.osgeo.org/gdal/wiki/UserDocs/ReadInZip
     // Requires GDAL>=1.6.0 with libz support, let's assume we have it.
     // This does not work for some file types, see VSIFileHandler doc.
-    QgsSettings settings;
-    if ( settings.value( u"qgis/scanZipInBrowser2"_s, "basic" ).toString() != "no"_L1 )
+    if ( QgsSettingsRegistryCore::settingsScanZipInBrowser->value() != "no"_L1 )
     {
       sFileFilters.prepend( createFileFilter_( QObject::tr( "GDAL/OGR VSIFileHandler" ), u"*.zip *.gz *.tar *.tar.gz *.tgz"_s ) );
       sExtensions << u"zip"_s << u"gz"_s << u"tar"_s << u"tar.gz"_s << u"tgz"_s;

--- a/src/core/qgsmeasureutils.cpp
+++ b/src/core/qgsmeasureutils.cpp
@@ -20,6 +20,7 @@
 #include "qgis.h"
 #include "qgsproject.h"
 #include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsunittypes.h"
 

--- a/src/core/qgsmeasureutils.cpp
+++ b/src/core/qgsmeasureutils.cpp
@@ -31,7 +31,7 @@ using namespace Qt::StringLiterals;
 QString QgsMeasureUtils::formatAreaForProject( QgsProject *project, double area, Qgis::AreaUnit unit )
 {
   QgsSettings settings;
-  const bool keepBaseUnit = settings.value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
+  const bool keepBaseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
 
   const Qgis::AreaUnit targetUnit = project->areaUnits();
   const double areaInTargetUnits = QgsUnitTypes::fromUnitToUnitFactor( unit, targetUnit ) * area;
@@ -64,7 +64,7 @@ QString QgsMeasureUtils::formatAreaForProject( QgsProject *project, double area,
 QString QgsMeasureUtils::formatDistanceForProject( QgsProject *project, double distance, Qgis::DistanceUnit unit )
 {
   QgsSettings settings;
-  const bool keepBaseUnit = settings.value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
+  const bool keepBaseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
 
   const Qgis::DistanceUnit targetUnit = project->distanceUnits();
   const double distanceInTargetUnits = QgsUnitTypes::fromUnitToUnitFactor( unit, targetUnit ) * distance;

--- a/src/core/qgsmeasureutils.cpp
+++ b/src/core/qgsmeasureutils.cpp
@@ -20,6 +20,7 @@
 #include "qgis.h"
 #include "qgsproject.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsunittypes.h"
 
 #include <QString>

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -155,6 +155,9 @@ const QgsSettingsEntryStringList *QgsSettingsRegistryCore::settingsCodeExecution
 const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsMeasurePlanimetric
   = new QgsSettingsEntryBool( u"planimetric"_s, QgsSettingsTree::sTreeMeasure, true, u"Whether measurements should be planimetric (ellipsoid off) or use the ellipsoid"_s );
 
+const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit
+  = new QgsSettingsEntryBool( u"keep-base-unit"_s, QgsSettingsTree::sTreeMeasure, true, u"Whether to keep base measurement units instead of converting to larger units"_s );
+
 const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod = new QgsSettingsEntryEnumFlag<
   Qgis::LayerTreeInsertionMethod>( u"insertion-method"_s, QgsSettingsTree::sTreeLayerTree, Qgis::LayerTreeInsertionMethod::AboveInsertionPoint, u"Method for inserting layers into the layer tree"_s );
 
@@ -192,6 +195,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
 
   // single settings - added in 4.2
   settingsMeasurePlanimetric->copyValueFromKey( u"measure/planimetric"_s, true );
+  settingsMeasureKeepBaseUnit->copyValueFromKey( u"qgis/measure/keepbaseunit"_s, true );
+  settingsMeasureKeepBaseUnit->copyValueFromKey( u"/qgis/measure/keepbaseunit"_s, true );
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"qgis/layerTreeInsertionMethod"_s, true );
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"/qgis/layerTreeInsertionMethod"_s, true );
 

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -158,6 +158,9 @@ const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsMeasurePlanimetric
 const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit
   = new QgsSettingsEntryBool( u"keep-base-unit"_s, QgsSettingsTree::sTreeMeasure, true, u"Whether to keep base measurement units instead of converting to larger units"_s );
 
+const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsMeasureDecimalPlaces
+  = new QgsSettingsEntryInteger( u"decimal-places"_s, QgsSettingsTree::sTreeMeasure, 3, u"Number of decimal places for measurements"_s );
+
 const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod = new QgsSettingsEntryEnumFlag<
   Qgis::LayerTreeInsertionMethod>( u"insertion-method"_s, QgsSettingsTree::sTreeLayerTree, Qgis::LayerTreeInsertionMethod::AboveInsertionPoint, u"Method for inserting layers into the layer tree"_s );
 
@@ -197,6 +200,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsMeasurePlanimetric->copyValueFromKey( u"measure/planimetric"_s, true );
   settingsMeasureKeepBaseUnit->copyValueFromKey( u"qgis/measure/keepbaseunit"_s, true );
   settingsMeasureKeepBaseUnit->copyValueFromKey( u"/qgis/measure/keepbaseunit"_s, true );
+  settingsMeasureDecimalPlaces->copyValueFromKey( u"qgis/measure/decimalplaces"_s, true );
+  settingsMeasureDecimalPlaces->copyValueFromKey( u"/qgis/measure/decimalplaces"_s, true );
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"qgis/layerTreeInsertionMethod"_s, true );
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"/qgis/layerTreeInsertionMethod"_s, true );
 

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -179,6 +179,9 @@ const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsSymbolsListGroup
 const QgsSettingsEntryColor *QgsSettingsRegistryCore::settingsDefaultCanvasColor
   = new QgsSettingsEntryColor( u"default-canvas-color"_s, QgsSettingsTree::sTreeQgis, QColor( 255, 255, 255 ), u"Default canvas background color"_s );
 
+const QgsSettingsEntryColor *QgsSettingsRegistryCore::settingsDefaultSelectionColor
+  = new QgsSettingsEntryColor( u"default-selection-color"_s, QgsSettingsTree::sTreeQgis, QColor( 255, 255, 0, 255 ), u"Default selection color"_s );
+
 QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   : QgsSettingsRegistry()
 {}
@@ -229,6 +232,10 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsSymbolsListGroupsIndex->copyValueFromKey( u"/qgis/symbolsListGroupsIndex"_s, true );
   settingsDefaultCanvasColor->copyValueFromKeys( u"qgis/default_canvas_color_red"_s, u"qgis/default_canvas_color_green"_s, u"qgis/default_canvas_color_blue"_s, QString(), true );
   settingsDefaultCanvasColor->copyValueFromKeys( u"/qgis/default_canvas_color_red"_s, u"/qgis/default_canvas_color_green"_s, u"/qgis/default_canvas_color_blue"_s, QString(), true );
+  settingsDefaultSelectionColor
+    ->copyValueFromKeys( u"qgis/default_selection_color_red"_s, u"qgis/default_selection_color_green"_s, u"qgis/default_selection_color_blue"_s, u"qgis/default_selection_color_alpha"_s, true );
+  settingsDefaultSelectionColor
+    ->copyValueFromKeys( u"/qgis/default_selection_color_red"_s, u"/qgis/default_selection_color_green"_s, u"/qgis/default_selection_color_blue"_s, u"/qgis/default_selection_color_alpha"_s, true );
 
 #if defined( HAVE_QTSERIALPORT )
   QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( u"core/gps/stop_bits"_s, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -170,6 +170,9 @@ const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsScanZipInBrowser
 const QgsSettingsEntryStringList *QgsSettingsRegistryCore::settingsScanItemsFastScanUris
   = new QgsSettingsEntryStringList( u"scan-items-fast-scan-uris"_s, QgsSettingsTree::sTreeQgis, QStringList(), u"URIs for fast scanning in browser"_s );
 
+const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsSymbolsListGroupsIndex
+  = new QgsSettingsEntryInteger( u"symbols-list-groups-index"_s, QgsSettingsTree::sTreeQgis, 0, u"Currently selected group index in symbols list"_s );
+
 QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   : QgsSettingsRegistry()
 {}
@@ -214,6 +217,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsScanZipInBrowser->copyValueFromKey( u"/qgis/scanZipInBrowser2"_s, true );
   settingsScanItemsFastScanUris->copyValueFromKey( u"qgis/scanItemsFastScanUris"_s, true );
   settingsScanItemsFastScanUris->copyValueFromKey( u"/qgis/scanItemsFastScanUris"_s, true );
+  settingsSymbolsListGroupsIndex->copyValueFromKey( u"qgis/symbolsListGroupsIndex"_s, true );
+  settingsSymbolsListGroupsIndex->copyValueFromKey( u"/qgis/symbolsListGroupsIndex"_s, true );
 
 #if defined( HAVE_QTSERIALPORT )
   QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( u"core/gps/stop_bits"_s, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -161,6 +161,9 @@ const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit
 const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsMeasureDecimalPlaces
   = new QgsSettingsEntryInteger( u"decimal-places"_s, QgsSettingsTree::sTreeMeasure, 3, u"Number of decimal places for measurements"_s );
 
+const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsMeasureDisplayUnits
+  = new QgsSettingsEntryString( u"display-units"_s, QgsSettingsTree::sTreeMeasure, QString(), u"Distance display units (encoded unit string)"_s );
+
 const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod = new QgsSettingsEntryEnumFlag<
   Qgis::LayerTreeInsertionMethod>( u"insertion-method"_s, QgsSettingsTree::sTreeLayerTree, Qgis::LayerTreeInsertionMethod::AboveInsertionPoint, u"Method for inserting layers into the layer tree"_s );
 
@@ -211,6 +214,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsMeasureKeepBaseUnit->copyValueFromKey( u"/qgis/measure/keepbaseunit"_s, true );
   settingsMeasureDecimalPlaces->copyValueFromKey( u"qgis/measure/decimalplaces"_s, true );
   settingsMeasureDecimalPlaces->copyValueFromKey( u"/qgis/measure/decimalplaces"_s, true );
+  settingsMeasureDisplayUnits->copyValueFromKey( u"qgis/measure/displayunits"_s, true );
+  settingsMeasureDisplayUnits->copyValueFromKey( u"/qgis/measure/displayunits"_s, true );
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"qgis/layerTreeInsertionMethod"_s, true );
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"/qgis/layerTreeInsertionMethod"_s, true );
   settingsScanZipInBrowser->copyValueFromKey( u"qgis/scanZipInBrowser2"_s, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -164,6 +164,9 @@ const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsMeasureDecimalPl
 const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod = new QgsSettingsEntryEnumFlag<
   Qgis::LayerTreeInsertionMethod>( u"insertion-method"_s, QgsSettingsTree::sTreeLayerTree, Qgis::LayerTreeInsertionMethod::AboveInsertionPoint, u"Method for inserting layers into the layer tree"_s );
 
+const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsScanZipInBrowser
+  = new QgsSettingsEntryString( u"scan-zip-in-browser"_s, QgsSettingsTree::sTreeQgis, u"basic"_s, u"Zip scanning behavior in browser (no, basic, full)"_s );
+
 QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   : QgsSettingsRegistry()
 {}
@@ -204,6 +207,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsMeasureDecimalPlaces->copyValueFromKey( u"/qgis/measure/decimalplaces"_s, true );
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"qgis/layerTreeInsertionMethod"_s, true );
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"/qgis/layerTreeInsertionMethod"_s, true );
+  settingsScanZipInBrowser->copyValueFromKey( u"qgis/scanZipInBrowser2"_s, true );
+  settingsScanZipInBrowser->copyValueFromKey( u"/qgis/scanZipInBrowser2"_s, true );
 
 #if defined( HAVE_QTSERIALPORT )
   QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( u"core/gps/stop_bits"_s, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -155,6 +155,9 @@ const QgsSettingsEntryStringList *QgsSettingsRegistryCore::settingsCodeExecution
 const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsMeasurePlanimetric
   = new QgsSettingsEntryBool( u"planimetric"_s, QgsSettingsTree::sTreeMeasure, true, u"Whether measurements should be planimetric (ellipsoid off) or use the ellipsoid"_s );
 
+const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod = new QgsSettingsEntryEnumFlag<
+  Qgis::LayerTreeInsertionMethod>( u"insertion-method"_s, QgsSettingsTree::sTreeLayerTree, Qgis::LayerTreeInsertionMethod::AboveInsertionPoint, u"Method for inserting layers into the layer tree"_s );
+
 QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   : QgsSettingsRegistry()
 {}
@@ -189,6 +192,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
 
   // single settings - added in 4.2
   settingsMeasurePlanimetric->copyValueFromKey( u"measure/planimetric"_s, true );
+  settingsLayerTreeInsertionMethod->copyValueFromKey( u"qgis/layerTreeInsertionMethod"_s, true );
+  settingsLayerTreeInsertionMethod->copyValueFromKey( u"/qgis/layerTreeInsertionMethod"_s, true );
 
 #if defined( HAVE_QTSERIALPORT )
   QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( u"core/gps/stop_bits"_s, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -152,6 +152,9 @@ const QgsSettingsEntryStringList *QgsSettingsRegistryCore::settingsCodeExecution
 const QgsSettingsEntryStringList *QgsSettingsRegistryCore::settingsCodeExecutionUntrustedProjectsFolders
   = new QgsSettingsEntryStringList( u"code-execution-denied-projects-folders"_s, QgsSettingsTree::sTreeCore, QStringList(), u"Projects and folders that are untrusted and denied execution of embedded scripts"_s );
 
+const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsMeasurePlanimetric
+  = new QgsSettingsEntryBool( u"planimetric"_s, QgsSettingsTree::sTreeMeasure, true, u"Whether measurements should be planimetric (ellipsoid off) or use the ellipsoid"_s );
+
 QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   : QgsSettingsRegistry()
 {}
@@ -183,6 +186,9 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   QgsNetworkAccessManager::settingsNetworkTimeout->copyValueFromKey( u"qgis/networkAndProxy/networkTimeout"_s, true );
 
   settingsLayerTreeShowFeatureCountForNewLayers->copyValueFromKey( u"core/layer-tree/show_feature_count_for_new_layers"_s, true );
+
+  // single settings - added in 4.2
+  settingsMeasurePlanimetric->copyValueFromKey( u"measure/planimetric"_s, true );
 
 #if defined( HAVE_QTSERIALPORT )
   QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( u"core/gps/stop_bits"_s, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -167,6 +167,9 @@ const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *QgsSettingsRegis
 const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsScanZipInBrowser
   = new QgsSettingsEntryString( u"scan-zip-in-browser"_s, QgsSettingsTree::sTreeQgis, u"basic"_s, u"Zip scanning behavior in browser (no, basic, full)"_s );
 
+const QgsSettingsEntryStringList *QgsSettingsRegistryCore::settingsScanItemsFastScanUris
+  = new QgsSettingsEntryStringList( u"scan-items-fast-scan-uris"_s, QgsSettingsTree::sTreeQgis, QStringList(), u"URIs for fast scanning in browser"_s );
+
 QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   : QgsSettingsRegistry()
 {}
@@ -209,6 +212,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"/qgis/layerTreeInsertionMethod"_s, true );
   settingsScanZipInBrowser->copyValueFromKey( u"qgis/scanZipInBrowser2"_s, true );
   settingsScanZipInBrowser->copyValueFromKey( u"/qgis/scanZipInBrowser2"_s, true );
+  settingsScanItemsFastScanUris->copyValueFromKey( u"qgis/scanItemsFastScanUris"_s, true );
+  settingsScanItemsFastScanUris->copyValueFromKey( u"/qgis/scanItemsFastScanUris"_s, true );
 
 #if defined( HAVE_QTSERIALPORT )
   QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( u"core/gps/stop_bits"_s, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -176,6 +176,9 @@ const QgsSettingsEntryStringList *QgsSettingsRegistryCore::settingsScanItemsFast
 const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsSymbolsListGroupsIndex
   = new QgsSettingsEntryInteger( u"symbols-list-groups-index"_s, QgsSettingsTree::sTreeQgis, 0, u"Currently selected group index in symbols list"_s );
 
+const QgsSettingsEntryColor *QgsSettingsRegistryCore::settingsDefaultCanvasColor
+  = new QgsSettingsEntryColor( u"default-canvas-color"_s, QgsSettingsTree::sTreeQgis, QColor( 255, 255, 255 ), u"Default canvas background color"_s );
+
 QgsSettingsRegistryCore::QgsSettingsRegistryCore()
   : QgsSettingsRegistry()
 {}
@@ -224,6 +227,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsScanItemsFastScanUris->copyValueFromKey( u"/qgis/scanItemsFastScanUris"_s, true );
   settingsSymbolsListGroupsIndex->copyValueFromKey( u"qgis/symbolsListGroupsIndex"_s, true );
   settingsSymbolsListGroupsIndex->copyValueFromKey( u"/qgis/symbolsListGroupsIndex"_s, true );
+  settingsDefaultCanvasColor->copyValueFromKeys( u"qgis/default_canvas_color_red"_s, u"qgis/default_canvas_color_green"_s, u"qgis/default_canvas_color_blue"_s, QString(), true );
+  settingsDefaultCanvasColor->copyValueFromKeys( u"/qgis/default_canvas_color_red"_s, u"/qgis/default_canvas_color_green"_s, u"/qgis/default_canvas_color_blue"_s, QString(), true );
 
 #if defined( HAVE_QTSERIALPORT )
   QgsGpsDetector::settingsGpsStopBits->copyValueFromKey( u"core/gps/stop_bits"_s, true );

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -194,6 +194,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for whether measurements should be planimetric (ellipsoid off) or use the ellipsoid
     static const QgsSettingsEntryBool *settingsMeasurePlanimetric;
 
+    //! Settings entry for layer tree insertion method
+    static const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *settingsLayerTreeInsertionMethod;
+
   private:
     friend class QgsApplication;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -200,6 +200,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for number of decimal places for measurements
     static const QgsSettingsEntryInteger *settingsMeasureDecimalPlaces;
 
+    //! Settings entry for distance display units
+    static const QgsSettingsEntryString *settingsMeasureDisplayUnits;
+
     //! Settings entry for layer tree insertion method
     static const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *settingsLayerTreeInsertionMethod;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -206,6 +206,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for zip scanning behavior in browser
     static const QgsSettingsEntryString *settingsScanZipInBrowser;
 
+    //! Settings entry for fast scan URIs in browser
+    static const QgsSettingsEntryStringList *settingsScanItemsFastScanUris;
+
   private:
     friend class QgsApplication;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -191,6 +191,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for projects and folders that are denied execution of embedded scripts across sessions
     static const QgsSettingsEntryStringList *settingsCodeExecutionUntrustedProjectsFolders;
 
+    //! Settings entry for whether measurements should be planimetric (ellipsoid off) or use the ellipsoid
+    static const QgsSettingsEntryBool *settingsMeasurePlanimetric;
+
   private:
     friend class QgsApplication;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -194,6 +194,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for whether measurements should be planimetric (ellipsoid off) or use the ellipsoid
     static const QgsSettingsEntryBool *settingsMeasurePlanimetric;
 
+    //! Settings entry for whether to keep base measurement units
+    static const QgsSettingsEntryBool *settingsMeasureKeepBaseUnit;
+
     //! Settings entry for layer tree insertion method
     static const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *settingsLayerTreeInsertionMethod;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -218,6 +218,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for default canvas background color
     static const QgsSettingsEntryColor *settingsDefaultCanvasColor;
 
+    //! Settings entry for default selection color
+    static const QgsSettingsEntryColor *settingsDefaultSelectionColor;
+
   private:
     friend class QgsApplication;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -197,6 +197,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for whether to keep base measurement units
     static const QgsSettingsEntryBool *settingsMeasureKeepBaseUnit;
 
+    //! Settings entry for number of decimal places for measurements
+    static const QgsSettingsEntryInteger *settingsMeasureDecimalPlaces;
+
     //! Settings entry for layer tree insertion method
     static const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *settingsLayerTreeInsertionMethod;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -203,6 +203,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for layer tree insertion method
     static const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *settingsLayerTreeInsertionMethod;
 
+    //! Settings entry for zip scanning behavior in browser
+    static const QgsSettingsEntryString *settingsScanZipInBrowser;
+
   private:
     friend class QgsApplication;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -209,6 +209,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for fast scan URIs in browser
     static const QgsSettingsEntryStringList *settingsScanItemsFastScanUris;
 
+    //! Settings entry for symbols list groups index
+    static const QgsSettingsEntryInteger *settingsSymbolsListGroupsIndex;
+
   private:
     friend class QgsApplication;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -215,6 +215,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for symbols list groups index
     static const QgsSettingsEntryInteger *settingsSymbolsListGroupsIndex;
 
+    //! Settings entry for default canvas background color
+    static const QgsSettingsEntryColor *settingsDefaultCanvasColor;
+
   private:
     friend class QgsApplication;
 

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -71,6 +71,8 @@ class CORE_EXPORT QgsSettingsTree
     static inline QgsSettingsTreeNode *sTreeAuthentication = treeRoot()->createChildNode( u"authentication"_s );
     static inline QgsSettingsTreeNode *sTreeDatabase = treeRoot()->createChildNode( u"database"_s );
     static inline QgsSettingsTreeNode *sTree3DMap = treeRoot()->createChildNode( u"3dmap"_s );
+    static inline QgsSettingsTreeNode *sTreeRasterHistogram = sTreeRaster->createChildNode( u"histogram"_s );
+    static inline QgsSettingsTreeNode *sTreeCad = sTreeDigitizing->createChildNode( u"cad"_s );
 
 #endif
 

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -36,6 +36,7 @@
 #include "qgsreadwritecontext.h"
 #include "qgsruntimeprofiler.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgssqliteutils.h"
 #include "qgssymbol.h"
 #include "qgssymbollayerregistry.h"
@@ -1421,8 +1422,7 @@ int QgsStyle::addTag( const QString &tagname )
   if ( nErr == SQLITE_OK )
     ( void ) sqlite3_step( statement.get() );
 
-  QgsSettings settings;
-  settings.setValue( u"qgis/symbolsListGroupsIndex"_s, 0 );
+  QgsSettingsRegistryCore::settingsSymbolsListGroupsIndex->setValue( 0 );
 
   emit groupsModified();
 
@@ -1517,8 +1517,7 @@ bool QgsStyle::remove( StyleEntity type, int id )
 
     if ( groupRemoved )
     {
-      QgsSettings settings;
-      settings.setValue( u"qgis/symbolsListGroupsIndex"_s, 0 );
+      QgsSettingsRegistryCore::settingsSymbolsListGroupsIndex->setValue( 0 );
 
       emit groupsModified();
     }
@@ -2341,8 +2340,7 @@ int QgsStyle::addSmartgroup( const QString &name, const QString &op, const QStri
 
   if ( runEmptyQuery( query ) )
   {
-    QgsSettings settings;
-    settings.setValue( u"qgis/symbolsListGroupsIndex"_s, 0 );
+    QgsSettingsRegistryCore::settingsSymbolsListGroupsIndex->setValue( 0 );
 
     emit groupsModified();
     return static_cast< int >( sqlite3_last_insert_rowid( mCurrentDB.get() ) );

--- a/src/gui/auth/qgsauthauthoritieseditor.cpp
+++ b/src/gui/auth/qgsauthauthoritieseditor.cpp
@@ -26,6 +26,7 @@
 #include "qgsauthtrustedcasdialog.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsvariantutils.h"
 
 #include <QAction>
@@ -721,6 +722,5 @@ QgsMessageBar *QgsAuthAuthoritiesEditor::messageBar()
 
 int QgsAuthAuthoritiesEditor::messageTimeout()
 {
-  const QgsSettings settings;
-  return settings.value( u"qgis/messageTimeout"_s, 5 ).toInt();
+  return QgsSettingsRegistryGui::settingsMessageTimeout->value();
 }

--- a/src/gui/auth/qgsauthidentitieseditor.cpp
+++ b/src/gui/auth/qgsauthidentitieseditor.cpp
@@ -25,6 +25,7 @@
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsvariantutils.h"
 
 #include <QMenu>
@@ -370,6 +371,5 @@ QgsMessageBar *QgsAuthIdentitiesEditor::messageBar()
 
 int QgsAuthIdentitiesEditor::messageTimeout()
 {
-  const QgsSettings settings;
-  return settings.value( u"qgis/messageTimeout"_s, 5 ).toInt();
+  return QgsSettingsRegistryGui::settingsMessageTimeout->value();
 }

--- a/src/gui/auth/qgsauthserverseditor.cpp
+++ b/src/gui/auth/qgsauthserverseditor.cpp
@@ -25,6 +25,7 @@
 #include "qgsauthsslimportdialog.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsvariantutils.h"
 
 #include <QMenu>
@@ -381,6 +382,5 @@ QgsMessageBar *QgsAuthServersEditor::messageBar()
 
 int QgsAuthServersEditor::messageTimeout()
 {
-  const QgsSettings settings;
-  return settings.value( u"qgis/messageTimeout"_s, 5 ).toInt();
+  return QgsSettingsRegistryGui::settingsMessageTimeout->value();
 }

--- a/src/gui/auth/qgsauthtrustedcasdialog.cpp
+++ b/src/gui/auth/qgsauthtrustedcasdialog.cpp
@@ -24,6 +24,7 @@
 #include "qgsauthmanager.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsvariantutils.h"
 
 #include <QPushButton>
@@ -294,6 +295,5 @@ QgsMessageBar *QgsAuthTrustedCAsDialog::messageBar()
 
 int QgsAuthTrustedCAsDialog::messageTimeout()
 {
-  const QgsSettings settings;
-  return settings.value( u"qgis/messageTimeout"_s, 5 ).toInt();
+  return QgsSettingsRegistryGui::settingsMessageTimeout->value();
 }

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -37,6 +37,7 @@
 #include "qgsprofilesourceregistry.h"
 #include "qgsprojectelevationproperties.h"
 #include "qgsscreenhelper.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsterrainprovider.h"
 
 #include <QPalette>
@@ -813,9 +814,8 @@ void QgsElevationProfileCanvas::zoomToRect( const QRectF &rect )
 void QgsElevationProfileCanvas::wheelZoom( QWheelEvent *event )
 {
   //get mouse wheel zoom behavior settings
-  QgsSettings settings;
-  double zoomFactor = settings.value( u"qgis/zoom_factor"_s, 2 ).toDouble();
-  bool reverseZoom = settings.value( u"qgis/reverse_wheel_zoom"_s, false ).toBool();
+  double zoomFactor = QgsSettingsRegistryGui::settingsZoomFactor->value();
+  bool reverseZoom = QgsSettingsRegistryGui::settingsReverseWheelZoom->value();
   bool zoomIn = reverseZoom ? event->angleDelta().y() < 0 : event->angleDelta().y() > 0;
 
   // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -23,6 +23,7 @@
 #include "qgsmapoverviewcanvas.h"
 #include "qgsproject.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsvectorlayer.h"
 
 #include <QString>
@@ -120,7 +121,7 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers()
     {
       case QgsGui::UseCrsOfFirstLayerAdded:
       {
-        const bool planimetric = QgsSettings().value( u"measure/planimetric"_s, true, QgsSettings::Core ).toBool();
+        const bool planimetric = QgsSettingsRegistryCore::settingsMeasurePlanimetric->value();
         // Only adjust ellipsoid to CRS if it's not set to planimetric
         QgsProject::instance()->setCrs( mFirstCRS.horizontalCrs(), !planimetric );
         const QgsCoordinateReferenceSystem vertCrs = mFirstCRS.verticalCrs();

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -23,6 +23,7 @@
 #include "qgsmapoverviewcanvas.h"
 #include "qgsproject.h"
 #include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsvectorlayer.h"
 

--- a/src/gui/layout/qgslayoutview.cpp
+++ b/src/gui/layout/qgslayoutview.cpp
@@ -37,6 +37,7 @@
 #include "qgsrectangle.h"
 #include "qgsscreenhelper.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 
 #include <QClipboard>
 #include <QMenu>
@@ -1213,9 +1214,8 @@ void QgsLayoutView::pushStatusMessage( const QString &message )
 void QgsLayoutView::wheelZoom( QWheelEvent *event )
 {
   //get mouse wheel zoom behavior settings
-  QgsSettings settings;
-  double zoomFactor = settings.value( u"qgis/zoom_factor"_s, 2 ).toDouble();
-  bool reverseZoom = settings.value( u"qgis/reverse_wheel_zoom"_s, false ).toBool();
+  double zoomFactor = QgsSettingsRegistryGui::settingsZoomFactor->value();
+  bool reverseZoom = QgsSettingsRegistryGui::settingsReverseWheelZoom->value();
   bool zoomIn = reverseZoom ? event->angleDelta().y() < 0 : event->angleDelta().y() > 0;
 
   // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps

--- a/src/gui/layout/qgslayoutviewtoolmoveitemcontent.cpp
+++ b/src/gui/layout/qgslayoutviewtoolmoveitemcontent.cpp
@@ -21,6 +21,7 @@
 #include "qgslayoutview.h"
 #include "qgslayoutviewmouseevent.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 
 #include <QString>
 
@@ -107,9 +108,8 @@ void QgsLayoutViewToolMoveItemContent::wheelEvent( QWheelEvent *event )
   if ( !item || !item->isSelected() )
     return;
 
-  const QgsSettings settings;
-  double zoomFactor = settings.value( u"qgis/zoom_factor"_s, 2.0 ).toDouble();
-  bool reverseZoom = settings.value( u"qgis/reverse_wheel_zoom"_s, false ).toBool();
+  double zoomFactor = QgsSettingsRegistryGui::settingsZoomFactor->value();
+  bool reverseZoom = QgsSettingsRegistryGui::settingsReverseWheelZoom->value();
   bool zoomIn = reverseZoom ? event->angleDelta().y() < 0 : event->angleDelta().y() > 0;
 
   // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps

--- a/src/gui/maptools/qgsmaptoolidentify.cpp
+++ b/src/gui/maptools/qgsmaptoolidentify.cpp
@@ -1503,7 +1503,7 @@ QString QgsMapToolIdentify::formatArea( double area ) const
 QString QgsMapToolIdentify::formatDistance( double distance, Qgis::DistanceUnit unit ) const
 {
   QgsSettings settings;
-  bool baseUnit = settings.value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
+  bool baseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
 
   return QgsDistanceArea::formatDistance( distance, mCoordinatePrecision, unit, baseUnit );
 }
@@ -1511,7 +1511,7 @@ QString QgsMapToolIdentify::formatDistance( double distance, Qgis::DistanceUnit 
 QString QgsMapToolIdentify::formatArea( double area, Qgis::AreaUnit unit ) const
 {
   QgsSettings settings;
-  bool baseUnit = settings.value( u"qgis/measure/keepbaseunit"_s, true ).toBool();
+  bool baseUnit = QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->value();
 
   return QgsDistanceArea::formatArea( area, mCoordinatePrecision, unit, baseUnit );
 }

--- a/src/gui/maptools/qgsmaptoolidentify.cpp
+++ b/src/gui/maptools/qgsmaptoolidentify.cpp
@@ -47,6 +47,7 @@
 #include "qgsrasterlayerelevationproperties.h"
 #include "qgsrenderer.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgssymbol.h"
 #include "qgstiles.h"
 #include "qgsunittypes.h"

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -27,6 +27,7 @@
 #include "qgsprocessingmodelcomponent.h"
 #include "qgsprocessingmodelparameter.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsxmlutils.h"
 
 #include <QApplication>
@@ -146,9 +147,8 @@ void QgsModelGraphicsView::wheelEvent( QWheelEvent *event )
 void QgsModelGraphicsView::wheelZoom( QWheelEvent *event )
 {
   //get mouse wheel zoom behavior settings
-  QgsSettings settings;
-  double zoomFactor = settings.value( u"qgis/zoom_factor"_s, 2 ).toDouble();
-  bool reverseZoom = settings.value( u"qgis/reverse_wheel_zoom"_s, false ).toBool();
+  double zoomFactor = QgsSettingsRegistryGui::settingsZoomFactor->value();
+  bool reverseZoom = QgsSettingsRegistryGui::settingsReverseWheelZoom->value();
   bool zoomIn = reverseZoom ? event->angleDelta().y() < 0 : event->angleDelta().y() > 0;
 
   // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps

--- a/src/gui/qgsadvanceddigitizingfloater.cpp
+++ b/src/gui/qgsadvanceddigitizingfloater.cpp
@@ -19,6 +19,7 @@
 #include "qgsfocuswatcher.h"
 #include "qgsmapcanvas.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgsunittypes.h"
 
 #include <QEnterEvent>
@@ -40,7 +41,7 @@ QgsAdvancedDigitizingFloater::QgsAdvancedDigitizingFloater( QgsMapCanvas *canvas
   setAttribute( Qt::WA_TransparentForMouseEvents );
   adjustSize();
 
-  setActive( QgsSettings().value( u"/Cad/Floater"_s, false ).toBool() );
+  setActive( QgsSettingsRegistryGui::settingsCadFloaterActive->value() );
 
   hideIfDisabled();
 
@@ -214,7 +215,7 @@ Qgis::CadMeasurementDisplayType QgsAdvancedDigitizingFloater::itemMeasurementDis
 
 void QgsAdvancedDigitizingFloater::setActive( bool active )
 {
-  QgsSettings().setValue( u"/Cad/Floater"_s, active );
+  QgsSettingsRegistryGui::settingsCadFloaterActive->setValue( active );
 
   mActive = active;
 

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -21,6 +21,7 @@
 #include "qgsdirectoryitem.h"
 #include "qgslayeritem.h"
 #include "qgsprojectitem.h"
+#include "qgssettingsregistrycore.h"
 
 #include <QFileDialog>
 #include <QString>
@@ -183,8 +184,7 @@ void QgsBrowserDockWidget::toggleFastScan()
 
   if ( item->type() == Qgis::BrowserItemType::Directory )
   {
-    QgsSettings settings;
-    QStringList fastScanDirs = settings.value( u"qgis/scanItemsFastScanUris"_s, QStringList() ).toStringList();
+    QStringList fastScanDirs = QgsSettingsRegistryCore::settingsScanItemsFastScanUris->value();
     const int idx = fastScanDirs.indexOf( item->path() );
     if ( idx != -1 )
     {
@@ -194,7 +194,7 @@ void QgsBrowserDockWidget::toggleFastScan()
     {
       fastScanDirs << item->path();
     }
-    settings.setValue( u"qgis/scanItemsFastScanUris"_s, fastScanDirs );
+    QgsSettingsRegistryCore::settingsScanItemsFastScanUris->setValue( fastScanDirs );
   }
 }
 

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -21,6 +21,7 @@
 #include "qgsdirectoryitem.h"
 #include "qgslayeritem.h"
 #include "qgsprojectitem.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 
 #include <QFileDialog>

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -25,6 +25,7 @@
 #include "qgsguiutils.h"
 #include "qgsproject.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgssymbollayerutils.h"
 
 #include <QBuffer>
@@ -120,7 +121,7 @@ void QgsColorButton::showColorDialog()
   const QgsSettings settings;
 
   // first check if we need to use the limited native dialogs
-  const bool useNative = settings.value( u"qgis/native_color_dialogs"_s, false ).toBool();
+  const bool useNative = QgsSettingsRegistryGui::settingsNativeColorDialogs->value();
   if ( useNative )
   {
     // why would anyone want this? who knows.... maybe the limited nature of native dialogs helps ease the transition for MapInfo users?

--- a/src/gui/qgscolordialog.cpp
+++ b/src/gui/qgscolordialog.cpp
@@ -19,6 +19,7 @@
 #include "qgsgui.h"
 #include "qgshelp.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 
 #include <QFileDialog>
 #include <QInputDialog>
@@ -87,7 +88,7 @@ QColor QgsColorDialog::getColor( const QColor &initialColor, QWidget *parent, co
 
   const QgsSettings settings;
   //using native color dialogs?
-  const bool useNative = settings.value( u"qgis/native_color_dialogs"_s, false ).toBool();
+  const bool useNative = QgsSettingsRegistryGui::settingsNativeColorDialogs->value();
   if ( useNative )
   {
     return QColorDialog::getColor( initialColor, parent, dialogTitle, allowOpacity ? QColorDialog::ShowAlphaChannel : ( QColorDialog::ColorDialogOption ) 0 );

--- a/src/gui/qgscolordialog.cpp
+++ b/src/gui/qgscolordialog.cpp
@@ -19,6 +19,7 @@
 #include "qgsgui.h"
 #include "qgshelp.h"
 #include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrygui.h"
 
 #include <QFileDialog>

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -216,7 +216,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
   mSettings.setSegmentationTolerance( segmentationTolerance );
   mSettings.setSegmentationToleranceType( toleranceType );
 
-  mWheelZoomFactor = settings.value( u"qgis/zoom_factor"_s, 2 ).toDouble();
+  mWheelZoomFactor = QgsSettingsRegistryGui::settingsZoomFactor->value();
 
   QSize s = viewport()->size();
   mSettings.setOutputSize( s );
@@ -2691,8 +2691,7 @@ void QgsMapCanvas::wheelEvent( QWheelEvent *e )
     return;
   }
 
-  QgsSettings settings;
-  bool reverseZoom = settings.value( u"qgis/reverse_wheel_zoom"_s, false ).toBool();
+  bool reverseZoom = QgsSettingsRegistryGui::settingsReverseWheelZoom->value();
   bool zoomIn = reverseZoom ? e->angleDelta().y() < 0 : e->angleDelta().y() > 0;
   double zoomFactor = zoomIn ? 1. / zoomInFactor() : zoomOutFactor();
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -210,8 +210,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
   connect( QgsProject::instance(), &QgsProject::projectColorsChanged, this, &QgsMapCanvas::redrawAllLayers );
 
   //segmentation parameters
-  QgsSettings settings;
-  double segmentationTolerance = settings.value( u"qgis/segmentationTolerance"_s, "0.01745" ).toDouble();
+  double segmentationTolerance = QgsSettingsRegistryGui::settingsSegmentationTolerance->value();
   QgsAbstractGeometry::SegmentationToleranceType toleranceType = settings.enumValue( u"qgis/segmentationToleranceType"_s, QgsAbstractGeometry::MaximumAngle );
   mSettings.setSegmentationTolerance( segmentationTolerance );
   mSettings.setSegmentationToleranceType( toleranceType );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -64,6 +64,7 @@ email                : sherman at mrcc.com
 #include "qgsruntimeprofiler.h"
 #include "qgsscreenhelper.h"
 #include "qgssettings.h"
+#include "qgssettingsentryenumflag.h"
 #include "qgssettingsregistrygui.h"
 #include "qgsstatusbar.h"
 #include "qgssvgcache.h"
@@ -210,10 +211,8 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
   connect( QgsProject::instance(), &QgsProject::projectColorsChanged, this, &QgsMapCanvas::redrawAllLayers );
 
   //segmentation parameters
-  double segmentationTolerance = QgsSettingsRegistryGui::settingsSegmentationTolerance->value();
-  QgsAbstractGeometry::SegmentationToleranceType toleranceType = settings.enumValue( u"qgis/segmentationToleranceType"_s, QgsAbstractGeometry::MaximumAngle );
-  mSettings.setSegmentationTolerance( segmentationTolerance );
-  mSettings.setSegmentationToleranceType( toleranceType );
+  mSettings.setSegmentationTolerance( QgsSettingsRegistryGui::settingsSegmentationTolerance->value() );
+  mSettings.setSegmentationToleranceType( QgsSettingsRegistryGui::settingsSegmentationToleranceType->value() );
 
   mWheelZoomFactor = QgsSettingsRegistryGui::settingsZoomFactor->value();
 

--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -167,7 +167,7 @@ void QgsMapOverviewCanvas::mouseReleaseEvent( QMouseEvent *e )
 void QgsMapOverviewCanvas::wheelEvent( QWheelEvent *e )
 {
   QgsSettings settings;
-  bool reverseZoom = settings.value( u"qgis/reverse_wheel_zoom"_s, false ).toBool();
+  bool reverseZoom = QgsSettingsRegistryGui::settingsReverseWheelZoom->value();
   bool zoomIn = reverseZoom ? e->angleDelta().y() < 0 : e->angleDelta().y() > 0;
   double zoomFactor = zoomIn ? 1. / mMapCanvas->zoomInFactor() : mMapCanvas->zoomOutFactor();
 

--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -27,6 +27,8 @@
 #include "qgsmaptopixel.h"
 #include "qgsproject.h"
 #include "qgsprojectviewsettings.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingsregistrygui.h"
 
 #include <QMouseEvent>
 #include <QPaintEvent>

--- a/src/gui/qgsmessagebar.cpp
+++ b/src/gui/qgsmessagebar.cpp
@@ -22,6 +22,7 @@
 #include "qgsmessagelog.h"
 #include "qgsmessageviewer.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 
 #include <QGridLayout>
 #include <QLabel>
@@ -230,8 +231,7 @@ int QgsMessageBar::defaultMessageTimeout( Qgis::MessageLevel level )
     case Qgis::MessageLevel::Info:
     case Qgis::MessageLevel::NoLevel:
     {
-      const QgsSettings settings;
-      return settings.value( u"qgis/messageTimeout"_s, 5 ).toInt();
+      return QgsSettingsRegistryGui::settingsMessageTimeout->value();
     }
 
     case Qgis::MessageLevel::Warning:

--- a/src/gui/qgsprovidersublayersdialog.cpp
+++ b/src/gui/qgsprovidersublayersdialog.cpp
@@ -22,6 +22,7 @@
 #include "qgsprovidersublayertask.h"
 #include "qgsproviderutils.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 #include "qgstaskmanager.h"
 
 #include <QDesktopServices>
@@ -278,7 +279,7 @@ void QgsProviderSublayersDialog::setGroupName( const QString &groupNameIn )
 {
   mGroupName = groupNameIn;
   const QgsSettings settings;
-  if ( settings.value( u"qgis/formatLayerName"_s, false ).toBool() )
+  if ( QgsSettingsRegistryGui::settingsFormatLayerName->value() )
   {
     mGroupName = QgsMapLayer::formatLayerName( mGroupName );
   }

--- a/src/gui/qgsprovidersublayersdialog.cpp
+++ b/src/gui/qgsprovidersublayersdialog.cpp
@@ -164,7 +164,7 @@ QgsProviderSublayersDialog::QgsProviderSublayersDialog(
   mLayersTree->expandAll();
 
   const QgsSettings settings;
-  const bool addToGroup = settings.value( u"/qgis/openSublayersInGroup"_s, false ).toBool();
+  const bool addToGroup = QgsSettingsRegistryGui::settingsOpenSublayersInGroup->value();
   mCbxAddToGroup->setChecked( addToGroup );
   mCbxAddToGroup->setVisible( !fileName.isEmpty() );
 
@@ -239,7 +239,7 @@ QgsProviderSublayersDialog::~QgsProviderSublayersDialog()
 {
   QgsSettings settings;
   settings.setValue( "/Windows/SubLayers/headerState", mLayersTree->header()->saveState() );
-  settings.setValue( u"/qgis/openSublayersInGroup"_s, mCbxAddToGroup->isChecked() );
+  QgsSettingsRegistryGui::settingsOpenSublayersInGroup->setValue( mCbxAddToGroup->isChecked() );
 
   if ( mTask )
     mTask->cancel();

--- a/src/gui/qgsstyleitemslistwidget.cpp
+++ b/src/gui/qgsstyleitemslistwidget.cpp
@@ -21,6 +21,7 @@
 #include "qgsproject.h"
 #include "qgsprojectstylesettings.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsstylemanagerdialog.h"
 #include "qgswindowmanagerinterface.h"
 
@@ -477,8 +478,7 @@ void QgsStyleItemsListWidget::populateGroups()
   }
   groupsCombo->blockSignals( false );
 
-  const QgsSettings settings;
-  index = settings.value( u"qgis/symbolsListGroupsIndex"_s, 0 ).toInt();
+  index = QgsSettingsRegistryCore::settingsSymbolsListGroupsIndex->value();
   groupsCombo->setCurrentIndex( index );
 
   mUpdatingGroups = false;
@@ -576,6 +576,5 @@ void QgsStyleItemsListWidget::onSelectionChanged( const QModelIndex &index, cons
 
 void QgsStyleItemsListWidget::groupsCombo_currentIndexChanged( int index )
 {
-  QgsSettings settings;
-  settings.setValue( u"qgis/symbolsListGroupsIndex"_s, index );
+  QgsSettingsRegistryCore::settingsSymbolsListGroupsIndex->setValue( index );
 }

--- a/src/gui/qgsstyleitemslistwidget.cpp
+++ b/src/gui/qgsstyleitemslistwidget.cpp
@@ -21,6 +21,7 @@
 #include "qgsproject.h"
 #include "qgsprojectstylesettings.h"
 #include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsstylemanagerdialog.h"
 #include "qgswindowmanagerinterface.h"

--- a/src/gui/qgssublayersdialog.cpp
+++ b/src/gui/qgssublayersdialog.cpp
@@ -19,6 +19,7 @@
 #include "qgslogger.h"
 #include "qgsproviderregistry.h"
 #include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrygui.h"
 
 #include <QPushButton>

--- a/src/gui/qgssublayersdialog.cpp
+++ b/src/gui/qgssublayersdialog.cpp
@@ -19,6 +19,7 @@
 #include "qgslogger.h"
 #include "qgsproviderregistry.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 
 #include <QPushButton>
 #include <QString>
@@ -216,7 +217,7 @@ int QgsSublayersDialog::exec()
   if ( mShowAddToGroupCheckbox )
   {
     mCbxAddToGroup->setVisible( true );
-    const bool addToGroup = settings.value( u"/qgis/openSublayersInGroup"_s, false ).toBool();
+    const bool addToGroup = QgsSettingsRegistryGui::settingsOpenSublayersInGroup->value();
     mCbxAddToGroup->setChecked( addToGroup );
   }
 
@@ -225,7 +226,7 @@ int QgsSublayersDialog::exec()
     QApplication::setOverrideCursor( cursor );
 
   if ( mShowAddToGroupCheckbox )
-    settings.setValue( u"/qgis/openSublayersInGroup"_s, mCbxAddToGroup->isChecked() );
+    QgsSettingsRegistryGui::settingsOpenSublayersInGroup->setValue( mCbxAddToGroup->isChecked() );
   return ret;
 }
 

--- a/src/gui/raster/qgsrasterhistogramwidget.cpp
+++ b/src/gui/raster/qgsrasterhistogramwidget.cpp
@@ -24,6 +24,7 @@
 #include "qgsrasterminmaxwidget.h"
 #include "qgsrasterrendererwidget.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrygui.h"
 
 #include <QActionGroup>
 #include <QDir>
@@ -85,11 +86,11 @@ QgsRasterHistogramWidget::QgsRasterHistogramWidget( QgsRasterLayer *lyr, QWidget
   mHistoMarkerMax = nullptr;
 
   const QgsSettings settings;
-  mHistoShowMarkers = settings.value( u"Raster/histogram/showMarkers"_s, false ).toBool();
+  mHistoShowMarkers = QgsSettingsRegistryGui::settingsRasterHistogramShowMarkers->value();
   // mHistoLoadApplyAll = settings.value( "/Raster/histogram/loadApplyAll", false ).toBool();
-  mHistoZoomToMinMax = settings.value( u"Raster/histogram/zoomToMinMax"_s, false ).toBool();
-  mHistoUpdateStyleToMinMax = settings.value( u"Raster/histogram/updateStyleToMinMax"_s, true ).toBool();
-  mHistoDrawLines = settings.value( u"Raster/histogram/drawLines"_s, true ).toBool();
+  mHistoZoomToMinMax = QgsSettingsRegistryGui::settingsRasterHistogramZoomToMinMax->value();
+  mHistoUpdateStyleToMinMax = QgsSettingsRegistryGui::settingsRasterHistogramUpdateStyleToMinMax->value();
+  mHistoDrawLines = QgsSettingsRegistryGui::settingsRasterHistogramDrawLines->value();
   // mHistoShowBands = (HistoShowBands) settings.value( "/Raster/histogram/showBands", (int) ShowAll ).toInt();
   mHistoShowBands = ShowAll;
 
@@ -747,23 +748,20 @@ void QgsRasterHistogramWidget::histoAction( const QString &actionName, bool acti
   if ( actionName == "Show markers"_L1 )
   {
     mHistoShowMarkers = actionFlag;
-    QgsSettings settings;
-    settings.setValue( u"Raster/histogram/showMarkers"_s, mHistoShowMarkers );
+    QgsSettingsRegistryGui::settingsRasterHistogramShowMarkers->setValue( mHistoShowMarkers );
     updateHistoMarkers();
     return;
   }
   else if ( actionName == "Zoom min_max"_L1 )
   {
     mHistoZoomToMinMax = actionFlag;
-    QgsSettings settings;
-    settings.setValue( u"Raster/histogram/zoomToMinMax"_s, mHistoZoomToMinMax );
+    QgsSettingsRegistryGui::settingsRasterHistogramZoomToMinMax->setValue( mHistoZoomToMinMax );
     return;
   }
   else if ( actionName == "Update min_max"_L1 )
   {
     mHistoUpdateStyleToMinMax = actionFlag;
-    QgsSettings settings;
-    settings.setValue( u"Raster/histogram/updateStyleToMinMax"_s, mHistoUpdateStyleToMinMax );
+    QgsSettingsRegistryGui::settingsRasterHistogramUpdateStyleToMinMax->setValue( mHistoUpdateStyleToMinMax );
     return;
   }
   else if ( actionName == "Show all"_L1 )
@@ -790,8 +788,7 @@ void QgsRasterHistogramWidget::histoAction( const QString &actionName, bool acti
   else if ( actionName == "Draw lines"_L1 )
   {
     mHistoDrawLines = actionFlag;
-    QgsSettings settings;
-    settings.setValue( u"Raster/histogram/drawLines"_s, mHistoDrawLines );
+    QgsSettingsRegistryGui::settingsRasterHistogramDrawLines->setValue( mHistoDrawLines );
     btnHistoCompute_clicked(); // refresh
     return;
   }

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsabstractdbsourceselect.h"
 #include "qgsapplication.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsstylemanagerdialog.h"
 
@@ -76,6 +77,9 @@ const QgsSettingsEntryDouble *QgsSettingsRegistryGui::settingsMagnifierFactorDef
 const QgsSettingsEntryDouble *QgsSettingsRegistryGui::settingsSegmentationTolerance
   = new QgsSettingsEntryDouble( u"segmentation-tolerance"_s, QgsSettingsTree::sTreeQgis, 0.01745, u"Segmentation tolerance for curved geometries"_s );
 
+const QgsSettingsEntryColor *QgsSettingsRegistryGui::settingsDefaultMeasureColor
+  = new QgsSettingsEntryColor( u"default-measure-color"_s, QgsSettingsTree::sTreeQgis, QColor( 222, 155, 67 ), u"Default measure tool color"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -117,6 +121,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsMagnifierFactorDefault->copyValueFromKey( u"/qgis/magnifier_factor_default"_s, true );
   settingsSegmentationTolerance->copyValueFromKey( u"qgis/segmentationTolerance"_s, true );
   settingsSegmentationTolerance->copyValueFromKey( u"/qgis/segmentationTolerance"_s, true );
+  settingsDefaultMeasureColor->copyValueFromKeys( u"qgis/default_measure_color_red"_s, u"qgis/default_measure_color_green"_s, u"qgis/default_measure_color_blue"_s, QString(), true );
+  settingsDefaultMeasureColor->copyValueFromKeys( u"/qgis/default_measure_color_red"_s, u"/qgis/default_measure_color_green"_s, u"/qgis/default_measure_color_blue"_s, QString(), true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -55,6 +55,9 @@ const QgsSettingsEntryString *QgsSettingsRegistryGui::settingsRasterDefaultPalet
 const QgsSettingsEntryInteger *QgsSettingsRegistryGui::settingsMessageTimeout
   = new QgsSettingsEntryInteger( u"message-timeout"_s, QgsSettingsTree::sTreeQgis, 5, u"Timeout in seconds for message bar messages"_s );
 
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsEnableAntiAliasing
+  = new QgsSettingsEntryBool( u"enable-anti-aliasing"_s, QgsSettingsTree::sTreeQgis, true, u"Whether anti-aliasing is enabled for rendering"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -82,6 +85,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsRasterDefaultPalette->copyValueFromKey( u"/Raster/defaultPalette"_s, true );
   settingsMessageTimeout->copyValueFromKey( u"qgis/messageTimeout"_s, true );
   settingsMessageTimeout->copyValueFromKey( u"/qgis/messageTimeout"_s, true );
+  settingsEnableAntiAliasing->copyValueFromKey( u"qgis/enable_anti_aliasing"_s, true );
+  settingsEnableAntiAliasing->copyValueFromKey( u"/qgis/enable_anti_aliasing"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -29,6 +29,27 @@ const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsRespectScreenDPI = n
 const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsCadFloaterActive
   = new QgsSettingsEntryBool( u"floater-active"_s, QgsSettingsTree::sTreeCad, false, u"Whether the CAD floater widget is active"_s );
 
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsRasterHistogramShowMarkers
+  = new QgsSettingsEntryBool( u"show-markers"_s, QgsSettingsTree::sTreeRasterHistogram, false, u"Whether to show markers on the raster histogram"_s );
+
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsRasterHistogramZoomToMinMax
+  = new QgsSettingsEntryBool( u"zoom-to-min-max"_s, QgsSettingsTree::sTreeRasterHistogram, false, u"Whether to zoom the raster histogram to min/max values"_s );
+
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsRasterHistogramUpdateStyleToMinMax
+  = new QgsSettingsEntryBool( u"update-style-to-min-max"_s, QgsSettingsTree::sTreeRasterHistogram, true, u"Whether to update the style when histogram changes to min/max values"_s );
+
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsRasterHistogramDrawLines
+  = new QgsSettingsEntryBool( u"draw-lines"_s, QgsSettingsTree::sTreeRasterHistogram, true, u"Whether to draw the raster histogram as lines"_s );
+
+const QgsSettingsEntryDouble *QgsSettingsRegistryGui::settingsZoomFactor
+  = new QgsSettingsEntryDouble( u"zoom-factor"_s, QgsSettingsTree::sTreeQgis, 2.0, u"Zoom factor for map canvas and other views"_s );
+
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsReverseWheelZoom
+  = new QgsSettingsEntryBool( u"reverse-wheel-zoom"_s, QgsSettingsTree::sTreeQgis, false, u"Whether to reverse the direction of wheel zoom"_s );
+
+const QgsSettingsEntryString *QgsSettingsRegistryGui::settingsRasterDefaultPalette
+  = new QgsSettingsEntryString( u"default-palette"_s, QgsSettingsTree::sTreeRaster, QString(), u"Default color ramp palette name for raster layers"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -42,6 +63,16 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
 
   // single settings - added in 4.2
   settingsCadFloaterActive->copyValueFromKey( u"/Cad/Floater"_s, true );
+  settingsRasterHistogramShowMarkers->copyValueFromKey( u"Raster/histogram/showMarkers"_s, true );
+  settingsRasterHistogramZoomToMinMax->copyValueFromKey( u"Raster/histogram/zoomToMinMax"_s, true );
+  settingsRasterHistogramUpdateStyleToMinMax->copyValueFromKey( u"Raster/histogram/updateStyleToMinMax"_s, true );
+  settingsRasterHistogramDrawLines->copyValueFromKey( u"Raster/histogram/drawLines"_s, true );
+  settingsZoomFactor->copyValueFromKey( u"qgis/zoom_factor"_s, true );
+  settingsZoomFactor->copyValueFromKey( u"/qgis/zoom_factor"_s, true );
+  settingsReverseWheelZoom->copyValueFromKey( u"qgis/reverse_wheel_zoom"_s, true );
+  settingsReverseWheelZoom->copyValueFromKey( u"/qgis/reverse_wheel_zoom"_s, true );
+  settingsRasterDefaultPalette->copyValueFromKey( u"Raster/defaultPalette"_s, true );
+  settingsRasterDefaultPalette->copyValueFromKey( u"/Raster/defaultPalette"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -61,6 +61,9 @@ const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsEnableAntiAliasing
 const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsNativeColorDialogs
   = new QgsSettingsEntryBool( u"native-color-dialogs"_s, QgsSettingsTree::sTreeQgis, false, u"Whether to use native color dialogs"_s );
 
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsFormatLayerName
+  = new QgsSettingsEntryBool( u"format-layer-name"_s, QgsSettingsTree::sTreeQgis, false, u"Whether to format layer names for better readability"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -92,6 +95,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsEnableAntiAliasing->copyValueFromKey( u"/qgis/enable_anti_aliasing"_s, true );
   settingsNativeColorDialogs->copyValueFromKey( u"qgis/native_color_dialogs"_s, true );
   settingsNativeColorDialogs->copyValueFromKey( u"/qgis/native_color_dialogs"_s, true );
+  settingsFormatLayerName->copyValueFromKey( u"qgis/formatLayerName"_s, true );
+  settingsFormatLayerName->copyValueFromKey( u"/qgis/formatLayerName"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -64,6 +64,9 @@ const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsNativeColorDialogs
 const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsFormatLayerName
   = new QgsSettingsEntryBool( u"format-layer-name"_s, QgsSettingsTree::sTreeQgis, false, u"Whether to format layer names for better readability"_s );
 
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsOpenSublayersInGroup
+  = new QgsSettingsEntryBool( u"open-sublayers-in-group"_s, QgsSettingsTree::sTreeQgis, false, u"Whether to open sublayers in a group"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -97,6 +100,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsNativeColorDialogs->copyValueFromKey( u"/qgis/native_color_dialogs"_s, true );
   settingsFormatLayerName->copyValueFromKey( u"qgis/formatLayerName"_s, true );
   settingsFormatLayerName->copyValueFromKey( u"/qgis/formatLayerName"_s, true );
+  settingsOpenSublayersInGroup->copyValueFromKey( u"qgis/openSublayersInGroup"_s, true );
+  settingsOpenSublayersInGroup->copyValueFromKey( u"/qgis/openSublayersInGroup"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -73,6 +73,9 @@ const QgsSettingsEntryInteger *QgsSettingsRegistryGui::settingsMapUpdateInterval
 const QgsSettingsEntryDouble *QgsSettingsRegistryGui::settingsMagnifierFactorDefault
   = new QgsSettingsEntryDouble( u"magnifier-factor-default"_s, QgsSettingsTree::sTreeQgis, 1.0, u"Default magnifier factor"_s );
 
+const QgsSettingsEntryDouble *QgsSettingsRegistryGui::settingsSegmentationTolerance
+  = new QgsSettingsEntryDouble( u"segmentation-tolerance"_s, QgsSettingsTree::sTreeQgis, 0.01745, u"Segmentation tolerance for curved geometries"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -112,6 +115,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsMapUpdateInterval->copyValueFromKey( u"/qgis/map_update_interval"_s, true );
   settingsMagnifierFactorDefault->copyValueFromKey( u"qgis/magnifier_factor_default"_s, true );
   settingsMagnifierFactorDefault->copyValueFromKey( u"/qgis/magnifier_factor_default"_s, true );
+  settingsSegmentationTolerance->copyValueFromKey( u"qgis/segmentationTolerance"_s, true );
+  settingsSegmentationTolerance->copyValueFromKey( u"/qgis/segmentationTolerance"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsabstractdbsourceselect.h"
 #include "qgsapplication.h"
+#include "qgssettingsentryenumflag.h"
 #include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsstylemanagerdialog.h"
@@ -80,6 +81,9 @@ const QgsSettingsEntryDouble *QgsSettingsRegistryGui::settingsSegmentationTolera
 const QgsSettingsEntryColor *QgsSettingsRegistryGui::settingsDefaultMeasureColor
   = new QgsSettingsEntryColor( u"default-measure-color"_s, QgsSettingsTree::sTreeQgis, QColor( 222, 155, 67 ), u"Default measure tool color"_s );
 
+const QgsSettingsEntryEnumFlag<QgsAbstractGeometry::SegmentationToleranceType> *QgsSettingsRegistryGui::settingsSegmentationToleranceType = new QgsSettingsEntryEnumFlag<
+  QgsAbstractGeometry::SegmentationToleranceType>( u"segmentation-tolerance-type"_s, QgsSettingsTree::sTreeQgis, QgsAbstractGeometry::MaximumAngle, u"Segmentation tolerance type for curved geometries"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -123,6 +127,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsSegmentationTolerance->copyValueFromKey( u"/qgis/segmentationTolerance"_s, true );
   settingsDefaultMeasureColor->copyValueFromKeys( u"qgis/default_measure_color_red"_s, u"qgis/default_measure_color_green"_s, u"qgis/default_measure_color_blue"_s, QString(), true );
   settingsDefaultMeasureColor->copyValueFromKeys( u"/qgis/default_measure_color_red"_s, u"/qgis/default_measure_color_green"_s, u"/qgis/default_measure_color_blue"_s, QString(), true );
+  settingsSegmentationToleranceType->copyValueFromKey( u"qgis/segmentationToleranceType"_s, true );
+  settingsSegmentationToleranceType->copyValueFromKey( u"/qgis/segmentationToleranceType"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -70,6 +70,9 @@ const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsOpenSublayersInGroup
 const QgsSettingsEntryInteger *QgsSettingsRegistryGui::settingsMapUpdateInterval
   = new QgsSettingsEntryInteger( u"map-update-interval"_s, QgsSettingsTree::sTreeQgis, 250, u"Map update interval in milliseconds"_s );
 
+const QgsSettingsEntryDouble *QgsSettingsRegistryGui::settingsMagnifierFactorDefault
+  = new QgsSettingsEntryDouble( u"magnifier-factor-default"_s, QgsSettingsTree::sTreeQgis, 1.0, u"Default magnifier factor"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -107,6 +110,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsOpenSublayersInGroup->copyValueFromKey( u"/qgis/openSublayersInGroup"_s, true );
   settingsMapUpdateInterval->copyValueFromKey( u"qgis/map_update_interval"_s, true );
   settingsMapUpdateInterval->copyValueFromKey( u"/qgis/map_update_interval"_s, true );
+  settingsMagnifierFactorDefault->copyValueFromKey( u"qgis/magnifier_factor_default"_s, true );
+  settingsMagnifierFactorDefault->copyValueFromKey( u"/qgis/magnifier_factor_default"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -58,6 +58,9 @@ const QgsSettingsEntryInteger *QgsSettingsRegistryGui::settingsMessageTimeout
 const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsEnableAntiAliasing
   = new QgsSettingsEntryBool( u"enable-anti-aliasing"_s, QgsSettingsTree::sTreeQgis, true, u"Whether anti-aliasing is enabled for rendering"_s );
 
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsNativeColorDialogs
+  = new QgsSettingsEntryBool( u"native-color-dialogs"_s, QgsSettingsTree::sTreeQgis, false, u"Whether to use native color dialogs"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -87,6 +90,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsMessageTimeout->copyValueFromKey( u"/qgis/messageTimeout"_s, true );
   settingsEnableAntiAliasing->copyValueFromKey( u"qgis/enable_anti_aliasing"_s, true );
   settingsEnableAntiAliasing->copyValueFromKey( u"/qgis/enable_anti_aliasing"_s, true );
+  settingsNativeColorDialogs->copyValueFromKey( u"qgis/native_color_dialogs"_s, true );
+  settingsNativeColorDialogs->copyValueFromKey( u"/qgis/native_color_dialogs"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -52,6 +52,9 @@ const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsNewLayersVisible
 const QgsSettingsEntryString *QgsSettingsRegistryGui::settingsRasterDefaultPalette
   = new QgsSettingsEntryString( u"default-palette"_s, QgsSettingsTree::sTreeRaster, QString(), u"Default color ramp palette name for raster layers"_s );
 
+const QgsSettingsEntryInteger *QgsSettingsRegistryGui::settingsMessageTimeout
+  = new QgsSettingsEntryInteger( u"message-timeout"_s, QgsSettingsTree::sTreeQgis, 5, u"Timeout in seconds for message bar messages"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -77,6 +80,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsNewLayersVisible->copyValueFromKey( u"/qgis/new_layers_visible"_s, true );
   settingsRasterDefaultPalette->copyValueFromKey( u"Raster/defaultPalette"_s, true );
   settingsRasterDefaultPalette->copyValueFromKey( u"/Raster/defaultPalette"_s, true );
+  settingsMessageTimeout->copyValueFromKey( u"qgis/messageTimeout"_s, true );
+  settingsMessageTimeout->copyValueFromKey( u"/qgis/messageTimeout"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -26,6 +26,9 @@ using namespace Qt::StringLiterals;
 
 const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsRespectScreenDPI = new QgsSettingsEntryBool( u"respect-screen-dpi"_s, QgsSettingsTree::sTreeGui, false );
 
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsCadFloaterActive
+  = new QgsSettingsEntryBool( u"floater-active"_s, QgsSettingsTree::sTreeCad, false, u"Whether the CAD floater widget is active"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -36,6 +39,9 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
 
   // single settings - added in 3.30
   settingsRespectScreenDPI->copyValueFromKey( u"gui/qgis/respect_screen_dpi"_s, {}, true );
+
+  // single settings - added in 4.2
+  settingsCadFloaterActive->copyValueFromKey( u"/Cad/Floater"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -41,11 +41,13 @@ const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsRasterHistogramUpdat
 const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsRasterHistogramDrawLines
   = new QgsSettingsEntryBool( u"draw-lines"_s, QgsSettingsTree::sTreeRasterHistogram, true, u"Whether to draw the raster histogram as lines"_s );
 
-const QgsSettingsEntryDouble *QgsSettingsRegistryGui::settingsZoomFactor
-  = new QgsSettingsEntryDouble( u"zoom-factor"_s, QgsSettingsTree::sTreeQgis, 2.0, u"Zoom factor for map canvas and other views"_s );
+const QgsSettingsEntryDouble *QgsSettingsRegistryGui::settingsZoomFactor = new QgsSettingsEntryDouble( u"zoom-factor"_s, QgsSettingsTree::sTreeQgis, 2.0, u"Zoom factor for map canvas and other views"_s );
 
 const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsReverseWheelZoom
   = new QgsSettingsEntryBool( u"reverse-wheel-zoom"_s, QgsSettingsTree::sTreeQgis, false, u"Whether to reverse the direction of wheel zoom"_s );
+
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsNewLayersVisible
+  = new QgsSettingsEntryBool( u"new-layers-visible"_s, QgsSettingsTree::sTreeQgis, true, u"Whether newly added layers are visible by default"_s );
 
 const QgsSettingsEntryString *QgsSettingsRegistryGui::settingsRasterDefaultPalette
   = new QgsSettingsEntryString( u"default-palette"_s, QgsSettingsTree::sTreeRaster, QString(), u"Default color ramp palette name for raster layers"_s );
@@ -71,6 +73,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsZoomFactor->copyValueFromKey( u"/qgis/zoom_factor"_s, true );
   settingsReverseWheelZoom->copyValueFromKey( u"qgis/reverse_wheel_zoom"_s, true );
   settingsReverseWheelZoom->copyValueFromKey( u"/qgis/reverse_wheel_zoom"_s, true );
+  settingsNewLayersVisible->copyValueFromKey( u"qgis/new_layers_visible"_s, true );
+  settingsNewLayersVisible->copyValueFromKey( u"/qgis/new_layers_visible"_s, true );
   settingsRasterDefaultPalette->copyValueFromKey( u"Raster/defaultPalette"_s, true );
   settingsRasterDefaultPalette->copyValueFromKey( u"/Raster/defaultPalette"_s, true );
 

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -67,6 +67,9 @@ const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsFormatLayerName
 const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsOpenSublayersInGroup
   = new QgsSettingsEntryBool( u"open-sublayers-in-group"_s, QgsSettingsTree::sTreeQgis, false, u"Whether to open sublayers in a group"_s );
 
+const QgsSettingsEntryInteger *QgsSettingsRegistryGui::settingsMapUpdateInterval
+  = new QgsSettingsEntryInteger( u"map-update-interval"_s, QgsSettingsTree::sTreeQgis, 250, u"Map update interval in milliseconds"_s );
+
 QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   : QgsSettingsRegistry()
 {
@@ -102,6 +105,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsFormatLayerName->copyValueFromKey( u"/qgis/formatLayerName"_s, true );
   settingsOpenSublayersInGroup->copyValueFromKey( u"qgis/openSublayersInGroup"_s, true );
   settingsOpenSublayersInGroup->copyValueFromKey( u"/qgis/openSublayersInGroup"_s, true );
+  settingsMapUpdateInterval->copyValueFromKey( u"qgis/map_update_interval"_s, true );
+  settingsMapUpdateInterval->copyValueFromKey( u"/qgis/map_update_interval"_s, true );
 
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/GPKGSourceSelect/HoldDialogOpen"_s, { u"ogr/GPKGSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"ogr/SQLiteSourceSelect/HoldDialogOpen"_s, { u"ogr/SQLiteSourceSelect"_s }, true );

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -87,6 +87,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
     //! Settings entry whether to open sublayers in a group
     static const QgsSettingsEntryBool *settingsOpenSublayersInGroup;
 
+    //! Settings entry map update interval in milliseconds
+    static const QgsSettingsEntryInteger *settingsMapUpdateInterval;
+
 #endif
 };
 

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -21,6 +21,7 @@
 #include "qgssettingsregistry.h"
 
 class QgsSettingsEntryBool;
+class QgsSettingsEntryColor;
 class QgsSettingsEntryDouble;
 class QgsSettingsEntryInteger;
 class QgsSettingsEntryString;
@@ -95,6 +96,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
 
     //! Settings entry segmentation tolerance for curved geometries
     static const QgsSettingsEntryDouble *settingsSegmentationTolerance;
+
+    //! Settings entry default measure tool color
+    static const QgsSettingsEntryColor *settingsDefaultMeasureColor;
 
 #endif
 };

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -90,6 +90,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
     //! Settings entry map update interval in milliseconds
     static const QgsSettingsEntryInteger *settingsMapUpdateInterval;
 
+    //! Settings entry default magnifier factor
+    static const QgsSettingsEntryDouble *settingsMagnifierFactorDefault;
+
 #endif
 };
 

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -81,6 +81,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
     //! Settings entry whether to use native color dialogs
     static const QgsSettingsEntryBool *settingsNativeColorDialogs;
 
+    //! Settings entry whether to format layer names
+    static const QgsSettingsEntryBool *settingsFormatLayerName;
+
 #endif
 };
 

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -65,6 +65,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
     //! Settings entry reverse wheel zoom
     static const QgsSettingsEntryBool *settingsReverseWheelZoom;
 
+    //! Settings entry whether newly added layers are visible
+    static const QgsSettingsEntryBool *settingsNewLayersVisible;
+
     //! Settings entry default raster color ramp palette name
     static const QgsSettingsEntryString *settingsRasterDefaultPalette;
 

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -84,6 +84,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
     //! Settings entry whether to format layer names
     static const QgsSettingsEntryBool *settingsFormatLayerName;
 
+    //! Settings entry whether to open sublayers in a group
+    static const QgsSettingsEntryBool *settingsOpenSublayersInGroup;
+
 #endif
 };
 

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -18,6 +18,7 @@
 #define QGSSETTINGSREGISTRYGUI_H
 
 #include "qgis_gui.h"
+#include "qgsabstractgeometry.h"
 #include "qgssettingsregistry.h"
 
 class QgsSettingsEntryBool;
@@ -25,6 +26,7 @@ class QgsSettingsEntryColor;
 class QgsSettingsEntryDouble;
 class QgsSettingsEntryInteger;
 class QgsSettingsEntryString;
+template<class T> class QgsSettingsEntryEnumFlag;
 
 /**
  * \ingroup gui
@@ -99,6 +101,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
 
     //! Settings entry default measure tool color
     static const QgsSettingsEntryColor *settingsDefaultMeasureColor;
+
+    //! Settings entry segmentation tolerance type for curved geometries
+    static const QgsSettingsEntryEnumFlag<QgsAbstractGeometry::SegmentationToleranceType> *settingsSegmentationToleranceType;
 
 #endif
 };

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -21,6 +21,8 @@
 #include "qgssettingsregistry.h"
 
 class QgsSettingsEntryBool;
+class QgsSettingsEntryDouble;
+class QgsSettingsEntryString;
 
 /**
  * \ingroup gui
@@ -44,6 +46,27 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
 
     //! Settings entry CAD floater active state
     static const QgsSettingsEntryBool *settingsCadFloaterActive;
+
+    //! Settings entry raster histogram show markers
+    static const QgsSettingsEntryBool *settingsRasterHistogramShowMarkers;
+
+    //! Settings entry raster histogram zoom to min/max
+    static const QgsSettingsEntryBool *settingsRasterHistogramZoomToMinMax;
+
+    //! Settings entry raster histogram update style to min/max
+    static const QgsSettingsEntryBool *settingsRasterHistogramUpdateStyleToMinMax;
+
+    //! Settings entry raster histogram draw lines
+    static const QgsSettingsEntryBool *settingsRasterHistogramDrawLines;
+
+    //! Settings entry zoom factor
+    static const QgsSettingsEntryDouble *settingsZoomFactor;
+
+    //! Settings entry reverse wheel zoom
+    static const QgsSettingsEntryBool *settingsReverseWheelZoom;
+
+    //! Settings entry default raster color ramp palette name
+    static const QgsSettingsEntryString *settingsRasterDefaultPalette;
 
 #endif
 };

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -78,6 +78,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
     //! Settings entry whether anti-aliasing is enabled for rendering
     static const QgsSettingsEntryBool *settingsEnableAntiAliasing;
 
+    //! Settings entry whether to use native color dialogs
+    static const QgsSettingsEntryBool *settingsNativeColorDialogs;
+
 #endif
 };
 

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -75,6 +75,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
     //! Settings entry message timeout in seconds
     static const QgsSettingsEntryInteger *settingsMessageTimeout;
 
+    //! Settings entry whether anti-aliasing is enabled for rendering
+    static const QgsSettingsEntryBool *settingsEnableAntiAliasing;
+
 #endif
 };
 

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -22,6 +22,7 @@
 
 class QgsSettingsEntryBool;
 class QgsSettingsEntryDouble;
+class QgsSettingsEntryInteger;
 class QgsSettingsEntryString;
 
 /**
@@ -70,6 +71,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
 
     //! Settings entry default raster color ramp palette name
     static const QgsSettingsEntryString *settingsRasterDefaultPalette;
+
+    //! Settings entry message timeout in seconds
+    static const QgsSettingsEntryInteger *settingsMessageTimeout;
 
 #endif
 };

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -93,6 +93,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
     //! Settings entry default magnifier factor
     static const QgsSettingsEntryDouble *settingsMagnifierFactorDefault;
 
+    //! Settings entry segmentation tolerance for curved geometries
+    static const QgsSettingsEntryDouble *settingsSegmentationTolerance;
+
 #endif
 };
 

--- a/src/gui/settings/qgssettingsregistrygui.h
+++ b/src/gui/settings/qgssettingsregistrygui.h
@@ -42,6 +42,9 @@ class GUI_EXPORT QgsSettingsRegistryGui : public QgsSettingsRegistry
     //! Settings entry respect screen dpi
     static const QgsSettingsEntryBool *settingsRespectScreenDPI;
 
+    //! Settings entry CAD floater active state
+    static const QgsSettingsEntryBool *settingsCadFloaterActive;
+
 #endif
 };
 

--- a/tests/src/app/testqgsidentify.cpp
+++ b/tests/src/app/testqgsidentify.cpp
@@ -237,7 +237,7 @@ void TestQgsIdentify::clickxy()
 void TestQgsIdentify::closestPoint()
 {
   QgsSettings s;
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
 
   //create a temporary layer
   auto tempLayer = std::make_unique<QgsVectorLayer>( u"LineStringZM?crs=epsg:3111&field=pk:int&field=col1:double&field=url:string"_s, u"vl"_s, u"memory"_s );
@@ -342,7 +342,7 @@ void TestQgsIdentify::closestPoint()
 void TestQgsIdentify::lengthCalculation()
 {
   QgsSettings s;
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
 
   //create a temporary layer
   auto tempLayer = std::make_unique<QgsVectorLayer>( u"LineString?crs=epsg:3111&field=pk:int&field=col1:double"_s, u"vl"_s, u"memory"_s );
@@ -391,7 +391,7 @@ void TestQgsIdentify::lengthCalculation()
   QGSCOMPARENEAR( length, 88355.1, 0.1 );
 
   //test unchecked "keep base units" setting
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, false );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( false );
   result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
   QCOMPARE( result.length(), 1 );
   derivedLength = result.at( 0 ).mDerivedAttributes[tr( "Length (Ellipsoidal — WGS84)" )];
@@ -402,7 +402,7 @@ void TestQgsIdentify::lengthCalculation()
   QGSCOMPARENEAR( length, 16.734000, 0.001 );
 
   // no conversion of Cartesian lengths between unit types
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
   QgsProject::instance()->setDistanceUnits( Qgis::DistanceUnit::Degrees );
   result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
   QCOMPARE( result.length(), 1 );
@@ -465,7 +465,7 @@ void TestQgsIdentify::lengthCalculation()
 void TestQgsIdentify::perimeterCalculation()
 {
   QgsSettings s;
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
 
   //create a temporary layer
   auto tempLayer = std::make_unique<QgsVectorLayer>( u"Polygon?crs=epsg:3111&field=pk:int&field=col1:double"_s, u"vl"_s, u"memory"_s );
@@ -516,7 +516,7 @@ void TestQgsIdentify::perimeterCalculation()
   QGSCOMPARENEAR( perimeter, 420873.0, 0.1 );
 
   //test unchecked "keep base units" setting
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, false );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( false );
   result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
   QCOMPARE( result.length(), 1 );
   derivedPerimeter = result.at( 0 ).mDerivedAttributes[tr( "Perimeter (Ellipsoidal — WGS84)" )];
@@ -527,7 +527,7 @@ void TestQgsIdentify::perimeterCalculation()
   QCOMPARE( perimeter, 79.711 );
 
   // no conversion of Cartesian lengths between unit types
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
   QgsProject::instance()->setDistanceUnits( Qgis::DistanceUnit::Degrees );
   result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
   QCOMPARE( result.length(), 1 );
@@ -542,7 +542,7 @@ void TestQgsIdentify::perimeterCalculation()
 void TestQgsIdentify::areaCalculation()
 {
   QgsSettings s;
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
 
   //create a temporary layer
   auto tempLayer = std::make_unique<QgsVectorLayer>( u"Polygon?crs=epsg:3111&field=pk:int&field=col1:double"_s, u"vl"_s, u"memory"_s );
@@ -594,7 +594,7 @@ void TestQgsIdentify::areaCalculation()
   QGSCOMPARENEAR( area, 388.280000, 0.001 );
 
   //test unchecked "keep base units" setting
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, false );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( false );
   QgsProject::instance()->setAreaUnits( Qgis::AreaUnit::SquareFeet );
   result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
   QCOMPARE( result.length(), 1 );
@@ -606,7 +606,7 @@ void TestQgsIdentify::areaCalculation()
   QGSCOMPARENEAR( area, 388.280000, 0.001 );
 
   // no conversion of Cartesian lengths between unit types
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
   QgsProject::instance()->setAreaUnits( Qgis::AreaUnit::SquareDegrees );
   result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << tempLayer.get() );
   QCOMPARE( result.length(), 1 );

--- a/tests/src/app/testqgsidentify.cpp
+++ b/tests/src/app/testqgsidentify.cpp
@@ -37,6 +37,7 @@
 #include "qgsrasterlayer.h"
 #include "qgsrasterlayertemporalproperties.h"
 #include "qgssettings.h"
+#include "qgssettingsregistrycore.h"
 #include "qgstest.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"

--- a/tests/src/app/testqgsmeasuretool.cpp
+++ b/tests/src/app/testqgsmeasuretool.cpp
@@ -19,6 +19,7 @@
 #include "qgsmeasuretool.h"
 #include "qgsproject.h"
 #include "qgsrubberband.h"
+#include "qgssettingsregistrycore.h"
 #include "qgstest.h"
 
 #include <QString>
@@ -359,7 +360,7 @@ void TestQgsMeasureTool::degreeDecimalPlaces()
   QgsProject::instance()->setDistanceUnits( Qgis::DistanceUnit::Degrees );
 
   QgsSettings s;
-  s.setValue( u"qgis/measure/decimalplaces"_s, 3 );
+  QgsSettingsRegistryCore::settingsMeasureDecimalPlaces->setValue( 3 );
 
   const std::unique_ptr<QgsMeasureTool> tool( new QgsMeasureTool( mCanvas, true ) );
   auto dlg = std::make_unique<QgsMeasureDialog>( tool.get() );

--- a/tests/src/app/testqgsmeasuretool.cpp
+++ b/tests/src/app/testqgsmeasuretool.cpp
@@ -87,7 +87,7 @@ void TestQgsMeasureTool::testLengthCalculationCartesian()
 {
   //test length measurement
   QgsSettings s;
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
 
   // set project CRS and ellipsoid
   const QgsCoordinateReferenceSystem srs( u"EPSG:3111"_s );
@@ -154,7 +154,7 @@ void TestQgsMeasureTool::testLengthCalculationProjected()
 {
   //test length measurement
   QgsSettings s;
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
 
   // set project CRS and ellipsoid
   const QgsCoordinateReferenceSystem srs( u"EPSG:3111"_s );
@@ -222,7 +222,7 @@ void TestQgsMeasureTool::testLengthCalculationNoCrs()
 {
   // test length measurement when no projection is set
   QSettings s;
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
 
   // set project CRS and ellipsoid
   mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem() );
@@ -249,7 +249,7 @@ void TestQgsMeasureTool::testAreaCalculationCartesian()
 {
   //test area measurement
   QgsSettings s;
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
 
   // set project CRS and ellipsoid
   const QgsCoordinateReferenceSystem srs( u"EPSG:3111"_s );
@@ -303,7 +303,7 @@ void TestQgsMeasureTool::testAreaCalculationProjected()
 {
   //test area measurement
   QgsSettings s;
-  s.setValue( u"/qgis/measure/keepbaseunit"_s, true );
+  QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit->setValue( true );
 
   // set project CRS and ellipsoid
   const QgsCoordinateReferenceSystem srs( u"EPSG:3111"_s );

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -346,7 +346,7 @@ void TestQgsProject::testProjectUnits()
 
   //first set a default QGIS distance unit
   QgsSettings s;
-  s.setValue( u"/qgis/measure/displayunits"_s, QgsUnitTypes::encodeUnit( Qgis::DistanceUnit::Feet ) );
+  QgsSettingsRegistryCore::settingsMeasureDisplayUnits->setValue( QgsUnitTypes::encodeUnit( Qgis::DistanceUnit::Feet ) );
 
   QgsProject *prj = new QgsProject;
   // new project should inherit QGIS default distance unit
@@ -354,7 +354,7 @@ void TestQgsProject::testProjectUnits()
   QCOMPARE( prj->distanceUnits(), Qgis::DistanceUnit::Feet );
 
   //changing default QGIS unit should not affect existing project
-  s.setValue( u"/qgis/measure/displayunits"_s, QgsUnitTypes::encodeUnit( Qgis::DistanceUnit::NauticalMiles ) );
+  QgsSettingsRegistryCore::settingsMeasureDisplayUnits->setValue( QgsUnitTypes::encodeUnit( Qgis::DistanceUnit::NauticalMiles ) );
   QCOMPARE( prj->distanceUnits(), Qgis::DistanceUnit::Feet );
 
   //test setting new units for project

--- a/tests/src/core/testziplayer.cpp
+++ b/tests/src/core/testziplayer.cpp
@@ -31,7 +31,8 @@ using namespace Qt::StringLiterals;
 #include "qgsdataitem.h"
 #include "qgsconfig.h"
 #include "qgsrasterrenderer.h"
-#include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingsregistrycore.h"
 #include "qgsdirectoryitem.h"
 #include "qgslayeritem.h"
 #include "qgszipitem.h"
@@ -49,7 +50,6 @@ class TestZipLayer : public QObject
   private:
     QString mDataDir;
     QString mScanZipSetting;
-    QString mSettingsKey;
 
     // get map layer using Passthru
     QgsMapLayer *getLayer( const QString &myPath, const QString &myName, const QString &myProviderKey );
@@ -249,10 +249,7 @@ bool TestZipLayer::testZipItem( const QString &myFileName, const QString &myChil
 int TestZipLayer::getLayerTransparency( const QString &myFileName, const QString &myProviderKey, const QString &myScanZipSetting )
 {
   int myTransparency = -1;
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, myScanZipSetting );
-  if ( myScanZipSetting != settings.value( mSettingsKey ).toString() )
-    return myTransparency;
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( myScanZipSetting );
 
   QgsMapLayer *myLayer = nullptr;
   if ( myFileName.endsWith( ".gz"_L1, Qt::CaseInsensitive ) )
@@ -299,9 +296,7 @@ void TestZipLayer::initTestCase()
   QCoreApplication::setApplicationName( u"QGIS-TEST"_s );
 
   // save current zipSetting value
-  QgsSettings settings;
-  mSettingsKey = u"/qgis/scanZipInBrowser2"_s;
-  mScanZipSetting = settings.value( mSettingsKey, "" ).toString();
+  mScanZipSetting = QgsSettingsRegistryCore::settingsScanZipInBrowser->value();
 }
 
 void TestZipLayer::cleanupTestCase()
@@ -309,114 +304,100 @@ void TestZipLayer::cleanupTestCase()
   QgsApplication::exitQgis();
 
   // restore zipSetting
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, mScanZipSetting );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( mScanZipSetting );
 }
 
 void TestZipLayer::testPassthruVectorZip()
 {
-  QgsSettings settings;
   QString myFileName = mDataDir + "points2.zip";
 
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItemPassthru( myFileName, "ogr" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItemPassthru( myFileName, "ogr" ) );
 }
 
 void TestZipLayer::testPassthruVectorTar()
 {
-  QgsSettings settings;
   QString myFileName = mDataDir + "points2.tar";
 
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItemPassthru( myFileName, "ogr" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItemPassthru( myFileName, "ogr" ) );
 }
 
 void TestZipLayer::testPassthruVectorGzip()
 {
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItemPassthru( mDataDir + "points3.geojson.gz", "ogr" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItemPassthru( mDataDir + "points3.geojson.gz", "ogr" ) );
 }
 
 void TestZipLayer::testPassthruRasterZip()
 {
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItemPassthru( mDataDir + "landsat_b1.zip", "gdal" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItemPassthru( mDataDir + "landsat_b1.zip", "gdal" ) );
 }
 
 void TestZipLayer::testPassthruRasterTar()
 {
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItemPassthru( mDataDir + "landsat_b1.tar", "gdal" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItemPassthru( mDataDir + "landsat_b1.tar", "gdal" ) );
 }
 
 void TestZipLayer::testPassthruRasterGzip()
 {
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItemPassthru( mDataDir + "landsat_b1.tif.gz", "gdal" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItemPassthru( mDataDir + "landsat_b1.tif.gz", "gdal" ) );
 }
 
 void TestZipLayer::testZipItemRaster()
 {
-  QgsSettings settings;
-
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItem( QDir::tempPath() + "/testzip.zip", "landsat_b1.tif" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItem( QDir::tempPath() + "/testzip.zip", "landsat_b1.tif" ) );
 }
 
 void TestZipLayer::testTarItemRaster()
 {
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItem( mDataDir + "testtar.tgz", "landsat_b1.tif" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItem( mDataDir + "testtar.tgz", "landsat_b1.tif" ) );
 }
 
 void TestZipLayer::testZipItemVector()
 {
-  QgsSettings settings;
-
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItem( QDir::tempPath() + "/testzip.zip", "points.shp" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItem( QDir::tempPath() + "/testzip.zip", "points.shp" ) );
 }
 
 void TestZipLayer::testTarItemVector()
 {
-  QgsSettings settings;
-
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItem( mDataDir + "testtar.tgz", "points.shp" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItem( mDataDir + "testtar.tgz", "points.shp" ) );
 }
 
@@ -426,15 +407,13 @@ void TestZipLayer::testZipItemAll()
   // using zipSetting 2 (Basic Scan) would raise errors, because QgsZipItem would not test for valid items
   // and return child names of the invalid items
   // test file does not contain invalid items (some of dash tests failed because of them)
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, "full" );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItem( QDir::tempPath() + "/testzip.zip", "" ) );
 }
 
 void TestZipLayer::testTarItemAll()
 {
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, "full" );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItem( mDataDir + "testtar.tgz", "" ) );
 }
 
@@ -475,30 +454,26 @@ void TestZipLayer::testGzipItemRasterTransparency()
 
 void TestZipLayer::testZipItemSubfolder()
 {
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItem( QDir::tempPath() + "/testzip.zip", "folder/folder2/landsat_b2.tif" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItem( QDir::tempPath() + "/testzip.zip", "folder/folder2/landsat_b2.tif" ) );
 }
 
 void TestZipLayer::testTarItemSubfolder()
 {
-  QgsSettings settings;
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
   QVERIFY( testZipItem( mDataDir + "testtar.tgz", "folder/folder2/landsat_b2.tif" ) );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
   QVERIFY( testZipItem( mDataDir + "testtar.tgz", "folder/folder2/landsat_b2.tif" ) );
 }
 
 
 void TestZipLayer::testZipItemVRT()
 {
-  QgsSettings settings;
-
-  settings.setValue( mSettingsKey, u"basic"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"basic"_s );
 
   QgsDataItem *zipItem = getItemFromZip( QDir::tempPath() + "/testzip.zip", "landsat_b1.vrt" );
   QVERIFY( zipItem );
@@ -522,7 +497,7 @@ void TestZipLayer::testZipItemVRT()
   QCOMPARE( sublayerItem->sublayerDetails().name(), u"landsat_b1.vrt"_s );
   QCOMPARE( sublayerItem->sublayerDetails().providerKey(), u"gdal"_s );
 
-  settings.setValue( mSettingsKey, u"full"_s );
+  QgsSettingsRegistryCore::settingsScanZipInBrowser->setValue( u"full"_s );
 
   zipItem = getItemFromZip( QDir::tempPath() + "/testzip.zip", "landsat_b1.vrt" );
   QVERIFY( zipItem );

--- a/tests/src/python/test_qgsmeasureutils.py
+++ b/tests/src/python/test_qgsmeasureutils.py
@@ -25,7 +25,7 @@ class TestQgsMeasureUtils(QgisTestCase):
         start_app()
 
     def test_format_distance(self):
-        QgsSettings().setValue("qgis/measure/keepbaseunit", True)
+        QgsSettingsRegistryCore.settingsMeasureKeepBaseUnit().setValue(True)
 
         p = QgsProject()
         p.setDistanceUnits(Qgis.DistanceUnit.Feet)
@@ -82,7 +82,7 @@ class TestQgsMeasureUtils(QgisTestCase):
         )
 
     def test_format_distance_no_keep_base_unit(self):
-        QgsSettings().setValue("qgis/measure/keepbaseunit", False)
+        QgsSettingsRegistryCore.settingsMeasureKeepBaseUnit().setValue(False)
 
         p = QgsProject()
         p.setDistanceUnits(Qgis.DistanceUnit.Feet)
@@ -139,7 +139,7 @@ class TestQgsMeasureUtils(QgisTestCase):
         )
 
     def test_format_area(self):
-        QgsSettings().setValue("qgis/measure/keepbaseunit", True)
+        QgsSettingsRegistryCore.settingsMeasureKeepBaseUnit().setValue(True)
 
         p = QgsProject()
         p.setAreaUnits(Qgis.AreaUnit.SquareFeet)
@@ -190,7 +190,7 @@ class TestQgsMeasureUtils(QgisTestCase):
         )
 
     def test_format_area_no_keep_base_unit(self):
-        QgsSettings().setValue("qgis/measure/keepbaseunit", False)
+        QgsSettingsRegistryCore.settingsMeasureKeepBaseUnit().setValue(False)
 
         p = QgsProject()
         p.setAreaUnits(Qgis.AreaUnit.SquareFeet)

--- a/tests/src/python/test_qgsmeasureutils.py
+++ b/tests/src/python/test_qgsmeasureutils.py
@@ -8,7 +8,7 @@ the Free Software Foundation; either version 2 of the License, or
 
 import unittest
 
-from qgis.core import Qgis, QgsMeasureUtils, QgsProject, QgsSettings
+from qgis.core import Qgis, QgsMeasureUtils, QgsProject, QgsSettingsTree
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.testing import QgisTestCase, start_app
 
@@ -21,11 +21,12 @@ class TestQgsMeasureUtils(QgisTestCase):
         QCoreApplication.setOrganizationName("QGIS_Test")
         QCoreApplication.setOrganizationDomain("QGIS_TestQgsMeasureUtils.com")
         QCoreApplication.setApplicationName("QGIS_TestQgsMeasureUtils")
-        QgsSettings().clear()
         start_app()
+        cls.setting = QgsSettingsTree.node("measure").childSetting("keep-base-unit")
+        cls.setting.clear()
 
     def test_format_distance(self):
-        QgsSettingsRegistryCore.settingsMeasureKeepBaseUnit().setValue(True)
+        self.setting.setValue(True)
 
         p = QgsProject()
         p.setDistanceUnits(Qgis.DistanceUnit.Feet)
@@ -82,7 +83,7 @@ class TestQgsMeasureUtils(QgisTestCase):
         )
 
     def test_format_distance_no_keep_base_unit(self):
-        QgsSettingsRegistryCore.settingsMeasureKeepBaseUnit().setValue(False)
+        self.setting.setValue(False)
 
         p = QgsProject()
         p.setDistanceUnits(Qgis.DistanceUnit.Feet)
@@ -139,7 +140,7 @@ class TestQgsMeasureUtils(QgisTestCase):
         )
 
     def test_format_area(self):
-        QgsSettingsRegistryCore.settingsMeasureKeepBaseUnit().setValue(True)
+        self.setting.setValue(True)
 
         p = QgsProject()
         p.setAreaUnits(Qgis.AreaUnit.SquareFeet)
@@ -190,7 +191,7 @@ class TestQgsMeasureUtils(QgisTestCase):
         )
 
     def test_format_area_no_keep_base_unit(self):
-        QgsSettingsRegistryCore.settingsMeasureKeepBaseUnit().setValue(False)
+        self.setting.setValue(False)
 
         p = QgsProject()
         p.setAreaUnits(Qgis.AreaUnit.SquareFeet)

--- a/tests/src/python/test_qgsmeasureutils.py
+++ b/tests/src/python/test_qgsmeasureutils.py
@@ -23,7 +23,7 @@ class TestQgsMeasureUtils(QgisTestCase):
         QCoreApplication.setApplicationName("QGIS_TestQgsMeasureUtils")
         start_app()
         cls.setting = QgsSettingsTree.node("measure").childSetting("keep-base-unit")
-        cls.setting.clear()
+        cls.setting.remove()
 
     def test_format_distance(self):
         self.setting.setValue(True)

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -40,7 +40,7 @@ from qgis.core import (
     QgsProjectDirtyBlocker,
     QgsRasterLayer,
     QgsSelectiveMaskingSourceSet,
-    QgsSettings,
+    QgsSettingsTree,
     QgsUnitTypes,
     QgsVectorLayer,
 )
@@ -1789,13 +1789,14 @@ class TestQgsProject(QgisTestCase):
 
     def testBackgroundColor(self):
         p = QgsProject()
-        s = QgsSettings()
 
-        red = int(s.value("qgis/default_canvas_color_red", 255))
-        green = int(s.value("qgis/default_canvas_color_green", 255))
-        blue = int(s.value("qgis/default_canvas_color_blue", 255))
+        defaultColor = (
+            QgsSettingsTree.node("qgis")
+            .childSetting("default-canvas-color")
+            .valueAsVariant()
+        )
         # test default canvas background color
-        self.assertEqual(p.backgroundColor(), QColor(red, green, blue))
+        self.assertEqual(p.backgroundColor(), defaultColor)
         spy = QSignalSpy(p.backgroundColorChanged)
         p.setBackgroundColor(QColor(0, 0, 0))
         self.assertEqual(len(spy), 1)
@@ -1807,14 +1808,14 @@ class TestQgsProject(QgisTestCase):
 
     def testSelectionColor(self):
         p = QgsProject()
-        s = QgsSettings()
 
-        red = int(s.value("qgis/default_selection_color_red", 255))
-        green = int(s.value("qgis/default_selection_color_green", 255))
-        blue = int(s.value("qgis/default_selection_color_blue", 0))
-        alpha = int(s.value("qgis/default_selection_color_alpha", 255))
+        defaultColor = (
+            QgsSettingsTree.node("qgis")
+            .childSetting("default-selection-color")
+            .valueAsVariant()
+        )
         # test default feature selection color
-        self.assertEqual(p.selectionColor(), QColor(red, green, blue, alpha))
+        self.assertEqual(p.selectionColor(), defaultColor)
         spy = QSignalSpy(p.selectionColorChanged)
         p.setSelectionColor(QColor(0, 0, 0, 50))
         self.assertEqual(len(spy), 1)


### PR DESCRIPTION
## Description

Migrating a few settings.
I'm taking the opportunity of the new major version, so the plan is to do only forward compatibility until 4.2 is released.

Errors spotted:
* the setting `measure/planimetric` had different default values across the calls
*  different keys when accessing settings: `/qgis/measure/keepbaseunit` vs `qgis/measure/keepbaseunit` (for a few others too)

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

