### PR TITLE
Add guard for unneeded workaround of old geos bug

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1536,13 +1536,15 @@ bool QgsGeometry::intersects( const QgsRectangle &r ) const
     return true;
   }
 
-  // Workaround for issue issue GH #51429
+#if ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 12 )
+  // Workaround for issue issue GH #51492
   // in case of multi polygon, intersection with an empty rect fails
   if ( flatType == Qgis::WkbType::MultiPolygon && r.isEmpty() )
   {
     const QgsPointXY center { r.xMinimum(), r.yMinimum() };
     return contains( QgsGeometry::fromPointXY( center ) );
   }
+#endif
 
   QgsGeometry g = fromRect( r );
   return intersects( g );

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -14127,8 +14127,8 @@ class TestQgsGeometry(QgisTestCase):
         self.assertTrue(poly.intersects(bbox))  # was failing here!
 
         # also test zero width/zero height empty bboxes
-        self.assertTrue(poly.intersects(QgsRectangle(-1, 1, 3, 1)))
-        self.assertTrue(poly.intersects(QgsRectangle(1, -1, 1, 3)))
+        self.assertTrue(poly.intersects(QgsRectangle(-1, 1, 42, 1)))
+        self.assertTrue(poly.intersects(QgsRectangle(1, -1, 1, 42)))
 
     def testSplitGeometry(self):
         """

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -14126,6 +14126,10 @@ class TestQgsGeometry(QgisTestCase):
         self.assertTrue(poly.boundingBox().intersects(bbox))
         self.assertTrue(poly.intersects(bbox))  # was failing here!
 
+        # also test zero width/zero height empty bboxes
+        self.assertTrue(poly.intersects(QgsRectangle(-1, 1, 3, 1)))
+        self.assertTrue(poly.intersects(QgsRectangle(1, -1, 1, 3)))
+
     def testSplitGeometry(self):
         """
         splitGeometry takes either QVector<QgsPoint> or QVector<QgsPointXY>


### PR DESCRIPTION
## Description
The underlying issue of #51492 seems to have been fixed since GEOS 3.12.0
The proposed fix #51773 considered an empty rectangle to be a point, while in practice it can also be a horizontal or vertical line. This caused wrong intersection results for rectangles of zero width or zero height.

Ping @elpaso

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
