### PR TITLE
Vector legend : fix count when ELSE rule with numeric fields

### DIFF
--- a/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -522,6 +522,7 @@ default QVariant.toString output.
 
 
 
+
     void rebuildHash();
 %Docstring
 hashtable for faster access to symbols

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -516,6 +516,8 @@ void QgsCategorizedSymbolRenderer::startRender( QgsRenderContext &context, const
     mExpression->prepare( &context.expressionContext() );
   }
 
+  mAttrIsNumeric = mAttrNum != -1 && fields.at( mAttrNum ).isNumeric();
+
   for ( const QgsRendererCategory &cat : std::as_const( mCategories ) )
   {
     cat.symbol()->startRender( context, fields );
@@ -1104,7 +1106,7 @@ QSet<QString> QgsCategorizedSymbolRenderer::legendKeysForFeature( const QgsFeatu
   {
     bool match = false;
 
-    if ( QgsVariantUtils::isNull( cat.value() ) )
+    if ( QgsVariantUtils::isNull( cat.value() ) || ( mAttrIsNumeric && cat.value().toString().isEmpty() ) )
     {
       elseRuleUUID = cat.uuid();
     }

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -490,6 +490,9 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
     //! attribute index (derived from attribute name in startRender)
     int mAttrNum = -1;
 
+    //! whether the attribute is numeric (derived from attribute name in startRender)
+    bool mAttrIsNumeric = false;
+
     //! hashtable for faster access to symbols
     QHash<QString, QgsSymbol *> mSymbolHash;
     bool mCounting = false;

--- a/tests/src/python/test_qgscategorizedsymbolrenderer.py
+++ b/tests/src/python/test_qgscategorizedsymbolrenderer.py
@@ -1782,45 +1782,61 @@ class TestQgsCategorizedSymbolRenderer(QgisTestCase):
         self.assertEqual(layer.featureCount(cat_default_id), 1)
 
     def test_layer_counts_other_categories(self):
-        layer = QgsVectorLayer("Point?field=test_field:string", "test_layer", "memory")
-        self.assertTrue(layer.isValid())
-        fields = layer.fields()
-        layer.startEditing()
-        self.assertEqual(fields[0].type(), QVariant.String)
+        """Test that features with values that don't match any category are counted in the
+        fallback 'else' category"""
 
-        # add test values
-        for attr_value in ["a", "b", None]:
-            f = QgsFeature(fields)
-            f.setAttributes([attr_value])
-            self.assertTrue(layer.addFeature(f))
+        def _test(type, values, fallback_value):
+            layer = QgsVectorLayer(
+                f"Point?field=test_field:{type}", "test_layer", "memory"
+            )
+            self.assertTrue(layer.isValid())
+            fields = layer.fields()
+            layer.startEditing()
 
-        self.assertEqual(layer.featureCount(), 3)
-        layer.commitChanges()
+            # add test values
+            values.append(None)
+            for attr_value in values:
+                f = QgsFeature(fields)
+                f.setAttributes([attr_value])
+                self.assertTrue(layer.addFeature(f))
 
-        renderer = QgsCategorizedSymbolRenderer()
-        renderer.setClassAttribute("test_field")
+            self.assertEqual(layer.featureCount(), 3)
+            layer.commitChanges()
 
-        renderer.addCategory(QgsRendererCategory("a", createMarkerSymbol(), "a"))
-        cat_a_id = renderer.categories()[-1].uuid()
-        renderer.addCategory(
-            QgsRendererCategory(QVariant(), createMarkerSymbol(), "other values")
-        )
-        cat_other_id = renderer.categories()[-1].uuid()
+            renderer = QgsCategorizedSymbolRenderer()
+            renderer.setClassAttribute("test_field")
 
-        self.assertEqual(renderer.legendKeys(), {cat_a_id, cat_other_id})
+            renderer.addCategory(
+                QgsRendererCategory(
+                    str(values[0]), createMarkerSymbol(), str(values[0])
+                )
+            )
+            cat_a_id = renderer.categories()[-1].uuid()
+            renderer.addCategory(
+                QgsRendererCategory(
+                    fallback_value, createMarkerSymbol(), "other values"
+                )
+            )
+            cat_other_id = renderer.categories()[-1].uuid()
 
-        ctx = QgsRenderContext()
-        renderer.startRender(ctx, layer.fields())
+            self.assertEqual(renderer.legendKeys(), {cat_a_id, cat_other_id})
 
-        self.assertEqual(
-            renderer.legendKeysForFeature(layer.getFeature(1), ctx), {cat_a_id}
-        )
-        self.assertEqual(
-            renderer.legendKeysForFeature(layer.getFeature(3), ctx), {cat_other_id}
-        )
-        self.assertEqual(
-            renderer.legendKeysForFeature(layer.getFeature(2), ctx), {cat_other_id}
-        )
+            ctx = QgsRenderContext()
+            renderer.startRender(ctx, layer.fields())
+
+            self.assertEqual(
+                renderer.legendKeysForFeature(layer.getFeature(1), ctx), {cat_a_id}
+            )
+            self.assertEqual(
+                renderer.legendKeysForFeature(layer.getFeature(3), ctx), {cat_other_id}
+            )
+            self.assertEqual(
+                renderer.legendKeysForFeature(layer.getFeature(2), ctx), {cat_other_id}
+            )
+
+        _test("string", ["a", "b"], QVariant())
+        _test("int", [1, 2], QVariant())
+        _test("int", [1, 2], "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Followup #65976 but with numeric fields, test added

In case the field is numeric the code path when setting the data after editing is slightly different, leading to the same issue fixed by #65976.

Also related to #52690
