### PR TITLE
set CMAKE_CXX_SCAN_FOR_MODULES to OFF 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ message(STATUS "QGIS version: ${COMPLETE_VERSION} ${RELEASE_NAME} (${QGIS_VERSIO
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 set (ENABLE_LOCAL_BUILD_SHORTCUTS FALSE CACHE BOOL "Disables some build steps which are only relevant for releases to speed up compilation time for development")
 


### PR DESCRIPTION
Not sure if we want this here or somewhere else, but since #65595 I have noticed much slower compile times unless I set the title flag to OFF (difference is about 20%).

AFAIK, we are not using modules, so this should be safe (?)