### PR TITLE
qgs3dmaptoolmeasureline: Fix potential crash when closing the dialog

### DIFF
--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -147,8 +147,11 @@ void Qgs3DMapToolMeasureLine::restart()
   mDone = false;
   mDialog->resetTable();
 
-  mRubberBand->reset();
-  mRubberBand->setHideLastMarker( true );
+  if ( mRubberBand )
+  {
+    mRubberBand->reset();
+    mRubberBand->setHideLastMarker( true );
+  }
 }
 
 void Qgs3DMapToolMeasureLine::undo()


### PR DESCRIPTION
## Description
When an other tool is activated, the measure line tool is deactivated and `mRubberBand` is reset to null in `deactivate()`. However, `Qgs3DMeasureDialog` is not closed, only hidden.
Later on, when the 3d view is closed, `Qgs3DMeasureDialog::reject` calls `Qgs3DMapToolMeasureLine::restart`, which tries to modify a null rubberband and creates the crash.

This issue is fixed by checking that the `mRubberBand` is not null when `Qgs3DMapToolMeasureLine::restart` is called.

## AI tool usage

No AI tool used