### PR TITLE
[app] Fix news sorting order on QGIS' welcome page

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsnewsfeedmodel.py
+++ b/python/PyQt6/core/auto_additions/qgsnewsfeedmodel.py
@@ -22,6 +22,9 @@ QgsNewsFeedModel.Link.__doc__ = "Optional entry URL link"
 QgsNewsFeedModel.Sticky = QgsNewsFeedModel.CustomRole.Sticky
 QgsNewsFeedModel.Sticky.is_monkey_patched = True
 QgsNewsFeedModel.Sticky.__doc__ = "Whether entry is sticky"
+QgsNewsFeedModel.Published = QgsNewsFeedModel.CustomRole.Published
+QgsNewsFeedModel.Published.is_monkey_patched = True
+QgsNewsFeedModel.Published.__doc__ = "Entry publication date"
 QgsNewsFeedModel.CustomRole.__doc__ = """Custom model roles.
 
 .. note::
@@ -37,6 +40,7 @@ QgsNewsFeedModel.CustomRole.__doc__ = """Custom model roles.
 * ``Image``: Optional entry image
 * ``Link``: Optional entry URL link
 * ``Sticky``: Whether entry is sticky
+* ``Published``: Entry publication date
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgsnewsfeedparser.py
+++ b/python/PyQt6/core/auto_additions/qgsnewsfeedparser.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/network/qgsnewsfeedparser.h
 try:
-    QgsNewsFeedParser.Entry.__attribute_docs__ = {'key': 'Unique entry identifier', 'title': 'Entry title', 'imageUrl': 'Optional URL for image associated with entry', 'image': 'Optional image data', 'content': 'HTML content of news entry', 'link': 'Optional URL link for entry', 'sticky': '``True`` if entry is "sticky" and should always be shown at the top', 'expiry': 'Optional auto-expiry time for entry'}
-    QgsNewsFeedParser.Entry.__annotations__ = {'key': int, 'title': str, 'imageUrl': str, 'image': 'QPixmap', 'content': str, 'link': 'QUrl', 'sticky': bool, 'expiry': 'QDateTime'}
+    QgsNewsFeedParser.Entry.__attribute_docs__ = {'key': 'Unique entry identifier', 'title': 'Entry title', 'imageUrl': 'Optional URL for image associated with entry', 'image': 'Optional image data', 'content': 'HTML content of news entry', 'link': 'Optional URL link for entry', 'sticky': '``True`` if entry is "sticky" and should always be shown at the top', 'published': 'Entry publication date', 'expiry': 'Optional auto-expiry time for entry'}
+    QgsNewsFeedParser.Entry.__annotations__ = {'key': int, 'title': str, 'imageUrl': str, 'image': 'QPixmap', 'content': str, 'link': 'QUrl', 'sticky': bool, 'published': 'QDateTime', 'expiry': 'QDateTime'}
     QgsNewsFeedParser.Entry.__group__ = ['network']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/network/qgsnewsfeedmodel.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnewsfeedmodel.sip.in
@@ -34,6 +34,7 @@ instance.
       Image,
       Link,
       Sticky,
+      Published,
     };
 
     QgsNewsFeedModel( QgsNewsFeedParser *parser, QObject *parent /TransferThis/ = 0 );

--- a/python/PyQt6/core/auto_generated/network/qgsnewsfeedparser.sip.in
+++ b/python/PyQt6/core/auto_generated/network/qgsnewsfeedparser.sip.in
@@ -49,6 +49,8 @@ Represents a single entry from a news feed.
 
         bool sticky;
 
+        QDateTime published;
+
         QDateTime expiry;
     };
 

--- a/src/core/network/qgsnewsfeedmodel.cpp
+++ b/src/core/network/qgsnewsfeedmodel.cpp
@@ -71,6 +71,9 @@ QVariant QgsNewsFeedModel::data( const QModelIndex &index, int role ) const
     case static_cast< int >( CustomRole::Sticky ):
       return entry.sticky;
 
+    case static_cast< int >( CustomRole::Published ):
+      return entry.published;
+
     case Qt::DecorationRole:
       if ( entry.image.isNull() )
         return QVariant();
@@ -88,6 +91,7 @@ QHash<int, QByteArray> QgsNewsFeedModel::roleNames() const
   roles[static_cast< int >( CustomRole::ImageUrl )] = "ImageUrl";
   roles[static_cast< int >( CustomRole::Link )] = "Link";
   roles[static_cast< int >( CustomRole::Sticky )] = "Sticky";
+  roles[static_cast< int >( CustomRole::Published )] = "Published";
   return roles;
 }
 
