### PR TITLE
[fix] Add missing SIP_OUT to QgsVectorLayer::deleteSelectedFeatures()

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1240,15 +1240,15 @@ Deletes a vertex from a feature.
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
-    bool deleteSelectedFeatures( int *deletedCount = 0, QgsVectorLayer::DeleteContext *context = 0 );
+    bool deleteSelectedFeatures( int *deletedCount /Out/ = 0, QgsVectorLayer::DeleteContext *context = 0 );
 %Docstring
 Deletes the selected features
 
-:param deletedCount: The number of successfully deleted features
 :param context: The chain of features who will be deleted for feedback
                 and to avoid endless recursions
 
-:return: ``True`` in case of success and ``False`` otherwise
+:return: - ``True`` in case of success and ``False`` otherwise
+         - deletedCount: The number of successfully deleted features
 %End
 
  Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, QgsFeatureId *featureId = 0 ) /Deprecated="Since 3.12. Will be removed in QGIS 5.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -1285,7 +1285,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      *
      * \returns TRUE in case of success and FALSE otherwise
      */
-    Q_INVOKABLE bool deleteSelectedFeatures( int *deletedCount = nullptr, QgsVectorLayer::DeleteContext *context = nullptr );
+    Q_INVOKABLE bool deleteSelectedFeatures( int *deletedCount SIP_OUT = nullptr, QgsVectorLayer::DeleteContext *context = nullptr );
 
     /**
      * Adds a ring to polygon/multipolygon features


### PR DESCRIPTION
So that the PyQGIS docs can reflect the real output tuple and remove the parameter that does not belong to that method in Python.

Currently we have:
<img width="819" height="229" alt="image" src="https://github.com/user-attachments/assets/11966192-af12-48ea-a9f3-a5f3d05a9afb" />


Supersedes https://github.com/qgis/pyqgis-api-docs-builder/pull/87

Note this doesn't break the PyQGIS API, because currently, the (output) parameter is not accepted, and the result is already a tuple.

------

_No AI was used_