### PR TITLE
[server][feature][qep 414] FlatGeobuf OAPIF export plus various fixes

### DIFF
--- a/python/PyQt6/server/auto_additions/qgsbufferserverresponse.py
+++ b/python/PyQt6/server/auto_additions/qgsbufferserverresponse.py
@@ -1,5 +1,5 @@
 # The following has been generated automatically from src/server/qgsbufferserverresponse.h
 try:
-    QgsBufferServerResponse.__overridden_methods__ = ['setHeader', 'removeHeader', 'header', 'headers', 'headersSent', 'setStatusCode', 'statusCode', 'sendError', 'io', 'finish', 'flush', 'clear', 'data', 'truncate']
+    QgsBufferServerResponse.__overridden_methods__ = ['setHeader', 'addHeader', 'removeHeader', 'header', 'fullHeaders', 'fullHeader', 'headers', 'headersSent', 'setStatusCode', 'statusCode', 'sendError', 'io', 'finish', 'flush', 'clear', 'data', 'truncate']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/server/auto_additions/qgsserverogcapi.py
+++ b/python/PyQt6/server/auto_additions/qgsserverogcapi.py
@@ -18,7 +18,23 @@ QgsServerOgcApi.OPENAPI3 = QgsServerOgcApi.ContentType.OPENAPI3
 QgsServerOgcApi.JSON = QgsServerOgcApi.ContentType.JSON
 QgsServerOgcApi.HTML = QgsServerOgcApi.ContentType.HTML
 QgsServerOgcApi.XML = QgsServerOgcApi.ContentType.XML
+QgsServerOgcApi.FLATGEOBUF = QgsServerOgcApi.ContentType.FLATGEOBUF
 QgsServerOgcApi.ContentType.baseClass = QgsServerOgcApi
+# monkey patching scoped based enum
+QgsServerOgcApi.Profile.NONE.__doc__ = "No profile"
+QgsServerOgcApi.Profile.RFC7946.__doc__ = "GeoJSON profile according to RFC7946"
+QgsServerOgcApi.Profile.JSONFG.__doc__ = "JSON Feature Geometry profile according to OGC API - Features 1.0"
+QgsServerOgcApi.Profile.JSONFG_PLUS.__doc__ = "JSON Feature Geometry profile with GeoJSON compatibility extensions"
+QgsServerOgcApi.Profile.__doc__ = """JSON profile
+
+* ``NONE``: No profile
+* ``RFC7946``: GeoJSON profile according to RFC7946
+* ``JSONFG``: JSON Feature Geometry profile according to OGC API - Features 1.0
+* ``JSONFG_PLUS``: JSON Feature Geometry profile with GeoJSON compatibility extensions
+
+"""
+# --
+QgsServerOgcApi.Profile.baseClass = QgsServerOgcApi
 try:
     QgsServerOgcApi.sanitizeUrl = staticmethod(QgsServerOgcApi.sanitizeUrl)
     QgsServerOgcApi.relToString = staticmethod(QgsServerOgcApi.relToString)

--- a/python/PyQt6/server/auto_additions/qgsserverogcapi.py
+++ b/python/PyQt6/server/auto_additions/qgsserverogcapi.py
@@ -23,14 +23,10 @@ QgsServerOgcApi.ContentType.baseClass = QgsServerOgcApi
 # monkey patching scoped based enum
 QgsServerOgcApi.Profile.NONE.__doc__ = "No profile"
 QgsServerOgcApi.Profile.RFC7946.__doc__ = "GeoJSON profile according to RFC7946"
-QgsServerOgcApi.Profile.JSONFG.__doc__ = "JSON Feature Geometry profile according to OGC API - Features 1.0"
-QgsServerOgcApi.Profile.JSONFG_PLUS.__doc__ = "JSON Feature Geometry profile with GeoJSON compatibility extensions"
 QgsServerOgcApi.Profile.__doc__ = """JSON profile
 
 * ``NONE``: No profile
 * ``RFC7946``: GeoJSON profile according to RFC7946
-* ``JSONFG``: JSON Feature Geometry profile according to OGC API - Features 1.0
-* ``JSONFG_PLUS``: JSON Feature Geometry profile with GeoJSON compatibility extensions
 
 """
 # --

--- a/python/PyQt6/server/auto_additions/qgsserverresponse.py
+++ b/python/PyQt6/server/auto_additions/qgsserverresponse.py
@@ -1,6 +1,6 @@
 # The following has been generated automatically from src/server/qgsserverresponse.h
 try:
     QgsServerResponse.__virtual_methods__ = ['write', 'finish', 'flush', 'feedback']
-    QgsServerResponse.__abstract_methods__ = ['setHeader', 'removeHeader', 'header', 'headers', 'headersSent', 'setStatusCode', 'statusCode', 'sendError', 'io', 'clear', 'data', 'truncate']
+    QgsServerResponse.__abstract_methods__ = ['setHeader', 'addHeader', 'removeHeader', 'header', 'fullHeader', 'headers', 'fullHeaders', 'headersSent', 'setStatusCode', 'statusCode', 'sendError', 'io', 'clear', 'data', 'truncate']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/server/auto_generated/qgsbufferserverresponse.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsbufferserverresponse.sip.in
@@ -29,6 +29,19 @@ usually an error to set Header after data have been sent through the
 wire
 %End
 
+    virtual void addHeader( const QString &key, const QString &value );
+
+%Docstring
+Add a header ``value`` for the given ``key``, without replacing any
+existing value for the same ``key`` Add Header entry to the response
+
+.. note::
+
+   that it is usually an error to set Header after data have been sent through the wire
+
+.. versionadded:: 4.2
+%End
+
     virtual void removeHeader( const QString &key );
 
 %Docstring
@@ -41,9 +54,21 @@ Clear header Undo a previous 'setHeader' call
 Returns the header value
 %End
 
-    virtual QMap<QString, QString> headers() const;
+    virtual QMap<QString, QList<QString>> fullHeaders() const;
 %Docstring
 Returns all the headers
+%End
+
+    virtual QList<QString> fullHeader( const QString &key ) const;
+%Docstring
+Returns all the values for a header ``key``
+%End
+
+    virtual QMap<QString, QString> headers() const;
+
+%Docstring
+Returns all the headers as a map: only the first value is returned if
+multiple values are set for the same header
 %End
 
     virtual bool headersSent() const;

--- a/python/PyQt6/server/auto_generated/qgsbufferserverresponse.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsbufferserverresponse.sip.in
@@ -48,10 +48,16 @@ existing value for the same ``key`` Add Header entry to the response
 Clear header Undo a previous 'setHeader' call
 %End
 
-    virtual QString header( const QString &key ) const;
+ virtual QString header( const QString &key ) const /Deprecated="Since 4.2. Use fullHeader() instead."/;
 
 %Docstring
-Returns the header value
+Returns a single header value, or an empty string if the header is not
+set. If multiple values are set for the same header, only the last value
+is returned.
+
+.. deprecated:: 4.2
+
+   Use :py:func:`~QgsBufferServerResponse.fullHeader` instead.
 %End
 
     virtual QMap<QString, QList<QString>> fullHeaders() const;
@@ -64,11 +70,15 @@ Returns all the headers
 Returns all the values for a header ``key``
 %End
 
-    virtual QMap<QString, QString> headers() const;
+ virtual QMap<QString, QString> headers() const /Deprecated="Since 4.2. Use fullHeaders() instead."/;
 
 %Docstring
-Returns all the headers as a map: only the first value is returned if
-multiple values are set for the same header
+Returns all the headers as a map: only the last value is returned if
+multiple values are set for the same header name.
+
+.. deprecated:: 4.2
+
+   Use :py:func:`~QgsBufferServerResponse.fullHeaders` instead.
 %End
 
     virtual bool headersSent() const;

--- a/python/PyQt6/server/auto_generated/qgsrequesthandler.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsrequesthandler.sip.in
@@ -57,10 +57,14 @@ Remove an HTTP response header
 Retrieve response header value
 %End
 
-    QMap<QString, QString> responseHeaders() const;
+ QMap<QString, QString> responseHeaders() const /Deprecated="Since 4.2. Use fullResponseHeaders() instead."/;
 %Docstring
 Returns the response headers: note that if multiple values are set for
-the same header, only the first one is returned
+the same header, only the last one is returned
+
+.. deprecated:: 4.2
+
+   Use :py:func:`~QgsRequestHandler.fullResponseHeaders` instead.
 %End
 
     QList<QString> fullResponseHeader( const QString &name ) const;
@@ -90,8 +94,7 @@ Remove an HTTP request header
 
     QString requestHeader( const QString &name ) const;
 %Docstring
-Retrieve request header value: note that if multiple values are set for
-the same header, only the first one is returned
+Retrieve request header value
 %End
 
     QMap<QString, QString> requestHeaders() const;

--- a/python/PyQt6/server/auto_generated/qgsrequesthandler.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsrequesthandler.sip.in
@@ -59,7 +59,23 @@ Retrieve response header value
 
     QMap<QString, QString> responseHeaders() const;
 %Docstring
-Returns the response headers
+Returns the response headers: note that if multiple values are set for
+the same header, only the first one is returned
+%End
+
+    QList<QString> fullResponseHeader( const QString &name ) const;
+%Docstring
+Returns the list of response headers for a given header ``name``
+
+.. versionadded:: 4.2
+%End
+
+    QMap<QString, QList<QString>> fullResponseHeaders() const;
+%Docstring
+Returns the response headers as a map of header name to list of values
+(to support multiple values for the same header)
+
+.. versionadded:: 4.2
 %End
 
     void setRequestHeader( const QString &name, const QString &value );
@@ -74,7 +90,8 @@ Remove an HTTP request header
 
     QString requestHeader( const QString &name ) const;
 %Docstring
-Retrieve request header value
+Retrieve request header value: note that if multiple values are set for
+the same header, only the first one is returned
 %End
 
     QMap<QString, QString> requestHeaders() const;

--- a/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
@@ -64,7 +64,16 @@ as instances of :py:class:`QgsServerOgcApiHandler`.
       OPENAPI3,
       JSON,
       HTML,
-      XML
+      XML,
+      FLATGEOBUF
+    };
+
+    enum class Profile
+    {
+      NONE,
+      RFC7946,
+      JSONFG,
+      JSONFG_PLUS
     };
 
     QgsServerOgcApi( QgsServerInterface *serverIface, const QString &rootPath, const QString &name, const QString &description = QString(), const QString &version = QString() );
@@ -91,6 +100,8 @@ QgsServerOgcApi constructor
 %Docstring
 Executes a request by passing the given ``context`` to the API handlers.
 %End
+
+
 
 
 

--- a/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverogcapi.sip.in
@@ -72,8 +72,10 @@ as instances of :py:class:`QgsServerOgcApiHandler`.
     {
       NONE,
       RFC7946,
-      JSONFG,
-      JSONFG_PLUS
+      // This not supported yet but I am leaving it here because
+      // I am very optimistic that it will be supported soon!
+      //  JSONFG,     //!< JSON Feature Geometry profile according to OGC API - Features 1.0
+      //  JSONFG_PLUS //!< JSON Feature Geometry profile with GeoJSON compatibility extensions
     };
 
     QgsServerOgcApi( QgsServerInterface *serverIface, const QString &rootPath, const QString &name, const QString &description = QString(), const QString &version = QString() );

--- a/python/PyQt6/server/auto_generated/qgsserverogcapihandler.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverogcapihandler.sip.in
@@ -186,6 +186,26 @@ its mime type, returns an empty string if there are not matches.
 
 
 
+    QString headerLink(
+      const QgsServerApiContext &context,
+      const QgsServerOgcApi::Rel &linkType = QgsServerOgcApi::Rel::self,
+      const QgsServerOgcApi::ContentType contentType = QgsServerOgcApi::ContentType::JSON,
+      const QgsServerOgcApi::Profile &profile = QgsServerOgcApi::Profile::NONE,
+      const QString &title = ""
+    ) const;
+%Docstring
+Builds and returns a header link to the resource.
+
+:param context: request context
+:param linkType: type of the link (rel attribute), default to SELF
+:param contentType: content type of the link (default to JSON)
+:param title: title of the link
+
+.. note::
+
+   not available in Python bindings
+%End
+
     void write( QVariant &data, const QgsServerApiContext &context, const QVariantMap &htmlMetadata = QVariantMap() ) const;
 %Docstring
 Writes ``data`` to the ``context`` response stream, content-type is

--- a/python/PyQt6/server/auto_generated/qgsserverresponse.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverresponse.sip.in
@@ -23,9 +23,24 @@ class QgsServerResponse
 
     virtual void setHeader( const QString &key, const QString &value ) = 0;
 %Docstring
-Set Header entry Add Header entry to the response Note that it is
-usually an error to set Header after data have been sent through the
-wire
+Set a single header ``value`` replacing any existing value for the same
+``key`` Add Header entry to the response
+
+.. note::
+
+   that it is usually an error to set Header after data have been sent through the wire
+%End
+
+    virtual void addHeader( const QString &key, const QString &value ) = 0;
+%Docstring
+Add a header ``value`` for the given ``key``, without replacing any
+existing value for the same ``key`` Add Header entry to the response
+
+.. note::
+
+   that it is usually an error to set Header after data have been sent through the wire
+
+.. versionadded:: 4.2
 %End
 
     virtual void removeHeader( const QString &key ) = 0;
@@ -36,18 +51,36 @@ Clear header Undo a previous 'setHeader' call
     virtual QString header( const QString &key ) const = 0;
 %Docstring
 Returns the header value
+
+.. note::
+
+   if multiple values are set for the same key, the last one is returned
+%End
+
+    virtual QList<QString> fullHeader( const QString &key ) const = 0;
+%Docstring
+Returns the header values for the given ``key``
+
+.. versionadded:: 4.2
 %End
 
     virtual QMap<QString, QString> headers() const = 0;
 %Docstring
-Returns the header value
+Returns the header values as a map: only the last value is returned if
+multiple values are set for the same header
+%End
+
+    virtual QMap<QString, QList<QString>> fullHeaders() const = 0;
+%Docstring
+Returns the header values
+
+.. versionadded:: 4.2
 %End
 
     virtual bool headersSent() const = 0;
 %Docstring
 Returns ``True`` if the headers have already been sent
 %End
-
 
     virtual void setStatusCode( int code ) = 0;
 %Docstring

--- a/python/PyQt6/server/auto_generated/qgsserverresponse.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverresponse.sip.in
@@ -55,13 +55,17 @@ Clear all header values for the given ``key`` Undo a previous
 'setHeader' call
 %End
 
-    virtual QString header( const QString &key ) const = 0;
+ virtual QString header( const QString &key ) const = 0 /Deprecated="Since 4.2. Use fullHeader() instead."/;
 %Docstring
 Returns a single header value for a given ``key``
 
 .. note::
 
    if multiple values are set for the same key, the last one is returned
+
+.. deprecated:: 4.2
+
+   Use :py:func:`~QgsServerResponse.fullHeader` instead.
 %End
 
     virtual QList<QString> fullHeader( const QString &key ) const = 0;
@@ -74,12 +78,16 @@ Returns a (possibly empty) list of all the header values for the given
 .. versionadded:: 4.2
 %End
 
-    virtual QMap<QString, QString> headers() const = 0;
+ virtual QMap<QString, QString> headers() const = 0 /Deprecated="Since 4.2. Use fullHeaders() instead."/;
 %Docstring
 Returns the header values as a map: only the last value is returned if
 multiple values are set for the same header
 
 .. seealso:: :py:func:`fullHeaders` to get all the values for all the headers
+
+.. deprecated:: 4.2
+
+   Use :py:func:`~QgsServerResponse.fullHeaders` instead.
 %End
 
     virtual QMap<QString, QList<QString>> fullHeaders() const = 0;

--- a/python/PyQt6/server/auto_generated/qgsserverresponse.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsserverresponse.sip.in
@@ -23,12 +23,16 @@ class QgsServerResponse
 
     virtual void setHeader( const QString &key, const QString &value ) = 0;
 %Docstring
-Set a single header ``value`` replacing any existing value for the same
-``key`` Add Header entry to the response
+Set a single header ``value`` replacing any existing value(s) for the
+same ``key``
 
 .. note::
 
    that it is usually an error to set Header after data have been sent through the wire
+
+.. seealso:: :py:func:`addHeader` for a method that allows setting multiple values for the same header key
+
+.. seealso:: :py:func:`removeHeader` to clear header values for a given key
 %End
 
     virtual void addHeader( const QString &key, const QString &value ) = 0;
@@ -40,17 +44,20 @@ existing value for the same ``key`` Add Header entry to the response
 
    that it is usually an error to set Header after data have been sent through the wire
 
+.. seealso:: :py:func:`setHeader` for a method that replaces any existing value(s) for the same header key
+
 .. versionadded:: 4.2
 %End
 
     virtual void removeHeader( const QString &key ) = 0;
 %Docstring
-Clear header Undo a previous 'setHeader' call
+Clear all header values for the given ``key`` Undo a previous
+'setHeader' call
 %End
 
     virtual QString header( const QString &key ) const = 0;
 %Docstring
-Returns the header value
+Returns a single header value for a given ``key``
 
 .. note::
 
@@ -59,7 +66,10 @@ Returns the header value
 
     virtual QList<QString> fullHeader( const QString &key ) const = 0;
 %Docstring
-Returns the header values for the given ``key``
+Returns a (possibly empty) list of all the header values for the given
+``key``
+
+.. seealso:: :py:func:`header` to get only the last value for a given header key
 
 .. versionadded:: 4.2
 %End
@@ -68,11 +78,15 @@ Returns the header values for the given ``key``
 %Docstring
 Returns the header values as a map: only the last value is returned if
 multiple values are set for the same header
+
+.. seealso:: :py:func:`fullHeaders` to get all the values for all the headers
 %End
 
     virtual QMap<QString, QList<QString>> fullHeaders() const = 0;
 %Docstring
