### PR TITLE
Move ExpressionContextGenerator of remove duplicates label ui

### DIFF
--- a/src/ui/qgslabelremoveduplicatesettingswidgetbase.ui
+++ b/src/ui/qgslabelremoveduplicatesettingswidgetbase.ui
@@ -64,20 +64,13 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QgsPropertyOverrideButton" name="mNoRepeatDistDDBtn">
-        <property name="text">
-         <string>…</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
        <widget class="QgsUnitSelectionWidget" name="mNoRepeatDistUnitWidget" native="true">
         <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
+         <enum>Qt::FocusPolicy::StrongFocus</enum>
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="3">
+      <item row="0" column="0" colspan="4">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Labels with the exact same text (including case) will not be placed if they are closer than this distance.</string>
@@ -87,13 +80,20 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="QgsPropertyOverrideButton" name="mNoRepeatDistDDBtn">
+        <property name="text">
+         <string>…</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>


### PR DESCRIPTION
It was displayed next to the unit combo, not the value spinbox it changes.

## Description

It was displayed next to the unit combo, not the value spinbox that it changes.

Before:
<img width="565" height="371" alt="Screenshot From 2026-03-23 13-29-50" src="https://github.com/user-attachments/assets/c3d82456-8201-476a-8602-f64731bf1338" />

After:

<img width="565" height="371" alt="Screenshot From 2026-03-23 14-54-27" src="https://github.com/user-attachments/assets/01eedf2d-1521-47d4-bc25-d076ee962f68" />



## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
