### PR TITLE
Pass non-canonicalized path to pathResolver.writePath

### DIFF
--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -4635,7 +4635,7 @@ QString QgsSymbolLayerUtils::svgSymbolPathToName( const QString &p, const QgsPat
   if ( isInSvgPaths )
     return path;
 
-  return pathResolver.writePath( path );
+  return pathResolver.writePath( p );
 }
 
 QPolygonF lineStringToQPolygonF( const QgsLineString *line )

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -335,6 +335,23 @@ void TestQgsProject::testPathResolverSvg()
   QCOMPARE( svg1x, ourSvgPath );
   QCOMPARE( svg2x, invalidSvgPath );
   QCOMPARE( svg3x, librarySvgPath );
+
+  // Test that relative paths are correctly handled if the QgsPathResolver is constructed with symlink path
+
+  QTemporaryDir tempdir;
+  QDir tmpdir( tempdir.path() );
+  tmpdir.mkdir( u"projectpath"_s );
+  tmpdir.mkdir( u"projectpath/symbols"_s );
+  QFile file = QFile( tempdir.filePath( u"projectpath/symbols/foo.svg"_s ) );
+  if ( file.open( QIODevice::WriteOnly ) )
+  {
+    file.write( "<svg></svg>" );
+    file.close();
+  }
+  QFile::link( tmpdir.filePath( u"projectpath"_s ), tmpdir.filePath( u"symlinkpath"_s ) );
+  tmpdir.mkdir( u"symlinkpath"_s );
+  QgsPathResolver symlinkresolver( tmpdir.filePath( u"symlinkpath/project.qgs"_s ) );
+  QCOMPARE( QgsSymbolLayerUtils::svgSymbolPathToName( tmpdir.filePath( u"symlinkpath/symbols/foo.svg"_s ), symlinkresolver ), u"./symbols/foo.svg"_s );
 }
 
 


### PR DESCRIPTION
## Description

QgsPathResolver::writePath does not canonicalize the project file path, hence passing a canonicalized path to QgsPathResolver::writePath would result in an absolute path if the project is opened from a symlinked path, even though the symbol path can be expressed relative to the project file.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

