### PR TITLE
Add 3d material settings to style database

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -105,6 +105,7 @@ if(WITH_APIDOC)
       ${CMAKE_SOURCE_DIR}/src/core/vectortile
       ${CMAKE_SOURCE_DIR}/src/core/web
       ${CMAKE_SOURCE_DIR}/src/gui
+      ${CMAKE_SOURCE_DIR}/src/gui/3d
       ${CMAKE_SOURCE_DIR}/src/gui/actions
       ${CMAKE_SOURCE_DIR}/src/gui/annotations
       ${CMAKE_SOURCE_DIR}/src/gui/attributetable

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -7729,7 +7729,7 @@ Qgis.MaterialRenderingTechnique.Points.__doc__ = "Point based rendering, require
 Qgis.MaterialRenderingTechnique.TrianglesWithFixedTexture.__doc__ = "Triangle based rendering, using a fixed, non-user-configurable texture (e.g. for terrain rendering)"
 Qgis.MaterialRenderingTechnique.TrianglesFromModel.__doc__ = "Triangle based rendering, using a model object source"
 Qgis.MaterialRenderingTechnique.TrianglesDataDefined.__doc__ = "Triangle based rendering with possibility of datadefined color"
-Qgis.MaterialRenderingTechnique.Billboards.__doc__ = "Rendering as flat billboards"
+Qgis.MaterialRenderingTechnique.Billboards.__doc__ = "Flat billboard rendering"
 Qgis.MaterialRenderingTechnique.__doc__ = """Material rendering techniques.
 
 .. warning::
@@ -7746,7 +7746,7 @@ Qgis.MaterialRenderingTechnique.__doc__ = """Material rendering techniques.
 * ``TrianglesWithFixedTexture``: Triangle based rendering, using a fixed, non-user-configurable texture (e.g. for terrain rendering)
 * ``TrianglesFromModel``: Triangle based rendering, using a model object source
 * ``TrianglesDataDefined``: Triangle based rendering with possibility of datadefined color
-* ``Billboards``: Rendering as flat billboards
+* ``Billboards``: Flat billboard rendering
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -7729,6 +7729,7 @@ Qgis.MaterialRenderingTechnique.Points.__doc__ = "Point based rendering, require
 Qgis.MaterialRenderingTechnique.TrianglesWithFixedTexture.__doc__ = "Triangle based rendering, using a fixed, non-user-configurable texture (e.g. for terrain rendering)"
 Qgis.MaterialRenderingTechnique.TrianglesFromModel.__doc__ = "Triangle based rendering, using a model object source"
 Qgis.MaterialRenderingTechnique.TrianglesDataDefined.__doc__ = "Triangle based rendering with possibility of datadefined color"
+Qgis.MaterialRenderingTechnique.Billboards.__doc__ = "Rendering as flat billboards"
 Qgis.MaterialRenderingTechnique.__doc__ = """Material rendering techniques.
 
 .. warning::
@@ -7745,6 +7746,7 @@ Qgis.MaterialRenderingTechnique.__doc__ = """Material rendering techniques.
 * ``TrianglesWithFixedTexture``: Triangle based rendering, using a fixed, non-user-configurable texture (e.g. for terrain rendering)
 * ``TrianglesFromModel``: Triangle based rendering, using a model object source
 * ``TrianglesDataDefined``: Triangle based rendering with possibility of datadefined color
+* ``Billboards``: Rendering as flat billboards
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgsstyle.py
+++ b/python/PyQt6/core/auto_additions/qgsstyle.py
@@ -116,6 +116,7 @@ QgsStyle.TextFormatEntity = QgsStyle.StyleEntity.TextFormatEntity
 QgsStyle.LabelSettingsEntity = QgsStyle.StyleEntity.LabelSettingsEntity
 QgsStyle.LegendPatchShapeEntity = QgsStyle.StyleEntity.LegendPatchShapeEntity
 QgsStyle.Symbol3DEntity = QgsStyle.StyleEntity.Symbol3DEntity
+QgsStyle.MaterialSettingsEntity = QgsStyle.StyleEntity.MaterialSettingsEntity
 # monkey patching scoped based enum
 QgsStyle.TextFormatContext.Labeling.__doc__ = "Text format used in labeling"
 QgsStyle.TextFormatContext.__doc__ = """Text format context.
@@ -168,5 +169,10 @@ except (NameError, AttributeError):
 try:
     QgsStyleSymbol3DEntity.__overridden_methods__ = ['type']
     QgsStyleSymbol3DEntity.__group__ = ['symbology']
+except (NameError, AttributeError):
+    pass
+try:
+    QgsStyleMaterialSettingsEntity.__overridden_methods__ = ['type']
+    QgsStyleMaterialSettingsEntity.__group__ = ['symbology']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgsstylemodel.py
+++ b/python/PyQt6/core/auto_additions/qgsstylemodel.py
@@ -40,6 +40,9 @@ QgsStyleModel.IsTitleRole = QgsStyleModel.CustomRole.IsTitle
 QgsStyleModel.Role.IsTitleRole = QgsStyleModel.CustomRole.IsTitle
 QgsStyleModel.IsTitleRole.is_monkey_patched = True
 QgsStyleModel.IsTitleRole.__doc__ = "True if the index corresponds to a title item \n.. versionadded:: 3.26"
+QgsStyleModel.MaterialType = QgsStyleModel.CustomRole.MaterialType
+QgsStyleModel.MaterialType.is_monkey_patched = True
+QgsStyleModel.MaterialType.__doc__ = "Material type (for material entities) \n.. versionadded:: 4.2"
 QgsStyleModel.CustomRole.__doc__ = """Custom model roles.
 
 .. note::
@@ -90,6 +93,10 @@ QgsStyleModel.CustomRole.__doc__ = """Custom model roles.
 
 
   Available as ``QgsStyleModel.IsTitleRole`` in older QGIS releases.
+
+* ``MaterialType``: Material type (for material entities)
+
+  .. versionadded:: 4.2
 
 
 """

--- a/python/PyQt6/core/auto_generated/3d/materials/qgsmaterialregistry.sip.in
+++ b/python/PyQt6/core/auto_generated/3d/materials/qgsmaterialregistry.sip.in
@@ -122,7 +122,7 @@ Registers a new material settings type. Takes ownership of the
 ``metadata`` instance.
 %End
 
-    QgsAbstractMaterialSettings *createMaterialSettings( const QString &type ) const /Factory/;
+    std::unique_ptr< QgsAbstractMaterialSettings > createMaterialSettings( const QString &type ) const;
 %Docstring
 Creates a new instance of the material settings of the specified
 ``type``.

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2419,6 +2419,7 @@ The development version
       TrianglesWithFixedTexture,
       TrianglesFromModel,
       TrianglesDataDefined,
+      Billboards,
     };
 
     enum class LightSourceType /BaseType=IntEnum/

--- a/python/PyQt6/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsstyle.sip.in
@@ -19,6 +19,7 @@ typedef QMap<QString, QgsTextFormat > QgsTextFormatMap;
 typedef QMap<QString, QgsPalLayerSettings > QgsLabelSettingsMap;
 
 
+
 typedef QMultiMap<QString, QString> QgsSmartConditionMap;
 
 
@@ -100,6 +101,7 @@ Constructor for QgsStyle, with the specified ``parent`` object.
       LabelSettingsEntity,
       LegendPatchShapeEntity,
       Symbol3DEntity,
+      MaterialSettingsEntity,
     };
 
     QString name() const;
@@ -264,7 +266,7 @@ Adds a 3d ``symbol`` with the specified ``name`` to the style. Ownership
 of ``symbol`` is transferred.
 
 If ``update`` is set to ``True``, the style database will be
-automatically updated with the new legend patch shape.
+automatically updated with the new 3d symbol.
 
 Returns ``True`` if the operation was successful.
 
@@ -273,6 +275,25 @@ Returns ``True`` if the operation was successful.
    Adding 3d symbols with the name of existing ones replaces them.
 
 .. versionadded:: 3.16
+%End
+
+    bool addMaterialSettings( const QString &name, QgsAbstractMaterialSettings *settings /Transfer/, bool update = false );
+%Docstring
+Adds a 3D material ``settings`` with the specified ``name`` to the
+style.
+
+Ownership of ``settings`` is transferred.
+
+If ``update`` is set to ``True``, the style database will be
+automatically updated with the new material settings.
+
+Returns ``True`` if the operation was successful.
+
+.. note::
+
+   Adding material settings with the name of existing ones replaces them.
+
+.. versionadded:: 4.2
 %End
 
     int addTag( const QString &tagName );
@@ -851,6 +872,51 @@ Returns a list of names of 3d symbols in the style.
 .. versionadded:: 3.16
 %End
 
+    bool saveMaterialSettings( const QString &name, QgsAbstractMaterialSettings *settings /Transfer/, bool favorite, const QStringList &tags );
+%Docstring
+Adds 3D material ``settings`` to the database.
+
+:param name: is the name of the material settings
+:param settings: 3D material settings to save. Ownership is transferred.
+:param favorite: is a boolean value to specify whether the material
+                 settings should be added to favorites
+:param tags: is a list of tags that are associated with the material
+             settings
+
+:return: returns the success state of the save operation
+
+.. versionadded:: 4.2
+%End
+
+    bool renameMaterialSettings( const QString &oldName, const QString &newName );
+%Docstring
+Changes a 3D material settings's name.
+
+.. versionadded:: 4.2
+%End
+
+    QStringList materialSettingsNames() const;
+%Docstring
+Returns a list of names of 3D material settings in the style.
+
+.. versionadded:: 4.2
+%End
+
+    int materialSettingsCount() const;
+%Docstring
+Returns count of 3D material settings in the style.
+
+.. versionadded:: 4.2
+%End
+
+    std::unique_ptr< QgsAbstractMaterialSettings > materialSettings( const QString &name ) const;
+%Docstring
+Returns a new copy of the 3D material settings with the specified
+``name``.
+
+.. versionadded:: 4.2
+%End
+
     bool createDatabase( const QString &filename );
 %Docstring
 Creates an on-disk database
@@ -1344,6 +1410,18 @@ database.
         sipType = sipType_QgsStyleLabelSettingsEntity;
         break;
 
+      case QgsStyle::LegendPatchShapeEntity:
+        sipType = sipType_QgsStyleLegendPatchShapeEntity;
+        break;
+
+      case QgsStyle::Symbol3DEntity:
+        sipType = sipType_QgsStyleSymbol3DEntity;
+        break;
+
+      case QgsStyle::MaterialSettingsEntity:
+        sipType = sipType_QgsStyleMaterialSettingsEntity;
+        break;
+
       case QgsStyle::SmartgroupEntity:
       case QgsStyle::TagEntity:
         sipType = 0;
@@ -1530,6 +1608,37 @@ Ownership of ``symbol`` is NOT transferred.
     const QgsAbstract3DSymbol *symbol() const;
 %Docstring
 Returns the entity's symbol.
+%End
+
+};
+
+
+class QgsStyleMaterialSettingsEntity : QgsStyleEntityInterface
+{
+%Docstring(signature="appended")
+A 3D material settings entity for :py:class:`QgsStyle` databases.
+
+.. versionadded:: 4.2
+%End
+
+%TypeHeaderCode
+#include "qgsstyle.h"
+%End
+  public:
+    QgsStyleMaterialSettingsEntity( const QgsAbstractMaterialSettings *settings );
+%Docstring
+Constructor for QgsStyleMaterialSettingsEntity, with the specified
+``settings``.
+
+Ownership of ``settings`` is NOT transferred.
+%End
+
+    virtual QgsStyle::StyleEntity type() const;
+
+
+    const QgsAbstractMaterialSettings *settings() const;
+%Docstring
+Returns the entity's settings.
 %End
 
 };

--- a/python/PyQt6/core/auto_generated/symbology/qgsstylemodel.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsstylemodel.sip.in
@@ -50,6 +50,7 @@ performance instead.
       StyleName,
       StyleFileName,
       IsTitle,
+      MaterialType
     };
 
     explicit QgsStyleModel( QgsStyle *style, QObject *parent /TransferThis/ = 0 );
@@ -210,7 +211,7 @@ Returns the symbol type filter.
 
 .. note::
 
-   This filter is only active if :py:class:`Qgis`.SymbolTypeFilterEnabled() is ``True``, and has
+   This filter is only active if :py:func:`~QgsStyleProxyModel.symbolTypeFilterEnabled` is ``True``, and has
    no effect on non-symbol entities (i.e. color ramps).
 
 .. seealso:: :py:func:`setSymbolType`
@@ -222,9 +223,9 @@ Sets the symbol ``type`` filter.
 
 .. note::
 
-   This filter is only active if :py:class:`Qgis`.SymbolTypeFilterEnabled() is ``True``.
+   This filter is only active if :py:func:`~QgsStyleProxyModel.symbolTypeFilterEnabled` is ``True``.
 
-.. seealso:: Qgis.SymbolType
+.. seealso:: :py:func:`symbolType`
 %End
 
     bool symbolTypeFilterEnabled() const;
@@ -233,7 +234,7 @@ Returns ``True`` if filtering by symbol type is enabled.
 
 .. seealso:: :py:func:`setSymbolTypeFilterEnabled`
 
-.. seealso:: Qgis.SymbolType
+.. seealso:: :py:func:`symbolType`
 %End
 
     void setSymbolTypeFilterEnabled( bool enabled );
@@ -241,10 +242,11 @@ Returns ``True`` if filtering by symbol type is enabled.
 Sets whether filtering by symbol type is ``enabled``.
 
 If ``enabled`` is ``False``, then the value of
-:py:class:`Qgis`.SymbolType() will have no effect on the model
-filtering. This has no effect on non-symbol entities (i.e. color ramps).
+:py:func:`~QgsStyleProxyModel.symbolType` will have no effect on the
+model filtering. This has no effect on non-symbol entities (i.e. color
+ramps).
 
-.. seealso:: Qgis.SymbolTypeFilterEnabled
+.. seealso:: :py:func:`symbolTypeFilterEnabled`
 
 .. seealso:: :py:func:`setSymbolType`
 %End
@@ -267,6 +269,59 @@ Sets the layer ``type`` filter. Set ``type`` to
 desired.
 
 .. seealso:: :py:func:`layerType`
+%End
+
+    bool renderingTechniqueFilterEnabled() const;
+%Docstring
+Returns ``True`` if filtering by material rendering technique is
+enabled.
+
+.. seealso:: :py:func:`setRenderingTechniqueFilterEnabled`
+
+.. seealso:: :py:func:`renderingTechnique`
+
+.. versionadded:: 4.2
+%End
+
+    void setRenderingTechniqueFilterEnabled( bool enabled );
+%Docstring
+Sets whether filtering by material rendering technique is ``enabled``.
+
+If ``enabled`` is ``False``, then the value of
+:py:func:`~QgsStyleProxyModel.renderingTechnique` will have no effect on
+the model filtering. This has no effect on non-material entities (i.e.
+color ramps).
+
+.. seealso:: :py:func:`renderingTechniqueFilterEnabled`
+
+.. seealso:: :py:func:`setRenderingTechnique`
+
+.. versionadded:: 4.2
+%End
+
+    Qgis::MaterialRenderingTechnique renderingTechnique() const;
+%Docstring
+Returns the rendering technique filter.
+
+.. note::
+
+   This filter is only active if :py:func:`~QgsStyleProxyModel.renderingTechniqueFilterEnabled` is ``True``, and has
+   no effect on non-material entities (i.e. color ramps).
+
+.. versionadded:: 4.2
+%End
+
+    void setRenderingTechnique( Qgis::MaterialRenderingTechnique technique );
+%Docstring
+Sets the rendering ``technique`` filter.
+
+.. note::
+
+   This filter is only active if :py:func:`~QgsStyleProxyModel.renderingTechniqueFilterEnabled` is ``True``.
+
+.. seealso:: :py:func:`renderingTechnique`
+
+.. versionadded:: 4.2
 %End
 
     void setTagId( int id );

--- a/python/PyQt6/gui/auto_additions/qgs3dsymbolwidget.py
+++ b/python/PyQt6/gui/auto_additions/qgs3dsymbolwidget.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/gui/qgs3dsymbolwidget.h
 try:
     Qgs3DSymbolWidget.__attribute_docs__ = {'changed': 'Emitted when the symbol is changed.\n'}
-    Qgs3DSymbolWidget.__abstract_methods__ = ['setSymbol', 'symbol', 'symbolType']
+    Qgs3DSymbolWidget.__abstract_methods__ = ['setSymbol', 'symbol', 'symbolType', 'renderingTechnique']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_additions/qgs3dsymbolwidget.py
+++ b/python/PyQt6/gui/auto_additions/qgs3dsymbolwidget.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/gui/qgs3dsymbolwidget.h
 try:
-    Qgs3DSymbolWidget.__attribute_docs__ = {'changed': 'Emitted when the symbol is changed.\n'}
+    Qgs3DSymbolWidget.__attribute_docs__ = {'changed': 'Emitted when the symbol is changed.\n', 'renderingTechniqueChanged': 'Emitted when the rendering technique associated with the symbol is\nchanged.\n\n.. warning::\n\n   This is not considered stable API, and may change in future QGIS releases. It is\n   exposed to the Python bindings as a tech preview only.\n\n.. versionadded:: 4.2\n'}
     Qgs3DSymbolWidget.__abstract_methods__ = ['setSymbol', 'symbol', 'symbolType', 'renderingTechnique']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_generated/qgs3dsymbolwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgs3dsymbolwidget.sip.in
@@ -44,6 +44,18 @@ Caller takes ownership of the returned symbol.
 Returns the symbol type handled by the widget.
 %End
 
+    virtual Qgis::MaterialRenderingTechnique renderingTechnique() const = 0;
+%Docstring
+Returns associated rendering technique.
+
+.. warning::
+
+   This is not considered stable API, and may change in future QGIS releases. It is
+   exposed to the Python bindings as a tech preview only.
+
+.. versionadded:: 4.2
+%End
+
   signals:
 
     void changed();

--- a/python/PyQt6/gui/auto_generated/qgs3dsymbolwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgs3dsymbolwidget.sip.in
@@ -62,6 +62,19 @@ Returns associated rendering technique.
 %Docstring
 Emitted when the symbol is changed.
 %End
+
+    void renderingTechniqueChanged();
+%Docstring
+Emitted when the rendering technique associated with the symbol is
+changed.
+
+.. warning::
+
+   This is not considered stable API, and may change in future QGIS releases. It is
+   exposed to the Python bindings as a tech preview only.
+
+.. versionadded:: 4.2
+%End
 };
 
 

--- a/python/PyQt6/gui/auto_generated/qgsstyleitemslistwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsstyleitemslistwidget.sip.in
@@ -84,6 +84,13 @@ Returns the type of the item currently selected in the widget.
 .. seealso:: :py:func:`currentItemName`
 %End
 
+    QgsStyleProxyModel *proxyModel();
+%Docstring
+Returns the associated proxy model.
+
+.. versionadded:: 4.2
+%End
+
   protected:
     virtual void showEvent( QShowEvent *event );
 

--- a/src/3d/materials/qgsgoochmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.cpp
@@ -58,6 +58,7 @@ QgsMaterial *QgsGoochMaterial3DHandler::toMaterial( const QgsAbstractMaterialSet
     case Qgis::MaterialRenderingTechnique::Lines:
     case Qgis::MaterialRenderingTechnique::InstancedPoints:
     case Qgis::MaterialRenderingTechnique::Points:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return nullptr;
   }
   return nullptr;

--- a/src/3d/materials/qgshighlightmaterial.cpp
+++ b/src/3d/materials/qgshighlightmaterial.cpp
@@ -68,6 +68,7 @@ void QgsHighlightMaterial::init( Qgis::MaterialRenderingTechnique renderingTechn
     }
     case Qgis::MaterialRenderingTechnique::Lines:
     case Qgis::MaterialRenderingTechnique::Points:
+    case Qgis::MaterialRenderingTechnique::Billboards:
     {
       // Lines are single color and do not need the highlight material
       // Billboards are not supported yet

--- a/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
@@ -50,6 +50,7 @@ QgsMaterial *QgsMetalRoughMaterial3DHandler::toMaterial( const QgsAbstractMateri
     case Qgis::MaterialRenderingTechnique::Lines:
     case Qgis::MaterialRenderingTechnique::InstancedPoints:
     case Qgis::MaterialRenderingTechnique::Points:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return nullptr;
   }
   return nullptr;

--- a/src/3d/materials/qgsphongmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongmaterial3dhandler.cpp
@@ -52,6 +52,7 @@ QgsMaterial *QgsPhongMaterial3DHandler::toMaterial( const QgsAbstractMaterialSet
     }
 
     case Qgis::MaterialRenderingTechnique::Lines:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return nullptr;
   }
   return nullptr;

--- a/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
@@ -104,6 +104,7 @@ QgsMaterial *QgsPhongTexturedMaterial3DHandler::toMaterial( const QgsAbstractMat
     }
 
     case Qgis::MaterialRenderingTechnique::Lines:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return nullptr;
   }
   return nullptr;

--- a/src/3d/materials/qgssimplelinematerial3dhandler.cpp
+++ b/src/3d/materials/qgssimplelinematerial3dhandler.cpp
@@ -43,6 +43,7 @@ QgsMaterial *QgsSimpleLineMaterial3DHandler::toMaterial( const QgsAbstractMateri
     case Qgis::MaterialRenderingTechnique::TrianglesWithFixedTexture:
     case Qgis::MaterialRenderingTechnique::TrianglesFromModel:
     case Qgis::MaterialRenderingTechnique::TrianglesDataDefined:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return nullptr;
 
     case Qgis::MaterialRenderingTechnique::Lines:

--- a/src/3d/symbols/qgsline3dsymbol.cpp
+++ b/src/3d/symbols/qgsline3dsymbol.cpp
@@ -83,9 +83,9 @@ void QgsLine3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteContex
 
   const QDomElement elemMaterial = elem.firstChildElement( u"material"_s );
   const QString materialType = elem.attribute( u"material_type"_s, u"phong"_s );
-  mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( materialType ) );
+  mMaterialSettings = Qgs3D::materialRegistry()->createMaterialSettings( materialType );
   if ( !mMaterialSettings )
-    mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( u"phong"_s ) );
+    mMaterialSettings = Qgs3D::materialRegistry()->createMaterialSettings( u"phong"_s );
   mMaterialSettings->readXml( elemMaterial, context );
 }
 

--- a/src/3d/symbols/qgspoint3dsymbol.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol.cpp
@@ -105,9 +105,9 @@ void QgsPoint3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteConte
 
   const QDomElement elemMaterial = elem.firstChildElement( u"material"_s );
   const QString materialType = elem.attribute( u"material_type"_s, u"phong"_s );
-  mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( materialType ) );
+  mMaterialSettings = Qgs3D::materialRegistry()->createMaterialSettings( materialType );
   if ( !mMaterialSettings )
-    mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( u"phong"_s ) );
+    mMaterialSettings = Qgs3D::materialRegistry()->createMaterialSettings( u"phong"_s );
   mMaterialSettings->readXml( elemMaterial, context );
 
   mShape = shapeFromString( elem.attribute( u"shape"_s ) );

--- a/src/3d/symbols/qgspolygon3dsymbol.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol.cpp
@@ -103,9 +103,9 @@ void QgsPolygon3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteCon
 
   const QDomElement elemMaterial = elem.firstChildElement( u"material"_s );
   const QString materialType = elem.attribute( u"material_type"_s, u"phong"_s );
-  mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( materialType ) );
+  mMaterialSettings = Qgs3D::materialRegistry()->createMaterialSettings( materialType );
   if ( !mMaterialSettings )
-    mMaterialSettings.reset( Qgs3D::materialRegistry()->createMaterialSettings( u"phong"_s ) );
+    mMaterialSettings = Qgs3D::materialRegistry()->createMaterialSettings( u"phong"_s );
   mMaterialSettings->readXml( elemMaterial, context );
 
   const QDomElement elemDDP = elem.firstChildElement( u"data-defined-properties"_s );

--- a/src/app/3d/qgsgoochmaterialwidget.cpp
+++ b/src/app/3d/qgsgoochmaterialwidget.cpp
@@ -95,6 +95,7 @@ void QgsGoochMaterialWidget::setTechnique( Qgis::MaterialRenderingTechnique tech
       mSpecularDataDefinedButton->setVisible( true );
       break;
     case Qgis::MaterialRenderingTechnique::Lines:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       // not supported
       break;
   }

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -106,7 +106,7 @@ void QgsLine3DSymbolWidget::updateGuiState()
 {
   const bool simple = chkSimpleLines->isChecked();
   spinExtrusion->setEnabled( !simple );
-  widgetMaterial->setTechnique( chkSimpleLines->isChecked() ? Qgis::MaterialRenderingTechnique::Lines : Qgis::MaterialRenderingTechnique::Triangles );
+  widgetMaterial->setTechnique( renderingTechnique() );
   widgetMaterial->setFilterByTechnique( true );
 
   // Altitude binding is not taken into account if altitude clamping is absolute.

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsline3dsymbolwidget.h"
 
+#include "qgsabstractmaterialsettings.h"
 #include "qgsline3dsymbol.h"
 
 #include <QString>
@@ -84,7 +85,7 @@ QgsAbstract3DSymbol *QgsLine3DSymbolWidget::symbol()
   sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentData().toInt() ) );
   sym->setAltitudeBinding( static_cast<Qgis::AltitudeBinding>( cboAltBinding->currentIndex() ) );
   sym->setRenderAsSimpleLines( chkSimpleLines->isChecked() );
-  sym->setMaterialSettings( widgetMaterial->settings() );
+  sym->setMaterialSettings( widgetMaterial->settings().release() );
   return sym.release();
 }
 

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -49,6 +49,7 @@ QgsLine3DSymbolWidget::QgsLine3DSymbolWidget( QWidget *parent )
   connect( chkSimpleLines, &QCheckBox::toggled, this, &QgsLine3DSymbolWidget::changed );
   connect( chkSimpleLines, &QCheckBox::toggled, this, &QgsLine3DSymbolWidget::updateGuiState );
   connect( chkSimpleLines, &QCheckBox::toggled, this, &QgsLine3DSymbolWidget::simple3DLinesToggled );
+  connect( chkSimpleLines, &QCheckBox::toggled, this, &QgsLine3DSymbolWidget::renderingTechniqueChanged );
   connect( widgetMaterial, &QgsMaterialWidget::changed, this, &QgsLine3DSymbolWidget::changed );
 
   widgetMaterial->setTechnique( renderingTechnique() );

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -51,7 +51,7 @@ QgsLine3DSymbolWidget::QgsLine3DSymbolWidget( QWidget *parent )
   connect( chkSimpleLines, &QCheckBox::toggled, this, &QgsLine3DSymbolWidget::simple3DLinesToggled );
   connect( widgetMaterial, &QgsMaterialWidget::changed, this, &QgsLine3DSymbolWidget::changed );
 
-  widgetMaterial->setTechnique( Qgis::MaterialRenderingTechnique::Triangles );
+  widgetMaterial->setTechnique( renderingTechnique() );
   widgetMaterial->setFilterByTechnique( true );
 }
 
@@ -73,7 +73,7 @@ void QgsLine3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVec
   cboAltBinding->setCurrentIndex( static_cast<int>( lineSymbol->altitudeBinding() ) );
   chkSimpleLines->setChecked( lineSymbol->renderAsSimpleLines() );
   widgetMaterial->setSettings( lineSymbol->materialSettings(), layer );
-  widgetMaterial->setTechnique( chkSimpleLines->isChecked() ? Qgis::MaterialRenderingTechnique::Lines : Qgis::MaterialRenderingTechnique::Triangles );
+  widgetMaterial->setTechnique( renderingTechnique() );
   widgetMaterial->setFilterByTechnique( true );
   updateGuiState();
 }
@@ -94,6 +94,11 @@ QgsAbstract3DSymbol *QgsLine3DSymbolWidget::symbol()
 QString QgsLine3DSymbolWidget::symbolType() const
 {
   return u"line"_s;
+}
+
+Qgis::MaterialRenderingTechnique QgsLine3DSymbolWidget::renderingTechnique() const
+{
+  return chkSimpleLines->isChecked() ? Qgis::MaterialRenderingTechnique::Lines : Qgis::MaterialRenderingTechnique::Triangles;
 }
 
 void QgsLine3DSymbolWidget::updateGuiState()

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -52,6 +52,7 @@ QgsLine3DSymbolWidget::QgsLine3DSymbolWidget( QWidget *parent )
   connect( widgetMaterial, &QgsMaterialWidget::changed, this, &QgsLine3DSymbolWidget::changed );
 
   widgetMaterial->setTechnique( Qgis::MaterialRenderingTechnique::Triangles );
+  widgetMaterial->setFilterByTechnique( true );
 }
 
 Qgs3DSymbolWidget *QgsLine3DSymbolWidget::create( QgsVectorLayer * )
@@ -73,6 +74,7 @@ void QgsLine3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVec
   chkSimpleLines->setChecked( lineSymbol->renderAsSimpleLines() );
   widgetMaterial->setSettings( lineSymbol->materialSettings(), layer );
   widgetMaterial->setTechnique( chkSimpleLines->isChecked() ? Qgis::MaterialRenderingTechnique::Lines : Qgis::MaterialRenderingTechnique::Triangles );
+  widgetMaterial->setFilterByTechnique( true );
   updateGuiState();
 }
 
@@ -99,6 +101,7 @@ void QgsLine3DSymbolWidget::updateGuiState()
   const bool simple = chkSimpleLines->isChecked();
   spinExtrusion->setEnabled( !simple );
   widgetMaterial->setTechnique( chkSimpleLines->isChecked() ? Qgis::MaterialRenderingTechnique::Lines : Qgis::MaterialRenderingTechnique::Triangles );
+  widgetMaterial->setFilterByTechnique( true );
 
   // Altitude binding is not taken into account if altitude clamping is absolute.
   // See: Qgs3DUtils::clampAltitudes()

--- a/src/app/3d/qgsline3dsymbolwidget.h
+++ b/src/app/3d/qgsline3dsymbolwidget.h
@@ -34,6 +34,7 @@ class QgsLine3DSymbolWidget : public Qgs3DSymbolWidget, private Ui::Line3DSymbol
     void setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorLayer *layer ) override;
     QgsAbstract3DSymbol *symbol() override;
     QString symbolType() const override;
+    Qgis::MaterialRenderingTechnique renderingTechnique() const override;
 
   private slots:
     void updateGuiState();

