### PR TITLE
sfcgal: properly use double values in primitive transformations

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
@@ -476,7 +476,7 @@ Scale this geometry by vector ``scaleFactor``.
 %Docstring
 Apply 3D matrix transform ``mat`` to geometry ``geom``
 
-:param mat: 4x4 transformation matrix (translation is defined of the 4th
+:param mat: 4x4 transformation matrix (translation is defined in the 4th
             column)
 :param errorMsg: Error message returned by SFGCAL
 

--- a/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
@@ -472,7 +472,7 @@ Scale this geometry by vector ``scaleFactor``.
                             operation
 %End
 
-    std::unique_ptr<QgsSfcgalGeometry> transform( const QMatrix4x4 &mat ) const;
+    std::unique_ptr<QgsSfcgalGeometry> transform( const QgsMatrix4x4 &mat ) const;
 %Docstring
 Apply 3D matrix transform ``mat`` to geometry ``geom``
 
@@ -788,7 +788,7 @@ Converts the current primitive to geometry. Works only with primitives.
 :raises QgsNotSupportedException: on QGIS builds based on SFCGAL < 2.3.
 %End
 
-    QMatrix4x4 primitiveTransform() const;
+    QgsMatrix4x4 primitiveTransform() const;
 %Docstring
 Returns the primitive transform matrix.
 

--- a/python/PyQt6/core/auto_generated/qgsmatrix4x4.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmatrix4x4.sip.in
@@ -85,6 +85,22 @@ components of a ``vector``.
 .. versionadded:: 4.2
 %End
 
+    void rotate( double angle, double x, double y, double z );
+%Docstring
+Multiples this matrix by another that rotates coordinates through
+``angle`` degrees about the vector (``x``, ``y``, ``z``).
+
+.. versionadded:: 4.2
+%End
+
+    void rotate( double angle, const QgsVector3D &vector );
+%Docstring
+Multiples this matrix by another that rotates coordinates through
+``angle`` degrees about ``vector``.
+
+.. versionadded:: 4.2
+%End
+
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsMatrix4x4(%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16)>" )

--- a/python/PyQt6/core/auto_generated/qgsmatrix4x4.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsmatrix4x4.sip.in
@@ -77,6 +77,14 @@ Returns whether this matrix is an identity matrix
 Sets matrix to be identity matrix
 %End
 
+    void scale( const QgsVector3D &vector );
+%Docstring
+Multiplies this matrix by another that scales coordinates by the
+components of a ``vector``.
+
+.. versionadded:: 4.2
+%End
+
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsMatrix4x4(%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16)>" )

--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -1008,7 +1008,7 @@ sfcgal::shared_geom QgsSfcgalEngine::toPolyhedralSurface( const sfcgal::geometry
 }
 
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )
-sfcgal::shared_geom QgsSfcgalEngine::transform( const sfcgal::geometry *geom, const QMatrix4x4 &mat, QString *errorMsg )
+sfcgal::shared_geom QgsSfcgalEngine::transform( const sfcgal::geometry *geom, const QgsMatrix4x4 &mat, QString *errorMsg )
 {
   sfcgal::errorHandler()->clearText( errorMsg );
   CHECK_NOT_NULL( geom, nullptr );
@@ -1039,7 +1039,7 @@ sfcgal::shared_prim QgsSfcgalEngine::createCube( double size, QString *errorMsg 
   return sfcgal::make_shared_prim( result );
 }
 
-sfcgal::shared_geom QgsSfcgalEngine::primitiveAsPolyhedral( const sfcgal::primitive *prim, const QMatrix4x4 &mat, QString *errorMsg )
+sfcgal::shared_geom QgsSfcgalEngine::primitiveAsPolyhedral( const sfcgal::primitive *prim, const QgsMatrix4x4 &mat, QString *errorMsg )
 {
   sfcgal::errorHandler()->clearText( errorMsg );
   CHECK_NOT_NULL( prim, nullptr );

--- a/src/core/geometry/qgssfcgalengine.h
+++ b/src/core/geometry/qgssfcgalengine.h
@@ -27,10 +27,9 @@
 #include "qgsexception.h"
 #include "qgsgeometry.h"
 #include "qgslogger.h"
+#include "qgsmatrix4x4.h"
 #include "qgspoint.h"
 #include "qgsvector3d.h"
-
-#include <QMatrix4x4>
 
 #define SIP_NO_FILE
 
@@ -708,7 +707,7 @@ class CORE_EXPORT QgsSfcgalEngine
      * \param mat 4x4 transformation matrix
      * \param errorMsg Error message returned by SFGCAL
      */
-    static sfcgal::shared_geom transform( const sfcgal::geometry *geom, const QMatrix4x4 &mat, QString *errorMsg = nullptr );
+    static sfcgal::shared_geom transform( const sfcgal::geometry *geom, const QgsMatrix4x4 &mat, QString *errorMsg = nullptr );
 
     /**
      * Creates a SFGAL geometry from a shared SFCGAL primitive (from SFCGAL library).
@@ -740,7 +739,7 @@ class CORE_EXPORT QgsSfcgalEngine
      * \param mat a transformation matrix
      * \param errorMsg Error message returned by SFGCAL
      */
-    static sfcgal::shared_geom primitiveAsPolyhedral( const sfcgal::primitive *prim, const QMatrix4x4 &mat = QMatrix4x4(), QString *errorMsg = nullptr );
+    static sfcgal::shared_geom primitiveAsPolyhedral( const sfcgal::primitive *prim, const QgsMatrix4x4 &mat = QgsMatrix4x4(), QString *errorMsg = nullptr );
 
     /**
      * Checks if \a primA and \a primB are equal.

--- a/src/core/geometry/qgssfcgalgeometry.cpp
+++ b/src/core/geometry/qgssfcgalgeometry.cpp
@@ -547,7 +547,7 @@ std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::rotate2D( double angle, co
   return resultGeom;
 }
 
-std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::transform( const QMatrix4x4 &mat ) const
+std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::transform( const QgsMatrix4x4 &mat ) const
 {
   QString errorMsg;
   sfcgal::errorHandler()->clearText( &errorMsg );
@@ -943,7 +943,7 @@ std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::primitiveAsPolyhedralSurfa
 #endif
 }
 
-QMatrix4x4 QgsSfcgalGeometry::primitiveTransform() const
+QgsMatrix4x4 QgsSfcgalGeometry::primitiveTransform() const
 {
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )
   if ( !mIsPrimitive )
@@ -1018,25 +1018,29 @@ void QgsSfcgalGeometry::primitiveSetParameter( const QString &name, const QVaria
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )
 void QgsSfcgalGeometry::setPrimitiveTranslate( const QgsVector3D &translation )
 {
-  mPrimTransform.translate( mPrimTransform.column( 3 ).toVector3D() + translation.toVector3D() );
+  const double *primTransformData = mPrimTransform.constData();
+  QgsVector3D prevTrans( primTransformData[12], primTransformData[13], primTransformData[14] );
+  mPrimTransform.translate( prevTrans + translation );
 }
 
 void QgsSfcgalGeometry::setPrimitiveScale( const QgsVector3D &scaleFactor, const QgsPoint &center )
 {
-  QVector3D qCenter( center.x(), center.y(), center.z() );
-  QVector3D prevTrans = mPrimTransform.column( 3 ).toVector3D();
+  QgsVector3D qCenter( center.x(), center.y(), center.z() );
+  const double *primTransformData = mPrimTransform.constData();
+  QgsVector3D prevTrans( primTransformData[12], primTransformData[13], primTransformData[14] );
   mPrimTransform.translate( prevTrans - qCenter );
-  mPrimTransform.scale( scaleFactor.toVector3D() );
+  mPrimTransform.scale( scaleFactor );
   mPrimTransform.translate( prevTrans + qCenter );
 }
 
 void QgsSfcgalGeometry::setPrimitiveRotation( double angle, const QgsVector3D &axisVector, const QgsPoint &center )
 {
-  QVector3D qCenter( center.x(), center.y(), center.z() );
-  QVector3D prevTrans = mPrimTransform.column( 3 ).toVector3D();
+  QgsVector3D qCenter( center.x(), center.y(), center.z() );
+  const double *primTransformData = mPrimTransform.constData();
+  QgsVector3D prevTrans( primTransformData[12], primTransformData[13], primTransformData[14] );
   mPrimTransform.translate( prevTrans - qCenter );
   // TODO: need to merge previous rotation values with the new ones
-  mPrimTransform.rotate( QQuaternion::fromAxisAndAngle( axisVector.toVector3D(), angle * 180.0 / M_PI ) );
+  mPrimTransform.rotate( angle * 180.0 / M_PI, axisVector );
   mPrimTransform.translate( prevTrans + qCenter );
 }
 

--- a/src/core/geometry/qgssfcgalgeometry.cpp
+++ b/src/core/geometry/qgssfcgalgeometry.cpp
@@ -1036,7 +1036,7 @@ void QgsSfcgalGeometry::setPrimitiveRotation( double angle, const QgsVector3D &a
   QVector3D prevTrans = mPrimTransform.column( 3 ).toVector3D();
   mPrimTransform.translate( prevTrans - qCenter );
   // TODO: need to merge previous rotation values with the new ones
-  mPrimTransform.rotate( QQuaternion::fromAxisAndAngle( axisVector.toVector3D(), angle ) );
+  mPrimTransform.rotate( QQuaternion::fromAxisAndAngle( axisVector.toVector3D(), angle * 180.0 / M_PI ) );
   mPrimTransform.translate( prevTrans + qCenter );
 }
 

--- a/src/core/geometry/qgssfcgalgeometry.h
+++ b/src/core/geometry/qgssfcgalgeometry.h
@@ -28,10 +28,10 @@ SIP_IF_MODULE( HAVE_SFCGAL_SIP )
 
 #include "qgsabstractgeometry.h"
 #include "qgslinestring.h"
+#include "qgsmatrix4x4.h"
 #include "qgspoint.h"
 #include "qgssfcgalengine.h"
 
-#include <QtGui/qmatrix4x4.h>
 
 /**
  * Wraps SFCGAL geometry object.
@@ -440,7 +440,7 @@ class CORE_EXPORT QgsSfcgalGeometry
      * \throws QgsSfcgalException if an error was encountered during the operation
      * \throws QgsNotSupportedException on QGIS builds based on SFCGAL < 2.3.
      */
-    std::unique_ptr<QgsSfcgalGeometry> transform( const QMatrix4x4 &mat ) const SIP_THROW( QgsSfcgalException );
+    std::unique_ptr<QgsSfcgalGeometry> transform( const QgsMatrix4x4 &mat ) const SIP_THROW( QgsSfcgalException );
 
     /**
      * Checks if \a otherGeom intersects this.
@@ -702,7 +702,7 @@ class CORE_EXPORT QgsSfcgalGeometry
      * \throws QgsSfcgalException if an error was encountered during the operation
      * \throws QgsNotSupportedException on QGIS builds based on SFCGAL < 2.3.
      */
-    QMatrix4x4 primitiveTransform() const SIP_THROW( QgsSfcgalException );
+    QgsMatrix4x4 primitiveTransform() const SIP_THROW( QgsSfcgalException );
 
   protected:
 
@@ -726,7 +726,7 @@ class CORE_EXPORT QgsSfcgalGeometry
 
     sfcgal::shared_prim mSfcgalPrim;
     sfcgal::primitiveType mPrimType;
-    QMatrix4x4 mPrimTransform;
+    QgsMatrix4x4 mPrimTransform;
 #endif
 };
 

--- a/src/core/geometry/qgssfcgalgeometry.h
+++ b/src/core/geometry/qgssfcgalgeometry.h
@@ -721,6 +721,7 @@ class CORE_EXPORT QgsSfcgalGeometry
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )
     void setPrimitiveTranslate( const QgsVector3D &translation );
     void setPrimitiveScale( const QgsVector3D &scaleFactor, const QgsPoint &center );
