### PR TITLE
qgsrulebasedchunkloader: Fix check in onTerrainElevationOffsetChanged

### DIFF
--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -300,7 +300,7 @@ bool QgsRuleBasedChunkedEntity::applyTerrainOffset() const
 
 void QgsRuleBasedChunkedEntity::onTerrainElevationOffsetChanged()
 {
-  const float previousOffset = mTransform->translation()[1];
+  const float previousOffset = mTransform->translation().z();
   float newOffset = static_cast<float>( qobject_cast<Qgs3DMapSettings *>( sender() )->terrainSettings()->elevationOffset() );
   if ( !applyTerrainOffset() )
   {


### PR DESCRIPTION
## Description

Offset is along the Z axis.

## AI tool usage

 no AI tool used