### PR TITLE
Greatly speed up the FeatureServer provider for map viewing

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -110,7 +110,6 @@ QVariantMap QgsArcGisRestQueryUtils::getObjects(
   const QStringList &fetchAttributes,
   bool fetchM,
   bool fetchZ,
-  const QgsRectangle &filterRect,
   QString &errorTitle,
   QString &errorText,
   const QgsHttpHeaders &requestHeaders,
@@ -145,12 +144,6 @@ QVariantMap QgsArcGisRestQueryUtils::getObjects(
 
   query.addQueryItem( u"returnM"_s, fetchM ? u"true"_s : u"false"_s );
   query.addQueryItem( u"returnZ"_s, fetchZ ? u"true"_s : u"false"_s );
-  if ( !filterRect.isNull() )
-  {
-    query.addQueryItem( u"geometry"_s, u"%1,%2,%3,%4"_s.arg( filterRect.xMinimum(), 0, 'f', -1 ).arg( filterRect.yMinimum(), 0, 'f', -1 ).arg( filterRect.xMaximum(), 0, 'f', -1 ).arg( filterRect.yMaximum(), 0, 'f', -1 ) );
-    query.addQueryItem( u"geometryType"_s, u"esriGeometryEnvelope"_s );
-    query.addQueryItem( u"spatialRel"_s, u"esriSpatialRelEnvelopeIntersects"_s );
-  }
   queryUrl.setQuery( query );
   return queryServiceJSON( queryUrl, authcfg, errorTitle, errorText, requestHeaders, feedback, urlPrefix );
 }

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -108,7 +108,6 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
      * \param fetchAttributes
      * \param fetchM
      * \param fetchZ
-     * \param filterRect
      * \param errorTitle
      * \param errorText
      * \param requestHeaders
@@ -124,7 +123,6 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
       const QStringList &fetchAttributes,
       bool fetchM,
       bool fetchZ,
-      const QgsRectangle &filterRect,
       QString &errorTitle,
       QString &errorText,
       const QgsHttpHeaders &requestHeaders = QgsHttpHeaders(),

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -173,7 +173,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
       if ( mRemainingFeatureIds.empty() )
         return false;
 
-      bool result = mSource->sharedData()->getFeature( mRequest.filterFid(), f, mInterruptionChecker );
+      bool result = mSource->sharedData()->getFeature( mRequest.filterFid(), f, mRemainingFeatureIds, mInterruptionChecker );
       if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
         return false;
 
@@ -204,7 +204,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
         bool isDeleted = mSource->sharedData()->isDeleted( mFeatureIterator );
         if ( !isDeleted )
         {
-          success = mSource->sharedData()->getFeature( mFeatureIterator, f, mInterruptionChecker );
+          success = mSource->sharedData()->getFeature( mFeatureIterator, f, mRemainingFeatureIds, mInterruptionChecker );
         }
 
         if ( !mFeatureIdList.empty() )

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -173,7 +173,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
       if ( mRemainingFeatureIds.empty() )
         return false;
 
-      bool result = mSource->sharedData()->getFeature( mRequest.filterFid(), f, QgsRectangle(), mInterruptionChecker );
+      bool result = mSource->sharedData()->getFeature( mRequest.filterFid(), f, mInterruptionChecker );
       if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
         return false;
 
@@ -204,7 +204,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
         bool isDeleted = mSource->sharedData()->isDeleted( mFeatureIterator );
         if ( !isDeleted )
         {
-          success = mSource->sharedData()->getFeature( mFeatureIterator, f, QgsRectangle(), mInterruptionChecker );
+          success = mSource->sharedData()->getFeature( mFeatureIterator, f, mInterruptionChecker );
         }
 
         if ( !mFeatureIdList.empty() )

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -181,7 +181,7 @@ QgsFeatureId QgsAfsSharedData::objectIdToFeatureId( quint32 oid )
   return mObjectIdToFeatureId.value( oid, -1 );
 }
 
-bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, QgsFeedback *feedback )
+bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QList<QgsFeatureId> &pendingFeatureIds, QgsFeedback *feedback )
 {
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   Q_ASSERT( mHasFetchedObjectIds );
@@ -196,25 +196,66 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, QgsFeedback *
 
   const QString authcfg = mDataSource.authConfigId();
   bool featureFetched = false;
-  int startId;
-  QList<quint32> objectIds;
+  QSet<quint32> objectIds;
+  objectIds.reserve( mMaximumFetchObjectsCount );
   QVariantMap queryData;
+  QList< QgsFeatureId > requestedFeatureIds;
+  requestedFeatureIds.reserve( mMaximumFetchObjectsCount );
+
+  if ( id < 0 || id >= mFeatureIdsToObjectIds.size() )
+    return false;
+
+  const quint32 targetObjectId = mFeatureIdsToObjectIds.at( id );
   while ( !featureFetched )
   {
-    startId = ( id / mMaximumFetchObjectsCount ) * mMaximumFetchObjectsCount;
-    const int stopId = std::min<size_t>( startId + mMaximumFetchObjectsCount, mFeatureIdsToObjectIds.length() );
     objectIds.clear();
-    objectIds.reserve( stopId - startId );
-    for ( int i = startId; i < stopId; ++i )
+    objectIds.insert( targetObjectId );
+    // first priority is to fill the batch with pending feature IDs, because we know
+    // these are desirable for the caller
+    for ( QgsFeatureId pendingId : pendingFeatureIds )
     {
-      if ( i >= 0 && i < mFeatureIdsToObjectIds.count() && !mDeletedFeatureIds.contains( i ) && !mCache.contains( i ) )
-        objectIds.append( mFeatureIdsToObjectIds.at( i ) );
+      if ( pendingId >= 0 && pendingId < mFeatureIdsToObjectIds.count() && !mDeletedFeatureIds.contains( pendingId ) && !mCache.contains( pendingId ) )
+      {
+        objectIds.insert( mFeatureIdsToObjectIds.at( pendingId ) );
+        if ( objectIds.size() >= mMaximumFetchObjectsCount )
+        {
+          break;
+        }
+      }
+    }
+
+    if ( objectIds.size() < mMaximumFetchObjectsCount )
+    {
+      // if batch isn't yet full, then fill remainder with sequential IDs we haven't yet fetched
+      const int startId = static_cast< int >( ( id / mMaximumFetchObjectsCount ) * mMaximumFetchObjectsCount );
+      const int stopId = static_cast< int >( mFeatureIdsToObjectIds.length() );
+      for ( int i = startId; i < stopId; ++i )
+      {
+        if ( i >= 0 && i < mFeatureIdsToObjectIds.count() && !mDeletedFeatureIds.contains( i ) && !mCache.contains( i ) )
+        {
+          objectIds.insert( mFeatureIdsToObjectIds.at( i ) );
+          if ( objectIds.size() >= mMaximumFetchObjectsCount )
+          {
+            break;
+          }
+        }
+      }
     }
 
     if ( objectIds.empty() )
     {
       QgsDebugMsgLevel( u"No valid features IDs to fetch"_s, 2 );
       return false;
+    }
+
+    // sort requested feature IDs, to make requests more cache friendly
+    // (as opposed to unpredictable set ordering)
+    QList< quint32 > requestedObjectIds = qgis::setToList( objectIds );
+    std::sort( requestedObjectIds.begin(), requestedObjectIds.end() );
+    requestedFeatureIds.clear();
+    for ( quint32 objectId : requestedObjectIds )
+    {
+      requestedFeatureIds.append( mObjectIdToFeatureId[objectId] );
     }
 
     // don't lock while doing the fetch
@@ -225,7 +266,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, QgsFeedback *
     queryData = QgsArcGisRestQueryUtils::getObjects(
       mDataSource.param( u"url"_s ),
       authcfg,
-      objectIds,
+      requestedObjectIds,
       mDataSource.param( u"crs"_s ),
       true,
       QStringList(),
@@ -274,7 +315,12 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, QgsFeedback *
   {
     const QVariantMap featureData = featuresData[i].toMap();
     QgsFeature feature;
-    QgsFeatureId featureId = startId + i;
+    if ( i >= requestedFeatureIds.size() )
+    {
+      QgsDebugError( u"Server responded with more features than expected -- results will be unpredictable!" );
+      break;
+    }
+    QgsFeatureId featureId = requestedFeatureIds[i];
 
     // Set attributes
     const QVariantMap attributesData = featureData[u"attributes"_s].toMap();

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -181,7 +181,7 @@ QgsFeatureId QgsAfsSharedData::objectIdToFeatureId( quint32 oid )
   return mObjectIdToFeatureId.value( oid, -1 );
 }
 
-bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRectangle &filterRect, QgsFeedback *feedback )
+bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, QgsFeedback *feedback )
 {
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   Q_ASSERT( mHasFetchedObjectIds );
@@ -191,7 +191,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
   if ( it != mCache.constEnd() )
   {
     f = it.value();
-    return filterRect.isNull() || ( f.hasGeometry() && f.geometry().intersects( filterRect ) );
+    return true;
   }
 
   const QString authcfg = mDataSource.authConfigId();
@@ -231,7 +231,6 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
       QStringList(),
       QgsWkbTypes::hasM( mGeometryType ),
       QgsWkbTypes::hasZ( mGeometryType ),
-      filterRect,
       errorTitle,
       errorMessage,
       mDataSource.httpHeaders(),
@@ -326,7 +325,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
   if ( it != mCache.constEnd() )
   {
     f = it.value();
-    return filterRect.isNull() || ( f.hasGeometry() && f.geometry().intersects( filterRect ) );
+    return true;
   }
 
   return false;

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -40,7 +40,7 @@ long long QgsAfsSharedData::objectIdCount() const
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   Q_ASSERT( mHasFetchedObjectIds );
 
-  return mObjectIds.size();
+  return mFeatureIdsToObjectIds.size();
 }
 
 long long QgsAfsSharedData::featureCount( QString &errorMessage )
@@ -51,7 +51,7 @@ long long QgsAfsSharedData::featureCount( QString &errorMessage )
   }
 
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
-  return mObjectIds.size() - mDeletedFeatureIds.size();
+  return mFeatureIdsToObjectIds.size() - mDeletedFeatureIds.size();
 }
 
 QgsRectangle QgsAfsSharedData::extent() const
