### PR TITLE
qgsauthmanager: Fix unused warning if HAVE_AUTH is disabled

### DIFF
--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -256,7 +256,9 @@ bool QgsAuthManager::ensureInitialized() const
 #endif
 }
 
+#ifdef HAVE_AUTH
 static char *sPassFileEnv = nullptr;
+#endif
 
 bool QgsAuthManager::initPrivate( const QString &pluginPath )
 {


### PR DESCRIPTION
## Description

`sPassFileEnv` is only used if `HAVE_AUTH` is ON

## AI tool usage

No AI tool used
