### PR TITLE
Add limit to features displayed in Identify Results, add more features by batch

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -594,6 +594,7 @@
         <file>themes/default/mLayoutItemTable.svg</file>
         <file>themes/default/mMessageLog.svg</file>
         <file>themes/default/mMessageLogRead.svg</file>
+        <file>themes/default/mShowMoreFeatures.svg</file>
         <file>themes/default/north_arrow.svg</file>
         <file>themes/default/diagramNone.svg</file>
         <file>themes/default/pie-chart.svg</file>

--- a/images/themes/default/mShowMoreFeatures.svg
+++ b/images/themes/default/mShowMoreFeatures.svg
@@ -1,0 +1,436 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48px"
+   height="48px"
+   id="svg6431"
+   sodipodi:version="0.32"
+   inkscape:version="0.46"
+   sodipodi:docbase="/home/jimmac/src/cvs/tango-icon-theme/scalable/actions"
+   sodipodi:docname="list-add.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs6433">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 24 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="48 : 24 : 1"
+       inkscape:persp3d-origin="24 : 16 : 1"
+       id="perspective70" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2091">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2093" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop2095" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7916">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7918" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.34020618;"
+         offset="1.0000000"
+         id="stop7920" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient8662">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop8664" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop8666" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8662"
+       id="radialGradient1503"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.000000,0.000000,0.000000,0.536723,-1.018989e-13,16.87306)"
+       cx="24.837126"
+       cy="36.421127"
+       fx="24.837126"
+       fy="36.421127"
+       r="15.644737" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2847">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop2849" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:0;"
+         offset="1"
+         id="stop2851" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2847"
+       id="linearGradient1488"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.000000,0.000000,0.000000,-1.000000,-1.242480,40.08170)"
+       x1="37.128052"
+       y1="29.729605"
+       x2="37.065414"
+       y2="26.194071" />
+    <linearGradient
+       id="linearGradient2831">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop2833" />
+      <stop
+         id="stop2855"
+         offset="0.33333334"
+         style="stop-color:#5b86be;stop-opacity:1;" />
+      <stop
+         style="stop-color:#83a8d8;stop-opacity:0;"
+         offset="1"
+         id="stop2835" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2831"
+       id="linearGradient1486"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-48.30498,-6.043298)"
+       x1="13.478554"
+       y1="10.612206"
+       x2="15.419417"
+       y2="19.115122" />
+    <linearGradient
+       id="linearGradient2380">
+      <stop
+         style="stop-color:#b9cfe7;stop-opacity:1"
+         offset="0"
+         id="stop2382" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop2384" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2682">
+      <stop
+         style="stop-color:#3977c3;stop-opacity:1;"
+         offset="0"
+         id="stop2684" />
+      <stop
+         style="stop-color:#89aedc;stop-opacity:0;"
+         offset="1"
+         id="stop2686" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2682"
+       id="linearGradient2688"
+       x1="36.713837"
+       y1="31.455952"
+       x2="37.124462"
+       y2="24.842253"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-48.77039,-5.765705)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2690">
+      <stop
+         style="stop-color:#c4d7eb;stop-opacity:1;"
+         offset="0"
+         id="stop2692" />
+      <stop
+         style="stop-color:#c4d7eb;stop-opacity:0;"
+         offset="1"
+         id="stop2694" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2690"
+       id="linearGradient2696"
+       x1="32.647972"
+       y1="30.748846"
+       x2="37.124462"
+       y2="24.842253"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-48.77039,-5.765705)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2871">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1;"
+         offset="0"
+         id="stop2873" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop2875" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2402">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop2404" />
+      <stop
+         style="stop-color:#528ac5;stop-opacity:1;"
+         offset="1"
+         id="stop2406" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2797"
+       id="linearGradient1493"
+       gradientUnits="userSpaceOnUse"
+       x1="5.9649176"
+       y1="26.048164"
+       x2="52.854097"
+       y2="26.048164" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2797">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop2799" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop2801" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2797"
+       id="linearGradient1491"
+       gradientUnits="userSpaceOnUse"
+       x1="5.9649176"
+       y1="26.048164"
+       x2="52.854097"
+       y2="26.048164" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7179">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop7181" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop7183" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2316">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2318" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.65979379;"
+         offset="1"
+         id="stop2320" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1322">
+      <stop
+         id="stop1324"
+         offset="0.0000000"
+         style="stop-color:#729fcf" />
+      <stop
+         id="stop1326"
+         offset="1.0000000"
+         style="stop-color:#5187d6;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1322"
+       id="linearGradient4975"
+       x1="34.892849"
+       y1="36.422989"
+       x2="45.918697"
+       y2="48.547989"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-18.01785,-13.57119)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7179"
+       id="linearGradient7185"
+       x1="13.435029"
+       y1="13.604306"
+       x2="22.374878"
+       y2="23.554308"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7179"
+       id="linearGradient7189"
+       gradientUnits="userSpaceOnUse"
+       x1="13.435029"
+       y1="13.604306"
+       x2="22.374878"
+       y2="23.554308"
+       gradientTransform="matrix(-1.000000,0.000000,0.000000,-1.000000,47.93934,50.02474)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2380"
+       id="linearGradient7180"
+       gradientUnits="userSpaceOnUse"
+       x1="62.513836"
+       y1="36.061237"
+       x2="15.984863"
+       y2="20.60858" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2871"
+       id="linearGradient7182"
+       gradientUnits="userSpaceOnUse"
+       x1="46.834816"
+       y1="45.264122"
+       x2="45.380436"
+       y2="50.939667" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2402"
+       id="linearGradient7184"
+       gradientUnits="userSpaceOnUse"
+       x1="18.935766"
+       y1="23.667896"
+       x2="53.588622"
+       y2="26.649362" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2871"
+       id="linearGradient7186"
+       gradientUnits="userSpaceOnUse"
+       x1="46.834816"
+       y1="45.264122"
+       x2="45.380436"
+       y2="50.939667" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7916"
+       id="linearGradient7922"
+       x1="16.874998"
+       y1="22.851799"
+       x2="27.900846"
+       y2="34.976799"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2091"
+       id="radialGradient2097"
+       cx="23.070683"
+       cy="35.127438"
+       fx="23.070683"
+       fy="35.127438"
+       r="10.319340"
+       gradientTransform="matrix(0.914812,1.265023e-2,-8.21502e-3,0.213562,2.253914,27.18889)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="0.15686275"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="-123.56934"
+     inkscape:cy="0.031886897"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1280"
+     inkscape:window-height="818"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false" />
+  <metadata
+     id="metadata6436">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Add</dc:title>
+        <dc:date>2006-01-04</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Andreas Nilsson</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source>http://tango-project.org</dc:source>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>add</rdf:li>
+            <rdf:li>plus</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       sodipodi:type="arc"
+       style="opacity:0.10824742;fill:url(#radialGradient2097);fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path1361"
+       sodipodi:cx="22.958872"
+       sodipodi:cy="34.94062"
+       sodipodi:rx="10.31934"
+       sodipodi:ry="2.320194"
+       d="M 33.278212 34.94062 A 10.31934 2.320194 0 1 1  12.639532,34.94062 A 10.31934 2.320194 0 1 1  33.278212 34.94062 z"
+       transform="matrix(1.550487,0,0,1.978714,-12.4813,-32.49103)" />
+    <path
+       style="font-size:59.901077px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125.00000%;writing-mode:lr-tb;text-anchor:start;fill:#75a1d0;fill-opacity:1.0000000;stroke:#3465a4;stroke-width:1.0000004px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1.0000000;font-family:Bitstream Vera Sans"
+       d="M 27.514356,37.542682 L 27.514356,28.515722 L 37.492820,28.475543 L 37.492820,21.480219 L 27.523285,21.480219 L 27.514356,11.520049 L 20.498082,11.531210 L 20.502546,21.462362 L 10.512920,21.536022 L 10.477206,28.504561 L 20.511475,28.475543 L 20.518171,37.515896 L 27.514356,37.542682 z "
+       id="text1314"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="font-size:59.901077px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125.00000%;writing-mode:lr-tb;text-anchor:start;opacity:0.40860215;fill:url(#linearGradient4975);fill-opacity:1.0000000;stroke:url(#linearGradient7922);stroke-width:1.0000006px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1.0000000;font-family:Bitstream Vera Sans"
+       d="M 26.498702,36.533920 L 26.498702,27.499738 L 36.501304,27.499738 L 36.494607,22.475309 L 26.507630,22.475309 L 26.507630,12.480335 L 21.512796,12.498193 L 21.521725,22.475309 L 11.495536,22.493166 L 11.468750,27.466256 L 21.533143,27.475185 L 21.519750,36.502670 L 26.498702,36.533920 z "
+       id="path7076"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="fill:#ffffff;fill-opacity:1.0000000;fill-rule:evenodd;stroke:none;stroke-width:1.0000000px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1.0000000;opacity:0.31182796"
+       d="M 11.000000,25.000000 C 11.000000,26.937500 36.984375,24.031250 36.984375,24.968750 L 36.984375,21.968750 L 27.000000,22.000000 L 27.000000,12.034772 L 21.000000,12.034772 L 21.000000,22.000000 L 11.000000,22.000000 L 11.000000,25.000000 z "
+       id="path7914"
+       sodipodi:nodetypes="ccccccccc" />
+  </g>
+</svg>

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -130,6 +130,7 @@ const QgsSettingsEntryInteger *QgsIdentifyResultsDialog::settingColumnWidth = ne
 
 const QgsSettingsEntryInteger *QgsIdentifyResultsDialog::settingColumnWidthTable = new QgsSettingsEntryInteger( u"identify-column-width-table"_s, QgsSettingsTree::sTreeWindowState, 0 );
 
