### PR TITLE
GDAL algorithms: bring back non-Create() capable formats such as AAIGRID .asc

### DIFF
--- a/python/plugins/grassprovider/grass_provider.py
+++ b/python/plugins/grassprovider/grass_provider.py
@@ -204,8 +204,8 @@ class GrassProvider(QgsProcessingProvider):
         # different from QGIS OGR version.
         return super().supportedOutputVectorLayerExtensions()
 
-    def supportedOutputRasterLayerExtensions(self):
-        return GrassUtils.getSupportedOutputRasterExtensions()
+    def getSupportedOutputRasterFormatAndExtensions(self):
+        return GrassUtils.getSupportedOutputRasterFormatAndExtensions()
 
     def canBeActivated(self):
         return not bool(GrassUtils.checkGrassIsInstalled())

--- a/python/plugins/grassprovider/grass_utils.py
+++ b/python/plugins/grassprovider/grass_utils.py
@@ -665,12 +665,12 @@ class GrassUtils:
             return "https://grass.osgeo.org/grass-stable/manuals/"
 
     @staticmethod
-    def getSupportedOutputRasterExtensions():
+    def getSupportedOutputRasterFormatAndExtensions():
         # We use the same extensions as GDAL because:
         # - GRASS is also using GDAL for raster imports.
         # - Chances that GRASS is compiled with another version of
         # GDAL than QGIS are very limited!
-        return GdalUtils.getSupportedOutputRasterExtensions()
+        return GdalUtils.getSupportedOutputRasterFormatAndExtensions()
 
     @staticmethod
     def getRasterFormatFromFilename(filename):

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -214,8 +214,8 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
         for a in self.algs:
             self.addAlgorithm(a)
 
