### PR TITLE
[api] Add option to generate tangents in tesselator

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsabstractmaterialsettings.py
+++ b/python/PyQt6/core/auto_additions/qgsabstractmaterialsettings.py
@@ -26,7 +26,7 @@ QgsAbstractMaterialSettings.Property.__doc__ = """Data definable properties.
 """
 # --
 try:
-    QgsAbstractMaterialSettings.__virtual_methods__ = ['readXml', 'writeXml', 'requiresTextureCoordinates']
+    QgsAbstractMaterialSettings.__virtual_methods__ = ['readXml', 'writeXml', 'requiresTextureCoordinates', 'requiresTangents']
     QgsAbstractMaterialSettings.__abstract_methods__ = ['type', 'clone', 'equals']
     QgsAbstractMaterialSettings.__group__ = ['3d', 'materials']
 except (NameError, AttributeError):

--- a/python/PyQt6/core/auto_generated/3d/materials/qgsabstractmaterialsettings.sip.in
+++ b/python/PyQt6/core/auto_generated/3d/materials/qgsabstractmaterialsettings.sip.in
@@ -99,6 +99,14 @@ generated during triangulation.
 .. versionadded:: 4.2
 %End
 
+    virtual bool requiresTangents() const;
+%Docstring
+Returns ``True`` if the material requires tangents generated during
+triangulation.
+
+.. versionadded:: 4.2
+%End
+
     enum class Property /BaseType=IntEnum/
     {
       Diffuse,

--- a/python/PyQt6/core/auto_generated/qgstessellator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstessellator.sip.in
@@ -131,62 +131,91 @@ Returns the rotation of texture UV coordinates (in degrees).
 
     void setAddTextureUVs( bool addTextureUVs );
 %Docstring
-Sets whether texture UV coordinates should be added to the output data
-(``True``) or not (``False``).
+Sets whether texture UV coordinates should be added to the output data.
+
+.. seealso:: :py:func:`hasTextureUVs`
 
 .. versionadded:: 4.0
 %End
 
     bool hasTextureUVs() const;
 %Docstring
-Returns whether texture UV coordinates are being added to the output
-data (``True``) or not (``False``).
+Returns ``True`` if texture UV coordinates are being added to the output
+data.
+
+.. seealso:: :py:func:`setAddTextureUVs`
 
 .. versionadded:: 4.0
 %End
 
     void setAddNormals( bool addNormals );
 %Docstring
-Sets whether normals should be added to the output data (``True``) or
-not (``False``).
+Sets whether normals should be added to the output data.
+
+.. seealso:: :py:func:`hasNormals`
 
 .. versionadded:: 4.0
 %End
 
     bool hasNormals() const;
 %Docstring
-Returns whether normals are being added to the output data (``True``) or
-not (``False``).
+Returns ``True`` if normals are being added to the output data.
+
+.. seealso:: :py:func:`setAddNormals`
 
 .. versionadded:: 4.0
 %End
 
+    void setAddTangents( bool addTangents );
+%Docstring
+Sets whether tangents should be added to the output data.
+
+.. seealso:: :py:func:`hasTangents`
+
+.. versionadded:: 4.2
+%End
+
+    bool hasTangents() const;
+%Docstring
+Returns ``True`` if tangents are being added to the output data.
+
+.. seealso:: :py:func:`setAddTangents`
+
+.. versionadded:: 4.2
+%End
+
     void setBackFacesEnabled( bool addBackFaces );
 %Docstring
-Sets whether back faces should be added to the output data (``True``) or
-not (``False``).
+Sets whether back faces should be added to the output data.
+
+.. seealso:: :py:func:`hasBackFacesEnabled`
 
 .. versionadded:: 4.0
 %End
 
     bool hasBackFacesEnabled() const;
 %Docstring
-Returns whether back faces are being added to the output data (``True``)
-or not (``False``).
+Returns ``True`` if back faces are being added to the output data.
+
+.. seealso:: :py:func:`setBackFacesEnabled`
 
 .. versionadded:: 4.0
 %End
 
     void setInvertNormals( bool invertNormals );
 %Docstring
-Sets whether normals should be inverted (``True``) or not (``False``).
+Sets whether normals should be inverted.
+
+.. seealso:: :py:func:`hasInvertedNormals`
 
 .. versionadded:: 4.0
 %End
 
     bool hasInvertedNormals() const;
 %Docstring
-Returns whether normals are inverted (``True``) or not (``False``).
+Returns ``True`` if normals are inverted.
+
+.. seealso:: :py:func:`setInvertNormals`
 
 .. versionadded:: 4.0
 %End

--- a/src/3d/qgstessellatedpolygongeometry.cpp
+++ b/src/3d/qgstessellatedpolygongeometry.cpp
@@ -22,12 +22,13 @@
 
 #include "moc_qgstessellatedpolygongeometry.cpp"
 
-QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals, bool _invertNormals, bool _addBackFaces, bool _addTextureCoords, QNode *parent )
+QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals, bool _invertNormals, bool _addBackFaces, bool _addTextureCoords, bool withTangents, QNode *parent )
   : QGeometry( parent )
   , mWithNormals( _withNormals )
   , mInvertNormals( _invertNormals )
   , mAddBackFaces( _addBackFaces )
   , mAddTextureCoords( _addTextureCoords )
