### PR TITLE
[themes] Fix tooltip text color in layout designer for night mapping under Qt6

### DIFF
--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1435,6 +1435,11 @@ QgsLayoutRuler {
     color: @textlight;
 }
 
+QgsLayoutView QToolTip
+{
+    color: @itembackground;
+}
+
 QgsAttributeFormWidget QComboBox:disabled {
     border: none;
     background-color: @itembackground;


### PR DESCRIPTION
## Description

Follows #65228. Fix the text color of tooltips in the layout designer for the Night Mapping theme in QGIS 4.0 / Qt6. 

Before:
<img width="400" alt="tooltip_color_wrong" src="https://github.com/user-attachments/assets/85bd6096-df7d-426a-84ae-686acf9aa8a5" />

After (as in QGIS 3.44 / Qt5 without the fix):
<img width="400" alt="tooltip_fine" src="https://github.com/user-attachments/assets/72c9bb67-6e24-4586-a3c3-ea04aea0388f" />

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.