### PR TITLE
Last simple settings migration in src/core (6)

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -4661,6 +4661,23 @@ Qgis.CrsWktVariant.__doc__ = """Coordinate reference system WKT formatting varia
 # --
 Qgis.CrsWktVariant.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.UnknownLayerCrsBehavior.NoAction.__doc__ = "Take no action and leave as unknown CRS"
+Qgis.UnknownLayerCrsBehavior.PromptUserForCrs.__doc__ = "User is prompted for a CRS choice"
+Qgis.UnknownLayerCrsBehavior.UseProjectCrs.__doc__ = "Copy the current project's CRS"
+Qgis.UnknownLayerCrsBehavior.UseDefaultCrs.__doc__ = "Use the default layer CRS set via QGIS options"
+Qgis.UnknownLayerCrsBehavior.__doc__ = """Behavior to use when encountering a layer with an unknown (invalid) CRS.
+
+.. versionadded:: 4.2
+
+* ``NoAction``: Take no action and leave as unknown CRS
+* ``PromptUserForCrs``: User is prompted for a CRS choice
+* ``UseProjectCrs``: Copy the current project's CRS
+* ``UseDefaultCrs``: Use the default layer CRS set via QGIS options
+
+"""
+# --
+Qgis.UnknownLayerCrsBehavior.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.Axis.X.__doc__ = "X-axis"
 Qgis.Axis.Y.__doc__ = "Y-axis"
 Qgis.Axis.Z.__doc__ = "Z-axis"

--- a/python/PyQt6/core/auto_generated/browser/qgsdirectoryitem.sip.in
+++ b/python/PyQt6/core/auto_generated/browser/qgsdirectoryitem.sip.in
@@ -223,6 +223,7 @@ Browser parameter widget implementation for directory items.
 #include "qgsdirectoryitem.h"
 %End
   public:
+
     QgsDirectoryParamWidget( const QString &path, QWidget *parent /TransferThis/ = 0 );
 
   protected:

--- a/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
+++ b/python/PyQt6/core/auto_generated/project/qgsproject.sip.in
@@ -37,6 +37,7 @@ reference open within the main QGIS application.
 %End
   public:
 
+
     enum class DataDefinedServerProperty /BaseType=IntEnum/
     {
       NoProperty,

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -1504,6 +1504,14 @@ The development version
       PreferredGdal,
     };
 
+    enum class UnknownLayerCrsBehavior /BaseType=IntEnum/
+    {
+      NoAction,
+      PromptUserForCrs,
+      UseProjectCrs,
+      UseDefaultCrs,
+    };
+
     enum class Axis /BaseType=IntEnum/
     {
       X,

--- a/python/PyQt6/core/auto_generated/qgsapplication.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsapplication.sip.in
@@ -458,7 +458,7 @@ Returns the QGIS platform name, e.g., "desktop", "server",
 Returns the QGIS application full name.
 
 It can be defined by the environment variable QGIS_APPLICATION_FULL_NAME
-or the /qgis/application_full_name in the QGIS config file.
+or the app/full-name setting in the QGIS config file.
 
 By default it is equal to :py:func:`~QgsApplication.applicationName`+'
 '+:py:func:`~QgsApplication.platform`

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -115,13 +115,6 @@ projections\defaultProjectCrs=EPSG:4326
 # "UsePresetCrs" - always use a preset CRS, see projections\defaultProjectCrs
 projections\newProjectCrsBehavior=UseCrsOfFirstLayerAdded
 
-# Specifies the behavior when adding a layer with unknown/invalid CRS to a project
-# "NoAction" - take no action and leave as unknown CRS
-# "PromptUserForCrs" - user is prompted for a CRS choice
-# "UseProjectCrs" - copy the current project's CRS
-# "UseDefaultCrs" - use the default layer CRS set via QGIS options
-projections\unknownCrsBehavior=NoAction
-
 # If the inherent inaccuracy in a selected CRS exceeds this threshold value (in meters),
 # a warning message will be shown to the user advising them to select an alternative
 # CRS if higher positional accuracy is required
@@ -224,6 +217,15 @@ anonymize-new=false
 # Whether or not to anonymize projects when saving
 # If set to true, then username information will not be stored in saved projects
 anonymize-saved=false
+
+[crs]
+
+# Specifies the behavior when adding a layer with unknown/invalid CRS to a project
+# "NoAction" - take no action and leave as unknown CRS
+# "PromptUserForCrs" - user is prompted for a CRS choice
+# "UseProjectCrs" - copy the current project's CRS
+# "UseDefaultCrs" - use the default layer CRS set via QGIS options
+unknown-crs-behavior=NoAction
 
 [colors]
 # These colors are used in logs.

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -178,15 +178,6 @@ leapSecondsCorrection=18
 
 [core]
 
-# Whether or not to anonymize newly created projects
-# If set to true, then project metadata items like AUTHOR and CREATION DATE
-# will not be automatically populated when a new project is created.
-projects\anonymize_new_projects=false
-
-# Whether or not to anonymize projects when saving
-# If set to true, then username information will not be stored in saved projects
-projects\anonymize_saved_projects=false
-
 # News feed settings
 # Set to true to disable the QGIS news feed on the welcome page
 NewsFeed\http00008000\disabled=false
@@ -219,6 +210,17 @@ rendering\label_candidates_limit_lines=0
 # time, at the expense of worse label placement or potentially missing map labels. A value of 0 indicates
 # that no limit is present.
 rendering\label_candidates_limit_polygons=0
+
+[project]
+
+# Whether or not to anonymize newly created projects
+# If set to true, then project metadata items like AUTHOR and CREATION DATE
+# will not be automatically populated when a new project is created.
+anonymize-new=false
+
+# Whether or not to anonymize projects when saving
+# If set to true, then username information will not be stored in saved projects
+anonymize-saved=false
 
 [colors]
 # These colors are used in logs.

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -178,6 +178,9 @@ leapSecondsCorrection=18
 
 [core]
 
+# If true, new projects are using relative paths. If false, new projects default to absolute paths.
+default-project-paths-relative=true
+
 # News feed settings
 # Set to true to disable the QGIS news feed on the welcome page
 NewsFeed\http00008000\disabled=false

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -650,7 +650,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mAreaUnitsComboBox->addItem( tr( "Square Degrees" ), static_cast<int>( Qgis::AreaUnit::SquareDegrees ) );
   mAreaUnitsComboBox->addItem( tr( "Map Units" ), static_cast<int>( Qgis::AreaUnit::Unknown ) );
 
-  Qgis::AreaUnit areaUnits = QgsUnitTypes::decodeAreaUnit( mSettings->value( u"/qgis/measure/areaunits"_s ).toString(), &ok );
+  Qgis::AreaUnit areaUnits = QgsUnitTypes::decodeAreaUnit( QgsSettingsRegistryCore::settingsMeasureAreaUnits->value(), &ok );
   if ( !ok )
     areaUnits = Qgis::AreaUnit::SquareMeters;
   mAreaUnitsComboBox->setCurrentIndex( mAreaUnitsComboBox->findData( static_cast<int>( areaUnits ) ) );
@@ -1747,7 +1747,7 @@ void QgsOptions::saveOptions()
   QgsSettingsRegistryCore::settingsMeasureDisplayUnits->setValue( QgsUnitTypes::encodeUnit( distanceUnit ) );
 
   Qgis::AreaUnit areaUnit = static_cast<Qgis::AreaUnit>( mAreaUnitsComboBox->currentData().toInt() );
-  mSettings->setValue( u"/qgis/measure/areaunits"_s, QgsUnitTypes::encodeUnit( areaUnit ) );
+  QgsSettingsRegistryCore::settingsMeasureAreaUnits->setValue( QgsUnitTypes::encodeUnit( areaUnit ) );
 
   Qgis::AngleUnit angleUnit = static_cast<Qgis::AngleUnit>( mAngleUnitsComboBox->currentData().toInt() );
   mSettings->setValue( u"/qgis/measure/angleunits"_s, QgsUnitTypes::encodeUnit( angleUnit ) );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -855,9 +855,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   mDefaultPathsComboBox->addItem( tr( "Absolute" ), static_cast<int>( Qgis::FilePathType::Absolute ) );
   mDefaultPathsComboBox->addItem( tr( "Relative" ), static_cast<int>( Qgis::FilePathType::Relative ) );
-  mDefaultPathsComboBox->setCurrentIndex( mDefaultPathsComboBox->findData(
-    static_cast<int>( mSettings->value( u"/qgis/defaultProjectPathsRelative"_s, QVariant( true ) ).toBool() ? Qgis::FilePathType::Relative : Qgis::FilePathType::Absolute )
-  ) );
+  mDefaultPathsComboBox->setCurrentIndex(
+    mDefaultPathsComboBox->findData( static_cast<int>( QgsProject::settingsDefaultProjectPathsRelative->value() ? Qgis::FilePathType::Relative : Qgis::FilePathType::Absolute ) )
+  );
 
   Qgis::ProjectFileFormat defaultProjectFileFormat = mSettings->enumValue( u"/qgis/defaultProjectFileFormat"_s, Qgis::ProjectFileFormat::Qgz );
   mFileFormatQgzButton->setChecked( defaultProjectFileFormat == Qgis::ProjectFileFormat::Qgz );
@@ -1702,7 +1702,7 @@ void QgsOptions::saveOptions()
   }
   QgsSettingsRegistryCore::settingsCodeExecutionUntrustedProjectsFolders->setValue( untrustedProjectsFoldersList );
 
-  mSettings->setValue( u"/qgis/defaultProjectPathsRelative"_s, static_cast<Qgis::FilePathType>( mDefaultPathsComboBox->currentData().toInt() ) == Qgis::FilePathType::Relative );
+  QgsProject::settingsDefaultProjectPathsRelative->setValue( static_cast<Qgis::FilePathType>( mDefaultPathsComboBox->currentData().toInt() ) == Qgis::FilePathType::Relative );
 
   mSettings->setEnumValue( u"/qgis/defaultProjectFileFormat"_s, mFileFormatQgsButton->isChecked() ? Qgis::ProjectFileFormat::Qgs : Qgis::ProjectFileFormat::Qgz );
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -575,7 +575,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
       break;
   }
 
-  QString myLayerDefaultCrs = mSettings->value( u"/Projections/layerDefaultCrs"_s, Qgis::geographicCrsAuthId() ).toString();
+  QString myLayerDefaultCrs = QgsSettingsRegistryCore::settingsLayerDefaultCrs->value();
   mLayerDefaultCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( myLayerDefaultCrs );
   leLayerGlobalCrs->setCrs( mLayerDefaultCrs );
 
@@ -1733,7 +1733,7 @@ void QgsOptions::saveOptions()
     QgsSettingsRegistryCore::settingsUnknownCrsBehavior->setValue( Qgis::UnknownLayerCrsBehavior::UseDefaultCrs );
   }
 
-  mSettings->setValue( u"/Projections/layerDefaultCrs"_s, mLayerDefaultCrs.authid() );
+  QgsSettingsRegistryCore::settingsLayerDefaultCrs->setValue( mLayerDefaultCrs.authid() );
   mSettings->setValue( u"/projections/defaultProjectCrs"_s, leProjectGlobalCrs->crs().authid(), QgsSettings::App );
   mSettings->setEnumValue( u"/projections/newProjectCrsBehavior"_s, radProjectUseCrsOfFirstLayer->isChecked() ? QgsGui::UseCrsOfFirstLayerAdded : QgsGui::UsePresetCrs, QgsSettings::App );
   mSettings->setValue( u"/projections/promptWhenMultipleTransformsExist"_s, mShowDatumTransformDialogCheckBox->isChecked(), QgsSettings::App );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -558,19 +558,19 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mCheckMonitorDirectories->setChecked( QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->value() );
 
   //set the default projection behavior radio buttons
-  const QgsOptions::UnknownLayerCrsBehavior mode = QgsSettings().enumValue( u"/projections/unknownCrsBehavior"_s, QgsOptions::UnknownLayerCrsBehavior::NoAction, QgsSettings::App );
+  const Qgis::UnknownLayerCrsBehavior mode = QgsSettingsRegistryCore::settingsUnknownCrsBehavior->value();
   switch ( mode )
   {
-    case NoAction:
+    case Qgis::UnknownLayerCrsBehavior::NoAction:
       radCrsNoAction->setChecked( true );
       break;
-    case PromptUserForCrs:
+    case Qgis::UnknownLayerCrsBehavior::PromptUserForCrs:
       radPromptForProjection->setChecked( true );
       break;
-    case UseProjectCrs:
+    case Qgis::UnknownLayerCrsBehavior::UseProjectCrs:
       radUseProjectProjection->setChecked( true );
       break;
-    case UseDefaultCrs:
+    case Qgis::UnknownLayerCrsBehavior::UseDefaultCrs:
       radUseGlobalProjection->setChecked( true );
       break;
   }
@@ -1718,19 +1718,19 @@ void QgsOptions::saveOptions()
   //projection defined...
   if ( radPromptForProjection->isChecked() )
   {
-    mSettings->setEnumValue( u"/projections/unknownCrsBehavior"_s, QgsOptions::UnknownLayerCrsBehavior::PromptUserForCrs, QgsSettings::App );
+    QgsSettingsRegistryCore::settingsUnknownCrsBehavior->setValue( Qgis::UnknownLayerCrsBehavior::PromptUserForCrs );
   }
   else if ( radUseProjectProjection->isChecked() )
   {
-    mSettings->setEnumValue( u"/projections/unknownCrsBehavior"_s, QgsOptions::UnknownLayerCrsBehavior::UseProjectCrs, QgsSettings::App );
+    QgsSettingsRegistryCore::settingsUnknownCrsBehavior->setValue( Qgis::UnknownLayerCrsBehavior::UseProjectCrs );
   }
   else if ( radCrsNoAction->isChecked() )
   {
-    mSettings->setEnumValue( u"/projections/unknownCrsBehavior"_s, QgsOptions::UnknownLayerCrsBehavior::NoAction, QgsSettings::App );
+    QgsSettingsRegistryCore::settingsUnknownCrsBehavior->setValue( Qgis::UnknownLayerCrsBehavior::NoAction );
   }
   else
   {
-    mSettings->setEnumValue( u"/projections/unknownCrsBehavior"_s, QgsOptions::UnknownLayerCrsBehavior::UseDefaultCrs, QgsSettings::App );
+    QgsSettingsRegistryCore::settingsUnknownCrsBehavior->setValue( Qgis::UnknownLayerCrsBehavior::UseDefaultCrs );
   }
 
   mSettings->setValue( u"/Projections/layerDefaultCrs"_s, mLayerDefaultCrs.authid() );

--- a/src/app/options/qgsoptions.h
+++ b/src/app/options/qgsoptions.h
@@ -46,20 +46,6 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     Q_OBJECT
   public:
     /**
-     * Behavior to use when encountering a layer with an unknown CRS
-     * \since QGIS 3.10
-     */
-    enum UnknownLayerCrsBehavior
-    {
-      NoAction = 0,         //!< Take no action and leave as unknown CRS
-      PromptUserForCrs = 1, //!< User is prompted for a CRS choice
-      UseProjectCrs = 2,    //!< Copy the current project's CRS
-      UseDefaultCrs = 3,    //!< Use the default layer CRS set via QGIS options
-    };
-    Q_ENUM( UnknownLayerCrsBehavior )
-
-
-    /**
      * Constructor
      * \param parent Parent widget (usually a QgisApp)
      * \param name name for the widget

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -653,18 +653,18 @@ static QgsMessageOutput *messageOutputViewer_()
 
 static void customSrsValidation_( QgsCoordinateReferenceSystem &srs )
 {
-  const QgsOptions::UnknownLayerCrsBehavior mode = QgsSettings().enumValue( u"/projections/unknownCrsBehavior"_s, QgsOptions::UnknownLayerCrsBehavior::NoAction, QgsSettings::App );
+  const Qgis::UnknownLayerCrsBehavior mode = QgsSettingsRegistryCore::settingsUnknownCrsBehavior->value();
   switch ( mode )
   {
-    case QgsOptions::UnknownLayerCrsBehavior::NoAction:
+    case Qgis::UnknownLayerCrsBehavior::NoAction:
       return;
 
-    case QgsOptions::UnknownLayerCrsBehavior::UseDefaultCrs:
+    case Qgis::UnknownLayerCrsBehavior::UseDefaultCrs:
       srs.createFromOgcWmsCrs( QgsSettings().value( u"Projections/layerDefaultCrs"_s, Qgis::geographicCrsAuthId() ).toString() );
       break;
 
-    case QgsOptions::UnknownLayerCrsBehavior::PromptUserForCrs:
-    case QgsOptions::UnknownLayerCrsBehavior::UseProjectCrs:
+    case Qgis::UnknownLayerCrsBehavior::PromptUserForCrs:
+    case Qgis::UnknownLayerCrsBehavior::UseProjectCrs:
       // can't take any action immediately for these -- we may be in a background thread
       break;
   }
@@ -910,13 +910,13 @@ void QgisApp::validateCrs( QgsCoordinateReferenceSystem &srs )
 {
   static QString sAuthId = QString();
 
-  const QgsOptions::UnknownLayerCrsBehavior mode = QgsSettings().enumValue( u"/projections/unknownCrsBehavior"_s, QgsOptions::UnknownLayerCrsBehavior::NoAction, QgsSettings::App );
+  const Qgis::UnknownLayerCrsBehavior mode = QgsSettingsRegistryCore::settingsUnknownCrsBehavior->value();
   switch ( mode )
   {
-    case QgsOptions::UnknownLayerCrsBehavior::NoAction:
+    case Qgis::UnknownLayerCrsBehavior::NoAction:
       break;
 
-    case QgsOptions::UnknownLayerCrsBehavior::UseDefaultCrs:
+    case Qgis::UnknownLayerCrsBehavior::UseDefaultCrs:
     {
       srs.createFromOgcWmsCrs( QgsSettings().value( u"Projections/layerDefaultCrs"_s, Qgis::geographicCrsAuthId() ).toString() );
       sAuthId = srs.authid();
@@ -924,7 +924,7 @@ void QgisApp::validateCrs( QgsCoordinateReferenceSystem &srs )
       break;
     }
 
-    case QgsOptions::UnknownLayerCrsBehavior::PromptUserForCrs:
+    case Qgis::UnknownLayerCrsBehavior::PromptUserForCrs:
     {
       // \note this class is not a descendent of QWidget so we can't pass
       // it in the ctor of the layer projection selector
@@ -964,7 +964,7 @@ void QgisApp::validateCrs( QgsCoordinateReferenceSystem &srs )
       break;
     }
 
-    case QgsOptions::UnknownLayerCrsBehavior::UseProjectCrs:
+    case Qgis::UnknownLayerCrsBehavior::UseProjectCrs:
     {
       // XXX TODO: Change project to store selected CS as 'projectCRS' not 'selectedWkt'
       srs = QgsProject::instance()->crs();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -660,7 +660,7 @@ static void customSrsValidation_( QgsCoordinateReferenceSystem &srs )
       return;
 
     case Qgis::UnknownLayerCrsBehavior::UseDefaultCrs:
-      srs.createFromOgcWmsCrs( QgsSettings().value( u"Projections/layerDefaultCrs"_s, Qgis::geographicCrsAuthId() ).toString() );
+      srs.createFromOgcWmsCrs( QgsSettingsRegistryCore::settingsLayerDefaultCrs->value() );
       break;
 
     case Qgis::UnknownLayerCrsBehavior::PromptUserForCrs:
@@ -918,7 +918,7 @@ void QgisApp::validateCrs( QgsCoordinateReferenceSystem &srs )
 
     case Qgis::UnknownLayerCrsBehavior::UseDefaultCrs:
     {
-      srs.createFromOgcWmsCrs( QgsSettings().value( u"Projections/layerDefaultCrs"_s, Qgis::geographicCrsAuthId() ).toString() );
+      srs.createFromOgcWmsCrs( QgsSettingsRegistryCore::settingsLayerDefaultCrs->value() );
       sAuthId = srs.authid();
       visibleMessageBar()->pushMessage( tr( "CRS was undefined" ), tr( "defaulting to CRS %1" ).arg( srs.userFriendlyIdentifier() ), Qgis::MessageLevel::Warning );
       break;

--- a/src/core/browser/qgsdirectoryitem.cpp
+++ b/src/core/browser/qgsdirectoryitem.cpp
@@ -51,6 +51,9 @@ const QgsSettingsEntryStringList *QgsDirectoryItem::settingsAlwaysMonitorItemUri
 const QgsSettingsEntryInteger *QgsDirectoryItem::settingsMinScanInterval
   = new QgsSettingsEntryInteger( u"minscaninterval"_s, QgsSettingsTree::sTreeBrowser, 10000, u"Minimum interval (in milliseconds) between two successive scans of a directory in the browser."_s );
 
+const QgsSettingsEntryVariant *QgsDirectoryParamWidget::settingsDirectoryHiddenColumns
+  = new QgsSettingsEntryVariant( u"directory-hidden-columns"_s, QgsSettingsTree::sTreeBrowser, QVariant( QVariantList() ), u"Indices of columns hidden in the directory browser parameter widget"_s );
+
 //
 // QgsDirectoryItem
 //
@@ -613,8 +616,7 @@ QgsDirectoryParamWidget::QgsDirectoryParamWidget( const QString &path, QWidget *
   addTopLevelItems( items );
 
   // hide columns that are not requested
-  const QgsSettings settings;
-  const QList<QVariant> lst = settings.value( u"dataitem/directoryHiddenColumns"_s ).toList();
+  const QList<QVariant> lst = settingsDirectoryHiddenColumns->value().toList();
   for ( const QVariant &colVariant : lst )
   {
     setColumnHidden( colVariant.toInt(), true );
@@ -652,14 +654,13 @@ void QgsDirectoryParamWidget::showHideColumn()
   setColumnHidden( columnIndex, !isColumnHidden( columnIndex ) );
 
   // save in settings
-  QgsSettings settings;
   QList<QVariant> lst;
   for ( int i = 0; i < columnCount(); i++ )
   {
     if ( isColumnHidden( i ) )
       lst.append( QVariant( i ) );
   }
-  settings.setValue( u"dataitem/directoryHiddenColumns"_s, lst );
+  settingsDirectoryHiddenColumns->setValue( lst );
 }
 
 //

--- a/src/core/browser/qgsdirectoryitem.h
+++ b/src/core/browser/qgsdirectoryitem.h
@@ -32,6 +32,7 @@ class QMouseEvent;
 class QgsSettingsEntryBool;
 class QgsSettingsEntryInteger;
 class QgsSettingsEntryStringList;
+class QgsSettingsEntryVariant;
 
 /**
  * \ingroup core
@@ -259,6 +260,8 @@ class CORE_EXPORT QgsDirectoryParamWidget : public QTreeWidget
     Q_OBJECT
 
   public:
+    static const QgsSettingsEntryVariant *settingsDirectoryHiddenColumns SIP_SKIP;
+
     QgsDirectoryParamWidget( const QString &path, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
   protected:

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -117,6 +117,8 @@ const QgsSettingsEntryBool *QgsProject::settingsAnonymizeNewProjects = new QgsSe
 
 const QgsSettingsEntryBool *QgsProject::settingsAnonymizeSavedProjects = new QgsSettingsEntryBool( u"anonymize-saved"_s, QgsSettingsTree::sTreeProject, false );
 
+const QgsSettingsEntryBool *QgsProject::settingsDefaultProjectPathsRelative = new QgsSettingsEntryBool( u"default-project-paths-relative"_s, QgsSettingsTree::sTreeCore, true );
+
 
 /**
  * Takes the given scope and key and convert them to a string list of key
@@ -1344,7 +1346,7 @@ void QgsProject::clear()
   writeEntry( u"PositionPrecision"_s, u"/Automatic"_s, true );
   writeEntry( u"PositionPrecision"_s, u"/DecimalPlaces"_s, 2 );
 
-  const bool defaultRelativePaths = mSettings.value( u"/qgis/defaultProjectPathsRelative"_s, true ).toBool();
+  const bool defaultRelativePaths = settingsDefaultProjectPathsRelative->value();
   setFilePathStorage( defaultRelativePaths ? Qgis::FilePathType::Relative : Qgis::FilePathType::Absolute );
 
   setBackgroundColor( QgsSettingsRegistryCore::settingsDefaultCanvasColor->value() );

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -71,6 +71,7 @@
 #include "qgsruntimeprofiler.h"
 #include "qgsselectivemaskingsourcesetmanager.h"
 #include "qgssensormanager.h"
+#include "qgssettingsentryenumflag.h"
 #include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgssettingstree.h"

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -5087,7 +5087,7 @@ QgsCoordinateReferenceSystem QgsProject::defaultCrsForNewLayers() const
   else
   {
     // global crs
-    const QString layerDefaultCrs = mSettings.value( u"/Projections/layerDefaultCrs"_s, u"EPSG:4326"_s ).toString();
+    const QString layerDefaultCrs = QgsSettingsRegistryCore::settingsLayerDefaultCrs->value();
     defaultCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( layerDefaultCrs );
   }
 

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -5079,9 +5079,7 @@ QgsCoordinateReferenceSystem QgsProject::defaultCrsForNewLayers() const
   QgsCoordinateReferenceSystem defaultCrs;
 
   // TODO QGIS 5.0 -- remove this method, and place it somewhere in app (where it belongs)
-  // in the meantime, we have a slightly hacky way to read the settings key using an enum which isn't available (since it lives in app)
-  if ( mSettings.value( u"/projections/unknownCrsBehavior"_s, u"NoAction"_s, QgsSettings::App ).toString() == u"UseProjectCrs"_s
-       || mSettings.value( u"/projections/unknownCrsBehavior"_s, 0, QgsSettings::App ).toString() == "2"_L1 )
+  if ( QgsSettingsRegistryCore::settingsUnknownCrsBehavior->value() == Qgis::UnknownLayerCrsBehavior::UseProjectCrs )
   {
     // for new layers if the new layer crs method is set to either prompt or use project, then we use the project crs
     defaultCrs = crs();

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -71,7 +71,9 @@
 #include "qgsruntimeprofiler.h"
 #include "qgsselectivemaskingsourcesetmanager.h"
 #include "qgssensormanager.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
+#include "qgssettingstree.h"
 #include "qgssnappingconfig.h"
 #include "qgsstyleentityvisitor.h"
 #include "qgsthreadingutils.h"
@@ -110,6 +112,11 @@ using namespace Qt::StringLiterals;
 
 // canonical project instance
 QgsProject *QgsProject::sProject = nullptr;
+
+const QgsSettingsEntryBool *QgsProject::settingsAnonymizeNewProjects = new QgsSettingsEntryBool( u"anonymize-new"_s, QgsSettingsTree::sTreeProject, false );
+
+const QgsSettingsEntryBool *QgsProject::settingsAnonymizeSavedProjects = new QgsSettingsEntryBool( u"anonymize-saved"_s, QgsSettingsTree::sTreeProject, false );
+
 
 /**
  * Takes the given scope and key and convert them to a string list of key
@@ -1269,7 +1276,7 @@ void QgsProject::clear()
   mCrs3D = QgsCoordinateReferenceSystem();
   mMetadata = QgsProjectMetadata();
   mElevationShadingRenderer = QgsElevationShadingRenderer();
-  if ( !mSettings.value( u"projects/anonymize_new_projects"_s, false, QgsSettings::Core ).toBool() )
+  if ( !settingsAnonymizeNewProjects->value() )
   {
     mMetadata.setCreationDateTime( QDateTime::currentDateTime() );
     mMetadata.setAuthor( QgsApplication::userFullName() );
@@ -3338,7 +3345,7 @@ bool QgsProject::writeProjectFile( const QString &filename )
   qgisNode.setAttribute( u"projectname"_s, title() );
   qgisNode.setAttribute( u"version"_s, Qgis::version() );
 
-  if ( !mSettings.value( u"projects/anonymize_saved_projects"_s, false, QgsSettings::Core ).toBool() )
+  if ( !settingsAnonymizeSavedProjects->value() )
   {
     const QString newSaveUser = QgsApplication::userLoginName();
     const QString newSaveUserFull = QgsApplication::userFullName();

--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -1292,7 +1292,7 @@ void QgsProject::clear()
   const Qgis::DistanceUnit distanceUnit = QgsUnitTypes::decodeDistanceUnit( QgsSettingsRegistryCore::settingsMeasureDisplayUnits->value(), &ok );
   setDistanceUnits( ok ? distanceUnit : Qgis::DistanceUnit::Meters );
   ok = false;
-  const Qgis::AreaUnit areaUnits = QgsUnitTypes::decodeAreaUnit( mSettings.value( u"/qgis/measure/areaunits"_s ).toString(), &ok );
+  const Qgis::AreaUnit areaUnits = QgsUnitTypes::decodeAreaUnit( QgsSettingsRegistryCore::settingsMeasureAreaUnits->value(), &ok );
   setAreaUnits( ok ? areaUnits : Qgis::AreaUnit::SquareMeters );
 
   setScaleMethod( Qgis::ScaleCalculationMethod::HorizontalMiddle );

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -138,6 +138,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
   public:
     static const QgsSettingsEntryBool *settingsAnonymizeNewProjects SIP_SKIP;
     static const QgsSettingsEntryBool *settingsAnonymizeSavedProjects SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsDefaultProjectPathsRelative SIP_SKIP;
 
     // *INDENT-OFF*
 

--- a/src/core/project/qgsproject.h
+++ b/src/core/project/qgsproject.h
@@ -91,6 +91,7 @@ class QgsPropertyCollection;
 class QgsMapViewsManager;
 class QgsProjectElevationProperties;
 class QgsProjectGpsSettings;
+class QgsSettingsEntryBool;
 class QgsSensorManager;
 class QgsObjectEntityVisitorInterface;
 class QgsObjectVisitorContext;
@@ -135,6 +136,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     Q_PROPERTY( Qgis::ScaleCalculationMethod scaleMethod READ scaleMethod WRITE setScaleMethod NOTIFY scaleMethodChanged )
 
   public:
+    static const QgsSettingsEntryBool *settingsAnonymizeNewProjects SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsAnonymizeSavedProjects SIP_SKIP;
+
     // *INDENT-OFF*
 
     /**

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -2585,6 +2585,20 @@ int QgisEvent = QEvent::User + 1;
     Q_ENUM( CrsWktVariant )
 
     /**
+     * Behavior to use when encountering a layer with an unknown (invalid) CRS.
+     *
+     * \since QGIS 4.2
+     */
+    enum class UnknownLayerCrsBehavior : int
+    {
+      NoAction = 0,         //!< Take no action and leave as unknown CRS
+      PromptUserForCrs = 1, //!< User is prompted for a CRS choice
+      UseProjectCrs = 2,    //!< Copy the current project's CRS
+      UseDefaultCrs = 3,    //!< Use the default layer CRS set via QGIS options
+    };
+    Q_ENUM( UnknownLayerCrsBehavior )
+
+    /**
      * Cartesian axes.
      *
      * \since QGIS 3.34

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -133,6 +133,8 @@ using namespace Qt::StringLiterals;
 
 const QgsSettingsEntryString *QgsApplication::settingsApplicationFullName = new QgsSettingsEntryString( u"full-name"_s, QgsSettingsTree::sTreeApp, QString() );
 
+const QgsSettingsEntryStringList *QgsApplication::settingsSkippedGdalDrivers = new QgsSettingsEntryStringList( u"skip-drivers"_s, QgsSettingsTree::sTreeGdal, QStringList() );
+
 const QgsSettingsEntryString *QgsApplication::settingsLocaleUserLocale = new QgsSettingsEntryString( u"userLocale"_s, QgsSettingsTree::sTreeLocale, QString() );
 
 const QgsSettingsEntryBool *QgsApplication::settingsLocaleOverrideFlag = new QgsSettingsEntryBool( u"overrideFlag"_s, QgsSettingsTree::sTreeLocale, false );
@@ -2022,32 +2024,14 @@ void QgsApplication::setSkippedGdalDrivers( const QStringList &skippedGdalDriver
   *sGdalSkipList() = skippedGdalDrivers;
   *sDeferredSkippedGdalDrivers() = deferredSkippedGdalDrivers;
 
-  QgsSettings settings;
-  settings.setValue( u"gdal/skipDrivers"_s, skippedGdalDrivers.join( ','_L1 ) );
+  settingsSkippedGdalDrivers->setValue( skippedGdalDrivers );
 
   applyGdalSkippedDrivers();
 }
 
 void QgsApplication::registerGdalDriversFromSettings()
 {
-  QgsSettings settings;
-  QString joinedList, delimiter;
-  if ( settings.contains( u"gdal/skipDrivers"_s ) )
-  {
-    joinedList = settings.value( u"gdal/skipDrivers"_s, QString() ).toString();
-    delimiter = u","_s;
-  }
-  else
-  {
-    joinedList = settings.value( u"gdal/skipList"_s, QString() ).toString();
-    delimiter = u" "_s;
-  }
-  QStringList myList;
-  if ( !joinedList.isEmpty() )
-  {
-    myList = joinedList.split( delimiter );
-  }
-  *sGdalSkipList() = myList;
+  *sGdalSkipList() = settingsSkippedGdalDrivers->value();
   applyGdalSkippedDrivers();
 }
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -131,6 +131,8 @@
 
 using namespace Qt::StringLiterals;
 
+const QgsSettingsEntryString *QgsApplication::settingsApplicationFullName = new QgsSettingsEntryString( u"full-name"_s, QgsSettingsTree::sTreeApp, QString() );
+
 const QgsSettingsEntryString *QgsApplication::settingsLocaleUserLocale = new QgsSettingsEntryString( u"userLocale"_s, QgsSettingsTree::sTreeLocale, QString() );
 
 const QgsSettingsEntryBool *QgsApplication::settingsLocaleOverrideFlag = new QgsSettingsEntryBool( u"overrideFlag"_s, QgsSettingsTree::sTreeLocale, false );
@@ -1499,8 +1501,11 @@ QString QgsApplication::applicationFullName()
     return *sApplicationFullName();
 
   //last resort
-  QgsSettings settings;
-  *sApplicationFullName() = settings.value( u"/qgis/application_full_name"_s, u"%1 %2"_s.arg( applicationName(), platform() ) ).toString();
+  const QString storedFullName = settingsApplicationFullName->value();
+  if ( !storedFullName.isEmpty() )
+    *sApplicationFullName() = storedFullName;
+  else
+    *sApplicationFullName() = u"%1 %2"_s.arg( applicationName(), platform() );
   return *sApplicationFullName();
 }
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -179,6 +179,8 @@ class CORE_EXPORT QgsApplication : public QApplication
   static const char *QGIS_APPLICATION_NAME;
 #ifndef SIP_RUN
 
+  static const QgsSettingsEntryString *settingsApplicationFullName SIP_SKIP;
+
   /**
    * Constructor for QgsApplication.
    *
@@ -510,7 +512,7 @@ class CORE_EXPORT QgsApplication : public QApplication
    * Returns the QGIS application full name.
    *
    * It can be defined by the environment variable QGIS_APPLICATION_FULL_NAME or
-   * the /qgis/application_full_name in the QGIS config file.
+   * the app/full-name setting in the QGIS config file.
    *
    * By default it is equal to applicationName()+' '+platform()
    *

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -181,6 +181,8 @@ class CORE_EXPORT QgsApplication : public QApplication
 
   static const QgsSettingsEntryString *settingsApplicationFullName SIP_SKIP;
 
+  static const QgsSettingsEntryStringList *settingsSkippedGdalDrivers SIP_SKIP;
+
   /**
    * Constructor for QgsApplication.
    *

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -269,6 +269,17 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsLayerDefaultCrs->copyValueFromKey( u"/Projections/layerDefaultCrs"_s, true );
   QgsApplication::settingsApplicationFullName->copyValueFromKey( u"qgis/application_full_name"_s, true );
   QgsApplication::settingsApplicationFullName->copyValueFromKey( u"/qgis/application_full_name"_s, true );
+
+  // gdal/skipDrivers was a comma-joined string; convert to a proper QStringList
+  {
+    QgsSettings s;
+    if ( s.contains( u"gdal/skipDrivers"_s ) )
+    {
+      const QString joined = s.value( u"gdal/skipDrivers"_s ).toString();
+      QgsApplication::settingsSkippedGdalDrivers->setValue( joined.isEmpty() ? QStringList() : joined.split( ','_L1 ) );
+      s.remove( u"gdal/skipDrivers"_s );
+    }
+  }
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"qgis/monitorDirectoriesInBrowser"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"/qgis/monitorDirectoriesInBrowser"_s, true );
   QgsFileBasedDataItemProvider::settingsScanItemsInBrowser->copyValueFromKey( u"qgis/scanItemsInBrowser2"_s, {}, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -36,6 +36,7 @@
 #include "qgsopenclutils.h"
 #include "qgsowsconnection.h"
 #include "qgsprocessing.h"
+#include "qgsproject.h"
 #include "qgsrasterlayer.h"
 #include "qgsrasterminmaxorigin.h"
 #include "qgsrasterrendererregistry.h"
@@ -247,6 +248,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"/qgis/layerTreeInsertionMethod"_s, true );
   settingsScanZipInBrowser->copyValueFromKey( u"qgis/scanZipInBrowser2"_s, true );
   settingsScanZipInBrowser->copyValueFromKey( u"/qgis/scanZipInBrowser2"_s, true );
+  QgsProject::settingsAnonymizeNewProjects->copyValueFromKey( u"core/projects/anonymize_new_projects"_s, true );
+  QgsProject::settingsAnonymizeSavedProjects->copyValueFromKey( u"core/projects/anonymize_saved_projects"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"qgis/monitorDirectoriesInBrowser"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"/qgis/monitorDirectoriesInBrowser"_s, true );
   QgsFileBasedDataItemProvider::settingsScanItemsInBrowser->copyValueFromKey( u"qgis/scanItemsInBrowser2"_s, {}, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -190,6 +190,9 @@ const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsMeasureDisplayUni
 const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsMeasureAreaUnits
   = new QgsSettingsEntryString( u"area-units"_s, QgsSettingsTree::sTreeMeasure, QString(), u"Area display units (encoded unit string)"_s );
 
+const QgsSettingsEntryEnumFlag<Qgis::UnknownLayerCrsBehavior> *QgsSettingsRegistryCore::settingsUnknownCrsBehavior
+  = new QgsSettingsEntryEnumFlag<Qgis::UnknownLayerCrsBehavior>( u"unknown-crs-behavior"_s, QgsSettingsTree::sTreeCrs, Qgis::UnknownLayerCrsBehavior::NoAction, u"Behavior when encountering a layer with an unknown CRS"_s );
+
 const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod = new QgsSettingsEntryEnumFlag<
   Qgis::LayerTreeInsertionMethod>( u"insertion-method"_s, QgsSettingsTree::sTreeLayerTree, Qgis::LayerTreeInsertionMethod::AboveInsertionPoint, u"Method for inserting layers into the layer tree"_s );
 
@@ -257,6 +260,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   QgsProject::settingsAnonymizeSavedProjects->copyValueFromKey( u"core/projects/anonymize_saved_projects"_s, true );
   QgsProject::settingsDefaultProjectPathsRelative->copyValueFromKey( u"qgis/defaultProjectPathsRelative"_s, true );
   QgsProject::settingsDefaultProjectPathsRelative->copyValueFromKey( u"/qgis/defaultProjectPathsRelative"_s, true );
+  // old key was stored under QgsSettings::App, i.e. "app/projections/unknownCrsBehavior"
+  settingsUnknownCrsBehavior->copyValueFromKey( u"app/projections/unknownCrsBehavior"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"qgis/monitorDirectoriesInBrowser"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"/qgis/monitorDirectoriesInBrowser"_s, true );
   QgsFileBasedDataItemProvider::settingsScanItemsInBrowser->copyValueFromKey( u"qgis/scanItemsInBrowser2"_s, {}, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -190,8 +190,8 @@ const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsMeasureDisplayUni
 const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsMeasureAreaUnits
   = new QgsSettingsEntryString( u"area-units"_s, QgsSettingsTree::sTreeMeasure, QString(), u"Area display units (encoded unit string)"_s );
 
-const QgsSettingsEntryEnumFlag<Qgis::UnknownLayerCrsBehavior> *QgsSettingsRegistryCore::settingsUnknownCrsBehavior
-  = new QgsSettingsEntryEnumFlag<Qgis::UnknownLayerCrsBehavior>( u"unknown-crs-behavior"_s, QgsSettingsTree::sTreeCrs, Qgis::UnknownLayerCrsBehavior::NoAction, u"Behavior when encountering a layer with an unknown CRS"_s );
+const QgsSettingsEntryEnumFlag<Qgis::UnknownLayerCrsBehavior> *QgsSettingsRegistryCore::settingsUnknownCrsBehavior = new QgsSettingsEntryEnumFlag<
+  Qgis::UnknownLayerCrsBehavior>( u"unknown-crs-behavior"_s, QgsSettingsTree::sTreeCrs, Qgis::UnknownLayerCrsBehavior::NoAction, u"Behavior when encountering a layer with an unknown CRS"_s );
 
 const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsLayerDefaultCrs
   = new QgsSettingsEntryString( u"layer-default-crs"_s, QgsSettingsTree::sTreeCrs, u"EPSG:4326"_s, u"Default CRS used for layers with unknown CRS when the unknown CRS behavior is set to UseDefaultCrs"_s );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -267,6 +267,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsUnknownCrsBehavior->copyValueFromKey( u"app/projections/unknownCrsBehavior"_s, true );
   settingsLayerDefaultCrs->copyValueFromKey( u"Projections/layerDefaultCrs"_s, true );
   settingsLayerDefaultCrs->copyValueFromKey( u"/Projections/layerDefaultCrs"_s, true );
+  QgsApplication::settingsApplicationFullName->copyValueFromKey( u"qgis/application_full_name"_s, true );
+  QgsApplication::settingsApplicationFullName->copyValueFromKey( u"/qgis/application_full_name"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"qgis/monitorDirectoriesInBrowser"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"/qgis/monitorDirectoriesInBrowser"_s, true );
   QgsFileBasedDataItemProvider::settingsScanItemsInBrowser->copyValueFromKey( u"qgis/scanItemsInBrowser2"_s, {}, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -193,6 +193,9 @@ const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsMeasureAreaUnits
 const QgsSettingsEntryEnumFlag<Qgis::UnknownLayerCrsBehavior> *QgsSettingsRegistryCore::settingsUnknownCrsBehavior
   = new QgsSettingsEntryEnumFlag<Qgis::UnknownLayerCrsBehavior>( u"unknown-crs-behavior"_s, QgsSettingsTree::sTreeCrs, Qgis::UnknownLayerCrsBehavior::NoAction, u"Behavior when encountering a layer with an unknown CRS"_s );
 
+const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsLayerDefaultCrs
+  = new QgsSettingsEntryString( u"layer-default-crs"_s, QgsSettingsTree::sTreeCrs, u"EPSG:4326"_s, u"Default CRS used for layers with unknown CRS when the unknown CRS behavior is set to UseDefaultCrs"_s );
+
 const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod = new QgsSettingsEntryEnumFlag<
   Qgis::LayerTreeInsertionMethod>( u"insertion-method"_s, QgsSettingsTree::sTreeLayerTree, Qgis::LayerTreeInsertionMethod::AboveInsertionPoint, u"Method for inserting layers into the layer tree"_s );
 
@@ -262,6 +265,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   QgsProject::settingsDefaultProjectPathsRelative->copyValueFromKey( u"/qgis/defaultProjectPathsRelative"_s, true );
   // old key was stored under QgsSettings::App, i.e. "app/projections/unknownCrsBehavior"
   settingsUnknownCrsBehavior->copyValueFromKey( u"app/projections/unknownCrsBehavior"_s, true );
+  settingsLayerDefaultCrs->copyValueFromKey( u"Projections/layerDefaultCrs"_s, true );
+  settingsLayerDefaultCrs->copyValueFromKey( u"/Projections/layerDefaultCrs"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"qgis/monitorDirectoriesInBrowser"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"/qgis/monitorDirectoriesInBrowser"_s, true );
   QgsFileBasedDataItemProvider::settingsScanItemsInBrowser->copyValueFromKey( u"qgis/scanItemsInBrowser2"_s, {}, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -187,6 +187,9 @@ const QgsSettingsEntryInteger *QgsSettingsRegistryCore::settingsMeasureDecimalPl
 const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsMeasureDisplayUnits
   = new QgsSettingsEntryString( u"display-units"_s, QgsSettingsTree::sTreeMeasure, QString(), u"Distance display units (encoded unit string)"_s );
 
+const QgsSettingsEntryString *QgsSettingsRegistryCore::settingsMeasureAreaUnits
+  = new QgsSettingsEntryString( u"area-units"_s, QgsSettingsTree::sTreeMeasure, QString(), u"Area display units (encoded unit string)"_s );
+
 const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod = new QgsSettingsEntryEnumFlag<
   Qgis::LayerTreeInsertionMethod>( u"insertion-method"_s, QgsSettingsTree::sTreeLayerTree, Qgis::LayerTreeInsertionMethod::AboveInsertionPoint, u"Method for inserting layers into the layer tree"_s );
 
@@ -244,6 +247,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsMeasureDecimalPlaces->copyValueFromKey( u"/qgis/measure/decimalplaces"_s, true );
   settingsMeasureDisplayUnits->copyValueFromKey( u"qgis/measure/displayunits"_s, true );
   settingsMeasureDisplayUnits->copyValueFromKey( u"/qgis/measure/displayunits"_s, true );
+  settingsMeasureAreaUnits->copyValueFromKey( u"qgis/measure/areaunits"_s, true );
+  settingsMeasureAreaUnits->copyValueFromKey( u"/qgis/measure/areaunits"_s, true );
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"qgis/layerTreeInsertionMethod"_s, true );
   settingsLayerTreeInsertionMethod->copyValueFromKey( u"/qgis/layerTreeInsertionMethod"_s, true );
   settingsScanZipInBrowser->copyValueFromKey( u"qgis/scanZipInBrowser2"_s, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -255,6 +255,8 @@ void QgsSettingsRegistryCore::migrateOldSettings()
   settingsScanZipInBrowser->copyValueFromKey( u"/qgis/scanZipInBrowser2"_s, true );
   QgsProject::settingsAnonymizeNewProjects->copyValueFromKey( u"core/projects/anonymize_new_projects"_s, true );
   QgsProject::settingsAnonymizeSavedProjects->copyValueFromKey( u"core/projects/anonymize_saved_projects"_s, true );
+  QgsProject::settingsDefaultProjectPathsRelative->copyValueFromKey( u"qgis/defaultProjectPathsRelative"_s, true );
+  QgsProject::settingsDefaultProjectPathsRelative->copyValueFromKey( u"/qgis/defaultProjectPathsRelative"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"qgis/monitorDirectoriesInBrowser"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"/qgis/monitorDirectoriesInBrowser"_s, true );
   QgsFileBasedDataItemProvider::settingsScanItemsInBrowser->copyValueFromKey( u"qgis/scanItemsInBrowser2"_s, {}, true );

--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -280,6 +280,9 @@ void QgsSettingsRegistryCore::migrateOldSettings()
       s.remove( u"gdal/skipDrivers"_s );
     }
   }
+
+  QgsDirectoryParamWidget::settingsDirectoryHiddenColumns->copyValueFromKey( u"dataitem/directoryHiddenColumns"_s, true );
+  QgsDirectoryParamWidget::settingsDirectoryHiddenColumns->copyValueFromKey( u"/dataitem/directoryHiddenColumns"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"qgis/monitorDirectoriesInBrowser"_s, true );
   QgsDirectoryItem::settingsMonitorDirectoriesInBrowser->copyValueFromKey( u"/qgis/monitorDirectoriesInBrowser"_s, true );
   QgsFileBasedDataItemProvider::settingsScanItemsInBrowser->copyValueFromKey( u"qgis/scanItemsInBrowser2"_s, {}, true );

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -215,6 +215,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for distance display units
     static const QgsSettingsEntryString *settingsMeasureDisplayUnits;
 
+    //! Settings entry for area display units
+    static const QgsSettingsEntryString *settingsMeasureAreaUnits;
+
     //! Settings entry for layer tree insertion method
     static const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *settingsLayerTreeInsertionMethod;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -218,6 +218,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for area display units
     static const QgsSettingsEntryString *settingsMeasureAreaUnits;
 
+    //! Settings entry for behavior when encountering a layer with an unknown CRS (NoAction, PromptUserForCrs, UseProjectCrs, UseDefaultCrs)
+    static const QgsSettingsEntryEnumFlag<Qgis::UnknownLayerCrsBehavior> *settingsUnknownCrsBehavior;
+
     //! Settings entry for layer tree insertion method
     static const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *settingsLayerTreeInsertionMethod;
 

--- a/src/core/settings/qgssettingsregistrycore.h
+++ b/src/core/settings/qgssettingsregistrycore.h
@@ -221,6 +221,9 @@ class CORE_EXPORT QgsSettingsRegistryCore : public QgsSettingsRegistry
     //! Settings entry for behavior when encountering a layer with an unknown CRS (NoAction, PromptUserForCrs, UseProjectCrs, UseDefaultCrs)
     static const QgsSettingsEntryEnumFlag<Qgis::UnknownLayerCrsBehavior> *settingsUnknownCrsBehavior;
 
+    //! Settings entry for the default CRS used for layers with unknown CRS
+    static const QgsSettingsEntryString *settingsLayerDefaultCrs;
+
     //! Settings entry for layer tree insertion method
     static const QgsSettingsEntryEnumFlag<Qgis::LayerTreeInsertionMethod> *settingsLayerTreeInsertionMethod;
 

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -68,6 +68,7 @@ class CORE_EXPORT QgsSettingsTree
     static inline QgsSettingsTreeNode *sTreePlugins = treeRoot()->createChildNode( u"plugins"_s );
     static inline QgsSettingsTreeNode *sTreeProcessing = treeRoot()->createChildNode( u"processing"_s );
     static inline QgsSettingsTreeNode *sTreeProfile = treeRoot()->createChildNode( u"profile"_s );
+    static inline QgsSettingsTreeNode *sTreeProject = treeRoot()->createChildNode( u"project"_s );
     static inline QgsSettingsTreeNode *sTreeProxy = treeRoot()->createChildNode( u"proxy"_s );
     static inline QgsSettingsTreeNode *sTreeRaster = treeRoot()->createChildNode( u"raster"_s );
     static inline QgsSettingsTreeNode *sTreeRendering = treeRoot()->createChildNode( u"rendering"_s );

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -53,6 +53,7 @@ class CORE_EXPORT QgsSettingsTree
     static inline QgsSettingsTreeNode *sTreeDigitizing = treeRoot()->createChildNode( u"digitizing"_s );
     static inline QgsSettingsTreeNode *sTreeElevationProfile = treeRoot()->createChildNode( u"elevation-profile"_s );
     static inline QgsSettingsTreeNode *sTreeFonts = treeRoot()->createChildNode( u"fonts"_s );
+    static inline QgsSettingsTreeNode *sTreeGdal = treeRoot()->createChildNode( u"gdal"_s );
     static inline QgsSettingsTreeNode *sTreeGeometryValidation = treeRoot()->createChildNode( u"geometry_validation"_s );
     static inline QgsSettingsTreeNode *sTreeGps = treeRoot()->createChildNode( u"gps"_s );
     static inline QgsSettingsTreeNode *sTreeGradientEditor = treeRoot()->createChildNode( u"gradient-editor"_s );

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -357,15 +357,8 @@ void QgsServerSettings::initSettings()
   }
 
   {
-    const Setting sApplicationName = {
-      QgsServerSettingsEnv::QGIS_SERVER_APPLICATION_NAME,
-      QgsServerSettingsEnv::DEFAULT_VALUE,
-      u"The QGIS Server application name"_s,
-      u"/qgis/application_full_name"_s,
-      QMetaType::Type::QString,
-      QVariant( QgsApplication::applicationFullName() ),
-      QVariant()
-    };
+    const Setting sApplicationName
+      = { QgsServerSettingsEnv::QGIS_SERVER_APPLICATION_NAME, QgsServerSettingsEnv::DEFAULT_VALUE, u"The QGIS Server application name"_s, u"app/full-name"_s, QMetaType::Type::QString, QVariant( QgsApplication::applicationFullName() ), QVariant() };
     mSettings[sApplicationName.envVar] = sApplicationName;
   }
 

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -356,7 +356,6 @@ void TestQgsProject::testProjectUnits()
   // DISTANCE
 
   //first set a default QGIS distance unit
-  QgsSettings s;
   QgsSettingsRegistryCore::settingsMeasureDisplayUnits->setValue( QgsUnitTypes::encodeUnit( Qgis::DistanceUnit::Feet ) );
 
   QgsProject *prj = new QgsProject;
@@ -375,14 +374,14 @@ void TestQgsProject::testProjectUnits()
   // AREA
 
   //first set a default QGIS area unit
-  s.setValue( u"/qgis/measure/areaunits"_s, QgsUnitTypes::encodeUnit( Qgis::AreaUnit::SquareYards ) );
+  QgsSettingsRegistryCore::settingsMeasureAreaUnits->setValue( QgsUnitTypes::encodeUnit( Qgis::AreaUnit::SquareYards ) );
 
   // new project should inherit QGIS default area unit
   prj->clear();
   QCOMPARE( prj->areaUnits(), Qgis::AreaUnit::SquareYards );
 
   //changing default QGIS unit should not affect existing project
-  s.setValue( u"/qgis/measure/areaunits"_s, QgsUnitTypes::encodeUnit( Qgis::AreaUnit::Acres ) );
+  QgsSettingsRegistryCore::settingsMeasureAreaUnits->setValue( QgsUnitTypes::encodeUnit( Qgis::AreaUnit::Acres ) );
   QCOMPARE( prj->areaUnits(), Qgis::AreaUnit::SquareYards );
 
   //test setting new units for project

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -23,6 +23,7 @@
 #include "qgsproject.h"
 #include "qgsrasterlayer.h"
 #include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
 #include "qgssettingsregistrycore.h"
 #include "qgssinglesymbolrenderer.h"
 #include "qgssymbollayerutils.h"
@@ -608,8 +609,7 @@ void TestQgsProject::projectSaveUser()
   QCOMPARE( p.lastSaveDateTime().date(), QDateTime::currentDateTime().date() );
   QCOMPARE( p.lastSaveVersion().text(), QgsProjectVersion( Qgis::version() ).text() );
 
-  QgsSettings s;
-  s.setValue( u"projects/anonymize_saved_projects"_s, true, QgsSettings::Core );
+  QgsProject::settingsAnonymizeSavedProjects->setValue( true );
 
   p.write();
 
@@ -619,7 +619,7 @@ void TestQgsProject::projectSaveUser()
   QVERIFY( !p.metadata().creationDateTime().isValid() );
   QVERIFY( !p.lastSaveDateTime().isValid() );
 
-  s.setValue( u"projects/anonymize_saved_projects"_s, false, QgsSettings::Core );
+  QgsProject::settingsAnonymizeSavedProjects->setValue( false );
 
   p.write();
   QCOMPARE( p.saveUser(), QgsApplication::userLoginName() );

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -784,20 +784,19 @@ void TestQgsProject::testCrsExpressions()
 
 void TestQgsProject::testDefaultRelativePaths()
 {
-  QgsSettings s;
-  const bool bk_defaultRelativePaths = s.value( u"/qgis/defaultProjectPathsRelative"_s, QVariant( true ) ).toBool();
+  const bool bk_defaultRelativePaths = QgsProject::settingsDefaultProjectPathsRelative->value();
 
-  s.setValue( u"/qgis/defaultProjectPathsRelative"_s, true );
+  QgsProject::settingsDefaultProjectPathsRelative->setValue( true );
   QgsProject p1;
   const bool p1PathsAbsolute = p1.readBoolEntry( u"Paths"_s, u"/Absolute"_s, false );
   const Qgis::FilePathType p1Type = p1.filePathStorage();
 
-  s.setValue( u"/qgis/defaultProjectPathsRelative"_s, false );
+  QgsProject::settingsDefaultProjectPathsRelative->setValue( false );
   p1.clear();
   const bool p1PathsAbsolute_2 = p1.readBoolEntry( u"Paths"_s, u"/Absolute"_s, false );
   const Qgis::FilePathType p2Type = p1.filePathStorage();
 
-  s.setValue( u"/qgis/defaultProjectPathsRelative"_s, bk_defaultRelativePaths );
+  QgsProject::settingsDefaultProjectPathsRelative->setValue( bk_defaultRelativePaths );
 
   QCOMPARE( p1PathsAbsolute, false );
   QCOMPARE( p1PathsAbsolute_2, true );


### PR DESCRIPTION
## Description

These are the last settings from src/core using QgsSettings, except the dynamic ones to be done later.

A new enum is created in qgis.h `UnknownLayerCrsBehavior`
## AI tool usage

 - [x] AI tool(s): I have a set of instructions to perform the migration that were fine-tuned on the former PRs. I have manually checked every commit.

