### PR TITLE
fix(point3dsymbol): make elevation relative to chunk origin

### DIFF
--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -555,7 +555,7 @@ void Qgs3DUtils::extractPointPositions(
     positions.append( QVector3D(
       static_cast<float>( pt.x() - chunkOrigin.x() + translation.x() ),
       static_cast<float>( pt.y() - chunkOrigin.y() + translation.y() ),
-      static_cast< float >( h + translation.z() )
+      static_cast<float>( h - chunkOrigin.z() + translation.z() )
     ) );
     // clang-format on
     QgsDebugMsgLevel( u"%1 %2 %3"_s.arg( positions.last().x() ).arg( positions.last().y() ).arg( positions.last().z() ), 2 );

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -685,8 +685,8 @@ void QgsModelPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qg
   // the elevation offset is applied separately in QTransform added to sub-entities
   const float symbolHeight = mSymbol->transform().data()[14];
   // as we are relative to chunk center elevation we have to add mChunkOrigin.z()
-  mZMin += symbolHeight + static_cast<float>( mChunkOrigin.z() );
-  mZMax += symbolHeight + static_cast<float>( mChunkOrigin.z() );
+  mZMin += static_cast<float>( symbolHeight + mChunkOrigin.z() );
+  mZMax += static_cast<float>( symbolHeight + mChunkOrigin.z() );
 }
 
 void QgsModelPoint3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )
@@ -939,8 +939,8 @@ void QgsPoint3DBillboardSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
   // the elevation offset is applied externally through a QTransform of QEntity so let's account for it
   const float billboardHeight = mSymbol->billboardHeight();
   // as we are relative to chunk center elevation we have to add mChunkOrigin.z()
-  mZMin += billboardHeight + static_cast<float>( mChunkOrigin.z() );
-  mZMax += billboardHeight + static_cast<float>( mChunkOrigin.z() );
+  mZMin += static_cast<float>( billboardHeight + mChunkOrigin.z() );
+  mZMax += static_cast<float>( billboardHeight + mChunkOrigin.z() );
 }
 
 void QgsPoint3DBillboardSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -265,8 +265,8 @@ void QgsInstancedPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
       }
 
       // as we are relative to chunk center elevation we have to add mChunkOrigin.z()
-      minZ += pos.z() + static_cast<float>( mChunkOrigin.z() );
-      maxZ += pos.z() + static_cast<float>( mChunkOrigin.z() );
+      minZ += static_cast< float >( pos.z() + mChunkOrigin.z() );
+      maxZ += static_cast< float >( pos.z() + mChunkOrigin.z() );
 
       if ( minZ < mZMin )
         mZMin = static_cast< float >( minZ );

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -265,8 +265,8 @@ void QgsInstancedPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
       }
 
       // as we are relative to chunk center elevation we have to add mChunkOrigin.z()
-      minZ += static_cast< float >( pos.z() + mChunkOrigin.z() );
-      maxZ += static_cast< float >( pos.z() + mChunkOrigin.z() );
+      minZ += pos.z() + mChunkOrigin.z();
+      maxZ += pos.z() + mChunkOrigin.z();
 
       if ( minZ < mZMin )
         mZMin = static_cast< float >( minZ );

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -264,8 +264,8 @@ void QgsInstancedPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
         maxZ *= zScale;
       }
 
-      minZ += pos.z();
-      maxZ += pos.z();
+      minZ += pos.z() + static_cast<float>( mChunkOrigin.z() );
+      maxZ += pos.z() + static_cast<float>( mChunkOrigin.z() );
 
       if ( minZ < mZMin )
         mZMin = static_cast< float >( minZ );
@@ -685,6 +685,9 @@ void QgsModelPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qg
   const float symbolHeight = mSymbol->transform().data()[14];
   mZMin += symbolHeight;
   mZMax += symbolHeight;
+
+  mZMin += static_cast<float>( mChunkOrigin.z() );
+  mZMax += static_cast<float>( mChunkOrigin.z() );
 }
 
 void QgsModelPoint3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )
@@ -938,6 +941,9 @@ void QgsPoint3DBillboardSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
   const float billboardHeight = mSymbol->billboardHeight();
   mZMin += billboardHeight;
   mZMax += billboardHeight;
+
+  mZMin += static_cast<float>( mChunkOrigin.z() );
+  mZMax += static_cast<float>( mChunkOrigin.z() );
 }
 
 void QgsPoint3DBillboardSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -264,6 +264,7 @@ void QgsInstancedPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
         maxZ *= zScale;
       }
 
+      // as we are relative to chunk center elevation we have to add mChunkOrigin.z()
       minZ += pos.z() + static_cast<float>( mChunkOrigin.z() );
       maxZ += pos.z() + static_cast<float>( mChunkOrigin.z() );
 
@@ -683,11 +684,9 @@ void QgsModelPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qg
 
   // the elevation offset is applied separately in QTransform added to sub-entities
   const float symbolHeight = mSymbol->transform().data()[14];
-  mZMin += symbolHeight;
-  mZMax += symbolHeight;
-
-  mZMin += static_cast<float>( mChunkOrigin.z() );
-  mZMax += static_cast<float>( mChunkOrigin.z() );
+  // as we are relative to chunk center elevation we have to add mChunkOrigin.z()
+  mZMin += symbolHeight + static_cast<float>( mChunkOrigin.z() );
+  mZMax += symbolHeight + static_cast<float>( mChunkOrigin.z() );
 }
 
 void QgsModelPoint3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )
@@ -939,11 +938,9 @@ void QgsPoint3DBillboardSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
 
   // the elevation offset is applied externally through a QTransform of QEntity so let's account for it
   const float billboardHeight = mSymbol->billboardHeight();
-  mZMin += billboardHeight;
-  mZMax += billboardHeight;
-
-  mZMin += static_cast<float>( mChunkOrigin.z() );
-  mZMax += static_cast<float>( mChunkOrigin.z() );
+  // as we are relative to chunk center elevation we have to add mChunkOrigin.z()
+  mZMin += billboardHeight + static_cast<float>( mChunkOrigin.z() );
+  mZMax += billboardHeight + static_cast<float>( mChunkOrigin.z() );
 }
 
 void QgsPoint3DBillboardSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )


### PR DESCRIPTION
Elevation data are referenced according to 0 but X/Y coordinates are computed according to chunk center. This PR makes the chunk center reference common to all coordinates.