### PR TITLE
[ClangTidy] Add code styling checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,19 @@
-Checks: 'bugprone-*,-bugprone-easily-swappable-parameters,-bugprone-virtual-near-miss,-bugprone-suspicious-include,-bugprone-branch-clone'
+Checks: 'bugprone-*,-bugprone-easily-swappable-parameters,-bugprone-virtual-near-miss,-bugprone-suspicious-include,-bugprone-branch-clone,readability-identifier-naming'
 HeaderFilterRegex: ''
+CheckOptions:
+
+  ### Coding style
+  ### see https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-314-coding-style.md
+
+  readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.EnumConstantCase: CamelCase
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.ClassPrefix: Qgs
+  readability-identifier-naming.MemberPrefix: m
+  readability-identifier-naming.MemberCase: CamelCase
+
+  # Static member
+  readability-identifier-naming.ClassMemberCase: CamelCase
+  readability-identifier-naming.ClassMemberPrefix: s
+
+  readability-identifier-naming.ConstexprVariableCase: UPPER_CASE


### PR DESCRIPTION
## Description

Add some clang-tidy checks to make sure Pull Requests comply to QGIS [coding guidelines](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-314-coding-style.md)

It checks that:
- Class starts with Qgs
- class member starts with 'm' and static one with 's'
- Enum/Class/Member name are CamelCase 
- Constexpr are UPPER_CASE

## AI tool usage

 - [x] Claude helped me to figure out the appropriate options. Each option has been then tested. 

