### PR TITLE
[server] Fix OGCAPI template paths wfs3->oapif

### DIFF
--- a/python/PyQt6/server/auto_generated/qgsserversettings.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserversettings.sip.in
@@ -279,12 +279,8 @@ environment variable QGIS_SERVER_API_WFS3_MAX_LIMIT.
 %Docstring
 Returns the server-wide root path for OAPIF (WFS3) service API.
 
-The default value is "/wfs3", this value can be changed by setting the
+The default value is "/ogcapi", this value can be changed by setting the
 environment variable QGIS_SERVER_API_WFS3_ROOT_PATH.
-
-.. note::
-
-   The default will be changed to "/ogcapi" for QGIS 4.
 
 .. versionadded:: 3.44.3
 %End

--- a/python/PyQt6/server/auto_generated/qgsserverstatichandler.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverstatichandler.sip.in
@@ -13,7 +13,7 @@ class QgsServerStaticHandler : QgsServerOgcApiHandler
 {
 %Docstring(signature="appended")
 Serves static files from the static path
-(resources/server/api/wfs3/static).
+(resources/server/api/ogc/static).
 
 .. seealso:: :py:func:`QgsServerOgcApiHandler.staticPath`
 

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -249,7 +249,7 @@ const QString QgsServerOgcApiHandler::staticPath( const QgsServerApiContext &con
 
 const QString QgsServerOgcApiHandler::templatePath( const QgsServerApiContext &context ) const
 {
-  // resources/server/api + /ogc/templates/ + operationId + .html
+  // resources/server/api + /ogc/templates/ + apiRootPath() + / + operationId() + .html
   QString path { context.serverInterface()->serverSettings()->apiResourcesDirectory() };
   path += "/ogc/templates"_L1;
   path += context.apiRootPath();
@@ -258,7 +258,6 @@ const QString QgsServerOgcApiHandler::templatePath( const QgsServerApiContext &c
   path += ".html"_L1;
   return path;
 }
-
 
 void QgsServerOgcApiHandler::htmlDump( const json &data, const QgsServerApiContext &context ) const
 {

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -219,14 +219,8 @@ void QgsServerSettings::initSettings()
 
   {
     // API WFS3 root path
-    // TODO: remove when QGIS 4 is released
-#if _QGIS_VERSION_INT > 40000
     const Setting sApiWfs3RootPath
       = { QgsServerSettingsEnv::QGIS_SERVER_API_WFS3_ROOT_PATH, QgsServerSettingsEnv::DEFAULT_VALUE, u"Root path for the OAPIF (WFS3) API"_s, u"/qgis/server_api_wfs3_root_path"_s, QMetaType::Type::QString, QVariant( "/ogcapi" ), QVariant() };
-#else
-    const Setting sApiWfs3RootPath
-      = { QgsServerSettingsEnv::QGIS_SERVER_API_WFS3_ROOT_PATH, QgsServerSettingsEnv::DEFAULT_VALUE, u"Root path for the OAPIF (WFS3) API"_s, u"/qgis/server_api_wfs3_root_path"_s, QMetaType::Type::QString, QVariant( "/wfs3" ), QVariant() };
-#endif
     mSettings[sApiWfs3RootPath.envVar] = sApiWfs3RootPath;
   }
 

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -267,9 +267,8 @@ class SERVER_EXPORT QgsServerSettings
     /**
      * Returns the server-wide root path for OAPIF (WFS3) service API.
      *
-     * The default value is "/wfs3", this value can be changed by setting the environment
+     * The default value is "/ogcapi", this value can be changed by setting the environment
      * variable QGIS_SERVER_API_WFS3_ROOT_PATH.
-     * \note The default will be changed to "/ogcapi" for QGIS 4.
      * \since QGIS 3.44.3
      */
     QString apiWfs3RootPath() const;

--- a/src/server/qgsserverstatichandler.h
+++ b/src/server/qgsserverstatichandler.h
@@ -25,7 +25,7 @@ using namespace Qt::StringLiterals;
 
 /**
  * \ingroup server
- * \brief Serves static files from the static path (resources/server/api/wfs3/static).
+ * \brief Serves static files from the static path (resources/server/api/ogc/static).
  * \see QgsServerOgcApiHandler::staticPath()
  * \since QGIS 3.16
  */

--- a/src/server/services/landingpage/qgslandingpagehandlers.cpp
+++ b/src/server/services/landingpage/qgslandingpagehandlers.cpp
@@ -128,6 +128,16 @@ QRegularExpression QgsLandingPageMapHandler::path() const
   return QRegularExpression( QStringLiteral( R"re(^%1/map/([a-f0-9]{32}).*$)re" ).arg( QgsLandingPageHandler::prefix( mSettings ) ) );
 }
 
+const QString QgsLandingPageMapHandler::templatePath( const QgsServerApiContext &context ) const
+{
+  // resources/server/api + /ogc/templates/wfs3/ + operationId() + .html
+  QString path { context.serverInterface()->serverSettings()->apiResourcesDirectory() };
+  path += "/ogc/templates/wfs3/"_L1;
+  path += QString::fromStdString( operationId() );
+  path += ".html"_L1;
+  return path;
+}
+
 
 QRegularExpression QgsLandingPageHandler::path() const
 {

--- a/src/server/services/landingpage/qgslandingpagehandlers.h
+++ b/src/server/services/landingpage/qgslandingpagehandlers.h
@@ -83,6 +83,7 @@ class QgsLandingPageMapHandler : public QgsServerOgcApiHandler
     std::string description() const override { return "Shows a map"; }
     std::string linkTitle() const override { return "Map Viewer"; }
     QgsServerOgcApi::Rel linkType() const override { return QgsServerOgcApi::Rel::self; }
+    const QString templatePath( const QgsServerApiContext &context ) const override;
 
   private:
     const QgsServerSettings *mSettings = nullptr;

--- a/src/server/services/wfs3/qgswfs3.cpp
+++ b/src/server/services/wfs3/qgswfs3.cpp
@@ -35,12 +35,7 @@ class QgsWfs3Module : public QgsServiceModule
   public:
     void registerSelf( QgsServiceRegistry &registry, QgsServerInterface *serverIface ) override
     {
-      // TODO: remove when QGIS 4 is released
-#if _QGIS_VERSION_INT >= 40000
       QString rootPath = u"/ogcapi"_s;
-#else
-      QString rootPath = u"/wfs3"_s;
-#endif
       if ( serverIface && serverIface->serverSettings() && !serverIface->serverSettings()->apiWfs3RootPath().isEmpty() )
       {
         rootPath = serverIface->serverSettings()->apiWfs3RootPath();

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -231,10 +231,9 @@ QgsFields QgsWfs3AbstractItemsHandler::publishedFields( const QgsVectorLayer *vL
 
 const QString QgsWfs3AbstractItemsHandler::templatePath( const QgsServerApiContext &context ) const
 {
-  // resources/server/api + /ogc/templates/ + operationId + .html
+  // resources/server/api + /ogc/templates/wfs3 + operationId + .html
   QString path { context.serverInterface()->serverSettings()->apiResourcesDirectory() };
-  path += "/ogc/templates/wfs3"_L1;
-  path += '/';
+  path += "/ogc/templates/wfs3/"_L1;
   path += QString::fromStdString( operationId() );
   path += ".html"_L1;
   return path;
@@ -286,6 +285,16 @@ json QgsWfs3LandingPageHandler::schema( const QgsServerApiContext &context ) con
             { "default", defaultResponse() } } } } }
   };
   return data;
+}
+
+const QString QgsWfs3LandingPageHandler::templatePath( const QgsServerApiContext &context ) const
+{
+  // resources/server/api + /ogc/templates/wfs3/ + operationId() + .html
+  QString path { context.serverInterface()->serverSettings()->apiResourcesDirectory() };
+  path += "/ogc/templates/wfs3/"_L1;
+  path += QString::fromStdString( operationId() );
+  path += ".html"_L1;
+  return path;
 }
 
 
@@ -1948,4 +1957,14 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
 
   } // end for loop
   return data;
+}
+
+const QString QgsWfs3ConformanceHandler::templatePath( const QgsServerApiContext &context ) const
+{
+  // resources/server/api + /ogc/templates/wfs3/ + operationId() + .html
+  QString path { context.serverInterface()->serverSettings()->apiResourcesDirectory() };
+  path += "/ogc/templates/wfs3/"_L1;
+  path += QString::fromStdString( operationId() );
+  path += ".html"_L1;
+  return path;
 }

