### PR TITLE
Enable parallel provider load for SensorThings provider

### DIFF
--- a/src/core/providers/sensorthings/qgssensorthingsprovider.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsprovider.cpp
@@ -337,6 +337,11 @@ QgsSensorThingsProviderMetadata::QgsSensorThingsProviderMetadata()
   : QgsProviderMetadata( QgsSensorThingsProvider::SENSORTHINGS_PROVIDER_KEY, QgsSensorThingsProvider::SENSORTHINGS_PROVIDER_DESCRIPTION )
 {}
 
+QgsProviderMetadata::ProviderCapabilities QgsSensorThingsProviderMetadata::providerCapabilities() const
+{
+  return QgsProviderMetadata::ProviderCapability::ParallelCreateProvider;
+}
+
 QIcon QgsSensorThingsProviderMetadata::icon() const
 {
   return QgsApplication::getThemeIcon( u"mIconSensorThings.svg"_s );

--- a/src/core/providers/sensorthings/qgssensorthingsprovider.h
+++ b/src/core/providers/sensorthings/qgssensorthingsprovider.h
@@ -89,6 +89,7 @@ class QgsSensorThingsProviderMetadata final : public QgsProviderMetadata
 
   public:
     QgsSensorThingsProviderMetadata();
+    QgsProviderMetadata::ProviderCapabilities providerCapabilities() const override;
     QIcon icon() const final;
     QList<QgsDataItemProvider *> dataItemProviders() const final;
     QVariantMap decodeUri( const QString &uri ) const final;


### PR DESCRIPTION
Makes it much faster to open projects containing multiple sensor things layers.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
