### PR TITLE
Move the point cloud "color modification" parameter to the "Point Symbol" group

### DIFF
--- a/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
@@ -65,7 +65,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="mLayerRenderingGroupBox_2">
+        <widget class="QgsCollapsibleGroupBox" name="mPointSymbolGroupBox">
          <property name="title">
           <string>Point Symbol</string>
          </property>
@@ -77,10 +77,10 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
           <property name="leftMargin">
-           <number>0</number>
+           <number>6</number>
           </property>
           <property name="rightMargin">
-           <number>3</number>
+           <number>6</number>
           </property>
           <item row="0" column="1" colspan="2">
            <widget class="QgsDoubleSpinBox" name="mPointSizeSpinBox">
@@ -286,10 +286,10 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_8">
           <property name="leftMargin">
-           <number>0</number>
+           <number>6</number>
           </property>
           <property name="rightMargin">
-           <number>3</number>
+           <number>6</number>
           </property>
           <item row="0" column="0">
            <widget class="QCheckBox" name="mHorizontalTriangleCheckBox">
@@ -388,7 +388,7 @@ Select Earlier to switch at a smaller scale (zoomed out) or Later to switch at a
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="mLayerRenderingGroupBox">
+        <widget class="QgsCollapsibleGroupBox" name="mLayerRenderingGroupBox">
          <property name="title">
           <string>Layer Rendering</string>
          </property>
@@ -400,10 +400,10 @@ Select Earlier to switch at a smaller scale (zoomed out) or Later to switch at a
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <property name="leftMargin">
-           <number>0</number>
+           <number>6</number>
           </property>
           <property name="rightMargin">
-           <number>3</number>
+           <number>6</number>
           </property>
           <item row="1" column="0">
            <widget class="QLabel" name="lblTransparency_2">
@@ -507,6 +507,12 @@ Select Earlier to switch at a smaller scale (zoomed out) or Later to switch at a
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -532,12 +538,6 @@ Select Earlier to switch at a smaller scale (zoomed out) or Later to switch at a
    <class>QgsPanelWidget</class>
    <extends>QWidget</extends>
    <header>qgspanelwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
@@ -247,20 +247,13 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="mHillshadingMultidirLabel">
-            <property name="text">
-             <string>Multidirectional</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
+          <item row="1" column="0" colspan="4">
            <widget class="QCheckBox" name="mHillshadingMultidirCheckBox">
             <property name="toolTip">
              <string>Use multidirectional lights instead of the specified azimuth for hillshading.</string>
             </property>
             <property name="text">
-             <string/>
+              <string>Use multidirectional lights</string>
             </property>
             <property name="tristate">
              <bool>false</bool>

--- a/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
@@ -122,6 +122,23 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="lblColorModifier">
+            <property name="toolTip">
+             <string>Applies an expression to adjust the colors of the point cloud. The renderer base color is accessible as @value.</string>
+            </property>
+            <property name="text">
+             <string>Color modification</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
+           <widget class="QgsFieldExpressionWidget" name="mColorExpressionWidget" native="true">
+            <property name="focusPolicy">
+             <enum>Qt::FocusPolicy::StrongFocus</enum>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -300,29 +317,6 @@
          </layout>
         </widget>
        </item>
-        <item>
-          <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
-          <property name="title">
-            <string>Color Modification</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,2">
-            <item row="0" column="0">
-            <widget class="QLabel" name="label1">
-              <property name="text">
-              <string>Base color accessible as @value</string>
-              </property>
-            </widget>
-            </item>
-            <item row="0" column="1">
-            <widget class="QgsFieldExpressionWidget" name="mColorExpressionWidget" native="true">
-              <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::StrongFocus</enum>
-              </property>
-            </widget>
-            </item>
-          </layout>
-          </widget>
-        </item>
        <item>
         <widget class="QgsCollapsibleGroupBox" name="mVpcGroupBox">
          <property name="title">
@@ -555,6 +549,11 @@ Select Earlier to switch at a smaller scale (zoomed out) or Later to switch at a
    <class>QgsDirectionalLightWidget</class>
    <extends>QWidget</extends>
    <header>qgsdirectionallightwidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>569</width>
-    <height>618</height>
+    <height>892</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -93,7 +93,7 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_2">
+           <widget class="QLabel" name="lblPointStyle">
             <property name="text">
              <string>Style</string>
             </property>
@@ -116,7 +116,7 @@
            <widget class="QComboBox" name="mPointStyleComboBox"/>
           </item>
           <item row="0" column="0">
-           <widget class="QLabel" name="lblTransparency_4">
+           <widget class="QLabel" name="lblPointSize">
             <property name="text">
              <string>Point size</string>
             </property>
@@ -180,7 +180,7 @@
            </widget>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="label_5">
+           <widget class="QLabel" name="lblEdlDistance">
             <property name="text">
              <string>Distance</string>
             </property>
@@ -194,7 +194,7 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="label_6">
+           <widget class="QLabel" name="lblEdlStrength">
             <property name="text">
              <string>Strength</string>
             </property>
@@ -561,6 +561,20 @@ Select Earlier to switch at a smaller scale (zoomed out) or Later to switch at a
   <tabstop>mPointSizeSpinBox</tabstop>
   <tabstop>mPointSizeUnitWidget</tabstop>
   <tabstop>mPointStyleComboBox</tabstop>
