### PR TITLE
testqgssfcgal: Fix memory leak in geometry cast

### DIFF
--- a/tests/src/core/geometry/testqgssfcgal.cpp
+++ b/tests/src/core/geometry/testqgssfcgal.cpp
@@ -748,7 +748,8 @@ void TestQgsSfcgal::intersection()
   QVERIFY2( intersectionGeom, "intersectionGeom is NULL. " );
   QCOMPARE( intersectionGeom->wkbType(), Qgis::WkbType::Polygon );
 
-  const QgsPolygon *intersectionPoly = qgsgeometry_cast<const QgsPolygon *>( intersectionGeom->asQgisGeometry().release() );
+  std::unique_ptr<QgsAbstractGeometry> qgsIntersection = intersectionGeom->asQgisGeometry();
+  const QgsPolygon *intersectionPoly = qgsgeometry_cast<const QgsPolygon *>( qgsIntersection.get() );
   QVERIFY( intersectionPoly );                               // check that the union created a feature
   QVERIFY( intersectionPoly->exteriorRing()->length() > 0 ); // check that the union created a feature
   QCOMPARE( intersectionPoly->exteriorRing()->asWkt(), u"LineString (40 80, 40 40, 80 40, 80 80, 40 80)"_s );
@@ -790,7 +791,8 @@ void TestQgsSfcgal::intersection3d()
       ")"_s
     );
 
-    const QgsMultiCurve *interCurve = qgsgeometry_cast<const QgsMultiCurve *>( scInterGeom->asQgisGeometry().release() );
+    std::unique_ptr<QgsAbstractGeometry> qgsIntersection = scInterGeom->asQgisGeometry();
+    const QgsMultiCurve *interCurve = qgsgeometry_cast<const QgsMultiCurve *>( qgsIntersection.get() );
     QCOMPARE( interCurve->partCount(), 2 ); // check that the operation created 2 features
     QCOMPARE( interCurve->curveN( 0 )->asWkt( 2 ), u"LineString Z (-5863.79 3335.64 20, -5551.89 3559.33 20)"_s );
     QCOMPARE( interCurve->curveN( 1 )->asWkt( 2 ), u"LineString Z (-5520.8 3581.62 20, -5551.89 3559.33 20)"_s );
@@ -812,7 +814,8 @@ void TestQgsSfcgal::intersection3d()
       ")"_s
     );
 
-    const QgsMultiCurve *interCurve = qgsgeometry_cast<const QgsMultiCurve *>( scInterGeom->asQgisGeometry().release() );
+    std::unique_ptr<QgsAbstractGeometry> qgsIntersection = scInterGeom->asQgisGeometry();
+    const QgsMultiCurve *interCurve = qgsgeometry_cast<const QgsMultiCurve *>( qgsIntersection.get() );
     QCOMPARE( interCurve->partCount(), 2 ); // check that the operation created 2 features
     QCOMPARE( interCurve->curveN( 0 )->asWkt( 2 ), u"LineString Z (-6321.91 3651.67 0, -6229.56 3717.9 0)"_s );
     QCOMPARE( interCurve->curveN( 1 )->asWkt( 2 ), u"LineString Z (-5814.13 4015.84 0, -6229.56 3717.9 0)"_s );
@@ -829,7 +832,8 @@ void TestQgsSfcgal::intersection3d()
     QCOMPARE( resultGeom->wkbType(), Qgis::WkbType::GeometryCollectionZ );
     QCOMPARE( resultGeom->partCount(), 7 );
 
-    const QgsGeometryCollection *castGeom = qgsgeometry_cast<const QgsGeometryCollection *>( resultGeom->asQgisGeometry().release() );
+    std::unique_ptr<QgsAbstractGeometry> qgsResult = resultGeom->asQgisGeometry();
+    const QgsGeometryCollection *castGeom = qgsgeometry_cast<const QgsGeometryCollection *>( qgsResult.get() );
     QVERIFY( castGeom != nullptr );
     QCOMPARE( castGeom->partCount(), 7 );
 
