### PR TITLE
Add feedback argument support for all geos methods

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsgeometryengine.py
+++ b/python/PyQt6/core/auto_additions/qgsgeometryengine.py
@@ -8,7 +8,7 @@ QgsGeometryEngine.InvalidBaseGeometry = QgsGeometryEngine.EngineOperationResult.
 QgsGeometryEngine.InvalidInput = QgsGeometryEngine.EngineOperationResult.InvalidInput
 QgsGeometryEngine.SplitCannotSplitPoint = QgsGeometryEngine.EngineOperationResult.SplitCannotSplitPoint
 try:
-    QgsGeometryEngine.__virtual_methods__ = ['splitGeometry']
+    QgsGeometryEngine.__virtual_methods__ = ['intersection', 'difference', 'symDifference', 'splitGeometry']
     QgsGeometryEngine.__abstract_methods__ = ['geometryChanged', 'prepareGeometry', 'intersection', 'difference', 'combine', 'symDifference', 'buffer', 'simplify', 'interpolate', 'envelope', 'centroid', 'pointOnSurface', 'convexHull', 'distance', 'distanceWithin', 'intersects', 'touches', 'crosses', 'within', 'overlaps', 'contains', 'disjoint', 'relate', 'relatePattern', 'area', 'length', 'isValid', 'isEqual', 'isFuzzyEqual', 'isEmpty', 'isSimple', 'offsetCurve']
     QgsGeometryEngine.__group__ = ['geometry']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometryengine.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometryengine.sip.in
@@ -105,7 +105,9 @@ relation tests against other geometries.
 .. seealso:: :py:func:`geometryChanged`
 %End
 
