### PR TITLE
add reverse tag to flip coordinates

### DIFF
--- a/src/analysis/processing/qgsalgorithmswapxy.cpp
+++ b/src/analysis/processing/qgsalgorithmswapxy.cpp
@@ -37,7 +37,7 @@ QString QgsSwapXYAlgorithm::displayName() const
 
 QStringList QgsSwapXYAlgorithm::tags() const
 {
-  return QObject::tr( "invert,flip,swap,switch,latitude,longitude" ).split( ',' );
+  return QObject::tr( "invert,flip,swap,switch,latitude,longitude,reverse" ).split( ',' );
 }
 
 QString QgsSwapXYAlgorithm::group() const


### PR DESCRIPTION
If I currently search in the expression editor by "reverse" query, I get the  results as the tag exists in the expression help but it's not working when searching in the processing toolbox and yesterday wasn't giving any results :). Now it does.