### PR TITLE
Fix QgsSvgMarkerSymbolLayer::bounds() shifted by scaleFactor 

### DIFF
--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -2957,6 +2957,10 @@ QRectF QgsSvgMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext &c
   const double aspectRatio = calculateAspectRatio( context, scaledWidth, hasDataDefinedAspectRatio );
   double scaledHeight = scaledWidth * ( !qgsDoubleNear( aspectRatio, 0.0 ) ? aspectRatio : mDefaultAspectRatio );
 
+  QPointF outputOffset;
+  double angle = 0.0;
+  calculateOffsetAndRotation( context, scaledWidth, scaledHeight, outputOffset, angle );
+
   scaledWidth = context.renderContext().convertToPainterUnits( scaledWidth, mSizeUnit, mSizeMapUnitScale );
   scaledHeight = context.renderContext().convertToPainterUnits( scaledHeight, mSizeUnit, mSizeMapUnitScale );
 
@@ -2965,10 +2969,6 @@ QRectF QgsSvgMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext &c
   {
     return QRectF();
   }
-
-  QPointF outputOffset;
-  double angle = 0.0;
-  calculateOffsetAndRotation( context, scaledWidth, scaledHeight, outputOffset, angle );
 
   double strokeWidth = mStrokeWidth;
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::Property::StrokeWidth ) )

--- a/tests/src/core/testqgssvgmarker.cpp
+++ b/tests/src/core/testqgssvgmarker.cpp
@@ -35,6 +35,7 @@ using namespace Qt::StringLiterals;
 #include <qgssinglesymbolrenderer.h>
 #include "qgsmarkersymbollayer.h"
 #include "qgsproperty.h"
+#include "qgsrendercontext.h"
 #include "qgssymbollayerutils.h"
 #include "qgsmarkersymbol.h"
 #include "qgsfontutils.h"
@@ -58,6 +59,7 @@ class TestQgsSvgMarkerSymbol : public QgsTest
 
     void svgMarkerSymbol();
     void bounds();
+    void boundsAnchorPoint();
     void boundsWidth();
     void bench();
     void anchor();
@@ -156,6 +158,67 @@ void TestQgsSvgMarkerSymbol::bounds()
   mMapSettings.setFlag( Qgis::MapSettingsFlag::DrawSymbolBounds, false );
   mSvgMarkerLayer->setDataDefinedProperty( QgsSymbolLayer::Property::Size, QgsProperty() );
   QVERIFY( result );
+}
+
+void TestQgsSvgMarkerSymbol::boundsAnchorPoint()
+{
+  // the bounds reported for a non-centered anchor must be equal
+  // to the center-anchored bounds translated by half the rendered
+  // symbol size, in pixels.
+
+  QgsSvgMarkerSymbolLayer layer( QgsSymbolLayerUtils::svgSymbolNameToPath( u"/backgrounds/background_square.svg"_s, QgsPathResolver() ) );
+  layer.setSize( 24.0 );
+  layer.setSizeUnit( Qgis::RenderUnit::Millimeters );
+  layer.setFixedAspectRatio( 1.0 );
+  layer.setStrokeWidth( 0.0 );
+  layer.setHorizontalAnchorPoint( Qgis::HorizontalAnchorPoint::Center );
+  layer.setVerticalAnchorPoint( Qgis::VerticalAnchorPoint::Center );
+
+  QgsMapSettings ms;
+  ms.setExtent( QgsRectangle( 0, 0, 1000, 1000 ) );
+  ms.setOutputSize( QSize( 500, 500 ) );
+  ms.setOutputDpi( 96 );
+  QgsRenderContext rc = QgsRenderContext::fromMapSettings( ms );
+  QgsSymbolRenderContext src( rc, Qgis::RenderUnit::Unknown, 1.0, false, Qgis::SymbolRenderHints() );
+
+  const QPointF point( 250, 250 );
+
+  layer.startRender( src );
+  const QRectF centerBounds = layer.bounds( point, src );
+  layer.stopRender( src );
+  QVERIFY( centerBounds.isValid() );
+
+  const double halfWidthPx = rc.convertToPainterUnits( layer.size(), layer.sizeUnit(), layer.sizeMapUnitScale() ) / 2.0;
+  const double halfHeightPx = halfWidthPx; // fixedAspectRatio == 1.0
+
+  layer.setVerticalAnchorPoint( Qgis::VerticalAnchorPoint::Bottom );
+  layer.startRender( src );
+  const QRectF bottomBounds = layer.bounds( point, src );
+  layer.stopRender( src );
+  QGSCOMPARENEAR( bottomBounds.center().x(), centerBounds.center().x(), 0.01 );
+  QGSCOMPARENEAR( bottomBounds.center().y(), centerBounds.center().y() - halfHeightPx, 0.01 );
+
+  layer.setVerticalAnchorPoint( Qgis::VerticalAnchorPoint::Top );
+  layer.startRender( src );
+  const QRectF topBounds = layer.bounds( point, src );
+  layer.stopRender( src );
+  QGSCOMPARENEAR( topBounds.center().x(), centerBounds.center().x(), 0.01 );
+  QGSCOMPARENEAR( topBounds.center().y(), centerBounds.center().y() + halfHeightPx, 0.01 );
+
+  layer.setVerticalAnchorPoint( Qgis::VerticalAnchorPoint::Center );
+  layer.setHorizontalAnchorPoint( Qgis::HorizontalAnchorPoint::Left );
+  layer.startRender( src );
+  const QRectF leftBounds = layer.bounds( point, src );
+  layer.stopRender( src );
+  QGSCOMPARENEAR( leftBounds.center().x(), centerBounds.center().x() + halfWidthPx, 0.01 );
+  QGSCOMPARENEAR( leftBounds.center().y(), centerBounds.center().y(), 0.01 );
+
+  layer.setHorizontalAnchorPoint( Qgis::HorizontalAnchorPoint::Right );
+  layer.startRender( src );
+  const QRectF rightBounds = layer.bounds( point, src );
+  layer.stopRender( src );
+  QGSCOMPARENEAR( rightBounds.center().x(), centerBounds.center().x() - halfWidthPx, 0.01 );
+  QGSCOMPARENEAR( rightBounds.center().y(), centerBounds.center().y(), 0.01 );
 }
 
 void TestQgsSvgMarkerSymbol::boundsWidth()


### PR DESCRIPTION
## Description

Issue spotted from Kadas application.

Avoid double scaled offset: calculate offset and rotation before converting `scaledWidth`/`scaledHeight` to painter units (`markerOffset()` re-applies the unit conversion)

Test is AI written, I checked that it's failing without the fix.
Fix correctly tested in Kadas application.


## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

