### PR TITLE
[QObjectUniquePtr] Introduce make_qobject_unique

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -555,7 +555,7 @@ void Qgs3DMapScene::update2DMapOverlay( const QVector<QgsPointXY> &extent2DAsPoi
   if ( !mMapOverlayEntity )
   {
     QgsWindow3DEngine *engine = qobject_cast<QgsWindow3DEngine *>( mEngine );
-    mMapOverlayEntity.reset( new QgsMapOverlayEntity( engine, &overlayRenderView, &mMap, this ) );
+    mMapOverlayEntity = make_qobject_unique<QgsMapOverlayEntity>( engine, &overlayRenderView, &mMap, this );
     mMapOverlayEntity->setEnabled( true );
     overlayRenderView.setEnabled( true );
   }

--- a/src/3d/qgsglobechunkedentity.cpp
+++ b/src/3d/qgsglobechunkedentity.cpp
@@ -467,7 +467,7 @@ class QgsGlobeMapUpdateJobFactory : public QgsChunkQueueJobFactory
 QgsGlobeEntity::QgsGlobeEntity( Qgs3DMapSettings *mapSettings )
   : QgsChunkedEntity( mapSettings, mapSettings->terrainSettings()->maximumScreenError(), new QgsGlobeChunkLoaderFactory( mapSettings ), true )
 {
-  mLayerWatcher.reset( new QgsLayerStyleWatcher( mapSettings ) );
+  mLayerWatcher = make_qobject_unique<QgsLayerStyleWatcher>( mapSettings );
   connect( mLayerWatcher.get(), &QgsLayerStyleWatcher::styleChanged, this, &QgsGlobeEntity::invalidateMapImages );
 
   connect( mapSettings, &Qgs3DMapSettings::showTerrainBoundingBoxesChanged, this, [this, mapSettings] { setShowBoundingBoxes( mapSettings->showTerrainBoundingBoxes() ); } );

--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -76,7 +76,7 @@ QgsRubberBand3D::QgsRubberBand3D( Qgs3DMapSettings &map, QgsAbstract3DEngine *en
 
 void QgsRubberBand3D::setupMarker( Qt3DCore::QEntity *parentEntity )
 {
-  mMarkerEntity.reset( new Qt3DCore::QEntity( parentEntity ) );
+  mMarkerEntity = make_qobject_unique<Qt3DCore::QEntity>( parentEntity );
   mMarkerGeometry = new QgsBillboardGeometry();
   mMarkerGeometryRenderer = new Qt3DRender::QGeometryRenderer;
   mMarkerGeometryRenderer->setPrimitiveType( Qt3DRender::QGeometryRenderer::Points );
@@ -93,7 +93,7 @@ void QgsRubberBand3D::setupMarker( Qt3DCore::QEntity *parentEntity )
 
 void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity )
 {
-  mLineEntity.reset( new Qt3DCore::QEntity( parentEntity ) );
+  mLineEntity = make_qobject_unique<Qt3DCore::QEntity>( parentEntity );
 
   QgsLineVertexData dummyLineData;
   mLineGeometry = dummyLineData.createGeometry( mLineEntity );
@@ -126,7 +126,7 @@ void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity )
 
 void QgsRubberBand3D::setupPolygon( Qt3DCore::QEntity *parentEntity )
 {
-  mPolygonEntity.reset( new Qt3DCore::QEntity( parentEntity ) );
+  mPolygonEntity = make_qobject_unique<Qt3DCore::QEntity>( parentEntity );
 
   mPolygonGeometry = new QgsTessellatedPolygonGeometry();
 

--- a/src/3d/terrain/qgsterrainentity.cpp
+++ b/src/3d/terrain/qgsterrainentity.cpp
@@ -66,7 +66,7 @@ QgsTerrainEntity::QgsTerrainEntity( Qgs3DMapSettings *map, Qt3DCore::QNode *pare
   map->terrainGenerator()->setTerrain( this );
   mIsValid = map->terrainGenerator()->isValid();
 
-  mLayerWatcher.reset( new QgsLayerStyleWatcher( map ) );
+  mLayerWatcher = make_qobject_unique<QgsLayerStyleWatcher>( map );
   connect( mLayerWatcher.get(), &QgsLayerStyleWatcher::styleChanged, this, &QgsTerrainEntity::invalidateMapImages );
 
   connect( map, &Qgs3DMapSettings::showTerrainBoundingBoxesChanged, this, &QgsTerrainEntity::onShowBoundingBoxesChanged );

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -813,20 +813,20 @@ void Qgs3DMapCanvasWidget::setMainCanvas( QgsMapCanvas *canvas )
   connect( mMainCanvas, &QgsMapCanvas::canvasColorChanged, this, &Qgs3DMapCanvasWidget::onMainCanvasColorChanged );
   connect( mMainCanvas, &QgsMapCanvas::extentsChanged, this, &Qgs3DMapCanvasWidget::onMainMapCanvasExtentChanged );
 
-  mCrossSectionRubberBand.reset( new QgsRubberBand( mMainCanvas, Qgis::GeometryType::Polygon ) );
+  mCrossSectionRubberBand = make_qobject_unique<QgsRubberBand>( mMainCanvas, Qgis::GeometryType::Polygon );
   QColor polygonColor = QColorConstants::Red.lighter();
   polygonColor.setAlphaF( 0.5 );
   mCrossSectionRubberBand->setColor( polygonColor );
 
   if ( !mViewFrustumHighlight )
   {
-    mViewFrustumHighlight.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Polygon ) );
+    mViewFrustumHighlight = make_qobject_unique<QgsRubberBand>( canvas, Qgis::GeometryType::Polygon );
     mViewFrustumHighlight->setColor( QColor::fromRgba( qRgba( 0, 0, 255, 50 ) ) );
   }
 
   if ( !mViewExtentHighlight )
   {
-    mViewExtentHighlight.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Polygon ) );
+    mViewExtentHighlight = make_qobject_unique<QgsRubberBand>( canvas, Qgis::GeometryType::Polygon );
     mViewExtentHighlight->setColor( QColor::fromRgba( qRgba( 255, 0, 0, 50 ) ) );
   }
 }

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -43,7 +43,7 @@ Qgs3DMapToolMeasureLine::Qgs3DMapToolMeasureLine( Qgs3DMapCanvasWidget *canvasWi
   : Qgs3DMapTool( canvasWidget->mapCanvas3D() )
 {
   // Dialog
-  mDialog.reset( new Qgs3DMeasureDialog( this, canvasWidget ) );
+  mDialog = make_qobject_unique<Qgs3DMeasureDialog>( this, canvasWidget );
   mDialog->setWindowFlags( mDialog->windowFlags() | Qt::Tool );
   mDialog->restorePosition();
 }

--- a/src/app/3d/qgsmaptoolclippingplanes.cpp
+++ b/src/app/3d/qgsmaptoolclippingplanes.cpp
@@ -39,9 +39,9 @@ QgsMapToolClippingPlanes::QgsMapToolClippingPlanes( QgsMapCanvas *canvas, Qgs3DM
   : QgsMapTool( canvas )
   , m3DCanvasWidget( mapCanvas )
 {
-  mRubberBandPolygon.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Polygon ) );
-  mRubberBandLines.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Line ) );
-  mRubberBandPoints.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Point ) );
+  mRubberBandPolygon = make_qobject_unique<QgsRubberBand>( canvas, Qgis::GeometryType::Polygon );
+  mRubberBandLines = make_qobject_unique<QgsRubberBand>( canvas, Qgis::GeometryType::Line );
+  mRubberBandPoints = make_qobject_unique<QgsRubberBand>( canvas, Qgis::GeometryType::Point );
   mRubberBandPoints->setColor( QColorConstants::Red );
   mRubberBandPoints->setIconSize( 10 );
   mRubberBandLines->setColor( QColorConstants::Red );

