### PR TITLE
Layer Name in WMS GetFeatureInfo JSON Result as featureType (JSON- FG) member

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -252,7 +252,7 @@ values.
 .. versionadded:: 3.40
 %End
 
-    QString exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), int indent = -1 ) const;
+    QString exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), int indent = -1, const QString &featureType = QString() ) const;
 %Docstring
 Returns a GeoJSON string representation of a feature.
 
@@ -263,6 +263,8 @@ Returns a GeoJSON string representation of a feature.
            feature's ID. If omitted, feature's ID is used.
 :param indent: number of indentation spaces for generated JSON (defaults
                to none)
+:param featureType: optional feature type to pass, like the layer name.
+                    If omitted, it is not written.
 
 :return: GeoJSON string
 

--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -263,8 +263,8 @@ Returns a GeoJSON string representation of a feature.
            feature's ID. If omitted, feature's ID is used.
 :param indent: number of indentation spaces for generated JSON (defaults
                to none)
-:param featureType: optional feature type to pass, like the layer name.
-                    If omitted, it is not written.
+
+.. versionadded:: 4.2
 
 :return: GeoJSON string
 

--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -263,8 +263,8 @@ Returns a GeoJSON string representation of a feature.
            feature's ID. If omitted, feature's ID is used.
 :param indent: number of indentation spaces for generated JSON (defaults
                to none)
-
-.. versionadded:: 4.2
+:param featureType: optional feature type to pass, like the layer name.
+                    If omitted, it is not written (since QGIS 4.2)
 
 :return: GeoJSON string
 

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -86,11 +86,11 @@ QgsCoordinateReferenceSystem QgsJsonExporter::sourceCrs() const
   return mCrs;
 }
 
-QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties, const QVariant &id, int indent ) const
+QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties, const QVariant &id, int indent, const QString &featureType ) const
 {
   try
   {
-    return QString::fromStdString( exportFeatureToJsonObject( feature, extraProperties, id ).dump( indent ) );
+    return QString::fromStdString( exportFeatureToJsonObject( feature, extraProperties, id, featureType ).dump( indent ) );
   }
   catch ( json::type_error &ex )
   {
@@ -104,11 +104,15 @@ QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVarian
   }
 }
 
-json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, const QVariantMap &extraProperties, const QVariant &id ) const
+json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, const QVariantMap &extraProperties, const QVariant &id, const QString &featureType ) const
 {
   json featureJson {
     { "type", "Feature" },
   };
+  if ( !featureType.isEmpty() )
+  {
+    featureJson["featureType"] = featureType.toStdString();
+  }
   if ( id.isValid() )
   {
     bool ok = false;

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -219,7 +219,7 @@ class CORE_EXPORT QgsJsonExporter
      * \param id optional ID to use as GeoJSON feature's ID instead of input feature's ID. If omitted, feature's
      * ID is used.
      * \param indent number of indentation spaces for generated JSON (defaults to none)
-     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written.
+     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written. \since QGIS 4.2
      * \returns GeoJSON string
      * \see exportFeatures()
      * \see exportFeatureToJsonObject()

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -219,11 +219,12 @@ class CORE_EXPORT QgsJsonExporter
      * \param id optional ID to use as GeoJSON feature's ID instead of input feature's ID. If omitted, feature's
      * ID is used.
      * \param indent number of indentation spaces for generated JSON (defaults to none)
+     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written.
      * \returns GeoJSON string
      * \see exportFeatures()
      * \see exportFeatureToJsonObject()
      */
-    QString exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), int indent = -1 ) const;
+    QString exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), int indent = -1, const QString &featureType = QString() ) const;
 
     /**
      * Returns a QJsonObject representation of a feature.
@@ -231,10 +232,12 @@ class CORE_EXPORT QgsJsonExporter
      * \param extraProperties map of extra attributes to include in feature's properties
      * \param id optional ID to use as GeoJSON feature's ID instead of input feature's ID. If omitted, feature's
      * ID is used.
+     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written.
      * \returns json object
      * \see exportFeatures()
      */
-    json exportFeatureToJsonObject( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant() ) const SIP_SKIP;
+    json exportFeatureToJsonObject( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), const QString &featureType = QString() ) const
+      SIP_SKIP;
 
 
     /**

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -232,7 +232,7 @@ class CORE_EXPORT QgsJsonExporter
      * \param extraProperties map of extra attributes to include in feature's properties
      * \param id optional ID to use as GeoJSON feature's ID instead of input feature's ID. If omitted, feature's
      * ID is used.
-     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written.
+     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written. \since QGIS 4.2
      * \returns json object
      * \see exportFeatures()
      */

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -219,7 +219,7 @@ class CORE_EXPORT QgsJsonExporter
      * \param id optional ID to use as GeoJSON feature's ID instead of input feature's ID. If omitted, feature's
      * ID is used.
      * \param indent number of indentation spaces for generated JSON (defaults to none)
