### PR TITLE
Add monkey patch to restore QGIS 3.x (unstable!) material api

### DIFF
--- a/python/PyQt6/3d/__init__.py.in
+++ b/python/PyQt6/3d/__init__.py.in
@@ -62,3 +62,5 @@ QgsPoint3DSymbol.Model = _Qgis.Point3DShape.Model
 QgsPoint3DSymbol.Model.is_monkey_patched = True
 QgsPoint3DSymbol.Billboard = _Qgis.Point3DShape.Billboard
 QgsPoint3DSymbol.Billboard.is_monkey_patched = True
+
+from qgis.core import QgsAbstractMaterialSettings, QgsGoochMaterialSettings, QgsMaterialSettingsAbstractMetadata, QgsMaterialRegistry, QgsMetalRoughMaterialSettings, QgsNullMaterialSettings, QgsPhongMaterialSettings, QgsPhongTexturedMaterialSettings, QgsSimpleLineMaterialSettings


### PR DESCRIPTION
This API was marked unstable, but it's trivial to maintain compatibility with existing code.
