### PR TITLE
qgsabstract3drenderer: Implement sip ConvertToSubClassCode for all sub classes

### DIFF
--- a/python/PyQt6/3d/auto_generated/qgsannotationlayer3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgsannotationlayer3drenderer.sip.in
@@ -53,12 +53,6 @@ class QgsAnnotationLayer3DRenderer : QgsAbstract3DRenderer
 %TypeHeaderCode
 #include "qgsannotationlayer3drenderer.h"
 %End
-%ConvertToSubClassCode
-    if ( dynamic_cast<QgsAnnotationLayer3DRenderer *>( sipCpp ) != nullptr )
-      sipType = sipType_QgsAnnotationLayer3DRenderer;
-    else
-      sipType = nullptr;
-%End
   public:
     QgsAnnotationLayer3DRenderer();
 

--- a/python/PyQt6/3d/auto_generated/qgstiledscenelayer3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgstiledscenelayer3drenderer.sip.in
@@ -47,16 +47,6 @@ class QgsTiledSceneLayer3DRenderer : QgsAbstract3DRenderer
 %TypeHeaderCode
 #include "qgstiledscenelayer3drenderer.h"
 %End
-%ConvertToSubClassCode
-    if ( sipCpp->type() == QLatin1String( "tiledscene" ) )
-    {
-      sipType = sipType_QgsTiledSceneLayer3DRenderer;
-    }
-    else
-    {
-      sipType = 0;
-    }
-%End
   public:
     QgsTiledSceneLayer3DRenderer();
 

--- a/python/PyQt6/core/auto_generated/3d/qgsabstract3drenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/3d/qgsabstract3drenderer.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsAbstract3DRenderer /Abstract/
 {
 %Docstring(signature="appended")
@@ -27,6 +28,24 @@ store large amount of data within a renderer (e.g. arrays of vertices).
 
 %TypeHeaderCode
 #include "qgsabstract3drenderer.h"
+%End
+%ConvertToSubClassCode
+
+    // QgsMeshLayer3DRenderer is not available in Python bindings
+    const QString type = sipCpp->type();
+
+    if ( sipCpp->type() == QLatin1String( "annotation" ) )
+      sipType = sipFindType( "QgsAnnotationLayer3DRenderer" );
+    else if ( sipCpp->type() == QLatin1String( "pointcloud" ) )
+      sipType = sipFindType( "QgsPointCloudLayer3DRenderer" );
+    else if ( sipCpp->type() == QLatin1String( "rulebased" ) )
+      sipType = sipFindType( "QgsRuleBased3DRenderer" );
+    else if ( sipCpp->type() == QLatin1String( "tiledscene" ) )
+      sipType = sipFindType( "QgsTiledSceneLayer3DRenderer" );
+    else if ( sipCpp->type() == QLatin1String( "vector" ) )
+      sipType = sipFindType( "QgsVectorLayer3DRenderer" );
+    else
+      sipType = nullptr;
 %End
   public:
     virtual ~QgsAbstract3DRenderer();

--- a/src/3d/qgsannotationlayer3drenderer.h
+++ b/src/3d/qgsannotationlayer3drenderer.h
@@ -58,15 +58,6 @@ class QgsAnnotationLayer;
  */
 class _3D_EXPORT QgsAnnotationLayer3DRenderer : public QgsAbstract3DRenderer
 {
-#ifdef SIP_RUN
-    SIP_CONVERT_TO_SUBCLASS_CODE
-    if ( dynamic_cast<QgsAnnotationLayer3DRenderer *>( sipCpp ) != nullptr )
-      sipType = sipType_QgsAnnotationLayer3DRenderer;
-    else
-      sipType = nullptr;
-  SIP_END
-#endif
-
   public:
     QgsAnnotationLayer3DRenderer();
 

--- a/src/3d/qgstiledscenelayer3drenderer.h
+++ b/src/3d/qgstiledscenelayer3drenderer.h
@@ -53,19 +53,6 @@ class _3D_EXPORT QgsTiledSceneLayer3DRendererMetadata : public Qgs3DRendererAbst
  */
 class _3D_EXPORT QgsTiledSceneLayer3DRenderer : public QgsAbstract3DRenderer
 {
-#ifdef SIP_RUN
-    SIP_CONVERT_TO_SUBCLASS_CODE
-    if ( sipCpp->type() == "tiledscene"_L1 )
-    {
-      sipType = sipType_QgsTiledSceneLayer3DRenderer;
-    }
-    else
-    {
-      sipType = 0;
-    }
-  SIP_END
-#endif
-
   public:
     QgsTiledSceneLayer3DRenderer();
 

--- a/src/core/3d/qgsabstract3drenderer.h
+++ b/src/core/3d/qgsabstract3drenderer.h
@@ -21,6 +21,8 @@
 
 #include <QString>
 
+using namespace Qt::StringLiterals;
+
 class QDomElement;
 class QgsProject;
 class QgsReadWriteContext;
@@ -46,6 +48,27 @@ namespace Qt3DCore
  */
 class CORE_EXPORT QgsAbstract3DRenderer SIP_ABSTRACT
 {
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+
+    // QgsMeshLayer3DRenderer is not available in Python bindings
+    const QString type = sipCpp->type();
+
+    if ( sipCpp->type() == "annotation"_L1 )
+      sipType = sipFindType( "QgsAnnotationLayer3DRenderer" );
+    else if ( sipCpp->type() == "pointcloud"_L1 )
+      sipType = sipFindType( "QgsPointCloudLayer3DRenderer" );
+    else if ( sipCpp->type() == "rulebased"_L1 )
+      sipType = sipFindType( "QgsRuleBased3DRenderer" );
+    else if ( sipCpp->type() == "tiledscene"_L1 )
+      sipType = sipFindType( "QgsTiledSceneLayer3DRenderer" );
+    else if ( sipCpp->type() == "vector"_L1 )
+      sipType = sipFindType( "QgsVectorLayer3DRenderer" );
+    else
+      sipType = nullptr;
+  SIP_END
+#endif
+
   public:
     virtual ~QgsAbstract3DRenderer() = default;
 


### PR DESCRIPTION
## Description

Calling `QgsMapLayer::renderer3D()` in Python returns a `QgsAbstract3DRenderer` instead of the appropriate subclass. It turns out that only `QgsAnnotationLayer3DRenderer` and `QgsTiledSceneLayer3DRenderer` implement sip `ConvertToSubClassCode`. However, even once those layer, one still get a `QgsAbstract3DRenderer` in Python.

By moving the `ConvertToSubClassCode` implementation to the base class and adding support for the missing renderer types, this now works. This is the same approach as [`QgsFeatureRenderer`](https://github.com/qgis/QGIS/blob/9d2ff9c27f07a48227c8069fb45706c05e126d8d/src/core/symbology/qgsrenderer.h#L113).

## AI tool usage

 -  No AI Tool used

cc @troopa81 @Djedouas 