### PR TITLE
Processing GDAL: fix outputting to a temporary layer

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithm.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithm.py
@@ -212,10 +212,4 @@ class GdalAlgorithm(QgsProcessingAlgorithm):
         return QCoreApplication.translate(context, string)
 
     def outputFormat(self, parameters, parameterName, context):
-        output_format = self.parameterAsOutputFormat(parameters, parameterName, context)
-        if not output_format:
-            out = self.parameterAsOutputLayer(parameters, parameterName, context)
-            output_format = QgsRasterFileWriter.driverForExtension(
-                os.path.splitext(out)[1]
-            )
-        return output_format
+        return self.parameterAsOutputRasterFormat(parameters, parameterName, context)

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -28,6 +28,7 @@ import nose2
 from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsPointXY,
+    QgsProcessing,
     QgsProcessingContext,
     QgsProcessingException,
     QgsProcessingFeedback,
@@ -40,6 +41,7 @@ from qgis.core import (
 )
 from qgis.testing import QgisTestCase, start_app, unittest
 
+import processing
 from processing.algs.gdal.aspect import aspect
 from processing.algs.gdal.AssignProjection import AssignProjection
 from processing.algs.gdal.buildvrt import buildvrt
@@ -6652,6 +6654,19 @@ class TestGdalRasterAlgorithms(QgisTestCase, AlgorithmsTestBase.AlgorithmsTest):
                     f"--recursive --detailed --input {indir} --output {outsource}",
                 ],
             )
+
+    def testGdalTranslateRun(self):
+
+        res = processing.run(
+            "gdal:translate",
+            {
+                "DISTANCE": 1,
+                "INPUT": os.path.join(testDataPath, "dem.tif"),
+                "OUTPUT": QgsProcessing.TEMPORARY_OUTPUT,
+            },
+            context=QgsProcessingContext(),
+        )
+        self.assertIn("OUTPUT", res)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes #65502
Uses QgsProcessingAlgorithm::parameterAsOutputRasterFormat() that received a fix in https://github.com/qgis/QGIS/pull/64465 to avoid creating 2 files.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

