### PR TITLE
Deprecate non z-up mode from QgsTessellator

### DIFF
--- a/python/PyQt6/core/auto_generated/qgstessellator.sip.in
+++ b/python/PyQt6/core/auto_generated/qgstessellator.sip.in
@@ -205,24 +205,28 @@ Returns the algorithm used for triangulation.
 .. versionadded:: 4.0
 %End
 
-    void setOutputZUp( bool zUp );
+ void setOutputZUp( bool zUp ) /Deprecated="Since 4.2. Has no effect no, outputs are always z-up."/;
 %Docstring
 Sets whether the "up" direction should be the Z axis on output
 (``True``), otherwise the "up" direction will be the Y axis (``False``).
 The default value is ``False`` (to keep compatibility for existing
 tessellator use cases).
 
-.. versionadded:: 3.42
+.. deprecated:: 4.2
+
+   Has no effect no, outputs are always z-up.
 %End
 
-    bool isOutputZUp() const;
+ bool isOutputZUp() const /Deprecated="Since 4.2. Has no effect no, outputs are always z-up."/;
 %Docstring
 Returns whether the "up" direction should be the Z axis on output
 (``True``), otherwise the "up" direction will be the Y axis (``False``).
 The default value is ``False`` (to keep compatibility for existing
 tessellator use cases).
 
-.. versionadded:: 3.42
+.. deprecated:: 4.2
+
+   Has no effect no, outputs are always z-up.
 %End
 
     void addPolygon( const QgsPolygon &polygon, float extrusionHeight );

