### PR TITLE
Sort individual layer settings xml in snapping config 

### DIFF
--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -15,6 +15,8 @@
  ***************************************************************************/
 #include "qgssnappingconfig.h"
 
+#include <algorithm>
+
 #include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgsproject.h"
@@ -571,13 +573,14 @@ void QgsSnappingConfig::writeProject( QDomDocument &doc )
   snapSettingsElem.setAttribute( u"maxScale"_s, mMaximumScale );
 
   QDomElement ilsElement = doc.createElement( u"individual-layer-settings"_s );
-  QHash<QgsVectorLayer *, IndividualLayerSettings>::const_iterator layerIt = mIndividualLayerSettings.constBegin();
-  for ( ; layerIt != mIndividualLayerSettings.constEnd(); ++layerIt )
+  QList<QgsVectorLayer *> sortedLayers = mIndividualLayerSettings.keys();
+  std::sort( sortedLayers.begin(), sortedLayers.end(), []( QgsVectorLayer *a, QgsVectorLayer *b ) { return a->id() < b->id(); } );
+  for ( QgsVectorLayer *layer : std::as_const( sortedLayers ) )
   {
-    const IndividualLayerSettings &setting = layerIt.value();
+    const IndividualLayerSettings &setting = mIndividualLayerSettings.value( layer );
 
     QDomElement layerElement = doc.createElement( u"layer-setting"_s );
-    layerElement.setAttribute( u"id"_s, layerIt.key()->id() );
+    layerElement.setAttribute( u"id"_s, layer->id() );
     layerElement.setAttribute( u"enabled"_s, QString::number( setting.enabled() ) );
     layerElement.setAttribute( u"type"_s, static_cast<int>( setting.typeFlag() ) );
     layerElement.setAttribute( u"tolerance"_s, setting.tolerance() );


### PR DESCRIPTION
## Description

We have multiple users working on the same .qgs project using version control. Sort `snapping-settings/individual-layer-settings` when saving to reduce diff. Sort by layer id instead of QHash random process order

related to: https://github.com/qgis/QGIS/issues/29192



## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

