### PR TITLE
Fix/multiframe undo restore

### DIFF
--- a/src/core/layout/qgslayoutframe.cpp
+++ b/src/core/layout/qgslayoutframe.cpp
@@ -170,13 +170,35 @@ void QgsLayoutFrame::cleanup()
   QgsLayoutItem::cleanup();
 }
 
+void QgsLayoutFrame::finalizeRestoreFromXml()
+{
+  QgsLayoutItem::finalizeRestoreFromXml();
+
+  // when a frame is deleted via the UI, only the QgsLayoutFrame item is removed —
+  // the parent multiframe remains in the layout with its data intact.
+  // on undo, readPropertiesFromElement() correctly resolves mMultiFrame via uuid,
+  // but the multiframe's internal frame list is not updated, so frameIndex() returns -1.
+  // re-register the frame in the multiframe and restore the original frame ordering
+  // and content sections.
+  if ( mMultiFrame && !mMultiFrame->frames().contains( this ) )
+  {
+    mMultiFrame->addFrame( this, false );
+    mMultiFrame->reorderFrames();
+    mMultiFrame->recalculateFrameSizes();
+    mMultiFrame->refresh();
+  }
+}
+
 void QgsLayoutFrame::draw( QgsLayoutItemRenderContext &context )
 {
   if ( mMultiFrame )
   {
     //calculate index of frame
     const int frameIndex = mMultiFrame->frameIndex( this );
-    Q_ASSERT_X( frameIndex >= 0, "QgsLayoutFrame::draw", "Invalid frame index for frame" );
+    //frame may not yet be registered in the multiframe during project load or undo restore —
+    //skip rendering silently until finalizeRestoreFromXml() completes the reconnection
+    if ( frameIndex < 0 )
+      return;
     mMultiFrame->render( context, mSection, frameIndex );
   }
 }

--- a/src/core/layout/qgslayoutframe.h
+++ b/src/core/layout/qgslayoutframe.h
@@ -117,6 +117,7 @@ class CORE_EXPORT QgsLayoutFrame : public QgsLayoutItem
     void drawBackground( QgsRenderContext &context ) override;
     bool writePropertiesToElement( QDomElement &parentElement, QDomDocument &document, const QgsReadWriteContext &context ) const override;
     bool readPropertiesFromElement( const QDomElement &itemElement, const QDomDocument &document, const QgsReadWriteContext &context ) override;
+    void finalizeRestoreFromXml() override;
 
   private:
     QgsLayoutFrame() = delete;

--- a/src/core/layout/qgslayoutmultiframe.cpp
+++ b/src/core/layout/qgslayoutmultiframe.cpp
@@ -24,6 +24,7 @@
 
 #include <QString>
 #include <QUuid>
+#include <cmath>
 
 #include "moc_qgslayoutmultiframe.cpp"
 
@@ -65,6 +66,14 @@ void QgsLayoutMultiFrame::addFrame( QgsLayoutFrame *frame, bool recalcFrameSizes
   if ( !frame || mFrameItems.contains( frame ) )
     return;
 
+  //track uuid in the ordered list so reorderFrames() can restore the correct
+  //sequence after undo, even for frames added via the UI rather than readXml()
+  if ( !mFrameUuids.contains( frame->uuid() ) )
+  {
+    mFrameUuids.append( frame->uuid() );
+    mFrameTemplateUuids.append( frame->uuid() );
+  }
+
   mFrameItems.push_back( frame );
   frame->mMultiFrame = this;
   connect( frame, &QgsLayoutItem::sizePositionChanged, this, &QgsLayoutMultiFrame::recalculateFrameSizes );
@@ -78,6 +87,36 @@ void QgsLayoutMultiFrame::addFrame( QgsLayoutFrame *frame, bool recalcFrameSizes
   {
     recalculateFrameSizes();
   }
+}
+
+void QgsLayoutMultiFrame::reorderFrames()
+{
+  //rebuild mFrameItems in the order recorded in mFrameUuids, which reflects the
+  //original authoring sequence (index 0 = main frame, 1 = first additional frame, etc.)
+  //frames not present in mFrameUuids are appended at the end
+  QList<QgsLayoutFrame *> ordered;
+  ordered.reserve( mFrameItems.size() );
+
+  for ( const QString &uuid : std::as_const( mFrameUuids ) )
+  {
+    for ( QgsLayoutFrame *frame : std::as_const( mFrameItems ) )
+    {
+      if ( frame->uuid() == uuid )
+      {
+        if ( !ordered.contains( frame ) )
+          ordered << frame;
+        break;
+      }
+    }
+  }
+
+  for ( QgsLayoutFrame *frame : std::as_const( mFrameItems ) )
+  {
+    if ( !ordered.contains( frame ) )
+      ordered << frame;
+  }
+
+  mFrameItems = ordered;
 }
 
 void QgsLayoutMultiFrame::setResizeMode( ResizeMode mode )
@@ -108,6 +147,13 @@ void QgsLayoutMultiFrame::recalculateFrameSizes()
   double totalHeight = size.height();
 
   if ( totalHeight < 1 )
+  {
+    return;
+  }
+
+  //guard against unreliable totalSize() values during restore (e.g. layer not yet resolved),
+  //which would cause the page-extension loop below to run unboundedly
+  if ( !std::isfinite( totalHeight ) || totalHeight > 1.0e7 )
   {
     return;
   }
@@ -330,9 +376,11 @@ void QgsLayoutMultiFrame::finalizeRestoreFromXml()
 
     if ( frame )
     {
-      addFrame( frame );
+      addFrame( frame, false );
     }
   }
