### PR TITLE
build(core): Fix cmake sqlite warning with cmake 4.3

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2776,6 +2776,11 @@ if (APPLE)
   target_link_libraries(qgis_core ${LIBTASN1_LIBRARY})
 endif()
 
+# SQLite::SQLite3 has been deprecated since CMake 4.3
+if(NOT TARGET SQLite3::SQLite3)
+  add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
+
 target_link_libraries(qgis_core
   ${QT_VERSION_BASE}::Core
   ${QT_VERSION_BASE}::Gui
@@ -2789,7 +2794,7 @@ target_link_libraries(qgis_core
   GEOS::geos_c
   GDAL::GDAL
   EXPAT::EXPAT
-  SQLite::SQLite3
+  SQLite3::SQLite3
   ${LIBZIP_LIBRARY}
   $<TARGET_NAME_IF_EXISTS:protobuf::libprotobuf-lite>
   ${ZLIB_LIBRARIES}


### PR DESCRIPTION
## Description
`SQLite::SQLite3` target has been deprecated since CMake 4.3 and replaced by `SQLite3::SQLite3`.

Add an alias to remove the warning and keep compatibility with previous CMake versions.

See: https://cmake.org/cmake/help/latest/module/FindSQLite3.html


## AI tool usage

No AI tool used