### PR TITLE
 Add scale_cubic_bezier expression function, handle bezier-cubic interpolation when converting MapBox styles

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsmapboxglstyleconverter.py
+++ b/python/PyQt6/core/auto_additions/qgsmapboxglstyleconverter.py
@@ -22,6 +22,25 @@ QgsMapBoxGlStyleConverter.PropertyType.__doc__ = """Property types, for interpol
 """
 # --
 QgsMapBoxGlStyleConverter.PropertyType.baseClass = QgsMapBoxGlStyleConverter
+# monkey patching scoped based enum
+QgsMapBoxGlStyleConverter.InterpolationType.Linear.__doc__ = "Linear interpolation"
+QgsMapBoxGlStyleConverter.InterpolationType.Exponential.__doc__ = "Exponential interpolation"
+QgsMapBoxGlStyleConverter.InterpolationType.CubicBezier.__doc__ = "Cubic-bezier interpolation"
+QgsMapBoxGlStyleConverter.InterpolationType.__doc__ = """Interpolation types, for interpolated value conversion
+
+.. warning::
+
+   This is private API only, and may change in future QGIS versions
+
+.. versionadded:: 4.2
+
+* ``Linear``: Linear interpolation
+* ``Exponential``: Exponential interpolation
+* ``CubicBezier``: Cubic-bezier interpolation
+
+"""
+# --
+QgsMapBoxGlStyleConverter.InterpolationType.baseClass = QgsMapBoxGlStyleConverter
 try:
     QgsMapBoxGlStyleConverter.parseFillLayer = staticmethod(QgsMapBoxGlStyleConverter.parseFillLayer)
     QgsMapBoxGlStyleConverter.parseLineLayer = staticmethod(QgsMapBoxGlStyleConverter.parseLineLayer)

--- a/python/PyQt6/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsmapboxglstyleconverter.sip.in
@@ -365,6 +365,13 @@ Constructor for QgsMapBoxGlStyleConverter.
       NumericArray,
     };
 
+    enum class InterpolationType
+    {
+      Linear,
+      Exponential,
+      CubicBezier,
+    };
+
     Result convert( const QVariantMap &style, QgsMapBoxGlStyleConversionContext *context = 0 );
 %Docstring
 Converts a JSON ``style`` map, and returns the resultant status of the
@@ -574,32 +581,50 @@ Parses a symbol layer as a renderer
          - rendererStyle: generated QGIS vector tile style
 %End
 
-    static QgsProperty parseInterpolateColorByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, QColor *defaultColor /Out/ = 0 );
+    static QgsProperty parseInterpolateColorByZoom(
+      const QVariantMap &json,
+      QgsMapBoxGlStyleConversionContext &context,
+      QColor *defaultColor /Out/ = 0,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential
+    );
 %Docstring
 Parses a color value which is interpolated by zoom range.
 
 :param json: definition of color interpolation
 :param context: conversion context
+:param type: interpolation type (since QGIS 4.2)
 
 :return: - :py:class:`QgsProperty` representing interpolation settings
          - defaultColor: a reasonable "default" color representing the
            overall property.
 %End
 
-    static QgsProperty parseInterpolateByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, double multiplier = 1, double *defaultNumber /Out/ = 0 );
+    static QgsProperty parseInterpolateByZoom(
+      const QVariantMap &json,
+      QgsMapBoxGlStyleConversionContext &context,
+      double multiplier = 1,
+      double *defaultNumber /Out/ = 0,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential
+    );
 %Docstring
 Parses a numeric value which is interpolated by zoom range.
 
 :param json: definition of interpolation
 :param context: conversion context
 :param multiplier: optional multiplication factor
+:param type: interpolation type (since QGIS 4.2)
 
 :return: - :py:class:`QgsProperty` representing interpolation settings
          - defaultNumber: a reasonable "default" number representing the
            overall property.
 %End
 
-    static QgsProperty parseInterpolateOpacityByZoom( const QVariantMap &json, int maxOpacity, QgsMapBoxGlStyleConversionContext *contextPtr = 0 );
+    static QgsProperty parseInterpolateOpacityByZoom(
+      const QVariantMap &json,
+      int maxOpacity,
+      QgsMapBoxGlStyleConversionContext *contextPtr = 0,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential
+    );
 %Docstring
 Interpolates opacity with either
 :py:func:`~QgsMapBoxGlStyleConverter.scale_linear` or
@@ -614,7 +639,17 @@ to set alpha component of color.
    This is private API only, and may change in future QGIS versions
 %End
 
-    static QString parseOpacityStops( double base, const QVariantList &stops, int maxOpacity, QgsMapBoxGlStyleConversionContext &context );
+    static QString parseOpacityStops(
+      double base,
+      const QVariantList &stops,
+      int maxOpacity,
+      QgsMapBoxGlStyleConversionContext &context,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential,
+      double x1 = 0,
+      double y1 = 0,
+      double x2 = 1,
+      double y2 = 1
+    );
 %Docstring
 Takes values from stops and uses either
 :py:func:`~QgsMapBoxGlStyleConverter.scale_linear` or
@@ -626,7 +661,13 @@ alpha component of color.
    This is private API only, and may change in future QGIS versions
 %End
 
-    static QgsProperty parseInterpolatePointByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, double multiplier = 1, QPointF *defaultPoint /Out/ = 0 );
+    static QgsProperty parseInterpolatePointByZoom(
+      const QVariantMap &json,
+      QgsMapBoxGlStyleConversionContext &context,
+      double multiplier = 1,
+      QPointF *defaultPoint /Out/ = 0,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential
+    );
 %Docstring
 Interpolates a point/offset with either
 :py:func:`~QgsMapBoxGlStyleConverter.scale_linear` or
@@ -649,7 +690,17 @@ uses :py:func:`~QgsMapBoxGlStyleConverter.parseStringStops` function.
    This is private API only, and may change in future QGIS versions
 %End
 
-    static QString parsePointStops( double base, const QVariantList &stops, QgsMapBoxGlStyleConversionContext &context, double multiplier = 1 );
+    static QString parsePointStops(
+      double base,
+      const QVariantList &stops,
+      QgsMapBoxGlStyleConversionContext &context,
+      double multiplier = 1,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential,
+      double x1 = 0,
+      double y1 = 0,
+      double x2 = 0,
+      double y2 = 0
+    );
 %Docstring
 Takes values from stops and uses either
 :py:func:`~QgsMapBoxGlStyleConverter.scale_linear` or
@@ -670,7 +721,17 @@ Takes numerical arrays from stops.
    This is private API only, and may change in future QGIS versions
 %End
 
-    static QString parseStops( double base, const QVariantList &stops, double multiplier, QgsMapBoxGlStyleConversionContext &context );
+    static QString parseStops(
+      double base,
+      const QVariantList &stops,
+      double multiplier,
+      QgsMapBoxGlStyleConversionContext &context,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential,
+      double x1 = 0,
+      double y1 = 0,
+      double x2 = 1,
+      double y2 = 1
+    );
 %Docstring
 Parses a list of interpolation stops
 
