### PR TITLE
fix 3d measure dialog being invisible on wayland

### DIFF
--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -399,7 +399,7 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
 
   mMapToolIdentify = new Qgs3DMapToolIdentify( mCanvas );
 
-  mMapToolMeasureLine = new Qgs3DMapToolMeasureLine( mCanvas );
+  mMapToolMeasureLine = new Qgs3DMapToolMeasureLine( this );
 
   mMapToolChangeAttribute = new Qgs3DMapToolPointCloudChangeAttribute( mCanvas );
 

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -660,7 +660,7 @@ void Qgs3DMapCanvasWidget::updateLayerRelatedActions( QgsMapLayer *layer )
     mActionUndo->setEnabled( false );
     mActionRedo->setEnabled( false );
 
-    if ( mCanvas->mapTool() )
+    if ( mCanvas->mapTool() && mCanvas->mapTool() == mMapToolChangeAttribute )
       mCanvas->setMapTool( nullptr );
 
     return;

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -17,7 +17,7 @@
 
 #include <memory>
 
-#include "qgs3dmapcanvas.h"
+#include "qgs3dmapcanvaswidget.h"
 #include "qgs3dmapscene.h"
 #include "qgs3dmeasuredialog.h"
 #include "qgs3dutils.h"
@@ -39,11 +39,11 @@
 
 using namespace Qt::StringLiterals;
 
-Qgs3DMapToolMeasureLine::Qgs3DMapToolMeasureLine( Qgs3DMapCanvas *canvas )
-  : Qgs3DMapTool( canvas )
+Qgs3DMapToolMeasureLine::Qgs3DMapToolMeasureLine( Qgs3DMapCanvasWidget *canvasWidget )
+  : Qgs3DMapTool( canvasWidget->mapCanvas3D() )
 {
   // Dialog
-  mDialog = std::make_unique<Qgs3DMeasureDialog>( this );
+  mDialog.reset( new Qgs3DMeasureDialog( this, canvasWidget ) );
   mDialog->setWindowFlags( mDialog->windowFlags() | Qt::Tool );
   mDialog->restorePosition();
 }

--- a/src/app/3d/qgs3dmaptoolmeasureline.h
+++ b/src/app/3d/qgs3dmaptoolmeasureline.h
@@ -19,9 +19,11 @@
 #include <memory>
 
 #include "qgs3dmaptool.h"
+#include "qgs3dmeasuredialog.h"
 #include "qgspoint.h"
+#include "qobjectuniqueptr.h"
 
-class Qgs3DMeasureDialog;
+class Qgs3DMapCanvasWidget;
 class QgsRubberBand3D;
 
 
@@ -30,7 +32,7 @@ class Qgs3DMapToolMeasureLine : public Qgs3DMapTool
     Q_OBJECT
 
   public:
-    Qgs3DMapToolMeasureLine( Qgs3DMapCanvas *canvas );
+    Qgs3DMapToolMeasureLine( Qgs3DMapCanvasWidget *canvas );
     ~Qgs3DMapToolMeasureLine() override;
 
     //! When we have added our last point, and not following
@@ -71,7 +73,7 @@ class Qgs3DMapToolMeasureLine : public Qgs3DMapTool
     bool mDone = true;
 
     //! Dialog
-    std::unique_ptr<Qgs3DMeasureDialog> mDialog;
+    QObjectUniquePtr<Qgs3DMeasureDialog> mDialog = nullptr;
 
     std::unique_ptr<QgsRubberBand3D> mRubberBand;
 

--- a/src/app/3d/qgs3dmeasuredialog.cpp
+++ b/src/app/3d/qgs3dmeasuredialog.cpp
@@ -32,8 +32,8 @@
 
 using namespace Qt::StringLiterals;
 
-Qgs3DMeasureDialog::Qgs3DMeasureDialog( Qgs3DMapToolMeasureLine *tool, Qt::WindowFlags f )
-  : QDialog( nullptr, f )
+Qgs3DMeasureDialog::Qgs3DMeasureDialog( Qgs3DMapToolMeasureLine *tool, QWidget *parent, Qt::WindowFlags f )
+  : QDialog( parent, f )
   , mTool( tool )
 {
   setupUi( this );

--- a/src/app/3d/qgs3dmeasuredialog.h
+++ b/src/app/3d/qgs3dmeasuredialog.h
@@ -29,7 +29,7 @@ class Qgs3DMeasureDialog : public QDialog, private Ui::QgsMeasureBase
 
   public:
     // Constructor
-    Qgs3DMeasureDialog( Qgs3DMapToolMeasureLine *tool, Qt::WindowFlags f = Qt::WindowFlags() );
+    Qgs3DMeasureDialog( Qgs3DMapToolMeasureLine *tool, QWidget *parent, Qt::WindowFlags f = Qt::WindowFlags() );
 
     //! Save position
     void saveWindowLocation();


### PR DESCRIPTION
## Description

This fix 2 issues. From the commit messages:

```
On wayland, the measure dialog is not visible because it does not have
any parent. Fix the issue by using `Qgs3DMapCanvasWidget` as parent.
```

```
On wayland, moving a 3D map tool dialog, such as the measure dialog,
emits a signal on the clipboard. This ends up calling
`Qgs3DMapCanvasWidget::updateLayerRelatedActions` which disables all
map tools. In fact, this workflow is used to disable the pointcloud
map tool if the new active layer is not a pointcloud one.

This issue is fixed by checking if the current map tool is the
pointcloud one.
```

## AI tool usage

No AI tool used