### PR TITLE
sfcgal: Add toSolid method

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
@@ -700,6 +700,19 @@ null pointer is returned.
                             operation
 %End
 
+    std::unique_ptr<QgsSfcgalGeometry> toSolid() const;
+%Docstring
+Converts the geometry to a Solid geometry. The geometry must be of type
+PolyhedralSurface
+
+:return: geometry as a Solid
+
+:raises QgsSfcgalException: if an error was encountered during the
+                            operation
+
+.. versionadded:: 4.2
+%End
+
 
 
     static std::unique_ptr<QgsSfcgalGeometry> createCube( double size );

--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -980,6 +980,16 @@ sfcgal::shared_geom QgsSfcgalEngine::approximateMedialAxis( const sfcgal::geomet
   return sfcgal::make_shared_geom( result );
 }
 
+sfcgal::shared_geom QgsSfcgalEngine::toSolid( const sfcgal::geometry *geom, QString *errorMsg )
+{
+  sfcgal::errorHandler()->clearText( errorMsg );
+  CHECK_NOT_NULL( geom, nullptr );
+
+  sfcgal::geometry *solid = sfcgal_geometry_make_solid( geom );
+  CHECK_SUCCESS( errorMsg, nullptr );
+
+  return sfcgal::make_shared_geom( solid );
+}
 
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )
 sfcgal::shared_geom QgsSfcgalEngine::transform( const sfcgal::geometry *geom, const QMatrix4x4 &mat, QString *errorMsg )

--- a/src/core/geometry/qgssfcgalengine.h
+++ b/src/core/geometry/qgssfcgalengine.h
@@ -673,6 +673,19 @@ class CORE_EXPORT QgsSfcgalEngine
      */
     static sfcgal::shared_geom approximateMedialAxis( const sfcgal::geometry *geom, QString *errorMsg = nullptr );
 
+    /**
+     * Converts a PolyhedralSurface geometry to a Solid geometry.
+     *
+     * The input geometry must be of type PolyhedralSurface. If the conversion fails, a null
+     * shared pointer is returned.
+     *
+     * \param geom the input geometry
+     * \param errorMsg Error message returned by SFGCAL
+     *
+     * \since QGIS 4.2
+     */
+    static sfcgal::shared_geom toSolid( const sfcgal::geometry *geom, QString *errorMsg = nullptr );
+
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )
 
     /**

--- a/src/core/geometry/qgssfcgalgeometry.cpp
+++ b/src/core/geometry/qgssfcgalgeometry.cpp
@@ -879,6 +879,20 @@ std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::approximateMedialAxis() co
   return resultGeom;
 }
 
+std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::toSolid() const
+{
+  QString errorMsg;
+  sfcgal::errorHandler()->clearText( &errorMsg );
+
+  sfcgal::shared_geom geom = workingGeom();
+  sfcgal::shared_geom solid = QgsSfcgalEngine::toSolid( geom.get(), &errorMsg );
+  THROW_ON_ERROR( &errorMsg );
+
+  std::unique_ptr<QgsSfcgalGeometry> solidGeom = QgsSfcgalEngine::toSfcgalGeometry( solid, &errorMsg );
+  THROW_ON_ERROR( &errorMsg );
+  return solidGeom;
+}
+
 std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::createCube( double size )
 {
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )

--- a/src/core/geometry/qgssfcgalgeometry.h
+++ b/src/core/geometry/qgssfcgalgeometry.h
@@ -617,6 +617,18 @@ class CORE_EXPORT QgsSfcgalGeometry
      */
     std::unique_ptr<QgsSfcgalGeometry> approximateMedialAxis() const SIP_THROW( QgsSfcgalException );
 
+    /**
+     * Converts the geometry to a Solid geometry.
+     * The geometry must be of type PolyhedralSurface
+     *
+     * \return geometry as a Solid
+     *
+     * \throws QgsSfcgalException if an error was encountered during the operation
+     *
+     * \since QGIS 4.2
+     */
+    std::unique_ptr<QgsSfcgalGeometry> toSolid() const SIP_THROW( QgsSfcgalException );
+
     // ============= PRIMITIVE
 
     /**

--- a/tests/src/core/geometry/testqgssfcgal.cpp
+++ b/tests/src/core/geometry/testqgssfcgal.cpp
@@ -96,6 +96,7 @@ class TestQgsSfcgal : public QgsTest
     void simplify();
     void approximateMedialAxis();
     void primitiveCube();
+    void toSolid();
 
   private:
     //! Must be called before each render test
@@ -1202,6 +1203,23 @@ void TestQgsSfcgal::primitiveCube()
   QCOMPARE( param.toDouble(), 8.2 );
 
 #endif
+}
+
+void TestQgsSfcgal::toSolid()
+{
+  QString phsWkt = u"POLYHEDRALSURFACE Z (((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),((0 0 0,1 0 0,0.5 0.5 1,0 0 0)),((1 0 0,1 1 0,0.5 0.5 1,1 0 0)),((1 1 0,0 1 0,0.5 0.5 1,1 1 0)),((0 1 0,0 0 0,0.5 0.5 1,0 1 0)))"_s;
+
+  QgsSfcgalGeometry sfcgalPolyhedralSurface( phsWkt );
+  QVERIFY2( sfcgalPolyhedralSurface.sfcgalGeometry() != nullptr, "Solid, input phs is NULL" );
+  QCOMPARE( sfcgalPolyhedralSurface.wkbType(), Qgis::WkbType::PolyhedralSurfaceZ );
+  std::unique_ptr<QgsSfcgalGeometry> solid = sfcgalPolyhedralSurface.toSolid();
+  QCOMPARE( solid->asWkt( 1 ), u"SOLID Z ((((0.0 0.0 0.0,0.0 1.0 0.0,1.0 1.0 0.0,1.0 0.0 0.0,0.0 0.0 0.0)),((0.0 0.0 0.0,1.0 0.0 0.0,0.5 0.5 1.0,0.0 0.0 0.0)),((1.0 0.0 0.0,1.0 1.0 0.0,0.5 0.5 1.0,1.0 0.0 0.0)),((1.0 1.0 0.0,0.0 1.0 0.0,0.5 0.5 1.0,1.0 1.0 0.0)),((0.0 1.0 0.0,0.0 0.0 0.0,0.5 0.5 1.0,0.0 1.0 0.0))))"_s );
+
+  // solid conversion does not work on a polygon
+  QgsSfcgalGeometry sfcgalPolygonZ( "POLYGON Z ((0 0 1, 20 0 2, 20 10 3, 0 10 4, 0 0 1))" );
+  QVERIFY2( sfcgalPolygonZ.sfcgalGeometry() != nullptr, "Solid, input polygon is NULL" );
+  QCOMPARE( sfcgalPolygonZ.wkbType(), Qgis::WkbType::PolygonZ );
+  QVERIFY_EXCEPTION_THROWN( sfcgalPolygonZ.toSolid(), QgsSfcgalException );
 }
 
 QGSTEST_MAIN( TestQgsSfcgal )


### PR DESCRIPTION
## Description

This adds a method to convert a PolyhedralSurface into its solid representation, allowing a switch from a surface-based representation to a volumetric one.

## AI tool usage

No AI tool used
