### PR TITLE
Fix/63672 fix plugins version issues

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -488,17 +488,17 @@ class Repositories(QObject):
                     experimental = False
                     if pluginNodes.item(i).firstChildElement(
                         "experimental"
-                    ).text().strip().upper() in ["TRUE", "YES"]:
+                    ).text().strip().upper() in ["TRUE", "YES", "1"]:
                         experimental = True
                     deprecated = False
                     if pluginNodes.item(i).firstChildElement(
                         "deprecated"
-                    ).text().strip().upper() in ["TRUE", "YES"]:
+                    ).text().strip().upper() in ["TRUE", "YES", "1"]:
                         deprecated = True
                     trusted = False
                     if pluginNodes.item(i).firstChildElement(
                         "trusted"
-                    ).text().strip().upper() in ["TRUE", "YES"]:
+                    ).text().strip().upper() in ["TRUE", "YES", "1"]:
                         trusted = True
                     icon = pluginNodes.item(i).firstChildElement("icon").text().strip()
                     if icon and not icon.startswith("http"):
@@ -668,7 +668,7 @@ class Repositories(QObject):
                     # if compatible, add the plugin to the list
                     if not pluginNodes.item(i).firstChildElement(
                         "disabled"
-                    ).text().strip().upper() in ["TRUE", "YES"]:
+                    ).text().strip().upper() in ["TRUE", "YES", "1"]:
                         if isCompatible(
                             pyQgisVersion(), qgisMinimumVersion, qgisMaximumVersion
                         ):
@@ -899,9 +899,9 @@ class Plugins(QObject):
             "library": path,
             "pythonic": True,
             "experimental": pluginMetadata("experimental").strip().upper()
-            in ["TRUE", "YES"],
+            in ["TRUE", "YES", "1"],
             "deprecated": pluginMetadata("deprecated").strip().upper()
-            in ["TRUE", "YES"],
+            in ["TRUE", "YES", "1"],
             "trusted": False,
             "version_available": "",
             "version_available_stable": "",
@@ -1019,7 +1019,7 @@ class Plugins(QObject):
                     if key not in self.mPlugins:
                         self.mPlugins[key] = plugin  # just add a new plugin
                     else:
-                        # update local plugin with remote metadata
+                        # Update local plugin with remote metadata.
                         # description, about, icon: only use remote data if local one not available. Prefer local version because of i18n.
                         # NOTE: don't prefer local name to not desynchronize names if repository doesn't support i18n.
                         # Also prefer local icon to avoid downloading.
@@ -1027,7 +1027,36 @@ class Plugins(QObject):
                             if attrib != "name":
                                 if not self.mPlugins[key][attrib] and plugin[attrib]:
                                     self.mPlugins[key][attrib] = plugin[attrib]
-                        # other remote metadata is preferred:
+
+                        # For version-specific fields, only update if the incoming version
+                        # is strictly higher than what we already have. This ensures that
+                        # when a repository lists multiple versions of the same plugin,
+                        # the highest available version always wins regardless of XML order.
+                        # (Fix for https://github.com/qgis/QGIS/issues/63672)
+                        incoming_stable = plugin.get("version_available_stable", "")
+                        current_stable = self.mPlugins[key].get(
+                            "version_available_stable", ""
+                        )
+                        update_stable = incoming_stable and (
+                            not current_stable
+                            or compareVersions(incoming_stable, current_stable) == 1
+                        )
+
+                        incoming_experimental = plugin.get(
+                            "version_available_experimental", ""
+                        )
+                        current_experimental = self.mPlugins[key].get(
+                            "version_available_experimental", ""
+                        )
+                        update_experimental = incoming_experimental and (
+                            not current_experimental
+                            or compareVersions(
+                                incoming_experimental, current_experimental
+                            )
+                            == 1
+                        )
+
+                        # Non-version remote metadata is always preferred (unchanged behavior)
                         for attrib in [
                             "name",
                             "plugin_id",
@@ -1043,29 +1072,43 @@ class Plugins(QObject):
                             "code_repository",
                             "experimental",
                             "deprecated",
-                            "version_available",
-                            "zip_repository",
-                            "download_url",
-                            "filename",
-                            "downloads",
-                            "average_vote",
-                            "rating_votes",
                             "trusted",
                             "plugin_dependencies",
-                            "version_available_stable",
-                            "version_available_experimental",
-                            "download_url_stable",
-                            "download_url_experimental",
-                            "create_date",
-                            "update_date",
-                            "create_date_stable",
-                            "update_date_stable",
-                            "create_date_experimental",
-                            "update_date_experimental",
                         ]:
                             if (
                                 attrib not in translatableAttributes or attrib == "name"
                             ):  # include name!
