### PR TITLE
Add domain column to Fields in Properties of vector layer

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -1033,9 +1033,9 @@ QgsVectorDataProvider.FeatureSymbology.__doc__ = "Provider is able retrieve embe
 QgsVectorDataProvider.CacheData = Qgis.VectorProviderCapability.CacheData
 QgsVectorDataProvider.CacheData.is_monkey_patched = True
 QgsVectorDataProvider.CacheData.__doc__ = "Provider caches source data and should force provider data reloads when dependent layers are committed \n.. versionadded:: 4.2"
-QgsVectorDataProvider.ListFieldDomains = Qgis.VectorProviderCapability.ListFieldDomains
-QgsVectorDataProvider.ListFieldDomains.is_monkey_patched = True
-QgsVectorDataProvider.ListFieldDomains.__doc__ = "Provider can list field domains and their properties \n.. versionadded:: 4.2"
+QgsVectorDataProvider.ReadFieldDomains = Qgis.VectorProviderCapability.ReadFieldDomains
+QgsVectorDataProvider.ReadFieldDomains.is_monkey_patched = True
+QgsVectorDataProvider.ReadFieldDomains.__doc__ = "Provider can read field domains and their properties \n.. versionadded:: 4.2"
 QgsVectorDataProvider.EditingCapabilities = Qgis.VectorProviderCapability.EditingCapabilities
 QgsVectorDataProvider.EditingCapabilities.is_monkey_patched = True
 QgsVectorDataProvider.EditingCapabilities.__doc__ = "Bitmask of all editing capabilities"
@@ -1088,7 +1088,7 @@ Qgis.VectorProviderCapability.__doc__ = """Vector data provider capabilities.
 
   .. versionadded:: 4.2
 
-* ``ListFieldDomains``: Provider can list field domains and their properties
+* ``ReadFieldDomains``: Provider can read field domains and their properties
 
   .. versionadded:: 4.2
 

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -1033,6 +1033,9 @@ QgsVectorDataProvider.FeatureSymbology.__doc__ = "Provider is able retrieve embe
 QgsVectorDataProvider.CacheData = Qgis.VectorProviderCapability.CacheData
 QgsVectorDataProvider.CacheData.is_monkey_patched = True
 QgsVectorDataProvider.CacheData.__doc__ = "Provider caches source data and should force provider data reloads when dependent layers are committed \n.. versionadded:: 4.2"
+QgsVectorDataProvider.ListFieldDomains = Qgis.VectorProviderCapability.ListFieldDomains
+QgsVectorDataProvider.ListFieldDomains.is_monkey_patched = True
+QgsVectorDataProvider.ListFieldDomains.__doc__ = "Provider can list field domains and their properties \n.. versionadded:: 4.2"
 QgsVectorDataProvider.EditingCapabilities = Qgis.VectorProviderCapability.EditingCapabilities
 QgsVectorDataProvider.EditingCapabilities.is_monkey_patched = True
 QgsVectorDataProvider.EditingCapabilities.__doc__ = "Bitmask of all editing capabilities"
@@ -1082,6 +1085,10 @@ Qgis.VectorProviderCapability.__doc__ = """Vector data provider capabilities.
   .. versionadded:: 3.20
 
 * ``CacheData``: Provider caches source data and should force provider data reloads when dependent layers are committed
+
+  .. versionadded:: 4.2
+
+* ``ListFieldDomains``: Provider can list field domains and their properties
 
   .. versionadded:: 4.2
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -369,6 +369,7 @@ The development version
       ReloadData,
       FeatureSymbology,
       CacheData,
+      ListFieldDomains,
       EditingCapabilities,
     };
 

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -369,7 +369,7 @@ The development version
       ReloadData,
       FeatureSymbology,
       CacheData,
