### PR TITLE
Avoid some crashes in QgsPolygon

### DIFF
--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -1322,6 +1322,9 @@ double QgsCurvePolygon::vertexAngle( QgsVertexId vertex ) const
 
 int QgsCurvePolygon::vertexCount( int /*part*/, int ring ) const
 {
+  if ( !mExteriorRing || ring < 0 || ring >= 1 + mInteriorRings.size() )
+    return 0;
+
   return ring == 0 ? mExteriorRing->vertexCount() : mInteriorRings[ring - 1]->vertexCount();
 }
 
@@ -1337,6 +1340,9 @@ int QgsCurvePolygon::partCount() const
 
 QgsPoint QgsCurvePolygon::vertexAt( QgsVertexId id ) const
 {
+  if ( !mExteriorRing || id.ring < 0 || id.ring >= 1 + mInteriorRings.size() )
+    return QgsPoint();
+
   return id.ring == 0 ? mExteriorRing->vertexAt( id ) : mInteriorRings[id.ring - 1]->vertexAt( id );
 }
 
@@ -1493,7 +1499,9 @@ int QgsCurvePolygon::childCount() const
 
 QgsAbstractGeometry *QgsCurvePolygon::childGeometry( int index ) const
 {
-  if ( index == 0 )
+  if ( index < 0 || index >= 1 + mInteriorRings.size() )
+    return nullptr;
+  else if ( index == 0 )
     return mExteriorRing.get();
   else
     return mInteriorRings.at( index - 1 );


### PR DESCRIPTION
## Description
Avoid crashes if `vertexCount()`, `vertexAt()` and `childGeometry()` are called on empty polygon or with out of bounds parameters.
While there's probably no bad usage in QGIS code, this can easily happen in python.


## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
