### PR TITLE
Allow user-defined QgsProcessingContext and QgisInterface in processi…

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -22,6 +22,7 @@ __copyright__ = "(C) 2012, Victor Olaya"
 import os
 import shutil
 from functools import partial
+from typing import Optional
 
 from qgis.core import (
     QgsApplication,
@@ -31,11 +32,13 @@ from qgis.core import (
     QgsMapLayerType,
     QgsMimeDataUtils,
     QgsProcessingAlgorithm,
+    QgsProcessingContext,
     QgsProcessingModelAlgorithm,
     QgsProcessingUtils,
     QgsSettings,
 )
 from qgis.gui import (
+    QgisInterface,
     QgsCustomDropHandler,
     QgsGui,
     QgsOptionsWidgetFactory,
@@ -419,7 +422,15 @@ class ProcessingPlugin(QObject):
                 )
 
     @pyqtSlot(str, QWidget, bool, bool)
-    def executeAlgorithm(self, alg_id, parent, in_place=False, as_batch=False):
+    def executeAlgorithm(
+        self,
+        alg_id,
+        parent,
+        in_place=False,
+        as_batch=False,
+        context=None,
+        iface=None,
+    ):
         """Executes a project model with GUI interaction if needed.
 
         :param alg_id: algorithm id
@@ -430,7 +441,14 @@ class ProcessingPlugin(QObject):
         :type in_place: bool, optional
         :param as_batch: execute as batch flag, defaults to False
         :type as_batch: bool, optional
+        :param context: optional QgsProcessingContext, defaults to standard
+        context using QgsProject.instance()
+        :type context: QgsProcessingContext, optional
+        :param iface: optional QgisInterface, defaults to main QGIS iface
+        :type iface: QgisInterface, optional
         """
+        if iface is None:
+            iface = self.iface
 
         config = {}
         if in_place:
@@ -471,8 +489,12 @@ class ProcessingPlugin(QObject):
             if d.name() not in (in_place_input_parameter_name, "OUTPUT")
         ]:
             parameters = {}
