### PR TITLE
[ui] Fix raster layer and vector tile layer properties dialog opening source hyperlink _in the browser area_ instead of the file manager

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -110,6 +110,8 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
   setupUi( this );
 
   mMetadataViewer = new QgsWebView( this );
+  mMetadataViewer->setOpenLinks( false );
+  connect( mMetadataViewer, &QTextBrowser::anchorClicked, this, &QgsRasterLayerProperties::openUrl );
   mOptsPage_Information->layout()->addWidget( mMetadataViewer );
 
   mRasterTransparencyWidget = new QgsRasterTransparencyWidget( mRasterLayer, canvas, this );
@@ -1302,10 +1304,11 @@ bool QgsRasterLayerProperties::rasterIsMultiBandColor()
 
 void QgsRasterLayerProperties::updateInformationContent()
 {
-  const QString myStyle = QgsApplication::reportStyleSheet( QgsApplication::StyleSheetType::WebBrowser );
-  // Inject the stylesheet
-  const QString html { mRasterLayer->htmlMetadata().replace( "<head>"_L1, QStringLiteral( R"raw(<head><style type="text/css">%1</style>)raw" ) ).arg( myStyle ) };
-  mMetadataViewer->setHtml( html );
+  QString myStyle = QgsApplication::reportStyleSheet();
+  myStyle.append( u"body { margin: 10px; }\n "_s );
+  mMetadataViewer->clear();
+  mMetadataViewer->document()->setDefaultStyleSheet( myStyle );
+  mMetadataViewer->setHtml( mRasterLayer->htmlMetadata() );
   mMetadataFilled = true;
 }
 

--- a/src/gui/vectortile/qgsvectortilelayerproperties.cpp
+++ b/src/gui/vectortile/qgsvectortilelayerproperties.cpp
@@ -90,6 +90,8 @@ QgsVectorTileLayerProperties::QgsVectorTileLayerProperties( QgsVectorTileLayer *
 
   mMapLayerServerPropertiesWidget->setHasWfsTitle( false );
 
+  connect( mMetadataViewer, &QTextBrowser::anchorClicked, this, &QgsVectorTileLayerProperties::openUrl );
+
   // update based on lyr's current state
   syncToLayer();
 
@@ -156,10 +158,11 @@ void QgsVectorTileLayerProperties::syncToLayer()
   /*
    * Information Tab
    */
-  const QString myStyle = QgsApplication::reportStyleSheet( QgsApplication::StyleSheetType::WebBrowser );
-  // Inject the stylesheet
-  const QString html { mLayer->htmlMetadata().replace( "<head>"_L1, QStringLiteral( R"raw(<head><style type="text/css">%1</style>)raw" ) ).arg( myStyle ) };
-  mMetadataViewer->setHtml( html );
+  QString myStyle = QgsApplication::reportStyleSheet();
+  myStyle.append( u"body { margin: 10px; }\n "_s );
+  mMetadataViewer->clear();
+  mMetadataViewer->document()->setDefaultStyleSheet( myStyle );
+  mMetadataViewer->setHtml( mLayer->htmlMetadata() );
 
   /*
    * Source


### PR DESCRIPTION
## Description

A Qt6 regression in the way QTextBrowser handles file:// hyperlink led to this beauty in QGIS 4.0 when trying to open the folder of a raster layer source from the properties dialog:

<img width="863" height="487" alt="image" src="https://github.com/user-attachments/assets/007787c7-41b1-4497-83f6-f1714226c455" />
