### PR TITLE
Fix issues in spotlight handling in phong shader

### DIFF
--- a/src/3d/shaders/light.inc.frag
+++ b/src/3d/shaders/light.inc.frag
@@ -72,7 +72,7 @@ void adsModelNormalMapped(const in vec3 worldPos,
                 // The light direction is in world space, convert to tangent space
                 if (lights[i].type == TYPE_SPOT) {
                     // Check if fragment is inside or outside of the spot light cone
-                    vec3 tsLightDirection = tangentMatrix * lights[i].direction;
+                    vec3 tsLightDirection = normalize(tangentMatrix * lights[i].direction);
                     if (degrees(acos(dot(-s, tsLightDirection))) > lights[i].cutOffAngle)
                         sDotN = 0.0;
                 }

--- a/src/3d/shaders/light.inc.frag
+++ b/src/3d/shaders/light.inc.frag
@@ -73,7 +73,8 @@ void adsModelNormalMapped(const in vec3 worldPos,
                 if (lights[i].type == TYPE_SPOT) {
                     // Check if fragment is inside or outside of the spot light cone
                     vec3 tsLightDirection = normalize(tangentMatrix * lights[i].direction);
-                    if (degrees(acos(dot(-s, tsLightDirection))) > lights[i].cutOffAngle)
+                    float cutOffCos = cos(radians(lights[i].cutOffAngle));
+                    if (dot(-s, tsLightDirection) < cutOffCos)
                         sDotN = 0.0;
                 }
             }
@@ -141,7 +142,8 @@ void adsModel(const in vec3 worldPos,
                 // The light direction is in world space already
                 if (lights[i].type == TYPE_SPOT) {
                     // Check if fragment is inside or outside of the spot light cone
-                    if (degrees(acos(dot(-s, lights[i].direction))) > lights[i].cutOffAngle)
+                    float cutOffCos = cos(radians(lights[i].cutOffAngle));
+                    if (dot(-s, lights[i].direction) < cutOffCos)
                         sDotN = 0.0;
                 }
             }
@@ -205,7 +207,8 @@ void adModel(const in vec3 worldPos,
                 // The light direction is in world space already
                 if (lights[i].type == TYPE_SPOT) {
                     // Check if fragment is inside or outside of the spot light cone
-                    if (degrees(acos(dot(-s, lights[i].direction))) > lights[i].cutOffAngle)
+                    float cutOffCos = cos(radians(lights[i].cutOffAngle));
+                    if (dot(-s, lights[i].direction) < cutOffCos)
                         sDotN = 0.0;
                 }
             }


### PR DESCRIPTION
## Description

- Fix missing normalization in phong spot light handling  - We shouldn't take the dot product of a non-normalized vector
- Avoid use of acos in phong shader - It's more stable and faster to directly calculate the cos of the cut off angle and use that for comparison

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

