### PR TITLE
Use point layer's altitude clamping, z offset and scale when rendering in 3d

### DIFF
--- a/python/PyQt6/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
+++ b/python/PyQt6/3d/auto_generated/symbols/qgspoint3dsymbol.sip.in
@@ -56,15 +56,25 @@ Caller takes ownership of the returned symbol.
     virtual void setDefaultPropertiesFromLayer( const QgsVectorLayer *layer );
 
 
-    Qgis::AltitudeClamping altitudeClamping() const;
+
+ Qgis::AltitudeClamping altitudeClamping() const /Deprecated="Since 4.2. Use QgsVectorLayerElevationProperties.clamping() instead."/;
 %Docstring
 Returns method that determines altitude (whether to clamp to feature to
-terrain)
+terrain).
+
+.. deprecated:: 4.2
+
+   Use :py:func:`QgsVectorLayerElevationProperties.clamping()` instead.
 %End
-    void setAltitudeClamping( Qgis::AltitudeClamping altClamping );
+
+ void setAltitudeClamping( Qgis::AltitudeClamping altClamping );
 %Docstring
-Sets method that determines altitude (whether to clamp to feature to
-terrain)
+Sets the method that determines altitude (whether to clamp to feature to
+terrain).
+
+.. deprecated:: 4.2
+
+   Use :py:func:`QgsVectorLayerElevationProperties.setClamping()` instead.
 %End
 
     QgsAbstractMaterialSettings *materialSettings() const;

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -523,7 +523,7 @@ QMatrix4x4 Qgs3DUtils::stringToMatrix4x4( const QString &str )
 }
 
 void Qgs3DUtils::extractPointPositions(
-  const QgsFeature &f, const Qgs3DRenderContext &context, const QgsVector3D &chunkOrigin, Qgis::AltitudeClamping altClamp, QVector<QVector3D> &positions, const QgsVector3D &translation
+  const QgsFeature &f, const Qgs3DRenderContext &context, const QgsVector3D &chunkOrigin, Qgis::AltitudeClamping altClamp, double zOffset, QVector<QVector3D> &positions, const QgsVector3D &translation
 )
 {
   const QgsAbstractGeometry *g = f.geometry().constGet();
@@ -542,13 +542,13 @@ void Qgs3DUtils::extractPointPositions(
     switch ( altClamp )
     {
       case Qgis::AltitudeClamping::Absolute:
-        h = geomZ;
+        h = geomZ + zOffset;
         break;
       case Qgis::AltitudeClamping::Terrain:
-        h = terrainZ;
+        h = terrainZ + zOffset;
         break;
       case Qgis::AltitudeClamping::Relative:
-        h = terrainZ + geomZ;
+        h = terrainZ + geomZ + zOffset;
         break;
     }
     // clang-format off

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -523,32 +523,37 @@ QMatrix4x4 Qgs3DUtils::stringToMatrix4x4( const QString &str )
 }
 
 void Qgs3DUtils::extractPointPositions(
-  const QgsFeature &f, const Qgs3DRenderContext &context, const QgsVector3D &chunkOrigin, Qgis::AltitudeClamping altClamp, double zOffset, QVector<QVector3D> &positions, const QgsVector3D &translation
+  const QgsFeature &f, const Qgs3DRenderContext &context, const QgsVector3D &chunkOrigin, Qgis::AltitudeClamping altClamp, double zOffset, double zScale, QVector<QVector3D> &positions, const QgsVector3D &translation
 )
 {
   const QgsAbstractGeometry *g = f.geometry().constGet();
   for ( auto it = g->vertices_begin(); it != g->vertices_end(); ++it )
   {
     const QgsPoint pt = *it;
-    float geomZ = 0;
+    double geomZ = 0;
     if ( pt.is3D() )
     {
       geomZ = pt.z();
+      if ( std::isnan( geomZ ) )
+      {
+        geomZ = 0;
+      }
     }
     const float terrainZ = context.terrainRenderingEnabled() && context.terrainGenerator()
                              ? static_cast<float>( context.terrainGenerator()->heightAt( pt.x(), pt.y(), context ) * context.terrainSettings()->verticalScale() )
                              : 0.f;
-    float h = 0.0f;
+    double h = 0.0;
+    // these equations must match the logic from QgsVectorLayerProfileGenerator::featureZToHeight
     switch ( altClamp )
     {
       case Qgis::AltitudeClamping::Absolute:
-        h = geomZ + zOffset;
+        h = geomZ * zScale + zOffset;
         break;
       case Qgis::AltitudeClamping::Terrain:
-        h = terrainZ + zOffset;
+        h = terrainZ * zScale + zOffset;
         break;
       case Qgis::AltitudeClamping::Relative:
-        h = terrainZ + geomZ + zOffset;
+        h = ( terrainZ + geomZ ) * zScale + zOffset;
         break;
     }
     // clang-format off

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -166,6 +166,7 @@ class _3D_EXPORT Qgs3DUtils
       const QgsVector3D &chunkOrigin,
       Qgis::AltitudeClamping altClamp,
       double zOffset,
+      double zScale,
       QVector<QVector3D> &positions,
       const QgsVector3D &translation = QgsVector3D( 0, 0, 0 )
     );

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -165,6 +165,7 @@ class _3D_EXPORT Qgs3DUtils
       const Qgs3DRenderContext &context,
       const QgsVector3D &chunkOrigin,
       Qgis::AltitudeClamping altClamp,
+      double zOffset,
       QVector<QVector3D> &positions,
       const QgsVector3D &translation = QgsVector3D( 0, 0, 0 )
     );

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -27,6 +27,7 @@
 #include "qgsrulebased3drenderer.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerchunkloader_p.h"
+#include "qgsvectorlayerelevationproperties.h"
 #include "qgsvectorlayerfeatureiterator.h"
 
 #include <QString>
@@ -189,6 +190,11 @@ QgsRuleBasedChunkLoaderFactory::QgsRuleBasedChunkLoaderFactory( const Qgs3DRende
   , mRootRule( rootRule->clone() )
   , mMaxFeatures( maxFeatures )
 {
+  if ( const QgsVectorLayerElevationProperties *props = qgis::down_cast<const QgsVectorLayerElevationProperties *>( vl->elevationProperties() ) )
+  {
+    mLayerAltitudeClamping = props->clamping();
+  }
+
   if ( context.crs().type() == Qgis::CrsType::Geocentric )
   {
     // TODO: add support for handling of vector layers
@@ -254,6 +260,7 @@ QgsRuleBasedChunkedEntity::~QgsRuleBasedChunkedEntity()
 bool QgsRuleBasedChunkedEntity::applyTerrainOffset() const
 {
   QgsRuleBasedChunkLoaderFactory *loaderFactory = static_cast<QgsRuleBasedChunkLoaderFactory *>( mChunkLoaderFactory );
+  bool useLayerClamping = false;
   if ( loaderFactory )
   {
     QgsRuleBased3DRenderer::Rule *rootRule = loaderFactory->mRootRule.get();
@@ -274,10 +281,13 @@ bool QgsRuleBasedChunkedEntity::applyTerrainOffset() const
         else if ( symbolType == "point" )
         {
           QgsPoint3DSymbol *pointSymbol = static_cast<QgsPoint3DSymbol *>( rule->symbol() );
-          if ( pointSymbol && pointSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
+          useLayerClamping = true;
+          Q_NOWARN_DEPRECATED_PUSH
+          if ( pointSymbol && pointSymbol->hasLegacyAltitudeClamping() && pointSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
           {
             return false;
           }
+          Q_NOWARN_DEPRECATED_POP
         }
         else if ( symbolType == "polygon" )
         {
@@ -291,6 +301,18 @@ bool QgsRuleBasedChunkedEntity::applyTerrainOffset() const
         {
           QgsDebugMsgLevel( u"QgsRuleBasedChunkedEntityChunkedEntity::applyTerrainOffset, unhandled symbol type %1"_s.arg( symbolType ), 2 );
         }
+      }
+    }
+
+    if ( useLayerClamping )
+    {
+      switch ( loaderFactory->mLayerAltitudeClamping )
+      {
+        case Qgis::AltitudeClamping::Absolute:
+          return false;
+        case Qgis::AltitudeClamping::Relative:
+        case Qgis::AltitudeClamping::Terrain:
+          break;
       }
     }
   }

--- a/src/3d/qgsrulebasedchunkloader_p.h
+++ b/src/3d/qgsrulebasedchunkloader_p.h
@@ -71,6 +71,8 @@ class QgsRuleBasedChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactory
     Qgs3DRenderContext mRenderContext;
     QgsVectorLayer *mLayer;
     std::unique_ptr<QgsRuleBased3DRenderer::Rule> mRootRule;
+    // only used for point layers for now
+    Qgis::AltitudeClamping mLayerAltitudeClamping = Qgis::AltitudeClamping::Terrain;
     //! Contains loaded nodes and whether they are leaf nodes or not
     mutable QHash< QString, bool > mNodesAreLeafs;
     int mMaxFeatures;

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -35,6 +35,7 @@
 #include "qgsraycastingutils.h"
 #include "qgstessellatedpolygongeometry.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectorlayerelevationproperties.h"
 #include "qgsvectorlayerfeatureiterator.h"
 
 #include <QString>
@@ -190,6 +191,41 @@ QgsVectorLayerChunkLoaderFactory::QgsVectorLayerChunkLoaderFactory( const Qgs3DR
   , mSymbol( symbol->clone() )
   , mMaxFeatures( maxFeatures )
 {
+  if ( const QgsVectorLayerElevationProperties *props = qgis::down_cast<const QgsVectorLayerElevationProperties *>( vl->elevationProperties() ) )
+  {
+    mLayerAltitudeClamping = props->clamping();
+  }
+
+  const QString symbolType = mSymbol->type();
+  if ( symbolType == "line"_L1 )
+  {
+    if ( QgsLine3DSymbol *lineSymbol = qgis::down_cast<QgsLine3DSymbol *>( mSymbol.get() ) )
+    {
+      mLayerAltitudeClamping = lineSymbol->altitudeClamping();
+    }
+  }
+  else if ( symbolType == "point"_L1 )
+  {
+    // if point symbol has the legacy deprecated symbol level setting for clamping set,
+    // override the layer's one with that
+    if ( QgsPoint3DSymbol *pointSymbol = qgis::down_cast<QgsPoint3DSymbol *>( mSymbol.get() ) )
+    {
+      Q_NOWARN_DEPRECATED_PUSH
+      if ( pointSymbol->hasLegacyAltitudeClamping() )
+      {
+        mLayerAltitudeClamping = pointSymbol->altitudeClamping();
+      }
+      Q_NOWARN_DEPRECATED_POP
+    }
+  }
+  else if ( symbolType == "polygon" )
+  {
+    if ( QgsPolygon3DSymbol *polygonSymbol = qgis::down_cast<QgsPolygon3DSymbol *>( mSymbol.get() ) )
+    {
+      mLayerAltitudeClamping = polygonSymbol->altitudeClamping();
+    }
+  }
+
   if ( context.crs().type() == Qgis::CrsType::Geocentric )
   {
     // TODO: add support for handling of vector layers
@@ -258,34 +294,13 @@ bool QgsVectorLayerChunkedEntity::applyTerrainOffset() const
   QgsVectorLayerChunkLoaderFactory *loaderFactory = static_cast<QgsVectorLayerChunkLoaderFactory *>( mChunkLoaderFactory );
   if ( loaderFactory )
   {
-    QString symbolType = loaderFactory->mSymbol.get()->type();
-    if ( symbolType == "line" )
+    switch ( loaderFactory->mLayerAltitudeClamping )
     {
-      QgsLine3DSymbol *lineSymbol = static_cast<QgsLine3DSymbol *>( loaderFactory->mSymbol.get() );
-      if ( lineSymbol && lineSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
-      {
+      case Qgis::AltitudeClamping::Absolute:
         return false;
-      }
-    }
-    else if ( symbolType == "point" )
-    {
-      QgsPoint3DSymbol *pointSymbol = static_cast<QgsPoint3DSymbol *>( loaderFactory->mSymbol.get() );
-      if ( pointSymbol && pointSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
-      {
-        return false;
-      }
-    }
-    else if ( symbolType == "polygon" )
-    {
-      QgsPolygon3DSymbol *polygonSymbol = static_cast<QgsPolygon3DSymbol *>( loaderFactory->mSymbol.get() );
-      if ( polygonSymbol && polygonSymbol->altitudeClamping() == Qgis::AltitudeClamping::Absolute )
-      {
-        return false;
-      }
-    }
-    else
-    {
-      QgsDebugMsgLevel( u"QgsVectorLayerChunkedEntity::applyTerrainOffset, unhandled symbol type %1"_s.arg( symbolType ), 2 );
+      case Qgis::AltitudeClamping::Relative:
+      case Qgis::AltitudeClamping::Terrain:
+        break;
     }
   }
 

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -70,6 +70,7 @@ class QgsVectorLayerChunkLoaderFactory : public QgsQuadtreeChunkLoaderFactory
     Qgs3DRenderContext mRenderContext;
     QgsVectorLayer *mLayer;
     std::unique_ptr<QgsAbstract3DSymbol> mSymbol;
+    Qgis::AltitudeClamping mLayerAltitudeClamping = Qgis::AltitudeClamping::Terrain;
     //! Contains loaded nodes and whether they are leaf nodes or not
     mutable QHash< QString, bool > mNodesAreLeafs;
     int mMaxFeatures;

--- a/src/3d/symbols/qgspoint3dsymbol.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol.cpp
@@ -151,8 +151,6 @@ void QgsPoint3DSymbol::setDefaultPropertiesFromLayer( const QgsVectorLayer *laye
 {
   const QgsVectorLayerElevationProperties *props = qgis::down_cast<const QgsVectorLayerElevationProperties *>( const_cast<QgsVectorLayer *>( layer )->elevationProperties() );
 
-  mAltClamping = props->clamping();
-  mTransform.data()[13] = static_cast<float>( props->zOffset() );
   mShapeProperties[u"length"_s] = props->extrusionEnabled() ? static_cast<float>( props->extrusionHeight() ) : 0.0f;
 }
 

--- a/src/3d/symbols/qgspoint3dsymbol.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol.cpp
@@ -48,13 +48,16 @@ QgsPoint3DSymbol::QgsPoint3DSymbol()
 }
 
 QgsPoint3DSymbol::QgsPoint3DSymbol( const QgsPoint3DSymbol &other )
-  : mAltClamping( other.altitudeClamping() )
-  , mMaterialSettings( other.materialSettings() ? other.materialSettings()->clone() : nullptr )
+  : mMaterialSettings( other.materialSettings() ? other.materialSettings()->clone() : nullptr )
   , mShape( other.shape() )
   , mShapeProperties( other.shapeProperties() )
   , mTransform( other.transform() )
   , mBillboardSymbol( other.billboardSymbol() ? other.billboardSymbol()->clone() : nullptr )
 {
+  Q_NOWARN_DEPRECATED_PUSH
+  mAltClamping = other.altitudeClamping();
+  mHasLegacyClamping = other.hasLegacyAltitudeClamping();
+  Q_NOWARN_DEPRECATED_POP
   setDataDefinedProperties( other.dataDefinedProperties() );
 }
 
@@ -65,7 +68,10 @@ void QgsPoint3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext &c
   QDomDocument doc = elem.ownerDocument();
 
   QDomElement elemDataProperties = doc.createElement( u"data"_s );
-  elemDataProperties.setAttribute( u"alt-clamping"_s, Qgs3DUtils::altClampingToString( mAltClamping ) );
+  if ( mHasLegacyClamping )
+  {
+    elemDataProperties.setAttribute( u"alt-clamping"_s, Qgs3DUtils::altClampingToString( mAltClamping ) );
+  }
   elem.appendChild( elemDataProperties );
 
   elem.setAttribute( u"material_type"_s, mMaterialSettings->type() );
@@ -101,7 +107,15 @@ void QgsPoint3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext &c
 void QgsPoint3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteContext &context )
 {
   const QDomElement elemDataProperties = elem.firstChildElement( u"data"_s );
-  mAltClamping = Qgs3DUtils::altClampingFromString( elemDataProperties.attribute( u"alt-clamping"_s ) );
+  if ( elemDataProperties.hasAttribute( u"alt-clamping"_s ) )
+  {
+    mAltClamping = Qgs3DUtils::altClampingFromString( elemDataProperties.attribute( u"alt-clamping"_s ) );
+    mHasLegacyClamping = true;
+  }
+  else
+  {
+    mHasLegacyClamping = false;
+  }
 
   const QDomElement elemMaterial = elem.firstChildElement( u"material"_s );
   const QString materialType = elem.attribute( u"material_type"_s, u"phong"_s );
@@ -140,6 +154,17 @@ void QgsPoint3DSymbol::setDefaultPropertiesFromLayer( const QgsVectorLayer *laye
   mAltClamping = props->clamping();
   mTransform.data()[13] = static_cast<float>( props->zOffset() );
   mShapeProperties[u"length"_s] = props->extrusionEnabled() ? static_cast<float>( props->extrusionHeight() ) : 0.0f;
+}
+
+bool QgsPoint3DSymbol::hasLegacyAltitudeClamping() const
+{
+  return mHasLegacyClamping;
+}
+
+void QgsPoint3DSymbol::setAltitudeClamping( Qgis::AltitudeClamping altClamping ) SIP_DEPRECATED
+{
+  mHasLegacyClamping = true;
+  mAltClamping = altClamping;
 }
 
 Qgis::Point3DShape QgsPoint3DSymbol::shapeFromString( const QString &shape )

--- a/src/3d/symbols/qgspoint3dsymbol.h
+++ b/src/3d/symbols/qgspoint3dsymbol.h
@@ -58,10 +58,28 @@ class _3D_EXPORT QgsPoint3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTOR
     QList<Qgis::GeometryType> compatibleGeometryTypes() const override;
     void setDefaultPropertiesFromLayer( const QgsVectorLayer *layer ) override;
 
-    //! Returns method that determines altitude (whether to clamp to feature to terrain)
-    Qgis::AltitudeClamping altitudeClamping() const { return mAltClamping; }
-    //! Sets method that determines altitude (whether to clamp to feature to terrain)
-    void setAltitudeClamping( Qgis::AltitudeClamping altClamping ) { mAltClamping = altClamping; }
+    /**
+     * Returns TRUE if the symbol has the legacy/deprecated altitudeClamping() setting set.
+     *
+     * \note Not available in Python bindings
+     *
+     * \deprecated QGIS 4.2. Will be removed in QGIS 5.0.
+     */
+    Q_DECL_DEPRECATED bool hasLegacyAltitudeClamping() const SIP_DEPRECATED SIP_SKIP;
+
+    /**
+     * Returns method that determines altitude (whether to clamp to feature to terrain).
+     *
+     * \deprecated QGIS 4.2. Use QgsVectorLayerElevationProperties::clamping() instead.
+     */
+    Q_DECL_DEPRECATED Qgis::AltitudeClamping altitudeClamping() const SIP_DEPRECATED { return mAltClamping; }
+
+    /**
+     * Sets the method that determines altitude (whether to clamp to feature to terrain).
+     *
+     * \deprecated QGIS 4.2. Use QgsVectorLayerElevationProperties::setClamping() instead.
+     */
+    Q_DECL_DEPRECATED void setAltitudeClamping( Qgis::AltitudeClamping altClamping );
 
     //! Returns material settings used for shading of the symbol
     QgsAbstractMaterialSettings *materialSettings() const;
@@ -172,6 +190,7 @@ class _3D_EXPORT QgsPoint3DSymbol : public QgsAbstract3DSymbol SIP_NODEFAULTCTOR
     bool exportGeometries( Qgs3DSceneExporter *exporter, Qt3DCore::QEntity *entity, const QString &objectNamePrefix ) const override SIP_SKIP;
 
   private:
+    bool mHasLegacyClamping = false;
     //! how to handle altitude of vector features
     Qgis::AltitudeClamping mAltClamping = Qgis::AltitudeClamping::Absolute;
 

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -26,6 +26,7 @@
 #include "qgspoint3dsymbol.h"
 #include "qgssourcecache.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectorlayerelevationproperties.h"
 
 #include <QString>
 #include <QUrl>
@@ -60,8 +61,9 @@ using namespace Qt::StringLiterals;
 class QgsInstancedPoint3DSymbolHandler : public QgsFeature3DHandler
 {
   public:
-    QgsInstancedPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds )
+    QgsInstancedPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping )
       : mSymbol( static_cast<QgsPoint3DSymbol *>( symbol->clone() ) )
+      , mAltitudeClamping( altitudeClamping )
       , mSelectedIds( selectedIds )
     {}
 
@@ -86,6 +88,7 @@ class QgsInstancedPoint3DSymbolHandler : public QgsFeature3DHandler
 
     // input specific for this class
     std::unique_ptr<QgsPoint3DSymbol> mSymbol;
+    Qgis::AltitudeClamping mAltitudeClamping = Qgis::AltitudeClamping::Terrain;
     QVector3D mSymbolScale;
     QQuaternion mSymbolRotation;
     QVector3D mPointTranslation;
@@ -134,7 +137,7 @@ void QgsInstancedPoint3DSymbolHandler::processFeature( const QgsFeature &feature
   }
 
   const std::size_t oldSize = out.positions.size();
-  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mSymbol->altitudeClamping(), out.positions, translation );
+  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, out.positions, translation );
 
   const std::size_t added = out.positions.size() - oldSize;
 
@@ -531,8 +534,9 @@ Qt3DCore::QGeometry *QgsInstancedPoint3DSymbolHandler::symbolGeometry( const Qgs
 class QgsModelPoint3DSymbolHandler : public QgsFeature3DHandler
 {
   public:
-    QgsModelPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds )
+    QgsModelPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping )
       : mSymbol( static_cast<QgsPoint3DSymbol *>( symbol->clone() ) )
+      , mAltitudeClamping( altitudeClamping )
       , mSelectedIds( selectedIds )
     {}
 
@@ -575,6 +579,7 @@ class QgsModelPoint3DSymbolHandler : public QgsFeature3DHandler
 
     // input specific for this class
     std::unique_ptr<QgsPoint3DSymbol> mSymbol;
+    Qgis::AltitudeClamping mAltitudeClamping = Qgis::AltitudeClamping::Terrain;
 
     QVector3D mSymbolScale;
     QQuaternion mSymbolRotation;
@@ -624,7 +629,7 @@ void QgsModelPoint3DSymbolHandler::processFeature( const QgsFeature &feature, co
   }
 
   const std::size_t oldSize = out.positions.size();
-  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mSymbol->altitudeClamping(), out.positions, translation );
+  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, out.positions, translation );
   const std::size_t added = out.positions.size() - oldSize;
 
   QVector3D scale = mSymbolScale;
@@ -832,8 +837,9 @@ QgsGeoTransform *QgsModelPoint3DSymbolHandler::transform( QVector3D position, co
 class QgsPoint3DBillboardSymbolHandler : public QgsFeature3DHandler
 {
   public:
-    QgsPoint3DBillboardSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds )
+    QgsPoint3DBillboardSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping )
       : mSymbol( static_cast<QgsPoint3DSymbol *>( symbol->clone() ) )
+      , mAltitudeClamping( altitudeClamping )
       , mSelectedIds( selectedIds )
     {}
 
@@ -852,6 +858,7 @@ class QgsPoint3DBillboardSymbolHandler : public QgsFeature3DHandler
 
     // input specific for this class
     std::unique_ptr<QgsPoint3DSymbol> mSymbol;
+    Qgis::AltitudeClamping mAltitudeClamping = Qgis::AltitudeClamping::Terrain;
     // inputs - generic
     QgsFeatureIds mSelectedIds;
     // outputs
@@ -877,7 +884,7 @@ void QgsPoint3DBillboardSymbolHandler::processFeature( const QgsFeature &feature
   if ( feature.geometry().isNull() )
     return;
 
-  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mSymbol->altitudeClamping(), out.positions );
+  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, out.positions );
   mFeatureCount++;
 }
 
@@ -951,13 +958,28 @@ namespace Qgs3DSymbolImpl
     if ( !pointSymbol )
       return nullptr;
 
+    // default to layer's altitude clamping
+    Qgis::AltitudeClamping altitudeClamping = Qgis::AltitudeClamping::Terrain;
+    if ( const QgsVectorLayerElevationProperties *props = qgis::down_cast<const QgsVectorLayerElevationProperties *>( layer->elevationProperties() ) )
+    {
+      altitudeClamping = props->clamping();
+    }
+    // ... but if point symbol has the legacy deprecated symbol level setting for clamping set,
+    // override the layer's one with that
+    Q_NOWARN_DEPRECATED_PUSH
+    if ( pointSymbol->hasLegacyAltitudeClamping() )
+    {
+      altitudeClamping = pointSymbol->altitudeClamping();
+    }
+    Q_NOWARN_DEPRECATED_POP
+
     if ( pointSymbol->shape() == Qgis::Point3DShape::Model )
-      return new QgsModelPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds() );
+      return new QgsModelPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping );
     // Add proper handler for billboard
     else if ( pointSymbol->shape() == Qgis::Point3DShape::Billboard )
-      return new QgsPoint3DBillboardSymbolHandler( pointSymbol, layer->selectedFeatureIds() );
+      return new QgsPoint3DBillboardSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping );
     else
-      return new QgsInstancedPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds() );
+      return new QgsInstancedPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping );
   }
 } // namespace Qgs3DSymbolImpl
 

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -61,10 +61,11 @@ using namespace Qt::StringLiterals;
 class QgsInstancedPoint3DSymbolHandler : public QgsFeature3DHandler
 {
   public:
-    QgsInstancedPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping, double zOffset )
+    QgsInstancedPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping, double zOffset, double zScale )
       : mSymbol( static_cast<QgsPoint3DSymbol *>( symbol->clone() ) )
       , mAltitudeClamping( altitudeClamping )
       , mZOffset( zOffset )
