### PR TITLE
Handle texture rotation in shaders instead of tesselator

### DIFF
--- a/python/PyQt6/core/auto_generated/qgstessellator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstessellator.sip.in
@@ -111,22 +111,22 @@ Returns which faces are generated during extrusion.
 .. versionadded:: 4.0
 %End
 
- void setTextureRotation( float rotation ) /Deprecated="Since 4.2. Handled in shaders now."/;
+ void setTextureRotation( float rotation ) /Deprecated="Since 4.2. Handled in shaders now. No longer has any effect on the texture coordinates."/;
 %Docstring
 Sets the rotation of texture UV coordinates (in degrees).
 
 .. deprecated:: 4.2
 
-   Handled in shaders now.
+   Handled in shaders now. No longer has any effect on the texture coordinates.
 %End
 
- float textureRotation() const /Deprecated="Since 4.2. Handled in shaders now."/;
+ float textureRotation() const /Deprecated="Since 4.2. Handled in shaders now. No longer has any effect on the texture coordinates."/;
 %Docstring
 Returns the rotation of texture UV coordinates (in degrees).
 
 .. deprecated:: 4.2
 
-   Handled in shaders now.
+   Handled in shaders now. No longer has any effect on the texture coordinates.
 %End
 
     void setAddTextureUVs( bool addTextureUVs );

--- a/python/PyQt6/core/auto_generated/qgstessellator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstessellator.sip.in
@@ -111,18 +111,22 @@ Returns which faces are generated during extrusion.
 .. versionadded:: 4.0
 %End
 
-    void setTextureRotation( float rotation );
+ void setTextureRotation( float rotation ) /Deprecated="Since 4.2. Handled in shaders now."/;
 %Docstring
 Sets the rotation of texture UV coordinates (in degrees).
 
-.. versionadded:: 4.0
+.. deprecated:: 4.2
+
+   Handled in shaders now.
 %End
 
-    float textureRotation() const;
+ float textureRotation() const /Deprecated="Since 4.2. Handled in shaders now."/;
 %Docstring
 Returns the rotation of texture UV coordinates (in degrees).
 
-.. versionadded:: 4.0
+.. deprecated:: 4.2
+
+   Handled in shaders now.
 %End
 
     void setAddTextureUVs( bool addTextureUVs );

--- a/src/3d/materials/qgsphongtexturedmaterial.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterial.cpp
@@ -15,6 +15,8 @@
 
 #include "qgsphongtexturedmaterial.h"
 
+#include "qgs3dutils.h"
+
 #include <QString>
 #include <QUrl>
 #include <Qt3DRender/QEffect>
@@ -32,6 +34,7 @@ QgsPhongTexturedMaterial::QgsPhongTexturedMaterial( QNode *parent )
   , mAmbientParameter( new Qt3DRender::QParameter( u"ambientColor"_s, QColor::fromRgbF( 0.05f, 0.05f, 0.05f, 1.0f ) ) )
   , mDiffuseTextureParameter( new Qt3DRender::QParameter( u"diffuseTexture"_s, QVariant() ) )
   , mDiffuseTextureScaleParameter( new Qt3DRender::QParameter( u"texCoordScale"_s, 1.0f ) )
+  , mDiffuseTextureRotationParameter( new Qt3DRender::QParameter( u"texCoordRotation"_s, 0.0f ) )
   , mSpecularParameter( new Qt3DRender::QParameter( u"specularColor"_s, QColor::fromRgbF( 0.01f, 0.01f, 0.01f, 1.0f ) ) )
   , mShininessParameter( new Qt3DRender::QParameter( u"shininess"_s, 150.0f ) )
   , mOpacityParameter( new Qt3DRender::QParameter( u"opacity"_s, 1.0f ) )
@@ -55,12 +58,17 @@ void QgsPhongTexturedMaterial::init()
   effect->addParameter( mAmbientParameter );
   effect->addParameter( mDiffuseTextureParameter );
   effect->addParameter( mDiffuseTextureScaleParameter );
