### PR TITLE
Fix esri map server handling if there is no extent info at layer level

### DIFF
--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -227,9 +227,15 @@ QgsAmsProvider::QgsAmsProvider( const QString &uri, const ProviderOptions &optio
   {
     extentData = mLayerInfo.value( u"extent"_s ).toMap();
   }
-  else
+  else if ( mLayerInfo.contains( u"fullExtent"_s ) )
   {
     extentData = mLayerInfo.value( u"fullExtent"_s ).toMap();
+  }
+
+  // tile services may not include layer-level extent info - fall back to service-level extent
+  if ( extentData.isEmpty() )
+  {
+    extentData = mServiceInfo.value( u"fullExtent"_s ).toMap();
   }
   mExtent.setXMinimum( extentData[u"xmin"_s].toDouble() );
   mExtent.setYMinimum( extentData[u"ymin"_s].toDouble() );

--- a/tests/src/python/test_provider_ams.py
+++ b/tests/src/python/test_provider_ams.py
@@ -786,6 +786,86 @@ class TestPyQgsAMSProvider(QgisTestCase, RasterProviderTestCase):
         self.assertEqual(rl.dataProvider().bandScale(1), 1)
         self.assertEqual(rl.dataProvider().bandOffset(1), 0)
 
+    def test_tile_service_extent_fallback_to_service_info(self):
+        """
+        Test that when a tile service layer has no extent info at the layer level,
+        the provider falls back to the service-level fullExtent.
+        """
+        endpoint = self.basetestpath + "/tile_extent_fallback_fake_qgis_http_endpoint"
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""
+                {
+ "currentVersion": 11.1,
+ "serviceDescription": "",
+ "mapName": "Layers",
+ "description": "",
+ "copyrightText": "",
+ "layers": [
+  {
+   "id": 1,
+   "name": "Layer 1",
+   "parentLayerId": -1,
+   "defaultVisibility": true,
+   "subLayerIds": null,
+   "minScale": 0,
+   "maxScale": 0,
+   "type": "Feature Layer"
+  }
+ ],
+ "spatialReference": {
+  "wkid": 4326,
+  "latestWkid": 4326
+ },
+ "singleFusedMapCache": true,
+ "fullExtent": {
+  "xmin": -10.0,
+  "ymin": -20.0,
+  "xmax": 30.0,
+  "ymax": 40.0,
+  "spatialReference": {
+   "wkid": 4326,
+   "latestWkid": 4326
+  }
+ },
+ "units": "esriDecimalDegrees",
+ "capabilities": "Map,TilesOnly"
+}"""
+            )
+        with open(self.sanitize_local_url(endpoint, "/1?f=json"), "wb") as f:
+            f.write(
+                b"""
+                {
+ "currentVersion": 11.1,
+ "id": 1,
+ "name": "Layer 1",
+ "type": "Feature Layer",
+ "parentLayer": {
+  "id": -1,
+  "name": "Root"
+ },
+ "defaultVisibility": true,
+ "minScale": 0,
+ "maxScale": 0,
+ "spatialReference": {
+  "wkid": 4326,
+  "latestWkid": 4326
+ }
+}"""
+            )
+
+        rl = QgsRasterLayer(
+            "url='http://" + endpoint + "' layer='1'",
+            "test",
+            "arcgismapserver",
+        )
+        self.assertTrue(rl.isValid())
+        self.assertEqual(rl.crs(), QgsCoordinateReferenceSystem("EPSG:4326"))
+        self.assertAlmostEqual(rl.extent().xMinimum(), -10.0, 5)
+        self.assertAlmostEqual(rl.extent().yMinimum(), -20.0, 5)
+        self.assertAlmostEqual(rl.extent().xMaximum(), 30.0, 5)
+        self.assertAlmostEqual(rl.extent().yMaximum(), 40.0, 5)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix loading of https://tiles.arcgis.com/tiles/goZLUACRDSDrf4xu/arcgis/rest/services/Ortofotomapa_2024/MapServer

In the current master, the layer loads with zero extent, so nothing shows up. Apparently extent info does not need to be on the layer level - see https://tiles.arcgis.com/tiles/goZLUACRDSDrf4xu/arcgis/rest/services/Ortofotomapa_2024/MapServer/0?f=json

The solution is to look at the parent service's extent if the layer level extent is missing. Now the layer loads and renders fine...

## AI tool usage

 - [x] used Claude Code to find the problem and create initial fix
