### PR TITLE
Docs: clarify FilterExpression behavior when using QgsEditorWidgetSetup in RelationReference Widget

### DIFF
--- a/python/PyQt6/core/auto_generated/qgseditorwidgetsetup.sip.in
+++ b/python/PyQt6/core/auto_generated/qgseditorwidgetsetup.sip.in
@@ -14,6 +14,10 @@ class QgsEditorWidgetSetup
 %Docstring(signature="appended")
 Holder for the widget type and its configuration for a field.
 %End
+When a FilterExpression is defined programmatically through
+:py:class:`QgsEditorWidgetSetup` (for example when configuring a
+RelationReference widget), the interactive filter UI may appear disabled
+because filtering is considered externally controlled.
 
 %TypeHeaderCode
 #include "qgseditorwidgetsetup.h"

--- a/src/core/qgseditorwidgetsetup.h
+++ b/src/core/qgseditorwidgetsetup.h
@@ -24,6 +24,10 @@
  * \ingroup core
  * \brief Holder for the widget type and its configuration for a field.
  *
+ * When a FilterExpression is defined programmatically through
+ * QgsEditorWidgetSetup (for example when configuring a RelationReference widget),
+ * the interactive filter UI may appear disabled because filtering is
+ * considered externally controlled.
  */
 class CORE_EXPORT QgsEditorWidgetSetup
 {


### PR DESCRIPTION
Fixes #63387 

The behavior of 'FilterExpression' when used with QgsEditorWidfetSetup' in the RelationReference widget can be confusing. When a filter expression is defined programmatically, the widget may disable the interactive filter UI even though the filter is still correctly applied to the related features. 

This PR adds clarification to 'QgsEditorWidgetSetup' documentation explaining how 'FilterExpression' interacts with the  RelationReference widget and why the interactive filter UI may appear disabled.

Notes  
No functional code changes
I have done Documentation improvement only
It helps the developers to understand the interaction between 'FilterExpression', 'ChainFilters', and the RelationReference widget UI.