--- a/src/app/3d/qgsrulebased3drendererwidget.cpp
+++ b/src/app/3d/qgsrulebased3drendererwidget.cpp
@@ -88,7 +88,7 @@ void QgsRuleBased3DRendererWidget::setLayer( QgsVectorLayer *layer )
     mRootRule = std::make_unique<QgsRuleBased3DRenderer::Rule>( nullptr );
   }
 
-  mModel.reset( new QgsRuleBased3DRendererModel( mRootRule.get() ) );
+  mModel = make_qobject_unique<QgsRuleBased3DRendererModel>( mRootRule.get() );
   viewRules->setModel( mModel );
 
   connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsRuleBased3DRendererWidget::widgetChanged );

--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -731,7 +731,7 @@ void QgsElevationProfileWidget::setMainCanvas( QgsMapCanvas *canvas )
   mCaptureCurveFromFeatureMapTool->setAction( mCaptureCurveFromFeatureAction );
   connect( mCaptureCurveFromFeatureMapTool.get(), &QgsMapToolProfileCurveFromFeature::curveCaptured, this, [this]( const QgsGeometry &curve ) { setProfileCurve( curve, true ); } );
 
-  mMapPointRubberBand.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Point ) );
+  mMapPointRubberBand = make_qobject_unique<QgsRubberBand>( canvas, Qgis::GeometryType::Point );
   mMapPointRubberBand->setZValue( 1000 );
   mMapPointRubberBand->setIcon( QgsRubberBand::ICON_FULL_DIAMOND );
   mMapPointRubberBand->setWidth( QgsGuiUtils::scaleIconSize( 8 ) );
