### PR TITLE
Clamp metalness/roughness to 0-1 range

### DIFF
--- a/python/PyQt6/core/auto_generated/3d/materials/qgsmetalroughmaterialsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/3d/materials/qgsmetalroughmaterialsettings.sip.in
@@ -57,14 +57,14 @@ Returns the base material color.
 
     double metalness() const;
 %Docstring
-Returns the material's metalness.
+Returns the material's metalness, as a value between 0 and 1.
 
 .. seealso:: :py:func:`setMetalness`
 %End
 
     double roughness() const;
 %Docstring
-Returns the material's roughness.
+Returns the material's roughness, as a value between 0 and 1.
 
 .. seealso:: :py:func:`setRoughness`
 %End
@@ -78,14 +78,14 @@ Sets the base material ``color``.
 
     void setMetalness( double metalness );
 %Docstring
-Returns the material's ``metalness``.
+Sets the material's ``metalness``, as a value between 0 and 1.
 
 .. seealso:: :py:func:`metalness`
 %End
 
     void setRoughness( double roughness );
 %Docstring
-Returns the material's ``roughness``.
+Sets the material's ``roughness``, as a value between 0 and 1.
 
 .. seealso:: :py:func:`roughness`
 %End

--- a/python/PyQt6/gui/auto_generated/qgspercentagewidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgspercentagewidget.sip.in
@@ -37,6 +37,13 @@ Returns the current percentage selected in the widget, as a factor from
 .. seealso:: :py:func:`valueChanged`
 %End
 
+    QgsDoubleSpinBox *spinBox();
+%Docstring
+Returns the spin box part of the widget.
+
+.. versionadded:: 4.2
+%End
+
   public slots:
 
     void setValue( double value );

--- a/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
@@ -42,8 +42,8 @@ QgsMaterial *QgsMetalRoughMaterial3DHandler::toMaterial( const QgsAbstractMateri
 
       QgsMetalRoughMaterial *material = new QgsMetalRoughMaterial;
       material->setBaseColor( context.isSelected() ? context.selectionColor() : metalRoughSettings->baseColor() );
-      material->setMetalness( metalRoughSettings->metalness() );
-      material->setRoughness( metalRoughSettings->roughness() );
+      material->setMetalness( std::clamp( metalRoughSettings->metalness(), 0.0, 1.0 ) );
+      material->setRoughness( std::clamp( metalRoughSettings->roughness(), 0.0, 1.0 ) );
       return material;
     }
 

