### PR TITLE
Remove colon at the end of widgets label in 3D Camera Controls dialog 

### DIFF
--- a/src/app/3d/qgs3dcameracontrolswidget.cpp
+++ b/src/app/3d/qgs3dcameracontrolswidget.cpp
@@ -21,6 +21,7 @@
 #include "qgs3dutils.h"
 #include "qgscameracontroller.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgshelp.h"
 #include "qgslayoututils.h"
 #include "qgssettingstree.h"
 
@@ -32,7 +33,8 @@
 
 using namespace Qt::StringLiterals;
 
-const QgsSettingsEntryBool *Qgs3DCameraControlsWidget::setting3DCameraControlsLiveUpdate = new QgsSettingsEntryBool( u"camera-controls-live-update"_s, QgsSettingsTree::sTree3DMap, true, u"Whether the 3D map is dynamically updated while camera controls are edited"_s );
+const QgsSettingsEntryBool *Qgs3DCameraControlsWidget::setting3DCameraControlsLiveUpdate
+  = new QgsSettingsEntryBool( u"camera-controls-live-update"_s, QgsSettingsTree::sTree3DMap, true, u"Whether the 3D map is dynamically updated while camera controls are edited"_s );
 
 Qgs3DCameraControlsWidget::Qgs3DCameraControlsWidget( Qgs3DMapCanvas *canvas, QWidget *parent )
   : QWidget( parent )
@@ -45,6 +47,7 @@ Qgs3DCameraControlsWidget::Qgs3DCameraControlsWidget( Qgs3DMapCanvas *canvas, QW
   connect( mAutoApplyTimer, &QTimer::timeout, this, &Qgs3DCameraControlsWidget::applySettings );
 
   connect( mButtonBox->button( QDialogButtonBox::Apply ), &QAbstractButton::clicked, this, &Qgs3DCameraControlsWidget::applySettings );
+  connect( mHelpButtonBox, &QDialogButtonBox::helpRequested, this, [] { QgsHelp::openHelp( u"map_views/3d_map_view.html"_s ); } );
   connect( mLiveApplyCheck, &QCheckBox::toggled, this, &Qgs3DCameraControlsWidget::liveApplyToggled );
 
   mLiveApplyCheck->setChecked( setting3DCameraControlsLiveUpdate->value() );
@@ -69,12 +72,7 @@ void Qgs3DCameraControlsWidget::updateCameraLookingAt()
   QgsVector3D worldLookingAt = m3DMapCanvas->mapSettings()->mapToWorldCoordinates( mapLookingAt );
   worldLookingAt.setZ( mCameraZ->value() );
 
-  m3DMapCanvas->cameraController()->setLookingAtPoint(
-    worldLookingAt,
-    m3DMapCanvas->cameraController()->distance(),
-    m3DMapCanvas->cameraController()->pitch(),
-    m3DMapCanvas->cameraController()->yaw()
-  );
+  m3DMapCanvas->cameraController()->setLookingAtPoint( worldLookingAt, m3DMapCanvas->cameraController()->distance(), m3DMapCanvas->cameraController()->pitch(), m3DMapCanvas->cameraController()->yaw() );
 }
 
 void Qgs3DCameraControlsWidget::updateFromCamera() const

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -294,7 +294,7 @@ Qgs3DMapCanvasWidget::Qgs3DMapCanvasWidget( const QString &name, bool isDocked )
   };
   createShortcuts( u"m3DSetSceneExtent"_s, &Qgs3DMapCanvasWidget::setSceneExtentOn2DCanvas );
 
-  mActionOpenCameraControlsWidget = new QAction( QgsApplication::getThemeIcon( u"/mIconCamera.svg"_s ), tr( "Camera controls" ), this );
+  mActionOpenCameraControlsWidget = new QAction( QgsApplication::getThemeIcon( u"/mIconCamera.svg"_s ), tr( "Camera Controls" ), this );
   connect( mActionOpenCameraControlsWidget, &QAction::triggered, this, &Qgs3DMapCanvasWidget::configureCamera );
   mCameraMenu->addAction( mActionOpenCameraControlsWidget );
 
@@ -847,7 +847,7 @@ void Qgs3DMapCanvasWidget::configureCamera()
 
   mCameraControlsDialog = new QDialog( this );
   mCameraControlsDialog->setAttribute( Qt::WA_DeleteOnClose );
-  mCameraControlsDialog->setWindowTitle( tr( "Camera controls" ) );
+  mCameraControlsDialog->setWindowTitle( tr( "Camera Controls" ) );
   mCameraControlsDialog->setObjectName( u"3DCameraControlsDialog"_s );
   mCameraControlsDialog->setMinimumSize( 300, 200 );
   QgsGui::enableAutoGeometryRestore( mCameraControlsDialog );

