### PR TITLE
[Plugin Manager] Don't show "Plugin Dependencies Manager" dlg if plugin_dependencies metadata is empty

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -410,6 +410,8 @@ def get_plugin_deps(plugin_id: str) -> dict[str, Optional[str]]:
         return result
 
     for dep in plugin_deps.split(","):
+        if not dep:
+            continue
         if "==" in dep:
             name, version_required = dep.split("==")
         else:


### PR DESCRIPTION
## Description

This PR avoids that the Plugin Dependencies Manager dialog window is incorrectly displayed if the plugin_dependencies metadata is empty (`plugin_dependencies=`) in the plugin's metadata.txt.
It also fixes cases like `plugin_dependencies=aaaa,` where a second empty row is incorrectly displayed in the Plugin Dependencies Manager dialog window.

Fixes https://github.com/qgis/QGIS/issues/65782.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
