### PR TITLE
Fix: Avoid the scientific notation (exponential form) for large values

### DIFF
--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
@@ -172,10 +172,10 @@ QString QgsDefaultSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper:
   {
     bool ok = false;
     const double doubleValue = QgsDoubleValidator::toDouble( text, &ok );
+
     if ( ok )
     {
-      text = QString::number( doubleValue );
-      ;
+      text = QString::number( doubleValue, 'f', QLocale::FloatingPointShortest );
     }
   }
 

--- a/tests/src/python/test_qgssearchwidgetwrapper.py
+++ b/tests/src/python/test_qgssearchwidgetwrapper.py
@@ -189,6 +189,11 @@ class PyQgsDefaultSearchWidgetWrapper(QgisTestCase):
             w.createExpression(QgsSearchWidgetWrapper.FilterFlag.LessThanOrEqualTo),
             '"fldint"<=5000',
         )
+        line_edit.setText("10,000,000")
+        self.assertEqual(
+            w.createExpression(QgsSearchWidgetWrapper.FilterFlag.LessThan),
+            '"fldint"<10000000',
+        )
 
         # numeric field (double)
         parent = QWidget()
@@ -209,6 +214,11 @@ class PyQgsDefaultSearchWidgetWrapper(QgisTestCase):
         self.assertEqual(
             w.createExpression(QgsSearchWidgetWrapper.FilterFlag.LessThanOrEqualTo),
             '"flddouble"<=5000.5',
+        )
+        line_edit.setText("10,000.5555555555")
+        self.assertEqual(
+            w.createExpression(QgsSearchWidgetWrapper.FilterFlag.LessThan),
+            '"flddouble"<10000.5555555555',
         )
 
         # date/time/datetime


### PR DESCRIPTION
Completes #64692 where the part in `createExpression was embarrassingly forgotten.

Adds test case for `createExpression`.

This fixes #65284 