### PR TITLE
Fix tangent transformation when non-uniform scaling in effect

### DIFF
--- a/src/3d/shaders/default.vert
+++ b/src/3d/shaders/default.vert
@@ -31,7 +31,7 @@ void main()
     // Transform position, normal, and tangent to world space
     worldPosition = vec3(modelMatrix * vec4(vertexPosition, 1.0));
     worldNormal = normalize(modelNormalMatrix * vertexNormal);
-    worldTangent.xyz = normalize(vec3(modelMatrix * vec4(vertexTangent.xyz, 0.0)));
+    worldTangent.xyz = normalize(modelNormalMatrix * vertexTangent.xyz);
     worldTangent.w = vertexTangent.w;
 
     // Calculate vertex position in clip coordinates


### PR DESCRIPTION
## Description

If a non-uniform scaling is in effect then we were incorrectly calculating the tangent (the normal calculation correctly handled this already)

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
