### PR TITLE
[vector layers] Do not pass on an invalid text color when applying conditional styling to the attribute table

### DIFF
--- a/src/core/qgsconditionalstyle.cpp
+++ b/src/core/qgsconditionalstyle.cpp
@@ -21,6 +21,7 @@
 #include "qgssymbollayerutils.h"
 
 #include <QPainter>
+#include <QPalette>
 #include <QString>
 
 #include "moc_qgsconditionalstyle.cpp"
@@ -296,9 +297,13 @@ QPixmap QgsConditionalStyle::renderPreview( const QSize &size ) const
   }
 
   if ( validTextColor() )
+  {
     painter.setPen( mTextColor );
+  }
   else
-    painter.setPen( Qt::black );
+  {
+    painter.setPen( QPalette().color( QPalette::Text ) );
+  }
 
   painter.setRenderHint( QPainter::Antialiasing );
   painter.setFont( font() );

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -811,7 +811,7 @@ QVariant QgsAttributeTableModel::data( const QModelIndex &index, int role ) cons
       {
         if ( role == Qt::BackgroundRole && style.validBackgroundColor() )
           return style.backgroundColor();
-        if ( role == Qt::ForegroundRole )
+        if ( role == Qt::ForegroundRole && style.validTextColor() )
           return style.textColor();
         if ( role == Qt::DecorationRole )
           return style.icon();


### PR DESCRIPTION
## Description

Attribute table's conditional styling was forcing a black text color when a style being applied had an invalid color. That made it play really badly with dark themed QGIS UI. This PR fixes that.