+    //!The rotation angle is in radians.
     void setPrimitiveRotation( double angle, const QgsVector3D &axisVector, const QgsPoint &center );
 
     sfcgal::shared_prim mSfcgalPrim;

--- a/src/core/geometry/qgssfcgalgeometry.h
+++ b/src/core/geometry/qgssfcgalgeometry.h
@@ -433,7 +433,7 @@ class CORE_EXPORT QgsSfcgalGeometry
     /**
      * Apply 3D matrix transform \a mat to geometry \a geom
      *
-     * \param mat 4x4 transformation matrix (translation is defined of the 4th column)
+     * \param mat 4x4 transformation matrix (translation is defined in the 4th column)
      * \param errorMsg Error message returned by SFGCAL
      * \return new geometry
      *

--- a/src/core/qgsmatrix4x4.cpp
+++ b/src/core/qgsmatrix4x4.cpp
@@ -156,3 +156,54 @@ void QgsMatrix4x4::scale( const QgsVector3D &vector )
   m[2][2] *= vector.z();
   m[2][3] *= vector.z();
 }
+
+void QgsMatrix4x4::rotate( double angle, double x, double y, double z )
+{
+  const double length = std::sqrt( x * x + y * y + z * z );
+  if ( qgsDoubleNear( length, 0.0 ) )
+  {
+    return;
+  }
+
+  const double nx = x / length;
+  const double ny = y / length;
+  const double nz = z / length;
+
+  const double angleRad = angle * M_PI / 180.0;
+  const double angleCos = std::cos( angleRad );
+  const double angleSin = std::sin( angleRad );
+  const double angleCosInv = 1.0 - angleCos;
+
+  const double nxny = nx * ny;
+  const double nxnz = nx * nz;
+  const double nynz = ny * nz;
+
+  // Rotation matrix
+  QgsMatrix4x4 rot;
+  rot.m[0][0] = angleCosInv * nx * nx + angleCos;
+  rot.m[0][1] = angleCosInv * nxny + nz * angleSin;
+  rot.m[0][2] = angleCosInv * nxnz - ny * angleSin;
+  rot.m[0][3] = 0.0;
+
+  rot.m[1][0] = angleCosInv * nxny - nz * angleSin;
+  rot.m[1][1] = angleCosInv * ny * ny + angleCos;
+  rot.m[1][2] = angleCosInv * nynz + nx * angleSin;
+  rot.m[1][3] = 0.0;
+
+  rot.m[2][0] = angleCosInv * nxnz + ny * angleSin;
+  rot.m[2][1] = angleCosInv * nynz - nx * angleSin;
+  rot.m[2][2] = angleCosInv * nz * nz + angleCos;
+  rot.m[2][3] = 0.0;
+
+  rot.m[3][0] = 0.0;
+  rot.m[3][1] = 0.0;
+  rot.m[3][2] = 0.0;
+  rot.m[3][3] = 1.0;
+
+  *this = *this * rot;
+}
+
+void QgsMatrix4x4::rotate( double angle, const QgsVector3D &vector )
+{
+  rotate( angle, vector.x(), vector.y(), vector.z() );
+}

--- a/src/core/qgsmatrix4x4.cpp
+++ b/src/core/qgsmatrix4x4.cpp
@@ -138,3 +138,21 @@ QgsMatrix4x4 operator*( const QgsMatrix4x4 &m1, const QgsMatrix4x4 &m2 )
   m.m[3][3] = m1.m[0][3] * m2.m[3][0] + m1.m[1][3] * m2.m[3][1] + m1.m[2][3] * m2.m[3][2] + m1.m[3][3] * m2.m[3][3];
   return m;
 }
+
+void QgsMatrix4x4::scale( const QgsVector3D &vector )
+{
+  m[0][0] *= vector.x();
+  m[0][1] *= vector.x();
+  m[0][2] *= vector.x();
+  m[0][3] *= vector.x();
+
+  m[1][0] *= vector.y();
+  m[1][1] *= vector.y();
+  m[1][2] *= vector.y();
+  m[1][3] *= vector.y();
+
+  m[2][0] *= vector.z();
+  m[2][1] *= vector.z();
+  m[2][2] *= vector.z();
+  m[2][3] *= vector.z();
+}

--- a/src/core/qgsmatrix4x4.h
+++ b/src/core/qgsmatrix4x4.h
@@ -99,6 +99,22 @@ class CORE_EXPORT QgsMatrix4x4
      */
     void scale( const QgsVector3D &vector );
 
