### PR TITLE
fix: qgis crash in style manager

### DIFF
--- a/src/ui/qgsstylegroupselectiondialogbase.ui
+++ b/src/ui/qgsstylegroupselectiondialogbase.ui
@@ -68,21 +68,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>SymbolsGroupSelectionDialogBase</sender>
-   <signal>destroyed()</signal>
-   <receiver>SymbolsGroupSelectionDialogBase</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>226</x>
-     <y>173</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>226</x>
-     <y>173</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>


### PR DESCRIPTION
fix: #65869
<img width="416" height="267" alt="image" src="https://github.com/user-attachments/assets/2f95336e-42d7-4590-b364-27d42707f732" />
The steps for the crash reoccurrence are as shown in the above figure.