### PR TITLE
Fix handling of qgsFlagValueToKeys when no flag set

### DIFF
--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -7319,6 +7319,13 @@ template<class T> QString qgsFlagValueToKeys( const T &value, bool *returnOk = n
   const QMetaEnum metaEnum = QMetaEnum::fromType<T>();
   Q_ASSERT( metaEnum.isValid() );
   int intValue = static_cast<int>( value );
+  if ( intValue == 0 )
+  {
+    if ( returnOk )
+      *returnOk = true;
+    return u"0"_s;
+  }
+
   const QByteArray ba = metaEnum.valueToKeys( intValue );
   // check that the int value does correspond to a flag
   // see https://stackoverflow.com/a/68495949/1548052
@@ -7345,6 +7352,14 @@ template<class T> T qgsFlagKeysToValue( const QString &keys, const T &defaultVal
       *returnOk = false;
     }
     return defaultValue;
+  }
+  else if ( keys == "0"_L1 )
+  {
+    if ( returnOk )
+    {
+      *returnOk = true;
+    }
+    return T();
   }
   const QMetaEnum metaEnum = QMetaEnum::fromType<T>();
   Q_ASSERT( metaEnum.isValid() );

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -763,6 +763,11 @@ void TestQgis::testQgsFlagValueToKeys()
   QCOMPARE( ok, true );
   QCOMPARE( qgsFlagValueToKeys( QgsFieldProxyModel::Filters( -10 ), &ok ), QString() );
   QCOMPARE( ok, false );
+
+  // with no flags set
+  filters = QgsFieldProxyModel::Filters();
+  QCOMPARE( qgsFlagValueToKeys( filters, &ok ), u"0"_s );
+  QCOMPARE( ok, true );
 }
 
 void TestQgis::testQgsFlagKeysToValue()
@@ -789,6 +794,13 @@ void TestQgis::testQgsFlagKeysToValue()
   // also try with an invalid int value
   QCOMPARE( qgsFlagKeysToValue( QString::number( -1 ), defaultValue, true, &ok ), defaultValue );
   QCOMPARE( ok, false );
+
+  // 0 = no flags set
+  QCOMPARE( qgsFlagKeysToValue( u"0"_s, defaultValue, true, &ok ), QgsFieldProxyModel::Filters() );
+  QCOMPARE( ok, true );
+  // "0" should work even if we aren't accepting ints
+  QCOMPARE( qgsFlagKeysToValue( u"0"_s, defaultValue, false, &ok ), QgsFieldProxyModel::Filters() );
+  QCOMPARE( ok, true );
 }
 
 void TestQgis::testQMapQVariantList()


### PR DESCRIPTION
## Description

This scenario wasn't handled correctly, resulting in loss of stored value and a qt warning when saving projects

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
