### PR TITLE
Add support for creating 3D symbology from 2D symbology

### DIFF
--- a/python/PyQt6/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
@@ -160,6 +160,8 @@ indicates the scale denominator, e.g. 1000.0 for a 1:1000 map. If set to
 %End
 
         QgsSymbol *symbol();
+
+
         QString label() const;
         bool dependsOnScale() const;
 
@@ -576,6 +578,8 @@ Creates a new rule based renderer from an SLD XML element.
 
 
     QgsRuleBasedRenderer::Rule *rootRule();
+
+
 
 
     static void refineRuleCategories( QgsRuleBasedRenderer::Rule *initialRule, QgsCategorizedSymbolRenderer *r );

--- a/src/3d/symbols/qgs3dsymbolutils.cpp
+++ b/src/3d/symbols/qgs3dsymbolutils.cpp
@@ -15,12 +15,26 @@
 
 #include "qgs3dsymbolutils.h"
 
+#include "qgs3dsymbolregistry.h"
 #include "qgsabstract3dsymbol.h"
 #include "qgsabstractmaterialsettings.h"
+#include "qgsapplication.h"
+#include "qgsfillsymbol.h"
+#include "qgsfillsymbollayer.h"
 #include "qgsline3dsymbol.h"
+#include "qgslinesymbol.h"
+#include "qgslinesymbollayer.h"
 #include "qgslogger.h"
+#include "qgsmarkersymbol.h"
+#include "qgsmarkersymbollayer.h"
+#include "qgsmetalroughmaterialsettings.h"
+#include "qgsmetalroughtexturedmaterialsettings.h"
+#include "qgsphongmaterialsettings.h"
+#include "qgsphongtexturedmaterialsettings.h"
 #include "qgspoint3dsymbol.h"
 #include "qgspolygon3dsymbol.h"
+#include "qgssymbol.h"
+#include "qgsvectorlayer.h"
 
 #include <QColor>
 #include <QPainter>
@@ -260,4 +274,110 @@ bool Qgs3DSymbolUtils::copyVectorSymbolMaterial( const QgsAbstract3DSymbol *from
   }
 
   return copied;
