### PR TITLE
Move variantmap to html method to QgsVariantUtils, fix issues on qt6

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsvariantutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvariantutils.sip.in
@@ -84,6 +84,7 @@ string is generated with elements separated by ‘;’.
 
 .. versionadded:: 4.0
 %End
+
 };
 
 /************************************************************************

--- a/src/core/qgsvariantutils.cpp
+++ b/src/core/qgsvariantutils.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsapplication.h"
 #include "qgslogger.h"
+#include "qgsstringutils.h"
 #include "qgsunsetattributevalue.h"
 
 #include <QBitArray>
@@ -730,4 +731,44 @@ QString QgsVariantUtils::displayString( const QVariant &variant, int precision )
   {
     return _displayString( variant, precision );
   }
+}
+
+QString QgsVariantUtils::variantToHtml( const QVariantMap &variantMap, const QString &title = QString() )
+{
+  QString result;
+  if ( !title.isEmpty() )
+  {
+    result += u"<tr><td class=\"highlight\">%1</td><td></td></tr>"_s.arg( title );
+  }
+  for ( auto it = variantMap.constBegin(); it != variantMap.constEnd(); ++it )
+  {
+    if ( ( it.value().type() == QVariant::List || it.value().type() == QVariant::StringList ) )
+    {
+      const QVariantList childList = it.value().toList();
+      result += u"<tr><td class=\"highlight\">%1</td><td><ul>"_s.arg( it.key() );
+      for ( const QVariant &v : childList )
+      {
+        if ( v.type() == QVariant::Map )
+        {
+          const QVariantMap grandChildMap = v.toMap();
+          result += u"<li><table>%1</table></li>"_s.arg( variantToHtml( grandChildMap ) );
+        }
+        else
+        {
+          result += u"<li>%1</li>"_s.arg( QgsStringUtils::insertLinks( v.toString() ) );
+        }
+      }
+      result += "</ul></td></tr>"_L1;
+    }
+    else if ( it.value().type() == QVariant::Map )
+    {
+      const QVariantMap childMap = it.value().toMap();
+      result += u"<tr><td class=\"highlight\">%1</td><td><table>%2</table></td></tr>"_s.arg( it.key(), variantToHtml( childMap ) );
+    }
+    else
+    {
+      result += u"<tr><td class=\"highlight\">%1</td><td>%2</td></tr>"_s.arg( it.key(), QgsStringUtils::insertLinks( it.value().toString() ) );
+    }
+  }
+  return result;
 }

--- a/src/core/qgsvariantutils.h
+++ b/src/core/qgsvariantutils.h
@@ -113,6 +113,14 @@ class CORE_EXPORT QgsVariantUtils
      * \since QGIS 4.0
      */
     static QString displayString( const QVariant &variant, int precision = -1 );
+
+    /**
+     * Exports a variant map to a HTML formatted representation.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 4.2
+     */
+    static QString variantToHtml( const QVariantMap &variant, const QString &title ) SIP_SKIP;
 };
 
 #endif // QGSVARIANTUTILS_H

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -468,50 +468,9 @@ QgsAmsProvider *QgsAmsProvider::clone() const
   return provider;
 }
 
-static inline QString dumpVariantMap( const QVariantMap &variantMap, const QString &title = QString() )
-{
-  QString result;
-  if ( !title.isEmpty() )
-  {
-    result += u"<tr><td class=\"highlight\">%1</td><td></td></tr>"_s.arg( title );
-  }
-  for ( auto it = variantMap.constBegin(); it != variantMap.constEnd(); ++it )
-  {
-    const QVariantMap childMap = it.value().toMap();
-    const QVariantList childList = it.value().toList();
-    if ( !childList.isEmpty() )
-    {
-      result += u"<tr><td class=\"highlight\">%1</td><td><ul>"_s.arg( it.key() );
-      for ( const QVariant &v : childList )
-      {
-        const QVariantMap grandChildMap = v.toMap();
-        if ( !grandChildMap.isEmpty() )
-        {
-          result += u"<li><table>%1</table></li>"_s.arg( dumpVariantMap( grandChildMap ) );
-        }
-        else
-        {
-          result += u"<li>%1</li>"_s.arg( QgsStringUtils::insertLinks( v.toString() ) );
-        }
-      }
-      result += "</ul></td></tr>"_L1;
-    }
-    else if ( !childMap.isEmpty() )
-    {
-      result += u"<tr><td class=\"highlight\">%1</td><td><table>%2</table></td></tr>"_s.arg( it.key(), dumpVariantMap( childMap ) );
-    }
-    else
-    {
-      result += u"<tr><td class=\"highlight\">%1</td><td>%2</td></tr>"_s.arg( it.key(), QgsStringUtils::insertLinks( it.value().toString() ) );
-    }
-  }
-  return result;
-}
-
 QString QgsAmsProvider::htmlMetadata() const
 {
-  // This must return the content of a HTML table starting by tr and ending by tr
-  return dumpVariantMap( mServiceInfo, tr( "Service Info" ) ) + dumpVariantMap( mLayerInfo, tr( "Layer Info" ) );
+  return QgsVariantUtils::variantToHtml( mServiceInfo, tr( "Service Info" ) ) + QgsVariantUtils::variantToHtml( mLayerInfo, tr( "Layer Info" ) );
 }
 
 static bool _fuzzyContainsRect( const QRectF &r1, const QRectF &r2 )


### PR DESCRIPTION
## Description

Seems QVariant::toList returns a character-by-character list when the variant is a string on qt6.  Fix by explicitly checking the type in advance.

(I've moved this to a common location as I'm needing it for an upcoming imageserver provider.)

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