+const int maxResults = 20;
 
 QgsIdentifyResultsWebView::QgsIdentifyResultsWebView( QWidget *parent )
   : QgsWebView( parent )
@@ -472,6 +473,7 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
 #endif
   connect( mOpenFormAction, &QAction::triggered, this, &QgsIdentifyResultsDialog::featureForm );
   connect( mClearResultsAction, &QAction::triggered, this, &QgsIdentifyResultsDialog::clear );
+  connect( mShowMoreFeatures, &QAction::triggered, this, &QgsIdentifyResultsDialog::showMoreFeatures );
   connect( mHelpToolAction, &QAction::triggered, this, &QgsIdentifyResultsDialog::showHelp );
 
   initSelectionModes();
@@ -1864,6 +1866,15 @@ void QgsIdentifyResultsDialog::clear()
   // keep it visible but disabled, it can switch from disabled/enabled
   // after raster format change
   mActionPrint->setDisabled( true );
+}
+
+void QgsIdentifyResultsDialog::showMoreFeatures() {
+  QgisApp::instance()->messageBar()->pushMessage( tr( "AAA" ), tr( "BBB." ), Qgis::MessageLevel::Warning );
+}
+
+const int QgsIdentifyResultsDialog::getMaxResults() const
+{
+  return maxResults;
 }
 
 void QgsIdentifyResultsDialog::updateViewModes()

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -130,8 +130,6 @@ const QgsSettingsEntryInteger *QgsIdentifyResultsDialog::settingColumnWidth = ne
 
 const QgsSettingsEntryInteger *QgsIdentifyResultsDialog::settingColumnWidthTable = new QgsSettingsEntryInteger( u"identify-column-width-table"_s, QgsSettingsTree::sTreeWindowState, 0 );
 
