### PR TITLE
WMS qgis:requestedWmsName (Group) in GetFeatureInfo JSON Result as foreign member

### DIFF
--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -252,7 +252,9 @@ values.
 .. versionadded:: 3.40
 %End
 
-    QString exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), int indent = -1, const QString &featureType = QString() ) const;
+    QString exportFeature(
+      const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), int indent = -1, const QVariantMap &extraMembers = QVariantMap()
+    ) const;
 %Docstring
 Returns a GeoJSON string representation of a feature.
 
@@ -263,8 +265,9 @@ Returns a GeoJSON string representation of a feature.
            feature's ID. If omitted, feature's ID is used.
 :param indent: number of indentation spaces for generated JSON (defaults
                to none)
-:param featureType: optional feature type to pass, like the layer name.
-                    If omitted, it is not written (since QGIS 4.2)
+:param extraMembers: are optional foreign members as e.g. the layer name
+                     to pass as featureType. If omitted, it is not
+                     written (since QGIS 4.2)
 
 :return: GeoJSON string
 

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -86,11 +86,11 @@ QgsCoordinateReferenceSystem QgsJsonExporter::sourceCrs() const
   return mCrs;
 }
 
-QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties, const QVariant &id, int indent, const QString &featureType ) const
+QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties, const QVariant &id, int indent, const QVariantMap &extraMembers ) const
 {
   try
   {
-    return QString::fromStdString( exportFeatureToJsonObject( feature, extraProperties, id, featureType ).dump( indent ) );
+    return QString::fromStdString( exportFeatureToJsonObject( feature, extraProperties, id, extraMembers ).dump( indent ) );
   }
   catch ( json::type_error &ex )
   {
@@ -104,15 +104,22 @@ QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVarian
   }
 }
 
-json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, const QVariantMap &extraProperties, const QVariant &id, const QString &featureType ) const
+json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, const QVariantMap &extraProperties, const QVariant &id, const QVariantMap &extraMembers ) const
 {
   json featureJson {
     { "type", "Feature" },
   };
-  if ( !featureType.isEmpty() )
+
+  //foreign members
+  if ( !extraMembers.isEmpty() )
   {
-    featureJson["featureType"] = featureType.toStdString();
+    QVariantMap::const_iterator it = extraMembers.constBegin();
+    for ( ; it != extraMembers.constEnd(); ++it )
+    {
+      featureJson[it.key().toStdString()] = QgsJsonUtils::jsonFromVariant( it.value() );
+    }
   }
+
   if ( id.isValid() )
   {
     bool ok = false;

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -219,12 +219,14 @@ class CORE_EXPORT QgsJsonExporter
      * \param id optional ID to use as GeoJSON feature's ID instead of input feature's ID. If omitted, feature's
      * ID is used.
      * \param indent number of indentation spaces for generated JSON (defaults to none)
-     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written (since QGIS 4.2)
+     * \param extraMembers are optional foreign members as e.g. the layer name to pass as featureType. If omitted, it is not written (since QGIS 4.2)
      * \returns GeoJSON string
      * \see exportFeatures()
      * \see exportFeatureToJsonObject()
      */
-    QString exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), int indent = -1, const QString &featureType = QString() ) const;
+    QString exportFeature(
+      const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), int indent = -1, const QVariantMap &extraMembers = QVariantMap()
+    ) const;
 
     /**
      * Returns a QJsonObject representation of a feature.
@@ -232,11 +234,11 @@ class CORE_EXPORT QgsJsonExporter
      * \param extraProperties map of extra attributes to include in feature's properties
      * \param id optional ID to use as GeoJSON feature's ID instead of input feature's ID. If omitted, feature's
      * ID is used.
-     * \param featureType optional feature type to pass, like the layer name. If omitted, it is not written (since QGIS 4.2)
+     * \param extraMembers are optional foreign members as e.g. the layer name to pass as featureType. If omitted, it is not written (since QGIS 4.2)
      * \returns json object
      * \see exportFeatures()
      */
