### PR TITLE
When a portion of a model is run, flag the dependent results as out of date

### DIFF
--- a/python/PyQt6/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -505,6 +505,14 @@ Flags the algorithm as having started.
 .. versionadded:: 4.2
 %End
 
+    void setOutdated();
+%Docstring
+Flags the algorithm as possibly being outdated (i.e. previous results
+are invalid due to changes elsewhere in the model).
+
+.. versionadded:: 4.2
+%End
+
     int indexForInput( const QString &parameterName ) const;
 %Docstring
 Returns the index for the input with the specified parameter name, or -1

--- a/python/PyQt6/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -208,6 +208,14 @@ the model, with an additional margin arounds items.
 %End
 
 
+    void flagChildrenAsOutdated( const QSet< QString > &children );
+%Docstring
+Flags a set of children as possibly being outdated (i.e. previous
+results are invalid due to changes elsewhere in the model).
+
+.. versionadded:: 4.2
+%End
+
   signals:
 
     void rebuildRequired();

--- a/python/PyQt6/gui/auto_generated/processing/qgsprocessingalgorithmwidgetbase.sip.in
+++ b/python/PyQt6/gui/auto_generated/processing/qgsprocessingalgorithmwidgetbase.sip.in
@@ -365,14 +365,14 @@ Hides the short help panel.
 Returns the widget's message bar.
 %End
 
-  protected:
-    virtual void closeEvent( QCloseEvent *e );
-
-
     QPushButton *runButton();
 %Docstring
 Returns the widget's run button.
 %End
