### PR TITLE
Do not suggest WGS84 as available CRS for WMS services where the project CRS is non Earth

### DIFF
--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1660,6 +1660,10 @@ QString QgsCoordinateReferenceSystem::toOgcUrn() const
     {
       return u"urn:ogc:def:crs:OGC:1.3:%1"_s.arg( parts[1] );
     }
+    else if ( parts[0].startsWith( "IAU"_L1 ) )
+    {
+      return u"urn:ogc:def:crs:%1::%2"_s.arg( parts[0], parts[1] );
+    }
     else
     {
       QgsMessageLog::logMessage( u"Error converting published CRS to URN %1: (not OGC or EPSG)"_s.arg( authid() ), u"CRS"_s, Qgis::MessageLevel::Critical );

--- a/src/core/proj/qgscoordinatereferencesystem.cpp
+++ b/src/core/proj/qgscoordinatereferencesystem.cpp
@@ -1662,7 +1662,18 @@ QString QgsCoordinateReferenceSystem::toOgcUrn() const
     }
     else if ( parts[0].startsWith( "IAU"_L1 ) )
     {
-      return u"urn:ogc:def:crs:%1::%2"_s.arg( parts[0], parts[1] );
+      if ( parts[0].contains( "_"_L1 ) )
+      {
+        const auto subParts = parts[0].split( '_' );
+        if ( subParts.length() == 2 )
+        {
+          return u"urn:ogc:def:crs:%1:%2:%3"_s.arg( subParts[0], subParts[1], parts[1] );
+        }
+      }
+      else
+      {
+        return u"urn:ogc:def:crs:%1::%2"_s.arg( parts[0], parts[1] );
+      }
     }
     else
     {

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3913,6 +3913,16 @@ QgsOgcCrsUtils::CRSFlavor QgsOgcCrsUtils::parseCrsName( const QString &crsName, 
     return CRSFlavor::HTTP_EPSG_DOT_XML;
   }
 
+  // urn with AUTHORITY:CODE - this skips version and does not even have empty space for it
+  const thread_local QRegularExpression re_ogc_urn_without_version( QRegularExpression::anchoredPattern( u"urn:ogc:def:crs:([^:]+):([^:]+)"_s ), QRegularExpression::CaseInsensitiveOption );
+  if ( const QRegularExpressionMatch match = re_ogc_urn_without_version.match( crsName ); match.hasMatch() )
+  {
+    authority = match.captured( 1 );
+    code = match.captured( 2 );
+    return CRSFlavor::OGC_URN;
+  }
+
+  // urn with AUTHORITY:[VERSION]:CODE
   const thread_local QRegularExpression re_ogc_urn( QRegularExpression::anchoredPattern( u"urn:ogc:def:crs:([^:]+):([^:]*):([^:]+)"_s ), QRegularExpression::CaseInsensitiveOption );
   if ( const QRegularExpressionMatch match = re_ogc_urn.match( crsName ); match.hasMatch() )
   {

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3913,11 +3913,14 @@ QgsOgcCrsUtils::CRSFlavor QgsOgcCrsUtils::parseCrsName( const QString &crsName, 
     return CRSFlavor::HTTP_EPSG_DOT_XML;
   }
 
-  const thread_local QRegularExpression re_ogc_urn( QRegularExpression::anchoredPattern( u"urn:ogc:def:crs:([^:]+).+(?<=:)([^:]+)"_s ), QRegularExpression::CaseInsensitiveOption );
+  const thread_local QRegularExpression re_ogc_urn( QRegularExpression::anchoredPattern( u"urn:ogc:def:crs:([^:]+):([^:]*):([^:]+)"_s ), QRegularExpression::CaseInsensitiveOption );
   if ( const QRegularExpressionMatch match = re_ogc_urn.match( crsName ); match.hasMatch() )
   {
     authority = match.captured( 1 );
-    code = match.captured( 2 );
+    const QString version = match.captured( 2 );
+    code = match.captured( 3 );
+    if ( authority.compare( u"IAU"_s, Qt::CaseInsensitive ) == 0 && !version.isEmpty() )
+      authority = u"%1_%2"_s.arg( authority, version );
     return CRSFlavor::OGC_URN;
   }
 

--- a/src/server/services/landingpage/qgslandingpageutils.cpp
+++ b/src/server/services/landingpage/qgslandingpageutils.cpp
@@ -233,8 +233,9 @@ json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServe
     if ( viewSettings && !viewSettings->defaultViewExtent().isEmpty() )
     {
       QgsRectangle extent { viewSettings->defaultViewExtent() };
-      // Need conversion?
-      if ( viewSettings->defaultViewExtent().crs().authid() != "EPSG:4326"_L1 )
+      // Only transform to EPSG:4326 for Earth-based CRS
+      const QgsCoordinateReferenceSystem viewCrs { viewSettings->defaultViewExtent().crs() };
+      if ( viewCrs.authid() != "EPSG:4326"_L1 && viewCrs.isEarthCrs() )
       {
         QgsCoordinateTransform ct { p->crs(), QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), p->transformContext() };
         extent = ct.transform( extent );
@@ -263,8 +264,8 @@ json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServe
               canvasElement.firstChildElement( u"xmax"_s ).text().toDouble(),
               canvasElement.firstChildElement( u"ymax"_s ).text().toDouble(),
             };
-            // Need conversion?
-            if ( temporaryProject.crs().authid() != "EPSG:4326"_L1 )
+            // Only transform to EPSG:4326 for Earth-based CRS
+            if ( temporaryProject.crs().authid() != "EPSG:4326"_L1 && temporaryProject.crs().isEarthCrs() )
             {
               QgsCoordinateTransform ct { temporaryProject.crs(), QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), temporaryProject.transformContext() };
               extent = ct.transform( extent );
@@ -298,7 +299,14 @@ json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServe
     info["description"] = description.toStdString();
     // CRS
     const QStringList wmsOutputCrsList { QgsServerProjectUtils::wmsOutputCrsList( *p ) };
-    const QString crs = wmsOutputCrsList.contains( u"EPSG:4326"_s ) || wmsOutputCrsList.isEmpty() ? u"EPSG:4326"_s : wmsOutputCrsList.first();
+    // Prefer EPSG:4326 for Earth-based projects; for non-Earth use the first available CRS or project CRS
+    QString crs;
+    if ( p->crs().isEarthCrs() && ( wmsOutputCrsList.contains( u"EPSG:4326"_s ) || wmsOutputCrsList.isEmpty() ) )
+      crs = u"EPSG:4326"_s;
+    else if ( !wmsOutputCrsList.isEmpty() )
+      crs = wmsOutputCrsList.first();
+    else
+      crs = p->crs().authid();
     info["crs"] = crs.toStdString();
     // Typenames for WMS
     const bool useIds { QgsServerProjectUtils::wmsUseLayerIds( *p ) };
@@ -349,13 +357,17 @@ json QgsLandingPageUtils::projectInfo( const QString &projectUri, const QgsServe
       }
     }
     info["extent"] = json::array( { extent.xMinimum(), extent.yMinimum(), extent.xMaximum(), extent.yMaximum() } );
-    QgsRectangle geographicExtent { extent };
-    if ( targetCrs.authid() != "EPSG:4326"_L1 )
+    // geographic_extent is only meaningful for Earth-based projects (EPSG:4326 is Earth-specific)
+    if ( targetCrs.isEarthCrs() )
     {
-      QgsCoordinateTransform ct { targetCrs, QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), p->transformContext() };
-      geographicExtent = ct.transform( geographicExtent );
+      QgsRectangle geographicExtent { extent };
+      if ( targetCrs.authid() != "EPSG:4326"_L1 )
+      {
+        QgsCoordinateTransform ct { targetCrs, QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), p->transformContext() };
+        geographicExtent = ct.transform( geographicExtent );
+      }
+      info["geographic_extent"] = json::array( { geographicExtent.xMinimum(), geographicExtent.yMinimum(), geographicExtent.xMaximum(), geographicExtent.yMaximum() } );
     }
