### PR TITLE
[arcgisrest] Support rotation for symbols based on fields

### DIFF
--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -107,19 +107,37 @@ Converts a spatial reference JSON definition to a
 :py:class:`QgsCoordinateReferenceSystem` value.
 %End
 
-    static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition );
+    static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition, QgsSymbolConverterContext &context );
 %Docstring
 Converts a symbol JSON ``definition`` to a :py:class:`QgsSymbol`.
 
-Caller takes ownership of the returned symbol.
+:param definition: symbol JSON definition
+:param context: conversion context, used to collect warnings and errors
+                encountered during conversion.
+
+:return: the converted symbol, or None on failure. Caller takes
+         ownership of the returned symbol.
+
+.. note::
+
+   The ``context`` parameter was added in QGIS 4.2
 %End
 
-    static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData );
+    static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData, QgsSymbolConverterContext &context );
 %Docstring
 Converts renderer JSON ``data`` to an equivalent
 :py:class:`QgsFeatureRenderer`.
 
-Caller takes ownership of the returned renderer.
+:param rendererData: renderer JSON data
+:param context: conversion context, used to collect warnings and errors
+                encountered during conversion.
+
+:return: the converted renderer, or None on failure. Caller takes
+         ownership of the returned renderer.
+
+.. note::
+
+   The ``context`` parameter was added in QGIS 4.2
 %End
 
     static std::unique_ptr< QgsAbstractVectorLayerLabeling > convertLabeling( const QVariantList &data );

--- a/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
+++ b/python/PyQt6/core/auto_generated/providers/arcgis/qgsarcgisrestutils.sip.in
@@ -123,6 +123,20 @@ Converts a symbol JSON ``definition`` to a :py:class:`QgsSymbol`.
    The ``context`` parameter was added in QGIS 4.2
 %End
 
+ static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition ) /Deprecated="Since 4.2. Use the overload with a QgsSymbolConverterContext argument instead."/;
+%Docstring
+Converts a symbol JSON ``definition`` to a :py:class:`QgsSymbol`.
+
+:param definition: symbol JSON definition
+
+:return: the converted symbol, or None on failure. Caller takes
+         ownership of the returned symbol.
+
+.. deprecated:: 4.2
+
+   Use the overload with a :py:class:`QgsSymbolConverterContext` argument instead.
+%End
+
     static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData, QgsSymbolConverterContext &context );
 %Docstring
 Converts renderer JSON ``data`` to an equivalent
@@ -138,6 +152,21 @@ Converts renderer JSON ``data`` to an equivalent
 .. note::
 
    The ``context`` parameter was added in QGIS 4.2
+%End
+
+ static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData ) /Deprecated="Since 4.2. Use the overload with a QgsSymbolConverterContext argument instead."/;
+%Docstring
+Converts renderer JSON ``data`` to an equivalent
+:py:class:`QgsFeatureRenderer`.
+
+:param rendererData: renderer JSON data
+
+:return: the converted renderer, or None on failure. Caller takes
+         ownership of the returned renderer.
+
+.. deprecated:: 4.2
+
+   Use the overload with a :py:class:`QgsSymbolConverterContext` argument instead.
 %End
 
     static std::unique_ptr< QgsAbstractVectorLayerLabeling > convertLabeling( const QVariantList &data );

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -626,10 +626,8 @@ QgsCoordinateReferenceSystem QgsArcGisRestUtils::convertSpatialReference( const 
   return crs;
 }
 
-std::unique_ptr< QgsSymbol > QgsArcGisRestUtils::convertSymbol( const QVariantMap &symbolData )
+std::unique_ptr< QgsSymbol > QgsArcGisRestUtils::convertSymbol( const QVariantMap &symbolData, QgsSymbolConverterContext &context )
 {
-  QgsReadWriteContext rwContext;
-  QgsSymbolConverterContext context( rwContext );
   return QgsSymbolConverterEsriRest().createSymbol( symbolData, context );
 }
 
@@ -762,7 +760,7 @@ std::unique_ptr<QgsAbstractVectorLayerLabeling > QgsArcGisRestUtils::convertLabe
   return std::make_unique< QgsRuleBasedLabeling >( root );
 }
 
-void QgsArcGisRestUtils::applyVisualVariables( const QVariantMap &rendererData, QgsSymbol *symbol )
+void QgsArcGisRestUtils::applyVisualVariables( const QVariantMap &rendererData, QgsSymbol *symbol, QgsSymbolConverterContext &context )
 {
   if ( !symbol )
     return;
@@ -780,7 +778,7 @@ void QgsArcGisRestUtils::applyVisualVariables( const QVariantMap &rendererData, 
       {
         // Check if it was a valueExpression that we don't support yet
         if ( !visualVariableData.value( u"valueExpression"_s ).toString().isEmpty() )
-          QgsDebugError( u"ESRI rotationInfo valueExpression is not yet supported"_s );
+          context.pushWarning( QObject::tr( "ESRI rotationInfo valueExpression is not yet supported" ) );
         continue;
       }
 
@@ -801,7 +799,7 @@ void QgsArcGisRestUtils::applyVisualVariables( const QVariantMap &rendererData, 
       }
       else
       {
-        QgsDebugError( u"ESRI rotationInfo rotationType '%1' is not supported."_s.arg( rotationType ) );
+        context.pushWarning( QObject::tr( "ESRI rotationInfo rotationType '%1' is not supported" ).arg( rotationType ) );
         continue;
       }
 
@@ -813,36 +811,36 @@ void QgsArcGisRestUtils::applyVisualVariables( const QVariantMap &rendererData, 
     }
     else
     {
-      QgsDebugError( u"ESRI visualVariable type %1 is not currently supported"_s.arg( variableType ) );
+      context.pushWarning( QObject::tr( "ESRI visualVariable type '%1' is not currently supported" ).arg( variableType ) );
     }
   }
 }
 
-void QgsArcGisRestUtils::applyVisualVariablesToRenderer( const QVariantMap &rendererData, QgsFeatureRenderer *renderer )
+void QgsArcGisRestUtils::applyVisualVariablesToRenderer( const QVariantMap &rendererData, QgsFeatureRenderer *renderer, QgsSymbolConverterContext &context )
 {
   if ( !renderer )
     return;
 
   // Apply visual variables to all symbols in the renderer
-  QgsRenderContext context;
-  const QgsSymbolList symbols = renderer->symbols( context );
+  QgsRenderContext renderContext;
+  const QgsSymbolList symbols = renderer->symbols( renderContext );
   for ( QgsSymbol *symbol : symbols )
   {
-    applyVisualVariables( rendererData, symbol );
+    applyVisualVariables( rendererData, symbol, context );
   }
 }
 
