### PR TITLE
fix(qgstessellator): ringToEarcutPoints hash was using pointer onto temp object

### DIFF
--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -34,32 +34,6 @@
 #include <QtDebug>
 #include <QtMath>
 
-// specialization of hash used by ringToEarcutPoints
-namespace std
-{
-  //! generate hash from std::array data type
-  template<typename T, std::size_t N> struct std_array_hash
-  {
-      std::size_t operator()( const std::array<T, N> &a ) const noexcept
-      {
-        std::size_t h = 1469598103934665603u; // FNV offset basis (64-bit)
-        for ( const T &e : a )
-        {
-          std::size_t v = std::hash<T> {}( e );
-          h ^= v;
-          h *= 1099511628211u; // FNV prime
-        }
-        return h;
-      }
-  };
-
-  //! declare hash specialization for std::array data type
-  template<typename T, size_t N> struct hash<array<T, N>>
-  {
-      size_t operator()( array<T, N> const &a ) const noexcept { return std_array_hash<T, N> {}( a ); }
-  };
-} //namespace std
-
 void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D &pt2, float height, float u1, float u2 )
 {
   const float dx = pt2.x() - pt1.x();
@@ -580,7 +554,7 @@ QVector3D QgsTessellator::applyTransformWithExtrusion( const QVector3D point, fl
   return QVector3D( static_cast<float>( fx ), static_cast<float>( fy ), static_cast<float>( fz ) );
 }
 
-void QgsTessellator::ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, QHash<std::array<double, 2>, float> &zHash ) const
+void QgsTessellator::ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, std::vector<float> &zHash ) const
 {
   const int pCount = ring->numPoints();
 
@@ -601,7 +575,7 @@ void QgsTessellator::ringToEarcutPoints( const QgsLineString *ring, std::vector<
 
     if ( !mInputZValueIgnored && srcZData )
     {
-      zHash.insert( pt, *srcZData++ );
+      zHash.push_back( *srcZData++ );
     }
   }
 }