-    virtual QgsAbstractGeometry *intersection( const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *intersection(
+      const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const = 0 /Factory/;
 %Docstring
 Calculate the intersection of this and ``geom``.
 
@@ -113,9 +115,13 @@ Calculate the intersection of this and ``geom``.
 :param errorMsg: Error message returned by GEOS
 :param parameters: can be used to specify parameters which control the
                    intersection results (since QGIS 3.28)
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 %End
 
-    virtual QgsAbstractGeometry *difference( const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *difference(
+      const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const = 0 /Factory/;
 %Docstring
 Calculate the difference of this and ``geom``.
 
@@ -123,9 +129,11 @@ Calculate the difference of this and ``geom``.
 :param errorMsg: Error message returned by GEOS
 :param parameters: can be used to specify parameters which control the
                    difference results (since QGIS 3.28)
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 %End
 
-    virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0 ) const = 0 /Factory/;
 %Docstring
 Calculate the combination of this and ``geom``.
 
@@ -133,9 +141,13 @@ Calculate the combination of this and ``geom``.
 :param errorMsg: Error message returned by GEOS
 :param parameters: can be used to specify parameters which control the
                    union results (since QGIS 3.28)
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 %End
 
-    virtual QgsAbstractGeometry *combine( const QVector<QgsAbstractGeometry *> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *combine(
+      const QVector<QgsAbstractGeometry *> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const = 0 /Factory/;
 %Docstring
 Calculate the combination of this and ``geometries``.
 
@@ -143,9 +155,11 @@ Calculate the combination of this and ``geometries``.
 :param errorMsg: Error message returned by GEOS
 :param parameters: can be used to specify parameters which control the
                    combination results (since QGIS 3.28)
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 %End
 
-    virtual QgsAbstractGeometry *combine( const QVector< QgsGeometry > &geometries, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *combine( const QVector< QgsGeometry > &geometries, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0 ) const = 0 /Factory/;
 %Docstring
 Calculate the combination of this and ``geometries``.
 
@@ -153,9 +167,13 @@ Calculate the combination of this and ``geometries``.
 :param errorMsg: Error message returned by GEOS
 :param parameters: can be used to specify parameters which control the
                    combination results (since QGIS 3.28)
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 %End
 
-    virtual QgsAbstractGeometry *symDifference( const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *symDifference(
+      const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const = 0 /Factory/;
 %Docstring
 Calculate the symmetric difference of this and ``geom``.
 
@@ -163,93 +181,167 @@ Calculate the symmetric difference of this and ``geom``.
 :param errorMsg: Error message returned by GEOS
 :param parameters: can be used to specify parameters which control the
                    difference results (since QGIS 3.28)
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 %End
-    virtual QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = 0 ) const = 0 /Factory/;
 
-    virtual QgsAbstractGeometry *buffer( double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0 /Factory/;
+%Docstring
+Buffers the geometry.
+
+:param distance: 
+:param segments: 
+:param errorMsg: Error message returned by GEOS
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
+%End
+
+    virtual QgsAbstractGeometry *buffer(
+      double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = 0, QgsFeedback *feedback = 0
+    ) const = 0 /Factory/;
 %Docstring
 Buffers a geometry.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
-    virtual QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = 0 ) const = 0 /Factory/;
-    virtual QgsAbstractGeometry *interpolate( double distance, QString *errorMsg = 0 ) const = 0 /Factory/;
+
+    virtual QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0 /Factory/;
+%Docstring
+Simplifies the geometery.
+
+:param tolerance: 
+:param errorMsg: Error message returned by GEOS
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
+%End
+
+    virtual QgsAbstractGeometry *interpolate( double distance, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0 /Factory/;
+%Docstring
+Interpolates a point by distance along the geometry.
+
+:param distance: 
+:param errorMsg: Error message returned by GEOS
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
+%End
+
     virtual QgsAbstractGeometry *envelope( QString *errorMsg = 0 ) const = 0 /Factory/;
 
-    virtual QgsPoint *centroid( QString *errorMsg = 0 ) const = 0 /Factory/;
+    virtual QgsPoint *centroid( QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0 /Factory/;
 %Docstring
-Calculates the centroid of this. May return a ```None```.
+Calculates the centroid of this. May return ``None``.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual QgsPoint *pointOnSurface( QString *errorMsg = 0 ) const = 0 /Factory/;
+    virtual QgsPoint *pointOnSurface( QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0 /Factory/;
 %Docstring
 Calculate a point that is guaranteed to be on the surface of this. May
-return a ```None```.
+return ``None``.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual QgsAbstractGeometry *convexHull( QString *errorMsg = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *convexHull( QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0 /Factory/;
 %Docstring
-Calculate the convex hull of this.
+Calculate the convex hull of this geometry.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual double distance( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
+    virtual double distance( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Calculates the distance between this and ``geom``.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual bool distanceWithin( const QgsAbstractGeometry *geom, double maxdistance, QString *errorMsg = 0 ) const = 0;
+    virtual bool distanceWithin( const QgsAbstractGeometry *geom, double maxdistance, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Checks if ``geom`` is within ``maxdistance`` distance from this geometry
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 
 .. versionadded:: 3.22
 %End
 
-    virtual bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Checks if ``geom`` intersects this.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Checks if ``geom`` touches this.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Checks if ``geom`` crosses this.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual bool within( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool within( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Checks if ``geom`` is within this.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Checks if ``geom`` overlaps this.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Checks if ``geom`` contains this.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Checks if ``geom`` is disjoint from this.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
+    virtual QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Returns the Dimensional Extended 9 Intersection Model (DE-9IM)
 representation of the relationship between the geometries.
 
 :param geom: geometry to relate to
 :param errorMsg: destination storage for any error message
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: DE-9IM string for relationship, or an empty string if an error
          occurred
 %End
 
-    virtual bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = 0 ) const = 0;
+    virtual bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Tests whether two geometries are related by a specified Dimensional
 Extended 9 Intersection Model (DE-9IM) pattern.
@@ -257,6 +349,8 @@ Extended 9 Intersection Model (DE-9IM) pattern.
 :param geom: geometry to relate to
 :param pattern: DE-9IM pattern for match
 :param errorMsg: destination storage for any error message
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: ``True`` if geometry relationship matches with pattern
 %End
@@ -264,7 +358,7 @@ Extended 9 Intersection Model (DE-9IM) pattern.
     virtual double area( QString *errorMsg = 0 ) const = 0;
     virtual double length( QString *errorMsg = 0 ) const = 0;
 
-    virtual bool isValid( QString *errorMsg = 0, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = 0 ) const = 0;
+    virtual bool isValid( QString *errorMsg = 0, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Returns ``True`` if the geometry is valid.
 
@@ -278,20 +372,25 @@ self-touching holes.
 
 If ``errorLoc`` is specified, it will be set to the geometry of the
 error location.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
-    virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const = 0;
+    virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Check if geometries that are topologically equivalent
 
 :param geom: other geom to compare with
 :param errorMsg: will be set to descriptive error string if the
                  operation fails
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: true if topologically equivalent, else false
 %End
 
-    virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = 0 ) const = 0;
+    virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0;
 %Docstring
 Checks if this is equal to ``geom`` ie. if each vertex of this is within
 the distance tolerance of the corresponding vertex in ``geom``. If both
@@ -302,6 +401,8 @@ are Null geometries, ```False``` is returned.
                 With a near zreo epsilon, this function will behave as
                 an exact comparison.
 :param errorMsg: destination storage for any error message
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: true if fuzzy equivalent, else false
 
@@ -337,9 +438,12 @@ Splits this geometry according to a given line.
            with the split
 %End
 
-    virtual QgsAbstractGeometry *offsetCurve( double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = 0 ) const = 0 /Factory/;
+    virtual QgsAbstractGeometry *offsetCurve( double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const = 0 /Factory/;
 %Docstring
 Offsets a curve.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
     void setLogErrors( bool enabled );

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
@@ -44,12 +44,17 @@ GEOS geometry engine constructor
 
 
 
-    std::unique_ptr< QgsAbstractGeometry > makeValid( Qgis::MakeValidMethod method = Qgis::MakeValidMethod::Linework, bool keepCollapsed = false, QString *errorMsg = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > makeValid(
+      Qgis::MakeValidMethod method = Qgis::MakeValidMethod::Linework, bool keepCollapsed = false, QString *errorMsg = 0, QgsFeedback *feedback = 0
+    ) const;
 %Docstring
 Repairs the geometry using GEOS make valid routine.
 
 The ``method`` and ``keepCollapsed`` arguments require builds based on
 GEOS 3.10 or later.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 
 :raises QgsNotSupportedException: on QGIS builds based on GEOS 3.9 or
                                   earlier when the ``method`` is not
@@ -65,23 +70,29 @@ GEOS 3.10 or later.
     virtual void prepareGeometry();
 
 
-    virtual QgsAbstractGeometry *intersection( const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+     virtual QgsAbstractGeometry *intersection(
+      const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const;
+     virtual QgsAbstractGeometry *difference(
+      const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const;
 
-    virtual QgsAbstractGeometry *difference( const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
-
-
-    std::unique_ptr< QgsAbstractGeometry > clip( const QgsRectangle &rectangle, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > clip( const QgsRectangle &rectangle, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Performs a fast, non-robust intersection between the geometry and a
 ``rectangle``. The returned geometry may be invalid.
 
 :param rectangle: clipping rectangle
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - clipped geometry
          - errorMsg: descriptive error string if the operation fails
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > subdivide( int maxNodes, QString *errorMsg /Out/ = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    std::unique_ptr< QgsAbstractGeometry > subdivide(
+      int maxNodes, QString *errorMsg /Out/ = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const;
 %Docstring
 Subdivides the geometry. The returned geometry will be a collection
 containing subdivided parts from the original geometry, where no part
@@ -99,43 +110,50 @@ Curved geometries are not supported.
 :param maxNodes: Maximum nodes used
 :param parameters: can be used to specify parameters which control the
                    subdivision results (since QGIS 3.28)
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - subdivided geometry
          - errorMsg: descriptive error string if the operation fails
 %End
 
-    virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+     virtual QgsAbstractGeometry *combine(
+      const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const;
+     virtual QgsAbstractGeometry *combine(
+      const QVector<QgsAbstractGeometry *> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const;
+     virtual QgsAbstractGeometry *combine(
+      const QVector< QgsGeometry > &, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const;
+     virtual QgsAbstractGeometry *symDifference(
+      const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0
+    ) const;
+    virtual QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual QgsAbstractGeometry *combine( const QVector<QgsAbstractGeometry *> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
-
-    virtual QgsAbstractGeometry *combine( const QVector< QgsGeometry > &, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
-
-    virtual QgsAbstractGeometry *symDifference( const QgsAbstractGeometry *geom, QString *errorMsg = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
-
-    virtual QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = 0 ) const;
-
-    virtual QgsAbstractGeometry *buffer( double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = 0 ) const;
+     virtual QgsAbstractGeometry *buffer(
+      double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = 0, QgsFeedback *feedback = 0
+    ) const;
 
 
+    virtual QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = 0 ) const;
-
-    virtual QgsAbstractGeometry *interpolate( double distance, QString *errorMsg = 0 ) const;
+    virtual QgsAbstractGeometry *interpolate( double distance, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
     virtual QgsAbstractGeometry *envelope( QString *errorMsg = 0 ) const;
 
-    virtual QgsPoint *centroid( QString *errorMsg = 0 ) const;
+    virtual QgsPoint *centroid( QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual QgsPoint *pointOnSurface( QString *errorMsg = 0 ) const;
+    virtual QgsPoint *pointOnSurface( QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual QgsAbstractGeometry *convexHull( QString *errorMsg = 0 ) const;
+    virtual QgsAbstractGeometry *convexHull( QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual double distance( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+    virtual double distance( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual bool distanceWithin( const QgsAbstractGeometry *geom, double maxdistance, QString *errorMsg = 0 ) const;
+    virtual bool distanceWithin( const QgsAbstractGeometry *geom, double maxdistance, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
 
-    bool contains( double x, double y, QString *errorMsg /Out/ = 0 ) const;
+    bool contains( double x, double y, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns ``True`` if the geometry contains the point at (``x``, ``y``).
 
@@ -144,6 +162,8 @@ This method is more efficient than creating a temporary
 
 :param x: x-coordinate of point to test
 :param y: y-coordinate of point to test
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - ``True`` if the geometry contains the point
          - errorMsg: descriptive error string if the operation fails
@@ -151,7 +171,7 @@ This method is more efficient than creating a temporary
 .. versionadded:: 3.26
 %End
 
-    double distance( double x, double y, QString *errorMsg /Out/ = 0 ) const;
+    double distance( double x, double y, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns the minimum distance from the geometry to the point at (``x``,
 ``y``).
@@ -161,6 +181,8 @@ This method is more efficient than creating a temporary
 
 :param x: x-coordinate of point to test
 :param y: y-coordinate of point to test
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - minimum distance
          - errorMsg: descriptive error string if the operation fails
@@ -168,7 +190,7 @@ This method is more efficient than creating a temporary
 .. versionadded:: 3.26
 %End
 
-    double hausdorffDistance( const QgsAbstractGeometry *geometry, QString *errorMsg /Out/ = 0 ) const;
+    double hausdorffDistance( const QgsAbstractGeometry *geometry, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns the Hausdorff distance between this geometry and another
 ``geometry``. This is basically a measure of how similar or dissimilar 2
@@ -187,6 +209,8 @@ If the default approximate provided by this method is insufficient, use
 :py:func:`~QgsGeos.hausdorffDistanceDensify` instead.
 
 :param geometry: geometry to compare to
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2)
 
 :return: - calculated Hausdorff distance
          - errorMsg: descriptive error string if the operation fails
@@ -194,7 +218,7 @@ If the default approximate provided by this method is insufficient, use
 .. seealso:: :py:func:`hausdorffDistanceDensify`
 %End
 
-    double hausdorffDistanceDensify( const QgsAbstractGeometry *geometry, double densifyFraction, QString *errorMsg /Out/ = 0 ) const;
+    double hausdorffDistanceDensify( const QgsAbstractGeometry *geometry, double densifyFraction, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns the Hausdorff distance between this geometry and another
 ``geometry``. This is basically a measure of how similar or dissimilar 2
@@ -214,6 +238,8 @@ the true Hausdorff distance for the geometries.
 
 :param geometry: geometry to compare to
 :param densifyFraction: fraction by which to densify each segment
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - calculated densified Hausdorff distance
          - errorMsg: descriptive error string if the operation fails
@@ -221,7 +247,7 @@ the true Hausdorff distance for the geometries.
 .. seealso:: :py:func:`hausdorffDistance`
 %End
 
-    double frechetDistance( const QgsAbstractGeometry *geometry, QString *errorMsg /Out/ = 0 ) const;
+    double frechetDistance( const QgsAbstractGeometry *geometry, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns the Fréchet distance between this geometry and another
 ``geometry``, restricted to discrete points for both geometries.
@@ -233,6 +259,8 @@ curves. Therefore it is often better than the Hausdorff distance.
 This method requires a QGIS build based on GEOS 3.7 or later.
 
 :param geometry: geometry to compare to
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - calculated Fréchet distance
          - errorMsg: descriptive error string if the operation fails
@@ -245,7 +273,7 @@ This method requires a QGIS build based on GEOS 3.7 or later.
 .. versionadded:: 3.20
 %End
 
-    double frechetDistanceDensify( const QgsAbstractGeometry *geometry, double densifyFraction, QString *errorMsg /Out/ = 0 ) const;
+    double frechetDistanceDensify( const QgsAbstractGeometry *geometry, double densifyFraction, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns the Fréchet distance between this geometry and another
 ``geometry``, restricted to discrete points for both geometries.
@@ -270,6 +298,8 @@ This method requires a QGIS build based on GEOS 3.7 or later.
 
 :param geometry: geometry to compare to
 :param densifyFraction: fraction by which to densify each segment
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - calculated densified Fréchet distance
          - errorMsg: descriptive error string if the operation fails
@@ -282,34 +312,34 @@ This method requires a QGIS build based on GEOS 3.7 or later.
 .. versionadded:: 3.20
 %End
 
-    virtual bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+    virtual bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+    virtual bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+    virtual bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual bool within( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+    virtual bool within( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+    virtual bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+    virtual bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+    virtual bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+    virtual QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = 0 ) const;
+    virtual bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
     virtual double area( QString *errorMsg = 0 ) const;
 
     virtual double length( QString *errorMsg = 0 ) const;
 
-    virtual bool isValid( QString *errorMsg = 0, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = 0 ) const;
+    virtual bool isValid( QString *errorMsg = 0, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = 0, QgsFeedback *feedback = 0 ) const;
 
 
-    virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = 0 ) const;
+    virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
-    virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = 0 ) const;
+    virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
 
     virtual bool isEmpty( QString *errorMsg = 0 ) const;
@@ -322,10 +352,12 @@ This method requires a QGIS build based on GEOS 3.7 or later.
     ) const;
 
 
-    virtual QgsAbstractGeometry *offsetCurve( double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = 0 ) const;
+    virtual QgsAbstractGeometry *offsetCurve( double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = 0, QgsFeedback *feedback = 0 ) const;
 
 
-    std::unique_ptr< QgsAbstractGeometry > singleSidedBuffer( double distance, int segments, Qgis::BufferSide side, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > singleSidedBuffer(
+      double distance, int segments, Qgis::BufferSide side, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0
+    ) const;
 %Docstring
 Returns a single sided buffer for a geometry. The buffer is only applied
 to one side of the geometry.
@@ -337,13 +369,15 @@ to one side of the geometry.
 :param joinStyle: join style for corners ( Round (1) / Miter (2) / Bevel
                   (3) )
 :param miterLimit: limit on the miter ratio used for very sharp corners
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - buffered geometry, or ``None`` if buffer could not be
            calculated
          - errorMsg: descriptive error string if the operation fails
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > maximumInscribedCircle( double tolerance, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > maximumInscribedCircle( double tolerance, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns the maximum inscribed circle.
 
@@ -367,6 +401,8 @@ other on the boundary of the inscribed circle.
 This method requires a QGIS build based on GEOS 3.9 or later.
 
 :param tolerance: tolerance to determine when iteration should end
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - A two-point linestring geometry, with the first point at the
            center of the inscribed circle and the second on the boundary
@@ -379,7 +415,9 @@ This method requires a QGIS build based on GEOS 3.9 or later.
 .. versionadded:: 3.20
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > largestEmptyCircle( double tolerance, const QgsAbstractGeometry *boundary = 0, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > largestEmptyCircle(
+      double tolerance, const QgsAbstractGeometry *boundary = 0, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0
+    ) const;
 %Docstring
 Constructs the Largest Empty Circle for a set of obstacle geometries, up
 to a specified tolerance.
@@ -401,6 +439,8 @@ This method requires a QGIS build based on GEOS 3.9 or later.
 
 :param tolerance: tolerance to determine when iteration should end
 :param boundary: optional set of boundary obstacles
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - A two-point linestring geometry, with first point at the
            center of the inscribed circle and the second on the boundary
@@ -417,7 +457,7 @@ This method requires a QGIS build based on GEOS 3.9 or later.
 .. versionadded:: 3.20
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > minimumWidth( QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > minimumWidth( QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns a linestring geometry which represents the minimum diameter of
 the geometry.
@@ -429,7 +469,8 @@ the geometry can be moved through, with a single rotation.
 
 This method requires a QGIS build based on GEOS 3.6 or later.
 
-
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - linestring representing the minimum diameter of the geometry
          - errorMsg: descriptive error string if the operation fails
@@ -440,7 +481,7 @@ This method requires a QGIS build based on GEOS 3.6 or later.
 .. versionadded:: 3.20
 %End
 
-    double minimumClearance( QString *errorMsg /Out/ = 0 ) const;
+    double minimumClearance( QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Computes the minimum clearance of a geometry.
 
@@ -460,7 +501,8 @@ If an error occurs while calculating the clearance NaN will be returned.
 
 This method requires a QGIS build based on GEOS 3.6 or later.
 
-
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - calculated minimum clearance of the geometry
          - errorMsg: descriptive error string if the operation fails
@@ -471,7 +513,7 @@ This method requires a QGIS build based on GEOS 3.6 or later.
 .. versionadded:: 3.20
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > minimumClearanceLine( QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > minimumClearanceLine( QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns a LineString whose endpoints define the minimum clearance of a
 geometry.
@@ -481,7 +523,8 @@ returned.
 
 This method requires a QGIS build based on GEOS 3.6 or later.
 
-
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - linestring geometry representing the minimum clearance of the
            geometry
@@ -493,7 +536,7 @@ This method requires a QGIS build based on GEOS 3.6 or later.
 .. versionadded:: 3.20
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > node( QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > node( QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns a (Multi)LineString representing the fully noded version of a
 collection of linestrings.
@@ -504,7 +547,8 @@ possible number of new nodes. The resulting linework is dissolved
 
 The input geometry type should be a (Multi)LineString.
 
-
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - (multi)linestring geometry representing the fully noded
            version of the collection of linestrings
@@ -513,7 +557,7 @@ The input geometry type should be a (Multi)LineString.
 .. versionadded:: 3.20
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > sharedPaths( const QgsAbstractGeometry *other, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > sharedPaths( const QgsAbstractGeometry *other, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Find paths shared between the two given lineal geometries (this and
 ``other``).
@@ -526,6 +570,8 @@ Returns a GeometryCollection having two elements:
   opposite direction on the two inputs
 
 :param other: geometry to compare against
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - shared paths, or ``None`` on exception
          - errorMsg: descriptive error string if the operation fails
@@ -534,12 +580,13 @@ Returns a GeometryCollection having two elements:
 %End
 
 
-    std::unique_ptr< QgsAbstractGeometry > mergeLines( QString *errorMsg /Out/ = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    std::unique_ptr< QgsAbstractGeometry > mergeLines( QString *errorMsg /Out/ = 0, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = 0 ) const;
 %Docstring
 Merges any connected lines in a LineString/MultiLineString geometry and
 converts them to single line strings.
 
-
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - a LineString or MultiLineString geometry, with any connected
            lines joined. An empty geometry will be returned if the input
@@ -549,11 +596,13 @@ converts them to single line strings.
            control the mergeLines results (since QGIS 3.44)
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > closestPoint( const QgsGeometry &other, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > closestPoint( const QgsGeometry &other, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns the closest point on the geometry to the other geometry.
 
 :param other: geometry to compare against
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - closest point
          - errorMsg: descriptive error string if the operation fails
@@ -561,11 +610,13 @@ Returns the closest point on the geometry to the other geometry.
 .. seealso:: :py:func:`shortestLine`
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > shortestLine( const QgsGeometry &other, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > shortestLine( const QgsGeometry &other, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns the shortest line joining this geometry to the other geometry.
 
 :param other: geometry to compare against
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - shortest line joining this geometry to the other geometry
          - errorMsg: descriptive error string if the operation fails
@@ -573,11 +624,13 @@ Returns the shortest line joining this geometry to the other geometry.
 .. seealso:: :py:func:`closestPoint`
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > shortestLine( const QgsAbstractGeometry *other, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > shortestLine( const QgsAbstractGeometry *other, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns the shortest line joining this geometry to the other geometry.
 
 :param other: geometry to compare against
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - shortest line joining this geometry to the other geometry
          - errorMsg: descriptive error string if the operation fails
@@ -587,7 +640,7 @@ Returns the shortest line joining this geometry to the other geometry.
 .. versionadded:: 3.20
 %End
 
-    double lineLocatePoint( const QgsPoint &point, QString *errorMsg /Out/ = 0 ) const;
+    double lineLocatePoint( const QgsPoint &point, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns a distance representing the location along this linestring of
 the closest point on this linestring geometry to the specified point.
@@ -596,6 +649,8 @@ to traverse to get to the closest location where this linestring comes
 to the specified point.
 
 :param point: point to seek proximity to
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - distance along line, or -1 on error
          - errorMsg: descriptive error string if the operation fails
@@ -605,7 +660,7 @@ to the specified point.
    only valid for linestring geometries
 %End
 
-    double lineLocatePoint( double x, double y, QString *errorMsg /Out/ = 0 ) const;
+    double lineLocatePoint( double x, double y, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns a distance representing the location along this linestring of
 the closest point on this linestring geometry to the point at (``x``,
@@ -618,6 +673,8 @@ This method is more efficient than creating a temporary
 
 :param x: x-coordinate of point to locate
 :param y: y-coordinate of point to locate
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - distance along line, or -1 on error
          - errorMsg: descriptive error string if the operation fails
@@ -630,7 +687,9 @@ This method is more efficient than creating a temporary
 %End
 
 
-    std::unique_ptr< QgsAbstractGeometry > voronoiDiagram( const QgsAbstractGeometry *extent = 0, double tolerance = 0.0, bool edgesOnly = false, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > voronoiDiagram(
+      const QgsAbstractGeometry *extent = 0, double tolerance = 0.0, bool edgesOnly = false, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0
+    ) const;
 %Docstring
 Creates a Voronoi diagram for the nodes contained within the geometry.
 
@@ -648,12 +707,14 @@ empty geometry will be returned if the diagram could not be calculated.
 :param extent: optional clipping envelope for the diagram
 :param tolerance: 
 :param edgesOnly: 
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - Voronoi diagram
          - errorMsg: descriptive error string if the operation fails
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > delaunayTriangulation( double tolerance = 0.0, bool edgesOnly = false, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > delaunayTriangulation( double tolerance = 0.0, bool edgesOnly = false, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns the Delaunay triangulation for the vertices of the geometry. The
 ``tolerance`` parameter specifies an optional snapping tolerance which
@@ -664,6 +725,8 @@ diagram could not be calculated.
 
 :param tolerance: 
 :param edgesOnly: 
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - Delaunay triangulation
          - errorMsg: descriptive error string if the operation fails
@@ -671,7 +734,7 @@ diagram could not be calculated.
 .. seealso:: :py:func:`constrainedDelaunayTriangulation`
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > constrainedDelaunayTriangulation( QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > constrainedDelaunayTriangulation( QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Returns a constrained Delaunay triangulation for the vertices of the
 geometry.
@@ -681,7 +744,8 @@ calculated.
 
 This method requires a QGIS build based on GEOS 3.11 or later.
 
-
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - constrained Delaunay triangulation
          - errorMsg: descriptive error string if the operation fails
@@ -734,7 +798,7 @@ This method requires a QGIS build based on GEOS 3.11 or later.
 %End
 
 
-    std::unique_ptr< QgsAbstractGeometry > simplifyCoverageVW( double tolerance, bool preserveBoundary, QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > simplifyCoverageVW( double tolerance, bool preserveBoundary, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Operates on a coverage (represented as a list of polygonal geometry with
 exactly matching edge geometry) to apply a Visvalingam–Whyatt
@@ -754,6 +818,8 @@ still be invalid.
 :param preserveBoundary: Set to ``True`` to preserve the outside edges
                          of the coverage without simplification, or
                          ``False`` to allow them to be simplified.
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - simplified coverage
          - errorMsg: descriptive error string if the operation fails
@@ -768,7 +834,7 @@ This method requires a QGIS build based on GEOS 3.12 or later.
 .. versionadded:: 3.36
 %End
 
-    std::unique_ptr< QgsAbstractGeometry > unionCoverage( QString *errorMsg /Out/ = 0 ) const;
+    std::unique_ptr< QgsAbstractGeometry > unionCoverage( QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0 ) const;
 %Docstring
 Optimized union algorithm for polygonal inputs that are correctly noded
 and do not overlap. It may generate an error (returns ``None``) for
@@ -778,7 +844,8 @@ guaranteed.
 The input geometry is the polygonal coverage to union, stored in a
 geometry collection. All members must be POLYGON or MULTIPOLYGON.
 
-
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: - unioned coverage
          - errorMsg: descriptive error string if the operation fails

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -27,6 +27,7 @@ email                : marco.hugentobler at sourcepole dot com
 using namespace Qt::StringLiterals;
 
 class QgsAbstractGeometry;
+class QgsFeedback;
 
 #ifdef SIP_RUN
 // clang-format off
@@ -130,9 +131,12 @@ class QgsAbstractGeometry;
      * \param geom geometry to perform the operation
      * \param errorMsg Error message returned by GEOS
      * \param parameters can be used to specify parameters which control the intersection results (since QGIS 3.28)
-     *
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      */
-    virtual QgsAbstractGeometry *intersection( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *intersection(
+      const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const
+      = 0 SIP_FACTORY;
 
     /**
      * Calculate the difference of this and \a geom.
@@ -140,9 +144,12 @@ class QgsAbstractGeometry;
      * \param geom geometry to perform the operation
      * \param errorMsg Error message returned by GEOS
      * \param parameters can be used to specify parameters which control the difference results (since QGIS 3.28)
-     *
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      */
-    virtual QgsAbstractGeometry *difference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *difference(
+      const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const
+      = 0 SIP_FACTORY;
 
     /**
      * Calculate the combination of this and \a geom.
@@ -150,10 +157,11 @@ class QgsAbstractGeometry;
      * \param geom geometry to perform the operation
      * \param errorMsg Error message returned by GEOS
      * \param parameters can be used to specify parameters which control the union results (since QGIS 3.28)
-     *
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      */
-    virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr ) const
+      = 0 SIP_FACTORY;
 
     /**
      * Calculate the combination of this and \a geometries.
@@ -161,10 +169,13 @@ class QgsAbstractGeometry;
      * \param geomList list of geometries to perform the operation
      * \param errorMsg Error message returned by GEOS
      * \param parameters can be used to specify parameters which control the combination results (since QGIS 3.28)
-     *
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      */
-    virtual QgsAbstractGeometry *combine( const QVector<QgsAbstractGeometry *> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *combine(
+      const QVector<QgsAbstractGeometry *> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const
+      = 0 SIP_FACTORY;
 
     // clang-format off
     /**
@@ -173,9 +184,9 @@ class QgsAbstractGeometry;
      * \param geometries list of geometries to perform the operation
      * \param errorMsg Error message returned by GEOS
      * \param parameters can be used to specify parameters which control the combination results (since QGIS 3.28)
-     *
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      */
-    virtual QgsAbstractGeometry *combine( const QVector< QgsGeometry > &geometries, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *combine( const QVector< QgsGeometry > &geometries, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr ) const = 0 SIP_FACTORY;
     // clang-format on
 
     /**
@@ -184,102 +195,151 @@ class QgsAbstractGeometry;
      * \param geom geometry to perform the operation
      * \param errorMsg Error message returned by GEOS
      * \param parameters can be used to specify parameters which control the difference results (since QGIS 3.28)
-     *
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      */
-    virtual QgsAbstractGeometry *symDifference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const = 0 SIP_FACTORY;
-    virtual QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *symDifference(
+      const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const
+      = 0 SIP_FACTORY;
+
+    /**
+     * Buffers the geometry.
+     * \param distance
+     * \param segments
+     * \param errorMsg Error message returned by GEOS
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
+     */
+    virtual QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0 SIP_FACTORY;
 
     /**
      * Buffers a geometry.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual QgsAbstractGeometry *buffer( double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
-    virtual QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
-    virtual QgsAbstractGeometry *interpolate( double distance, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *buffer(
+      double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr
+    ) const
+      = 0 SIP_FACTORY;
+
+    /**
+     * Simplifies the geometery.
+     * \param tolerance
+     * \param errorMsg Error message returned by GEOS
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
+     */
+    virtual QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0 SIP_FACTORY;
+
+    /**
+     * Interpolates a point by distance along the geometry.
+     *
+     * \param distance
+     * \param errorMsg Error message returned by GEOS
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
+     */
+    virtual QgsAbstractGeometry *interpolate( double distance, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0 SIP_FACTORY;
+
     virtual QgsAbstractGeometry *envelope( QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
 
     /**
      * Calculates the centroid of this.
-     * May return a `NULLPTR`.
+     * May return NULLPTR.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      *
      */
-    virtual QgsPoint *centroid( QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsPoint *centroid( QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0 SIP_FACTORY;
 
     /**
      * Calculate a point that is guaranteed to be on the surface of this.
-     * May return a `NULLPTR`.
+     * May return NULLPTR.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual QgsPoint *pointOnSurface( QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsPoint *pointOnSurface( QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0 SIP_FACTORY;
 
     /**
-     * Calculate the convex hull of this.
+     * Calculate the convex hull of this geometry.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual QgsAbstractGeometry *convexHull( QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *convexHull( QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0 SIP_FACTORY;
 
     /**
      * Calculates the distance between this and \a geom.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual double distance( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual double distance( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Checks if \a geom is within \a maxdistance distance from this geometry
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
+     *
      * \since QGIS 3.22
      */
-    virtual bool distanceWithin( const QgsAbstractGeometry *geom, double maxdistance, QString *errorMsg = nullptr ) const = 0;
+    virtual bool distanceWithin( const QgsAbstractGeometry *geom, double maxdistance, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Checks if \a geom intersects this.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Checks if \a geom touches this.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Checks if \a geom crosses this.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Checks if \a geom is within this.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual bool within( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool within( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Checks if \a geom overlaps this.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Checks if \a geom contains this.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Checks if \a geom is disjoint from this.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Returns the Dimensional Extended 9 Intersection Model (DE-9IM) representation of the
      * relationship between the geometries.
      * \param geom geometry to relate to
      * \param errorMsg destination storage for any error message
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
+     *
      * \returns DE-9IM string for relationship, or an empty string if an error occurred
      */
-    virtual QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Tests whether two geometries are related by a specified Dimensional Extended 9 Intersection Model (DE-9IM)
@@ -287,9 +347,10 @@ class QgsAbstractGeometry;
      * \param geom geometry to relate to
      * \param pattern DE-9IM pattern for match
      * \param errorMsg destination storage for any error message
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      * \returns TRUE if geometry relationship matches with pattern
      */
-    virtual bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = nullptr ) const = 0;
+    virtual bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     virtual double area( QString *errorMsg = nullptr ) const = 0;
     virtual double length( QString *errorMsg = nullptr ) const = 0;
@@ -304,16 +365,19 @@ class QgsAbstractGeometry;
      * validity checks (e.g. ESRI) permit self-touching holes.
      *
      * If \a errorLoc is specified, it will be set to the geometry of the error location.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual bool isValid( QString *errorMsg = nullptr, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = nullptr ) const = 0;
+    virtual bool isValid( QString *errorMsg = nullptr, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Check if geometries that are topologically equivalent
      * \param geom other geom to compare with
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      * \return true if topologically equivalent, else false
      */
-    virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const = 0;
+    virtual bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     /**
      * Checks if this is equal to \a geom ie. if each vertex of this is within the distance tolerance of the corresponding vertex in \a geom.
@@ -321,10 +385,11 @@ class QgsAbstractGeometry;
      * \param geom geometry to compare with
      * \param epsilon maximum difference for coordinates between the objects. With a near zreo epsilon, this function will behave as an exact comparison.
      * \param errorMsg destination storage for any error message
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      * \return true if fuzzy equivalent, else false
      * \since QGIS 4.2
      */
-    virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = nullptr ) const = 0;
+    virtual bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0;
 
     virtual bool isEmpty( QString *errorMsg ) const = 0;
 
@@ -359,8 +424,11 @@ class QgsAbstractGeometry;
 
     /**
      * Offsets a curve.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    virtual QgsAbstractGeometry *offsetCurve( double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsAbstractGeometry *offsetCurve( double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const = 0
+      SIP_FACTORY;
 
     /**
      * Sets whether warnings and errors encountered during the geometry operations should be logged.

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -199,7 +199,7 @@ QgsGeometry QgsGeos::geometryFromGeos( const geos::unique_ptr &geos )
   return g;
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::makeValid( Qgis::MakeValidMethod method, bool keepCollapsed, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::makeValid( Qgis::MakeValidMethod method, bool keepCollapsed, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -223,6 +223,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::makeValid( Qgis::MakeValidMethod m
 #else
 
   GEOSMakeValidParams *params = GEOSMakeValidParams_create_r( context );
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   switch ( method )
   {
     case Qgis::MakeValidMethod::Linework:
@@ -316,17 +317,17 @@ void QgsGeos::cacheGeos( Qgis::GeosCreationFlags flags ) const
   mGeos = asGeos( mGeometry, mPrecision, flags );
 }
 
-QgsAbstractGeometry *QgsGeos::intersection( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters ) const
+QgsAbstractGeometry *QgsGeos::intersection( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
-  return overlay( geom, OverlayIntersection, errorMsg, parameters ).release();
+  return overlay( geom, OverlayIntersection, errorMsg, parameters, feedback ).release();
 }
 
-QgsAbstractGeometry *QgsGeos::difference( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters ) const
+QgsAbstractGeometry *QgsGeos::difference( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
-  return overlay( geom, OverlayDifference, errorMsg, parameters ).release();
+  return overlay( geom, OverlayDifference, errorMsg, parameters, feedback ).release();
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::clip( const QgsRectangle &rect, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::clip( const QgsRectangle &rect, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos || rect.isNull() || rect.isEmpty() )
   {
@@ -335,6 +336,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::clip( const QgsRectangle &rect, QS
 
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos::unique_ptr opGeom( GEOSClipByRect_r( QgsGeosContext::get(), mGeos.get(), rect.xMinimum(), rect.yMinimum(), rect.xMaximum(), rect.yMaximum() ) );
     return fromGeos( opGeom.get() );
   }
@@ -447,7 +449,7 @@ void QgsGeos::subdivideRecursive( const GEOSGeometry *currentPart, int maxNodes,
   }
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::subdivide( int maxNodes, QString *errorMsg, const QgsGeometryParameters &parameters ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::subdivide( int maxNodes, QString *errorMsg, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -460,6 +462,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::subdivide( int maxNodes, QString *
   std::unique_ptr< QgsGeometryCollection > parts = QgsGeometryFactory::createCollectionOfType( mGeometry->wkbType() );
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     subdivideRecursive( mGeos.get(), maxNodes, 0, parts.get(), mGeometry->boundingBox(), parameters.gridSize() );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
@@ -467,12 +470,12 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::subdivide( int maxNodes, QString *
   return std::move( parts );
 }
 
-QgsAbstractGeometry *QgsGeos::combine( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters ) const
+QgsAbstractGeometry *QgsGeos::combine( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
-  return overlay( geom, OverlayUnion, errorMsg, parameters ).release();
+  return overlay( geom, OverlayUnion, errorMsg, parameters, feedback ).release();
 }
 
-QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsAbstractGeometry *> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters ) const
+QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsAbstractGeometry *> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
   std::vector<geos::unique_ptr> geosGeometries;
   geosGeometries.reserve( geomList.size() );
@@ -485,6 +488,7 @@ QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsAbstractGeometry *> &geo
   }
 
   GEOSContextHandle_t context = QgsGeosContext::get();
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   geos::unique_ptr geomUnion;
   try
   {
@@ -504,7 +508,7 @@ QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsAbstractGeometry *> &geo
   return result.release();
 }
 
-QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsGeometry> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters ) const
+QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsGeometry> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
   std::vector<geos::unique_ptr> geosGeometries;
   geosGeometries.reserve( geomList.size() );
@@ -517,6 +521,7 @@ QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsGeometry> &geomList, QSt
   }
 
   GEOSContextHandle_t context = QgsGeosContext::get();
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   geos::unique_ptr geomUnion;
   try
   {
@@ -537,9 +542,9 @@ QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsGeometry> &geomList, QSt
   return result.release();
 }
 
-QgsAbstractGeometry *QgsGeos::symDifference( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters ) const
+QgsAbstractGeometry *QgsGeos::symDifference( const QgsAbstractGeometry *geom, QString *errorMsg, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
-  return overlay( geom, OverlaySymDifference, errorMsg, parameters ).release();
+  return overlay( geom, OverlaySymDifference, errorMsg, parameters, feedback ).release();
 }
 
 static bool isZVerticalLine( const QgsAbstractGeometry *geom, double tolerance = 4 * std::numeric_limits<double>::epsilon() )
@@ -579,7 +584,7 @@ static bool isZVerticalLine( const QgsAbstractGeometry *geom, double tolerance =
   return isVertical;
 }
 
-double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
   double distance = -1.0;
   if ( !mGeos )
@@ -588,6 +593,7 @@ double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg ) c
   }
 
   geos::unique_ptr otherGeosGeom;
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
 
   // GEOSPreparedDistance_r is not able to properly compute the distance if one
   // of the geometries if a vertical line (LineString Z((X Y Z1, X Y Z2, ..., X Y Zn))).
@@ -625,7 +631,7 @@ double QgsGeos::distance( const QgsAbstractGeometry *geom, QString *errorMsg ) c
   return distance;
 }
 
-double QgsGeos::distance( double x, double y, QString *errorMsg ) const
+double QgsGeos::distance( double x, double y, QString *errorMsg, QgsFeedback *feedback ) const
 {
   double distance = -1.0;
   if ( !mGeos )
@@ -633,6 +639,7 @@ double QgsGeos::distance( double x, double y, QString *errorMsg ) const
     return distance;
   }
 
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   geos::unique_ptr point = createGeosPointXY( x, y, false, 0, false, 0, 2, 0 );
   if ( !point )
     return distance;
@@ -654,7 +661,7 @@ double QgsGeos::distance( double x, double y, QString *errorMsg ) const
   return distance;
 }
 
-bool QgsGeos::distanceWithin( const QgsAbstractGeometry *geom, double maxdist, QString *errorMsg ) const
+bool QgsGeos::distanceWithin( const QgsAbstractGeometry *geom, double maxdist, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -663,7 +670,7 @@ bool QgsGeos::distanceWithin( const QgsAbstractGeometry *geom, double maxdist, Q
 
   if ( qgsDoubleNear( maxdist, 0.0 ) )
   {
-    return intersects( geom, errorMsg );
+    return intersects( geom, errorMsg, feedback );
   }
 
   geos::unique_ptr otherGeosGeom;
@@ -693,6 +700,7 @@ bool QgsGeos::distanceWithin( const QgsAbstractGeometry *geom, double maxdist, Q
   double distance;
 
   GEOSContextHandle_t context = QgsGeosContext::get();
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   try
   {
     if ( mGeosPrepared && !isZVerticalLine( mGeometry->simplifiedTypeRef() ) )
@@ -717,10 +725,11 @@ bool QgsGeos::distanceWithin( const QgsAbstractGeometry *geom, double maxdist, Q
   return distance <= maxdist;
 }
 
-bool QgsGeos::contains( double x, double y, QString *errorMsg ) const
+bool QgsGeos::contains( double x, double y, QString *errorMsg, QgsFeedback *feedback ) const
 {
   bool result = false;
   GEOSContextHandle_t context = QgsGeosContext::get();
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   try
   {
 #if GEOS_VERSION_MAJOR > 3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR >= 12 )
@@ -760,7 +769,7 @@ bool QgsGeos::contains( double x, double y, QString *errorMsg ) const
   return result;
 }
 
-double QgsGeos::hausdorffDistance( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+double QgsGeos::hausdorffDistance( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
   double distance = -1.0;
   if ( !mGeos )
@@ -768,6 +777,7 @@ double QgsGeos::hausdorffDistance( const QgsAbstractGeometry *geom, QString *err
     return distance;
   }
 
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   geos::unique_ptr otherGeosGeom( asGeos( geom, mPrecision ) );
   if ( !otherGeosGeom )
   {
@@ -783,7 +793,7 @@ double QgsGeos::hausdorffDistance( const QgsAbstractGeometry *geom, QString *err
   return distance;
 }
 
-double QgsGeos::hausdorffDistanceDensify( const QgsAbstractGeometry *geom, double densifyFraction, QString *errorMsg ) const
+double QgsGeos::hausdorffDistanceDensify( const QgsAbstractGeometry *geom, double densifyFraction, QString *errorMsg, QgsFeedback *feedback ) const
 {
   double distance = -1.0;
   if ( !mGeos )
@@ -791,6 +801,7 @@ double QgsGeos::hausdorffDistanceDensify( const QgsAbstractGeometry *geom, doubl
     return distance;
   }
 
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   geos::unique_ptr otherGeosGeom( asGeos( geom, mPrecision ) );
   if ( !otherGeosGeom )
   {
@@ -806,7 +817,7 @@ double QgsGeos::hausdorffDistanceDensify( const QgsAbstractGeometry *geom, doubl
   return distance;
 }
 
-double QgsGeos::frechetDistance( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+double QgsGeos::frechetDistance( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
   double distance = -1.0;
   if ( !mGeos )
@@ -814,6 +825,7 @@ double QgsGeos::frechetDistance( const QgsAbstractGeometry *geom, QString *error
     return distance;
   }
 
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   geos::unique_ptr otherGeosGeom( asGeos( geom, mPrecision ) );
   if ( !otherGeosGeom )
   {
@@ -829,7 +841,7 @@ double QgsGeos::frechetDistance( const QgsAbstractGeometry *geom, QString *error
   return distance;
 }
 
-double QgsGeos::frechetDistanceDensify( const QgsAbstractGeometry *geom, double densifyFraction, QString *errorMsg ) const
+double QgsGeos::frechetDistanceDensify( const QgsAbstractGeometry *geom, double densifyFraction, QString *errorMsg, QgsFeedback *feedback ) const
 {
   double distance = -1.0;
   if ( !mGeos )
@@ -837,6 +849,7 @@ double QgsGeos::frechetDistanceDensify( const QgsAbstractGeometry *geom, double 
     return distance;
   }
 
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   geos::unique_ptr otherGeosGeom( asGeos( geom, mPrecision ) );
   if ( !otherGeosGeom )
   {
@@ -852,13 +865,14 @@ double QgsGeos::frechetDistanceDensify( const QgsAbstractGeometry *geom, double 
   return distance;
 }
 
-bool QgsGeos::intersects( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+bool QgsGeos::intersects( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos || !geom )
   {
     return false;
   }
 
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
 #if GEOS_VERSION_MAJOR > 3 || ( GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR >= 12 )
   // special optimised case for point intersects
   if ( const QgsPoint *point = qgsgeometry_cast< const QgsPoint * >( geom->simplifiedTypeRef() ) )
@@ -885,27 +899,27 @@ bool QgsGeos::intersects( const QgsAbstractGeometry *geom, QString *errorMsg ) c
   return relation( geom, RelationIntersects, errorMsg );
 }
 
-bool QgsGeos::touches( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+bool QgsGeos::touches( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
-  return relation( geom, RelationTouches, errorMsg );
+  return relation( geom, RelationTouches, errorMsg, feedback );
 }
 
-bool QgsGeos::crosses( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+bool QgsGeos::crosses( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
-  return relation( geom, RelationCrosses, errorMsg );
+  return relation( geom, RelationCrosses, errorMsg, feedback );
 }
 
-bool QgsGeos::within( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+bool QgsGeos::within( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
-  return relation( geom, RelationWithin, errorMsg );
+  return relation( geom, RelationWithin, errorMsg, feedback );
 }
 
-bool QgsGeos::overlaps( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+bool QgsGeos::overlaps( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
-  return relation( geom, RelationOverlaps, errorMsg );
+  return relation( geom, RelationOverlaps, errorMsg, feedback );
 }
 
-bool QgsGeos::contains( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+bool QgsGeos::contains( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos || !geom )
   {
@@ -916,6 +930,7 @@ bool QgsGeos::contains( const QgsAbstractGeometry *geom, QString *errorMsg ) con
   // special optimised case for point containment
   if ( const QgsPoint *point = qgsgeometry_cast< const QgsPoint * >( geom->simplifiedTypeRef() ) )
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     if ( mGeosPrepared )
     {
       try
@@ -935,15 +950,15 @@ bool QgsGeos::contains( const QgsAbstractGeometry *geom, QString *errorMsg ) con
   }
 #endif
 
-  return relation( geom, RelationContains, errorMsg );
+  return relation( geom, RelationContains, errorMsg, feedback );
 }
 
-bool QgsGeos::disjoint( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+bool QgsGeos::disjoint( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
-  return relation( geom, RelationDisjoint, errorMsg );
+  return relation( geom, RelationDisjoint, errorMsg, feedback );
 }
 
-QString QgsGeos::relate( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+QString QgsGeos::relate( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -958,6 +973,7 @@ QString QgsGeos::relate( const QgsAbstractGeometry *geom, QString *errorMsg ) co
 
   QString result;
   GEOSContextHandle_t context = QgsGeosContext::get();
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   try
   {
     char *r = GEOSRelate_r( context, mGeos.get(), geosGeom.get() );
@@ -979,7 +995,7 @@ QString QgsGeos::relate( const QgsAbstractGeometry *geom, QString *errorMsg ) co
   return result;
 }
 
-bool QgsGeos::relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg ) const
+bool QgsGeos::relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos || !geom )
   {
@@ -994,6 +1010,8 @@ bool QgsGeos::relatePattern( const QgsAbstractGeometry *geom, const QString &pat
 
   bool result = false;
   GEOSContextHandle_t context = QgsGeosContext::get();
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
+
   try
   {
     result = ( GEOSRelatePattern_r( context, mGeos.get(), geosGeom.get(), pattern.toLocal8Bit().constData() ) == 1 );
@@ -1905,7 +1923,7 @@ geos::unique_ptr QgsGeos::asGeos( const QgsAbstractGeometry *geom, double precis
   return nullptr;
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg, const QgsGeometryParameters &parameters ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
   if ( !mGeos || !geom )
   {
@@ -1917,6 +1935,8 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry
   {
     return nullptr;
   }
+
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
 
   const double gridSize = parameters.gridSize();
 
@@ -1997,7 +2017,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::overlay( const QgsAbstractGeometry
   }
 }
 
-bool QgsGeos::relation( const QgsAbstractGeometry *geom, Relation r, QString *errorMsg ) const
+bool QgsGeos::relation( const QgsAbstractGeometry *geom, Relation r, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos || !geom )
   {
@@ -2011,6 +2031,8 @@ bool QgsGeos::relation( const QgsAbstractGeometry *geom, Relation r, QString *er
   }
 
   GEOSContextHandle_t context = QgsGeosContext::get();
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
+
   bool result = false;
   try
   {
@@ -2081,7 +2103,7 @@ bool QgsGeos::relation( const QgsAbstractGeometry *geom, Relation r, QString *er
   return result;
 }
 
-QgsAbstractGeometry *QgsGeos::buffer( double distance, int segments, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::buffer( double distance, int segments, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2091,19 +2113,23 @@ QgsAbstractGeometry *QgsGeos::buffer( double distance, int segments, QString *er
   geos::unique_ptr geos;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
+
     geos.reset( GEOSBuffer_r( QgsGeosContext::get(), mGeos.get(), distance, segments ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() ).release();
 }
 
-QgsAbstractGeometry *QgsGeos::buffer( double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::buffer( double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg, QgsFeedback *feedback ) const
 {
-  geos::unique_ptr geos = buffer( mGeos.get(), distance, segments, endCapStyle, joinStyle, miterLimit, errorMsg );
+  geos::unique_ptr geos = buffer( mGeos.get(), distance, segments, endCapStyle, joinStyle, miterLimit, errorMsg, feedback );
   return fromGeos( geos.get() ).release();
 }
 
-geos::unique_ptr QgsGeos::buffer( const GEOSGeometry *geometry, double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg )
+geos::unique_ptr QgsGeos::buffer(
+  const GEOSGeometry *geometry, double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg, QgsFeedback *feedback
+)
 {
   if ( !geometry )
   {
@@ -2113,13 +2139,14 @@ geos::unique_ptr QgsGeos::buffer( const GEOSGeometry *geometry, double distance,
   geos::unique_ptr geos;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSBufferWithStyle_r( QgsGeosContext::get(), geometry, distance, segments, static_cast< int >( endCapStyle ), static_cast< int >( joinStyle ), miterLimit ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return geos;
 }
 
-QgsAbstractGeometry *QgsGeos::simplify( double tolerance, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::simplify( double tolerance, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2128,13 +2155,14 @@ QgsAbstractGeometry *QgsGeos::simplify( double tolerance, QString *errorMsg ) co
   geos::unique_ptr geos;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSTopologyPreserveSimplify_r( QgsGeosContext::get(), mGeos.get(), tolerance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() ).release();
 }
 
-QgsAbstractGeometry *QgsGeos::interpolate( double distance, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::interpolate( double distance, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2143,13 +2171,14 @@ QgsAbstractGeometry *QgsGeos::interpolate( double distance, QString *errorMsg ) 
   geos::unique_ptr geos;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSInterpolate_r( QgsGeosContext::get(), mGeos.get(), distance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() ).release();
 }
 
-QgsPoint *QgsGeos::centroid( QString *errorMsg ) const
+QgsPoint *QgsGeos::centroid( QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2163,6 +2192,7 @@ QgsPoint *QgsGeos::centroid( QString *errorMsg ) const
   GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSGetCentroid_r( context, mGeos.get() ) );
 
     if ( !geos )
@@ -2191,7 +2221,7 @@ QgsAbstractGeometry *QgsGeos::envelope( QString *errorMsg ) const
   return fromGeos( geos.get() ).release();
 }
 
-QgsPoint *QgsGeos::pointOnSurface( QString *errorMsg ) const
+QgsPoint *QgsGeos::pointOnSurface( QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2205,6 +2235,7 @@ QgsPoint *QgsGeos::pointOnSurface( QString *errorMsg ) const
   geos::unique_ptr geos;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSPointOnSurface_r( context, mGeos.get() ) );
 
     if ( !geos || GEOSisEmpty_r( context, geos.get() ) != 0 )
@@ -2220,7 +2251,7 @@ QgsPoint *QgsGeos::pointOnSurface( QString *errorMsg ) const
   return new QgsPoint( x, y );
 }
 
-QgsAbstractGeometry *QgsGeos::convexHull( QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::convexHull( QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2229,6 +2260,7 @@ QgsAbstractGeometry *QgsGeos::convexHull( QString *errorMsg ) const
 
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos::unique_ptr cHull( GEOSConvexHull_r( QgsGeosContext::get(), mGeos.get() ) );
     std::unique_ptr< QgsAbstractGeometry > cHullGeom = fromGeos( cHull.get() );
     return cHullGeom.release();
@@ -2260,7 +2292,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsGeos::concaveHull( double targetPercen
 #endif
 }
 
-Qgis::CoverageValidityResult QgsGeos::validateCoverage( double gapWidth, std::unique_ptr<QgsAbstractGeometry> *invalidEdges, QString *errorMsg ) const
+Qgis::CoverageValidityResult QgsGeos::validateCoverage( double gapWidth, std::unique_ptr<QgsAbstractGeometry> *invalidEdges, QString *errorMsg, QgsFeedback *feedback ) const
 {
 #if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 12
   ( void ) gapWidth;
@@ -2275,6 +2307,7 @@ Qgis::CoverageValidityResult QgsGeos::validateCoverage( double gapWidth, std::un
     return Qgis::CoverageValidityResult::Error;
   }
 
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
@@ -2305,7 +2338,7 @@ Qgis::CoverageValidityResult QgsGeos::validateCoverage( double gapWidth, std::un
 #endif
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::simplifyCoverageVW( double tolerance, bool preserveBoundary, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::simplifyCoverageVW( double tolerance, bool preserveBoundary, QString *errorMsg, QgsFeedback *feedback ) const
 {
 #if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 12
   ( void ) tolerance;
@@ -2322,6 +2355,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::simplifyCoverageVW( double toleran
 
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos::unique_ptr simplified( GEOSCoverageSimplifyVW_r( QgsGeosContext::get(), mGeos.get(), tolerance, preserveBoundary ? 1 : 0 ) );
     std::unique_ptr< QgsAbstractGeometry > simplifiedGeom = fromGeos( simplified.get() );
     return simplifiedGeom;
@@ -2330,7 +2364,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::simplifyCoverageVW( double toleran
 #endif
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::unionCoverage( QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::unionCoverage( QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2341,6 +2375,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::unionCoverage( QString *errorMsg )
 
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos::unique_ptr unioned( GEOSCoverageUnion_r( QgsGeosContext::get(), mGeos.get() ) );
     std::unique_ptr< QgsAbstractGeometry > result = fromGeos( unioned.get() );
     return result;
@@ -2348,7 +2383,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::unionCoverage( QString *errorMsg )
   CATCH_GEOS_WITH_ERRMSG( nullptr )
 }
 
-bool QgsGeos::isValid( QString *errorMsg, const bool allowSelfTouchingHoles, QgsGeometry *errorLoc ) const
+bool QgsGeos::isValid( QString *errorMsg, const bool allowSelfTouchingHoles, QgsGeometry *errorLoc, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2358,6 +2393,8 @@ bool QgsGeos::isValid( QString *errorMsg, const bool allowSelfTouchingHoles, Qgs
   }
 
   GEOSContextHandle_t context = QgsGeosContext::get();
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
+
   try
   {
     GEOSGeometry *g1 = nullptr;
@@ -2410,7 +2447,7 @@ bool QgsGeos::isValid( QString *errorMsg, const bool allowSelfTouchingHoles, Qgs
   CATCH_GEOS_WITH_ERRMSG( false )
 }
 
-bool QgsGeos::isEqual( const QgsAbstractGeometry *geom, QString *errorMsg ) const
+bool QgsGeos::isEqual( const QgsAbstractGeometry *geom, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos || !geom )
   {
@@ -2419,6 +2456,7 @@ bool QgsGeos::isEqual( const QgsAbstractGeometry *geom, QString *errorMsg ) cons
 
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos::unique_ptr geosGeom( asGeos( geom, mPrecision ) );
     if ( !geosGeom )
     {
@@ -2430,7 +2468,7 @@ bool QgsGeos::isEqual( const QgsAbstractGeometry *geom, QString *errorMsg ) cons
   CATCH_GEOS_WITH_ERRMSG( false )
 }
 
-bool QgsGeos::isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg ) const
+bool QgsGeos::isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos || !geom )
   {
@@ -2439,6 +2477,8 @@ bool QgsGeos::isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QSt
 
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
+
     geos::unique_ptr geosGeom( asGeos( geom, mPrecision ) );
     if ( !geosGeom )
     {
@@ -2765,7 +2805,7 @@ geos::unique_ptr QgsGeos::createGeosPolygon( const QgsAbstractGeometry *poly, do
   return geosPolygon;
 }
 
-geos::unique_ptr QgsGeos::offsetCurve( const GEOSGeometry *geometry, double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg )
+geos::unique_ptr QgsGeos::offsetCurve( const GEOSGeometry *geometry, double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg, QgsFeedback *feedback )
 {
   if ( !geometry )
     return nullptr;
@@ -2777,22 +2817,25 @@ geos::unique_ptr QgsGeos::offsetCurve( const GEOSGeometry *geometry, double dist
     // https://github.com/qgis/QGIS/issues/53165#issuecomment-1563470832
     if ( segments < 8 )
       segments = 8;
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     offset.reset( GEOSOffsetCurve_r( QgsGeosContext::get(), geometry, distance, segments, static_cast< int >( joinStyle ), miterLimit ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return offset;
 }
 
-QgsAbstractGeometry *QgsGeos::offsetCurve( double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg ) const
+QgsAbstractGeometry *QgsGeos::offsetCurve( double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg, QgsFeedback *feedback ) const
 {
-  geos::unique_ptr res = offsetCurve( mGeos.get(), distance, segments, joinStyle, miterLimit, errorMsg );
+  geos::unique_ptr res = offsetCurve( mGeos.get(), distance, segments, joinStyle, miterLimit, errorMsg, feedback );
   if ( !res )
     return nullptr;
 
   return fromGeos( res.get() ).release();
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::singleSidedBuffer( double distance, int segments, Qgis::BufferSide side, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::singleSidedBuffer(
+  double distance, int segments, Qgis::BufferSide side, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg, QgsFeedback *feedback
+) const
 {
   if ( !mGeos )
   {
@@ -2801,6 +2844,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::singleSidedBuffer( double distance
 
   geos::unique_ptr geos;
   GEOSContextHandle_t context = QgsGeosContext::get();
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   try
   {
     geos::buffer_params_unique_ptr bp( GEOSBufferParams_create_r( context ) );
@@ -2819,7 +2863,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::singleSidedBuffer( double distance
   return fromGeos( geos.get() );
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::maximumInscribedCircle( double tolerance, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::maximumInscribedCircle( double tolerance, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2829,13 +2873,14 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::maximumInscribedCircle( double tol
   geos::unique_ptr geos;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSMaximumInscribedCircle_r( QgsGeosContext::get(), mGeos.get(), tolerance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::largestEmptyCircle( double tolerance, const QgsAbstractGeometry *boundary, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::largestEmptyCircle( double tolerance, const QgsAbstractGeometry *boundary, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2849,13 +2894,14 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::largestEmptyCircle( double toleran
     if ( boundary )
       boundaryGeos = asGeos( boundary );
 
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSLargestEmptyCircle_r( QgsGeosContext::get(), mGeos.get(), boundaryGeos.get(), tolerance ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumWidth( QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumWidth( QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2865,13 +2911,14 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumWidth( QString *errorMsg ) 
   geos::unique_ptr geos;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSMinimumWidth_r( QgsGeosContext::get(), mGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
 }
 
-double QgsGeos::minimumClearance( QString *errorMsg ) const
+double QgsGeos::minimumClearance( QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2882,6 +2929,7 @@ double QgsGeos::minimumClearance( QString *errorMsg ) const
   double res = 0;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     if ( GEOSMinimumClearance_r( QgsGeosContext::get(), mGeos.get(), &res ) != 0 )
       return std::numeric_limits< double >::quiet_NaN();
   }
@@ -2889,7 +2937,7 @@ double QgsGeos::minimumClearance( QString *errorMsg ) const
   return res;
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumClearanceLine( QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumClearanceLine( QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2899,13 +2947,14 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::minimumClearanceLine( QString *err
   geos::unique_ptr geos;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSMinimumClearanceLine_r( QgsGeosContext::get(), mGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::node( QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::node( QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -2915,13 +2964,14 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::node( QString *errorMsg ) const
   geos::unique_ptr geos;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSNode_r( QgsGeosContext::get(), mGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
   return fromGeos( geos.get() );
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::sharedPaths( const QgsAbstractGeometry *other, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::sharedPaths( const QgsAbstractGeometry *other, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos || !other )
   {
@@ -2935,6 +2985,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::sharedPaths( const QgsAbstractGeom
     if ( !otherGeos )
       return nullptr;
 
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSSharedPaths_r( QgsGeosContext::get(), mGeos.get(), otherGeos.get() ) );
   }
   CATCH_GEOS_WITH_ERRMSG( nullptr )
@@ -3073,7 +3124,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::reshapeGeometry( const QgsLineStri
   }
 }
 
-std::unique_ptr< QgsAbstractGeometry > QgsGeos::mergeLines( QString *errorMsg, const QgsGeometryParameters &parameters ) const
+std::unique_ptr< QgsAbstractGeometry > QgsGeos::mergeLines( QString *errorMsg, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -3084,6 +3135,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsGeos::mergeLines( QString *errorMsg, c
   if ( GEOSGeomTypeId_r( context, mGeos.get() ) != GEOS_MULTILINESTRING )
     return nullptr;
 
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   geos::unique_ptr geos;
   try
   {
@@ -3100,7 +3152,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsGeos::mergeLines( QString *errorMsg, c
   return fromGeos( geos.get() );
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::closestPoint( const QgsGeometry &other, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::closestPoint( const QgsGeometry &other, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos || isEmpty() || other.isEmpty() )
   {
@@ -3113,6 +3165,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::closestPoint( const QgsGeometry &o
     return nullptr;
   }
 
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   GEOSContextHandle_t context = QgsGeosContext::get();
   double nx = 0.0;
   double ny = 0.0;
@@ -3144,17 +3197,17 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::closestPoint( const QgsGeometry &o
   return std::make_unique< QgsPoint >( nx, ny );
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::shortestLine( const QgsGeometry &other, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::shortestLine( const QgsGeometry &other, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos || other.isEmpty() )
   {
     return nullptr;
   }
 
-  return shortestLine( other.constGet(), errorMsg );
+  return shortestLine( other.constGet(), errorMsg, feedback );
 }
 
-std::unique_ptr< QgsAbstractGeometry > QgsGeos::shortestLine( const QgsAbstractGeometry *other, QString *errorMsg ) const
+std::unique_ptr< QgsAbstractGeometry > QgsGeos::shortestLine( const QgsAbstractGeometry *other, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !other || other->isEmpty() )
     return nullptr;
@@ -3165,6 +3218,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsGeos::shortestLine( const QgsAbstractG
     return nullptr;
   }
 
+  QgsScopedGeosContextRegisterFeedback interrupt( feedback );
   GEOSContextHandle_t context = QgsGeosContext::get();
   double nx1 = 0.0;
   double ny1 = 0.0;
@@ -3202,7 +3256,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsGeos::shortestLine( const QgsAbstractG
   return line;
 }
 
-double QgsGeos::lineLocatePoint( const QgsPoint &point, QString *errorMsg ) const
+double QgsGeos::lineLocatePoint( const QgsPoint &point, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -3218,6 +3272,7 @@ double QgsGeos::lineLocatePoint( const QgsPoint &point, QString *errorMsg ) cons
   double distance = -1;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     distance = GEOSProject_r( QgsGeosContext::get(), mGeos.get(), otherGeom.get() );
   }
   catch ( QgsGeosException &e )
@@ -3233,7 +3288,7 @@ double QgsGeos::lineLocatePoint( const QgsPoint &point, QString *errorMsg ) cons
   return distance;
 }
 
-double QgsGeos::lineLocatePoint( double x, double y, QString *errorMsg ) const
+double QgsGeos::lineLocatePoint( double x, double y, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -3247,6 +3302,7 @@ double QgsGeos::lineLocatePoint( double x, double y, QString *errorMsg ) const
   double distance = -1;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     distance = GEOSProject_r( QgsGeosContext::get(), mGeos.get(), point.get() );
   }
   catch ( QgsGeosException &e )
@@ -3262,7 +3318,7 @@ double QgsGeos::lineLocatePoint( double x, double y, QString *errorMsg ) const
   return distance;
 }
 
-QgsGeometry QgsGeos::polygonize( const QVector<const QgsAbstractGeometry *> &geometries, QString *errorMsg )
+QgsGeometry QgsGeos::polygonize( const QVector<const QgsAbstractGeometry *> &geometries, QString *errorMsg, QgsFeedback *feedback )
 {
   GEOSGeometry **const lineGeosGeometries = new GEOSGeometry *[geometries.size()];
   int validLines = 0;
@@ -3279,6 +3335,7 @@ QgsGeometry QgsGeos::polygonize( const QVector<const QgsAbstractGeometry *> &geo
   GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos::unique_ptr result( GEOSPolygonize_r( context, lineGeosGeometries, validLines ) );
     for ( int i = 0; i < validLines; ++i )
     {
@@ -3302,7 +3359,7 @@ QgsGeometry QgsGeos::polygonize( const QVector<const QgsAbstractGeometry *> &geo
   }
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::voronoiDiagram( const QgsAbstractGeometry *extent, double tolerance, bool edgesOnly, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::voronoiDiagram( const QgsAbstractGeometry *extent, double tolerance, bool edgesOnly, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -3323,6 +3380,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::voronoiDiagram( const QgsAbstractG
   GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSVoronoiDiagram_r( context, mGeos.get(), extentGeosGeom.get(), tolerance, edgesOnly ) );
 
     if ( !geos || GEOSisEmpty_r( context, geos.get() ) != 0 )
@@ -3335,7 +3393,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::voronoiDiagram( const QgsAbstractG
   CATCH_GEOS_WITH_ERRMSG( nullptr )
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::delaunayTriangulation( double tolerance, bool edgesOnly, QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::delaunayTriangulation( double tolerance, bool edgesOnly, QString *errorMsg, QgsFeedback *feedback ) const
 {
   if ( !mGeos )
   {
@@ -3346,6 +3404,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::delaunayTriangulation( double tole
   geos::unique_ptr geos;
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSDelaunayTriangulation_r( context, mGeos.get(), tolerance, edgesOnly ) );
 
     if ( !geos || GEOSisEmpty_r( context, geos.get() ) != 0 )
@@ -3358,7 +3417,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::delaunayTriangulation( double tole
   CATCH_GEOS_WITH_ERRMSG( nullptr )
 }
 
-std::unique_ptr<QgsAbstractGeometry> QgsGeos::constrainedDelaunayTriangulation( QString *errorMsg ) const
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::constrainedDelaunayTriangulation( QString *errorMsg, QgsFeedback *feedback ) const
 {
 #if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 11
   ( void ) errorMsg;
@@ -3373,6 +3432,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::constrainedDelaunayTriangulation( 
   GEOSContextHandle_t context = QgsGeosContext::get();
   try
   {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
     geos.reset( GEOSConstrainedDelaunayTriangulation_r( context, mGeos.get() ) );
 
     if ( !geos || GEOSisEmpty_r( context, geos.get() ) != 0 )

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -203,12 +203,14 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * The \a method and \a keepCollapsed arguments require builds based on GEOS 3.10 or later.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
+     *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.9 or earlier when the \a method is not Qgis::MakeValidMethod::Linework or the \a keepCollapsed option is set.
      * \since QGIS 3.20
      */
-    std::unique_ptr< QgsAbstractGeometry > makeValid( Qgis::MakeValidMethod method = Qgis::MakeValidMethod::Linework, bool keepCollapsed = false, QString *errorMsg = nullptr ) const SIP_THROW(
-      QgsNotSupportedException
-    );
+    std::unique_ptr< QgsAbstractGeometry > makeValid(
+      Qgis::MakeValidMethod method = Qgis::MakeValidMethod::Linework, bool keepCollapsed = false, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr
+    ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Adds a new island polygon to a multipolygon feature
@@ -223,8 +225,12 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
     void geometryChanged() override;
     void prepareGeometry() override;
 
-    QgsAbstractGeometry *intersection( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const override;
-    QgsAbstractGeometry *difference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const override;
+    QgsAbstractGeometry *intersection(
+      const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const override;
+    QgsAbstractGeometry *difference(
+      const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const override;
 
     /**
      * Performs a fast, non-robust intersection between the geometry and
@@ -232,10 +238,11 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \param rectangle clipping rectangle
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns clipped geometry
      */
-    std::unique_ptr< QgsAbstractGeometry > clip( const QgsRectangle &rectangle, QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > clip( const QgsRectangle &rectangle, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Subdivides the geometry. The returned geometry will be a collection containing subdivided parts
@@ -252,36 +259,51 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param maxNodes Maximum nodes used
      * \param errorMsg will be set to descriptive error string if the operation fails
      * \param parameters can be used to specify parameters which control the subdivision results (since QGIS 3.28)
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns subdivided geometry
      */
-    std::unique_ptr< QgsAbstractGeometry > subdivide( int maxNodes, QString *errorMsg SIP_OUT = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    std::unique_ptr< QgsAbstractGeometry > subdivide(
+      int maxNodes, QString *errorMsg SIP_OUT = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const;
 
-    QgsAbstractGeometry *combine( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const override;
-    QgsAbstractGeometry *combine( const QVector<QgsAbstractGeometry *> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const override;
-    QgsAbstractGeometry *combine( const QVector< QgsGeometry > &, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const override;
-    QgsAbstractGeometry *symDifference( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const override;
-    QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = nullptr ) const override;
-    QgsAbstractGeometry *buffer( double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr ) const override;
+    QgsAbstractGeometry *combine(
+      const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const override;
+    QgsAbstractGeometry *combine(
+      const QVector<QgsAbstractGeometry *> &geomList, QString *errorMsg, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const override;
+    QgsAbstractGeometry *combine(
+      const QVector< QgsGeometry > &, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const override;
+    QgsAbstractGeometry *symDifference(
+      const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const override;
+    QgsAbstractGeometry *buffer( double distance, int segments, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    QgsAbstractGeometry *buffer(
+      double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr
+    ) const override;
 
     /**
      * Directly calculates the buffer for a GEOS geometry object and returns a GEOS geometry result.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      *
      * \note Not available in Python bindings
      * \since QGIS 3.42
      */
     SIP_SKIP static geos::unique_ptr buffer(
-      const GEOSGeometry *geometry, double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr
+      const GEOSGeometry *geometry, double distance, int segments, Qgis::EndCapStyle endCapStyle, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr
     );
 
-    QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = nullptr ) const override;
-    QgsAbstractGeometry *interpolate( double distance, QString *errorMsg = nullptr ) const override;
+    QgsAbstractGeometry *simplify( double tolerance, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    QgsAbstractGeometry *interpolate( double distance, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
     QgsAbstractGeometry *envelope( QString *errorMsg = nullptr ) const override;
-    QgsPoint *centroid( QString *errorMsg = nullptr ) const override;
-    QgsPoint *pointOnSurface( QString *errorMsg = nullptr ) const override;
-    QgsAbstractGeometry *convexHull( QString *errorMsg = nullptr ) const override;
-    double distance( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    bool distanceWithin( const QgsAbstractGeometry *geom, double maxdistance, QString *errorMsg = nullptr ) const override;
+    QgsPoint *centroid( QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    QgsPoint *pointOnSurface( QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    QgsAbstractGeometry *convexHull( QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    double distance( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    bool distanceWithin( const QgsAbstractGeometry *geom, double maxdistance, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
 
     /**
      * Returns TRUE if the geometry contains the point at (\a x, \a y).
@@ -291,12 +313,13 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param x x-coordinate of point to test
      * \param y y-coordinate of point to test
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns TRUE if the geometry contains the point
      *
      * \since QGIS 3.26
      */
-    bool contains( double x, double y, QString *errorMsg SIP_OUT = nullptr ) const;
+    bool contains( double x, double y, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Returns the minimum distance from the geometry to the point at (\a x, \a y).
@@ -306,12 +329,13 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param x x-coordinate of point to test
      * \param y y-coordinate of point to test
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns minimum distance
      *
      * \since QGIS 3.26
      */
-    double distance( double x, double y, QString *errorMsg SIP_OUT = nullptr ) const;
+    double distance( double x, double y, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Returns the Hausdorff distance between this geometry and another \a geometry. This is basically a measure of how similar or dissimilar 2 geometries are.
@@ -327,12 +351,13 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \param geometry geometry to compare to
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2)
      *
      * \returns calculated Hausdorff distance
      *
      * \see hausdorffDistanceDensify()
      */
-    double hausdorffDistance( const QgsAbstractGeometry *geometry, QString *errorMsg SIP_OUT = nullptr ) const;
+    double hausdorffDistance( const QgsAbstractGeometry *geometry, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Returns the Hausdorff distance between this geometry and another \a geometry. This is basically a measure of how similar or dissimilar 2 geometries are.
@@ -350,12 +375,13 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param geometry geometry to compare to
      * \param densifyFraction fraction by which to densify each segment
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns calculated densified Hausdorff distance
      *
      * \see hausdorffDistance()
      */
-    double hausdorffDistanceDensify( const QgsAbstractGeometry *geometry, double densifyFraction, QString *errorMsg SIP_OUT = nullptr ) const;
+    double hausdorffDistanceDensify( const QgsAbstractGeometry *geometry, double densifyFraction, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Returns the Fréchet distance between this geometry and another \a geometry, restricted to discrete points for both geometries.
@@ -367,6 +393,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \param geometry geometry to compare to
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns calculated Fréchet distance
      *
@@ -374,7 +401,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \see frechetDistanceDensify()
      * \since QGIS 3.20
      */
-    double frechetDistance( const QgsAbstractGeometry *geometry, QString *errorMsg SIP_OUT = nullptr ) const SIP_THROW( QgsNotSupportedException );
+    double frechetDistance( const QgsAbstractGeometry *geometry, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Returns the Fréchet distance between this geometry and another \a geometry, restricted to discrete points for both geometries.
@@ -397,6 +424,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param geometry geometry to compare to
      * \param densifyFraction fraction by which to densify each segment
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns calculated densified Fréchet distance
      *
@@ -404,23 +432,25 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \see frechetDistance()
      * \since QGIS 3.20
      */
-    double frechetDistanceDensify( const QgsAbstractGeometry *geometry, double densifyFraction, QString *errorMsg SIP_OUT = nullptr ) const SIP_THROW( QgsNotSupportedException );
+    double frechetDistanceDensify( const QgsAbstractGeometry *geometry, double densifyFraction, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const SIP_THROW(
+      QgsNotSupportedException
+    );
 
-    bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    bool within( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = nullptr ) const override;
+    bool intersects( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    bool touches( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    bool crosses( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    bool within( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    bool overlaps( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    bool contains( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    bool disjoint( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    QString relate( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    bool relatePattern( const QgsAbstractGeometry *geom, const QString &pattern, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
     double area( QString *errorMsg = nullptr ) const override;
     double length( QString *errorMsg = nullptr ) const override;
-    bool isValid( QString *errorMsg = nullptr, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = nullptr ) const override;
+    bool isValid( QString *errorMsg = nullptr, bool allowSelfTouchingHoles = false, QgsGeometry *errorLoc = nullptr, QgsFeedback *feedback = nullptr ) const override;
 
-    bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr ) const override;
-    bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = nullptr ) const override;
+    bool isEqual( const QgsAbstractGeometry *geom, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
+    bool isFuzzyEqual( const QgsAbstractGeometry *geom, double epsilon, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
 
     bool isEmpty( QString *errorMsg = nullptr ) const override;
     bool isSimple( QString *errorMsg = nullptr ) const override;
@@ -432,12 +462,16 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
     /**
      * Directly calculates the offset curve for a GEOS geometry object and returns a GEOS geometry result.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
+     *
      * \note Not available in Python bindings
      * \since QGIS 3.42
      */
-    SIP_SKIP static geos::unique_ptr offsetCurve( const GEOSGeometry *geometry, double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr );
+    SIP_SKIP static geos::unique_ptr offsetCurve(
+      const GEOSGeometry *geometry, double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr
+    );
 
-    QgsAbstractGeometry *offsetCurve( double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr ) const override;
+    QgsAbstractGeometry *offsetCurve( double distance, int segments, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const override;
 
     /**
      * Returns a single sided buffer for a geometry. The buffer is only
@@ -448,9 +482,13 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param joinStyle join style for corners ( Round (1) / Miter (2) / Bevel (3) )
      * \param miterLimit limit on the miter ratio used for very sharp corners
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
+     *
      * \returns buffered geometry, or NULLPTR if buffer could not be calculated
      */
-    std::unique_ptr< QgsAbstractGeometry > singleSidedBuffer( double distance, int segments, Qgis::BufferSide side, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > singleSidedBuffer(
+      double distance, int segments, Qgis::BufferSide side, Qgis::JoinStyle joinStyle, double miterLimit, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr
+    ) const;
 
     /**
      * Returns the maximum inscribed circle.
@@ -474,6 +512,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \param tolerance tolerance to determine when iteration should end
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns A two-point linestring geometry, with the first point at the center of the inscribed circle and the second
      * on the boundary of the inscribed circle.
@@ -482,7 +521,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \since QGIS 3.20
      */
-    std::unique_ptr< QgsAbstractGeometry > maximumInscribedCircle( double tolerance, QString *errorMsg SIP_OUT = nullptr ) const SIP_THROW( QgsNotSupportedException );
+    std::unique_ptr< QgsAbstractGeometry > maximumInscribedCircle( double tolerance, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Constructs the Largest Empty Circle for a set of obstacle geometries, up to a
@@ -504,6 +543,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param tolerance tolerance to determine when iteration should end
      * \param boundary optional set of boundary obstacles
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns A two-point linestring geometry, with first point at the center of the inscribed circle and the second
      * on the boundary of the inscribed circle.
@@ -514,9 +554,9 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \since QGIS 3.20
      */
-    std::unique_ptr< QgsAbstractGeometry > largestEmptyCircle( double tolerance, const QgsAbstractGeometry *boundary = nullptr, QString *errorMsg SIP_OUT = nullptr ) const SIP_THROW(
-      QgsNotSupportedException
-    );
+    std::unique_ptr< QgsAbstractGeometry > largestEmptyCircle(
+      double tolerance, const QgsAbstractGeometry *boundary = nullptr, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr
+    ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Returns a linestring geometry which represents the minimum diameter of the geometry.
@@ -529,6 +569,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * This method requires a QGIS build based on GEOS 3.6 or later.
      *
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns linestring representing the minimum diameter of the geometry
      *
@@ -536,7 +577,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \since QGIS 3.20
      */
-    std::unique_ptr< QgsAbstractGeometry > minimumWidth( QString *errorMsg SIP_OUT = nullptr ) const SIP_THROW( QgsNotSupportedException );
+    std::unique_ptr< QgsAbstractGeometry > minimumWidth( QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Computes the minimum clearance of a geometry.
@@ -556,6 +597,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * This method requires a QGIS build based on GEOS 3.6 or later.
      *
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns calculated minimum clearance of the geometry
      *
@@ -563,7 +605,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \since QGIS 3.20
      */
-    double minimumClearance( QString *errorMsg SIP_OUT = nullptr ) const SIP_THROW( QgsNotSupportedException );
+    double minimumClearance( QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Returns a LineString whose endpoints define the minimum clearance of a geometry.
@@ -573,6 +615,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * This method requires a QGIS build based on GEOS 3.6 or later.
      *
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns linestring geometry representing the minimum clearance of the geometry
      *
@@ -580,7 +623,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \since QGIS 3.20
      */
-    std::unique_ptr< QgsAbstractGeometry > minimumClearanceLine( QString *errorMsg SIP_OUT = nullptr ) const SIP_THROW( QgsNotSupportedException );
+    std::unique_ptr< QgsAbstractGeometry > minimumClearanceLine( QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Returns a (Multi)LineString representing the fully noded version of a collection of linestrings.
@@ -591,12 +634,13 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * The input geometry type should be a (Multi)LineString.
      *
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns (multi)linestring geometry representing the fully noded version of the collection of linestrings
      *
      * \since QGIS 3.20
      */
-    std::unique_ptr< QgsAbstractGeometry > node( QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > node( QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Find paths shared between the two given lineal geometries (this and \a other).
@@ -610,12 +654,13 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \param other geometry to compare against
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns shared paths, or NULLPTR on exception
      *
      * \since QGIS 3.20
      */
-    std::unique_ptr< QgsAbstractGeometry > sharedPaths( const QgsAbstractGeometry *other, QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > sharedPaths( const QgsAbstractGeometry *other, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Reshapes the geometry using a line
@@ -633,49 +678,54 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * converts them to single line strings.
      *
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
+     *
      * \returns a LineString or MultiLineString geometry, with any connected lines
      * joined. An empty geometry will be returned if the input geometry was not a
      * LineString/MultiLineString geometry.
      * \param parameters can be used to specify parameters which control the mergeLines results (since QGIS 3.44)
      */
-    std::unique_ptr< QgsAbstractGeometry > mergeLines( QString *errorMsg SIP_OUT = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    std::unique_ptr< QgsAbstractGeometry > mergeLines( QString *errorMsg SIP_OUT = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Returns the closest point on the geometry to the other geometry.
      *
      * \param other geometry to compare against
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns closest point
      *
      * \see shortestLine()
      */
-    std::unique_ptr< QgsAbstractGeometry > closestPoint( const QgsGeometry &other, QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > closestPoint( const QgsGeometry &other, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Returns the shortest line joining this geometry to the other geometry.
      *
      * \param other geometry to compare against
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns shortest line joining this geometry to the other geometry
      *
      * \see closestPoint()
      */
-    std::unique_ptr< QgsAbstractGeometry > shortestLine( const QgsGeometry &other, QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > shortestLine( const QgsGeometry &other, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Returns the shortest line joining this geometry to the other geometry.
      *
      * \param other geometry to compare against
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns shortest line joining this geometry to the other geometry
      *
      * \see closestPoint()
      * \since QGIS 3.20
      */
-    std::unique_ptr< QgsAbstractGeometry > shortestLine( const QgsAbstractGeometry *other, QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > shortestLine( const QgsAbstractGeometry *other, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Returns a distance representing the location along this linestring of the closest point
@@ -685,10 +735,12 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \param point point to seek proximity to
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
+     *
      * \returns distance along line, or -1 on error
      * \note only valid for linestring geometries
      */
-    double lineLocatePoint( const QgsPoint &point, QString *errorMsg SIP_OUT = nullptr ) const;
+    double lineLocatePoint( const QgsPoint &point, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Returns a distance representing the location along this linestring of the closest point
@@ -701,6 +753,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param x x-coordinate of point to locate
      * \param y y-coordinate of point to locate
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns distance along line, or -1 on error
      *
@@ -708,7 +761,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \since QGIS 3.26
      */
-    double lineLocatePoint( double x, double y, QString *errorMsg SIP_OUT = nullptr ) const;
+    double lineLocatePoint( double x, double y, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Creates a GeometryCollection geometry containing possible polygons formed from the constituent
@@ -718,9 +771,11 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * pass the result to polygonize().
      * An empty geometry will be returned in the case of errors.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
+     *
      * \note Not available in Python bindings
      */
-    SIP_SKIP static QgsGeometry polygonize( const QVector<const QgsAbstractGeometry *> &geometries, QString *errorMsg = nullptr );
+    SIP_SKIP static QgsGeometry polygonize( const QVector<const QgsAbstractGeometry *> &geometries, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr );
 
     /**
      * Creates a Voronoi diagram for the nodes contained within the geometry.
@@ -740,10 +795,13 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param tolerance
      * \param edgesOnly
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns Voronoi diagram
      */
-    std::unique_ptr< QgsAbstractGeometry > voronoiDiagram( const QgsAbstractGeometry *extent = nullptr, double tolerance = 0.0, bool edgesOnly = false, QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > voronoiDiagram(
+      const QgsAbstractGeometry *extent = nullptr, double tolerance = 0.0, bool edgesOnly = false, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr
+    ) const;
 
     /**
      * Returns the Delaunay triangulation for the vertices of the geometry.
@@ -756,12 +814,13 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param tolerance
      * \param edgesOnly
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns Delaunay triangulation
      *
      * \see constrainedDelaunayTriangulation()
      */
-    std::unique_ptr< QgsAbstractGeometry > delaunayTriangulation( double tolerance = 0.0, bool edgesOnly = false, QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > delaunayTriangulation( double tolerance = 0.0, bool edgesOnly = false, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Returns a constrained Delaunay triangulation for the vertices of the geometry.
@@ -771,6 +830,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * This method requires a QGIS build based on GEOS 3.11 or later.
      *
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns constrained Delaunay triangulation
      *
@@ -779,7 +839,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \since QGIS 3.36
      */
-    std::unique_ptr< QgsAbstractGeometry > constrainedDelaunayTriangulation( QString *errorMsg SIP_OUT = nullptr ) const SIP_THROW( QgsNotSupportedException );
+    std::unique_ptr< QgsAbstractGeometry > constrainedDelaunayTriangulation( QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Returns a possibly concave geometry that encloses the input geometry.
@@ -825,6 +885,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * collection of the same length as the input, with a MULTILINESTRING of the error edges for each invalid polygon,
      * or an EMPTY where the polygon is a valid participant in the coverage. Pass NULLPTR if you do not want the invalid edges returned.
      * \param errorMsg
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * This method requires a QGIS build based on GEOS 3.12 or later.
      *
@@ -834,7 +895,9 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \see simplifyCoverageVW()
      * \since QGIS 3.36
      */
-    SIP_SKIP Qgis::CoverageValidityResult validateCoverage( double gapWidth, std::unique_ptr< QgsAbstractGeometry > *invalidEdges, QString *errorMsg = nullptr ) const SIP_THROW( QgsNotSupportedException );
+    SIP_SKIP Qgis::CoverageValidityResult validateCoverage(
+      double gapWidth, std::unique_ptr< QgsAbstractGeometry > *invalidEdges, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr
+    ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Operates on a coverage (represented as a list of polygonal geometry with exactly matching edge geometry) to apply
@@ -850,6 +913,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param tolerance A tolerance parameter in linear units.
      * \param preserveBoundary Set to TRUE to preserve the outside edges of the coverage without simplification, or FALSE to allow them to be simplified.
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns simplified coverage
      *
@@ -859,7 +923,9 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \see validateCoverage()
      * \since QGIS 3.36
      */
-    std::unique_ptr< QgsAbstractGeometry > simplifyCoverageVW( double tolerance, bool preserveBoundary, QString *errorMsg SIP_OUT = nullptr ) const SIP_THROW( QgsNotSupportedException );
+    std::unique_ptr< QgsAbstractGeometry > simplifyCoverageVW( double tolerance, bool preserveBoundary, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const SIP_THROW(
+      QgsNotSupportedException
+    );
 
     /**
      * Optimized union algorithm for polygonal inputs that are correctly noded and do not overlap.
@@ -870,13 +936,14 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * All members must be POLYGON or MULTIPOLYGON.
      *
      * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      *
      * \returns unioned coverage
      *
      * \see validateCoverage()
      * \since QGIS 3.36
      */
-    std::unique_ptr< QgsAbstractGeometry > unionCoverage( QString *errorMsg SIP_OUT = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > unionCoverage( QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const;
 
     /**
      * Create a geometry from a GEOSGeometry
@@ -952,8 +1019,10 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param op Overlay Operation
      * \param parameters can be used to specify parameters which control the overlay results (since QGIS 3.28)
      */
-    std::unique_ptr< QgsAbstractGeometry > overlay( const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
-    bool relation( const QgsAbstractGeometry *geom, Relation r, QString *errorMsg = nullptr ) const;
+    std::unique_ptr< QgsAbstractGeometry > overlay(
+      const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr
+    ) const;
+    bool relation( const QgsAbstractGeometry *geom, Relation r, QString *errorMsg = nullptr, QgsFeedback *feedback = nullptr ) const;
     static GEOSCoordSequence *createCoordinateSequence( const QgsCurve *curve, double precision, bool forceClose = false );
     static std::unique_ptr< QgsLineString > sequenceToLinestring( const GEOSGeometry *geos, bool hasZ, bool hasM );
     static int numberOfGeometries( GEOSGeometry *g );

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -1018,6 +1018,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \param errorMsg Error message returned by GEOS
      * \param op Overlay Operation
      * \param parameters can be used to specify parameters which control the overlay results (since QGIS 3.28)
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      */
     std::unique_ptr< QgsAbstractGeometry > overlay(
       const QgsAbstractGeometry *geom, Overlay op, QString *errorMsg = nullptr, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback *feedback = nullptr


### PR DESCRIPTION
## Description

Add feedback argument support for all geos methods

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