-    json exportFeatureToJsonObject( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), const QString &featureType = QString() ) const
+    json exportFeatureToJsonObject( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), const QVariantMap &extraMembers = QVariantMap() ) const
       SIP_SKIP;
 
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3029,10 +3029,11 @@ namespace QgsWms
 
   QByteArray QgsRenderer::convertFeatureInfoToJson( const QList<QgsMapLayer *> &layers, const QDomDocument &doc, const QgsCoordinateReferenceSystem &destCRS ) const
   {
-    json json {
+    json jsonCollection {
       { "type", "FeatureCollection" },
       { "features", json::array() },
     };
+
     const bool withGeometry = ( QgsServerProjectUtils::wmsFeatureInfoAddWktGeometry( *mProject ) && mWmsParameters.withGeometry() );
     const bool withDisplayName = mWmsParameters.withDisplayName();
 
@@ -3053,6 +3054,16 @@ namespace QgsWms
 
       if ( !layer )
         continue;
+
+      // check if the layers have been requested by something other than their layer name (like the group)
+      // and if so, keep the highest ancestor as requestedWmsName
+      QStringList requestedWmsNames = mContext.acceptableLayersToRender().value( layer );
+      requestedWmsNames.removeAll( layerName );
+      QString requestedWmsName;
+      if ( !requestedWmsNames.isEmpty() )
+      {
+        requestedWmsName = requestedWmsNames.first();
+      }
 
       if ( layer->type() == Qgis::LayerType::Vector )
       {
@@ -3147,7 +3158,7 @@ namespace QgsWms
         exporter.setIncludeGeometry( withGeometry );
         exporter.setTransformGeometries( false );
 
-        QgsJsonUtils::addCrsInfo( json, destCRS );
+        QgsJsonUtils::addCrsInfo( jsonCollection, destCRS );
 
         for ( const auto &feature : std::as_const( features ) )
         {
@@ -3160,16 +3171,13 @@ namespace QgsWms
           QVariantMap extraMembers;
           extraMembers["featureType"] = layerName;
 
-          // check if the layers have been requested by something other than their layer name (like the group)
-          // and if so, add the highest ancestor to extra members
-          QStringList requestedWmsName = mContext.acceptableLayersToRender().value( layer );
-          requestedWmsName.removeAll( layerName );
+          // if existing, add the requestedWmsName to extra members
           if ( !requestedWmsName.isEmpty() )
           {
-            extraMembers["requestedWmsName"] = requestedWmsName.first();
+            extraMembers["requestedWmsName"] = requestedWmsName;
           }
 
-          json["features"].push_back( exporter.exportFeatureToJsonObject( feature, extraProperties, id, extraMembers ) );
+          jsonCollection["features"].push_back( exporter.exportFeatureToJsonObject( feature, extraProperties, id, extraMembers ) );
         }
       }
       else // raster layer
@@ -3190,14 +3198,20 @@ namespace QgsWms
           properties[name.toStdString()] = value.toStdString();
         }
 
-        json["features"].push_back( { { "type", "Feature" }, { "featureType", layerName.toStdString() }, { "id", layerName.toStdString() }, { "properties", properties } } );
+        json jsonFeature = { { "type", "Feature" }, { "featureType", layerName.toStdString() }, { "id", layerName.toStdString() }, { "properties", properties } };
+
+        if ( !requestedWmsName.isEmpty() )
+        {
+          jsonFeature["requestedWmsName"] = requestedWmsName.toStdString();
+        }
+        jsonCollection["features"].push_back( jsonFeature );
       }
     }
 #ifdef QGISDEBUG
     // This is only useful to generate human readable reference files for tests
-    return QByteArray::fromStdString( json.dump( 2 ) );
+    return QByteArray::fromStdString( jsonCollection.dump( 2 ) );
 #else
