### PR TITLE
When going from single<->rule based 3d renderer, don't reset all settings

### DIFF
--- a/python/PyQt6/3d/auto_additions/qgsrulebased3drenderer.py
+++ b/python/PyQt6/3d/auto_additions/qgsrulebased3drenderer.py
@@ -7,10 +7,11 @@ try:
 except (NameError, AttributeError):
     pass
 try:
-    QgsRuleBased3DRendererMetadata.__overridden_methods__ = ['createRenderer']
+    QgsRuleBased3DRenderer.convertFromRenderer = staticmethod(QgsRuleBased3DRenderer.convertFromRenderer)
+    QgsRuleBased3DRenderer.__overridden_methods__ = ['type', 'clone', 'writeXml', 'readXml']
 except (NameError, AttributeError):
     pass
 try:
-    QgsRuleBased3DRenderer.__overridden_methods__ = ['type', 'clone', 'writeXml', 'readXml']
+    QgsRuleBased3DRendererMetadata.__overridden_methods__ = ['createRenderer']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/3d/auto_additions/qgsvectorlayer3drenderer.py
+++ b/python/PyQt6/3d/auto_additions/qgsvectorlayer3drenderer.py
@@ -1,9 +1,10 @@
 # The following has been generated automatically from src/3d/qgsvectorlayer3drenderer.h
 try:
-    QgsVectorLayer3DRendererMetadata.__overridden_methods__ = ['createRenderer']
+    QgsVectorLayer3DRenderer.convertFromRenderer = staticmethod(QgsVectorLayer3DRenderer.convertFromRenderer)
+    QgsVectorLayer3DRenderer.__overridden_methods__ = ['type', 'clone', 'writeXml', 'readXml']
 except (NameError, AttributeError):
     pass
 try:
-    QgsVectorLayer3DRenderer.__overridden_methods__ = ['type', 'clone', 'writeXml', 'readXml']
+    QgsVectorLayer3DRendererMetadata.__overridden_methods__ = ['createRenderer']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
@@ -146,11 +146,12 @@ Returns tiling settings of the renderer
     virtual void resolveReferences( const QgsProject &project );
 
 
-  protected:
     void copyBaseProperties( QgsAbstractVectorLayer3DRenderer *r ) const;
 %Docstring
 Copies common properties of this object to another object
 %End
+
+  protected:
     void writeXmlBaseProperties( QDomElement &elem, const QgsReadWriteContext &context ) const;
 %Docstring
 Writes common properties of this object to DOM element

--- a/python/PyQt6/3d/auto_generated/qgsrulebased3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgsrulebased3drenderer.sip.in
@@ -261,6 +261,16 @@ Returns pointer to the root rule
     virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context );
 
 