+    /**
+     * Multiples this matrix by another that rotates coordinates through
+     * \a angle degrees about the vector (\a x, \a y, \a z).
+     *
+     * \since QGIS 4.2
+     */
+    void rotate( double angle, double x, double y, double z );
+
+    /**
+     * Multiples this matrix by another that rotates coordinates through
+     * \a angle degrees about \a vector.
+     *
+     * \since QGIS 4.2
+     */
+    void rotate( double angle, const QgsVector3D &vector );
+
 #ifdef SIP_RUN
 // clang-format off
     SIP_PYOBJECT __repr__();

--- a/src/core/qgsmatrix4x4.h
+++ b/src/core/qgsmatrix4x4.h
@@ -92,6 +92,13 @@ class CORE_EXPORT QgsMatrix4x4
     //! Sets matrix to be identity matrix
     void setToIdentity() SIP_HOLDGIL;
 
+    /**
+     * Multiplies this matrix by another that scales coordinates by the components of a \a vector.
+     *
+     * \since QGIS 4.2
+     */
+    void scale( const QgsVector3D &vector );
+
 #ifdef SIP_RUN
 // clang-format off
     SIP_PYOBJECT __repr__();

--- a/tests/src/core/geometry/testqgssfcgal.cpp
+++ b/tests/src/core/geometry/testqgssfcgal.cpp
@@ -38,6 +38,7 @@ using namespace Qt::StringLiterals;
 #include "qgsgeometry.h"
 #include "qgstriangulatedsurface.h"
 #include "qgslinestring.h"
