### PR TITLE
Vector legend : fix count when ELSE rule

### DIFF
--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -1097,9 +1097,18 @@ QSet<QString> QgsCategorizedSymbolRenderer::legendKeysForFeature( const QgsFeatu
 {
   const QVariant value = valueForFeature( feature, context );
 
+  // "all other values" category value (AKA "else" rule) is represented with an invalid QVariant
+  QString elseRuleUUID;
+
   for ( const QgsRendererCategory &cat : mCategories )
   {
     bool match = false;
+
+    if ( QgsVariantUtils::isNull( cat.value() ) )
+    {
+      elseRuleUUID = cat.uuid();
+    }
+
     if ( cat.value().userType() == QMetaType::Type::QVariantList )
     {
       const QVariantList list = cat.value().toList();
@@ -1133,6 +1142,12 @@ QSet<QString> QgsCategorizedSymbolRenderer::legendKeysForFeature( const QgsFeatu
       else
         return QSet< QString >();
     }
+  }
+
+  // if there is an "else" rule category, then the feature will be rendered with that category symbol
+  if ( !elseRuleUUID.isEmpty() )
+  {
+    return QSet< QString >() << elseRuleUUID;
   }
 
   return QSet< QString >();

--- a/tests/src/python/test_qgscategorizedsymbolrenderer.py
+++ b/tests/src/python/test_qgscategorizedsymbolrenderer.py
@@ -1781,6 +1781,47 @@ class TestQgsCategorizedSymbolRenderer(QgisTestCase):
         self.assertEqual(layer.featureCount(cat_b_id), 2)
         self.assertEqual(layer.featureCount(cat_default_id), 1)
 
+    def test_layer_counts_other_categories(self):
+        layer = QgsVectorLayer("Point?field=test_field:string", "test_layer", "memory")
+        self.assertTrue(layer.isValid())
+        fields = layer.fields()
+        layer.startEditing()
+        self.assertEqual(fields[0].type(), QVariant.String)
+
+        # add test values
+        for attr_value in ["a", "b", None]:
+            f = QgsFeature(fields)
+            f.setAttributes([attr_value])
+            self.assertTrue(layer.addFeature(f))
+
+        self.assertEqual(layer.featureCount(), 3)
+        layer.commitChanges()
+
+        renderer = QgsCategorizedSymbolRenderer()
+        renderer.setClassAttribute("test_field")
+
+        renderer.addCategory(QgsRendererCategory("a", createMarkerSymbol(), "a"))
+        cat_a_id = renderer.categories()[-1].uuid()
+        renderer.addCategory(
+            QgsRendererCategory(QVariant(), createMarkerSymbol(), "other values")
+        )
+        cat_other_id = renderer.categories()[-1].uuid()
+
+        self.assertEqual(renderer.legendKeys(), {cat_a_id, cat_other_id})
+
+        ctx = QgsRenderContext()
+        renderer.startRender(ctx, layer.fields())
+
+        self.assertEqual(
+            renderer.legendKeysForFeature(layer.getFeature(1), ctx), {cat_a_id}
+        )
+        self.assertEqual(
+            renderer.legendKeysForFeature(layer.getFeature(3), ctx), {cat_other_id}
+        )
+        self.assertEqual(
+            renderer.legendKeysForFeature(layer.getFeature(2), ctx), {cat_other_id}
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix an (unreported?) issue with categorized renderer feature count in the legend tree where the features that do non match anything are not counted in the "else" rule.

Maybe also fix #52690