+}
+
+std::unique_ptr<QgsAbstract3DSymbol> Qgs3DSymbolUtils::create3DSymbolFrom2D( const QgsVectorLayer *vLayer, const QgsSymbol *symbol2D, const QgsRenderContext &context )
+{
+  if ( !symbol2D || !vLayer )
+  {
+    return nullptr;
+  }
+
+  auto symbol3D = std::unique_ptr<QgsAbstract3DSymbol>( QgsApplication::symbol3DRegistry()->defaultSymbolForGeometryType( vLayer->geometryType() ) );
+  symbol3D->setDefaultPropertiesFromLayer( vLayer );
+
+  // set the main color
+  Qgs3DSymbolUtils::setVectorSymbolBaseColor( symbol3D.get(), symbol2D->color() );
+  if ( symbol3D->type() == "line"_L1 )
+  {
+    QgsLine3DSymbol *lineSymbol3D = dynamic_cast<QgsLine3DSymbol *>( symbol3D.get() );
+    // lines geometry type - retrieve its width
+    if ( const QgsLineSymbol *lineSymbol = dynamic_cast<const QgsLineSymbol *>( symbol2D ) )
+    {
+      if ( lineSymbol->symbolLayerCount() > 0 )
+      {
+        const QgsSymbolLayer *symbolLayer = lineSymbol->symbolLayer( 0 );
+        if ( const QgsSimpleLineSymbolLayer *simpleLineLayer = dynamic_cast<const QgsSimpleLineSymbolLayer *>( symbolLayer ) )
+        {
+          const double lineWidthPixels = std::max( 1.0, context.convertToPainterUnits( simpleLineLayer->width(), simpleLineLayer->widthUnit() ) );
+          lineSymbol3D->setWidth( static_cast<float>( lineWidthPixels ) );
+        }
+      }
+    }
+  }
+  else if ( symbol3D->type() == "point"_L1 )
+  {
+    QgsPoint3DSymbol *pointSymbol3D = dynamic_cast<QgsPoint3DSymbol *>( symbol3D.get() );
+    if ( const QgsMarkerSymbol *markerSymbol = dynamic_cast<const QgsMarkerSymbol *>( symbol2D ) )
+    {
+      if ( markerSymbol->symbolLayerCount() > 0 )
+      {
+        const QgsSymbolLayer *symbolLayer = markerSymbol->symbolLayer( 0 );
+        if ( const QgsSimpleMarkerSymbolLayer *simpleMarkerLayer = dynamic_cast<const QgsSimpleMarkerSymbolLayer *>( symbolLayer ) )
+        {
+          const double sizeMapUnits = std::max( 1.0, context.convertToMapUnits( markerSymbol->size(), markerSymbol->sizeUnit() ) );
+
+          switch ( simpleMarkerLayer->shape() )
+          {
+            case Qgis::MarkerShape::Circle:
+            {
+              pointSymbol3D->setShape( Qgis::Point3DShape::Sphere );
+              QVariantMap vmSphere;
+              vmSphere[u"radius"_s] = sizeMapUnits / 2.;
+              pointSymbol3D->setShapeProperties( vmSphere );
+              break;
+            }
+            case Qgis::MarkerShape::Square:
+            {
+              pointSymbol3D->setShape( Qgis::Point3DShape::Cube );
+              QVariantMap vmCube;
+              vmCube[u"size"_s] = sizeMapUnits;
+              pointSymbol3D->setShapeProperties( vmCube );
+              break;
+            }
+
+            case Qgis::MarkerShape::Triangle:
+            case Qgis::MarkerShape::EquilateralTriangle:
+            {
+              QVariantMap vmCone;
+              vmCone[u"length"_s] = sizeMapUnits;
+              vmCone[u"topRadius"_s] = sizeMapUnits / 10.;
+              vmCone[u"bottomRadius"_s] = sizeMapUnits / 2.;
+              pointSymbol3D->setShapeProperties( vmCone );
+              pointSymbol3D->setShape( Qgis::Point3DShape::Cone );
+              break;
+            }
+
+            default:
+              break;
+          }
+        }
+      }
+    }
+  }
+
+  // handle opacity
+  QgsAbstractMaterialSettings *materialSettings = symbol3D->materialSettings();
+  if ( materialSettings->type() == "phong"_L1 )
+  {
+    QgsPhongMaterialSettings *phongSettings = dynamic_cast<QgsPhongMaterialSettings *>( materialSettings );
+    phongSettings->setOpacity( symbol2D->opacity() );
+  }
+  else if ( materialSettings->type() == "phongtextured"_L1 )
+  {
+    QgsPhongTexturedMaterialSettings *phongTexturedSettings = dynamic_cast<QgsPhongTexturedMaterialSettings *>( materialSettings );
+    phongTexturedSettings->setOpacity( symbol2D->opacity() );
+  }
+  else if ( materialSettings->type() == "metalroughtextured"_L1 )
+  {
+    QgsMetalRoughTexturedMaterialSettings *metalTexturedSettings = dynamic_cast<QgsMetalRoughTexturedMaterialSettings *>( materialSettings );
+    metalTexturedSettings->setOpacity( symbol2D->opacity() );
+  }
+  else if ( materialSettings->type() == "metalrough"_L1 )
+  {
+    QgsMetalRoughMaterialSettings *metalSettings = dynamic_cast<QgsMetalRoughMaterialSettings *>( materialSettings );
+    metalSettings->setOpacity( symbol2D->opacity() );
+  }
+
+  return symbol3D;
 }

--- a/src/3d/symbols/qgs3dsymbolutils.h
+++ b/src/3d/symbols/qgs3dsymbolutils.h
@@ -25,6 +25,8 @@
 #define SIP_NO_FILE
 
 class QgsAbstract3DSymbol;
+class QgsVectorLayer;
+class QgsSymbol;
 
 /**
  * \ingroup qgis_3d
@@ -77,6 +79,25 @@ class _3D_EXPORT Qgs3DSymbolUtils
      * \returns TRUE if the material properties were successfully copied, FALSE otherwise.
      */
     static bool copyVectorSymbolMaterial( const QgsAbstract3DSymbol *fromSymbol, QgsAbstract3DSymbol *toSymbol );
+
+    /**
+     * Creates a 3D symbol from a 2D symbol.
+     *
+     * The generated 3D symbol attempts to preserve the common visual
+     * properties of the input 2D symbol:
+     *
+     * - base color
+     * - opacity
+     * - marker size and basic marker shapes for point layers
+     * - line width for line layers
+     * - polygon edge settings for polygon layers
+     *
+     * \param vLayer the vector layer
+     * \param symbol2D the input 2D symbol
+     * \param context the rendering context
+     * \returns a 3D symbol, or nullptr if creation failed
+     */
+    static std::unique_ptr<QgsAbstract3DSymbol> create3DSymbolFrom2D( const QgsVectorLayer *vLayer, const QgsSymbol *symbol2D, const QgsRenderContext &context );
 };
 
 #endif // QGS3DSYMBOLUTILS_H

--- a/src/app/3d/qgscategorized3drendererwidget.cpp
+++ b/src/app/3d/qgscategorized3drendererwidget.cpp
@@ -15,6 +15,7 @@
 
 #include "qgscategorized3drendererwidget.h"
 