@@ -1372,7 +1372,7 @@ void QgsElevationProfileWidget::createOrUpdateRubberBands()
 {
   if ( !mRubberBand )
   {
-    mRubberBand.reset( new QgsRubberBand( mMainCanvas, Qgis::GeometryType::Line ) );
+    mRubberBand = make_qobject_unique<QgsRubberBand>( mMainCanvas, Qgis::GeometryType::Line );
     mRubberBand->setZValue( 1000 );
     mRubberBand->setWidth( QgsGuiUtils::scaleIconSize( 2 ) );
 
@@ -1425,7 +1425,7 @@ void QgsElevationProfileWidget::createOrUpdateRubberBands()
   {
     if ( !mToleranceRubberBand )
     {
-      mToleranceRubberBand.reset( new QgsRubberBand( mMainCanvas, Qgis::GeometryType::Polygon ) );
+      mToleranceRubberBand = make_qobject_unique<QgsRubberBand>( mMainCanvas, Qgis::GeometryType::Polygon );
       mToleranceRubberBand->setZValue( 999 );
 
       QgsSymbolLayerList layers;

--- a/src/app/labeling/qgsmaptoolrotatelabel.cpp
+++ b/src/app/labeling/qgsmaptoolrotatelabel.cpp
@@ -340,7 +340,7 @@ void QgsMapToolRotateLabel::createRotationPreviewBox()
   if ( boxPoints.empty() )
     return;
 
-  mRotationPreviewBox.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Line ) );
+  mRotationPreviewBox = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Line );
   mRotationPreviewBox->setColor( QColor( 0, 0, 255, 65 ) );
   mRotationPreviewBox->setWidth( 3 );
   setRotationPreviewBox( mCurrentRotation - mStartRotation );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12604,7 +12604,7 @@ void QgisApp::customize()
 
   if ( !mCustomizationDialog )
   {
-    mCustomizationDialog.reset( new QgsCustomizationDialog( this ) );
+    mCustomizationDialog = make_qobject_unique<QgsCustomizationDialog>( this );
   }
 
   mCustomizationDialog->show();

--- a/src/app/qgsmaptoolfeaturearray.cpp
+++ b/src/app/qgsmaptoolfeaturearray.cpp
@@ -45,7 +45,7 @@ void QgsMapToolFeatureArray::activate()
 {
   QgsMapToolAdvancedDigitizing::activate();
 
-  mUserInputWidget.reset( new QgsFeatureArrayUserWidget() );
+  mUserInputWidget = make_qobject_unique< QgsFeatureArrayUserWidget>();
   connect( mUserInputWidget.get(), &QgsFeatureArrayUserWidget::modeChanged, this, [this]( QgsMapToolFeatureArray::ArrayMode mode ) { mMode = mode; } );
   connect( mUserInputWidget.get(), &QgsFeatureArrayUserWidget::featureCountChanged, this, [this]( int value ) {
     mFeatureCount = value;

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -298,12 +298,12 @@ QgsVertexTool::QgsVertexTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWid
   mEndpointMarker->setVisible( false );
 
   // Control polygon for NURBS curves
-  mNurbsControlPolygonBand.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Line ) );
+  mNurbsControlPolygonBand = make_qobject_unique<QgsRubberBand>( canvas, Qgis::GeometryType::Line );
   applyNurbsControlPolygonStyle( mNurbsControlPolygonBand.get() );
   mNurbsControlPolygonBand->setVisible( false );
 
   // Poly-Bézier visualization
-  mBezierMarker.reset( new QgsBezierMarker( canvas, this ) );
+  mBezierMarker = make_qobject_unique<QgsBezierMarker>( canvas, this );
 }
 
 QgsVertexTool::~QgsVertexTool()
@@ -1662,7 +1662,7 @@ void QgsVertexTool::updateVertexEditor( QgsVectorLayer *layer, QgsFeatureId fid 
       return;
     }
 
-    mLockedFeature.reset( new QgsLockedFeature( fid, layer, mCanvas ) );
+    mLockedFeature = make_qobject_unique<QgsLockedFeature>( fid, layer, mCanvas );
     connect( mLockedFeature->layer(), &QgsVectorLayer::featureDeleted, this, &QgsVertexTool::cleanEditor );
     for ( int i = 0; i < mSelectedVertices.length(); ++i )
     {

--- a/src/core/qobjectuniqueptr.h
+++ b/src/core/qobjectuniqueptr.h
@@ -102,7 +102,7 @@ template<class T> class QObjectUniquePtr
 
     inline QObjectUniquePtr<T> &operator=( T *p )
     {
-      mPtr.assign( static_cast<QObjectType *>( p ) );
+      mPtr = static_cast<QObjectType *>( p );
       return *this;
     }
 
@@ -445,5 +445,16 @@ template<class T> inline bool operator!=( const QObjectParentUniquePtr<T> &p1, c
   return p1.operator->() != p2.operator->();
 }
 
+
+/**
+ * Create an object owned by a QObjectUniquePtr.
+ *  \param _Tp A non-array object type.
+ *  \param __args Constructor arguments for the new object.
+ *  Returns A `QObjectUniquePtr` that owns the new object.
+ */
+template<typename _Tp, typename... _Args> constexpr inline QObjectUniquePtr<_Tp> make_qobject_unique( _Args &&...__args )
+{
+  return QObjectUniquePtr<_Tp>( new _Tp( std::forward<_Args>( __args )... ) );
+}
 
 #endif // QOBJECTUNIQUEPTR_H

--- a/src/core/qobjectuniqueptr.h
+++ b/src/core/qobjectuniqueptr.h
@@ -448,13 +448,13 @@ template<class T> inline bool operator!=( const QObjectParentUniquePtr<T> &p1, c
 
 /**
  * Create an object owned by a QObjectUniquePtr.
- *  \tparam _Tp A non-array object type.
- *  \param __args Constructor arguments for the new object.
+ *  \tparam Tp A non-array object type.
+ *  \param args Constructor arguments for the new object.
  *  Returns A `QObjectUniquePtr` that owns the new object.
  */
-template<typename _Tp, typename... _Args> constexpr inline QObjectUniquePtr<_Tp> make_qobject_unique( _Args &&...__args )
+template<typename Tp, typename... Args> constexpr inline QObjectUniquePtr<Tp> make_qobject_unique( Args &&...args )
 {
-  return QObjectUniquePtr<_Tp>( new _Tp( std::forward<_Args>( __args )... ) );
+  return QObjectUniquePtr<Tp>( new Tp( std::forward<Args>( args )... ) );
 }
 
 #endif // QOBJECTUNIQUEPTR_H

--- a/src/core/qobjectuniqueptr.h
+++ b/src/core/qobjectuniqueptr.h
@@ -448,7 +448,7 @@ template<class T> inline bool operator!=( const QObjectParentUniquePtr<T> &p1, c
 
 /**
  * Create an object owned by a QObjectUniquePtr.
- *  \param _Tp A non-array object type.
+ *  \tparam _Tp A non-array object type.
  *  \param __args Constructor arguments for the new object.
  *  Returns A `QObjectUniquePtr` that owns the new object.
  */

--- a/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
+++ b/src/gui/annotations/qgscreateannotationitemmaptool_impl.cpp
@@ -271,7 +271,7 @@ void QgsCreatePictureItemMapTool::cadCanvasPressEvent( QgsMapMouseEvent *event )
     mFirstPoint = event->snapPoint();
     mRect.setRect( mFirstPoint.x(), mFirstPoint.y(), mFirstPoint.x(), mFirstPoint.y() );
 
-    mRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Polygon ) );
+    mRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Polygon );
     mRubberBand->setWidth( digitizingStrokeWidth() );
     QColor color = digitizingStrokeColor();
 
@@ -416,7 +416,7 @@ void QgsCreateRectangleTextItemMapTool::cadCanvasPressEvent( QgsMapMouseEvent *e
     mFirstPoint = event->snapPoint();
     mRect.setRect( mFirstPoint.x(), mFirstPoint.y(), mFirstPoint.x(), mFirstPoint.y() );
 
-    mRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Polygon ) );
+    mRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Polygon );
     mRubberBand->setWidth( digitizingStrokeWidth() );
     QColor color = digitizingStrokeColor();
 

