### PR TITLE
fix: make uniform logic for min/max Z estimate

### DIFF
--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -433,6 +433,14 @@ class _3D_EXPORT Qgs3DUtils
      * \since QGIS 3.44
      */
     static std::unique_ptr<Qt3DRender::QCamera> copyCamera( Qt3DRender::QCamera *cam ) SIP_SKIP;
+
+    // we start with a maximal z range because we can't know this upfront. There's too many
+    // factors to consider eg vertex z data, terrain heights, data defined offsets and extrusion heights,...
+    // This range will be refined after populating the nodes to the actual z range of the generated chunks nodes.
+    // Assuming the vertical height is in meter, then it's extremely unlikely that a real vertical
+    // height will exceed this amount!
+    static constexpr double MINIMUM_VECTOR_Z_ESTIMATE = -100000;
+    static constexpr double MAXIMUM_VECTOR_Z_ESTIMATE = 100000;
 };
 
 #endif // QGS3DUTILS_H

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -390,15 +390,7 @@ Qt3DCore::QEntity *QgsRuleBased3DRenderer::createEntity( Qgs3DMapSettings *map )
   if ( !vl )
     return nullptr;
 
-  // we start with a maximal z range because we can't know this upfront. There's too many
-  // factors to consider eg vertex z data, terrain heights, data defined offsets and extrusion heights,...
-  // This range will be refined after populating the nodes to the actual z range of the generated chunks nodes.
-  // Assuming the vertical height is in meter, then it's extremely unlikely that a real vertical
-  // height will exceed this amount!
-  constexpr double MINIMUM_VECTOR_Z_ESTIMATE = -100000;
-  constexpr double MAXIMUM_VECTOR_Z_ESTIMATE = 100000;
-
-  return new QgsRuleBasedChunkedEntity( map, vl, MINIMUM_VECTOR_Z_ESTIMATE, MAXIMUM_VECTOR_Z_ESTIMATE, tilingSettings(), mRootRule );
+  return new QgsRuleBasedChunkedEntity( map, vl, Qgs3DUtils::MINIMUM_VECTOR_Z_ESTIMATE, Qgs3DUtils::MAXIMUM_VECTOR_Z_ESTIMATE, tilingSettings(), mRootRule );
 }
 
 void QgsRuleBased3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const

--- a/src/3d/qgsvectorlayer3drenderer.cpp
+++ b/src/3d/qgsvectorlayer3drenderer.cpp
@@ -69,14 +69,7 @@ Qt3DCore::QEntity *QgsVectorLayer3DRenderer::createEntity( Qgs3DMapSettings *map
   if ( !mSymbol || !vl )
     return nullptr;
 
-  // we start with a maximal z range because we can't know this upfront. There's too many
-  // factors to consider eg vertex z data, terrain heights, data defined offsets and extrusion heights,...
-  // This range will be refined after populating the nodes to the actual z range of the generated chunks nodes.
-  // Assuming the vertical height is in meter, then it's extremely unlikely that a real vertical
-  // height will exceed this amount!
-  constexpr double MINIMUM_VECTOR_Z_ESTIMATE = -100000;
-  constexpr double MAXIMUM_VECTOR_Z_ESTIMATE = 100000;
-  return new QgsVectorLayerChunkedEntity( map, vl, MINIMUM_VECTOR_Z_ESTIMATE, MAXIMUM_VECTOR_Z_ESTIMATE, tilingSettings(), mSymbol.get() );
+  return new QgsVectorLayerChunkedEntity( map, vl, Qgs3DUtils::MINIMUM_VECTOR_Z_ESTIMATE, Qgs3DUtils::MAXIMUM_VECTOR_Z_ESTIMATE, tilingSettings(), mSymbol.get() );
 }
 
 void QgsVectorLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const

