### PR TITLE
[imageserver] Set useful min/max for imageserver provider layers from pixel type

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -235,10 +235,14 @@ Parses a capabilities string to known values.
 
     static Qgis::DataType dataTypeFromString( const QString &pixelType );
 %Docstring
-Returns the raster data type corresponding to an ESRI pixelType string.
+Returns the raster data type corresponding to an ESRI ``pixelType``
+string.
 
 .. versionadded:: 4.2
 %End
+
+
+
 
     static Qgis::RasterColorInterpretation colorInterpretationFromBandName( const QString &bandName );
 %Docstring

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -1778,6 +1778,102 @@ Qgis::DataType QgsArcGisRestUtils::dataTypeFromString( const QString &pixelType 
   return Qgis::DataType::UnknownDataType;
 }
 
+QgsArcGisRestUtils::PixelTypeLimitUsefulness QgsArcGisRestUtils::pixelTypeLimitUsefulness( const QString &pixelType )
+{
+  if ( pixelType.compare( "U8"_L1, Qt::CaseInsensitive ) == 0
+       || pixelType.compare( "U4"_L1, Qt::CaseInsensitive ) == 0
+       || pixelType.compare( "U2"_L1, Qt::CaseInsensitive ) == 0
+       || pixelType.compare( "U1"_L1, Qt::CaseInsensitive ) == 0
+       || pixelType.compare( "S8"_L1, Qt::CaseInsensitive ) == 0
+       || pixelType.compare( "U16"_L1, Qt::CaseInsensitive ) == 0
+       || pixelType.compare( "S16"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return PixelTypeLimitUsefulness { true, true };
+  }
+  else if ( pixelType.compare( "U32"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return PixelTypeLimitUsefulness { true, false };
+  }
+  else if ( pixelType.compare( "S32"_L1, Qt::CaseInsensitive ) == 0
+            || pixelType.compare( "F32"_L1, Qt::CaseInsensitive ) == 0
+            || pixelType.compare( "F64"_L1, Qt::CaseInsensitive ) == 0
+            || pixelType.compare( "C64"_L1, Qt::CaseInsensitive ) == 0
+            || pixelType.compare( "C128"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return PixelTypeLimitUsefulness { false, false };
+  }
+  else
+  {
+    QgsDebugError( u"Unknown pixelType: %1"_s.arg( pixelType ) );
+  }
+
+  return PixelTypeLimitUsefulness { false, false };
+}
+
+std::optional<std::pair<double, double> > QgsArcGisRestUtils::rangeForPixelType( const QString &pixelType )
+{
+  if ( pixelType.compare( "U8"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( 0.0, 255.0 );
+  }
+  else if ( pixelType.compare( "U4"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( 0.0, 15.0 );
+  }
+  else if ( pixelType.compare( "U2"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( 0.0, 3.0 );
+  }
+  else if ( pixelType.compare( "U1"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( 0.0, 1.0 );
+  }
+  else if ( pixelType.compare( "S8"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( -128.0, 127.0 );
+  }
+  else if ( pixelType.compare( "U16"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( 0.0, 65535.0 );
+  }
+  else if ( pixelType.compare( "S16"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( -32768.0, 32767.0 );
+  }
+  else if ( pixelType.compare( "U32"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( 0.0, static_cast<double>( std::numeric_limits<uint32_t>::max() ) );
+  }
+  else if ( pixelType.compare( "S32"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( static_cast<double>( std::numeric_limits<int32_t>::lowest() ), static_cast<double>( std::numeric_limits<int32_t>::max() ) );
+  }
+  else if ( pixelType.compare( "F32"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( static_cast<double>( std::numeric_limits<float>::lowest() ), static_cast<double>( std::numeric_limits<float>::max() ) );
+  }
+  else if ( pixelType.compare( "F64"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    return std::make_pair( std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max() );
+  }
+  else if ( pixelType.compare( "C64"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    // C64 = 32-bit real + 32-bit imaginary
+    return std::make_pair( static_cast<double>( std::numeric_limits<float>::lowest() ), static_cast<double>( std::numeric_limits<float>::max() ) );
+  }
+  else if ( pixelType.compare( "C128"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    // C128 = 64-bit real + 64-bit imaginary
+    return std::make_pair( std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max() );
+  }
+  else
+  {
+    QgsDebugError( u"Unknown pixelType: %1"_s.arg( pixelType ) );
+  }
+
+  return std::nullopt;
+}
+
 Qgis::RasterColorInterpretation QgsArcGisRestUtils::colorInterpretationFromBandName( const QString &bandName )
 {
   if ( bandName.isEmpty() )

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -282,11 +282,53 @@ class CORE_EXPORT QgsArcGisRestUtils
     static Qgis::ArcGisRestServiceCapabilities serviceCapabilitiesFromString( const QString &capabilities );
 
     /**
-     * Returns the raster data type corresponding to an ESRI pixelType string.
+     * Returns the raster data type corresponding to an ESRI \a pixelType string.
      *
      * \since QGIS 4.2
      */
     static Qgis::DataType dataTypeFromString( const QString &pixelType );
+
+#ifndef SIP_RUN
+    /**
+     * Struct representing whether the theoretical limits of a pixel type are
+     * useful for describing actual data boundaries.
+     *
+     * \note Not available in Python bindings
+     *
+     * \since QGIS 4.2
+     */
+    struct PixelTypeLimitUsefulness
+    {
+        //! TRUE if the theoretical minimum value is a useful data boundary (e.g., 0 for unsigned types)
+        bool minIsUseful = false;
+        //! TRUE if the theoretical maximum value is a useful data boundary (e.g., 255 for U8)
+        bool maxIsUseful = false;
+    };
+#endif
+
+    /**
+     * Returns whether the theoretical minimum and maximum values for a given ESRI
+     * \a pixelType are practically useful for representing expected data ranges.
+     *
+     * For instance, an unsigned 8-bit integer ('U8') has a useful minimum (0)
+     * and maximum (255). Conversely, floating-point types ('F32'/'F64') return FALSE
+     * because their maximum theoretical limits are too large to represent a useful
+     * indication of the actual data present in a layer.
+     *
+     * \note Not available in Python bindings
+     *
+     * \since QGIS 4.2
+     */
+    SIP_SKIP static PixelTypeLimitUsefulness pixelTypeLimitUsefulness( const QString &pixelType );
+
+    /**
+     * Returns the valid data range given an ESRI \a pixelType string.
+     *
+     * \note Not available in Python bindings
+     *
+     * \since QGIS 4.2
+     */
+    SIP_SKIP static std::optional< std::pair< double, double > > rangeForPixelType( const QString &pixelType );
 
     /**
      * Attempts to match arbitrary band name strings to a QGIS raster color interpretation.

--- a/src/providers/arcgisrest/qgsimageserverprovider.cpp
+++ b/src/providers/arcgisrest/qgsimageserverprovider.cpp
@@ -242,6 +242,27 @@ QgsImageServerProvider::QgsImageServerProvider( const QString &uri, const Provid
     }
   }
 
+  // populate remaining missing min/max values with appropriate values for certain data types, if we can!
+  const QgsArcGisRestUtils::PixelTypeLimitUsefulness pixelTypeLimitUsefulness = QgsArcGisRestUtils::pixelTypeLimitUsefulness( mPixelType );
+  if ( pixelTypeLimitUsefulness.minIsUseful || pixelTypeLimitUsefulness.maxIsUseful )
+  {
+    const std::optional< std::pair< double, double > > typeRange = QgsArcGisRestUtils::rangeForPixelType( mPixelType );
+    if ( pixelTypeLimitUsefulness.minIsUseful && typeRange.has_value() )
+    {
+      for ( qsizetype i = mMinValues.count(); i < mBandCount; ++i )
+      {
+        mMinValues.append( typeRange->first );
+      }
+    }
+    if ( pixelTypeLimitUsefulness.maxIsUseful && typeRange.has_value() )
+    {
+      for ( qsizetype i = mMaxValues.count(); i < mBandCount; ++i )
+      {
+        mMaxValues.append( typeRange->second );
+      }
+    }
+  }
+
   QgsLayerMetadata::SpatialExtent spatialExtent;
   spatialExtent.bounds = QgsBox3D( mExtent );
   spatialExtent.extentCrs = mCrs;

--- a/tests/src/python/test_provider_imageserver.py
+++ b/tests/src/python/test_provider_imageserver.py
@@ -1430,6 +1430,196 @@ class TestPyQgsImageServerProvider(QgisTestCase, RasterProviderTestCase):
         self.assertTrue(rl.dataProvider().useSourceNoDataValue(1))
         self.assertEqual(rl.dataProvider().sourceNoDataValue(1), 32767.0)
 
+    def test_missing_min_max(self):
+        """
+        Test guessing min/max values from pixel type
+        """
+        DATA = {
+            "U8": (0, 255),
+            "U4": (0, 15),
+            "U2": (0, 3),
+            "U1": (0, 1),
+            "S8": (-128.0, 127.0),
+            "U16": (0.0, 65535.0),
+            "S16": (-32768.0, 32767.0),
+            "U32": (0, None),
+            "S32": (None, None),
+            "F32": (None, None),
+            "F64": (None, None),
+            "C64": (None, None),
+            "C128": (None, None),
+        }
+
+        for pixel_type, (min, max) in DATA.items():
+            for test_min in (True, False):
+                endpoint = (
+                    self.basetestpath
+                    + f"/minmax{pixel_type}{test_min}_test_fake_qgis_http_endpoint"
+                )
+                with open(self.sanitize_local_url(endpoint, "?f=json"), "wb") as f:
+                    f.write(
+                        """
+                        {
+         "currentVersion": 10.91,
+         "name": "CharlotteLAS",
+         "description": "My service description",
+         "copyrightText": "My copyright string",
+         "extent": {
+          "xmin": 1440000,
+          "ymin": 535000,
+          "xmax": 1455000,
+          "ymax": 550000,
+          "spatialReference": {
+           "wkid": 102719,
+           "latestWkid": 2264
+          }
+         },
+         "initialExtent": {
+          "xmin": 1440000,
+          "ymin": 535000,
+          "xmax": 1455000,
+          "ymax": 550000,
+          "spatialReference": {
+           "wkid": 102719,
+           "latestWkid": 2264
+          }
+         },
+         "fullExtent": {
+          "xmin": 1440000,
+          "ymin": 535000,
+          "xmax": 1455000,
+          "ymax": 550000,
+          "spatialReference": {
+           "wkid": 102719,
+           "latestWkid": 2264
+          }
+         },
+         "hasMultidimensions": false,
+         "pixelSizeX": 10,
+         "pixelSizeY": 10,
+         "datasetFormat": "AMD",
+         "uncompressedSize": 9000000,
+         "blockWidth": 2048,
+         "blockHeight": 256,
+         "compressionType": "None",
+         "bandNames": [
+          "Band_1"
+         ],
+         "allowCopy": true,
+         "allowAnalysis": true,
+         "bandCount": 1,
+         "pixelType": "PIXEL_TYPE",
+         "minPixelSize": 0,
+         "maxPixelSize": 0,
+         "serviceDataType": "esriImageServiceDataTypeGeneric",
+         "objectIdField": "OBJECTID",
+         "fields": [
+          {
+           "name": "OBJECTID",
+           "type": "esriFieldTypeOID",
+           "alias": "OBJECTID",
+           "domain": null
+          }
+         ],
+         "capabilities": "Image,Metadata,Catalog,Mensuration",
+         "defaultMosaicMethod": "Northwest",
+         "allowedMosaicMethods": "NorthWest,Center,LockRaster,ByAttribute,Nadir,Viewpoint,Seamline,None",
+         "sortField": "",
+         "sortValue": null,
+         "sortAscending": true,
+         "mosaicOperator": "First",
+         "maxDownloadSizeLimit": 0,
+         "defaultCompressionQuality": 10000,
+         "defaultResamplingMethod": "Bilinear",
+         "maxImageHeight": 4100,
+         "maxImageWidth": 15000,
+         "maxRecordCount": 1000,
+         "maxDownloadImageCount": 0,
+         "maxMosaicImageCount": 20,
+         "allowRasterFunction": true,
+         "rasterFunctionInfos": [
+         ],
+         "rasterTypeInfos": [
+          {
+           "name": "Raster Dataset",
+           "description": "Supports all ArcGIS Raster Datasets",
+           "help": ""
+          }
+         ],
+         "mensurationCapabilities": "Basic",
+         "hasHistograms": true,
+         "hasColormap": false,
+         "hasRasterAttributeTable": false,
+         "minScale": 0,
+         "maxScale": 0,
+         "exportTilesAllowed": false,
+         "supportsStatistics": true,
+         "supportsAdvancedQueries": true,
+         "editFieldsInfo": null,
+         "ownershipBasedAccessControlForRasters": null,
+         "allowComputeTiePoints": false,
+         "useStandardizedQueries": true,
+         "advancedQueryCapabilities": {
+          "useStandardizedQueries": true,
+          "supportsStatistics": true,
+          "supportsOrderBy": true,
+          "supportsDistinct": true,
+          "supportsPagination": true
+         },
+         "spatialReference": {
+          "wkid": 102719,
+          "latestWkid": 2264
+         }
+        }""".replace("PIXEL_TYPE", pixel_type).encode()
+                    )
+
+                rl = QgsRasterLayer(
+                    "url='http://" + endpoint + "'",
+                    "test",
+                    "arcgisimageserver",
+                )
+                self.assertTrue(rl.isValid())
+                if test_min:
+                    if min is not None:
+                        self.assertTrue(
+                            rl.dataProvider().hasStatistics(
+                                1, Qgis.RasterBandStatistic.Min
+                            ),
+                            f"No minimum for {pixel_type}, should be set",
+                        )
+                        band_stats = rl.dataProvider().bandStatistics(
+                            1, Qgis.RasterBandStatistic.Min
+                        )
+                        self.assertEqual(band_stats.bandNumber, 1)
+                        self.assertEqual(band_stats.minimumValue, min)
+                    else:
+                        self.assertFalse(
+                            rl.dataProvider().hasStatistics(
+                                1, Qgis.RasterBandStatistic.Min
+                            ),
+                            f"Unexpected minimum {band_stats.minimumValue} for {pixel_type}, should not be set",
+                        )
+                else:
+                    if max is not None:
+                        self.assertTrue(
+                            rl.dataProvider().hasStatistics(
+                                1, Qgis.RasterBandStatistic.Max
+                            ),
+                            f"No maximum for {pixel_type}, should be set",
+                        )
+                        band_stats = rl.dataProvider().bandStatistics(
+                            1, Qgis.RasterBandStatistic.Min
+                        )
+                        self.assertEqual(band_stats.bandNumber, 1)
+                        self.assertEqual(band_stats.maximumValue, max)
+                    else:
+                        self.assertFalse(
+                            rl.dataProvider().hasStatistics(
+                                1, Qgis.RasterBandStatistic.Max
+                            ),
+                            f"Unexpected maximum {band_stats.maximumValue} for {pixel_type}, should not be set",
+                        )
+
     @unittest.skipIf(
         not QgsGdalUtils.supportsMrfLercCompression(),
         "GDAL build with LERC support required",


### PR DESCRIPTION
For the ImageServer provider: If no explicit min/max stats are present in the service definition, try to guess these based on pixel type. (Where the pixel type is has a "useful" limit, i.e not a theoretical maximum for float/double types)

Fixes some ImageServer layers load with unhelpful renderers set to a 0-0 pixel value range.

## Description

[Replace this with some text explaining the rationale and details about this pull request]

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