-     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written. \since QGIS 4.2
+     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written (since QGIS 4.2)
      * \returns GeoJSON string
      * \see exportFeatures()
      * \see exportFeatureToJsonObject()
@@ -232,7 +232,7 @@ class CORE_EXPORT QgsJsonExporter
      * \param extraProperties map of extra attributes to include in feature's properties
      * \param id optional ID to use as GeoJSON feature's ID instead of input feature's ID. If omitted, feature's
      * ID is used.
-     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written. \since QGIS 4.2
+     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written (since QGIS 4.2)
      * \returns json object
      * \see exportFeatures()
      */

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3157,7 +3157,7 @@ namespace QgsWms
           {
             extraProperties.insert( u"display_name"_s, fidDisplayNameMap.value( feature.id() ) );
           }
-          json["features"].push_back( exporter.exportFeatureToJsonObject( feature, extraProperties, id ) );
+          json["features"].push_back( exporter.exportFeatureToJsonObject( feature, extraProperties, id, layerName ) );
         }
       }
       else // raster layer
@@ -3178,7 +3178,7 @@ namespace QgsWms
           properties[name.toStdString()] = value.toStdString();
         }
 
-        json["features"].push_back( { { "type", "Feature" }, { "id", layerName.toStdString() }, { "properties", properties } } );
+        json["features"].push_back( { { "type", "Feature" }, { "featureType", layerName.toStdString() }, { "id", layerName.toStdString() }, { "properties", properties } } );
       }
     }
 #ifdef QGISDEBUG

--- a/tests/src/core/testqgsjsonutils.cpp
+++ b/tests/src/core/testqgsjsonutils.cpp
@@ -230,7 +230,6 @@ void TestQgsJsonUtils::testExportFeatureJson()
   feature.setAttributes( QgsAttributes() << u"a value"_s << 1 << 2.0 );
 
   const QgsJsonExporter exporter { &vl };
