### PR TITLE
Modify vertex tool to use deleteVertices instead of deleteVertex

### DIFF
--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1253,6 +1253,8 @@ Deletes a set of vertices from a feature.
    by a call to :py:func:`~QgsVectorLayer.startEditing`. Changes made to features using this method are not committed
    to the underlying data provider until a :py:func:`~QgsVectorLayer.commitChanges` call is made. Any uncommitted
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
+
+.. versionadded:: 4.2
 %End
 
     bool deleteSelectedFeatures( int *deletedCount /Out/ = 0, QgsVectorLayer::DeleteContext *context = 0 );

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayer.sip.in
@@ -1240,6 +1240,21 @@ Deletes a vertex from a feature.
    changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
 %End
 
+    Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices );
+%Docstring
+Deletes a set of vertices from a feature.
+
+:param featureId: ID of feature to remove vertices from
+:param vertices: set of vertex indices to delete
+
+.. note::
+
+   Calls to :py:func:`~QgsVectorLayer.deleteVertices` are only valid for layers in which edits have been enabled
+   by a call to :py:func:`~QgsVectorLayer.startEditing`. Changes made to features using this method are not committed
+   to the underlying data provider until a :py:func:`~QgsVectorLayer.commitChanges` call is made. Any uncommitted
+   changes can be discarded by calling :py:func:`~QgsVectorLayer.rollBack`.
+%End
+
     bool deleteSelectedFeatures( int *deletedCount /Out/ = 0, QgsVectorLayer::DeleteContext *context = 0 );
 %Docstring
 Deletes the selected features

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
@@ -57,6 +57,14 @@ Deletes a vertex from a feature.
 :param vertex: index of vertex to delete
 %End
 
+    Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices );
+%Docstring
+Deletes a set of vertices from a feature.
+
+:param featureId: ID of feature to remove vertices from
+:param vertices: set of vertex indices to delete
+%End
+
  Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /Deprecated="Since 3.12. Will be removed in QGIS 5.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;
 %Docstring
 Adds a ring to polygon/multipolygon features

--- a/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
+++ b/python/PyQt6/core/auto_generated/vector/qgsvectorlayereditutils.sip.in
@@ -63,6 +63,8 @@ Deletes a set of vertices from a feature.
 
 :param featureId: ID of feature to remove vertices from
 :param vertices: set of vertex indices to delete
+
+.. versionadded:: 4.2
 %End
 
  Qgis::GeometryOperationResult addRing( const QVector<QgsPointXY> &ring, const QgsFeatureIds &targetFeatureIds = QgsFeatureIds(), QgsFeatureId *modifiedFeatureId = 0 ) /Deprecated="Since 3.12. Will be removed in QGIS 5.0. Use the variant which accepts QgsPoint objects instead of QgsPointXY."/;

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2776,54 +2776,6 @@ void QgsVertexTool::deleteVertex()
     toDeleteGrouped[vertex.layer][vertex.fid].append( vertex.vertexId );
   }
 
-  // de-duplicate vertices in linear rings - if there is the first vertex selected,
-  // then also the last vertex will be selected - but we want just one out of the pair
-  // also deselect vertices of parts or rings that will be automatically removed
-  QHash<QgsVectorLayer *, QHash<QgsFeatureId, QList<int>>>::iterator lIt = toDeleteGrouped.begin();
-  for ( ; lIt != toDeleteGrouped.end(); ++lIt )
-  {
-    QgsVectorLayer *layer = lIt.key();
-    QHash<QgsFeatureId, QList<int>> &featuresDict = lIt.value();
-
-    QHash<QgsFeatureId, QList<int>>::iterator fIt = featuresDict.begin();
-    for ( ; fIt != featuresDict.end(); ++fIt )
-    {
-      QgsFeatureId fid = fIt.key();
-      QList<int> &vertexIds = fIt.value();
-      if ( vertexIds.count() >= 2 && ( layer->geometryType() == Qgis::GeometryType::Polygon || layer->geometryType() == Qgis::GeometryType::Line ) )
-      {
-        std::sort( vertexIds.begin(), vertexIds.end(), std::greater<int>() );
-        const QgsGeometry geom = cachedGeometry( layer, fid );
-        const QgsAbstractGeometry *ag = geom.constGet();
-        QVector<QVector<int>> numberOfVertices;
-        for ( int p = 0; p < ag->partCount(); ++p )
-        {
-          numberOfVertices.append( QVector<int>() );
-          for ( int r = 0; r < ag->ringCount( p ); ++r )
-          {
-            numberOfVertices[p].append( ag->vertexCount( p, r ) );
-          }
-        }
-        // polygonal rings with less than 4 vertices get deleted automatically
-        // linear parts with less than 2 vertices get deleted automatically
-        // let's keep that number and don't remove vertices beyond that point
-        const int minAllowedVertices = geom.type() == Qgis::GeometryType::Polygon ? 4 : 2;
-        for ( int i = vertexIds.count() - 1; i >= 0; --i )
-        {
-          QgsVertexId vid;
-          if ( geom.vertexIdFromVertexNr( vertexIds[i], vid ) )
-          {
-            // also don't try to delete the first vertex of a ring since we have already deleted the last
-            if ( numberOfVertices.at( vid.part ).at( vid.ring ) < minAllowedVertices || ( 0 == vid.vertex && geom.type() == Qgis::GeometryType::Polygon ) )
-              vertexIds.removeOne( vertexIds.at( i ) );
-            else
-              --numberOfVertices[vid.part][vid.ring];
-          }
-        }
-      }
-    }
-  }
-
   // main for cycle to delete all selected vertices
   QHash<QgsVectorLayer *, QHash<QgsFeatureId, QList<int>>>::iterator it = toDeleteGrouped.begin();
   for ( ; it != toDeleteGrouped.end(); ++it )
