### PR TITLE
provide easy access to a settings node for plugins

### DIFF
--- a/python/PyQt6/core/auto_generated/settings/qgssettingstree.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingstree.sip.in
@@ -41,13 +41,28 @@ Returns the tree node at the given ``key``
 
     static QgsSettingsTreeNode *createPluginTreeNode( const QString &pluginName );
 %Docstring
-Creates a settings tree node for the given ``pluginName``
+Creates a settings tree node for the given ``pluginName``.
+
+.. note::
+
+   For Python plugins, the node is created automatically by QGIS
+   when the plugin is started and is exposed as the
+   ``QGIS_PLUGIN_SETTINGS_NODE`` attribute on the plugin package.
+   Plugin authors should retrieve it with
+   ``from <my_plugin> import QGIS_PLUGIN_SETTINGS_NODE`` rather than
+   calling this method directly.
 %End
 
 
     static void unregisterPluginTreeNode( const QString &pluginName );
 %Docstring
-Unregisters the tree node for the given plugin
+Unregisters the tree node for the given plugin.
+
+.. note::
+
+   For Python plugins, the node is unregistered automatically by
+   QGIS when the plugin is unloaded; plugins do not need to call this
+   method themselves.
 %End
 };
 

--- a/python/PyQt6/core/auto_generated/settings/qgssettingstree.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingstree.sip.in
@@ -45,11 +45,11 @@ Creates a settings tree node for the given ``pluginName``.
 
 .. note::
 
-   For Python plugins, the node is created automatically by QGIS
+   Since QGIS 4.2 for Python plugins, the node is created automatically by QGIS
    when the plugin is started and is exposed as the
-   ``QGIS_PLUGIN_SETTINGS_NODE`` attribute on the plugin package.
+   ``SETTINGS_NODE`` attribute on the plugin package.
    Plugin authors should retrieve it with
-   ``from <my_plugin> import QGIS_PLUGIN_SETTINGS_NODE`` rather than
+   ``from <my_plugin> import SETTINGS_NODE`` rather than
    calling this method directly.
 %End
 
@@ -60,7 +60,7 @@ Unregisters the tree node for the given plugin.
 
 .. note::
 
-   For Python plugins, the node is unregistered automatically by
+   Since QGIS 4.2 for Python plugins, the node is unregistered automatically by
    QGIS when the plugin is unloaded; plugins do not need to call this
    method themselves.
 %End

--- a/python/utils.py
+++ b/python/utils.py
@@ -483,7 +483,7 @@ def _startPlugin(packageName: str) -> bool:
     # import time. The node lives at "plugins/<packageName>" in the settings
     # tree and is automatically removed in unloadPlugin().
     try:
