### PR TITLE
tryAcquire now supports negative timer

### DIFF
--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -105,22 +105,12 @@ template<typename T> class QgsConnectionPoolGroup
       QgsDebugMsgLevel( u"Trying to acquire connection"_s, 2 );
       const int requiredFreeConnectionCount = requestMayBeNested ? 1 : 3;
       // we are going to acquire a resource - if no resource is available, we will block here
-      if ( timeout >= 0 )
+      if ( !sem.tryAcquire( requiredFreeConnectionCount, QDeadlineTimer( timeout ) ) )
       {
-        if ( !sem.tryAcquire( requiredFreeConnectionCount, timeout ) )
-        {
-          QgsDebugMsgLevel( u"Failed to acquire semaphore"_s, 2 );
-          return nullptr;
-        }
+        QgsDebugMsgLevel( u"Failed to acquire semaphore"_s, 2 );
+        return nullptr;
       }
-      else
-      {
-        // we should still be able to use tryAcquire with a negative timeout here, but
-        // tryAcquire is broken on Qt > 5.8 with negative timeouts - see
-        // https://bugreports.qt.io/browse/QTBUG-64413
-        // https://lists.osgeo.org/pipermail/qgis-developer/2017-November/050456.html
-        sem.acquire( requiredFreeConnectionCount );
-      }
+
       sem.release( requiredFreeConnectionCount - 1 );
 
       // quick (preferred) way - use cached connection


### PR DESCRIPTION
the original issue has been fixed
see https://github.com/qt/qtbase/blob/6.8/src/corelib/thread/qsemaphore.cpp#L502

original ticket https://qt-project.atlassian.net/browse/QTBUG-64413



## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

