### PR TITLE
Fix the GENERATE_SIP_PYTHON_MODULE_CODE macro in the SIPMacros.cmake module file.

### DIFF
--- a/cmake/SIPMacros.cmake
+++ b/cmake/SIPMacros.cmake
@@ -119,10 +119,22 @@ MACRO(GENERATE_SIP_PYTHON_MODULE_CODE MODULE_NAME MODULE_SIP SIP_FILES CPP_FILES
 
     # Make our common files available in the SIP build
     IF(WIN32)
-      set(SIP_PYTHONPATH "${CMAKE_SOURCE_DIR}\\python\\common;$ENV{PYTHONPATH}")
+      # Build the whole NAME=VALUE pair first, then pass it as one quoted argument to `cmake -E env`; otherwise ';' may be split by CMake.
+      SET(_sip_pythonpath_sep ";")
+      SET(_sip_common_pythonpath "${CMAKE_SOURCE_DIR}\\python\\common")
     ELSE()
-      set(SIP_PYTHONPATH "${CMAKE_SOURCE_DIR}/python/common:$ENV{PYTHONPATH}")
+      SET(_sip_pythonpath_sep ":")
+      SET(_sip_common_pythonpath "${CMAKE_SOURCE_DIR}/python/common")
     ENDIF()
+
+    IF(DEFINED ENV{PYTHONPATH} AND NOT "$ENV{PYTHONPATH}" STREQUAL "")
+      SET(SIP_PYTHONPATH "${_sip_common_pythonpath}${_sip_pythonpath_sep}$ENV{PYTHONPATH}")
+    ELSE()
+      SET(SIP_PYTHONPATH "${_sip_common_pythonpath}")
+    ENDIF()
+
+    # Keep PYTHONPATH assignment as a single argv element for cmake -E env.
+    SET(_sip_pythonpath_env "PYTHONPATH=${SIP_PYTHONPATH}")
 
     SET(_sip_disable_features ${SIP_DISABLE_FEATURES})
     LIST(TRANSFORM _sip_disable_features PREPEND --disable-feature=)
@@ -131,7 +143,7 @@ MACRO(GENERATE_SIP_PYTHON_MODULE_CODE MODULE_NAME MODULE_SIP SIP_FILES CPP_FILES
 
     ADD_CUSTOM_COMMAND(
       OUTPUT ${_sip_output_files}
-      COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${SIP_PYTHONPATH} ${SIPCMD}
+      COMMAND ${CMAKE_COMMAND} -E env "${_sip_pythonpath_env}" ${SIPCMD}
       WORKING_DIRECTORY ${_module_path}
       MAIN_DEPENDENCY ${_configured_module_sip}
       DEPENDS ${SIP_EXTRA_FILES_DEPEND}


### PR DESCRIPTION
## Description

## Environment setup instructions

- Operating system: Windows 10 Pro 22H2
- Instruction set architecture: x64
- Compilation tool chain: 
   - Visual Studio 2022 (17.14.27) 
   - CMake (3.28.1)

- Compilation directives 
```powershell 
cmake -S I:\github_repos\QGIS -B I:\QGISCompilations\VisualStudio2022\master\qgis-project -G "Visual Studio 17 2022" -A x64 -DBUILD_WITH_QT6=ON -DWITH_QTWEBENGINE=ON -DWITH_QTWEBKIT=OFF -DWITH_GRASS7=OFF -DENABLE_TESTS=OFF -DGITCOMMAND=E:\git\install\bin\git.exe -DCMAKE_INSTALL_PREFIX=I:\QGISCompilations\VisualStudio2022\master\qgis-install -DUSE_CCACHE=OFF 
```

## Problem description

SIP module build errors will occur when compiling the QGIS project of the master branch, as shown in the following log, concentrated in the three targets of `python_module_qgis__core`, `python_module_qgis__3d_p`, and `python_module_qgis__gui`:
```text
[2026-04-11 22:46:21.662] [INFO] [build:ALL_BUILD] Generating core/out/_core/sip_corepart0.cpp, core/out/_core/sip_corepart1.cpp, core/out/_core/sip_corepart2.cpp, core/out/_core/sip_corepart3.cpp, core/out/_core/sip_corepart4.cpp, core/out/_core/sip_corepart5.cpp, core/out/_core/sip_corepart6.cpp, core/out/_core/sip_corepart7.cpp, core/out/_core/sip_corepart8.cpp, core/out/_core/sip_corepart9.cpp, core/out/_core/sip_corepart10.cpp, core/out/_core/sip_corepart11.cpp, core/out/_core/sip_corepart12.cpp, core/out/_core/sip_corepart13.cpp, core/out/_core/sip_corepart14.cpp, core/out/_core/sip_corepart15.cpp, core/out/_core/sip_corepart16.cpp, core/out/_core/sip_corepart17.cpp, core/out/_core/sip_corepart18.cpp, core/out/_core/sip_corepart19.cpp, core/out/_core/sip_corepart20.cpp, core/out/_core/sip_corepart21.cpp, core/out/_core/sip_corepart22.cpp, core/out/_core/sip_corepart23.cpp, core/out/_core/sip_corepart24.cpp, core/out/_core/sip_corepart25.cpp, core/out/_core/sip_corepart26.cpp, core/out/_core/sip_corepart27.cpp
[2026-04-11 22:46:21.797] [INFO] [build:ALL_BUILD] no such file or directory
[2026-04-11 22:46:21.894] [INFO] [build:ALL_BUILD] qgspostgresutils.cpp
[2026-04-11 22:46:21.915] [INFO] [build:ALL_BUILD] C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): error MSB8066: The custom build for "I:\QGISCompilations\VisualStudio2022\master\qgis-project\python\core\core.sip;I:\github_repos\QGIS\python\CMakeLists.txt" exited with code 1. [I:\QGISCompilations\VisualStudio2022\master\qgis-project\python\python_module_qgis__core.vcxproj]
```

Use codex to analyze the pipeline-Desktop-Windows-x64-master-Qt6-RelWithDebInfo-20260411-222850.log log file and locate the QGIS/cmake/SIPMacros.cmake file. This is because on Windows systems, the `SIP_PYTHONPATH` environment variable in the *.cmake file separates multiple paths through the `;` symbol, and in On Linux systems, the `SIP_PYTHONPATH` environment variable in the *.cmake file uses the `:` symbol to separate multiple paths. At the same time, [Tool CMake official documentation](https://cmake.org/cmake/help/v3.28/manual/cmake-language.7.html) explains that its list delimiter is also a ; symbol, and explains that in some contexts, strings will be split into list elements by ;, especially in the evaluation phase of unquoted argument. Therefore, on Windows platforms, if the *.cmake module file is written incorrectly, CMake may include a single ; Strings of symbols are split as list elements.

Assume SIP_PYTHONPATH has the following values:
```text
SIP_PYTHONPATH=I:\\github_repos\\QGIS\\python\\common;E:\\osgeo4w-setup\\OSGeo4W40001\\apps\\grass\\grass84\\etc\\python;
```

Then after passing the following command (${CMAKE_COMMAND} -E env PYTHONPATH=${SIP_PYTHONPATH} ${SIPCMD}), it will be split into cmake -E env PYTHONPATH=I:\\github_repos\\QGIS\\python\\common;E:\\osgeo4w-setup\\OSGeo4W40001\\apps\\grass\\grass84\\etc\\python; ${SIPCMD} command because PYTHONPATH=I:\\github_repos\\QGIS\\python\\common;E:\\osgeo4w-setup\\OSGeo4W40001\\apps\\grass\\grass84\\etc\\python; does not include double quotes, so it will be regarded as a list element by cmake, and will be split into multiple elements instead of being regarded as one element. The expected PYTHONPATH environment variable argument ended up being split into multiple argv elements, breaking calls to `cmake -E env` and causing SIP generation to fail.
```cmake
ADD_CUSTOM_COMMAND( 
OUTPUT ${_sip_output_files} 
COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${SIP_PYTHONPATH} ${SIPCMD} 
WORKING_DIRECTORY ${_module_path} 
MAIN_DEPENDENCY ${_configured_module_sip} 
DEPENDS ${SIP_EXTRA_FILES_DEPEND} 
VERBATIM
)
```

## Compilation log description

- The pipeline-Desktop-Windows-x64-master-Qt6-RelWithDebInfo-20260411-222850.log file is the compilation log before modification. The error is located near the string containing `no such file or directory`, and the overall compilation result is `failed`.
- The pipeline-Desktop-Windows-x64-master-Qt6-RelWithDebInfo-20260411-231405.log file is the modified compilation log, and the overall compilation result is `successful`.

[pipeline-Desktop-Windows-x64-master-Qt6-RelWithDebInfo-20260411-222850.log](https://github.com/user-attachments/files/26654598/pipeline-Desktop-Windows-x64-master-Qt6-RelWithDebInfo-20260411-222850.log)
[pipeline-Desktop-Windows-x64-master-Qt6-RelWithDebInfo-20260411-231405.log](https://github.com/user-attachments/files/26654599/pipeline-Desktop-Windows-x64-master-Qt6-RelWithDebInfo-20260411-231405.log)

## AI tool usage

1. Use codex to analyze the build log files to locate the problematic file. Specifically, codex identified the `GENERATE_SIP_PYTHON_MODULE_CODE` macro in the `SIPMacros.cmake` module file as causing a configure phase error when used on Windows platforms.

2. Use codex to collect information from the CMake official documentation regarding the use cases and special cases of lists.
 
- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
