### PR TITLE
Move global settings defaults to a memory hash in QgsSettingsEntryBase

### DIFF
--- a/python/PyQt6/core/auto_additions/qgssettingsentry.py
+++ b/python/PyQt6/core/auto_additions/qgssettingsentry.py
@@ -1,5 +1,6 @@
 # The following has been generated automatically from src/core/settings/qgssettingsentry.h
 try:
+    QgsSettingsEntryBase.setGlobalSettingsPath = staticmethod(QgsSettingsEntryBase.setGlobalSettingsPath)
     QgsSettingsEntryBase.dynamicKeyPartToList = staticmethod(QgsSettingsEntryBase.dynamicKeyPartToList)
     QgsSettingsEntryBase.__virtual_methods__ = ['typeId', 'settingsType', 'checkValueVariant']
     QgsSettingsEntryBase.__group__ = ['settings']

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -60,7 +60,9 @@ settings description for the gui.
 Sets the path to the global settings INI file and loads all keys into an
 in-memory hash for use as defaults by :py:class:`QgsSettingsEntry`.
 
-This should be called once at application startup.
+This must be called once at application startup, before
+:py:class:`QgsApplication` initialisation, and only from the main
+thread.
 
 :param path: the path to the global settings INI file.
 

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -55,16 +55,19 @@ settings description for the gui.
 %End
   public:
 
-    static void setGlobalSettingsPath( const QString &path );
+    static bool setGlobalSettingsPath( const QString &path );
 %Docstring
 Sets the path to the global settings INI file and loads all keys into an
 in-memory hash for use as defaults by :py:class:`QgsSettingsEntry`.
 
 This must be called once at application startup, before
-:py:class:`QgsApplication` initialisation, and only from the main
+:py:class:`QgsApplication` initialization, and only from the main
 thread.
 
 :param path: the path to the global settings INI file.
+
+:return: true if the file was successfully loaded, false if the path was
+         empty or the file did not exist.
 
 .. versionadded:: 4.2
 %End

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -69,6 +69,7 @@ This should be called once at application startup.
 
 
 
+
     static QStringList dynamicKeyPartToList( const QString &dynamicKeyPart );
 %Docstring
 Transforms a dynamic key part string to list

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -75,6 +75,8 @@ thread.
 
 
 
+
+
     static QStringList dynamicKeyPartToList( const QString &dynamicKeyPart );
 %Docstring
 Transforms a dynamic key part string to list

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -55,6 +55,20 @@ settings description for the gui.
 %End
   public:
 
+    static void setGlobalSettingsPath( const QString &path );
+%Docstring
+Sets the path to the global settings INI file and loads all keys into an
+in-memory hash for use as defaults by :py:class:`QgsSettingsEntry`.
+
+This should be called once at application startup.
+
+:param path: the path to the global settings INI file.
+
+.. versionadded:: 3.44
+%End
+
+
+
     static QStringList dynamicKeyPartToList( const QString &dynamicKeyPart );
 %Docstring
 Transforms a dynamic key part string to list

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -66,7 +66,7 @@ thread.
 
 :param path: the path to the global settings INI file.
 
-.. versionadded:: 4.0.2
+.. versionadded:: 4.2
 %End
 
 

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -64,7 +64,7 @@ This should be called once at application startup.
 
 :param path: the path to the global settings INI file.
 
-.. versionadded:: 3.44
+.. versionadded:: 4.0.2
 %End
 
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -85,6 +85,7 @@ typedef SInt32 SRefCon;
 
 #include "qgscustomization.h"
 #include "qgssettings.h"
+#include "qgssettingsentry.h"
 #include "qgsfontutils.h"
 #include "qgsmessagelog.h"
 #include "qgspythonrunner.h"
@@ -1097,6 +1098,7 @@ int main( int argc, char *argv[] )
     }
     else
     {
+      QgsSettingsEntryBase::setGlobalSettingsPath( globalsettingsfile );
       preApplicationLogMessages << QObject::tr( "Successfully loaded globalsettingsfile path: %1" ).arg( globalsettingsfile ), u"QGIS"_s;
     }
   }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1092,13 +1092,15 @@ int main( int argc, char *argv[] )
 
   if ( !globalsettingsfile.isEmpty() )
   {
-    if ( !QgsSettings::setGlobalSettingsPath( globalsettingsfile ) )
+    bool ok1 = QgsSettingsEntryBase::setGlobalSettingsPath( globalsettingsfile );
+    bool ok2 = QgsSettings::setGlobalSettingsPath( globalsettingsfile );
+
+    if ( !ok1 || !ok2 )
     {
       preApplicationWarningMessages << QObject::tr( "Invalid globalsettingsfile path: %1" ).arg( globalsettingsfile ), u"QGIS"_s;
     }
     else
     {
-      QgsSettingsEntryBase::setGlobalSettingsPath( globalsettingsfile );
       preApplicationLogMessages << QObject::tr( "Successfully loaded globalsettingsfile path: %1" ).arg( globalsettingsfile ), u"QGIS"_s;
     }
   }

--- a/src/core/qgsthreadingutils.h
+++ b/src/core/qgsthreadingutils.h
@@ -190,6 +190,41 @@ using namespace Qt::StringLiterals;
   ( void ) ( other );
 #endif
 
+#ifdef __clang_analyzer__
+#define QGIS_CHECK_MAIN_THREAD_ACCESS \
+  do                                  \
+  {                                   \
+  } while ( false );
+#elif defined( AGGRESSIVE_SAFE_MODE )
+#define QGIS_CHECK_MAIN_THREAD_ACCESS                                                                                                                                  \
+  if ( QThread::currentThread() != QCoreApplication::instance()->thread() )                                                                                            \
+  {                                                                                                                                                                    \
+    qFatal(                                                                                                                                                            \
+      "%s",                                                                                                                                                            \
+      u"%2 (%1:%3) must be called from the main thread [current: 0x%4, main: 0x%5]"_s.arg( QString( __FILE__ ), QString( __FUNCTION__ ), QString::number( __LINE__ ) ) \
+        .arg( reinterpret_cast< qint64 >( QThread::currentThread() ), 0, 16 )                                                                                          \
+        .arg( reinterpret_cast< qint64 >( QCoreApplication::instance()->thread() ), 0, 16 )                                                                            \
+        .toLocal8Bit()                                                                                                                                                 \
+        .constData()                                                                                                                                                   \
+    );                                                                                                                                                                 \
+  }
+#elif defined( QGISDEBUG )
+#define QGIS_CHECK_MAIN_THREAD_ACCESS                                                                                                                                              \
+  if ( QThread::currentThread() != QCoreApplication::instance()->thread() )                                                                                                        \
+  {                                                                                                                                                                                \
+    qWarning() << u"%2 (%1:%3) must be called from the main thread [current: 0x%4, main: 0x%5]"_s.arg( QString( __FILE__ ), QString( __FUNCTION__ ), QString::number( __LINE__ ) ) \
+                    .arg( reinterpret_cast< qint64 >( QThread::currentThread() ), 0, 16 )                                                                                          \
+                    .arg( reinterpret_cast< qint64 >( QCoreApplication::instance()->thread() ), 0, 16 )                                                                            \
+                    .toLocal8Bit()                                                                                                                                                 \
+                    .constData();                                                                                                                                                  \
+  }
+#else
+#define QGIS_CHECK_MAIN_THREAD_ACCESS \
+  do                                  \
+  {                                   \
+  } while ( false );
+#endif
+
 
 /**
  * \ingroup core

--- a/src/core/qgsuserprofile.cpp
+++ b/src/core/qgsuserprofile.cpp
@@ -57,16 +57,9 @@ const QString QgsUserProfile::name() const
 
 void QgsUserProfile::initSettings() const
 {
-  // On WASM, Qt uses localStorage for QSettings - no custom path needed
 #ifndef __EMSCRIPTEN__
-  // tell QSettings to use INI format and save the file in custom config path
-  QSettings::setDefaultFormat( QSettings::IniFormat );
-  QSettings::setPath( QSettings::IniFormat, QSettings::UserScope, folder() );
+  QgsSettingsEntryBase::setupUserSettings( folder() );
 #endif
-
-  // Signal that QSettings is now configured so each thread's
-  // instance will be recreated with the correct format and path.
-  QgsSettingsEntryBase::reinitUserSettings();
 }
 
 const QString QgsUserProfile::alias() const

--- a/src/core/qgsuserprofile.cpp
+++ b/src/core/qgsuserprofile.cpp
@@ -18,6 +18,7 @@
 #include <sqlite3.h>
 
 #include "qgsapplication.h"
+#include "qgssettingsentry.h"
 #include "qgssqliteutils.h"
 
 #include <QDir>
@@ -62,6 +63,10 @@ void QgsUserProfile::initSettings() const
   QSettings::setDefaultFormat( QSettings::IniFormat );
   QSettings::setPath( QSettings::IniFormat, QSettings::UserScope, folder() );
 #endif
+
+  // Signal that QSettings is now configured so each thread's
+  // instance will be recreated with the correct format and path.
+  QgsSettingsEntryBase::initUserSettings();
 }
 
 const QString QgsUserProfile::alias() const

--- a/src/core/qgsuserprofile.cpp
+++ b/src/core/qgsuserprofile.cpp
@@ -66,7 +66,7 @@ void QgsUserProfile::initSettings() const
 
   // Signal that QSettings is now configured so each thread's
   // instance will be recreated with the correct format and path.
-  QgsSettingsEntryBase::initUserSettings();
+  QgsSettingsEntryBase::reinitUserSettings();
 }
 
 const QString QgsUserProfile::alias() const

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -57,7 +57,7 @@ QVariant QgsSettingsEntryBase::globalDefault( const QString &key )
 
 QVariant QgsSettingsEntryBase::valueFromSettingsWithGlobalDefault( const QString &resolvedKey, const QVariant &defaultValue ) const
 {
-  const QVariant userValue = QgsSettings::get()->value( resolvedKey );
+  const QVariant userValue = QSettings().value( resolvedKey );
   if ( !QgsVariantUtils::isNull( userValue ) )
     return userValue;
 
@@ -162,13 +162,13 @@ bool QgsSettingsEntryBase::hasDynamicKey() const
 bool QgsSettingsEntryBase::exists( const QString &dynamicKeyPart ) const
 {
   const QString resolvedKey = key( dynamicKeyPart );
-  return QgsSettings::get()->contains( resolvedKey ) || sGlobalDefaults.contains( resolvedKey );
+  return QSettings().contains( resolvedKey ) || sGlobalDefaults.contains( resolvedKey );
 }
 
 bool QgsSettingsEntryBase::exists( const QStringList &dynamicKeyPartList ) const
 {
   const QString resolvedKey = key( dynamicKeyPartList );
-  return QgsSettings::get()->contains( resolvedKey ) || sGlobalDefaults.contains( resolvedKey );
+  return QSettings().contains( resolvedKey ) || sGlobalDefaults.contains( resolvedKey );
 }
 
 Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKeyPartList ) const
@@ -178,7 +178,7 @@ Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKey
   if ( sGlobalDefaults.contains( resolvedKey ) )
     return Qgis::SettingsOrigin::Global;
 
-  if ( QgsSettings::get()->contains( resolvedKey ) )
+  if ( QSettings().contains( resolvedKey ) )
     return Qgis::SettingsOrigin::Local;
 
   return Qgis::SettingsOrigin::Any;

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -147,12 +147,14 @@ bool QgsSettingsEntryBase::hasDynamicKey() const
 
 bool QgsSettingsEntryBase::exists( const QString &dynamicKeyPart ) const
 {
-  return QgsSettings::get()->contains( key( dynamicKeyPart ) );
+  const QString resolvedKey = key( dynamicKeyPart );
+  return QgsSettings::get()->contains( resolvedKey ) || sGlobalDefaults.contains( resolvedKey );
 }
 
 bool QgsSettingsEntryBase::exists( const QStringList &dynamicKeyPartList ) const
 {
-  return QgsSettings::get()->contains( key( dynamicKeyPartList ) );
+  const QString resolvedKey = key( dynamicKeyPartList );
+  return QgsSettings::get()->contains( resolvedKey ) || sGlobalDefaults.contains( resolvedKey );
 }
 
 Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKeyPartList ) const

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -18,17 +18,17 @@
 #include "qgslogger.h"
 #include "qgssettings.h"
 #include "qgssettingstreenode.h"
-#include "qgsvariantutils.h"
 
 #include <QDir>
 #include <QRegularExpression>
 #include <QSettings>
 #include <QString>
+#include <QThread>
 
 using namespace Qt::StringLiterals;
 
-/**
- * Set to true by initUserSettings() once QSettings::setDefaultFormat()
+/*
+ * Set to true by reinitUserSettings() once QSettings::setDefaultFormat()
  * and setPath() have been called. Each thread's QSettings instance is
  * (re-)created on first access after this flag becomes true, so it
  * picks up the correct IniFormat and profile path.
@@ -41,26 +41,28 @@ static std::atomic<bool> sSettingsInitialized { false };
 static QSettings &sUserSettings()
 {
   thread_local QSettings *sSettings = nullptr;
-  thread_local bool sCreatedAfterInit = false;
+  thread_local bool sCreatedBeforeInit = true;
 
-  if ( !sSettings || ( !sCreatedAfterInit && sSettingsInitialized.load( std::memory_order_acquire ) ) )
+  if ( !sSettings || ( sCreatedBeforeInit && sSettingsInitialized.load( std::memory_order_acquire ) ) )
   {
     delete sSettings;
     sSettings = new QSettings();
-    sCreatedAfterInit = sSettingsInitialized.load( std::memory_order_relaxed );
+    sCreatedBeforeInit = !sSettingsInitialized.load( std::memory_order_relaxed );
   }
   return *sSettings;
 }
 
 QHash<QString, QVariant> QgsSettingsEntryBase::sGlobalDefaults;
 
-void QgsSettingsEntryBase::initUserSettings()
+void QgsSettingsEntryBase::reinitUserSettings()
 {
   sSettingsInitialized.store( true, std::memory_order_release );
 }
 
 void QgsSettingsEntryBase::setGlobalSettingsPath( const QString &path )
 {
+  Q_ASSERT_X( QThread::isMainThread(), "QgsSettingsEntryBase::setGlobalSettingsPath", "Must be called from the main thread" );
+
   sGlobalDefaults.clear();
   if ( path.isEmpty() || !QFile::exists( path ) )
     return;
@@ -93,10 +95,11 @@ QString QgsSettingsEntryBase::sanitizeGlobalKey( const QString &key )
 
 QVariant QgsSettingsEntryBase::valueFromSettingsWithGlobalDefault( const QString &resolvedKey, const QVariant &defaultValue ) const
 {
-  const QVariant userValue = sUserSettings().value( resolvedKey );
-  if ( !QgsVariantUtils::isNull( userValue ) )
-    return userValue;
+  if ( sUserSettings().contains( resolvedKey ) )
+    return sUserSettings().value( resolvedKey );
 
+  // sGlobalDefaults is populated once on the main thread before any worker
+  // threads start, so concurrent reads are safe (no concurrent modification).
   const auto it = sGlobalDefaults.constFind( sanitizeGlobalKey( resolvedKey ) );
   if ( it != sGlobalDefaults.constEnd() )
     return it.value();
@@ -211,6 +214,8 @@ Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKey
 {
   const QString resolvedKey = key( dynamicKeyPartList );
 
+  // Global takes precedence: if the key was defined in the global INI
+  // its origin is Global regardless of whether the user also overrides it.
   if ( sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) ) )
     return Qgis::SettingsOrigin::Global;
 

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -32,42 +32,41 @@ using namespace Qt::StringLiterals;
  * and setPath() have been called. Each thread's QSettings instance is
  * (re-)created on first access after this flag becomes true, so it
  * picks up the correct IniFormat and profile path.
- *
- * std::atomic ensures the write is visible to all threads without
- * undefined behavior (C++ data-race rules).
  */
