### PR TITLE
Fix loss of data defined marker/line symbol layer size changes

### DIFF
--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -102,14 +102,14 @@ void DataDefinedRestorer::save()
 
 void DataDefinedRestorer::restore()
 {
-  if ( mMarker )
+  if ( mMarker && mMarker->symbolLayerCount() > 1 )
   {
     if ( mDDSize && ( mSize != mMarkerSymbolLayer->size() || mMarkerOffset != mMarkerSymbolLayer->offset() ) )
       mMarker->setDataDefinedSize( mDDSize );
     if ( mDDAngle && mAngle != mMarkerSymbolLayer->angle() )
       mMarker->setDataDefinedAngle( mDDAngle );
   }
-  else if ( mLine )
+  else if ( mLine && mLine->symbolLayerCount() > 1 )
   {
     if ( mDDWidth && ( mWidth != mLineSymbolLayer->width() || mLineOffset != mLineSymbolLayer->offset() ) )
       mLine->setDataDefinedWidth( mDDWidth );


### PR DESCRIPTION
This pattern of events can lead to old data defined expressions resurrecting themselves:

1. Create a marker symbol
2. Go to the first (only) symbol layer's settings, set an expression for data-defined size
3. do some other stuff, then go back to changing that symbol's settings
4. Go to the first (only) symbol layer's settings, CHANGE the data defined size expression.
5. Make some other change in the widget (eg change the fixed size value)
6. Click somewhere else to dismiss the symbol layer widget, eg go back up to the top-level symbol settings

The changes to the data defined size expression are lost, and the old version keeps resurrecting itself.

Hack around this by disabling the strange logic which explicitly restores the old value when a symbol only has a single layer.

This strange logic was introduced in https://github.com/qgis/QGIS/pull/2167, and is intended to auto-scale any child symbol layer data-defined size expressions to match changes in the overall marker symbol's size. The logic is rather broken though (eg, resulting in the silent loss of expression changes described above). It's also questionable if this logic is desirable in the first place.

But it's also 11 year old logic, so I'm reluctant to just rip it out. Instead, disable it when a symbol only has a SINGLE layer, so at least the impact of the bug is removed in a case where the original logic makes no sense anyway.

(Note that there's remaining issues with the 11 yo fix, because I can also get expression change loss when editing data defined scale expressions on multi-layer symbols)