@@ -678,6 +739,11 @@ Parses a list of interpolation stops
 :param stops: definition of interpolation stops
 :param multiplier: optional multiplication factor
 :param context: conversion context
+:param type: interpolation type
+:param x1: control point for bezier-cubic interpolation
+:param y1: control point for bezier-cubic interpolation
+:param x2: control point for bezier-cubic interpolation
+:param y2: control point for bezier-cubic interpolation
 %End
 
     static QString parseStringStops( const QVariantList &stops, QgsMapBoxGlStyleConversionContext &context, const QVariantMap &conversionMap, QString *defaultString /Out/ = 0 );
@@ -820,7 +886,20 @@ function.
    This is private API only, and may change in future QGIS versions
 %End
 
-    static QString interpolateExpression( double zoomMin, double zoomMax, QVariant valueMin, QVariant valueMax, double base, double multiplier = 1, QgsMapBoxGlStyleConversionContext *contextPtr = 0 );
+    static QString interpolateExpression(
+      double zoomMin,
+      double zoomMax,
+      QVariant valueMin,
+      QVariant valueMax,
+      double base,
+      double multiplier = 1,
+      double x1 = 0,
+      double y1 = 0,
+      double x2 = 1,
+      double y2 = 1,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential,
+      QgsMapBoxGlStyleConversionContext *contextPtr = 0
+    );
 %Docstring
 Generates an interpolation for values between ``valueMin`` and
 ``valueMax``, scaled between the ranges ``zoomMin`` to ``zoomMax``.

--- a/resources/function_help/json/scale_cubic_bezier
+++ b/resources/function_help/json/scale_cubic_bezier
@@ -1,0 +1,44 @@
+{
+  "name": "scale_cubic_bezier",
+  "type": "function",
+  "groups": ["Math"],
+  "description": "Transforms a given value from an input domain to an output range using a cubic Bézier curve. This function can be used to ease values in or out of the specified output range using custom control points.",
+  "arguments": [{
+    "arg": "value",
+    "description": "A value in the input domain. The function will return a corresponding scaled value in the output range."
+  }, {
+    "arg": "domain_min",
+    "description": "Specifies the minimum value in the input domain, the smallest value the input value should take."
+  }, {
+    "arg": "domain_max",
+    "description": "Specifies the maximum value in the input domain, the largest value the input value should take."
+  }, {
+    "arg": "range_min",
+    "description": "Specifies the minimum value in the output range, the smallest value which should be output by the function."
+  }, {
+    "arg": "range_max",
+    "description": "Specifies the maximum value in the output range, the largest value which should be output by the function."
+  }, {
+    "arg": "x1",
+    "description": "The x-coordinate of the first control point. Must be a value between 0 and 1."
+  }, {
+    "arg": "y1",
+    "description": "The y-coordinate of the first control point. Must be a value between 0 and 1."
+  }, {
+    "arg": "x2",
+    "description": "The x-coordinate of the second control point. Must be a value between 0 and 1."
+  }, {
+    "arg": "y2",
+    "description": "The y-coordinate of the second control point. Must be a value between 0 and 1."
+  }],
+  "examples": [{
+    "expression": "scale_cubic_bezier(5, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0)",
+    "returns": "50.0",
+    "note": "easing in and out using a symmetrical cubic Bézier curve"
+  }, {
+    "expression": "scale_cubic_bezier(5, 0, 10, 0, 100, 0.25, 0.1, 0.25, 1.0)",
+    "returns": "80.24034",
+    "note": "a standard ease curve, accelerating quickly before decelerating gradually"
+  }],
+  "tags": ["cubic", "bezier", "curve", "ease", "transforms", "output", "given", "input", "domain", "range", "specified", "values", "interpolation"]
+}

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -608,6 +608,109 @@ static QVariant fcnExponentialScale( const QVariantList &values, const QgsExpres
   return QVariant( ( rangeMax - rangeMin ) * ratio + rangeMin );
 }
 
+static QVariant fcnCubicBezierScale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  const double val = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
+  const double domainMin = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
+  const double domainMax = QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent );
+  const double rangeMin = QgsExpressionUtils::getDoubleValue( values.at( 3 ), parent );
+  const double rangeMax = QgsExpressionUtils::getDoubleValue( values.at( 4 ), parent );
+
+  const double x1 = QgsExpressionUtils::getDoubleValue( values.at( 5 ), parent );
+  const double y1 = QgsExpressionUtils::getDoubleValue( values.at( 6 ), parent );
+  const double x2 = QgsExpressionUtils::getDoubleValue( values.at( 7 ), parent );
+  const double y2 = QgsExpressionUtils::getDoubleValue( values.at( 8 ), parent );
+
+  if ( x1 < 0.0 || x1 > 1.0 || y1 < 0.0 || y1 > 1.0 || x2 < 0.0 || x2 > 1.0 || y2 < 0.0 || y2 > 1.0 )
+  {
+    parent->setEvalErrorString( QObject::tr( "Cubic bezier control points must be between 0 and 1" ) );
+    return QVariant();
+  }
+
+  if ( domainMin >= domainMax )
+  {
+    parent->setEvalErrorString( QObject::tr( "Domain max must be greater than domain min" ) );
+    return QVariant();
+  }
+
+  // outside of domain?
+  if ( val >= domainMax )
+  {
+    return rangeMax;
+  }
+  else if ( val <= domainMin )
+  {
+    return rangeMin;
+  }
+
+  // normalize input to [0, 1] range
+  const double t = ( val - domainMin ) / ( domainMax - domainMin );
+
+  // solve using UnitBezier approach (based on MapLibre native's implementation)
+  const double cx = 3.0 * x1;
+  const double bx = 3.0 * ( x2 - x1 ) - cx;
+  const double ax = 1.0 - cx - bx;
+  const double cy = 3.0 * y1;
+  const double by = 3.0 * ( y2 - y1 ) - cy;
+  const double ay = 1.0 - cy - by;
+
+  constexpr double epsilon = 1e-6;
+
+  // solve for s using Newton's method (8 iterations)
+  double s = t;
+  bool solved = false;
+  for ( int i = 0; i < 8; ++i )
+  {
+    const double x2val = ( ( ax * s + bx ) * s + cx ) * s - t;
+    if ( std::fabs( x2val ) < epsilon )
+    {
+      solved = true;
+      break;
+    }
+    const double d2 = ( 3.0 * ax * s + 2.0 * bx ) * s + cx;
+    if ( std::fabs( d2 ) < 1e-6 )
+      break;
+    s = s - x2val / d2;
+  }
+
+  if ( !solved )
+  {
+    // fallback to bisection approach
+    double t0 = 0.0;
+    double t1 = 1.0;
+    s = t;
+
+    if ( s < t0 )
+    {
+      s = t0;
+      solved = true;
+    }
+    else if ( s > t1 )
+    {
+      s = t1;
+      solved = true;
+    }
+
+    while ( !solved && t0 < t1 )
+    {
+      const double x2val = ( ( ax * s + bx ) * s + cx ) * s;
+      if ( std::fabs( x2val - t ) < epsilon )
+      {
+        solved = true;
+        break;
+      }
+      if ( t > x2val )
+        t0 = s;
+      else
+        t1 = s;
+      s = ( t1 - t0 ) * 0.5 + t0;
+    }
+  }
+
+  const double easedT = ( ( ay * s + by ) * s + cy ) * s;
+  return QVariant( ( rangeMax - rangeMin ) * easedT + rangeMin );
+}
+
 static QVariant fcnMax( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariant result = QgsVariantUtils::createNullVariant( QMetaType::Type::Double );
@@ -9126,6 +9229,21 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
              << QgsExpressionFunction::Parameter( u"range_max"_s )
              << QgsExpressionFunction::Parameter( u"exponent"_s ),
            fcnExponentialScale,
+           u"Math"_s
+         )
+      << new QgsStaticExpressionFunction(
+           u"scale_cubic_bezier"_s,
+           QgsExpressionFunction::ParameterList()
+             << QgsExpressionFunction::Parameter( u"value"_s )
+             << QgsExpressionFunction::Parameter( u"domain_min"_s )
+             << QgsExpressionFunction::Parameter( u"domain_max"_s )
+             << QgsExpressionFunction::Parameter( u"range_min"_s )
+             << QgsExpressionFunction::Parameter( u"range_max"_s )
+             << QgsExpressionFunction::Parameter( u"x1"_s )
+             << QgsExpressionFunction::Parameter( u"y1"_s )
+             << QgsExpressionFunction::Parameter( u"x2"_s )
+             << QgsExpressionFunction::Parameter( u"y2"_s ),
+           fcnCubicBezierScale,
            u"Math"_s
          )
       << new QgsStaticExpressionFunction( u"floor"_s, QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( u"value"_s ), fcnFloor, u"Math"_s )

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -2460,7 +2460,7 @@ bool QgsMapBoxGlStyleConverter::parseSymbolLayerAsRenderer( const QVariantMap &j
   return false;
 }
 
-QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateColorByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, QColor *defaultColor )
+QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateColorByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, QColor *defaultColor, InterpolationType type )
 {
   const double base = json.value( u"base"_s, u"1"_s ).toDouble();
   const QVariantList stops = json.value( u"stops"_s ).toList();
@@ -2512,10 +2512,62 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateColorByZoom( const QVaria
                       .arg(
                         bz,
                         tz,
-                        interpolateExpression( bz.toDouble(), tz.toDouble(), bcHue, tcHue, base, 1, &context ),
-                        interpolateExpression( bz.toDouble(), tz.toDouble(), bcSat, tcSat, base, 1, &context ),
-                        interpolateExpression( bz.toDouble(), tz.toDouble(), bcLight, tcLight, base, 1, &context ),
-                        interpolateExpression( bz.toDouble(), tz.toDouble(), bcAlpha, tcAlpha, base, 1, &context )
+                        interpolateExpression(
+                          bz.toDouble(),
+                          tz.toDouble(),
+                          bcHue,
+                          tcHue,
+                          base,
+                          1,
+                          json.value( u"x1"_s ).toDouble(),
+                          json.value( u"y1"_s ).toDouble(),
+                          json.value( u"x2"_s ).toDouble(),
+                          json.value( u"y2"_s ).toDouble(),
+                          type,
+                          &context
+                        ),
+                        interpolateExpression(
+                          bz.toDouble(),
+                          tz.toDouble(),
+                          bcSat,
+                          tcSat,
+                          base,
+                          1,
+                          json.value( u"x1"_s ).toDouble(),
+                          json.value( u"y1"_s ).toDouble(),
+                          json.value( u"x2"_s ).toDouble(),
+                          json.value( u"y2"_s ).toDouble(),
+                          type,
+                          &context
+                        ),
+                        interpolateExpression(
+                          bz.toDouble(),
+                          tz.toDouble(),
+                          bcLight,
+                          tcLight,
+                          base,
+                          1,
+                          json.value( u"x1"_s ).toDouble(),
+                          json.value( u"y1"_s ).toDouble(),
+                          json.value( u"x2"_s ).toDouble(),
+                          json.value( u"y2"_s ).toDouble(),
+                          type,
+                          &context
+                        ),
+                        interpolateExpression(
+                          bz.toDouble(),
+                          tz.toDouble(),
+                          bcAlpha,
+                          tcAlpha,
+                          base,
+                          1,
+                          json.value( u"x1"_s ).toDouble(),
+                          json.value( u"y1"_s ).toDouble(),
+                          json.value( u"x2"_s ).toDouble(),
+                          json.value( u"y2"_s ).toDouble(),
+                          type,
+                          &context
+                        )
                       );
     }
     else
@@ -2523,19 +2575,70 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateColorByZoom( const QVaria
       const QString bottomColorExpr = parseColorExpression( bcVariant, context );
       const QString topColorExpr = parseColorExpression( tcVariant, context );
 
-      caseString
-        += QStringLiteral(
-             "WHEN @vector_tile_zoom >= %1 AND @vector_tile_zoom < %2 THEN color_hsla("
-             "%3, %4, %5, %6) "
-        )
-             .arg(
-               bz,
-               tz,
-               interpolateExpression( bz.toDouble(), tz.toDouble(), colorComponent.arg( bottomColorExpr ).arg( "hsl_hue" ), colorComponent.arg( topColorExpr ).arg( "hsl_hue" ), base, 1, &context ),
-               interpolateExpression( bz.toDouble(), tz.toDouble(), colorComponent.arg( bottomColorExpr ).arg( "hsl_saturation" ), colorComponent.arg( topColorExpr ).arg( "hsl_saturation" ), base, 1, &context ),
-               interpolateExpression( bz.toDouble(), tz.toDouble(), colorComponent.arg( bottomColorExpr ).arg( "lightness" ), colorComponent.arg( topColorExpr ).arg( "lightness" ), base, 1, &context ),
-               interpolateExpression( bz.toDouble(), tz.toDouble(), colorComponent.arg( bottomColorExpr ).arg( "alpha" ), colorComponent.arg( topColorExpr ).arg( "alpha" ), base, 1, &context )
-             );
+      caseString += QStringLiteral(
+                      "WHEN @vector_tile_zoom >= %1 AND @vector_tile_zoom < %2 THEN color_hsla("
+                      "%3, %4, %5, %6) "
+      )
+                      .arg(
+                        bz,
+                        tz,
+                        interpolateExpression(
+                          bz.toDouble(),
+                          tz.toDouble(),
+                          colorComponent.arg( bottomColorExpr ).arg( "hsl_hue" ),
+                          colorComponent.arg( topColorExpr ).arg( "hsl_hue" ),
+                          base,
+                          1,
+                          json.value( u"x1"_s ).toDouble(),
+                          json.value( u"y1"_s ).toDouble(),
+                          json.value( u"x2"_s ).toDouble(),
+                          json.value( u"y2"_s ).toDouble(),
+                          type,
+                          &context
+                        ),
+                        interpolateExpression(
+                          bz.toDouble(),
+                          tz.toDouble(),
+                          colorComponent.arg( bottomColorExpr ).arg( "hsl_saturation" ),
+                          colorComponent.arg( topColorExpr ).arg( "hsl_saturation" ),
+                          base,
+                          1,
+                          json.value( u"x1"_s ).toDouble(),
+                          json.value( u"y1"_s ).toDouble(),
+                          json.value( u"x2"_s ).toDouble(),
+                          json.value( u"y2"_s ).toDouble(),
+                          type,
+                          &context
+                        ),
+                        interpolateExpression(
+                          bz.toDouble(),
+                          tz.toDouble(),
+                          colorComponent.arg( bottomColorExpr ).arg( "lightness" ),
+                          colorComponent.arg( topColorExpr ).arg( "lightness" ),
+                          base,
+                          1,
+                          json.value( u"x1"_s ).toDouble(),
+                          json.value( u"y1"_s ).toDouble(),
+                          json.value( u"x2"_s ).toDouble(),
+                          json.value( u"y2"_s ).toDouble(),
+                          type,
+                          &context
+                        ),
+                        interpolateExpression(
+                          bz.toDouble(),
+                          tz.toDouble(),
+                          colorComponent.arg( bottomColorExpr ).arg( "alpha" ),
+                          colorComponent.arg( topColorExpr ).arg( "alpha" ),
+                          base,
+                          1,
+                          json.value( u"x1"_s ).toDouble(),
+                          json.value( u"y1"_s ).toDouble(),
+                          json.value( u"x2"_s ).toDouble(),
+                          json.value( u"y2"_s ).toDouble(),
+                          type,
+                          &context
+                        )
+                      );
     }
   }
 
