### PR TITLE
Move point instancing from handler to gooch and phong base classes

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -7790,6 +7790,22 @@ Qgis.MaterialRenderingTechnique.__doc__ = """Material rendering techniques.
 # --
 Qgis.MaterialRenderingTechnique.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.InstancedMaterialFlag.DataDefinedScale.__doc__ = "Per-instance data-defined scale"
+Qgis.InstancedMaterialFlag.DataDefinedRotation.__doc__ = "Per-instance data-defined rotation"
+Qgis.InstancedMaterialFlag.__doc__ = """Optional per-instance properties of instanced materials.
+
+.. versionadded:: 4.2
+
+* ``DataDefinedScale``: Per-instance data-defined scale
+* ``DataDefinedRotation``: Per-instance data-defined rotation
+
+"""
+# --
+Qgis.InstancedMaterialFlag.baseClass = Qgis
+Qgis.InstancedMaterialFlags = lambda flags=0: Qgis.InstancedMaterialFlag(flags)
+Qgis.InstancedMaterialFlags.baseClass = Qgis
+InstancedMaterialFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
 Qgis.TextureFilterQuality.Trilinear.__doc__ = "Trilinear (LinearMipmapLinear)"
 Qgis.TextureFilterQuality.Anisotropic2x.__doc__ = "Anisotropic filtering (2x)"
 Qgis.TextureFilterQuality.Anisotropic4x.__doc__ = "Anisotropic filtering (4x)"

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2439,6 +2439,14 @@ The development version
       Billboards,
     };
 
+    enum class InstancedMaterialFlag /BaseType=IntFlag/
+    {
+      DataDefinedScale,
+      DataDefinedRotation,
+    };
+    typedef QFlags<Qgis::InstancedMaterialFlag> InstancedMaterialFlags;
+
+
     enum class TextureFilterQuality /BaseType=IntEnum/
     {
       Trilinear,
@@ -4097,6 +4105,8 @@ QFlags<Qgis::MapGridFrameSideFlag> operator|(Qgis::MapGridFrameSideFlag f1, QFla
 QFlags<Qgis::SymbolConverterCapability> operator|(Qgis::SymbolConverterCapability f1, QFlags<Qgis::SymbolConverterCapability> f2);
 
 QFlags<Qgis::ArcGisRestServiceCapability> operator|(Qgis::ArcGisRestServiceCapability f1, QFlags<Qgis::ArcGisRestServiceCapability> f2);
+
+QFlags<Qgis::InstancedMaterialFlag> operator|(Qgis::InstancedMaterialFlag f1, QFlags<Qgis::InstancedMaterialFlag> f2);
 
 
 

--- a/src/3d/materials/qgsgoochmaterial.cpp
+++ b/src/3d/materials/qgsgoochmaterial.cpp
@@ -32,7 +32,7 @@
 using namespace Qt::StringLiterals;
 
 ///@cond PRIVATE
-QgsGoochMaterial::QgsGoochMaterial( bool instanced, bool hasDDScale, bool hasDDRotation, QNode *parent )
+QgsGoochMaterial::QgsGoochMaterial( QNode *parent )
   : QgsMaterial( parent )
   , mDiffuseParameter( new Qt3DRender::QParameter( u"kd"_s, QVariant() ) )
   , mSpecularParameter( new Qt3DRender::QParameter( u"ks"_s, QVariant() ) )
@@ -41,9 +41,6 @@ QgsGoochMaterial::QgsGoochMaterial( bool instanced, bool hasDDScale, bool hasDDR
   , mShininessParameter( new Qt3DRender::QParameter( u"shininess"_s, 100.0f ) )
   , mAlphaParameter( new Qt3DRender::QParameter( u"alpha"_s, 0.25f ) )
   , mBetaParameter( new Qt3DRender::QParameter( u"beta"_s, 0.5f ) )
-  , mInstanced( instanced )
-  , mHasDDScale( hasDDScale )
-  , mHasDDRotation( hasDDRotation )
 {
   setDiffuse( QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
   setSpecular( QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) );
@@ -88,6 +85,13 @@ void QgsGoochMaterial::init()
   updateShaders();
 }
 
+void QgsGoochMaterial::setInstancingEnabled( bool enabled, Qgis::InstancedMaterialFlags flags )
+{
+  mInstanced = enabled;
+  mInstanceFlags = flags;
+  updateShaders();
+}
+
 void QgsGoochMaterial::updateShaders()
 {
   const QByteArray fragCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/gooch.frag"_s ) );
@@ -95,9 +99,9 @@ void QgsGoochMaterial::updateShaders()
   if ( mInstanced )
   {
     QStringList defines;
-    if ( mHasDDScale )
+    if ( mInstanceFlags.testFlag( Qgis::InstancedMaterialFlag::DataDefinedScale ) )
       defines << u"USE_INSTANCE_SCALE"_s;
-    if ( mHasDDRotation )
+    if ( mInstanceFlags.testFlag( Qgis::InstancedMaterialFlag::DataDefinedRotation ) )
       defines << u"USE_INSTANCE_ROTATION"_s;
     const QByteArray vertCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/instanced.vert"_s ) );
     mShaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qgs3DUtils::addDefinesToShaderCode( vertCode, defines ) );

--- a/src/3d/materials/qgsgoochmaterial.cpp
+++ b/src/3d/materials/qgsgoochmaterial.cpp
@@ -32,7 +32,7 @@
 using namespace Qt::StringLiterals;
 
 ///@cond PRIVATE
-QgsGoochMaterial::QgsGoochMaterial( QNode *parent )
+QgsGoochMaterial::QgsGoochMaterial( bool instanced, bool hasDDScale, bool hasDDRotation, QNode *parent )
   : QgsMaterial( parent )
   , mDiffuseParameter( new Qt3DRender::QParameter( u"kd"_s, QVariant() ) )
   , mSpecularParameter( new Qt3DRender::QParameter( u"ks"_s, QVariant() ) )
@@ -41,6 +41,9 @@ QgsGoochMaterial::QgsGoochMaterial( QNode *parent )
   , mShininessParameter( new Qt3DRender::QParameter( u"shininess"_s, 100.0f ) )
   , mAlphaParameter( new Qt3DRender::QParameter( u"alpha"_s, 0.25f ) )
   , mBetaParameter( new Qt3DRender::QParameter( u"beta"_s, 0.5f ) )
+  , mInstanced( instanced )
+  , mHasDDScale( hasDDScale )
+  , mHasDDRotation( hasDDRotation )
 {
   setDiffuse( QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
   setSpecular( QColor::fromRgbF( 1.0f, 1.0f, 1.0f, 1.0f ) );
@@ -89,7 +92,18 @@ void QgsGoochMaterial::updateShaders()
 {
   const QByteArray fragCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/gooch.frag"_s ) );
 
-  if ( mDataDefinedEnabled )
+  if ( mInstanced )
+  {
+    QStringList defines;
+    if ( mHasDDScale )
+      defines << u"USE_INSTANCE_SCALE"_s;
+    if ( mHasDDRotation )
+      defines << u"USE_INSTANCE_ROTATION"_s;
+    const QByteArray vertCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/instanced.vert"_s ) );
+    mShaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qgs3DUtils::addDefinesToShaderCode( vertCode, defines ) );
+    mShaderProgram->setFragmentShaderCode( fragCode );
+  }
+  else if ( mDataDefinedEnabled )
   {
     mShaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/goochDataDefined.vert"_s ) ) );
     mShaderProgram->setFragmentShaderCode( Qgs3DUtils::addDefinesToShaderCode( fragCode, QStringList( { u"DATA_DEFINED"_s } ) ) );

--- a/src/3d/materials/qgsgoochmaterial.h
+++ b/src/3d/materials/qgsgoochmaterial.h
@@ -44,8 +44,11 @@ class _3D_EXPORT QgsGoochMaterial : public QgsMaterial
   public:
     /**
      * Constructor for QgsGoochMaterial, with the specified \a parent node.
+     * Set \a instanced to TRUE when the material will be used with instanced point rendering.
+     * \a hasDDScale and \a hasDDRotation enable per-instance scale and rotation support,
+     * and only take effect when \a instanced is TRUE.
      */
-    explicit QgsGoochMaterial( Qt3DCore::QNode *parent = nullptr );
+    explicit QgsGoochMaterial( bool instanced = false, bool hasDDScale = false, bool hasDDRotation = false, Qt3DCore::QNode *parent = nullptr );
     ~QgsGoochMaterial() override;
 
   public slots:
@@ -81,6 +84,9 @@ class _3D_EXPORT QgsGoochMaterial : public QgsMaterial
     Qt3DRender::QParameter *mBetaParameter = nullptr;
     Qt3DRender::QShaderProgram *mShaderProgram = nullptr;
     bool mDataDefinedEnabled = false;
+    bool mInstanced = false;
+    bool mHasDDScale = false;
+    bool mHasDDRotation = false;
 };
 
 ///@endcond PRIVATE

--- a/src/3d/materials/qgsgoochmaterial.h
+++ b/src/3d/materials/qgsgoochmaterial.h
@@ -16,6 +16,7 @@
 #ifndef QGSGOOCHMATERIAL_H
 #define QGSGOOCHMATERIAL_H
 
+#include "qgis.h"
 #include "qgis_3d.h"
 #include "qgsmaterial.h"
 
@@ -44,12 +45,16 @@ class _3D_EXPORT QgsGoochMaterial : public QgsMaterial
   public:
     /**
      * Constructor for QgsGoochMaterial, with the specified \a parent node.
-     * Set \a instanced to TRUE when the material will be used with instanced point rendering.
-     * \a hasDDScale and \a hasDDRotation enable per-instance scale and rotation support,
-     * and only take effect when \a instanced is TRUE.
      */
-    explicit QgsGoochMaterial( bool instanced = false, bool hasDDScale = false, bool hasDDRotation = false, Qt3DCore::QNode *parent = nullptr );
+    explicit QgsGoochMaterial( Qt3DCore::QNode *parent = nullptr );
     ~QgsGoochMaterial() override;
+
+    /**
+     * Enables or disables instanced point rendering mode.
+     * When \a enabled is TRUE the material uses the instanced vertex shader.
+     * \a flags controls which per-instance attributes (scale, rotation) are active.
+     */
+    void setInstancingEnabled( bool enabled, Qgis::InstancedMaterialFlags flags );
 
   public slots:
     //! Sets diffuse color component, must be a SRGB color
@@ -85,8 +90,7 @@ class _3D_EXPORT QgsGoochMaterial : public QgsMaterial
     Qt3DRender::QShaderProgram *mShaderProgram = nullptr;
     bool mDataDefinedEnabled = false;
     bool mInstanced = false;
-    bool mHasDDScale = false;
-    bool mHasDDRotation = false;
+    Qgis::InstancedMaterialFlags mInstanceFlags;
 };
 
 ///@endcond PRIVATE

--- a/src/3d/materials/qgsgoochmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.cpp
@@ -37,7 +37,15 @@ QgsMaterial *QgsGoochMaterial3DHandler::toMaterial( const QgsAbstractMaterialSet
 {
   switch ( technique )
   {
+    case Qgis::MaterialRenderingTechnique::InstancedPoints:
+    {
+      if ( context.isHighlighted() )
+        return new QgsHighlightMaterial( technique );
+      return toInstancedMaterial( settings, context, false, false );
+    }
+
     case Qgis::MaterialRenderingTechnique::Triangles:
+    case Qgis::MaterialRenderingTechnique::Points:
     case Qgis::MaterialRenderingTechnique::TrianglesDataDefined:
     case Qgis::MaterialRenderingTechnique::TrianglesWithFixedTexture:
     case Qgis::MaterialRenderingTechnique::TrianglesFromModel:
@@ -51,8 +59,6 @@ QgsMaterial *QgsGoochMaterial3DHandler::toMaterial( const QgsAbstractMaterialSet
     }
 
     case Qgis::MaterialRenderingTechnique::Lines:
-    case Qgis::MaterialRenderingTechnique::InstancedPoints:
-    case Qgis::MaterialRenderingTechnique::Points:
     case Qgis::MaterialRenderingTechnique::Billboards:
       return nullptr;
   }
@@ -164,19 +170,25 @@ bool QgsGoochMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot
   return true;
 }
 
-QgsMaterial *QgsGoochMaterial3DHandler::buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const
+QgsMaterial *QgsGoochMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const
+{
+  return buildMaterial( settings, context, true, hasDDScale, hasDDRotation );
+}
+
+QgsMaterial *QgsGoochMaterial3DHandler::buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool instanced, bool hasDDScale, bool hasDDRotation ) const
 {
   const QgsGoochMaterialSettings *goochSettings = dynamic_cast< const QgsGoochMaterialSettings * >( settings );
   Q_ASSERT( goochSettings );
   const QgsPropertyCollection &dataDefinedProperties = goochSettings->dataDefinedProperties();
 
-  QgsGoochMaterial *material = new QgsGoochMaterial;
+  QgsGoochMaterial *material = new QgsGoochMaterial( instanced, hasDDScale, hasDDRotation );
   material->setObjectName( u"goochMaterial"_s );
 
   applySettingsToMaterial( goochSettings, material );
   if ( context.isSelected() )
     material->setDiffuse( context.selectionColor() );
-  material->setDataDefinedEnabled( dataDefinedProperties.hasActiveProperties() );
+  if ( !instanced )
+    material->setDataDefinedEnabled( dataDefinedProperties.hasActiveProperties() );
 
   return material;
 }

--- a/src/3d/materials/qgsgoochmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.cpp
@@ -39,9 +39,8 @@ QgsMaterial *QgsGoochMaterial3DHandler::toMaterial( const QgsAbstractMaterialSet
   {
     case Qgis::MaterialRenderingTechnique::InstancedPoints:
     {
-      if ( context.isHighlighted() )
-        return new QgsHighlightMaterial( technique );
-      return toInstancedMaterial( settings, context, false, false );
+      Q_ASSERT( false );
+      return nullptr;
     }
 
     case Qgis::MaterialRenderingTechnique::Triangles:
@@ -55,7 +54,18 @@ QgsMaterial *QgsGoochMaterial3DHandler::toMaterial( const QgsAbstractMaterialSet
         return new QgsHighlightMaterial( technique );
       }
 
-      return buildMaterial( settings, context );
+      const QgsGoochMaterialSettings *goochSettings = dynamic_cast< const QgsGoochMaterialSettings * >( settings );
+      Q_ASSERT( goochSettings );
+      const QgsPropertyCollection &dataDefinedProperties = goochSettings->dataDefinedProperties();
+
+      QgsGoochMaterial *material = new QgsGoochMaterial();
+      material->setObjectName( u"goochMaterial"_s );
+      applySettingsToMaterial( goochSettings, material );
+      if ( context.isSelected() )
+        material->setDiffuse( context.selectionColor() );
+      material->setDataDefinedEnabled( dataDefinedProperties.hasActiveProperties() );
+
+      return material;
     }
 
     case Qgis::MaterialRenderingTechnique::Lines:
@@ -170,25 +180,17 @@ bool QgsGoochMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot
   return true;
 }
 
-QgsMaterial *QgsGoochMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const
+QgsMaterial *QgsGoochMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const
 {
-  return buildMaterial( settings, context, true, hasDDScale, hasDDRotation );
-}
+  const QgsGoochMaterialSettings *goochSettings = qgis::down_cast< const QgsGoochMaterialSettings * >( settings );
 
-QgsMaterial *QgsGoochMaterial3DHandler::buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool instanced, bool hasDDScale, bool hasDDRotation ) const
-{
-  const QgsGoochMaterialSettings *goochSettings = dynamic_cast< const QgsGoochMaterialSettings * >( settings );
-  Q_ASSERT( goochSettings );
-  const QgsPropertyCollection &dataDefinedProperties = goochSettings->dataDefinedProperties();
+  QgsGoochMaterial *material = new QgsGoochMaterial();
+  material->setInstancingEnabled( true, flags );
 
-  QgsGoochMaterial *material = new QgsGoochMaterial( instanced, hasDDScale, hasDDRotation );
   material->setObjectName( u"goochMaterial"_s );
-
   applySettingsToMaterial( goochSettings, material );
   if ( context.isSelected() )
     material->setDiffuse( context.selectionColor() );
-  if ( !instanced )
-    material->setDataDefinedEnabled( dataDefinedProperties.hasActiveProperties() );
 
   return material;
 }

--- a/src/3d/materials/qgsgoochmaterial3dhandler.h
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.h
@@ -46,7 +46,7 @@ class _3D_EXPORT QgsGoochMaterial3DHandler : public QgsAbstractMaterial3DHandler
     bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 
   private:
-    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const override SIP_FACTORY;
+    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const override;
     static void applySettingsToMaterial( const QgsGoochMaterialSettings *settings, QgsGoochMaterial *material );
 };
 

--- a/src/3d/materials/qgsgoochmaterial3dhandler.h
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.h
@@ -39,6 +39,7 @@ class _3D_EXPORT QgsGoochMaterial3DHandler : public QgsAbstractMaterial3DHandler
 
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override;
+    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const override;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
     QByteArray dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const override;
     int dataDefinedByteStride( const QgsAbstractMaterialSettings *settings ) const override;
@@ -46,7 +47,6 @@ class _3D_EXPORT QgsGoochMaterial3DHandler : public QgsAbstractMaterial3DHandler
     bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 
   private:
-    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const override;
     static void applySettingsToMaterial( const QgsGoochMaterialSettings *settings, QgsGoochMaterial *material );
 };
 

--- a/src/3d/materials/qgsgoochmaterial3dhandler.h
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.h
@@ -47,8 +47,8 @@ class _3D_EXPORT QgsGoochMaterial3DHandler : public QgsAbstractMaterial3DHandler
 
   private:
     //! Constructs a material from shader files
-    QgsMaterial *buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const;
-
+    QgsMaterial *buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool instanced = false, bool hasDDScale = false, bool hasDDRotation = false ) const;
+    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const override SIP_FACTORY;
     static void applySettingsToMaterial( const QgsGoochMaterialSettings *settings, QgsGoochMaterial *material );
 };
 

--- a/src/3d/materials/qgsgoochmaterial3dhandler.h
+++ b/src/3d/materials/qgsgoochmaterial3dhandler.h
@@ -46,9 +46,7 @@ class _3D_EXPORT QgsGoochMaterial3DHandler : public QgsAbstractMaterial3DHandler
     bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 
   private:
-    //! Constructs a material from shader files
-    QgsMaterial *buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool instanced = false, bool hasDDScale = false, bool hasDDRotation = false ) const;
-    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const override SIP_FACTORY;
+    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const override SIP_FACTORY;
     static void applySettingsToMaterial( const QgsGoochMaterialSettings *settings, QgsGoochMaterial *material );
 };
 

--- a/src/3d/materials/qgsmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmaterial3dhandler.cpp
@@ -43,6 +43,8 @@ QgsMaterialContext QgsMaterialContext::fromRenderContext( const Qgs3DRenderConte
 QgsMaterial *QgsAbstractMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const
 {
   Q_UNUSED( flags )
+  Q_UNUSED( settings )
+  Q_UNUSED( context )
   return nullptr;
 }
 

--- a/src/3d/materials/qgsmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmaterial3dhandler.cpp
@@ -43,7 +43,7 @@ QgsMaterialContext QgsMaterialContext::fromRenderContext( const Qgs3DRenderConte
 QgsMaterial *QgsAbstractMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const
 {
   Q_UNUSED( flags )
-  return toMaterial( settings, Qgis::MaterialRenderingTechnique::InstancedPoints, context );
+  return nullptr;
 }
 
 QByteArray QgsAbstractMaterial3DHandler::dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const

--- a/src/3d/materials/qgsmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmaterial3dhandler.cpp
@@ -40,6 +40,13 @@ QgsMaterialContext QgsMaterialContext::fromRenderContext( const Qgs3DRenderConte
   return res;
 }
 
+QgsMaterial *QgsAbstractMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const
+{
+  Q_UNUSED( hasDDScale )
+  Q_UNUSED( hasDDRotation )
+  return toMaterial( settings, Qgis::MaterialRenderingTechnique::InstancedPoints, context );
+}
+
 QByteArray QgsAbstractMaterial3DHandler::dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const
 {
   Q_UNUSED( settings )

--- a/src/3d/materials/qgsmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmaterial3dhandler.cpp
@@ -40,10 +40,9 @@ QgsMaterialContext QgsMaterialContext::fromRenderContext( const Qgs3DRenderConte
   return res;
 }
 
-QgsMaterial *QgsAbstractMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const
+QgsMaterial *QgsAbstractMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const
 {
-  Q_UNUSED( hasDDScale )
-  Q_UNUSED( hasDDRotation )
+  Q_UNUSED( flags )
   return toMaterial( settings, Qgis::MaterialRenderingTechnique::InstancedPoints, context );
 }
 

--- a/src/3d/materials/qgsmaterial3dhandler.h
+++ b/src/3d/materials/qgsmaterial3dhandler.h
@@ -151,6 +151,16 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
     virtual QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const = 0 SIP_FACTORY;
 
     /**
+     * Creates a QgsMaterial for instanced point rendering.
+     * \a hasDDScale and \a hasDDRotation control whether USE_INSTANCE_SCALE /
+     * USE_INSTANCE_ROTATION defines are injected into the vertex shader.
+     * The default implementation delegates to toMaterial() with InstancedPoints technique.
+     * Subclasses that support instancing override this to construct the material with the
+     * correct shader from the start.
+     */
+    virtual QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const SIP_FACTORY;
+
+    /**
      * Returns the parameters to be exported to .mtl file
      */
     virtual QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const = 0;

--- a/src/3d/materials/qgsmaterial3dhandler.h
+++ b/src/3d/materials/qgsmaterial3dhandler.h
@@ -155,7 +155,7 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
      *
      * The \a flags argument controls which per-instance attributes are active.
      *
-     * The default implementation returns nullptr.
+     * The default implementation returns NULLPTR.
      *
      * Subclasses that support instancing must override this method to construct the material with the
      * correct shader from the start.

--- a/src/3d/materials/qgsmaterial3dhandler.h
+++ b/src/3d/materials/qgsmaterial3dhandler.h
@@ -152,13 +152,15 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
 
     /**
      * Creates a QgsMaterial for instanced point rendering.
-     * \a hasDDScale and \a hasDDRotation control whether USE_INSTANCE_SCALE /
-     * USE_INSTANCE_ROTATION defines are injected into the vertex shader.
+     * \a flags controls which per-instance attributes are active: setting
+     * DataDefinedScale injects USE_INSTANCE_SCALE
+     * DataDefinedRotation injects USE_INSTANCE_ROTATION
+     * into the vertex shader.
      * The default implementation delegates to toMaterial() with InstancedPoints technique.
      * Subclasses that support instancing override this to construct the material with the
      * correct shader from the start.
      */
-    virtual QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const SIP_FACTORY;
+    virtual QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const SIP_FACTORY;
 
     /**
      * Returns the parameters to be exported to .mtl file

--- a/src/3d/materials/qgsmaterial3dhandler.h
+++ b/src/3d/materials/qgsmaterial3dhandler.h
@@ -152,15 +152,18 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
 
     /**
      * Creates a QgsMaterial for instanced point rendering.
-     * \a flags controls which per-instance attributes are active: setting
-     * DataDefinedScale injects USE_INSTANCE_SCALE
-     * DataDefinedRotation injects USE_INSTANCE_ROTATION
-     * into the vertex shader.
-     * The default implementation delegates to toMaterial() with InstancedPoints technique.
-     * Subclasses that support instancing override this to construct the material with the
+     *
+     * The \a flags argument controls which per-instance attributes are active:
+     *
+     * - Qgis::InstancedMaterialFlag::DataDefinedScale injects ``USE_INSTANCE_SCALE`` into the vertex shader.
+     * - Qgis::InstancedMaterialFlag::DataDefinedRotation injects ``USE_INSTANCE_ROTATION`` into the vertex shader.
+     *
+     * The default implementation delegates to toMaterial() with the Qgis::MaterialRenderingTechnique::InstancedPoints technique.
+     *
+     * Subclasses that support instancing must override this method to construct the material with the
      * correct shader from the start.
      */
-    virtual QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const SIP_FACTORY;
+    virtual QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const;
 
     /**
      * Returns the parameters to be exported to .mtl file

--- a/src/3d/materials/qgsmaterial3dhandler.h
+++ b/src/3d/materials/qgsmaterial3dhandler.h
@@ -153,12 +153,9 @@ class _3D_EXPORT QgsAbstractMaterial3DHandler SIP_ABSTRACT
     /**
      * Creates a QgsMaterial for instanced point rendering.
      *
-     * The \a flags argument controls which per-instance attributes are active:
+     * The \a flags argument controls which per-instance attributes are active.
      *
-     * - Qgis::InstancedMaterialFlag::DataDefinedScale injects ``USE_INSTANCE_SCALE`` into the vertex shader.
-     * - Qgis::InstancedMaterialFlag::DataDefinedRotation injects ``USE_INSTANCE_ROTATION`` into the vertex shader.
-     *
-     * The default implementation delegates to toMaterial() with the Qgis::MaterialRenderingTechnique::InstancedPoints technique.
+     * The default implementation returns nullptr.
      *
      * Subclasses that support instancing must override this method to construct the material with the
      * correct shader from the start.

--- a/src/3d/materials/qgsphongmaterial.cpp
+++ b/src/3d/materials/qgsphongmaterial.cpp
@@ -32,16 +32,13 @@
 using namespace Qt::StringLiterals;
 
 ///@cond PRIVATE
-QgsPhongMaterial::QgsPhongMaterial( bool instanced, bool hasDDScale, bool hasDDRotation, QNode *parent )
+QgsPhongMaterial::QgsPhongMaterial( QNode *parent )
   : QgsMaterial( parent )
   , mAmbientParameter( new Qt3DRender::QParameter( u"ambientColor"_s, QVariant() ) )
   , mDiffuseParameter( new Qt3DRender::QParameter( u"diffuseColor"_s, QVariant() ) )
   , mSpecularParameter( new Qt3DRender::QParameter( u"specularColor"_s, QVariant() ) )
   , mShininessParameter( new Qt3DRender::QParameter( u"shininess"_s, 0.0f ) )
   , mOpacityParameter( new Qt3DRender::QParameter( u"opacity"_s, 1.0f ) )
-  , mInstanced( instanced )
-  , mHasDDScale( hasDDScale )
-  , mHasDDRotation( hasDDRotation )
 {
   setAmbient( QColor::fromRgbF( 0.1f, 0.1f, 0.1f, 1.0f ) );
   setDiffuse( QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
@@ -83,6 +80,13 @@ void QgsPhongMaterial::init()
   updateShaders();
 }
 
+void QgsPhongMaterial::setInstancingEnabled( bool enabled, Qgis::InstancedMaterialFlags flags )
+{
+  mInstanced = enabled;
+  mInstanceFlags = flags;
+  updateShaders();
+}
+
 void QgsPhongMaterial::updateShaders()
 {
   const QByteArray fragCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/phong.frag"_s ) );
@@ -90,9 +94,9 @@ void QgsPhongMaterial::updateShaders()
   if ( mInstanced )
   {
     QStringList defines;
-    if ( mHasDDScale )
+    if ( mInstanceFlags.testFlag( Qgis::InstancedMaterialFlag::DataDefinedScale ) )
       defines << u"USE_INSTANCE_SCALE"_s;
-    if ( mHasDDRotation )
+    if ( mInstanceFlags.testFlag( Qgis::InstancedMaterialFlag::DataDefinedRotation ) )
       defines << u"USE_INSTANCE_ROTATION"_s;
     const QByteArray vertCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/instanced.vert"_s ) );
     mShaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qgs3DUtils::addDefinesToShaderCode( vertCode, defines ) );

--- a/src/3d/materials/qgsphongmaterial.cpp
+++ b/src/3d/materials/qgsphongmaterial.cpp
@@ -32,13 +32,16 @@
 using namespace Qt::StringLiterals;
 
 ///@cond PRIVATE
-QgsPhongMaterial::QgsPhongMaterial( QNode *parent )
+QgsPhongMaterial::QgsPhongMaterial( bool instanced, bool hasDDScale, bool hasDDRotation, QNode *parent )
   : QgsMaterial( parent )
   , mAmbientParameter( new Qt3DRender::QParameter( u"ambientColor"_s, QVariant() ) )
   , mDiffuseParameter( new Qt3DRender::QParameter( u"diffuseColor"_s, QVariant() ) )
   , mSpecularParameter( new Qt3DRender::QParameter( u"specularColor"_s, QVariant() ) )
   , mShininessParameter( new Qt3DRender::QParameter( u"shininess"_s, 0.0f ) )
   , mOpacityParameter( new Qt3DRender::QParameter( u"opacity"_s, 1.0f ) )
+  , mInstanced( instanced )
+  , mHasDDScale( hasDDScale )
+  , mHasDDRotation( hasDDRotation )
 {
   setAmbient( QColor::fromRgbF( 0.1f, 0.1f, 0.1f, 1.0f ) );
   setDiffuse( QColor::fromRgbF( 0.7f, 0.7f, 0.7f, 1.0f ) );
@@ -84,7 +87,18 @@ void QgsPhongMaterial::updateShaders()
 {
   const QByteArray fragCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/phong.frag"_s ) );
 
-  if ( mDataDefinedEnabled )
+  if ( mInstanced )
+  {
+    QStringList defines;
+    if ( mHasDDScale )
+      defines << u"USE_INSTANCE_SCALE"_s;
+    if ( mHasDDRotation )
+      defines << u"USE_INSTANCE_ROTATION"_s;
+    const QByteArray vertCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/instanced.vert"_s ) );
+    mShaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qgs3DUtils::addDefinesToShaderCode( vertCode, defines ) );
+    mShaderProgram->setFragmentShaderCode( fragCode );
+  }
+  else if ( mDataDefinedEnabled )
   {
     mShaderProgram->setShaderCode( Qt3DRender::QShaderProgram::Vertex, Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/phongDataDefined.vert"_s ) ) );
     mShaderProgram->setFragmentShaderCode( Qgs3DUtils::addDefinesToShaderCode( fragCode, QStringList( { u"DATA_DEFINED"_s } ) ) );

--- a/src/3d/materials/qgsphongmaterial.h
+++ b/src/3d/materials/qgsphongmaterial.h
@@ -45,8 +45,11 @@ class _3D_EXPORT QgsPhongMaterial : public QgsMaterial
   public:
     /**
      * Constructor for QgsPhongMaterial, with the specified \a parent node.
+     * Set \a instanced to TRUE when the material will be used with instanced point rendering.
+     * \a hasDDScale and \a hasDDRotation enable per-instance scale and rotation support,
+     * and are only meaningful when \a instanced is TRUE.
      */
-    explicit QgsPhongMaterial( Qt3DCore::QNode *parent = nullptr );
+    explicit QgsPhongMaterial( bool instanced = false, bool hasDDScale = false, bool hasDDRotation = false, Qt3DCore::QNode *parent = nullptr );
     ~QgsPhongMaterial() override;
 
   public slots:
@@ -77,6 +80,9 @@ class _3D_EXPORT QgsPhongMaterial : public QgsMaterial
     Qt3DRender::QParameter *mOpacityParameter = nullptr;
     Qt3DRender::QShaderProgram *mShaderProgram = nullptr;
     bool mDataDefinedEnabled = false;
+    bool mInstanced = false;
+    bool mHasDDScale = false;
+    bool mHasDDRotation = false;
 };
 
 ///@endcond PRIVATE

--- a/src/3d/materials/qgsphongmaterial.h
+++ b/src/3d/materials/qgsphongmaterial.h
@@ -16,6 +16,7 @@
 #ifndef QGSPHONGMATERIAL_H
 #define QGSPHONGMATERIAL_H
 
+#include "qgis.h"
 #include "qgis_3d.h"
 #include "qgsmaterial.h"
 
@@ -45,11 +46,16 @@ class _3D_EXPORT QgsPhongMaterial : public QgsMaterial
   public:
     /**
      * Constructor for QgsPhongMaterial, with the specified \a parent node.
-     * Set \a instanced to TRUE when the material will be used with instanced point rendering.
-     * \a hasDDScale and \a hasDDRotation enable per-instance scale and rotation support,
-     * and are only meaningful when \a instanced is TRUE.
      */
-    explicit QgsPhongMaterial( bool instanced = false, bool hasDDScale = false, bool hasDDRotation = false, Qt3DCore::QNode *parent = nullptr );
+    explicit QgsPhongMaterial( Qt3DCore::QNode *parent = nullptr );
+
+    /**
+     * Enables or disables instanced point rendering mode.
+     * When \a enabled is TRUE the material uses the instanced vertex shader.
+     * \a flags controls which per-instance attributes (scale, rotation) are active.
+     */
+    void setInstancingEnabled( bool enabled, Qgis::InstancedMaterialFlags flags );
+
     ~QgsPhongMaterial() override;
 
   public slots:
@@ -81,8 +87,7 @@ class _3D_EXPORT QgsPhongMaterial : public QgsMaterial
     Qt3DRender::QShaderProgram *mShaderProgram = nullptr;
     bool mDataDefinedEnabled = false;
     bool mInstanced = false;
-    bool mHasDDScale = false;
-    bool mHasDDRotation = false;
+    Qgis::InstancedMaterialFlags mInstanceFlags;
 };
 
 ///@endcond PRIVATE

--- a/src/3d/materials/qgsphongmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongmaterial3dhandler.cpp
@@ -37,8 +37,13 @@ QgsMaterial *QgsPhongMaterial3DHandler::toMaterial( const QgsAbstractMaterialSet
 {
   switch ( technique )
   {
-    case Qgis::MaterialRenderingTechnique::Triangles:
     case Qgis::MaterialRenderingTechnique::InstancedPoints:
+    {
+      if ( context.isHighlighted() )
+        return new QgsHighlightMaterial( technique );
+      return toInstancedMaterial( settings, context, false, false );
+    }
+    case Qgis::MaterialRenderingTechnique::Triangles:
     case Qgis::MaterialRenderingTechnique::Points:
     case Qgis::MaterialRenderingTechnique::TrianglesDataDefined:
     case Qgis::MaterialRenderingTechnique::TrianglesWithFixedTexture:
@@ -239,26 +244,27 @@ bool QgsPhongMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot
   return true;
 }
 
-QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const
+QgsMaterial *QgsPhongMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const
+{
+  return buildMaterial( settings, context, true, hasDDScale, hasDDRotation );
+}
+
+QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool instanced, bool hasDDScale, bool hasDDRotation ) const
 {
   const QgsPhongMaterialSettings *phongSettings = dynamic_cast< const QgsPhongMaterialSettings * >( settings );
   Q_ASSERT( phongSettings );
 
-  QgsPhongMaterial *material = new QgsPhongMaterial;
+  QgsPhongMaterial *material = new QgsPhongMaterial( instanced, hasDDScale, hasDDRotation );
   material->setObjectName( u"phongMaterial"_s );
 
-  material->setDataDefinedEnabled( phongSettings->dataDefinedProperties().hasActiveProperties() );
+  const QColor ambient = context.isSelected() ? context.selectionColor().darker() : phongSettings->ambient();
+  const QColor diffuse = context.isSelected() ? context.selectionColor() : phongSettings->diffuse();
+  material->setAmbient( ambient, static_cast<float>( phongSettings->ambientCoefficient() ) );
+  material->setDiffuse( diffuse, static_cast<float>( phongSettings->diffuseCoefficient() ) );
+  material->setSpecular( phongSettings->specular(), static_cast<float>( phongSettings->specularCoefficient() ) );
 
-  if ( !phongSettings->dataDefinedProperties().hasActiveProperties() )
-  {
-    const QColor ambient = context.isSelected() ? context.selectionColor().darker() : phongSettings->ambient();
-    const QColor diffuse = context.isSelected() ? context.selectionColor() : phongSettings->diffuse();
-    const QColor specular = phongSettings->specular();
-
-    material->setAmbient( ambient, static_cast<float>( phongSettings->ambientCoefficient() ) );
-    material->setDiffuse( diffuse, static_cast<float>( phongSettings->diffuseCoefficient() ) );
-    material->setSpecular( specular, static_cast<float>( phongSettings->specularCoefficient() ) );
-  }
+  if ( !instanced )
+    material->setDataDefinedEnabled( phongSettings->dataDefinedProperties().hasActiveProperties() );
 
   material->setShininess( static_cast<float>( phongSettings->shininess() ) );
   material->setOpacity( static_cast<float>( phongSettings->opacity() ) );

--- a/src/3d/materials/qgsphongmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongmaterial3dhandler.cpp
@@ -39,9 +39,8 @@ QgsMaterial *QgsPhongMaterial3DHandler::toMaterial( const QgsAbstractMaterialSet
   {
     case Qgis::MaterialRenderingTechnique::InstancedPoints:
     {
-      if ( context.isHighlighted() )
-        return new QgsHighlightMaterial( technique );
-      return toInstancedMaterial( settings, context, false, false );
+      Q_ASSERT( false );
+      return nullptr;
     }
     case Qgis::MaterialRenderingTechnique::Triangles:
     case Qgis::MaterialRenderingTechnique::Points:
@@ -54,7 +53,26 @@ QgsMaterial *QgsPhongMaterial3DHandler::toMaterial( const QgsAbstractMaterialSet
         return new QgsHighlightMaterial( technique );
       }
 
-      return buildMaterial( settings, context );
+      const QgsPhongMaterialSettings *phongSettings = dynamic_cast< const QgsPhongMaterialSettings * >( settings );
+      Q_ASSERT( phongSettings );
+
+      QgsPhongMaterial *material = new QgsPhongMaterial();
+      material->setObjectName( u"phongMaterial"_s );
+
+      const bool dataDefined = phongSettings->dataDefinedProperties().hasActiveProperties();
+      if ( !dataDefined )
+      {
+        const QColor ambient = context.isSelected() ? context.selectionColor().darker() : phongSettings->ambient();
+        const QColor diffuse = context.isSelected() ? context.selectionColor() : phongSettings->diffuse();
+        material->setAmbient( ambient, static_cast<float>( phongSettings->ambientCoefficient() ) );
+        material->setDiffuse( diffuse, static_cast<float>( phongSettings->diffuseCoefficient() ) );
+        material->setSpecular( phongSettings->specular(), static_cast<float>( phongSettings->specularCoefficient() ) );
+      }
+      material->setShininess( static_cast<float>( phongSettings->shininess() ) );
+      material->setOpacity( static_cast<float>( phongSettings->opacity() ) );
+      material->setDataDefinedEnabled( dataDefined );
+
+      return material;
     }
 
     case Qgis::MaterialRenderingTechnique::Lines:
@@ -244,17 +262,12 @@ bool QgsPhongMaterial3DHandler::updatePreviewScene( Qt3DCore::QEntity *sceneRoot
   return true;
 }
 
-QgsMaterial *QgsPhongMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const
+QgsMaterial *QgsPhongMaterial3DHandler::toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const
 {
-  return buildMaterial( settings, context, true, hasDDScale, hasDDRotation );
-}
+  const QgsPhongMaterialSettings *phongSettings = qgis::down_cast< const QgsPhongMaterialSettings * >( settings );
 
-QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool instanced, bool hasDDScale, bool hasDDRotation ) const
-{
-  const QgsPhongMaterialSettings *phongSettings = dynamic_cast< const QgsPhongMaterialSettings * >( settings );
-  Q_ASSERT( phongSettings );
-
-  QgsPhongMaterial *material = new QgsPhongMaterial( instanced, hasDDScale, hasDDRotation );
+  QgsPhongMaterial *material = new QgsPhongMaterial();
+  material->setInstancingEnabled( true, flags );
   material->setObjectName( u"phongMaterial"_s );
 
   const QColor ambient = context.isSelected() ? context.selectionColor().darker() : phongSettings->ambient();
@@ -262,10 +275,6 @@ QgsMaterial *QgsPhongMaterial3DHandler::buildMaterial( const QgsAbstractMaterial
   material->setAmbient( ambient, static_cast<float>( phongSettings->ambientCoefficient() ) );
   material->setDiffuse( diffuse, static_cast<float>( phongSettings->diffuseCoefficient() ) );
   material->setSpecular( phongSettings->specular(), static_cast<float>( phongSettings->specularCoefficient() ) );
-
-  if ( !instanced )
-    material->setDataDefinedEnabled( phongSettings->dataDefinedProperties().hasActiveProperties() );
-
   material->setShininess( static_cast<float>( phongSettings->shininess() ) );
   material->setOpacity( static_cast<float>( phongSettings->opacity() ) );
 

--- a/src/3d/materials/qgsphongmaterial3dhandler.h
+++ b/src/3d/materials/qgsphongmaterial3dhandler.h
@@ -44,9 +44,7 @@ class _3D_EXPORT QgsPhongMaterial3DHandler : public QgsAbstractMaterial3DHandler
     bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 
   private:
-    //! Constructs a material from shader files
-    QgsMaterial *buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool instanced = false, bool hasDDScale = false, bool hasDDRotation = false ) const;
-    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const override SIP_FACTORY;
+    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const override SIP_FACTORY;
 };
 
 

--- a/src/3d/materials/qgsphongmaterial3dhandler.h
+++ b/src/3d/materials/qgsphongmaterial3dhandler.h
@@ -37,14 +37,12 @@ class _3D_EXPORT QgsPhongMaterial3DHandler : public QgsAbstractMaterial3DHandler
 
     QMap<QString, QString> toExportParameters( const QgsAbstractMaterialSettings *settings ) const override;
     QgsMaterial *toMaterial( const QgsAbstractMaterialSettings *settings, Qgis::MaterialRenderingTechnique technique, const QgsMaterialContext &context ) const override SIP_FACTORY;
+    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const override;
     void addParametersToEffect( Qt3DRender::QEffect *effect, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &materialContext ) const override;
     QByteArray dataDefinedVertexColorsAsByte( const QgsAbstractMaterialSettings *settings, const QgsExpressionContext &expressionContext ) const override;
     int dataDefinedByteStride( const QgsAbstractMaterialSettings *settings ) const override;
     void applyDataDefinedToGeometry( const QgsAbstractMaterialSettings *settings, Qt3DCore::QGeometry *geometry, int vertexCount, const QByteArray &data ) const override;
     bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
-
-  private:
-    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const override;
 };
 
 

--- a/src/3d/materials/qgsphongmaterial3dhandler.h
+++ b/src/3d/materials/qgsphongmaterial3dhandler.h
@@ -44,7 +44,7 @@ class _3D_EXPORT QgsPhongMaterial3DHandler : public QgsAbstractMaterial3DHandler
     bool updatePreviewScene( Qt3DCore::QEntity *sceneRoot, const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const override;
 
   private:
-    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const override SIP_FACTORY;
+    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, Qgis::InstancedMaterialFlags flags ) const override;
 };
 
 

--- a/src/3d/materials/qgsphongmaterial3dhandler.h
+++ b/src/3d/materials/qgsphongmaterial3dhandler.h
@@ -45,7 +45,8 @@ class _3D_EXPORT QgsPhongMaterial3DHandler : public QgsAbstractMaterial3DHandler
 
   private:
     //! Constructs a material from shader files
-    QgsMaterial *buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context ) const;
+    QgsMaterial *buildMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool instanced = false, bool hasDDScale = false, bool hasDDRotation = false ) const;
+    QgsMaterial *toInstancedMaterial( const QgsAbstractMaterialSettings *settings, const QgsMaterialContext &context, bool hasDDScale, bool hasDDRotation ) const override SIP_FACTORY;
 };
 
 

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -320,7 +320,14 @@ QgsMaterial *QgsInstancedPoint3DSymbolHandler::material( const QgsPoint3DSymbol 
 
   const QgsAbstractMaterialSettings *settings = symbol->materialSettings();
   if ( const QgsAbstractMaterial3DHandler *handler = Qgs3D::handlerForMaterialSettings( settings ) )
-    return handler->toInstancedMaterial( settings, materialContext, hasDataDefinedScale, hasDataDefinedRotation );
+  {
+    Qgis::InstancedMaterialFlags flags;
+    if ( hasDataDefinedScale )
+      flags |= Qgis::InstancedMaterialFlag::DataDefinedScale;
+    if ( hasDataDefinedRotation )
+      flags |= Qgis::InstancedMaterialFlag::DataDefinedRotation;
+    return handler->toInstancedMaterial( settings, materialContext, flags );
+  }
 
   return nullptr;
 }

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -291,6 +291,8 @@ void QgsInstancedPoint3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, co
   materialContext.setIsSelected( selected );
   materialContext.setIsHighlighted( mHighlightingEnabled );
   QgsMaterial *mat = material( mSymbol.get(), materialContext, !out.scales.empty(), !out.rotations.empty() );
+  if ( !mat )
+    return;
 
   mat->addParameter( new Qt3DRender::QParameter( "symbolScale", mSymbolScale, mat ) );
   mat->addParameter( new Qt3DRender::QParameter( "symbolRotation", mSymbolRotation.toVector4D(), mat ) );
@@ -313,52 +315,14 @@ void QgsInstancedPoint3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, co
 
 QgsMaterial *QgsInstancedPoint3DSymbolHandler::material( const QgsPoint3DSymbol *symbol, const QgsMaterialContext &materialContext, bool hasDataDefinedScale, bool hasDataDefinedRotation )
 {
-  std::unique_ptr<QgsMaterial> material;
-
   if ( materialContext.isHighlighted() )
-  {
-    material = std::make_unique<QgsHighlightMaterial>( Qgis::MaterialRenderingTechnique::InstancedPoints );
-  }
-  else
-  {
-    Qt3DRender::QFilterKey *filterKey = new Qt3DRender::QFilterKey;
-    filterKey->setName( u"renderingStyle"_s );
-    filterKey->setValue( "forward" );
+    return new QgsHighlightMaterial( Qgis::MaterialRenderingTechnique::InstancedPoints );
 
-    Qt3DRender::QShaderProgram *shaderProgram = new Qt3DRender::QShaderProgram;
+  const QgsAbstractMaterialSettings *settings = symbol->materialSettings();
+  if ( const QgsAbstractMaterial3DHandler *handler = Qgs3D::handlerForMaterialSettings( settings ) )
+    return handler->toInstancedMaterial( settings, materialContext, hasDataDefinedScale, hasDataDefinedRotation );
 
-    const QByteArray vertexShaderCode = Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/instanced.vert"_s ) );
-    QStringList defines;
-    if ( hasDataDefinedScale )
-      defines << u"USE_INSTANCE_SCALE"_s;
-    if ( hasDataDefinedRotation )
-      defines << u"USE_INSTANCE_ROTATION"_s;
-
-    const QByteArray finalVertexShaderCode = Qgs3DUtils::addDefinesToShaderCode( vertexShaderCode, defines );
-    shaderProgram->setVertexShaderCode( finalVertexShaderCode );
-    shaderProgram->setFragmentShaderCode( Qt3DRender::QShaderProgram::loadSource( QUrl( u"qrc:/shaders/phong.frag"_s ) ) );
-
-    Qt3DRender::QRenderPass *renderPass = new Qt3DRender::QRenderPass;
-    renderPass->setShaderProgram( shaderProgram );
-
-    Qt3DRender::QTechnique *technique = new Qt3DRender::QTechnique;
-    technique->addFilterKey( filterKey );
-    technique->addRenderPass( renderPass );
-    technique->graphicsApiFilter()->setApi( Qt3DRender::QGraphicsApiFilter::OpenGL );
-    technique->graphicsApiFilter()->setProfile( Qt3DRender::QGraphicsApiFilter::CoreProfile );
-    technique->graphicsApiFilter()->setMajorVersion( 3 );
-    technique->graphicsApiFilter()->setMinorVersion( 2 );
-
-    Qt3DRender::QEffect *effect = new Qt3DRender::QEffect;
-    effect->addTechnique( technique );
-
-    Qgs3D::addMaterialParametersToEffect( effect, symbol->materialSettings(), materialContext );
-
-    material = std::make_unique<QgsMaterial>();
-    material->setEffect( effect );
-  }
-
-  return material.release();
+  return nullptr;
 }
 
 Qt3DRender::QGeometryRenderer *QgsInstancedPoint3DSymbolHandler::renderer(

--- a/src/core/3d/materials/qgsgoochmaterialsettings.cpp
+++ b/src/core/3d/materials/qgsgoochmaterialsettings.cpp
@@ -40,10 +40,10 @@ bool QgsGoochMaterialSettings::supportsTechnique( Qgis::MaterialRenderingTechniq
     case Qgis::MaterialRenderingTechnique::TrianglesWithFixedTexture:
     case Qgis::MaterialRenderingTechnique::TrianglesFromModel:
     case Qgis::MaterialRenderingTechnique::TrianglesDataDefined:
+    case Qgis::MaterialRenderingTechnique::InstancedPoints:
       return true;
 
     case Qgis::MaterialRenderingTechnique::Lines:
-    case Qgis::MaterialRenderingTechnique::InstancedPoints:
     case Qgis::MaterialRenderingTechnique::Points:
     case Qgis::MaterialRenderingTechnique::Billboards:
       return false;

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4352,6 +4352,20 @@ int QgisEvent = QEvent::User + 1;
     Q_ENUM( MaterialRenderingTechnique )
 
     /**
+     * Optional per-instance properties of instanced materials.
+     *
+     * \since QGIS 4.2
+     */
+    enum class InstancedMaterialFlag : int SIP_ENUM_BASETYPE( IntFlag )
+    {
+      DataDefinedScale = 1 << 0,    //!< Per-instance data-defined scale
+      DataDefinedRotation = 1 << 1, //!< Per-instance data-defined rotation
+    };
+    Q_ENUM( InstancedMaterialFlag )
+    Q_DECLARE_FLAGS( InstancedMaterialFlags, InstancedMaterialFlag )
+    Q_FLAG( InstancedMaterialFlags )
+
+    /**
      * Texture filtering qualities.
      *
      * \since QGIS 4.2
@@ -6997,6 +7011,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ExtrusionFaces )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::MapGridFrameSideFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::SymbolConverterCapabilities )
 Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::ArcGisRestServiceCapabilities )
+Q_DECLARE_OPERATORS_FOR_FLAGS( Qgis::InstancedMaterialFlags )
 Q_DECLARE_METATYPE( Qgis::LayoutRenderFlags )
 Q_DECLARE_METATYPE( QTimeZone )
 


### PR DESCRIPTION
This PR extract point instancing from handler to phong and gooch material classes.

<img width="1237" height="1143" alt="Screenshot_20260507_224315" src="https://github.com/user-attachments/assets/f0ce9d6a-308c-4539-9956-dd9d8a7c691f" />

<img width="3839" height="1999" alt="Screenshot_20260507_212229" src="https://github.com/user-attachments/assets/0dcb8385-e47c-453d-a33e-5bcf40d83f78" />


## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

I tried to bug AI to help load an .obj with textures (had a, supposedly correct, .mtl file with .pngs), but failed to get any result. Object loads correctly, but not textures were applied to it.
The only supporting textured format I found was .gltf.