-    info["geographic_extent"] = json::array( { geographicExtent.xMinimum(), geographicExtent.yMinimum(), geographicExtent.xMaximum(), geographicExtent.yMaximum() } );
 
     // Metadata
     json metadata;

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -59,7 +59,7 @@ namespace QgsWms
 
     void appendCrsElementToLayer( QDomDocument &doc, QDomElement &layerElement, const QDomElement &precedingElement, const QString &crsText );
 
-    void appendCrsElementsToLayer( QDomDocument &doc, QDomElement &layerElement, const QStringList &crsList, const QStringList &constrainedCrsList );
+    void appendCrsElementsToLayer( QDomDocument &doc, QDomElement &layerElement, const QStringList &crsList, const QStringList &constrainedCrsList, bool hasEarthCrs = true );
 
     void appendLayerStyles( QDomDocument &doc, QDomElement &layerElem, const QgsWmsLayerInfos &layerInfos, const QgsProject *project, const QgsWmsRequest &request, const QgsServerSettings *settings );
 
@@ -786,7 +786,7 @@ namespace QgsWms
     const QgsRectangle wgs84BoundingRect = combineWgs84BoundingRect( layerIds, wmsLayerInfos );
     QMap<QString, QgsRectangle> crsExtents = combineCrsExtents( layerIds, wmsLayerInfos );
 