-        package.QGIS_PLUGIN_SETTINGS_NODE = QgsSettingsTree.createPluginTreeNode(
+        package.SETTINGS_NODE = QgsSettingsTree.createPluginTreeNode(
             packageName
         )
     except Exception:

--- a/python/utils.py
+++ b/python/utils.py
@@ -483,9 +483,7 @@ def _startPlugin(packageName: str) -> bool:
     # import time. The node lives at "plugins/<packageName>" in the settings
     # tree and is automatically removed in unloadPlugin().
     try:
-        package.SETTINGS_NODE = QgsSettingsTree.createPluginTreeNode(
-            packageName
-        )
+        package.SETTINGS_NODE = QgsSettingsTree.createPluginTreeNode(packageName)
     except Exception:
         QgsMessageLog.logMessage(
             f"Could not create settings tree node for plugin '{packageName}':\n{traceback.format_exc()}",

--- a/python/utils.py
+++ b/python/utils.py
@@ -35,7 +35,13 @@ import traceback
 import warnings
 from typing import Optional
 
-from qgis.core import Qgis, QgsMessageLog, QgsMessageOutput, qgsfunction
+from qgis.core import (
+    Qgis,
+    QgsMessageLog,
+    QgsMessageOutput,
+    QgsSettingsTree,
+    qgsfunction,
+)
 from qgis.gui import QgsMessageBar
 from qgis.PyQt.QtCore import (
     QT_VERSION_STR,
@@ -472,10 +478,31 @@ def _startPlugin(packageName: str) -> bool:
 
     package = sys.modules[packageName]
 
+    # Create the plugin's settings tree node and expose it as a module-level
+    # attribute so the plugin can access it during classFactory and at module
+    # import time. The node lives at "plugins/<packageName>" in the settings
+    # tree and is automatically removed in unloadPlugin().
+    try:
+        package.QGIS_PLUGIN_SETTINGS_NODE = QgsSettingsTree.createPluginTreeNode(
+            packageName
+        )
+    except Exception:
+        QgsMessageLog.logMessage(
+            f"Could not create settings tree node for plugin '{packageName}':\n{traceback.format_exc()}",
+            "Plugins",
+            Qgis.MessageLevel.Warning,
+        )
+
     # create an instance of the plugin
     try:
         plugins[packageName] = package.classFactory(iface)
     except:
+        # classFactory failed: drop the just-created settings node so we don't
+        # leave a stale empty node behind.
+        try:
+            QgsSettingsTree.unregisterPluginTreeNode(packageName)
+        except Exception:
+            pass
         _unloadPluginModules(packageName)
         errMsg = QCoreApplication.translate(
             "Python", "Couldn't load plugin '{0}'"
@@ -657,6 +684,16 @@ def unloadPlugin(packageName: str) -> bool:
             messagebar=True,
         )
         return False
+    finally:
+        # Always remove the plugin's settings tree node, even if unload() raised.
+        try:
+            QgsSettingsTree.unregisterPluginTreeNode(packageName)
+        except Exception:
+            QgsMessageLog.logMessage(
+                f"Could not unregister settings tree node for plugin '{packageName}':\n{traceback.format_exc()}",
+                "Plugins",
+                Qgis.MessageLevel.Warning,
+            )
 
 
 def _unloadPluginModules(packageName: str):

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -99,11 +99,11 @@ class CORE_EXPORT QgsSettingsTree
     /**
      * Creates a settings tree node for the given \a pluginName.
      *
-     * \note For Python plugins, the node is created automatically by QGIS
+     * \note Since QGIS 4.2 for Python plugins, the node is created automatically by QGIS
      * when the plugin is started and is exposed as the
      * ``QGIS_PLUGIN_SETTINGS_NODE`` attribute on the plugin package.
      * Plugin authors should retrieve it with
-     * ``from <my_plugin> import QGIS_PLUGIN_SETTINGS_NODE`` rather than
+     * ``from <my_plugin> import SETTINGS_NODE`` rather than
      * calling this method directly.
      */
     static QgsSettingsTreeNode *createPluginTreeNode( const QString &pluginName );
@@ -112,7 +112,7 @@ class CORE_EXPORT QgsSettingsTree
     /**
      * Unregisters the tree node for the given plugin.
      *
-     * \note For Python plugins, the node is unregistered automatically by
+     * \note Since QGIS 4.2 for Python plugins, the node is unregistered automatically by
      * QGIS when the plugin is unloaded; plugins do not need to call this
      * method themselves.
      */

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -97,13 +97,24 @@ class CORE_EXPORT QgsSettingsTree
     static const QgsSettingsTreeNode *node( const QString &key ) { return treeRoot()->childNode( key ); }
 
     /**
-     * Creates a settings tree node for the given \a pluginName
+     * Creates a settings tree node for the given \a pluginName.
+     *
+     * \note For Python plugins, the node is created automatically by QGIS
+     * when the plugin is started and is exposed as the
+     * ``QGIS_PLUGIN_SETTINGS_NODE`` attribute on the plugin package.
+     * Plugin authors should retrieve it with
+     * ``from <my_plugin> import QGIS_PLUGIN_SETTINGS_NODE`` rather than
+     * calling this method directly.
      */
     static QgsSettingsTreeNode *createPluginTreeNode( const QString &pluginName );
 
 
     /**
-     * Unregisters the tree node for the given plugin
+     * Unregisters the tree node for the given plugin.
+     *
+     * \note For Python plugins, the node is unregistered automatically by
+     * QGIS when the plugin is unloaded; plugins do not need to call this
+     * method themselves.
      */
     static void unregisterPluginTreeNode( const QString &pluginName );
 };


### PR DESCRIPTION
This should simplify a lot the use of the new settings API in plugins.
Thanks to @Guts' idea :)

This is how this would look like:

```python
# my_plugin/settings.py
from qgis.core import QgsSettingsEntryBool, QgsSettingsEntryString
from . import SETTINGS_NODE as _node

GREETING = QgsSettingsEntryString("greeting", _node, "Hello")
LOUD = QgsSettingsEntryBool("loud", _node, False)
```

```python
# my_plugin/my_plugin.py
from qgis.core import Qgis, QgsMessageLog

from . import settings


class MyPlugin:
    def __init__(self, iface):
        self.iface = iface

    def initGui(self):
        pass

    def unload(self):
        pass

    def say_hello(self):
        msg = settings.GREETING.value()
        if settings.LOUD.value():
            msg = msg.upper() + "!!!"
        QgsMessageLog.logMessage(msg, "MyPlugin", Qgis.MessageLevel.Info)

        # write a setting back
        settings.LOUD.setValue(not settings.LOUD.value())
```

<img width="564" height="547" alt="image" src="https://github.com/user-attachments/assets/2d8109e0-337a-479f-b3e5-ca40dd57ab87" />

<img width="829" height="265" alt="image" src="https://github.com/user-attachments/assets/b60a6da0-0ab6-4181-99e1-3bb867392871" />


Open for the discussion, I'll add a test if we move forward.

  [x] AI: used to challenge the idea + write the code