### PR TITLE
Don't copy plugins, compiled python files when migrating to 4.0

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsfileutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsfileutils.sip.in
@@ -245,7 +245,7 @@ already exist is found.
     typedef QFlags<QgsFileUtils::CopyFlag> CopyFlags;
 
 
-    static bool copyDirectory( const QString &source, const QString &destination, QgsFileUtils::CopyFlags flags = QgsFileUtils::CopyFlags() );
+    static bool copyDirectory( const QString &source, const QString &destination, QgsFileUtils::CopyFlags flags = QgsFileUtils::CopyFlags(), const QStringList &excludePatterns = QStringList() );
 %Docstring
 Recursively copies a whole directory.
 
@@ -258,6 +258,10 @@ were copied.
 
 Since QGIS 4.0.1 the ``flags`` argument can be used to specify flags
 controlling the behavior of the copy operation.
+
+Since QGIS 4.0.1 the ``excludePatterns`` argument can be used to specify
+a list of regular expressions. Any files or folders matching any of
+these patterns will be excluded from the copy.
 
 .. versionadded:: 4.0
 %End

--- a/src/app/qgsversionmigration.cpp
+++ b/src/app/qgsversionmigration.cpp
@@ -377,7 +377,10 @@ QgsError Qgs3To4Migration::runMigration( const QString &oldProfilePath, const QS
   newProfileDir.remove( u"symbology-style.db"_s );
 
   QgsError errors;
-  QgsFileUtils::copyDirectory( oldProfilePath, newProfilePath, QgsFileUtils::CopyFlag::NoSymLinks );
+
+  // don't copy:
+  // - compiled pycache or pyc files!
+  QgsFileUtils::copyDirectory( oldProfilePath, newProfilePath, QgsFileUtils::CopyFlag::NoSymLinks, { u".*\\b__pycache__$"_s, u".*\\.[pP][yY][cC]$"_s } );
 
   newProfileDir.remove( u"QGIS/QGIS4.ini"_s );
   newProfileDir.rename( u"QGIS/QGIS3.ini"_s, u"QGIS/QGIS4.ini"_s );

--- a/src/app/qgsversionmigration.cpp
+++ b/src/app/qgsversionmigration.cpp
@@ -380,7 +380,8 @@ QgsError Qgs3To4Migration::runMigration( const QString &oldProfilePath, const QS
 
   // don't copy:
   // - compiled pycache or pyc files!
-  QgsFileUtils::copyDirectory( oldProfilePath, newProfilePath, QgsFileUtils::CopyFlag::NoSymLinks, { u".*\\b__pycache__$"_s, u".*\\.[pP][yY][cC]$"_s } );
+  // - any plugin folders -- require users to reinstall those, so that we don't copy broken, non-updated 3.x plugins
+  QgsFileUtils::copyDirectory( oldProfilePath, newProfilePath, QgsFileUtils::CopyFlag::NoSymLinks, { u".*\\b__pycache__$"_s, u".*\\.[pP][yY][cC]$"_s, u".*[\\/]python[\\/]plugins$"_s } );
 
   newProfileDir.remove( u"QGIS/QGIS4.ini"_s );
   newProfileDir.rename( u"QGIS/QGIS3.ini"_s, u"QGIS/QGIS4.ini"_s );

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -635,7 +635,7 @@ QString QgsFileUtils::uniquePath( const QString &path )
   return uniquePath;
 }
 
-bool QgsFileUtils::copyDirectory( const QString &source, const QString &destination, CopyFlags flags )
+bool QgsFileUtils::copyDirectory( const QString &source, const QString &destination, CopyFlags flags, const QStringList &excludePatterns )
 {
   QDir sourceDir( source );
   if ( !sourceDir.exists() )
@@ -654,6 +654,13 @@ bool QgsFileUtils::copyDirectory( const QString &source, const QString &destinat
     }
   }
 
+  QVector< QRegularExpression > excludeRegExs;
+  excludeRegExs.reserve( excludePatterns.size() );
+  for ( const QString &pattern : excludePatterns )
+  {
+    excludeRegExs.append( QRegularExpression( pattern ) );
+  }
+
   bool copiedAll = true;
 
   QDir::Filters fileFilters = QDir::Files;
@@ -665,6 +672,23 @@ bool QgsFileUtils::copyDirectory( const QString &source, const QString &destinat
   for ( const QString &file : files )
   {
     const QString srcFileName = sourceDir.filePath( file );
+
+    bool skip = false;
+    for ( const QRegularExpression &excludeRegEx : std::as_const( excludeRegExs ) )
+    {
+      const QRegularExpressionMatch match = excludeRegEx.match( srcFileName );
+      if ( match.hasMatch() )
+      {
+        QgsDebugMsgLevel( u"Skipping %1, matches exclusion pattern %2"_s.arg( srcFileName, excludeRegEx.pattern() ), 1 );
+        skip = true;
+        break;
+      }
+    }
+    if ( skip )
+    {
+      continue;
+    }
+
     const QString destFileName = destDir.filePath( file );
     if ( !QFile::copy( srcFileName, destFileName ) )
     {
@@ -682,8 +706,25 @@ bool QgsFileUtils::copyDirectory( const QString &source, const QString &destinat
   for ( const QString &dir : dirs )
   {
     const QString srcDirName = sourceDir.filePath( dir );
+
+    bool skip = false;
+    for ( const QRegularExpression &excludeRegEx : std::as_const( excludeRegExs ) )
+    {
+      const QRegularExpressionMatch match = excludeRegEx.match( srcDirName );
+      if ( match.hasMatch() )
+      {
+        QgsDebugMsgLevel( u"Skipping %1, matches exclusion pattern %2"_s.arg( srcDirName, excludeRegEx.pattern() ), 1 );
+        skip = true;
+        break;
+      }
+    }
+    if ( skip )
+    {
+      continue;
+    }
+
     const QString destDirName = destDir.filePath( dir );
-    if ( !copyDirectory( srcDirName, destDirName, flags ) )
+    if ( !copyDirectory( srcDirName, destDirName, flags, excludePatterns ) )
     {
       copiedAll = false;
     }

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -679,7 +679,7 @@ bool QgsFileUtils::copyDirectory( const QString &source, const QString &destinat
       const QRegularExpressionMatch match = excludeRegEx.match( srcFileName );
       if ( match.hasMatch() )
       {
-        QgsDebugMsgLevel( u"Skipping %1, matches exclusion pattern %2"_s.arg( srcFileName, excludeRegEx.pattern() ), 1 );
+        QgsDebugMsgLevel( u"Skipping %1, matches exclusion pattern %2"_s.arg( srcFileName, excludeRegEx.pattern() ), 2 );
         skip = true;
         break;
       }
@@ -713,7 +713,7 @@ bool QgsFileUtils::copyDirectory( const QString &source, const QString &destinat
       const QRegularExpressionMatch match = excludeRegEx.match( srcDirName );
       if ( match.hasMatch() )
       {
-        QgsDebugMsgLevel( u"Skipping %1, matches exclusion pattern %2"_s.arg( srcDirName, excludeRegEx.pattern() ), 1 );
+        QgsDebugMsgLevel( u"Skipping %1, matches exclusion pattern %2"_s.arg( srcDirName, excludeRegEx.pattern() ), 2 );
         skip = true;
         break;
       }

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -269,9 +269,12 @@ class CORE_EXPORT QgsFileUtils
      * Since QGIS 4.0.1 the \a flags argument can be used to specify flags controlling the
      * behavior of the copy operation.
      *
+     * Since QGIS 4.0.1 the \a excludePatterns argument can be used to specify a list of regular expressions. Any files or
+     * folders matching any of these patterns will be excluded from the copy.
+     *
      * \since QGIS 4.0
      */
-    static bool copyDirectory( const QString &source, const QString &destination, QgsFileUtils::CopyFlags flags = QgsFileUtils::CopyFlags() );
+    static bool copyDirectory( const QString &source, const QString &destination, QgsFileUtils::CopyFlags flags = QgsFileUtils::CopyFlags(), const QStringList &excludePatterns = QStringList() );
 
     /**
      * Replaces all occurrences of a given string in a file.

--- a/tests/src/python/test_qgsfileutils.py
+++ b/tests/src/python/test_qgsfileutils.py
@@ -614,6 +614,75 @@ class TestQgsFileUtils(unittest.TestCase):
                 new_content = f.read()
             self.assertEqual(new_content, "this is my TeSt file\nwith some TeSts")
 
+    def test_copy_directory(self):
+        """
+        Test QgsFileUtils.copyDirectory
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # make directory structure to copy
+            src_dir = os.path.join(temp_dir, "src")
+            os.mkdir(src_dir)
+            with open(os.path.join(src_dir, "file1.txt"), "w") as f:
+                f.write("data")
+            with open(os.path.join(src_dir, "exclude_file.dat"), "w") as f:
+                f.write("data")
+
+            sub_dir = os.path.join(src_dir, "sub_dir")
+            os.mkdir(sub_dir)
+            with open(os.path.join(sub_dir, "file2.txt"), "w") as f:
+                f.write("data")
+            with open(os.path.join(sub_dir, "exclude_sub_file.dat"), "w") as f:
+                f.write("data")
+
+            exclude_dir = os.path.join(src_dir, "exclude_dir")
+            os.mkdir(exclude_dir)
+            with open(os.path.join(exclude_dir, "file3.txt"), "w") as f:
+                f.write("data")
+
+            # source directory does not exist:
+            missing_dir = os.path.join(temp_dir, "missing")
+            dest_missing = os.path.join(temp_dir, "dest_missing")
+            self.assertFalse(QgsFileUtils.copyDirectory(missing_dir, dest_missing))
+
+            # copy whole folder:
+            dest_basic = os.path.join(temp_dir, "dest_basic")
+            self.assertTrue(QgsFileUtils.copyDirectory(src_dir, dest_basic))
+            self.assertTrue(os.path.exists(os.path.join(dest_basic, "file1.txt")))
+            self.assertTrue(
+                os.path.exists(os.path.join(dest_basic, "exclude_file.dat"))
+            )
+            self.assertTrue(
+                os.path.exists(os.path.join(dest_basic, "sub_dir", "file2.txt"))
+            )
+            self.assertTrue(
+                os.path.exists(os.path.join(dest_basic, "exclude_dir", "file3.txt"))
+            )
+
+            # using exclude patterns:
+            dest_exclude = os.path.join(temp_dir, "dest_exclude")
+            self.assertTrue(
+                QgsFileUtils.copyDirectory(
+                    src_dir,
+                    dest_exclude,
+                    excludePatterns=[r".*\.dat$", ".*exclude_dir.*"],
+                )
+            )
+
+            self.assertTrue(os.path.exists(os.path.join(dest_exclude, "file1.txt")))
+            self.assertTrue(
+                os.path.exists(os.path.join(dest_exclude, "sub_dir", "file2.txt"))
+            )
+
+            self.assertFalse(
+                os.path.exists(os.path.join(dest_exclude, "exclude_file.dat"))
+            )
+            self.assertFalse(os.path.exists(os.path.join(dest_exclude, "exclude_dir")))
+            self.assertFalse(
+                os.path.exists(
+                    os.path.join(dest_exclude, "sub_dir", "exclude_sub_file.dat")
+                )
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Don't copy any plugins during migration of user profile to 4.0: require users to reinstall those, so that we don't copy broken,
non-updated 3.x plugins. Also avoid copying any potentially broken compiled pyc files.