### PR TITLE
[ui] Fix overview panel missing global/project contexts leading unfaithful renderings

### DIFF
--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -20,6 +20,8 @@
 
 #include <limits>
 
+#include "qgsexpressioncontext.h"
+#include "qgsexpressioncontextutils.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaplayer.h"
@@ -232,6 +234,15 @@ void QgsMapOverviewCanvas::refresh()
   QgsDebugMsgLevel( u"oveview - starting new"_s, 2 );
 
   mSettings.setDevicePixelRatio( static_cast<float>( devicePixelRatioF() ) );
+
+  // build the expression context
+  QgsExpressionContext expressionContext;
+  expressionContext << QgsExpressionContextUtils::globalScope() << QgsExpressionContextUtils::mapSettingsScope( mSettings );
+  if ( QgsProject::instance() )
+  {
+    expressionContext << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+  }
+  mSettings.setExpressionContext( expressionContext );
 
   // TODO: setup overview mode
   mJob = new QgsMapRendererSequentialJob( mSettings );


### PR DESCRIPTION
## Description

The map window overview panel's rendering job was missing QGIS' global and project expression contexts, which could result in "unfaithful" renderings when for e.g. a symbology would rely on project-level variables.

Before:

<img width="1021" height="753" alt="Screenshot From 2026-04-17 16-41-13" src="https://github.com/user-attachments/assets/9f13602e-12b2-4323-bfec-5d02a79a3506" />

With the fix in:

<img width="1021" height="753" alt="Screenshot From 2026-04-17 16-40-51" src="https://github.com/user-attachments/assets/4a82dd2c-a907-4a07-aeea-0bf688bed93f" />

