### PR TITLE
Settings migration (7)

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -8502,6 +8502,21 @@ Qgis.LayerTreeInsertionMethod.__doc__ = """Layer tree insertion methods
 # --
 Qgis.LayerTreeInsertionMethod.baseClass = Qgis
 # monkey patching scoped based enum
+Qgis.LegendLayerDoubleClickAction.LayerProperties.__doc__ = "Open the layer properties dialog"
+Qgis.LegendLayerDoubleClickAction.AttributeTable.__doc__ = "Open the attribute table"
+Qgis.LegendLayerDoubleClickAction.LayerStyling.__doc__ = "Open the layer styling dock"
+Qgis.LegendLayerDoubleClickAction.__doc__ = """Action performed when double-clicking a layer in the legend.
+
+.. versionadded:: 4.0
+
+* ``LayerProperties``: Open the layer properties dialog
+* ``AttributeTable``: Open the attribute table
+* ``LayerStyling``: Open the layer styling dock
+
+"""
+# --
+Qgis.LegendLayerDoubleClickAction.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.LayerTreeFilterFlag.SkipVisibilityCheck.__doc__ = "If set, the standard visibility check should be skipped"
 Qgis.LayerTreeFilterFlag.__doc__ = """Layer tree filter flags.
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2710,6 +2710,13 @@ The development version
       OptimalInInsertionGroup,
     };
 
+    enum class LegendLayerDoubleClickAction /BaseType=IntEnum/
+    {
+      LayerProperties,
+      AttributeTable,
+      LayerStyling,
+    };
+
     enum class LayerTreeFilterFlag /BaseType=IntFlag/
     {
       SkipVisibilityCheck,

--- a/python/PyQt6/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsmapcanvas.sip.in
@@ -37,6 +37,7 @@ Map canvas is a class for displaying all GIS data types on a canvas.
       sipType = nullptr;
 %End
   public:
+
     QgsMapCanvas( QWidget *parent /TransferThis/ = 0 );
 %Docstring
 Constructor

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1607,7 +1607,7 @@ int main( int argc, char *argv[] )
     mypSplash->move( currentDesktopsCenter - mypSplash->rect().center() );
   }
 