-    return QByteArray::fromStdString( json.dump() );
+    return QByteArray::fromStdString( jsonCollection.dump() );
 #endif
   }
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -112,6 +112,9 @@ using namespace Qt::StringLiterals;
 
 namespace QgsWms
 {
+  constexpr const char *MEMBERNAME_FEATURETYPE = "featureType";                     // name of the JSON-FG member describing the layer name
+  constexpr const char *MEMBERNAME_QGIS_REQUESTEDWMSNAME = "qgis:requestedWmsName"; // name of the QGIS member describing the name of the group that requested this layer
+
   QgsRenderer::QgsRenderer( const QgsWmsRenderContext &context )
     : mContext( context )
   {
@@ -3169,12 +3172,12 @@ namespace QgsWms
             extraProperties.insert( u"display_name"_s, fidDisplayNameMap.value( feature.id() ) );
           }
           QVariantMap extraMembers;
-          extraMembers["featureType"] = layerName;
+          extraMembers[MEMBERNAME_FEATURETYPE] = layerName;
 
           // if existing, add the requestedWmsName to extra members
           if ( !requestedWmsName.isEmpty() )
           {
-            extraMembers["qgis:requestedWmsName"] = requestedWmsName;
+            extraMembers[MEMBERNAME_QGIS_REQUESTEDWMSNAME] = requestedWmsName;
           }
 
           jsonCollection["features"].push_back( exporter.exportFeatureToJsonObject( feature, extraProperties, id, extraMembers ) );
@@ -3198,11 +3201,11 @@ namespace QgsWms
           properties[name.toStdString()] = value.toStdString();
         }
 
-        json jsonFeature = { { "type", "Feature" }, { "featureType", layerName.toStdString() }, { "id", layerName.toStdString() }, { "properties", properties } };
+        json jsonFeature = { { "type", "Feature" }, { MEMBERNAME_FEATURETYPE, layerName.toStdString() }, { "id", layerName.toStdString() }, { "properties", properties } };
 
         if ( !requestedWmsName.isEmpty() )
         {
-          jsonFeature["qgis:requestedWmsName"] = requestedWmsName.toStdString();
+          jsonFeature[MEMBERNAME_QGIS_REQUESTEDWMSNAME] = requestedWmsName.toStdString();
         }
         jsonCollection["features"].push_back( jsonFeature );
       }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3157,7 +3157,19 @@ namespace QgsWms
           {
             extraProperties.insert( u"display_name"_s, fidDisplayNameMap.value( feature.id() ) );
           }
-          json["features"].push_back( exporter.exportFeatureToJsonObject( feature, extraProperties, id, layerName ) );
+          QVariantMap extraMembers;
+          extraMembers["featureType"] = layerName;
+
+          // check if the layers have been requested by something other than their layer name (like the group)
+          // and if so, add the highest ancestor to extra members
+          QStringList requestedWmsName = mContext.acceptableLayersToRender().value( layer );
+          requestedWmsName.removeAll( layerName );
+          if ( !requestedWmsName.isEmpty() )
+          {
+            extraMembers["requestedWmsName"] = requestedWmsName.first();
+          }
+
+          json["features"].push_back( exporter.exportFeatureToJsonObject( feature, extraProperties, id, extraMembers ) );
         }
       }
       else // raster layer

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3174,7 +3174,7 @@ namespace QgsWms
           // if existing, add the requestedWmsName to extra members
           if ( !requestedWmsName.isEmpty() )
           {
-            extraMembers["requestedWmsName"] = requestedWmsName;
+            extraMembers["qgis:requestedWmsName"] = requestedWmsName;
           }
 
           jsonCollection["features"].push_back( exporter.exportFeatureToJsonObject( feature, extraProperties, id, extraMembers ) );
@@ -3202,7 +3202,7 @@ namespace QgsWms
 
         if ( !requestedWmsName.isEmpty() )
         {
-          jsonFeature["requestedWmsName"] = requestedWmsName.toStdString();
+          jsonFeature["qgis:requestedWmsName"] = requestedWmsName.toStdString();
         }
         jsonCollection["features"].push_back( jsonFeature );
       }

