### PR TITLE
qgslogger.h: make sure parameters of QgsDebug.... macros are compile tested on non-debug builds

### DIFF
--- a/src/3d/chunks/qgschunkedentity.cpp
+++ b/src/3d/chunks/qgschunkedentity.cpp
@@ -222,6 +222,7 @@ void QgsChunkedEntity::handleSceneUpdate( const SceneContext &sceneContext )
   if ( pendingJobsCount() != oldJobsCount )
     emit pendingJobsCountChanged();
 
+#ifdef QGISDEBUG
   QgsDebugMsgLevel(
     u"update: active %1 enabled %2 disabled %3 | culled %4 | loading %5 loaded %6 | unloaded %7 elapsed %8ms"_s.arg( mActiveNodes.count() )
       .arg( enabled )
@@ -233,6 +234,7 @@ void QgsChunkedEntity::handleSceneUpdate( const SceneContext &sceneContext )
       .arg( t.elapsed() ),
     2
   );
+#endif
 }
 
 

--- a/src/3d/qgsabstractfeaturebasedchunkedentity.cpp
+++ b/src/3d/qgsabstractfeaturebasedchunkedentity.cpp
@@ -137,7 +137,9 @@ QList<QgsRayCastHit> QgsAbstractFeatureBasedChunkedEntity::rayIntersection(
     hit.setProperties( { { u"fid"_s, nearestFid } } );
     result.append( hit );
   }
+#ifdef QGISDEBUG
   QgsDebugMsgLevel( u"Active Nodes: %1, checked nodes: %2, hits found: %3, incompatible geometries: %4"_s.arg( nodesAll ).arg( nodeUsed ).arg( hits ).arg( ignoredGeometries ), 2 );
+#endif
   return result;
 }
 

--- a/src/3d/qgstiledscenechunkloader_p.cpp
+++ b/src/3d/qgstiledscenechunkloader_p.cpp
@@ -525,7 +525,9 @@ QList<QgsRayCastHit> QgsTiledSceneLayerChunkedEntity::rayIntersection( const Qgs
     result.append( hit );
   }
 
+#ifdef QGISDEBUG
   QgsDebugMsgLevel( u"Active Nodes: %1, checked nodes: %2, hits found: %3"_s.arg( nodesAll ).arg( nodeUsed ).arg( hits ), 2 );
+#endif
   return result;
 }
 

--- a/src/core/qgslogger.h
+++ b/src/core/qgslogger.h
@@ -36,41 +36,72 @@ class QFile;
 #ifndef SIP_RUN
 
 #ifdef QGISDEBUG
+
 #define QgsDebugError( str ) QgsLogger::debug( QString( str ), 0, __FILE__, __FUNCTION__, __LINE__ )
-#define QgsDebugMsgLevel( str, level )                                               \
-  if ( ( level ) <= QgsLogger::debugLevel() )                                        \
-  {                                                                                  \
-    QgsLogger::debug( QString( str ), ( level ), __FILE__, __FUNCTION__, __LINE__ ); \
-  }                                                                                  \
-  ( void ) ( 0 )
+
+#define QgsDebugMsgLevel( str, level )                                                 \
+  do                                                                                   \
+  {                                                                                    \
+    if ( ( level ) <= QgsLogger::debugLevel() )                                        \
+    {                                                                                  \
+      QgsLogger::debug( QString( str ), ( level ), __FILE__, __FUNCTION__, __LINE__ ); \
+    }                                                                                  \
+  } while ( false )
+
 #define QgsDebugErrorLoc( str, file, func, line ) QgsLogger::debug( QString( str ), 0, ( file ), ( func ), ( line ) )
