### PR TITLE
Fix CircularString deleteVertex removing geometry on invalid vertex index

### DIFF
--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -1271,14 +1271,16 @@ bool QgsCircularString::moveVertex( QgsVertexId position, const QgsPoint &newPos
 bool QgsCircularString::deleteVertex( QgsVertexId position )
 {
   int nVertices = this->numPoints();
+
+  if ( position.vertex < 0 || position.vertex > ( nVertices - 1 ) )
+  {
+    return false;
+  }
+
   if ( nVertices < 4 ) //circular string must have at least 3 vertices
   {
     clear();
     return true;
-  }
-  if ( position.vertex < 0 || position.vertex > ( nVertices - 1 ) )
-  {
-    return false;
   }
 
   if ( position.vertex < ( nVertices - 2 ) )

--- a/tests/src/core/geometry/testqgscircularstring.cpp
+++ b/tests/src/core/geometry/testqgscircularstring.cpp
@@ -1089,7 +1089,7 @@ void TestQgsCircularString::deleteVertex()
   //empty line
   QgsCircularString cs;
 
-  QVERIFY( cs.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QVERIFY( !cs.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
   QVERIFY( cs.isEmpty() );
 
   //valid line
@@ -1117,7 +1117,7 @@ void TestQgsCircularString::deleteVertex()
   QCOMPARE( cs.numPoints(), 0 );
   QVERIFY( cs.isEmpty() );
 
-  QVERIFY( cs.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
+  QVERIFY( !cs.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
   QVERIFY( cs.isEmpty() );
 
   //removing a vertex from a 3 point circular string should remove the whole line

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -9792,8 +9792,8 @@ class TestQgsGeometry(QgisTestCase):
         invalidVertex1 = QgsVertexId(0, 0, -1)
         invalidVertex2 = QgsVertexId(0, 0, 3)
 
-        assert not c.deleteVertex(invalidVertex1)
-        assert not c.deleteVertex(invalidVertex2)
+        self.assertFalse(c.deleteVertex(invalidVertex1))
+        self.assertFalse(c.deleteVertex(invalidVertex2))
 
     def testDeleteVertexCompoundCurve(self):
 

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -9780,6 +9780,21 @@ class TestQgsGeometry(QgisTestCase):
         assert not geom.deleteVertex(-1)
         assert not geom.deleteVertex(5)
 
+        # test invalid range deletion on abstract geometry
+        p1 = QgsPoint(0, 0)
+        p2 = QgsPoint(1, 1)
+        p3 = QgsPoint(2, 0)
+
+        c = QgsCircularString()
+
+        c.setPoints([p1, p2, p3])
+
+        invalidVertex1 = QgsVertexId(0, 0, -1)
+        invalidVertex2 = QgsVertexId(0, 0, 3)
+
+        assert not c.deleteVertex(invalidVertex1)
+        assert not c.deleteVertex(invalidVertex2)
+
     def testDeleteVertexCompoundCurve(self):
 
         wkt = "CompoundCurve ((0 0,1 1))"


### PR DESCRIPTION
Doing a round of reviews of #63257, so I had a brief look at some `deleteVertex` implementations.

This fixes an issue of removing the whole CircularString when an invalid `VertexId` is given by moving the `noOfVertices` check after the index validity check. This only happens when noOfVertices = 3.

If/when `deleteVertices` is merged, I think `deleteVertex` should be deprecated in favor of `deleteVertices`. For a single vertex deletion, the methods should be identical and potential fixes should only have to be performed in a single method.

No AI used.