### PR TITLE
[nmea] Insure we correctly reflect RTK quality from NMEA streams containing both GGA and RMC sentences

### DIFF
--- a/python/PyQt6/core/auto_generated/gps/qgsnmeaconnection.sip.in
+++ b/python/PyQt6/core/auto_generated/gps/qgsnmeaconnection.sip.in
@@ -70,6 +70,7 @@ process HDT sentence
 %Docstring
 process HCHDG sentence
 %End
+
 };
 
 /************************************************************************

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -235,6 +235,7 @@ void QgsNmeaConnection::processGgaSentence( const char *data, int len )
     {
       mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Unknown;
     }
+    mLastGGAQualityIndicator = mLastGPSInformation.qualityIndicator;
 
     // use GSA for satellites in use;
   }
@@ -320,59 +321,59 @@ void QgsNmeaConnection::processRmcSentence( const char *data, int len )
     // convert mode to signal (aka quality) indicator
     // (see https://gitlab.com/fhuberts/nmealib/-/blob/master/src/info.c#L27)
     // UM98x Status == D  (Differential)
+    Qgis::GpsQualityIndicator rmcQualityIndicator = Qgis::GpsQualityIndicator::Invalid;
     if ( result.status == 'A' || result.status == 'D' )
     {
       if ( result.mode == 'A' )
       {
-        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::GPS );
-        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::GPS;
+        rmcQualityIndicator = Qgis::GpsQualityIndicator::GPS;
       }
       else if ( result.mode == 'D' )
       {
-        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::DGPS );
-        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::DGPS;
+        rmcQualityIndicator = Qgis::GpsQualityIndicator::DGPS;
       }
       else if ( result.mode == 'P' )
       {
-        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::PPS );
-        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::PPS;
+        rmcQualityIndicator = Qgis::GpsQualityIndicator::PPS;
       }
       else if ( result.mode == 'R' )
       {
-        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::RTK );
-        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::RTK;
+        rmcQualityIndicator = Qgis::GpsQualityIndicator::RTK;
       }
       else if ( result.mode == 'F' )
       {
-        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::FloatRTK );
-        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::FloatRTK;
+        rmcQualityIndicator = Qgis::GpsQualityIndicator::FloatRTK;
       }
       else if ( result.mode == 'E' )
       {
-        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::Estimated );
-        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Estimated;
+        rmcQualityIndicator = Qgis::GpsQualityIndicator::Estimated;
       }
       else if ( result.mode == 'M' )
       {
-        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::Manual );
-        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Manual;
+        rmcQualityIndicator = Qgis::GpsQualityIndicator::Manual;
       }
       else if ( result.mode == 'S' )
       {
-        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::Simulation );
-        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Simulation;
+        rmcQualityIndicator = Qgis::GpsQualityIndicator::Simulation;
       }
       else
       {
-        mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::Unknown );
-        mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Unknown;
+        rmcQualityIndicator = Qgis::GpsQualityIndicator::Unknown;
       }
     }
     else if ( result.status == 'V' )
     {
-      mLastGPSInformation.quality = static_cast<int>( Qgis::GpsQualityIndicator::Invalid );
-      mLastGPSInformation.qualityIndicator = Qgis::GpsQualityIndicator::Invalid;
+      rmcQualityIndicator = Qgis::GpsQualityIndicator::Invalid;
     }
+
+    // some GNSS devices will fail to report an RTK quality through RMC sentences,
+    // use the better quality value from GGA and RMC sentences
+    if ( mLastGGAQualityIndicator != Qgis::GpsQualityIndicator::RTK && mLastGGAQualityIndicator != Qgis::GpsQualityIndicator::FloatRTK )
+    {
+      mLastGPSInformation.quality = static_cast<int>( rmcQualityIndicator );
+      mLastGPSInformation.qualityIndicator = rmcQualityIndicator;
+    }
+
     // for other cases: quality and qualityIndicator read by GGA
   }
 

--- a/src/core/gps/qgsnmeaconnection.h
+++ b/src/core/gps/qgsnmeaconnection.h
@@ -62,6 +62,9 @@ class CORE_EXPORT QgsNmeaConnection : public QgsGpsConnection
     void processHdtSentence( const char *data, int len );
     //! process HCHDG sentence
     void processHchdgSentence( const char *data, int len );
+
+  private:
+    Qgis::GpsQualityIndicator mLastGGAQualityIndicator = Qgis::GpsQualityIndicator::Invalid;
 };
 
 #endif // QGSNMEACONNECTION_H

--- a/tests/src/core/testqgsnmeaconnection.cpp
+++ b/tests/src/core/testqgsnmeaconnection.cpp
@@ -90,6 +90,7 @@ class TestQgsNmeaConnection : public QgsTest
     void testComponent_data();
     void testComponent();
     void testIncompleteMessage();
+    void testGgaRcmRTKDivergence();
 };
 
 void TestQgsNmeaConnection::initTestCase()
@@ -561,6 +562,27 @@ void TestQgsNmeaConnection::testIncompleteMessage()
   QCOMPARE( info.componentValue( Qgis::GpsInformationComponent::Altitude ).toDouble(), 35 );
   QCOMPARE( info.componentValue( Qgis::GpsInformationComponent::GroundSpeed ).toDouble(), 0 );
   QCOMPARE( info.componentValue( Qgis::GpsInformationComponent::Bearing ).toDouble(), 0 );
+}
+
+void TestQgsNmeaConnection::testGgaRcmRTKDivergence()
+{
+  ReplayNmeaConnection connection;
+
+  QgsGpsInformation info = connection.push( u"$GPGGA,225651.00,3617.56130011,N,09718.50567350,W,4,03,4.4,322.480,M,-25.964,M,,*56"_s );
+  QCOMPARE( info.quality, 4 );
+  QCOMPARE( info.qualityIndicator, Qgis::GpsQualityIndicator::RTK );
+
+  info = connection.push( u"$GPRMC,225651.00,A,3617.56130011,N,09718.50567350,W,0.065,231.147,100316,999.9000,E,D,V"_s );
+  QCOMPARE( info.quality, 4 );
+  QCOMPARE( info.qualityIndicator, Qgis::GpsQualityIndicator::RTK );
+
+  info = connection.push( u"$GPGGA,225651.00,3617.56130011,N,09718.50567350,W,2,03,4.4,322.480,M,-25.964,M,,*56"_s );
+  QCOMPARE( info.quality, 2 );
+  QCOMPARE( info.qualityIndicator, Qgis::GpsQualityIndicator::DGPS );
+
+  info = connection.push( u"$GPRMC,225651.00,A,3617.56130011,N,09718.50567350,W,0.065,231.147,100316,999.9000,E,F,V"_s );
+  QCOMPARE( info.quality, 5 );
+  QCOMPARE( info.qualityIndicator, Qgis::GpsQualityIndicator::FloatRTK );
 }
 
 QGSTEST_MAIN( TestQgsNmeaConnection )


### PR DESCRIPTION
## Description

I've stumbled on a GNSS device that (correctly) reported RTK quality within its GGA sentences while reporting a generic DGPS quality within its RMC sentences. It seems to be an issue with some chips that's worth accounting for.