### PR TITLE
fix: accept strings as overlap feature unique identifer

### DIFF
--- a/src/analysis/processing/qgsalgorithmfixgeometryoverlap.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometryoverlap.cpp
@@ -77,9 +77,7 @@ void QgsFixGeometryOverlapAlgorithm::initAlgorithm( const QVariantMap &configura
   addParameter( new QgsProcessingParameterFeatureSource( u"INPUT"_s, QObject::tr( "Input layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPolygon ) ) );
   addParameter( new QgsProcessingParameterFeatureSource( u"ERRORS"_s, QObject::tr( "Error layer" ), QList<int>() << static_cast<int>( Qgis::ProcessingSourceType::VectorPoint ) ) );
   addParameter( new QgsProcessingParameterField( u"UNIQUE_ID"_s, QObject::tr( "Field of original feature unique identifier" ), QString(), u"ERRORS"_s ) );
-  addParameter(
-    new QgsProcessingParameterField( u"OVERLAP_FEATURE_UNIQUE_IDX"_s, QObject::tr( "Field of overlap feature unique identifier" ), QString(), u"ERRORS"_s, Qgis::ProcessingFieldParameterDataType::Numeric )
-  );
+  addParameter( new QgsProcessingParameterField( u"OVERLAP_FEATURE_UNIQUE_IDX"_s, QObject::tr( "Field of overlap feature unique identifier" ), QString(), u"ERRORS"_s ) );
   addParameter( new QgsProcessingParameterField( u"ERROR_VALUE_ID"_s, QObject::tr( "Field of error value" ), u"gc_error"_s, u"ERRORS"_s, Qgis::ProcessingFieldParameterDataType::Numeric ) );
 
   addParameter( new QgsProcessingParameterFeatureSink( u"OUTPUT"_s, QObject::tr( "No-overlap layer" ), Qgis::ProcessingSourceType::VectorPolygon ) );


### PR DESCRIPTION
Fixes: #65883

## Description

The form for the "Delete overlaps" algorithm  refuses to accept string features as the OVERLAP_FEATURE_UNIQUE_IDX parameter in the UI, even though the underlying algorithm supports them.

This removes the incorrect constraint in the UI.


## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
