### PR TITLE
[Postgres] Update styles to match new layer name when layer is renamed 

### DIFF
--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -625,7 +625,7 @@ void QgsPostgresDataItemGuiProvider::renameLayer( QgsPGLayerItem *layerItem, Qgs
     const QString updateStylesSql = u"UPDATE public.layer_styles SET f_table_name=%1 WHERE f_table_schema=%2 AND f_table_name=%3"_s
                                       .arg( QgsPostgresConn::quotedValue( dlg.name() ), QgsPostgresConn::quotedValue( schemaName ), QgsPostgresConn::quotedValue( tableName ) );
 
-    const QgsPostgresResult stylesResult( conn->LoggedPQexec( "QgsPostgresDataItemGuiProvider", updateStylesSql ) );
+    QgsPostgresResult stylesResult( conn->LoggedPQexec( "QgsPostgresDataItemGuiProvider", updateStylesSql ) );
     if ( stylesResult.PQresultStatus() != PGRES_COMMAND_OK )
     {
       notify( tr( "Rename %1" ).arg( typeName ), tr( "Unable to update layer styles for '%1'.\n%2" ).arg( dlg.name(), stylesResult.PQresultErrorMessage() ), context, Qgis::MessageLevel::Warning );

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -625,7 +625,7 @@ void QgsPostgresDataItemGuiProvider::renameLayer( QgsPGLayerItem *layerItem, Qgs
     const QString updateStylesSql = u"UPDATE public.layer_styles SET f_table_name=%1 WHERE f_table_schema=%2 AND f_table_name=%3"_s
                                       .arg( QgsPostgresConn::quotedValue( dlg.name() ), QgsPostgresConn::quotedValue( schemaName ), QgsPostgresConn::quotedValue( tableName ) );
 
-    QgsPostgresResult stylesResult( conn->LoggedPQexec( "QgsPostgresDataItemGuiProvider", updateStylesSql ) );
+    const QgsPostgresResult stylesResult( conn->LoggedPQexec( "QgsPostgresDataItemGuiProvider", updateStylesSql ) );
     if ( stylesResult.PQresultStatus() != PGRES_COMMAND_OK )
     {
       notify( tr( "Rename %1" ).arg( typeName ), tr( "Unable to update layer styles for '%1'.\n%2" ).arg( dlg.name(), stylesResult.PQresultErrorMessage() ), context, Qgis::MessageLevel::Warning );

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -620,15 +620,17 @@ void QgsPostgresDataItemGuiProvider::renameLayer( QgsPGLayerItem *layerItem, Qgs
 
   notify( tr( "Rename %1" ).arg( typeName ), tr( "%1 '%2' renamed correctly to '%3'." ).arg( typeName, oldName, newName ), context, Qgis::MessageLevel::Success );
 
-  const QString updateStylesSql = u"UPDATE public.layer_styles SET f_table_name=%1 WHERE f_table_schema=%2 AND f_table_name=%3"_s
-                                    .arg( QgsPostgresConn::quotedValue( dlg.name() ), QgsPostgresConn::quotedValue( schemaName ), QgsPostgresConn::quotedValue( tableName ) );
-
-  QgsPostgresResult stylesResult( conn->LoggedPQexec( "QgsPostgresDataItemGuiProvider", updateStylesSql ) );
-  if ( stylesResult.PQresultStatus() != PGRES_COMMAND_OK )
+  if ( QgsPostgresUtils::tableExists( conn, u"public"_s, u"layer_styles"_s ) )
   {
-    notify( tr( "Rename %1" ).arg( typeName ), tr( "Unable to update layer styles for '%1'.\n%2" ).arg( dlg.name(), stylesResult.PQresultErrorMessage() ), context, Qgis::MessageLevel::Warning );
-  }
+    const QString updateStylesSql = u"UPDATE public.layer_styles SET f_table_name=%1 WHERE f_table_schema=%2 AND f_table_name=%3"_s
+                                      .arg( QgsPostgresConn::quotedValue( dlg.name() ), QgsPostgresConn::quotedValue( schemaName ), QgsPostgresConn::quotedValue( tableName ) );
 
+    QgsPostgresResult stylesResult( conn->LoggedPQexec( "QgsPostgresDataItemGuiProvider", updateStylesSql ) );
+    if ( stylesResult.PQresultStatus() != PGRES_COMMAND_OK )
+    {
+      notify( tr( "Rename %1" ).arg( typeName ), tr( "Unable to update layer styles for '%1'.\n%2" ).arg( dlg.name(), stylesResult.PQresultErrorMessage() ), context, Qgis::MessageLevel::Warning );
+    }
+  }
   conn->unref();
 
   if ( layerItem->parent() )

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -620,6 +620,15 @@ void QgsPostgresDataItemGuiProvider::renameLayer( QgsPGLayerItem *layerItem, Qgs
 
   notify( tr( "Rename %1" ).arg( typeName ), tr( "%1 '%2' renamed correctly to '%3'." ).arg( typeName, oldName, newName ), context, Qgis::MessageLevel::Success );
 
+  const QString updateStylesSql = u"UPDATE public.layer_styles SET f_table_name=%1 WHERE f_table_schema=%2 AND f_table_name=%3"_s
+                                    .arg( QgsPostgresConn::quotedValue( dlg.name() ), QgsPostgresConn::quotedValue( schemaName ), QgsPostgresConn::quotedValue( tableName ) );
+
+  QgsPostgresResult stylesResult( conn->LoggedPQexec( "QgsPostgresDataItemGuiProvider", updateStylesSql ) );
+  if ( stylesResult.PQresultStatus() != PGRES_COMMAND_OK )
+  {
+    notify( tr( "Rename %1" ).arg( typeName ), tr( "Unable to update layer styles for '%1'.\n%2" ).arg( dlg.name(), stylesResult.PQresultErrorMessage() ), context, Qgis::MessageLevel::Warning );
+  }
+
   conn->unref();
 
   if ( layerItem->parent() )

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -218,11 +218,11 @@ void QgsPostgresProviderConnection::renameTablePrivate( const QString &schema, c
   executeSqlPrivate( u"ALTER TABLE %1.%2 RENAME TO %3"_s.arg( QgsPostgresConn::quotedIdentifier( schema ), QgsPostgresConn::quotedIdentifier( name ), QgsPostgresConn::quotedIdentifier( newName ) ) );
 
   const QgsDataSourceUri dsUri { uri() };
-  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( dsUri, false ), -1, false );
+  auto conn = std::make_shared<QgsPoolPostgresConn>( QgsPostgresConn::connectionInfo( QgsDataSourceUri( uri() ), false ) );
 
   if ( conn )
   {
-    if ( QgsPostgresUtils::tableExists( conn, u"public"_s, u"layer_styles"_s ) )
+    if ( QgsPostgresUtils::tableExists( conn->get(), u"public"_s, u"layer_styles"_s ) )
     {
       try
       {
@@ -234,8 +234,6 @@ void QgsPostgresProviderConnection::renameTablePrivate( const QString &schema, c
         QgsDebugError( u"Failed to update layer_styles table: %1"_s.arg( e.what() ) );
       }
     }
-
-    QgsPostgresConnPool::instance()->releaseConnection( conn );
   }
 }
 

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -224,9 +224,17 @@ void QgsPostgresProviderConnection::renameTablePrivate( const QString &schema, c
   {
     if ( QgsPostgresUtils::tableExists( conn, u"public"_s, u"layer_styles"_s ) )
     {
-      executeSqlPrivate( u"UPDATE public.layer_styles SET f_table_name=%1 WHERE f_table_schema=%2 AND f_table_name=%3"_s
-                           .arg( QgsPostgresConn::quotedValue( newName ), QgsPostgresConn::quotedValue( schema ), QgsPostgresConn::quotedValue( name ) ) );
+      try
+      {
+        executeSqlPrivate( u"UPDATE public.layer_styles SET f_table_name=%1 WHERE f_table_schema=%2 AND f_table_name=%3"_s
+                             .arg( QgsPostgresConn::quotedValue( newName ), QgsPostgresConn::quotedValue( schema ), QgsPostgresConn::quotedValue( name ) ) );
+      }
+      catch ( const QgsProviderConnectionException &e )
+      {
+        QgsDebugError( u"Failed to update layer_styles table: %1"_s.arg( e.what() ) );
+      }
     }
+
     QgsPostgresConnPool::instance()->releaseConnection( conn );
   }
 }

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -215,6 +215,8 @@ void QgsPostgresProviderConnection::dropRasterTable( const QString &schema, cons
 void QgsPostgresProviderConnection::renameTablePrivate( const QString &schema, const QString &name, const QString &newName ) const
 {
   executeSqlPrivate( u"ALTER TABLE %1.%2 RENAME TO %3"_s.arg( QgsPostgresConn::quotedIdentifier( schema ), QgsPostgresConn::quotedIdentifier( name ), QgsPostgresConn::quotedIdentifier( newName ) ) );
+  executeSqlPrivate( u"UPDATE public.layer_styles SET f_table_name=%1 WHERE f_table_schema=%2 AND f_table_name=%3"_s
+                       .arg( QgsPostgresConn::quotedValue( newName ), QgsPostgresConn::quotedValue( schema ), QgsPostgresConn::quotedValue( name ) ) );
 }
 
 QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsPostgresProviderConnection::tablesPrivate( const QString &schema, const QString &table, const TableFlags &flags, QgsFeedback *feedback ) const

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -24,6 +24,7 @@
 #include "qgspostgresconnpool.h"
 #include "qgspostgresprovider.h"
 #include "qgspostgresprovidermetadatautils.h"
+#include "qgspostgresutils.h"
 #include "qgssettings.h"
 #include "qgsvectorlayer.h"
 
@@ -215,8 +216,19 @@ void QgsPostgresProviderConnection::dropRasterTable( const QString &schema, cons
 void QgsPostgresProviderConnection::renameTablePrivate( const QString &schema, const QString &name, const QString &newName ) const
 {
   executeSqlPrivate( u"ALTER TABLE %1.%2 RENAME TO %3"_s.arg( QgsPostgresConn::quotedIdentifier( schema ), QgsPostgresConn::quotedIdentifier( name ), QgsPostgresConn::quotedIdentifier( newName ) ) );
-  executeSqlPrivate( u"UPDATE public.layer_styles SET f_table_name=%1 WHERE f_table_schema=%2 AND f_table_name=%3"_s
-                       .arg( QgsPostgresConn::quotedValue( newName ), QgsPostgresConn::quotedValue( schema ), QgsPostgresConn::quotedValue( name ) ) );
+
+  const QgsDataSourceUri dsUri { uri() };
+  QgsPostgresConn *conn = QgsPostgresConnPool::instance()->acquireConnection( QgsPostgresConn::connectionInfo( dsUri, false ), -1, false );
+
+  if ( conn )
+  {
+    if ( QgsPostgresUtils::tableExists( conn, u"public"_s, u"layer_styles"_s ) )
+    {
+      executeSqlPrivate( u"UPDATE public.layer_styles SET f_table_name=%1 WHERE f_table_schema=%2 AND f_table_name=%3"_s
+                           .arg( QgsPostgresConn::quotedValue( newName ), QgsPostgresConn::quotedValue( schema ), QgsPostgresConn::quotedValue( name ) ) );
+    }
+    QgsPostgresConnPool::instance()->releaseConnection( conn );
+  }
 }
 
 QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsPostgresProviderConnection::tablesPrivate( const QString &schema, const QString &table, const TableFlags &flags, QgsFeedback *feedback ) const

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -1969,6 +1969,13 @@ void QgsPostgresProviderConnection::moveTableToSchema( const QString &sourceSche
     }
   }
 
+  if ( QgsPostgresUtils::tableExists( conn->get(), u"public"_s, u"layer_styles"_s ) )
+  {
+    const QString sqlMoveStyles = u"UPDATE public.layer_styles SET f_table_schema=%1 WHERE f_table_schema=%2 AND f_table_name=%3;"_s
+                                    .arg( QgsPostgresConn::quotedValue( targetSchema ), QgsPostgresConn::quotedValue( sourceSchema ), QgsPostgresConn::quotedValue( tableName ) );
+    sqlAdditionalCommands.append( sqlMoveStyles );
+  }
+
   conn->get()->begin();
 
   QgsPostgresResult resMove( conn->get()->LoggedPQexec( "QgsPostgresProviderConnection", u"%1 %2"_s.arg( sqlMoveTable ).arg( sqlAdditionalCommands ) ) );

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -1123,8 +1123,8 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
             "postgres",
         )
         self.assertTrue(vl.isValid())
-        err = vl.saveStyleToDatabase("test_style", "", False, "")
-        self.assertFalse(err)
+        result, msg = vl.saveStyleToDatabaseV2("test_style", "", False, "")
+        self.assertTrue(result == QgsMapLayer.SaveStyleResult.Success)
 
         # Verify style was saved under the original name
         rows = conn.executeSql(

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -20,6 +20,7 @@ from qgis.core import (
     QgsDataSourceUri,
     QgsField,
     QgsFields,
+    QgsMapLayer,
     QgsProviderConnectionException,
     QgsProviderRegistry,
     QgsRasterLayer,
@@ -1175,8 +1176,8 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
             "postgres",
         )
         self.assertTrue(vl.isValid())
-        err = vl.saveStyleToDatabaseV2("test_style_move", "", False, "")
-        self.assertFalse(err)
+        result, msg = vl.saveStyleToDatabaseV2("test_style_move", "", False, "")
+        self.assertTrue(result == QgsMapLayer.SaveStyleResult.Success)
 
         # Verify style initially points to the source schema
         rows = conn.executeSql(

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -1154,6 +1154,62 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
             "DROP TABLE IF EXISTS qgis_test.rename_style_test_renamed CASCADE"
         )
 
+    def test_move_table_to_schema_updates_layer_styles(self):
+        """Test that moving a table also updates f_table_schema in layer_styles."""
+        md = QgsProviderRegistry.instance().providerMetadata("postgres")
+        conn = md.createConnection(self.uri, {})
+
+        conn.executeSql(
+            """
+            DROP TABLE IF EXISTS qgis_test.move_style_test CASCADE;
+            DROP SCHEMA IF EXISTS qgis_schema_test CASCADE;
+            CREATE TABLE qgis_test.move_style_test (id SERIAL PRIMARY KEY, geom geometry(POINT,4326));
+            INSERT INTO qgis_test.move_style_test (geom) VALUES (ST_GeomFromText('POINT(0 0)', 4326));
+            CREATE SCHEMA IF NOT EXISTS qgis_schema_test;
+            """
+        )
+
+        vl = QgsVectorLayer(
+            conn.tableUri("qgis_test", "move_style_test"),
+            "test_move_with_style",
+            "postgres",
+        )
+        self.assertTrue(vl.isValid())
+        err = vl.saveStyleToDatabaseV2("test_style_move", "", False, "")
+        self.assertFalse(err)
+
+        # Verify style initially points to the source schema
+        rows = conn.executeSql(
+            "SELECT f_table_schema FROM public.layer_styles "
+            "WHERE f_table_schema = 'qgis_test' AND f_table_name = 'move_style_test'"
+        )
+        self.assertEqual(len(rows), 1)
+
+        conn.moveTableToSchema(
+            "qgis_test",
+            "move_style_test",
+            "qgis_schema_test",
+        )
+
+        # Style must now reference the target schema
+        rows = conn.executeSql(
+            "SELECT f_table_schema FROM public.layer_styles "
+            "WHERE f_table_schema = 'qgis_schema_test' AND f_table_name = 'move_style_test'"
+        )
+        self.assertEqual(len(rows), 1)
+
+        # No stale row for the old schema
+        rows = conn.executeSql(
+            "SELECT f_table_schema FROM public.layer_styles "
+            "WHERE f_table_schema = 'qgis_test' AND f_table_name = 'move_style_test'"
+        )
+        self.assertEqual(len(rows), 0)
+
+        conn.executeSql(
+            "DROP TABLE IF EXISTS qgis_schema_test.move_style_test CASCADE;"
+            "DROP SCHEMA IF EXISTS qgis_schema_test CASCADE;"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -1103,6 +1103,57 @@ CREATE FOREIGN TABLE IF NOT EXISTS points_csv (
             tables,
         )
 
+    def test_rename_table_updates_layer_styles(self):
+        """Test that renaming a table also updates f_table_name in layer_styles."""
+        md = QgsProviderRegistry.instance().providerMetadata("postgres")
+        conn = md.createConnection(self.uri, {})
+
+        conn.executeSql(
+            """
+            DROP TABLE IF EXISTS qgis_test.rename_style_test CASCADE;
+            CREATE TABLE qgis_test.rename_style_test (id SERIAL PRIMARY KEY, geom geometry(POINT,4326));
+            INSERT INTO qgis_test.rename_style_test (geom) VALUES (ST_GeomFromText('POINT(0 0)', 4326));
+            """
+        )
+
+        vl = QgsVectorLayer(
+            conn.tableUri("qgis_test", "rename_style_test"),
+            "test_rename_with_style",
+            "postgres",
+        )
+        self.assertTrue(vl.isValid())
+        err = vl.saveStyleToDatabase("test_style", "", False, "")
+        self.assertFalse(err)
+
+        # Verify style was saved under the original name
+        rows = conn.executeSql(
+            "SELECT f_table_name FROM public.layer_styles "
+            "WHERE f_table_schema = 'qgis_test' AND f_table_name = 'rename_style_test'"
+        )
+        self.assertEqual(len(rows), 1)
+
+        conn.renameVectorTable(
+            "qgis_test", "rename_style_test", "rename_style_test_renamed"
+        )
+
+        # Style must now reference the new table name
+        rows = conn.executeSql(
+            "SELECT f_table_name FROM public.layer_styles "
+            "WHERE f_table_schema = 'qgis_test' AND f_table_name = 'rename_style_test_renamed'"
+        )
+        self.assertEqual(len(rows), 1)
+
+        # No stale row for the old name
+        rows = conn.executeSql(
+            "SELECT f_table_name FROM public.layer_styles "
+            "WHERE f_table_schema = 'qgis_test' AND f_table_name = 'rename_style_test'"
+        )
+        self.assertEqual(len(rows), 0)
+
+        conn.executeSql(
+            "DROP TABLE IF EXISTS qgis_test.rename_style_test_renamed CASCADE"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

When PostgreSQL table is renamed (either from browser or from provider connection) the styles associated withe layer need to updated in **layer_styles** table to match the new layer name.

Funded by: Ocean Winds

Fixes #65360

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. 


