### PR TITLE
[wms] Ensure we store deduced CRS in provider/layer sources

### DIFF
--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -813,9 +813,10 @@ void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProv
     QgsDebugMsgLevel( u"Set Data provider QgsLayerMetadata identifier[%1]"_s.arg( metadata().identifier() ), 4 );
   }
 
-  if ( provider == "gdal"_L1 )
+  if ( provider == "gdal"_L1 || provider == "wms"_L1 )
   {
-    // make sure that the /vsigzip or /vsizip is added to uri, if applicable
+    // if provider has updated its URI, make sure we store the updated one.
+    // TODO: this probably should be enabled for all provider, but we'll play it safe for now...
     mDataSource = mDataProvider->dataSourceUri();
   }
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -113,7 +113,7 @@ struct LessThanTileRequest
 };
 
 
-QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &options, const QgsWmsCapabilities *capabilities )
+QgsWmsProvider::QgsWmsProvider( const QString &uri, const ProviderOptions &options, const QgsWmsCapabilities *capabilities )
   : QgsRasterDataProvider( uri, options )
   , mHttpGetLegendGraphicResponse( nullptr )
   , mImageCrs( DEFAULT_LATLON_CRS )
@@ -133,6 +133,9 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
     appendError( ERR( tr( "Cannot parse URI" ) ) );
     return;
   }
+
+  QgsDataSourceUri sourceUri;
+  sourceUri.setEncodedUri( uri );
 
   if ( !addLayers() )
     return;
@@ -207,6 +210,7 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
         if ( property.name == mSettings.mActiveSubLayers[0] )
         {
           mSettings.mCrsId = property.preferredAvailableCrs();
+          sourceUri.setParam( u"crs"_s, mSettings.mCrsId );
           break;
         }
       }
@@ -276,6 +280,22 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
   }
 
   mValid = true;
+
+  // this is very messy, but XYZ/mbtile providers don't use encoded URIs. So we'll only update the
+  // stored data source URI for non-xyz/mbtile sources. For now this is safe, as we've only got logic
+  // in place above to change the URI params for non-xyz/mbtile sources, but this will possibly need
+  // to be revised in future if that assumption changes...
+  if ( !mSettings.mXyz )
+  {
+    // update stored source URI string for provider, as we may have guessed parameters in the logic
+    // above (such as picking a CRS if it wasn't explicitly specified), and we need to ensure that
+    // the provider's URI string is a full representation of the state of the provider at the time
+    // these parameters were deduced (eg, to protect against the order of get capabilities CRSes changing,
+    // which would mean we pick a different default CRS, which would differ from the CRS stored at the
+    // MAP LAYER level, leading to a broken layer...)
+    setDataSourceUri( sourceUri.encodedUri() );
+  }
+
   QgsDebugMsgLevel( u"exiting constructor."_s, 4 );
 }
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -134,6 +134,8 @@ QgsWmsProvider::QgsWmsProvider( const QString &uri, const ProviderOptions &optio
     return;
   }
 
+  // non for xyz sources, this tracks the actual resolved properties of the
+  // WMS provider (eg detected CRS when no crs was specified in the original source uri)
   QgsDataSourceUri sourceUri;
   sourceUri.setEncodedUri( uri );
 

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -193,8 +193,14 @@ void TestQgsWmsProvider::noCrsSpecified()
 {
   QgsWmsProvider provider( u"http://localhost:8380/mapserv?xxx&layers=agri_zones&styles=&format=image/jpg"_s, QgsDataProvider::ProviderOptions(), mCapabilities );
   QCOMPARE( provider.crs().authid(), u"EPSG:2056"_s );
+  // assert that deduced crs has been embedded into the provider's source, so that it can't change even if the provider's capabilities response is changed.
+  // NOTE: this isn't ideal -- it would be preferable if the provider always updated its CRS to match the service. But the CRS is ALSO stored at a map layer
+  // level, and we MUST ensure that the CRS stored at the layer level is always reflected by the provider. Otherwise if the provider capabilities changes,
+  // then the two can get out-of-sync resulting in a broken layer
+  QCOMPARE( provider.dataSourceUri(), u"crs=EPSG%3A2056&format=image%2Fjpg&http://localhost:8380/mapserv?xxx&layers=agri_zones&styles="_s );
   QgsWmsProvider provider2( u"http://localhost:8380/mapserv?xxx&layers=agri_zones&styles=&format=image/jpg&crs=EPSG:4326"_s, QgsDataProvider::ProviderOptions(), mCapabilities );
   QCOMPARE( provider2.crs().authid(), u"EPSG:4326"_s );
+  QCOMPARE( provider2.dataSourceUri(), u"crs=EPSG%3A4326&format=image%2Fjpg&http://localhost:8380/mapserv?xxx&layers=agri_zones&styles="_s );
 
   QFile file( QStringLiteral( TEST_DATA_DIR ) + "/provider/GetCapabilities2.xml" );
   QVERIFY( file.open( QIODevice::ReadOnly | QIODevice::Text ) );


### PR DESCRIPTION
The deduced crs must be embedded into the provider's source, so that it can't change even if the provider's capabilities response is changed.

NOTE: this isn't ideal -- it would be preferable if the provider always updated its CRS to match the service. But the CRS is ALSO stored at a map layer level, and we MUST ensure that the CRS stored at the layer level is always reflected by the provider. Otherwise if the provider capabilities changes, then the two can get out-of-sync resulting in a broken layer


In general I think some wider reworking is desirable here. I think ideally the layer-level CRS would only be stored if the user has explicitly changed it from the provider's CRS, i.e. it is purely a way of storing a CRS overridden at the layer's level (for cases when the provider can't deduce this information, or if it's incorrect). In all other cases we are better to determine the ACTUAL crs from the data provider, so that sources correctly respond and automatically handle changes to the backend data store (eg a postgres table which the db administrator has changed to a different CRS). But that's a intrusive change which needs wider discussion, so I'm just throwing a band-aid on top of the issue here....
