### PR TITLE
[qml] Upgrade QgsSatelliteInfo class to a Q_GADGET

### DIFF
--- a/python/PyQt6/core/auto_generated/gps/qgssatelliteinformation.sip.in
+++ b/python/PyQt6/core/auto_generated/gps/qgssatelliteinformation.sip.in
@@ -20,6 +20,9 @@ Encapsulates information relating to a GPS satellite.
 #include "qgssatelliteinformation.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
     int id;
 
     bool inUse;

--- a/src/core/gps/qgssatelliteinformation.cpp
+++ b/src/core/gps/qgssatelliteinformation.cpp
@@ -16,3 +16,5 @@
  ***************************************************************************/
 
 #include "qgssatelliteinformation.h"
+
+#include "moc_qgssatelliteinformation.cpp"

--- a/src/core/gps/qgssatelliteinformation.h
+++ b/src/core/gps/qgssatelliteinformation.h
@@ -32,6 +32,16 @@
 */
 class CORE_EXPORT QgsSatelliteInfo
 {
+    Q_GADGET
+
+    Q_PROPERTY( int id MEMBER id )
+    Q_PROPERTY( bool inUse MEMBER inUse )
+    Q_PROPERTY( double elevation MEMBER elevation )
+    Q_PROPERTY( double azimuth MEMBER azimuth )
+    Q_PROPERTY( double signal MEMBER signal )
+    Q_PROPERTY( QChar satType MEMBER satType )
+    Q_PROPERTY( Qgis::GnssConstellation constellation READ constellation )
+
   public:
     /**
      * Contains the satellite identifier number.


### PR DESCRIPTION
## Description

This class can be particularly useful when wanting to do a skyplot within a QML scene.