@@ -878,7 +882,8 @@ void TestQgsSfcgal::unionCheck1()
 
   QVERIFY( combinedGeom->partCount() > 0 ); // check that the union did not fail
 
-  const QgsGeometryCollection *castGeom = qgsgeometry_cast<const QgsGeometryCollection *>( combinedGeom->asQgisGeometry().release() );
+  std::unique_ptr<QgsAbstractGeometry> qgsCombined = combinedGeom->asQgisGeometry();
+  const QgsGeometryCollection *castGeom = qgsgeometry_cast<const QgsGeometryCollection *>( qgsCombined.get() );
   QVERIFY( castGeom != nullptr );
 
   paintMultiPolygon( castGeom );
@@ -902,7 +907,8 @@ void TestQgsSfcgal::unionCheck2()
 
   QVERIFY( combinedGeom->partCount() > 0 ); // check that the union did not fail
 
-  const QgsPolygon *castGeom = qgsgeometry_cast<const QgsPolygon *>( combinedGeom->asQgisGeometry().release() );
+  std::unique_ptr<QgsAbstractGeometry> qgsCombined = combinedGeom->asQgisGeometry();
+  const QgsPolygon *castGeom = qgsgeometry_cast<const QgsPolygon *>( qgsCombined.get() );
   QVERIFY( castGeom != nullptr );
 
   paintPolygon( castGeom );
@@ -923,7 +929,8 @@ void TestQgsSfcgal::differenceCheck1()
 
   QVERIFY( diffGeom->partCount() > 0 ); // check that the union did not fail
 
-  const QgsPolygon *castGeom = qgsgeometry_cast<const QgsPolygon *>( diffGeom->asQgisGeometry().release() );
+  std::unique_ptr<QgsAbstractGeometry> qgsDiff = diffGeom->asQgisGeometry();
+  const QgsPolygon *castGeom = qgsgeometry_cast<const QgsPolygon *>( qgsDiff.get() );
   QVERIFY( castGeom != nullptr );
 
   paintPolygon( castGeom );
@@ -941,7 +948,8 @@ void TestQgsSfcgal::differenceCheck2()
 
   QVERIFY( diffGeom->partCount() > 0 ); // check that the union did not fail
 
-  const QgsPolygon *castGeom = qgsgeometry_cast<const QgsPolygon *>( diffGeom->asQgisGeometry().release() );
+  std::unique_ptr<QgsAbstractGeometry> qgsDiff = diffGeom->asQgisGeometry();
+  const QgsPolygon *castGeom = qgsgeometry_cast<const QgsPolygon *>( qgsDiff.get() );
   QVERIFY( castGeom != nullptr );
 
   paintPolygon( castGeom );
@@ -981,7 +989,8 @@ void TestQgsSfcgal::difference3d()
     QCOMPARE( scDiffGeom->wkbType(), Qgis::WkbType::TINZ );
     QVERIFY2( scDiffGeom, "diffGeom is NULL." );
 
-    const QgsTriangulatedSurface *castGeom = qgsgeometry_cast<const QgsTriangulatedSurface *>( scDiffGeom->asQgisGeometry().release() );
+    std::unique_ptr<QgsAbstractGeometry> qgsDiff = scDiffGeom->asQgisGeometry();
+    const QgsTriangulatedSurface *castGeom = qgsgeometry_cast<const QgsTriangulatedSurface *>( qgsDiff.get() );
     QVERIFY( castGeom != nullptr );
 
     // 3rd: prepare compare


### PR DESCRIPTION
## Description

`QgsSfcgalGeometry::asQgisGeometry` returns a
`std::unique_ptr<QgsAbstractGeometry>`. Those unique_ptr are released to cast the geometry to its geometry type. However, those pointers are never freed.

This issue is fixed by using `get` instead of `release` on the created unique_ptr. This way, the unique_ptr keeps track of the allocated memory and it is automatically released.

## AI tool usage

 - No AI Tool used