### PR TITLE
fix(QgsDemTerrainTileLoader): avoid nullptr delete when mClonedProvider is not defined

### DIFF
--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -172,9 +172,7 @@ QgsDemHeightMapGenerator::QgsDemHeightMapGenerator( QgsRasterLayer *dtm, const Q
 {}
 
 QgsDemHeightMapGenerator::~QgsDemHeightMapGenerator()
-{
-  delete mClonedProvider;
-}
+{}
 
 
 static QByteArray _readDtmData( QgsRasterDataProvider *provider, const QgsRectangle &extent, int res, const QgsCoordinateReferenceSystem &destCrs, const QgsRectangle &clippingExtent )

--- a/src/3d/terrain/qgsdemterraintileloader_p.h
+++ b/src/3d/terrain/qgsdemterraintileloader_p.h
@@ -114,7 +114,7 @@ class QgsDemHeightMapGenerator : public QObject
     const QgsRectangle mDtmExtent;
 
     //! cloned provider to be used in worker thread
-    QgsRasterDataProvider *mClonedProvider = nullptr;
+    std::unique_ptr<QgsRasterDataProvider> mClonedProvider;
 
     QgsTilingScheme mTilingScheme;
 


### PR DESCRIPTION
Should never occur in current code state but it add safety

