### PR TITLE
sfcgal: Add toPolyhedralSurface method

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
@@ -713,6 +713,19 @@ PolyhedralSurface
 .. versionadded:: 4.2
 %End
 
+    std::unique_ptr<QgsSfcgalGeometry> toPolyhedralSurface() const;
+%Docstring
+Converts the geometry to a PolyhedralSurface geometry. The geometry must
+be of type Solid
+
+:return: geometry as a PolyhedralSurface
+
+:raises QgsSfcgalException: if an error was encountered during the
+                            operation
+
+.. versionadded:: 4.2
+%End
+
 
 
     static std::unique_ptr<QgsSfcgalGeometry> createCube( double size );

--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -924,30 +924,12 @@ sfcgal::shared_geom QgsSfcgalEngine::extrude( const sfcgal::geometry *geom, cons
   // sfcgal_geometry_extrude returns a SOLID
   // This is not handled by QGIS
   // convert it to a PolyhedralSurface
-  sfcgal_geometry_t *polySurface = sfcgal_polyhedral_surface_create();
-  for ( unsigned int shellIdx = 0; shellIdx < sfcgal_solid_num_shells( solid ); ++shellIdx )
-  {
-    const sfcgal_geometry_t *shell = sfcgal_solid_shell_n( solid, shellIdx );
-#if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 1, 0 )
-    for ( unsigned int polyIdx = 0; polyIdx < sfcgal_polyhedral_surface_num_patches( shell ); ++polyIdx )
-    {
-      const sfcgal_geometry_t *patch = sfcgal_polyhedral_surface_patch_n( shell, polyIdx );
-      sfcgal_polyhedral_surface_add_patch( polySurface, sfcgal_geometry_clone( patch ) );
-    }
-#else
-    for ( unsigned int polyIdx = 0; polyIdx < sfcgal_polyhedral_surface_num_polygons( shell ); ++polyIdx )
-    {
-      const sfcgal_geometry_t *patch = sfcgal_polyhedral_surface_polygon_n( shell, polyIdx );
-      sfcgal_polyhedral_surface_add_polygon( polySurface, sfcgal_geometry_clone( patch ) );
-    }
-#endif
-  }
-
+  sfcgal::shared_geom polySurface = QgsSfcgalEngine::toPolyhedralSurface( solid, errorMsg );
   sfcgal_geometry_delete( solid );
 
   CHECK_SUCCESS( errorMsg, nullptr );
 
-  return sfcgal::make_shared_geom( polySurface );
+  return polySurface;
 }
 
 sfcgal::shared_geom QgsSfcgalEngine::simplify( const sfcgal::geometry *geom, double tolerance, bool preserveTopology, QString *errorMsg )

--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -991,6 +991,40 @@ sfcgal::shared_geom QgsSfcgalEngine::toSolid( const sfcgal::geometry *geom, QStr
   return sfcgal::make_shared_geom( solid );
 }
 
+sfcgal::shared_geom QgsSfcgalEngine::toPolyhedralSurface( const sfcgal::geometry *geom, QString *errorMsg )
+{
+  sfcgal::errorHandler()->clearText( errorMsg );
+  CHECK_NOT_NULL( geom, nullptr );
+
+  if ( sfcgal_geometry_type_id( geom ) != SFCGAL_TYPE_SOLID )
+  {
+    sfcgal::errorHandler()->addText( u"toPolyhedralSurface() only applies to solids"_s );
+    return nullptr;
+  }
+
+  sfcgal_geometry_t *polySurface = sfcgal_polyhedral_surface_create();
+  for ( unsigned int shellIdx = 0; shellIdx < sfcgal_solid_num_shells( geom ); ++shellIdx )
+  {
+    const sfcgal_geometry_t *shell = sfcgal_solid_shell_n( geom, shellIdx );
+#if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 1, 0 )
+    for ( unsigned int polyIdx = 0; polyIdx < sfcgal_polyhedral_surface_num_patches( shell ); ++polyIdx )
+    {
+      const sfcgal_geometry_t *patch = sfcgal_polyhedral_surface_patch_n( shell, polyIdx );
+      sfcgal_polyhedral_surface_add_patch( polySurface, sfcgal_geometry_clone( patch ) );
+    }
+#else
+    for ( unsigned int polyIdx = 0; polyIdx < sfcgal_polyhedral_surface_num_polygons( shell ); ++polyIdx )
+    {
+      const sfcgal_geometry_t *patch = sfcgal_polyhedral_surface_polygon_n( shell, polyIdx );
+      sfcgal_polyhedral_surface_add_polygon( polySurface, sfcgal_geometry_clone( patch ) );
+    }
+#endif
+  }
+
+  CHECK_SUCCESS( errorMsg, nullptr );
+  return sfcgal::make_shared_geom( polySurface );
+}
+
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )
 sfcgal::shared_geom QgsSfcgalEngine::transform( const sfcgal::geometry *geom, const QMatrix4x4 &mat, QString *errorMsg )
 {

--- a/src/core/geometry/qgssfcgalengine.h
+++ b/src/core/geometry/qgssfcgalengine.h
@@ -686,6 +686,19 @@ class CORE_EXPORT QgsSfcgalEngine
      */
     static sfcgal::shared_geom toSolid( const sfcgal::geometry *geom, QString *errorMsg = nullptr );
 
+    /**
+     * Converts a Solid geometry to a PolyhedralSurface geometry.
+     *
+     * The input geometry must be of type Solid. If the conversion fails, a null
+     * shared pointer is returned.
+     *
+     * \param geom the input geometry
+     * \param errorMsg Error message returned by SFGCAL
+     *
+     * \since QGIS 4.2
+     */
+    static sfcgal::shared_geom toPolyhedralSurface( const sfcgal::geometry *geom, QString *errorMsg = nullptr );
+
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )
 
     /**

--- a/src/core/geometry/qgssfcgalgeometry.cpp
+++ b/src/core/geometry/qgssfcgalgeometry.cpp
@@ -893,6 +893,20 @@ std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::toSolid() const
   return solidGeom;
 }
 
+std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::toPolyhedralSurface() const
+{
+  QString errorMsg;
+  sfcgal::errorHandler()->clearText( &errorMsg );
+
+  sfcgal::shared_geom geom = workingGeom();
+  sfcgal::shared_geom phs = QgsSfcgalEngine::toPolyhedralSurface( geom.get(), &errorMsg );
+  THROW_ON_ERROR( &errorMsg );
+
+  std::unique_ptr<QgsSfcgalGeometry> phsGeom = QgsSfcgalEngine::toSfcgalGeometry( phs, &errorMsg );
+  THROW_ON_ERROR( &errorMsg );
+  return phsGeom;
+}
+
 std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::createCube( double size )
 {
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )

--- a/src/core/geometry/qgssfcgalgeometry.h
+++ b/src/core/geometry/qgssfcgalgeometry.h
@@ -629,6 +629,18 @@ class CORE_EXPORT QgsSfcgalGeometry
      */
     std::unique_ptr<QgsSfcgalGeometry> toSolid() const SIP_THROW( QgsSfcgalException );
 
