### PR TITLE
do not return virtual file system path as default path in the file content widget (refs #37308)

### DIFF
--- a/src/gui/layout/qgslayoutpicturewidget.cpp
+++ b/src/gui/layout/qgslayoutpicturewidget.cpp
@@ -49,7 +49,7 @@ QgsLayoutPictureWidget::QgsLayoutPictureWidget( QgsLayoutItemPicture *picture )
 
   mSvgSelectorWidget->setAllowParameters( true );
   mSvgSelectorWidget->sourceLineEdit()->setPropertyOverrideToolButtonVisible( true );
-  mSvgSelectorWidget->sourceLineEdit()->setLastPathSettingsKey( u"/UI/lastSVGMarkerDir"_s );
+  mSvgSelectorWidget->sourceLineEdit()->setLastPathSettingsKey( u"/UI/lastComposerPictureDir"_s );
   mSvgSelectorWidget->initParametersModel( layoutObject(), coverageLayer() );
 
   mResizeModeComboBox->addItem( tr( "Zoom" ), QgsLayoutItemPicture::Zoom );
@@ -97,8 +97,6 @@ QgsLayoutPictureWidget::QgsLayoutPictureWidget( QgsLayoutItemPicture *picture )
     mPicture->setClippingItem( item );
     mPicture->endCommand();
   } );
-
-  mSvgSelectorWidget->sourceLineEdit()->setLastPathSettingsKey( u"/UI/lastComposerPictureDir"_s );
 
   setPanelTitle( tr( "Picture Properties" ) );
 

--- a/src/gui/qgsfilecontentsourcelineedit.cpp
+++ b/src/gui/qgsfilecontentsourcelineedit.cpp
@@ -273,7 +273,7 @@ void QgsAbstractFileContentSourceLineEdit::mFileLineEdit_textEdited( const QStri
 
 QString QgsAbstractFileContentSourceLineEdit::defaultPath() const
 {
-  if ( QFileInfo::exists( source() ) )
+  if ( QFileInfo( source() ).isNativePath() && QFileInfo::exists( source() ) )
     return source();
 
   return QgsSettings().value( settingsKey(), QDir::homePath() ).toString();


### PR DESCRIPTION
## Description

North arrow layout item uses `:/images/north_arrows/layout_default_north_arrow.svg` as a default image. When user tries to change image by clicking on "…" button the file dialog will use this path as a working directory (if this is a first time action and last used path is not saved in the QGIS settings) and as this is not an actual path on the filesystem, user will see a warning message "The file or folder does not exists".

We should not use virtual file system paths as a default path for file dialogs.

Refs #37308.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.