### PR TITLE
Partially fix slow expression builder widget construction times

### DIFF
--- a/python/PyQt6/gui/auto_additions/qgscodeeditorpython.py
+++ b/python/PyQt6/gui/auto_additions/qgscodeeditorpython.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/gui/codeeditors/qgscodeeditorpython.h
 try:
     QgsCodeEditorPython.__virtual_methods__ = ['showApiDocumentation']
-    QgsCodeEditorPython.__overridden_methods__ = ['language', 'languageCapabilities', 'checkSyntax', 'toggleComment', 'initializeLexer', 'keyPressEvent', 'reformatCodeString', 'populateContextMenu']
+    QgsCodeEditorPython.__overridden_methods__ = ['language', 'languageCapabilities', 'checkSyntax', 'toggleComment', 'initializeLexer', 'keyPressEvent', 'showEvent', 'reformatCodeString', 'populateContextMenu']
     QgsCodeEditorPython.__group__ = ['codeeditors']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
+++ b/python/PyQt6/gui/auto_generated/codeeditors/qgscodeeditorpython.sip.in
@@ -126,6 +126,8 @@ Toggle comment for the selected text.
 
     virtual void keyPressEvent( QKeyEvent *event );
 
+    virtual void showEvent( QShowEvent *event );
+
     virtual QString reformatCodeString( const QString &string );
 
     virtual void populateContextMenu( QMenu *menu );

--- a/src/gui/codeeditors/qgscodeeditorpython.cpp
+++ b/src/gui/codeeditors/qgscodeeditorpython.cpp
@@ -139,9 +139,42 @@ void QgsCodeEditorPython::initializeLexer()
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::TripleSingleQuote ), QsciLexerPython::TripleSingleQuotedString );
   pyLexer->setColor( lexerColor( QgsCodeEditorColorScheme::ColorRole::TripleDoubleQuote ), QsciLexerPython::TripleDoubleQuotedString );
 
-  auto apis = std::make_unique<QsciAPIs>( pyLexer );
+  setLexer( pyLexer );
 
   QgsSettings settings;
+  const int threshold = settings.value( u"pythonConsole/autoCompThreshold"_s, 2 ).toInt();
+  setAutoCompletionThreshold( threshold );
+  if ( !settings.value( "pythonConsole/autoCompleteEnabled", true ).toBool() )
+  {
+    setAutoCompletionSource( AcsNone );
+  }
+  else
+  {
+    const QString autoCompleteSource = settings.value( u"pythonConsole/autoCompleteSource"_s, u"fromAPI"_s ).toString();
+    if ( autoCompleteSource == "fromDoc"_L1 )
+      setAutoCompletionSource( AcsDocument );
+    else if ( autoCompleteSource == "fromDocAPI"_L1 )
+      setAutoCompletionSource( AcsAll );
+    else
+      setAutoCompletionSource( AcsAPIs );
+  }
+
+  setLineNumbersVisible( true );
+  setIndentationsUseTabs( false );
+  setIndentationGuides( true );
+
+  runPostLexerConfigurationTasks();
+
+  mInitializedLexer = false;
+  if ( isVisible() )
+    deferredInitializeLexer();
+}
+
+void QgsCodeEditorPython::deferredInitializeLexer()
+{
+  QgsSettings settings;
+  auto apis = std::make_unique<QsciAPIs>( lexer() );
+
   if ( mAPISFilesList.isEmpty() )
   {
     if ( settings.value( u"pythonConsole/preloadAPI"_s, true ).toBool() )
@@ -195,32 +228,9 @@ void QgsCodeEditorPython::initializeLexer()
     }
     apis->prepare();
   }
-  pyLexer->setAPIs( apis.release() );
+  lexer()->setAPIs( apis.release() );
 
-  setLexer( pyLexer );
-
-  const int threshold = settings.value( u"pythonConsole/autoCompThreshold"_s, 2 ).toInt();
-  setAutoCompletionThreshold( threshold );
-  if ( !settings.value( "pythonConsole/autoCompleteEnabled", true ).toBool() )
-  {
-    setAutoCompletionSource( AcsNone );
-  }
-  else
-  {
-    const QString autoCompleteSource = settings.value( u"pythonConsole/autoCompleteSource"_s, u"fromAPI"_s ).toString();
-    if ( autoCompleteSource == "fromDoc"_L1 )
-      setAutoCompletionSource( AcsDocument );
-    else if ( autoCompleteSource == "fromDocAPI"_L1 )
-      setAutoCompletionSource( AcsAll );
-    else
-      setAutoCompletionSource( AcsAPIs );
-  }
-
-  setLineNumbersVisible( true );
-  setIndentationsUseTabs( false );
-  setIndentationGuides( true );
-
-  runPostLexerConfigurationTasks();
+  mInitializedLexer = true;
 }
 
 void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
@@ -348,6 +358,15 @@ void QgsCodeEditorPython::keyPressEvent( QKeyEvent *event )
 
   // Let QgsCodeEditor handle the keyboard event
   return QgsCodeEditor::keyPressEvent( event );
+}
+
+void QgsCodeEditorPython::showEvent( QShowEvent *event )
+{
+  if ( !mInitializedLexer )
+  {
+    deferredInitializeLexer();
+  }
+  QgsCodeEditor::showEvent( event );
 }
 
 QString QgsCodeEditorPython::reformatCodeString( const QString &string )

--- a/src/gui/codeeditors/qgscodeeditorpython.h
+++ b/src/gui/codeeditors/qgscodeeditorpython.h
@@ -154,6 +154,7 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
   protected:
     void initializeLexer() override;
     void keyPressEvent( QKeyEvent *event ) override;
+    void showEvent( QShowEvent *event ) override;
     QString reformatCodeString( const QString &string ) override;
     void populateContextMenu( QMenu *menu ) override;
 
@@ -171,11 +172,13 @@ class GUI_EXPORT QgsCodeEditorPython : public QgsCodeEditor
     QString mPapFile;
 
     Qgis::ScriptLanguageCapabilities mCapabilities;
+    bool mInitializedLexer = false;
 
     static const QMap<QString, QString> sCompletionPairs;
 
     // Only used for selected text
     static const QStringList sCompletionSingleCharacters;
+    void deferredInitializeLexer();
 };
 
 #endif


### PR DESCRIPTION
This widget takes quite a while to show -- it's partially due to the (double!) python code editors shown on the second tab, which trigger a costly load of the python autocomplete data.

Defer this load until the python code editors are actually shown, speeding up the widget for the most common use of it.

## Description

[Replace this with some text explaining the rationale and details about this pull request]

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