@@ -91,7 +91,7 @@ std::shared_ptr<QgsAfsSharedData> QgsAfsSharedData::clone() const
   copy->mMaximumFetchObjectsCount = mMaximumFetchObjectsCount;
   copy->mObjectIdFieldName = mObjectIdFieldName;
   copy->mObjectIdFieldIdx = mObjectIdFieldIdx;
-  copy->mObjectIds = mObjectIds;
+  copy->mFeatureIdsToObjectIds = mFeatureIdsToObjectIds;
   copy->mObjectIdToFeatureId = mObjectIdToFeatureId;
   copy->mDeletedFeatureIds = mDeletedFeatureIds;
   copy->mCache = mCache;
@@ -117,7 +117,7 @@ void QgsAfsSharedData::clearCache()
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Write );
 
   mCache.clear();
-  mObjectIds.clear();
+  mFeatureIdsToObjectIds.clear();
   mObjectIdToFeatureId.clear();
   mDeletedFeatureIds.clear();
   mHasFetchedObjectIds = false;
@@ -151,13 +151,13 @@ bool QgsAfsSharedData::getObjectIds( QString &errorMessage )
   }
 
   const QVariantList objectIds = objectIdData.value( u"objectIds"_s ).toList();
-  mObjectIds.reserve( mObjectIds.size() + objectIds.size() );
+  mFeatureIdsToObjectIds.reserve( mFeatureIdsToObjectIds.size() + objectIds.size() );
   mObjectIdToFeatureId.reserve( mObjectIdToFeatureId.size() + objectIds.size() );
   for ( const QVariant &objectId : objectIds )
   {
     const int objectIdInt = objectId.toInt();
-    mObjectIdToFeatureId.insert( objectIdInt, mObjectIds.size() );
-    mObjectIds.append( objectIdInt );
+    mObjectIdToFeatureId.insert( objectIdInt, mFeatureIdsToObjectIds.size() );
+    mFeatureIdsToObjectIds.append( objectIdInt );
   }
   mHasFetchedObjectIds = true;
   return true;
@@ -170,7 +170,7 @@ quint32 QgsAfsSharedData::featureIdToObjectId( QgsFeatureId id, QString &error )
     return 0;
   }
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
-  return mObjectIds.value( id, -1 );
+  return mFeatureIdsToObjectIds.value( id, -1 );
 }
 
 QgsFeatureId QgsAfsSharedData::objectIdToFeatureId( quint32 oid )