-
   const auto expectedJson { QStringLiteral(
     "{\"bbox\":[1.12,1.12,5.45,5.33],\"geometry\":{\"coordinates\":"
     "[[[1.12,1.34],[5.45,1.12],[5.34,5.33],[1.56,5.2],[1.12,1.34]],"
@@ -245,8 +244,6 @@ void TestQgsJsonUtils::testExportFeatureJson()
   QCOMPARE( json, expectedJson );
 
   const QgsJsonExporter exporterPrecision { &vl, 1 };
-
-
   const auto expectedJsonPrecision { QStringLiteral(
     "{\"bbox\":[1.1,1.1,5.5,5.3],\"geometry\":{\"coordinates\":"
     "[[[1.1,1.3],[5.5,1.1],[5.3,5.3],[1.6,5.2],[1.1,1.3]],"
@@ -260,6 +257,24 @@ void TestQgsJsonUtils::testExportFeatureJson()
   QCOMPARE( QString::fromStdString( jPrecision.dump() ), expectedJsonPrecision );
   const auto jsonPrecision { exporterPrecision.exportFeature( feature ) };
   QCOMPARE( jsonPrecision, expectedJsonPrecision );
+
+  const QgsJsonExporter exporterFeatureTypeAndIdAndExtraProperties { &vl };
+  const auto expectedJsonFeatureTypeAndIdAndExtraProperties { QStringLiteral(
+    "{\"bbox\":[1.12,1.12,5.45,5.33],\"featureType\":\"theForestLayer\",\"geometry\":{\"coordinates\":"
+    "[[[1.12,1.34],[5.45,1.12],[5.34,5.33],[1.56,5.2],[1.12,1.34]],"
+    "[[2.0,2.0],[3.0,2.0],[3.0,3.0],[2.0,3.0],[2.0,2.0]]],\"type\":\"Polygon\"}"
+    ",\"id\":\"theForestLayer-1337\",\"properties\":{\"andAnExtraProperty\":1337,\"flddbl\":2.0,\"fldint\":1,\"fldtxt\":\"a value\"}"
+    ",\"type\":\"Feature\"}"
+  ) };
+  QString layerName( u"theForestLayer"_s );
+  QString genericFeatureId( u"theForestLayer-1337"_s );
+  QVariantMap extraProperties;
+  extraProperties.insert( u"andAnExtraProperty"_s, 1337 );
+
+  const auto jFeatureType( exporter.exportFeatureToJsonObject( feature, extraProperties, genericFeatureId, layerName ) );
+  QCOMPARE( QString::fromStdString( jFeatureType.dump() ), expectedJsonFeatureTypeAndIdAndExtraProperties );
+  const auto jsonFeatureType = exporter.exportFeature( feature, extraProperties, genericFeatureId, -1, layerName );
+  QCOMPARE( jsonFeatureType, expectedJsonFeatureTypeAndIdAndExtraProperties );
 }
 
 void TestQgsJsonUtils::testExportFeatureJsonCrs()

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo_postgres.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo_postgres.py
@@ -167,12 +167,14 @@ class TestQgsServerWMSGetFeatureInfoPG(TestQgsServerWMSTestBase):
             {
                 "features": [
                     {
+                        "featureType": "someData",
                         "geometry": None,
                         "id": "someData.1@@1",
                         "properties": {"name": "1-1", "pk1": 1, "pk2": 1},
                         "type": "Feature",
                     },
                     {
+                        "featureType": "someData",
                         "geometry": None,
                         "id": "someData.1@@2",
                         "properties": {"name": "1-2", "pk1": 1, "pk2": 2},

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-mesh-json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-mesh-json.txt
@@ -1,2 +1,2 @@
 *****
-Content-Type: application/json; charset=utf-8{"features": [{"id": "landsat", "properties": {"GDAL Band Number 1": "125.729"}, "type": "Feature"}], "type": "FeatureCollection"}
+Content-Type: application/json; charset=utf-8{"features": [{"featureType": "landsat", "id": "landsat", "properties": {"GDAL Band Number 1": "125.729"}, "type": "Feature"}], "type": "FeatureCollection"}

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_alias_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_alias_json.txt
@@ -11,6 +11,7 @@ Content-Type: application/json; charset=utf-8
     },
   "features": [
     {
+      "featureType": "fields_alias",
       "geometry": null,
       "id": "fields_alias.2",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_exclude_attribute_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_exclude_attribute_json.txt
@@ -11,6 +11,7 @@ Content-Type: application/json; charset=utf-8
     },
   "features": [
     {
+      "featureType": "exclude_attribute",
       "geometry": null,
       "id": "exclude_attribute.2",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_ogc.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_ogc.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "testlayer èé",
       "geometry": null,
       "id": "testlayer èé.1",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_ogc_complex.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_ogc_complex.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "testlayer èé",
       "geometry": null,
       "id": "testlayer èé.1",
       "properties": {
@@ -14,6 +15,7 @@ Content-Type: application/json; charset=utf-8
       "type": "Feature"
     },
     {
+      "featureType": "testlayer èé",
       "geometry": null,
       "id": "testlayer èé.2",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geojson.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geojson.txt
@@ -11,6 +11,7 @@ Content-Type: application/geo+json; charset=utf-8
     },
   "features": [
     {
+      "featureType": "testlayer èé",
       "geometry": null,
       "id": "testlayer èé.2",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_CRS84_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_CRS84_json.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "testlayer2",
       "geometry": {
         "coordinates": [
           8.2035,

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_json.txt
@@ -11,6 +11,7 @@ Content-Type: application/json; charset=utf-8
     },
   "features": [
     {
+      "featureType": "testlayer èé",
       "geometry": {
         "coordinates": [
           913204.9128,

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "as_areas",
       "geometry": null,
       "id": "as_areas.18",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_cities.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_cities.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "as-areas-short-name",
       "geometry": null,
       "id": "as-areas-short-name.18",
       "properties": {
@@ -33,6 +34,7 @@ Content-Type: application/json; charset=utf-8
       "type": "Feature"
     },
     {
+      "featureType": "cdb_lines",
       "geometry": null,
       "id": "cdb_lines.13",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_nested.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_nested.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "as-areas-short-name",
       "geometry": null,
       "id": "as-areas-short-name.18",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_top.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_top.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "cdb_lines",
       "geometry": null,
       "id": "cdb_lines.13",
       "properties": {
@@ -17,6 +18,7 @@ Content-Type: application/json; charset=utf-8
       "type": "Feature"
     },
     {
+      "featureType": "as-areas-short-name",
       "geometry": null,
       "id": "as-areas-short-name.18",
       "properties": {
@@ -46,6 +48,7 @@ Content-Type: application/json; charset=utf-8
       "type": "Feature"
     },
     {
+      "featureType": "as-areas-short-name-query-copy",
       "geometry": null,
       "id": "as-areas-short-name-query-copy.18",
       "properties": {
@@ -75,6 +78,7 @@ Content-Type: application/json; charset=utf-8
       "type": "Feature"
     },
     {
+      "featureType": "osm",
       "id": "osm",
       "properties": {
         "Band 1": "255",

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "as-areas-short-name-query-copy",
       "geometry": null,
       "id": "as-areas-short-name-query-copy.18",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_json.txt
@@ -11,6 +11,7 @@ Content-Type: application/json; charset=utf-8
     },
   "features": [
     {
+      "featureType": "testlayer èé",
       "geometry": null,
       "id": "testlayer èé.2",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_json_layer_ids.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_json_layer_ids.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774",
       "geometry": null,
       "id": "testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774.1",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_json_layer_ids_raster.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_json_layer_ids_raster.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "landsat_a7d15b35_ca83_4b23_a9fb_af3fbdd60d15",
       "id": "landsat_a7d15b35_ca83_4b23_a9fb_af3fbdd60d15",
       "properties": {
         "Band 1": "127",

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_multiple_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_multiple_json.txt
@@ -11,6 +11,7 @@ Content-Type: application/json; charset=utf-8
     },
   "features": [
     {
+      "featureType": "testlayer èé",
       "geometry": null,
       "id": "testlayer èé.0",
       "properties": {
@@ -21,6 +22,7 @@ Content-Type: application/json; charset=utf-8
       "type": "Feature"
     },
     {
+      "featureType": "testlayer èé",
       "geometry": null,
       "id": "testlayer èé.1",
       "properties": {
@@ -31,6 +33,7 @@ Content-Type: application/json; charset=utf-8
       "type": "Feature"
     },
     {
+      "featureType": "fields_alias",
       "geometry": null,
       "id": "fields_alias.0",
       "properties": {
@@ -41,6 +44,7 @@ Content-Type: application/json; charset=utf-8
       "type": "Feature"
     },
     {
+      "featureType": "fields_alias",
       "geometry": null,
       "id": "fields_alias.1",
       "properties": {
@@ -51,6 +55,7 @@ Content-Type: application/json; charset=utf-8
       "type": "Feature"
     },
     {
+      "featureType": "exclude_attribute",
       "geometry": null,
       "id": "exclude_attribute.0",
       "properties": {
@@ -60,6 +65,7 @@ Content-Type: application/json; charset=utf-8
       "type": "Feature"
     },
     {
+      "featureType": "exclude_attribute",
       "geometry": null,
       "id": "exclude_attribute.1",
       "properties": {

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_raster_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_raster_json.txt
@@ -4,6 +4,7 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
+      "featureType": "landsat",
       "id": "landsat",
       "properties": {
         "Band 1": "125",

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_raster_nodata_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_raster_nodata_json.txt
@@ -1,2 +1,2 @@
 *****
-Content-Type: application/json; charset=utf-8{"features": [{"id": "requires_warped_vrt", "properties": {"Band 1": "null"}, "type": "Feature"}], "type": "FeatureCollection"}
+Content-Type: application/json; charset=utf-8{"features": [{"featureType": "requires_warped_vrt", "id": "requires_warped_vrt", "properties": {"Band 1": "null"}, "type": "Feature"}], "type": "FeatureCollection"}

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_raster_nodata_out_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_raster_nodata_out_json.txt
@@ -1,2 +1,2 @@
 *****
-Content-Type: application/json; charset=utf-8{"features": [{"id": "requires_warped_vrt", "properties": {}, "type": "Feature"}], "type": "FeatureCollection"}
+Content-Type: application/json; charset=utf-8{"features": [{"featureType": "requires_warped_vrt", "id": "requires_warped_vrt", "properties": {}, "type": "Feature"}], "type": "FeatureCollection"}

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_raster_nodata_zero_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_raster_nodata_zero_json.txt
@@ -1,2 +1,2 @@
 *****
-Content-Type: application/json; charset=utf-8{"features": [{"id": "requires_warped_vrt", "properties": {"Band 1": "0"}, "type": "Feature"}], "type": "FeatureCollection"}
+Content-Type: application/json; charset=utf-8{"features": [{"featureType": "requires_warped_vrt", "id": "requires_warped_vrt", "properties": {"Band 1": "0"}, "type": "Feature"}], "type": "FeatureCollection"}


### PR DESCRIPTION
## Description

This implements the QEP https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-410-json-layer-name.md

A WMS `GetFeatureInfo` requests returns a JSON including the layer name (or short-name or layer-id depending on the setting) as **FeatureType**:

```json
{
  "features": [
    {
      "featureType": "testlayer èé",
      "geometry": null,
      "id": "testlayer èé.2",
      "properties": {
        "id": 2,
        "name": "two"
      },
      "type": "Feature"
    },
    {
      "featureType": "testlayer èé",
      "geometry": null,
      "id": "testlayer èé.3",
      "properties": {
        "id": 3,
        "name": "three"
      },
      "type": "Feature"
    }
  ],
  "type": "FeatureCollection"
}
```

The **featureType** member is  introduced in the ["OGC Features and Geometries JSON" (JSON-FG) specification](https://docs.ogc.org/is/21-045r1/21-045r1.html#feature-types). In GeoJSON, this additional member is permitted as a [foreign member](https://datatracker.ietf.org/doc/html/rfc7946#section-6.1).

### Sponsor

[The Canton of Solothurn](https://so.ch/verwaltung/bau-und-justizdepartement/amt-fuer-geoinformation)
