### PR TITLE
Add explicit bool operator for QgsLayerTreeNode

### DIFF
--- a/python/PyQt6/core/auto_generated/layertree/qgslayertreenode.sip.in
+++ b/python/PyQt6/core/auto_generated/layertree/qgslayertreenode.sip.in
@@ -117,6 +117,12 @@ Returns the number of children contained in the node.
     sipRes = sipCpp->children().count();
 %End
 
+    //! Ensures that bool(obj) returns ``True`` (otherwise __len__() would be used)
+    int __bool__() const;
+%MethodCode
+    sipRes = true;
+%End
+
     SIP_PYOBJECT __getitem__( int index ) /TypeHint="QgsLayerTreeNode"/;
 %Docstring
 Returns the child node at the specified ``index``.

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -131,6 +131,12 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     sipRes = sipCpp->children().count();
     % End
 
+    //! Ensures that bool(obj) returns TRUE (otherwise __len__() would be used)
+    int __bool__() const;
+    % MethodCode
+    sipRes = true;
+    % End
+
     /**
      * Returns the child node at the specified ``index``.
      *

--- a/tests/src/python/test_qgslayertree.py
+++ b/tests/src/python/test_qgslayertree.py
@@ -43,12 +43,15 @@ class TestQgsLayerTree(QgisTestCase):
         Test python methods for layer tree classes
         """
         group = QgsLayerTreeGroup("test")
+        self.assertTrue(group)
         self.assertEqual(len(group), 0)
         with self.assertRaises(IndexError):
             group[0]
         with self.assertRaises(IndexError):
             group[-1]
         group2 = group.addGroup("test 2")
+        self.assertTrue(group)
+        self.assertTrue(group2)
         self.assertEqual(len(group), 1)
         self.assertEqual(group[0], group2)
         with self.assertRaises(IndexError):
@@ -65,6 +68,7 @@ class TestQgsLayerTree(QgisTestCase):
         layer = QgsVectorLayer("Point?field=fldtxt:string", "layer1", "memory")
         layer_node = group.addLayer(layer)
         self.assertEqual(len(group), 3)
+        self.assertTrue(group)
         self.assertEqual(group[0], group2)
         self.assertEqual(group[1], group3)
         self.assertEqual(group[2], layer_node)


### PR DESCRIPTION
Prevents python delegating truth to non-zero len values

Fixes #65755