+    static std::unique_ptr< QgsRuleBased3DRenderer > convertFromRenderer( const QgsAbstractVectorLayer3DRenderer *renderer, QgsVectorLayer *layer = 0 );
+%Docstring
+Creates a new QgsRuleBased3DRenderer from an existing ``renderer``.
+
+:return: a new renderer if the conversion was possible, otherwise
+         ``None``.
+
+.. versionadded:: 4.2
+%End
+
 };
 
 /************************************************************************

--- a/python/PyQt6/3d/auto_generated/qgsvectorlayer3drenderer.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgsvectorlayer3drenderer.sip.in
@@ -74,6 +74,16 @@ Returns 3D symbol associated with the renderer
     virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context );
 
 
+    static std::unique_ptr< QgsVectorLayer3DRenderer > convertFromRenderer( const QgsAbstractVectorLayer3DRenderer *renderer, QgsVectorLayer *layer = 0 );
+%Docstring
+Creates a new QgsVectorLayer3DRenderer from an existing ``renderer``.
+
+:return: a new renderer if the conversion was possible, otherwise
+         ``None``.
+
+.. versionadded:: 4.2
+%End
+
   private:
     QgsVectorLayer3DRenderer( const QgsVectorLayer3DRenderer & );
     QgsVectorLayer3DRenderer &operator=( const QgsVectorLayer3DRenderer & );

--- a/src/3d/qgsabstractvectorlayer3drenderer.h
+++ b/src/3d/qgsabstractvectorlayer3drenderer.h
@@ -134,9 +134,10 @@ class _3D_EXPORT QgsAbstractVectorLayer3DRenderer : public QgsAbstract3DRenderer
 
     void resolveReferences( const QgsProject &project ) override;
 
-  protected:
     //! Copies common properties of this object to another object
     void copyBaseProperties( QgsAbstractVectorLayer3DRenderer *r ) const;
+
+  protected:
     //! Writes common properties of this object to DOM element
     void writeXmlBaseProperties( QDomElement &elem, const QgsReadWriteContext &context ) const;
     //! Reads common properties of this object from DOM element

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -24,6 +24,7 @@
 #include "qgsfeature3dhandler_p.h"
 #include "qgsrulebasedchunkloader_p.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectorlayer3drenderer.h"
 #include "qgsxmlutils.h"
 
 #include <QString>
@@ -409,4 +410,32 @@ void QgsRuleBased3DRenderer::readXml( const QDomElement &elem, const QgsReadWrit
   readXmlBaseProperties( elem, context );
 
   // root rule is read before class constructed
+}
+
+std::unique_ptr<QgsRuleBased3DRenderer> QgsRuleBased3DRenderer::convertFromRenderer( const QgsAbstractVectorLayer3DRenderer *renderer, QgsVectorLayer * )
+{
+  std::unique_ptr< QgsRuleBased3DRenderer > r;
+  if ( renderer->type() == "rulebased"_L1 )
+  {
+    r.reset( dynamic_cast<const QgsRuleBased3DRenderer *>( renderer )->clone() );
+  }
+  else if ( renderer->type() == "vector"_L1 )
+  {
+    const QgsVectorLayer3DRenderer *singleSymbolRenderer = dynamic_cast<const QgsVectorLayer3DRenderer *>( renderer );
+    if ( !singleSymbolRenderer )
+      return nullptr;
+
+    std::unique_ptr< QgsAbstract3DSymbol > origSymbol( singleSymbolRenderer->symbol()->clone() );
+    auto rootRule = std::make_unique< Rule >( nullptr );
+    rootRule->appendChild( new Rule( origSymbol.release() ) );
+
+    r = std::make_unique< QgsRuleBased3DRenderer >( rootRule.release() );
+  }
+
+  if ( r )
+  {
+    renderer->copyBaseProperties( r.get() );
+  }
+
+  return r;
 }

--- a/src/3d/qgsrulebased3drenderer.h
+++ b/src/3d/qgsrulebased3drenderer.h
@@ -308,6 +308,15 @@ class _3D_EXPORT QgsRuleBased3DRenderer : public QgsAbstractVectorLayer3DRendere
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
     void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
 
+    /**
+     * Creates a new QgsRuleBased3DRenderer from an existing \a renderer.
+     *
+     * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
+     *
+     * \since QGIS 4.2
+     */
+    static std::unique_ptr< QgsRuleBased3DRenderer > convertFromRenderer( const QgsAbstractVectorLayer3DRenderer *renderer, QgsVectorLayer *layer = nullptr );
+
   private:
     Rule *mRootRule = nullptr;
 };

--- a/src/3d/qgsvectorlayer3drenderer.cpp
+++ b/src/3d/qgsvectorlayer3drenderer.cpp
@@ -18,6 +18,7 @@
 #include "qgs3dsymbolregistry.h"
 #include "qgs3dutils.h"
 #include "qgsapplication.h"
+#include "qgsrulebased3drenderer.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerchunkloader_p.h"
 #include "qgsxmlutils.h"
@@ -96,4 +97,41 @@ void QgsVectorLayer3DRenderer::readXml( const QDomElement &elem, const QgsReadWr
   mSymbol.reset( QgsApplication::symbol3DRegistry()->createSymbol( symbolType ) );
   if ( mSymbol )
     mSymbol->readXml( elemSymbol, context );
+}
+
+std::unique_ptr<QgsVectorLayer3DRenderer> QgsVectorLayer3DRenderer::convertFromRenderer( const QgsAbstractVectorLayer3DRenderer *renderer, QgsVectorLayer * )
+{
+  std::unique_ptr< QgsVectorLayer3DRenderer > r;
+  if ( renderer->type() == "vector"_L1 )
+  {
+    r.reset( dynamic_cast<const QgsVectorLayer3DRenderer *>( renderer )->clone() );
+  }
+  else if ( renderer->type() == "rulebased"_L1 )
+  {
+    const QgsRuleBased3DRenderer *ruleBasedRenderer = dynamic_cast<const QgsRuleBased3DRenderer *>( renderer );
+    if ( !ruleBasedRenderer->rootRule()->children().isEmpty() )
+    {
+      std::unique_ptr< QgsAbstract3DSymbol > origSymbol;
+      const QList< QgsRuleBased3DRenderer::Rule * > children = ruleBasedRenderer->rootRule()->children();
+      for ( const QgsRuleBased3DRenderer::Rule *child : children )
+      {
+        if ( child->symbol() )
+        {
+          origSymbol.reset( child->symbol()->clone() );
+          break;
+        }
+      }
+      if ( origSymbol )
+      {
+        r = std::make_unique< QgsVectorLayer3DRenderer >( origSymbol.release() );
+      }
+    }
+  }
+
+  if ( r )
+  {
+    renderer->copyBaseProperties( r.get() );
+  }
+
+  return r;
 }