+#include "qgsmatrix4x4.h"
 #include "qgspolygon.h"
 #include "qgsgeometryengine.h"
 #include "qgscircle.h"
@@ -112,12 +113,12 @@ class TestQgsSfcgal : public QgsTest
 
     std::unique_ptr<QgsSfcgalGeometry> openWktFile( const QString &wktFile );
 
-    inline bool qFuzzyCompare2( float f1, float f2, float epsilon = 0.000001 ) { return std::abs( f1 - f2 ) < epsilon; }
+    inline bool qFuzzyCompare2( double f1, double f2, double epsilon = 0.000001 ) { return std::abs( f1 - f2 ) < epsilon; }
 
-    inline bool qFuzzyCompare2( const QMatrix4x4 &m1, const QMatrix4x4 &m2, float epsilon = 0.000001 )
+    inline bool qFuzzyCompare2( const QgsMatrix4x4 &m1, const QgsMatrix4x4 &m2, float epsilon = 0.000001 )
     {
-      const float *d1 = m1.data();
-      const float *d2 = m2.data();
+      const double *d1 = m1.constData();
+      const double *d2 = m2.constData();
       return qFuzzyCompare2( d1[0 * 4 + 0], d2[0 * 4 + 0], epsilon )
              && qFuzzyCompare2( d1[0 * 4 + 1], d2[0 * 4 + 1], epsilon )
              && qFuzzyCompare2( d1[0 * 4 + 2], d2[0 * 4 + 2], epsilon )
@@ -1144,7 +1145,7 @@ void TestQgsSfcgal::primitiveCube()
 
   // check translate
   std::unique_ptr<QgsSfcgalGeometry> cubeT = cube->translate( { 1.0, 2.0, 3.0 } );
-  QCOMPARE( cubeT->primitiveTransform(), QMatrix4x4( 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 2.0, 0.0, 0.0, 1.0, 3.0, 0.0, 0.0, 0.0, 1.0 ) );
+  QCOMPARE( cubeT->primitiveTransform(), QgsMatrix4x4( 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 2.0, 0.0, 0.0, 1.0, 3.0, 0.0, 0.0, 0.0, 1.0 ) );
   QCOMPARE(
     cubeT->asWkt( 0 ),
     u"POLYHEDRALSURFACE Z (((1 2 3,1 7 3,6 7 3,6 2 3,1 2 3)),"
@@ -1157,9 +1158,9 @@ void TestQgsSfcgal::primitiveCube()
 
   // check rotate
   std::unique_ptr<QgsSfcgalGeometry> cubeR = cube->rotate3D( M_PI / 2.0, { 0.0, 0.0, 1.0 }, { 0.0, 0.0, 0.0 } );
-  QVERIFY( qFuzzyCompare2( cubeR->primitiveTransform(), QMatrix4x4( -1.0e-07, -1.0, 0.0, 0.0, 1.0, -1.0e-07, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ) ) );
+  QVERIFY( qFuzzyCompare2( cubeR->primitiveTransform(), QgsMatrix4x4( -1.0e-07, -1.0, 0.0, 0.0, 1.0, -1.0e-07, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ) ) );
   cubeR = cube->rotate3D( M_PI / 2.0, { 0.0, 0.0, 1.0 }, { 1.0, 2.0, 3.0 } );
-  QVERIFY( qFuzzyCompare2( cubeR->primitiveTransform(), QMatrix4x4( -1.0e-07, -1.0, 0.0, -3.0, 1.0, -1.0e-07, 0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ) ) );
+  QVERIFY( qFuzzyCompare2( cubeR->primitiveTransform(), QgsMatrix4x4( -1.0e-07, -1.0, 0.0, -3.0, 1.0, -1.0e-07, 0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ) ) );
   QCOMPARE(
     cubeR->asWkt( 0 ),
     u"POLYHEDRALSURFACE Z (((-3 -1 0,-8 -1 0,-8 4 0,-3 4 0,-3 -1 0)),"
@@ -1172,9 +1173,9 @@ void TestQgsSfcgal::primitiveCube()
 
   // check scale
   std::unique_ptr<QgsSfcgalGeometry> cubeS = cube->scale( { 1.0, 2.0, 3.0 }, { 0.0, 0.0, 0.0 } );
-  QCOMPARE( cubeS->primitiveTransform(), QMatrix4x4( 1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 0.0, 1.0 ) );
+  QCOMPARE( cubeS->primitiveTransform(), QgsMatrix4x4( 1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 0.0, 1.0 ) );
   cubeS = cube->scale( { 1.0, 2.0, 3.0 }, { 1.0, 2.0, 3.0 } );
-  QCOMPARE( cubeS->primitiveTransform(), QMatrix4x4( 1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 2.0, 0.0, 0.0, 3.0, 6.0, 0.0, 0.0, 0.0, 1.0 ) );
+  QCOMPARE( cubeS->primitiveTransform(), QgsMatrix4x4( 1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 2.0, 0.0, 0.0, 3.0, 6.0, 0.0, 0.0, 0.0, 1.0 ) );
   QCOMPARE(
     cubeS->asWkt( 0 ),
     u"POLYHEDRALSURFACE Z (((0 2 6,0 12 6,5 12 6,5 2 6,0 2 6)),"

--- a/tests/src/core/geometry/testqgssfcgal.cpp
+++ b/tests/src/core/geometry/testqgssfcgal.cpp
@@ -1156,9 +1156,9 @@ void TestQgsSfcgal::primitiveCube()
   );
 
   // check rotate
-  std::unique_ptr<QgsSfcgalGeometry> cubeR = cube->rotate3D( 90, { 0.0, 0.0, 1.0 }, { 0.0, 0.0, 0.0 } );
+  std::unique_ptr<QgsSfcgalGeometry> cubeR = cube->rotate3D( M_PI / 2.0, { 0.0, 0.0, 1.0 }, { 0.0, 0.0, 0.0 } );
   QVERIFY( qFuzzyCompare2( cubeR->primitiveTransform(), QMatrix4x4( -1.0e-07, -1.0, 0.0, 0.0, 1.0, -1.0e-07, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ) ) );
-  cubeR = cube->rotate3D( 90, { 0.0, 0.0, 1.0 }, { 1.0, 2.0, 3.0 } );
+  cubeR = cube->rotate3D( M_PI / 2.0, { 0.0, 0.0, 1.0 }, { 1.0, 2.0, 3.0 } );
   QVERIFY( qFuzzyCompare2( cubeR->primitiveTransform(), QMatrix4x4( -1.0e-07, -1.0, 0.0, -3.0, 1.0, -1.0e-07, 0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ) ) );
   QCOMPARE(
     cubeR->asWkt( 0 ),

--- a/tests/src/python/test_qgsmatrix4x4.py
+++ b/tests/src/python/test_qgsmatrix4x4.py
@@ -12,6 +12,7 @@ __author__ = "(C) 2023 by Martin Dobias"
 __date__ = "18/07/2023"
 __copyright__ = "Copyright 2023, The QGIS Project"
 
+import math
 import unittest
 
 from qgis.core import (
@@ -191,6 +192,84 @@ class TestQgsMatrix4x4(QgisTestCase):
                 1.0,
             ],
         )
+
+    def test_rotate(self):
+        """
+        Test rotating a matrix
+        """
+        mat = QgsMatrix4x4()
+        mat2 = QgsMatrix4x4()
+        self.assertAlmostEqual(mat, mat2)
+        mat.rotate(90.0, QgsVector3D(0, 1, 0))
+        result = mat.data()
+        expected_result = [
+            0.0,
+            0.0,
+            -1.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+        ]
+        for value, expected in zip(result, expected_result):
+            self.assertAlmostEqual(value, expected)
+
+        mat2.rotate(90.0, 0, 1, 0)
+        self.assertAlmostEqual(mat, mat2)
+
+        mat = QgsMatrix4x4(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 0, 0, 1)
+        mat2 = mat
+        self.assertAlmostEqual(mat, mat2)
+
+        mat.rotate(45, QgsVector3D(1, 0, 0))
+        result = mat.data()
+        expected_result = [
+            1.0,
+            5.0,
+            9.0,
+            0.0,
+            5.0 * math.sqrt(2) / 2.0,
+            13.0 * math.sqrt(2) / 2.0,
+            21.0 * math.sqrt(2) / 2.0,
+            0.0,
+            math.sqrt(2) / 2.0,
+            math.sqrt(2) / 2.0,
+            math.sqrt(2) / 2.0,
+            0.0,
+            4.0,
+            8.0,
+            12.0,
+            1.0,
+        ]
+        for value, expected in zip(result, expected_result):
+            self.assertAlmostEqual(value, expected)
+
+        mat2.rotate(45, 1, 0, 0)
+        self.assertAlmostEqual(mat, mat2)
+
+        # combine rotation and translation
+        mat = QgsMatrix4x4()
+        mat.translate(QgsVector3D(5, 1, -2))
+        self.assertEqual(mat.data(), [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 1, -2, 1])
+
+        mat.rotate(90.0, 0, 0, 1)
+        expected_result = [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 5, 1, -2, 1]
+        for value, expected in zip(mat.data(), expected_result):
+            self.assertAlmostEqual(value, expected)
+
+        mat.translate(QgsVector3D(-1, 5, 2))
+        expected_result = [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+        for value, expected in zip(mat.data(), expected_result):
+            self.assertAlmostEqual(value, expected)
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsmatrix4x4.py
+++ b/tests/src/python/test_qgsmatrix4x4.py
@@ -139,6 +139,59 @@ class TestQgsMatrix4x4(QgisTestCase):
             ],
         )
 
+    def test_scale(self):
+        """
+        Test scaling a matrix
+        """
+        mat = QgsMatrix4x4()
+        mat.scale(QgsVector3D(2, 3, 5))
+        self.assertEqual(
+            mat.data(),
+            [
+                2.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                3.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                5.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+            ],
+        )
+
+        mat = QgsMatrix4x4(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 0, 0, 1)
+
+        mat.scale(QgsVector3D(0.5, 2, 1))
+        self.assertEqual(
+            mat.data(),
+            [
+                0.5,
+                2.5,
+                4.5,
+                0.0,
+                4.0,
+                12.0,
+                20.0,
+                0.0,
+                3.0,
+                7.0,
+                11.0,
+                0.0,
+                4.0,
+                8.0,
+                12.0,
+                1.0,
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

SFCGAL API expects double value for transformations. However, `SfCGALEngine` uses float internally with a loss of precision. This is fixed by switching from `QMatrix4x4` to `QgsMatrix4x4` for transform operations and storage. This is achieved by adding support for `scale` and `rotate` in `QgsMatrix4x4`.

This PR also fixes a missing radians -> degrees conversion in `QgsSfcgalGeometry::setPrimitiveRotation`

## AI tool usage

 no AI tool used