+  , mWithTangents( withTangents )
 {
   mVertexBuffer = new Qt3DCore::QBuffer( this );
   mIndexBuffer = new Qt3DCore::QBuffer( this );
@@ -35,6 +36,7 @@ QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals,
   QgsTessellator tmpTess;
   tmpTess.setAddNormals( mWithNormals );
   tmpTess.setAddTextureUVs( mAddTextureCoords );
+  tmpTess.setAddTangents( mWithTangents );
   const int stride = tmpTess.stride();
 
   mPositionAttribute = new Qt3DCore::QAttribute( this );
@@ -46,6 +48,7 @@ QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals,
   mPositionAttribute->setByteStride( stride );
   mPositionAttribute->setByteOffset( 0 );
   addAttribute( mPositionAttribute );
+  int vertexBufferOffset = 3 * sizeof( float );
 
   mIndexAttribute = new Qt3DCore::QAttribute( this );
   mIndexAttribute->setName( "indexBuffer" );
@@ -63,8 +66,22 @@ QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals,
     mNormalAttribute->setAttributeType( Qt3DCore::QAttribute::VertexAttribute );
     mNormalAttribute->setBuffer( mVertexBuffer );
     mNormalAttribute->setByteStride( stride );
-    mNormalAttribute->setByteOffset( 3 * sizeof( float ) );
+    mNormalAttribute->setByteOffset( vertexBufferOffset );
     addAttribute( mNormalAttribute );
+    vertexBufferOffset += 3 * sizeof( float );
+  }
+  if ( mWithTangents )
+  {
+    mTangentAttribute = new Qt3DCore::QAttribute( this );
+    mTangentAttribute->setName( Qt3DCore::QAttribute::defaultTangentAttributeName() ); // "vertexTangent"
+    mTangentAttribute->setVertexBaseType( Qt3DCore::QAttribute::Float );
+    mTangentAttribute->setVertexSize( 4 );
+    mTangentAttribute->setAttributeType( Qt3DCore::QAttribute::VertexAttribute );
+    mTangentAttribute->setBuffer( mVertexBuffer );
+    mTangentAttribute->setByteStride( stride );
+    mTangentAttribute->setByteOffset( vertexBufferOffset );
+    addAttribute( mTangentAttribute );
+    vertexBufferOffset += 4 * sizeof( float );
   }
   if ( mAddTextureCoords )
   {
@@ -75,8 +92,9 @@ QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( bool _withNormals,
     mTextureCoordsAttribute->setAttributeType( Qt3DCore::QAttribute::VertexAttribute );
     mTextureCoordsAttribute->setBuffer( mVertexBuffer );
     mTextureCoordsAttribute->setByteStride( stride );
-    mTextureCoordsAttribute->setByteOffset( mWithNormals ? 6 * sizeof( float ) : 3 * sizeof( float ) );
+    mTextureCoordsAttribute->setByteOffset( vertexBufferOffset );
     addAttribute( mTextureCoordsAttribute );
+    vertexBufferOffset += 2 * sizeof( float );
   }
 }
 
@@ -89,6 +107,8 @@ void QgsTessellatedPolygonGeometry::setVertexBufferData( const QByteArray &verte
   mPositionAttribute->setCount( vertexCount );
   if ( mNormalAttribute )
     mNormalAttribute->setCount( vertexCount );
+  if ( mTangentAttribute )
+    mTangentAttribute->setCount( vertexCount );
   if ( mTextureCoordsAttribute )
     mTextureCoordsAttribute->setCount( vertexCount );
 }

--- a/src/3d/qgstessellatedpolygongeometry.h
+++ b/src/3d/qgstessellatedpolygongeometry.h
@@ -47,7 +47,7 @@ class QgsTessellatedPolygonGeometry : public Qt3DCore::QGeometry
     Q_OBJECT
   public:
     //! Constructor
-    QgsTessellatedPolygonGeometry( bool _withNormals = true, bool invertNormals = false, bool addBackFaces = false, bool addTextureCoords = false, QNode *parent = nullptr );
+    QgsTessellatedPolygonGeometry( bool _withNormals = true, bool invertNormals = false, bool addBackFaces = false, bool addTextureCoords = false, bool withTangents = false, QNode *parent = nullptr );
 
     //! Returns whether the normals of triangles will be inverted (useful for fixing clockwise / counter-clockwise face vertex orders)
     bool invertNormals() const { return mInvertNormals; }
@@ -102,6 +102,7 @@ class QgsTessellatedPolygonGeometry : public Qt3DCore::QGeometry
   private:
     Qt3DCore::QAttribute *mPositionAttribute = nullptr;
     Qt3DCore::QAttribute *mNormalAttribute = nullptr;
+    Qt3DCore::QAttribute *mTangentAttribute = nullptr;
     Qt3DCore::QAttribute *mTextureCoordsAttribute = nullptr;
     Qt3DCore::QBuffer *mVertexBuffer = nullptr;
     Qt3DCore::QBuffer *mIndexBuffer = nullptr;
@@ -114,6 +115,7 @@ class QgsTessellatedPolygonGeometry : public Qt3DCore::QGeometry
     bool mInvertNormals = false;
     bool mAddBackFaces = false;
     bool mAddTextureCoords = false;
+    bool mWithTangents = false;
 };
 
 #endif // QGSTESSELLATEDPOLYGONGEOMETRY_H

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -92,12 +92,14 @@ bool QgsBufferedLine3DSymbolHandler::prepare( const Qgs3DRenderContext &, QSet<Q
   mChunkOrigin.setZ( 0. ); // set the chunk origin to the bottom of the box, as the tessellator currently always considers origin z to be zero
   mChunkExtent = chunkExtent;
 
-  const bool requiresTextureCoordinates = mSymbol->materialSettings() ? mSymbol->materialSettings()->requiresTextureCoordinates() : false;
+  const bool requiresTextureCoordinates = mSymbol->materialSettings() && mSymbol->materialSettings()->requiresTextureCoordinates();
+  const bool requiresTangents = mSymbol->materialSettings() && mSymbol->materialSettings()->requiresTangents();
 
   auto lineDataNormalTessellator = std::make_unique<QgsTessellator>();
   lineDataNormalTessellator->setOrigin( mChunkOrigin );
   lineDataNormalTessellator->setAddNormals( true );
   lineDataNormalTessellator->setAddTextureUVs( requiresTextureCoordinates );
+  lineDataNormalTessellator->setAddTangents( requiresTangents );
   lineDataNormalTessellator->setExtrusionFaces( Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof );
   lineDataNormalTessellator->setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
 
@@ -107,6 +109,7 @@ bool QgsBufferedLine3DSymbolHandler::prepare( const Qgs3DRenderContext &, QSet<Q
   lineDataSelectedTessellator->setOrigin( mChunkOrigin );
   lineDataSelectedTessellator->setAddNormals( true );
   lineDataSelectedTessellator->setAddTextureUVs( requiresTextureCoordinates );
+  lineDataSelectedTessellator->setAddTangents( requiresTangents );
   lineDataSelectedTessellator->setExtrusionFaces( Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof );
   lineDataSelectedTessellator->setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
 
@@ -221,7 +224,9 @@ void QgsBufferedLine3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, cons
   const int vertexCount = vertexBuffer.count() / lineData.tessellator->stride();
   const size_t indexCount = lineData.tessellator->dataVerticesCount();
 
-  QgsTessellatedPolygonGeometry *geometry = new QgsTessellatedPolygonGeometry( true, false, false, mSymbol->materialSettings() ? mSymbol->materialSettings()->requiresTextureCoordinates() : false );
+  QgsTessellatedPolygonGeometry *geometry = new QgsTessellatedPolygonGeometry(
+    true, false, false, mSymbol->materialSettings() && mSymbol->materialSettings()->requiresTextureCoordinates(), mSymbol->materialSettings() && mSymbol->materialSettings()->requiresTangents()
+  );
   geometry->setVertexBufferData( vertexBuffer, vertexCount, lineData.triangleIndexFids, lineData.triangleIndexStartingIndices );
   geometry->setIndexBufferData( indexBuffer, indexCount );
 

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -99,6 +99,7 @@ bool QgsPolygon3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QSet
   outEdges.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), 0, context, mChunkOrigin );
 
   const bool requiresTextureCoordinates = mSymbol->materialSettings() && mSymbol->materialSettings()->requiresTextureCoordinates();
