### PR TITLE
Expose concave hull of polygons functionality

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2065,9 +2065,10 @@ must be non-overlapping).
                     Maximum Edge Length to be scale-free. A value of 1
                     produces the convex hull; a value of 0 produces the
                     original polygons.
-:param allowHoles: is the concave hull allowed to contain holes?
-:param isTight: does the hull follow the outer boundaries of the input
-                polygons.
+:param allowHoles: set to ``True`` to allow the concave hull to contain
+                   holes
+:param isTight: set to ``True`` if the concave hull should follow the
+                outer boundaries of the input polygons
 :param feedback: optional feedback object for early cancellation.
 
 :raises QgsNotSupportedException: on QGIS builds based on GEOS 3.10 or

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2028,7 +2028,54 @@ early cancellation.
 :raises QgsNotSupportedException: on QGIS builds based on GEOS 3.10 or
                                   earlier.
 
+.. seealso:: :py:func:`concaveHullOfPolygons`
+
 .. versionadded:: 3.28
+%End
+
+    QgsGeometry concaveHullOfPolygons( double lengthRatio, bool allowHoles = false, bool isTight = false, QgsFeedback *feedback = 0 ) const;
+%Docstring
+Constructs a concave hull of a set of polygons, respecting the polygons
+as constraints.
+
+A concave hull is a (possibly) non-convex polygon containing all the
+input polygons.
+
+The computed hull "fills the gap" between the polygons, and does not
+intersect their interior.
+
+A set of polygons has a sequence of hulls of increasing concaveness,
+determined by a numeric target parameter.
+
+The concave hull is constructed by removing the longest outer edges of
+the Delaunay Triangulation of the space between the polygons, until the
+target criterion parameter is reached.
+
+The "Maximum Edge Length" parameter limits the length of the longest
+edge between polygons to be no larger than this value. This can be
+expressed as a ratio between the lengths of the longest and shortest
+edges.
+
+The input geometry must be a valid Polygon or MultiPolygon (i.e. they
+must be non-overlapping).
+
+:param lengthRatio: specifies the Maximum Edge Length as a fraction of
+                    the difference between the longest and shortest edge
+                    lengths between the polygons. This normalizes the
+                    Maximum Edge Length to be scale-free. A value of 1
+                    produces the convex hull; a value of 0 produces the
+                    original polygons.
+:param allowHoles: is the concave hull allowed to contain holes?
+:param isTight: does the hull follow the outer boundaries of the input
+                polygons.
+:param feedback: optional feedback object for early cancellation.
+
+:raises QgsNotSupportedException: on QGIS builds based on GEOS 3.10 or
+                                  earlier.
+
+.. seealso:: :py:func:`concaveHull`
+
+.. versionadded:: 4.2
 %End
 
     QgsGeometry voronoiDiagram( const QgsGeometry &extent = QgsGeometry(), double tolerance = 0.0, bool edgesOnly = false ) const;

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
@@ -792,7 +792,60 @@ This method requires a QGIS build based on GEOS 3.11 or later.
 :raises QgsNotSupportedException: on QGIS builds based on GEOS 3.10 or
                                   earlier.
 
+.. seealso:: :py:func:`concaveHullOfPolygons`
+
 .. seealso:: :py:func:`convexHull`
+
+.. versionadded:: 3.28
+%End
+
+    std::unique_ptr< QgsAbstractGeometry > concaveHullOfPolygons(
+      double lengthRatio, bool allowHoles = false, bool isTight = false, QString *errorMsg /Out/ = 0, QgsFeedback *feedback = 0
+    ) const;
+%Docstring
+Constructs a concave hull of a set of polygons, respecting the polygons
+as constraints.
+
+A concave hull is a (possibly) non-convex polygon containing all the
+input polygons.
+
+The computed hull "fills the gap" between the polygons, and does not
+intersect their interior.
+
+A set of polygons has a sequence of hulls of increasing concaveness,
+determined by a numeric target parameter.
+
+The concave hull is constructed by removing the longest outer edges of
+the Delaunay Triangulation of the space between the polygons, until the
+target criterion parameter is reached.
+
+The "Maximum Edge Length" parameter limits the length of the longest
+edge between polygons to be no larger than this value. This can be
+expressed as a ratio between the lengths of the longest and shortest
+edges.
+
+The input geometry *must* be a *valid* MultiPolygon (i.e. they must be
+non-overlapping).
+
+:param lengthRatio: specifies the Maximum Edge Length as a fraction of
+                    the difference between the longest and shortest edge
+                    lengths between the polygons. This normalizes the
+                    Maximum Edge Length to be scale-free. A value of 1
+                    produces the convex hull; a value of 0 produces the
+                    original polygons.
+:param allowHoles: is the concave hull allowed to contain holes?
+:param isTight: does the hull follow the outer boundaries of the input
+                polygons.
+:param feedback: optional feedback object for early cancellation.
+
+This method requires a QGIS build based on GEOS 3.11 or later.
+
+:raises QgsNotSupportedException: on QGIS builds based on GEOS 3.10 or
+                                  earlier.
+
+.. seealso:: :py:func:`concaveHull`
+
+:return: - errorMsg: descriptive error string if the operation fails
 
 .. versionadded:: 3.28
 %End

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeos.sip.in
@@ -833,9 +833,10 @@ non-overlapping).
                     Maximum Edge Length to be scale-free. A value of 1
                     produces the convex hull; a value of 0 produces the
                     original polygons.
-:param allowHoles: is the concave hull allowed to contain holes?
-:param isTight: does the hull follow the outer boundaries of the input
-                polygons.
+:param allowHoles: set to ``True`` to allow the concave hull to contain
+                   holes
+:param isTight: set to ``True`` if the concave hull should follow the
+                outer boundaries of the input polygons
 :param feedback: optional feedback object for early cancellation.
 
 This method requires a QGIS build based on GEOS 3.11 or later.
@@ -847,7 +848,7 @@ This method requires a QGIS build based on GEOS 3.11 or later.
 
 :return: - errorMsg: descriptive error string if the operation fails
 
-.. versionadded:: 3.28
+.. versionadded:: 4.2
 %End
 
 

--- a/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons.gml
+++ b/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons.gml
@@ -10,13 +10,13 @@
   <ogr:featureMember>
     <ogr:concave_hull_of_polygons gml:id="concave_hull_of_polygons.0">
       <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 2</gml:lowerCorner><gml:upperCorner>3 4</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_of_polygons.geom.0"><gml:exterior><gml:LinearRing><gml:posList>3 3 3 4 1 4 1 2 2 2 3 3</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:geometryProperty><gml:MultiSurface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_of_polygons.geom.0"><gml:surfaceMember><gml:Polygon gml:id="concave_hull_of_polygons.geom.0.0"><gml:exterior><gml:LinearRing><gml:posList>1 2 2 2 2 3 3 3 3 4 1 4 1 2</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember></gml:MultiSurface></ogr:geometryProperty>
       <ogr:fid>multipolys.0</ogr:fid>
       <ogr:Bname>Test</ogr:Bname>
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
-      <ogr:area>3.500000</ogr:area>
-      <ogr:perimeter>7.414214</ogr:perimeter>
+      <ogr:area>3.000000</ogr:area>
+      <ogr:perimeter>8.000000</ogr:perimeter>
     </ogr:concave_hull_of_polygons>
   </ogr:featureMember>
   <ogr:featureMember>

