### PR TITLE
[vcpkg] Enable ZSTD compression support in libtiff

### DIFF
--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -39,7 +39,8 @@
       "name": "gdal",
       "default-features": false,
       "features": [
-        "freexl"
+        "freexl",
+        "zstd"
       ]
     },
     "geos",
@@ -94,12 +95,6 @@
     "qtmultimedia",
     "qt5compat",
     "qtkeychain-qt6",
-    {
-      "name": "tiff",
-      "features": [
-        "zstd"
-      ]
-    },
     "zlib",
     "zstd"
   ],

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -94,6 +94,12 @@
     "qtmultimedia",
     "qt5compat",
     "qtkeychain-qt6",
+    {
+      "name": "tiff",
+      "features": [
+        "zstd"
+      ]
+    },
     "zlib",
     "zstd"
   ],


### PR DESCRIPTION
## Summary
- Adds `tiff` as a direct vcpkg dependency with the `zstd` feature enabled
- Fixes GeoTIFF files with ZSTD compression being unreadable on macOS (and other vcpkg-based builds)

## Root cause
GDAL's vcpkg port depends on `tiff` with `default-features: false`, and its own `zstd` feature only adds the zstd library for GDAL's use — it does **not** propagate the `zstd` feature to the `tiff` port. This results in `libtiff.dylib` being built without ZSTD codec support.

By adding `tiff[zstd]` as a direct QGIS dependency, vcpkg merges the feature requests and produces a libtiff that includes ZSTD alongside the default codecs (jpeg, lzma, zip).

Fixes https://github.com/qgis/QGIS/issues/65409