--- a/tests/src/core/testqgsjsonutils.cpp
+++ b/tests/src/core/testqgsjsonutils.cpp
@@ -281,16 +281,16 @@ void TestQgsJsonUtils::testExportFeatureJson()
 
   const QgsJsonExporter exporterForeignMembers { &vl };
   const auto expectedJsonForeignMembers { QStringLiteral(
-    "{\"bbox\":[1.12,1.12,5.45,5.33],\"featureType\":\"anotherForestLayer\",\"geometry\":{\"coordinates\":"
+    "{\"bbox\":[1.12,1.12,5.45,5.33],\"featureType\":\"anotherForestLayer\",\"geometry\":{\"coordinates\":" //#spellok
     "[[[1.12,1.34],[5.45,1.12],[5.34,5.33],[1.56,5.2],[1.12,1.34]],"
     "[[2.0,2.0],[3.0,2.0],[3.0,3.0],[2.0,3.0],[2.0,2.0]]],\"type\":\"Polygon\"}"
     ",\"id\":123,\"justAnotherDummy\":\"dum di da di dum di da\",\"properties\":{\"flddbl\":2.0,\"fldint\":1,\"fldtxt\":\"a value\"}" //#spellok
-    ",\"qgis:requestedWmsName\":\"theForestGroup\",\"type\":\"Feature\"}"
+    ",\"qgis:requestedWmsName\":\"theForestGroup\",\"type\":\"Feature\"}"                                                             //#spellok
   ) };
 
   QVariantMap moreExtraMembers;
-  moreExtraMembers["featureType"] = u"anotherForestLayer"_s;
-  moreExtraMembers["qgis:requestedWmsName"] = u"theForestGroup"_s;
+  moreExtraMembers["featureType"] = u"anotherForestLayer"_s;          //#spellok
+  moreExtraMembers["qgis:requestedWmsName"] = u"theForestGroup"_s;    //#spellok
   moreExtraMembers["justAnotherDummy"] = u"dum di da di dum di da"_s; //#spellok
 
   const auto jForeignMembers( exporterForeignMembers.exportFeatureToJsonObject( feature, QVariantMap(), QVariant(), moreExtraMembers ) );

--- a/tests/src/core/testqgsjsonutils.cpp
+++ b/tests/src/core/testqgsjsonutils.cpp
@@ -274,9 +274,9 @@ void TestQgsJsonUtils::testExportFeatureJson()
   QVariantMap extraProperties;
   extraProperties.insert( u"andAnExtraProperty"_s, 1337 );
 
-  const auto jFeatureType( exporter.exportFeatureToJsonObject( feature, extraProperties, genericFeatureId, extraMembers ) );
+  const auto jFeatureType( exporterFeatureTypeAndIdAndExtraProperties.exportFeatureToJsonObject( feature, extraProperties, genericFeatureId, extraMembers ) );
   QCOMPARE( QString::fromStdString( jFeatureType.dump() ), expectedJsonFeatureTypeAndIdAndExtraProperties );
-  const auto jsonFeatureType = exporter.exportFeature( feature, extraProperties, genericFeatureId, -1, extraMembers );
+  const auto jsonFeatureType = exporterFeatureTypeAndIdAndExtraProperties.exportFeature( feature, extraProperties, genericFeatureId, -1, extraMembers );
   QCOMPARE( jsonFeatureType, expectedJsonFeatureTypeAndIdAndExtraProperties );
 
   const QgsJsonExporter exporterForeignMembers { &vl };
@@ -285,18 +285,18 @@ void TestQgsJsonUtils::testExportFeatureJson()
     "[[[1.12,1.34],[5.45,1.12],[5.34,5.33],[1.56,5.2],[1.12,1.34]],"
     "[[2.0,2.0],[3.0,2.0],[3.0,3.0],[2.0,3.0],[2.0,2.0]]],\"type\":\"Polygon\"}"
     ",\"id\":123,\"justAnotherDummy\":\"dum di da di dum di da\",\"properties\":{\"flddbl\":2.0,\"fldint\":1,\"fldtxt\":\"a value\"}" //#spellok
