### PR TITLE
Enable parallel provider load for AFS, AMS providers, and some related fixes

### DIFF
--- a/src/auth/oauth2/core/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2method.cpp
@@ -741,8 +741,11 @@ void QgsAuthOAuth2Method::putOAuth2Bundle( const QString &authcfg, QgsO2 *bundle
   QgsReadWriteLocker locker( mO2CacheLock, QgsReadWriteLocker::Write );
   QgsDebugMsgLevel( u"Putting oauth2 bundle for authcfg: %1"_s.arg( authcfg ), 2 );
   mOAuth2ConfigCache.insert( authcfg, bundle );
-  // Restart the timer so that we have a full interval before the next cleanup
+// Restart the timer so that we have a full interval before the next cleanup
+// Suppress warning: Potential leak of memory pointed to by 'callable' [clang-analyzer-cplusplus.NewDeleteLeaks]
+#ifndef __clang_analyzer__
   QMetaObject::invokeMethod( &mCacheHousekeepingTimer, qOverload<>( &QTimer::start ), Qt::QueuedConnection );
+#endif
 }
 
 void QgsAuthOAuth2Method::removeOAuth2Bundle( const QString &authcfg )

--- a/src/auth/oauth2/core/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/core/qgsauthoauth2method.cpp
@@ -742,7 +742,7 @@ void QgsAuthOAuth2Method::putOAuth2Bundle( const QString &authcfg, QgsO2 *bundle
   QgsDebugMsgLevel( u"Putting oauth2 bundle for authcfg: %1"_s.arg( authcfg ), 2 );
   mOAuth2ConfigCache.insert( authcfg, bundle );
   // Restart the timer so that we have a full interval before the next cleanup
-  mCacheHousekeepingTimer.start();
+  QMetaObject::invokeMethod( &mCacheHousekeepingTimer, qOverload<>( &QTimer::start ), Qt::QueuedConnection );
 }
 
 void QgsAuthOAuth2Method::removeOAuth2Bundle( const QString &authcfg )

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1618,6 +1618,8 @@ void QgsProject::preloadProviders(
           std::unique_ptr<QgsDataProvider> provider( finishedRun->dataProvider() );
           Q_ASSERT( provider && provider->isValid() );
 
+          QgsDebugMsgLevel( u"Retrieved created provider for %1 (belongs to thread %2)"_s.arg( layId, QgsThreadingUtils::threadDescription(provider->thread() ) ), 2 );
+
           loadedProviders.insert( layId, provider.release() );
           emit layerLoaded( i, totalProviderCount );
         }

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1618,7 +1618,8 @@ void QgsProject::preloadProviders(
           std::unique_ptr<QgsDataProvider> provider( finishedRun->dataProvider() );
           Q_ASSERT( provider && provider->isValid() );
 
-          QgsDebugMsgLevel( u"Retrieved created provider for %1 (belongs to thread %2)"_s.arg( layId, QgsThreadingUtils::threadDescription(provider->thread() ) ), 2 );
+          provider->moveToThread( QThread::currentThread() );
+          QgsDebugMsgLevel( u"Retrieved created provider for %1 (belongs to thread %2)"_s.arg( layId, QgsThreadingUtils::threadDescription( provider->thread() ) ), 2 );
 
           loadedProviders.insert( layId, provider.release() );
           emit layerLoaded( i, totalProviderCount );

--- a/src/core/providers/qgsrunnableprovidercreator.cpp
+++ b/src/core/providers/qgsrunnableprovidercreator.cpp
@@ -15,10 +15,10 @@
  ***************************************************************************/
 #include "qgsrunnableprovidercreator.h"
 
+#include "qgslogger.h"
 #include "qgsproviderregistry.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsthreadingutils.h"
-#include "qgslogger.h"
 
 #include <QDebug>
 #include <QString>
@@ -51,7 +51,9 @@ void QgsRunnableProviderCreator::run()
 
   QgsDebugMsgLevel( u"Created provider for %1: %2 - %3 belongs to thread %4"_s.arg( mLayerId, mProviderKey, mDataSource, QgsThreadingUtils::threadDescription( mDataProvider->thread() ) ), 2 );
 
-  mDataProvider->moveToThread( QObject::thread() );
+  // detach from thread, so that the creator of QgsRunnableProviderCreator can "pull" the data provider
+  // (we can't push it to a thread here, because we don't know what the target thread for the owner will be)
+  mDataProvider->moveToThread( nullptr );
 
   emit providerCreated( mDataProvider->isValid(), mLayerId );
 }

