### PR TITLE
GDAL algorithms: bring back non-Create() capable formats such as AAIGRID .asc

### DIFF
--- a/python/PyQt6/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
+++ b/python/PyQt6/analysis/auto_generated/processing/pdal/qgspdalalgorithms.sip.in
@@ -42,7 +42,7 @@ Constructor for QgsPdalAlgorithms.
 
     virtual QStringList supportedOutputVectorLayerExtensions() const;
 
-    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+    virtual QList<QgsProcessingFormatExtensionPair> supportedOutputRasterLayerFormatAndExtensions() const;
 
     virtual QStringList supportedOutputPointCloudLayerExtensions() const;
 

--- a/python/PyQt6/core/auto_additions/qgsprocessingparameters.py
+++ b/python/PyQt6/core/auto_additions/qgsprocessingparameters.py
@@ -1,5 +1,15 @@
 # The following has been generated automatically from src/core/processing/qgsprocessingparameters.h
 try:
+    QgsProcessingFormatExtensionPair.__attribute_docs__ = {'format': 'Unique format name (GDAL driver name)', 'extension': 'File extension'}
+    QgsProcessingFormatExtensionPair.__annotations__ = {'format': str, 'extension': str}
+    QgsProcessingFormatExtensionPair.__doc__ = """
+Details of available filters and formats.
+
+.. versionadded:: 4.2"""
+    QgsProcessingFormatExtensionPair.__group__ = ['processing']
+except (NameError, AttributeError):
+    pass
+try:
     QgsProcessingFeatureSourceDefinition.__attribute_docs__ = {'source': "Source definition. Usually a static property set to a source layer's ID or file name.", 'selectedFeaturesOnly': '``True`` if only selected features in the source should be used by algorithms.', 'featureLimit': 'If set to a value > 0, places a limit on the maximum number of features which will be\nread from the source.\n\n.. versionadded:: 3.14', 'filterExpression': 'Optional expression filter to use for filtering features which will be read from the source.\n\n.. versionadded:: 3.32', 'flags': 'Flags which dictate source behavior.\n\n.. versionadded:: 3.14', 'geometryCheck': 'Geometry check method to apply to this source. This setting is only\nutilized if the :py:class:`Qgis`.ProcessingFeatureSourceDefinitionFlag.OverrideDefaultGeometryCheck is\nset in QgsProcessingFeatureSourceDefinition.flags.\n\n.. versionadded:: 3.14'}
     QgsProcessingFeatureSourceDefinition.__annotations__ = {'source': 'QgsProperty', 'selectedFeaturesOnly': bool, 'featureLimit': int, 'filterExpression': str, 'flags': 'Qgis.ProcessingFeatureSourceDefinitionFlags', 'geometryCheck': 'Qgis.InvalidGeometryCheck'}
     QgsProcessingFeatureSourceDefinition.__group__ = ['processing']

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -13,6 +13,21 @@
 
 
 
