### PR TITLE
fix crash when showing attribute table with outdated form config

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2737,13 +2737,22 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
         newWidgetInfo.widget->setObjectName( fields.at( fldIdx ).name() );
         const QString customComment = fields.at( fldIdx ).customComment();
         newWidgetInfo.hint = customComment.isNull() ? fields.at( fldIdx ).comment() : customComment;
+
+        newWidgetInfo.labelOnTop = mLayer->editFormConfig().labelOnTop( fldIdx );
+        newWidgetInfo.labelText = mLayer->attributeDisplayName( fldIdx );
+        newWidgetInfo.labelText.replace( '&', "&&"_L1 ); // need to escape '&' or they'll be replace by _ in the label text
+
+        newWidgetInfo.toolTip = ( QgsFieldModel::fieldToolTipExtended( fields.at( fldIdx ), mLayer ) );
+      }
+      else
+      {
+        QgsDebugError( u"Attribute form references unknown field '%1' on layer '%2' - skipping widget"_s.arg( fieldDef->name(), mLayer ? mLayer->name() : QString() ) );
+        newWidgetInfo.labelOnTop = false;
+        newWidgetInfo.labelText = fieldDef->name();
+        newWidgetInfo.labelText.replace( '&', "&&"_L1 );
+        newWidgetInfo.toolTip.clear();
       }
 
-      newWidgetInfo.labelOnTop = mLayer->editFormConfig().labelOnTop( fldIdx );
-      newWidgetInfo.labelText = mLayer->attributeDisplayName( fldIdx );
-      newWidgetInfo.labelText.replace( '&', "&&"_L1 ); // need to escape '&' or they'll be replace by _ in the label text
-
-      newWidgetInfo.toolTip = ( QgsFieldModel::fieldToolTipExtended( fields.at( fldIdx ), mLayer ) );
       newWidgetInfo.showLabel = widgetDef->showLabel();
 
       break;

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -72,6 +72,7 @@ class TestQgsAttributeForm : public QObject
     void testCaseInsensitiveFieldConstraint();
     void testCompositeForeignKeyHidesNonFirstFields();
     void testCustomComments();
+    void testFormWithMissingField();
 
   private:
     QLabel *constraintsLabel( QgsAttributeForm *form, QgsEditorWidgetWrapper *ww )
@@ -1460,6 +1461,35 @@ void TestQgsAttributeForm::testCustomComments()
   ww1->setValues( u"Ned"_s, QVariantList() );
   form.updateLabels();
   QCOMPARE( buddyLabels.value( ww4->widget() )->parentWidget()->toolTip(), u"<b>Fourth field</b> (f4)<br><font style='font-family:monospace; white-space: nowrap;'>string NULL</font><br><em>Comment with Ned</em>"_s ); //it's the alias and the data defined comment
+}
+
+void TestQgsAttributeForm::testFormWithMissingField()
+{
+  // a drag-and-drop form layout references a
+  // field that does not exist on the layer (e.g. field was renamed / removed).
+  const QString def = u"Point?field=col0:integer"_s;
+  auto layer = std::make_unique<QgsVectorLayer>( def, u"test"_s, u"memory"_s );
+  QVERIFY( layer->isValid() );
+  layer->setEditorWidgetSetup( 0, QgsEditorWidgetSetup( u"TextEdit"_s, QVariantMap() ) );
+
+  QgsEditFormConfig editFormConfig = layer->editFormConfig();
+  editFormConfig.clearTabs();
+  editFormConfig.invisibleRootContainer()->addChildElement( new QgsAttributeEditorField( "col0", 0, editFormConfig.invisibleRootContainer() ) );
+  // Reference to a field that does not exist on the layer
+  editFormConfig.invisibleRootContainer()->addChildElement( new QgsAttributeEditorField( "missing_field", -1, editFormConfig.invisibleRootContainer() ) );
+  editFormConfig.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+  layer->setEditFormConfig( editFormConfig );
+
+  QgsFeature ft( layer->dataProvider()->fields(), 1 );
+  ft.setAttribute( u"col0"_s, 1 );
+
+  QgsAttributeForm form( layer.get() );
+  form.setFeature( ft );
+
+  // The valid field still has a corresponding editor widget
+  QVERIFY( form.mFormEditorWidgets.contains( 0 ) );
+  // No widget is registered for the bogus field index -1
+  QVERIFY( !form.mFormEditorWidgets.contains( -1 ) );
 }
 
 QGSTEST_MAIN( TestQgsAttributeForm )


### PR DESCRIPTION
## Description

with an outdated form config, opening the attribute table was crashing 

crashed introduced by https://github.com/qgis/QGIS/pull/65499

## AI tool usage

 - [x] AI tool(s) used to write the test


An example with a really outdated config:

<img width="387" height="582" alt="image" src="https://github.com/user-attachments/assets/ce00afc5-e09e-4402-8d7a-0901ae14cc2b" />

<img width="834" height="737" alt="image" src="https://github.com/user-attachments/assets/72fb0a39-cb81-4c7c-9aeb-7d51aa9276a7" />

I would say it makes sense like this (i.e. not removing outdated fields), but no strong opinion here.