### PR TITLE
[imageserver] Add support for tile image servers

### DIFF
--- a/src/core/providers/arcgis/qgsarcgisrestquery.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestquery.cpp
@@ -414,6 +414,12 @@ QUrl QgsArcGisRestQueryUtils::parseUrl( const QUrl &url, bool *isTestEndpoint )
     }
 #endif
     modifiedUrlString = modifiedUrlString.mid( 0, modifiedUrlString.indexOf( '?' ) ) + args;
+
+    if ( modifiedUrlString.contains( "tile/" ) )
+    {
+      modifiedUrlString = modifiedUrlString.left( modifiedUrlString.indexOf( "tile/" ) + 4 ) + modifiedUrlString.mid( modifiedUrlString.indexOf( "tile/" ) + 4 ).replace( '/', '_' );
+    }
+
     QgsDebugMsgLevel( u"Get %1 (after laundering)"_s.arg( modifiedUrlString ), 2 );
     modifiedUrl = QUrl::fromLocalFile( modifiedUrlString );
     if ( !QFile::exists( modifiedUrlString ) )

--- a/src/providers/arcgisrest/CMakeLists.txt
+++ b/src/providers/arcgisrest/CMakeLists.txt
@@ -8,7 +8,6 @@ set (AFS_SRCS
 )
 if (WITH_GUI)
   set(AFS_GUI_SRCS
-    qgsarcgisimageserversourcewidget.cpp
     qgsarcgisrestdataitemguiprovider.cpp
     qgsarcgisrestprovidergui.cpp
     qgsarcgisrestsourceselect.cpp
@@ -17,7 +16,6 @@ if (WITH_GUI)
   )
 
   set(AFS_UIS
-    ${CMAKE_SOURCE_DIR}/src/ui/qgsarcgisimageserversourcewidgetbase.ui
     ${CMAKE_SOURCE_DIR}/src/ui/qgsarcgisrestsourcewidgetbase.ui
     ${CMAKE_SOURCE_DIR}/src/ui/qgsarcgisservicesourceselectbase.ui
     ${CMAKE_SOURCE_DIR}/src/ui/qgsnewarcgisrestconnectionbase.ui
@@ -140,6 +138,16 @@ endif()
 set (IMS_SRCS
   qgsimageserverprovider.cpp
 )
+if (WITH_GUI)
+  set(IMS_GUI_SRCS
+    qgsimageserverprovidergui.cpp
+    qgsarcgisimageserversourcewidget.cpp
+  )
+
+  set(IMS_UIS
+    ${CMAKE_SOURCE_DIR}/src/ui/qgsarcgisimageserversourcewidgetbase.ui
+  )
+endif()
 
 add_library (provider_arcgisimageserver_a STATIC ${IMS_SRCS})
 
@@ -155,19 +163,55 @@ target_link_libraries (provider_arcgisimageserver_a
   ${QCA_LIBRARY}
 )
 
+set_target_properties(provider_arcgisimageserver_a PROPERTIES UNITY_BUILD ${ENABLE_UNITY_BUILDS})
+
+if (WITH_GUI)
+  qt_wrap_ui(IMS_UIS_H ${IMS_UIS})
+
+  add_library(provider_arcgisimageserver_gui_a STATIC ${IMS_GUI_SRCS} ${IMS_UIS_H})
+
+  set_target_properties(provider_arcgisimageserver_gui_a PROPERTIES UNITY_BUILD ${ENABLE_UNITY_BUILDS})
+
+  target_link_libraries(provider_arcgisimageserver_a
+    qgis_gui
+  )
+  target_link_libraries(provider_arcgisimageserver_gui_a
+    qgis_gui
+  )
+
+  include_directories(SYSTEM
+    ${CMAKE_BINARY_DIR}/src/ui
+    ${QSCINTILLA_INCLUDE_DIR}
+  )
+
+  add_dependencies(provider_arcgisimageserver_gui_a ui)
+endif()
+
 if (FORCE_STATIC_LIBS)
   # for (external) mobile apps to be able to pick up provider for linking
   install (TARGETS provider_arcgisimageserver_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  if (WITH_GUI)
+    install (TARGETS provider_arcgisimageserver_gui_a ARCHIVE DESTINATION ${QGIS_PLUGIN_DIR})
+  endif()
 else()
-  add_library(provider_arcgisimageserver MODULE ${IMS_SRCS})
+  add_library(provider_arcgisimageserver MODULE ${IMS_SRCS} ${IMS_GUI_SRCS} ${IMS_UIS_H})
 
   # We use private headers from core that need this
   target_compile_definitions(provider_arcgisimageserver PRIVATE "CMAKE_SOURCE_DIR=\"${CMAKE_SOURCE_DIR}\"")
+
+  set_target_properties(provider_arcgisimageserver PROPERTIES UNITY_BUILD ${ENABLE_UNITY_BUILDS})
 
   target_link_libraries(provider_arcgisimageserver
     qgis_core
     ${QCA_LIBRARY}
   )
+
+  if (WITH_GUI)
+    target_link_libraries(provider_arcgisimageserver
+      qgis_gui
+    )
+    add_dependencies(provider_arcgisimageserver ui)
+  endif()
 
   install (TARGETS provider_arcgisimageserver
     RUNTIME DESTINATION ${QGIS_PLUGIN_DIR}

--- a/src/providers/arcgisrest/qgsarcgisimageserversourcewidget.cpp
+++ b/src/providers/arcgisrest/qgsarcgisimageserversourcewidget.cpp
@@ -18,7 +18,10 @@
 #include "qgsarcgisimageserversourcewidget.h"
 
 #include "qgsgdalutils.h"
+#include "qgsimageserverprovider.h"
+#include "qgsmaplayer.h"
 #include "qgsproviderregistry.h"
+#include "qgsrasterlayer.h"
 
 #include <QString>
 
@@ -26,11 +29,35 @@
 
 using namespace Qt::StringLiterals;
 
-QgsArcGisImageServerSourceWidget::QgsArcGisImageServerSourceWidget( const QString &providerKey, QWidget *parent )
+QgsArcGisImageServerSourceWidget::QgsArcGisImageServerSourceWidget( QgsMapLayer *layer, QWidget *parent )
   : QgsProviderSourceWidget( parent )
-  , mProviderKey( providerKey )
+  , mProviderKey( layer->providerType() )
 {
   setupUi( this );
+
+  QgsRasterLayer *rasterLayer = qobject_cast< QgsRasterLayer * >( layer );
+  if ( QgsRasterDataProvider *dataProvider = rasterLayer->dataProvider() )
+  {
+    QgsImageServerProvider *imageServerProvider = qobject_cast< QgsImageServerProvider * >( dataProvider );
+    // this widget should ONLY be used for image server provider!
+    Q_ASSERT( imageServerProvider );
+    if ( imageServerProvider->serviceCapabilities().testFlag( Qgis::ArcGisRestServiceCapability::TilesOnly ) )
+    {
+      mUseTilesCheckBox->setChecked( true );
+      mUseTilesCheckBox->setEnabled( false );
+      mUseTilesCheckBox->setToolTip( tr( "This service only supports data retrieval via tiles" ) );
+    }
+    else if ( !imageServerProvider->supportsTiles() )
+    {
+      mUseTilesCheckBox->setChecked( false );
+      mUseTilesCheckBox->setEnabled( false );
+      mUseTilesCheckBox->setToolTip( tr( "This service does not support data retrieval via tiles" ) );
+    }
+    else
+    {
+      mUseTilesCheckBox->setEnabled( true );
+    }
+  }
 
   mImageFormatCombo->addItem( tr( "Default" ) );
   mImageFormatCombo->addItem( tr( "TIFF" ), u"tiff"_s );
@@ -60,6 +87,12 @@ void QgsArcGisImageServerSourceWidget::setSourceUri( const QString &uri )
   if ( mImageFormatCombo->currentIndex() < 0 )
   {
     mImageFormatCombo->setCurrentIndex( 0 );
+  }
+
+  if ( mUseTilesCheckBox->isEnabled() )
+  {
+    // always default to tiled mode, it's opt-out
+    mUseTilesCheckBox->setChecked( mSourceParts.value( u"tiled"_s, true ).toBool() );
   }
 }
 
@@ -91,6 +124,11 @@ QString QgsArcGisImageServerSourceWidget::sourceUri() const
     parts.insert( u"format"_s, format );
   else
     parts.remove( u"format"_s );
+
+  if ( mUseTilesCheckBox->isEnabled() && !mUseTilesCheckBox->isChecked() )
+    parts.insert( u"tiled"_s, false );
+  else
+    parts.remove( u"tiled"_s );
 
   return QgsProviderRegistry::instance()->encodeUri( mProviderKey, parts );
 }

--- a/src/providers/arcgisrest/qgsarcgisimageserversourcewidget.h
+++ b/src/providers/arcgisrest/qgsarcgisimageserversourcewidget.h
@@ -23,12 +23,14 @@
 
 #include <QVariantMap>
 
+class QgsMapLayer;
+
 class QgsArcGisImageServerSourceWidget : public QgsProviderSourceWidget, private Ui::QgsArcGisImageServerSourceWidgetBase
 {
     Q_OBJECT
 
   public:
-    QgsArcGisImageServerSourceWidget( const QString &providerKey, QWidget *parent = nullptr );
+    QgsArcGisImageServerSourceWidget( QgsMapLayer *layer, QWidget *parent = nullptr );
 
     void setSourceUri( const QString &uri ) override;
     QString sourceUri() const override;

--- a/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestdataitemguiprovider.cpp
@@ -121,6 +121,12 @@ void QgsArcGisRestDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
     connect( viewInfo, &QAction::triggered, this, [serviceItem] { QDesktopServices::openUrl( QUrl( serviceItem->path() ) ); } );
     menu->addAction( viewInfo );
   }
+  else if ( QgsArcGisImageServiceItem *serviceItem = qobject_cast<QgsArcGisImageServiceItem *>( item ) )
+  {
+    QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
+    connect( viewInfo, &QAction::triggered, this, [serviceItem] { QDesktopServices::openUrl( QUrl( serviceItem->path() ) ); } );
+    menu->addAction( viewInfo );
+  }
   else if ( QgsArcGisRestParentLayerItem *layerItem = qobject_cast<QgsArcGisRestParentLayerItem *>( item ) )
   {
     if ( layerItem->allLayersMapServerUri().isValid() )
@@ -161,6 +167,13 @@ void QgsArcGisRestDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
     menu->addSeparator();
   }
   else if ( QgsArcGisSceneServiceLayerItem *layerItem = qobject_cast<QgsArcGisSceneServiceLayerItem *>( item ) )
+  {
+    QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
+    connect( viewInfo, &QAction::triggered, this, [layerItem] { QDesktopServices::openUrl( QUrl( layerItem->path() ) ); } );
+    menu->addAction( viewInfo );
+    menu->addSeparator();
+  }
+  else if ( QgsArcGisImageServiceLayerItem *layerItem = qobject_cast<QgsArcGisImageServiceLayerItem *>( item ) )
   {
     QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
     connect( viewInfo, &QAction::triggered, this, [layerItem] { QDesktopServices::openUrl( QUrl( layerItem->path() ) ); } );

--- a/src/providers/arcgisrest/qgsarcgisrestprovidergui.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestprovidergui.cpp
@@ -17,7 +17,6 @@
 
 #include "qgsafsprovider.h"
 #include "qgsapplication.h"
-#include "qgsarcgisimageserversourcewidget.h"
 #include "qgsarcgisrestdataitemguiprovider.h"
 #include "qgsarcgisrestsourceselect.h"
 #include "qgsarcgisrestsourcewidget.h"
@@ -55,7 +54,7 @@ class QgsArcGisRestSourceWidgetProvider : public QgsProviderSourceWidgetProvider
     QString providerKey() const override { return QgsAfsProvider::AFS_PROVIDER_KEY; }
     bool canHandleLayer( QgsMapLayer *layer ) const override
     {
-      if ( layer->providerType() != QgsAfsProvider::AFS_PROVIDER_KEY && layer->providerType() != "arcgismapserver"_L1 && layer->providerType() != "arcgisimageserver"_L1 )
+      if ( layer->providerType() != QgsAfsProvider::AFS_PROVIDER_KEY && layer->providerType() != "arcgismapserver"_L1 )
         return false;
 
       return true;
@@ -65,10 +64,6 @@ class QgsArcGisRestSourceWidgetProvider : public QgsProviderSourceWidgetProvider
       if ( layer->providerType() == QgsAfsProvider::AFS_PROVIDER_KEY || layer->providerType() == "arcgismapserver"_L1 )
       {
         return new QgsArcGisRestSourceWidget( layer->providerType(), parent );
-      }
-      else if ( layer->providerType() == QgsAfsProvider::AFS_PROVIDER_KEY || layer->providerType() == "arcgisimageserver"_L1 )
-      {
-        return new QgsArcGisImageServerSourceWidget( layer->providerType(), parent );
       }
       return nullptr;
     }

--- a/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestsourceselect.cpp
@@ -184,7 +184,7 @@ void QgsArcGisRestSourceSelect::showEvent( QShowEvent * )
   mBrowserView->expand( mProxyModel->index( 0, 0 ) );
   mBrowserView->setHeaderHidden( true );
 
-  mProxyModel->setShownDataItemProviderKeyFilter( QStringList() << u"AFS"_s << u"arcgisfeatureserver"_s << u"AMS"_s << u"arcgismapserver"_s << u"I3S"_s << u"esrii3s"_s );
+  mProxyModel->setShownDataItemProviderKeyFilter( QStringList() << u"AFS"_s << u"arcgisfeatureserver"_s << u"AMS"_s << u"arcgismapserver"_s << u"I3S"_s << u"esrii3s"_s << u"arcgisimageserver"_s );
 
   const QModelIndex afsSourceIndex = mBrowserModel->findPath( u"arcgisfeatureserver:"_s );
   mBrowserView->setRootIndex( mProxyModel->mapFromSource( afsSourceIndex ) );
@@ -591,6 +591,10 @@ QString QgsArcGisRestSourceSelect::indexToUri( const QModelIndex &proxyIndex, QS
       uri.removeParam( u"format"_s );
       uri.setParam( u"format"_s, getSelectedImageEncoding() );
       serviceType = Qgis::ArcGisRestServiceType::MapServer;
+    }
+    else if ( qobject_cast<QgsArcGisImageServiceLayerItem *>( layerItem ) )
+    {
+      serviceType = Qgis::ArcGisRestServiceType::ImageServer;
     }
     else if ( qobject_cast<QgsArcGisSceneServiceLayerItem *>( layerItem ) )
     {

--- a/src/providers/arcgisrest/qgsimageserverprovider.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovider.cpp
@@ -18,11 +18,11 @@
 #include "qgsimageserverprovider.h"
 
 #include <cpl_vsi.h>
-#include <gdal.h>
 
 #include "qgsapplication.h"
 #include "qgsarcgisrestquery.h"
 #include "qgsarcgisrestutils.h"
+#include "qgsauthmanager.h"
 #include "qgsblockingnetworkrequest.h"
 #include "qgsdatasourceuri.h"
 #include "qgsgdalutils.h"
@@ -32,7 +32,7 @@
 #include "qgsrasteridentifyresult.h"
 #include "qgssetrequestinitiator_p.h"
 #include "qgsstringutils.h"
-#include "qgstilecache.h"
+#include "qgstiledownloadmanager.h"
 
 #include <QDir>
 #include <QFontMetrics>
@@ -76,13 +76,10 @@ QgsImageServerProvider::QgsImageServerProvider( const QString &uri, const Provid
     return;
   }
 
-  if ( mCapabilities.testFlag( Qgis::ArcGisRestServiceCapability::TilesOnly ) )
+  mRasterCapabilities = Qgis::RasterInterfaceCapability::Size;
+  if ( !mCapabilities.testFlag( Qgis::ArcGisRestServiceCapability::TilesOnly ) )
   {
-    // not an image service
-    appendError( QgsErrorMessage( tr( "Service has support for Image Tiles only -- this is currently not supported" ) ) );
-    QgsMessageLog::logMessage( tr( "Service has support for Image Tiles only -- this is currently not supported" ), tr( "ImageServer" ) );
-    mValid = false;
-    return;
+    mRasterCapabilities |= Qgis::RasterInterfaceCapability::Identify | Qgis::RasterInterfaceCapability::IdentifyValue;
   }
 
   mHasRat = mServiceInfo.value( u"hasRasterAttributeTable"_s ).toBool();
@@ -241,8 +238,8 @@ QgsImageServerProvider::QgsImageServerProvider( const QString &uri, const Provid
   mLayerMetadata.setExtent( metadataExtent );
   mLayerMetadata.setCrs( mCrs );
 
-  mTiled = mServiceInfo.value( u"singleFusedMapCache"_s ).toBool();
-  if ( dataSource.param( u"tiled"_s ).toLower() == "false" || dataSource.param( u"tiled"_s ) == "0" )
+  mTiled = mServiceInfo.value( u"singleFusedMapCache"_s ).toBool() || mCapabilities.testFlag( Qgis::ArcGisRestServiceCapability::TilesOnly );
+  if ( ( dataSource.param( u"tiled"_s ).toLower() == "false" || dataSource.param( u"tiled"_s ) == "0" ) && !mCapabilities.testFlag( Qgis::ArcGisRestServiceCapability::TilesOnly ) )
   {
     mTiled = false;
   }
@@ -278,6 +275,11 @@ QgsImageServerProvider::QgsImageServerProvider( const QString &uri, const Provid
     }
     std::sort( mResolutions.begin(), mResolutions.end() );
   }
+
+  if ( mServiceInfo.contains( u"minLOD"_s ) )
+    mMinLOD = mServiceInfo.value( u"minLOD"_s ).toInt();
+  if ( mServiceInfo.contains( u"maxLOD"_s ) )
+    mMaxLOD = mServiceInfo.value( u"maxLOD"_s ).toInt();
 }
 
 QgsImageServerProvider::QgsImageServerProvider( const QgsImageServerProvider &other, const QgsDataProvider::ProviderOptions &providerOptions )
@@ -286,6 +288,7 @@ QgsImageServerProvider::QgsImageServerProvider( const QgsImageServerProvider &ot
   , mServiceInfo( other.mServiceInfo )
   , mLayerInfo( other.mLayerInfo )
   , mCapabilities( other.mCapabilities )
+  , mRasterCapabilities( other.mRasterCapabilities )
   , mCrs( other.mCrs )
   , mExtent( other.mExtent )
   , mPixelSizeX( other.mPixelSizeX )
@@ -300,6 +303,8 @@ QgsImageServerProvider::QgsImageServerProvider( const QgsImageServerProvider &ot
   , mStdevValues( other.mStdevValues )
   , mRequestHeaders( other.mRequestHeaders )
   , mTiled( other.mTiled )
+  , mMinLOD( other.mMinLOD )
+  , mMaxLOD( other.mMaxLOD )
   , mMaxImageWidth( other.mMaxImageWidth )
   , mMaxImageHeight( other.mMaxImageHeight )
   , mLayerMetadata( other.mLayerMetadata )
@@ -359,7 +364,7 @@ Qgis::RasterColorInterpretation QgsImageServerProvider::colorInterpretation( int
 
 Qgis::RasterInterfaceCapabilities QgsImageServerProvider::capabilities() const
 {
-  return Qgis::RasterInterfaceCapability::Size | Qgis::RasterInterfaceCapability::Identify | Qgis::RasterInterfaceCapability::IdentifyValue;
+  return mRasterCapabilities;
 }
 
 int QgsImageServerProvider::xSize() const
@@ -599,7 +604,7 @@ bool QgsImageServerProvider::readBlock( int bandNo, const QgsRectangle &viewExte
   if ( !mValid || width <= 0 || height <= 0 )
     return false;
 
-  QgsDataSourceUri dataSource( dataSourceUri() );
+  const QgsDataSourceUri dataSource( dataSourceUri() );
   QString url = dataSource.param( u"url"_s );
   if ( !dataSource.param( u"layer"_s ).isEmpty() )
   {
@@ -615,6 +620,63 @@ bool QgsImageServerProvider::readBlock( int bandNo, const QgsRectangle &viewExte
   {
     QgsDebugMsgLevel( u"draw request outside view extent."_s, 2 );
     return false;
+  }
+
+  const GDALDataType gdalType = QgsGdalUtils::gdalDataTypeFromQgisDataType( mDataType );
+  const int elementSize = GDALGetDataTypeSizeBytes( gdalType );
+  const std::size_t pixelCount = static_cast< std::size_t >( width ) * static_cast< std::size_t >( height );
+
+  // pre-fill the entire buffer with NoData (ie pad the exterior of the subrect containing the actual data from the service)
+  const bool hasNoData = mSrcHasNoDataValue.size() >= bandNo && mSrcHasNoDataValue.at( bandNo - 1 );
+  const double noDataVal = hasNoData ? mSrcNoDataValue.at( bandNo - 1 ) : 0.0;
+  switch ( mDataType )
+  {
+    case Qgis::DataType::Byte:
+      std::fill_n( static_cast<quint8 *>( data ), pixelCount, static_cast<quint8>( noDataVal ) );
+      break;
+    case Qgis::DataType::Int8:
+      std::fill_n( static_cast<qint8 *>( data ), pixelCount, static_cast<qint8>( noDataVal ) );
+      break;
+    case Qgis::DataType::UInt16:
+      std::fill_n( static_cast<quint16 *>( data ), pixelCount, static_cast<quint16>( noDataVal ) );
+      break;
+    case Qgis::DataType::Int16:
+      std::fill_n( static_cast<qint16 *>( data ), pixelCount, static_cast<qint16>( noDataVal ) );
+      break;
+    case Qgis::DataType::UInt32:
+      std::fill_n( static_cast<quint32 *>( data ), pixelCount, static_cast<quint32>( noDataVal ) );
+      break;
+    case Qgis::DataType::Int32:
+      std::fill_n( static_cast<qint32 *>( data ), pixelCount, static_cast<qint32>( noDataVal ) );
+      break;
+
+    case Qgis::DataType::Float32:
+    {
+      float fillVal = hasNoData ? static_cast<float>( noDataVal ) : std::numeric_limits<float>::quiet_NaN();
+      std::fill_n( static_cast<float *>( data ), pixelCount, fillVal );
+      break;
+    }
+    case Qgis::DataType::Float64:
+    {
+      double fillVal = hasNoData ? noDataVal : std::numeric_limits<double>::quiet_NaN();
+      std::fill_n( static_cast<double *>( data ), pixelCount, fillVal );
+      break;
+    }
+
+    case Qgis::DataType::UnknownDataType:
+    case Qgis::DataType::CInt16:
+    case Qgis::DataType::CInt32:
+    case Qgis::DataType::CFloat32:
+    case Qgis::DataType::CFloat64:
+    case Qgis::DataType::ARGB32:
+    case Qgis::DataType::ARGB32_Premultiplied:
+      memset( data, 0, static_cast<size_t>( pixelCount ) * elementSize );
+      break;
+  }
+
+  if ( mTiled )
+  {
+    return readTiledBlock( viewExtent, width, height, data, gdalType, elementSize, feedback );
   }
 
   QRect blockSubRectPixels( 0, 0, width, height ); // Hoisted and defaults to full size
@@ -708,57 +770,6 @@ bool QgsImageServerProvider::readBlock( int bandNo, const QgsRectangle &viewExte
     return false;
   }
 
-  const GDALDataType gdalType = QgsGdalUtils::gdalDataTypeFromQgisDataType( mDataType );
-  const int elementSize = GDALGetDataTypeSizeBytes( gdalType );
-  const std::size_t pixelCount = static_cast< std::size_t >( width ) * static_cast< std::size_t >( height );
-
-  // pre-fill the entire buffer with NoData (ie pad the exterior of the subrect containing the actual data from the service)
-  const bool hasNoData = mSrcHasNoDataValue.size() >= bandNo && mSrcHasNoDataValue.at( bandNo - 1 );
-  const double noDataVal = hasNoData ? mSrcNoDataValue.at( bandNo - 1 ) : 0.0;
-  switch ( mDataType )
-  {
-    case Qgis::DataType::Byte:
-      std::fill_n( static_cast<quint8 *>( data ), pixelCount, static_cast<quint8>( noDataVal ) );
-      break;
-    case Qgis::DataType::Int8:
-      std::fill_n( static_cast<qint8 *>( data ), pixelCount, static_cast<qint8>( noDataVal ) );
-      break;
-    case Qgis::DataType::UInt16:
-      std::fill_n( static_cast<quint16 *>( data ), pixelCount, static_cast<quint16>( noDataVal ) );
-      break;
-    case Qgis::DataType::Int16:
-      std::fill_n( static_cast<qint16 *>( data ), pixelCount, static_cast<qint16>( noDataVal ) );
-      break;
-    case Qgis::DataType::UInt32:
-      std::fill_n( static_cast<quint32 *>( data ), pixelCount, static_cast<quint32>( noDataVal ) );
-      break;
-    case Qgis::DataType::Int32:
-      std::fill_n( static_cast<qint32 *>( data ), pixelCount, static_cast<qint32>( noDataVal ) );
-      break;
-
-    case Qgis::DataType::Float32:
-    {
-      float fillVal = hasNoData ? static_cast<float>( noDataVal ) : std::numeric_limits<float>::quiet_NaN();
-      std::fill_n( static_cast<float *>( data ), pixelCount, fillVal );
-      break;
-    }
-    case Qgis::DataType::Float64:
-    {
-      double fillVal = hasNoData ? noDataVal : std::numeric_limits<double>::quiet_NaN();
-      std::fill_n( static_cast<double *>( data ), pixelCount, fillVal );
-      break;
-    }
-
-    case Qgis::DataType::UnknownDataType:
-    case Qgis::DataType::CInt16:
-    case Qgis::DataType::CInt32:
-    case Qgis::DataType::CFloat32:
-    case Qgis::DataType::CFloat64:
-    case Qgis::DataType::ARGB32:
-    case Qgis::DataType::ARGB32_Premultiplied:
-      memset( data, 0, static_cast<size_t>( pixelCount ) * elementSize );
-      break;
-  }
 
   if ( feedback && feedback->isCanceled() )
   {
@@ -793,6 +804,231 @@ bool QgsImageServerProvider::readBlock( int bandNo, const QgsRectangle &viewExte
   }
 
   return err == CE_None;
+}
+
+bool QgsImageServerProvider::readTiledBlock( const QgsRectangle &viewExtent, int width, int height, void *data, GDALDataType gdalType, int elementSize, QgsRasterBlockFeedback *feedback )
+{
+  const QgsDataSourceUri dataSource( dataSourceUri() );
+  const QString baseUrl = dataSource.param( u"url"_s );
+  const QString authcfg = dataSource.authConfigId();
+
+  const double targetResolution = viewExtent.width() / width;
+
+  // tile details
+  const QVariantMap tileInfo = mServiceInfo.value( u"tileInfo"_s ).toMap();
+  const int tileWidth = tileInfo[u"cols"_s].toInt();
+  const int tileHeight = tileInfo[u"rows"_s].toInt();
+  const QVariantMap origin = tileInfo[u"origin"_s].toMap();
+  const double originX = origin[u"x"_s].toDouble();
+  const double originY = origin[u"y"_s].toDouble();
+
+  // sort level of detail array by decreasing resolution, i.e. less detailed tiles first
+  QList<QVariant> lodEntries = tileInfo[u"lods"_s].toList();
+  if ( lodEntries.isEmpty() )
+    return false;
+
+  // sometimes the lods array contains NOT available levels, i.e. outside of the minLOD/maxLOD range!
+  // strip them out here
+  lodEntries.erase(
+    std::remove_if(
+      lodEntries.begin(),
+      lodEntries.end(),
+      [this]( const QVariant &lodEntry ) {
+        const int currentLevel = lodEntry.toMap()[u"level"_s].toInt();
+        return ( mMaxLOD >= 0 && currentLevel > mMaxLOD ) || ( mMinLOD >= 0 && currentLevel < mMinLOD );
+      }
+    ),
+    lodEntries.end()
+  );
+
+  if ( lodEntries.isEmpty() )
+    return false;
+  std::sort( lodEntries.begin(), lodEntries.end(), []( const QVariant &a, const QVariant &b ) { return a.toMap().value( u"resolution"_s ).toDouble() > b.toMap().value( u"resolution"_s ).toDouble(); } );
+
+  // pick appropriate tile level to match target resolution
+  // iterate through the lod array to find the first level (ie, the most course level)
+  // that satisfies the required resolution
+  int level = lodEntries.constLast().toMap().value( u"level"_s ).toInt();
+  double resolution = lodEntries.constLast().toMap().value( u"resolution"_s ).toDouble();
+  for ( const QVariant &lodEntry : std::as_const( lodEntries ) )
+  {
+    if ( lodEntry.toMap()[u"resolution"_s].toDouble() <= targetResolution )
+    {
+      level = lodEntry.toMap()[u"level"_s].toInt();
+      resolution = lodEntry.toMap()[u"resolution"_s].toDouble();
+      break;
+    }
+  }
+
+  // calculate required tile ranges
+  const int tileXStart = static_cast<int>( std::floor( ( viewExtent.xMinimum() - originX ) / ( tileWidth * resolution ) ) );
+  const int tileYStart = static_cast<int>( std::floor( ( originY - viewExtent.yMaximum() ) / ( tileHeight * resolution ) ) );
+  const int tileXEnd = static_cast<int>( std::ceil( ( viewExtent.xMaximum() - originX ) / ( tileWidth * resolution ) ) );
+  const int tileYEnd = static_cast<int>( std::ceil( ( originY - viewExtent.yMinimum() ) / ( tileHeight * resolution ) ) );
+
+  // build list of requested tiles
+  TileRequests requests;
+  int index = 0;
+  for ( int tileY = tileYStart; tileY <= tileYEnd; ++tileY )
+  {
+    for ( int tileX = tileXStart; tileX <= tileXEnd; ++tileX )
+    {
+      const QUrl url = QgsArcGisRestQueryUtils::parseUrl( QUrl( baseUrl + u"/tile/%1/%2/%3"_s.arg( level ).arg( tileY ).arg( tileX ) ) );
+      // calculate map extent for tile
+      const double tileXMin = originX + tileX * ( resolution * tileWidth );
+      const double tileXMax = tileXMin + ( resolution * tileWidth );
+      const double tileYMax = originY - tileY * ( resolution * tileHeight );
+      const double tileYMin = tileYMax - ( resolution * tileHeight );
+      const QgsRectangle mapExtent( tileXMin, tileYMin, tileXMax, tileYMax );
+      if ( viewExtent.intersects( mapExtent ) )
+      {
+        requests.push_back( TileRequest( url, index++, mapExtent ) );
+      }
+    }
+  }
+
+  QHash<int, QByteArray> tileData;
+  tileData.reserve( requests.size() );
+  if ( QThread::currentThread() == QApplication::instance()->thread() )
+  {
+    // running on main thread, use a blocking get to handle authcfg and SSL errors ok.
+    for ( const TileRequest &r : std::as_const( requests ) )
+    {
+      if ( feedback && feedback->isCanceled() )
+        break;
+
+      QNetworkRequest request( r.url );
+      QgsSetRequestInitiatorClass( request, u"QgsImageServerProvider"_s );
+      request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
+      request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
+      mRequestHeaders.updateNetworkRequest( request );
+      const QgsNetworkReplyContent reply = QgsNetworkAccessManager::instance()->blockingGet( request, authcfg, false, feedback );
+      if ( reply.error() == QNetworkReply::NoError )
+      {
+        tileData.insert( r.index, reply.content() );
+      }
+    }
+  }
+  else
+  {
+    // running on background thread, use tile download manager for efficient network handling
+    std::vector<std::unique_ptr<QgsTileDownloadManagerReply>> replies;
+    replies.reserve( requests.size() );
+    std::vector<TileRequest> activeRequests;
+    activeRequests.reserve( requests.size() );
+
+    // use a local event loop to loop until all required tiles are fetched. This is safe to do, we are in a background thread
+    QEventLoop loop;
+    if ( feedback )
+    {
+      QObject::connect( feedback, &QgsFeedback::canceled, &loop, &QEventLoop::quit );
+    }
+
+    int pendingReplies = 0;
+    auto onReplyFinished = [&pendingReplies, &loop] {
+      pendingReplies--;
+      if ( pendingReplies == 0 )
+        loop.quit();
+    };
+
+    for ( const TileRequest &r : std::as_const( requests ) )
+    {
+      QNetworkRequest request( r.url );
+      QgsSetRequestInitiatorClass( request, u"QgsImageServerProvider"_s );
+      request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
+      request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
+      mRequestHeaders.updateNetworkRequest( request );
+
+      if ( !authcfg.isEmpty() && !QgsApplication::authManager()->updateNetworkRequest( request, authcfg ) )
+        continue;
+
+      std::unique_ptr<QgsTileDownloadManagerReply> reply( QgsApplication::tileDownloadManager()->get( request ) );
+      QObject::connect( reply.get(), &QgsTileDownloadManagerReply::finished, &loop, onReplyFinished );
+      replies.emplace_back( std::move( reply ) );
+
+      activeRequests.push_back( r );
+      pendingReplies++;
+    }
+
+    if ( pendingReplies != 0 )
+    {
+      // loop till all replies are finished
+      loop.exec();
+
+      if ( !feedback || !feedback->isCanceled() )
+      {
+        for ( size_t i = 0; i < replies.size(); ++i )
+        {
+          if ( replies[i]->hasFinished() && replies[i]->error() == QNetworkReply::NoError )
+          {
+            tileData.insert( activeRequests[i].index, replies[i]->data() );
+          }
+        }
+      }
+    }
+  }
+
+  if ( tileData.isEmpty() || ( feedback && feedback->isCanceled() ) )
+    return false;
+
+  // got all tile data. Now we need to stitch the tiles together into a single raster block.
+  // we use GDAL to read tile data, as it may been compressed in eg LERC format
+
+  bool success = true;
+  for ( const TileRequest &req : std::as_const( requests ) )
+  {
+    if ( feedback && feedback->isCanceled() )
+      break;
+
+    auto tileDataIt = tileData.constFind( req.index );
+    if ( tileDataIt == tileData.constEnd() )
+    {
+      continue;
+    }
+    QByteArray rawTileData = tileDataIt.value();
+    if ( rawTileData.isEmpty() )
+    {
+      continue;
+    }
+
+    // use GDAL to read raw raster data, and handle eg lerc decompression
+    // first create in-memory dataset
+    const QString vsimemFilename = u"/vsimem/ims_tile_%1_%2"_s.arg( QUuid::createUuid().toString( QUuid::WithoutBraces ) ).arg( req.index );
+    VSIFCloseL( VSIFileFromMemBuffer( vsimemFilename.toUtf8().constData(), reinterpret_cast<GByte *>( rawTileData.data() ), rawTileData.size(), false ) );
+
+    // open the in-memory dataset
+    GDALDatasetH hDS = GDALOpen( vsimemFilename.toUtf8().constData(), GA_ReadOnly );
+    if ( hDS )
+    {
+      GDALRasterBandH hBand = GDALGetRasterBand( hDS, 1 );
+      if ( hBand )
+      {
+        // pixels from requested block covered by this tile
+        // (i.e. the "destination" rect)
+        const QRect blockPixelRect = QgsRasterBlock::subRect( viewExtent, width, height, req.mapExtent );
+        // pixels from tile that we need (tile may be partially outside of requested block extent)
+        // (i.e. the "source" rect)
+        const QRect tilePixelRect = QgsRasterBlock::subRect( req.mapExtent, GDALGetRasterXSize( hDS ), GDALGetRasterYSize( hDS ), req.mapExtent.intersect( viewExtent ) );
+
+        // copy tile data into block data
+        void *targetData = static_cast<GByte *>( data ) + ( static_cast<GSpacing>( blockPixelRect.y() ) * width + blockPixelRect.x() ) * elementSize;
+        GSpacing lineSpace = static_cast<GSpacing>( width ) * elementSize;
+        if ( GDALRasterIOEx( hBand, GF_Read, tilePixelRect.x(), tilePixelRect.y(), tilePixelRect.width(), tilePixelRect.height(), targetData, blockPixelRect.width(), blockPixelRect.height(), gdalType, elementSize, lineSpace, nullptr )
+             != CPLErr::CE_None )
+        {
+          success = false;
+        }
+      }
+      GDALClose( hDS );
+    }
+    else
+    {
+      success = false;
+    }
+    VSIUnlink( vsimemFilename.toUtf8().constData() );
+  }
+
+  return success;
 }
 
 bool QgsImageServerProvider::readNativeAttributeTable( QString *errorMessage )

--- a/src/providers/arcgisrest/qgsimageserverprovider.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovider.cpp
@@ -228,6 +228,18 @@ QgsImageServerProvider::QgsImageServerProvider( const QString &uri, const Provid
   if ( mLayerInfo.value( u"serviceDataType"_s ).toString().compare( "esriImageServiceDataTypeElevation"_L1, Qt::CaseInsensitive ) == 0 )
   {
     elevationProperties()->setContainsElevationData( true );
+    // set extreme Earth elevation limits for elevation data if service did not contain this information
+    if ( mCrs.isEarthCrs() )
+    {
+      for ( qsizetype i = mMinValues.count(); i < mBandCount; ++i )
+      {
+        mMinValues.append( -11500 );
+      }
+      for ( qsizetype i = mMaxValues.count(); i < mBandCount; ++i )
+      {
+        mMaxValues.append( 9000 );
+      }
+    }
   }
 
   QgsLayerMetadata::SpatialExtent spatialExtent;

--- a/src/providers/arcgisrest/qgsimageserverprovider.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovider.cpp
@@ -238,7 +238,9 @@ QgsImageServerProvider::QgsImageServerProvider( const QString &uri, const Provid
   mLayerMetadata.setExtent( metadataExtent );
   mLayerMetadata.setCrs( mCrs );
 
-  mTiled = mServiceInfo.value( u"singleFusedMapCache"_s ).toBool() || mCapabilities.testFlag( Qgis::ArcGisRestServiceCapability::TilesOnly );
+  mSupportsTiles = mServiceInfo.value( u"singleFusedMapCache"_s ).toBool() || mCapabilities.testFlag( Qgis::ArcGisRestServiceCapability::TilesOnly );
+  // default to tiled mode
+  mTiled = mSupportsTiles;
   if ( ( dataSource.param( u"tiled"_s ).toLower() == "false" || dataSource.param( u"tiled"_s ) == "0" ) && !mCapabilities.testFlag( Qgis::ArcGisRestServiceCapability::TilesOnly ) )
   {
     mTiled = false;
@@ -302,6 +304,7 @@ QgsImageServerProvider::QgsImageServerProvider( const QgsImageServerProvider &ot
   , mMeanValues( other.mMeanValues )
   , mStdevValues( other.mStdevValues )
   , mRequestHeaders( other.mRequestHeaders )
+  , mSupportsTiles( other.mSupportsTiles )
   , mTiled( other.mTiled )
   , mMinLOD( other.mMinLOD )
   , mMaxLOD( other.mMaxLOD )
@@ -1167,6 +1170,10 @@ QVariantMap QgsImageServerProviderMetadata::decodeUri( const QString &uri ) cons
   {
     components.insert( u"layer"_s, dsUri.param( u"layer"_s ) );
   }
+  if ( dsUri.param( u"tiled"_s ).compare( "false"_L1, Qt::CaseInsensitive ) == 0 || dsUri.param( u"tiled"_s ) == "0" )
+  {
+    components.insert( u"tiled"_s, false );
+  }
 
   return components;
 }
@@ -1190,6 +1197,10 @@ QString QgsImageServerProviderMetadata::encodeUri( const QVariantMap &parts ) co
   if ( !parts.value( u"format"_s ).toString().isEmpty() )
   {
     dsUri.setParam( u"format"_s, parts.value( u"format"_s ).toString() );
+  }
+  if ( parts.contains( u"tiled"_s ) && !parts.value( u"tiled"_s ).toBool() )
+  {
+    dsUri.setParam( u"tiled"_s, u"false"_s );
   }
   if ( !parts.value( u"layer"_s ).toString().isEmpty() )
   {

--- a/src/providers/arcgisrest/qgsimageserverprovider.h
+++ b/src/providers/arcgisrest/qgsimageserverprovider.h
@@ -40,6 +40,11 @@ class QgsImageServerProvider : public QgsRasterDataProvider
     QgsImageServerProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions, Qgis::DataProviderReadFlags flags = Qgis::DataProviderReadFlags() );
 
     explicit QgsImageServerProvider( const QgsImageServerProvider &other, const QgsDataProvider::ProviderOptions &providerOptions );
+
+
+    Qgis::ArcGisRestServiceCapabilities serviceCapabilities() const { return mCapabilities; }
+    bool supportsTiles() const { return mSupportsTiles; }
+
     Qgis::DataProviderFlags flags() const override;
     Qgis::RasterProviderCapabilities providerCapabilities() const override;
     /* Inherited from QgsDataProvider */
@@ -105,6 +110,7 @@ class QgsImageServerProvider : public QgsRasterDataProvider
     QImage mCachedImage;
     QgsRectangle mCachedImageExtent;
     QgsHttpHeaders mRequestHeaders;
+    bool mSupportsTiles = false;
     bool mTiled = false;
     int mMinLOD = -1;
     int mMaxLOD = -1;

--- a/src/providers/arcgisrest/qgsimageserverprovider.h
+++ b/src/providers/arcgisrest/qgsimageserverprovider.h
@@ -18,6 +18,8 @@
 #ifndef QGSIMAGESERVERPROVIDER_H
 #define QGSIMAGESERVERPROVIDER_H
 
+#include <gdal.h>
+
 #include "qgscoordinatereferencesystem.h"
 #include "qgshttpheaders.h"
 #include "qgsprovidermetadata.h"
@@ -79,10 +81,13 @@ class QgsImageServerProvider : public QgsRasterDataProvider
     bool readNativeAttributeTable( QString *errorMessage = nullptr ) override;
 
   private:
+    bool readTiledBlock( const QgsRectangle &viewExtent, int width, int height, void *data, GDALDataType gdalType, int elementSize, QgsRasterBlockFeedback *feedback );
+
     bool mValid = false;
     QVariantMap mServiceInfo;
     QVariantMap mLayerInfo;
     Qgis::ArcGisRestServiceCapabilities mCapabilities;
+    Qgis::RasterInterfaceCapabilities mRasterCapabilities;
     QgsCoordinateReferenceSystem mCrs;
     QgsRectangle mExtent;
     double mPixelSizeX = 1;
@@ -100,8 +105,9 @@ class QgsImageServerProvider : public QgsRasterDataProvider
     QImage mCachedImage;
     QgsRectangle mCachedImageExtent;
     QgsHttpHeaders mRequestHeaders;
-    int mTileReqNo = 0;
     bool mTiled = false;
+    int mMinLOD = -1;
+    int mMaxLOD = -1;
     int mMaxImageWidth = 4096;
     int mMaxImageHeight = 4096;
     QgsLayerMetadata mLayerMetadata;
@@ -115,6 +121,19 @@ class QgsImageServerProvider : public QgsRasterDataProvider
      * Resets cached image
     */
     void reloadProviderData() override;
+
+    struct TileRequest
+    {
+        TileRequest( const QUrl &u, int i, const QgsRectangle &mapExtent )
+          : url( u )
+          , index( i )
+          , mapExtent( mapExtent )
+        {}
+        QUrl url;
+        int index;
+        QgsRectangle mapExtent;
+    };
+    typedef QList<TileRequest> TileRequests;
 };
 
 class QgsImageServerProviderMetadata : public QgsProviderMetadata

--- a/src/providers/arcgisrest/qgsimageserverprovidergui.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovidergui.cpp
@@ -1,0 +1,72 @@
+/***************************************************************************
+  qgsimageserverprovidergui.cpp
+  --------------------------------------
+  Date                 : April 2026
+  Copyright            : (C) 2026 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsimageserverprovidergui.h"
+
+#include "qgsarcgisimageserversourcewidget.h"
+#include "qgsmaplayer.h"
+#include "qgsproviderguimetadata.h"
+#include "qgsprovidersourcewidgetprovider.h"
+#include "qgssourceselectprovider.h"
+
+#include <QString>
+
+using namespace Qt::StringLiterals;
+
+
+class QgsImageServerSourceWidgetProvider : public QgsProviderSourceWidgetProvider
+{
+  public:
+    QgsImageServerSourceWidgetProvider()
+      : QgsProviderSourceWidgetProvider()
+    {}
+    QString providerKey() const override { return u"arcgisimageserver"_s; }
+    bool canHandleLayer( QgsMapLayer *layer ) const override
+    {
+      if ( layer->providerType() != "arcgisimageserver"_L1 )
+        return false;
+
+      return true;
+    }
+    QgsProviderSourceWidget *createWidget( QgsMapLayer *layer, QWidget *parent = nullptr ) override
+    {
+      if ( layer->providerType() == "arcgisimageserver"_L1 )
+      {
+        return new QgsArcGisImageServerSourceWidget( layer, parent );
+      }
+      return nullptr;
+    }
+};
+
+
+QgsImageServerProviderGuiMetadata::QgsImageServerProviderGuiMetadata()
+  : QgsProviderGuiMetadata( u"arcgisimageserver"_s )
+{}
+
+
+QList<QgsProviderSourceWidgetProvider *> QgsImageServerProviderGuiMetadata::sourceWidgetProviders()
+{
+  QList<QgsProviderSourceWidgetProvider *> providers;
+  providers << new QgsImageServerSourceWidgetProvider();
+  return providers;
+}
+
+
+#ifndef HAVE_STATIC_PROVIDERS
+QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
+{
+  return new QgsImageServerProviderGuiMetadata();
+}
+#endif

--- a/src/providers/arcgisrest/qgsimageserverprovidergui.h
+++ b/src/providers/arcgisrest/qgsimageserverprovidergui.h
@@ -1,0 +1,24 @@
+/***************************************************************************
+  qgsimageserverprovidergui.h
+  --------------------------------------
+  Date                 : April 2026
+  Copyright            : (C) 2026 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsproviderguimetadata.h"
+
+class QgsImageServerProviderGuiMetadata : public QgsProviderGuiMetadata
+{
+  public:
+    QgsImageServerProviderGuiMetadata();
+
+    QList<QgsProviderSourceWidgetProvider *> sourceWidgetProviders() override;
+};

--- a/src/ui/qgsarcgisimageserversourcewidgetbase.ui
+++ b/src/ui/qgsarcgisimageserversourcewidgetbase.ui
@@ -26,7 +26,20 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="1" column="0" colspan="2">
+   <item row="0" column="1">
+    <widget class="QComboBox" name="mImageFormatCombo"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="lblReferer">
+     <property name="text">
+      <string>Referer</string>
+     </property>
+     <property name="buddy">
+      <cstring>mEditReferer</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
     <widget class="QGroupBox" name="mAuthGroupBox">
      <property name="title">
       <string>Authentication</string>
@@ -50,17 +63,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="lblReferer">
-     <property name="text">
-      <string>Referer</string>
-     </property>
-     <property name="buddy">
-      <cstring>mEditReferer</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QLineEdit" name="mEditReferer">
      <property name="toolTip">
       <string>Optional custom referer</string>
@@ -74,8 +77,12 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="mImageFormatCombo"/>
+   <item row="1" column="0" colspan="2">
+    <widget class="QCheckBox" name="mUseTilesCheckBox">
+     <property name="text">
+      <string>Retrieve data via tiles</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/tests/src/python/test_provider_imageserver.py
+++ b/tests/src/python/test_provider_imageserver.py
@@ -725,7 +725,7 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
  "maxRecordCount": 1000,
  "maxDownloadImageCount": 20,
  "maxMosaicImageCount": 20,
- "singleFusedMapCache": true,
+ "singleFusedMapCache": false,
  "tileInfo": {
   "rows": 256,
   "cols": 256,
@@ -1343,7 +1343,7 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
   "sortField" : "",
   "sortValue" : null,
   "sortAscending" : true,
-  "singleFusedMapCache" : true,
+  "singleFusedMapCache" : false,
   "tileInfo" : {
     "rows" : 256,
     "cols" : 256,
@@ -1862,6 +1862,170 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
                 [6, 31, 106587346.0, 179, 174, 163, "Barren Land"],
             ],
         )
+
+    def test_fetch_block_tiled_one_tile(self):
+        """
+        Test fetching data from a tiled service, one tile required only
+        """
+        endpoint = self.basetestpath + "/fetch_tiled_fake_qgis_http_endpoint"
+
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""{
+  "currentVersion": 10.91,
+  "pixelType": "U16",
+  "capabilities": "Image",
+  "singleFusedMapCache": true,
+  "serviceDataType": "esriImageServiceDataTypeElevation",
+  "minLOD": 0,
+  "maxLOD": 0,
+  "fullExtent": {
+    "xmin": 0,
+    "ymin": 0,
+    "xmax": 10,
+    "ymax": 10,
+    "spatialReference": {"wkid": 4326}
+  },
+  "bandCount": 1,
+  "type": "ImageServer",
+  "tileInfo": {
+    "rows": 2,
+    "cols": 2,
+    "format": "TIFF",
+    "origin": {"x": 0, "y": 10},
+    "spatialReference": {"wkid": 4326},
+    "lods": [
+      {"level": 0, "resolution": 5.0, "scale": 10000}
+    ]
+  }
+}"""
+            )
+
+        # 2x2 TIFF for tile at /tile/0/0/0
+        mem_ds = gdal.GetDriverByName("MEM").Create("", 2, 2, 1, gdal.GDT_UInt16)
+        mem_ds.GetRasterBand(1).WriteRaster(
+            0, 0, 2, 2, struct.pack("H" * 4, 11, 22, 33, 44)
+        )
+        gdal.GetDriverByName("GTiff").CreateCopy("/vsimem/test_tile.tif", mem_ds)
+        vsi_file = gdal.VSIFOpenL("/vsimem/test_tile.tif", "rb")
+        gdal.VSIFSeekL(vsi_file, 0, 2)
+        size = gdal.VSIFTellL(vsi_file)
+        gdal.VSIFSeekL(vsi_file, 0, 0)
+        tiff_blob = gdal.VSIFReadL(1, size, vsi_file)
+        gdal.VSIFCloseL(vsi_file)
+        gdal.Unlink("/vsimem/test_tile.tif")
+
+        with open(self.sanitize_local_url(endpoint, "/tile/0/0/0"), "wb") as f:
+            f.write(tiff_blob)
+
+        rl = QgsRasterLayer(
+            "url='http://" + endpoint + "'", "test", "arcgisimageserver"
+        )
+        self.assertTrue(rl.isValid())
+
+        block = rl.dataProvider().block(1, QgsRectangle(0, 0, 10, 10), 2, 2)
+        self.assertTrue(block.isValid())
+
+        self.assertEqual(block.value(0, 0), 11)
+        self.assertEqual(block.value(0, 1), 22)
+        self.assertEqual(block.value(1, 0), 33)
+        self.assertEqual(block.value(1, 1), 44)
+
+    def test_fetch_block_tiled_multiple(self):
+        """
+        Test fetching a block from a tiled service that requires downloading
+        and stitching multiple tiles together
+        """
+        endpoint = self.basetestpath + "/fetch_tiled_multi_fake_qgis_http_endpoint"
+
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""{
+  "currentVersion": 10.91,
+  "pixelType": "U16",
+  "capabilities": "Image",
+  "singleFusedMapCache": true,
+  "serviceDataType": "esriImageServiceDataTypeElevation",
+  "minLOD": 0,
+  "maxLOD": 0,
+  "fullExtent": {
+    "xmin": 0,
+    "ymin": 0,
+    "xmax": 20,
+    "ymax": 20,
+    "spatialReference": {"wkid": 4326}
+  },
+  "bandCount": 1,
+  "type": "ImageServer",
+  "tileInfo": {
+    "rows": 2,
+    "cols": 2,
+    "format": "TIFF",
+    "origin": {"x": 0, "y": 20},
+    "spatialReference": {"wkid": 4326},
+    "lods": [
+      {"level": 0, "resolution": 5.0, "scale": 10000}
+    ]
+  }
+}"""
+            )
+
+        def create_tile(vals):
+            mem_ds = gdal.GetDriverByName("MEM").Create("", 2, 2, 1, gdal.GDT_UInt16)
+            mem_ds.GetRasterBand(1).WriteRaster(0, 0, 2, 2, struct.pack("H" * 4, *vals))
+            gdal.GetDriverByName("GTiff").CreateCopy("/vsimem/test_tile.tif", mem_ds)
+            vsi_file = gdal.VSIFOpenL("/vsimem/test_tile.tif", "rb")
+            gdal.VSIFSeekL(vsi_file, 0, 2)
+            size = gdal.VSIFTellL(vsi_file)
+            gdal.VSIFSeekL(vsi_file, 0, 0)
+            blob = gdal.VSIFReadL(1, size, vsi_file)
+            gdal.VSIFCloseL(vsi_file)
+            gdal.Unlink("/vsimem/test_tile.tif")
+            return blob
+
+        # mock the 4 tiles required to build the full 20x20 extent
+        with open(
+            self.sanitize_local_url(endpoint, "/tile/0/0/0"), "wb"
+        ) as f:  # Top-Left
+            f.write(create_tile([1, 2, 3, 4]))
+        with open(
+            self.sanitize_local_url(endpoint, "/tile/0/0/1"), "wb"
+        ) as f:  # Top-Right
+            f.write(create_tile([5, 6, 7, 8]))
+        with open(
+            self.sanitize_local_url(endpoint, "/tile/0/1/0"), "wb"
+        ) as f:  # Bottom-Left
+            f.write(create_tile([9, 10, 11, 12]))
+        with open(
+            self.sanitize_local_url(endpoint, "/tile/0/1/1"), "wb"
+        ) as f:  # Bottom-Right
+            f.write(create_tile([13, 14, 15, 16]))
+
+        rl = QgsRasterLayer(
+            "url='http://" + endpoint + "'", "test", "arcgisimageserver"
+        )
+        self.assertTrue(rl.isValid())
+
+        block = rl.dataProvider().block(
+            1, QgsRectangle(0.001, 0.001, 19.999, 19.999), 4, 4
+        )
+        self.assertTrue(block.isValid())
+        self.assertEqual(block.value(0, 0), 1)
+        self.assertEqual(block.value(0, 1), 2)
+        self.assertEqual(block.value(0, 2), 5)
+        self.assertEqual(block.value(0, 3), 6)
+        self.assertEqual(block.value(1, 0), 3)
+        self.assertEqual(block.value(1, 1), 4)
+        self.assertEqual(block.value(1, 2), 7)
+        self.assertEqual(block.value(1, 3), 8)
+        self.assertEqual(block.value(2, 0), 9)
+        self.assertEqual(block.value(2, 1), 10)
+        self.assertEqual(block.value(2, 2), 13)
+        self.assertEqual(block.value(2, 3), 14)
+        self.assertEqual(block.value(3, 0), 11)
+        self.assertEqual(block.value(3, 1), 12)
+        self.assertEqual(block.value(3, 2), 15)
+        self.assertEqual(block.value(3, 3), 16)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Adds support for tiled image servers. This is beneficial for some services, where the tiled data is much faster to retrieve then exported images. It also means we support services which ONLY allow tiled requests, eg https://tiles.arcgis.com/tiles/goZLUACRDSDrf4xu/arcgis/rest/services/grid_1m_2021/ImageServer 

Uses QgsTileDownloadManagerReply for responsive tile fetching

Funded by République et canton de Genève


## AI tool usage

 - [x] AI tool(s) Gemini was used to help with unit tests, and for logic for GDAL based stitching of raw tile data. This has all been carefully double checked by hand.