### PR TITLE
regroup common vector chunked entity logic in a base class

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -7,6 +7,7 @@ set(QGIS_3D_SRCS
   qgs3daxissettings.cpp
   qgsaabb.cpp
   qgsabstract3dengine.cpp
+  qgsabstractfeaturebasedchunkedentity.cpp
   qgsabstractvectorlayer3drenderer.cpp
   qgsannotationlayer3drenderer.cpp
   qgsannotationlayerchunkloader_p.cpp
@@ -166,6 +167,7 @@ set(QGIS_3D_HDRS
   qgs3dwiredmesh_p.h
   qgsaabb.h
   qgsabstract3dengine.h
+  qgsabstractfeaturebasedchunkedentity.h
   qgsabstractvectorlayer3drenderer.h
   qgsannotationlayer3drenderer.h
   qgsannotationlayerchunkloader_p.h

--- a/src/3d/qgsabstractfeaturebasedchunkedentity.cpp
+++ b/src/3d/qgsabstractfeaturebasedchunkedentity.cpp
@@ -1,0 +1,144 @@
+/***************************************************************************
+  qgsabstractfeaturebasedchunkedentity.cpp
+  --------------------------------------
+  Date                 : March 2026
+  Copyright            : (C) 2026 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsabstractfeaturebasedchunkedentity.h"
+
+#include "qgs3dmapsettings.h"
+#include "qgs3dutils.h"
+#include "qgschunknode.h"
+#include "qgsfeatureid.h"
+#include "qgsgeotransform.h"
+#include "qgsraycastcontext.h"
+#include "qgsraycastingutils.h"
+#include "qgstessellatedpolygongeometry.h"
+
+#include <QString>
+#include <Qt3DCore/QTransform>
+#include <Qt3DRender/QGeometryRenderer>
+
+#include "moc_qgsabstractfeaturebasedchunkedentity.cpp"
+
+using namespace Qt::StringLiterals;
+
+///@cond PRIVATE
+
+QgsAbstractFeatureBasedChunkedEntity::QgsAbstractFeatureBasedChunkedEntity(
+  Qgs3DMapSettings *mapSettings, float tau, QgsChunkLoaderFactory *loaderFactory, bool ownsFactory, int primitivesBudget, Qt3DCore::QNode *parent
+)
+  : QgsChunkedEntity( mapSettings, tau, loaderFactory, ownsFactory, primitivesBudget, parent )
+{
+  mTransform = new Qt3DCore::QTransform;
+  this->addComponent( mTransform );
+
+  connect( mapSettings, &Qgs3DMapSettings::terrainSettingsChanged, this, &QgsAbstractFeatureBasedChunkedEntity::onTerrainElevationOffsetChanged );
+}
+
+void QgsAbstractFeatureBasedChunkedEntity::onTerrainElevationOffsetChanged()
+{
+  QgsDebugMsgLevel( u"QgsAbstractFeatureBasedChunkedEntity::onTerrainElevationOffsetChanged"_s, 2 );
+
+  float newOffset = static_cast<float>( mMapSettings->terrainSettings()->elevationOffset() );
+  if ( !applyTerrainOffset() )
+  {
+    newOffset = 0.0;
+  }
+  mTransform->setTranslation( QVector3D( 0.0f, 0.0f, newOffset ) );
+}
+
+QList<QgsRayCastHit> QgsAbstractFeatureBasedChunkedEntity::rayIntersection( const QgsRay3D &ray, const QgsRayCastContext &context ) const
+{
+  return rayIntersection( activeNodes(), mTransform->matrix(), ray, context, mMapSettings->origin() );
+}
+
+QList<QgsRayCastHit> QgsAbstractFeatureBasedChunkedEntity::rayIntersection(
+  const QList<QgsChunkNode *> &activeNodes, const QMatrix4x4 &transformMatrix, const QgsRay3D &ray, const QgsRayCastContext &context, const QgsVector3D &origin
+) const
+{
+  QgsDebugMsgLevel( u"Ray cast on vector layer"_s, 2 );
+#ifdef QGISDEBUG
+  int nodeUsed = 0;
+  int nodesAll = 0;
+  int hits = 0;
+  int ignoredGeometries = 0;
+#endif
+  QList<QgsRayCastHit> result;
+
+  float minDist = -1;
+  QVector3D intersectionPoint;
+  QgsFeatureId nearestFid = FID_NULL;
+
+  for ( QgsChunkNode *node : activeNodes )
+  {
+#ifdef QGISDEBUG
+    nodesAll++;
+#endif
+
+    QgsAABB nodeBbox = Qgs3DUtils::mapToWorldExtent( node->box3D(), origin );
+
+    if ( node->entity() && ( minDist < 0 || nodeBbox.distanceFromPoint( ray.origin() ) < minDist ) && QgsRayCastingUtils::rayBoxIntersection( ray, nodeBbox ) )
+    {
+#ifdef QGISDEBUG
+      nodeUsed++;
+#endif
+      const QList<Qt3DRender::QGeometryRenderer *> rendLst = node->entity()->findChildren<Qt3DRender::QGeometryRenderer *>();
+      for ( const auto &rend : rendLst )
+      {
+        auto *geom = rend->geometry();
+        QgsTessellatedPolygonGeometry *polygonGeom = qobject_cast<QgsTessellatedPolygonGeometry *>( geom );
+        if ( !polygonGeom )
+        {
+#ifdef QGISDEBUG
+          ignoredGeometries++;
+#endif
+          continue; // other QGeometry types are not supported for now
+        }
+
+        QVector3D nodeIntPoint;
+        int triangleIndex = -1;
+
+        // the node geometry has been translated by chunkOrigin
+        // This translation is stored in the QTransform component
+        // this needs to be taken into account to get the whole transformation
+        const QMatrix4x4 nodeTransformMatrix = node->entity()->findChild<QgsGeoTransform *>()->matrix();
+        const QMatrix4x4 fullTransformMatrix = transformMatrix * nodeTransformMatrix;
+        if ( QgsRayCastingUtils::rayMeshIntersection( rend, ray, context.maximumDistance(), fullTransformMatrix, nodeIntPoint, triangleIndex ) )
+        {
+#ifdef QGISDEBUG
+          hits++;
+#endif
+          float dist = ( ray.origin() - nodeIntPoint ).length();
+          if ( minDist < 0 || dist < minDist )
+          {
+            minDist = dist;
+            intersectionPoint = nodeIntPoint;
+            nearestFid = polygonGeom->triangleIndexToFeatureId( triangleIndex );
+          }
+        }
+      }
+    }
+  }
+  if ( !FID_IS_NULL( nearestFid ) )
+  {
+    QgsRayCastHit hit;
+    hit.setDistance( minDist );
+    hit.setMapCoordinates( Qgs3DUtils::worldToMapCoordinates( intersectionPoint, origin ) );
+    hit.setProperties( { { u"fid"_s, nearestFid } } );
+    result.append( hit );
+  }
+  QgsDebugMsgLevel( u"Active Nodes: %1, checked nodes: %2, hits found: %3, incompatible geometries: %4"_s.arg( nodesAll ).arg( nodeUsed ).arg( hits ).arg( ignoredGeometries ), 2 );
+  return result;
+}
+
+/// @endcond

--- a/src/3d/qgsabstractfeaturebasedchunkedentity.h
+++ b/src/3d/qgsabstractfeaturebasedchunkedentity.h
@@ -1,0 +1,74 @@
+/***************************************************************************
+  qgsabstractfeaturebasedchunkedentity.h
+  --------------------------------------
+  Date                 : March 2026
+  Copyright            : (C) 2026 by Jean Felder
+  Email                : jean dot felder at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSABSTRACTFEATUREBASEDCHUNKEDENTITY_H
+#define QGSABSTRACTFEATUREBASEDCHUNKEDENTITY_H
+
+#include "qgis_3d.h"
+
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the QGIS API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+
+#include "qgschunkedentity.h"
+
+namespace Qt3DCore
+{
+  class QTransform;
+}
+
+/**
+ * Abstract base class for handling common logic of chunked entities in vector layers and annotations.
+ *
+ * \since QGIS 4.2
+ */
+class _3D_EXPORT QgsAbstractFeatureBasedChunkedEntity : public QgsChunkedEntity
+{
+    Q_OBJECT
+
+  public:
+    //! Constructs the entity.
+    QgsAbstractFeatureBasedChunkedEntity(
+      Qgs3DMapSettings *mapSettings, float tau, QgsChunkLoaderFactory *loaderFactory, bool ownsFactory, int primitivesBudget = std::numeric_limits<int>::max(), Qt3DCore::QNode *parent = nullptr
+    );
+
+    QList<QgsRayCastHit> rayIntersection( const QgsRay3D &ray, const QgsRayCastContext &context ) const override;
+
+  protected slots:
+    void onTerrainElevationOffsetChanged();
+
+  private:
+    //! Returns whether terrain offset should be applied based on the layer's altitude clamping mode.
+    virtual bool applyTerrainOffset() const = 0;
+
+    //! Performs ray casting against active nodes and returns the nearest hit.
+    QList<QgsRayCastHit> rayIntersection( const QList<QgsChunkNode *> &activeNodes, const QMatrix4x4 &transformMatrix, const QgsRay3D &ray, const QgsRayCastContext &context, const QgsVector3D &origin ) const;
+
+  private:
+    Qt3DCore::QTransform *mTransform = nullptr;
+};
+
+/// @endcond
+
+#endif // QGSABSTRACTFEATUREBASEDCHUNKEDENTITY_H

--- a/src/3d/qgsannotationlayerchunkloader_p.cpp
+++ b/src/3d/qgsannotationlayerchunkloader_p.cpp
@@ -595,21 +595,14 @@ QgsAnnotationLayerChunkedEntity::QgsAnnotationLayerChunkedEntity(
   double zMin,
   double zMax
 )
-  : QgsChunkedEntity(
+  : QgsAbstractFeatureBasedChunkedEntity(
       map,
       -1, // max. allowed screen error (negative tau means that we need to go until leaves are reached)
       new QgsAnnotationLayerChunkLoaderFactory( Qgs3DRenderContext::fromMapSettings( map ), layer, 3, clamping, zOffset, showCallouts, calloutLineColor, calloutLineWidth, textFormat, zMin, zMax ),
       true
     )
 {
-  mTransform = new Qt3DCore::QTransform;
-  if ( applyTerrainOffset() )
-  {
-    mTransform->setTranslation( QVector3D( 0.0f, 0.0f, static_cast<float>( map->terrainSettings()->elevationOffset() ) ) );
-  }
-  this->addComponent( mTransform );
-
-  connect( map, &Qgs3DMapSettings::terrainSettingsChanged, this, &QgsAnnotationLayerChunkedEntity::onTerrainElevationOffsetChanged );
+  onTerrainElevationOffsetChanged();
 }
 
 QgsAnnotationLayerChunkedEntity::~QgsAnnotationLayerChunkedEntity()
@@ -628,15 +621,11 @@ bool QgsAnnotationLayerChunkedEntity::applyTerrainOffset() const
   return true;
 }
 
-void QgsAnnotationLayerChunkedEntity::onTerrainElevationOffsetChanged()
+QList<QgsRayCastHit> QgsAnnotationLayerChunkedEntity::rayIntersection( const QgsRay3D &ray, const QgsRayCastContext &context ) const
 {
-  QgsDebugMsgLevel( u"QgsAnnotationLayerChunkedEntity::onTerrainElevationOffsetChanged"_s, 2 );
-  float newOffset = static_cast<float>( qobject_cast<Qgs3DMapSettings *>( sender() )->terrainSettings()->elevationOffset() );
-  if ( !applyTerrainOffset() )
-  {
-    newOffset = 0.0;
-  }
-  mTransform->setTranslation( QVector3D( 0.0f, 0.0f, newOffset ) );
+  Q_UNUSED( ray )
+  Q_UNUSED( context )
+  return {};
 }
 
 

--- a/src/3d/qgsannotationlayerchunkloader_p.h
+++ b/src/3d/qgsannotationlayerchunkloader_p.h
@@ -28,8 +28,8 @@
 //
 
 #include "qgs3drendercontext.h"
+#include "qgsabstractfeaturebasedchunkedentity.h"
 #include "qgsbillboardgeometry.h"
-#include "qgschunkedentity.h"
 #include "qgschunkloader.h"
 #include "qgstextformat.h"
 
@@ -139,7 +139,7 @@ class QgsAnnotationLayerChunkLoader : public QgsChunkLoader
  *
  * \since QGIS 4.0
  */
-class QgsAnnotationLayerChunkedEntity : public QgsChunkedEntity
+class QgsAnnotationLayerChunkedEntity : public QgsAbstractFeatureBasedChunkedEntity
 {
     Q_OBJECT
   public:
@@ -158,15 +158,10 @@ class QgsAnnotationLayerChunkedEntity : public QgsChunkedEntity
     );
     ~QgsAnnotationLayerChunkedEntity() override;
 
-  private slots:
-    void onTerrainElevationOffsetChanged();
+    QList<QgsRayCastHit> rayIntersection( const QgsRay3D &ray, const QgsRayCastContext &context ) const override;
 
   private:
-    Qt3DCore::QTransform *mTransform = nullptr;
-
-    bool applyTerrainOffset() const;
-
-    friend class TestQgsChunkedEntity;
+    bool applyTerrainOffset() const override;
 };
 
 /// @endcond

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -231,16 +231,9 @@ QVector<QgsChunkNode *> QgsRuleBasedChunkLoaderFactory::createChildren( QgsChunk
 QgsRuleBasedChunkedEntity::QgsRuleBasedChunkedEntity(
   Qgs3DMapSettings *map, QgsVectorLayer *vl, double zMin, double zMax, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsRuleBased3DRenderer::Rule *rootRule
 )
-  : QgsChunkedEntity( map, 3, new QgsRuleBasedChunkLoaderFactory( Qgs3DRenderContext::fromMapSettings( map ), vl, rootRule, zMin, zMax, tilingSettings.maximumChunkFeatures() ), true )
+  : QgsAbstractFeatureBasedChunkedEntity( map, 3, new QgsRuleBasedChunkLoaderFactory( Qgs3DRenderContext::fromMapSettings( map ), vl, rootRule, zMin, zMax, tilingSettings.maximumChunkFeatures() ), true )
 {
-  mTransform = new Qt3DCore::QTransform;
-  if ( applyTerrainOffset() )
-  {
-    mTransform->setTranslation( QVector3D( 0.0f, 0.0f, static_cast<float>( map->terrainSettings()->elevationOffset() ) ) );
-  }
-  this->addComponent( mTransform );
-  connect( map, &Qgs3DMapSettings::terrainSettingsChanged, this, &QgsRuleBasedChunkedEntity::onTerrainElevationOffsetChanged );
-
+  onTerrainElevationOffsetChanged();
   setShowBoundingBoxes( tilingSettings.showBoundingBoxes() );
 }
 
@@ -298,18 +291,4 @@ bool QgsRuleBasedChunkedEntity::applyTerrainOffset() const
   return true;
 }
 
-void QgsRuleBasedChunkedEntity::onTerrainElevationOffsetChanged()
-{
-  float newOffset = static_cast<float>( qobject_cast<Qgs3DMapSettings *>( sender() )->terrainSettings()->elevationOffset() );
-  if ( !applyTerrainOffset() )
-  {
-    newOffset = 0.0;
-  }
-  mTransform->setTranslation( QVector3D( 0.0f, 0.0f, newOffset ) );
-}
-
-QList<QgsRayCastHit> QgsRuleBasedChunkedEntity::rayIntersection( const QgsRay3D &ray, const QgsRayCastContext &context ) const
-{
-  return QgsVectorLayerChunkedEntity::rayIntersection( activeNodes(), mTransform->matrix(), ray, context, mMapSettings->origin() );
-}
 /// @endcond

--- a/src/3d/qgsrulebasedchunkloader_p.h
+++ b/src/3d/qgsrulebasedchunkloader_p.h
@@ -28,7 +28,7 @@
 //
 
 #include "qgs3drendercontext.h"
-#include "qgschunkedentity.h"
+#include "qgsabstractfeaturebasedchunkedentity.h"
 #include "qgschunkloader.h"
 #include "qgsrulebased3drenderer.h"
 
@@ -121,23 +121,17 @@ class QgsRuleBasedChunkLoader : public QgsChunkLoader
  *
  * \since QGIS 3.12
  */
-class QgsRuleBasedChunkedEntity : public QgsChunkedEntity
+class QgsRuleBasedChunkedEntity : public QgsAbstractFeatureBasedChunkedEntity
 {
     Q_OBJECT
   public:
     //! Constructs the entity. The argument maxLevel determines how deep the tree of tiles will be
     explicit QgsRuleBasedChunkedEntity( Qgs3DMapSettings *map, QgsVectorLayer *vl, double zMin, double zMax, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsRuleBased3DRenderer::Rule *rootRule );
 
-    QList<QgsRayCastHit> rayIntersection( const QgsRay3D &ray, const QgsRayCastContext &context ) const override;
-
     ~QgsRuleBasedChunkedEntity() override;
-  private slots:
-    void onTerrainElevationOffsetChanged();
 
   private:
-    Qt3DCore::QTransform *mTransform = nullptr;
-
-    bool applyTerrainOffset() const;
+    bool applyTerrainOffset() const override;
 };
 
 /// @endcond

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -312,7 +312,6 @@ QList<QgsRayCastHit> QgsVectorLayerChunkedEntity::rayIntersection(
   const QList<QgsChunkNode *> &activeNodes, const QMatrix4x4 &transformMatrix, const QgsRay3D &ray, const QgsRayCastContext &context, const QgsVector3D &origin
 )
 {
-  Q_UNUSED( context )
   QgsDebugMsgLevel( u"Ray cast on vector layer"_s, 2 );
 #ifdef QGISDEBUG
   int nodeUsed = 0;

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -25,15 +25,10 @@
 #include "qgseventtracing.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeature3dhandler_p.h"
-#include "qgsgeotransform.h"
 #include "qgsline3dsymbol.h"
 #include "qgslogger.h"
 #include "qgspoint3dsymbol.h"
 #include "qgspolygon3dsymbol.h"
-#include "qgsray3d.h"
-#include "qgsraycastcontext.h"
-#include "qgsraycastingutils.h"
-#include "qgstessellatedpolygongeometry.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerfeatureiterator.h"
 
@@ -232,17 +227,9 @@ QVector<QgsChunkNode *> QgsVectorLayerChunkLoaderFactory::createChildren( QgsChu
 QgsVectorLayerChunkedEntity::QgsVectorLayerChunkedEntity(
   Qgs3DMapSettings *map, QgsVectorLayer *vl, double zMin, double zMax, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsAbstract3DSymbol *symbol
 )
-  : QgsChunkedEntity( map, 3, new QgsVectorLayerChunkLoaderFactory( Qgs3DRenderContext::fromMapSettings( map ), vl, symbol, zMin, zMax, tilingSettings.maximumChunkFeatures() ), true )
+  : QgsAbstractFeatureBasedChunkedEntity( map, 3, new QgsVectorLayerChunkLoaderFactory( Qgs3DRenderContext::fromMapSettings( map ), vl, symbol, zMin, zMax, tilingSettings.maximumChunkFeatures() ), true )
 {
-  mTransform = new Qt3DCore::QTransform;
-  if ( applyTerrainOffset() )
-  {
-    mTransform->setTranslation( QVector3D( 0.0f, 0.0f, static_cast<float>( map->terrainSettings()->elevationOffset() ) ) );
-  }
-  this->addComponent( mTransform );
-
-  connect( map, &Qgs3DMapSettings::terrainSettingsChanged, this, &QgsVectorLayerChunkedEntity::onTerrainElevationOffsetChanged );
-
+  onTerrainElevationOffsetChanged();
   setShowBoundingBoxes( tilingSettings.showBoundingBoxes() );
 }
 
@@ -290,101 +277,6 @@ bool QgsVectorLayerChunkedEntity::applyTerrainOffset() const
   }
 
   return true;
-}
-
-void QgsVectorLayerChunkedEntity::onTerrainElevationOffsetChanged()
-{
-  QgsDebugMsgLevel( u"QgsVectorLayerChunkedEntity::onTerrainElevationOffsetChanged"_s, 2 );
-  float newOffset = static_cast<float>( qobject_cast<Qgs3DMapSettings *>( sender() )->terrainSettings()->elevationOffset() );
-  if ( !applyTerrainOffset() )
-  {
-    newOffset = 0.0;
-  }
-  mTransform->setTranslation( QVector3D( 0.0f, 0.0f, newOffset ) );
-}
-
-QList<QgsRayCastHit> QgsVectorLayerChunkedEntity::rayIntersection( const QgsRay3D &ray, const QgsRayCastContext &context ) const
-{
-  return QgsVectorLayerChunkedEntity::rayIntersection( activeNodes(), mTransform->matrix(), ray, context, mMapSettings->origin() );
-}
-
-QList<QgsRayCastHit> QgsVectorLayerChunkedEntity::rayIntersection(
-  const QList<QgsChunkNode *> &activeNodes, const QMatrix4x4 &transformMatrix, const QgsRay3D &ray, const QgsRayCastContext &context, const QgsVector3D &origin
-)
-{
-  QgsDebugMsgLevel( u"Ray cast on vector layer"_s, 2 );
-#ifdef QGISDEBUG
-  int nodeUsed = 0;
-  int nodesAll = 0;
-  int hits = 0;
-  int ignoredGeometries = 0;
-#endif
-  QList<QgsRayCastHit> result;
-
-  float minDist = -1;
-  QVector3D intersectionPoint;
-  QgsFeatureId nearestFid = FID_NULL;
-
-  for ( QgsChunkNode *node : activeNodes )
-  {
-#ifdef QGISDEBUG
-    nodesAll++;
-#endif
-
-    QgsAABB nodeBbox = Qgs3DUtils::mapToWorldExtent( node->box3D(), origin );
-
-    if ( node->entity() && ( minDist < 0 || nodeBbox.distanceFromPoint( ray.origin() ) < minDist ) && QgsRayCastingUtils::rayBoxIntersection( ray, nodeBbox ) )
-    {
-#ifdef QGISDEBUG
-      nodeUsed++;
-#endif
-      const QList<Qt3DRender::QGeometryRenderer *> rendLst = node->entity()->findChildren<Qt3DRender::QGeometryRenderer *>();
-      for ( const auto &rend : rendLst )
-      {
-        auto *geom = rend->geometry();
-        QgsTessellatedPolygonGeometry *polygonGeom = qobject_cast<QgsTessellatedPolygonGeometry *>( geom );
-        if ( !polygonGeom )
-        {
-#ifdef QGISDEBUG
-          ignoredGeometries++;
-#endif
-          continue; // other QGeometry types are not supported for now
-        }
-
-        QVector3D nodeIntPoint;
-        int triangleIndex = -1;
-
-        // the node geometry has been translated by chunkOrigin
-        // This translation is stored in the QTransform component
-        // this needs to be taken into account to get the whole transformation
-        const QMatrix4x4 nodeTransformMatrix = node->entity()->findChild<QgsGeoTransform *>()->matrix();
-        const QMatrix4x4 fullTransformMatrix = transformMatrix * nodeTransformMatrix;
-        if ( QgsRayCastingUtils::rayMeshIntersection( rend, ray, context.maximumDistance(), fullTransformMatrix, nodeIntPoint, triangleIndex ) )
-        {
-#ifdef QGISDEBUG
-          hits++;
-#endif
-          float dist = ( ray.origin() - nodeIntPoint ).length();
-          if ( minDist < 0 || dist < minDist )
-          {
-            minDist = dist;
-            intersectionPoint = nodeIntPoint;
-            nearestFid = polygonGeom->triangleIndexToFeatureId( triangleIndex );
-          }
-        }
-      }
-    }
-  }
-  if ( !FID_IS_NULL( nearestFid ) )
-  {
-    QgsRayCastHit hit;
-    hit.setDistance( minDist );
-    hit.setMapCoordinates( Qgs3DUtils::worldToMapCoordinates( intersectionPoint, origin ) );
-    hit.setProperties( { { u"fid"_s, nearestFid } } );
-    result.append( hit );
-  }
-  QgsDebugMsgLevel( u"Active Nodes: %1, checked nodes: %2, hits found: %3, incompatible geometries: %4"_s.arg( nodesAll ).arg( nodeUsed ).arg( hits ).arg( ignoredGeometries ), 2 );
-  return result;
 }
 
 /// @endcond

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -28,7 +28,7 @@
 //
 
 #include "qgs3drendercontext.h"
-#include "qgschunkedentity.h"
+#include "qgsabstractfeaturebasedchunkedentity.h"
 #include "qgschunkloader.h"
 
 #define SIP_NO_FILE
@@ -119,31 +119,17 @@ class QgsVectorLayerChunkLoader : public QgsChunkLoader
  *
  * \since QGIS 3.12
  */
-class QgsVectorLayerChunkedEntity : public QgsChunkedEntity
+class QgsVectorLayerChunkedEntity : public QgsAbstractFeatureBasedChunkedEntity
 {
     Q_OBJECT
   public:
     //! Constructs the entity. The argument maxLevel determines how deep the tree of tiles will be
     explicit QgsVectorLayerChunkedEntity( Qgs3DMapSettings *map, QgsVectorLayer *vl, double zMin, double zMax, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsAbstract3DSymbol *symbol );
 
-    QList<QgsRayCastHit> rayIntersection( const QgsRay3D &ray, const QgsRayCastContext &context ) const override;
-
     ~QgsVectorLayerChunkedEntity() override;
-  private slots:
-    void onTerrainElevationOffsetChanged();
 
   private:
-    friend class QgsRuleBasedChunkedEntity;
-    //! This implementation is shared between QgsVectorLayerChunkedEntity and QgsRuleBasedChunkedEntity
-    static QList<QgsRayCastHit> rayIntersection(
-      const QList<QgsChunkNode *> &activeNodes, const QMatrix4x4 &transformMatrix, const QgsRay3D &ray, const QgsRayCastContext &context, const QgsVector3D &origin
-    );
-
-    Qt3DCore::QTransform *mTransform = nullptr;
-
-    bool applyTerrainOffset() const;
-
-    friend class TestQgsChunkedEntity;
+    bool applyTerrainOffset() const override;
 };
 
 /// @endcond


### PR DESCRIPTION
## Description

`QgsVectorLayerChunkedEntity`, `QgsAnnotationLayerChunkedEntity` and
`QgsRuleBasedChunkedEntity` share a lot of code and logic:
- `mTransform`
- `rayIntersection`
- offset elevation change

Move all this logic into a new parent class which inherits from
QgsChunkedEntity: `QgsAbstractVectorLayerChunkedEntity`. This allows
to remove duplicate code and simplify the offset and rayintersection
logic for vector layers.

## AI tool usage

 - No AI Tool used
 