+#include "qgisapp.h"
 #include "qgs3dsymbolregistry.h"
 #include "qgs3dsymbolutils.h"
 #include "qgsabstract3dsymbol.h"
@@ -153,6 +154,7 @@ QgsCategorized3DRendererWidget::QgsCategorized3DRendererWidget( QWidget *parent 
   connect( mBtnDeleteAllCategories, &QAbstractButton::clicked, this, &QgsCategorized3DRendererWidget::deleteAllCategories );
   connect( mBtnDeleteUnusedCategories, &QAbstractButton::clicked, this, &QgsCategorized3DRendererWidget::deleteUnusedCategories );
   connect( mBtnAddCategory, &QAbstractButton::clicked, this, &QgsCategorized3DRendererWidget::addCategory );
+  connect( mBtnUpdateCategoriesFrom2D, &QAbstractButton::clicked, this, &QgsCategorized3DRendererWidget::updateCategoriesFrom2D );
 
   connect( mBtnColorRamp, &QgsColorRampButton::colorRampChanged, this, &QgsCategorized3DRendererWidget::applyColorRamp );
 }
@@ -217,6 +219,16 @@ void QgsCategorized3DRendererWidget::updateUiFromRenderer()
   if ( mRenderer->sourceColorRamp() )
   {
     whileBlocking( mBtnColorRamp )->setColorRamp( mRenderer->sourceColorRamp() );
+  }
+
+  if ( mLayer )
+  {
+    QgsFeatureRenderer *renderer2D = mLayer->renderer();
+    const bool hasCategorizedSymbol2D = renderer2D && renderer2D->type() == "categorizedSymbol"_L1;
+
+    mBtnUpdateCategoriesFrom2D->setEnabled( hasCategorizedSymbol2D );
+    const QString toolTip = hasCategorizedSymbol2D ? QString() : tr( "Requires a categorized 2D renderer" );
+    mBtnUpdateCategoriesFrom2D->setToolTip( toolTip );
   }
 }
 
@@ -479,6 +491,94 @@ void QgsCategorized3DRendererWidget::addCategory()
   const Qgs3DRendererCategory category( QVariant(), symbol->clone(), true );
   mModel->addCategory( category );
   emit widgetChanged();
+}
+
+void QgsCategorized3DRendererWidget::updateCategoriesFrom2D()
+{
+  if ( !mModel || !mLayer )
+  {
+    return;
+  }
+
+  QgsFeatureRenderer *renderer2D = mLayer->renderer();
+  if ( renderer2D && renderer2D->type() == "categorizedSymbol"_L1 )
+  {
+    const QgsCategorizedSymbolRenderer *categorizedRenderer2D = dynamic_cast<const QgsCategorizedSymbolRenderer *>( renderer2D );
+    if ( mRenderer->classAttribute() != categorizedRenderer2D->classAttribute() )
+    {
+      // If the categorized attribute has changed, rebuild the whole
+      // renderer from the 2D categorized renderer, as existing 3D categories
+      // are no longer meaningful.
+      QgsRenderContext context = QgsRenderContext::fromMapSettings( QgisApp::instance()->mapCanvas()->mapSettings() );
+      QList<Qgs3DRendererCategory> categories3D;
+      for ( const QgsRendererCategory &category2D : categorizedRenderer2D->categories() )
+      {
+        std::unique_ptr<QgsAbstract3DSymbol> symbol3D = Qgs3DSymbolUtils::create3DSymbolFrom2D( mLayer, category2D.symbol(), context );
+        Qgs3DRendererCategory category3D( category2D.value(), symbol3D.release(), category2D.renderState() );
+        categories3D.append( category3D );
+      }
+
+      auto newRenderer3D = std::make_unique<QgsCategorized3DRenderer>( categorizedRenderer2D->classAttribute(), categories3D );
+      std::unique_ptr<QgsAbstract3DSymbol> sourceSymbol3D = Qgs3DSymbolUtils::create3DSymbolFrom2D( mLayer, categorizedRenderer2D->sourceSymbol(), context );
+      newRenderer3D->setSourceSymbol( sourceSymbol3D.release() );
+      if ( categorizedRenderer2D->sourceColorRamp() )
+      {
+        newRenderer3D->setSourceColorRamp( categorizedRenderer2D->sourceColorRamp()->clone() );
+      }
+      mRenderer = std::move( newRenderer3D );
+      mCategorizedSymbol.reset( mRenderer->sourceSymbol()->clone() );
+      mModel->setRenderer( mRenderer.get() );
+
+      updateUiFromRenderer();
+    }
+    else
+    {
+      // Same class attribute.
+      // Add missing categories from the 2D renderer
+      // and remove 3D categories which do not exist in the 2D renderer.
+      QSet<QVariant> existing3DCategoriesValues;
+      for ( const Qgs3DRendererCategory &category3D : mRenderer->categories() )
+      {
+        existing3DCategoriesValues.insert( category3D.value() );
+      }
+
+      QgsRenderContext context = QgsRenderContext::fromMapSettings( QgisApp::instance()->mapCanvas()->mapSettings() );
+      QSet<QVariant> categories2DValues;
+      for ( const QgsRendererCategory &category2D : categorizedRenderer2D->categories() )
+      {
+        categories2DValues.insert( category2D.value() );
+
+        // Add categories which exist in the 2D renderer but are missing
+        // from the 3D renderer.
+        if ( !existing3DCategoriesValues.contains( category2D.value() ) )
+        {
+          std::unique_ptr<QgsAbstract3DSymbol> symbol3D = Qgs3DSymbolUtils::create3DSymbolFrom2D( mLayer, category2D.symbol(), context );
+          std::unique_ptr<QgsAbstract3DSymbol> newCatSymbol( mCategorizedSymbol->clone() );
+          Qgs3DSymbolUtils::copyVectorSymbolMaterial( symbol3D.get(), newCatSymbol.get() );
+          Qgs3DRendererCategory category3D( category2D.value(), newCatSymbol.release(), category2D.renderState() );
+          mModel->addCategory( category3D );
+        }
+      }
+
+      // Remove 3D categories which do not exist in the 2D renderer.
+      QList<int> categoriesToDelete;
+      for ( int i = static_cast<int>( mRenderer->categories().count() ) - 1; i >= 0; --i )
+      {
+        const Qgs3DRendererCategory &category3D = mRenderer->categories().at( i );
+        if ( !categories2DValues.contains( category3D.value() ) )
+        {
+          categoriesToDelete.append( i );
+        }
+      }
+      if ( !categoriesToDelete.isEmpty() )
+      {
+        mModel->deleteRows( categoriesToDelete );
+      }
+
+      mModel->updateSymbology();
+      emit widgetChanged();
+    }
+  }
 }
 
 Qgs3DCategoryList QgsCategorized3DRendererWidget::selectedCategoryList() const