--- a/src/core/providers/qgsrunnableprovidercreator.cpp
+++ b/src/core/providers/qgsrunnableprovidercreator.cpp
@@ -17,6 +17,8 @@
 
 #include "qgsproviderregistry.h"
 #include "qgsruntimeprofiler.h"
+#include "qgsthreadingutils.h"
+#include "qgslogger.h"
 
 #include <QDebug>
 #include <QString>
@@ -40,10 +42,17 @@ QgsRunnableProviderCreator::QgsRunnableProviderCreator(
 
 void QgsRunnableProviderCreator::run()
 {
+  QgsScopedThreadName threadName( u"pcreate:%1"_s.arg( mProviderKey ) );
+  QgsDebugMsgLevel( u"Creating provider in parallel for %1: %2 - %3 in thread %4"_s.arg( mLayerId, mProviderKey, mDataSource, QgsThreadingUtils::threadDescription( QThread::currentThread() ) ), 2 );
+
   // should use thread-local profiler
   QgsScopedRuntimeProfile profile( "Create data providers/" + mLayerId, u"projectload"_s );
   mDataProvider.reset( QgsProviderRegistry::instance()->createProvider( mProviderKey, mDataSource, mOptions, mFlags ) );
+
+  QgsDebugMsgLevel( u"Created provider for %1: %2 - %3 belongs to thread %4"_s.arg( mLayerId, mProviderKey, mDataSource, QgsThreadingUtils::threadDescription( mDataProvider->thread() ) ), 2 );
+
   mDataProvider->moveToThread( QObject::thread() );
+
   emit providerCreated( mDataProvider->isValid(), mLayerId );
 }
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -578,6 +578,10 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteCon
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   mPreloadedProvider.reset( preloadedProvider );
+  if ( mPreloadedProvider )
+  {
+    QGIS_CHECK_QOBJECT_THREAD_EQUALITY( mPreloadedProvider.get() );
+  }
 
   bool layerError;
   mReadFlags = flags;

--- a/src/core/qgsthreadingutils.cpp
+++ b/src/core/qgsthreadingutils.cpp
@@ -15,7 +15,17 @@
 
 #include "qgsthreadingutils.h"
 
+#include <QCoreApplication>
+#include <QString>
+
+using namespace Qt::StringLiterals;
+
 #if defined( QGISDEBUG )
 QSet< QString > QgsThreadingUtils::sEmittedWarnings;
 QMutex QgsThreadingUtils::sEmittedWarningMutex;
 #endif
+
+QString QgsThreadingUtils::threadDescription( QThread *thread )
+{
+  return u"%1%2"_s.arg( thread == qApp->thread() ? u"MAIN thread"_s : QString() ).arg( reinterpret_cast< qint64 >( QThread::currentThread() ), 0, 16 );
+}

--- a/src/core/qgsthreadingutils.h
+++ b/src/core/qgsthreadingutils.h
@@ -318,6 +318,13 @@ class CORE_EXPORT QgsThreadingUtils
     //! Mutex protecting sEmittedWarnings
     static QMutex sEmittedWarningMutex;
 #endif
+
+    /**
+     * Returns a descriptive identifier for a \a thread.
+     *
+     * \since QGIS 4.2
+     */
+    static QString threadDescription( QThread *thread );
 };
 
 

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -2247,9 +2247,14 @@ bool QgsVectorLayer::setDataProvider( QString const &provider, const QgsDataProv
     profile = std::make_unique< QgsScopedRuntimeProfile >( tr( "Create %1 provider" ).arg( provider ), u"projectload"_s );
 
   if ( mPreloadedProvider )
-    mDataProvider = qobject_cast< QgsVectorDataProvider * >( mPreloadedProvider.release() );
+  {
+    QgsDebugMsgLevel( u"Attaching map layer %1 to preloaded data provider. Provider belongs to thread %2"_s.arg( id(), QgsThreadingUtils::threadDescription( mPreloadedProvider->thread() ) ), 2 );
+    mDataProvider = qobject_cast< QgsVectorDataProvider * >( mPreloadedProvider.release() ); 
+  }
   else
+  {
     mDataProvider = qobject_cast<QgsVectorDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, mDataSource, options, flags ) );