-    appendCrsElementsToLayer( doc, parentLayer, crsExtents.keys(), QStringList() );
+    appendCrsElementsToLayer( doc, parentLayer, crsExtents.keys(), QStringList(), !wgs84BoundingRect.isNull() );
     appendLayerWgs84BoundingRect( doc, parentLayer, wgs84BoundingRect );
     appendLayerCrsExtents( doc, parentLayer, crsExtents );
 
@@ -864,15 +864,18 @@ namespace QgsWms
     {
       const QgsCoordinateReferenceSystem wgs84 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( Qgis::geographicCrsAuthId() );
 
-      // Get WMS WGS84 bounding rectangle
+      // Get WMS WGS84 bounding rectangle (only meaningful for Earth-based CRS)
       QgsRectangle wmsWgs84BoundingRect;
-      try
+      if ( project->crs().isEarthCrs() )
       {
-        wmsWgs84BoundingRect = QgsWmsLayerInfos::transformExtent( wmsExtent, project->crs(), wgs84, project->transformContext(), true );
-      }
-      catch ( QgsCsException &cse )
-      {
-        QgsMessageLog::logMessage( u"Error transforming extent: %1"_s.arg( cse.what() ), u"Server"_s, Qgis::MessageLevel::Warning );
+        try
+        {
+          wmsWgs84BoundingRect = QgsWmsLayerInfos::transformExtent( wmsExtent, project->crs(), wgs84, project->transformContext(), true );
+        }
+        catch ( QgsCsException &cse )
+        {
+          QgsMessageLog::logMessage( u"Error transforming extent: %1"_s.arg( cse.what() ), u"Server"_s, Qgis::MessageLevel::Warning );
+        }
       }
 
       // Get WMS extents in output CRSes
@@ -888,7 +891,7 @@ namespace QgsWms
 
       layerParentElem.setAttribute( u"queryable"_s, hasQueryableLayers( projectLayerTreeRoot->findLayerIds(), wmsLayerInfos ) ? u"1"_s : u"0"_s );
 
-      appendCrsElementsToLayer( doc, layerParentElem, wmsCrsExtents.keys(), QStringList() );
+      appendCrsElementsToLayer( doc, layerParentElem, wmsCrsExtents.keys(), QStringList(), project->crs().isEarthCrs() );
       appendLayerWgs84BoundingRect( doc, layerParentElem, wmsWgs84BoundingRect );
       appendLayerCrsExtents( doc, layerParentElem, wmsCrsExtents );
 
@@ -1256,7 +1259,7 @@ namespace QgsWms
           // Append not null Bounding rectangles
           if ( !layerInfos.wgs84BoundingRect.isNull() )
           {
-            appendCrsElementsToLayer( doc, layerElem, layerInfos.crsExtents.keys(), QStringList() );
+            appendCrsElementsToLayer( doc, layerElem, layerInfos.crsExtents.keys(), QStringList(), l->crs().isEarthCrs() );
 
             appendLayerWgs84BoundingRect( doc, layerElem, layerInfos.wgs84BoundingRect );
 
@@ -1432,7 +1435,7 @@ namespace QgsWms
       }
     }
 
-    void appendCrsElementsToLayer( QDomDocument &doc, QDomElement &layerElement, const QStringList &crsList, const QStringList &constrainedCrsList )
+    void appendCrsElementsToLayer( QDomDocument &doc, QDomElement &layerElement, const QStringList &crsList, const QStringList &constrainedCrsList, bool hasEarthCrs )
     {
       if ( layerElement.isNull() )
       {
@@ -1470,9 +1473,9 @@ namespace QgsWms
         }
       }
 