+  <tabstop>mColorExpressionWidget</tabstop>
+  <tabstop>mEyeDomeLightingGroupBox</tabstop>
+  <tabstop>mEdlStrengthSpinBox</tabstop>
+  <tabstop>mEdlDistanceSpinBox</tabstop>
+  <tabstop>mHillshadeGroupBox</tabstop>
+  <tabstop>mHillshadingZFactorSpinBox</tabstop>
+  <tabstop>mHillshadingMultidirCheckBox</tabstop>
+  <tabstop>mTriangulateGroupBox</tabstop>
+  <tabstop>mHorizontalTriangleCheckBox</tabstop>
+  <tabstop>mHorizontalTriangleThresholdSpinBox</tabstop>
+  <tabstop>mZoomOutOptions</tabstop>
+  <tabstop>mLabels</tabstop>
+  <tabstop>mLabelOptions</tabstop>
+  <tabstop>mOverviewSwitchingScale</tabstop>
   <tabstop>mDrawOrderComboBox</tabstop>
   <tabstop>mMaxErrorSpinBox</tabstop>
   <tabstop>mMaxErrorUnitWidget</tabstop>

--- a/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
+++ b/src/ui/pointcloud/qgspointcloudrendererpropsdialogbase.ui
@@ -132,7 +132,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1" colspan="2">
+          <item row="2" column="1" colspan="3">
            <widget class="QgsFieldExpressionWidget" name="mColorExpressionWidget" native="true">
             <property name="focusPolicy">
              <enum>Qt::FocusPolicy::StrongFocus</enum>
@@ -160,7 +160,7 @@
           <property name="sizeConstraint">
            <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
           </property>
-          <item row="3" column="1">
+          <item row="0" column="1" colspan="2">
            <widget class="QgsDoubleSpinBox" name="mEdlStrengthSpinBox">
             <property name="toolTip">
              <string>Adjusts how strong the added shading will be. Greater values mean stronger effect.</string>
@@ -179,28 +179,28 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="1" column="0">
            <widget class="QLabel" name="lblEdlDistance">
             <property name="text">
              <string>Distance</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="1" column="1" colspan="2">
            <widget class="QgsDoubleSpinBox" name="mEdlDistanceSpinBox">
             <property name="toolTip">
              <string>Distance away from the original pixel to sample neighbors.</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="0" column="0">
            <widget class="QLabel" name="lblEdlStrength">
             <property name="text">
              <string>Strength</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="2">
+          <item row="1" column="3">
            <widget class="QgsUnitSelectionWidget" name="mEdlDistanceUnit" native="true"/>
           </item>
          </layout>
@@ -224,7 +224,7 @@
           <property name="sizeConstraint">
            <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
           </property>
-          <item row="0" column="1">
+          <item row="0" column="1" colspan="3">
            <widget class="QgsDoubleSpinBox" name="mHillshadingZFactorSpinBox">
             <property name="toolTip">
              <string>Vertical exageration for hillshading</string>
@@ -267,7 +267,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="2">
+          <item row="2" column="0" colspan="4">
            <widget class="QgsDirectionalLightWidget" name="mDirectionalLightWidget" native="true"/>
           </item>
          </layout>
@@ -298,7 +298,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="0" column="1" colspan="2">
            <widget class="QgsDoubleSpinBox" name="mHorizontalTriangleThresholdSpinBox">
             <property name="toolTip">
              <string>Maximum Triangle Side Size in Horizontal Plan</string>
@@ -311,7 +311,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
+          <item row="0" column="3">
            <widget class="QgsUnitSelectionWidget" name="mHorizontalTriangleUnitWidget" native="true"/>
           </item>
          </layout>
@@ -325,41 +325,34 @@
          <property name="checkable">
           <bool>false</bool>
          </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
          <layout class="QGridLayout" name="gridLayout_3">
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
           <item row="1" column="0">
            <widget class="QCheckBox" name="mLabels">
             <property name="text">
              <string>Show tile labels</string>
             </property>
+            <property name="tristate">
+             <bool>false</bool>
+            </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>301</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
           <item row="0" column="0">
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="lblZoomedOut">
             <property name="text">
              <string>When zoomed out</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1" colspan="2">
+          <item row="0" column="1" colspan="3">
            <widget class="QComboBox" name="mZoomOutOptions"/>
           </item>
-          <item row="1" column="2">
+          <item row="1" column="3">
            <widget class="QgsFontButton" name="mLabelOptions">
             <property name="text">
              <string/>
@@ -367,13 +360,13 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="lblOverviewScale">
             <property name="text">
              <string>Overview switching scale</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" colspan="2">
+           <item row="2" column="1" colspan="3">
            <widget class="QComboBox" name="mOverviewSwitchingScale">
             <property name="toolTip">
              <string>Sets the zoom level at which the individual point cloud files will get rendered instead of the overview or their extents.
@@ -435,8 +428,8 @@ Select Earlier to switch at a smaller scale (zoomed out) or Later to switch at a
           <item row="3" column="1" colspan="3">
            <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>4</horstretch>
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
@@ -452,8 +445,8 @@ Select Earlier to switch at a smaller scale (zoomed out) or Later to switch at a
           <item row="0" column="1" colspan="3">
            <widget class="QComboBox" name="mDrawOrderComboBox">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>4</horstretch>
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>


### PR DESCRIPTION
instead of a dedicated single item group with a parameter label that is not really meaningful.
A proper label is added to the option and information in the current one are moved to the toolTip.
Also harmonize margins and fix tab stops order

No AI tool usage

Before 
<img width="923" height="788" alt="Copie d&#39;écran_20260529_104640" src="https://github.com/user-attachments/assets/d00b964c-037d-48a1-9c7f-d90b73f0a68e" />

After
<img width="911" height="784" alt="Copie d&#39;écran_20260601_171815" src="https://github.com/user-attachments/assets/7bd54130-1443-409e-a5a7-bb062dca52d0" />
