### PR TITLE
pyplugininstaller:showPluginManagerWhenReady - Add a parameter to set the filter term

### DIFF
--- a/python/PyQt6/gui/auto_generated/qgspluginmanagerinterface.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgspluginmanagerinterface.sip.in
@@ -51,9 +51,12 @@ clear the repository listWidget
 add repository to the repository listWidget
 %End
 
-    virtual void showPluginManager( int tabIndex = -1 ) = 0;
+    virtual void showPluginManager( int tabIndex = -1, const QString &searchTerm = QString() ) = 0;
 %Docstring
-show the Plugin Manager window and optionally open tab tabIndex
+Shows the Plugin Manager window and optionally open tab tabIndex and
+pre-fill search term.
+
+The ``searchTerm`` argument was added in QGIS 4.2
 %End
 
     virtual void pushMessage( const QString &text, Qgis::MessageLevel level = Qgis::MessageLevel::Info, int duration = -1 ) = 0;

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -319,15 +319,20 @@ class QgsPluginInstaller(QObject):
         self.exportPluginsToManager()
 
     # ----------------------------------------- #
-    def showPluginManagerWhenReady(self, tab_index: int = -1) -> None:
+    def showPluginManagerWhenReady(
+        self, tab_index: int = -1, search_term: str = ""
+    ) -> None:
         """
         Open the plugin manager window.
 
         If fetching is still in progress, it shows the progress window first
-        Optionally pass the index of tab to be opened
+        Optionally pass the index of tab to be opened and a search term
+        to filter plugins in the manager
 
         :param tab_index: index of the tab to be opened
         :type tab_index: int
+        :param search_term: text used to filter plugins in the manager
+        :type search_term: str
         """
         if self.message_bar_widget:
             if not sip.isdeleted(self.message_bar_widget):
@@ -347,7 +352,7 @@ class QgsPluginInstaller(QObject):
         except (ValueError, TypeError):
             tab_index = -1
 
-        iface.pluginManagerInterface().showPluginManager(tab_index)
+        iface.pluginManagerInterface().showPluginManager(tab_index, search_term)
 
     # ----------------------------------------- #
     def onManagerClose(self):

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -319,9 +319,16 @@ class QgsPluginInstaller(QObject):
         self.exportPluginsToManager()
 
     # ----------------------------------------- #
-    def showPluginManagerWhenReady(self, *params):
-        """Open the plugin manager window. If fetching is still in progress, it shows the progress window first"""
-        """ Optionally pass the index of tab to be opened in params """
+    def showPluginManagerWhenReady(self, tab_index: int = -1) -> None:
+        """
+        Open the plugin manager window.
+
+        If fetching is still in progress, it shows the progress window first
+        Optionally pass the index of tab to be opened
+
+        :param tab_index: index of the tab to be opened
+        :type tab_index: int
+        """
         if self.message_bar_widget:
             if not sip.isdeleted(self.message_bar_widget):
                 iface.messageBar().popWidget(self.message_bar_widget)
@@ -331,13 +338,16 @@ class QgsPluginInstaller(QObject):
         self.exportRepositoriesToManager()
         self.exportPluginsToManager()
 
-        # finally, show the plugin manager window
-        tabIndex = -1
-        if len(params) == 1:
-            indx = str(params[0])
-            if indx.isdigit() and int(indx) > -1 and int(indx) < 7:
-                tabIndex = int(indx)
-        iface.pluginManagerInterface().showPluginManager(tabIndex)
+        # Finally, show the plugin manager window
+        # Ensure that the index is within a valid range
+        try:
+            tab_index = int(tab_index)
+            if tab_index < 0 or tab_index > 6:
+                tab_index = -1
+        except (ValueError, TypeError):
+            tab_index = -1
+
+        iface.pluginManagerInterface().showPluginManager(tab_index)
 
     # ----------------------------------------- #
     def onManagerClose(self):

