### PR TITLE
Expose imageserver connections in browser, many cleanups

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -38,6 +38,109 @@
 
 using namespace Qt::StringLiterals;
 
+Qgis::ArcGisRestServiceType QgsArcGisRestQueryUtils::sniffServiceTypeFromUrl( const QUrl &url )
+{
+  if ( url.isEmpty() || !url.isValid() )
+  {
+    return Qgis::ArcGisRestServiceType::Unknown;
+  }
+
+  const QString path = url.path();
+  if ( path.isEmpty() )
+  {
+    return Qgis::ArcGisRestServiceType::Unknown;
+  }
+  const QStringList pathSegments = path.split( '/', Qt::SkipEmptyParts );
+
+  // iterate backwards through the URL segments.
+  // we want to catch both root services (.../FeatureServer)
+  // and layer-specific URLs (.../FeatureServer/0 or .../FeatureServer/query)
+  for ( const QString &segment : pathSegments | std::views::reverse )
+  {
+    if ( segment.compare( "FeatureServer"_L1, Qt::CaseInsensitive ) == 0 )
+    {
+      return Qgis::ArcGisRestServiceType::FeatureServer;
+    }
+    if ( segment.compare( "MapServer"_L1, Qt::CaseInsensitive ) == 0 )
+    {
+      return Qgis::ArcGisRestServiceType::MapServer;
+    }
+    if ( segment.compare( "ImageServer"_L1, Qt::CaseInsensitive ) == 0 )
+    {
+      return Qgis::ArcGisRestServiceType::ImageServer;
+    }
+    if ( segment.compare( "SceneServer"_L1, Qt::CaseInsensitive ) == 0 )
+    {
+      return Qgis::ArcGisRestServiceType::SceneServer;
+    }
+  }
+
+  return Qgis::ArcGisRestServiceType::Unknown;
+}
+
+Qgis::ArcGisRestServiceType QgsArcGisRestQueryUtils::sniffServiceTypeFromJson( const QVariantMap &json )
+{
+  if ( json.empty() )
+  {
+    return Qgis::ArcGisRestServiceType::Unknown;
+  }
+
+  // try to sniff an imageserver
+  if ( json.contains( u"pixelSizeX"_s )
+       || json.contains( u"bandCount"_s )
+       || json.contains( u"mensurationCapabilities"_s )
+       || json.value( u"serviceDataType"_s ).toString().startsWith( "esriImageService"_L1, Qt::CaseInsensitive ) )
+  {
+    return Qgis::ArcGisRestServiceType::ImageServer;
+  }
+
+  // try to sniff a mapserver
+  if ( json.contains( u"mapName"_s ) || json.contains( u"singleFusedMapCache"_s ) ) // note that imageservers also have this tag, hence why we checked for those first
+  {
+    return Qgis::ArcGisRestServiceType::MapServer;
+  }
+
+  // try to sniff FeatureServer
+  if ( json.contains( u"hasVersionedData"_s ) || json.contains( u"syncEnabled"_s ) || json.contains( u"allowGeometryUpdates"_s ) || json.contains( u"supportsDisconnectedEditing"_s ) )
+  {
+    return Qgis::ArcGisRestServiceType::FeatureServer;
+  }
+
+  // try to sniff SceneServer -- this works for direct layer endpoints (e.g. SceneServer/0)
+  if ( json.contains( u"store"_s ) && json.contains( u"layerType"_s ) )
+  {
+    return Qgis::ArcGisRestServiceType::SceneServer;
+  }
+
+  if ( json.contains( u"layers"_s ) )
+  {
+    const QVariantList layersList = json.value( u"layers"_s ).toList();
+    if ( !layersList.empty() )
+    {
+      const QVariantMap firstLayer = layersList.first().toMap();
+      // "layerType" is distinct to SceneServer layers:
+      if ( firstLayer.contains( u"layerType"_s ) || firstLayer.contains( u"store"_s ) )
+      {
+        return Qgis::ArcGisRestServiceType::SceneServer;
+      }
+    }
+  }
+
+  // catch feature-server layer-level endpoints (e.g. MapServer/0)
+  // this can detect feature servers only -- eg for a mapserver layer it will be flagged
+  // as a feature server
+  if ( json.contains( u"type"_s ) )
+  {
+    const QString typeStr = json.value( u"type"_s ).toString();
+    if ( typeStr.compare( "Feature Layer"_L1, Qt::CaseInsensitive ) == 0 || typeStr.compare( "Table"_L1, Qt::CaseInsensitive ) == 0 )
+    {
+      return Qgis::ArcGisRestServiceType::FeatureServer;
+    }
+  }
+
+  return Qgis::ArcGisRestServiceType::Unknown;
+}
+
 QVariantMap QgsArcGisRestQueryUtils::getServiceInfo(
   const QString &baseurl, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsHttpHeaders &requestHeaders, const QString &urlPrefix, bool forceRefresh
 )

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -15,6 +15,8 @@
 
 #include "qgsarcgisrestquery.h"
 
+#include <ranges>
+
 #include "qgsapplication.h"
 #include "qgsarcgisrestutils.h"
 #include "qgsauthmanager.h"
