### PR TITLE
Fix @geometry and $geometry different results for geometry generator

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -287,7 +287,26 @@ static QVariant fcnGenerateSeries( const QVariantList &values, const QgsExpressi
   return array;
 }
 
-static QVariant fcnGetVariable( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnGeometry( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * )
+{
+  if ( !context )
+    return QVariant();
+
+  // prefer geometry from context if it's present, otherwise fallback to context's feature's geometry
+  if ( context->hasGeometry() )
+    return context->geometry();
+  else
+  {
+    FEAT_FROM_CONTEXT( context, f )
+    QgsGeometry geom = f.geometry();
+    if ( !geom.isNull() )
+      return  QVariant::fromValue( geom );
+    else
+      return QVariant();
+  }
+}
+
+static QVariant fcnGetVariable( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction *node )
 {
   if ( !context )
     return QVariant();
@@ -304,11 +323,7 @@ static QVariant fcnGetVariable( const QVariantList &values, const QgsExpressionC
   }
   else if ( name == QLatin1String( "geometry" ) )
   {
-    if ( !context->hasFeature() )
-      return QVariant();
-
-    const QgsFeature feature = context->feature();
-    return feature.hasGeometry() ? QVariant::fromValue( feature.geometry() ) : QVariant();
+    return fcnGeometry( values, context, parent, node );
   }
   else
   {
@@ -4255,26 +4270,6 @@ static QVariant fcnMat( const QVariantList &values, const QgsExpressionContext *
     return QVariant( v.value<QgsPoint>().m() );
   else
     return QVariant();
-}
-
-
-static QVariant fcnGeometry( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * )
-{
-  if ( !context )
-    return QVariant();
-
-  // prefer geometry from context if it's present, otherwise fallback to context's feature's geometry
-  if ( context->hasGeometry() )
-    return context->geometry();
-  else
-  {
-    FEAT_FROM_CONTEXT( context, f )
-    QgsGeometry geom = f.geometry();
-    if ( !geom.isNull() )
-      return  QVariant::fromValue( geom );
-    else
-      return QVariant();
-  }
 }
 
 static QVariant fcnGeomFromWKT( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -6202,25 +6202,25 @@ class TestQgsExpression : public QObject
     {
       QgsExpressionContext context;
 
-      QgsExpression exp = QgsExpression( u"$geometry"_s );
+      QgsExpression exp = QgsExpression( QStringLiteral( "$geometry" ) );
       QVERIFY( exp.prepare( &context ) );
       QVERIFY( !exp.hasEvalError() );
       QVERIFY( QgsVariantUtils::isNull( exp.evaluate( &context ) ) );
-      exp = QgsExpression( u"@geometry"_s );
+      exp = QgsExpression( QStringLiteral( "@geometry" ) );
       QVERIFY( exp.prepare( &context ) );
       QVERIFY( !exp.hasEvalError() );
       QVERIFY( QgsVariantUtils::isNull( exp.evaluate( &context ) ) );
 
       // using geometry directly set on context
       context.setGeometry( QgsGeometry::fromPoint( QgsPoint( 1, 2 ) ) );
-      exp = QgsExpression( u"geom_to_wkt($geometry)"_s );
+      exp = QgsExpression( QStringLiteral( "geom_to_wkt($geometry)" ) );
       QVERIFY( exp.prepare( &context ) );
       QVERIFY( !exp.hasEvalError() );
-      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (1 2)"_s );
-      exp = QgsExpression( u"geom_to_wkt(@geometry)"_s );
+      QCOMPARE( exp.evaluate( &context ).toString(), QStringLiteral( "Point (1 2)" ) );
+      exp = QgsExpression( QStringLiteral( "geom_to_wkt(@geometry)" ) );
       QVERIFY( exp.prepare( &context ) );
       QVERIFY( !exp.hasEvalError() );
-      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (1 2)"_s );
+      QCOMPARE( exp.evaluate( &context ).toString(), QStringLiteral( "Point (1 2)" ) );
 
       // using geometry via feature
 
@@ -6228,25 +6228,25 @@ class TestQgsExpression : public QObject
       QgsFeature f;
       f.setGeometry( QgsGeometry::fromPoint( QgsPoint( 11, 22 ) ) );
       context.setFeature( f );
-      exp = QgsExpression( u"geom_to_wkt($geometry)"_s );
+      exp = QgsExpression( QStringLiteral( "geom_to_wkt($geometry)" ) );
       QVERIFY( exp.prepare( &context ) );
       QVERIFY( !exp.hasEvalError() );
-      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (11 22)"_s );
-      exp = QgsExpression( u"geom_to_wkt(@geometry)"_s );
+      QCOMPARE( exp.evaluate( &context ).toString(), QStringLiteral( "Point (11 22)" ) );
+      exp = QgsExpression( QStringLiteral( "geom_to_wkt(@geometry)" ) );
       QVERIFY( exp.prepare( &context ) );
       QVERIFY( !exp.hasEvalError() );
-      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (11 22)"_s );
+      QCOMPARE( exp.evaluate( &context ).toString(), QStringLiteral( "Point (11 22)" ) );
 
       // geometry set directly should take precedence over the geometry from the feature
       context.setGeometry( QgsGeometry::fromPoint( QgsPoint( 1, 2 ) ) );
-      exp = QgsExpression( u"geom_to_wkt($geometry)"_s );
+      exp = QgsExpression( QStringLiteral( "geom_to_wkt($geometry)" ) );
       QVERIFY( exp.prepare( &context ) );
       QVERIFY( !exp.hasEvalError() );
-      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (1 2)"_s );
-      exp = QgsExpression( u"geom_to_wkt(@geometry)"_s );
+      QCOMPARE( exp.evaluate( &context ).toString(), QStringLiteral( "Point (1 2)" ) );
+      exp = QgsExpression( QStringLiteral( "geom_to_wkt(@geometry)" ) );
       QVERIFY( exp.prepare( &context ) );
       QVERIFY( !exp.hasEvalError() );
-      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (1 2)"_s );
+      QCOMPARE( exp.evaluate( &context ).toString(), QStringLiteral( "Point (1 2)" ) );
     }
 };
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -6197,6 +6197,57 @@ class TestQgsExpression : public QObject
 
       QCOMPARE( QgsExpressionNodeLiteral( value ).dump(), expected );
     }
+
+    void testGeometryRetrieval()
+    {
+      QgsExpressionContext context;
+
+      QgsExpression exp = QgsExpression( u"$geometry"_s );
+      QVERIFY( exp.prepare( &context ) );
+      QVERIFY( !exp.hasEvalError() );
+      QVERIFY( QgsVariantUtils::isNull( exp.evaluate( &context ) ) );
+      exp = QgsExpression( u"@geometry"_s );
+      QVERIFY( exp.prepare( &context ) );
+      QVERIFY( !exp.hasEvalError() );
+      QVERIFY( QgsVariantUtils::isNull( exp.evaluate( &context ) ) );
+
+      // using geometry directly set on context
+      context.setGeometry( QgsGeometry::fromPoint( QgsPoint( 1, 2 ) ) );
+      exp = QgsExpression( u"geom_to_wkt($geometry)"_s );
+      QVERIFY( exp.prepare( &context ) );
+      QVERIFY( !exp.hasEvalError() );
+      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (1 2)"_s );
+      exp = QgsExpression( u"geom_to_wkt(@geometry)"_s );
+      QVERIFY( exp.prepare( &context ) );
+      QVERIFY( !exp.hasEvalError() );
+      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (1 2)"_s );
+
+      // using geometry via feature
+
+      context = QgsExpressionContext();
+      QgsFeature f;
+      f.setGeometry( QgsGeometry::fromPoint( QgsPoint( 11, 22 ) ) );
+      context.setFeature( f );
+      exp = QgsExpression( u"geom_to_wkt($geometry)"_s );
+      QVERIFY( exp.prepare( &context ) );
+      QVERIFY( !exp.hasEvalError() );
+      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (11 22)"_s );
+      exp = QgsExpression( u"geom_to_wkt(@geometry)"_s );
+      QVERIFY( exp.prepare( &context ) );
+      QVERIFY( !exp.hasEvalError() );
+      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (11 22)"_s );
+
+      // geometry set directly should take precedence over the geometry from the feature
+      context.setGeometry( QgsGeometry::fromPoint( QgsPoint( 1, 2 ) ) );
+      exp = QgsExpression( u"geom_to_wkt($geometry)"_s );
+      QVERIFY( exp.prepare( &context ) );
+      QVERIFY( !exp.hasEvalError() );
+      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (1 2)"_s );
+      exp = QgsExpression( u"geom_to_wkt(@geometry)"_s );
+      QVERIFY( exp.prepare( &context ) );
+      QVERIFY( !exp.hasEvalError() );
+      QCOMPARE( exp.evaluate( &context ).toString(), u"Point (1 2)"_s );
+    }
 };
 
 QGSTEST_MAIN( TestQgsExpression )


### PR DESCRIPTION
Ensure that @geometry always uses identical logic for retrieving geometry from the expression context as the older $geometry function.

Manual backport of https://github.com/qgis/QGIS/pull/65489