### PR TITLE
[wms] Set propert tile pixel ratio for XYZ tiles from openstreetmap.org when not specified or set to unknown

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1853,6 +1853,13 @@ bool QgsWmsProvider::setupXyzCapabilities( const QString &uri, const QgsRectangl
   if ( parsedUri.hasParam( u"tilePixelRatio"_s ) )
     tilePixelRatio = parsedUri.param( u"tilePixelRatio"_s ).toDouble();
 
+  if ( tilePixelRatio == 0 && parsedUri.param( u"url"_s ).contains( "openstreetmap"_L1, Qt::CaseInsensitive ) )
+  {
+    // pixel ratio of XYZ tiles served on openstreetmap.org known, set accordingly to insure
+    // tile downloads are skyrocketing on high screen/output DPI.
+    tilePixelRatio = 1;
+  }
+
   if ( tilePixelRatio != 0 )
   {
     // known tile pixel ratio - will be doing auto-scaling of tiles based on output DPI

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1856,7 +1856,7 @@ bool QgsWmsProvider::setupXyzCapabilities( const QString &uri, const QgsRectangl
   if ( tilePixelRatio == 0 && parsedUri.param( u"url"_s ).contains( "openstreetmap"_L1, Qt::CaseInsensitive ) )
   {
     // pixel ratio of XYZ tiles served on openstreetmap.org known, set accordingly to insure
-    // tile downloads are skyrocketing on high screen/output DPI.
+    // tile downloads are not skyrocketing on high screen/output DPI.
     tilePixelRatio = 1;
   }
 


### PR DESCRIPTION
## Description

This allows us to be as gentle as we can be with openstreetmap.org layers on high DPI screens when users use an XYZ raster layer where the URL is [tile.]openstreetmap.org and the tile pixel ratio information is not specified or set to unknown.

This will have an immediate impact for old projects that inserted OSM layers from the default OSM layer within our browser panel _prior to the version we started explicitly setting the tile pixel rario_, or from a 3rd party plugin (quickmapservice), etc.

As mentioned here (https://github.com/qgis/QGIS/issues/63249#issuecomment-4182915395).

_The explicit tile pixel ratio setting for the OSM layer we ship by default in OSM came in Sept. 2024, I assume there's plenty of projects that predate that :)_