### PR TITLE
Avoid some unwanted block reading errors if the reading was explicitly canceled

### DIFF
--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -166,8 +166,11 @@ QgsRasterBlock *QgsRasterDataProvider::block( int bandNo, QgsRectangle const &bo
 
     if ( !readBlock( bandNo, tmpExtent, tmpWidth, tmpHeight, tmpBlock->bits(), feedback ) )
     {
-      QgsDebugError( u"Error occurred while reading block"_s );
-      block->setError( { tr( "Error occurred while reading block." ), u"Raster"_s } );
+      if ( !feedback || !feedback->isCanceled() )
+      {
+        QgsDebugError( u"Error occurred while reading block"_s );
+        block->setError( { tr( "Error occurred while reading block." ), u"Raster"_s } );
+      }
       block->setValid( false );
       block->setIsNoData();
       return block.release();
@@ -222,9 +225,12 @@ QgsRasterBlock *QgsRasterDataProvider::block( int bandNo, QgsRectangle const &bo
   {
     if ( !readBlock( bandNo, boundingBox, width, height, block->bits(), feedback ) )
     {
-      QgsDebugError( u"Error occurred while reading block"_s );
+      if ( !feedback || !feedback->isCanceled() )
+      {
+        QgsDebugError( u"Error occurred while reading block"_s );
+        block->setError( { tr( "Error occurred while reading block." ), u"Raster"_s } );
+      }
       block->setIsNoData();
-      block->setError( { tr( "Error occurred while reading block." ), u"Raster"_s } );
       block->setValid( false );
       return block.release();
     }


### PR DESCRIPTION
## Description

These are just noise in that scenario

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