-static std::atomic<bool> sSettingsInitialized { false };
+static bool sSettingsInitialized = false;
 
 static QSettings &sUserSettings()
 {
   thread_local QSettings *sSettings = nullptr;
   thread_local bool sCreatedBeforeInit = true;
 
-  if ( !sSettings || ( sCreatedBeforeInit && sSettingsInitialized.load( std::memory_order_acquire ) ) )
+  if ( !sSettings || ( sCreatedBeforeInit && sSettingsInitialized ) )
   {
     delete sSettings;
     sSettings = new QSettings();
-    sCreatedBeforeInit = !sSettingsInitialized.load( std::memory_order_relaxed );
+    sCreatedBeforeInit = !sSettingsInitialized;
   }
   return *sSettings;
 }
 
-QHash<QString, QVariant> QgsSettingsEntryBase::sGlobalDefaults;
-
 void QgsSettingsEntryBase::setupUserSettings( const QString &profilePath )
 {
+  Q_ASSERT_X( !sSettingsInitialized, "setupUserSettings", "Must only be called once" );
+  Q_ASSERT_X( QThread::isMainThread(), "setupUserSettings", "Must be called from the main thread" );
   QSettings::setDefaultFormat( QSettings::IniFormat );
   QSettings::setPath( QSettings::IniFormat, QSettings::UserScope, profilePath );
-  sSettingsInitialized.store( true, std::memory_order_release );
+  sSettingsInitialized = true;
 }
 
-void QgsSettingsEntryBase::setGlobalSettingsPath( const QString &path )
+QHash<QString, QVariant> QgsSettingsEntryBase::sGlobalDefaults;
+
+bool QgsSettingsEntryBase::setGlobalSettingsPath( const QString &path )
 {
   Q_ASSERT_X( QThread::isMainThread(), "QgsSettingsEntryBase::setGlobalSettingsPath", "Must be called from the main thread" );
 
   sGlobalDefaults.clear();
   if ( path.isEmpty() || !QFile::exists( path ) )
-    return;
+    return false;
 
   const QSettings globalSettings( path, QSettings::IniFormat );
   const QStringList keys = globalSettings.allKeys();
@@ -76,6 +75,8 @@ void QgsSettingsEntryBase::setGlobalSettingsPath( const QString &path )
   {
     sGlobalDefaults.insert( key, globalSettings.value( key ) );
   }
+
+  return true;
 }
 
 bool QgsSettingsEntryBase::hasGlobalDefault( const QString &key )

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -22,9 +22,37 @@
 
 #include <QDir>
 #include <QRegularExpression>
+#include <QSettings>
 #include <QString>
 
 using namespace Qt::StringLiterals;