-std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const QVariantMap &rendererData )
+std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const QVariantMap &rendererData, QgsSymbolConverterContext &context )
 {
   const QString type = rendererData.value( u"type"_s ).toString();
   if ( type == "simple"_L1 )
   {
     const QVariantMap symbolProps = rendererData.value( u"symbol"_s ).toMap();
-    std::unique_ptr< QgsSymbol > symbol( convertSymbol( symbolProps ) );
+    std::unique_ptr< QgsSymbol > symbol( convertSymbol( symbolProps, context ) );
     if ( symbol )
     {
       // Apply visual variables (e.g., rotation) to the symbol
-      applyVisualVariables( rendererData, symbol.get() );
+      applyVisualVariables( rendererData, symbol.get(), context );
       return std::make_unique< QgsSingleSymbolRenderer >( symbol.release() );
     }
     else
@@ -878,14 +876,14 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
       const QVariantMap categoryData = category.toMap();
       const QString value = categoryData.value( u"value"_s ).toString();
       const QString label = categoryData.value( u"label"_s ).toString();
-      std::unique_ptr< QgsSymbol > symbol( QgsArcGisRestUtils::convertSymbol( categoryData.value( u"symbol"_s ).toMap() ) );
+      std::unique_ptr< QgsSymbol > symbol( QgsArcGisRestUtils::convertSymbol( categoryData.value( u"symbol"_s ).toMap(), context ) );
       if ( symbol )
       {
         categoryList.append( QgsRendererCategory( value, symbol.release(), label ) );
       }
     }
 
-    std::unique_ptr< QgsSymbol > defaultSymbol( convertSymbol( rendererData.value( u"defaultSymbol"_s ).toMap() ) );
+    std::unique_ptr< QgsSymbol > defaultSymbol( convertSymbol( rendererData.value( u"defaultSymbol"_s ).toMap(), context ) );
     if ( defaultSymbol )
     {
       categoryList.append( QgsRendererCategory( QVariant(), defaultSymbol.release(), rendererData.value( u"defaultLabel"_s ).toString() ) );
@@ -897,7 +895,7 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
     auto renderer = std::make_unique< QgsCategorizedSymbolRenderer >( attribute, categoryList );
 
     // Apply visual variables (e.g., rotation) to all category symbols
-    applyVisualVariablesToRenderer( rendererData, renderer.get() );
+    applyVisualVariablesToRenderer( rendererData, renderer.get(), context );
 
     return renderer;
   }
@@ -919,7 +917,7 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
     {
       symbolData = classBreakInfos.at( 0 ).toMap().value( u"symbol"_s ).toMap();
     }
-    std::unique_ptr< QgsSymbol > symbol( QgsArcGisRestUtils::convertSymbol( symbolData ) );
+    std::unique_ptr< QgsSymbol > symbol( QgsArcGisRestUtils::convertSymbol( symbolData, context ) );
     if ( !symbol )
       return nullptr;
 
@@ -984,7 +982,7 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
       }
       else
       {
-        QgsDebugError( u"ESRI visualVariable type %1 is not currently supported"_s.arg( variableType ) );
+        context.pushWarning( QObject::tr( "ESRI visualVariable type '%1' is not currently supported" ).arg( variableType ) );
       }
     }
 
@@ -1031,13 +1029,13 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
     }
     else if ( !esriMode.isEmpty() )
     {
-      QgsDebugError( u"ESRI classification mode %1 is not currently supported"_s.arg( esriMode ) );
+      context.pushWarning( QObject::tr( "ESRI classification mode '%1' is not currently supported" ).arg( esriMode ) );
     }
 
     for ( const QVariant &classBreakInfo : classBreakInfos )
     {
       const QVariantMap symbolData = classBreakInfo.toMap().value( u"symbol"_s ).toMap();
-      std::unique_ptr< QgsSymbol > symbol( QgsArcGisRestUtils::convertSymbol( symbolData ) );
+      std::unique_ptr< QgsSymbol > symbol( QgsArcGisRestUtils::convertSymbol( symbolData, context ) );
       double classMaxValue = classBreakInfo.toMap().value( u"classMaxValue"_s ).toDouble();
       const QString label = classBreakInfo.toMap().value( u"label"_s ).toString();
 
@@ -1053,7 +1051,7 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
     }
 
     // Apply visual variables (e.g., rotation) to all class symbols
-    applyVisualVariablesToRenderer( rendererData, graduatedRenderer.get() );
+    applyVisualVariablesToRenderer( rendererData, graduatedRenderer.get(), context );
 
     return graduatedRenderer;
   }

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -794,13 +794,15 @@ void QgsArcGisRestUtils::applyVisualVariables( const QVariantMap &rendererData, 
         // Conversion: QGIS_angle = 90 - ArcGIS_angle
         angleProperty = QgsProperty::fromExpression( u"90 - %1"_s.arg( QgsExpression::quotedColumnRef( field ) ) );
       }
-      else
+      else if ( rotationType == "geographic"_L1 )
       {
-        if ( rotationType != "geographic"_L1 )
-          QgsDebugError( u"ESRI rotationInfo rotationType '%1' is not supported, defaulting to 'geographic'"_s.arg( rotationType ) );
-
         // ArcGIS geographic: 0° = North, clockwise (same as QGIS)
         angleProperty = QgsProperty::fromField( field );
+      }
+      else
+      {
+        QgsDebugError( u"ESRI rotationInfo rotationType '%1' is not supported."_s.arg( rotationType ) );
+        continue;
       }
 
       // Apply rotation to all symbol layers

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -823,20 +823,6 @@ void QgsArcGisRestUtils::applyVisualVariables( const QVariantMap &rendererData, 
   }
 }
 
-void QgsArcGisRestUtils::applyVisualVariablesToRenderer( const QVariantMap &rendererData, QgsFeatureRenderer *renderer, QgsSymbolConverterContext &context )
-{
-  if ( !renderer )
-    return;
-
-  // Apply visual variables to all symbols in the renderer
-  QgsRenderContext renderContext;
-  const QgsSymbolList symbols = renderer->symbols( renderContext );
-  for ( QgsSymbol *symbol : symbols )
-  {
-    applyVisualVariables( rendererData, symbol, context );
-  }
-}
-
 std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const QVariantMap &rendererData, QgsSymbolConverterContext &context )
 {
   const QString type = rendererData.value( u"type"_s ).toString();
@@ -886,6 +872,9 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
       std::unique_ptr< QgsSymbol > symbol( QgsArcGisRestUtils::convertSymbol( categoryData.value( u"symbol"_s ).toMap(), context ) );
       if ( symbol )
       {
+        // Apply visual variables (e.g., rotation) to the symbol
+        applyVisualVariables( rendererData, symbol.get(), context );
+
         categoryList.append( QgsRendererCategory( value, symbol.release(), label ) );
       }
     }