--- a/src/3d/processing/qgsalgorithmtessellate.cpp
+++ b/src/3d/processing/qgsalgorithmtessellate.cpp
@@ -134,7 +134,6 @@ QgsFeatureList QgsTessellateAlgorithm::processFeature( const QgsFeature &feature
         const QgsRectangle bounds = f.geometry().boundingBox();
         QgsTessellator t;
         t.setBounds( bounds );
-        t.setOutputZUp( true );
 
         if ( f.geometry().isMultipart() )
         {

--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -462,7 +462,6 @@ void QgsRubberBand3D::updateGeometry()
       QgsTessellator tessellator;
       tessellator.setOrigin( mMapSettings->origin() );
       tessellator.setAddNormals( true );
-      tessellator.setOutputZUp( true );
       tessellator.addPolygon( *polygon, 0 );
       if ( !tessellator.error().isEmpty() )
       {

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -112,9 +112,6 @@ bool QgsBufferedLine3DSymbolHandler::prepare( const Qgs3DRenderContext &, QSet<Q
 
   mLineDataSelected.tessellator = std::move( lineDataSelectedTessellator );
 
-  mLineDataNormal.tessellator->setOutputZUp( true );
-  mLineDataSelected.tessellator->setOutputZUp( true );
-
   return true;
 }
 

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -98,17 +98,15 @@ bool QgsPolygon3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QSet
   outEdges.withAdjacency = true;
   outEdges.init( mSymbol->altitudeClamping(), mSymbol->altitudeBinding(), 0, context, mChunkOrigin );
 
-  const bool requiresTextureCoordinates = mSymbol->materialSettings() ? mSymbol->materialSettings()->requiresTextureCoordinates() : false;
+  const bool requiresTextureCoordinates = mSymbol->materialSettings() && mSymbol->materialSettings()->requiresTextureCoordinates();
 
   auto tessellator = std::make_unique<QgsTessellator>();
   tessellator->setOrigin( mChunkOrigin );
   tessellator->setAddNormals( true );
   tessellator->setInvertNormals( mSymbol->invertNormals() );
   tessellator->setBackFacesEnabled( mSymbol->addBackFaces() );
-  tessellator->setOutputZUp( true );
   tessellator->setExtrusionFaces( mSymbol->extrusionFaces() );
   tessellator->setAddTextureUVs( requiresTextureCoordinates );
-  tessellator->setOutputZUp( true );
   tessellator->setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
 
   outNormal.tessellator = std::move( tessellator );
@@ -118,10 +116,8 @@ bool QgsPolygon3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QSet
   tessellator->setAddNormals( true );
   tessellator->setInvertNormals( mSymbol->invertNormals() );
   tessellator->setBackFacesEnabled( mSymbol->addBackFaces() );
-  tessellator->setOutputZUp( true );
   tessellator->setExtrusionFaces( mSymbol->extrusionFaces() );
   tessellator->setAddTextureUVs( requiresTextureCoordinates );
-  tessellator->setOutputZUp( true );
   tessellator->setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
 
   outSelected.tessellator = std::move( tessellator );

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -40,7 +40,7 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
   const float dy = pt2.y() - pt1.y();
 
   // perpendicular vector in plane to [x,y] is [-y,x]
-  QVector3D vn = mOutputZUp ? QVector3D( -dy, dx, 0 ) : QVector3D( -dy, 0, -dx );
+  QVector3D vn = QVector3D( -dy, dx, 0 );
   vn.normalize();
 
   float u0, v0;
@@ -96,10 +96,7 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
 
   // triangle 1 vertex 1
   mIndexBuffer << uniqueVertexCount();
-  if ( mOutputZUp )
-    mData << pt1.x() << pt1.y() << pt1.z() + height;
-  else
-    mData << pt1.x() << pt1.z() + height << -pt1.y();
+  mData << pt1.x() << pt1.y() << pt1.z() + height;
   if ( mAddNormals )
     mData << vn.x() << vn.y() << vn.z();
   if ( mAddTextureCoords )
@@ -107,10 +104,7 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
 
   // triangle 1 vertex 2
   mIndexBuffer << uniqueVertexCount();
-  if ( mOutputZUp )
-    mData << pt2.x() << pt2.y() << pt2.z() + height;
-  else
-    mData << pt2.x() << pt2.z() + height << -pt2.y();
+  mData << pt2.x() << pt2.y() << pt2.z() + height;
   if ( mAddNormals )
     mData << vn.x() << vn.y() << vn.z();
   if ( mAddTextureCoords )
@@ -118,10 +112,7 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
 
   // triangle 1 vertex 3
   mIndexBuffer << uniqueVertexCount();
-  if ( mOutputZUp )
-    mData << pt1.x() << pt1.y() << pt1.z();
-  else
-    mData << pt1.x() << pt1.z() << -pt1.y();
+  mData << pt1.x() << pt1.y() << pt1.z();
   if ( mAddNormals )
     mData << vn.x() << vn.y() << vn.z();
   if ( mAddTextureCoords )
@@ -135,10 +126,7 @@ void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D
 
   // triangle 2 vertex 3
   mIndexBuffer << uniqueVertexCount();
-  if ( mOutputZUp )
-    mData << pt2.x() << pt2.y() << pt2.z();
-  else
-    mData << pt2.x() << pt2.z() << -pt2.y();
+  mData << pt2.x() << pt2.y() << pt2.z();
   if ( mAddNormals )
     mData << vn.x() << vn.y() << vn.z();
   if ( mAddTextureCoords )
@@ -243,6 +231,9 @@ void QgsTessellator::setTriangulationAlgorithm( Qgis::TriangulationAlgorithm alg
 {
   mTriangulationAlgorithm = algorithm;
 }
+
+void QgsTessellator::setOutputZUp( bool )
+{}
 
 void QgsTessellator::updateStride()
 {
@@ -558,12 +549,7 @@ QVector3D QgsTessellator::applyTransformWithExtrusion( const QVector3D point, fl
   if ( fz > mZMax )
     mZMax = static_cast<float>( fz );
 
-  // NOLINTBEGIN(bugprone-branch-clone);
-  if ( mOutputZUp )
-    return QVector3D( static_cast<float>( fx ), static_cast<float>( fy ), static_cast<float>( fz ) );
-  else
-    return QVector3D( static_cast<float>( fx ), static_cast<float>( fz ), static_cast<float>( -fy ) );
-  // NOLINTEND(bugprone-branch-clone)
+  return QVector3D( static_cast<float>( fx ), static_cast<float>( fy ), static_cast<float>( fz ) );
 }
 
 
@@ -750,15 +736,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
     calculateBaseTransform( pNormal, &base );
     polygonNew.reset( transformPolygonToNewBase( polygon, extrusionOrigin, &base, mScale ) );
 
-    QVector3D normal;
-    if ( !mOutputZUp )
-    {
-      normal = QVector3D( pNormal.x(), pNormal.z(), -pNormal.y() );
-    }
-    else
-    {
-      normal = pNormal;
-    }
+    QVector3D normal = pNormal;
     // our 3x3 matrix is orthogonal, so for inverse we only need to transpose it
     base = base.transposed();
 
@@ -935,21 +913,10 @@ std::unique_ptr<QgsMultiPolygon> QgsTessellator::asMultiPolygon() const
     const uint32_t index2 = mIndexBuffer[i + 1] * noOfElements;
     const uint32_t index3 = mIndexBuffer[i + 2] * noOfElements;
 
-    if ( mOutputZUp )
-    {
-      const QgsPoint p1( mData[index1], mData[index1 + 1], mData[index1 + 2] );
-      const QgsPoint p2( mData[index2], mData[index2 + 1], mData[index2 + 2] );
-      const QgsPoint p3( mData[index3], mData[index3 + 1], mData[index3 + 2] );
-      mp->addGeometry( new QgsTriangle( p1, p2, p3 ) );
-    }
-    else
-    {
-      // tessellator geometry is x, z, -y
-      const QgsPoint p1( mData[index1], -mData[index1 + 2], mData[index1 + 1] );
-      const QgsPoint p2( mData[index2], -mData[index2 + 2], mData[index2 + 1] );
-      const QgsPoint p3( mData[index3], -mData[index3 + 2], mData[index3 + 1] );
-      mp->addGeometry( new QgsTriangle( p1, p2, p3 ) );
-    }
+    const QgsPoint p1( mData[index1], mData[index1 + 1], mData[index1 + 2] );
+    const QgsPoint p2( mData[index2], mData[index2 + 1], mData[index2 + 2] );
+    const QgsPoint p3( mData[index3], mData[index3 + 1], mData[index3 + 2] );
+    mp->addGeometry( new QgsTriangle( p1, p2, p3 ) );
   }
 
   return mp;

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -183,17 +183,17 @@ class CORE_EXPORT QgsTessellator
      * Sets whether the "up" direction should be the Z axis on output (TRUE),
      * otherwise the "up" direction will be the Y axis (FALSE). The default
      * value is FALSE (to keep compatibility for existing tessellator use cases).
-     * \since QGIS 3.42
+     * \deprecated QGIS 4.2. Has no effect no, outputs are always z-up.
      */
-    void setOutputZUp( bool zUp ) { mOutputZUp = zUp; }
+    Q_DECL_DEPRECATED void setOutputZUp( bool zUp ) SIP_DEPRECATED;
 
     /**
      * Returns whether the "up" direction should be the Z axis on output (TRUE),
      * otherwise the "up" direction will be the Y axis (FALSE). The default
      * value is FALSE (to keep compatibility for existing tessellator use cases).
-     * \since QGIS 3.42
+     * \deprecated QGIS 4.2. Has no effect no, outputs are always z-up.
      */
-    bool isOutputZUp() const { return mOutputZUp; }
+    Q_DECL_DEPRECATED bool isOutputZUp() const SIP_DEPRECATED { return true; }
 
     //! Tessellates a triangle and adds its vertex entries to the output data array
     void addPolygon( const QgsPolygon &polygon, float extrusionHeight );
@@ -296,7 +296,6 @@ class CORE_EXPORT QgsTessellator
     bool mInvertNormals = false;
     bool mAddBackFaces = false;
     bool mAddTextureCoords = false;
-    bool mOutputZUp = false;
     QVector<float> mData;
     int mStride = 3 * sizeof( float );
     bool mInputZValueIgnored = false;

--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -1461,7 +1461,6 @@ bool QgsVectorLayerProfileGenerator::generateProfileForPolygons()
           const QgsRectangle bounds = clampedPolygon->boundingBox();
           QgsTessellator t;
           t.setBounds( bounds );
-          t.setOutputZUp( true );
           t.addPolygon( *clampedPolygon, 0 );
 
           tessellation = QgsGeometry( t.asMultiPolygon() );

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -279,7 +279,6 @@ void TestQgsTessellator::testBasic()
   QgsTessellator tesCD;
   tesCD.setOrigin( QgsVector3D( 0, 0, 0 ) );
   tesCD.setAddNormals( false );
-  tesCD.setOutputZUp( true );
   tesCD.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesCD, false ), trianglesCD ) );
 
@@ -288,7 +287,6 @@ void TestQgsTessellator::testBasic()
 
   QgsTessellator tesZCD;
   tesZCD.setAddNormals( false );
-  tesZCD.setOutputZUp( true );
   tesZCD.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesZCD, false ), trianglesZCD ) );
 