-Returns the header values
+Returns all the header values
+
+.. seealso:: :py:func:`headers` to get only the last value for each header key
 
 .. versionadded:: 4.2
 %End

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -369,10 +369,11 @@ class TcpServerWorker : public QObject
       }
 
       clientConnection->write( u"Server: QGIS\r\n"_s.toUtf8() );
-      const auto responseHeaders { response.headers() };
+      const auto responseHeaders { response.fullHeaders() };
       for ( auto it = responseHeaders.constBegin(); it != responseHeaders.constEnd(); ++it )
       {
-        clientConnection->write( u"%1: %2\r\n"_s.arg( it.key(), it.value() ).toUtf8() );
+        for ( const QString &headerValue : std::as_const( it.value() ) )
+          clientConnection->write( u"%1: %2\r\n"_s.arg( it.key(), headerValue ).toUtf8() );
       }
       clientConnection->write( "\r\n" );
       const QByteArray body { response.body() };

--- a/src/server/qgsbufferserverresponse.cpp
+++ b/src/server/qgsbufferserverresponse.cpp
@@ -43,7 +43,21 @@ void QgsBufferServerResponse::removeHeader( const QString &key )
 void QgsBufferServerResponse::setHeader( const QString &key, const QString &value )
 {
   if ( !mHeadersSent )
-    mHeaders.insert( key, value );
+  {
+    mHeaders[key] = QList<QString>() << value;
+  }
+}
+
+void QgsBufferServerResponse::addHeader( const QString &key, const QString &value )
+{
+  if ( !mHeadersSent )
+  {
+    if ( !mHeaders.contains( key ) )
+    {
+      mHeaders[key] = QList<QString>();
+    }
+    mHeaders[key].append( value );
+  }
 }
 
 void QgsBufferServerResponse::setStatusCode( int code )
@@ -53,7 +67,18 @@ void QgsBufferServerResponse::setStatusCode( int code )
 
 QString QgsBufferServerResponse::header( const QString &key ) const
 {
-  return mHeaders.value( key );
+  const QList<QString> values = mHeaders.value( key );
+  return values.isEmpty() ? QString() : values.last();
+}
+
+QMap<QString, QString> QgsBufferServerResponse::headers() const
+{
+  QMap<QString, QString> singleHeaders;
+  for ( auto it = mHeaders.keyBegin(); it != mHeaders.keyEnd(); ++it )
+  {
+    singleHeaders.insert( *it, header( *it ) );
+  }
+  return singleHeaders;
 }
 
 bool QgsBufferServerResponse::headersSent() const
@@ -93,7 +118,7 @@ void QgsBufferServerResponse::finish()
   {
     if ( !mHeaders.contains( "Content-Length" ) )
     {
-      mHeaders.insert( u"Content-Length"_s, QString::number( mBuffer.pos() ) );
+      mHeaders.insert( u"Content-Length"_s, QList<QString>() << QString::number( mBuffer.pos() ) );
     }
   }
   flush();
@@ -132,4 +157,10 @@ void QgsBufferServerResponse::truncate()
 {
   mBuffer.seek( 0 );
   mBuffer.buffer().clear();
+}
+
+
+QList<QString> QgsBufferServerResponse::fullHeader( const QString &key ) const
+{
+  return mHeaders.value( key );
 }

--- a/src/server/qgsbufferserverresponse.h
+++ b/src/server/qgsbufferserverresponse.h
@@ -47,6 +47,14 @@ class SERVER_EXPORT QgsBufferServerResponse : public QgsServerResponse
     void setHeader( const QString &key, const QString &value ) override;
 
     /**
+     *  Add a header \a value for the given \a key, without replacing any existing value for the same \a key
+     *  Add Header entry to the response
+     *  \note that it is usually an error to set Header after data have been sent through the wire
+     *  \since QGIS 4.2
+     */
+    void addHeader( const QString &key, const QString &value ) override;
+
+    /**
      * Clear header
      * Undo a previous 'setHeader' call
      */
@@ -60,7 +68,17 @@ class SERVER_EXPORT QgsBufferServerResponse : public QgsServerResponse
     /**
      * Returns all the headers
      */
-    QMap<QString, QString> headers() const override { return mHeaders; }
+    QMap<QString, QList<QString>> fullHeaders() const override { return mHeaders; }
+
+    /**
+     * Returns all the values for a header \a key
+     */
+    virtual QList<QString> fullHeader( const QString &key ) const override;
+
+    /**
+     * Returns all the headers as a map: only the first value is returned if multiple values are set for the same header
+     */
+    QMap<QString, QString> headers() const override;
 
     /**
      * Returns TRUE if the headers have already been sent
@@ -141,7 +159,7 @@ class SERVER_EXPORT QgsBufferServerResponse : public QgsServerResponse
     QgsBufferServerResponse( const QgsBufferServerResponse & ) SIP_FORCE;
 #endif
 
-    QMap<QString, QString> mHeaders;
+    QMap<QString, QList<QString>> mHeaders;
     QBuffer mBuffer;
     QByteArray mBody;
     bool mFinished = false;

--- a/src/server/qgsbufferserverresponse.h
+++ b/src/server/qgsbufferserverresponse.h
@@ -61,9 +61,11 @@ class SERVER_EXPORT QgsBufferServerResponse : public QgsServerResponse
     void removeHeader( const QString &key ) override;
 
     /**
-     * Returns the header value
+     * Returns a single header value, or an empty string if the header is not set.
+     * If multiple values are set for the same header, only the last value is returned.
+     * \deprecated QGIS 4.2. Use fullHeader() instead.
      */
-    QString header( const QString &key ) const override;
+    Q_DECL_DEPRECATED QString header( const QString &key ) const override SIP_DEPRECATED;
 
     /**
      * Returns all the headers
@@ -76,9 +78,10 @@ class SERVER_EXPORT QgsBufferServerResponse : public QgsServerResponse
     virtual QList<QString> fullHeader( const QString &key ) const override;
 
     /**
-     * Returns all the headers as a map: only the first value is returned if multiple values are set for the same header
+     * Returns all the headers as a map: only the last value is returned if multiple values are set for the same header name.
+     * \deprecated QGIS 4.2. Use fullHeaders() instead.
      */
-    QMap<QString, QString> headers() const override;
+    Q_DECL_DEPRECATED QMap<QString, QString> headers() const override SIP_DEPRECATED;
 
     /**
      * Returns TRUE if the headers have already been sent

--- a/src/server/qgsfcgiserverresponse.cpp
+++ b/src/server/qgsfcgiserverresponse.cpp
@@ -239,12 +239,41 @@ void QgsFcgiServerResponse::removeHeader( const QString &key )
   mHeaders.remove( key );
 }
 
+void QgsFcgiServerResponse::addHeader( const QString &key, const QString &value )
+{
+  if ( !mHeadersSent )
+  {
+    if ( !mHeaders.contains( key ) )
+    {
+      mHeaders[key] = QList<QString>();
+    }
+    mHeaders[key].append( value );
+  }
+}
+
+
 void QgsFcgiServerResponse::setHeader( const QString &key, const QString &value )
 {
-  mHeaders.insert( key, value );
+  mHeaders[key] = QList<QString>() << value;
 }
 
 QString QgsFcgiServerResponse::header( const QString &key ) const
+{
+  const QList<QString> values = mHeaders.value( key );
+  return values.isEmpty() ? QString() : values.last();
+}
+
+QMap<QString, QString> QgsFcgiServerResponse::headers() const
+{
+  QMap<QString, QString> singleHeaders;
+  for ( auto it = mHeaders.keyBegin(); it != mHeaders.keyEnd(); ++it )
+  {
+    singleHeaders.insert( *it, header( *it ) );
+  }
+  return singleHeaders;
+}
+
+QList<QString> QgsFcgiServerResponse::fullHeader( const QString &key ) const
 {
   return mHeaders.value( key );
 }
@@ -257,7 +286,8 @@ bool QgsFcgiServerResponse::headersSent() const
 void QgsFcgiServerResponse::setStatusCode( int code )
 {
   // fcgi applications must return HTTP status in header
-  mHeaders.insert( u"Status"_s, u" %1"_s.arg( code ) );
+  removeHeader( u"Status"_s );
+  setHeader( u"Status"_s, u" %1"_s.arg( code ) );
   // Store the code to make it available for plugins
   mStatusCode = code;
 }
@@ -302,7 +332,7 @@ void QgsFcgiServerResponse::finish()
   {
     if ( !mHeaders.contains( "Content-Length" ) )
     {
-      mHeaders.insert( u"Content-Length"_s, QString::number( mBuffer.pos() ) );
+      setHeader( u"Content-Length"_s, QString::number( mBuffer.pos() ) );
     }
   }
   flush();
@@ -314,13 +344,16 @@ void QgsFcgiServerResponse::flush()
   if ( !mHeadersSent )
   {
     // Send all headers
-    QMap<QString, QString>::const_iterator it;
+    QMap<QString, QList<QString>>::const_iterator it;
     for ( it = mHeaders.constBegin(); it != mHeaders.constEnd(); ++it )
     {
-      fputs( it.key().toUtf8(), FCGI_stdout );
-      fputs( ": ", FCGI_stdout );
-      fputs( it.value().toUtf8(), FCGI_stdout );
-      fputs( "\n", FCGI_stdout );
+      for ( const QString &headerValue : std::as_const( it.value() ) )
+      {
+        fputs( it.key().toUtf8(), FCGI_stdout );
+        fputs( ": ", FCGI_stdout );
+        fputs( headerValue.toUtf8(), FCGI_stdout );
+        fputs( "\n", FCGI_stdout );
+      }
     }
     fputs( "\n", FCGI_stdout );
     mHeadersSent = true;
@@ -353,9 +386,6 @@ void QgsFcgiServerResponse::clear()
   mHeaders.clear();
   mBuffer.seek( 0 );
   mBuffer.buffer().clear();
-
-  // Restore default headers
-  setDefaultHeaders();
 }
 
 
@@ -374,5 +404,5 @@ void QgsFcgiServerResponse::truncate()
 
 void QgsFcgiServerResponse::setDefaultHeaders()
 {
-  mHeaders.insert( u"Server"_s, u" QGIS FCGI server - QGIS version %1"_s.arg( Qgis::version() ) );
+  QgsFcgiServerResponse::setHeader( u"Server"_s, u" QGIS FCGI server - QGIS version %1"_s.arg( Qgis::version() ) );
 }

--- a/src/server/qgsfcgiserverresponse.h
+++ b/src/server/qgsfcgiserverresponse.h
@@ -86,7 +86,11 @@ class SERVER_EXPORT QgsFcgiServerResponse : public QgsServerResponse
 
     QString header( const QString &key ) const override;
 
-    QMap<QString, QString> headers() const override { return mHeaders; }
+    QMap<QString, QString> headers() const override;
+
+    QList<QString> fullHeader( const QString &key ) const override;
+
+    QMap<QString, QList<QString>> fullHeaders() const override { return mHeaders; }
 
     bool headersSent() const override;
 
@@ -119,8 +123,10 @@ class SERVER_EXPORT QgsFcgiServerResponse : public QgsServerResponse
      */
     QgsFeedback *feedback() const override { return mFeedback.get(); }
 
+    void addHeader( const QString &key, const QString &value ) override;
+
   private:
-    QMap<QString, QString> mHeaders;
+    QMap<QString, QList<QString>> mHeaders;
     QBuffer mBuffer;
     bool mFinished = false;
     bool mHeadersSent = false;

--- a/src/server/qgsfilterresponsedecorator.h
+++ b/src/server/qgsfilterresponsedecorator.h
@@ -60,9 +60,19 @@ class QgsFilterResponseDecorator : public QgsServerResponse
 
     void removeHeader( const QString &key ) override { mResponse.removeHeader( key ); }
 
-    QString header( const QString &key ) const override { return mResponse.header( key ); }
+    Q_DECL_DEPRECATED QString header( const QString &key ) const override
+    {
+      Q_NOWARN_DEPRECATED_PUSH
+      return mResponse.header( key );
+      Q_NOWARN_DEPRECATED_POP
+    }
 
-    QMap<QString, QString> headers() const override { return mResponse.headers(); }
+    Q_DECL_DEPRECATED QMap<QString, QString> headers() const override
+    {
+      Q_NOWARN_DEPRECATED_PUSH
+      return mResponse.headers();
+      Q_NOWARN_DEPRECATED_POP
+    }
 
     virtual QList<QString> fullHeader( const QString &key ) const override { return mResponse.fullHeader( key ); }
 

--- a/src/server/qgsfilterresponsedecorator.h
+++ b/src/server/qgsfilterresponsedecorator.h
@@ -56,11 +56,17 @@ class QgsFilterResponseDecorator : public QgsServerResponse
 
     void setHeader( const QString &key, const QString &value ) override { mResponse.setHeader( key, value ); }
 
+    void addHeader( const QString &key, const QString &value ) override { mResponse.addHeader( key, value ); }
+
     void removeHeader( const QString &key ) override { mResponse.removeHeader( key ); }
 
     QString header( const QString &key ) const override { return mResponse.header( key ); }
 
     QMap<QString, QString> headers() const override { return mResponse.headers(); }
+
+    virtual QList<QString> fullHeader( const QString &key ) const override { return mResponse.fullHeader( key ); }
+
+    virtual QMap<QString, QList<QString> > fullHeaders() const override { return mResponse.fullHeaders(); }
 
     bool headersSent() const override { return mResponse.headersSent(); }
 

--- a/src/server/qgsrequesthandler.cpp
+++ b/src/server/qgsrequesthandler.cpp
@@ -64,12 +64,16 @@ void QgsRequestHandler::removeResponseHeader( const QString &name )
 
 QString QgsRequestHandler::responseHeader( const QString &name ) const
 {
+  Q_NOWARN_DEPRECATED_PUSH
   return mResponse.header( name );
+  Q_NOWARN_DEPRECATED_POP
 }
 
 QMap<QString, QString> QgsRequestHandler::responseHeaders() const
 {
+  Q_NOWARN_DEPRECATED_PUSH
   return mResponse.headers();
+  Q_NOWARN_DEPRECATED_POP
 }
 
 QList<QString> QgsRequestHandler::fullResponseHeader( const QString &name ) const

--- a/src/server/qgsrequesthandler.cpp
+++ b/src/server/qgsrequesthandler.cpp
@@ -72,6 +72,16 @@ QMap<QString, QString> QgsRequestHandler::responseHeaders() const
   return mResponse.headers();
 }
 
