### PR TITLE
Set unit for mapboxGl symbol spacing to context target unit

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -2086,7 +2086,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer(
     // main checkbox in labeling GUI
     QgsLabelThinningSettings thinningSettings = labelSettings.thinningSettings();
     thinningSettings.setAllowDuplicateRemoval( true );
-    thinningSettings.setMinimumDistanceToDuplicateUnit( Qgis::RenderUnit::Pixels );
+    thinningSettings.setMinimumDistanceToDuplicateUnit( context.targetUnit() );
     labelSettings.setThinningSettings( thinningSettings );
 
     QgsProperty spacingProp;

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -2960,6 +2960,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
     def testSymbolSpacingNumeric(self):
         """Test symbol-spacing with a simple numeric value"""
         context = QgsMapBoxGlStyleConversionContext()
+        context.setTargetUnit(Qgis.RenderUnit.Percentage)
         style = {
             "layout": {
                 "text-field": "{name}",
@@ -2982,10 +2983,15 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabelDistance)
         self.assertTrue(prop.isActive())
         self.assertEqual(prop.asExpression(), "250")
+        self.assertEqual(
+            ls.thinningSettings().minimumDistanceToDuplicateUnit(),
+            Qgis.RenderUnit.Percentage,
+        )
 
     def testSymbolSpacingList(self):
         """Test symbol-spacing with interpolate stops"""
         context = QgsMapBoxGlStyleConversionContext()
+        context.setTargetUnit(Qgis.RenderUnit.Pixels)
         style = {
             "layout": {
                 "text-field": "{name}",
@@ -3011,10 +3017,15 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
             prop.asExpression(),
             "CASE  WHEN @vector_tile_zoom >= 14 THEN (800)  WHEN @vector_tile_zoom >= 10 THEN (600) ELSE (300) END",
         )
+        self.assertEqual(
+            ls.thinningSettings().minimumDistanceToDuplicateUnit(),
+            Qgis.RenderUnit.Pixels,
+        )
 
     def testSymbolSpacingMap(self):
         """Test symbol-spacing with a QVariantMap stops definition"""
         context = QgsMapBoxGlStyleConversionContext()
+        context.setTargetUnit(Qgis.RenderUnit.MapUnits)
         style = {
             "layout": {
                 "text-field": "{name}",
@@ -3043,6 +3054,10 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         self.assertEqual(
             prop.asExpression(),
             "scale_linear(@vector_tile_zoom,2,6,0.2,0)",
+        )
+        self.assertEqual(
+            ls.thinningSettings().minimumDistanceToDuplicateUnit(),
+            Qgis.RenderUnit.MapUnits,
         )
 
 

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -2961,6 +2961,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         """Test symbol-spacing with a simple numeric value"""
         context = QgsMapBoxGlStyleConversionContext()
         context.setTargetUnit(Qgis.RenderUnit.Percentage)
+        context.setPixelSizeConversionFactor(2.0)
         style = {
             "layout": {
                 "text-field": "{name}",
@@ -2982,7 +2983,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         dd = ls.dataDefinedProperties()
         prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabelDistance)
         self.assertTrue(prop.isActive())
-        self.assertEqual(prop.asExpression(), "250")
+        self.assertEqual(prop.asExpression(), "500")
         self.assertEqual(
             ls.thinningSettings().minimumDistanceToDuplicateUnit(),
             Qgis.RenderUnit.Percentage,
@@ -2992,6 +2993,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         """Test symbol-spacing with interpolate stops"""
         context = QgsMapBoxGlStyleConversionContext()
         context.setTargetUnit(Qgis.RenderUnit.Pixels)
+        context.setPixelSizeConversionFactor(2.0)
         style = {
             "layout": {
                 "text-field": "{name}",
@@ -3015,7 +3017,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         self.assertTrue(prop.isActive())
         self.assertEqual(
             prop.asExpression(),
-            "CASE  WHEN @vector_tile_zoom >= 14 THEN (800)  WHEN @vector_tile_zoom >= 10 THEN (600) ELSE (300) END",
+            "CASE  WHEN @vector_tile_zoom >= 14 THEN (1600)  WHEN @vector_tile_zoom >= 10 THEN (1200) ELSE (600) END",
         )
         self.assertEqual(
             ls.thinningSettings().minimumDistanceToDuplicateUnit(),
@@ -3026,6 +3028,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         """Test symbol-spacing with a QVariantMap stops definition"""
         context = QgsMapBoxGlStyleConversionContext()
         context.setTargetUnit(Qgis.RenderUnit.MapUnits)
+        context.setPixelSizeConversionFactor(2.0)
         style = {
             "layout": {
                 "text-field": "{name}",
@@ -3053,7 +3056,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         self.assertTrue(prop.isActive())
         self.assertEqual(
             prop.asExpression(),
-            "scale_linear(@vector_tile_zoom,2,6,0.2,0)",
+            "(scale_linear(@vector_tile_zoom,2,6,0.2,0)) * 2",
         )
         self.assertEqual(
             ls.thinningSettings().minimumDistanceToDuplicateUnit(),


### PR DESCRIPTION
## Description

Sets the target unit to the correct unit, derived from the context for MapboxGl symbol spacing. See https://github.com/qgis/QGIS/pull/65498#discussion_r2993094192

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
