### PR TITLE
Fix crash when double clicking on welcome page recent projects / template projects items

### DIFF
--- a/src/app/qgswelcomescreen.cpp
+++ b/src/app/qgswelcomescreen.cpp
@@ -26,6 +26,7 @@
 #include <QMessageBox>
 #include <QQmlContext>
 #include <QString>
+#include <QTimer>
 #include <QUrl>
 #include <QVBoxLayout>
 
@@ -43,22 +44,26 @@ QgsWelcomeScreenController::QgsWelcomeScreenController( QgsWelcomeScreen *welcom
 
 void QgsWelcomeScreenController::openProject( const QString &path )
 {
-  QgisApp::instance()->openProject( path );
+  // QTimer needed to prevent crashes when the Item bound to the calling function is deleted by the ListView
+  QTimer::singleShot( 1, this, [path]() { QgisApp::instance()->openProject( path ); } );
 }
 
 void QgsWelcomeScreenController::createBlankProject()
 {
-  QgisApp::instance()->newProject();
+  // QTimer needed to prevent crashes when the Item bound to the calling function is deleted by the ListView
+  QTimer::singleShot( 1, this, []() { QgisApp::instance()->newProject(); } );
 }
 
 void QgsWelcomeScreenController::createProjectFromBasemap()
 {
-  QgisApp::instance()->fileNewWithBasemap();
+  // QTimer needed to prevent crashes when the Item bound to the calling function is deleted by the ListView
+  QTimer::singleShot( 1, this, []() { QgisApp::instance()->fileNewWithBasemap(); } );
 }
 
 void QgsWelcomeScreenController::createProjectFromTemplate( const QString &path )
 {
-  QgisApp::instance()->fileNewFromTemplate( path );
+  // QTimer needed to prevent crashes when the Item bound to the calling function is deleted by the ListView
+  QTimer::singleShot( 1, this, [path]() { QgisApp::instance()->fileNewFromTemplate( path ); } );
 }
 
 void QgsWelcomeScreenController::clearRecentProjects()

--- a/src/app/qml/WelcomeScreen.qml
+++ b/src/app/qml/WelcomeScreen.qml
@@ -151,6 +151,7 @@ Item {
                 onClicked: (mouse) => {
                              if (mouse.button == Qt.LeftButton && isEnabled) {
                                welcomeScreenController.openProject(ProjectPath);
+                               welcomeScreenController.hideScene();
                              } else if (mouse.button == Qt.RightButton) {
                                recentProjectsMenu.projectIndex = index;
                                recentProjectsMenu.projectPinned = Pinned;
@@ -318,12 +319,15 @@ Item {
                     switch (Type) {
                     case TemplateProjectsModel.TemplateType.Blank:
                       welcomeScreenController.createBlankProject(); //#spellok
+                      welcomeScreenController.hideScene();
                       return;
                     case TemplateProjectsModel.TemplateType.Basemap:
                       welcomeScreenController.createProjectFromBasemap();
+                      welcomeScreenController.hideScene();
                       return;
                     default:
                       welcomeScreenController.createProjectFromTemplate(TemplateNativePath || ""); //#spellok
+                      welcomeScreenController.hideScene();
                       return;
                     }
                   } else if (mouse.button == Qt.RightButton) {


### PR DESCRIPTION
## Description

This most likely fixes https://github.com/qgis/QGIS/issues/65421 -- I could not replicate the crash as described (maybe my finger clicks are not fast enough? ;)) but I was able to create a crash condition by adding a second dummy QgisApp::instance()->openProject(path); after the first one, which I think hits the same root cause.