### PR TITLE
Use unique_ptr when class has clear ownership

### DIFF
--- a/src/gui/labeling/qgsrulebasedlabelingwidget.cpp
+++ b/src/gui/labeling/qgsrulebasedlabelingwidget.cpp
@@ -93,22 +93,22 @@ QgsRuleBasedLabelingWidget::QgsRuleBasedLabelingWidget( QgsVectorLayer *layer, Q
   if ( mLayer->labeling() && mLayer->labeling()->type() == "rule-based"_L1 )
   {
     const QgsRuleBasedLabeling *rl = static_cast<const QgsRuleBasedLabeling *>( mLayer->labeling() );
-    mRootRule = rl->rootRule()->clone( false );
+    mRootRule.reset( rl->rootRule()->clone( false ) );
   }
   else if ( mLayer->labeling() && mLayer->labeling()->type() == "simple"_L1 )
   {
     // copy simple label settings to first rule
-    mRootRule = new QgsRuleBasedLabeling::Rule( nullptr );
+    mRootRule = std::make_unique<class QgsRuleBasedLabeling::Rule>( nullptr );
     auto newSettings = std::make_unique<QgsPalLayerSettings>( mLayer->labeling()->settings() );
     newSettings->drawLabels = true; // otherwise we may be trying to copy a "blocking" setting to a rule - which is confusing for users!
     mRootRule->appendChild( new QgsRuleBasedLabeling::Rule( newSettings.release() ) );
   }
   else
   {
-    mRootRule = new QgsRuleBasedLabeling::Rule( nullptr );
+    mRootRule = std::make_unique<class QgsRuleBasedLabeling::Rule>( nullptr );
   }
 
-  mModel = new QgsRuleBasedLabelingModel( mRootRule );
+  mModel = new QgsRuleBasedLabelingModel( mRootRule.get() );
   viewRules->setModel( mModel );
 
   connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsRuleBasedLabelingWidget::widgetChanged );
@@ -117,9 +117,7 @@ QgsRuleBasedLabelingWidget::QgsRuleBasedLabelingWidget( QgsVectorLayer *layer, Q
 }
 
 QgsRuleBasedLabelingWidget::~QgsRuleBasedLabelingWidget()
