### PR TITLE
[arcgisrest] Handle null outline for fill symbols

### DIFF
--- a/src/core/symbology/converters/qgssymbolconverteresrirest.cpp
+++ b/src/core/symbology/converters/qgssymbolconverteresrirest.cpp
@@ -129,7 +129,7 @@ std::unique_ptr<QgsFillSymbol> QgsSymbolConverterEsriRest::parseEsriFillSymbolJs
 
   // Check if outline is null - ArcGIS services may return "outline": null
   const QVariant outlineVariant = symbolData.value( u"outline"_s );
-  if ( !outlineVariant.isNull() )
+  if ( !QgsVariantUtils::isNull( outlineVariant ) )
   {
     const QVariantMap outlineData = outlineVariant.toMap();
     lineColor = convertColor( outlineData.value( u"color"_s ) );
@@ -181,7 +181,7 @@ std::unique_ptr<QgsFillSymbol> QgsSymbolConverterEsriRest::parseEsriPictureFillS
 
   // Check if outline is null - ArcGIS services may return "outline": null
   const QVariant outlineVariant = symbolData.value( u"outline"_s );
-  if ( !outlineVariant.isNull() )
+  if ( !QgsVariantUtils::isNull( outlineVariant ) )
   {
     const QVariantMap outlineData = outlineVariant.toMap();
     const QColor lineColor = convertColor( outlineData.value( u"color"_s ) );
@@ -238,7 +238,7 @@ std::unique_ptr<QgsMarkerSymbol> QgsSymbolConverterEsriRest::parseEsriMarkerSymb
 
   // Check if outline is null - ArcGIS services may return "outline": null
   const QVariant outlineVariant = symbolData.value( u"outline"_s );
-  if ( !outlineVariant.isNull() )
+  if ( !QgsVariantUtils::isNull( outlineVariant ) )
   {
     const QVariantMap outlineData = outlineVariant.toMap();
     lineColor = convertColor( outlineData.value( u"color"_s ) );

--- a/src/core/symbology/converters/qgssymbolconverteresrirest.cpp
+++ b/src/core/symbology/converters/qgssymbolconverteresrirest.cpp
@@ -123,11 +123,20 @@ std::unique_ptr<QgsFillSymbol> QgsSymbolConverterEsriRest::parseEsriFillSymbolJs
   const QColor fillColor = convertColor( symbolData.value( u"color"_s ) );
   const Qt::BrushStyle brushStyle = convertFillStyle( symbolData.value( u"style"_s ).toString() );
 
-  const QVariantMap outlineData = symbolData.value( u"outline"_s ).toMap();
-  const QColor lineColor = convertColor( outlineData.value( u"color"_s ) );
-  const Qt::PenStyle penStyle = convertLineStyle( outlineData.value( u"style"_s ).toString() );
-  bool ok = false;
-  const double penWidthInPoints = outlineData.value( u"width"_s ).toDouble( &ok );
+  QColor lineColor;
+  Qt::PenStyle penStyle = Qt::NoPen;
+  double penWidthInPoints = 0;
+
+  // Check if outline is null - ArcGIS services may return "outline": null
+  const QVariant outlineVariant = symbolData.value( u"outline"_s );
+  if ( !outlineVariant.isNull() )
+  {
+    const QVariantMap outlineData = outlineVariant.toMap();
+    lineColor = convertColor( outlineData.value( u"color"_s ) );
+    penStyle = convertLineStyle( outlineData.value( u"style"_s ).toString() );
+    bool ok = false;
+    penWidthInPoints = outlineData.value( u"width"_s ).toDouble( &ok );
+  }
 
   QgsSymbolLayerList layers;
   auto fillLayer = std::make_unique< QgsSimpleFillSymbolLayer >( fillColor, brushStyle, lineColor, penStyle, penWidthInPoints );
@@ -170,14 +179,19 @@ std::unique_ptr<QgsFillSymbol> QgsSymbolConverterEsriRest::parseEsriPictureFillS
   fillLayer->setOffsetUnit( Qgis::RenderUnit::Points );
   layers.append( fillLayer.release() );
 
-  const QVariantMap outlineData = symbolData.value( u"outline"_s ).toMap();
-  const QColor lineColor = convertColor( outlineData.value( u"color"_s ) );
-  const Qt::PenStyle penStyle = convertLineStyle( outlineData.value( u"style"_s ).toString() );
-  const double penWidthInPoints = outlineData.value( u"width"_s ).toDouble( &ok );
+  // Check if outline is null - ArcGIS services may return "outline": null
+  const QVariant outlineVariant = symbolData.value( u"outline"_s );
+  if ( !outlineVariant.isNull() )
+  {
+    const QVariantMap outlineData = outlineVariant.toMap();
+    const QColor lineColor = convertColor( outlineData.value( u"color"_s ) );
+    const Qt::PenStyle penStyle = convertLineStyle( outlineData.value( u"style"_s ).toString() );
+    const double penWidthInPoints = outlineData.value( u"width"_s ).toDouble( &ok );
 
-  auto lineLayer = std::make_unique< QgsSimpleLineSymbolLayer >( lineColor, penWidthInPoints, penStyle );
-  lineLayer->setWidthUnit( Qgis::RenderUnit::Points );
-  layers.append( lineLayer.release() );
+    auto lineLayer = std::make_unique< QgsSimpleLineSymbolLayer >( lineColor, penWidthInPoints, penStyle );
+    lineLayer->setWidthUnit( Qgis::RenderUnit::Points );
+    layers.append( lineLayer.release() );
+  }
 
   auto symbol = std::make_unique< QgsFillSymbol >( layers );
   return symbol;
@@ -218,10 +232,19 @@ std::unique_ptr<QgsMarkerSymbol> QgsSymbolConverterEsriRest::parseEsriMarkerSymb
   const double xOffset = symbolData.value( u"xoffset"_s ).toDouble();
   const double yOffset = symbolData.value( u"yoffset"_s ).toDouble();
 
-  const QVariantMap outlineData = symbolData.value( u"outline"_s ).toMap();
-  const QColor lineColor = convertColor( outlineData.value( u"color"_s ) );
-  const Qt::PenStyle penStyle = convertLineStyle( outlineData.value( u"style"_s ).toString() );
-  double penWidthInPoints = outlineData.value( u"width"_s ).toDouble( &ok );
+  QColor lineColor;
+  Qt::PenStyle penStyle = Qt::NoPen;
+  double penWidthInPoints = 0;
+
+  // Check if outline is null - ArcGIS services may return "outline": null
+  const QVariant outlineVariant = symbolData.value( u"outline"_s );
+  if ( !outlineVariant.isNull() )
+  {
+    const QVariantMap outlineData = outlineVariant.toMap();
+    lineColor = convertColor( outlineData.value( u"color"_s ) );
+    penStyle = convertLineStyle( outlineData.value( u"style"_s ).toString() );
+    penWidthInPoints = outlineData.value( u"width"_s ).toDouble( &ok );
+  }
 
   QgsSymbolLayerList layers;
   auto markerLayer = std::make_unique< QgsSimpleMarkerSymbolLayer >( shape, sizeInPoints, angleCW, Qgis::ScaleMethod::ScaleArea, fillColor, lineColor );

--- a/tests/src/core/testqgsarcgisrestutils.cpp
+++ b/tests/src/core/testqgsarcgisrestutils.cpp
@@ -58,10 +58,13 @@ class TestQgsArcGisRestUtils : public QObject
     void testParseEsriLineStyle();
     void testParseEsriColorJson();
     void testParseMarkerSymbol();
+    void testParseMarkerSymbolNullOutline();
     void testPictureMarkerSymbol();
     void testParseLineSymbol();
     void testParseFillSymbol();
+    void testParseFillSymbolNullOutline();
     void testParsePictureFillSymbol();
+    void testParsePictureFillSymbolNullOutline();
     void testParseRendererSimple();
     void testParseRendererCategorized();
     void testParseLabeling();
@@ -341,6 +344,40 @@ void TestQgsArcGisRestUtils::testParseMarkerSymbol()
   QVERIFY( !symbol );
 }
 
+void TestQgsArcGisRestUtils::testParseMarkerSymbolNullOutline()
+{
+  // Test that null outline is handled correctly - should result in no outline
+  const QVariantMap map = jsonStringToMap(
+    "{"
+    "\"type\": \"esriSMS\","
+    "\"style\": \"esriSMSCircle\","
+    "\"color\": ["
+    "115,"
+    "76,"
+    "10,"
+    "200"
+    "],"
+    "\"size\": 8,"
+    "\"angle\": 0,"
+    "\"xoffset\": 0,"
+    "\"yoffset\": 0,"
+    "\"outline\": null"
+    "}"
+  );
+  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsMarkerSymbol *marker = dynamic_cast<QgsMarkerSymbol *>( symbol.get() );
+  QVERIFY( marker );
+  QCOMPARE( marker->symbolLayerCount(), 1 );
+  QgsSimpleMarkerSymbolLayer *markerLayer = dynamic_cast<QgsSimpleMarkerSymbolLayer *>( marker->symbolLayer( 0 ) );
+  QVERIFY( markerLayer );
+  QCOMPARE( markerLayer->color(), QColor( 115, 76, 10, 200 ) );
+  QCOMPARE( markerLayer->size(), 8.0 );
+  QCOMPARE( markerLayer->sizeUnit(), Qgis::RenderUnit::Points );
+  QCOMPARE( markerLayer->shape(), Qgis::MarkerShape::Circle );
+  // Verify no outline
+  QCOMPARE( markerLayer->strokeStyle(), Qt::NoPen );
+}
+
 void TestQgsArcGisRestUtils::testPictureMarkerSymbol()
 {
   const QVariantMap map = jsonStringToMap(
@@ -445,6 +482,35 @@ void TestQgsArcGisRestUtils::testParseFillSymbol()
   QCOMPARE( fillLayer->strokeStyle(), Qt::DashDotLine );
 }
 
+void TestQgsArcGisRestUtils::testParseFillSymbolNullOutline()
+{
+  // Test that null outline is handled correctly - based on real-world ArcGIS service
+  // (ChBfsVolkszaehlungBevoelkerungsstatistikEinwohner)
+  const QVariantMap map = jsonStringToMap(
+    "{"
+    "\"type\": \"esriSFS\","
+    "\"style\": \"esriSFSSolid\","
+    "\"color\": ["
+    "255,"
+    "254,"
+    "180,"
+    "255"
+    "],"
+    "\"outline\": null"
+    "}"
+  );
+  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsFillSymbol *fill = dynamic_cast<QgsFillSymbol *>( symbol.get() );
+  QVERIFY( fill );
+  QCOMPARE( fill->symbolLayerCount(), 1 );
+  QgsSimpleFillSymbolLayer *fillLayer = dynamic_cast<QgsSimpleFillSymbolLayer *>( fill->symbolLayer( 0 ) );
+  QVERIFY( fillLayer );
+  QCOMPARE( fillLayer->fillColor(), QColor( 255, 254, 180, 255 ) );
+  QCOMPARE( fillLayer->brushStyle(), Qt::SolidPattern );
+  // Verify no outline
+  QCOMPARE( fillLayer->strokeStyle(), Qt::NoPen );
+}
+
 
 void TestQgsArcGisRestUtils::testParsePictureFillSymbol()
 {
@@ -485,6 +551,33 @@ void TestQgsArcGisRestUtils::testParsePictureFillSymbol()
   QCOMPARE( lineLayer->width(), 5.0 );
   QCOMPARE( lineLayer->widthUnit(), Qgis::RenderUnit::Points );
   QCOMPARE( lineLayer->penStyle(), Qt::DashDotLine );
+}
+
+void TestQgsArcGisRestUtils::testParsePictureFillSymbolNullOutline()
+{
+  // Test that null outline is handled correctly - picture fill should have no outline layer
+  const QVariantMap map = jsonStringToMap(
+    "{"
+    "\"type\": \"esriPFS\","
+    "\"url\": \"866880A0\","
+    "\"imageData\": \"abcdef\","
+    "\"contentType\": \"image/png\","
+    "\"width\": 20,"
+    "\"height\": 25,"
+    "\"angle\": 0,"
+    "\"outline\": null"
+    "}"
+  );
+  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsFillSymbol *fill = dynamic_cast<QgsFillSymbol *>( symbol.get() );
+  QVERIFY( fill );
+  // With null outline, should only have 1 layer (raster fill), not 2
+  QCOMPARE( fill->symbolLayerCount(), 1 );
+  QgsRasterFillSymbolLayer *fillLayer = dynamic_cast<QgsRasterFillSymbolLayer *>( fill->symbolLayer( 0 ) );
+  QVERIFY( fillLayer );
+  QCOMPARE( fillLayer->imageFilePath(), QString( "base64:abcdef" ) );
+  QCOMPARE( fillLayer->width(), 20.0 );
+  QCOMPARE( fillLayer->sizeUnit(), Qgis::RenderUnit::Points );
 }
 
 void TestQgsArcGisRestUtils::testParseRendererSimple()


### PR DESCRIPTION
## Description

ArcGIS REST services may not return `"outline": {...}` parameter for esriSMS, esriSFS, and esriPFS symbols. Per the [ArcGIS documentation](https://developers.arcgis.com/rest/services-reference/enterprise/symbol-objects/), the outline field is optional in all three cases.

At the moment a black outline is wrongly displayed by default.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
