### PR TITLE
[arcgis] Fix crash with the legend fetcher trying to access a deleted object

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -20,6 +20,7 @@
 #include "qgshttpheaders.h"
 #include "qgsrectangle.h"
 
+#include <QPointer>
 #include <QString>
 #include <QVariantMap>
 
@@ -234,7 +235,7 @@ class CORE_EXPORT QgsArcGisAsyncQuery : public QObject
     void handleReply();
 
   private:
-    QNetworkReply *mReply = nullptr;
+    QPointer<QNetworkReply> mReply;
     QByteArray *mResult = nullptr;
 };
 


### PR DESCRIPTION
## Description

We're deleting the mReply object  here (https://github.com/nirvn/QGIS/blob/3a3247a6fb80c11ed4a1e3fef63a7a161740eafb/src/core/providers/arcgis/qgsarcgisrestquery.cpp#L589) but not making the pointer null, which can lead to crashes. Making the reply a QPointer<QNetworkReply> protects us from this scenario.