--- a/src/3d/terrain/qgsterraingenerator.cpp
+++ b/src/3d/terrain/qgsterraingenerator.cpp
@@ -32,7 +32,11 @@ QgsBox3D QgsTerrainGenerator::rootChunkBox3D( const Qgs3DMapSettings &map ) cons
 
   float hMin, hMax;
   rootChunkHeightRange( hMin, hMax );
-  return QgsBox3D( te.xMinimum(), te.yMinimum(), hMin * map.terrainSettings()->verticalScale(), te.xMaximum(), te.yMaximum(), hMax * map.terrainSettings()->verticalScale() );
+  if ( hMin > Qgs3DUtils::MINIMUM_VECTOR_Z_ESTIMATE )
+    hMin *= static_cast<float>( map.terrainSettings()->verticalScale() );
+  if ( hMax < Qgs3DUtils::MAXIMUM_VECTOR_Z_ESTIMATE )
+    hMax *= static_cast<float>( map.terrainSettings()->verticalScale() );
+  return QgsBox3D( te.xMinimum(), te.yMinimum(), hMin, te.xMaximum(), te.yMaximum(), hMax );
 }
 
 float QgsTerrainGenerator::rootChunkError( const Qgs3DMapSettings &map ) const
@@ -46,8 +50,16 @@ float QgsTerrainGenerator::rootChunkError( const Qgs3DMapSettings &map ) const
 void QgsTerrainGenerator::rootChunkHeightRange( float &hMin, float &hMax ) const
 {
   // TODO: makes sense to have kind of default implementation?
-  hMin = 0;
-  hMax = 8848;
+  hMin = Qgs3DUtils::MINIMUM_VECTOR_Z_ESTIMATE;
+  hMax = Qgs3DUtils::MAXIMUM_VECTOR_Z_ESTIMATE;
+}
+
+float QgsTerrainGenerator::heightAt( double x, double y, const Qgs3DRenderContext &context ) const
+{
+  Q_UNUSED( x )
+  Q_UNUSED( y )
+  Q_UNUSED( context )
+  return std::numeric_limits<float>::quiet_NaN();
 }
 
 QString QgsTerrainGenerator::typeToString( QgsTerrainGenerator::Type type )

--- a/src/3d/terrain/qgsterraingenerator.cpp
+++ b/src/3d/terrain/qgsterraingenerator.cpp
@@ -32,10 +32,6 @@ QgsBox3D QgsTerrainGenerator::rootChunkBox3D( const Qgs3DMapSettings &map ) cons
 
   float hMin, hMax;
   rootChunkHeightRange( hMin, hMax );
-  if ( hMin > Qgs3DUtils::MINIMUM_VECTOR_Z_ESTIMATE )
-    hMin *= static_cast<float>( map.terrainSettings()->verticalScale() );
-  if ( hMax < Qgs3DUtils::MAXIMUM_VECTOR_Z_ESTIMATE )
-    hMax *= static_cast<float>( map.terrainSettings()->verticalScale() );
   return QgsBox3D( te.xMinimum(), te.yMinimum(), hMin, te.xMaximum(), te.yMaximum(), hMax );
 }
 

--- a/src/3d/terrain/qgsterraingenerator.cpp
+++ b/src/3d/terrain/qgsterraingenerator.cpp
@@ -54,14 +54,6 @@ void QgsTerrainGenerator::rootChunkHeightRange( float &hMin, float &hMax ) const
   hMax = Qgs3DUtils::MAXIMUM_VECTOR_Z_ESTIMATE;
 }
 
-float QgsTerrainGenerator::heightAt( double x, double y, const Qgs3DRenderContext &context ) const
-{
-  Q_UNUSED( x )
-  Q_UNUSED( y )
-  Q_UNUSED( context )
-  return std::numeric_limits<float>::quiet_NaN();
-}
-
 QString QgsTerrainGenerator::typeToString( QgsTerrainGenerator::Type type )
 {
   switch ( type )


### PR DESCRIPTION
Min max Z estimates are made differently from one renderer to another. This PR fixes that.