### PR TITLE
[afs] Defer retrieval of all feature ids until its actually needed

### DIFF
--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -119,7 +119,15 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
   if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
     return false;
 
-  if ( mFeatureIterator >= mSource->sharedData()->objectIdCount() )
+  QString errorMessage;
+  if ( !mSource->sharedData()->ensureObjectIdsFetched( errorMessage ) )
+  {
+    QgsDebugError( errorMessage );
+    return false;
+  }
+
+  const long long objectIdCount = mSource->sharedData()->objectIdCount();
+  if ( mFeatureIterator >= objectIdCount )
     return false;
 
   if ( mDeferredFeaturesInFilterRectCheck )
@@ -184,7 +192,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
     case Qgis::FeatureRequestFilterType::Expression:
     case Qgis::FeatureRequestFilterType::NoFilter:
     {
-      while ( mFeatureIterator < mSource->sharedData()->objectIdCount() )
+      while ( mFeatureIterator < objectIdCount )
       {
         if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
           return false;

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -74,6 +74,8 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   mLayerDescription = layerData[u"description"_s].toString();
   mCapabilityStrings = layerData[u"capabilities"_s].toString().split( ',' );
 
+  mSharedData->mObjectIdFieldName = layerData[u"objectIdField"_s].toString();
+
   if ( mCapabilityStrings.contains( "update"_L1, Qt::CaseInsensitive ) )
   {
     // if the user has update capability, see if this extends to field definition modification
@@ -166,8 +168,6 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
     }
   }
 
-  QString objectIdFieldName;
-
   // Read fields
   const QVariantList fields = layerData.value( u"fields"_s ).toList();
   for ( const QVariant &fieldData : fields )
@@ -182,9 +182,9 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
       // skip geometry field
       continue;
     }
-    if ( fieldTypeString == "esriFieldTypeOID"_L1 )
+    if ( mSharedData->mObjectIdFieldName.isEmpty() && fieldTypeString == "esriFieldTypeOID"_L1 )
     {
-      objectIdFieldName = fieldName;
+      mSharedData->mObjectIdFieldName = fieldName;
     }
     if ( type == QMetaType::Type::UnknownType )
     {
@@ -225,8 +225,25 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
 
     mSharedData->mFields.append( field );
   }
