### PR TITLE
Fix #51368: Handle edge cases in removePassword for credential dialog

### DIFF
--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -245,10 +245,26 @@ QString QgsDataSourceUri::removePassword( const QString &aUri, bool hide )
   {
     if ( aUri.contains( " password='"_L1 ) )
     {
+      // Match password='...' at end of string (no trailing space) — fixes #51368
+      regexp.setPattern( u" password='[^']*'$"_s );
+      if ( hide )
+        safeName.replace( regexp, u" password=%1"_s.arg( HIDING_TOKEN ) );
+      else
+        safeName.replace( regexp, QString() );
+
+      // Match password='...' in middle of string (original pattern, requires trailing space)
       regexp.setPattern( u" password='[^']*' "_s );
     }
     else
     {
+      // Match password=value at end of string (no trailing space) — fixes #51368
+      regexp.setPattern( u" password=\\S+$"_s );
+      if ( hide )
+        safeName.replace( regexp, u" password=%1"_s.arg( HIDING_TOKEN ) );
+      else
+        safeName.replace( regexp, QString() );
+
+      // Match password=value in middle of string (original pattern, requires trailing space)
       regexp.setPattern( u" password=.* "_s );
     }
 
@@ -260,7 +276,7 @@ QString QgsDataSourceUri::removePassword( const QString &aUri, bool hide )
     {
       safeName.replace( regexp, u" "_s );
     }
-  }
+  } 
   else if ( aUri.contains( ",password="_L1 ) )
   {
     regexp.setPattern( u",password=.*,"_s );

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -825,6 +825,22 @@ void TestQgsDataSourceUri::checkRemovePassword()
   const QString uri4
     = QgsDataSourceUri::removePassword( u"dbname='geodata' host=localhost port=5432 user='jgr' password='s Hertogenbosch 2023' srid=4326 table=\"Rocha\".\"pocos_gebox_005\" (rast)"_s, true );
   QCOMPARE( uri4, u"dbname='geodata' host=localhost port=5432 user='jgr' password=XXXXXXXX srid=4326 table=\"Rocha\".\"pocos_gebox_005\" (rast)"_s );
+
+   // Edge case: quoted password as LAST parameter (no trailing space) — remove mode
+  const QString uri5 = QgsDataSourceUri::removePassword( u"dbname='test' host=localhost port=5432 user='admin' password='secret'"_s );
+  QCOMPARE( uri5, u"dbname='test' host=localhost port=5432 user='admin'"_s );
+
+  // Edge case: quoted password as LAST parameter (no trailing space) — hide mode
+  const QString uri6 = QgsDataSourceUri::removePassword( u"dbname='test' host=localhost port=5432 user='admin' password='secret'"_s, true );
+  QCOMPARE( uri6, u"dbname='test' host=localhost port=5432 user='admin' password=XXXXXXXX"_s );
+
+  // Edge case: unquoted password as LAST parameter (no trailing space) — remove mode
+  const QString uri7 = QgsDataSourceUri::removePassword( u"dbname='test' host=localhost port=5432 user='admin' password=secret"_s );
+  QCOMPARE( uri7, u"dbname='test' host=localhost port=5432 user='admin'"_s );
+
+  // Edge case: unquoted password as LAST parameter (no trailing space) — hide mode
+  const QString uri8 = QgsDataSourceUri::removePassword( u"dbname='test' host=localhost port=5432 user='admin' password=secret"_s, true );
+  QCOMPARE( uri8, u"dbname='test' host=localhost port=5432 user='admin' password=XXXXXXXX"_s );  
 }
 
 void TestQgsDataSourceUri::checkUnicodeUri()


### PR DESCRIPTION
The removePassword() regex patterns required a trailing space after the password value, causing the password to remain visible when it is the last parameter in a libpq connection string (no trailing space).

This fix adds additional regex patterns that match password values followed by end-of-string ($), covering:
- password='value' as last parameter (no trailing space)
- password=value (unquoted) as last parameter

The original patterns for passwords in the middle of the string (with trailing space) are preserved unchanged.

Security: Prevents shoulder-surfing exposure of database credentials in the QgsCredentialDialog realm/domain label.

Fixes #51368
Ref #18593

## Description

**AI Tool Disclosure (QEP-408):** This contribution was developed with substantial assistance from Claude (Anthropic). The security issue was identified during real-world use of PostGIS connections at my job. The root cause analysis, regex fix, and test cases were developed with LLM assistance and reviewed/verified by the contributor against actual connection strings.

Assisted-by: Claude (Anthropic)


## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
