### PR TITLE
[imageserver] Add a workaround to handle RGB sources with nodata masks

### DIFF
--- a/src/providers/arcgisrest/qgsimageserverprovider.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovider.cpp
@@ -676,7 +676,7 @@ bool QgsImageServerProvider::readBlock( int bandNo, const QgsRectangle &viewExte
 
   query.addQueryItem( u"f"_s, u"image"_s );
   query.addQueryItem( u"bandIds"_s, QString::number( bandNo - 1 ) );
-  query.addQueryItem( u"interpretation"_s, u"RSP_BilinearInterpolation"_s );
+  query.addQueryItem( u"interpolation"_s, u"RSP_BilinearInterpolation"_s );
   query.addQueryItem( u"pixelType"_s, mPixelType );
 
   // determine the request format

--- a/src/providers/arcgisrest/qgsimageserverprovider.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovider.cpp
@@ -762,6 +762,11 @@ bool QgsImageServerProvider::readBlockInternal(
     requestFormat = dataSource.param( u"format"_s );
     vsiExtension.clear();
   }
+  else if ( mDataType == Qgis::DataType::Byte )
+  {
+     requestFormat = u"png8"_s;
+     vsiExtension = u".png"_s;
+  }
   else if ( mMaximumLercVersionSupported > 0 && ( mDataType == Qgis::DataType::Float32 || mDataType == Qgis::DataType::Float64 ) )
   {
     // if the data is floating point and both server and client support it, request LERC compression for smaller transfers

--- a/src/providers/arcgisrest/qgsimageserverprovider.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovider.cpp
@@ -752,6 +752,8 @@ bool QgsImageServerProvider::readBlockInternal(
   query.addQueryItem( u"interpolation"_s, u"RSP_BilinearInterpolation"_s );
   query.addQueryItem( u"pixelType"_s, mPixelType );
 
+  int responseBandNumber = 1;
+
   // determine the request format
   // default to tiff as a safe option since it handles all bit depths and nodata.
   QString requestFormat = u"tiff"_s;
@@ -764,8 +766,18 @@ bool QgsImageServerProvider::readBlockInternal(
   }
   else if ( mDataType == Qgis::DataType::Byte )
   {
-     requestFormat = u"png8"_s;
-     vsiExtension = u".png"_s;
+    requestFormat = u"png8"_s;
+    vsiExtension = u".png"_s;
+    // hack to get around ImageServer pixel mask logic for RGB images
+    if ( mServiceInfo.value( u"serviceDataType"_s ).toString() == "esriImageServiceDataTypeRGB" )
+    {
+      // gross hack -- for RGB byte data, we need to force the service to return a PNG32 image so that we
+      // get the alpha mask.
+      // we'll throw away two of those unwanted bands shortly :o
+      requestFormat = u"png32"_s;
+      query.removeQueryItem( u"bandIds"_s );
+      responseBandNumber = bandNo;
+    }
   }
   else if ( mMaximumLercVersionSupported > 0 && ( mDataType == Qgis::DataType::Float32 || mDataType == Qgis::DataType::Float64 ) )
   {
@@ -821,8 +833,7 @@ bool QgsImageServerProvider::readBlockInternal(
     return false;
   }
 
-  // we'll always have a single-band raster, so we request the first band
-  GDALRasterBandH hBand = GDALGetRasterBand( hDS, 1 );
+  GDALRasterBandH hBand = GDALGetRasterBand( hDS, responseBandNumber );
   if ( !hBand || ( feedback && feedback->isCanceled() ) )
   {
     GDALClose( hDS );

--- a/src/providers/arcgisrest/qgsimageserverprovider.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovider.cpp
@@ -799,24 +799,41 @@ bool QgsImageServerProvider::readBlockInternal(
   queryUrl.setQuery( query );
 
   queryUrl = QgsArcGisRestQueryUtils::parseUrl( queryUrl );
-
-  QgsBlockingNetworkRequest networkRequest;
-  networkRequest.setAuthCfg( mAuthCfg );
-  QNetworkRequest req( queryUrl );
-  mRequestHeaders.updateNetworkRequest( req );
-  QgsSetRequestInitiatorClass( req, u"QgsImageServerProvider"_s );
-
-  if ( networkRequest.get( req, false, feedback ) != QgsBlockingNetworkRequest::NoError )
+  QByteArray rawData;
+  if ( queryUrl == mLastReply.requestUrl )
   {
-    if ( !feedback || !feedback->isCanceled() )
-    {
-      QgsDebugMsgLevel( u"Network request failed: %1"_s.arg( networkRequest.errorMessage() ), 2 );
-    }
-    return false;
+    // optimization -- if we are requesting the EXACT same data as the last request, just take the
+    // same reply. This helps with the RGB data situation, where QGIS requests three separate blocks
+    // for the different channels, yet we have to retrieve the data as a complete RGB request from
+    // ImageServer providers. (Otherwise we'd been requesting the RGB data for just the red channel and
+    // throwing away the green and blue, then requesting the RGB data again for the green channel and
+    // throwing away the red and blue, etc...)
+    rawData = mLastReply.response;
   }
+  else
+  {
+    mLastReply = ServiceReply();
 
-  const QgsNetworkReplyContent reply = networkRequest.reply();
-  QByteArray rawData = reply.content();
+    QgsBlockingNetworkRequest networkRequest;
+    networkRequest.setAuthCfg( mAuthCfg );
+    QNetworkRequest req( queryUrl );
+    mRequestHeaders.updateNetworkRequest( req );
+    QgsSetRequestInitiatorClass( req, u"QgsImageServerProvider"_s );
+
+    if ( networkRequest.get( req, false, feedback ) != QgsBlockingNetworkRequest::NoError )
+    {
+      if ( !feedback || !feedback->isCanceled() )
+      {
+        QgsDebugMsgLevel( u"Network request failed: %1"_s.arg( networkRequest.errorMessage() ), 2 );
+      }
+      return false;
+    }
+
+    const QgsNetworkReplyContent reply = networkRequest.reply();
+    rawData = reply.content();
+    mLastReply.requestUrl = queryUrl;
+    mLastReply.response = rawData;
+  }
   if ( rawData.isEmpty() || ( feedback && feedback->isCanceled() ) )
     return false;
 

--- a/src/providers/arcgisrest/qgsimageserverprovider.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovider.cpp
@@ -581,7 +581,80 @@ QList<double> QgsImageServerProvider::nativeResolutions() const
   return mResolutions;
 }
 
+QgsRasterBlock *QgsImageServerProvider::block( int bandNo, const QgsRectangle &boundingBox, int width, int height, QgsRasterBlockFeedback *feedback )
+{
+  auto block = std::make_unique< QgsRasterBlock >( dataType( bandNo ), width, height );
+
+  bool useNoDataMask = true;
+  if ( sourceHasNoDataValue( bandNo ) && useSourceNoDataValue( bandNo ) )
+  {
+    block->setNoDataValue( sourceNoDataValue( bandNo ) );
+    useNoDataMask = false;
+  }
+
+  if ( block->isEmpty() )
+  {
+    QgsDebugError( u"Couldn't create raster block"_s );
+    block->setError( { tr( "Couldn't create raster block." ), u"Raster"_s } );
+    block->setValid( false );
+    return block.release();
+  }
+
+  if ( !mExtent.intersects( boundingBox ) )
+  {
+    // the requested extent is completely outside of the raster's extent - nothing to do
+    block->setIsNoData();
+    return block.release();
+  }
+  if ( !mExtent.contains( boundingBox ) )
+  {
+    QRect subRect = QgsRasterBlock::subRect( boundingBox, width, height, mExtent );
+    block->setIsNoDataExcept( subRect );
+  }
+
+  std::vector<GByte> maskData;
+  const qgssize dataSize = static_cast< qgssize >( width ) * static_cast< qgssize >( height );
+  if ( useNoDataMask )
+  {
+    maskData.resize( dataSize );
+  }
+
+  bool foundNoDataMask = false;
+  if ( !readBlockInternal( bandNo, boundingBox, width, height, block->bits(), useNoDataMask ? &maskData : nullptr, &foundNoDataMask, feedback ) )
+  {
+    if ( !feedback || !feedback->isCanceled() )
+    {
+      QgsDebugError( u"Error occurred while reading block"_s );
+      block->setError( { tr( "Error occurred while reading block." ), u"Raster"_s } );
+    }
+    block->setIsNoData();
+    block->setValid( false );
+    return block.release();
+  }
+  else if ( useNoDataMask && foundNoDataMask )
+  {
+    for ( qgssize i = 0; i < dataSize; ++i )
+    {
+      if ( maskData[i] == 0 )
+      {
+        block->setIsNoData( i );
+      }
+    }
+  }
+
+  block->applyScaleOffset( bandScale( bandNo ), bandOffset( bandNo ) );
+  block->applyNoDataValues( userNoDataValues( bandNo ) );
+  return block.release();
+}
+
 bool QgsImageServerProvider::readBlock( int bandNo, const QgsRectangle &viewExtent, int width, int height, void *data, QgsRasterBlockFeedback *feedback )
+{
+  return readBlockInternal( bandNo, viewExtent, width, height, data, nullptr, nullptr, feedback );
+}
+
+bool QgsImageServerProvider::readBlockInternal(
+  int bandNo, const QgsRectangle &viewExtent, int width, int height, void *data, std::vector<GByte> *noDataMask, bool *foundNoDataMask, QgsRasterBlockFeedback *feedback
+)
 {
   if ( !mValid || width <= 0 || height <= 0 )
     return false;
@@ -752,7 +825,6 @@ bool QgsImageServerProvider::readBlock( int bandNo, const QgsRectangle &viewExte
     return false;
   }
 
-
   if ( feedback && feedback->isCanceled() )
   {
     GDALClose( hDS );
@@ -776,6 +848,25 @@ bool QgsImageServerProvider::readBlock( int bandNo, const QgsRectangle &viewExte
   const GSpacing lineSpace = static_cast<GSpacing>( width ) * elementSize;
   const CPLErr err
     = GDALRasterIOEx( hBand, GF_Read, 0, 0, GDALGetRasterXSize( hDS ), GDALGetRasterYSize( hDS ), targetData, blockSubRectPixels.width(), blockSubRectPixels.height(), gdalType, pixelSpace, lineSpace, &extraArg );
+
+  if ( noDataMask )
+  {
+    *foundNoDataMask = false;
+    const int maskFlags = GDALGetMaskFlags( hBand );
+    if ( !( maskFlags & GMF_ALL_VALID ) )
+    {
+      if ( GDALRasterBandH hMaskBand = GDALGetMaskBand( hBand ) )
+      {
+        // Read the mask array
+        CPLErr err = GDALRasterIOEx( hMaskBand, GF_Read, 0, 0, GDALGetRasterXSize( hDS ), GDALGetRasterYSize( hDS ), noDataMask->data(), width, height, GDT_Byte, 0, 0, nullptr );
+
+        if ( err == CE_None )
+        {
+          *foundNoDataMask = true;
+        }
+      }
+    }
+  }
 
   GDALClose( hDS );
   VSIUnlink( vsimemFilename.toUtf8().constData() );

--- a/src/providers/arcgisrest/qgsimageserverprovider.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovider.cpp
@@ -175,39 +175,6 @@ QgsImageServerProvider::QgsImageServerProvider( const QString &uri, const Provid
     }
   }
 
-  // for integer data types, we enforce that there is a nodata value for every band.
-  // we require this as we can't fallback to a nan value for padding raster blocks
-  // with nodata when required
-  switch ( mDataType )
-  {
-    case Qgis::DataType::UnknownDataType:
-      break;
-
-    case Qgis::DataType::Byte:
-    case Qgis::DataType::UInt16:
-    case Qgis::DataType::Int16:
-    case Qgis::DataType::UInt32:
-    case Qgis::DataType::Int32:
-    case Qgis::DataType::Int8:
-      while ( mSrcHasNoDataValue.size() < mBandCount )
-      {
-        mSrcNoDataValue.append( QgsArcGisRestUtils::defaultNoDataForDataType( mDataType, ok ) );
-        mSrcHasNoDataValue.append( true );
-        mUseSrcNoDataValue.append( true );
-      }
-      break;
-
-    case Qgis::DataType::Float32:
-    case Qgis::DataType::Float64:
-    case Qgis::DataType::CInt16:
-    case Qgis::DataType::CInt32:
-    case Qgis::DataType::CFloat32:
-    case Qgis::DataType::CFloat64:
-    case Qgis::DataType::ARGB32:
-    case Qgis::DataType::ARGB32_Premultiplied:
-      break;
-  }
-
   for ( const QVariant &min : mLayerInfo.value( u"minValues"_s ).toList() )
   {
     mMinValues.append( min.toDouble() );

--- a/src/providers/arcgisrest/qgsimageserverprovider.h
+++ b/src/providers/arcgisrest/qgsimageserverprovider.h
@@ -79,6 +79,7 @@ class QgsImageServerProvider : public QgsRasterDataProvider
     QString htmlMetadata() const override;
     QgsRasterIdentifyResult identify( const QgsPointXY &point, Qgis::RasterIdentifyFormat format, const QgsRectangle &extent = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
     QList<double> nativeResolutions() const override;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle &boundingBox, int width, int height, QgsRasterBlockFeedback *feedback = nullptr ) override;
 
   protected:
     using QgsRasterDataProvider::readBlock;
@@ -87,6 +88,7 @@ class QgsImageServerProvider : public QgsRasterDataProvider
 
   private:
     bool readTiledBlock( const QgsRectangle &viewExtent, int width, int height, void *data, GDALDataType gdalType, int elementSize, QgsRasterBlockFeedback *feedback );
+    bool readBlockInternal( int bandNo, const QgsRectangle &viewExtent, int width, int height, void *data, std::vector<GByte> *noDataMask, bool *foundNoDataMask, QgsRasterBlockFeedback *feedback = nullptr );
 
     bool mValid = false;
     QVariantMap mServiceInfo;

--- a/src/providers/arcgisrest/qgsimageserverprovider.h
+++ b/src/providers/arcgisrest/qgsimageserverprovider.h
@@ -125,6 +125,13 @@ class QgsImageServerProvider : public QgsRasterDataProvider
     int mMaximumLercVersionSupported = 0;
     bool mHasRat = false;
 
+    struct ServiceReply
+    {
+        QUrl requestUrl;
+        QByteArray response;
+    };
+    ServiceReply mLastReply;
+
     /**
      * Resets cached image
     */

--- a/tests/src/python/test_provider_imageserver.py
+++ b/tests/src/python/test_provider_imageserver.py
@@ -1640,6 +1640,72 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
         self.assertAlmostEqual(block.value(1, 0), 150, delta=15)
         self.assertAlmostEqual(block.value(1, 1), 200, delta=15)
 
+    def test_fetch_block_png(self):
+        """
+        Test fetching a block for a U8 data type when no explicit format is specified
+        """
+        endpoint = self.basetestpath + "/fetch_png_fake_qgis_http_endpoint"
+
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""{
+  "currentVersion": 10.91,
+  "pixelType": "U8",
+  "extent": {
+    "xmin": 0,
+    "ymin": 0,
+    "xmax": 10,
+    "ymax": 10,
+    "spatialReference": {
+      "wkid": 4326
+    }
+  },
+  "capabilities": "Image",
+  "bandCount": 1,
+  "type": "ImageServer",
+  "serviceSourceType": "esriImageServiceSourceTypeDataset",
+  "serviceDataType": "esriImageServiceDataTypeElevation",
+  "spatialReference": {
+    "wkid": 4326,
+    "latestWkid": 4326
+  }
+}"""
+            )
+
+        # 2x2 PNG blob
+        mem_ds = gdal.GetDriverByName("MEM").Create("", 2, 2, 1, gdal.GDT_Byte)
+        # raster data = 10, 20, 30, 40
+        mem_ds.GetRasterBand(1).WriteRaster(
+            0, 0, 2, 2, struct.pack("B" * 4, 10, 20, 30, 40)
+        )
+
+        gdal.GetDriverByName("PNG").CreateCopy("/vsimem/test.png", mem_ds)
+
+        vsi_file = gdal.VSIFOpenL("/vsimem/test.png", "rb")
+        gdal.VSIFSeekL(vsi_file, 0, 2)
+        size = gdal.VSIFTellL(vsi_file)
+        gdal.VSIFSeekL(vsi_file, 0, 0)
+        jpg_blob = gdal.VSIFReadL(1, size, vsi_file)
+        gdal.VSIFCloseL(vsi_file)
+        gdal.Unlink("/vsimem/test.png")
+
+        query = "/exportImage?bbox=0.000000,0.000000,10.000000,10.000000&size=2,2&f=image&bandIds=0&interpolation=RSP_BilinearInterpolation&pixelType=U8&format=png8"
+        with open(self.sanitize_local_url(endpoint, query), "wb") as f:
+            f.write(jpg_blob)
+
+        rl = QgsRasterLayer(
+            "url='http://" + endpoint + "'", "test", "arcgisimageserver"
+        )
+        self.assertTrue(rl.isValid())
+
+        block = rl.dataProvider().block(1, QgsRectangle(0, 0, 10, 10), 2, 2)
+        self.assertTrue(block.isValid())
+
+        self.assertEqual(block.value(0, 0), 10)
+        self.assertEqual(block.value(0, 1), 20)
+        self.assertEqual(block.value(1, 0), 30)
+        self.assertEqual(block.value(1, 1), 40)
+
     def test_raster_attribute_table(self):
         """
         Test fetching raster attribute table

--- a/tests/src/python/test_provider_imageserver.py
+++ b/tests/src/python/test_provider_imageserver.py
@@ -1497,7 +1497,11 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
 
         # fetch block outside raster extent
         block = rl.dataProvider().block(1, QgsRectangle(20, 20, 30, 30), 2, 2)
-        self.assertFalse(block.isValid())
+        self.assertTrue(block.isValid())
+        # should be all no-data
+        for r in range(0, 2):
+            for c in range(0, 2):
+                self.assertTrue(block.isNoData(r, c))
 
         # invalid size
         block = rl.dataProvider().block(1, QgsRectangle(0, 0, 10, 10), 0, 0)

--- a/tests/src/python/test_provider_imageserver.py
+++ b/tests/src/python/test_provider_imageserver.py
@@ -1483,7 +1483,7 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
         lerc_blob = gdal.VSIFReadL(1, size, vsi_file)
         gdal.VSIFCloseL(vsi_file)
         gdal.Unlink("/vsimem/test.lrc")
-        query = "/exportImage?bbox=0.000000,0.000000,10.000000,10.000000&size=2,2&f=image&bandIds=0&interpretation=RSP_BilinearInterpolation&pixelType=F32&lercVersion=2&compression=LERC&compressionTolerance=0&format=lerc"
+        query = "/exportImage?bbox=0.000000,0.000000,10.000000,10.000000&size=2,2&f=image&bandIds=0&interpolation=RSP_BilinearInterpolation&pixelType=F32&lercVersion=2&compression=LERC&compressionTolerance=0&format=lerc"
         with open(self.sanitize_local_url(endpoint, query), "wb") as f:
             f.write(lerc_blob)
 
@@ -1550,7 +1550,7 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
         gdal.VSIFCloseL(vsi_file)
         gdal.Unlink("/vsimem/test.tif")
 
-        query = "/exportImage?bbox=0.000000,0.000000,10.000000,10.000000&size=2,2&f=image&bandIds=0&interpretation=RSP_BilinearInterpolation&pixelType=U16&format=tiff"
+        query = "/exportImage?bbox=0.000000,0.000000,10.000000,10.000000&size=2,2&f=image&bandIds=0&interpolation=RSP_BilinearInterpolation&pixelType=U16&format=tiff"
 
         with open(self.sanitize_local_url(endpoint, query), "wb") as f:
             f.write(tiff_blob)
@@ -1617,7 +1617,7 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
         gdal.VSIFCloseL(vsi_file)
         gdal.Unlink("/vsimem/test.jpg")
 
-        query = "/exportImage?bbox=0.000000,0.000000,10.000000,10.000000&size=2,2&f=image&bandIds=0&interpretation=RSP_BilinearInterpolation&pixelType=U8&format=jpg"
+        query = "/exportImage?bbox=0.000000,0.000000,10.000000,10.000000&size=2,2&f=image&bandIds=0&interpolation=RSP_BilinearInterpolation&pixelType=U8&format=jpg"
         with open(self.sanitize_local_url(endpoint, query), "wb") as f:
             f.write(jpg_blob)
 

--- a/tests/src/python/test_provider_imageserver.py
+++ b/tests/src/python/test_provider_imageserver.py
@@ -1706,6 +1706,119 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
         self.assertEqual(block.value(1, 0), 30)
         self.assertEqual(block.value(1, 1), 40)
 
+    def test_fetch_block_rgb_alpha(self):
+        """
+        Test fetching a block for a RGB service, where we need the
+        source's nodata mask
+        """
+        endpoint = self.basetestpath + "/fetch_rgb_mask_fake_qgis_http_endpoint"
+
+        with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+            f.write(
+                b"""{
+  "currentVersion": 10.91,
+  "pixelType": "U8",
+  "extent": {
+    "xmin": 0,
+    "ymin": 0,
+    "xmax": 10,
+    "ymax": 10,
+    "spatialReference": {
+      "wkid": 4326
+    }
+  },
+  "capabilities": "Image",
+  "bandCount": 3,
+  "type": "ImageServer",
+  "serviceSourceType": "esriImageServiceSourceTypeDataset",
+  "serviceDataType": "esriImageServiceDataTypeRGB",
+  "spatialReference": {
+    "wkid": 4326,
+    "latestWkid": 4326
+  }
+}"""
+            )
+
+        mem_ds = gdal.GetDriverByName("MEM").Create("", 2, 2, 4, gdal.GDT_Byte)
+
+        # checkerboard pattern of Valid/NoData
+        # Pixel 0,0: Valid (Alpha 255)
+        # Pixel 0,1: NoData (Alpha 0)
+        # Pixel 1,0: Valid (Alpha 255)
+        # Pixel 1,1: NoData (Alpha 0)
+
+        # Band 1 (Red) - values: 10, 0, 50, 0
+        mem_ds.GetRasterBand(1).WriteRaster(
+            0, 0, 2, 2, struct.pack("B" * 4, 10, 0, 50, 0)
+        )
+        # Band 2 (Green) - values: 20, 0, 60, 0
+        mem_ds.GetRasterBand(2).WriteRaster(
+            0, 0, 2, 2, struct.pack("B" * 4, 20, 0, 60, 0)
+        )
+        # Band 3 (Blue) - values: 30, 0, 70, 0
+        mem_ds.GetRasterBand(3).WriteRaster(
+            0, 0, 2, 2, struct.pack("B" * 4, 30, 0, 70, 0)
+        )
+        # Band 4 (Alpha Mask) - values: 255, 0, 255, 0
+        mem_ds.GetRasterBand(4).WriteRaster(
+            0, 0, 2, 2, struct.pack("B" * 4, 255, 0, 255, 0)
+        )
+
+        gdal.GetDriverByName("PNG").CreateCopy("/vsimem/test_rgba.png", mem_ds)
+
+        vsi_file = gdal.VSIFOpenL("/vsimem/test_rgba.png", "rb")
+        gdal.VSIFSeekL(vsi_file, 0, 2)
+        size = gdal.VSIFTellL(vsi_file)
+        gdal.VSIFSeekL(vsi_file, 0, 0)
+        png_blob = gdal.VSIFReadL(1, size, vsi_file)
+        gdal.VSIFCloseL(vsi_file)
+        gdal.Unlink("/vsimem/test_rgba.png")
+
+        # the query MUST NOT include &bandIds= because the image server provider logic strips it out
+        # and forces &format=png32 when serviceDataType == esriImageServiceDataTypeRGB
+        # See QgsImageServerProvider::readBlockInternal for further explanations
+        query = "/exportImage?bbox=0.000000,0.000000,10.000000,10.000000&size=2,2&f=image&interpolation=RSP_BilinearInterpolation&pixelType=U8&format=png32"
+        with open(self.sanitize_local_url(endpoint, query), "wb") as f:
+            f.write(png_blob)
+
+        rl = QgsRasterLayer(
+            "url='http://" + endpoint + "'", "test", "arcgisimageserver"
+        )
+        self.assertTrue(rl.isValid())
+
+        # Band 1 (Red)
+        block_b1 = rl.dataProvider().block(1, QgsRectangle(0, 0, 10, 10), 2, 2)
+        self.assertTrue(block_b1.isValid())
+
+        self.assertFalse(block_b1.isNoData(0, 0))
+        self.assertEqual(block_b1.value(0, 0), 10)
+        self.assertTrue(block_b1.isNoData(0, 1))
+        self.assertFalse(block_b1.isNoData(1, 0))
+        self.assertEqual(block_b1.value(1, 0), 50)
+        self.assertTrue(block_b1.isNoData(1, 1))
+
+        # Band 2 (Green)
+        block_b2 = rl.dataProvider().block(2, QgsRectangle(0, 0, 10, 10), 2, 2)
+        self.assertTrue(block_b2.isValid())
+
+        self.assertFalse(block_b2.isNoData(0, 0))
+        self.assertEqual(block_b2.value(0, 0), 20)
+        self.assertTrue(block_b2.isNoData(0, 1))
+        self.assertFalse(block_b2.isNoData(1, 0))
+        self.assertEqual(block_b2.value(1, 0), 60)
+        self.assertTrue(block_b2.isNoData(1, 1))
+
+        # Band 3 (Red)
+        block_b3 = rl.dataProvider().block(3, QgsRectangle(0, 0, 10, 10), 2, 2)
+        self.assertTrue(block_b3.isValid())
+
+        self.assertFalse(block_b3.isNoData(0, 0))
+        self.assertEqual(block_b3.value(0, 0), 30)
+        self.assertTrue(block_b3.isNoData(0, 1))
+        self.assertFalse(block_b3.isNoData(1, 0))
+        self.assertEqual(block_b3.value(1, 0), 70)
+        self.assertTrue(block_b3.isNoData(1, 1))
+
     def test_raster_attribute_table(self):
         """
         Test fetching raster attribute table

--- a/tests/src/python/test_provider_imageserver.py
+++ b/tests/src/python/test_provider_imageserver.py
@@ -1102,13 +1102,9 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
         self.assertEqual(rl.dataProvider().dataType(3), Qgis.DataType.UInt16)
         self.assertEqual(rl.dataProvider().dataType(4), Qgis.DataType.UInt16)
 
-        # we always populate nodata values for integers, so that we can
-        # safely pad raster blocks which were requested outside of the
-        # providers extent
         for i in range(1, 5):
-            self.assertTrue(rl.dataProvider().sourceHasNoDataValue(i))
-            self.assertTrue(rl.dataProvider().useSourceNoDataValue(i))
-            self.assertEqual(rl.dataProvider().sourceNoDataValue(i), 65535)
+            self.assertFalse(rl.dataProvider().sourceHasNoDataValue(i))
+            self.assertFalse(rl.dataProvider().useSourceNoDataValue(i))
 
         self.assertFalse(rl.elevationProperties().isEnabled())
 


### PR DESCRIPTION
## Description

Adds a hack/workaround to allow us to retrieve the source's nodata mask when reading RGB imagery from an imageserver provider.

The only way to retrieve this alpha mask is to retrieve the data as a PNG32 with all 4 bands (R/G/B/A), and then throw away the
two extra unwanted bands.

~~(This is quite inefficient -- due to QGIS' rendering pipeline, a raster provider must retrieve all bands in separate requests.
So we end up requesting the SAME 4 band data from the source 3 times!...)~~ handled via a simple cache mechanism

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