--- a/src/app/3d/qgscategorized3drendererwidget.h
+++ b/src/app/3d/qgscategorized3drendererwidget.h
@@ -67,6 +67,7 @@ class QgsCategorized3DRendererWidget : public QgsPanelWidget, private Ui::QgsCat
     void categoriesDoubleClicked( const QModelIndex &idx );
     void addCategory();
     void addCategories();
+    void updateCategoriesFrom2D();
 
     /**
      * Applies the color ramp passed on by the color ramp button

--- a/src/app/3d/qgsrulebased3drendererwidget.cpp
+++ b/src/app/3d/qgsrulebased3drendererwidget.cpp
@@ -15,13 +15,17 @@
 
 #include "qgsrulebased3drendererwidget.h"
 
+#include "qgisapp.h"
 #include "qgs3dsymbolregistry.h"
+#include "qgs3dsymbolutils.h"
 #include "qgs3dutils.h"
 #include "qgsapplication.h"
 #include "qgsexpressionbuilderdialog.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgslogger.h"
+#include "qgsmapcanvas.h"
 #include "qgsrulebased3drenderer.h"
+#include "qgsrulebasedrenderer.h"
 #include "qgssymbol3dwidget.h"
 #include "qgsvectorlayer.h"
 
@@ -57,6 +61,7 @@ QgsRuleBased3DRendererWidget::QgsRuleBased3DRendererWidget( QWidget *parent )
 
   connect( viewRules, &QAbstractItemView::doubleClicked, this, static_cast<void ( QgsRuleBased3DRendererWidget::* )( const QModelIndex & )>( &QgsRuleBased3DRendererWidget::editRule ) );
 
+  connect( mBtnUpdateRulesFrom2D, &QAbstractButton::clicked, this, &QgsRuleBased3DRendererWidget::updateRulesFrom2D );
   connect( btnAddRule, &QAbstractButton::clicked, this, &QgsRuleBased3DRendererWidget::addRule );
   connect( btnEditRule, &QAbstractButton::clicked, this, static_cast<void ( QgsRuleBased3DRendererWidget::* )()>( &QgsRuleBased3DRendererWidget::editRule ) );
   connect( btnRemoveRule, &QAbstractButton::clicked, this, &QgsRuleBased3DRendererWidget::removeRule );
@@ -94,6 +99,16 @@ void QgsRuleBased3DRendererWidget::setLayer( QgsVectorLayer *layer )
   connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsRuleBased3DRendererWidget::widgetChanged );
   connect( mModel, &QAbstractItemModel::rowsInserted, this, &QgsRuleBased3DRendererWidget::widgetChanged );
   connect( mModel, &QAbstractItemModel::rowsRemoved, this, &QgsRuleBased3DRendererWidget::widgetChanged );
+
+  if ( mLayer )
+  {
+    QgsFeatureRenderer *renderer2D = mLayer->renderer();
+    const bool hasRuleBasedSymbol2D = renderer2D && renderer2D->type() == "RuleRenderer"_L1;
+
+    mBtnUpdateRulesFrom2D->setEnabled( hasRuleBasedSymbol2D );
+    const QString toolTip = hasRuleBasedSymbol2D ? QString() : tr( "Requires a rule-based 2D renderer" );
+    mBtnUpdateRulesFrom2D->setToolTip( toolTip );
+  }
 }
 
 void QgsRuleBased3DRendererWidget::setDockMode( bool dockMode )
@@ -111,6 +126,60 @@ void QgsRuleBased3DRendererWidget::setDockMode( bool dockMode )
   QgsPanelWidget::setDockMode( dockMode );
 }
 
+void QgsRuleBased3DRendererWidget::updateRulesFrom2D()
+{
+  QgsFeatureRenderer *renderer2D = mLayer->renderer();
+  // Add missing rules from the 2D renderer
+  // and remove 3D rules which do not exist in the 2D renderer.
+  if ( renderer2D )
+  {
+    const QgsRuleBasedRenderer *ruleRenderer2D = dynamic_cast<const QgsRuleBasedRenderer *>( renderer2D );
+    if ( ruleRenderer2D )
+    {
+      const auto ruleKey = []( const auto *rule ) { return ( rule->isElse() ? u"ELSE|"_s : u"RULE|"_s ) + rule->filterExpression(); };
+
+      QSet<QString> existingRules3DKeys;
+      for ( const QgsRuleBased3DRenderer::Rule *rule3D : mRootRule->children() )
+      {
+        existingRules3DKeys.insert( ruleKey( rule3D ) );
+      }
+
+      QSet<QString> rules2DKeys;
+      QgsRenderContext context = QgsRenderContext::fromMapSettings( QgisApp::instance()->mapCanvas()->mapSettings() );
+      for ( const QgsRuleBasedRenderer::Rule *rule2D : ruleRenderer2D->rootRule()->children() )
+      {
+        const QString rule2DKey = ruleKey( rule2D );
+        rules2DKeys.insert( rule2DKey );
+
+        // Add rules which exist in the 2D renderer but are missing
+        // from the 3D renderer.
+        if ( !existingRules3DKeys.contains( rule2DKey ) )
+        {
+          std::unique_ptr<QgsAbstract3DSymbol> symbol3D = Qgs3DSymbolUtils::create3DSymbolFrom2D( mLayer, rule2D->symbol(), context );
+          QgsRuleBased3DRenderer::Rule *rule3D = new QgsRuleBased3DRenderer::Rule( symbol3D.release(), rule2D->filterExpression(), rule2D->label(), rule2D->isElse() );
+          mModel->insertRule( QModelIndex(), mModel->rowCount(), rule3D );
+        }
+      }
+
+      // Remove 3D rules which do not exist in the 2D renderer.
+      QList<int> rulesToDelete;
+      QgsRuleBased3DRenderer::RuleList children3D = mRootRule->children();
+      for ( int rowIdx = 0; rowIdx < children3D.count(); ++rowIdx )
+      {
+        const QString key3D = ruleKey( children3D[rowIdx] );
+        if ( !rules2DKeys.contains( key3D ) )
+        {
+          rulesToDelete.append( rowIdx );
+        }
+      }
+      std::sort( rulesToDelete.begin(), rulesToDelete.end(), std::greater<int>() );
+      for ( int rowIdx : rulesToDelete )
+      {
+        mModel->removeRows( rowIdx, 1, QModelIndex() );
+      }
+    }
+  }
+}
 
 void QgsRuleBased3DRendererWidget::addRule()
 {

--- a/src/app/3d/qgsrulebased3drendererwidget.h
+++ b/src/app/3d/qgsrulebased3drendererwidget.h
@@ -92,6 +92,7 @@ class QgsRuleBased3DRendererWidget : public QgsPanelWidget, private Ui::QgsRuleB
     void setDockMode( bool dockMode ) override;
 
   protected slots:
+    void updateRulesFrom2D();
     void addRule();
     void editRule();
     void editRule( const QModelIndex &index );

--- a/src/app/3d/qgsvectorlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.cpp
@@ -15,12 +15,16 @@
 
 #include "qgsvectorlayer3drendererwidget.h"
 
+#include "qgisapp.h"
 #include "qgs3dsymbolregistry.h"
+#include "qgs3dsymbolutils.h"
 #include "qgsapplication.h"
 #include "qgscategorized3drenderer.h"
 #include "qgscategorized3drendererwidget.h"
+#include "qgsmapcanvas.h"
 #include "qgsrulebased3drenderer.h"
 #include "qgsrulebased3drendererwidget.h"
+#include "qgssinglesymbolrenderer.h"
 #include "qgssymbol3dwidget.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayer3dpropertieswidget.h"
@@ -89,9 +93,23 @@ void QgsSingleSymbol3DRendererWidget::setLayer( QgsVectorLayer *layer )
   }
   if ( !rendererSet )
   {
-    const std::unique_ptr<QgsAbstract3DSymbol> sym( QgsApplication::symbol3DRegistry()->defaultSymbolForGeometryType( mLayer->geometryType() ) );
-    sym->setDefaultPropertiesFromLayer( mLayer );
-    widgetSymbol->setSymbol( sym.get(), mLayer );
+    std::unique_ptr<QgsAbstract3DSymbol> symbol3D;
+    QgsFeatureRenderer *renderer2D = mLayer->renderer();
+    // Initialize the 3D symbol from the 2D single-symbol renderer
+    // to provide a matching default appearance
+    if ( renderer2D && renderer2D->type() == "singleSymbol"_L1 )
+    {
+      QgsSingleSymbolRenderer *singleRenderer2D = dynamic_cast<QgsSingleSymbolRenderer *>( renderer2D );
+      QgsRenderContext context = QgsRenderContext::fromMapSettings( QgisApp::instance()->mapCanvas()->mapSettings() );
+      symbol3D = Qgs3DSymbolUtils::create3DSymbolFrom2D( mLayer, singleRenderer2D->symbol(), context );
+    }
+    else
+    {
+      symbol3D.reset( QgsApplication::symbol3DRegistry()->defaultSymbolForGeometryType( mLayer->geometryType() ) );
+      symbol3D->setDefaultPropertiesFromLayer( mLayer );
+    }
+
+    widgetSymbol->setSymbol( symbol3D.get(), mLayer );
   }
 }
 

--- a/src/core/symbology/qgsrulebasedrenderer.h
+++ b/src/core/symbology/qgsrulebasedrenderer.h
@@ -217,6 +217,14 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
         bool isScaleOK( double scale ) const;
 
         QgsSymbol *symbol() { return mSymbol.get(); }
+
+        /**
+         * Returns the symbol associated with the rule.
+         *
+         * \since QGIS 4.2
+         */
+        const QgsSymbol *symbol() const SIP_SKIP { return mSymbol.get(); }
+
         QString label() const { return mLabel; }
         bool dependsOnScale() const { return mMaximumScale != 0 || mMinimumScale != 0; }
 