+  effect->addParameter( mDiffuseTextureRotationParameter );
   effect->addParameter( mSpecularParameter );
   effect->addParameter( mShininessParameter );
   effect->addParameter( mOpacityParameter );
 
   Qt3DRender::QShaderProgram *gL3Shader = new Qt3DRender::QShaderProgram();
-  gL3Shader->setVertexShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/default.vert"_s ) ) );
+
+  const QByteArray vertexShaderCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/default.vert"_s ) );
+  const QByteArray finalVertexShaderCode = Qgs3DUtils::addDefinesToShaderCode( vertexShaderCode, QStringList( { "TEXTURE_ROTATION" } ) );
+  gL3Shader->setVertexShaderCode( finalVertexShaderCode );
+
   gL3Shader->setFragmentShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/diffuseSpecular.frag"_s ) ) );
 
   Qt3DRender::QTechnique *gL3Technique = new Qt3DRender::QTechnique();
@@ -96,6 +104,11 @@ void QgsPhongTexturedMaterial::setDiffuseTexture( Qt3DRender::QAbstractTexture *
 void QgsPhongTexturedMaterial::setDiffuseTextureScale( float diffuseTextureScale )
 {
   mDiffuseTextureScaleParameter->setValue( diffuseTextureScale );
+}
+
+void QgsPhongTexturedMaterial::setDiffuseTextureRotation( float textureRotation )
+{
+  mDiffuseTextureRotationParameter->setValue( textureRotation );
 }
 
 void QgsPhongTexturedMaterial::setSpecular( const QColor &specular )

--- a/src/3d/materials/qgsphongtexturedmaterial.h
+++ b/src/3d/materials/qgsphongtexturedmaterial.h
@@ -72,6 +72,7 @@ class _3D_EXPORT QgsPhongTexturedMaterial : public QgsMaterial
     void setDiffuseTexture( Qt3DRender::QAbstractTexture *texture );
 
     void setDiffuseTextureScale( float textureScale );
+    void setDiffuseTextureRotation( float textureRotation );
     void setSpecular( const QColor &specular );
     void setShininess( float shininess );
     void setOpacity( float opacity );
@@ -97,6 +98,7 @@ class _3D_EXPORT QgsPhongTexturedMaterial : public QgsMaterial
     Qt3DRender::QParameter *mAmbientParameter = nullptr;
     Qt3DRender::QParameter *mDiffuseTextureParameter = nullptr;
     Qt3DRender::QParameter *mDiffuseTextureScaleParameter = nullptr;
+    Qt3DRender::QParameter *mDiffuseTextureRotationParameter = nullptr;
     Qt3DRender::QParameter *mSpecularParameter = nullptr;
     Qt3DRender::QParameter *mShininessParameter = nullptr;
     Qt3DRender::QParameter *mOpacityParameter = nullptr;

--- a/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
@@ -98,6 +98,7 @@ QgsMaterial *QgsPhongTexturedMaterial3DHandler::toMaterial( const QgsAbstractMat
 
       material->setDiffuseTexture( texture );
       material->setDiffuseTextureScale( static_cast<float>( phongSettings->textureScale() ) );
+      material->setDiffuseTextureRotation( static_cast<float>( phongSettings->textureRotation() ) );
 
       return material;
     }
@@ -157,6 +158,8 @@ bool QgsPhongTexturedMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *s
 
   if ( Qt3DRender::QParameter *p = findParameter( effect, u"texCoordScale"_s ) )
     p->setValue( phongSettings->textureScale() );
+  if ( Qt3DRender::QParameter *p = findParameter( effect, u"texCoordRotation"_s ) )
+    p->setValue( phongSettings->textureRotation() );
   if ( Qt3DRender::QParameter *p = findParameter( effect, u"specularColor"_s ) )
     p->setValue( phongSettings->specular() );
   if ( Qt3DRender::QParameter *p = findParameter( effect, u"shininess"_s ) )

--- a/src/3d/shaders/default.vert
+++ b/src/3d/shaders/default.vert
@@ -18,6 +18,9 @@ uniform mat3 modelNormalMatrix;
 uniform mat4 mvp;
 
 uniform float texCoordScale;
+#ifdef TEXTURE_ROTATION
+uniform float texCoordRotation;
+#endif
 
 #ifdef CLIPPING
     #pragma include clipplane.shaderinc
@@ -25,8 +28,19 @@ uniform float texCoordScale;
 
 void main()
 {
-    // Pass through scaled texture coordinates
+#ifdef TEXTURE_ROTATION
+    // handle texture rotation
+    float rad = radians(texCoordRotation);
+    float c = cos(rad);
+    float s = sin(rad);
+    mat2 rotMat = mat2(c, s, -s, c);
+
+    // rotate and scale texture coordinates
+    texCoord = (rotMat * vertexTexCoord) * texCoordScale;
+#else
+    // scale texture coordinates
     texCoord = vertexTexCoord * texCoordScale;
+#endif
 
     // Transform position, normal, and tangent to world space
     worldPosition = vec3(modelMatrix * vec4(vertexPosition, 1.0));

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -94,7 +94,6 @@ bool QgsBufferedLine3DSymbolHandler::prepare( const Qgs3DRenderContext &, QSet<Q
 
   const QgsPhongTexturedMaterialSettings *texturedMaterialSettings = dynamic_cast<const QgsPhongTexturedMaterialSettings *>( mSymbol->materialSettings() );
 
-  const float textureRotation = texturedMaterialSettings ? static_cast<float>( texturedMaterialSettings->textureRotation() ) : 0;
   const bool requiresTextureCoordinates = texturedMaterialSettings ? texturedMaterialSettings->requiresTextureCoordinates() : false;
 
   auto lineDataNormalTessellator = std::make_unique<QgsTessellator>();
@@ -102,7 +101,6 @@ bool QgsBufferedLine3DSymbolHandler::prepare( const Qgs3DRenderContext &, QSet<Q
   lineDataNormalTessellator->setAddNormals( true );
   lineDataNormalTessellator->setAddTextureUVs( requiresTextureCoordinates );
   lineDataNormalTessellator->setExtrusionFaces( Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof );
-  lineDataNormalTessellator->setTextureRotation( textureRotation );
   lineDataNormalTessellator->setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
 
   mLineDataNormal.tessellator = std::move( lineDataNormalTessellator );
@@ -112,7 +110,6 @@ bool QgsBufferedLine3DSymbolHandler::prepare( const Qgs3DRenderContext &, QSet<Q
   lineDataSelectedTessellator->setAddNormals( true );
   lineDataSelectedTessellator->setAddTextureUVs( requiresTextureCoordinates );
   lineDataSelectedTessellator->setExtrusionFaces( Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof );
-  lineDataSelectedTessellator->setTextureRotation( textureRotation );
   lineDataSelectedTessellator->setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
 
   mLineDataSelected.tessellator = std::move( lineDataSelectedTessellator );

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -107,7 +107,6 @@ bool QgsPolygon3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QSet
   tessellator->setBackFacesEnabled( mSymbol->addBackFaces() );
   tessellator->setOutputZUp( true );
   tessellator->setExtrusionFaces( mSymbol->extrusionFaces() );
-  tessellator->setTextureRotation( texturedMaterialSettings ? static_cast<float>( texturedMaterialSettings->textureRotation() ) : 0.f );
   tessellator->setAddTextureUVs( texturedMaterialSettings && texturedMaterialSettings->requiresTextureCoordinates() );
   tessellator->setOutputZUp( true );
   tessellator->setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
@@ -121,7 +120,6 @@ bool QgsPolygon3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QSet
   tessellator->setBackFacesEnabled( mSymbol->addBackFaces() );
   tessellator->setOutputZUp( true );
   tessellator->setExtrusionFaces( mSymbol->extrusionFaces() );
-  tessellator->setTextureRotation( texturedMaterialSettings ? static_cast<float>( texturedMaterialSettings->textureRotation() ) : 0.f );
   tessellator->setAddTextureUVs( texturedMaterialSettings && texturedMaterialSettings->requiresTextureCoordinates() );
   tessellator->setOutputZUp( true );
   tessellator->setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -175,7 +175,9 @@ QgsTessellator::QgsTessellator( double originX, double originY, bool addNormals,
   setBackFacesEnabled( addBackFaces );
   setAddTextureUVs( addTextureCoords );
   setInputZValueIgnored( noZ );
+  Q_NOWARN_DEPRECATED_PUSH
   setTextureRotation( textureRotation );
+  Q_NOWARN_DEPRECATED_POP
 }
 
 QgsTessellator::QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals, bool addBackFaces, bool noZ, bool addTextureCoords, int facade, float textureRotation )
@@ -187,7 +189,9 @@ QgsTessellator::QgsTessellator( const QgsRectangle &bounds, bool addNormals, boo
   setInvertNormals( invertNormals );
   setBackFacesEnabled( addBackFaces );
   setInputZValueIgnored( noZ );
+  Q_NOWARN_DEPRECATED_PUSH
   setTextureRotation( textureRotation );
+  Q_NOWARN_DEPRECATED_POP
 }
 
 void QgsTessellator::setOrigin( const QgsVector3D &origin )

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -34,18 +34,6 @@
 #include <QtDebug>
 #include <QtMath>
 
-static std::pair<float, float> rotateCoords( float x, float y, float origin_x, float origin_y, float r )
-{
-  r = qDegreesToRadians( r );
-  float x0 = x - origin_x, y0 = y - origin_y;
-  // p0 = x0 + i * y0
-  // rot = cos(r) + i * sin(r)
-  // p0 * rot = x0 * cos(r) - y0 * sin(r) + i * [ x0 * sin(r) + y0 * cos(r) ]
-  const float x1 = origin_x + x0 * qCos( r ) - y0 * qSin( r );
-  const float y1 = origin_y + x0 * qSin( r ) + y0 * qCos( r );
-  return std::make_pair( x1, y1 );
-}
-
 void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D &pt2, float height )
 {
   const float dx = pt2.x() - pt1.x();
@@ -106,13 +94,6 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
   textureCoordinates.push_back( u3 );
   textureCoordinates.push_back( v3 );
 
-  for ( int i = 0; i < textureCoordinates.size(); i += 2 )
-  {
-    const std::pair<float, float> rotated = rotateCoords( textureCoordinates[i], textureCoordinates[i + 1], 0, 0, mTextureRotation );
-    textureCoordinates[i] = rotated.first;
-    textureCoordinates[i + 1] = rotated.second;
-  }
-
   // triangle 1 vertex 1
   mIndexBuffer << uniqueVertexCount();
   if ( mOutputZUp )
@@ -166,7 +147,7 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
 
 QgsTessellator::QgsTessellator() = default;
 
-QgsTessellator::QgsTessellator( double originX, double originY, bool addNormals, bool invertNormals, bool addBackFaces, bool noZ, bool addTextureCoords, int facade, float textureRotation )
+QgsTessellator::QgsTessellator( double originX, double originY, bool addNormals, bool invertNormals, bool addBackFaces, bool noZ, bool addTextureCoords, int facade, float )
 {
   setOrigin( QgsVector3D( originX, originY, 0 ) );
   setAddNormals( addNormals );
@@ -175,12 +156,9 @@ QgsTessellator::QgsTessellator( double originX, double originY, bool addNormals,
   setBackFacesEnabled( addBackFaces );
   setAddTextureUVs( addTextureCoords );
   setInputZValueIgnored( noZ );
-  Q_NOWARN_DEPRECATED_PUSH
-  setTextureRotation( textureRotation );
-  Q_NOWARN_DEPRECATED_POP
 }
 
-QgsTessellator::QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals, bool addBackFaces, bool noZ, bool addTextureCoords, int facade, float textureRotation )
+QgsTessellator::QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals, bool addBackFaces, bool noZ, bool addTextureCoords, int facade, float )
 {
   setAddTextureUVs( addTextureCoords );
   setExtrusionFacesLegacy( facade );
@@ -189,9 +167,6 @@ QgsTessellator::QgsTessellator( const QgsRectangle &bounds, bool addNormals, boo
   setInvertNormals( invertNormals );
   setBackFacesEnabled( addBackFaces );
   setInputZValueIgnored( noZ );
-  Q_NOWARN_DEPRECATED_PUSH
-  setTextureRotation( textureRotation );
-  Q_NOWARN_DEPRECATED_POP
 }
 
 void QgsTessellator::setOrigin( const QgsVector3D &origin )
@@ -239,10 +214,8 @@ void QgsTessellator::setExtrusionFacesLegacy( int facade )
   }
 }
 
-void QgsTessellator::setTextureRotation( float rotation )
-{
-  mTextureRotation = rotation;
-}
+void QgsTessellator::setTextureRotation( float )
+{}
 
 void QgsTessellator::setBackFacesEnabled( bool addBackFaces )
 {
@@ -729,8 +702,7 @@ void QgsTessellator::addVertex(
     }
     if ( mAddTextureCoords )
     {
-      const std::pair<float, float> pr = rotateCoords( static_cast<float>( point.x() ), static_cast<float>( point.y() ), 0.0f, 0.0f, mTextureRotation );
-      mData << pr.first << pr.second;
+      mData << point.x() << point.y();
     }
   }
 }
@@ -746,8 +718,7 @@ void QgsTessellator::addVertex( const QVector3D &point, const QVector3D &normal,
   }
   if ( mAddTextureCoords )
   {
-    const std::pair<float, float> pr = rotateCoords( static_cast<float>( point.x() ), static_cast<float>( point.y() ), 0.0f, 0.0f, mTextureRotation );
-    mData << pr.first << pr.second;
+    mData << point.x() << point.y();
   }
 }
 

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -109,15 +109,15 @@ class CORE_EXPORT QgsTessellator
 
     /**
      * Sets the rotation of texture UV coordinates (in degrees).
-     * \since QGIS 4.0
+     * \deprecated QGIS 4.2. Handled in shaders now.
      */
