### PR TITLE
Improve handling of odd length dash array during MapBox GL style conversion

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsmapboxglstyleconverter.py
+++ b/python/PyQt6/core/auto_additions/qgsmapboxglstyleconverter.py
@@ -7,6 +7,7 @@ QgsMapBoxGlStyleConverter.PropertyType.Numeric.__doc__ = "Numeric property (e.g.
 QgsMapBoxGlStyleConverter.PropertyType.Opacity.__doc__ = "Opacity property"
 QgsMapBoxGlStyleConverter.PropertyType.Point.__doc__ = "Point/offset property"
 QgsMapBoxGlStyleConverter.PropertyType.NumericArray.__doc__ = "Numeric array for dash arrays or such"
+QgsMapBoxGlStyleConverter.PropertyType.DashArray.__doc__ = "Dash array. Like numeric array, but must be even length array. Odd length arrays are considered as having an additional 0 value. \n.. versionadded:: 4.2"
 QgsMapBoxGlStyleConverter.PropertyType.__doc__ = """Property types, for interpolated value conversion
 
 .. warning::
@@ -18,6 +19,10 @@ QgsMapBoxGlStyleConverter.PropertyType.__doc__ = """Property types, for interpol
 * ``Opacity``: Opacity property
 * ``Point``: Point/offset property
 * ``NumericArray``: Numeric array for dash arrays or such
