### PR TITLE
Use ghcr instead of actions cache for build deps docker

### DIFF
--- a/.ci/ogc/build.sh
+++ b/.ci/ogc/build.sh
@@ -9,7 +9,7 @@ export LANG="C.UTF-8"
 
 export CCACHE_TEMPDIR=/tmp
 # Github workflow cache max size is 2.0, but ccache data get compressed (roughly 1/5?)
-ccache -M 2.0G
+ccache -M 500M
 
 # Temporarily uncomment to debug ccache issues
 # export CCACHE_LOGFILE=/tmp/cache.debug

--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -37,6 +37,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build:

--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build Docker Container
         id: docker-build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
@@ -66,8 +73,9 @@ jobs:
           tags: qgis/qgis-deps-ogc:${{ github.event.pull_request.base.ref || github.ref_name }}
           context: .ci/ogc
           file: .ci/ogc/Dockerfile
-          cache-from: type=registry,ref=qgis/qgis-deps-ogc:buildcache
-          cache-to: type=registry,ref=qgis/qgis-deps-ogc:buildcache,mode=min
+          cache-from: type=registry,ref=ghcr.io/qgis/qgis-deps-ogc:buildcache
+          #  Replace with ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/qgis/qgis-deps-ogc:buildcache,mode=min' || '' }}
+          cache-to: type=registry,ref=ghcr.io/qgis/qgis-deps-ogc:buildcache,mode=min
           load: true
 
       - name: Run build

--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -66,7 +66,7 @@ jobs:
           context: .ci/ogc
           file: .ci/ogc/Dockerfile
           cache-from: type=registry,ref=qgis/qgis-deps-ogc:buildcache
-          cache-to: type=registry,qgis/qgis-deps-ogc:buildcache,mode=min
+          cache-to: type=registry,ref=qgis/qgis-deps-ogc:buildcache,mode=min
           load: true
 
       - name: Run build

--- a/.github/workflows/ogc.yml
+++ b/.github/workflows/ogc.yml
@@ -65,8 +65,8 @@ jobs:
           tags: qgis/qgis-deps-ogc:${{ github.event.pull_request.base.ref || github.ref_name }}
           context: .ci/ogc
           file: .ci/ogc/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=qgis/qgis-deps-ogc:buildcache
+          cache-to: type=registry,qgis/qgis-deps-ogc:buildcache,mode=min
           load: true
 
       - name: Run build


### PR DESCRIPTION
Also decrease ccache size for ogc builds to 500M

Further reduce the pressure on github actions cache