### PR TITLE
[qml] Expose abstract, project and layer metadata details as properties

### DIFF
--- a/python/PyQt6/core/auto_generated/metadata/qgsabstractmetadatabase.sip.in
+++ b/python/PyQt6/core/auto_generated/metadata/qgsabstractmetadatabase.sip.in
@@ -44,6 +44,9 @@ against the native QGIS metadata schema can be performed using
 %TypeHeaderCode
 #include "qgsabstractmetadatabase.h"
 %End
+  public:
+    static const QMetaObject staticMetaObject;
+
 %ConvertToSubClassCode
     if ( dynamic_cast< QgsLayerMetadata * >( sipCpp ) != NULL )
       sipType = sipType_QgsLayerMetadata;
@@ -53,7 +56,6 @@ against the native QGIS metadata schema can be performed using
       sipType = NULL;
 %End
   public:
-
 
     typedef QMap< QString, QStringList > KeywordMap;
 

--- a/python/PyQt6/core/auto_generated/metadata/qgslayermetadata.sip.in
+++ b/python/PyQt6/core/auto_generated/metadata/qgslayermetadata.sip.in
@@ -41,6 +41,9 @@ against the native QGIS metadata schema can be performed using
 #include "qgslayermetadata.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
     struct SpatialExtent
     {
         QgsCoordinateReferenceSystem extentCrs;

--- a/python/PyQt6/core/auto_generated/metadata/qgsprojectmetadata.sip.in
+++ b/python/PyQt6/core/auto_generated/metadata/qgsprojectmetadata.sip.in
@@ -43,6 +43,9 @@ against the native QGIS metadata schema can be performed using
 #include "qgsprojectmetadata.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
     QgsProjectMetadata();
 
     virtual QgsProjectMetadata *clone() const /Factory/;

--- a/src/core/metadata/qgsabstractmetadatabase.cpp
+++ b/src/core/metadata/qgsabstractmetadatabase.cpp
@@ -22,6 +22,8 @@
 
 #include <QString>
 
+#include "moc_qgsabstractmetadatabase.cpp"
+
 using namespace Qt::StringLiterals;
 
 QString QgsAbstractMetadataBase::identifier() const

--- a/src/core/metadata/qgsabstractmetadatabase.h
+++ b/src/core/metadata/qgsabstractmetadatabase.h
@@ -59,6 +59,8 @@ class QgsTranslationContext;
  */
 class CORE_EXPORT QgsAbstractMetadataBase
 {
+    Q_GADGET
+
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
     if ( dynamic_cast< QgsLayerMetadata * >( sipCpp ) != NULL )
@@ -67,11 +69,14 @@ class CORE_EXPORT QgsAbstractMetadataBase
       sipType = sipType_QgsProjectMetadata;
     else
       sipType = NULL;
-  SIP_END
+    SIP_END
 #endif
 
-  public:
+    Q_PROPERTY( QString type READ type )
+    Q_PROPERTY( QString title READ title )
+    Q_PROPERTY( QString abstract READ abstract )
 
+  public:
     // NOTE - these really belong in a separate namespace, but SIP says no, I want to make you waste more time
     // TODO: dump sip
 

--- a/src/core/metadata/qgslayermetadata.cpp
+++ b/src/core/metadata/qgslayermetadata.cpp
@@ -23,6 +23,8 @@
 #include <QRegularExpression>
 #include <QString>
 
+#include "moc_qgslayermetadata.cpp"
+
 using namespace Qt::StringLiterals;
 
 QgsLayerMetadata *QgsLayerMetadata::clone() const

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -54,6 +54,11 @@ class QgsMapLayer;
  */
 class CORE_EXPORT QgsLayerMetadata : public QgsAbstractMetadataBase
 {
+    Q_GADGET
+
+    Q_PROPERTY( QStringList rights READ rights )
+    Q_PROPERTY( QStringList licenses READ licenses )
+
   public:
     /**
      * Metadata spatial extent structure.

--- a/src/core/metadata/qgsprojectmetadata.cpp
+++ b/src/core/metadata/qgsprojectmetadata.cpp
@@ -23,6 +23,8 @@
 #include <QDomNode>
 #include <QString>
 
+#include "moc_qgsprojectmetadata.cpp"
+
 using namespace Qt::StringLiterals;
 
 bool QgsProjectMetadata::readMetadataXml( const QDomElement &metadataElement, const QgsReadWriteContext &context )

--- a/src/core/metadata/qgsprojectmetadata.h
+++ b/src/core/metadata/qgsprojectmetadata.h
@@ -52,6 +52,10 @@
  */
 class CORE_EXPORT QgsProjectMetadata : public QgsAbstractMetadataBase
 {
+    Q_GADGET
+
+    Q_PROPERTY( QString author READ author )
+
   public:
     QgsProjectMetadata() = default;
 


### PR DESCRIPTION
## Description

We were already exposing the Qgs*Metadata member as a property in QgsProject and QgsMapLayer but didn't have any Q_PROPERTY defined to easily access these in a QML environment.