+* ``DashArray``: Dash array. Like numeric array, but must be even length array. Odd length arrays are considered as having an additional 0 value.
+
+  .. versionadded:: 4.2
+
 
 """
 # --

--- a/python/PyQt6/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -363,6 +363,7 @@ Constructor for QgsMapBoxGlStyleConverter.
       Opacity,
       Point,
       NumericArray,
+      DashArray,
     };
 
     Result convert( const QVariantMap &style, QgsMapBoxGlStyleConversionContext *context = 0 );

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -720,7 +720,7 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
 
         if ( dashSource.at( 0 ).userType() == QMetaType::Type::QString )
         {
-          QgsProperty property = parseValueList( dashSource, PropertyType::NumericArray, context, 1, 255, nullptr, nullptr );
+          QgsProperty property = parseValueList( dashSource, PropertyType::DashArray, context, 1, 255, nullptr, nullptr );
           if ( !lineWidthProperty.asExpression().isEmpty() )
           {
             property = QgsProperty::fromExpression(
@@ -752,9 +752,8 @@ bool QgsMapBoxGlStyleConverter::parseLineLayer( const QVariantMap &jsonLayer, Qg
           else if ( rawDashVectorSizes.size() % 2 == 1 )
           {
             // odd number of dash pattern sizes -- this isn't permitted by Qt/QGIS, but isn't explicitly blocked by the MapBox specs
-            // MapBox seems to add the extra dash element to the first dash size
-            rawDashVectorSizes[0] = rawDashVectorSizes[0] + rawDashVectorSizes[rawDashVectorSizes.size() - 1];
-            rawDashVectorSizes.resize( rawDashVectorSizes.size() - 1 );
+            // MapBox seems to implicitly add a 0 length gap to the array if odd length.
+            rawDashVectorSizes.append( 0 );
           }
 
           if ( !rawDashVectorSizes.isEmpty() && ( !lineWidthProperty.asExpression().isEmpty() ) )
@@ -3093,6 +3092,29 @@ QgsProperty QgsMapBoxGlStyleConverter::parseMatchList(
         }
         break;
       }
+
+      case PropertyType::DashArray:
+      {
+        if ( value.toList().count() == 2 && value.toList().first().toString() == "literal"_L1 )
+        {
+          QStringList dashValues = value.toList().at( 1 ).toStringList();
+          if ( dashValues.length() % 2 == 1 )
+          {
+            dashValues << u"0"_s;
+          }
+          valueString = u"array(%1)"_s.arg( dashValues.join( ',' ) );
+        }
+        else
+        {
+          QStringList dashValues = value.toStringList();
+          if ( dashValues.length() % 2 == 1 )
+          {
+            dashValues << u"0"_s;
+          }
+          valueString = u"array(%1)"_s.arg( dashValues.join( ',' ) );
+        }
+        break;
+      }
     }
 
     if ( matchString.count() == 1 )
@@ -3165,6 +3187,29 @@ QgsProperty QgsMapBoxGlStyleConverter::parseMatchList(
           }
           break;
         }
+
+        case PropertyType::DashArray:
+        {
+          if ( json.constLast().toList().count() == 2 && json.constLast().toList().first().toString() == "literal"_L1 )
+          {
+            QStringList dashValues = json.constLast().toList().at( 1 ).toStringList();
+            if ( dashValues.length() % 2 == 1 )
+            {
+              dashValues << u"0"_s;
+            }
+            elseValue = u"array(%1)"_s.arg( dashValues.join( ',' ) );
+          }
+          else
+          {
+            QStringList dashValues = json.constLast().toStringList();
+            if ( dashValues.length() % 2 == 1 )
+            {
+              dashValues << u"0"_s;
+            }
+            elseValue = u"array(%1)"_s.arg( dashValues.join( ',' ) );
+          }
+          break;
+        }
       }
       break;
     }
@@ -3193,7 +3238,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseStepList(
     const QVariant stepValue = json.value( i + 1 );
 
     QString valueString;
-    if ( stepValue.canConvert<QVariantList>() && ( stepValue.toList().count() != 2 || type != PropertyType::Point ) && type != PropertyType::NumericArray )
+    if ( stepValue.canConvert<QVariantList>() && ( stepValue.toList().count() != 2 || type != PropertyType::Point ) && type != PropertyType::NumericArray && type != PropertyType::DashArray )
     {
       valueString = parseValueList( stepValue.toList(), type, context, multiplier, maxOpacity, defaultColor, defaultNumber ).expressionString();
     }
@@ -3237,6 +3282,29 @@ QgsProperty QgsMapBoxGlStyleConverter::parseStepList(
           else
           {
             valueString = u"array(%1)"_s.arg( stepValue.toStringList().join( ',' ) );
+          }
+          break;
+        }
+
+        case PropertyType::DashArray:
+        {
+          if ( stepValue.toList().count() == 2 && stepValue.toList().first().toString() == "literal"_L1 )
+          {
+            QStringList dashValues = stepValue.toList().at( 1 ).toStringList();
+            if ( dashValues.length() % 2 == 1 )
+            {
+              dashValues << u"0"_s;
+            }
+            valueString = u"array(%1)"_s.arg( dashValues.join( ',' ) );
+          }
+          else
+          {
+            QStringList dashValues = stepValue.toStringList();
+            if ( dashValues.length() % 2 == 1 )
+            {
+              dashValues << u"0"_s;
+            }
+            valueString = u"array(%1)"_s.arg( dashValues.join( ',' ) );
           }
           break;
         }
@@ -3314,6 +3382,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateListByZoom(
       return parseInterpolatePointByZoom( props, context, multiplier );
 
     case PropertyType::NumericArray:
+    case PropertyType::DashArray:
       context.pushWarning( QObject::tr( "%1: Skipping unsupported numeric array in interpolate" ).arg( context.layerId() ) );
       return QgsProperty();
   }

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -370,6 +370,7 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
       Opacity,      //!< Opacity property
       Point,        //!< Point/offset property
       NumericArray, //!< Numeric array for dash arrays or such
+      DashArray,    //!< Dash array. Like numeric array, but must be even length array. Odd length arrays are considered as having an additional 0 value. \since QGIS 4.2
     };
     Q_ENUM( PropertyType )
 

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -1750,7 +1750,9 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
             rendererStyle.geometryType(), QgsWkbTypes.GeometryType.LineGeometry
         )
         self.assertTrue(rendererStyle.symbol()[0].useCustomDashPattern())
-        self.assertEqual(rendererStyle.symbol()[0].customDashVector(), [6.0, 3.0])
+        self.assertEqual(
+            rendererStyle.symbol()[0].customDashVector(), [1.5, 3.0, 4.5, 0.0]
+        )
         dd_properties = rendererStyle.symbol().symbolLayers()[0].dataDefinedProperties()
         self.assertEqual(
             dd_properties.property(
@@ -1771,7 +1773,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
                 QgsSymbolLayer.Property.PropertyCustomDash
             ).asExpression(),
             (
-                "array_to_string(array_foreach(array(4,2),@element * ("
+                "array_to_string(array_foreach(array(1,2,3,0),@element * ("
                 "CASE WHEN @vector_tile_zoom >= 10 AND @vector_tile_zoom <= 11 THEN scale_exponential(@vector_tile_zoom,10,11,1.5,2,1.2) "
                 "WHEN @vector_tile_zoom > 11 AND @vector_tile_zoom <= 12 THEN scale_exponential(@vector_tile_zoom,11,12,2,3,1.2) "
                 "WHEN @vector_tile_zoom > 12 AND @vector_tile_zoom <= 13 THEN scale_exponential(@vector_tile_zoom,12,13,3,5,1.2) "
@@ -1779,6 +1781,45 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
                 "WHEN @vector_tile_zoom > 14 AND @vector_tile_zoom <= 16 THEN scale_exponential(@vector_tile_zoom,14,16,6,10,1.2) "
                 "WHEN @vector_tile_zoom > 16 AND @vector_tile_zoom <= 17 THEN scale_exponential(@vector_tile_zoom,16,17,10,12,1.2) "
                 "WHEN @vector_tile_zoom > 17 THEN 12 END)), ';')"
+            ),
+        )
+
+    def testParseLineDashArrayStepOddNumber(self):
+        conversion_context = QgsMapBoxGlStyleConversionContext()
+        style = {
+            "id": "water line (intermittent)/river",
+            "type": "line",
+            "source": "esri",
+            "source-layer": "water line (intermittent)",
+            "filter": ["==", "_symbol", 3],
+            "minzoom": 10,
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-color": "#aad3df",
+                "line-dasharray": [
+                    "step",
+                    ["zoom"],
+                    ["literal", [1]],
+                    2,
+                    ["literal", [1, 1, 3]],
+                ],
+                "line-width": 1.2,
+            },
+        }
+        has_renderer, rendererStyle = QgsMapBoxGlStyleConverter.parseLineLayer(
+            style, conversion_context
+        )
+        self.assertTrue(has_renderer)
+        self.assertEqual(
+            rendererStyle.geometryType(), QgsWkbTypes.GeometryType.LineGeometry
+        )
+        dd_properties = rendererStyle.symbol().symbolLayers()[0].dataDefinedProperties()
+        self.assertEqual(
+            dd_properties.property(
+                QgsSymbolLayer.Property.PropertyCustomDash
+            ).asExpression(),
+            (
+                "array_to_string(CASE  WHEN @vector_tile_zoom >= 2 THEN (array(1,1,3,0)) ELSE (array(1,0)) END, ';')"
             ),
         )
 


### PR DESCRIPTION
Treat the arrays as implicitly having an extra "0" gap element on the end, to exactly match how mapbox renders these
