### PR TITLE
Silence uninitialized var warning

### DIFF
--- a/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
+++ b/src/core/pointcloud/qgspointcloudlayerrenderer.cpp
@@ -229,7 +229,7 @@ bool QgsPointCloudLayerRenderer::render()
     const double overviewSwitchingScale = mRenderer->overviewSwitchingScale();
     const bool zoomedOut = renderExtent.width() > mAverageSubIndexWidth * overviewSwitchingScale || renderExtent.height() > mAverageSubIndexHeight * overviewSwitchingScale;
 
-    bool shouldRenderOverviews, shouldRenderExtents;
+    bool shouldRenderOverviews = false, shouldRenderExtents = false;
     switch ( mRenderer->zoomOutBehavior() )
     {
       case Qgis::PointCloudZoomOutRenderBehavior::RenderOverview:


### PR DESCRIPTION
```
../src/core/pointcloud/qgspointcloudlayerrenderer.cpp: In member function ‘virtual bool QgsPointCloudLayerRenderer::render()’:
../src/core/pointcloud/qgspointcloudlayerrenderer.cpp:266:24: warning: ‘shouldRenderExtents’ may be used uninitialized [-Wmaybe-uninitialized]
  266 |       if ( ( zoomedOut && shouldRenderExtents ) || ( !zoomedOut && ( !pc || !pc.isValid() ) ) )
      |            ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
../src/core/pointcloud/qgspointcloudlayerrenderer.cpp:232:33: note: ‘shouldRenderExtents’ was declared here
  232 |     bool shouldRenderOverviews, shouldRenderExtents;
      |                                 ^~~~~~~~~~~~~~~~~~~

```