+
+  update();
 }
 
 void QgsLayoutMultiFrame::refresh()
@@ -554,9 +602,21 @@ bool QgsLayoutMultiFrame::readXml( const QDomElement &element, const QDomDocumen
       if ( !frameNodes.isEmpty() )
       {
         QDomElement frameItemElement = frameNodes.at( 0 ).toElement();
-        auto newFrame = std::make_unique< QgsLayoutFrame >( mLayout, this );
-        newFrame->readXml( frameItemElement, doc, context );
-        addFrame( newFrame.release(), false );
+
+        //reuse an existing frame with this uuid if present in the scene, to avoid
+        //creating a duplicate that would be left orphaned and rendered with an invalid frame index
+        QgsLayoutItem *existingItem = mLayout->itemByUuid( uuid, true );
+        QgsLayoutFrame *existingFrame = qobject_cast<QgsLayoutFrame *>( existingItem );
+        if ( existingFrame )
+        {
+          addFrame( existingFrame, false );
+        }
+        else
+        {
+          auto newFrame = std::make_unique< QgsLayoutFrame >( mLayout, this );
+          newFrame->readXml( frameItemElement, doc, context );
+          addFrame( newFrame.release(), false );
+        }
       }
     }
   }

--- a/src/core/layout/qgslayoutmultiframe.h
+++ b/src/core/layout/qgslayoutmultiframe.h
@@ -331,6 +331,14 @@ class CORE_EXPORT QgsLayoutMultiFrame : public QgsLayoutObject, public QgsLayout
      */
     virtual void finalizeRestoreFromXml();
 
