### PR TITLE
Fix QgsLineString SIP code

### DIFF
--- a/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgslinestring.sip.in
@@ -98,7 +98,7 @@ point in the sequence.
               double d = PyFloat_AsDouble( element );
               if ( PyErr_Occurred() )
               {
-                Py_DECREF( value );
+                Py_DECREF( element );
                 sipIsErr = 1;
                 break;
               }

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -138,7 +138,7 @@ class CORE_EXPORT QgsLineString : public QgsCurve
               double d = PyFloat_AsDouble( element );
               if ( PyErr_Occurred() )
               {
-                Py_DECREF( value );
+                Py_DECREF( element );
                 sipIsErr = 1;
                 break;
               }


### PR DESCRIPTION
Finally got tired of the `test_qgsgeometry.py` passing 50% of the time and the other 50% failing with a seg fault.

Right after the loop, the value is dereferenced, no need to do it twice. 

AI use: Claude spotted the issue.

ping @dvdkon 