--- a/src/app/3d/qgsphongmaterialwidget.cpp
+++ b/src/app/3d/qgsphongmaterialwidget.cpp
@@ -103,6 +103,7 @@ void QgsPhongMaterialWidget::setTechnique( Qgis::MaterialRenderingTechnique tech
     }
 
     case Qgis::MaterialRenderingTechnique::Lines:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       // not supported
       break;
   }

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -315,7 +315,7 @@ QgsAbstract3DSymbol *QgsPoint3DSymbolWidget::symbol()
   sym->setAltitudeClamping( static_cast<Qgis::AltitudeClamping>( cboAltClamping->currentIndex() ) );
   sym->setShape( cboShape->itemData( cboShape->currentIndex() ).value<Qgis::Point3DShape>() );
   sym->setShapeProperties( vm );
-  sym->setMaterialSettings( widgetMaterial->settings() );
+  sym->setMaterialSettings( widgetMaterial->settings().release() );
   sym->setTransform( tr );
 
   QgsPropertyCollection ddp;

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -226,6 +226,7 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
 
   widgetMaterial->setSettings( pointSymbol->materialSettings(), layer );
   widgetMaterial->setTechnique( technique );
+  widgetMaterial->setFilterByTechnique( true );
 
   if ( forceNullMaterial )
   {
@@ -405,6 +406,7 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
   }
 
   widgetMaterial->setTechnique( technique );
+  widgetMaterial->setFilterByTechnique( true );
 
   if ( cboShape->currentIndex() == 6 )
   {

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -174,7 +174,7 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
   cboAltClamping->setCurrentIndex( static_cast<int>( pointSymbol->altitudeClamping() ) );
 
   cboShape->setCurrentIndex( cboShape->findData( QVariant::fromValue( pointSymbol->shape() ) ) );
-  Qgis::MaterialRenderingTechnique technique = Qgis::MaterialRenderingTechnique::InstancedPoints;
+  mRenderingTechnique = Qgis::MaterialRenderingTechnique::InstancedPoints;
   bool forceNullMaterial = false;
   switch ( pointSymbol->shape() )
   {
@@ -207,7 +207,7 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
       forceNullMaterial = ( pointSymbol->shapeProperties().contains( u"overwriteMaterial"_s ) && !pointSymbol->shapeProperties().value( u"overwriteMaterial"_s ).toBool() )
                           || !pointSymbol->materialSettings()
                           || pointSymbol->materialSettings()->type() == "null"_L1;
-      technique = Qgis::MaterialRenderingTechnique::TrianglesFromModel;
+      mRenderingTechnique = Qgis::MaterialRenderingTechnique::TrianglesFromModel;
 
       whileBlocking( mComboModelUpAxis )->setCurrentIndex( mComboModelUpAxis->findData( pointSymbol->shapeProperty( u"upAxis"_s ).toString() ) );
       whileBlocking( mComboModelForwardAxis )->setCurrentIndex( mComboModelForwardAxis->findData( pointSymbol->shapeProperty( u"forwardAxis"_s ).toString() ) );
@@ -218,14 +218,14 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
       {
         btnChangeSymbol->setSymbol( pointSymbol->billboardSymbol()->clone() );
       }
-      technique = Qgis::MaterialRenderingTechnique::Points;
+      mRenderingTechnique = Qgis::MaterialRenderingTechnique::Points;
       break;
     case Qgis::Point3DShape::ExtrudedText:
       break;
   }
 
   widgetMaterial->setSettings( pointSymbol->materialSettings(), layer );
-  widgetMaterial->setTechnique( technique );
+  widgetMaterial->setTechnique( mRenderingTechnique );
   widgetMaterial->setFilterByTechnique( true );
 
   if ( forceNullMaterial )
@@ -339,6 +339,11 @@ QString QgsPoint3DSymbolWidget::symbolType() const
   return u"point"_s;
 }
 
+Qgis::MaterialRenderingTechnique QgsPoint3DSymbolWidget::renderingTechnique() const
+{
+  return mRenderingTechnique;
+}
+
 void QgsPoint3DSymbolWidget::onShapeChanged()
 {
   QList<QWidget *> allWidgets;
@@ -369,7 +374,7 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
   materialsGroupBox->show();
   transformationWidget->show();
   QList<QWidget *> activeWidgets;
-  Qgis::MaterialRenderingTechnique technique = Qgis::MaterialRenderingTechnique::InstancedPoints;
+  mRenderingTechnique = Qgis::MaterialRenderingTechnique::InstancedPoints;
   switch ( cboShape->currentData().value<Qgis::Point3DShape>() )
   {
     case Qgis::Point3DShape::Sphere:
@@ -392,20 +397,20 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
       break;
     case Qgis::Point3DShape::Model:
       activeWidgets << labelModel << lineEditModel << mComboModelForwardAxis << mComboModelUpAxis << labelUpAxis << labelForwardAxis;
-      technique = Qgis::MaterialRenderingTechnique::TrianglesFromModel;
+      mRenderingTechnique = Qgis::MaterialRenderingTechnique::TrianglesFromModel;
       break;
     case Qgis::Point3DShape::Billboard:
       activeWidgets << labelBillboardHeight << spinBillboardHeight << labelBillboardSymbol << btnChangeSymbol;
       // Always hide material and transformationwidget for billboard
       materialsGroupBox->hide();
       transformationWidget->hide();
-      technique = Qgis::MaterialRenderingTechnique::Points;
+      mRenderingTechnique = Qgis::MaterialRenderingTechnique::Points;
       break;
     case Qgis::Point3DShape::ExtrudedText:
       break;
   }
 
-  widgetMaterial->setTechnique( technique );
+  widgetMaterial->setTechnique( mRenderingTechnique );
   widgetMaterial->setFilterByTechnique( true );
 
   if ( cboShape->currentIndex() == 6 )

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -218,7 +218,7 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
       {
         btnChangeSymbol->setSymbol( pointSymbol->billboardSymbol()->clone() );
       }
-      mRenderingTechnique = Qgis::MaterialRenderingTechnique::Points;
+      mRenderingTechnique = Qgis::MaterialRenderingTechnique::Billboards;
       break;
     case Qgis::Point3DShape::ExtrudedText:
       break;
@@ -405,7 +405,7 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
       // Always hide material and transformationwidget for billboard
       materialsGroupBox->hide();
       transformationWidget->hide();
-      mRenderingTechnique = Qgis::MaterialRenderingTechnique::Points;
+      mRenderingTechnique = Qgis::MaterialRenderingTechnique::Billboards;
       break;
     case Qgis::Point3DShape::ExtrudedText:
       break;

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -227,6 +227,7 @@ void QgsPoint3DSymbolWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVe
   widgetMaterial->setSettings( pointSymbol->materialSettings(), layer );
   widgetMaterial->setTechnique( mRenderingTechnique );
   widgetMaterial->setFilterByTechnique( true );
+  emit renderingTechniqueChanged();
 
   if ( forceNullMaterial )
   {
@@ -412,6 +413,7 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
 
   widgetMaterial->setTechnique( mRenderingTechnique );
   widgetMaterial->setFilterByTechnique( true );
+  emit renderingTechniqueChanged();
 
   if ( cboShape->currentIndex() == 6 )
   {

--- a/src/app/3d/qgspoint3dsymbolwidget.h
+++ b/src/app/3d/qgspoint3dsymbolwidget.h
@@ -35,9 +35,13 @@ class QgsPoint3DSymbolWidget : public Qgs3DSymbolWidget, private Ui::Point3DSymb
     void setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorLayer *layer ) final;
     QgsAbstract3DSymbol *symbol() final;
     QString symbolType() const final;
+    Qgis::MaterialRenderingTechnique renderingTechnique() const final;
 
   private slots:
     void onShapeChanged();
+
+  private:
+    Qgis::MaterialRenderingTechnique mRenderingTechnique = Qgis::MaterialRenderingTechnique::InstancedPoints;
 };
 
 #endif // QGSPOINT3DSYMBOLWIDGET_H

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -17,6 +17,7 @@
 
 #include "qgis.h"
 #include "qgs3dtypes.h"
+#include "qgsabstractmaterialsettings.h"
 #include "qgspolygon3dsymbol.h"
 
 #include <QString>
@@ -109,7 +110,7 @@ QgsAbstract3DSymbol *QgsPolygon3DSymbolWidget::symbol()
   sym->setExtrusionFaces( qgsFlagKeysToValue( cboRenderedFacade->currentData().toString(), Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof ) );
   sym->setAddBackFaces( chkAddBackFaces->isChecked() );
   sym->setInvertNormals( chkInvertNormals->isChecked() );
-  sym->setMaterialSettings( widgetMaterial->settings() );
+  sym->setMaterialSettings( widgetMaterial->settings().release() );
 
   QgsPropertyCollection ddp;
   ddp.setProperty( QgsAbstract3DSymbol::Property::Height, btnHeightDD->toProperty() );

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -65,7 +65,7 @@ QgsPolygon3DSymbolWidget::QgsPolygon3DSymbolWidget( QWidget *parent )
   connect( cboAltClamping, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPolygon3DSymbolWidget::changed );
   connect( cboAltClamping, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPolygon3DSymbolWidget::updateGuiState );
 
-  widgetMaterial->setTechnique( Qgis::MaterialRenderingTechnique::TrianglesDataDefined );
+  widgetMaterial->setTechnique( renderingTechnique() );
   widgetMaterial->setFilterByTechnique( true );
 }
 
@@ -128,6 +128,11 @@ QgsAbstract3DSymbol *QgsPolygon3DSymbolWidget::symbol()
 QString QgsPolygon3DSymbolWidget::symbolType() const
 {
   return u"polygon"_s;
+}
+
+Qgis::MaterialRenderingTechnique QgsPolygon3DSymbolWidget::renderingTechnique() const
+{
+  return Qgis::MaterialRenderingTechnique::TrianglesDataDefined;
 }
 
 void QgsPolygon3DSymbolWidget::updateGuiState()

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -66,6 +66,7 @@ QgsPolygon3DSymbolWidget::QgsPolygon3DSymbolWidget( QWidget *parent )
   connect( cboAltClamping, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPolygon3DSymbolWidget::updateGuiState );
 
   widgetMaterial->setTechnique( Qgis::MaterialRenderingTechnique::TrianglesDataDefined );
+  widgetMaterial->setFilterByTechnique( true );
 }
 
 Qgs3DSymbolWidget *QgsPolygon3DSymbolWidget::create( QgsVectorLayer * )

--- a/src/app/3d/qgspolygon3dsymbolwidget.h
+++ b/src/app/3d/qgspolygon3dsymbolwidget.h
@@ -34,6 +34,7 @@ class QgsPolygon3DSymbolWidget : public Qgs3DSymbolWidget, private Ui::Polygon3D
     void setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorLayer *layer ) override;
     QgsAbstract3DSymbol *symbol() override;
     QString symbolType() const override;
+    Qgis::MaterialRenderingTechnique renderingTechnique() const override;
 
   private slots:
     void updateGuiState();

--- a/src/app/3d/qgssymbol3dwidget.cpp
+++ b/src/app/3d/qgssymbol3dwidget.cpp
@@ -18,7 +18,11 @@
 #include "qgs3dsymbolregistry.h"
 #include "qgs3dsymbolwidget.h"
 #include "qgsabstract3dsymbol.h"
+#include "qgsabstractmaterialsettings.h"
 #include "qgsapplication.h"
+#include "qgsline3dsymbol.h"
+#include "qgspoint3dsymbol.h"
+#include "qgspolygon3dsymbol.h"
 #include "qgsproject.h"
 #include "qgsprojectstylesettings.h"
 #include "qgsstyleitemslistwidget.h"
@@ -27,8 +31,11 @@
 
 #include <QMessageBox>
 #include <QStackedWidget>
+#include <QString>
 
 #include "moc_qgssymbol3dwidget.cpp"
+
+using namespace Qt::StringLiterals;
 
 QgsSymbol3DWidget::QgsSymbol3DWidget( QgsVectorLayer *layer, QWidget *parent )
   : QWidget( parent )
@@ -48,7 +55,7 @@ QgsSymbol3DWidget::QgsSymbol3DWidget( QgsVectorLayer *layer, QWidget *parent )
 
   mStyleWidget = new QgsStyleItemsListWidget( this );
   mStyleWidget->setStyle( QgsStyle::defaultStyle() );
-  mStyleWidget->setEntityType( QgsStyle::Symbol3DEntity );
+  mStyleWidget->setEntityTypes( QList<QgsStyle::StyleEntity>() << QgsStyle::Symbol3DEntity << QgsStyle::MaterialSettingsEntity );
   mStyleWidget->setLayerType( mLayer->geometryType() );
 
   connect( mStyleWidget, &QgsStyleItemsListWidget::selectionChangedWithStylePath, this, &QgsSymbol3DWidget::setSymbolFromStyle );
@@ -87,7 +94,7 @@ void QgsSymbol3DWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorL
   updateSymbolWidget( symbol );
 }
 
-void QgsSymbol3DWidget::setSymbolFromStyle( const QString &name, QgsStyle::StyleEntity, const QString &stylePath )
+void QgsSymbol3DWidget::setSymbolFromStyle( const QString &name, QgsStyle::StyleEntity entity, const QString &stylePath )
 {
   if ( name.isEmpty() )
     return;
@@ -98,12 +105,54 @@ void QgsSymbol3DWidget::setSymbolFromStyle( const QString &name, QgsStyle::Style
   if ( !style )
     style = QgsStyle::defaultStyle();
 
-  // get new instance of symbol from style
-  const std::unique_ptr<QgsAbstract3DSymbol> s( style->symbol3D( name ) );
-  if ( !s )
-    return;
+  switch ( entity )
+  {
+    case QgsStyle::SymbolEntity:
+    case QgsStyle::TagEntity:
+    case QgsStyle::ColorrampEntity:
+    case QgsStyle::SmartgroupEntity:
+    case QgsStyle::TextFormatEntity:
+    case QgsStyle::LabelSettingsEntity:
+    case QgsStyle::LegendPatchShapeEntity:
+      break;
 
-  setSymbol( s.get(), mLayer );
+    case QgsStyle::Symbol3DEntity:
+    {
+      // get new instance of symbol from style
+      const std::unique_ptr<QgsAbstract3DSymbol> s( style->symbol3D( name ) );
+      if ( !s )
+        return;
+
+      setSymbol( s.get(), mLayer );
+      emit widgetChanged();
+      break;
+    }
+    case QgsStyle::MaterialSettingsEntity:
+    {
+      // get new instance of material from style
+      std::unique_ptr<QgsAbstractMaterialSettings> material( style->materialSettings( name ) );
+      if ( !material )
+        return;
+
+      std::unique_ptr< QgsAbstract3DSymbol > newSymbol = symbol();
+      if ( newSymbol && newSymbol->type() == "line"_L1 )
+      {
+        qgis::down_cast< QgsLine3DSymbol *>( newSymbol.get() )->setMaterialSettings( material.release() );
+      }
+      else if ( newSymbol && newSymbol->type() == "point"_L1 )
+      {
+        qgis::down_cast< QgsPoint3DSymbol *>( newSymbol.get() )->setMaterialSettings( material.release() );
+      }
+      else if ( newSymbol && newSymbol->type() == "polygon"_L1 )
+      {
+        qgis::down_cast< QgsPolygon3DSymbol *>( newSymbol.get() )->setMaterialSettings( material.release() );
+      }
+
+      setSymbol( newSymbol.get(), mLayer );
+      emit widgetChanged();
+      break;
+    }
+  }
 }
 
 void QgsSymbol3DWidget::saveSymbol()
@@ -118,27 +167,82 @@ void QgsSymbol3DWidget::saveSymbol()
 
   QgsStyle *destinationStyle = saveDlg.destinationStyle();
 
-  std::unique_ptr<QgsAbstract3DSymbol> newSymbol( symbol() );
-
-  // check if there is no symbol with same name
-  if ( destinationStyle->symbol3DNames().contains( saveDlg.name() ) )
+  switch ( saveDlg.selectedType() )
   {
-    const int res = QMessageBox::warning( this, tr( "Save 3D Symbol" ), tr( "A 3D symbol with the name '%1' already exists. Overwrite?" ).arg( saveDlg.name() ), QMessageBox::Yes | QMessageBox::No );
-    if ( res != QMessageBox::Yes )
+    case QgsStyle::SymbolEntity:
+    case QgsStyle::TagEntity:
+    case QgsStyle::ColorrampEntity:
+    case QgsStyle::SmartgroupEntity:
+    case QgsStyle::TextFormatEntity:
+    case QgsStyle::LabelSettingsEntity:
+    case QgsStyle::LegendPatchShapeEntity:
+      break;
+
+    case QgsStyle::Symbol3DEntity:
     {
-      return;
+      std::unique_ptr<QgsAbstract3DSymbol> newSymbol( symbol() );
+
+      // check if there is no symbol with same name
+      if ( destinationStyle->symbol3DNames().contains( saveDlg.name() ) )
+      {
+        const int res = QMessageBox::warning( this, tr( "Save 3D Symbol" ), tr( "A 3D symbol with the name '%1' already exists. Overwrite?" ).arg( saveDlg.name() ), QMessageBox::Yes | QMessageBox::No );
+        if ( res != QMessageBox::Yes )
+        {
+          return;
+        }
+        destinationStyle->removeEntityByName( QgsStyle::Symbol3DEntity, saveDlg.name() );
+      }
+
+      const QStringList symbolTags = saveDlg.tags().split( ',' );
+
+      // add new symbol to style and re-populate the list
+      QgsAbstract3DSymbol *s = newSymbol.get();
+      destinationStyle->addSymbol3D( saveDlg.name(), newSymbol.release() );
+
+      // make sure the symbol is stored
+      destinationStyle->saveSymbol3D( saveDlg.name(), s, saveDlg.isFavorite(), symbolTags );
+      break;
     }
-    destinationStyle->removeEntityByName( QgsStyle::Symbol3DEntity, saveDlg.name() );
+
+    case QgsStyle::MaterialSettingsEntity:
+    {
+      std::unique_ptr<QgsAbstract3DSymbol> newSymbol( symbol() );
+      std::unique_ptr<QgsAbstractMaterialSettings> newMaterial;
+      if ( newSymbol && newSymbol->type() == "line"_L1 )
+      {
+        newMaterial.reset( qgis::down_cast< QgsLine3DSymbol *>( newSymbol.get() )->materialSettings()->clone() );
+      }
+      else if ( newSymbol && newSymbol->type() == "point"_L1 )
+      {
+        newMaterial.reset( qgis::down_cast< QgsPoint3DSymbol *>( newSymbol.get() )->materialSettings()->clone() );
+      }
+      else if ( newSymbol && newSymbol->type() == "polygon"_L1 )
+      {
+        newMaterial.reset( qgis::down_cast< QgsPolygon3DSymbol *>( newSymbol.get() )->materialSettings()->clone() );
+      }
+
+      // check if there is material with same name
+      if ( destinationStyle->materialSettingsNames().contains( saveDlg.name() ) )
+      {
+        const int res = QMessageBox::warning( this, tr( "Save Material" ), tr( "A material with the name '%1' already exists. Overwrite?" ).arg( saveDlg.name() ), QMessageBox::Yes | QMessageBox::No );
+        if ( res != QMessageBox::Yes )
+        {
+          return;
+        }
+        destinationStyle->removeEntityByName( QgsStyle::MaterialSettingsEntity, saveDlg.name() );
+      }
+
+      const QStringList symbolTags = saveDlg.tags().split( ',' );
+
+      // add new material to style and re-populate the list
+      QgsAbstractMaterialSettings *s = newMaterial.get();
+      destinationStyle->addMaterialSettings( saveDlg.name(), newMaterial.release() );
+
+      // make sure the material is stored
+      destinationStyle->saveMaterialSettings( saveDlg.name(), s, saveDlg.isFavorite(), symbolTags );
+      break;
+    }
   }
-
-  const QStringList symbolTags = saveDlg.tags().split( ',' );
-
-  // add new symbol to style and re-populate the list
-  QgsAbstract3DSymbol *s = newSymbol.get();
-  destinationStyle->addSymbol3D( saveDlg.name(), newSymbol.release() );
-
-  // make sure the symbol is stored
-  destinationStyle->saveSymbol3D( saveDlg.name(), s, saveDlg.isFavorite(), symbolTags );
 }
 
 void QgsSymbol3DWidget::updateSymbolWidget( const QgsAbstract3DSymbol *newSymbol )

--- a/src/app/3d/qgssymbol3dwidget.cpp
+++ b/src/app/3d/qgssymbol3dwidget.cpp
@@ -265,6 +265,14 @@ void QgsSymbol3DWidget::updateSymbolWidget( const QgsAbstract3DSymbol *newSymbol
       widgetStack->setCurrentWidget( w );
       // start receiving updates from widget
       connect( w, &Qgs3DSymbolWidget::changed, this, &QgsSymbol3DWidget::widgetChanged );
+
+      connect( w, &Qgs3DSymbolWidget::renderingTechniqueChanged, this, [w, this] {
+        mStyleWidget->proxyModel()->setRenderingTechnique( w->renderingTechnique() );
+        mStyleWidget->proxyModel()->setRenderingTechniqueFilterEnabled( true );
+      } );
+
+      mStyleWidget->proxyModel()->setRenderingTechnique( w->renderingTechnique() );
+      mStyleWidget->proxyModel()->setRenderingTechniqueFilterEnabled( true );
       return;
     }
   }

--- a/src/app/3d/qgssymbol3dwidget.cpp
+++ b/src/app/3d/qgssymbol3dwidget.cpp
@@ -94,11 +94,6 @@ void QgsSymbol3DWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorL
   updateSymbolWidget( symbol );
 }
 
-Qgis::MaterialRenderingTechnique QgsSymbol3DWidget::renderingTechnique() const
-{
-  return Qgis::MaterialRenderingTechnique::Triangles;
-}
-
 void QgsSymbol3DWidget::setSymbolFromStyle( const QString &name, QgsStyle::StyleEntity entity, const QString &stylePath )
 {
   if ( name.isEmpty() )

--- a/src/app/3d/qgssymbol3dwidget.cpp
+++ b/src/app/3d/qgssymbol3dwidget.cpp
@@ -94,6 +94,11 @@ void QgsSymbol3DWidget::setSymbol( const QgsAbstract3DSymbol *symbol, QgsVectorL
   updateSymbolWidget( symbol );
 }
 
+Qgis::MaterialRenderingTechnique QgsSymbol3DWidget::renderingTechnique() const
+{
+  return Qgis::MaterialRenderingTechnique::Triangles;
+}
+
 void QgsSymbol3DWidget::setSymbolFromStyle( const QString &name, QgsStyle::StyleEntity entity, const QString &stylePath )
 {
   if ( name.isEmpty() )

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -369,7 +369,6 @@ if (WITH_3D)
     3d/qgsgoochmaterialwidget.cpp
     3d/qgslightswidget.cpp
     3d/qgsline3dsymbolwidget.cpp
-    3d/qgsmaterialwidget.cpp
     3d/qgsmesh3dsymbolwidget.cpp
     3d/qgsmetalroughmaterialwidget.cpp
     3d/qgsnullmaterialwidget.cpp

--- a/src/core/3d/materials/qgsabstractmaterialsettings.cpp
+++ b/src/core/3d/materials/qgsabstractmaterialsettings.cpp
@@ -33,6 +33,7 @@ void QgsAbstractMaterialSettings::writeXml( QDomElement &element, const QgsReadW
   QDomElement elemDataDefinedProperties = element.ownerDocument().createElement( u"data-defined-properties"_s );
   mDataDefinedProperties.writeXml( elemDataDefinedProperties, propertyDefinitions() );
   element.appendChild( elemDataDefinedProperties );
+  element.setAttribute( u"type"_s, type() );
 }
 
 void QgsAbstractMaterialSettings::setDataDefinedProperties( const QgsPropertyCollection &collection )

--- a/src/core/3d/materials/qgsgoochmaterialsettings.cpp
+++ b/src/core/3d/materials/qgsgoochmaterialsettings.cpp
@@ -45,6 +45,7 @@ bool QgsGoochMaterialSettings::supportsTechnique( Qgis::MaterialRenderingTechniq
     case Qgis::MaterialRenderingTechnique::Lines:
     case Qgis::MaterialRenderingTechnique::InstancedPoints:
     case Qgis::MaterialRenderingTechnique::Points:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return false;
   }
   return false;

--- a/src/core/3d/materials/qgsmaterialregistry.cpp
+++ b/src/core/3d/materials/qgsmaterialregistry.cpp
@@ -72,12 +72,12 @@ bool QgsMaterialRegistry::addMaterialSettingsType( QgsMaterialSettingsAbstractMe
   return true;
 }
 
-QgsAbstractMaterialSettings *QgsMaterialRegistry::createMaterialSettings( const QString &type ) const
+std::unique_ptr< QgsAbstractMaterialSettings > QgsMaterialRegistry::createMaterialSettings( const QString &type ) const
 {
   if ( !mMetadata.contains( type ) )
     return nullptr;
 
-  return mMetadata[type]->create();
+  return std::unique_ptr< QgsAbstractMaterialSettings >( mMetadata[type]->create() );
 }
 
 QgsMaterialSettingsAbstractMetadata *QgsMaterialRegistry::materialSettingsMetadata( const QString &type ) const

--- a/src/core/3d/materials/qgsmaterialregistry.h
+++ b/src/core/3d/materials/qgsmaterialregistry.h
@@ -243,7 +243,7 @@ class CORE_EXPORT QgsMaterialRegistry
      *
      * Returns NULLPTR if the specified type is not found in the registry.
      */
-    QgsAbstractMaterialSettings *createMaterialSettings( const QString &type ) const SIP_FACTORY;
+    std::unique_ptr< QgsAbstractMaterialSettings > createMaterialSettings( const QString &type ) const;
 
   private:
 #ifdef SIP_RUN

--- a/src/core/3d/materials/qgsmetalroughmaterialsettings.cpp
+++ b/src/core/3d/materials/qgsmetalroughmaterialsettings.cpp
@@ -39,6 +39,7 @@ bool QgsMetalRoughMaterialSettings::supportsTechnique( Qgis::MaterialRenderingTe
     case Qgis::MaterialRenderingTechnique::Points:
     case Qgis::MaterialRenderingTechnique::Lines:
     case Qgis::MaterialRenderingTechnique::InstancedPoints:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return false;
   }
   return false;

--- a/src/core/3d/materials/qgsnullmaterialsettings.cpp
+++ b/src/core/3d/materials/qgsnullmaterialsettings.cpp
@@ -38,6 +38,7 @@ bool QgsNullMaterialSettings::supportsTechnique( Qgis::MaterialRenderingTechniqu
     case Qgis::MaterialRenderingTechnique::TrianglesWithFixedTexture:
     case Qgis::MaterialRenderingTechnique::TrianglesDataDefined:
     case Qgis::MaterialRenderingTechnique::Lines:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return false;
   }
   return false;

--- a/src/core/3d/materials/qgsphongmaterialsettings.cpp
+++ b/src/core/3d/materials/qgsphongmaterialsettings.cpp
@@ -40,6 +40,7 @@ bool QgsPhongMaterialSettings::supportsTechnique( Qgis::MaterialRenderingTechniq
       return true;
 
     case Qgis::MaterialRenderingTechnique::Lines:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return false;
   }
   return false;

--- a/src/core/3d/materials/qgsphongtexturedmaterialsettings.cpp
+++ b/src/core/3d/materials/qgsphongtexturedmaterialsettings.cpp
@@ -41,6 +41,7 @@ bool QgsPhongTexturedMaterialSettings::supportsTechnique( Qgis::MaterialRenderin
     case Qgis::MaterialRenderingTechnique::TrianglesFromModel:
     case Qgis::MaterialRenderingTechnique::InstancedPoints:
     case Qgis::MaterialRenderingTechnique::Lines:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return false;
   }
   return false;

--- a/src/core/3d/materials/qgssimplelinematerialsettings.cpp
+++ b/src/core/3d/materials/qgssimplelinematerialsettings.cpp
@@ -40,6 +40,7 @@ bool QgsSimpleLineMaterialSettings::supportsTechnique( Qgis::MaterialRenderingTe
     case Qgis::MaterialRenderingTechnique::TrianglesWithFixedTexture:
     case Qgis::MaterialRenderingTechnique::TrianglesFromModel:
     case Qgis::MaterialRenderingTechnique::TrianglesDataDefined:
+    case Qgis::MaterialRenderingTechnique::Billboards:
       return false;
   }
   return false;

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4313,6 +4313,7 @@ int QgisEvent = QEvent::User + 1;
       TrianglesWithFixedTexture, //!< Triangle based rendering, using a fixed, non-user-configurable texture (e.g. for terrain rendering)
       TrianglesFromModel,        //!< Triangle based rendering, using a model object source
       TrianglesDataDefined,      //!< Triangle based rendering with possibility of datadefined color
+      Billboards,                //!< Rendering as flat billboards
     };
     Q_ENUM( MaterialRenderingTechnique )
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4313,7 +4313,7 @@ int QgisEvent = QEvent::User + 1;
       TrianglesWithFixedTexture, //!< Triangle based rendering, using a fixed, non-user-configurable texture (e.g. for terrain rendering)
       TrianglesFromModel,        //!< Triangle based rendering, using a model object source
       TrianglesDataDefined,      //!< Triangle based rendering with possibility of datadefined color
-      Billboards,                //!< Rendering as flat billboards
+      Billboards,                //!< Flat billboard rendering
     };
     Q_ENUM( MaterialRenderingTechnique )
 

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -2908,7 +2908,7 @@ bool QgsStyle::exportXml( const QString &filename )
     {
       materialSettingEl.setAttribute( u"tags"_s, tags.join( ',' ) );
     }
-    if ( favorite3DSymbols.contains( it.key() ) )
+    if ( favoriteMaterialSettings.contains( it.key() ) )
     {
       materialSettingEl.setAttribute( u"favorite"_s, u"1"_s );
     }

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -19,6 +19,7 @@
 
 #include "qgs3dsymbolregistry.h"
 #include "qgsabstract3dsymbol.h"
+#include "qgsabstractmaterialsettings.h"
 #include "qgsapplication.h"
 #include "qgscolorramp.h"
 #include "qgsfillsymbol.h"
@@ -30,6 +31,7 @@
 #include "qgslogger.h"
 #include "qgsmarkersymbol.h"
 #include "qgsmarkersymbollayer.h"