--- a/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolmodifyannotation.cpp
@@ -134,7 +134,7 @@ void QgsMapToolModifyAnnotation::cadCanvasMoveEvent( QgsMapMouseEvent *event )
         std::unique_ptr<QgsAnnotationItemEditOperationTransientResults> operationResults( item->transientEditResultsV2( &operation, context ) );
         if ( operationResults )
         {
-          mTemporaryRubberBand.reset( new QgsRubberBand( mCanvas, operationResults->representativeGeometry().type() ) );
+          mTemporaryRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, operationResults->representativeGeometry().type() );
           const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
           mTemporaryRubberBand->setWidth( scaleFactor );
           mTemporaryRubberBand->setToGeometry( operationResults->representativeGeometry(), layer->crs() );
@@ -163,7 +163,7 @@ void QgsMapToolModifyAnnotation::cadCanvasMoveEvent( QgsMapMouseEvent *event )
         std::unique_ptr<QgsAnnotationItemEditOperationTransientResults> operationResults( item->transientEditResultsV2( &operation, context ) );
         if ( operationResults )
         {
-          mTemporaryRubberBand.reset( new QgsRubberBand( mCanvas, operationResults->representativeGeometry().type() ) );
+          mTemporaryRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, operationResults->representativeGeometry().type() );
           const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
           mTemporaryRubberBand->setWidth( scaleFactor );
           mTemporaryRubberBand->setToGeometry( operationResults->representativeGeometry(), layer->crs() );