@@ -893,6 +882,9 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
     std::unique_ptr< QgsSymbol > defaultSymbol( convertSymbol( rendererData.value( u"defaultSymbol"_s ).toMap(), context ) );
     if ( defaultSymbol )
     {
+      // Apply visual variables (e.g., rotation) to the symbol
+      applyVisualVariables( rendererData, defaultSymbol.get(), context );
+
       categoryList.append( QgsRendererCategory( QVariant(), defaultSymbol.release(), rendererData.value( u"defaultLabel"_s ).toString() ) );
     }
 
@@ -900,10 +892,6 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
       return nullptr;
 
     auto renderer = std::make_unique< QgsCategorizedSymbolRenderer >( attribute, categoryList );
-
-    // Apply visual variables (e.g., rotation) to all category symbols
-    applyVisualVariablesToRenderer( rendererData, renderer.get(), context );
-
     return renderer;
   }
   else if ( type == "classBreaks"_L1 )
@@ -1046,6 +1034,9 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
       double classMaxValue = classBreakInfo.toMap().value( u"classMaxValue"_s ).toDouble();
       const QString label = classBreakInfo.toMap().value( u"label"_s ).toString();
 
+      // Apply visual variables (e.g., rotation) to the symbol
+      applyVisualVariables( rendererData, symbol.get(), context );
+
       QgsRendererRange range;
 
       range.setLowerValue( lastValue );
@@ -1056,9 +1047,6 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
       lastValue = classMaxValue;
       graduatedRenderer->addClass( range );
     }
-
-    // Apply visual variables (e.g., rotation) to all class symbols
-    applyVisualVariablesToRenderer( rendererData, graduatedRenderer.get(), context );
 
     return graduatedRenderer;
   }

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -631,6 +631,13 @@ std::unique_ptr< QgsSymbol > QgsArcGisRestUtils::convertSymbol( const QVariantMa
   return QgsSymbolConverterEsriRest().createSymbol( symbolData, context );
 }
 
+std::unique_ptr< QgsSymbol > QgsArcGisRestUtils::convertSymbol( const QVariantMap &symbolData )
+{
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  return convertSymbol( symbolData, context );
+}
+
 std::unique_ptr<QgsAbstractVectorLayerLabeling > QgsArcGisRestUtils::convertLabeling( const QVariantList &labelingData )
 {
   if ( labelingData.empty() )
@@ -1066,6 +1073,13 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
     return nullptr;
   }
   return nullptr;
+}
+
+std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const QVariantMap &rendererData )
+{
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  return convertRenderer( rendererData, context );
 }
 
 QString QgsArcGisRestUtils::convertLabelingExpression( const QString &string )

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -762,6 +762,74 @@ std::unique_ptr<QgsAbstractVectorLayerLabeling > QgsArcGisRestUtils::convertLabe
   return std::make_unique< QgsRuleBasedLabeling >( root );
 }
 
+void QgsArcGisRestUtils::applyVisualVariables( const QVariantMap &rendererData, QgsSymbol *symbol )
+{
+  if ( !symbol )
+    return;
+
+  const QVariantList visualVariablesData = rendererData.value( u"visualVariables"_s ).toList();
+  for ( const QVariant &visualVariable : visualVariablesData )
+  {
+    const QVariantMap visualVariableData = visualVariable.toMap();
+    const QString variableType = visualVariableData.value( u"type"_s ).toString();
+
+    if ( variableType == "rotationInfo"_L1 )
+    {
+      const QString field = visualVariableData.value( u"field"_s ).toString();
+      if ( field.isEmpty() )
+      {
+        // Check if it was a valueExpression that we don't support yet
+        if ( !visualVariableData.value( u"valueExpression"_s ).toString().isEmpty() )
+          QgsDebugError( u"ESRI rotationInfo valueExpression is not yet supported"_s );
+        continue;
+      }
+
+      const QString rotationType = visualVariableData.value( u"rotationType"_s ).toString();
+
+      QgsProperty angleProperty;
+      if ( rotationType == "arithmetic"_L1 )
+      {
+        // ArcGIS arithmetic: 0° = East, counter-clockwise
+        // QGIS: 0° = North, clockwise
+        // Conversion: QGIS_angle = 90 - ArcGIS_angle
+        angleProperty = QgsProperty::fromExpression( u"90 - \"%1\""_s.arg( field ) );
+      }
+      else
+      {
+        if ( rotationType != "geographic"_L1 )
+          QgsDebugError( u"ESRI rotationInfo rotationType '%1' is not supported, defaulting to 'geographic'"_s.arg( rotationType ) );
+
+        // ArcGIS geographic: 0° = North, clockwise (same as QGIS)
+        angleProperty = QgsProperty::fromField( field );
+      }
+
+      // Apply rotation to all symbol layers
+      for ( int layer = 0; layer < symbol->symbolLayerCount(); ++layer )
+      {
+        symbol->symbolLayer( layer )->setDataDefinedProperty( QgsSymbolLayer::Property::Angle, angleProperty );
+      }
+    }
+    else
+    {
+      QgsDebugError( u"ESRI visualVariable type %1 is not currently supported"_s.arg( variableType ) );
+    }
+  }
+}
+
+void QgsArcGisRestUtils::applyVisualVariablesToRenderer( const QVariantMap &rendererData, QgsFeatureRenderer *renderer )
+{
+  if ( !renderer )
+    return;
+
+  // Apply visual variables to all symbols in the renderer
+  QgsRenderContext context;
+  const QgsSymbolList symbols = renderer->symbols( context );
+  for ( QgsSymbol *symbol : symbols )
+  {
+    applyVisualVariables( rendererData, symbol );
+  }
+}
+
 std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const QVariantMap &rendererData )
 {
   const QString type = rendererData.value( u"type"_s ).toString();
@@ -770,7 +838,11 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
     const QVariantMap symbolProps = rendererData.value( u"symbol"_s ).toMap();
     std::unique_ptr< QgsSymbol > symbol( convertSymbol( symbolProps ) );
     if ( symbol )
+    {
+      // Apply visual variables (e.g., rotation) to the symbol
+      applyVisualVariables( rendererData, symbol.get() );
       return std::make_unique< QgsSingleSymbolRenderer >( symbol.release() );
+    }
     else
       return nullptr;
   }
