### PR TITLE
Add geom_from_geojson function to field calculator

### DIFF
--- a/resources/function_help/json/geom_from_geojson
+++ b/resources/function_help/json/geom_from_geojson
@@ -2,7 +2,7 @@
   "name": "geom_from_geojson",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns a geometry from a GeoJSON representation of geometry.",
+  "description": "Returns a geometry from a GeoJSON  Geometry fragments. It throws an error if you try to use it on a whole JSON document (Feature or FeatureCollection).",
   "arguments": [{
     "arg": "geojson",
     "description": "GeoJSON representation of a geometry as a string"

--- a/resources/function_help/json/geom_from_geojson
+++ b/resources/function_help/json/geom_from_geojson
@@ -15,5 +15,5 @@
     "expression": "geom_from_geojson('{\"type\":\"LineString\",\"coordinates\":[[4,5],[6,7]]}')",
     "returns": "a line geometry object"
   }],
-  "tags": ["representation", "conversion"]
+  "tags": ["geojson", "text", "representation", "conversion"]
 }

--- a/resources/function_help/json/geom_from_geojson
+++ b/resources/function_help/json/geom_from_geojson
@@ -1,0 +1,19 @@
+{
+  "name": "geom_from_geojson",
+  "type": "function",
+  "groups": ["GeometryGroup"],
+  "description": "Returns a geometry from a GeoJSON representation of geometry.",
+  "arguments": [{
+    "arg": "geojson",
+    "description": "GeoJSON representation of a geometry as a string"
+  }],
+  "examples": [{
+    "expression": "geom_from_geojson('{\"type\":\"Point\",\"coordinates\":[4,5]}')",
+    "returns": "a point geometry object"
+  },
+  {
+    "expression": "geom_from_geojson('{\"type\":\"LineString\",\"coordinates\":[[4,5],[6,7]]}')",
+    "returns": "a line geometry object"
+  }],
+  "tags": ["representation", "conversion"]
+}

--- a/resources/function_help/json/geom_from_geojson
+++ b/resources/function_help/json/geom_from_geojson
@@ -2,7 +2,7 @@
   "name": "geom_from_geojson",
   "type": "function",
   "groups": ["GeometryGroup"],
-  "description": "Returns a geometry from a GeoJSON  Geometry fragments. It throws an error if you try to use it on a whole JSON document (Feature or FeatureCollection).",
+  "description": "Returns a geometry from a GeoJSON Geometry fragment. An error will be thrown if this function is used on a whole JSON document (Feature or FeatureCollection).",
   "arguments": [{
     "arg": "geojson",
     "description": "GeoJSON representation of a geometry as a string"

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -41,6 +41,7 @@
 #include "qgsgeometryutils.h"
 #include "qgsgeos.h"
 #include "qgshstoreutils.h"
+#include "qgsjsonutils.h"
 #include "qgslinestring.h"
 #include "qgsmagneticmodel.h"
 #include "qgsmaptopixelgeometrysimplifier.h"
@@ -4705,6 +4706,14 @@ static QVariant fcnGeomFromWKT( const QVariantList &values, const QgsExpressionC
 {
   QString wkt = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QgsGeometry geom = QgsGeometry::fromWkt( wkt );
+  QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
+  return result;
+}
+
+static QVariant fcnGeomFromGeoJSON( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QString geojson = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
+  QgsGeometry geom = QgsJsonUtils::geometryFromGeoJson ( geojson );
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }
@@ -9915,6 +9924,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
       << new QgsStaticExpressionFunction( u"y_min"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry"_s ), fcnYMin, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false, QStringList() << u"ymin"_s )
       << new QgsStaticExpressionFunction( u"y_max"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry"_s ), fcnYMax, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false, QStringList() << u"ymax"_s )
       << new QgsStaticExpressionFunction( u"geom_from_wkt"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"text"_s ), fcnGeomFromWKT, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false, QStringList() << u"geomFromWKT"_s )
+      << new QgsStaticExpressionFunction( u"geom_from_geojson"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"text"_s ), fcnGeomFromGeoJSON, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false, QStringList() << u"geomFromGeoJSON"_s )
       << new QgsStaticExpressionFunction( u"geom_from_wkb"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"binary"_s ), fcnGeomFromWKB, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false )
       << new QgsStaticExpressionFunction( u"geom_from_gml"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"gml"_s ), fcnGeomFromGML, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false, QStringList() << u"geomFromGML"_s )
       << new QgsStaticExpressionFunction( u"flip_coordinates"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry"_s ), fcnFlipCoordinates, u"GeometryGroup"_s )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -4714,8 +4714,14 @@ static QVariant fcnGeomFromGeoJSON( const QVariantList &values, const QgsExpress
 {
   QString geojson = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
   QgsGeometry geom = QgsJsonUtils::geometryFromGeoJson( geojson );
-  QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
-  return result;
+
+  if ( geom.isNull() )
+  {
+    parent->setEvalErrorString( QObject::tr( "Could not parse the GeoJSON string" ) );
+    return QVariant();
+  }
+
+  return QVariant::fromValue( geom );
 }
 
 static QVariant fcnGeomFromWKB( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -4713,7 +4713,7 @@ static QVariant fcnGeomFromWKT( const QVariantList &values, const QgsExpressionC
 static QVariant fcnGeomFromGeoJSON( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QString geojson = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
-  QgsGeometry geom = QgsJsonUtils::geometryFromGeoJson ( geojson );
+  QgsGeometry geom = QgsJsonUtils::geometryFromGeoJson( geojson );
   QVariant result = !geom.isNull() ? QVariant::fromValue( geom ) : QVariant();
   return result;
 }
@@ -9924,7 +9924,17 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
       << new QgsStaticExpressionFunction( u"y_min"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry"_s ), fcnYMin, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false, QStringList() << u"ymin"_s )
       << new QgsStaticExpressionFunction( u"y_max"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry"_s ), fcnYMax, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false, QStringList() << u"ymax"_s )
       << new QgsStaticExpressionFunction( u"geom_from_wkt"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"text"_s ), fcnGeomFromWKT, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false, QStringList() << u"geomFromWKT"_s )
-      << new QgsStaticExpressionFunction( u"geom_from_geojson"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"text"_s ), fcnGeomFromGeoJSON, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false, QStringList() << u"geomFromGeoJSON"_s )
+      << new QgsStaticExpressionFunction(
+           u"geom_from_geojson"_s,
+           QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"text"_s ),
+           fcnGeomFromGeoJSON,
+           u"GeometryGroup"_s,
+           QString(),
+           false,
+           QSet<QString>(),
+           false,
+           QStringList() << u"geomFromGeoJSON"_s
+         )
       << new QgsStaticExpressionFunction( u"geom_from_wkb"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"binary"_s ), fcnGeomFromWKB, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false )
       << new QgsStaticExpressionFunction( u"geom_from_gml"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"gml"_s ), fcnGeomFromGML, u"GeometryGroup"_s, QString(), false, QSet<QString>(), false, QStringList() << u"geomFromGML"_s )
       << new QgsStaticExpressionFunction( u"flip_coordinates"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"geometry"_s ), fcnFlipCoordinates, u"GeometryGroup"_s )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1247,7 +1247,7 @@ class TestQgsExpression : public QObject
       QTest::newRow( "geom_from_wkb not geom" ) << "geom_to_wkt(geom_from_wkb(make_point(4,5)))" << true << QVariant();
       QTest::newRow( "geom_from_wkb null" ) << "geom_to_wkt(geom_from_wkb(NULL))" << false << QVariant();
       QTest::newRow( "geom_from_geojson" ) << "geom_to_wkt(geom_from_geojson('{\"type\":\"Point\",\"coordinates\":[4,5]}'))" << false << QVariant( "Point (4 5)" );
