### PR TITLE
Add option to lock Value Map widget, enable it for fields using a Domain

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1145,6 +1145,7 @@ void QgsOgrProvider::loadFields()
 
             QVariantMap editorConfig;
             editorConfig.insert( u"map"_s, valueConfig );
+            editorConfig.insert( u"isLocked"_s, true );
             newField.setEditorWidgetSetup( QgsEditorWidgetSetup( u"ValueMap"_s, editorConfig ) );
             break;
           }

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -50,6 +50,8 @@ QgsValueMapConfigDlg::QgsValueMapConfigDlg( QgsVectorLayer *vl, int fieldIdx, QW
   connect( removeSelectedButton, &QAbstractButton::clicked, this, &QgsValueMapConfigDlg::removeSelectedButtonPushed );
   connect( loadFromLayerButton, &QAbstractButton::clicked, this, &QgsValueMapConfigDlg::loadFromLayerButtonPushed );
   connect( loadFromCSVButton, &QAbstractButton::clicked, this, &QgsValueMapConfigDlg::loadFromCSVButtonPushed );
+  connect( lockButton, &QAbstractButton::clicked, this, &QgsValueMapConfigDlg::setLocked );
+
   connect( tableWidget, &QTableWidget::cellChanged, this, &QgsValueMapConfigDlg::vCellChanged );
   tableWidget->installEventFilter( this );
 }
@@ -86,6 +88,7 @@ QVariantMap QgsValueMapConfigDlg::config()
 
   QVariantMap cfg;
   cfg.insert( u"map"_s, valueList );
+  cfg.insert( u"isLocked"_s, mIsLocked );
   return cfg;
 }
 
@@ -120,6 +123,10 @@ void QgsValueMapConfigDlg::setConfig( const QVariantMap &config )
   }
 
   updateMap( orderedList, false );
+
+  const bool locked = config.value( u"isLocked"_s, false ).toBool();
+  setLocked( locked );
+  lockButton->setChecked( locked );
 }
 
 void QgsValueMapConfigDlg::vCellChanged( int row, int column )
@@ -379,6 +386,19 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
   if ( fileName.isNull() )
     return;
   loadMapFromCSV( fileName );
+}
+
+void QgsValueMapConfigDlg::setLocked( bool locked )
+{
+  mIsLocked = locked;
+  addNullButton->setDisabled( mIsLocked );
+  removeSelectedButton->setDisabled( mIsLocked );
+  loadFromLayerButton->setDisabled( mIsLocked );
+  loadFromCSVButton->setDisabled( mIsLocked );
+  tableWidget->setEditTriggers(
+    mIsLocked ? QAbstractItemView::EditTrigger::NoEditTriggers
+              : QAbstractItemView::EditTrigger::DoubleClicked | QAbstractItemView::EditTrigger::EditKeyPressed | QAbstractItemView::EditTrigger::AnyKeyPressed
+  );
 }
 
 void QgsValueMapConfigDlg::loadMapFromCSV( const QString &filePath )

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
@@ -86,6 +86,8 @@ class GUI_EXPORT QgsValueMapConfigDlg : public QgsEditorConfigWidget,
      */
     QString checkValueLength( const QString &value );
 
+    bool mIsLocked = false;
+
 
   private slots:
     void copySelectionToClipboard();
@@ -94,6 +96,7 @@ class GUI_EXPORT QgsValueMapConfigDlg : public QgsEditorConfigWidget,
     void removeSelectedButtonPushed();
     void loadFromLayerButtonPushed();
     void loadFromCSVButtonPushed();
+    void setLocked( bool locked );
 
     friend class TestQgsValueMapConfigDlg;
 };

--- a/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
@@ -14,44 +14,22 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="3">
-    <widget class="QLabel" name="valueMapLabel">
-     <property name="text">
-      <string>Combo box with predefined items. Value is stored in the attribute, description is shown in the combo box.</string>
+   <item row="2" column="2">
+    <widget class="QPushButton" name="lockButton">
+     <property name="toolTip">
+      <string>Lock the Value Map table to avoid accidental modification of values</string>
      </property>
