### PR TITLE
Fix user settings are completely wiped on migration (3.44 backport)

### DIFF
--- a/src/core/settings/qgssettings.cpp
+++ b/src/core/settings/qgssettings.cpp
@@ -201,6 +201,10 @@ void QgsSettings::sync()
 void QgsSettings::remove( const QString &key, const QgsSettings::Section section )
 {
   const QString pKey = prefixedKey( key, section );
+  if ( pKey.isEmpty() )
+  {
+    QgsDebugError( QStringLiteral( "QSettings::remove called with empty key -- this probably wasn't intentional, but will result in ALL SETTINGS GETTING DELETED!" ) );
+  }
   mUserSettings->remove( pKey );
 }
 
@@ -314,7 +318,12 @@ void QgsSettings::setValue( const QString &key, const QVariant &value, const Qgs
   // might be a nullptr (for example in case of standalone scripts or apps).
   else if ( mGlobalSettings && mGlobalSettings->value( prefixedKey( key, section ) ) == currentValue )
   {
-    mUserSettings->remove( prefixedKey( key, section ) );
+    const QString resolvedKey = prefixedKey( key, section );
+    if ( resolvedKey.isEmpty() )
+    {
+      QgsDebugError( QStringLiteral( "QSettings::remove called with empty key -- this probably wasn't intentional, but will result in ALL SETTINGS GETTING DELETED!" ) );
+    }
+    mUserSettings->remove( resolvedKey );
   }
 }
 

--- a/src/core/settings/qgssettingsentryimpl.cpp
+++ b/src/core/settings/qgssettingsentryimpl.cpp
@@ -259,7 +259,8 @@ bool QgsSettingsEntryColor::copyValueFromKeys( const QString &redKey, const QStr
       settings->remove( redKey );
       settings->remove( greenKey );
       settings->remove( blueKey );
-      settings->remove( alphaKey );
+      if ( !alphaKey.isNull() )
+        settings->remove( alphaKey );
     }
 
     if ( value() != oldValue )

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -16,6 +16,7 @@
 #include "qgssettingsregistrygui.h"
 
 #include "qgsapplication.h"
+#include "qgssettings.h"
 #include "qgssettingsregistrycore.h"
 #include "qgsstylemanagerdialog.h"
 #include "qgsabstractdbsourceselect.h"
@@ -28,6 +29,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   // copy values from old keys to new keys and delete the old ones
   // for backward compatibility, old keys are recreated when the registry gets deleted
 
+  QgsSettings::holdFlush();
+
   // single settings - added in 3.30
   settingsRespectScreenDPI->copyValueFromKey( QStringLiteral( "gui/qgis/respect_screen_dpi" ), {}, true );
 
@@ -36,6 +39,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( QStringLiteral( "Windows/MSSQLSourceSelect/HoldDialogOpen" ), { QStringLiteral( "MSSQLSourceSelect" ) }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( QStringLiteral( "Windows/PgSourceSelect/HoldDialogOpen" ), { QStringLiteral( "PgSourceSelect" ) }, true );
   QgsAbstractDbSourceSelect::settingHoldDialogOpen->copyValueFromKey( QStringLiteral( "Windows/SpatiaLiteSourceSelect/HoldDialogOpen" ), { QStringLiteral( "SpatiaLiteSourceSelect" ) }, true );
+
+  QgsSettings::releaseFlush();
 }
 
 QgsSettingsRegistryGui::~QgsSettingsRegistryGui()


### PR DESCRIPTION
Fixes QgsSettingsEntryColor::copyValueFromKeys deletes all settings when the removeSettingAtKey option is true, and no alphaKey is specified.

This is because the QSettings::remove API is absolutely ridiculous and WIPES THE ENTIRE QSettings store if the requested key is an
empty string.

Manual backport of to https://github.com/qgis/QGIS/pull/65330

Skipping queued ltr branch due to risk of data loss from this bug