### PR TITLE
Fix crash when grouping items in the layout designer

### DIFF
--- a/src/gui/layout/qgslayoutitemslistview.cpp
+++ b/src/gui/layout/qgslayoutitemslistview.cpp
@@ -119,7 +119,10 @@ void QgsLayoutItemsListView::setCurrentLayout( QgsLayout *layout )
   setColumnWidth( 1, Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'x' ) * 4 );
   header()->setSectionsMovable( false );
 
-  connect( selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsLayoutItemsListView::updateSelection );
+  // Queued so updateSelection() does not run synchronously from inside
+  // a source model row insertion (e.g. when grouping items), which
+  // would emit dataChanged mid-transaction and corrupt the proxy.
+  connect( selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsLayoutItemsListView::updateSelection, Qt::QueuedConnection );
 }
 
 void QgsLayoutItemsListView::keyPressEvent( QKeyEvent *event )
@@ -150,8 +153,8 @@ void QgsLayoutItemsListView::updateSelection()
 {
   // Do nothing if we are currently updating the selection
   // because user has selected/deselected some items in the
-  // graphics view
-  if ( !mModel || mUpdatingFromView )
+  // graphics view, or if we are already inside this method.
+  if ( !mModel || mUpdatingFromView || mUpdatingSelection )
     return;
 
   // Set the updating flag


### PR DESCRIPTION
## Description

Fixes #61702

### Reproduction

On master at `ce4915f3`:

1. Open a print layout and add two items (e.g. a north arrow and a label)
2. Select both in the items list, then click **Group items**
3. QGIS crashes with a segmentation fault from stack overflow

### Root cause

`QgsLayoutItemsListView::updateSelection()` is connected to `QItemSelectionModel::selectionChanged` with a direct connection.

When a new group is created, `QgsLayoutView::groupSelectedItems` → `QgsLayout::addLayoutItem` → `QgsLayoutModel::rebuildZList` calls `beginInsertRows`, which shifts the persistent indices held by the items list view's selection model and causes `QItemSelectionModel` to emit `selectionChanged` synchronously — *from inside the still-open `beginInsertRows` transaction*.

`updateSelection()` then runs mid-transaction and calls `QgsLayoutItem::setSelected()` on items, which calls `QgsLayoutModel::updateItemSelectStatus()` and emits `dataChanged` on the source model. Emitting `dataChanged` from inside a `beginInsertRows`/`endInsertRows` bracket is a `QAbstractItemModel` contract violation.

On Qt 6.9.2 this cascades into infinite recursion:

```
groupSelectedItems
 → addLayoutItem → rebuildZList → beginInsertRows
   → persistent index shift → selectionChanged
     → updateSelection → setSelected → dataChanged
       → QTreeView::dataChanged touches selection model
         → selectionChanged → (recurses) → stack overflow (SIGSEGV)
```

The earlier manifestation reported in the issue thread — a duplicate row appearing for the newly created group in the items list that disappears after closing and reopening the layout — is the same root cause: the mid-transaction `dataChanged` corrupts `QSortFilterProxyModel`'s internal source-to-proxy mapping cache and the new row ends up mapped twice. Rebuilding the proxy from scratch (by closing and reopening the layout) clears the duplicate.

### Fix

Change the `selectionChanged` → `updateSelection` connection to `Qt::QueuedConnection`, so `updateSelection()` runs on the next event loop iteration — after `endInsertRows` has completed and the source model is in a consistent state.

Also add `mUpdatingSelection` to `updateSelection()`'s re-entry guard, matching the guard that `onItemFocused()` already uses. With the queued connection this is defense in depth, but it is cheap and protects against future refactors that might reintroduce a synchronous path into the slot.

Total diff: **1 file, +6 −3 lines.**

### Verification

Built master at `ce4915f3` twice, unpatched and with this patch, on Ubuntu 25.10 + Qt 6.9.2:

| Scenario | master (no fix) | master + this PR |
|---|---|---|
| 2 items → group | **SIGSEGV** | clean |
| 4 items → group | — | clean |
| Group then ungroup | — | clean |
| 3 consecutive groupings | — | clean |

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

Claude assisted with root cause analysis, fix implementation, and PR description drafting. The fix was verified by building QGIS from source and testing manually. I have reviewed and understand all code in this PR.