### PR TITLE
Add early cancelation to some geometry operation calls

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2286,7 +2286,7 @@ Performs a fast, non-robust intersection between the geometry and a
 ``rectangle``. The returned geometry may be invalid.
 %End
 
-    QgsGeometry combine( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    QgsGeometry combine( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = 0 ) const;
 %Docstring
 Returns a geometry representing all the points in this geometry and
 other (a union geometry operation).
@@ -2304,6 +2304,9 @@ returned geometry.
 
 Since QGIS 3.28 the optional ``parameters`` argument can be used to
 specify parameters which control the union results.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
     QgsGeometry mergeLines( const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
@@ -3044,7 +3047,7 @@ original geometry.
 .. versionadded:: 3.20
 %End
 
-    static QgsGeometry unaryUnion( const QVector<QgsGeometry> &geometries, const QgsGeometryParameters &parameters = QgsGeometryParameters() );
+    static QgsGeometry unaryUnion( const QVector<QgsGeometry> &geometries, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = 0 );
 %Docstring
 Compute the unary union on a list of ``geometries``. May be faster than
 an iterative union on a set of geometries. The returned geometry will be
@@ -3054,6 +3057,9 @@ errors.
 
 Since QGIS 3.28 the optional ``parameters`` argument can be used to
 specify parameters which control the union results.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
     static QgsGeometry polygonize( const QVector<QgsGeometry> &geometries );

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2841,7 +2841,7 @@ project properties
 .. versionadded:: 3.34
 %End
 
-    QgsGeometry makeValid( Qgis::MakeValidMethod method = Qgis::MakeValidMethod::Linework, bool keepCollapsed = false ) const;
+    QgsGeometry makeValid( Qgis::MakeValidMethod method = Qgis::MakeValidMethod::Linework, bool keepCollapsed = false, QgsFeedback* feedback = 0 ) const;
 %Docstring
 Attempts to make an invalid geometry valid without losing vertices.
 
@@ -2857,6 +2857,9 @@ geometry.
 
 The ``method`` and ``keepCollapsed`` arguments are available since QGIS
 3.28. They require builds based on GEOS 3.10 or later.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 
 :return: new valid QgsGeometry or null geometry on error
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1303,12 +1303,14 @@ Replaces a part of this geometry with another line
 %End
 
 
-    QgsGeometry makeDifference( const QgsGeometry &other ) const;
+    QgsGeometry makeDifference( const QgsGeometry &other, QgsFeedback* feedback = 0 ) const;
 %Docstring
 Returns the geometry formed by modifying this geometry such that it does
 not intersect the other geometry.
 
 :param other: geometry that should not be intersect
+:param feedback: optional feedback object for early cancellation (since
+                 QGIS 4.2).
 
 :return: difference geometry, or empty geometry if difference could not
          be calculated
@@ -2257,7 +2259,7 @@ average angle from the segment either side of the node is returned.
 .. seealso:: :py:func:`angleAtVertex`
 %End
 
-    QgsGeometry intersection( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    QgsGeometry intersection( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = 0 ) const;
 %Docstring
 Returns a geometry representing the points shared by this geometry and
 other.
@@ -2271,6 +2273,9 @@ returned geometry.
 
 Since QGIS 3.28 the optional ``parameters`` argument can be used to
 specify parameters which control the intersection results.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
     QgsGeometry clipped( const QgsRectangle &rectangle );

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2184,7 +2184,7 @@ Returns a null geometry on exception.
 .. versionadded:: 3.20
 %End
 
-    QgsGeometry subdivide( int maxNodes = 256, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    QgsGeometry subdivide( int maxNodes = 256, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = 0 ) const;
 %Docstring
 Subdivides the geometry. The returned geometry will be a collection
 containing subdivided parts from the original geometry, where no part
@@ -2208,6 +2208,9 @@ returned geometry.
 
 Since QGIS 3.28 the optional ``parameters`` argument can be used to
 specify parameters which control the subdivision results.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
     QgsGeometry interpolate( double distance ) const;
@@ -2278,12 +2281,15 @@ The optional ``feedback`` argument allows for early cancellation (since
 QGIS 4.2).
 %End
 
-    QgsGeometry clipped( const QgsRectangle &rectangle );
+    QgsGeometry clipped( const QgsRectangle &rectangle, QgsFeedback* feedback = 0 );
 %Docstring
 Clips the geometry using the specified ``rectangle``.
 
 Performs a fast, non-robust intersection between the geometry and a
 ``rectangle``. The returned geometry may be invalid.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
     QgsGeometry combine( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = 0 ) const;
@@ -2322,7 +2328,7 @@ Since QGIS 3.44 the optional ``parameters`` argument can be used to
 specify parameters which control the mergeLines results.
 %End
 
-    QgsGeometry difference( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    QgsGeometry difference( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = 0 ) const;
 %Docstring
 Returns a geometry representing the points making up this geometry that
 do not make up other.
@@ -2336,6 +2342,9 @@ returned geometry.
 
 Since QGIS 3.28 the optional ``parameters`` argument can be used to
 specify parameters which control the difference results.
+
+The optional ``feedback`` argument allows for early cancellation (since
+QGIS 4.2).
 %End
 
     QgsGeometry symDifference( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;

--- a/src/analysis/mesh/qgsmeshcontours.cpp
+++ b/src/analysis/mesh/qgsmeshcontours.cpp
@@ -230,7 +230,7 @@ QgsGeometry QgsMeshContours::exportPolygons( double min_value, double max_value,
   }
   else
   {
-    const QgsGeometry res = QgsGeometry::unaryUnion( multiPolygon );
+    const QgsGeometry res = QgsGeometry::unaryUnion( multiPolygon, QgsGeometryParameters(), feedback );
     return res;
   }
 }

--- a/src/analysis/processing/qgsalgorithmaggregate.cpp
+++ b/src/analysis/processing/qgsalgorithmaggregate.cpp
@@ -240,7 +240,7 @@ QVariantMap QgsAggregateAlgorithm::processAlgorithm( const QVariantMap &paramete
 
     if ( !geometry.isNull() && !geometry.isEmpty() )
     {
-      geometry = QgsGeometry::unaryUnion( geometry.asGeometryCollection() );
+      geometry = QgsGeometry::unaryUnion( geometry.asGeometryCollection(), QgsGeometryParameters(), feedback );
       if ( geometry.isEmpty() )
       {
         QStringList keyString;

--- a/src/analysis/processing/qgsalgorithmbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmbuffer.cpp
@@ -212,7 +212,7 @@ QVariantMap QgsBufferAlgorithm::processAlgorithm( const QVariantMap &parameters,
 
   if ( dissolve && !bufferedGeometriesForDissolve.isEmpty() )
   {
-    QgsGeometry finalGeometry = QgsGeometry::unaryUnion( bufferedGeometriesForDissolve );
+    QgsGeometry finalGeometry = QgsGeometry::unaryUnion( bufferedGeometriesForDissolve, QgsGeometryParameters(), feedback );
     finalGeometry.convertToMultiType();
     QgsFeature f;
     f.setAttributes( dissolveAttrs );

--- a/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
+++ b/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
@@ -224,7 +224,7 @@ QVariantMap QgsCalculateVectorOverlapsAlgorithm::processAlgorithm( const QVarian
           break;
 
         // dissolve intersecting features, calculate total area of them within our buffer
-        const QgsGeometry overlayDissolved = QgsGeometry::unaryUnion( intersectingGeoms, geometryParameters );
+        const QgsGeometry overlayDissolved = QgsGeometry::unaryUnion( intersectingGeoms, geometryParameters, feedback );
 
         if ( feedback->isCanceled() )
           break;

--- a/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
+++ b/src/analysis/processing/qgsalgorithmcalculateoverlaps.cpp
@@ -229,7 +229,7 @@ QVariantMap QgsCalculateVectorOverlapsAlgorithm::processAlgorithm( const QVarian
         if ( feedback->isCanceled() )
           break;
 
-        const QgsGeometry overlayIntersection = inputGeom.intersection( overlayDissolved, geometryParameters );
+        const QgsGeometry overlayIntersection = inputGeom.intersection( overlayDissolved, geometryParameters, feedback );
 
         double overlayArea = 0;
         try

--- a/src/analysis/processing/qgsalgorithmclip.cpp
+++ b/src/analysis/processing/qgsalgorithmclip.cpp
@@ -143,7 +143,7 @@ QVariantMap QgsClipAlgorithm::processAlgorithm( const QVariantMap &parameters, Q
   QgsGeometry combinedClipGeom;
   if ( clipGeoms.length() > 1 )
   {
-    combinedClipGeom = QgsGeometry::unaryUnion( clipGeoms );
+    combinedClipGeom = QgsGeometry::unaryUnion( clipGeoms, QgsGeometryParameters(), feedback );
     if ( combinedClipGeom.isEmpty() )
     {
       throw QgsProcessingException( QObject::tr( "Could not create the combined clip geometry: %1" ).arg( combinedClipGeom.lastError() ) );
@@ -213,7 +213,7 @@ QVariantMap QgsClipAlgorithm::processAlgorithm( const QVariantMap &parameters, Q
         newGeometry = combinedClipGeom.intersection( currentGeometry, feedback );
         if ( newGeometry.wkbType() == Qgis::WkbType::Unknown || QgsWkbTypes::flatType( newGeometry.wkbType() ) == Qgis::WkbType::GeometryCollection )
         {
-          const QgsGeometry intCom = inputFeature.geometry().combine( newGeometry );
+          const QgsGeometry intCom = inputFeature.geometry().combine( newGeometry, QgsGeometryParameters(), feedback );
           const QgsGeometry intSym = inputFeature.geometry().symDifference( newGeometry );
           newGeometry = intCom.difference( intSym );
         }

--- a/src/analysis/processing/qgsalgorithmclip.cpp
+++ b/src/analysis/processing/qgsalgorithmclip.cpp
@@ -210,12 +210,12 @@ QVariantMap QgsClipAlgorithm::processAlgorithm( const QVariantMap &parameters, Q
       if ( !engine->contains( inputFeature.geometry().constGet() ) )
       {
         const QgsGeometry currentGeometry = inputFeature.geometry();
-        newGeometry = combinedClipGeom.intersection( currentGeometry, feedback );
+        newGeometry = combinedClipGeom.intersection( currentGeometry, QgsGeometryParameters(), feedback );
         if ( newGeometry.wkbType() == Qgis::WkbType::Unknown || QgsWkbTypes::flatType( newGeometry.wkbType() ) == Qgis::WkbType::GeometryCollection )
         {
           const QgsGeometry intCom = inputFeature.geometry().combine( newGeometry, QgsGeometryParameters(), feedback );
           const QgsGeometry intSym = inputFeature.geometry().symDifference( newGeometry );
-          newGeometry = intCom.difference( intSym );
+          newGeometry = intCom.difference( intSym, QgsGeometryParameters(), feedback );
         }
       }
       else

--- a/src/analysis/processing/qgsalgorithmclip.cpp
+++ b/src/analysis/processing/qgsalgorithmclip.cpp
@@ -210,7 +210,7 @@ QVariantMap QgsClipAlgorithm::processAlgorithm( const QVariantMap &parameters, Q
       if ( !engine->contains( inputFeature.geometry().constGet() ) )
       {
         const QgsGeometry currentGeometry = inputFeature.geometry();
-        newGeometry = combinedClipGeom.intersection( currentGeometry );
+        newGeometry = combinedClipGeom.intersection( currentGeometry, feedback );
         if ( newGeometry.wkbType() == Qgis::WkbType::Unknown || QgsWkbTypes::flatType( newGeometry.wkbType() ) == Qgis::WkbType::GeometryCollection )
         {
           const QgsGeometry intCom = inputFeature.geometry().combine( newGeometry );

--- a/src/analysis/processing/qgsalgorithmdissolve.cpp
+++ b/src/analysis/processing/qgsalgorithmdissolve.cpp
@@ -297,7 +297,7 @@ QVariantMap QgsDissolveAlgorithm::processAlgorithm( const QVariantMap &parameter
     context,
     feedback,
     [&]( const QVector<QgsGeometry> &parts ) -> QgsGeometry {
-      QgsGeometry result( QgsGeometry::unaryUnion( parts ) );
+      QgsGeometry result( QgsGeometry::unaryUnion( parts, QgsGeometryParameters(), feedback ) );
       if ( QgsWkbTypes::geometryType( result.wkbType() ) == Qgis::GeometryType::Line )
         result = result.mergeLines();
       // Geos may fail in some cases, let's try a slower but safer approach
@@ -311,7 +311,7 @@ QVariantMap QgsDissolveAlgorithm::processAlgorithm( const QVariantMap &parameter
         result = QgsGeometry();
         for ( const auto &p : parts )
         {
-          result = QgsGeometry::unaryUnion( QVector< QgsGeometry >() << result << p );
+          result = QgsGeometry::unaryUnion( QVector< QgsGeometry >() << result << p, QgsGeometryParameters(), feedback );
           if ( QgsWkbTypes::geometryType( result.wkbType() ) == Qgis::GeometryType::Line )
             result = result.mergeLines();
           if ( feedback->isCanceled() )

--- a/src/analysis/processing/qgsalgorithmextractbyextent.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyextent.cpp
@@ -112,7 +112,7 @@ QVariantMap QgsExtractByExtentAlgorithm::processAlgorithm( const QVariantMap &pa
 
     if ( clip )
     {
-      QgsGeometry g = f.geometry().intersection( clipGeom, feedback );
+      QgsGeometry g = f.geometry().intersection( clipGeom, QgsGeometryParameters(), feedback );
 
       if ( g.type() != Qgis::GeometryType::Point )
       {

--- a/src/analysis/processing/qgsalgorithmextractbyextent.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyextent.cpp
@@ -112,7 +112,7 @@ QVariantMap QgsExtractByExtentAlgorithm::processAlgorithm( const QVariantMap &pa
 
     if ( clip )
     {
-      QgsGeometry g = f.geometry().intersection( clipGeom );
+      QgsGeometry g = f.geometry().intersection( clipGeom, feedback );
 
       if ( g.type() != Qgis::GeometryType::Point )
       {

--- a/src/analysis/processing/qgsalgorithmfixgeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.cpp
@@ -129,7 +129,7 @@ QgsFeatureList QgsFixGeometriesAlgorithm::processFeature( const QgsFeature &feat
 
   QgsFeature outputFeature = feature;
 
-  QgsGeometry outputGeometry = outputFeature.geometry().makeValid( mMethod );
+  QgsGeometry outputGeometry = outputFeature.geometry().makeValid( mMethod, false, feedback );
   if ( outputGeometry.isNull() )
   {
     feedback->pushInfo( QObject::tr( "makeValid failed for feature %1 " ).arg( feature.id() ) );

--- a/src/analysis/processing/qgsalgorithmjoinbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbylocation.cpp
@@ -559,7 +559,7 @@ bool QgsJoinByLocationAlgorithm::processFeatureFromInputSource( QgsFeature &base
         case JoinToLargestOverlap:
         {
           // calculate area of overlap
-          std::unique_ptr<QgsAbstractGeometry> intersection( engine->intersection( joinFeature.geometry().constGet() ) );
+          std::unique_ptr<QgsAbstractGeometry> intersection( engine->intersection( joinFeature.geometry().constGet(), nullptr, QgsGeometryParameters(), feedback ) );
           double overlap = 0;
           switch ( QgsWkbTypes::geometryType( intersection->wkbType() ) )
           {

--- a/src/analysis/processing/qgsalgorithmlinedensity.cpp
+++ b/src/analysis/processing/qgsalgorithmlinedensity.cpp
@@ -232,7 +232,7 @@ QVariantMap QgsLineDensityAlgorithm::processAlgorithm( const QVariantMap &parame
             double analysisLineLength = 0;
             try
             {
-              analysisLineLength = mDa.measureLength( QgsGeometry( engine->intersection( mIndex.geometry( id ).constGet() ) ) );
+              analysisLineLength = mDa.measureLength( QgsGeometry( engine->intersection( mIndex.geometry( id ).constGet(), nullptr, QgsGeometryParameters(), feedback ) ) );
             }
             catch ( QgsCsException & )
             {

--- a/src/analysis/processing/qgsalgorithmlineintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmlineintersection.cpp
@@ -157,7 +157,7 @@ QVariantMap QgsLineIntersectionAlgorithm::processAlgorithm( const QVariantMap &p
         if ( engine->intersects( tmpGeom.constGet() ) )
         {
           QgsMultiPointXY points;
-          QgsGeometry intersectGeom = inGeom.intersection( tmpGeom, feedback );
+          QgsGeometry intersectGeom = inGeom.intersection( tmpGeom, QgsGeometryParameters(), feedback );
           QgsAttributes outAttributes;
           for ( int a : std::as_const( fieldIndicesA ) )
           {

--- a/src/analysis/processing/qgsalgorithmlineintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmlineintersection.cpp
@@ -157,7 +157,7 @@ QVariantMap QgsLineIntersectionAlgorithm::processAlgorithm( const QVariantMap &p
         if ( engine->intersects( tmpGeom.constGet() ) )
         {
           QgsMultiPointXY points;
-          QgsGeometry intersectGeom = inGeom.intersection( tmpGeom );
+          QgsGeometry intersectGeom = inGeom.intersection( tmpGeom, feedback );
           QgsAttributes outAttributes;
           for ( int a : std::as_const( fieldIndicesA ) )
           {

--- a/src/analysis/processing/qgsalgorithmpolygonize.cpp
+++ b/src/analysis/processing/qgsalgorithmpolygonize.cpp
@@ -110,7 +110,7 @@ QVariantMap QgsPolygonizeAlgorithm::processAlgorithm( const QVariantMap &paramet
   feedback->setProgress( 40 );
 
   feedback->pushInfo( QObject::tr( "Noding lines…" ) );
-  const QgsGeometry lines = QgsGeometry::unaryUnion( linesList );
+  const QgsGeometry lines = QgsGeometry::unaryUnion( linesList, QgsGeometryParameters(), feedback );
   if ( feedback->isCanceled() )
     return QVariantMap();
   feedback->setProgress( 45 );

--- a/src/analysis/processing/qgsalgorithmsubdivide.cpp
+++ b/src/analysis/processing/qgsalgorithmsubdivide.cpp
@@ -99,7 +99,7 @@ QgsFeatureList QgsSubdivideAlgorithm::processFeature( const QgsFeature &f, QgsPr
     if ( mDynamicMaxNodes )
       maxNodes = mMaxNodesProperty.valueAsDouble( context.expressionContext(), maxNodes );
 
-    feature.setGeometry( feature.geometry().subdivide( maxNodes, feedback ) );
+    feature.setGeometry( feature.geometry().subdivide( maxNodes, QgsGeometryParameters(), feedback ) );
     if ( !feature.hasGeometry() )
     {
       feedback->reportError( QObject::tr( "Error calculating subdivision for feature %1" ).arg( feature.id() ) );

--- a/src/analysis/processing/qgsalgorithmsubdivide.cpp
+++ b/src/analysis/processing/qgsalgorithmsubdivide.cpp
@@ -99,7 +99,7 @@ QgsFeatureList QgsSubdivideAlgorithm::processFeature( const QgsFeature &f, QgsPr
     if ( mDynamicMaxNodes )
       maxNodes = mMaxNodesProperty.valueAsDouble( context.expressionContext(), maxNodes );
 
-    feature.setGeometry( feature.geometry().subdivide( maxNodes ) );
+    feature.setGeometry( feature.geometry().subdivide( maxNodes, feedback ) );
     if ( !feature.hasGeometry() )
     {
       feedback->reportError( QObject::tr( "Error calculating subdivision for feature %1" ).arg( feature.id() ) );

--- a/src/analysis/processing/qgsalgorithmsumlinelength.cpp
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.cpp
@@ -235,7 +235,7 @@ QgsFeatureList QgsSumLineLengthAlgorithm::processFeature( const QgsFeature &feat
 
       if ( engine->intersects( lineFeature.geometry().constGet() ) )
       {
-        const QgsGeometry outGeom = polyGeom.intersection( lineFeature.geometry(), feedback );
+        const QgsGeometry outGeom = polyGeom.intersection( lineFeature.geometry(), QgsGeometryParameters(), feedback );
         try
         {
           length += mDa.measureLength( outGeom );

--- a/src/analysis/processing/qgsalgorithmsumlinelength.cpp
+++ b/src/analysis/processing/qgsalgorithmsumlinelength.cpp
@@ -235,7 +235,7 @@ QgsFeatureList QgsSumLineLengthAlgorithm::processFeature( const QgsFeature &feat
 
       if ( engine->intersects( lineFeature.geometry().constGet() ) )
       {
-        const QgsGeometry outGeom = polyGeom.intersection( lineFeature.geometry() );
+        const QgsGeometry outGeom = polyGeom.intersection( lineFeature.geometry(), feedback );
         try
         {
           length += mDa.measureLength( outGeom );

--- a/src/analysis/processing/qgsalgorithmvoronoipolygons.cpp
+++ b/src/analysis/processing/qgsalgorithmvoronoipolygons.cpp
@@ -188,7 +188,7 @@ QString QgsVoronoiPolygonsAlgorithm::voronoiWithAttributes( const QVariantMap &p
       QgsFeature f;
       f.setFields( fields );
 
-      QgsGeometry voronoiClippedToExtent = QgsGeometry( extentEngine->intersection( collectionPart.constGet() ) );
+      QgsGeometry voronoiClippedToExtent = QgsGeometry( extentEngine->intersection( collectionPart.constGet(), nullptr, QgsGeometryParameters(), feedback ) );
       voronoiClippedToExtent.convertGeometryCollectionToSubclass( Qgis::GeometryType::Polygon );
       if ( !voronoiClippedToExtent.isEmpty() )
       {
@@ -285,7 +285,7 @@ QString QgsVoronoiPolygonsAlgorithm::voronoiWithoutAttributes( const QVariantMap
       }
       QgsFeature f;
       f.setFields( fields );
-      f.setGeometry( QgsGeometry( extentEngine->intersection( collection[i].constGet() ) ) );
+      f.setGeometry( QgsGeometry( extentEngine->intersection( collection[i].constGet(), nullptr, QgsGeometryParameters(), feedback ) ) );
       f.setAttributes( QgsAttributes() << i );
       if ( !sink->addFeature( f, QgsFeatureSink::FastInsert ) )
         throw QgsProcessingException( writeFeatureError( sink.get(), parameters, u"OUTPUT"_s ) );

--- a/src/analysis/processing/qgsoverlayutils.cpp
+++ b/src/analysis/processing/qgsoverlayutils.cpp
@@ -192,7 +192,7 @@ void QgsOverlayUtils::difference(
 
       if ( !geometriesB.isEmpty() )
       {
-        const QgsGeometry geomB = QgsGeometry::unaryUnion( geometriesB, parameters );
+        const QgsGeometry geomB = QgsGeometry::unaryUnion( geometriesB, parameters, feedback );
         if ( !geomB.lastError().isEmpty() )
         {
           // This may happen if input geometries from a layer do not line up well (for example polygons

--- a/src/analysis/processing/qgsoverlayutils.cpp
+++ b/src/analysis/processing/qgsoverlayutils.cpp
@@ -329,7 +329,7 @@ void QgsOverlayUtils::intersection(
       if ( !engine->intersects( tmpGeom.constGet() ) )
         continue;
 
-      QgsGeometry intGeom = geom.intersection( tmpGeom, parameters );
+      QgsGeometry intGeom = geom.intersection( tmpGeom, parameters, feedback );
       if ( !sanitizeIntersectionResult( intGeom, geometryType ) )
         continue;
 
@@ -418,7 +418,7 @@ void QgsOverlayUtils::resolveOverlaps( const QgsFeatureSource &source, QgsFeatur
       if ( !g1engine->intersects( g2.constGet() ) )
         continue;
 
-      QgsGeometry geomIntersection = g1.intersection( g2, parameters );
+      QgsGeometry geomIntersection = g1.intersection( g2, parameters, feedback );
       if ( !sanitizeIntersectionResult( geomIntersection, geometryType ) )
         continue;
 

--- a/src/analysis/processing/qgsoverlayutils.cpp
+++ b/src/analysis/processing/qgsoverlayutils.cpp
@@ -202,7 +202,7 @@ void QgsOverlayUtils::difference(
           // 2. fix geometries (removes polygons collapsed to lines etc.) using MakeValid
           throw QgsProcessingException( u"%1\n\n%2"_s.arg( QObject::tr( "GEOS geoprocessing error: unary union failed." ), geomB.lastError() ) );
         }
-        geom = geom.difference( geomB, parameters );
+        geom = geom.difference( geomB, parameters, feedback );
       }
 
       if ( !geom.isNull() && !sanitizeDifferenceResult( geom, geometryType, flags ) )
@@ -454,7 +454,7 @@ void QgsOverlayUtils::resolveOverlaps( const QgsFeatureSource &source, QgsFeatur
       // update f1
       //
 
-      QgsGeometry g12 = g1.difference( g2, parameters );
+      QgsGeometry g12 = g1.difference( g2, parameters, feedback );
 
       index.deleteFeature( f );
       geometries.remove( fid1 );
@@ -472,7 +472,7 @@ void QgsOverlayUtils::resolveOverlaps( const QgsFeatureSource &source, QgsFeatur
       // update f2
       //
 
-      QgsGeometry g21 = g2.difference( g1, parameters );
+      QgsGeometry g21 = g2.difference( g1, parameters, feedback );
 
       QgsFeature f2old( fid2 );
       f2old.setGeometry( g2 );

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -91,7 +91,7 @@ QgsGeometryCheck::Result QgsGeometryGapCheck::collectErrors(
 
     // Create union of allowed gaps
     QString errMsg;
-    allowedGapsGeom.reset( allowedGapsEngine->combine( allowedGaps, &errMsg ) );
+    allowedGapsGeom.reset( allowedGapsEngine->combine( allowedGaps, &errMsg, QgsGeometryParameters(), feedback ) );
     allowedGapsGeomEngine.reset( QgsGeometry::createGeometryEngine( allowedGapsGeom.get(), mContext->tolerance ) );
     allowedGapsGeomEngine->prepareGeometry();
   }
@@ -123,7 +123,7 @@ QgsGeometryCheck::Result QgsGeometryGapCheck::collectErrors(
 
   // Create union of geometry
   QString errMsg;
-  const std::unique_ptr<QgsAbstractGeometry> unionGeom( geomEngine->combine( geomList, &errMsg ) );
+  const std::unique_ptr<QgsAbstractGeometry> unionGeom( geomEngine->combine( geomList, &errMsg, QgsGeometryParameters(), feedback ) );
   if ( !unionGeom )
   {
     messages.append( tr( "Gap check: %1" ).arg( errMsg ) );

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -149,7 +149,7 @@ QgsGeometryCheck::Result QgsGeometryGapCheck::collectErrors(
   // Compute difference between envelope and union to obtain gap polygons
   geomEngine.reset( QgsGeometry::createGeometryEngine( envelope.get(), mContext->tolerance ) );
   geomEngine->prepareGeometry();
-  std::unique_ptr<QgsAbstractGeometry> diffGeom( geomEngine->difference( unionGeom.get(), &errMsg ) );
+  std::unique_ptr<QgsAbstractGeometry> diffGeom( geomEngine->difference( unionGeom.get(), &errMsg, QgsGeometryParameters(), feedback ) );
   if ( !diffGeom )
   {
     messages.append( tr( "Gap check: %1" ).arg( errMsg ) );

--- a/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.cpp
@@ -85,7 +85,7 @@ QgsGeometryCheck::Result QgsGeometryOverlapCheck::collectErrors(
       const QgsAbstractGeometry *geomB = geometryB.constGet();
       if ( geomEngineA->overlaps( geomB, &errMsg ) )
       {
-        std::unique_ptr<QgsAbstractGeometry> interGeom( geomEngineA->intersection( geomB ) );
+        std::unique_ptr<QgsAbstractGeometry> interGeom( geomEngineA->intersection( geomB, nullptr, QgsGeometryParameters(), feedback ) );
         if ( interGeom && !interGeom->isEmpty() )
         {
           QgsGeometryCheckerUtils::filter1DTypes( interGeom.get() );

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1284,7 +1284,7 @@ Qgis::GeometryOperationResult QgsGeometry::reshapeGeometry( const QgsLineString 
   return Qgis::GeometryOperationResult::GeometryEngineError;
 }
 
-int QgsGeometry::makeDifferenceInPlace( const QgsGeometry &other )
+int QgsGeometry::makeDifferenceInPlace( const QgsGeometry &other, QgsFeedback *feedback )
 {
   if ( !d->geometry || !other.d->geometry )
   {
@@ -1294,7 +1294,7 @@ int QgsGeometry::makeDifferenceInPlace( const QgsGeometry &other )
   QgsGeos geos( d->geometry.get() );
 
   mLastError.clear();
-  std::unique_ptr< QgsAbstractGeometry > diffGeom( geos.intersection( other.constGet(), &mLastError ) );
+  std::unique_ptr< QgsAbstractGeometry > diffGeom( geos.intersection( other.constGet(), &mLastError, QgsGeometryParameters(), feedback ) );
   if ( !diffGeom )
   {
     return 1;
@@ -1304,7 +1304,7 @@ int QgsGeometry::makeDifferenceInPlace( const QgsGeometry &other )
   return 0;
 }
 
-QgsGeometry QgsGeometry::makeDifference( const QgsGeometry &other ) const
+QgsGeometry QgsGeometry::makeDifference( const QgsGeometry &other, QgsFeedback *feedback ) const
 {
   if ( !d->geometry || other.isNull() )
   {
@@ -1314,7 +1314,7 @@ QgsGeometry QgsGeometry::makeDifference( const QgsGeometry &other ) const
   QgsGeos geos( d->geometry.get() );
 
   mLastError.clear();
-  std::unique_ptr< QgsAbstractGeometry > diffGeom( geos.intersection( other.constGet(), &mLastError ) );
+  std::unique_ptr< QgsAbstractGeometry > diffGeom( geos.intersection( other.constGet(), &mLastError, QgsGeometryParameters(), feedback ) );
   if ( !diffGeom )
   {
     QgsGeometry result;
@@ -3212,7 +3212,7 @@ double QgsGeometry::interpolateAngle( double distance ) const
   }
 }
 
-QgsGeometry QgsGeometry::intersection( const QgsGeometry &geometry, const QgsGeometryParameters &parameters ) const
+QgsGeometry QgsGeometry::intersection( const QgsGeometry &geometry, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
   if ( !d->geometry || geometry.isNull() )
   {
@@ -3222,7 +3222,7 @@ QgsGeometry QgsGeometry::intersection( const QgsGeometry &geometry, const QgsGeo
   QgsGeos geos( d->geometry.get() );
 
   mLastError.clear();
-  std::unique_ptr< QgsAbstractGeometry > resultGeom( geos.intersection( geometry.d->geometry.get(), &mLastError, parameters ) );
+  std::unique_ptr< QgsAbstractGeometry > resultGeom( geos.intersection( geometry.d->geometry.get(), &mLastError, parameters, feedback ) );
 
   if ( !resultGeom )
   {

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3234,7 +3234,7 @@ QgsGeometry QgsGeometry::intersection( const QgsGeometry &geometry, const QgsGeo
   return QgsGeometry( std::move( resultGeom ) );
 }
 
-QgsGeometry QgsGeometry::combine( const QgsGeometry &geometry, const QgsGeometryParameters &parameters ) const
+QgsGeometry QgsGeometry::combine( const QgsGeometry &geometry, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
   if ( !d->geometry || geometry.isNull() )
   {
@@ -3243,7 +3243,7 @@ QgsGeometry QgsGeometry::combine( const QgsGeometry &geometry, const QgsGeometry
 
   QgsGeos geos( d->geometry.get() );
   mLastError.clear();
-  std::unique_ptr< QgsAbstractGeometry > resultGeom( geos.combine( geometry.d->geometry.get(), &mLastError, parameters ) );
+  std::unique_ptr< QgsAbstractGeometry > resultGeom( geos.combine( geometry.d->geometry.get(), &mLastError, parameters, feedback ) );
   if ( !resultGeom )
   {
     QgsGeometry geom;
@@ -3827,12 +3827,12 @@ bool QgsGeometry::isFuzzyEqual( const QgsGeometry &g, double epsilon, Qgis::Geom
   BUILTIN_UNREACHABLE
 }
 
-QgsGeometry QgsGeometry::unaryUnion( const QVector<QgsGeometry> &geometries, const QgsGeometryParameters &parameters )
+QgsGeometry QgsGeometry::unaryUnion( const QVector<QgsGeometry> &geometries, const QgsGeometryParameters &parameters, QgsFeedback *feedback )
 {
   QgsGeos geos( nullptr );
 
   QString error;
-  std::unique_ptr< QgsAbstractGeometry > geom( geos.combine( geometries, &error, parameters ) );
+  std::unique_ptr< QgsAbstractGeometry > geom( geos.combine( geometries, &error, parameters, feedback ) );
   QgsGeometry result( std::move( geom ) );
   result.mLastError = error;
   return result;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3059,7 +3059,7 @@ QgsGeometry QgsGeometry::sharedPaths( const QgsGeometry &other ) const
   return result;
 }
 
-QgsGeometry QgsGeometry::subdivide( int maxNodes, const QgsGeometryParameters &parameters ) const
+QgsGeometry QgsGeometry::subdivide( int maxNodes, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
   if ( !d->geometry )
   {
@@ -3076,7 +3076,7 @@ QgsGeometry QgsGeometry::subdivide( int maxNodes, const QgsGeometryParameters &p
 
   QgsGeos geos( geom );
   mLastError.clear();
-  std::unique_ptr< QgsAbstractGeometry > result( geos.subdivide( maxNodes, &mLastError, parameters ) );
+  std::unique_ptr< QgsAbstractGeometry > result( geos.subdivide( maxNodes, &mLastError, parameters, feedback ) );
   if ( !result )
   {
     QgsGeometry geom;
@@ -3273,7 +3273,7 @@ QgsGeometry QgsGeometry::mergeLines( const QgsGeometryParameters &parameters ) c
   return result;
 }
 
-QgsGeometry QgsGeometry::difference( const QgsGeometry &geometry, const QgsGeometryParameters &parameters ) const
+QgsGeometry QgsGeometry::difference( const QgsGeometry &geometry, const QgsGeometryParameters &parameters, QgsFeedback *feedback ) const
 {
   if ( !d->geometry || geometry.isNull() )
   {
@@ -3283,7 +3283,7 @@ QgsGeometry QgsGeometry::difference( const QgsGeometry &geometry, const QgsGeome
   QgsGeos geos( d->geometry.get() );
 
   mLastError.clear();
-  std::unique_ptr< QgsAbstractGeometry > resultGeom( geos.difference( geometry.d->geometry.get(), &mLastError, parameters ) );
+  std::unique_ptr< QgsAbstractGeometry > resultGeom( geos.difference( geometry.d->geometry.get(), &mLastError, parameters, feedback ) );
   if ( !resultGeom )
   {
     QgsGeometry geom;
@@ -3909,7 +3909,7 @@ void QgsGeometry::mapToPixel( const QgsMapToPixel &mtp )
   }
 }
 
-QgsGeometry QgsGeometry::clipped( const QgsRectangle &rectangle )
+QgsGeometry QgsGeometry::clipped( const QgsRectangle &rectangle, QgsFeedback *feedback )
 {
   if ( !d->geometry || rectangle.isNull() || rectangle.isEmpty() )
   {
@@ -3918,7 +3918,7 @@ QgsGeometry QgsGeometry::clipped( const QgsRectangle &rectangle )
 
   QgsGeos geos( d->geometry.get() );
   mLastError.clear();
-  std::unique_ptr< QgsAbstractGeometry > resultGeom = geos.clip( rectangle, &mLastError );
+  std::unique_ptr< QgsAbstractGeometry > resultGeom = geos.clip( rectangle, &mLastError, feedback );
   if ( !resultGeom )
   {
     QgsGeometry result;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3498,14 +3498,14 @@ int QgsGeometry::avoidIntersections( const QList<QgsVectorLayer *> &avoidInterse
   return 4;
 }
 
-QgsGeometry QgsGeometry::makeValid( Qgis::MakeValidMethod method, bool keepCollapsed ) const
+QgsGeometry QgsGeometry::makeValid( Qgis::MakeValidMethod method, bool keepCollapsed, QgsFeedback *feedback ) const
 {
   if ( !d->geometry )
     return QgsGeometry();
 
   mLastError.clear();
   QgsGeos geos( d->geometry.get() );
-  std::unique_ptr< QgsAbstractGeometry > g( geos.makeValid( method, keepCollapsed, &mLastError ) );
+  std::unique_ptr< QgsAbstractGeometry > g( geos.makeValid( method, keepCollapsed, &mLastError, feedback ) );
 
   QgsGeometry result = QgsGeometry( std::move( g ) );
   result.mLastError = mLastError;

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2781,12 +2781,13 @@ class CORE_EXPORT QgsGeometry
      * The \a method and \a keepCollapsed arguments are available since QGIS 3.28.
      * They require builds based on GEOS 3.10 or later.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
+     *
      * \returns new valid QgsGeometry or null geometry on error
      *
      * \throws QgsNotSupportedException on QGIS builds based on GEOS 3.9 or earlier when the \a method is not Qgis::MakeValidMethod::Linework or the \a keepCollapsed option is set.
-     *
      */
-    QgsGeometry makeValid( Qgis::MakeValidMethod method = Qgis::MakeValidMethod::Linework, bool keepCollapsed = false ) const SIP_THROW( QgsNotSupportedException );
+    QgsGeometry makeValid( Qgis::MakeValidMethod method = Qgis::MakeValidMethod::Linework, bool keepCollapsed = false, QgsFeedback* feedback = nullptr ) const SIP_THROW( QgsNotSupportedException );
 
     /**
      * Returns the orientation of the polygon.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1287,17 +1287,19 @@ class CORE_EXPORT QgsGeometry
     /**
      * Changes this geometry such that it does not intersect the other geometry
      * \param other geometry that should not be intersect
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      * \note Not available in Python
      */
-    int makeDifferenceInPlace( const QgsGeometry &other ) SIP_SKIP;
+    int makeDifferenceInPlace( const QgsGeometry &other, QgsFeedback* feedback = nullptr ) SIP_SKIP;
 
     /**
      * Returns the geometry formed by modifying this geometry such that it does not
      * intersect the other geometry.
      * \param other geometry that should not be intersect
+     * \param feedback optional feedback object for early cancellation (since QGIS 4.2).
      * \returns difference geometry, or empty geometry if difference could not be calculated
      */
-    QgsGeometry makeDifference( const QgsGeometry &other ) const;
+    QgsGeometry makeDifference( const QgsGeometry &other, QgsFeedback* feedback = nullptr ) const;
 
     /**
      * Returns the bounding box of the geometry.
@@ -2112,8 +2114,10 @@ class CORE_EXPORT QgsGeometry
      *
      * Since QGIS 3.28 the optional \a parameters argument can be used to specify parameters which
      * control the intersection results.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    QgsGeometry intersection( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    QgsGeometry intersection( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = nullptr ) const;
 
     /**
      * Clips the geometry using the specified \a rectangle.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2063,8 +2063,9 @@ class CORE_EXPORT QgsGeometry
      * Since QGIS 3.28 the optional \a parameters argument can be used to specify parameters which
      * control the subdivision results.
      *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    QgsGeometry subdivide( int maxNodes = 256, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    QgsGeometry subdivide( int maxNodes = 256, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = nullptr ) const;
 
     /**
      * Returns an interpolated point on the geometry at the specified \a distance.
@@ -2124,8 +2125,10 @@ class CORE_EXPORT QgsGeometry
      *
      * Performs a fast, non-robust intersection between the geometry and
      * a \a rectangle. The returned geometry may be invalid.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    QgsGeometry clipped( const QgsRectangle &rectangle );
+    QgsGeometry clipped( const QgsRectangle &rectangle, QgsFeedback* feedback = nullptr );
 
     /**
      * Returns a geometry representing all the points in this geometry and other (a

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2140,8 +2140,10 @@ class CORE_EXPORT QgsGeometry
      *
      * Since QGIS 3.28 the optional \a parameters argument can be used to specify parameters which
      * control the union results.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    QgsGeometry combine( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    QgsGeometry combine( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = nullptr ) const;
 
     /**
      * Merges any connected lines in a LineString/MultiLineString geometry and
@@ -2165,8 +2167,10 @@ class CORE_EXPORT QgsGeometry
      *
      * Since QGIS 3.28 the optional \a parameters argument can be used to specify parameters which
      * control the difference results.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    QgsGeometry difference( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters() ) const;
+    QgsGeometry difference( const QgsGeometry &geometry, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = nullptr ) const;
 
     /**
      * Returns a geometry representing the points making up this geometry that do not make up other.
@@ -2955,8 +2959,10 @@ class CORE_EXPORT QgsGeometry
      *
      * Since QGIS 3.28 the optional \a parameters argument can be used to specify parameters which
      * control the union results.
+     *
+     * The optional \a feedback argument allows for early cancellation (since QGIS 4.2).
      */
-    static QgsGeometry unaryUnion( const QVector<QgsGeometry> &geometries, const QgsGeometryParameters &parameters = QgsGeometryParameters() );
+    static QgsGeometry unaryUnion( const QVector<QgsGeometry> &geometries, const QgsGeometryParameters &parameters = QgsGeometryParameters(), QgsFeedback* feedback = nullptr );
 
     /**
      * Creates a GeometryCollection geometry containing possible polygons formed from the constituent

--- a/src/core/labeling/qgslabelingengine.cpp
+++ b/src/core/labeling/qgslabelingengine.cpp
@@ -352,7 +352,7 @@ void QgsLabelingEngine::solve( QgsRenderContext &context )
   const QList< QgsLabelBlockingRegion > blockingRegions = mMapSettings.labelBlockingRegions();
   for ( const QgsLabelBlockingRegion &region : blockingRegions )
   {
-    mapBoundaryGeom = mapBoundaryGeom.difference( region.geometry );
+    mapBoundaryGeom = mapBoundaryGeom.difference( region.geometry, QgsGeometryParameters(), context.feedback() );
   }
 
   if ( settings.flags() & Qgis::LabelingFlag::DrawCandidates )

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2743,7 +2743,7 @@ std::unique_ptr< QgsTextLabelFeature> QgsPalLayerSettings::generateLabelFeature(
   if ( !context.featureClipGeometry().isEmpty() )
   {
     const Qgis::GeometryType expectedType = geom.type();
-    geom = geom.intersection( context.featureClipGeometry(), context.feedback() );
+    geom = geom.intersection( context.featureClipGeometry(), QgsGeometryParameters(), context.feedback() );
     geom.convertGeometryCollectionToSubclass( expectedType );
   }
 

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -4638,7 +4638,7 @@ QgsGeometry QgsPalLabeling::prepareGeometry( const QgsGeometry &geometry, QgsRen
         QgsGeometry partGeom( ( *it )->clone() );
         if ( !partGeom.isGeosValid() )
         {
-          partGeom = partGeom.makeValid();
+          partGeom = partGeom.makeValid( Qgis::MakeValidMethod::Linework, false, context.feedback() );
         }
         parts.append( partGeom );
       }
@@ -4646,7 +4646,7 @@ QgsGeometry QgsPalLabeling::prepareGeometry( const QgsGeometry &geometry, QgsRen
     }
     else if ( !geom.isGeosValid() )
     {
-      QgsGeometry bufferGeom = geom.makeValid();
+      QgsGeometry bufferGeom = geom.makeValid( Qgis::MakeValidMethod::Linework, false, context.feedback() );
       if ( bufferGeom.isNull() )
       {
         QgsDebugError( u"Could not repair geometry: %1"_s.arg( bufferGeom.lastError() ) );

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2743,7 +2743,7 @@ std::unique_ptr< QgsTextLabelFeature> QgsPalLayerSettings::generateLabelFeature(
   if ( !context.featureClipGeometry().isEmpty() )
   {
     const Qgis::GeometryType expectedType = geom.type();
-    geom = geom.intersection( context.featureClipGeometry() );
+    geom = geom.intersection( context.featureClipGeometry(), context.feedback() );
     geom.convertGeometryCollectionToSubclass( expectedType );
   }
 
@@ -4659,7 +4659,7 @@ QgsGeometry QgsPalLabeling::prepareGeometry( const QgsGeometry &geometry, QgsRen
   if ( mustClipExact )
   {
     // now do the real intersection against the actual clip geometry
-    QgsGeometry clipGeom = geom.intersection( clipGeometry );
+    QgsGeometry clipGeom = geom.intersection( clipGeometry, QgsGeometryParameters(), context.feedback() );
     if ( clipGeom.isEmpty() )
     {
       return QgsGeometry();

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -4611,7 +4611,7 @@ QgsGeometry QgsPalLabeling::prepareGeometry( const QgsGeometry &geometry, QgsRen
   if ( mustClip )
   {
     // nice and fast, but can result in invalid geometries. At least it will potentially strip out a bunch of unwanted vertices upfront!
-    QgsGeometry clipGeom = geom.clipped( clipGeometry.boundingBox() );
+    QgsGeometry clipGeom = geom.clipped( clipGeometry.boundingBox(), context.feedback() );
     if ( clipGeom.isEmpty() )
       return QgsGeometry();
 

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -985,7 +985,7 @@ bool QgsTriangulatedPointCloudLayerProfileGenerator::generateProfile( const QgsP
     QgsGeos geosPoly( &triangle );
     geosPoly.prepareGeometry();
 
-    std::unique_ptr<QgsAbstractGeometry> intersectingGeom( geosPoly.intersection( sourceCurve, nullptr, QgsGeometryParameters(), mFeedback ) );
+    std::unique_ptr<QgsAbstractGeometry> intersectingGeom( geosPoly.intersection( sourceCurve, nullptr, QgsGeometryParameters(), mFeedback.get() ) );
     if ( !intersectingGeom )
       continue;
 

--- a/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerprofilegenerator.cpp
@@ -985,7 +985,7 @@ bool QgsTriangulatedPointCloudLayerProfileGenerator::generateProfile( const QgsP
     QgsGeos geosPoly( &triangle );
     geosPoly.prepareGeometry();
 
-    std::unique_ptr<QgsAbstractGeometry> intersectingGeom( geosPoly.intersection( sourceCurve ) );
+    std::unique_ptr<QgsAbstractGeometry> intersectingGeom( geosPoly.intersection( sourceCurve, nullptr, QgsGeometryParameters(), mFeedback ) );
     if ( !intersectingGeom )
       continue;
 

--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
@@ -385,7 +385,7 @@ QgsFeatureIds QgsSensorThingsSharedData::getFeatureIdsInExtent( const QgsRectang
   if ( noMoreFeatures && res && ( !feedback || !feedback->isCanceled() ) )
   {
     locker.changeMode( QgsReadWriteLocker::Write );
-    mCachedExtent = QgsGeometry::unaryUnion( { mCachedExtent, extentGeom } );
+    mCachedExtent = QgsGeometry::unaryUnion( { mCachedExtent, extentGeom }, QgsGeometryParameters(), feedback );
   }
   nextPage = noMoreFeatures || !res ? QString() : queryUrl;
 

--- a/src/core/qgsmapclippingutils.cpp
+++ b/src/core/qgsmapclippingutils.cpp
@@ -56,7 +56,7 @@ QgsGeometry QgsMapClippingUtils::calculateFeatureRequestGeometry( const QList< Q
     }
     else
     {
-      result = result.intersection( region.geometry() );
+      result = result.intersection( region.geometry, QgsGeometryParameters(), context.feedback() );
     }
   }
 
@@ -102,7 +102,7 @@ QgsGeometry QgsMapClippingUtils::calculateFeatureIntersectionGeometry( const QLi
     }
     else
     {
-      result = result.intersection( region.geometry() );
+      result = result.intersection( region.geometry(), QgsGeometryParameters(), context.feedback() );
     }
   }
 
@@ -169,7 +169,7 @@ QPainterPath QgsMapClippingUtils::calculatePainterClipRegion( const QList<QgsMap
     }
     else
     {
-      result = result.intersection( region.geometry() );
+      result = result.intersection( region.geometry(), QgsGeometryParameters(), context.feedback() );
     }
   }
 
@@ -206,7 +206,7 @@ QgsGeometry QgsMapClippingUtils::calculateLabelIntersectionGeometry( const QList
     }
     else
     {
-      result = result.intersection( region.geometry() );
+      result = result.intersection( region.geometry(), QgsGeometryParameters(), context.feedback() );
     }
   }
 

--- a/src/core/qgsmapclippingutils.cpp
+++ b/src/core/qgsmapclippingutils.cpp
@@ -56,7 +56,7 @@ QgsGeometry QgsMapClippingUtils::calculateFeatureRequestGeometry( const QList< Q
     }
     else
     {
-      result = result.intersection( region.geometry, QgsGeometryParameters(), context.feedback() );
+      result = result.intersection( region.geometry(), QgsGeometryParameters(), context.feedback() );
     }
   }
 

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -5708,7 +5708,7 @@ void QgsRandomMarkerFillSymbolLayer::render( QgsRenderContext &context, const QV
     }
   }
 
-  const QgsGeometry geom = geometryParts.count() != 1 ? QgsGeometry::unaryUnion( geometryParts ) : geometryParts.at( 0 );
+  const QgsGeometry geom = geometryParts.count() != 1 ? QgsGeometry::unaryUnion( geometryParts, QgsGeometryParameters(), context.feedback() ) : geometryParts.at( 0 );
 
   if ( clipPoints )
   {

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -3429,7 +3429,7 @@ void QgsLinePatternFillSymbolLayer::renderPolygon( const QPolygonF &points, cons
     if ( shapeEngine )
     {
       QgsLineString ls( QgsPoint( x1, y1 ), QgsPoint( x2, y2 ) );
-      std::unique_ptr< QgsAbstractGeometry > intersection( shapeEngine->intersection( &ls ) );
+      std::unique_ptr< QgsAbstractGeometry > intersection( shapeEngine->intersection( &ls, nullptr, QgsGeometryParameters(), context.renderContext().feedback() ) );
       for ( auto it = intersection->const_parts_begin(); it != intersection->const_parts_end(); ++it )
       {
         if ( const QgsLineString *ls = qgsgeometry_cast< const QgsLineString * >( *it ) )

--- a/src/core/symbology/qgsmergedfeaturerenderer.cpp
+++ b/src/core/symbology/qgsmergedfeaturerenderer.cpp
@@ -317,7 +317,7 @@ void QgsMergedFeatureRenderer::stopRender( QgsRenderContext &context )
     {
       case QgsMergedFeatureRenderer::Merge:
       {
-        QgsGeometry unioned( QgsGeometry::unaryUnion( cit.geometries ) );
+        QgsGeometry unioned( QgsGeometry::unaryUnion( cit.geometries, QgsGeometryParameters(), context.feedback() ) );
         if ( unioned.type() == Qgis::GeometryType::Line )
           unioned = unioned.mergeLines();
         feat.setGeometry( unioned );
@@ -327,7 +327,7 @@ void QgsMergedFeatureRenderer::stopRender( QgsRenderContext &context )
       case QgsMergedFeatureRenderer::MergeAndInvert:
       {
         // compute the unary union on the polygons
-        const QgsGeometry unioned( QgsGeometry::unaryUnion( cit.geometries ) );
+        const QgsGeometry unioned( QgsGeometry::unaryUnion( cit.geometries, QgsGeometryParameters(), context.feedback() ) );
         // compute the difference with the extent
         const QgsGeometry rect = QgsGeometry::fromPolygonXY( mExtentPolygon );
         const QgsGeometry final = rect.difference( unioned );

--- a/src/core/symbology/qgsmergedfeaturerenderer.cpp
+++ b/src/core/symbology/qgsmergedfeaturerenderer.cpp
@@ -330,7 +330,7 @@ void QgsMergedFeatureRenderer::stopRender( QgsRenderContext &context )
         const QgsGeometry unioned( QgsGeometry::unaryUnion( cit.geometries, QgsGeometryParameters(), context.feedback() ) );
         // compute the difference with the extent
         const QgsGeometry rect = QgsGeometry::fromPolygonXY( mExtentPolygon );
-        const QgsGeometry final = rect.difference( unioned );
+        const QgsGeometry final = rect.difference( unioned, QgsGeometryParameters(), context.feedback() );
         feat.setGeometry( final );
         break;
       }

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -1744,7 +1744,7 @@ void QgsSymbol::renderFeature(
         // renderer settings, e.g. if polygons are being rendered using a rule based renderer based on the feature's area,
         // then we need to ensure that the original feature area is used instead of the clipped area..
         QgsGeos geos( processedGeometry );
-        std::unique_ptr< QgsAbstractGeometry > clippedGeom( geos.intersection( context.featureClipGeometry().constGet() ) );
+        std::unique_ptr< QgsAbstractGeometry > clippedGeom( geos.intersection( context.featureClipGeometry().constGet(), nullptr, QgsGeometryParameters(), context.feedback() ) );
         if ( clippedGeom )
         {
           temporaryGeometryContainer.set( clippedGeom.release() );

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -1103,9 +1103,9 @@ QPainterPath generateClipPath( const QgsRenderContext &renderContext, const QStr
     }
 #if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR < 10
     // structure would be better, but too old GEOS
-    mergedGeom = mergedGeom.makeValid( Qgis::MakeValidMethod::Linework );
+    mergedGeom = mergedGeom.makeValid( Qgis::MakeValidMethod::Linework, false, renderContext.feedback() );
 #else
-    mergedGeom = mergedGeom.makeValid( Qgis::MakeValidMethod::Structure );
+    mergedGeom = mergedGeom.makeValid( Qgis::MakeValidMethod::Structure, false, renderContext.feedback() );
 #endif
     if ( !mergedGeom.isEmpty() )
     {

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -1119,7 +1119,7 @@ QPainterPath generateClipPath( const QgsRenderContext &renderContext, const QStr
       {
         exterior = QgsGeometry::fromRect( contextBounds );
       }
-      const QgsGeometry maskGeom = exterior.difference( mergedGeom );
+      const QgsGeometry maskGeom = exterior.difference( mergedGeom, QgsGeometryParameters(), renderContext.feedback() );
       if ( !maskGeom.isNull() )
       {
         return maskGeom.constGet()->asQPainterPath();

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -1095,7 +1095,7 @@ QPainterPath generateClipPath( const QgsRenderContext &renderContext, const QStr
   if ( !clipGeometries.empty() )
   {
     foundGeometries = true;
-    QgsGeometry mergedGeom = QgsGeometry::unaryUnion( clipGeometries );
+    QgsGeometry mergedGeom = QgsGeometry::unaryUnion( clipGeometries, QgsGeometryParameters(), renderContext.feedback() );
     if ( renderContext.maskSettings().simplifyTolerance() > 0 )
     {
       QgsGeos geos( mergedGeom.constGet() );

--- a/src/core/vector/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/vector/qgsvectorlayerdiagramprovider.cpp
@@ -251,7 +251,7 @@ QgsLabelFeature *QgsVectorLayerDiagramProvider::registerDiagram( const QgsFeatur
   if ( !clipGeometry.isEmpty() )
   {
     const Qgis::GeometryType expectedType = geom.type();
-    geom = geom.intersection( clipGeometry );
+    geom = geom.intersection( clipGeometry, QgsGeometryParameters(), context.feedback() );
     geom.convertGeometryCollectionToSubclass( expectedType );
   }
   if ( geom.isEmpty() )

--- a/src/core/vectortile/qgsvectortilemvtencoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtencoder.cpp
@@ -217,7 +217,7 @@ void QgsVectorTileMVTEncoder::addLayer( QgsVectorLayer *layer, QgsFeedback *feed
     }
 
     // clip
-    const QgsGeometry clippedToTile = g.clipped( tileExtent );
+    const QgsGeometry clippedToTile = g.clipped( tileExtent, feedback );
     if ( clippedToTile.isEmpty() )
     {
       // this can often happen -- the transformation of the tile's bounding box to the layer's bounding box


### PR DESCRIPTION
Wherever easy, add early cancelation for intersection/makeValid/unaryUnion/combine/difference/subdivide and clip calls.

(This includes processing algorithm cancellation or map render cancellation)