### PR TITLE
Make fetch depth dynamic in pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,9 +16,25 @@ jobs:
       issues: write
 
     steps:
+      - name: Compute fetch depth
+        id: fetch_depth
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            CREATED="${{ github.event.pull_request.created_at }}"
+            NOW_TS=$(date -u +%s)
+            THEN_TS=$(date -u -d "$CREATED" +%s)
+            DAYS=$(( (NOW_TS - THEN_TS) / 86400 ))
+            [ "$DAYS" -lt 0 ] && DAYS=0
+            DEPTH=$(( 100 + 10 * DAYS ))
+          else
+            DEPTH=200
+          fi
+          echo "Using fetch-depth=$DEPTH"
+          echo "depth=$DEPTH" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 200
+          fetch-depth: ${{ steps.fetch_depth.outputs.depth }}
           persist-credentials: true  # We need to persist credentials because of later git push
 
       - name: Set up Python


### PR DESCRIPTION
## Description

This would solve failing jobs on old PRs like this one [#65286](https://github.com/qgis/QGIS/pull/65286)

The other solution would be to bump to ~500 hundreds.

No strong opinion what is best:
- cost increased fetch depth (useless in 95%)
- code complexity in the workflow

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

