### PR TITLE
Convert some more mapbox expressions

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -3448,7 +3448,11 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
   {
     return u"to_real(%1)"_s.arg( parseValue( expression.value( 1 ), context ) );
   }
-  if ( op == "literal"_L1 )
+  else if ( op == "sqrt"_L1 )
+  {
+    return u"sqrt(%1)"_s.arg( parseValue( expression.value( 1 ), context ) );
+  }
+  else if ( op == "literal"_L1 )
   {
     return expression.value( 1 ).toString();
   }

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -3683,6 +3683,10 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
     }
     return caseString;
   }
+  else if ( op == "pitch"_L1 )
+  {
+    return u"0"_s;
+  }
   else
   {
     context.pushWarning( QObject::tr( "%1: Skipping unsupported expression \"%2\"" ).arg( context.layerId(), op ) );

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -3641,6 +3641,18 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
   {
     return u"@vector_tile_zoom"_s;
   }
+  else if ( op == "coalesce"_L1 )
+  {
+    QString coalesceString = u"coalesce("_s;
+    for ( int i = 1; i < expression.size(); i++ )
+    {
+      if ( i > 1 )
+        coalesceString += ", "_L1;
+      coalesceString += parseValue( expression.value( i ), context );
+    }
+    coalesceString += ')'_L1;
+    return coalesceString;
+  }
   else if ( op == "concat"_L1 )
   {
     QString concatString = u"concat("_s;

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -932,6 +932,14 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
             """0""",
         )
 
+        self.assertEqual(
+            QgsMapBoxGlStyleConverter.parseExpression(
+                ["coalesce", ["get", "name_en"], ["get", "name"]],
+                conversion_context,
+            ),
+            """coalesce("name_en", "name")""",
+        )
+
     def testConvertLabels(self):
         context = QgsMapBoxGlStyleConversionContext()
         style = {

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -924,6 +924,14 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
             """sqrt("sizerank")""",
         )
 
+        self.assertEqual(
+            QgsMapBoxGlStyleConverter.parseExpression(
+                ["pitch"],
+                conversion_context,
+            ),
+            """0""",
+        )
+
     def testConvertLabels(self):
         context = QgsMapBoxGlStyleConversionContext()
         style = {

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -916,6 +916,14 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
             "((10 + 10) * (1 + 2))",
         )
 
+        self.assertEqual(
+            QgsMapBoxGlStyleConverter.parseExpression(
+                ["sqrt", ["get", "sizerank"]],
+                conversion_context,
+            ),
+            """sqrt("sizerank")""",
+        )
+
     def testConvertLabels(self):
         context = QgsMapBoxGlStyleConversionContext()
         style = {


### PR DESCRIPTION
## Description

Converts:

- sqrt: direct match for qgis expression
- coalesce: again, can be directly translated
- pitch: translate to a hardcoded '0' constant, since the maps will always be viewed in 2d from above.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
