### PR TITLE
QgsSfcgalGeometry: Add split3D algorithm

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
@@ -336,6 +336,26 @@ Checks if ``geom`` is empty.
                             operation
 %End
 
+    std::unique_ptr<QgsSfcgalGeometry> geometryN( unsigned int index ) const;
+%Docstring
+Returns the geometry component of a geometry collection at the specified
+index.
+
+- For geometries composed of multiple elements (e.g. GeometryColletion,
+  MultiPoint, MultiLineString, MultiPolygon), this method returns the
+  sub-geometry at the given index.
+- For singular geometries, return the geometry itself when index is 0.
+
+:param index: index of geometry to return
+
+:return: the sub-geometry
+
+:raises QgsSfcgalException: if an error was encountered during the
+                            operation
+
+.. versionadded:: 4.2
+%End
+
     double area( bool withDiscretization = false ) const;
 %Docstring
 Computes the area of ``geom``.

--- a/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgssfcgalgeometry.sip.in
@@ -508,6 +508,33 @@ Apply 3D matrix transform ``mat`` to geometry ``geom``
 :raises QgsNotSupportedException: on QGIS builds based on SFCGAL < 2.3.
 %End
 
+    std::unique_ptr<QgsSfcgalGeometry> split3D( const QgsPoint &planePoint, const QgsVector3D &planeNormal, bool closeGeometries ) const;
+%Docstring
+Splits the given geometry with a plane defined by a point ``planePoint``
+and a normal vector ``planeNormal``.
+
+:param planePoint: a point belonging to the splitting plane
+:param planeNormal: the normal vector of the splitting plane
+:param closeGeometries: If true, ensures resulting geometries are
+                        closed.
+:param errorMsg: Error message returned by SFGCAL
+
+:return: A GeometryCollection containing the split geometries, or an
+         empty GeometryCollection if the plane does not intersect the
+         geometry
+
+.. note::
+
+   the geometry needs to be a PolyhedralSurface or a TIN
+
+:raises QgsSfcgalException: if an error was encountered during the
+                            operation
+
+:raises QgsNotSupportedException: on QGIS builds based on SFCGAL < 2.3.
+
+.. versionadded:: 4.2
+%End
+
     bool intersects( const QgsAbstractGeometry *otherGeom ) const;
 %Docstring
 Checks if ``otherGeom`` intersects this.

--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -633,6 +633,65 @@ bool QgsSfcgalEngine::isSimple( const sfcgal::geometry *geom, QString *errorMsg 
 #endif
 }
 