+      , mZScale( zScale )
       , mSelectedIds( selectedIds )
     {}
 
@@ -91,6 +92,7 @@ class QgsInstancedPoint3DSymbolHandler : public QgsFeature3DHandler
     std::unique_ptr<QgsPoint3DSymbol> mSymbol;
     Qgis::AltitudeClamping mAltitudeClamping = Qgis::AltitudeClamping::Terrain;
     double mZOffset = 0;
+    double mZScale = 1;
     QVector3D mSymbolScale;
     QQuaternion mSymbolRotation;
     QVector3D mPointTranslation;
@@ -139,7 +141,7 @@ void QgsInstancedPoint3DSymbolHandler::processFeature( const QgsFeature &feature
   }
 
   const std::size_t oldSize = out.positions.size();
-  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, mZOffset, out.positions, translation );
+  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, mZOffset, mZScale, out.positions, translation );
 
   const std::size_t added = out.positions.size() - oldSize;
 
@@ -536,10 +538,11 @@ Qt3DCore::QGeometry *QgsInstancedPoint3DSymbolHandler::symbolGeometry( const Qgs
 class QgsModelPoint3DSymbolHandler : public QgsFeature3DHandler
 {
   public:
-    QgsModelPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping, double zOffset )
+    QgsModelPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping, double zOffset, double zScale )
       : mSymbol( static_cast<QgsPoint3DSymbol *>( symbol->clone() ) )
       , mAltitudeClamping( altitudeClamping )
       , mZOffset( zOffset )
