### PR TITLE
Support directly dropping image files onto QgsImageSourceLineEdit

### DIFF
--- a/src/app/3d/qgs3dmodelsourcelineedit.cpp
+++ b/src/app/3d/qgs3dmodelsourcelineedit.cpp
@@ -27,7 +27,7 @@ using namespace Qt::StringLiterals;
 
 ///@cond PRIVATE
 
-QString Qgs3DModelSourceLineEdit::fileFilter() const
+QString Qgs3DModelSourceLineEdit::fileFilter( bool ) const
 {
   return tr( "All files" ) + " (*.*)";
 }

--- a/src/app/3d/qgs3dmodelsourcelineedit.h
+++ b/src/app/3d/qgs3dmodelsourcelineedit.h
@@ -42,7 +42,7 @@ class Qgs3DModelSourceLineEdit : public QgsAbstractFileContentSourceLineEdit
   private:
 #ifndef SIP_RUN
     ///@cond PRIVATE
-    QString fileFilter() const override;
+    QString fileFilter( bool includeAllFiles ) const override;
     QString selectFileTitle() const override;
     QString fileFromUrlTitle() const override;
     QString fileFromUrlText() const override;

--- a/src/gui/qgsfilecontentsourcelineedit.cpp
+++ b/src/gui/qgsfilecontentsourcelineedit.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsfilecontentsourcelineedit.h"
 
+#include "qgsfilewidget.h"
 #include "qgsfilterlineedit.h"
 #include "qgsmessagebar.h"
 #include "qgspropertyoverridebutton.h"
