### PR TITLE
Fix permissions for wasm workflow

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build:


### PR DESCRIPTION
## Description

Should fix the failing package cache