+      , mZScale( zScale )
       , mSelectedIds( selectedIds )
     {}
 
@@ -584,6 +587,7 @@ class QgsModelPoint3DSymbolHandler : public QgsFeature3DHandler
     std::unique_ptr<QgsPoint3DSymbol> mSymbol;
     Qgis::AltitudeClamping mAltitudeClamping = Qgis::AltitudeClamping::Terrain;
     double mZOffset = 0;
+    double mZScale = 1;
 
     QVector3D mSymbolScale;
     QQuaternion mSymbolRotation;
@@ -633,7 +637,7 @@ void QgsModelPoint3DSymbolHandler::processFeature( const QgsFeature &feature, co
   }
 
   const std::size_t oldSize = out.positions.size();
-  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, mZOffset, out.positions, translation );
+  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, mZOffset, mZScale, out.positions, translation );
   const std::size_t added = out.positions.size() - oldSize;
 
   QVector3D scale = mSymbolScale;
@@ -841,10 +845,11 @@ QgsGeoTransform *QgsModelPoint3DSymbolHandler::transform( QVector3D position, co
 class QgsPoint3DBillboardSymbolHandler : public QgsFeature3DHandler
 {
   public:
-    QgsPoint3DBillboardSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping, double zOffset )
+    QgsPoint3DBillboardSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping, double zOffset, double zScale )
       : mSymbol( static_cast<QgsPoint3DSymbol *>( symbol->clone() ) )
       , mAltitudeClamping( altitudeClamping )
       , mZOffset( zOffset )