@@ -573,6 +581,16 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
     /////
 
     QgsRuleBasedRenderer::Rule *rootRule() { return mRootRule; }
+
+
+    /**
+     * Returns the root rule of the rule-based renderer.
+     *
+     * The root rule is the top-level container for all renderer rules.
+     *
+     * \since QGIS 4.2
+     */
+    const QgsRuleBasedRenderer::Rule *rootRule() const SIP_SKIP { return mRootRule; }
 
     //////
 

--- a/src/ui/3d/qgscategorized3drendererwidget.ui
+++ b/src/ui/3d/qgscategorized3drendererwidget.ui
@@ -140,6 +140,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="mBtnUpdateCategoriesFrom2D">
+       <property name="text">
+        <string>Update from 2D</string>
+       </property>
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="mBtnAddCategory">
        <property name="toolTip">
         <string>Add</string>

--- a/src/ui/3d/qgsrulebased3drendererwidget.ui
+++ b/src/ui/3d/qgsrulebased3drendererwidget.ui
@@ -54,6 +54,16 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QPushButton" name="mBtnUpdateRulesFrom2D">
+       <property name="text">
+        <string>Update from 2D</string>
+       </property>
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="btnAddRule">
        <property name="toolTip">
         <string>Add rule</string>

--- a/tests/src/3d/testqgs3dsymbolutils.cpp
+++ b/tests/src/3d/testqgs3dsymbolutils.cpp
@@ -15,16 +15,25 @@
 
 #include "qgs3d.h"
 #include "qgs3dsymbolutils.h"