+#include "qgsmaterialregistry.h"
 #include "qgspolygon.h"
 #include "qgsproject.h"
 #include "qgsprojectstylesettings.h"
@@ -79,6 +81,16 @@ enum Symbol3DTable
   Symbol3DTableFavoriteId, //!< 3d symbol is favorite flag
 };
 
+/**
+ * Columns available in the 3D material settings table.
+ */
+enum MaterialSettingsTable
+{
+  MaterialSettingsTableId,         //!< 3d material settings ID
+  MaterialSettingsTableName,       //!< 3d material settings name
+  MaterialSettingsTableXML,        //!< 3d material settings definition (as XML)
+  MaterialSettingsTableFavoriteId, //!< 3d material settings is favorite flag
+};
 
 QgsStyle *QgsStyle::sDefaultStyle = nullptr;
 
@@ -138,6 +150,9 @@ bool QgsStyle::addEntity( const QString &name, const QgsStyleEntityInterface *en
 
     case Symbol3DEntity:
       return addSymbol3D( name, static_cast< const QgsStyleSymbol3DEntity * >( entity )->symbol()->clone(), update );
+
+    case MaterialSettingsEntity:
+      return addMaterialSettings( name, static_cast< const QgsStyleMaterialSettingsEntity * >( entity )->settings()->clone(), update );
 
     case TagEntity:
     case SmartgroupEntity:
@@ -308,6 +323,9 @@ bool QgsStyle::renameEntity( QgsStyle::StyleEntity type, const QString &oldName,
     case Symbol3DEntity:
       return renameSymbol3D( oldName, newName );
 
+    case MaterialSettingsEntity:
+      return renameMaterialSettings( oldName, newName );
+
     case TagEntity:
     case SmartgroupEntity:
       return false;
@@ -334,14 +352,13 @@ const QgsSymbol *QgsStyle::symbolRef( const QString &name ) const
 
 int QgsStyle::symbolCount()
 {
-  return mSymbols.count();
+  return static_cast< int >( mSymbols.count() );
 }
 
 QStringList QgsStyle::symbolNames() const
 {
   return mSymbols.keys();
 }
-
 
 bool QgsStyle::addColorRamp( const QString &name, QgsColorRamp *colorRamp, bool update )
 {
@@ -456,6 +473,28 @@ bool QgsStyle::addSymbol3D( const QString &name, QgsAbstract3DSymbol *symbol, bo
   return true;
 }
 
+bool QgsStyle::addMaterialSettings( const QString &name, QgsAbstractMaterialSettings *settings, bool update )
+{
+  // delete previous settings (if any)
+  auto it = mMaterialSettings.constFind( name );
+  if ( it != mMaterialSettings.constEnd() )
+  {
+    // TODO remove groups and tags?
+    delete it.value();
+    mMaterialSettings.insert( name, settings );
+    if ( update )
+      updateSymbol( MaterialSettingsEntity, name );
+  }
+  else
+  {
+    mMaterialSettings.insert( name, settings );
+    if ( update )
+      saveMaterialSettings( name, settings, false, QStringList() );
+  }
+
+  return true;
+}
+
 bool QgsStyle::saveColorRamp( const QString &name, const QgsColorRamp *ramp, bool favorite, const QStringList &tags )
 {
   // insert it into the database
@@ -506,7 +545,7 @@ const QgsColorRamp *QgsStyle::colorRampRef( const QString &name ) const
 
 int QgsStyle::colorRampCount()
 {
-  return mColorRamps.count();
+  return static_cast< int >( mColorRamps.count() );
 }
 
 QStringList QgsStyle::colorRampNames() const
@@ -610,6 +649,11 @@ void QgsStyle::createTables()
     "name TEXT UNIQUE,"
     "xml TEXT,"
     "favorite INTEGER);"
+    "CREATE TABLE materialsettings("
+    "id INTEGER PRIMARY KEY,"
+    "name TEXT UNIQUE,"
+    "xml TEXT,"
+    "favorite INTEGER);"
     "CREATE TABLE tag("
     "id INTEGER PRIMARY KEY,"
     "name TEXT);"
@@ -631,6 +675,9 @@ void QgsStyle::createTables()
     "CREATE TABLE symbol3dtagmap("
     "tag_id INTEGER NOT NULL,"
     "symbol3d_id INTEGER);"
+    "CREATE TABLE materialsettingstagmap("
+    "tag_id INTEGER NOT NULL,"
+    "materialsettings_id INTEGER);"
     "CREATE TABLE smartgroup("
     "id INTEGER PRIMARY KEY,"
     "name TEXT,"
@@ -722,6 +769,24 @@ bool QgsStyle::load( const QString &filename )
     runEmptyQuery( query );
   }
 
+  // make sure 3D material settings table exists
+  query = qgs_sqlite3_mprintf( "SELECT name FROM sqlite_master WHERE name='materialsettings'" );
+  statement = mCurrentDB.prepare( query, rc );
+  if ( rc != SQLITE_OK || sqlite3_step( statement.get() ) != SQLITE_ROW )
+  {
+    query = qgs_sqlite3_mprintf(
+      "CREATE TABLE materialsettings("
+      "id INTEGER PRIMARY KEY,"
+      "name TEXT UNIQUE,"
+      "xml TEXT,"
+      "favorite INTEGER);"
+      "CREATE TABLE materialsettingstagmap("
+      "tag_id INTEGER NOT NULL,"
+      "materialsettings_id INTEGER);"
+    );
+    runEmptyQuery( query );
+  }
+
   // Make sure there are no Null fields in parenting symbols and groups
   query = qgs_sqlite3_mprintf(
     "UPDATE symbol SET favorite=0 WHERE favorite IS NULL;"
@@ -730,6 +795,7 @@ bool QgsStyle::load( const QString &filename )
     "UPDATE labelsettings SET favorite=0 WHERE favorite IS NULL;"
     "UPDATE legendpatchshapes SET favorite=0 WHERE favorite IS NULL;"
     "UPDATE symbol3d SET favorite=0 WHERE favorite IS NULL;"
+    "UPDATE materialsettings SET favorite=0 WHERE favorite IS NULL;"
   );
   runEmptyQuery( query );
 
@@ -847,7 +913,7 @@ bool QgsStyle::load( const QString &filename )
   }
 
   {
-    QgsScopedRuntimeProfile profile( tr( "Load 3D symbols shapes" ) );
+    QgsScopedRuntimeProfile profile( tr( "Load 3D symbols" ) );
     query = qgs_sqlite3_mprintf( "SELECT * FROM symbol3d" );
     statement = mCurrentDB.prepare( query, rc );
 
@@ -884,6 +950,39 @@ bool QgsStyle::load( const QString &filename )
           QgsDebugError( "Cannot open 3d symbol " + settingsName );
           continue;
         }
+      }
+    }
+  }
+
+  {
+    QgsScopedRuntimeProfile profile( tr( "Load material settings" ) );
+    query = qgs_sqlite3_mprintf( "SELECT * FROM materialsettings" );
+    statement = mCurrentDB.prepare( query, rc );
+
+    while ( rc == SQLITE_OK && sqlite3_step( statement.get() ) == SQLITE_ROW )
+    {
+      QDomDocument doc;
+      const QString settingsName = statement.columnAsText( MaterialSettingsTableName );
+      QgsScopedRuntimeProfile profile( settingsName );
+      const QString xmlstring = statement.columnAsText( MaterialSettingsTableXML );
+      if ( !doc.setContent( xmlstring ) )
+      {
+        QgsDebugError( "Cannot open material settings " + settingsName );
+        continue;
+      }
+      QDomElement settingsElement = doc.documentElement();
+
+      const QString materialType = settingsElement.attribute( u"type"_s );
+      std::unique_ptr< QgsAbstractMaterialSettings > settings = QgsApplication::materialRegistry()->createMaterialSettings( materialType );
+      if ( settings )
+      {
+        settings->readXml( settingsElement, QgsReadWriteContext() );
+        mMaterialSettings.insert( settingsName, settings.release() );
+      }
+      else
+      {
+        QgsDebugError( "Cannot open material settings " + settingsName );
+        continue;
       }
     }
   }
@@ -1331,6 +1430,85 @@ QStringList QgsStyle::symbol3DNames() const
   return m3dSymbols.keys();
 }
 
+bool QgsStyle::saveMaterialSettings( const QString &name, QgsAbstractMaterialSettings *settings, bool favorite, const QStringList &tags )
+{
+  // insert it into the database
+  QDomDocument doc( u"dummy"_s );
+  QDomElement elem = doc.createElement( u"settings"_s );
+  elem.setAttribute( u"type"_s, settings->type() );
+  settings->writeXml( elem, QgsReadWriteContext() );
+
+  QByteArray xmlArray;
+  QTextStream stream( &xmlArray );
+  elem.save( stream, 4 );
+  QString query = qgs_sqlite3_mprintf( "INSERT INTO materialsettings VALUES (NULL, '%q', '%q', %d);", name.toUtf8().constData(), xmlArray.constData(), ( favorite ? 1 : 0 ) );
+  if ( !runEmptyQuery( query ) )
+  {
+    QgsDebugError( u"Couldn't insert material settings into the database!"_s );
+    return false;
+  }
+
+  mCachedFavorites[MaterialSettingsEntity].insert( name, favorite );
+
+  tagSymbol( MaterialSettingsEntity, name, tags );
+
+  emit entityAdded( MaterialSettingsEntity, name );
+
+  return true;
+}
+
+bool QgsStyle::renameMaterialSettings( const QString &oldName, const QString &newName )
+{
+  if ( mMaterialSettings.contains( newName ) )
+  {
+    QgsDebugError( u"material settings of new name already exists."_s );
+    return false;
+  }
+
+  if ( !mMaterialSettings.contains( oldName ) )
+    return false;
+  std::unique_ptr< QgsAbstractMaterialSettings > settings( mMaterialSettings.take( oldName ) );
+
+  mMaterialSettings.insert( newName, settings.release() );
+  mCachedTags[MaterialSettingsEntity].remove( oldName );
+  mCachedFavorites[MaterialSettingsEntity].remove( oldName );
+
+  int materialSettingsId = 0;
+  sqlite3_statement_unique_ptr statement;
+  QString query = qgs_sqlite3_mprintf( "SELECT id FROM materialsettings WHERE name='%q'", oldName.toUtf8().constData() );
+  int nErr;
+  statement = mCurrentDB.prepare( query, nErr );
+  if ( nErr == SQLITE_OK && sqlite3_step( statement.get() ) == SQLITE_ROW )
+  {
+    materialSettingsId = sqlite3_column_int( statement.get(), 0 );
+  }
+  const bool result = rename( MaterialSettingsEntity, materialSettingsId, newName );
+  if ( result )
+  {
+    emit entityRenamed( MaterialSettingsEntity, oldName, newName );
+  }
+
+  return result;
+}
+
+QStringList QgsStyle::materialSettingsNames() const
+{
+  return mMaterialSettings.keys();
+}
+
+int QgsStyle::materialSettingsCount() const
+{
+  return static_cast< int >( mMaterialSettings.size() );
+}
+
+std::unique_ptr< QgsAbstractMaterialSettings > QgsStyle::materialSettings( const QString &name ) const
+{
+  auto it = mMaterialSettings.constFind( name );
+  if ( it != mMaterialSettings.constEnd() )
+    return std::unique_ptr< QgsAbstractMaterialSettings >( it.value()->clone() );
+  return nullptr;
+}
+
 QStringList QgsStyle::symbolsOfFavorite( StyleEntity type ) const
 {
   if ( !mCurrentDB )
@@ -1547,6 +1725,15 @@ bool QgsStyle::removeEntityByName( QgsStyle::StyleEntity type, const QString &na
     {
       std::unique_ptr< QgsAbstract3DSymbol > symbol( m3dSymbols.take( name ) );
       if ( !symbol )
+        return false;
+
+      break;
+    }
+
+    case QgsStyle::MaterialSettingsEntity:
+    {
+      std::unique_ptr< QgsAbstractMaterialSettings > settings( mMaterialSettings.take( name ) );
+      if ( !settings )
         return false;
 
       break;
@@ -2159,7 +2346,7 @@ QgsTextFormat QgsStyle::textFormat( const QString &name ) const
 
 int QgsStyle::textFormatCount() const
 {
-  return mTextFormats.count();
+  return static_cast< int >( mTextFormats.count() );
 }
 
 QStringList QgsStyle::textFormatNames() const
@@ -2184,7 +2371,7 @@ QgsLegendPatchShape QgsStyle::legendPatchShape( const QString &name ) const
 
 int QgsStyle::legendPatchShapesCount() const
 {
-  return mLegendPatchShapes.count();
+  return static_cast< int >( mLegendPatchShapes.count() );
 }
 
 Qgis::SymbolType QgsStyle::legendPatchShapeSymbolType( const QString &name ) const
@@ -2206,7 +2393,7 @@ QgsAbstract3DSymbol *QgsStyle::symbol3D( const QString &name ) const
 
 int QgsStyle::symbol3DCount() const
 {
-  return m3dSymbols.count();
+  return static_cast< int >( m3dSymbols.count() );
 }
 
 QList<Qgis::GeometryType> QgsStyle::symbol3DCompatibleGeometryTypes( const QString &name ) const
@@ -2229,7 +2416,7 @@ Qgis::GeometryType QgsStyle::labelSettingsLayerType( const QString &name ) const
 
 int QgsStyle::labelSettingsCount() const
 {
-  return mLabelSettings.count();
+  return static_cast< int >( mLabelSettings.count() );
 }
 
 QStringList QgsStyle::labelSettingsNames() const
@@ -2297,6 +2484,9 @@ QStringList QgsStyle::allNames( QgsStyle::StyleEntity type ) const
 
     case Symbol3DEntity:
       return symbol3DNames();
+
+    case MaterialSettingsEntity:
+      return materialSettingsNames();
 
     case TagEntity:
       return tags();
@@ -2583,6 +2773,7 @@ bool QgsStyle::exportXml( const QString &filename )
   const QStringList favoriteTextFormats = symbolsOfFavorite( TextFormatEntity );
   const QStringList favoriteLegendShapes = symbolsOfFavorite( LegendPatchShapeEntity );
   const QStringList favorite3DSymbols = symbolsOfFavorite( Symbol3DEntity );
+  const QStringList favoriteMaterialSettings = symbolsOfFavorite( MaterialSettingsEntity );
 
   // save symbols and attach tags
   QDomElement symbolsElem = QgsSymbolLayerUtils::saveSymbols( mSymbols, u"symbols"_s, doc, QgsReadWriteContext() );
@@ -2681,7 +2872,7 @@ bool QgsStyle::exportXml( const QString &filename )
     legendPatchShapesElem.appendChild( legendPatchShapeEl );
   }
 
-  // save symbols and attach tags
+  // save 3D symbols and attach tags
   QDomElement symbols3DElem = doc.createElement( u"symbols3d"_s );
   for ( auto it = m3dSymbols.constBegin(); it != m3dSymbols.constEnd(); ++it )
   {
@@ -2703,12 +2894,33 @@ bool QgsStyle::exportXml( const QString &filename )
     symbols3DElem.appendChild( symbolEl );
   }
 
+  // save material settings and attach tags
+  QDomElement materialSettingsElem = doc.createElement( u"materialsettings"_s );
+  for ( auto it = mMaterialSettings.constBegin(); it != mMaterialSettings.constEnd(); ++it )
+  {
+    QDomElement materialSettingEl = doc.createElement( u"material"_s );
+    materialSettingEl.setAttribute( u"name"_s, it.key() );
+    QDomElement defEl = doc.createElement( u"definition"_s );
+    it.value()->writeXml( defEl, QgsReadWriteContext() );
+    materialSettingEl.appendChild( defEl );
+    QStringList tags = tagsOfSymbol( MaterialSettingsEntity, it.key() );
+    if ( tags.count() > 0 )
+    {
+      materialSettingEl.setAttribute( u"tags"_s, tags.join( ',' ) );
+    }
+    if ( favorite3DSymbols.contains( it.key() ) )
+    {
+      materialSettingEl.setAttribute( u"favorite"_s, u"1"_s );
+    }
+    materialSettingsElem.appendChild( materialSettingEl );
+  }
   root.appendChild( symbolsElem );
   root.appendChild( rampsElem );
   root.appendChild( textFormatsElem );
   root.appendChild( labelSettingsElem );
   root.appendChild( legendPatchShapesElem );
   root.appendChild( symbols3DElem );
+  root.appendChild( materialSettingsElem );
 
   // save
   QFile f( filename );
@@ -3058,6 +3270,55 @@ bool QgsStyle::importXml( const QString &filename, int sinceVersion )
     }
   }
 
+  // load material settings
+  if ( version == STYLE_CURRENT_VERSION )
+  {
+    const QDomElement materialSettingsElement = docEl.firstChildElement( u"materialsettings"_s );
+    e = materialSettingsElement.firstChildElement();
+    for ( ; !e.isNull(); e = e.nextSiblingElement() )
+    {
+      const int entityAddedVersion = e.attribute( u"addedVersion"_s ).toInt();
+      if ( entityAddedVersion != 0 && sinceVersion != -1 && entityAddedVersion <= sinceVersion )
+      {
+        // skip the symbol, should already be present
+        continue;
+      }
+
+      if ( e.tagName() == "material"_L1 )
+      {
+        QString name = e.attribute( u"name"_s );
+        QStringList tags;
+        if ( e.hasAttribute( u"tags"_s ) )
+        {
+          tags = e.attribute( u"tags"_s ).split( ',' );
+        }
+        bool favorite = false;
+        if ( e.hasAttribute( u"favorite"_s ) && e.attribute( u"favorite"_s ) == "1"_L1 )
+        {
+          favorite = true;
+        }
+
+        const QDomElement materialElem = e.firstChildElement();
+        const QString type = materialElem.attribute( u"type"_s );
+        std::unique_ptr< QgsAbstractMaterialSettings > settings( QgsApplication::materialRegistry()->createMaterialSettings( type ) );
+        if ( settings )
+        {
+          settings->readXml( materialElem, QgsReadWriteContext() );
+          QgsAbstractMaterialSettings *newMaterial = settings.get();
+          addMaterialSettings( name, settings.release() );
+          if ( mCurrentDB )
+          {
+            saveMaterialSettings( name, newMaterial, favorite, tags );
+          }
+        }
+      }
+      else
+      {
+        QgsDebugError( "unknown tag: " + e.tagName() );
+      }
+    }
+  }
+
   query = qgs_sqlite3_mprintf( "COMMIT TRANSACTION;" );
   runEmptyQuery( query );
 
@@ -3151,6 +3412,28 @@ bool QgsStyle::updateSymbol( StyleEntity type, const QString &name )
       }
       symEl.save( stream, 4 );
       query = qgs_sqlite3_mprintf( "UPDATE symbol3d SET xml='%q' WHERE name='%q';", xmlArray.constData(), name.toUtf8().constData() );
+      break;
+    }
+
+    case MaterialSettingsEntity:
+    {
+      // check if it is an existing symbol
+      auto it = mMaterialSettings.constFind( name );
+      if ( it == mMaterialSettings.constEnd() || !it.value() )
+      {
+        QgsDebugError( u"Update request received for unavailable material"_s );
+        return false;
+      }
+
+      symEl = doc.createElement( u"material"_s );
+      it.value()->writeXml( symEl, QgsReadWriteContext() );
+      if ( symEl.isNull() )
+      {
+        QgsDebugError( u"Couldn't convert material settings to valid XML!"_s );
+        return false;
+      }
+      symEl.save( stream, 4 );
+      query = qgs_sqlite3_mprintf( "UPDATE materialsettings SET xml='%q' WHERE name='%q';", xmlArray.constData(), name.toUtf8().constData() );
       break;
     }
 
@@ -3268,6 +3551,7 @@ bool QgsStyle::updateSymbol( StyleEntity type, const QString &name )
       case TagEntity:
       case SmartgroupEntity:
       case Symbol3DEntity:
+      case MaterialSettingsEntity:
         break;
     }
     emit entityChanged( type, name );
@@ -3356,6 +3640,9 @@ QString QgsStyle::entityTableName( QgsStyle::StyleEntity type )
     case Symbol3DEntity:
       return u"symbol3d"_s;
 
+    case MaterialSettingsEntity:
+      return u"materialsettings"_s;
+
     case TagEntity:
       return u"tag"_s;
 
@@ -3387,6 +3674,9 @@ QString QgsStyle::tagmapTableName( QgsStyle::StyleEntity type )
     case Symbol3DEntity:
       return u"symbol3dtagmap"_s;
 
+    case MaterialSettingsEntity:
+      return u"materialsettingstagmap"_s;
+
     case TagEntity:
     case SmartgroupEntity:
       break;
@@ -3415,6 +3705,9 @@ QString QgsStyle::tagmapEntityIdFieldName( QgsStyle::StyleEntity type )
 
     case Symbol3DEntity:
       return u"symbol3d_id"_s;
+
+    case MaterialSettingsEntity:
+      return u"materialsettings_id"_s;
 
     case TagEntity:
     case SmartgroupEntity:
@@ -3451,4 +3744,9 @@ QgsStyle::StyleEntity QgsStyleLegendPatchShapeEntity::type() const
 QgsStyle::StyleEntity QgsStyleSymbol3DEntity::type() const
 {
   return QgsStyle::Symbol3DEntity;
+}
+
+QgsStyle::StyleEntity QgsStyleMaterialSettingsEntity::type() const
+{
+  return QgsStyle::MaterialSettingsEntity;
 }

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -37,6 +37,7 @@ class QgsStyleEntityInterface;
 class QgsAbstract3DSymbol;
 class QDomDocument;
 class QDomElement;
+class QgsAbstractMaterialSettings;
 
 typedef QMap<QString, QgsColorRamp * > QgsVectorColorRampMap;
 typedef QMap<int, QString> QgsSymbolGroupMap;
@@ -52,6 +53,7 @@ typedef QMap<QString, QgsTextFormat > QgsTextFormatMap;
  * \since QGIS 3.10
  */
 typedef QMap<QString, QgsPalLayerSettings > QgsLabelSettingsMap;
+
 
 /*
  * Constants used to describe copy-paste MIME types
@@ -210,6 +212,7 @@ class CORE_EXPORT QgsStyle : public QObject
       LabelSettingsEntity,    //!< Label settings
       LegendPatchShapeEntity, //!< Legend patch shape \since QGIS 3.14
       Symbol3DEntity,         //!< 3D symbol entity \since QGIS 3.14
+      MaterialSettingsEntity, //!< Material settings \since QGIS 4.2
     };
 
     /**
@@ -334,7 +337,7 @@ class CORE_EXPORT QgsStyle : public QObject
     /**
      * Adds a 3d \a symbol with the specified \a name to the style. Ownership of \a symbol is transferred.
      *
-     * If \a update is set to TRUE, the style database will be automatically updated with the new legend patch shape.
+     * If \a update is set to TRUE, the style database will be automatically updated with the new 3d symbol.
      *
      * Returns TRUE if the operation was successful.
      *
@@ -342,6 +345,20 @@ class CORE_EXPORT QgsStyle : public QObject
      * \since QGIS 3.16
      */
     bool addSymbol3D( const QString &name, QgsAbstract3DSymbol *symbol SIP_TRANSFER, bool update = false );
+
+    /**
+     * Adds a 3D material \a settings with the specified \a name to the style.
+     *
+     * Ownership of \a settings is transferred.
+     *
+     * If \a update is set to TRUE, the style database will be automatically updated with the new material settings.
+     *
+     * Returns TRUE if the operation was successful.
+     *
+     * \note Adding material settings with the name of existing ones replaces them.
+     * \since QGIS 4.2
+     */
+    bool addMaterialSettings( const QString &name, QgsAbstractMaterialSettings *settings SIP_TRANSFER, bool update = false );
 
     /**
      * Adds a new tag and returns the tag's id
@@ -852,41 +869,80 @@ class CORE_EXPORT QgsStyle : public QObject
     QStringList symbol3DNames() const;
 
     /**
+     * Adds 3D material \a settings to the database.
+     *
+     * \param name is the name of the material settings
+     * \param settings 3D material settings to save. Ownership is transferred.
+     * \param favorite is a boolean value to specify whether the material settings should be added to favorites
+     * \param tags is a list of tags that are associated with the material settings
+     * \returns returns the success state of the save operation
+     *
+     * \since QGIS 4.2
+     */
+    bool saveMaterialSettings( const QString &name, QgsAbstractMaterialSettings *settings SIP_TRANSFER, bool favorite, const QStringList &tags );
+
+    /**
+     * Changes a 3D material settings's name.
+     *
+     * \since QGIS 4.2
+     */
+    bool renameMaterialSettings( const QString &oldName, const QString &newName );
+
+    /**
+     * Returns a list of names of 3D material settings in the style.
+     * \since QGIS 4.2
+     */
+    QStringList materialSettingsNames() const;
+
+    /**
+     * Returns count of 3D material settings in the style.
+     * \since QGIS 4.2
+     */
+    int materialSettingsCount() const;
+
+    /**
+     * Returns a new copy of the 3D material settings with the specified \a name.
+     *
+     * \since QGIS 4.2
+     */
+    std::unique_ptr< QgsAbstractMaterialSettings > materialSettings( const QString &name ) const;
+
+    /**
      * Creates an on-disk database
      *
-     *  This function creates a new on-disk permanent style database.
-     *  \returns returns the success state of the database creation
-     *  \see createMemoryDatabase()
+     * This function creates a new on-disk permanent style database.
+     * \returns returns the success state of the database creation
+     * \see createMemoryDatabase()
      */
     bool createDatabase( const QString &filename );
 
     /**
      * Creates a temporary memory database
      *
-     *  This function is used to create a temporary style database in case a permanent on-disk database is not needed.
-     *  \returns returns the success state of the temporary memory database creation
-     *  \see createDatabase()
+     * This function is used to create a temporary style database in case a permanent on-disk database is not needed.
+     * \returns returns the success state of the temporary memory database creation
+     * \see createDatabase()
      */
     bool createMemoryDatabase();
 
     /**
      * Creates tables structure for new database
      *
-     *  This function is used to create the tables structure in a newly-created database.
-     *  \see createDatabase()
-     *  \see createMemoryDatabase()
+     * This function is used to create the tables structure in a newly-created database.
+     * \see createDatabase()
+     * \see createMemoryDatabase()
      */
     void createTables();
 
     /**
      * Loads a file into the style
      *
-     *  This function will load an on-disk database and populate styles.
-     *  \param filename location of the database to load styles from
-     *  \returns TRUE if the database was successfully loaded. If FALSE is
-     *  returned then a detailed error message can be retrieved via errorString().
+     * This function will load an on-disk database and populate styles.
+     * \param filename location of the database to load styles from
+     * \returns TRUE if the database was successfully loaded. If FALSE is
+     * returned then a detailed error message can be retrieved via errorString().
      *
-     *  \see errorString()
+     * \see errorString()
      */
     bool load( const QString &filename );
 
@@ -895,8 +951,8 @@ class CORE_EXPORT QgsStyle : public QObject
      *
      * The current fileName() will be used if no explicit \a filename is specified.
      *
-     *  \returns TRUE if the style was successfully saved. If FALSE is
-     *  returned then a detailed error message can be retrieved via errorString().
+     * \returns TRUE if the style was successfully saved. If FALSE is
+     * returned then a detailed error message can be retrieved via errorString().
      *
      * \see fileName()
      * \see load()
@@ -940,18 +996,18 @@ class CORE_EXPORT QgsStyle : public QObject
     /**
      * Returns the names of the symbols which have a matching 'substring' in its definition
      *
-     *  \param type is either SymbolEntity or ColorrampEntity
-     *  \param qword is the query string to search the symbols or colorramps.
-     *  \returns A QStringList of the matched symbols or colorramps
+     * \param type is either SymbolEntity or ColorrampEntity
+     * \param qword is the query string to search the symbols or colorramps.
+     * \returns A QStringList of the matched symbols or colorramps
      */
     QStringList findSymbols( StyleEntity type, const QString &qword );
 
     /**
      * Returns the tags associated with the symbol
      *
-     *  \param type is either SymbolEntity or ColorrampEntity
-     *  \param symbol is the name of the symbol or color ramp
-     *  \returns A QStringList of the tags that have been applied to that symbol/colorramp
+     * \param type is either SymbolEntity or ColorrampEntity
+     * \param symbol is the name of the symbol or color ramp
+     * \returns A QStringList of the tags that have been applied to that symbol/colorramp
      */
     QStringList tagsOfSymbol( StyleEntity type, const QString &symbol );
 
@@ -966,10 +1022,10 @@ class CORE_EXPORT QgsStyle : public QObject
     /**
      * Returns whether a given tag is associated with the symbol
      *
-     *  \param type is either SymbolEntity or ColorrampEntity
-     *  \param symbol is the name of the symbol or color ramp
-     *  \param tag the name of the tag to look for
-     *  \returns A boolean value identicating whether a tag was found attached to the symbol
+     * \param type is either SymbolEntity or ColorrampEntity
+     * \param symbol is the name of the symbol or color ramp
+     * \param tag the name of the tag to look for
+     * \returns A boolean value identicating whether a tag was found attached to the symbol
      */
     bool symbolHasTag( StyleEntity type, const QString &symbol, const QString &tag );
 
@@ -1250,6 +1306,7 @@ class CORE_EXPORT QgsStyle : public QObject
     QgsLabelSettingsMap mLabelSettings;
     QMap<QString, QgsLegendPatchShape > mLegendPatchShapes;
     QMap<QString, QgsAbstract3DSymbol * > m3dSymbols;
+    QMap<QString, QgsAbstractMaterialSettings * > mMaterialSettings;
 
     QHash< QgsStyle::StyleEntity, QHash< QString, QStringList > > mCachedTags;
     QHash< QgsStyle::StyleEntity, QHash< QString, bool > > mCachedFavorites;
@@ -1363,6 +1420,18 @@ class CORE_EXPORT QgsStyleEntityInterface
 
       case QgsStyle::LabelSettingsEntity:
         sipType = sipType_QgsStyleLabelSettingsEntity;
+        break;
+
+      case QgsStyle::LegendPatchShapeEntity:
+        sipType = sipType_QgsStyleLegendPatchShapeEntity;
+        break;
+
+      case QgsStyle::Symbol3DEntity:
+        sipType = sipType_QgsStyleSymbol3DEntity;
+        break;
+
+      case QgsStyle::MaterialSettingsEntity:
+        sipType = sipType_QgsStyleMaterialSettingsEntity;
         break;
 
       case QgsStyle::SmartgroupEntity:
@@ -1551,6 +1620,36 @@ class CORE_EXPORT QgsStyleSymbol3DEntity : public QgsStyleEntityInterface
 
   private:
     const QgsAbstract3DSymbol *mSymbol = nullptr;
+};
+
+
+/**
+ * \class QgsStyleMaterialSettingsEntity
+ * \ingroup core
+ * \brief A 3D material settings entity for QgsStyle databases.
+ * \since QGIS 4.2
+ */
+class CORE_EXPORT QgsStyleMaterialSettingsEntity : public QgsStyleEntityInterface
+{
+  public:
+    /**
+   * Constructor for QgsStyleMaterialSettingsEntity, with the specified \a settings.
+   *
+   * Ownership of \a settings is NOT transferred.
+   */
+    QgsStyleMaterialSettingsEntity( const QgsAbstractMaterialSettings *settings )
+      : mSettings( settings )
+    {}
+
+    QgsStyle::StyleEntity type() const override;
+
+    /**
+   * Returns the entity's settings.
+   */
+    const QgsAbstractMaterialSettings *settings() const { return mSettings; }
+
+  private:
+    const QgsAbstractMaterialSettings *mSettings = nullptr;
 };
 
 #endif

--- a/src/core/symbology/qgsstylemodel.cpp
+++ b/src/core/symbology/qgsstylemodel.cpp
@@ -933,7 +933,11 @@ Qgis::MaterialRenderingTechnique QgsStyleProxyModel::renderingTechnique() const
 
 void QgsStyleProxyModel::setRenderingTechnique( Qgis::MaterialRenderingTechnique technique )
 {
+  if ( mRenderingTechnique == technique )
+    return;
+
   mRenderingTechnique = technique;
+  invalidateFilter();
 }
 
 QgsStyleProxyModel::QgsStyleProxyModel( QgsStyleModel *model, QObject *parent )

--- a/src/core/symbology/qgsstylemodel.cpp
+++ b/src/core/symbology/qgsstylemodel.cpp
@@ -34,7 +34,8 @@ using namespace Qt::StringLiterals;
 
 const double ICON_PADDING_FACTOR = 0.16;
 
-const auto ENTITIES = { QgsStyle::SymbolEntity, QgsStyle::ColorrampEntity, QgsStyle::TextFormatEntity, QgsStyle::LabelSettingsEntity, QgsStyle::LegendPatchShapeEntity, QgsStyle::Symbol3DEntity };
+const auto ENTITIES
+  = { QgsStyle::SymbolEntity, QgsStyle::ColorrampEntity, QgsStyle::TextFormatEntity, QgsStyle::LabelSettingsEntity, QgsStyle::LegendPatchShapeEntity, QgsStyle::Symbol3DEntity, QgsStyle::MaterialSettingsEntity };
 
 QgsAbstractStyleEntityIconGenerator *QgsStyleModel::sIconGenerator = nullptr;
 
@@ -231,6 +232,7 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
               case QgsStyle::TagEntity:
               case QgsStyle::SmartgroupEntity:
               case QgsStyle::Symbol3DEntity:
+              case QgsStyle::MaterialSettingsEntity:
                 break;
             }
             return tooltip;
@@ -387,6 +389,7 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
             }
 
             case QgsStyle::Symbol3DEntity:
+            case QgsStyle::MaterialSettingsEntity:
             {
               // hack for now -- we just use a generic "3d icon" svg file.
               // TODO - render proper thumbnails
@@ -396,10 +399,21 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
               if ( !icon.isNull() )
                 return icon;
 
-              if ( sIconGenerator && !mPending3dSymbolIcons.contains( name ) )
+              if ( entityType == QgsStyle::Symbol3DEntity )
               {
-                mPending3dSymbolIcons.insert( name );
-                sIconGenerator->generateIcon( mStyle, QgsStyle::Symbol3DEntity, name );
+                if ( sIconGenerator && !mPending3dSymbolIcons.contains( name ) )
+                {
+                  mPending3dSymbolIcons.insert( name );
+                  sIconGenerator->generateIcon( mStyle, entityType, name );
+                }
+              }
+              else if ( entityType == QgsStyle::MaterialSettingsEntity )
+              {
+                if ( sIconGenerator && !mPendingMaterialSettingsIcons.contains( name ) )
+                {
+                  mPendingMaterialSettingsIcons.insert( name );
+                  sIconGenerator->generateIcon( mStyle, entityType, name );
+                }
               }
 
               // TODO - use hourglass icon
@@ -456,6 +470,7 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
         case QgsStyle::LabelSettingsEntity:
         case QgsStyle::TextFormatEntity:
         case QgsStyle::Symbol3DEntity:
+        case QgsStyle::MaterialSettingsEntity:
           return QVariant();
       }
       return QVariant();
@@ -475,6 +490,7 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
         case QgsStyle::ColorrampEntity:
         case QgsStyle::SmartgroupEntity:
         case QgsStyle::TextFormatEntity:
+        case QgsStyle::MaterialSettingsEntity:
           return QVariant();
       }
       return QVariant();
@@ -503,6 +519,7 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
         case QgsStyle::ColorrampEntity:
         case QgsStyle::SmartgroupEntity:
         case QgsStyle::TextFormatEntity:
+        case QgsStyle::MaterialSettingsEntity:
           return QVariant();
       }
       return QVariant();
@@ -633,7 +650,7 @@ int QgsStyleModel::rowCount( const QModelIndex &parent ) const
   {
     int count = 0;
     for ( QgsStyle::StyleEntity type : ENTITIES )
-      count += mEntityNames[type].size();
+      count += static_cast< int >( mEntityNames[type].size() );
     return count;
   }
   return 0;
@@ -682,7 +699,7 @@ void QgsStyleModel::onEntityAdded( QgsStyle::StyleEntity type, const QString &na
   const QStringList newSymbolNames = mStyle->allNames( type );
 
   // find index of newly added symbol
-  const int newNameIndex = newSymbolNames.indexOf( name );
+  const int newNameIndex = static_cast< int >( newSymbolNames.indexOf( name ) );
   if ( newNameIndex < 0 )
     return; // shouldn't happen
 
@@ -699,7 +716,7 @@ void QgsStyleModel::onEntityRemoved( QgsStyle::StyleEntity type, const QString &
   const QStringList newSymbolNames = mStyle->allNames( type );
 
   // find index of removed symbol
-  const int oldNameIndex = oldSymbolNames.indexOf( name );
+  const int oldNameIndex = static_cast< int >( oldSymbolNames.indexOf( name ) );
   if ( oldNameIndex < 0 )
     return; // shouldn't happen
 
@@ -714,14 +731,14 @@ void QgsStyleModel::onEntityChanged( QgsStyle::StyleEntity type, const QString &
   mIconCache[type].remove( name );
 
   const int offset = offsetForEntity( type );
-  QModelIndex i = index( offset + mEntityNames[type].indexOf( name ), Tags );
+  QModelIndex i = index( offset + static_cast< int >( mEntityNames[type].indexOf( name ) ), Tags );
   emit dataChanged( i, i, QVector< int >() << Qt::DecorationRole );
 }
 
 void QgsStyleModel::onFavoriteChanged( QgsStyle::StyleEntity type, const QString &name, bool )
 {
   const int offset = offsetForEntity( type );
-  QModelIndex i = index( offset + mEntityNames[type].indexOf( name ), Name );
+  QModelIndex i = index( offset + static_cast< int >( mEntityNames[type].indexOf( name ) ), Name );
   emit dataChanged( i, i, QVector< int >() << static_cast< int >( CustomRole::IsFavorite ) );
 }
 
@@ -732,12 +749,12 @@ void QgsStyleModel::onEntityRename( QgsStyle::StyleEntity type, const QString &o
   const QStringList newSymbolNames = mStyle->allNames( type );
 
   // find index of removed symbol
-  const int oldNameIndex = oldSymbolNames.indexOf( oldName );
+  const int oldNameIndex = static_cast< int >( oldSymbolNames.indexOf( oldName ) );
   if ( oldNameIndex < 0 )
     return; // shouldn't happen
 
   // find index of added symbol
-  const int newNameIndex = newSymbolNames.indexOf( newName );
+  const int newNameIndex = static_cast< int >( newSymbolNames.indexOf( newName ) );
   if ( newNameIndex < 0 )
     return; // shouldn't happen
 
@@ -756,7 +773,7 @@ void QgsStyleModel::onEntityRename( QgsStyle::StyleEntity type, const QString &o
 void QgsStyleModel::onTagsChanged( int entity, const QString &name, const QStringList & )
 {
   QgsStyle::StyleEntity type = static_cast< QgsStyle::StyleEntity >( entity );
-  int row = mEntityNames[type].indexOf( name ) + offsetForEntity( type );
+  int row = static_cast< int >( mEntityNames[type].indexOf( name ) ) + offsetForEntity( type );
   switch ( static_cast< QgsStyle::StyleEntity >( entity ) )
   {
     case QgsStyle::TagEntity:
@@ -773,7 +790,7 @@ void QgsStyleModel::rebuildSymbolIcons()
 {
   mIconCache[QgsStyle::SymbolEntity].clear();
   mExpressionContext.reset();
-  const int lastRow = mEntityNames[QgsStyle::SymbolEntity].count() - 1;
+  const int lastRow = static_cast< int >( mEntityNames[QgsStyle::SymbolEntity].count() ) - 1;
   if ( lastRow >= 0 )
   {
     emit dataChanged( index( 0, 0 ), index( lastRow, 0 ), QVector<int>() << Qt::DecorationRole );
@@ -782,13 +799,19 @@ void QgsStyleModel::rebuildSymbolIcons()
 
 void QgsStyleModel::iconGenerated( QgsStyle::StyleEntity type, const QString &name, const QIcon &icon )
 {
-  int row = mEntityNames[type].indexOf( name ) + offsetForEntity( type );
+  int row = static_cast< int >( mEntityNames[type].indexOf( name ) ) + offsetForEntity( type );
 
   switch ( type )
   {
     case QgsStyle::Symbol3DEntity:
       mPending3dSymbolIcons.remove( name );
       mIconCache[QgsStyle::Symbol3DEntity].insert( name, icon );
+      emit dataChanged( index( row, 0 ), index( row, 0 ) );
+      break;
+
+    case QgsStyle::MaterialSettingsEntity:
+      mPendingMaterialSettingsIcons.remove( name );
+      mIconCache[QgsStyle::MaterialSettingsEntity].insert( name, icon );
       emit dataChanged( index( row, 0 ), index( row, 0 ) );
       break;
 
@@ -808,7 +831,7 @@ QgsStyle::StyleEntity QgsStyleModel::entityTypeFromRow( int row ) const
   int maxRowForEntity = 0;
   for ( QgsStyle::StyleEntity type : ENTITIES )
   {
-    maxRowForEntity += mEntityNames[type].size();
+    maxRowForEntity += static_cast< int >( mEntityNames[type].size() );
     if ( row < maxRowForEntity )
       return type;
   }
@@ -826,7 +849,7 @@ int QgsStyleModel::offsetForEntity( QgsStyle::StyleEntity entity ) const
     if ( type == entity )
       return offset;
 
-    offset += mEntityNames[type].size();
+    offset += static_cast< int >( mEntityNames[type].size() );
   }
   return 0;
 }
@@ -926,6 +949,7 @@ bool QgsStyleProxyModel::filterAcceptsRow( int source_row, const QModelIndex &so
       case QgsStyle::ColorrampEntity:
       case QgsStyle::SmartgroupEntity:
       case QgsStyle::LegendPatchShapeEntity:
+      case QgsStyle::MaterialSettingsEntity:
         break;
 
       case QgsStyle::LabelSettingsEntity:

--- a/src/core/symbology/qgsstylemodel.cpp
+++ b/src/core/symbology/qgsstylemodel.cpp
@@ -15,10 +15,12 @@
 
 #include "qgsstylemodel.h"
 
+#include "qgsabstractmaterialsettings.h"
 #include "qgsapplication.h"
 #include "qgscombinedstylemodel.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsimagecache.h"
+#include "qgsmaterialregistry.h"
 #include "qgsstyle.h"
 #include "qgssvgcache.h"
 #include "qgssymbollayerutils.h"
@@ -525,6 +527,29 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
       return QVariant();
     }
 
+    case static_cast< int >( CustomRole::MaterialType ):
+    {
+      switch ( entityType )
+      {
+        case QgsStyle::MaterialSettingsEntity:
+        {
+          std::unique_ptr< QgsAbstractMaterialSettings > settings = mStyle->materialSettings( name );
+          return settings ? settings->type() : QVariant();
+        }
+
+        case QgsStyle::LegendPatchShapeEntity:
+        case QgsStyle::TagEntity:
+        case QgsStyle::ColorrampEntity:
+        case QgsStyle::SmartgroupEntity:
+        case QgsStyle::LabelSettingsEntity:
+        case QgsStyle::TextFormatEntity:
+        case QgsStyle::Symbol3DEntity:
+        case QgsStyle::SymbolEntity:
+          return QVariant();
+      }
+      return QVariant();
+    }
+
     case static_cast< int >( CustomRole::EntityName ):
       return name;
 
@@ -901,6 +926,16 @@ void QgsStyleProxyModel::initialize()
   }
 }
 
+Qgis::MaterialRenderingTechnique QgsStyleProxyModel::renderingTechnique() const
+{
+  return mRenderingTechnique;
+}
+
+void QgsStyleProxyModel::setRenderingTechnique( Qgis::MaterialRenderingTechnique technique )
+{
+  mRenderingTechnique = technique;
+}
+
 QgsStyleProxyModel::QgsStyleProxyModel( QgsStyleModel *model, QObject *parent )
   : QSortFilterProxyModel( parent )
   , mModel( model )
@@ -920,7 +955,7 @@ QgsStyleProxyModel::QgsStyleProxyModel( QgsCombinedStyleModel *model, QObject *p
 
 bool QgsStyleProxyModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
-  if ( mFilterString.isEmpty() && !mEntityFilterEnabled && !mSymbolTypeFilterEnabled && mTagId < 0 && mSmartGroupId < 0 && !mFavoritesOnly && mTagFilter.isEmpty() )
+  if ( mFilterString.isEmpty() && !mEntityFilterEnabled && !mSymbolTypeFilterEnabled && !mRenderingTechniqueFilterEnabled && mTagId < 0 && mSmartGroupId < 0 && !mFavoritesOnly && mTagFilter.isEmpty() )
     return true;
 
   const QModelIndex index = sourceModel()->index( source_row, 0, source_parent );
@@ -1009,6 +1044,19 @@ bool QgsStyleProxyModel::filterAcceptsRow( int source_row, const QModelIndex &so
     }
   }
 
+  if ( mRenderingTechniqueFilterEnabled && styleEntityType == QgsStyle::MaterialSettingsEntity )
+  {
+    const QString materialType = sourceModel()->data( index, static_cast< int >( QgsStyleModel::CustomRole::MaterialType ) ).toString();
+    if ( !materialType.isEmpty() )
+    {
+      if ( const QgsMaterialSettingsAbstractMetadata *metadata = QgsApplication::materialRegistry()->materialSettingsMetadata( materialType ) )
+      {
+        if ( !metadata->supportsTechnique( mRenderingTechnique ) )
+          return false;
+      }
+    }
+  }
+
   return true;
 }
 
@@ -1077,6 +1125,20 @@ Qgis::GeometryType QgsStyleProxyModel::layerType() const
 void QgsStyleProxyModel::setLayerType( Qgis::GeometryType type )
 {
   mLayerType = type;
+  invalidateFilter();
+}
+
+bool QgsStyleProxyModel::renderingTechniqueFilterEnabled() const
+{
+  return mRenderingTechniqueFilterEnabled;
+}
+
+void QgsStyleProxyModel::setRenderingTechniqueFilterEnabled( bool enabled )
+{
+  if ( mRenderingTechniqueFilterEnabled == enabled )
+    return;
+
+  mRenderingTechniqueFilterEnabled = enabled;
   invalidateFilter();
 }
 

--- a/src/core/symbology/qgsstylemodel.h
+++ b/src/core/symbology/qgsstylemodel.h
@@ -157,6 +157,7 @@ class CORE_EXPORT QgsStyleModel : public QAbstractItemModel
       StyleName,                                                                          //!< Name of associated QgsStyle (QgsStyle::name()) \since QGIS 3.26
       StyleFileName,                                                                      //!< File name of associated QgsStyle (QgsStyle::fileName()) \since QGIS 3.26
       IsTitle SIP_MONKEYPATCH_COMPAT_NAME( IsTitleRole ),                                 //!< True if the index corresponds to a title item \since QGIS 3.26
+      MaterialType                                                                        //!< Material type (for material entities) \since QGIS 4.2
     };
     Q_ENUM( CustomRole )
     // *INDENT-ON*
@@ -346,7 +347,7 @@ class CORE_EXPORT QgsStyleProxyModel : public QSortFilterProxyModel
     /**
      * Returns the symbol type filter.
      *
-     * \note This filter is only active if Qgis::SymbolTypeFilterEnabled() is TRUE, and has
+     * \note This filter is only active if symbolTypeFilterEnabled() is TRUE, and has
      * no effect on non-symbol entities (i.e. color ramps).
      *
      * \see setSymbolType()
@@ -356,9 +357,9 @@ class CORE_EXPORT QgsStyleProxyModel : public QSortFilterProxyModel
     /**
      * Sets the symbol \a type filter.
      *
-     * \note This filter is only active if Qgis::SymbolTypeFilterEnabled() is TRUE.
+     * \note This filter is only active if symbolTypeFilterEnabled() is TRUE.
      *
-     * \see Qgis::SymbolType()
+     * \see symbolType()
      */
     void setSymbolType( Qgis::SymbolType type );
 
@@ -366,18 +367,18 @@ class CORE_EXPORT QgsStyleProxyModel : public QSortFilterProxyModel
      * Returns TRUE if filtering by symbol type is enabled.
      *
      * \see setSymbolTypeFilterEnabled()
-     * \see Qgis::SymbolType()
+     * \see symbolType()
      */
     bool symbolTypeFilterEnabled() const;
 
     /**
      * Sets whether filtering by symbol type is \a enabled.
      *
-     * If \a enabled is FALSE, then the value of Qgis::SymbolType() will have no
+     * If \a enabled is FALSE, then the value of symbolType() will have no
      * effect on the model filtering. This has
      * no effect on non-symbol entities (i.e. color ramps).
      *
-     * \see Qgis::SymbolTypeFilterEnabled()
+     * \see symbolTypeFilterEnabled()
      * \see setSymbolType()
      */
     void setSymbolTypeFilterEnabled( bool enabled );
@@ -399,6 +400,48 @@ class CORE_EXPORT QgsStyleProxyModel : public QSortFilterProxyModel
      * \see layerType()
      */
     void setLayerType( Qgis::GeometryType type );
+
+    /**
+     * Returns TRUE if filtering by material rendering technique is enabled.
+     *
+     * \see setRenderingTechniqueFilterEnabled()
+     * \see renderingTechnique()
+     * \since QGIS 4.2
+     */
+    bool renderingTechniqueFilterEnabled() const;
+
+    /**
+     * Sets whether filtering by material rendering technique is \a enabled.
+     *
+     * If \a enabled is FALSE, then the value of renderingTechnique() will have no
+     * effect on the model filtering. This has
+     * no effect on non-material entities (i.e. color ramps).
+     *
+     * \see renderingTechniqueFilterEnabled()
+     * \see setRenderingTechnique()
+     * \since QGIS 4.2
+     */
+    void setRenderingTechniqueFilterEnabled( bool enabled );
+
+    /**
+     * Returns the rendering technique filter.
+     *
+     * \note This filter is only active if renderingTechniqueFilterEnabled() is TRUE, and has
+     * no effect on non-material entities (i.e. color ramps).
+     *
+     * \since QGIS 4.2
+     */
+    Qgis::MaterialRenderingTechnique renderingTechnique() const;
+
+    /**
+     * Sets the rendering \a technique filter.
+     *
+     * \note This filter is only active if renderingTechniqueFilterEnabled() is TRUE.
+     *
+     * \see renderingTechnique()
+     * \since QGIS 4.2
+     */
+    void setRenderingTechnique( Qgis::MaterialRenderingTechnique technique );
 
     /**
      * Sets a tag \a id to filter style entities by. Only entities with the given
@@ -538,6 +581,9 @@ class CORE_EXPORT QgsStyleProxyModel : public QSortFilterProxyModel
     Qgis::SymbolType mSymbolType = Qgis::SymbolType::Marker;
 
     Qgis::GeometryType mLayerType = Qgis::GeometryType::Unknown;
+
+    bool mRenderingTechniqueFilterEnabled = false;
+    Qgis::MaterialRenderingTechnique mRenderingTechnique = Qgis::MaterialRenderingTechnique::Triangles;
 };
 
 #endif //QGSSTYLEMODEL_H

--- a/src/core/symbology/qgsstylemodel.h
+++ b/src/core/symbology/qgsstylemodel.h
@@ -239,6 +239,7 @@ class CORE_EXPORT QgsStyleModel : public QAbstractItemModel
 
     static QgsAbstractStyleEntityIconGenerator *sIconGenerator;
     mutable QSet< QString > mPending3dSymbolIcons;
+    mutable QSet< QString > mPendingMaterialSettingsIcons;
 
     QgsStyle::StyleEntity entityTypeFromRow( int row ) const;
 

--- a/src/gui/3d/qgsmaterialwidget.cpp
+++ b/src/gui/3d/qgsmaterialwidget.cpp
@@ -15,8 +15,8 @@
 
 #include "qgsmaterialwidget.h"
 
-#include "qgs3d.h"
 #include "qgsabstractmaterialsettings.h"
+#include "qgsapplication.h"
 #include "qgsmaterialregistry.h"
 #include "qgsmaterialsettingswidget.h"
 #include "qgsphongmaterialsettings.h"
@@ -29,15 +29,15 @@
 using namespace Qt::StringLiterals;
 
 QgsMaterialWidget::QgsMaterialWidget( QWidget *parent )
-  : QWidget( parent )
+  : QgsPanelWidget( parent )
   , mCurrentSettings( std::make_unique<QgsPhongMaterialSettings>() )
 {
   setupUi( this );
 
-  const QStringList materialTypes = Qgs3D::materialRegistry()->materialSettingsTypes();
+  const QStringList materialTypes = QgsApplication::materialRegistry()->materialSettingsTypes();
   for ( const QString &type : materialTypes )
   {
-    mMaterialTypeComboBox->addItem( Qgs3D::materialRegistry()->materialSettingsMetadata( type )->icon(), Qgs3D::materialRegistry()->materialSettingsMetadata( type )->visibleName(), type );
+    mMaterialTypeComboBox->addItem( QgsApplication::materialRegistry()->materialSettingsMetadata( type )->icon(), QgsApplication::materialRegistry()->materialSettingsMetadata( type )->visibleName(), type );
   }
 
   connect( mMaterialTypeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsMaterialWidget::materialTypeChanged );
@@ -46,17 +46,22 @@ QgsMaterialWidget::QgsMaterialWidget( QWidget *parent )
 void QgsMaterialWidget::setTechnique( Qgis::MaterialRenderingTechnique technique )
 {
   mTechnique = technique;
+  rebuildAvailableTypes();
+}
+
+void QgsMaterialWidget::rebuildAvailableTypes()
+{
   const QString prevType = mMaterialTypeComboBox->currentData().toString();
   mMaterialTypeComboBox->blockSignals( true );
   mMaterialTypeComboBox->clear();
 
-  const QStringList materialTypes = Qgs3D::materialRegistry()->materialSettingsTypes();
+  const QStringList materialTypes = QgsApplication::materialRegistry()->materialSettingsTypes();
   for ( const QString &type : materialTypes )
   {
-    if ( !Qgs3D::materialRegistry()->materialSettingsMetadata( type )->supportsTechnique( technique ) )
+    if ( mFilterByTechnique && !QgsApplication::materialRegistry()->materialSettingsMetadata( type )->supportsTechnique( mTechnique ) )
       continue;
 
-    mMaterialTypeComboBox->addItem( Qgs3D::materialRegistry()->materialSettingsMetadata( type )->icon(), Qgs3D::materialRegistry()->materialSettingsMetadata( type )->visibleName(), type );
+    mMaterialTypeComboBox->addItem( QgsApplication::materialRegistry()->materialSettingsMetadata( type )->icon(), QgsApplication::materialRegistry()->materialSettingsMetadata( type )->visibleName(), type );
   }
 
   const int prevIndex = mMaterialTypeComboBox->findData( prevType );
@@ -73,10 +78,18 @@ void QgsMaterialWidget::setTechnique( Qgis::MaterialRenderingTechnique technique
     mMaterialTypeComboBox->setCurrentIndex( prevIndex );
 
   if ( QgsMaterialSettingsWidget *w = qobject_cast<QgsMaterialSettingsWidget *>( mStackedWidget->currentWidget() ) )
-    w->setTechnique( technique );
+  {
+    w->setTechnique( mTechnique );
+  }
 
   mMaterialTypeComboBox->blockSignals( false );
   materialTypeChanged();
+}
+
+void QgsMaterialWidget::setFilterByTechnique( bool enabled )
+{
+  mFilterByTechnique = enabled;
+  rebuildAvailableTypes();
 }
 
 void QgsMaterialWidget::setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer )
@@ -87,9 +100,9 @@ void QgsMaterialWidget::setSettings( const QgsAbstractMaterialSettings *settings
   updateMaterialWidget();
 }
 
-QgsAbstractMaterialSettings *QgsMaterialWidget::settings()
+std::unique_ptr< QgsAbstractMaterialSettings > QgsMaterialWidget::settings()
 {
-  return mCurrentSettings->clone();
+  return std::unique_ptr< QgsAbstractMaterialSettings >( mCurrentSettings->clone() );
 }
 
 void QgsMaterialWidget::setType( const QString &type )
@@ -106,7 +119,7 @@ void QgsMaterialWidget::materialTypeChanged()
   if ( existingType == newType )
     return;
 
-  if ( QgsMaterialSettingsAbstractMetadata *am = Qgs3D::materialRegistry()->materialSettingsMetadata( newType ) )
+  if ( QgsMaterialSettingsAbstractMetadata *am = QgsApplication::materialRegistry()->materialSettingsMetadata( newType ) )
   {
     // change material to a new (with different type)
     // base new layer on existing materials's properties
@@ -148,7 +161,7 @@ void QgsMaterialWidget::updateMaterialWidget()
   }
 
   const QString settingsType = mCurrentSettings->type();
-  if ( QgsMaterialSettingsAbstractMetadata *am = Qgs3D::materialRegistry()->materialSettingsMetadata( settingsType ) )
+  if ( QgsMaterialSettingsAbstractMetadata *am = QgsApplication::materialRegistry()->materialSettingsMetadata( settingsType ) )
   {
     if ( QgsMaterialSettingsWidget *w = am->createWidget() )
     {

--- a/src/gui/3d/qgsmaterialwidget.cpp
+++ b/src/gui/3d/qgsmaterialwidget.cpp
@@ -17,16 +17,23 @@
 
 #include "qgsabstractmaterialsettings.h"
 #include "qgsapplication.h"
+#include "qgsgui.h"
 #include "qgsmaterialregistry.h"
 #include "qgsmaterialsettingswidget.h"
 #include "qgsphongmaterialsettings.h"
 #include "qgsreadwritecontext.h"
+#include "qgsvectorlayer.h"
 
+#include <QDialogButtonBox>
 #include <QString>
 
 #include "moc_qgsmaterialwidget.cpp"
 
 using namespace Qt::StringLiterals;
+
+//
+// QgsMaterialWidget
+//
 
 QgsMaterialWidget::QgsMaterialWidget( QWidget *parent )
   : QgsPanelWidget( parent )
@@ -176,4 +183,36 @@ void QgsMaterialWidget::updateMaterialWidget()
   }
   // When anything is not right
   mStackedWidget->setCurrentWidget( mPageDummy );
+}
+
+
+//
+// QgsMaterialWidgetDialog
+//
+
+QgsMaterialWidgetDialog::QgsMaterialWidgetDialog( const QgsAbstractMaterialSettings *settings, QWidget *parent )
+  : QDialog( parent )
+{
+  QgsGui::enableAutoGeometryRestore( this );
+
+  QVBoxLayout *vLayout = new QVBoxLayout();
+  mWidget = new QgsMaterialWidget();
+  vLayout->addWidget( mWidget, 1 );
+
+  if ( settings )
+  {
+    mWidget->setSettings( settings, nullptr );
+  }
+
+  mButtonBox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Ok, Qt::Horizontal );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  vLayout->addWidget( mButtonBox );
+  setLayout( vLayout );
+  setWindowTitle( tr( "Material" ) );
+}
+
+std::unique_ptr<QgsAbstractMaterialSettings> QgsMaterialWidgetDialog::settings()
+{
+  return mWidget->settings();
 }

--- a/src/gui/3d/qgsmaterialwidget.cpp
+++ b/src/gui/3d/qgsmaterialwidget.cpp
@@ -216,3 +216,8 @@ std::unique_ptr<QgsAbstractMaterialSettings> QgsMaterialWidgetDialog::settings()
 {
   return mWidget->settings();
 }
+
+QDialogButtonBox *QgsMaterialWidgetDialog::buttonBox()
+{
+  return mButtonBox;
+}

--- a/src/gui/3d/qgsmaterialwidget.cpp
+++ b/src/gui/3d/qgsmaterialwidget.cpp
@@ -37,17 +37,23 @@ using namespace Qt::StringLiterals;
 
 QgsMaterialWidget::QgsMaterialWidget( QWidget *parent )
   : QgsPanelWidget( parent )
-  , mCurrentSettings( std::make_unique<QgsPhongMaterialSettings>() )
 {
   setupUi( this );
 
   const QStringList materialTypes = QgsApplication::materialRegistry()->materialSettingsTypes();
   for ( const QString &type : materialTypes )
   {
+    if ( type == "null"_L1 )
+      continue;
+
     mMaterialTypeComboBox->addItem( QgsApplication::materialRegistry()->materialSettingsMetadata( type )->icon(), QgsApplication::materialRegistry()->materialSettingsMetadata( type )->visibleName(), type );
   }
 
+  mMaterialTypeComboBox->setCurrentIndex( -1 );
   connect( mMaterialTypeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsMaterialWidget::materialTypeChanged );
+  materialTypeChanged();
+
+  setSettings( new QgsPhongMaterialSettings(), nullptr );
 }
 
 void QgsMaterialWidget::setTechnique( Qgis::MaterialRenderingTechnique technique )
@@ -67,6 +73,9 @@ void QgsMaterialWidget::rebuildAvailableTypes()
   {
     if ( mFilterByTechnique && !QgsApplication::materialRegistry()->materialSettingsMetadata( type )->supportsTechnique( mTechnique ) )
       continue;
+
+    else if ( type == "null"_L1 && !mFilterByTechnique )
+      continue; // don't expose null as an option if we're showing in a generic mode
 
     mMaterialTypeComboBox->addItem( QgsApplication::materialRegistry()->materialSettingsMetadata( type )->icon(), QgsApplication::materialRegistry()->materialSettingsMetadata( type )->visibleName(), type );
   }
@@ -109,7 +118,7 @@ void QgsMaterialWidget::setSettings( const QgsAbstractMaterialSettings *settings
 
 std::unique_ptr< QgsAbstractMaterialSettings > QgsMaterialWidget::settings()
 {
-  return std::unique_ptr< QgsAbstractMaterialSettings >( mCurrentSettings->clone() );
+  return mCurrentSettings ? std::unique_ptr< QgsAbstractMaterialSettings >( mCurrentSettings->clone() ) : nullptr;
 }
 
 void QgsMaterialWidget::setType( const QString &type )

--- a/src/gui/3d/qgsmaterialwidget.cpp
+++ b/src/gui/3d/qgsmaterialwidget.cpp
@@ -56,6 +56,8 @@ QgsMaterialWidget::QgsMaterialWidget( QWidget *parent )
   setSettings( new QgsPhongMaterialSettings(), nullptr );
 }
 
+QgsMaterialWidget::~QgsMaterialWidget() = default;
+
 void QgsMaterialWidget::setTechnique( Qgis::MaterialRenderingTechnique technique )
 {
   mTechnique = technique;

--- a/src/gui/3d/qgsmaterialwidget.h
+++ b/src/gui/3d/qgsmaterialwidget.h
@@ -20,33 +20,92 @@
 
 #include <memory>
 
-#include "qgsabstractmaterialsettings.h"
+#include "qgis_gui.h"
 
 #include <QWidget>
 
+#define SIP_NO_FILE
+
+class QgsAbstractMaterialSettings;
 class QgsVectorLayer;
 
-//! Widget for configuration of material settings
-class QgsMaterialWidget : public QWidget, private Ui::MaterialWidgetBase
+/**
+ * \ingroup gui
+ * \class QgsMaterialWidget
+ *
+ * \brief A widget allowing users to customize a 3d materials.
+ *
+ * \note Not available in Python bindings
+ */
+class GUI_EXPORT QgsMaterialWidget : public QgsPanelWidget, private Ui::MaterialWidgetBase
 {
     Q_OBJECT
   public:
+    /**
+     * Constructor for QgsMaterialWidget.
+     */
     explicit QgsMaterialWidget( QWidget *parent = nullptr );
 
     /**
      * Sets the required rendering \a technique which the material must support.
      *
      * This is used to filter the available material choices in the widget.
+     *
+     * \note This setting is only respected when filterByTechnique() is TRUE.
+     *
+     * \see technique()
+     * \see filterByTechnique()
      */
     void setTechnique( Qgis::MaterialRenderingTechnique technique );
 
-    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer );
-    QgsAbstractMaterialSettings *settings();
+    /**
+     * Returns the required rendering technique which the material must support.
+     *
+     * This is used to filter the available material choices in the widget.
+     *
+     * \note This setting is only respected when filterByTechnique() is TRUE.
+     *
+     * \see setTechnique()
+     * \see filterByTechnique()
+     */
+    Qgis::MaterialRenderingTechnique technique() const { return mTechnique; }
 
+    /**
+     * Sets whether available materials should be filtered by technique.
+     *
+     * \see filterByTechnique()
+     * \see setTechnique()
+     */
+    void setFilterByTechnique( bool enabled );
+
+    /**
+     * Returns whether available materials are filtered by technique.
+     *
+     * \see setFilterByTechnique()
+     * \see setTechnique()
+     */
+    bool filterByTechnique() const { return mFilterByTechnique; }
+
+    /**
+     * Sets the widget state to match material \a settings.
+     */
+    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer );
+
+    /**
+     * Returns the current settings defined by the widget.
+     */
+    std::unique_ptr< QgsAbstractMaterialSettings > settings();
+
+    /**
+     * Sets the current material \a type.
+     */
     void setType( const QString &type );
 
   signals:
 
+    /**
+     * Emitted when the material defined by the widget is changed.
+     */
     void changed();
 
   private slots:
@@ -55,9 +114,12 @@ class QgsMaterialWidget : public QWidget, private Ui::MaterialWidgetBase
 
   private:
     void updateMaterialWidget();
+    void rebuildAvailableTypes();
     QgsVectorLayer *mLayer = nullptr;
 
     std::unique_ptr<QgsAbstractMaterialSettings> mCurrentSettings;
+
+    bool mFilterByTechnique = false;
     Qgis::MaterialRenderingTechnique mTechnique = Qgis::MaterialRenderingTechnique::Triangles;
 };
 

--- a/src/gui/3d/qgsmaterialwidget.h
+++ b/src/gui/3d/qgsmaterialwidget.h
@@ -50,6 +50,7 @@ class GUI_EXPORT QgsMaterialWidget : public QgsPanelWidget, private Ui::Material
      * Constructor for QgsMaterialWidget.
      */
     explicit QgsMaterialWidget( QWidget *parent = nullptr );
+    ~QgsMaterialWidget() override;
 
     /**
      * Sets the required rendering \a technique which the material must support.

--- a/src/gui/3d/qgsmaterialwidget.h
+++ b/src/gui/3d/qgsmaterialwidget.h
@@ -145,9 +145,14 @@ class GUI_EXPORT QgsMaterialWidgetDialog : public QDialog
     QgsMaterialWidgetDialog( const QgsAbstractMaterialSettings *settings, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
-   * Returns the current settings defined by the dialog.
-   */
+    * Returns the current settings defined by the dialog.
+    */
     std::unique_ptr< QgsAbstractMaterialSettings > settings();
+
+    /**
+     * Returns the dialog's button box.
+     */
+    QDialogButtonBox *buttonBox();
 
   private:
     QgsMaterialWidget *mWidget = nullptr;

--- a/src/gui/3d/qgsmaterialwidget.h
+++ b/src/gui/3d/qgsmaterialwidget.h
@@ -39,6 +39,7 @@ class QDialogButtonBox;
  * \brief A widget allowing users to customize a 3d material.
  *
  * \note Not available in Python bindings
+ * \since QGIS 4.2
  */
 class GUI_EXPORT QgsMaterialWidget : public QgsPanelWidget, private Ui::MaterialWidgetBase
 {

--- a/src/gui/3d/qgsmaterialwidget.h
+++ b/src/gui/3d/qgsmaterialwidget.h
@@ -22,18 +22,21 @@
 
 #include "qgis_gui.h"
 
+#include <QDialog>
+#include <QPointer>
 #include <QWidget>
 
 #define SIP_NO_FILE
 
 class QgsAbstractMaterialSettings;
 class QgsVectorLayer;
+class QDialogButtonBox;
 
 /**
  * \ingroup gui
  * \class QgsMaterialWidget
  *
- * \brief A widget allowing users to customize a 3d materials.
+ * \brief A widget allowing users to customize a 3d material.
  *
  * \note Not available in Python bindings
  */
@@ -115,12 +118,41 @@ class GUI_EXPORT QgsMaterialWidget : public QgsPanelWidget, private Ui::Material
   private:
     void updateMaterialWidget();
     void rebuildAvailableTypes();
-    QgsVectorLayer *mLayer = nullptr;
+    QPointer< QgsVectorLayer > mLayer;
 
     std::unique_ptr<QgsAbstractMaterialSettings> mCurrentSettings;
 
     bool mFilterByTechnique = false;
     Qgis::MaterialRenderingTechnique mTechnique = Qgis::MaterialRenderingTechnique::Triangles;
 };
+
+
+/**
+ * \ingroup gui
+ * \brief A dialog for configuring a 3D material.
+ *
+ * \note Not available in Python bindings
+ * \since QGIS 4.2
+ */
+class GUI_EXPORT QgsMaterialWidgetDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+    /**
+   * Constructor for QgsMaterialWidgetDialog, initially showing the specified material \a settings.
+   */
+    QgsMaterialWidgetDialog( const QgsAbstractMaterialSettings *settings, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+   * Returns the current settings defined by the dialog.
+   */
+    std::unique_ptr< QgsAbstractMaterialSettings > settings();
+
+  private:
+    QgsMaterialWidget *mWidget = nullptr;
+    QDialogButtonBox *mButtonBox = nullptr;
+};
+
 
 #endif // QGSMATERIALWIDGET_H

--- a/src/gui/3d/qgsmaterialwidget.h
+++ b/src/gui/3d/qgsmaterialwidget.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 
+#include "qgis.h"
 #include "qgis_gui.h"
 
 #include <QDialog>

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(QGIS_GUI_SRCS
+  3d/qgsmaterialwidget.cpp
+
   actions/qgsactionmenu.cpp
   actions/qgsmaplayeraction.cpp
   actions/qgsmaplayeractioncontext.cpp
@@ -1109,6 +1111,8 @@ set(QGIS_GUI_HDRS
   qgsvscrollarea.h
   qgswindowmanagerinterface.h
 
+  3d/qgsmaterialwidget.h
+
   actions/qgsactionmenu.h
   actions/qgsmaplayeraction.h
   actions/qgsmaplayeractioncontext.h
@@ -1925,6 +1929,7 @@ target_include_directories(qgis_gui SYSTEM PUBLIC
 
 target_include_directories(qgis_gui PUBLIC
   ${CMAKE_SOURCE_DIR}/src/gui
+  ${CMAKE_SOURCE_DIR}/src/gui/3d
   ${CMAKE_SOURCE_DIR}/src/gui/actions
   ${CMAKE_SOURCE_DIR}/src/gui/annotations
   ${CMAKE_SOURCE_DIR}/src/gui/attributeformconfig

--- a/src/gui/labeling/qgslabelinggui.cpp
+++ b/src/gui/labeling/qgslabelinggui.cpp
@@ -839,6 +839,7 @@ void QgsLabelingGui::setFormatFromStyle( const QString &name, QgsStyle::StyleEnt
     case QgsStyle::TextFormatEntity:
     case QgsStyle::LegendPatchShapeEntity:
     case QgsStyle::Symbol3DEntity:
+    case QgsStyle::MaterialSettingsEntity:
     {
       QgsTextFormatWidget::setFormatFromStyle( name, type, stylePath );
       return;
@@ -935,6 +936,7 @@ void QgsLabelingGui::saveFormat()
     case QgsStyle::SmartgroupEntity:
     case QgsStyle::LegendPatchShapeEntity:
     case QgsStyle::Symbol3DEntity:
+    case QgsStyle::MaterialSettingsEntity:
       break;
   }
 }

--- a/src/gui/qgs3dsymbolwidget.h
+++ b/src/gui/qgs3dsymbolwidget.h
@@ -75,6 +75,16 @@ class GUI_EXPORT Qgs3DSymbolWidget : public QWidget
      * Emitted when the symbol is changed.
      */
     void changed();
+
+    /**
+     * Emitted when the rendering technique associated with the symbol is changed.
+     *
+     * \warning This is not considered stable API, and may change in future QGIS releases. It is
+     * exposed to the Python bindings as a tech preview only.
+     *
+     * \since QGIS 4.2
+     */
+    void renderingTechniqueChanged();
 };
 
 

--- a/src/gui/qgs3dsymbolwidget.h
+++ b/src/gui/qgs3dsymbolwidget.h
@@ -16,6 +16,7 @@
 #ifndef QGS3DSYMBOLWIDGET_H
 #define QGS3DSYMBOLWIDGET_H
 
+#include "qgis.h"
 #include "qgis_gui.h"
 #include "qgis_sip.h"
 

--- a/src/gui/qgs3dsymbolwidget.h
+++ b/src/gui/qgs3dsymbolwidget.h
@@ -59,6 +59,16 @@ class GUI_EXPORT Qgs3DSymbolWidget : public QWidget
      */
     virtual QString symbolType() const = 0;
 
+    /**
+     * Returns associated rendering technique.
+     *
+     * \warning This is not considered stable API, and may change in future QGIS releases. It is
+     * exposed to the Python bindings as a tech preview only.
+     *
+     * \since QGIS 4.2
+     */
+    virtual Qgis::MaterialRenderingTechnique renderingTechnique() const = 0;
+
   signals:
 
     /**

--- a/src/gui/qgsstyleitemslistwidget.cpp
+++ b/src/gui/qgsstyleitemslistwidget.cpp
@@ -341,6 +341,13 @@ void QgsStyleItemsListWidget::setEntityTypes( const QList<QgsStyle::StyleEntity>
     if ( allGroup >= 0 )
       groupsCombo->setItemText( allGroup, tr( "All Settings" ) );
   }
+  else if ( filters.length() == 2 && filters.contains( QgsStyle::Symbol3DEntity ) && filters.contains( QgsStyle::MaterialSettingsEntity ) )
+  {
+    btnSaveSymbol->setText( tr( "Save Symbol" ) );
+    btnSaveSymbol->setToolTip( tr( "Save 3D symbol or material to styles" ) );
+    if ( allGroup >= 0 )
+      groupsCombo->setItemText( allGroup, tr( "All Symbols" ) );
+  }
 }
 
 void QgsStyleItemsListWidget::setSymbolType( Qgis::SymbolType type )

--- a/src/gui/qgsstyleitemslistwidget.cpp
+++ b/src/gui/qgsstyleitemslistwidget.cpp
@@ -314,6 +314,13 @@ void QgsStyleItemsListWidget::setEntityType( QgsStyle::StyleEntity type )
         groupsCombo->setItemText( allGroup, tr( "All 3D Symbols" ) );
       break;
 
+    case QgsStyle::MaterialSettingsEntity:
+      btnSaveSymbol->setText( tr( "Save Material…" ) );
+      btnSaveSymbol->setToolTip( tr( "Save material to styles" ) );
+      if ( allGroup >= 0 )
+        groupsCombo->setItemText( allGroup, tr( "All Materials" ) );
+      break;
+
     case QgsStyle::TagEntity:
     case QgsStyle::SmartgroupEntity:
       break;
@@ -442,6 +449,10 @@ void QgsStyleItemsListWidget::populateGroups()
 
       case QgsStyle::Symbol3DEntity:
         allText = tr( "All 3D Symbols" );
+        break;
+
+      case QgsStyle::MaterialSettingsEntity:
+        allText = tr( "All Materials" );
         break;
 
       case QgsStyle::TagEntity:

--- a/src/gui/qgsstyleitemslistwidget.cpp
+++ b/src/gui/qgsstyleitemslistwidget.cpp
@@ -407,6 +407,11 @@ QgsStyle::StyleEntity QgsStyleItemsListWidget::currentEntityType() const
   return static_cast<QgsStyle::StyleEntity>( mModel->data( index, static_cast<int>( QgsStyleModel::CustomRole::Type ) ).toInt() );
 }
 
+QgsStyleProxyModel *QgsStyleItemsListWidget::proxyModel()
+{
+  return mModel;
+}
+
 void QgsStyleItemsListWidget::showEvent( QShowEvent *event )
 {
   // restore header sizes on show event -- because this widget is used in multiple places simultaneously

--- a/src/gui/qgsstyleitemslistwidget.h
+++ b/src/gui/qgsstyleitemslistwidget.h
@@ -167,6 +167,13 @@ class GUI_EXPORT QgsStyleItemsListWidget : public QWidget, private Ui::QgsStyleI
      */
     QgsStyle::StyleEntity currentEntityType() const;
 
+    /**
+     * Returns the associated proxy model.
+     *
+     * \since QGIS 4.2
+     */
+    QgsStyleProxyModel *proxyModel();
+
   protected:
     void showEvent( QShowEvent *event ) override;
 

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -2210,6 +2210,7 @@ void QgsTextFormatWidget::setFormatFromStyle( const QString &name, QgsStyle::Sty
     case QgsStyle::SmartgroupEntity:
     case QgsStyle::LegendPatchShapeEntity:
     case QgsStyle::Symbol3DEntity:
+    case QgsStyle::MaterialSettingsEntity:
       return;
 
     case QgsStyle::TextFormatEntity:

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -2384,7 +2384,8 @@ void QgsStyleManagerDialog::removeItem()
 
   if ( allTypesSelected() )
   {
-    if ( QMessageBox::Yes != QMessageBox::question( this, tr( "Remove Items" ), QString( tr( "Do you really want to remove %n item(s)?", nullptr, items.count() ) ), QMessageBox::Yes, QMessageBox::No ) )
+    if ( QMessageBox::Yes
+         != QMessageBox::question( this, tr( "Remove Items" ), QString( tr( "Do you really want to remove %n item(s)?", nullptr, static_cast< int >( items.count() ) ) ), QMessageBox::Yes, QMessageBox::No ) )
       return;
   }
   else
@@ -2392,43 +2393,48 @@ void QgsStyleManagerDialog::removeItem()
     if ( currentItemType() < 3 )
     {
       if ( QMessageBox::Yes
-           != QMessageBox::question( this, tr( "Remove Symbol" ), QString( tr( "Do you really want to remove %n symbol(s)?", nullptr, items.count() ) ), QMessageBox::Yes, QMessageBox::No ) )
+           != QMessageBox::question( this, tr( "Remove Symbol" ), QString( tr( "Do you really want to remove %n symbol(s)?", nullptr, static_cast< int >( items.count() ) ) ), QMessageBox::Yes, QMessageBox::No ) )
         return;
     }
     else if ( currentItemType() == 3 )
     {
       if ( QMessageBox::Yes
-           != QMessageBox::question( this, tr( "Remove Color Ramp" ), QString( tr( "Do you really want to remove %n ramp(s)?", nullptr, items.count() ) ), QMessageBox::Yes, QMessageBox::No ) )
+           != QMessageBox::question( this, tr( "Remove Color Ramp" ), QString( tr( "Do you really want to remove %n ramp(s)?", nullptr, static_cast< int >( items.count() ) ) ), QMessageBox::Yes, QMessageBox::No ) )
         return;
     }
     else if ( currentItemType() == 4 )
     {
       if ( QMessageBox::Yes
-           != QMessageBox::question( this, tr( "Remove Text Formats" ), QString( tr( "Do you really want to remove %n text format(s)?", nullptr, items.count() ) ), QMessageBox::Yes, QMessageBox::No ) )
+           != QMessageBox::
+             question( this, tr( "Remove Text Formats" ), QString( tr( "Do you really want to remove %n text format(s)?", nullptr, static_cast< int >( items.count() ) ) ), QMessageBox::Yes, QMessageBox::No ) )
         return;
     }
     else if ( currentItemType() == 5 )
     {
       if ( QMessageBox::Yes
-           != QMessageBox::question( this, tr( "Remove Label Settings" ), QString( tr( "Do you really want to remove %n label setting(s)?", nullptr, items.count() ) ), QMessageBox::Yes, QMessageBox::No ) )
+           != QMessageBox::
+             question( this, tr( "Remove Label Settings" ), QString( tr( "Do you really want to remove %n label setting(s)?", nullptr, static_cast< int >( items.count() ) ) ), QMessageBox::Yes, QMessageBox::No ) )
         return;
     }
     else if ( currentItemType() == 6 )
     {
       if ( QMessageBox::Yes
-           != QMessageBox::question( this, tr( "Remove Legend Patch Shapes" ), QString( tr( "Do you really want to remove %n legend patch shape(s)?", nullptr, items.count() ) ), QMessageBox::Yes, QMessageBox::No ) )
+           != QMessageBox::
+             question( this, tr( "Remove Legend Patch Shapes" ), QString( tr( "Do you really want to remove %n legend patch shape(s)?", nullptr, static_cast< int >( items.count() ) ) ), QMessageBox::Yes, QMessageBox::No ) )
         return;
     }
     else if ( currentItemType() == 7 )
     {
       if ( QMessageBox::Yes
-           != QMessageBox::question( this, tr( "Remove 3D Symbols" ), QString( tr( "Do you really want to remove %n 3D symbol(s)?", nullptr, items.count() ) ), QMessageBox::Yes, QMessageBox::No ) )
+           != QMessageBox::
+             question( this, tr( "Remove 3D Symbols" ), QString( tr( "Do you really want to remove %n 3D symbol(s)?", nullptr, static_cast< int >( items.count() ) ) ), QMessageBox::Yes, QMessageBox::No ) )
         return;
     }
     else if ( currentItemType() == 8 )
     {
       if ( QMessageBox::Yes
-           != QMessageBox::question( this, tr( "Remove Material" ), QString( tr( "Do you really want to remove %n material(s)?", nullptr, items.count() ) ), QMessageBox::Yes, QMessageBox::No ) )
+           != QMessageBox::
+             question( this, tr( "Remove Material" ), QString( tr( "Do you really want to remove %n material(s)?", nullptr, static_cast< int >( items.count() ) ) ), QMessageBox::Yes, QMessageBox::No ) )
         return;
     }
   }

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -645,7 +645,7 @@ void QgsStyleManagerDialog::tabItemType_currentChanged( int )
   {
     btnAddItem->setMenu( mMenuBtnAddItemLegendPatchShape );
   }