+  }
 
   if ( !mDataProvider )
   {

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -2249,7 +2249,7 @@ bool QgsVectorLayer::setDataProvider( QString const &provider, const QgsDataProv
   if ( mPreloadedProvider )
   {
     QgsDebugMsgLevel( u"Attaching map layer %1 to preloaded data provider. Provider belongs to thread %2"_s.arg( id(), QgsThreadingUtils::threadDescription( mPreloadedProvider->thread() ) ), 2 );
-    mDataProvider = qobject_cast< QgsVectorDataProvider * >( mPreloadedProvider.release() ); 
+    mDataProvider = qobject_cast< QgsVectorDataProvider * >( mPreloadedProvider.release() );
   }
   else
   {

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -789,6 +789,11 @@ QIcon QgsAfsProviderMetadata::icon() const
   return QgsApplication::getThemeIcon( u"mIconAfs.svg"_s );
 }
 
+QgsProviderMetadata::ProviderCapabilities QgsAfsProviderMetadata::providerCapabilities() const
+{
+  return QgsProviderMetadata::ProviderCapability::ParallelCreateProvider;
+}
+
 QList<QgsDataItemProvider *> QgsAfsProviderMetadata::dataItemProviders() const
 {
   QList<QgsDataItemProvider *> providers;

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -123,6 +123,7 @@ class QgsAfsProviderMetadata : public QgsProviderMetadata
   public:
     QgsAfsProviderMetadata();
     QIcon icon() const override;
+    QgsProviderMetadata::ProviderCapabilities providerCapabilities() const override;
     QList<QgsDataItemProvider *> dataItemProviders() const override;
     QVariantMap decodeUri( const QString &uri ) const override;
     QString encodeUri( const QVariantMap &parts ) const override;

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -1288,6 +1288,11 @@ QIcon QgsAmsProviderMetadata::icon() const
   return QgsApplication::getThemeIcon( u"mIconAms.svg"_s );
 }
 
+QgsProviderMetadata::ProviderCapabilities QgsAmsProviderMetadata::providerCapabilities() const
+{
+  return QgsProviderMetadata::ProviderCapability::ParallelCreateProvider;
+}
+
 QgsAmsProvider *QgsAmsProviderMetadata::createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, Qgis::DataProviderReadFlags flags )
 {
   return new QgsAmsProvider( uri, options, flags );

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -238,6 +238,7 @@ class QgsAmsProviderMetadata : public QgsProviderMetadata
   public:
     QgsAmsProviderMetadata();
     QIcon icon() const override;
+    QgsProviderMetadata::ProviderCapabilities providerCapabilities() const override;
     QgsAmsProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, Qgis::DataProviderReadFlags flags = Qgis::DataProviderReadFlags() ) override;
     QVariantMap decodeUri( const QString &uri ) const override;
     QString encodeUri( const QVariantMap &parts ) const override;


### PR DESCRIPTION
## Description

Enables parallel provider loading for the ArcGIS FeatureServer/MapServer providers, giving much faster project load times when a project contains multiple FeatureServer/MapServer layers.

I've also added some debugging output relating to parallel layer loading, and fixed a (very minor) bug which could be triggered when creating a project using parallel loading on a background thread.

Funded by République et canton de Genève

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

