### PR TITLE
qgsbox3d: fix toString method for the empty case

### DIFF
--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -341,8 +341,6 @@ QString QgsBox3D::toString( int precision ) const
 
   if ( isNull() )
     rep = u"Null"_s;
-  else if ( isEmpty() )
-    rep = u"Empty"_s;
   else
     rep = u"%1,%2,%3 : %4,%5,%6"_s.arg( mBounds2d.xMinimum(), 0, 'f', precision )
             .arg( mBounds2d.yMinimum(), 0, 'f', precision )

--- a/tests/src/python/test_qgsbox3d.py
+++ b/tests/src/python/test_qgsbox3d.py
@@ -515,13 +515,28 @@ class TestQgsBox3d(unittest.TestCase):
 
     def testToString(self):
         box1 = QgsBox3d()
+        self.assertTrue(box1.isNull())
         self.assertEqual(box1.toString(), "Null")
 
         box2 = QgsBox3d(0, 0, 0, 0, 0, 0)
-        self.assertEqual(box2.toString(), "Empty")
+        self.assertTrue(box2.isEmpty())
+        self.assertEqual(
+            box2.toString(),
+            (
+                "0.0000000000000000,0.0000000000000000,0.0000000000000000 : "
+                "0.0000000000000000,0.0000000000000000,0.0000000000000000"
+            ),
+        )
 
         box3 = QgsBox3d(1, 1, 1, 1, 1, 1)
-        self.assertEqual(box3.toString(), "Empty")
+        self.assertTrue(box3.isEmpty())
+        self.assertEqual(
+            box3.toString(),
+            (
+                "1.0000000000000000,1.0000000000000000,1.0000000000000000 : "
+                "1.0000000000000000,1.0000000000000000,1.0000000000000000"
+            ),
+        )
 
         box4 = QgsBox3d(1, 2, 3, 4, 5, 6)
         self.assertEqual(


### PR DESCRIPTION
## Description

`QgsBox3d::toString()` was introduced in
06a09f83f31ae39e23ff860c4502eb425a14f14b to reproduce `QgsRectangle`
behavior. However, QgsRectangle::toString() behavior was changed
shortly after to fix `isEmpty()`.
`QgsRectangle::toString()` now returns a full string when it is empty.

This change changes `QgsBox3d::toString()` behavior to match the
`QgsRectangle` one.

See: https://github.com/qgis/QGIS/pull/54646

## AI tool usage

 No AI tool used


cc @benoitdm-oslandia @strk 