--- a/src/3d/qgsvectorlayer3drenderer.h
+++ b/src/3d/qgsvectorlayer3drenderer.h
@@ -69,6 +69,15 @@ class _3D_EXPORT QgsVectorLayer3DRenderer : public QgsAbstractVectorLayer3DRende
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
     void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
 
+    /**
+     * Creates a new QgsVectorLayer3DRenderer from an existing \a renderer.
+     *
+     * \returns a new renderer if the conversion was possible, otherwise NULLPTR.
+     *
+     * \since QGIS 4.2
+     */
+    static std::unique_ptr< QgsVectorLayer3DRenderer > convertFromRenderer( const QgsAbstractVectorLayer3DRenderer *renderer, QgsVectorLayer *layer = nullptr );
+
   private:
     std::unique_ptr<QgsAbstract3DSymbol> mSymbol; //!< 3D symbol that defines appearance
 

--- a/src/app/3d/qgsrulebased3drendererwidget.cpp
+++ b/src/app/3d/qgsrulebased3drendererwidget.cpp
@@ -75,9 +75,16 @@ void QgsRuleBased3DRendererWidget::setLayer( QgsVectorLayer *layer )
     QgsRuleBased3DRenderer *ruleRenderer = static_cast<QgsRuleBased3DRenderer *>( r );
     mRootRule.reset( ruleRenderer->rootRule()->clone() );
   }
-  else
+  else if ( QgsAbstractVectorLayer3DRenderer *vectorRenderer = dynamic_cast< QgsAbstractVectorLayer3DRenderer * >( r ) )
   {
-    // TODO: handle the special case when switching from single symbol renderer
+    std::unique_ptr< QgsRuleBased3DRenderer > newRenderer = QgsRuleBased3DRenderer::convertFromRenderer( vectorRenderer );
+    if ( newRenderer )
+    {
+      mRootRule.reset( newRenderer->rootRule()->clone() );
+    }
+  }
+  if ( !mRootRule )
+  {
     mRootRule = std::make_unique<QgsRuleBased3DRenderer::Rule>( nullptr );
   }
 

--- a/src/app/3d/qgsvectorlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.cpp
@@ -69,12 +69,23 @@ void QgsSingleSymbol3DRendererWidget::setLayer( QgsVectorLayer *layer )
   mLayer = layer;
 
   QgsAbstract3DRenderer *r = mLayer->renderer3D();
+  bool rendererSet = false;
   if ( r && r->type() == "vector"_L1 )
   {
     QgsVectorLayer3DRenderer *vectorRenderer = static_cast<QgsVectorLayer3DRenderer *>( r );
     widgetSymbol->setSymbol( vectorRenderer->symbol(), mLayer );
+    rendererSet = true;
   }
-  else
+  else if ( QgsAbstractVectorLayer3DRenderer *vectorRenderer = dynamic_cast< QgsAbstractVectorLayer3DRenderer * >( r ) )
+  {
+    std::unique_ptr< QgsVectorLayer3DRenderer > newRenderer = QgsVectorLayer3DRenderer::convertFromRenderer( vectorRenderer );
+    if ( newRenderer )
+    {
+      widgetSymbol->setSymbol( newRenderer->symbol(), mLayer );
+      rendererSet = true;
+    }
+  }
+  if ( !rendererSet )
   {
     const std::unique_ptr<QgsAbstract3DSymbol> sym( QgsApplication::symbol3DRegistry()->defaultSymbolForGeometryType( mLayer->geometryType() ) );
     sym->setDefaultPropertiesFromLayer( mLayer );


### PR DESCRIPTION
Follow same approach as we use for 2d renderer conversion, so eg single->rule based copies the single symbol as a new initial rule, and rule->single grabs the symbol from the FIRST rule


## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
