### PR TITLE
[mssql] Fix not using geometry_columns to retrieve tables

### DIFF
--- a/src/providers/mssql/qgsmssqlproviderconnection.cpp
+++ b/src/providers/mssql/qgsmssqlproviderconnection.cpp
@@ -396,7 +396,7 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsMssqlProviderConn
 
   // Defaults to false
   const bool useGeometryColumnsOnly {
-    !table.isEmpty() && ( dsUri.hasParam( u"geometryColumnsOnly"_s ) && ( dsUri.param( u"geometryColumnsOnly"_s ) == "true"_L1 || dsUri.param( u"geometryColumnsOnly"_s ) == '1' ) )
+    table.isEmpty() && ( dsUri.hasParam( u"geometryColumnsOnly"_s ) && ( dsUri.param( u"geometryColumnsOnly"_s ) == "true"_L1 || dsUri.param( u"geometryColumnsOnly"_s ) == '1' ) )
   };
 
   // Defaults to true


### PR DESCRIPTION
...for database connections with the geometryColumnsOnly flag set
