### PR TITLE
Update StartupWMClass in org.qgis.qgis.desktop.in to QGIS4

### DIFF
--- a/linux/org.qgis.qgis.desktop.in
+++ b/linux/org.qgis.qgis.desktop.in
@@ -10,4 +10,4 @@ StartupNotify=false
 Categories=Qt;Education;Science;Geography;
 MimeType=application/x-qgis-project;application/x-qgis-project-container;application/x-qgis-layer-settings;application/x-qgis-layer-definition;application/x-qgis-composer-template;image/tiff;image/jpeg;image/jp2;application/x-raster-aig;application/x-raster-ecw;application/x-raster-mrsid;application/x-mapinfo-mif;application/x-esri-shape;application/vnd.google-earth.kml+xml;application/vnd.google-earth.kmz;application/geopackage+sqlite3;
 Keywords=map;globe;postgis;wms;wfs;ogc;osgeo;
-StartupWMClass=QGIS3
+StartupWMClass=QGIS4


### PR DESCRIPTION
## Description

Following the QGIS 4.0 release, the running application window broadcasts a WM_CLASS of QGIS4. However, the Linux desktop entry template still references QGIS3, this causes problems in Gnome for window grouping. Simple fix by updating the StartupWMClass in org.qgis.qgis.desktop.in linux desktop file.