+                                if plugin.get(attrib, False):
+                                    self.mPlugins[key][attrib] = plugin[attrib]
+
+                        # Version-specific fields: only overwrite when the incoming version
+                        # is higher than what is already stored.
+                        if update_stable:
+                            for attrib in [
+                                "version_available",
+                                "version_available_stable",
+                                "download_url",
+                                "download_url_stable",
+                                "filename",
+                                "zip_repository",
+                                "downloads",
+                                "average_vote",
+                                "rating_votes",
+                                "create_date",
+                                "update_date",
+                                "create_date_stable",
+                                "update_date_stable",
+                            ]:
+                                if plugin.get(attrib, False):
+                                    self.mPlugins[key][attrib] = plugin[attrib]
+
+                        if update_experimental:
+                            for attrib in [
+                                "version_available_experimental",
+                                "download_url_experimental",
+                                "create_date_experimental",
+                                "update_date_experimental",
+                            ]:
                                 if plugin.get(attrib, False):
                                     self.mPlugins[key][attrib] = plugin[attrib]
 

--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -1019,7 +1019,7 @@ class Plugins(QObject):
                     if key not in self.mPlugins:
                         self.mPlugins[key] = plugin  # just add a new plugin
                     else:
-                        # Update local plugin with remote metadata.
+                        # Update local plugin with remote metadata
                         # description, about, icon: only use remote data if local one not available. Prefer local version because of i18n.
                         # NOTE: don't prefer local name to not desynchronize names if repository doesn't support i18n.
                         # Also prefer local icon to avoid downloading.

--- a/python/pyplugin_installer/version_compare.py
+++ b/python/pyplugin_installer/version_compare.py
@@ -47,7 +47,15 @@ def normalizeVersion(s):
     try:
         return Version(s).public
     except InvalidVersion:
-        return ""
+        # handles bit more things than packaging:
+        #   like "ver. 1.0-201609011405-2690BD9"
+        pattern = r"^(?P<epoch>\D+)?(?P<version>(?P<release>\d+(?:\.\d+)*)(?P<pre>(?:a|alpha|b|beta|rc)\d+?)?((?P<post>\.post\d+))?(?P<dev>\.dev\d+)?)(?P<build>\+|-\S+)?$"
+        m = re.match(pattern, s.lower())
+        if not m:
+            return ""
+        return Version(
+            f"{m.group('release') or ''}{m.group('pre') or ''}{m.group('post') or ''}{m.group('dev') or ''}"
+        ).public
 
 
 # ------------------------------------------------------------------------ #

--- a/python/pyplugin_installer/version_compare.py
+++ b/python/pyplugin_installer/version_compare.py
@@ -31,19 +31,7 @@ and returns integer value:
 
 -----------------------------------------------------------------------------
 HOW DOES IT WORK...