+
+  protected:
+    virtual void closeEvent( QCloseEvent *e );
+
 
     QPushButton *cancelButton();
 %Docstring

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -1195,6 +1195,11 @@ QColor QgsModelChildAlgorithmGraphicItem::textColor( QgsModelComponentGraphicIte
 
 QColor QgsModelChildAlgorithmGraphicItem::outlineColor() const
 {
+  if ( mOutdated )
+  {
+    return QColor( 150, 150, 0 );
+  }
+
   switch ( mResults.executionStatus() )
   {
     case Qgis::ProcessingModelChildAlgorithmExecutionStatus::NotExecuted:
@@ -1407,6 +1412,7 @@ void QgsModelChildAlgorithmGraphicItem::setResults( const QgsProcessingModelChil
   if ( mResults == results )
     return;
 
+  mOutdated = false;
   const QList< QgsModelArrowItem * > arrows = outgoingArrows();
   if ( results.executionStatus() == Qgis::ProcessingModelChildAlgorithmExecutionStatus::NotExecuted )
   {
@@ -1498,6 +1504,12 @@ void QgsModelChildAlgorithmGraphicItem::setProgress( double progress )
 void QgsModelChildAlgorithmGraphicItem::setStarted()
 {
   mStarted = true;
+  update();
+}
+
+void QgsModelChildAlgorithmGraphicItem::setOutdated()
+{
+  mOutdated = true;
   update();
 }
 

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -565,6 +565,13 @@ class GUI_EXPORT QgsModelChildAlgorithmGraphicItem : public QgsModelComponentGra
     void setStarted();
 
     /**
+     * Flags the algorithm as possibly being outdated (i.e. previous results are invalid due to changes elsewhere in the model).
+     *
+     * \since QGIS 4.2
+     */
+    void setOutdated();
+
+    /**
      * Returns the index for the input with the specified parameter name, or -1 if the parameter could not be matched.
      *
      * \see indexForOutput()
@@ -644,6 +651,7 @@ class GUI_EXPORT QgsModelChildAlgorithmGraphicItem : public QgsModelComponentGra
     QPicture mPicture;
     QPixmap mPixmap;
     bool mStarted = false;
+    bool mOutdated = false;
     QgsProcessingModelChildAlgorithmResult mResults;
     double mProgress = -1;
     bool mIsValid = true;

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -542,6 +542,7 @@ void QgsModelDesignerDialog::setModelScene( QgsModelGraphicsScene *scene )
       return;
 
     repaintModel();
+    mScene->flagChildrenAsOutdated( mOutdatedChildResults );
   } );
   connect( mScene, &QgsModelGraphicsScene::componentAboutToChange, this, [this]( const QString &description, const QString &id ) { beginUndoCommand( description, id ); } );
   connect( mScene, &QgsModelGraphicsScene::componentChanged, this, [this] { endUndoCommand(); } );
@@ -563,6 +564,9 @@ QgsProcessingFeedback *QgsModelDesignerDialog::createFeedback()
 {
   auto result = std::make_unique< QgsProcessingModelFeedback >();
   mScene->setupFeedbackConnections( result.get() );
+  connect( result.get(), &QgsProcessingModelFeedback::childResultReported, this, [this]( const QString &childId, const QgsProcessingModelChildAlgorithmResult & ) {
+    mOutdatedChildResults.remove( childId );
+  } );
   return result.release();
 }
 
@@ -1283,6 +1287,14 @@ void QgsModelDesignerDialog::run( const QSet<QString> &childAlgorithmSubset )
         context->setModelInitialRunConfig( std::move( modelConfig ) );
 
         mScene->resetChildAlgorithmItems( childAlgorithmSubset );
+
+        // for all algorithms downstream of the subset which won't be re-run, flag their old results as outdated.
+        for ( const QString &child : childAlgorithmSubset )
+        {
+          const QSet< QString > outdated = mModel->dependentChildAlgorithms( child );
+          mScene->flagChildrenAsOutdated( outdated );
+          mOutdatedChildResults.unite( outdated );
+        }
       }
       else
       {
@@ -1305,6 +1317,7 @@ void QgsModelDesignerDialog::run( const QSet<QString> &childAlgorithmSubset )
 
 void QgsModelDesignerDialog::showChildAlgorithmOutputs( const QString &childId )
 {
+  const bool isOutdated = mOutdatedChildResults.contains( childId );
   const QString childDescription = mModel->childAlgorithm( childId ).description();
 
   const QgsProcessingModelChildAlgorithmResult result = mLastResult.childResults().value( childId );
@@ -1377,6 +1390,11 @@ void QgsModelDesignerDialog::showChildAlgorithmOutputs( const QString &childId )
   if ( !foundResults )
   {
     mMessageBar->pushWarning( QString(), tr( "No results are available for %1" ).arg( childDescription ) );
+    return;
+  }
+  else if ( isOutdated )
+  {
+    mMessageBar->pushWarning( QString(), tr( "These results are outdated, and may not reflect the most recent model execution" ) );
     return;
   }
 }

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -1252,6 +1252,12 @@ void QgsModelDesignerDialog::run( const QSet<QString> &childAlgorithmSubset )
     mAlgorithmWidget->setLogLevel( Qgis::ProcessingLogLevel::ModelDebug );
     mAlgorithmWidget->setParameters( mModel->designerParameterValues() );
 
+    if ( !childAlgorithmSubset.isEmpty() )
+    {
+      mAlgorithmWidget->runButton()->setText( tr( "Run Subset" ) );
+      mAlgorithmWidget->runButton()->setToolTip( tr( "Runs a subset of the child algorithms from this model" ) );
+    }
+
     connect( mAlgorithmWidget.get(), &QgsProcessingAlgorithmWidgetBase::algorithmAboutToRun, this, [this, childAlgorithmSubset]( QgsProcessingContext *context ) {
       if ( !childAlgorithmSubset.empty() )
       {

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -271,6 +271,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public QgsProcessi
     int mBlockRepaints = 0;
 
     QgsProcessingModelResult mLastResult;
+    QSet< QString > mOutdatedChildResults;
 
     bool isDirty() const;
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -137,6 +137,17 @@ void QgsModelGraphicsScene::setupFeedbackConnections( QgsProcessingModelFeedback
   } );
 }
 
+void QgsModelGraphicsScene::flagChildrenAsOutdated( const QSet<QString> &children )
+{
+  for ( const QString &child : children )
+  {
+    if ( QgsModelChildAlgorithmGraphicItem *item = childAlgorithmItem( child ) )
+    {
+      item->setOutdated();
+    }
+  }
+}
+
 QgsModelComponentGraphicItem *QgsModelGraphicsScene::createParameterGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelParameter *param ) const
 {
   return new QgsModelParameterGraphicItem( param, model, nullptr );

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -222,6 +222,13 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
      */
     void setupFeedbackConnections( QgsProcessingModelFeedback *feedback ) SIP_SKIP;
 
+    /**
+     * Flags a set of children as possibly being outdated (i.e. previous results are invalid due to changes elsewhere in the model).
+     *
+     * \since QGIS 4.2
+     */
+    void flagChildrenAsOutdated( const QSet< QString > &children );
+
   signals:
 
     /**

--- a/src/gui/processing/qgsprocessingalgorithmwidgetbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmwidgetbase.h
@@ -371,13 +371,13 @@ class GUI_EXPORT QgsProcessingAlgorithmWidgetBase : public QWidget, public QgsPr
      */
     QgsMessageBar *messageBar();
 
-  protected:
-    void closeEvent( QCloseEvent *e ) override;
-
     /**
      * Returns the widget's run button.
      */
     QPushButton *runButton();
+
+  protected:
+    void closeEvent( QCloseEvent *e ) override;
 
     /**
      * Returns the widget's cancel button.


### PR DESCRIPTION
## Description
We shade these in an orange color, and show a message bar warning when the user views them to indicate that they may be out of date and not reflect the current state of the model.

Sponsored by City of Canning
## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
