### PR TITLE
Show preview of 3d materials when editing styles

### DIFF
--- a/src/3d/materials/qgsgoochmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.cpp
@@ -156,6 +156,29 @@ void QgsGoochMaterial3DHandler::applyDataDefinedToGeometry( const QgsAbstractMat
   dataBuffer->setData( data );
 }
 
+void QgsGoochMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+{
+  const QgsGoochMaterialSettings *goochSettings = qgis::down_cast< const QgsGoochMaterialSettings * >( settings );
+
+  QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
+  Qt3DRender::QEffect *effect = material->effect();
+
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"kd"_s ) )
+    p->setValue( goochSettings->diffuse() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"ks"_s ) )
+    p->setValue( goochSettings->specular() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"kblue"_s ) )
+    p->setValue( goochSettings->cool() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"kyellow"_s ) )
+    p->setValue( goochSettings->warm() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"shininess"_s ) )
+    p->setValue( goochSettings->shininess() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"alpha"_s ) )
+    p->setValue( goochSettings->alpha() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"beta"_s ) )
+    p->setValue( goochSettings->beta() );
+}
+
 QgsMaterial *QgsGoochMaterial3DHandler::buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const
 {
   const QgsGoochMaterialSettings *goochSettings = dynamic_cast< const QgsGoochMaterialSettings * >( settings );

--- a/src/3d/materials/qgsgoochmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.cpp
@@ -161,6 +161,9 @@ void QgsGoochMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot
   const QgsGoochMaterialSettings *goochSettings = qgis::down_cast< const QgsGoochMaterialSettings * >( settings );
 
   QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
+  if ( material->objectName() != "goochMaterial"_L1 )
+    return;
+
   Qt3DRender::QEffect *effect = material->effect();
 
   if ( Qt3DRender::QParameter *p = findParameter( effect, u"kd"_s ) )
@@ -186,6 +189,7 @@ QgsMaterial *QgsGoochMaterial3DHandler::buildMaterial( const QgsAbstractMaterial
   const QgsPropertyCollection &dataDefinedProperties = goochSettings->dataDefinedProperties();
 
   QgsMaterial *material = new QgsMaterial;
+  material->setObjectName( u"goochMaterial"_s );
 
   Qt3DRender::QEffect *effect = new Qt3DRender::QEffect( material );
 

--- a/src/3d/materials/qgsgoochmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.cpp
@@ -156,13 +156,13 @@ void QgsGoochMaterial3DHandler::applyDataDefinedToGeometry( const QgsAbstractMat
   dataBuffer->setData( data );
 }
 
-void QgsGoochMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+bool QgsGoochMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
 {
   const QgsGoochMaterialSettings *goochSettings = qgis::down_cast< const QgsGoochMaterialSettings * >( settings );
 
   QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
   if ( material->objectName() != "goochMaterial"_L1 )
-    return;
+    return false;
 
   Qt3DRender::QEffect *effect = material->effect();
 
@@ -180,6 +180,8 @@ void QgsGoochMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot
     p->setValue( goochSettings->alpha() );
   if ( Qt3DRender::QParameter *p = findParameter( effect, u"beta"_s ) )
     p->setValue( goochSettings->beta() );
+
+  return true;
 }
 
 QgsMaterial *QgsGoochMaterial3DHandler::buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const

--- a/src/3d/materials/qgsgoochmaterial3dhandler.h
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.h
@@ -41,7 +41,7 @@ class _3D_EXPORT QgsGoochMaterial3DHandler : public QgsAbstractMaterial3DHandler
     QByteArray dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const override;
     int dataDefinedByteStride( const QgsAbstractMaterialSettings *settings ) const override;
     void applyDataDefinedToGeometry( const QgsAbstractMaterialSettings *settings, Qt3DCore::QGeometry *geometry, int vertexCount, const QByteArray &data ) const override;
-    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
+    bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 
   private:
     //! Constructs a material from shader files

--- a/src/3d/materials/qgsgoochmaterial3dhandler.h
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.h
@@ -41,6 +41,7 @@ class _3D_EXPORT QgsGoochMaterial3DHandler : public QgsAbstractMaterial3DHandler
     QByteArray dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const override;
     int dataDefinedByteStride( const QgsAbstractMaterialSettings *settings ) const override;
     void applyDataDefinedToGeometry( const QgsAbstractMaterialSettings *settings, Qt3DCore::QGeometry *geometry, int vertexCount, const QByteArray &data ) const override;
+    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 
   private:
     //! Constructs a material from shader files

--- a/src/3d/materials/qgsmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmaterial3dhandler.cpp
@@ -16,6 +16,12 @@
 #include "qgsmaterial3dhandler.h"
 
 #include <QString>
+#include <Qt3DCore/QEntity>
+#include <Qt3DCore/QTransform>
+#include <Qt3DExtras/QSphereMesh>
+#include <Qt3DRender/QParameter>
+#include <Qt3DRender/QPointLight>
+#include <Qt3DRender/QTechnique>
 
 using namespace Qt::StringLiterals;
 
@@ -38,4 +44,67 @@ void QgsAbstractMaterial3DHandler::applyDataDefinedToGeometry( const QgsAbstract
 int QgsAbstractMaterial3DHandler::dataDefinedByteStride( const QgsAbstractMaterialSettings * ) const
 {
   return 0;
+}
+
+Qt3DRender::QParameter *QgsAbstractMaterial3DHandler::findParameter( Qt3DRender::QEffect *effect, const QString &name )
+{
+  const QList<Qt3DRender::QParameter *> parameters = effect->parameters();
+  for ( Qt3DRender::QParameter *parameter : parameters )
+  {
+    if ( parameter->name() == name )
+    {
+      return parameter;
+    }
+  }
+
+  const QList< Qt3DRender::QTechnique *> techniques = effect->techniques();
+  for ( Qt3DRender::QTechnique *technique : techniques )
+  {
+    const QList<Qt3DRender::QParameter *> parameters = technique->parameters();
+    for ( Qt3DRender::QParameter *parameter : parameters )
+    {
+      if ( parameter->name() == name )
+      {
+        return parameter;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+Qt3DCore::QEntity *QgsAbstractMaterial3DHandler::createPreviewMesh( Qt3DCore::QEntity *parent ) const
+{
+  auto *entity = new Qt3DCore::QEntity( parent );
+  auto *mesh = new Qt3DExtras::QSphereMesh( entity );
+  mesh->setRadius( 1.0f );
+  mesh->setRings( 32 );
+  mesh->setSlices( 32 );
+  entity->addComponent( mesh );
+  return entity;
+}
+
+Qt3DCore::QEntity *QgsAbstractMaterial3DHandler::createPreviewScene( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *, Qt3DCore::QEntity *parent ) const
+{
+  auto *root = new Qt3DCore::QEntity( parent );
+
+  Qt3DCore::QEntity *meshEntity = createPreviewMesh( root );
+  Q_ASSERT( meshEntity );
+  meshEntity->setObjectName( "mesh" );
+  if ( QgsMaterial *mat = toMaterial( settings, Qgis::MaterialRenderingTechnique::Triangles, context ) )
+  {
+    mat->setParent( meshEntity );
+    meshEntity->addComponent( mat );
+  }
+
+  auto *lightEntity = new Qt3DCore::QEntity( root );
+  auto *light = new Qt3DRender::QPointLight( lightEntity );
+  light->setColor( Qt::white );
+  light->setIntensity( 1.0f );
+  auto *lightTransform = new Qt3DCore::QTransform( lightEntity );
+  lightTransform->setTranslation( QVector3D( 3, 3, 3 ) );
+  lightEntity->addComponent( light );
+  lightEntity->addComponent( lightTransform );
+
+  return root;
 }

--- a/src/3d/materials/qgsmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmaterial3dhandler.cpp
@@ -18,6 +18,8 @@
 #include <QString>
 #include <Qt3DCore/QEntity>
 #include <Qt3DCore/QTransform>
+#include <Qt3DExtras/QConeMesh>
+#include <Qt3DExtras/QCuboidMesh>
 #include <Qt3DExtras/QSphereMesh>
 #include <Qt3DRender/QParameter>
 #include <Qt3DRender/QPointLight>
@@ -44,6 +46,23 @@ void QgsAbstractMaterial3DHandler::applyDataDefinedToGeometry( const QgsAbstract
 int QgsAbstractMaterial3DHandler::dataDefinedByteStride( const QgsAbstractMaterialSettings * ) const
 {
   return 0;
+}
+
+QList<QgsAbstractMaterial3DHandler::PreviewMeshType> QgsAbstractMaterial3DHandler::previewMeshTypes() const
+{
+  PreviewMeshType sphere;
+  sphere.type = u"sphere"_s;
+  sphere.displayName = QObject::tr( "Sphere" );
+
+  PreviewMeshType cube;
+  cube.type = u"cube"_s;
+  cube.displayName = QObject::tr( "Cube" );
+
+  PreviewMeshType cone;
+  cone.type = u"cone"_s;
+  cone.displayName = QObject::tr( "Cone" );
+
+  return { sphere, cube, cone };
 }
 
 Qt3DRender::QParameter *QgsAbstractMaterial3DHandler::findParameter( Qt3DRender::QEffect *effect, const QString &name )
@@ -73,22 +92,53 @@ Qt3DRender::QParameter *QgsAbstractMaterial3DHandler::findParameter( Qt3DRender:
   return nullptr;
 }
 
-Qt3DCore::QEntity *QgsAbstractMaterial3DHandler::createPreviewMesh( Qt3DCore::QEntity *parent ) const
+Qt3DCore::QEntity *QgsAbstractMaterial3DHandler::createPreviewMesh( const QString &type, Qt3DCore::QEntity *parent ) const
 {
   auto *entity = new Qt3DCore::QEntity( parent );
-  auto *mesh = new Qt3DExtras::QSphereMesh( entity );
-  mesh->setRadius( 1.0f );
-  mesh->setRings( 32 );
-  mesh->setSlices( 32 );
-  entity->addComponent( mesh );
+  if ( type == "sphere"_L1 )
+  {
+    auto *mesh = new Qt3DExtras::QSphereMesh( entity );
+    mesh->setRadius( 1.0f );
+    mesh->setRings( 32 );
+    mesh->setSlices( 32 );
+    entity->addComponent( mesh );
+  }
+  else if ( type == "cube"_L1 )
+  {
+    auto *mesh = new Qt3DExtras::QCuboidMesh( entity );
+    mesh->setXExtent( 1.8f );
+    mesh->setYExtent( 1.8f );
+    mesh->setZExtent( 1.8f );
+
+    auto *transform = new Qt3DCore::QTransform( mesh );
+    transform->setRotation( QQuaternion::fromEulerAngles( 15, 35, 15 ) );
+
+    entity->addComponent( mesh );
+    entity->addComponent( transform );
+  }
+  else if ( type == "cone"_L1 )
+  {
+    auto *mesh = new Qt3DExtras::QConeMesh( entity );
+    mesh->setBottomRadius( 1.2f );
+    mesh->setLength( 1.8f );
+    mesh->setRings( 32 );
+    mesh->setSlices( 32 );
+    auto *transform = new Qt3DCore::QTransform( mesh );
+    transform->setRotation( QQuaternion::fromEulerAngles( 5, 0, 0 ) );
+
+    entity->addComponent( mesh );
+    entity->addComponent( transform );
+  }
   return entity;
 }
 
-Qt3DCore::QEntity *QgsAbstractMaterial3DHandler::createPreviewScene( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *, Qt3DCore::QEntity *parent ) const
+Qt3DCore::QEntity *QgsAbstractMaterial3DHandler::createPreviewScene(
+  const QgsAbstractMaterialSettings *settings, const QString &type, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *, Qt3DCore::QEntity *parent
+) const
 {
   auto *root = new Qt3DCore::QEntity( parent );
 
-  Qt3DCore::QEntity *meshEntity = createPreviewMesh( root );
+  Qt3DCore::QEntity *meshEntity = createPreviewMesh( type, root );
   Q_ASSERT( meshEntity );
   meshEntity->setObjectName( "mesh" );
   if ( QgsMaterial *mat = toMaterial( settings, Qgis::MaterialRenderingTechnique::Triangles, context ) )

--- a/src/3d/materials/qgsmaterial3dhandler.h
+++ b/src/3d/materials/qgsmaterial3dhandler.h
@@ -158,6 +158,22 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
     virtual int dataDefinedByteStride( const QgsAbstractMaterialSettings *settings ) const;
 
     /**
+     * Encapsulates information about available preview meshes.
+     */
+    struct PreviewMeshType
+    {
+        //! Identifier string
+        QString type;
+        //! Translated, user-friendly name
+        QString displayName;
+    };
+
+    /**
+     * Returns a list of available preview mesh types for the material.
+     */
+    virtual QList< PreviewMeshType > previewMeshTypes() const;
+
+    /**
      * Creates a new entity representing a suitable preview mesh for this material type.
      *
      * The default implementation returns a sphere. This method can be overridden to provide
@@ -165,10 +181,10 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
      *
      * Ownership of the returned entity resides with the \a parent entity.
      */
-    virtual Qt3DCore::QEntity *createPreviewMesh( Qt3DCore::QEntity *parent ) const;
+    virtual Qt3DCore::QEntity *createPreviewMesh( const QString &type, Qt3DCore::QEntity *parent ) const;
 
     /**
-     * Builds a complete self-contained scene for previewing the material.
+     * Builds a complete self-contained scene for previewing the material, using the specified mesh \a type.
      *
      * The scene contains a mesh with the associated material applied, and appropriate lighting.
      *
@@ -176,7 +192,9 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
      *
      * This method can be overridden to customize the lighting or mesh for a specific material.
      */
-    virtual Qt3DCore::QEntity *createPreviewScene( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *window, Qt3DCore::QEntity *parent ) const;
+    virtual Qt3DCore::QEntity *createPreviewScene(
+      const QgsAbstractMaterialSettings *settings, const QString &type, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *window, Qt3DCore::QEntity *parent
+    ) const;
 
     /**
      * Updates an existing material preview scene with new material \a settings.

--- a/src/3d/materials/qgsmaterial3dhandler.h
+++ b/src/3d/materials/qgsmaterial3dhandler.h
@@ -38,6 +38,10 @@ namespace Qt3DCore
 {
   class QGeometry;
 }
+namespace Qt3DExtras
+{
+  class Qt3DWindow;
+}
 
 /**
  * \ingroup qgis_3d
@@ -152,6 +156,45 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
      * \since QGIS 3.18
      */
     virtual int dataDefinedByteStride( const QgsAbstractMaterialSettings *settings ) const;
+
+    /**
+     * Creates a new entity representing a suitable preview mesh for this material type.
+     *
+     * The default implementation returns a sphere. This method can be overridden to provide
+     * more appropriate meshes when applicable for a particular material implementation.
+     *
+     * Ownership of the returned entity resides with the \a parent entity.
+     */
+    virtual Qt3DCore::QEntity *createPreviewMesh( Qt3DCore::QEntity *parent ) const;
+
+    /**
+     * Builds a complete self-contained scene for previewing the material.
+     *
+     * The scene contains a mesh with the associated material applied, and appropriate lighting.
+     *
+     * The returned entity is the scene root, parented to \a parent.
+     *
+     * This method can be overridden to customize the lighting or mesh for a specific material.
+     */
+    virtual Qt3DCore::QEntity *createPreviewScene( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *window, Qt3DCore::QEntity *parent ) const;
+
+    /**
+     * Updates an existing material preview scene with new material \a settings.
+     *
+     * This method is called on every material setting parameter change while configuring
+     * materials, so the implementation must be cheap (e.g. involve no entity creation, just direct
+     * manipulation of existing attributes).
+     */
+    virtual void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const = 0;
+
+  protected:
+    /**
+     * Finds an existing parameter in an \a effect by \a name.
+     *
+     * This method searches both parameters which are directly applied \a effect and
+     * also parameters applied to all techniques present in the effect.
+     */
+    static Qt3DRender::QParameter *findParameter( Qt3DRender::QEffect *effect, const QString &name );
 };
 
 

--- a/src/3d/materials/qgsmaterial3dhandler.h
+++ b/src/3d/materials/qgsmaterial3dhandler.h
@@ -202,8 +202,10 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
      * This method is called on every material setting parameter change while configuring
      * materials, so the implementation must be cheap (e.g. involve no entity creation, just direct
      * manipulation of existing attributes).
+     *
+     * Returns FALSE if the scene could not be updated in place and needs to be regenered via createPreviewScene().
      */
-    virtual void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const = 0;
+    virtual bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const = 0;
 
   protected:
     /**

--- a/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
@@ -43,6 +43,7 @@ QgsMaterial *QgsMetalRoughMaterial3DHandler::toMaterial( const QgsAbstractMateri
       }
 
       QgsMetalRoughMaterial *material = new QgsMetalRoughMaterial;
+      material->setObjectName( u"metalRoughMaterial"_s );
       material->setBaseColor( context.isSelected() ? context.selectionColor() : metalRoughSettings->baseColor() );
       material->setMetalness( std::clamp( metalRoughSettings->metalness(), 0.0, 1.0 ) );
       material->setRoughness( std::clamp( metalRoughSettings->roughness(), 0.0, 1.0 ) );
@@ -72,6 +73,9 @@ void QgsMetalRoughMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *scen
   const QgsMetalRoughMaterialSettings *metalRoughSettings = qgis::down_cast< const QgsMetalRoughMaterialSettings * >( settings );
 
   QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
+  if ( material->objectName() != "metalRoughMaterial"_L1 )
+    return;
+
   Qt3DRender::QEffect *effect = material->effect();
 
   if ( Qt3DRender::QParameter *p = findParameter( effect, u"baseColor"_s ) )

--- a/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
@@ -20,6 +20,8 @@
 #include "qgsmetalroughmaterialsettings.h"
 
 #include <QString>
+#include <Qt3DCore/QEntity>
+#include <Qt3DRender/QParameter>
 
 using namespace Qt::StringLiterals;
 
@@ -64,3 +66,18 @@ QMap<QString, QString> QgsMetalRoughMaterial3DHandler::toExportParameters( const
 
 void QgsMetalRoughMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffect *, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
 {}
+
+void QgsMetalRoughMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+{
+  const QgsMetalRoughMaterialSettings *metalRoughSettings = qgis::down_cast< const QgsMetalRoughMaterialSettings * >( settings );
+
+  QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
+  Qt3DRender::QEffect *effect = material->effect();
+
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"baseColor"_s ) )
+    p->setValue( metalRoughSettings->baseColor() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"metalness"_s ) )
+    p->setValue( metalRoughSettings->metalness() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"roughness"_s ) )
+    p->setValue( metalRoughSettings->roughness() );
+}

--- a/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
@@ -68,13 +68,13 @@ QMap<QString, QString> QgsMetalRoughMaterial3DHandler::toExportParameters( const
 void QgsMetalRoughMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffect *, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
 {}
 
-void QgsMetalRoughMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+bool QgsMetalRoughMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
 {
   const QgsMetalRoughMaterialSettings *metalRoughSettings = qgis::down_cast< const QgsMetalRoughMaterialSettings * >( settings );
 
   QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
   if ( material->objectName() != "metalRoughMaterial"_L1 )
-    return;
+    return false;
 
   Qt3DRender::QEffect *effect = material->effect();
 
@@ -84,4 +84,5 @@ void QgsMetalRoughMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *scen
     p->setValue( metalRoughSettings->metalness() );
   if ( Qt3DRender::QParameter *p = findParameter( effect, u"roughness"_s ) )
     p->setValue( metalRoughSettings->roughness() );
+  return true;
 }

--- a/src/3d/materials/qgsmetalroughmaterial3dhandler.h
+++ b/src/3d/materials/qgsmetalroughmaterial3dhandler.h
@@ -37,6 +37,7 @@ class _3D_EXPORT QgsMetalRoughMaterial3DHandler : public QgsAbstractMaterial3DHa
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
+    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 };
 
 

--- a/src/3d/materials/qgsmetalroughmaterial3dhandler.h
+++ b/src/3d/materials/qgsmetalroughmaterial3dhandler.h
@@ -37,7 +37,7 @@ class _3D_EXPORT QgsMetalRoughMaterial3DHandler : public QgsAbstractMaterial3DHa
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
-    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
+    bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 };
 
 

--- a/src/3d/materials/qgsnullmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsnullmaterial3dhandler.cpp
@@ -40,3 +40,6 @@ QMap<QString, QString> QgsNullMaterial3DHandler::toExportParameters( const QgsAb
 
 void QgsNullMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffect *, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
 {}
+
+void QgsNullMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
+{}

--- a/src/3d/materials/qgsnullmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsnullmaterial3dhandler.cpp
@@ -41,5 +41,7 @@ QMap<QString, QString> QgsNullMaterial3DHandler::toExportParameters( const QgsAb
 void QgsNullMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffect *, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
 {}
 
-void QgsNullMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
-{}
+bool QgsNullMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
+{
+  return true;
+}

--- a/src/3d/materials/qgsnullmaterial3dhandler.h
+++ b/src/3d/materials/qgsnullmaterial3dhandler.h
@@ -37,7 +37,7 @@ class _3D_EXPORT QgsNullMaterial3DHandler : public QgsAbstractMaterial3DHandler
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
-    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
+    bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 };
 
 

--- a/src/3d/materials/qgsnullmaterial3dhandler.h
+++ b/src/3d/materials/qgsnullmaterial3dhandler.h
@@ -37,6 +37,7 @@ class _3D_EXPORT QgsNullMaterial3DHandler : public QgsAbstractMaterial3DHandler
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
+    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 };
 
 

--- a/src/3d/materials/qgsphongmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongmaterial3dhandler.cpp
@@ -224,6 +224,9 @@ void QgsPhongMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot
   const QgsPhongMaterialSettings *phongSettings = qgis::down_cast< const QgsPhongMaterialSettings * >( settings );
 
   QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
+  if ( material->objectName() != "phongMaterial"_L1 )
+    return;
+
   Qt3DRender::QEffect *effect = material->effect();
 
   const QColor ambient = phongSettings->ambient();
@@ -274,6 +277,7 @@ QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterial
   Q_ASSERT( phongSettings );
 
   QgsMaterial *material = new QgsMaterial;
+  material->setObjectName( u"phongMaterial"_s );
 
   Qt3DRender::QEffect *effect = new Qt3DRender::QEffect( material );
 

--- a/src/3d/materials/qgsphongmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongmaterial3dhandler.cpp
@@ -219,13 +219,13 @@ void QgsPhongMaterial3DHandler::applyDataDefinedToGeometry( const QgsAbstractMat
   dataBuffer->setData( data );
 }
 
-void QgsPhongMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+bool QgsPhongMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
 {
   const QgsPhongMaterialSettings *phongSettings = qgis::down_cast< const QgsPhongMaterialSettings * >( settings );
 
   QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
   if ( material->objectName() != "phongMaterial"_L1 )
-    return;
+    return false;
 
   Qt3DRender::QEffect *effect = material->effect();
 
@@ -269,6 +269,8 @@ void QgsPhongMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot
 
   if ( Qt3DRender::QParameter *p = findParameter( effect, u"opacity"_s ) )
     p->setValue( static_cast<float>( phongSettings->opacity() ) );
+
+  return true;
 }
 
 QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const

--- a/src/3d/materials/qgsphongmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongmaterial3dhandler.cpp
@@ -219,6 +219,55 @@ void QgsPhongMaterial3DHandler::applyDataDefinedToGeometry( const QgsAbstractMat
   dataBuffer->setData( data );
 }
 
+void QgsPhongMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+{
+  const QgsPhongMaterialSettings *phongSettings = qgis::down_cast< const QgsPhongMaterialSettings * >( settings );
+
+  QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
+  Qt3DRender::QEffect *effect = material->effect();
+
+  const QColor ambient = phongSettings->ambient();
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"ambientColor"_s ) )
+  {
+    p->setValue(
+      QColor::fromRgbF(
+        static_cast< float >( ambient.redF() * phongSettings->ambientCoefficient() ),
+        static_cast< float >( ambient.greenF() * phongSettings->ambientCoefficient() ),
+        static_cast< float >( ambient.blueF() * phongSettings->ambientCoefficient() )
+      )
+    );
+  }
+  const QColor diffuse = phongSettings->diffuse();
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"diffuseColor"_s ) )
+  {
+    p->setValue(
+      QColor::fromRgbF(
+        static_cast<float >( diffuse.redF() * phongSettings->diffuseCoefficient() ),
+        static_cast< float >( diffuse.greenF() * phongSettings->diffuseCoefficient() ),
+        static_cast< float >( diffuse.blueF() * phongSettings->diffuseCoefficient() )
+      )
+    );
+  }
+
+  const QColor specularColor = phongSettings->specular();
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"specularColor"_s ) )
+  {
+    p->setValue(
+      QColor::fromRgbF(
+        static_cast< float >( specularColor.redF() * phongSettings->specularCoefficient() ),
+        static_cast< float >( specularColor.greenF() * phongSettings->specularCoefficient() ),
+        static_cast< float >( specularColor.blueF() * phongSettings->specularCoefficient() )
+      )
+    );
+  }
+
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"shininess"_s ) )
+    p->setValue( static_cast<float>( phongSettings->shininess() ) );
+
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"opacity"_s ) )
+    p->setValue( static_cast<float>( phongSettings->opacity() ) );
+}
+
 QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const
 {
   const QgsPhongMaterialSettings *phongSettings = dynamic_cast< const QgsPhongMaterialSettings * >( settings );

--- a/src/3d/materials/qgsphongmaterial3dhandler.h
+++ b/src/3d/materials/qgsphongmaterial3dhandler.h
@@ -41,7 +41,7 @@ class _3D_EXPORT QgsPhongMaterial3DHandler : public QgsAbstractMaterial3DHandler
     QByteArray dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const override;
     int dataDefinedByteStride( const QgsAbstractMaterialSettings *settings ) const override;
     void applyDataDefinedToGeometry( const QgsAbstractMaterialSettings *settings, Qt3DCore::QGeometry *geometry, int vertexCount, const QByteArray &data ) const override;
-    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
+    bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 
   private:
     //! Constructs a material from shader files

--- a/src/3d/materials/qgsphongmaterial3dhandler.h
+++ b/src/3d/materials/qgsphongmaterial3dhandler.h
@@ -41,6 +41,7 @@ class _3D_EXPORT QgsPhongMaterial3DHandler : public QgsAbstractMaterial3DHandler
     QByteArray dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const override;
     int dataDefinedByteStride( const QgsAbstractMaterialSettings *settings ) const override;
     void applyDataDefinedToGeometry( const QgsAbstractMaterialSettings *settings, Qt3DCore::QGeometry *geometry, int vertexCount, const QByteArray &data ) const override;
+    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 
   private:
     //! Constructs a material from shader files

--- a/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
@@ -26,6 +26,7 @@
 
 #include <QMap>
 #include <QString>
+#include <Qt3DCore/QEntity>
 #include <Qt3DRender/QEffect>
 #include <Qt3DRender/QGraphicsApiFilter>
 #include <Qt3DRender/QPaintedTextureImage>
@@ -136,4 +137,29 @@ void QgsPhongTexturedMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffe
   effect->addParameter( ambientParameter );
   effect->addParameter( specularParameter );
   effect->addParameter( shininessParameter );
+}
+
+void QgsPhongTexturedMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+{
+  const QgsPhongTexturedMaterialSettings *phongSettings = qgis::down_cast< const QgsPhongTexturedMaterialSettings * >( settings );
+
+  QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
+  Qt3DRender::QEffect *effect = material->effect();
+
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"ambientColor"_s ) )
+    p->setValue( phongSettings->ambient() );
+
+  Qt3DRender::QTexture2D *texture = material->findChild<Qt3DRender::QTexture2D *>();
+  bool fitsInCache;
+  texture->addTextureImage( new QgsImageTexture( QgsApplication::imageCache()->pathAsImage( phongSettings->diffuseTexturePath(), QSize(), true, 1.0, fitsInCache ) ) );
+  texture->removeTextureImage( texture->textureImages().at( 0 ) );
+
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"texCoordScale"_s ) )
+    p->setValue( phongSettings->textureScale() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"specularColor"_s ) )
+    p->setValue( phongSettings->specular() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"shininess"_s ) )
+    p->setValue( phongSettings->shininess() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"opacity"_s ) )
+    p->setValue( phongSettings->opacity() );
 }

--- a/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
@@ -74,6 +74,7 @@ QgsMaterial *QgsPhongTexturedMaterial3DHandler::toMaterial( const QgsAbstractMat
       }
 
       QgsPhongTexturedMaterial *material = new QgsPhongTexturedMaterial();
+      material->setObjectName( u"phongTexturedMaterial"_s );
 
       int opacity = static_cast<int>( phongSettings->opacity() * 255.0 );
       QColor ambient = context.isSelected() ? context.selectionColor().darker() : phongSettings->ambient();
@@ -144,6 +145,9 @@ void QgsPhongTexturedMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *s
   const QgsPhongTexturedMaterialSettings *phongSettings = qgis::down_cast< const QgsPhongTexturedMaterialSettings * >( settings );
 
   QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
+  if ( material->objectName() != "phongTexturedMaterial"_L1 )
+    return;
+
   Qt3DRender::QEffect *effect = material->effect();
 
   if ( Qt3DRender::QParameter *p = findParameter( effect, u"ambientColor"_s ) )

--- a/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
@@ -140,13 +140,13 @@ void QgsPhongTexturedMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffe
   effect->addParameter( shininessParameter );
 }
 
-void QgsPhongTexturedMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+bool QgsPhongTexturedMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
 {
   const QgsPhongTexturedMaterialSettings *phongSettings = qgis::down_cast< const QgsPhongTexturedMaterialSettings * >( settings );
 
   QgsMaterial *material = sceneRoot->findChild<QgsMaterial *>();
   if ( material->objectName() != "phongTexturedMaterial"_L1 )
-    return;
+    return false;
 
   Qt3DRender::QEffect *effect = material->effect();
 
@@ -166,4 +166,5 @@ void QgsPhongTexturedMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *s
     p->setValue( phongSettings->shininess() );
   if ( Qt3DRender::QParameter *p = findParameter( effect, u"opacity"_s ) )
     p->setValue( phongSettings->opacity() );
+  return true;
 }

--- a/src/3d/materials/qgsphongtexturedmaterial3dhandler.h
+++ b/src/3d/materials/qgsphongtexturedmaterial3dhandler.h
@@ -39,7 +39,7 @@ class _3D_EXPORT QgsPhongTexturedMaterial3DHandler : public QgsAbstractMaterial3
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
-    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
+    bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 };
 
 

--- a/src/3d/materials/qgsphongtexturedmaterial3dhandler.h
+++ b/src/3d/materials/qgsphongtexturedmaterial3dhandler.h
@@ -39,6 +39,7 @@ class _3D_EXPORT QgsPhongTexturedMaterial3DHandler : public QgsAbstractMaterial3
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
+    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 };
 
 

--- a/src/3d/materials/qgssimplelinematerial3dhandler.cpp
+++ b/src/3d/materials/qgssimplelinematerial3dhandler.cpp
@@ -131,7 +131,15 @@ void QgsSimpleLineMaterial3DHandler::applyDataDefinedToGeometry( const QgsAbstra
   dataBuffer->setData( data );
 }
 
-Qt3DCore::QEntity *QgsSimpleLineMaterial3DHandler::createPreviewMesh( Qt3DCore::QEntity *parent ) const
+QList<QgsAbstractMaterial3DHandler::PreviewMeshType> QgsSimpleLineMaterial3DHandler::previewMeshTypes() const
+{
+  PreviewMeshType lines;
+  lines.type = u"lines"_s;
+  lines.displayName = QObject::tr( "Lines" );
+  return { lines };
+}
+
+Qt3DCore::QEntity *QgsSimpleLineMaterial3DHandler::createPreviewMesh( const QString &, Qt3DCore::QEntity *parent ) const
 {
   auto *entity = new Qt3DCore::QEntity( parent );
   auto *renderer = new Qt3DRender::QGeometryRenderer( entity );
@@ -153,11 +161,11 @@ Qt3DCore::QEntity *QgsSimpleLineMaterial3DHandler::createPreviewMesh( Qt3DCore::
 }
 
 Qt3DCore::QEntity *QgsSimpleLineMaterial3DHandler::createPreviewScene(
-  const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *window, Qt3DCore::QEntity *parent
+  const QgsAbstractMaterialSettings *settings, const QString &type, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *window, Qt3DCore::QEntity *parent
 ) const
 {
   auto *root = new Qt3DCore::QEntity( parent );
-  Qt3DCore::QEntity *mesh = createPreviewMesh( root );
+  Qt3DCore::QEntity *mesh = createPreviewMesh( type, root );
 
   QgsMaterial *mat = toMaterial( settings, Qgis::MaterialRenderingTechnique::Lines, context );
   QgsLineMaterial *lineMaterial = qobject_cast<QgsLineMaterial *>( mat );

--- a/src/3d/materials/qgssimplelinematerial3dhandler.cpp
+++ b/src/3d/materials/qgssimplelinematerial3dhandler.cpp
@@ -185,10 +185,12 @@ Qt3DCore::QEntity *QgsSimpleLineMaterial3DHandler::createPreviewScene(
   return root;
 }
 
-void QgsSimpleLineMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+bool QgsSimpleLineMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
 {
   const QgsSimpleLineMaterialSettings *lineSettings = qgis::down_cast< const QgsSimpleLineMaterialSettings * >( settings );
 
   QgsLineMaterial *material = sceneRoot->findChild<QgsLineMaterial *>();
   material->setLineColor( lineSettings->ambient() );
+
+  return true;
 }

--- a/src/3d/materials/qgssimplelinematerial3dhandler.cpp
+++ b/src/3d/materials/qgssimplelinematerial3dhandler.cpp
@@ -16,6 +16,8 @@
 #include "qgssimplelinematerial3dhandler.h"
 
 #include "qgslinematerial_p.h"
+#include "qgslinestring.h"
+#include "qgslinevertexdata_p.h"
 #include "qgssimplelinematerialsettings.h"
 
 #include <QMap>
@@ -23,7 +25,9 @@
 #include <Qt3DCore/QAttribute>
 #include <Qt3DCore/QBuffer>
 #include <Qt3DCore/QGeometry>
+#include <Qt3DExtras/Qt3DWindow>
 #include <Qt3DRender/QEffect>
+#include <Qt3DRender/QGeometryRenderer>
 #include <Qt3DRender/QParameter>
 #include <Qt3DRender/QTexture>
 
@@ -125,4 +129,58 @@ void QgsSimpleLineMaterial3DHandler::applyDataDefinedToGeometry( const QgsAbstra
   geometry->addAttribute( colorAttribute );
 
   dataBuffer->setData( data );
+}
+
+Qt3DCore::QEntity *QgsSimpleLineMaterial3DHandler::createPreviewMesh( Qt3DCore::QEntity *parent ) const
+{
+  auto *entity = new Qt3DCore::QEntity( parent );
+  auto *renderer = new Qt3DRender::QGeometryRenderer( entity );
+  renderer->setPrimitiveType( Qt3DRender::QGeometryRenderer::LineStripAdjacency );
+
+  QgsLineVertexData lineVertexData;
+  lineVertexData.withAdjacency = true;
+  constexpr double s = 1.0;
+  // just a boring old flat square
+  lineVertexData.addLineString( QgsLineString( { -s, s, s, -s, -s }, { -s, -s, s, s, -s }, { 0, 0, 0, 0, 0 } ) );
+  Qt3DCore::QGeometry *geometry = lineVertexData.createGeometry( entity );
+  renderer->setGeometry( geometry );
+  renderer->setVertexCount( static_cast< int >( lineVertexData.indexes.count() ) );
+  renderer->setPrimitiveRestartEnabled( true );
+  renderer->setRestartIndexValue( 0 );
+
+  entity->addComponent( renderer );
+  return entity;
+}
+
+Qt3DCore::QEntity *QgsSimpleLineMaterial3DHandler::createPreviewScene(
+  const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *window, Qt3DCore::QEntity *parent
+) const
+{
+  auto *root = new Qt3DCore::QEntity( parent );
+  Qt3DCore::QEntity *mesh = createPreviewMesh( root );
+
+  QgsMaterial *mat = toMaterial( settings, Qgis::MaterialRenderingTechnique::Lines, context );
+  QgsLineMaterial *lineMaterial = qobject_cast<QgsLineMaterial *>( mat );
+  Q_ASSERT( lineMaterial );
+  lineMaterial->setLineWidth( 2 );
+  if ( window )
+  {
+    // ensure viewport size is updated if preview widget window size changes
+    auto updateViewport = [lineMaterial, window]() { lineMaterial->setViewportSize( QSizeF( window->width(), window->height() ) ); };
+    QObject::connect( window, &Qt3DExtras::Qt3DWindow::widthChanged, lineMaterial, updateViewport );
+    QObject::connect( window, &Qt3DExtras::Qt3DWindow::heightChanged, lineMaterial, updateViewport );
+    updateViewport();
+  }
+
+  mat->setParent( mesh );
+  mesh->addComponent( mat );
+  return root;
+}
+
+void QgsSimpleLineMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+{
+  const QgsSimpleLineMaterialSettings *lineSettings = qgis::down_cast< const QgsSimpleLineMaterialSettings * >( settings );
+
+  QgsLineMaterial *material = sceneRoot->findChild<QgsLineMaterial *>();
+  material->setLineColor( lineSettings->ambient() );
 }

--- a/src/3d/materials/qgssimplelinematerial3dhandler.h
+++ b/src/3d/materials/qgssimplelinematerial3dhandler.h
@@ -42,6 +42,9 @@ class _3D_EXPORT QgsSimpleLineMaterial3DHandler : public QgsAbstractMaterial3DHa
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
     QByteArray dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const override;
     void applyDataDefinedToGeometry( const QgsAbstractMaterialSettings *settings, Qt3DCore::QGeometry *geometry, int vertexCount, const QByteArray &data ) const override;
+    Qt3DCore::QEntity *createPreviewMesh( Qt3DCore::QEntity *parent ) const override;
+    Qt3DCore::QEntity *createPreviewScene( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *window, Qt3DCore::QEntity *parent ) const override;
+    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 };
 
 

--- a/src/3d/materials/qgssimplelinematerial3dhandler.h
+++ b/src/3d/materials/qgssimplelinematerial3dhandler.h
@@ -47,7 +47,7 @@ class _3D_EXPORT QgsSimpleLineMaterial3DHandler : public QgsAbstractMaterial3DHa
     Qt3DCore::QEntity *createPreviewScene(
       const QgsAbstractMaterialSettings *settings, const QString &type, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *window, Qt3DCore::QEntity *parent
     ) const override;
-    void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
+    bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 };
 
 

--- a/src/3d/materials/qgssimplelinematerial3dhandler.h
+++ b/src/3d/materials/qgssimplelinematerial3dhandler.h
@@ -42,8 +42,11 @@ class _3D_EXPORT QgsSimpleLineMaterial3DHandler : public QgsAbstractMaterial3DHa
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
     QByteArray dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const override;
     void applyDataDefinedToGeometry( const QgsAbstractMaterialSettings *settings, Qt3DCore::QGeometry *geometry, int vertexCount, const QByteArray &data ) const override;
-    Qt3DCore::QEntity *createPreviewMesh( Qt3DCore::QEntity *parent ) const override;
-    Qt3DCore::QEntity *createPreviewScene( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *window, Qt3DCore::QEntity *parent ) const override;
+    QList< PreviewMeshType > previewMeshTypes() const override;
+    Qt3DCore::QEntity *createPreviewMesh( const QString &type, Qt3DCore::QEntity *parent ) const override;
+    Qt3DCore::QEntity *createPreviewScene(
+      const QgsAbstractMaterialSettings *settings, const QString &type, const QgsMaterialContext &context, Qt3DExtras::Qt3DWindow *window, Qt3DCore::QEntity *parent
+    ) const override;
     void updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 };
 

--- a/src/3d/qgs3d.h
+++ b/src/3d/qgs3d.h
@@ -117,15 +117,16 @@ class _3D_EXPORT Qgs3D
      * \since QGIS 4.2
      */
     static int materialDataDefinedByteStride( const QgsAbstractMaterialSettings *settings );
-#endif
-
-  private:
-    Qgs3D();
 
     /**
      * Returns the handler to use for a material \a settings.
      */
     static const QgsAbstractMaterial3DHandler *handlerForMaterialSettings( const QgsAbstractMaterialSettings *settings );
+
+#endif
+
+  private:
+    Qgs3D();
 
 #ifdef SIP_RUN
     Qgs3D( const Qgs3D &other );

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -412,7 +412,7 @@ float Qgs3DUtils::clampAltitude( const QgsPoint &p, Qgis::AltitudeClamping altCl
     }
   }
 
-  const float z = ( terrainZ + geomZ ) * static_cast<float>( context.terrainSettings()->verticalScale() ) + offset;
+  const float z = ( terrainZ + geomZ ) * ( context.terrainSettings() ? static_cast<float>( context.terrainSettings()->verticalScale() ) : 1 ) + offset;
   return z;
 }
 
@@ -460,7 +460,7 @@ void Qgs3DUtils::clampAltitudes( QgsLineString *lineString, Qgis::AltitudeClampi
         break;
     }
 
-    const float z = ( terrainZ + geomZ ) * static_cast<float>( context.terrainSettings()->verticalScale() ) + offset;
+    const float z = ( terrainZ + geomZ ) * ( context.terrainSettings() ? static_cast<float>( context.terrainSettings()->verticalScale() ) : 1 ) + offset;
     lineString->setZAt( i, z );
   }
 }
@@ -536,7 +536,7 @@ void Qgs3DUtils::extractPointPositions(
       geomZ = pt.z();
     }
     const float terrainZ = context.terrainRenderingEnabled() && context.terrainGenerator()
-                             ? static_cast<float>( context.terrainGenerator()->heightAt( pt.x(), pt.y(), context ) * context.terrainSettings()->verticalScale() )
+                             ? static_cast<float>( context.terrainGenerator()->heightAt( pt.x(), pt.y(), context ) * ( context.terrainSettings() ? context.terrainSettings()->verticalScale() : 1 ) )
                              : 0.f;
     float h = 0.0f;
     switch ( altClamp )

--- a/src/app/3d/qgsgoochmaterialwidget.cpp
+++ b/src/app/3d/qgsgoochmaterialwidget.cpp
@@ -111,7 +111,7 @@ void QgsGoochMaterialWidget::setTechnique( Qgis::MaterialRenderingTechnique tech
   }
 }
 
-QgsAbstractMaterialSettings *QgsGoochMaterialWidget::settings()
+std::unique_ptr<QgsAbstractMaterialSettings> QgsGoochMaterialWidget::settings()
 {
   auto m = std::make_unique<QgsGoochMaterialSettings>();
   m->setDiffuse( btnDiffuse->color() );
@@ -128,7 +128,7 @@ QgsAbstractMaterialSettings *QgsGoochMaterialWidget::settings()
   mPropertyCollection.setProperty( QgsAbstractMaterialSettings::Property::Specular, mSpecularDataDefinedButton->toProperty() );
   m->setDataDefinedProperties( mPropertyCollection );
 
-  return m.release();
+  return m;
 }
 
 void QgsGoochMaterialWidget::setPreviewVisible( bool visible )

--- a/src/app/3d/qgsgoochmaterialwidget.cpp
+++ b/src/app/3d/qgsgoochmaterialwidget.cpp
@@ -24,6 +24,7 @@ QgsGoochMaterialWidget::QgsGoochMaterialWidget( QWidget *parent )
   : QgsMaterialSettingsWidget( parent )
 {
   setupUi( this );
+  mPreviewWidget->hide();
 
   QgsGoochMaterialSettings defaultMaterial;
   setSettings( &defaultMaterial, nullptr );
@@ -46,6 +47,8 @@ QgsGoochMaterialWidget::QgsGoochMaterialWidget( QWidget *parent )
   connect( mWarmDataDefinedButton, &QgsPropertyOverrideButton::changed, this, &QgsGoochMaterialWidget::changed );
   connect( mCoolDataDefinedButton, &QgsPropertyOverrideButton::changed, this, &QgsGoochMaterialWidget::changed );
   connect( mSpecularDataDefinedButton, &QgsPropertyOverrideButton::changed, this, &QgsGoochMaterialWidget::changed );
+
+  connect( this, &QgsGoochMaterialWidget::changed, this, &QgsGoochMaterialWidget::updatePreview );
 }
 
 QgsMaterialSettingsWidget *QgsGoochMaterialWidget::create()
@@ -72,6 +75,8 @@ void QgsGoochMaterialWidget::setSettings( const QgsAbstractMaterialSettings *set
   mWarmDataDefinedButton->init( static_cast<int>( QgsAbstractMaterialSettings::Property::Warm ), mPropertyCollection, settings->propertyDefinitions(), layer, true );
   mCoolDataDefinedButton->init( static_cast<int>( QgsAbstractMaterialSettings::Property::Cool ), mPropertyCollection, settings->propertyDefinitions(), layer, true );
   mSpecularDataDefinedButton->init( static_cast<int>( QgsAbstractMaterialSettings::Property::Specular ), mPropertyCollection, settings->propertyDefinitions(), layer, true );
+
+  updatePreview();
 }
 
 void QgsGoochMaterialWidget::setTechnique( Qgis::MaterialRenderingTechnique technique )
@@ -119,4 +124,18 @@ QgsAbstractMaterialSettings *QgsGoochMaterialWidget::settings()
   m->setDataDefinedProperties( mPropertyCollection );
 
   return m.release();
+}
+
+void QgsGoochMaterialWidget::setPreviewVisible( bool visible )
+{
+  mPreviewWidget->setVisible( visible );
+  updatePreview();
+}
+
+void QgsGoochMaterialWidget::updatePreview()
+{
+  if ( mPreviewWidget->isHidden() )
+    return;
+  const std::unique_ptr<QgsAbstractMaterialSettings> newSettings( settings() );
+  mPreviewWidget->updatePreview( newSettings.get() );
 }

--- a/src/app/3d/qgsgoochmaterialwidget.cpp
+++ b/src/app/3d/qgsgoochmaterialwidget.cpp
@@ -18,13 +18,18 @@
 #include "qgis.h"
 #include "qgsgoochmaterialsettings.h"
 
+#include <QString>
+
 #include "moc_qgsgoochmaterialwidget.cpp"
+
+using namespace Qt::StringLiterals;
 
 QgsGoochMaterialWidget::QgsGoochMaterialWidget( QWidget *parent )
   : QgsMaterialSettingsWidget( parent )
 {
   setupUi( this );
   mPreviewWidget->hide();
+  mPreviewWidget->setMaterialType( u"gooch"_s );
 
   QgsGoochMaterialSettings defaultMaterial;
   setSettings( &defaultMaterial, nullptr );

--- a/src/app/3d/qgsgoochmaterialwidget.h
+++ b/src/app/3d/qgsgoochmaterialwidget.h
@@ -33,7 +33,7 @@ class QgsGoochMaterialWidget : public QgsMaterialSettingsWidget, private Ui::Goo
     static QgsMaterialSettingsWidget *create();
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
     void setTechnique( Qgis::MaterialRenderingTechnique technique ) final;
-    QgsAbstractMaterialSettings *settings() final;
+    std::unique_ptr< QgsAbstractMaterialSettings > settings() final;
 
   public slots:
     void setPreviewVisible( bool visible ) final;

--- a/src/app/3d/qgsgoochmaterialwidget.h
+++ b/src/app/3d/qgsgoochmaterialwidget.h
@@ -31,9 +31,15 @@ class QgsGoochMaterialWidget : public QgsMaterialSettingsWidget, private Ui::Goo
     explicit QgsGoochMaterialWidget( QWidget *parent = nullptr );
 
     static QgsMaterialSettingsWidget *create();
-    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) override;
-    void setTechnique( Qgis::MaterialRenderingTechnique technique ) override;
-    QgsAbstractMaterialSettings *settings() override;
+    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
+    void setTechnique( Qgis::MaterialRenderingTechnique technique ) final;
+    QgsAbstractMaterialSettings *settings() final;
+
+  public slots:
+    void setPreviewVisible( bool visible ) final;
+
+  private slots:
+    void updatePreview();
 };
 
 #endif // QGSGOOCHMATERIALWIDGET_H

--- a/src/app/3d/qgsmaterialpreviewwidget.cpp
+++ b/src/app/3d/qgsmaterialpreviewwidget.cpp
@@ -86,7 +86,11 @@ void QgsMaterialPreviewWidget::updatePreview( const QgsAbstractMaterialSettings 
   }
   else
   {
-    handler->updatePreviewScene( mPreviewScene, mLastPreviewSettings.get(), context );
+    if ( !handler->updatePreviewScene( mPreviewScene, mLastPreviewSettings.get(), context ) )
+    {
+      delete mPreviewScene;
+      mPreviewScene = handler->createPreviewScene( mLastPreviewSettings.get(), mPreviewSceneType, context, mView, mSceneRoot );
+    }
   }
 }
 