@@ -651,7 +625,7 @@ std::vector<QVector3D> QgsTessellator::generateConstrainedDelaunayTriangles( con
 
 std::vector<QVector3D> QgsTessellator::generateEarcutTriangles( const QgsPolygon *polygonNew )
 {
-  QHash<std::array<double, 2>, float> z;
+  std::vector<float> z;
   std::vector<std::vector<std::array<double, 2>>> rings;
   std::vector<std::array<double, 2>> polyline;
 
@@ -683,7 +657,7 @@ std::vector<QVector3D> QgsTessellator::generateEarcutTriangles( const QgsPolygon
     double x = vertex[0];
     double y = vertex[1];
 
-    float zValue = z.value( vertex, 0.0f );
+    float zValue = ( mInputZValueIgnored ? 0.0f : z[vertexIndex] );
 
     trianglePoints.emplace_back( x / mScale, y / mScale, zValue );
   }

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -34,6 +34,32 @@
 #include <QtDebug>
 #include <QtMath>
 
+// specialization of hash used by ringToEarcutPoints
+namespace std
+{
+  //! generate hash from std::array data type
+  template<typename T, std::size_t N> struct std_array_hash
+  {
+      std::size_t operator()( const std::array<T, N> &a ) const noexcept
+      {
+        std::size_t h = 1469598103934665603u; // FNV offset basis (64-bit)
+        for ( const T &e : a )
+        {
+          std::size_t v = std::hash<T> {}( e );
+          h ^= v;
+          h *= 1099511628211u; // FNV prime
+        }
+        return h;
+      }
+  };
+
+  //! declare hash specialization for std::array data type
+  template<typename T, size_t N> struct hash<array<T, N>>
+  {
+      size_t operator()( array<T, N> const &a ) const noexcept { return std_array_hash<T, N> {}( a ); }
+  };
+} //namespace std
+
 void QgsTessellator::addExtrusionWallQuad( const QVector3D &pt1, const QVector3D &pt2, float height, float u1, float u2 )
 {
   const float dx = pt2.x() - pt1.x();
@@ -554,8 +580,7 @@ QVector3D QgsTessellator::applyTransformWithExtrusion( const QVector3D point, fl
   return QVector3D( static_cast<float>( fx ), static_cast<float>( fy ), static_cast<float>( fz ) );
 }
 
-
-void QgsTessellator::ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, QHash<std::array<double, 2> *, float> *zHash )
+void QgsTessellator::ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, QHash<std::array<double, 2>, float> &zHash ) const
 {
   const int pCount = ring->numPoints();
 
@@ -574,9 +599,9 @@ void QgsTessellator::ringToEarcutPoints( const QgsLineString *ring, std::vector<
     std::array<double, 2> pt = { x, y };
     polyline.push_back( pt );
 
-    if ( zHash && srcZData )
+    if ( !mInputZValueIgnored && srcZData )
     {
-      ( *zHash )[&pt] = *srcZData++;
+      zHash.insert( pt, *srcZData++ );
     }
   }
 }
@@ -626,17 +651,17 @@ std::vector<QVector3D> QgsTessellator::generateConstrainedDelaunayTriangles( con
 
 std::vector<QVector3D> QgsTessellator::generateEarcutTriangles( const QgsPolygon *polygonNew )
 {
-  QHash<std::array<double, 2> *, float> z;
+  QHash<std::array<double, 2>, float> z;
   std::vector<std::vector<std::array<double, 2>>> rings;
   std::vector<std::array<double, 2>> polyline;
 
-  ringToEarcutPoints( qgsgeometry_cast< const QgsLineString * >( polygonNew->exteriorRing() ), polyline, mInputZValueIgnored ? nullptr : &z );
+  ringToEarcutPoints( qgsgeometry_cast< const QgsLineString * >( polygonNew->exteriorRing() ), polyline, z );
   rings.push_back( polyline );
 
   for ( int i = 0; i < polygonNew->numInteriorRings(); ++i )
   {
     std::vector<std::array<double, 2>> holePolyline;
-    ringToEarcutPoints( qgsgeometry_cast<const QgsLineString *>( polygonNew->interiorRing( i ) ), holePolyline, mInputZValueIgnored ? nullptr : &z );
+    ringToEarcutPoints( qgsgeometry_cast<const QgsLineString *>( polygonNew->interiorRing( i ) ), holePolyline, z );
     rings.push_back( holePolyline );
   }
 
@@ -658,7 +683,7 @@ std::vector<QVector3D> QgsTessellator::generateEarcutTriangles( const QgsPolygon
     double x = vertex[0];
     double y = vertex[1];
 
-    float zValue = z.value( &vertex, 0.0f );
+    float zValue = z.value( vertex, 0.0f );
 
     trianglePoints.emplace_back( x / mScale, y / mScale, zValue );
   }

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -554,7 +554,7 @@ QVector3D QgsTessellator::applyTransformWithExtrusion( const QVector3D point, fl
   return QVector3D( static_cast<float>( fx ), static_cast<float>( fy ), static_cast<float>( fz ) );
 }
 
-void QgsTessellator::ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, std::vector<float> &zHash ) const
+void QgsTessellator::ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, std::vector<double> &zValues ) const
 {
   const int pCount = ring->numPoints();
 
@@ -567,16 +567,16 @@ void QgsTessellator::ringToEarcutPoints( const QgsLineString *ring, std::vector<
   // earcut handles duplicates, we do not need to remove them here
   for ( int i = 0; i < pCount - 1; ++i )
   {
-    const float x = static_cast<float>( *srcXData++ );
-    const float y = static_cast<float>( *srcYData++ );
+    const double x = *srcXData++;
+    const double y = *srcYData++;
 
     std::array<double, 2> pt = { x, y };
     polyline.push_back( pt );
+  }
 
-    if ( !mInputZValueIgnored && srcZData )
-    {
-      zHash.push_back( *srcZData++ );
-    }
+  if ( !mInputZValueIgnored && ring->is3D() && srcZData )
+  {
+    zValues.insert( zValues.end(), srcZData, srcZData + pCount - 1 );
   }
 }
 
@@ -625,18 +625,24 @@ std::vector<QVector3D> QgsTessellator::generateConstrainedDelaunayTriangles( con
 
 std::vector<QVector3D> QgsTessellator::generateEarcutTriangles( const QgsPolygon *polygonNew )
 {
-  std::vector<float> z;
-  std::vector<std::vector<std::array<double, 2>>> rings;
-  std::vector<std::array<double, 2>> polyline;
+  std::vector<double> zValues;
+  if ( !mInputZValueIgnored && polygonNew->is3D() )
+    zValues.reserve( polygonNew->nCoordinates() );
 
-  ringToEarcutPoints( qgsgeometry_cast< const QgsLineString * >( polygonNew->exteriorRing() ), polyline, z );
-  rings.push_back( polyline );
+  std::vector<std::vector<std::array<double, 2>>> rings;
+  rings.reserve( polygonNew->numInteriorRings() );
+
+  {
+    std::vector<std::array<double, 2>> polyline;
+    ringToEarcutPoints( qgsgeometry_cast< const QgsLineString * >( polygonNew->exteriorRing() ), polyline, zValues );
+    rings.push_back( std::move( polyline ) );
+  }
 
   for ( int i = 0; i < polygonNew->numInteriorRings(); ++i )
   {
     std::vector<std::array<double, 2>> holePolyline;
-    ringToEarcutPoints( qgsgeometry_cast<const QgsLineString *>( polygonNew->interiorRing( i ) ), holePolyline, z );
-    rings.push_back( holePolyline );
+    ringToEarcutPoints( qgsgeometry_cast<const QgsLineString *>( polygonNew->interiorRing( i ) ), holePolyline, zValues );
+    rings.push_back( std::move( holePolyline ) );
   }
 
   std::vector<std::array<double, 2>> points;
@@ -647,19 +653,17 @@ std::vector<QVector3D> QgsTessellator::generateEarcutTriangles( const QgsPolygon
 
   std::vector<uint32_t> indices = mapbox::earcut<uint32_t>( rings );
   std::vector<QVector3D> trianglePoints;
-  trianglePoints.reserve( points.size() );
+  trianglePoints.reserve( indices.size() );
 
   for ( size_t i = 0; i < indices.size(); i++ )
   {
     uint32_t vertexIndex = indices[i];
-    std::array<double, 2> vertex = points[vertexIndex];
 
-    double x = vertex[0];
-    double y = vertex[1];
+    float x = static_cast<float>( points[vertexIndex][0] );
+    float y = static_cast<float>( points[vertexIndex][1] );
+    float z = static_cast<float>( mInputZValueIgnored ? 0.0 : zValues[vertexIndex] );
 
-    float zValue = ( mInputZValueIgnored ? 0.0f : z[vertexIndex] );
-
-    trianglePoints.emplace_back( x / mScale, y / mScale, zValue );
+    trianglePoints.emplace_back( x / mScale, y / mScale, z );
   }
 
   return trianglePoints;

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -328,7 +328,7 @@ class CORE_EXPORT QgsTessellator
     void addVertex( const QVector3D &point, const QVector3D &normal, const QVector4D &tangent, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset, bool isFloor = false );
     void makeWalls( const QgsLineString &ring, bool ccw, float extrusionHeight );
     void addExtrusionWallQuad( const QVector3D &pt1, const QVector3D &pt2, float height, float u1, float u2 );
-    void ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, QHash<std::array<double, 2> *, float> *zHash );
+    void ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, QHash<std::array<double, 2>, float> &zHash ) const;
     std::vector<QVector3D> generateConstrainedDelaunayTriangles( const QgsPolygon *polygonNew );
     std::vector<QVector3D> generateEarcutTriangles( const QgsPolygon *polygonNew );
 

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -328,7 +328,7 @@ class CORE_EXPORT QgsTessellator
     void addVertex( const QVector3D &point, const QVector3D &normal, const QVector4D &tangent, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset, bool isFloor = false );
     void makeWalls( const QgsLineString &ring, bool ccw, float extrusionHeight );
     void addExtrusionWallQuad( const QVector3D &pt1, const QVector3D &pt2, float height, float u1, float u2 );
-    void ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, QHash<std::array<double, 2>, float> &zHash ) const;
+    void ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, std::vector<float> &zHash ) const;
     std::vector<QVector3D> generateConstrainedDelaunayTriangles( const QgsPolygon *polygonNew );
     std::vector<QVector3D> generateEarcutTriangles( const QgsPolygon *polygonNew );
 

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -328,7 +328,7 @@ class CORE_EXPORT QgsTessellator
     void addVertex( const QVector3D &point, const QVector3D &normal, const QVector4D &tangent, float extrusionHeight, QMatrix4x4 *transformMatrix, const QgsPoint *originOffset, bool isFloor = false );
     void makeWalls( const QgsLineString &ring, bool ccw, float extrusionHeight );
     void addExtrusionWallQuad( const QVector3D &pt1, const QVector3D &pt2, float height, float u1, float u2 );
-    void ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, std::vector<float> &zHash ) const;
+    void ringToEarcutPoints( const QgsLineString *ring, std::vector<std::array<double, 2>> &polyline, std::vector<double> &zValues ) const;
     std::vector<QVector3D> generateConstrainedDelaunayTriangles( const QgsPolygon *polygonNew );
     std::vector<QVector3D> generateEarcutTriangles( const QgsPolygon *polygonNew );
 


### PR DESCRIPTION
When displaying 3D extruded polygons the qgstessellator::ringToEarcutPoints function is called to compute roof and floor. This function stored in hash map the pointer onto temp object then use pointer onto another temp object to retrieve data. It resulted in wrong roof/floor points as illustrated:

<img width="956" height="598" alt="image" src="https://github.com/user-attachments/assets/f547049a-0495-40ca-bd7f-5b84db32635b" />

This PR fix that behaviour by adding a specialisation to QHash in order to handle std::array object. Here is the new result:

<img width="956" height="598" alt="image" src="https://github.com/user-attachments/assets/153d2266-9ed7-41d3-ac90-5b001fff1bc1" />