@@ -2840,17 +2792,11 @@ void QgsVertexTool::deleteVertex()
       QgsFeatureId fid = it2.key();
       QList<int> &vertexIds = it2.value();
 
-      Qgis::VectorEditResult res = Qgis::VectorEditResult::Success;
-      std::sort( vertexIds.begin(), vertexIds.end(), std::greater<int>() );
-      for ( int vertexId : vertexIds )
+      Qgis::VectorEditResult res = layer->deleteVertices( fid, QSet<int>( vertexIds.begin(), vertexIds.end() ) );
+      if ( res != Qgis::VectorEditResult::Success && res != Qgis::VectorEditResult::EmptyGeometry )
       {
-        if ( res != Qgis::VectorEditResult::EmptyGeometry )
-          res = layer->deleteVertex( fid, vertexId );
-        if ( res != Qgis::VectorEditResult::EmptyGeometry && res != Qgis::VectorEditResult::Success )
-        {
-          QgsDebugError( u"failed to delete vertex %1 %2 %3!"_s.arg( layer->name() ).arg( fid ).arg( vertexId ) );
-          success = false;
-        }
+        QgsDebugError( u"failed to delete vertices from feature %1 %2!"_s.arg( layer->name() ).arg( fid ) );
+        success = false;
       }
 
       if ( res == Qgis::VectorEditResult::EmptyGeometry )

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1511,7 +1511,7 @@ Qgis::VectorEditResult QgsVectorLayer::deleteVertices( QgsFeatureId featureId, c
   QgsVectorLayerEditUtils utils( this );
   Qgis::VectorEditResult result = utils.deleteVertices( featureId, vertices );
 
-  if ( result == Qgis::VectorEditResult::Success )
+  if ( result == Qgis::VectorEditResult::Success || result == Qgis::VectorEditResult::EmptyGeometry )
     updateExtents();
   return result;
 }

--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -1501,6 +1501,20 @@ Qgis::VectorEditResult QgsVectorLayer::deleteVertex( QgsFeatureId featureId, int
   return result;
 }
 
+Qgis::VectorEditResult QgsVectorLayer::deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices )
+{
+  QGIS_PROTECT_QOBJECT_THREAD_ACCESS
+
+  if ( !isValid() || !mEditBuffer || !mDataProvider )
+    return Qgis::VectorEditResult::InvalidLayer;
+
+  QgsVectorLayerEditUtils utils( this );
+  Qgis::VectorEditResult result = utils.deleteVertices( featureId, vertices );
+
+  if ( result == Qgis::VectorEditResult::Success )
+    updateExtents();
+  return result;
+}
 
 bool QgsVectorLayer::deleteSelectedFeatures( int *deletedCount, QgsVectorLayer::DeleteContext *context )
 {

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -1286,6 +1286,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
      * by a call to startEditing(). Changes made to features using this method are not committed
      * to the underlying data provider until a commitChanges() call is made. Any uncommitted
      * changes can be discarded by calling rollBack().
+     *
+     * \since QGIS 4.2
      */
     Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices );
 