--- a/src/app/3d/qgsmetalroughmaterialwidget.cpp
+++ b/src/app/3d/qgsmetalroughmaterialwidget.cpp
@@ -24,18 +24,16 @@ QgsMetalRoughMaterialWidget::QgsMetalRoughMaterialWidget( QWidget *parent, bool 
   : QgsMaterialSettingsWidget( parent )
 {
   setupUi( this );
-  mSpinMetalness->setClearValue( 0, tr( "None" ) );
-  mSpinRoughness->setClearValue( 0, tr( "None" ) );
 
   QgsMetalRoughMaterialSettings defaultMaterial;
   setSettings( &defaultMaterial, nullptr );
 
   connect( mButtonBaseColor, &QgsColorButton::colorChanged, this, &QgsMetalRoughMaterialWidget::changed );
-  connect( mSpinMetalness, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, [this] {
+  connect( mMetalnessWidget, &QgsPercentageWidget::valueChanged, this, [this] {
     updateWidgetState();
     emit changed();
   } );
-  connect( mSpinRoughness, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, [this] {
+  connect( mRoughnessWidget, &QgsPercentageWidget::valueChanged, this, [this] {
     updateWidgetState();
     emit changed();
   } );
@@ -55,8 +53,8 @@ void QgsMetalRoughMaterialWidget::setSettings( const QgsAbstractMaterialSettings
   if ( !material )
     return;
   mButtonBaseColor->setColor( material->baseColor() );
-  mSpinMetalness->setValue( material->metalness() );
-  mSpinRoughness->setValue( material->roughness() );
+  mMetalnessWidget->setValue( material->metalness() );
+  mRoughnessWidget->setValue( material->roughness() );
 
   mPropertyCollection = settings->dataDefinedProperties();
 
@@ -67,8 +65,8 @@ QgsAbstractMaterialSettings *QgsMetalRoughMaterialWidget::settings()
 {
   auto m = std::make_unique<QgsMetalRoughMaterialSettings>();
   m->setBaseColor( mButtonBaseColor->color() );
-  m->setMetalness( static_cast<float>( mSpinMetalness->value() ) );
-  m->setRoughness( static_cast<float>( mSpinRoughness->value() ) );
+  m->setMetalness( mMetalnessWidget->value() );
+  m->setRoughness( mRoughnessWidget->value() );
   m->setDataDefinedProperties( mPropertyCollection );
   return m.release();
 }

--- a/src/app/3d/qgsmetalroughmaterialwidget.cpp
+++ b/src/app/3d/qgsmetalroughmaterialwidget.cpp
@@ -28,6 +28,10 @@ QgsMetalRoughMaterialWidget::QgsMetalRoughMaterialWidget( QWidget *parent, bool 
   QgsMetalRoughMaterialSettings defaultMaterial;
   setSettings( &defaultMaterial, nullptr );
 
+  // clear has no meaning here
+  mMetalnessWidget->spinBox()->setShowClearButton( false );
+  mRoughnessWidget->spinBox()->setShowClearButton( false );
+
   connect( mButtonBaseColor, &QgsColorButton::colorChanged, this, &QgsMetalRoughMaterialWidget::changed );
   connect( mMetalnessWidget, &QgsPercentageWidget::valueChanged, this, [this] {
     updateWidgetState();

--- a/src/core/3d/materials/qgsmetalroughmaterialsettings.h
+++ b/src/core/3d/materials/qgsmetalroughmaterialsettings.h
@@ -60,14 +60,14 @@ class CORE_EXPORT QgsMetalRoughMaterialSettings : public QgsAbstractMaterialSett
     QColor baseColor() const { return mBaseColor; }
 
     /**
-     * Returns the material's metalness.
+     * Returns the material's metalness, as a value between 0 and 1.
      *
      * \see setMetalness()
      */
     double metalness() const { return mMetalness; }
 
     /**
-     * Returns the material's roughness.
+     * Returns the material's roughness, as a value between 0 and 1.
      *
      * \see setRoughness()
      */
@@ -81,14 +81,14 @@ class CORE_EXPORT QgsMetalRoughMaterialSettings : public QgsAbstractMaterialSett
     void setBaseColor( const QColor &color ) { mBaseColor = color; }
 
     /**
-     * Returns the material's \a metalness.
+     * Sets the material's \a metalness, as a value between 0 and 1.
      *
      * \see metalness()
      */
     void setMetalness( double metalness ) { mMetalness = metalness; }
 
     /**
-     * Returns the material's \a roughness.
+     * Sets the material's \a roughness, as a value between 0 and 1.
      *
      * \see roughness()
      */

--- a/src/gui/qgspercentagewidget.cpp
+++ b/src/gui/qgspercentagewidget.cpp
@@ -64,6 +64,11 @@ double QgsPercentageWidget::value() const
   return mSpinBox->value() / 100.0;
 }
 
+QgsDoubleSpinBox *QgsPercentageWidget::spinBox()
+{
+  return mSpinBox;
+}
+
 void QgsPercentageWidget::setValue( double value )
 {
   mSpinBox->setValue( value * 100.0 );

--- a/src/gui/qgspercentagewidget.h
+++ b/src/gui/qgspercentagewidget.h
@@ -48,6 +48,13 @@ class GUI_EXPORT QgsPercentageWidget : public QWidget
      */
     double value() const;
 
+    /**
+     * Returns the spin box part of the widget.
+     *
+     * \since QGIS 4.2
+     */
+    QgsDoubleSpinBox *spinBox();
+
   public slots:
 
     /**

--- a/src/ui/3d/metalroughmaterialwidget.ui
+++ b/src/ui/3d/metalroughmaterialwidget.ui
@@ -45,9 +45,9 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QgsDoubleSpinBox" name="mSpinMetalness">
-     <property name="maximum">
-      <double>1000.000000000000000</double>
+    <widget class="QgsPercentageWidget" name="mMetalnessWidget" native="true">
+     <property name="focusPolicy">
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
      </property>
     </widget>
    </item>
@@ -59,9 +59,9 @@
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QgsDoubleSpinBox" name="mSpinRoughness">
-     <property name="maximum">
-      <double>1000.000000000000000</double>
+    <widget class="QgsPercentageWidget" name="mRoughnessWidget" native="true">
+     <property name="focusPolicy">
+      <enum>Qt::FocusPolicy::StrongFocus</enum>
      </property>
     </widget>
    </item>
@@ -79,10 +79,15 @@
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsPercentageWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspercentagewidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mButtonBaseColor</tabstop>
-  <tabstop>mSpinMetalness</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
And adjust UI so that we use a 0-1 slider instead of free ranged spin boxes.

Setting the metalness or roughness to values > 1 results in corrupted shading.