+  const bool requiresTangents = mSymbol->materialSettings() && mSymbol->materialSettings()->requiresTangents();
 
   auto tessellator = std::make_unique<QgsTessellator>();
   tessellator->setOrigin( mChunkOrigin );
@@ -107,6 +108,7 @@ bool QgsPolygon3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QSet
   tessellator->setBackFacesEnabled( mSymbol->addBackFaces() );
   tessellator->setExtrusionFaces( mSymbol->extrusionFaces() );
   tessellator->setAddTextureUVs( requiresTextureCoordinates );
+  tessellator->setAddTangents( requiresTangents );
   tessellator->setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
 
   outNormal.tessellator = std::move( tessellator );
@@ -118,6 +120,7 @@ bool QgsPolygon3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QSet
   tessellator->setBackFacesEnabled( mSymbol->addBackFaces() );
   tessellator->setExtrusionFaces( mSymbol->extrusionFaces() );
   tessellator->setAddTextureUVs( requiresTextureCoordinates );
+  tessellator->setAddTangents( requiresTangents );
   tessellator->setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
 
   outSelected.tessellator = std::move( tessellator );
@@ -365,8 +368,13 @@ void QgsPolygon3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs
   const int vertexCount = polyData.tessellator->uniqueVertexCount();
   const size_t indexCount = polyData.tessellator->dataVerticesCount();
 
-  QgsTessellatedPolygonGeometry *geometry
-    = new QgsTessellatedPolygonGeometry( true, mSymbol->invertNormals(), mSymbol->addBackFaces(), mSymbol->materialSettings() && mSymbol->materialSettings()->requiresTextureCoordinates() );
+  QgsTessellatedPolygonGeometry *geometry = new QgsTessellatedPolygonGeometry(
+    true,
+    mSymbol->invertNormals(),
+    mSymbol->addBackFaces(),
+    mSymbol->materialSettings() && mSymbol->materialSettings()->requiresTextureCoordinates(),
+    mSymbol->materialSettings() && mSymbol->materialSettings()->requiresTangents()
+  );
 
   geometry->setVertexBufferData( vertexBuffer, vertexCount, polyData.triangleIndexFids, polyData.triangleIndexStartingIndices );
   geometry->setIndexBufferData( indexBuffer, indexCount );

--- a/src/core/3d/materials/qgsabstractmaterialsettings.cpp
+++ b/src/core/3d/materials/qgsabstractmaterialsettings.cpp
@@ -41,6 +41,11 @@ bool QgsAbstractMaterialSettings::requiresTextureCoordinates() const
   return false;
 }
 
+bool QgsAbstractMaterialSettings::requiresTangents() const
+{
+  return false;
+}
+
 void QgsAbstractMaterialSettings::setDataDefinedProperties( const QgsPropertyCollection &collection )
 {
   mDataDefinedProperties = collection;

--- a/src/core/3d/materials/qgsabstractmaterialsettings.h
+++ b/src/core/3d/materials/qgsabstractmaterialsettings.h
@@ -113,6 +113,14 @@ class CORE_EXPORT QgsAbstractMaterialSettings SIP_ABSTRACT
      */
     virtual bool requiresTextureCoordinates() const;
 
+    /**
+     * Returns TRUE if the material requires tangents generated
+     * during triangulation.
+     *
+     * \since QGIS 4.2
+     */
+    virtual bool requiresTangents() const;
+
     // *INDENT-OFF*
     //! Data definable properties.
     enum class Property SIP_MONKEYPATCH_SCOPEENUM_UNNEST( QgsAbstractMaterialSettings, Property ) : int

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -43,6 +43,23 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
   QVector3D vn = QVector3D( -dy, dx, 0 );
   vn.normalize();
 
+  QVector4D vt;
+  if ( mAddTangents )
+  {
+    // first make tangents following the walls horizontally
+    QVector3D tangentDir( dx, dy, 0 );
+    tangentDir.normalize();
+
+    // if we flipped the direction of U along the wall, then we'll need to adjust the tangent accordingly
+    // so that it's always pointing in the direction of increasing U
+    if ( u2 < u1 )
+    {
+      tangentDir = -tangentDir;
+    }
+
+    vt = QVector4D( tangentDir.x(), tangentDir.y(), tangentDir.z(), 1.0f );
+  }
+
   // here, we have to flip the z coordinate from an "increasing vertically" axis
   // to a "decreasing vertically" axis -- otherwise textures are rendered upside down.
   // we align textures so that the bottom of the texture is aligned to the bottom of
@@ -58,6 +75,8 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
   mData << pt1.x() << pt1.y() << pt1.z() + height;
   if ( mAddNormals )
     mData << vn.x() << vn.y() << vn.z();
+  if ( mAddTangents )
+    mData << vt.x() << vt.y() << vt.z() << vt.w();
   if ( mAddTextureCoords )
     mData << u1 << v0;
 
@@ -66,6 +85,8 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
   mData << pt2.x() << pt2.y() << pt2.z() + height;
   if ( mAddNormals )
     mData << vn.x() << vn.y() << vn.z();
+  if ( mAddTangents )
+    mData << vt.x() << vt.y() << vt.z() << vt.w();
   if ( mAddTextureCoords )
     mData << u2 << v1;
 
@@ -74,6 +95,8 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
   mData << pt1.x() << pt1.y() << pt1.z();
   if ( mAddNormals )
     mData << vn.x() << vn.y() << vn.z();
+  if ( mAddTangents )
+    mData << vt.x() << vt.y() << vt.z() << vt.w();
   if ( mAddTextureCoords )
     mData << u1 << v2;
 
@@ -88,6 +111,8 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
   mData << pt2.x() << pt2.y() << pt2.z();
   if ( mAddNormals )
     mData << vn.x() << vn.y() << vn.z();
+  if ( mAddTangents )
+    mData << vt.x() << vt.y() << vt.z() << vt.w();
   if ( mAddTextureCoords )
     mData << u2 << v3;
 }
