### PR TITLE
Fix QGIS version in the crash handler and qgis_process

### DIFF
--- a/src/core/qgstrackedvectorlayertools.h
+++ b/src/core/qgstrackedvectorlayertools.h
@@ -69,7 +69,7 @@ class CORE_EXPORT QgsTrackedVectorLayerTools : public QgsVectorLayerTools
 
   private:
     const QgsVectorLayerTools *mBackend = nullptr;
-    // TODO QGIS3: remove mutable once methods are no longer const
+    // TODO QGIS5: remove mutable once methods are no longer const
     mutable QMap<QgsVectorLayer *, QgsFeatureIds> mAddedFeatures;
 };
 

--- a/src/crashhandler/main.cpp
+++ b/src/crashhandler/main.cpp
@@ -43,7 +43,7 @@ int main( int argc, char *argv[] )
   QApplication app( argc, argv );
   QApplication::setQuitOnLastWindowClosed( true );
   QCoreApplication::setOrganizationName( "QGIS" );
-  QCoreApplication::setApplicationName( "QGIS3" );
+  QCoreApplication::setApplicationName( "QGIS4" );
 
   QString extraInfoFile = QString( argv[1] );
   std::cout << "Extra Info File: " << extraInfoFile.toUtf8().constData() << std::endl;

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -167,7 +167,7 @@ int main( int argc, char *argv[] )
   // Set up the QSettings environment must be done after qapp is created
   QgsApplication::setOrganizationName( u"QGIS"_s );
   QgsApplication::setOrganizationDomain( u"qgis.org"_s );
-  QgsApplication::setApplicationName( u"QGIS3"_s );
+  QgsApplication::setApplicationName( u"QGIS4"_s );
 
   QgsApplication::init();
   QgsApplication::initQgis();


### PR DESCRIPTION
## Description

Crash handler and `qgis_process` are still use `QGIS3` as an application name while QGIS itself sets it to `QGIS4`. As a result crash data are written to `~/.local/share/QGIS/QGIS3` while everything else is kept in `~/.local/share/QGIS/QGIS4` and `qgis_process`enables plugins in the wrong config (see https://github.com/qgis/QGIS/issues/44783#issuecomment-4363278346)

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.