-    ",\"requestedWmsName\":\"theForestGroup\",\"type\":\"Feature\"}"
+    ",\"qgis:requestedWmsName\":\"theForestGroup\",\"type\":\"Feature\"}"
   ) };
 
   QVariantMap moreExtraMembers;
   moreExtraMembers["featureType"] = u"anotherForestLayer"_s;
-  moreExtraMembers["requestedWmsName"] = u"theForestGroup"_s;
+  moreExtraMembers["qgis:requestedWmsName"] = u"theForestGroup"_s;
   moreExtraMembers["justAnotherDummy"] = u"dum di da di dum di da"_s; //#spellok
 
-  const auto jForeignMembers( exporter.exportFeatureToJsonObject( feature, QVariantMap(), QVariant(), moreExtraMembers ) );
+  const auto jForeignMembers( exporterForeignMembers.exportFeatureToJsonObject( feature, QVariantMap(), QVariant(), moreExtraMembers ) );
   QCOMPARE( QString::fromStdString( jForeignMembers.dump() ), expectedJsonForeignMembers );
-  const auto jsonForeignMembers = exporter.exportFeature( feature, QVariantMap(), QVariant(), -1, moreExtraMembers );
-  QCOMPARE( jsonFeatureType, expectedJsonFeatureTypeAndIdAndExtraProperties );
+  const auto jsonForeignMembers = exporterForeignMembers.exportFeature( feature, QVariantMap(), QVariant(), -1, moreExtraMembers );
+  QCOMPARE( jsonForeignMembers, expectedJsonForeignMembers );
 }
 
 void TestQgsJsonUtils::testExportFeatureJsonCrs()

--- a/tests/src/core/testqgsjsonutils.cpp
+++ b/tests/src/core/testqgsjsonutils.cpp
@@ -284,14 +284,14 @@ void TestQgsJsonUtils::testExportFeatureJson()
     "{\"bbox\":[1.12,1.12,5.45,5.33],\"featureType\":\"anotherForestLayer\",\"geometry\":{\"coordinates\":"
     "[[[1.12,1.34],[5.45,1.12],[5.34,5.33],[1.56,5.2],[1.12,1.34]],"
     "[[2.0,2.0],[3.0,2.0],[3.0,3.0],[2.0,3.0],[2.0,2.0]]],\"type\":\"Polygon\"}"
-    ",\"id\":123,\"justAnotherDummy\":\"dum di da di dum di da\",\"properties\":{\"flddbl\":2.0,\"fldint\":1,\"fldtxt\":\"a value\"}"
+    ",\"id\":123,\"justAnotherDummy\":\"dum di da di dum di da\",\"properties\":{\"flddbl\":2.0,\"fldint\":1,\"fldtxt\":\"a value\"}" //#spellok
     ",\"requestedWmsName\":\"theForestGroup\",\"type\":\"Feature\"}"
   ) };
 
   QVariantMap moreExtraMembers;
   moreExtraMembers["featureType"] = u"anotherForestLayer"_s;
   moreExtraMembers["requestedWmsName"] = u"theForestGroup"_s;
-  moreExtraMembers["justAnotherDummy"] = u"dum di da di dum di da"_s;
+  moreExtraMembers["justAnotherDummy"] = u"dum di da di dum di da"_s; //#spellok
 
   const auto jForeignMembers( exporter.exportFeatureToJsonObject( feature, QVariantMap(), QVariant(), moreExtraMembers ) );
   QCOMPARE( QString::fromStdString( jForeignMembers.dump() ), expectedJsonForeignMembers );

--- a/tests/src/core/testqgsjsonutils.cpp
+++ b/tests/src/core/testqgsjsonutils.cpp
@@ -267,13 +267,35 @@ void TestQgsJsonUtils::testExportFeatureJson()
     ",\"type\":\"Feature\"}"
   ) };
   QString layerName( u"theForestLayer"_s );