+#include "qgsabstract3dsymbol.h"
+#include "qgsfillsymbol.h"
+#include "qgsfillsymbollayer.h"
 #include "qgsgoochmaterialsettings.h"
 #include "qgsline3dsymbol.h"
+#include "qgslinesymbol.h"
+#include "qgslinesymbollayer.h"
+#include "qgsmarkersymbol.h"
+#include "qgsmarkersymbollayer.h"
 #include "qgsmetalroughmaterialsettings.h"
 #include "qgsnullmaterialsettings.h"
 #include "qgsphongmaterialsettings.h"
 #include "qgsphongtexturedmaterialsettings.h"
 #include "qgspoint3dsymbol.h"
 #include "qgspolygon3dsymbol.h"
+#include "qgsrendercontext.h"
 #include "qgssimplelinematerialsettings.h"
 #include "qgstest.h"
+#include "qgsvectorlayer.h"
 
 #include <QString>
 
@@ -50,6 +59,7 @@ class TestQgs3DSymbolUtils : public QgsTest
     void testVectorSymbolPreviewIcon();
     void testSetVectorSymbolBaseColor();
     void testCopyVectorSymbolMaterial();
+    void testCreate3DSymbolFrom2D();
 };
 
 //runs before all tests
@@ -326,6 +336,109 @@ void TestQgs3DSymbolUtils::testCopyVectorSymbolMaterial()
   QCOMPARE( newPhongSettings->specular().blue(), phongSettings.specular().blue() );
   QCOMPARE( newPhongSettings->opacity(), phongSettings.opacity() );
   QCOMPARE( newPhongSettings->shininess(), phongSettings.shininess() );
