### PR TITLE
[wfs3] Return partial collections list when ACL denies a layer

### DIFF
--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -475,6 +475,10 @@ void QgsWfs3CollectionsHandler::handleRequest( const QgsServerApiContext &contex
       {
         // Skip non-published layers
       }
+      catch ( QgsServerApiPermissionDeniedException & )
+      {
+        // Skip layers denied by access control filters and return a partial list
+      }
     }
   }
 

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -757,6 +757,34 @@ class QgsServerAPITest(QgsServerAPITestBase):
         ids = [l["id"] for l in jresult["collections"]]
         self.assertNotIn("layer1_with_short_name", ids)
 
+    def test_wfs3_collections_json_partial_access_control(self):
+        """Test WFS3 API collections returns partial list when one layer is denied"""
+
+        request = QgsBufferServerRequest("http://server.qgis.org/wfs3/collections.json")
+        project = QgsProject()
+        project.read(
+            os.path.join(self.temporary_path, "qgis_server", "test_project_api.qgs")
+        )
+
+        server = QgsServer()
+
+        # Access control filter to exclude one published layer
+        acfilter = RestrictedLayerAccessControl(
+            server.serverInterface(),
+            ["testlayer20150528120452665"],
+        )
+        server.serverInterface().registerAccessControl(acfilter, 100)
+
+        response = QgsBufferServerResponse()
+        server.handleRequest(request, response, project)
+        self.assertEqual(response.headers()["Content-Type"], "application/json")
+        self.assertEqual(response.statusCode(), 200)
+        result = bytes(response.body()).decode("utf8")
+        jresult = json.loads(result)
+        ids = [l["id"] for l in jresult["collections"]]
+        self.assertNotIn("testlayer èé", ids)
+        self.assertIn("layer1_with_short_name", ids)
+
     def test_wfs3_collections_html(self):
         """Test WFS3 API collections in html format"""
         request = QgsBufferServerRequest("http://server.qgis.org/wfs3/collections.html")


### PR DESCRIPTION
Avoid failing /collections with a global 404 when an access control plugin blocks one published layer, and verify JSON/HTML responses keep returning accessible collections.

## Description

When we have an access control plugin that allows us to access to only some layers,
want to access to wgs3/collections (OGCAPI Feature) we get a 404 error instead of getting only the accessible layers.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.