### PR TITLE
[ui] Further dynamic layout tweaks to allow for the welcome screen to live in the tiniest of space

### DIFF
--- a/src/app/qgswelcomescreen.cpp
+++ b/src/app/qgswelcomescreen.cpp
@@ -178,8 +178,8 @@ void QgsWelcomeScreen::refreshGeometry()
 {
   if ( QWidget *parentWidget = qobject_cast<QWidget *>( parent() ) )
   {
-    const int adjustedWidth = std::min( mOriginalWidth, parentWidget->width() - 80 );
-    const int adjustedHeight = std::min( mOriginalHeight, parentWidget->height() - 80 );
+    const int adjustedWidth = std::min( mOriginalWidth, parentWidget->width() - 10 );
+    const int adjustedHeight = std::min( mOriginalHeight, parentWidget->height() - 60 );
     const int adjustedX = ( parentWidget->width() - adjustedWidth ) / 2;
     const int adjustedY = ( parentWidget->height() - adjustedHeight ) / 2;
     setGeometry( adjustedX, adjustedY, adjustedWidth, adjustedHeight );

--- a/src/app/qml/WelcomeScreen.qml
+++ b/src/app/qml/WelcomeScreen.qml
@@ -13,7 +13,6 @@ Item {
 
   property bool narrowLayout: height < 350 || width < 480
 
-  visible: height >= 300 && width >= 360
   width: 1100
   height: 720
 
@@ -26,6 +25,10 @@ Item {
 
     Rectangle {
       id: mainCard
+
+      property bool tinyHeight: height < 175
+      property bool shortHeight: height < 350
+
       Layout.fillWidth: true
       Layout.fillHeight: true
       radius: 10
@@ -38,20 +41,22 @@ Item {
           left: parent.left
           right: parent.right
           bottom: footer.top
-          topMargin: 28
+          topMargin: mainCard.shortHeight ? 16 : 20
           leftMargin: 28
           rightMargin: 28
           bottomMargin: 8
         }
         columns: welcomeScreen.narrowLayout ? 1 : 2
         columnSpacing: 20
-        rowSpacing: 10
+        rowSpacing: welcomeScreen.narrowLayout ? 0 : 10
 
         Column {
           Layout.maximumWidth: welcomeScreen.narrowLayout ? parent.width : parent.width * 0.52
           Layout.fillWidth: true
+          Layout.preferredHeight: mainCard.shortHeight ? 0 : -1
           Layout.alignment: Qt.AlignTop
           spacing: 10
+          clip: true
 
           Image {
             source: "images/qgis.svg"
@@ -100,9 +105,11 @@ Item {
 
             TabBar {
               id: tabBar
+              width: parent.width
               background: Item {
                 anchors.fill: parent
               }
+              clip: true
 
               TabButton {
                 text: qsTr("Recent")
@@ -595,6 +602,7 @@ Item {
           bottom: parent.bottom
           bottomMargin: 0
         }
+        height: mainCard.tinyHeight ? 0 : implicitHeight
 
         onSupportClicked: {
           Qt.openUrlExternally("https://www.qgis.org/funding/donate/")

--- a/src/app/qml/components/FooterBar.qml
+++ b/src/app/qml/components/FooterBar.qml
@@ -10,6 +10,7 @@ Rectangle {
   
   implicitHeight: 60
   color: "transparent"
+  clip: true
 
   RowLayout {
     anchors.fill: parent


### PR DESCRIPTION
## Description

Fixes https://github.com/qgis/QGIS/issues/66031 by reducing margins a bit and doing more dynamic layout tweaks. Instead of hiding the welcome screen when living in a tiny map canvas area, we progressively remove some components (logo + slogan and bottom bar).

Deliberately exaggerated, this is how it looks with a tall bottom panel and a wide left/right panel:

<img width="1133" height="900" alt="Screenshot From 2026-05-07 19-06-54" src="https://github.com/user-attachments/assets/f277f0ec-fde9-4aa0-9639-0e393d6495bd" />

This is how it looks on a new profile when users have not yet resized to a decent width/height for their screens:

<img width="1496" height="720" alt="Screenshot From 2026-05-07 19-07-49" src="https://github.com/user-attachments/assets/49885ea5-1744-4939-85ef-33d20d552343" />