+    /**
+     * Converts the geometry to a PolyhedralSurface geometry.
+     * The geometry must be of type Solid
+     *
+     * \return geometry as a PolyhedralSurface
+     *
+     * \throws QgsSfcgalException if an error was encountered during the operation
+     *
+     * \since QGIS 4.2
+     */
+    std::unique_ptr<QgsSfcgalGeometry> toPolyhedralSurface() const SIP_THROW( QgsSfcgalException );
+
     // ============= PRIMITIVE
 
     /**

--- a/tests/src/core/geometry/testqgssfcgal.cpp
+++ b/tests/src/core/geometry/testqgssfcgal.cpp
@@ -97,6 +97,7 @@ class TestQgsSfcgal : public QgsTest
     void approximateMedialAxis();
     void primitiveCube();
     void toSolid();
+    void toPolyhedralSurface();
 
   private:
     //! Must be called before each render test
@@ -1220,6 +1221,22 @@ void TestQgsSfcgal::toSolid()
   QVERIFY2( sfcgalPolygonZ.sfcgalGeometry() != nullptr, "Solid, input polygon is NULL" );
   QCOMPARE( sfcgalPolygonZ.wkbType(), Qgis::WkbType::PolygonZ );
   QVERIFY_EXCEPTION_THROWN( sfcgalPolygonZ.toSolid(), QgsSfcgalException );
+}
+
+void TestQgsSfcgal::toPolyhedralSurface()
+{
+  QString solidWkt = u"SOLID Z ((((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),((0 0 0,1 0 0,0.5 0.5 1,0 0 0)),((1 0 0,1 1 0,0.5 0.5 1,1 0 0)),((1 1 0,0 1 0,0.5 0.5 1,1 1 0)),((0 1 0,0 0 0,0.5 0.5 1,0 1 0))))"_s;
+
+  QgsSfcgalGeometry sfcgalSolid( solidWkt );
+  QVERIFY2( sfcgalSolid.sfcgalGeometry() != nullptr, "toPolyhedralSurface, input solid is NULL" );
+  std::unique_ptr<QgsSfcgalGeometry> phs = sfcgalSolid.toPolyhedralSurface();
+  QCOMPARE( phs->asWkt( 1 ), u"POLYHEDRALSURFACE Z (((0.0 0.0 0.0,0.0 1.0 0.0,1.0 1.0 0.0,1.0 0.0 0.0,0.0 0.0 0.0)),((0.0 0.0 0.0,1.0 0.0 0.0,0.5 0.5 1.0,0.0 0.0 0.0)),((1.0 0.0 0.0,1.0 1.0 0.0,0.5 0.5 1.0,1.0 0.0 0.0)),((1.0 1.0 0.0,0.0 1.0 0.0,0.5 0.5 1.0,1.0 1.0 0.0)),((0.0 1.0 0.0,0.0 0.0 0.0,0.5 0.5 1.0,0.0 1.0 0.0)))"_s );
+
+  // solid conversion does not work on a polygon
+  QgsSfcgalGeometry sfcgalPolygonZ( u"POLYGON Z ((0 0 1, 20 0 2, 20 10 3, 0 10 4, 0 0 1))"_s );
+  QVERIFY2( sfcgalPolygonZ.sfcgalGeometry() != nullptr, "toPolyhedralSurface, input polygon is NULL" );
+  QCOMPARE( sfcgalPolygonZ.wkbType(), Qgis::WkbType::PolygonZ );
+  QVERIFY_EXCEPTION_THROWN( sfcgalPolygonZ.toPolyhedralSurface(), QgsSfcgalException );
 }
 
 QGSTEST_MAIN( TestQgsSfcgal )


### PR DESCRIPTION
## Description

inverse function of #65293 
 
This adds a method to convert a Solid into its polyhedralSurface
representation, allowing a switch from a volume-based representation
to a surface one.

## AI tool usage

No AI tool used