@@ -296,7 +294,6 @@ void TestQgsTessellator::testBasic()
   tesEarcut.setOrigin( QgsVector3D( 0, 0, 0 ) );
   tesEarcut.setAddNormals( false );
   tesEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
-  tesEarcut.setOutputZUp( true );
   tesEarcut.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesEarcut, false ), trianglesEarcut ) );
 
@@ -305,7 +302,6 @@ void TestQgsTessellator::testBasic()
 
   QgsTessellator tesZEarcut;
   tesZEarcut.setAddNormals( false );
-  tesZEarcut.setOutputZUp( true );
   tesZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesZEarcut.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesZEarcut, false ), trianglesZEarcut ) );
@@ -316,7 +312,6 @@ void TestQgsTessellator::testBasic()
 
   QgsTessellator tesNormalsCD;
   tesNormalsCD.setAddNormals( true );
-  tesNormalsCD.setOutputZUp( true );
   tesNormalsCD.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsCD, true ), trianglesNormalsCD ) );
   QCOMPARE( tesNormalsCD.zMinimum(), 0 );
@@ -324,7 +319,6 @@ void TestQgsTessellator::testBasic()
 
   QgsTessellator tesNormalsZCD;
   tesNormalsZCD.setAddNormals( true );
-  tesNormalsZCD.setOutputZUp( true );
   tesNormalsZCD.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsZCD, true ), trianglesNormalsZCD ) );
 
