### PR TITLE
qgsexpressionfunction: Fix unused parameter warning without timezone

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1509,6 +1509,7 @@ static QVariant fcnGetTimeZone( const QVariantList &values, const QgsExpressionC
   }
   return QVariant();
 #else
+  Q_UNUSED( values )
   parent->setEvalErrorString( QObject::tr( "Qt is built without Qt timezone support, cannot use fcnGetTimeZone" ) );
   return QVariant();
 #endif
@@ -1526,6 +1527,7 @@ static QVariant fcnSetTimeZone( const QVariantList &values, const QgsExpressionC
   }
   return QVariant();
 #else
+  Q_UNUSED( values )
   parent->setEvalErrorString( QObject::tr( "Qt is built without Qt timezone support, cannot use fcnSetTimeZone" ) );
   return QVariant();
 #endif
@@ -1542,6 +1544,7 @@ static QVariant fcnConvertTimeZone( const QVariantList &values, const QgsExpress
   }
   return QVariant();
 #else
+  Q_UNUSED( values )
   parent->setEvalErrorString( QObject::tr( "Qt is built without Qt timezone support, cannot use fcnConvertTimeZone" ) );
   return QVariant();
 #endif
@@ -1557,6 +1560,7 @@ static QVariant fcnTimeZoneToId( const QVariantList &values, const QgsExpression
   }
   return QVariant();
 #else
+  Q_UNUSED( values )
   parent->setEvalErrorString( QObject::tr( "Qt is built without Qt timezone support, cannot use fcnTimeZoneToId" ) );
   return QVariant();
 #endif


### PR DESCRIPTION
## Description

```
/home/runner/work/QGIS/QGIS/src/core/expression/qgsexpressionfunction.cpp:1502:53: warning: unused parameter 'values' [-Wunused-parameter]
 1502 | static QVariant fcnGetTimeZone( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
      |                                                     ^
/home/runner/work/QGIS/QGIS/src/core/expression/qgsexpressionfunction.cpp:1517:53: warning: unused parameter 'values' [-Wunused-parameter]
 1517 | static QVariant fcnSetTimeZone( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
      |                                                     ^
/home/runner/work/QGIS/QGIS/src/core/expression/qgsexpressionfunction.cpp:1534:57: warning: unused parameter 'values' [-Wunused-parameter]
 1534 | static QVariant fcnConvertTimeZone( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
      |                                                         ^
/home/runner/work/QGIS/QGIS/src/core/expression/qgsexpressionfunction.cpp:1550:54: warning: unused parameter 'values' [-Wunused-parameter]
 1550 | static QVariant fcnTimeZoneToId( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
      |               
```

## AI tool usage

 No AI Tool used