@@ -55,7 +57,7 @@ Qgis::ArcGisRestServiceType QgsArcGisRestQueryUtils::sniffServiceTypeFromUrl( co
   // iterate backwards through the URL segments.
   // we want to catch both root services (.../FeatureServer)
   // and layer-specific URLs (.../FeatureServer/0 or .../FeatureServer/query)
-  for ( const QString &segment : pathSegments | std::views::reverse )
+  for ( const QString &segment : pathSegments | std::ranges::views::reverse )
   {
     if ( segment.compare( "FeatureServer"_L1, Qt::CaseInsensitive ) == 0 )
     {

--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -504,7 +504,7 @@ void QgsArcGisRestQueryUtils::visitServiceItems( const std::function<void( const
 }
 
 void QgsArcGisRestQueryUtils::addLayerItems(
-  const std::function< void( const LayerItemDetails &details )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const QString &parentSupportedFormats, const ServiceTypeFilter filter
+  const std::function< void( const LayerItemDetails &details )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const QString &parentSupportedFormats, Qgis::ArcGisRestServiceType serviceType
 )
 {
   const QgsCoordinateReferenceSystem crs = QgsArcGisRestUtils::convertSpatialReference( serviceData.value( u"spatialReference"_s ).toMap() );
@@ -529,16 +529,14 @@ void QgsArcGisRestQueryUtils::addLayerItems(
       break;
   }
   Qgis::ArcGisRestServiceCapabilities capabilities = QgsArcGisRestUtils::serviceCapabilitiesFromString( serviceData.value( u"capabilities"_s ).toString() );
-
-  // If the requested layer type is vector, do not show raster-only layers (i.e. non query-able layers)
-
-  if ( serviceData.value( u"serviceDataType"_s ).toString().startsWith( "esriImageService"_L1 ) )
+  if ( serviceType == Qgis::ArcGisRestServiceType::ImageServer )
   {
     // consider ImageServices as having both render and query capabilities, so we can load them
     // as either raster or vector
     capabilities.setFlag( Qgis::ArcGisRestServiceCapability::Map, true );
     capabilities.setFlag( Qgis::ArcGisRestServiceCapability::Query, true );
   }
+
   const QVariantList layerInfoList = serviceData.value( u"layers"_s ).toList();
   for ( const QVariant &layerInfo : layerInfoList )
   {
@@ -568,9 +566,10 @@ void QgsArcGisRestQueryUtils::addLayerItems(
       }
 #endif
 
-    if ( filter == ServiceTypeFilter::Scene )
+    // deal with the easy stuff first -- if we found a scene server layer, then it can ONLY be loaded as a scene
+    if ( serviceType == Qgis::ArcGisRestServiceType::SceneServer )
     {
-      details.serviceType = ServiceTypeFilter::Scene;
+      details.serviceType = Qgis::ArcGisRestServiceType::SceneServer;
       details.geometryType = Qgis::GeometryType::Unknown;
       details.url = parentUrl;
       details.isParentLayer = false;
@@ -583,11 +582,11 @@ void QgsArcGisRestQueryUtils::addLayerItems(
 
     // Yes, potentially we may visit twice, once as as a raster (if applicable), and once as a vector (if applicable)!
     bool exposedAsVector = false;
-    if ( capabilities.testFlag( Qgis::ArcGisRestServiceCapability::Query ) && ( filter == ServiceTypeFilter::Vector || filter == ServiceTypeFilter::AllTypes ) )
+    if ( capabilities.testFlag( Qgis::ArcGisRestServiceCapability::Query ) && ( serviceType == Qgis::ArcGisRestServiceType::FeatureServer || serviceType == Qgis::ArcGisRestServiceType::MapServer ) )
     {
       exposedAsVector = true;
       const Qgis::WkbType wkbType = QgsArcGisRestUtils::convertGeometryType( geometryType );
-      details.serviceType = ServiceTypeFilter::Vector;
+      details.serviceType = Qgis::ArcGisRestServiceType::FeatureServer;
       details.geometryType = QgsWkbTypes::geometryType( wkbType );
       details.url = parentUrl + '/' + details.layerId;
       details.format = format;
@@ -606,13 +605,13 @@ void QgsArcGisRestQueryUtils::addLayerItems(
       }
     }
 
-    if ( capabilities.testFlag( Qgis::ArcGisRestServiceCapability::Map ) && ( filter == ServiceTypeFilter::Raster || filter == ServiceTypeFilter::AllTypes ) )
+    if ( capabilities.testFlag( Qgis::ArcGisRestServiceCapability::Map ) && ( serviceType == Qgis::ArcGisRestServiceType::FeatureServer || serviceType == Qgis::ArcGisRestServiceType::MapServer ) )
     {
       Qgis::WkbType wkbType = Qgis::WkbType::Unknown;
       if ( capabilities.testFlag( Qgis::ArcGisRestServiceCapability::Query ) )
         wkbType = QgsArcGisRestUtils::convertGeometryType( geometryType );
 
-      details.serviceType = ServiceTypeFilter::Raster;
+      details.serviceType = serviceType == Qgis::ArcGisRestServiceType::Unknown ? Qgis::ArcGisRestServiceType::MapServer : serviceType;
       details.geometryType = QgsWkbTypes::geometryType( wkbType );
       details.url = parentUrl + '/' + details.layerId;
       details.format = format;
@@ -636,19 +635,19 @@ void QgsArcGisRestQueryUtils::addLayerItems(
   }
 
   const QVariantList tableInfoList = serviceData.value( u"tables"_s ).toList();
-  for ( const QVariant &tableInfo : tableInfoList )
+  if ( capabilities.testFlag( Qgis::ArcGisRestServiceCapability::Query ) && serviceType == Qgis::ArcGisRestServiceType::FeatureServer )
   {
-    const QVariantMap tableInfoMap = tableInfo.toMap();
-
-    LayerItemDetails details;
-    details.layerId = tableInfoMap.value( u"id"_s ).toString();
-    details.parentLayerId = tableInfoMap.value( u"parentLayerId"_s ).toString();
-    details.name = tableInfoMap.value( u"name"_s ).toString();
-    details.description = tableInfoMap.value( u"description"_s ).toString();
-
-    if ( capabilities.testFlag( Qgis::ArcGisRestServiceCapability::Query ) && ( filter == ServiceTypeFilter::Vector || filter == ServiceTypeFilter::AllTypes ) )
+    for ( const QVariant &tableInfo : tableInfoList )
     {
-      details.serviceType = ServiceTypeFilter::Vector;
+      const QVariantMap tableInfoMap = tableInfo.toMap();
+
+      LayerItemDetails details;
+      details.layerId = tableInfoMap.value( u"id"_s ).toString();
+      details.parentLayerId = tableInfoMap.value( u"parentLayerId"_s ).toString();
+      details.name = tableInfoMap.value( u"name"_s ).toString();
+      details.description = tableInfoMap.value( u"description"_s ).toString();
+
+      details.serviceType = Qgis::ArcGisRestServiceType::FeatureServer;
       details.geometryType = Qgis::GeometryType::Null;
       details.url = parentUrl + '/' + details.layerId;
       details.format = format;
@@ -668,12 +667,92 @@ void QgsArcGisRestQueryUtils::addLayerItems(
     }
   }
 
+  if ( layerInfoList.isEmpty() && tableInfoList.isEmpty() && serviceType != Qgis::ArcGisRestServiceType::Unknown )
+  {
+    // haven't found any layers yet. But maybe the definition is for a layer itself.
+    switch ( serviceType )
+    {
+      case Qgis::ArcGisRestServiceType::FeatureServer:
+      {
+        LayerItemDetails details;
+        details.layerId = serviceData.value( u"id"_s ).toString();
+        details.name = serviceData.value( u"name"_s ).toString();
+        details.description = serviceData.value( u"description"_s ).toString();
+        const QString geometryType = serviceData.value( u"geometryType"_s ).toString();
+        const Qgis::WkbType wkbType = QgsArcGisRestUtils::convertGeometryType( geometryType );
+        details.serviceType = Qgis::ArcGisRestServiceType::FeatureServer;
+        details.geometryType = QgsWkbTypes::geometryType( wkbType );
+        details.url = parentUrl;
+        details.format = format;
+        details.isMapServerWithQueryCapability = capabilities.testFlag( Qgis::ArcGisRestServiceCapability::Map );
+        details.isParentLayer = false;
+        details.crs = crs;
+        visitor( details );
+        break;
+      }
+      case Qgis::ArcGisRestServiceType::MapServer:
+      {
+        LayerItemDetails details;
+        details.name = serviceData.value( u"serviceDescription"_s ).toString();
+        details.description = serviceData.value( u"description"_s ).toString();
+        details.serviceType = Qgis::ArcGisRestServiceType::MapServer;
+        details.geometryType = Qgis::GeometryType::Unknown;
+        details.url = parentUrl;
+        details.isParentLayer = false;
+        details.crs = crs;
+        details.format = format;
+        details.isMapServerWithQueryCapability = false;
+        details.isMapServerSpecialAllLayersOption = false;
+        visitor( details );
+        break;
+      }
+      case Qgis::ArcGisRestServiceType::ImageServer:
+      {
+        LayerItemDetails details;
+        details.layerId = QString();
+        details.parentLayerId = QString();
+        details.name = serviceData.value( u"name"_s ).toString();
+        details.description = serviceData.value( u"description"_s ).toString();
+        details.serviceType = Qgis::ArcGisRestServiceType::ImageServer;
+        details.geometryType = Qgis::GeometryType::Unknown;
+        details.url = parentUrl;
+        details.isParentLayer = false;
+        details.crs = crs;
+        details.format = format;
+        details.isMapServerWithQueryCapability = false;
+        visitor( details );
+        break;
+      }
+      case Qgis::ArcGisRestServiceType::SceneServer:
+      {
+        LayerItemDetails details;
+        details.layerId = serviceData.value( u"id"_s ).toString();
+        details.name = serviceData.value( u"name"_s ).toString();
+        details.description = serviceData.value( u"description"_s ).toString();
+        details.serviceType = Qgis::ArcGisRestServiceType::SceneServer;
+        details.geometryType = Qgis::GeometryType::Unknown;
+        details.url = parentUrl;
+        details.isParentLayer = false;
+        details.crs = crs;
+        details.format = format;
+        details.isMapServerWithQueryCapability = false;
+        visitor( details );
+        break;
+      }
+      case Qgis::ArcGisRestServiceType::GlobeServer:
+      case Qgis::ArcGisRestServiceType::GPServer:
+      case Qgis::ArcGisRestServiceType::GeocodeServer:
+      case Qgis::ArcGisRestServiceType::Unknown:
+        break;
+    }
+  }
+
   // Add root MapServer as raster layer when multiple layers are listed
-  if ( filter != ServiceTypeFilter::Vector && layerInfoList.count() > 1 && serviceData.contains( u"supportedImageFormatTypes"_s ) )
+  if ( serviceType != Qgis::ArcGisRestServiceType::FeatureServer && layerInfoList.count() > 1 && serviceData.contains( u"supportedImageFormatTypes"_s ) )
   {
     LayerItemDetails details;
     details.parentLayerId = QString();
-    details.serviceType = ServiceTypeFilter::Raster;
+    details.serviceType = serviceType == Qgis::ArcGisRestServiceType::Unknown ? Qgis::ArcGisRestServiceType::MapServer : serviceType;
     details.geometryType = Qgis::GeometryType::Unknown;
     details.url = parentUrl;
     details.isParentLayer = false;
@@ -681,24 +760,6 @@ void QgsArcGisRestQueryUtils::addLayerItems(
     details.format = format;
     details.isMapServerWithQueryCapability = false;
     details.isMapServerSpecialAllLayersOption = true;
-    visitor( details );
-  }
-
-  // Add root ImageServer as layer
-  if ( serviceData.value( u"serviceDataType"_s ).toString().startsWith( "esriImageService"_L1 ) )
-  {
-    LayerItemDetails details;
-    details.layerId = QString();
-    details.parentLayerId = QString();
-    details.name = serviceData.value( u"name"_s ).toString();
-    details.description = serviceData.value( u"description"_s ).toString();
-    details.serviceType = ServiceTypeFilter::Raster;
-    details.geometryType = Qgis::GeometryType::Unknown;
-    details.url = parentUrl;
-    details.isParentLayer = false;
-    details.crs = crs;
-    details.format = format;
-    details.isMapServerWithQueryCapability = false;
     visitor( details );
   }
 }

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -52,6 +52,18 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
     };
 
     /**
+     * Attempts to resolve the service type from a \a url.
+     *
+     * This may not be successful, e.g. when the service is sitting behind an internal proxy.
+     */
+    static Qgis::ArcGisRestServiceType sniffServiceTypeFromUrl( const QUrl &url );
+
+    /**
+     * Attempts to resolve the service type from a \a json definition.
+     */
+    static Qgis::ArcGisRestServiceType sniffServiceTypeFromJson( const QVariantMap &json );
+
+    /**
      * Retrieves JSON service info for the specified base URL.
      */
     static QVariantMap getServiceInfo(

--- a/src/core/providers/arcgis/qgsarcgisrestquery.h
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.h
@@ -45,11 +45,11 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
      */
     enum class ServiceTypeFilter
     {
-      AllTypes, //!< All types
-      Vector,   //!< Vector type
-      Raster,   //!< Raster type
-      Scene     //!< Scene
+      Vector = 1 << 0,
+      Raster = 1 << 1,
+      Scene = 1 << 2,
     };
+    Q_DECLARE_FLAGS( ServiceTypeFilters, ServiceTypeFilter );
 
     /**
      * Attempts to resolve the service type from a \a url.
@@ -209,7 +209,7 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
         //! Parent layer ID
         QString parentLayerId;
         //! Service type
-        ServiceTypeFilter serviceType = ServiceTypeFilter::AllTypes;
+        Qgis::ArcGisRestServiceType serviceType = Qgis::ArcGisRestServiceType::Unknown;
         //! Geometry type
         Qgis::GeometryType geometryType = Qgis::GeometryType::Unknown;
         //! Layer ID
@@ -236,11 +236,7 @@ class CORE_EXPORT QgsArcGisRestQueryUtils
      * Calls the specified \a visitor function on all layer items found within the given service data.
      */
     static void addLayerItems(
-      const std::function<void( const LayerItemDetails &details )> &visitor,
-      const QVariantMap &serviceData,
-      const QString &parentUrl,
-      const QString &parentSupportedFormats,
-      const ServiceTypeFilter filter = ServiceTypeFilter::AllTypes
+      const std::function<void( const LayerItemDetails &details )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const QString &parentSupportedFormats, Qgis::ArcGisRestServiceType serviceType
     );
 
     /**
@@ -293,6 +289,8 @@ class CORE_EXPORT QgsArcGisAsyncParallelQuery : public QObject
     QString mAuthCfg;
     QgsHttpHeaders mRequestHeaders;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsArcGisRestQueryUtils::ServiceTypeFilters )
 
 ///@endcond
 

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
@@ -236,7 +236,7 @@ void addLayerItems(
 
             case Qgis::ArcGisRestServiceType::ImageServer:
             {
-              layerItem = std::make_unique< QgsArcGisImageServiceLayerItem>( parent, details.url, details.layerId, details.name, details.crs, details.format, authcfg, headers, urlPrefix );
+              layerItem = std::make_unique< QgsArcGisImageServiceLayerItem>( parent, details.url, details.name, details.crs, authcfg, headers, urlPrefix );
               break;
             }
           }
@@ -989,20 +989,11 @@ Qgis::BrowserItemFilterFlags QgsArcGisMapServiceLayerItem::filterFlags() const
 //
 
 QgsArcGisImageServiceLayerItem::QgsArcGisImageServiceLayerItem(
-  QgsDataItem *parent,
-  const QString &url,
-  const QString &id,
-  const QString &title,
-  const QgsCoordinateReferenceSystem &crs,
-  const QString &format,
-  const QString &authcfg,
-  const QgsHttpHeaders &headers,
-  const QString &urlPrefix
+  QgsDataItem *parent, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix
 )
   : QgsArcGisRestLayerItem( parent, url, title, crs, Qgis::BrowserLayerType::Raster, u"arcgisimageserver"_s )
 {
-  const QString trimmedUrl = id.isEmpty() ? url : url.left( url.length() - 1 - id.length() ); // trim '/0' from end of url -- AMS provider requires this omitted
-  mUri = u"format='%1' layer='%2' url='%3'"_s.arg( format, id, trimmedUrl );
+  mUri = u"url='%1'"_s.arg( url );
   if ( !authcfg.isEmpty() )
     mUri += u" authcfg='%1'"_s.arg( authcfg );
 

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
@@ -785,10 +785,9 @@ QVector<QgsDataItem *> QgsArcGisImageServiceItem::createChildren()
     return items;
   }
 
-  const QString supportedFormats = u"JPGPNG,PNG,PNG8,PNG24,JPG,BMP,GIF,TIFF,PNG32,BIP,BSQ,LERC"_s;
-  addFolderItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, supportedFormats, mForceRefresh );
-  addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, supportedFormats, mForceRefresh );
-  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, Qgis::ArcGisRestServiceType::ImageServer, supportedFormats, mForceRefresh );
+  addFolderItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, {}, mForceRefresh );
+  addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, {}, mForceRefresh );
+  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, Qgis::ArcGisRestServiceType::ImageServer, {}, mForceRefresh );
   return items;
 }
 

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
@@ -120,9 +120,15 @@ void addServiceItems(
       switch ( serviceType )
       {
         case Qgis::ArcGisRestServiceType::MapServer:
+        {
+          auto serviceItem = std::make_unique<QgsArcGisMapServiceItem>( parent, name, url, url, authcfg, headers, urlPrefix, forceRefresh );
+          items.append( serviceItem.release() );
+          break;
+        }
+
         case Qgis::ArcGisRestServiceType::ImageServer:
         {
-          auto serviceItem = std::make_unique<QgsArcGisMapServiceItem>( parent, name, url, url, authcfg, headers, urlPrefix, serviceType, forceRefresh );
+          auto serviceItem = std::make_unique<QgsArcGisImageServiceItem>( parent, name, url, url, authcfg, headers, urlPrefix, forceRefresh );
           items.append( serviceItem.release() );
           break;
         }
@@ -162,7 +168,7 @@ void addLayerItems(
   const QgsHttpHeaders &headers,
   const QString urlPrefix,
   QgsDataItem *parent,
-  QgsArcGisRestQueryUtils::ServiceTypeFilter serviceTypeFilter,
+  Qgis::ArcGisRestServiceType serviceType,
   const QString &supportedFormats,
   bool forceRefresh
 )
@@ -172,9 +178,7 @@ void addLayerItems(
   QMap<QString, QgsMimeDataUtils::Uri> mapServerUrisForAllLayersRender;
 
   QgsArcGisRestQueryUtils::addLayerItems(
-    [parent, &layerItems, &parents, &mapServerUrisForAllLayersRender, authcfg, headers, urlPrefix, serviceTypeFilter, supportedFormats, forceRefresh](
-      const QgsArcGisRestQueryUtils::LayerItemDetails &details
-    ) {
+    [parent, &layerItems, &parents, &mapServerUrisForAllLayersRender, authcfg, headers, urlPrefix, serviceType, supportedFormats, forceRefresh]( const QgsArcGisRestQueryUtils::LayerItemDetails &details ) {
       Q_UNUSED( forceRefresh )
 
       if ( !details.parentLayerId.isEmpty() )
@@ -202,7 +206,7 @@ void addLayerItems(
                                                               : details.geometryType == Qgis::GeometryType::Null  ? Qgis::BrowserLayerType::TableLayer
                                                                                                                   : Qgis::BrowserLayerType::Vector;
 
-      if ( details.isParentLayer && details.serviceType != QgsArcGisRestQueryUtils::ServiceTypeFilter::Raster )
+      if ( details.isParentLayer && details.serviceType != Qgis::ArcGisRestServiceType::MapServer )
       {
         if ( !layerItems.value( details.layerId ) )
         {
@@ -213,25 +217,39 @@ void addLayerItems(
       else
       {
         std::unique_ptr<QgsDataItem> layerItem;
-        switch ( serviceTypeFilter == QgsArcGisRestQueryUtils::ServiceTypeFilter::AllTypes ? details.serviceType : serviceTypeFilter )
+        switch ( details.serviceType )
         {
-          case QgsArcGisRestQueryUtils::ServiceTypeFilter::Vector:
+          case Qgis::ArcGisRestServiceType::FeatureServer:
             layerItem = std::make_unique<QgsArcGisFeatureServiceLayerItem>(
               parent, details.url, details.name, details.crs, authcfg, headers, urlPrefix, browserLayerGeometryType, details.isMapServerWithQueryCapability, details.format, details.layerId
             );
             break;
 
-          case QgsArcGisRestQueryUtils::ServiceTypeFilter::Raster:
-            layerItem = std::make_unique<
-              QgsArcGisMapServiceLayerItem>( parent, details.url, details.layerId, details.name, details.crs, details.format, authcfg, headers, urlPrefix, details.isMapServerWithQueryCapability );
-            static_cast<QgsArcGisMapServiceLayerItem *>( layerItem.get() )->setSupportedFormats( supportedFormats );
-            break;
+          case Qgis::ArcGisRestServiceType::MapServer:
+          {
+            {
+              layerItem = std::make_unique<
+                QgsArcGisMapServiceLayerItem>( parent, details.url, details.layerId, details.name, details.crs, details.format, authcfg, headers, urlPrefix, details.isMapServerWithQueryCapability );
+              static_cast<QgsArcGisMapServiceLayerItem *>( layerItem.get() )->setSupportedFormats( supportedFormats );
+              break;
+            }
 
-          case QgsArcGisRestQueryUtils::ServiceTypeFilter::Scene:
+            case Qgis::ArcGisRestServiceType::ImageServer:
+            {
+              layerItem = std::make_unique< QgsArcGisImageServiceLayerItem>( parent, details.url, details.layerId, details.name, details.crs, details.format, authcfg, headers, urlPrefix );
+              break;
+            }
+          }
+
+          case Qgis::ArcGisRestServiceType::SceneServer:
             layerItem = std::make_unique<QgsArcGisSceneServiceLayerItem>( parent, details.url, details.name, details.crs, authcfg, headers, urlPrefix );
             break;
 
-          case QgsArcGisRestQueryUtils::ServiceTypeFilter::AllTypes:
+
+          case Qgis::ArcGisRestServiceType::GlobeServer:
+          case Qgis::ArcGisRestServiceType::GPServer:
+          case Qgis::ArcGisRestServiceType::GeocodeServer:
+          case Qgis::ArcGisRestServiceType::Unknown:
             break;
         }
         if ( layerItem )
@@ -241,7 +259,7 @@ void addLayerItems(
     serviceData,
     parentUrl,
     supportedFormats,
-    serviceTypeFilter
+    serviceType
   );
 
   // create groups
@@ -337,9 +355,15 @@ QVector<QgsDataItem *> QgsArcGisRestConnectionItem::createChildren()
       return items;
     }
 
+    Qgis::ArcGisRestServiceType serviceType = QgsArcGisRestQueryUtils::sniffServiceTypeFromUrl( url );
+    if ( serviceType == Qgis::ArcGisRestServiceType::Unknown )
+    {
+      serviceType = QgsArcGisRestQueryUtils::sniffServiceTypeFromJson( serviceData );
+    }
+
     addFolderItems( items, serviceData, url, authcfg, headers, urlPrefix, this, QString(), mForceRefresh );
     addServiceItems( items, serviceData, url, authcfg, headers, urlPrefix, this, QString(), mForceRefresh );
-    addLayerItems( items, serviceData, url, authcfg, headers, urlPrefix, this, QgsArcGisRestQueryUtils::ServiceTypeFilter::AllTypes, QString(), mForceRefresh );
+    addLayerItems( items, serviceData, url, authcfg, headers, urlPrefix, this, serviceType, QString(), mForceRefresh );
   }
 
   return items;
@@ -485,19 +509,13 @@ QVector<QgsDataItem *> QgsArcGisPortalGroupItem::createChildren()
     {
       items << new QgsArcGisSceneServiceItem( this, itemData.value( u"title"_s ).toString(), itemData.value( u"url"_s ).toString(), itemData.value( u"url"_s ).toString(), mAuthCfg, mHeaders, mUrlPrefix, mForceRefresh );
     }
+    else if ( itemData.value( u"type"_s ).toString().compare( u"Map Service"_s, Qt::CaseInsensitive ) == 0 )
+    {
+      items << new QgsArcGisMapServiceItem( this, itemData.value( u"title"_s ).toString(), itemData.value( u"url"_s ).toString(), itemData.value( u"url"_s ).toString(), mAuthCfg, mHeaders, mUrlPrefix, mForceRefresh );
+    }
     else
     {
-      items << new QgsArcGisMapServiceItem(
-        this,
-        itemData.value( u"title"_s ).toString(),
-        itemData.value( u"url"_s ).toString(),
-        itemData.value( u"url"_s ).toString(),
-        mAuthCfg,
-        mHeaders,
-        mUrlPrefix,
-        itemData.value( u"type"_s ).toString().compare( u"Map Service"_s, Qt::CaseInsensitive ) == 0 ? Qgis::ArcGisRestServiceType::MapServer : Qgis::ArcGisRestServiceType::ImageServer,
-        mForceRefresh
-      );
+      items << new QgsArcGisImageServiceItem( this, itemData.value( u"title"_s ).toString(), itemData.value( u"url"_s ).toString(), itemData.value( u"url"_s ).toString(), mAuthCfg, mHeaders, mUrlPrefix, mForceRefresh );
     }
   }
 
@@ -546,9 +564,15 @@ QVector<QgsDataItem *> QgsArcGisRestServicesItem::createChildren()
     return items;
   }
 
+  Qgis::ArcGisRestServiceType serviceType = QgsArcGisRestQueryUtils::sniffServiceTypeFromUrl( mUrl );
+  if ( serviceType == Qgis::ArcGisRestServiceType::Unknown )
+  {
+    serviceType = QgsArcGisRestQueryUtils::sniffServiceTypeFromJson( serviceData );
+  }
+
   addFolderItems( items, serviceData, mUrl, mAuthCfg, mHeaders, mUrlPrefix, this, QString(), mForceRefresh );
   addServiceItems( items, serviceData, mUrl, mAuthCfg, mHeaders, mUrlPrefix, this, QString(), mForceRefresh );
-  addLayerItems( items, serviceData, mUrl, mAuthCfg, mHeaders, mUrlPrefix, this, QgsArcGisRestQueryUtils::ServiceTypeFilter::AllTypes, QString(), mForceRefresh );
+  addLayerItems( items, serviceData, mUrl, mAuthCfg, mHeaders, mUrlPrefix, this, serviceType, QString(), mForceRefresh );
   return items;
 }
 
@@ -604,7 +628,8 @@ QVector<QgsDataItem *> QgsArcGisRestFolderItem::createChildren()
 
   addFolderItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, mSupportedFormats, mForceRefresh );
   addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, mSupportedFormats, mForceRefresh );
-  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, QgsArcGisRestQueryUtils::ServiceTypeFilter::Vector, mSupportedFormats, mForceRefresh );
+  // TO confirm -- is this possible? Can folder items have direct child layers, or do they always need to be placed in services first?
+  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, Qgis::ArcGisRestServiceType::Unknown, mSupportedFormats, mForceRefresh );
   return items;
 }
 
@@ -658,7 +683,7 @@ QVector<QgsDataItem *> QgsArcGisFeatureServiceItem::createChildren()
 
   addFolderItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, mSupportedFormats, mForceRefresh );
   addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, mSupportedFormats, mForceRefresh );
-  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, QgsArcGisRestQueryUtils::ServiceTypeFilter::Vector, mSupportedFormats, mForceRefresh );
+  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, Qgis::ArcGisRestServiceType::FeatureServer, mSupportedFormats, mForceRefresh );
   return items;
 }
 
@@ -674,22 +699,13 @@ bool QgsArcGisFeatureServiceItem::equal( const QgsDataItem *other )
 //
 
 QgsArcGisMapServiceItem::QgsArcGisMapServiceItem(
-  QgsDataItem *parent,
-  const QString &name,
-  const QString &path,
-  const QString &baseUrl,
-  const QString &authcfg,
-  const QgsHttpHeaders &headers,
-  const QString &urlPrefix,
-  Qgis::ArcGisRestServiceType serviceType,
-  bool forceRefresh
+  QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, bool forceRefresh
 )
   : QgsDataCollectionItem( parent, name, path, u"AMS"_s )
   , mBaseUrl( baseUrl )
   , mAuthCfg( authcfg )
   , mHeaders( headers )
   , mUrlPrefix( urlPrefix )
-  , mServiceType( serviceType )
   , mForceRefresh( forceRefresh )
 {
   mIconName = u"mIconAms.svg"_s;
@@ -716,12 +732,11 @@ QVector<QgsDataItem *> QgsArcGisMapServiceItem::createChildren()
     return items;
   }
 
-  const QString supportedFormats = mServiceType == Qgis::ArcGisRestServiceType::ImageServer ? u"JPGPNG,PNG,PNG8,PNG24,JPG,BMP,GIF,TIFF,PNG32,BIP,BSQ,LERC"_s // ImageServer supported formats
-                                                                                            : serviceData.value( u"supportedImageFormatTypes"_s ).toString();
+  const QString supportedFormats = serviceData.value( u"supportedImageFormatTypes"_s ).toString();
 
   addFolderItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, supportedFormats, mForceRefresh );
   addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, supportedFormats, mForceRefresh );
-  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, QgsArcGisRestQueryUtils::ServiceTypeFilter::AllTypes, supportedFormats, mForceRefresh );
+  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, Qgis::ArcGisRestServiceType::MapServer, supportedFormats, mForceRefresh );
   return items;
 }
 
@@ -730,6 +745,59 @@ bool QgsArcGisMapServiceItem::equal( const QgsDataItem *other )
   const QgsArcGisMapServiceItem *o = qobject_cast<const QgsArcGisMapServiceItem *>( other );
   return ( type() == other->type() && o && mPath == o->mPath && mName == o->mName );
 }
+
+
+//
+// QgsArcGisImageServiceItem
+//
+
+QgsArcGisImageServiceItem::QgsArcGisImageServiceItem(
+  QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, bool forceRefresh
+)
+  : QgsDataCollectionItem( parent, name, path, u"IMS"_s )
+  , mBaseUrl( baseUrl )
+  , mAuthCfg( authcfg )
+  , mHeaders( headers )
+  , mUrlPrefix( urlPrefix )
+  , mForceRefresh( forceRefresh )
+{
+  mIconName = u"mIconAms.svg"_s;
+  mCapabilities |= Qgis::BrowserItemCapability::Collapse;
+  setToolTip( path );
+}
+
+QVector<QgsDataItem *> QgsArcGisImageServiceItem::createChildren()
+{
+  const QString url = mPath;
+
+  QVector<QgsDataItem *> items;
+  QString errorTitle, errorMessage;
+  const QVariantMap serviceData = QgsArcGisRestQueryUtils::getServiceInfo( url, mAuthCfg, errorTitle, errorMessage, mHeaders, mUrlPrefix, mForceRefresh );
+  if ( serviceData.isEmpty() )
+  {
+    if ( !errorMessage.isEmpty() )
+    {
+      auto error = std::make_unique<QgsErrorItem>( this, tr( "Connection failed: %1" ).arg( errorTitle ), mPath + "/error" );
+      error->setToolTip( errorMessage );
+      items.append( error.release() );
+      QgsDebugError( "Connection failed - " + errorMessage );
+    }
+    return items;
+  }
+
+  const QString supportedFormats = u"JPGPNG,PNG,PNG8,PNG24,JPG,BMP,GIF,TIFF,PNG32,BIP,BSQ,LERC"_s;
+  addFolderItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, supportedFormats, mForceRefresh );
+  addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, supportedFormats, mForceRefresh );
+  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, Qgis::ArcGisRestServiceType::ImageServer, supportedFormats, mForceRefresh );
+  return items;
+}
+
+bool QgsArcGisImageServiceItem::equal( const QgsDataItem *other )
+{
+  const QgsArcGisImageServiceItem *o = qobject_cast<const QgsArcGisImageServiceItem *>( other );
+  return ( type() == other->type() && o && mPath == o->mPath && mName == o->mName );
+}
+
 
 //
 // QgsArcGisSceneServiceItem
@@ -771,7 +839,7 @@ QVector<QgsDataItem *> QgsArcGisSceneServiceItem::createChildren()
 
   addFolderItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, mSupportedFormats, mForceRefresh );
   addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, mHeaders, mUrlPrefix, this, mSupportedFormats, mForceRefresh );
-  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, QgsArcGisRestQueryUtils::ServiceTypeFilter::Scene, mSupportedFormats, mForceRefresh );
+  addLayerItems( items, serviceData, mPath, mAuthCfg, mHeaders, mUrlPrefix, this, Qgis::ArcGisRestServiceType::SceneServer, mSupportedFormats, mForceRefresh );
   return items;
 }
 
@@ -914,6 +982,38 @@ Qgis::BrowserItemFilterFlags QgsArcGisMapServiceLayerItem::filterFlags() const
     res.setFlag( Qgis::BrowserItemFilterFlag::HideWhenNotFilteringByLayerType );
   }
   return res;
+}
+
+
+//
+// QgsArcGisImageServiceLayerItem
+//
+
+QgsArcGisImageServiceLayerItem::QgsArcGisImageServiceLayerItem(
+  QgsDataItem *parent,
+  const QString &url,
+  const QString &id,
+  const QString &title,
+  const QgsCoordinateReferenceSystem &crs,
+  const QString &format,
+  const QString &authcfg,
+  const QgsHttpHeaders &headers,
+  const QString &urlPrefix
+)
+  : QgsArcGisRestLayerItem( parent, url, title, crs, Qgis::BrowserLayerType::Raster, u"arcgisimageserver"_s )
+{
+  const QString trimmedUrl = id.isEmpty() ? url : url.left( url.length() - 1 - id.length() ); // trim '/0' from end of url -- AMS provider requires this omitted
+  mUri = u"format='%1' layer='%2' url='%3'"_s.arg( format, id, trimmedUrl );
+  if ( !authcfg.isEmpty() )
+    mUri += u" authcfg='%1'"_s.arg( authcfg );
+
+  if ( !urlPrefix.isEmpty() )
+    mUri += u" urlprefix='%1'"_s.arg( urlPrefix );
+
+  mUri += headers.toSpacedString();
+
+  setState( Qgis::BrowserItemState::Populated );
+  setToolTip( mPath );
 }
 
 //

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
@@ -178,7 +178,7 @@ void addLayerItems(
   QMap<QString, QgsMimeDataUtils::Uri> mapServerUrisForAllLayersRender;
 
   QgsArcGisRestQueryUtils::addLayerItems(
-    [parent, &layerItems, &parents, &mapServerUrisForAllLayersRender, authcfg, headers, urlPrefix, serviceType, supportedFormats, forceRefresh]( const QgsArcGisRestQueryUtils::LayerItemDetails &details ) {
+    [parent, &layerItems, &parents, &mapServerUrisForAllLayersRender, authcfg, headers, urlPrefix, supportedFormats, forceRefresh]( const QgsArcGisRestQueryUtils::LayerItemDetails &details ) {
       Q_UNUSED( forceRefresh )
 
       if ( !details.parentLayerId.isEmpty() )

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.cpp
@@ -654,7 +654,7 @@ QgsArcGisFeatureServiceItem::QgsArcGisFeatureServiceItem(
 {
   mIconName = u"mIconAfs.svg"_s;
   mCapabilities |= Qgis::BrowserItemCapability::Collapse;
-  setToolTip( path );
+  setToolTip( u"<p><b>FeatureServer</b></p><p>%1</p>"_s.arg( path ) );
 }
 
 void QgsArcGisFeatureServiceItem::setSupportedFormats( const QString &formats )
@@ -710,7 +710,7 @@ QgsArcGisMapServiceItem::QgsArcGisMapServiceItem(
 {
   mIconName = u"mIconAms.svg"_s;
   mCapabilities |= Qgis::BrowserItemCapability::Collapse;
-  setToolTip( path );
+  setToolTip( u"<p><b>MapServer</b></p><p>%1</p>"_s.arg( path ) );
 }
 
 QVector<QgsDataItem *> QgsArcGisMapServiceItem::createChildren()
@@ -763,7 +763,7 @@ QgsArcGisImageServiceItem::QgsArcGisImageServiceItem(
 {
   mIconName = u"mIconAms.svg"_s;
   mCapabilities |= Qgis::BrowserItemCapability::Collapse;
-  setToolTip( path );
+  setToolTip( u"<p><b>ImageServer</b></p><p>%1</p>"_s.arg( path ) );
 }
 
 QVector<QgsDataItem *> QgsArcGisImageServiceItem::createChildren()

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.h
@@ -407,15 +407,7 @@ class QgsArcGisImageServiceLayerItem : public QgsArcGisRestLayerItem
 
   public:
     QgsArcGisImageServiceLayerItem(
-      QgsDataItem *parent,
-      const QString &url,
-      const QString &id,
-      const QString &title,
-      const QgsCoordinateReferenceSystem &crs,
-      const QString &format,
-      const QString &authcfg,
-      const QgsHttpHeaders &headers,
-      const QString &urlPrefix
+      QgsDataItem *parent, const QString &url, const QString &title, const QgsCoordinateReferenceSystem &crs, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix
     );
 
     void setSupportedFormats( const QString &formats ) { mSupportedFormats = formats; }

--- a/src/providers/arcgisrest/qgsarcgisrestdataitems.h
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitems.h
@@ -214,7 +214,7 @@ class QgsArcGisFeatureServiceItem : public QgsDataCollectionItem
 };
 
 /**
- * Represents a ArcGIS REST "Map Service" (or "Image Service") item.
+ * Represents a ArcGIS REST "Map Service" item.
  *
  * Usually has no child items, but sometimes services are nested and will contain other QgsArcGisMapServiceItem children
  * or QgsArcGisRestFolderItem children.
@@ -224,15 +224,7 @@ class QgsArcGisMapServiceItem : public QgsDataCollectionItem
     Q_OBJECT
   public:
     QgsArcGisMapServiceItem(
-      QgsDataItem *parent,
-      const QString &name,
-      const QString &path,
-      const QString &baseUrl,
-      const QString &authcfg,
-      const QgsHttpHeaders &headers,
-      const QString &urlPrefix,
-      Qgis::ArcGisRestServiceType serviceType,
-      bool forceRefresh
+      QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, bool forceRefresh
     );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
@@ -245,10 +237,36 @@ class QgsArcGisMapServiceItem : public QgsDataCollectionItem
     QString mAuthCfg;
     QgsHttpHeaders mHeaders;
     QString mUrlPrefix;
-    Qgis::ArcGisRestServiceType mServiceType = Qgis::ArcGisRestServiceType::Unknown;
     bool mForceRefresh = false;
     QgsMimeDataUtils::Uri mAllLayersMapServerUri;
 };
+
+
+/**
+ * Represents a ArcGIS REST "Image Service" item.
+ *
+ * Usually has no child items, but sometimes services are nested and will contain other QgsArcGisImageServiceItem children
+ * or QgsArcGisRestFolderItem children.
+ */
+class QgsArcGisImageServiceItem : public QgsDataCollectionItem
+{
+    Q_OBJECT
+  public:
+    QgsArcGisImageServiceItem(
+      QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg, const QgsHttpHeaders &headers, const QString &urlPrefix, bool forceRefresh
+    );
+    QVector<QgsDataItem *> createChildren() override;
+    bool equal( const QgsDataItem *other ) override;
+
+  private:
+    QString mFolder;
+    QString mBaseUrl;
+    QString mAuthCfg;
+    QgsHttpHeaders mHeaders;
+    QString mUrlPrefix;
+    bool mForceRefresh = false;
+};
+
 
 /**
  * Represents a ArcGIS REST "Scene Service"
@@ -347,7 +365,7 @@ class QgsArcGisFeatureServiceLayerItem : public QgsArcGisRestLayerItem
 };
 
 /**
- * Represents a ArcGIS REST "Map Service" (or "Image Service") layer item.
+ * Represents a ArcGIS REST "Map Service" layer item.
  */
 
 class QgsArcGisMapServiceLayerItem : public QgsArcGisRestLayerItem
@@ -376,6 +394,35 @@ class QgsArcGisMapServiceLayerItem : public QgsArcGisRestLayerItem
   private:
     QString mSupportedFormats;
     bool mIsMapServerWithQueryCapability = false;
+};
+
+
+/**
+ * Represents a ArcGIS REST "Image Service" layer item.
+ */
+
+class QgsArcGisImageServiceLayerItem : public QgsArcGisRestLayerItem
+{
+    Q_OBJECT
+
+  public:
+    QgsArcGisImageServiceLayerItem(
+      QgsDataItem *parent,
+      const QString &url,
+      const QString &id,
+      const QString &title,
+      const QgsCoordinateReferenceSystem &crs,
+      const QString &format,
+      const QString &authcfg,
+      const QgsHttpHeaders &headers,
+      const QString &urlPrefix
+    );
+
+    void setSupportedFormats( const QString &formats ) { mSupportedFormats = formats; }
+    QString supportedFormats() const { return mSupportedFormats; }
+
+  private:
+    QString mSupportedFormats;
 };
 
 /**

--- a/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
@@ -355,6 +355,12 @@ void QgsArcGisRestSourceSelect::addButtonClicked()
         break;
 
       case Qgis::ArcGisRestServiceType::ImageServer:
+        Q_NOWARN_DEPRECATED_PUSH
+        emit addRasterLayer( uri, layerName, u"arcgisimageserver"_s );
+        Q_NOWARN_DEPRECATED_POP
+        emit addLayer( Qgis::LayerType::Raster, uri, layerName, u"arcgisimageserver"_s );
+        break;
+
       case Qgis::ArcGisRestServiceType::GlobeServer:
       case Qgis::ArcGisRestServiceType::GPServer:
       case Qgis::ArcGisRestServiceType::GeocodeServer:


### PR DESCRIPTION
## Description

Many improvements to showing ESRI rest services in browser:

- Show ImageServer services, and allowing loading them as raster layers
- Allow connections which point directly to a specific layer endpoint
- Allow connections which point directly to a mapserver layer
- Cleanup code a lot and simplify

Funded by République et canton de Genève

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
