### PR TITLE
[backport release-3_44][projects] Once the author metadata is set, don't overwrite its value

### DIFF
--- a/src/core/project/qgsproject.cpp
+++ b/src/core/project/qgsproject.cpp
@@ -3282,7 +3282,10 @@ bool QgsProject::writeProjectFile( const QString &filename )
     qgisNode.setAttribute( QStringLiteral( "saveUserFull" ), newSaveUserFull );
     mSaveUser = newSaveUser;
     mSaveUserFull = newSaveUserFull;
-    mMetadata.setAuthor( QgsApplication::userFullName() );
+    if ( mMetadata.author().isEmpty() )
+    {
+      mMetadata.setAuthor( QgsApplication::userFullName() );
+    }
     if ( !mMetadata.creationDateTime().isValid() )
     {
       mMetadata.setCreationDateTime( QDateTime( QDateTime::currentDateTime() ) );


### PR DESCRIPTION
## Description

Manual backport of https://github.com/qgis/QGIS/commit/15be1eb348fc29a897ee8f45f9c2ab505aad1d59 which I somehow missed back in September 2025.

Without this fix in, the project metadata's author value - which users _can and should_ be able to edit - gets overwritten every time the project is saved.