### PR TITLE
CI: fix failures on OGC API features tests for QGIS server

### DIFF
--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -83,7 +83,9 @@ jobs:
       - name: Install pyogctest
         run: |
           sudo apt-get update && sudo apt-get install python3-virtualenv virtualenv
-          virtualenv -p /usr/bin/python3 venv && source venv/bin/activate && pip install pyogctest
+          # Re-enable below once https://github.com/rouault/pyogctest/tree/ogcapi_root is merged into upstream https://github.com/pblottiere/pyogctest
+          # virtualenv -p /usr/bin/python3 venv && source venv/bin/activate && pip install pyogctest
+          virtualenv -p /usr/bin/python3 venv && source venv/bin/activate && pip install git+https://github.com/rouault/pyogctest.git@ogcapi_root
 
       - name: Run WMS 1.3.0 OGC tests
         run: |
@@ -97,6 +99,6 @@ jobs:
         run: |
           cd data && git clone https://github.com/qgis/QGIS-Training-Data && cd -
           docker compose -f .ci/ogc/docker-compose.yml up -d
-          source venv/bin/activate && pyogctest -n ogc_qgis -s ogcapif -v -u http://$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' qgis_server_nginx)/qgisserver_ogcapif
+          source venv/bin/activate && pyogctest -n ogc_qgis -s ogcapif --ogcapi-root /ogcapi -v -u http://$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' qgis_server_nginx)/qgisserver_ogcapif
         env:
           DOCKER_IMAGE: ${{ steps.docker-build.outputs.imageid }}


### PR DESCRIPTION
Since we bumped the version number to 4.0, OGC API Features nominal endpoint is /ogcapi, while pyogctest requests on /wfs3 by default. This is made configurable with https://github.com/rouault/pyogctest/commit/738dd6a9acb81eb746145d5e74dd05016eab4b19

pyogctest pull request: https://github.com/pblottiere/pyogctest/pull/13