-      QTest::newRow( "geom_from_geojson not geom" ) << "geom_from_geojson('blop')" << false << QVariant();
+      QTest::newRow( "geom_from_geojson not geom" ) << "geom_from_geojson('blop')" << true << QVariant();
       QTest::newRow( "geom_from_geojson null" ) << "geom_to_wkt(geom_from_geojson(NULL))" << false << QVariant();
       QTest::newRow( "geometry_type not geom" ) << "geometry_type('g')" << true << QVariant();
       QTest::newRow( "geometry_type null" ) << "geometry_type(NULL)" << false << QVariant();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1246,6 +1246,9 @@ class TestQgsExpression : public QObject
       QTest::newRow( "geom_to_wkb not geom" ) << "geom_to_wkt(geom_from_wkb(geom_to_wkb('a')))" << true << QVariant();
       QTest::newRow( "geom_from_wkb not geom" ) << "geom_to_wkt(geom_from_wkb(make_point(4,5)))" << true << QVariant();
       QTest::newRow( "geom_from_wkb null" ) << "geom_to_wkt(geom_from_wkb(NULL))" << false << QVariant();
+      QTest::newRow( "geom_from_geojson" ) << "geom_to_wkt(geom_from_geojson('{\"type\":\"Point\",\"coordinates\":[4,5]}'))" << false << QVariant( "Point (4 5)" );
+      QTest::newRow( "geom_from_geojson not geom" ) << "geom_from_geojson('blop')" << false << QVariant();
+      QTest::newRow( "geom_from_geojson null" ) << "geom_to_wkt(geom_from_geojson(NULL))" << false << QVariant();
       QTest::newRow( "geometry_type not geom" ) << "geometry_type('g')" << true << QVariant();
       QTest::newRow( "geometry_type null" ) << "geometry_type(NULL)" << false << QVariant();
       QTest::newRow( "geometry_type point" ) << "geometry_type(geom_from_wkt('POINT(1 2)'))" << false << QVariant( u"Point"_s );


### PR DESCRIPTION
## Description

Add the function `geom_from_geojson`  in the field calculator.

Issue : https://github.com/qgis/QGIS/issues/64137

Thanks to @ValentinBuira for the coaching during the #rencontresQGISFr

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