@@ -2585,7 +2688,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateColorByZoom( const QVaria
   return QgsProperty::fromExpression( caseString );
 }
 
-QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, double multiplier, double *defaultNumber )
+QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, double multiplier, double *defaultNumber, InterpolationType type )
 {
   const double base = json.value( u"base"_s, u"1"_s ).toDouble();
   const QVariantList stops = json.value( u"stops"_s ).toList();
@@ -2602,12 +2705,18 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateByZoom( const QVariantMap
       stops.last().toList().value( 1 ),                // valueMax
       base,
       multiplier,
+      json.value( u"x1"_s ).toDouble(),
+      json.value( u"y1"_s ).toDouble(),
+      json.value( u"x2"_s ).toDouble(),
+      json.value( u"y2"_s ).toDouble(),
+      type,
       &context
     );
   }
   else
   {
-    scaleExpression = parseStops( base, stops, multiplier, context );
+    scaleExpression
+      = parseStops( base, stops, multiplier, context, type, json.value( u"x1"_s ).toDouble(), json.value( u"y1"_s ).toDouble(), json.value( u"x2"_s ).toDouble(), json.value( u"y2"_s ).toDouble() );
   }
 
   if ( !stops.empty() && defaultNumber )
@@ -2616,7 +2725,7 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateByZoom( const QVariantMap
   return QgsProperty::fromExpression( scaleExpression );
 }
 
-QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateOpacityByZoom( const QVariantMap &json, int maxOpacity, QgsMapBoxGlStyleConversionContext *contextPtr )
+QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateOpacityByZoom( const QVariantMap &json, int maxOpacity, QgsMapBoxGlStyleConversionContext *contextPtr, InterpolationType type )
 {
   QgsMapBoxGlStyleConversionContext context;
   if ( contextPtr )
@@ -2643,17 +2752,25 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateOpacityByZoom( const QVar
       numeric ? QString::number( top * maxOpacity ) : QString( "(%1) * %2" ).arg( parseValue( tv, context ) ).arg( maxOpacity ),
       base,
       1,
+      json.value( u"x1"_s ).toDouble(),
+      json.value( u"y1"_s ).toDouble(),
+      json.value( u"x2"_s ).toDouble(),
+      json.value( u"y2"_s ).toDouble(),
+      type,
       &context
     ) );
   }
   else
   {
-    scaleExpression = parseOpacityStops( base, stops, maxOpacity, context );
+    scaleExpression
+      = parseOpacityStops( base, stops, maxOpacity, context, type, json.value( u"x1"_s ).toDouble(), json.value( u"y1"_s ).toDouble(), json.value( u"x2"_s ).toDouble(), json.value( u"y2"_s ).toDouble() );
   }
   return QgsProperty::fromExpression( scaleExpression );
 }
 
-QString QgsMapBoxGlStyleConverter::parseOpacityStops( double base, const QVariantList &stops, int maxOpacity, QgsMapBoxGlStyleConversionContext &context )
+QString QgsMapBoxGlStyleConverter::parseOpacityStops(
+  double base, const QVariantList &stops, int maxOpacity, QgsMapBoxGlStyleConversionContext &context, InterpolationType type, double x1, double y1, double x2, double y2
+)
 {
   QString caseString = u"CASE WHEN @vector_tile_zoom < %1 THEN set_color_part(@symbol_color, 'alpha', %2)"_s.arg( stops.value( 0 ).toList().value( 0 ).toString() )
                          .arg( stops.value( 0 ).toList().value( 1 ).toDouble() * maxOpacity );
@@ -2680,6 +2797,11 @@ QString QgsMapBoxGlStyleConverter::parseOpacityStops( double base, const QVarian
                         numeric ? QString::number( top * maxOpacity ) : QString( "(%1) * %2" ).arg( parseValue( tv, context ) ).arg( maxOpacity ),
                         base,
                         1,
+                        x1,
+                        y1,
+                        x2,
+                        y2,
+                        type,
                         &context
                       )
                     );
@@ -2698,7 +2820,7 @@ QString QgsMapBoxGlStyleConverter::parseOpacityStops( double base, const QVarian
   return caseString;
 }
 
