### PR TITLE
Allow loading vector tile sprites directly from mapbox hosted styles

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsvectortileutils.py
+++ b/python/PyQt6/core/auto_additions/qgsvectortileutils.py
@@ -10,6 +10,7 @@ try:
     QgsVectorTileUtils.formatXYZUrlTemplate = staticmethod(QgsVectorTileUtils.formatXYZUrlTemplate)
     QgsVectorTileUtils.checkXYZUrlTemplate = staticmethod(QgsVectorTileUtils.checkXYZUrlTemplate)
     QgsVectorTileUtils.loadSprites = staticmethod(QgsVectorTileUtils.loadSprites)
+    QgsVectorTileUtils.resolveMapboxUri = staticmethod(QgsVectorTileUtils.resolveMapboxUri)
     QgsVectorTileUtils.__group__ = ['vectortile']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/vectortile/qgsvectortileutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsvectortileutils.sip.in
@@ -93,6 +93,14 @@ Downloads the sprite image and sets it to the conversion context
 :param styleUrl: optional the style url
 %End
 
+    static QString resolveMapboxUri( const QString &uri, const QString &accessToken );
+%Docstring
+Resolves a URI which uses the mapbox:// protocol to a standard HTTPS
+URL.
+
+.. versionadded:: 4.2
+%End
+
 };
 
 /************************************************************************

--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -38,6 +38,7 @@
 #include <QJsonDocument>
 #include <QPolygon>
 #include <QString>
+#include <QUrlQuery>
 
 using namespace Qt::StringLiterals;
 
@@ -341,6 +342,15 @@ void QgsVectorTileUtils::loadSprites( const QVariantMap &styleDefinition, QgsMap
       {
         return sprite;
       }
+      else if ( sprite.startsWith( "mapbox://"_L1 ) )
+      {
+        const QUrl url( styleUrl );
+        const QUrlQuery query( url.query() );
+        if ( query.hasQueryItem( u"access_token"_s ) )
+        {
+          return resolveMapboxUri( sprite, query.queryItemValue( u"access_token"_s ) );
+        }
+      }
       else if ( sprite.startsWith( '/'_L1 ) )
       {
         const QUrl url( styleUrl );
@@ -427,5 +437,37 @@ void QgsVectorTileUtils::loadSprites( const QVariantMap &styleDefinition, QgsMap
 
       ++spritesIterator;
     }
+  }
+}
+
+QString QgsVectorTileUtils::resolveMapboxUri( const QString &uri, const QString &accessToken )
+{
+  const QUrl url( uri );
+  if ( url.scheme() != "mapbox"_L1 )
+  {
+    return uri;
+  }
+
+  const QString host = url.host();
+  if ( host == "styles"_L1 )
+  {
+    // e.g. mapbox://styles/mapbox/dark-v11
+    return u"https://api.mapbox.com/styles/v1%1?access_token=%2"_s.arg( url.path(), accessToken );
+  }
+  else if ( host == "sprites" )
+  {
+    // e.g. mapbox://sprites/mapbox/streets-v11
+    return u"https://api.mapbox.com/styles/v1%1/sprite?access_token=%2"_s.arg( url.path(), accessToken );
+  }
+  else if ( host == "fonts" )
+  {
+    // e.g. mapbox://fonts/mapbox/Open Sans Regular/{range}.pbf
+    return u"https://api.mapbox.com/fonts/v1%1?access_token=%2"_s.arg( url.path(), accessToken );
+  }
+  else
+  {
+    // sources:
+    // e.g. mapbox://{username}.{tileset_id}
+    return u"https://api.mapbox.com/v4/%1.json?secure&access_token=%2"_s.arg( host, accessToken );
   }
 }

--- a/src/core/vectortile/qgsvectortileutils.h
+++ b/src/core/vectortile/qgsvectortileutils.h
@@ -98,6 +98,13 @@ class CORE_EXPORT QgsVectorTileUtils
      */
     static void loadSprites( const QVariantMap &styleDefinition, QgsMapBoxGlStyleConversionContext &context, const QString &styleUrl = QString() );
 
+    /**
+     * Resolves a URI which uses the mapbox:// protocol to a standard HTTPS URL.
+     *
+     * \since QGIS 4.2
+     */
+    static QString resolveMapboxUri( const QString &uri, const QString &accessToken );
+
   private:
     //! Parses the style URL to get a list of named source URLs.
     static QMap<QString, QString> parseStyleSourceUrl( const QString &styleUrl, const QgsHttpHeaders &headers = QgsHttpHeaders(), const QString &authCfg = QString() );

--- a/tests/src/core/testqgsvectortileutils.cpp
+++ b/tests/src/core/testqgsvectortileutils.cpp
@@ -45,6 +45,8 @@ class TestQgsVectorTileUtils : public QObject
 
     void test_scaleToZoomLevel();
     void test_urlsFromStyle();
+    void test_mapboxUrls_data();
+    void test_mapboxUrls();
 };
 
 
@@ -105,6 +107,29 @@ void TestQgsVectorTileUtils::test_urlsFromStyle()
   QCOMPARE( sources.value( "plan_ign" ), "https://data.geopf.fr/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf" );
   QVERIFY( sources.contains( "plan_ign_relative" ) );
   QCOMPARE( sources.value( "plan_ign_relative" ), "file:///tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf" );
+}
+
+
+void TestQgsVectorTileUtils::test_mapboxUrls_data()
+{
+  QTest::addColumn<QString>( "url" );
+  QTest::addColumn<QString>( "apiKey" );
+  QTest::addColumn<QString>( "expected" );
+
+  QTest::newRow( "not mapbox" ) << "https://mytiles.com" << QString() << "https://mytiles.com";
+  QTest::newRow( "mapbox style" ) << "mapbox://styles/mapbox/dark-v11" << "abc123" << "https://api.mapbox.com/styles/v1/mapbox/dark-v11?access_token=abc123";
+  QTest::newRow( "mapbox sprite" ) << "mapbox://sprites/mapbox/streets-v11" << "abc123" << "https://api.mapbox.com/styles/v1/mapbox/streets-v11/sprite?access_token=abc123";
+  QTest::newRow( "mapbox fonts" ) << "mapbox://fonts/mapbox/Open Sans Regular/123.pbf" << "abc123" << "https://api.mapbox.com/fonts/v1/mapbox/Open Sans Regular/123.pbf?access_token=abc123";
+  QTest::newRow( "mapbox sources" ) << "mapbox://username.tileset_id" << "abc123" << "https://api.mapbox.com/v4/username.tileset_id.json?secure&access_token=abc123";
+}
+
+void TestQgsVectorTileUtils::test_mapboxUrls()
+{
+  QFETCH( QString, url );
+  QFETCH( QString, apiKey );
+  QFETCH( QString, expected );
+
+  QCOMPARE( QgsVectorTileUtils::resolveMapboxUri( url, apiKey ), expected );
 }
 
 QGSTEST_MAIN( TestQgsVectorTileUtils )


### PR DESCRIPTION
Handles resolving the mapbox:// URIs used in mapbox hosted style JSON to real http URLs so that we can successfully retrieve the associated sprite definitions and images.