--- a/src/core/vector/qgsvectorlayer.h
+++ b/src/core/vector/qgsvectorlayer.h
@@ -1279,6 +1279,17 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer,
     Qgis::VectorEditResult deleteVertex( QgsFeatureId featureId, int vertex );
 
     /**
+     * Deletes a set of vertices from a feature.
+     * \param featureId ID of feature to remove vertices from
+     * \param vertices set of vertex indices to delete
+     * \note Calls to deleteVertices() are only valid for layers in which edits have been enabled
+     * by a call to startEditing(). Changes made to features using this method are not committed
+     * to the underlying data provider until a commitChanges() call is made. Any uncommitted
+     * changes can be discarded by calling rollBack().
+     */
+    Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices );
+
+    /**
      * Deletes the selected features
      * \param deletedCount The number of successfully deleted features
      * \param context The chain of features who will be deleted for feedback and to avoid endless recursions

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -135,6 +135,32 @@ Qgis::VectorEditResult QgsVectorLayerEditUtils::deleteVertex( QgsFeatureId featu
   return !geometry.isNull() ? Qgis::VectorEditResult::Success : Qgis::VectorEditResult::EmptyGeometry;
 }
 
+Qgis::VectorEditResult QgsVectorLayerEditUtils::deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices )
+{
+  if ( !mLayer->isSpatial() )
+    return Qgis::VectorEditResult::InvalidLayer;
+
+  if ( vertices.isEmpty() )
+    return Qgis::VectorEditResult::Success;
+
+  QgsFeature f;
+  if ( !mLayer->getFeatures( QgsFeatureRequest().setFilterFid( featureId ).setNoAttributes() ).nextFeature( f ) || !f.hasGeometry() )
+    return Qgis::VectorEditResult::FetchFeatureFailed;
+
+  QgsGeometry geometry = f.geometry();
+
+  if ( !geometry.deleteVertices( vertices ) )
+    return Qgis::VectorEditResult::EditFailed;
+
+  if ( geometry.constGet() && geometry.constGet()->nCoordinates() == 0 )
+  {
+    // Last vertex deleted, set geometry to null
+    geometry.set( nullptr );
+  }
+
+  mLayer->changeGeometry( featureId, geometry );
+  return !geometry.isNull() ? Qgis::VectorEditResult::Success : Qgis::VectorEditResult::EmptyGeometry;
+}
 
 static Qgis::GeometryOperationResult staticAddRing( QgsVectorLayer *layer, std::unique_ptr< QgsCurve > &ring, const QgsFeatureIds &targetFeatureIds, QgsFeatureIds *modifiedFeatureIds, bool firstOne = true )
 {

--- a/src/core/vector/qgsvectorlayereditutils.cpp
+++ b/src/core/vector/qgsvectorlayereditutils.cpp
@@ -140,9 +140,6 @@ Qgis::VectorEditResult QgsVectorLayerEditUtils::deleteVertices( QgsFeatureId fea
   if ( !mLayer->isSpatial() )
     return Qgis::VectorEditResult::InvalidLayer;
 
-  if ( vertices.isEmpty() )
-    return Qgis::VectorEditResult::Success;
-
   QgsFeature f;
   if ( !mLayer->getFeatures( QgsFeatureRequest().setFilterFid( featureId ).setNoAttributes() ).nextFeature( f ) || !f.hasGeometry() )
     return Qgis::VectorEditResult::FetchFeatureFailed;

--- a/src/core/vector/qgsvectorlayereditutils.h
+++ b/src/core/vector/qgsvectorlayereditutils.h
@@ -71,6 +71,13 @@ class CORE_EXPORT QgsVectorLayerEditUtils
     Qgis::VectorEditResult deleteVertex( QgsFeatureId featureId, int vertex );
 
     /**
+     * Deletes a set of vertices from a feature.
+     * \param featureId ID of feature to remove vertices from
+     * \param vertices set of vertex indices to delete
+     */
+    Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices );
+
+    /**
      * Adds a ring to polygon/multipolygon features
      * \param ring ring to add
      * \param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise

--- a/src/core/vector/qgsvectorlayereditutils.h
+++ b/src/core/vector/qgsvectorlayereditutils.h
@@ -74,6 +74,8 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      * Deletes a set of vertices from a feature.
      * \param featureId ID of feature to remove vertices from
      * \param vertices set of vertex indices to delete
+     *
+     * \since QGIS 4.2
      */
     Qgis::VectorEditResult deleteVertices( QgsFeatureId featureId, const QSet<int> &vertices );
 


### PR DESCRIPTION
This PR modifies the vertex tool to use `deleteVertices` instead of iterating selected vertices and calling `deleteVertex` for each one.

This fixes multiple issues:
- vertex tool doesn't need to de-duplicate or do other checks before calling `deleteVertices`, everything is handled by the geometry methods
- deletion of vertices is now finally being properly done, especially for circularstrings and compoundcurves
- using the vertex tool to delete thousands of vertices at once will no longer hang QGIS and make it unresponsive, it also won't fill up the RAM by doing it

Please see https://github.com/qgis/QGIS/pull/63257#issuecomment-3478234519 for details (make sure to check the two screencasts at the end).

Thanks again to @uclaros for reviewing the PR no one would touch, for guidance and great suggestions. 
I realize it is a big change, but I am confident that we are solving many issues with it and it is worth it.

AI use: when AI will be capable of this, I will no longer be programming.