### PR TITLE
Follow up recent cache Vary response handling

### DIFF
--- a/src/core/network/qgsnetworkaccessmanager.cpp
+++ b/src/core/network/qgsnetworkaccessmanager.cpp
@@ -412,9 +412,17 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
       // on the version in the cache
       if ( diskCache->hasInvalidMatchForRequest( modifiedRequest ) )
       {
-        // can't use the previously cached response for this request, so explicitly block that
-        modifiedRequest.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
-        modifiedRequest.setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
+        if ( modifiedRequest.attribute( QNetworkRequest::CacheSaveControlAttribute ).toBool() )
+        {
+          // evict the previous invalid response, so this response will be cached
+          diskCache->remove( modifiedRequest.url() );
+        }
+        else
+        {
+          // can't use the previously cached response for this request, so explicitly block that
+          modifiedRequest.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork );
+          modifiedRequest.setAttribute( QNetworkRequest::CacheSaveControlAttribute, false );
+        }
       }
     }
 

--- a/tests/src/python/test_qgsnetworkaccessmanager.py
+++ b/tests/src/python/test_qgsnetworkaccessmanager.py
@@ -597,6 +597,48 @@ class TestQgsNetworkAccessManager(QgisTestCase):
         self.assertFalse(
             reply.attribute(QNetworkRequest.Attribute.SourceIsFromCacheAttribute)
         )
+        # but should have been stored in the cache, evicting the original vary response
+        reply = QgsNetworkAccessManager.instance().blockingGet(request)
+        self.assertTrue(
+            reply.attribute(QNetworkRequest.Attribute.SourceIsFromCacheAttribute)
+        )
+
+        # original response should have been evicted from cache, but in turn
+        # evict the Bearer response from the cache
+        request.setRawHeader(b"Authorization", b"")
+        reply = QgsNetworkAccessManager.instance().blockingGet(request)
+        self.assertFalse(
+            reply.attribute(QNetworkRequest.Attribute.SourceIsFromCacheAttribute)
+        )
+        reply = QgsNetworkAccessManager.instance().blockingGet(request)
+        self.assertTrue(
+            reply.attribute(QNetworkRequest.Attribute.SourceIsFromCacheAttribute)
+        )
+
+        # if a new request with a different Authorization header is set NOT to
+        # save the result in cache, then we shouldn't evict the previous
+        # non-matching response
+        request.setRawHeader(b"Authorization", b"Bearer: mytoken")
+        request.setAttribute(QNetworkRequest.Attribute.CacheSaveControlAttribute, False)
+        # can't use blockingGet here -- that always sets CacheSaveControlAttribute to True!
+        reply = QgsNetworkAccessManager.instance().get(request)
+        wait_spy = QSignalSpy(reply.finished)
+        wait_spy.wait()
+        self.assertFalse(
+            reply.attribute(QNetworkRequest.Attribute.SourceIsFromCacheAttribute)
+        )
+        reply = QgsNetworkAccessManager.instance().get(request)
+        wait_spy = QSignalSpy(reply.finished)
+        wait_spy.wait()
+        self.assertFalse(
+            reply.attribute(QNetworkRequest.Attribute.SourceIsFromCacheAttribute)
+        )
+        # we shouldn't have evicted this reply, can still retrieve it from cache
+        request.setRawHeader(b"Authorization", b"")
+        reply = QgsNetworkAccessManager.instance().blockingGet(request)
+        self.assertTrue(
+            reply.attribute(QNetworkRequest.Attribute.SourceIsFromCacheAttribute)
+        )
 
     def test_cache_control_vary_accept(self):
         """


### PR DESCRIPTION
Instead of completely skipping the cache for a new request where the previously cached response was for a non-matching Vary attribute, now we force evict the old reply from the cache.

The previous behavior meant that only the FIRST value for the varied attribute would ever be cached. Now we always cache the MOST RECENTLY requested value for the varied attribute.
