### PR TITLE
Processing: add logic to define if a raster output parameter is for GDAL CreateCopy() formats or not

### DIFF
--- a/python/PyQt6/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
+++ b/python/PyQt6/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
@@ -42,7 +42,7 @@ Constructor for QgsPdalAlgorithms.
 
     virtual QStringList supportedOutputVectorLayerExtensions() const;
 
-    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions( bool includeCreateCopy = false ) const;
 
     virtual QStringList supportedOutputPointCloudLayerExtensions() const;
 

--- a/python/PyQt6/core/auto_additions/qgsrasterfilewriter.py
+++ b/python/PyQt6/core/auto_additions/qgsrasterfilewriter.py
@@ -1,5 +1,6 @@
 # The following has been generated automatically from src/core/raster/qgsrasterfilewriter.h
 QgsRasterFileWriter.SortRecommended = QgsRasterFileWriter.RasterFormatOption.SortRecommended
+QgsRasterFileWriter.ListCreateCopy = QgsRasterFileWriter.RasterFormatOption.ListCreateCopy
 QgsRasterFileWriter.RasterFormatOptions = lambda flags=0: QgsRasterFileWriter.RasterFormatOption(flags)
 try:
     QgsRasterFileWriter.FilterFormatDetails.__attribute_docs__ = {'driverName': 'Unique driver name', 'filterString': 'Filter string for file picker dialogs'}

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -4246,6 +4246,22 @@ If ``createByDefault`` is ``False`` and the parameter is ``optional``,
 then this destination output will not be created by default.
 %End
 
+    QgsProcessingParameterRasterDestination &setAcceptCreateCopyFormats();
+%Docstring
+Indicates that raster formats that only support creation from a source
+dataset (to be opposed to creation from scratch) are also accepted.
+
+.. versionadded:: 4.2
+%End
+
+    bool acceptsCreateCopyFormats() const;
+%Docstring
+Returns whether raster formats that only support creation from a source
+dataset (to be opposed to creation from scratch) are also accepted.
+
+.. versionadded:: 4.2
+%End
+
     static QString typeName();
 %Docstring
 Returns the type name for the parameter class.
@@ -4296,6 +4312,7 @@ Returns a list of (format, file extension) supported by this provider.
 %Docstring
 Creates a new parameter using the definition from a script code.
 %End
+
 };
 
 class QgsProcessingParameterFileDestination : QgsProcessingDestinationParameter

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -137,7 +137,7 @@ providers in a "beta" or "untrustworthy" state.
 Returns ``True`` if the provider is active and able to run algorithms.
 %End
 
-    QStringList supportedOutputRasterLayerExtensions() const;
+    QStringList supportedOutputRasterLayerExtensions(bool includeCreateCopy = false) const;
 %Docstring
 Returns a list of the raster format file extensions supported by this
 provider.
@@ -148,15 +148,23 @@ provider.
 
 .. seealso:: :py:func:`supportedOutputVectorTileLayerExtensions`
 
+If ``includeCreateCopy`` (added in QGIS 4.2) is set to true, raster
+formats that only support creation from a source dataset (to be opposed
+to creation from scratch) are also listed.
+
 .. note::
 
    Since QGIS 4.0, this method is no longer virtual and use internally
    :py:func:`~QgsProcessingProvider.supportedOutputRasterLayerFormatAndExtensions` instead.
 %End
 
-    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions(bool includeCreateCopy = false) const;
 %Docstring
 Returns a list of (format, file extension) supported by this provider.
+
+If ``includeCreateCopy`` (added in QGIS 4.2) is set to true, raster
+formats that only support creation from a source dataset (to be opposed
+to creation from scratch) are also listed.
 
 .. versionadded:: 4.0
 %End

--- a/python/PyQt6/core/auto_generated/qgsgdalutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsgdalutils.sip.in
@@ -56,6 +56,7 @@ Utilities for working with GDAL.
 
 
 
+
     static bool supportsTiffLercCompression();
 %Docstring
 Returns ``True`` if the GDAL library used by this QGIS install supports