--- a/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons.gml
+++ b/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons.gml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ concave_hull_of_polygons.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 0</gml:lowerCorner><gml:upperCorner>6 9</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                                             
+  <ogr:featureMember>
+    <ogr:concave_hull_of_polygons gml:id="concave_hull_of_polygons.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 2</gml:lowerCorner><gml:upperCorner>3 4</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_of_polygons.geom.0"><gml:exterior><gml:LinearRing><gml:posList>3 3 3 4 1 4 1 2 2 2 3 3</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>multipolys.0</ogr:fid>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>1</ogr:Bintval>
+      <ogr:Bfloatval>0.123</ogr:Bfloatval>
+      <ogr:area>3.500000</ogr:area>
+      <ogr:perimeter>7.414214</ogr:perimeter>
+    </ogr:concave_hull_of_polygons>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_of_polygons gml:id="concave_hull_of_polygons.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 7</gml:lowerCorner><gml:upperCorner>6 9</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_of_polygons.geom.1"><gml:exterior><gml:LinearRing><gml:posList>4 7 5 7 6 7 6 9 5 9 4 8 3 8 -1 8 -1 7 3 7 4 7</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>multipolys.1</ogr:fid>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
+      <ogr:area>8.500000</ogr:area>
+      <ogr:perimeter>17.414214</ogr:perimeter>
+    </ogr:concave_hull_of_polygons>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_of_polygons gml:id="concave_hull_of_polygons.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>0 0</gml:lowerCorner><gml:upperCorner>1 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiSurface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_of_polygons.geom.2"><gml:surfaceMember><gml:Polygon gml:id="concave_hull_of_polygons.geom.2.0"><gml:exterior><gml:LinearRing><gml:posList>0 0 1 0 1 1 0 1 0 0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember></gml:MultiSurface></ogr:geometryProperty>
+      <ogr:fid>multipolys.2</ogr:fid>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>2</ogr:Bintval>
+      <ogr:Bfloatval>-0.123</ogr:Bfloatval>
+      <ogr:area>1.000000</ogr:area>
+      <ogr:perimeter>4.000000</ogr:perimeter>
+    </ogr:concave_hull_of_polygons>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_of_polygons gml:id="concave_hull_of_polygons.3">
+      <ogr:fid>multipolys.3</ogr:fid>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>3</ogr:Bintval>
+      <ogr:Bfloatval>0</ogr:Bfloatval>
+      <ogr:area xsi:nil="true"/>
+      <ogr:perimeter xsi:nil="true"/>
+    </ogr:concave_hull_of_polygons>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons.xsd
+++ b/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons.xsd
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="concave_hull_of_polygons" type="ogr:concave_hull_of_polygons_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="concave_hull_of_polygons_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:SurfacePropertyType" nillable="true" minOccurs="0" maxOccurs="1"/> <!-- restricted to Polygon --><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="Bname" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="4"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="Bintval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="Bfloatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="area" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="6"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="perimeter" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="6"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons_03.gml
+++ b/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons_03.gml
@@ -10,13 +10,13 @@
   <ogr:featureMember>
     <ogr:concave_hull_of_polygons_03 gml:id="concave_hull_of_polygons_03.0">
       <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 2</gml:lowerCorner><gml:upperCorner>3 4</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_of_polygons_03.geom.0"><gml:exterior><gml:LinearRing><gml:posList>3 3 3 4 1 4 1 2 2 2 3 3</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:geometryProperty><gml:MultiSurface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_of_polygons_03.geom.0"><gml:surfaceMember><gml:Polygon gml:id="concave_hull_of_polygons_03.geom.0.0"><gml:exterior><gml:LinearRing><gml:posList>1 2 2 2 2 3 3 3 3 4 1 4 1 2</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember></gml:MultiSurface></ogr:geometryProperty>
       <ogr:fid>multipolys.0</ogr:fid>
       <ogr:Bname>Test</ogr:Bname>
       <ogr:Bintval>1</ogr:Bintval>
       <ogr:Bfloatval>0.123</ogr:Bfloatval>
-      <ogr:area>3.500000</ogr:area>
-      <ogr:perimeter>7.414214</ogr:perimeter>
+      <ogr:area>3.000000</ogr:area>
+      <ogr:perimeter>8.000000</ogr:perimeter>
     </ogr:concave_hull_of_polygons_03>
   </ogr:featureMember>
   <ogr:featureMember>

--- a/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons_03.gml
+++ b/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons_03.gml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ concave_hull_of_polygons_03.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 0</gml:lowerCorner><gml:upperCorner>6 9</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                                             
+  <ogr:featureMember>
+    <ogr:concave_hull_of_polygons_03 gml:id="concave_hull_of_polygons_03.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 2</gml:lowerCorner><gml:upperCorner>3 4</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_of_polygons_03.geom.0"><gml:exterior><gml:LinearRing><gml:posList>3 3 3 4 1 4 1 2 2 2 3 3</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>multipolys.0</ogr:fid>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>1</ogr:Bintval>
+      <ogr:Bfloatval>0.123</ogr:Bfloatval>
+      <ogr:area>3.500000</ogr:area>
+      <ogr:perimeter>7.414214</ogr:perimeter>
+    </ogr:concave_hull_of_polygons_03>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_of_polygons_03 gml:id="concave_hull_of_polygons_03.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 7</gml:lowerCorner><gml:upperCorner>6 9</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_of_polygons_03.geom.1"><gml:exterior><gml:LinearRing><gml:posList>4 7 5 7 6 7 6 9 5 9 3 8 -1 8 -1 7 3 7 4 7</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>multipolys.1</ogr:fid>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
+      <ogr:area>9.000000</ogr:area>
+      <ogr:perimeter>17.236068</ogr:perimeter>
+    </ogr:concave_hull_of_polygons_03>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_of_polygons_03 gml:id="concave_hull_of_polygons_03.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>0 0</gml:lowerCorner><gml:upperCorner>1 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiSurface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_of_polygons_03.geom.2"><gml:surfaceMember><gml:Polygon gml:id="concave_hull_of_polygons_03.geom.2.0"><gml:exterior><gml:LinearRing><gml:posList>0 0 1 0 1 1 0 1 0 0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember></gml:MultiSurface></ogr:geometryProperty>
+      <ogr:fid>multipolys.2</ogr:fid>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>2</ogr:Bintval>
+      <ogr:Bfloatval>-0.123</ogr:Bfloatval>
+      <ogr:area>1.000000</ogr:area>
+      <ogr:perimeter>4.000000</ogr:perimeter>
+    </ogr:concave_hull_of_polygons_03>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_of_polygons_03 gml:id="concave_hull_of_polygons_03.3">
+      <ogr:fid>multipolys.3</ogr:fid>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>3</ogr:Bintval>
+      <ogr:Bfloatval>0</ogr:Bfloatval>
+      <ogr:area xsi:nil="true"/>
+      <ogr:perimeter xsi:nil="true"/>
+    </ogr:concave_hull_of_polygons_03>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons_03.xsd
+++ b/python/plugins/processing/tests/testdata/expected/concave_hull_of_polygons_03.xsd
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="concave_hull_of_polygons_03" type="ogr:concave_hull_of_polygons_03_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="concave_hull_of_polygons_03_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:SurfacePropertyType" nillable="true" minOccurs="0" maxOccurs="1"/> <!-- restricted to Polygon --><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="Bname" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="4"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="Bintval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="Bfloatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="area" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="6"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="perimeter" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="6"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/concave_hull_polygons.gml
+++ b/python/plugins/processing/tests/testdata/expected/concave_hull_polygons.gml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ concave_hull_polygons.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 0</gml:lowerCorner><gml:upperCorner>6 9</gml:upperCorner></gml:Envelope></gml:boundedBy>
+                                                                                                                                                                             
+  <ogr:featureMember>
+    <ogr:concave_hull_polygons gml:id="concave_hull_polygons.0">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>1 2</gml:lowerCorner><gml:upperCorner>3 4</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_polygons.geom.0"><gml:exterior><gml:LinearRing><gml:posList>3 3 3 4 1 4 1 2 2 2 3 3</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>multipolys.0</ogr:fid>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>1</ogr:Bintval>
+      <ogr:Bfloatval>0.123</ogr:Bfloatval>
+      <ogr:area>3.500000</ogr:area>
+      <ogr:perimeter>7.414214</ogr:perimeter>
+    </ogr:concave_hull_polygons>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_polygons gml:id="concave_hull_polygons.1">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-1 7</gml:lowerCorner><gml:upperCorner>6 9</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_polygons.geom.1"><gml:exterior><gml:LinearRing><gml:posList>3 8 -1 8 -1 7 3 7 4 7 5 7 6 7 6 9 5 9 3 8</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <ogr:fid>multipolys.1</ogr:fid>
+      <ogr:Bname xsi:nil="true"/>
+      <ogr:Bintval xsi:nil="true"/>
+      <ogr:Bfloatval xsi:nil="true"/>
+      <ogr:area>9.000000</ogr:area>
+      <ogr:perimeter>17.236068</ogr:perimeter>
+    </ogr:concave_hull_polygons>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_polygons gml:id="concave_hull_polygons.2">
+      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>0 0</gml:lowerCorner><gml:upperCorner>1 1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:MultiSurface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="concave_hull_polygons.geom.2"><gml:surfaceMember><gml:Polygon gml:id="concave_hull_polygons.geom.2.0"><gml:exterior><gml:LinearRing><gml:posList>0 0 1 0 1 1 0 1 0 0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember></gml:MultiSurface></ogr:geometryProperty>
+      <ogr:fid>multipolys.2</ogr:fid>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>2</ogr:Bintval>
+      <ogr:Bfloatval>-0.123</ogr:Bfloatval>
+      <ogr:area>1.000000</ogr:area>
+      <ogr:perimeter>4.000000</ogr:perimeter>
+    </ogr:concave_hull_polygons>
+  </ogr:featureMember>
+  <ogr:featureMember>
+    <ogr:concave_hull_polygons gml:id="concave_hull_polygons.3">
+      <ogr:fid>multipolys.3</ogr:fid>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>3</ogr:Bintval>
+      <ogr:Bfloatval>0</ogr:Bfloatval>
+      <ogr:area xsi:nil="true"/>
+      <ogr:perimeter xsi:nil="true"/>
+    </ogr:concave_hull_polygons>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/concave_hull_polygons.xsd
+++ b/python/plugins/processing/tests/testdata/expected/concave_hull_polygons.xsd
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    targetNamespace="http://ogr.maptools.org/"
+    xmlns:ogr="http://ogr.maptools.org/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0"
+    elementFormDefault="qualified"
+    version="1.0">
+<xs:annotation>
+  <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+    <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+  </xs:appinfo>
+</xs:annotation>
+<xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+<xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="featureMember">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="gml:AbstractFeatureMemberType">
+                <xs:sequence>
+                  <xs:element ref="gml:AbstractFeature"/>
+                </xs:sequence>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="concave_hull_polygons" type="ogr:concave_hull_polygons_Type" substitutionGroup="gml:AbstractFeature"/>
+<xs:complexType name="concave_hull_polygons_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:SurfacePropertyType" nillable="true" minOccurs="0" maxOccurs="1"/> <!-- restricted to Polygon --><!-- srsName="urn:ogc:def:crs:EPSG::4326" -->
+        <xs:element name="fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="Bname" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="4"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="Bintval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="Bfloatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="area" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="6"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="perimeter" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="6"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -310,6 +310,26 @@ tests:
             precision: 5
             normalize: True
 