@@ -801,7 +801,7 @@ void QgsMapToolModifyAnnotation::createHoverBand()
 {
   const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
 
-  mHoverRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Line ) );
+  mHoverRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Line );
   mHoverRubberBand->setWidth( scaleFactor );
   mHoverRubberBand->setSecondaryStrokeColor( QColor( 255, 255, 255, 100 ) );
   mHoverRubberBand->setColor( QColor( 100, 100, 100, 155 ) );
@@ -811,7 +811,7 @@ void QgsMapToolModifyAnnotation::createHoveredNodeBand()
 {
   const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
 
-  mHoveredNodeRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Point ) );
+  mHoveredNodeRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Point );
   mHoveredNodeRubberBand->setIcon( QgsRubberBand::ICON_FULL_BOX );
   mHoveredNodeRubberBand->setWidth( scaleFactor );
   mHoveredNodeRubberBand->setIconSize( scaleFactor * 5 );
@@ -822,7 +822,7 @@ void QgsMapToolModifyAnnotation::createSelectedItemBand()
 {
   const double scaleFactor = canvas()->fontMetrics().xHeight() * .2;
 
-  mSelectedRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Line ) );
+  mSelectedRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Line );
   mSelectedRubberBand->setWidth( scaleFactor );
   mSelectedRubberBand->setSecondaryStrokeColor( QColor( 255, 255, 255, 100 ) );
   mSelectedRubberBand->setColor( QColor( 50, 50, 50, 200 ) );

--- a/src/gui/annotations/qgsmaptoolselectannotation.cpp
+++ b/src/gui/annotations/qgsmaptoolselectannotation.cpp
@@ -107,7 +107,7 @@ QgsMapToolSelectAnnotation::~QgsMapToolSelectAnnotation()
 
 void QgsMapToolSelectAnnotation::activate()
 {
-  mMouseHandles.reset( new QgsMapToolSelectAnnotationMouseHandles( this, mCanvas ) );
+  mMouseHandles = make_qobject_unique<QgsMapToolSelectAnnotationMouseHandles>( this, mCanvas );
 
   QgsMapToolAdvancedDigitizing::activate();
 }