--- a/src/app/pluginmanager/qgsapppluginmanagerinterface.cpp
+++ b/src/app/pluginmanager/qgsapppluginmanagerinterface.cpp
@@ -29,7 +29,7 @@ QgsAppPluginManagerInterface::QgsAppPluginManagerInterface( QgsPluginManager *pl
   : mPluginManager( pluginManager )
 {}
 
-void QgsAppPluginManagerInterface::showPluginManager( int tabIndex )
+void QgsAppPluginManagerInterface::showPluginManager( int tabIndex, const QString &searchTerm )
 {
   mPluginManager->getCppPluginsMetadata();
   mPluginManager->reloadModelData();
@@ -38,6 +38,11 @@ void QgsAppPluginManagerInterface::showPluginManager( int tabIndex )
   if ( tabIndex > -1 )
   {
     mPluginManager->selectTabItem( tabIndex );
+  }
+
+  if ( !searchTerm.isEmpty() )
+  {
+    mPluginManager->search( searchTerm );
   }
 
   mPluginManager->exec();

--- a/src/app/pluginmanager/qgsapppluginmanagerinterface.h
+++ b/src/app/pluginmanager/qgsapppluginmanagerinterface.h
@@ -52,8 +52,8 @@ class QgsAppPluginManagerInterface : public QgsPluginManagerInterface
     //! Adds a repository to the repository listWidget
     void addToRepositoryList( const QMap<QString, QString> &repository ) override;
 
-    //! Shows the Plugin Manager window and optionally open tab tabIndex
-    void showPluginManager( int tabIndex = -1 ) override;
+    //! Shows the Plugin Manager window and optionally open tab tabIndex and pre-fill search term
+    void showPluginManager( int tabIndex = -1, const QString &searchTerm = QString() ) override;
 
     //! Shows the given message in the Plugin Manager internal message bar
     void pushMessage( const QString &text, Qgis::MessageLevel level = Qgis::MessageLevel::Info, int duration = -1 ) override;

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -1762,3 +1762,8 @@ void QgsPluginManager::showHelp()
 {
   QgsHelp::openHelp( u"plugins/plugins.html"_s );
 }
+
+void QgsPluginManager::search( const QString &searchTerm )
+{
+  leFilter->setText( searchTerm );
+}

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -208,6 +208,9 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
     //! vote button was clicked
     void submitVote();
 
+    //! Set search text
+    void search( const QString &searchTerm );
+
   protected:
     //! Reimplement QgsOptionsDialogBase method as we have a custom window title what would be overwritten by this method
     void showEvent( QShowEvent *e ) override;

--- a/src/gui/qgspluginmanagerinterface.h
+++ b/src/gui/qgspluginmanagerinterface.h
@@ -54,8 +54,12 @@ class GUI_EXPORT QgsPluginManagerInterface : public QObject
     //! add repository to the repository listWidget
     virtual void addToRepositoryList( const QMap<QString, QString> &repository ) = 0;
 
-    //! show the Plugin Manager window and optionally open tab tabIndex
-    virtual void showPluginManager( int tabIndex = -1 ) = 0;
+    /**
+     * Shows the Plugin Manager window and optionally open tab tabIndex and pre-fill search term.
+     *
+     * The \a searchTerm argument was added in QGIS 4.2
+     */
+    virtual void showPluginManager( int tabIndex = -1, const QString &searchTerm = QString() ) = 0;
 
     //! show the given message in the Plugin Manager internal message bar
     virtual void pushMessage( const QString &text, Qgis::MessageLevel level = Qgis::MessageLevel::Info, int duration = -1 ) = 0;


### PR DESCRIPTION
## Description

When using `showPluginManagerWhenReady`, one can already specify the tab to be opened. This PR Adds a second optional parameter: the search term used to filter plugins in the manager.

This is achieved by adding a new "search" method in `QgsPluginManager` which allows to set the search term and using it in `QgsAppPluginManagerInterface`. 

## AI tool usage

 - no AI tool used


cc @Guts @florentfougeres 