@@ -333,7 +327,6 @@ void TestQgsTessellator::testBasic()
 
   QgsTessellator tesNormalsEarcut;
   tesNormalsEarcut.setAddNormals( true );
-  tesNormalsEarcut.setOutputZUp( true );
   tesNormalsEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesNormalsEarcut.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsEarcut, true ), trianglesNormalsEarcut ) );
@@ -343,7 +336,6 @@ void TestQgsTessellator::testBasic()
 
   QgsTessellator tesNormalsZEarcut;
   tesNormalsZEarcut.setAddNormals( true );
-  tesNormalsZEarcut.setOutputZUp( true );
   tesNormalsZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesNormalsZEarcut.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsZEarcut, true ), trianglesNormalsZEarcut ) );
@@ -371,7 +363,6 @@ void TestQgsTessellator::testBasic()
   QgsTessellator tesInvertedNormalsCD;
   tesInvertedNormalsCD.setAddNormals( true );
   tesInvertedNormalsCD.setInvertNormals( true );
-  tesInvertedNormalsCD.setOutputZUp( true );
   tesInvertedNormalsCD.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsCD, true ), trianglesInvertedNormalsCD ) );
 
@@ -382,7 +373,6 @@ void TestQgsTessellator::testBasic()
   tesInvertedNormalsZCD.setExtrusionFaces( Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof );
   tesInvertedNormalsZCD.setAddNormals( true );
   tesInvertedNormalsZCD.setInvertNormals( true );
-  tesInvertedNormalsZCD.setOutputZUp( true );
   tesInvertedNormalsZCD.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsZCD, true ), trianglesInvertedNormalsZCD ) );
 
@@ -392,7 +382,6 @@ void TestQgsTessellator::testBasic()
   QgsTessellator tesInvertedNormalsEarcut;
   tesInvertedNormalsEarcut.setAddNormals( true );
   tesInvertedNormalsEarcut.setInvertNormals( true );
-  tesInvertedNormalsEarcut.setOutputZUp( true );
   tesInvertedNormalsEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesInvertedNormalsEarcut.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsEarcut, true ), trianglesInvertedNormalsEarcut ) );
@@ -403,7 +392,6 @@ void TestQgsTessellator::testBasic()
   QgsTessellator tesInvertedNormalsZEarcut;
   tesInvertedNormalsZEarcut.setAddNormals( true );
   tesInvertedNormalsZEarcut.setInvertNormals( true );