+}
+
+void TestQgs3DSymbolUtils::testCreate3DSymbolFrom2D()
+{
+  auto layerPolygon = std::make_unique<QgsVectorLayer>( u"Polygon?crs=EPSG:4326"_s, u"test_polygon"_s, u"memory"_s );
+  QVERIFY( layerPolygon->isValid() );
+  QCOMPARE( layerPolygon->wkbType(), Qgis::WkbType::Polygon );
+
+  QgsMapSettings mapSettings;
+  mapSettings.setOutputSize( QSize( 400, 400 ) );
+  mapSettings.setOutputDpi( 96 );
+  const QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
+
+  // null 2d symbol
+  std::unique_ptr<QgsAbstract3DSymbol> symbol3D = Qgs3DSymbolUtils::create3DSymbolFrom2D( layerPolygon.get(), nullptr, context );
+  QVERIFY( !symbol3D );
+
+  // polygon
+  {
+    auto fillSymbol2D = std::make_unique<QgsFillSymbol>();
+    auto fillSymbolLayer = std::make_unique<QgsSimpleFillSymbolLayer>();
+    fillSymbolLayer->setFillColor( QColor( 0, 255, 255 ) );
+    fillSymbol2D->changeSymbolLayer( 0, fillSymbolLayer.release() );
+
+    auto symbol3D = Qgs3DSymbolUtils::create3DSymbolFrom2D( layerPolygon.get(), fillSymbol2D.get(), context );
+
+    QVERIFY( symbol3D );
+    QCOMPARE( symbol3D->type(), u"polygon"_s );
+    const QgsPolygon3DSymbol *polygonSymbol = dynamic_cast<const QgsPolygon3DSymbol *>( symbol3D.get() );
+    QVERIFY( polygonSymbol );
+
+    const QgsAbstractMaterialSettings *material = polygonSymbol->materialSettings();
+    QVERIFY( material );
+    QCOMPARE( material->averageColor().red(), 0 );
+    QCOMPARE( material->averageColor().green(), 255 );
+    QCOMPARE( material->averageColor().blue(), 255 );
+  }
+
+  // point
+  {
+    auto layerPoint = std::make_unique<QgsVectorLayer>( u"Point?crs=EPSG:4326"_s, u"test_point"_s, u"memory"_s );
+    QVERIFY( layerPoint->isValid() );
+    QCOMPARE( layerPoint->wkbType(), Qgis::WkbType::Point );
+
+    auto markerSymbol = std::make_unique<QgsMarkerSymbol>();
+    auto markerSymbolLayer = std::make_unique<QgsSimpleMarkerSymbolLayer>( Qgis::MarkerShape::Circle, 4.0, 0.0, Qgis::ScaleMethod::ScaleDiameter, QColor( 120, 0, 0 ), QColor() );
+    markerSymbol->changeSymbolLayer( 0, markerSymbolLayer.release() );
+    markerSymbol->setOpacity( 0.5 );
+    markerSymbol->setSizeUnit( Qgis::RenderUnit::Pixels );
+
+    std::unique_ptr<QgsAbstract3DSymbol> symbol3D = Qgs3DSymbolUtils::create3DSymbolFrom2D( layerPoint.get(), markerSymbol.get(), context );
+
+    QVERIFY( symbol3D );
+    QCOMPARE( symbol3D->type(), u"point"_s );
+    QgsPoint3DSymbol *point3DSymbol = dynamic_cast<QgsPoint3DSymbol *>( symbol3D.get() );
+    QVERIFY( point3DSymbol );
+    QCOMPARE( point3DSymbol->shape(), Qgis::Point3DShape::Sphere );
+
+    QVariantMap props = point3DSymbol->shapeProperties();
+    QVERIFY( props.contains( "radius" ) );
+    QCOMPARE( props.value( "radius" ).toDouble(), 2.0 );
+
+    QgsAbstractMaterialSettings *material = point3DSymbol->materialSettings();
+    QVERIFY( material );
+    QCOMPARE( material->type(), u"metalrough"_s );
+    const QgsMetalRoughMaterialSettings *metalMaterial = dynamic_cast<const QgsMetalRoughMaterialSettings *>( material );
+    QVERIFY( metalMaterial );
+    QCOMPARE( metalMaterial->opacity(), 0.5 );
+    QCOMPARE( metalMaterial->averageColor().red(), 120 );
+    QCOMPARE( metalMaterial->averageColor().green(), 0 );
+    QCOMPARE( metalMaterial->averageColor().blue(), 0 );
+  }
+
+  // line
+  {
+    auto layerLine = std::make_unique<QgsVectorLayer>( u"LineString?crs=EPSG:4326"_s, u"test_linestring"_s, u"memory"_s );
+    QVERIFY( layerLine->isValid() );
+    QCOMPARE( layerLine->wkbType(), Qgis::WkbType::LineString );
+
+    auto lineSymbolLayer = std::make_unique<QgsSimpleLineSymbolLayer>();
+    lineSymbolLayer->setWidth( 5.0 );
+    lineSymbolLayer->setWidthUnit( Qgis::RenderUnit::Pixels );
+    auto symbol2D = std::make_unique<QgsLineSymbol>();
+    symbol2D->changeSymbolLayer( 0, lineSymbolLayer.release() );
+
+    auto symbol3D = Qgs3DSymbolUtils::create3DSymbolFrom2D( layerLine.get(), symbol2D.get(), context );
+    QVERIFY( symbol3D );
+    QCOMPARE( symbol3D->type(), u"line"_s );
+
+    const QgsLine3DSymbol *lineSymbol3D = dynamic_cast<const QgsLine3DSymbol *>( symbol3D.get() );
+    QVERIFY( lineSymbol3D );
+    QCOMPARE( static_cast<double>( lineSymbol3D->width() ), 5.0 );
+
+    QgsAbstractMaterialSettings *material = lineSymbol3D->materialSettings();
+    QVERIFY( material );
+    QCOMPARE( material->type(), u"metalrough"_s );
+    const QgsMetalRoughMaterialSettings *metalMaterial = dynamic_cast<const QgsMetalRoughMaterialSettings *>( material );
+    QVERIFY( metalMaterial );
+    QCOMPARE( metalMaterial->opacity(), 1.0 );
+    QCOMPARE( metalMaterial->averageColor().red(), 35 );
+    QCOMPARE( metalMaterial->averageColor().green(), 35 );
+    QCOMPARE( metalMaterial->averageColor().blue(), 35 );
+  }
 }
 
 QGSTEST_MAIN( TestQgs3DSymbolUtils )