@@ -176,7 +176,7 @@ void QgsMapToolSelectAnnotation::cadCanvasMoveEvent( QgsMapMouseEvent *event )
       if ( !mDragging )
       {
         mDragging = true;
-        mSelectionRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Polygon ) );
+        mSelectionRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Polygon );
         QColor color( Qt::blue );
         color.setAlpha( 63 );
         mSelectionRubberBand->setColor( color );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -344,12 +344,12 @@ void QgsRelationReferenceWidget::setEditorContext( const QgsAttributeEditorConte
   mCanvas = canvas;
   mMessageBar = messageBar;
 
-  mMapToolIdentify.reset( new QgsMapToolIdentifyFeature( mCanvas ) );
+  mMapToolIdentify = make_qobject_unique<QgsMapToolIdentifyFeature>( mCanvas );
   mMapToolIdentify->setButton( mMapIdentificationButton );
 
   if ( mEditorContext.cadDockWidget() )
   {
-    mMapToolDigitize.reset( new QgsMapToolDigitizeFeature( mCanvas, mEditorContext.cadDockWidget() ) );
+    mMapToolDigitize = make_qobject_unique<QgsMapToolDigitizeFeature>( mCanvas, mEditorContext.cadDockWidget() );
     mMapToolDigitize->setButton( mAddEntryButton );
     updateAddEntryButton();
   }

--- a/src/gui/maptools/qgsmaptoolextent.cpp
+++ b/src/gui/maptools/qgsmaptoolextent.cpp
@@ -24,7 +24,7 @@
 QgsMapToolExtent::QgsMapToolExtent( QgsMapCanvas *canvas )
   : QgsMapTool( canvas )
 {
-  mRubberBand.reset( new QgsRubberBand( canvas, Qgis::GeometryType::Polygon ) );
+  mRubberBand = make_qobject_unique<QgsRubberBand>( canvas, Qgis::GeometryType::Polygon );
 }
 
 void QgsMapToolExtent::activate()

--- a/src/gui/maptools/qgsmaptoolextraitem.cpp
+++ b/src/gui/maptools/qgsmaptoolextraitem.cpp
@@ -470,7 +470,7 @@ void QgsMapToolModifyExtraItems::canvasPressEvent( QgsMapMouseEvent *e )
   {
     case State::SelectFeature:
       selectFeature( e );
-      mMouseHandles.reset( new QgsMapToolModifyExtraItemMouseHandles( this, mCanvas ) );
+      mMouseHandles = make_qobject_unique<QgsMapToolModifyExtraItemMouseHandles>( this, mCanvas );
       break;
 
     case State::FeatureSelected:
@@ -547,7 +547,7 @@ void QgsMapToolModifyExtraItems::canvasMoveEvent( QgsMapMouseEvent *event )
           if ( !mDragging )
           {
             mDragging = true;
-            mSelectionRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Polygon ) );
+            mSelectionRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Polygon );
             QColor color( Qt::blue );
             color.setAlpha( 63 );
             mSelectionRubberBand->setColor( color );

--- a/src/gui/maptools/qgsmaptoolzoom.cpp
+++ b/src/gui/maptools/qgsmaptoolzoom.cpp
@@ -60,7 +60,7 @@ void QgsMapToolZoom::canvasMoveEvent( QgsMapMouseEvent *e )
   if ( !mDragging )
   {
     mDragging = true;
-    mRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Polygon ) );
+    mRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Polygon );
 
     QColor color( Qt::blue );
     color.setAlpha( 63 );

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -335,7 +335,7 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
 
   // We use a QObjectUniquePtr here because we want to delete QgsModelViewToolSelect
   // mouse handles before everything else and don't want to wait for QObject destructor to destroy it
