### PR TITLE
[fix] Avoid losing rendering order in the Profile canvas when changing layer elevation properties

### DIFF
--- a/python/PyQt6/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
+++ b/python/PyQt6/core/auto_generated/elevation/qgsabstractprofilegenerator.sip.in
@@ -402,7 +402,7 @@ Returns a unique identifier representing the source of the profile.
 
 For generators associated with a map layer the source ID will match the
 layer's :py:func:`QgsMapLayer.id()`. Other (non-map-layer) sources will
-have a different unique ID with its own custom interpretation.gen
+have a different unique ID with its own custom interpretation.
 %End
 
     virtual Qgis::ProfileGeneratorFlags flags() const;

--- a/src/core/elevation/qgsabstractprofilegenerator.h
+++ b/src/core/elevation/qgsabstractprofilegenerator.h
@@ -409,7 +409,7 @@ class CORE_EXPORT QgsAbstractProfileGenerator
      * Returns a unique identifier representing the source of the profile.
      *
      * For generators associated with a map layer the source ID will match the layer's QgsMapLayer::id(). Other (non-map-layer) sources
-     * will have a different unique ID with its own custom interpretation.gen
+     * will have a different unique ID with its own custom interpretation.
      */
     virtual QString sourceId() const = 0;
 

--- a/src/core/elevation/qgsprofilerenderer.cpp
+++ b/src/core/elevation/qgsprofilerenderer.cpp
@@ -238,13 +238,11 @@ bool QgsProfilePlotRenderer::replaceSourceInternal( QgsAbstractProfileSource *so
     return false;
 
   QString sourceId = generator->sourceId();
-  bool res = false;
   for ( auto &job : mJobs )
   {
     if ( job->generator && job->generator->sourceId() == sourceId )
     {
       job->mutex.lock();
-      res = true;
       if ( clearPreviousResults || job->generator->type() != generator->type() )
       {
         job->results.reset();
@@ -263,13 +261,13 @@ bool QgsProfilePlotRenderer::replaceSourceInternal( QgsAbstractProfileSource *so
         {
           it = mGenerators.erase( it );
           mGenerators.emplace( it, std::move( generator ) );
-          break;
+          return true;
         }
         it++;
       }
     }
   }
-  return res;
+  return false;
 }
 
 void QgsProfilePlotRenderer::regenerateInvalidatedResults()

--- a/src/core/elevation/qgsprofilerenderer.cpp
+++ b/src/core/elevation/qgsprofilerenderer.cpp
@@ -260,11 +260,13 @@ bool QgsProfilePlotRenderer::replaceSourceInternal( QgsAbstractProfileSource *so
       for ( auto it = mGenerators.begin(); it != mGenerators.end(); )
       {
         if ( ( *it )->sourceId() == sourceId )
+        {
           it = mGenerators.erase( it );
-        else
-          it++;
+          mGenerators.emplace( it, std::move( generator ) );
+          break;
+        }
+        it++;
       }
-      mGenerators.emplace_back( std::move( generator ) );
     }
   }
   return res;

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -963,7 +963,7 @@ void QgsElevationProfileCanvas::generationFinished()
   {
     // here we should invalidate cached results only for the layers which have been refined
 
-    // and if no layers are being refeined, don't invalidate anything
+    // and if no layers are being refined, don't invalidate anything
 
     mPlotItem->updatePlot();
   }

--- a/tests/src/python/test_qgsvectorlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsvectorlayerprofilegenerator.py
@@ -3379,6 +3379,34 @@ class TestQgsVectorLayerProfileGenerator(QgisTestCase):
         # comparing against results from https://geodesyapps.ga.gov.au/ausgeoid2020
         self.assertAlmostEqual(res.constGet().z(), 5543.325, 3)
 
+    def testRenderProfileReplaceSourceRenderingOrder(self):
+        # For issue #62677
+        def create_layer(name):
+            l = QgsVectorLayer("LineStringZ?crs=EPSG:27700", name, "memory")
+            l.setCrs(QgsCoordinateReferenceSystem())
+            self.assertTrue(l.isValid())
+            return l
+
+        vl = create_layer("above")
+        vl2 = create_layer("below")
+
+        curve = QgsLineString()
+        req = QgsProfileRequest(curve)
+
+        plot_renderer = QgsProfilePlotRenderer([vl2, vl], req)
+        sources = plot_renderer.sourceIds()
+        self.assertEqual(sources, [vl2.id(), vl.id()])
+
+        plot_renderer.replaceSource(
+            vl2
+        )  # E.g., after a change in the elevation profile settings
+        sources = plot_renderer.sourceIds()
+        self.assertEqual(
+            sources,
+            [vl2.id(), vl.id()],
+            "The order of the generators does not correspond to the order of the sources! (i.e., issue #62677)",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix #62677
Fix #64806

Includes unit test.

-----------
_No AI was used._