-    void setTextureRotation( float rotation );
+    Q_DECL_DEPRECATED void setTextureRotation( float rotation ) SIP_DEPRECATED;
 
     /**
      * Returns the rotation of texture UV coordinates (in degrees).
-     * \since QGIS 4.0
+     * \deprecated QGIS 4.2. Handled in shaders now.
      */
-    float textureRotation() const { return mTextureRotation; }
+    Q_DECL_DEPRECATED float textureRotation() const SIP_DEPRECATED { return mTextureRotation; }
 
     /**
      * Sets whether texture UV coordinates should be added to the output data (TRUE) or not (FALSE).

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -109,15 +109,15 @@ class CORE_EXPORT QgsTessellator
 
     /**
      * Sets the rotation of texture UV coordinates (in degrees).
-     * \deprecated QGIS 4.2. Handled in shaders now.
+     * \deprecated QGIS 4.2. Handled in shaders now. No longer has any effect on the texture coordinates.
      */
     Q_DECL_DEPRECATED void setTextureRotation( float rotation ) SIP_DEPRECATED;
 
     /**
      * Returns the rotation of texture UV coordinates (in degrees).
-     * \deprecated QGIS 4.2. Handled in shaders now.
+     * \deprecated QGIS 4.2. Handled in shaders now. No longer has any effect on the texture coordinates.
      */
-    Q_DECL_DEPRECATED float textureRotation() const SIP_DEPRECATED { return mTextureRotation; }
+    Q_DECL_DEPRECATED float textureRotation() const SIP_DEPRECATED { return 0; }
 
     /**
      * Sets whether texture UV coordinates should be added to the output data (TRUE) or not (FALSE).
@@ -302,7 +302,6 @@ class CORE_EXPORT QgsTessellator
     bool mInputZValueIgnored = false;
     Qgis::ExtrusionFaces mExtrusionFaces = Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof;
     Qgis::TriangulationAlgorithm mTriangulationAlgorithm = Qgis::TriangulationAlgorithm::ConstrainedDelaunay;
-    float mTextureRotation = 0.0f;
     float mScale = 1.0f;
     QString mError;
 


### PR DESCRIPTION
It's more efficient this way, and means we don't have to re-tesselate when the texture rotation is changed.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
