### PR TITLE
Fix loss of render floors setting when saving polygon 3d symbols

### DIFF
--- a/src/3d/symbols/qgspolygon3dsymbol.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol.cpp
@@ -68,7 +68,7 @@ void QgsPolygon3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext 
   elemDataProperties.setAttribute( u"culling-mode"_s, Qgs3DUtils::cullingModeToString( mCullingMode ) );
   elemDataProperties.setAttribute( u"invert-normals"_s, mInvertNormals ? u"1"_s : u"0"_s );
   elemDataProperties.setAttribute( u"add-back-faces"_s, mAddBackFaces ? u"1"_s : u"0"_s );
-  elemDataProperties.setAttribute( u"rendered-facade"_s, qgsEnumValueToKey( mExtrusionFaces ) );
+  elemDataProperties.setAttribute( u"rendered-facade"_s, qgsFlagValueToKeys( mExtrusionFaces ) );
   elem.appendChild( elemDataProperties );
 
   elem.setAttribute( u"material_type"_s, mMaterialSettings->type() );
@@ -99,7 +99,7 @@ void QgsPolygon3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteCon
   mCullingMode = Qgs3DUtils::cullingModeFromString( elemDataProperties.attribute( u"culling-mode"_s ) );
   mInvertNormals = elemDataProperties.attribute( u"invert-normals"_s ).toInt();
   mAddBackFaces = elemDataProperties.attribute( u"add-back-faces"_s ).toInt();
-  mExtrusionFaces = qgsEnumKeyToValue( elemDataProperties.attribute( u"rendered-facade"_s ), Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof );
+  mExtrusionFaces = qgsFlagKeysToValue( elemDataProperties.attribute( u"rendered-facade"_s ), Qgis::ExtrusionFace::Walls | Qgis::ExtrusionFace::Roof );
 
   const QDomElement elemMaterial = elem.firstChildElement( u"material"_s );
   const QString materialType = elem.attribute( u"material_type"_s, u"phong"_s );


### PR DESCRIPTION
## Description

Use correct method to read/write flags based value to string.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

