### PR TITLE
Allow loading vector tile sprites directly from mapbox hosted styles (backport)

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsvectortileutils.py
+++ b/python/PyQt6/core/auto_additions/qgsvectortileutils.py
@@ -10,6 +10,7 @@ try:
     QgsVectorTileUtils.formatXYZUrlTemplate = staticmethod(QgsVectorTileUtils.formatXYZUrlTemplate)
     QgsVectorTileUtils.checkXYZUrlTemplate = staticmethod(QgsVectorTileUtils.checkXYZUrlTemplate)
     QgsVectorTileUtils.loadSprites = staticmethod(QgsVectorTileUtils.loadSprites)
+    QgsVectorTileUtils.resolveMapboxUri = staticmethod(QgsVectorTileUtils.resolveMapboxUri)
     QgsVectorTileUtils.__group__ = ['vectortile']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/vectortile/qgsvectortileutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vectortile/qgsvectortileutils.sip.in
@@ -96,6 +96,14 @@ Downloads the sprite image and sets it to the conversion context
 :param styleUrl: optional the style url
 %End
 
+    static QString resolveMapboxUri( const QString &uri, const QString &accessToken );
+%Docstring
+Resolves a URI which uses the mapbox:// protocol to a standard HTTPS
+URL.
+
+.. versionadded:: 4.2
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_additions/qgsvectortileutils.py
+++ b/python/core/auto_additions/qgsvectortileutils.py
@@ -10,6 +10,7 @@ try:
     QgsVectorTileUtils.formatXYZUrlTemplate = staticmethod(QgsVectorTileUtils.formatXYZUrlTemplate)
     QgsVectorTileUtils.checkXYZUrlTemplate = staticmethod(QgsVectorTileUtils.checkXYZUrlTemplate)
     QgsVectorTileUtils.loadSprites = staticmethod(QgsVectorTileUtils.loadSprites)
+    QgsVectorTileUtils.resolveMapboxUri = staticmethod(QgsVectorTileUtils.resolveMapboxUri)
     QgsVectorTileUtils.__group__ = ['vectortile']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/vectortile/qgsvectortileutils.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortileutils.sip.in
@@ -96,6 +96,14 @@ Downloads the sprite image and sets it to the conversion context
 :param styleUrl: optional the style url
 %End
 
+    static QString resolveMapboxUri( const QString &uri, const QString &accessToken );
+%Docstring
+Resolves a URI which uses the mapbox:// protocol to a standard HTTPS
+URL.
+
+.. versionadded:: 4.2
+%End
+
 };
 
 /************************************************************************

--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -20,6 +20,7 @@
 #include <QPolygon>
 #include <QJsonDocument>
 #include <QJsonArray>
+#include <QUrlQuery>
 
 #include "qgscoordinatetransform.h"
 #include "qgsgeometrycollection.h"
@@ -344,6 +345,15 @@ void QgsVectorTileUtils::loadSprites( const QVariantMap &styleDefinition, QgsMap
       {
         return sprite;
       }
+      else if ( sprite.startsWith( QLatin1String( "mapbox://" ) ) )
+      {
+        const QUrl url( styleUrl );
+        const QUrlQuery query( url.query() );
+        if ( query.hasQueryItem( QStringLiteral( "access_token" ) ) )
+        {
+          return resolveMapboxUri( sprite, query.queryItemValue( QStringLiteral( "access_token" ) ) );
+        }
+      }
       else if ( sprite.startsWith( QLatin1String( "/" ) ) )
       {
         const QUrl url( styleUrl );
@@ -435,3 +445,34 @@ void QgsVectorTileUtils::loadSprites( const QVariantMap &styleDefinition, QgsMap
   }
 }
 
+QString QgsVectorTileUtils::resolveMapboxUri( const QString &uri, const QString &accessToken )
+{
+  const QUrl url( uri );
+  if ( url.scheme() != QLatin1String( "mapbox" ) )
+  {
+    return uri;
+  }
+
+  const QString host = url.host();
+  if ( host == QLatin1String( "styles" ) )
+  {
+    // e.g. mapbox://styles/mapbox/dark-v11
+    return QStringLiteral( "https://api.mapbox.com/styles/v1%1?access_token=%2" ).arg( url.path(), accessToken );
+  }
+  else if ( host == "sprites" )
+  {
+    // e.g. mapbox://sprites/mapbox/streets-v11
+    return QStringLiteral( "https://api.mapbox.com/styles/v1%1/sprite?access_token=%2" ).arg( url.path(), accessToken );
+  }
+  else if ( host == "fonts" )
+  {
+    // e.g. mapbox://fonts/mapbox/Open Sans Regular/{range}.pbf
+    return QStringLiteral( "https://api.mapbox.com/fonts/v1%1?access_token=%2" ).arg( url.path(), accessToken );
+  }
+  else
+  {
+    // sources:
+    // e.g. mapbox://{username}.{tileset_id}
+    return QStringLiteral( "https://api.mapbox.com/v4/%1.json?secure&access_token=%2" ).arg( host, accessToken );
+  }
+}

--- a/src/core/vectortile/qgsvectortileutils.h
+++ b/src/core/vectortile/qgsvectortileutils.h
@@ -101,6 +101,13 @@ class CORE_EXPORT QgsVectorTileUtils
      */
     static void loadSprites( const QVariantMap &styleDefinition, QgsMapBoxGlStyleConversionContext &context, const QString &styleUrl = QString() );
 
