### PR TITLE
Fix GLTF loading by passing base uri

### DIFF
--- a/src/analysis/processing/qgsalgorithmgltftovector.cpp
+++ b/src/analysis/processing/qgsalgorithmgltftovector.cpp
@@ -27,6 +27,7 @@
 #include "qgspolygon.h"
 #include "qgsvector3d.h"
 
+#include <QFileInfo>
 #include <QMatrix4x4>
 #include <QString>
 
@@ -319,7 +320,7 @@ QVariantMap QgsGltfToVectorFeaturesAlgorithm::processAlgorithm( const QVariantMa
   tinygltf::Model model;
   QString errors;
   QString warnings;
-  if ( !QgsGltfUtils::loadGltfModel( fileContent, model, &errors, &warnings ) )
+  if ( !QgsGltfUtils::loadGltfModel( fileContent, model, &errors, &warnings, QFileInfo( path ).absolutePath() ) )
   {
     throw QgsProcessingException( QObject::tr( "Error loading GLTF model: %1" ).arg( errors ) );
   }

--- a/src/core/tiledscene/qgsgltfutils.cpp
+++ b/src/core/tiledscene/qgsgltfutils.cpp
@@ -345,7 +345,7 @@ bool QgsGltfUtils::loadImageDataWithQImage(
   return true;
 }
 
-bool QgsGltfUtils::loadGltfModel( const QByteArray &data, tinygltf::Model &model, QString *errors, QString *warnings )
+bool QgsGltfUtils::loadGltfModel( const QByteArray &data, tinygltf::Model &model, QString *errors, QString *warnings, const QString &baseDir )
 {
   tinygltf::TinyGLTF loader;
 
@@ -357,7 +357,6 @@ bool QgsGltfUtils::loadGltfModel( const QByteArray &data, tinygltf::Model &model
   // (and there's a lot of non-compliant GLTF out there!)
   loader.SetParseStrictness( tinygltf::ParseStrictness::Permissive );
 
-  std::string baseDir; // TODO: may be useful to set it from baseUri
   std::string err, warn;
 
   bool res;
@@ -368,11 +367,11 @@ bool QgsGltfUtils::loadGltfModel( const QByteArray &data, tinygltf::Model &model
       *errors = QObject::tr( "GLTF version 1 tiles cannot be loaded" );
       return false;
     }
-    res = loader.LoadBinaryFromMemory( &model, &err, &warn, ( const unsigned char * ) data.constData(), data.size(), baseDir );
+    res = loader.LoadBinaryFromMemory( &model, &err, &warn, ( const unsigned char * ) data.constData(), data.size(), baseDir.toStdString() );
   }
   else
   {
-    res = loader.LoadASCIIFromString( &model, &err, &warn, data.constData(), data.size(), baseDir );
+    res = loader.LoadASCIIFromString( &model, &err, &warn, data.constData(), data.size(), baseDir.toStdString() );
   }
 
   if ( errors )

--- a/src/core/tiledscene/qgsgltfutils.h
+++ b/src/core/tiledscene/qgsgltfutils.h
@@ -159,7 +159,7 @@ class CORE_EXPORT QgsGltfUtils
      * and stores the result in the given \a model. Returns true on success.
      * May set \a errors and/or \a warnings if they are not null pointers.
      */
-    static bool loadGltfModel( const QByteArray &data, tinygltf::Model &model, QString *errors, QString *warnings );
+    static bool loadGltfModel( const QByteArray &data, tinygltf::Model &model, QString *errors, QString *warnings, const QString &baseDir = QString() );
 
     /**
      * Returns the index for the scene to load from a \a model.


### PR DESCRIPTION
Fixes loading of .gltf files by passing base uri (previously, .bin could not be located correctly when read from json). 
GLTF spec defines relative paths.

## AI tool usage

 - [ ] No AI used.