-QgsProperty QgsMapBoxGlStyleConverter::parseInterpolatePointByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, double multiplier, QPointF *defaultPoint )
+QgsProperty QgsMapBoxGlStyleConverter::parseInterpolatePointByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, double multiplier, QPointF *defaultPoint, InterpolationType type )
 {
   const double base = json.value( u"base"_s, u"1"_s ).toDouble();
   const QVariantList stops = json.value( u"stops"_s ).toList();
@@ -2716,6 +2838,11 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolatePointByZoom( const QVaria
         stops.last().toList().value( 1 ).toList().value( 0 ),
         base,
         multiplier,
+        json.value( u"x1"_s ).toDouble(),
+        json.value( u"y1"_s ).toDouble(),
+        json.value( u"x2"_s ).toDouble(),
+        json.value( u"y2"_s ).toDouble(),
+        type,
         &context
       ),
       interpolateExpression(
@@ -2725,13 +2852,19 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolatePointByZoom( const QVaria
         stops.last().toList().value( 1 ).toList().value( 1 ),
         base,
         multiplier,
+        json.value( u"x1"_s ).toDouble(),
+        json.value( u"y1"_s ).toDouble(),
+        json.value( u"x2"_s ).toDouble(),
+        json.value( u"y2"_s ).toDouble(),
+        type,
         &context
       )
     );
   }
   else
   {
-    scaleExpression = parsePointStops( base, stops, context, multiplier );
+    scaleExpression
+      = parsePointStops( base, stops, context, multiplier, type, json.value( u"x1"_s ).toDouble(), json.value( u"y1"_s ).toDouble(), json.value( u"x2"_s ).toDouble(), json.value( u"y2"_s ).toDouble() );
   }
 
   if ( !stops.empty() && defaultPoint )
@@ -2751,7 +2884,9 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateStringByZoom( const QVari
   return QgsProperty::fromExpression( scaleExpression );
 }
 