--- a/src/app/tiledscene/qgstiledsceneelevationpropertieswidget.cpp
+++ b/src/app/tiledscene/qgstiledsceneelevationpropertieswidget.cpp
@@ -42,7 +42,7 @@ QgsTiledSceneElevationPropertiesWidget::QgsTiledSceneElevationPropertiesWidget( 
   connect( mScaleZSpinBox, qOverload<double>( &QDoubleSpinBox::valueChanged ), this, &QgsTiledSceneElevationPropertiesWidget::onChanged );
   connect( mShiftZAxisButton, &QPushButton::clicked, this, &QgsTiledSceneElevationPropertiesWidget::shiftSceneZAxis );
 
-  // setProperty( "helpPage", u"working_with_point_clouds/point_clouds.html#elevation-properties"_s );
+  setProperty( "helpPage", u"working_with_3d_tiles/3d_tiles.html#elevation-properties"_s );
 }
 
 void QgsTiledSceneElevationPropertiesWidget::syncToLayer( QgsMapLayer *layer )

--- a/src/ui/3d/qgs3dcameracontrolswidget.ui
+++ b/src/ui/3d/qgs3dcameracontrolswidget.ui
@@ -20,14 +20,14 @@
    <item row="5" column="0">
     <widget class="QLabel" name="labelDistanceFromCenterPoint">
      <property name="text">
-      <string>Distance from center:</string>
+      <string>Distance from center</string>
      </property>
     </widget>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="labelY">
      <property name="text">
-      <string>Looking at Y:</string>
+      <string>Looking at Y</string>
      </property>
     </widget>
    </item>
@@ -47,7 +47,7 @@
    <item row="1" column="1">
     <widget class="QDoubleSpinBox" name="mCameraX"/>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="9" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <spacer name="horizontalSpacer">
@@ -93,6 +93,19 @@
      </item>
     </layout>
    </item>
+   <item row="8" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="6" column="1">
     <widget class="QDoubleSpinBox" name="mCameraPitch">
      <property name="suffix">
@@ -106,7 +119,7 @@
    <item row="3" column="0">
     <widget class="QLabel" name="labelZ">
      <property name="text">
-      <string>Looking at Z:</string>
+      <string>Looking at Z</string>
      </property>
     </widget>
    </item>
@@ -123,26 +136,35 @@
    <item row="1" column="0">
     <widget class="QLabel" name="labelX">
      <property name="text">
-      <string>Looking at X:</string>
+      <string>Looking at X</string>
      </property>
     </widget>
    </item>
    <item row="7" column="0">
     <widget class="QLabel" name="labelHeading">
      <property name="text">
-      <string>Heading:</string>
+      <string>Heading</string>
      </property>
     </widget>
    </item>
    <item row="6" column="0">
     <widget class="QLabel" name="labelPitch">
      <property name="text">
-      <string>Pitch:</string>
+      <string>Pitch</string>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mCameraX</tabstop>
+  <tabstop>mCameraY</tabstop>
+  <tabstop>mCameraZ</tabstop>
+  <tabstop>mCameraDistanceFromCenterPoint</tabstop>
+  <tabstop>mCameraPitch</tabstop>
+  <tabstop>mCameraHeading</tabstop>
+  <tabstop>mLiveApplyCheck</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/3d/qgs3dcameracontrolswidget.ui
+++ b/src/ui/3d/qgs3dcameracontrolswidget.ui
@@ -50,6 +50,13 @@
    <item row="9" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QDialogButtonBox" name="mHelpButtonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::StandardButton::Help</set>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Orientation::Horizontal</enum>


### PR DESCRIPTION
refs [rule 4](https://docs.qgis.org/testing/en/docs/developers_guide/hig.html):
> Do not end labels for widgets or group boxes with a colon: Adding a colon causes visual noise and does not impart additional meaning, so don’t use them. An exception to this rule is when you have two labels next to each other e.g.: Label1 Plugin (Path:) Label2 [/path/to/plugins]

Also add and fix help button.

PS: I couldn't find how to fix the widgets shrinking...

Before
<img width="885" height="607" alt="Peek 06-06-2026 16-36" src="https://github.com/user-attachments/assets/b208d6ea-da01-44eb-baf0-c06d184c489a" />


After
<img width="885" height="607" alt="Peek 06-06-2026 16-28" src="https://github.com/user-attachments/assets/538eee53-5079-4d10-ab6f-6af512ee2e0b" />
