### PR TITLE
qgssfcgalengine: Properly check wkb buffer allocation

### DIFF
--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -366,6 +366,7 @@ QByteArray QgsSfcgalEngine::toWkb( const sfcgal::geometry *geom, QString *errorM
   char *wkbHex;
   size_t len = 0;
   sfcgal_geometry_as_wkb( geom, &wkbHex, &len );
+  CHECK_SUCCESS( errorMsg, QByteArray() );
   QByteArray wkbArray( wkbHex, static_cast<int>( len ) );
 
 #if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 1, 0 )
@@ -374,7 +375,6 @@ QByteArray QgsSfcgalEngine::toWkb( const sfcgal::geometry *geom, QString *errorM
   free( wkbHex );
 #endif
 
-  CHECK_SUCCESS( errorMsg, QByteArray() );
   return wkbArray;
 }
 


### PR DESCRIPTION
## Description

In `QgsSfcgalEngine::toWkb`, `sfcgal_free_buffer` is called to free the allocated `wkbHex`. However, `sfcgal_geometry_as_wkb` operation may have failed. In that case, wkbHex is not allocated and the buffer cannot be used.

This issue is fixed by calling `CHECK_SUCCESS` immediately after `sfcgal_geometry_as_wkb`so that the function returns early on failure before using the buffer.

## AI tool usage

 - No AI tool used