### PR TITLE
Backport 65498 to release 3 44

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -2048,6 +2048,51 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     }
   }
 
+  if ( jsonLayout.contains( u"symbol-spacing"_s ) )
+  {
+    double spacing;
+    const QVariant jsonSpacing = jsonLayout.value( u"symbol-spacing"_s );
+
+    // main checkbox in labeling GUI
+    QgsLabelThinningSettings thinningSettings = labelSettings.thinningSettings();
+    thinningSettings.setAllowDuplicateRemoval( true );
+    labelSettings.setThinningSettings( thinningSettings );
+
+    QgsProperty spacingProp;
+
+    switch ( jsonSpacing.userType() )
+    {
+      case QMetaType::Type::Int:
+      case QMetaType::Type::LongLong:
+      case QMetaType::Type::Double:
+      {
+        spacing = jsonSpacing.toDouble() * context.pixelSizeConversionFactor();
+        spacingProp = QgsProperty::fromValue( spacing );
+        break;
+      }
+
+      case QMetaType::Type::QVariantMap:
+      {
+        spacingProp = parseInterpolateByZoom( jsonSpacing.toMap(), context, context.pixelSizeConversionFactor(), &spacing );
+        break;
+      }
+
+      case QMetaType::Type::QVariantList:
+      case QMetaType::Type::QStringList:
+      {
+        spacingProp = parseValueList( jsonSpacing.toList(), PropertyType::Numeric, context, context.pixelSizeConversionFactor(), 255, nullptr, &spacing );
+        break;
+      }
+
+      default:
+        context.pushWarning( QObject::tr( "%1: Skipping unsupported symbol-spacing type (%2)" ).arg( context.layerId(), QMetaType::typeName( static_cast<QMetaType::Type>( jsonSpacing.userType() ) ) ) );
+        break;
+    }
+
+    spacingProp.setActive( true );
+    ddLabelProperties.setProperty( QgsPalLayerSettings::Property::RemoveDuplicateLabels, spacingProp );
+  }
+
   if ( textSize >= 0 )
   {
     // TODO -- this probably needs revisiting -- it was copied from the MapTiler code, but may be wrong...

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -2048,10 +2048,10 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     }
   }
 
-  if ( jsonLayout.contains( u"symbol-spacing"_s ) )
+  if ( jsonLayout.contains( QStringLiteral( "symbol-spacing" ) ) )
   {
     double spacing;
-    const QVariant jsonSpacing = jsonLayout.value( u"symbol-spacing"_s );
+    const QVariant jsonSpacing = jsonLayout.value( QStringLiteral( "symbol-spacing" ) );
 
     // main checkbox in labeling GUI
     QgsLabelThinningSettings thinningSettings = labelSettings.thinningSettings();

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -2056,6 +2056,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     // main checkbox in labeling GUI
     QgsLabelThinningSettings thinningSettings = labelSettings.thinningSettings();
     thinningSettings.setAllowDuplicateRemoval( true );
+    thinningSettings.setMinimumDistanceToDuplicateUnit( Qgis::RenderUnit::Pixels );
     labelSettings.setThinningSettings( thinningSettings );
 
     QgsProperty spacingProp;

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -2090,7 +2090,7 @@ void QgsMapBoxGlStyleConverter::parseSymbolLayer( const QVariantMap &jsonLayer, 
     }
 
     spacingProp.setActive( true );
-    ddLabelProperties.setProperty( QgsPalLayerSettings::Property::RemoveDuplicateLabels, spacingProp );
+    ddLabelProperties.setProperty( QgsPalLayerSettings::Property::RemoveDuplicateLabelDistance, spacingProp );
   }
 
   if ( textSize >= 0 )

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -2840,6 +2840,94 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         expected = "CASE WHEN \"class\" IN ('sinkhole') THEN 'base64:[snip]' WHEN \"class\" IN ('sinkhole_rock','sinkhole_scree') THEN 'base64:[snip]' WHEN \"class\" IN ('sinkhole_ice','sinkhole_water') THEN 'base64:[snip]' ELSE '' END"
         self.assertEqual(strip_base64(sprite_property), expected)
 
