### PR TITLE
fix unity build

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1073,6 +1073,11 @@ set(QGIS_CORE_SRCS
   qgsuserprofilemanager.cpp
 )
 
+set_source_files_properties(
+  project/qgsprojectstoredobjectmanagermodel.cpp
+  PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+)
+
 if(WITH_QTPOSITIONING)
   set(QGIS_CORE_SRCS ${QGIS_CORE_SRCS}
     gps/qgsqtlocationconnection.cpp)


### PR DESCRIPTION
Fixes:

```
In file included from src/core/CMakeFiles/qgis_core.dir/Unity/unity_88_cxx.cxx:19:
/build/qgis-4.1.0+git20260505+dd8756de4ef+99sid/src/core/project/qgsprojectstoredobjectmanagermodel.cpp:335:152: error: specialization of 'T* QgsProjectStoredObjectManagerModel<T>::objectFromIndex(const QModelIndex&) const [with T = QgsSelectiveMaskingSourceSet]' after instantiation
  335 | template<> QgsSelectiveMaskingSourceSet *QgsProjectStoredObjectManagerModel<QgsSelectiveMaskingSourceSet>::objectFromIndex( const QModelIndex &index ) const
      |                                                                                                                                                        ^~~~~
/build/qgis-4.1.0+git20260505+dd8756de4ef+99sid/src/core/project/qgsprojectstoredobjectmanagermodel.cpp:344:146: error: specialization of 'QModelIndex QgsProjectStoredObjectManagerModel<T>::indexFromObject(T*) const [with T = QgsSelectiveMaskingSourceSet]' after instantiation
  344 | template<> QModelIndex QgsProjectStoredObjectManagerModel<QgsSelectiveMaskingSourceSet>::indexFromObject( QgsSelectiveMaskingSourceSet *object ) const
```