### PR TITLE
Make AI slop PRs have a shorter stale time

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -55,7 +55,7 @@ jobs:
 
 
         stale-pr-label: 'stale'
-        exempt-pr-labels: 'Merge After Thaw,Frozen'
+        exempt-pr-labels: 'Merge After Thaw,Frozen,Slop!⚠️⚠️'
         days-before-pr-stale: 14
         days-before-pr-close: 7
 

--- a/.github/workflows/stale_slop.yml
+++ b/.github/workflows/stale_slop.yml
@@ -1,0 +1,63 @@
+name: 👓 Handle stale issues
+on:
+  schedule:
+  - cron: "30 2 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      pull-requests: write  # for actions/stale to close stale PRs
+    if: github.repository_owner == 'qgis'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v10
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: >
+          The QGIS project highly values your contribution and would love to see
+          this work merged!
+          Unfortunately this PR has been marked as AI written and has not had any activity
+          in the last 5 days and is being automatically marked as "stale".
+          If you think this pull request should be merged, please check
+
+          - that you have personally verified that the AI driven changes work, fit within
+            existing QGIS architecture and design, and are well-written.
+
+          - that all unit tests are passing
+
+          - that all comments by reviewers have been addressed
+
+          - that there is enough information for reviewers, in particular
+
+            - link to any issues which this pull request fixes
+
+            - add a description of workflows which this pull request fixes
+
+            - add screenshots if applicable
+
+          - that you have written unit tests where possible
+
+          If there is no further activity on this pull request, it will be closed in 5
+          days.
+
+        close-pr-message: >
+          While we hate to see this happen, this PR has been automatically closed because
+          it has not had any activity in the last 10 days. If this pull request should be
+          reconsidered, please follow the guidelines in the previous comment and reopen
+          this pull request. Or, if you have any further questions, just ask! We love to
+          help, and if there's anything the QGIS project can do to help push this PR forward
+          please let us know how we can assist.
+
+        stale-pr-label: 'stale'
+        exempt-pr-labels: 'Merge After Thaw,Frozen'
+        only-pr-labels: 'Slop!⚠️⚠️'
+        days-before-pr-stale: 5
+        days-before-pr-close: 10
+
+        days-before-issue-stale: -1
+        days-before-issue-close: -1
+
+        operations-per-run: 1000


### PR DESCRIPTION
Lowers the stalebot threshold for AI slop PRs to 5 days before flagging as stale, 10 days before auto-close

May help us stay on top of the oncoming slop avalanche

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