-const int maxResults = 20;
-
 QgsIdentifyResultsWebView::QgsIdentifyResultsWebView( QWidget *parent )
   : QgsWebView( parent )
 {
@@ -1870,11 +1868,6 @@ void QgsIdentifyResultsDialog::clear()
 
 void QgsIdentifyResultsDialog::showMoreFeatures() {
   emit ( moreFeaturesRequested() );
-}
-
-const int QgsIdentifyResultsDialog::getMaxResults() const
-{
-  return maxResults;
 }
 
 void QgsIdentifyResultsDialog::updateViewModes()

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1869,8 +1869,6 @@ void QgsIdentifyResultsDialog::clear()
 }
 
 void QgsIdentifyResultsDialog::showMoreFeatures() {
-  QgisApp::instance()->messageBar()->pushMessage( tr( "AAA" ), tr( "BBB." ), Qgis::MessageLevel::Warning );
-  // MITODO Resume here April 22 morning 
   emit ( moreFeaturesRequested() );
 }
 

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1870,6 +1870,8 @@ void QgsIdentifyResultsDialog::clear()
 
 void QgsIdentifyResultsDialog::showMoreFeatures() {
   QgisApp::instance()->messageBar()->pushMessage( tr( "AAA" ), tr( "BBB." ), Qgis::MessageLevel::Warning );
+  // MITODO Resume here April 22 morning 
+  emit ( moreFeaturesRequested() );
 }
 
 const int QgsIdentifyResultsDialog::getMaxResults() const

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -130,6 +130,7 @@ const QgsSettingsEntryInteger *QgsIdentifyResultsDialog::settingColumnWidth = ne
 
 const QgsSettingsEntryInteger *QgsIdentifyResultsDialog::settingColumnWidthTable = new QgsSettingsEntryInteger( u"identify-column-width-table"_s, QgsSettingsTree::sTreeWindowState, 0 );
 