+      , mZScale( zScale )
       , mSelectedIds( selectedIds )
     {}
 
@@ -865,6 +870,7 @@ class QgsPoint3DBillboardSymbolHandler : public QgsFeature3DHandler
     std::unique_ptr<QgsPoint3DSymbol> mSymbol;
     Qgis::AltitudeClamping mAltitudeClamping = Qgis::AltitudeClamping::Terrain;
     double mZOffset = 0;
+    double mZScale = 1;
     // inputs - generic
     QgsFeatureIds mSelectedIds;
     // outputs
@@ -890,7 +896,7 @@ void QgsPoint3DBillboardSymbolHandler::processFeature( const QgsFeature &feature
   if ( feature.geometry().isNull() )
     return;
 
-  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, mZOffset, out.positions );
+  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, mZOffset, mZScale, out.positions );
   mFeatureCount++;
 }
 
@@ -967,10 +973,12 @@ namespace Qgs3DSymbolImpl
     // default to layer's altitude clamping
     Qgis::AltitudeClamping altitudeClamping = Qgis::AltitudeClamping::Terrain;
     double zOffset = 0;
+    double zScale = 1;
     if ( const QgsVectorLayerElevationProperties *props = qgis::down_cast<const QgsVectorLayerElevationProperties *>( layer->elevationProperties() ) )
     {
       altitudeClamping = props->clamping();
       zOffset = props->zOffset();
+      zScale = props->zScale();
     }
     // ... but if point symbol has the legacy deprecated symbol level setting for clamping set,
     // override the layer's one with that