### PR DESCRIPTION
## Description

This adds a new "From 2D Symbology" entry to the 3D symbology combox. This allows to create a new 3D symbology from the 2D one. If a 3d symbology already exists, it is replaced by this a new 3d symbology. This can be useful to quickly replicate 2D rules/categories or have similar colors between the 2D and 3D representations.

If the current 2D symbology style does not have a 3D equivalent, the entry is disabled.

For example, if the 2D symbology is "Categorized", it creates a 3D "Categorized" symbology, copies each category and tries to creates 3d symbols based on the 3D one.   

As there is no perfect match between the 2D symbols properties and the 3D symbol properties, only simple properties can be copied:

| 2D Property       | 3D Equivalent                                                |
|-------------------|-------------------------------------------------------------|
| Fill color        | QgsMaterialSettings::setColorsFromBase(fillColor) |
| Opacity           | Opacity |
| Point size        | Sphere radius |
| Square size        | Cube size |
| Triangle size | Cone length / topRadius / BottomRadius |
| Rule-based styles | Each 2D rule becomes a 3D rule with the mapped properties |
| categorized styles | Each 2D category becomes a 3D category with the mapped properties |



### categorized

<img width="567" height="718" alt="image" src="https://github.com/user-attachments/assets/b9e92da6-e61b-4ac3-ae42-1eac897b27f5" />

### rule-based

<img width="567" height="718" alt="image" src="https://github.com/user-attachments/assets/ec827505-db52-401d-8b17-ba71d78413b5" />

## single symbol

<img width="567" height="718" alt="image" src="https://github.com/user-attachments/assets/8ee6fe47-3ed1-4932-a316-c19b744fe3a4" />


## AI tool usage

No AI tool used


**Funded by Stadt Frankfurt am Main**