+
+QHash<QString, QVariant> QgsSettingsEntryBase::sGlobalDefaults;
+
+void QgsSettingsEntryBase::setGlobalSettingsPath( const QString &path )
+{
+  sGlobalDefaults.clear();
+  if ( path.isEmpty() || !QFile::exists( path ) )
+    return;
+
+  const QSettings globalSettings( path, QSettings::IniFormat );
+  const QStringList keys = globalSettings.allKeys();
+  sGlobalDefaults.reserve( keys.size() );
+  for ( const QString &key : keys )
+  {
+    sGlobalDefaults.insert( key, globalSettings.value( key ) );
+  }
+}
+
+bool QgsSettingsEntryBase::hasGlobalDefault( const QString &key )
+{
+  return sGlobalDefaults.contains( key );
+}
+
+QVariant QgsSettingsEntryBase::globalDefault( const QString &key )
+{
+  return sGlobalDefaults.value( key );
+}
 
 QgsSettingsEntryBase::QgsSettingsEntryBase( const QString &key, QgsSettingsTreeNode *parent, const QVariant &defaultValue, const QString &description, Qgis::SettingsOptions options )
   : mParentTreeElement( parent )

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -51,8 +51,9 @@ static QSettings &sUserSettings()
 
 void QgsSettingsEntryBase::setupUserSettings( const QString &profilePath )
 {
-  Q_ASSERT_X( !sSettingsInitialized, "setupUserSettings", "Must only be called once" );
   Q_ASSERT_X( QThread::isMainThread(), "setupUserSettings", "Must be called from the main thread" );
+  if ( sSettingsInitialized )
+    return;
   QSettings::setDefaultFormat( QSettings::IniFormat );
   QSettings::setPath( QSettings::IniFormat, QSettings::UserScope, profilePath );
   sSettingsInitialized = true;

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -17,7 +17,6 @@
 
 #include "qgslogger.h"
 #include "qgssettings.h"
-#include "qgssettingsproxy.h"
 #include "qgssettingstreenode.h"
 #include "qgsvariantutils.h"
 
@@ -193,12 +192,12 @@ Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKey
 
 void QgsSettingsEntryBase::remove( const QString &dynamicKeyPart ) const
 {
-  QgsSettings::get()->remove( key( dynamicKeyPart ) );
+  QSettings().remove( key( dynamicKeyPart ) );
 }
 
 void QgsSettingsEntryBase::remove( const QStringList &dynamicKeyPartList ) const
 {
-  QgsSettings::get()->remove( key( dynamicKeyPartList ) );
+  QSettings().remove( key( dynamicKeyPartList ) );
 }
 
 int QgsSettingsEntryBase::section() const
@@ -214,19 +213,32 @@ bool QgsSettingsEntryBase::setVariantValue( const QVariant &value, const QString
 bool QgsSettingsEntryBase::setVariantValue( const QVariant &value, const QStringList &dynamicKeyPartList ) const
 {
   mHasChanged = true;
-  auto settings = QgsSettings::get();
+  const QString resolvedKey = key( dynamicKeyPartList );
+
   if ( mOptions.testFlag( Qgis::SettingsOption::SaveFormerValue ) )
   {
     if ( exists( dynamicKeyPartList ) )
     {
-      QVariant currentValue = valueAsVariant( key( dynamicKeyPartList ) );
+      QVariant currentValue = valueAsVariant( dynamicKeyPartList );
       if ( value != currentValue )
       {
-        settings->setValue( formerValuekey( dynamicKeyPartList ), currentValue );
+        QSettings().setValue( formerValuekey( dynamicKeyPartList ), currentValue );
       }
     }
   }
-  settings->setValue( key( dynamicKeyPartList ), value );
+
+  // Read current effective value (user -> global hash -> default)
+  const QVariant currentValue = valueAsVariant( dynamicKeyPartList );
+  if ( ( currentValue.isValid() || value.isValid() ) && ( currentValue != value ) )
+  {
+    QSettings().setValue( resolvedKey, value );
+  }
+  // If the new value equals the global default, remove the user override
+  // so the global default takes effect naturally and keeps user QSettings clean
+  else if ( hasGlobalDefault( resolvedKey ) && globalDefault( resolvedKey ) == currentValue )
+  {
+    QSettings().remove( resolvedKey );
+  }
   return true;
 }
 
@@ -291,27 +303,27 @@ QVariant QgsSettingsEntryBase::formerValueAsVariant( const QString &dynamicKeyPa
 QVariant QgsSettingsEntryBase::formerValueAsVariant( const QStringList &dynamicKeyPartList ) const
 {
   Q_ASSERT( mOptions.testFlag( Qgis::SettingsOption::SaveFormerValue ) );
-  QVariant defaultValueOverride = valueAsVariant( key( dynamicKeyPartList ) );
-  return QgsSettings::get()->value( formerValuekey( dynamicKeyPartList ), defaultValueOverride );
+  QVariant defaultValueOverride = valueAsVariant( dynamicKeyPartList );
+  return QSettings().value( formerValuekey( dynamicKeyPartList ), defaultValueOverride );
 }
 
 bool QgsSettingsEntryBase::copyValueFromKey( const QString &key, const QStringList &dynamicKeyPartList, bool removeSettingAtKey ) const
 {
-  auto settings = QgsSettings::get();
+  QSettings settings;
 
   const QString oldCompleteKey = completeKeyPrivate( key, dynamicKeyPartList );
 
-  if ( settings->contains( oldCompleteKey ) )
+  if ( settings.contains( oldCompleteKey ) )
   {
     if ( !exists( dynamicKeyPartList ) )
     {
-      QVariant oldValue = settings->value( oldCompleteKey, mDefaultValue );
+      QVariant oldValue = settings.value( oldCompleteKey, mDefaultValue );
       // do not copy if it is equal to the default value
       if ( oldValue != defaultValueAsVariant() )
         setVariantValue( oldValue, dynamicKeyPartList );
     }
     if ( removeSettingAtKey )
-      settings->remove( oldCompleteKey );
+      settings.remove( oldCompleteKey );
     return true;
   }
 
@@ -321,7 +333,7 @@ bool QgsSettingsEntryBase::copyValueFromKey( const QString &key, const QStringLi
 void QgsSettingsEntryBase::copyValueToKey( const QString &key, const QStringList &dynamicKeyPartList ) const
 {
   const QString completeKey = completeKeyPrivate( key, dynamicKeyPartList );
-  QgsSettings::get()->setValue( completeKey, valueAsVariant( dynamicKeyPartList ) );
+  QSettings().setValue( completeKey, valueAsVariant( dynamicKeyPartList ) );
 }
 
 void QgsSettingsEntryBase::copyValueToKeyIfChanged( const QString &key, const QStringList &dynamicKeyPartList ) const

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -19,6 +19,7 @@
 #include "qgssettings.h"
 #include "qgssettingsproxy.h"
 #include "qgssettingstreenode.h"
+#include "qgsvariantutils.h"
 
 #include <QDir>
 #include <QRegularExpression>
@@ -52,6 +53,19 @@ bool QgsSettingsEntryBase::hasGlobalDefault( const QString &key )
 QVariant QgsSettingsEntryBase::globalDefault( const QString &key )
 {
   return sGlobalDefaults.value( key );
+}
+
+QVariant QgsSettingsEntryBase::valueFromSettingsWithGlobalDefault( const QString &resolvedKey, const QVariant &defaultValue ) const
+{
+  const QVariant userValue = QgsSettings::get()->value( resolvedKey );
+  if ( !QgsVariantUtils::isNull( userValue ) )
+    return userValue;
+
+  const auto it = sGlobalDefaults.constFind( resolvedKey );
+  if ( it != sGlobalDefaults.constEnd() )
+    return it.value();
+
+  return defaultValue;
 }
 
 QgsSettingsEntryBase::QgsSettingsEntryBase( const QString &key, QgsSettingsTreeNode *parent, const QVariant &defaultValue, const QString &description, Qgis::SettingsOptions options )
@@ -224,7 +238,7 @@ QVariant QgsSettingsEntryBase::valueAsVariant( const QString &dynamicKeyPart ) c
 
 QVariant QgsSettingsEntryBase::valueAsVariant( const QStringList &dynamicKeyPartList ) const
 {
-  return QgsSettings::get()->value( key( dynamicKeyPartList ), mDefaultValue );
+  return valueFromSettingsWithGlobalDefault( key( dynamicKeyPartList ), mDefaultValue );
 }
 
 QVariant QgsSettingsEntryBase::valueAsVariant( const QString &dynamicKeyPart, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const
@@ -237,19 +251,19 @@ QVariant QgsSettingsEntryBase::valueAsVariant( const QString &dynamicKeyPart, bo
 QVariant QgsSettingsEntryBase::valueAsVariant( const QStringList &dynamicKeyPartList, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const
 {
   if ( useDefaultValueOverride )
-    return QgsSettings::get()->value( key( dynamicKeyPartList ), defaultValueOverride );
+    return valueFromSettingsWithGlobalDefault( key( dynamicKeyPartList ), defaultValueOverride );
   else
-    return QgsSettings::get()->value( key( dynamicKeyPartList ), mDefaultValue );
+    return valueFromSettingsWithGlobalDefault( key( dynamicKeyPartList ), mDefaultValue );
 }
 
 QVariant QgsSettingsEntryBase::valueAsVariantWithDefaultOverride( const QVariant &defaultValueOverride, const QString &dynamicKeyPart ) const
 {
-  return QgsSettings::get()->value( key( dynamicKeyPart ), defaultValueOverride );
+  return valueFromSettingsWithGlobalDefault( key( dynamicKeyPart ), defaultValueOverride );
 }
 
 QVariant QgsSettingsEntryBase::valueAsVariantWithDefaultOverride( const QVariant &defaultValueOverride, const QStringList &dynamicKeyPartList ) const
 {
-  return QgsSettings::get()->value( key( dynamicKeyPartList ), defaultValueOverride );
+  return valueFromSettingsWithGlobalDefault( key( dynamicKeyPartList ), defaultValueOverride );
 }
 
 QVariant QgsSettingsEntryBase::defaultValueAsVariant() const

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -28,7 +28,7 @@
 using namespace Qt::StringLiterals;
 
 /*
- * Set to true by reinitUserSettings() once QSettings::setDefaultFormat()
+ * Set to true by setupUserSettings() once QSettings::setDefaultFormat()
  * and setPath() have been called. Each thread's QSettings instance is
  * (re-)created on first access after this flag becomes true, so it
  * picks up the correct IniFormat and profile path.
@@ -54,8 +54,10 @@ static QSettings &sUserSettings()
 
 QHash<QString, QVariant> QgsSettingsEntryBase::sGlobalDefaults;
 
-void QgsSettingsEntryBase::reinitUserSettings()
+void QgsSettingsEntryBase::setupUserSettings( const QString &profilePath )
 {
+  QSettings::setDefaultFormat( QSettings::IniFormat );
+  QSettings::setPath( QSettings::IniFormat, QSettings::UserScope, profilePath );
   sSettingsInitialized.store( true, std::memory_order_release );
 }
 

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -47,12 +47,19 @@ void QgsSettingsEntryBase::setGlobalSettingsPath( const QString &path )
 
 bool QgsSettingsEntryBase::hasGlobalDefault( const QString &key )
 {
-  return sGlobalDefaults.contains( key );
+  return sGlobalDefaults.contains( sanitizeGlobalKey( key ) );
 }
 
 QVariant QgsSettingsEntryBase::globalDefault( const QString &key )
 {
-  return sGlobalDefaults.value( key );
+  return sGlobalDefaults.value( sanitizeGlobalKey( key ) );
+}
+
+QString QgsSettingsEntryBase::sanitizeGlobalKey( const QString &key )
+{
+  if ( key.startsWith( '/' ) )
+    return key.mid( 1 );
+  return key;
 }
 
 QVariant QgsSettingsEntryBase::valueFromSettingsWithGlobalDefault( const QString &resolvedKey, const QVariant &defaultValue ) const
@@ -61,7 +68,7 @@ QVariant QgsSettingsEntryBase::valueFromSettingsWithGlobalDefault( const QString
   if ( !QgsVariantUtils::isNull( userValue ) )
     return userValue;
 
-  const auto it = sGlobalDefaults.constFind( resolvedKey );
+  const auto it = sGlobalDefaults.constFind( sanitizeGlobalKey( resolvedKey ) );
   if ( it != sGlobalDefaults.constEnd() )
     return it.value();
 
@@ -162,20 +169,20 @@ bool QgsSettingsEntryBase::hasDynamicKey() const
 bool QgsSettingsEntryBase::exists( const QString &dynamicKeyPart ) const
 {
   const QString resolvedKey = key( dynamicKeyPart );
-  return QSettings().contains( resolvedKey ) || sGlobalDefaults.contains( resolvedKey );
+  return QSettings().contains( resolvedKey ) || sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) );
 }
 
 bool QgsSettingsEntryBase::exists( const QStringList &dynamicKeyPartList ) const
 {
   const QString resolvedKey = key( dynamicKeyPartList );
-  return QSettings().contains( resolvedKey ) || sGlobalDefaults.contains( resolvedKey );
+  return QSettings().contains( resolvedKey ) || sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) );
 }
 
 Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKeyPartList ) const
 {
   const QString resolvedKey = key( dynamicKeyPartList );
 
-  if ( sGlobalDefaults.contains( resolvedKey ) )
+  if ( sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) ) )
     return Qgis::SettingsOrigin::Global;
 
   if ( QSettings().contains( resolvedKey ) )

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -27,7 +27,37 @@
 
 using namespace Qt::StringLiterals;
 
+/**
+ * Set to true by initUserSettings() once QSettings::setDefaultFormat()
+ * and setPath() have been called. Each thread's QSettings instance is
+ * (re-)created on first access after this flag becomes true, so it
+ * picks up the correct IniFormat and profile path.
+ *
+ * std::atomic ensures the write is visible to all threads without
+ * undefined behavior (C++ data-race rules).
+ */
+static std::atomic<bool> sSettingsInitialized { false };
+
+static QSettings &sUserSettings()
+{
+  thread_local QSettings *sSettings = nullptr;
+  thread_local bool sCreatedAfterInit = false;
+
+  if ( !sSettings || ( !sCreatedAfterInit && sSettingsInitialized.load( std::memory_order_acquire ) ) )
+  {
+    delete sSettings;
+    sSettings = new QSettings();
+    sCreatedAfterInit = sSettingsInitialized.load( std::memory_order_relaxed );
+  }
+  return *sSettings;
+}
+
 QHash<QString, QVariant> QgsSettingsEntryBase::sGlobalDefaults;
+
+void QgsSettingsEntryBase::initUserSettings()
+{
+  sSettingsInitialized.store( true, std::memory_order_release );
+}
 
 void QgsSettingsEntryBase::setGlobalSettingsPath( const QString &path )
 {
@@ -63,7 +93,7 @@ QString QgsSettingsEntryBase::sanitizeGlobalKey( const QString &key )
 
 QVariant QgsSettingsEntryBase::valueFromSettingsWithGlobalDefault( const QString &resolvedKey, const QVariant &defaultValue ) const
 {
-  const QVariant userValue = QSettings().value( resolvedKey );
+  const QVariant userValue = sUserSettings().value( resolvedKey );
   if ( !QgsVariantUtils::isNull( userValue ) )
     return userValue;
 
@@ -168,13 +198,13 @@ bool QgsSettingsEntryBase::hasDynamicKey() const
 bool QgsSettingsEntryBase::exists( const QString &dynamicKeyPart ) const
 {
   const QString resolvedKey = key( dynamicKeyPart );
-  return QSettings().contains( resolvedKey ) || sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) );
+  return sUserSettings().contains( resolvedKey ) || sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) );
 }
 
 bool QgsSettingsEntryBase::exists( const QStringList &dynamicKeyPartList ) const
 {
   const QString resolvedKey = key( dynamicKeyPartList );
-  return QSettings().contains( resolvedKey ) || sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) );
+  return sUserSettings().contains( resolvedKey ) || sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) );
 }
 
 Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKeyPartList ) const
@@ -184,7 +214,7 @@ Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKey
   if ( sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) ) )
     return Qgis::SettingsOrigin::Global;
 
-  if ( QSettings().contains( resolvedKey ) )
+  if ( sUserSettings().contains( resolvedKey ) )
     return Qgis::SettingsOrigin::Local;
 
   return Qgis::SettingsOrigin::Any;
@@ -192,12 +222,12 @@ Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKey
 
 void QgsSettingsEntryBase::remove( const QString &dynamicKeyPart ) const
 {
-  QSettings().remove( key( dynamicKeyPart ) );
+  sUserSettings().remove( key( dynamicKeyPart ) );
 }
 
 void QgsSettingsEntryBase::remove( const QStringList &dynamicKeyPartList ) const
 {
-  QSettings().remove( key( dynamicKeyPartList ) );
+  sUserSettings().remove( key( dynamicKeyPartList ) );
 }
 
 int QgsSettingsEntryBase::section() const
@@ -222,7 +252,7 @@ bool QgsSettingsEntryBase::setVariantValue( const QVariant &value, const QString
       QVariant currentValue = valueAsVariant( dynamicKeyPartList );
       if ( value != currentValue )
       {
-        QSettings().setValue( formerValuekey( dynamicKeyPartList ), currentValue );
+        sUserSettings().setValue( formerValuekey( dynamicKeyPartList ), currentValue );
       }
     }
   }
