### PR TITLE
set file filters for output in the Generate elevation profile image algorithm (fix #64915)

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsprocessingutils.py
+++ b/python/PyQt6/core/auto_additions/qgsprocessingutils.py
@@ -80,6 +80,8 @@ try:
     QgsProcessingUtils.removePointerValuesFromMap = staticmethod(QgsProcessingUtils.removePointerValuesFromMap)
     QgsProcessingUtils.preprocessQgisProcessParameters = staticmethod(QgsProcessingUtils.preprocessQgisProcessParameters)
     QgsProcessingUtils.resolveDefaultEncoding = staticmethod(QgsProcessingUtils.resolveDefaultEncoding)
+    QgsProcessingUtils.supportedImageFormats = staticmethod(QgsProcessingUtils.supportedImageFormats)
+    QgsProcessingUtils.supportedImageFileFilters = staticmethod(QgsProcessingUtils.supportedImageFileFilters)
     QgsProcessingUtils.__group__ = ['processing']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -712,6 +712,28 @@ encoding system (mostly UTF-8 on Unix-like, windows-1252 on Windows).
 .. versionadded:: 3.32
 %End
 
+    static QStringList supportedImageFormats();
+%Docstring
+Returns a list of image format extensions supported by QImageWriter.
+
+The returned list excludes SVG as it is typically handled via other
+exporters, and has the PNG format listed first as the recommended
+default. Remaining formats are sorted alphabetically.
+
+.. versionadded:: 4.2
+%End
+
+    static QString supportedImageFileFilters();
+%Docstring
+Returns a file filter string of all supported image formats, suitable
+for use in file picker dialogs.
+
+The returned string excludes SVG formats and prioritizes the PNG format
+as the recommended default. Remaining filters are sorted alphabetically.
+
+.. versionadded:: 4.2
+%End
+
 };
 
 class QgsProcessingFeatureSource : QgsFeatureSource

--- a/src/analysis/processing/qgsalgorithmgenerateelevationprofile.cpp
+++ b/src/analysis/processing/qgsalgorithmgenerateelevationprofile.cpp
@@ -30,6 +30,7 @@
 #include "qgsterrainprovider.h"
 #include "qgstextformat.h"
 
+#include <QImageWriter>
 #include <QString>
 
 using namespace Qt::StringLiterals;
@@ -146,7 +147,29 @@ void QgsGenerateElevationProfileAlgorithm::initAlgorithm( const QVariantMap & )
   dpiParam->setFlags( dpiParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( dpiParam.release() );
 
-  addParameter( new QgsProcessingParameterFileDestination( u"OUTPUT"_s, QObject::tr( "Output image" ) ) );
+  QStringList fileFilters;
+  const auto supportedFormats { QImageWriter::supportedImageFormats() };
+  for ( const QByteArray &format : supportedFormats )
+  {
+    if ( format == "svg" )
+    {
+      continue;
+    }
+
+    const QString longName = format.toUpper() + QObject::tr( " format" );
+    const QString glob = u"*."_s + format;
+
+    if ( format == "png" && !fileFilters.empty() )
+    {
+      fileFilters.insert( 0, u"%1 (%2 %3)"_s.arg( longName, glob.toLower(), glob.toUpper() ) );
+    }
+    else
+    {
+      fileFilters.append( u"%1 (%2 %3)"_s.arg( longName, glob.toLower(), glob.toUpper() ) );
+    }
+  }
+
+  addParameter( new QgsProcessingParameterFileDestination( u"OUTPUT"_s, QObject::tr( "Output image" ), fileFilters.join( ";;"_L1 ) ) );
 }
 
 QString QgsGenerateElevationProfileAlgorithm::name() const

--- a/src/analysis/processing/qgsalgorithmgenerateelevationprofile.cpp
+++ b/src/analysis/processing/qgsalgorithmgenerateelevationprofile.cpp
@@ -147,29 +147,7 @@ void QgsGenerateElevationProfileAlgorithm::initAlgorithm( const QVariantMap & )
   dpiParam->setFlags( dpiParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( dpiParam.release() );
 
-  QStringList fileFilters;
-  const auto supportedFormats { QImageWriter::supportedImageFormats() };
-  for ( const QByteArray &format : supportedFormats )
-  {
-    if ( format == "svg" )
-    {
-      continue;
-    }
-
-    const QString longName = format.toUpper() + QObject::tr( " format" );
-    const QString glob = u"*."_s + format;
-
-    if ( format == "png" && !fileFilters.empty() )
-    {
-      fileFilters.insert( 0, u"%1 (%2 %3)"_s.arg( longName, glob.toLower(), glob.toUpper() ) );
-    }
-    else
-    {
-      fileFilters.append( u"%1 (%2 %3)"_s.arg( longName, glob.toLower(), glob.toUpper() ) );
-    }
-  }
-
-  addParameter( new QgsProcessingParameterFileDestination( u"OUTPUT"_s, QObject::tr( "Output image" ), fileFilters.join( ";;"_L1 ) ) );
+  addParameter( new QgsProcessingParameterFileDestination( u"OUTPUT"_s, QObject::tr( "Output image" ), QgsProcessingUtils::supportedImageFileFilters() ) );
 }
 
 QString QgsGenerateElevationProfileAlgorithm::name() const

