### PR TITLE
Fix settings wiped on migration

### DIFF
--- a/src/core/settings/qgssettings.cpp
+++ b/src/core/settings/qgssettings.cpp
@@ -199,6 +199,10 @@ void QgsSettings::sync()
 void QgsSettings::remove( const QString &key, const QgsSettings::Section section )
 {
   const QString pKey = prefixedKey( key, section );
+  if ( pKey.isEmpty() )
+  {
+    QgsDebugError( u"QSettings::remove called with empty key -- this probably wasn't intentional, but will result in ALL SETTINGS GETTING DELETED!"_s );
+  }
   mUserSettings->remove( pKey );
 }
 
@@ -312,7 +316,12 @@ void QgsSettings::setValue( const QString &key, const QVariant &value, const Qgs
   // might be a nullptr (for example in case of standalone scripts or apps).
   else if ( mGlobalSettings && mGlobalSettings->value( prefixedKey( key, section ) ) == currentValue )
   {
-    mUserSettings->remove( prefixedKey( key, section ) );
+    const QString resolvedKey = prefixedKey( key, section );
+    if ( resolvedKey.isEmpty() )
+    {
+      QgsDebugError( u"QSettings::remove called with empty key -- this probably wasn't intentional, but will result in ALL SETTINGS GETTING DELETED!"_s );
+    }
+    mUserSettings->remove( resolvedKey );
   }
 }
 

--- a/src/core/settings/qgssettingsentryimpl.cpp
+++ b/src/core/settings/qgssettingsentryimpl.cpp
@@ -248,7 +248,8 @@ bool QgsSettingsEntryColor::copyValueFromKeys( const QString &redKey, const QStr
       settings->remove( redKey );
       settings->remove( greenKey );
       settings->remove( blueKey );
-      settings->remove( alphaKey );
+      if ( !alphaKey.isNull() )
+        settings->remove( alphaKey );
     }
 
     if ( value() != oldValue )

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsabstractdbsourceselect.h"
 #include "qgsapplication.h"
+#include "qgssettings.h"
 #include "qgssettingsentryenumflag.h"
 #include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
@@ -92,6 +93,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
 
   // TODO: remove in QGIS 4.4 (after LTR 4.2)
 
+  QgsSettings::holdFlush();
+
   // single settings - added in 3.30
   settingsRespectScreenDPI->copyValueFromKey( u"gui/qgis/respect_screen_dpi"_s, {}, true );
 
@@ -135,6 +138,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"Windows/MSSQLSourceSelect/HoldDialogOpen"_s, { u"MSSQLSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"Windows/PgSourceSelect/HoldDialogOpen"_s, { u"PgSourceSelect"_s }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( u"Windows/SpatiaLiteSourceSelect/HoldDialogOpen"_s, { u"SpatiaLiteSourceSelect"_s }, true );
+
+  QgsSettings::releaseFlush();
 }
 
 QgsSettingsRegistryGui::~QgsSettingsRegistryGui()


### PR DESCRIPTION
Fixes QgsSettingsEntryColor::copyValueFromKeys deletes all settings when the removeSettingAtKey option is true, and no alphaKey is specified.

This is because the QSettings::remove API is absolutely ridiculous and WIPES THE ENTIRE QSettings store if the requested key is an
empty string.