+
 QgsIdentifyResultsWebView::QgsIdentifyResultsWebView( QWidget *parent )
   : QgsWebView( parent )
 {

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -208,6 +208,9 @@ class APP_EXPORT QgsIdentifyResultsDialog : public QDialog, private Ui::QgsIdent
     //! Adds feature from identify results
     void addFeature( const QgsMapToolIdentify::IdentifyResult &result );
 
+
+    const int getMaxResults() const;
+
     //! Map tool was deactivated
     void deactivate();
 
@@ -229,6 +232,8 @@ class APP_EXPORT QgsIdentifyResultsDialog : public QDialog, private Ui::QgsIdent
     QgsExpressionContextScope expressionContextScope() const;
 
     QgsMapToolSelectionHandler::SelectionMode selectionMode() const;
+
+    void showMoreFeatures();
 
   signals:
     void selectedFeatureChanged( QgsVectorLayer *, QgsFeatureId featureId );

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -208,9 +208,6 @@ class APP_EXPORT QgsIdentifyResultsDialog : public QDialog, private Ui::QgsIdent
     //! Adds feature from identify results
     void addFeature( const QgsMapToolIdentify::IdentifyResult &result );
 
-
-    const int getMaxResults() const;
-
     //! Map tool was deactivated
     void deactivate();
 

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -253,6 +253,8 @@ class APP_EXPORT QgsIdentifyResultsDialog : public QDialog, private Ui::QgsIdent
     //! Emitted when all feature highlights are removed
     void highlightsCleared();
 
+    void moreFeaturesRequested();
+
   public slots:
     //! Remove results
     void clear();

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -155,10 +155,10 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
     if ( results.size() != 1 || !QgsIdentifyResultsDialog::settingIdentifyAutoFeatureForm->value() )
       qDebug() << "Total results:" << results.size();
       resultsDialog()->QDialog::show();
-    int maxResults = resultsDialog()->getMaxResults();
+    mMaxResults = resultsDialog()->getMaxResults();
     QList<IdentifyResult>::const_iterator result = results.constBegin();
 
-    while (result != results.constEnd() && resultsIdx <= maxResults) {
+    while (result != results.constEnd() && resultsIdx <= mMaxResults) {
       resultsDialog()->addFeature( *result );
       ++result;
       ++resultsIdx;
@@ -166,7 +166,7 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
 
     // Call QgsIdentifyResultsDialog::show() to adjust with items
     resultsDialog()->show();
-    if (results.size() > maxResults) {
+    if (results.size() > mMaxResults) {
       QgisApp::instance()->messageBar()->pushMessage( tr( "Hidden Features" ), tr( "Some features not displayed in Identify Results, use the Show More Features button." ), Qgis::MessageLevel::Warning );
     }
   }

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -153,15 +153,13 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
     // Show the dialog before items are inserted so that items can resize themselves
     // according to dialog size also the first time, see also #9377
     if ( results.size() != 1 || !QgsIdentifyResultsDialog::settingIdentifyAutoFeatureForm->value() )
-      qDebug() << "Total results:" << results.size();
       resultsDialog()->QDialog::show();
-    mMaxResults = resultsDialog()->getMaxResults();
     QList<IdentifyResult>::const_iterator result = results.constBegin();
 
-    while (result != results.constEnd() && resultsIdx <= mMaxResults) {
+    while (result != results.constEnd() && mResultsIdx < mMaxResults) {
       resultsDialog()->addFeature( *result );
       ++result;
-      ++resultsIdx;
+      ++mResultsIdx;
     };
 
     // Call QgsIdentifyResultsDialog::show() to adjust with items
@@ -180,15 +178,15 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
   };
 
   mMoreFeaturesConnection = connect( resultsDialog(), &QgsIdentifyResultsDialog::moreFeaturesRequested, this, [this, results ]() {
-    this->handleShowMoreFeatures( results, resultsIdx );
+    this->handleShowMoreFeatures( results, mResultsIdx );
   } );
 
 }
 
 void QgsMapToolIdentifyAction::handleShowMoreFeatures( const QList<IdentifyResult> &l, int startIdx) {  
-  qDebug() << "CLICKED";
-  QList<IdentifyResult>::const_iterator nextFeature = l.constBegin() + startIdx + 1;
+  QList<IdentifyResult>::const_iterator nextFeature = l.constBegin() + startIdx; // MITODO Fix this - Will crash if selected feature is 1 only and this is clicked (no feature to add)
   resultsDialog()->addFeature( *nextFeature );
+  ++mResultsIdx;
 }
 
 void QgsMapToolIdentifyAction::canvasMoveEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -157,13 +157,13 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
       resultsDialog()->QDialog::show();
     
     int maxResults = resultsDialog()->getMaxResults();
-    int count = 1;
+    int resultsIdx = 1;
     QList<IdentifyResult>::const_iterator result = results.constBegin();
 
-    while (result != results.constEnd() && count <= maxResults) {
+    while (result != results.constEnd() && resultsIdx <= maxResults) {
       resultsDialog()->addFeature( *result );
       ++result;
-      ++count;
+      ++resultsIdx;
     };
 
     // Call QgsIdentifyResultsDialog::show() to adjust with items
@@ -181,19 +181,20 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
     QObject::disconnect( mMoreFeaturesConnection );
   };
 
-  mMoreFeaturesConnection = connect( resultsDialog(), &QgsIdentifyResultsDialog::moreFeaturesRequested, this, [this, results ]() {
-    this->handleShowMoreFeatures( results );
+  mMoreFeaturesConnection = connect( resultsDialog(), &QgsIdentifyResultsDialog::moreFeaturesRequested, this, [this, results, resultsIdx ]() {
+    this->handleShowMoreFeatures( results, resultsIdx, resultsIdx+4);
   } );
 
 }
 
-void QgsMapToolIdentifyAction::handleShowMoreFeatures( const QList<IdentifyResult> &l ) {  
+void QgsMapToolIdentifyAction::handleShowMoreFeatures( const QList<IdentifyResult> &l, int startIdx, int endIdx) {  
   // MITODO
   // Create a collection of already displayed features
   // Create a collection of remaining features e.g. results minus displayed features
   // If button is clicked, add 20 more features
   // If remaining != 0, display message
-  qDebug() << "Total results:" << l.size();
+  qDebug() << "CLICKED";
+  resultsDialog()->addFeature( l.at(startIdx) );
 }
 
 void QgsMapToolIdentifyAction::canvasMoveEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -45,6 +45,7 @@
 #include <QStatusBar>
 #include <QString>
 #include <QVariant>
+#include <QDebug>
 
 #include "moc_qgsmaptoolidentifyaction.cpp"
 
@@ -152,6 +153,7 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
     // Show the dialog before items are inserted so that items can resize themselves
     // according to dialog size also the first time, see also #9377
     if ( results.size() != 1 || !QgsIdentifyResultsDialog::settingIdentifyAutoFeatureForm->value() )
+      qDebug() << "Total results:" << results.size();
       resultsDialog()->QDialog::show();
     
     int maxResults = resultsDialog()->getMaxResults();
@@ -173,6 +175,25 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
 
   // update possible view modes
   resultsDialog()->updateViewModes();
+
+  // Remove previous connection to avoid adding new features to results
+  if (mMoreFeaturesConnection) {
+    QObject::disconnect( mMoreFeaturesConnection );
+  };
+
+  mMoreFeaturesConnection = connect( resultsDialog(), &QgsIdentifyResultsDialog::moreFeaturesRequested, this, [this, results ]() {
+    this->handleShowMoreFeatures( results );
+  } );
+
+}
+
+void QgsMapToolIdentifyAction::handleShowMoreFeatures( const QList<IdentifyResult> &l ) {  
+  // MITODO
+  // Create a collection of already displayed features
+  // Create a collection of remaining features e.g. results minus displayed features
+  // If button is clicked, add 20 more features
+  // If remaining != 0, display message
+  qDebug() << "Total results:" << l.size();
 }
 
 void QgsMapToolIdentifyAction::canvasMoveEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -112,6 +112,9 @@ void QgsMapToolIdentifyAction::showAttributeTable( QgsMapLayer *layer, const QLi
 void QgsMapToolIdentifyAction::identifyFromGeometry()
 {
   resultsDialog()->clear();
+  if (mResultsIdx > 0) {
+    mResultsIdx = 0;
+  }
   connect( this, &QgsMapToolIdentifyAction::identifyMessage, QgisApp::instance(), &QgisApp::showStatusMessage );
 
   const QgsGeometry geometry = mSelectionHandler->selectedGeometry();
@@ -165,7 +168,7 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
     // Call QgsIdentifyResultsDialog::show() to adjust with items
     resultsDialog()->show();
     if (results.size() > mMaxResults) {
-      QgisApp::instance()->messageBar()->pushMessage( tr( "Hidden Features" ), tr( "Some features not displayed in Identify Results, use the Show More Features button." ), Qgis::MessageLevel::Warning );
+      QgisApp::instance()->messageBar()->pushMessage( tr( "Some features not displayed in Identify Results, use the Show More Features button." ), Qgis::MessageLevel::Warning );
     }
   }
 
@@ -178,15 +181,19 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
   };
 
   mMoreFeaturesConnection = connect( resultsDialog(), &QgsIdentifyResultsDialog::moreFeaturesRequested, this, [this, results ]() {
-    this->handleShowMoreFeatures( results, mResultsIdx );
+    this->handleShowMoreFeatures( results, mResultsIdx, results.size() );
   } );
 
 }
 
-void QgsMapToolIdentifyAction::handleShowMoreFeatures( const QList<IdentifyResult> &l, int startIdx) {  
-  QList<IdentifyResult>::const_iterator nextFeature = l.constBegin() + startIdx; // MITODO Fix this - Will crash if selected feature is 1 only and this is clicked (no feature to add)
-  resultsDialog()->addFeature( *nextFeature );
-  ++mResultsIdx;
+void QgsMapToolIdentifyAction::handleShowMoreFeatures( const QList<IdentifyResult> &l, int startIdx, int featureCount) {  
+  QList<IdentifyResult>::const_iterator nextFeature = l.constBegin() + startIdx;
+  if (mResultsIdx == featureCount) {
+    QgisApp::instance()->messageBar()->pushMessage( tr( "All features displayed already" ), Qgis::MessageLevel::Warning );
+  } else {
+    resultsDialog()->addFeature( *nextFeature );
+    ++mResultsIdx;
+  }
 }
 
 void QgsMapToolIdentifyAction::canvasMoveEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -45,7 +45,6 @@
 #include <QStatusBar>
 #include <QString>
 #include <QVariant>
-#include <QDebug>
 
 #include "moc_qgsmaptoolidentifyaction.cpp"
 
@@ -187,12 +186,21 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
 }
 
 void QgsMapToolIdentifyAction::handleShowMoreFeatures( const QList<IdentifyResult> &l, int startIdx, int featureCount) {  
+  // Put index starting at the  21st feature or the next feature after mMaxResults is reached
   QList<IdentifyResult>::const_iterator nextFeature = l.constBegin() + startIdx;
-  if (mResultsIdx == featureCount) {
-    QgisApp::instance()->messageBar()->pushMessage( tr( "All features displayed already" ), Qgis::MessageLevel::Warning );
-  } else {
-    resultsDialog()->addFeature( *nextFeature );
-    ++mResultsIdx;
+
+  // Add features by batch
+  int newResultsIdx = 0;
+  while (newResultsIdx < mResultsBatchSize) {
+    if (mResultsIdx == featureCount) {
+      QgisApp::instance()->messageBar()->pushMessage( tr( "All features displayed already" ), Qgis::MessageLevel::Warning );
+      break;
+    } else {
+      resultsDialog()->addFeature( *nextFeature );
+      ++mResultsIdx;    // Counter for all the features of a layer, should not exceed the layer's feature count
+      ++newResultsIdx; // Counter for the features after the first batch added to Identify Results
+      ++nextFeature;    // Moves on to the next feature
+    }
   }
 }
 

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -30,6 +30,7 @@
 #include "qgsmaplayeraction.h"
 #include "qgsmapmouseevent.h"
 #include "qgsmaptoolselectionhandler.h"
+#include "qgsmessagebar.h"
 #include "qgsproject.h"
 #include "qgsrasterlayer.h"
 #include "qgssettingsentryenumflag.h"
@@ -152,15 +153,22 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
     // according to dialog size also the first time, see also #9377
     if ( results.size() != 1 || !QgsIdentifyResultsDialog::settingIdentifyAutoFeatureForm->value() )
       resultsDialog()->QDialog::show();
+    
+    int maxResults = resultsDialog()->getMaxResults();
+    int count = 1;
+    QList<IdentifyResult>::const_iterator result = results.constBegin();
 
-    QList<IdentifyResult>::const_iterator result;
-    for ( result = results.constBegin(); result != results.constEnd(); ++result )
-    {
+    while (result != results.constEnd() && count <= maxResults) {
       resultsDialog()->addFeature( *result );
-    }
+      ++result;
+      ++count;
+    };
 
     // Call QgsIdentifyResultsDialog::show() to adjust with items
     resultsDialog()->show();
+    if (results.size() > maxResults) {
+      QgisApp::instance()->messageBar()->pushMessage( tr( "Hidden Features" ), tr( "Some features not displayed in Identify Results, use the Show More Features button." ), Qgis::MessageLevel::Warning );
+    }
   }
 
   // update possible view modes

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -155,9 +155,7 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
     if ( results.size() != 1 || !QgsIdentifyResultsDialog::settingIdentifyAutoFeatureForm->value() )
       qDebug() << "Total results:" << results.size();
       resultsDialog()->QDialog::show();
-    
     int maxResults = resultsDialog()->getMaxResults();
-    int resultsIdx = 1;
     QList<IdentifyResult>::const_iterator result = results.constBegin();
 
     while (result != results.constEnd() && resultsIdx <= maxResults) {
@@ -181,20 +179,16 @@ void QgsMapToolIdentifyAction::identifyFromGeometry()
     QObject::disconnect( mMoreFeaturesConnection );
   };
 
-  mMoreFeaturesConnection = connect( resultsDialog(), &QgsIdentifyResultsDialog::moreFeaturesRequested, this, [this, results, resultsIdx ]() {
-    this->handleShowMoreFeatures( results, resultsIdx, resultsIdx+4);
+  mMoreFeaturesConnection = connect( resultsDialog(), &QgsIdentifyResultsDialog::moreFeaturesRequested, this, [this, results ]() {
+    this->handleShowMoreFeatures( results, resultsIdx );
   } );
 
 }
 
-void QgsMapToolIdentifyAction::handleShowMoreFeatures( const QList<IdentifyResult> &l, int startIdx, int endIdx) {  
-  // MITODO
-  // Create a collection of already displayed features
-  // Create a collection of remaining features e.g. results minus displayed features
-  // If button is clicked, add 20 more features
-  // If remaining != 0, display message
+void QgsMapToolIdentifyAction::handleShowMoreFeatures( const QList<IdentifyResult> &l, int startIdx) {  
   qDebug() << "CLICKED";
-  resultsDialog()->addFeature( l.at(startIdx) );
+  QList<IdentifyResult>::const_iterator nextFeature = l.constBegin() + startIdx + 1;
+  resultsDialog()->addFeature( *nextFeature );
 }
 
 void QgsMapToolIdentifyAction::canvasMoveEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -81,6 +81,8 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
      */
     QgsIdentifyResultsDialog *resultsDialog();
 
+    int mMaxResults;
+
   public slots:
     void handleCopyToClipboard( QgsFeatureStore & );
     void handleChangedRasterResults( QList<QgsMapToolIdentify::IdentifyResult> &results );

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -81,8 +81,6 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
      */
     QgsIdentifyResultsDialog *resultsDialog();
 
-    int mMaxResults;
-
   public slots:
     void handleCopyToClipboard( QgsFeatureStore & );
     void handleChangedRasterResults( QList<QgsMapToolIdentify::IdentifyResult> &results );
@@ -113,7 +111,9 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
 
     QMetaObject::Connection mMoreFeaturesConnection;
 
-    int resultsIdx = 1;
+    const int mMaxResults = 5;
+    
+    int mResultsIdx = 0;
 };
 
 #endif

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -84,7 +84,7 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
   public slots:
     void handleCopyToClipboard( QgsFeatureStore & );
     void handleChangedRasterResults( QList<QgsMapToolIdentify::IdentifyResult> &results );
-    void handleShowMoreFeatures( const QList<QgsMapToolIdentify::IdentifyResult> &l, int startIdx );
+    void handleShowMoreFeatures( const QList<QgsMapToolIdentify::IdentifyResult> &l, int startIdx, int featureCount );
 
   signals:
 
@@ -111,7 +111,9 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
 
     QMetaObject::Connection mMoreFeaturesConnection;
 
-    const int mMaxResults = 5;
+    const int mMaxResults = 20;
+
+    const int mResultsBatchSize = 10;
     
     int mResultsIdx = 0;
 };

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -84,6 +84,7 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
   public slots:
     void handleCopyToClipboard( QgsFeatureStore & );
     void handleChangedRasterResults( QList<QgsMapToolIdentify::IdentifyResult> &results );
+    void handleShowMoreFeatures( const QList<QgsMapToolIdentify::IdentifyResult> &l );
 
   signals:
 
@@ -107,6 +108,8 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
     void setClickContextScope( const QgsPointXY &point );
 
     friend class TestQgsIdentify;
+
+    QMetaObject::Connection mMoreFeaturesConnection;
 };
 
 #endif

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -84,7 +84,7 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
   public slots:
     void handleCopyToClipboard( QgsFeatureStore & );
     void handleChangedRasterResults( QList<QgsMapToolIdentify::IdentifyResult> &results );
-    void handleShowMoreFeatures( const QList<QgsMapToolIdentify::IdentifyResult> &l, int startIdx, int endIdx );
+    void handleShowMoreFeatures( const QList<QgsMapToolIdentify::IdentifyResult> &l, int startIdx );
 
   signals:
 
@@ -110,6 +110,8 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
     friend class TestQgsIdentify;
 
     QMetaObject::Connection mMoreFeaturesConnection;
+
+    int resultsIdx = 1;
 };
 
 #endif

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -84,7 +84,7 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
   public slots:
     void handleCopyToClipboard( QgsFeatureStore & );
     void handleChangedRasterResults( QList<QgsMapToolIdentify::IdentifyResult> &results );