-      ListFieldDomains,
+      ReadFieldDomains,
       EditingCapabilities,
     };
 

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3758,7 +3758,7 @@ void QgsOgrProvider::computeCapabilities()
   }
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION( 3, 5, 0 )
-  if ( mOgrLayer && GDALGetMetadataItem( mOgrLayer->driver(), GDAL_DCAP_FIELD_DOMAINS, nullptr ) )
+  if ( GDALGetMetadataItem( mOgrLayer->driver(), GDAL_DCAP_FIELD_DOMAINS, nullptr ) )
   {
     ability |= Qgis::VectorProviderCapability::ListFieldDomains;
   }

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3757,6 +3757,13 @@ void QgsOgrProvider::computeCapabilities()
 #endif
   }
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION( 3, 5, 0 )
+  if ( mOgrLayer && GDALGetMetadataItem( mOgrLayer->driver(), GDAL_DCAP_FIELD_DOMAINS, nullptr ) )
+  {
+    ability |= Qgis::VectorProviderCapability::ListFieldDomains;
+  }
+#endif
+
   ability |= Qgis::VectorProviderCapability::ReadLayerMetadata;
   ability |= Qgis::VectorProviderCapability::ReloadData;
 

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3760,7 +3760,7 @@ void QgsOgrProvider::computeCapabilities()
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION( 3, 5, 0 )
   if ( GDALGetMetadataItem( mOgrLayer->driver(), GDAL_DCAP_FIELD_DOMAINS, nullptr ) )
   {
-    ability |= Qgis::VectorProviderCapability::ListFieldDomains;
+    ability |= Qgis::VectorProviderCapability::ReadFieldDomains;
   }
 #endif
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -549,6 +549,7 @@ int QgisEvent = QEvent::User + 1;
       ReloadData = 1 << 26, //!< Provider is able to force reload data
       FeatureSymbology = 1 << 27, //!< Provider is able retrieve embedded symbology associated with individual features \since QGIS 3.20
       CacheData = 1 << 28, //!< Provider caches source data and should force provider data reloads when dependent layers are committed \since QGIS 4.2
+      ListFieldDomains = 1 << 29, //!< Provider can list field domains and their properties \since QGIS 4.2
       EditingCapabilities = AddFeatures | DeleteFeatures | ChangeAttributeValues | ChangeGeometries | AddAttributes | DeleteAttributes | RenameAttributes, //!< Bitmask of all editing capabilities
     };
     Q_ENUM( VectorProviderCapability )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -549,7 +549,7 @@ int QgisEvent = QEvent::User + 1;
       ReloadData = 1 << 26, //!< Provider is able to force reload data
       FeatureSymbology = 1 << 27, //!< Provider is able retrieve embedded symbology associated with individual features \since QGIS 3.20
       CacheData = 1 << 28, //!< Provider caches source data and should force provider data reloads when dependent layers are committed \since QGIS 4.2
-      ListFieldDomains = 1 << 29, //!< Provider can list field domains and their properties \since QGIS 4.2
+      ReadFieldDomains = 1 << 29, //!< Provider can read field domains and their properties \since QGIS 4.2
       EditingCapabilities = AddFeatures | DeleteFeatures | ChangeAttributeValues | ChangeGeometries | AddAttributes | DeleteAttributes | RenameAttributes, //!< Bitmask of all editing capabilities
     };
     Q_ENUM( VectorProviderCapability )

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -16,6 +16,7 @@
 
 #include "qgssourcefieldsproperties.h"
 
+#include "qgsabstractdatabaseproviderconnection.h"
 #include "qgsaddattrdialog.h"
 #include "qgsapplication.h"
 #include "qgscheckablecombobox.h"
@@ -23,6 +24,8 @@
 #include "qgsgui.h"
 #include "qgsnative.h"
 #include "qgsproject.h"
+#include "qgsprovidermetadata.h"
+#include "qgsproviderregistry.h"
 #include "qgsvectorlayer.h"
 
 #include <QString>