+  QVariantMap extraMembers;
+  extraMembers["featureType"] = layerName;
+
   QString genericFeatureId( u"theForestLayer-1337"_s );
   QVariantMap extraProperties;
   extraProperties.insert( u"andAnExtraProperty"_s, 1337 );
 
-  const auto jFeatureType( exporter.exportFeatureToJsonObject( feature, extraProperties, genericFeatureId, layerName ) );
+  const auto jFeatureType( exporter.exportFeatureToJsonObject( feature, extraProperties, genericFeatureId, extraMembers ) );
   QCOMPARE( QString::fromStdString( jFeatureType.dump() ), expectedJsonFeatureTypeAndIdAndExtraProperties );
-  const auto jsonFeatureType = exporter.exportFeature( feature, extraProperties, genericFeatureId, -1, layerName );
+  const auto jsonFeatureType = exporter.exportFeature( feature, extraProperties, genericFeatureId, -1, extraMembers );
+  QCOMPARE( jsonFeatureType, expectedJsonFeatureTypeAndIdAndExtraProperties );
+
+  const QgsJsonExporter exporterForeignMembers { &vl };
+  const auto expectedJsonForeignMembers { QStringLiteral(
+    "{\"bbox\":[1.12,1.12,5.45,5.33],\"featureType\":\"anotherForestLayer\",\"geometry\":{\"coordinates\":"
+    "[[[1.12,1.34],[5.45,1.12],[5.34,5.33],[1.56,5.2],[1.12,1.34]],"
+    "[[2.0,2.0],[3.0,2.0],[3.0,3.0],[2.0,3.0],[2.0,2.0]]],\"type\":\"Polygon\"}"
+    ",\"id\":123,\"justAnotherDummy\":\"dum di da di dum di da\",\"properties\":{\"flddbl\":2.0,\"fldint\":1,\"fldtxt\":\"a value\"}"
+    ",\"requestedWmsName\":\"theForestGroup\",\"type\":\"Feature\"}"
+  ) };
+
+  QVariantMap moreExtraMembers;
+  moreExtraMembers["featureType"] = u"anotherForestLayer"_s;
+  moreExtraMembers["requestedWmsName"] = u"theForestGroup"_s;
+  moreExtraMembers["justAnotherDummy"] = u"dum di da di dum di da"_s;
+
+  const auto jForeignMembers( exporter.exportFeatureToJsonObject( feature, QVariantMap(), QVariant(), moreExtraMembers ) );
+  QCOMPARE( QString::fromStdString( jForeignMembers.dump() ), expectedJsonForeignMembers );
+  const auto jsonForeignMembers = exporter.exportFeature( feature, QVariantMap(), QVariant(), -1, moreExtraMembers );
   QCOMPARE( jsonFeatureType, expectedJsonFeatureTypeAndIdAndExtraProperties );
 }
 

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -816,6 +816,20 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
             normalizeJson=True,
         )
 
+        # test on requesting the group_name (expected requestedWmsName as foreign member)
+        self.wms_request_compare(
+            "GetFeatureInfo",
+            "&layers=group_name&styles=&"
+            + "info_format=application%2Fjson&transparent=true&"
+            + "width=600&height=400&srs=OGC:CRS84&"
+            + "bbox=8.2034387,44.9014173,8.2036094,44.9015094&"
+            + "query_layers=group_name&X=203&Y=116&"
+            + "with_geometry=true",
+            "wms_getfeatureinfo_group_name_json",
+            "test_project.qgs",
+            normalizeJson=True,
+        )
+
     def testGetFeatureInfoGroupedLayers(self):
         """Test that we can get feature info from the top and group layers"""
 
@@ -859,7 +873,7 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
             + "&INFO_FORMAT=application/json"
             + "&I=0&J=1"
             + "&FEATURE_COUNT=10",
-            "wms_getfeatureinfo_group_name_areas_nested",
+            "wms_getfeatureinfo_group_name_areas_nested_direct",
             "test_project_wms_grouped_nested_layers.qgs",
             normalizeJson=True,
         )