-     <property name="wordWrap">
+     <property name="icon">
+      <iconset resource="../../../images/images.qrc">
+       <normaloff>:/images/themes/default/unlockedGray.svg</normaloff>
+       <normalon>:/images/themes/default/lockedGray.svg</normalon>:/images/themes/default/unlockedGray.svg</iconset>
+     </property>
+     <property name="checkable">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QPushButton" name="loadFromLayerButton">
-     <property name="text">
-      <string>Load Data from Layer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="loadFromCSVButton">
-     <property name="text">
-      <string>Load Data from CSV File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>339</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0" colspan="3">
+   <item row="3" column="0" colspan="5">
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
       <widget class="QTableWidget" name="tableWidget">
@@ -88,7 +66,14 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0" colspan="3">
+   <item row="2" column="0">
+    <widget class="QPushButton" name="loadFromLayerButton">
+     <property name="text">
+      <string>Load Data from Layer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="5">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QPushButton" name="addNullButton">
@@ -107,7 +92,7 @@
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -119,15 +104,46 @@
      </item>
     </layout>
    </item>
+   <item row="0" column="0" colspan="5">
+    <widget class="QLabel" name="valueMapLabel">
+     <property name="text">
+      <string>Combo box with predefined items. Value is stored in the attribute, description is shown in the combo box.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>339</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="1">
+    <widget class="QPushButton" name="loadFromCSVButton">
+     <property name="text">
+      <string>Load Data from CSV File</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>loadFromLayerButton</tabstop>
-  <tabstop>loadFromCSVButton</tabstop>
   <tabstop>tableWidget</tabstop>
   <tabstop>addNullButton</tabstop>
   <tabstop>removeSelectedButton</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/tests/src/gui/testqgsvaluemapconfigdlg.cpp
+++ b/tests/src/gui/testqgsvaluemapconfigdlg.cpp
@@ -40,6 +40,8 @@ class TestQgsValueMapConfigDlg : public QObject
 
     void testLoadFromCSV();
     void testTestTrimValues();
+    void testLockValues();
+    void testLockValuesForDomain();
 };
 
 void TestQgsValueMapConfigDlg::initTestCase()
@@ -116,6 +118,78 @@ void TestQgsValueMapConfigDlg::testTestTrimValues()
   valueList[u"33"_s] = u"Choice 33"_s;
   valueMapConfig->updateMap( valueList, false );
   QVERIFY( valueMapConfig->mValueMapErrorsLabel->text().contains( u"trimmed"_s ) );
