### PR TITLE
Allow use of gooch, metal rough materials with instanced points

### DIFF
--- a/src/3d/materials/qgsgoochmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.cpp
@@ -64,8 +64,22 @@ QgsMaterial *QgsGoochMaterial3DHandler::toMaterial( const QgsAbstractMaterialSet
   return nullptr;
 }
 
-void QgsGoochMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffect *, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
-{}
+void QgsGoochMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const
+{
+  const QgsGoochMaterialSettings *goochSettings = dynamic_cast< const QgsGoochMaterialSettings * >( settings );
+  Q_ASSERT( goochSettings );
+
+  const QColor diffuseColor = context.isSelected() ? context.selectionColor() : goochSettings->diffuse();
+
+  effect->addParameter( new Qt3DRender::QParameter( u"kd"_s, diffuseColor ) );
+  effect->addParameter( new Qt3DRender::QParameter( u"ks"_s, goochSettings->specular() ) );
+  effect->addParameter( new Qt3DRender::QParameter( u"kblue"_s, goochSettings->cool() ) );
+  effect->addParameter( new Qt3DRender::QParameter( u"kyellow"_s, goochSettings->warm() ) );
+
+  effect->addParameter( new Qt3DRender::QParameter( u"shininess"_s, goochSettings->shininess() ) );
+  effect->addParameter( new Qt3DRender::QParameter( u"alpha"_s, goochSettings->alpha() ) );
+  effect->addParameter( new Qt3DRender::QParameter( u"beta"_s, goochSettings->beta() ) );
+}
 
 QByteArray QgsGoochMaterial3DHandler::dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const
 {
@@ -218,6 +232,9 @@ QgsMaterial *QgsGoochMaterial3DHandler::buildMaterial( const QgsAbstractMaterial
 
     const QByteArray finalFragmentShaderCode = Qgs3DUtils::addDefinesToShaderCode( fragmentShaderCode, QStringList( { "DATA_DEFINED" } ) );
     shaderProgram->setFragmentShaderCode( finalFragmentShaderCode );
+    technique->addParameter( new Qt3DRender::QParameter( u"shininess"_s, goochSettings->shininess() ) );
+    technique->addParameter( new Qt3DRender::QParameter( u"alpha"_s, goochSettings->alpha() ) );
+    technique->addParameter( new Qt3DRender::QParameter( u"beta"_s, goochSettings->beta() ) );
   }
   else
   {
@@ -225,20 +242,11 @@ QgsMaterial *QgsGoochMaterial3DHandler::buildMaterial( const QgsAbstractMaterial
     const QUrl urlVert( u"qrc:/shaders/default.vert"_s );
     shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( urlVert ) );
     shaderProgram->setFragmentShaderCode( fragmentShaderCode );
-
-    const QColor diffuseColor = context.isSelected() ? context.selectionColor() : goochSettings->diffuse();
-    effect->addParameter( new Qt3DRender::QParameter( u"kd"_s, diffuseColor ) );
-    effect->addParameter( new Qt3DRender::QParameter( u"ks"_s, goochSettings->specular() ) );
-    effect->addParameter( new Qt3DRender::QParameter( u"kblue"_s, goochSettings->cool() ) );
-    effect->addParameter( new Qt3DRender::QParameter( u"kyellow"_s, goochSettings->warm() ) );
+    addParametersToEffect( effect, settings, context );
   }
 
   renderPass->setShaderProgram( shaderProgram );
   technique->addRenderPass( renderPass );
-
-  technique->addParameter( new Qt3DRender::QParameter( u"shininess"_s, goochSettings->shininess() ) );
-  technique->addParameter( new Qt3DRender::QParameter( u"alpha"_s, goochSettings->alpha() ) );
-  technique->addParameter( new Qt3DRender::QParameter( u"beta"_s, goochSettings->beta() ) );
 
   effect->addTechnique( technique );
   material->setEffect( effect );

--- a/src/3d/materials/qgsgoochmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.cpp
@@ -81,6 +81,12 @@ void QgsGoochMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffect *effe
   effect->addParameter( new Qt3DRender::QParameter( u"beta"_s, goochSettings->beta() ) );
 }
 
