### PR TITLE
Fix 3D CRS becoming stale

### DIFF
--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -124,10 +124,7 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers()
         // Only adjust ellipsoid to CRS if it's not set to planimetric
         QgsProject::instance()->setCrs( mFirstCRS.horizontalCrs(), !planimetric );
         const QgsCoordinateReferenceSystem vertCrs = mFirstCRS.verticalCrs();
-        if ( vertCrs.isValid() )
-        {
-          QgsProject::instance()->setVerticalCrs( vertCrs );
-        }
+        QgsProject::instance()->setVerticalCrs( vertCrs );
         break;
       }
 


### PR DESCRIPTION
fixes: #65122

Since mVerticalCrs is not reset in this method, when rebuilding the 3D CRS, we could end up getting unexpected results, since rebuilding of it depends on the value of mVerticalCrs.