### PR TITLE
Locale fallback

### DIFF
--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -2079,12 +2079,21 @@ bool QgsProject::readProjectFile( const QString &filename, Qgis::ProjectReadFlag
   QgsApplication::profiler()->clear( u"projectload"_s );
   QgsScopedRuntimeProfile profile( tr( "Setting up translations" ), u"projectload"_s );
 
-  const QString localeFileName = u"%1_%2"_s.arg( QFileInfo( mFile ).baseName(), QgsApplication::settingsLocaleUserLocale->value() );
+  const QString locale = QgsApplication::settingsLocaleUserLocale->value();
+  const QString projectBaseName = QFileInfo( mFile ).baseName();
+  const QString projectDir = QFileInfo( mFile ).absolutePath();
+  QString localeFileName = u"%1_%2"_s.arg( projectBaseName, locale );
 
-  if ( QFile( u"%1/%2.qm"_s.arg( QFileInfo( mFile ).absolutePath(), localeFileName ) ).exists() )
+  if ( !QFile( u"%1/%2.qm"_s.arg( projectDir, localeFileName ) ).exists() && locale.contains( '_' ) )
+  {
+    // Fallback: try language-only locale (e.g., "fr" from "fr_CH")
+    localeFileName = u"%1_%2"_s.arg( projectBaseName, locale.left( locale.indexOf( '_' ) ) );
+  }
+
+  if ( QFile( u"%1/%2.qm"_s.arg( projectDir, localeFileName ) ).exists() )
   {
     mTranslator = std::make_unique< QTranslator >();
-    ( void ) mTranslator->load( localeFileName, QFileInfo( mFile ).absolutePath() );
+    ( void ) mTranslator->load( localeFileName, projectDir );
   }
 
   profile.switchTask( tr( "Reading project file" ) );

--- a/tests/src/core/testqgstranslateproject.cpp
+++ b/tests/src/core/testqgstranslateproject.cpp
@@ -49,6 +49,7 @@ class TestQgsTranslateProject : public QObject
 
     void createTsFile();
     void translateProject();
+    void translateProjectLocaleFallback();
 
   private:
     QString original_locale;
@@ -405,6 +406,33 @@ void TestQgsTranslateProject::translateProject()
   QString deProjectFileName( TEST_DATA_DIR );
   deProjectFileName = deProjectFileName + "/project_translation/points_translation_de.qgs";
   const QFile deProjectFile( deProjectFileName );
+  QVERIFY( deProjectFile.exists() );
+}
+
+void TestQgsTranslateProject::translateProjectLocaleFallback()
+{
+  // Test that a locale like "de_CH" falls back to using the "de" .qm file
+  // when no "de_CH" .qm file exists
+  QgsApplication::settingsLocaleUserLocale->setValue( "de_CH" );
+  QString projectFileName( TEST_DATA_DIR );
+  projectFileName = projectFileName + "/project_translation/points_translation.qgs";
+  QgsProject::instance()->read( projectFileName );
+
+  // The de.qm file exists but de_CH.qm does not — translation should still work via fallback
+  QgsVectorLayer *points_layer = QgsProject::instance()->mapLayer<QgsVectorLayer *>( "points_240d6bd6_9203_470a_994a_aae13cd9fa04" );
+  QgsVectorLayer *lines_layer = QgsProject::instance()->mapLayer<QgsVectorLayer *>( "lines_a677672a_bf5d_410d_98c9_d326a5719a1b" );
+
+  QVERIFY( points_layer );
+  QVERIFY( lines_layer );
+
+  // Verify translations are applied (same as the "de" locale test)
+  QCOMPARE( lines_layer->name(), u"Linien"_s );  //#spellok
+  QCOMPARE( points_layer->name(), u"Punkte"_s ); //#spellok
+
+  // Also verify a translated project file was created with the fallback locale suffix
+  QString deChProjectFileName( TEST_DATA_DIR );
+  deChProjectFileName = deChProjectFileName + "/project_translation/points_translation_de.qgs";
+  const QFile deProjectFile( deChProjectFileName );
   QVERIFY( deProjectFile.exists() );
 }
 


### PR DESCRIPTION
When translating a project, if we have a locale set to de_CH and only a _de.qm file, fallback to it.