### PR TITLE
disable atlas-related checkbox in the layout chart widget if atlas is not enabled (fix #65612)

### DIFF
--- a/src/gui/layout/qgslayoutchartwidget.cpp
+++ b/src/gui/layout/qgslayoutchartwidget.cpp
@@ -20,6 +20,7 @@
 #include "qgsapplication.h"
 #include "qgsgui.h"
 #include "qgslayout.h"
+#include "qgslayoutatlas.h"
 #include "qgslayoutchartseriesdetailswidget.h"
 #include "qgslayoutitemchart.h"
 #include "qgsplotregistry.h"
@@ -73,6 +74,12 @@ QgsLayoutChartWidget::QgsLayoutChartWidget( QgsLayoutItemChart *chartItem )
 
   setGuiElementValues();
   updateButtonsState();
+
+  if ( QgsLayoutAtlas *atlas = layoutAtlas() )
+  {
+    connect( atlas, &QgsLayoutAtlas::toggled, this, &QgsLayoutChartWidget::layoutAtlasToggled );
+    layoutAtlasToggled( atlas->enabled() );
+  }
 
   connect( mChartItem, &QgsLayoutObject::changed, this, &QgsLayoutChartWidget::setGuiElementValues );
 }
@@ -542,4 +549,17 @@ void QgsLayoutChartWidget::updateButtonsState()
   mSortCheckBox->setEnabled( enable );
   mAddSeriesPushButton->setEnabled( enable );
   mRemoveSeriesPushButton->setEnabled( mSeriesListWidget->count() > 0 );
+}
+
+void QgsLayoutChartWidget::layoutAtlasToggled( bool atlasEnabled )
+{
+  if ( atlasEnabled )
+  {
+    mIntersectAtlasCheckBox->setEnabled( true );
+  }
+  else
+  {
+    mIntersectAtlasCheckBox->setEnabled( false );
+    mIntersectAtlasCheckBox->setChecked( false );
+  }
 }

--- a/src/gui/layout/qgslayoutchartwidget.h
+++ b/src/gui/layout/qgslayoutchartwidget.h
@@ -72,6 +72,8 @@ class GUI_EXPORT QgsLayoutChartWidget : public QgsLayoutItemBaseWidget, private 
     void mFilterOnlyVisibleFeaturesCheckBox_stateChanged( int state );
     void mIntersectAtlasCheckBox_stateChanged( int state );
 
+    void layoutAtlasToggled( bool atlasEnabled );
+
   private:
     //! Sets the GUI elements to the values of mChartItem
     void setGuiElementValues();


### PR DESCRIPTION
## Description

If atlas is not used having "Use only features intersecting atlas features" checkbox enabled in the layout chart item properties is confusing and not consistent with other items. It should be disabled with atlas is not enabled.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.