### PR TITLE
Use safer approach to set initial focus in expression builder to editor

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgsexpressionbuilderwidget.py
+++ b/python/PyQt6/gui/auto_additions/qgsexpressionbuilderwidget.py
@@ -8,7 +8,6 @@ QgsExpressionBuilderWidget.Flag.baseClass = QgsExpressionBuilderWidget
 Flag = QgsExpressionBuilderWidget  # dirty hack since SIP seems to introduce the flags in module
 try:
     QgsExpressionBuilderWidget.__attribute_docs__ = {'expressionParsed': 'Emitted when the user changes the expression in the widget. Users of\nthis widget should connect to this signal to decide if to let the user\ncontinue.\n\n:param isValid: Is ``True`` if the expression the user has typed is\n                valid.\n', 'evalErrorChanged': 'Will be set to ``True`` if the current expression text reported an eval\nerror with the context.\n', 'parserErrorChanged': 'Will be set to ``True`` if the current expression text reported a parser\nerror with the context.\n'}
-    QgsExpressionBuilderWidget.__overridden_methods__ = ['showEvent']
     QgsExpressionBuilderWidget.__signal_arguments__ = {'expressionParsed': ['isValid: bool']}
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -467,10 +467,6 @@ Will be set to ``True`` if the current expression text reported a parser
 error with the context.
 %End
 
-  protected:
-    virtual void showEvent( QShowEvent *e );
-
-
       public:
 };
 

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -242,6 +242,8 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
  : param params_as_list : Set this to True to pass the function parameters as a list. Can be used to mimic \n\
                         behavior before 3.32, when args was not \"auto\". Defaults to False.\n\
 \"\"\"" ) );
+
+  txtExpressionString->setFocus();
 }
 
 
@@ -835,12 +837,6 @@ void QgsExpressionBuilderWidget::setProject( QgsProject *project )
 {
   mProject = project;
   mExpressionTreeView->setProject( project );
-}
-
-void QgsExpressionBuilderWidget::showEvent( QShowEvent *e )
-{
-  QWidget::showEvent( e );
-  txtExpressionString->setFocus();
 }
 
 void QgsExpressionBuilderWidget::createErrorMarkers( const QList<QgsExpression::ParserError> &errors )

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -468,9 +468,6 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      */
     void parserErrorChanged();
 
-  protected:
-    void showEvent( QShowEvent *e ) override;
-
   private:
     class ExpressionTreeMenuProvider : public QgsExpressionTreeView::MenuProvider
     {


### PR DESCRIPTION
Makes the set focus behavior less forceful/grabby, which eg caused the focus to immediately switch to the expression builder when clicking on a processing child algorithm with a expression widget shown in the configuration form.

Fixes #65975

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