@@ -201,8 +205,8 @@ bool QgsNewsFeedProxyModel::lessThan( const QModelIndex &left, const QModelIndex
   if ( rightSticky && !leftSticky )
     return false;
 
-  // else sort by descending key
-  const int leftKey = sourceModel()->data( left, static_cast< int >( QgsNewsFeedModel::CustomRole::Key ) ).toInt();
-  const int rightKey = sourceModel()->data( right, static_cast< int >( QgsNewsFeedModel::CustomRole::Key ) ).toInt();
-  return rightKey < leftKey;
+  // else sort by descending publication date
+  const QDateTime leftPublished = sourceModel()->data( left, static_cast< int >( QgsNewsFeedModel::CustomRole::Published ) ).toDateTime();
+  const QDateTime rightPublished = sourceModel()->data( right, static_cast< int >( QgsNewsFeedModel::CustomRole::Published ) ).toDateTime();
+  return rightPublished < leftPublished;
 }

--- a/src/core/network/qgsnewsfeedmodel.h
+++ b/src/core/network/qgsnewsfeedmodel.h
@@ -52,6 +52,7 @@ class CORE_EXPORT QgsNewsFeedModel : public QAbstractItemModel
       Image,                  //!< Optional entry image
       Link,                   //!< Optional entry URL link
       Sticky,                 //!< Whether entry is sticky
+      Published,              //!< Entry publication date
     };
     Q_ENUM( CustomRole )
     // *INDENT-ON*

--- a/src/core/network/qgsnewsfeedparser.cpp
+++ b/src/core/network/qgsnewsfeedparser.cpp
@@ -48,6 +48,7 @@ const QgsSettingsEntryString *QgsNewsFeedParser::settingsFeedEntryImageUrl = new
 const QgsSettingsEntryString *QgsNewsFeedParser::settingsFeedEntryContent = new QgsSettingsEntryString( u"content"_s, sTreeNewsFeedEntries, QString(), u"Entry content"_s );
 const QgsSettingsEntryString *QgsNewsFeedParser::settingsFeedEntryLink = new QgsSettingsEntryString( u"link"_s, sTreeNewsFeedEntries, QString(), u"Entry link"_s );
 const QgsSettingsEntryBool *QgsNewsFeedParser::settingsFeedEntrySticky = new QgsSettingsEntryBool( u"sticky"_s, sTreeNewsFeedEntries, false );
+const QgsSettingsEntryVariant *QgsNewsFeedParser::settingsFeedEntryPublished = new QgsSettingsEntryVariant( u"published"_s, sTreeNewsFeedEntries, QVariant(), u"Publication date"_s );
 const QgsSettingsEntryVariant *QgsNewsFeedParser::settingsFeedEntryExpiry = new QgsSettingsEntryVariant( u"expiry"_s, sTreeNewsFeedEntries, QVariant(), u"Expiry date"_s );
 
 
@@ -247,6 +248,7 @@ void QgsNewsFeedParser::onFetch( const QString &content )
     incomingEntry.content = entryMap.value( u"content"_s ).toString();
     incomingEntry.link = entryMap.value( u"url"_s ).toString();
     incomingEntry.sticky = entryMap.value( u"sticky"_s ).toBool();
+    incomingEntry.published.setSecsSinceEpoch( entryMap.value( u"publish_from"_s ).toLongLong() );
     bool hasExpiry = false;
     const qlonglong expiry = entryMap.value( u"publish_to"_s ).toLongLong( &hasExpiry );
     if ( hasExpiry )