-#define QgsDebugMsgLevelLoc( str, level, file, func, line )                      \
-  if ( ( level ) <= QgsLogger::debugLevel() )                                    \
-  {                                                                              \
-    QgsLogger::debug( QString( str ), ( level ), ( file ), ( func ), ( line ) ); \
-  }                                                                              \
-  ( void ) ( 0 )
+
+#define QgsDebugMsgLevelLoc( str, level, file, func, line )                        \
+  do                                                                               \
+  {                                                                                \
+    if ( ( level ) <= QgsLogger::debugLevel() )                                    \
+    {                                                                              \
+      QgsLogger::debug( QString( str ), ( level ), ( file ), ( func ), ( line ) ); \
+    }                                                                              \
+  } while ( false )
+
 #define QgsDebugCall QgsScopeLogger _qgsScopeLogger( __FILE__, __FUNCTION__, __LINE__ )
+
 #else
+
 #define QgsDebugCall \
   do                 \
   {                  \
   } while ( false )
-#define QgsDebugError( str ) \
-  do                         \
-  {                          \
+
+#define QgsDebugError( str )                            \
+  do                                                    \
+  {                                                     \
+    if constexpr ( false )                              \
+    {                                                   \
+      QgsLogger::debug( QString( str ), 0, "", "", 0 ); \
+    }                                                   \
   } while ( false )
-#define QgsDebugMsgLevel( str, level ) \
-  do                                   \
-  {                                    \
+
+#define QgsDebugMsgLevel( str, level )                          \
+  do                                                            \
+  {                                                             \
+    if constexpr ( false )                                      \
+    {                                                           \
+      QgsLogger::debug( QString( str ), ( level ), "", "", 0 ); \
+    }                                                           \
   } while ( false )
-#define QgsDebugErrorLoc( str, file, func, line ) \
-  do                                              \
-  {                                               \
+
+#define QgsDebugErrorLoc( str, file, func, line )                          \
+  do                                                                       \
+  {                                                                        \
+    if constexpr ( false )                                                 \
+    {                                                                      \
+      QgsLogger::debug( QString( str ), 0, ( file ), ( func ), ( line ) ); \
+    }                                                                      \
   } while ( false )
-#define QgsDebugMsgLevelLoc( str, level, file, func, line ) \
-  do                                                        \
-  {                                                         \
+
+#define QgsDebugMsgLevelLoc( str, level, file, func, line )                        \
+  do                                                                               \
+  {                                                                                \
+    if constexpr ( false )                                                         \
+    {                                                                              \
+      QgsLogger::debug( QString( str ), ( level ), ( file ), ( func ), ( line ) ); \
+    }                                                                              \
   } while ( false )
 #endif
 

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -317,7 +317,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QList<Q
     QgsFeature feature;
     if ( i >= requestedFeatureIds.size() )
     {
-      QgsDebugError( u"Server responded with more features than expected -- results will be unpredictable!" );
+      QgsDebugError( u"Server responded with more features than expected -- results will be unpredictable!"_s );
       break;
     }
     QgsFeatureId featureId = requestedFeatureIds[i];

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -1235,8 +1235,10 @@ void QgsAmsTiledImageDownloadHandler::repeatTileRequest( QNetworkRequest const &
     QgsMessageLog::logMessage( error, tr( "Network" ) );
     return;
   }
+#ifdef QGISDEBUG
   QgsDebugMsgLevel( u"repeat tileRequest %1 %2(retry %3) for url: %4"_s.arg( tileReqNo ).arg( tileNo ).arg( retry ).arg( url ), 2 );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( TileRetry ), retry );
+#endif
 
   QNetworkReply *reply = QgsNetworkAccessManager::instance()->get( request );
   mReplies << reply;

--- a/src/providers/grass/qgsgrassimport.cpp
+++ b/src/providers/grass/qgsgrassimport.cpp
@@ -258,9 +258,6 @@ bool QgsGrassRasterImport::import()
     }
 
     Qgis::DataType qgis_out_type = Qgis::DataType::UnknownDataType;
-#ifdef QGISDEBUG
-    RASTER_MAP_TYPE data_type = -1;
-#endif
     switch ( provider->dataType( band ) )
     {
       case Qgis::DataType::Byte:
@@ -289,8 +286,6 @@ bool QgsGrassRasterImport::import()
         setError( tr( "Data type %1 not supported" ).arg( static_cast<int>( provider->dataType( band ) ) ) );
         return false;
     }
-
-    QgsDebugMsgLevel( QString( "data_type = %1" ).arg( data_type ), 3 );
 
     QString module = QgsGrass::qgisGrassModulePath() + "/qgis.r.in";
     QStringList arguments;

--- a/src/providers/oracle/qgsoracleconn.h
+++ b/src/providers/oracle/qgsoracleconn.h
@@ -109,6 +109,8 @@ struct QgsOracleLayerProperty
       return QString( "%1.%2.%3 type=%4 srid=%5 view=%6%7 sql=%8" )
         .arg( ownerName, tableName, geometryColName, typeString, sridString, isView ? "yes" : "no", isView ? QString( " pk=%1" ).arg( pkCols.join( "|" ) ) : "", sql );
     }
+#else
+    inline QString toString() const { return QString(); }
 #endif
 };
 

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -2015,7 +2015,9 @@ void QgsPostgresConn::deduceEndian()
     if ( resOID.PQresultStatus() == PGRES_FATAL_ERROR )
     {
       errorCounter++;
+#ifdef QGISDEBUG
       QgsDebugMsgLevel( u"QUERY #%1 PGRES_FATAL_ERROR %2"_s.arg( queryCounter ).arg( PQerrorMessage().trimmed() ), 2 );
+#endif
       continue;
     }
 