--- a/src/app/3d/qgsmaterialpreviewwidget.cpp
+++ b/src/app/3d/qgsmaterialpreviewwidget.cpp
@@ -23,6 +23,8 @@
 #include <Qt3DExtras/Qt3DWindow>
 #include <Qt3DRender/QCamera>
 
+#include "moc_qgsmaterialpreviewwidget.cpp"
+
 QgsMaterialPreviewWidget::QgsMaterialPreviewWidget( QWidget *parent )
   : QWidget( parent )
 {

--- a/src/app/3d/qgsmaterialpreviewwidget.cpp
+++ b/src/app/3d/qgsmaterialpreviewwidget.cpp
@@ -27,7 +27,7 @@ QgsMaterialPreviewWidget::QgsMaterialPreviewWidget( QWidget *parent )
   : QWidget( parent )
 {
   mView = new Qt3DExtras::Qt3DWindow();
-  mView->defaultFrameGraph()->setClearColor( QColor( 40, 40, 40 ) );
+  mView->defaultFrameGraph()->setClearColor( palette().color( QPalette::ColorGroup::Active, QPalette::ColorRole::Window ) );
 
   QWidget *container = QWidget::createWindowContainer( mView, this );
   container->setMinimumSize( 200, 200 );

--- a/src/app/3d/qgsmaterialpreviewwidget.cpp
+++ b/src/app/3d/qgsmaterialpreviewwidget.cpp
@@ -1,0 +1,68 @@
+/***************************************************************************
+  qgsmaterialpreviewwidget.cpp
+  --------------------------------------
+  Date                 : March 2026
+  Copyright            : (C) 2026 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaterialpreviewwidget.h"
+
+#include "qgs3d.h"
+#include "qgsmaterial3dhandler.h"
+
+#include <QVBoxLayout>
+#include <Qt3DExtras/QForwardRenderer>
+#include <Qt3DExtras/Qt3DWindow>
+#include <Qt3DRender/QCamera>
+
+QgsMaterialPreviewWidget::QgsMaterialPreviewWidget( QWidget *parent )
+  : QWidget( parent )
+{
+  mView = new Qt3DExtras::Qt3DWindow();
+  mView->defaultFrameGraph()->setClearColor( QColor( 40, 40, 40 ) );
+
+  QWidget *container = QWidget::createWindowContainer( mView, this );
+  container->setMinimumSize( 200, 200 );
+  container->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
+
+  auto *layout = new QVBoxLayout();
+  layout->setContentsMargins( 0, 0, 0, 0 );
+  layout->addWidget( container );
+  setLayout( layout );
+
+  mSceneRoot = new Qt3DCore::QEntity;
+  setupCamera( mView->camera() );
+  mView->setRootEntity( mSceneRoot );
+}
+
+void QgsMaterialPreviewWidget::setupCamera( Qt3DRender::QCamera *camera )
+{
+  camera->lens()->setPerspectiveProjection( 45.0f, 1.0f, 0.1f, 100.0f );
+  camera->setPosition( { 0, 0, 4 } );
+  camera->setViewCenter( { 0, 0, 0 } );
+}
+
+void QgsMaterialPreviewWidget::updatePreview( const QgsAbstractMaterialSettings *settings )
+{
+  const QgsAbstractMaterial3DHandler *handler = Qgs3D::handlerForMaterialSettings( settings );
+  if ( !handler )
+    return;
+
+  QgsMaterialContext context;
+  if ( !mPreviewScene )
+  {
+    mPreviewScene = handler->createPreviewScene( settings, context, mView, mSceneRoot );
+  }
+  else
+  {
+    handler->updatePreviewScene( mPreviewScene, settings, context );
+  }
+}

--- a/src/app/3d/qgsmaterialpreviewwidget.cpp
+++ b/src/app/3d/qgsmaterialpreviewwidget.cpp
@@ -16,8 +16,13 @@
 #include "qgsmaterialpreviewwidget.h"
 
 #include "qgs3d.h"
-#include "qgsmaterial3dhandler.h"
+#include "qgsabstractmaterialsettings.h"
+#include "qgsapplication.h"
+#include "qgsmaterialregistry.h"
 
+#include <QActionGroup>
+#include <QMenu>
+#include <QMouseEvent>
 #include <QVBoxLayout>
 #include <Qt3DExtras/QForwardRenderer>
 #include <Qt3DExtras/Qt3DWindow>
@@ -30,6 +35,8 @@ QgsMaterialPreviewWidget::QgsMaterialPreviewWidget( QWidget *parent )
 {
   mView = new Qt3DExtras::Qt3DWindow();
   mView->defaultFrameGraph()->setClearColor( palette().color( QPalette::ColorGroup::Active, QPalette::ColorRole::Window ) );
+
+  mView->installEventFilter( this );
 
   QWidget *container = QWidget::createWindowContainer( mView, this );
   container->setMinimumSize( 200, 200 );
@@ -45,6 +52,18 @@ QgsMaterialPreviewWidget::QgsMaterialPreviewWidget( QWidget *parent )
   mView->setRootEntity( mSceneRoot );
 }
 
+void QgsMaterialPreviewWidget::setMaterialType( const QString &type )
+{
+  if ( const QgsMaterialSettingsMetadata *metadata = dynamic_cast< const QgsMaterialSettingsMetadata * >( QgsApplication::materialRegistry()->materialSettingsMetadata( type ) ) )
+  {
+    if ( const QgsAbstractMaterial3DHandler *handler = metadata->handler() )
+    {
+      mMeshTypes = handler->previewMeshTypes();
+      mPreviewSceneType = mMeshTypes.at( 0 ).type;
+    }
+  }
+}
+
 void QgsMaterialPreviewWidget::setupCamera( Qt3DRender::QCamera *camera )
 {
   camera->lens()->setPerspectiveProjection( 45.0f, 1.0f, 0.1f, 100.0f );
@@ -54,17 +73,53 @@ void QgsMaterialPreviewWidget::setupCamera( Qt3DRender::QCamera *camera )
 
 void QgsMaterialPreviewWidget::updatePreview( const QgsAbstractMaterialSettings *settings )
 {
-  const QgsAbstractMaterial3DHandler *handler = Qgs3D::handlerForMaterialSettings( settings );
+  mLastPreviewSettings.reset( settings->clone() );
+  const QgsAbstractMaterial3DHandler *handler = Qgs3D::handlerForMaterialSettings( mLastPreviewSettings.get() );
   if ( !handler )
     return;
 
   QgsMaterialContext context;
   if ( !mPreviewScene )
   {
-    mPreviewScene = handler->createPreviewScene( settings, context, mView, mSceneRoot );
+    delete mPreviewScene;
+    mPreviewScene = handler->createPreviewScene( mLastPreviewSettings.get(), mPreviewSceneType, context, mView, mSceneRoot );
   }
   else
   {
-    handler->updatePreviewScene( mPreviewScene, settings, context );
+    handler->updatePreviewScene( mPreviewScene, mLastPreviewSettings.get(), context );
   }
+}
+
+bool QgsMaterialPreviewWidget::eventFilter( QObject *watched, QEvent *event )
+{
+  if ( watched == mView && event->type() == QEvent::MouseButtonPress )
+  {
+    QMouseEvent *mouseEvent = static_cast<QMouseEvent *>( event );
+    if ( mouseEvent->button() == Qt::RightButton )
+    {
+      QMenu menu( this );
+      auto actionGroup = new QActionGroup( &menu );
+      actionGroup->setExclusive( true );
+      for ( const QgsAbstractMaterial3DHandler::PreviewMeshType &type : mMeshTypes )
+      {
+        QAction *action = new QAction( type.displayName, &menu );
+        action->setCheckable( true );
+        action->setChecked( type.type == mPreviewSceneType );
+        connect( action, &QAction::toggled, this, [this, type]( bool checked ) {
+          if ( checked )
+          {
+            mPreviewSceneType = type.type;
+            mPreviewScene->deleteLater();
+            mPreviewScene = nullptr;
+            updatePreview( mLastPreviewSettings.get() );
+          }
+        } );
+        menu.addAction( action );
+        actionGroup->addAction( action );
+      }
+      menu.exec( mouseEvent->globalPosition().toPoint() );
+      return true;
+    }
+  }
+  return QWidget::eventFilter( watched, event );
 }

--- a/src/app/3d/qgsmaterialpreviewwidget.h
+++ b/src/app/3d/qgsmaterialpreviewwidget.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+  qgsmaterialpreviewwidget.h
+  --------------------------------------
+  Date                 : March 2026
+  Copyright            : (C) 2026 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMATERIALPREVIEWWIDGET_H
+#define QGSMATERIALPREVIEWWIDGET_H
+
+#include <QWidget>
+
+class QgsAbstractMaterial3DHandler;
+class QgsAbstractMaterialSettings;
+
+namespace Qt3DRender
+{
+  class QCamera;
+}
+
+namespace Qt3DExtras
+{
+  class Qt3DWindow;
+}
+
+namespace Qt3DCore
+{
+  class QEntity;
+}
+
+//! Widget for previewing 3D materials
+class QgsMaterialPreviewWidget : public QWidget
+{
+    Q_OBJECT
+  public:
+    explicit QgsMaterialPreviewWidget( QWidget *parent = nullptr );
+
+    void updatePreview( const QgsAbstractMaterialSettings *settings );
+
+  private:
+    void setupCamera( Qt3DRender::QCamera *camera );
+
+    Qt3DExtras::Qt3DWindow *mView = nullptr;
+    Qt3DCore::QEntity *mSceneRoot = nullptr;
+    Qt3DCore::QEntity *mPreviewScene = nullptr;
+};
+#endif // QGSMATERIALPREVIEWWIDGET_H

--- a/src/app/3d/qgsmaterialpreviewwidget.h
+++ b/src/app/3d/qgsmaterialpreviewwidget.h
@@ -16,6 +16,8 @@
 #ifndef QGSMATERIALPREVIEWWIDGET_H
 #define QGSMATERIALPREVIEWWIDGET_H
 
+#include "qgsmaterial3dhandler.h"
+
 #include <QWidget>
 
 class QgsAbstractMaterial3DHandler;
@@ -43,13 +45,22 @@ class QgsMaterialPreviewWidget : public QWidget
   public:
     explicit QgsMaterialPreviewWidget( QWidget *parent = nullptr );
 
+    void setMaterialType( const QString &type );
+
     void updatePreview( const QgsAbstractMaterialSettings *settings );
+
+  protected:
+    bool eventFilter( QObject *watched, QEvent *event ) override;
 
   private:
     void setupCamera( Qt3DRender::QCamera *camera );
 
     Qt3DExtras::Qt3DWindow *mView = nullptr;
     Qt3DCore::QEntity *mSceneRoot = nullptr;
+    QString mPreviewSceneType;
     Qt3DCore::QEntity *mPreviewScene = nullptr;
+
+    QList< QgsAbstractMaterial3DHandler::PreviewMeshType > mMeshTypes;
+    std::unique_ptr< QgsAbstractMaterialSettings > mLastPreviewSettings;
 };
 #endif // QGSMATERIALPREVIEWWIDGET_H

--- a/src/app/3d/qgsmetalroughmaterialwidget.cpp
+++ b/src/app/3d/qgsmetalroughmaterialwidget.cpp
@@ -24,6 +24,7 @@ QgsMetalRoughMaterialWidget::QgsMetalRoughMaterialWidget( QWidget *parent, bool 
   : QgsMaterialSettingsWidget( parent )
 {
   setupUi( this );
+  mPreviewWidget->hide();
 
   QgsMetalRoughMaterialSettings defaultMaterial;
   setSettings( &defaultMaterial, nullptr );
@@ -41,6 +42,8 @@ QgsMetalRoughMaterialWidget::QgsMetalRoughMaterialWidget( QWidget *parent, bool 
     updateWidgetState();
     emit changed();
   } );
+
+  connect( this, &QgsMetalRoughMaterialWidget::changed, this, &QgsMetalRoughMaterialWidget::updatePreview );
 }
 
 QgsMaterialSettingsWidget *QgsMetalRoughMaterialWidget::create()
@@ -63,6 +66,7 @@ void QgsMetalRoughMaterialWidget::setSettings( const QgsAbstractMaterialSettings
   mPropertyCollection = settings->dataDefinedProperties();
 
   updateWidgetState();
+  updatePreview();
 }
 
 QgsAbstractMaterialSettings *QgsMetalRoughMaterialWidget::settings()
@@ -75,5 +79,19 @@ QgsAbstractMaterialSettings *QgsMetalRoughMaterialWidget::settings()
   return m.release();
 }
 
+void QgsMetalRoughMaterialWidget::setPreviewVisible( bool visible )
+{
+  mPreviewWidget->setVisible( visible );
+  updatePreview();
+}
+
 void QgsMetalRoughMaterialWidget::updateWidgetState()
 {}
+
+void QgsMetalRoughMaterialWidget::updatePreview()
+{
+  if ( mPreviewWidget->isHidden() )
+    return;
+  const std::unique_ptr<QgsAbstractMaterialSettings> newSettings( settings() );
+  mPreviewWidget->updatePreview( newSettings.get() );
+}

--- a/src/app/3d/qgsmetalroughmaterialwidget.cpp
+++ b/src/app/3d/qgsmetalroughmaterialwidget.cpp
@@ -16,6 +16,7 @@
 #include "qgsmetalroughmaterialwidget.h"
 
 #include "qgis.h"
+#include "qgsdoublespinbox.h"
 #include "qgsmetalroughmaterialsettings.h"
 
 #include <QString>

--- a/src/app/3d/qgsmetalroughmaterialwidget.cpp
+++ b/src/app/3d/qgsmetalroughmaterialwidget.cpp
@@ -18,13 +18,18 @@
 #include "qgis.h"
 #include "qgsmetalroughmaterialsettings.h"
 
+#include <QString>
+
 #include "moc_qgsmetalroughmaterialwidget.cpp"
+
+using namespace Qt::StringLiterals;
 
 QgsMetalRoughMaterialWidget::QgsMetalRoughMaterialWidget( QWidget *parent, bool )
   : QgsMaterialSettingsWidget( parent )
 {
   setupUi( this );
   mPreviewWidget->hide();
+  mPreviewWidget->setMaterialType( u"metalrough"_s );
 
   QgsMetalRoughMaterialSettings defaultMaterial;
   setSettings( &defaultMaterial, nullptr );

--- a/src/app/3d/qgsmetalroughmaterialwidget.cpp
+++ b/src/app/3d/qgsmetalroughmaterialwidget.cpp
@@ -75,14 +75,14 @@ void QgsMetalRoughMaterialWidget::setSettings( const QgsAbstractMaterialSettings
   updatePreview();
 }
 
-QgsAbstractMaterialSettings *QgsMetalRoughMaterialWidget::settings()
+std::unique_ptr<QgsAbstractMaterialSettings> QgsMetalRoughMaterialWidget::settings()
 {
   auto m = std::make_unique<QgsMetalRoughMaterialSettings>();
   m->setBaseColor( mButtonBaseColor->color() );
   m->setMetalness( mMetalnessWidget->value() );
   m->setRoughness( mRoughnessWidget->value() );
   m->setDataDefinedProperties( mPropertyCollection );
-  return m.release();
+  return m;
 }
 
 void QgsMetalRoughMaterialWidget::setPreviewVisible( bool visible )

--- a/src/app/3d/qgsmetalroughmaterialwidget.h
+++ b/src/app/3d/qgsmetalroughmaterialwidget.h
@@ -35,7 +35,7 @@ class QgsMetalRoughMaterialWidget : public QgsMaterialSettingsWidget, private Ui
 
     void setTechnique( Qgis::MaterialRenderingTechnique technique ) final;
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
-    QgsAbstractMaterialSettings *settings() final;
+    std::unique_ptr< QgsAbstractMaterialSettings > settings() final;
   public slots:
     void setPreviewVisible( bool visible ) final;
   private slots:

--- a/src/app/3d/qgsmetalroughmaterialwidget.h
+++ b/src/app/3d/qgsmetalroughmaterialwidget.h
@@ -35,9 +35,9 @@ class QgsMetalRoughMaterialWidget : public QgsMaterialSettingsWidget, private Ui
 
     void setTechnique( Qgis::MaterialRenderingTechnique technique ) final;
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
-    QgsAbstractMaterialSettings *settings() override;
+    QgsAbstractMaterialSettings *settings() final;
   public slots:
-    void setPreviewVisible( bool visible ) override;
+    void setPreviewVisible( bool visible ) final;
   private slots:
 
     void updateWidgetState();

--- a/src/app/3d/qgsmetalroughmaterialwidget.h
+++ b/src/app/3d/qgsmetalroughmaterialwidget.h
@@ -36,10 +36,12 @@ class QgsMetalRoughMaterialWidget : public QgsMaterialSettingsWidget, private Ui
     void setTechnique( Qgis::MaterialRenderingTechnique technique ) final;
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
     QgsAbstractMaterialSettings *settings() override;
-
+  public slots:
+    void setPreviewVisible( bool visible ) override;
   private slots:
 
     void updateWidgetState();
+    void updatePreview();
 };
 
 #endif // QGSMETALROUGHMATERIALWIDGET_H

--- a/src/app/3d/qgsnullmaterialwidget.cpp
+++ b/src/app/3d/qgsnullmaterialwidget.cpp
@@ -38,3 +38,6 @@ QgsAbstractMaterialSettings *QgsNullMaterialWidget::settings()
 {
   return new QgsNullMaterialSettings();
 }
+
+void QgsNullMaterialWidget::setPreviewVisible( bool )
+{}

--- a/src/app/3d/qgsnullmaterialwidget.cpp
+++ b/src/app/3d/qgsnullmaterialwidget.cpp
@@ -34,9 +34,9 @@ QgsMaterialSettingsWidget *QgsNullMaterialWidget::create()
 void QgsNullMaterialWidget::setSettings( const QgsAbstractMaterialSettings *, QgsVectorLayer * )
 {}
 
-QgsAbstractMaterialSettings *QgsNullMaterialWidget::settings()
+std::unique_ptr<QgsAbstractMaterialSettings> QgsNullMaterialWidget::settings()
 {
-  return new QgsNullMaterialSettings();
+  return std::make_unique< QgsNullMaterialSettings >();
 }
 
 void QgsNullMaterialWidget::setPreviewVisible( bool )

--- a/src/app/3d/qgsnullmaterialwidget.h
+++ b/src/app/3d/qgsnullmaterialwidget.h
@@ -33,6 +33,8 @@ class QgsNullMaterialWidget : public QgsMaterialSettingsWidget, private Ui::Null
     static QgsMaterialSettingsWidget *create();
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) override;
     QgsAbstractMaterialSettings *settings() override;
+  public slots:
+    void setPreviewVisible( bool visible ) override;
 };
 
 #endif // QGSNULLMATERIALWIDGET_H

--- a/src/app/3d/qgsnullmaterialwidget.h
+++ b/src/app/3d/qgsnullmaterialwidget.h
@@ -31,10 +31,10 @@ class QgsNullMaterialWidget : public QgsMaterialSettingsWidget, private Ui::Null
     explicit QgsNullMaterialWidget( QWidget *parent = nullptr );
 
     static QgsMaterialSettingsWidget *create();
-    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) override;
-    QgsAbstractMaterialSettings *settings() override;
+    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
+    std::unique_ptr< QgsAbstractMaterialSettings > settings() final;
   public slots:
-    void setPreviewVisible( bool visible ) override;
+    void setPreviewVisible( bool visible ) final;
 };
 
 #endif // QGSNULLMATERIALWIDGET_H

--- a/src/app/3d/qgsphongmaterialwidget.cpp
+++ b/src/app/3d/qgsphongmaterialwidget.cpp
@@ -145,7 +145,7 @@ void QgsPhongMaterialWidget::setSettings( const QgsAbstractMaterialSettings *set
   updatePreview();
 }
 
-QgsAbstractMaterialSettings *QgsPhongMaterialWidget::settings()
+std::unique_ptr<QgsAbstractMaterialSettings> QgsPhongMaterialWidget::settings()
 {
   auto m = std::make_unique<QgsPhongMaterialSettings>();
   m->setDiffuse( btnDiffuse->color() );
@@ -165,7 +165,7 @@ QgsAbstractMaterialSettings *QgsPhongMaterialWidget::settings()
   mPropertyCollection.setProperty( QgsAbstractMaterialSettings::Property::Specular, mSpecularDataDefinedButton->toProperty() );
   m->setDataDefinedProperties( mPropertyCollection );
 
-  return m.release();
+  return m;
 }
 
 void QgsPhongMaterialWidget::setHasOpacity( const bool opacity )

--- a/src/app/3d/qgsphongmaterialwidget.cpp
+++ b/src/app/3d/qgsphongmaterialwidget.cpp
@@ -18,7 +18,11 @@
 #include "qgis.h"
 #include "qgsphongmaterialsettings.h"
 
+#include <QString>
+
 #include "moc_qgsphongmaterialwidget.cpp"
+
+using namespace Qt::StringLiterals;
 
 QgsPhongMaterialWidget::QgsPhongMaterialWidget( QWidget *parent, bool hasOpacity )
   : QgsMaterialSettingsWidget( parent )
@@ -26,6 +30,8 @@ QgsPhongMaterialWidget::QgsPhongMaterialWidget( QWidget *parent, bool hasOpacity
 {
   setupUi( this );
   mPreviewWidget->hide();
+  mPreviewWidget->setMaterialType( u"phong"_s );
+
   mOpacityWidget->setVisible( mHasOpacity );
   mLblOpacity->setVisible( mHasOpacity );
   spinShininess->setClearValue( 0, tr( "None" ) );

--- a/src/app/3d/qgsphongmaterialwidget.cpp
+++ b/src/app/3d/qgsphongmaterialwidget.cpp
@@ -25,6 +25,7 @@ QgsPhongMaterialWidget::QgsPhongMaterialWidget( QWidget *parent, bool hasOpacity
   , mHasOpacity( hasOpacity )
 {
   setupUi( this );
+  mPreviewWidget->hide();
   mOpacityWidget->setVisible( mHasOpacity );
   mLblOpacity->setVisible( mHasOpacity );
   spinShininess->setClearValue( 0, tr( "None" ) );
@@ -55,6 +56,8 @@ QgsPhongMaterialWidget::QgsPhongMaterialWidget( QWidget *parent, bool hasOpacity
   {
     connect( mOpacityWidget, &QgsOpacityWidget::opacityChanged, this, &QgsPhongMaterialWidget::changed );
   }
+
+  connect( this, &QgsPhongMaterialWidget::changed, this, &QgsPhongMaterialWidget::updatePreview );
 }
 
 QgsMaterialSettingsWidget *QgsPhongMaterialWidget::create()
@@ -133,6 +136,7 @@ void QgsPhongMaterialWidget::setSettings( const QgsAbstractMaterialSettings *set
   mSpecularDataDefinedButton->init( static_cast<int>( QgsAbstractMaterialSettings::Property::Specular ), mPropertyCollection, settings->propertyDefinitions(), layer, true );
 
   updateWidgetState();
+  updatePreview();
 }
 
 QgsAbstractMaterialSettings *QgsPhongMaterialWidget::settings()
@@ -178,6 +182,12 @@ void QgsPhongMaterialWidget::setHasOpacity( const bool opacity )
   }
 }
 
+void QgsPhongMaterialWidget::setPreviewVisible( bool visible )
+{
+  mPreviewWidget->setVisible( visible );
+  updatePreview();
+}
+
 void QgsPhongMaterialWidget::updateWidgetState()
 {
   if ( spinShininess->value() > 0 )
@@ -190,4 +200,12 @@ void QgsPhongMaterialWidget::updateWidgetState()
     btnSpecular->setEnabled( false );
     btnSpecular->setToolTip( tr( "Specular color is disabled because material has no shininess" ) );
   }
+}
+
+void QgsPhongMaterialWidget::updatePreview()
+{
+  if ( mPreviewWidget->isHidden() )
+    return;
+  const std::unique_ptr<QgsAbstractMaterialSettings> newSettings( settings() );
+  mPreviewWidget->updatePreview( newSettings.get() );
 }

--- a/src/app/3d/qgsphongmaterialwidget.h
+++ b/src/app/3d/qgsphongmaterialwidget.h
@@ -36,14 +36,17 @@ class QgsPhongMaterialWidget : public QgsMaterialSettingsWidget, private Ui::Pho
 
     void setTechnique( Qgis::MaterialRenderingTechnique technique ) final;
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
-    QgsAbstractMaterialSettings *settings() override;
+    QgsAbstractMaterialSettings *settings() final;
 
     bool hasOpacity() const { return mHasOpacity; }
     void setHasOpacity( const bool opacity );
-
+  public slots:
+    void setPreviewVisible( bool visible ) final;
   private slots:
 
     void updateWidgetState();
+
+    void updatePreview();
 
   private:
     bool mHasOpacity; //! whether to display the opacity slider

--- a/src/app/3d/qgsphongmaterialwidget.h
+++ b/src/app/3d/qgsphongmaterialwidget.h
@@ -36,7 +36,7 @@ class QgsPhongMaterialWidget : public QgsMaterialSettingsWidget, private Ui::Pho
 
     void setTechnique( Qgis::MaterialRenderingTechnique technique ) final;
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
-    QgsAbstractMaterialSettings *settings() final;
+    std::unique_ptr< QgsAbstractMaterialSettings > settings() final;
 
     bool hasOpacity() const { return mHasOpacity; }
     void setHasOpacity( const bool opacity );

--- a/src/app/3d/qgsphongtexturedmaterialwidget.cpp
+++ b/src/app/3d/qgsphongtexturedmaterialwidget.cpp
@@ -76,7 +76,7 @@ void QgsPhongTexturedMaterialWidget::setSettings( const QgsAbstractMaterialSetti
   updatePreview();
 }
 
-QgsAbstractMaterialSettings *QgsPhongTexturedMaterialWidget::settings()
+std::unique_ptr<QgsAbstractMaterialSettings> QgsPhongTexturedMaterialWidget::settings()
 {
   auto m = std::make_unique<QgsPhongTexturedMaterialSettings>();
   m->setAmbient( btnAmbient->color() );
@@ -88,7 +88,7 @@ QgsAbstractMaterialSettings *QgsPhongTexturedMaterialWidget::settings()
   m->setTextureRotation( textureRotationSpinBox->value() );
   m->setDataDefinedProperties( mPropertyCollection );
 
-  return m.release();
+  return m;
 }
 
 void QgsPhongTexturedMaterialWidget::setPreviewVisible( bool visible )

--- a/src/app/3d/qgsphongtexturedmaterialwidget.cpp
+++ b/src/app/3d/qgsphongtexturedmaterialwidget.cpp
@@ -24,6 +24,7 @@ QgsPhongTexturedMaterialWidget::QgsPhongTexturedMaterialWidget( QWidget *parent 
   : QgsMaterialSettingsWidget( parent )
 {
   setupUi( this );
+  mPreviewWidget->hide();
 
   spinShininess->setClearValue( 0, tr( "None" ) );
 
@@ -42,6 +43,8 @@ QgsPhongTexturedMaterialWidget::QgsPhongTexturedMaterialWidget( QWidget *parent 
   connect( textureFile, &QgsImageSourceLineEdit::sourceChanged, this, &QgsPhongTexturedMaterialWidget::changed );
   connect( textureScaleSpinBox, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsPhongTexturedMaterialWidget::changed );
   connect( textureRotationSpinBox, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsPhongTexturedMaterialWidget::changed );
+
+  connect( this, &QgsPhongTexturedMaterialWidget::changed, this, &QgsPhongTexturedMaterialWidget::updatePreview );
 }
 
 QgsMaterialSettingsWidget *QgsPhongTexturedMaterialWidget::create()
@@ -65,6 +68,7 @@ void QgsPhongTexturedMaterialWidget::setSettings( const QgsAbstractMaterialSetti
   mPropertyCollection = settings->dataDefinedProperties();
 
   updateWidgetState();
+  updatePreview();
 }
 
 QgsAbstractMaterialSettings *QgsPhongTexturedMaterialWidget::settings()
@@ -82,6 +86,12 @@ QgsAbstractMaterialSettings *QgsPhongTexturedMaterialWidget::settings()
   return m.release();
 }
 
+void QgsPhongTexturedMaterialWidget::setPreviewVisible( bool visible )
+{
+  mPreviewWidget->setVisible( visible );
+  updatePreview();
+}
+
 void QgsPhongTexturedMaterialWidget::updateWidgetState()
 {
   if ( spinShininess->value() > 0 )
@@ -94,4 +104,12 @@ void QgsPhongTexturedMaterialWidget::updateWidgetState()
     btnSpecular->setEnabled( false );
     btnSpecular->setToolTip( tr( "Specular color is disabled because material has no shininess" ) );
   }
+}
+
+void QgsPhongTexturedMaterialWidget::updatePreview()
+{
+  if ( mPreviewWidget->isHidden() )
+    return;
+  const std::unique_ptr<QgsAbstractMaterialSettings> newSettings( settings() );
+  mPreviewWidget->updatePreview( newSettings.get() );
 }

--- a/src/app/3d/qgsphongtexturedmaterialwidget.cpp
+++ b/src/app/3d/qgsphongtexturedmaterialwidget.cpp
@@ -18,13 +18,18 @@
 #include "qgis.h"
 #include "qgsphongtexturedmaterialsettings.h"
 
+#include <QString>
+
 #include "moc_qgsphongtexturedmaterialwidget.cpp"
+
+using namespace Qt::StringLiterals;
 
 QgsPhongTexturedMaterialWidget::QgsPhongTexturedMaterialWidget( QWidget *parent )
   : QgsMaterialSettingsWidget( parent )
 {
   setupUi( this );
   mPreviewWidget->hide();
+  mPreviewWidget->setMaterialType( u"phongtextured"_s );
 
   spinShininess->setClearValue( 0, tr( "None" ) );
 

--- a/src/app/3d/qgsphongtexturedmaterialwidget.h
+++ b/src/app/3d/qgsphongtexturedmaterialwidget.h
@@ -34,10 +34,12 @@ class QgsPhongTexturedMaterialWidget : public QgsMaterialSettingsWidget, private
 
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
     QgsAbstractMaterialSettings *settings() final;
-
+  public slots:
+    void setPreviewVisible( bool visible ) override;
   private slots:
 
     void updateWidgetState();
+    void updatePreview();
 };
 
 #endif // QGSPHONGTEXTUREDMATERIALWIDGET_H

--- a/src/app/3d/qgsphongtexturedmaterialwidget.h
+++ b/src/app/3d/qgsphongtexturedmaterialwidget.h
@@ -33,9 +33,9 @@ class QgsPhongTexturedMaterialWidget : public QgsMaterialSettingsWidget, private
     static QgsMaterialSettingsWidget *create();
 
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
-    QgsAbstractMaterialSettings *settings() final;
+    std::unique_ptr< QgsAbstractMaterialSettings > settings() final;
   public slots:
-    void setPreviewVisible( bool visible ) override;
+    void setPreviewVisible( bool visible ) final;
   private slots:
 
     void updateWidgetState();

--- a/src/app/3d/qgssimplelinematerialwidget.cpp
+++ b/src/app/3d/qgssimplelinematerialwidget.cpp
@@ -18,13 +18,18 @@
 #include "qgis.h"
 #include "qgssimplelinematerialsettings.h"
 
+#include <QString>
+
 #include "moc_qgssimplelinematerialwidget.cpp"
+
+using namespace Qt::StringLiterals;
 
 QgsSimpleLineMaterialWidget::QgsSimpleLineMaterialWidget( QWidget *parent )
   : QgsMaterialSettingsWidget( parent )
 {
   setupUi( this );
   mPreviewWidget->hide();
+  mPreviewWidget->setMaterialType( u"simpleline"_s );
 
   QgsSimpleLineMaterialSettings defaultMaterial;
   setSettings( &defaultMaterial, nullptr );

--- a/src/app/3d/qgssimplelinematerialwidget.cpp
+++ b/src/app/3d/qgssimplelinematerialwidget.cpp
@@ -59,7 +59,7 @@ void QgsSimpleLineMaterialWidget::setSettings( const QgsAbstractMaterialSettings
   updatePreview();
 }
 
-QgsAbstractMaterialSettings *QgsSimpleLineMaterialWidget::settings()
+std::unique_ptr<QgsAbstractMaterialSettings> QgsSimpleLineMaterialWidget::settings()
 {
   auto m = std::make_unique<QgsSimpleLineMaterialSettings>();
   m->setAmbient( btnAmbient->color() );
@@ -67,7 +67,7 @@ QgsAbstractMaterialSettings *QgsSimpleLineMaterialWidget::settings()
   mPropertyCollection.setProperty( QgsAbstractMaterialSettings::Property::Ambient, mAmbientDataDefinedButton->toProperty() );
   m->setDataDefinedProperties( mPropertyCollection );
 
-  return m.release();
+  return m;
 }
 
 void QgsSimpleLineMaterialWidget::setPreviewVisible( bool visible )

--- a/src/app/3d/qgssimplelinematerialwidget.cpp
+++ b/src/app/3d/qgssimplelinematerialwidget.cpp
@@ -24,12 +24,15 @@ QgsSimpleLineMaterialWidget::QgsSimpleLineMaterialWidget( QWidget *parent )
   : QgsMaterialSettingsWidget( parent )
 {
   setupUi( this );
+  mPreviewWidget->hide();
 
   QgsSimpleLineMaterialSettings defaultMaterial;
   setSettings( &defaultMaterial, nullptr );
 
   connect( btnAmbient, &QgsColorButton::colorChanged, this, &QgsSimpleLineMaterialWidget::changed );
   connect( mAmbientDataDefinedButton, &QgsPropertyOverrideButton::changed, this, &QgsSimpleLineMaterialWidget::changed );
+
+  connect( this, &QgsSimpleLineMaterialWidget::changed, this, &QgsSimpleLineMaterialWidget::updatePreview );
 }
 
 QgsMaterialSettingsWidget *QgsSimpleLineMaterialWidget::create()
@@ -47,6 +50,8 @@ void QgsSimpleLineMaterialWidget::setSettings( const QgsAbstractMaterialSettings
 
   mPropertyCollection = settings->dataDefinedProperties();
   mAmbientDataDefinedButton->init( static_cast<int>( QgsAbstractMaterialSettings::Property::Ambient ), mPropertyCollection, settings->propertyDefinitions(), layer, true );
+
+  updatePreview();
 }
 
 QgsAbstractMaterialSettings *QgsSimpleLineMaterialWidget::settings()
@@ -58,4 +63,18 @@ QgsAbstractMaterialSettings *QgsSimpleLineMaterialWidget::settings()
   m->setDataDefinedProperties( mPropertyCollection );
 
   return m.release();
+}
+
+void QgsSimpleLineMaterialWidget::setPreviewVisible( bool visible )
+{
+  mPreviewWidget->setVisible( visible );
+  updatePreview();
+}
+
+void QgsSimpleLineMaterialWidget::updatePreview()
+{
+  if ( mPreviewWidget->isHidden() )
+    return;
+  const std::unique_ptr<QgsAbstractMaterialSettings> newSettings( settings() );
+  mPreviewWidget->updatePreview( newSettings.get() );
 }

--- a/src/app/3d/qgssimplelinematerialwidget.h
+++ b/src/app/3d/qgssimplelinematerialwidget.h
@@ -29,10 +29,10 @@ class QgsSimpleLineMaterialWidget : public QgsMaterialSettingsWidget, private Ui
 
     static QgsMaterialSettingsWidget *create();
 
-    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) override;
-    QgsAbstractMaterialSettings *settings() override;
+    void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) final;
+    std::unique_ptr< QgsAbstractMaterialSettings > settings() final;
   public slots:
-    void setPreviewVisible( bool visible ) override;
+    void setPreviewVisible( bool visible ) final;
 
   private slots:
     void updatePreview();

--- a/src/app/3d/qgssimplelinematerialwidget.h
+++ b/src/app/3d/qgssimplelinematerialwidget.h
@@ -31,6 +31,11 @@ class QgsSimpleLineMaterialWidget : public QgsMaterialSettingsWidget, private Ui
 
     void setSettings( const QgsAbstractMaterialSettings *settings, QgsVectorLayer *layer ) override;
     QgsAbstractMaterialSettings *settings() override;
+  public slots:
+    void setPreviewVisible( bool visible ) override;
+
+  private slots:
+    void updatePreview();
 };
 
 #endif // QGSSIMPLELINEMATERIALWIDGET_H

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -369,6 +369,7 @@ if (WITH_3D)
     3d/qgsgoochmaterialwidget.cpp
     3d/qgslightswidget.cpp
     3d/qgsline3dsymbolwidget.cpp
+    3d/qgsmaterialpreviewwidget.cpp
     3d/qgsmesh3dsymbolwidget.cpp
     3d/qgsmetalroughmaterialwidget.cpp
     3d/qgsnullmaterialwidget.cpp

--- a/src/gui/3d/qgsmaterialwidget.cpp
+++ b/src/gui/3d/qgsmaterialwidget.cpp
@@ -232,6 +232,8 @@ QgsMaterialWidgetDialog::QgsMaterialWidgetDialog( const QgsAbstractMaterialSetti
   vLayout->addWidget( mButtonBox );
   setLayout( vLayout );
   setWindowTitle( tr( "Material" ) );
+
+  connect( mWidget, &QgsPanelWidget::panelAccepted, this, &QDialog::reject );
 }
 
 std::unique_ptr<QgsAbstractMaterialSettings> QgsMaterialWidgetDialog::settings()

--- a/src/gui/3d/qgsmaterialwidget.cpp
+++ b/src/gui/3d/qgsmaterialwidget.cpp
@@ -172,7 +172,7 @@ void QgsMaterialWidget::materialWidgetChanged()
 {
   if ( QgsMaterialSettingsWidget *w = qobject_cast<QgsMaterialSettingsWidget *>( mStackedWidget->currentWidget() ) )
   {
-    mCurrentSettings.reset( w->settings() );
+    mCurrentSettings = w->settings();
   }
   emit changed();
 }

--- a/src/gui/3d/qgsmaterialwidget.cpp
+++ b/src/gui/3d/qgsmaterialwidget.cpp
@@ -129,6 +129,15 @@ void QgsMaterialWidget::setType( const QString &type )
   materialTypeChanged();
 }
 
+void QgsMaterialWidget::setPreviewVisible( bool visible )
+{
+  mPreviewVisible = visible;
+  if ( QgsMaterialSettingsWidget *w = qobject_cast<QgsMaterialSettingsWidget *>( mStackedWidget->currentWidget() ) )
+  {
+    w->setPreviewVisible( visible );
+  }
+}
+
 void QgsMaterialWidget::materialTypeChanged()
 {
   std::unique_ptr<QgsAbstractMaterialSettings> currentSettings( settings() );
@@ -185,6 +194,7 @@ void QgsMaterialWidget::updateMaterialWidget()
     {
       w->setSettings( mCurrentSettings.get(), mLayer );
       w->setTechnique( mTechnique );
+      w->setPreviewVisible( mPreviewVisible );
       mStackedWidget->addWidget( w );
       mStackedWidget->setCurrentWidget( w );
       // start receiving updates from widget
@@ -208,6 +218,7 @@ QgsMaterialWidgetDialog::QgsMaterialWidgetDialog( const QgsAbstractMaterialSetti
 
   QVBoxLayout *vLayout = new QVBoxLayout();
   mWidget = new QgsMaterialWidget();
+  mWidget->setPreviewVisible( true );
   vLayout->addWidget( mWidget, 1 );
 
   if ( settings )

--- a/src/gui/3d/qgsmaterialwidget.h
+++ b/src/gui/3d/qgsmaterialwidget.h
@@ -107,6 +107,13 @@ class GUI_EXPORT QgsMaterialWidget : public QgsPanelWidget, private Ui::Material
      */
     void setType( const QString &type );
 
+  public slots:
+
+    /**
+     * Sets whether the material preview widget should be visible.
+     */
+    void setPreviewVisible( bool visible );
+
   signals:
 
     /**
@@ -121,6 +128,7 @@ class GUI_EXPORT QgsMaterialWidget : public QgsPanelWidget, private Ui::Material
   private:
     void updateMaterialWidget();
     void rebuildAvailableTypes();
+    bool mPreviewVisible = false;
     QPointer< QgsVectorLayer > mLayer;
 
     std::unique_ptr<QgsAbstractMaterialSettings> mCurrentSettings;

--- a/src/gui/qgsmaterialsettingswidget.h
+++ b/src/gui/qgsmaterialsettingswidget.h
@@ -63,6 +63,13 @@ class GUI_EXPORT QgsMaterialSettingsWidget : public QWidget
      */
     virtual QgsAbstractMaterialSettings *settings() = 0 SIP_FACTORY;
 
+  public slots:
+
+    /**
+     * Sets whether the material preview widget should be visible.
+     */
+    virtual void setPreviewVisible( bool visible ) = 0;
+
   signals:
 
     /**

--- a/src/gui/qgsmaterialsettingswidget.h
+++ b/src/gui/qgsmaterialsettingswidget.h
@@ -61,7 +61,7 @@ class GUI_EXPORT QgsMaterialSettingsWidget : public QWidget
      *
      * Caller takes ownership of the returned settings.
      */
-    virtual QgsAbstractMaterialSettings *settings() = 0 SIP_FACTORY;
+    virtual std::unique_ptr< QgsAbstractMaterialSettings > settings() = 0 SIP_FACTORY;
 
   public slots:
 

--- a/src/ui/3d/goochmaterialwidget.ui
+++ b/src/ui/3d/goochmaterialwidget.ui
@@ -6,62 +6,29 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>394</width>
-    <height>326</height>
+    <width>646</width>
+    <height>349</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
-    <widget class="QLabel" name="lblShininess">
-     <property name="toolTip">
-      <string>How shiny smooth surfaces are.</string>
-     </property>
-     <property name="text">
-      <string>Shininess</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
+   <item row="2" column="1">
     <widget class="QLabel" name="lblAmbient_2">
      <property name="text">
       <string>Cool</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lblDiffuse">
-     <property name="toolTip">
-      <string>Color of light reflected from rough surfaces.</string>
-     </property>
+   <item row="1" column="1">
+    <widget class="QLabel" name="lblAmbient">
      <property name="text">
-      <string>Diffuse</string>
+      <string>Warm</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinAlpha">
-     <property name="maximum">
-      <double>1000.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="lblSpecular">
-     <property name="toolTip">
-      <string>Color of light reflecting from smooth surfaces.</string>
-     </property>
-     <property name="text">
-      <string>Specular</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
+   <item row="0" column="2">
     <widget class="QgsColorButton" name="btnDiffuse">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -77,43 +44,58 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinShininess">
-     <property name="minimum">
-      <double>1.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>1000.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>100.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="lblShininess_2">
-     <property name="text">
-      <string>Alpha</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QgsColorButton" name="btnCool">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
-   </item>
    <item row="6" column="1">
+    <widget class="QLabel" name="lblShininess_3">
+     <property name="text">
+      <string>Beta</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QgsPropertyOverrideButton" name="mSpecularDataDefinedButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="lblShininess">
+     <property name="toolTip">
+      <string>How shiny smooth surfaces are.</string>
+     </property>
+     <property name="text">
+      <string>Shininess</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QgsPropertyOverrideButton" name="mWarmDataDefinedButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="lblDiffuse">
+     <property name="toolTip">
+      <string>Color of light reflected from rough surfaces.</string>
+     </property>
+     <property name="text">
+      <string>Diffuse</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="lblSpecular">
+     <property name="toolTip">
+      <string>Color of light reflecting from smooth surfaces.</string>
+     </property>
+     <property name="text">
+      <string>Specular</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2">
     <widget class="QgsDoubleSpinBox" name="spinBeta">
      <property name="maximum">
       <double>1000.000000000000000</double>
@@ -123,14 +105,14 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="lblShininess_3">
+   <item row="0" column="3">
+    <widget class="QgsPropertyOverrideButton" name="mDiffuseDataDefinedButton">
      <property name="text">
-      <string>Beta</string>
+      <string>...</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="3" column="2">
     <widget class="QgsColorButton" name="btnSpecular">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -146,7 +128,14 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="3">
+    <widget class="QgsPropertyOverrideButton" name="mCoolDataDefinedButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
     <widget class="QgsColorButton" name="btnWarm">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -162,38 +151,72 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lblAmbient">
-     <property name="text">
-      <string>Warm</string>
+   <item row="5" column="2">
+    <widget class="QgsDoubleSpinBox" name="spinAlpha">
+     <property name="maximum">
+      <double>1000.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mDiffuseDataDefinedButton">
-     <property name="text">
-      <string>...</string>
+   <item row="4" column="2">
+    <widget class="QgsDoubleSpinBox" name="spinShininess">
+     <property name="minimum">
+      <double>1.000000000000000</double>
      </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mWarmDataDefinedButton">
-     <property name="text">
-      <string>...</string>
+     <property name="maximum">
+      <double>1000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>100.000000000000000</double>
      </property>
     </widget>
    </item>
    <item row="2" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mCoolDataDefinedButton">
-     <property name="text">
-      <string>...</string>
+    <widget class="QgsColorButton" name="btnCool">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mSpecularDataDefinedButton">
+   <item row="5" column="1">
+    <widget class="QLabel" name="lblShininess_2">
      <property name="text">
-      <string>...</string>
+      <string>Alpha</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" rowspan="8">
+    <widget class="QgsMaterialPreviewWidget" name="mPreviewWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>200</height>
+      </size>
      </property>
     </widget>
    </item>
@@ -214,6 +237,12 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMaterialPreviewWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsmaterialpreviewwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/3d/metalroughmaterialwidget.ui
+++ b/src/ui/3d/metalroughmaterialwidget.ui
@@ -6,22 +6,43 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>378</width>
-    <height>107</height>
+    <width>739</width>
+    <height>409</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="1,2">
-   <item row="0" column="0">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="2,1,2">
+   <item row="2" column="1">
+    <widget class="QLabel" name="lblRoughness">
+     <property name="text">
+      <string>Roughness</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
     <widget class="QLabel" name="lblSpecular">
      <property name="text">
       <string>Base color</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="1" column="1">
+    <widget class="QLabel" name="lblMetalness">
+     <property name="text">
+      <string>Metalness</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QgsPercentageWidget" name="mMetalnessWidget" native="true">
+     <property name="focusPolicy">
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
     <widget class="QgsColorButton" name="mButtonBaseColor">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -37,31 +58,33 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lblShininess">
-     <property name="text">
-      <string>Metalness</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QgsPercentageWidget" name="mMetalnessWidget" native="true">
-     <property name="focusPolicy">
-      <enum>Qt::FocusPolicy::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="lblShininess_2">
-     <property name="text">
-      <string>Roughness</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
+   <item row="2" column="2">
     <widget class="QgsPercentageWidget" name="mRoughnessWidget" native="true">
      <property name="focusPolicy">
       <enum>Qt::FocusPolicy::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" rowspan="4">
+    <widget class="QgsMaterialPreviewWidget" name="mPreviewWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>200</height>
+      </size>
      </property>
     </widget>
    </item>
@@ -75,9 +98,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <class>QgsMaterialPreviewWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsmaterialpreviewwidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsPercentageWidget</class>

--- a/src/ui/3d/phongmaterialwidget.ui
+++ b/src/ui/3d/phongmaterialwidget.ui
@@ -6,129 +6,22 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>394</width>
-    <height>210</height>
+    <width>472</width>
+    <height>250</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
-    <widget class="QLabel" name="lblSpecular">
-     <property name="toolTip">
-      <string>Color of light reflecting from smooth surfaces.</string>
-     </property>
-     <property name="text">
-      <string>Specular</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="lblAmbient">
-     <property name="toolTip">
-      <string>Color of light that is scattered around the entire scene.</string>
-     </property>
-     <property name="text">
-      <string>Ambient</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="lblShininess">
-     <property name="toolTip">
-      <string>How shiny smooth surfaces are.</string>
-     </property>
-     <property name="text">
-      <string>Shininess</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QgsColorButton" name="btnAmbient">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QgsPercentageWidget" name="mDiffuseCoefficientWidget" native="true">
+   <item row="5" column="2">
+    <widget class="QgsPercentageWidget" name="mSpecularCoefficientWidget" native="true">
      <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QgsPercentageWidget" name="mAmbientCoefficientWidget" native="true">
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mDiffuseDataDefinedButton">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lblDiffuse">
-     <property name="toolTip">
-      <string>Color of light reflected from rough surfaces.</string>
-     </property>
-     <property name="text">
-      <string>Diffuse</string>
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
      </property>
     </widget>
    </item>
    <item row="4" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mSpecularDataDefinedButton">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="mLblOpacity">
-     <property name="text">
-      <string>Opacity</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QgsColorButton" name="btnDiffuse">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QgsPropertyOverrideButton" name="mAmbientDataDefinedButton">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
     <widget class="QgsColorButton" name="btnSpecular">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -144,24 +37,154 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1" colspan="2">
-    <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
+   <item row="0" column="1">
+    <widget class="QLabel" name="lblDiffuse">
+     <property name="toolTip">
+      <string>Color of light reflected from rough surfaces.</string>
+     </property>
+     <property name="text">
+      <string>Diffuse</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1" colspan="2">
+   <item row="6" column="1">
+    <widget class="QLabel" name="lblShininess">
+     <property name="toolTip">
+      <string>How shiny smooth surfaces are.</string>
+     </property>
+     <property name="text">
+      <string>Shininess</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QgsPropertyOverrideButton" name="mDiffuseDataDefinedButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QgsPropertyOverrideButton" name="mAmbientDataDefinedButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="lblSpecular">
+     <property name="toolTip">
+      <string>Color of light reflecting from smooth surfaces.</string>
+     </property>
+     <property name="text">
+      <string>Specular</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2" colspan="2">
     <widget class="QgsDoubleSpinBox" name="spinShininess">
      <property name="maximum">
       <double>1000.000000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QgsPercentageWidget" name="mSpecularCoefficientWidget" native="true">
+   <item row="2" column="2">
+    <widget class="QgsColorButton" name="btnAmbient">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLabel" name="mLblOpacity">
+     <property name="text">
+      <string>Opacity</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QgsPercentageWidget" name="mDiffuseCoefficientWidget" native="true">
      <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2" colspan="2">
+    <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+     <property name="focusPolicy">
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QgsPercentageWidget" name="mAmbientCoefficientWidget" native="true">
+     <property name="focusPolicy">
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <widget class="QgsPropertyOverrideButton" name="mSpecularDataDefinedButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="lblAmbient">
+     <property name="toolTip">
+      <string>Color of light that is scattered around the entire scene.</string>
+     </property>
+     <property name="text">
+      <string>Ambient</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QgsColorButton" name="btnDiffuse">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" rowspan="9">
+    <widget class="QgsMaterialPreviewWidget" name="mPreviewWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>200</height>
+      </size>
      </property>
     </widget>
    </item>
@@ -194,6 +217,12 @@
    <class>QgsPercentageWidget</class>
    <extends>QWidget</extends>
    <header>qgspercentagewidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMaterialPreviewWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsmaterialpreviewwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/3d/phongtexturedmaterialwidgetbase.ui
+++ b/src/ui/3d/phongtexturedmaterialwidgetbase.ui
@@ -6,15 +6,59 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>394</width>
-    <height>252</height>
+    <width>720</width>
+    <height>423</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="1">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="2,1,2">
+   <item row="4" column="2">
+    <widget class="QgsImageSourceLineEdit" name="textureFile" native="true"/>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLabel" name="lblTextureRotation">
+     <property name="text">
+      <string>Texture rotation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QgsDoubleSpinBox" name="spinShininess">
+     <property name="maximum">
+      <double>1000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="lblOpacity">
+     <property name="text">
+      <string>Opacity</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="lblAmbient">
+     <property name="toolTip">
+      <string>Color of light that is scattered around the entire scene.</string>
+     </property>
+     <property name="text">
+      <string>Ambient</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="lblShininess">
+     <property name="toolTip">
+      <string>How shiny smooth surfaces are.</string>
+     </property>
+     <property name="text">
+      <string>Shininess</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
     <widget class="QgsDoubleSpinBox" name="textureScaleSpinBox">
      <property name="suffix">
       <string> %</string>
@@ -33,33 +77,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinShininess">
-     <property name="maximum">
-      <double>1000.000000000000000</double>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="1">
-    <widget class="QgsColorButton" name="btnSpecular">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QgsImageSourceLineEdit" name="textureFile" native="true"/>
-   </item>
-   <item row="1" column="0">
     <widget class="QLabel" name="lblSpecular">
      <property name="toolTip">
       <string>Color of light reflecting from smooth surfaces.</string>
@@ -69,64 +87,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="lblTextureRotation">
-     <property name="text">
-      <string>Texture rotation</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lblAmbient">
-     <property name="toolTip">
-      <string>Color of light that is scattered around the entire scene.</string>
-     </property>
-     <property name="text">
-      <string>Ambient</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="lblTextureScale">
-     <property name="text">
-      <string>Texture scale</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="lblShininess">
-     <property name="toolTip">
-      <string>How shiny smooth surfaces are.</string>
-     </property>
-     <property name="text">
-      <string>Shininess</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QgsColorButton" name="btnAmbient">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>120</width>
-       <height>0</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="lblTextureScale_2">
-     <property name="text">
-      <string>Diffuse texture</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
+   <item row="6" column="2">
     <widget class="QgsDoubleSpinBox" name="textureRotationSpinBox">
      <property name="suffix">
       <string> °</string>
@@ -142,15 +103,77 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="lblOpacity">
-     <property name="text">
-      <string>Opacity</string>
+   <item row="0" column="2">
+    <widget class="QgsColorButton" name="btnAmbient">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="1" column="2">
+    <widget class="QgsColorButton" name="btnSpecular">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLabel" name="lblTextureScale">
+     <property name="text">
+      <string>Texture scale</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
     <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true"/>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="lblTextureScale_2">
+     <property name="text">
+      <string>Diffuse texture</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" rowspan="8">
+    <widget class="QgsMaterialPreviewWidget" name="mPreviewWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>200</height>
+      </size>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -164,6 +187,18 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMaterialPreviewWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsmaterialpreviewwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/3d/simplelinematerialwidgetbase.ui
+++ b/src/ui/3d/simplelinematerialwidgetbase.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>394</width>
-    <height>25</height>
+    <width>703</width>
+    <height>317</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="2,1,2,0">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -26,7 +26,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="1">
+   <item row="0" column="2">
     <widget class="QgsColorButton" name="btnAmbient">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -42,17 +42,40 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="1">
+    <widget class="QLabel" name="lblAmbient">
+     <property name="text">
+      <string>Color</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
     <widget class="QgsPropertyOverrideButton" name="mAmbientDataDefinedButton">
      <property name="text">
       <string>...</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lblAmbient">
-     <property name="text">
-      <string>Color</string>
+   <item row="1" column="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" rowspan="2">
+    <widget class="QgsMaterialPreviewWidget" name="mPreviewWidget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>200</height>
+      </size>
      </property>
     </widget>
    </item>
@@ -68,6 +91,12 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMaterialPreviewWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsmaterialpreviewwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
When editing materials through the style manager, show a live preview of the material.

Another step towards providing a nice out-of-the-box set of materials ready for use.

<img width="798" height="494" alt="image" src="https://github.com/user-attachments/assets/d8e704a4-390a-44da-b1b4-72d4098b45da" />

<img width="690" height="407" alt="image" src="https://github.com/user-attachments/assets/c539af8a-6423-4567-ba2d-56a21687ac97" />
