### PR TITLE
Change behavior of layout guide position editing

### DIFF
--- a/src/core/layout/qgslayoutguidecollection.cpp
+++ b/src/core/layout/qgslayoutguidecollection.cpp
@@ -597,7 +597,7 @@ QgsLayoutGuideProxyModel::QgsLayoutGuideProxyModel( QObject *parent, Qt::Orienta
   , mOrientation( orientation )
   , mPage( page )
 {
-  setDynamicSortFilter( true );
+  setDynamicSortFilter( false );
   sort( 0 );
 }
 

--- a/src/gui/layout/qgslayoutguidewidget.cpp
+++ b/src/gui/layout/qgslayoutguidewidget.cpp
@@ -43,11 +43,16 @@ QgsLayoutGuideWidget::QgsLayoutGuideWidget( QWidget *parent, QgsLayout *layout, 
   mHozGuidesTableView->setEditTriggers( QAbstractItemView::AllEditTriggers );
   mVertGuidesTableView->setEditTriggers( QAbstractItemView::AllEditTriggers );
 
-  mHozGuidesTableView->setItemDelegateForColumn( 0, new QgsLayoutGuidePositionDelegate( mHozGuidesTableView ) );
+  QgsLayoutGuidePositionDelegate *hozPosDelegate = new QgsLayoutGuidePositionDelegate( mHozGuidesTableView );
+  mHozGuidesTableView->setItemDelegateForColumn( 0, hozPosDelegate );
   mHozGuidesTableView->setItemDelegateForColumn( 1, new QgsLayoutGuideUnitDelegate( mHozGuidesTableView ) );
 
-  mVertGuidesTableView->setItemDelegateForColumn( 0, new QgsLayoutGuidePositionDelegate( mVertGuidesTableView ) );
+  QgsLayoutGuidePositionDelegate *vertPosDelegate = new QgsLayoutGuidePositionDelegate( mVertGuidesTableView );
+  mVertGuidesTableView->setItemDelegateForColumn( 0, vertPosDelegate );
   mVertGuidesTableView->setItemDelegateForColumn( 1, new QgsLayoutGuideUnitDelegate( mVertGuidesTableView ) );
+
+  connect( hozPosDelegate, &QAbstractItemDelegate::closeEditor, mHozProxyModel, [this]( QWidget *, QAbstractItemDelegate::EndEditHint ) { mHozProxyModel->invalidate(); } );
+  connect( vertPosDelegate, &QAbstractItemDelegate::closeEditor, mVertProxyModel, [this]( QWidget *, QAbstractItemDelegate::EndEditHint ) { mVertProxyModel->invalidate(); } );
 
   connect( mAddHozGuideButton, &QPushButton::clicked, this, &QgsLayoutGuideWidget::addHorizontalGuide );
   connect( mAddVertGuideButton, &QPushButton::clicked, this, &QgsLayoutGuideWidget::addVerticalGuide );

--- a/src/gui/layout/qgslayoutguidewidget.cpp
+++ b/src/gui/layout/qgslayoutguidewidget.cpp
@@ -73,14 +73,32 @@ QgsLayoutGuideWidget::QgsLayoutGuideWidget( QWidget *parent, QgsLayout *layout, 
 
 void QgsLayoutGuideWidget::addHorizontalGuide()
 {
+  const int newSourceRow = mLayout->guides().rowCount( QModelIndex() );
   auto newGuide = std::make_unique<QgsLayoutGuide>( Qt::Horizontal, QgsLayoutMeasurement( 0 ), mLayout->pageCollection()->page( mPage ) );
   mLayout->guides().addGuide( newGuide.release() );
+
+  const QModelIndex sourceIndex = mLayout->guides().index( newSourceRow, 0 );
+  const QModelIndex proxyIndex = mHozProxyModel->mapFromSource( sourceIndex );
+  if ( proxyIndex.isValid() )
+  {
+    mHozGuidesTableView->selectionModel()->select( proxyIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+    mHozGuidesTableView->edit( proxyIndex );
+  }
 }
 
 void QgsLayoutGuideWidget::addVerticalGuide()
 {
+  const int newSourceRow = mLayout->guides().rowCount( QModelIndex() );
   auto newGuide = std::make_unique<QgsLayoutGuide>( Qt::Vertical, QgsLayoutMeasurement( 0 ), mLayout->pageCollection()->page( mPage ) );
   mLayout->guides().addGuide( newGuide.release() );
+
+  const QModelIndex sourceIndex = mLayout->guides().index( newSourceRow, 0 );
+  const QModelIndex proxyIndex = mVertProxyModel->mapFromSource( sourceIndex );
+  if ( proxyIndex.isValid() )
+  {
+    mVertGuidesTableView->selectionModel()->select( proxyIndex, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+    mVertGuidesTableView->edit( proxyIndex );
+  }
 }
 
 void QgsLayoutGuideWidget::deleteHorizontalGuide()


### PR DESCRIPTION
## Description

Currently when adding guides in layout the list of guides in the widget is sorted every time the value changes (see the video in the first issue) which is really unpleasant and annoying. This fixes that, only sorting the list of guides when editing of values changes.  The behaviour or lines on actual layout is unchanged these still move with every change of value (as visible in the screencast).

<img width="1153" height="821" alt="Peek 2026-05-08 15-14" src="https://github.com/user-attachments/assets/016d83b4-57b1-46bb-b2c2-caf579651616" />

Fixes #62371 and #51652

Funded by: Ocean Winds

## AI tool usage

 - [x ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. 