@@ -2040,7 +2042,9 @@ void QgsPostgresConn::deduceEndian()
     return;
   }
 
+#ifdef QGISDEBUG
   QgsDebugMsgLevel( u"Back to old deduceEndian(): PQstatus() - %1, queryCounter = %2, errorCounter = %3"_s.arg( PQstatus() ).arg( queryCounter ).arg( errorCounter ), 2 );
+#endif
 
   QgsPostgresResult res( LoggedPQexec( u"QgsPostgresConn"_s, u"select regclass('pg_class')::oid"_s ) );
   QString oidValue = res.PQgetvalue( 0, 0 );

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -155,6 +155,8 @@ struct QgsPostgresLayerProperty
 
       return u"%1.%2.%3 type=%4 srid=%5 pkCols=%6 sql=%7 nSpCols=%8"_s.arg( schemaName, tableName, geometryColName, typeString, sridString, pkCols.join( '|'_L1 ), sql ).arg( nSpCols );
     }
+#else
+    inline QString toString() const { return QString(); }
 #endif
 };
 

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -2383,7 +2383,9 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
       }
     }
 
+#ifdef QGISDEBUG
     QgsDebugMsgLevel( u"add layer %1"_s.arg( id ), 2 );
+#endif
     mTileLayersSupported << tileLayer;
   }
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -4957,10 +4957,9 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
   int tileReqNo = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( TileReqNo ) ).toInt();
   int tileNo = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( TileIndex ) ).toInt();
   QRectF r = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( TileRect ) ).toRectF();
+  QUrl tileUrl = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( TileUrl ) ).value<QUrl>();
 #ifdef QGISDEBUG
   int retry = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( TileRetry ) ).toInt();
-#endif
-  QUrl tileUrl = reply->request().attribute( static_cast<QNetworkRequest::Attribute>( TileUrl ) ).value<QUrl>();
 
   QgsDebugMsgLevel(
     u"tile reply %1 (%2) tile:%3(retry %4) rect:%5,%6 %7,%8) fromcache:%9 %10 url:%11"_s.arg( tileReqNo )
@@ -4975,6 +4974,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
       .arg( reply->error() == QNetworkReply::NoError ? QString() : u"error: "_s + reply->errorString(), reply->url().toString() ),
     4
   );
+#endif
 
   if ( reply->error() == QNetworkReply::NoError )
   {


### PR DESCRIPTION
Using if constexpr(false) tricks enable to make the compiler check the well-formedness of the expressions, while optimizing them out.