@@ -820,7 +892,12 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
     if ( categoryList.empty() )
       return nullptr;
 
-    return std::make_unique< QgsCategorizedSymbolRenderer >( attribute, categoryList );
+    auto renderer = std::make_unique< QgsCategorizedSymbolRenderer >( attribute, categoryList );
+
+    // Apply visual variables (e.g., rotation) to all category symbols
+    applyVisualVariablesToRenderer( rendererData, renderer.get() );
+
+    return renderer;
   }
   else if ( type == "classBreaks"_L1 )
   {
@@ -898,6 +975,11 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
 
         return std::make_unique< QgsSingleSymbolRenderer >( symbol.release() );
       }
+      else if ( variableType == "rotationInfo"_L1 )
+      {
+        // Rotation will be handled below after the renderer is created
+        continue;
+      }
       else
       {
         QgsDebugError( u"ESRI visualVariable type %1 is not currently supported"_s.arg( variableType ) );
@@ -967,6 +1049,9 @@ std::unique_ptr< QgsFeatureRenderer > QgsArcGisRestUtils::convertRenderer( const
       lastValue = classMaxValue;
       graduatedRenderer->addClass( range );
     }
+
+    // Apply visual variables (e.g., rotation) to all class symbols
+    applyVisualVariablesToRenderer( rendererData, graduatedRenderer.get() );
 
     return graduatedRenderer;
   }

--- a/src/core/providers/arcgis/qgsarcgisrestutils.cpp
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.cpp
@@ -792,7 +792,7 @@ void QgsArcGisRestUtils::applyVisualVariables( const QVariantMap &rendererData, 
         // ArcGIS arithmetic: 0° = East, counter-clockwise
         // QGIS: 0° = North, clockwise
         // Conversion: QGIS_angle = 90 - ArcGIS_angle
-        angleProperty = QgsProperty::fromExpression( u"90 - \"%1\""_s.arg( field ) );
+        angleProperty = QgsProperty::fromExpression( u"90 - %1"_s.arg( QgsExpression::quotedColumnRef( field ) ) );
       }
       else
       {

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -53,6 +53,7 @@ class QgsCurvePolygon;
 class QgsFeature;
 class QgsLineString;
 class QgsCurve;
+class QgsSymbolConverterContext;
 
 /**
  * \ingroup core
@@ -148,16 +149,22 @@ class CORE_EXPORT QgsArcGisRestUtils
     /**
      * Converts a symbol JSON \a definition to a QgsSymbol.
      *
-     * Caller takes ownership of the returned symbol.
+     * \param definition symbol JSON definition
+     * \param context conversion context, used to collect warnings and errors encountered during conversion.
+     * \returns the converted symbol, or nullptr on failure. Caller takes ownership of the returned symbol.
+     * \note The \a context parameter was added in QGIS 4.2
      */
-    static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition );
+    static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition, QgsSymbolConverterContext &context );
 
     /**
      * Converts renderer JSON \a data to an equivalent QgsFeatureRenderer.
      *
-     * Caller takes ownership of the returned renderer.
+     * \param rendererData renderer JSON data
+     * \param context conversion context, used to collect warnings and errors encountered during conversion.
+     * \returns the converted renderer, or nullptr on failure. Caller takes ownership of the returned renderer.
+     * \note The \a context parameter was added in QGIS 4.2
      */
-    static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData );
+    static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData, QgsSymbolConverterContext &context );
 
     /**
      * Converts labeling JSON \a data to an equivalent QGIS vector labeling.
@@ -356,15 +363,17 @@ class CORE_EXPORT QgsArcGisRestUtils
      * Applies visual variables from renderer JSON \a data to a \a symbol.
      *
      * Currently only rotation visual variables (\c rotationInfo) are supported.
+     * Warnings and errors encountered during conversion are pushed to \a context.
      */
-    static void applyVisualVariables( const QVariantMap &rendererData, QgsSymbol *symbol );
+    static void applyVisualVariables( const QVariantMap &rendererData, QgsSymbol *symbol, QgsSymbolConverterContext &context );
 
     /**
      * Applies visual variables from renderer JSON \a data to all symbols in a \a renderer.
      *
      * Currently only rotation visual variables (\c rotationInfo) are supported.
+     * Warnings and errors encountered during conversion are pushed to \a context.
      */
-    static void applyVisualVariablesToRenderer( const QVariantMap &rendererData, QgsFeatureRenderer *renderer );
+    static void applyVisualVariablesToRenderer( const QVariantMap &rendererData, QgsFeatureRenderer *renderer, QgsSymbolConverterContext &context );
 
     /**
      * Converts a JSON \a list to a point geometry of the specified wkb \a type.

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -353,6 +353,20 @@ class CORE_EXPORT QgsArcGisRestUtils
 
   private:
     /**
+     * Applies visual variables from renderer JSON \a data to a \a symbol.
+     *
+     * Currently only rotation visual variables (\c rotationInfo) are supported.
+     */
+    static void applyVisualVariables( const QVariantMap &rendererData, QgsSymbol *symbol );
+
+    /**
+     * Applies visual variables from renderer JSON \a data to all symbols in a \a renderer.
+     *
+     * Currently only rotation visual variables (\c rotationInfo) are supported.
+     */
+    static void applyVisualVariablesToRenderer( const QVariantMap &rendererData, QgsFeatureRenderer *renderer );
+
+    /**
      * Converts a JSON \a list to a point geometry of the specified wkb \a type.
      */
     static std::unique_ptr< QgsPoint > convertPoint( const QVariantList &list, Qgis::WkbType type );

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -157,6 +157,15 @@ class CORE_EXPORT QgsArcGisRestUtils
     static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition, QgsSymbolConverterContext &context );
 
     /**
+     * Converts a symbol JSON \a definition to a QgsSymbol.
+     *
+     * \param definition symbol JSON definition
+     * \returns the converted symbol, or nullptr on failure. Caller takes ownership of the returned symbol.
+     * \deprecated QGIS 4.2. Use the overload with a QgsSymbolConverterContext argument instead.
+     */
+    Q_DECL_DEPRECATED static std::unique_ptr< QgsSymbol > convertSymbol( const QVariantMap &definition ) SIP_DEPRECATED;
+
+    /**
      * Converts renderer JSON \a data to an equivalent QgsFeatureRenderer.
      *
      * \param rendererData renderer JSON data
@@ -165,6 +174,15 @@ class CORE_EXPORT QgsArcGisRestUtils
      * \note The \a context parameter was added in QGIS 4.2
      */
     static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData, QgsSymbolConverterContext &context );