@@ -236,17 +266,17 @@ bool QgsSettingsEntryBase::setVariantValue( const QVariant &value, const QString
     if ( sGlobalDefaults.contains( sanitizedKey ) && sGlobalDefaults.value( sanitizedKey ) == value )
     {
       // New value matches global default — remove user override instead of writing
-      QSettings().remove( resolvedKey );
+      sUserSettings().remove( resolvedKey );
     }
     else
     {
-      QSettings().setValue( resolvedKey, value );
+      sUserSettings().setValue( resolvedKey, value );
     }
   }
   // Value unchanged and equals global default — clean up stale user key if present
   else if ( hasGlobalDefault( resolvedKey ) && globalDefault( resolvedKey ) == currentValue )
   {
-    QSettings().remove( resolvedKey );
+    sUserSettings().remove( resolvedKey );
   }
   return true;
 }
@@ -313,12 +343,12 @@ QVariant QgsSettingsEntryBase::formerValueAsVariant( const QStringList &dynamicK
 {
   Q_ASSERT( mOptions.testFlag( Qgis::SettingsOption::SaveFormerValue ) );
   QVariant defaultValueOverride = valueAsVariant( dynamicKeyPartList );
-  return QSettings().value( formerValuekey( dynamicKeyPartList ), defaultValueOverride );
+  return sUserSettings().value( formerValuekey( dynamicKeyPartList ), defaultValueOverride );
 }
 
 bool QgsSettingsEntryBase::copyValueFromKey( const QString &key, const QStringList &dynamicKeyPartList, bool removeSettingAtKey ) const
 {
-  QSettings settings;
+  QSettings &settings = sUserSettings();
 
   const QString oldCompleteKey = completeKeyPrivate( key, dynamicKeyPartList );
 
@@ -342,7 +372,7 @@ bool QgsSettingsEntryBase::copyValueFromKey( const QString &key, const QStringLi
 void QgsSettingsEntryBase::copyValueToKey( const QString &key, const QStringList &dynamicKeyPartList ) const
 {
   const QString completeKey = completeKeyPrivate( key, dynamicKeyPartList );
-  QSettings().setValue( completeKey, valueAsVariant( dynamicKeyPartList ) );
+  sUserSettings().setValue( completeKey, valueAsVariant( dynamicKeyPartList ) );
 }
 
 void QgsSettingsEntryBase::copyValueToKeyIfChanged( const QString &key, const QStringList &dynamicKeyPartList ) const

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -231,10 +231,19 @@ bool QgsSettingsEntryBase::setVariantValue( const QVariant &value, const QString
   const QVariant currentValue = valueAsVariant( dynamicKeyPartList );
   if ( ( currentValue.isValid() || value.isValid() ) && ( currentValue != value ) )
   {
-    QSettings().setValue( resolvedKey, value );
+    // Value is changing — check if new value equals global default
+    const QString sanitizedKey = sanitizeGlobalKey( resolvedKey );
+    if ( sGlobalDefaults.contains( sanitizedKey ) && sGlobalDefaults.value( sanitizedKey ) == value )
+    {
+      // New value matches global default — remove user override instead of writing
+      QSettings().remove( resolvedKey );
+    }
+    else
+    {
+      QSettings().setValue( resolvedKey, value );
+    }
   }
-  // If the new value equals the global default, remove the user override
-  // so the global default takes effect naturally and keeps user QSettings clean
+  // Value unchanged and equals global default — clean up stale user key if present
   else if ( hasGlobalDefault( resolvedKey ) && globalDefault( resolvedKey ) == currentValue )
   {
     QSettings().remove( resolvedKey );

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -18,12 +18,12 @@
 #include "qgslogger.h"
 #include "qgssettings.h"
 #include "qgssettingstreenode.h"
+#include "qgsthreadingutils.h"
 
 #include <QDir>
 #include <QRegularExpression>
 #include <QSettings>
 #include <QString>
-#include <QThread>
 
 using namespace Qt::StringLiterals;
 
@@ -51,9 +51,10 @@ static QSettings &sUserSettings()
 
 void QgsSettingsEntryBase::setupUserSettings( const QString &profilePath )
 {
-  Q_ASSERT_X( QThread::isMainThread(), "setupUserSettings", "Must be called from the main thread" );
+  QGIS_CHECK_MAIN_THREAD_ACCESS
   if ( sSettingsInitialized )
     return;
+
   QSettings::setDefaultFormat( QSettings::IniFormat );
   QSettings::setPath( QSettings::IniFormat, QSettings::UserScope, profilePath );
   sSettingsInitialized = true;
@@ -63,7 +64,7 @@ QHash<QString, QVariant> QgsSettingsEntryBase::sGlobalDefaults;
 
 bool QgsSettingsEntryBase::setGlobalSettingsPath( const QString &path )
 {
-  Q_ASSERT_X( QThread::isMainThread(), "QgsSettingsEntryBase::setGlobalSettingsPath", "Must be called from the main thread" );
+  QGIS_CHECK_MAIN_THREAD_ACCESS
 
   sGlobalDefaults.clear();
   if ( path.isEmpty() || !QFile::exists( path ) )
@@ -88,6 +89,33 @@ bool QgsSettingsEntryBase::hasGlobalDefault( const QString &key )
 QVariant QgsSettingsEntryBase::globalDefault( const QString &key )
 {
   return sGlobalDefaults.value( sanitizeGlobalKey( key ) );
+}
+
+QSettings &QgsSettingsEntryBase::userSettings()
+{
+  return sUserSettings();
+}
+
+QStringList QgsSettingsEntryBase::globalChildGroups( const QString &prefix )
+{
+  QString normalizedPrefix = sanitizeGlobalKey( prefix );
+  if ( !normalizedPrefix.endsWith( '/' ) )
+    normalizedPrefix.append( '/' );
+
+  const int prefixLen = normalizedPrefix.size();
+  QStringList result;
+
+  for ( auto it = sGlobalDefaults.constBegin(); it != sGlobalDefaults.constEnd(); ++it )
+  {
+    if ( it.key().startsWith( normalizedPrefix ) )
+    {
+      const int slashPos = it.key().indexOf( '/', prefixLen );
+      const QString group = ( slashPos < 0 ) ? it.key().mid( prefixLen ) : it.key().mid( prefixLen, slashPos - prefixLen );
+      if ( !group.isEmpty() && !result.contains( group ) )
+        result.append( group );
+    }
+  }
+  return result;
 }
 
 QString QgsSettingsEntryBase::sanitizeGlobalKey( const QString &key )

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -157,7 +157,15 @@ bool QgsSettingsEntryBase::exists( const QStringList &dynamicKeyPartList ) const
 
 Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKeyPartList ) const
 {
-  return QgsSettings::get()->origin( key( dynamicKeyPartList ) );
+  const QString resolvedKey = key( dynamicKeyPartList );
+
+  if ( sGlobalDefaults.contains( resolvedKey ) )
+    return Qgis::SettingsOrigin::Global;
+
+  if ( QgsSettings::get()->contains( resolvedKey ) )
+    return Qgis::SettingsOrigin::Local;
+
+  return Qgis::SettingsOrigin::Any;
 }
 
 void QgsSettingsEntryBase::remove( const QString &dynamicKeyPart ) const

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -264,26 +264,16 @@ bool QgsSettingsEntryBase::setVariantValue( const QVariant &value, const QString
     }
   }
 
-  // Read current effective value (user -> global hash -> default)
-  const QVariant currentValue = valueAsVariant( dynamicKeyPartList );
-  if ( ( currentValue.isValid() || value.isValid() ) && ( currentValue != value ) )
-  {
-    // Value is changing — check if new value equals global default
-    const QString sanitizedKey = sanitizeGlobalKey( resolvedKey );
-    if ( sGlobalDefaults.contains( sanitizedKey ) && sGlobalDefaults.value( sanitizedKey ) == value )
-    {
-      // New value matches global default — remove user override instead of writing
-      sUserSettings().remove( resolvedKey );
-    }
-    else
-    {
-      sUserSettings().setValue( resolvedKey, value );
-    }
-  }
-  // Value unchanged and equals global default — clean up stale user key if present
-  else if ( hasGlobalDefault( resolvedKey ) && globalDefault( resolvedKey ) == currentValue )
+  // If the new value matches a global default, remove the user override
+  // so the global default takes effect naturally. Otherwise always write.
+  const QString sanitizedKey = sanitizeGlobalKey( resolvedKey );
+  if ( sGlobalDefaults.contains( sanitizedKey ) && sGlobalDefaults.value( sanitizedKey ) == value )
   {
     sUserSettings().remove( resolvedKey );
+  }
+  else
+  {
+    sUserSettings().setValue( resolvedKey, value );
   }
   return true;
 }

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -106,6 +106,8 @@ class CORE_EXPORT QgsSettingsEntryBase
      * before QgsApplication initialization,
      * and only from the main thread.
      *
+     * If called a second time, it will have no effect.
+     *
      * \since QGIS 4.2
      */
     static void setupUserSettings( const QString &profilePath ) SIP_SKIP;

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -78,13 +78,14 @@ class CORE_EXPORT QgsSettingsEntryBase
      * into an in-memory hash for use as defaults by QgsSettingsEntry.
      *
      * This must be called once at application startup, before QgsApplication
-     * initialisation, and only from the main thread.
+     * initialization, and only from the main thread.
      *
      * \param path the path to the global settings INI file.
+     * \return true if the file was successfully loaded, false if the path was empty or the file did not exist.
      *
      * \since QGIS 4.2
      */
-    static void setGlobalSettingsPath( const QString &path );
+    static bool setGlobalSettingsPath( const QString &path );
 
     /**
      * Returns TRUE if the global settings INI file contains a value for the given \a key.
@@ -95,11 +96,15 @@ class CORE_EXPORT QgsSettingsEntryBase
 
     /**
      * Configures QSettings to use IniFormat at the given \a profilePath
-     * and bumps the internal generation counter so that each thread's
-     * QSettings instance is recreated on next access.
+     * so that each thread's QSettings instance is recreated on next access
+     * with the correct format and path.
      *
-     * This is a convenience wrapper around QSettings::setDefaultFormat(),
-     * QSettings::setPath() and the internal generation bump.
+     * This is a convenience wrapper around QSettings::setDefaultFormat()
+     * and QSettings::setPath().
+     *
+     * It should be called once at application startup,
+     * before QgsApplication initialization,
+     * and only from the main thread.
      *
      * \since QGIS 4.2
      */

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -23,6 +23,8 @@
 #include "qgis_sip.h"
 
 #include <QColor>
+#include <QHash>
+#include <QSettings>
 #include <QString>
 
 using namespace Qt::StringLiterals;
@@ -119,6 +121,31 @@ class CORE_EXPORT QgsSettingsEntryBase
      * \since QGIS 4.2
      */
     static QVariant globalDefault( const QString &key ) SIP_SKIP;
+
+    /**
+     * Returns a reference to the thread-local QSettings instance used
+     * internally by all QgsSettingsEntry operations.
+     *
+     * \note This is intended for internal use by the settings framework
+     * (e.g. QgsSettingsTreeNamedListNode). Prefer using QgsSettingsEntry
+     * accessors instead.
+     *
+     * \since QGIS 4.2
+     */
+    static QSettings &userSettings() SIP_SKIP;
+
+    /**
+     * Returns the list of child group names found under \a prefix
+     * in the global defaults hash.
+     *
+     * The \a prefix is a tree-based key (may start with '/').
+     * A trailing '/' is added automatically if not present.
+     *
+     * \note This is intended for internal use by QgsSettingsTreeNamedListNode.
+     *
+     * \since QGIS 4.2
+     */
+    static QStringList globalChildGroups( const QString &prefix ) SIP_SKIP;
 
     /**
      * Transforms a dynamic key part string to list

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -93,6 +93,18 @@ class CORE_EXPORT QgsSettingsEntryBase
     static bool hasGlobalDefault( const QString &key ) SIP_SKIP;
 
     /**
+     * Bumps the internal settings generation counter, causing each
+     * thread's QSettings instance to be recreated on next access.
+     *
+     * Must be called after QSettings::setDefaultFormat() and
+     * QSettings::setPath() so that new instances pick up the
+     * correct format (IniFormat) and profile path.
+     *
+     * \since QGIS 4.0.2
+     */
+    static void initUserSettings() SIP_SKIP;
+
+    /**
      * Returns the global default value for the given \a key,
      * or an invalid QVariant if not found.
      *

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -74,6 +74,33 @@ class CORE_EXPORT QgsSettingsEntryBase
   public:
 
     /**
+     * Sets the path to the global settings INI file and loads all keys
+     * into an in-memory hash for use as defaults by QgsSettingsEntry.
+     *
+     * This should be called once at application startup.
+     *
+     * \param path the path to the global settings INI file.
+     *
+     * \since QGIS 3.44
+     */
+    static void setGlobalSettingsPath( const QString &path );
+
+    /**
+     * Returns TRUE if a global default is defined for the given \a key.
+     *
+     * \since QGIS 3.44
+     */
+    static bool hasGlobalDefault( const QString &key ) SIP_SKIP;
+
+    /**
+     * Returns the global default value for the given \a key,
+     * or an invalid QVariant if not found.
+     *
+     * \since QGIS 3.44
+     */
+    static QVariant globalDefault( const QString &key ) SIP_SKIP;
+
+    /**
      * Transforms a dynamic key part string to list
      * \since QGIS 3.26
      */
@@ -354,6 +381,8 @@ class CORE_EXPORT QgsSettingsEntryBase
     QString formerValuekey( const QStringList &dynamicKeyPartList ) const;
 
     QString completeKeyPrivate( const QString &key, const QStringList &dynamicKeyPartList ) const;
+
+    static QHash<QString, QVariant> sGlobalDefaults;
 
     QgsSettingsTreeNode *mParentTreeElement = nullptr;
     QString mName;

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -378,6 +378,7 @@ class CORE_EXPORT QgsSettingsEntryBase
     bool hasChanged() const { return mHasChanged; }
 
   private:
+    QVariant valueFromSettingsWithGlobalDefault( const QString &resolvedKey, const QVariant &defaultValue ) const SIP_SKIP;
     QString formerValuekey( const QStringList &dynamicKeyPartList ) const;
 
     QString completeKeyPrivate( const QString &key, const QStringList &dynamicKeyPartList ) const;

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -383,6 +383,8 @@ class CORE_EXPORT QgsSettingsEntryBase
 
     QString completeKeyPrivate( const QString &key, const QStringList &dynamicKeyPartList ) const;
 
+    static QString sanitizeGlobalKey( const QString &key );
+
     static QHash<QString, QVariant> sGlobalDefaults;
 
     QgsSettingsTreeNode *mParentTreeElement = nullptr;

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -81,14 +81,14 @@ class CORE_EXPORT QgsSettingsEntryBase
      *
      * \param path the path to the global settings INI file.
      *
-     * \since QGIS 3.44
+     * \since QGIS 4.0.2
      */
     static void setGlobalSettingsPath( const QString &path );
 
     /**
      * Returns TRUE if a global default is defined for the given \a key.
      *
-     * \since QGIS 3.44
+     * \since QGIS 4.0.2
      */
     static bool hasGlobalDefault( const QString &key ) SIP_SKIP;
 
@@ -96,7 +96,7 @@ class CORE_EXPORT QgsSettingsEntryBase
      * Returns the global default value for the given \a key,
      * or an invalid QVariant if not found.
      *
-     * \since QGIS 3.44
+     * \since QGIS 4.0.2
      */
     static QVariant globalDefault( const QString &key ) SIP_SKIP;
 

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -82,14 +82,14 @@ class CORE_EXPORT QgsSettingsEntryBase
      *
      * \param path the path to the global settings INI file.
      *
-     * \since QGIS 4.0.2
+     * \since QGIS 4.2
      */
     static void setGlobalSettingsPath( const QString &path );
 
     /**
      * Returns TRUE if the global settings INI file contains a value for the given \a key.
      *
-     * \since QGIS 4.0.2
+     * \since QGIS 4.2
      */
     static bool hasGlobalDefault( const QString &key ) SIP_SKIP;
 
@@ -101,7 +101,7 @@ class CORE_EXPORT QgsSettingsEntryBase
      * This is a convenience wrapper around QSettings::setDefaultFormat(),
      * QSettings::setPath() and the internal generation bump.
      *
-     * \since QGIS 4.0.2
+     * \since QGIS 4.2
      */
     static void setupUserSettings( const QString &profilePath ) SIP_SKIP;
 
@@ -109,7 +109,7 @@ class CORE_EXPORT QgsSettingsEntryBase
      * Returns the global default value for the given \a key,
      * or an invalid QVariant if not found.
      *
-     * \since QGIS 4.0.2
+     * \since QGIS 4.2
      */
     static QVariant globalDefault( const QString &key ) SIP_SKIP;
 

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -94,16 +94,16 @@ class CORE_EXPORT QgsSettingsEntryBase
     static bool hasGlobalDefault( const QString &key ) SIP_SKIP;
 
     /**
-     * Bumps the internal settings generation counter, causing each
-     * thread's QSettings instance to be recreated on next access.
+     * Configures QSettings to use IniFormat at the given \a profilePath
+     * and bumps the internal generation counter so that each thread's
+     * QSettings instance is recreated on next access.
      *
-     * Must be called after QSettings::setDefaultFormat() and
-     * QSettings::setPath() so that new instances pick up the
-     * correct format (IniFormat) and profile path.
+     * This is a convenience wrapper around QSettings::setDefaultFormat(),
+     * QSettings::setPath() and the internal generation bump.
      *
      * \since QGIS 4.0.2
      */
-    static void reinitUserSettings() SIP_SKIP;
+    static void setupUserSettings( const QString &profilePath ) SIP_SKIP;
 
     /**
      * Returns the global default value for the given \a key,

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -77,7 +77,8 @@ class CORE_EXPORT QgsSettingsEntryBase
      * Sets the path to the global settings INI file and loads all keys
      * into an in-memory hash for use as defaults by QgsSettingsEntry.
      *
-     * This should be called once at application startup.
+     * This must be called once at application startup, before QgsApplication
+     * initialisation, and only from the main thread.
      *
      * \param path the path to the global settings INI file.
      *
@@ -86,7 +87,7 @@ class CORE_EXPORT QgsSettingsEntryBase
     static void setGlobalSettingsPath( const QString &path );
 
     /**
-     * Returns TRUE if a global default is defined for the given \a key.
+     * Returns TRUE if the global settings INI file contains a value for the given \a key.
      *
      * \since QGIS 4.0.2
      */
@@ -102,7 +103,7 @@ class CORE_EXPORT QgsSettingsEntryBase
      *
      * \since QGIS 4.0.2
      */
-    static void initUserSettings() SIP_SKIP;
+    static void reinitUserSettings() SIP_SKIP;
 
     /**
      * Returns the global default value for the given \a key,

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -461,34 +461,6 @@ void QgsSettingsRegistryCore::migrateOldSettings()
       }
     }
   }
-
-  // recent CRS
-  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsAuthId->copyValueFromKey( u"UI/recentProjectionsAuthId"_s, {}, true );
-  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsAuthId->copyValueFromKey( u"crs/recentProjectionsAuthId"_s, {}, true );
-  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsWkt->copyValueFromKey( u"UI/recentProjectionsWkt"_s, {}, true );
-  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsWkt->copyValueFromKey( u"crs/recentProjectionsWkt"_s, {}, true );
-  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsProj4->copyValueFromKey( u"UI/recentProjectionsProj4"_s, {}, true );
-  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsProj4->copyValueFromKey( u"crs/recentProjectionsProj4"_s, {}, true );
-
-  // auth settings
-  QgsAuthManager::settingsPasswordHelperInsecureFallback->copyValueFromKey( u"auth/password_helper_insecure_fallback"_s, {}, true );
-  QgsAuthManager::settingsUsePasswordHelper->copyValueFromKey( u"auth/use_password_helper"_s, {}, true );
-  QgsAuthManager::settingsPasswordHelperLogging->copyValueFromKey( u"auth/password_helper_logging"_s, {}, true );
-
-  // raster cumulative cut
-  QgsRasterMinMaxOrigin::settingsCumulativeCutLower->copyValueFromKey( u"Raster/cumulativeCutLower"_s, {}, true );
-  QgsRasterMinMaxOrigin::settingsCumulativeCutLower->copyValueFromKey( u"raster/cumulativeCutLower"_s, {}, true );
-  QgsRasterMinMaxOrigin::settingsCumulativeCutUpper->copyValueFromKey( u"Raster/cumulativeCutUpper"_s, {}, true );
-  QgsRasterMinMaxOrigin::settingsCumulativeCutUpper->copyValueFromKey( u"raster/cumulativeCutUpper"_s, {}, true );
-
-  // CptCity
-  QgsCptCityArchive::settingsCptCityBaseDir->copyValueFromKey( u"CptCity/baseDir"_s, {}, true );
-  QgsCptCityArchive::settingsCptCityBaseDir->copyValueFromKey( u"core/cptcity-base-dir"_s, {}, true );
-  QgsCptCityArchive::settingsCptCityArchiveName->copyValueFromKey( u"CptCity/archiveName"_s, {}, true );
-  QgsCptCityArchive::settingsCptCityArchiveName->copyValueFromKey( u"core/cptcity-archive-name"_s, {}, true );
-
-  // encoding
-  QgsVectorFileWriter::settingsDefaultEncoding->copyValueFromKey( u"UI/encoding"_s, {}, true );
 }
 
 void QgsSettingsRegistryCore::backwardCompatibility()

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -30,10 +30,10 @@
 #include "qgssettings.h"
 #include "qgssettingsentryenumflag.h"
 #include "qgssettingsentryimpl.h"
-#include "qgssettingsproxy.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectortileconnection.h"
 
+#include <QSettings>
 #include <QString>
 #include <QThread>
 
@@ -197,14 +197,6 @@ QgsSettingsRegistryCore::~QgsSettingsRegistryCore()
 
 void QgsSettingsRegistryCore::migrateOldSettings()
 {
-  // This method triggers a ton of QgsSettings constructions and destructions, which is very expensive
-  // as it involves writing new values to the underlying ini files.
-  // Accordingly we place a hold on constructing new QgsSettings objects for the duration of the method,
-  // so that only a single QgsSettings object is created and destroyed at the end of this method.
-  QgsSettings::holdFlush();
-
-  auto settings = QgsSettings::get();
-
   // copy values from old keys to new keys and delete the old ones
   // for backward compatibility, old keys are recreated when the registry gets deleted
 
@@ -307,9 +299,10 @@ void QgsSettingsRegistryCore::migrateOldSettings()
 
   // locator filters - added in 3.30
   {
-    settings->beginGroup( u"gui/locator_filters"_s );
-    const QStringList childKeys = settings->childKeys();
-    settings->endGroup();
+    QSettings locatorSettings;
+    locatorSettings.beginGroup( u"gui/locator_filters"_s );
+    const QStringList childKeys = locatorSettings.childKeys();
+    locatorSettings.endGroup();
     for ( const QString &childKey : childKeys )
     {
       if ( childKey.startsWith( "enabled"_L1 ) )
@@ -454,7 +447,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   {
     if ( QgsBabelFormatRegistry::sTreeBabelDevices->items().count() == 0 )
     {
-      const QStringList deviceNames = settings->value( u"/Plugin-GPS/devices/deviceList"_s ).toStringList();
+      QSettings babelSettings;
+      const QStringList deviceNames = babelSettings.value( u"/Plugin-GPS/devices/deviceList"_s ).toStringList();
 
       for ( const QString &device : deviceNames )
       {
@@ -468,7 +462,33 @@ void QgsSettingsRegistryCore::migrateOldSettings()
     }
   }
 
-  QgsSettings::releaseFlush();
+  // recent CRS
+  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsAuthId->copyValueFromKey( u"UI/recentProjectionsAuthId"_s, {}, true );
+  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsAuthId->copyValueFromKey( u"crs/recentProjectionsAuthId"_s, {}, true );
+  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsWkt->copyValueFromKey( u"UI/recentProjectionsWkt"_s, {}, true );
+  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsWkt->copyValueFromKey( u"crs/recentProjectionsWkt"_s, {}, true );
+  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsProj4->copyValueFromKey( u"UI/recentProjectionsProj4"_s, {}, true );
+  QgsCoordinateReferenceSystemRegistry::settingsRecentProjectionsProj4->copyValueFromKey( u"crs/recentProjectionsProj4"_s, {}, true );
+
+  // auth settings
+  QgsAuthManager::settingsPasswordHelperInsecureFallback->copyValueFromKey( u"auth/password_helper_insecure_fallback"_s, {}, true );
+  QgsAuthManager::settingsUsePasswordHelper->copyValueFromKey( u"auth/use_password_helper"_s, {}, true );
+  QgsAuthManager::settingsPasswordHelperLogging->copyValueFromKey( u"auth/password_helper_logging"_s, {}, true );
+
+  // raster cumulative cut
+  QgsRasterMinMaxOrigin::settingsCumulativeCutLower->copyValueFromKey( u"Raster/cumulativeCutLower"_s, {}, true );
+  QgsRasterMinMaxOrigin::settingsCumulativeCutLower->copyValueFromKey( u"raster/cumulativeCutLower"_s, {}, true );
+  QgsRasterMinMaxOrigin::settingsCumulativeCutUpper->copyValueFromKey( u"Raster/cumulativeCutUpper"_s, {}, true );
+  QgsRasterMinMaxOrigin::settingsCumulativeCutUpper->copyValueFromKey( u"raster/cumulativeCutUpper"_s, {}, true );
+
+  // CptCity
+  QgsCptCityArchive::settingsCptCityBaseDir->copyValueFromKey( u"CptCity/baseDir"_s, {}, true );
+  QgsCptCityArchive::settingsCptCityBaseDir->copyValueFromKey( u"core/cptcity-base-dir"_s, {}, true );
+  QgsCptCityArchive::settingsCptCityArchiveName->copyValueFromKey( u"CptCity/archiveName"_s, {}, true );
+  QgsCptCityArchive::settingsCptCityArchiveName->copyValueFromKey( u"core/cptcity-archive-name"_s, {}, true );
+
+  // encoding
+  QgsVectorFileWriter::settingsDefaultEncoding->copyValueFromKey( u"UI/encoding"_s, {}, true );
 }
 
 void QgsSettingsRegistryCore::backwardCompatibility()

--- a/src/core/settings/qgssettingstreenode.cpp
+++ b/src/core/settings/qgssettingstreenode.cpp
@@ -16,9 +16,8 @@
 #include "qgssettingstreenode.h"
 
 #include "qgsexception.h"
-#include "qgssettings.h"
+#include "qgssettingsentry.h"
 #include "qgssettingsentryimpl.h"
-#include "qgssettingsproxy.h"
 
 #include <QDir>
 #include <QString>
@@ -184,10 +183,29 @@ QStringList QgsSettingsTreeNamedListNode::items( Qgis::SettingsOrigin origin, co
 
 
   const QString completeKeyParam = completeKeyWithNamedItems( mItemsCompleteKey, parentsNamedItems );
-  auto settings = QgsSettings::get();
-  settings->beginGroup( completeKeyParam );
-  const QStringList res = settings->childGroups( origin );
-  settings->endGroup();
+
+  QStringList res;
+
+  // Collect items from the user QSettings
+  if ( origin != Qgis::SettingsOrigin::Global )
+  {
+    QSettings &settings = QgsSettingsEntryBase::userSettings();
+    settings.beginGroup( completeKeyParam );
+    res = settings.childGroups();
+    settings.endGroup();
+  }
+
+  // Collect items from the global defaults hash
+  if ( origin != Qgis::SettingsOrigin::Local )
+  {
+    const QStringList globalGroups = QgsSettingsEntryBase::globalChildGroups( completeKeyParam );
+    for ( const QString &group : globalGroups )
+    {
+      if ( !res.contains( group ) )
+        res.append( group );
+    }
+  }
+
   return res;
 }
 
@@ -227,7 +245,7 @@ void QgsSettingsTreeNamedListNode::deleteItem( const QString &item, const QStrin
   QStringList args = parentsNamedItems;
   args << item;
   QString key = completeKeyWithNamedItems( mCompleteKey, args );
-  QgsSettings::get()->remove( key );
+  QgsSettingsEntryBase::userSettings().remove( key );
 }
 
 void QgsSettingsTreeNamedListNode::deleteAllItems( const QStringList &parentsNamedItems )
@@ -238,13 +256,13 @@ void QgsSettingsTreeNamedListNode::deleteAllItems( const QStringList &parentsNam
     );
 
   const QStringList children = items( parentsNamedItems );
-  auto settings = QgsSettings::get();
+  QSettings &settings = QgsSettingsEntryBase::userSettings();
   for ( const QString &child : children )
   {
     QStringList args = parentsNamedItems;
     args << child;
     QString key = completeKeyWithNamedItems( mCompleteKey, args );
-    settings->remove( key );
+    settings.remove( key );
   }
 }
 

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -46,6 +46,7 @@ typedef SInt32 SRefCon;
 #include "qgsprocess.h"
 #include "qgsapplication.h"
 #include "qgsproviderregistry.h"
+#include "qgssettingsentry.h"
 
 #ifdef HAVE_OPENCL
 #include "qgsopenclutils.h"
@@ -119,6 +120,11 @@ int main( int argc, char *argv[] )
   }
 
   QgsApplication app( argc, argv, false, QString(), u"qgis_process"_s );
+
+  // Load global settings defaults into the in-memory hash
+  const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" );
+  if ( globalSettingsFile )
+    QgsSettingsEntryBase::setGlobalSettingsPath( QString::fromLocal8Bit( globalSettingsFile ) );
 
   // Build a local QCoreApplication from arguments. This way, arguments are correctly parsed from their native locale
   // It will use QString::fromLocal8Bit( argv ) under Unix and GetCommandLine() under Windows.

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -46,7 +46,6 @@ typedef SInt32 SRefCon;
 #include "qgsprocess.h"
 #include "qgsapplication.h"
 #include "qgsproviderregistry.h"
-#include "qgssettingsentry.h"
 
 #ifdef HAVE_OPENCL
 #include "qgsopenclutils.h"
@@ -120,11 +119,6 @@ int main( int argc, char *argv[] )
   }
 
   QgsApplication app( argc, argv, false, QString(), u"qgis_process"_s );
-
-  // Load global settings defaults into the in-memory hash
-  const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" );
-  if ( globalSettingsFile )
-    QgsSettingsEntryBase::setGlobalSettingsPath( QString::fromLocal8Bit( globalSettingsFile ) );
 
   // Build a local QCoreApplication from arguments. This way, arguments are correctly parsed from their native locale
   // It will use QString::fromLocal8Bit( argv ) under Unix and GetCommandLine() under Windows.

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -46,6 +46,8 @@ typedef SInt32 SRefCon;
 #include "qgsprocess.h"
 #include "qgsapplication.h"
 #include "qgsproviderregistry.h"
+#include "qgssettings.h"
+#include "qgssettingsentry.h"
 
 #ifdef HAVE_OPENCL
 #include "qgsopenclutils.h"
@@ -119,6 +121,14 @@ int main( int argc, char *argv[] )
   }
 
   QgsApplication app( argc, argv, false, QString(), u"qgis_process"_s );
+
+  const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" );
+  if ( globalSettingsFile )
+  {
+    const QString path = QString::fromLocal8Bit( globalSettingsFile );
+    QgsSettings::setGlobalSettingsPath( path );
+    QgsSettingsEntryBase::setGlobalSettingsPath( path );
+  }
 
   // Build a local QCoreApplication from arguments. This way, arguments are correctly parsed from their native locale
   // It will use QString::fromLocal8Bit( argv ) under Unix and GetCommandLine() under Windows.

--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -26,6 +26,8 @@
 #include "qgsfcgiserverrequest.h"
 #include "qgsfcgiserverresponse.h"
 #include "qgsserver.h"
+#include "qgssettings.h"
+#include "qgssettingsentry.h"
 
 #include <QFontDatabase>
 #include <QString>
@@ -76,6 +78,14 @@ int main( int argc, char *argv[] )
   }
   // since version 3.0 QgsServer now needs a qApp so initialize QgsApplication
   const QgsApplication app( argc, argv, withDisplay, QString(), u"server"_s );
+
+  const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" );
+  if ( globalSettingsFile )
+  {
+    const QString path = QString::fromLocal8Bit( globalSettingsFile );
+    QgsSettings::setGlobalSettingsPath( path );
+    QgsSettingsEntryBase::setGlobalSettingsPath( path );
+  }
 
   QgsServer server;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS

--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -26,7 +26,6 @@
 #include "qgsfcgiserverrequest.h"
 #include "qgsfcgiserverresponse.h"
 #include "qgsserver.h"
-#include "qgssettingsentry.h"
 
 #include <QFontDatabase>
 #include <QString>
@@ -77,11 +76,6 @@ int main( int argc, char *argv[] )
   }
   // since version 3.0 QgsServer now needs a qApp so initialize QgsApplication
   const QgsApplication app( argc, argv, withDisplay, QString(), u"server"_s );
-
-  // Load global settings defaults into the in-memory hash
-  const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" );
-  if ( globalSettingsFile )
-    QgsSettingsEntryBase::setGlobalSettingsPath( QString::fromLocal8Bit( globalSettingsFile ) );
 
   QgsServer server;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS

--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -26,6 +26,7 @@
 #include "qgsfcgiserverrequest.h"
 #include "qgsfcgiserverresponse.h"
 #include "qgsserver.h"
+#include "qgssettingsentry.h"
 
 #include <QFontDatabase>
 #include <QString>
@@ -76,6 +77,12 @@ int main( int argc, char *argv[] )
   }
   // since version 3.0 QgsServer now needs a qApp so initialize QgsApplication
   const QgsApplication app( argc, argv, withDisplay, QString(), u"server"_s );
+
+  // Load global settings defaults into the in-memory hash
+  const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" );
+  if ( globalSettingsFile )
+    QgsSettingsEntryBase::setGlobalSettingsPath( QString::fromLocal8Bit( globalSettingsFile ) );
+
   QgsServer server;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
   server.initPython();

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -37,7 +37,6 @@ using namespace Qt::StringLiterals;
 #include "qgscommandlineutils.h"
 #include "qgsconfig.h"
 #include "qgsserver.h"
-#include "qgssettingsentry.h"
 #include "qgsbufferserverrequest.h"
 #include "qgsbufferserverresponse.h"
 #include "qgsapplication.h"
@@ -499,11 +498,6 @@ int main( int argc, char *argv[] )
 
   // since version 3.0 QgsServer now needs a qApp so initialize QgsApplication
   const QgsApplication app( argc, argv, withDisplay, QString(), u"QGIS Development Server"_s );
-
-  // Load global settings defaults into the in-memory hash
-  const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" );
-  if ( globalSettingsFile )
-    QgsSettingsEntryBase::setGlobalSettingsPath( QString::fromLocal8Bit( globalSettingsFile ) );
 
   QCoreApplication::setOrganizationName( QgsApplication::QGIS_ORGANIZATION_NAME );
   QCoreApplication::setOrganizationDomain( QgsApplication::QGIS_ORGANIZATION_DOMAIN );

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -37,6 +37,7 @@ using namespace Qt::StringLiterals;
 #include "qgscommandlineutils.h"
 #include "qgsconfig.h"
 #include "qgsserver.h"
+#include "qgssettingsentry.h"
 #include "qgsbufferserverrequest.h"
 #include "qgsbufferserverresponse.h"
 #include "qgsapplication.h"
@@ -498,6 +499,11 @@ int main( int argc, char *argv[] )
 
   // since version 3.0 QgsServer now needs a qApp so initialize QgsApplication
   const QgsApplication app( argc, argv, withDisplay, QString(), u"QGIS Development Server"_s );
+
+  // Load global settings defaults into the in-memory hash
+  const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" );
+  if ( globalSettingsFile )
+    QgsSettingsEntryBase::setGlobalSettingsPath( QString::fromLocal8Bit( globalSettingsFile ) );
 
   QCoreApplication::setOrganizationName( QgsApplication::QGIS_ORGANIZATION_NAME );
   QCoreApplication::setOrganizationDomain( QgsApplication::QGIS_ORGANIZATION_DOMAIN );

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -37,6 +37,8 @@ using namespace Qt::StringLiterals;
 #include "qgscommandlineutils.h"
 #include "qgsconfig.h"
 #include "qgsserver.h"
+#include "qgssettings.h"
+#include "qgssettingsentry.h"
 #include "qgsbufferserverrequest.h"
 #include "qgsbufferserverresponse.h"
 #include "qgsapplication.h"
@@ -498,6 +500,14 @@ int main( int argc, char *argv[] )
 
   // since version 3.0 QgsServer now needs a qApp so initialize QgsApplication
   const QgsApplication app( argc, argv, withDisplay, QString(), u"QGIS Development Server"_s );
+
+  const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" );
+  if ( globalSettingsFile )
+  {
+    const QString path = QString::fromLocal8Bit( globalSettingsFile );
+    QgsSettings::setGlobalSettingsPath( path );
+    QgsSettingsEntryBase::setGlobalSettingsPath( path );
+  }
 
   QCoreApplication::setOrganizationName( QgsApplication::QGIS_ORGANIZATION_NAME );
   QCoreApplication::setOrganizationDomain( QgsApplication::QGIS_ORGANIZATION_DOMAIN );

--- a/tests/src/core/testqgssettingsentry.cpp
+++ b/tests/src/core/testqgssettingsentry.cpp
@@ -19,7 +19,9 @@
 #include "qgstest.h"
 
 #include <QObject>
+#include <QSettings>
 #include <QString>
+#include <QTemporaryDir>
 
 using namespace Qt::StringLiterals;
 
@@ -41,6 +43,11 @@ class TestQgsSettingsEntry : public QObject
     void flagValue();
     void testFormerValue();
     void testChanged();
+    void testGlobalDefault();
+    void testGlobalDefaultOverriddenByUser();
+    void testGlobalOrigin();
+    void testGlobalExists();
+    void testLoadGlobalDefaults();
 };
 
 void TestQgsSettingsEntry::settingsKey()
@@ -230,6 +237,133 @@ void TestQgsSettingsEntry::testChanged()
 
   settingsEntryInteger.copyValueToKeyIfChanged( u"testSetting"_s );
   QCOMPARE( QgsSettings().value( u"testSetting"_s ).toInt(), 11111 );
+}
+
+void TestQgsSettingsEntry::testGlobalDefault()
+{
+  // Create a temporary INI file with a known key
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"globaltest/myint"_s, 42 );
+    globalIni.setValue( u"globaltest/mystring"_s, u"hello"_s );
+    globalIni.sync();
+  }
+
+  QgsSettingsEntryBase::setGlobalSettingsPath( iniPath );
+
+  // Setting defined only in global INI — no user value set
+  const QgsSettingsEntryInteger intEntry( u"myint"_s, u"globaltest"_s, 0 );
+  QCOMPARE( intEntry.value(), 42 );
+
+  const QgsSettingsEntryString strEntry( u"mystring"_s, u"globaltest"_s, QString() );
+  QCOMPARE( strEntry.value(), u"hello"_s );
+
+  // Clean up
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+}
+
+void TestQgsSettingsEntry::testGlobalDefaultOverriddenByUser()
+{
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"globaltest/overridden"_s, 100 );
+    globalIni.sync();
+  }
+
+  QgsSettingsEntryBase::setGlobalSettingsPath( iniPath );
+
+  const QgsSettingsEntryInteger entry( u"overridden"_s, u"globaltest"_s, 0 );
+
+  // User overrides the global value
+  entry.setValue( 999 );
+  QCOMPARE( entry.value(), 999 );
+
+  // Clean up
+  entry.remove();
+  // With user value removed, global default should return
+  QCOMPARE( entry.value(), 100 );
+
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+}
+
+void TestQgsSettingsEntry::testGlobalOrigin()
+{
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"globaltest/globalonly"_s, 1 );
+    globalIni.setValue( u"globaltest/both"_s, 10 );
+    globalIni.sync();
+  }
+
+  QgsSettingsEntryBase::setGlobalSettingsPath( iniPath );
+
+  // Global-only key
+  const QgsSettingsEntryInteger globalOnly( u"globalonly"_s, u"globaltest"_s, 0 );
+  QCOMPARE( globalOnly.origin( QStringList() ), Qgis::SettingsOrigin::Global );
+
+  // Key in both: Global-first semantics
+  const QgsSettingsEntryInteger both( u"both"_s, u"globaltest"_s, 0 );
+  both.setValue( 20 );
+  QCOMPARE( both.origin( QStringList() ), Qgis::SettingsOrigin::Global );
+
+  // User-only key (not in global)
+  const QgsSettingsEntryInteger userOnly( u"useronly"_s, u"globaltest"_s, 0 );
+  userOnly.setValue( 5 );
+  QCOMPARE( userOnly.origin( QStringList() ), Qgis::SettingsOrigin::Local );
+
+  // Non-existent key
+  const QgsSettingsEntryInteger absent( u"absent"_s, u"globaltest"_s, 0 );
+  QCOMPARE( absent.origin( QStringList() ), Qgis::SettingsOrigin::Any );
+
+  // Clean up
+  both.remove();
+  userOnly.remove();
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+}
+
+void TestQgsSettingsEntry::testGlobalExists()
+{
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"globaltest/existskey"_s, u"val"_s );
+    globalIni.sync();
+  }
+
+  QgsSettingsEntryBase::setGlobalSettingsPath( iniPath );
+
+  const QgsSettingsEntryString entry( u"existskey"_s, u"globaltest"_s, QString() );
+  // exists() should return true even though no user value is set
+  QVERIFY( entry.exists() );
+
+  const QgsSettingsEntryString absent( u"nope"_s, u"globaltest"_s, QString() );
+  QVERIFY( !absent.exists() );
+
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+}
+
+void TestQgsSettingsEntry::testLoadGlobalDefaults()
+{
+  // Empty path should not crash
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+
+  // Non-existent file should not crash
+  QgsSettingsEntryBase::setGlobalSettingsPath( u"/nonexistent/path/file.ini"_s );
+
+  // Verify hash is empty after non-existent path
+  const QgsSettingsEntryInteger entry( u"testkey"_s, u"test"_s, 99 );
+  QCOMPARE( entry.value(), 99 );
 }
 
 

--- a/tests/src/core/testqgssettingsentry.cpp
+++ b/tests/src/core/testqgssettingsentry.cpp
@@ -148,7 +148,7 @@ void TestQgsSettingsEntry::flagValue()
   const Qgis::LayerFilters hasGeometry = Qgis::LayerFilters( Qgis::LayerFilter::HasGeometry );
 
   // Make sure the setting is not existing
-  QgsSettings().remove( settingsKey );
+  QgsSettings().remove( u"%1/%2"_s.arg( mSettingsSection, settingsKey ) );
 
   const QgsSettingsEntryEnumFlag settingsEntryFlag( settingsKey, mSettingsSection, Qgis::LayerFilters(), u"Filters"_s );
 

--- a/tests/src/core/testqgssettingsentry.cpp
+++ b/tests/src/core/testqgssettingsentry.cpp
@@ -22,6 +22,7 @@
 #include <QSettings>
 #include <QString>
 #include <QTemporaryDir>
+#include <QThread>
 
 using namespace Qt::StringLiterals;
 
@@ -49,6 +50,7 @@ class TestQgsSettingsEntry : public QObject
     void testGlobalExists();
     void testLoadGlobalDefaults();
     void testSetValueGlobalDefaultCleanup();
+    void testThreadSafety();
 };
 
 void TestQgsSettingsEntry::settingsKey()
@@ -311,10 +313,10 @@ void TestQgsSettingsEntry::testGlobalOrigin()
   const QgsSettingsEntryInteger globalOnly( u"globalonly"_s, u"globaltest"_s, 0 );
   QCOMPARE( globalOnly.origin( QStringList() ), Qgis::SettingsOrigin::Global );
 
-  // Key in both: Global-first semantics
+  // Key in both: Local-first
   const QgsSettingsEntryInteger both( u"both"_s, u"globaltest"_s, 0 );
   both.setValue( 20 );
-  QCOMPARE( both.origin( QStringList() ), Qgis::SettingsOrigin::Global );
+  QCOMPARE( both.origin( QStringList() ), Qgis::SettingsOrigin::Local );
 
   // User-only key (not in global)
   const QgsSettingsEntryInteger userOnly( u"useronly"_s, u"globaltest"_s, 0 );
@@ -403,6 +405,48 @@ void TestQgsSettingsEntry::testSetValueGlobalDefaultCleanup()
   // Set the same value again — should not re-write (no change)
   entry.setValue( 123 );
   QVERIFY( QSettings().contains( entry.key() ) );
+  QCOMPARE( entry.value(), 123 );
+
+  // Clean up
+  entry.remove();
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+}
+
+void TestQgsSettingsEntry::testThreadSafety()
+{
+  // Verify that global defaults populated on the main thread are readable
+  // from a worker thread, and that a value written in a worker thread
+  // is visible from the main thread afterwards.
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"threadtest/globalval"_s, 77 );
+    globalIni.sync();
+  }
+
+  QgsSettingsEntryBase::setGlobalSettingsPath( iniPath );
+
+  const QgsSettingsEntryInteger entry( u"globalval"_s, u"threadtest"_s, 0 );
+
+  // Main thread sees the global default
+  QCOMPARE( entry.value(), 77 );
+
+  // Worker thread reads global default and writes a user override
+  int workerReadValue = 0;
+  auto *thread = QThread::create( [&] {
+    workerReadValue = entry.value();
+    entry.setValue( 123 );
+  } );
+  thread->start();
+  thread->wait();
+  delete thread;
+
+  // Worker saw the global default
+  QCOMPARE( workerReadValue, 77 );
+
+  // Main thread sees the value written by the worker
   QCOMPARE( entry.value(), 123 );
 
   // Clean up

--- a/tests/src/core/testqgssettingsentry.cpp
+++ b/tests/src/core/testqgssettingsentry.cpp
@@ -48,6 +48,7 @@ class TestQgsSettingsEntry : public QObject
     void testGlobalOrigin();
     void testGlobalExists();
     void testLoadGlobalDefaults();
+    void testSetValueGlobalDefaultCleanup();
 };
 
 void TestQgsSettingsEntry::settingsKey()
@@ -364,6 +365,49 @@ void TestQgsSettingsEntry::testLoadGlobalDefaults()
   // Verify hash is empty after non-existent path
   const QgsSettingsEntryInteger entry( u"testkey"_s, u"test"_s, 99 );
   QCOMPARE( entry.value(), 99 );
+}
+
+void TestQgsSettingsEntry::testSetValueGlobalDefaultCleanup()
+{
+  // When setting a value equal to the global default, the user key
+  // should be removed so the global default takes effect naturally.
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"globaltest/cleanup"_s, 50 );
+    globalIni.sync();
+  }
+
+  QgsSettingsEntryBase::setGlobalSettingsPath( iniPath );
+
+  const QgsSettingsEntryInteger entry( u"cleanup"_s, u"globaltest"_s, 0 );
+
+  // Set a different value — should write to user QSettings
+  entry.setValue( 999 );
+  QVERIFY( QSettings().contains( entry.key() ) );
+  QCOMPARE( entry.value(), 999 );
+
+  // Set value back to the global default — should remove user key
+  entry.setValue( 50 );
+  QVERIFY( !QSettings().contains( entry.key() ) );
+  // Value should still be 50 (from global hash)
+  QCOMPARE( entry.value(), 50 );
+
+  // Set a value when no user key exists and value differs — should write
+  entry.setValue( 123 );
+  QVERIFY( QSettings().contains( entry.key() ) );
+  QCOMPARE( entry.value(), 123 );
+
+  // Set the same value again — should not re-write (no change)
+  entry.setValue( 123 );
+  QVERIFY( QSettings().contains( entry.key() ) );
+  QCOMPARE( entry.value(), 123 );
+
+  // Clean up
+  entry.remove();
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
 }
 
 

--- a/tests/src/core/testqgssettingsentry.cpp
+++ b/tests/src/core/testqgssettingsentry.cpp
@@ -313,10 +313,10 @@ void TestQgsSettingsEntry::testGlobalOrigin()
   const QgsSettingsEntryInteger globalOnly( u"globalonly"_s, u"globaltest"_s, 0 );
   QCOMPARE( globalOnly.origin( QStringList() ), Qgis::SettingsOrigin::Global );
 
-  // Key in both: Local-first
+  // Key in both: Global takes precedence for origin
   const QgsSettingsEntryInteger both( u"both"_s, u"globaltest"_s, 0 );
   both.setValue( 20 );
-  QCOMPARE( both.origin( QStringList() ), Qgis::SettingsOrigin::Local );
+  QCOMPARE( both.origin( QStringList() ), Qgis::SettingsOrigin::Global );
 
   // User-only key (not in global)
   const QgsSettingsEntryInteger userOnly( u"useronly"_s, u"globaltest"_s, 0 );

--- a/tests/src/python/test_qgssettingsentry.py
+++ b/tests/src/python/test_qgssettingsentry.py
@@ -732,6 +732,34 @@ class TestQgsSettingsEntry(QgisTestCase):
 
             QgsSettingsEntryBase.setGlobalSettingsPath("")
 
+    def test_set_value_global_default_cleanup(self):
+        """Setting a value equal to the global default removes the user key."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ini_path = os.path.join(tmpdir, "global.ini")
+            gs = QSettings(ini_path, QSettings.Format.IniFormat)
+            gs.setValue("plugins/globaltest/cleanup", 50)
+            gs.sync()
+            del gs
+
+            QgsSettingsEntryBase.setGlobalSettingsPath(ini_path)
+
+            entry = QgsSettingsEntryInteger("cleanup", "globaltest", 0)
+
+            # Set a different value — should write to user QSettings
+            entry.setValue(999)
+            self.assertTrue(QSettings().contains(entry.key()))
+            self.assertEqual(entry.value(), 999)
+
+            # Set value back to the global default — should remove user key
+            entry.setValue(50)
+            self.assertFalse(QSettings().contains(entry.key()))
+            # Value should still be 50 (from global hash)
+            self.assertEqual(entry.value(), 50)
+
+            # Clean up
+            entry.remove()
+            QgsSettingsEntryBase.setGlobalSettingsPath("")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgssettingsentry.py
+++ b/tests/src/python/test_qgssettingsentry.py
@@ -9,6 +9,8 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
 
+import os
+import tempfile
 import unittest
 
 from qgis import core as qgis_core
@@ -16,6 +18,7 @@ from qgis.core import (
     Qgis,
     QgsMapLayerProxyModel,
     QgsSettings,
+    QgsSettingsEntryBase,
     QgsSettingsEntryBool,
     QgsSettingsEntryColor,
     QgsSettingsEntryDouble,
@@ -29,7 +32,7 @@ from qgis.core import (
     QgsSettingsTree,
     QgsUnitTypes,
 )
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import QSettings, Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.testing import QgisTestCase, start_app
 
@@ -637,6 +640,97 @@ class TestQgsSettingsEntry(QgisTestCase):
         settingsEntrySrc.copyValueToKey(f"plugins/{self.pluginName}/{settingsDestKey}")
         self.assertTrue(settingsEntryDest.exists())
         self.assertEqual(settingsEntryDest.value(), settingsEntryDest.value())
+
+    def test_global_default(self):
+        """Global INI value used when no user value is set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ini_path = os.path.join(tmpdir, "global.ini")
+            gs = QSettings(ini_path, QSettings.Format.IniFormat)
+            gs.setValue("globaltest/myint", 42)
+            gs.setValue("globaltest/mystring", "hello")
+            gs.sync()
+            del gs
+
+            QgsSettingsEntryBase.setGlobalSettingsPath(ini_path)
+
+            int_entry = QgsSettingsEntryInteger("myint", "globaltest", 0)
+            self.assertEqual(int_entry.value(), 42)
+
+            str_entry = QgsSettingsEntryString("mystring", "globaltest", "")
+            self.assertEqual(str_entry.value(), "hello")
+
+            QgsSettingsEntryBase.setGlobalSettingsPath("")
+
+    def test_global_default_overridden_by_user(self):
+        """User value takes precedence over global default."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ini_path = os.path.join(tmpdir, "global.ini")
+            gs = QSettings(ini_path, QSettings.Format.IniFormat)
+            gs.setValue("globaltest/overridden", 100)
+            gs.sync()
+            del gs
+
+            QgsSettingsEntryBase.setGlobalSettingsPath(ini_path)
+
+            entry = QgsSettingsEntryInteger("overridden", "globaltest", 0)
+            entry.setValue(999)
+            self.assertEqual(entry.value(), 999)
+
+            # Remove user value -> global should return
+            entry.remove()
+            self.assertEqual(entry.value(), 100)
+
+            QgsSettingsEntryBase.setGlobalSettingsPath("")
+
+    def test_global_origin(self):
+        """origin() returns Global/Local/Any correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ini_path = os.path.join(tmpdir, "global.ini")
+            gs = QSettings(ini_path, QSettings.Format.IniFormat)
+            gs.setValue("globaltest/globalonly", 1)
+            gs.setValue("globaltest/both", 10)
+            gs.sync()
+            del gs
+
+            QgsSettingsEntryBase.setGlobalSettingsPath(ini_path)
+
+            global_only = QgsSettingsEntryInteger("globalonly", "globaltest", 0)
+            self.assertEqual(global_only.origin([]), Qgis.SettingsOrigin.Global)
+
+            both = QgsSettingsEntryInteger("both", "globaltest", 0)
+            both.setValue(20)
+            self.assertEqual(both.origin([]), Qgis.SettingsOrigin.Global)
+
+            user_only = QgsSettingsEntryInteger("useronly", "globaltest", 0)
+            user_only.setValue(5)
+            self.assertEqual(user_only.origin([]), Qgis.SettingsOrigin.Local)
+
+            absent = QgsSettingsEntryInteger("absent", "globaltest", 0)
+            self.assertEqual(absent.origin([]), Qgis.SettingsOrigin.Any)
+
+            # Clean up
+            both.remove()
+            user_only.remove()
+            QgsSettingsEntryBase.setGlobalSettingsPath("")
+
+    def test_global_exists(self):
+        """exists() returns True for global-only keys."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ini_path = os.path.join(tmpdir, "global.ini")
+            gs = QSettings(ini_path, QSettings.Format.IniFormat)
+            gs.setValue("globaltest/existskey", "val")
+            gs.sync()
+            del gs
+
+            QgsSettingsEntryBase.setGlobalSettingsPath(ini_path)
+
+            entry = QgsSettingsEntryString("existskey", "globaltest", "")
+            self.assertTrue(entry.exists())
+
+            absent = QgsSettingsEntryString("nope", "globaltest", "")
+            self.assertFalse(absent.exists())
+
+            QgsSettingsEntryBase.setGlobalSettingsPath("")
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgssettingsentry.py
+++ b/tests/src/python/test_qgssettingsentry.py
@@ -646,8 +646,8 @@ class TestQgsSettingsEntry(QgisTestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             ini_path = os.path.join(tmpdir, "global.ini")
             gs = QSettings(ini_path, QSettings.Format.IniFormat)
-            gs.setValue("globaltest/myint", 42)
-            gs.setValue("globaltest/mystring", "hello")
+            gs.setValue("plugins/globaltest/myint", 42)
+            gs.setValue("plugins/globaltest/mystring", "hello")
             gs.sync()
             del gs
 
@@ -666,7 +666,7 @@ class TestQgsSettingsEntry(QgisTestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             ini_path = os.path.join(tmpdir, "global.ini")
             gs = QSettings(ini_path, QSettings.Format.IniFormat)
-            gs.setValue("globaltest/overridden", 100)
+            gs.setValue("plugins/globaltest/overridden", 100)
             gs.sync()
             del gs
 
@@ -687,8 +687,8 @@ class TestQgsSettingsEntry(QgisTestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             ini_path = os.path.join(tmpdir, "global.ini")
             gs = QSettings(ini_path, QSettings.Format.IniFormat)
-            gs.setValue("globaltest/globalonly", 1)
-            gs.setValue("globaltest/both", 10)
+            gs.setValue("plugins/globaltest/globalonly", 1)
+            gs.setValue("plugins/globaltest/both", 10)
             gs.sync()
             del gs
 
@@ -718,7 +718,7 @@ class TestQgsSettingsEntry(QgisTestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             ini_path = os.path.join(tmpdir, "global.ini")
             gs = QSettings(ini_path, QSettings.Format.IniFormat)
-            gs.setValue("globaltest/existskey", "val")
+            gs.setValue("plugins/globaltest/existskey", "val")
             gs.sync()
             del gs
 


### PR DESCRIPTION
Use thread-local QSettings singleton in QgsSettingsEntryBase

Replace per-call `QSettings()` construction with a thread-local `QSettings` pointer that is lazily created per thread.


Current situation:
`QgsSettings` opens the global INI file on every construction. Since most calls create a `QgsSettings` on the stack each time they read a value, this overhead dominates every settings read. `QgsSettingsEntryBase` replaces the global INI with a memory hash (loaded once at startup) and reuses a thread-local `QSettings` for user settings, eliminating both costs.

### Implementation

An `std::atomic<bool>` flag (`sSettingsInitialized`) is set by `initUserSettings()`, called from `QgsUserProfile::initSettings()` after `QSettings::setDefaultFormat(IniFormat)` and `setPath()` have been configured. Each thread checks this flag on its first access and (re-)creates its `QSettings` instance with the correct format and path.

Each thread owns its own `QSettings` instance (`QSettings` is reentrant but not thread-safe for shared instances). The only shared state is a lock-free atomic bool.

### Benchmarks

macOS arm64 (Apple Silicon), 100-key global INI, 100k iterations:

#### Single value read

| Scenario | `QgsSettings` (old) | `QgsSettingsEntry` (new) | Speedup |
|---|--:|--:|--:|
| User key (reused `QgsSettings`) | 246 ns | 254 ns | 1.0x |
| Global key (reused `QgsSettings`) | 302 ns | 267 ns | 1.1x |
| User key (new `QgsSettings` per call) | 12,269 ns | 235 ns | **52x** |
| Global key (new `QgsSettings` per call) | 14,312 ns | 260 ns | **55x** |

#### Construction overhead

| | Time |
|---|--:|
| `QgsSettings()` ctor+dtor | 11,792 ns |
| `QSettings()` ctor+dtor | 9,031 ns |

#### Realistic startup: read 100 keys × 1000 rounds

| Scenario | Time | Per 100 reads |
|---|--:|--:|
| `QgsSettings` (new per read) | 1,265 ms | 1.3 ms |
| `QgsSettings` (reused) | 51 ms | 0.05 ms |
| `QgsSettingsEntry` (new) | 30 ms | 0.03 ms |

The typical pattern in the codebase (new `QgsSettings` per call) is **52–55x faster** with the new implementation. Even against a reused `QgsSettings` instance, `QgsSettingsEntry` is at parity or slightly faster.

AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools must be indicated. Failure to be honest might result in banning.