### PR TITLE
[server][oapif]Fix #66363 FGB export when qgs_fid

### DIFF
--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1194,7 +1194,12 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
 
   const auto attributes { featureRequest.subsetOfAttributes() };
   QgsFields exportedFields;
-  exportedFields.append( QgsField( u"qgs_fid"_s, QMetaType::Type::QString ) );
+  const bool addQgsFid { mapLayer->dataProvider()->pkAttributeIndexes().count() > 1 && mapLayer->fields().lookupField( u"qgs_fid"_s ) == -1 };
+  if ( addQgsFid )
+  {
+    exportedFields.append( QgsField( u"qgs_fid"_s, QMetaType::Type::QString ) );
+  }
+
   for ( int i = 0; i < mapLayer->fields().count(); i++ )
   {
     if ( !attributes.isEmpty() && !attributes.contains( i ) )
@@ -1228,7 +1233,6 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
   QgsFeatureIterator features { mapLayer->getFeatures( featureRequest ) };
   QgsFeature feat;
   qlonglong i { 0 };
-  QMap<QgsFeatureId, QString> fidMap;
 
   while ( features.nextFeature( feat ) )
   {
@@ -1236,13 +1240,14 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
     if ( i >= exportContext.offset )
     {
       // Patch feature to add the server feature id
-      const QgsFeatureId originalFid { feat.id() };
-      const QString newFid { QgsServerFeatureId::getServerFid( feat, mapLayer->dataProvider()->pkAttributeIndexes() ) };
-      fidMap.insert( originalFid, newFid );
-      QgsAttributes attributes = feat.attributes();
-      attributes.insert( 0, newFid );
-      feat.setFields( exportedFields );
-      feat.setAttributes( attributes );
+      if ( addQgsFid )
+      {
+        const QString newFid { QgsServerFeatureId::getServerFid( feat, mapLayer->dataProvider()->pkAttributeIndexes() ) };
+        QgsAttributes attributes = feat.attributes();
+        attributes.insert( 0, newFid );
+        feat.setAttributes( attributes );
+        feat.setFields( exportedFields );
+      }
       featureList << feat;
     }
     i++;
@@ -1271,6 +1276,7 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
     }
   }
 
+  // cannot be const:
   for ( QgsFeature &f : featureList )
   {
     if ( !writer->addFeature( f ) )

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1194,6 +1194,7 @@ void QgsWfs3CollectionsItemsHandler::writeFlatGeobufOutput( const QgsVectorLayer
 
   const auto attributes { featureRequest.subsetOfAttributes() };
   QgsFields exportedFields;
+  // Server FID is required if the layer has a compound primary key and doesn't already have a field named "qgs_fid"
   const bool addQgsFid { mapLayer->dataProvider()->pkAttributeIndexes().count() > 1 && mapLayer->fields().lookupField( u"qgs_fid"_s ) == -1 };
   if ( addQgsFid )
   {

--- a/tests/src/python/test_qgsserver_api.py
+++ b/tests/src/python/test_qgsserver_api.py
@@ -54,7 +54,7 @@ from qgis.server import (
 )
 from qgis.testing import unittest
 from test_qgsserver import QgsServerTestBase
-from utilities import unitTestDataPath
+from utilities import compareWkt, unitTestDataPath
 
 
 class QgsServerAPIUtilsTest(QgsServerTestBase):
@@ -1040,7 +1040,7 @@ class QgsServerAPITest(QgsServerAPITestBase):
             return layer
 
         layer = _get_layer()
-        self.assertEqual(layer.getFeature(0).attributes(), ["0", 1, "one", "one èé"])
+        self.assertEqual(layer.getFeature(0).attributes(), [1, "one", "one èé"])
         geom = layer.getFeature(0).geometry()
         self.assertAlmostEqual(geom.asPoint().x(), 8.20349, 4)
         self.assertAlmostEqual(geom.asPoint().y(), 44.90148, 4)
@@ -1056,17 +1056,49 @@ class QgsServerAPITest(QgsServerAPITestBase):
         self.assertEqual(headers["OGC-NumberReturned"][0], "2")
 
         layer = _get_layer()
-        self.assertEqual(layer.getFeature(0).attributes(), ["1", 2, "two", "two àò"])
+        self.assertEqual(layer.getFeature(0).attributes(), [2, "two", "two àò"])
         geom = layer.getFeature(0).geometry()
         self.assertAlmostEqual(geom.asPoint().x(), 8.20354, 4)
         self.assertAlmostEqual(geom.asPoint().y(), 44.90148, 4)
 
-        self.assertEqual(
-            layer.getFeature(1).attributes(), ["2", 3, "three", "three èé↓"]
-        )
+        self.assertEqual(layer.getFeature(1).attributes(), [3, "three", "three èé↓"])
         geom = layer.getFeature(1).geometry()
         self.assertAlmostEqual(geom.asPoint().x(), 8.20345, 4)
         self.assertAlmostEqual(geom.asPoint().y(), 44.90139, 4)
+
+    def test_wfs3_collection_items_geobuf_qgsfid(self):
+
+        mem_layer = QgsVectorLayer(
+            "Point?crs=epsg:4326&field=id:integer&field=qgs_fid:integer",
+            "mem_layer",
+            "memory",
+        )
+        self.assertTrue(mem_layer.isValid())
+        f = QgsFeature(mem_layer.fields())
+        f.setAttributes([1, 123])
+        f.setGeometry(QgsGeometry.fromWkt("POINT(4 5)"))
+        self.assertTrue(mem_layer.dataProvider().addFeatures([f]))
+        project = QgsProject()
+        project.addMapLayer(mem_layer)
+        # Expose to WFS3 API
+        project.writeEntry("WFSLayers", "/", [mem_layer.id()])
+        request = QgsBufferServerRequest(
+            "http://server.qgis.org/wfs3/collections/mem_layer/items.fgb?limit=1"
+        )
+        response = QgsBufferServerResponse()
+        self.server.handleRequest(request, response, project)
+        # Open response body as FGB and check attributes
+        temp_dir = QtCore.QTemporaryDir()
+        temp_path = temp_dir.path()
+        path = os.path.join(temp_path, "mem_layer.fgb")
+        with open(path.encode("utf8"), "wb") as f:
+            f.write(response.body())
+        layer = QgsVectorLayer(path, "mem_layer", "ogr")
+        self.assertTrue(layer.isValid())
+        self.assertEqual(layer.getFeature(0).attributes(), [1, 123])
+        # Check geometry
+        geom = layer.getFeature(0).geometry()
+        self.assertTrue(compareWkt(geom.asWkt(), "POINT (4 5)"))
 
     def test_wfs3_collection_items_aspatial_flatgeobuf(self):
         """Test flatgeobuf output for non spatial layer"""


### PR DESCRIPTION
Also, do not add qgs_fid if there are no composite PKs

Fix #66363
 