+
+    /**
+     * Converts renderer JSON \a data to an equivalent QgsFeatureRenderer.
+     *
+     * \param rendererData renderer JSON data
+     * \returns the converted renderer, or nullptr on failure. Caller takes ownership of the returned renderer.
+     * \deprecated QGIS 4.2. Use the overload with a QgsSymbolConverterContext argument instead.
+     */
+    Q_DECL_DEPRECATED static std::unique_ptr< QgsFeatureRenderer > convertRenderer( const QVariantMap &rendererData ) SIP_DEPRECATED;
 
     /**
      * Converts labeling JSON \a data to an equivalent QGIS vector labeling.

--- a/src/core/providers/arcgis/qgsarcgisrestutils.h
+++ b/src/core/providers/arcgis/qgsarcgisrestutils.h
@@ -386,14 +386,6 @@ class CORE_EXPORT QgsArcGisRestUtils
     static void applyVisualVariables( const QVariantMap &rendererData, QgsSymbol *symbol, QgsSymbolConverterContext &context );
 
     /**
-     * Applies visual variables from renderer JSON \a data to all symbols in a \a renderer.
-     *
-     * Currently only rotation visual variables (\c rotationInfo) are supported.
-     * Warnings and errors encountered during conversion are pushed to \a context.
-     */
-    static void applyVisualVariablesToRenderer( const QVariantMap &rendererData, QgsFeatureRenderer *renderer, QgsSymbolConverterContext &context );
-
-    /**
      * Converts a JSON \a list to a point geometry of the specified wkb \a type.
      */
     static std::unique_ptr< QgsPoint > convertPoint( const QVariantList &list, Qgis::WkbType type );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -31,6 +31,7 @@
 #include "qgsreadwritelocker.h"
 #include "qgsrenderer.h"
 #include "qgsruntimeprofiler.h"
+#include "qgssymbolconverter.h"
 #include "qgsvariantutils.h"
 #include "qgsvectorlayerlabeling.h"
 
@@ -786,7 +787,9 @@ void QgsAfsProvider::reloadProviderData()
 
 QgsFeatureRenderer *QgsAfsProvider::createRenderer( const QVariantMap & ) const
 {
-  return QgsArcGisRestUtils::convertRenderer( mRendererDataMap ).release();
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  return QgsArcGisRestUtils::convertRenderer( mRendererDataMap, context ).release();
 }
 
 QgsAbstractVectorLayerLabeling *QgsAfsProvider::createLabeling( const QVariantMap & ) const

--- a/tests/src/core/testqgsarcgisrestutils.cpp
+++ b/tests/src/core/testqgsarcgisrestutils.cpp
@@ -263,7 +263,10 @@ void TestQgsArcGisRestUtils::testParseMarkerSymbol()
     "}"
     "}"
   );
-  std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map, context ) );
+  QVERIFY( context.warnings().isEmpty() );
   QgsMarkerSymbol *marker = dynamic_cast<QgsMarkerSymbol *>( symbol.get() );
   QVERIFY( marker );
   QCOMPARE( marker->symbolLayerCount(), 1 );
@@ -327,8 +330,10 @@ void TestQgsArcGisRestUtils::testParseMarkerSymbol()
     "}"
     "}"
   );
-
-  std::unique_ptr<QgsSymbol> fontSymbol( QgsArcGisRestUtils::convertSymbol( fontMap ) );
+  QgsReadWriteContext rwContext2;
+  QgsSymbolConverterContext context2( rwContext2 );
+  std::unique_ptr<QgsSymbol> fontSymbol( QgsArcGisRestUtils::convertSymbol( fontMap, context2 ) );
+  QVERIFY( context2.warnings().isEmpty() );
   QgsMarkerSymbol *fontMarker = dynamic_cast<QgsMarkerSymbol *>( fontSymbol.get() );
   QVERIFY( fontMarker );
   QCOMPARE( fontMarker->symbolLayerCount(), 1 );
@@ -401,7 +406,10 @@ void TestQgsArcGisRestUtils::testPictureMarkerSymbol()
     "\"yoffset\": 17"
     "}"
   );
-  std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map, context ) );
+  QVERIFY( context.warnings().isEmpty() );
   QgsMarkerSymbol *marker = dynamic_cast<QgsMarkerSymbol *>( symbol.get() );
   QVERIFY( marker );
   QCOMPARE( marker->symbolLayerCount(), 1 );
@@ -435,7 +443,10 @@ void TestQgsArcGisRestUtils::testParseLineSymbol()
     "\"width\": 7"
     "}"
   );
-  std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map, context ) );
+  QVERIFY( context.warnings().isEmpty() );
   QgsLineSymbol *line = dynamic_cast<QgsLineSymbol *>( symbol.get() );
   QVERIFY( line );
   QCOMPARE( line->symbolLayerCount(), 1 );
@@ -476,7 +487,10 @@ void TestQgsArcGisRestUtils::testParseFillSymbol()
     "}"
     "}"
   );
-  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsReadWriteContext rwContextFill;
+  QgsSymbolConverterContext contextFill( rwContextFill );
+  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map, contextFill ) );
+  QVERIFY( contextFill.warnings().isEmpty() );
   QgsFillSymbol *fill = dynamic_cast<QgsFillSymbol *>( symbol.get() );
   QVERIFY( fill );
   QCOMPARE( fill->symbolLayerCount(), 1 );
@@ -544,7 +558,10 @@ void TestQgsArcGisRestUtils::testParsePictureFillSymbol()
     "}"
     "}"
   );
-  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsReadWriteContext rwContextPFill;
+  QgsSymbolConverterContext contextPFill( rwContextPFill );
+  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map, contextPFill ) );
+  QVERIFY( contextPFill.warnings().isEmpty() );
   QgsFillSymbol *fill = dynamic_cast<QgsFillSymbol *>( symbol.get() );
   QVERIFY( fill );
   QCOMPARE( fill->symbolLayerCount(), 2 );
@@ -620,7 +637,9 @@ void TestQgsArcGisRestUtils::testParseRendererSimple()
     "}"
     "}"
   );
-  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map, context ) );
   QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
   QVERIFY( ssRenderer );
   QVERIFY( ssRenderer->symbol() );