+struct QgsProcessingFormatExtensionPair
+{
+%TypeHeaderCode
+#include "qgsprocessingparameters.h"
+%End
+    QString format;
+
+    QString extension;
+
+    QgsProcessingFormatExtensionPair( const QString &format, const QString &extension );
+%Docstring
+Constructor
+%End
+};
+
 
 class QgsProcessingFeatureSourceDefinition
 {
@@ -4285,11 +4300,11 @@ parameter.
    Use :py:func:`~QgsProcessingParameterRasterDestination.supportedOutputRasterLayerFormatAndExtensions` instead.
 %End
 
-    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+    virtual QList<QgsProcessingFormatExtensionPair> supportedOutputRasterLayerFormatAndExtensions() const;
 %Docstring
 Returns a list of (format, file extension) supported by this provider.
 
-.. versionadded:: 3.40
+.. versionadded:: 4.2
 %End
 
     static QgsProcessingParameterRasterDestination *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -154,11 +154,11 @@ provider.
    :py:func:`~QgsProcessingProvider.supportedOutputRasterLayerFormatAndExtensions` instead.
 %End
 
-    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+    virtual QList<QgsProcessingFormatExtensionPair> supportedOutputRasterLayerFormatAndExtensions() const;
 %Docstring
 Returns a list of (format, file extension) supported by this provider.
 
-.. versionadded:: 4.0
+.. versionadded:: 4.2
 %End
 
 

--- a/python/plugins/grassprovider/grass_provider.py
+++ b/python/plugins/grassprovider/grass_provider.py
@@ -204,8 +204,8 @@ class GrassProvider(QgsProcessingProvider):
         # different from QGIS OGR version.
         return super().supportedOutputVectorLayerExtensions()
 
-    def supportedOutputRasterLayerExtensions(self):
-        return GrassUtils.getSupportedOutputRasterExtensions()
+    def getSupportedOutputRasterFormatAndExtensions(self):
+        return GrassUtils.getSupportedOutputRasterFormatAndExtensions()
 
     def canBeActivated(self):
         return not bool(GrassUtils.checkGrassIsInstalled())

--- a/python/plugins/grassprovider/grass_utils.py
+++ b/python/plugins/grassprovider/grass_utils.py
@@ -665,12 +665,12 @@ class GrassUtils:
             return "https://grass.osgeo.org/grass-stable/manuals/"
 
     @staticmethod
-    def getSupportedOutputRasterExtensions():
+    def getSupportedOutputRasterFormatAndExtensions():
         # We use the same extensions as GDAL because:
         # - GRASS is also using GDAL for raster imports.
         # - Chances that GRASS is compiled with another version of
         # GDAL than QGIS are very limited!
-        return GdalUtils.getSupportedOutputRasterExtensions()
+        return GdalUtils.getSupportedOutputRasterFormatAndExtensions()
 
     @staticmethod
     def getRasterFormatFromFilename(filename):

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -214,8 +214,8 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
         for a in self.algs:
             self.addAlgorithm(a)
 
-    def supportedOutputRasterLayerExtensions(self):
-        return GdalUtils.getSupportedOutputRasterExtensions()
+    def supportedOutputRasterLayerFormatAndExtensions(self):
+        return GdalUtils.getSupportedOutputRasterFormatAndExtensions()
 
     def supportsNonFileBasedOutput(self):
         """

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -41,6 +41,7 @@ from qgis.core import (
     QgsProcessingContext,
     QgsProcessingException,
     QgsProcessingFeedback,
+    QgsProcessingFormatExtensionPair,
     QgsProcessingRasterLayerDefinition,
     QgsProcessingUtils,
     QgsProviderRegistry,
@@ -297,15 +298,18 @@ class GdalUtils:
         return allexts
 
     @staticmethod
-    def getSupportedOutputRasterExtensions():
-        allexts = []
-        for exts in list(GdalUtils.getSupportedOutputRasters().values()):
+    def getSupportedOutputRasterFormatAndExtensions():
+        res = []
+        for format, exts in GdalUtils.getSupportedOutputRasters().items():
             for ext in exts:
-                if ext not in allexts and ext not in ["", "tif", "tiff"]:
-                    allexts.append(ext)
-        allexts.sort()
-        allexts[0:0] = ["tif", "tiff"]
-        return allexts
+                if ext != "" and format != "GTiff":
+                    res.append(QgsProcessingFormatExtensionPair(format, ext))
+        res.sort(key=lambda pair: (pair.format, pair.extension))
+        res[0:0] = [
+            QgsProcessingFormatExtensionPair("GTiff", "tif"),
+            QgsProcessingFormatExtensionPair("GTiff", "tiff"),
+        ]
+        return res
 
     @staticmethod
     def getVectorDriverFromFileName(filename):

--- a/src/analysis/processing/pdal/qgspdalalgorithms.cpp
+++ b/src/analysis/processing/pdal/qgspdalalgorithms.cpp
@@ -91,9 +91,9 @@ QStringList QgsPdalAlgorithms::supportedOutputVectorLayerExtensions() const
   return QStringList() << u"gpkg"_s;
 }
 
-QList<QPair<QString, QString>> QgsPdalAlgorithms::supportedOutputRasterLayerFormatAndExtensions() const
+QList<QgsProcessingFormatExtensionPair> QgsPdalAlgorithms::supportedOutputRasterLayerFormatAndExtensions() const
 {
-  return QList<QPair<QString, QString>>() << QPair<QString, QString>( QString(), u"tif"_s );
+  return QList<QgsProcessingFormatExtensionPair>() << QgsProcessingFormatExtensionPair( QString(), u"tif"_s );
 }
 
 QStringList QgsPdalAlgorithms::supportedOutputPointCloudLayerExtensions() const

--- a/src/analysis/processing/pdal/qgspdalalgorithms.h
+++ b/src/analysis/processing/pdal/qgspdalalgorithms.h
@@ -47,7 +47,7 @@ class ANALYSIS_EXPORT QgsPdalAlgorithms : public QgsProcessingProvider
     bool supportsNonFileBasedOutput() const override;
 
     QStringList supportedOutputVectorLayerExtensions() const override;
-    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override;
+    QList<QgsProcessingFormatExtensionPair> supportedOutputRasterLayerFormatAndExtensions() const override;
     QStringList supportedOutputPointCloudLayerExtensions() const override;
 
   protected:

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -7137,17 +7137,25 @@ QString QgsProcessingParameterRasterDestination::defaultFileExtension() const
 QString QgsProcessingParameterRasterDestination::createFileFilter() const
 {
   QStringList filters;
-  const QList<QPair<QString, QString>> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
+  const QList<QgsProcessingFormatExtensionPair> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
   // Note: the returned filter list MUST be in the same order as the output
   // of supportedOutputRasterLayerFormatAndExtensions(), otherwise
   // QgsProcessingLayerOutputDestinationWidget::selectFile() will misbehave.
-  for ( const QPair<QString, QString> &formatAndExt : std::as_const( formatAndExtensions ) )
+  for ( const QgsProcessingFormatExtensionPair &formatAndExt : std::as_const( formatAndExtensions ) )
   {
-    QString format = formatAndExt.first;
-    const QString &extension = formatAndExt.second;
+    QString format = formatAndExt.format;
+    const QString &extension = formatAndExt.extension;
     if ( format.isEmpty() )
+    {
       format = extension;
-    filters << QObject::tr( "%1 files (*.%2)" ).arg( format.toUpper(), extension.toLower() );
+      filters << QObject::tr( "%1 files (*.%2)" ).arg( format.toUpper(), extension.toLower() );
+    }
+    else
+    {
+      // QgsProcessingLayerOutputDestinationWidget::selectFile() is sensitive
+      // to this "%1 - %2" format
+      filters << QObject::tr( "%1 - %2 files (*.%3)" ).arg( format.toUpper(), extension.toLower(), extension.toLower() );
+    }
   }
 
   return filters.join( ";;"_L1 ) + u";;"_s + QObject::tr( "All files (*.*)" );
@@ -7155,16 +7163,16 @@ QString QgsProcessingParameterRasterDestination::createFileFilter() const
 
 QStringList QgsProcessingParameterRasterDestination::supportedOutputRasterLayerExtensions() const
 {
-  const QList<QPair<QString, QString>> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
+  const QList<QgsProcessingFormatExtensionPair> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
   QSet< QString > extensions;
-  for ( const QPair<QString, QString> &formatAndExt : std::as_const( formatAndExtensions ) )
+  for ( const QgsProcessingFormatExtensionPair &formatAndExt : std::as_const( formatAndExtensions ) )
   {
-    extensions.insert( formatAndExt.second );
+    extensions.insert( formatAndExt.extension );
   }
   return QStringList( extensions.constBegin(), extensions.constEnd() );
 }
 
-QList<QPair<QString, QString>> QgsProcessingParameterRasterDestination::supportedOutputRasterLayerFormatAndExtensions() const
+QList<QgsProcessingFormatExtensionPair> QgsProcessingParameterRasterDestination::supportedOutputRasterLayerFormatAndExtensions() const
 {
   if ( auto *lOriginalProvider = originalProvider() )
   {

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -51,6 +51,29 @@ class QgsPointCloudLayer;
 class QgsAnnotationLayer;
 
 /**
+ * \class QgsProcessingFormatExtensionPair
+ * \ingroup core
+ *
+ * \brief Details of available filters and formats.
+ *
+ * \since QGIS 4.2
+ */
+struct CORE_EXPORT QgsProcessingFormatExtensionPair
+{
+    //! Unique format name (GDAL driver name)
+    QString format;
+
+    //! File extension
+    QString extension;
+
+    //! Constructor
+    QgsProcessingFormatExtensionPair( const QString &format, const QString &extension )
+      : format( format )
+      , extension( extension )
+    {}
+};
+
+/**
  * \class QgsProcessingFeatureSourceDefinition
  * \ingroup core
  *
@@ -3856,9 +3879,9 @@ class CORE_EXPORT QgsProcessingParameterRasterDestination : public QgsProcessing
     /**
      * Returns a list of (format, file extension) supported by this provider.
      *
-     * \since QGIS 3.40
+     * \since QGIS 4.2
      */
-    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+    virtual QList<QgsProcessingFormatExtensionPair> supportedOutputRasterLayerFormatAndExtensions() const;
 
     /**
      * Creates a new parameter using the definition from a script code.

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -71,29 +71,29 @@ QString QgsProcessingProvider::versionInfo() const
 
 QStringList QgsProcessingProvider::supportedOutputRasterLayerExtensions() const
 {
-  const QList<QPair<QString, QString>> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
+  const QList<QgsProcessingFormatExtensionPair> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
   QSet< QString > extensions;
   QStringList res;
-  for ( const QPair<QString, QString> &formatAndExt : std::as_const( formatAndExtensions ) )
+  for ( const QgsProcessingFormatExtensionPair &formatAndExt : std::as_const( formatAndExtensions ) )
   {
-    if ( !extensions.contains( formatAndExt.second ) )
+    if ( !extensions.contains( formatAndExt.extension ) )
     {
-      extensions.insert( formatAndExt.second );
-      res << formatAndExt.second;
+      extensions.insert( formatAndExt.extension );
+      res << formatAndExt.extension;
     }
   }
   return res;
 }
 
-QList<QPair<QString, QString>> QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensions() const
+QList<QgsProcessingFormatExtensionPair> QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensions() const
 {
   return supportedOutputRasterLayerFormatAndExtensionsDefault();
 }
 
-QList<QPair<QString, QString>> QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensionsDefault()
+QList<QgsProcessingFormatExtensionPair> QgsProcessingProvider::supportedOutputRasterLayerFormatAndExtensionsDefault()
 {
   const auto formats = QgsRasterFileWriter::supportedFiltersAndFormats();
-  QList<QPair<QString, QString>> res;
+  QList<QgsProcessingFormatExtensionPair> res;
 
   const thread_local QRegularExpression rx( u"\\*\\.([a-zA-Z0-9]*)"_s );
 
@@ -105,38 +105,38 @@ QList<QPair<QString, QString>> QgsProcessingProvider::supportedOutputRasterLayer
       continue;
 
     const QString matched = match.captured( 1 );
-    res << QPair<QString, QString>( format.driverName, matched );
+    res << QgsProcessingFormatExtensionPair( format.driverName, matched );
   }
 
-  std::sort( res.begin(), res.end(), []( const QPair<QString, QString> &a, const QPair<QString, QString> &b ) -> bool {
+  std::sort( res.begin(), res.end(), []( const QgsProcessingFormatExtensionPair &a, const QgsProcessingFormatExtensionPair &b ) -> bool {
     for ( const QString &tifExt : { u"tif"_s, u"tiff"_s } )
     {
-      if ( a.second == tifExt )
+      if ( a.extension == tifExt )
       {
-        if ( b.second == a.second )
+        if ( b.extension == a.extension )
         {
-          if ( a.first == "GTiff"_L1 )
+          if ( a.format == "GTiff"_L1 )
             return true;
-          else if ( b.first == "GTiff"_L1 )
+          else if ( b.format == "GTiff"_L1 )
             return false;
-          return a.first.toLower().localeAwareCompare( b.first.toLower() ) < 0;
+          return a.format.toLower().localeAwareCompare( b.format.toLower() ) < 0;
         }
         return true;
       }
-      else if ( b.second == tifExt )
+      else if ( b.extension == tifExt )
         return false;
     }
 
-    if ( a.second == "gpkg"_L1 )
+    if ( a.extension == "gpkg"_L1 )
     {
-      if ( b.second == a.second )
-        return a.first.toLower().localeAwareCompare( b.first.toLower() ) < 0;
+      if ( b.extension == a.extension )
+        return a.format.toLower().localeAwareCompare( b.format.toLower() ) < 0;
       return true;
     }
-    else if ( b.second == "gpkg"_L1 )
+    else if ( b.extension == "gpkg"_L1 )
       return false;
 
-    return a.second.toLower().localeAwareCompare( b.second.toLower() ) < 0;
+    return a.extension.toLower().localeAwareCompare( b.extension.toLower() ) < 0;
   } );
 
   return res;
@@ -324,10 +324,10 @@ QString QgsProcessingProvider::defaultRasterFileFormat() const
 {
   const QString userDefault = QgsProcessingUtils::defaultRasterFormat();
 
-  const QList<QPair<QString, QString>> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
-  for ( const QPair<QString, QString> &formatAndExt : std::as_const( formatAndExtensions ) )
+  const QList<QgsProcessingFormatExtensionPair> formatAndExtensions = supportedOutputRasterLayerFormatAndExtensions();
+  for ( const QgsProcessingFormatExtensionPair &formatAndExt : std::as_const( formatAndExtensions ) )
   {
-    if ( formatAndExt.first.compare( userDefault, Qt::CaseInsensitive ) == 0 )
+    if ( formatAndExt.format.compare( userDefault, Qt::CaseInsensitive ) == 0 )
     {
       // user set default is supported by provider, use that
       return userDefault;
@@ -336,7 +336,7 @@ QString QgsProcessingProvider::defaultRasterFileFormat() const
 
   if ( !formatAndExtensions.empty() )
   {
-    return formatAndExtensions.at( 0 ).first;
+    return formatAndExtensions.at( 0 ).format;
   }
   else
   {

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -153,16 +153,16 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
     /**
      * Returns a list of (format, file extension) supported by this provider.
      *
-     * \since QGIS 4.0
+     * \since QGIS 4.2
      */
-    virtual QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const;
+    virtual QList<QgsProcessingFormatExtensionPair> supportedOutputRasterLayerFormatAndExtensions() const;
 
     /**
      * Returns a list of (format, file extension) supported by GDAL
      *
-     * \since QGIS 4.0
+     * \since QGIS 4.2
      */
-    static QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensionsDefault() SIP_SKIP;
+    static QList<QgsProcessingFormatExtensionPair> supportedOutputRasterLayerFormatAndExtensionsDefault() SIP_SKIP;
 
     /**
      * Returns a list of the vector format file extensions supported by this provider.

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -428,6 +428,8 @@ void QgsProcessingLayerOutputDestinationWidget::selectFile()
     Q_ASSERT( dest );
     lastFormatPath = u"/Processing/LastRasterOutputFormat"_s;
     lastFormat = settings.value( lastFormatPath, dest->defaultFileFormat() ).toString();
+    lastExtPath = u"/Processing/LastRasterOutputExt"_s;
+    lastExt = settings.value( lastExtPath, u".%1"_s.arg( mParameter->defaultFileExtension() ) ).toString();
   }
   else if ( mParameter->type() == QgsProcessingParameterPointCloudDestination::typeName() )
   {
@@ -443,17 +445,40 @@ void QgsProcessingLayerOutputDestinationWidget::selectFile()
   // get default filter
   const QStringList filters = fileFilter.split( u";;"_s );
   QString lastFilter;
-  for ( const QString &f : filters )
+  if ( !lastFormat.isEmpty() && !lastExt.isEmpty() )
   {
-    if ( !lastFormat.isEmpty() && f.contains( lastFormat, Qt::CaseInsensitive ) )
+    // If we have both the format and extension, use in priority the filter
+    // that associates both, in case of multiple extensions per format.
+    for ( const QString &f : filters )
     {
-      lastFilter = f;
-      break;
+      // "%1 - %2 " pattern from QgsProcessingParameterRasterDestination::createFileFilter()
+      if ( f.contains( u"%1 - %2 "_s.arg( lastFormat, lastExt ), Qt::CaseInsensitive ) )
+      {
+        lastFilter = f;
+        break;
+      }
     }
-    else if ( !lastExt.isEmpty() && f.contains( u"*.%1"_s.arg( lastExt ), Qt::CaseInsensitive ) )
+  }
+  if ( lastFilter.isEmpty() && !lastFormat.isEmpty() )
+  {
+    for ( const QString &f : filters )
     {
-      lastFilter = f;
-      break;
+      if ( f.contains( lastFormat, Qt::CaseInsensitive ) )
+      {
+        lastFilter = f;
+        break;
+      }
+    }
+  }
+  if ( lastFilter.isEmpty() && !lastExt.isEmpty() )
+  {
+    for ( const QString &f : filters )
+    {
+      if ( f.contains( u"*.%1"_s.arg( lastExt ), Qt::CaseInsensitive ) )
+      {
+        lastFilter = f;
+        break;
+      }
     }
   }
 
@@ -474,14 +499,14 @@ void QgsProcessingLayerOutputDestinationWidget::selectFile()
     if ( mParameter->type() == QgsProcessingParameterRasterDestination::typeName() )
     {
       const QgsProcessingParameterRasterDestination *rasterParam = static_cast<const QgsProcessingParameterRasterDestination *>( mParameter );
-      const QList<QPair<QString, QString>> formatAndExtensions = rasterParam->supportedOutputRasterLayerFormatAndExtensions();
+      const QList<QgsProcessingFormatExtensionPair> formatAndExtensions = rasterParam->supportedOutputRasterLayerFormatAndExtensions();
       Q_ASSERT( formatAndExtensions.size() + 1 == filters.size() ); // filters have one more entry for all files
       int idxFilter = 0;
       for ( const QString &f : filters )
       {
         if ( f == lastFilter )
         {
-          mFormat = formatAndExtensions[idxFilter].first;
+          mFormat = formatAndExtensions[idxFilter].format;
           break;
         }
         ++idxFilter;
@@ -494,7 +519,7 @@ void QgsProcessingLayerOutputDestinationWidget::selectFile()
     settings.setValue( u"/Processing/LastOutputPath"_s, QFileInfo( filename ).path() );
     if ( !lastFormatPath.isEmpty() && !mFormat.isEmpty() )
       settings.setValue( lastFormatPath, mFormat );
-    else if ( !lastExtPath.isEmpty() )
+    if ( !lastExtPath.isEmpty() )
       settings.setValue( lastExtPath, QFileInfo( filename ).suffix().toLower() );
 
     emit skipOutputChanged( false );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -209,6 +209,7 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
       QCOMPARE( rasterParam->defaultFileExtension(), u"tif"_s ); // before alg is accessible
       QVERIFY( addParameter( rasterParam ) );
       QCOMPARE( rasterParam->defaultFileExtension(), u"tif"_s );
+      QVERIFY( rasterParam->createFileFilter().contains( u"GTIFF - tif files (*.tif)"_s ) );
 
       // should allow parameters with same name but different case (required for grass provider)
       QgsProcessingParameterBoolean *p1C = new QgsProcessingParameterBoolean( "P1" );
@@ -618,9 +619,9 @@ class DummyProvider3 : public QgsProcessingProvider // clazy:exclude=missing-qob
 
     QStringList supportedOutputTableExtensions() const override { return QStringList() << u"dbf"_s; }
 
-    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override
+    QList<QgsProcessingFormatExtensionPair> supportedOutputRasterLayerFormatAndExtensions() const override
     {
-      return QList<QPair<QString, QString>>() << QPair<QString, QString>( u"XYZ"_s, u"xyz"_s ) << QPair<QString, QString>( u"BMP"_s, u"bmp"_s );
+      return QList<QgsProcessingFormatExtensionPair>() << QgsProcessingFormatExtensionPair( u"XYZ"_s, u"xyz"_s ) << QgsProcessingFormatExtensionPair( u"BMP"_s, u"bmp"_s );
     }
 
     QStringList supportedOutputPointCloudLayerExtensions() const override { return QStringList() << u"las"_s << u"ept.json"_s; }
@@ -639,7 +640,10 @@ class DummyProvider4 : public QgsProcessingProvider // clazy:exclude=missing-qob
 
     QStringList supportedOutputVectorLayerExtensions() const override { return QStringList() << u"mif"_s; }
 
-    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override { return QList<QPair<QString, QString>>() << QPair<QString, QString>( QString(), u"mig"_s ); }
+    QList<QgsProcessingFormatExtensionPair> supportedOutputRasterLayerFormatAndExtensions() const override
+    {
+      return QList<QgsProcessingFormatExtensionPair>() << QgsProcessingFormatExtensionPair( QString(), u"mig"_s );
+    }
 
     void loadAlgorithms() override { QVERIFY( addAlgorithm( new DummyAlgorithm2( "alg1" ) ) ); }
 };
@@ -8683,12 +8687,12 @@ void TestQgsProcessing::parameterRasterOut()
   QVERIFY( def->createFileFilter().contains( u"*.*"_s ) );
 
   const QStringList filters = def->createFileFilter().split( u";;"_s );
-  const QList<QPair<QString, QString>> formatAndExtensions = def->supportedOutputRasterLayerFormatAndExtensions();
+  const QList<QgsProcessingFormatExtensionPair> formatAndExtensions = def->supportedOutputRasterLayerFormatAndExtensions();
   QCOMPARE( filters.size(), formatAndExtensions.size() + 1 ); // filters have one more entry for all files
   for ( qsizetype i = 0; i < formatAndExtensions.size(); ++i )
   {
-    QVERIFY( filters[i].contains( formatAndExtensions[i].first.toUpper() ) );
-    QVERIFY( filters[i].contains( formatAndExtensions[i].second ) );
+    QVERIFY( filters[i].contains( formatAndExtensions[i].format.toUpper() ) );
+    QVERIFY( filters[i].contains( formatAndExtensions[i].extension ) );
   }
 
   QVariantMap params;

--- a/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
+++ b/tests/src/analysis/testqgsprocessingmodelalgorithm.cpp
@@ -120,7 +120,10 @@ class DummyProvider4 : public QgsProcessingProvider // clazy:exclude=missing-qob
 
     QStringList supportedOutputVectorLayerExtensions() const override { return QStringList() << u"mif"_s; }
 
-    QList<QPair<QString, QString>> supportedOutputRasterLayerFormatAndExtensions() const override { return QList<QPair<QString, QString>>() << QPair<QString, QString>( u"XYZ"_s, u"xyz"_s ); }
+    QList<QgsProcessingFormatExtensionPair> supportedOutputRasterLayerFormatAndExtensions() const override
+    {
+      return QList<QgsProcessingFormatExtensionPair>() << QgsProcessingFormatExtensionPair( u"XYZ"_s, u"xyz"_s );
+    }
 
     void loadAlgorithms() override
     {


### PR DESCRIPTION
Fixes #66319

The issue was that GdalAlgorithmProvider still defined the old supportedOutputRasterLayerExtensions() method that is no longer virtual, and thus it was no longer an override. Using
supportedOutputRasterLayerFormatAndExtensions() instead is the key fix. Same for GrassProvider.

I also had to change the signature of methods added in 4.0 that were using ``QPair<QString, QString>`` which doesn't map to SIP automatically.

<img width="244" height="468" alt="image" src="https://github.com/user-attachments/assets/6ff2f536-52bc-4fa1-810c-3ca032f70a20" />


## AI tool usage

 - [ ] No AI tool
