### PR TITLE
Fix duplicate word typos in code comments

### DIFF
--- a/python/PyQt6/core/auto_generated/raster/qgsexiftools.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsexiftools.sip.in
@@ -34,7 +34,7 @@ Returns a map object containing all exif tags stored in the image at
 
     static QVariant readTag( const QString &imagePath, const QString &key );
 %Docstring
-Returns the value of of an exif tag ``key`` stored in the image at
+Returns the value of an exif tag ``key`` stored in the image at
 ``imagePath``.
 
 .. versionadded:: 3.22

--- a/python/PyQt6/server/auto_generated/qgsrequesthandler.sip.in
+++ b/python/PyQt6/server/auto_generated/qgsrequesthandler.sip.in
@@ -79,7 +79,7 @@ Retrieve request header value
 
     QMap<QString, QString> requestHeaders() const;
 %Docstring
-Returns the the Request headers
+Returns the Request headers
 %End
 
     void clear();

--- a/src/3d/qgs3dmapcanvas.h
+++ b/src/3d/qgs3dmapcanvas.h
@@ -209,7 +209,7 @@ class _3D_EXPORT Qgs3DMapCanvas : public QWindow
     //! Emitted when the 3D map canvas was successfully saved as image
     void savedAsImage( const QString &fileName );
 
-    //! Emitted when the the map setting is changed
+    //! Emitted when the map setting is changed
     void mapSettingsChanged();
 
     //! Emitted when the FPS count changes (at most every frame)

--- a/src/core/raster/qgsexiftools.h
+++ b/src/core/raster/qgsexiftools.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsExifTools
     static QVariantMap readTags( const QString &imagePath );
 
     /**
-     * Returns the value of of an exif tag \a key stored in the image at \a imagePath.
+     * Returns the value of an exif tag \a key stored in the image at \a imagePath.
      * \since QGIS 3.22
      */
     static QVariant readTag( const QString &imagePath, const QString &key );

--- a/src/server/qgsrequesthandler.h
+++ b/src/server/qgsrequesthandler.h
@@ -77,7 +77,7 @@ class SERVER_EXPORT QgsRequestHandler
     //! Retrieve request header value
     QString requestHeader( const QString &name ) const;
 
-    //! Returns the the Request headers
+    //! Returns the Request headers
     QMap<QString, QString> requestHeaders() const;
 
     //! Clears the response body and headers

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -59,7 +59,7 @@ using namespace Qt::StringLiterals;
 
 // Server status static initializers.
 // Default values are for C++, SIP bindings will override their
-// options in in init()
+// options in init()
 
 QString *QgsServer::sConfigFilePath = nullptr;
 QgsCapabilitiesCache *QgsServer::sCapabilitiesCache = nullptr;


### PR DESCRIPTION
Remove duplicated words in inline documentation/comments:

- `src/3d/qgs3dmapcanvas.h`: `the the` → `the`
- `src/server/qgsrequesthandler.h`: `the the` → `the`
- `src/server/qgsserver.cpp`: `in in` → `in`
- `src/core/raster/qgsexiftools.h`: `of of` → `of`

These are pure comment fixes with no functional changes.

## Description

This PR fixes four duplicate-word typos in inline Doxygen comments of public API headers (files marked with `*_EXPORT` macros). The affected comments surface in the generated API documentation at https://api.qgis.org, so the fixes improve user-facing documentation quality. No functional code is changed.

## AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.