### PR TITLE
Add API Header auth config support to gdal provider

### DIFF
--- a/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
@@ -131,19 +131,34 @@ bool QgsAuthApiHeaderMethod::updateDataSourceUriItems( QStringList &connectionIt
 #endif
 
     const QString uri( connectionItems.first() );
-    const QStringList uriParts( uri.split( '/', Qt::SplitBehaviorFlags::SkipEmptyParts ) );
+    const QStringList uriParts( uri.split( '/' ) );
     QString prefixes;
     for ( const QString &part : uriParts )
     {
-      prefixes += '/' + part;
-      if ( QgsGdalUtils::isVsiArchivePrefix( part ) )
+      // skip the first leading slash, it will be added by the next part
+      if ( prefixes.isEmpty() && part.isEmpty() )
         continue;
 
-      if ( QgsGdalUtils::vsiHandlerType( part ) == Qgis::VsiHandlerType::Network )
-        break;
+      prefixes += '/' + part;
 
-      QgsDebugError( u"Update request config FAILED for authcfg: %1: Only network requests support API Header auth cfg"_s.arg( authcfg ) );
-      return false;
+      // skip if it's a second slash in a row
+      if ( part.isEmpty() )
+        continue;
+
+      switch ( QgsGdalUtils::vsiHandlerType( part ) )
+      {
+        case Qgis::VsiHandlerType::Cloud:
+        case Qgis::VsiHandlerType::Invalid:
+        case Qgis::VsiHandlerType::Memory:
+        case Qgis::VsiHandlerType::Other:
+          QgsDebugError( u"Update request config FAILED for authcfg: %1: Only network requests support API Header auth cfg"_s.arg( authcfg ) );
+          return false;
+        case Qgis::VsiHandlerType::Archive:
+          continue;
+        case Qgis::VsiHandlerType::Network:
+          break;
+      }
+      break;
     }
 
     const QString url( QUrl::toPercentEncoding( uri.mid( prefixes.length() + 1 ) ) );

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.cpp
@@ -18,6 +18,7 @@
 
 #include "qgsapplication.h"
 #include "qgsauthmanager.h"
+#include "qgsgdalutils.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
 
@@ -45,13 +46,21 @@ QMap<QString, QgsAuthMethodConfig> QgsAuthApiHeaderMethod::sAuthConfigCache = QM
 QgsAuthApiHeaderMethod::QgsAuthApiHeaderMethod()
 {
   setVersion( 2 );
-  setExpansions( QgsAuthMethod::NetworkRequest );
+  Expansions exp( QgsAuthMethod::NetworkRequest );
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION( 3, 11, 0 )
+  exp |= QgsAuthMethod::DataSourceUri;
+#endif
+  setExpansions( exp );
   setDataProviders(
     QStringList()
     << u"ows"_s
     << u"wfs"_s // convert to lowercase
     << u"wcs"_s
     << u"wms"_s
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION( 3, 11, 0 )
+    << u"gdal"_s
+    << u"ogr"_s
+#endif
   );
 }
 
@@ -97,6 +106,66 @@ bool QgsAuthApiHeaderMethod::updateNetworkRequest( QNetworkRequest &request, con
     else
     {
       QgsDebugError( u"The header key was empty, we shouldn't have empty header keys at this point"_s );
+    }
+  }
+
+  return true;
+}
+
+bool QgsAuthApiHeaderMethod::updateDataSourceUriItems( QStringList &connectionItems, const QString &authcfg, const QString &dataprovider )
+{
+  const QgsAuthMethodConfig config = getMethodConfig( authcfg );
+  if ( !config.isValid() )
+  {
+    QgsDebugError( u"Update request config FAILED for authcfg: %1: config invalid"_s.arg( authcfg ) );
+    return false;
+  }
+
+  if ( dataprovider == "ogr"_L1 || dataprovider == "gdal"_L1 )
+  {
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION( 3, 11, 0 )
+    Q_UNUSED( connectionItems )
+
+    QgsDebugError( u"Update request config FAILED for authcfg: %1: GDAL 3.11 is required for API Header auth method"_s.arg( authcfg ) );
+    return false;
+#endif
+
+    const QString uri( connectionItems.first() );
+    const QStringList uriParts( uri.split( '/', Qt::SplitBehaviorFlags::SkipEmptyParts ) );
+    QString prefixes;
+    for ( const QString &part : uriParts )
+    {
+      prefixes += '/' + part;
+      if ( QgsGdalUtils::isVsiArchivePrefix( part ) )
+        continue;
+
+      if ( QgsGdalUtils::vsiHandlerType( part ) == Qgis::VsiHandlerType::Network )
+        break;
+
+      QgsDebugError( u"Update request config FAILED for authcfg: %1: Only network requests support API Header auth cfg"_s.arg( authcfg ) );
+      return false;
+    }
+
+    const QString url( QUrl::toPercentEncoding( uri.mid( prefixes.length() + 1 ) ) );
+
+    QString headers;
+    QMapIterator<QString, QString> i( config.configMap() );
+    while ( i.hasNext() )
+    {
+      const QString delim = i.hasPrevious() ? u"&"_s : QString();
+
+      i.next();
+
+      const QString headerKey( QUrl::toPercentEncoding( i.key() ) );
+      const QString headerValue( QUrl::toPercentEncoding( i.value() ) );
+
+      headers.append( u"%1header.%2=%3"_s.arg( delim, headerKey, headerValue ) );
+    }
+
+    if ( !headers.isEmpty() )
+    {
+      const QString newUri( u"%1?%2&url=%3"_s.arg( prefixes, headers, url ) );
+      connectionItems.replace( 0, newUri );
     }
   }
 

--- a/src/auth/apiheader/core/qgsauthapiheadermethod.h
+++ b/src/auth/apiheader/core/qgsauthapiheadermethod.h
@@ -43,6 +43,7 @@ class QgsAuthApiHeaderMethod : public QgsAuthMethod
     QString displayDescription() const override;
 
     bool updateNetworkRequest( QNetworkRequest &request, const QString &authcfg, const QString &dataprovider = QString() ) override;
+    bool updateDataSourceUriItems( QStringList &connectionItems, const QString &authcfg, const QString &dataprovider = QString() ) override;
 
     void clearCachedConfig( const QString &authcfg ) override;
     void updateMethodConfig( QgsAuthMethodConfig &config ) override;


### PR DESCRIPTION
## Description
`QgsAuthApiHeaderMethod` cannot be used with the GDAL and OGR providers.

Since GDAL 3.11 one can pass http headers to `vsicurl` using the format:
```
/vsicurl?header.Key=Value&url=http://host/file.tif
```

By implementing `updateDataSourceUriItems()` for `QgsAuthApiHeaderMethod` we can convert the API Headers defined in the auth config into `/vsicurl?` parameters for gdal and ogr providers in specific.



## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