+  - algorithm: native:concavehullbyfeature
+    name: Concave hull (polygons)
+    condition:
+      geos:
+        at_least: 31100
+    params:
+      ALPHA: 0.3
+      HOLES: true
+      INPUT:
+        name: multipolys.gml|layername=multipolys
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/concave_hull_polygons.gml
+        type: vector
+        compare:
+          geometry:
+            precision: 5
+            normalize: True
+
   - algorithm: qgis:knearestconcavehull
     name: K-nearest Neighbor Concave Hull - Points (k=7)
     params:

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
@@ -769,7 +769,7 @@ tests:
         name: expected/geometry_by_expression_layerref.gml
         type: vector
 
-  - algorithm: native:concavehullofpolygons
+  - algorithm: native:tightconcavehullofpolygons
     name: Concave hull of polygons (0.1 ratio)
     condition:
       geos:
@@ -780,7 +780,6 @@ tests:
         name: multipolys.gml|layername=multipolys
         type: vector
       RATIO: 0.1
-      TIGHT: false
     results:
       OUTPUT:
         name: expected/concave_hull_of_polygons.gml
@@ -790,7 +789,7 @@ tests:
             precision: 5
             normalize: True
 
-  - algorithm: native:concavehullofpolygons
+  - algorithm: native:tightconcavehullofpolygons
     name: Concave hull of polygons (0.3 ratio)
     condition:
       geos:
@@ -801,7 +800,6 @@ tests:
         name: multipolys.gml|layername=multipolys
         type: vector
       RATIO: 0.3
-      TIGHT: false
     results:
       OUTPUT:
         name: expected/concave_hull_of_polygons_03.gml

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests5.yaml
@@ -768,3 +768,45 @@ tests:
       OUTPUT:
         name: expected/geometry_by_expression_layerref.gml
         type: vector
+
+  - algorithm: native:concavehullofpolygons
+    name: Concave hull of polygons (0.1 ratio)
+    condition:
+      geos:
+        at_least: 31100
+    params:
+      HOLES: true
+      INPUT:
+        name: multipolys.gml|layername=multipolys
+        type: vector
+      RATIO: 0.1
+      TIGHT: false
+    results:
+      OUTPUT:
+        name: expected/concave_hull_of_polygons.gml
+        type: vector
+        compare:
+          geometry:
+            precision: 5
+            normalize: True
+
+  - algorithm: native:concavehullofpolygons
+    name: Concave hull of polygons (0.3 ratio)
+    condition:
+      geos:
+        at_least: 31100
+    params:
+      HOLES: true
+      INPUT:
+        name: multipolys.gml|layername=multipolys
+        type: vector
+      RATIO: 0.3
+      TIGHT: false
+    results:
+      OUTPUT:
+        name: expected/concave_hull_of_polygons_03.gml
+        type: vector
+        compare:
+          geometry:
+            precision: 5
+            normalize: True

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -97,6 +97,7 @@ set(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmclip.cpp
   processing/qgsalgorithmconcavehull.cpp
   processing/qgsalgorithmconcavehullbyfeature.cpp
+  processing/qgsalgorithmconcavehullofpolygons.cpp
   processing/qgsalgorithmconditionalbranch.cpp
   processing/qgsalgorithmconstantraster.cpp
   processing/qgsalgorithmconverttocurves.cpp

--- a/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
@@ -84,7 +84,7 @@ void QgsConcaveHullByFeatureAlgorithm::initParameters( const QVariantMap & )
 
 QList<int> QgsConcaveHullByFeatureAlgorithm::inputLayerTypes() const
 {
-  return QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPoint );
+  return QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPoint ) << static_cast<int>( Qgis::ProcessingSourceType::VectorLine ) << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon );
 }
 
 QgsFields QgsConcaveHullByFeatureAlgorithm::outputFields( const QgsFields &inputFields ) const
