### PR TITLE
[processing] Add renderer usage detail when using the rasterize map and create XYZ tiles algorithms

### DIFF
--- a/src/analysis/processing/qgsalgorithmrasterize.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterize.cpp
@@ -232,6 +232,7 @@ QVariantMap QgsRasterizeAlgorithm::processAlgorithm( const QVariantMap &paramete
   geoTransform[5] = -mapUnitsPerPixel;
   GDALSetGeoTransform( hOutputDataset.get(), geoTransform );
 
+  mMapSettings.setRendererUsage( Qgis::RendererUsage::Export );
   mMapSettings.setOutputImageFormat( QImage::Format_ARGB32 );
   mMapSettings.setDestinationCrs( mCrs );
   mMapSettings.setFlag( Qgis::MapSettingsFlag::Antialiasing, true );

--- a/src/analysis/processing/qgsalgorithmxyztiles.cpp
+++ b/src/analysis/processing/qgsalgorithmxyztiles.cpp
@@ -245,6 +245,7 @@ void QgsXyzTilesBaseAlgorithm::startJobs()
     {
       continue;
     }
+    settings.setRendererUsage( Qgis::RendererUsage::Export );
     settings.setOutputImageFormat( QImage::Format_ARGB32_Premultiplied );
     settings.setTransformContext( mTransformContext );
     settings.setDestinationCrs( mMercatorCrs );


### PR DESCRIPTION
## Description

This will help better diagnose the uses of vector/raster tile layers relying on the {usage} tag (including possibly the default openstreetmap XYZ layer QGIS ships with). @jef-n , that's in relation to the commit I spotted while reading the issue on OSM operations github repo,

Note that doing this does mean we essentially split the cache. I.e., these three URLs will  have distinct cache entries:

https://tile.openstreetmap.org/7/63/42.png
vs.
https://tile.openstreetmap.org/7/63/42.png?usage=view
vs.
https://tile.openstreetmap.org/7/63/42.png?usage=export

This means while we get a bit more info on where the issue potentially comes from, we lower the efficiency of caching to begin with. @jef-n , that's something that makes me wonder whether we should (or should not) add a usage tag to our shipped URL.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