@@ -981,16 +989,17 @@ namespace Qgs3DSymbolImpl
       // assume z offset was already handled in the symbol translation, which was the only way this was done
       // in older QGIS versions
       zOffset = 0;
+      zScale = 1;
     }
     Q_NOWARN_DEPRECATED_POP
 
     if ( pointSymbol->shape() == Qgis::Point3DShape::Model )
-      return new QgsModelPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping, zOffset );
+      return new QgsModelPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping, zOffset, zScale );
     // Add proper handler for billboard
     else if ( pointSymbol->shape() == Qgis::Point3DShape::Billboard )
-      return new QgsPoint3DBillboardSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping, zOffset );
+      return new QgsPoint3DBillboardSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping, zOffset, zScale );
     else
-      return new QgsInstancedPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping, zOffset );
+      return new QgsInstancedPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping, zOffset, zScale );
   }
 } // namespace Qgs3DSymbolImpl
 

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -61,9 +61,10 @@ using namespace Qt::StringLiterals;
 class QgsInstancedPoint3DSymbolHandler : public QgsFeature3DHandler
 {
   public:
-    QgsInstancedPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping )
+    QgsInstancedPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping, double zOffset )
       : mSymbol( static_cast<QgsPoint3DSymbol *>( symbol->clone() ) )
       , mAltitudeClamping( altitudeClamping )
+      , mZOffset( zOffset )
       , mSelectedIds( selectedIds )
     {}
 
@@ -89,6 +90,7 @@ class QgsInstancedPoint3DSymbolHandler : public QgsFeature3DHandler
     // input specific for this class
     std::unique_ptr<QgsPoint3DSymbol> mSymbol;
     Qgis::AltitudeClamping mAltitudeClamping = Qgis::AltitudeClamping::Terrain;
+    double mZOffset = 0;
     QVector3D mSymbolScale;
     QQuaternion mSymbolRotation;
     QVector3D mPointTranslation;