-      // Support for CRS:84 is mandatory (equals EPSG:4326 with reversed axis)
+      // Support for CRS:84 is mandatory for Earth-based layers (equals EPSG:4326 with reversed axis)
       // https://github.com/opengeospatial/ets-wms13/blob/47155399c09b200cb21382874fdb21d5fae4ab6e/src/site/markdown/index.md
-      if ( version == "1.3.0"_L1 )
+      if ( version == "1.3.0"_L1 && hasEarthCrs )
       {
         appendCrsElementToLayer( doc, layerElement, CRSPrecedingElement, QString( "CRS:84" ) );
       }

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -542,6 +542,14 @@ void TestQgsCoordinateReferenceSystem::fromOgcWmsCrs()
 
   myCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( u"not a crs"_s );
   QVERIFY( !myCrs.isValid() );
+
+  myCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( u"urn:ogc:def:crs:EPSG::3857"_s );
+  QVERIFY( myCrs.isValid() );
+  QCOMPARE( myCrs.authid(), u"EPSG:3857"_s );
+
+  myCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( u"urn:ogc:def:crs:IAU:2015:30100"_s );
+  QVERIFY( myCrs.isValid() );
+  QCOMPARE( myCrs.authid(), u"IAU_2015:30100"_s );
 }
 
 void TestQgsCoordinateReferenceSystem::ogcWmsCrsCache()
@@ -2329,7 +2337,7 @@ void TestQgsCoordinateReferenceSystem::toOgcUrn()
   // IAU CRS (non-Earth): should use urn:ogc:def:crs:IAU_2015::<code> format
   crs = QgsCoordinateReferenceSystem( u"IAU_2015:30100"_s );
   QVERIFY( crs.isValid() );
-  QCOMPARE( crs.toOgcUrn(), u"urn:ogc:def:crs:IAU_2015::30100"_s );
+  QCOMPARE( crs.toOgcUrn(), u"urn:ogc:def:crs:IAU:2015:30100"_s );
 }
 
 QGSTEST_MAIN( TestQgsCoordinateReferenceSystem )

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -118,6 +118,7 @@ class TestQgsCoordinateReferenceSystem : public QObject
     void fromProj4EPSG20936();
     void projFactors();
     void toOgcUri();
+    void toOgcUrn();
 
   private:
     void debugPrint( QgsCoordinateReferenceSystem &crs );
@@ -2313,6 +2314,22 @@ void TestQgsCoordinateReferenceSystem::toOgcUri()
   crs = QgsCoordinateReferenceSystem( u"OGC:CRS84"_s );
   QVERIFY( crs.isValid() );
   QCOMPARE( crs.toOgcUri(), "http://www.opengis.net/def/crs/OGC/1.3/CRS84" );
+}
+
+void TestQgsCoordinateReferenceSystem::toOgcUrn()
+{
+  QgsCoordinateReferenceSystem crs( u"EPSG:4326"_s );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.toOgcUrn(), u"urn:ogc:def:crs:EPSG::4326"_s );
+
+  crs = QgsCoordinateReferenceSystem( u"OGC:CRS84"_s );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.toOgcUrn(), u"urn:ogc:def:crs:OGC:1.3:CRS84"_s );
+
+  // IAU CRS (non-Earth): should use urn:ogc:def:crs:IAU_2015::<code> format
+  crs = QgsCoordinateReferenceSystem( u"IAU_2015:30100"_s );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.toOgcUrn(), u"urn:ogc:def:crs:IAU_2015::30100"_s );
 }
 
 QGSTEST_MAIN( TestQgsCoordinateReferenceSystem )

--- a/tests/src/python/test_qgsserver_landingpage.py
+++ b/tests/src/python/test_qgsserver_landingpage.py
@@ -20,6 +20,13 @@ import shutil
 # Deterministic XML
 os.environ["QT_HASH_SEED"] = "1"
 