-QString QgsMapBoxGlStyleConverter::parsePointStops( double base, const QVariantList &stops, QgsMapBoxGlStyleConversionContext &context, double multiplier )
+QString QgsMapBoxGlStyleConverter::parsePointStops(
+  double base, const QVariantList &stops, QgsMapBoxGlStyleConversionContext &context, double multiplier, InterpolationType type, double x1, double y1, double x2, double y2
+)
 {
   QString caseString = u"CASE "_s;
 
@@ -2782,8 +2917,8 @@ QString QgsMapBoxGlStyleConverter::parsePointStops( double base, const QVariantL
                     .arg(
                       bz.toString(),
                       tz.toString(),
-                      interpolateExpression( bz.toDouble(), tz.toDouble(), bv.toList().value( 0 ), tv.toList().value( 0 ), base, multiplier, &context ),
-                      interpolateExpression( bz.toDouble(), tz.toDouble(), bv.toList().value( 1 ), tv.toList().value( 1 ), base, multiplier, &context )
+                      interpolateExpression( bz.toDouble(), tz.toDouble(), bv.toList().value( 0 ), tv.toList().value( 0 ), base, multiplier, x1, y1, x2, y2, type, &context ),
+                      interpolateExpression( bz.toDouble(), tz.toDouble(), bv.toList().value( 1 ), tv.toList().value( 1 ), base, multiplier, x1, y1, x2, y2, type, &context )
                     );
   }
   caseString += "END"_L1;
@@ -2829,7 +2964,9 @@ QString QgsMapBoxGlStyleConverter::parseArrayStops( const QVariantList &stops, Q
   return caseString;
 }
 
-QString QgsMapBoxGlStyleConverter::parseStops( double base, const QVariantList &stops, double multiplier, QgsMapBoxGlStyleConversionContext &context )
+QString QgsMapBoxGlStyleConverter::parseStops(
+  double base, const QVariantList &stops, double multiplier, QgsMapBoxGlStyleConversionContext &context, InterpolationType type, double x1, double y1, double x2, double y2
+)
 {
   QString caseString = u"CASE "_s;
 
@@ -2859,7 +2996,7 @@ QString QgsMapBoxGlStyleConverter::parseStops( double base, const QVariantList &
                     "WHEN @vector_tile_zoom %1 %2 AND @vector_tile_zoom <= %3 "
                     "THEN %4 "
     )
-                    .arg( lowerComparator, bz.toString(), tz.toString(), interpolateExpression( bz.toDouble(), tz.toDouble(), bv, tv, base, multiplier, &context ) );
+                    .arg( lowerComparator, bz.toString(), tz.toString(), interpolateExpression( bz.toDouble(), tz.toDouble(), bv, tv, base, multiplier, x1, y1, x2, y2, type, &context ) );
   }
 
   const QVariant z = stops.last().toList().value( 0 );
@@ -3266,16 +3403,29 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateListByZoom(
     return QgsProperty();
   }
 
-  double base = 1;
-  const QString technique = json.value( 1 ).toList().value( 0 ).toString();
+  const QVariantList parts = json.value( 1 ).toList();
+  const QString technique = parts.value( 0 ).toString();
+  InterpolationType interpolationType = InterpolationType::Linear;
+  QVariantMap props;
+
   if ( technique == "linear"_L1 )
-    base = 1;
+  {
+    props.insert( u"base"_s, 1 );
+    interpolationType = InterpolationType::Linear;
+  }
   else if ( technique == "exponential"_L1 )
-    base = json.value( 1 ).toList().value( 1 ).toDouble();
+  {
+    props.insert( u"base"_s, parts.value( 1 ).toDouble() );
+    interpolationType = InterpolationType::Exponential;
+  }
   else if ( technique == "cubic-bezier"_L1 )
   {
-    context.pushWarning( QObject::tr( "%1: Cubic-bezier interpolation is not supported, linear used instead." ).arg( context.layerId() ) );
-    base = 1;
+    interpolationType = InterpolationType::CubicBezier;
+
+    props.insert( u"x1"_s, parts.value( 1 ).toDouble() );
+    props.insert( u"y1"_s, parts.value( 2 ).toDouble() );
+    props.insert( u"x2"_s, parts.value( 3 ).toDouble() );
+    props.insert( u"y2"_s, parts.value( 4 ).toDouble() );
   }
   else
   {
@@ -3296,22 +3446,21 @@ QgsProperty QgsMapBoxGlStyleConverter::parseInterpolateListByZoom(
     stops.push_back( QVariantList() << json.value( i ).toString() << json.value( i + 1 ) );
   }
 
-  QVariantMap props;
   props.insert( u"stops"_s, stops );
-  props.insert( u"base"_s, base );
+
   switch ( type )
   {
     case PropertyType::Color:
-      return parseInterpolateColorByZoom( props, context, defaultColor );
+      return parseInterpolateColorByZoom( props, context, defaultColor, interpolationType );
 
     case PropertyType::Numeric:
-      return parseInterpolateByZoom( props, context, multiplier, defaultNumber );
+      return parseInterpolateByZoom( props, context, multiplier, defaultNumber, interpolationType );
 
     case PropertyType::Opacity:
-      return parseInterpolateOpacityByZoom( props, maxOpacity, &context );
+      return parseInterpolateOpacityByZoom( props, maxOpacity, &context, interpolationType );
 
     case PropertyType::Point:
-      return parseInterpolatePointByZoom( props, context, multiplier );
+      return parseInterpolatePointByZoom( props, context, multiplier, nullptr, interpolationType );
 
     case PropertyType::NumericArray:
       context.pushWarning( QObject::tr( "%1: Skipping unsupported numeric array in interpolate" ).arg( context.layerId() ) );
@@ -3348,7 +3497,9 @@ void QgsMapBoxGlStyleConverter::colorAsHslaComponents( const QColor &color, int 
   alpha = color.alpha();
 }
 
-QString QgsMapBoxGlStyleConverter::interpolateExpression( double zoomMin, double zoomMax, QVariant valueMin, QVariant valueMax, double base, double multiplier, QgsMapBoxGlStyleConversionContext *contextPtr )
+QString QgsMapBoxGlStyleConverter::interpolateExpression(
+  double zoomMin, double zoomMax, QVariant valueMin, QVariant valueMax, double base, double multiplier, double x1, double y1, double x2, double y2, InterpolationType type, QgsMapBoxGlStyleConversionContext *contextPtr
+)
 {
   QgsMapBoxGlStyleConversionContext context;
   if ( contextPtr )
@@ -3387,13 +3538,25 @@ QString QgsMapBoxGlStyleConverter::interpolateExpression( double zoomMin, double
   }
   else
   {
-    if ( base == 1 )
+    switch ( type )
     {
-      expression = u"scale_linear(@vector_tile_zoom,%1,%2,%3,%4)"_s.arg( zoomMin ).arg( zoomMax ).arg( minValueExpr ).arg( maxValueExpr );
-    }
-    else
-    {
-      expression = u"scale_exponential(@vector_tile_zoom,%1,%2,%3,%4,%5)"_s.arg( zoomMin ).arg( zoomMax ).arg( minValueExpr ).arg( maxValueExpr ).arg( base );
+      case InterpolationType::Linear:
+        expression = u"scale_linear(@vector_tile_zoom,%1,%2,%3,%4)"_s.arg( zoomMin ).arg( zoomMax ).arg( minValueExpr ).arg( maxValueExpr );
+        break;
+      case InterpolationType::Exponential:
+        if ( base == 1 )
+        {
+          expression = u"scale_linear(@vector_tile_zoom,%1,%2,%3,%4)"_s.arg( zoomMin ).arg( zoomMax ).arg( minValueExpr ).arg( maxValueExpr );
+        }
+        else
+        {
+          expression = u"scale_exponential(@vector_tile_zoom,%1,%2,%3,%4,%5)"_s.arg( zoomMin ).arg( zoomMax ).arg( minValueExpr ).arg( maxValueExpr ).arg( base );
+        }
+        break;
+
+      case InterpolationType::CubicBezier:
+        expression = u"scale_cubic_bezier(@vector_tile_zoom,%1,%2,%3,%4,%5,%6,%7,%8)"_s.arg( zoomMin ).arg( zoomMax ).arg( minValueExpr ).arg( maxValueExpr ).arg( x1 ).arg( y1 ).arg( x2 ).arg( y2 );
+        break;
     }
   }
 

--- a/src/core/vectortile/qgsmapboxglstyleconverter.h
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.h
@@ -374,6 +374,19 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
     Q_ENUM( PropertyType )
 
     /**
+     * Interpolation types, for interpolated value conversion
+     * \warning This is private API only, and may change in future QGIS versions
+     * \since QGIS 4.2
+     */
+    enum class InterpolationType
+    {
+      Linear,      //!< Linear interpolation
+      Exponential, //!< Exponential interpolation
+      CubicBezier, //!< Cubic-bezier interpolation
+    };
+    Q_ENUM( InterpolationType )
+
+    /**
      * Converts a JSON \a style map, and returns the resultant status of the conversion.
      *
      * If an error occurs during conversion then a descriptive error message can be retrieved
@@ -550,10 +563,16 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      * \param json definition of color interpolation
      * \param context conversion context
      * \param defaultColor optional storage for a reasonable "default" color representing the overall property.
+     * \param type interpolation type (since QGIS 4.2)
      *
      * \returns QgsProperty representing interpolation settings
      */
-    static QgsProperty parseInterpolateColorByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, QColor *defaultColor SIP_OUT = nullptr );
+    static QgsProperty parseInterpolateColorByZoom(
+      const QVariantMap &json,
+      QgsMapBoxGlStyleConversionContext &context,
+      QColor *defaultColor SIP_OUT = nullptr,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential
+    );
 
     /**
      * Parses a numeric value which is interpolated by zoom range.
@@ -562,10 +581,17 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      * \param context conversion context
      * \param multiplier optional multiplication factor
      * \param defaultNumber optional storage for a reasonable "default" number representing the overall property.
+     * \param type interpolation type (since QGIS 4.2)
      *
      * \returns QgsProperty representing interpolation settings
      */
-    static QgsProperty parseInterpolateByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, double multiplier = 1, double *defaultNumber SIP_OUT = nullptr );
+    static QgsProperty parseInterpolateByZoom(
+      const QVariantMap &json,
+      QgsMapBoxGlStyleConversionContext &context,
+      double multiplier = 1,
+      double *defaultNumber SIP_OUT = nullptr,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential
+    );
 
     /**
      * Interpolates opacity with either scale_linear() or scale_exp() (depending on base value).
@@ -574,7 +600,12 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      *
      * \warning This is private API only, and may change in future QGIS versions
      */
-    static QgsProperty parseInterpolateOpacityByZoom( const QVariantMap &json, int maxOpacity, QgsMapBoxGlStyleConversionContext *contextPtr = nullptr );
+    static QgsProperty parseInterpolateOpacityByZoom(
+      const QVariantMap &json,
+      int maxOpacity,
+      QgsMapBoxGlStyleConversionContext *contextPtr = nullptr,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential
+    );
 
     /**
      * Takes values from stops and uses either scale_linear() or scale_exp() functions
@@ -582,7 +613,17 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      *
      * \warning This is private API only, and may change in future QGIS versions
      */
-    static QString parseOpacityStops( double base, const QVariantList &stops, int maxOpacity, QgsMapBoxGlStyleConversionContext &context );
+    static QString parseOpacityStops(
+      double base,
+      const QVariantList &stops,
+      int maxOpacity,
+      QgsMapBoxGlStyleConversionContext &context,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential,
+      double x1 = 0,
+      double y1 = 0,
+      double x2 = 1,
+      double y2 = 1
+    );
 
     /**
      * Interpolates a point/offset with either scale_linear() or scale_exp() (depending on base value).
@@ -590,7 +631,13 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      *
      * \warning This is private API only, and may change in future QGIS versions
      */
-    static QgsProperty parseInterpolatePointByZoom( const QVariantMap &json, QgsMapBoxGlStyleConversionContext &context, double multiplier = 1, QPointF *defaultPoint SIP_OUT = nullptr );
+    static QgsProperty parseInterpolatePointByZoom(
+      const QVariantMap &json,
+      QgsMapBoxGlStyleConversionContext &context,
+      double multiplier = 1,
+      QPointF *defaultPoint SIP_OUT = nullptr,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential
+    );
 
     /**
      * Interpolates a string by zoom.
@@ -606,7 +653,17 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      *
      * \warning This is private API only, and may change in future QGIS versions
      */
-    static QString parsePointStops( double base, const QVariantList &stops, QgsMapBoxGlStyleConversionContext &context, double multiplier = 1 );
+    static QString parsePointStops(
+      double base,
+      const QVariantList &stops,
+      QgsMapBoxGlStyleConversionContext &context,
+      double multiplier = 1,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential,
+      double x1 = 0,
+      double y1 = 0,
+      double x2 = 0,
+      double y2 = 0
+    );
 
     /**
      * Takes numerical arrays from stops.
@@ -622,8 +679,23 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      * \param stops definition of interpolation stops
      * \param multiplier optional multiplication factor
      * \param context conversion context
+     * \param type interpolation type
+     * \param x1 control point for bezier-cubic interpolation
+     * \param y1 control point for bezier-cubic interpolation
+     * \param x2 control point for bezier-cubic interpolation
+     * \param y2 control point for bezier-cubic interpolation
      */
-    static QString parseStops( double base, const QVariantList &stops, double multiplier, QgsMapBoxGlStyleConversionContext &context );
+    static QString parseStops(
+      double base,
+      const QVariantList &stops,
+      double multiplier,
+      QgsMapBoxGlStyleConversionContext &context,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential,
+      double x1 = 0,
+      double y1 = 0,
+      double x2 = 1,
+      double y2 = 1
+    );
 
     /**
      * Parses a list of interpolation stops containing string values.
@@ -751,7 +823,20 @@ class CORE_EXPORT QgsMapBoxGlStyleConverter
      *
      * \warning This is private API only, and may change in future QGIS versions
      */
-    static QString interpolateExpression( double zoomMin, double zoomMax, QVariant valueMin, QVariant valueMax, double base, double multiplier = 1, QgsMapBoxGlStyleConversionContext *contextPtr = nullptr );
+    static QString interpolateExpression(
+      double zoomMin,
+      double zoomMax,
+      QVariant valueMin,
+      QVariant valueMax,
+      double base,
+      double multiplier = 1,
+      double x1 = 0,
+      double y1 = 0,
+      double x2 = 1,
+      double y2 = 1,
+      QgsMapBoxGlStyleConverter::InterpolationType type = QgsMapBoxGlStyleConverter::InterpolationType::Exponential,
+      QgsMapBoxGlStyleConversionContext *contextPtr = nullptr
+    );
 
     /**
      * Converts a value to Qt::PenCapStyle enum from JSON value.

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1188,6 +1188,24 @@ class TestQgsExpression : public QObject
       QTest::newRow( "scale_exponential(5,0,10,0,100,2)" ) << "scale_exponential(5,0,10,0,100,2)" << false << QVariant( 3.0303030303030303 );
       QTest::newRow( "scale_exponential(3,0,10,0,100,0.5)" ) << "scale_exponential(3,0,10,0,100,0.5)" << false << QVariant( 87.58553274682306 );
 
+      QTest::newRow( "scale_cubic_bezier(5, 0, 10, 0, 100, 0, 0, 1, 1)" ) << "scale_cubic_bezier(5, 0, 10, 0, 100, 0, 0, 1, 1)" << false << QVariant( 50.0 );
+      QTest::newRow( "scale_cubic_bezier(0, 0, 10, 0, 100, 0, 0, 1, 1)" ) << "scale_cubic_bezier(0, 0, 10, 0, 100, 0, 0, 1, 1)" << false << QVariant( 0.0 );
+      QTest::newRow( "scale_cubic_bezier(10, 0, 10, 0, 100, 0, 0, 1, 1)" ) << "scale_cubic_bezier(10, 0, 10, 0, 100, 0, 0, 1, 1)" << false << QVariant( 100.0 );
+      QTest::newRow( "scale_cubic_bezier(-1, 0, 10, 0, 100, 0, 0, 1, 1)" ) << "scale_cubic_bezier(-1, 0, 10, 0, 100, 0, 0, 1, 1)" << false << QVariant( 0.0 );
+      QTest::newRow( "scale_cubic_bezier(11, 0, 10, 0, 100, 0, 0, 1, 1)" ) << "scale_cubic_bezier(11, 0, 10, 0, 100, 0, 0, 1, 1)" << false << QVariant( 100.0 );
+      QTest::newRow( "scale_cubic_bezier(15, 10, 20, 100, 200, 0, 0, 1, 1)" ) << "scale_cubic_bezier(15, 10, 20, 100, 200, 0, 0, 1, 1)" << false << QVariant( 150.0 );
+      QTest::newRow( "scale_cubic_bezier(5, 0, 10, 0, 100, 0.25, 0.1, 0.25, 1.0)" ) << "round(scale_cubic_bezier(5, 0, 10, 0, 100, 0.25, 0.1, 0.25, 1.0),5)" << false << QVariant( 80.24034 );
+      QTest::newRow( "scale_cubic_bezier(5, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0)" ) << "round(scale_cubic_bezier(5, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0),5)" << false << QVariant( 50.0 );
+      QTest::newRow( "scale_cubic_bezier(5, 0, 10, 0, 100, 1.0, 0.0, 0.0, 1.0)" ) << "round(scale_cubic_bezier(5, 0, 10, 0, 100, 1.0, 0.0, 0.0, 1.0),5)" << false << QVariant( 50.0 );
+      QTest::newRow( "scale_cubic_bezier(-5, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0)" ) << "scale_cubic_bezier(-5, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0)" << false << QVariant( 0.0 );
+      QTest::newRow( "scale_cubic_bezier(0, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0)" ) << "scale_cubic_bezier(0, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0)" << false << QVariant( 0.0 );
+      QTest::newRow( "scale_cubic_bezier(10, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0)" ) << "scale_cubic_bezier(10, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0)" << false << QVariant( 100.0 );
+      QTest::newRow( "scale_cubic_bezier(15, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0)" ) << "scale_cubic_bezier(15, 0, 10, 0, 100, 0.42, 0.0, 0.58, 1.0)" << false << QVariant( 100.0 );
+      QTest::newRow( "invalid scale_cubic_bezier(5, 10, 0, 0, 100, 0, 0, 1, 1)" ) << "scale_cubic_bezier(5, 10, 0, 0, 100, 0, 0, 1, 1)" << true << QVariant();
+      QTest::newRow( "invalid scale_cubic_bezier(5, 0, 10, 0, 100, 1.5, 0, 1, 1)" ) << "scale_cubic_bezier(5, 0, 10, 0, 100, 1.5, 0, 1, 1)" << true << QVariant();
+      QTest::newRow( "invalid scale_cubic_bezier(5, 0, 10, 0, 100, -0.5, 0, 1, 1)" ) << "scale_cubic_bezier(5, 0, 10, 0, 100, -0.5, 0, 1, 1)" << true << QVariant();
+      QTest::newRow( "invalid scale_cubic_bezier(5, 0, 10, 0, 100, 0, 0, 1, 2.0)" ) << "scale_cubic_bezier(5, 0, 10, 0, 100, 0, 0, 1, 2.0)" << true << QVariant();
+
       // cast functions
       QTest::newRow( "double to int" ) << "toint(3.2)" << false << QVariant( 3 );
       QTest::newRow( "text to int" ) << "toint('53')" << false << QVariant( 53 );

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -82,6 +82,23 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
             QgsMapBoxGlStyleConverter.interpolateExpression(5, 13, 27, 27, 1.5, 2), "54"
         )
 
+        self.assertEqual(
+            QgsMapBoxGlStyleConverter.interpolateExpression(
+                5,
+                13,
+                27,
+                29,
+                1,
+                1,
+                0.42,
+                0.0,
+                0.58,
+                1.0,
+                QgsMapBoxGlStyleConverter.InterpolationType.CubicBezier,
+            ),
+            "scale_cubic_bezier(@vector_tile_zoom,5,13,27,29,0.42,0,0.58,1)",
+        )
+
     def testColorAsHslaComponents(self):
         self.assertEqual(
             QgsMapBoxGlStyleConverter.colorAsHslaComponents(QColor.fromHsl(30, 50, 70)),
@@ -642,6 +659,33 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
         self.assertEqual(
             prop.expressionString(),
             'CASE WHEN @vector_tile_zoom >= 12 AND @vector_tile_zoom <= 13 THEN (CASE WHEN ((to_real("ele") % 100) IS 0) THEN 0.75 ELSE 0 END) * 0.264583 WHEN @vector_tile_zoom > 13 AND @vector_tile_zoom <= 14 THEN (scale_linear(@vector_tile_zoom,13,14,CASE WHEN ((to_real("ele") % 100) IS 0) THEN 0.75 ELSE 0 END,CASE WHEN ((to_real("ele") % 100) IS 0) THEN 1 ELSE 0 END)) * 0.264583 WHEN @vector_tile_zoom > 14 AND @vector_tile_zoom <= 14.5 THEN (scale_linear(@vector_tile_zoom,14,14.5,CASE WHEN ((to_real("ele") % 100) IS 0) THEN 1 ELSE 0 END,CASE WHEN ((to_real("ele") % 100) IS 0) THEN 1.5 ELSE CASE WHEN ((to_real("ele") % 20) IS 0) THEN 0.75 ELSE 0 END END)) * 0.264583 WHEN @vector_tile_zoom > 14.5 AND @vector_tile_zoom <= 15 THEN (scale_linear(@vector_tile_zoom,14.5,15,CASE WHEN ((to_real("ele") % 100) IS 0) THEN 1.5 ELSE CASE WHEN ((to_real("ele") % 20) IS 0) THEN 0.75 ELSE 0 END END,CASE WHEN ((to_real("ele") % 100) IS 0) THEN 1.75 ELSE CASE WHEN ((to_real("ele") % 20) IS 0) THEN 1 ELSE 0 END END)) * 0.264583 WHEN @vector_tile_zoom > 15 AND @vector_tile_zoom <= 16.5 THEN (scale_linear(@vector_tile_zoom,15,16.5,CASE WHEN ((to_real("ele") % 100) IS 0) THEN 1.75 ELSE CASE WHEN ((to_real("ele") % 20) IS 0) THEN 1 ELSE 0 END END,CASE WHEN ((to_real("ele") % 100) IS 0) THEN 2 ELSE CASE WHEN ((to_real("ele") % 10) IS 0) THEN 1 ELSE 0 END END)) * 0.264583 WHEN @vector_tile_zoom > 16.5 THEN ( ( CASE WHEN ((to_real("ele") % 100) IS 0) THEN 2 ELSE CASE WHEN ((to_real("ele") % 10) IS 0) THEN 1 ELSE 0 END END ) * 0.264583 ) END',
+        )
+
+        prop, default_color, default_val = (
+            QgsMapBoxGlStyleConverter.parseInterpolateListByZoom(
+                [
+                    "interpolate",
+                    ["cubic-bezier", 0.2, 0, 0.9, 1],
+                    ["zoom"],
+                    3,
+                    ["step", ["get", "symbolrank"], 11, 9, 10],
+                    6,
+                    ["step", ["get", "symbolrank"], 14, 9, 12, 12, 10],
+                    8,
+                    ["step", ["get", "symbolrank"], 16, 9, 14, 12, 12, 15, 10],
+                    13,
+                    ["step", ["get", "symbolrank"], 22, 9, 20, 12, 16, 15, 14],
+                ],
+                QgsMapBoxGlStyleConverter.PropertyType.Numeric,
+                conversion_context,
+                2,
+            )
+        )
+        self.assertEqual(
+            prop.expressionString(),
+            (
+                """CASE WHEN @vector_tile_zoom >= 3 AND @vector_tile_zoom <= 6 THEN (scale_cubic_bezier(@vector_tile_zoom,3,6,CASE  WHEN "symbolrank" >= 9 THEN (10) ELSE (11) END,CASE  WHEN "symbolrank" >= 12 THEN (10)  WHEN "symbolrank" >= 9 THEN (12) ELSE (14) END,0.2,0,0.9,1)) * 2 WHEN @vector_tile_zoom > 6 AND @vector_tile_zoom <= 8 THEN (scale_cubic_bezier(@vector_tile_zoom,6,8,CASE  WHEN "symbolrank" >= 12 THEN (10)  WHEN "symbolrank" >= 9 THEN (12) ELSE (14) END,CASE  WHEN "symbolrank" >= 15 THEN (10)  WHEN "symbolrank" >= 12 THEN (12)  WHEN "symbolrank" >= 9 THEN (14) ELSE (16) END,0.2,0,0.9,1)) * 2 WHEN @vector_tile_zoom > 8 AND @vector_tile_zoom <= 13 THEN (scale_cubic_bezier(@vector_tile_zoom,8,13,CASE  WHEN "symbolrank" >= 15 THEN (10)  WHEN "symbolrank" >= 12 THEN (12)  WHEN "symbolrank" >= 9 THEN (14) ELSE (16) END,CASE  WHEN "symbolrank" >= 15 THEN (14)  WHEN "symbolrank" >= 12 THEN (16)  WHEN "symbolrank" >= 9 THEN (20) ELSE (22) END,0.2,0,0.9,1)) * 2 WHEN @vector_tile_zoom > 13 THEN ( ( CASE  WHEN "symbolrank" >= 15 THEN (14)  WHEN "symbolrank" >= 12 THEN (16)  WHEN "symbolrank" >= 9 THEN (20) ELSE (22) END ) * 2 ) END"""
+            ),
         )
 
     def testParseExpression(self):


### PR DESCRIPTION
## Description

Complements the existing scale_linear, scale_exponential functions and adds a new bezier-cubic based interpolation method. This is then used when converting MapBox styles using the "cubic-bezier" interpolation type.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