@@ -934,7 +948,7 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
             + "&INFO_FORMAT=application/json"
             + "&I=0&J=1"
             + "&FEATURE_COUNT=10",
-            "wms_getfeatureinfo_group_query_child",
+            "wms_getfeatureinfo_group_query_child_ok",
             "test_project_wms_grouped_nested_layers.qgs",
             normalizeJson=True,
         )
@@ -949,7 +963,7 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
             + "&INFO_FORMAT=application/json"
             + "&I=0&J=1"
             + "&FEATURE_COUNT=10",
-            "wms_getfeatureinfo_group_query_child",
+            "wms_getfeatureinfo_group_query_child_direct",
             "test_project_wms_grouped_nested_layers.qgs",
             normalizeJson=True,
         )

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas.txt
@@ -31,6 +31,7 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
+      "requestedWmsName": "areas and symbols",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas.txt
@@ -31,7 +31,7 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
-      "requestedWmsName": "areas and symbols",
+      "qgis:requestedWmsName": "areas and symbols",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_cities.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_cities.txt
@@ -31,7 +31,7 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
-      "requestedWmsName": "areas and symbols",
+      "qgis:requestedWmsName": "areas and symbols",
       "type": "Feature"
     },
     {
@@ -46,7 +46,7 @@ Content-Type: application/json; charset=utf-8
         "ortsrat": "Fallersleben/Sülfeld",
         "typ": "Ortsteil"
       },
