### PR TITLE
Use depth buffer to set transparent pixels in material thumbnails instead of flood fill hack

### DIFF
--- a/src/app/3d/qgs3dicongenerator.cpp
+++ b/src/app/3d/qgs3dicongenerator.cpp
@@ -160,7 +160,7 @@ void Qgs3DIconGenerator::generateThumbnailForMaterial( QgsStyle *style, const QS
   if ( thumbnail.isNull() )
   {
     thumbnail = renderMaterial( settings.get() );
-    thumbnail.save( targetFileName, "WEBP" );
+    thumbnail.save( targetFileName, "WEBP", 97 );
   }
 
   const QList<QSize> sizes = iconSizes();

--- a/src/app/3d/qgs3dicongenerator.cpp
+++ b/src/app/3d/qgs3dicongenerator.cpp
@@ -185,8 +185,8 @@ QImage Qgs3DIconGenerator::renderMaterial( const QgsAbstractMaterialSettings *se
   const QSize size( 600, 600 );
   engine.setSize( size );
 
-  // clear color -- will be replaced with transparent color
-  constexpr QColor CLEAR_COLOR = QColor( 255, 0, 255 );
+  // clear color -- use black
+  constexpr QColor CLEAR_COLOR = QColor( 0, 0, 0 );
   engine.setClearColor( CLEAR_COLOR );
   engine.frameGraph()->setRenderCaptureEnabled( true );
 
@@ -246,14 +246,41 @@ QImage Qgs3DIconGenerator::renderMaterial( const QgsAbstractMaterialSettings *se
     captureLoop.exec();
   }
 
-  // replace background color with transparent
-  thumbnail = QgsImageOperation::floodFill( thumbnail, QPoint( 0, 0 ), QColor( 0, 0, 0, 0 ), 1 );
-  // another bit of a hack to get nice previews for simple lines -- the flood fill doesn't work well for those, because
-  // the center of the preview image is supposed to be transparent but it's surrounded by color:
-  if ( thumbnail.pixelColor( 300, 300 ) == CLEAR_COLOR )
+  QImage depthThumbnail;
   {
-    thumbnail = QgsImageOperation::floodFill( thumbnail, QPoint( 300, 300 ), QColor( 0, 0, 0, 0 ), 1 );
+    QEventLoop captureLoop;
+    QObject::connect( &engine, &QgsAbstract3DEngine::depthBufferCaptured, &captureLoop, [&depthThumbnail, &captureLoop]( const QImage &img ) {
+      depthThumbnail = img;
+      captureLoop.quit();
+    } );
+
+    engine.renderSettings()->setRenderPolicy( Qt3DRender::QRenderSettings::RenderPolicy::OnDemand );
+    engine.requestDepthBufferCapture();
+    captureLoop.exec();
   }
 
+  setMaximumDepthAsTransparent( depthThumbnail, thumbnail );
   return thumbnail;
+}
+
+void Qgs3DIconGenerator::setMaximumDepthAsTransparent( const QImage &depthImage, QImage &renderImage )
+{
+  const int width = renderImage.width();
+  const int height = renderImage.height();
+
+  constexpr QRgb maxDepthColor = qRgb( 0, 0, 255 );
+  constexpr QRgb transparentPixel = qRgba( 0, 0, 0, 0 );
+
+  for ( int y = 0; y < height; ++y )
+  {
+    const QRgb *maskPixels = reinterpret_cast<const QRgb *>( depthImage.constScanLine( y ) );
+    QRgb *renderPixels = reinterpret_cast<QRgb *>( renderImage.scanLine( y ) );
+    for ( int x = 0; x < width; ++x )
+    {
+      if ( maskPixels[x] == maxDepthColor )
+      {
+        renderPixels[x] = transparentPixel;
+      }
+    }
+  }
 }

--- a/src/app/3d/qgs3dicongenerator.h
+++ b/src/app/3d/qgs3dicongenerator.h
@@ -33,6 +33,7 @@ class Qgs3DIconGenerator : public QgsAbstractStyleEntityIconGenerator
     void generateThumbnailForMaterial( QgsStyle *style, const QString &name );
     static QImage renderMaterial( const QgsAbstractMaterialSettings *material );
     static QImage scaleAndCenterImage( const QImage &source, const QSize &targetSize );
+    static void setMaximumDepthAsTransparent( const QImage &depthImage, QImage &renderImage );
 };
 
 #endif //QGS3DICONGENERATOR_H


### PR DESCRIPTION

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
