### PR TITLE
[FEATURE] Add full HTTP Headers support to XYZ tile connections

### DIFF
--- a/src/gui/qgshttpheaderwidget.cpp
+++ b/src/gui/qgshttpheaderwidget.cpp
@@ -40,6 +40,9 @@ QgsHttpHeaderWidget::QgsHttpHeaderWidget( QWidget *parent )
   // Action and interaction connections
   connect( btnAddQueryPair, &QToolButton::clicked, this, &QgsHttpHeaderWidget::addQueryPair );
   connect( btnRemoveQueryPair, &QToolButton::clicked, this, &QgsHttpHeaderWidget::removeQueryPair );
+
+  connect( mRefererLineEdit, &QLineEdit::textChanged, this, &QgsHttpHeaderWidget::changed );
+  connect( tblwdgQueryPairs, &QTableWidget::cellChanged, this, &QgsHttpHeaderWidget::changed );
 }
 
 QgsHttpHeaderWidget::~QgsHttpHeaderWidget() = default;
@@ -98,7 +101,9 @@ void QgsHttpHeaderWidget::addQueryPair()
 
 void QgsHttpHeaderWidget::removeQueryPair()
 {
+  // removing a row does not fire QTableWidget::cellChanged
   tblwdgQueryPairs->removeRow( tblwdgQueryPairs->currentRow() );
+  emit changed();
 }
 
 

--- a/src/gui/qgshttpheaderwidget.h
+++ b/src/gui/qgshttpheaderwidget.h
@@ -75,6 +75,15 @@ class GUI_EXPORT QgsHttpHeaderWidget : public QWidget, private Ui::QgsHttpHeader
      */
     Q_DECL_DEPRECATED void updateSettings( QgsSettings &settings, const QString &key ) const SIP_DEPRECATED;
 