-First, both arguments are converted to uppercase Unicode and stripped of
-'VERSION' or 'VER.' prefix. Then they are chopped into a list of particular
-numeric and alphabetic elements. The dots, dashes and underlines are recognized
-as delimiters. Also numbers and non numbers are separated. See example below:
-
-'Ver 0.03-120_rc7foo' is converted to ['0','03','120','RC','7','FOO']
-
-Then every pair of elements, from left to right, is compared as string
-or as number to provide the best result (you know, 11>9 but also '03'>'007').
-The comparing stops when one of elements is greater. If comparing achieves
-the end of the shorter list and the matter is still unresolved, the longer
-list is usually recognized as higher, except following suffixes:
-ALPHA, BETA, RC, PREVIEW and TRUNK which make the version number lower.
+It relies on packaging.version and PEP440 for version comparisons
 """
 
 import re
@@ -56,37 +44,15 @@ from qgis.core import Qgis
 
 def normalizeVersion(s):
     """remove possible prefix from given string and convert to uppercase"""
-
-    prefixes = [
-        "VERSION",
-        "VER.",
-        "VER",
-        "V.",
-        "V",
-        "REVISION",
-        "REV.",
-        "REV",
-        "R.",
-        "R",
-    ]
-    if not s:
+    try:
+        return Version(s).public
+    except InvalidVersion:
         return ""
-    s = str(s).upper()
-    for i in prefixes:
-        if s[: len(i)] == i:
-            s = s.replace(i, "")
-    s = s.strip()
-    return s
 
 
 # ------------------------------------------------------------------------ #
 def compareVersions(a, b):
     """Compare two version numbers. Return 0 if a==b or error, 1 if a>b and 2 if b>a"""
-    if not a or not b:
-        return 0
-    a = normalizeVersion(a)
-    b = normalizeVersion(b)
-
     try:
         # PEP 440 comparison
         va, vb = Version(a), Version(b)
@@ -98,6 +64,8 @@ def compareVersions(a, b):
             return 0
     except InvalidVersion:
         # blunt str comparison
+        a = normalizeVersion(a)
+        b = normalizeVersion(b)
         if a < b:
             return 2
         elif a > b:
@@ -106,63 +74,12 @@ def compareVersions(a, b):
             return 0
 
 
-"""
-COMPARE CURRENT QGIS VERSION WITH qgisMinimumVersion AND qgisMaximumVersion
-ALLOWED FORMATS ARE: major.minor OR major.minor.bugfix, where each segment must be 0..99
-"""
-
-
-def splitVersion(s):
-    """split string into 2 or 3 numerical segments"""
-    if not s or type(s) is not str:
-        return None
-    l = str(s).split(".")
-    for c in l:
-        if not c.isnumeric():
-            return None
-        if int(c) > 99:
-            return None
-    if len(l) not in [2, 3]:
-        return None
-    return l
-
-
 def isCompatible(curVer, minVer, maxVer):
-    """Compare current QGIS version with qgisMinVersion and qgisMaxVersion"""
+    """Check if minVer <= curVer <= maxVer"""
 
-    if not minVer or not curVer or not maxVer:
-        return False
-
-    minVer = splitVersion(re.sub(r"[^0-9.]+", "", minVer))
-    maxVer = splitVersion(re.sub(r"[^0-9.]+", "", maxVer))
-    curVer = splitVersion(re.sub(r"[^0-9.]+", "", curVer))
-
-    if not minVer or not curVer or not maxVer:
-        return False
-
-    if len(minVer) < 3:
-        minVer += ["0"]
-
-    if len(curVer) < 3:
-        curVer += ["0"]
-
-    if len(maxVer) < 3:
-        maxVer += ["99"]
-
-    minVer = f"{int(minVer[0]):04n}{int(minVer[1]):04n}{int(minVer[2]):04n}"
-    maxVer = f"{int(maxVer[0]):04n}{int(maxVer[1]):04n}{int(maxVer[2]):04n}"
-    curVer = f"{int(curVer[0]):04n}{int(curVer[1]):04n}{int(curVer[2]):04n}"
-
-    return minVer <= curVer and maxVer >= curVer
+    return compareVersions(curVer, minVer) < 2 and compareVersions(maxVer, curVer) < 2
 
 
-def pyQgisVersion():
-    """Return current QGIS version number as X.Y.Z for testing plugin compatibility.
-    If Y = 99, bump up to (X+1.0.0), so e.g. 2.99 becomes 3.0.0
-    This way QGIS X.99 is only compatible with plugins for the upcoming major release.
-    """
-    x, y, z = re.findall(r"^(\d*).(\d*).(\d*)", Qgis.QGIS_VERSION)[0]
-    if y == "99":
-        x = str(int(x) + 1)
-        y = z = "0"
-    return f"{x}.{y}.{z}"
+def pyQgisVersion() -> str:
+    """Return current QGIS version number."""
+    return Version(Qgis.QGIS_VERSION.split("-", 1)[0]).public

--- a/python/pyplugin_installer/version_compare.py
+++ b/python/pyplugin_installer/version_compare.py
@@ -17,9 +17,7 @@
  *                                                                         *
  ***************************************************************************/
 
-Here is Python function for comparing version numbers. It's case insensitive
-and recognizes all major notations, prefixes (ver. and version), delimiters
-(. - and _) and suffixes (alpha, beta, rc, preview and trunk).
+Here is Python function for comparing version numbers.
 
 Usage: compareVersions(version1, version2)
 
@@ -30,8 +28,19 @@ and returns integer value:
 2 - version 2 is higher
 
 -----------------------------------------------------------------------------
-HOW DOES IT WORK...
-It relies on packaging.version and PEP440 for version comparisons
+
+It relies on packaging.version and PEP440 for version comparisons,
+in a nutshell, this relies on the following scheme (PEP440):
+        `[N!]N(.N)*[{a|b|rc}N][.postN][.devN]`
+
+we also tweaked a more permissive regexp for backward compatibility:
+    - case insensitive
+    - allow `alpha`, `beta` in full wording
+    - works with `[+local]` segment version instead of `[-local]`
+
+see :
+    https://packaging.pypa.io/en/stable/version.html
+    https://peps.python.org/pep-0440/
 """
 
 import re