-  else if ( !readOnly && isSymbol3D ) // 3d symbol tab
+  else if ( !readOnly && isSymbol3D ) // 3D symbol tab
   {
     btnAddItem->setMenu( mMenuBtnAddItemSymbol3D );
   }

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -18,6 +18,7 @@
 #include "qgs3dsymbolregistry.h"
 #include "qgs3dsymbolwidget.h"
 #include "qgsabstract3dsymbol.h"
+#include "qgsabstractmaterialsettings.h"
 #include "qgsapplication.h"
 #include "qgscolorbrewercolorrampdialog.h"
 #include "qgscolorramp.h"
@@ -32,6 +33,7 @@
 #include "qgslinesymbol.h"
 #include "qgslogger.h"
 #include "qgsmarkersymbol.h"
+#include "qgsmaterialwidget.h"
 #include "qgsmessagebar.h"
 #include "qgspresetcolorrampdialog.h"
 #include "qgsproject.h"
@@ -378,6 +380,11 @@ void QgsStyleManagerDialog::init()
   mMenuBtnAddItemLegendPatchShape->addAction( item );
 
   mMenuBtnAddItemAll->addSeparator();
+  item = new QAction( QgsApplication::getThemeIcon( u"3d.svg"_s ), tr( "Material…" ), this );
+  connect( item, &QAction::triggered, this, [this]( bool ) { addMaterialSettings(); } );
+  mMenuBtnAddItemAll->addAction( item );
+
+  mMenuBtnAddItemAll->addSeparator();
   item = new QAction( QgsApplication::getThemeIcon( u"3d.svg"_s ), tr( "3D Point Symbol…" ), this );
   connect( item, &QAction::triggered, this, [this]( bool ) { addSymbol3D( u"point"_s ); } );
   mMenuBtnAddItemAll->addAction( item );
@@ -612,19 +619,21 @@ void QgsStyleManagerDialog::populateTypes()
 void QgsStyleManagerDialog::tabItemType_currentChanged( int )
 {
   // when in Color Ramp tab, add menu to add item button and hide "Export symbols as PNG/SVG"
-  const bool isSymbol = currentItemType() != 3 && currentItemType() != 4 && currentItemType() != 5 && currentItemType() != 6 && currentItemType() != 7;
+  const bool isSymbol = currentItemType() != 3 && currentItemType() != 4 && currentItemType() != 5 && currentItemType() != 6 && currentItemType() != 7 && currentItemType() != 8;
   const bool isColorRamp = currentItemType() == 3;
   const bool isTextFormat = currentItemType() == 4;
   const bool isLabelSettings = currentItemType() == 5;
   const bool isLegendPatchShape = currentItemType() == 6;
   const bool isSymbol3D = currentItemType() == 7;
+  const bool isMaterialSettings = currentItemType() == 8;
   searchBox->setPlaceholderText(
     isSymbol             ? tr( "Filter symbols…" )
     : isColorRamp        ? tr( "Filter color ramps…" )
     : isTextFormat       ? tr( "Filter text symbols…" )
     : isLabelSettings    ? tr( "Filter label settings…" )
     : isLegendPatchShape ? tr( "Filter legend patch shapes…" )
-                         : tr( "Filter 3D symbols…" )
+    : isSymbol3D         ? tr( "Filter 3D symbols…" )
+                         : tr( "Filter materials…" )
   );
 
   const bool readOnly = isReadOnly();
@@ -636,9 +645,13 @@ void QgsStyleManagerDialog::tabItemType_currentChanged( int )
   {
     btnAddItem->setMenu( mMenuBtnAddItemLegendPatchShape );
   }
-  else if ( !readOnly && isSymbol3D ) // legend patch shape tab
+  else if ( !readOnly && isSymbol3D ) // 3d symbol tab
   {
     btnAddItem->setMenu( mMenuBtnAddItemSymbol3D );
+  }
+  else if ( !readOnly && isMaterialSettings ) //  material settings tab
+  {
+    btnAddItem->setMenu( nullptr );
   }
   else if ( !readOnly && isLabelSettings ) // label settings tab
   {
@@ -668,7 +681,8 @@ void QgsStyleManagerDialog::tabItemType_currentChanged( int )
                    : isTextFormat       ? QgsStyle::TextFormatEntity
                    : isLabelSettings    ? QgsStyle::LabelSettingsEntity
                    : isLegendPatchShape ? QgsStyle::LegendPatchShapeEntity
-                                        : QgsStyle::Symbol3DEntity )
+                   : isSymbol3D         ? QgsStyle::Symbol3DEntity
+                                        : QgsStyle::MaterialSettingsEntity )
     );
     mModel->setEntityFilterEnabled( !allTypesSelected() );
     mModel->setSymbolTypeFilterEnabled( isSymbol && !allTypesSelected() );
@@ -749,6 +763,7 @@ void QgsStyleManagerDialog::copyItem()
     case QgsStyle::Symbol3DEntity:
     case QgsStyle::TagEntity:
     case QgsStyle::SmartgroupEntity:
+    case QgsStyle::MaterialSettingsEntity:
       return;
   }
 }
@@ -873,6 +888,8 @@ int QgsStyleManagerDialog::selectedItemType()
     return 6;
   else if ( entity == QgsStyle::Symbol3DEntity )
     return 7;
+  else if ( entity == QgsStyle::MaterialSettingsEntity )
+    return 8;
 
   return mModel->data( index, static_cast<int>( QgsStyleModel::CustomRole::SymbolType ) ).toInt();
 }
@@ -929,6 +946,7 @@ int QgsStyleManagerDialog::copyItems(
   const QStringList favoriteLabelSettings = src->symbolsOfFavorite( QgsStyle::LabelSettingsEntity );
   const QStringList favoriteLegendPatchShapes = src->symbolsOfFavorite( QgsStyle::LegendPatchShapeEntity );
   const QStringList favorite3dSymbols = src->symbolsOfFavorite( QgsStyle::Symbol3DEntity );
+  const QStringList favoriteMaterialSettings = src->symbolsOfFavorite( QgsStyle::MaterialSettingsEntity );
 
   for ( auto &details : items )
   {
@@ -989,6 +1007,8 @@ int QgsStyleManagerDialog::copyItems(
               prompt = false;
               overwriteAll = false;
               break;
+            default:
+              break;
           }
         }
 
@@ -1044,6 +1064,8 @@ int QgsStyleManagerDialog::copyItems(
               prompt = false;
               overwriteAll = false;
               break;
+            default:
+              break;
           }
         }
 
@@ -1097,6 +1119,9 @@ int QgsStyleManagerDialog::copyItems(
               prompt = false;
               overwriteAll = false;
               break;
+
+            default:
+              break;
           }
         }
 
@@ -1149,6 +1174,9 @@ int QgsStyleManagerDialog::copyItems(
               prompt = false;
               overwriteAll = false;
               break;
+
+            default:
+              break;
           }
         }
 
@@ -1200,6 +1228,9 @@ int QgsStyleManagerDialog::copyItems(
             case QMessageBox::NoToAll:
               prompt = false;
               overwriteAll = false;
+              break;
+
+            default:
               break;
           }
         }
@@ -1255,6 +1286,9 @@ int QgsStyleManagerDialog::copyItems(
               prompt = false;
               overwriteAll = false;
               break;
+
+            default:
+              break;
           }
         }
 
