### PR TITLE
Fix cmake errors

### DIFF
--- a/cmake/FindSpatiaLite.cmake
+++ b/cmake/FindSpatiaLite.cmake
@@ -17,8 +17,10 @@ if(PkgConfig_FOUND)
 endif()
 
 if(PC_SPATIALITE_FOUND)
-  add_library(spatialite::spatialite ALIAS PkgConfig::PC_SPATIALITE)
-  set(SPATIALITE_FOUND TRUE)
+  if(NOT TARGET spatialite::spatialite)
+    add_library(spatialite::spatialite ALIAS PkgConfig::PC_SPATIALITE)
+    set(SPATIALITE_FOUND TRUE)
+  endif()
 else()
   # Fallback for systems without PkgConfig, e.g. OSGeo4W
 

--- a/cmake/Findnlohmann_json.cmake
+++ b/cmake/Findnlohmann_json.cmake
@@ -1,12 +1,14 @@
 if(WITH_INTERNAL_NLOHMANN_JSON)
   # Create imported target nlohmann_json::nlohmann_json
-  add_library(nlohmann_json::nlohmann_json INTERFACE IMPORTED)
+  if(NOT TARGET nlohmann_json::nlohmann_json)
+    add_library(nlohmann_json::nlohmann_json INTERFACE IMPORTED)
   
-  set_target_properties(nlohmann_json::nlohmann_json PROPERTIES
-    INTERFACE_COMPILE_DEFINITIONS "\$<\$<NOT:\$<BOOL:ON>>:JSON_USE_GLOBAL_UDLS=0>;\$<\$<NOT:\$<BOOL:ON>>:JSON_USE_IMPLICIT_CONVERSIONS=0>;\$<\$<BOOL:OFF>:JSON_DISABLE_ENUM_SERIALIZATION=1>;\$<\$<BOOL:OFF>:JSON_DIAGNOSTICS=1>;\$<\$<BOOL:OFF>:JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON=1>"
-    INTERFACE_COMPILE_FEATURES "cxx_std_11"
-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/external/nlohmann/"
-  )
+    set_target_properties(nlohmann_json::nlohmann_json PROPERTIES
+      INTERFACE_COMPILE_DEFINITIONS "\$<\$<NOT:\$<BOOL:ON>>:JSON_USE_GLOBAL_UDLS=0>;\$<\$<NOT:\$<BOOL:ON>>:JSON_USE_IMPLICIT_CONVERSIONS=0>;\$<\$<BOOL:OFF>:JSON_DISABLE_ENUM_SERIALIZATION=1>;\$<\$<BOOL:OFF>:JSON_DIAGNOSTICS=1>;\$<\$<BOOL:OFF>:JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON=1>"
+      INTERFACE_COMPILE_FEATURES "cxx_std_11"
+      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/external/nlohmann/"
+    )
+  endif()
 else()
   find_package(nlohmann_json CONFIG REQUIRED)
 endif()


### PR DESCRIPTION
Avoids some cmake errors:

- add_library cannot create imported target "nlohmann_json::nlohmann_json" because another target with the same name already exists.
- add_library cannot create ALIAS target "spatialite::spatialite" because another target with the same name already exists.

(Note sure why these are only now appearing for me -- possibly related to a cmake or some other library update?)