--- a/python/pyplugin_installer/version_compare.py
+++ b/python/pyplugin_installer/version_compare.py
@@ -49,8 +49,10 @@ def normalizeVersion(s):
     except InvalidVersion:
         # handles bit more things than packaging:
         #   like "ver. 1.0-201609011405-2690BD9"
-        pattern = r"^(?P<epoch>\D+)?(?P<version>(?P<release>\d+(?:\.\d+)*)(?P<pre>(?:a|alpha|b|beta|rc)\d+?)?((?P<post>\.post\d+))?(?P<dev>\.dev\d+)?)(?P<build>\+|-\S+)?$"
-        m = re.match(pattern, s.lower())
+        pattern = re.compile(
+            r"^(?P<epoch>\D+)?(?P<version>(?P<release>\d+(?:\.\d+)*)(?P<pre>(?:a|alpha|b|beta|rc)\d+?)?((?P<post>\.post\d+))?(?P<dev>\.dev\d+)?)(?P<build>\+|-\S+)?$"
+        )
+        m = pattern.match(s.lower())
         if not m:
             return ""
         return Version(


### PR DESCRIPTION
Adresses the issue https://github.com/qgis/QGIS/issues/63672  

## Description

Fixes the plugin manager failing to detect available upgrades when a custom repository lists multiple compatible versions of the same plugin in its XML response.

### Problem

When a repository XML file contains more than one entry for the same plugin (e.g. versions 0.1 and 0.2 both compatible with the running QGIS version), `Plugins.rebuild()` would unconditionally overwrite version-related fields on every iteration over the repo cache. The final detected version — and therefore the computed status (`upgradeable`, `installed`, etc.) — depended entirely on the order of entries in the XML rather than which version was actually the highest.

For example, given MyPlugin 0.2 listed before MyPlugin 0.1, with 0.1 currently installed:
- iteration 1 correctly sets `version_available_stable = 0.2` → status `upgradeable`
- iteration 2 overwrites `version_available_stable = 0.1` → status `installed`

The available upgrade was silently lost.

This behaviour affects any custom repository that returns multiple versions of the same plugin — a use case that is not prohibited by the plugin XML specification.

### Fix

In the merge block inside `Plugins.rebuild()` that updates an already-present `mPlugins` entry with remote metadata, the attribute update logic is split into two categories:

- **Non-version metadata** (`name`, `author_name`, `tags`, `homepage`, `tracker`, etc.) continues to be unconditionally overwritten by remote data, preserving existing behaviour.
- **Version-specific fields** (`version_available_stable`, `version_available_experimental`, `download_url_stable`, `download_url_experimental`, `filename`, date fields, etc.) are now only overwritten when `compareVersions()` confirms the incoming version is strictly higher than what is already stored. This check is performed independently for the stable and experimental tracks.

This guarantees that the highest available version always wins regardless of XML entry order, and that the subsequent status computation (`upgradeable`, `installed`, `newer`, etc.) always operates on correct data.

Fixes #63672

## AI tool usage
- [x] AI tool(s) (Claude 4.6, chat only, no code/IDE integrated stuff) supported the development of this PR (the split mecanism of `rebuild()` and fairly, wrote this PR message). Implementations were prompt guided and the code was reviewed by a human (the author of this PR).