### PR TITLE
Add documentation for QgsGeos::combine method

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -461,7 +461,16 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::subdivide( int maxNodes, QString *
 
   return std::move( parts );
 }
-
+/**
+ * Combines this geometry with another geometry.
+ *
+ * This method performs a geometric union between the current geometry
+ * and the provided geometry using the GEOS overlay union operation.
+ *
+ * @param geom geometry to combine with
+ * @param errorMsg optional error message if the operation fails
+ * @return resulting combined geometry
+ */
 QgsAbstractGeometry *QgsGeos::combine( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters ) const
 {
   return overlay( geom, OverlayUnion, errorMsg, parameters ).release();

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -467,9 +467,9 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::subdivide( int maxNodes, QString *
  * This method performs a geometric union between the current geometry
  * and the provided geometry using the GEOS overlay union operation.
  *
- * @param geom geometry to combine with
- * @param errorMsg optional error message if the operation fails
- * @return resulting combined geometry
+ * \param geom geometry to combine with
+ * \param errorMsg optional error message if the operation fails
+ * \return resulting combined geometry
  */
 QgsAbstractGeometry *QgsGeos::combine( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters ) const
 {

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -469,6 +469,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::subdivide( int maxNodes, QString *
  *
  * \param geom geometry to combine with
  * \param errorMsg optional error message if the operation fails
+ * \param parameters additional geometry operations parameters
  * \return resulting combined geometry
  */
 QgsAbstractGeometry *QgsGeos::combine( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters ) const


### PR DESCRIPTION
This PR adds a documentation comment for the QgsGeos::combine method in qgsgeos.cpp.
The comment explains the purpose of the method, its parameters, and the returned geometry. 
This improves code readability and helps developers understand how the combine operation 
performs a geometric union using the GEOS overlay union operation.

No functional changes were made to the code.