--- a/python/PyQt6/core/auto_generated/raster/qgsrasterfilewriter.sip.in
+++ b/python/PyQt6/core/auto_generated/raster/qgsrasterfilewriter.sip.in
@@ -27,6 +27,7 @@ formats and data providers can be used by calling
     enum RasterFormatOption /BaseType=IntEnum/
     {
       SortRecommended,
+      ListCreateCopy,
     };
     typedef QFlags<QgsRasterFileWriter::RasterFormatOption> RasterFormatOptions;
 

--- a/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
@@ -161,7 +161,7 @@ class ClipRasterByExtent(GdalAlgorithm):
         self.addParameter(
             QgsProcessingParameterRasterDestination(
                 self.OUTPUT, self.tr("Clipped (extent)")
-            )
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/aspect.py
+++ b/python/plugins/processing/algs/gdal/aspect.py
@@ -133,7 +133,9 @@ class aspect(GdalAlgorithm):
         self.addParameter(extra_param)
 
         self.addParameter(
-            QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr("Aspect"))
+            QgsProcessingParameterRasterDestination(
+                self.OUTPUT, self.tr("Aspect")
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/hillshade.py
+++ b/python/plugins/processing/algs/gdal/hillshade.py
@@ -173,7 +173,9 @@ class hillshade(GdalAlgorithm):
         self.addParameter(extra_param)
 
         self.addParameter(
-            QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr("Hillshade"))
+            QgsProcessingParameterRasterDestination(
+                self.OUTPUT, self.tr("Hillshade")
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/pansharp.py
+++ b/python/plugins/processing/algs/gdal/pansharp.py
@@ -124,7 +124,9 @@ class pansharp(GdalAlgorithm):
         self.addParameter(extra_param)
 
         self.addParameter(
-            QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr("Output"))
+            QgsProcessingParameterRasterDestination(
+                self.OUTPUT, self.tr("Output")
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/pct2rgb.py
+++ b/python/plugins/processing/algs/gdal/pct2rgb.py
@@ -65,7 +65,9 @@ class pct2rgb(GdalAlgorithm):
             )
         )
         self.addParameter(
-            QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr("PCT to RGB"))
+            QgsProcessingParameterRasterDestination(
+                self.OUTPUT, self.tr("PCT to RGB")
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/rearrange_bands.py
+++ b/python/plugins/processing/algs/gdal/rearrange_bands.py
@@ -123,7 +123,9 @@ class rearrange_bands(GdalAlgorithm):
         self.addParameter(dataType_param)
 
         self.addParameter(
-            QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr("Converted"))
+            QgsProcessingParameterRasterDestination(
+                self.OUTPUT, self.tr("Converted")
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/rgb2pct.py
+++ b/python/plugins/processing/algs/gdal/rgb2pct.py
@@ -61,7 +61,9 @@ class rgb2pct(GdalAlgorithm):
         )
 
         self.addParameter(
-            QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr("RGB to PCT"))
+            QgsProcessingParameterRasterDestination(
+                self.OUTPUT, self.tr("RGB to PCT")
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/slope.py
+++ b/python/plugins/processing/algs/gdal/slope.py
@@ -136,7 +136,9 @@ class slope(GdalAlgorithm):
         self.addParameter(extra_param)
 
         self.addParameter(
-            QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr("Slope"))
+            QgsProcessingParameterRasterDestination(
+                self.OUTPUT, self.tr("Slope")
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/tpi.py
+++ b/python/plugins/processing/algs/gdal/tpi.py
@@ -98,7 +98,7 @@ class tpi(GdalAlgorithm):
         self.addParameter(
             QgsProcessingParameterRasterDestination(
                 self.OUTPUT, self.tr("Topographic Position Index")
-            )
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/translate.py
+++ b/python/plugins/processing/algs/gdal/translate.py
@@ -154,7 +154,9 @@ class translate(GdalAlgorithm):
         self.addParameter(dataType_param)
 
         self.addParameter(
-            QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr("Converted"))
+            QgsProcessingParameterRasterDestination(
+                self.OUTPUT, self.tr("Converted")
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/tri.py
+++ b/python/plugins/processing/algs/gdal/tri.py
@@ -98,7 +98,7 @@ class tri(GdalAlgorithm):
         self.addParameter(
             QgsProcessingParameterRasterDestination(
                 self.OUTPUT, self.tr("Terrain Ruggedness Index")
-            )
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -220,7 +220,9 @@ class warp(GdalAlgorithm):
         self.addParameter(extra_param)
 
         self.addParameter(
-            QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr("Reprojected"))
+            QgsProcessingParameterRasterDestination(
+                self.OUTPUT, self.tr("Reprojected")
+            ).setAcceptCreateCopyFormats()
         )
 
     def name(self):

--- a/src/analysis/processing/pdal/qgspdalalgorithms.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithms.cpp
@@ -91,8 +91,9 @@ QStringList QgsPdalAlgorithms::supportedOutputVectorLayerExtensions() const
   return QStringList() << u"gpkg"_s;
 }
 
-QList<QPair<QString, QString>> QgsPdalAlgorithms::supportedOutputRasterLayerFormatAndExtensions() const
+QList<QPair<QString, QString>> QgsPdalAlgorithms::supportedOutputRasterLayerFormatAndExtensions( bool includeCreateCopy ) const
 {
+  Q_UNUSED( includeCreateCopy );
   return QList<QPair<QString, QString>>() << QPair<QString, QString>( QString(), u"tif"_s );
 }
 

--- a/src/analysis/processing/pdal/qgspdalalgorithms.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithms.h
@@ -47,7 +47,7 @@ class ANALYSIS_EXPORT QgsPdalAlgorithms : public QgsProcessingProvider
     bool supportsNonFileBasedOutput() const override;
 
     QStringList supportedOutputVectorLayerExtensions() const override;
-    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override;
+    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions( bool includeCreateCopy = false ) const override;
     QStringList supportedOutputPointCloudLayerExtensions() const override;
 
   protected:

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -7040,6 +7040,12 @@ QgsProcessingParameterDefinition *QgsProcessingParameterRasterDestination::clone
   return new QgsProcessingParameterRasterDestination( *this );
 }
 
+QgsProcessingParameterRasterDestination &QgsProcessingParameterRasterDestination::setAcceptCreateCopyFormats()
+{
+  mAcceptCreateCopy = true;
+  return *this;
+}
+
 bool QgsProcessingParameterRasterDestination::checkValueIsAcceptable( const QVariant &input, QgsProcessingContext * ) const
 {
   QVariant var = input;
@@ -7168,15 +7174,15 @@ QList<QPair<QString, QString>> QgsProcessingParameterRasterDestination::supporte
 {
   if ( auto *lOriginalProvider = originalProvider() )
   {
-    return lOriginalProvider->supportedOutputRasterLayerFormatAndExtensions();
+    return lOriginalProvider->supportedOutputRasterLayerFormatAndExtensions( mAcceptCreateCopy );
   }
   else if ( QgsProcessingProvider *p = provider() )
   {
-    return p->supportedOutputRasterLayerFormatAndExtensions();
+    return p->supportedOutputRasterLayerFormatAndExtensions( mAcceptCreateCopy );
   }
   else
   {
-    return QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensionsDefault();
+    return QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensionsDefault( mAcceptCreateCopy );
   }
 }
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -3825,6 +3825,22 @@ class CORE_EXPORT QgsProcessingParameterRasterDestination : public QgsProcessing
     QgsProcessingParameterRasterDestination( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(), bool optional = false, bool createByDefault = true );
 
     /**
+     * Indicates that raster formats that only support creation from a source
+     * dataset (to be opposed to creation from scratch) are also accepted.
+     *
+     * \since QGIS 4.2
+     */
+    QgsProcessingParameterRasterDestination &setAcceptCreateCopyFormats();
+
+    /**
+     * Returns whether raster formats that only support creation from a source
+     * dataset (to be opposed to creation from scratch) are also accepted.
+     *
+     * \since QGIS 4.2
+     */
+    bool acceptsCreateCopyFormats() const { return mAcceptCreateCopy; }
+
+    /**
      * Returns the type name for the parameter class.
      */
     static QString typeName() { return u"rasterDestination"_s; }
@@ -3864,6 +3880,9 @@ class CORE_EXPORT QgsProcessingParameterRasterDestination : public QgsProcessing
      * Creates a new parameter using the definition from a script code.
      */
     static QgsProcessingParameterRasterDestination *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) SIP_FACTORY;
+
+  private:
+    bool mAcceptCreateCopy = false;
 };
 
 /**

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -69,9 +69,9 @@ QString QgsProcessingProvider::versionInfo() const
   return QString();
 }
 
-QStringList QgsProcessingProvider::supportedOutputRasterLayerExtensions() const
+QStringList QgsProcessingProvider::supportedOutputRasterLayerExtensions( bool includeCreateCopy ) const
 {
-  const QList<QPair<QString, QString>> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
+  const QList<QPair<QString, QString>> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions( includeCreateCopy );
   QSet< QString > extensions;
   QStringList res;
   for ( const QPair<QString, QString> &formatAndExt : std::as_const( formatAndExtensions ) )
@@ -85,14 +85,16 @@ QStringList QgsProcessingProvider::supportedOutputRasterLayerExtensions() const
   return res;
 }
 
-QList<QPair<QString, QString>> QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensions() const
+QList<QPair<QString, QString>> QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensions( bool includeCreateCopy ) const
 {
-  return supportedOutputRasterLayerFormatAndExtensionsDefault();
+  return supportedOutputRasterLayerFormatAndExtensionsDefault( includeCreateCopy );
 }
 
-QList<QPair<QString, QString>> QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensionsDefault()
+QList<QPair<QString, QString>> QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensionsDefault( bool includeCreateCopy )
 {
-  const auto formats = QgsRasterFileWriter::supportedFiltersAndFormats();
+  const auto formats = QgsRasterFileWriter::supportedFiltersAndFormats(
+    includeCreateCopy ? static_cast<QgsRasterFileWriter::RasterFormatOption>( QgsRasterFileWriter::ListCreateCopy | QgsRasterFileWriter::SortRecommended ) : QgsRasterFileWriter::SortRecommended
+  );
   QList<QPair<QString, QString>> res;
 
   const thread_local QRegularExpression rx( u"\\*\\.([a-zA-Z0-9]*)"_s );
@@ -261,9 +263,10 @@ bool QgsProcessingProvider::isSupportedOutputValue( const QVariant &outputValue,
   }
   else if ( parameter->type() == QgsProcessingParameterRasterDestination::typeName() )
   {
+    const QgsProcessingParameterRasterDestination *rasterParam = static_cast<const QgsProcessingParameterRasterDestination *>( parameter );
     const QFileInfo fi( outputPath );
     const QString extension = fi.suffix();
-    if ( !supportedOutputRasterLayerExtensions().contains( extension, Qt::CaseInsensitive ) )
+    if ( !supportedOutputRasterLayerExtensions( rasterParam->acceptsCreateCopyFormats() ).contains( extension, Qt::CaseInsensitive ) )
     {
       error = tr( "“.%1” files are not supported as outputs for this algorithm" ).arg( extension );
       return false;

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -145,24 +145,36 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * \see supportedOutputPointCloudLayerExtensions()
      * \see supportedOutputVectorTileLayerExtensions()
      *
+     * If \a includeCreateCopy (added in QGIS 4.2) is set to true, raster formats
+     * that only support creation from a source dataset (to be opposed to creation
+     * from scratch) are also listed.
+     *
      * \note Since QGIS 4.0, this method is no longer virtual and use internally
      * supportedOutputRasterLayerFormatAndExtensions() instead.
      */
-    QStringList supportedOutputRasterLayerExtensions() const;
+    QStringList supportedOutputRasterLayerExtensions(bool includeCreateCopy = false) const;
 
     /**
      * Returns a list of (format, file extension) supported by this provider.
      *
+     * If \a includeCreateCopy (added in QGIS 4.2) is set to true, raster formats
+     * that only support creation from a source dataset (to be opposed to creation
+     * from scratch) are also listed.
+     *
      * \since QGIS 4.0
      */
-    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions(bool includeCreateCopy = false) const;
 
     /**
      * Returns a list of (format, file extension) supported by GDAL
      *
+     * If \a includeCreateCopy (added in QGIS 4.2) is set to true, raster formats
+     * that only support creation from a source dataset (to be opposed to creation
+     * from scratch) are also listed.
+     *
      * \since QGIS 4.0
      */
-    static QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensionsDefault() SIP_SKIP;
+    static QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensionsDefault(bool includeCreateCopy = false) SIP_SKIP;
 
     /**
      * Returns a list of the vector format file extensions supported by this provider.

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -173,6 +173,11 @@ bool QgsGdalUtils::supportsRasterCreate( GDALDriverH driver )
   return GDALGetMetadataItem( driver, GDAL_DCAP_CREATE, nullptr ) && GDALGetMetadataItem( driver, GDAL_DCAP_RASTER, nullptr );
 }
 
+bool QgsGdalUtils::supportsRasterCreateCopy( GDALDriverH driver )
+{
+  return supportsRasterCreate( driver ) || ( GDALGetMetadataItem( driver, GDAL_DCAP_CREATECOPY, nullptr ) && GDALGetMetadataItem( driver, GDAL_DCAP_RASTER, nullptr ) );
+}
+
 gdal::dataset_unique_ptr QgsGdalUtils::createSingleBandMemoryDataset( GDALDataType dataType, const QgsRectangle &extent, int width, int height, const QgsCoordinateReferenceSystem &crs )
 {
   return createMultiBandMemoryDataset( dataType, 1, extent, width, height, crs );

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -107,6 +107,14 @@ class CORE_EXPORT QgsGdalUtils
     SIP_SKIP static bool supportsRasterCreate( GDALDriverH driver );
 
     /**
+     * Reads whether a driver supports GDALCreateCopy() for raster purposes.
+     * \param driver GDAL driver
+     * \returns TRUE if a driver supports GDALCreateCopy() for raster purposes.
+     * \since QGIS 4.2
+     */
+    SIP_SKIP static bool supportsRasterCreateCopy( GDALDriverH driver );
+
+    /**
      * Creates a new single band memory dataset with given parameters
      * \since QGIS 3.8
      */

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -1291,7 +1291,7 @@ QList< QgsRasterFileWriter::FilterFormatDetails > QgsRasterFileWriter::supported
     GDALDriverH drv = GDALGetDriver( i );
     if ( drv )
     {
-      if ( QgsGdalUtils::supportsRasterCreate( drv ) )
+      if ( QgsGdalUtils::supportsRasterCreate( drv ) || ( ( options & ListCreateCopy ) && QgsGdalUtils::supportsRasterCreateCopy( drv ) ) )
       {
         const QString drvName = GDALGetDriverShortName( drv );
         const QString filterString = filterForDriver( drvName );

--- a/src/core/raster/qgsrasterfilewriter.h
+++ b/src/core/raster/qgsrasterfilewriter.h
@@ -49,6 +49,7 @@ class CORE_EXPORT QgsRasterFileWriter
     enum RasterFormatOption SIP_ENUM_BASETYPE( IntFlag )
     {
       SortRecommended = 1 << 1, //!< Use recommended sort order, with extremely commonly used formats listed first
+      ListCreateCopy = 1 << 2, //!< Also list formats that support creation only by copying from an existing dataset (added in QGIS 4.2). By default, only formats that support creation from scratch are listed.
     };
     Q_DECLARE_FLAGS( RasterFormatOptions, RasterFormatOption )
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -618,8 +618,9 @@ class DummyProvider3 : public QgsProcessingProvider // clazy:exclude=missing-qob
 
     QStringList supportedOutputTableExtensions() const override { return QStringList() << u"dbf"_s; }
 
-    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override
+    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions( bool includeCreateCopy = false ) const override
     {
+      Q_UNUSED( includeCreateCopy );
       return QList<QPair<QString, QString>>() << QPair<QString, QString>( u"XYZ"_s, u"xyz"_s ) << QPair<QString, QString>( u"BMP"_s, u"bmp"_s );
     }
 
@@ -639,7 +640,21 @@ class DummyProvider4 : public QgsProcessingProvider // clazy:exclude=missing-qob
 
     QStringList supportedOutputVectorLayerExtensions() const override { return QStringList() << u"mif"_s; }
 
-    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override { return QList<QPair<QString, QString>>() << QPair<QString, QString>( QString(), u"mig"_s ); }
+    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions( bool includeCreateCopy = false ) const override
+    {
+      Q_UNUSED( includeCreateCopy );
+      return QList<QPair<QString, QString>>() << QPair<QString, QString>( QString(), u"mig"_s );
+    }
+
+    void loadAlgorithms() override { QVERIFY( addAlgorithm( new DummyAlgorithm2( "alg1" ) ) ); }
+};
+
+class DummyProvider5 : public QgsProcessingProvider // clazy:exclude=missing-qobject-macro
+{
+  public:
+    DummyProvider5() = default;
+    QString id() const override { return u"dummy5"_s; }
+    QString name() const override { return u"dummy5"_s; }
 
     void loadAlgorithms() override { QVERIFY( addAlgorithm( new DummyAlgorithm2( "alg1" ) ) ); }
 };
@@ -8666,6 +8681,8 @@ void TestQgsProcessing::parameterRasterOut()
   QVERIFY( !def->checkValueIsAcceptable( QgsProcessingOutputLayerDefinition( "" ) ) );
   QVERIFY( def->checkValueIsAcceptable( QgsProperty::fromValue( u"layer12312312"_s ) ) );
   QVERIFY( !def->checkValueIsAcceptable( QgsProperty::fromValue( QString() ) ) );
+  QVERIFY( !def->acceptsCreateCopyFormats() );
+
 
   // should be OK with or without context - it's an output layer!
   QVERIFY( def->checkValueIsAcceptable( "c:/Users/admin/Desktop/roads_clipped_transformed_v1_reprojected_final_clipped_aAAA.tif" ) );
@@ -8689,7 +8706,14 @@ void TestQgsProcessing::parameterRasterOut()
   {
     QVERIFY( filters[i].contains( formatAndExtensions[i].first.toUpper() ) );
     QVERIFY( filters[i].contains( formatAndExtensions[i].second ) );
+    QVERIFY( formatAndExtensions[i].first.toUpper() != "AAIGRID"_L1 );
   }
+
+  def->setAcceptCreateCopyFormats();
+  QVERIFY( def->acceptsCreateCopyFormats() );
+
+  const QList<QPair<QString, QString>> formatAndExtensions2 = def->supportedOutputRasterLayerFormatAndExtensions();
+  QVERIFY( formatAndExtensions2.size() > formatAndExtensions.size() );
 
   QVariantMap params;
   params.insert( "non_optional", "test.tif" );
@@ -8800,6 +8824,11 @@ void TestQgsProcessing::parameterRasterOut()
   QVERIFY( provider.isSupportedOutputValue( "d:/test.xyz", def.get(), context, error ) );
   QVERIFY( provider.isSupportedOutputValue( "d:/test.XYZ", def.get(), context, error ) );
   QVERIFY( provider.isSupportedOutputValue( QgsProcessingOutputLayerDefinition( "d:/test.XYZ" ), def.get(), context, error ) );
+
+  const DummyProvider5 provider5;
+  QVERIFY( !provider5.isSupportedOutputValue( "d:/test.asc", def.get(), context, error ) );
+  def->setAcceptCreateCopyFormats();
+  QVERIFY( provider5.isSupportedOutputValue( "d:/test.asc", def.get(), context, error ) );
 
   // test layers to load on completion
   def = std::make_unique<QgsProcessingParameterRasterDestination>( "x", u"desc"_s, u"default.tif"_s, true );

--- a/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
+++ b/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
@@ -120,7 +120,11 @@ class DummyProvider4 : public QgsProcessingProvider // clazy:exclude=missing-qob
 
     QStringList supportedOutputVectorLayerExtensions() const override { return QStringList() << u"mif"_s; }
 
-    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override { return QList<QPair<QString, QString>>() << QPair<QString, QString>( u"XYZ"_s, u"xyz"_s ); }
+    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions( bool includeCreateCopy = false ) const override
+    {
+      Q_UNUSED( includeCreateCopy );
+      return QList<QPair<QString, QString>>() << QPair<QString, QString>( u"XYZ"_s, u"xyz"_s );
+    }
 
     void loadAlgorithms() override
     {


### PR DESCRIPTION
and set it where apprpriate in GDAL processing algorithms

fixes #66319

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