-  tesInvertedNormalsZEarcut.setOutputZUp( true );
   tesInvertedNormalsZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesInvertedNormalsZEarcut.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsZEarcut, true ), trianglesInvertedNormalsZEarcut ) );
@@ -458,7 +446,6 @@ void TestQgsTessellator::testBasicClockwise()
   // without normals
 
   QgsTessellator tesCD;
-  tesCD.setOutputZUp( true );
   tesCD.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesCD, false ), trianglesCD ) );
 
@@ -466,7 +453,6 @@ void TestQgsTessellator::testBasicClockwise()
   QCOMPARE( tesCD.zMaximum(), 0 );
 
   QgsTessellator tesZCD;
-  tesZCD.setOutputZUp( true );
   tesZCD.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesZCD, false ), trianglesZCD ) );
 
@@ -476,7 +462,6 @@ void TestQgsTessellator::testBasicClockwise()
 
   QgsTessellator tesN;
   tesN.setAddNormals( true );
-  tesN.setOutputZUp( true );
   tesN.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesN, true ), trianglesNormalsCD ) );
 
@@ -485,7 +470,6 @@ void TestQgsTessellator::testBasicClockwise()
 
   QgsTessellator tesNZ;
   tesNZ.setAddNormals( true );
-  tesNZ.setOutputZUp( true );
   tesNZ.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesNZ, true ), trianglesNormalsZCD ) );
 
@@ -494,7 +478,6 @@ void TestQgsTessellator::testBasicClockwise()
 
   QgsTessellator tesEarcut;
   tesEarcut.setAddNormals( true );
-  tesEarcut.setOutputZUp( true );
   tesEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesEarcut.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesEarcut, true ), trianglesNormalsEarcut ) );
@@ -504,7 +487,6 @@ void TestQgsTessellator::testBasicClockwise()
 
   QgsTessellator tesZEarcut;
   tesZEarcut.setAddNormals( true );
-  tesZEarcut.setOutputZUp( true );
   tesZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesZEarcut.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesZEarcut, true ), trianglesNormalsZEarcut ) );
@@ -533,7 +515,6 @@ void TestQgsTessellator::testBasicClockwise()
   QgsTessellator tesInvertedNormalsCD;
   tesInvertedNormalsCD.setAddNormals( true );
   tesInvertedNormalsCD.setInvertNormals( true );
-  tesInvertedNormalsCD.setOutputZUp( true );
   tesInvertedNormalsCD.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsCD, true ), trianglesInvertedNormalsCD ) );
 
@@ -543,7 +524,6 @@ void TestQgsTessellator::testBasicClockwise()
   QgsTessellator tesInvertedNormalsZCD;
   tesInvertedNormalsZCD.setAddNormals( true );
   tesInvertedNormalsZCD.setInvertNormals( true );
-  tesInvertedNormalsZCD.setOutputZUp( true );
   tesInvertedNormalsZCD.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsZCD, true ), trianglesInvertedNormalsZCD ) );
 
@@ -553,7 +533,6 @@ void TestQgsTessellator::testBasicClockwise()
   QgsTessellator tesInvertedNormalsEarcut;
   tesInvertedNormalsEarcut.setAddNormals( true );
   tesInvertedNormalsEarcut.setInvertNormals( true );
-  tesInvertedNormalsEarcut.setOutputZUp( true );
   tesInvertedNormalsEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesInvertedNormalsEarcut.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsEarcut, true ), trianglesInvertedNormalsEarcut ) );
@@ -564,7 +543,6 @@ void TestQgsTessellator::testBasicClockwise()
   QgsTessellator tesInvertedNormalsZEarcut;
   tesInvertedNormalsZEarcut.setAddNormals( true );
   tesInvertedNormalsZEarcut.setInvertNormals( true );
-  tesInvertedNormalsZEarcut.setOutputZUp( true );
   tesInvertedNormalsZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesInvertedNormalsZEarcut.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesInvertedNormalsZEarcut, true ), trianglesInvertedNormalsZEarcut ) );
@@ -598,7 +576,6 @@ void TestQgsTessellator::testWalls()
 
   QgsTessellator tRect;
   tRect.setAddNormals( true );
