### PR TITLE
Optimise phong shading

### DIFF
--- a/src/3d/shaders/light.inc.frag
+++ b/src/3d/shaders/light.inc.frag
@@ -40,7 +40,6 @@ void adsModelNormalMapped(const in vec3 worldPos,
     specularColor = vec3(0.0);
 
     // We perform all work in tangent space, so we convert quantities from world space
-    vec3 tsPos = tangentMatrix * worldPos;
     vec3 n = normalize(tsNormal);
     vec3 v = normalize(tangentMatrix * (worldEye - worldPos));
     vec3 s = vec3(0.0);
@@ -53,8 +52,8 @@ void adsModelNormalMapped(const in vec3 worldPos,
             // Point and Spot lights
 
             // Transform the light position from world to tangent space
-            vec3 tsLightPos = tangentMatrix * lights[i].position;
-            vec3 sUnnormalized = tsLightPos - tsPos;
+            vec3 worldLightDir = lights[i].position - worldPos;
+            vec3 sUnnormalized = tangentMatrix * worldLightDir;
             s = normalize(sUnnormalized); // Light direction in tangent space
 
             // Calculate the attenuation factor


### PR DESCRIPTION
Remove an unnecessary matrix multiplication

original:

vec3 tsPos = tangentMatrix * worldPos;
vec3 tsLightPos = tangentMatrix * lights[i].position; vec3 sUnnormalized = tsLightPos - tsPos;

=> expanding tsPos:

vec3 tsLightPos = tangentMatrix * lights[i].position; vec3 sUnnormalized = tsLightPos - tangentMatrix * worldPos;

=> expanding tsLightPos:

vec3 sUnnormalized = tangentMatrix * lights[i].position - tangentMatrix * worldPos;

=> matrix multiplication is distributive:

vec3 sUnnormalized = tangentMatrix * (lights[i].position - worldPos);

=> (extracting the world light direction vector for readability)

vec3 worldLightDir = lights[i].position - worldPos; vec3 sUnnormalized = tangentMatrix * worldLightDir;

## Description

[Replace this with some text explaining the rationale and details about this pull request]

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
