### PR TITLE
[FEATURE] Allow embedding base64 images in Image Decoration

### DIFF
--- a/src/app/decorations/qgsdecorationimage.cpp
+++ b/src/app/decorations/qgsdecorationimage.cpp
@@ -123,9 +123,14 @@ QString QgsDecorationImage::imagePath()
 {
   if ( !mImagePath.isEmpty() )
   {
+    if ( mImagePath.startsWith( "base64:"_L1, Qt::CaseInsensitive ) || mImagePath.startsWith( "http://"_L1, Qt::CaseInsensitive ) || mImagePath.startsWith( "https://"_L1, Qt::CaseInsensitive ) )
+    {
+      return mImagePath;
+    }
+
     QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( mImagePath, QgsProject::instance()->pathResolver() );
-    const bool validSvg = QFileInfo::exists( resolvedPath );
-    if ( validSvg )
+    const bool validFile = QFileInfo::exists( resolvedPath );
+    if ( validFile )
     {
       return resolvedPath;
     }

--- a/src/app/decorations/qgsdecorationimagedialog.cpp
+++ b/src/app/decorations/qgsdecorationimagedialog.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 
 #include "qgsdecorationimage.h"
+#include "qgsfilecontentsourcelineedit.h"
 #include "qgsgui.h"
 #include "qgshelp.h"
 #include "qgsimagecache.h"
@@ -72,8 +73,8 @@ QgsDecorationImageDialog::QgsDecorationImageDialog( QgsDecorationImage &deco, QW
   grpEnable->setChecked( mDeco.enabled() );
   connect( grpEnable, &QGroupBox::toggled, this, [this] { updateEnabledColorButtons(); } );
 
-  wgtImagePath->setFilePath( mDeco.imagePath() );
-  connect( wgtImagePath, &QgsFileWidget::fileChanged, this, &QgsDecorationImageDialog::updateImagePath );
+  wgtImagePath->setSource( mDeco.imagePath() );
+  connect( wgtImagePath, &QgsImageSourceLineEdit::sourceChanged, this, &QgsDecorationImageDialog::updateImagePath );
   updateImagePath( mDeco.imagePath() );
 
   pbnChangeColor->setAllowOpacity( true );

--- a/src/ui/qgsdecorationimagedialog.ui
+++ b/src/ui/qgsdecorationimagedialog.ui
@@ -74,7 +74,7 @@
        </widget>
       </item>
       <item row="0" column="2" colspan="3">
-       <widget class="QgsFileWidget" name="wgtImagePath" native="true"/>
+       <widget class="QgsImageSourceLineEdit" name="wgtImagePath" native="true"/>
       </item>
       <item row="1" column="1">
        <widget class="QLabel" name="colorLabel">
@@ -319,9 +319,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFileWidget</class>
+   <class>QgsImageSourceLineEdit</class>
    <extends>QWidget</extends>
-   <header>qgsfilewidget.h</header>
+   <header>qgsfilecontentsourcelineedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
 ## Description 

Replacing the the UI for the Image Decoration dialog, by updating to use `QgsImageSourceLineEdit` instead of the older `QgsFileWidget`.

The core `QgsDecorationImage::imagePath()` logic was updated to properly recognize `base64:` and `http(s)://` prefixes

The Image Decoration feature now allows to embed images directly into QGIS project file. Now is possible to select "Embed File..." practical for ensuring the decoration remains visible when sharing the project file

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ea069307-de11-4d15-a939-90d424ac0eec" />

## AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

*Note: AI (Google Gemini) used interactively for general C++ syntax alignment anddebugging during development.*
