### PR TITLE
Mark more QgsVectorLayer and QgsMapLayer functions as invokable from QML

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -668,7 +668,7 @@ Returns the number of features that are selected in this layer.
 .. seealso:: :py:func:`selectedFeatureIds`
 %End
 
-    void selectByRect( QgsRectangle &rect, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
+    void selectByRect( const QgsRectangle &rect, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
 %Docstring
 Selects features found within the search rectangle (in layer's
 coordinates)
@@ -746,7 +746,7 @@ Selects not selected features and deselects selected ones
 Select all the features
 %End
 
-    void invertSelectionInRectangle( QgsRectangle &rect );
+    void invertSelectionInRectangle( const QgsRectangle &rect );
 %Docstring
 Inverts selection of features found within the search rectangle (in
 layer's coordinates)

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -561,7 +561,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual QgsMapLayerRenderer *createMapRenderer( QgsRenderContext &rendererContext ) = 0 SIP_FACTORY;
 
     //! Returns the extent of the layer.
-    virtual QgsRectangle extent() const;
+    Q_INVOKABLE virtual QgsRectangle extent() const;
 
     /**
      * Returns the 3D extent of the layer.
@@ -577,7 +577,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \param forceRecalculate True to return the current WGS84 extent whatever the read flags
      * \since QGIS 3.20
      */
-    QgsRectangle wgs84Extent( bool forceRecalculate = false ) const;
+    Q_INVOKABLE QgsRectangle wgs84Extent( bool forceRecalculate = false ) const;
 
     /**
      * Returns the status of the layer. An invalid layer is one which has a bad datasource

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -516,16 +516,19 @@ void QgsVectorLayer::deselect( const QgsFeatureIds &featureIds )
   emit selectionChanged( QgsFeatureIds(), featureIds, false );
 }
 
-void QgsVectorLayer::selectByRect( QgsRectangle &rect, Qgis::SelectBehavior behavior )
+void QgsVectorLayer::selectByRect( const QgsRectangle &rect, Qgis::SelectBehavior behavior )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   // normalize the rectangle
-  rect.normalize();
+  QgsRectangle normalizedRect = rect;
+  normalizedRect.normalize();
 
   QgsFeatureIds newSelection;
 
-  QgsFeatureIterator features = getFeatures( QgsFeatureRequest().setFilterRect( rect ).setFlags( Qgis::FeatureRequestFlag::ExactIntersect | Qgis::FeatureRequestFlag::NoGeometry ).setNoAttributes() );
+  QgsFeatureIterator features = getFeatures(
+    QgsFeatureRequest().setFilterRect( normalizedRect ).setFlags( Qgis::FeatureRequestFlag::ExactIntersect | Qgis::FeatureRequestFlag::NoGeometry ).setNoAttributes()
+  );
 
   QgsFeature feat;
   while ( features.nextFeature( feat ) )
@@ -681,14 +684,15 @@ void QgsVectorLayer::selectAll()
   selectByIds( allFeatureIds() );
 }
 
-void QgsVectorLayer::invertSelectionInRectangle( QgsRectangle &rect )
+void QgsVectorLayer::invertSelectionInRectangle( const QgsRectangle &rect )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   // normalize the rectangle
-  rect.normalize();
+  QgsRectangle normalizedRect = rect;
+  normalizedRect.normalize();
 
-  QgsFeatureIterator fit = getFeatures( QgsFeatureRequest().setFilterRect( rect ).setFlags( Qgis::FeatureRequestFlag::NoGeometry | Qgis::FeatureRequestFlag::ExactIntersect ).setNoAttributes() );
+  QgsFeatureIterator fit = getFeatures( QgsFeatureRequest().setFilterRect( normalizedRect ).setFlags( Qgis::FeatureRequestFlag::NoGeometry | Qgis::FeatureRequestFlag::ExactIntersect ).setNoAttributes() );
 
   QgsFeatureIds selectIds;
   QgsFeatureIds deselectIds;

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -808,11 +808,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * \param rect search rectangle
      * \param behavior selection type, allows adding to current selection, removing
      * from selection, etc.
-     * \see invertSelectionInRectangle(QgsRectangle & rect)
+     * \see invertSelectionInRectangle()
      * \see selectByExpression()
      * \see selectByIds()
      */
-    void selectByRect( QgsRectangle &rect, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
+    Q_INVOKABLE void selectByRect( const QgsRectangle &rect, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
 
     /**
      * Selects matching features using an expression.
@@ -865,7 +865,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      *
      * \see   invertSelection()
      */
-    Q_INVOKABLE void invertSelectionInRectangle( QgsRectangle &rect );
+    Q_INVOKABLE void invertSelectionInRectangle( const QgsRectangle &rect );
 
     /**
      * Returns a copy of the user-selected features.

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -812,7 +812,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * \see selectByExpression()
      * \see selectByIds()
      */
-    Q_INVOKABLE void selectByRect( QgsRectangle &rect, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
+    void selectByRect( QgsRectangle &rect, Qgis::SelectBehavior behavior = Qgis::SelectBehavior::SetSelection );
 
     /**
      * Selects matching features using an expression.
@@ -1215,7 +1215,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * \see changeGeometry()
      * \see changeAttributeValue()
     */
-    Q_INVOKABLE bool updateFeature( QgsFeature &feature, bool skipDefaultValues = false );
+    bool updateFeature( QgsFeature &feature, bool skipDefaultValues = false );
 
     /**
      * Inserts a new vertex before the given vertex number,
@@ -1708,7 +1708,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * \see changeAttributeValue()
      * \see updateFeature()
      */
-    Q_INVOKABLE bool changeGeometry( QgsFeatureId fid, QgsGeometry &geometry, bool skipDefaultValue = false );
+    bool changeGeometry( QgsFeatureId fid, QgsGeometry &geometry, bool skipDefaultValue = false );
 
     /**
      * Changes an attribute value for a feature (but does not immediately commit the changes).

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -2248,7 +2248,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * \see minimumValue()
      * \see maximumValue()
      */
-    QSet<QVariant> uniqueValues( int fieldIndex, int limit = -1 ) const final;
+    Q_INVOKABLE QSet<QVariant> uniqueValues( int fieldIndex, int limit = -1 ) const final;
 
     /**
      * Returns unique string values of an attribute which contain a specified subset string. Subset
@@ -2279,7 +2279,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * \see minimumAndMaximumValue()
      * \see uniqueValues()
      */
-    QVariant minimumValue( int index ) const final;
+    Q_INVOKABLE QVariant minimumValue( int index ) const final;
 
     /**
      * Returns the maximum value for an attribute column or an invalid variant in case of error.
@@ -2295,7 +2295,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * \see minimumAndMaximumValue()
      * \see uniqueValues()
      */
-    QVariant maximumValue( int index ) const final;
+    Q_INVOKABLE QVariant maximumValue( int index ) const final;
 
 
     /**


### PR DESCRIPTION
## Description

Marking a few more functions in these key classes as invokable from QML.

I'm removing the invokable flag for selectByRect, updateFeature, and changeGeometry as they contain non-const parameters, which makes them incompatible with a QML environment, therefore useless here. That avoids people reading our QGIS API documentation and thinking they can use these.