### PR TITLE
Add feedback support for cancellation of concave hull

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2010,7 +2010,7 @@ can be retrieved by calling :py:func:`~QgsGeometry.lastError` on the
 returned geometry.
 %End
 
-    QgsGeometry concaveHull( double targetPercent, bool allowHoles = false ) const;
+    QgsGeometry concaveHull( double targetPercent, bool allowHoles = false, QgsFeedback * feedback = 0 ) const;
 %Docstring
 Returns a possibly concave polygon that contains all the points in the
 geometry.
@@ -2021,6 +2021,9 @@ geometry.
 If an error was encountered while creating the result, more information
 can be retrieved by calling :py:func:`~QgsGeometry.lastError` on the
 returned geometry.
+
+The optional ``feedback`` argument was added in QGIS 4.2 to support
+early cancellation.
 
 :raises QgsNotSupportedException: on QGIS builds based on GEOS 3.10 or
                                   earlier.

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
@@ -694,7 +694,7 @@ This method requires a QGIS build based on GEOS 3.11 or later.
 .. versionadded:: 3.36
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > concaveHull( double targetPercent, bool allowHoles = false, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > concaveHull( double targetPercent, bool allowHoles = false, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns a possibly concave geometry that encloses the input geometry.
 
@@ -719,6 +719,8 @@ This method requires a QGIS build based on GEOS 3.11 or later.
 
 :param targetPercent: 
 :param allowHoles: 
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - concave geometry that encloses the input geometry
          - errorMsg: descriptive error string if the operation fails

--- a/src/analysis/processing/qgsalgorithmconcavehull.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehull.cpp
@@ -149,7 +149,7 @@ void QgsConcaveHullAlgorithm::concaveHullGeos( std::unique_ptr<QgsFeatureSink> &
       allPoints.addPartV2( qgsgeometry_cast<const QgsPoint *>( geom )->clone(), Qgis::WkbType::Point );
     }
   }
-  const QgsGeometry concaveHull = allPoints.concaveHull( mPercentage, mAllowHoles );
+  const QgsGeometry concaveHull = allPoints.concaveHull( mPercentage, mAllowHoles, feedback );
 
   if ( concaveHull.isNull() && !concaveHull.lastError().isEmpty() )
   {

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2919,7 +2919,7 @@ QgsGeometry QgsGeometry::convexHull() const
   return QgsGeometry( std::move( cHull ) );
 }
 
-QgsGeometry QgsGeometry::concaveHull( double targetPercent, bool allowHoles ) const
+QgsGeometry QgsGeometry::concaveHull( double targetPercent, bool allowHoles, QgsFeedback *feedback ) const
 {
   if ( !d->geometry )
   {
@@ -2927,7 +2927,7 @@ QgsGeometry QgsGeometry::concaveHull( double targetPercent, bool allowHoles ) co
   }
   QgsGeos geos( d->geometry.get() );
   mLastError.clear();
-  std::unique_ptr< QgsAbstractGeometry > concaveHull( geos.concaveHull( targetPercent, allowHoles, &mLastError ) );
+  std::unique_ptr< QgsAbstractGeometry > concaveHull( geos.concaveHull( targetPercent, allowHoles, &mLastError, feedback ) );
   if ( !concaveHull )
   {
     QgsGeometry geom;

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1909,12 +1909,13 @@ class CORE_EXPORT QgsGeometry
      * If an error was encountered while creating the result, more information can be retrieved
      * by calling lastError() on the returned geometry.
      *
-     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.10 or earlier.
+     * The optional \a feedback argument was added in QGIS 4.2 to support early cancellation.
      *
+     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.10 or earlier.
      *
      * \since QGIS 3.28
      */
-    QgsGeometry concaveHull( double targetPercent, bool allowHoles = false ) const SIP_THROW( QgsNotSupportedException );
+    QgsGeometry concaveHull( double targetPercent, bool allowHoles = false, QgsFeedback * feedback = nullptr ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Creates a Voronoi diagram for the nodes contained within the geometry.

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -2236,7 +2236,7 @@ QgsAbstractGeometry *QgsGeos::convexHull( QString *errorMsg ) const
   CATCH_GEOS_WITH_ERRMSG( nullptr )
 }
 
-std::unique_ptr< QgsAbstractGeometry > QgsGeos::concaveHull( double targetPercent, bool allowHoles, QString *errorMsg ) const
+std::unique_ptr< QgsAbstractGeometry > QgsGeos::concaveHull( double targetPercent, bool allowHoles, QString *errorMsg, QgsFeedback *feedback ) const
 {
 #if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 11
   ( void ) allowHoles;
@@ -2251,6 +2251,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsGeos::concaveHull( double targetPercen
 
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos::unique_ptr concaveHull( GEOSConcaveHull_r( QgsGeosContext::get(), mGeos.get(), targetPercent, allowHoles ) );
     std::unique_ptr< QgsAbstractGeometry > concaveHullGeom = fromGeos( concaveHull.get() );
     return concaveHullGeom;

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -20,6 +20,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include <memory>
 
 #include "qgsabstractgeometry.h"
+#include "qgsfeedback.h"
 #include "qgsgeometrycollection.h"
 #include "qgsgeometryeditutils.h"
 #include "qgsgeometryfactory.h"
@@ -45,14 +46,18 @@ using namespace Qt::StringLiterals;
     return r;                  \
   }
 
-#define CATCH_GEOS_WITH_ERRMSG( r ) \
-  catch ( QgsGeosException & e )    \
-  {                                 \
-    if ( errorMsg )                 \
-    {                               \
-      *errorMsg = e.what();         \
-    }                               \
-    return r;                       \
+#define CATCH_GEOS_WITH_ERRMSG( r )                                                 \
+  catch ( QgsGeosException & e )                                                    \
+  {                                                                                 \
+    if ( errorMsg )                                                                 \
+    {                                                                               \
+      *errorMsg = e.what();                                                         \
+      if ( errorMsg->startsWith( "InterruptedException"_L1, Qt::CaseInsensitive ) ) \
+      {                                                                             \
+        errorMsg->clear();                                                          \
+      }                                                                             \
+    }                                                                               \
+    return r;                                                                       \
   }
 
 /// @cond PRIVATE
@@ -3911,3 +3916,29 @@ int QgsGeos::geomDigits( const GEOSGeometry *geom )
 
   return maxDigits;
 }
+
+QgsScopedGeosContextRegisterFeedback::QgsScopedGeosContextRegisterFeedback( QgsFeedback *feedback )
+  : mFeedback( feedback )
+{
+#if GEOS_VERSION_MAJOR > 3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR >= 14 )
+  GEOSContext_setInterruptCallback_r( QgsGeosContext::get(), &callback, reinterpret_cast< void * >( mFeedback ) );
+#endif
+}
+
+QgsScopedGeosContextRegisterFeedback::~QgsScopedGeosContextRegisterFeedback()
+{
+#if GEOS_VERSION_MAJOR > 3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR >= 14 )
+  GEOSContext_setInterruptCallback_r( QgsGeosContext::get(), nullptr, nullptr );
+#endif
+}
+
+#if GEOS_VERSION_MAJOR > 3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR >= 14 )
+int QgsScopedGeosContextRegisterFeedback::callback( void *userData )
+{
+  if ( !userData )
+    return 0;
+
+  QgsFeedback *feedback = reinterpret_cast< QgsFeedback * >( userData );
+  return feedback && feedback->isCanceled() ? 1 : 0;
+}
+#endif

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -3919,12 +3919,17 @@ int QgsGeos::geomDigits( const GEOSGeometry *geom )
 }
 
 QgsScopedGeosContextRegisterFeedback::QgsScopedGeosContextRegisterFeedback( QgsFeedback *feedback )
+#if GEOS_VERSION_MAJOR > 3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR >= 14 )
   : mFeedback( feedback )
 {
-#if GEOS_VERSION_MAJOR > 3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR >= 14 )
   GEOSContext_setInterruptCallback_r( QgsGeosContext::get(), &callback, reinterpret_cast< void * >( mFeedback ) );
-#endif
 }
+#else
+{
+  ( void ) feedback;
+}
+#endif
+
 
 QgsScopedGeosContextRegisterFeedback::~QgsScopedGeosContextRegisterFeedback()
 {

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -801,6 +801,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param targetPercent
      * \param allowHoles
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns concave geometry that encloses the input geometry
      *
@@ -808,7 +809,9 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \see convexHull()
      * \since QGIS 3.28
      */
-    std::unique_ptr< QgsAbstractGeometry > concaveHull( double targetPercent, bool allowHoles = false, QString *errorMsg SIP_OUT = nullptr ) const SIP_THROW( QgsNotSupportedException );
+    std::unique_ptr< QgsAbstractGeometry > concaveHull( double targetPercent, bool allowHoles = false, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const SIP_THROW(
+      QgsNotSupportedException
+    );
 
     /**
      * Analyze a coverage (represented as a collection of polygonal geometry with exactly matching edge

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -69,6 +69,42 @@ class CORE_EXPORT QgsGeosContext
 };
 
 /**
+ * \ingroup core
+ *
+ * \brief Scoped object for setting the current thread GEOS context feedback object.
+ *
+ * Temporarily overrides the current thread GEOS context feedback object, resetting it to NULLPTR on destruction.
+ *
+ * \note Not available in Python bindings
+ * \note Requires GEOS 3.14 or later. On earlier GEOS versions this has no effect.
+ *
+ * \since QGIS 4.2
+ */
+class CORE_EXPORT QgsScopedGeosContextRegisterFeedback
+{
+  public:
+    /**
+   * Registers a \a feedback object for GEOS interruption checking.
+   *
+   * Applies to the current thread only.
+   *
+   * The \a feedback object must exist for the lifetime of this object.
+   */
+    QgsScopedGeosContextRegisterFeedback( QgsFeedback *feedback );
+
+    /**
+   * Resets the GEOS interruption checker for the current thread.
+   */
+    ~QgsScopedGeosContextRegisterFeedback();
+
+  private:
+#if GEOS_VERSION_MAJOR > 3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR >= 14 )
+    static int callback( void *userData );
+#endif
+    QgsFeedback *mFeedback = nullptr;
+};
+
+/**
  * Contains geos related utilities and functions.
  * \note not available in Python bindings.
  */

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -100,8 +100,8 @@ class CORE_EXPORT QgsScopedGeosContextRegisterFeedback
   private:
 #if GEOS_VERSION_MAJOR > 3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR >= 14 )
     static int callback( void *userData );
-#endif
     QgsFeedback *mFeedback = nullptr;
+#endif
 };
 
 /**


### PR DESCRIPTION
## Description

Adds a framework for registering a QgsFeedback object for the current thread, so that GEOS operations can be interrupted early.

Requires GEOS 3.14 or later.

Implemented for the concave hull operation and algorithm for now.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
