### PR TITLE
[map renderer] Fix background color fill when composing image for non-default image format

### DIFF
--- a/src/core/maprenderer/qgsmaprendererjob.cpp
+++ b/src/core/maprenderer/qgsmaprendererjob.cpp
@@ -1346,7 +1346,7 @@ QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings, const st
   image.setDevicePixelRatio( settings.devicePixelRatio() );
   image.setDotsPerMeterX( static_cast<int>( settings.outputDpi() * 39.37 ) );
   image.setDotsPerMeterY( static_cast<int>( settings.outputDpi() * 39.37 ) );
-  image.fill( settings.backgroundColor().rgba() );
+  image.fill( settings.backgroundColor() );
 
   const QgsElevationShadingRenderer mapShadingRenderer = settings.elevationShadingRenderer();
   std::unique_ptr<QgsElevationMap> mainElevationMap;

--- a/tests/src/python/test_qgsmaprenderer.py
+++ b/tests/src/python/test_qgsmaprenderer.py
@@ -29,7 +29,7 @@ from qgis.core import (
     QgsVectorLayerSimpleLabeling,
 )
 from qgis.PyQt.QtCore import QSize
-from qgis.PyQt.QtGui import QImage, QPainter
+from qgis.PyQt.QtGui import QColor, QImage, QPainter
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.testing import QgisTestCase, start_app
 
@@ -446,6 +446,19 @@ class TestQgsMapRenderer(QgisTestCase):
 
         self.runRendererChecks(create_job)
         p.end()
+
+    def testOutputFormatBackgroundColor(self):
+        """ensure a custom output format has the correct background color fill"""
+        ms = QgsMapSettings()
+        ms.setOutputImageFormat(QImage.Format.Format_RGBA8888_Premultiplied)
+        ms.setOutputSize(QSize(10, 10))
+        ms.setBackgroundColor(QColor(255, 0, 0))
+
+        job = QgsMapRendererParallelJob(ms)
+        job.start()
+        job.waitForFinished()
+
+        self.assertEqual(job.renderedImage().pixelColor(0, 0), QColor(255, 0, 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

When doing a map renderer job using a map setting's image format such as QImage::Format_RGBA8888_Premultiplied, the background color RGB channels are mixed up. This PR fixes that.

_This was spotted in QField and the commit confirmed as fixing the issue._