### PR TITLE
[auth] Fix missing authentication methods when making static QGIS builds

### DIFF
--- a/src/auth/maptiler_hmacsha256/CMakeLists.txt
+++ b/src/auth/maptiler_hmacsha256/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 # static library
 add_library(authmethod_maptilerhmacsha256_a STATIC ${AUTH_MAPTILER_HMACSHA256_SRCS} ${AUTH_MAPTILER_HMACSHA256_HDRS} ${AUTH_MAPTILER_HMACSHA256_UIS_H})
 
-target_include_directories(authmethod_maptilerhmacsha256_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/hmacsha256/core)
+target_include_directories(authmethod_maptilerhmacsha256_a PUBLIC ${CMAKE_SOURCE_DIR}/src/auth/maptiler_hmacsha256/core)
 
 target_link_libraries(authmethod_maptilerhmacsha256_a qgis_core)
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2917,11 +2917,15 @@ if (FORCE_STATIC_LIBS)
 
   if (WITH_AUTH)
     target_link_libraries(qgis_core
+      authmethod_apiheader_a
+      authmethod_awss3_a
       authmethod_basic_a
       authmethod_esritoken_a
       authmethod_identcert_a
+      authmethod_maptilerhmacsha256_a
       authmethod_pkipaths_a
       authmethod_pkcs12_a
+      authmethod_planetary_computer_a
     )
     if(WITH_OAUTH2_PLUGIN)
       target_link_libraries(qgis_core authmethod_oauth2_a)

--- a/src/core/auth/qgsauthmethodregistry.cpp
+++ b/src/core/auth/qgsauthmethodregistry.cpp
@@ -29,14 +29,18 @@
 using namespace Qt::StringLiterals;
 
 #ifdef HAVE_STATIC_PROVIDERS
+#include "qgsauthapiheadermethod.h"
+#include "qgsauthawss3method.h"
 #include "qgsauthbasicmethod.h"
 #include "qgsauthesritokenmethod.h"
 #include "qgsauthidentcertmethod.h"
+#include "qgsauthmaptilerhmacsha256method.h"
 #ifdef HAVE_OAUTH2_PLUGIN
 #include "qgsauthoauth2method.h"
 #endif
 #include "qgsauthpkipathsmethod.h"
 #include "qgsauthpkcs12method.h"
+#include "qgsauthplanetarycomputermethod.h"
 #endif
 
 #include <QString>
@@ -104,14 +108,18 @@ QgsAuthMethodRegistry::QgsAuthMethodRegistry( const QString &pluginPath )
 void QgsAuthMethodRegistry::init()
 {
 #ifdef HAVE_STATIC_PROVIDERS
+  mAuthMethods[QgsAuthApiHeaderMethod::AUTH_METHOD_KEY] = new QgsAuthApiHeaderMethodMetadata();
+  mAuthMethods[QgsAuthAwsS3Method::AUTH_METHOD_KEY] = new QgsAuthAwsS3MethodMetadata();
   mAuthMethods[QgsAuthBasicMethod::AUTH_METHOD_KEY] = new QgsAuthBasicMethodMetadata();
   mAuthMethods[QgsAuthEsriTokenMethod::AUTH_METHOD_KEY] = new QgsAuthEsriTokenMethodMetadata();
   mAuthMethods[QgsAuthIdentCertMethod::AUTH_METHOD_KEY] = new QgsAuthIdentCertMethodMetadata();
+  mAuthMethods[QgsAuthMapTilerHmacSha256Method::AUTH_METHOD_KEY] = new QgsAuthMapTilerHmacSha256MethodMetadata();
 #ifdef HAVE_OAUTH2_PLUGIN
   mAuthMethods[QgsAuthOAuth2Method::AUTH_METHOD_KEY] = new QgsAuthOAuth2MethodMetadata();
 #endif
   mAuthMethods[QgsAuthPkiPathsMethod::AUTH_METHOD_KEY] = new QgsAuthPkiPathsMethodMetadata();
   mAuthMethods[QgsAuthPkcs12Method::AUTH_METHOD_KEY] = new QgsAuthPkcs12MethodMetadata();
+  mAuthMethods[QgsAuthPlanetaryComputerMethod::AUTH_METHOD_KEY] = new QgsAuthPlanetaryComputerMethodMetadata();
 #else
   typedef QgsAuthMethodMetadata *factory_function();
 


### PR DESCRIPTION
## Description

Quite a few new authentication methods were missing from static builds, this PR remedies to that.