-            feedback = MessageBarProgress(algname=alg.displayName())
-            ok, results = execute_in_place(alg, parameters, feedback=feedback)
+            feedback = MessageBarProgress(
+                algname=alg.displayName(), messagebar=iface.messageBar()
+            )
+            ok, results = execute_in_place(
+                alg, parameters, context=context, feedback=feedback
+            )
             if ok:
                 iface.messageBar().pushSuccess(
                     "",
@@ -489,7 +511,9 @@ class ProcessingPlugin(QObject):
             dlg = alg.createCustomParametersWidget(parent)
 
             if not dlg:
-                dlg = AlgorithmDialog(alg, in_place, iface.mainWindow())
+                dlg = AlgorithmDialog(
+                    alg, in_place, iface.mainWindow(), context=context
+                )
             canvas = iface.mapCanvas()
             prevMapTool = canvas.mapTool()
             dlg.show()
@@ -504,11 +528,13 @@ class ProcessingPlugin(QObject):
                 except RuntimeError:
                     pass
         else:
-            feedback = MessageBarProgress(algname=alg.displayName())
-            context = dataobjects.createContext(feedback)
+            feedback = MessageBarProgress(
+                algname=alg.displayName(), messagebar=iface.messageBar()
+            )
+            context = dataobjects.createContext(feedback, parent_context=context)
             parameters = {}
             ret, results = execute(alg, parameters, context, feedback)
-            handleAlgorithmResults(alg, context, feedback)
+            handleAlgorithmResults(alg, context, feedback, iface=iface)
             feedback.close()
 
     def sync_in_place_button_state(self, layer=None):

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -21,17 +21,21 @@ __copyright__ = "(C) 2012, Victor Olaya"
 
 import datetime
 import time
+from typing import Optional
 
+import qgis.utils
 from qgis.core import (
     Qgis,
     QgsApplication,
     QgsProcessingAlgorithm,
     QgsProcessingAlgRunnerTask,
+    QgsProcessingContext,
     QgsProcessingFeatureSourceDefinition,
     QgsProcessingOutputHtml,
     QgsProxyProgressTask,
 )
 from qgis.gui import (
+    QgisInterface,
     QgsGui,
     QgsProcessingAlgorithmDialogBase,
     QgsProcessingContextGenerator,
@@ -53,14 +57,14 @@ from processing.tools import dataobjects
 
 
 class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
-    def __init__(self, alg, in_place=False, parent=None):
+    def __init__(self, alg, in_place=False, parent=None, context=None, iface=None):
         super().__init__(parent)
-
         self.feedback_dialog = None
         self.in_place = in_place
-        self.active_layer = iface.activeLayer() if self.in_place else None
-
-        self.context = None
+        _iface = iface if iface is not None else qgis.utils.iface
+        self._iface = _iface
+        self.active_layer = _iface.activeLayer() if self.in_place else None
+        self.context = context
         self.feedback = None
         self.history_log_id = None
         self.history_details = {}
@@ -106,12 +110,21 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         )
 
     def getParametersPanel(self, alg, parent):
-        panel = ParametersPanel(parent, alg, self.in_place, self.active_layer)
+        panel = ParametersPanel(
+            parent,
+            alg,
+            self.in_place,
+            self.active_layer,
+            context=self.context,
+            iface=self._iface,
+        )
         return panel
 
     def runAsBatch(self):
         self.close()
-        dlg = BatchAlgorithmDialog(self.algorithm().create(), parent=iface.mainWindow())
+        dlg = BatchAlgorithmDialog(
+            self.algorithm().create(), parent=iface.mainWindow(), context=self.context
+        )
         dlg.show()
         dlg.exec()
 

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -20,8 +20,10 @@ __date__ = "August 2012"
 __copyright__ = "(C) 2012, Victor Olaya"
 
 import time
+from typing import Optional
 
 from qgis.core import (
+    QgsProcessingContext,
     QgsProcessingOutputBoolean,
     QgsProcessingOutputHtml,
     QgsProcessingOutputNumber,
@@ -39,17 +41,19 @@ from processing.tools.system import getTempFilename
 
 
 class BatchAlgorithmDialog(QgsProcessingBatchAlgorithmDialogBase):
-    def __init__(self, alg, parent=None):
+    def __init__(self, alg, parent=None, context=None, iface=None):
         super().__init__(parent)
+        import qgis.utils
 
+        self._iface = iface if iface is not None else qgis.utils.iface
+        self.context = context
         self.setAlgorithm(alg)
-
         self.setWindowTitle(
             self.tr("Batch Processing - {0}").format(self.algorithm().displayName())
         )
-        self.setMainWidget(BatchPanel(self, self.algorithm()))
-
-        self.context = None
+        self.setMainWidget(
+            BatchPanel(self, self.algorithm(), context=self.context, iface=self._iface)
+        )
         self.hideShortHelp()
 
     def runAsSingle(self):
@@ -68,12 +72,14 @@ class BatchAlgorithmDialog(QgsProcessingBatchAlgorithmDialogBase):
     def processingContext(self):
         if self.context is None:
             self.feedback = self.createFeedback()
-            self.context = dataobjects.createContext(self.feedback)
+            self.context = dataobjects.createContext(
+                self.feedback, parent_context=self.context
+            )
             self.context.setLogLevel(self.logLevel())
         return self.context
 
     def createContext(self, feedback):
-        return dataobjects.createContext(feedback)
+        return dataobjects.createContext(feedback, parent_context=self.context)
 
     def runAlgorithm(self):
         alg_parameters = []

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -520,11 +520,14 @@ class BatchPanel(QgsPanelWidget, WIDGET):
     FORMAT = "format"
     CURRENT_FORMAT = "batch_3.40"
 
-    def __init__(self, parent, alg):
+    def __init__(self, parent, alg, context=None, iface=None):
         super().__init__(None)
         self.setupUi(self)
 
         self.wrappers = []
+        import qgis.utils
+
+        self._iface = iface if iface is not None else qgis.utils.iface
 
         self.btnAdvanced.hide()
 
@@ -552,7 +555,7 @@ class BatchPanel(QgsPanelWidget, WIDGET):
         self.tblParameters.horizontalHeader().setDefaultSectionSize(250)
         self.tblParameters.horizontalHeader().setMinimumSectionSize(150)
 
-        self.processing_context = createContext()
+        self.processing_context = createContext(parent_context=context)
 
         class ContextGenerator(QgsProcessingContextGenerator):
             def __init__(self, context):
@@ -836,9 +839,9 @@ class BatchPanel(QgsPanelWidget, WIDGET):
 
         widget_context = QgsProcessingParameterWidgetContext()
         widget_context.setProject(QgsProject.instance())
-        if iface is not None:
-            widget_context.setActiveLayer(iface.activeLayer())
-            widget_context.setMapCanvas(iface.mapCanvas())
+        if self._iface is not None:
+            widget_context.setActiveLayer(self._iface.activeLayer())
+            widget_context.setMapCanvas(self._iface.mapCanvas())
 
         widget_context.setMessageBar(self.parent.messageBar())
 

--- a/python/plugins/processing/gui/MessageBarProgress.py
+++ b/python/plugins/processing/gui/MessageBarProgress.py
@@ -28,11 +28,15 @@ from processing.gui.MessageDialog import MessageDialog
 
 
 class MessageBarProgress(QgsProcessingFeedback):
-    def __init__(self, algname=None):
+    def __init__(self, algname=None, messagebar=None):
         QgsProcessingFeedback.__init__(self)
+        import qgis.utils
 
         self.msg = []
-        self.progressMessageBar = iface.messageBar().createMessage(
+        _messagebar = (
+            messagebar if messagebar is not None else qgis.utils.iface.messageBar()
+        )
+        self.progressMessageBar = _messagebar.createMessage(
             self.tr("Executing algorithm <i>{}</i>").format(algname if algname else "")
         )
         self.progress = QProgressBar()
@@ -42,7 +46,7 @@ class MessageBarProgress(QgsProcessingFeedback):
             Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
         )
         self.progressMessageBar.layout().addWidget(self.progress)
-        self.message_bar_item = iface.messageBar().pushWidget(
+        self.message_bar_item = _messagebar.pushWidget(
             self.progressMessageBar, Qgis.MessageLevel.Info
         )
 

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -23,6 +23,9 @@ __author__ = "Victor Olaya"
 __date__ = "August 2012"
 __copyright__ = "(C) 2012, Victor Olaya"
 
+from typing import Optional
+
+import qgis.utils
 from qgis.core import (
     Qgis,
     QgsProcessingModelAlgorithm,
@@ -32,6 +35,7 @@ from qgis.core import (
     QgsProject,
 )
 from qgis.gui import (
+    QgisInterface,
     QgsAbstractProcessingParameterWidgetWrapper,
     QgsGui,
     QgsProcessingContextGenerator,
@@ -41,7 +45,6 @@ from qgis.gui import (
     QgsProcessingParametersWidget,
     QgsProcessingParameterWidgetContext,
 )
-from qgis.utils import iface
 
 from processing.gui.AlgorithmDialogBase import AlgorithmDialogBase
 from processing.gui.wrappers import WidgetWrapper, WidgetWrapperFactory
@@ -49,7 +52,9 @@ from processing.tools.dataobjects import createContext
 
 
 class ParametersPanel(QgsProcessingParametersWidget):
-    def __init__(self, parent, alg, in_place=False, active_layer=None):
+    def __init__(
+        self, parent, alg, in_place=False, active_layer=None, context=None, iface=None
+    ):
         super().__init__(alg, parent)
         self.in_place = in_place
         self.active_layer = active_layer
@@ -58,7 +63,7 @@ class ParametersPanel(QgsProcessingParametersWidget):
 
         self.extra_parameters = {}
 
-        self.processing_context = createContext()
+        self.processing_context = createContext(parent_context=context)
 
         class ContextGenerator(QgsProcessingContextGenerator):
             def __init__(self, context):
@@ -87,10 +92,11 @@ class ParametersPanel(QgsProcessingParametersWidget):
 
         widget_context = QgsProcessingParameterWidgetContext()
         widget_context.setProject(QgsProject.instance())
-        if iface is not None:
-            widget_context.setMapCanvas(iface.mapCanvas())
-            widget_context.setBrowserModel(iface.browserModel())
-            widget_context.setActiveLayer(iface.activeLayer())
+        _iface = iface if iface is not None else qgis.utils.iface
+        if _iface is not None:
+            widget_context.setMapCanvas(_iface.mapCanvas())
+            widget_context.setBrowserModel(_iface.browserModel())
+            widget_context.setActiveLayer(_iface.activeLayer())
 
         widget_context.setMessageBar(self.parent().messageBar())
         if isinstance(self.algorithm(), QgsProcessingModelAlgorithm):

--- a/python/plugins/processing/gui/Postprocessing.py
+++ b/python/plugins/processing/gui/Postprocessing.py
@@ -121,9 +121,14 @@ def handleAlgorithmResults(
     context: QgsProcessingContext,
     feedback: Optional[QgsProcessingFeedback] = None,
     parameters: Optional[dict] = None,
+    iface=None,
 ):
     if not parameters:
         parameters = {}
+    import qgis.utils
+
+    if iface is None:
+        iface = qgis.utils.iface
     if feedback is None:
         feedback = QgsProcessingFeedback()
     wrong_layers = []

--- a/python/plugins/processing/tools/dataobjects.py
+++ b/python/plugins/processing/tools/dataobjects.py
@@ -56,10 +56,14 @@ TYPE_TABLE = 5
 # changing this signature? make sure you update the signature in
 # python/processing/__init__.py too!
 # Docstring for this function is in python/processing/__init__.py
-def createContext(feedback=None):
+def createContext(feedback=None, parent_context=None):
     context = QgsProcessingContext()
-    context.setProject(QgsProject.instance())
-    context.setFeedback(feedback)
+    if parent_context is not None:
+        context.copyThreadSafeSettings(parent_context)
+    else:
+        context.setProject(QgsProject.instance())
+    if feedback is not None:
+        context.setFeedback(feedback)
 
     invalid_features_method = ProcessingConfig.getSetting(
         ProcessingConfig.FILTER_INVALID_GEOMETRIES

--- a/python/processing/__init__.py
+++ b/python/processing/__init__.py
@@ -149,15 +149,15 @@ def execAlgorithmDialog(
 
 def createContext(
     feedback: Optional[_QgsProcessingFeedback] = None,
+    parent_context: Optional[_QgsProcessingContext] = None,
 ) -> _QgsProcessingContext:
     """
     Creates a default processing context
-
     :param feedback: Optional existing QgsProcessingFeedback object, or None to use a default feedback object
     :type feedback: Optional[QgsProcessingFeedback]
-
+    :param parent_context: Optional existing QgsProcessingContext to copy settings from
+    :type parent_context: Optional[QgsProcessingContext]
     :returns: New QgsProcessingContext object
-
     :raises: QgsNotSupportedException if the Processing plugin has not been loaded
     """
     from qgis.core import QgsNotSupportedException


### PR DESCRIPTION
Extends the processing plugin to execute QgsProcessingAlgorithms with a user-defined QgsProcessingContext and QgisInterface, rather than always assuming the main QGIS GUI context.
The following classes and functions now accept optional context and/or iface parameters:

ProcessingPlugin.executeAlgorithm() — accepts context and iface
AlgorithmDialog.__init__() — accepts context and iface
BatchAlgorithmDialog.__init__() — accepts context and iface
BatchPanel.__init__() — accepts context and iface
ParametersPanel.__init__() — accepts context and iface
MessageBarProgress.__init__() — accepts messagebar
handleAlgorithmResults() — accepts iface
dataobjects.createContext() — accepts parent_context

When not provided, all parameters fall back to current default behaviour (QgsProject.instance() and qgis.utils.iface) , fully backwards compatible, zero breaking changes.
Use case
Plugins like EnMAP-Box and EO Time Series Viewer extend QGIS with their own QgsProject, layer trees, and map canvases. When users launch a processing algorithm from these plugins, they expect the parameterization dialog to use layers and canvases from the plugin . not from the main QGIS GUI. This change makes that possible without reimplementing dialogs from scratch.
Testing
Verified that the default call path (no context or iface passed) behaves identically to before. Custom context path verified by passing an empty QgsProject ,layer dropdowns correctly show no layers.
AI Assistance Disclosure
Parts of the development process used AI tools for assistance.
All design decisions, code modifications, and testing were performed and verified manually.

**Addresses** #60764 