@@ -44,8 +45,9 @@ QgsAbstractFileContentSourceLineEdit::QgsAbstractFileContentSourceLineEdit( QWid
 {
   QHBoxLayout *layout = new QHBoxLayout( this );
   layout->setContentsMargins( 0, 0, 0, 0 );
-  mFileLineEdit = new QgsFilterLineEdit( this );
+  mFileLineEdit = new QgsFileDropEdit( this );
   mFileLineEdit->setShowClearButton( true );
+  mFileLineEdit->setStorageMode( QgsFileWidget::StorageMode::GetFile );
   mFileToolButton = new QToolButton( this );
   mFileToolButton->setText( QString( QChar( 0x2026 ) ) );
   mPropertyOverrideButton = new QgsPropertyOverrideButton( this );
@@ -84,6 +86,16 @@ QgsAbstractFileContentSourceLineEdit::QgsAbstractFileContentSourceLineEdit( QWid
     mFileLineEdit->setPlaceholderText( QString() );
     mBase64.clear();
     emit sourceChanged( QString() );
+  } );
+
+  connect( mFileLineEdit, &QgsFileDropEdit::fileDropped, this, [this]( const QString &file ) {
+    mMode = ModeFile;
+    mBase64.clear();
+    mFileLineEdit->setText( file );
+    mFileLineEdit->setPlaceholderText( QString() );
+    const QFileInfo fi( file );
+    QgsSettings().setValue( settingsKey(), fi.absolutePath() );
+    emit sourceChanged( mFileLineEdit->text() );
   } );
 
   mPropertyOverrideButton->setVisible( mPropertyOverrideButtonVisible );
@@ -142,7 +154,7 @@ void QgsAbstractFileContentSourceLineEdit::setSource( const QString &source )
 void QgsAbstractFileContentSourceLineEdit::selectFile()
 {
   QgsSettings s;
-  const QString file = QFileDialog::getOpenFileName( nullptr, selectFileTitle(), defaultPath(), fileFilter() );
+  const QString file = QFileDialog::getOpenFileName( nullptr, selectFileTitle(), defaultPath(), fileFilter( true ) );
   const QFileInfo fi( file );
   if ( file.isEmpty() || !fi.exists() || file == source() )
   {
@@ -173,7 +185,7 @@ void QgsAbstractFileContentSourceLineEdit::selectUrl()
 void QgsAbstractFileContentSourceLineEdit::embedFile()
 {
   QgsSettings s;
-  const QString file = QFileDialog::getOpenFileName( nullptr, embedFileTitle(), defaultPath(), fileFilter() );
+  const QString file = QFileDialog::getOpenFileName( nullptr, embedFileTitle(), defaultPath(), fileFilter( true ) );
   const QFileInfo fi( file );
   if ( file.isEmpty() || !fi.exists() )
   {
@@ -209,7 +221,7 @@ void QgsAbstractFileContentSourceLineEdit::embedFile()
 void QgsAbstractFileContentSourceLineEdit::extractFile()
 {
   QgsSettings s;
-  const QString file = QFileDialog::getSaveFileName( nullptr, extractFileTitle(), defaultPath(), fileFilter() );
+  const QString file = QFileDialog::getSaveFileName( nullptr, extractFileTitle(), defaultPath(), fileFilter( true ) );
   // return dialog focus on Mac
   activateWindow();
   raise();
@@ -290,7 +302,14 @@ QgsMessageBar *QgsAbstractFileContentSourceLineEdit::messageBar() const
 ///@cond PRIVATE
 
 
-QString QgsPictureSourceLineEditBase::fileFilter() const
+QgsPictureSourceLineEditBase::QgsPictureSourceLineEditBase( Format format, QWidget *parent )
+  : QgsAbstractFileContentSourceLineEdit( parent )
+  , mFormat( format )
+{
+  mFileLineEdit->setFilters( fileFilter( false ) );
+}
+
+QString QgsPictureSourceLineEditBase::fileFilter( bool includeAllFiles ) const
 {
   switch ( mFormat )
   {
@@ -304,7 +323,7 @@ QString QgsPictureSourceLineEditBase::fileFilter() const
       {
         formatsFilter.append( QString( u"*.%1"_s ).arg( QString( format ) ) );
       }
-      return QString( "%1 (%2);;%3 (*.*)" ).arg( tr( "Images" ), formatsFilter.join( ' '_L1 ), tr( "All files" ) );
+      return QString( "%1 (%2) " ).arg( tr( "Images" ), formatsFilter.join( ' '_L1 ) ) + ( includeAllFiles ? QString( ";;%1 (*.*)" ).arg( tr( "All files" ) ) : QString() );
     }
 
     case AnimatedImage:
@@ -315,7 +334,8 @@ QString QgsPictureSourceLineEditBase::fileFilter() const
       {
         formatsFilter.append( QString( u"*.%1"_s ).arg( QString( format ) ) );
       }
-      return QString( "%1 (%2);;%3 (*.*)" ).arg( tr( "Animated Images" ), formatsFilter.join( ' '_L1 ), tr( "All files" ) );
+      return QString( "%1 (%2)" ).arg( tr( "Animated Images" ), formatsFilter.join( ' '_L1 ) ) + ( includeAllFiles ? QString( ";;%1 (*.*)" ).arg( tr( "All files" ) ) : QString() );
+      ;
     }
   }
   BUILTIN_UNREACHABLE

--- a/src/gui/qgsfilecontentsourcelineedit.h
+++ b/src/gui/qgsfilecontentsourcelineedit.h
@@ -22,7 +22,7 @@
 #include <QString>
 #include <QWidget>
 
-class QgsFilterLineEdit;
+class QgsFileDropEdit;
 class QToolButton;
 class QgsMessageBar;
 class QgsPropertyOverrideButton;
@@ -110,7 +110,7 @@ class GUI_EXPORT QgsAbstractFileContentSourceLineEdit : public QWidget SIP_ABSTR
     /**
      * Returns the widget's file filter string.
      */
-    virtual QString fileFilter() const = 0; // cppcheck-suppress pureVirtualCall
+    virtual QString fileFilter( bool includeAllFiles ) const = 0; // cppcheck-suppress pureVirtualCall
 
     /**
      * Returns the translated title to use for the select file dialog.
@@ -145,6 +145,9 @@ class GUI_EXPORT QgsAbstractFileContentSourceLineEdit : public QWidget SIP_ABSTR
 ///@endcond
 #endif
 
+  protected:
+    SIP_SKIP QgsFileDropEdit *mFileLineEdit = nullptr;
+
   private slots:
     void selectFile();
     void selectUrl();
@@ -162,7 +165,6 @@ class GUI_EXPORT QgsAbstractFileContentSourceLineEdit : public QWidget SIP_ABSTR
     Mode mMode = ModeFile;
     bool mPropertyOverrideButtonVisible = false;
 
-    QgsFilterLineEdit *mFileLineEdit = nullptr;
     QToolButton *mFileToolButton = nullptr;
     QgsPropertyOverrideButton *mPropertyOverrideButton = nullptr;
     QString mLastPathKey;
@@ -212,23 +214,20 @@ class GUI_EXPORT QgsPictureSourceLineEditBase : public QgsAbstractFileContentSou
     /**
      * Constructor for QgsImageSourceLineEdit, with the specified \a parent widget.
      */
-    QgsPictureSourceLineEditBase( Format format, QWidget *parent SIP_TRANSFERTHIS = nullptr )
-      : QgsAbstractFileContentSourceLineEdit( parent )
-      , mFormat( format )
-    {}
+    QgsPictureSourceLineEditBase( Format format, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
   private:
     Format mFormat = Svg;
 
 #ifndef SIP_RUN
     ///@cond PRIVATE
-    QString fileFilter() const override;
-    QString selectFileTitle() const override;
-    QString fileFromUrlTitle() const override;
-    QString fileFromUrlText() const override;
-    QString embedFileTitle() const override;
-    QString extractFileTitle() const override;
-    QString defaultSettingsKey() const override;
+    QString fileFilter( bool includeAllFiles ) const final;
+    QString selectFileTitle() const final;
+    QString fileFromUrlTitle() const final;
+    QString fileFromUrlText() const final;
+    QString embedFileTitle() const final;
+    QString extractFileTitle() const final;
+    QString defaultSettingsKey() const final;
     ///@endcond
 #endif
 };


### PR DESCRIPTION
Allows dragging and dropping image files onto the widget from file explorers, replacing the full contents of the widget with the dropped file path (before this would annoyingly INSERT the dropped file path into the middle of the existing text)

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