@@ -416,6 +419,23 @@ void QgsSourceFieldsProperties::attributesListCellChanged( int row, int column )
 void QgsSourceFieldsProperties::attributesListCellPressed( int /*row*/, int /*column*/ )
 {
   updateButtons();
+}
+
+bool QgsSourceFieldsProperties::providerSupportsFieldDomains() const
+{
+  if ( !mLayer )
+    return false;
+
+  QgsProviderMetadata *md = QgsProviderRegistry::instance()->providerMetadata( mLayer->providerType() );
+  if ( !md )
+    return false;
+
+  std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn( dynamic_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( mLayer->source(), {} ) ) );
+
+  if ( !conn )
+    return false;
+
+  return conn->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::ListFieldDomains );
 }
 
 //NICE FUNCTIONS

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -178,7 +178,7 @@ void QgsSourceFieldsProperties::attributeAdded( int idx )
     switch ( mLayer->fields().fieldOrigin( idx ) )
     {
       case Qgis::FieldOrigin::Expression:
-        if ( i == 7 )
+        if ( i == AttrCommentCol )
           continue;
         mFieldsList->item( row, i )->setBackground( expressionColor );
         break;

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -110,7 +110,11 @@ void QgsSourceFieldsProperties::loadRows()
   for ( int i = 0; i < fields.count(); ++i )
     attributeAdded( i );
 
-  mFieldsList->setColumnHidden( AttrFieldDomainCol, !providerSupportsFieldDomains() );
+  if ( mLayer->dataProvider() )
+  {
+    mFieldsList->setColumnHidden( AttrFieldDomainCol, !mLayer->dataProvider()->capabilities().testFlag( Qgis::VectorProviderCapability::ListFieldDomains ) );
+  }
+
   mFieldsList->resizeColumnsToContents();
   connect( mFieldsList, &QTableWidget::cellChanged, this, &QgsSourceFieldsProperties::attributesListCellChanged );
 
@@ -197,7 +201,10 @@ void QgsSourceFieldsProperties::attributeAdded( int idx )
   if ( sorted )
     mFieldsList->setSortingEnabled( true );
 
-  mFieldsList->setColumnHidden( AttrFieldDomainCol, !providerSupportsFieldDomains() );
+  if ( mLayer->dataProvider() )
+  {
+    mFieldsList->setColumnHidden( AttrFieldDomainCol, !mLayer->dataProvider()->capabilities().testFlag( Qgis::VectorProviderCapability::ListFieldDomains ) );
+  }
 }
 
 