+void QgsGoochMaterial3DHandler::addFragmentShaderForInstancedPointsProgram( Qt3DRender::QShaderProgram *shaderProgram, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
+{
+  const QByteArray fragmentShaderCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/gooch.frag"_s ) );
+  shaderProgram->setFragmentShaderCode( fragmentShaderCode );
+}
+
 QByteArray QgsGoochMaterial3DHandler::dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const
 {
   const QgsGoochMaterialSettings *goochSettings = dynamic_cast< const QgsGoochMaterialSettings * >( settings );
@@ -241,7 +247,7 @@ QgsMaterial *QgsGoochMaterial3DHandler::buildMaterial( const QgsAbstractMaterial
     //Load shader programs
     const QUrl urlVert( u"qrc:/shaders/default.vert"_s );
     shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( urlVert ) );
-    shaderProgram->setFragmentShaderCode( fragmentShaderCode );
+    addFragmentShaderForInstancedPointsProgram( shaderProgram, settings, context );
     addParametersToEffect( effect, settings, context );
   }
 

--- a/src/3d/materials/qgsgoochmaterial3dhandler.h
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.h
@@ -38,6 +38,7 @@ class _3D_EXPORT QgsGoochMaterial3DHandler : public QgsAbstractMaterial3DHandler
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
+    void addFragmentShaderForInstancedPointsProgram( Qt3DRender::QShaderProgram *shaderProgram, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
     QByteArray dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const override;
     int dataDefinedByteStride( const QgsAbstractMaterialSettings *settings ) const override;
     void applyDataDefinedToGeometry( const QgsAbstractMaterialSettings *settings, Qt3DCore::QGeometry *geometry, int vertexCount, const QByteArray &data ) const override;

--- a/src/3d/materials/qgsmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmaterial3dhandler.cpp
@@ -35,6 +35,9 @@ QByteArray QgsAbstractMaterial3DHandler::dataDefinedVertexColorsAsByte( const Qg
   return QByteArray();
 }
 
+void QgsAbstractMaterial3DHandler::addFragmentShaderForInstancedPointsProgram( Qt3DRender::QShaderProgram *, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
+{}
+
 void QgsAbstractMaterial3DHandler::applyDataDefinedToGeometry( const QgsAbstractMaterialSettings *settings, Qt3DCore::QGeometry *geometry, int vertexCount, const QByteArray &dataDefinedBytes ) const
 {
   Q_UNUSED( settings )

--- a/src/3d/materials/qgsmaterial3dhandler.h
+++ b/src/3d/materials/qgsmaterial3dhandler.h
@@ -42,6 +42,10 @@ namespace Qt3DExtras
 {
   class Qt3DWindow;
 }
+namespace Qt3DRender
+{
+  class QShaderProgram;
+}
 
 /**
  * \ingroup qgis_3d
@@ -137,6 +141,14 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
      * Adds parameters from the material \a settings to a destination \a effect.
      */
     virtual void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const = 0;
+
+    /**
+     * Adds the required fragment shader to a \a shaderProgram, for correct rendering of instanced points.
+     *
+     * The default implementation does nothing. This must be implemented for materials which support the
+     * instanced points technique.
+     */
+    virtual void addFragmentShaderForInstancedPointsProgram( Qt3DRender::QShaderProgram *shaderProgram, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const;
 
     /**
      * Applies the data defined bytes, \a dataDefinedBytes, on the \a geometry by filling a specific vertex buffer that will be used by the shader.

--- a/src/3d/materials/qgsmetalroughmaterial.cpp
+++ b/src/3d/materials/qgsmetalroughmaterial.cpp
@@ -247,25 +247,7 @@ void QgsMetalRoughMaterial::init()
 
 void QgsMetalRoughMaterial::updateFragmentShader()
 {
-  // pre-process fragment shader and add #defines based on whether using maps for some properties
-  QByteArray fragmentShaderCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/metalrough.frag"_s ) );
-  QStringList defines;
-  if ( mUsingBaseColorMap )
-    defines += "BASE_COLOR_MAP";
-  if ( mUsingMetalnessMap )
-    defines += "METALNESS_MAP";
-  if ( mUsingRoughnessMap )
-    defines += "ROUGHNESS_MAP";
-  if ( mUsingAmbientOcclusionMap )
-    defines += "AMBIENT_OCCLUSION_MAP";
-  if ( mUsingNormalMap )
-    defines += "NORMAL_MAP";
-
-  if ( mFlatShading )
-    defines += "FLAT_SHADING";
-
-  QByteArray finalShaderCode = Qgs3DUtils::addDefinesToShaderCode( fragmentShaderCode, defines );
-  mMetalRoughGL3Shader->setFragmentShaderCode( finalShaderCode );
+  addFragmentShaderToProgram( mMetalRoughGL3Shader, mUsingBaseColorMap, mUsingMetalnessMap, mUsingRoughnessMap, mUsingAmbientOcclusionMap, mUsingNormalMap, mFlatShading );
 }
 
 void QgsMetalRoughMaterial::handleTextureScaleChanged( const QVariant &var )
@@ -276,6 +258,30 @@ void QgsMetalRoughMaterial::handleTextureScaleChanged( const QVariant &var )
 bool QgsMetalRoughMaterial::flatShadingEnabled() const
 {
   return mFlatShading;
+}
+
+void QgsMetalRoughMaterial::addFragmentShaderToProgram(
+  Qt3DRender::QShaderProgram *shaderProgram, bool usingColorMap, bool usingMetalnessMap, bool usingRoughnessMap, bool usingAmbientOcclusionMap, bool usingNormalMap, bool usingFlatShading
+)
+{
+  QByteArray fragmentShaderCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/metalrough.frag"_s ) );
+  QStringList defines;
+  if ( usingColorMap )
+    defines += "BASE_COLOR_MAP";
+  if ( usingMetalnessMap )
+    defines += "METALNESS_MAP";
+  if ( usingRoughnessMap )
+    defines += "ROUGHNESS_MAP";
+  if ( usingAmbientOcclusionMap )
+    defines += "AMBIENT_OCCLUSION_MAP";
+  if ( usingNormalMap )
+    defines += "NORMAL_MAP";
+
+  if ( usingFlatShading )
+    defines += "FLAT_SHADING";
+
+  QByteArray finalShaderCode = Qgs3DUtils::addDefinesToShaderCode( fragmentShaderCode, defines );
+  shaderProgram->setFragmentShaderCode( finalShaderCode );
 }
 
 void QgsMetalRoughMaterial::setFlatShadingEnabled( bool enabled )

--- a/src/3d/materials/qgsmetalroughmaterial.h
+++ b/src/3d/materials/qgsmetalroughmaterial.h
@@ -71,6 +71,10 @@ class _3D_EXPORT QgsMetalRoughMaterial : public QgsMaterial
      */
     bool flatShadingEnabled() const;
 
+    static void addFragmentShaderToProgram(
+      Qt3DRender::QShaderProgram *shaderProgram, bool usingColorMap, bool usingMetalnessMap, bool usingRoughnessMap, bool usingAmbientOcclusionMap, bool usingNormalMap, bool usingFlatShading
+    );
+
   public slots:
     void setBaseColor( const QVariant &baseColor );
     void setMetalness( const QVariant &metalness );

--- a/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
@@ -59,6 +59,11 @@ QgsMaterial *QgsMetalRoughMaterial3DHandler::toMaterial( const QgsAbstractMateri
   return nullptr;
 }
 
+void QgsMetalRoughMaterial3DHandler::addFragmentShaderForInstancedPointsProgram( Qt3DRender::QShaderProgram *shaderProgram, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
+{
+  QgsMetalRoughMaterial::addFragmentShaderToProgram( shaderProgram, false, false, false, false, false, false );
+}
+
 QMap<QString, QString> QgsMetalRoughMaterial3DHandler::toExportParameters( const QgsAbstractMaterialSettings * ) const
 {
   QMap<QString, QString> parameters;

--- a/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmetalroughmaterial3dhandler.cpp
@@ -65,8 +65,14 @@ QMap<QString, QString> QgsMetalRoughMaterial3DHandler::toExportParameters( const
   return parameters;
 }
 
-void QgsMetalRoughMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffect *, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
-{}
+void QgsMetalRoughMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
+{
+  const QgsMetalRoughMaterialSettings *metalRoughSettings = qgis::down_cast< const QgsMetalRoughMaterialSettings * >( settings );
+
+  effect->addParameter( new Qt3DRender::QParameter( u"baseColor"_s, metalRoughSettings->baseColor() ) );
+  effect->addParameter( new Qt3DRender::QParameter( u"metalness"_s, metalRoughSettings->metalness() ) );
+  effect->addParameter( new Qt3DRender::QParameter( u"roughness"_s, metalRoughSettings->roughness() ) );
+}
 
 bool QgsMetalRoughMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext & ) const
 {

--- a/src/3d/materials/qgsmetalroughmaterial3dhandler.h
+++ b/src/3d/materials/qgsmetalroughmaterial3dhandler.h
@@ -36,6 +36,7 @@ class _3D_EXPORT QgsMetalRoughMaterial3DHandler : public QgsAbstractMaterial3DHa
 
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
+    void addFragmentShaderForInstancedPointsProgram( Qt3DRender::QShaderProgram *shaderProgram, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
     bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 };

--- a/src/3d/materials/qgsphongmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongmaterial3dhandler.cpp
@@ -113,6 +113,12 @@ void QgsPhongMaterial3DHandler::addParametersToEffect( Qt3DRender::QEffect *effe
   effect->addParameter( opacityParameter );
 }
 
+void QgsPhongMaterial3DHandler::addFragmentShaderForInstancedPointsProgram( Qt3DRender::QShaderProgram *shaderProgram, const QgsAbstractMaterialSettings *, const QgsMaterialContext & ) const
+{
+  const QByteArray fragmentShaderCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/phong.frag"_s ) );
+  shaderProgram->setFragmentShaderCode( fragmentShaderCode );
+}
+
 QByteArray QgsPhongMaterial3DHandler::dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const
 {
   const QgsPhongMaterialSettings *phongSettings = dynamic_cast< const QgsPhongMaterialSettings * >( settings );
@@ -299,13 +305,12 @@ QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterial
   renderPass->setShaderProgram( shaderProgram );
   technique->addRenderPass( renderPass );
 
-  const QByteArray fragmentShaderCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/phong.frag"_s ) );
-
   if ( phongSettings->dataDefinedProperties().hasActiveProperties() )
   {
     // Load shader programs
     const QUrl urlVert( u"qrc:/shaders/phongDataDefined.vert"_s );
     shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( urlVert ) );
+    const QByteArray fragmentShaderCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/phong.frag"_s ) );
     const QByteArray finalFragmentShaderCode = Qgs3DUtils::addDefinesToShaderCode( fragmentShaderCode, QStringList( { "DATA_DEFINED" } ) );
     shaderProgram->setFragmentShaderCode( finalFragmentShaderCode );
     effect->addParameter( new Qt3DRender::QParameter( u"shininess"_s, static_cast<float>( phongSettings->shininess() ) ) );
@@ -316,7 +321,7 @@ QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterial
     // Load shader programs
     const QUrl urlVert( u"qrc:/shaders/default.vert"_s );
     shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( urlVert ) );
-    shaderProgram->setFragmentShaderCode( fragmentShaderCode );
+    addFragmentShaderForInstancedPointsProgram( shaderProgram, settings, context );
     addParametersToEffect( effect, settings, context );
   }
 

--- a/src/3d/materials/qgsphongmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongmaterial3dhandler.cpp
@@ -308,6 +308,8 @@ QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterial
     shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( urlVert ) );
     const QByteArray finalFragmentShaderCode = Qgs3DUtils::addDefinesToShaderCode( fragmentShaderCode, QStringList( { "DATA_DEFINED" } ) );
     shaderProgram->setFragmentShaderCode( finalFragmentShaderCode );
+    effect->addParameter( new Qt3DRender::QParameter( u"shininess"_s, static_cast<float>( phongSettings->shininess() ) ) );
+    effect->addParameter( new Qt3DRender::QParameter( u"opacity"_s, static_cast<float>( phongSettings->opacity() ) ) );
   }
   else
   {
@@ -315,38 +317,8 @@ QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterial
     const QUrl urlVert( u"qrc:/shaders/default.vert"_s );
     shaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( urlVert ) );
     shaderProgram->setFragmentShaderCode( fragmentShaderCode );
-
-    const QColor ambient = context.isSelected() ? context.selectionColor().darker() : phongSettings->ambient();
-    const QColor diffuse = context.isSelected() ? context.selectionColor() : phongSettings->diffuse();
-
-    effect->addParameter( new Qt3DRender::QParameter(
-      u"ambientColor"_s,
-      QColor::fromRgbF(
-        static_cast< float >( ambient.redF() * phongSettings->ambientCoefficient() ),
-        static_cast< float >( ambient.greenF() * phongSettings->ambientCoefficient() ),
-        static_cast< float >( ambient.blueF() * phongSettings->ambientCoefficient() )
-      )
-    ) );
-    effect->addParameter( new Qt3DRender::QParameter(
-      u"diffuseColor"_s,
-      QColor::fromRgbF(
-        static_cast< float >( diffuse.redF() * phongSettings->diffuseCoefficient() ),
-        static_cast< float >( diffuse.greenF() * phongSettings->diffuseCoefficient() ),
-        static_cast< float >( diffuse.blueF() * phongSettings->diffuseCoefficient() )
-      )
-    ) );
-    effect->addParameter( new Qt3DRender::QParameter(
-      u"specularColor"_s,
-      QColor::fromRgbF(
-        static_cast< float >( phongSettings->specular().redF() * phongSettings->specularCoefficient() ),
-        static_cast< float >( phongSettings->specular().greenF() * phongSettings->specularCoefficient() ),
-        static_cast< float >( phongSettings->specular().blueF() * phongSettings->specularCoefficient() )
-      )
-    ) );
+    addParametersToEffect( effect, settings, context );
   }
-
-  effect->addParameter( new Qt3DRender::QParameter( u"shininess"_s, static_cast<float>( phongSettings->shininess() ) ) );
-  effect->addParameter( new Qt3DRender::QParameter( u"opacity"_s, static_cast<float>( phongSettings->opacity() ) ) );
 
   effect->addTechnique( technique );
   material->setEffect( effect );

--- a/src/3d/materials/qgsphongmaterial3dhandler.h
+++ b/src/3d/materials/qgsphongmaterial3dhandler.h
@@ -38,6 +38,7 @@ class _3D_EXPORT QgsPhongMaterial3DHandler : public QgsAbstractMaterial3DHandler
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
+    void addFragmentShaderForInstancedPointsProgram( Qt3DRender::QShaderProgram *shaderProgram, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
     QByteArray dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const override;
     int dataDefinedByteStride( const QgsAbstractMaterialSettings *settings ) const override;
     void applyDataDefinedToGeometry( const QgsAbstractMaterialSettings *settings, Qt3DCore::QGeometry *geometry, int vertexCount, const QByteArray &data ) const override;

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -336,7 +336,15 @@ QgsMaterial *QgsInstancedPoint3DSymbolHandler::material( const QgsPoint3DSymbol 
 
     const QByteArray finalVertexShaderCode = Qgs3DUtils::addDefinesToShaderCode( vertexShaderCode, defines );
     shaderProgram->setVertexShaderCode( finalVertexShaderCode );
-    shaderProgram->setFragmentShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/phong.frag"_s ) ) );
+    if ( const QgsAbstractMaterial3DHandler *handler = Qgs3D::handlerForMaterialSettings( symbol->materialSettings() ) )
+    {
+      handler->addFragmentShaderForInstancedPointsProgram( shaderProgram, symbol->materialSettings(), materialContext );
+    }
+    else
+    {
+      QgsDebugError( u"No material handler found!"_s );
+      shaderProgram->setFragmentShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/phong.frag"_s ) ) );
+    }
 
     Qt3DRender::QRenderPass *renderPass = new Qt3DRender::QRenderPass;
     renderPass->setShaderProgram( shaderProgram );

--- a/src/core/3d/materials/qgsgoochmaterialsettings.cpp
+++ b/src/core/3d/materials/qgsgoochmaterialsettings.cpp
@@ -40,10 +40,10 @@ bool QgsGoochMaterialSettings::supportsTechnique( Qgis::MaterialRenderingTechniq
     case Qgis::MaterialRenderingTechnique::TrianglesWithFixedTexture:
     case Qgis::MaterialRenderingTechnique::TrianglesFromModel:
     case Qgis::MaterialRenderingTechnique::TrianglesDataDefined:
+    case Qgis::MaterialRenderingTechnique::InstancedPoints:
       return true;
 
     case Qgis::MaterialRenderingTechnique::Lines:
-    case Qgis::MaterialRenderingTechnique::InstancedPoints:
     case Qgis::MaterialRenderingTechnique::Points:
     case Qgis::MaterialRenderingTechnique::Billboards:
       return false;

--- a/src/core/3d/materials/qgsmetalroughmaterialsettings.cpp
+++ b/src/core/3d/materials/qgsmetalroughmaterialsettings.cpp
@@ -34,11 +34,11 @@ bool QgsMetalRoughMaterialSettings::supportsTechnique( Qgis::MaterialRenderingTe
     case Qgis::MaterialRenderingTechnique::TrianglesWithFixedTexture:
     case Qgis::MaterialRenderingTechnique::TrianglesFromModel:
     case Qgis::MaterialRenderingTechnique::TrianglesDataDefined:
+    case Qgis::MaterialRenderingTechnique::InstancedPoints:
       return true;
 
     case Qgis::MaterialRenderingTechnique::Points:
     case Qgis::MaterialRenderingTechnique::Lines:
-    case Qgis::MaterialRenderingTechnique::InstancedPoints:
     case Qgis::MaterialRenderingTechnique::Billboards:
       return false;
   }


### PR DESCRIPTION
## Description

Don't hardcode the phong shader when in instanced points mode, so that we can support other material types with instanced point symbols.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
