### PR TITLE
A couple of paper cut fixes for the QML editor widget's configuration dialog

### DIFF
--- a/src/gui/codeeditors/qgscodeeditor.cpp
+++ b/src/gui/codeeditors/qgscodeeditor.cpp
@@ -117,6 +117,9 @@ QgsCodeEditor::QgsCodeEditor( QWidget *parent, const QString &title, bool foldin
   setSciWidget();
   setHorizontalScrollBarPolicy( Qt::ScrollBarAsNeeded );
 
+  SendScintilla( SCI_STYLESETBACK, STYLE_DEFAULT, lexerColor( QgsCodeEditorColorScheme::ColorRole::Background ) );
+  SendScintilla( SCI_STYLESETFORE, STYLE_DEFAULT, lexerColor( QgsCodeEditorColorScheme::ColorRole::Default ) );
+
   SendScintilla( SCI_SETADDITIONALSELECTIONTYPING, 1 );
   SendScintilla( SCI_SETMULTIPASTE, 1 );
   SendScintilla( SCI_SETVIRTUALSPACEOPTIONS, SCVS_RECTANGULARSELECTION );
@@ -124,6 +127,7 @@ QgsCodeEditor::QgsCodeEditor( QWidget *parent, const QString &title, bool foldin
   SendScintilla( SCI_SETMARGINTYPEN, static_cast<int>( QgsCodeEditor::MarginRole::ErrorIndicators ), SC_MARGIN_SYMBOL );
   SendScintilla( SCI_SETMARGINMASKN, static_cast<int>( QgsCodeEditor::MarginRole::ErrorIndicators ), 1 << MARKER_NUMBER );
   setMarginWidth( static_cast<int>( QgsCodeEditor::MarginRole::ErrorIndicators ), 0 );
+
   setAnnotationDisplay( QsciScintilla::AnnotationBoxed );
 
   connect( QgsGui::instance(), &QgsGui::optionsChanged, this, [this] {
@@ -165,6 +169,8 @@ QgsCodeEditor::QgsCodeEditor( QWidget *parent, const QString &title, bool foldin
   mLastEditTimer->setInterval( 1000 );
   connect( mLastEditTimer, &QTimer::timeout, this, &QgsCodeEditor::onLastEditTimeout );
   connect( this, &QgsCodeEditor::textChanged, mLastEditTimer, qOverload<>( &QTimer::start ) );
+
+  SendScintilla( SCI_STYLECLEARALL );
 }
 
 // Workaround a bug in QScintilla 2.8.X

--- a/src/gui/editorwidgets/qgsqmlwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsqmlwidgetwrapper.cpp
@@ -23,9 +23,12 @@
 
 #include <QQmlContext>
 #include <QQmlEngine>
+#include <QString>
 #include <QUrl>
 
 #include "moc_qgsqmlwidgetwrapper.cpp"
+
+using namespace Qt::StringLiterals;
 
 QgsQmlWidgetWrapper::QgsQmlWidgetWrapper( QgsVectorLayer *layer, QWidget *editor, QWidget *parent )
   : QgsWidgetWrapper( layer, editor, parent )
@@ -74,7 +77,9 @@ void QgsQmlWidgetWrapper::initWidget( QWidget *editor )
     return;
   }
 
-  mWidget->setSource( QUrl::fromLocalFile( mQmlFile.fileName() ) );
+  QUrl sourceUrl = QUrl::fromLocalFile( mQmlFile.fileName() );
+  sourceUrl.setQuery( u"t=%1"_s.arg( QDateTime::currentSecsSinceEpoch() ) );
+  mWidget->setSource( sourceUrl );
 
   mQmlFile.close();
 }
@@ -119,7 +124,6 @@ void QgsQmlWidgetWrapper::setQmlCode( const QString &qmlCode )
 
   mQmlFile.resize( 0 );
   mQmlFile.write( mQmlCode.toUtf8() );
-
   mQmlFile.close();
 }
 

--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -322,13 +322,6 @@ void QgsAttributesFormLayoutView::onItemDoubleClicked( const QModelIndex &index 
       QgsFeature previewFeature;
       mLayer->getFeatures().nextFeature( previewFeature );
 
-      //update preview on text change
-      connect( qmlCode, &QgsCodeEditor::editingTimeout, this, [qmlWrapper, qmlCode, previewFeature] {
-        qmlWrapper->setQmlCode( qmlCode->text() );
-        qmlWrapper->reinitWidget();
-        qmlWrapper->setFeature( previewFeature );
-      } );
-
       //templates
       QComboBox *qmlObjectTemplate = new QComboBox();
       qmlObjectTemplate->addItem( tr( "Free Text…" ) );
@@ -457,9 +450,37 @@ void QgsAttributesFormLayoutView::onItemDoubleClicked( const QModelIndex &index 
       expressionWidgetBox->layout()->addWidget( expressionWidget );
       expressionWidgetBox->layout()->addWidget( addFieldButton );
       expressionWidgetBox->layout()->addWidget( editExpressionButton );
-      expressionWidgetBox->layout()->addWidget( editExpressionButton );
       layout->addWidget( qmlCodeBox );
       layout->addWidget( qmlCode );
+
+      QTextEdit *errorFeedbackWidget = new QTextEdit();
+      errorFeedbackWidget->setMaximumHeight( 90 );
+      layout->addWidget( errorFeedbackWidget );
+
+      //update preview on text change
+      connect( qmlCode, &QgsCodeEditor::editingTimeout, this, [qmlWrapper, qmlCode, previewFeature, errorFeedbackWidget] {
+        qmlWrapper->setQmlCode( qmlCode->text() );
+        qmlWrapper->reinitWidget();
+        qmlWrapper->setFeature( previewFeature );
+        if ( QQuickWidget *qmlWidget = dynamic_cast<QQuickWidget *>( qmlWrapper->widget() ) )
+        {
+          const QList<QQmlError> errors = qmlWidget->errors();
+          if ( !errors.isEmpty() )
+          {
+            QStringList errorStrings;
+            for ( const QQmlError &error : errors )
+            {
+              errorStrings << u"%1:%2: %3"_s.arg( QString::number( error.line() ), QString::number( error.column() ), error.description() );
+            }
+            errorFeedbackWidget->setText( errorStrings.join( "\n" ) );
+          }
+          else
+          {
+            errorFeedbackWidget->setText( QObject::tr( "Valid code" ) );
+          }
+        }
+      } );
+
       QScrollArea *qmlPreviewBox = new QgsScrollArea();
       qmlPreviewBox->setMinimumWidth( 200 );
       qmlPreviewBox->setWidget( qmlWrapper->widget() );

--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -335,7 +335,7 @@ void QgsAttributesFormLayoutView::onItemDoubleClicked( const QModelIndex &index 
       qmlObjectTemplate->addItem( tr( "Rectangle" ) );
       qmlObjectTemplate->addItem( tr( "Pie Chart" ) );
       qmlObjectTemplate->addItem( tr( "Bar Chart" ) );
-      connect( qmlObjectTemplate, qOverload<int>( &QComboBox::activated ), qmlCode, [qmlCode]( int index ) {
+      connect( qmlObjectTemplate, qOverload<int>( &QComboBox::currentIndexChanged ), qmlCode, [qmlCode]( int index ) {
         qmlCode->clear();
         switch ( index )
         {

--- a/src/gui/vector/qgsattributesformview.cpp
+++ b/src/gui/vector/qgsattributesformview.cpp
@@ -313,7 +313,8 @@ void QgsAttributesFormLayoutView::onItemDoubleClicked( const QModelIndex &index 
       QLineEdit *title = new QLineEdit( itemName );
 
       //qmlCode
-      QgsCodeEditor *qmlCode = new QgsCodeEditor( this );
+      QgsCodeEditor *qmlCode = new QgsCodeEditor( this, QString(), true, true, QgsCodeEditor::Flag::CodeFolding, QgsCodeEditor::Mode::ScriptEditor );
+      qmlCode->setLineNumbersVisible( true );
       qmlCode->setEditingTimeoutInterval( 250 );
       qmlCode->setText( itemData.qmlElementEditorConfiguration().qmlCode );
 


### PR DESCRIPTION
## Description

This PR takes care of a couple of paper cuts when using the QML editor widget's configuration dialog.

First, the code editor widget itself was not properly styled (due to the absence of a proper lexer), which in turn created really hard to read situations on dark / gray themes.  Look at the current line's dark gray with dark text here:

<img width="915" height="703" alt="Screenshot From 2026-05-02 16-59-54" src="https://github.com/user-attachments/assets/30b9d2ed-b33b-43a0-a460-b6389e218847" />

With the PR in, we can read :partying_face: 

<img width="915" height="703" alt="Screenshot From 2026-05-02 16-59-34" src="https://github.com/user-attachments/assets/8548ea6a-c979-4777-8cf0-f07d8b41c7c1" />

Furthermore, the preview area would not reliably update as users were crafting the text. This is fixed now (it might be a Qt6 regression).

Finally, if you were not launching QGIS from a console (i.e. 99.9% of our users :) ), it was impossible to get any feedback as to whether the QML code entered was valid or not, and to know error(s) occurring with the code. The PR adds a feedback area that provides useful hints for users to fix broken QML code:

<img width="1090" height="982" alt="Screenshot From 2026-05-02 17-55-14" src="https://github.com/user-attachments/assets/56a9a854-0172-41a2-8dba-70a6d9d33410" />