+}
+
+void TestQgsValueMapConfigDlg::testLockValues()
+{
+  QgsVectorLayer vl( u"LineString?crs=epsg:3111&field=pk:int&field=name:string"_s, u"vl1"_s, u"memory"_s );
+
+  QList<QVariant> valueList;
+  QVariantMap value;
+  value.insert( u"Basic unquoted record"_s, QString( "1" ) );
+  valueList << value;
+  value.clear();
+  value.insert( u"Forest type"_s, QString( "2" ) );
+  valueList << value;
+  value.clear();
+  value.insert( u"So-called \"data\""_s, QString( "three" ) );
+  valueList << value;
+  value.clear();
+  value.insert( u"444"_s, QString( "4" ) );
+  valueList << value;
+  value.clear();
+  value.insert( u"five"_s, QString( "5" ) );
+  valueList << value;
+
+  QVariantMap map;
+  map.insert( u"map"_s, valueList );
+  std::unique_ptr<QgsValueMapConfigDlg> valueMapConfig;
+  valueMapConfig.reset( static_cast<QgsValueMapConfigDlg *>( QgsGui::editorWidgetRegistry()->createConfigWidget( u"ValueMap"_s, &vl, 1, nullptr ) ) );
+  valueMapConfig->setConfig( map );
+  QVERIFY( !valueMapConfig->mIsLocked );
+  QVERIFY( valueMapConfig->addNullButton->isEnabled() );
+  QVERIFY( valueMapConfig->removeSelectedButton->isEnabled() );
+  QVERIFY( valueMapConfig->loadFromLayerButton->isEnabled() );
+  QVERIFY( valueMapConfig->loadFromCSVButton->isEnabled() );
+  QCOMPARE( valueMapConfig->tableWidget->editTriggers(), QAbstractItemView::EditTrigger::DoubleClicked | QAbstractItemView::EditTrigger::EditKeyPressed | QAbstractItemView::EditTrigger::AnyKeyPressed );
+
+  map.insert( u"isLocked"_s, true );
+  valueMapConfig->setConfig( map );
+  QVERIFY( valueMapConfig->mIsLocked );
+  QVERIFY( !valueMapConfig->addNullButton->isEnabled() );
+  QVERIFY( !valueMapConfig->removeSelectedButton->isEnabled() );
+  QVERIFY( !valueMapConfig->loadFromLayerButton->isEnabled() );
+  QVERIFY( !valueMapConfig->loadFromCSVButton->isEnabled() );
+  QCOMPARE( valueMapConfig->tableWidget->editTriggers(), QAbstractItemView::EditTrigger::NoEditTriggers );
+}
+
+void TestQgsValueMapConfigDlg::testLockValuesForDomain()
+{
+  QgsVectorLayer vl( u"%1/domains.gpkg|layername=test"_s.arg( TEST_DATA_DIR ) );
+
+  const int domainField = vl.fields().indexFromName( u"with_enum_domain"_s );
+  std::unique_ptr<QgsValueMapConfigDlg> valueMapConfig;
+  valueMapConfig.reset( static_cast<QgsValueMapConfigDlg *>( QgsGui::editorWidgetRegistry()->createConfigWidget( u"ValueMap"_s, &vl, domainField, nullptr ) ) );
+
+  QgsEditorWidgetSetup setup = vl.fields().field( domainField ).editorWidgetSetup();
+  valueMapConfig->setConfig( setup.config() );
+
+  QCOMPARE( valueMapConfig->config().value( u"map"_s ).toList().size(), 2 );
+  QVERIFY( valueMapConfig->config().value( u"isLocked"_s, false ).toBool() );
+  QVERIFY( valueMapConfig->mIsLocked );
+  QVERIFY( !valueMapConfig->addNullButton->isEnabled() );
+  QVERIFY( !valueMapConfig->removeSelectedButton->isEnabled() );
+  QVERIFY( !valueMapConfig->loadFromLayerButton->isEnabled() );
+  QVERIFY( !valueMapConfig->loadFromCSVButton->isEnabled() );
+  QCOMPARE( valueMapConfig->tableWidget->editTriggers(), QAbstractItemView::EditTrigger::NoEditTriggers );
+
+  valueMapConfig->setLocked( false );
+  QVERIFY( !valueMapConfig->mIsLocked );
+  QVERIFY( valueMapConfig->addNullButton->isEnabled() );
+  QVERIFY( valueMapConfig->removeSelectedButton->isEnabled() );
+  QVERIFY( valueMapConfig->loadFromLayerButton->isEnabled() );
+  QVERIFY( valueMapConfig->loadFromCSVButton->isEnabled() );
+  QCOMPARE( valueMapConfig->tableWidget->editTriggers(), QAbstractItemView::EditTrigger::DoubleClicked | QAbstractItemView::EditTrigger::EditKeyPressed | QAbstractItemView::EditTrigger::AnyKeyPressed );
 }
 
 QGSTEST_MAIN( TestQgsValueMapConfigDlg )


### PR DESCRIPTION
## Description
When a geopackage field is controlled by a Domain, then its form widget is automatically set to Value Map and the key/value pairs are populated with the values in the Domain.
However, users are allowed to modify the Value Map key/value pairs, and set values that are not compatible with the Domain. This can result in layer features' modifications that cannot be eventually stored on the provider leading to user confusion.
This PR introduces a padlock icon that locks the ValueMap configuration widget to prevent such modifications, and it is locked by default for fields controlled by a Domain.

<img width="770" height="405" alt="Peek 2026-05-28 14-50" src="https://github.com/user-attachments/assets/0e7c0109-9225-42ea-9173-0332175f7954" />

While the logic of locking the Value Map values is mostly required in Domain controlled fields, I opted to include it for all Value Map fields (unlocked by default) since it can save from headaches.

This PR partially addresses #63864 and was funded by Ocean Winds


## AI tool usage
 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
