### PR TITLE
Fix Python and Qt slots conflict when using CMAKE_UNITY_BUILD

### DIFF
--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -20,7 +20,9 @@
 #undef _DEBUG
 #endif
 #endif
+#undef slots
 #include <Python.h>
+#define slots Q_SLOTS
 
 #include "qgspythonutilsimpl.h"
 


### PR DESCRIPTION
First time tried to compile with CMAKE_UNITY_BUILD and got this:

```
qgispython.dir/Unity/unity_0_cxx.cxx.o.d -o src/python/CMakeFiles/qgispython.dir/Unity/unity_0_cxx.cxx.o -c /home/viperminiq/dev/QGISbuilds/materials-instancing/buildDebug/src/python/C
MakeFiles/qgispython.dir/Unity/unity_0_cxx.cxx 
In file included from /usr/include/python3.14/Python.h:82, 
                from /home/viperminiq/dev/QGISbuilds/materials-instancing/src/python/qgspythonutilsimpl.cpp:23, 
                from src/python/CMakeFiles/qgispython.dir/Unity/unity_0_cxx.cxx:10: 
/usr/include/python3.14/object.h:384:23: error: expected unqualified-id before ';' token 
 384 |    PyType_Slot *slots; /* terminated by slot==0. */
```


https://lindevs.com/embed-python-header-in-qt-by-resolving-keyword-conflict

I took the code from a comment in: https://github.com/pytorch/pytorch/issues/19405
(in the discussion, there are more links to the problem)