### PR TITLE
[fix] Update output parameter order in docs for QgsVectorFileWriter::writeAsVectorFormatV3()

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -557,11 +557,11 @@ Writes a layer out to a vector file.
 
 :return: - Error message code, or QgsVectorFileWriter.NoError if the
            write operation was successful
+         - errorMessage: the error message text, if an error occurs
+           while writing the layer
          - newFilename: potentially modified file name (output
            parameter)
          - newLayer: potentially modified layer name (output parameter)
-         - errorMessage: the error message text, if an error occurs
-           while writing the layer
 
 .. versionadded:: 3.20
 %End

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -773,9 +773,9 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param fileName file name to write to
      * \param transformContext coordinate transform context
      * \param options save options
+     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
      * \param newFilename potentially modified file name (output parameter)
      * \param newLayer potentially modified layer name (output parameter)
-     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
      * \returns Error message code, or QgsVectorFileWriter.NoError if the write operation was successful
      * \since QGIS 3.20
      */


### PR DESCRIPTION
So that PyQGIS docs get the outputs in the correct order.

Fixes #66007

----------------

*No AI was used*