@@ -111,20 +111,38 @@ QgsFeatureList QgsConcaveHullByFeatureAlgorithm::processFeature( const QgsFeatur
   if ( f.hasGeometry() )
   {
     QgsGeometry outputGeometry;
-    const QgsAbstractGeometry *inputGeometry = f.geometry().constGet();
-    const QgsGeometryCollection *collection = qgsgeometry_cast< const QgsGeometryCollection * >( inputGeometry );
-    if ( !collection || collection->numGeometries() == 1 )
+    if ( f.geometry().type() == Qgis::GeometryType::Point )
     {
-      feedback->reportError( QObject::tr( "Cannot calculate convex hull for a single point feature (%1) (try 'Concave hull (by layer)' algorithm instead)." ).arg( f.id() ) );
-      f.clearGeometry();
+      const QgsAbstractGeometry *inputGeometry = f.geometry().constGet();
+      const QgsGeometryCollection *collection = qgsgeometry_cast< const QgsGeometryCollection * >( inputGeometry );
+      if ( !collection || collection->numGeometries() == 1 )
+      {
+        feedback->reportError( QObject::tr( "Cannot calculate convex hull for a single point feature (%1) (try 'Concave hull (by layer)' algorithm instead)." ).arg( f.id() ) );
+        f.clearGeometry();
+      }
+      else
+      {
+        outputGeometry = f.geometry().concaveHull( mPercentage, mAllowHoles );
+        if ( outputGeometry.isNull() && !outputGeometry.lastError().isEmpty() )
+          feedback->reportError( outputGeometry.lastError() );
+        f.setGeometry( outputGeometry );
+      }
     }
-    else
+    else if ( f.geometry().type() == Qgis::GeometryType::Line )
     {
       outputGeometry = f.geometry().concaveHull( mPercentage, mAllowHoles );
       if ( outputGeometry.isNull() && !outputGeometry.lastError().isEmpty() )
         feedback->reportError( outputGeometry.lastError() );
       f.setGeometry( outputGeometry );
     }
+    else if ( f.geometry().type() == Qgis::GeometryType::Polygon )
+    {
+      outputGeometry = f.geometry().concaveHullOfPolygons( mPercentage, mAllowHoles );
+      if ( outputGeometry.isNull() && !outputGeometry.lastError().isEmpty() )
+        feedback->reportError( outputGeometry.lastError() );
+      f.setGeometry( outputGeometry );
+    }
+
     if ( outputGeometry.type() == Qgis::GeometryType::Polygon )
     {
       QgsAttributes attrs = f.attributes();

--- a/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
@@ -59,9 +59,12 @@ QString QgsConcaveHullByFeatureAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm calculates the concave hull for each feature in an input layer." )
          + u"\n\n"_s
-         + QObject::tr( "A concave hull is a polygon which contains all the points of the input geometries, but is a better approximation than the convex hull to the area occupied by the input." )
+         + QObject::tr( "For point and line layers, a concave hull is a polygon which contains all the vertices of the input geometries, but is a better approximation than the convex hull to the area occupied by the input." )
          + u"\n\n"_s
-         + QObject::tr( "It is frequently used to convert a multi-point into a polygonal area which contains all the points from the input geometry." )
+         + QObject::tr(
+           "When the input is a polygon layer, the algorithm operates differently: it computes a concave hull that strictly respects the boundaries of the input polygons. The computed hull fills the "
+           "empty space between the polygons within a multi-polygon feature, but does not intersect their interior."
+         )
          + u"\n\n"_s
          + QObject::tr( "See the 'Concave hull (by layer)' algorithm for a concave hull calculation which covers the whole layer or grouped subsets of features." );
 }
@@ -78,8 +81,20 @@ QgsConcaveHullByFeatureAlgorithm *QgsConcaveHullByFeatureAlgorithm::createInstan
 
 void QgsConcaveHullByFeatureAlgorithm::initParameters( const QVariantMap & )
 {
-  addParameter( new QgsProcessingParameterNumber( u"ALPHA"_s, QObject::tr( "Threshold (0-1, where 1 is equivalent with Convex Hull)" ), Qgis::ProcessingNumberParameterType::Double, 0.3, false, 0, 1 ) );
-  addParameter( new QgsProcessingParameterBoolean( u"HOLES"_s, QObject::tr( "Allow holes" ), true ) );
+  auto alphaParam
+    = std::make_unique<QgsProcessingParameterNumber>( u"ALPHA"_s, QObject::tr( "Threshold (0-1, where 1 is equivalent with Convex Hull)" ), Qgis::ProcessingNumberParameterType::Double, 0.3, false, 0, 1 );
+  alphaParam->setHelp(
+    QObject::tr(
+      "Controls the concaveness of the computed hull. A value of 1 produces the convex hull, while a value closer to 0 produces a highly concave hull. For point and line layers, this value "
+      "represents the target percentage of the convex hull area. For polygon layers, it specifies the maximum edge length as a fraction of the difference between the longest and shortest edge "
+      "lengths in the empty space between polygons."
+    )
+  );
+  addParameter( alphaParam.release() );
+
+  auto holesParam = std::make_unique<QgsProcessingParameterBoolean>( u"HOLES"_s, QObject::tr( "Allow holes" ), true );
+  holesParam->setHelp( QObject::tr( "Controls whether the computed concave hull is allowed to contain holes." ) );
+  addParameter( holesParam.release() );
 }
 
 QList<int> QgsConcaveHullByFeatureAlgorithm::inputLayerTypes() const

--- a/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
@@ -62,8 +62,8 @@ QString QgsConcaveHullByFeatureAlgorithm::shortHelpString() const
          + QObject::tr( "For point and line layers, a concave hull is a polygon which contains all the vertices of the input geometries, but is a better approximation than the convex hull to the area occupied by the input." )
          + u"\n\n"_s
          + QObject::tr(
-           "When the input is a polygon layer, the algorithm operates differently: it computes a concave hull that strictly respects the boundaries of the input polygons. The computed hull fills the "
-           "empty space between the polygons within a multi-polygon feature, but does not intersect their interior."
+           "When the input is a polygon layer, the algorithm operates differently: it computes a concave hull that respects the interior of the input polygons. The concave hull does not intersect "
+           "the polygon interiors. The computed hull also fills the empty space between the polygons within a multi-polygon feature."
          )
          + u"\n\n"_s
          + QObject::tr( "See the 'Concave hull (by layer)' algorithm for a concave hull calculation which covers the whole layer or grouped subsets of features." );
@@ -132,7 +132,7 @@ QgsFeatureList QgsConcaveHullByFeatureAlgorithm::processFeature( const QgsFeatur
       const QgsGeometryCollection *collection = qgsgeometry_cast< const QgsGeometryCollection * >( inputGeometry );
       if ( !collection || collection->numGeometries() == 1 )
       {
-        feedback->reportError( QObject::tr( "Cannot calculate convex hull for a single point feature (%1) (try 'Concave hull (by layer)' algorithm instead)." ).arg( f.id() ) );
+        feedback->reportError( QObject::tr( "Cannot calculate concave hull for a single point feature (%1) (try 'Concave hull (by layer)' algorithm instead)." ).arg( f.id() ) );
         f.clearGeometry();
       }
       else

--- a/src/analysis/processing/qgsalgorithmconcavehullofpolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullofpolygons.cpp
@@ -37,7 +37,7 @@ QString QgsConcaveHullOfPolygonsAlgorithm::displayName() const
 
 QStringList QgsConcaveHullOfPolygonsAlgorithm::tags() const
 {
-  return QObject::tr( "concave,hull,bounds,bounding,convex,multipolygons,boundary" ).split( ',' );
+  return QObject::tr( "concave,hull,bounds,bounding,convex,multipolygons,boundary,fill,holes,between,space" ).split( ',' );
 }
 
 QString QgsConcaveHullOfPolygonsAlgorithm::group() const

--- a/src/analysis/processing/qgsalgorithmconcavehullofpolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullofpolygons.cpp
@@ -58,7 +58,7 @@ QString QgsConcaveHullOfPolygonsAlgorithm::shortHelpString() const
   return QObject::tr( "This algorithm calculates a concave hull for each multi-polygon feature in an input layer." )
          + u"\n\n"_s
          + QObject::tr(
-           "Unlike the standard Concave Hull algorithm, a Concave Hull of Polygons is a (possibly) non-convex polygon containing all the input polygons. The computed hull fills the gaps between the "
+           "Unlike the standard Concave Hull algorithm, a tight concave hull is a (possibly) non-convex polygon containing all the input polygons. The computed hull fills the gaps between the "
            "polygons without intersecting their interiors. It strictly follows the outer boundaries of the input polygons, allowing you to fill gaps between them without distorting their original "
            "shapes."
          )

--- a/src/analysis/processing/qgsalgorithmconcavehullofpolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullofpolygons.cpp
@@ -1,0 +1,168 @@
+/***************************************************************************
+                         qgsalgorithmconcavehullofpolygons.cpp
+                         ---------------------
+    begin                : March 2026
+    copyright            : (C) 2026 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmconcavehullofpolygons.h"
+
+#include "qgsgeometrycollection.h"
+
+#include <QString>
+
+using namespace Qt::StringLiterals;
+
+///@cond PRIVATE
+
+QString QgsConcaveHullOfPolygonsAlgorithm::name() const
+{
+  return u"concavehullofpolygons"_s;
+}
+
+QString QgsConcaveHullOfPolygonsAlgorithm::displayName() const
+{
+  return QObject::tr( "Concave hull (of polygons)" );
+}
+
+QStringList QgsConcaveHullOfPolygonsAlgorithm::tags() const
+{
+  return QObject::tr( "concave,hull,bounds,bounding,convex,multipolygons,boundary" ).split( ',' );
+}
+
+QString QgsConcaveHullOfPolygonsAlgorithm::group() const
+{
+  return QObject::tr( "Vector geometry" );
+}
+
+QString QgsConcaveHullOfPolygonsAlgorithm::groupId() const
+{
+  return u"vectorgeometry"_s;
+}
+
+QString QgsConcaveHullOfPolygonsAlgorithm::outputName() const
+{
+  return QObject::tr( "Concave hulls" );
+}
+
+QString QgsConcaveHullOfPolygonsAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm calculates a concave hull for each multi-polygon feature in an input layer." )
+         + u"\n\n"_s
+         + QObject::tr(
+           "Unlike the standard Concave Hull algorithm, a Concave Hull of Polygons is a (possibly) non-convex polygon containing all the input polygons. The computed hull fills the gaps between the "
+           "polygons without intersecting their interiors."
+         )
+         + u"\n\n"_s
+         + QObject::tr(
+           "It is particularly useful for cases such as generalizing groups of building outlines, creating 'district' polygons around blocks, or removing gaps and joining disjoint sets of polygons."
+         )
+         + u"\n\n"_s
+         + QObject::tr( "The algorithm works by creating a constrained Delaunay Triangulation of the space between the polygons and removing the longest outer edges until a target criterion is reached." )
+         + u"\n\n"_s
+         + QObject::tr( "The input geometry must be a valid Polygon or MultiPolygon (i.e., the individual polygons must not overlap)." );
+}
+
+QString QgsConcaveHullOfPolygonsAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Constructs a concave hull for a set of polygons, respecting the polygons as constraints and filling gaps between them." );
+}
+
+QgsConcaveHullOfPolygonsAlgorithm *QgsConcaveHullOfPolygonsAlgorithm::createInstance() const
+{
+  return new QgsConcaveHullOfPolygonsAlgorithm();
+}
+
+void QgsConcaveHullOfPolygonsAlgorithm::initParameters( const QVariantMap & )
+{
+  auto ratioParam
+    = std::make_unique<QgsProcessingParameterNumber>( u"RATIO"_s, QObject::tr( "Ratio (0-1, where 1 is equivalent with Convex Hull)" ), Qgis::ProcessingNumberParameterType::Double, 0.3, false, 0, 1 );
+  ratioParam->setHelp(
+    QObject::tr(
+      "Specifies the maximum edge length as a fraction of the difference between the longest and shortest edge lengths between the polygons. This normalizes the maximum edge length to be scale-free. "
+      "A value of 1 produces the convex hull; a value of 0 produces the original polygons."
+    )
+  );
+  addParameter( ratioParam.release() );
+
+  auto holesParam = std::make_unique<QgsProcessingParameterBoolean>( u"HOLES"_s, QObject::tr( "Allow holes" ), true );
+  holesParam->setHelp( QObject::tr( "Controls whether the computed concave hull is allowed to contain holes." ) );
+  addParameter( holesParam.release() );
+
+  auto tightParam = std::make_unique<QgsProcessingParameterBoolean>( u"TIGHT"_s, QObject::tr( "Follow the outer boundaries of input polygons tightly" ), false );
+  tightParam->setHelp(
+    QObject::tr( "If checked, the hull follows the outer boundaries of the input polygons tightly. This allows filling gaps between polygons without distorting their original outer boundaries." )
+  );
+  addParameter( tightParam.release() );
+}
+
+QList<int> QgsConcaveHullOfPolygonsAlgorithm::inputLayerTypes() const
+{
+  return QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon );
+}
+
+QgsFields QgsConcaveHullOfPolygonsAlgorithm::outputFields( const QgsFields &inputFields ) const
+{
+  QgsFields newFields;
+  newFields.append( QgsField( u"area"_s, QMetaType::Type::Double, QString(), 20, 6 ) );
+  newFields.append( QgsField( u"perimeter"_s, QMetaType::Type::Double, QString(), 20, 6 ) );
+  return QgsProcessingUtils::combineFields( inputFields, newFields );
+}
+
+bool QgsConcaveHullOfPolygonsAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+#if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 11
+  throw QgsProcessingException( QObject::tr( "This algorithm requires a QGIS build based on GEOS 3.11 or later" ) );
+#endif
+  mPercentage = parameterAsDouble( parameters, u"RATIO"_s, context );
+  mAllowHoles = parameterAsBool( parameters, u"HOLES"_s, context );
+  mTight = parameterAsBool( parameters, u"TIGHT"_s, context );
+  return true;
+}
+
+QgsFeatureList QgsConcaveHullOfPolygonsAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
+{
+  QgsFeature f = feature;
+  if ( f.hasGeometry() )
+  {
+    QgsGeometry outputGeometry;
+    outputGeometry = f.geometry().concaveHullOfPolygons( mPercentage, mAllowHoles, mTight );
+    if ( outputGeometry.isNull() && !outputGeometry.lastError().isEmpty() )
+      feedback->reportError( outputGeometry.lastError() );
+    f.setGeometry( outputGeometry );
+
+    if ( outputGeometry.type() == Qgis::GeometryType::Polygon )
+    {
+      QgsAttributes attrs = f.attributes();
+      attrs << outputGeometry.constGet()->area() << outputGeometry.constGet()->perimeter();
+      f.setAttributes( attrs );
+    }
+    else
+    {
+      if ( outputGeometry.type() == Qgis::GeometryType::Line )
+      {
+        feedback->pushWarning( QObject::tr( "Concave hull for feature %1 resulted in a linestring, ignoring" ).arg( f.id() ) );
+      }
+      else if ( outputGeometry.type() == Qgis::GeometryType::Point )
+      {
+        feedback->pushWarning( QObject::tr( "Concave hull for feature %1 resulted in a point, ignoring" ).arg( f.id() ) );
+      }
+      QgsAttributes attrs = f.attributes();
+      attrs << QVariant() << QVariant();
+      f.setAttributes( attrs );
+    }
+  }
+  return QgsFeatureList() << f;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmconcavehullofpolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullofpolygons.cpp
@@ -17,8 +17,6 @@
 
 #include "qgsalgorithmconcavehullofpolygons.h"
 
-#include "qgsgeometrycollection.h"
-
 #include <QString>
 
 using namespace Qt::StringLiterals;
@@ -27,17 +25,17 @@ using namespace Qt::StringLiterals;
 
 QString QgsConcaveHullOfPolygonsAlgorithm::name() const
 {
-  return u"concavehullofpolygons"_s;
+  return u"tightconcavehullofpolygons"_s;
 }
 
 QString QgsConcaveHullOfPolygonsAlgorithm::displayName() const
 {
-  return QObject::tr( "Concave hull (of polygons)" );
+  return QObject::tr( "Fill gaps between polygons" );
 }
 
 QStringList QgsConcaveHullOfPolygonsAlgorithm::tags() const
 {
-  return QObject::tr( "concave,hull,bounds,bounding,convex,multipolygons,boundary,fill,holes,between,space" ).split( ',' );
+  return QObject::tr( "concave,hull,bounds,bounding,convex,multipolygons,boundary,fill,holes,between,space,tight,strict" ).split( ',' );
 }
 
 QString QgsConcaveHullOfPolygonsAlgorithm::group() const
@@ -52,7 +50,7 @@ QString QgsConcaveHullOfPolygonsAlgorithm::groupId() const
 
 QString QgsConcaveHullOfPolygonsAlgorithm::outputName() const
 {
-  return QObject::tr( "Concave hulls" );
+  return QObject::tr( "Tight concave hulls" );
 }
 
 QString QgsConcaveHullOfPolygonsAlgorithm::shortHelpString() const
@@ -61,7 +59,8 @@ QString QgsConcaveHullOfPolygonsAlgorithm::shortHelpString() const
          + u"\n\n"_s
          + QObject::tr(
            "Unlike the standard Concave Hull algorithm, a Concave Hull of Polygons is a (possibly) non-convex polygon containing all the input polygons. The computed hull fills the gaps between the "
-           "polygons without intersecting their interiors."
+           "polygons without intersecting their interiors. It strictly follows the outer boundaries of the input polygons, allowing you to fill gaps between them without distorting their original "
+           "shapes."
          )
          + u"\n\n"_s
          + QObject::tr(
@@ -75,7 +74,7 @@ QString QgsConcaveHullOfPolygonsAlgorithm::shortHelpString() const
 
 QString QgsConcaveHullOfPolygonsAlgorithm::shortDescription() const
 {
-  return QObject::tr( "Constructs a concave hull for a set of polygons, respecting the polygons as constraints and filling gaps between them." );
+  return QObject::tr( "Constructs a tight concave hull for a set of polygons, filling gaps between them while strictly preserving their original outer boundaries." );
 }
 
 QgsConcaveHullOfPolygonsAlgorithm *QgsConcaveHullOfPolygonsAlgorithm::createInstance() const
@@ -98,12 +97,6 @@ void QgsConcaveHullOfPolygonsAlgorithm::initParameters( const QVariantMap & )
   auto holesParam = std::make_unique<QgsProcessingParameterBoolean>( u"HOLES"_s, QObject::tr( "Allow holes" ), true );
   holesParam->setHelp( QObject::tr( "Controls whether the computed concave hull is allowed to contain holes." ) );
   addParameter( holesParam.release() );
-
-  auto tightParam = std::make_unique<QgsProcessingParameterBoolean>( u"TIGHT"_s, QObject::tr( "Follow the outer boundaries of input polygons tightly" ), false );
-  tightParam->setHelp(
-    QObject::tr( "If checked, the hull follows the outer boundaries of the input polygons tightly. This allows filling gaps between polygons without distorting their original outer boundaries." )
-  );
-  addParameter( tightParam.release() );
 }
 
 QList<int> QgsConcaveHullOfPolygonsAlgorithm::inputLayerTypes() const
@@ -126,7 +119,6 @@ bool QgsConcaveHullOfPolygonsAlgorithm::prepareAlgorithm( const QVariantMap &par
 #endif
   mPercentage = parameterAsDouble( parameters, u"RATIO"_s, context );
   mAllowHoles = parameterAsBool( parameters, u"HOLES"_s, context );
-  mTight = parameterAsBool( parameters, u"TIGHT"_s, context );
   return true;
 }
 
@@ -136,7 +128,7 @@ QgsFeatureList QgsConcaveHullOfPolygonsAlgorithm::processFeature( const QgsFeatu
   if ( f.hasGeometry() )
   {
     QgsGeometry outputGeometry;
-    outputGeometry = f.geometry().concaveHullOfPolygons( mPercentage, mAllowHoles, mTight );
+    outputGeometry = f.geometry().concaveHullOfPolygons( mPercentage, mAllowHoles, true );
     if ( outputGeometry.isNull() && !outputGeometry.lastError().isEmpty() )
       feedback->reportError( outputGeometry.lastError() );
     f.setGeometry( outputGeometry );

--- a/src/analysis/processing/qgsalgorithmconcavehullofpolygons.h
+++ b/src/analysis/processing/qgsalgorithmconcavehullofpolygons.h
@@ -1,0 +1,71 @@
+/***************************************************************************
+                         qgsalgorithmconcavehullofpolygons.h
+                         ---------------------
+    begin                : March 2026
+    copyright            : (C) 2026 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMCONCAVEHULLOFPOLYGONS_H
+#define QGSALGORITHMCONCAVEHULLOFPOLYGONS_H
+
+
+#include "qgis_sip.h"
+#include "qgsapplication.h"
+#include "qgsprocessingalgorithm.h"
+
+#include <QString>
+
+#define SIP_NO_FILE
+
+using namespace Qt::StringLiterals;
+
+///@cond PRIVATE
+
+
+/**
+ * Native concave hull of polygons algorithm.
+ */
+class QgsConcaveHullOfPolygonsAlgorithm : public QgsProcessingFeatureBasedAlgorithm
+{
+  public:
+    QgsConcaveHullOfPolygonsAlgorithm() = default;
+    QIcon icon() const override { return QgsApplication::getThemeIcon( u"/algorithms/mAlgorithmConvexHull.svg"_s ); }
+    QString svgIconPath() const override { return QgsApplication::iconPath( u"/algorithms/mAlgorithmConvexHull.svg"_s ); }
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsConcaveHullOfPolygonsAlgorithm *createInstance() const override SIP_FACTORY;
+    void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
+    QList<int> inputLayerTypes() const override;
+
+  protected:
+    QString outputName() const override;
+    Qgis::WkbType outputWkbType( Qgis::WkbType ) const override { return Qgis::WkbType::Polygon; }
+    QgsFields outputFields( const QgsFields &inputFields ) const override;
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsFeatureList processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+  private:
+    double mPercentage = 0;
+    bool mAllowHoles = false;
+    bool mTight = false;
+};
+
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMCONCAVEHULLOFPOLYGONS_H

--- a/src/analysis/processing/qgsalgorithmconcavehullofpolygons.h
+++ b/src/analysis/processing/qgsalgorithmconcavehullofpolygons.h
@@ -62,7 +62,6 @@ class QgsConcaveHullOfPolygonsAlgorithm : public QgsProcessingFeatureBasedAlgori
   private:
     double mPercentage = 0;
     bool mAllowHoles = false;
-    bool mTight = false;
 };
 
 

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -69,6 +69,7 @@
 #include "qgsalgorithmclip.h"
 #include "qgsalgorithmconcavehull.h"
 #include "qgsalgorithmconcavehullbyfeature.h"
+#include "qgsalgorithmconcavehullofpolygons.h"
 #include "qgsalgorithmconditionalbranch.h"
 #include "qgsalgorithmconstantraster.h"
 #include "qgsalgorithmconvertgeometrytype.h"
@@ -417,6 +418,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsCombineStylesAlgorithm() );
   addAlgorithm( new QgsConcaveHullAlgorithm() );
   addAlgorithm( new QgsConcaveHullByFeatureAlgorithm() );
+  addAlgorithm( new QgsConcaveHullOfPolygonsAlgorithm() );
   addAlgorithm( new QgsConditionalBranchAlgorithm() );
   addAlgorithm( new QgsConstantRasterAlgorithm() );
   addAlgorithm( new QgsConvertToCurvesAlgorithm() );

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2937,6 +2937,32 @@ QgsGeometry QgsGeometry::concaveHull( double targetPercent, bool allowHoles, Qgs
   return QgsGeometry( std::move( concaveHull ) );
 }
 
+QgsGeometry QgsGeometry::concaveHullOfPolygons( double lengthRatio, bool allowHoles, bool isTight, QgsFeedback *feedback ) const
+{
+  if ( !d->geometry )
+  {
+    return QgsGeometry();
+  }
+
+  if ( type() != Qgis::GeometryType::Polygon )
+  {
+    QgsGeometry geom;
+    geom.mLastError = u"Only Polygon or MultiPolygon geometries are supported"_s;
+    return geom;
+  }
+
+  QgsGeos geos( d->geometry.get() );
+  mLastError.clear();
+  std::unique_ptr< QgsAbstractGeometry > concaveHull( geos.concaveHullOfPolygons( lengthRatio, allowHoles, isTight, &mLastError, feedback ) );
+  if ( !concaveHull )
+  {
+    QgsGeometry geom;
+    geom.mLastError = mLastError;
+    return geom;
+  }
+  return QgsGeometry( std::move( concaveHull ) );
+}
+
 QgsGeometry QgsGeometry::voronoiDiagram( const QgsGeometry &extent, double tolerance, bool edgesOnly ) const
 {
   if ( !d->geometry )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1913,9 +1913,47 @@ class CORE_EXPORT QgsGeometry
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.10 or earlier.
      *
+     * \see concaveHullOfPolygons()
      * \since QGIS 3.28
      */
     QgsGeometry concaveHull( double targetPercent, bool allowHoles = false, QgsFeedback * feedback = nullptr ) const SIP_THROW( QgsNotSupportedException );
+
+    /**
+     * Constructs a concave hull of a set of polygons, respecting the polygons as constraints.
+     *
+     * A concave hull is a (possibly) non-convex polygon containing all the input polygons.
+     *
+     * The computed hull "fills the gap" between the polygons, and does not intersect their interior.
+     *
+     * A set of polygons has a sequence of hulls of increasing concaveness,
+     * determined by a numeric target parameter.
+     *
+     * The concave hull is constructed by removing the longest outer edges
+     * of the Delaunay Triangulation of the space between the polygons,
+     * until the target criterion parameter is reached.
+     *
+     * The "Maximum Edge Length" parameter limits the length of the longest edge between polygons
+     * to be no larger than this value. This can be expressed as a ratio between the lengths of the
+     * longest and shortest edges.
+     *
+     * The input geometry must be a valid Polygon or MultiPolygon (i.e. they must be non-overlapping).
+     *
+     * \param lengthRatio specifies the Maximum Edge Length as a
+     *        fraction of the difference between the longest and
+     *        shortest edge lengths between the polygons.
+     *        This normalizes the Maximum Edge Length to be scale-free.
+     *        A value of 1 produces the convex hull; a value of 0 produces
+     *        the original polygons.
+     * \param allowHoles is the concave hull allowed to contain holes?
+     * \param isTight does the hull follow the outer boundaries of the input polygons.
+     * \param feedback optional feedback object for early cancellation.
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.10 or earlier.
+     *
+     * \see concaveHull()
+     * \since QGIS 4.2
+     */
+    QgsGeometry concaveHullOfPolygons( double lengthRatio, bool allowHoles = false, bool isTight = false, QgsFeedback *feedback = nullptr ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Creates a Voronoi diagram for the nodes contained within the geometry.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1944,8 +1944,8 @@ class CORE_EXPORT QgsGeometry
      *        This normalizes the Maximum Edge Length to be scale-free.
      *        A value of 1 produces the convex hull; a value of 0 produces
      *        the original polygons.
-     * \param allowHoles is the concave hull allowed to contain holes?
-     * \param isTight does the hull follow the outer boundaries of the input polygons.
+     * \param allowHoles set to TRUE to allow the concave hull to contain holes
+     * \param isTight set to TRUE if the concave hull should follow the outer boundaries of the input polygons
      * \param feedback optional feedback object for early cancellation.
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.10 or earlier.

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -2292,6 +2292,30 @@ std::unique_ptr< QgsAbstractGeometry > QgsGeos::concaveHull( double targetPercen
 #endif
 }
 
+std::unique_ptr<QgsAbstractGeometry> QgsGeos::concaveHullOfPolygons( double lengthRatio, bool allowHoles, bool isTight, QString *errorMsg, QgsFeedback *feedback ) const
+{
+#if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 11
+  ( void ) allowHoles;
+  ( void ) targetPercent;
+  ( void ) errorMsg;
+  throw QgsNotSupportedException( QObject::tr( "Calculating concaveHullOfPolygons requires a QGIS build based on GEOS 3.11 or later" ) );
+#else
+  if ( !mGeos )
+  {
+    return nullptr;
+  }
+
+  try
+  {
+    QgsScopedGeosContextRegisterFeedback interrupt( feedback );
+    geos::unique_ptr concaveHull( GEOSConcaveHullOfPolygons_r( QgsGeosContext::get(), mGeos.get(), lengthRatio, isTight ? 1 : 0, allowHoles ? 1 : 0 ) );
+    std::unique_ptr< QgsAbstractGeometry > concaveHullGeom = fromGeos( concaveHull.get() );
+    return concaveHullGeom;
+  }
+  CATCH_GEOS_WITH_ERRMSG( nullptr )
+#endif
+}
+
 Qgis::CoverageValidityResult QgsGeos::validateCoverage( double gapWidth, std::unique_ptr<QgsAbstractGeometry> *invalidEdges, QString *errorMsg, QgsFeedback *feedback ) const
 {
 #if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 12

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -900,8 +900,8 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *        This normalizes the Maximum Edge Length to be scale-free.
      *        A value of 1 produces the convex hull; a value of 0 produces
      *        the original polygons.
-     * \param allowHoles is the concave hull allowed to contain holes?
-     * \param isTight does the hull follow the outer boundaries of the input polygons.
+     * \param allowHoles set to TRUE to allow the concave hull to contain holes
+     * \param isTight set to TRUE if the concave hull should follow the outer boundaries of the input polygons
      * \param errorMsg will be set to descriptive error string if the operation fails
      * \param feedback optional feedback object for early cancellation.
      *
@@ -909,7 +909,7 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.10 or earlier.
      * \see concaveHull()
-     * \since QGIS 3.28
+     * \since QGIS 4.2
      */
     std::unique_ptr< QgsAbstractGeometry > concaveHullOfPolygons(
       double lengthRatio, bool allowHoles = false, bool isTight = false, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -866,12 +866,54 @@ class CORE_EXPORT QgsGeos : public QgsGeometryEngine
      * \returns concave geometry that encloses the input geometry
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.10 or earlier.
+     * \see concaveHullOfPolygons()
      * \see convexHull()
      * \since QGIS 3.28
      */
     std::unique_ptr< QgsAbstractGeometry > concaveHull( double targetPercent, bool allowHoles = false, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr ) const SIP_THROW(
       QgsNotSupportedException
     );
+
+    /**
+     * Constructs a concave hull of a set of polygons, respecting the polygons as constraints.
+     *
+     * A concave hull is a (possibly) non-convex polygon containing all the input polygons.
+     *
+     * The computed hull "fills the gap" between the polygons, and does not intersect their interior.
+     *
+     * A set of polygons has a sequence of hulls of increasing concaveness,
+     * determined by a numeric target parameter.
+     *
+     * The concave hull is constructed by removing the longest outer edges
+     * of the Delaunay Triangulation of the space between the polygons,
+     * until the target criterion parameter is reached.
+     *
+     * The "Maximum Edge Length" parameter limits the length of the longest edge between polygons
+     * to be no larger than this value. This can be expressed as a ratio between the lengths of the
+     * longest and shortest edges.
+     *
+     * The input geometry *must* be a *valid* MultiPolygon (i.e. they must be non-overlapping).
+     *
+     * \param lengthRatio specifies the Maximum Edge Length as a
+     *        fraction of the difference between the longest and
+     *        shortest edge lengths between the polygons.
+     *        This normalizes the Maximum Edge Length to be scale-free.
+     *        A value of 1 produces the convex hull; a value of 0 produces
+     *        the original polygons.
+     * \param allowHoles is the concave hull allowed to contain holes?
+     * \param isTight does the hull follow the outer boundaries of the input polygons.
+     * \param errorMsg will be set to descriptive error string if the operation fails
+     * \param feedback optional feedback object for early cancellation.
+     *
+     * This method requires a QGIS build based on GEOS 3.11 or later.
+     *
+     * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.10 or earlier.
+     * \see concaveHull()
+     * \since QGIS 3.28
+     */
+    std::unique_ptr< QgsAbstractGeometry > concaveHullOfPolygons(
+      double lengthRatio, bool allowHoles = false, bool isTight = false, QString *errorMsg SIP_OUT = nullptr, QgsFeedback *feedback = nullptr
+    ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Analyze a coverage (represented as a collection of polygonal geometry with exactly matching edge

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -14819,7 +14819,8 @@ class TestQgsGeometry(QgisTestCase):
         g = l1.concaveHullOfPolygons(1, False, True)
         g.normalize()
         self.assertEqual(
-            g.asWkt(), "MultiPolygon (((1 9, 5 8, 9 9, 4 4, 7 1, 2 1, 1 9)))"
+            g.constGet().simplifiedTypeRef().asWkt(),
+            "Polygon ((1 9, 5 8, 9 9, 4 4, 7 1, 2 1, 1 9))",
         )
         l1 = QgsGeometry.fromWkt("POLYGON ((1 9, 5 8, 9 9, 4 4, 7 1, 2 1, 1 9))")
         g = l1.concaveHullOfPolygons(1, False, False)
@@ -14856,7 +14857,8 @@ class TestQgsGeometry(QgisTestCase):
         g = l1.concaveHullOfPolygons(1, False, True)
         g.normalize()
         self.assertEqual(
-            g.asWkt(), "Polygon ((1 1, 1 6, 1 9, 5 8, 9 9, 9 6, 9 1, 1 1))"
+            g.constGet().simplifiedTypeRef().asWkt(),
+            "Polygon ((1 1, 1 6, 1 9, 5 8, 9 9, 9 6, 9 1, 1 1))",
         )
 
         l1 = QgsGeometry.fromWkt(
@@ -14871,19 +14873,19 @@ class TestQgsGeometry(QgisTestCase):
         g = l1.concaveHullOfPolygons(0.2, False, True)
         g.normalize()
         self.assertEqual(
-            g.asWkt(),
+            g.constGet().simplifiedTypeRef().asWkt(),
             "Polygon ((0 2, 3 4, 4 5, 0 7, 4 10, 5 9, 9 10, 8 8, 10 9, 8 5, 10 3, 7 0, 6 3, 5 3, 4 0, 0 2))",
         )
         g = l1.concaveHullOfPolygons(0.5, False, True)
         g.normalize()
         self.assertEqual(
-            g.asWkt(),
+            g.constGet().simplifiedTypeRef().asWkt(),
             "Polygon ((0 2, 3 4, 4 5, 0 7, 4 10, 5 9, 9 10, 8 8, 10 9, 8 5, 10 3, 7 0, 4 0, 0 2))",
         )
         g = l1.concaveHullOfPolygons(1, False, True)
         g.normalize()
         self.assertEqual(
-            g.asWkt(),
+            g.constGet().simplifiedTypeRef().asWkt(),
             "Polygon ((0 2, 0 7, 4 10, 9 10, 8 8, 10 9, 8 5, 10 3, 7 0, 4 0, 0 2))",
         )
 
@@ -14900,7 +14902,7 @@ class TestQgsGeometry(QgisTestCase):
         g = l1.concaveHullOfPolygons(1, True, False)
         g.normalize()
         self.assertEqual(
-            g.asWkt(),
+            g.constGet().simplifiedTypeRef().asWkt(),
             "Polygon ((1 0, 1 4, 1 5, 1 9, 5 9, 6 9, 8 9, 9 5, 8 0, 6 0, 5 0, 1 0))",
         )
 

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -14806,6 +14806,104 @@ class TestQgsGeometry(QgisTestCase):
             "GeometryCollection (Point (1 2),LineString (3 4, 5 6),Polygon ((0 0, 1 0, 1 1, 0 1, 0 0)))",
         )
 
+    @unittest.skipIf(Qgis.geosVersionInt() < 31100, "GEOS 3.11 required")
+    def testConcaveHullOfPolygons(self):
+        """
+        Test QgsGeometry.concaveHullOfPolygons
+        """
+        l1 = QgsGeometry.fromWkt("MULTIPOLYGON EMPTY")
+        self.assertEqual(
+            l1.concaveHullOfPolygons(1, False, True).asWkt(), "Polygon EMPTY"
+        )
+        l1 = QgsGeometry.fromWkt("POLYGON ((1 9, 5 8, 9 9, 4 4, 7 1, 2 1, 1 9))")
+        g = l1.concaveHullOfPolygons(1, False, True)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(), "MultiPolygon (((1 9, 5 8, 9 9, 4 4, 7 1, 2 1, 1 9)))"
+        )
+        l1 = QgsGeometry.fromWkt("POLYGON ((1 9, 5 8, 9 9, 4 4, 7 1, 2 1, 1 9))")
+        g = l1.concaveHullOfPolygons(1, False, False)
+        g.normalize()
+        self.assertEqual(g.asWkt(), "Polygon ((1 9, 9 9, 7 1, 2 1, 1 9))")
+        l1 = QgsGeometry.fromWkt(
+            "MULTIPOLYGON (((100 200, 100 300, 150 250, 200 300, 200 200, 100 200)), ((100 100, 200 100, 150 50, 100 100)))"
+        )
+        g = l1.concaveHullOfPolygons(1, False, True)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(),
+            "Polygon ((100 100, 100 200, 100 300, 150 250, 200 300, 200 200, 200 100, 150 50, 100 100))",
+        )
+        l1 = QgsGeometry.fromWkt(
+            "MULTIPOLYGON (((100 200, 100 300, 150 250, 200 300, 200 200, 100 200)), ((100 100, 200 100, 150 50, 100 100)))"
+        )
+        g = l1.concaveHullOfPolygons(1, False, False)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(),
+            "Polygon ((100 100, 100 200, 100 300, 200 300, 200 200, 200 100, 150 50, 100 100))",
+        )
+
+        l1 = QgsGeometry.fromWkt(
+            "MULTIPOLYGON (((1 9, 5 8, 9 9, 9 6, 6 4, 4 4, 1 6, 1 9)), ((1 1, 4 3, 6 3, 9 1, 1 1)))"
+        )
+        g = l1.concaveHullOfPolygons(0, False, True)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(),
+            "MultiPolygon (((1 6, 1 9, 5 8, 9 9, 9 6, 6 4, 4 4, 1 6)),((1 1, 4 3, 6 3, 9 1, 1 1)))",
+        )
+        g = l1.concaveHullOfPolygons(1, False, True)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(), "Polygon ((1 1, 1 6, 1 9, 5 8, 9 9, 9 6, 9 1, 1 1))"
+        )
+
+        l1 = QgsGeometry.fromWkt(
+            "MULTIPOLYGON (((0 7, 4 10, 3 7, 5 6, 4 5, 0 7)), ((4 0, 0 2, 3 4, 5 3, 4 0)), ((9 10, 8 8, 10 9, 8 5, 10 3, 7 0, 6 3, 7 4, 7 6, 5 9, 9 10)))"
+        )
+        g = l1.concaveHullOfPolygons(0, False, True)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(),
+            "MultiPolygon (((5 9, 9 10, 8 8, 10 9, 8 5, 10 3, 7 0, 6 3, 7 4, 7 6, 5 9)),((0 7, 4 10, 3 7, 5 6, 4 5, 0 7)),((0 2, 3 4, 5 3, 4 0, 0 2)))",
+        )
+        g = l1.concaveHullOfPolygons(0.2, False, True)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(),
+            "Polygon ((0 2, 3 4, 4 5, 0 7, 4 10, 5 9, 9 10, 8 8, 10 9, 8 5, 10 3, 7 0, 6 3, 5 3, 4 0, 0 2))",
+        )
+        g = l1.concaveHullOfPolygons(0.5, False, True)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(),
+            "Polygon ((0 2, 3 4, 4 5, 0 7, 4 10, 5 9, 9 10, 8 8, 10 9, 8 5, 10 3, 7 0, 4 0, 0 2))",
+        )
+        g = l1.concaveHullOfPolygons(1, False, True)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(),
+            "Polygon ((0 2, 0 7, 4 10, 9 10, 8 8, 10 9, 8 5, 10 3, 7 0, 4 0, 0 2))",
+        )
+
+        # with hole
+        l1 = QgsGeometry.fromWkt(
+            "MULTIPOLYGON (((1 9, 5 9, 5 7, 3 7, 3 5, 1 5, 1 9)), ((1 4, 3 4, 3 2, 5 2, 5 0, 1 0, 1 4)), ((6 9, 8 9, 9 5, 8 0, 6 0, 6 2, 8 5, 6 7, 6 9)))"
+        )
+        g = l1.concaveHullOfPolygons(0, True, False)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(),
+            "MultiPolygon (((6 0, 6 2, 8 5, 6 7, 6 9, 8 9, 9 5, 8 0, 6 0)),((1 5, 1 9, 5 9, 5 7, 3 7, 3 5, 1 5)),((1 0, 1 4, 3 4, 3 2, 5 2, 5 0, 1 0)))",
+        )
+        g = l1.concaveHullOfPolygons(1, True, False)
+        g.normalize()
+        self.assertEqual(
+            g.asWkt(),
+            "Polygon ((1 0, 1 4, 1 5, 1 9, 5 9, 6 9, 8 9, 9 5, 8 0, 6 0, 5 0, 1 0))",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR:

1. Exposes the GEOS "concave hull of polygons" functionality for use in PyQGIS
2. Allows polygon (and line) feature input for the Concave Hull by Feature algorithm. Previously a user would have to first extract vertices from the polygon to calculate the concave hull from the points, but that approach ignores the interior of the polygons.
3. Adds a dedicated "Fill gaps between polygons" algorithm:

Unlike the standard Concave Hull algorithm, a Concave Hull of Polygons is a (possibly) non-convex polygon containing all the input polygons. The computed hull fills the gaps between the polygons without intersecting their interiors.  It strictly follows the outer boundaries of the input polygons, allowing you to fill gaps between them without distorting their original shapes.

It is particularly useful for cases such as generalizing groups of building outlines, creating 'district' polygons around blocks, or
removing gaps and joining disjoint sets of polygons.

See https://lin-ear-th-inking.blogspot.com/2022/05/concave-hulls-of-polygons.html?m=1 for more details