@@ -694,7 +713,9 @@ void TestQgsArcGisRestUtils::testParseRendererCategorized()
     "]"
     "}"
   );
-  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map, context ) );
   QgsCategorizedSymbolRenderer *catRenderer = dynamic_cast<QgsCategorizedSymbolRenderer *>( renderer.get() );
   QVERIFY( catRenderer );
   QCOMPARE( catRenderer->categories().count(), 2 );
@@ -724,7 +745,9 @@ void TestQgsArcGisRestUtils::testVisualVariableRotationGeographic()
     "]"
     "}"
   );
-  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData, context ) );
   const QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
   QVERIFY( ssRenderer );
   const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
@@ -751,7 +774,9 @@ void TestQgsArcGisRestUtils::testVisualVariableRotationArithmetic()
     "]"
     "}"
   );
-  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData, context ) );
   const QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
   QVERIFY( ssRenderer );
   const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
@@ -777,7 +802,9 @@ void TestQgsArcGisRestUtils::testVisualVariableRotationDefaultsToGeographic()
     "]"
     "}"
   );
-  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData, context ) );
   const QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
   QVERIFY( ssRenderer );
   const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
@@ -804,11 +831,15 @@ void TestQgsArcGisRestUtils::testVisualVariableRotationValueExpressionSkipped()
     "]"
     "}"
   );
-  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData, context ) );
   const QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
   QVERIFY( ssRenderer );
   const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
   QVERIFY( !prop.isActive() );
+  QVERIFY( !context.warnings().isEmpty() );
+  QVERIFY( context.warnings().first().contains( u"$feature.ANGLE * 2"_s ) );
 }
 
 void TestQgsArcGisRestUtils::testVisualVariableRotationSimpleRenderer()
@@ -836,7 +867,9 @@ void TestQgsArcGisRestUtils::testVisualVariableRotationSimpleRenderer()
     "]"
     "}"
   );
-  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map, context ) );
   QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
   QVERIFY( ssRenderer );
   QVERIFY( ssRenderer->symbol() );
@@ -878,7 +911,9 @@ void TestQgsArcGisRestUtils::testVisualVariableRotationCategorizedRenderer()
     "]"
     "}"
   );
-  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map, context ) );
   QgsCategorizedSymbolRenderer *catRenderer = dynamic_cast<QgsCategorizedSymbolRenderer *>( renderer.get() );
   QVERIFY( catRenderer );
   QCOMPARE( catRenderer->categories().count(), 2 );
@@ -925,7 +960,9 @@ void TestQgsArcGisRestUtils::testVisualVariableRotationGraduatedRenderer()
     "]"
     "}"
   );
-  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map, context ) );
   QgsGraduatedSymbolRenderer *gradRenderer = dynamic_cast<QgsGraduatedSymbolRenderer *>( renderer.get() );
   QVERIFY( gradRenderer );
   QVERIFY( gradRenderer->ranges().count() >= 2 );

--- a/tests/src/core/testqgsarcgisrestutils.cpp
+++ b/tests/src/core/testqgsarcgisrestutils.cpp
@@ -787,7 +787,7 @@ void TestQgsArcGisRestUtils::testVisualVariableRotationArithmetic()
 
 void TestQgsArcGisRestUtils::testVisualVariableRotationDefaultsToGeographic()
 {
-  // When rotationType is absent the implementation defaults to geographic
+  // When rotationType is absent the implementation does not apply rotation
   const QVariantMap rendererData = jsonStringToMap(
     "{"
     "\"type\": \"simple\","
@@ -808,9 +808,7 @@ void TestQgsArcGisRestUtils::testVisualVariableRotationDefaultsToGeographic()
   const QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
   QVERIFY( ssRenderer );
   const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
-  QVERIFY( prop.isActive() );
-  QCOMPARE( prop.propertyType(), Qgis::PropertyType::Field );
-  QCOMPARE( prop.field(), u"BEARING"_s );
+  QVERIFY( !prop.isActive() );
 }
 
 void TestQgsArcGisRestUtils::testVisualVariableRotationValueExpressionSkipped()
@@ -839,7 +837,7 @@ void TestQgsArcGisRestUtils::testVisualVariableRotationValueExpressionSkipped()
   const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
   QVERIFY( !prop.isActive() );
   QVERIFY( !context.warnings().isEmpty() );
-  QVERIFY( context.warnings().first().contains( u"$feature.ANGLE * 2"_s ) );
+  QVERIFY( context.warnings().first().contains( u"valueExpression"_s ) );
 }
 
 void TestQgsArcGisRestUtils::testVisualVariableRotationSimpleRenderer()

--- a/tests/src/core/testqgsarcgisrestutils.cpp
+++ b/tests/src/core/testqgsarcgisrestutils.cpp
@@ -21,6 +21,7 @@
 #include "qgscategorizedsymbolrenderer.h"
 #include "qgsfillsymbol.h"
 #include "qgsfillsymbollayer.h"
+#include "qgsgraduatedsymbolrenderer.h"
 #include "qgslinesymbol.h"
 #include "qgslinesymbollayer.h"
 #include "qgslogger.h"
@@ -67,6 +68,13 @@ class TestQgsArcGisRestUtils : public QObject
     void testParsePictureFillSymbolNullOutline();
     void testParseRendererSimple();
     void testParseRendererCategorized();
+    void testVisualVariableRotationGeographic();
+    void testVisualVariableRotationArithmetic();
+    void testVisualVariableRotationDefaultsToGeographic();
+    void testVisualVariableRotationValueExpressionSkipped();
+    void testVisualVariableRotationSimpleRenderer();
+    void testVisualVariableRotationCategorizedRenderer();
+    void testVisualVariableRotationGraduatedRenderer();
     void testParseLabeling();
     void testParseCompoundCurve();
     void testParsePolyline();
@@ -696,6 +704,239 @@ void TestQgsArcGisRestUtils::testParseRendererCategorized()
   QCOMPARE( catRenderer->categories().at( 1 ).value().toString(), u"Canada"_s );
   QCOMPARE( catRenderer->categories().at( 1 ).label(), u"Canada"_s );
   QVERIFY( catRenderer->categories().at( 1 ).symbol() );