+  signals:
+
+    /**
+     * Emitted when the referer or any key/value header pair shown in the widget is changed.
+     *
+     * \since QGIS 4.1
+     */
+    void changed();
+
   private slots:
 
     /**

--- a/src/providers/wms/qgsxyzconnectiondialog.cpp
+++ b/src/providers/wms/qgsxyzconnectiondialog.cpp
@@ -52,7 +52,7 @@ void QgsXyzConnectionDialog::setConnection( const QgsXyzConnection &conn )
   mSourceWidget->setZMax( conn.zMax );
   mSourceWidget->setUsername( conn.username );
   mSourceWidget->setPassword( conn.password );
-  mSourceWidget->setReferer( conn.httpHeaders[QgsHttpHeaders::KEY_REFERER].toString() );
+  mSourceWidget->setHttpHeaders( conn.httpHeaders );
   mSourceWidget->setTilePixelRatio( conn.tilePixelRatio );
   mSourceWidget->setAuthCfg( conn.authCfg );
   mSourceWidget->setInterpretation( conn.interpretation );
@@ -67,7 +67,7 @@ QgsXyzConnection QgsXyzConnectionDialog::connection() const
   conn.zMax = mSourceWidget->zMax();
   conn.username = mSourceWidget->username();
   conn.password = mSourceWidget->password();
-  conn.httpHeaders[QgsHttpHeaders::KEY_REFERER] = mSourceWidget->referer();
+  conn.httpHeaders = mSourceWidget->httpHeaders();
   conn.tilePixelRatio = mSourceWidget->tilePixelRatio();
   conn.authCfg = mSourceWidget->authcfg();
   conn.interpretation = mSourceWidget->interpretation();

--- a/src/providers/wms/qgsxyzsourcewidget.cpp
+++ b/src/providers/wms/qgsxyzsourcewidget.cpp
@@ -68,6 +68,10 @@ void QgsXyzSourceWidget::setSourceUri( const QString &uri )
   mAuthSettings->setPassword( mSourceParts.value( u"password"_s ).toString() );
   QgsHttpHeaders headers;
   headers.setFromMap( mSourceParts );
+  // ensure the referer key is always present, otherwise QgsHttpHeaderWidget::setHeaders()
+  // will not clear a previously shown referer when the URI has none
+  if ( !headers.keys().contains( QgsHttpHeaders::KEY_REFERER ) )
+    headers[QgsHttpHeaders::KEY_REFERER] = QString();
   mHttpHeaders->setHeaders( headers );
 
   int index = 0; // default is "unknown"

--- a/src/providers/wms/qgsxyzsourcewidget.cpp
+++ b/src/providers/wms/qgsxyzsourcewidget.cpp
@@ -47,6 +47,7 @@ QgsXyzSourceWidget::QgsXyzSourceWidget( QWidget *parent )
   connect( mAuthSettings, &QgsAuthSettingsWidget::configIdChanged, this, &QgsProviderSourceWidget::changed );
   connect( mAuthSettings, &QgsAuthSettingsWidget::usernameChanged, this, &QgsProviderSourceWidget::changed );
   connect( mAuthSettings, &QgsAuthSettingsWidget::passwordChanged, this, &QgsProviderSourceWidget::changed );
+  connect( mHttpHeaders, &QgsHttpHeaderWidget::changed, this, &QgsProviderSourceWidget::changed );
   connect( mComboTileResolution, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsProviderSourceWidget::changed );
 
   mInterpretationCombo = new QgsWmsInterpretationComboBox( this );

--- a/src/providers/wms/qgsxyzsourcewidget.cpp
+++ b/src/providers/wms/qgsxyzsourcewidget.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsxyzsourcewidget.h"
 
+#include "qgshttpheaderwidget.h"
 #include "qgsproviderregistry.h"
 #include "qgswmssourceselect.h"
 
@@ -46,7 +47,6 @@ QgsXyzSourceWidget::QgsXyzSourceWidget( QWidget *parent )
   connect( mAuthSettings, &QgsAuthSettingsWidget::configIdChanged, this, &QgsProviderSourceWidget::changed );
   connect( mAuthSettings, &QgsAuthSettingsWidget::usernameChanged, this, &QgsProviderSourceWidget::changed );
   connect( mAuthSettings, &QgsAuthSettingsWidget::passwordChanged, this, &QgsProviderSourceWidget::changed );
-  connect( mEditReferer, &QLineEdit::textChanged, this, &QgsProviderSourceWidget::changed );
   connect( mComboTileResolution, qOverload<int>( &QComboBox::currentIndexChanged ), this, &QgsProviderSourceWidget::changed );
 
   mInterpretationCombo = new QgsWmsInterpretationComboBox( this );
@@ -66,7 +66,9 @@ void QgsXyzSourceWidget::setSourceUri( const QString &uri )
   mSpinZMax->setValue( mCheckBoxZMax->isChecked() ? mSourceParts.value( u"zmax"_s ).toInt() : 18 );
   mAuthSettings->setUsername( mSourceParts.value( u"username"_s ).toString() );
   mAuthSettings->setPassword( mSourceParts.value( u"password"_s ).toString() );
-  mEditReferer->setText( mSourceParts.value( u"http-header:referer"_s ).toString() );
+  QgsHttpHeaders headers;
+  headers.setFromMap( mSourceParts );
+  mHttpHeaders->setHeaders( headers );
 
   int index = 0; // default is "unknown"
   if ( mSourceParts.value( u"tilePixelRatio"_s ).toInt() == 2. )
@@ -103,10 +105,16 @@ QString QgsXyzSourceWidget::sourceUri() const
   else
     parts.remove( u"password"_s );
 
-  if ( !mEditReferer->text().isEmpty() )
-    parts.insert( u"referer"_s, mEditReferer->text() );
-  else
-    parts.remove( u"referer"_s );
+  QStringList keysToRemove;
+  for ( auto it = parts.constBegin(); it != parts.constEnd(); ++it )
+  {
+    if ( it.key().startsWith( QgsHttpHeaders::PARAM_PREFIX ) || it.key() == QgsHttpHeaders::KEY_REFERER )
+      keysToRemove.append( it.key() );
+  }
+  for ( const QString &key : keysToRemove )
+    parts.remove( key );
+
+  mHttpHeaders->httpHeaders().updateMap( parts );
 
   if ( mComboTileResolution->currentIndex() > 0 )
     parts.insert( u"tilePixelRatio"_s, mComboTileResolution->currentIndex() );
@@ -188,14 +196,14 @@ QString QgsXyzSourceWidget::authcfg() const
   return mAuthSettings->configId();
 }
 
-void QgsXyzSourceWidget::setReferer( const QString &referer )
+void QgsXyzSourceWidget::setHttpHeaders( const QgsHttpHeaders &headers )
 {
-  mEditReferer->setText( referer );
+  mHttpHeaders->setHeaders( headers );
 }
 
-QString QgsXyzSourceWidget::referer() const
+QgsHttpHeaders QgsXyzSourceWidget::httpHeaders() const
 {
-  return mEditReferer->text();
+  return mHttpHeaders->httpHeaders();
 }
 
 void QgsXyzSourceWidget::setTilePixelRatio( int ratio )

--- a/src/providers/wms/qgsxyzsourcewidget.h
+++ b/src/providers/wms/qgsxyzsourcewidget.h
@@ -20,6 +20,7 @@
 #include "ui_qgsxyzsourcewidgetbase.h"
 
 #include "qgsprovidersourcewidget.h"
+#include "qgshttpheaders.h"
 
 #include <QVariantMap>
 
@@ -52,8 +53,8 @@ class QgsXyzSourceWidget : public QgsProviderSourceWidget, private Ui::QgsXyzSou
     QString password() const;
     QString authcfg() const;
 
-    void setReferer( const QString &referer );
-    QString referer() const;
+    void setHttpHeaders( const QgsHttpHeaders &headers );
+    QgsHttpHeaders httpHeaders() const;
 
     void setTilePixelRatio( int ratio );
     int tilePixelRatio() const;

--- a/src/ui/qgsxyzsourcewidgetbase.ui
+++ b/src/ui/qgsxyzsourcewidgetbase.ui
@@ -88,15 +88,8 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="lblReferer">
-     <property name="text">
-      <string>Referer</string>
-     </property>
-     <property name="buddy">
-      <cstring>mEditReferer</cstring>
-     </property>
-    </widget>
+   <item row="4" column="0" colspan="2">
+    <widget class="QgsHttpHeaderWidget" name="mHttpHeaders" native="true"/>
    </item>
    <item row="0" column="1">
     <widget class="QLineEdit" name="mEditUrl">
@@ -146,13 +139,6 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QLineEdit" name="mEditReferer">
-     <property name="toolTip">
-      <string>Optional custom referer</string>
-     </property>
-    </widget>
-   </item>
    <item row="6" column="1">
     <layout class="QHBoxLayout" name="mInterpretationLayout">
      <property name="spacing">
@@ -167,6 +153,19 @@
      </property>
     </widget>
    </item>
+   <item row="7" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -174,6 +173,12 @@
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsHttpHeaderWidget</class>
+   <extends>QWidget</extends>
+   <header>qgshttpheaderwidget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsAuthSettingsWidget</class>
@@ -194,7 +199,7 @@
   <tabstop>mSpinZMin</tabstop>
   <tabstop>mCheckBoxZMax</tabstop>
   <tabstop>mSpinZMax</tabstop>
-  <tabstop>mEditReferer</tabstop>
+  <tabstop>mHttpHeaders</tabstop>
   <tabstop>mComboTileResolution</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
## Description

This PR enables the user to provide HTTP headers for XYZ tile layers, matching the existing WMS behaviour.

It reuses `QgsHttpHeaderWidget` which is what the WMS dialog uses to collect referrer & arbitrary HTTP headers. The backend already supported full headers; this is a UI-only change.

<img width="638" height="814" alt="image" src="https://github.com/user-attachments/assets/103325ca-058e-4450-95d0-9c52dc9dd735" />


## AI tool usage

[x] Claude supported my development of this PR.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