-    void handleShowMoreFeatures( const QList<QgsMapToolIdentify::IdentifyResult> &l );
+    void handleShowMoreFeatures( const QList<QgsMapToolIdentify::IdentifyResult> &l, int startIdx, int endIdx );
 
   signals:
 

--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -69,6 +69,7 @@
          <addaction name="mExpandNewAction"/>
          <addaction name="separator"/>
          <addaction name="mClearResultsAction"/>
+         <addaction name="mShowMoreFeatures"/>
          <addaction name="separator"/>
          <addaction name="mActionCopy"/>
          <addaction name="mActionPrint"/>
@@ -287,6 +288,18 @@
    </property>
    <property name="toolTip">
     <string>Clear Results</string>
+   </property>
+  </action>
+    <action name="mShowMoreFeatures">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mShowMoreFeatures.svg</normaloff>:/images/themes/default/mShowMoreFeatures.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Show More Features</string>
+   </property>
+   <property name="toolTip">
+    <string>Show More Features</string>
    </property>
   </action>
   <action name="mActionCopy">


### PR DESCRIPTION
## Description

- Fixes #60567 
- Limit features in Identify Results panel to 20
- User will click a button to add 10 more features until all features are shown

https://github.com/user-attachments/assets/bb0a8e9d-44bb-46f2-878a-8973ff33d646

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.