+}
+
+void TestQgsArcGisRestUtils::testVisualVariableRotationGeographic()
+{
+  // Geographic rotation: 0° = North, clockwise — maps directly to a field property
+  const QVariantMap rendererData = jsonStringToMap(
+    "{"
+    "\"type\": \"simple\","
+    "\"symbol\": "
+    "{\"color\":[0,0,128,128],\"size\":15,\"angle\":0,\"xoffset\":0,\"yoffset\":0,\"type\":\"esriSMS\",\"style\":\"esriSMSCircle\",\"outline\":{\"color\":[0,0,128,255],\"width\":1,\"type\":"
+    "\"esriSLS\",\"style\":\"esriSLSSolid\"}},"
+    "\"visualVariables\": ["
+    "{"
+    "\"type\": \"rotationInfo\","
+    "\"field\": \"WIND_DIR\","
+    "\"rotationType\": \"geographic\""
+    "}"
+    "]"
+    "}"
+  );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData ) );
+  const QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
+  QVERIFY( ssRenderer );
+  const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
+  QVERIFY( prop.isActive() );
+  QCOMPARE( prop.propertyType(), Qgis::PropertyType::Field );
+  QCOMPARE( prop.field(), u"WIND_DIR"_s );
+}
+
+void TestQgsArcGisRestUtils::testVisualVariableRotationArithmetic()
+{
+  // Arithmetic rotation: 0° = East, CCW — must be converted via "90 - field"
+  const QVariantMap rendererData = jsonStringToMap(
+    "{"
+    "\"type\": \"simple\","
+    "\"symbol\": "
+    "{\"color\":[0,0,128,128],\"size\":15,\"angle\":0,\"xoffset\":0,\"yoffset\":0,\"type\":\"esriSMS\",\"style\":\"esriSMSCircle\",\"outline\":{\"color\":[0,0,128,255],\"width\":1,\"type\":"
+    "\"esriSLS\",\"style\":\"esriSLSSolid\"}},"
+    "\"visualVariables\": ["
+    "{"
+    "\"type\": \"rotationInfo\","
+    "\"field\": \"ROTATION\","
+    "\"rotationType\": \"arithmetic\""
+    "}"
+    "]"
+    "}"
+  );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData ) );
+  const QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
+  QVERIFY( ssRenderer );
+  const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
+  QVERIFY( prop.isActive() );
+  QCOMPARE( prop.propertyType(), Qgis::PropertyType::Expression );
+  QCOMPARE( prop.expressionString(), u"90 - \"ROTATION\""_s );
+}
+
+void TestQgsArcGisRestUtils::testVisualVariableRotationDefaultsToGeographic()
+{
+  // When rotationType is absent the implementation defaults to geographic
+  const QVariantMap rendererData = jsonStringToMap(
+    "{"
+    "\"type\": \"simple\","
+    "\"symbol\": "
+    "{\"color\":[0,0,128,128],\"size\":15,\"angle\":0,\"xoffset\":0,\"yoffset\":0,\"type\":\"esriSMS\",\"style\":\"esriSMSCircle\",\"outline\":{\"color\":[0,0,128,255],\"width\":1,\"type\":"
+    "\"esriSLS\",\"style\":\"esriSLSSolid\"}},"
+    "\"visualVariables\": ["
+    "{"
+    "\"type\": \"rotationInfo\","
+    "\"field\": \"BEARING\""
+    "}"
+    "]"
+    "}"
+  );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData ) );
+  const QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
+  QVERIFY( ssRenderer );
+  const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
+  QVERIFY( prop.isActive() );
+  QCOMPARE( prop.propertyType(), Qgis::PropertyType::Field );
+  QCOMPARE( prop.field(), u"BEARING"_s );
+}
+
+void TestQgsArcGisRestUtils::testVisualVariableRotationValueExpressionSkipped()
+{
+  // valueExpression (Arcade) is not supported yet — no rotation should be applied
+  const QVariantMap rendererData = jsonStringToMap(
+    "{"
+    "\"type\": \"simple\","
+    "\"symbol\": "
+    "{\"color\":[0,0,128,128],\"size\":15,\"angle\":0,\"xoffset\":0,\"yoffset\":0,\"type\":\"esriSMS\",\"style\":\"esriSMSCircle\",\"outline\":{\"color\":[0,0,128,255],\"width\":1,\"type\":"
+    "\"esriSLS\",\"style\":\"esriSLSSolid\"}},"
+    "\"visualVariables\": ["
+    "{"
+    "\"type\": \"rotationInfo\","
+    "\"valueExpression\": \"$feature.ANGLE * 2\","
+    "\"rotationType\": \"geographic\""
+    "}"
+    "]"
+    "}"
+  );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( rendererData ) );
+  const QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
+  QVERIFY( ssRenderer );
+  const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
+  QVERIFY( !prop.isActive() );
+}
+
+void TestQgsArcGisRestUtils::testVisualVariableRotationSimpleRenderer()
+{
+  // Rotation visual variable is applied to the symbol of a simple renderer
+  const QVariantMap map = jsonStringToMap(
+    "{"
+    "\"type\": \"simple\","
+    "\"symbol\": {"
+    "\"color\": [0,0,128,128],"
+    "\"size\": 15,"
+    "\"angle\": 0,"
+    "\"xoffset\": 0,"
+    "\"yoffset\": 0,"
+    "\"type\": \"esriSMS\","
+    "\"style\": \"esriSMSCircle\","
+    "\"outline\": {\"color\":[0,0,128,255],\"width\":1,\"type\":\"esriSLS\",\"style\":\"esriSLSSolid\"}"
+    "},"
+    "\"visualVariables\": ["
+    "{"
+    "\"type\": \"rotationInfo\","
+    "\"field\": \"HEADING\","
+    "\"rotationType\": \"geographic\""
+    "}"
+    "]"
+    "}"
+  );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map ) );
+  QgsSingleSymbolRenderer *ssRenderer = dynamic_cast<QgsSingleSymbolRenderer *>( renderer.get() );
+  QVERIFY( ssRenderer );
+  QVERIFY( ssRenderer->symbol() );
+  const QgsProperty prop = ssRenderer->symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
+  QVERIFY( prop.isActive() );
+  QCOMPARE( prop.propertyType(), Qgis::PropertyType::Field );
+  QCOMPARE( prop.field(), u"HEADING"_s );
+}
+
+void TestQgsArcGisRestUtils::testVisualVariableRotationCategorizedRenderer()
+{
+  // Rotation visual variable is applied to all category symbols of a uniqueValue renderer
+  const QVariantMap map = jsonStringToMap(
+    "{"
+    "\"type\": \"uniqueValue\","
+    "\"field1\": \"COUNTRY\","
+    "\"uniqueValueInfos\": ["
+    "{"
+    "\"value\": \"US\","
+    "\"symbol\": "
+    "{\"color\":[253,127,111,255],\"size\":12,\"angle\":0,\"xoffset\":0,\"yoffset\":0,\"type\":\"esriSMS\",\"style\":\"esriSMSCircle\",\"outline\":{\"color\":[26,26,26,255],\"width\":0.75,\"type\":"
+    "\"esriSLS\",\"style\":\"esriSLSSolid\"}},"
+    "\"label\": \"United States\""
+    "},"
+    "{"
+    "\"value\": \"Canada\","
+    "\"symbol\": "
+    "{\"color\":[126,176,213,255],\"size\":12,\"angle\":0,\"xoffset\":0,\"yoffset\":0,\"type\":\"esriSMS\",\"style\":\"esriSMSCircle\",\"outline\":{\"color\":[26,26,26,255],\"width\":0.75,\"type\":"
+    "\"esriSLS\",\"style\":\"esriSLSSolid\"}},"
+    "\"label\": \"Canada\""
+    "}"
+    "],"
+    "\"visualVariables\": ["
+    "{"
+    "\"type\": \"rotationInfo\","
+    "\"field\": \"WIND_DIR\","
+    "\"rotationType\": \"arithmetic\""
+    "}"
+    "]"
+    "}"
+  );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map ) );
+  QgsCategorizedSymbolRenderer *catRenderer = dynamic_cast<QgsCategorizedSymbolRenderer *>( renderer.get() );
+  QVERIFY( catRenderer );
+  QCOMPARE( catRenderer->categories().count(), 2 );
+  for ( const QgsRendererCategory &category : catRenderer->categories() )
+  {
+    QVERIFY( category.symbol() );
+    const QgsProperty prop = category.symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
+    QVERIFY( prop.isActive() );
+    QCOMPARE( prop.propertyType(), Qgis::PropertyType::Expression );
+    QCOMPARE( prop.expressionString(), u"90 - \"WIND_DIR\""_s );
+  }
+}
+
+void TestQgsArcGisRestUtils::testVisualVariableRotationGraduatedRenderer()
+{
+  // Rotation visual variable is applied to all class symbols of a classBreaks renderer
+  const QVariantMap map = jsonStringToMap(
+    "{"
+    "\"type\": \"classBreaks\","
+    "\"field\": \"POPULATION\","
+    "\"minValue\": 0,"
+    "\"classBreakInfos\": ["
+    "{"
+    "\"classMaxValue\": 1000,"
+    "\"symbol\": "
+    "{\"color\":[255,0,0,255],\"size\":8,\"angle\":0,\"xoffset\":0,\"yoffset\":0,\"type\":\"esriSMS\",\"style\":\"esriSMSCircle\",\"outline\":{\"color\":[0,0,0,255],\"width\":1,\"type\":\"esriSLS\","
+    "\"style\":\"esriSLSSolid\"}},"
+    "\"label\": \"< 1000\""
+    "},"
+    "{"
+    "\"classMaxValue\": 5000,"
+    "\"symbol\": "
+    "{\"color\":[0,255,0,255],\"size\":14,\"angle\":0,\"xoffset\":0,\"yoffset\":0,\"type\":\"esriSMS\",\"style\":\"esriSMSCircle\",\"outline\":{\"color\":[0,0,0,255],\"width\":1,\"type\":\"esriSLS\","
+    "\"style\":\"esriSLSSolid\"}},"
+    "\"label\": \"1000 - 5000\""
+    "}"
+    "],"
+    "\"visualVariables\": ["
+    "{"
+    "\"type\": \"rotationInfo\","
+    "\"field\": \"HEADING\","
+    "\"rotationType\": \"geographic\""
+    "}"
+    "]"
+    "}"
+  );
+  const std::unique_ptr<QgsFeatureRenderer> renderer( QgsArcGisRestUtils::convertRenderer( map ) );
+  QgsGraduatedSymbolRenderer *gradRenderer = dynamic_cast<QgsGraduatedSymbolRenderer *>( renderer.get() );
+  QVERIFY( gradRenderer );
+  QVERIFY( gradRenderer->ranges().count() >= 2 );
+  for ( const QgsRendererRange &range : gradRenderer->ranges() )
+  {
+    QVERIFY( range.symbol() );
+    const QgsProperty prop = range.symbol()->symbolLayer( 0 )->dataDefinedProperties().property( QgsSymbolLayer::Property::Angle );
+    QVERIFY( prop.isActive() );
+    QCOMPARE( prop.propertyType(), Qgis::PropertyType::Field );
+    QCOMPARE( prop.field(), u"HEADING"_s );
+  }
 }
 
 void TestQgsArcGisRestUtils::testParseLabeling()

