### PR TITLE
QgsSymbolLayerUtils::parseExtraItems(): fix wrong use of string instead of char

### DIFF
--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -6021,7 +6021,7 @@ QgsSymbolLayerUtils::ExtraItems QgsSymbolLayerUtils::parseExtraItems( const QStr
   int iChar = 0;
   for ( const QChar &c : strExtraItems )
   {
-    if ( !currentNumber.isEmpty() && ( c.isSpace() || c == "," ) )
+    if ( !currentNumber.isEmpty() && ( c.isSpace() || c == ',' ) )
     {
       error = addNumber( c );
     }


### PR DESCRIPTION
## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
