### PR TITLE
[dxf] Ensure exports using Meters at Scale units work

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -884,7 +884,10 @@ void QgsDxfExport::prepareRenderers()
   mRenderContext = QgsRenderContext();
   mRenderContext.setRendererScale( mSymbologyScale );
   mRenderContext.setExtent( mMapSettings.extent() );
-
+  QgsDistanceArea da;
+  da.setSourceCrs( mMapSettings.destinationCrs(), mMapSettings.transformContext() );
+  da.setEllipsoid( mMapSettings.ellipsoid() );
+  mRenderContext.setDistanceArea( da );
   mRenderContext.setScaleFactor( 96.0 / 25.4 );
   mRenderContext.setMapToPixel(
     QgsMapToPixel( 1.0 / mFactor, mMapSettings.extent().center().x(), mMapSettings.extent().center().y(), std::floor( mMapSettings.extent().width() * mFactor ), std::floor( mMapSettings.extent().height() * mFactor ), 0 )

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -88,6 +88,7 @@ class TestQgsDxfExport : public QObject
     void testMinimumLineWidthExport();
     void testWritingCodepage();
     void testExpressionContext();
+    void testMetersAtScale();
 
   private:
     QgsVectorLayer *mPointLayer = nullptr;
@@ -2011,6 +2012,55 @@ void TestQgsDxfExport::testExpressionContext()
   QgsTextFormat format;
   format.setFont( QgsFontUtils::getStandardTestFont( u"Bold"_s ).family() );
   format.setSize( 12 );
+  format.setNamedStyle( u"Bold"_s );
+  format.setColor( QColor( 200, 0, 200 ) );
+  settings.setFormat( format );
+  mPointLayerNoSymbols->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
+  mPointLayerNoSymbols->setLabelsEnabled( true );
+
+  QgsDxfExport d;
+  d.addLayers( QList<QgsDxfExport::DxfLayer>() << QgsDxfExport::DxfLayer( mPointLayerNoSymbols ) << QgsDxfExport::DxfLayer( vl.get() ) );
+
+  QgsMapSettings mapSettings;
+  const QSize size( 640, 480 );
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( mPointLayerNoSymbols->extent() );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << mPointLayerNoSymbols << vl.get() );
+  mapSettings.setOutputDpi( 96 );
+  mapSettings.setDestinationCrs( mPointLayerNoSymbols->crs() );
+
+  d.setMapSettings( mapSettings );
+  d.setSymbologyScale( 1000 );
+  d.setSymbologyExport( Qgis::FeatureSymbologyExport::PerFeature );
+
+  const QString file = getTempFileName( "context_dxf" );
+  QFile dxfFile( file );
+  QCOMPARE( d.writeToFile( &dxfFile, u"CP1252"_s ), QgsDxfExport::ExportResult::Success );
+  dxfFile.close();
+  QString debugInfo;
+  QVERIFY2( fileContainsText( file, "REGEX Biplane", &debugInfo ), debugInfo.toUtf8().constData() );
+}
+
+void TestQgsDxfExport::testMetersAtScale()
+{
+  // This test is aimed at testing whether the render unit "meters in map units" exports
+
+  auto vl = std::make_unique<QgsVectorLayer>( u"LineString?crs=epsg:4326&field=id:string"_s, u"vl"_s, u"memory"_s );
+
+  QgsFeature f;
+  f.setAttributes( QgsAttributes() << u"1"_s );
+  f.setGeometry( QgsGeometry::fromWkt( u"LineString (-112.5 44.9, -88.6 44.9)"_s ) );
+  QVERIFY( vl->dataProvider()->addFeature( f ) );
+
+  vl->setRenderer( new QgsSingleSymbolRenderer( QgsLineSymbol::createSimple( { { u"color"_s, u"#000000"_s }, { u"outline_width"_s, 0.6 } } ).release() ) );
+
+  QgsPalLayerSettings settings;
+  settings.fieldName = u"represent_value(\"Class\")"_s;
+  settings.isExpression = true;
+  QgsTextFormat format;
+  format.setFont( QgsFontUtils::getStandardTestFont( u"Bold"_s ).family() );
+  format.setSize( 12 );
+  format.setSizeUnit( Qgis::RenderUnit::MetersInMapUnits );
   format.setNamedStyle( u"Bold"_s );
   format.setColor( QColor( 200, 0, 200 ) );
   settings.setFormat( format );


### PR DESCRIPTION
This requires that the render context has the correct distance area calculator set.