-      "requestedWmsName": "city and district boundaries",
+      "qgis:requestedWmsName": "city and district boundaries",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_nested.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_nested.txt
@@ -31,6 +31,7 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
+      "requestedWmsName": "areas and symbols",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_nested.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_nested.txt
@@ -31,7 +31,7 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
-      "requestedWmsName": "areas and symbols",
+      "qgis:requestedWmsName": "areas and symbols",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_nested_direct.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_areas_nested_direct.txt
@@ -31,22 +31,6 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
-      "requestedWmsName": "areas and symbols",
-      "type": "Feature"
-    },
-    {
-      "featureType": "cdb_lines",
-      "geometry": null,
-      "id": "cdb_lines.13",
-      "properties": {
-        "fid": 13,
-        "id": 12,
-        "id_long": null,
-        "name": "Fallersleben",
-        "ortsrat": "Fallersleben/Sülfeld",
-        "typ": "Ortsteil"
-      },
-      "requestedWmsName": "city and district boundaries",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_json.txt
@@ -1,0 +1,26 @@
+*****
+Content-Type: application/json; charset=utf-8
+
+{
+  "features": [
+    {
+      "featureType": "testlayer2",
+      "geometry": {
+        "coordinates": [
+          8.2035,
+          44.9015
+        ],
+        "type": "Point"
+      },
+      "id": "testlayer2.0",
+      "properties": {
+        "id": 1,
+        "name": "one",
+        "utf8nameè": "one èé"
+      },
+      "requestedWmsName": "group_name",
+      "type": "Feature"
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_json.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_name_json.txt
@@ -18,7 +18,7 @@ Content-Type: application/json; charset=utf-8
         "name": "one",
         "utf8nameè": "one èé"
       },
-      "requestedWmsName": "group_name",
+      "qgis:requestedWmsName": "group_name",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child.txt
@@ -31,6 +31,7 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
+      "requestedWmsName": "query_child",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child.txt
@@ -31,7 +31,7 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
-      "requestedWmsName": "query_child",
+      "qgis:requestedWmsName": "query_child",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child_direct.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child_direct.txt
@@ -4,9 +4,9 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
-      "featureType": "as-areas-short-name",
+      "featureType": "as-areas-short-name-query-copy",
       "geometry": null,
-      "id": "as-areas-short-name.18",
+      "id": "as-areas-short-name-query-copy.18",
       "properties": {
         "bearbeiter": "scholle-b",
         "bemerkung": "",
@@ -31,22 +31,6 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
-      "requestedWmsName": "areas and symbols",
-      "type": "Feature"
-    },
-    {
-      "featureType": "cdb_lines",
-      "geometry": null,
-      "id": "cdb_lines.13",
-      "properties": {
-        "fid": 13,
-        "id": 12,
-        "id_long": null,
-        "name": "Fallersleben",
-        "ortsrat": "Fallersleben/Sülfeld",
-        "typ": "Ortsteil"
-      },
-      "requestedWmsName": "city and district boundaries",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child_ok.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child_ok.txt
@@ -4,9 +4,9 @@ Content-Type: application/json; charset=utf-8
 {
   "features": [
     {
-      "featureType": "as-areas-short-name",
+      "featureType": "as-areas-short-name-query-copy",
       "geometry": null,
-      "id": "as-areas-short-name.18",
+      "id": "as-areas-short-name-query-copy.18",
       "properties": {
         "bearbeiter": "scholle-b",
         "bemerkung": "",
@@ -31,22 +31,7 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
-      "requestedWmsName": "areas and symbols",
-      "type": "Feature"
-    },
-    {
-      "featureType": "cdb_lines",
-      "geometry": null,
-      "id": "cdb_lines.13",
-      "properties": {
-        "fid": 13,
-        "id": 12,
-        "id_long": null,
-        "name": "Fallersleben",
-        "ortsrat": "Fallersleben/Sülfeld",
-        "typ": "Ortsteil"
-      },
-      "requestedWmsName": "city and district boundaries",
+      "requestedWmsName": "child_ok",
       "type": "Feature"
     }
   ],

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child_ok.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_group_query_child_ok.txt
@@ -31,7 +31,7 @@ Content-Type: application/json; charset=utf-8
         "umrisstyp": "durchgezogen",
         "veranstaltung": ""
       },
-      "requestedWmsName": "child_ok",
+      "qgis:requestedWmsName": "child_ok",
       "type": "Feature"
     }
   ],


### PR DESCRIPTION
On a WMS GetFeatureInfo request, we return the requested WMS name in the GeoJSON of the feature if the requested name was not the layer name itself (meaning it must have been the group).

Since this integration, we return the layer name as a foreign member in the GeoJSON of the feature on WMS GetFeatureInfo:

```json
  "features": [
    {
      "featureType": "testlayer",
      "geometry": null,
      "id": "testlayer2.2",
      "properties": {
        "id": 3,
        "name": "three",
        "utf8nameè": "three èé↓"
      },
      "type": "Feature"
    }
  ]
```

Now additionally we return as well the  `qgis:requestedWmsName`:

```json
  "features": [
    {
      "featureType": "testlayer",
      "geometry": null,
      "id": "testlayer2.2",
      "properties": {
        "id": 3,
        "name": "three",
        "utf8nameè": "three èé↓"
      },
      "qgis:requestedWmsName": "group_name",
      "type": "Feature"
    }
  ]
```

We always return the highest ancestor. This means that for a layer like:
```
- group_1
  |- group_2
     |- group_3
        |- the_layer
```

On `QUERY_LAYERS=the_layer` -> no `qgis:requestedWmsName`
On `QUERY_LAYERS=the_layer,group_2` -> `qgis:requestedWmsName` is "group_2"
On `QUERY_LAYERS=the_layer,group_2, group_1` -> `qgis:requestedWmsName` is "group_1"
On `QUERY_LAYERS=group2` -> `qgis:requestedWmsName` is "group2"
etc.

This integration changes the parameters of `exportFeatureToJsonObject` following #66008 and removes `featureType` as a seperate parameter. Instead `featureType` (the layer name) is now passed as an `extraMember` value.

The namespace `qgis:` we use on foreign member that are qgis specific. `featureType` is a official JSON-FG member and should not be prefixed. 

### Sponsor

[The Canton of Solothurn](https://so.ch/verwaltung/bau-und-justizdepartement/amt-fuer-geoinformation)
