### PR TITLE
fix: Measure dialog repositioning on canvas click with Qt6

### DIFF
--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -225,19 +225,7 @@ void QgsMeasureTool::canvasReleaseEvent( QgsMapMouseEvent *e )
     addPoint( point );
   }
 
-#if QT_VERSION >= QT_VERSION_CHECK( 6, 7, 0 ) && QT_VERSION < QT_VERSION_CHECK( 6, 9, 3 )
-  // Workaround for QTBUG-139291 (Qt 6.7.0 – 6.9.2): QDialog::setVisible() bypasses
-  // QWidget::setVisible(), so WA_WState_ExplicitShowHide is never set. This causes
-  // every show() call on an already-visible dialog to emit QShowEvent, which triggers
-  // QgsWidgetStateHelper::restoreGeometry() and repositions the dialog.
-  // Fixed in Qt 6.9.3 (commit c0abf94edb8).
-  if ( !mDialog->isVisible() )
-    mDialog->show();
-  else
-    mDialog->raise();
-#else
   mDialog->show();
-#endif
 }
 
 void QgsMeasureTool::undo()

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -225,7 +225,19 @@ void QgsMeasureTool::canvasReleaseEvent( QgsMapMouseEvent *e )
     addPoint( point );
   }
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 7, 0 ) && QT_VERSION < QT_VERSION_CHECK( 6, 9, 3 )
+  // Workaround for QTBUG-139291 (Qt 6.7.0 – 6.9.2): QDialog::setVisible() bypasses
+  // QWidget::setVisible(), so WA_WState_ExplicitShowHide is never set. This causes
+  // every show() call on an already-visible dialog to emit QShowEvent, which triggers
+  // QgsWidgetStateHelper::restoreGeometry() and repositions the dialog.
+  // Fixed in Qt 6.9.3 (commit c0abf94edb8).
+  if ( !mDialog->isVisible() )
+    mDialog->show();
+  else
+    mDialog->raise();
+#else
   mDialog->show();
+#endif
 }
 
 void QgsMeasureTool::undo()

--- a/src/gui/qgswidgetstatehelper_p.cpp
+++ b/src/gui/qgswidgetstatehelper_p.cpp
@@ -50,10 +50,6 @@ bool QgsWidgetStateHelper::eventFilter( QObject *object, QEvent *event )
     QWidget *widget = qobject_cast<QWidget *>( object );
 
     // Skip geometry restore if the widget has already been shown once.
-    // Workaround for QTBUG-139291 (Qt 6.7.0 – 6.9.2): QDialog::setVisible() bypasses
-    // QWidget::setVisible(), so WA_WState_ExplicitShowHide is never set. This causes
-    // every show() on an already-visible QDialog to emit a spurious QShowEvent, which
-    // would re-restore the saved geometry and reposition the window.
     if ( widget->property( "widgetStateHelperWasShown" ).toBool() )
       return QObject::eventFilter( object, event );
 

--- a/src/gui/qgswidgetstatehelper_p.cpp
+++ b/src/gui/qgswidgetstatehelper_p.cpp
@@ -42,11 +42,21 @@ bool QgsWidgetStateHelper::eventFilter( QObject *object, QEvent *event )
       const QString name = widgetSafeName( widget );
       const QString key = mKeys[name];
       QgsGuiUtils::saveGeometry( widget, key );
+      widget->setProperty( "widgetStateHelperWasShown", QVariant( false ) );
     }
   }
   else if ( event->type() == QEvent::Show )
   {
     QWidget *widget = qobject_cast<QWidget *>( object );
+
+    // Skip geometry restore if the widget has already been shown once.
+    // Workaround for QTBUG-139291 (Qt 6.7.0 – 6.9.2): QDialog::setVisible() bypasses
+    // QWidget::setVisible(), so WA_WState_ExplicitShowHide is never set. This causes
+    // every show() on an already-visible QDialog to emit a spurious QShowEvent, which
+    // would re-restore the saved geometry and reposition the window.
+    if ( widget->property( "widgetStateHelperWasShown" ).toBool() )
+      return QObject::eventFilter( object, event );
+
     const QString name = widgetSafeName( widget );
 
     // If window is already maximized by Window Manager,


### PR DESCRIPTION
Hello QGIS developers, I am happy to share with you my first contribution. Despite it's a small one, it fixes a really annoying bug.

## Description

The measure dialog was repositioning to the center on every canvas click with Qt6, while it worked fine with Qt5.
Calling `show()` on an already visible dialog in `canvasReleaseEvent()` causes the issue. In Qt6, this triggers a `QEvent::Show` even when the window is already shown, which causes `QgsWidgetStateHelper` to restore the saved geometry.

The fix checks if the dialog is visible before calling `show()`, and uses `raise()` instead to bring it to front without triggering geometry restoration.

I don't think this fix need to be backported because the issue only happen on Qt6 builds.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

## Technical

This PR fix the issue : #62919