@@ -137,7 +139,7 @@ void QgsInstancedPoint3DSymbolHandler::processFeature( const QgsFeature &feature
   }
 
   const std::size_t oldSize = out.positions.size();
-  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, out.positions, translation );
+  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, mZOffset, out.positions, translation );
 
   const std::size_t added = out.positions.size() - oldSize;
 
@@ -534,9 +536,10 @@ Qt3DCore::QGeometry *QgsInstancedPoint3DSymbolHandler::symbolGeometry( const Qgs
 class QgsModelPoint3DSymbolHandler : public QgsFeature3DHandler
 {
   public:
-    QgsModelPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping )
+    QgsModelPoint3DSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping, double zOffset )
       : mSymbol( static_cast<QgsPoint3DSymbol *>( symbol->clone() ) )
       , mAltitudeClamping( altitudeClamping )
+      , mZOffset( zOffset )
       , mSelectedIds( selectedIds )
     {}
 
@@ -580,6 +583,7 @@ class QgsModelPoint3DSymbolHandler : public QgsFeature3DHandler
     // input specific for this class
     std::unique_ptr<QgsPoint3DSymbol> mSymbol;
     Qgis::AltitudeClamping mAltitudeClamping = Qgis::AltitudeClamping::Terrain;
+    double mZOffset = 0;
 
     QVector3D mSymbolScale;
     QQuaternion mSymbolRotation;
@@ -629,7 +633,7 @@ void QgsModelPoint3DSymbolHandler::processFeature( const QgsFeature &feature, co
   }
 
   const std::size_t oldSize = out.positions.size();
-  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, out.positions, translation );
+  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, mZOffset, out.positions, translation );
   const std::size_t added = out.positions.size() - oldSize;
 
   QVector3D scale = mSymbolScale;
@@ -837,9 +841,10 @@ QgsGeoTransform *QgsModelPoint3DSymbolHandler::transform( QVector3D position, co
 class QgsPoint3DBillboardSymbolHandler : public QgsFeature3DHandler
 {
   public:
-    QgsPoint3DBillboardSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping )
+    QgsPoint3DBillboardSymbolHandler( const QgsPoint3DSymbol *symbol, const QgsFeatureIds &selectedIds, Qgis::AltitudeClamping altitudeClamping, double zOffset )
       : mSymbol( static_cast<QgsPoint3DSymbol *>( symbol->clone() ) )
       , mAltitudeClamping( altitudeClamping )
+      , mZOffset( zOffset )
       , mSelectedIds( selectedIds )
     {}
 
@@ -859,6 +864,7 @@ class QgsPoint3DBillboardSymbolHandler : public QgsFeature3DHandler
     // input specific for this class
     std::unique_ptr<QgsPoint3DSymbol> mSymbol;
     Qgis::AltitudeClamping mAltitudeClamping = Qgis::AltitudeClamping::Terrain;
+    double mZOffset = 0;
     // inputs - generic
     QgsFeatureIds mSelectedIds;
     // outputs
@@ -884,7 +890,7 @@ void QgsPoint3DBillboardSymbolHandler::processFeature( const QgsFeature &feature
   if ( feature.geometry().isNull() )
     return;
 
-  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, out.positions );
+  Qgs3DUtils::extractPointPositions( feature, context, mChunkOrigin, mAltitudeClamping, mZOffset, out.positions );
   mFeatureCount++;
 }
 
@@ -960,9 +966,11 @@ namespace Qgs3DSymbolImpl
 
     // default to layer's altitude clamping
     Qgis::AltitudeClamping altitudeClamping = Qgis::AltitudeClamping::Terrain;
+    double zOffset = 0;
     if ( const QgsVectorLayerElevationProperties *props = qgis::down_cast<const QgsVectorLayerElevationProperties *>( layer->elevationProperties() ) )
     {
       altitudeClamping = props->clamping();
+      zOffset = props->zOffset();
     }
     // ... but if point symbol has the legacy deprecated symbol level setting for clamping set,
     // override the layer's one with that
@@ -970,16 +978,19 @@ namespace Qgs3DSymbolImpl
     if ( pointSymbol->hasLegacyAltitudeClamping() )
     {
       altitudeClamping = pointSymbol->altitudeClamping();
+      // assume z offset was already handled in the symbol translation, which was the only way this was done
+      // in older QGIS versions
+      zOffset = 0;
     }
     Q_NOWARN_DEPRECATED_POP
 
     if ( pointSymbol->shape() == Qgis::Point3DShape::Model )
-      return new QgsModelPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping );
+      return new QgsModelPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping, zOffset );
     // Add proper handler for billboard
     else if ( pointSymbol->shape() == Qgis::Point3DShape::Billboard )
-      return new QgsPoint3DBillboardSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping );
+      return new QgsPoint3DBillboardSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping, zOffset );
     else
-      return new QgsInstancedPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping );
+      return new QgsInstancedPoint3DSymbolHandler( pointSymbol, layer->selectedFeatureIds(), altitudeClamping, zOffset );
   }
 } // namespace Qgs3DSymbolImpl
 

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -69,6 +69,9 @@ QgsPoint3DSymbolWidget::QgsPoint3DSymbolWidget( QWidget *parent )
   setSymbol( &defaultSymbol, nullptr );
   onShapeChanged();
 
+  // hide by default, only shown for symbols with the legacy setting
+  labelAltClamping->hide();
+  cboAltClamping->hide();
   connect( cboAltClamping, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPoint3DSymbolWidget::changed );
   connect( cboShape, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPoint3DSymbolWidget::onShapeChanged );
   QList<QDoubleSpinBox *> spinWidgets;
@@ -107,7 +110,14 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
   if ( !pointSymbol )
     return;
 
-  cboAltClamping->setCurrentIndex( static_cast<int>( pointSymbol->altitudeClamping() ) );
+  Q_NOWARN_DEPRECATED_PUSH
+  cboAltClamping->setVisible( pointSymbol->hasLegacyAltitudeClamping() );
+  labelAltClamping->setVisible( pointSymbol->hasLegacyAltitudeClamping() );
+  if ( !cboAltClamping->isHidden() )
+  {
+    cboAltClamping->setCurrentIndex( static_cast<int>( pointSymbol->altitudeClamping() ) );
+  }
+  Q_NOWARN_DEPRECATED_POP
 
   cboShape->setCurrentIndex( cboShape->findData( QVariant::fromValue( pointSymbol->shape() ) ) );
   QgsMaterialSettingsRenderingTechnique technique = QgsMaterialSettingsRenderingTechnique::InstancedPoints;