+    /**
+     * Resolves a URI which uses the mapbox:// protocol to a standard HTTPS URL.
+     *
+     * \since QGIS 4.2
+     */
+    static QString resolveMapboxUri( const QString &uri, const QString &accessToken );
+
   private:
     //! Parses the style URL to get a list of named source URLs.
     static QMap<QString, QString> parseStyleSourceUrl( const QString &styleUrl, const QgsHttpHeaders &headers = QgsHttpHeaders(), const QString &authCfg = QString() );

--- a/tests/src/core/testqgsvectortileutils.cpp
+++ b/tests/src/core/testqgsvectortileutils.cpp
@@ -42,6 +42,8 @@ class TestQgsVectorTileUtils : public QObject
 
     void test_scaleToZoomLevel();
     void test_urlsFromStyle();
+    void test_mapboxUrls_data();
+    void test_mapboxUrls();
 };
 
 
@@ -102,6 +104,29 @@ void TestQgsVectorTileUtils::test_urlsFromStyle()
   QCOMPARE( sources.value( "plan_ign" ), "https://data.geopf.fr/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf" );
   QVERIFY( sources.contains( "plan_ign_relative" ) );
   QCOMPARE( sources.value( "plan_ign_relative" ), "file:///tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf" );
+}
+
+
+void TestQgsVectorTileUtils::test_mapboxUrls_data()
+{
+  QTest::addColumn<QString>( "url" );
+  QTest::addColumn<QString>( "apiKey" );
+  QTest::addColumn<QString>( "expected" );
+
+  QTest::newRow( "not mapbox" ) << "https://mytiles.com" << QString() << "https://mytiles.com";
+  QTest::newRow( "mapbox style" ) << "mapbox://styles/mapbox/dark-v11" << "abc123" << "https://api.mapbox.com/styles/v1/mapbox/dark-v11?access_token=abc123";
+  QTest::newRow( "mapbox sprite" ) << "mapbox://sprites/mapbox/streets-v11" << "abc123" << "https://api.mapbox.com/styles/v1/mapbox/streets-v11/sprite?access_token=abc123";
+  QTest::newRow( "mapbox fonts" ) << "mapbox://fonts/mapbox/Open Sans Regular/123.pbf" << "abc123" << "https://api.mapbox.com/fonts/v1/mapbox/Open Sans Regular/123.pbf?access_token=abc123";
+  QTest::newRow( "mapbox sources" ) << "mapbox://username.tileset_id" << "abc123" << "https://api.mapbox.com/v4/username.tileset_id.json?secure&access_token=abc123";
+}
+
+void TestQgsVectorTileUtils::test_mapboxUrls()
+{
+  QFETCH( QString, url );
+  QFETCH( QString, apiKey );
+  QFETCH( QString, expected );
+
+  QCOMPARE( QgsVectorTileUtils::resolveMapboxUri( url, apiKey ), expected );
 }
 
 QGSTEST_MAIN( TestQgsVectorTileUtils )


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/65700