--- a/src/server/services/wfs3/qgswfs3handlers.h
+++ b/src/server/services/wfs3/qgswfs3handlers.h
@@ -122,6 +122,7 @@ class QgsWfs3LandingPageHandler : public QgsServerOgcApiHandler
     std::string linkTitle() const override { return "Landing page"; }
     QgsServerOgcApi::Rel linkType() const override { return QgsServerOgcApi::Rel::self; }
     json schema( const QgsServerApiContext &context ) const override;
+    QString const templatePath( const QgsServerApiContext &context ) const override;
 };
 
 /**
@@ -147,6 +148,7 @@ class QgsWfs3ConformanceHandler : public QgsServerOgcApiHandler
     std::string linkTitle() const override { return "WFS 3.0 conformance classes"; }
     QgsServerOgcApi::Rel linkType() const override { return QgsServerOgcApi::Rel::conformance; }
     json schema( const QgsServerApiContext &context ) const override;
+    const QString templatePath( const QgsServerApiContext &context ) const override;
 };
 
 

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -383,14 +383,12 @@ class QgsServerAPITest(QgsServerAPITestBase):
 
     def setUp(self):
         super().setUp()
-        # TODO: Remove when QGIS 4 is released
-        # Default url will change when QGIS 4 is released, set it to /wfs3 for now
-        if Qgis.versionInt() >= 40000:
-            os.environ.update({"QGIS_SERVER_API_WFS3_ROOT_PATH": "/wfs3"})
-            iface = self.server.serverInterface()
-            iface.reloadSettings()
-            iface.serviceRegistry().cleanUp()
-            iface.serviceRegistry().init(QgsApplication.libexecPath() + "server", iface)
+        # Default url has changed in QGIS 4 stick to /wfs3 for the tests
+        os.environ.update({"QGIS_SERVER_API_WFS3_ROOT_PATH": "/wfs3"})
+        iface = self.server.serverInterface()
+        iface.reloadSettings()
+        iface.serviceRegistry().cleanUp()
+        iface.serviceRegistry().init(QgsApplication.libexecPath() + "server", iface)
 
     # Set env context manager
     @contextmanager


### PR DESCRIPTION
After the default api URL root path change the
template path needs to be hardcoded (this doesn't
reduce the class functionality because it's only
done for the existing private classes and it is
an implementation detail).

Followup #63086