-    def supportedOutputRasterLayerExtensions(self):
-        return GdalUtils.getSupportedOutputRasterExtensions()
+    def supportedOutputRasterLayerFormatAndExtensions(self):
+        return GdalUtils.getSupportedOutputRasterFormatAndExtensions()
 
     def supportsNonFileBasedOutput(self):
         """

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -297,15 +297,18 @@ class GdalUtils:
         return allexts
 
     @staticmethod
-    def getSupportedOutputRasterExtensions():
-        allexts = []
-        for exts in list(GdalUtils.getSupportedOutputRasters().values()):
+    def getSupportedOutputRasterFormatAndExtensions():
+        res = []
+        for format, exts in GdalUtils.getSupportedOutputRasters().items():
             for ext in exts:
-                if ext not in allexts and ext not in ["", "tif", "tiff"]:
-                    allexts.append(ext)
-        allexts.sort()
-        allexts[0:0] = ["tif", "tiff"]
-        return allexts
+                if ext != "" and format != "GTiff":
+                    res.append((format, ext))
+        res.sort()
+        res[0:0] = [
+            ("GTiff", "tif"),
+            ("GTiff", "tiff"),
+        ]
+        return res
 
     @staticmethod
     def getVectorDriverFromFileName(filename):

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -7143,11 +7143,18 @@ QString QgsProcessingParameterRasterDestination::createFileFilter() const
   // QgsProcessingLayerOutputDestinationWidget::selectFile() will misbehave.
   for ( const QPair<QString, QString> &formatAndExt : std::as_const( formatAndExtensions ) )
   {
-    QString format = formatAndExt.first;
+    const QString &format = formatAndExt.first;
     const QString &extension = formatAndExt.second;
     if ( format.isEmpty() )
-      format = extension;
-    filters << QObject::tr( "%1 files (*.%2)" ).arg( format.toUpper(), extension.toLower() );
+    {
+      filters << QObject::tr( "%1 files (*.%2)" ).arg( extension.toUpper(), extension.toLower() );
+    }
+    else
+    {
+      // QgsProcessingLayerOutputDestinationWidget::selectFile() is sensitive
+      // to this "%1 - %2" format
+      filters << QObject::tr( "%1 - %2 files (*.%3)" ).arg( format.toUpper(), extension.toLower(), extension.toLower() );
+    }
   }
 
   return filters.join( ";;"_L1 ) + u";;"_s + QObject::tr( "All files (*.*)" );

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -428,6 +428,8 @@ void QgsProcessingLayerOutputDestinationWidget::selectFile()
     Q_ASSERT( dest );
     lastFormatPath = u"/Processing/LastRasterOutputFormat"_s;
     lastFormat = settings.value( lastFormatPath, dest->defaultFileFormat() ).toString();
+    lastExtPath = u"/Processing/LastRasterOutputExt"_s;
+    lastExt = settings.value( lastExtPath, u".%1"_s.arg( mParameter->defaultFileExtension() ) ).toString();
   }
   else if ( mParameter->type() == QgsProcessingParameterPointCloudDestination::typeName() )
   {
@@ -443,17 +445,40 @@ void QgsProcessingLayerOutputDestinationWidget::selectFile()
   // get default filter
   const QStringList filters = fileFilter.split( u";;"_s );
   QString lastFilter;
-  for ( const QString &f : filters )
+  if ( !lastFormat.isEmpty() && !lastExt.isEmpty() )
   {
-    if ( !lastFormat.isEmpty() && f.contains( lastFormat, Qt::CaseInsensitive ) )
+    // If we have both the format and extension, use in priority the filter
+    // that associates both, in case of multiple extensions per format.
+    for ( const QString &f : filters )
     {
-      lastFilter = f;
-      break;
+      // "%1 - %2 " pattern from QgsProcessingParameterRasterDestination::createFileFilter()
+      if ( f.contains( u"%1 - %2 "_s.arg( lastFormat, lastExt ), Qt::CaseInsensitive ) )
+      {
+        lastFilter = f;
+        break;
+      }
     }
-    else if ( !lastExt.isEmpty() && f.contains( u"*.%1"_s.arg( lastExt ), Qt::CaseInsensitive ) )
+  }
+  if ( lastFilter.isEmpty() && !lastFormat.isEmpty() )
+  {
+    for ( const QString &f : filters )
     {
-      lastFilter = f;
-      break;
+      if ( f.contains( lastFormat, Qt::CaseInsensitive ) )
+      {
+        lastFilter = f;
+        break;
+      }
+    }
+  }
+  if ( lastFilter.isEmpty() && !lastExt.isEmpty() )
+  {
+    for ( const QString &f : filters )
+    {
+      if ( f.contains( u"*.%1"_s.arg( lastExt ), Qt::CaseInsensitive ) )
+      {
+        lastFilter = f;
+        break;
+      }
     }
   }
 
@@ -494,7 +519,7 @@ void QgsProcessingLayerOutputDestinationWidget::selectFile()
     settings.setValue( u"/Processing/LastOutputPath"_s, QFileInfo( filename ).path() );
     if ( !lastFormatPath.isEmpty() && !mFormat.isEmpty() )
       settings.setValue( lastFormatPath, mFormat );
-    else if ( !lastExtPath.isEmpty() )
+    if ( !lastExtPath.isEmpty() )
       settings.setValue( lastExtPath, QFileInfo( filename ).suffix().toLower() );
 
     emit skipOutputChanged( false );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -209,6 +209,7 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
       QCOMPARE( rasterParam->defaultFileExtension(), u"tif"_s ); // before alg is accessible
       QVERIFY( addParameter( rasterParam ) );
       QCOMPARE( rasterParam->defaultFileExtension(), u"tif"_s );
+      QVERIFY( rasterParam->createFileFilter().contains( u"GTIFF - tif files (*.tif)"_s ) );
 
       // should allow parameters with same name but different case (required for grass provider)
       QgsProcessingParameterBoolean *p1C = new QgsProcessingParameterBoolean( "P1" );


### PR DESCRIPTION
Fixes #66319

The issue was that GdalAlgorithmProvider still defined the old supportedOutputRasterLayerExtensions() method that is no longer virtual, and thus it was no longer an override. Using
supportedOutputRasterLayerFormatAndExtensions() instead is the key fix. Same for GrassProvider.

<img width="244" height="468" alt="image" src="https://github.com/user-attachments/assets/6ff2f536-52bc-4fa1-810c-3ca032f70a20" />
