### PR TITLE
[app] Handle link-less news items, insure consistent padding/margin under all circumstances

### DIFF
--- a/src/app/qml/WelcomeScreen.qml
+++ b/src/app/qml/WelcomeScreen.qml
@@ -554,6 +554,7 @@ Item {
               description: Content
               imageSource: ImageUrl
               showCloseButton: true
+              showLink: Link != ""
 
               onReadMoreClicked: {
                 Qt.openUrlExternally(Link);

--- a/src/app/qml/components/NewsCard.qml
+++ b/src/app/qml/components/NewsCard.qml
@@ -12,7 +12,9 @@ Rectangle {
   property string description: ""
   property string imageSource: ""
   property string linkText: qsTr("Read more...")
+  
   property bool showCloseButton: false
+  property bool showLink: false
 
   signal readMoreClicked
   signal closeClicked
@@ -46,13 +48,14 @@ Rectangle {
 
     Text {
       Layout.fillWidth: true
-      text: root.description
+      textFormat: Text.RichText
+      text: '<style type="text/css">p:last-child { background-color:"red";margin:0; }</style>' + root.description
       font.pointSize: Application.font.pointSize * 0.8
       color: "#4a5568"
       wrapMode: Text.WordWrap
       lineHeight: 1.3
       linkColor: "#589632"
-      
+
       onLinkActivated: link => {
         Qt.openUrlExternally(link);
       }
@@ -60,6 +63,7 @@ Rectangle {
 
     Text {
       Layout.fillWidth: true
+      visible: root.showLink
       text: root.linkText
       font.pointSize: Application.font.pointSize * 0.8
       font.underline: mouseArea.containsMouse

--- a/src/core/network/qgsnewsfeedparser.cpp
+++ b/src/core/network/qgsnewsfeedparser.cpp
@@ -243,9 +243,9 @@ void QgsNewsFeedParser::onFetch( const QString &content )
     Entry incomingEntry;
     const QVariantMap entryMap = e.toMap();
     incomingEntry.key = entryMap.value( u"pk"_s ).toInt();
-    incomingEntry.title = entryMap.value( u"title"_s ).toString();
+    incomingEntry.title = entryMap.value( u"title"_s ).toString().trimmed();
     incomingEntry.imageUrl = entryMap.value( u"image"_s ).toString();
-    incomingEntry.content = entryMap.value( u"content"_s ).toString();
+    incomingEntry.content = entryMap.value( u"content"_s ).toString().trimmed();
     incomingEntry.link = entryMap.value( u"url"_s ).toString();
     incomingEntry.sticky = entryMap.value( u"sticky"_s ).toBool();
     incomingEntry.published.setSecsSinceEpoch( entryMap.value( u"publish_from"_s ).toLongLong() );


### PR DESCRIPTION
## Description

Some of the QGIS news feed items do not have links, yet we were showing a dead "read more..." hyperlink. This PR fixes that, and also takes care of insuring we have consistent padding/margin of news items under all circumstances.

Result:

<img width="1135" height="561" alt="image" src="https://github.com/user-attachments/assets/b648ff38-4358-40da-97f9-8bec0aaa4d6c" />
