### PR TITLE
[ClangTidy] Disable member prefix check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,10 @@ CheckOptions:
   readability-identifier-naming.EnumConstantCase: CamelCase
   readability-identifier-naming.ClassCase: CamelCase
   readability-identifier-naming.ClassPrefix: Qgs
-  readability-identifier-naming.MemberPrefix: m
+
+  # Not applicable for public member, comment it for now
+  # readability-identifier-naming.MemberPrefix: m
+
   readability-identifier-naming.MemberCase: CamelCase
 
   # Static member


### PR DESCRIPTION
Because 'm' prefix doesn't apply for public member. We could revive it later when our clang CI version would support [Query Based Custom Clang-Tidy Checks](https://clang.llvm.org/extra/clang-tidy/QueryBasedCustomChecks.html).

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