@@ -253,9 +260,9 @@ void QgsSourceFieldsProperties::setRow( int row, int idx, const QgsField &field 
 
   for ( const int i : { AttrIdCol, AttrNameCol, AttrAliasCol, AttrTypeCol, AttrTypeNameCol, AttrLengthCol, AttrPrecCol, AttrCommentCol, AttrFieldDomainCol } )
   {
-    if ( notEditableCols[i] != AttrCommentCol || mLayer->fields().fieldOrigin( idx ) != Qgis::FieldOrigin::Expression )
+    if ( i != AttrCommentCol || mLayer->fields().fieldOrigin( idx ) != Qgis::FieldOrigin::Expression )
       mFieldsList->item( row, i )->setFlags( mFieldsList->item( row, i )->flags() & ~Qt::ItemIsEditable );
-    if ( notEditableCols[i] == AttrAliasCol )
+    if ( i == AttrAliasCol )
       mFieldsList->item( row, i )->setToolTip( tr( "Edit alias in the Form config tab" ) );
   }
   const bool canRenameFields = mLayer->isEditable() && ( mLayer->dataProvider()->capabilities() & Qgis::VectorProviderCapability::RenameAttributes ) && !mLayer->readOnly();
@@ -424,23 +431,6 @@ void QgsSourceFieldsProperties::attributesListCellChanged( int row, int column )
 void QgsSourceFieldsProperties::attributesListCellPressed( int /*row*/, int /*column*/ )
 {
   updateButtons();
-}
-
-bool QgsSourceFieldsProperties::providerSupportsFieldDomains() const
-{
-  if ( !mLayer )
-    return false;
-
-  QgsProviderMetadata *md = QgsProviderRegistry::instance()->providerMetadata( mLayer->providerType() );
-  if ( !md )
-    return false;
-
-  std::unique_ptr<QgsAbstractDatabaseProviderConnection> conn( dynamic_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( mLayer->source(), {} ) ) );
-
-  if ( !conn )
-    return false;
-
-  return conn->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::ListFieldDomains );
 }
 
 //NICE FUNCTIONS

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -79,7 +79,7 @@ QgsSourceFieldsProperties::QgsSourceFieldsProperties( QgsVectorLayer *layer, QWi
   configurationFlagsWi->setToolTip( tr( "Configures the field" ) );
   mFieldsList->setHorizontalHeaderItem( AttrConfigurationFlagsCol, configurationFlagsWi );
   mFieldsList->setHorizontalHeaderItem( AttrAliasCol, new QTableWidgetItem( tr( "Alias" ) ) );
-  const auto fieldDomainWi = new QTableWidgetItem( tr( "Field Domain" ) );
+  const auto fieldDomainWidget = new QTableWidgetItem( tr( "Field Domain" ) );
   fieldDomainWi->setToolTip( tr( "Field domain associated with the field" ) );
   mFieldsList->setHorizontalHeaderItem( AttrFieldDomainCol, fieldDomainWi );
 
@@ -251,10 +251,7 @@ void QgsSourceFieldsProperties::setRow( int row, int idx, const QgsField &field 
 
   mFieldsList->setItem( row, AttrFieldDomainCol, new QTableWidgetItem( field.constraints().domainName() ) );
 
-  QList<int> notEditableCols = QList<int>() << AttrIdCol << AttrNameCol << AttrAliasCol << AttrTypeCol << AttrTypeNameCol << AttrLengthCol << AttrPrecCol << AttrCommentCol << AttrFieldDomainCol;
-
-  const auto constNotEditableCols = notEditableCols;
-  for ( const int i : constNotEditableCols )
+for ( const int i : { AttrIdCol, AttrNameCol, AttrAliasCol, AttrTypeCol, AttrTypeNameCol, AttrLengthCol, AttrPrecCol, AttrCommentCol, AttrFieldDomainCol } )
   {
     if ( notEditableCols[i] != AttrCommentCol || mLayer->fields().fieldOrigin( idx ) != Qgis::FieldOrigin::Expression )
       mFieldsList->item( row, i )->setFlags( mFieldsList->item( row, i )->flags() & ~Qt::ItemIsEditable );

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -80,8 +80,8 @@ QgsSourceFieldsProperties::QgsSourceFieldsProperties( QgsVectorLayer *layer, QWi
   mFieldsList->setHorizontalHeaderItem( AttrConfigurationFlagsCol, configurationFlagsWi );
   mFieldsList->setHorizontalHeaderItem( AttrAliasCol, new QTableWidgetItem( tr( "Alias" ) ) );
   const auto fieldDomainWidget = new QTableWidgetItem( tr( "Field Domain" ) );
-  fieldDomainWi->setToolTip( tr( "Field domain associated with the field" ) );
-  mFieldsList->setHorizontalHeaderItem( AttrFieldDomainCol, fieldDomainWi );
+  fieldDomainWidget->setToolTip( tr( "Field domain associated with the field" ) );
+  mFieldsList->setHorizontalHeaderItem( AttrFieldDomainCol, fieldDomainWidget );
 
   mFieldsList->setSortingEnabled( true );
   mFieldsList->sortByColumn( 0, Qt::AscendingOrder );
@@ -251,7 +251,7 @@ void QgsSourceFieldsProperties::setRow( int row, int idx, const QgsField &field 
 
   mFieldsList->setItem( row, AttrFieldDomainCol, new QTableWidgetItem( field.constraints().domainName() ) );
 
-for ( const int i : { AttrIdCol, AttrNameCol, AttrAliasCol, AttrTypeCol, AttrTypeNameCol, AttrLengthCol, AttrPrecCol, AttrCommentCol, AttrFieldDomainCol } )
+  for ( const int i : { AttrIdCol, AttrNameCol, AttrAliasCol, AttrTypeCol, AttrTypeNameCol, AttrLengthCol, AttrPrecCol, AttrCommentCol, AttrFieldDomainCol } )
   {
     if ( notEditableCols[i] != AttrCommentCol || mLayer->fields().fieldOrigin( idx ) != Qgis::FieldOrigin::Expression )
       mFieldsList->item( row, i )->setFlags( mFieldsList->item( row, i )->flags() & ~Qt::ItemIsEditable );

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -79,6 +79,9 @@ QgsSourceFieldsProperties::QgsSourceFieldsProperties( QgsVectorLayer *layer, QWi
   configurationFlagsWi->setToolTip( tr( "Configures the field" ) );
   mFieldsList->setHorizontalHeaderItem( AttrConfigurationFlagsCol, configurationFlagsWi );
   mFieldsList->setHorizontalHeaderItem( AttrAliasCol, new QTableWidgetItem( tr( "Alias" ) ) );
+  const auto fieldDomainWi = new QTableWidgetItem( tr( "Field Domain" ) );
+  fieldDomainWi->setToolTip( tr( "Field domain associated with the field" ) );
+  mFieldsList->setHorizontalHeaderItem( AttrFieldDomainCol, fieldDomainWi );
 
   mFieldsList->setSortingEnabled( true );
   mFieldsList->sortByColumn( 0, Qt::AscendingOrder );
@@ -107,6 +110,7 @@ void QgsSourceFieldsProperties::loadRows()
   for ( int i = 0; i < fields.count(); ++i )
     attributeAdded( i );
 
+  mFieldsList->setColumnHidden( AttrFieldDomainCol, !providerSupportsFieldDomains() );
   mFieldsList->resizeColumnsToContents();
   connect( mFieldsList, &QTableWidget::cellChanged, this, &QgsSourceFieldsProperties::attributesListCellChanged );
 
@@ -192,6 +196,8 @@ void QgsSourceFieldsProperties::attributeAdded( int idx )
 
   if ( sorted )
     mFieldsList->setSortingEnabled( true );
+
+  mFieldsList->setColumnHidden( AttrFieldDomainCol, !providerSupportsFieldDomains() );
 }
 
 
@@ -243,7 +249,9 @@ void QgsSourceFieldsProperties::setRow( int row, int idx, const QgsField &field 
     mFieldsList->setItem( row, AttrCommentCol, new QTableWidgetItem( field.comment() ) );
   }
 
-  QList<int> notEditableCols = QList<int>() << AttrIdCol << AttrNameCol << AttrAliasCol << AttrTypeCol << AttrTypeNameCol << AttrLengthCol << AttrPrecCol << AttrCommentCol;
+  mFieldsList->setItem( row, AttrFieldDomainCol, new QTableWidgetItem( field.constraints().domainName() ) );
+
+  QList<int> notEditableCols = QList<int>() << AttrIdCol << AttrNameCol << AttrAliasCol << AttrTypeCol << AttrTypeNameCol << AttrLengthCol << AttrPrecCol << AttrCommentCol << AttrFieldDomainCol;
 
   const auto constNotEditableCols = notEditableCols;
   for ( const int i : constNotEditableCols )

--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -112,7 +112,7 @@ void QgsSourceFieldsProperties::loadRows()
 
   if ( mLayer->dataProvider() )
   {
-    mFieldsList->setColumnHidden( AttrFieldDomainCol, !mLayer->dataProvider()->capabilities().testFlag( Qgis::VectorProviderCapability::ListFieldDomains ) );
+    mFieldsList->setColumnHidden( AttrFieldDomainCol, !mLayer->dataProvider()->capabilities().testFlag( Qgis::VectorProviderCapability::ReadFieldDomains ) );
   }
 
   mFieldsList->resizeColumnsToContents();
@@ -203,7 +203,7 @@ void QgsSourceFieldsProperties::attributeAdded( int idx )
 
   if ( mLayer->dataProvider() )
   {
-    mFieldsList->setColumnHidden( AttrFieldDomainCol, !mLayer->dataProvider()->capabilities().testFlag( Qgis::VectorProviderCapability::ListFieldDomains ) );
+    mFieldsList->setColumnHidden( AttrFieldDomainCol, !mLayer->dataProvider()->capabilities().testFlag( Qgis::VectorProviderCapability::ReadFieldDomains ) );
   }
 }
 

--- a/src/gui/vector/qgssourcefieldsproperties.h
+++ b/src/gui/vector/qgssourcefieldsproperties.h
@@ -87,6 +87,7 @@ class GUI_EXPORT QgsSourceFieldsProperties : public QWidget, private Ui_QgsSourc
       AttrTypeNameCol,
       AttrLengthCol,
       AttrPrecCol,
+      AttrFieldDomainCol,
       AttrCommentCol,
       AttrConfigurationFlagsCol,
       AttrColCount,

--- a/src/gui/vector/qgssourcefieldsproperties.h
+++ b/src/gui/vector/qgssourcefieldsproperties.h
@@ -94,6 +94,7 @@ class GUI_EXPORT QgsSourceFieldsProperties : public QWidget, private Ui_QgsSourc
 
   private:
     void updateFieldRenamingStatus();
+    bool providerSupportsFieldDomains() const;
 
   signals:
     void toggleEditing();

--- a/src/gui/vector/qgssourcefieldsproperties.h
+++ b/src/gui/vector/qgssourcefieldsproperties.h
@@ -95,7 +95,6 @@ class GUI_EXPORT QgsSourceFieldsProperties : public QWidget, private Ui_QgsSourc
 
   private:
     void updateFieldRenamingStatus();
-    bool providerSupportsFieldDomains() const;
 
   signals:
     void toggleEditing();

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -5257,7 +5257,7 @@ class PyQgsOGRProvider(QgisTestCase):
         self.assertTrue(vl.isValid())
         self.assertFalse(
             vl.dataProvider().capabilities()
-            & Qgis.VectorProviderCapability.ListFieldDomains
+            & Qgis.VectorProviderCapability.ReadFieldDomains
         )
 
 

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -5249,6 +5249,17 @@ class PyQgsOGRProvider(QgisTestCase):
             metadata.urisReferToSame(uri1, uri2, Qgis.SourceHierarchyLevel.Object)
         )
 
+    def testListFieldDomainsCapabilityShapefile(self):
+        """Shapefile provider should not report ListFieldDomains capability"""
+        vl = QgsVectorLayer(
+            os.path.join(unitTestDataPath(), "points.shp"), "test", "ogr"
+        )
+        self.assertTrue(vl.isValid())
+        self.assertFalse(
+            vl.dataProvider().capabilities()
+            & Qgis.VectorProviderCapability.ListFieldDomains
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -3926,6 +3926,18 @@ class TestPyQgsOGRProviderGpkg(QgisTestCase):
                 "wrong data type for attribute int_field of feature 2: Got QString, expected int",
             )
 
+    def testListFieldDomainsCapability(self):
+        """GeoPackage provider should report ListFieldDomains capability"""
+        srcpath = os.path.join(TEST_DATA_DIR, "provider")
+        srcfile = os.path.join(srcpath, "geopackage.gpkg")
+
+        vl = QgsVectorLayer(f"{srcfile}|layername=geopackage", "test", "ogr")
+        self.assertTrue(vl.isValid())
+        self.assertTrue(
+            vl.dataProvider().capabilities()
+            & Qgis.VectorProviderCapability.ListFieldDomains
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -3935,7 +3935,7 @@ class TestPyQgsOGRProviderGpkg(QgisTestCase):
         self.assertTrue(vl.isValid())
         self.assertTrue(
             vl.dataProvider().capabilities()
-            & Qgis.VectorProviderCapability.ListFieldDomains
+            & Qgis.VectorProviderCapability.ReadFieldDomains
         )
 
 


### PR DESCRIPTION
## Description

Adds column with **Field Domain** (filled with field domain name that is associated with the column) column info **Field**  tab of **Layer properties**. The column is invisible if  the provider does not support field domains.

<img width="1240" height="824" alt="Clipboard 2 jpg" src="https://github.com/user-attachments/assets/d6092a46-5b93-4022-a007-fdae485ac357" />

Funded by: Ocean Winds

Fixes #63620

## AI tool usage

 - [x ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use]