+QList<QString> QgsRequestHandler::fullResponseHeader( const QString &name ) const
+{
+  return mResponse.fullHeader( name );
+}
+
+QMap<QString, QList<QString> > QgsRequestHandler::fullResponseHeaders() const
+{
+  return mResponse.fullHeaders();
+}
+
 void QgsRequestHandler::setRequestHeader( const QString &name, const QString &value )
 {
   mRequest.setHeader( name, value );

--- a/src/server/qgsrequesthandler.h
+++ b/src/server/qgsrequesthandler.h
@@ -65,8 +65,11 @@ class SERVER_EXPORT QgsRequestHandler
     //! Retrieve response header value
     QString responseHeader( const QString &name ) const;
 
-    //! Returns the response headers: note that if multiple values are set for the same header, only the first one is returned
-    QMap<QString, QString> responseHeaders() const;
+    /**
+     *  Returns the response headers: note that if multiple values are set for the same header, only the last one is returned
+     *  \deprecated QGIS 4.2. Use fullResponseHeaders() instead.
+     */
+    Q_DECL_DEPRECATED QMap<QString, QString> responseHeaders() const SIP_DEPRECATED;
 
     /**
      * Returns the list of response headers for a given header \a name
@@ -86,7 +89,7 @@ class SERVER_EXPORT QgsRequestHandler
     //! Remove an HTTP request header
     void removeRequestHeader( const QString &name );
 
-    //! Retrieve request header value: note that if multiple values are set for the same header, only the first one is returned
+    //! Retrieve request header value
     QString requestHeader( const QString &name ) const;
 
     //! Returns the Request headers

--- a/src/server/qgsrequesthandler.h
+++ b/src/server/qgsrequesthandler.h
@@ -65,8 +65,20 @@ class SERVER_EXPORT QgsRequestHandler
     //! Retrieve response header value
     QString responseHeader( const QString &name ) const;
 
-    //! Returns the response headers
+    //! Returns the response headers: note that if multiple values are set for the same header, only the first one is returned
     QMap<QString, QString> responseHeaders() const;
+
+    /**
+     * Returns the list of response headers for a given header \a name
+     * \since QGIS 4.2
+     */
+    QList<QString> fullResponseHeader( const QString &name ) const;
+
+    /**
+     * Returns the response headers as a map of header name to list of values (to support multiple values for the same header)
+     * \since QGIS 4.2
+     */
+    QMap<QString, QList<QString>> fullResponseHeaders() const;
 
     //! Sets an HTTP request header
     void setRequestHeader( const QString &name, const QString &value );
@@ -74,7 +86,7 @@ class SERVER_EXPORT QgsRequestHandler
     //! Remove an HTTP request header
     void removeRequestHeader( const QString &name );
 
-    //! Retrieve request header value
+    //! Retrieve request header value: note that if multiple values are set for the same header, only the first one is returned
     QString requestHeader( const QString &name ) const;
 
     //! Returns the Request headers

--- a/src/server/qgsserverogcapi.cpp
+++ b/src/server/qgsserverogcapi.cpp
@@ -193,7 +193,7 @@ QString QgsServerOgcApi::contentTypeToExtension( const ContentType &ct )
   const QString extension { contentTypeToString( ct ).toLower() };
   // Special case for flatgeobuf, which is a bit too long for
   // an extension and has a widely used alternative (fgb)
-  if ( extension.compare( u"flatgeobuf"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+  if ( extension.compare( u"flatgeobuf" s_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
   {
     return u"fgb"_s;
   }

--- a/src/server/qgsserverogcapi.cpp
+++ b/src/server/qgsserverogcapi.cpp
@@ -131,10 +131,14 @@ QString QgsServerOgcApi::profileToString( const Profile &profile )
   {
     case Profile::RFC7946:
       return u"json"_s;
+#if 0
+    // This not supported yet but I am leaving it here because
+    // I am very optimistic that it will be supported soon!
     case Profile::JSONFG:
       return u"jsonfg"_s;
     case Profile::JSONFG_PLUS:
       return u"jsonfg-plus"_s;
+#endif
     case Profile::NONE:
       return QString();
   }
@@ -148,10 +152,14 @@ QString QgsServerOgcApi::profileToUri( const Profile &profile )
   {
     case Profile::RFC7946:
       return u"http://www.opengis.net/def/profile/OGC/0/rfc7946"_s;
+#if 0
+    // This not supported yet but I am leaving it here because
+    // I am very optimistic that it will be supported soon!
     case Profile::JSONFG:
       return u"http://www.opengis.net/def/profile/OGC/0/jsonfg"_s;
     case Profile::JSONFG_PLUS:
       return u"http://www.opengis.net/def/profile/OGC/0/jsonfg-plus"_s;
+#endif
     case Profile::NONE:
       return QString();
   }
@@ -182,7 +190,14 @@ std::string QgsServerOgcApi::contentTypeToStdString( const ContentType &ct )
 
 QString QgsServerOgcApi::contentTypeToExtension( const ContentType &ct )
 {
-  return contentTypeToString( ct ).toLower();
+  const QString extension { contentTypeToString( ct ).toLower() };
+  // Special case for flatgeobuf, which is a bit too long for
+  // an extension and has a widely used alternative (fgb)
+  if ( extension.compare( u"flatgeobuf"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+  {
+    return u"fgb"_s;
+  }
+  return extension;
 }
 
 QgsServerOgcApi::ContentType QgsServerOgcApi::contentTypeFromExtension( const std::string &extension )

--- a/src/server/qgsserverogcapi.cpp
+++ b/src/server/qgsserverogcapi.cpp
@@ -193,7 +193,7 @@ QString QgsServerOgcApi::contentTypeToExtension( const ContentType &ct )
   const QString extension { contentTypeToString( ct ).toLower() };
   // Special case for flatgeobuf, which is a bit too long for
   // an extension and has a widely used alternative (fgb)
-  if ( extension.compare( u"flatgeobuf" s_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+  if ( extension.compare( u"flatgeobuf"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
   {
     return u"fgb"_s;
   }

--- a/src/server/qgsserverogcapi.cpp
+++ b/src/server/qgsserverogcapi.cpp
@@ -138,6 +138,8 @@ QString QgsServerOgcApi::profileToString( const Profile &profile )
     case Profile::NONE:
       return QString();
   }
+  Q_UNREACHABLE();
+  return QString();
 }
 
 QString QgsServerOgcApi::profileToUri( const Profile &profile )
@@ -153,6 +155,8 @@ QString QgsServerOgcApi::profileToUri( const Profile &profile )
     case Profile::NONE:
       return QString();
   }
+  Q_UNREACHABLE();
+  return QString();
 }
 
 std::string QgsServerOgcApi::relToString( const Rel &rel )

--- a/src/server/qgsserverogcapi.cpp
+++ b/src/server/qgsserverogcapi.cpp
@@ -36,6 +36,7 @@ QMap<QgsServerOgcApi::ContentType, QStringList> QgsServerOgcApi::sContentTypeMim
   map[QgsServerOgcApi::ContentType::HTML] = QStringList { u"text/html"_s };
   map[QgsServerOgcApi::ContentType::OPENAPI3] = QStringList { u"application/vnd.oai.openapi+json;version=3.0"_s };
   map[QgsServerOgcApi::ContentType::XML] = QStringList { u"application/xml"_s };
+  map[QgsServerOgcApi::ContentType::FLATGEOBUF] = QStringList { u"application/flatgeobuf"_s, u"application/vnd.fgb"_s };
   return map;
 }();
 
@@ -122,6 +123,36 @@ const QMap<QgsServerOgcApi::ContentType, QStringList> QgsServerOgcApi::contentTy
 const QHash<QgsServerOgcApi::ContentType, QList<QgsServerOgcApi::ContentType>> QgsServerOgcApi::contentTypeAliases()
 {
   return sContentTypeAliases;
+}
+
+QString QgsServerOgcApi::profileToString( const Profile &profile )
+{
+  switch ( profile )
+  {
+    case Profile::RFC7946:
+      return u"json"_s;
+    case Profile::JSONFG:
+      return u"jsonfg"_s;
+    case Profile::JSONFG_PLUS:
+      return u"jsonfg-plus"_s;
+    case Profile::NONE:
+      return QString();
+  }
+}
+
+QString QgsServerOgcApi::profileToUri( const Profile &profile )
+{
+  switch ( profile )
+  {
+    case Profile::RFC7946:
+      return u"http://www.opengis.net/def/profile/OGC/0/rfc7946"_s;
+    case Profile::JSONFG:
+      return u"http://www.opengis.net/def/profile/OGC/0/jsonfg"_s;
+    case Profile::JSONFG_PLUS:
+      return u"http://www.opengis.net/def/profile/OGC/0/jsonfg-plus"_s;
+    case Profile::NONE:
+      return QString();
+  }
 }
 
 std::string QgsServerOgcApi::relToString( const Rel &rel )

--- a/src/server/qgsserverogcapi.h
+++ b/src/server/qgsserverogcapi.h
@@ -79,9 +79,20 @@ class SERVER_EXPORT QgsServerOgcApi : public QgsServerApi
       OPENAPI3, //!< "application/openapi+json;version=3.0"
       JSON,
       HTML,
-      XML
+      XML,
+      FLATGEOBUF //!< "application/flatgeobuf"
     };
     Q_ENUM( ContentType )
+
+    //! JSON profile
+    enum class Profile
+    {
+      NONE,       //!< No profile
+      RFC7946,    //!< GeoJSON profile according to RFC7946
+      JSONFG,     //!< JSON Feature Geometry profile according to OGC API - Features 1.0
+      JSONFG_PLUS //!< JSON Feature Geometry profile with GeoJSON compatibility extensions
+    };
+    Q_ENUM( Profile )
 
     /**
      * QgsServerOgcApi constructor
@@ -117,6 +128,18 @@ class SERVER_EXPORT QgsServerOgcApi : public QgsServerApi
      * \note not available in Python bindings
      */
     static const QHash<QgsServerOgcApi::ContentType, QList<QgsServerOgcApi::ContentType>> contentTypeAliases() SIP_SKIP;
+
+    /**
+     * Returns a string representation of the \a profile.
+     * \note not available in Python bindings
+     */
+    static QString profileToString( const QgsServerOgcApi::Profile &profile ) SIP_SKIP;
+
+    /**
+     * Returns a URI string representation of the \a profile.
+     * \note not available in Python bindings
+     */
+    static QString profileToUri( const QgsServerOgcApi::Profile &profile ) SIP_SKIP;
 
     // Utilities
 #ifndef SIP_RUN

--- a/src/server/qgsserverogcapi.h
+++ b/src/server/qgsserverogcapi.h
@@ -87,10 +87,12 @@ class SERVER_EXPORT QgsServerOgcApi : public QgsServerApi
     //! JSON profile
     enum class Profile
     {
-      NONE,       //!< No profile
-      RFC7946,    //!< GeoJSON profile according to RFC7946
-      JSONFG,     //!< JSON Feature Geometry profile according to OGC API - Features 1.0
-      JSONFG_PLUS //!< JSON Feature Geometry profile with GeoJSON compatibility extensions
+      NONE,    //!< No profile
+      RFC7946, //!< GeoJSON profile according to RFC7946
+      // This not supported yet but I am leaving it here because
+      // I am very optimistic that it will be supported soon!
+      //  JSONFG,     //!< JSON Feature Geometry profile according to OGC API - Features 1.0
+      //  JSONFG_PLUS //!< JSON Feature Geometry profile with GeoJSON compatibility extensions
     };
     Q_ENUM( Profile )
 

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -126,6 +126,9 @@ void QgsServerOgcApiHandler::write( json &data, const QgsServerApiContext &conte
     case QgsServerOgcApi::ContentType::XML:
       // Not handled yet
       break;
+    case QgsServerOgcApi::ContentType::FLATGEOBUF:
+      // Handled separately in the handler if supported, so do nothing here
+      break;
   }
 }
 
@@ -210,6 +213,33 @@ json QgsServerOgcApiHandler::link( const QgsServerApiContext &context, const Qgs
     { "title", title != "" ? title : linkTitle() },
   };
   return l;
+}
+
+QString QgsServerOgcApiHandler::headerLink(
+  const QgsServerApiContext &context, const QgsServerOgcApi::Rel &linkType, const QgsServerOgcApi::ContentType contentType, const QgsServerOgcApi::Profile &profile, const QString &title
+) const
+{
+  const QString profileStr { profile != QgsServerOgcApi::Profile::NONE ? QgsServerOgcApi::profileToString( profile ) : QString() };
+  QString hrefStr = QString::fromStdString( href( context, "/", QgsServerOgcApi::contentTypeToExtension( contentType ) ) );
+
+  if ( !profileStr.isEmpty() )
+  {
+    hrefStr += "&profile=" + profileStr;
+  }
+
+  QString linkStr = u"<%1>; rel=\"%2\"; title=\"%3\"; type=\"%4\""_s.arg(
+    QString::fromStdString( href( context, "/", QgsServerOgcApi::contentTypeToExtension( contentType ) ) ),
+    QString::fromStdString( QgsServerOgcApi::relToString( linkType ) ),
+    !title.isEmpty() ? title : QString::fromStdString( linkTitle() ),
+    QString::fromStdString( QgsServerOgcApi::mimeType( contentType ) )
+  );
+
+  if ( !profileStr.isEmpty() )
+  {
+    linkStr += QString( "; profile=\"%1\"" ).arg( profileStr );
+  }
+
+  return linkStr;
 }
 
 json QgsServerOgcApiHandler::links( const QgsServerApiContext &context ) const
@@ -461,7 +491,21 @@ QgsServerOgcApi::ContentType QgsServerOgcApiHandler::contentTypeFromRequest( con
     }
     else
     {
-      QgsMessageLog::logMessage( u"The client requested an unsupported extension: %1"_s.arg( extension ), u"Server"_s, Qgis::MessageLevel::Warning );
+      // Hardcoded aliases
+      if ( ( extension.compare( u"JSONFG"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 ) || ( extension.compare( u"JSONFG-PLUS"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 ) )
+      {
+        result = QgsServerOgcApi::ContentType::JSON;
+        found = true;
+      }
+      else if ( extension.compare( u"FGB"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+      {
+        result = QgsServerOgcApi::ContentType::FLATGEOBUF;
+        found = true;
+      }
+      else
+      {
+        QgsMessageLog::logMessage( u"The client requested an unsupported extension: %1"_s.arg( extension ), u"Server"_s, Qgis::MessageLevel::Warning );
+      }
     }
   }
   // ... then "Accept"

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -492,12 +492,18 @@ QgsServerOgcApi::ContentType QgsServerOgcApiHandler::contentTypeFromRequest( con
     else
     {
       // Hardcoded aliases
+#if 0
+    // This not supported yet but I am leaving it here because
+    // I am very optimistic that it will be supported soon!
+
       if ( ( extension.compare( u"JSONFG"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 ) || ( extension.compare( u"JSONFG-PLUS"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 ) )
       {
         result = QgsServerOgcApi::ContentType::JSON;
         found = true;
       }
-      else if ( extension.compare( u"FGB"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
+      else
+#endif
+      if ( extension.compare( u"FGB"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 )
       {
         result = QgsServerOgcApi::ContentType::FLATGEOBUF;
         found = true;

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -224,13 +224,17 @@ QString QgsServerOgcApiHandler::headerLink(
 
   if ( !profileStr.isEmpty() )
   {
-    hrefStr += "&profile=" + profileStr;
+    hrefStr += u"&profile="_s + profileStr;
   }
+
+  QString titleStr = !title.isEmpty() ? title : QString::fromStdString( linkTitle() );
+  titleStr.replace( '\\', "\\\\"_L1 );
+  titleStr.replace( '"', "\\\""_L1 );
 
   QString linkStr = u"<%1>; rel=\"%2\"; title=\"%3\"; type=\"%4\""_s.arg(
     QString::fromStdString( href( context, "/", QgsServerOgcApi::contentTypeToExtension( contentType ) ) ),
     QString::fromStdString( QgsServerOgcApi::relToString( linkType ) ),
-    !title.isEmpty() ? title : QString::fromStdString( linkTitle() ),
+    titleStr,
     QString::fromStdString( QgsServerOgcApi::mimeType( contentType ) )
   );
 

--- a/src/server/qgsserverogcapihandler.h
+++ b/src/server/qgsserverogcapihandler.h
@@ -272,24 +272,6 @@ class SERVER_EXPORT QgsServerOgcApiHandler
       const std::string &title = ""
     ) const;
 
-
-    /**
-     * Builds and returns a header link to the resource.
-     *
-     * \param context request context
-     * \param linkType type of the link (rel attribute), default to SELF
-     * \param contentType content type of the link (default to JSON)
-     * \param title title of the link
-     * \note not available in Python bindings
-     */
-    QString headerLink(
-      const QgsServerApiContext &context,
-      const QgsServerOgcApi::Rel &linkType = QgsServerOgcApi::Rel::self,
-      const QgsServerOgcApi::ContentType contentType = QgsServerOgcApi::ContentType::JSON,
-      const QgsServerOgcApi::Profile &profile = QgsServerOgcApi::Profile::NONE,
-      const QString &title = ""
-    ) const;
-
     /**
      * Returns all the links for the given request \a context.
      *
@@ -313,6 +295,23 @@ class SERVER_EXPORT QgsServerOgcApiHandler
     QgsVectorLayer *layerFromContext( const QgsServerApiContext &context ) const;
 
 #endif // SIP skipped
+
+    /**
+     * Builds and returns a header link to the resource.
+     *
+     * \param context request context
+     * \param linkType type of the link (rel attribute), default to SELF
+     * \param contentType content type of the link (default to JSON)
+     * \param title title of the link
+     * \note not available in Python bindings
+     */
+    QString headerLink(
+      const QgsServerApiContext &context,
+      const QgsServerOgcApi::Rel &linkType = QgsServerOgcApi::Rel::self,
+      const QgsServerOgcApi::ContentType contentType = QgsServerOgcApi::ContentType::JSON,
+      const QgsServerOgcApi::Profile &profile = QgsServerOgcApi::Profile::NONE,
+      const QString &title = ""
+    ) const;
 
     /**
      * Writes \a data to the \a context response stream, content-type is calculated from the \a context request,

--- a/src/server/qgsserverogcapihandler.h
+++ b/src/server/qgsserverogcapihandler.h
@@ -272,6 +272,24 @@ class SERVER_EXPORT QgsServerOgcApiHandler
       const std::string &title = ""
     ) const;
 
+
+    /**
+     * Builds and returns a header link to the resource.
+     *
+     * \param context request context
+     * \param linkType type of the link (rel attribute), default to SELF
+     * \param contentType content type of the link (default to JSON)
+     * \param title title of the link
+     * \note not available in Python bindings
+     */
+    QString headerLink(
+      const QgsServerApiContext &context,
+      const QgsServerOgcApi::Rel &linkType = QgsServerOgcApi::Rel::self,
+      const QgsServerOgcApi::ContentType contentType = QgsServerOgcApi::ContentType::JSON,
+      const QgsServerOgcApi::Profile &profile = QgsServerOgcApi::Profile::NONE,
+      const QString &title = ""
+    ) const;
+
     /**
      * Returns all the links for the given request \a context.
      *

--- a/src/server/qgsserverquerystringparameter.cpp
+++ b/src/server/qgsserverquerystringparameter.cpp
@@ -40,19 +40,29 @@ QgsServerQueryStringParameter::~QgsServerQueryStringParameter()
 
 QVariant QgsServerQueryStringParameter::value( const QgsServerApiContext &context ) const
 {
+  // Case insensitive check
+  const QUrlQuery urlQuery( context.request()->url() );
+  const QList<std::pair<QString, QString>> items = urlQuery.queryItems();
+  QString nameInQueryString;
+  QVariant value;
+  for ( const auto &pair : std::as_const( items ) )
+  {
+    if ( pair.first.compare( mName, Qt::CaseInsensitive ) == 0 )
+    {
+      nameInQueryString = pair.first;
+      value = pair.second;
+      break;
+    }
+  }
+
   // 1: check required
-  if ( mRequired && !QUrlQuery( context.request()->url() ).hasQueryItem( mName ) )
+  if ( mRequired && nameInQueryString.isEmpty() )
   {
     throw QgsServerApiBadRequestException( u"Missing required argument: '%1'"_s.arg( mName ) );
   }
 
   // 2: get value from query string or set it to the default
-  QVariant value;
-  if ( QUrlQuery( context.request()->url() ).hasQueryItem( mName ) )
-  {
-    value = QUrlQuery( context.request()->url() ).queryItemValue( mName, QUrl::FullyDecoded );
-  }
-  else if ( mDefaultValue.isValid() )
+  if ( nameInQueryString.isEmpty() && mDefaultValue.isValid() )
   {
     value = mDefaultValue;
   }

--- a/src/server/qgsserverquerystringparameter.cpp
+++ b/src/server/qgsserverquerystringparameter.cpp
@@ -42,7 +42,7 @@ QVariant QgsServerQueryStringParameter::value( const QgsServerApiContext &contex
 {
   // Case insensitive check
   const QUrlQuery urlQuery( context.request()->url() );
-  const QList<std::pair<QString, QString>> items = urlQuery.queryItems();
+  const QList<std::pair<QString, QString>> items = urlQuery.queryItems( QUrl::FullyDecoded );
   QString nameInQueryString;
   QVariant value;
   for ( const auto &pair : std::as_const( items ) )

--- a/src/server/qgsserverresponse.h
+++ b/src/server/qgsserverresponse.h
@@ -70,8 +70,9 @@ class SERVER_EXPORT QgsServerResponse
     /**
      * Returns a single header value for a given \a key
      * \note if multiple values are set for the same key, the last one is returned
+     * \deprecated QGIS 4.2. Use fullHeader() instead.
      */
-    virtual QString header( const QString &key ) const = 0;
+    Q_DECL_DEPRECATED virtual QString header( const QString &key ) const = 0 SIP_DEPRECATED;
 
     /**
      * Returns a (possibly empty) list of all the header values for the given \a key
@@ -83,8 +84,9 @@ class SERVER_EXPORT QgsServerResponse
     /**
      * Returns the header values as a map: only the last value is returned if multiple values are set for the same header
      * \see fullHeaders() to get all the values for all the headers
+     * \deprecated QGIS 4.2. Use fullHeaders() instead.
      */
-    virtual QMap<QString, QString> headers() const = 0;
+    Q_DECL_DEPRECATED virtual QMap<QString, QString> headers() const = 0 SIP_DEPRECATED;
 
     /**
      * Returns all the header values

--- a/src/server/qgsserverresponse.h
+++ b/src/server/qgsserverresponse.h
@@ -45,9 +45,10 @@ class SERVER_EXPORT QgsServerResponse
     virtual ~QgsServerResponse() = default;
 
     /**
-     *  Set a single header \a value replacing any existing value for the same \a key
-     *  Add Header entry to the response
+     *  Set a single header \a value replacing any existing value(s) for the same \a key
      *  \note that it is usually an error to set Header after data have been sent through the wire
+     *  \see addHeader() for a method that allows setting multiple values for the same header key
+     *  \see removeHeader() to clear header values for a given key
      */
     virtual void setHeader( const QString &key, const QString &value ) = 0;
 
@@ -55,35 +56,39 @@ class SERVER_EXPORT QgsServerResponse
      *  Add a header \a value for the given \a key, without replacing any existing value for the same \a key
      *  Add Header entry to the response
      *  \note that it is usually an error to set Header after data have been sent through the wire
+     *  \see setHeader() for a method that replaces any existing value(s) for the same header key
      *  \since QGIS 4.2
      */
     virtual void addHeader( const QString &key, const QString &value ) = 0;
 
     /**
-     * Clear header
+     * Clear all header values for the given \a key
      * Undo a previous 'setHeader' call
      */
     virtual void removeHeader( const QString &key ) = 0;
 
     /**
-     * Returns the header value
+     * Returns a single header value for a given \a key
      * \note if multiple values are set for the same key, the last one is returned
      */
     virtual QString header( const QString &key ) const = 0;
 
     /**
-     * Returns the header values for the given \a key
+     * Returns a (possibly empty) list of all the header values for the given \a key
+     * \see header() to get only the last value for a given header key
      * \since QGIS 4.2
      */
     virtual QList<QString> fullHeader( const QString &key ) const = 0;
 
     /**
      * Returns the header values as a map: only the last value is returned if multiple values are set for the same header
+     * \see fullHeaders() to get all the values for all the headers
      */
     virtual QMap<QString, QString> headers() const = 0;
 
     /**
-     * Returns the header values
+     * Returns all the header values
+     * \see headers() to get only the last value for each header key
      * \since QGIS 4.2
      */
     virtual QMap<QString, QList<QString>> fullHeaders() const = 0;

--- a/src/server/qgsserverresponse.h
+++ b/src/server/qgsserverresponse.h
@@ -45,11 +45,19 @@ class SERVER_EXPORT QgsServerResponse
     virtual ~QgsServerResponse() = default;
 
     /**
-     *  Set Header entry
+     *  Set a single header \a value replacing any existing value for the same \a key
      *  Add Header entry to the response
-     *  Note that it is usually an error to set Header after data have been sent through the wire
+     *  \note that it is usually an error to set Header after data have been sent through the wire
      */
     virtual void setHeader( const QString &key, const QString &value ) = 0;
+
+    /**
+     *  Add a header \a value for the given \a key, without replacing any existing value for the same \a key
+     *  Add Header entry to the response
+     *  \note that it is usually an error to set Header after data have been sent through the wire
+     *  \since QGIS 4.2
+     */
+    virtual void addHeader( const QString &key, const QString &value ) = 0;
 
     /**
      * Clear header
@@ -59,19 +67,31 @@ class SERVER_EXPORT QgsServerResponse
 
     /**
      * Returns the header value
+     * \note if multiple values are set for the same key, the last one is returned
      */
     virtual QString header( const QString &key ) const = 0;
 
     /**
-     * Returns the header value
+     * Returns the header values for the given \a key
+     * \since QGIS 4.2
+     */
+    virtual QList<QString> fullHeader( const QString &key ) const = 0;
+
+    /**
+     * Returns the header values as a map: only the last value is returned if multiple values are set for the same header
      */
     virtual QMap<QString, QString> headers() const = 0;
+
+    /**
+     * Returns the header values
+     * \since QGIS 4.2
+     */
+    virtual QMap<QString, QList<QString>> fullHeaders() const = 0;
 
     /**
      * Returns TRUE if the headers have already been sent
      */
     virtual bool headersSent() const = 0;
-
 
     /**
      * Set the http status code

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -292,6 +292,26 @@ bool QgsWfs3AbstractItemsHandler::canUpdateFeatures( const QgsVectorLayer *mapLa
   return false;
 }
 
+QUrlQuery QgsWfs3AbstractItemsHandler::removeOffsetAndLimit( const QUrlQuery &urlQuery )
+{
+  // Since headers are stored in a case sensitive map,
+  // make sure we are clearing the correct case if any
+  QUrlQuery query( urlQuery );
+  const QList<std::pair<QString, QString>> items = query.queryItems();
+  for ( const auto &pair : std::as_const( items ) )
+  {
+    if ( pair.first.compare( "offset"_L1, Qt::CaseInsensitive ) == 0 )
+    {
+      query.removeAllQueryItems( pair.first );
+    }
+    else if ( pair.first.compare( "limit"_L1, Qt::CaseInsensitive ) == 0 )
+    {
+      query.removeAllQueryItems( pair.first );
+    }
+  }
+  return query;
+}
+
 QgsWfs3LandingPageHandler::QgsWfs3LandingPageHandler()
 {}
 
@@ -992,10 +1012,7 @@ void QgsWfs3CollectionsItemsHandler::writeJsonOutput( const QgsVectorLayer *mapL
 
   // Url without offset and limit
   QUrl cleanedUrl { url };
-  QUrlQuery query( cleanedUrl );
-  query.removeQueryItem( u"limit"_s );
-  query.removeQueryItem( u"offset"_s );
-  cleanedUrl.setQuery( query );
+  cleanedUrl.setQuery( removeOffsetAndLimit( QUrlQuery( url.query() ) ) );
 
   QString cleanedUrlAsString { cleanedUrl.toString() };
 
@@ -1297,11 +1314,7 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
 
     // Url without offset and limit
     QUrl cleanedUrl { url };
-    QUrlQuery query( cleanedUrl );
-    query.removeQueryItem( u"limit"_s );
-    query.removeQueryItem( u"offset"_s );
-    cleanedUrl.setQuery( query );
-
+    cleanedUrl.setQuery( removeOffsetAndLimit( QUrlQuery( url.query() ) ) );
     QString cleanedUrlAsString { cleanedUrl.toString() };
 
     if ( !cleanedUrl.hasQuery() )

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -33,6 +33,7 @@
 #include "qgsserverprojectutils.h"
 #include "qgsserverrequest.h"
 #include "qgsserverresponse.h"
+#include "qgsvectorfilewriter.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerutils.h"
 
@@ -460,7 +461,12 @@ void QgsWfs3CollectionsHandler::handleRequest( const QgsServerApiContext &contex
               { { "href", href( context, u"/%1/items"_s.arg( shortName ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::HTML ) ) },
                 { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::items ) },
                 { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::HTML ) },
-                { "title", title + " as HTML" } } /* TODO: not sure what these "concepts" are about, neither if they are mandatory
+                { "title", title + " as HTML" } },
+              { { "href", href( context, u"/%1/items"_s.arg( shortName ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::FLATGEOBUF ) ) },
+                { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::items ) },
+                { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::FLATGEOBUF ) },
+                { "title", title + " as FlatGeobuf" } }
+              /* TODO: not sure what these "concepts" are about, neither if they are mandatory
             {
               { "href", href( api, context.request(), u"/%1/concepts"_s.arg( shortName ) )  },
               { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::item ) },
@@ -539,19 +545,18 @@ void QgsWfs3DescribeCollectionHandler::handleRequest( const QgsServerApiContext 
   const QString shortName { mapLayer->serverProperties()->shortName().isEmpty() ? mapLayer->name() : mapLayer->serverProperties()->shortName() };
   const QString typeName { mapLayer->serverProperties()->wfsTypeName() };
   json linksList = links( context );
-  linksList.push_back(
-    { { "href", href( context, u"/items"_s, QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::GEOJSON ) ) },
-      { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::items ) },
-      { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::GEOJSON ) },
-      { "title", itemsTitle + " as " + QgsServerOgcApi::contentTypeToStdString( QgsServerOgcApi::ContentType::GEOJSON ) } }
-  );
 
-  linksList.push_back(
-    { { "href", href( context, u"/items"_s, QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::HTML ) ) },
-      { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::items ) },
-      { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::HTML ) },
-      { "title", itemsTitle + " as " + QgsServerOgcApi::contentTypeToStdString( QgsServerOgcApi::ContentType::HTML ) } }
-  );
+  for ( const auto ct : { QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::ContentType::HTML, QgsServerOgcApi::ContentType::FLATGEOBUF } )
+  {
+    linksList.push_back(
+      { { "href", href( context, u"/items"_s, QgsServerOgcApi::contentTypeToExtension( ct ) ) },
+        { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::items ) },
+        { "type", QgsServerOgcApi::mimeType( ct ) },
+        { "title", itemsTitle + " as " + QgsServerOgcApi::contentTypeToStdString( ct ) } }
+    );
+  }
+
+  // TODO: add JSONFG and JSONFG-PLUS
 
   linksList.push_back(
     { { "href",
@@ -626,7 +631,7 @@ json QgsWfs3DescribeCollectionHandler::schema( const QgsServerApiContext &contex
 
 QgsWfs3CollectionsItemsHandler::QgsWfs3CollectionsItemsHandler()
 {
-  setContentTypes( { QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::ContentType::HTML } );
+  setContentTypes( { QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::ContentType::HTML, QgsServerOgcApi::ContentType::FLATGEOBUF } );
 }
 
 QList<QgsServerQueryStringParameter> QgsWfs3CollectionsItemsHandler::parameters( const QgsServerApiContext &context ) const
@@ -919,24 +924,417 @@ const QList<QgsServerQueryStringParameter> QgsWfs3CollectionsItemsHandler::field
   return params;
 }
 
-void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &context ) const
+void QgsWfs3CollectionsItemsHandler::writeJsonOutput( const QgsVectorLayer *mapLayer, QgsFeatureRequest &featureRequest, const QgsServerApiContext &apiContext, const ExportContext &exportContext ) const
 {
-  if ( !context.project() )
+  const std::string title { mapLayer->serverProperties()->wfsTitle().isEmpty() ? mapLayer->name().toStdString() : mapLayer->serverProperties()->wfsTitle().toStdString() };
+
+  // Exporter for JSON output
+  QgsJsonExporter exporter { const_cast<QgsVectorLayer *>( mapLayer ) };
+  exporter.setAttributes( featureRequest.subsetOfAttributes() );
+  exporter.setAttributeDisplayName( true );
+  exporter.setSourceCrs( mapLayer->crs() );
+  exporter.setTransformGeometries( false );
+  QgsFeatureList featureList;
+  QgsFeatureIterator features { mapLayer->getFeatures( featureRequest ) };
+  QgsFeature feat;
+  long i { 0 };
+  QMap<QgsFeatureId, QString> fidMap;
+
+  while ( features.nextFeature( feat ) )
+  {
+    // Ignore records before offset
+    if ( i >= exportContext.offset )
+    {
+      fidMap.insert( feat.id(), QgsServerFeatureId::getServerFid( feat, mapLayer->dataProvider()->pkAttributeIndexes() ) );
+      featureList << feat;
+    }
+    i++;
+  }
+
+  // Count features
+  long matchedFeaturesCount = 0;
+  if ( exportContext.attrFilters.isEmpty() && exportContext.filterRect.isNull() )
+  {
+    matchedFeaturesCount = mapLayer->featureCount();
+  }
+  else
+  {
+    if ( exportContext.filterExpression.isEmpty() )
+    {
+      featureRequest.setNoAttributes();
+    }
+
+    featureRequest.setFlags( Qgis::FeatureRequestFlag::NoGeometry );
+    featureRequest.setLimit( -1 );
+    features = mapLayer->getFeatures( featureRequest );
+
+    while ( features.nextFeature( feat ) )
+    {
+      matchedFeaturesCount++;
+    }
+  }
+
+  json data = exporter.exportFeaturesToJsonObject( featureList );
+
+  // Patch feature IDs with server feature IDs
+  for ( int i = 0; i < featureList.length(); i++ )
+  {
+    data["features"][i]["id"] = fidMap.value( data["features"][i]["id"] ).toStdString();
+  }
+
+  // Add some metadata
+  data["numberMatched"] = matchedFeaturesCount;
+  data["numberReturned"] = featureList.count();
+  data["links"] = links( apiContext );
+
+  // Current url
+  const QUrl url { apiContext.request()->url() };
+
+  // Url without offset and limit
+  QUrl cleanedUrl { url };
+  QUrlQuery query( cleanedUrl );
+  query.removeQueryItem( u"limit"_s );
+  query.removeQueryItem( u"offset"_s );
+  cleanedUrl.setQuery( query );
+
+  QString cleanedUrlAsString { cleanedUrl.toString() };
+
+  if ( !cleanedUrl.hasQuery() )
+  {
+    cleanedUrlAsString += '?';
+  }
+  else
+  {
+    cleanedUrlAsString += '&';
+  }
+
+  // Pagesize metadata
+  json pagesize = json::array();
+  const qlonglong maxLimit { apiContext.serverInterface()->serverSettings()->apiWfs3MaxLimit() };
+  if ( matchedFeaturesCount > 1 && maxLimit > 1 )
+  {
+    const std::string pageSizeOneLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=1"_s.toStdString() };
+    pagesize.push_back( { { "title", "1" }, { "href", pageSizeOneLink } } );
+    if ( matchedFeaturesCount > 10 && maxLimit > 10 )
+    {
+      const std::string pageSizeTenLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=10"_s.toStdString() };
+      pagesize.push_back( { { "title", "10" }, { "href", pageSizeTenLink } } );
+    }
+    if ( matchedFeaturesCount > 20 && maxLimit > 20 )
+    {
+      const std::string pageSizeTwentyLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=20"_s.toStdString() };
+      pagesize.push_back( { { "title", "20" }, { "href", pageSizeTwentyLink } } );
+    }
+    if ( matchedFeaturesCount > 50 && maxLimit > 50 )
+    {
+      const std::string pageSizeFiftyLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=50"_s.toStdString() };
+      pagesize.push_back( { { "title", "50" }, { "href", pageSizeFiftyLink } } );
+    }
+    if ( matchedFeaturesCount > 100 && maxLimit > 100 )
+    {
+      const std::string pageSizeHundredLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=100"_s.toStdString() };
+      pagesize.push_back( { { "title", "100" }, { "href", pageSizeHundredLink } } );
+    }
+    if ( matchedFeaturesCount > 1000 && maxLimit > 1000 )
+    {
+      const std::string pageSizeThousandLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=1000"_s.toStdString() };
+      pagesize.push_back( { { "title", "1000" }, { "href", pageSizeThousandLink } } );
+    }
+    std::string maxTitle = "All";
+    if ( maxLimit < matchedFeaturesCount )
+    {
+      maxTitle = "Maximum";
+    }
+    const std::string pageSizeMaxLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=%1"_s.arg( maxLimit ).toStdString() };
+    pagesize.push_back( { { "title", maxTitle }, { "href", pageSizeMaxLink } } );
+  }
+
+  // Get the self link
+  json selfLink;
+  for ( const auto &l : data["links"] )
+  {
+    if ( l["rel"] == "self" )
+    {
+      selfLink = l;
+      break;
+    }
+  }
+
+  // Pagination metadata
+  json pagination = json::array();
+
+  if ( exportContext.limit != 0 )
+  {
+    // Add prev - next links
+    json prevLink;
+    if ( exportContext.offset != 0 )
+    {
+      prevLink = selfLink;
+      prevLink["href"] = cleanedUrlAsString.toStdString() + u"offset=%1&limit=%2"_s.arg( std::max<long>( 0, exportContext.offset - exportContext.limit ) ).arg( exportContext.limit ).toStdString();
+      prevLink["rel"] = "prev";
+      prevLink["title"] = "Previous page";
+      data["links"].push_back( prevLink );
+    }
+
+    json nextLink;
+    if ( exportContext.limit + exportContext.offset < matchedFeaturesCount )
+    {
+      nextLink = selfLink;
+      nextLink["href"] = cleanedUrlAsString.toStdString()
+                         + u"offset=%1&limit=%2"_s.arg( std::min<long>( matchedFeaturesCount, exportContext.limit + exportContext.offset ) ).arg( exportContext.limit ).toStdString();
+      nextLink["rel"] = "next";
+      nextLink["title"] = "Next page";
+      data["links"].push_back( nextLink );
+    }
+
+    // Pagination
+    if ( matchedFeaturesCount - exportContext.limit > 0 )
+    {
+      const int totalPages { static_cast<int>( std::ceil( static_cast<float>( matchedFeaturesCount ) / static_cast<float>( exportContext.limit ) ) ) };
+      const int currentPage { static_cast<int>( exportContext.offset / exportContext.limit + 1 ) };
+      const std::string currentPageLink { selfLink["href"] };
+
+      std::string prevPageLink;
+      if ( prevLink.contains( std::string { "href" } ) )
+      {
+        prevPageLink = prevLink["href"];
+      }
+
+      std::string nextPageLink;
+      if ( nextLink.contains( std::string { "href" } ) )
+      {
+        nextPageLink = nextLink["href"];
+      }
+
+      const std::string firstPageLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=%1"_s.arg( exportContext.limit ).toStdString() };
+      const std::string lastPageLink { cleanedUrlAsString.toStdString() + u"offset=%1&limit=%2"_s.arg( totalPages * exportContext.limit - exportContext.limit ).arg( exportContext.limit ).toStdString() };
+
+      if ( currentPage != 1 )
+      {
+        pagination.push_back( { { "title", "1" }, { "href", firstPageLink }, { "class", "page-item" } } );
+      }
+      if ( currentPage > 3 )
+      {
+        pagination.push_back( { { "title", "\u2026" }, { "class", "page-item disabled" } } );
+      }
+      if ( currentPage > 2 )
+      {
+        pagination.push_back( { { "title", std::to_string( currentPage - 1 ) }, { "href", prevPageLink }, { "class", "page-item" } } );
+      }
+      pagination.push_back( { { "title", std::to_string( currentPage ) }, { "href", currentPageLink }, { "class", "page-item active" } } );
+      if ( currentPage < totalPages - 1 )
+      {
+        pagination.push_back( { { "title", std::to_string( currentPage + 1 ) }, { "href", nextPageLink }, { "class", "page-item" } } );
+      }
+      if ( currentPage < totalPages - 2 )
+      {
+        pagination.push_back( { { "title", "\u2026" }, { "class", "page-item disabled" } } );
+      }
+      if ( currentPage != totalPages )
+      {
+        pagination.push_back( { { "title", std::to_string( totalPages ) }, { "href", lastPageLink }, { "class", "page-item" } } );
+      }
+
+      // Add first - last links
+      // Since we are having them ready, not mandatory by the spec but allowed
+      json firstLink = selfLink;
+      firstLink["href"] = firstPageLink;
+      firstLink["rel"] = "first";
+      firstLink["title"] = "First page";
+      data["links"].push_back( firstLink );
+
+      json lastLink = selfLink;
+      lastLink["href"] = lastPageLink;
+      lastLink["rel"] = "last";
+      lastLink["title"] = "Last page";
+      data["links"].push_back( lastLink );
+    }
+  }
+
+  json navigation = json::array();
+  navigation.push_back( { { "title", "Landing page" }, { "href", parentLink( url, 3 ).toStdString() } } );
+  navigation.push_back( { { "title", "Collections" }, { "href", parentLink( url, 2 ).toStdString() } } );
+  navigation.push_back( { { "title", title }, { "href", parentLink( url, 1 ).toStdString() } } );
+
+  const json htmlMetadata {
+    { "pageTitle", "Features in layer " + title },
+    { "layerTitle", title },
+    { "geojsonUrl", href( apiContext, "/", QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::GEOJSON ) ) },
+    { "pagesize", pagesize },
+    { "pagination", pagination },
+    { "navigation", navigation }
+  };
+
+  write( data, apiContext, htmlMetadata );
+}
+
+void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer *mapLayer, QgsFeatureRequest &featureRequest, const QgsServerApiContext &apiContext, const ExportContext &exportContext ) const
+{
+  const QString destination = VSIMemGenerateHiddenFilename( "data.fgb" );
+  // RIIA deleter for generated file
+  QObject obj;
+  obj.connect( &obj, &QObject::destroyed, [destination]() { VSIUnlink( destination.toStdString().c_str() ); } );
+
+  const auto attributes { featureRequest.subsetOfAttributes() };
+  QgsFields exportedFields;
+  exportedFields.append( QgsField( u"qgs_fid"_s, QMetaType::Type::QString ) );
+  for ( int i = 0; i < mapLayer->fields().count(); i++ )
+  {
+    if ( !attributes.isEmpty() && !attributes.contains( i ) )
+    {
+      continue;
+    }
+    exportedFields.append( mapLayer->fields().field( i ) );
+  }
+
+  QgsVectorFileWriter::SaveVectorOptions saveOptions;
+  saveOptions.driverName = u"FlatGeobuf"_s;
+
+  if ( featureRequest.destinationCrs() != mapLayer->crs() )
+  {
+    saveOptions.ct = QgsCoordinateTransform( mapLayer->crs(), featureRequest.destinationCrs(), featureRequest.transformContext() );
+  }
+
+  std::unique_ptr<QgsVectorFileWriter> writer(
+    QgsVectorFileWriter::create( destination, exportedFields, mapLayer->wkbType(), featureRequest.destinationCrs(), featureRequest.transformContext(), saveOptions )
+  );
+  if ( writer->hasError() )
+  {
+    throw QgsServerApiInternalServerError( u"Could not export layer %1 to FlatGeobuf: %2"_s.arg( mapLayer->name(), writer->errorMessage() ) );
+  }
+
+  QgsFeatureList featureList;
+  QgsFeatureIterator features { mapLayer->getFeatures( featureRequest ) };
+  QgsFeature feat;
+  qlonglong i { 0 };
+  QMap<QgsFeatureId, QString> fidMap;
+
+  while ( features.nextFeature( feat ) )
+  {
+    // Ignore records before offset
+    if ( i >= exportContext.offset )
+    {
+      // Patch feature to add the server feature id
+      const QgsFeatureId originalFid { feat.id() };
+      const QString newFid { QgsServerFeatureId::getServerFid( feat, mapLayer->dataProvider()->pkAttributeIndexes() ) };
+      fidMap.insert( originalFid, newFid );
+      QgsAttributes attributes = feat.attributes();
+      attributes.insert( 0, newFid );
+      feat.setFields( exportedFields );
+      feat.setAttributes( attributes );
+      featureList << feat;
+    }
+    i++;
+  }
+
+  // Count features
+  long matchedFeaturesCount = 0;
+  if ( exportContext.attrFilters.isEmpty() && exportContext.filterRect.isNull() )
+  {
+    matchedFeaturesCount = mapLayer->featureCount();
+  }
+  else
+  {
+    if ( exportContext.filterExpression.isEmpty() )
+    {
+      featureRequest.setNoAttributes();
+    }
+
+    featureRequest.setFlags( Qgis::FeatureRequestFlag::NoGeometry );
+    featureRequest.setLimit( -1 );
+    features = mapLayer->getFeatures( featureRequest );
+
+    while ( features.nextFeature( feat ) )
+    {
+      matchedFeaturesCount++;
+    }
+  }
+
+  for ( QgsFeature &f : featureList )
+  {
+    if ( !writer->addFeature( f ) )
+    {
+      throw QgsServerApiInternalServerError( u"Error adding feature with id %1 to FlatGeobuf export: %2"_s.arg( f.id() ).arg( writer->errorMessage() ) );
+    }
+  }
+
+  writer->finalize();
+
+  if ( writer->hasError() )
+  {
+    throw QgsServerApiInternalServerError( u"Error finalizing FlatGeobuf export: %1"_s.arg( writer->errorMessage() ) );
+  }
+
+  writer.reset();
+
+  apiContext.response()->setStatusCode( 200 );
+
+
+  QDateTime time { QDateTime::currentDateTime() };
+  time.setTimeSpec( Qt::TimeSpec::UTC );
+  apiContext.response()->setHeader( u"date"_s, time.toString( Qt::DateFormat::ISODate ) );
+  apiContext.response()->setHeader( u"content-Type"_s, u"application/flatgeobuf"_s );
+  apiContext.response()->setHeader( u"content-disposition"_s, u"inline; filename=\"%1.fgb\""_s.arg( mapLayer->name() ) );
+  apiContext.response()->setHeader( u"content-crs"_s, featureRequest.destinationCrs().toOgcUri() );
+  apiContext.response()->setHeader( u"ogc-numberreturned"_s, QString::number( featureList.count() ) );
+
+  // Add alternate links
+  apiContext.response()->setHeader( u"link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::RFC7946, u"This document as GEOJSON"_s ) );
+  apiContext.response()->setHeader( u"link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::HTML, QgsServerOgcApi::Profile::NONE, u"This document as HTML"_s ) );
+  apiContext.response()->setHeader( u"link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::JSONFG, u"This document as JSONFG"_s ) );
+  apiContext.response()
+    ->setHeader( u"link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::JSONFG_PLUS, u"This document as JSONFG-PLUS"_s ) );
+
+  // Add next link
+  if ( exportContext.limit + exportContext.offset < matchedFeaturesCount )
+  {
+    // Current url
+    const QUrl url { apiContext.request()->url() };
+
+    // Url without offset and limit
+    QUrl cleanedUrl { url };
+    QUrlQuery query( cleanedUrl );
+    query.removeQueryItem( u"limit"_s );
+    query.removeQueryItem( u"offset"_s );
+    cleanedUrl.setQuery( query );
+
+    QString cleanedUrlAsString { cleanedUrl.toString() };
+
+    if ( !cleanedUrl.hasQuery() )
+    {
+      cleanedUrlAsString += '?';
+    }
+    else
+    {
+      cleanedUrlAsString += '&';
+    }
+    const QString nextHref = cleanedUrlAsString + u"offset=%1&limit=%2"_s.arg( std::min<long>( matchedFeaturesCount, exportContext.limit + exportContext.offset ) ).arg( exportContext.limit );
+    apiContext.response()->setHeader( u"link"_s, u"<%1>; rel=\"next\"; title=\"Next page\"; type=\"application/flatgeobuf\""_s.arg( nextHref ) );
+  }
+
+  // Retrieve data from the buffer and send it
+  vsi_l_offset pnDataLength;
+  const char *dataPtr = reinterpret_cast<char *>( VSIGetMemFileBuffer( destination.toStdString().c_str(), &pnDataLength, false ) );
+  const QByteArray data { QByteArray::fromRawData( dataPtr, pnDataLength ) };
+  apiContext.response()->write( data );
+}
+
+void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &apiContext ) const
+{
+  if ( !apiContext.project() )
   {
     throw QgsServerApiImproperlyConfiguredException( u"Project is invalid or undefined"_s );
   }
-  QgsVectorLayer *mapLayer { layerFromContext( context ) };
+  QgsVectorLayer *mapLayer { layerFromContext( apiContext ) };
   Q_ASSERT( mapLayer );
 
   // Check if the layer is published, raise not found if it is not
-  checkLayerIsAccessible( mapLayer, context );
-
-  const std::string title { mapLayer->serverProperties()->wfsTitle().isEmpty() ? mapLayer->name().toStdString() : mapLayer->serverProperties()->wfsTitle().toStdString() };
+  checkLayerIsAccessible( mapLayer, apiContext );
 
   // Get parameters
-  QVariantMap params = values( context );
+  QVariantMap params = values( apiContext );
 
-  switch ( context.request()->method() )
+  switch ( apiContext.request()->method() )
   {
     // //////////////////////////////////////////////////////////////
     // Retrieve features
@@ -977,7 +1375,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
 
       // Attribute filters
       QgsStringMap attrFilters;
-      const QgsFields constPublishedFields { publishedFields( mapLayer, context ) };
+      const QgsFields constPublishedFields { publishedFields( mapLayer, apiContext ) };
       for ( const QgsField &f : constPublishedFields )
       {
         QString val = params.value( f.name() ).toString();
@@ -1055,7 +1453,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       // ////////////////////////////////////////////////////////////////////////////////////////////////////
       // End of input control: inputs are valid, process the request
 
-      QgsFeatureRequest featureRequest = filteredRequest( mapLayer, context, requestedProperties );
+      QgsFeatureRequest featureRequest = filteredRequest( mapLayer, apiContext, requestedProperties );
 
       if ( !sortBy.isEmpty() )
       {
@@ -1064,7 +1462,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
 
       if ( !filterRect.isNull() )
       {
-        const QgsCoordinateTransform ct( bboxCrs, crs, context.project()->transformContext() );
+        const QgsCoordinateTransform ct( bboxCrs, crs, apiContext.project()->transformContext() );
         try
         {
           featureRequest.setFilterRect( ct.transform( filterRect ) );
@@ -1106,245 +1504,27 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       }
 
       // WFS3 core specs only serves 4326
-      featureRequest.setDestinationCrs( crs, context.project()->transformContext() );
+      featureRequest.setDestinationCrs( crs, apiContext.project()->transformContext() );
       // Add offset to limit because paging is not supported by QgsFeatureRequest
       featureRequest.setLimit( limit + offset );
-      QgsJsonExporter exporter { mapLayer };
-      exporter.setAttributes( featureRequest.subsetOfAttributes() );
-      exporter.setAttributeDisplayName( true );
-      exporter.setSourceCrs( mapLayer->crs() );
-      exporter.setTransformGeometries( false );
-      QgsFeatureList featureList;
-      QgsFeatureIterator features { mapLayer->getFeatures( featureRequest ) };
-      QgsFeature feat;
-      long i { 0 };
-      QMap<QgsFeatureId, QString> fidMap;
 
-      while ( features.nextFeature( feat ) )
+      const ExportContext exportContext { limit, offset, attrFilters, filterExpression, filterRect };
+
+      const QgsServerOgcApi::ContentType contentType { contentTypeFromRequest( apiContext.request() ) };
+      switch ( contentType )
       {
-        // Ignore records before offset
-        if ( i >= offset )
-        {
-          fidMap.insert( feat.id(), QgsServerFeatureId::getServerFid( feat, mapLayer->dataProvider()->pkAttributeIndexes() ) );
-          featureList << feat;
-        }
-        i++;
-      }
-
-      // Count features
-      long matchedFeaturesCount = 0;
-      if ( attrFilters.isEmpty() && filterRect.isNull() )
-      {
-        matchedFeaturesCount = mapLayer->featureCount();
-      }
-      else
-      {
-        if ( filterExpression.isEmpty() )
-        {
-          featureRequest.setNoAttributes();
-        }
-
-        featureRequest.setFlags( Qgis::FeatureRequestFlag::NoGeometry );
-        featureRequest.setLimit( -1 );
-        features = mapLayer->getFeatures( featureRequest );
-
-        while ( features.nextFeature( feat ) )
-        {
-          matchedFeaturesCount++;
-        }
-      }
-
-      json data = exporter.exportFeaturesToJsonObject( featureList );
-
-      // Patch feature IDs with server feature IDs
-      for ( int i = 0; i < featureList.length(); i++ )
-      {
-        data["features"][i]["id"] = fidMap.value( data["features"][i]["id"] ).toStdString();
-      }
-
-      // Add some metadata
-      data["numberMatched"] = matchedFeaturesCount;
-      data["numberReturned"] = featureList.count();
-      data["links"] = links( context );
-
-      // Current url
-      const QUrl url { context.request()->url() };
-
-      // Url without offset and limit
-      QUrl cleanedUrl { url };
-      QUrlQuery query( cleanedUrl );
-      query.removeQueryItem( u"limit"_s );
-      query.removeQueryItem( u"offset"_s );
-      cleanedUrl.setQuery( query );
-
-      QString cleanedUrlAsString { cleanedUrl.toString() };
-
-      if ( !cleanedUrl.hasQuery() )
-      {
-        cleanedUrlAsString += '?';
-      }
-      else
-      {
-        cleanedUrlAsString += '&';
-      }
-
-      // Pagesize metadata
-      json pagesize = json::array();
-      const qlonglong maxLimit { context.serverInterface()->serverSettings()->apiWfs3MaxLimit() };
-      if ( matchedFeaturesCount > 1 && maxLimit > 1 )
-      {
-        const std::string pageSizeOneLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=1"_s.toStdString() };
-        pagesize.push_back( { { "title", "1" }, { "href", pageSizeOneLink } } );
-        if ( matchedFeaturesCount > 10 && maxLimit > 10 )
-        {
-          const std::string pageSizeTenLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=10"_s.toStdString() };
-          pagesize.push_back( { { "title", "10" }, { "href", pageSizeTenLink } } );
-        }
-        if ( matchedFeaturesCount > 20 && maxLimit > 20 )
-        {
-          const std::string pageSizeTwentyLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=20"_s.toStdString() };
-          pagesize.push_back( { { "title", "20" }, { "href", pageSizeTwentyLink } } );
-        }
-        if ( matchedFeaturesCount > 50 && maxLimit > 50 )
-        {
-          const std::string pageSizeFiftyLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=50"_s.toStdString() };
-          pagesize.push_back( { { "title", "50" }, { "href", pageSizeFiftyLink } } );
-        }
-        if ( matchedFeaturesCount > 100 && maxLimit > 100 )
-        {
-          const std::string pageSizeHundredLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=100"_s.toStdString() };
-          pagesize.push_back( { { "title", "100" }, { "href", pageSizeHundredLink } } );
-        }
-        if ( matchedFeaturesCount > 1000 && maxLimit > 1000 )
-        {
-          const std::string pageSizeThousandLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=1000"_s.toStdString() };
-          pagesize.push_back( { { "title", "1000" }, { "href", pageSizeThousandLink } } );
-        }
-        std::string maxTitle = "All";
-        if ( maxLimit < matchedFeaturesCount )
-        {
-          maxTitle = "Maximum";
-        }
-        const std::string pageSizeMaxLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=%1"_s.arg( maxLimit ).toStdString() };
-        pagesize.push_back( { { "title", maxTitle }, { "href", pageSizeMaxLink } } );
-      }
-
-      // Get the self link
-      json selfLink;
-      for ( const auto &l : data["links"] )
-      {
-        if ( l["rel"] == "self" )
-        {
-          selfLink = l;
+        case QgsServerOgcApi::ContentType::JSON:
+        case QgsServerOgcApi::ContentType::GEOJSON:
+        case QgsServerOgcApi::ContentType::HTML:
+          writeJsonOutput( mapLayer, featureRequest, apiContext, exportContext );
           break;
-        }
+        case QgsServerOgcApi::ContentType::FLATGEOBUF:
+          writeFlatGeobufOutput( mapLayer, featureRequest, apiContext, exportContext );
+          break;
+        default:
+          throw QgsServerApiInternalServerError( u"Unsupported content type"_s );
       }
 
-      // Pagination metadata
-      json pagination = json::array();
-
-      if ( limit != 0 )
-      {
-        // Add prev - next links
-        json prevLink;
-        if ( offset != 0 )
-        {
-          prevLink = selfLink;
-          prevLink["href"] = cleanedUrlAsString.toStdString() + u"offset=%1&limit=%2"_s.arg( std::max<long>( 0, offset - limit ) ).arg( limit ).toStdString();
-          prevLink["rel"] = "prev";
-          prevLink["title"] = "Previous page";
-          data["links"].push_back( prevLink );
-        }
-
-        json nextLink;
-        if ( limit + offset < matchedFeaturesCount )
-        {
-          nextLink = selfLink;
-          nextLink["href"] = cleanedUrlAsString.toStdString() + u"offset=%1&limit=%2"_s.arg( std::min<long>( matchedFeaturesCount, limit + offset ) ).arg( limit ).toStdString();
-          nextLink["rel"] = "next";
-          nextLink["title"] = "Next page";
-          data["links"].push_back( nextLink );
-        }
-
-        // Pagination
-        if ( matchedFeaturesCount - limit > 0 )
-        {
-          const int totalPages { static_cast<int>( std::ceil( static_cast<float>( matchedFeaturesCount ) / static_cast<float>( limit ) ) ) };
-          const int currentPage { static_cast<int>( offset / limit + 1 ) };
-          const std::string currentPageLink { selfLink["href"] };
-
-          std::string prevPageLink;
-          if ( prevLink.contains( std::string { "href" } ) )
-          {
-            prevPageLink = prevLink["href"];
-          }
-
-          std::string nextPageLink;
-          if ( nextLink.contains( std::string { "href" } ) )
-          {
-            nextPageLink = nextLink["href"];
-          }
-
-          const std::string firstPageLink { cleanedUrlAsString.toStdString() + u"offset=0&limit=%1"_s.arg( limit ).toStdString() };
-          const std::string lastPageLink { cleanedUrlAsString.toStdString() + u"offset=%1&limit=%2"_s.arg( totalPages * limit - limit ).arg( limit ).toStdString() };
-
-          if ( currentPage != 1 )
-          {
-            pagination.push_back( { { "title", "1" }, { "href", firstPageLink }, { "class", "page-item" } } );
-          }
-          if ( currentPage > 3 )
-          {
-            pagination.push_back( { { "title", "\u2026" }, { "class", "page-item disabled" } } );
-          }
-          if ( currentPage > 2 )
-          {
-            pagination.push_back( { { "title", std::to_string( currentPage - 1 ) }, { "href", prevPageLink }, { "class", "page-item" } } );
-          }
-          pagination.push_back( { { "title", std::to_string( currentPage ) }, { "href", currentPageLink }, { "class", "page-item active" } } );
-          if ( currentPage < totalPages - 1 )
-          {
-            pagination.push_back( { { "title", std::to_string( currentPage + 1 ) }, { "href", nextPageLink }, { "class", "page-item" } } );
-          }
-          if ( currentPage < totalPages - 2 )
-          {
-            pagination.push_back( { { "title", "\u2026" }, { "class", "page-item disabled" } } );
-          }
-          if ( currentPage != totalPages )
-          {
-            pagination.push_back( { { "title", std::to_string( totalPages ) }, { "href", lastPageLink }, { "class", "page-item" } } );
-          }
-
-          // Add first - last links
-          // Since we are having them ready, not mandatory by the spec but allowed
-          json firstLink = selfLink;
-          firstLink["href"] = firstPageLink;
-          firstLink["rel"] = "first";
-          firstLink["title"] = "First page";
-          data["links"].push_back( firstLink );
-
-          json lastLink = selfLink;
-          lastLink["href"] = lastPageLink;
-          lastLink["rel"] = "last";
-          lastLink["title"] = "Last page";
-          data["links"].push_back( lastLink );
-        }
-      }
-
-      json navigation = json::array();
-      navigation.push_back( { { "title", "Landing page" }, { "href", parentLink( url, 3 ).toStdString() } } );
-      navigation.push_back( { { "title", "Collections" }, { "href", parentLink( url, 2 ).toStdString() } } );
-      navigation.push_back( { { "title", title }, { "href", parentLink( url, 1 ).toStdString() } } );
-
-      const json htmlMetadata {
-        { "pageTitle", "Features in layer " + title },
-        { "layerTitle", title },
-        { "geojsonUrl", href( context, "/", QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::GEOJSON ) ) },
-        { "pagesize", pagesize },
-        { "pagination", pagination },
-        { "navigation", navigation }
-      };
-
-      write( data, context, htmlMetadata );
       break;
     }
     // //////////////////////////////////////////////////////////////
@@ -1352,7 +1532,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
     case QgsServerRequest::Method::PostMethod:
     {
       // First: check permissions
-      const QStringList wfstInsertLayerIds = QgsServerProjectUtils::wfstInsertLayerIds( *context.project() );
+      const QStringList wfstInsertLayerIds = QgsServerProjectUtils::wfstInsertLayerIds( *apiContext.project() );
       if ( !wfstInsertLayerIds.contains( mapLayer->id() ) || !mapLayer->dataProvider()->capabilities().testFlag( Qgis::VectorProviderCapability::AddFeatures ) )
       {
         throw QgsServerApiPermissionDeniedException( u"Features cannot be added to layer '%1'"_s.arg( mapLayer->name() ) );
@@ -1361,7 +1541,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 
       // get access controls
-      QgsAccessControl *accessControl = context.serverInterface()->accessControls();
+      QgsAccessControl *accessControl = apiContext.serverInterface()->accessControls();
       if ( accessControl && !accessControl->layerInsertPermission( mapLayer ) )
       {
         throw QgsServerApiPermissionDeniedException( u"No ACL permissions to insert features on layer '%1'"_s.arg( mapLayer->name() ) );
@@ -1379,11 +1559,11 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       try
       {
         // Parse
-        json postData = json::parse( context.request()->data().toStdString() );
+        json postData = json::parse( apiContext.request()->data().toStdString() );
 
         // Process data: extract geometry (because we need to process attributes in a much more complex way)
-        const QgsFields fields = QgsOgrUtils::stringToFields( context.request()->data(), QTextCodec::codecForName( "UTF-8" ) );
-        const QgsFeatureList features = QgsOgrUtils::stringToFeatureList( context.request()->data(), fields, QTextCodec::codecForName( "UTF-8" ) );
+        const QgsFields fields = QgsOgrUtils::stringToFields( apiContext.request()->data(), QTextCodec::codecForName( "UTF-8" ) );
+        const QgsFeatureList features = QgsOgrUtils::stringToFeatureList( apiContext.request()->data(), fields, QTextCodec::codecForName( "UTF-8" ) );
         if ( features.isEmpty() )
         {
           throw QgsServerApiBadRequestException( u"Posted data does not contain any feature"_s );
@@ -1401,7 +1581,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
           QgsGeometry geom { feat.geometry() };
           try
           {
-            geom.transform( QgsCoordinateTransform( QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), mapLayer->crs(), context.project()->transformContext() ) );
+            geom.transform( QgsCoordinateTransform( QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), mapLayer->crs(), apiContext.project()->transformContext() ) );
           }
           catch ( QgsCsException & )
           {
@@ -1413,7 +1593,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
         // Process attributes
         try
         {
-          const QgsFields authorizedFields { publishedFields( mapLayer, context ) };
+          const QgsFields authorizedFields { publishedFields( mapLayer, apiContext ) };
           QStringList authorizedFieldNames;
           for ( const auto &f : authorizedFields )
           {
@@ -1469,10 +1649,10 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
         feat = featuresToAdd.first();
 
         // Send response
-        context.response()->setStatusCode( 201 );
-        context.response()->setHeader( u"Content-Type"_s, u"application/geo+json"_s );
+        apiContext.response()->setStatusCode( 201 );
+        apiContext.response()->setHeader( u"Content-Type"_s, u"application/geo+json"_s );
 
-        QUrl collectionUrl { context.request()->url() };
+        QUrl collectionUrl { apiContext.request()->url() };
         // Remove query and fragment
         collectionUrl.setQuery( QString() );
         collectionUrl.setFragment( QString() );
@@ -1483,8 +1663,8 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
           url.append( '/' );
         }
 
-        context.response()->setHeader( u"Location"_s, url + QString::number( feat.id() ) );
-        context.response()->write( "\"string\"" );
+        apiContext.response()->setHeader( u"Location"_s, url + QString::number( feat.id() ) );
+        apiContext.response()->write( "\"string\"" );
       }
       catch ( json::exception &ex )
       {
@@ -1494,35 +1674,35 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
     }
     case QgsServerRequest::Method::OptionsMethod:
     {
-      context.response()->setStatusCode( 200 );
+      apiContext.response()->setStatusCode( 200 );
       QStringList methods;
       methods << u"GET"_s << u"OPTIONS"_s;
-      if ( canInsertFeatures( mapLayer, context ) )
+      if ( canInsertFeatures( mapLayer, apiContext ) )
       {
         methods << u"POST"_s;
       }
-      if ( canDeleteFeatures( mapLayer, context ) )
+      if ( canDeleteFeatures( mapLayer, apiContext ) )
       {
         methods << u"DELETE"_s;
       }
-      if ( canUpdateFeatures( mapLayer, context ) )
+      if ( canUpdateFeatures( mapLayer, apiContext ) )
       {
         methods << u"PUT"_s << u"PATCH"_s;
       }
-      context.response()->setHeader( u"Allow"_s, methods.join( ", " ) );
+      apiContext.response()->setHeader( u"Allow"_s, methods.join( ", " ) );
       break;
     }
     // Error
     default:
     {
-      throw QgsServerApiNotImplementedException( u"%1 method is not implemented."_s.arg( QgsServerRequest::methodToString( context.request()->method() ) ) );
+      throw QgsServerApiNotImplementedException( u"%1 method is not implemented."_s.arg( QgsServerRequest::methodToString( apiContext.request()->method() ) ) );
     }
   } // end switch
 }
 
 QgsWfs3CollectionsFeatureHandler::QgsWfs3CollectionsFeatureHandler()
 {
-  setContentTypes( { QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::ContentType::HTML } );
+  setContentTypes( { QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::ContentType::HTML, QgsServerOgcApi::ContentType::FLATGEOBUF } );
 }
 
 void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext &context ) const

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1208,7 +1208,7 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
   saveOptions.driverName = u"FlatGeobuf"_s;
   if ( !mapLayer->isSpatial() )
   {
-    saveOptions.datasourceOptions = u"SPATIAL_INDEX=NO"_s;
+    saveOptions.layerOptions.append( u"SPATIAL_INDEX=NO"_s );
   }
 
   if ( featureRequest.destinationCrs() != mapLayer->crs() )
@@ -1337,9 +1337,9 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
   vsi_l_offset nDataLength = 0;
   const char *dataPtr = reinterpret_cast<char *>( VSIGetMemFileBuffer( destination.toStdString().c_str(), &nDataLength, false ) );
 
-  Q_ASSERT( pnDataLength <= std::numeric_limits<qsizetype>::max() );
+  Q_ASSERT( nDataLength <= std::numeric_limits<qsizetype>::max() );
 
-  const QByteArray data { QByteArray::fromRawData( dataPtr, static_cast<qsizetype>( pnDataLength ) ) };
+  const QByteArray data { QByteArray::fromRawData( dataPtr, static_cast<qsizetype>( nDataLength ) ) };
   apiContext.response()->write( data );
 }
 

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1272,18 +1272,22 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
 
   QDateTime time { QDateTime::currentDateTime() };
   time.setTimeSpec( Qt::TimeSpec::UTC );
-  apiContext.response()->setHeader( u"date"_s, time.toString( Qt::DateFormat::ISODate ) );
-  apiContext.response()->setHeader( u"content-Type"_s, u"application/flatgeobuf"_s );
-  apiContext.response()->setHeader( u"content-disposition"_s, u"inline; filename=\"%1.fgb\""_s.arg( mapLayer->name() ) );
-  apiContext.response()->setHeader( u"content-crs"_s, featureRequest.destinationCrs().toOgcUri() );
-  apiContext.response()->setHeader( u"ogc-numberreturned"_s, QString::number( featureList.count() ) );
+  apiContext.response()->setHeader( u"Date"_s, time.toString( Qt::DateFormat::ISODate ) );
+  apiContext.response()->setHeader( u"Content-Type"_s, u"application/flatgeobuf"_s );
+  apiContext.response()->setHeader( u"Content-Disposition"_s, u"inline; filename=\"%1.fgb\""_s.arg( mapLayer->name() ) );
+  apiContext.response()->setHeader( u"Content-Crs"_s, featureRequest.destinationCrs().toOgcUri() );
+  apiContext.response()->setHeader( u"OGC-NumberReturned"_s, QString::number( featureList.count() ) );
 
   // Add alternate links
-  apiContext.response()->setHeader( u"link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::RFC7946, u"This document as GEOJSON"_s ) );
-  apiContext.response()->setHeader( u"link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::HTML, QgsServerOgcApi::Profile::NONE, u"This document as HTML"_s ) );
+  apiContext.response()->addHeader( u"Link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::RFC7946, u"This document as GEOJSON"_s ) );
+  apiContext.response()->addHeader( u"Link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::HTML, QgsServerOgcApi::Profile::NONE, u"This document as HTML"_s ) );
+#if 0
+    // This not supported yet but I am leaving it here because
+    // I am very optimistic that it will be supported soon!
   apiContext.response()->setHeader( u"link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::JSONFG, u"This document as JSONFG"_s ) );
   apiContext.response()
     ->setHeader( u"link"_s, headerLink( apiContext, QgsServerOgcApi::Rel::alternate, QgsServerOgcApi::ContentType::GEOJSON, QgsServerOgcApi::Profile::JSONFG_PLUS, u"This document as JSONFG-PLUS"_s ) );
+#endif
 
   // Add next link
   if ( exportContext.limit + exportContext.offset < matchedFeaturesCount )
@@ -1309,7 +1313,7 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
       cleanedUrlAsString += '&';
     }
     const QString nextHref = cleanedUrlAsString + u"offset=%1&limit=%2"_s.arg( std::min<long>( matchedFeaturesCount, exportContext.limit + exportContext.offset ) ).arg( exportContext.limit );
-    apiContext.response()->setHeader( u"link"_s, u"<%1>; rel=\"next\"; title=\"Next page\"; type=\"application/flatgeobuf\""_s.arg( nextHref ) );
+    apiContext.response()->addHeader( u"Link"_s, u"<%1>; rel=\"next\"; title=\"Next page\"; type=\"application/flatgeobuf\""_s.arg( nextHref ) );
   }
 
   // Retrieve data from the buffer and send it

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1206,6 +1206,10 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
 
   QgsVectorFileWriter::SaveVectorOptions saveOptions;
   saveOptions.driverName = u"FlatGeobuf"_s;
+  if ( !mapLayer->isSpatial() )
+  {
+    saveOptions.datasourceOptions = u"SPATIAL_INDEX=NO"_s;
+  }
 
   if ( featureRequest.destinationCrs() != mapLayer->crs() )
   {
@@ -1330,14 +1334,10 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
   }
 
   // Retrieve data from the buffer and send it
-  vsi_l_offset pnDataLength;
-  const char *dataPtr = reinterpret_cast<char *>( VSIGetMemFileBuffer( destination.toStdString().c_str(), &pnDataLength, false ) );
+  vsi_l_offset nDataLength = 0;
+  const char *dataPtr = reinterpret_cast<char *>( VSIGetMemFileBuffer( destination.toStdString().c_str(), &nDataLength, false ) );
 
-  // Check that pnDataLength fits in qsizetype
-  if ( pnDataLength > std::numeric_limits<qsizetype>::max() )
-  {
-    throw QgsServerApiInternalServerError( u"Exported data is too large to be sent in the response"_s );
-  }
+  Q_ASSERT( pnDataLength <= std::numeric_limits<qsizetype>::max() );
 
   const QByteArray data { QByteArray::fromRawData( dataPtr, static_cast<qsizetype>( pnDataLength ) ) };
   apiContext.response()->write( data );

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1332,7 +1332,14 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
   // Retrieve data from the buffer and send it
   vsi_l_offset pnDataLength;
   const char *dataPtr = reinterpret_cast<char *>( VSIGetMemFileBuffer( destination.toStdString().c_str(), &pnDataLength, false ) );
-  const QByteArray data { QByteArray::fromRawData( dataPtr, pnDataLength ) };
+
+  // Check that pnDataLength fits in qsizetype
+  if ( pnDataLength > std::numeric_limits<qsizetype>::max() )
+  {
+    throw QgsServerApiInternalServerError( u"Exported data is too large to be sent in the response"_s );
+  }
+
+  const QByteArray data { QByteArray::fromRawData( dataPtr, static_cast<qsizetype>( pnDataLength ) ) };
   apiContext.response()->write( data );
 }
 

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1575,6 +1575,9 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &a
           throw QgsServerApiInternalServerError( u"Feature is not valid"_s );
         }
 
+        // FIXME: in JSON-FG we might have a different CRS than 4326,
+        // we should check for a crs member in the JSON and use it if present
+
         // Transform geometry
         if ( mapLayer->crs() != QgsCoordinateReferenceSystem::fromEpsgId( 4326 ) )
         {

--- a/src/server/services/wfs3/qgswfs3handlers.h
+++ b/src/server/services/wfs3/qgswfs3handlers.h
@@ -234,7 +234,7 @@ class QgsWfs3CollectionsItemsHandler : public QgsWfs3AbstractItemsHandler
   public:
     QgsWfs3CollectionsItemsHandler();
     void handleRequest( const QgsServerApiContext &apiContext ) const override;
-    QRegularExpression path() const override { return QRegularExpression( R"re(/collections/(?<collectionId>[^/]+)/items(\.geojson|\.json|\.html|\.flatgeobuf|\.fgb|/)?$)re" ); }
+    QRegularExpression path() const override { return QRegularExpression( R"re(/collections/(?<collectionId>[^/]+)/items(\.geojson|\.json|\.html|\.fgb|/)?$)re" ); }
     std::string operationId() const override { return "getFeatures"; }
     std::string summary() const override { return "Retrieve features of feature collection {collectionId}."; }
     std::string description() const override
@@ -277,7 +277,7 @@ class QgsWfs3CollectionsFeatureHandler : public QgsWfs3AbstractItemsHandler
   public:
     QgsWfs3CollectionsFeatureHandler();
     void handleRequest( const QgsServerApiContext &context ) const override;
-    QRegularExpression path() const override { return QRegularExpression( R"re(/collections/(?<collectionId>[^/]+)/items/(?<featureId>[^/]+?)(\.json|\.geojson|\.html|\.flatgeobuf|\.fgb|/)?$)re" ); }
+    QRegularExpression path() const override { return QRegularExpression( R"re(/collections/(?<collectionId>[^/]+)/items/(?<featureId>[^/]+?)(\.json|\.geojson|\.html|\.fgb|/)?$)re" ); }
     std::string operationId() const override { return "getFeature"; }
     std::string description() const override
     {

--- a/src/server/services/wfs3/qgswfs3handlers.h
+++ b/src/server/services/wfs3/qgswfs3handlers.h
@@ -227,8 +227,8 @@ class QgsWfs3CollectionsItemsHandler : public QgsWfs3AbstractItemsHandler
 {
   public:
     QgsWfs3CollectionsItemsHandler();
-    void handleRequest( const QgsServerApiContext &context ) const override;
-    QRegularExpression path() const override { return QRegularExpression( R"re(/collections/(?<collectionId>[^/]+)/items(\.geojson|\.json|\.html|/)?$)re" ); }
+    void handleRequest( const QgsServerApiContext &apiContext ) const override;
+    QRegularExpression path() const override { return QRegularExpression( R"re(/collections/(?<collectionId>[^/]+)/items(\.geojson|\.json|\.html|\.flatgeobuf|\.fgb|/)?$)re" ); }
     std::string operationId() const override { return "getFeatures"; }
     std::string summary() const override { return "Retrieve features of feature collection {collectionId}."; }
     std::string description() const override
@@ -237,7 +237,7 @@ class QgsWfs3CollectionsItemsHandler : public QgsWfs3AbstractItemsHandler
              "consist of multiple feature collections. A feature collection is often a "
              "collection of features of a similar type, based on a common schema. "
              "Use content negotiation or specify a file extension to request HTML (.html) "
-             "or GeoJSON (.json).";
+             "GeoJSON (.json) or FlatGeobuf (.fgb).";
     }
     std::string linkTitle() const override { return "Retrieve the features of the collection"; }
     QStringList tags() const override { return { u"Features"_s }; }
@@ -246,8 +246,23 @@ class QgsWfs3CollectionsItemsHandler : public QgsWfs3AbstractItemsHandler
     json schema( const QgsServerApiContext &context ) const override;
 
   private:
+    struct ExportContext
+    {
+        qlonglong limit = -1;
+        qlonglong offset = 0;
+        QgsStringMap attrFilters;
+        QString filterExpression;
+        QgsRectangle filterRect;
+    };
+
     // Retrieve the fields filter parameters
     const QList<QgsServerQueryStringParameter> fieldParameters( const QgsVectorLayer *mapLayer, const QgsServerApiContext &context ) const;
+
+    // Json output
+    void writeJsonOutput( const QgsVectorLayer *mapLayer, QgsFeatureRequest &featureRequest, const QgsServerApiContext &apiContext, const ExportContext &exportContext ) const;
+
+    // FlatGeobuf output
+    void writeFlatGeobufOutput( const QgsVectorLayer *mapLayer, QgsFeatureRequest &featureRequest, const QgsServerApiContext &apiContext, const ExportContext &exportContext ) const;
 };
 
 
@@ -256,11 +271,12 @@ class QgsWfs3CollectionsFeatureHandler : public QgsWfs3AbstractItemsHandler
   public:
     QgsWfs3CollectionsFeatureHandler();
     void handleRequest( const QgsServerApiContext &context ) const override;
-    QRegularExpression path() const override { return QRegularExpression( R"re(/collections/(?<collectionId>[^/]+)/items/(?<featureId>[^/]+?)(\.json|\.geojson|\.html|/)?$)re" ); }
+    QRegularExpression path() const override { return QRegularExpression( R"re(/collections/(?<collectionId>[^/]+)/items/(?<featureId>[^/]+?)(\.json|\.geojson|\.html|\.flatgeobuf|\.fgb|/)?$)re" ); }
     std::string operationId() const override { return "getFeature"; }
     std::string description() const override
     {
-      return "Retrieve a feature with ID {featureId} from the collection with ID {collectionId}; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json).";
+      return "Retrieve a feature with ID {featureId} from the collection with ID {collectionId}; use content negotiation or specify a file extension to request HTML (.html), GeoJSON (.json) or "
+             "FlatGeobuf (.fgb).";
     }
     std::string summary() const override { return "Retrieve a single feature with ID {featureId} from the collection with ID {collectionId}."; }
     std::string linkTitle() const override { return "Retrieve a feature"; }

--- a/src/server/services/wfs3/qgswfs3handlers.h
+++ b/src/server/services/wfs3/qgswfs3handlers.h
@@ -94,6 +94,12 @@ class QgsWfs3AbstractItemsHandler : public QgsServerOgcApiHandler
      * but does not check if the user has permissions to edit the layer, as this is expected to be handled by plugins.
      */
     bool canUpdateFeatures( const QgsVectorLayer *mapLayer, const QgsServerApiContext &context ) const;
+
+    /**
+     * Removes the 'offset' and 'limit' query parameters from the given \a urlQuery ignoring case,
+     * and returns the modified query.
+     */
+    static QUrlQuery removeOffsetAndLimit( const QUrlQuery &urlQuery );
 };
 
 /**

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -223,7 +223,7 @@ class QgsServerAPITestBase(QgsServerTestBase):
     """QGIS API server tests"""
 
     # Set to True in child classes to re-generate reference files for this class
-    regeregenerate_api_reference = False
+    regenerate_api_reference = True
 
     def assertEqualBrackets(self, actual, expected):
         """Also counts parenthesis"""
@@ -312,7 +312,7 @@ class QgsServerAPITestBase(QgsServerTestBase):
                 result = result.replace(k, v)
 
         path = os.path.join(self.temporary_path, "qgis_server", subdir, reference_file)
-        if self.regeregenerate_api_reference:
+        if self.regenerate_api_reference:
             overwrite_path = os.path.join(
                 unitTestDataPath("qgis_server"), subdir, reference_file
             )
@@ -995,6 +995,78 @@ class QgsServerAPITest(QgsServerAPITestBase):
             project,
             "test_wfs3_collections_items_as-areas-short-name_3857.json",
         )
+
+    def test_wfs3_collection_items_flatgeobuf(self):
+        """Test WFS3 API items"""
+        project = QgsProject()
+        project.read(
+            os.path.join(self.temporary_path, "qgis_server", "test_project_api.qgs")
+        )
+        request = QgsBufferServerRequest(
+            "http://server.qgis.org/wfs3/collections/testlayer%20èé/items.fgb?limit=1"
+        )
+        server = QgsServer()
+        response = QgsBufferServerResponse()
+        server.handleRequest(request, response, project)
+        body = response.body()
+
+        # Check headers
+        headers = response.fullHeaders()
+        self.assertEqual(headers["Content-Type"][0], "application/flatgeobuf")
+        self.assertEqual(headers["OGC-NumberReturned"][0], "1")
+        self.assertEqual(
+            headers["Content-Disposition"][0], 'inline; filename="testlayer èé.fgb"'
+        )
+        self.assertEqual(headers["OGC-NumberReturned"][0], "1")
+        self.assertEqual(
+            headers["Link"],
+            [
+                '<http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson?limit=1>; rel="alternate"; title="This document as GEOJSON"; type="application/geo+json"; profile="json"',
+                '<http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html?limit=1>; rel="alternate"; title="This document as HTML"; type="text/html"',
+                '<http://server.qgis.org/wfs3/collections/testlayer èé/items.fgb?offset=1&limit=1>; rel="next"; title="Next page"; type="application/flatgeobuf"',
+            ],
+        )
+
+        def _get_layer():
+            # Save to temporary file .fgb
+            path = os.path.join(
+                self.temporary_path, "qgis_server", "api", "testlayer.fgb"
+            )
+            with open(path, "wb") as f:
+                f.write(bytes(response.body()))
+            # Open file with QgsVectorLayer and check features
+            layer = QgsVectorLayer(path, "testlayer", "ogr")
+            self.assertTrue(layer.isValid())
+            return layer
+
+        layer = _get_layer()
+        self.assertEqual(layer.getFeature(0).attributes(), ["0", 1, "one", "one èé"])
+        geom = layer.getFeature(0).geometry()
+        self.assertAlmostEqual(geom.asPoint().x(), 8.20349, 4)
+        self.assertAlmostEqual(geom.asPoint().y(), 44.90148, 4)
+
+        # Request 2 features from next page
+        request = QgsBufferServerRequest(
+            "http://server.qgis.org/wfs3/collections/testlayer%20èé/items.fgb?offset=1&limit=2"
+        )
+        response = QgsBufferServerResponse()
+        server.handleRequest(request, response, project)
+        # Check headers
+        headers = response.fullHeaders()
+        self.assertEqual(headers["OGC-NumberReturned"][0], "2")
+
+        layer = _get_layer()
+        self.assertEqual(layer.getFeature(0).attributes(), ["1", 2, "two", "two àò"])
+        geom = layer.getFeature(0).geometry()
+        self.assertAlmostEqual(geom.asPoint().x(), 8.20354, 4)
+        self.assertAlmostEqual(geom.asPoint().y(), 44.90148, 4)
+
+        self.assertEqual(
+            layer.getFeature(1).attributes(), ["2", 3, "three", "three èé↓"]
+        )
+        geom = layer.getFeature(1).geometry()
+        self.assertAlmostEqual(geom.asPoint().x(), 8.20345, 4)
+        self.assertAlmostEqual(geom.asPoint().y(), 44.90139, 4)
 
     def test_invalid_args(self):
         """Test wrong args"""

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -1068,6 +1068,39 @@ class QgsServerAPITest(QgsServerAPITestBase):
         self.assertAlmostEqual(geom.asPoint().x(), 8.20345, 4)
         self.assertAlmostEqual(geom.asPoint().y(), 44.90139, 4)
 
+    def test_wfs3_collection_items_aspatial_flatgeobuf(self):
+        """Test flatgeobuf output for non spatial layer"""
+
+        fields = QgsFields()
+        fields.append(QgsField("name", QtCore.QMetaType.Type.QString))
+        layer = QgsMemoryProviderUtils.createMemoryLayer("aspatial", fields)
+        self.assertTrue(layer.isValid())
+        self.assertFalse(layer.isSpatial())
+
+        f = QgsFeature(fields)
+        f.setAttribute("name", "feature 123")
+        layer.dataProvider().addFeatures([f])
+
+        p = QgsProject()
+        p.addMapLayer(layer)
+        p.writeEntry("WFSLayers", "/", [layer.id()])
+
+        request = QgsBufferServerRequest(
+            "http://server.qgis.org/wfs3/collections/aspatial/items.fgb?limit=1"
+        )
+        response = QgsBufferServerResponse()
+        self.server.handleRequest(request, response, p)
+
+        temp_dir = QtCore.QTemporaryDir()
+        temp_path = temp_dir.path()
+        path = os.path.join(temp_path, "aspatial.fgb")
+        with open(path.encode("utf8"), "wb") as f:
+            f.write(response.body())
+        v = QgsVectorLayer(path, "aspatial", "ogr")
+        self.assertTrue(v.isValid())
+        f = next(v.getFeatures())
+        self.assertEqual(f["name"], "feature 123")
+
     def test_invalid_args(self):
         """Test wrong args"""
         project = QgsProject()

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -3040,6 +3040,32 @@ class HandlerException(QgsServerOgcApiHandler):
 class QgsServerOgcAPITest(QgsServerAPITestBase):
     """QGIS OGC API server tests"""
 
+    def testQgsServerOgcApiHandlerLink(self):
+        """Test OGC API handlers header link function"""
+
+        h = Handler1()
+        request = QgsBufferServerRequest(
+            "http://server.qgis.org/services/api1/handlerone?value1=42"
+        )
+        response = QgsBufferServerResponse()
+        project = QgsProject()
+        ctx = QgsServerApiContext(
+            "/services/api1", request, response, project, self.server.serverInterface()
+        )
+        title = 'a title with special chars: èé and "quotes" and back \\ slash'
+        hlink = h.headerLink(
+            ctx,
+            QgsServerOgcApi.Rel.alternate,
+            QgsServerOgcApi.ContentType.JSON,
+            QgsServerOgcApi.Profile.NONE,
+            title,
+        )
+
+        self.assertEqual(
+            hlink,
+            '<http://server.qgis.org/services/api1/handlerone.json?value1=42>; rel="alternate"; title="a title with special chars: èé and \\"quotes\\" and back \\\\ slash"; type="application/json"',
+        )
+
     def testOgcApi(self):
         """Test OGC API"""
 

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -223,7 +223,7 @@ class QgsServerAPITestBase(QgsServerTestBase):
     """QGIS API server tests"""
 
     # Set to True in child classes to re-generate reference files for this class
-    regenerate_api_reference = True
+    regenerate_api_reference = False
 
     def assertEqualBrackets(self, actual, expected):
         """Also counts parenthesis"""

--- a/tests/src/python/test_qgsserver_landingpage.py
+++ b/tests/src/python/test_qgsserver_landingpage.py
@@ -41,7 +41,7 @@ class QgsServerLandingPageTest(QgsServerAPITestBase):
     """QGIS Server Landing Page tests"""
 
     # Set to True in child classes to re-generate reference files for this class
-    # regeregenerate_api_reference = True
+    regenerate_api_reference = False
 
     @classmethod
     def setUpClass(cls):
@@ -120,7 +120,7 @@ class QgsServerLandingPageTest(QgsServerAPITestBase):
         actual_projects = {p["title"]: p for p in actual_j["projects"]}
         expected_projects = {p["title"]: p for p in expected_j["projects"]}
 
-        if self.regeregenerate_api_reference:
+        if self.regenerate_api_reference:
             # Try to change timestamp
             try:
                 content = actual.split("\n")

--- a/tests/src/python/test_qgsserver_response.py
+++ b/tests/src/python/test_qgsserver_response.py
@@ -34,6 +34,38 @@ class QgsServerResponseTest(unittest.TestCase):
         for k, v in response.headers().items():
             self.assertEqual(headers[k], v)
 
+    def test_fullHeaders(self):
+
+        headers = (
+            ("header-key-1", "key-1-value-1"),
+            ("header-key-1", "key-1-value-2"),
+            ("header-key-2", "key-2-value-1"),
+        )
+
+        response = QgsBufferServerResponse()
+        for k, v in headers:
+            response.addHeader(k, v)
+
+        self.assertEqual(
+            response.fullHeaders(),
+            {
+                "header-key-1": ["key-1-value-1", "key-1-value-2"],
+                "header-key-2": ["key-2-value-1"],
+            },
+        )
+        self.assertEqual(
+            response.fullHeader("header-key-1"), ["key-1-value-1", "key-1-value-2"]
+        )
+        self.assertEqual(
+            response.headers(),
+            {"header-key-1": "key-1-value-2", "header-key-2": "key-2-value-1"},
+        )
+        self.assertEqual(response.header("header-key-1"), "key-1-value-2")
+
+        # Test that setHeader overrides the previous value
+        response.setHeader("header-key-1", "key-1-value-3")
+        self.assertEqual(response.fullHeader("header-key-1"), ["key-1-value-3"])
+
     def test_statusCode(self):
         """Test return status HTTP code"""
         response = QgsBufferServerResponse()

--- a/tests/testdata/qgis_server/api/test_wfs3_api_project.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_api_project.json
@@ -702,7 +702,7 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
     },
     "/wfs3/collections/exclude_attribute/items": {
       "get": {
-        "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) or GeoJSON (.json).",
+        "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) GeoJSON (.json) or FlatGeobuf (.fgb).",
         "operationId": "getFeatures_testlayer_èé_2_a5f61891_b949_43e3_ad30_84013fc922de",
         "parameters": [
           {
@@ -806,7 +806,7 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
     },
     "/wfs3/collections/exclude_attribute/items/{featureId}": {
       "get": {
-        "description": "Retrieve a feature with ID {featureId} from the collection with ID {collectionId}; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json).",
+        "description": "Retrieve a feature with ID {featureId} from the collection with ID {collectionId}; use content negotiation or specify a file extension to request HTML (.html), GeoJSON (.json) or FlatGeobuf (.fgb).",
         "operationId": "getFeature_testlayer_èé_2_a5f61891_b949_43e3_ad30_84013fc922de_GET",
         "parameters": [
           {
@@ -895,7 +895,7 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
     },
     "/wfs3/collections/fields_alias/items": {
       "get": {
-        "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) or GeoJSON (.json).",
+        "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) GeoJSON (.json) or FlatGeobuf (.fgb).",
         "operationId": "getFeatures_testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774",
         "parameters": [
           {
@@ -1010,7 +1010,7 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
     },
     "/wfs3/collections/fields_alias/items/{featureId}": {
       "get": {
-        "description": "Retrieve a feature with ID {featureId} from the collection with ID {collectionId}; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json).",
+        "description": "Retrieve a feature with ID {featureId} from the collection with ID {collectionId}; use content negotiation or specify a file extension to request HTML (.html), GeoJSON (.json) or FlatGeobuf (.fgb).",
         "operationId": "getFeature_testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774_GET",
         "parameters": [
           {
@@ -1099,7 +1099,7 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
     },
     "/wfs3/collections/layer1_with_short_name/items": {
       "get": {
-        "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) or GeoJSON (.json).",
+        "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) GeoJSON (.json) or FlatGeobuf (.fgb).",
         "operationId": "getFeatures_testlayer_c0988fd7_97ca_451d_adbc_37ad6d10583a",
         "parameters": [
           {
@@ -1214,7 +1214,7 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
     },
     "/wfs3/collections/layer1_with_short_name/items/{featureId}": {
       "get": {
-        "description": "Retrieve a feature with ID {featureId} from the collection with ID {collectionId}; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json).",
+        "description": "Retrieve a feature with ID {featureId} from the collection with ID {collectionId}; use content negotiation or specify a file extension to request HTML (.html), GeoJSON (.json) or FlatGeobuf (.fgb).",
         "operationId": "getFeature_testlayer_c0988fd7_97ca_451d_adbc_37ad6d10583a_GET",
         "parameters": [
           {
@@ -1303,7 +1303,7 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
     },
     "/wfs3/collections/testlayer èé/items": {
       "get": {
-        "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) or GeoJSON (.json).",
+        "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) GeoJSON (.json) or FlatGeobuf (.fgb).",
         "operationId": "getFeatures_testlayer20150528120452665",
         "parameters": [
           {
@@ -1488,7 +1488,7 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
         ]
       },
       "get": {
-        "description": "Retrieve a feature with ID {featureId} from the collection with ID {collectionId}; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json).",
+        "description": "Retrieve a feature with ID {featureId} from the collection with ID {collectionId}; use content negotiation or specify a file extension to request HTML (.html), GeoJSON (.json) or FlatGeobuf (.fgb).",
         "operationId": "getFeature_testlayer20150528120452665_GET",
         "parameters": [
           {

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_layer1_with_short_name.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_layer1_with_short_name.json
@@ -50,6 +50,12 @@ Content-Type: application/json
       "type": "text/html"
     },
     {
+      "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.fgb",
+      "rel": "items",
+      "title": "A Layer1 with a short name items as FLATGEOBUF",
+      "type": "application/flatgeobuf"
+    },
+    {
       "href": "http://server.qgis.org/?request=DescribeFeatureType&typename=layer1_with_short_name&service=WFS&version=2.0",
       "rel": "describedBy",
       "title": "Schema for A Layer1 with a short name",

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_points_timefilters.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_points_timefilters.json
@@ -55,6 +55,12 @@ Content-Type: application/json
       "type": "text/html"
     },
     {
+      "href": "http://server.qgis.org/wfs3/collections/points/items.fgb",
+      "rel": "items",
+      "title": "points items as FLATGEOBUF",
+      "type": "application/flatgeobuf"
+    },
+    {
       "href": "http://server.qgis.org/?request=DescribeFeatureType&typename=points&service=WFS&version=2.0",
       "rel": "describedBy",
       "title": "Schema for points",

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.html
@@ -31,6 +31,8 @@
 
     <link rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html" title="A test wfs vector layer èé items as HTML" type="text/html">
 
+    <link rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb" title="A test wfs vector layer èé items as FLATGEOBUF" type="application/flatgeobuf">
+
     <link rel="describedBy" href="http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer_èé&service=WFS&version=2.0" title="Schema for A test wfs vector layer èé" type="application/xml">
 
 
@@ -79,6 +81,8 @@
         
         
         
+        
+        
         ">A test wfs vector layer èé</a></h1>
         <h3>Available CRSs</h3>
         <ul>
@@ -118,6 +122,10 @@
             
                 
                 <li><a rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html">A test wfs vector layer èé items as HTML</a></li>
+                
+            
+                
+                <li><a rel="items" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb">A test wfs vector layer èé items as FLATGEOBUF</a></li>
                 
             
                 

--- a/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collection_testlayer_èé.json
@@ -50,6 +50,12 @@ Content-Type: application/json
       "type": "text/html"
     },
     {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb",
+      "rel": "items",
+      "title": "A test wfs vector layer èé items as FLATGEOBUF",
+      "type": "application/flatgeobuf"
+    },
+    {
       "href": "http://server.qgis.org/?request=DescribeFeatureType&typename=testlayer_èé&service=WFS&version=2.0",
       "rel": "describedBy",
       "title": "Schema for A test wfs vector layer èé",

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_3857.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_3857.json
@@ -985,6 +985,12 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
+      "href": "http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3857",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
+    },
+    {
       "href": "http://server.qgis.org/wfs3/collections/as-areas-short-name/items?crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3857&offset=10&limit=10",
       "rel": "next",
       "title": "Next page",

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_4326.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as-areas-short-name_4326.json
@@ -985,6 +985,12 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
+      "href": "http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F4326",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
+    },
+    {
       "href": "http://server.qgis.org/wfs3/collections/as-areas-short-name/items?crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F4326&offset=10&limit=10",
       "rel": "next",
       "title": "Next page",

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_1.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_1.html
@@ -27,6 +27,8 @@
 
     <link rel="self" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=0&limit=6" title="Retrieve the features of the collection as HTML" type="text/html">
 
+    <link rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=0&limit=6" title="Retrieve the features of the collection as FLATGEOBUF" type="application/flatgeobuf">
+
     <link rel="next" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=6&limit=6" title="Next page" type="text/html">
 
     <link rel="first" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=0&limit=6" title="First page" type="text/html">
@@ -56,6 +58,8 @@
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
               
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.geojson?offset=0&limit=6" target="_blank">GEOJSON</a></li>
+              
+                  <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=0&limit=6" target="_blank">FLATGEOBUF</a></li>
               
               </ul>
           </div>

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_2.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_2.html
@@ -27,6 +27,8 @@
 
     <link rel="self" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=6&limit=6" title="Retrieve the features of the collection as HTML" type="text/html">
 
+    <link rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=6&limit=6" title="Retrieve the features of the collection as FLATGEOBUF" type="application/flatgeobuf">
+
     <link rel="prev" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=0&limit=6" title="Previous page" type="text/html">
 
     <link rel="next" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=12&limit=6" title="Next page" type="text/html">
@@ -58,6 +60,8 @@
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
               
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.geojson?offset=6&limit=6" target="_blank">GEOJSON</a></li>
+              
+                  <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=6&limit=6" target="_blank">FLATGEOBUF</a></li>
               
               </ul>
           </div>

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_3.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_3.html
@@ -27,6 +27,8 @@
 
     <link rel="self" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=12&limit=6" title="Retrieve the features of the collection as HTML" type="text/html">
 
+    <link rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=12&limit=6" title="Retrieve the features of the collection as FLATGEOBUF" type="application/flatgeobuf">
+
     <link rel="prev" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=6&limit=6" title="Previous page" type="text/html">
 
     <link rel="next" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=18&limit=6" title="Next page" type="text/html">
@@ -58,6 +60,8 @@
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
               
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.geojson?offset=12&limit=6" target="_blank">GEOJSON</a></li>
+              
+                  <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=12&limit=6" target="_blank">FLATGEOBUF</a></li>
               
               </ul>
           </div>

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_4.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_4.html
@@ -27,6 +27,8 @@
 
     <link rel="self" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=18&limit=6" title="Retrieve the features of the collection as HTML" type="text/html">
 
+    <link rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=18&limit=6" title="Retrieve the features of the collection as FLATGEOBUF" type="application/flatgeobuf">
+
     <link rel="prev" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=12&limit=6" title="Previous page" type="text/html">
 
     <link rel="next" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=24&limit=6" title="Next page" type="text/html">
@@ -58,6 +60,8 @@
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
               
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.geojson?offset=18&limit=6" target="_blank">GEOJSON</a></li>
+              
+                  <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=18&limit=6" target="_blank">FLATGEOBUF</a></li>
               
               </ul>
           </div>

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_5.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_5.html
@@ -27,6 +27,8 @@
 
     <link rel="self" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=24&limit=6" title="Retrieve the features of the collection as HTML" type="text/html">
 
+    <link rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=24&limit=6" title="Retrieve the features of the collection as FLATGEOBUF" type="application/flatgeobuf">
+
     <link rel="prev" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=18&limit=6" title="Previous page" type="text/html">
 
     <link rel="next" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=30&limit=6" title="Next page" type="text/html">
@@ -58,6 +60,8 @@
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
               
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.geojson?offset=24&limit=6" target="_blank">GEOJSON</a></li>
+              
+                  <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=24&limit=6" target="_blank">FLATGEOBUF</a></li>
               
               </ul>
           </div>

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_6.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_6.html
@@ -27,6 +27,8 @@
 
     <link rel="self" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=30&limit=6" title="Retrieve the features of the collection as HTML" type="text/html">
 
+    <link rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=30&limit=6" title="Retrieve the features of the collection as FLATGEOBUF" type="application/flatgeobuf">
+
     <link rel="prev" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=24&limit=6" title="Previous page" type="text/html">
 
     <link rel="next" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=36&limit=6" title="Next page" type="text/html">
@@ -58,6 +60,8 @@
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
               
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.geojson?offset=30&limit=6" target="_blank">GEOJSON</a></li>
+              
+                  <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=30&limit=6" target="_blank">FLATGEOBUF</a></li>
               
               </ul>
           </div>

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_7.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_as_areas_short_name_7.html
@@ -27,6 +27,8 @@
 
     <link rel="self" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=36&limit=6" title="Retrieve the features of the collection as HTML" type="text/html">
 
+    <link rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=36&limit=6" title="Retrieve the features of the collection as FLATGEOBUF" type="application/flatgeobuf">
+
     <link rel="prev" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=30&limit=6" title="Previous page" type="text/html">
 
     <link rel="first" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.html?offset=0&limit=6" title="First page" type="text/html">
@@ -56,6 +58,8 @@
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
               
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.geojson?offset=36&limit=6" target="_blank">GEOJSON</a></li>
+              
+                  <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/as-areas-short-name/items.fgb?offset=36&limit=6" target="_blank">FLATGEOBUF</a></li>
               
               </ul>
           </div>

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_exclude_attribute_0.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_exclude_attribute_0.json
@@ -21,6 +21,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve a feature as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/exclude_attribute/items/0.fgb",
+      "rel": "alternate",
+      "title": "Retrieve a feature as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "properties": {

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_layer1_with_short_name_eq_tw_star.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_layer1_with_short_name_eq_tw_star.json
@@ -31,6 +31,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve the features of the collection as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.fgb?name=tw*",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "numberMatched": 1,

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_layer1_with_short_name_eq_two.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_layer1_with_short_name_eq_two.json
@@ -31,6 +31,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve the features of the collection as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.fgb?name=two",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "numberMatched": 1,

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_layer1_with_short_name_sort_by_name.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_layer1_with_short_name_sort_by_name.json
@@ -63,6 +63,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve the features of the collection as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.fgb?sortby=name",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "numberMatched": 3,

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_layer1_with_short_name_sort_by_name_asc.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_layer1_with_short_name_sort_by_name_asc.json
@@ -63,6 +63,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve the features of the collection as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.fgb?sortby=name&sortdesc=0",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "numberMatched": 3,

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_layer1_with_short_name_sort_by_name_desc.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_layer1_with_short_name_sort_by_name_desc.json
@@ -63,6 +63,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve the features of the collection as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.fgb?sortby=name&sortdesc=1",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "numberMatched": 3,

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer25832_bbox.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer25832_bbox.json
@@ -29,6 +29,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve the features of the collection as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer25832/items.fgb?bbox=7.16305252070271603,44.75906320523620963,7.3418755610416051,44.87555723151492515",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "numberMatched": 1,

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé.html
@@ -27,6 +27,8 @@
 
     <link rel="self" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html" title="Retrieve the features of the collection as HTML" type="text/html">
 
+    <link rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb" title="Retrieve the features of the collection as FLATGEOBUF" type="application/flatgeobuf">
+
 
 
     <title>Features in layer A test wfs vector layer èé</title>
@@ -50,6 +52,8 @@
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
               
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson" target="_blank">GEOJSON</a></li>
+              
+                  <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb" target="_blank">FLATGEOBUF</a></li>
               
               </ul>
           </div>

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé.json
@@ -63,6 +63,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve the features of the collection as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "numberMatched": 3,

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_1.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_1.html
@@ -27,6 +27,8 @@
 
     <link rel="self" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.html?limit=0" title="Retrieve the features of the collection as HTML" type="text/html">
 
+    <link rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb?limit=0" title="Retrieve the features of the collection as FLATGEOBUF" type="application/flatgeobuf">
+
 
 
     <title>Features in layer A test wfs vector layer èé</title>
@@ -50,6 +52,8 @@
               <ul class="list-unstyled list-separated m-0 p-0 text-muted">
               
                   <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.geojson?limit=0" target="_blank">GEOJSON</a></li>
+              
+                  <li><a rel="alternate" href="http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb?limit=0" target="_blank">FLATGEOBUF</a></li>
               
               </ul>
           </div>

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_bbox.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_bbox.json
@@ -31,6 +31,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve the features of the collection as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb?bbox=8.203495,44.901482,8.203497,44.901484",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "numberMatched": 1,

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_bbox_3857.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_bbox_3857.json
@@ -47,6 +47,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve the features of the collection as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb?bbox=913191,5606014,913234,5606029&bbox-crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3857",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "numberMatched": 2,

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_crs_3857.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_crs_3857.json
@@ -63,6 +63,12 @@ Content-Type: application/geo+json
       "rel": "alternate",
       "title": "Retrieve the features of the collection as HTML",
       "type": "text/html"
+    },
+    {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb?crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3857",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
     }
   ],
   "numberMatched": 3,

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1.json
@@ -33,6 +33,12 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb?limit=1",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
+    },
+    {
       "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?offset=1&limit=1",
       "rel": "next",
       "title": "Next page",

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_1.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_1.json
@@ -33,6 +33,12 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb?limit=1&offset=1",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
+    },
+    {
       "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?offset=0&limit=1",
       "rel": "prev",
       "title": "Previous page",

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_2.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_1_offset_2.json
@@ -33,6 +33,12 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb?limit=1&offset=2",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
+    },
+    {
       "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?offset=1&limit=1",
       "rel": "prev",
       "title": "Previous page",

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_2.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_items_testlayer_èé_limit_2.json
@@ -49,6 +49,12 @@ Content-Type: application/geo+json
       "type": "text/html"
     },
     {
+      "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb?limit=2",
+      "rel": "alternate",
+      "title": "Retrieve the features of the collection as FLATGEOBUF",
+      "type": "application/flatgeobuf"
+    },
+    {
       "href": "http://server.qgis.org/wfs3/collections/testlayer èé/items?offset=2&limit=2",
       "rel": "next",
       "title": "Next page",

--- a/tests/testdata/qgis_server/api/test_wfs3_collections_project.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_collections_project.json
@@ -39,6 +39,12 @@ Content-Type: application/json
           "rel": "items",
           "title": "A test wfs vector layer èé as HTML",
           "type": "text/html"
+        },
+        {
+          "href": "http://server.qgis.org/wfs3/collections/testlayer%20%C3%A8%C3%A9/items.fgb",
+          "rel": "items",
+          "title": "A test wfs vector layer èé as FlatGeobuf",
+          "type": "application/flatgeobuf"
         }
       ],
       "title": "A test wfs vector layer èé"
@@ -80,6 +86,12 @@ Content-Type: application/json
           "rel": "items",
           "title": "A Layer1 with a short name as HTML",
           "type": "text/html"
+        },
+        {
+          "href": "http://server.qgis.org/wfs3/collections/layer1_with_short_name/items.fgb",
+          "rel": "items",
+          "title": "A Layer1 with a short name as FlatGeobuf",
+          "type": "application/flatgeobuf"
         }
       ],
       "title": "A Layer1 with a short name"
@@ -121,6 +133,12 @@ Content-Type: application/json
           "rel": "items",
           "title": "A test vector layer exclude attrs as HTML",
           "type": "text/html"
+        },
+        {
+          "href": "http://server.qgis.org/wfs3/collections/exclude_attribute/items.fgb",
+          "rel": "items",
+          "title": "A test vector layer exclude attrs as FlatGeobuf",
+          "type": "application/flatgeobuf"
         }
       ],
       "title": "A test vector layer exclude attrs"
@@ -162,6 +180,12 @@ Content-Type: application/json
           "rel": "items",
           "title": "A test vector layer with aliases as HTML",
           "type": "text/html"
+        },
+        {
+          "href": "http://server.qgis.org/wfs3/collections/fields_alias/items.fgb",
+          "rel": "items",
+          "title": "A test vector layer with aliases as FlatGeobuf",
+          "type": "application/flatgeobuf"
         }
       ],
       "title": "A test vector layer with aliases"


### PR DESCRIPTION
## Description

Partial implementation of QEP 414 https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-414-server-oapif-jsonfg-flatgeobuf.md

- Add FlatGeobuf export format to QGIS Server OAPIF service
- fix #65858 by checking query string parameters in a case-insensitive manner
- fix unreported issue with the lack of multiple header support in QgsServerResponse classes (only a single header per name was stored)
- pave the road for OAPIF Profiles to support JSON-FG

Funded by: QGIS user group Germany (QGIS Anwendergruppe Deutschland e.V.)

## AI tool usage

 - [x] AI tool Copilot supported my development of this PR by providing autocomplete suggestions within QT-Creator. Limited to a max of 3-4 lines of code each time except for the tests where the autocomplete suggestions max hit a dozen of lines.  No vibe coding or command prompt was used.