@@ -180,6 +205,12 @@ void QgsTessellator::setAddNormals( bool addNormals )
   updateStride();
 }
 
+void QgsTessellator::setAddTangents( bool addTangents )
+{
+  mAddTangents = addTangents;
+  updateStride();
+}
+
 void QgsTessellator::setAddTextureUVs( bool addTextureUVs )
 {
   mAddTextureCoords = addTextureUVs;
@@ -199,6 +230,8 @@ void QgsTessellator::updateStride()
   mStride = 3 * sizeof( float );
   if ( mAddNormals )
     mStride += 3 * sizeof( float );
+  if ( mAddTangents )
+    mStride += 4 * sizeof( float );
   if ( mAddTextureCoords )
     mStride += 2 * sizeof( float );
 }
@@ -636,6 +669,7 @@ std::vector<QVector3D> QgsTessellator::generateEarcutTriangles( const QgsPolygon
 void QgsTessellator::addVertex(
   const QVector3D &point,
   const QVector3D &normal,
+  const QVector4D &tangent,
   float extrusionHeight,
   QMatrix4x4 *transformMatrix,
   const QgsPoint *originOffset,
@@ -645,7 +679,7 @@ void QgsTessellator::addVertex(
 )
 {
   const QVector3D pt = applyTransformWithExtrusion( point, extrusionHeight, transformMatrix, originOffset );
-  const VertexPoint vertex( pt, normal );
+  const VertexPoint vertex( pt, normal, tangent );
   if ( vertexBuffer->contains( vertex ) )
   {
     unsigned int index = vertexBuffer->value( vertex );
@@ -661,6 +695,10 @@ void QgsTessellator::addVertex(
     if ( mAddNormals )
     {
       mData << normal.x() << normal.y() << normal.z();
+    }
+    if ( mAddTangents )
+    {
+      mData << tangent.x() << tangent.y() << tangent.z() << tangent.w();
     }
     if ( mAddTextureCoords )
     {
@@ -679,7 +717,7 @@ void QgsTessellator::addVertex(
   }
 }
 
-void QgsTessellator::addVertex( const QVector3D &point, const QVector3D &normal, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset, bool isFloor )
+void QgsTessellator::addVertex( const QVector3D &point, const QVector3D &normal, const QVector4D &tangent, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset, bool isFloor )
 {
   const QVector3D pt = applyTransformWithExtrusion( point, extrusionHeight, transformMatrix, originOffset );
   mIndexBuffer << uniqueVertexCount();
@@ -687,6 +725,10 @@ void QgsTessellator::addVertex( const QVector3D &point, const QVector3D &normal,
   if ( mAddNormals )
   {
     mData << normal.x() << normal.y() << normal.z();
+  }
+  if ( mAddTangents )
+  {
+    mData << tangent.x() << tangent.y() << tangent.z() << tangent.w();
   }
   if ( mAddTextureCoords )
   {
@@ -711,6 +753,13 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
     return;
 
   const QVector3D pNormal = !mInputZValueIgnored ? calculateNormal( exterior, mOrigin.x(), mOrigin.y(), mOrigin.z(), mInvertNormals, extrusionHeight ) : QVector3D();
+  // calculate the tangent for the flat polygon (roof and floor)
+  const QVector4D frontTangent( 1.0f, 0.0f, 0.0f, 1.0f );
+  const QVector4D floorFrontTangent( -1.0f, 0.0f, 0.0f, 1.0f );
+  // back face tangent
+  const QVector4D backTangent( frontTangent.x(), frontTangent.y(), frontTangent.z(), -1.0f );
+  const QVector4D floorBackTangent( floorFrontTangent.x(), floorFrontTangent.y(), floorFrontTangent.z(), -1.0f );
+
   const int pCount = exterior->numPoints();
   if ( pCount == 0 )
     return;
@@ -748,7 +797,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
 
       for ( const QVector3D &point : points )
       {
-        addVertex( point, normal, extrusionHeight, &base, &extrusionOrigin );
+        addVertex( point, normal, frontTangent, extrusionHeight, &base, &extrusionOrigin );
       }
 
       if ( mAddBackFaces )
@@ -756,7 +805,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
         for ( size_t i = points.size(); i-- > 0; )
         {
           const QVector3D &point = points[i];
-          addVertex( point, -normal, extrusionHeight, &base, &extrusionOrigin );
+          addVertex( point, -normal, backTangent, extrusionHeight, &base, &extrusionOrigin );
         }
       }
 
@@ -764,7 +813,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
       {
         for ( const QVector3D &point : points )
         {
-          addVertex( point, normal, 0.0, &base, &extrusionOrigin, true );
+          addVertex( point, normal, floorFrontTangent, 0.0, &base, &extrusionOrigin, true );
         }
 
         if ( mAddBackFaces )
@@ -772,7 +821,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
           for ( size_t i = points.size(); i-- > 0; )
           {
             const QVector3D &point = points[i];
-            addVertex( point, -normal, 0.0, &base, &extrusionOrigin, true );
+            addVertex( point, -normal, floorBackTangent, 0.0, &base, &extrusionOrigin, true );
           }
         }
       }
@@ -838,7 +887,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
           // roof
           for ( const QVector3D &point : points )
           {
-            addVertex( point, normal, extrusionHeight, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize );
+            addVertex( point, normal, frontTangent, extrusionHeight, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize );
           }
 
           if ( mAddBackFaces )
@@ -846,7 +895,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
             for ( size_t i = points.size(); i-- > 0; )
             {
               const QVector3D &point = points[i];
-              addVertex( point, -normal, extrusionHeight, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize );
+              addVertex( point, -normal, backTangent, extrusionHeight, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize );
             }
           }
 
@@ -854,7 +903,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
           {
             for ( const QVector3D &point : points )
             {
-              addVertex( point, normal, 0.0, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize, true );
+              addVertex( point, normal, floorFrontTangent, 0.0, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize, true );
             }
 
             if ( mAddBackFaces )
@@ -862,7 +911,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
               for ( size_t i = points.size(); i-- > 0; )
               {
                 const QVector3D &point = points[i];
-                addVertex( point, -normal, 0.0, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize, true );
+                addVertex( point, -normal, floorBackTangent, 0.0, &base, &extrusionOrigin, &vertexBuffer, vertexBufferSize, true );
               }
             }
           }

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -120,49 +120,81 @@ class CORE_EXPORT QgsTessellator
     Q_DECL_DEPRECATED float textureRotation() const SIP_DEPRECATED { return 0; }
 
     /**
-     * Sets whether texture UV coordinates should be added to the output data (TRUE) or not (FALSE).
+     * Sets whether texture UV coordinates should be added to the output data.
+     *
+     * \see hasTextureUVs()
      * \since QGIS 4.0
      */
     void setAddTextureUVs( bool addTextureUVs );
 
     /**
-     * Returns whether texture UV coordinates are being added to the output data (TRUE) or not (FALSE).
+     * Returns TRUE if texture UV coordinates are being added to the output data.
+     *
+     * \see setAddTextureUVs()
      * \since QGIS 4.0
      */
     bool hasTextureUVs() const { return mAddTextureCoords; }
 
     /**
-     * Sets whether normals should be added to the output data (TRUE) or not (FALSE).
+     * Sets whether normals should be added to the output data.
+     *
+     * \see hasNormals()
      * \since QGIS 4.0
      */
     void setAddNormals( bool addNormals );
 
     /**
-     * Returns whether normals are being added to the output data (TRUE) or not (FALSE).
+     * Returns TRUE if normals are being added to the output data.
+     *
+     * \see setAddNormals()
      * \since QGIS 4.0
      */
     bool hasNormals() const { return mAddNormals; }
 
     /**
-     * Sets whether back faces should be added to the output data (TRUE) or not (FALSE).
+     * Sets whether tangents should be added to the output data.
+     *
+     * \see hasTangents()
+     * \since QGIS 4.2
+     */
+    void setAddTangents( bool addTangents );
+
+    /**
+     * Returns TRUE if tangents are being added to the output data.
+     *
+     * \see setAddTangents()
+     * \since QGIS 4.2
+     */
+    bool hasTangents() const { return mAddTangents; }
+
+    /**
+     * Sets whether back faces should be added to the output data.
+     *
+     * \see hasBackFacesEnabled()
      * \since QGIS 4.0
      */
     void setBackFacesEnabled( bool addBackFaces );
 
     /**
-     * Returns whether back faces are being added to the output data (TRUE) or not (FALSE).
+     * Returns TRUE if back faces are being added to the output data.
+     *
+     * \see setBackFacesEnabled()
      * \since QGIS 4.0
      */
     bool hasBackFacesEnabled() const { return mAddBackFaces; }
 
     /**
-     * Sets whether normals should be inverted (TRUE) or not (FALSE).
+     * Sets whether normals should be inverted.
+     *
+     * \see hasInvertedNormals()
      * \since QGIS 4.0
      */
     void setInvertNormals( bool invertNormals );
 
     /**
-     * Returns whether normals are inverted (TRUE) or not (FALSE).
+     * Returns TRUE if normals are inverted.
+     *
+     * \see setInvertNormals()
      * \since QGIS 4.0
      */
     bool hasInvertedNormals() const { return mInvertNormals; }
@@ -266,13 +298,14 @@ class CORE_EXPORT QgsTessellator
     {
         QVector3D position;
         QVector3D normal;
+        QVector4D tangent;
 
-        inline bool operator==( const VertexPoint &other ) const { return position == other.position && normal == other.normal; }
+        inline bool operator==( const VertexPoint &other ) const { return position == other.position && normal == other.normal && tangent == other.tangent; }
     };
 
-    friend uint qHash( const VertexPoint &key )
+    friend uint qHash( const VertexPoint &key, size_t seed )
     {
-      return qHash( key.position.x() ) ^ qHash( key.position.y() ) ^ qHash( key.position.z() ) ^ qHash( key.normal.x() ) ^ qHash( key.normal.y() ) ^ qHash( key.normal.z() );
+      return qHashMulti( seed, key.position.x(), key.position.y(), key.position.z(), key.normal.x(), key.normal.y(), key.normal.z(), key.tangent.x(), key.tangent.y(), key.tangent.z(), key.tangent.w() );
     }
 
     QVector<uint32_t> mIndexBuffer;
@@ -284,6 +317,7 @@ class CORE_EXPORT QgsTessellator
     void addVertex(
       const QVector3D &point,
       const QVector3D &normal,
+      const QVector4D &tangent,
       float extrusionHeight,
       QMatrix4x4 *transformMatrix,
       const QgsPoint *originOffset,
@@ -291,7 +325,7 @@ class CORE_EXPORT QgsTessellator
       const size_t &vertexBufferOffset,
       bool isFloor = false
     );
-    void addVertex( const QVector3D &point, const QVector3D &normal, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset, bool isFloor = false );
+    void addVertex( const QVector3D &point, const QVector3D &normal, const QVector4D &tangent, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset, bool isFloor = false );
     void makeWalls( const QgsLineString &ring, bool ccw, float extrusionHeight );
     void addExtrusionWallQuad( const QVector3D &pt1, const QVector3D &pt2, float height, float u1, float u2 );
     void ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, QHash<std::array<double, 2> *, float> *zHash );
@@ -300,6 +334,7 @@ class CORE_EXPORT QgsTessellator
 
     QgsVector3D mOrigin = QgsVector3D( 0, 0, 0 );
     bool mAddNormals = false;
+    bool mAddTangents = false;
     bool mInvertNormals = false;
     bool mAddBackFaces = false;
     bool mAddTextureCoords = false;

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -22,12 +22,17 @@
 
 #include <QString>
 #include <QVector3D>
+#include <QVector4D>
 
 using namespace Qt::StringLiterals;
 
 static bool qgsVectorNear( const QVector3D &v1, const QVector3D &v2, double eps )
 {
   return qgsDoubleNear( v1.x(), v2.x(), eps ) && qgsDoubleNear( v1.y(), v2.y(), eps ) && qgsDoubleNear( v1.z(), v2.z(), eps );
+}
+static bool qgsVectorNear( const QVector4D &v1, const QVector4D &v2, double eps )
+{
+  return qgsDoubleNear( v1.x(), v2.x(), eps ) && qgsDoubleNear( v1.y(), v2.y(), eps ) && qgsDoubleNear( v1.z(), v2.z(), eps ) && qgsDoubleNear( v1.w(), v2.w(), eps );
 }
 
 /**
@@ -37,7 +42,17 @@ static bool qgsVectorNear( const QVector3D &v1, const QVector3D &v2, double eps 
 struct TriangleCoords
 {
     //! Constructs from expected triangle coordinates
-    TriangleCoords( const QVector3D &a, const QVector3D &b, const QVector3D &c, const QVector3D &na = QVector3D(), const QVector3D &nb = QVector3D(), const QVector3D &nc = QVector3D() )
+    TriangleCoords(
+      const QVector3D &a,
+      const QVector3D &b,
+      const QVector3D &c,
+      const QVector3D &na = QVector3D(),
+      const QVector3D &nb = QVector3D(),
+      const QVector3D &nc = QVector3D(),
+      const QVector4D &ta = QVector4D(),
+      const QVector4D &tb = QVector4D(),
+      const QVector4D &tc = QVector4D()
+    )
     {
       pts[0] = a;
       pts[1] = b;
@@ -45,6 +60,9 @@ struct TriangleCoords
       normals[0] = na;
       normals[1] = nb;
       normals[2] = nc;
+      tangents[0] = ta;
+      tangents[1] = tb;
+      tangents[2] = tc;
     }
 
 
@@ -58,7 +76,10 @@ struct TriangleCoords
              && qgsVectorNear( pts[2], other.pts[2], eps )
              && qgsVectorNear( normals[0], other.normals[0], eps )
              && qgsVectorNear( normals[1], other.normals[1], eps )
-             && qgsVectorNear( normals[2], other.normals[2], eps );
+             && qgsVectorNear( normals[2], other.normals[2], eps )
+             && qgsVectorNear( tangents[0], other.tangents[0], eps )
+             && qgsVectorNear( tangents[1], other.tangents[1], eps )
+             && qgsVectorNear( tangents[2], other.tangents[2], eps );
     }
 
     bool operator!=( const TriangleCoords &other ) const { return !operator==( other ); }
@@ -93,16 +114,31 @@ struct TriangleCoords
         }
       }
 
+      for ( int i = 0; i < 3; ++i )
+      {
+        if ( !qgsVectorNear( tangents[i], other.tangents[i], eps ) )
+        {
+          if ( !qgsDoubleNear( tangents[i].x(), other.tangents[i].x(), eps ) )
+            return tangents[i].x() < other.tangents[i].x();
+          if ( !qgsDoubleNear( tangents[i].y(), other.tangents[i].y(), eps ) )
+            return tangents[i].y() < other.tangents[i].y();
+          if ( !qgsDoubleNear( tangents[i].z(), other.tangents[i].z(), eps ) )
+            return tangents[i].z() < other.tangents[i].z();
+          if ( !qgsDoubleNear( tangents[i].w(), other.tangents[i].w(), eps ) )
+            return tangents[i].w() < other.tangents[i].w();
+        }
+      }
       return false;
     }
 
-    void dump() const { qDebug() << pts[0] << pts[1] << pts[2] << normals[0] << normals[1] << normals[2]; }
+    void dump() const { qDebug() << pts[0] << pts[1] << pts[2] << normals[0] << normals[1] << normals[2] << tangents[0] << tangents[1] << tangents[2]; }
 
     QVector3D pts[3];
     QVector3D normals[3];
+    QVector4D tangents[3];
 };
 
-QList<TriangleCoords> extractTriangles( QgsTessellator &tessellator, bool withNormals )
+QList<TriangleCoords> extractTriangles( QgsTessellator &tessellator, bool withNormals, bool withTangents = false )
 {
   QList<TriangleCoords> triangles;
 
@@ -138,7 +174,19 @@ QList<TriangleCoords> extractTriangles( QgsTessellator &tessellator, bool withNo
     QVector3D p1( vertex1[0], vertex1[1], vertex1[2] );
     QVector3D p2( vertex2[0], vertex2[1], vertex2[2] );
 
-    if ( withNormals )
+    if ( withNormals && withTangents )
+    {
+      QVector3D n0( vertex0[3], vertex0[4], vertex0[5] );
+      QVector3D n1( vertex1[3], vertex1[4], vertex1[5] );
+      QVector3D n2( vertex2[3], vertex2[4], vertex2[5] );
+
+      QVector4D t0( vertex0[6], vertex0[7], vertex0[8], vertex0[9] );
+      QVector4D t1( vertex1[6], vertex1[7], vertex1[8], vertex1[9] );
+      QVector4D t2( vertex2[6], vertex2[7], vertex2[8], vertex2[9] );
+
+      triangles.append( TriangleCoords( p0, p1, p2, n0, n1, n2, t0, t1, t2 ) );
+    }
+    else if ( withNormals )
     {
       QVector3D n0( vertex0[3], vertex0[4], vertex0[5] );
       QVector3D n1( vertex1[3], vertex1[4], vertex1[5] );
@@ -159,6 +207,7 @@ bool checkTriangleOutput( const QList<TriangleCoords> &output, const QList<Trian
 {
   if ( output.size() != expected.size() )
   {
+    qDebug() << "Expected size " << expected.size() << " got " << output.size();
     return false;
   }
 
@@ -205,6 +254,7 @@ class TestQgsTessellator : public QgsTest
     void testBasic();
     void testBasicClockwise();
     void testWalls();
+    void testWallsTangents();
     void testBackEdges();
     void test2DTriangle();
     void test3DTriangle();
@@ -267,6 +317,15 @@ void TestQgsTessellator::testBasic()
   trianglesNormalsZCD << TriangleCoords( QVector3D( 1, 2, 3 ), QVector3D( 2, 1, 3 ), QVector3D( 3, 2, 3 ), up, up, up );
   trianglesNormalsZCD << TriangleCoords( QVector3D( 1, 2, 3 ), QVector3D( 1, 1, 3 ), QVector3D( 2, 1, 3 ), up, up, up );
 
+  QList<TriangleCoords> trianglesNormalsTangentsCD;
+  const QVector4D alongX( 1, 0, 0, 1 );
+  trianglesNormalsTangentsCD << TriangleCoords( QVector3D( 1, 2, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 3, 2, 0 ), up, up, up, alongX, alongX, alongX );
+  trianglesNormalsTangentsCD << TriangleCoords( QVector3D( 1, 2, 0 ), QVector3D( 1, 1, 0 ), QVector3D( 2, 1, 0 ), up, up, up, alongX, alongX, alongX );
+
+  QList<TriangleCoords> trianglesNormalsTangentsZCD;
+  trianglesNormalsTangentsZCD << TriangleCoords( QVector3D( 1, 2, 3 ), QVector3D( 2, 1, 3 ), QVector3D( 3, 2, 3 ), up, up, up, alongX, alongX, alongX );
+  trianglesNormalsTangentsZCD << TriangleCoords( QVector3D( 1, 2, 3 ), QVector3D( 1, 1, 3 ), QVector3D( 2, 1, 3 ), up, up, up, alongX, alongX, alongX );
+
   QList<TriangleCoords> trianglesNormalsEarcut;
   trianglesNormalsEarcut << TriangleCoords( QVector3D( 3, 2, 0 ), QVector3D( 1, 2, 0 ), QVector3D( 1, 1, 0 ), up, up, up );
   trianglesNormalsEarcut << TriangleCoords( QVector3D( 1, 1, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 3, 2, 0 ), up, up, up );
@@ -324,6 +383,23 @@ void TestQgsTessellator::testBasic()
 
   QCOMPARE( tesNormalsZCD.zMinimum(), 3 );
   QCOMPARE( tesNormalsZCD.zMaximum(), 3 );
+
+  // with tangents
+  QgsTessellator tesNormalsTangentsCD;
+  tesNormalsTangentsCD.setAddNormals( true );
+  tesNormalsTangentsCD.setAddTangents( true );
+  tesNormalsTangentsCD.addPolygon( polygon, 0 );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsTangentsCD, true, true ), trianglesNormalsTangentsCD ) );
+  QCOMPARE( tesNormalsTangentsCD.zMinimum(), 0 );
+  QCOMPARE( tesNormalsTangentsCD.zMaximum(), 0 );
+
+  QgsTessellator tesNormalsTangentsZCD;
+  tesNormalsTangentsZCD.setAddNormals( true );
+  tesNormalsTangentsZCD.setAddTangents( true );
+  tesNormalsTangentsZCD.addPolygon( polygonZ, 0 );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsTangentsZCD, true, true ), trianglesNormalsTangentsZCD ) );
+  QCOMPARE( tesNormalsTangentsZCD.zMinimum(), 3 );
+  QCOMPARE( tesNormalsTangentsZCD.zMaximum(), 3 );
 
   QgsTessellator tesNormalsEarcut;
   tesNormalsEarcut.setAddNormals( true );
@@ -435,6 +511,15 @@ void TestQgsTessellator::testBasicClockwise()
   trianglesNormalsZCD << TriangleCoords( QVector3D( 2, 1, 3 ), QVector3D( 1, 1, 3 ), QVector3D( 1, 2, 3 ), down, down, down );
   trianglesNormalsZCD << TriangleCoords( QVector3D( 3, 2, 3 ), QVector3D( 2, 1, 3 ), QVector3D( 1, 2, 3 ), down, down, down );
 
+  const QVector4D alongX( 1, 0, 0, 1 );
+  QList<TriangleCoords> trianglesNormalsTangentsCD;
+  trianglesNormalsTangentsCD << TriangleCoords( QVector3D( 2, 1, 0 ), QVector3D( 1, 1, 0 ), QVector3D( 1, 2, 0 ), down, down, down, alongX, alongX, alongX );
+  trianglesNormalsTangentsCD << TriangleCoords( QVector3D( 3, 2, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 1, 2, 0 ), down, down, down, alongX, alongX, alongX );
+
+  QList<TriangleCoords> trianglesNormalsTangentsZCD;
+  trianglesNormalsTangentsZCD << TriangleCoords( QVector3D( 2, 1, 3 ), QVector3D( 1, 1, 3 ), QVector3D( 1, 2, 3 ), down, down, down, alongX, alongX, alongX );
+  trianglesNormalsTangentsZCD << TriangleCoords( QVector3D( 3, 2, 3 ), QVector3D( 2, 1, 3 ), QVector3D( 1, 2, 3 ), down, down, down, alongX, alongX, alongX );
+
   QList<TriangleCoords> trianglesNormalsEarcut;
   trianglesNormalsEarcut << TriangleCoords( QVector3D( 3, 2, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 1, 1, 0 ), down, down, down );
   trianglesNormalsEarcut << TriangleCoords( QVector3D( 1, 1, 0 ), QVector3D( 1, 2, 0 ), QVector3D( 3, 2, 0 ), down, down, down );
@@ -475,6 +560,24 @@ void TestQgsTessellator::testBasicClockwise()
 
   QCOMPARE( tesNZ.zMinimum(), 3 );
   QCOMPARE( tesNZ.zMaximum(), 3 );
+
+  // with tangents
+
+  QgsTessellator tesNT;
+  tesNT.setAddNormals( true );
+  tesNT.setAddTangents( true );
+  tesNT.addPolygon( polygon, 0 );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesNT, true, true ), trianglesNormalsTangentsCD ) );
+  QCOMPARE( tesNT.zMinimum(), 0 );
+  QCOMPARE( tesNT.zMaximum(), 0 );
+
+  QgsTessellator tesNZT;
+  tesNZT.setAddNormals( true );
+  tesNZT.setAddTangents( true );
+  tesNZT.addPolygon( polygonZ, 0 );
+  QVERIFY( checkTriangleOutput( extractTriangles( tesNZT, true, true ), trianglesNormalsTangentsZCD ) );
+  QCOMPARE( tesNZT.zMinimum(), 3 );
+  QCOMPARE( tesNZT.zMaximum(), 3 );
 
   QgsTessellator tesEarcut;
   tesEarcut.setAddNormals( true );
@@ -618,6 +721,51 @@ void TestQgsTessellator::testWalls()
 
   QCOMPARE( tZ.zMinimum(), 1 );
   QCOMPARE( tZ.zMaximum(), 14 );
+}
+
+void TestQgsTessellator::testWallsTangents()
+{
+  QgsPolygon rect;
+  rect.fromWkt( "POLYGON((0 0, 3 0, 3 2, 0 2, 0 0))" );
+
+  const QVector3D zPos( 0, 0, 1 );
+  const QVector3D xPos( 1, 0, 0 );
+  const QVector3D yPos( 0, 1, 0 );
+  const QVector3D xNeg( -1, 0, 0 );
+  const QVector3D yNeg( 0, -1, 0 );
+
+  QList<TriangleCoords> tcRect;
+  tcRect << TriangleCoords( QVector3D( 0, 2, 1 ), QVector3D( 3, 0, 1 ), QVector3D( 3, 2, 1 ), zPos, zPos, zPos, QVector4D( 1, 0, 0, 1 ), QVector4D( 1, 0, 0, 1 ), QVector4D( 1, 0, 0, 1 ) );
+  tcRect << TriangleCoords( QVector3D( 0, 2, 1 ), QVector3D( 0, 0, 1 ), QVector3D( 3, 0, 1 ), zPos, zPos, zPos, QVector4D( 1, 0, 0, 1 ), QVector4D( 1, 0, 0, 1 ), QVector4D( 1, 0, 0, 1 ) );
+  tcRect << TriangleCoords( QVector3D( 0, 0, 1 ), QVector3D( 0, 2, 1 ), QVector3D( 0, 0, 0 ), xNeg, xNeg, xNeg, QVector4D( 0, -1, 0, 1 ), QVector4D( 0, -1, 0, 1 ), QVector4D( 0, -1, 0, 1 ) );
+  tcRect << TriangleCoords( QVector3D( 0, 0, 0 ), QVector3D( 0, 2, 1 ), QVector3D( 0, 2, 0 ), xNeg, xNeg, xNeg, QVector4D( 0, -1, 0, 1 ), QVector4D( 0, -1, 0, 1 ), QVector4D( 0, -1, 0, 1 ) );
+  tcRect << TriangleCoords( QVector3D( 0, 2, 1 ), QVector3D( 3, 2, 1 ), QVector3D( 0, 2, 0 ), yPos, yPos, yPos, QVector4D( -1, 0, 0, 1 ), QVector4D( -1, 0, 0, 1 ), QVector4D( -1, 0, 0, 1 ) );
+  tcRect << TriangleCoords( QVector3D( 0, 2, 0 ), QVector3D( 3, 2, 1 ), QVector3D( 3, 2, 0 ), yPos, yPos, yPos, QVector4D( -1, 0, 0, 1 ), QVector4D( -1, 0, 0, 1 ), QVector4D( -1, 0, 0, 1 ) );
+  tcRect << TriangleCoords( QVector3D( 3, 2, 1 ), QVector3D( 3, 0, 1 ), QVector3D( 3, 2, 0 ), xPos, xPos, xPos, QVector4D( 0, 1, 0, 1 ), QVector4D( 0, 1, 0, 1 ), QVector4D( 0, 1, 0, 1 ) );
+  tcRect << TriangleCoords( QVector3D( 3, 2, 0 ), QVector3D( 3, 0, 1 ), QVector3D( 3, 0, 0 ), xPos, xPos, xPos, QVector4D( 0, 1, 0, 1 ), QVector4D( 0, 1, 0, 1 ), QVector4D( 0, 1, 0, 1 ) );
+  tcRect << TriangleCoords( QVector3D( 3, 0, 1 ), QVector3D( 0, 0, 1 ), QVector3D( 3, 0, 0 ), yNeg, yNeg, yNeg, QVector4D( 1, 0, 0, 1 ), QVector4D( 1, 0, 0, 1 ), QVector4D( 1, 0, 0, 1 ) );
+  tcRect << TriangleCoords( QVector3D( 3, 0, 0 ), QVector3D( 0, 0, 1 ), QVector3D( 0, 0, 0 ), yNeg, yNeg, yNeg, QVector4D( 1, 0, 0, 1 ), QVector4D( 1, 0, 0, 1 ), QVector4D( 1, 0, 0, 1 ) );
+
+  QgsTessellator tRect;
+  tRect.setAddNormals( true );
+  tRect.setAddTangents( true );
+  tRect.addPolygon( rect, 1 );
+  QVERIFY( checkTriangleOutput( extractTriangles( tRect, true, true ), tcRect ) );
+  QCOMPARE( tRect.zMinimum(), 0 );
+  QCOMPARE( tRect.zMaximum(), 1 );
+
+  // try to extrude a polygon with reverse (clock-wise) order of vertices and check it is still fine
+
+  QgsPolygon rectRev;
+  rectRev.fromWkt( "POLYGON((0 0, 0 2, 3 2, 3 0, 0 0))" );
+
+  QgsTessellator tRectRev;
+  tRectRev.setAddNormals( true );
+  tRectRev.setAddTangents( true );
+  tRectRev.addPolygon( rectRev, 1 );
+  QVERIFY( checkTriangleOutput( extractTriangles( tRectRev, true, true ), tcRect ) );
+  QCOMPARE( tRectRev.zMinimum(), 0 );
+  QCOMPARE( tRectRev.zMaximum(), 1 );
 }
 
 void TestQgsTessellator::testBackEdges()


### PR DESCRIPTION
Add option to generate tangents in tesselator - these are required for normal texture maps in materials, which will unlock much improved 3d material rendering

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. Tessellator math was double checked using gemini