@@ -202,13 +202,13 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, QgsFeedback *
   while ( !featureFetched )
   {
     startId = ( id / mMaximumFetchObjectsCount ) * mMaximumFetchObjectsCount;
-    const int stopId = std::min<size_t>( startId + mMaximumFetchObjectsCount, mObjectIds.length() );
+    const int stopId = std::min<size_t>( startId + mMaximumFetchObjectsCount, mFeatureIdsToObjectIds.length() );
     objectIds.clear();
     objectIds.reserve( stopId - startId );
     for ( int i = startId; i < stopId; ++i )
     {
-      if ( i >= 0 && i < mObjectIds.count() && !mDeletedFeatureIds.contains( i ) && !mCache.contains( i ) )
-        objectIds.append( mObjectIds.at( i ) );
+      if ( i >= 0 && i < mFeatureIdsToObjectIds.count() && !mDeletedFeatureIds.contains( i ) && !mCache.contains( i ) )
+        objectIds.append( mFeatureIdsToObjectIds.at( i ) );
     }
 
     if ( objectIds.empty() )
@@ -365,7 +365,7 @@ bool QgsAfsSharedData::deleteFeatures( const QgsFeatureIds &ids, QString &error,
   QStringList stringIds;
   for ( const QgsFeatureId id : ids )
   {
-    stringIds.append( QString::number( mObjectIds[id] ) );
+    stringIds.append( QString::number( mFeatureIdsToObjectIds[id] ) );
   }
   locker.unlock();
 
@@ -444,10 +444,10 @@ bool QgsAfsSharedData::addFeatures( QgsFeatureList &features, QString &errorMess
     const QVariantMap resultMap = result.toMap();
     const long long objectId = resultMap.value( u"objectId"_s ).toLongLong();
 
-    const QgsFeatureId newId = mObjectIds.size();
+    const QgsFeatureId newId = mFeatureIdsToObjectIds.size();
     features[i].setId( newId );
     mObjectIdToFeatureId.insert( objectId, newId );
-    mObjectIds.append( objectId );
+    mFeatureIdsToObjectIds.append( objectId );
 
     i++;
   }

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -64,12 +64,13 @@ class QgsAfsSharedData
      *
      * \param id target feature ID
      * \param f feature to be populated
+     * \param pendingFeatureIds optional list of other features which are desirable to request in a batch operation, if a network request is required to fetch the target feature.
      * \param feedback
      * \returns TRUE if matching feature was retrieved
      *
      * \warning ensureObjectIdsFetched() MUST have been called before calling this!
      */
-    bool getFeature( QgsFeatureId id, QgsFeature &f, QgsFeedback *feedback = nullptr );
+    bool getFeature( QgsFeatureId id, QgsFeature &f, const QList<QgsFeatureId> &pendingFeatureIds = QList< QgsFeatureId >(), QgsFeedback *feedback = nullptr );
 
     // ensureObjectIdsFetched MUST have been called!
     QgsFeatureIds getFeatureIdsInExtent( const QgsRectangle &extent, QgsFeedback *feedback );

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -59,8 +59,18 @@ class QgsAfsSharedData
     // lock must already be obtained by caller, and ensureObjectIdsFetched MUST have been called!
     QgsFeatureId objectIdToFeatureId( quint32 oid );
 
-    // ensureObjectIdsFetched MUST have been called!
-    bool getFeature( QgsFeatureId id, QgsFeature &f, const QgsRectangle &filterRect = QgsRectangle(), QgsFeedback *feedback = nullptr );
+    /**
+     * Retrieves a feature by \a id.
+     *
+     * \param id target feature ID
+     * \param f feature to be populated
+     * \param feedback
+     * \returns TRUE if matching feature was retrieved
+     *
+     * \warning ensureObjectIdsFetched() MUST have been called before calling this!
+     */
+    bool getFeature( QgsFeatureId id, QgsFeature &f, QgsFeedback *feedback = nullptr );
+
     // ensureObjectIdsFetched MUST have been called!
     QgsFeatureIds getFeatureIdsInExtent( const QgsRectangle &extent, QgsFeedback *feedback );
 

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -101,7 +101,9 @@ class QgsAfsSharedData
     QString mObjectIdFieldName;
     int mObjectIdFieldIdx = -1;
 
-    QList<quint32> mObjectIds;
+    // list index is feature id, value is object ID
+    QList<quint32> mFeatureIdsToObjectIds;
+    // hash key is object ID, value is feature ID
     QHash<quint32, QgsFeatureId> mObjectIdToFeatureId;
 
     QSet<QgsFeatureId> mDeletedFeatureIds;

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -248,7 +248,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             QgisTestCase.sanitize_local_url(
                 endpoint,
-                "/query?f=json&objectIds=5,3,1,2,4&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
+                "/query?f=json&objectIds=1,2,3,4,5&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
             ),
             "wb",
         ) as f:
@@ -406,7 +406,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             QgisTestCase.sanitize_local_url(
                 endpoint,
-                "/query?f=json&objectIds=3,2,4&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
+                "/query?f=json&objectIds=2,3,4&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
             ),
             "wb",
         ) as f:
@@ -510,7 +510,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             QgisTestCase.sanitize_local_url(
                 endpoint,
-                "/query?f=json&objectIds=3,2&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
+                "/query?f=json&objectIds=2,3&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
             ),
             "wb",
         ) as f:
@@ -587,7 +587,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             QgisTestCase.sanitize_local_url(
                 endpoint,
-                "/query?f=json&objectIds=5,3,1,2,4&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false&geometry=-71.123000,66.330000,-65.320000,78.300000&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelEnvelopeIntersects",
+                "/query?f=json&objectIds=1,2,3,4,5&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false&geometry=-71.123000,66.330000,-65.320000,78.300000&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelEnvelopeIntersects",
             ),
             "wb",
         ) as f:
@@ -1236,7 +1236,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             self.sanitize_local_url(
                 endpoint,
-                "/query?f=json&objectIds=5,3,1,2,4&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
+                "/query?f=json&objectIds=1,2,3,4,5&inSR=4326&outSR=4326&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
             ),
             "wb",
         ) as f:
@@ -1708,7 +1708,7 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
         with open(
             self.sanitize_local_url(
                 endpoint,
-                "/query?f=json&objectIds=5,3,1,2,4&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
+                "/query?f=json&objectIds=1,2,3,4,5&returnGeometry=true&outFields=*&returnM=false&returnZ=false",
             ),
             "wb",
         ) as f:

--- a/tests/src/python/test_provider_afs.py
+++ b/tests/src/python/test_provider_afs.py
@@ -578,33 +578,6 @@ class TestPyQgsAFSProvider(QgisTestCase, ProviderTestCase):
             "x": -68.2,
             "y": 70.8
            }
-          },
-          {
-           "attributes": {
-            "OBJECTID": 4,
-            "pk": 4,
-            "cnt": 400,
-            "name": "Honey",
-            "name2":"Honey",
-            "num_char":"4",
-            "dt": """
-                    + str(
-                        QDateTime(
-                            QDate(2021, 5, 4), QTime(13, 13, 14)
-                        ).toMSecsSinceEpoch()
-                    )
-                    + """,
-            "date": """
-                    + str(
-                        QDateTime(QDate(2021, 5, 4), QTime(0, 0, 0)).toMSecsSinceEpoch()
-                    )
-                    + """,
-            "time": "13:13:14"
-           },
-           "geometry": {
-            "x": -65.32,
-            "y": 78.3
-           }
           }
          ]
         }"""


### PR DESCRIPTION
## Description

Before, when we needed a feature, we'd build a "batch" of adjacent feature IDs we hadn't yet requested from the service.
These were effectively random, and could be geographically located well outside of the requested map extent.

Now, we pass the list of feature ids that the iterator actually wants to that batch request, so that we don't just blindly add
random features to the batch, but instead add features which the iterator needs.

This results in much less network requests to get the features actually matching the requested request, giving a much more
responsive provider. (The actual TOTAL number of requests to get EVERY feature from the service doesn't change, so eg opening
the attribute table would result in the same total number of requests).

Funded by République et canton de Genève

Left = before, right = after. Check out the much reduced number of requests outgoing for the same map extent!

https://github.com/user-attachments/assets/949bbc20-c0e0-4079-a6a3-54f7f927cdef


## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
