### PR TITLE
Revert "Disable unity build for Windows CI build"

### DIFF
--- a/.github/workflows/windows-qt6.yml
+++ b/.github/workflows/windows-qt6.yml
@@ -88,7 +88,7 @@ jobs:
                 -D WITH_SFCGAL=ON \
                 -D ENABLE_TESTS=OFF \
                 -D USE_CCACHE=ON \
-                -D ENABLE_UNITY_BUILDS=OFF \
+                -D ENABLE_UNITY_BUILDS=ON \
                 -D FLEX_EXECUTABLE="${SOURCE_DIR}/win_flex.exe" \
                 -D BISON_EXECUTABLE="${SOURCE_DIR}/win_bison.exe" \
                 -D USE_CCACHE=ON \


### PR DESCRIPTION
This reverts commit d9419718e75795a8a62eb1bdd5040ca8831cb583.

## Description

Let's see if thing work again. Motivation: the Win build in https://github.com/qgis/QGIS/pull/65864 has been running for 4 hours nw...