@@ -1263,6 +1297,64 @@ int QgsStyleManagerDialog::copyItems(
           QgsAbstract3DSymbol *newSymbol = symbol.get();
           dst->addSymbol3D( details.name, symbol.release() );
           dst->saveSymbol3D( details.name, newSymbol, addItemToFavorites, symbolTags );
+          count++;
+        }
+        break;
+      }
+
+      case QgsStyle::MaterialSettingsEntity:
+      {
+        std::unique_ptr<QgsAbstractMaterialSettings > settings( src->materialSettings( details.name ) );
+        if ( !settings )
+          continue;
+
+        const bool hasDuplicateName = dst->materialSettingsNames().contains( details.name );
+        bool overwriteThis = false;
+        if ( isImport )
+          addItemToFavorites = favoriteMaterialSettings.contains( details.name );
+
+        if ( hasDuplicateName && prompt )
+        {
+          cursorOverride.reset();
+          int res = QMessageBox::warning(
+            parentWidget,
+            isImport ? tr( "Import Material" ) : tr( "Export Material" ),
+            tr( "A material with the name “%1” already exists.\nOverwrite?" ).arg( details.name ),
+            QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel
+          );
+          cursorOverride = std::make_unique<QgsTemporaryCursorOverride>( Qt::WaitCursor );
+          switch ( res )
+          {
+            case QMessageBox::Cancel:
+              return count;
+
+            case QMessageBox::No:
+              continue;
+
+            case QMessageBox::Yes:
+              overwriteThis = true;
+              break;
+
+            case QMessageBox::YesToAll:
+              prompt = false;
+              overwriteAll = true;
+              break;
+
+            case QMessageBox::NoToAll:
+              prompt = false;
+              overwriteAll = false;
+              break;
+
+            default:
+              break;
+          }
+        }
+
+        if ( !hasDuplicateName || overwriteAll || overwriteThis )
+        {
+          QgsAbstractMaterialSettings *newSettings = settings.get();
+          dst->addMaterialSettings( details.name, settings.release() );
+          dst->saveMaterialSettings( details.name, newSettings, addItemToFavorites, symbolTags );
           count++;
         }
         break;
@@ -1366,6 +1458,8 @@ int QgsStyleManagerDialog::currentItemType()
     case 7:
       return 6;
     case 8:
+      return 8;
+    case 9:
       return 7;
     default:
       return 0;
@@ -1410,6 +1504,10 @@ void QgsStyleManagerDialog::addItem()
   {
     // actually never hit, because we present a submenu when adding 3d symbols
     // changed = addSymbol3D();
+  }
+  else if ( currentItemType() == 8 )
+  {
+    changed = addMaterialSettings();
   }
   else
   {
@@ -1728,6 +1826,10 @@ void QgsStyleManagerDialog::editItem()
   else if ( selectedItemType() == 7 )
   {
     editSymbol3D();
+  }
+  else if ( selectedItemType() == 8 )
+  {
+    editMaterialSettings();
   }
   else
   {
@@ -2149,6 +2251,98 @@ bool QgsStyleManagerDialog::editSymbol3D()
   return true;
 }
 
+bool QgsStyleManagerDialog::addMaterialSettings()
+{
+  QgsMaterialWidgetDialog dialog( nullptr, this );
+  dialog.setWindowTitle( tr( "New Material" ) );
+  if ( isReadOnly() )
+    dialog.buttonBox()->button( QDialogButtonBox::Ok )->setEnabled( false );
+
+  if ( !dialog.exec() )
+    return false;
+
+  std::unique_ptr< QgsAbstractMaterialSettings > settings = dialog.settings();
+  if ( !settings )
+    return false;
+
+  QgsStyleSaveDialog saveDlg( this, QgsStyle::MaterialSettingsEntity );
+  const QString defaultTag = groupTree->currentIndex().isValid() ? groupTree->currentIndex().data( GroupModelRoles::TagName ).toString() : QString();
+  saveDlg.setDefaultTags( defaultTag );
+  if ( !saveDlg.exec() )
+    return false;
+  QString name = saveDlg.name();
+
+  // request valid/unique name
+  bool nameInvalid = true;
+  while ( nameInvalid )
+  {
+    // validate name
+    if ( name.isEmpty() )
+    {
+      QMessageBox::warning( this, tr( "Save Material" ), tr( "Cannot save materials without a name. Enter a name." ) );
+    }
+    else if ( mStyle->materialSettingsNames().contains( name ) )
+    {
+      int res = QMessageBox::warning( this, tr( "Save Material" ), tr( "A material with the name '%1' already exists. Overwrite?" ).arg( name ), QMessageBox::Yes | QMessageBox::No );
+      if ( res == QMessageBox::Yes )
+      {
+        mStyle->removeEntityByName( QgsStyle::MaterialSettingsEntity, name );
+        nameInvalid = false;
+      }
+    }
+    else
+    {
+      // valid name
+      nameInvalid = false;
+    }
+    if ( nameInvalid )
+    {
+      bool ok;
+      name = QInputDialog::getText( this, tr( "Material Name" ), tr( "Please enter a name for the new material:" ), QLineEdit::Normal, name, &ok );
+      if ( !ok )
+      {
+        return false;
+      }
+    }
+  }
+
+  QStringList symbolTags = saveDlg.tags().split( ',' );
+
+  // add new material to style and re-populate the list
+  QgsAbstractMaterialSettings *newSettings = settings.get();
+  mStyle->addMaterialSettings( name, settings.release() );
+  mStyle->saveMaterialSettings( name, newSettings, saveDlg.isFavorite(), symbolTags );
+
+  mModified = true;
+  return true;
+}
+
+bool QgsStyleManagerDialog::editMaterialSettings()
+{
+  const QString settingsName = currentItemName();
+  if ( settingsName.isEmpty() )
+    return false;
+
+  std::unique_ptr<QgsAbstractMaterialSettings> settings( mStyle->materialSettings( settingsName ) );
+  if ( !settings )
+    return false;
+
+  // let the user edit the settings and update list when done
+  QgsMaterialWidgetDialog dlg( settings.get(), this );
+  dlg.setWindowTitle( settingsName );
+  if ( !dlg.exec() )
+    return false;
+
+  settings = dlg.settings();
+  if ( !settings )
+    return false;
+
+  // by adding the setting to style with the same name the old effectively gets overwritten
+  mStyle->addMaterialSettings( settingsName, settings.release(), true );
+  mModified = true;
+  return true;
+}
+
 void QgsStyleManagerDialog::addStyleDatabase( bool createNew )
 {
   QString initialFolder = QgsStyleManagerDialog::settingLastStyleDatabaseFolder->value();
@@ -2229,6 +2423,12 @@ void QgsStyleManagerDialog::removeItem()
     {
       if ( QMessageBox::Yes
            != QMessageBox::question( this, tr( "Remove 3D Symbols" ), QString( tr( "Do you really want to remove %n 3D symbol(s)?", nullptr, items.count() ) ), QMessageBox::Yes, QMessageBox::No ) )
+        return;
+    }
+    else if ( currentItemType() == 8 )
+    {
+      if ( QMessageBox::Yes
+           != QMessageBox::question( this, tr( "Remove Material" ), QString( tr( "Do you really want to remove %n material(s)?", nullptr, items.count() ) ), QMessageBox::Yes, QMessageBox::No ) )
         return;
     }
   }

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -487,6 +487,9 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     bool addSymbol3D( const QString &type );
     bool editSymbol3D();
 
+    bool addMaterialSettings();
+    bool editMaterialSettings();
+
     void addStyleDatabase( bool createNew );
 
     friend class QgsStyleExportImportDialog;

--- a/src/gui/symbology/qgsstylesavedialog.cpp
+++ b/src/gui/symbology/qgsstylesavedialog.cpp
@@ -74,7 +74,12 @@ QgsStyleSaveDialog::QgsStyleSaveDialog( QWidget *parent, QgsStyle::StyleEntity t
 
     case QgsStyle::Symbol3DEntity:
       this->setWindowTitle( tr( "Save New 3D Symbol" ) );
-      possibleEntities << QgsStyle::Symbol3DEntity;
+      possibleEntities << QgsStyle::Symbol3DEntity << QgsStyle::MaterialSettingsEntity;
+      break;
+
+    case QgsStyle::MaterialSettingsEntity:
+      this->setWindowTitle( tr( "Save New Material Settings" ) );
+      possibleEntities << QgsStyle::MaterialSettingsEntity;
       break;
 
     case QgsStyle::TagEntity:
@@ -130,6 +135,10 @@ QgsStyleSaveDialog::QgsStyleSaveDialog( QWidget *parent, QgsStyle::StyleEntity t
 
         case QgsStyle::Symbol3DEntity:
           mComboSaveAs->addItem( QgsApplication::getThemeIcon( u"3d.svg"_s ), tr( "3D Symbol" ), e );
+          break;
+
+        case QgsStyle::MaterialSettingsEntity:
+          mComboSaveAs->addItem( QgsApplication::getThemeIcon( u"3d.svg"_s ), tr( "Material" ), e );
           break;
 
         case QgsStyle::TagEntity:

--- a/src/ui/3d/materialwidget.ui
+++ b/src/ui/3d/materialwidget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MaterialWidgetBase</class>
- <widget class="QWidget" name="MaterialWidgetBase">
+ <widget class="QgsPanelWidget" name="MaterialWidgetBase">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -51,4 +51,12 @@
  </widget>
  <resources/>
  <connections/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
 </ui>

--- a/src/ui/qgsstylemanagerdialogbase.ui
+++ b/src/ui/qgsstylemanagerdialogbase.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QSplitter" name="mSplitter">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="handleWidth">
       <number>3</number>
@@ -119,7 +119,7 @@
           </size>
          </property>
          <property name="editTriggers">
-          <set>QAbstractItemView::DoubleClicked</set>
+          <set>QAbstractItemView::EditTrigger::DoubleClicked</set>
          </property>
         </widget>
        </item>
@@ -257,7 +257,7 @@
          <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -288,7 +288,7 @@
             <bool>true</bool>
            </property>
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
           </widget>
          </item>
@@ -462,6 +462,15 @@
              <string>Legend Patch Shapes</string>
             </attribute>
            </widget>
+           <widget class="QWidget" name="tabMaterialSettings">
+            <attribute name="icon">
+             <iconset resource="../../images/images.qrc">
+              <normaloff>:/images/themes/default/3d.svg</normaloff>:/images/themes/default/3d.svg</iconset>
+            </attribute>
+            <attribute name="title">
+             <string>Materials</string>
+            </attribute>
+           </widget>
            <widget class="QWidget" name="tab3DSymbols">
             <attribute name="icon">
              <iconset resource="../../images/images.qrc">
@@ -501,7 +510,7 @@
                 </sizepolicy>
                </property>
                <property name="editTriggers">
-                <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+                <set>QAbstractItemView::EditTrigger::EditKeyPressed|QAbstractItemView::EditTrigger::SelectedClicked</set>
                </property>
                <property name="iconSize">
                 <size>
@@ -510,19 +519,19 @@
                 </size>
                </property>
                <property name="textElideMode">
-                <enum>Qt::ElideNone</enum>
+                <enum>Qt::TextElideMode::ElideNone</enum>
                </property>
                <property name="flow">
-                <enum>QListView::LeftToRight</enum>
+                <enum>QListView::Flow::LeftToRight</enum>
                </property>
                <property name="resizeMode">
-                <enum>QListView::Adjust</enum>
+                <enum>QListView::ResizeMode::Adjust</enum>
                </property>
                <property name="spacing">
                 <number>5</number>
                </property>
                <property name="viewMode">
-                <enum>QListView::IconMode</enum>
+                <enum>QListView::ViewMode::IconMode</enum>
                </property>
                <property name="uniformItemSizes">
                 <bool>false</bool>
@@ -564,10 +573,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+      <set>QDialogButtonBox::StandardButton::Close|QDialogButtonBox::StandardButton::Help</set>
      </property>
      <property name="centerButtons">
       <bool>false</bool>
@@ -761,7 +770,6 @@
   <tabstop>searchBox</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>

--- a/tests/src/3d/testqgsmaterialregistry.cpp
+++ b/tests/src/3d/testqgsmaterialregistry.cpp
@@ -153,7 +153,7 @@ void TestQgsMaterialRegistry::createMaterial()
   QVERIFY( dummySymbol );
 
   //try creating a bad material
-  material.reset( registry->createMaterialSettings( u"bad material"_s ) );
+  material = registry->createMaterialSettings( u"bad material"_s );
   QVERIFY( !material.get() );
 }
 

--- a/tests/src/core/testqgsstyle.cpp
+++ b/tests/src/core/testqgsstyle.cpp
@@ -55,6 +55,8 @@ using namespace Qt::StringLiterals;
 #include "qgs3dsymbolregistry.h"
 #include "qgsmarkersymbol.h"
 #include "qgsfillsymbol.h"
+#include "qgsgoochmaterialsettings.h"
+#include "qgsphongmaterialsettings.h"
 
 /**
  * \ingroup UnitTests
@@ -111,6 +113,7 @@ class TestStyle : public QgsTest
     void testCreateLabelSettings();
     void testCreateLegendPatchShapes();
     void testCreate3dSymbol();
+    void testCreateMaterialSettings();
     void testLoadColorRamps();
     void testSaveLoad();
     void testFavorites();
@@ -512,6 +515,70 @@ void TestStyle::testCreate3dSymbol()
   QVERIFY( mStyle->symbol3DNames().contains( u"test_settings2"_s ) );
 }
 
+void TestStyle::testCreateMaterialSettings()
+{
+  QVERIFY( mStyle->materialSettingsNames().isEmpty() );
+  QCOMPARE( mStyle->materialSettingsCount(), 0 );
+  // non existent settings, should be default
+  QVERIFY( !mStyle->materialSettings( QString( "blah" ) ) );
+
+  const QSignalSpy spy( mStyle, &QgsStyle::entityAdded );
+  const QSignalSpy spyChanged( mStyle, &QgsStyle::entityChanged );
+
+  // add material
+  QgsGoochMaterialSettings settings;
+  settings.setWarm( QColor( 0, 0, 255 ) );
+  QVERIFY( mStyle->addMaterialSettings( "test_settings", settings.clone(), true ) );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spyChanged.count(), 0 );
+
+  QVERIFY( mStyle->materialSettingsNames().contains( u"test_settings"_s ) );
+  QCOMPARE( mStyle->materialSettingsCount(), 1 );
+  std::unique_ptr<QgsGoochMaterialSettings> retrieved( dynamic_cast<QgsGoochMaterialSettings *>( mStyle->materialSettings( u"test_settings"_s ).release() ) );
+  QCOMPARE( retrieved->warm().name(), u"#0000ff"_s );
+
+  settings.setWarm( QColor( 0, 255, 255 ) );
+  QVERIFY( mStyle->addMaterialSettings( "test_settings", settings.clone(), true ) );
+  QVERIFY( mStyle->materialSettingsNames().contains( u"test_settings"_s ) );
+  QCOMPARE( mStyle->materialSettingsCount(), 1 );
+  retrieved.reset( dynamic_cast<QgsGoochMaterialSettings *>( mStyle->materialSettings( u"test_settings"_s ).release() ) );
+  QCOMPARE( retrieved->warm().name(), u"#00ffff"_s );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spyChanged.count(), 1 );
+
+  QgsPhongMaterialSettings phong;
+  phong.setAmbient( QColor( 0, 155, 255 ) );
+  QVERIFY( mStyle->addMaterialSettings( "test_format2", phong.clone(), true ) );
+  QVERIFY( mStyle->materialSettingsNames().contains( u"test_format2"_s ) );
+  QCOMPARE( mStyle->materialSettingsCount(), 2 );
+  retrieved.reset( dynamic_cast<QgsGoochMaterialSettings *>( mStyle->materialSettings( u"test_settings"_s ).release() ) );
+  QCOMPARE( retrieved->warm().name(), u"#00ffff"_s );
+  std::unique_ptr<QgsPhongMaterialSettings> retrieved2( dynamic_cast<QgsPhongMaterialSettings *>( mStyle->materialSettings( u"test_format2"_s ).release() ) );
+  QCOMPARE( retrieved2->ambient().name(), u"#009bff"_s );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spyChanged.count(), 1 );
+
+  // save and restore
+  QVERIFY( mStyle->exportXml( QDir::tempPath() + "/text_style.xml" ) );
+
+  QgsStyle style2;
+  QVERIFY( style2.importXml( QDir::tempPath() + "/text_style.xml" ) );
+
+  QVERIFY( style2.materialSettingsNames().contains( u"test_settings"_s ) );
+  QVERIFY( style2.materialSettingsNames().contains( u"test_format2"_s ) );
+  QCOMPARE( style2.materialSettingsCount(), 2 );
+  retrieved.reset( dynamic_cast<QgsGoochMaterialSettings *>( style2.materialSettings( u"test_settings"_s ).release() ) );
+  QCOMPARE( retrieved->warm().name(), u"#00ffff"_s );
+  retrieved2.reset( dynamic_cast<QgsPhongMaterialSettings *>( style2.materialSettings( u"test_format2"_s ).release() ) );
+  QCOMPARE( retrieved2->ambient().name(), u"#009bff"_s );
+
+  QCOMPARE( mStyle->allNames( QgsStyle::MaterialSettingsEntity ), QStringList() << u"test_format2"_s << u"test_settings"_s );
+
+  QgsStyleMaterialSettingsEntity entity( &settings );
+  QVERIFY( mStyle->addEntity( "test_settings2", &entity, true ) );
+  QVERIFY( mStyle->materialSettingsNames().contains( u"test_settings2"_s ) );
+}
+
 void TestStyle::testLoadColorRamps()
 {
   const QStringList colorRamps = mStyle->colorRampNames();
@@ -773,6 +840,32 @@ void TestStyle::testFavorites()
   favorites = mStyle->symbolsOfFavorite( QgsStyle::Symbol3DEntity );
   QCOMPARE( favorites.count(), 0 );
   QVERIFY( !mStyle->isFavorite( QgsStyle::Symbol3DEntity, u"settings_1"_s ) );
+
+  // material settings
+  const QgsGoochMaterialSettings materialSettings1;
+  QVERIFY( mStyle->addMaterialSettings( u"settings_1"_s, materialSettings1.clone(), true ) );
+  favorites = mStyle->symbolsOfFavorite( QgsStyle::MaterialSettingsEntity );
+  QCOMPARE( favorites.count(), 0 );
+  QVERIFY( !mStyle->isFavorite( QgsStyle::MaterialSettingsEntity, u"settings_1"_s ) );
+
+  mStyle->addFavorite( QgsStyle::MaterialSettingsEntity, u"settings_1"_s );
+  QCOMPARE( favoriteChangedSpy.count(), 13 );
+  QCOMPARE( favoriteChangedSpy.at( 12 ).at( 0 ).toInt(), static_cast<int>( QgsStyle::MaterialSettingsEntity ) );
+  QCOMPARE( favoriteChangedSpy.at( 12 ).at( 1 ).toString(), u"settings_1"_s );
+  QCOMPARE( favoriteChangedSpy.at( 12 ).at( 2 ).toBool(), true );
+  favorites = mStyle->symbolsOfFavorite( QgsStyle::MaterialSettingsEntity );
+  QCOMPARE( favorites.count(), 1 );
+  QVERIFY( favorites.contains( u"settings_1"_s ) );
+  QVERIFY( mStyle->isFavorite( QgsStyle::MaterialSettingsEntity, u"settings_1"_s ) );
+
+  mStyle->removeFavorite( QgsStyle::MaterialSettingsEntity, u"settings_1"_s );
+  QCOMPARE( favoriteChangedSpy.count(), 14 );
+  QCOMPARE( favoriteChangedSpy.at( 13 ).at( 0 ).toInt(), static_cast<int>( QgsStyle::MaterialSettingsEntity ) );
+  QCOMPARE( favoriteChangedSpy.at( 13 ).at( 1 ).toString(), u"settings_1"_s );
+  QCOMPARE( favoriteChangedSpy.at( 13 ).at( 2 ).toBool(), false );
+  favorites = mStyle->symbolsOfFavorite( QgsStyle::MaterialSettingsEntity );
+  QCOMPARE( favorites.count(), 0 );
+  QVERIFY( !mStyle->isFavorite( QgsStyle::MaterialSettingsEntity, u"settings_1"_s ) );
 }
 
 void TestStyle::testTags()
@@ -1269,6 +1362,68 @@ void TestStyle::testTags()
   QCOMPARE( tagsChangedSpy.at( 41 ).at( 0 ).toInt(), static_cast<int>( QgsStyle::Symbol3DEntity ) );
   QCOMPARE( tagsChangedSpy.at( 41 ).at( 1 ).toString(), u"3dsymbol1"_s );
   QCOMPARE( tagsChangedSpy.at( 41 ).at( 2 ).toStringList(), QStringList() );
+
+  // materials
+  // tag format
+  const QgsGoochMaterialSettings material1;
+  QVERIFY( mStyle->addMaterialSettings( "material1", material1.clone(), true ) );
+  const QgsGoochMaterialSettings material2;
+  QVERIFY( mStyle->addMaterialSettings( "material2", material1.clone(), true ) );
+
+  QVERIFY( mStyle->tagSymbol( QgsStyle::MaterialSettingsEntity, "material1", QStringList() << "blue" << "starry" ) );
+  QCOMPARE( tagsChangedSpy.count(), 45 );
+  QCOMPARE( tagsChangedSpy.at( 44 ).at( 0 ).toInt(), static_cast<int>( QgsStyle::MaterialSettingsEntity ) );
+  QCOMPARE( tagsChangedSpy.at( 44 ).at( 1 ).toString(), u"material1"_s );
+  QCOMPARE( tagsChangedSpy.at( 44 ).at( 2 ).toStringList(), QStringList() << u"blue"_s << u"starry"_s );
+
+  QVERIFY( mStyle->tagSymbol( QgsStyle::MaterialSettingsEntity, "material2", QStringList() << "red" << "circle" ) );
+  QCOMPARE( tagsChangedSpy.count(), 46 );
+  QCOMPARE( tagsChangedSpy.at( 45 ).at( 0 ).toInt(), static_cast<int>( QgsStyle::MaterialSettingsEntity ) );
+  QCOMPARE( tagsChangedSpy.at( 45 ).at( 1 ).toString(), u"material2"_s );
+  QCOMPARE( tagsChangedSpy.at( 45 ).at( 2 ).toStringList(), QStringList() << u"red"_s << u"circle"_s );
+
+  //bad format name
+  QVERIFY( !mStyle->tagSymbol( QgsStyle::MaterialSettingsEntity, "no patch", QStringList() << "red" << "circle" ) );
+  QCOMPARE( tagsChangedSpy.count(), 46 );
+  //tag which hasn't been added yet
+  QVERIFY( mStyle->tagSymbol( QgsStyle::MaterialSettingsEntity, "material2", QStringList() << "red settings" ) );
+  QCOMPARE( tagsChangedSpy.count(), 47 );
+  QCOMPARE( tagsChangedSpy.at( 46 ).at( 0 ).toInt(), static_cast<int>( QgsStyle::MaterialSettingsEntity ) );
+  QCOMPARE( tagsChangedSpy.at( 46 ).at( 1 ).toString(), u"material2"_s );
+  QCOMPARE( tagsChangedSpy.at( 46 ).at( 2 ).toStringList(), QStringList() << u"red"_s << u"circle"_s << u"red settings"_s );
+
+  tags = mStyle->tags();
+  QVERIFY( tags.contains( u"red settings"_s ) );
+
+  //check that tags have been applied
+  tags = mStyle->tagsOfSymbol( QgsStyle::MaterialSettingsEntity, u"material1"_s );
+  QCOMPARE( tags.count(), 2 );
+  QVERIFY( tags.contains( "blue" ) );
+  QVERIFY( tags.contains( "starry" ) );
+  tags = mStyle->tagsOfSymbol( QgsStyle::MaterialSettingsEntity, u"material2"_s );
+  QCOMPARE( tags.count(), 3 );
+  QVERIFY( tags.contains( "red" ) );
+  QVERIFY( tags.contains( "circle" ) );
+  QVERIFY( tags.contains( "red settings" ) );
+
+  //remove a tag, including a non-present tag
+  QVERIFY( mStyle->detagSymbol( QgsStyle::MaterialSettingsEntity, "material1", QStringList() << "bad" << "blue" ) );
+  tags = mStyle->tagsOfSymbol( QgsStyle::MaterialSettingsEntity, u"material1"_s );
+  QCOMPARE( tags.count(), 1 );
+  QVERIFY( tags.contains( "starry" ) );
+  QCOMPARE( tagsChangedSpy.count(), 48 );
+  QCOMPARE( tagsChangedSpy.at( 47 ).at( 0 ).toInt(), static_cast<int>( QgsStyle::MaterialSettingsEntity ) );
+  QCOMPARE( tagsChangedSpy.at( 47 ).at( 1 ).toString(), u"material1"_s );
+  QCOMPARE( tagsChangedSpy.at( 47 ).at( 2 ).toStringList(), QStringList() << u"starry"_s );
+
+  // completely detag symbol
+  QVERIFY( mStyle->detagSymbol( QgsStyle::MaterialSettingsEntity, u"material1"_s ) );
+  tags = mStyle->tagsOfSymbol( QgsStyle::MaterialSettingsEntity, u"material1"_s );
+  QCOMPARE( tags.count(), 0 );
+  QCOMPARE( tagsChangedSpy.count(), 49 );
+  QCOMPARE( tagsChangedSpy.at( 48 ).at( 0 ).toInt(), static_cast<int>( QgsStyle::MaterialSettingsEntity ) );
+  QCOMPARE( tagsChangedSpy.at( 48 ).at( 1 ).toString(), u"material1"_s );
+  QCOMPARE( tagsChangedSpy.at( 48 ).at( 2 ).toStringList(), QStringList() );
 }
 
 void TestStyle::testSmartGroup()
@@ -1309,6 +1464,11 @@ void TestStyle::testSmartGroup()
   const Dummy3DSymbol symbol3d2;
   QVERIFY( style.addSymbol3D( "different symbol3D bbb", symbol3d2.clone(), true ) );
 
+  const QgsGoochMaterialSettings material1;
+  QVERIFY( style.addMaterialSettings( "material a", material1.clone(), true ) );
+  const QgsGoochMaterialSettings material2;
+  QVERIFY( style.addMaterialSettings( "different mt bbb", material2.clone(), true ) );
+
   QVERIFY( style.smartgroupNames().empty() );
   QVERIFY( style.smartgroup( 5 ).isEmpty() );
   QCOMPARE( style.smartgroupId( u"no exist"_s ), 0 );
@@ -1328,6 +1488,7 @@ void TestStyle::testSmartGroup()
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::LabelSettingsEntity, 1 ), QStringList() << u"settings a"_s );
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::LegendPatchShapeEntity, 1 ), QStringList() << u"shp a"_s );
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::Symbol3DEntity, 1 ), QStringList() << u"symbol3D a"_s );
+  QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::MaterialSettingsEntity, 1 ), QStringList() << u"material a"_s );
 
   res = style.addSmartgroup( u"tag"_s, u"OR"_s, QStringList(), QStringList(), QStringList() << "c", QStringList() << "a" );
   QCOMPARE( res, 2 );
@@ -1343,6 +1504,7 @@ void TestStyle::testSmartGroup()
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::LabelSettingsEntity, 2 ), QStringList() << u"different l bbb"_s );
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::LegendPatchShapeEntity, 2 ), QStringList() << u"different shp bbb"_s );
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::Symbol3DEntity, 2 ), QStringList() << u"different symbol3D bbb"_s );
+  QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::MaterialSettingsEntity, 2 ), QStringList() << u"different mt bbb"_s );
 
   // tag some symbols
   style.tagSymbol( QgsStyle::SymbolEntity, "symbolA", QStringList() << "red" << "blue" );
@@ -1357,6 +1519,8 @@ void TestStyle::testSmartGroup()
   style.tagSymbol( QgsStyle::LegendPatchShapeEntity, "different shp bbb", QStringList() << "blue" << "red" );
   style.tagSymbol( QgsStyle::Symbol3DEntity, "symbol3D a", QStringList() << "blue" );
   style.tagSymbol( QgsStyle::Symbol3DEntity, "different symbol3D bbb", QStringList() << "blue" << "red" );
+  style.tagSymbol( QgsStyle::MaterialSettingsEntity, "material a", QStringList() << "blue" );
+  style.tagSymbol( QgsStyle::MaterialSettingsEntity, "different mt bbb", QStringList() << "blue" << "red" );
 
   // adding tags modifies groups!
   QCOMPARE( groupModifiedSpy.count(), 4 );
@@ -1375,6 +1539,7 @@ void TestStyle::testSmartGroup()
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::LabelSettingsEntity, 3 ), QStringList() << u"settings a"_s );
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::LegendPatchShapeEntity, 3 ), QStringList() << u"shp a"_s );
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::Symbol3DEntity, 3 ), QStringList() << u"symbol3D a"_s );
+  QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::MaterialSettingsEntity, 3 ), QStringList() << u"material a"_s );
 
   res = style.addSmartgroup( u"combined"_s, u"AND"_s, QStringList() << "blue", QStringList(), QStringList(), QStringList() << "a" );
   QCOMPARE( res, 4 );
@@ -1390,6 +1555,7 @@ void TestStyle::testSmartGroup()
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::LabelSettingsEntity, 4 ), QStringList() << u"different l bbb"_s );
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::LegendPatchShapeEntity, 4 ), QStringList() << u"different shp bbb"_s );
   QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::Symbol3DEntity, 4 ), QStringList() << u"different symbol3D bbb"_s );
+  QCOMPARE( style.symbolsOfSmartgroup( QgsStyle::MaterialSettingsEntity, 4 ), QStringList() << u"different mt bbb"_s );
 
   style.remove( QgsStyle::SmartgroupEntity, 1 );
   QCOMPARE( style.smartgroupNames(), QStringList() << u"tag"_s << u"tags"_s << u"combined"_s );
@@ -1455,6 +1621,10 @@ class TestVisitor : public QgsStyleEntityVisitorInterface
 
         case QgsStyle::Symbol3DEntity:
           mFound << u"symbol 3d: %1 %2 %3"_s.arg( entity.description, entity.identifier, static_cast<const QgsStyleSymbol3DEntity *>( entity.entity )->symbol()->type() );
+          break;
+
+        case QgsStyle::MaterialSettingsEntity:
+          mFound << u"material: %1 %2 %3"_s.arg( entity.description, entity.identifier, static_cast<const QgsStyleMaterialSettingsEntity *>( entity.entity )->settings()->type() );
           break;
 
         case QgsStyle::TagEntity:

--- a/tests/src/python/test_qgsstylemodel.py
+++ b/tests/src/python/test_qgsstylemodel.py
@@ -16,6 +16,7 @@ from qgis.core import (
     QgsAbstract3DSymbol,
     QgsFillSymbol,
     QgsGeometry,
+    QgsGoochMaterialSettings,
     QgsLegendPatchShape,
     QgsLimitedRandomColorRamp,
     QgsLinePatternFillSymbolLayer,
@@ -736,6 +737,93 @@ class TestQgsStyleModel(QgisTestCase):
             None,
         )
 
+    def test_style_with_material_settings(self):
+        style = QgsStyle()
+        style.createMemoryDatabase()
+
+        # style with material settings
+
+        material_a = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("a", material_a, True))
+        style.tagSymbol(
+            QgsStyle.StyleEntity.MaterialSettingsEntity, "a", ["tag 1", "tag 2"]
+        )
+        material_B = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("B ", material_B, True))
+        material_b = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("b", material_b, True))
+        material_C = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("C", material_C, True))
+        style.tagSymbol(QgsStyle.StyleEntity.MaterialSettingsEntity, "C", ["tag 3"])
+        style.addFavorite(QgsStyle.StyleEntity.MaterialSettingsEntity, "C")
+        material_C = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings(" ----c/- ", material_C, True))
+
+        model = QgsStyleModel(style)
+        self.assertEqual(model.rowCount(), 5)
+        self.assertEqual(model.columnCount(), 2)
+
+        self.assertTrue(model.index(0, 0).isValid())
+        self.assertFalse(model.index(10, 0).isValid())
+        self.assertFalse(model.index(0, 10).isValid())
+
+        self.assertFalse(model.parent(model.index(0, 0)).isValid())
+
+        for role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
+            self.assertIsNone(model.data(model.index(-1, 0), role))
+            self.assertIsNone(model.data(model.index(-1, 1), role))
+            self.assertEqual(model.data(model.index(0, 0), role), " ----c/- ")
+            self.assertFalse(model.data(model.index(0, 1), role))
+            self.assertIsNone(model.data(model.index(0, 2), role))
+            self.assertIsNone(model.data(model.index(0, -1), role))
+            self.assertEqual(model.data(model.index(1, 0), role), "B ")
+            self.assertFalse(model.data(model.index(1, 1), role))
+            self.assertEqual(model.data(model.index(2, 0), role), "C")
+            self.assertEqual(model.data(model.index(2, 1), role), "tag 3")
+            self.assertEqual(model.data(model.index(3, 0), role), "a")
+            self.assertEqual(model.data(model.index(3, 1), role), "tag 1, tag 2")
+            self.assertEqual(model.data(model.index(4, 0), role), "b")
+            self.assertFalse(model.data(model.index(4, 1), role))
+            self.assertIsNone(model.data(model.index(5, 0), role))
+            self.assertIsNone(model.data(model.index(5, 1), role))
+
+        # decorations
+        self.assertIsNone(
+            model.data(model.index(-1, 0), Qt.ItemDataRole.DecorationRole)
+        )
+        self.assertIsNone(model.data(model.index(0, 1), Qt.ItemDataRole.DecorationRole))
+        self.assertIsNone(model.data(model.index(5, 0), Qt.ItemDataRole.DecorationRole))
+        # self.assertFalse(model.data(model.index(0, 0), Qt.DecorationRole).isNull())
+
+        self.assertEqual(
+            model.data(model.index(0, 0), QgsStyleModel.Role.TypeRole),
+            QgsStyle.StyleEntity.MaterialSettingsEntity,
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), QgsStyleModel.Role.TypeRole),
+            QgsStyle.StyleEntity.MaterialSettingsEntity,
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), QgsStyleModel.Role.TypeRole),
+            QgsStyle.StyleEntity.MaterialSettingsEntity,
+        )
+
+        self.assertEqual(
+            model.data(model.index(0, 0), QgsStyleModel.Role.IsFavoriteRole), False
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), QgsStyleModel.Role.IsFavoriteRole), False
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), QgsStyleModel.Role.IsFavoriteRole), True
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), QgsStyleModel.Role.IsFavoriteRole), False
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), QgsStyleModel.Role.IsFavoriteRole), False
+        )
+
     def test_mixed_style(self):
         """
         Test style with both symbols and ramps
@@ -814,12 +902,24 @@ class TestQgsStyleModel(QgisTestCase):
         symbol3d_b = Dummy3dSymbol()
         self.assertTrue(style.addSymbol3D("symbol3d c", symbol3d_b, True))
 
+        material_a = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material a", material_a, True))
+        style.tagSymbol(
+            QgsStyle.StyleEntity.MaterialSettingsEntity,
+            "material a",
+            ["tag 1", "tag 2"],
+        )
+        material_B = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material B ", material_B, True))
+        material_b = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material c", material_b, True))
+
         model = QgsStyleModel(style)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
         self.assertEqual(model.columnCount(), 2)
 
         self.assertTrue(model.index(0, 0).isValid())
-        self.assertFalse(model.index(20, 0).isValid())
+        self.assertFalse(model.index(23, 0).isValid())
         self.assertFalse(model.index(0, 10).isValid())
 
         self.assertFalse(model.parent(model.index(0, 0)).isValid())
@@ -869,8 +969,16 @@ class TestQgsStyleModel(QgisTestCase):
             self.assertEqual(model.data(model.index(18, 1), role), "tag 1, tag 2")
             self.assertEqual(model.data(model.index(19, 0), role), "symbol3d c")
             self.assertFalse(model.data(model.index(19, 1), role))
-            self.assertIsNone(model.data(model.index(20, 0), role))
-            self.assertIsNone(model.data(model.index(20, 1), role))
+
+            self.assertEqual(model.data(model.index(20, 0), role), "material B ")
+            self.assertFalse(model.data(model.index(20, 1), role))
+            self.assertEqual(model.data(model.index(21, 0), role), "material a")
+            self.assertEqual(model.data(model.index(21, 1), role), "tag 1, tag 2")
+            self.assertEqual(model.data(model.index(22, 0), role), "material c")
+            self.assertFalse(model.data(model.index(22, 1), role))
+
+            self.assertIsNone(model.data(model.index(23, 0), role))
+            self.assertIsNone(model.data(model.index(23, 1), role))
 
         # decorations
         self.assertIsNone(
@@ -878,7 +986,7 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertIsNone(model.data(model.index(0, 1), Qt.ItemDataRole.DecorationRole))
         self.assertIsNone(
-            model.data(model.index(20, 0), Qt.ItemDataRole.DecorationRole)
+            model.data(model.index(23, 0), Qt.ItemDataRole.DecorationRole)
         )
         self.assertFalse(
             model.data(model.index(0, 0), Qt.ItemDataRole.DecorationRole).isNull()
@@ -968,6 +1076,18 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(19, 0), QgsStyleModel.Role.TypeRole),
             QgsStyle.StyleEntity.Symbol3DEntity,
+        )
+        self.assertEqual(
+            model.data(model.index(20, 0), QgsStyleModel.Role.TypeRole),
+            QgsStyle.StyleEntity.MaterialSettingsEntity,
+        )
+        self.assertEqual(
+            model.data(model.index(21, 0), QgsStyleModel.Role.TypeRole),
+            QgsStyle.StyleEntity.MaterialSettingsEntity,
+        )
+        self.assertEqual(
+            model.data(model.index(22, 0), QgsStyleModel.Role.TypeRole),
+            QgsStyle.StyleEntity.MaterialSettingsEntity,
         )
 
     def test_add_delete_symbols(self):
@@ -1964,6 +2084,270 @@ class TestQgsStyleModel(QgisTestCase):
             model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
 
+    def test_add_material(self):
+        style = QgsStyle()
+        style.createMemoryDatabase()
+
+        model = QgsStyleModel(style)
+        symbol = createMarkerSymbol()
+        self.assertTrue(style.addSymbol("a", symbol, True))
+        symbol = createMarkerSymbol()
+        self.assertTrue(style.addSymbol("c", symbol, True))
+        self.assertEqual(model.rowCount(), 2)
+
+        ramp_a = QgsLimitedRandomColorRamp(5)
+        self.assertTrue(style.addColorRamp("ramp a", ramp_a, True))
+        self.assertEqual(model.rowCount(), 3)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "c"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp a"
+        )
+
+        format_a = QgsTextFormat()
+        self.assertTrue(style.addTextFormat("format a", format_a, True))
+        self.assertEqual(model.rowCount(), 4)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "c"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp a"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "format a"
+        )
+
+        settings_a = QgsPalLayerSettings()
+        self.assertTrue(style.addLabelSettings("settings a", settings_a, True))
+        self.assertEqual(model.rowCount(), 5)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "c"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp a"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "format a"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "settings a"
+        )
+
+        shape_a = QgsLegendPatchShape()
+        self.assertTrue(style.addLegendPatchShape("shape a", shape_a, True))
+        self.assertEqual(model.rowCount(), 6)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "c"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp a"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "format a"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "settings a"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "shape a"
+        )
+
+        symbol3d_a = Dummy3dSymbol()
+        self.assertTrue(style.addSymbol3D("symbol3d a", symbol3d_a, True))
+        self.assertEqual(model.rowCount(), 7)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "c"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp a"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "format a"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "settings a"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "shape a"
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole), "symbol3d a"
+        )
+
+        material_a = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material a", material_a, True))
+        self.assertEqual(model.rowCount(), 8)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "c"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp a"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "format a"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "settings a"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "shape a"
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole), "symbol3d a"
+        )
+        self.assertEqual(
+            model.data(model.index(7, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+
+        material_B = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material c", material_B, True))
+        self.assertEqual(model.rowCount(), 9)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "c"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp a"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "format a"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "settings a"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "shape a"
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole), "symbol3d a"
+        )
+        self.assertEqual(
+            model.data(model.index(7, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(8, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
+
+        material_b = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material b", material_b, True))
+        self.assertEqual(model.rowCount(), 10)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "c"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp a"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "format a"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "settings a"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "shape a"
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole), "symbol3d a"
+        )
+        self.assertEqual(
+            model.data(model.index(7, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(8, 0), Qt.ItemDataRole.DisplayRole), "material b"
+        )
+        self.assertEqual(
+            model.data(model.index(9, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
+
+        self.assertTrue(
+            style.removeEntityByName(
+                QgsStyle.StyleEntity.MaterialSettingsEntity, "material a"
+            )
+        )
+        self.assertEqual(model.rowCount(), 9)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "c"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp a"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "format a"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "settings a"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "shape a"
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole), "symbol3d a"
+        )
+        self.assertEqual(
+            model.data(model.index(7, 0), Qt.ItemDataRole.DisplayRole), "material b"
+        )
+        self.assertEqual(
+            model.data(model.index(8, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
+
+        self.assertTrue(
+            style.removeEntityByName(
+                QgsStyle.StyleEntity.LegendPatchShapeEntity, "shape a"
+            )
+        )
+        self.assertEqual(model.rowCount(), 8)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "c"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp a"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "format a"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "settings a"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "symbol3d a"
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole), "material b"
+        )
+        self.assertEqual(
+            model.data(model.index(7, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
+
     def test_renamed(self):
         style = QgsStyle()
         style.createMemoryDatabase()
@@ -1993,8 +2377,12 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertTrue(style.addSymbol3D("symbol3d a", symbol3d_a, True))
         symbol3d_B = Dummy3dSymbol()
         self.assertTrue(style.addSymbol3D("symbol3d c", symbol3d_B, True))
+        material_a = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material a", material_a, True))
+        material_B = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material c", material_B, True))
 
-        self.assertEqual(model.rowCount(), 12)
+        self.assertEqual(model.rowCount(), 14)
         self.assertEqual(
             model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "a"
         )
@@ -2031,9 +2419,15 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameSymbol("a", "b"))
-        self.assertEqual(model.rowCount(), 12)
+        self.assertEqual(model.rowCount(), 14)
         self.assertEqual(
             model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "b"
         )
@@ -2070,9 +2464,15 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameSymbol("b", "d"))
-        self.assertEqual(model.rowCount(), 12)
+        self.assertEqual(model.rowCount(), 14)
         self.assertEqual(
             model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "c"
         )
@@ -2109,9 +2509,15 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameSymbol("d", "e"))
-        self.assertEqual(model.rowCount(), 12)
+        self.assertEqual(model.rowCount(), 14)
         self.assertEqual(
             model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "c"
         )
@@ -2148,9 +2554,15 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameSymbol("c", "f"))
-        self.assertEqual(model.rowCount(), 12)
+        self.assertEqual(model.rowCount(), 14)
         self.assertEqual(
             model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "e"
         )
@@ -2187,9 +2599,15 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameColorRamp("ramp a", "ramp b"))
-        self.assertEqual(model.rowCount(), 12)
+        self.assertEqual(model.rowCount(), 14)
         self.assertEqual(
             model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "e"
         )
@@ -2225,6 +2643,12 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
         )
 
         self.assertTrue(style.renameColorRamp("ramp b", "ramp d"))
@@ -2264,6 +2688,12 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameColorRamp("ramp d", "ramp e"))
         self.assertEqual(
@@ -2301,6 +2731,12 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
         )
 
         self.assertTrue(style.renameColorRamp("ramp c", "ramp f"))
@@ -2340,9 +2776,15 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameTextFormat("format a", "format b"))
-        self.assertEqual(model.rowCount(), 12)
+        self.assertEqual(model.rowCount(), 14)
         self.assertEqual(
             model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "e"
         )
@@ -2378,6 +2820,12 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
         )
 
         self.assertTrue(style.renameTextFormat("format b", "format d"))
@@ -2417,6 +2865,12 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameTextFormat("format d", "format e"))
         self.assertEqual(
@@ -2454,6 +2908,12 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
         )
 
         self.assertTrue(style.renameTextFormat("format c", "format f"))
@@ -2493,9 +2953,15 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameLabelSettings("settings a", "settings b"))
-        self.assertEqual(model.rowCount(), 12)
+        self.assertEqual(model.rowCount(), 14)
         self.assertEqual(
             model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "e"
         )
@@ -2531,6 +2997,12 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
         )
 
         self.assertTrue(style.renameLabelSettings("settings b", "settings d"))
@@ -2570,6 +3042,12 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameLabelSettings("settings d", "settings e"))
         self.assertEqual(
@@ -2607,6 +3085,12 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
         )
 
         self.assertTrue(style.renameLabelSettings("settings c", "settings f"))
@@ -2646,9 +3130,15 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameLegendPatchShape("shape a", "shape b"))
-        self.assertEqual(model.rowCount(), 12)
+        self.assertEqual(model.rowCount(), 14)
         self.assertEqual(
             model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "e"
         )
@@ -2684,6 +3174,12 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
         )
 
         self.assertTrue(style.renameLegendPatchShape("shape b", "shape d"))
@@ -2723,6 +3219,12 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameLegendPatchShape("shape d", "shape e"))
         self.assertEqual(
@@ -2760,6 +3262,12 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
         )
 
         self.assertTrue(style.renameLegendPatchShape("shape c", "shape f"))
@@ -2799,9 +3307,15 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameSymbol3D("symbol3d a", "symbol3d b"))
-        self.assertEqual(model.rowCount(), 12)
+        self.assertEqual(model.rowCount(), 14)
         self.assertEqual(
             model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "e"
         )
@@ -2837,6 +3351,12 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d c"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
         )
 
         self.assertTrue(style.renameSymbol3D("symbol3d b", "symbol3d d"))
@@ -2876,6 +3396,12 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d d"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
 
         self.assertTrue(style.renameSymbol3D("symbol3d d", "symbol3d e"))
         self.assertEqual(
@@ -2913,6 +3439,12 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d e"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
         )
 
         self.assertTrue(style.renameSymbol3D("symbol3d c", "symbol3d f"))
@@ -2952,6 +3484,189 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d f"
         )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material a"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
+
+        self.assertTrue(style.renameMaterialSettings("material a", "material b"))
+        self.assertEqual(model.rowCount(), 14)
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "e"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "f"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp e"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "ramp f"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "format e"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "format f"
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole), "settings e"
+        )
+        self.assertEqual(
+            model.data(model.index(7, 0), Qt.ItemDataRole.DisplayRole), "settings f"
+        )
+        self.assertEqual(
+            model.data(model.index(8, 0), Qt.ItemDataRole.DisplayRole), "shape e"
+        )
+        self.assertEqual(
+            model.data(model.index(9, 0), Qt.ItemDataRole.DisplayRole), "shape f"
+        )
+        self.assertEqual(
+            model.data(model.index(10, 0), Qt.ItemDataRole.DisplayRole), "symbol3d e"
+        )
+        self.assertEqual(
+            model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d f"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material b"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
+
+        self.assertTrue(style.renameMaterialSettings("material b", "material d"))
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "e"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "f"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp e"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "ramp f"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "format e"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "format f"
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole), "settings e"
+        )
+        self.assertEqual(
+            model.data(model.index(7, 0), Qt.ItemDataRole.DisplayRole), "settings f"
+        )
+        self.assertEqual(
+            model.data(model.index(8, 0), Qt.ItemDataRole.DisplayRole), "shape e"
+        )
+        self.assertEqual(
+            model.data(model.index(9, 0), Qt.ItemDataRole.DisplayRole), "shape f"
+        )
+        self.assertEqual(
+            model.data(model.index(10, 0), Qt.ItemDataRole.DisplayRole), "symbol3d e"
+        )
+        self.assertEqual(
+            model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d f"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material d"
+        )
+
+        self.assertTrue(style.renameMaterialSettings("material d", "material e"))
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "e"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "f"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp e"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "ramp f"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "format e"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "format f"
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole), "settings e"
+        )
+        self.assertEqual(
+            model.data(model.index(7, 0), Qt.ItemDataRole.DisplayRole), "settings f"
+        )
+        self.assertEqual(
+            model.data(model.index(8, 0), Qt.ItemDataRole.DisplayRole), "shape e"
+        )
+        self.assertEqual(
+            model.data(model.index(9, 0), Qt.ItemDataRole.DisplayRole), "shape f"
+        )
+        self.assertEqual(
+            model.data(model.index(10, 0), Qt.ItemDataRole.DisplayRole), "symbol3d e"
+        )
+        self.assertEqual(
+            model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d f"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material c"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material e"
+        )
+
+        self.assertTrue(style.renameMaterialSettings("material c", "material f"))
+        self.assertEqual(
+            model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole), "e"
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), Qt.ItemDataRole.DisplayRole), "f"
+        )
+        self.assertEqual(
+            model.data(model.index(2, 0), Qt.ItemDataRole.DisplayRole), "ramp e"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 0), Qt.ItemDataRole.DisplayRole), "ramp f"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), Qt.ItemDataRole.DisplayRole), "format e"
+        )
+        self.assertEqual(
+            model.data(model.index(5, 0), Qt.ItemDataRole.DisplayRole), "format f"
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole), "settings e"
+        )
+        self.assertEqual(
+            model.data(model.index(7, 0), Qt.ItemDataRole.DisplayRole), "settings f"
+        )
+        self.assertEqual(
+            model.data(model.index(8, 0), Qt.ItemDataRole.DisplayRole), "shape e"
+        )
+        self.assertEqual(
+            model.data(model.index(9, 0), Qt.ItemDataRole.DisplayRole), "shape f"
+        )
+        self.assertEqual(
+            model.data(model.index(10, 0), Qt.ItemDataRole.DisplayRole), "symbol3d e"
+        )
+        self.assertEqual(
+            model.data(model.index(11, 0), Qt.ItemDataRole.DisplayRole), "symbol3d f"
+        )
+        self.assertEqual(
+            model.data(model.index(12, 0), Qt.ItemDataRole.DisplayRole), "material e"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 0), Qt.ItemDataRole.DisplayRole), "material f"
+        )
 
     def test_tags_changed(self):
         style = QgsStyle()
@@ -2982,6 +3697,10 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertTrue(style.addSymbol3D("symbol3d a", symbol3d_a, True))
         symbol3d_B = Dummy3dSymbol()
         self.assertTrue(style.addSymbol3D("symbol3d c", symbol3d_B, True))
+        material_a = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material a", material_a, True))
+        material_B = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material c", material_B, True))
 
         self.assertFalse(model.data(model.index(0, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(1, 1), Qt.ItemDataRole.DisplayRole))
@@ -2995,6 +3714,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.SymbolEntity, "a", ["t1", "t2"])
         self.assertEqual(
@@ -3011,6 +3732,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.SymbolEntity, "a", ["t3"])
         self.assertEqual(
@@ -3027,6 +3750,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.ColorrampEntity, "ramp a", ["t1", "t2"])
         self.assertEqual(
@@ -3045,6 +3770,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.ColorrampEntity, "ramp c", ["t3"])
         self.assertEqual(
@@ -3065,6 +3792,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.SymbolEntity, "c", ["t4"])
         self.assertEqual(
@@ -3087,6 +3816,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.detagSymbol(QgsStyle.StyleEntity.SymbolEntity, "c", ["t4"])
         self.assertEqual(
@@ -3107,6 +3838,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.detagSymbol(QgsStyle.StyleEntity.ColorrampEntity, "ramp a", ["t1"])
         self.assertEqual(
@@ -3127,6 +3860,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.TextFormatEntity, "format a", ["t1", "t2"])
         self.assertEqual(
@@ -3149,6 +3884,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.TextFormatEntity, "format c", ["t3"])
         self.assertEqual(
@@ -3173,6 +3910,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.TextFormatEntity, "c", ["t6"])
         self.assertEqual(
@@ -3197,6 +3936,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.detagSymbol(QgsStyle.StyleEntity.TextFormatEntity, "format c", ["t3"])
         self.assertEqual(
@@ -3219,6 +3960,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(
             QgsStyle.StyleEntity.LabelSettingsEntity, "settings a", ["t1", "t2"]
@@ -3245,6 +3988,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.LabelSettingsEntity, "settings c", ["t3"])
         self.assertEqual(
@@ -3271,6 +4016,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.LabelSettingsEntity, "c", ["t7"])
         self.assertEqual(
@@ -3297,6 +4044,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.detagSymbol(
             QgsStyle.StyleEntity.LabelSettingsEntity, "settings c", ["t3"]
@@ -3323,6 +4072,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(
             QgsStyle.StyleEntity.LabelSettingsEntity, "settings a", ["t1", "t2"]
@@ -3349,6 +4100,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.LabelSettingsEntity, "settings c", ["t3"])
         self.assertEqual(
@@ -3375,6 +4128,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.LabelSettingsEntity, "c", ["t7"])
         self.assertEqual(
@@ -3401,6 +4156,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.detagSymbol(
             QgsStyle.StyleEntity.LabelSettingsEntity, "settings c", ["t3"]
@@ -3427,6 +4184,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(
             QgsStyle.StyleEntity.LegendPatchShapeEntity, "shape a", ["t1", "t2"]
@@ -3455,6 +4214,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.LegendPatchShapeEntity, "shape c", ["t3"])
         self.assertEqual(
@@ -3483,6 +4244,8 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.LegendPatchShapeEntity, "c", ["t7"])
         self.assertEqual(
@@ -3511,6 +4274,8 @@ class TestQgsStyleModel(QgisTestCase):
         )
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.detagSymbol(
             QgsStyle.StyleEntity.LegendPatchShapeEntity, "shape c", ["t3"]
@@ -3539,6 +4304,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole))
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.Symbol3DEntity, "symbol3d a", ["t1", "t2"])
         self.assertEqual(
@@ -3567,6 +4334,8 @@ class TestQgsStyleModel(QgisTestCase):
             model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
         )
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.Symbol3DEntity, "symbol3d c", ["t3"])
         self.assertEqual(
@@ -3597,6 +4366,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole), "t3"
         )
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.tagSymbol(QgsStyle.StyleEntity.Symbol3DEntity, "c", ["t7"])
         self.assertEqual(
@@ -3627,6 +4398,8 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole), "t3"
         )
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
         style.detagSymbol(QgsStyle.StyleEntity.Symbol3DEntity, "symbol3d c", ["t3"])
         self.assertEqual(
@@ -3655,6 +4428,146 @@ class TestQgsStyleModel(QgisTestCase):
             model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
         )
         self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
+
+        style.tagSymbol(
+            QgsStyle.StyleEntity.MaterialSettingsEntity, "material a", ["t1", "t2"]
+        )
+        self.assertEqual(
+            model.data(model.index(0, 1), Qt.ItemDataRole.DisplayRole), "t1, t2, t3"
+        )
+        self.assertFalse(model.data(model.index(1, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(2, 1), Qt.ItemDataRole.DisplayRole), "t2"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 1), Qt.ItemDataRole.DisplayRole), "t3"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(5, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(6, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(7, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(8, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
+
+        style.tagSymbol(
+            QgsStyle.StyleEntity.MaterialSettingsEntity, "material c", ["t3"]
+        )
+        self.assertEqual(
+            model.data(model.index(0, 1), Qt.ItemDataRole.DisplayRole), "t1, t2, t3"
+        )
+        self.assertFalse(model.data(model.index(1, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(2, 1), Qt.ItemDataRole.DisplayRole), "t2"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 1), Qt.ItemDataRole.DisplayRole), "t3"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(5, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(6, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(7, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(8, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole), "t3"
+        )
+
+        style.tagSymbol(QgsStyle.StyleEntity.MaterialSettingsEntity, "c", ["t7"])
+        self.assertEqual(
+            model.data(model.index(0, 1), Qt.ItemDataRole.DisplayRole), "t1, t2, t3"
+        )
+        self.assertFalse(model.data(model.index(1, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(2, 1), Qt.ItemDataRole.DisplayRole), "t2"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 1), Qt.ItemDataRole.DisplayRole), "t3"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(5, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(6, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(7, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(8, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertEqual(
+            model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole), "t3"
+        )
+
+        style.detagSymbol(
+            QgsStyle.StyleEntity.MaterialSettingsEntity, "material c", ["t3"]
+        )
+        self.assertEqual(
+            model.data(model.index(0, 1), Qt.ItemDataRole.DisplayRole), "t1, t2, t3"
+        )
+        self.assertFalse(model.data(model.index(1, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(2, 1), Qt.ItemDataRole.DisplayRole), "t2"
+        )
+        self.assertEqual(
+            model.data(model.index(3, 1), Qt.ItemDataRole.DisplayRole), "t3"
+        )
+        self.assertEqual(
+            model.data(model.index(4, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(5, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(6, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(7, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(8, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(9, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(10, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(11, 1), Qt.ItemDataRole.DisplayRole))
+        self.assertEqual(
+            model.data(model.index(12, 1), Qt.ItemDataRole.DisplayRole), "t1, t2"
+        )
+        self.assertFalse(model.data(model.index(13, 1), Qt.ItemDataRole.DisplayRole))
 
     def test_filter_proxy(self):
         style = QgsStyle()
@@ -3736,52 +4649,69 @@ class TestQgsStyleModel(QgisTestCase):
         symbol3d_B.layer_types = [QgsWkbTypes.GeometryType.LineGeometry]
         self.assertTrue(style.addSymbol3D("sym3d c", symbol3d_B, True))
 
+        material_a = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material a", material_a, True))
+        style.tagSymbol(
+            QgsStyle.StyleEntity.MaterialSettingsEntity,
+            "material a",
+            ["tag 1", "tag 2"],
+        )
+        material_B = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material BB", material_B, True))
+        material_B = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material c", material_B, True))
+
         model = QgsStyleProxyModel(style)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
 
         # filter string
         model.setFilterString("xx")
         self.assertEqual(model.filterString(), "xx")
         self.assertEqual(model.rowCount(), 0)
         model.setFilterString("b")
-        self.assertEqual(model.rowCount(), 7)
+        self.assertEqual(model.rowCount(), 8)
         self.assertEqual(model.data(model.index(0, 0)), "b")
         self.assertEqual(model.data(model.index(1, 0)), "BB")
         self.assertEqual(model.data(model.index(2, 0)), "format BB")
+        self.assertEqual(model.data(model.index(3, 0)), "material BB")
+        self.assertEqual(model.data(model.index(4, 0)), "ramp BB")
+        self.assertEqual(model.data(model.index(5, 0)), "settings BB")
+        self.assertEqual(model.data(model.index(6, 0)), "shape BB")
+        self.assertEqual(model.data(model.index(7, 0)), "sym3d BB")
+        model.setFilterString("bb")
+        self.assertEqual(model.rowCount(), 7)
+        self.assertEqual(model.data(model.index(0, 0)), "BB")
+        self.assertEqual(model.data(model.index(1, 0)), "format BB")
+        self.assertEqual(model.data(model.index(2, 0)), "material BB")
         self.assertEqual(model.data(model.index(3, 0)), "ramp BB")
         self.assertEqual(model.data(model.index(4, 0)), "settings BB")
         self.assertEqual(model.data(model.index(5, 0)), "shape BB")
         self.assertEqual(model.data(model.index(6, 0)), "sym3d BB")
-        model.setFilterString("bb")
-        self.assertEqual(model.rowCount(), 6)
-        self.assertEqual(model.data(model.index(0, 0)), "BB")
-        self.assertEqual(model.data(model.index(1, 0)), "format BB")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp BB")
-        self.assertEqual(model.data(model.index(3, 0)), "settings BB")
-        self.assertEqual(model.data(model.index(4, 0)), "shape BB")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d BB")
         model.setFilterString("tag 1")
-        self.assertEqual(model.rowCount(), 6)
+        self.assertEqual(model.rowCount(), 7)
         self.assertEqual(model.data(model.index(0, 0)), "a")
         self.assertEqual(model.data(model.index(1, 0)), "format a")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp a")
-        self.assertEqual(model.data(model.index(3, 0)), "settings a")
-        self.assertEqual(model.data(model.index(4, 0)), "shape a")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d a")
+        self.assertEqual(model.data(model.index(2, 0)), "material a")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp a")
+        self.assertEqual(model.data(model.index(4, 0)), "settings a")
+        self.assertEqual(model.data(model.index(5, 0)), "shape a")
+        self.assertEqual(model.data(model.index(6, 0)), "sym3d a")
         model.setFilterString("TAG 1")
-        self.assertEqual(model.rowCount(), 6)
+        self.assertEqual(model.rowCount(), 7)
         self.assertEqual(model.data(model.index(0, 0)), "a")
         self.assertEqual(model.data(model.index(1, 0)), "format a")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp a")
-        self.assertEqual(model.data(model.index(3, 0)), "settings a")
-        self.assertEqual(model.data(model.index(4, 0)), "shape a")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d a")
+        self.assertEqual(model.data(model.index(2, 0)), "material a")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp a")
+        self.assertEqual(model.data(model.index(4, 0)), "settings a")
+        self.assertEqual(model.data(model.index(5, 0)), "shape a")
+        self.assertEqual(model.data(model.index(6, 0)), "sym3d a")
         model.setFilterString("ram b")
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "ramp BB")
         model.setFilterString("mat b")
-        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.rowCount(), 2)
         self.assertEqual(model.data(model.index(0, 0)), "format BB")
+        self.assertEqual(model.data(model.index(1, 0)), "material BB")
         model.setFilterString("ta ram")  # match ta -> "tag 1", ram -> "ramp a"
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "ramp a")
@@ -3795,15 +4725,15 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "sym3d a")
         model.setFilterString("")
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
 
         # entity type
         model.setEntityFilter(QgsStyle.StyleEntity.SymbolEntity)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
         model.setEntityFilter(QgsStyle.StyleEntity.TextFormatEntity)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
         model.setEntityFilter(QgsStyle.StyleEntity.ColorrampEntity)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
         model.setEntityFilterEnabled(True)
         self.assertEqual(model.rowCount(), 3)
         self.assertEqual(model.data(model.index(0, 0)), "ramp a")
@@ -3866,33 +4796,46 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(model.data(model.index(0, 0)), "sym3d BB")
         model.setFilterString("")
 
+        model.setEntityFilter(QgsStyle.StyleEntity.MaterialSettingsEntity)
+        self.assertEqual(model.rowCount(), 3)
+        self.assertEqual(model.data(model.index(0, 0)), "material a")
+        self.assertEqual(model.data(model.index(1, 0)), "material BB")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        model.setFilterString("BB")
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "material BB")
+        model.setFilterString("")
+
         model.setEntityFilter(QgsStyle.StyleEntity.SymbolEntity)
         model.setEntityFilterEnabled(False)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
 
         # symbol type filter
         model.setSymbolType(QgsSymbol.SymbolType.Line)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
         model.setSymbolType(QgsSymbol.SymbolType.Marker)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
         model.setSymbolTypeFilterEnabled(True)
-        self.assertEqual(model.rowCount(), 16)
+        self.assertEqual(model.rowCount(), 19)
         self.assertEqual(model.data(model.index(0, 0)), "a")
         self.assertEqual(model.data(model.index(1, 0)), "another")
         self.assertEqual(model.data(model.index(2, 0)), "BB")
         self.assertEqual(model.data(model.index(3, 0)), "format a")
         self.assertEqual(model.data(model.index(4, 0)), "format BB")
         self.assertEqual(model.data(model.index(5, 0)), "format c")
-        self.assertEqual(model.data(model.index(6, 0)), "ramp a")
-        self.assertEqual(model.data(model.index(7, 0)), "ramp BB")
-        self.assertEqual(model.data(model.index(8, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(9, 0)), "settings a")
-        self.assertEqual(model.data(model.index(10, 0)), "settings BB")
-        self.assertEqual(model.data(model.index(11, 0)), "settings c")
-        self.assertEqual(model.data(model.index(12, 0)), "shape a")
-        self.assertEqual(model.data(model.index(13, 0)), "sym3d a")
-        self.assertEqual(model.data(model.index(14, 0)), "sym3d BB")
-        self.assertEqual(model.data(model.index(15, 0)), "sym3d c")
+        self.assertEqual(model.data(model.index(6, 0)), "material a")
+        self.assertEqual(model.data(model.index(7, 0)), "material BB")
+        self.assertEqual(model.data(model.index(8, 0)), "material c")
+        self.assertEqual(model.data(model.index(9, 0)), "ramp a")
+        self.assertEqual(model.data(model.index(10, 0)), "ramp BB")
+        self.assertEqual(model.data(model.index(11, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(12, 0)), "settings a")
+        self.assertEqual(model.data(model.index(13, 0)), "settings BB")
+        self.assertEqual(model.data(model.index(14, 0)), "settings c")
+        self.assertEqual(model.data(model.index(15, 0)), "shape a")
+        self.assertEqual(model.data(model.index(16, 0)), "sym3d a")
+        self.assertEqual(model.data(model.index(17, 0)), "sym3d BB")
+        self.assertEqual(model.data(model.index(18, 0)), "sym3d c")
 
         model.setEntityFilterEnabled(True)
         self.assertEqual(model.rowCount(), 3)
@@ -3929,7 +4872,7 @@ class TestQgsStyleModel(QgisTestCase):
         model.setFilterString("")
         model.setSymbolTypeFilterEnabled(False)
         model.setEntityFilterEnabled(False)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
 
         # tag id filter
         self.assertEqual(model.tagId(), -1)
@@ -3937,13 +4880,14 @@ class TestQgsStyleModel(QgisTestCase):
         tag_3_id = style.tagId("tag 3")
         model.setTagId(tag_1_id)
         self.assertEqual(model.tagId(), tag_1_id)
-        self.assertEqual(model.rowCount(), 6)
+        self.assertEqual(model.rowCount(), 7)
         self.assertEqual(model.data(model.index(0, 0)), "a")
         self.assertEqual(model.data(model.index(1, 0)), "format a")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp a")
-        self.assertEqual(model.data(model.index(3, 0)), "settings a")
-        self.assertEqual(model.data(model.index(4, 0)), "shape a")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d a")
+        self.assertEqual(model.data(model.index(2, 0)), "material a")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp a")
+        self.assertEqual(model.data(model.index(4, 0)), "settings a")
+        self.assertEqual(model.data(model.index(5, 0)), "shape a")
+        self.assertEqual(model.data(model.index(6, 0)), "sym3d a")
         model.setEntityFilterEnabled(True)
         model.setEntityFilter(QgsStyle.StyleEntity.ColorrampEntity)
         self.assertEqual(model.rowCount(), 1)
@@ -3960,6 +4904,9 @@ class TestQgsStyleModel(QgisTestCase):
         model.setEntityFilter(QgsStyle.StyleEntity.Symbol3DEntity)
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "sym3d a")
+        model.setEntityFilter(QgsStyle.StyleEntity.MaterialSettingsEntity)
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "material a")
         model.setEntityFilterEnabled(False)
         model.setFilterString("ra")
         self.assertEqual(model.rowCount(), 1)
@@ -3976,10 +4923,13 @@ class TestQgsStyleModel(QgisTestCase):
         model.setFilterString("3d")
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "sym3d a")
+        model.setFilterString("mater")
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "material a")
         model.setEntityFilterEnabled(False)
         model.setFilterString("")
         model.setTagId(-1)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
         model.setTagId(tag_3_id)
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "C")
@@ -4018,20 +4968,31 @@ class TestQgsStyleModel(QgisTestCase):
         style.detagSymbol(QgsStyle.StyleEntity.Symbol3DEntity, "sym3d c")
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "C")
+        style.tagSymbol(
+            QgsStyle.StyleEntity.MaterialSettingsEntity, "material c", ["tag 3"]
+        )
+        self.assertEqual(model.rowCount(), 2)
+        self.assertEqual(model.data(model.index(0, 0)), "C")
+        self.assertEqual(model.data(model.index(1, 0)), "material c")
+        style.detagSymbol(QgsStyle.StyleEntity.MaterialSettingsEntity, "material c")
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "C")
+
         model.setTagId(-1)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
 
         # tag string filter
         self.assertFalse(model.tagString())
         model.setTagString("tag 1")
         self.assertEqual(model.tagString(), "tag 1")
-        self.assertEqual(model.rowCount(), 6)
+        self.assertEqual(model.rowCount(), 7)
         self.assertEqual(model.data(model.index(0, 0)), "a")
         self.assertEqual(model.data(model.index(1, 0)), "format a")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp a")
-        self.assertEqual(model.data(model.index(3, 0)), "settings a")
-        self.assertEqual(model.data(model.index(4, 0)), "shape a")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d a")
+        self.assertEqual(model.data(model.index(2, 0)), "material a")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp a")
+        self.assertEqual(model.data(model.index(4, 0)), "settings a")
+        self.assertEqual(model.data(model.index(5, 0)), "shape a")
+        self.assertEqual(model.data(model.index(6, 0)), "sym3d a")
         model.setEntityFilterEnabled(True)
         model.setEntityFilter(QgsStyle.StyleEntity.ColorrampEntity)
         self.assertEqual(model.rowCount(), 1)
@@ -4048,6 +5009,9 @@ class TestQgsStyleModel(QgisTestCase):
         model.setEntityFilter(QgsStyle.StyleEntity.Symbol3DEntity)
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "sym3d a")
+        model.setEntityFilter(QgsStyle.StyleEntity.MaterialSettingsEntity)
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "material a")
         model.setEntityFilterEnabled(False)
         model.setFilterString("ra")
         self.assertEqual(model.rowCount(), 1)
@@ -4064,10 +5028,13 @@ class TestQgsStyleModel(QgisTestCase):
         model.setFilterString("3d")
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "sym3d a")
+        model.setFilterString("matEr")
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "material a")
         model.setEntityFilterEnabled(False)
         model.setFilterString("")
         model.setTagString("")
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
         model.setTagString("tag 3")
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "C")
@@ -4104,10 +5071,19 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(model.data(model.index(0, 0)), "C")
         self.assertEqual(model.data(model.index(1, 0)), "sym3d c")
         style.detagSymbol(QgsStyle.StyleEntity.Symbol3DEntity, "sym3d c")
+
+        style.tagSymbol(
+            QgsStyle.StyleEntity.MaterialSettingsEntity, "material c", ["tag 3"]
+        )
+        self.assertEqual(model.rowCount(), 2)
+        self.assertEqual(model.data(model.index(0, 0)), "C")
+        self.assertEqual(model.data(model.index(1, 0)), "material c")
+        style.detagSymbol(QgsStyle.StyleEntity.MaterialSettingsEntity, "material c")
+
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "C")
         model.setTagString("")
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
 
         # favorite filter
         style.addFavorite(QgsStyle.StyleEntity.ColorrampEntity, "ramp c")
@@ -4116,16 +5092,18 @@ class TestQgsStyleModel(QgisTestCase):
         style.addFavorite(QgsStyle.StyleEntity.LabelSettingsEntity, "settings c")
         style.addFavorite(QgsStyle.StyleEntity.LegendPatchShapeEntity, "shape c")
         style.addFavorite(QgsStyle.StyleEntity.Symbol3DEntity, "sym3d c")
+        style.addFavorite(QgsStyle.StyleEntity.MaterialSettingsEntity, "material c")
         self.assertEqual(model.favoritesOnly(), False)
         model.setFavoritesOnly(True)
         self.assertEqual(model.favoritesOnly(), True)
-        self.assertEqual(model.rowCount(), 6)
+        self.assertEqual(model.rowCount(), 7)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings c")
-        self.assertEqual(model.data(model.index(4, 0)), "shape c")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d c")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(4, 0)), "settings c")
+        self.assertEqual(model.data(model.index(5, 0)), "shape c")
+        self.assertEqual(model.data(model.index(6, 0)), "sym3d c")
         model.setEntityFilterEnabled(True)
         model.setEntityFilter(QgsStyle.StyleEntity.ColorrampEntity)
         self.assertEqual(model.rowCount(), 1)
@@ -4142,118 +5120,152 @@ class TestQgsStyleModel(QgisTestCase):
         model.setEntityFilter(QgsStyle.StyleEntity.Symbol3DEntity)
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "sym3d c")
+        model.setEntityFilter(QgsStyle.StyleEntity.MaterialSettingsEntity)
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "material c")
         model.setEntityFilterEnabled(False)
-        model.setFilterString("er")
+        model.setFilterString("her")
         self.assertEqual(model.rowCount(), 1)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         model.setEntityFilterEnabled(False)
         model.setFilterString("")
-        self.assertEqual(model.rowCount(), 6)
+        self.assertEqual(model.rowCount(), 7)
         style.addFavorite(QgsStyle.StyleEntity.ColorrampEntity, "ramp a")
+        self.assertEqual(model.rowCount(), 8)
+        self.assertEqual(model.data(model.index(0, 0)), "another")
+        self.assertEqual(model.data(model.index(1, 0)), "format c")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp a")
+        self.assertEqual(model.data(model.index(4, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(5, 0)), "settings c")
+        self.assertEqual(model.data(model.index(6, 0)), "shape c")
+        self.assertEqual(model.data(model.index(7, 0)), "sym3d c")
+        style.removeFavorite(QgsStyle.StyleEntity.ColorrampEntity, "ramp a")
         self.assertEqual(model.rowCount(), 7)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp a")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
         self.assertEqual(model.data(model.index(3, 0)), "ramp c")
         self.assertEqual(model.data(model.index(4, 0)), "settings c")
         self.assertEqual(model.data(model.index(5, 0)), "shape c")
         self.assertEqual(model.data(model.index(6, 0)), "sym3d c")
-        style.removeFavorite(QgsStyle.StyleEntity.ColorrampEntity, "ramp a")
-        self.assertEqual(model.rowCount(), 6)
-        self.assertEqual(model.data(model.index(0, 0)), "another")
-        self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings c")
-        self.assertEqual(model.data(model.index(4, 0)), "shape c")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d c")
         style.addFavorite(QgsStyle.StyleEntity.TextFormatEntity, "format a")
-        self.assertEqual(model.rowCount(), 7)
+        self.assertEqual(model.rowCount(), 8)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "format a")
         self.assertEqual(model.data(model.index(2, 0)), "format c")
+        self.assertEqual(model.data(model.index(3, 0)), "material c")
+        self.assertEqual(model.data(model.index(4, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(5, 0)), "settings c")
+        self.assertEqual(model.data(model.index(6, 0)), "shape c")
+        self.assertEqual(model.data(model.index(7, 0)), "sym3d c")
+        style.removeFavorite(QgsStyle.StyleEntity.TextFormatEntity, "format a")
+        self.assertEqual(model.rowCount(), 7)
+        self.assertEqual(model.data(model.index(0, 0)), "another")
+        self.assertEqual(model.data(model.index(1, 0)), "format c")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
         self.assertEqual(model.data(model.index(3, 0)), "ramp c")
         self.assertEqual(model.data(model.index(4, 0)), "settings c")
         self.assertEqual(model.data(model.index(5, 0)), "shape c")
         self.assertEqual(model.data(model.index(6, 0)), "sym3d c")
-        style.removeFavorite(QgsStyle.StyleEntity.TextFormatEntity, "format a")
-        self.assertEqual(model.rowCount(), 6)
+        style.addFavorite(QgsStyle.StyleEntity.LabelSettingsEntity, "settings a")
+        self.assertEqual(model.rowCount(), 8)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings c")
-        self.assertEqual(model.data(model.index(4, 0)), "shape c")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d c")
-        style.addFavorite(QgsStyle.StyleEntity.LabelSettingsEntity, "settings a")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(4, 0)), "settings a")
+        self.assertEqual(model.data(model.index(5, 0)), "settings c")
+        self.assertEqual(model.data(model.index(6, 0)), "shape c")
+        self.assertEqual(model.data(model.index(7, 0)), "sym3d c")
+        style.removeFavorite(QgsStyle.StyleEntity.LabelSettingsEntity, "settings a")
         self.assertEqual(model.rowCount(), 7)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings a")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp c")
         self.assertEqual(model.data(model.index(4, 0)), "settings c")
         self.assertEqual(model.data(model.index(5, 0)), "shape c")
         self.assertEqual(model.data(model.index(6, 0)), "sym3d c")
-        style.removeFavorite(QgsStyle.StyleEntity.LabelSettingsEntity, "settings a")
-        self.assertEqual(model.rowCount(), 6)
+        style.addFavorite(QgsStyle.StyleEntity.LegendPatchShapeEntity, "shape a")
+        self.assertEqual(model.rowCount(), 8)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings c")
-        self.assertEqual(model.data(model.index(4, 0)), "shape c")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d c")
-        style.addFavorite(QgsStyle.StyleEntity.LegendPatchShapeEntity, "shape a")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(4, 0)), "settings c")
+        self.assertEqual(model.data(model.index(5, 0)), "shape a")
+        self.assertEqual(model.data(model.index(6, 0)), "shape c")
+        self.assertEqual(model.data(model.index(7, 0)), "sym3d c")
+        style.removeFavorite(QgsStyle.StyleEntity.LegendPatchShapeEntity, "shape a")
         self.assertEqual(model.rowCount(), 7)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings c")
-        self.assertEqual(model.data(model.index(4, 0)), "shape a")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(4, 0)), "settings c")
         self.assertEqual(model.data(model.index(5, 0)), "shape c")
         self.assertEqual(model.data(model.index(6, 0)), "sym3d c")
-        style.removeFavorite(QgsStyle.StyleEntity.LegendPatchShapeEntity, "shape a")
-        self.assertEqual(model.rowCount(), 6)
+        style.addFavorite(QgsStyle.StyleEntity.Symbol3DEntity, "sym3d a")
+        self.assertEqual(model.rowCount(), 8)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings c")
-        self.assertEqual(model.data(model.index(4, 0)), "shape c")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d c")
-        style.addFavorite(QgsStyle.StyleEntity.Symbol3DEntity, "sym3d a")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(4, 0)), "settings c")
+        self.assertEqual(model.data(model.index(5, 0)), "shape c")
+        self.assertEqual(model.data(model.index(6, 0)), "sym3d a")
+        self.assertEqual(model.data(model.index(7, 0)), "sym3d c")
+        style.removeFavorite(QgsStyle.StyleEntity.Symbol3DEntity, "sym3d a")
         self.assertEqual(model.rowCount(), 7)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings c")
-        self.assertEqual(model.data(model.index(4, 0)), "shape c")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d a")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(4, 0)), "settings c")
+        self.assertEqual(model.data(model.index(5, 0)), "shape c")
         self.assertEqual(model.data(model.index(6, 0)), "sym3d c")
-        style.removeFavorite(QgsStyle.StyleEntity.Symbol3DEntity, "sym3d a")
-        self.assertEqual(model.rowCount(), 6)
+        style.addFavorite(QgsStyle.StyleEntity.MaterialSettingsEntity, "material a")
+        self.assertEqual(model.rowCount(), 8)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings c")
-        self.assertEqual(model.data(model.index(4, 0)), "shape c")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d c")
+        self.assertEqual(model.data(model.index(2, 0)), "material a")
+        self.assertEqual(model.data(model.index(3, 0)), "material c")
+        self.assertEqual(model.data(model.index(4, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(5, 0)), "settings c")
+        self.assertEqual(model.data(model.index(6, 0)), "shape c")
+        self.assertEqual(model.data(model.index(7, 0)), "sym3d c")
+        style.removeFavorite(QgsStyle.StyleEntity.MaterialSettingsEntity, "material a")
+        self.assertEqual(model.rowCount(), 7)
+        self.assertEqual(model.data(model.index(0, 0)), "another")
+        self.assertEqual(model.data(model.index(1, 0)), "format c")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        self.assertEqual(model.data(model.index(3, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(4, 0)), "settings c")
+        self.assertEqual(model.data(model.index(5, 0)), "shape c")
+        self.assertEqual(model.data(model.index(6, 0)), "sym3d c")
 
         style.addFavorite(QgsStyle.StyleEntity.SymbolEntity, "BB")
-        self.assertEqual(model.rowCount(), 7)
+        self.assertEqual(model.rowCount(), 8)
         self.assertEqual(model.data(model.index(0, 0)), "another")
         self.assertEqual(model.data(model.index(1, 0)), "BB")
         self.assertEqual(model.data(model.index(2, 0)), "format c")
+        self.assertEqual(model.data(model.index(3, 0)), "material c")
+        self.assertEqual(model.data(model.index(4, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(5, 0)), "settings c")
+        self.assertEqual(model.data(model.index(6, 0)), "shape c")
+        self.assertEqual(model.data(model.index(7, 0)), "sym3d c")
+        style.removeFavorite(QgsStyle.StyleEntity.SymbolEntity, "another")
+        self.assertEqual(model.rowCount(), 7)
+        self.assertEqual(model.data(model.index(0, 0)), "BB")
+        self.assertEqual(model.data(model.index(1, 0)), "format c")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
         self.assertEqual(model.data(model.index(3, 0)), "ramp c")
         self.assertEqual(model.data(model.index(4, 0)), "settings c")
         self.assertEqual(model.data(model.index(5, 0)), "shape c")
         self.assertEqual(model.data(model.index(6, 0)), "sym3d c")
-        style.removeFavorite(QgsStyle.StyleEntity.SymbolEntity, "another")
-        self.assertEqual(model.rowCount(), 6)
-        self.assertEqual(model.data(model.index(0, 0)), "BB")
-        self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings c")
-        self.assertEqual(model.data(model.index(4, 0)), "shape c")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d c")
         model.setFavoritesOnly(False)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
 
         # smart group filter
         style.addSmartgroup("smart", "AND", ["tag 3"], [], ["c"], [])
@@ -4264,54 +5276,65 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(model.data(model.index(0, 0)), "C")
         style.addSmartgroup("smart", "OR", ["tag 3"], [], ["c"], [])
         model.setSmartGroupId(2)
-        self.assertEqual(model.rowCount(), 6)
+        self.assertEqual(model.rowCount(), 7)
         self.assertEqual(model.data(model.index(0, 0)), "C")
         self.assertEqual(model.data(model.index(1, 0)), "format c")
-        self.assertEqual(model.data(model.index(2, 0)), "ramp c")
-        self.assertEqual(model.data(model.index(3, 0)), "settings c")
-        self.assertEqual(model.data(model.index(4, 0)), "shape c")
-        self.assertEqual(model.data(model.index(5, 0)), "sym3d c")
-        style.tagSymbol(QgsStyle.StyleEntity.SymbolEntity, "a", ["tag 3"])
-        self.assertEqual(model.rowCount(), 7)
-        self.assertEqual(model.data(model.index(0, 0)), "a")
-        self.assertEqual(model.data(model.index(1, 0)), "C")
-        self.assertEqual(model.data(model.index(2, 0)), "format c")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
         self.assertEqual(model.data(model.index(3, 0)), "ramp c")
         self.assertEqual(model.data(model.index(4, 0)), "settings c")
         self.assertEqual(model.data(model.index(5, 0)), "shape c")
         self.assertEqual(model.data(model.index(6, 0)), "sym3d c")
-        style.renameColorRamp("ramp c", "x")
-        self.assertEqual(model.rowCount(), 6)
+        style.tagSymbol(QgsStyle.StyleEntity.SymbolEntity, "a", ["tag 3"])
+        self.assertEqual(model.rowCount(), 8)
         self.assertEqual(model.data(model.index(0, 0)), "a")
         self.assertEqual(model.data(model.index(1, 0)), "C")
         self.assertEqual(model.data(model.index(2, 0)), "format c")
+        self.assertEqual(model.data(model.index(3, 0)), "material c")
+        self.assertEqual(model.data(model.index(4, 0)), "ramp c")
+        self.assertEqual(model.data(model.index(5, 0)), "settings c")
+        self.assertEqual(model.data(model.index(6, 0)), "shape c")
+        self.assertEqual(model.data(model.index(7, 0)), "sym3d c")
+        style.renameColorRamp("ramp c", "x")
+        self.assertEqual(model.rowCount(), 7)
+        self.assertEqual(model.data(model.index(0, 0)), "a")
+        self.assertEqual(model.data(model.index(1, 0)), "C")
+        self.assertEqual(model.data(model.index(2, 0)), "format c")
+        self.assertEqual(model.data(model.index(3, 0)), "material c")
+        self.assertEqual(model.data(model.index(4, 0)), "settings c")
+        self.assertEqual(model.data(model.index(5, 0)), "shape c")
+        self.assertEqual(model.data(model.index(6, 0)), "sym3d c")
+        style.renameTextFormat("format c", "x")
+        self.assertEqual(model.rowCount(), 6)
+        self.assertEqual(model.data(model.index(0, 0)), "a")
+        self.assertEqual(model.data(model.index(1, 0)), "C")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
         self.assertEqual(model.data(model.index(3, 0)), "settings c")
         self.assertEqual(model.data(model.index(4, 0)), "shape c")
         self.assertEqual(model.data(model.index(5, 0)), "sym3d c")
-        style.renameTextFormat("format c", "x")
+        style.renameLabelSettings("settings c", "x")
         self.assertEqual(model.rowCount(), 5)
         self.assertEqual(model.data(model.index(0, 0)), "a")
         self.assertEqual(model.data(model.index(1, 0)), "C")
-        self.assertEqual(model.data(model.index(2, 0)), "settings c")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
         self.assertEqual(model.data(model.index(3, 0)), "shape c")
         self.assertEqual(model.data(model.index(4, 0)), "sym3d c")
-        style.renameLabelSettings("settings c", "x")
+        style.renameLegendPatchShape("shape c", "x")
         self.assertEqual(model.rowCount(), 4)
         self.assertEqual(model.data(model.index(0, 0)), "a")
         self.assertEqual(model.data(model.index(1, 0)), "C")
-        self.assertEqual(model.data(model.index(2, 0)), "shape c")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
         self.assertEqual(model.data(model.index(3, 0)), "sym3d c")
-        style.renameLegendPatchShape("shape c", "x")
+        style.renameSymbol3D("sym3d c", "x")
         self.assertEqual(model.rowCount(), 3)
         self.assertEqual(model.data(model.index(0, 0)), "a")
         self.assertEqual(model.data(model.index(1, 0)), "C")
-        self.assertEqual(model.data(model.index(2, 0)), "sym3d c")
-        style.renameSymbol3D("sym3d c", "x")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        style.renameMaterialSettings("material c", "x")
         self.assertEqual(model.rowCount(), 2)
         self.assertEqual(model.data(model.index(0, 0)), "a")
         self.assertEqual(model.data(model.index(1, 0)), "C")
         model.setSmartGroupId(-1)
-        self.assertEqual(model.rowCount(), 20)
+        self.assertEqual(model.rowCount(), 23)
 
         model.setEntityFilter(QgsStyle.StyleEntity.LabelSettingsEntity)
         model.setEntityFilterEnabled(True)
@@ -4421,9 +5444,11 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertTrue(style.addLegendPatchShape("shape a", shape_a, True))
         symbol3d_a = Dummy3dSymbol()
         self.assertTrue(style.addSymbol3D("symbol3d a", symbol3d_a, True))
+        material_a = QgsGoochMaterialSettings()
+        self.assertTrue(style.addMaterialSettings("material a", material_a, True))
 
         model = QgsStyleModel(style)
-        self.assertEqual(model.rowCount(), 6)
+        self.assertEqual(model.rowCount(), 7)
 
         self.assertEqual(style.symbolNames(), ["a"])
         self.assertFalse(model.setData(QModelIndex(), "b", Qt.ItemDataRole.EditRole))
@@ -4489,6 +5514,17 @@ class TestQgsStyleModel(QgisTestCase):
             "symbol3d new name",
         )
         self.assertEqual(style.symbol3DNames(), ["symbol3d new name"])
+
+        self.assertTrue(
+            model.setData(
+                model.index(6, 0), "material new name", Qt.ItemDataRole.EditRole
+            )
+        )
+        self.assertEqual(
+            model.data(model.index(6, 0), Qt.ItemDataRole.DisplayRole),
+            "material new name",
+        )
+        self.assertEqual(style.materialSettingsNames(), ["material new name"])
 
     def test_reset_symbollayer_ids(self):
         """

--- a/tests/src/python/test_qgsstylemodel.py
+++ b/tests/src/python/test_qgsstylemodel.py
@@ -13,6 +13,7 @@ __copyright__ = "Copyright 2018, The QGIS Project"
 import unittest
 
 from qgis.core import (
+    Qgis,
     QgsAbstract3DSymbol,
     QgsFillSymbol,
     QgsGeometry,
@@ -23,6 +24,8 @@ from qgis.core import (
     QgsLineSymbol,
     QgsMarkerSymbol,
     QgsPalLayerSettings,
+    QgsPhongMaterialSettings,
+    QgsSimpleLineMaterialSettings,
     QgsStyle,
     QgsStyleModel,
     QgsStyleProxyModel,
@@ -748,7 +751,7 @@ class TestQgsStyleModel(QgisTestCase):
         style.tagSymbol(
             QgsStyle.StyleEntity.MaterialSettingsEntity, "a", ["tag 1", "tag 2"]
         )
-        material_B = QgsGoochMaterialSettings()
+        material_B = QgsPhongMaterialSettings()
         self.assertTrue(style.addMaterialSettings("B ", material_B, True))
         material_b = QgsGoochMaterialSettings()
         self.assertTrue(style.addMaterialSettings("b", material_b, True))
@@ -806,6 +809,19 @@ class TestQgsStyleModel(QgisTestCase):
         self.assertEqual(
             model.data(model.index(4, 0), QgsStyleModel.Role.TypeRole),
             QgsStyle.StyleEntity.MaterialSettingsEntity,
+        )
+
+        self.assertEqual(
+            model.data(model.index(0, 0), QgsStyleModel.Role.MaterialType),
+            "gooch",
+        )
+        self.assertEqual(
+            model.data(model.index(1, 0), QgsStyleModel.Role.MaterialType),
+            "phong",
+        )
+        self.assertEqual(
+            model.data(model.index(4, 0), QgsStyleModel.Role.MaterialType),
+            "gooch",
         )
 
         self.assertEqual(
@@ -4656,7 +4672,7 @@ class TestQgsStyleModel(QgisTestCase):
             "material a",
             ["tag 1", "tag 2"],
         )
-        material_B = QgsGoochMaterialSettings()
+        material_B = QgsSimpleLineMaterialSettings()
         self.assertTrue(style.addMaterialSettings("material BB", material_B, True))
         material_B = QgsGoochMaterialSettings()
         self.assertTrue(style.addMaterialSettings("material c", material_B, True))
@@ -4871,6 +4887,39 @@ class TestQgsStyleModel(QgisTestCase):
 
         model.setFilterString("")
         model.setSymbolTypeFilterEnabled(False)
+        model.setEntityFilterEnabled(False)
+        self.assertEqual(model.rowCount(), 23)
+
+        # rendering technique filter
+        model.setEntityFilter(QgsStyle.StyleEntity.MaterialSettingsEntity)
+        model.setEntityFilterEnabled(True)
+        self.assertEqual(model.rowCount(), 3)
+        model.setRenderingTechnique(Qgis.MaterialRenderingTechnique.Lines)
+        self.assertEqual(model.rowCount(), 3)
+        self.assertEqual(model.data(model.index(0, 0)), "material a")
+        self.assertEqual(model.data(model.index(1, 0)), "material BB")
+        self.assertEqual(model.data(model.index(2, 0)), "material c")
+        model.setRenderingTechniqueFilterEnabled(True)
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "material BB")
+        model.setRenderingTechnique(Qgis.MaterialRenderingTechnique.Triangles)
+        self.assertEqual(model.rowCount(), 2)
+        self.assertEqual(model.data(model.index(0, 0)), "material a")
+        self.assertEqual(model.data(model.index(1, 0)), "material c")
+
+        model.setFilterString("c")
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "material c")
+        model.setRenderingTechniqueFilterEnabled(False)
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "material c")
+        model.setRenderingTechniqueFilterEnabled(True)
+        model.setFilterString("")
+        model.setRenderingTechnique(Qgis.MaterialRenderingTechnique.Lines)
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), "material BB")
+        model.setFilterString("")
+        model.setRenderingTechniqueFilterEnabled(False)
         model.setEntityFilterEnabled(False)
         self.assertEqual(model.rowCount(), 23)
 


### PR DESCRIPTION
## Description

This PR adds support for managing 3d material settings to the style database (and style manager dialog). Users can create presets of 3d materials, and manage them alongside other style objects (eg allowing tagging, favourites, etc).

In follow up PRs I will:

1. ~~Allow selection of and reuse of these materials when configuring 3d symbols (so eg you can easily apply a "brick" texture~~ included here
2. Add a nice set of out-of-the-box materials for use in the default style library
3. Generate nice thumbnails of the materials when they are saved

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

