### PR TITLE
Fix build for Ubuntu 24.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,7 +578,7 @@ if(WITH_CORE)
   # search for Qt
 
   set(QT_VERSION_MAJOR 6)
-  set(QT_MIN_VERSION 6.6.0)
+  set(QT_MIN_VERSION 6.4.0)
   set(QT_VERSION_BASE "Qt6")
   set(QT_VERSION_BASE_LOWER "qt6")
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -128,7 +128,7 @@ if(${SIP_VERSION_STR} VERSION_LESS 6.11.0)
 else()
   set(SIP_MOVABLE_STR "Movable,")
 endif()
-if(QT_VERSION VERSION_LESS 6.5.0)
+if(Qt6Core_VERSION_MINOR LESS 5)
 # https://github.com/qgis/QGIS/issues/57760
 # https://www.riverbankcomputing.com/pipermail/pyqt/2024-June/045923.html
 set(SIP_QLIST_QINT64 [[

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -121,9 +121,68 @@ if(NOT WITH_SFCGAL)
 endif()
 
 # sip 6.11 has support for the Movable Mapped Type Annotation
+# Including the annotation with older sip versions will throw a parser error,
+# so we need to generate a file without it for older versions
 if(${SIP_VERSION_STR} VERSION_LESS 6.11.0)
   set(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} MOVABLE_MAPPED_TYPE)
+else()
+  set(SIP_MOVABLE_STR "Movable,")
 endif()
+if(QT_VERSION VERSION_LESS 6.5.0)
+# https://github.com/qgis/QGIS/issues/57760
+# https://www.riverbankcomputing.com/pipermail/pyqt/2024-June/045923.html
+set(SIP_QLIST_QINT64 [[
+%MappedType QList<qint64>
+    /TypeHintIn="Iterable[int]",
+    TypeHintOut="List[int]", TypeHintValue="[]"/
+{
+%TypeHeaderCode
+#include <QList>
+    %End
+
+    %ConvertFromTypeCode
+        // Create the list.
+        PyObject *l;
+
+if ((l = PyList_New(sipCpp->size())) == NULL)
+    return NULL;
+
+// Set the list elements.
+QList<qint64>::iterator it = sipCpp->begin();
+for (int i = 0; it != sipCpp->end(); ++it, ++i)
+{
+    PyObject *tobj;
+
+    if ((tobj = PyLong_FromLongLong(*it)) == NULL)
+    {
+      Py_DECREF(l);
+      return NULL;
+    }
+    PyList_SET_ITEM(l, i, tobj);
+}
+
+return l;
+%End
+
+    %ConvertToTypeCode
+    // Check the type if that is all that is required.
+    if (sipIsErr == NULL)
+    return PyList_Check(sipPy);
+
+QList<qint64> *qlist = new QList<qint64>;
+
+for (int i = 0; i < PyList_GET_SIZE(sipPy); ++i)
+{
+    *qlist << PyLong_AsLongLong(PyList_GET_ITEM(sipPy, i));
+}
+
+*sipCppPtr = qlist;
+return sipGetState(sipTransferObj);
+%End
+};
+]])
+endif()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/PyQt6/core/conversions.sip.in ${CMAKE_CURRENT_BINARY_DIR}/PyQt6/core/conversions.sip @ONLY)
 
 # Deprecated annotation supports message only since version 6.9.0 with abi-version 12.16 / 13.9 and above
 if(${SIP_VERSION_STR} VERSION_LESS 6.9.0)

--- a/python/PyQt6/core/conversions.sip.in
+++ b/python/PyQt6/core/conversions.sip.in
@@ -1246,7 +1246,7 @@ which are not wrapped by PyQt:
 
 %If (MOVABLE_MAPPED_TYPE)
 template <TYPE>
-%MappedType std::unique_ptr<TYPE> /Movable,NoRelease,AllowNone,TypeHint="Optional[TYPE]",TypeHintValue="TYPE"/
+%MappedType std::unique_ptr<TYPE> /@SIP_MOVABLE_STR@NoRelease,AllowNone,TypeHint="Optional[TYPE]",TypeHintValue="TYPE"/
 {
 %TypeHeaderCode
 #include <memory>
@@ -1622,6 +1622,8 @@ template <TYPE>
   return sipGetState(sipTransferObj);
 %End
 };
+
+@SIP_QLIST_QINT64@
 
 %MappedType QVector<long long>
     /TypeHintIn="Iterable[int]",

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -505,7 +505,7 @@ if(QGISPOSTFIX)
 endif()
 
 # NO_GENERATE_EXTRA_QMLDIRS was added in Qt 6.9.0
-if(QT_VERSION VERSION_LESS 6.9.0)
+if(Qt6Core_VERSION_MINOR LESS 9)
 qt_add_qml_module(qgis_app
     URI org.qgis.app
     VERSION 1.0

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -504,6 +504,29 @@ if(QGISPOSTFIX)
   )
 endif()
 
+# NO_GENERATE_EXTRA_QMLDIRS was added in Qt 6.9.0
+if(QT_VERSION VERSION_LESS 6.9.0)
+qt_add_qml_module(qgis_app
+    URI org.qgis.app
+    VERSION 1.0
+    QML_FILES
+        qml/WelcomeScreen.qml
+        qml/components/CustomScrollBar.qml
+        qml/components/NewsCard.qml
+        qml/components/ProjectCard.qml
+        qml/components/UpdateNotificationBar.qml
+        qml/components/FooterBar.qml
+    OUTPUT_DIRECTORY
+        ${CMAKE_CURRENT_BINARY_DIR}/qml/org/qgis/app
+    RESOURCE_PREFIX
+        /qt/qml/
+    RESOURCES
+        qml/images/basemap.jpg
+        qml/images/close.svg
+        qml/images/love.svg
+        qml/images/qgis.svg
+)
+else()
 qt_add_qml_module(qgis_app
     URI org.qgis.app
     VERSION 1.0
@@ -525,6 +548,7 @@ qt_add_qml_module(qgis_app
         qml/images/qgis.svg
     NO_GENERATE_EXTRA_QMLDIRS
 )
+endif()
 
 target_compile_definitions(qgis_app PRIVATE "QT_PLUGINS_DIR=\"${QT_PLUGINS_DIR}\"")
 target_compile_definitions(qgis_app PRIVATE "QGISPOSTFIX=\"${QGISPOSTFIX}\"")

--- a/src/core/auth/qgsauthconfigurationstoragedb.cpp
+++ b/src/core/auth/qgsauthconfigurationstoragedb.cpp
@@ -22,6 +22,7 @@
 #include <QSqlDriver>
 #include <QSqlError>
 #include <QSqlQuery>
+#include <QSqlRecord>
 #include <QString>
 #include <QThread>
 #include <QUrlQuery>
@@ -177,12 +178,18 @@ bool QgsAuthConfigurationStorageDb::authDbQuery( QSqlQuery *query, const QString
 
   auto boundQuery = []( const QSqlQuery *query ) -> QString {
     QString str = query->lastQuery();
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 6, 0 )
     const QStringList keys = query->boundValueNames();
+#endif
     const QVariantList values = query->boundValues();
     QMap<QString, QVariant> boundValues;
-    for ( int i = 0; i < keys.count(); i++ )
+    for ( int i = 0; i < values.count(); i++ )
     {
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 6, 0 )
       boundValues.insert( keys.at( i ), values.at( i ).toString() );
+#else
+      boundValues.insert( query->record().fieldName( i ), values.at( i ).toString() );
+#endif
     }
     QMapIterator<QString, QVariant> it = QMapIterator<QString, QVariant>( boundValues );
     while ( it.hasNext() )

--- a/src/core/multimedia/qgsvideoexporter.cpp
+++ b/src/core/multimedia/qgsvideoexporter.cpp
@@ -15,14 +15,15 @@
 
 #include "qgsvideoexporter.h"
 
-#include "qgsfeedback.h"
 #include "qgsexception.h"
+#include "qgsfeedback.h"
 
 #include <QDirIterator>
 #include <QString>
 #include <QUrl>
 #include <QtMultimedia/QMediaCaptureSession>
 #include <QtMultimedia/QVideoFrame>
+
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
 #include <QtMultimedia/QVideoFrameInput>
 #endif

--- a/src/core/multimedia/qgsvideoexporter.cpp
+++ b/src/core/multimedia/qgsvideoexporter.cpp
@@ -16,13 +16,16 @@
 #include "qgsvideoexporter.h"
 
 #include "qgsfeedback.h"
+#include "qgsexception.h"
 
 #include <QDirIterator>
 #include <QString>
 #include <QUrl>
 #include <QtMultimedia/QMediaCaptureSession>
 #include <QtMultimedia/QVideoFrame>
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
 #include <QtMultimedia/QVideoFrameInput>
+#endif
 
 #include "moc_qgsvideoexporter.cpp"
 

--- a/src/core/multimedia/qgsvideoexporter.h
+++ b/src/core/multimedia/qgsvideoexporter.h
@@ -258,7 +258,9 @@ class CORE_EXPORT QgsVideoExporter : public QObject
 
     std::unique_ptr< QMediaCaptureSession > mSession;
     std::unique_ptr< QMediaRecorder > mRecorder;
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
     std::unique_ptr< QVideoFrameInput > mVideoInput;
+#endif
 };
 
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -2295,6 +2295,7 @@ QString QgsMapLayer::loadSldStyle( const QString &uri, bool &resultFlag )
   if ( myFile.open( QFile::ReadOnly ) )
   {
     // read file
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
     QXmlStreamReader xmlReader( &myFile );
     xmlReader.addExtraNamespaceDeclaration( QXmlStreamNamespaceDeclaration( u"sld"_s, u"http://www.opengis.net/sld"_s ) );
     xmlReader.addExtraNamespaceDeclaration( QXmlStreamNamespaceDeclaration( u"fes"_s, u"http://www.opengis.net/fes/2.0"_s ) );
@@ -2310,6 +2311,9 @@ QString QgsMapLayer::loadSldStyle( const QString &uri, bool &resultFlag )
       line = result.errorLine;
       column = result.errorColumn;
     }
+#else
+    resultFlag = myDocument.setContent( &myFile, true, &myErrorMessage, &line, &column );
+#endif
     if ( !resultFlag )
       myErrorMessage = tr( "%1 at line %2 column %3" ).arg( myErrorMessage ).arg( line ).arg( column );
     myFile.close();

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -443,10 +443,14 @@ long QgsTaskManager::addTaskPrivate( QgsTask *task, QgsTaskList dependencies, bo
   if ( task->thread() != this->thread() )
   {
     QgsDebugMsgLevel( u"Task \"%1\" created in background thread, pushing to main thread"_s.arg( task->description() ), 1 );
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     if ( !task->moveToThread( this->thread() ) )
     {
       QgsDebugError( u"Failed to move task \"%1\" from background thread to task manager thread"_s.arg( task->description() ) );
     }
+#else
+    task->moveToThread( this->thread() );
+#endif
   }
 
   if ( !mInitialized )

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -443,7 +443,7 @@ long QgsTaskManager::addTaskPrivate( QgsTask *task, QgsTaskList dependencies, bo
   if ( task->thread() != this->thread() )
   {
     QgsDebugMsgLevel( u"Task \"%1\" created in background thread, pushing to main thread"_s.arg( task->description() ), 1 );
-#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 7, 0 )
     if ( !task->moveToThread( this->thread() ) )
     {
       QgsDebugError( u"Failed to move task \"%1\" from background thread to task manager thread"_s.arg( task->description() ) );

--- a/src/core/qgsvariantutils.cpp
+++ b/src/core/qgsvariantutils.cpp
@@ -588,7 +588,9 @@ QVariant::Type QgsVariantUtils::metaTypeToVariantType( QMetaType::Type metaType 
       return QVariant::Type::UInt;
 
     case QMetaType::Float:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     case QMetaType::Float16:
+#endif
       return QVariant::Type::Double;
 
     // no mapping possible:

--- a/src/core/qgsvariantutils.cpp
+++ b/src/core/qgsvariantutils.cpp
@@ -588,7 +588,7 @@ QVariant::Type QgsVariantUtils::metaTypeToVariantType( QMetaType::Type metaType 
       return QVariant::Type::UInt;
 
     case QMetaType::Float:
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
     case QMetaType::Float16:
 #endif
       return QVariant::Type::Double;

--- a/tests/src/analysis/testqgsnetworkanalysis.cpp
+++ b/tests/src/analysis/testqgsnetworkanalysis.cpp
@@ -639,7 +639,8 @@ void TestQgsNetworkAnalysis::testSpeedStrategy()
   featureWithNegativeAttributes.setAttributes( QgsAttributes() << -5 << -10 );
 
   QgsNetworkSpeedStrategy strategyAttribute0( 0, 60, FEET_TO_METERS );
-  QCOMPARE( strategyAttribute0.requiredAttributes(), { 0 } );
+  const QSet<int> expected0 = QSet( { 0 } );
+  QCOMPARE( strategyAttribute0.requiredAttributes(), expected0 );
   QCOMPARE( strategyAttribute0.cost( DISTANCE_IN_METERS, f ).toDouble(), DISTANCE_IN_FEET / 5 );
   // should use default speed for null attributes values
   QCOMPARE( strategyAttribute0.cost( DISTANCE_IN_METERS, featureWithNullAttributes ).toDouble(), DISTANCE_IN_FEET / 60 );
@@ -647,7 +648,8 @@ void TestQgsNetworkAnalysis::testSpeedStrategy()
   QCOMPARE( strategyAttribute0.cost( DISTANCE_IN_METERS, featureWithNegativeAttributes ).toDouble(), DISTANCE_IN_FEET / 60 );
 
   QgsNetworkSpeedStrategy strategyAttribute1( 1, 60, FEET_TO_METERS );
-  QCOMPARE( strategyAttribute1.requiredAttributes(), { 1 } );
+  const QSet<int> expected1 = QSet( { 1 } );
+  QCOMPARE( strategyAttribute1.requiredAttributes(), expected1 );
   QCOMPARE( strategyAttribute1.cost( DISTANCE_IN_METERS, f ).toDouble(), DISTANCE_IN_FEET / 10 );
   // should use default speed for null attributes values
   QCOMPARE( strategyAttribute1.cost( DISTANCE_IN_METERS, featureWithNullAttributes ).toDouble(), DISTANCE_IN_FEET / 60 );


### PR DESCRIPTION
## Description

This PR restores the ability to build for Ubuntu 24.04 (which is still the current LTS release), with Qt 6.4.2 and SIP 6.8.3.

Despite the stated minimum Qt version of 6.6, it seems the previous minimum version was actually 6.9. The 6.9 requirement was added by 4c5926b18f17b195f0e019df40696a884d9bf075 (or at least it was causing build issues for me), while there was existing code that required 6.7 and 6.8.

Furthermore, despite the mitigations attempted in #63814, SIP 6.11 also appeared to be a hard requirement. Including the `Movable` annotation in a file was sufficient to trigger a parser error, even though the feature was turned off by a flag. To avoid this issue, I'm using CMake to remove the annotation entirely when the feature isn't enabled. I also used the CMake processing to include the fix mentioned in #57760 only for Qt <6.5, which should avoid the problems with including it mentioned in that issue.

I think these fixes should probably also be backported to 4.0.

If you choose not to merge this PR, the documentation on the minimum versions should at least be updated.

## AI tool usage

No LLMs or other "AI" were used for this PR.