-  tRect.setOutputZUp( true );
   tRect.addPolygon( rect, 1 );
   QVERIFY( checkTriangleOutput( extractTriangles( tRect, true ), tcRect ) );
   QCOMPARE( tRect.zMinimum(), 0 );
@@ -611,7 +588,6 @@ void TestQgsTessellator::testWalls()
 
   QgsTessellator tRectRev;
   tRectRev.setAddNormals( true );
-  tRectRev.setOutputZUp( true );
   tRectRev.addPolygon( rectRev, 1 );
   QVERIFY( checkTriangleOutput( extractTriangles( tRectRev, true ), tcRect ) );
   QCOMPARE( tRectRev.zMinimum(), 0 );
@@ -637,7 +613,6 @@ void TestQgsTessellator::testWalls()
   tc << TriangleCoords( QVector3D( 2, 1, 2 ), QVector3D( 1, 1, 11 ), QVector3D( 1, 1, 1 ) );
 
   QgsTessellator tZ;
-  tZ.setOutputZUp( true );
   tZ.addPolygon( polygonZ, 10 );
   QVERIFY( checkTriangleOutput( extractTriangles( tZ, false ), tc ) );
 
@@ -691,7 +666,6 @@ void TestQgsTessellator::testBackEdges()
 
   QgsTessellator t;
   t.setAddNormals( true );
-  t.setOutputZUp( true );
   t.setBackFacesEnabled( true );
   t.setExtrusionFaces( Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof | Qgis::ExtrusionFace::Floor );
   t.addPolygon( rect, 1 );
@@ -716,7 +690,6 @@ void TestQgsTessellator::test2DTriangle()
 
     QgsTessellator tessellatorNormalsCD;
     tessellatorNormalsCD.setAddNormals( true );
-    tessellatorNormalsCD.setOutputZUp( true );
     tessellatorNormalsCD.addPolygon( polygon, 0 );
     QVERIFY( checkTriangleOutput( extractTriangles( tessellatorNormalsCD, true ), trianglesNormalsCD ) );
 
@@ -728,7 +701,6 @@ void TestQgsTessellator::test2DTriangle()
 
     QgsTessellator tessellatorNormalsEarcut;
     tessellatorNormalsEarcut.setAddNormals( true );
-    tessellatorNormalsEarcut.setOutputZUp( true );
     tessellatorNormalsEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
     tessellatorNormalsEarcut.addPolygon( polygon, 0 );
     QVERIFY( checkTriangleOutput( extractTriangles( tessellatorNormalsEarcut, true ), trianglesNormalsEarcut ) );
@@ -764,7 +736,6 @@ void TestQgsTessellator::test2DTriangle()
 
     QgsTessellator tesNormalsCD;
     tesNormalsCD.setAddNormals( true );
-    tesNormalsCD.setOutputZUp( true );
     tesNormalsCD.addPolygon( polygon, 7 );
     QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsCD, true ), trianglesNormalsCD ) );
 
@@ -790,7 +761,6 @@ void TestQgsTessellator::test3DTriangle()
 
     QgsTessellator tN;
     tN.setAddNormals( true );
-    tN.setOutputZUp( true );
     tN.addPolygon( polygon, 0 );
     QVERIFY( checkTriangleOutput( extractTriangles( tN, true ), tcNormals ) );
 
@@ -826,7 +796,6 @@ void TestQgsTessellator::test3DTriangle()
 
     QgsTessellator tesNormalsEarcut;
     tesNormalsEarcut.setAddNormals( true );
-    tesNormalsEarcut.setOutputZUp( true );
     tesNormalsEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
     tesNormalsEarcut.addPolygon( polygon, 7 );
     QVERIFY( checkTriangleOutput( extractTriangles( tesNormalsEarcut, true ), trianglesNormalsEarcut ) );
@@ -845,12 +814,10 @@ void TestQgsTessellator::asMultiPolygon()
   polygonZ.fromWkt( "POLYGONZ((1 1 1, 2 1 2, 3 2 3, 1 2 4, 1 1 1))" );
 
   QgsTessellator t;