+    /**
+     * Reorders the internal frame list to match the original authoring order recorded in mFrameUuids.
+     * Called after undo restoration to correct the frame sequence when frames were restored
+     * in a different order than they were originally created.
+     * \see finalizeRestoreFromXml()
+     */
+    void reorderFrames();
+
   public slots:
 
     /**

--- a/tests/src/core/testqgslayoutmultiframe.cpp
+++ b/tests/src/core/testqgslayoutmultiframe.cpp
@@ -50,6 +50,8 @@ class TestQgsLayoutMultiFrame : public QgsTest
     void displayName();
     void undoRedo(); //test that combinations of frame/multiframe undo/redo don't crash
     void undoRedoRemovedFrame2();
+    void undoDeleteMainFrame(); //test that deleting the main frame and undoing restores it at index 0
+    void undoDeleteMultipleFrames(); //test that deleting multiple frames and undoing restores original order
     void registry();
     void deleteFrame();
     void writeReadXml();
@@ -301,6 +303,95 @@ void TestQgsLayoutMultiFrame::undoRedoRemovedFrame2()
   QgsLayoutFrame *frame1 = new QgsLayoutFrame( mLayout, htmlItem );
   frame1->attemptSetSceneRect( QRectF( 0, 0, 100, 200 ) );
   htmlItem->addFrame( frame1 );
+}
+
+void TestQgsLayoutMultiFrame::undoDeleteMainFrame()
+{
+  //test that deleting the main frame (index 0) and undoing restores it at index 0,
+  //not appended at the end of the frame list
+  QgsLayout l( QgsProject::instance() );
+  l.initializeDefaults();
+  l.undoStack()->stack()->clear();
+
+  QgsLayoutItemHtml *htmlItem = new QgsLayoutItemHtml( &l );
+  QgsLayoutFrame *frame1 = new QgsLayoutFrame( &l, htmlItem );
+  frame1->attemptSetSceneRect( QRectF( 0, 0, 100, 200 ) );
+  htmlItem->addFrame( frame1 );
+  const QString uuid1 = frame1->uuid();
+
+  QgsLayoutFrame *frame2 = new QgsLayoutFrame( &l, htmlItem );
+  frame2->attemptSetSceneRect( QRectF( 0, 210, 100, 200 ) );
+  htmlItem->addFrame( frame2 );
+  const QString uuid2 = frame2->uuid();
+
+  QCOMPARE( htmlItem->frameIndex( frame1 ), 0 );
+  QCOMPARE( htmlItem->frameIndex( frame2 ), 1 );
+
+  //delete the main frame via the layout (simulates UI deletion)
+  l.removeLayoutItem( frame1 );
+  QCOMPARE( htmlItem->frameCount(), 1 );
+
+  //undo — frame1 must be restored at index 0, not appended after frame2
+  l.undoStack()->stack()->undo();
+  QCOMPARE( htmlItem->frameCount(), 2 );
+
+  QgsLayoutFrame *restoredFrame1 = qobject_cast<QgsLayoutFrame *>( l.itemByUuid( uuid1, true ) );
+  QgsLayoutFrame *restoredFrame2 = qobject_cast<QgsLayoutFrame *>( l.itemByUuid( uuid2, true ) );
+  QVERIFY( restoredFrame1 );
+  QVERIFY( restoredFrame2 );
+  QCOMPARE( htmlItem->frameIndex( restoredFrame1 ), 0 );
+  QCOMPARE( htmlItem->frameIndex( restoredFrame2 ), 1 );
+}
+
+void TestQgsLayoutMultiFrame::undoDeleteMultipleFrames()
+{
+  //test that deleting multiple frames and undoing restores them in the original order
+  QgsLayout l( QgsProject::instance() );
+  l.initializeDefaults();
+  l.undoStack()->stack()->clear();
+
+  QgsLayoutItemHtml *htmlItem = new QgsLayoutItemHtml( &l );
+  QgsLayoutFrame *frame1 = new QgsLayoutFrame( &l, htmlItem );
+  frame1->attemptSetSceneRect( QRectF( 0, 0, 100, 200 ) );
+  htmlItem->addFrame( frame1 );
+  const QString uuid1 = frame1->uuid();
+
+  QgsLayoutFrame *frame2 = new QgsLayoutFrame( &l, htmlItem );
+  frame2->attemptSetSceneRect( QRectF( 0, 210, 100, 200 ) );
+  htmlItem->addFrame( frame2 );
+  const QString uuid2 = frame2->uuid();
+
+  QgsLayoutFrame *frame3 = new QgsLayoutFrame( &l, htmlItem );
+  frame3->attemptSetSceneRect( QRectF( 0, 420, 100, 200 ) );
+  htmlItem->addFrame( frame3 );
+  const QString uuid3 = frame3->uuid();
+
+  QCOMPARE( htmlItem->frameIndex( frame1 ), 0 );
+  QCOMPARE( htmlItem->frameIndex( frame2 ), 1 );
+  QCOMPARE( htmlItem->frameIndex( frame3 ), 2 );
+
+  //delete all three frames
+  l.removeLayoutItem( frame1 );
+  l.removeLayoutItem( frame2 );
+  l.removeLayoutItem( frame3 );
+  QCOMPARE( htmlItem->frameCount(), 0 );
+
+  //undo all three deletions
+  l.undoStack()->stack()->undo();
+  l.undoStack()->stack()->undo();
+  l.undoStack()->stack()->undo();
+  QCOMPARE( htmlItem->frameCount(), 3 );
+
+  //original order must be restored regardless of undo insertion order
+  QgsLayoutFrame *r1 = qobject_cast<QgsLayoutFrame *>( l.itemByUuid( uuid1, true ) );
+  QgsLayoutFrame *r2 = qobject_cast<QgsLayoutFrame *>( l.itemByUuid( uuid2, true ) );
+  QgsLayoutFrame *r3 = qobject_cast<QgsLayoutFrame *>( l.itemByUuid( uuid3, true ) );
+  QVERIFY( r1 );
+  QVERIFY( r2 );
+  QVERIFY( r3 );
+  QCOMPARE( htmlItem->frameIndex( r1 ), 0 );
+  QCOMPARE( htmlItem->frameIndex( r2 ), 1 );
+  QCOMPARE( htmlItem->frameIndex( r3 ), 2 );
 }
 
 void TestQgsLayoutMultiFrame::registry()


### PR DESCRIPTION
### Problem

QGIS would crash immediately when performing Undo (Ctrl+Z) after deleting a table item (`QgsLayoutItemAttributeTable`) in the Print Layout. The crash was caused by a `Q_ASSERT_X` failure in `QgsLayoutFrame::draw()`, triggered because the frame restored by Undo was not re-registered in the MultiFrame’s internal list (`mFrameItems`). As a result, `frameIndex()` returned `-1`.

Fixes #62691

### Solution

- Replaced the `Q_ASSERT_X` in `draw()` with an early return to handle the transient state during project loading.
- Overrode `finalizeRestoreFromXml()` in `QgsLayoutFrame` to re-register the frame in the parent MultiFrame, restore the original frame order, and update the table’s data cache.
- Added `reorderFrames()` in `QgsLayoutMultiFrame` to rebuild `mFrameItems` in the original authoring order after Undo restores frames in reverse order.
- Updated `addFrame()` to keep `mFrameUuids` synchronized with frames created via the UI, providing a stable ordering reference across delete/undo cycles.
- Added a safeguard in `recalculateFrameSizes()` against invalid `totalSize()` values that could cause a `std::vector` overflow during restoration.

This patch was developed with AI assistance for analysis and coding and was subsequently reviewed and tested manually. The implementation appears reasonable, but I would appreciate a technical review to confirm it. I believe the benefit of fixing this bug justifies the review effort.

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