-  mSelectTool.reset( new QgsModelViewToolSelect( mView ) );
+  mSelectTool = make_qobject_unique<QgsModelViewToolSelect>( mView );
   mSelectTool->setAction( mActionSelectMoveItem );
 
   mToolsActionGroup->addAction( mActionSelectMoveItem );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -4011,7 +4011,7 @@ void QgsProcessingPointPanel::updateRubberBand()
 
   if ( !mMapPointRubberBand )
   {
-    mMapPointRubberBand.reset( new QgsRubberBand( mCanvas, Qgis::GeometryType::Point ) );
+    mMapPointRubberBand = make_qobject_unique<QgsRubberBand>( mCanvas, Qgis::GeometryType::Point );
     mMapPointRubberBand->setZValue( 1000 );
     mMapPointRubberBand->setIcon( QgsRubberBand::ICON_X );
 

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -291,7 +291,7 @@ void QgsRelationEditorWidget::setEditorContext( const QgsAttributeEditorContext 
 
   if ( context.mapCanvas() && context.cadDockWidget() )
   {
-    mMapToolDigitize.reset( new QgsMapToolDigitizeFeature( context.mapCanvas(), context.cadDockWidget() ) );
+    mMapToolDigitize = make_qobject_unique<QgsMapToolDigitizeFeature>( context.mapCanvas(), context.cadDockWidget() );
     mMapToolDigitize->setButton( mAddFeatureGeometryButton );
   }
 

--- a/src/gui/stac/qgsstacsourceselect.cpp
+++ b/src/gui/stac/qgsstacsourceselect.cpp
@@ -590,7 +590,7 @@ void QgsStacSourceSelect::highlightFootprint( const QModelIndex &index )
   QgsGeometry geom = index.data( QgsStacItemListModel::Role::Geometry ).value<QgsGeometry>();
   if ( QgsMapCanvas *map = mapCanvas() )
   {
-    mCurrentItemBand.reset( new QgsRubberBand( map, Qgis::GeometryType::Polygon ) );
+    mCurrentItemBand = make_qobject_unique<QgsRubberBand>( map, Qgis::GeometryType::Polygon );
     mCurrentItemBand->setFillColor( QColor::fromRgb( 255, 0, 0, 128 ) );
     mCurrentItemBand->setToGeometry( geom, QgsCoordinateReferenceSystem::fromEpsgId( 4326 ) );
   }

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -2441,11 +2441,11 @@ void QgsTemplatedLineSymbolLayerWidget::toggleMapToolEditBlankSegments( bool tog
   switch ( mSymbolType )
   {
     case TemplatedSymbolType::Hash:
-      mMapToolEditBlankSegments.reset( new QgsMapToolEditBlankSegments<QgsHashedLineSymbolLayer>( context().mapCanvas(), vectorLayer(), mLayer, mBlankSegmentsDDButton ) );
+      mMapToolEditBlankSegments = make_qobject_unique<QgsMapToolEditBlankSegments<QgsHashedLineSymbolLayer>>( context().mapCanvas(), vectorLayer(), mLayer, mBlankSegmentsDDButton );
       break;
 
     case TemplatedSymbolType::Marker:
-      mMapToolEditBlankSegments.reset( new QgsMapToolEditBlankSegments<QgsMarkerLineSymbolLayer>( context().mapCanvas(), vectorLayer(), mLayer, mBlankSegmentsDDButton ) );
+      mMapToolEditBlankSegments = make_qobject_unique<QgsMapToolEditBlankSegments<QgsMarkerLineSymbolLayer>>( context().mapCanvas(), vectorLayer(), mLayer, mBlankSegmentsDDButton );
       break;
   }
 
@@ -2458,7 +2458,7 @@ void QgsTemplatedLineSymbolLayerWidget::toggleMapToolAddExtraItem( bool toggled 
   if ( !toggled || ( mMapToolAddExtraItem.get() && context().mapCanvas()->mapTool() == mMapToolAddExtraItem.get() ) )
     return;
 
-  mMapToolAddExtraItem.reset( new QgsMapToolAddExtraItem( context().mapCanvas(), vectorLayer(), mLayer, mExtraItemsDDBtn ) );
+  mMapToolAddExtraItem = make_qobject_unique<QgsMapToolAddExtraItem>( context().mapCanvas(), vectorLayer(), mLayer, mExtraItemsDDBtn );
   mMapToolAddExtraItem->setAction( mAddExtraItemAction );
   context().mapCanvas()->setMapTool( mMapToolAddExtraItem );
 }
@@ -2468,7 +2468,7 @@ void QgsTemplatedLineSymbolLayerWidget::toggleMapToolModifyExtraItem( bool toggl
   if ( !toggled || ( mMapToolModifyExtraItem.get() && context().mapCanvas()->mapTool() == mMapToolModifyExtraItem.get() ) )
     return;
 
-  mMapToolModifyExtraItem.reset( new QgsMapToolModifyExtraItems( context().mapCanvas(), vectorLayer(), mLayer, mExtraItemsDDBtn ) );
+  mMapToolModifyExtraItem = make_qobject_unique<QgsMapToolModifyExtraItems>( context().mapCanvas(), vectorLayer(), mLayer, mExtraItemsDDBtn );
   mMapToolModifyExtraItem->setAction( mModifyExtraItemAction );
   context().mapCanvas()->setMapTool( mMapToolModifyExtraItem );
 }

--- a/src/plugins/topology/checkDock.cpp
+++ b/src/plugins/topology/checkDock.cpp
@@ -64,9 +64,9 @@ checkDock::checkDock( QgisInterface *qIface, QWidget *parent )
   mTestTable = mConfigureDialog->rulesTable();
 
   QgsMapCanvas *canvas = qIface->mapCanvas(); // mQgisApp->mapCanvas();
-  mRBFeature1.reset( new QgsRubberBand( canvas ) );
-  mRBFeature2.reset( new QgsRubberBand( canvas ) );
-  mRBConflict.reset( new QgsRubberBand( canvas ) );
+  mRBFeature1 = make_qobject_unique<QgsRubberBand>( canvas );
+  mRBFeature2 = make_qobject_unique<QgsRubberBand>( canvas );
+  mRBConflict = make_qobject_unique<QgsRubberBand>( canvas );
 
   mRBFeature1->setColor( QColor( 0, 0, 255, 65 ) );
   mRBFeature2->setColor( QColor( 0, 255, 0, 65 ) );

--- a/tests/src/gui/testqgsmaptooleditblanksegments.cpp
+++ b/tests/src/gui/testqgsmaptooleditblanksegments.cpp
@@ -112,7 +112,7 @@ void TestQgsMapToolEditBlankSegments::cleanupTestCase()
 
 void TestQgsMapToolEditBlankSegments::init()
 {
-  mMapToolEditBlankSegments.reset( new QgsMapToolEditBlankSegments<QgsMarkerLineSymbolLayer>( mCanvas.get(), mLayer.get(), mSymbolLayer, mPropertyButton.get() ) );
+  mMapToolEditBlankSegments = make_qobject_unique<QgsMapToolEditBlankSegments<QgsMarkerLineSymbolLayer>>( mCanvas.get(), mLayer.get(), mSymbolLayer, mPropertyButton.get() );
   mCanvas->setMapTool( mMapToolEditBlankSegments );
 }
 

--- a/tests/src/gui/testqgsmaptoolextraitem.cpp
+++ b/tests/src/gui/testqgsmaptoolextraitem.cpp
@@ -114,10 +114,10 @@ void TestQgsMapToolExtraItem::cleanupTestCase()
 
 void TestQgsMapToolExtraItem::init()
 {
-  mMapToolAddExtraItems.reset( new QgsMapToolAddExtraItem( mCanvas.get(), mLayer.get(), mSymbolLayer, mPropertyButton.get() ) );
+  mMapToolAddExtraItems = make_qobject_unique<QgsMapToolAddExtraItem>( mCanvas.get(), mLayer.get(), mSymbolLayer, mPropertyButton.get() );
   mCanvas->setMapTool( mMapToolAddExtraItems );
 
-  mMapToolModifyExtraItems.reset( new QgsMapToolModifyExtraItems( mCanvas.get(), mLayer.get(), mSymbolLayer, mPropertyButton.get() ) );
+  mMapToolModifyExtraItems = make_qobject_unique<QgsMapToolModifyExtraItems>( mCanvas.get(), mLayer.get(), mSymbolLayer, mPropertyButton.get() );
   mCanvas->setMapTool( mMapToolModifyExtraItems );
 }
 


### PR DESCRIPTION
`make_qobject_unique` to create a QObjectUniquePtr. This mimic the std::unique_ptr `make_unique` function.

## AI tool usage

None

**Funded by [Security Project For QGIS](https://oslandia.com/en/security-project-for-qgis/)**