+    def testSymbolSpacingNumeric(self):
+        """Test symbol-spacing with a simple numeric value"""
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "layout": {
+                "text-field": "{name}",
+                "text-size": 12,
+                "symbol-spacing": 250,
+            },
+            "type": "symbol",
+            "id": "poi_label",
+            "paint": {
+                "text-color": "#666",
+            },
+            "source-layer": "poi_label",
+        }
+        renderer, has_renderer, labeling, has_labeling = (
+            QgsMapBoxGlStyleConverter.parseSymbolLayer(style, context)
+        )
+        self.assertTrue(has_labeling)
+        ls = labeling.labelSettings()
+        dd = ls.dataDefinedProperties()
+        prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabels)
+        self.assertTrue(prop.isActive())
+        self.assertEqual(prop.asExpression(), "250")
+
+    def testSymbolSpacingList(self):
+        """Test symbol-spacing with interpolate stops"""
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "layout": {
+                "text-field": "{name}",
+                "text-size": 12,
+                "symbol-spacing": ["step", ["zoom"], 300, 10, 600, 14, 800],
+            },
+            "type": "symbol",
+            "id": "poi_label",
+            "paint": {
+                "text-color": "#666",
+            },
+            "source-layer": "poi_label",
+        }
+        renderer, has_renderer, labeling, has_labeling = (
+            QgsMapBoxGlStyleConverter.parseSymbolLayer(style, context)
+        )
+        self.assertTrue(has_labeling)
+        ls = labeling.labelSettings()
+        dd = ls.dataDefinedProperties()
+        prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabels)
+        self.assertTrue(prop.isActive())
+        self.assertEqual(
+            prop.asExpression(),
+            "CASE  WHEN @vector_tile_zoom >= 14 THEN (800)  WHEN @vector_tile_zoom >= 10 THEN (600) ELSE (300) END",
+        )
+
+    def testSymbolSpacingMap(self):
+        """Test symbol-spacing with a QVariantMap stops definition"""
+        context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "layout": {
+                "text-field": "{name}",
+                "text-size": 12,
+                "symbol-spacing": {"stops": [[2, 0.2], [6, 0]]},
+            },
+            "type": "symbol",
+            "id": "poi_label",
+            "paint": {
+                "text-color": "#666",
+            },
+            "source-layer": "poi_label",
+        }
+
+        renderer, has_renderer, labeling, has_labeling = (
+            QgsMapBoxGlStyleConverter.parseSymbolLayer(style, context)
+        )
+        self.assertFalse(has_renderer)
+        self.assertTrue(has_labeling)
+
+        ls = labeling.labelSettings()
+        dd = ls.dataDefinedProperties()
+        prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabels)
+
+        self.assertTrue(prop.isActive())
+        self.assertEqual(
+            prop.asExpression(),
+            "scale_linear(@vector_tile_zoom,2,6,0.2,0)",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -2862,7 +2862,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         self.assertTrue(has_labeling)
         ls = labeling.labelSettings()
         dd = ls.dataDefinedProperties()
-        prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabels)
+        prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabelDistance)
         self.assertTrue(prop.isActive())
         self.assertEqual(prop.asExpression(), "250")
 
@@ -2888,7 +2888,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         self.assertTrue(has_labeling)
         ls = labeling.labelSettings()
         dd = ls.dataDefinedProperties()
-        prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabels)
+        prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabelDistance)
         self.assertTrue(prop.isActive())
         self.assertEqual(
             prop.asExpression(),
@@ -2920,7 +2920,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
 
         ls = labeling.labelSettings()
         dd = ls.dataDefinedProperties()
-        prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabels)
+        prop = dd.property(QgsPalLayerSettings.Property.RemoveDuplicateLabelDistance)
 
         self.assertTrue(prop.isActive())
         self.assertEqual(


### PR DESCRIPTION
## Description

Backport https://github.com/qgis/QGIS/pull/65498, supersedes #65559.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