+sfcgal::shared_geom QgsSfcgalEngine::geometryN( const sfcgal::geometry *geom, unsigned int index, QString *errorMsg )
+{
+  sfcgal::errorHandler()->clearText( errorMsg );
+  CHECK_NOT_NULL( geom, nullptr );
+
+  sfcgal_geometry_type_t type = sfcgal_geometry_type_id( geom );
+  CHECK_SUCCESS( errorMsg, nullptr );
+
+  const sfcgal::geometry *out = nullptr;
+
+  switch ( type )
+  {
+    case SFCGAL_TYPE_GEOMETRYCOLLECTION:
+    case SFCGAL_TYPE_MULTILINESTRING:
+    case SFCGAL_TYPE_MULTIPOINT:
+    case SFCGAL_TYPE_MULTIPOLYGON:
+    case SFCGAL_TYPE_MULTISOLID:
+    {
+#if SFCGAL_VERSION_NUM < SFCGAL_MAKE_VERSION( 2, 1, 0 )
+      // Prior to version 2.1, index < nrGeoms is not checked
+      // by sfcgal_geometry_collection_geometry_n
+      const unsigned int nrGeoms = sfcgal_geometry_collection_num_geometries( geom );
+      if ( index < nrGeoms )
+      {
+        out = sfcgal_geometry_collection_geometry_n( geom, index );
+      }
+      else
+      {
+        sfcgal::errorHandler()->addText( u"Cannot access geometry at position %s. GeometryCollection has only %d geometries."_s.arg( index ).arg( nrGeoms ) );
+      }
+#else
+      out = sfcgal_geometry_collection_geometry_n( geom, index );
+#endif
+      break;
+    }
+    case SFCGAL_TYPE_LINESTRING:
+    case SFCGAL_TYPE_POINT:
+    case SFCGAL_TYPE_POLYGON:
+    case SFCGAL_TYPE_POLYHEDRALSURFACE:
+    case SFCGAL_TYPE_SOLID:
+    case SFCGAL_TYPE_TRIANGLE:
+    case SFCGAL_TYPE_TRIANGULATEDSURFACE:
+      if ( index == 0 )
+      {
+        out = geom;
+      }
+      break;
+    default:
+      out = nullptr;
+  }
+
+  CHECK_SUCCESS( errorMsg, nullptr );
+
+  sfcgal::shared_geom result = cloneGeometry( out, errorMsg );
+  CHECK_SUCCESS( errorMsg, nullptr );
+
+  return result;
+}
+
 sfcgal::shared_geom QgsSfcgalEngine::boundary( const sfcgal::geometry *geom, QString *errorMsg )
 {
 #if SFCGAL_VERSION_NUM < SFCGAL_MAKE_VERSION( 2, 1, 0 )

--- a/src/core/geometry/qgssfcgalengine.cpp
+++ b/src/core/geometry/qgssfcgalengine.cpp
@@ -1092,6 +1092,17 @@ sfcgal::shared_geom QgsSfcgalEngine::transform( const sfcgal::geometry *geom, co
   return sfcgal::make_shared_geom( result );
 }
 
+sfcgal::shared_geom QgsSfcgalEngine::split3D( const sfcgal::geometry *geom, const QgsPoint &planePoint, const QgsVector3D &planeNormal, bool closeGeometries, QString *errorMsg )
+{
+  sfcgal::errorHandler()->clearText( errorMsg );
+  CHECK_NOT_NULL( geom, nullptr );
+
+  sfcgal::geometry *result = sfcgal_geometry_split_3d( geom, planePoint.x(), planePoint.y(), planePoint.z(), planeNormal.x(), planeNormal.y(), planeNormal.z(), closeGeometries );
+
+  CHECK_SUCCESS( errorMsg, nullptr );
+  return sfcgal::make_shared_geom( result );
+}
+
 std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalEngine::toSfcgalGeometry( sfcgal::shared_prim &prim, sfcgal::primitiveType type, QString *errorMsg )
 {
   sfcgal::errorHandler()->clearText( errorMsg );

--- a/src/core/geometry/qgssfcgalengine.h
+++ b/src/core/geometry/qgssfcgalengine.h
@@ -729,6 +729,22 @@ class CORE_EXPORT QgsSfcgalEngine
     static sfcgal::shared_geom transform( const sfcgal::geometry *geom, const QgsMatrix4x4 &mat, QString *errorMsg = nullptr );
 
     /**
+     * Splits the given geometry with a plane defined by a point \a planePoint and a normal vector \a planeNormal.
+     *
+     * \param geom the 3D geometry on which to perform the operation: a PolyhedralSurface or a TIN
+     * \param planePoint a point belonging to the splitting plane
+     * \param planeNormal the normal vector of the splitting plane
+     * \param closeGeometries If true, ensures resulting geometries are closed.
+     * \param errorMsg Error message returned by SFGCAL
+     *
+     * \return A GeometryCollection containing the split geometries, or an empty
+     *         GeometryCollection if the plane does not intersect the geometry
+     *
+     * \since QGIS 4.2
+     */
+    static sfcgal::shared_geom split3D( const sfcgal::geometry *geom, const QgsPoint &planePoint, const QgsVector3D &planeNormal, bool closeGeometries, QString *errorMsg = nullptr );
+
+    /**
      * Creates a SFGAL geometry from a shared SFCGAL primitive (from SFCGAL library).
      *
      * \param prim primitive to perform the operation

--- a/src/core/geometry/qgssfcgalengine.h
+++ b/src/core/geometry/qgssfcgalengine.h
@@ -431,6 +431,23 @@ class CORE_EXPORT QgsSfcgalEngine
      */
     static bool isSimple( const sfcgal::geometry *geom, QString *errorMsg = nullptr );
 
+
+    /**
+     * Returns the geometry component of a geometry collection at the specified index.
+     *
+     * - For geometries composed of multiple elements (e.g. GeometryColletion, MultiPoint,
+     *   MultiLineString, MultiPolygon), this method returns the sub-geometry at the given index.
+     * - For singular geometries, return the geometry itself when index is 0.
+     *
+     * \param geom geometry to perform the operation
+     * \param index index of geometry to return
+     * \param errorMsg Error message returned by SFGCAL
+     * \return the sub-geometry or a nullptr if the operation failed
+     *
+     * \since QGIS 4.2
+     */
+    static sfcgal::shared_geom geometryN( const sfcgal::geometry *geom, unsigned int index, QString *errorMsg = nullptr );
+
     /**
      * Calculate the boundary of \a geom
      *

--- a/src/core/geometry/qgssfcgalgeometry.cpp
+++ b/src/core/geometry/qgssfcgalgeometry.cpp
@@ -448,6 +448,20 @@ bool QgsSfcgalGeometry::isSimple() const
   return result;
 }
 
+std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::geometryN( unsigned int index ) const
+{
+  QString errorMsg;
+  sfcgal::errorHandler()->clearText( &errorMsg );
+
+  sfcgal::shared_geom geom = workingGeom();
+  sfcgal::shared_geom result = QgsSfcgalEngine::geometryN( geom.get(), index );
+  THROW_ON_ERROR( &errorMsg );
+
+  std::unique_ptr<QgsSfcgalGeometry> resultGeom = QgsSfcgalEngine::toSfcgalGeometry( result, &errorMsg );
+  THROW_ON_ERROR( &errorMsg );
+  return resultGeom;
+}
+
 QgsPoint QgsSfcgalGeometry::centroid() const
 {
   QString errorMsg;

--- a/src/core/geometry/qgssfcgalgeometry.cpp
+++ b/src/core/geometry/qgssfcgalgeometry.cpp
@@ -907,6 +907,28 @@ std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::toSolid() const
   return solidGeom;
 }
 
+std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::split3D( const QgsPoint &planePoint, const QgsVector3D &planeNormal, bool closeGeometries ) const
+{
+  QString errorMsg;
+  sfcgal::errorHandler()->clearText( &errorMsg );
+
+#if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )
+  sfcgal::shared_geom geom = workingGeom();
+
+  sfcgal::shared_geom result = QgsSfcgalEngine::split3D( geom.get(), planePoint, planeNormal, closeGeometries );
+  THROW_ON_ERROR( &errorMsg );
+
+  std::unique_ptr<QgsSfcgalGeometry> resultGeom = QgsSfcgalEngine::toSfcgalGeometry( result, &errorMsg );
+  THROW_ON_ERROR( &errorMsg );
+  return resultGeom;
+#else
+  Q_UNUSED( planePoint )
+  Q_UNUSED( planeNormal )
+  Q_UNUSED( closeGeometries )
+  throw QgsNotSupportedException( QObject::tr( "This operation requires a QGIS build based on SFCGAL 2.3 or later" ) );
+#endif
+}
+
 std::unique_ptr<QgsSfcgalGeometry> QgsSfcgalGeometry::toPolyhedralSurface() const
 {
   QString errorMsg;

--- a/src/core/geometry/qgssfcgalgeometry.h
+++ b/src/core/geometry/qgssfcgalgeometry.h
@@ -321,6 +321,22 @@ class CORE_EXPORT QgsSfcgalGeometry
     bool isEmpty() const SIP_THROW( QgsSfcgalException );
 
     /**
+     * Returns the geometry component of a geometry collection at the specified index.
+     *
+     * - For geometries composed of multiple elements (e.g. GeometryColletion, MultiPoint,
+     *   MultiLineString, MultiPolygon), this method returns the sub-geometry at the given index.
+     * - For singular geometries, return the geometry itself when index is 0.
+     *
+     * \param index index of geometry to return
+     * \return the sub-geometry
+     *
+     * \throws QgsSfcgalException if an error was encountered during the operation
+     *
+     * \since QGIS 4.2
+     */
+    std::unique_ptr<QgsSfcgalGeometry> geometryN( unsigned int index ) const SIP_THROW( QgsSfcgalException );
+
+    /**
      * Computes the area of \a geom.
      * \param withDiscretization If true, the area is computed
      * using the real discretization with radial segments. If false, the area is

--- a/src/core/geometry/qgssfcgalgeometry.h
+++ b/src/core/geometry/qgssfcgalgeometry.h
@@ -459,6 +459,25 @@ class CORE_EXPORT QgsSfcgalGeometry
     std::unique_ptr<QgsSfcgalGeometry> transform( const QgsMatrix4x4 &mat ) const SIP_THROW( QgsSfcgalException );
 
     /**
+     * Splits the given geometry with a plane defined by a point \a planePoint and a normal vector \a planeNormal.
+     *
+     * \param planePoint a point belonging to the splitting plane
+     * \param planeNormal the normal vector of the splitting plane
+     * \param closeGeometries If true, ensures resulting geometries are closed.
+     * \param errorMsg Error message returned by SFGCAL
+     * \return A GeometryCollection containing the split geometries, or an empty
+     *         GeometryCollection if the plane does not intersect the geometry
+     *
+     * \note the geometry needs to be a PolyhedralSurface or a TIN
+     *
+     * \throws QgsSfcgalException if an error was encountered during the operation
+     * \throws QgsNotSupportedException on QGIS builds based on SFCGAL < 2.3.
+     *
+     * \since QGIS 4.2
+     */
+    std::unique_ptr<QgsSfcgalGeometry> split3D( const QgsPoint &planePoint, const QgsVector3D &planeNormal, bool closeGeometries ) const SIP_THROW( QgsSfcgalException );
+
+    /**
      * Checks if \a otherGeom intersects this.
      *
      * \param otherGeom geometry to perform the operation

--- a/tests/src/core/geometry/testqgssfcgal.cpp
+++ b/tests/src/core/geometry/testqgssfcgal.cpp
@@ -101,6 +101,7 @@ class TestQgsSfcgal : public QgsTest
     void toPolyhedralSurface();
     void geometryN_data();
     void geometryN();
+    void split3D();
 
   private:
     //! Must be called before each render test
@@ -1327,6 +1328,41 @@ void TestQgsSfcgal::geometryN()
       QVERIFY_EXCEPTION_THROWN( geom.geometryN( 1 ), QgsSfcgalException );
     }
   }
+}
+
+void TestQgsSfcgal::split3D()
+{
+#if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION( 2, 3, 0 )
+  std::unique_ptr<QgsSfcgalGeometry> cube = QgsSfcgalGeometry::createCube( 5 );
+  QCOMPARE( cube->wkbType(), Qgis::WkbType::PolyhedralSurfaceZ );
+  QCOMPARE( cube->geometryType(), "cube" );
+
+  std::unique_ptr<QgsSfcgalGeometry> poly = cube->primitiveAsPolyhedralSurface();
+
+  const QgsPoint planePoint( 0.0, 0.0, 0.0 );
+  const QgsVector3D planeNormal( 1.0, 0.0, -1.0 );
+
+  std::unique_ptr<QgsSfcgalGeometry> splitCube = poly->split3D( planePoint, planeNormal, true );
+  QCOMPARE( splitCube->wkbType(), Qgis::WkbType::GeometryCollectionZ );
+  QCOMPARE( splitCube->partCount(), 2 );
+
+  std::unique_ptr<QgsSfcgalGeometry> firstPart = splitCube->geometryN( 0 );
+  const QString expectedFirstPartWkt = "POLYHEDRALSURFACE Z (((5.0 0.0 5.0,5.0 5.0 5.0,0.0 5.0 5.0,0.0 0.0 5.0,5.0 0.0 5.0)),"
+                                       "((5.0 0.0 5.0,0.0 0.0 5.0,0.0 0.0 0.0,2.5 0.0 2.5,5.0 0.0 5.0)),"
+                                       "((0.0 5.0 5.0,5.0 5.0 5.0,0.0 5.0 0.0,0.0 5.0 5.0)),"
+                                       "((0.0 0.0 0.0,0.0 5.0 0.0,5.0 5.0 5.0,5.0 0.0 5.0,2.5 0.0 2.5,0.0 0.0 0.0)),"
+                                       "((0.0 5.0 0.0,0.0 0.0 0.0,0.0 0.0 5.0,0.0 5.0 5.0,0.0 5.0 0.0)))";
+
+
+  std::unique_ptr<QgsSfcgalGeometry> secondPart = splitCube->geometryN( 1 );
+  const QString expectedSecondPartWkt = "POLYHEDRALSURFACE Z (((0.0 0.0 0.0,0.0 5.0 0.0,5.0 5.0 0.0,5.0 0.0 0.0,0.0 0.0 0.0)),"
+                                        "((0.0 0.0 0.0,5.0 0.0 0.0,5.0 0.0 5.0,2.5 0.0 2.5,0.0 0.0 0.0)),"
+                                        "((5.0 5.0 0.0,0.0 5.0 0.0,5.0 5.0 5.0,5.0 5.0 0.0)),"
+                                        "((5.0 0.0 0.0,5.0 5.0 0.0,5.0 5.0 5.0,5.0 0.0 5.0,5.0 0.0 0.0)),"
+                                        "((0.0 5.0 0.0,0.0 0.0 0.0,2.5 0.0 2.5,5.0 0.0 5.0,5.0 5.0 5.0,0.0 5.0 0.0)))";
+  QCOMPARE( secondPart->asWkt( 1 ), expectedSecondPartWkt );
+
+#endif
 }
 
 QGSTEST_MAIN( TestQgsSfcgal )

--- a/tests/src/core/geometry/testqgssfcgal.cpp
+++ b/tests/src/core/geometry/testqgssfcgal.cpp
@@ -99,6 +99,8 @@ class TestQgsSfcgal : public QgsTest
     void primitiveCube();
     void toSolid();
     void toPolyhedralSurface();
+    void geometryN_data();
+    void geometryN();
 
   private:
     //! Must be called before each render test
@@ -1259,6 +1261,72 @@ void TestQgsSfcgal::toPolyhedralSurface()
   QVERIFY2( sfcgalPolygonZ.sfcgalGeometry() != nullptr, "toPolyhedralSurface, input polygon is NULL" );
   QCOMPARE( sfcgalPolygonZ.wkbType(), Qgis::WkbType::PolygonZ );
   QVERIFY_EXCEPTION_THROWN( sfcgalPolygonZ.toPolyhedralSurface(), QgsSfcgalException );
+}
+
+void TestQgsSfcgal::geometryN_data()
+{
+  QTest::addColumn<QString>( "wkt" );
+  QTest::addColumn<unsigned int>( "partCount" );
+  QTest::addColumn<QString>( "firstGeomWkt" );
+
+  QTest::newRow( "point z" ) << u"POINT Z (30 10 2)"_s << 1u << u"POINT Z (30 10 2)"_s;
+
+  QTest::newRow( "linestring z" ) << u"LINESTRING Z (0 0 2,10 10 2,20 0 2)"_s << 3u << u"LINESTRING Z (0 0 2,10 10 2,20 0 2)"_s;
+
+  QTest::newRow( "polygon z no hole" ) << u"POLYGON Z ((0 0 0,10 0 0,10 10 0,0 10 0,0 0 0))"_s << 1u << u"POLYGON Z ((0 0 0,10 0 0,10 10 0,0 10 0,0 0 0))"_s;
+
+  QTest::newRow( "polygon z with hole" ) << u"POLYGON Z ((0 0 2,10 0 2,10 10 2,0 10 2,0 0 2),(2 2 2,8 2 2,8 8 2,2 8 2,2 2 2))"_s << 2u << u"POLYGON Z ((0 0 2,10 0 2,10 10 2,0 10 2,0 0 2),(2 2 2,8 2 2,8 8 2,2 8 2,2 2 2))"_s;
+
+  QTest::newRow( "multipoint z" ) << u"MULTIPOINT Z ((10 40 1),(40 30 3),(20 20 -2),(30 10 7))"_s << 4u << u"POINT Z (10 40 1)"_s;
+
+  QTest::newRow( "multilinestring z" ) << u"MULTILINESTRING Z ((10 10 2,20 20 2),(15 15 7,30 15 8))"_s << 2u << u"LINESTRING Z (10 10 2,20 20 2)"_s;
+
+  QTest::newRow( "multipolygon z" ) << u"MULTIPOLYGON Z (((0 0 0,10 0 0,10 10 0,0 10 0,0 0 0)))"_s << 1u << u"POLYGON Z ((0 0 0,10 0 0,10 10 0,0 10 0,0 0 0))"_s;
+
+  QTest::newRow( "geometrycollection z" ) << u"GEOMETRYCOLLECTION Z (POINT Z (10 10 7),LINESTRING Z (20 20 3,30 30 5))"_s << 2u << u"POINT Z (10 10 7)"_s;
+
+  QTest::newRow( "triangle z" ) << u"TRIANGLE Z ((0 0 3,10 0 3,5 10 3,0 0 3))"_s << 3u << u"TRIANGLE Z ((0 0 3,10 0 3,5 10 3,0 0 3))"_s;
+
+  QTest::newRow( "tin z" ) << u"TIN Z (((0 0 2,10 0 2,5 10 2,0 0 2)),((10 0 2,20 0 2,15 10 2,10 0 2)))"_s << 2u << u"TIN Z (((0 0 2,10 0 2,5 10 2,0 0 2)),((10 0 2,20 0 2,15 10 2,10 0 2)))"_s;
+
+  QTest::newRow( "polyhedralsurface z" )
+    << u"POLYHEDRALSURFACE Z (((0 0 0,10 0 0,10 10 0,0 10 0,0 0 0)),((0 0 0,10 0 0,5 5 0,0 0 0)))"_s
+    << 2u
+    << u"POLYHEDRALSURFACE Z (((0 0 0,10 0 0,10 10 0,0 10 0,0 0 0)),((0 0 0,10 0 0,5 5 0,0 0 0)))"_s;
+}
+
+void TestQgsSfcgal::geometryN()
+{
+  QFETCH( QString, wkt );
+  QFETCH( unsigned int, partCount );
+  QFETCH( QString, firstGeomWkt );
+
+  QgsSfcgalGeometry geom( wkt );
+  QVERIFY( !geom.isEmpty() );
+  QCOMPARE( geom.partCount(), partCount );
+
+  std::unique_ptr<QgsSfcgalGeometry> subGeom = geom.geometryN( 0 );
+  QCOMPARE( subGeom->asWkt( 0 ), firstGeomWkt );
+
+  // singular geometry
+  // index > 0 is invalid
+  const bool isSingular = ( wkt == firstGeomWkt );
+  if ( isSingular )
+  {
+    QVERIFY_EXCEPTION_THROWN( geom.geometryN( 1 ), QgsSfcgalException );
+  }
+  else
+  {
+    if ( partCount > 1 )
+    {
+      std::unique_ptr<QgsSfcgalGeometry> lastGeom = geom.geometryN( partCount - 1 );
+      QVERIFY( lastGeom );
+    }
+    else
+    {
+      QVERIFY_EXCEPTION_THROWN( geom.geometryN( 1 ), QgsSfcgalException );
+    }
+  }
 }
 
 QGSTEST_MAIN( TestQgsSfcgal )

--- a/tests/src/python/test_qgssfcgal.py
+++ b/tests/src/python/test_qgssfcgal.py
@@ -235,6 +235,28 @@ class TestQgsSFCGAL(QgisTestCase):
         param = cube.primitiveParameter("size")
         self.assertEqual(param, 5.0)
 
+    def test_geometry_n(self):
+        # Singular geometry
+        poly_wkt = (
+            "POLYGON Z ((0.0 0.0 1.0,1.0 0.0 1.0,1.0 1.0 1.0,0.0 1.0 1.0,0.0 0.0 1.0),"
+            "(0.2 0.2 1.0,0.2 0.8 1.0,0.8 0.8 1.0,0.8 0.2 1.0,0.2 0.2 1.0))"
+        )
+        polygon = QgsSfcgalGeometry.fromWkt(poly_wkt)
+        self.assertEqual(polygon.partCount(), 2)
+        self.assertEqual(polygon.geometryN(0).asWkt(1), poly_wkt)
+
+        with self.assertRaises(QgsSfcgalException):
+            polygon.geometryN(1)
+
+        # Geometry Collection
+        geom_collection_wkt = "MULTIPOINT Z ((3 4 5),(5 2 7))"
+        collection = QgsSfcgalGeometry.fromWkt(geom_collection_wkt)
+        self.assertEqual(collection.partCount(), 2)
+        self.assertEqual(collection.geometryN(0).asWkt(0), "POINT Z (3 4 5)")
+        self.assertEqual(collection.geometryN(1).asWkt(0), "POINT Z (5 2 7)")
+        with self.assertRaises(QgsSfcgalException):
+            collection.geometryN(2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

This introduces a new algorithm in `QgsSfcgalGeometry` which allows to split a 3D geometry by a plane

## AI tool usage

No AI tool used

## Example

A cube cut along its main diagonal

<img width="872" height="697" alt="Capture d’écran du 2026-05-06 00-19-33" src="https://github.com/user-attachments/assets/e5e0c9cf-b0ff-4d97-a019-cde236395468" />


Funded by Stadt Frankfurt am Main