@@ -338,6 +340,7 @@ QgsNewsFeedParser::Entry QgsNewsFeedParser::readEntryFromSettings( const int key
   entry.content = settingsFeedEntryContent->value( { mFeedKey, QString::number( key ) } );
   entry.link = settingsFeedEntryLink->value( { mFeedKey, QString::number( key ) } );
   entry.sticky = settingsFeedEntrySticky->value( { mFeedKey, QString::number( key ) } );
+  entry.published = settingsFeedEntryPublished->value( { mFeedKey, QString::number( key ) } ).toDateTime();
   entry.expiry = settingsFeedEntryExpiry->value( { mFeedKey, QString::number( key ) } ).toDateTime();
   if ( !entry.imageUrl.isEmpty() )
   {
@@ -363,6 +366,7 @@ void QgsNewsFeedParser::storeEntryInSettings( const QgsNewsFeedParser::Entry &en
   settingsFeedEntryContent->setValue( entry.content, { mFeedKey, QString::number( entry.key ) } );
   settingsFeedEntryLink->setValue( entry.link.toString(), { mFeedKey, QString::number( entry.key ) } );
   settingsFeedEntrySticky->setValue( entry.sticky, { mFeedKey, QString::number( entry.key ) } );
+  settingsFeedEntryPublished->setValue( entry.published, { mFeedKey, QString::number( entry.key ) } );
   if ( entry.expiry.isValid() )
     settingsFeedEntryExpiry->setValue( entry.expiry, { mFeedKey, QString::number( entry.key ) } );
 }

--- a/src/core/network/qgsnewsfeedparser.h
+++ b/src/core/network/qgsnewsfeedparser.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsNewsFeedParser : public QObject
     static const QgsSettingsEntryString *settingsFeedEntryContent;
     static const QgsSettingsEntryString *settingsFeedEntryLink;
     static const QgsSettingsEntryBool *settingsFeedEntrySticky;
+    static const QgsSettingsEntryVariant *settingsFeedEntryPublished;
     static const QgsSettingsEntryVariant *settingsFeedEntryExpiry;
 #endif
 
@@ -95,6 +96,9 @@ class CORE_EXPORT QgsNewsFeedParser : public QObject
 
         //! TRUE if entry is "sticky" and should always be shown at the top
         bool sticky = false;
+
+        //! Entry publication date
+        QDateTime published;
 
         //! Optional auto-expiry time for entry
         QDateTime expiry;

--- a/tests/src/core/testqgsnewsfeedparser.cpp
+++ b/tests/src/core/testqgsnewsfeedparser.cpp
@@ -371,33 +371,33 @@ void TestQgsNewsFeedParser::testProxyModel()
   QCOMPARE( model.data( model.index( 2, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Sticky ) ).toBool(), false );
   QCOMPARE( model.data( model.index( 3, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Sticky ) ).toBool(), false );
   QCOMPARE( model.data( model.index( 4, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Sticky ) ).toBool(), false );
-  QCOMPARE( model.data( model.index( 0, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Key ) ).toInt(), 6 );
-  QCOMPARE( model.data( model.index( 1, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Key ) ).toInt(), 4 );
+  QCOMPARE( model.data( model.index( 0, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Key ) ).toInt(), 4 );
+  QCOMPARE( model.data( model.index( 1, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Key ) ).toInt(), 6 );
   QCOMPARE( model.data( model.index( 2, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Key ) ).toInt(), 11 );
-  QCOMPARE( model.data( model.index( 3, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Key ) ).toInt(), 5 );
-  QCOMPARE( model.data( model.index( 4, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Key ) ).toInt(), 3 );
-  QCOMPARE( model.data( model.index( 0, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS core will be rewritten in Rust"_s );
-  QCOMPARE( model.data( model.index( 1, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Next Microsoft Windows code name revealed"_s );
+  QCOMPARE( model.data( model.index( 3, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Key ) ).toInt(), 3 );
+  QCOMPARE( model.data( model.index( 4, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Key ) ).toInt(), 5 );
+  QCOMPARE( model.data( model.index( 0, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Next Microsoft Windows code name revealed"_s );
+  QCOMPARE( model.data( model.index( 1, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS core will be rewritten in Rust"_s );
   QCOMPARE( model.data( model.index( 2, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS Italian Meeting"_s );
-  QCOMPARE( model.data( model.index( 3, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Null Island QGIS Meeting"_s );
-  QCOMPARE( model.data( model.index( 4, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS acquired by ESRI"_s );
+  QCOMPARE( model.data( model.index( 3, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS acquired by ESRI"_s );
+  QCOMPARE( model.data( model.index( 4, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Null Island QGIS Meeting"_s );
 
   // remove an entry
   parser.dismissEntry( 11 );
   QCOMPARE( model.rowCount(), 4 );
-  QCOMPARE( model.data( model.index( 0, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS core will be rewritten in Rust"_s );
-  QCOMPARE( model.data( model.index( 1, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Next Microsoft Windows code name revealed"_s );
-  QCOMPARE( model.data( model.index( 2, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Null Island QGIS Meeting"_s );
-  QCOMPARE( model.data( model.index( 3, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS acquired by ESRI"_s );
+  QCOMPARE( model.data( model.index( 0, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Next Microsoft Windows code name revealed"_s );
+  QCOMPARE( model.data( model.index( 1, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS core will be rewritten in Rust"_s );
+  QCOMPARE( model.data( model.index( 2, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS acquired by ESRI"_s );
+  QCOMPARE( model.data( model.index( 3, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Null Island QGIS Meeting"_s );
 
   // construct a new model/parser -- should initially have stored entries
   QgsNewsFeedParser parser2( url );
   const QgsNewsFeedProxyModel model2( &parser2 );
   QCOMPARE( model2.rowCount(), 4 );
-  QCOMPARE( model2.data( model2.index( 0, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS core will be rewritten in Rust"_s );
-  QCOMPARE( model2.data( model2.index( 1, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Next Microsoft Windows code name revealed"_s );
-  QCOMPARE( model2.data( model2.index( 2, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Null Island QGIS Meeting"_s );
-  QCOMPARE( model2.data( model2.index( 3, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS acquired by ESRI"_s );
+  QCOMPARE( model2.data( model2.index( 0, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Next Microsoft Windows code name revealed"_s );
+  QCOMPARE( model2.data( model2.index( 1, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS core will be rewritten in Rust"_s );
+  QCOMPARE( model2.data( model2.index( 2, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"QGIS acquired by ESRI"_s );
+  QCOMPARE( model2.data( model2.index( 3, 0, QModelIndex() ), static_cast<int>( QgsNewsFeedModel::CustomRole::Title ) ).toString(), u"Null Island QGIS Meeting"_s );
 }
 
 void TestQgsNewsFeedParser::testUpdatedEntries()


### PR DESCRIPTION
## Description

Until now, QGIS news model assumed that a bigger PK meant a newer article. This is not always true. We are fortunate enough to get a publication date though, let's use that :)