### PR TITLE
qgsterrainentity: Ensure proper compilation on gcc

### DIFF
--- a/src/3d/terrain/qgsterrainentity.h
+++ b/src/3d/terrain/qgsterrainentity.h
@@ -32,6 +32,7 @@
 
 #include "qgschunkedentity.h"
 #include "qgschunkqueuejob.h"
+#include "qgslayerstylewatcher.h"
 #include "qobjectuniqueptr.h"
 
 #define SIP_NO_FILE
@@ -47,7 +48,6 @@ class QgsCoordinateTransform;
 class QgsMapLayer;
 class QgsTerrainGenerator;
 class TerrainMapUpdateJobFactory;
-class QgsLayerStyleWatcher;
 
 /**
  * \ingroup qgis_3d


### PR DESCRIPTION
## Description

Forward declaration does not always work:

```
/home/jean/dev/QGIS/src/core/qobjectuniqueptr.h: In instantiation of ‘QObjectUniquePtr<T>::QObjectUniquePtr(T*) [with T = QgsLayerStyleWatcher]’:
/home/jean/dev/QGIS/src/3d/terrain/qgsterrainentity.h:86:60:   required from here
   86 |     QObjectUniquePtr<QgsLayerStyleWatcher> mLayerWatcher = nullptr;
      |                                                            ^~~~~~~
/home/jean/dev/QGIS/src/core/qobjectuniqueptr.h:69:9: error: no matching function for call to ‘QPointer<QObject>::QPointer(QgsLayerStyleWatcher*&)’
   69 |       : mPtr( p )
      |         ^~~~~~~~~
/home/jean/dev/QGIS/src/core/qobjectuniqueptr.h:69:9: note: there are 7 candidates
In file included from /usr/include/x86_64-linux-gnu/qt6/QtCore/QPointer:1,
                 from /home/jean/dev/QGIS/src/3d/framegraph/qgsabstractrenderview.h:22,
                 from /home/jean/dev/QGIS/src/3d/framegraph/qgs3daxisrenderview.h:20,
                 from /home/jean/dev/QGIS/src/3d/qgs3daxis.cpp:18:
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:47:5: note: candidate 1: ‘template<class X, typename std::enable_if<is_convertible_v<U*, QObject*>, bool>::type <anonymous> > QPointer<T>::QPointer(const QPointer<X>&) [with typename std::enable_if<is_convertible_v<U*, T*>, bool>::type <anonymous> = X; T = QObject]’
   47 |     QPointer(const QPointer<X> &other) noexcept
      |     ^~~~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:47:5: note: template argument deduction/substitution failed:
/home/jean/dev/QGIS/src/core/qobjectuniqueptr.h:69:9: note:   mismatched types ‘const QPointer<T>’ and ‘QgsLayerStyleWatcher*’
   69 |       : mPtr( p )
      |         ^~~~~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:43:5: note: candidate 2: ‘template<class X, typename std::enable_if<is_convertible_v<U*, QObject*>, bool>::type <anonymous> > QPointer<T>::QPointer(QPointer<X>&&) [with typename std::enable_if<is_convertible_v<U*, T*>, bool>::type <anonymous> = X; T = QObject]’
   43 |     QPointer(QPointer<X> &&other) noexcept
      |     ^~~~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:43:5: note: template argument deduction/substitution failed:
/home/jean/dev/QGIS/src/core/qobjectuniqueptr.h:69:9: note:   mismatched types ‘QPointer<T>’ and ‘QgsLayerStyleWatcher*’
   69 |       : mPtr( p )
      |         ^~~~~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:37:12: note: candidate 3: ‘template<class> QPointer<T>::QPointer(T*) [with T = QObject]’
   37 |     inline QPointer(T *p) : wp(p, true) { }
      |            ^~~~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:37:12: note: template argument deduction/substitution failed:
/home/jean/dev/QGIS/src/core/qobjectuniqueptr.h:69:15: note:   cannot convert ‘p’ (type ‘QgsLayerStyleWatcher*’) to type ‘QObject*’
   69 |       : mPtr( p )
      |               ^
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:34:15: note: candidate 4: ‘constexpr QPointer<T>::QPointer(std::nullptr_t) [with T = QObject; std::nullptr_t = std::nullptr_t]’
   34 |     constexpr QPointer(std::nullptr_t) noexcept : QPointer{} {}
      |               ^~~~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:34:24: note: no known conversion for argument 1 from ‘QgsLayerStyleWatcher*’ to ‘std::nullptr_t’
   34 |     constexpr QPointer(std::nullptr_t) noexcept : QPointer{} {}
      |                        ^~~~~~~~~~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:32:5: note: candidate 5: ‘constexpr QPointer<T>::QPointer() [with T = QObject]’
   32 |     QPointer() noexcept = default;
      |     ^~~~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:32:5: note: candidate expects 0 arguments, 1 provided
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:18:7: note: candidate 6: ‘QPointer<QObject>::QPointer(const QPointer<QObject>&)’
   18 | class QPointer
      |       ^~~~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:18:7: note: no known conversion for argument 1 from ‘QgsLayerStyleWatcher*’ to ‘const QPointer<QObject>&’
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:18:7: note: candidate 7: ‘QPointer<QObject>::QPointer(QPointer<QObject>&&)’
/usr/include/x86_64-linux-gnu/qt6/QtCore/qpointer.h:18:7: note: no known conversion for argument 1 from ‘QgsLayerStyleWatcher*’ to ‘QPointer<QObject>&&’
[350/3591] Building CXX object src/3d/CMakeFiles/qgis_3d.dir/qgs3dmapscene.cpp.o
ninja: build stopped: subcommand failed.
```

## AI tool usage

 - No AI Tool used