### PR TITLE
Fix diffuse lighting for metal rough material

### DIFF
--- a/src/3d/shaders/metalrough.frag
+++ b/src/3d/shaders/metalrough.frag
@@ -261,7 +261,7 @@ vec3 pbrIblModel(const in vec3 wNormal,
 
     // Calculate diffuse component
     vec3 diffuseColor = (1.0 - metalness) * baseColor;
-    vec3 diffuse = diffuseColor * texture(envLight.irradiance, l).rgb;
+    vec3 diffuse = diffuseColor * texture(envLight.irradiance, n).rgb;
 
     // Calculate specular component
     vec3 dielectricColor = vec3(0.04);


### PR DESCRIPTION
The diffuse component is supposed to be calculated on the normal, not reflection

(The original shader code was taken from qt3d, but there's no point submitting this fix upstream)