### PR TITLE
Fix Layer Styling panel crash when switching saved styles

### DIFF
--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -70,7 +70,7 @@ QgsMapLayerStyleManagerWidget::QgsMapLayerStyleManagerWidget( QgsMapLayer *layer
   QAction *loadDefaultAction = toolbar->addAction( tr( "Restore Default" ) );
   connect( loadDefaultAction, &QAction::triggered, this, &QgsMapLayerStyleManagerWidget::loadDefault );
 
-  connect( mStyleList, &QAbstractItemView::clicked, this, &QgsMapLayerStyleManagerWidget::styleClicked );
+  connect( mStyleList, &QAbstractItemView::clicked, this, &QgsMapLayerStyleManagerWidget::styleClicked, Qt::QueuedConnection );
 
   setLayout( new QVBoxLayout() );
   layout()->setContentsMargins( 0, 0, 0, 0 );


### PR DESCRIPTION
## Description

Fixes a crash in the Layer Styling panel that occurs when clicking a saved style in the Style Manager tab (Qt 6 only).

**Root cause:** `QgsMapLayerStyleManagerWidget` connects `mStyleList::clicked` to `styleClicked` with the default `Qt::DirectConnection`. Clicking a saved style fires this call chain synchronously, still inside `QListView::mouseReleaseEvent`:

```
QListView::mouseReleaseEvent
  → clicked() signal  [Qt::DirectConnection]
    → styleClicked()
      → setCurrentStyle()
        → emit currentStyleChanged()
          → mStyleList->setCurrentIndex()   ← modifies selection model
```

On Qt 6, `setCurrentIndex()` invalidates `d->pressedIndex` (a `QPersistentModelIndex` held by the view's event handler). When `mouseReleaseEvent` resumes after the `clicked()` handler returns, it dereferences the now-invalid index → SIGSEGV on Linux, access violation (0xbaadf00d) on Windows.

The crash does **not** occur when switching styles via:
- Right-click layer → Styles submenu (`QAction::triggered` fires from the menu event loop, outside any view event handler)
- Layer Properties dialog (`QComboBox::currentIndexChanged`, also outside a view event handler)

**Fix:** Change the `clicked → styleClicked` connection to `Qt::QueuedConnection` so `styleClicked()` runs on the next event loop iteration — after `mouseReleaseEvent` has fully completed and released `d->pressedIndex`.

One-line change in `src/gui/qgsmaplayerstylemanagerwidget.cpp`.

Fixes #65476

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.