### PR TITLE
[FEATURE] Support concatenation in export of label Styles to SLD

### DIFF
--- a/src/core/labeling/qgsvectorlayerlabeling.cpp
+++ b/src/core/labeling/qgsvectorlayerlabeling.cpp
@@ -15,6 +15,9 @@
 #include "qgsvectorlayerlabeling.h"
 
 #include "qgis.h"
+#include "qgsexpression.h"
+#include "qgsexpressionnode.h"
+#include "qgsexpressionnodeimpl.h"
 #include "qgsmarkersymbol.h"
 #include "qgsmarkersymbollayer.h"
 #include "qgspallabeling.h"
@@ -220,6 +223,87 @@ void appendSimpleFunction( QDomDocument &doc, QDomElement &parent, const QString
   function.appendChild( property );
 }
 
+/**
+ * Recursively flattens a QgsExpression concatenation tree into a single list of SLD operands.
+ */
+static void flattenConcatenation( QDomDocument &doc, QDomElement &parent, const QgsExpressionNode *node )
+{
+  const QgsExpressionNodeBinaryOperator *binNode = dynamic_cast<const QgsExpressionNodeBinaryOperator *>( node );
+  if ( binNode && binNode->op() == QgsExpressionNodeBinaryOperator::boConcat )
+  {
+    // Recursive step: drill down into left and right branches without creating new tags
+    flattenConcatenation( doc, parent, binNode->opLeft() );
+    flattenConcatenation( doc, parent, binNode->opRight() );
+  }
+  else
+  {
+    // Base case: handle leaf nodes (columns or literal strings) and append them as children
+    if ( const QgsExpressionNodeColumnRef *column = dynamic_cast<const QgsExpressionNodeColumnRef *>( node ) )
+    {
+      QDomElement propElement = doc.createElement( QStringLiteral( "ogc:PropertyName" ) );
+      propElement.appendChild( doc.createTextNode( column->name() ) );
+      parent.appendChild( propElement );
+    }
+    else if ( const QgsExpressionNodeLiteral *literal = dynamic_cast<const QgsExpressionNodeLiteral *>( node ) )
+    {
+      QDomElement litElement = doc.createElement( QStringLiteral( "ogc:Literal" ) );
+      litElement.appendChild( doc.createTextNode( literal->value().toString() ) );
+      parent.appendChild( litElement );
+    }
+  }
+}
+
+/**
+ * Appends a QgsExpression node to an SLD document.
+ * Specifically handles string concatenation (||) by creating a single <ogc:Function name="Concatenate">
+ * element containing all recursively discovered operands.
+ */
+static bool appendExpressionAsSld( QDomDocument &doc, QDomElement &parent, const QgsExpressionNode *node )
+{
+  switch ( node->nodeType() )
+  {
+    case QgsExpressionNode::ntBinaryOperator:
+    {
+      const QgsExpressionNodeBinaryOperator *binNode = static_cast<const QgsExpressionNodeBinaryOperator *>( node );
+      if ( binNode->op() == QgsExpressionNodeBinaryOperator::boConcat )
+      {
+        // Create the main Concatenate function tag once
+        QDomElement funcElement = doc.createElement( QStringLiteral( "ogc:Function" ) );
+        funcElement.setAttribute( QStringLiteral( "name" ), QStringLiteral( "Concatenate" ) );
+
+        // Populate it with all flattened parts of the expression
+        flattenConcatenation( doc, funcElement, binNode );
+
+        parent.appendChild( funcElement );
+        return true;
+      }
+      return false;
+    }
+
+    case QgsExpressionNode::ntColumnRef:
+    {
+      const QgsExpressionNodeColumnRef *column = static_cast<const QgsExpressionNodeColumnRef *>( node );
+      QDomElement propElement = doc.createElement( QStringLiteral( "ogc:PropertyName" ) );
+      propElement.appendChild( doc.createTextNode( column->name() ) );
+      parent.appendChild( propElement );
+      return true;
+    }
+
+    case QgsExpressionNode::ntLiteral:
+    {
+      const QgsExpressionNodeLiteral *literal = static_cast<const QgsExpressionNodeLiteral *>( node );
+      QDomElement litElement = doc.createElement( QStringLiteral( "ogc:Literal" ) );
+      litElement.appendChild( doc.createTextNode( literal->value().toString() ) );
+      parent.appendChild( litElement );
+      return true;
+    }
+
+    default:
+      // Return false for complex expressions not yet supported by the SLD exporter
+      return false;
+  }
+}
+
 std::unique_ptr<QgsMarkerSymbolLayer> backgroundToMarkerLayer( const QgsTextBackgroundSettings &settings )
 {
   std::unique_ptr<QgsMarkerSymbolLayer> layer;
@@ -320,11 +404,24 @@ bool QgsAbstractVectorLayerLabeling::writeTextSymbolizer( QDomNode &parent, QgsP
   const QFont font = format.font();
   QDomElement labelElement = doc.createElement( u"se:Label"_s );
   textSymbolizerElement.appendChild( labelElement );
+
   if ( settings.isExpression )
   {
-    context.pushError( QObject::tr( "Labels containing expressions cannot be exported to SLD. Skipping label '%1'" ).arg( settings.getLabelExpression()->dump() ) );
-    labelElement.appendChild( doc.createTextNode( "Placeholder" ) );
+    bool success = false;
+    if ( settings.getLabelExpression() && settings.getLabelExpression()->rootNode() )
+    {
+      // Attempt to export the expression as an SLD Concatenate function
+      success = appendExpressionAsSld( doc, labelElement, settings.getLabelExpression()->rootNode() );
+    }
+
+    if ( !success )
+    {
+      // Fallback: If the expression is too complex, push an error and use a placeholder
+      context.pushError( QObject::tr( "Complex expressions in labels cannot be exported to SLD. Skipping label '%1'" ).arg( settings.getLabelExpression()->dump() ) );
+      labelElement.appendChild( doc.createTextNode( "Placeholder" ) );
+    }
   }
+
   else
   {
     Qgis::Capitalization capitalization = format.capitalization();

--- a/src/core/labeling/qgsvectorlayerlabeling.cpp
+++ b/src/core/labeling/qgsvectorlayerlabeling.cpp
@@ -16,10 +16,9 @@
 
 #include "qgis.h"
 #include "qgsexpression.h"
-#include "qgsexpressionnode.h"
-#include "qgsexpressionnodeimpl.h"
 #include "qgsmarkersymbol.h"
 #include "qgsmarkersymbollayer.h"
+#include "qgsogcutils.h"
 #include "qgspallabeling.h"
 #include "qgsrulebasedlabeling.h"
 #include "qgssldexportcontext.h"
@@ -223,87 +222,6 @@ void appendSimpleFunction( QDomDocument &doc, QDomElement &parent, const QString
   function.appendChild( property );
 }
 
-/**
- * Recursively flattens a QgsExpression concatenation tree into a single list of SLD operands.
- */
-static void flattenConcatenation( QDomDocument &doc, QDomElement &parent, const QgsExpressionNode *node )
-{
-  const QgsExpressionNodeBinaryOperator *binNode = dynamic_cast<const QgsExpressionNodeBinaryOperator *>( node );
-  if ( binNode && binNode->op() == QgsExpressionNodeBinaryOperator::boConcat )
-  {
-    // Recursive step: drill down into left and right branches without creating new tags
-    flattenConcatenation( doc, parent, binNode->opLeft() );
-    flattenConcatenation( doc, parent, binNode->opRight() );
-  }
-  else
-  {
-    // Base case: handle leaf nodes (columns or literal strings) and append them as children
-    if ( const QgsExpressionNodeColumnRef *column = dynamic_cast<const QgsExpressionNodeColumnRef *>( node ) )
-    {
-      QDomElement propElement = doc.createElement( QStringLiteral( "ogc:PropertyName" ) );
-      propElement.appendChild( doc.createTextNode( column->name() ) );
-      parent.appendChild( propElement );
-    }
-    else if ( const QgsExpressionNodeLiteral *literal = dynamic_cast<const QgsExpressionNodeLiteral *>( node ) )
-    {
-      QDomElement litElement = doc.createElement( QStringLiteral( "ogc:Literal" ) );
-      litElement.appendChild( doc.createTextNode( literal->value().toString() ) );
-      parent.appendChild( litElement );
-    }
-  }
-}
-
-/**
- * Appends a QgsExpression node to an SLD document.
- * Specifically handles string concatenation (||) by creating a single <ogc:Function name="Concatenate">
- * element containing all recursively discovered operands.
- */
-static bool appendExpressionAsSld( QDomDocument &doc, QDomElement &parent, const QgsExpressionNode *node )
-{
-  switch ( node->nodeType() )
-  {
-    case QgsExpressionNode::ntBinaryOperator:
-    {
-      const QgsExpressionNodeBinaryOperator *binNode = static_cast<const QgsExpressionNodeBinaryOperator *>( node );
-      if ( binNode->op() == QgsExpressionNodeBinaryOperator::boConcat )
-      {
-        // Create the main Concatenate function tag once
-        QDomElement funcElement = doc.createElement( QStringLiteral( "ogc:Function" ) );
-        funcElement.setAttribute( QStringLiteral( "name" ), QStringLiteral( "Concatenate" ) );
-
-        // Populate it with all flattened parts of the expression
-        flattenConcatenation( doc, funcElement, binNode );
-
-        parent.appendChild( funcElement );
-        return true;
-      }
-      return false;
-    }
-
-    case QgsExpressionNode::ntColumnRef:
-    {
-      const QgsExpressionNodeColumnRef *column = static_cast<const QgsExpressionNodeColumnRef *>( node );
-      QDomElement propElement = doc.createElement( QStringLiteral( "ogc:PropertyName" ) );
-      propElement.appendChild( doc.createTextNode( column->name() ) );
-      parent.appendChild( propElement );
-      return true;
-    }
-
-    case QgsExpressionNode::ntLiteral:
-    {
-      const QgsExpressionNodeLiteral *literal = static_cast<const QgsExpressionNodeLiteral *>( node );
-      QDomElement litElement = doc.createElement( QStringLiteral( "ogc:Literal" ) );
-      litElement.appendChild( doc.createTextNode( literal->value().toString() ) );
-      parent.appendChild( litElement );
-      return true;
-    }
-
-    default:
-      // Return false for complex expressions not yet supported by the SLD exporter
-      return false;
-  }
-}
-
 std::unique_ptr<QgsMarkerSymbolLayer> backgroundToMarkerLayer( const QgsTextBackgroundSettings &settings )
 {
   std::unique_ptr<QgsMarkerSymbolLayer> layer;
@@ -407,18 +325,18 @@ bool QgsAbstractVectorLayerLabeling::writeTextSymbolizer( QDomNode &parent, QgsP
 
   if ( settings.isExpression )
   {
-    bool success = false;
-    if ( settings.getLabelExpression() && settings.getLabelExpression()->rootNode() )
-    {
-      // Attempt to export the expression as an SLD Concatenate function
-      success = appendExpressionAsSld( doc, labelElement, settings.getLabelExpression()->rootNode() );
-    }
+    QString errorMsg;
+    // try to convert the expression to an SLD expression, if it fails we will log the error and add a placeholder text
+    QDomElement expressionElem = QgsOgcUtils::expressionToOgcExpression( *settings.getLabelExpression(), doc, &errorMsg );
 
-    if ( !success )
+    if ( !expressionElem.isNull() )
     {
-      // Fallback: If the expression is too complex, push an error and use a placeholder
-      context.pushError( QObject::tr( "Complex expressions in labels cannot be exported to SLD. Skipping label '%1'" ).arg( settings.getLabelExpression()->dump() ) );
-      labelElement.appendChild( doc.createTextNode( "Placeholder" ) );
+      labelElement.appendChild( expressionElem );
+    }
+    else
+    {
+      context.pushError( QObject::tr( "Complex expressions in labels cannot be exported to SLD: %1. Skipping label '%2'" ).arg( errorMsg, settings.getLabelExpression()->dump() ) );
+      labelElement.appendChild( doc.createTextNode( u"Placeholder"_s ) );
     }
   }
 

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -2242,52 +2242,40 @@ QDomElement QgsOgcUtilsExprToFilter::expressionBinaryOperatorToOgcFilter( const 
 {
   QgsExpressionNodeBinaryOperator::BinaryOperator op = node->op();
 
-  // 1) Special handling for concatenation operator (||)
+  // Special handling for concatenation operator (||)
   if ( op == QgsExpressionNodeBinaryOperator::boConcat )
   {
     QDomElement funcElem = mDoc.createElement( mFilterPrefix + u":Function"_s );
     funcElem.setAttribute( u"name"_s, u"Concatenate"_s );
 
-    bool ok = true;
-    std::function<void( const QgsExpressionNode * )> appendParts = [&]( const QgsExpressionNode * n )
-    {
-      if ( !ok )
-        return;
-
+    std::function<bool( const QgsExpressionNode * )> appendParts = [&]( const QgsExpressionNode *n ) -> bool {
       if ( n->nodeType() == QgsExpressionNode::ntBinaryOperator )
       {
-        const QgsExpressionNodeBinaryOperator *binNode = static_cast<const QgsExpressionNodeBinaryOperator *>( n );
+        const auto *binNode = static_cast<const QgsExpressionNodeBinaryOperator *>( n );
         if ( binNode->op() == QgsExpressionNodeBinaryOperator::boConcat )
         {
-          appendParts( binNode->opLeft() );
-          appendParts( binNode->opRight() );
-          return;
+          return appendParts( binNode->opLeft() ) && appendParts( binNode->opRight() );
         }
       }
 
       // Try to convert the expression node to an OGC filter element
       QDomElement subElem = expressionNodeToOgcFilter( n, expression, context );
-      
-      if ( !subElem.isNull() )
+
+      if ( subElem.isNull() )
       {
-        funcElem.appendChild( subElem );
+        return false;
       }
-      else
-      {
-        // If any part of the concatenation cannot be converted,
-        // we should mark the entire operation as unsuccessful.
-        ok = false;
-      }
+      funcElem.appendChild( subElem );
+      return true;
     };
 
-    appendParts( node );
-
-    if ( !ok )
+    if ( !appendParts( node ) )
+    {
       return QDomElement(); // Return empty element if any part of the concatenation could not be converted
-
+    }
     return funcElem;
   }
-  // 2) Handle other binary operators
+  // Handle other binary operators
   const QDomElement leftElem = expressionNodeToOgcFilter( node->opLeft(), expression, context );
   if ( !mErrorMessage.isEmpty() )
     return QDomElement();

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 #include "qgsogcutils.h"
 
+#include <functional>
 #include <memory>
 #include <ogr_api.h>
 
@@ -2239,11 +2240,37 @@ QDomElement QgsOgcUtilsExprToFilter::expressionUnaryOperatorToOgcFilter( const Q
 
 QDomElement QgsOgcUtilsExprToFilter::expressionBinaryOperatorToOgcFilter( const QgsExpressionNodeBinaryOperator *node, QgsExpression *expression, const QgsExpressionContext *context )
 {
+  QgsExpressionNodeBinaryOperator::BinaryOperator op = node->op();
+
+  // 1) Special handling for concatenation operator (||)
+  if ( op == QgsExpressionNodeBinaryOperator::boConcat )
+  {
+    QDomElement funcElem = mDoc.createElement( mFilterPrefix + u":Function"_s );
+    funcElem.setAttribute( u"name"_s, u"Concatenate"_s );
+
+    // Recursively append all parts of the concatenation as arguments to the function element.
+    std::function<void( const QgsExpressionNode * )> appendParts = [&]( const QgsExpressionNode *n ) {
+      if ( n->nodeType() == QgsExpressionNode::ntBinaryOperator )
+      {
+        const QgsExpressionNodeBinaryOperator *binNode = static_cast<const QgsExpressionNodeBinaryOperator *>( n );
+        if ( binNode->op() == QgsExpressionNodeBinaryOperator::boConcat )
+        {
+          appendParts( binNode->opLeft() );
+          appendParts( binNode->opRight() );
+          return;
+        }
+      }
+      funcElem.appendChild( expressionNodeToOgcFilter( n, expression, context ) );
+    };
+
+    appendParts( node );
+    return funcElem;
+  }
+
+  // 2) Handle other binary operators
   const QDomElement leftElem = expressionNodeToOgcFilter( node->opLeft(), expression, context );
   if ( !mErrorMessage.isEmpty() )
     return QDomElement();
-
-  QgsExpressionNodeBinaryOperator::BinaryOperator op = node->op();
 
   // before right operator is parsed: to allow NULL handling
   if ( op == QgsExpressionNodeBinaryOperator::boIs || op == QgsExpressionNodeBinaryOperator::boIsNot )

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -2248,8 +2248,12 @@ QDomElement QgsOgcUtilsExprToFilter::expressionBinaryOperatorToOgcFilter( const 
     QDomElement funcElem = mDoc.createElement( mFilterPrefix + u":Function"_s );
     funcElem.setAttribute( u"name"_s, u"Concatenate"_s );
 
-    // Recursively append all parts of the concatenation as arguments to the function element.
-    std::function<void( const QgsExpressionNode * )> appendParts = [&]( const QgsExpressionNode *n ) {
+    bool ok = true;
+    std::function<void( const QgsExpressionNode * )> appendParts = [&]( const QgsExpressionNode * n )
+    {
+      if ( !ok )
+        return;
+
       if ( n->nodeType() == QgsExpressionNode::ntBinaryOperator )
       {
         const QgsExpressionNodeBinaryOperator *binNode = static_cast<const QgsExpressionNodeBinaryOperator *>( n );
@@ -2260,13 +2264,29 @@ QDomElement QgsOgcUtilsExprToFilter::expressionBinaryOperatorToOgcFilter( const 
           return;
         }
       }
-      funcElem.appendChild( expressionNodeToOgcFilter( n, expression, context ) );
+
+      // Try to convert the expression node to an OGC filter element
+      QDomElement subElem = expressionNodeToOgcFilter( n, expression, context );
+      
+      if ( !subElem.isNull() )
+      {
+        funcElem.appendChild( subElem );
+      }
+      else
+      {
+        // If any part of the concatenation cannot be converted,
+        // we should mark the entire operation as unsuccessful.
+        ok = false;
+      }
     };
 
     appendParts( node );
+
+    if ( !ok )
+      return QDomElement(); // Return empty element if any part of the concatenation could not be converted
+
     return funcElem;
   }
-
   // 2) Handle other binary operators
   const QDomElement leftElem = expressionNodeToOgcFilter( node->opLeft(), expression, context );
   if ( !mErrorMessage.isEmpty() )

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -1177,8 +1177,8 @@ void TestQgsOgcUtils::testExpressionToOgcFilterWFS20_data()
     << QString();
 
   QTest::newRow( "binary_concat" )
-    << u"NAME || ' - ' || STATUS"_s  // exprText
-    << QString()                     // srsName
+    << u"NAME || ' - ' || STATUS"_s // exprText
+    << QString()                    // srsName
     << QString(
          "<fes:Filter xmlns:fes=\"http://www.opengis.net/fes/2.0\">"
          "<fes:Function name=\"Concatenate\">"
@@ -1187,9 +1187,9 @@ void TestQgsOgcUtils::testExpressionToOgcFilterWFS20_data()
          "<fes:ValueReference>STATUS</fes:ValueReference>"
          "</fes:Function>"
          "</fes:Filter>"
-       )                             // xmlText
-    << QString()                     // namespacePrefix
-    << QString();                    // namespaceURI
+       )          // xmlText
+    << QString()  // namespacePrefix
+    << QString(); // namespaceURI
 }
 
 Q_DECLARE_METATYPE( QgsOgcUtils::GMLVersion )

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -1175,6 +1175,21 @@ void TestQgsOgcUtils::testExpressionToOgcFilterWFS20_data()
        )
     << QString()
     << QString();
+
+  QTest::newRow( "binary_concat" )
+    << u"NAME || ' - ' || STATUS"_s  // exprText
+    << QString()                     // srsName
+    << QString(
+         "<fes:Filter xmlns:fes=\"http://www.opengis.net/fes/2.0\">"
+         "<fes:Function name=\"Concatenate\">"
+         "<fes:ValueReference>NAME</fes:ValueReference>"
+         "<fes:Literal> - </fes:Literal>"
+         "<fes:ValueReference>STATUS</fes:ValueReference>"
+         "</fes:Function>"
+         "</fes:Filter>"
+       )                             // xmlText
+    << QString()                     // namespacePrefix
+    << QString();                    // namespaceURI
 }
 
 Q_DECLARE_METATYPE( QgsOgcUtils::GMLVersion )

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -29,6 +29,7 @@
 #include "qgstest.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerfeaturecounter.h"
+#include "qgsvectorlayerlabeling.h"
 
 #include <QDomDocument>
 #include <QFile>
@@ -1423,6 +1424,33 @@ class TestQgsRuleBasedRenderer : public QgsTest
       Q_ASSERT( ruleElse->isElse() );
     }
 
+    void testLabelingConcatenationSld()
+    {
+      // 1) Create a layer
+      auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=name:string&field=status:string"_s, u"test"_s, u"memory"_s );
+
+      // 2) Set labeling with a concatenation expression
+      QgsPalLayerSettings settings;
+      settings.isExpression = true;
+      settings.fieldName = u"name || ' - ' || status"_s;
+      layer->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
+      layer->setLabelsEnabled( true );
+
+      // 3) Export to SLD
+      QgsSldExportContext context;
+      QDomDocument doc = layer->exportSldStyleV3( context );
+
+      QString sld = doc.toString();
+
+      // 4) Verify that the concatenation is correctly represented in the SLD as a Function with the correct arguments
+      QVERIFY( sld.contains( u"<ogc:Function name=\"Concatenate\">"_s ) );
+      QVERIFY( sld.contains( u"<ogc:PropertyName>name</ogc:PropertyName>"_s ) );
+      QVERIFY( sld.contains( u"<ogc:Literal> - </ogc:Literal>"_s ) );
+      QVERIFY( sld.contains( u"<ogc:PropertyName>status</ogc:PropertyName>"_s ) );
+
+      // Verify that it is "flat" (only one Concatenate)
+      QCOMPARE( sld.count( u"name=\"Concatenate\""_s ), 1 );
+    }
 
   private:
     void xml2domElement( const QString &testFile, QDomDocument &doc )

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -16,6 +16,7 @@
 #include "qgscategorizedsymbolrenderer.h"
 #include "qgsembeddedsymbolrenderer.h"
 #include "qgsfillsymbol.h"
+#include "qgsfontutils.h"
 #include "qgsgeometry.h"
 #include "qgsgraduatedsymbolrenderer.h"
 #include "qgsmarkersymbol.h"
@@ -1426,30 +1427,61 @@ class TestQgsRuleBasedRenderer : public QgsTest
 
     void testLabelingConcatenationSld()
     {
-      // 1) Create a layer
+      // Create a layer
       auto layer = std::make_unique< QgsVectorLayer >( u"Point?field=name:string&field=status:string"_s, u"test"_s, u"memory"_s );
 
-      // 2) Set labeling with a concatenation expression
+      // Set labeling with a concatenation expression
       QgsPalLayerSettings settings;
       settings.isExpression = true;
       settings.fieldName = u"name || ' - ' || status"_s;
+
+      QgsTextFormat format;
+      format.setFont( QgsFontUtils::getStandardTestFont( u"Bold"_s ).family() );
+      format.setSizeUnit( Qgis::RenderUnit::Pixels );
+      format.setSize( 10 );
+      format.setColor( QColor( 0, 0, 0 ) );
+      format.buffer().setEnabled( false );
+      format.shadow().setEnabled( false );
+      settings.setFormat( format );
+
       layer->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
       layer->setLabelsEnabled( true );
 
-      // 3) Export to SLD
+      // Set a simple marker symbol for the layer
+      auto *markerLayer = new QgsSimpleMarkerSymbolLayer();
+      markerLayer->setColor( QColor( 255, 0, 0 ) );
+      markerLayer->setStrokeColor( QColor( 0, 0, 0 ) );
+      markerLayer->setStrokeWidthUnit( Qgis::RenderUnit::Pixels );
+      markerLayer->setStrokeWidth( 0.5 );
+      markerLayer->setSizeUnit( Qgis::RenderUnit::Pixels );
+      markerLayer->setSize( 5 );
+
+      QgsSymbolLayerList layers;
+      layers.append( markerLayer );
+
+      auto symbol = std::make_unique< QgsMarkerSymbol >( layers );
+
+      auto *singleRule = new QgsRuleBasedRenderer::Rule( symbol.release() );
+      singleRule->setLabel( u"Single symbol"_s );
+      QgsRuleBasedRenderer::Rule *rootRule = new QgsRuleBasedRenderer::Rule( nullptr );
+      rootRule->appendChild( singleRule );
+      layer->setRenderer( new QgsRuleBasedRenderer( rootRule ) );
+
+      // Export to SLD
       QgsSldExportContext context;
       QDomDocument doc = layer->exportSldStyleV3( context );
 
-      QString sld = doc.toString();
+      QString sld = doc.toString( 2 );
 
-      // 4) Verify that the concatenation is correctly represented in the SLD as a Function with the correct arguments
-      QVERIFY2( sld.contains( u"<ogc:Function name=\"Concatenate\">"_s ), sld.toUtf8().constData() );
-      QVERIFY2( sld.contains( u"<ogc:PropertyName>name</ogc:PropertyName>"_s ), sld.toUtf8().constData() );
-      QVERIFY2( sld.contains( u"<ogc:Literal> - </ogc:Literal>"_s ), sld.toUtf8().constData() );
-      QVERIFY2( sld.contains( u"<ogc:PropertyName>status</ogc:PropertyName>"_s ), sld.toUtf8().constData() );
+      // Load the expected SLD from an external file
+      const QString expectedSldPath = TEST_DATA_DIR + u"/rulebasedrenderer_expected_concatenation.sld"_s;
+      QFile file( expectedSldPath );
+      QVERIFY2( file.open( QIODevice::ReadOnly | QIODevice::Text ), "Failed to open the expected SLD file" );
 
-      // Verify that it is "flat" (only one Concatenate)
-      QCOMPARE( sld.count( u"name=\"Concatenate\""_s ), 1 );
+      QString expectedSld = QString::fromUtf8( file.readAll() );
+      file.close();
+
+      QCOMPARE( sld.trimmed(), expectedSld.trimmed() );
     }
 
   private:

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -1443,10 +1443,10 @@ class TestQgsRuleBasedRenderer : public QgsTest
       QString sld = doc.toString();
 
       // 4) Verify that the concatenation is correctly represented in the SLD as a Function with the correct arguments
-      QVERIFY( sld.contains( u"<ogc:Function name=\"Concatenate\">"_s ) );
-      QVERIFY( sld.contains( u"<ogc:PropertyName>name</ogc:PropertyName>"_s ) );
-      QVERIFY( sld.contains( u"<ogc:Literal> - </ogc:Literal>"_s ) );
-      QVERIFY( sld.contains( u"<ogc:PropertyName>status</ogc:PropertyName>"_s ) );
+      QVERIFY2( sld.contains( u"<ogc:Function name=\"Concatenate\">"_s ), sld.toUtf8().constData() );
+      QVERIFY2( sld.contains( u"<ogc:PropertyName>name</ogc:PropertyName>"_s ), sld.toUtf8().constData() );
+      QVERIFY2( sld.contains( u"<ogc:Literal> - </ogc:Literal>"_s ), sld.toUtf8().constData() );
+      QVERIFY2( sld.contains( u"<ogc:PropertyName>status</ogc:PropertyName>"_s ), sld.toUtf8().constData() );
 
       // Verify that it is "flat" (only one Concatenate)
       QCOMPARE( sld.count( u"name=\"Concatenate\""_s ), 1 );

--- a/tests/testdata/rulebasedrenderer_expected_concatenation.sld
+++ b/tests/testdata/rulebasedrenderer_expected_concatenation.sld
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" version="1.1.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <se:Name>test</se:Name>
+    <UserStyle>
+      <se:Name>test</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Single symbol</se:Name>
+          <se:Description>
+            <se:Title>Single symbol</se:Title>
+          </se:Description>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#ff0000</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke>
+                  <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+                  <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+                </se:Stroke>
+              </se:Mark>
+              <se:Size>5</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:TextSymbolizer>
+            <se:Label>
+              <ogc:Function name="Concatenate">
+                <ogc:PropertyName>name</ogc:PropertyName>
+                <ogc:Literal> - </ogc:Literal>
+                <ogc:PropertyName>status</ogc:PropertyName>
+              </ogc:Function>
+            </se:Label>
+            <se:Font>
+              <se:SvgParameter name="font-family">QGIS Vera Sans</se:SvgParameter>
+              <se:SvgParameter name="font-size">10</se:SvgParameter>
+            </se:Font>
+            <se:LabelPlacement>
+              <se:PointPlacement>
+                <se:AnchorPoint>
+                  <se:AnchorPointX>0</se:AnchorPointX>
+                  <se:AnchorPointY>0.5</se:AnchorPointY>
+                </se:AnchorPoint>
+              </se:PointPlacement>
+            </se:LabelPlacement>
+            <se:Fill>
+              <se:SvgParameter name="fill">#000000</se:SvgParameter>
+            </se:Fill>
+            <se:VendorOption name="maxDisplacement">1</se:VendorOption>
+          </se:TextSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
## Description
Fixes #65310 

This PR implements support for the string concatenation operator (`||`) in label expressions when exporting styles to SLD (Styled Layer Descriptor).

## Technical Implementation

* **Centralized Logic:** The concatenation support is integrated directly into `QgsOgcUtilsExprToFilter::expressionBinaryOperatorToOgcFilter`. By utilizing the shared utility in `QgsOgcUtils`, the implementation ensures consistent SLD export across different parts of the QGIS core.
* **Recursive Flattening:** The implementation uses a recursive approach to handle multiple concatenation operands. It ensures that expressions like `a || b || c` are exported as a single, flat `<ogc:Function name="Concatenate">` element with multiple children.

## Verification Results

### Unit Testing
* **Dedicated Test Case:** Added `testLabelingConcatenationSld` to `tests/src/core/testqgsrulebasedrenderer.cpp`. This test specifically verifies the flattening logic and the correct XML structure of the exported concatenation functions.
* **Regression Testing:** All **1072 tests passed** in the automated CI suite (Fedora/Qt6).

### Manual Verification
Manual export was verified using the Windows build artifact. The resulting SLD correctly represents concatenated labels in a flat structure:

**Example Export:**

```xml
<se:Label>
<ogc:Function name="Concatenate">
<ogc:PropertyName>name</ogc:PropertyName>
<ogc:Literal> - </ogc:Literal>
<ogc:PropertyName>status</ogc:PropertyName>
<ogc:Literal> - </ogc:Literal>
<ogc:PropertyName>Priority</ogc:PropertyName>
<ogc:Literal> - </ogc:Literal>
<ogc:PropertyName>Reputation</ogc:PropertyName>
<ogc:Literal> - </ogc:Literal>
<ogc:PropertyName>Rating</ogc:PropertyName>
</ogc:Function>
</se:Label>
```
 
<img width="1920" height="1080" alt="test_layer" src="https://github.com/user-attachments/assets/ba783a92-967e-414b-af5a-f25cb4a9370b" />

## AI tool usage

Development of this PR was supported by Gemini (AI tool) for troubleshooting CI issues and refining the C++ logic.

## Exported SLD

<details>
<summary>Click to view the generated SLD XML</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" version="1.1.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd">
  <NamedLayer>
    <se:Name>test_layer — test</se:Name>
    <UserStyle>
      <se:Name>test_layer — test</se:Name>
      <se:FeatureTypeStyle>
        <se:Rule>
          <se:Name>Single symbol</se:Name>
          <se:PointSymbolizer>
            <se:Graphic>
              <se:Mark>
                <se:WellKnownName>circle</se:WellKnownName>
                <se:Fill>
                  <se:SvgParameter name="fill">#7d8b8f</se:SvgParameter>
                </se:Fill>
                <se:Stroke>
                  <se:SvgParameter name="stroke">#232323</se:SvgParameter>
                  <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
                </se:Stroke>
              </se:Mark>
              <se:Size>7</se:Size>
            </se:Graphic>
          </se:PointSymbolizer>
        </se:Rule>
        <se:Rule>
          <se:TextSymbolizer>
            <se:Label>
              <ogc:Function name="Concatenate">
                <ogc:PropertyName>name</ogc:PropertyName>
                <ogc:Literal> - </ogc:Literal>
                <ogc:PropertyName>status</ogc:PropertyName>
                <ogc:Literal> - </ogc:Literal>
                <ogc:PropertyName>Priority</ogc:PropertyName>
                <ogc:Literal> - </ogc:Literal>
                <ogc:PropertyName>Reputation</ogc:PropertyName>
                <ogc:Literal> - </ogc:Literal>
                <ogc:PropertyName>Rating</ogc:PropertyName>
              </ogc:Function>
            </se:Label>
            <se:Font>
              <se:SvgParameter name="font-family">Open Sans</se:SvgParameter>
              <se:SvgParameter name="font-size">13</se:SvgParameter>
            </se:Font>
            <se:LabelPlacement>
              <se:PointPlacement>
                <se:AnchorPoint>
                  <se:AnchorPointX>0</se:AnchorPointX>
                  <se:AnchorPointY>0.5</se:AnchorPointY>
                </se:AnchorPoint>
              </se:PointPlacement>
            </se:LabelPlacement>
            <se:Fill>
              <se:SvgParameter name="fill">#323232</se:SvgParameter>
            </se:Fill>
            <se:VendorOption name="maxDisplacement">1</se:VendorOption>
          </se:TextSymbolizer>
        </se:Rule>
      </se:FeatureTypeStyle>
    </UserStyle>
  </NamedLayer>
</StyledLayerDescriptor>
```