@@ -243,7 +253,12 @@ QgsAbstract3DSymbol *QgsPoint3DSymbolWidget::symbol()
   tr.scale( sca );
   tr.rotate( rot );
 
-  sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentIndex() ) );
+  if ( !cboAltClamping->isHidden() )
+  {
+    Q_NOWARN_DEPRECATED_PUSH
+    sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentIndex() ) );
+    Q_NOWARN_DEPRECATED_POP
+  }
   sym->setShape( cboShape->itemData( cboShape->currentIndex() ).value<Qgis::Point3DShape>() );
   sym->setShapeProperties( vm );
   sym->setMaterialSettings( widgetMaterial->settings() );

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -15,12 +15,16 @@
 
 #include "qgspoint3dsymbolwidget.h"
 
+#include "qgisapp.h"
 #include "qgs3dutils.h"
 #include "qgsabstractmaterialsettings.h"
 #include "qgslayoututils.h"
 #include "qgsmarkersymbol.h"
 #include "qgspoint3dsymbol.h"
 #include "qgssymbolbutton.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectorlayerelevationproperties.h"
+#include "vector/qgsvectorelevationpropertieswidget.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -52,6 +56,15 @@ QgsPoint3DSymbolWidget::QgsPoint3DSymbolWidget( QWidget *parent )
   spinLength->setClearValue( 10.0 );
   spinTopRadius->setClearValue( 0.0 );
   spinBillboardHeight->setClearValue( 0.0 );
+
+  mLabelElevationDescription->hide();
+  mLabelElevationDescription->setOpenExternalLinks( false );
+  connect( mLabelElevationDescription, &QLabel::linkActivated, this, [this] {
+    if ( !mLayer )
+      return;
+
+    QgisApp::instance()->showLayerProperties( mLayer, u"mOptsPage_Elevation"_s );
+  } );
 
   cboShape->addItem( tr( "Sphere" ), QVariant::fromValue( Qgis::Point3DShape::Sphere ) );
   cboShape->addItem( tr( "Cylinder" ), QVariant::fromValue( Qgis::Point3DShape::Cylinder ) );
@@ -99,9 +112,11 @@ QgsPoint3DSymbolWidget::QgsPoint3DSymbolWidget( QWidget *parent )
   connect( mButtonDDRotationZ, &QgsPropertyOverrideButton::changed, this, &QgsPoint3DSymbolWidget::changed );
 }
 
-Qgs3DSymbolWidget *QgsPoint3DSymbolWidget::create( QgsVectorLayer * )
+Qgs3DSymbolWidget *QgsPoint3DSymbolWidget::create( QgsVectorLayer *layer )
 {
-  return new QgsPoint3DSymbolWidget();
+  auto widget = new QgsPoint3DSymbolWidget();
+  widget->updateUiForLayer( layer );
+  return widget;
 }
 
 void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorLayer *layer )
@@ -110,12 +125,19 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
   if ( !pointSymbol )
     return;
 
+  updateUiForLayer( layer );
+
   Q_NOWARN_DEPRECATED_PUSH
   cboAltClamping->setVisible( pointSymbol->hasLegacyAltitudeClamping() );
   labelAltClamping->setVisible( pointSymbol->hasLegacyAltitudeClamping() );
   if ( !cboAltClamping->isHidden() )
   {
     cboAltClamping->setCurrentIndex( static_cast<int>( pointSymbol->altitudeClamping() ) );
+  }
+  if ( pointSymbol->hasLegacyAltitudeClamping() )
+  {
+    mLabelElevationDescription->setText( u"<b>%1</b>"_s.arg( tr( "This symbol uses legacy configuration for altitude clamping and offset, and will ignore the layer's elevation settings." ) ) );
+    mLabelElevationDescription->show();
   }
   Q_NOWARN_DEPRECATED_POP
 
@@ -361,4 +383,28 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
   }
 
   emit changed();
+}
+
+void QgsPoint3DSymbolWidget::updateUiForLayer( QgsVectorLayer *layer )
+{
+  mLayer = layer;
+  if ( !layer )
+  {
+    mLabelElevationDescription->hide();
+    return;
+  }
+
+  QgsVectorLayerElevationProperties *elevationProperties = qobject_cast< QgsVectorLayerElevationProperties * >( mLayer->elevationProperties() );
+  if ( !elevationProperties )
+  {
+    mLabelElevationDescription->hide();
+    return;
+  }
+
+  const QString formattedClampingDescription = QgsVectorElevationPropertiesWidget::clampingDescription( elevationProperties->clamping() );
+
+  const QString explanationParagraph = u"<p>%1</p>"_s.arg( QObject::tr( "This can be changed from the layer's <a href=\"#elevprops\">Elevation Properties</a> page." ) );
+
+  mLabelElevationDescription->setText( formattedClampingDescription + explanationParagraph );
+  mLabelElevationDescription->show();
 }

--- a/src/app/3d/qgspoint3dsymbolwidget.h
+++ b/src/app/3d/qgspoint3dsymbolwidget.h
@@ -20,6 +20,8 @@
 
 #include "qgs3dsymbolwidget.h"
 
+#include <QPointer>
+
 class QgsPoint3DSymbol;
 
 
@@ -38,6 +40,11 @@ class QgsPoint3DSymbolWidget : public Qgs3DSymbolWidget, private Ui::Point3DSymb
 
   private slots:
     void onShapeChanged();
+
+  private:
+    void updateUiForLayer( QgsVectorLayer *layer );
+
+    QPointer< QgsVectorLayer > mLayer;
 };
 
 #endif // QGSPOINT3DSYMBOLWIDGET_H

--- a/src/app/vector/qgsvectorelevationpropertieswidget.cpp
+++ b/src/app/vector/qgsvectorelevationpropertieswidget.cpp
@@ -281,10 +281,27 @@ void QgsVectorElevationPropertiesWidget::onChanged()
     emit widgetChanged();
 }
 