-  if ( !takeScreenShots && !myHideSplash && !settings.value( u"qgis/hideSplash"_s ).toBool() )
+  if ( !takeScreenShots && !myHideSplash && !QgisApp::settingsHideSplash->value() )
   {
     //for win and linux we can just automask and png transparency areas will be used
     mypSplash->setMask( pixmap.mask() );

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1616,11 +1616,11 @@ int main( int argc, char *argv[] )
 
   // optionally restore default window state
   // use restoreDefaultWindowState setting only if NOT using command line (then it is set already)
-  if ( myRestoreDefaultWindowState || settings.value( u"qgis/restoreDefaultWindowState"_s, false ).toBool() )
+  if ( myRestoreDefaultWindowState || QgisApp::settingsRestoreDefaultWindowState->value() )
   {
     QgsDebugMsgLevel( u"Resetting /UI/state settings!"_s, 2 );
     settings.remove( u"/UI/state"_s );
-    settings.remove( u"/qgis/restoreDefaultWindowState"_s );
+    QgisApp::settingsRestoreDefaultWindowState->remove();
   }
 
   if ( hideBrowser )

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -519,11 +519,10 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   cmbAttrTableBehavior->setCurrentIndex( cmbAttrTableBehavior->findData( mSettings->enumValue( u"/qgis/attributeTableBehavior"_s, QgsAttributeTableFilterModel::ShowAll ) ) );
 
   mAttrTableViewComboBox->clear();
-  mAttrTableViewComboBox->addItem( tr( "Remember Last View" ), -1 );
-  mAttrTableViewComboBox->addItem( tr( "Table View" ), QgsDualView::AttributeTable );
-  mAttrTableViewComboBox->addItem( tr( "Form View" ), QgsDualView::AttributeEditor );
-  const int currentAttrTableView = QgsAttributeTableDialog::settingsAttributeTableRememberLastView->value() ? -1 : static_cast<int>( QgsAttributeTableDialog::settingsAttributeTableView->value() );
-  mAttrTableViewComboBox->setCurrentIndex( mAttrTableViewComboBox->findData( currentAttrTableView ) );
+  mAttrTableViewComboBox->addItem( tr( "Remember Last View" ), QgsAttributeTableDialog::RememberLast );
+  mAttrTableViewComboBox->addItem( tr( "Table View" ), QgsAttributeTableDialog::AttributeTable );
+  mAttrTableViewComboBox->addItem( tr( "Form View" ), QgsAttributeTableDialog::AttributeEditor );
+  mAttrTableViewComboBox->setCurrentIndex( mAttrTableViewComboBox->findData( static_cast<int>( QgsAttributeTableDialog::settingsAttributeTableInitialView->value() ) ) );
 
   spinBoxAttrTableRowCache->setValue( QgsDualView::settingsAttributeTableRowCache->value() );
   spinBoxAttrTableRowCache->setClearValue( 10000 );
@@ -1641,16 +1640,7 @@ void QgsOptions::saveOptions()
   QgsAttributeTableDialog::settingsAttributeTableDefaultDocked->setValue( cbxAttributeTableDocked->isChecked() );
   QgsAttributeTableDialog::settingsAutosizeAttributeTable->setValue( cbxAutosizeAttributeTable->isChecked() );
   mSettings->setEnumValue( u"/qgis/attributeTableBehavior"_s, ( QgsAttributeTableFilterModel::FilterMode ) cmbAttrTableBehavior->currentData().toInt() );
-  const int selectedAttrTableView = mAttrTableViewComboBox->currentData().toInt();
-  if ( selectedAttrTableView < 0 )
-  {
-    QgsAttributeTableDialog::settingsAttributeTableRememberLastView->setValue( true );
-  }
-  else
-  {
-    QgsAttributeTableDialog::settingsAttributeTableRememberLastView->setValue( false );
-    QgsAttributeTableDialog::settingsAttributeTableView->setValue( static_cast<QgsDualView::ViewMode>( selectedAttrTableView ) );
-  }
+  QgsAttributeTableDialog::settingsAttributeTableInitialView->setValue( static_cast<QgsAttributeTableDialog::InitialView>( mAttrTableViewComboBox->currentData().toInt() ) );
   QgsDualView::settingsAttributeTableRowCache->setValue( spinBoxAttrTableRowCache->value() );
   mSettings->setEnumValue( u"/qgis/promptForSublayers"_s, static_cast<Qgis::SublayerPromptMode>( cmbPromptSublayers->currentData().toInt() ) );
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -793,7 +793,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mLegendGraphicResolutionSpinBox->setValue( mSettings->value( u"/qgis/defaultLegendGraphicResolution"_s, 0 ).toInt() );
 
   // Map Tips delay
-  mMapTipsDelaySpinBox->setValue( mSettings->value( u"qgis/mapTipsDelay"_s, 850 ).toInt() );
+  mMapTipsDelaySpinBox->setValue( QgisApp::settingsMapTipsDelay->value() );
   mMapTipsDelaySpinBox->setClearValue( 850 );
 
   mRespectScreenDpiCheckBox->setChecked( QgsSettingsRegistryGui::settingsRespectScreenDPI->value() );
@@ -1656,7 +1656,7 @@ void QgsOptions::saveOptions()
   QgsSymbolLegendNode::MAXIMUM_SIZE = mLegendSymbolMaximumSizeSpinBox->value();
 
   mSettings->setValue( u"/qgis/defaultLegendGraphicResolution"_s, mLegendGraphicResolutionSpinBox->value() );
-  mSettings->setValue( u"/qgis/mapTipsDelay"_s, mMapTipsDelaySpinBox->value() );
+  QgisApp::settingsMapTipsDelay->setValue( mMapTipsDelaySpinBox->value() );
   QgsSettingsRegistryGui::settingsRespectScreenDPI->setValue( mRespectScreenDpiCheckBox->isChecked() );
 
   mSettings->setEnumValue( u"/qgis/copyFeatureFormat"_s, ( QgsClipboard::CopyFormat ) mComboCopyFeatureFormat->currentData().toInt() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -760,7 +760,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   cbxLegendClassifiers->setChecked( QgsSettingsRegistryCore::settingsLayerTreeShowLegendClassifiers->value() );
   mShowFeatureCountByDefaultCheckBox->setChecked( QgsSettingsRegistryCore::settingsLayerTreeShowFeatureCountForNewLayers->value() );
-  cbxHideSplash->setChecked( mSettings->value( u"/qgis/hideSplash"_s, false ).toBool() );
+  cbxHideSplash->setChecked( QgisApp::settingsHideSplash->value() );
   cbxShowNews->setChecked( !mSettings->value( u"%1/disabled"_s.arg( QgsNewsFeedParser::keyForFeed( QgsWelcomeScreen::newsFeedUrl() ) ), false, QgsSettings::Core ).toBool() );
   cbxCheckVersion->setChecked( mSettings->value( u"/qgis/checkVersion"_s, true ).toBool() );
   cbxCheckVersion->setVisible( mSettings->value( u"/qgis/allowVersionCheck"_s, true ).toBool() );
@@ -1633,7 +1633,7 @@ void QgsOptions::saveOptions()
   bool showLegendClassifiers = QgsSettingsRegistryCore::settingsLayerTreeShowLegendClassifiers->value();
   QgsSettingsRegistryCore::settingsLayerTreeShowLegendClassifiers->setValue( cbxLegendClassifiers->isChecked() );
   QgsSettingsRegistryCore::settingsLayerTreeShowFeatureCountForNewLayers->setValue( mShowFeatureCountByDefaultCheckBox->isChecked() );
-  mSettings->setValue( u"/qgis/hideSplash"_s, cbxHideSplash->isChecked() );
+  QgisApp::settingsHideSplash->setValue( cbxHideSplash->isChecked() );
   mSettings->setValue( u"%1/disabled"_s.arg( QgsNewsFeedParser::keyForFeed( QgsWelcomeScreen::newsFeedUrl() ) ), !cbxShowNews->isChecked(), QgsSettings::Core );
 
   mSettings->setValue( u"/qgis/checkVersion"_s, cbxCheckVersion->isChecked() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -522,7 +522,10 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mAttrTableViewComboBox->addItem( tr( "Remember Last View" ), -1 );
   mAttrTableViewComboBox->addItem( tr( "Table View" ), QgsDualView::AttributeTable );
   mAttrTableViewComboBox->addItem( tr( "Form View" ), QgsDualView::AttributeEditor );
-  mAttrTableViewComboBox->setCurrentIndex( mAttrTableViewComboBox->findData( mSettings->value( u"/qgis/attributeTableView"_s, -1 ).toInt() ) );
+  const int currentAttrTableView = QgsAttributeTableDialog::settingsAttributeTableRememberLastView->value()
+                                     ? -1
+                                     : static_cast<int>( QgsAttributeTableDialog::settingsAttributeTableView->value() );
+  mAttrTableViewComboBox->setCurrentIndex( mAttrTableViewComboBox->findData( currentAttrTableView ) );
 
   spinBoxAttrTableRowCache->setValue( mSettings->value( u"/qgis/attributeTableRowCache"_s, 10000 ).toInt() );
   spinBoxAttrTableRowCache->setClearValue( 10000 );
@@ -1640,7 +1643,16 @@ void QgsOptions::saveOptions()
   QgsAttributeTableDialog::settingsAttributeTableDefaultDocked->setValue( cbxAttributeTableDocked->isChecked() );
   QgsAttributeTableDialog::settingsAutosizeAttributeTable->setValue( cbxAutosizeAttributeTable->isChecked() );
   mSettings->setEnumValue( u"/qgis/attributeTableBehavior"_s, ( QgsAttributeTableFilterModel::FilterMode ) cmbAttrTableBehavior->currentData().toInt() );
-  mSettings->setValue( u"/qgis/attributeTableView"_s, mAttrTableViewComboBox->currentData() );
+  const int selectedAttrTableView = mAttrTableViewComboBox->currentData().toInt();
+  if ( selectedAttrTableView < 0 )
+  {
+    QgsAttributeTableDialog::settingsAttributeTableRememberLastView->setValue( true );
+  }
+  else
+  {
+    QgsAttributeTableDialog::settingsAttributeTableRememberLastView->setValue( false );
+    QgsAttributeTableDialog::settingsAttributeTableView->setValue( static_cast<QgsDualView::ViewMode>( selectedAttrTableView ) );
+  }
   mSettings->setValue( u"/qgis/attributeTableRowCache"_s, spinBoxAttrTableRowCache->value() );
   mSettings->setEnumValue( u"/qgis/promptForSublayers"_s, static_cast<Qgis::SublayerPromptMode>( cmbPromptSublayers->currentData().toInt() ) );
 

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -817,7 +817,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   pbnMeasureColor->setContext( u"gui"_s );
   pbnMeasureColor->setDefaultColor( QColor( 222, 155, 67 ) );
 
-  int projOpen = mSettings->value( u"/qgis/projOpenAtLaunch"_s, 0 ).toInt();
+  int projOpen = QgisApp::settingsProjOpenAtLaunch->value();
   mProjectOnLaunchCmbBx->setCurrentIndex( projOpen );
   mProjectOnLaunchLineEdit->setText( mSettings->value( u"/qgis/projOpenAtLaunchPath"_s ).toString() );
   mProjectOnLaunchLineEdit->setEnabled( projOpen == 2 );
@@ -1666,7 +1666,7 @@ void QgsOptions::saveOptions()
   QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod->setValue( mLayerTreeInsertionMethod->currentData().value<Qgis::LayerTreeInsertionMethod>() );
 
   // project
-  mSettings->setValue( u"/qgis/projOpenAtLaunch"_s, mProjectOnLaunchCmbBx->currentIndex() );
+  QgisApp::settingsProjOpenAtLaunch->setValue( mProjectOnLaunchCmbBx->currentIndex() );
   mSettings->setValue( u"/qgis/projOpenAtLaunchPath"_s, mProjectOnLaunchLineEdit->text() );
 
   QgisApp::settingsAskToSaveProjectChanges->setValue( chbAskToSaveProjectChanges->isChecked() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -762,7 +762,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mShowFeatureCountByDefaultCheckBox->setChecked( QgsSettingsRegistryCore::settingsLayerTreeShowFeatureCountForNewLayers->value() );
   cbxHideSplash->setChecked( QgisApp::settingsHideSplash->value() );
   cbxShowNews->setChecked( !mSettings->value( u"%1/disabled"_s.arg( QgsNewsFeedParser::keyForFeed( QgsWelcomeScreen::newsFeedUrl() ) ), false, QgsSettings::Core ).toBool() );
-  cbxCheckVersion->setChecked( mSettings->value( u"/qgis/checkVersion"_s, true ).toBool() );
+  cbxCheckVersion->setChecked( QgsWelcomeScreen::settingsCheckVersion->value() );
   cbxCheckVersion->setVisible( mSettings->value( u"/qgis/allowVersionCheck"_s, true ).toBool() );
   cbxAttributeTableDocked->setChecked( QgsAttributeTableDialog::settingsAttributeTableDefaultDocked->value() );
   cbxAutosizeAttributeTable->setChecked( QgsAttributeTableDialog::settingsAutosizeAttributeTable->value() );
@@ -1636,7 +1636,7 @@ void QgsOptions::saveOptions()
   QgisApp::settingsHideSplash->setValue( cbxHideSplash->isChecked() );
   mSettings->setValue( u"%1/disabled"_s.arg( QgsNewsFeedParser::keyForFeed( QgsWelcomeScreen::newsFeedUrl() ) ), !cbxShowNews->isChecked(), QgsSettings::Core );
 
-  mSettings->setValue( u"/qgis/checkVersion"_s, cbxCheckVersion->isChecked() );
+  QgsWelcomeScreen::settingsCheckVersion->setValue( cbxCheckVersion->isChecked() );
   QgsAttributeTableDialog::settingsAttributeTableDefaultDocked->setValue( cbxAttributeTableDocked->isChecked() );
   QgsAttributeTableDialog::settingsAutosizeAttributeTable->setValue( cbxAutosizeAttributeTable->isChecked() );
   mSettings->setEnumValue( u"/qgis/attributeTableBehavior"_s, ( QgsAttributeTableFilterModel::FilterMode ) cmbAttrTableBehavior->currentData().toInt() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -819,7 +819,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   int projOpen = QgisApp::settingsProjOpenAtLaunch->value();
   mProjectOnLaunchCmbBx->setCurrentIndex( projOpen );
-  mProjectOnLaunchLineEdit->setText( mSettings->value( u"/qgis/projOpenAtLaunchPath"_s ).toString() );
+  mProjectOnLaunchLineEdit->setText( QgisApp::settingsProjOpenAtLaunchPath->value() );
   mProjectOnLaunchLineEdit->setEnabled( projOpen == 2 );
   mProjectOnLaunchPushBtn->setEnabled( projOpen == 2 );
   connect( mProjectOnLaunchPushBtn, &QAbstractButton::pressed, this, &QgsOptions::selectProjectOnLaunch );
@@ -1667,7 +1667,7 @@ void QgsOptions::saveOptions()
 
   // project
   QgisApp::settingsProjOpenAtLaunch->setValue( mProjectOnLaunchCmbBx->currentIndex() );
-  mSettings->setValue( u"/qgis/projOpenAtLaunchPath"_s, mProjectOnLaunchLineEdit->text() );
+  QgisApp::settingsProjOpenAtLaunchPath->setValue( mProjectOnLaunchLineEdit->text() );
 
   QgisApp::settingsAskToSaveProjectChanges->setValue( chbAskToSaveProjectChanges->isChecked() );
   mSettings->setValue( u"qgis/askToDeleteLayers"_s, mLayerDeleteConfirmationChkBx->isChecked() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -826,7 +826,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   chbAskToSaveProjectChanges->setChecked( QgisApp::settingsAskToSaveProjectChanges->value() );
   mLayerDeleteConfirmationChkBx->setChecked( mSettings->value( u"qgis/askToDeleteLayers"_s, true ).toBool() );
-  chbWarnOldProjectVersion->setChecked( mSettings->value( u"/qgis/warnOldProjectVersion"_s, QVariant( true ) ).toBool() );
+  chbWarnOldProjectVersion->setChecked( QgisApp::settingsWarnOldProjectVersion->value() );
 
   Qgis::EmbeddedScriptMode embeddedScriptMode = QgsSettingsRegistryCore::settingsCodeExecutionBehaviorUndeterminedProjects->value();
   mProjectTrustBehaviorComboBox->setCurrentIndex( mProjectTrustBehaviorComboBox->findData( QVariant::fromValue( embeddedScriptMode ) ) );
@@ -1671,7 +1671,7 @@ void QgsOptions::saveOptions()
 
   QgisApp::settingsAskToSaveProjectChanges->setValue( chbAskToSaveProjectChanges->isChecked() );
   mSettings->setValue( u"qgis/askToDeleteLayers"_s, mLayerDeleteConfirmationChkBx->isChecked() );
-  mSettings->setValue( u"/qgis/warnOldProjectVersion"_s, chbWarnOldProjectVersion->isChecked() );
+  QgisApp::settingsWarnOldProjectVersion->setValue( chbWarnOldProjectVersion->isChecked() );
   if ( ( mSettings->value( u"/qgis/projectTemplateDir"_s ).toString() != leTemplateFolder->text() ) || ( mSettings->value( u"/qgis/newProjectDefault"_s ).toBool() != cbxProjectDefaultNew->isChecked() ) )
   {
     mSettings->setValue( u"/qgis/newProjectDefault"_s, cbxProjectDefaultNew->isChecked() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -824,7 +824,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mProjectOnLaunchPushBtn->setEnabled( projOpen == 2 );
   connect( mProjectOnLaunchPushBtn, &QAbstractButton::pressed, this, &QgsOptions::selectProjectOnLaunch );
 
-  chbAskToSaveProjectChanges->setChecked( mSettings->value( u"qgis/askToSaveProjectChanges"_s, QVariant( true ) ).toBool() );
+  chbAskToSaveProjectChanges->setChecked( QgisApp::settingsAskToSaveProjectChanges->value() );
   mLayerDeleteConfirmationChkBx->setChecked( mSettings->value( u"qgis/askToDeleteLayers"_s, true ).toBool() );
   chbWarnOldProjectVersion->setChecked( mSettings->value( u"/qgis/warnOldProjectVersion"_s, QVariant( true ) ).toBool() );
 
@@ -1669,7 +1669,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( u"/qgis/projOpenAtLaunch"_s, mProjectOnLaunchCmbBx->currentIndex() );
   mSettings->setValue( u"/qgis/projOpenAtLaunchPath"_s, mProjectOnLaunchLineEdit->text() );
 
-  mSettings->setValue( u"/qgis/askToSaveProjectChanges"_s, chbAskToSaveProjectChanges->isChecked() );
+  QgisApp::settingsAskToSaveProjectChanges->setValue( chbAskToSaveProjectChanges->isChecked() );
   mSettings->setValue( u"qgis/askToDeleteLayers"_s, mLayerDeleteConfirmationChkBx->isChecked() );
   mSettings->setValue( u"/qgis/warnOldProjectVersion"_s, chbWarnOldProjectVersion->isChecked() );
   if ( ( mSettings->value( u"/qgis/projectTemplateDir"_s ).toString() != leTemplateFolder->text() ) || ( mSettings->value( u"/qgis/newProjectDefault"_s ).toBool() != cbxProjectDefaultNew->isChecked() ) )

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -774,7 +774,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mComboCopyFeatureFormat->setCurrentIndex( mComboCopyFeatureFormat->findData( mSettings->enumValue( u"/qgis/copyFeatureFormat"_s, QgsClipboard::AttributesWithWKT ) ) );
   leNullValue->setText( QgsApplication::nullRepresentation() );
 
-  cmbLegendDoubleClickAction->setCurrentIndex( mSettings->value( u"/qgis/legendDoubleClickAction"_s, 0 ).toInt() );
+  cmbLegendDoubleClickAction->setCurrentIndex( static_cast<int>( QgisApp::settingsLegendDoubleClickAction->value() ) );
 
   mLayerTreeInsertionMethod->addItem( tr( "Above currently selected layer" ), QVariant::fromValue( Qgis::LayerTreeInsertionMethod::AboveInsertionPoint ) );
   mLayerTreeInsertionMethod->addItem( tr( "Always on top of the layer tree" ), QVariant::fromValue( Qgis::LayerTreeInsertionMethod::TopOfTree ) );
@@ -1662,7 +1662,7 @@ void QgsOptions::saveOptions()
   mSettings->setEnumValue( u"/qgis/copyFeatureFormat"_s, ( QgsClipboard::CopyFormat ) mComboCopyFeatureFormat->currentData().toInt() );
   QgisApp::instance()->setMapTipsDelay( mMapTipsDelaySpinBox->value() );
 
-  mSettings->setValue( u"/qgis/legendDoubleClickAction"_s, cmbLegendDoubleClickAction->currentIndex() );
+  QgisApp::settingsLegendDoubleClickAction->setValue( static_cast<Qgis::LegendLayerDoubleClickAction>( cmbLegendDoubleClickAction->currentIndex() ) );
   QgsSettingsRegistryCore::settingsLayerTreeInsertionMethod->setValue( mLayerTreeInsertionMethod->currentData().value<Qgis::LayerTreeInsertionMethod>() );
 
   // project

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -864,7 +864,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mFileFormatQgsButton->setChecked( defaultProjectFileFormat == Qgis::ProjectFileFormat::Qgs );
 
   // templates
-  cbxProjectDefaultNew->setChecked( mSettings->value( u"/qgis/newProjectDefault"_s, QVariant( false ) ).toBool() );
+  cbxProjectDefaultNew->setChecked( QgisApp::settingsNewProjectDefault->value() );
   QString templateDirName = mSettings->value( u"/qgis/projectTemplateDir"_s, QString( QgsApplication::qgisSettingsDirPath() + "project_templates" ) ).toString();
   // make dir if it doesn't exist - should just be called once
   QDir templateDir;
@@ -1672,9 +1672,9 @@ void QgsOptions::saveOptions()
   QgisApp::settingsAskToSaveProjectChanges->setValue( chbAskToSaveProjectChanges->isChecked() );
   mSettings->setValue( u"qgis/askToDeleteLayers"_s, mLayerDeleteConfirmationChkBx->isChecked() );
   QgisApp::settingsWarnOldProjectVersion->setValue( chbWarnOldProjectVersion->isChecked() );
-  if ( ( mSettings->value( u"/qgis/projectTemplateDir"_s ).toString() != leTemplateFolder->text() ) || ( mSettings->value( u"/qgis/newProjectDefault"_s ).toBool() != cbxProjectDefaultNew->isChecked() ) )
+  if ( ( mSettings->value( u"/qgis/projectTemplateDir"_s ).toString() != leTemplateFolder->text() ) || ( QgisApp::settingsNewProjectDefault->value() != cbxProjectDefaultNew->isChecked() ) )
   {
-    mSettings->setValue( u"/qgis/newProjectDefault"_s, cbxProjectDefaultNew->isChecked() );
+    QgisApp::settingsNewProjectDefault->setValue( cbxProjectDefaultNew->isChecked() );
     mSettings->setValue( u"/qgis/projectTemplateDir"_s, leTemplateFolder->text() );
     QgisApp::instance()->updateProjectFromTemplates();
   }

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -522,12 +522,10 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mAttrTableViewComboBox->addItem( tr( "Remember Last View" ), -1 );
   mAttrTableViewComboBox->addItem( tr( "Table View" ), QgsDualView::AttributeTable );
   mAttrTableViewComboBox->addItem( tr( "Form View" ), QgsDualView::AttributeEditor );
-  const int currentAttrTableView = QgsAttributeTableDialog::settingsAttributeTableRememberLastView->value()
-                                     ? -1
-                                     : static_cast<int>( QgsAttributeTableDialog::settingsAttributeTableView->value() );
+  const int currentAttrTableView = QgsAttributeTableDialog::settingsAttributeTableRememberLastView->value() ? -1 : static_cast<int>( QgsAttributeTableDialog::settingsAttributeTableView->value() );
   mAttrTableViewComboBox->setCurrentIndex( mAttrTableViewComboBox->findData( currentAttrTableView ) );
 
-  spinBoxAttrTableRowCache->setValue( mSettings->value( u"/qgis/attributeTableRowCache"_s, 10000 ).toInt() );
+  spinBoxAttrTableRowCache->setValue( QgsDualView::settingsAttributeTableRowCache->value() );
   spinBoxAttrTableRowCache->setClearValue( 10000 );
   spinBoxAttrTableRowCache->setSpecialValueText( tr( "All" ) );
 
@@ -1653,7 +1651,7 @@ void QgsOptions::saveOptions()
     QgsAttributeTableDialog::settingsAttributeTableRememberLastView->setValue( false );
     QgsAttributeTableDialog::settingsAttributeTableView->setValue( static_cast<QgsDualView::ViewMode>( selectedAttrTableView ) );
   }
-  mSettings->setValue( u"/qgis/attributeTableRowCache"_s, spinBoxAttrTableRowCache->value() );
+  QgsDualView::settingsAttributeTableRowCache->setValue( spinBoxAttrTableRowCache->value() );
   mSettings->setEnumValue( u"/qgis/promptForSublayers"_s, static_cast<Qgis::SublayerPromptMode>( cmbPromptSublayers->currentData().toInt() ) );
 
   QgsFileBasedDataItemProvider::settingsScanItemsInBrowser->setValue( cmbScanItemsInBrowser->currentData().toString() );

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -2046,7 +2046,7 @@ void QgsOptions::restoreDefaultWindowState()
   // richard
   if ( QMessageBox::warning( this, tr( "Restore UI Defaults" ), tr( "Are you sure to reset the UI to default (needs restart)?" ), QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
     return;
-  mSettings->setValue( u"/qgis/restoreDefaultWindowState"_s, true );
+  QgisApp::settingsRestoreDefaultWindowState->setValue( true );
 }
 
 void QgsOptions::mCustomVariablesChkBx_toggled( bool chkd )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1002,6 +1002,8 @@ const QgsSettingsEntryBool *QgisApp::settingsNewProjectDefault
   = new QgsSettingsEntryBool( u"new-project-default"_s, QgsSettingsTree::sTreeProject, false, u"Whether new projects open from the default project template"_s );
 const QgsSettingsEntryInteger *QgisApp::settingsProjOpenAtLaunch
   = new QgsSettingsEntryInteger( u"proj-open-at-launch"_s, QgsSettingsTree::sTreeProject, 0, u"Behavior when QGIS launches: 0=new project, 1=most recent, 2=welcome page, 3=specific project"_s );
+const QgsSettingsEntryString *QgisApp::settingsProjOpenAtLaunchPath
+  = new QgsSettingsEntryString( u"proj-open-at-launch-path"_s, QgsSettingsTree::sTreeProject, QString(), u"Path of the specific project to open at launch"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
@@ -6068,7 +6070,7 @@ void QgisApp::fileOpenAfterLaunch()
   }
   if ( mProjOpen == 2 ) // specific project
   {
-    projPath = settings.value( u"qgis/projOpenAtLaunchPath"_s ).toString();
+    projPath = settingsProjOpenAtLaunchPath->value();
   }
 
   // whether last auto-opening of a project failed

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -996,6 +996,8 @@ const QgsSettingsEntryBool *QgisApp::settingsMapTipsEnabled = new QgsSettingsEnt
 const QgsSettingsEntryInteger *QgisApp::settingsMapTipsDelay = new QgsSettingsEntryInteger( u"delay"_s, QgsSettingsTree::sTreeMapTips, 850, u"Delay in milliseconds before a map tip is displayed"_s );
 const QgsSettingsEntryBool *QgisApp::settingsAskToSaveProjectChanges
   = new QgsSettingsEntryBool( u"ask-to-save-project-changes"_s, QgsSettingsTree::sTreeProject, true, u"Whether to ask the user to save project changes when closing"_s );
+const QgsSettingsEntryBool *QgisApp::settingsWarnOldProjectVersion
+  = new QgsSettingsEntryBool( u"warn-old-project-version"_s, QgsSettingsTree::sTreeProject, true, u"Whether to warn when opening a project saved with an older QGIS version"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
@@ -16415,7 +16417,7 @@ void QgisApp::projectVersionMismatchOccurred( const QString &projectVersion )
   {
     QgsSettings settings;
 
-    if ( settings.value( u"qgis/warnOldProjectVersion"_s, QVariant( true ) ).toBool() )
+    if ( settingsWarnOldProjectVersion->value() )
     {
       QString smalltext = tr(
                             "This project file was saved by QGIS version %1."

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1000,6 +1000,8 @@ const QgsSettingsEntryBool *QgisApp::settingsWarnOldProjectVersion
   = new QgsSettingsEntryBool( u"warn-old-project-version"_s, QgsSettingsTree::sTreeProject, true, u"Whether to warn when opening a project saved with an older QGIS version"_s );
 const QgsSettingsEntryBool *QgisApp::settingsNewProjectDefault
   = new QgsSettingsEntryBool( u"new-project-default"_s, QgsSettingsTree::sTreeProject, false, u"Whether new projects open from the default project template"_s );
+const QgsSettingsEntryInteger *QgisApp::settingsProjOpenAtLaunch
+  = new QgsSettingsEntryInteger( u"proj-open-at-launch"_s, QgsSettingsTree::sTreeProject, 0, u"Behavior when QGIS launches: 0=new project, 1=most recent, 2=welcome page, 3=specific project"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
@@ -1120,7 +1122,7 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
   endProfile();
 
   // what type of project to auto-open
-  mProjOpen = settings.value( u"qgis/projOpenAtLaunch"_s, 0 ).toInt();
+  mProjOpen = settingsProjOpenAtLaunch->value();
 
   // a bar to warn the user with non-blocking messages
   startProfile( tr( "Message bar" ) );
@@ -6085,7 +6087,7 @@ void QgisApp::fileOpenAfterLaunch()
     settings.setValue( u"qgis/projOpenedOKAtLaunch"_s, QVariant( true ) );
 
     // set auto-open project back to 'New' to avoid re-opening bad project
-    settings.setValue( u"qgis/projOpenAtLaunch"_s, QVariant( 0 ) );
+    settingsProjOpenAtLaunch->setValue( 0 );
 
     visibleMessageBar()->pushMessage( autoOpenMsgTitle, tr( "Failed to open: %1" ).arg( projPath ), Qgis::MessageLevel::Critical );
     return;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1004,6 +1004,8 @@ const QgsSettingsEntryInteger *QgisApp::settingsProjOpenAtLaunch
   = new QgsSettingsEntryInteger( u"proj-open-at-launch"_s, QgsSettingsTree::sTreeProject, 0, u"Behavior when QGIS launches: 0=new project, 1=most recent, 2=welcome page, 3=specific project"_s );
 const QgsSettingsEntryString *QgisApp::settingsProjOpenAtLaunchPath
   = new QgsSettingsEntryString( u"proj-open-at-launch-path"_s, QgsSettingsTree::sTreeProject, QString(), u"Path of the specific project to open at launch"_s );
+const QgsSettingsEntryBool *QgisApp::settingsProjOpenedOKAtLaunch
+  = new QgsSettingsEntryBool( u"project-opened-ok-at-launch"_s, QgsSettingsTree::sTreeProject, true, u"Whether the project specified to open at launch was opened successfully last time"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
@@ -5957,7 +5959,7 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
   // don't open template if last auto-opening of a project failed
   if ( !forceBlank )
   {
-    forceBlank = !settings.value( u"qgis/projOpenedOKAtLaunch"_s, QVariant( true ) ).toBool();
+    forceBlank = !settingsProjOpenedOKAtLaunch->value();
   }
 
   if ( !forceBlank && settingsNewProjectDefault->value() )
@@ -6074,7 +6076,7 @@ void QgisApp::fileOpenAfterLaunch()
   }
 
   // whether last auto-opening of a project failed
-  bool projOpenedOK = settings.value( u"qgis/projOpenedOKAtLaunch"_s, QVariant( true ) ).toBool();
+  bool projOpenedOK = settingsProjOpenedOKAtLaunch->value();
 
   // notify user if last attempt at auto-opening a project failed
 
@@ -6086,7 +6088,7 @@ void QgisApp::fileOpenAfterLaunch()
   if ( !projOpenedOK )
   {
     // only show the following 'auto-open project failed' message once, at launch
-    settings.setValue( u"qgis/projOpenedOKAtLaunch"_s, QVariant( true ) );
+    settingsProjOpenedOKAtLaunch->setValue( true );
 
     // set auto-open project back to 'New' to avoid re-opening bad project
     settingsProjOpenAtLaunch->setValue( 0 );
@@ -6122,7 +6124,7 @@ void QgisApp::fileOpenAfterLaunch()
   if ( projectIsFromStorage || QFile::exists( projPath ) )
   {
     // set flag to check on next app launch if the following project opened OK
-    settings.setValue( u"qgis/projOpenedOKAtLaunch"_s, QVariant( false ) );
+    settingsProjOpenedOKAtLaunch->setValue( false );
 
     if ( !addProject( projPath ) )
     {
@@ -6142,8 +6144,7 @@ void QgisApp::fileOpenAfterLaunch()
 
 void QgisApp::fileOpenedOKAfterLaunch()
 {
-  QgsSettings settings;
-  settings.setValue( u"qgis/projOpenedOKAtLaunch"_s, QVariant( true ) );
+  settingsProjOpenedOKAtLaunch->setValue( true );
 }
 
 void QgisApp::fileNewFromTemplateAction( QAction *qAction )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1006,6 +1006,8 @@ const QgsSettingsEntryString *QgisApp::settingsProjOpenAtLaunchPath
   = new QgsSettingsEntryString( u"proj-open-at-launch-path"_s, QgsSettingsTree::sTreeProject, QString(), u"Path of the specific project to open at launch"_s );
 const QgsSettingsEntryBool *QgisApp::settingsProjOpenedOKAtLaunch
   = new QgsSettingsEntryBool( u"project-opened-ok-at-launch"_s, QgsSettingsTree::sTreeProject, true, u"Whether the project specified to open at launch was opened successfully last time"_s );
+const QgsSettingsEntryBool *QgisApp::settingsShowScriptWarning
+  = new QgsSettingsEntryBool( u"show-script-warning"_s, QgsSettingsTree::sTreeApp, true, u"Whether to warn the user before running a Python script embedded in a project"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
@@ -7019,7 +7021,7 @@ void QgisApp::runScript( const QString &filePath )
     return;
 
   QgsSettings settings;
-  bool showScriptWarning = settings.value( u"UI/showScriptWarning"_s, true ).toBool();
+  bool showScriptWarning = settingsShowScriptWarning->value();
 
   QMessageBox msgbox;
   if ( showScriptWarning )
@@ -7033,7 +7035,7 @@ void QgisApp::runScript( const QString &filePath )
     QCheckBox *cb = new QCheckBox( tr( "Don't show this again." ) );
     msgbox.setCheckBox( cb );
     msgbox.exec();
-    settings.setValue( u"UI/showScriptWarning"_s, !msgbox.checkBox()->isChecked() );
+    settingsShowScriptWarning->setValue( !msgbox.checkBox()->isChecked() );
   }
 
   if ( !showScriptWarning || msgbox.result() == QMessageBox::Yes )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -993,6 +993,7 @@ const QgsSettingsEntryBool *QgisApp::settingsEnableEventTracing
   = new QgsSettingsEntryBool( u"enable-event-tracing"_s, QgsSettingsTree::sTreeApp, false, u"Whether event tracing is enabled for performance diagnostics"_s );
 const QgsSettingsEntryBool *QgisApp::settingsHideSplash = new QgsSettingsEntryBool( u"hide-splash"_s, QgsSettingsTree::sTreeApp, false, u"Whether the splash screen is hidden at QGIS startup"_s );
 const QgsSettingsEntryBool *QgisApp::settingsMapTipsEnabled = new QgsSettingsEntryBool( u"enabled"_s, QgsSettingsTree::sTreeMapTips, false, u"Whether map tips are enabled"_s );
+const QgsSettingsEntryInteger *QgisApp::settingsMapTipsDelay = new QgsSettingsEntryInteger( u"delay"_s, QgsSettingsTree::sTreeMapTips, 850, u"Delay in milliseconds before a map tip is displayed"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
@@ -5156,7 +5157,7 @@ void QgisApp::createMapTips()
   // set the delay to 0.850 seconds or time defined in the Settings
   // timer will be started next time the mouse moves
   QgsSettings settings;
-  int timerInterval = settings.value( u"qgis/mapTipsDelay"_s, 850 ).toInt();
+  int timerInterval = settingsMapTipsDelay->value();
   mpMapTipsTimer->setInterval( timerInterval );
   mpMapTipsTimer->setSingleShot( true );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -691,10 +691,9 @@ void QgisApp::emitCustomCrsValidation( QgsCoordinateReferenceSystem &srs )
 void QgisApp::layerTreeViewDoubleClicked( const QModelIndex &index )
 {
   Q_UNUSED( index )
-  QgsSettings settings;
-  switch ( settings.value( u"qgis/legendDoubleClickAction"_s, 0 ).toInt() )
+  switch ( settingsLegendDoubleClickAction->value() )
   {
-    case 0:
+    case Qgis::LegendLayerDoubleClickAction::LayerProperties:
     {
       //show properties
       if ( mLayerTreeView )
@@ -725,14 +724,14 @@ void QgisApp::layerTreeViewDoubleClicked( const QModelIndex &index )
       QgisApp::instance()->layerProperties();
       break;
     }
-    case 1:
+    case Qgis::LegendLayerDoubleClickAction::AttributeTable:
     {
       QgsSettings settings;
       QgsAttributeTableFilterModel::FilterMode initialMode = settings.enumValue( u"qgis/attributeTableBehavior"_s, QgsAttributeTableFilterModel::ShowAll );
       QgisApp::instance()->attributeTable( initialMode );
       break;
     }
-    case 2:
+    case Qgis::LegendLayerDoubleClickAction::LayerStyling:
       mapStyleDock( true );
       break;
     default:
@@ -989,6 +988,8 @@ QgisApp *QgisApp::sInstance = nullptr;
 const QgisApp::AppOptions QgisApp::DEFAULT_OPTIONS = QgisApp::AppOptions( QgisApp::AppOption::RestorePlugins ) | QgisApp::AppOption::EnablePython;
 
 const QgsSettingsEntryBool *QgisApp::settingsAskToDeleteFeatures = new QgsSettingsEntryBool( u"ask-to-delete-features"_s, QgsSettingsTree::sTreeApp, true );
+const QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction> *QgisApp::settingsLegendDoubleClickAction
+  = new QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction>( u"legend-double-click-action"_s, QgsSettingsTree::sTreeApp, Qgis::LegendLayerDoubleClickAction::LayerProperties, u"Action performed when double-clicking a layer in the legend"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1010,6 +1010,8 @@ const QgsSettingsEntryBool *QgisApp::settingsShowScriptWarning
   = new QgsSettingsEntryBool( u"show-script-warning"_s, QgsSettingsTree::sTreeApp, true, u"Whether to warn the user before running a Python script embedded in a project"_s );
 const QgsSettingsEntryBool *QgisApp::settingsDisplayWaylandWarning
   = new QgsSettingsEntryBool( u"display-wayland-warning"_s, QgsSettingsTree::sTreeGui, true, u"Whether to show the warning dialog when running QGIS under Wayland"_s );
+const QgsSettingsEntryBool *QgisApp::settingsRestoreDefaultWindowState
+  = new QgsSettingsEntryBool( u"restore-default-window-state"_s, QgsSettingsTree::sTreeApp, false, u"Whether to restore the default window state on next QGIS startup"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -766,14 +766,13 @@ void QgisApp::onActiveLayerChanged( QgsMapLayer *layer )
 
 void QgisApp::toggleEventTracing()
 {
-  QgsSettings settings;
-  if ( !settings.value( u"qgis/enableEventTracing"_s, false ).toBool() )
+  if ( !settingsEnableEventTracing->value() )
   {
     // make sure the setting is available in Options > Advanced
-    if ( !settings.contains( u"qgis/enableEventTracing"_s ) )
-      settings.setValue( u"qgis/enableEventTracing"_s, false );
+    if ( !settingsEnableEventTracing->exists() )
+      settingsEnableEventTracing->setValue( false );
 
-    messageBar()->pushWarning( tr( "Event Tracing" ), tr( "Tracing is not enabled. Look for \"enableEventTracing\" in Options > Advanced." ) );
+    messageBar()->pushWarning( tr( "Event Tracing" ), tr( "Tracing is not enabled. Look for \"enable-event-tracing\" in Options > Advanced." ) );
     return;
   }
 
@@ -990,6 +989,8 @@ const QgisApp::AppOptions QgisApp::DEFAULT_OPTIONS = QgisApp::AppOptions( QgisAp
 const QgsSettingsEntryBool *QgisApp::settingsAskToDeleteFeatures = new QgsSettingsEntryBool( u"ask-to-delete-features"_s, QgsSettingsTree::sTreeApp, true );
 const QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction> *QgisApp::settingsLegendDoubleClickAction
   = new QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction>( u"legend-double-click-action"_s, QgsSettingsTree::sTreeApp, Qgis::LegendLayerDoubleClickAction::LayerProperties, u"Action performed when double-clicking a layer in the legend"_s );
+const QgsSettingsEntryBool *QgisApp::settingsEnableEventTracing
+  = new QgsSettingsEntryBool( u"enable-event-tracing"_s, QgsSettingsTree::sTreeApp, false, u"Whether event tracing is enabled for performance diagnostics"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1008,6 +1008,8 @@ const QgsSettingsEntryBool *QgisApp::settingsProjOpenedOKAtLaunch
   = new QgsSettingsEntryBool( u"project-opened-ok-at-launch"_s, QgsSettingsTree::sTreeProject, true, u"Whether the project specified to open at launch was opened successfully last time"_s );
 const QgsSettingsEntryBool *QgisApp::settingsShowScriptWarning
   = new QgsSettingsEntryBool( u"show-script-warning"_s, QgsSettingsTree::sTreeApp, true, u"Whether to warn the user before running a Python script embedded in a project"_s );
+const QgsSettingsEntryBool *QgisApp::settingsDisplayWaylandWarning
+  = new QgsSettingsEntryBool( u"display-wayland-warning"_s, QgsSettingsTree::sTreeGui, true, u"Whether to show the warning dialog when running QGIS under Wayland"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
@@ -1998,7 +2000,7 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
 
   if ( QGuiApplication::platformName() == "wayland"_L1 )
   {
-    const bool displayWaylandWarning = settings.value( u"/UI/displayWaylandWarning"_s, true ).toBool();
+    const bool displayWaylandWarning = settingsDisplayWaylandWarning->value();
     if ( displayWaylandWarning )
     {
       const QString shortMessage = tr( "Wayland session detected: User experience will be degraded" );
@@ -2027,7 +2029,7 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
 
       QPushButton *ignoreButton = new QPushButton( tr( "Ignore" ) );
       connect( ignoreButton, &QPushButton::clicked, this, [this, messageWidget] {
-        QgsSettings().setValue( u"/UI/displayWaylandWarning"_s, false );
+        QgisApp::settingsDisplayWaylandWarning->setValue( false );
         messageBar()->popWidget( messageWidget );
       } );
       messageWidget->layout()->addWidget( ignoreButton );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1094,12 +1094,12 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
 
   connect( mMapCanvas, &QgsMapCanvas::messageEmitted, this, &QgisApp::displayMessage );
 
-  if ( !settings.value( u"qgis/main_canvas_preview_jobs"_s ).isValid() )
+  if ( !QgsMapCanvas::settingsMainCanvasPreviewJobs->exists() )
   {
     // So that it appears in advanced settings
-    settings.setValue( u"qgis/main_canvas_preview_jobs"_s, true );
+    QgsMapCanvas::settingsMainCanvasPreviewJobs->setValue( true );
   }
-  mMapCanvas->setPreviewJobsEnabled( settings.value( u"qgis/main_canvas_preview_jobs"_s, true ).toBool() );
+  mMapCanvas->setPreviewJobsEnabled( QgsMapCanvas::settingsMainCanvasPreviewJobs->value() );
   // record profiling time on the main canvas only
   mMapCanvas->mapSettings().setFlag( Qgis::MapSettingsFlag::RecordProfile );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -992,6 +992,7 @@ const QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction> *QgisApp::set
 const QgsSettingsEntryBool *QgisApp::settingsEnableEventTracing
   = new QgsSettingsEntryBool( u"enable-event-tracing"_s, QgsSettingsTree::sTreeApp, false, u"Whether event tracing is enabled for performance diagnostics"_s );
 const QgsSettingsEntryBool *QgisApp::settingsHideSplash = new QgsSettingsEntryBool( u"hide-splash"_s, QgsSettingsTree::sTreeApp, false, u"Whether the splash screen is hidden at QGIS startup"_s );
+const QgsSettingsEntryBool *QgisApp::settingsMapTipsEnabled = new QgsSettingsEntryBool( u"enabled"_s, QgsSettingsTree::sTreeMapTips, false, u"Whether map tips are enabled"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
@@ -1750,7 +1751,7 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
 
   mMapTipsVisible = false;
   // This turns on the map tip if they where active in the last session
-  if ( settings.value( u"qgis/enableMapTips"_s, false ).toBool() )
+  if ( settingsMapTipsEnabled->value() )
   {
     toggleMapTips( true );
   }
@@ -10719,7 +10720,7 @@ void QgisApp::toggleMapTips( bool enabled )
 {
   mMapTipsVisible = enabled;
   // Store if maptips are active
-  QgsSettings().setValue( u"/qgis/enableMapTips"_s, mMapTipsVisible );
+  QgisApp::settingsMapTipsEnabled->setValue( mMapTipsVisible );
 
   // if off, stop the timer
   if ( !mMapTipsVisible )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -991,6 +991,7 @@ const QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction> *QgisApp::set
   = new QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction>( u"legend-double-click-action"_s, QgsSettingsTree::sTreeApp, Qgis::LegendLayerDoubleClickAction::LayerProperties, u"Action performed when double-clicking a layer in the legend"_s );
 const QgsSettingsEntryBool *QgisApp::settingsEnableEventTracing
   = new QgsSettingsEntryBool( u"enable-event-tracing"_s, QgsSettingsTree::sTreeApp, false, u"Whether event tracing is enabled for performance diagnostics"_s );
+const QgsSettingsEntryBool *QgisApp::settingsHideSplash = new QgsSettingsEntryBool( u"hide-splash"_s, QgsSettingsTree::sTreeApp, false, u"Whether the splash screen is hidden at QGIS startup"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2917,7 +2917,7 @@ void QgisApp::applyDefaultSettingsToCanvas( QgsMapCanvas *canvas )
   canvas->enableAntiAliasing( QgsSettingsRegistryGui::settingsEnableAntiAliasing->value() );
   double zoomFactor = QgsSettingsRegistryGui::settingsZoomFactor->value();
   canvas->setWheelFactor( zoomFactor );
-  canvas->setCachingEnabled( settings.value( u"qgis/enable_render_caching"_s, true ).toBool() );
+  canvas->setCachingEnabled( QgsMapCanvas::settingsEnableRenderCaching->value() );
   canvas->setParallelRenderingEnabled( settings.value( u"qgis/parallel_rendering"_s, true ).toBool() );
   canvas->setMapUpdateInterval( QgsSettingsRegistryGui::settingsMapUpdateInterval->value() );
   canvas->setSegmentationTolerance( QgsSettingsRegistryGui::settingsSegmentationTolerance->value() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -998,6 +998,8 @@ const QgsSettingsEntryBool *QgisApp::settingsAskToSaveProjectChanges
   = new QgsSettingsEntryBool( u"ask-to-save-project-changes"_s, QgsSettingsTree::sTreeProject, true, u"Whether to ask the user to save project changes when closing"_s );
 const QgsSettingsEntryBool *QgisApp::settingsWarnOldProjectVersion
   = new QgsSettingsEntryBool( u"warn-old-project-version"_s, QgsSettingsTree::sTreeProject, true, u"Whether to warn when opening a project saved with an older QGIS version"_s );
+const QgsSettingsEntryBool *QgisApp::settingsNewProjectDefault
+  = new QgsSettingsEntryBool( u"new-project-default"_s, QgsSettingsTree::sTreeProject, false, u"Whether new projects open from the default project template"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
@@ -5449,7 +5451,7 @@ void QgisApp::updateProjectFromTemplates()
   }
 
   // add <blank> entry, which loads a blank template (regardless of "default template")
-  if ( settings.value( u"qgis/newProjectDefault"_s, QVariant( false ) ).toBool() )
+  if ( settingsNewProjectDefault->value() )
     mProjectFromTemplateMenu->addAction( tr( "< Blank >" ) );
 }
 
@@ -5954,7 +5956,7 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
     forceBlank = !settings.value( u"qgis/projOpenedOKAtLaunch"_s, QVariant( true ) ).toBool();
   }
 
-  if ( !forceBlank && settings.value( u"qgis/newProjectDefault"_s, QVariant( false ) ).toBool() )
+  if ( !forceBlank && settingsNewProjectDefault->value() )
   {
     fileNewFromDefaultTemplate();
   }
@@ -6092,7 +6094,7 @@ void QgisApp::fileOpenAfterLaunch()
   if ( mProjOpen == 3 ) // new project
   {
     // open default template, if defined
-    if ( settings.value( u"qgis/newProjectDefault"_s, QVariant( false ) ).toBool() )
+    if ( settingsNewProjectDefault->value() )
     {
       fileNewFromDefaultTemplate();
     }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -987,8 +987,8 @@ QgisApp *QgisApp::sInstance = nullptr;
 const QgisApp::AppOptions QgisApp::DEFAULT_OPTIONS = QgisApp::AppOptions( QgisApp::AppOption::RestorePlugins ) | QgisApp::AppOption::EnablePython;
 
 const QgsSettingsEntryBool *QgisApp::settingsAskToDeleteFeatures = new QgsSettingsEntryBool( u"ask-to-delete-features"_s, QgsSettingsTree::sTreeApp, true );
-const QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction> *QgisApp::settingsLegendDoubleClickAction
-  = new QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction>( u"legend-double-click-action"_s, QgsSettingsTree::sTreeApp, Qgis::LegendLayerDoubleClickAction::LayerProperties, u"Action performed when double-clicking a layer in the legend"_s );
+const QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction> *QgisApp::settingsLegendDoubleClickAction = new QgsSettingsEntryEnumFlag<
+  Qgis::LegendLayerDoubleClickAction>( u"legend-double-click-action"_s, QgsSettingsTree::sTreeApp, Qgis::LegendLayerDoubleClickAction::LayerProperties, u"Action performed when double-clicking a layer in the legend"_s );
 const QgsSettingsEntryBool *QgisApp::settingsEnableEventTracing
   = new QgsSettingsEntryBool( u"enable-event-tracing"_s, QgsSettingsTree::sTreeApp, false, u"Whether event tracing is enabled for performance diagnostics"_s );
 const QgsSettingsEntryBool *QgisApp::settingsHideSplash = new QgsSettingsEntryBool( u"hide-splash"_s, QgsSettingsTree::sTreeApp, false, u"Whether the splash screen is hidden at QGIS startup"_s );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -994,6 +994,8 @@ const QgsSettingsEntryBool *QgisApp::settingsEnableEventTracing
 const QgsSettingsEntryBool *QgisApp::settingsHideSplash = new QgsSettingsEntryBool( u"hide-splash"_s, QgsSettingsTree::sTreeApp, false, u"Whether the splash screen is hidden at QGIS startup"_s );
 const QgsSettingsEntryBool *QgisApp::settingsMapTipsEnabled = new QgsSettingsEntryBool( u"enabled"_s, QgsSettingsTree::sTreeMapTips, false, u"Whether map tips are enabled"_s );
 const QgsSettingsEntryInteger *QgisApp::settingsMapTipsDelay = new QgsSettingsEntryInteger( u"delay"_s, QgsSettingsTree::sTreeMapTips, 850, u"Delay in milliseconds before a map tip is displayed"_s );
+const QgsSettingsEntryBool *QgisApp::settingsAskToSaveProjectChanges
+  = new QgsSettingsEntryBool( u"ask-to-save-project-changes"_s, QgsSettingsTree::sTreeProject, true, u"Whether to ask the user to save project changes when closing"_s );
 
 QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
@@ -13734,7 +13736,7 @@ bool QgisApp::saveDirty()
   QgsCanvasRefreshBlocker refreshBlocker;
 
   QgsSettings settings;
-  bool askThem = settings.value( u"qgis/askToSaveProjectChanges"_s, true ).toBool();
+  bool askThem = settingsAskToSaveProjectChanges->value();
 
   if ( askThem && QgsProject::instance()->isDirty() )
   {

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -245,6 +245,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction> *settingsLegendDoubleClickAction SIP_SKIP;
     static const QgsSettingsEntryBool *settingsEnableEventTracing SIP_SKIP;
     static const QgsSettingsEntryBool *settingsHideSplash SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsMapTipsEnabled SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -243,6 +243,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     static const QgsSettingsEntryBool *settingsAskToDeleteFeatures;
     static const QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction> *settingsLegendDoubleClickAction SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsEnableEventTracing SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -247,6 +247,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryBool *settingsHideSplash SIP_SKIP;
     static const QgsSettingsEntryBool *settingsMapTipsEnabled SIP_SKIP;
     static const QgsSettingsEntryInteger *settingsMapTipsDelay SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsAskToSaveProjectChanges SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -115,6 +115,8 @@ class Qgs3DMapCanvasWidget;
 class QgsVertexEditor;
 class QgsMapLayerActionContext;
 class QgsSettingsEntryBool;
+class QgsSettingsEntryInteger;
+template<class T> class QgsSettingsEntryEnumFlag;
 
 class QDomDocument;
 class QNetworkReply;
@@ -240,6 +242,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const AppOptions DEFAULT_OPTIONS;
 
     static const QgsSettingsEntryBool *settingsAskToDeleteFeatures;
+    static const QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction> *settingsLegendDoubleClickAction SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -254,6 +254,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryString *settingsProjOpenAtLaunchPath SIP_SKIP;
     static const QgsSettingsEntryBool *settingsProjOpenedOKAtLaunch SIP_SKIP;
     static const QgsSettingsEntryBool *settingsShowScriptWarning SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsDisplayWaylandWarning SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -248,6 +248,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryBool *settingsMapTipsEnabled SIP_SKIP;
     static const QgsSettingsEntryInteger *settingsMapTipsDelay SIP_SKIP;
     static const QgsSettingsEntryBool *settingsAskToSaveProjectChanges SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsWarnOldProjectVersion SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -252,6 +252,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryBool *settingsNewProjectDefault SIP_SKIP;
     static const QgsSettingsEntryInteger *settingsProjOpenAtLaunch SIP_SKIP;
     static const QgsSettingsEntryString *settingsProjOpenAtLaunchPath SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsProjOpenedOKAtLaunch SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -246,6 +246,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryBool *settingsEnableEventTracing SIP_SKIP;
     static const QgsSettingsEntryBool *settingsHideSplash SIP_SKIP;
     static const QgsSettingsEntryBool *settingsMapTipsEnabled SIP_SKIP;
+    static const QgsSettingsEntryInteger *settingsMapTipsDelay SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -250,6 +250,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryBool *settingsAskToSaveProjectChanges SIP_SKIP;
     static const QgsSettingsEntryBool *settingsWarnOldProjectVersion SIP_SKIP;
     static const QgsSettingsEntryBool *settingsNewProjectDefault SIP_SKIP;
+    static const QgsSettingsEntryInteger *settingsProjOpenAtLaunch SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -255,6 +255,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryBool *settingsProjOpenedOKAtLaunch SIP_SKIP;
     static const QgsSettingsEntryBool *settingsShowScriptWarning SIP_SKIP;
     static const QgsSettingsEntryBool *settingsDisplayWaylandWarning SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsRestoreDefaultWindowState SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -253,6 +253,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryInteger *settingsProjOpenAtLaunch SIP_SKIP;
     static const QgsSettingsEntryString *settingsProjOpenAtLaunchPath SIP_SKIP;
     static const QgsSettingsEntryBool *settingsProjOpenedOKAtLaunch SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsShowScriptWarning SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -251,6 +251,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryBool *settingsWarnOldProjectVersion SIP_SKIP;
     static const QgsSettingsEntryBool *settingsNewProjectDefault SIP_SKIP;
     static const QgsSettingsEntryInteger *settingsProjOpenAtLaunch SIP_SKIP;
+    static const QgsSettingsEntryString *settingsProjOpenAtLaunchPath SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -244,6 +244,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryBool *settingsAskToDeleteFeatures;
     static const QgsSettingsEntryEnumFlag<Qgis::LegendLayerDoubleClickAction> *settingsLegendDoubleClickAction SIP_SKIP;
     static const QgsSettingsEntryBool *settingsEnableEventTracing SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsHideSplash SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -249,6 +249,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     static const QgsSettingsEntryInteger *settingsMapTipsDelay SIP_SKIP;
     static const QgsSettingsEntryBool *settingsAskToSaveProjectChanges SIP_SKIP;
     static const QgsSettingsEntryBool *settingsWarnOldProjectVersion SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsNewProjectDefault SIP_SKIP;
 
     //! Constructor
     QgisApp(

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -68,11 +68,8 @@ const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAttributeTableDefau
 
 const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAutosizeAttributeTable = new QgsSettingsEntryBool( u"autosize-attribute-table"_s, QgsSettingsTree::sTreeAttributeTable, false );
 
-const QgsSettingsEntryEnumFlag<QgsDualView::ViewMode> *QgsAttributeTableDialog::settingsAttributeTableView
-  = new QgsSettingsEntryEnumFlag<QgsDualView::ViewMode>( u"attribute-table-view"_s, QgsSettingsTree::sTreeAttributeTable, QgsDualView::AttributeTable, u"Initial attribute table view"_s );
-
-const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAttributeTableRememberLastView
-  = new QgsSettingsEntryBool( u"remember-last-view"_s, QgsSettingsTree::sTreeAttributeTable, true, u"Whether to remember the last used attribute table view when reopening it."_s );
+const QgsSettingsEntryEnumFlag<QgsAttributeTableDialog::InitialView> *QgsAttributeTableDialog::settingsAttributeTableInitialView = new QgsSettingsEntryEnumFlag<
+  QgsAttributeTableDialog::InitialView>( u"attribute-table-initial-view"_s, QgsSettingsTree::sTreeAttributeTable, QgsAttributeTableDialog::RememberLast, u"Initial attribute table view (or remember last used view)"_s );
 
 const QgsSettingsEntryEnumFlag<QgsAttributeTableConfig::AddFeatureMethod> *QgsAttributeTableDialog::settingsDefaultAddFeatureMethod = new QgsSettingsEntryEnumFlag<
   QgsAttributeTableConfig::AddFeatureMethod>( u"default-add-feature-method"_s, QgsSettingsTree::sTreeAttributeTable, QgsAttributeTableConfig::AddFeatureMethod::Table, u"Default method used to add a new feature from the attribute table when no per-layer method is set."_s );
@@ -435,13 +432,14 @@ QgsAttributeTableDialog::QgsAttributeTableDialog(
     mUpdateExpressionText->setLeftHandButtonStyle( true );
 
     int initialView;
-    if ( QgsAttributeTableDialog::settingsAttributeTableRememberLastView->value() )
+    const QgsAttributeTableDialog::InitialView configuredView = QgsAttributeTableDialog::settingsAttributeTableInitialView->value();
+    if ( configuredView == QgsAttributeTableDialog::RememberLast )
     {
       initialView = settings.value( u"qgis/attributeTableLastView"_s, QgsDualView::AttributeTable ).toInt();
     }
     else
     {
-      initialView = QgsAttributeTableDialog::settingsAttributeTableView->value();
+      initialView = static_cast<int>( configuredView );
     }
     mMainView->setView( static_cast<QgsDualView::ViewMode>( initialView ) );
     mMainViewButtonGroup->button( initialView )->setChecked( true );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -68,6 +68,10 @@ const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAttributeTableDefau
 
 const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAutosizeAttributeTable = new QgsSettingsEntryBool( u"autosize-attribute-table"_s, QgsSettingsTree::sTreeAttributeTable, false );
 
+const QgsSettingsEntryEnumFlag<QgsDualView::ViewMode> *QgsAttributeTableDialog::settingsAttributeTableView = new QgsSettingsEntryEnumFlag<QgsDualView::ViewMode>( u"attribute-table-view"_s, QgsSettingsTree::sTreeAttributeTable, QgsDualView::AttributeTable, u"Initial attribute table view"_s );
+
+const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAttributeTableRememberLastView = new QgsSettingsEntryBool( u"remember-last-view"_s, QgsSettingsTree::sTreeAttributeTable, true, u"Whether to remember the last used attribute table view when reopening it."_s );
+
 const QgsSettingsEntryEnumFlag<QgsAttributeTableConfig::AddFeatureMethod> *QgsAttributeTableDialog::settingsDefaultAddFeatureMethod = new QgsSettingsEntryEnumFlag<
   QgsAttributeTableConfig::AddFeatureMethod>( u"default-add-feature-method"_s, QgsSettingsTree::sTreeAttributeTable, QgsAttributeTableConfig::AddFeatureMethod::Table, u"Default method used to add a new feature from the attribute table when no per-layer method is set."_s );
 
@@ -428,10 +432,14 @@ QgsAttributeTableDialog::QgsAttributeTableDialog(
     mUpdateExpressionText->setLayer( mLayer );
     mUpdateExpressionText->setLeftHandButtonStyle( true );
 
-    int initialView = settings.value( u"qgis/attributeTableView"_s, -1 ).toInt();
-    if ( initialView < 0 )
+    int initialView;
+    if ( QgsAttributeTableDialog::settingsAttributeTableRememberLastView->value() )
     {
       initialView = settings.value( u"qgis/attributeTableLastView"_s, QgsDualView::AttributeTable ).toInt();
+    }
+    else
+    {
+      initialView = QgsAttributeTableDialog::settingsAttributeTableView->value();
     }
     mMainView->setView( static_cast<QgsDualView::ViewMode>( initialView ) );
     mMainViewButtonGroup->button( initialView )->setChecked( true );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -68,9 +68,11 @@ const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAttributeTableDefau
 
 const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAutosizeAttributeTable = new QgsSettingsEntryBool( u"autosize-attribute-table"_s, QgsSettingsTree::sTreeAttributeTable, false );
 
-const QgsSettingsEntryEnumFlag<QgsDualView::ViewMode> *QgsAttributeTableDialog::settingsAttributeTableView = new QgsSettingsEntryEnumFlag<QgsDualView::ViewMode>( u"attribute-table-view"_s, QgsSettingsTree::sTreeAttributeTable, QgsDualView::AttributeTable, u"Initial attribute table view"_s );
+const QgsSettingsEntryEnumFlag<QgsDualView::ViewMode> *QgsAttributeTableDialog::settingsAttributeTableView
+  = new QgsSettingsEntryEnumFlag<QgsDualView::ViewMode>( u"attribute-table-view"_s, QgsSettingsTree::sTreeAttributeTable, QgsDualView::AttributeTable, u"Initial attribute table view"_s );
 
-const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAttributeTableRememberLastView = new QgsSettingsEntryBool( u"remember-last-view"_s, QgsSettingsTree::sTreeAttributeTable, true, u"Whether to remember the last used attribute table view when reopening it."_s );
+const QgsSettingsEntryBool *QgsAttributeTableDialog::settingsAttributeTableRememberLastView
+  = new QgsSettingsEntryBool( u"remember-last-view"_s, QgsSettingsTree::sTreeAttributeTable, true, u"Whether to remember the last used attribute table view when reopening it."_s );
 
 const QgsSettingsEntryEnumFlag<QgsAttributeTableConfig::AddFeatureMethod> *QgsAttributeTableDialog::settingsDefaultAddFeatureMethod = new QgsSettingsEntryEnumFlag<
   QgsAttributeTableConfig::AddFeatureMethod>( u"default-add-feature-method"_s, QgsSettingsTree::sTreeAttributeTable, QgsAttributeTableConfig::AddFeatureMethod::Table, u"Default method used to add a new feature from the attribute table when no per-layer method is set."_s );

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -52,6 +52,12 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     //! Settings entry whether attribute tables are docked by default
     static const QgsSettingsEntryBool *settingsAttributeTableDefaultDocked SIP_SKIP;
 
+    //! Settings entry for the initial attribute table view (table or form)
+    static const QgsSettingsEntryEnumFlag<QgsDualView::ViewMode> *settingsAttributeTableView SIP_SKIP;
+
+    //! Settings entry whether to remember the last used attribute table view instead of using settingsAttributeTableView
+    static const QgsSettingsEntryBool *settingsAttributeTableRememberLastView SIP_SKIP;
+
     /**
      * Constructor
      * \param layer layer pointer

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -52,11 +52,22 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     //! Settings entry whether attribute tables are docked by default
     static const QgsSettingsEntryBool *settingsAttributeTableDefaultDocked SIP_SKIP;
 
-    //! Settings entry for the initial attribute table view (table or form)
-    static const QgsSettingsEntryEnumFlag<QgsDualView::ViewMode> *settingsAttributeTableView SIP_SKIP;
+    /**
+     * Initial attribute table view used when opening the dialog.
+     *
+     * Mirrors QgsDualView::ViewMode but adds a sentinel value to
+     * mean "reuse the view last used in the dialog".
+     */
+    enum InitialView
+    {
+      RememberLast = -1,                              //!< Reuse the view last used in the dialog
+      AttributeTable = QgsDualView::AttributeTable,   //!< Table layout
+      AttributeEditor = QgsDualView::AttributeEditor, //!< Form layout
+    };
+    Q_ENUM( InitialView )
 
-    //! Settings entry whether to remember the last used attribute table view instead of using settingsAttributeTableView
-    static const QgsSettingsEntryBool *settingsAttributeTableRememberLastView SIP_SKIP;
+    //! Settings entry for the initial attribute table view (table, form or remember last)
+    static const QgsSettingsEntryEnumFlag<QgsAttributeTableDialog::InitialView> *settingsAttributeTableInitialView SIP_SKIP;
 
     /**
      * Constructor

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -766,7 +766,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   mFileName->setStorageMode( QgsFileWidget::SaveFile );
   mFileName->setFilter( tr( "DXF files" ) + " (*.dxf *.DXF)" );
   mFileName->setDialogTitle( tr( "Export as DXF" ) );
-  mFileName->setDefaultRoot( settings.value( u"qgis/lastDxfDir"_s, QDir::homePath() ).toString() );
+  mFileName->setDefaultRoot( QgsDxfExportDialog::settingsLastDxfDir->value() );
 
   connect( this, &QDialog::accepted, this, &QgsDxfExportDialog::saveSettings );
   connect( mSelectAllButton, &QAbstractButton::clicked, this, &QgsDxfExportDialog::selectAll );
@@ -778,7 +778,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   connect( mFileName, &QgsFileWidget::fileChanged, this, [this]( const QString &filePath ) {
     QgsSettings settings;
     QFileInfo tmplFileInfo( filePath );
-    settings.setValue( u"qgis/lastDxfDir"_s, tmplFileInfo.absolutePath() );
+    QgsDxfExportDialog::settingsLastDxfDir->setValue( tmplFileInfo.absolutePath() );
 
     setOkEnabled();
   } );
@@ -1264,7 +1264,7 @@ void QgsDxfExportDialog::saveSettings()
 {
   QgsSettings settings;
   QFileInfo dxfFileInfo( mFileName->filePath() );
-  settings.setValue( u"qgis/lastDxfDir"_s, dxfFileInfo.absolutePath() );
+  QgsDxfExportDialog::settingsLastDxfDir->setValue( dxfFileInfo.absolutePath() );
   settings.setValue( u"qgis/lastDxfSymbologyMode"_s, mSymbologyModeComboBox->currentIndex() );
   settings.setValue( u"qgis/lastSymbologyExportScale"_s, mScaleWidget->scale() != 0 ? 1.0 / mScaleWidget->scale() : 0 );
   settings.setValue( u"qgis/lastDxfMapRectangle"_s, mMapExtentCheckBox->isChecked() );

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -110,6 +110,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
   public:
     static inline QgsSettingsTreeNode *sTreeAppDdxf = QgsSettingsTree::sTreeApp->createChildNode( u"dxf"_s );
     static const inline QgsSettingsEntryString *settingsDxfLastSettingsDir = new QgsSettingsEntryString( u"last-settings-dir"_s, sTreeAppDdxf, QDir::homePath() );
+    static const inline QgsSettingsEntryString *settingsLastDxfDir = new QgsSettingsEntryString( u"last-dir"_s, sTreeAppDdxf, QDir::homePath(), u"Last directory used for DXF export"_s );
 
     QgsDxfExportDialog( QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
     ~QgsDxfExportDialog() override;

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -45,6 +45,8 @@
 #include "qgsrendererpropertiesdialog.h"
 #include "qgsrendererrasterpropertieswidget.h"
 #include "qgsrendererregistry.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingstree.h"
 #include "qgsstyle.h"
 #include "qgssymbolwidgetcontext.h"
 #include "qgsundowidget.h"
@@ -970,6 +972,10 @@ void QgsLayerStylingWidget::emitLayerStyleRenamed()
 }
 
 
+const QgsSettingsEntryInteger *QgsMapLayerStyleCommand::settingsStyleUndoMergeTimeout
+  = new QgsSettingsEntryInteger( u"style-undo-merge-timeout"_s, QgsSettingsTree::sTreeGui, 500, u"Timeout in milliseconds for merging successive style undo commands"_s );
+
+
 QgsMapLayerStyleCommand::QgsMapLayerStyleCommand( QgsMapLayer *layer, const QString &text, const QDomNode &current, const QDomNode &last, bool triggerRepaint )
   : QUndoCommand( text )
   , mLayer( layer )
@@ -1009,7 +1015,7 @@ bool QgsMapLayerStyleCommand::mergeWith( const QUndoCommand *other )
   // only merge commands if they are created shortly after each other
   // (e.g. user keeps modifying one property)
   QgsSettings settings;
-  int timeout = settings.value( u"UI/styleUndoMergeTimeout"_s, 500 ).toInt();
+  int timeout = settingsStyleUndoMergeTimeout->value();
   if ( mTime.msecsTo( otherCmd->mTime ) > timeout )
     return false;
 

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -55,6 +55,7 @@ class QgsVectorTileBasicRendererWidget;
 class QgsVectorTileBasicLabelingWidget;
 class QgsAnnotationLayer;
 class QgsLayerTreeGroup;
+class QgsSettingsEntryInteger;
 
 class APP_EXPORT QgsLayerStyleManagerWidgetFactory : public QgsMapLayerConfigWidgetFactory
 {
@@ -68,6 +69,8 @@ class APP_EXPORT QgsLayerStyleManagerWidgetFactory : public QgsMapLayerConfigWid
 class APP_EXPORT QgsMapLayerStyleCommand : public QUndoCommand
 {
   public:
+    static const QgsSettingsEntryInteger *settingsStyleUndoMergeTimeout SIP_SKIP;
+
     QgsMapLayerStyleCommand( QgsMapLayer *layer, const QString &text, const QDomNode &current, const QDomNode &last, bool triggerRepaint = true );
 
     /**

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -71,6 +71,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsLegendDoubleClickAction->copyValueFromKey( u"qgis/legendDoubleClickAction"_s, true );
   QgisApp::settingsLegendDoubleClickAction->copyValueFromKey( u"/qgis/legendDoubleClickAction"_s, true );
   QgisApp::settingsEnableEventTracing->copyValueFromKey( u"qgis/enableEventTracing"_s, true );
+  QgisApp::settingsHideSplash->copyValueFromKey( u"qgis/hideSplash"_s, true );
+  QgisApp::settingsHideSplash->copyValueFromKey( u"/qgis/hideSplash"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -81,6 +81,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsAskToSaveProjectChanges->copyValueFromKey( u"/qgis/askToSaveProjectChanges"_s, true );
   QgisApp::settingsWarnOldProjectVersion->copyValueFromKey( u"qgis/warnOldProjectVersion"_s, true );
   QgisApp::settingsWarnOldProjectVersion->copyValueFromKey( u"/qgis/warnOldProjectVersion"_s, true );
+  QgisApp::settingsNewProjectDefault->copyValueFromKey( u"qgis/newProjectDefault"_s, true );
+  QgisApp::settingsNewProjectDefault->copyValueFromKey( u"/qgis/newProjectDefault"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -70,6 +70,7 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgsIdentifyResultsDialog::settingColumnWidthTable->copyValueFromKey( u"Windows/Identify/columnWidthTable"_s, true );
   QgisApp::settingsLegendDoubleClickAction->copyValueFromKey( u"qgis/legendDoubleClickAction"_s, true );
   QgisApp::settingsLegendDoubleClickAction->copyValueFromKey( u"/qgis/legendDoubleClickAction"_s, true );
+  QgisApp::settingsEnableEventTracing->copyValueFromKey( u"qgis/enableEventTracing"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -87,6 +87,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsProjOpenAtLaunch->copyValueFromKey( u"/qgis/projOpenAtLaunch"_s, true );
   QgisApp::settingsProjOpenAtLaunchPath->copyValueFromKey( u"qgis/projOpenAtLaunchPath"_s, true );
   QgisApp::settingsProjOpenAtLaunchPath->copyValueFromKey( u"/qgis/projOpenAtLaunchPath"_s, true );
+  QgisApp::settingsProjOpenedOKAtLaunch->copyValueFromKey( u"qgis/projOpenedOKAtLaunch"_s, true );
+  QgisApp::settingsProjOpenedOKAtLaunch->copyValueFromKey( u"/qgis/projOpenedOKAtLaunch"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -19,6 +19,7 @@
 
 #include "qgisapp.h"
 #include "qgsattributetabledialog.h"
+#include "qgsdualview.h"
 #include "qgsgui.h"
 #include "qgsidentifyresultsdialog.h"
 #include "qgsimagewarper.h"
@@ -98,6 +99,29 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"qgis/restoreDefaultWindowState"_s, true );
   QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"/qgis/restoreDefaultWindowState"_s, true );
   QgsMapLayerStyleCommand::settingsStyleUndoMergeTimeout->copyValueFromKey( u"UI/styleUndoMergeTimeout"_s, true );
+  // Legacy qgis/attributeTableView used -1 as a sentinel meaning "remember last view";
+  // split into two new settings (an enum view + a boolean remember-last-view flag).
+  {
+    QgsSettings legacySettings;
+    QVariant legacyAttrTableView = legacySettings.value( u"qgis/attributeTableView"_s );
+    if ( !legacyAttrTableView.isValid() )
+      legacyAttrTableView = legacySettings.value( u"/qgis/attributeTableView"_s );
+    if ( legacyAttrTableView.isValid() )
+    {
+      const int legacyValue = legacyAttrTableView.toInt();
+      if ( legacyValue < 0 )
+      {
+        QgsAttributeTableDialog::settingsAttributeTableRememberLastView->setValue( true );
+      }
+      else
+      {
+        QgsAttributeTableDialog::settingsAttributeTableRememberLastView->setValue( false );
+        QgsAttributeTableDialog::settingsAttributeTableView->setValue( static_cast<QgsDualView::ViewMode>( legacyValue ) );
+      }
+      legacySettings.remove( u"qgis/attributeTableView"_s );
+      legacySettings.remove( u"/qgis/attributeTableView"_s );
+    }
+  }
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -92,6 +92,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgsWelcomeScreen::settingsCheckVersion->copyValueFromKey( u"qgis/checkVersion"_s, true );
   QgsWelcomeScreen::settingsCheckVersion->copyValueFromKey( u"/qgis/checkVersion"_s, true );
   QgisApp::settingsShowScriptWarning->copyValueFromKey( u"UI/showScriptWarning"_s, true );
+  QgisApp::settingsDisplayWaylandWarning->copyValueFromKey( u"UI/displayWaylandWarning"_s, true );
+  QgisApp::settingsDisplayWaylandWarning->copyValueFromKey( u"/UI/displayWaylandWarning"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -68,6 +68,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgsIdentifyResultsDialog::settingHideDerivedAttributes->copyValueFromKey( u"/Map/hideDerivedAttributes"_s, true );
   QgsIdentifyResultsDialog::settingColumnWidth->copyValueFromKey( u"Windows/Identify/columnWidth"_s, true );
   QgsIdentifyResultsDialog::settingColumnWidthTable->copyValueFromKey( u"Windows/Identify/columnWidthTable"_s, true );
+  QgisApp::settingsLegendDoubleClickAction->copyValueFromKey( u"qgis/legendDoubleClickAction"_s, true );
+  QgisApp::settingsLegendDoubleClickAction->copyValueFromKey( u"/qgis/legendDoubleClickAction"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -32,6 +32,7 @@
 #include "qgssettingsentryimpl.h"
 #include "qgssettingsenumflageditorwidgetwrapper.h"
 #include "qgssettingsproxy.h"
+#include "qgswelcomescreen.h"
 
 #include <QString>
 
@@ -100,7 +101,6 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"qgis/restoreDefaultWindowState"_s, true );
   QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"/qgis/restoreDefaultWindowState"_s, true );
   QgsMapLayerStyleCommand::settingsStyleUndoMergeTimeout->copyValueFromKey( u"UI/styleUndoMergeTimeout"_s, true );
-<<<<<<< HEAD
   // Legacy qgis/attributeTableView used -1 as a sentinel meaning "remember last view";
   // split into two new settings (an enum view + a boolean remember-last-view flag).
   {

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -22,6 +22,7 @@
 #include "qgsgui.h"
 #include "qgsidentifyresultsdialog.h"
 #include "qgsimagewarper.h"
+#include "qgslayerstylingwidget.h"
 #include "qgspluginmanager.h"
 #include "qgssettings.h"
 #include "qgssettingseditorwidgetregistry.h"
@@ -96,6 +97,7 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsDisplayWaylandWarning->copyValueFromKey( u"/UI/displayWaylandWarning"_s, true );
   QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"qgis/restoreDefaultWindowState"_s, true );
   QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"/qgis/restoreDefaultWindowState"_s, true );
+  QgsMapLayerStyleCommand::settingsStyleUndoMergeTimeout->copyValueFromKey( u"UI/styleUndoMergeTimeout"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -77,6 +77,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsMapTipsEnabled->copyValueFromKey( u"/qgis/enableMapTips"_s, true );
   QgisApp::settingsMapTipsDelay->copyValueFromKey( u"qgis/mapTipsDelay"_s, true );
   QgisApp::settingsMapTipsDelay->copyValueFromKey( u"/qgis/mapTipsDelay"_s, true );
+  QgisApp::settingsAskToSaveProjectChanges->copyValueFromKey( u"qgis/askToSaveProjectChanges"_s, true );
+  QgisApp::settingsAskToSaveProjectChanges->copyValueFromKey( u"/qgis/askToSaveProjectChanges"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -91,6 +91,7 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsProjOpenedOKAtLaunch->copyValueFromKey( u"/qgis/projOpenedOKAtLaunch"_s, true );
   QgsWelcomeScreen::settingsCheckVersion->copyValueFromKey( u"qgis/checkVersion"_s, true );
   QgsWelcomeScreen::settingsCheckVersion->copyValueFromKey( u"/qgis/checkVersion"_s, true );
+  QgisApp::settingsShowScriptWarning->copyValueFromKey( u"UI/showScriptWarning"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -73,6 +73,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsEnableEventTracing->copyValueFromKey( u"qgis/enableEventTracing"_s, true );
   QgisApp::settingsHideSplash->copyValueFromKey( u"qgis/hideSplash"_s, true );
   QgisApp::settingsHideSplash->copyValueFromKey( u"/qgis/hideSplash"_s, true );
+  QgisApp::settingsMapTipsEnabled->copyValueFromKey( u"qgis/enableMapTips"_s, true );
+  QgisApp::settingsMapTipsEnabled->copyValueFromKey( u"/qgis/enableMapTips"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -102,7 +102,7 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"/qgis/restoreDefaultWindowState"_s, true );
   QgsMapLayerStyleCommand::settingsStyleUndoMergeTimeout->copyValueFromKey( u"UI/styleUndoMergeTimeout"_s, true );
   // Legacy qgis/attributeTableView used -1 as a sentinel meaning "remember last view";
-  // split into two new settings (an enum view + a boolean remember-last-view flag).
+  // migrate to the new enum-based setting (with RememberLast as a sentinel value).
   {
     QgsSettings legacySettings;
     QVariant legacyAttrTableView = legacySettings.value( u"qgis/attributeTableView"_s );
@@ -111,15 +111,12 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
     if ( legacyAttrTableView.isValid() )
     {
       const int legacyValue = legacyAttrTableView.toInt();
+      QgsAttributeTableDialog::InitialView newValue;
       if ( legacyValue < 0 )
-      {
-        QgsAttributeTableDialog::settingsAttributeTableRememberLastView->setValue( true );
-      }
+        newValue = QgsAttributeTableDialog::RememberLast;
       else
-      {
-        QgsAttributeTableDialog::settingsAttributeTableRememberLastView->setValue( false );
-        QgsAttributeTableDialog::settingsAttributeTableView->setValue( static_cast<QgsDualView::ViewMode>( legacyValue ) );
-      }
+        newValue = static_cast<QgsAttributeTableDialog::InitialView>( legacyValue );
+      QgsAttributeTableDialog::settingsAttributeTableInitialView->setValue( newValue );
       legacySettings.remove( u"qgis/attributeTableView"_s );
       legacySettings.remove( u"/qgis/attributeTableView"_s );
     }

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -75,6 +75,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsHideSplash->copyValueFromKey( u"/qgis/hideSplash"_s, true );
   QgisApp::settingsMapTipsEnabled->copyValueFromKey( u"qgis/enableMapTips"_s, true );
   QgisApp::settingsMapTipsEnabled->copyValueFromKey( u"/qgis/enableMapTips"_s, true );
+  QgisApp::settingsMapTipsDelay->copyValueFromKey( u"qgis/mapTipsDelay"_s, true );
+  QgisApp::settingsMapTipsDelay->copyValueFromKey( u"/qgis/mapTipsDelay"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -85,6 +85,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsNewProjectDefault->copyValueFromKey( u"/qgis/newProjectDefault"_s, true );
   QgisApp::settingsProjOpenAtLaunch->copyValueFromKey( u"qgis/projOpenAtLaunch"_s, true );
   QgisApp::settingsProjOpenAtLaunch->copyValueFromKey( u"/qgis/projOpenAtLaunch"_s, true );
+  QgisApp::settingsProjOpenAtLaunchPath->copyValueFromKey( u"qgis/projOpenAtLaunchPath"_s, true );
+  QgisApp::settingsProjOpenAtLaunchPath->copyValueFromKey( u"/qgis/projOpenAtLaunchPath"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -79,6 +79,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsMapTipsDelay->copyValueFromKey( u"/qgis/mapTipsDelay"_s, true );
   QgisApp::settingsAskToSaveProjectChanges->copyValueFromKey( u"qgis/askToSaveProjectChanges"_s, true );
   QgisApp::settingsAskToSaveProjectChanges->copyValueFromKey( u"/qgis/askToSaveProjectChanges"_s, true );
+  QgisApp::settingsWarnOldProjectVersion->copyValueFromKey( u"qgis/warnOldProjectVersion"_s, true );
+  QgisApp::settingsWarnOldProjectVersion->copyValueFromKey( u"/qgis/warnOldProjectVersion"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -83,6 +83,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsWarnOldProjectVersion->copyValueFromKey( u"/qgis/warnOldProjectVersion"_s, true );
   QgisApp::settingsNewProjectDefault->copyValueFromKey( u"qgis/newProjectDefault"_s, true );
   QgisApp::settingsNewProjectDefault->copyValueFromKey( u"/qgis/newProjectDefault"_s, true );
+  QgisApp::settingsProjOpenAtLaunch->copyValueFromKey( u"qgis/projOpenAtLaunch"_s, true );
+  QgisApp::settingsProjOpenAtLaunch->copyValueFromKey( u"/qgis/projOpenAtLaunch"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -20,6 +20,7 @@
 #include "qgisapp.h"
 #include "qgsattributetabledialog.h"
 #include "qgsdualview.h"
+#include "qgsdxfexportdialog.h"
 #include "qgsgui.h"
 #include "qgsidentifyresultsdialog.h"
 #include "qgsimagewarper.h"
@@ -99,6 +100,7 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"qgis/restoreDefaultWindowState"_s, true );
   QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"/qgis/restoreDefaultWindowState"_s, true );
   QgsMapLayerStyleCommand::settingsStyleUndoMergeTimeout->copyValueFromKey( u"UI/styleUndoMergeTimeout"_s, true );
+<<<<<<< HEAD
   // Legacy qgis/attributeTableView used -1 as a sentinel meaning "remember last view";
   // split into two new settings (an enum view + a boolean remember-last-view flag).
   {
@@ -122,6 +124,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
       legacySettings.remove( u"/qgis/attributeTableView"_s );
     }
   }
+  QgsDxfExportDialog::settingsLastDxfDir->copyValueFromKey( u"qgis/lastDxfDir"_s, true );
+  QgsDxfExportDialog::settingsLastDxfDir->copyValueFromKey( u"/qgis/lastDxfDir"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -89,6 +89,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsProjOpenAtLaunchPath->copyValueFromKey( u"/qgis/projOpenAtLaunchPath"_s, true );
   QgisApp::settingsProjOpenedOKAtLaunch->copyValueFromKey( u"qgis/projOpenedOKAtLaunch"_s, true );
   QgisApp::settingsProjOpenedOKAtLaunch->copyValueFromKey( u"/qgis/projOpenedOKAtLaunch"_s, true );
+  QgsWelcomeScreen::settingsCheckVersion->copyValueFromKey( u"qgis/checkVersion"_s, true );
+  QgsWelcomeScreen::settingsCheckVersion->copyValueFromKey( u"/qgis/checkVersion"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgssettingsregistryapp.cpp
+++ b/src/app/qgssettingsregistryapp.cpp
@@ -94,6 +94,8 @@ QgsSettingsRegistryApp::QgsSettingsRegistryApp()
   QgisApp::settingsShowScriptWarning->copyValueFromKey( u"UI/showScriptWarning"_s, true );
   QgisApp::settingsDisplayWaylandWarning->copyValueFromKey( u"UI/displayWaylandWarning"_s, true );
   QgisApp::settingsDisplayWaylandWarning->copyValueFromKey( u"/UI/displayWaylandWarning"_s, true );
+  QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"qgis/restoreDefaultWindowState"_s, true );
+  QgisApp::settingsRestoreDefaultWindowState->copyValueFromKey( u"/qgis/restoreDefaultWindowState"_s, true );
   QgisApp::settingsAskToDeleteFeatures->copyValueFromKey( u"app/askToDeleteFeatures"_s, true );
   QgsPluginManager::settingsAutomaticallyCheckForPluginUpdates->copyValueFromKey( u"plugins/automatically-check-for-updates"_s, true );
   QgsPluginManager::settingsAllowExperimental->copyValueFromKey( u"app/plugin_installer/allowExperimental"_s, true );

--- a/src/app/qgswelcomescreen.cpp
+++ b/src/app/qgswelcomescreen.cpp
@@ -21,6 +21,8 @@
 #include "qgsapplication.h"
 #include "qgspluginmanager.h"
 #include "qgssettings.h"
+#include "qgssettingsentryimpl.h"
+#include "qgssettingstree.h"
 
 #include <QAbstractButton>
 #include <QMessageBox>
@@ -117,6 +119,9 @@ void QgsWelcomeScreenController::forwardDrop( const QString &text, const QString
 }
 
 
+const QgsSettingsEntryBool *QgsWelcomeScreen::settingsCheckVersion
+  = new QgsSettingsEntryBool( u"check-version"_s, QgsSettingsTree::sTreeApp, true, u"Whether the welcome screen should check for a newer QGIS version online"_s );
+
 QgsWelcomeScreen::QgsWelcomeScreen( bool skipVersionCheck, QWidget *parent )
   : QQuickWidget( parent )
 {
@@ -152,7 +157,7 @@ QgsWelcomeScreen::QgsWelcomeScreen( bool skipVersionCheck, QWidget *parent )
 
   QgsSettings settings;
   mVersionInfo = new QgsVersionInfo();
-  if ( !QgsApplication::isRunningFromBuildDir() && settings.value( u"/qgis/allowVersionCheck"_s, true ).toBool() && settings.value( u"qgis/checkVersion"_s, true ).toBool() && !skipVersionCheck )
+  if ( !QgsApplication::isRunningFromBuildDir() && settings.value( u"/qgis/allowVersionCheck"_s, true ).toBool() && settingsCheckVersion->value() && !skipVersionCheck )
   {
     connect( mVersionInfo, &QgsVersionInfo::versionInfoAvailable, this, &QgsWelcomeScreen::versionInfoReceived );
     mVersionInfo->checkVersion();

--- a/src/app/qgswelcomescreen.h
+++ b/src/app/qgswelcomescreen.h
@@ -28,6 +28,7 @@
 #include <QQuickWidget>
 
 class QgsWelcomeScreen;
+class QgsSettingsEntryBool;
 
 
 class QgsWelcomeScreenController : public QObject
@@ -67,6 +68,8 @@ class QgsWelcomeScreen : public QQuickWidget
     Q_OBJECT
 
   public:
+    static const QgsSettingsEntryBool *settingsCheckVersion SIP_SKIP;
+
     QgsWelcomeScreen( bool skipVersionCheck = false, QWidget *parent = nullptr );
     ~QgsWelcomeScreen() override = default;
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4870,6 +4870,19 @@ int QgisEvent = QEvent::User + 1;
     Q_ENUM( LayerTreeInsertionMethod )
 
     /**
+     * Action performed when double-clicking a layer in the legend.
+     *
+     * \since QGIS 4.0
+     */
+    enum class LegendLayerDoubleClickAction : int
+    {
+      LayerProperties = 0, //!< Open the layer properties dialog
+      AttributeTable = 1,  //!< Open the attribute table
+      LayerStyling = 2,    //!< Open the layer styling dock
+    };
+    Q_ENUM( LegendLayerDoubleClickAction )
+
+    /**
      * Layer tree filter flags.
      *
      * \since QGIS 3.32

--- a/src/core/settings/qgssettingstree.h
+++ b/src/core/settings/qgssettingstree.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsSettingsTree
     static inline QgsSettingsTreeNode *sTreeLayout = treeRoot()->createChildNode( u"layout"_s );
     static inline QgsSettingsTreeNode *sTreeLocale = treeRoot()->createChildNode( u"locale"_s );
     static inline QgsSettingsTreeNode *sTreeMap = treeRoot()->createChildNode( u"map"_s );
+    static inline QgsSettingsTreeNode *sTreeMapTips = treeRoot()->createChildNode( u"map-tips"_s );
     static inline QgsSettingsTreeNode *sTreeNetwork = treeRoot()->createChildNode( u"network"_s );
     static inline QgsSettingsTreeNode *sTreeQgis = treeRoot()->createChildNode( u"qgis"_s );
     static inline QgsSettingsTreeNode *sTreePlugins = treeRoot()->createChildNode( u"plugins"_s );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -60,6 +60,9 @@ using namespace Qt::StringLiterals;
 const QgsSettingsEntryBool *QgsDualView::settingsFeatureListHighlightFeature
   = new QgsSettingsEntryBool( u"feature-list-highlight-feature"_s, QgsSettingsTree::sTreeAttributeTable, true, QObject::tr( "Whether to highlight/flash features in the feature list view" ) );
 
+const QgsSettingsEntryInteger *QgsDualView::settingsAttributeTableRowCache
+  = new QgsSettingsEntryInteger( u"row-cache"_s, QgsSettingsTree::sTreeAttributeTable, 10000, QObject::tr( "Maximum number of rows to cache in the attribute table (0 means cache all rows)" ) );
+
 const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::conditionalFormattingSplitterState = std::make_unique<
   QgsSettingsEntryVariant>( u"attribute-table-splitter-state"_s, QgsSettingsTree::sTreeWindowState, QgsVariantUtils::createNullVariant( QMetaType::Type::QByteArray ), u"State of conditional formatting splitter's layout so it could be restored when opening attribute table view."_s );
 const std::unique_ptr<QgsSettingsEntryVariant> QgsDualView::attributeEditorSplitterState = std::make_unique<
@@ -459,8 +462,7 @@ void QgsDualView::setSelectedOnTop( bool selectedOnTop )
 void QgsDualView::initLayerCache( bool cacheGeometry )
 {
   // Initialize the cache
-  const QgsSettings settings;
-  const int cacheSize = settings.value( u"qgis/attributeTableRowCache"_s, "10000" ).toInt();
+  const int cacheSize = settingsAttributeTableRowCache->value();
   mLayerCache = new QgsVectorLayerCache( mLayer, cacheSize, this );
   mLayerCache->setCacheSubsetOfAttributes( requiredAttributes( mLayer ) );
   mLayerCache->setCacheGeometry( cacheGeometry );

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -32,6 +32,7 @@ class QgsMapLayerAction;
 class QgsScrollArea;
 class QgsFieldConditionalFormatWidget;
 class QgsSettingsEntryBool;
+class QgsSettingsEntryInteger;
 class QgsSettingsEntryVariant;
 
 /**
@@ -88,6 +89,13 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      * \since QGIS 4.0.1
      */
     static const QgsSettingsEntryBool *settingsFeatureListHighlightFeature;
+
+    /**
+     * Settings entry for the maximum number of rows to cache in the attribute table.
+     * A value of 0 means cache all rows.
+     * \since QGIS 4.0.1
+     */
+    static const QgsSettingsEntryInteger *settingsAttributeTableRowCache;
 
 #endif
 

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -50,6 +50,11 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     Q_OBJECT
 
   public:
+
+    static const QgsSettingsEntryBool *settingsFeatureListHighlightFeature SIP_SKIP;
+
+    static const QgsSettingsEntryInteger *settingsAttributeTableRowCache SIP_SKIP;
+
     /**
      * The view modes, in which this widget can present information.
      * Relates to the QStackedWidget stacks.
@@ -81,23 +86,6 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
       ZoomToFeature, //!< The map is zoomed to contained the feature bounding-box
     };
     Q_ENUM( FeatureListBrowsingAction )
-
-#ifndef SIP_RUN
-
-    /**
-     * Settings entry for whether features are highlighted/flashed in the feature list.
-     * \since QGIS 4.0.1
-     */
-    static const QgsSettingsEntryBool *settingsFeatureListHighlightFeature;
-
-    /**
-     * Settings entry for the maximum number of rows to cache in the attribute table.
-     * A value of 0 means cache all rows.
-     * \since QGIS 4.0.1
-     */
-    static const QgsSettingsEntryInteger *settingsAttributeTableRowCache;
-
-#endif
 
     /**
      * \brief Constructor

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -110,6 +110,8 @@ using namespace Qt::StringLiterals;
 const QgsSettingsEntryString *QgsMapCanvas::settingsCustomCoordinateCrs = new QgsSettingsEntryString( u"custom-coordinate-crs"_s, QgsSettingsTree::sTreeMap, QString() );
 const QgsSettingsEntryBool *QgsMapCanvas::settingsMainCanvasPreviewJobs
   = new QgsSettingsEntryBool( u"main-canvas-preview-jobs"_s, QgsSettingsTree::sTreeRendering, true, u"Whether the main map canvas displays preview tiles while rendering"_s );
+const QgsSettingsEntryBool *QgsMapCanvas::settingsEnableRenderCaching
+  = new QgsSettingsEntryBool( u"enable-render-caching"_s, QgsSettingsTree::sTreeRendering, true, u"Whether map rendering uses a cache to speed up redraws"_s );
 
 /**
  * \ingroup gui

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -108,6 +108,8 @@ email                : sherman at mrcc.com
 using namespace Qt::StringLiterals;
 
 const QgsSettingsEntryString *QgsMapCanvas::settingsCustomCoordinateCrs = new QgsSettingsEntryString( u"custom-coordinate-crs"_s, QgsSettingsTree::sTreeMap, QString() );
+const QgsSettingsEntryBool *QgsMapCanvas::settingsMainCanvasPreviewJobs
+  = new QgsSettingsEntryBool( u"main-canvas-preview-jobs"_s, QgsSettingsTree::sTreeRendering, true, u"Whether the main map canvas displays preview tiles while rendering"_s );
 
 /**
  * \ingroup gui

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -56,6 +56,7 @@ class QgsMapToPixel;
 class QgsMapLayer;
 class QgsHighlight;
 class QgsSettingsEntryString;
+class QgsSettingsEntryBool;
 class QgsVectorLayer;
 
 class QgsLabelingResults;
@@ -107,6 +108,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
     Q_PROPERTY( bool previewJobsEnabled READ previewJobsEnabled WRITE setPreviewJobsEnabled )
 
   public:
+    static const QgsSettingsEntryBool *settingsMainCanvasPreviewJobs SIP_SKIP;
+
     //! Constructor
     QgsMapCanvas( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -109,6 +109,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView, public QgsExpressionContex
 
   public:
     static const QgsSettingsEntryBool *settingsMainCanvasPreviewJobs SIP_SKIP;
+    static const QgsSettingsEntryBool *settingsEnableRenderCaching SIP_SKIP;
 
     //! Constructor
     QgsMapCanvas( QWidget *parent SIP_TRANSFERTHIS = nullptr );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -114,6 +114,7 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   settingsCadFloaterActive->copyValueFromKey( u"/Cad/Floater"_s, true );
   QgsAdvancedDigitizingDockWidget::settingsCadCommonAngle->copyValueFromKey( u"/Cad/CommonAngle"_s, true );
   QgsMapCanvas::settingsCustomCoordinateCrs->copyValueFromKey( u"qgis/custom_coordinate_crs"_s, true );
+  QgsMapCanvas::settingsMainCanvasPreviewJobs->copyValueFromKey( u"qgis/main_canvas_preview_jobs"_s, true );
   QgsGradientColorRampDialog::settingsPlotHue->copyValueFromKey( u"GradientEditor/plotHue"_s, true );
   QgsGradientColorRampDialog::settingsPlotLightness->copyValueFromKey( u"GradientEditor/plotLightness"_s, true );
   QgsGradientColorRampDialog::settingsPlotSaturation->copyValueFromKey( u"GradientEditor/plotSaturation"_s, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -115,6 +115,7 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   QgsAdvancedDigitizingDockWidget::settingsCadCommonAngle->copyValueFromKey( u"/Cad/CommonAngle"_s, true );
   QgsMapCanvas::settingsCustomCoordinateCrs->copyValueFromKey( u"qgis/custom_coordinate_crs"_s, true );
   QgsMapCanvas::settingsMainCanvasPreviewJobs->copyValueFromKey( u"qgis/main_canvas_preview_jobs"_s, true );
+  QgsMapCanvas::settingsEnableRenderCaching->copyValueFromKey( u"qgis/enable_render_caching"_s, true );
   QgsGradientColorRampDialog::settingsPlotHue->copyValueFromKey( u"GradientEditor/plotHue"_s, true );
   QgsGradientColorRampDialog::settingsPlotLightness->copyValueFromKey( u"GradientEditor/plotLightness"_s, true );
   QgsGradientColorRampDialog::settingsPlotSaturation->copyValueFromKey( u"GradientEditor/plotSaturation"_s, true );

--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -116,6 +116,8 @@ QgsSettingsRegistryGui::QgsSettingsRegistryGui()
   QgsMapCanvas::settingsCustomCoordinateCrs->copyValueFromKey( u"qgis/custom_coordinate_crs"_s, true );
   QgsMapCanvas::settingsMainCanvasPreviewJobs->copyValueFromKey( u"qgis/main_canvas_preview_jobs"_s, true );
   QgsMapCanvas::settingsEnableRenderCaching->copyValueFromKey( u"qgis/enable_render_caching"_s, true );
+  QgsDualView::settingsAttributeTableRowCache->copyValueFromKey( u"qgis/attributeTableRowCache"_s, true );
+  QgsDualView::settingsAttributeTableRowCache->copyValueFromKey( u"/qgis/attributeTableRowCache"_s, true );
   QgsGradientColorRampDialog::settingsPlotHue->copyValueFromKey( u"GradientEditor/plotHue"_s, true );
   QgsGradientColorRampDialog::settingsPlotLightness->copyValueFromKey( u"GradientEditor/plotLightness"_s, true );
   QgsGradientColorRampDialog::settingsPlotSaturation->copyValueFromKey( u"GradientEditor/plotSaturation"_s, true );


### PR DESCRIPTION

| # | Commit | Legacy key | New key | Type | Tree node |
|---|---|---|---|---|---|
| 1 | 8526bae5208 | `qgis/legendDoubleClickAction` | `legend-double-click-action` | `EnumFlag<Qgis::LegendLayerDoubleClickAction>` | `sTreeApp` |
| 2 | 848be8581b6 | `qgis/enableEventTracing` | `enable-event-tracing` | `Bool` | `sTreeApp` |
| 3 | f0293b78ab9 | `qgis/main_canvas_preview_jobs` | `main-canvas-preview-jobs` | `Bool` | `sTreeGui` (QgsMapCanvas) |
| 4 | 9fd67f97cf9 | `qgis/enable_render_caching` | `enable-render-caching` | `Bool` | `sTreeGui` (QgsMapCanvas) |
| 5 | 7ae528dbab3 | `qgis/hideSplash` | `hide-splash` | `Bool` | `sTreeApp` |
| 6 | 28026e824ab | `qgis/enableMapTips` | `enabled` | `Bool` | `sTreeMapTips` |
| 7 | f40ff1a12ad | `qgis/mapTipsDelay` | `delay` | `Integer` | `sTreeMapTips` |
| 8 | 6e1d0ea176c | `qgis/askToSaveProjectChanges` | `ask-to-save-project-changes` | `Bool` | `sTreeProject` |
| 9 | 0161dc3724f | `qgis/warnOldProjectVersion` | `warn-old-project-version` | `Bool` | `sTreeProject` |
| 10 | 01bbc140727 | `qgis/newProjectDefault` | `new-project-default` | `Bool` | `sTreeProject` |
| 11 | fb1736affbe | `qgis/projOpenAtLaunch` | `proj-open-at-launch` | `Integer` | `sTreeProject` |
| 12 | d630b046a20 | `qgis/projOpenAtLaunchPath` | `proj-open-at-launch-path` | `String` | `sTreeProject` |
| 13 | 9481e4a71b2 | `qgis/projOpenedOKAtLaunch` | `project-opened-ok-at-launch` | `Bool` | `sTreeProject` |
| 14 | b3ff6e18197 | `qgis/checkVersion` | `check-version` | `Bool` | `sTreeApp` |
| 15 | 4e124ac6270 | `UI/showScriptWarning` | `show-script-warning` | `Bool` | `sTreeApp` |
| 16 | f1e960652c1 | `UI/displayWaylandWarning` | `display-wayland-warning` | `Bool` | `sTreeGui` |
| 17 | 6e285746518 | `qgis/restoreDefaultWindowState` | `restore-default-window-state` | `Bool` | `sTreeApp` |
| 18 | 3c814eb2b7d | `UI/styleUndoMergeTimeout` | `style-undo-merge-timeout` | `Integer` | `sTreeGui` (QgsMapLayerStyleCommand) |
| 19 | 186f4f12095 | `qgis/attributeTableView` | `attribute-table-view` + `attribute-table-remember-last-view` | `EnumFlag<QgsDualView::ViewMode>` + `Bool` | `sTreeApp` (QgsAttributeTableDialog) |
| 20 | c16393337c9 | `qgis/lastDxfDir` | `last-dxf-dir` | `String` | `sTreeApp` (QgsDxfExportDialog) |
| 21 | a6d335b0f14 | `qgis/attributeTableRowCache` | `row-cache` | `Integer` | `sTreeAttributeTable` (QgsDualView) |


A new top-level tree node `map-tips` was added.

## AI tool usage

 - [x]  AI tool(s): I have a set of instructions to perform the migration that were fine-tuned on the former PRs. I have manually checked every commit.