--- a/tests/src/core/testqgsarcgisrestutils.cpp
+++ b/tests/src/core/testqgsarcgisrestutils.cpp
@@ -377,7 +377,9 @@ void TestQgsArcGisRestUtils::testParseMarkerSymbolNullOutline()
     "\"outline\": null"
     "}"
   );
-  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map, context ) );
   QgsMarkerSymbol *marker = dynamic_cast<QgsMarkerSymbol *>( symbol.get() );
   QVERIFY( marker );
   QCOMPARE( marker->symbolLayerCount(), 1 );
@@ -521,7 +523,9 @@ void TestQgsArcGisRestUtils::testParseFillSymbolNullOutline()
     "\"outline\": null"
     "}"
   );
-  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map, context ) );
   QgsFillSymbol *fill = dynamic_cast<QgsFillSymbol *>( symbol.get() );
   QVERIFY( fill );
   QCOMPARE( fill->symbolLayerCount(), 1 );
@@ -593,7 +597,9 @@ void TestQgsArcGisRestUtils::testParsePictureFillSymbolNullOutline()
     "\"outline\": null"
     "}"
   );
-  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map ) );
+  QgsReadWriteContext rwContext;
+  QgsSymbolConverterContext context( rwContext );
+  const std::unique_ptr<QgsSymbol> symbol( QgsArcGisRestUtils::convertSymbol( map, context ) );
   QgsFillSymbol *fill = dynamic_cast<QgsFillSymbol *>( symbol.get() );
   QVERIFY( fill );
   // With null outline, should only have 1 layer (raster fill), not 2


### PR DESCRIPTION
## Description

Adds support for [ArcGIS REST `visualVariables`](https://developers.arcgis.com/web-map-specification/objects/rotationInfo_visualVariable/) of type `rotationInfo` when loading ArcGIS REST layers.
The rotation is applied to all symbol layers across simple, categorized, and graduated renderers.

Only `field` property is supported. `valueExpression` is skipped with a debug log.

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
