### PR TITLE
Don't show skirts on the edges of the map scene

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -7781,6 +7781,28 @@ Qgis.VerticalAxisInversion.__doc__ = """Vertical axis inversion options for 3D v
 # --
 Qgis.VerticalAxisInversion.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.TileEdge.Left.__doc__ = "Left edge"
+Qgis.TileEdge.Right.__doc__ = "Right edge"
+Qgis.TileEdge.Top.__doc__ = "Top edge"
+Qgis.TileEdge.Bottom.__doc__ = "Bottom edge"
+Qgis.TileEdge.All.__doc__ = "Skirts on all edges"
+Qgis.TileEdge.__doc__ = """Tile edge flags.
+
+.. versionadded:: 4.2
+
+* ``Left``: Left edge
+* ``Right``: Right edge
+* ``Top``: Top edge
+* ``Bottom``: Bottom edge
+* ``All``: Skirts on all edges
+
+"""
+# --
+Qgis.TileEdge.baseClass = Qgis
+Qgis.TileEdges = lambda flags=0: Qgis.TileEdge(flags)
+Qgis.TileEdges.baseClass = Qgis
+TileEdges = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
 Qgis.ProfileSurfaceSymbology.Line.__doc__ = "The elevation surface will be rendered using a line symbol"
 Qgis.ProfileSurfaceSymbology.FillBelow.__doc__ = "The elevation surface will be rendered using a fill symbol below the surface level"
 Qgis.ProfileSurfaceSymbology.FillAbove.__doc__ = "The elevation surface will be rendered using a fill symbol above the surface level \n.. versionadded:: 3.32"

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2436,6 +2436,19 @@ The development version
       Always,
     };
 
+    enum class TileEdge /BaseType=IntFlag/
+    {
+      Left,
+      Right,
+      Top,
+      Bottom,
+      All
+    };
+
+    typedef QFlags<Qgis::TileEdge> TileEdges;
+
+
+
     enum class ProfileSurfaceSymbology /BaseType=IntEnum/
     {
       Line,
@@ -4019,6 +4032,8 @@ QFlags<Qgis::ExtrusionFace> operator|(Qgis::ExtrusionFace f1, QFlags<Qgis::Extru
 QFlags<Qgis::MapGridFrameSideFlag> operator|(Qgis::MapGridFrameSideFlag f1, QFlags<Qgis::MapGridFrameSideFlag> f2);
 
 QFlags<Qgis::SymbolConverterCapability> operator|(Qgis::SymbolConverterCapability f1, QFlags<Qgis::SymbolConverterCapability> f2);
+
+QFlags<Qgis::TileEdge> operator|(Qgis::TileEdge f1, QFlags<Qgis::TileEdge> f2);
 
 
 

--- a/src/3d/terrain/qgsdemterraintilegeometry_p.cpp
+++ b/src/3d/terrain/qgsdemterraintilegeometry_p.cpp
@@ -34,7 +34,7 @@
 
 using namespace Qt3DRender;
 
-static QByteArray createPlaneVertexData( int res, float side, float vertScale, float skirtHeight, const QByteArray &heights )
+static QByteArray createPlaneVertexData( int res, float side, float vertScale, float skirtHeight, const QByteArray &heights, Qgis::TileEdges skirtEdges )
 {
   Q_ASSERT( res >= 2 );
   Q_ASSERT( heights.count() == res * res * static_cast<int>( sizeof( float ) ) );
@@ -83,9 +83,17 @@ static QByteArray createPlaneVertexData( int res, float side, float vertScale, f
 
       float height;
       if ( i == iBound && j == jBound )
+      {
         height = *zBits++;
+      }
       else
-        height = zData[jBound * resolution.width() + iBound] - skirtHeight;
+      {
+        const bool applySkirtToEdge = ( i < 0 && skirtEdges.testFlag( Qgis::TileEdge::Left ) )
+                                      || ( i > iMax && skirtEdges.testFlag( Qgis::TileEdge::Right ) )
+                                      || ( j < 0 && skirtEdges.testFlag( Qgis::TileEdge::Top ) )
+                                      || ( j > jMax && skirtEdges.testFlag( Qgis::TileEdge::Bottom ) );
+        height = zData[jBound * resolution.width() + iBound] - ( applySkirtToEdge ? skirtHeight : 0 );
+      }
 
       if ( std::isnan( height ) )
         height = noDataHeight;
@@ -213,15 +221,16 @@ static QByteArray createPlaneIndexData( int res, const QByteArray &heightMap )
 class PlaneVertexBufferFunctor : public Qt3DCore::QAbstractFunctor
 {
   public:
-    explicit PlaneVertexBufferFunctor( int resolution, float side, float vertScale, float skirtHeight, const QByteArray &heightMap )
+    explicit PlaneVertexBufferFunctor( int resolution, float side, float vertScale, float skirtHeight, const QByteArray &heightMap, Qgis::TileEdges skirtEdges )
       : mResolution( resolution )
       , mSide( side )
       , mVertScale( vertScale )
       , mSkirtHeight( skirtHeight )
       , mHeightMap( heightMap )
+      , mSkirtEdges( skirtEdges )
     {}
 
-    QByteArray operator()() { return createPlaneVertexData( mResolution, mSide, mVertScale, mSkirtHeight, mHeightMap ); }
+    QByteArray operator()() { return createPlaneVertexData( mResolution, mSide, mVertScale, mSkirtHeight, mHeightMap, mSkirtEdges ); }
 
     qintptr id() const override { return reinterpret_cast<qintptr>( &Qt3DCore::FunctorType<PlaneVertexBufferFunctor>::id ); }
 
@@ -230,7 +239,12 @@ class PlaneVertexBufferFunctor : public Qt3DCore::QAbstractFunctor
       const PlaneVertexBufferFunctor *otherFunctor = dynamic_cast<const PlaneVertexBufferFunctor *>( &other );
       if ( otherFunctor )
         return (
-          otherFunctor->mResolution == mResolution && otherFunctor->mSide == mSide && otherFunctor->mVertScale == mVertScale && otherFunctor->mSkirtHeight == mSkirtHeight && otherFunctor->mHeightMap == mHeightMap
+          otherFunctor->mResolution == mResolution
+          && otherFunctor->mSide == mSide
+          && otherFunctor->mVertScale == mVertScale
+          && otherFunctor->mSkirtHeight == mSkirtHeight
+          && otherFunctor->mHeightMap == mHeightMap
+          && otherFunctor->mSkirtEdges == mSkirtEdges
         );
       return false;
     }
@@ -241,6 +255,7 @@ class PlaneVertexBufferFunctor : public Qt3DCore::QAbstractFunctor
     float mVertScale;
     float mSkirtHeight;
     QByteArray mHeightMap;
+    Qgis::TileEdges mSkirtEdges;
 };
 
 //! Generates index buffer for DEM terrain tiles
@@ -272,12 +287,13 @@ class PlaneIndexBufferFunctor : public Qt3DCore::QAbstractFunctor
 // ------------
 
 
-DemTerrainTileGeometry::DemTerrainTileGeometry( int resolution, float side, float vertScale, float skirtHeight, const QByteArray &heightMap, DemTerrainTileGeometry::QNode *parent )
+DemTerrainTileGeometry::DemTerrainTileGeometry( int resolution, float side, float vertScale, float skirtHeight, const QByteArray &heightMap, Qgis::TileEdges skirtEdges, DemTerrainTileGeometry::QNode *parent )
   : QGeometry( parent )
   , mResolution( resolution )
   , mSide( side )
   , mVertScale( vertScale )
   , mSkirtHeight( skirtHeight )
+  , mSkirtEdges( skirtEdges )
   , mHeightMap( heightMap )
 {
   init();
@@ -394,7 +410,7 @@ void DemTerrainTileGeometry::init()
   // switched to setting data instead of just setting data generators because we also need the buffers
   // available for ray-mesh intersections and we can't access the private copy of data in Qt (if there is any)
 
-  mVertexBuffer->setData( PlaneVertexBufferFunctor( mResolution, mSide, mVertScale, mSkirtHeight, mHeightMap )() );
+  mVertexBuffer->setData( PlaneVertexBufferFunctor( mResolution, mSide, mVertScale, mSkirtHeight, mHeightMap, mSkirtEdges )() );
   mIndexBuffer->setData( PlaneIndexBufferFunctor( mResolution, mHeightMap )() );
 
   addAttribute( mPositionAttribute );

--- a/src/3d/terrain/qgsdemterraintilegeometry_p.h
+++ b/src/3d/terrain/qgsdemterraintilegeometry_p.h
@@ -28,6 +28,8 @@
 //
 
 
+#include "qgis.h"
+
 #include <QImage>
 #include <QSize>
 #include <Qt3DCore/QGeometry>
@@ -43,6 +45,7 @@ namespace Qt3DCore
 class QgsRay3D;
 class QgsRayCastContext;
 
+
 /**
  * \ingroup qgis_3d
  * \brief Stores attributes and vertex/index buffers for one terrain tile based on DEM.
@@ -54,9 +57,11 @@ class DemTerrainTileGeometry : public Qt3DCore::QGeometry
   public:
     /**
      * Constructs a terrain tile geometry. Resolution is the number of vertices on one side of the tile,
-     * heightMap is array of float values with one height value for each vertex
+     * heightMap is array of float values with one height value for each vertex.
+     *
+     * The \a skirtEdges flag controls which edges of the tile get skirts.
      */
-    explicit DemTerrainTileGeometry( int resolution, float side, float vertScale, float skirtHeight, const QByteArray &heightMap, QNode *parent = nullptr );
+    explicit DemTerrainTileGeometry( int resolution, float side, float vertScale, float skirtHeight, const QByteArray &heightMap, Qgis::TileEdges skirtEdges = Qgis::TileEdge::All, QNode *parent = nullptr );
 
     bool rayIntersection( const QgsRay3D &ray, const QgsRayCastContext &context, const QMatrix4x4 &worldTransform, QVector3D &intersectionPoint );
 
@@ -72,6 +77,7 @@ class DemTerrainTileGeometry : public Qt3DCore::QGeometry
     float mSide;
     float mVertScale;
     float mSkirtHeight;
+    Qgis::TileEdges mSkirtEdges = Qgis::TileEdge::All;
     QByteArray mHeightMap;
     Qt3DCore::QAttribute *mPositionAttribute = nullptr;
     Qt3DCore::QAttribute *mNormalAttribute = nullptr;

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -107,16 +107,27 @@ Qt3DCore::QEntity *QgsDemTerrainTileLoader::createEntity( Qt3DCore::QEntity *par
   }
 
   Qgs3DMapSettings *map = terrain()->mapSettings();
-  QgsChunkNodeId nodeId = mNode->tileId();
-  QgsRectangle extent = map->terrainGenerator()->tilingScheme().tileToExtent( nodeId );
-  double side = extent.width();
+  const QgsChunkNodeId nodeId = mNode->tileId();
+  const QgsRectangle extent = map->terrainGenerator()->tilingScheme().tileToExtent( nodeId );
+  const double side = extent.width();
+
+  // work out which edges of this tile are internal edges and need skirts
+  // to hide cracks between tiles, vs which are on the outer edges of the map
+  // and don't need skirts
+  const QgsRectangle rootExtent = map->terrainGenerator()->tilingScheme().tileToExtent( 0, 0, 0 );
+  const double eps = side * 0.01;
+  Qgis::TileEdges skirtEdges;
+  skirtEdges.setFlag( Qgis::TileEdge::Left, !qgsDoubleNear( extent.xMinimum(), rootExtent.xMinimum(), eps ) );
+  skirtEdges.setFlag( Qgis::TileEdge::Right, !qgsDoubleNear( extent.xMaximum(), rootExtent.xMaximum(), eps ) );
+  skirtEdges.setFlag( Qgis::TileEdge::Top, !qgsDoubleNear( extent.yMaximum(), rootExtent.yMaximum(), eps ) );
+  skirtEdges.setFlag( Qgis::TileEdge::Bottom, !qgsDoubleNear( extent.yMinimum(), rootExtent.yMinimum(), eps ) );
 
   QgsTerrainTileEntity *entity = new QgsTerrainTileEntity( nodeId );
 
   // create geometry renderer
 
   Qt3DRender::QGeometryRenderer *mesh = new Qt3DRender::QGeometryRenderer;
-  mesh->setGeometry( new DemTerrainTileGeometry( mResolution, side, map->terrainSettings()->verticalScale(), mSkirtHeight, mHeightMap, mesh ) );
+  mesh->setGeometry( new DemTerrainTileGeometry( mResolution, side, map->terrainSettings()->verticalScale(), mSkirtHeight, mHeightMap, skirtEdges, mesh ) );
   entity->addComponent( mesh ); // takes ownership if the component has no parent
 
   // create material

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4347,6 +4347,30 @@ int QgisEvent = QEvent::User + 1;
     Q_ENUM( VerticalAxisInversion )
 
     /**
+     * Tile edge flags.
+     *
+     * \since QGIS 4.2
+     */
+    enum class TileEdge : int SIP_ENUM_BASETYPE( IntFlag )
+    {
+      Left = 1 << 0,                    //!< Left edge
+      Right = 1 << 1,                   //!< Right edge
+      Top = 1 << 2,                     //!< Top edge
+      Bottom = 1 << 3,                  //!< Bottom edge
+      All = Left | Right | Top | Bottom //!< Skirts on all edges
+    };
+    Q_ENUM( TileEdge )
+
+    /**
+     * Tile edge flags.
+     *
+     * \since QGIS 4.2
+     */
+    Q_DECLARE_FLAGS( TileEdges, TileEdge )
+    Q_FLAG( TileEdges )
+
+
+    /**
      * Surface symbology type for elevation profile plots.
      *
      * \since QGIS 3.26
@@ -6858,6 +6882,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::CurvedTextFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ExtrusionFaces )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapGridFrameSideFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolConverterCapabilities )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::TileEdges )
 Q_DECLARE_METATYPE( Qgis::LayoutRenderFlags )
 Q_DECLARE_METATYPE( QTimeZone )
 


### PR DESCRIPTION
These are designed to hide artifacts between terrain tiles, so they aren't required on the edges of the map
