### PR TITLE
Restore attribute table tests that have been disabled for a while

### DIFF
--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -111,6 +111,11 @@ QVariant QgsAttributeTableFilterModel::data( const QModelIndex &index, int role 
       const QModelIndex fieldIndex = QSortFilterProxyModel::mapToSource( QSortFilterProxyModel::index( index.row(), 0, index.parent() ) );
       return sourceModel()->data( fieldIndex, static_cast<int>( QgsAttributeTableModel::CustomRole::FeatureId ) );
     }
+    else if ( role == static_cast<int>( QgsAttributeTableModel::CustomRole::Sort ) )
+    {
+      const QModelIndex fieldIndex = QSortFilterProxyModel::mapToSource( QSortFilterProxyModel::index( index.row(), 0, index.parent() ) );
+      return sourceModel()->data( fieldIndex, static_cast<int>( QgsAttributeTableModel::CustomRole::Sort ) );
+    }
   }
   else if ( role == static_cast<int>( CustomRole::Type ) )
     return ColumnTypeField;

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -57,8 +57,6 @@ class TestQgsAttributeTable : public QObject
     // will be called before each testfunction is executed.
     void cleanup() {} // will be called after every testfunction.
 
-  public slots:
-
     void testRegression15974();
     void testFieldCalculation();
     void testFieldCalculationArea();
@@ -66,8 +64,6 @@ class TestQgsAttributeTable : public QObject
     void testSelected();
     void testEdited();
     void testSelectedOnTop();
-    void testSortByDisplayExpression();
-    void testOrderColumn();
     void testFilteredFeatures();
     void testOpenWithFilterExpression();
     void testVisibleTemporal();
@@ -77,8 +73,9 @@ class TestQgsAttributeTable : public QObject
     void testMultiEditMakeUncommittedChanges();
     void testInvalidView();
     void testEnsureEditSelection();
-  private slots:
     void testFetchAllAttributes();
+    void testSortByDisplayExpression();
+    void testOrderColumn();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -436,6 +433,7 @@ void TestQgsAttributeTable::testSortByDisplayExpression()
   auto dlg = std::make_unique<QgsAttributeTableDialog>( tempLayer.get() );
 
   dlg->mMainView->mFeatureListView->setDisplayExpression( "pk" );
+  dlg->mMainView->mFeatureListModel->setSortByDisplayExpression( true );
   QgsFeatureListModel *listModel = dlg->mMainView->mFeatureListModel;
   QCOMPARE( listModel->rowCount(), 3 );
 
@@ -461,7 +459,7 @@ void TestQgsAttributeTable::testSortNumbers()
   f1.setAttribute( 1, 2.001 );
   QgsFeature f2( tempLayer->dataProvider()->fields(), 2 );
   f2.setAttribute( 0, 2 );
-  f2.setAttribute( 1, 1001 );
+  f2.setAttribute( 1, 11001 );
   QgsFeature f3( tempLayer->dataProvider()->fields(), 3 );
   f3.setAttribute( 0, 3 );
   f3.setAttribute( 1, 10.0001 );
@@ -484,11 +482,11 @@ void TestQgsAttributeTable::testSortNumbers()
 
   QCOMPARE( model->data( model->index( 2, 1 ), Qt::ItemDataRole::DisplayRole ).toString(), QString( "2,00100" ) );
   QCOMPARE( model->data( model->index( 1, 1 ), Qt::ItemDataRole::DisplayRole ).toString(), QString( "10,00010" ) );
-  QCOMPARE( model->data( model->index( 0, 1 ), Qt::ItemDataRole::DisplayRole ).toString(), QString( "1.001,00000" ) );
+  QCOMPARE( model->data( model->index( 0, 1 ), Qt::ItemDataRole::DisplayRole ).toString(), QString( "11.001,00000" ) );
 
   QCOMPARE( model->data( model->index( 2, 2 ), static_cast<int>( QgsAttributeTableModel::CustomRole::Sort ) ).toDouble(), 2.001 );
   QCOMPARE( model->data( model->index( 1, 2 ), static_cast<int>( QgsAttributeTableModel::CustomRole::Sort ) ).toDouble(), 10.0001 );
-  QCOMPARE( model->data( model->index( 0, 2 ), static_cast<int>( QgsAttributeTableModel::CustomRole::Sort ) ).toDouble(), 1001.0 );
+  QCOMPARE( model->data( model->index( 0, 2 ), static_cast<int>( QgsAttributeTableModel::CustomRole::Sort ) ).toDouble(), 11001.0 );
 
   QCOMPARE( dlg->mMainView->mTableView->horizontalHeader()->sortIndicatorSection(), 1 );
   QCOMPARE( dlg->mMainView->mTableView->horizontalHeader()->sortIndicatorOrder(), Qt::SortOrder::DescendingOrder );
@@ -617,23 +615,23 @@ void TestQgsAttributeTable::testOrderColumn()
   QVERIFY( tempLayer->isValid() );
 
   QgsFeature f1( tempLayer->dataProvider()->fields(), 1 );
-  f1.setAttribute( 0, 1 );
-  f1.setAttribute( 1, 13 );
-  f1.setAttribute( 2, 7 );
+  f1.setAttribute( 0, 1 );  // pk
+  f1.setAttribute( 1, 13 ); // col1
+  f1.setAttribute( 2, 7 );  // col2
   QVERIFY( tempLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 ) );
 
   auto dlg = std::make_unique<QgsAttributeTableDialog>( tempLayer.get() );
 
   // Issue https://github.com/qgis/QGIS/issues/28493
   // When we reorder column (last column becomes first column), and we select an entire row
-  // the currentIndex is no longer the first column, and consequently it breaks edition
+  // the currentIndex is no longer the first column, and consequently it breaks editing
 
   QgsAttributeTableConfig config = QgsAttributeTableConfig();
   config.update( tempLayer->dataProvider()->fields() );
   QVector<QgsAttributeTableConfig::ColumnConfig> columns = config.columns();
 
   // move last column in first position
-  columns.move( 2, 0 );
+  columns.move( 2, 0 ); // col2, pk, col1
   config.setColumns( columns );
 
   dlg->mMainView->setAttributeTableConfig( config );
@@ -651,14 +649,14 @@ void TestQgsAttributeTable::testOrderColumn()
 
   qDebug() << filterModel->mapFromSource( filterModel->sourceModel()->index( 0, 0 ) );
 
-  // column 0 is indeed column 2 since we move it
+  // column 0 is indeed column 2 since we moved it
   QCOMPARE( filterModel->sortColumn(), 2 );
 
   // Assume an action column at the index 0,3
   // When we request the source index, it should be invalid (because there is no source of this column)
   index = filterModel->mapToSource( filterModel->sourceModel()->index( 0, 3 ) );
-  QVERIFY( index.isValid() );
-  // "hen we request the source index by mapToMaster, there should be returned the source index of the first column
+  QVERIFY( !index.isValid() );
+  // Then we request the source index by mapToMaster, there should be returned the source index of the first column
   // that's done to provide the feature
   index = filterModel->mapToMaster( filterModel->sourceModel()->index( 0, 3 ) );
   QCOMPARE( index.column(), 0 );


### PR DESCRIPTION
due to my mistake in
https://github.com/qgis/QGIS/pull/53168/changes#diff-4a7addb15c37611abf9690c64cd4e0f65394658c67a5f29bbd1c564665cb81bdR55

