### PR TITLE
[wms] Only draw cached openstreetmap.org tiles when rendering canvas preview jobs

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -855,6 +855,7 @@ QImage QgsWmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, int
     const QgsWmtsTileMatrix *tm = nullptr;
     std::unique_ptr<QgsWmtsTileMatrix> tempTm;
     enum QgsTileMode tileMode;
+    const bool drawCacheOnly = feedback && feedback->renderContext().testFlag( Qgis::RenderContextFlag::RenderPreviewJob ) && dataSourceUri().contains( u"openstreetmap.org"_s );
 
     if ( mSettings.mTiled )
     {
@@ -1053,7 +1054,7 @@ QImage QgsWmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, int
     int t0 = t.elapsed();
     // draw other res tiles if preview
     QPainter p( &image );
-    if ( feedback && feedback->isPreviewOnly() && missing.count() > 0 )
+    if ( missing.count() > 0 && ( ( feedback && feedback->isPreviewOnly() ) || drawCacheOnly ) )
     {
       // some tiles are still missing, so let's see if we have any cached tiles
       // from lower or higher resolution available to give the user a bit of context
@@ -1063,7 +1064,10 @@ QImage QgsWmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, int
 #if 0 // for debugging
       p.fillRect( image->rect(), QBrush( Qt::lightGray, Qt::CrossPattern ) );
 #endif
-      p.setRenderHint( QPainter::SmoothPixmapTransform, false ); // let's not waste time with bilinear filtering
+      if ( feedback && feedback->isPreviewOnly() )
+      {
+        p.setRenderHint( QPainter::SmoothPixmapTransform, false ); // let's not waste time with bilinear filtering
+      }
 
       QList<TileImage> lowerResTiles, lowerResTiles2, higherResTiles;
       // first we check lower resolution tiles: one level back, then two levels back (if there is still some area not covered),
@@ -1130,6 +1134,10 @@ QImage QgsWmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, int
     {
       QgsDebugMsgLevel( u"PREVIEW - CACHED: %1 / MISSING: %2"_s.arg( tileImages.count() ).arg( requests.count() - tileImages.count() ), 4 );
       QgsDebugMsgLevel( u"PREVIEW - TIME: this res %1 ms | other res %2 ms | TOTAL %3 ms"_s.arg( t0 + t2 ).arg( t1 ).arg( t0 + t1 + t2 ), 4 );
+    }
+    else if ( drawCacheOnly )
+    {
+      return image;
     }
     else if ( !requestsFinal.isEmpty() )
     {


### PR DESCRIPTION
## Description

QGIS continues to be a significant driver of tiles downloads from OpenStreetMap's main servers. Graphs of the usage seems to indicate this is not merely a few mega crawls but rather the avg. QGIS user download a large amount of tiles with peeks during daytime of the days of the week.

One way I suspect _we can have a substantial positive impact is by avoiding the download of non-cached tiles_ when doing map canvas preview rendering (i.e. the 8 quadrants we draw around the visible map canvas to enhance panning/zooming experience), and instead rely only on cached tiles (both of the desired zoom level as well as up to 2 levels down and one level up).

While part of the original aim for these preview renderings was to fetch additional tiles to make them readily available, it's a series of tile fetching that's not strictly necessary and causes additional stress with the OSM server infrastructure.

Here's how panning around looks like with preview areas using only the cached tiles available:

https://github.com/user-attachments/assets/fa761120-7825-4668-a7e2-5cfd63b7410c

This to me feels like a completely acceptable visual trade (and one that's arguably necessary). This will also mean that the QGIS network cache won't grow as fast, and will hold more tiles that were meant to be viewed.