### PR TITLE
[Backport 3.44] Build: fix build against latest GDAL 3.13.0dev

### DIFF
--- a/external/mdal/frmts/mdal_gdal.cpp
+++ b/external/mdal/frmts/mdal_gdal.cpp
@@ -175,8 +175,7 @@ double MDAL::DriverGdal::parseMetadataTime( const std::string &time_s )
 MDAL::DriverGdal::metadata_hash MDAL::DriverGdal::parseMetadata( GDALMajorObjectH gdalObject, const char *pszDomain /* = 0 */ )
 {
   MDAL::DriverGdal::metadata_hash meta;
-  char **GDALmetadata = nullptr;
-  GDALmetadata = GDALGetMetadata( gdalObject, pszDomain );
+  CSLConstList GDALmetadata = GDALGetMetadata( gdalObject, pszDomain );
 
   if ( GDALmetadata )
   {

--- a/src/analysis/processing/qgsalgorithmimportphotos.cpp
+++ b/src/analysis/processing/qgsalgorithmimportphotos.cpp
@@ -397,7 +397,7 @@ QVariantMap QgsImportPhotosAlgorithm::processAlgorithm( const QVariantMap &param
       continue;
     }
 
-    char **GDALmetadata = GDALGetMetadata( hDS.get(), nullptr );
+    CSLConstList GDALmetadata = GDALGetMetadata( hDS.get(), nullptr );
     if ( !GDALmetadata )
     {
       GDALmetadata = GDALGetMetadata( hDS.get(), "EXIF" );

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -500,7 +500,7 @@ void QgsGdalProvider::loadMetadata()
     // read ESRI FileGeodatabase/Personal Geodatabase layer metadata
     // (This branch is only possible on GDAL 3.7+, in earlier releases there was
     // no raster OpenFileGDB driver)
-    if ( char **GDALmetadata = GDALGetMetadata( mGdalDataset, "xml:documentation" ) )
+    if ( CSLConstList GDALmetadata = GDALGetMetadata( mGdalDataset, "xml:documentation" ) )
     {
       const QString metadata( GDALmetadata[0] );
       if ( !metadata.isEmpty() )
@@ -548,7 +548,7 @@ QString QgsGdalProvider::htmlMetadata() const
   for ( int i = 1; i <= GDALGetRasterCount( dsForMetadata ); ++i )
   {
     GDALRasterBandH gdalBand = GDALGetRasterBand( dsForMetadata, i );
-    char **GDALmetadata = GDALGetMetadata( gdalBand, nullptr );
+    CSLConstList GDALmetadata = GDALGetMetadata( gdalBand, nullptr );
     myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Band %1" ).arg( i ) + QStringLiteral( "</td><td>" );
     if ( GDALmetadata )
     {
@@ -579,7 +579,7 @@ QString QgsGdalProvider::htmlMetadata() const
     myMetadata += tr( "Mask band (exposed as alpha band)" ) + QStringLiteral( "<br />\n" );
   }
 
-  char **GDALmetadata = GDALGetMetadata( dsForMetadata, nullptr );
+  CSLConstList GDALmetadata = GDALGetMetadata( dsForMetadata, nullptr );
   if ( GDALmetadata )
   {
     QStringList metadata = QgsOgrUtils::cStringListToQStringList( GDALmetadata );
@@ -1287,7 +1287,7 @@ QString QgsGdalProvider::generateBandName( int bandNumber ) const
 
   if ( mDriverName == QLatin1String( "netCDF" ) || mDriverName == QLatin1String( "GTiff" ) )
   {
-    char **GDALmetadata = GDALGetMetadata( mGdalDataset, nullptr );
+    CSLConstList GDALmetadata = GDALGetMetadata( mGdalDataset, nullptr );
     if ( GDALmetadata )
     {
       QStringList metadata = QgsOgrUtils::cStringListToQStringList( GDALmetadata );
@@ -1830,7 +1830,7 @@ QList<QgsProviderSublayerDetails> QgsGdalProvider::sublayerDetails( GDALDatasetH
 
   QList<QgsProviderSublayerDetails> res;
 
-  char **metadata = GDALGetMetadata( dataset, "SUBDATASETS" );
+  CSLConstList metadata = GDALGetMetadata( dataset, "SUBDATASETS" );
 
   QVariantMap uriParts = decodeGdalUri( baseUri );
   const QString datasetPath = uriParts.value( QStringLiteral( "path" ) ).toString();

--- a/src/core/providers/ogr/qgsogrproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsogrproviderconnection.cpp
@@ -419,7 +419,7 @@ void QgsOgrProviderConnection::setDefaultCapabilities()
   mGeometryColumnCapabilities |= GeometryColumnCapability::SinglePolygon;
 #endif
 
-  char **driverMetadata = GDALGetMetadata( hDriver, nullptr );
+  CSLConstList driverMetadata = GDALGetMetadata( hDriver, nullptr );
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,6,0)
   if ( CSLFetchBoolean( driverMetadata, GDAL_DCAP_Z_GEOMETRIES, false ) )

--- a/src/core/providers/ogr/qgsogrprovidermetadata.cpp
+++ b/src/core/providers/ogr/qgsogrprovidermetadata.cpp
@@ -103,7 +103,7 @@ bool QgsOgrProviderMetadata::createDatabase( const QString &uri, QString &errorM
     return false;
   }
 
-  char **metadata = GDALGetMetadata( poDriver, nullptr );
+  CSLConstList metadata = GDALGetMetadata( poDriver, nullptr );
 
   if ( !CSLFetchBoolean( metadata, GDAL_DCAP_VECTOR, false )
        || !CSLFetchBoolean( metadata, GDAL_DCAP_CREATE, false ) )

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -496,7 +496,7 @@ QString QgsGdalUtils::helpCreationOptionsFormat( const QString &format )
   if ( myGdalDriver )
   {
     // first report details and help page
-    char **GDALmetadata = GDALGetMetadata( myGdalDriver, nullptr );
+    CSLConstList GDALmetadata = GDALGetMetadata( myGdalDriver, nullptr );
     message += QLatin1String( "Format Details:\n" );
     message += QStringLiteral( "  Extension: %1\n" ).arg( CSLFetchNameValue( GDALmetadata, GDAL_DMD_EXTENSION ) );
     message += QStringLiteral( "  Short Name: %1" ).arg( GDALGetDriverShortName( myGdalDriver ) );

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -1153,7 +1153,7 @@ QgsFields QgsOgrUtils::stringToFields( const QString &string, QTextCodec *encodi
   return fields;
 }
 
-QStringList QgsOgrUtils::cStringListToQStringList( char **stringList )
+QStringList QgsOgrUtils::cStringListToQStringList( const char *const *stringList )
 {
   if ( !stringList )
     return {};

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -312,7 +312,7 @@ class CORE_EXPORT QgsOgrUtils
      *
      * \since QGIS 3.2
      */
-    static QStringList cStringListToQStringList( char **stringList );
+    static QStringList cStringListToQStringList( const char *const *stringList );
 
     /**
      * Converts a OGRwkbGeometryType to QgsWkbTypes::Type

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -158,7 +158,7 @@ bool QgsVectorFileWriter::supportsFeatureStyles( const QString &driverName )
   if ( !gdalDriver )
     return false;
 
-  char **driverMetadata = GDALGetMetadata( gdalDriver, nullptr );
+  CSLConstList driverMetadata = GDALGetMetadata( gdalDriver, nullptr );
   if ( !driverMetadata )
     return false;
 
@@ -4179,7 +4179,7 @@ QString QgsVectorFileWriter::driverForExtension( const QString &extension )
     GDALDriverH drv = GDALGetDriver( i );
     if ( drv )
     {
-      char **driverMetadata = GDALGetMetadata( drv, nullptr );
+      CSLConstList driverMetadata = GDALGetMetadata( drv, nullptr );
       if ( CSLFetchBoolean( driverMetadata, GDAL_DCAP_CREATE, false ) && CSLFetchBoolean( driverMetadata, GDAL_DCAP_VECTOR, false ) )
       {
         QString drvName = GDALGetDriverShortName( drv );

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -1090,7 +1090,7 @@ QString QgsRasterFileWriter::driverForExtension( const QString &extension )
     GDALDriverH drv = GDALGetDriver( i );
     if ( drv )
     {
-      char **driverMetadata = GDALGetMetadata( drv, nullptr );
+      CSLConstList driverMetadata = GDALGetMetadata( drv, nullptr );
       if ( CSLFetchBoolean( driverMetadata, GDAL_DCAP_RASTER, false ) )
       {
         QString drvName = GDALGetDriverShortName( drv );
@@ -1113,7 +1113,7 @@ QStringList QgsRasterFileWriter::extensionsForFormat( const QString &format )
   GDALDriverH drv = GDALGetDriverByName( format.toLocal8Bit().data() );
   if ( drv )
   {
-    char **driverMetadata = GDALGetMetadata( drv, nullptr );
+    CSLConstList driverMetadata = GDALGetMetadata( drv, nullptr );
     if ( CSLFetchBoolean( driverMetadata, GDAL_DCAP_RASTER, false ) )
     {
       return QString( GDALGetMetadataItem( drv, GDAL_DMD_EXTENSIONS, nullptr ) ).split( ' ' );


### PR DESCRIPTION
Backport of PR #64557

Since https://github.com/OSGeo/gdal/pull/13658 , GDALGetMetadata() return a CSLConstList=const char* const* instead of char**, better reflecting its semantics.
The change in this PR is backwards compatible with earlier GDAL versions