-  t.setOutputZUp( true );
   t.addPolygon( polygon, 0 );
   QCOMPARE( t.asMultiPolygon()->asWkt(), u"MultiPolygon Z (((1 2 0, 2 1 0, 3 2 0, 1 2 0)),((1 2 0, 1 1 0, 2 1 0, 1 2 0)))"_s );
 
   QgsTessellator t2;
-  t2.setOutputZUp( true );
   t2.addPolygon( polygonZ, 0 );
   QCOMPARE( t2.asMultiPolygon()->asWkt( 6 ), u"MultiPolygon Z (((1 2 4, 2 1 2, 3 2 3, 1 2 4)),((1 2 4, 1 1 1, 2 1 2, 1 2 4)))"_s );
 }
@@ -871,7 +838,6 @@ void TestQgsTessellator::testBadCoordinates()
   trianglesZEarcut << TriangleCoords( QVector3D( 1, 2, 1 ), QVector3D( 2, 1, 1 ), QVector3D( 2, 1, 2 ) );
 
   QgsTessellator tesZCD;
-  tesZCD.setOutputZUp( true );
   tesZCD.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesZCD, false ), trianglesZCD ) );
 
@@ -879,7 +845,6 @@ void TestQgsTessellator::testBadCoordinates()
   QCOMPARE( tesZCD.zMaximum(), 2.0f );
 
   QgsTessellator tesZEarcut;
-  tesZEarcut.setOutputZUp( true );
   tesZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesZEarcut.addPolygon( polygonZ, 0 );
 
@@ -902,7 +867,6 @@ void TestQgsTessellator::testBadCoordinates()
   trianglesEarcut << TriangleCoords( QVector3D( 1, 1, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 3, 2, 0 ) );
 
   QgsTessellator tesCD;
-  tesCD.setOutputZUp( true );
   tesCD.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesCD, false ), trianglesCD ) );
 
@@ -910,7 +874,6 @@ void TestQgsTessellator::testBadCoordinates()
   QCOMPARE( tesCD.zMaximum(), 0 );
 
   QgsTessellator tesEarcut;
-  tesEarcut.setOutputZUp( true );
   tesEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesEarcut.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesEarcut, false ), trianglesEarcut ) );
@@ -925,7 +888,6 @@ void TestQgsTessellator::testIssue17745()
 
   QgsTessellator t;
   t.setAddNormals( true );
-  t.setOutputZUp( true );
   QgsPolygon p;
   const bool resWktRead = p.fromWkt( "Polygon((0 0, 1 1e-15, 4 0, 4 5, 1 5, 0 5, 0 0))" );
   QVERIFY( resWktRead );
@@ -943,7 +905,6 @@ void TestQgsTessellator::testCrashSelfIntersection()
 
   QgsTessellator t;
   t.setAddNormals( true );
-  t.setOutputZUp( true );
   QgsPolygon p;
   const bool resWktRead = p.fromWkt(
     "PolygonZ ((-744809.80499999970197678 -1042371.96730000153183937 260.460968017578125, -744809.80299999937415123 -1042371.92199999839067459 260.460968017578125, -744810.21599999815225601 "
@@ -966,7 +927,6 @@ void TestQgsTessellator::testCrashEmptyPolygon()
 
   QgsTessellator t;
   t.setAddNormals( true );
-  t.setOutputZUp( true );
   QgsPolygon p;
   const bool resWktRead = p.fromWkt( "PolygonZ ((0 0 0, 0 0 0, 0 0 0))" );
   QVERIFY( resWktRead );
@@ -986,7 +946,6 @@ void TestQgsTessellator::testBoundsScaling()
   // without using bounds -- numerically unstable, expect no result
   QgsTessellator t;
   t.setAddNormals( true );
-  t.setOutputZUp( true );
   t.addPolygon( polygon, 0 );
   QCOMPARE( t.uniqueVertexCount(), 0 );
 
@@ -994,7 +953,6 @@ void TestQgsTessellator::testBoundsScaling()
   QgsTessellator t2;
   t2.setBounds( polygon.boundingBox() );
   t2.setAddNormals( true );
-  t2.setOutputZUp( true );
   t2.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( t2, true ), tc ) );
   QCOMPARE( t2.zMinimum(), 0 );
@@ -1014,7 +972,6 @@ void TestQgsTessellator::testNoZ()
   QgsTessellator t;
   t.setBounds( polygonZ.boundingBox() );
   t.setInputZValueIgnored( true );