+from qgis.core import (
+    QgsCoordinateReferenceSystem,
+    QgsFeature,
+    QgsGeometry,
+    QgsProject,
+    QgsVectorLayer,
+)
 from qgis.PyQt import QtCore
 from qgis.server import (
     QgsBufferServerRequest,
@@ -255,6 +262,58 @@ class QgsServerLandingPageTest(QgsServerAPITestBase):
             response.headers()["Location"],
             "http://server.qgis.org/ows/catalog/index.html",
         )
+
+    def test_project_json_non_earth_crs(self):
+        """Test landing page omits geographic_extent for non-Earth CRS projects"""
+        tmpdir = QtCore.QTemporaryDir()
+
+        # Create a minimal project with a non-Earth (Moon) CRS layer
+        project = QgsProject()
+        layer = QgsVectorLayer(
+            "Point?crs=IAU_2015:30190&field=fid:integer", "moon_layer", "memory"
+        )
+        project.addMapLayers([layer])
+        project.setCrs(QgsCoordinateReferenceSystem("IAU_2015:30190"))
+        project.setTitle("Moon Test Project")
+        f = QgsFeature(layer.fields())
+        f.setGeometry(QgsGeometry.fromWkt("point(0.5 0.5)"))
+        f.setAttributes([1])
+        layer.dataProvider().addFeatures([f])
+        project_path = os.path.join(tmpdir.path(), "moon_project.qgs")
+        project.write(project_path)
+
+        original_dirs = os.environ.get(
+            "QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES", ""
+        )
+        try:
+            os.environ["QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES"] = tmpdir.path()
+
+            # Get the project list to find the non-Earth project's ID
+            request = QgsBufferServerRequest("http://server.qgis.org/index.json")
+            request.setHeader("Accept", "application/json")
+            response = QgsBufferServerResponse()
+            self.server.handleRequest(request, response)
+            j = json.loads(bytes(response.body()))
+            self.assertEqual(len(j["projects"]), 1)
+            project_id = j["projects"][0]["id"]
+
+            # Request the project info
+            request = QgsBufferServerRequest(f"http://server.qgis.org/map/{project_id}")
+            request.setHeader("Accept", "application/json")
+            response = QgsBufferServerResponse()
+            self.server.handleRequest(request, response)
+            jdata = json.loads(bytes(response.body()))
+            project_info = jdata["project"]
+
+            # CRS should be the native IAU CRS, not EPSG:4326
+            self.assertNotEqual(project_info["crs"], "EPSG:4326")
+            self.assertIn("IAU_2015:30190", project_info["crs"])
+
+            # geographic_extent must be absent — it is Earth-specific (EPSG:4326)
+            self.assertNotIn("geographic_extent", project_info)
+
+        finally:
+            os.environ["QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES"] = original_dirs
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -646,6 +646,25 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
         self.assertIn("<se:DisplacementX>-36</se:DisplacementX>", body)
         self.assertIn("<se:DisplacementY>-18</se:DisplacementY>", body)
 
+    def test_wms_getcapabilities_non_earth_crs(self):
+        """Test WMS GetCapabilities omits CRS:84 and EX_GeographicBoundingBox for non-Earth CRS layers"""
+        project = QgsProject()
+        layer = QgsMemoryProviderUtils.createMemoryLayer(
+            "moon_layer",
+            QgsFields(),
+            QgsWkbTypes.Type.Point,
+            QgsCoordinateReferenceSystem("IAU_2015:30100"),
+        )
+        project.addMapLayer(layer)
+
+        qs = "?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities"
+        _, body = self._execute_request_project(qs, project)
+
+        # CRS:84 is Earth-specific and must not appear for non-Earth layers
+        self.assertNotIn(b"CRS:84", body)
+        # EX_GeographicBoundingBox is a WGS84 bounding box and must not appear for non-Earth layers
+        self.assertNotIn(b"EX_GeographicBoundingBox", body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

The WGS:4326 or CRS:84 get silently pushed as available to pretty much all WMS layers. While it works ok for Earth data, it does not work if the project CRS is non Earth one. Generally IAU crs, but it can identified precisely by celestial body. 

This PR fixes primary instertion of WGS:4326 to project and layer in WMS service and inclusion of bounding box in LatLong coordinates (does not make sense for non Earth crs). 

But there are also other minor fixies:
-  `toOgcUrn()` can now handle **IAU** coordinate codes 
-  server landing page should not offer WGS:4326 as default CRS for projects


## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
