### PR TITLE
Add additional QML module dependencies to the debian packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,10 @@ Architecture: all
 Depends:
  libjs-jquery,
  libjs-leaflet,
- qml-module-qtcharts,
+ qml6-module-qtcharts,
+ qml6-module-qtquick-controls,
+ qml6-module-qtquick-effects,
+ qml6-module-qtquick-layouts,
  ${misc:Depends}
 Description: QGIS - architecture-independent data
  QGIS is a Geographic Information System (GIS) which manages, analyzes and

--- a/debian/control.in
+++ b/debian/control.in
@@ -86,7 +86,10 @@ Architecture: all
 Depends:
  libjs-jquery,
  libjs-leaflet,
- qml-module-qtcharts,
+ qml6-module-qtcharts,
+ qml6-module-qtquick-controls,
+ qml6-module-qtquick-effects,
+ qml6-module-qtquick-layouts,
  ${misc:Depends}
 Description: QGIS - architecture-independent data
  QGIS is a Geographic Information System (GIS) which manages, analyzes and


### PR DESCRIPTION
## Description

@jef-n , this PR does two things:

- corrects the Qt6 QML QtCharts dependency to qml6-module-qtcharts 
- adds three additional QML modules needed to display the new landing welcome page

@marcelosoaressouza , as discussed yesterday.