-  t.setOutputZUp( true );
   t.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( t, false ), tc ) );
   QCOMPARE( t.zMinimum(), 0 );
@@ -1029,7 +986,6 @@ void TestQgsTessellator::testTriangulationDoesNotCrash()
   polygon.fromWkt( "Polygon((0 0, -5 -3e-10, -10 -2e-10, -10 -4, 0 -4))" );
   QgsTessellator t;
   t.setAddNormals( true );
-  t.setOutputZUp( true );
   t.addPolygon( polygon, 0 );
 
   // let's also test earcut here
@@ -1045,7 +1001,6 @@ void TestQgsTessellator::testCrash2DTriangle()
   // must not be declared with mNoz = true
   QgsTessellator t;
   t.setAddNormals( true );
-  t.setOutputZUp( true );
   t.addPolygon( polygon, 0 ); // must not crash - that's all we test here
 
   // let's also test earcut here
@@ -1070,7 +1025,6 @@ void TestQgsTessellator::narrowPolygon()
   );
   QgsTessellator t;
   t.setBounds( polygon.boundingBox() );
-  t.setOutputZUp( true );
   t.addPolygon( polygon, 0 );
   QgsGeometry res( t.asMultiPolygon() );
   res.translate( polygon.boundingBox().xMinimum(), polygon.boundingBox().yMinimum() );
@@ -1088,24 +1042,13 @@ void TestQgsTessellator::testOutputZUp()
 
   QgsTessellator tZUp;
   tZUp.setAddNormals( true );
-  tZUp.setOutputZUp( true );
   tZUp.addPolygon( polygon, 0 );
-
-  QgsTessellator tYUp;
-  tYUp.setAddNormals( true );
-  tYUp.setOutputZUp( false );
-  tYUp.addPolygon( polygon, 0 );
 
   QList<TriangleCoords> expectedOutputZUp;
   expectedOutputZUp << TriangleCoords( QVector3D( 1, 2, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 3, 2, 0 ), QVector3D( 0, 0, 1 ), QVector3D( 0, 0, 1 ), QVector3D( 0, 0, 1 ) );
   expectedOutputZUp << TriangleCoords( QVector3D( 1, 2, 0 ), QVector3D( 1, 1, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 0, 0, 1 ), QVector3D( 0, 0, 1 ), QVector3D( 0, 0, 1 ) );
 
-  QList<TriangleCoords> expectedOutputYUp;
-  expectedOutputYUp << TriangleCoords( QVector3D( 1, 0, -2 ), QVector3D( 2, 0, -1 ), QVector3D( 3, 0, -2 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ) );
-  expectedOutputYUp << TriangleCoords( QVector3D( 1, 0, -2 ), QVector3D( 1, 0, -1 ), QVector3D( 2, 0, -1 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ), QVector3D( 0, 1, 0 ) );
-
   QVERIFY( checkTriangleOutput( extractTriangles( tZUp, true ), expectedOutputZUp ) );
-  QVERIFY( checkTriangleOutput( extractTriangles( tYUp, true ), expectedOutputYUp ) );
 }
 
 void TestQgsTessellator::testDuplicatePoints()
@@ -1122,12 +1065,10 @@ void TestQgsTessellator::testDuplicatePoints()
   trianglesZEarcut << TriangleCoords( QVector3D( 1, 1, 3 ), QVector3D( 2, 1, 3 ), QVector3D( 3, 2, 3 ) );
 
   QgsTessellator tesZCD;
-  tesZCD.setOutputZUp( true );
   tesZCD.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesZCD, false ), trianglesZCD ) );
 
   QgsTessellator tesZEarcut;
-  tesZEarcut.setOutputZUp( true );
   tesZEarcut.setTriangulationAlgorithm( Qgis::TriangulationAlgorithm::Earcut );
   tesZEarcut.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( extractTriangles( tesZEarcut, false ), trianglesZEarcut ) );


### PR DESCRIPTION
Everywhere we use this class we use z-up mode, and the non z-up path greatly complicates the logic.

Make it a no-op and deprecate it. It is highly unlikely third party python code would be generating normals with this class in a non z-up mode.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