--- a/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
@@ -84,7 +84,6 @@ void QgsLayoutAtlasToImageAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterExpression( u"FILENAME_EXPRESSION"_s, QObject::tr( "Output filename expression" ), u"'output_'||@atlas_featurenumber"_s, u"COVERAGE_LAYER"_s ) );
   addParameter( new QgsProcessingParameterFile( u"FOLDER"_s, QObject::tr( "Output folder" ), Qgis::ProcessingFileParameterBehavior::Folder ) );
 
-
   auto layersParam
     = std::make_unique<QgsProcessingParameterMultipleLayers>( u"LAYERS"_s, QObject::tr( "Map layers to assign to unlocked map item(s)" ), Qgis::ProcessingSourceType::MapLayer, QVariant(), true );
   layersParam->setFlags( layersParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
@@ -175,16 +174,9 @@ QVariantMap QgsLayoutAtlasToImageAlgorithm::processAlgorithm( const QVariantMap 
   const QString directory = parameterAsFileOutput( parameters, u"FOLDER"_s, context );
   const QString fileName = QDir( directory ).filePath( u"atlas"_s );
 
-  QStringList imageFormats;
-  const QList<QByteArray> supportedImageFormats { QImageWriter::supportedImageFormats() };
-  for ( const QByteArray &format : supportedImageFormats )
-  {
-    if ( format == QByteArray( "svg" ) )
-      continue;
-    imageFormats << QString( format );
-  }
+  const QStringList imageFormats = QgsProcessingUtils::supportedImageFormats();
   const int idx = parameterAsEnum( parameters, u"EXTENSION"_s, context );
-  const QString extension = '.' + imageFormats.at( idx );
+  const QString extension = '.' + imageFormats.at( idx ).toLower();
 
   QgsLayoutExporter::ImageExportSettings settings;
 

--- a/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
@@ -90,15 +90,7 @@ void QgsLayoutAtlasToImageAlgorithm::initAlgorithm( const QVariantMap & )
   layersParam->setFlags( layersParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( layersParam.release() );
 
-  QStringList imageFormats;
-  const QList<QByteArray> supportedImageFormats { QImageWriter::supportedImageFormats() };
-  for ( const QByteArray &format : supportedImageFormats )
-  {
-    if ( format == QByteArray( "svg" ) )
-      continue;
-    imageFormats << QString( format );
-  }
-  auto extensionParam = std::make_unique<QgsProcessingParameterEnum>( u"EXTENSION"_s, QObject::tr( "Image format" ), imageFormats, false, imageFormats.indexOf( "png"_L1 ) );
+  auto extensionParam = std::make_unique<QgsProcessingParameterEnum>( u"EXTENSION"_s, QObject::tr( "Image format" ), QgsProcessingUtils::supportedImageFormats(), false, 0 );
   extensionParam->setFlags( extensionParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( extensionParam.release() );
 

--- a/src/analysis/processing/qgsalgorithmlayouttoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayouttoimage.cpp
@@ -90,23 +90,7 @@ void QgsLayoutToImageAlgorithm::initAlgorithm( const QVariantMap & )
   antialias->setFlags( antialias->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( antialias.release() );
 
-  QStringList imageFilters;
-  const auto supportedImageFormats { QImageWriter::supportedImageFormats() };
-  for ( const QByteArray &format : supportedImageFormats )
-  {
-    if ( format == "svg" )
-      continue;
-
-    const QString longName = format.toUpper() + QObject::tr( " format" );
-    const QString glob = u"*."_s + format;
-
-    if ( format == "png" && !imageFilters.empty() )
-      imageFilters.insert( 0, u"%1 (%2 %3)"_s.arg( longName, glob.toLower(), glob.toUpper() ) );
-    else
-      imageFilters.append( u"%1 (%2 %3)"_s.arg( longName, glob.toLower(), glob.toUpper() ) );
-  }
-
-  addParameter( new QgsProcessingParameterFileDestination( u"OUTPUT"_s, QObject::tr( "Image file" ), imageFilters.join( ";;"_L1 ) ) );
+  addParameter( new QgsProcessingParameterFileDestination( u"OUTPUT"_s, QObject::tr( "Image file" ), QgsProcessingUtils::supportedImageFileFilters() ) );
 }
 
 Qgis::ProcessingAlgorithmFlags QgsLayoutToImageAlgorithm::flags() const

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -39,6 +39,7 @@
 #include "qgsvectorlayerfeatureiterator.h"
 #include "qgsvectortilelayer.h"
 
+#include <QImageWriter>
 #include <QRegularExpression>
 #include <QString>
 #include <QTextCodec>
@@ -1592,7 +1593,6 @@ QgsFields QgsProcessingUtils::combineFields( const QgsFields &fieldsA, const Qgs
   return outFields;
 }
 
-
 QList<int> QgsProcessingUtils::fieldNamesToIndices( const QStringList &fieldNames, const QgsFields &fields )
 {
   QList<int> indices;
@@ -1614,7 +1614,6 @@ QList<int> QgsProcessingUtils::fieldNamesToIndices( const QStringList &fieldName
   }
   return indices;
 }
-
 
 QgsFields QgsProcessingUtils::indicesToFields( const QList<int> &indices, const QgsFields &fields )
 {
@@ -1800,6 +1799,53 @@ QString QgsProcessingUtils::resolveDefaultEncoding( const QString &defaultEncodi
   }
 
   return defaultEncoding;
+}
+
+QStringList QgsProcessingUtils::supportedImageFormats()
+{
+  const QList<QByteArray> supportedFormats = QImageWriter::supportedImageFormats();
+  QStringList formats;
+  formats.reserve( supportedFormats.size() );
+
+  for ( const QByteArray &format : supportedFormats )
+  {
+    if ( format == "svg" )
+    {
+      continue;
+    }
+    formats.append( QString::fromUtf8( format ).toUpper() );
+  }
+
+  std::sort( formats.begin(), formats.end(), []( const QString &a, const QString &b ) -> bool {
+    if ( a == "PNG"_L1 )
+    {
+      return true;
+    }
+    if ( b == "PNG"_L1 )
+    {
+      return false;
+    }
+    return a.localeAwareCompare( b ) < 0;
+  } );
+
+  return formats;
+}
+
+QString QgsProcessingUtils::supportedImageFileFilters()
+{
+  const QStringList formats = supportedImageFormats();
+  QStringList fileFilters;
+  fileFilters.reserve( formats.size() );
+
+  for ( const QString &format : formats )
+  {
+    const QString longName = format + QObject::tr( " format" );
+    const QString glob = u"*."_s + format;
+
+    fileFilters.append( u"%1 (%2 %3)"_s.arg( longName, glob.toLower(), glob ) );
+  }
+
+  return fileFilters.join( ";;"_L1 );
 }
 
 //

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -646,6 +646,26 @@ class CORE_EXPORT QgsProcessingUtils
      */
     static QString resolveDefaultEncoding( const QString &defaultEncoding = "System" );
 
+     /**
+     * Returns a list of image format extensions supported by QImageWriter.
+     *
+     * The returned list excludes SVG as it is typically handled via other exporters, and has the PNG format
+     * listed first as the recommended default. Remaining formats are sorted alphabetically.
+     *
+     * \since QGIS 4.2
+     */
+    static QStringList supportedImageFormats();
+
+    /**
+     * Returns a file filter string of all supported image formats, suitable for use in file picker dialogs.
+     *
+     * The returned string excludes SVG formats and prioritizes the PNG format as the recommended default.
+     * Remaining filters are sorted alphabetically.
+     *
+     * \since QGIS 4.2
+     */
+    static QString supportedImageFileFilters();
+
   private:
     static bool canUseLayer( const QgsRasterLayer *layer );
     static bool canUseLayer( const QgsMeshLayer *layer );

--- a/tests/src/python/test_qgsprocessingutils.py
+++ b/tests/src/python/test_qgsprocessingutils.py
@@ -161,6 +161,22 @@ class TestQgsProcessingUtils(QgisTestCase):
         obtained_names = [field.name() for field in combined]
         self.assertEqual(expected_names, obtained_names)
 
+    def test_supportedImageFormats(self):
+        formats = QgsProcessingUtils.supportedImageFormats()
+        self.assertTrue(len(formats) > 0)
+        self.assertEqual(formats[0], "PNG")
+        self.assertNotIn("SVG", formats)
+        remaining_formats = formats[1:]
+        self.assertEqual(remaining_formats, sorted(remaining_formats))
+
+    def test_supportedImageFileFilters(self):
+        filters = QgsProcessingUtils.supportedImageFileFilters()
+        self.assertTrue(len(filters) > 0)
+        self.assertTrue(filters.startswith("PNG format (*.png *.PNG)"))
+        self.assertIn(";;", filters)
+        self.assertNotIn("SVG", filters)
+        self.assertNotIn("svg", filters)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Add file filters with supported image formats to the Generate elevation profile image Processing algorithm.

Fixes #64915.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.