-{
-  delete mRootRule;
-}
+{}
 
 void QgsRuleBasedLabelingWidget::setDockMode( bool dockMode )
 {
@@ -688,12 +686,12 @@ QgsLabelingRulePropsWidget::QgsLabelingRulePropsWidget( QgsRuleBasedLabeling::Ru
   if ( mRule->settings() )
   {
     groupSettings->setChecked( true );
-    mSettings = new QgsPalLayerSettings( *mRule->settings() ); // use a clone!
+    mSettings = std::make_unique<QgsPalLayerSettings>( *mRule->settings() ); // use a clone!
   }
   else
   {
     groupSettings->setChecked( false );
-    mSettings = new QgsPalLayerSettings;
+    mSettings = std::make_unique<QgsPalLayerSettings>();
   }
 
   mLabelingGui = new QgsLabelingGui( mMapCanvas, *mSettings, this );
@@ -721,9 +719,7 @@ QgsLabelingRulePropsWidget::QgsLabelingRulePropsWidget( QgsRuleBasedLabeling::Ru
 }
 
 QgsLabelingRulePropsWidget::~QgsLabelingRulePropsWidget()
-{
-  delete mSettings;
-}
+{}
 
 void QgsLabelingRulePropsWidget::setDockMode( bool dockMode )
 {

--- a/src/gui/labeling/qgsrulebasedlabelingwidget.h
+++ b/src/gui/labeling/qgsrulebasedlabelingwidget.h
@@ -114,7 +114,7 @@ class GUI_EXPORT QgsRuleBasedLabelingWidget : public QgsPanelWidget, private Ui:
     ~QgsRuleBasedLabelingWidget() override;
 
     //! Gives access to the internal root of the rule tree
-    const QgsRuleBasedLabeling::Rule *rootRule() const { return mRootRule; }
+    const QgsRuleBasedLabeling::Rule *rootRule() const { return mRootRule.get(); }
 
     void setDockMode( bool dockMode ) override;
 
@@ -134,7 +134,7 @@ class GUI_EXPORT QgsRuleBasedLabelingWidget : public QgsPanelWidget, private Ui:
     QgsVectorLayer *mLayer = nullptr;
     QgsMapCanvas *mCanvas = nullptr;
 
-    QgsRuleBasedLabeling::Rule *mRootRule = nullptr;
+    std::unique_ptr<QgsRuleBasedLabeling::Rule> mRootRule;
     QgsRuleBasedLabelingModel *mModel = nullptr;
 
     QAction *mCopyAction = nullptr;
@@ -199,7 +199,7 @@ class GUI_EXPORT QgsLabelingRulePropsWidget : public QgsPanelWidget, private Ui:
     QgsVectorLayer *mLayer = nullptr;
 
     QgsLabelingGui *mLabelingGui = nullptr;
-    QgsPalLayerSettings *mSettings = nullptr; // a clone of original settings
+    std::unique_ptr<QgsPalLayerSettings> mSettings; // a clone of original settings
 
     QgsMapCanvas *mMapCanvas = nullptr;
 };

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -75,9 +75,7 @@ QgsLayerTreeViewBase::QgsLayerTreeViewBase( QWidget *parent )
 }
 
 QgsLayerTreeViewBase::~QgsLayerTreeViewBase()
-{
-  delete mBlockDoubleClickTimer;
-}
+{}
 
 void QgsLayerTreeViewBase::mouseDoubleClickEvent( QMouseEvent *event )
 {
@@ -486,9 +484,7 @@ QgsLayerTreeView::QgsLayerTreeView( QWidget *parent )
 }
 
 QgsLayerTreeView::~QgsLayerTreeView()
-{
-  delete mMenuProvider;
-}
+{}
 
 void QgsLayerTreeView::setModel( QAbstractItemModel *model )
 {
@@ -533,8 +529,7 @@ void QgsLayerTreeView::setModel( QgsLayerTreeModel *treeModel, QgsLayerTreeProxy
 
 void QgsLayerTreeView::setMenuProvider( QgsLayerTreeViewMenuProvider *menuProvider )
 {
-  delete mMenuProvider;
-  mMenuProvider = menuProvider;
+  mMenuProvider.reset( menuProvider );
 }
 
 void QgsLayerTreeView::setLayerVisible( QgsMapLayer *layer, bool visible )

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -469,7 +469,7 @@ class GUI_EXPORT QgsLayerTreeView : public QgsLayerTreeViewBase
     //! Sets provider for context menu. Takes ownership of the instance
     void setMenuProvider( QgsLayerTreeViewMenuProvider *menuProvider SIP_TRANSFER );
     //! Returns pointer to the context menu provider. May be NULLPTR
-    QgsLayerTreeViewMenuProvider *menuProvider() const { return mMenuProvider; }
+    QgsLayerTreeViewMenuProvider *menuProvider() const { return mMenuProvider.get(); }
 
     /**
      * Convenience methods which sets the visible state of the specified map \a layer.
@@ -618,7 +618,7 @@ class GUI_EXPORT QgsLayerTreeView : public QgsLayerTreeViewBase
 
   protected:
     //! Context menu provider. Owned by the view.
-    QgsLayerTreeViewMenuProvider *mMenuProvider = nullptr;
+    std::unique_ptr<QgsLayerTreeViewMenuProvider> mMenuProvider;
     //! Keeps track of current layer ID (to check when to emit signal about change of current layer)
     QString mCurrentLayerID;
     //! Storage of indicators used with the tree view

--- a/src/gui/maptools/qgsmaptoolzoom.cpp
+++ b/src/gui/maptools/qgsmaptoolzoom.cpp
@@ -43,9 +43,7 @@ QgsMapToolZoom::QgsMapToolZoom( QgsMapCanvas *canvas, bool zoomOut )
 }
 
 QgsMapToolZoom::~QgsMapToolZoom()
-{
-  delete mRubberBand;
-}
+{}
 
 QgsMapTool::Flags QgsMapToolZoom::flags() const
 {
@@ -62,8 +60,8 @@ void QgsMapToolZoom::canvasMoveEvent( QgsMapMouseEvent *e )
   if ( !mDragging )
   {
     mDragging = true;
-    delete mRubberBand;
-    mRubberBand = new QgsRubberBand( mCanvas, Qgis::GeometryType::Polygon );
+    mRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Polygon ) );
+
     QColor color( Qt::blue );
     color.setAlpha( 63 );
     mRubberBand->setColor( color );
@@ -110,8 +108,8 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent *e )
   if ( !mDragging || tooShort )
   {
     mDragging = false;
-    delete mRubberBand;
-    mRubberBand = nullptr;
+    mRubberBand.reset();
+
 
     // change to zoom in/out by the default multiple
     mCanvas->zoomWithCenter( e->x(), e->y(), !mZoomOut );
@@ -119,8 +117,8 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent *e )
   else
   {
     mDragging = false;
-    delete mRubberBand;
-    mRubberBand = nullptr;
+    mRubberBand.reset();
+
 
     // store the rectangle
     mZoomRect.setRight( e->pos().x() );
@@ -148,8 +146,8 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent *e )
 
 void QgsMapToolZoom::deactivate()
 {
-  delete mRubberBand;
-  mRubberBand = nullptr;
+  mRubberBand.reset();
+
 
   QgsMapTool::deactivate();
 }
@@ -184,7 +182,6 @@ void QgsMapToolZoom::keyReleaseEvent( QKeyEvent *e )
   if ( e->key() == Qt::Key_Escape && mDragging )
   {
     mCanceled = true;
-    delete mRubberBand;
-    mRubberBand = nullptr;
+    mRubberBand.reset();
   }
 }

--- a/src/gui/maptools/qgsmaptoolzoom.h
+++ b/src/gui/maptools/qgsmaptoolzoom.h
@@ -18,6 +18,7 @@
 
 #include "qgis_gui.h"
 #include "qgsmaptool.h"
+#include "qobjectuniqueptr.h"
 
 #include <QRect>
 
@@ -62,7 +63,7 @@ class GUI_EXPORT QgsMapToolZoom : public QgsMapTool
     //! Flag to indicate the user has canceled the current zoom operation
     bool mCanceled = false;
 
-    QgsRubberBand *mRubberBand = nullptr;
+    QObjectUniquePtr<QgsRubberBand> mRubberBand;
 
     QCursor mZoomOutCursor;
     QCursor mZoomInCursor;

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -402,7 +402,6 @@ QgsModelDesignerDialog::~QgsModelDesignerDialog()
   settings.setValue( u"ModelDesigner/state"_s, saveState(), QgsSettings::App );
 
   mIgnoreUndoStackChanges++;
-  delete mSelectTool; // delete mouse handles before everything else
 }
 
 void QgsModelDesignerDialog::closeEvent( QCloseEvent *event )

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -332,7 +332,9 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   mToolsActionGroup->addAction( mActionPan );
   connect( mActionPan, &QAction::triggered, mPanTool, [this] { mView->setTool( mPanTool ); } );
 
-  mSelectTool = new QgsModelViewToolSelect( mView );
+  // We use a QObjectUniquePtr here because we want to delete QgsModelViewToolSelect
+  // mouse handles before everything else and don't want to wait for QObject destructor to destroy it
+  mSelectTool.reset( new QgsModelViewToolSelect( mView ) );
   mSelectTool->setAction( mActionSelectMoveItem );
 
   mToolsActionGroup->addAction( mActionSelectMoveItem );

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -23,6 +23,7 @@
 #include "qgsmodelundocommand.h"
 #include "qgsprocessingmodelchilddependency.h"
 #include "qgsprocessingtoolboxmodel.h"
+#include "qobjectuniqueptr.h"
 
 class QgsMessageBar;
 class QgsProcessingModelAlgorithm;
@@ -231,7 +232,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     QActionGroup *mToolsActionGroup = nullptr;
 
     QgsModelViewToolPan *mPanTool = nullptr;
-    QgsModelViewToolSelect *mSelectTool = nullptr;
+    QObjectUniquePtr<QgsModelViewToolSelect> mSelectTool;
     QgsModelGraphicsScene *mScene = nullptr;
 
     bool mHasChanged = false;

--- a/src/gui/proj/qgscoordinateboundspreviewmapwidget.cpp
+++ b/src/gui/proj/qgscoordinateboundspreviewmapwidget.cpp
@@ -54,13 +54,9 @@ QgsCoordinateBoundsPreviewMapWidget::QgsCoordinateBoundsPreviewMapWidget( QWidge
 QgsCoordinateBoundsPreviewMapWidget::~QgsCoordinateBoundsPreviewMapWidget()
 {
   setMapTool( nullptr );
-  delete mPanTool;
-  mPanTool = nullptr;
+
 
   qDeleteAll( mLayers );
-  delete mPreviewBand;
-  delete mCanvasPreviewBand;
-  delete mCanvasCenterMarker;
 }
 
 void QgsCoordinateBoundsPreviewMapWidget::setPreviewRect( const QgsRectangle &rect )

--- a/src/gui/stac/qgsstacsourceselect.cpp
+++ b/src/gui/stac/qgsstacsourceselect.cpp
@@ -48,7 +48,7 @@ using namespace Qt::StringLiterals;
 
 QgsStacSourceSelect::QgsStacSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode theWidgetMode )
   : QgsAbstractDataSourceWidget( parent, fl, theWidgetMode )
-  , mStac( new QgsStacController )
+  , mStac( std::make_unique<QgsStacController>() )
   , mItemsModel( new QgsStacItemListModel( this ) )
 {
   setupUi( this );
@@ -68,9 +68,9 @@ QgsStacSourceSelect::QgsStacSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
 
   populateConnectionList();
 
-  connect( mStac, &QgsStacController::finishedStacObjectRequest, this, &QgsStacSourceSelect::onStacObjectRequestFinished );
-  connect( mStac, &QgsStacController::finishedItemCollectionRequest, this, &QgsStacSourceSelect::onItemCollectionRequestFinished );
-  connect( mStac, &QgsStacController::finishedCollectionsRequest, this, &QgsStacSourceSelect::onCollectionsRequestFinished );
+  connect( mStac.get(), &QgsStacController::finishedStacObjectRequest, this, &QgsStacSourceSelect::onStacObjectRequestFinished );
+  connect( mStac.get(), &QgsStacController::finishedItemCollectionRequest, this, &QgsStacSourceSelect::onItemCollectionRequestFinished );
+  connect( mStac.get(), &QgsStacController::finishedCollectionsRequest, this, &QgsStacSourceSelect::onCollectionsRequestFinished );
 
   mItemsView->setModel( mItemsModel );
   mItemsView->setItemDelegate( new QgsStacItemDelegate( this ) );
@@ -84,7 +84,7 @@ QgsStacSourceSelect::QgsStacSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
 
   connect( mFootprintsCheckBox, &QCheckBox::clicked, this, &QgsStacSourceSelect::showFootprints );
 
-  mParametersDialog = new QgsStacSearchParametersDialog( mStac, mapCanvas(), this );
+  mParametersDialog = new QgsStacSearchParametersDialog( mStac.get(), mapCanvas(), this );
 
   connect( mFiltersButton, &QToolButton::clicked, mParametersDialog, &QgsStacSearchParametersDialog::open );
   connect( mParametersDialog, &QgsStacSearchParametersDialog::finished, this, &QgsStacSourceSelect::onSearchParametersDialogClosed );
@@ -93,9 +93,7 @@ QgsStacSourceSelect::QgsStacSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
 }
 
 QgsStacSourceSelect::~QgsStacSourceSelect()
-{
-  delete mStac;
-}
+{}
 
 void QgsStacSourceSelect::hideEvent( QHideEvent *e )
 {

--- a/src/gui/stac/qgsstacsourceselect.h
+++ b/src/gui/stac/qgsstacsourceselect.h
@@ -108,7 +108,7 @@ class GUI_EXPORT QgsStacSourceSelect : public QgsAbstractDataSourceWidget, priva
     QUrl mNextPageUrl;
     int mCollectionsPageCounter = 0;
 
-    QgsStacController *mStac = nullptr;
+    std::unique_ptr<QgsStacController> mStac;
     QgsStacItemListModel *mItemsModel = nullptr;
     QgsStacSearchParametersDialog *mParametersDialog = nullptr;
     QObjectUniquePtr<QgsRubberBand> mCurrentItemBand;

--- a/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
+++ b/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
@@ -117,10 +117,10 @@ QgsDataDefinedSizeLegendWidget::QgsDataDefinedSizeLegendWidget( const QgsDataDef
 
   // prepare layer and model to preview legend
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  mPreviewLayer = new QgsVectorLayer( u"Point?crs=EPSG:4326"_s, u"Preview"_s, u"memory"_s, options );
-  mPreviewTree = new QgsLayerTree;
-  mPreviewLayerNode = mPreviewTree->addLayer( mPreviewLayer ); // node owned by the tree
-  mPreviewModel = new QgsLayerTreeModel( mPreviewTree );
+  mPreviewLayer = std::make_unique<QgsVectorLayer>( u"Point?crs=EPSG:4326"_s, u"Preview"_s, u"memory"_s, options );
+  mPreviewTree = std::make_unique<QgsLayerTree>();
+  mPreviewLayerNode = mPreviewTree->addLayer( mPreviewLayer.get() ); // node owned by the tree
+  mPreviewModel = new QgsLayerTreeModel( mPreviewTree.get() );
   if ( canvas )
     mPreviewModel->setLegendMapViewData( canvas->mapUnitsPerPixel(), canvas->mapSettings().outputDpi(), canvas->scale() );
   viewLayerTree->setModel( mPreviewModel );
@@ -139,11 +139,7 @@ QgsDataDefinedSizeLegendWidget::QgsDataDefinedSizeLegendWidget( const QgsDataDef
 }
 
 QgsDataDefinedSizeLegendWidget::~QgsDataDefinedSizeLegendWidget()
-{
-  delete mPreviewModel;
-  delete mPreviewTree;
-  delete mPreviewLayer;
-}
+{}
 
 QgsDataDefinedSizeLegend *QgsDataDefinedSizeLegendWidget::dataDefinedSizeLegend() const
 {

--- a/src/gui/symbology/qgsdatadefinedsizelegendwidget.h
+++ b/src/gui/symbology/qgsdatadefinedsizelegendwidget.h
@@ -76,9 +76,9 @@ class GUI_EXPORT QgsDataDefinedSizeLegendWidget : public QgsPanelWidget, private
     bool mOverrideSymbol = false;                   //!< If true, symbol should not be editable because it will be overridden
     QgsProperty mSizeProperty;                      //!< Definition of data-defined size of symbol (should have a size scale transformer associated)
     QgsLayerTreeModel *mPreviewModel = nullptr;
-    QgsLayerTree *mPreviewTree = nullptr;
+    std::unique_ptr<QgsLayerTree> mPreviewTree;
     QgsLayerTreeLayer *mPreviewLayerNode = nullptr;
-    QgsVectorLayer *mPreviewLayer = nullptr;
+    std::unique_ptr<QgsVectorLayer> mPreviewLayer;
     QgsMapCanvas *mMapCanvas = nullptr;
     QStandardItemModel *mSizeClassesModel = nullptr;
 };

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -632,7 +632,6 @@ void QgsGraduatedSymbolRendererWidget::mSizeUnitWidget_changed()
 
 QgsGraduatedSymbolRendererWidget::~QgsGraduatedSymbolRendererWidget()
 {
-  delete mModel;
   mParameterWidgetWrappers.clear();
 }
 

--- a/src/gui/symbology/qgsrendererpropertiesdialog.cpp
+++ b/src/gui/symbology/qgsrendererpropertiesdialog.cpp
@@ -184,9 +184,7 @@ void QgsRendererPropertiesDialog::connectValueChanged( const QList<QWidget *> &w
 }
 
 QgsRendererPropertiesDialog::~QgsRendererPropertiesDialog()
-{
-  delete mPaintEffect;
-}
+{}
 
 void QgsRendererPropertiesDialog::setMapCanvas( QgsMapCanvas *canvas )
 {
@@ -361,8 +359,8 @@ void QgsRendererPropertiesDialog::syncToLayer()
   {
     if ( mLayer->renderer()->paintEffect() )
     {
-      mPaintEffect = mLayer->renderer()->paintEffect()->clone();
-      mEffectWidget->setPaintEffect( mPaintEffect );
+      mPaintEffect.reset( mLayer->renderer()->paintEffect()->clone() );
+      mEffectWidget->setPaintEffect( mPaintEffect.get() );
     }
 
     mOrderBy = mLayer->renderer()->orderBy();

--- a/src/gui/symbology/qgsrendererpropertiesdialog.h
+++ b/src/gui/symbology/qgsrendererpropertiesdialog.h
@@ -150,7 +150,7 @@ class GUI_EXPORT QgsRendererPropertiesDialog : public QDialog, private Ui::QgsRe
 
     QgsRendererWidget *mActiveWidget = nullptr;
 
-    QgsPaintEffect *mPaintEffect = nullptr;
+    std::unique_ptr<QgsPaintEffect> mPaintEffect;
 
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
@@ -82,8 +82,6 @@ QgsSingleSymbolRendererWidget::~QgsSingleSymbolRendererWidget()
 {
   mSingleSymbol.reset();
   mRenderer.reset();
-
-  delete mSelector;
 }
 
 QgsFeatureRenderer *QgsSingleSymbolRendererWidget::renderer()

--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -66,8 +66,6 @@ QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle *style, QWidget
   mTempStyle->createMemoryDatabase();
 
   // TODO validate
-  mGroupSelectionDlg = nullptr;
-  mTempFile = nullptr;
 
   QgsStyle *dialogStyle = nullptr;
   if ( mDialogMode == Import )
@@ -238,10 +236,7 @@ void QgsStyleExportImportDialog::moveStyles( QModelIndexList *selection, QgsStyl
 }
 
 QgsStyleExportImportDialog::~QgsStyleExportImportDialog()
-{
-  delete mTempFile;
-  delete mGroupSelectionDlg;
-}
+{}
 
 void QgsStyleExportImportDialog::setImportFilePath( const QString &path )
 {
@@ -432,7 +427,7 @@ void QgsStyleExportImportDialog::importFileChanged( const QString &path )
 
 void QgsStyleExportImportDialog::downloadStyleXml( const QUrl &url )
 {
-  mTempFile = new QTemporaryFile();
+  mTempFile = std::make_unique<QTemporaryFile>();
   if ( mTempFile->open() )
   {
     mFileName = mTempFile->fileName();

--- a/src/gui/symbology/qgsstyleexportimportdialog.h
+++ b/src/gui/symbology/qgsstyleexportimportdialog.h
@@ -155,7 +155,7 @@ class GUI_EXPORT QgsStyleExportImportDialog : public QDialog, private Ui::QgsSty
     void moveStyles( QModelIndexList *selection, QgsStyle *src, QgsStyle *dst );
 
     QgsStyleGroupSelectionDialog *mGroupSelectionDlg = nullptr;
-    QTemporaryFile *mTempFile = nullptr;
+    std::unique_ptr<QTemporaryFile> mTempFile;
 
     QString mFileName;
     Mode mDialogMode;


### PR DESCRIPTION
Regarding classes already parented to using Qt mecanism, I followed this rule:

- If the class inherits from QgsRubberBand, QgsMapTool or any classes being a QObject, use QObjectUniquePtr so we are sure we are not deleting twice the object.
  
- If the class inherits from QGraphicsItem, use with std::unique_ptr even though another class has already the ownership because the previous code was explicitly deleting it, so was assuming that it was deleting always before the real owner.

When the object is parented to this, I didn't use unique_ptr and just remove the extra delete instruction.

## AI tool usage

None

**Funded by [Security Project For QGIS](https://oslandia.com/en/security-project-for-qgis/)**