### PR TITLE
Show dialog on in-place algorithm without parameters on start via locator

### DIFF
--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -233,38 +233,16 @@ class InPlaceAlgorithmLocatorFilter(QgsLocatorFilter):
             dlg.exec()
             return
 
-        in_place_input_parameter_name = "INPUT"
-        if hasattr(alg, "inputParameterName"):
-            in_place_input_parameter_name = alg.inputParameterName()
-
-        if [
-            d
-            for d in alg.parameterDefinitions()
-            if d.name() not in (in_place_input_parameter_name, "OUTPUT")
-        ]:
-            dlg = alg.createCustomParametersWidget(parent=iface.mainWindow())
-            if not dlg:
-                dlg = AlgorithmDialog(alg, True, parent=iface.mainWindow())
-            canvas = iface.mapCanvas()
-            prevMapTool = canvas.mapTool()
-            dlg.show()
-            dlg.exec()
-            if canvas.mapTool() != prevMapTool:
-                try:
-                    canvas.mapTool().reset()
-                except:
-                    pass
-                canvas.setMapTool(prevMapTool)
-        else:
-            feedback = MessageBarProgress(algname=alg.displayName())
-            parameters = {}
-            ok, results = execute_in_place(alg, parameters, feedback=feedback)
-            if ok:
-                iface.messageBar().pushSuccess(
-                    "",
-                    self.tr(
-                        "{algname} completed. %n feature(s) processed.",
-                        n=results["__count"],
-                    ).format(algname=alg.displayName()),
-                )
-            feedback.close()
+        dlg = alg.createCustomParametersWidget(parent=iface.mainWindow())
+        if not dlg:
+            dlg = AlgorithmDialog(alg, True, parent=iface.mainWindow())
+        canvas = iface.mapCanvas()
+        prevMapTool = canvas.mapTool()
+        dlg.show()
+        dlg.exec()
+        if canvas.mapTool() != prevMapTool:
+            try:
+                canvas.mapTool().reset()
+            except:
+                pass
+            canvas.setMapTool(prevMapTool)

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -41,6 +41,7 @@ from qgis.gui import (
     QgsProcessingParametersWidget,
     QgsProcessingParameterWidgetContext,
 )
+from qgis.PyQt.QtWidgets import QLabel, QSizePolicy, QVBoxLayout, QWidget
 from qgis.utils import iface
 
 from processing.gui.AlgorithmDialogBase import AlgorithmDialogBase
@@ -52,6 +53,7 @@ class ParametersPanel(QgsProcessingParametersWidget):
     def __init__(self, parent, alg, in_place=False, active_layer=None):
         super().__init__(alg, parent)
         self.in_place = in_place
+
         self.active_layer = active_layer
 
         self.wrappers = {}
@@ -99,6 +101,24 @@ class ParametersPanel(QgsProcessingParametersWidget):
         in_place_input_parameter_name = "INPUT"
         if hasattr(self.algorithm(), "inputParameterName"):
             in_place_input_parameter_name = self.algorithm().inputParameterName()
+
+        # If there are no parameters to show because it's in-place, we add the info label.
+        # Still, it needs the following steps to create the parameter widgets (even when hidden).
+        if self.in_place and not [
+            d
+            for d in self.algorithm().parameterDefinitions()
+            if d.name() not in (in_place_input_parameter_name, "OUTPUT")
+        ]:
+            widget = QWidget(self)
+            layout = QVBoxLayout(widget)
+            label = QLabel(widget)
+            label.setWordWrap(True)
+            label.setText(
+                f"<i>{self.tr('No additional parameters are required. This algorithm will activate edit mode and modify the features in place.')}</i>"
+            )
+            layout.addWidget(label)
+            layout.addStretch()
+            self.addExtraWidget(widget)
 
         # Create widgets and put them in layouts
         for param in self.algorithm().parameterDefinitions():

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -113,9 +113,10 @@ class ParametersPanel(QgsProcessingParametersWidget):
             layout = QVBoxLayout(widget)
             label = QLabel(widget)
             label.setWordWrap(True)
-            label.setText(
-                f"<i>{self.tr('No additional parameters are required. This algorithm will activate edit mode and modify the features in place.')}</i>"
-            )
+            info_text = self.tr(
+                "<i>No additional parameters are required. This algorithm will activate edit mode and modify the features on layer <b>{layername}</b> in place.</i>"
+            ).format(layername=self.active_layer.name())
+            label.setText(info_text)
             layout.addWidget(label)
             layout.addStretch()
             self.addExtraWidget(widget)


### PR DESCRIPTION
The dialog of the in-place algorithm used to be suppressed when there were no additional parameters.

It's still the case when started via toolbox.

But, when started via the locator, it now shows the dialog again (to avoid unintended data corruption).

Additionally, it shows a label in the "empty" dialog to inform the user.

<img width="796" height="573" alt="image" src="https://github.com/user-attachments/assets/0bbc3ba9-d44a-4b31-80cc-5a55d62ca828" />

This is a slim and efficient solution of the issue #65156


### Sponsor

[The Canton of Solothurn](https://so.ch/verwaltung/bau-und-justizdepartement/amt-fuer-geoinformation)