-  if ( objectIdFieldName.isEmpty() )
-    objectIdFieldName = u"objectid"_s;
+  if ( mSharedData->mObjectIdFieldName.isEmpty() )
+    mSharedData->mObjectIdFieldName = u"objectid"_s;
+
+  for ( int idx = 0, nIdx = mSharedData->mFields.count(); idx < nIdx; ++idx )
+  {
+    if ( mSharedData->mFields.at( idx ).name() == mSharedData->mObjectIdFieldName )
+    {
+      mSharedData->mObjectIdFieldIdx = idx;
+
+      // primary key is not null, unique
+      QgsFieldConstraints constraints = mSharedData->mFields.at( idx ).constraints();
+      constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
+      constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
+      mSharedData->mFields[idx].setConstraints( constraints );
+      mSharedData->mFields[idx].setReadOnly( true );
+
+      break;
+    }
+  }
 
   if ( isTable )
   {
@@ -392,12 +409,13 @@ bool QgsAfsProvider::addFeatures( QgsFeatureList &flist, Flags )
   // field to QgsUnsetAttributeValue. This is required to maintain stable API which allowed
   // provider default value clause strings to be used as an alias for unset attributes.
   // TODO QGIS 5 - We can remove this when we no longer need to respect that.
+  const int objectIdFieldIndex = mSharedData->objectIdFieldIndex();
   for ( int i = 0; i < flist.size(); ++i )
   {
     QgsFeature &f = flist[i];
-    if ( mSharedData->mObjectIdFieldIdx >= 0 && f.attributes().size() > mSharedData->mObjectIdFieldIdx && f.attribute( mSharedData->mObjectIdFieldIdx ) == "Autogenerate"_L1 )
+    if ( objectIdFieldIndex >= 0 && f.attributes().size() > objectIdFieldIndex && f.attribute( objectIdFieldIndex ) == "Autogenerate"_L1 )
     {
-      f.setAttribute( mSharedData->mObjectIdFieldIdx, QgsUnsetAttributeValue() );
+      f.setAttribute( objectIdFieldIndex, QgsUnsetAttributeValue() );
     }
   }
 
@@ -432,7 +450,7 @@ bool QgsAfsProvider::changeAttributeValues( const QgsChangedAttributesMap &attrM
   QgsFeatureList updatedFeatures;
   updatedFeatures.reserve( attrMap.size() );
 
-  const int objectIdFieldIndex = mSharedData->mObjectIdFieldIdx;
+  const int objectIdFieldIndex = mSharedData->objectIdFieldIndex();
 
   while ( it.nextFeature( feature ) )
   {
@@ -467,7 +485,7 @@ bool QgsAfsProvider::changeGeometryValues( const QgsGeometryMap &geometryMap )
     return false;
 
   const QgsFields fields = mSharedData->mFields;
-  const int objectIdFieldIndex = mSharedData->mObjectIdFieldIdx;
+  const int objectIdFieldIndex = mSharedData->objectIdFieldIndex();
 
   QgsFeatureList updatedFeatures;
   updatedFeatures.reserve( geometryMap.size() );
@@ -520,7 +538,7 @@ bool QgsAfsProvider::changeFeatures( const QgsChangedAttributesMap &attrMap, con
 
   QgsFeatureList updatedFeatures;
   updatedFeatures.reserve( attrMap.size() );
-  const int objectIdFieldIndex = mSharedData->mObjectIdFieldIdx;
+  const int objectIdFieldIndex = mSharedData->objectIdFieldIndex();
 
   while ( it.nextFeature( feature ) )
   {
@@ -656,19 +674,19 @@ Qgis::VectorProviderCapabilities QgsAfsProvider::capabilities() const
 
 QgsAttributeList QgsAfsProvider::pkAttributeIndexes() const
 {
-  return QgsAttributeList() << mSharedData->mObjectIdFieldIdx;
+  return QgsAttributeList() << mSharedData->objectIdFieldIndex();
 }
 
 QString QgsAfsProvider::defaultValueClause( int fieldId ) const
 {
-  if ( fieldId == mSharedData->mObjectIdFieldIdx )
+  if ( fieldId == mSharedData->objectIdFieldIndex() )
     return u"Autogenerate"_s;
   return QString();
 }
 
 bool QgsAfsProvider::skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint, const QVariant &value ) const
 {
-  return fieldIndex == mSharedData->mObjectIdFieldIdx && ( QgsVariantUtils::isUnsetAttributeValue( value ) || value.toString() == "Autogenerate"_L1 );
+  return fieldIndex == mSharedData->objectIdFieldIndex() && ( QgsVariantUtils::isUnsetAttributeValue( value ) || value.toString() == "Autogenerate"_L1 );
 }
 
 QString QgsAfsProvider::subsetString() const

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -312,15 +312,6 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   if ( profile )
     profile->switchTask( tr( "Retrieve object IDs" ) );
 
-  // Read OBJECTIDs of all features: these may not be a continuous sequence,
-  // and we need to store these to iterate through the features. This query
-  // also returns the name of the ObjectID field.
-  if ( !mSharedData->getObjectIds( errorMessage ) )
-  {
-    appendError( QgsErrorMessage( errorMessage, u"AFSProvider"_s ) );
-    return;
-  }
-
   // layer metadata
 
   mLayerMetadata.setIdentifier( mSharedData->mDataSource.param( u"url"_s ) );
@@ -368,7 +359,14 @@ Qgis::WkbType QgsAfsProvider::wkbType() const
 
 long long QgsAfsProvider::featureCount() const
 {
-  return mSharedData->featureCount();
+  QString error;
+  const long long result = mSharedData->featureCount( error );
+  if ( result < 0 )
+  {
+    pushError( error );
+    return static_cast< long long >( Qgis::FeatureCountState::UnknownCount );
+  }
+  return result;
 }
 
 QgsFields QgsAfsProvider::fields() const
@@ -498,7 +496,13 @@ bool QgsAfsProvider::changeGeometryValues( const QgsGeometryMap &geometryMap )
     QgsFeature feature( fields );
     feature.setId( id );
     // we ONLY require the objectId field set here
-    feature.setAttribute( objectIdFieldIndex, mSharedData->featureIdToObjectId( id ) );
+    QString error;
+    feature.setAttribute( objectIdFieldIndex, mSharedData->featureIdToObjectId( id, error ) );
+    if ( !error.isEmpty() )
+    {
+      pushError( tr( "Error while updating features: %1" ).arg( error ) );
+      return false;
+    }
     feature.setGeometry( it.value() );
 
     updatedFeatures.append( feature );

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -125,23 +125,11 @@ bool QgsAfsSharedData::getObjectIds( QString &errorMessage )
     errorMessage = QObject::tr( "Failed to determine objectIdFieldName and/or objectIds" );
     return false;
   }
-  mObjectIdFieldName = objectIdData[u"objectIdFieldName"_s].toString();
-  for ( int idx = 0, nIdx = mFields.count(); idx < nIdx; ++idx )
+  if ( objectIdData[u"objectIdFieldName"_s].toString() != mObjectIdFieldName )
   {
-    if ( mFields.at( idx ).name() == mObjectIdFieldName )
-    {
-      mObjectIdFieldIdx = idx;
-
-      // primary key is not null, unique
-      QgsFieldConstraints constraints = mFields.at( idx ).constraints();
-      constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
-      constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
-      mFields[idx].setConstraints( constraints );
-      mFields[idx].setReadOnly( true );
-
-      break;
-    }
+    QgsDebugError( u"Object ID field name mismatch: %1 vs %2"_s.arg( objectIdData[u"objectIdFieldName"_s].toString(), mObjectIdFieldName ) );
   }
+
   const QVariantList objectIds = objectIdData.value( u"objectIds"_s ).toList();
   mObjectIds.reserve( mObjectIds.size() + objectIds.size() );
   mObjectIdToFeatureId.reserve( mObjectIdToFeatureId.size() + objectIds.size() );
@@ -613,6 +601,12 @@ bool QgsAfsSharedData::hasCachedAllFeatures() const
 {
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   return mCache.count() == featureCount();
+}
+
+int QgsAfsSharedData::objectIdFieldIndex() const
+{
+  QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
+  return mObjectIdFieldIdx;
 }
 
 QVariantMap QgsAfsSharedData::postData( const QUrl &url, const QByteArray &payload, QgsFeedback *feedback, bool &ok, QString &errorText ) const

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -38,11 +38,18 @@ using namespace Qt::StringLiterals;
 long long QgsAfsSharedData::objectIdCount() const
 {
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
+  Q_ASSERT( mHasFetchedObjectIds );
+
   return mObjectIds.size();
 }
 
-long long QgsAfsSharedData::featureCount() const
+long long QgsAfsSharedData::featureCount( QString &errorMessage )
 {
+  if ( !ensureObjectIdsFetched( errorMessage ) )
+  {
+    return -1;
+  }
+
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   return mObjectIds.size() - mDeletedFeatureIds.size();
 }
@@ -59,10 +66,24 @@ QgsAfsSharedData::QgsAfsSharedData( const QgsDataSourceUri &uri )
   : mDataSource( uri )
 {}
 
+bool QgsAfsSharedData::ensureObjectIdsFetched( QString &errorMessage )
+{
+  QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
+  if ( mHasFetchedObjectIds )
+    return true;
+
+  locker.unlock();
+  // Read OBJECTIDs of all features: these may not be a continuous sequence,
+  // and we need to store these to iterate through the features. This query
+  // also returns the name of the ObjectID field.
+  return getObjectIds( errorMessage );
+}
+
 std::shared_ptr<QgsAfsSharedData> QgsAfsSharedData::clone() const
 {
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   auto copy = std::make_shared<QgsAfsSharedData>( mDataSource );
+  copy->mHasFetchedObjectIds = mHasFetchedObjectIds;
   copy->mLimitBBox = mLimitBBox;
   copy->mExtent = mExtent;
   copy->mGeometryType = mGeometryType;
@@ -99,8 +120,7 @@ void QgsAfsSharedData::clearCache()
   mObjectIds.clear();
   mObjectIdToFeatureId.clear();
   mDeletedFeatureIds.clear();
-  QString error;
-  getObjectIds( error );
+  mHasFetchedObjectIds = false;
 }
 
 bool QgsAfsSharedData::getObjectIds( QString &errorMessage )
@@ -139,17 +159,24 @@ bool QgsAfsSharedData::getObjectIds( QString &errorMessage )
     mObjectIdToFeatureId.insert( objectIdInt, mObjectIds.size() );
     mObjectIds.append( objectIdInt );
   }
+  mHasFetchedObjectIds = true;
   return true;
 }
 
-quint32 QgsAfsSharedData::featureIdToObjectId( QgsFeatureId id )
+quint32 QgsAfsSharedData::featureIdToObjectId( QgsFeatureId id, QString &error )
 {
+  if ( !ensureObjectIdsFetched( error ) )
+  {
+    return 0;
+  }
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
   return mObjectIds.value( id, -1 );
 }
 
-QgsFeatureId QgsAfsSharedData::objectIdToFeatureId( quint32 oid ) const
+QgsFeatureId QgsAfsSharedData::objectIdToFeatureId( quint32 oid )
 {
+  Q_ASSERT( mHasFetchedObjectIds );
+
   // lock must already be obtained by caller!
   return mObjectIdToFeatureId.value( oid, -1 );
 }
@@ -157,6 +184,7 @@ QgsFeatureId QgsAfsSharedData::objectIdToFeatureId( quint32 oid ) const
 bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRectangle &filterRect, QgsFeedback *feedback )
 {
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
+  Q_ASSERT( mHasFetchedObjectIds );
 
   // If cached, return cached feature
   QMap<QgsFeatureId, QgsFeature>::const_iterator it = mCache.constFind( id );
@@ -314,6 +342,8 @@ QgsFeatureIds QgsAfsSharedData::getFeatureIdsInExtent( const QgsRectangle &exten
     getObjectIdsByExtent( mDataSource.param( u"url"_s ), extent, errorTitle, errorText, authcfg, mDataSource.httpHeaders(), feedback, mDataSource.sql(), mDataSource.param( u"urlprefix"_s ) );
 
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
+  Q_ASSERT( mHasFetchedObjectIds );
+
   QgsFeatureIds ids;
   for ( const quint32 objectId : objectIdsInRect )
   {
@@ -327,6 +357,10 @@ QgsFeatureIds QgsAfsSharedData::getFeatureIdsInExtent( const QgsRectangle &exten
 bool QgsAfsSharedData::deleteFeatures( const QgsFeatureIds &ids, QString &error, QgsFeedback *feedback )
 {
   error.clear();
+  if ( !ensureObjectIdsFetched( error ) )
+  {
+    return false;
+  }
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
 
   QStringList stringIds;
@@ -361,6 +395,11 @@ bool QgsAfsSharedData::deleteFeatures( const QgsFeatureIds &ids, QString &error,
 bool QgsAfsSharedData::addFeatures( QgsFeatureList &features, QString &errorMessage, QgsFeedback *feedback )
 {
   errorMessage.clear();
+  if ( !ensureObjectIdsFetched( errorMessage ) )
+  {
+    return false;
+  }
+
   QUrl queryUrl( mDataSource.param( u"url"_s ) + "/addFeatures" );
 
   QgsArcGisRestContext context;
@@ -419,6 +458,10 @@ bool QgsAfsSharedData::addFeatures( QgsFeatureList &features, QString &errorMess
 bool QgsAfsSharedData::updateFeatures( const QgsFeatureList &features, bool includeGeometries, bool includeAttributes, QString &error, QgsFeedback *feedback )
 {
   error.clear();
+  if ( !ensureObjectIdsFetched( error ) )
+  {
+    return false;
+  }
   QUrl queryUrl( mDataSource.param( u"url"_s ) + "/updateFeatures" );
 
   QgsArcGisRestContext context;
@@ -516,6 +559,10 @@ bool QgsAfsSharedData::addFields( const QString &adminUrl, const QList<QgsField>
 bool QgsAfsSharedData::deleteFields( const QString &adminUrl, const QgsAttributeIds &attributes, QString &error, QgsFeedback *feedback )
 {
   error.clear();
+  if ( !ensureObjectIdsFetched( error ) )
+  {
+    return false;
+  }
   QUrl queryUrl( adminUrl + "/deleteFromDefinition" );
 
   QVariantList fieldsJson;
@@ -565,6 +612,10 @@ bool QgsAfsSharedData::deleteFields( const QString &adminUrl, const QgsAttribute
 bool QgsAfsSharedData::addAttributeIndex( const QString &adminUrl, int attribute, QString &error, QgsFeedback *feedback )
 {
   error.clear();
+  if ( !ensureObjectIdsFetched( error ) )
+  {
+    return false;
+  }
   QUrl queryUrl( adminUrl + "/addToDefinition" );
 
   const QString name = mFields.field( attribute ).name();
@@ -597,10 +648,20 @@ bool QgsAfsSharedData::addAttributeIndex( const QString &adminUrl, int attribute
   return true;
 }
 
-bool QgsAfsSharedData::hasCachedAllFeatures() const
+bool QgsAfsSharedData::hasCachedAllFeatures()
 {
   QgsReadWriteLocker locker( mReadWriteLock, QgsReadWriteLocker::Read );
-  return mCache.count() == featureCount();
+  if ( !mHasFetchedObjectIds )
+    return false;
+
+  QString error;
+  const long long count = featureCount( error );
+  if ( count < 0 )
+  {
+    return false;
+  }
+
+  return mCache.count() == count;
 }
 
 int QgsAfsSharedData::objectIdFieldIndex() const

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -68,6 +68,8 @@ class QgsAfsSharedData
 
     bool hasCachedAllFeatures() const;
 
+    int objectIdFieldIndex() const;
+
   private:
     QVariantMap postData( const QUrl &url, const QByteArray &payload, QgsFeedback *feedback, bool &ok, QString &errorText ) const;
 

--- a/src/providers/arcgisrest/qgsafsshareddata.h
+++ b/src/providers/arcgisrest/qgsafsshareddata.h
@@ -34,11 +34,14 @@ class QgsAfsSharedData
   public:
     QgsAfsSharedData( const QgsDataSourceUri &uri );
 
+    bool ensureObjectIdsFetched( QString &errorMessage );
+
     //! Creates a deep copy of this shared data
     std::shared_ptr<QgsAfsSharedData> clone() const;
 
+    // ensureObjectIdsFetched MUST have been called!
     long long objectIdCount() const;
-    long long featureCount() const;
+    long long featureCount( QString &errorMessage );
     bool isDeleted( QgsFeatureId id ) const { return mDeletedFeatureIds.contains( id ); }
     const QgsFields &fields() const { return mFields; }
     QgsRectangle extent() const;
@@ -51,12 +54,14 @@ class QgsAfsSharedData
 
     bool getObjectIds( QString &errorMessage );
 
-    quint32 featureIdToObjectId( QgsFeatureId id );
+    quint32 featureIdToObjectId( QgsFeatureId id, QString &error );
 
-    // lock must already be obtained by caller!
-    QgsFeatureId objectIdToFeatureId( quint32 oid ) const;
+    // lock must already be obtained by caller, and ensureObjectIdsFetched MUST have been called!
+    QgsFeatureId objectIdToFeatureId( quint32 oid );
 
+    // ensureObjectIdsFetched MUST have been called!
     bool getFeature( QgsFeatureId id, QgsFeature &f, const QgsRectangle &filterRect = QgsRectangle(), QgsFeedback *feedback = nullptr );
+    // ensureObjectIdsFetched MUST have been called!
     QgsFeatureIds getFeatureIdsInExtent( const QgsRectangle &extent, QgsFeedback *feedback );
 
     bool deleteFeatures( const QgsFeatureIds &id, QString &error, QgsFeedback *feedback );
@@ -66,7 +71,7 @@ class QgsAfsSharedData
     bool deleteFields( const QString &adminUrl, const QgsAttributeIds &attributes, QString &error, QgsFeedback *feedback );
     bool addAttributeIndex( const QString &adminUrl, int attribute, QString &error, QgsFeedback *feedback );
 
-    bool hasCachedAllFeatures() const;
+    bool hasCachedAllFeatures();
 
     int objectIdFieldIndex() const;
 
@@ -76,6 +81,7 @@ class QgsAfsSharedData
     friend class QgsAfsProvider;
     mutable QReadWriteLock mReadWriteLock { QReadWriteLock::Recursive };
     QgsDataSourceUri mDataSource;
+    bool mHasFetchedObjectIds = false;
     bool mLimitBBox = false;
     QgsRectangle mExtent;
     Qgis::WkbType mGeometryType = Qgis::WkbType::Unknown;


### PR DESCRIPTION
## Description

Instead of doing an immediate upfront (expensive!) retrieval of all feature IDs in the layer on creation of the provider, defer
this until its actually required.

By deferring we make it likely that the retrieval will occur on a background thread instead of blocking the main thread, as generally the first features requested for a newly created layer happen as part of the map render, which runs in a background thread.

Speeds up initial creation of FeatureServer layers, especially useful when loading a project containing multiple layers or when first
adding a large FeatureServer layer to a new project.

Funded by République et canton de Genève

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