+QString QgsVectorElevationPropertiesWidget::clampingDescription( Qgis::AltitudeClamping clamping )
+{
+  switch ( clamping )
+  {
+    case Qgis::AltitudeClamping::Absolute:
+      return u"<p><b>%1</b></p><p>%2</p>"_s.arg( tr( "Elevation will be taken directly from features." ), tr( "Z values from the features will be used for elevation, and the terrain height will be ignored." ) );
+
+    case Qgis::AltitudeClamping::Relative:
+      return u"<p><b>%1</b></p><p>%2</p>"_s.arg( tr( "Elevation is relative to terrain height." ), tr( "Any z values present in the features will be added to the terrain height." ) );
+
+    case Qgis::AltitudeClamping::Terrain:
+      return u"<p><b>%1</b></p><p>%2</p>"_s.arg( tr( "Feature elevation will be taken directly from the terrain height." ), tr( "Any existing z values present in the features will be ignored." ) );
+  }
+  BUILTIN_UNREACHABLE
+}
+
 void QgsVectorElevationPropertiesWidget::clampingChanged()
 {
   bool enableScale = true;
   bool enableBinding = !mLayer || mLayer->geometryType() != Qgis::GeometryType::Point;
+  mLabelClampingExplanation->setText( clampingDescription( static_cast<Qgis::AltitudeClamping>( mComboClamping->currentData().toInt() ) ) );
   switch ( static_cast<Qgis::AltitudeClamping>( mComboClamping->currentData().toInt() ) )
   {
     case Qgis::AltitudeClamping::Absolute:

--- a/src/app/vector/qgsvectorelevationpropertieswidget.h
+++ b/src/app/vector/qgsvectorelevationpropertieswidget.h
@@ -34,6 +34,8 @@ class QgsVectorElevationPropertiesWidget : public QgsMapLayerConfigWidget, priva
 
     void syncToLayer( QgsMapLayer *layer ) final;
 
+    static QString clampingDescription( Qgis::AltitudeClamping clamping );
+
     QgsExpressionContext createExpressionContext() const override;
 
   public slots:

--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -1655,6 +1655,7 @@ double QgsVectorLayerProfileGenerator::featureZToHeight( double x, double y, dou
     case Qgis::AltitudeClamping::Relative:
     case Qgis::AltitudeClamping::Terrain:
     {
+      // make sure these stay consistent with the equations in Qgs3DUtils::extractPointPositions
       const double terrainZ = terrainHeight( x, y );
       if ( !std::isnan( terrainZ ) )
       {

--- a/src/ui/3d/point3dsymbolwidget.ui
+++ b/src/ui/3d/point3dsymbolwidget.ui
@@ -31,7 +31,153 @@
      <property name="verticalSpacing">
       <number>6</number>
      </property>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Shape</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="labelLength">
+       <property name="text">
+        <string>Length</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="labelModel">
+       <property name="text">
+        <string>Model</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinBillboardHeight">
+       <property name="minimum">
+        <double>-99999.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="labelBillboardSymbol">
+       <property name="text">
+        <string>Billboard symbol</string>
+       </property>
+      </widget>
+     </item>
      <item row="5" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinBottomRadius">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="Qgs3DModelSourceLineEdit" name="lineEditModel" native="true"/>
+       </item>
+      </layout>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="labelAltClamping">
+       <property name="text">
+        <string>Altitude clamping</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinTopRadius">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="labelSize">
+       <property name="text">
+        <string>Size</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="labelBillboardHeight">
+       <property name="text">
+        <string>Billboard Height</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinRadius">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelBottomRadius">
+       <property name="text">
+        <string>Bottom radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinLength">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelTopRadius">
+       <property name="text">
+        <string>Top radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="cboShape"/>
+     </item>
+     <item row="11" column="1">
+      <widget class="QComboBox" name="cboAltClamping">
+       <item>
+        <property name="text">
+         <string>Absolute</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Relative</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Terrain</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelRadius">
+       <property name="text">
+        <string>Radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
       <widget class="QgsDoubleSpinBox" name="spinSize">
        <property name="maximum">
         <double>99999.000000000000000</double>
@@ -41,7 +187,24 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelMinorRadius">
+       <property name="text">
+        <string>Minor radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinMinorRadius">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>5.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <widget class="QgsSymbolButton" name="btnChangeSymbol">
@@ -71,166 +234,13 @@
        </item>
       </layout>
      </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="labelAltClamping">
+     <item row="0" column="0" colspan="2">
+      <widget class="QLabel" name="mLabelElevationDescription">
        <property name="text">
-        <string>Altitude clamping</string>
+        <string>TextLabel</string>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelRadius">
-       <property name="text">
-        <string>Radius</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinBottomRadius">
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>10.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="Qgs3DModelSourceLineEdit" name="lineEditModel" native="true"/>
-       </item>
-      </layout>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="labelBillboardSymbol">
-       <property name="text">
-        <string>Billboard symbol</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="labelBillboardHeight">
-       <property name="text">
-        <string>Billboard Height</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinLength">
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>10.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="cboShape"/>
-     </item>
-     <item row="8" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinBillboardHeight">
-       <property name="minimum">
-        <double>-99999.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="labelBottomRadius">
-       <property name="text">
-        <string>Bottom radius</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinMinorRadius">
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>5.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="labelModel">
-       <property name="text">
-        <string>Model</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="labelLength">
-       <property name="text">
-        <string>Length</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="labelMinorRadius">
-       <property name="text">
-        <string>Minor radius</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="labelTopRadius">
-       <property name="text">
-        <string>Top radius</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinRadius">
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>10.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1">
-      <widget class="QComboBox" name="cboAltClamping">
-       <item>
-        <property name="text">
-         <string>Absolute</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Relative</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Terrain</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QgsDoubleSpinBox" name="spinTopRadius">
-       <property name="maximum">
-        <double>99999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="labelSize">
-       <property name="text">
-        <string>Size</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Shape</string>
+       <property name="wordWrap">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -496,10 +506,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -507,9 +521,10 @@
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMaterialWidget</class>
@@ -522,11 +537,6 @@
    <extends>QWidget</extends>
    <header>qgs3dmodelsourcelineedit.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsSymbolButton</class>
-   <extends>QToolButton</extends>
-   <header>qgssymbolbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsvectorelevationpropertieswidgetbase.ui
+++ b/src/ui/qgsvectorelevationpropertieswidgetbase.ui
@@ -285,7 +285,7 @@
       <enum>Qt::FocusPolicy::StrongFocus</enum>
      </property>
      <property name="title">
-      <string>Custom Tolerance</string>
+      <string>Custom Elevation Profile Tolerance</string>
      </property>
      <property name="checkable">
       <bool>true</bool>


### PR DESCRIPTION
And remove/deprecated the 3d point symbol version of these settings. 

These settings do not belong at the symbol level. They are innate properties of the layer/data itself, and are also exposed as a layer level properties from the layer's elevation properties tab.

By removing these properties from the symbol, we ensure that 3d point symbols are reusable across different datasets -- their
configuration becomes generic, and no longer tied to one particular layer's z value structure.

In order to handle existing projects (where the symbol's clamping may differ from the elevation properties clamping) we add a new flag for hasLegacyAltitudeClamping() which is only true for symbols read from xml with the now deprecated
setting. The old UI settings are only shown now for symbols in existing projects which have this legacy property set.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.