### PR TITLE
Extract rubberband renderview into a dedicated class

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -120,6 +120,7 @@ set(QGIS_3D_SRCS
   framegraph/qgsoverlaytexturerenderview.cpp
   framegraph/qgspostprocessingentity.cpp
   framegraph/qgsrenderpassquad.cpp
+  framegraph/qgsrubberbandrenderview.cpp
   framegraph/qgspostprocessingrenderview.cpp
   framegraph/qgsshadowrenderview.cpp
   framegraph/qgsframegraph.cpp
@@ -271,6 +272,7 @@ set(QGIS_3D_HDRS
   framegraph/qgspostprocessingentity.h
   framegraph/qgsrenderpassquad.h
   framegraph/qgspostprocessingrenderview.h
+  framegraph/qgsrubberbandrenderview.h
   framegraph/qgsshadowrenderview.h
 
   symbols/qgs3dsymbolutils.h

--- a/src/3d/framegraph/qgsframegraph.cpp
+++ b/src/3d/framegraph/qgsframegraph.cpp
@@ -28,6 +28,7 @@
 #include "qgsoverlaytexturerenderview.h"
 #include "qgspostprocessingentity.h"
 #include "qgspostprocessingrenderview.h"
+#include "qgsrubberbandrenderview.h"
 #include "qgsshadowrenderview.h"
 #include "qgssunlightsettings.h"
 
@@ -61,6 +62,7 @@ const QString QgsFrameGraph::sAmbientOcclusionRenderView = "ambient_occlusion";
 const QString QgsFrameGraph::sBloomRenderView = "bloom";
 const QString QgsFrameGraph::sPostprocRenderView = "post_processing";
 const QString QgsFrameGraph::sHighlightsRenderView = "highlights";
+const QString QgsFrameGraph::sRubberRenderView = "rubber_band";
 
 void QgsFrameGraph::constructForwardRenderPass()
 {
@@ -180,36 +182,11 @@ void QgsFrameGraph::constructBloomRenderPass()
   registerRenderView( std::unique_ptr<QgsBloomRenderView>( rv ), sBloomRenderView );
 }
 
-Qt3DRender::QFrameGraphNode *QgsFrameGraph::constructRubberBandsPass()
+void QgsFrameGraph::constructRubberBandsPass( Qt3DRender::QFrameGraphNode *topNode )
 {
-  mRubberBandsCameraSelector = new Qt3DRender::QCameraSelector;
-  mRubberBandsCameraSelector->setObjectName( "RubberBands Pass CameraSelector" );
-  mRubberBandsCameraSelector->setCamera( mMainCamera );
-
-  mRubberBandsLayerFilter = new Qt3DRender::QLayerFilter( mRubberBandsCameraSelector );
-  mRubberBandsLayerFilter->addLayer( mRubberBandsLayer );
-
-  Qt3DRender::QBlendEquationArguments *blendState = new Qt3DRender::QBlendEquationArguments;
-  blendState->setSourceRgb( Qt3DRender::QBlendEquationArguments::SourceAlpha );
-  blendState->setDestinationRgb( Qt3DRender::QBlendEquationArguments::OneMinusSourceAlpha );
-
-  Qt3DRender::QBlendEquation *blendEquation = new Qt3DRender::QBlendEquation;
-  blendEquation->setBlendFunction( Qt3DRender::QBlendEquation::Add );
-
-  mRubberBandsStateSet = new Qt3DRender::QRenderStateSet( mRubberBandsLayerFilter );
-  Qt3DRender::QDepthTest *depthTest = new Qt3DRender::QDepthTest;
-  depthTest->setDepthFunction( Qt3DRender::QDepthTest::Always );
-  mRubberBandsStateSet->addRenderState( depthTest );
-  mRubberBandsStateSet->addRenderState( blendState );
-  mRubberBandsStateSet->addRenderState( blendEquation );
-
-  // Here we attach our drawings to the render target also used by forward pass.
-  // This is kind of okay, but as a result, post-processing effects get applied
-  // to rubber bands too. Ideally we would want them on top of everything.
-  mRubberBandsRenderTargetSelector = new Qt3DRender::QRenderTargetSelector( mRubberBandsStateSet );
-  mRubberBandsRenderTargetSelector->setTarget( forwardRenderView().renderTargetSelector()->target() );
-
-  return mRubberBandsCameraSelector;
+  // rubber band render view writes to the same output textures than the forward render view:
+  QgsRubberBandRenderView *rv = new QgsRubberBandRenderView( sRubberRenderView, mMainCamera, mRootEntity, forwardRenderView().renderTargetSelector()->target() );
+  registerRenderView( std::unique_ptr<QgsRubberBandRenderView>( rv ), sRubberRenderView, topNode );
 }
 
 void QgsFrameGraph::constructDepthRenderPass()
@@ -275,10 +252,6 @@ QgsFrameGraph::QgsFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *m
   mRootEntity = root;
   mMainCamera = mainCamera;
 
-  mRubberBandsLayer = new Qt3DRender::QLayer;
-  mRubberBandsLayer->setObjectName( "mRubberBandsLayer" );
-  mRubberBandsLayer->setRecursive( true );
-
   mRenderSurfaceSelector = new Qt3DRender::QRenderSurfaceSelector;
 
   QObject *surfaceObj = dynamic_cast<QObject *>( surface );
@@ -304,9 +277,7 @@ QgsFrameGraph::QgsFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *m
   constructHighlightsPass();
 
   // rubber bands (they should be always on top)
-  Qt3DRender::QFrameGraphNode *rubberBandsPass = constructRubberBandsPass();
-  rubberBandsPass->setObjectName( "rubberBandsPass" );
-  rubberBandsPass->setParent( mGlobalParamsStorage );
+  constructRubberBandsPass( mGlobalParamsStorage );
 
   mMsaaBlitNode = new Qt3DRender::QBlitFramebuffer( mGlobalParamsStorage );
   mMsaaBlitNode->setObjectName( "MsaaBlitFramebuffer" );
@@ -341,10 +312,6 @@ QgsFrameGraph::QgsFrameGraph( QSurface *surface, QSize s, Qt3DRender::QCamera *m
   mMsaaClearBuffers->setEnabled( false );
   mMsaaClearBuffers->setBuffers( Qt3DRender::QClearBuffers::ColorDepthBuffer );
   new Qt3DRender::QNoDraw( mMsaaClearBuffers );
-
-  mRubberBandsRootEntity = new Qt3DCore::QEntity( mRootEntity );
-  mRubberBandsRootEntity->setObjectName( "mRubberBandsRootEntity" );
-  mRubberBandsRootEntity->addComponent( mRubberBandsLayer );
 }
 
 void QgsFrameGraph::unregisterRenderView( const QString &name )
@@ -627,7 +594,7 @@ void QgsFrameGraph::setMsaaEnabled( bool enabled )
 
   Qt3DRender::QRenderTarget *target = enabled ? forwardRenderView().msaaRenderTarget() : forwardRenderView().regularRenderTarget();
   highlightsRenderView().setRenderTarget( target );
-  mRubberBandsRenderTargetSelector->setTarget( target );
+  rubberBandRenderView().renderTargetSelector()->setTarget( target );
   mMsaaBlitNode->setEnabled( enabled );
   mMsaaDepthBlitNode->setEnabled( enabled );
 }
@@ -687,4 +654,10 @@ QgsHighlightsRenderView &QgsFrameGraph::highlightsRenderView()
 QgsOverlayTextureRenderView &QgsFrameGraph::overlayTextureRenderView()
 {
   return *( postprocessingRenderView().overlayTextureRenderView() );
+}
+
+QgsRubberBandRenderView &QgsFrameGraph::rubberBandRenderView()
+{
+  QgsAbstractRenderView *rv = mRenderViewMap[QgsFrameGraph::sRubberRenderView].get();
+  return *( dynamic_cast<QgsRubberBandRenderView *>( rv ) );
 }

--- a/src/3d/framegraph/qgsframegraph.h
+++ b/src/3d/framegraph/qgsframegraph.h
@@ -64,6 +64,7 @@ class QgsOverlayTextureEntity;
 class QgsOverlayTextureRenderView;
 class QgsPostprocessingEntity;
 class QgsPostprocessingRenderView;
+class QgsRubberBandRenderView;
 class QgsRectangle;
 class QgsShadowRenderView;
 class QgsShadowSettings;
@@ -94,9 +95,6 @@ class _3D_EXPORT QgsFrameGraph : public Qt3DCore::QEntity
 
     //! Returns the main camera
     Qt3DRender::QCamera *mainCamera() { return mMainCamera; }
-
-    //! Returns entity for all rubber bands (to show them always on top)
-    Qt3DCore::QEntity *rubberBandsRootEntity() { return mRubberBandsRootEntity; }
 
     //! Returns the render capture object used to take an image of the scene
     Qt3DRender::QRenderCapture *renderCapture();
@@ -245,6 +243,12 @@ class _3D_EXPORT QgsFrameGraph : public Qt3DCore::QEntity
     QgsPostprocessingRenderView &postprocessingRenderView();
 
     /**
+     * Returns rubber band renderview
+     * \since QGIS 3.44
+     */
+    QgsRubberBandRenderView &rubberBandRenderView();
+
+    /**
      * Updates shadow bias, light and texture size according to \a shadowSettings and \a lightSources
      * \since QGIS 3.44
      */
@@ -292,6 +296,7 @@ class _3D_EXPORT QgsFrameGraph : public Qt3DCore::QEntity
     //! Postprocessing render view name
     static const QString sPostprocRenderView;
     static const QString sHighlightsRenderView;
+    static const QString sRubberRenderView;
 
   private:
     Qt3DRender::QRenderSurfaceSelector *mRenderSurfaceSelector = nullptr;
@@ -310,21 +315,11 @@ class _3D_EXPORT QgsFrameGraph : public Qt3DCore::QEntity
     Qt3DRender::QRenderCapture *mThumbnailCapture = nullptr;
     Qt3DRender::QTexture2D *mThumbnailTexture = nullptr;
 
-    // Rubber bands pass
-    Qt3DRender::QCameraSelector *mRubberBandsCameraSelector = nullptr;
-    Qt3DRender::QLayerFilter *mRubberBandsLayerFilter = nullptr;
-    Qt3DRender::QRenderStateSet *mRubberBandsStateSet = nullptr;
-    Qt3DRender::QRenderTargetSelector *mRubberBandsRenderTargetSelector = nullptr;
-
     QSize mSize = QSize( 1024, 768 );
 
     QVector3D mLightDirection = QVector3D( 0.0, -1.0f, 0.0f );
 
     Qt3DCore::QEntity *mRootEntity = nullptr;
-
-    Qt3DRender::QLayer *mRubberBandsLayer = nullptr;
-
-    Qt3DCore::QEntity *mRubberBandsRootEntity = nullptr;
 
     //! depth texture debugging
     QgsOverlayTextureEntity *mDepthTextureDebugging = nullptr;
@@ -337,7 +332,7 @@ class _3D_EXPORT QgsFrameGraph : public Qt3DCore::QEntity
     void constructDepthRenderPass();
     void constructAmbientOcclusionRenderPass();
     void constructBloomRenderPass();
-    Qt3DRender::QFrameGraphNode *constructRubberBandsPass();
+    void constructRubberBandsPass( Qt3DRender::QFrameGraphNode *topNode = nullptr );
     void constructMsaaBlitNodes();
 
     void constructThumbnailCapturePass();

--- a/src/3d/framegraph/qgsframegraph.h
+++ b/src/3d/framegraph/qgsframegraph.h
@@ -244,7 +244,7 @@ class _3D_EXPORT QgsFrameGraph : public Qt3DCore::QEntity
 
     /**
      * Returns rubber band renderview
-     * \since QGIS 3.44
+     * \since QGIS 4.4
      */
     QgsRubberBandRenderView &rubberBandRenderView();
 

--- a/src/3d/framegraph/qgsrubberbandrenderview.cpp
+++ b/src/3d/framegraph/qgsrubberbandrenderview.cpp
@@ -1,0 +1,85 @@
+/***************************************************************************
+  qgsrubberbandrenderview.cpp
+  --------------------------------------
+  Date                 : June 2026
+  Copyright            : (C) 2026 by Benoit De Mezzo and (C) 2020 by Belgacem Nedjima
+  Email                : benoit dot de dot mezzo at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrubberbandrenderview.h"
+
+#include <Qt3DRender/QBlendEquation>
+#include <Qt3DRender/QBlendEquationArguments>
+#include <Qt3DRender/QCamera>
+#include <Qt3DRender/QCameraSelector>
+#include <Qt3DRender/QDepthTest>
+#include <Qt3DRender/QLayer>
+#include <Qt3DRender/QLayerFilter>
+#include <Qt3DRender/QRenderStateSet>
+#include <Qt3DRender/QRenderTargetSelector>
+#include <Qt3DRender/qsubtreeenabler.h>
+
+QgsRubberBandRenderView::QgsRubberBandRenderView( const QString &viewName, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *rootSceneEntity, Qt3DRender::QRenderTarget *fwdRenderTarget )
+  : QgsAbstractRenderView( viewName )
+  , mMainCamera( mainCamera )
+{
+  mLayer = new Qt3DRender::QLayer;
+  mLayer->setRecursive( true );
+  mLayer->setObjectName( mViewName + "::Layer" );
+
+  // rubberband rendering pass
+  constructRenderPass( fwdRenderTarget ); //#spellok
+
+  mRubberBandsRootEntity = new Qt3DCore::QEntity( rootSceneEntity );
+  mRubberBandsRootEntity->setObjectName( "mRubberBandsRootEntity" );
+  mRubberBandsRootEntity->addComponent( mLayer );
+}
+
+void QgsRubberBandRenderView::constructRenderPass( Qt3DRender::QRenderTarget *fwdRenderTarget ) //#spellok
+{
+  Qt3DRender::QCameraSelector *cameraSelector = new Qt3DRender::QCameraSelector( mRendererEnabler );
+  cameraSelector->setObjectName( mViewName + "::CameraSelector" );
+  cameraSelector->setCamera( mMainCamera );
+
+  Qt3DRender::QLayerFilter *layerFilter = new Qt3DRender::QLayerFilter( cameraSelector );
+  layerFilter->addLayer( mLayer );
+
+  Qt3DRender::QRenderStateSet *stateSet = new Qt3DRender::QRenderStateSet( layerFilter );
+
+  Qt3DRender::QDepthTest *depthTest = new Qt3DRender::QDepthTest;
+  depthTest->setDepthFunction( Qt3DRender::QDepthTest::Always );
+  stateSet->addRenderState( depthTest );
+
+  Qt3DRender::QBlendEquationArguments *blendState = new Qt3DRender::QBlendEquationArguments;
+  blendState->setSourceRgb( Qt3DRender::QBlendEquationArguments::SourceAlpha );
+  blendState->setDestinationRgb( Qt3DRender::QBlendEquationArguments::OneMinusSourceAlpha );
+  stateSet->addRenderState( blendState );
+
+  Qt3DRender::QBlendEquation *blendEquation = new Qt3DRender::QBlendEquation;
+  blendEquation->setBlendFunction( Qt3DRender::QBlendEquation::Add );
+  stateSet->addRenderState( blendEquation );
+
+  // Here we attach our drawings to the render target also used by forward pass.
+  // This is kind of okay, but as a result, post-processing effects get applied
+  // to rubber bands too. Ideally we would want them on top of everything.
+  mRenderTargetSelector = new Qt3DRender::QRenderTargetSelector( stateSet );
+
+  mRenderTargetSelector->setTarget( fwdRenderTarget );
+}
+
+Qt3DCore::QEntity *QgsRubberBandRenderView::rubberBandEntity() const
+{
+  return mRubberBandsRootEntity;
+}
+
+Qt3DRender::QRenderTargetSelector *QgsRubberBandRenderView::renderTargetSelector() const
+{
+  return mRenderTargetSelector;
+};

--- a/src/3d/framegraph/qgsrubberbandrenderview.cpp
+++ b/src/3d/framegraph/qgsrubberbandrenderview.cpp
@@ -37,9 +37,9 @@ QgsRubberBandRenderView::QgsRubberBandRenderView( const QString &viewName, Qt3DR
   // rubberband rendering pass
   constructRenderPass( fwdRenderTarget ); //#spellok
 
-  mRubberBandsRootEntity = new Qt3DCore::QEntity( rootSceneEntity );
-  mRubberBandsRootEntity->setObjectName( "mRubberBandsRootEntity" );
-  mRubberBandsRootEntity->addComponent( mLayer );
+  mRootEntity = new Qt3DCore::QEntity( rootSceneEntity );
+  mRootEntity->setObjectName( "mRubberBandsRootEntity" );
+  mRootEntity->addComponent( mLayer );
 }
 
 void QgsRubberBandRenderView::constructRenderPass( Qt3DRender::QRenderTarget *fwdRenderTarget ) //#spellok
@@ -76,7 +76,7 @@ void QgsRubberBandRenderView::constructRenderPass( Qt3DRender::QRenderTarget *fw
 
 Qt3DCore::QEntity *QgsRubberBandRenderView::rubberBandEntity() const
 {
-  return mRubberBandsRootEntity;
+  return mRootEntity;
 }
 
 Qt3DRender::QRenderTargetSelector *QgsRubberBandRenderView::renderTargetSelector() const

--- a/src/3d/framegraph/qgsrubberbandrenderview.h
+++ b/src/3d/framegraph/qgsrubberbandrenderview.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+  qgsrubberbandrenderview.h
+  --------------------------------------
+  Date                 : June 2026
+  Copyright            : (C) 2026 by Benoit De Mezzo and (C) 2020 by Belgacem Nedjima
+  Email                : benoit dot de dot mezzo at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRUBBERBANDRENDERVIEW_H
+#define QGSRUBBERBANDRENDERVIEW_H
+
+#include "qgsabstractrenderview.h"
+
+#define SIP_NO_FILE
+
+namespace Qt3DRender
+{
+  class QLayer;
+  class QCamera;
+  class QTexture2D;
+  class QRenderTargetSelector;
+  class QRenderTarget;
+} // namespace Qt3DRender
+
+namespace Qt3DCore
+{
+  class QEntity;
+} // namespace Qt3DCore
+
+/**
+ * \ingroup qgis_3d
+ * \brief Container class that holds different objects related to rubberband rendering
+ *
+ * \note Not available in Python bindings
+ *
+ * The rubberband buffer render pass is made to copy the rubberband buffer into
+ * an RGB texture that can be captured into a QImage and sent to the CPU for
+ * calculating real 3D points from mouse coordinates (for zoom, rotation, drag..)
+ *
+ * \since QGIS 4.2
+ */
+class QgsRubberBandRenderView : public QgsAbstractRenderView
+{
+  public:
+    //! Default constructor
+    QgsRubberBandRenderView( const QString &viewName, Qt3DRender::QCamera *mainCamera, Qt3DCore::QEntity *rootSceneEntity, Qt3DRender::QRenderTarget *fwdRenderTarget );
+
+    //! Returns entity for all rubber bands (to show them always on top)
+    Qt3DCore::QEntity *rubberBandEntity() const;
+
+    //! Returns rubberband tard selector
+    Qt3DRender::QRenderTargetSelector *renderTargetSelector() const;
+
+  private:
+    Qt3DRender::QLayer *mLayer = nullptr;
+    Qt3DRender::QCamera *mMainCamera = nullptr;
+    Qt3DRender::QRenderTargetSelector *mRenderTargetSelector = nullptr;
+    Qt3DCore::QEntity *mRubberBandsRootEntity = nullptr;
+
+    void constructRenderPass( Qt3DRender::QRenderTarget *fwdRenderTarget ); //#spellok
+};
+
+#endif // QGSRUBBERBANDRENDERVIEW_H

--- a/src/3d/framegraph/qgsrubberbandrenderview.h
+++ b/src/3d/framegraph/qgsrubberbandrenderview.h
@@ -44,7 +44,7 @@ namespace Qt3DCore
  * an RGB texture that can be captured into a QImage and sent to the CPU for
  * calculating real 3D points from mouse coordinates (for zoom, rotation, drag..)
  *
- * \since QGIS 4.2
+ * \since QGIS 4.4
  */
 class QgsRubberBandRenderView : public QgsAbstractRenderView
 {
@@ -62,7 +62,7 @@ class QgsRubberBandRenderView : public QgsAbstractRenderView
     Qt3DRender::QLayer *mLayer = nullptr;
     Qt3DRender::QCamera *mMainCamera = nullptr;
     Qt3DRender::QRenderTargetSelector *mRenderTargetSelector = nullptr;
-    Qt3DCore::QEntity *mRubberBandsRootEntity = nullptr;
+    Qt3DCore::QEntity *mRootEntity = nullptr;
 
     void constructRenderPass( Qt3DRender::QRenderTarget *fwdRenderTarget ); //#spellok
 };

--- a/src/3d/qgs3dhighlightfeaturehandler.cpp
+++ b/src/3d/qgs3dhighlightfeaturehandler.cpp
@@ -192,7 +192,7 @@ void Qgs3DHighlightFeatureHandler::highlightFeature( QgsFeature feature, QgsMapL
 
       if ( !mRubberBands.contains( layer ) )
       {
-        QgsRubberBand3D *band = new QgsRubberBand3D( *mScene->mapSettings(), mScene->engine(), mScene->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Point );
+        QgsRubberBand3D *band = new QgsRubberBand3D( *mScene->mapSettings(), mScene->engine(), Qgis::GeometryType::Point );
 
         const QgsSettings settings;
         const QColor color = QColor( settings.value( u"Map/highlight/color"_s, Qgis::DEFAULT_HIGHLIGHT_COLOR.name() ).toString() );

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -59,6 +59,7 @@
 #include "qgspointcloudlayer.h"
 #include "qgspointcloudlayer3drenderer.h"
 #include "qgspostprocessingentity.h"
+#include "qgsrubberbandrenderview.h"
 #include "qgsrulebased3drenderer.h"
 #include "qgsshadowrenderview.h"
 #include "qgsskyboxentity.h"
@@ -1527,7 +1528,8 @@ void Qgs3DMapScene::onOriginChanged()
     transform->setOrigin( mMap.origin() );
   }
 
-  const QList<QgsGeoTransform *> rubberBandGeoTransforms = mEngine->frameGraph()->rubberBandsRootEntity()->findChildren<QgsGeoTransform *>();
+  Qt3DCore::QEntity *parentEntity = mEngine->frameGraph()->rubberBandRenderView().rubberBandEntity();
+  const QList<QgsGeoTransform *> rubberBandGeoTransforms = parentEntity->findChildren<QgsGeoTransform *>();
   for ( QgsGeoTransform *transform : rubberBandGeoTransforms )
   {
     transform->setOrigin( mMap.origin() );

--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -20,6 +20,7 @@
 #include "qgs3dutils.h"
 #include "qgsabstract3dengine.h"
 #include "qgsbillboardgeometry.h"
+#include "qgsframegraph.h"
 #include "qgsgeotransform.h"
 #include "qgslinematerial_p.h"
 #include "qgslinestring.h"
@@ -29,6 +30,7 @@
 #include "qgsmessagelog.h"
 #include "qgspoint3dbillboardmaterial.h"
 #include "qgspolygon.h"
+#include "qgsrubberbandrenderview.h"
 #include "qgssymbollayer.h"
 #include "qgssymbollayerutils.h"
 #include "qgstessellatedpolygongeometry.h"
@@ -49,23 +51,25 @@ using namespace Qt::StringLiterals;
 /// @cond PRIVATE
 
 
-QgsRubberBand3D::QgsRubberBand3D( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine, Qt3DCore::QEntity *parentEntity, const Qgis::GeometryType geometryType )
+QgsRubberBand3D::QgsRubberBand3D( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine, const Qgis::GeometryType geometryType )
   : mMapSettings( &map )
   , mEngine( engine )
   , mGeometryType( geometryType )
 {
+  Qt3DCore::QEntity *parentEntity = mEngine->frameGraph()->rubberBandRenderView().rubberBandEntity();
+
   switch ( mGeometryType )
   {
     case Qgis::GeometryType::Point:
       setupMarker( parentEntity );
       break;
     case Qgis::GeometryType::Line:
-      setupLine( parentEntity );
+      setupLine( parentEntity, engine );
       setupMarker( parentEntity );
       break;
     case Qgis::GeometryType::Polygon:
       setupMarker( parentEntity );
-      setupLine( parentEntity );
+      setupLine( parentEntity, engine );
       setupPolygon( parentEntity );
       break;
     case Qgis::GeometryType::Null:
@@ -92,7 +96,7 @@ void QgsRubberBand3D::setupMarker( Qt3DCore::QEntity *parentEntity )
   mMarkerEntity->addComponent( mMarkerTransform );
 }
 
-void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity )
+void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity, QgsAbstract3DEngine *engine )
 {
   mLineEntity = make_qobject_unique<Qt3DCore::QEntity>( parentEntity );
 
@@ -115,8 +119,8 @@ void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity )
   mLineMaterial->setLineWidth( mWidth );
   mLineMaterial->setLineColor( mColor );
 
-  QObject::connect( mEngine, &QgsAbstract3DEngine::sizeChanged, mLineMaterial, [this] { mLineMaterial->setViewportSize( mEngine->size() ); } );
-  mLineMaterial->setViewportSize( mEngine->size() );
+  QObject::connect( engine, &QgsAbstract3DEngine::sizeChanged, mLineMaterial, [this] { mLineMaterial->setViewportSize( mEngine->size() ); } );
+  mLineMaterial->setViewportSize( engine->size() );
 
   mLineEntity->addComponent( mLineMaterial );
 

--- a/src/3d/qgsrubberband3d.cpp
+++ b/src/3d/qgsrubberband3d.cpp
@@ -64,12 +64,12 @@ QgsRubberBand3D::QgsRubberBand3D( Qgs3DMapSettings &map, QgsAbstract3DEngine *en
       setupMarker( parentEntity );
       break;
     case Qgis::GeometryType::Line:
-      setupLine( parentEntity, engine );
+      setupLine( parentEntity );
       setupMarker( parentEntity );
       break;
     case Qgis::GeometryType::Polygon:
       setupMarker( parentEntity );
-      setupLine( parentEntity, engine );
+      setupLine( parentEntity );
       setupPolygon( parentEntity );
       break;
     case Qgis::GeometryType::Null:
@@ -96,7 +96,7 @@ void QgsRubberBand3D::setupMarker( Qt3DCore::QEntity *parentEntity )
   mMarkerEntity->addComponent( mMarkerTransform );
 }
 
-void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity, QgsAbstract3DEngine *engine )
+void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity )
 {
   mLineEntity = make_qobject_unique<Qt3DCore::QEntity>( parentEntity );
 
@@ -119,8 +119,8 @@ void QgsRubberBand3D::setupLine( Qt3DCore::QEntity *parentEntity, QgsAbstract3DE
   mLineMaterial->setLineWidth( mWidth );
   mLineMaterial->setLineColor( mColor );
 
-  QObject::connect( engine, &QgsAbstract3DEngine::sizeChanged, mLineMaterial, [this] { mLineMaterial->setViewportSize( mEngine->size() ); } );
-  mLineMaterial->setViewportSize( engine->size() );
+  QObject::connect( mEngine, &QgsAbstract3DEngine::sizeChanged, mLineMaterial, [this] { mLineMaterial->setViewportSize( mEngine->size() ); } );
+  mLineMaterial->setViewportSize( mEngine->size() );
 
   mLineEntity->addComponent( mLineMaterial );
 

--- a/src/3d/qgsrubberband3d.h
+++ b/src/3d/qgsrubberband3d.h
@@ -91,7 +91,7 @@ class _3D_EXPORT QgsRubberBand3D
       Circle
     };
 
-    QgsRubberBand3D( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine, Qt3DCore::QEntity *parentEntity, Qgis::GeometryType geometryType = Qgis::GeometryType::Line );
+    QgsRubberBand3D( Qgs3DMapSettings &map, QgsAbstract3DEngine *engine, Qgis::GeometryType geometryType = Qgis::GeometryType::Line );
     ~QgsRubberBand3D();
 
     //! Returns the rubber band width in pixels
@@ -206,7 +206,7 @@ class _3D_EXPORT QgsRubberBand3D
     void updateGeometry();
     void updateMarkerMaterial();
     void setupMarker( Qt3DCore::QEntity *parentEntity );
-    void setupLine( Qt3DCore::QEntity *parentEntity );
+    void setupLine( Qt3DCore::QEntity *parentEntity, QgsAbstract3DEngine *engine );
     void setupPolygon( Qt3DCore::QEntity *parentEntity );
     //! negative index counts from end
     void removePoint( int index );

--- a/src/3d/qgsrubberband3d.h
+++ b/src/3d/qgsrubberband3d.h
@@ -206,7 +206,7 @@ class _3D_EXPORT QgsRubberBand3D
     void updateGeometry();
     void updateMarkerMaterial();
     void setupMarker( Qt3DCore::QEntity *parentEntity );
-    void setupLine( Qt3DCore::QEntity *parentEntity, QgsAbstract3DEngine *engine );
+    void setupLine( Qt3DCore::QEntity *parentEntity );
     void setupPolygon( Qt3DCore::QEntity *parentEntity );
     //! negative index counts from end
     void removePoint( int index );

--- a/src/app/3d/qgs3dmapcanvaswidget.cpp
+++ b/src/app/3d/qgs3dmapcanvaswidget.cpp
@@ -1445,7 +1445,7 @@ void Qgs3DMapCanvasWidget::updateProfileCursorPosition( QgsElevationProfile *pro
 
   if ( !data.cursorLineRubberBand )
   {
-    data.cursorLineRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Line );
+    data.cursorLineRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), Qgis::GeometryType::Line );
     data.cursorLineRubberBand->setColor( QColor( 0, 0, 0, 200 ) );
     data.cursorLineRubberBand->setWidth( 3 );
     data.cursorLineRubberBand->setMarkersEnabled( false );
@@ -1504,7 +1504,7 @@ void Qgs3DMapCanvasWidget::updateProfileCursorPosition( QgsElevationProfile *pro
 
   if ( !data.cursorPolygonRubberBand )
   {
-    data.cursorPolygonRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Polygon );
+    data.cursorPolygonRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), Qgis::GeometryType::Polygon );
     data.cursorPolygonRubberBand->setColor( QColor( 50, 50, 50, 100 ) );
     data.cursorPolygonRubberBand->setWidth( 0 );
     data.cursorPolygonRubberBand->setMarkersEnabled( false );
@@ -1599,7 +1599,7 @@ void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profil
 
   if ( !data.rubberBandZMin )
   {
-    data.rubberBandZMin = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), geomType );
+    data.rubberBandZMin = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), geomType );
     data.rubberBandZMin->setColor( QColor( 200, 200, 200, 200 ) );
     data.rubberBandZMin->setOutlineColor( QColor( 200, 200, 200, 200 ) );
     data.rubberBandZMin->setWidth( 3 );
@@ -1609,7 +1609,7 @@ void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profil
 
   if ( !data.rubberBandZMax )
   {
-    data.rubberBandZMax = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), geomType );
+    data.rubberBandZMax = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), geomType );
     data.rubberBandZMax->setColor( QColor( 200, 200, 200, 200 ) );
     data.rubberBandZMax->setOutlineColor( QColor( 200, 200, 200, 200 ) );
     data.rubberBandZMax->setWidth( 3 );
@@ -1707,7 +1707,7 @@ void Qgs3DMapCanvasWidget::updateProfileRubberBands( QgsElevationProfile *profil
 
     if ( !data.rubberBandSideLines[i] )
     {
-      data.rubberBandSideLines[i] = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Line );
+      data.rubberBandSideLines[i] = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), Qgis::GeometryType::Line );
       data.rubberBandSideLines[i]->setColor( QColor( 200, 200, 200, 150 ) );
       data.rubberBandSideLines[i]->setWidth( 3 );
       data.rubberBandSideLines[i]->setMarkersEnabled( false );

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -52,7 +52,7 @@ Qgs3DMapToolMeasureLine::~Qgs3DMapToolMeasureLine() = default;
 
 void Qgs3DMapToolMeasureLine::activate()
 {
-  mRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity() );
+  mRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine() );
 
   restart();
   updateSettings();

--- a/src/app/3d/qgs3dmaptoolpointcloudchangeattributepaintbrush.cpp
+++ b/src/app/3d/qgs3dmaptoolpointcloudchangeattributepaintbrush.cpp
@@ -55,14 +55,14 @@ void Qgs3DMapToolPointCloudChangeAttributePaintbrush::run()
 void Qgs3DMapToolPointCloudChangeAttributePaintbrush::activate()
 {
   mCanvas->cameraController()->setInputHandlersEnabled( false );
-  mSelectionRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Point );
+  mSelectionRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), Qgis::GeometryType::Point );
   mSelectionRubberBand->setMarkerOutlineStyle( Qt::PenStyle::DotLine );
   mSelectionRubberBand->setWidth( 32 );
   mSelectionRubberBand->setOutlineColor( mSelectionRubberBand->color() );
   mSelectionRubberBand->setColor( QColorConstants::Transparent );
   mSelectionRubberBand->addPoint( Qgs3DUtils::screenPointToMapCoordinates( QCursor::pos(), mCanvas->size(), mCanvas->cameraController(), mCanvas->mapSettings() ) );
   mIsActive = true;
-  mHighlighterRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Polygon );
+  mHighlighterRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), Qgis::GeometryType::Polygon );
   mHighlighterRubberBand->setMarkersEnabled( false );
   mHighlighterRubberBand->setEdgesEnabled( false );
 }

--- a/src/app/3d/qgs3dmaptoolpointcloudchangeattributepolygon.cpp
+++ b/src/app/3d/qgs3dmaptoolpointcloudchangeattributepolygon.cpp
@@ -150,7 +150,7 @@ void Qgs3DMapToolPointCloudChangeAttributePolygon::activate()
   // cannot move this to the constructor as there are no mapSettings available yet when the tool is created
   if ( !mPolygonRubberBand )
   {
-    mPolygonRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Polygon );
+    mPolygonRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), Qgis::GeometryType::Polygon );
     if ( mToolType == Polygon )
     {
       mPolygonRubberBand->setHideLastMarker( true );
@@ -163,7 +163,7 @@ void Qgs3DMapToolPointCloudChangeAttributePolygon::activate()
   }
   if ( !mLineRubberBand && mToolType != Polygon )
   {
-    mLineRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), mCanvas->engine()->frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Line );
+    mLineRubberBand = std::make_unique<QgsRubberBand3D>( *mCanvas->mapSettings(), mCanvas->engine(), Qgis::GeometryType::Line );
     mLineRubberBand->setHideLastMarker( true );
   }
 }

--- a/tests/src/3d/testqgsrubberband3drendering.cpp
+++ b/tests/src/3d/testqgsrubberband3drendering.cpp
@@ -109,7 +109,7 @@ void TestQgsRubberBand3DRendering::testRubberBandPoint()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );
   engine.setRootEntity( scene );
 
-  QgsRubberBand3D pointRubberBand( *map, &engine, engine.frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Point );
+  QgsRubberBand3D pointRubberBand( *map, &engine, Qgis::GeometryType::Point );
   pointRubberBand.addPoint( QgsPoint( fullExtent.center().x() - 25, fullExtent.center().y() - 25, 0 ) );
   pointRubberBand.addPoint( QgsPoint( fullExtent.center().x() + 25, fullExtent.center().y() - 25, 0 ) );
   pointRubberBand.addPoint( QgsPoint( fullExtent.center().x() - 25, fullExtent.center().y() + 25, 0 ) );
@@ -142,7 +142,7 @@ void TestQgsRubberBand3DRendering::testRubberBandLine()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );
   engine.setRootEntity( scene );
 
-  QgsRubberBand3D pointRubberBand( *map, &engine, engine.frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Line );
+  QgsRubberBand3D pointRubberBand( *map, &engine, Qgis::GeometryType::Line );
   pointRubberBand.setGeometry( QgsGeometry( mPoints->clone() ) );
 
   scene->cameraController()->resetView( 90 );
@@ -172,7 +172,7 @@ void TestQgsRubberBand3DRendering::testRubberBandPolygon()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );
   engine.setRootEntity( scene );
 
-  QgsRubberBand3D pointRubberBand( *map, &engine, engine.frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Polygon );
+  QgsRubberBand3D pointRubberBand( *map, &engine, Qgis::GeometryType::Polygon );
   pointRubberBand.setGeometry( QgsGeometry( new QgsPolygon( mPoints->clone() ) ) );
 
   scene->cameraController()->resetView( 90 );
@@ -202,7 +202,7 @@ void TestQgsRubberBand3DRendering::testRubberBandHiddenMarker()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );
   engine.setRootEntity( scene );
 
-  QgsRubberBand3D pointRubberBand( *map, &engine, engine.frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Polygon );
+  QgsRubberBand3D pointRubberBand( *map, &engine, Qgis::GeometryType::Polygon );
   pointRubberBand.setMarkersEnabled( false );
   pointRubberBand.setGeometry( QgsGeometry( new QgsPolygon( mPoints->clone() ) ) );
 
@@ -235,7 +235,7 @@ void TestQgsRubberBand3DRendering::testRubberBandHiddenLastMarker()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );
   engine.setRootEntity( scene );
 
-  QgsRubberBand3D pointRubberBand( *map, &engine, engine.frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Line );
+  QgsRubberBand3D pointRubberBand( *map, &engine, Qgis::GeometryType::Line );
   pointRubberBand.setHideLastMarker( true );
   pointRubberBand.setGeometry( QgsGeometry( mPoints->clone() ) );
 
@@ -266,7 +266,7 @@ void TestQgsRubberBand3DRendering::testRubberBandHiddenEdges()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );
   engine.setRootEntity( scene );
 
-  QgsRubberBand3D pointRubberBand( *map, &engine, engine.frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Polygon );
+  QgsRubberBand3D pointRubberBand( *map, &engine, Qgis::GeometryType::Polygon );
   pointRubberBand.setEdgesEnabled( false );
   pointRubberBand.setGeometry( QgsGeometry( new QgsPolygon( mPoints->clone() ) ) );
 
@@ -299,7 +299,7 @@ void TestQgsRubberBand3DRendering::testRubberBandHiddenPolygonFill()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *map, &engine );
   engine.setRootEntity( scene );
 
-  QgsRubberBand3D pointRubberBand( *map, &engine, engine.frameGraph()->rubberBandsRootEntity(), Qgis::GeometryType::Polygon );
+  QgsRubberBand3D pointRubberBand( *map, &engine, Qgis::GeometryType::Polygon );
   pointRubberBand.setFillEnabled( false );
   pointRubberBand.setGeometry( QgsGeometry( new QgsPolygon( mPoints->clone() ) ) );
 

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_1/expected_framegraph.txt
@@ -1,111 +1,113 @@
-(Qt3DRender::QRenderSurfaceSelector{8/<no_name>})
-  (Qt3DRender::QViewport{9/<no_name>})
-    (Qt3DRender::QRenderPassFilter{10/GlobalParametersStore})
-      (Qt3DRender::QNoDraw{11/shadow::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{12/shadow::SubtreeEnabler}) [D]
-          (Qt3DRender::QLayerFilter{15/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {13/shadow::Layer} ]) ]
-            (Qt3DRender::QClearBuffers{16/<no_name>})
-              (Qt3DRender::QRenderStateSet{17/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
-                (Qt3DRender::QCameraSelector{24/shadow::CameraSelector_0}) [ (Qt3DRender::QCamera:{21/shadow::LightCamera_0}) ]
-                  (Qt3DRender::QRenderTargetSelector{25/<no_name>}) [ (outputs:[ (Depth:{14[DepthFormat]/shadow::MapTextureArray) ]) ]
-                (Qt3DRender::QCameraSelector{31/shadow::CameraSelector_1}) [ (Qt3DRender::QCamera:{28/shadow::LightCamera_1}) ]
-                  (Qt3DRender::QRenderTargetSelector{32/<no_name>}) [ (outputs:[ (Depth:{14[DepthFormat]/shadow::MapTextureArray) ]) ]
-                (Qt3DRender::QCameraSelector{38/shadow::CameraSelector_2}) [ (Qt3DRender::QCamera:{35/shadow::LightCamera_2}) ]
-                  (Qt3DRender::QRenderTargetSelector{39/<no_name>}) [ (outputs:[ (Depth:{14[DepthFormat]/shadow::MapTextureArray) ]) ]
-                (Qt3DRender::QCameraSelector{45/shadow::CameraSelector_3}) [ (Qt3DRender::QCamera:{42/shadow::LightCamera_3}) ]
-                  (Qt3DRender::QRenderTargetSelector{46/<no_name>}) [ (outputs:[ (Depth:{14[DepthFormat]/shadow::MapTextureArray) ]) ]
-      (Qt3DRender::QNoDraw{49/forward::NoDraw}) [D]
-        (Qt3DRender::QSubtreeEnabler{50/forward::SubtreeEnabler})
-          (Qt3DRender::QCameraSelector{54/forward::CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-            (Qt3DRender::QLayerFilter{55/<no_name>}) [ (AcceptAnyMatchingLayers:[ {51/forward::Layer} ]) ]
-              (Qt3DRender::QRenderStateSet{56/forward::Clip Plane RenderStateSet}) [  ]
-                (Qt3DRender::QRenderTargetSelector{63/<no_name>}) [ (outputs:[ (DepthStencil:{59[D24S8]/<no_name>), (Color0:{58[RGBA16F]/<no_name>) ]) ]
-                  (Qt3DRender::QLayerFilter{64/<no_name>}) [ (DiscardAnyMatchingLayers:[ {52/forward::TransparentLayer}, {53/forward::BackgroundLayer} ]) ]
-                    (Qt3DRender::QRenderStateSet{65/<no_name>}) [ (QDepthTest:Less), (QCullFace:Back) ]
-                      (Qt3DRender::QFrustumCulling{68/<no_name>})
-                        (Qt3DRender::QClearBuffers{69/<no_name>})
-                          (Qt3DRender::QDebugOverlay{70/<no_name>}) [D]
-                  (Qt3DRender::QLayerFilter{71/<no_name>}) [ (AcceptAnyMatchingLayers:[ {53/forward::BackgroundLayer} ]) ]
-                  (Qt3DRender::QLayerFilter{72/<no_name>}) [ (AcceptAnyMatchingLayers:[ {52/forward::TransparentLayer} ]) ]
-                    (Qt3DRender::QSortPolicy{73/<no_name>})
-                      (Qt3DRender::QRenderStateSet{74/<no_name>}) [ (QDepthTest:Less), (QNoDepthMask), (QCullFace:NoCulling), (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                      (Qt3DRender::QRenderStateSet{80/<no_name>}) [ (QDepthTest:Less), (QColorMask:[ (red:false), (green:false), (blue:false), (alpha:false) ]), (QCullFace:NoCulling) ]
-      (Qt3DRender::QNoDraw{84/highlights::NoDraw}) [D]
-        (Qt3DRender::QSubtreeEnabler{85/highlights::SubtreeEnabler})
-          (Qt3DRender::QRenderTargetSelector{87/<no_name>}) [ (outputs:[ (DepthStencil:{59[D24S8]/<no_name>), (Color0:{58[RGBA16F]/<no_name>) ]) ]
-            (Qt3DRender::QRenderStateSet{88/<no_name>}) [ (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add), (QNoDepthMask), (QDepthTest:Always), (QCullFace:NoCulling) ]
-              (Qt3DRender::QClearBuffers{90/<no_name>})
-                (Qt3DRender::QCameraSelector{91/<no_name>}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-                  (Qt3DRender::QLayerFilter{92/<no_name>}) [ (AcceptAnyMatchingLayers:[ {86/highlights::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{100/<no_name>}) [ (QNoDepthMask), (QDepthTest:Always), (QCullFace:NoCulling) ]
-              (Qt3DRender::QCameraSelector{106/Highlights Pass CameraSelector2}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-                (Qt3DRender::QLayerFilter{107/<no_name>}) [ (AcceptAnyMatchingLayers:[ {86/highlights::Layer} ]) ]
+(Qt3DRender::QRenderSurfaceSelector{7/<no_name>})
+  (Qt3DRender::QViewport{8/<no_name>})
+    (Qt3DRender::QRenderPassFilter{9/GlobalParametersStore})
+      (Qt3DRender::QNoDraw{10/shadow::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{11/shadow::SubtreeEnabler}) [D]
+          (Qt3DRender::QLayerFilter{14/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {12/shadow::Layer} ]) ]
+            (Qt3DRender::QClearBuffers{15/<no_name>})
+              (Qt3DRender::QRenderStateSet{16/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
+                (Qt3DRender::QCameraSelector{23/shadow::CameraSelector_0}) [ (Qt3DRender::QCamera:{20/shadow::LightCamera_0}) ]
+                  (Qt3DRender::QRenderTargetSelector{24/<no_name>}) [ (outputs:[ (Depth:{13[DepthFormat]/shadow::MapTextureArray) ]) ]
+                (Qt3DRender::QCameraSelector{30/shadow::CameraSelector_1}) [ (Qt3DRender::QCamera:{27/shadow::LightCamera_1}) ]
+                  (Qt3DRender::QRenderTargetSelector{31/<no_name>}) [ (outputs:[ (Depth:{13[DepthFormat]/shadow::MapTextureArray) ]) ]
+                (Qt3DRender::QCameraSelector{37/shadow::CameraSelector_2}) [ (Qt3DRender::QCamera:{34/shadow::LightCamera_2}) ]
+                  (Qt3DRender::QRenderTargetSelector{38/<no_name>}) [ (outputs:[ (Depth:{13[DepthFormat]/shadow::MapTextureArray) ]) ]
+                (Qt3DRender::QCameraSelector{44/shadow::CameraSelector_3}) [ (Qt3DRender::QCamera:{41/shadow::LightCamera_3}) ]
+                  (Qt3DRender::QRenderTargetSelector{45/<no_name>}) [ (outputs:[ (Depth:{13[DepthFormat]/shadow::MapTextureArray) ]) ]
+      (Qt3DRender::QNoDraw{48/forward::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{49/forward::SubtreeEnabler})
+          (Qt3DRender::QCameraSelector{53/forward::CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+            (Qt3DRender::QLayerFilter{54/<no_name>}) [ (AcceptAnyMatchingLayers:[ {50/forward::Layer} ]) ]
+              (Qt3DRender::QRenderStateSet{55/forward::Clip Plane RenderStateSet}) [  ]
+                (Qt3DRender::QRenderTargetSelector{62/<no_name>}) [ (outputs:[ (DepthStencil:{58[D24S8]/<no_name>), (Color0:{57[RGBA16F]/<no_name>) ]) ]
+                  (Qt3DRender::QLayerFilter{63/<no_name>}) [ (DiscardAnyMatchingLayers:[ {51/forward::TransparentLayer}, {52/forward::BackgroundLayer} ]) ]
+                    (Qt3DRender::QRenderStateSet{64/<no_name>}) [ (QDepthTest:Less), (QCullFace:Back) ]
+                      (Qt3DRender::QFrustumCulling{67/<no_name>})
+                        (Qt3DRender::QClearBuffers{68/<no_name>})
+                          (Qt3DRender::QDebugOverlay{69/<no_name>}) [D]
+                  (Qt3DRender::QLayerFilter{70/<no_name>}) [ (AcceptAnyMatchingLayers:[ {52/forward::BackgroundLayer} ]) ]
+                  (Qt3DRender::QLayerFilter{71/<no_name>}) [ (AcceptAnyMatchingLayers:[ {51/forward::TransparentLayer} ]) ]
+                    (Qt3DRender::QSortPolicy{72/<no_name>})
+                      (Qt3DRender::QRenderStateSet{73/<no_name>}) [ (QDepthTest:Less), (QNoDepthMask), (QCullFace:NoCulling), (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                      (Qt3DRender::QRenderStateSet{79/<no_name>}) [ (QDepthTest:Less), (QColorMask:[ (red:false), (green:false), (blue:false), (alpha:false) ]), (QCullFace:NoCulling) ]
+      (Qt3DRender::QNoDraw{83/highlights::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{84/highlights::SubtreeEnabler})
+          (Qt3DRender::QRenderTargetSelector{86/<no_name>}) [ (outputs:[ (DepthStencil:{58[D24S8]/<no_name>), (Color0:{57[RGBA16F]/<no_name>) ]) ]
+            (Qt3DRender::QRenderStateSet{87/<no_name>}) [ (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add), (QNoDepthMask), (QDepthTest:Always), (QCullFace:NoCulling) ]
+              (Qt3DRender::QClearBuffers{89/<no_name>})
+                (Qt3DRender::QCameraSelector{90/<no_name>}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+                  (Qt3DRender::QLayerFilter{91/<no_name>}) [ (AcceptAnyMatchingLayers:[ {85/highlights::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{99/<no_name>}) [ (QNoDepthMask), (QDepthTest:Always), (QCullFace:NoCulling) ]
+              (Qt3DRender::QCameraSelector{105/Highlights Pass CameraSelector2}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+                (Qt3DRender::QLayerFilter{106/<no_name>}) [ (AcceptAnyMatchingLayers:[ {85/highlights::Layer} ]) ]
+                  (Qt3DRender::QViewport{107/<no_name>})
                   (Qt3DRender::QViewport{108/<no_name>})
                   (Qt3DRender::QViewport{109/<no_name>})
                   (Qt3DRender::QViewport{110/<no_name>})
-                  (Qt3DRender::QViewport{111/<no_name>})
-      (Qt3DRender::QCameraSelector{112/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-        (Qt3DRender::QLayerFilter{113/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mRubberBandsLayer} ]) ]
-          (Qt3DRender::QRenderStateSet{116/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
-            (Qt3DRender::QRenderTargetSelector{118/<no_name>}) [ (outputs:[ (DepthStencil:{59[D24S8]/<no_name>), (Color0:{58[RGBA16F]/<no_name>) ]) ]
-      (Qt3DRender::QBlitFramebuffer{119/MsaaBlitFramebuffer}) [D]
-        (Qt3DRender::QNoDraw{120/<no_name>})
-      (Qt3DRender::QBlitFramebuffer{121/MsaaDepthBlitFramebuffer}) [D]
-        (Qt3DRender::QNoDraw{122/<no_name>})
-      (Qt3DRender::QNoDraw{123/depth::NoDraw}) [D]
-        (Qt3DRender::QSubtreeEnabler{124/depth::SubtreeEnabler})
-          (Qt3DRender::QLayerFilter{126/<no_name>}) [ (AcceptAnyMatchingLayers:[ {125/depth::Layer} ]) ]
-            (Qt3DRender::QRenderTargetSelector{127/<no_name>}) [ (outputs:[ (Color0:{129[RGB8_UNorm]/depth::mColorTexture) ]) ]
-              (Qt3DRender::QRenderCapture{131/<no_name>})
-      (Qt3DRender::QNoDraw{144/ambient_occlusion::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{145/ambient_occlusion::SubtreeEnabler}) [D]
-          (Qt3DRender::QRenderStateSet{148/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-            (Qt3DRender::QLayerFilter{151/<no_name>}) [ (AcceptAnyMatchingLayers:[ {146/ambient_occlusion::Layer(AO)} ]) ]
-              (Qt3DRender::QRenderTargetSelector{155/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{153[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
-          (Qt3DRender::QRenderStateSet{178/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-            (Qt3DRender::QLayerFilter{181/<no_name>}) [ (AcceptAnyMatchingLayers:[ {147/ambient_occlusion::Layer(Blur)} ]) ]
-              (Qt3DRender::QRenderTargetSelector{185/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{183[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
-      (Qt3DRender::QNoDraw{198/bloom::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{199/bloom::SubtreeEnabler}) [D]
-          (Qt3DRender::QRenderStateSet{202/<no_name>}) [  ]
-            (Qt3DRender::QRenderTargetSelector{207/<no_name>}) [ (outputs:[ (Color0:{206[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QClearBuffers{208/<no_name>})
-                (Qt3DRender::QLayerFilter{209/<no_name>}) [ (AcceptAnyMatchingLayers:[ {203/bloom::Layer(DownsamplePass1)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{226/<no_name>}) [ (outputs:[ (Color0:{225[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QClearBuffers{227/<no_name>})
-                (Qt3DRender::QLayerFilter{228/<no_name>}) [ (AcceptAnyMatchingLayers:[ {222/bloom::Layer(DownsamplePass2)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{245/<no_name>}) [ (outputs:[ (Color0:{244[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QClearBuffers{246/<no_name>})
-                (Qt3DRender::QLayerFilter{247/<no_name>}) [ (AcceptAnyMatchingLayers:[ {241/bloom::Layer(DownsamplePass3)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{264/<no_name>}) [ (outputs:[ (Color0:{263[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QClearBuffers{265/<no_name>})
-                (Qt3DRender::QLayerFilter{266/<no_name>}) [ (AcceptAnyMatchingLayers:[ {260/bloom::Layer(DownsamplePass4)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{283/<no_name>}) [ (outputs:[ (Color0:{282[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QClearBuffers{284/<no_name>})
-                (Qt3DRender::QLayerFilter{285/<no_name>}) [ (AcceptAnyMatchingLayers:[ {279/bloom::Layer(DownsamplePass5)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{301/<no_name>}) [ (outputs:[ (Color0:{263[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QRenderStateSet{302/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                (Qt3DRender::QLayerFilter{317/<no_name>}) [ (AcceptAnyMatchingLayers:[ {298/bloom::Layer(UpsamplePass4)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{321/<no_name>}) [ (outputs:[ (Color0:{244[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QRenderStateSet{322/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                (Qt3DRender::QLayerFilter{337/<no_name>}) [ (AcceptAnyMatchingLayers:[ {318/bloom::Layer(UpsamplePass3)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{341/<no_name>}) [ (outputs:[ (Color0:{225[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QRenderStateSet{342/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                (Qt3DRender::QLayerFilter{357/<no_name>}) [ (AcceptAnyMatchingLayers:[ {338/bloom::Layer(UpsamplePass2)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{361/<no_name>}) [ (outputs:[ (Color0:{206[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QRenderStateSet{362/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                (Qt3DRender::QLayerFilter{377/<no_name>}) [ (AcceptAnyMatchingLayers:[ {358/bloom::Layer(UpsamplePass1)} ]) ]
-      (Qt3DRender::QNoDraw{378/post_processing::NoDraw}) [D]
-        (Qt3DRender::QSubtreeEnabler{379/post_processing::SubtreeEnabler})
-          (Qt3DRender::QRenderTargetSelector{380/post_processing::RenderTargetSelector}) [D] [ (outputs:[ (Color0:{383[RGB8_UNorm]/post_processing::ColorTarget), (Depth:{385[DepthFormat]/post_processing::DepthTarget) ]) ]
-            (Qt3DRender::QLayerFilter{386/post_processing::Sub pass::Postprocessing}) [ (AcceptAnyMatchingLayers:[ {387/<no_name>} ]) ]
-              (Qt3DRender::QClearBuffers{388/<no_name>})
-            (Qt3DRender::QNoDraw{423/post_processing::Sub pass::OverlayTexture::NoDraw})
-              (Qt3DRender::QSubtreeEnabler{424/post_processing::Sub pass::OverlayTexture::SubtreeEnabler}) [D]
-                (Qt3DRender::QLayerFilter{426/<no_name>}) [ (AcceptAnyMatchingLayers:[ {425/post_processing::Sub pass::OverlayTexture::Layer} ]) ]
-                  (Qt3DRender::QRenderStateSet{427/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-            (Qt3DRender::QNoDraw{430/post_processing::Sub pass::RenderCapture})
-              (Qt3DRender::QRenderCapture{431/<no_name>})
-      (Qt3DRender::QRenderTargetSelector{432/<no_name>}) [ (outputs:[ (DepthStencil:{59[D24S8]/<no_name>), (Color0:{58[RGBA16F]/<no_name>) ]) ]
-        (Qt3DRender::QClearBuffers{433/<no_name>}) [D]
-          (Qt3DRender::QNoDraw{434/<no_name>})
+      (Qt3DRender::QNoDraw{111/rubber_band::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{112/rubber_band::SubtreeEnabler})
+          (Qt3DRender::QCameraSelector{114/rubber_band::CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+            (Qt3DRender::QLayerFilter{115/<no_name>}) [ (AcceptAnyMatchingLayers:[ {113/rubber_band::Layer} ]) ]
+              (Qt3DRender::QRenderStateSet{116/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
+                (Qt3DRender::QRenderTargetSelector{120/<no_name>}) [ (outputs:[ (DepthStencil:{58[D24S8]/<no_name>), (Color0:{57[RGBA16F]/<no_name>) ]) ]
+      (Qt3DRender::QBlitFramebuffer{122/MsaaBlitFramebuffer}) [D]
+        (Qt3DRender::QNoDraw{123/<no_name>})
+      (Qt3DRender::QBlitFramebuffer{124/MsaaDepthBlitFramebuffer}) [D]
+        (Qt3DRender::QNoDraw{125/<no_name>})
+      (Qt3DRender::QNoDraw{126/depth::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{127/depth::SubtreeEnabler})
+          (Qt3DRender::QLayerFilter{129/<no_name>}) [ (AcceptAnyMatchingLayers:[ {128/depth::Layer} ]) ]
+            (Qt3DRender::QRenderTargetSelector{130/<no_name>}) [ (outputs:[ (Color0:{132[RGB8_UNorm]/depth::mColorTexture) ]) ]
+              (Qt3DRender::QRenderCapture{134/<no_name>})
+      (Qt3DRender::QNoDraw{147/ambient_occlusion::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{148/ambient_occlusion::SubtreeEnabler}) [D]
+          (Qt3DRender::QRenderStateSet{151/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+            (Qt3DRender::QLayerFilter{154/<no_name>}) [ (AcceptAnyMatchingLayers:[ {149/ambient_occlusion::Layer(AO)} ]) ]
+              (Qt3DRender::QRenderTargetSelector{158/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{156[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
+          (Qt3DRender::QRenderStateSet{181/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+            (Qt3DRender::QLayerFilter{184/<no_name>}) [ (AcceptAnyMatchingLayers:[ {150/ambient_occlusion::Layer(Blur)} ]) ]
+              (Qt3DRender::QRenderTargetSelector{188/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{186[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
+      (Qt3DRender::QNoDraw{201/bloom::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{202/bloom::SubtreeEnabler}) [D]
+          (Qt3DRender::QRenderStateSet{205/<no_name>}) [  ]
+            (Qt3DRender::QRenderTargetSelector{210/<no_name>}) [ (outputs:[ (Color0:{209[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QClearBuffers{211/<no_name>})
+                (Qt3DRender::QLayerFilter{212/<no_name>}) [ (AcceptAnyMatchingLayers:[ {206/bloom::Layer(DownsamplePass1)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{229/<no_name>}) [ (outputs:[ (Color0:{228[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QClearBuffers{230/<no_name>})
+                (Qt3DRender::QLayerFilter{231/<no_name>}) [ (AcceptAnyMatchingLayers:[ {225/bloom::Layer(DownsamplePass2)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{248/<no_name>}) [ (outputs:[ (Color0:{247[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QClearBuffers{249/<no_name>})
+                (Qt3DRender::QLayerFilter{250/<no_name>}) [ (AcceptAnyMatchingLayers:[ {244/bloom::Layer(DownsamplePass3)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{267/<no_name>}) [ (outputs:[ (Color0:{266[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QClearBuffers{268/<no_name>})
+                (Qt3DRender::QLayerFilter{269/<no_name>}) [ (AcceptAnyMatchingLayers:[ {263/bloom::Layer(DownsamplePass4)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{286/<no_name>}) [ (outputs:[ (Color0:{285[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QClearBuffers{287/<no_name>})
+                (Qt3DRender::QLayerFilter{288/<no_name>}) [ (AcceptAnyMatchingLayers:[ {282/bloom::Layer(DownsamplePass5)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{304/<no_name>}) [ (outputs:[ (Color0:{266[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QRenderStateSet{305/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                (Qt3DRender::QLayerFilter{320/<no_name>}) [ (AcceptAnyMatchingLayers:[ {301/bloom::Layer(UpsamplePass4)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{324/<no_name>}) [ (outputs:[ (Color0:{247[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QRenderStateSet{325/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                (Qt3DRender::QLayerFilter{340/<no_name>}) [ (AcceptAnyMatchingLayers:[ {321/bloom::Layer(UpsamplePass3)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{344/<no_name>}) [ (outputs:[ (Color0:{228[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QRenderStateSet{345/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                (Qt3DRender::QLayerFilter{360/<no_name>}) [ (AcceptAnyMatchingLayers:[ {341/bloom::Layer(UpsamplePass2)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{364/<no_name>}) [ (outputs:[ (Color0:{209[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QRenderStateSet{365/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                (Qt3DRender::QLayerFilter{380/<no_name>}) [ (AcceptAnyMatchingLayers:[ {361/bloom::Layer(UpsamplePass1)} ]) ]
+      (Qt3DRender::QNoDraw{381/post_processing::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{382/post_processing::SubtreeEnabler})
+          (Qt3DRender::QRenderTargetSelector{383/post_processing::RenderTargetSelector}) [D] [ (outputs:[ (Color0:{386[RGB8_UNorm]/post_processing::ColorTarget), (Depth:{388[DepthFormat]/post_processing::DepthTarget) ]) ]
+            (Qt3DRender::QLayerFilter{389/post_processing::Sub pass::Postprocessing}) [ (AcceptAnyMatchingLayers:[ {390/<no_name>} ]) ]
+              (Qt3DRender::QClearBuffers{391/<no_name>})
+            (Qt3DRender::QNoDraw{426/post_processing::Sub pass::OverlayTexture::NoDraw})
+              (Qt3DRender::QSubtreeEnabler{427/post_processing::Sub pass::OverlayTexture::SubtreeEnabler}) [D]
+                (Qt3DRender::QLayerFilter{429/<no_name>}) [ (AcceptAnyMatchingLayers:[ {428/post_processing::Sub pass::OverlayTexture::Layer} ]) ]
+                  (Qt3DRender::QRenderStateSet{430/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+            (Qt3DRender::QNoDraw{433/post_processing::Sub pass::RenderCapture})
+              (Qt3DRender::QRenderCapture{434/<no_name>})
+      (Qt3DRender::QRenderTargetSelector{435/<no_name>}) [ (outputs:[ (DepthStencil:{58[D24S8]/<no_name>), (Color0:{57[RGBA16F]/<no_name>) ]) ]
+        (Qt3DRender::QClearBuffers{436/<no_name>}) [D]
+          (Qt3DRender::QNoDraw{437/<no_name>})

--- a/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
+++ b/tests/testdata/control_files/3d/expected_ambient_occlusion_2/expected_framegraph.txt
@@ -1,111 +1,113 @@
-(Qt3DRender::QRenderSurfaceSelector{8/<no_name>})
-  (Qt3DRender::QViewport{9/<no_name>})
-    (Qt3DRender::QRenderPassFilter{10/GlobalParametersStore})
-      (Qt3DRender::QNoDraw{11/shadow::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{12/shadow::SubtreeEnabler}) [D]
-          (Qt3DRender::QLayerFilter{15/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {13/shadow::Layer} ]) ]
-            (Qt3DRender::QClearBuffers{16/<no_name>})
-              (Qt3DRender::QRenderStateSet{17/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
-                (Qt3DRender::QCameraSelector{24/shadow::CameraSelector_0}) [ (Qt3DRender::QCamera:{21/shadow::LightCamera_0}) ]
-                  (Qt3DRender::QRenderTargetSelector{25/<no_name>}) [ (outputs:[ (Depth:{14[DepthFormat]/shadow::MapTextureArray) ]) ]
-                (Qt3DRender::QCameraSelector{31/shadow::CameraSelector_1}) [ (Qt3DRender::QCamera:{28/shadow::LightCamera_1}) ]
-                  (Qt3DRender::QRenderTargetSelector{32/<no_name>}) [ (outputs:[ (Depth:{14[DepthFormat]/shadow::MapTextureArray) ]) ]
-                (Qt3DRender::QCameraSelector{38/shadow::CameraSelector_2}) [ (Qt3DRender::QCamera:{35/shadow::LightCamera_2}) ]
-                  (Qt3DRender::QRenderTargetSelector{39/<no_name>}) [ (outputs:[ (Depth:{14[DepthFormat]/shadow::MapTextureArray) ]) ]
-                (Qt3DRender::QCameraSelector{45/shadow::CameraSelector_3}) [ (Qt3DRender::QCamera:{42/shadow::LightCamera_3}) ]
-                  (Qt3DRender::QRenderTargetSelector{46/<no_name>}) [ (outputs:[ (Depth:{14[DepthFormat]/shadow::MapTextureArray) ]) ]
-      (Qt3DRender::QNoDraw{49/forward::NoDraw}) [D]
-        (Qt3DRender::QSubtreeEnabler{50/forward::SubtreeEnabler})
-          (Qt3DRender::QCameraSelector{54/forward::CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-            (Qt3DRender::QLayerFilter{55/<no_name>}) [ (AcceptAnyMatchingLayers:[ {51/forward::Layer} ]) ]
-              (Qt3DRender::QRenderStateSet{56/forward::Clip Plane RenderStateSet}) [  ]
-                (Qt3DRender::QRenderTargetSelector{63/<no_name>}) [ (outputs:[ (DepthStencil:{59[D24S8]/<no_name>), (Color0:{58[RGBA16F]/<no_name>) ]) ]
-                  (Qt3DRender::QLayerFilter{64/<no_name>}) [ (DiscardAnyMatchingLayers:[ {52/forward::TransparentLayer}, {53/forward::BackgroundLayer} ]) ]
-                    (Qt3DRender::QRenderStateSet{65/<no_name>}) [ (QDepthTest:Less), (QCullFace:Back) ]
-                      (Qt3DRender::QFrustumCulling{68/<no_name>})
-                        (Qt3DRender::QClearBuffers{69/<no_name>})
-                          (Qt3DRender::QDebugOverlay{70/<no_name>}) [D]
-                  (Qt3DRender::QLayerFilter{71/<no_name>}) [ (AcceptAnyMatchingLayers:[ {53/forward::BackgroundLayer} ]) ]
-                  (Qt3DRender::QLayerFilter{72/<no_name>}) [ (AcceptAnyMatchingLayers:[ {52/forward::TransparentLayer} ]) ]
-                    (Qt3DRender::QSortPolicy{73/<no_name>})
-                      (Qt3DRender::QRenderStateSet{74/<no_name>}) [ (QDepthTest:Less), (QNoDepthMask), (QCullFace:NoCulling), (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                      (Qt3DRender::QRenderStateSet{80/<no_name>}) [ (QDepthTest:Less), (QColorMask:[ (red:false), (green:false), (blue:false), (alpha:false) ]), (QCullFace:NoCulling) ]
-      (Qt3DRender::QNoDraw{84/highlights::NoDraw}) [D]
-        (Qt3DRender::QSubtreeEnabler{85/highlights::SubtreeEnabler})
-          (Qt3DRender::QRenderTargetSelector{87/<no_name>}) [ (outputs:[ (DepthStencil:{59[D24S8]/<no_name>), (Color0:{58[RGBA16F]/<no_name>) ]) ]
-            (Qt3DRender::QRenderStateSet{88/<no_name>}) [ (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add), (QNoDepthMask), (QDepthTest:Always), (QCullFace:NoCulling) ]
-              (Qt3DRender::QClearBuffers{90/<no_name>})
-                (Qt3DRender::QCameraSelector{91/<no_name>}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-                  (Qt3DRender::QLayerFilter{92/<no_name>}) [ (AcceptAnyMatchingLayers:[ {86/highlights::Layer} ]) ]
-            (Qt3DRender::QRenderStateSet{100/<no_name>}) [ (QNoDepthMask), (QDepthTest:Always), (QCullFace:NoCulling) ]
-              (Qt3DRender::QCameraSelector{106/Highlights Pass CameraSelector2}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-                (Qt3DRender::QLayerFilter{107/<no_name>}) [ (AcceptAnyMatchingLayers:[ {86/highlights::Layer} ]) ]
+(Qt3DRender::QRenderSurfaceSelector{7/<no_name>})
+  (Qt3DRender::QViewport{8/<no_name>})
+    (Qt3DRender::QRenderPassFilter{9/GlobalParametersStore})
+      (Qt3DRender::QNoDraw{10/shadow::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{11/shadow::SubtreeEnabler}) [D]
+          (Qt3DRender::QLayerFilter{14/<no_name>}) [D] [ (AcceptAnyMatchingLayers:[ {12/shadow::Layer} ]) ]
+            (Qt3DRender::QClearBuffers{15/<no_name>})
+              (Qt3DRender::QRenderStateSet{16/<no_name>}) [ (QDepthTest:Less), (QCullFace:Front), (QPolygonOffset:[ (scaleFactor:1.1), (depthSteps:4) ]) ]
+                (Qt3DRender::QCameraSelector{23/shadow::CameraSelector_0}) [ (Qt3DRender::QCamera:{20/shadow::LightCamera_0}) ]
+                  (Qt3DRender::QRenderTargetSelector{24/<no_name>}) [ (outputs:[ (Depth:{13[DepthFormat]/shadow::MapTextureArray) ]) ]
+                (Qt3DRender::QCameraSelector{30/shadow::CameraSelector_1}) [ (Qt3DRender::QCamera:{27/shadow::LightCamera_1}) ]
+                  (Qt3DRender::QRenderTargetSelector{31/<no_name>}) [ (outputs:[ (Depth:{13[DepthFormat]/shadow::MapTextureArray) ]) ]
+                (Qt3DRender::QCameraSelector{37/shadow::CameraSelector_2}) [ (Qt3DRender::QCamera:{34/shadow::LightCamera_2}) ]
+                  (Qt3DRender::QRenderTargetSelector{38/<no_name>}) [ (outputs:[ (Depth:{13[DepthFormat]/shadow::MapTextureArray) ]) ]
+                (Qt3DRender::QCameraSelector{44/shadow::CameraSelector_3}) [ (Qt3DRender::QCamera:{41/shadow::LightCamera_3}) ]
+                  (Qt3DRender::QRenderTargetSelector{45/<no_name>}) [ (outputs:[ (Depth:{13[DepthFormat]/shadow::MapTextureArray) ]) ]
+      (Qt3DRender::QNoDraw{48/forward::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{49/forward::SubtreeEnabler})
+          (Qt3DRender::QCameraSelector{53/forward::CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+            (Qt3DRender::QLayerFilter{54/<no_name>}) [ (AcceptAnyMatchingLayers:[ {50/forward::Layer} ]) ]
+              (Qt3DRender::QRenderStateSet{55/forward::Clip Plane RenderStateSet}) [  ]
+                (Qt3DRender::QRenderTargetSelector{62/<no_name>}) [ (outputs:[ (DepthStencil:{58[D24S8]/<no_name>), (Color0:{57[RGBA16F]/<no_name>) ]) ]
+                  (Qt3DRender::QLayerFilter{63/<no_name>}) [ (DiscardAnyMatchingLayers:[ {51/forward::TransparentLayer}, {52/forward::BackgroundLayer} ]) ]
+                    (Qt3DRender::QRenderStateSet{64/<no_name>}) [ (QDepthTest:Less), (QCullFace:Back) ]
+                      (Qt3DRender::QFrustumCulling{67/<no_name>})
+                        (Qt3DRender::QClearBuffers{68/<no_name>})
+                          (Qt3DRender::QDebugOverlay{69/<no_name>}) [D]
+                  (Qt3DRender::QLayerFilter{70/<no_name>}) [ (AcceptAnyMatchingLayers:[ {52/forward::BackgroundLayer} ]) ]
+                  (Qt3DRender::QLayerFilter{71/<no_name>}) [ (AcceptAnyMatchingLayers:[ {51/forward::TransparentLayer} ]) ]
+                    (Qt3DRender::QSortPolicy{72/<no_name>})
+                      (Qt3DRender::QRenderStateSet{73/<no_name>}) [ (QDepthTest:Less), (QNoDepthMask), (QCullFace:NoCulling), (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                      (Qt3DRender::QRenderStateSet{79/<no_name>}) [ (QDepthTest:Less), (QColorMask:[ (red:false), (green:false), (blue:false), (alpha:false) ]), (QCullFace:NoCulling) ]
+      (Qt3DRender::QNoDraw{83/highlights::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{84/highlights::SubtreeEnabler})
+          (Qt3DRender::QRenderTargetSelector{86/<no_name>}) [ (outputs:[ (DepthStencil:{58[D24S8]/<no_name>), (Color0:{57[RGBA16F]/<no_name>) ]) ]
+            (Qt3DRender::QRenderStateSet{87/<no_name>}) [ (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add), (QNoDepthMask), (QDepthTest:Always), (QCullFace:NoCulling) ]
+              (Qt3DRender::QClearBuffers{89/<no_name>})
+                (Qt3DRender::QCameraSelector{90/<no_name>}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+                  (Qt3DRender::QLayerFilter{91/<no_name>}) [ (AcceptAnyMatchingLayers:[ {85/highlights::Layer} ]) ]
+            (Qt3DRender::QRenderStateSet{99/<no_name>}) [ (QNoDepthMask), (QDepthTest:Always), (QCullFace:NoCulling) ]
+              (Qt3DRender::QCameraSelector{105/Highlights Pass CameraSelector2}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+                (Qt3DRender::QLayerFilter{106/<no_name>}) [ (AcceptAnyMatchingLayers:[ {85/highlights::Layer} ]) ]
+                  (Qt3DRender::QViewport{107/<no_name>})
                   (Qt3DRender::QViewport{108/<no_name>})
                   (Qt3DRender::QViewport{109/<no_name>})
                   (Qt3DRender::QViewport{110/<no_name>})
-                  (Qt3DRender::QViewport{111/<no_name>})
-      (Qt3DRender::QCameraSelector{112/rubberBandsPass}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
-        (Qt3DRender::QLayerFilter{113/<no_name>}) [ (AcceptAnyMatchingLayers:[ {7/mRubberBandsLayer} ]) ]
-          (Qt3DRender::QRenderStateSet{116/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
-            (Qt3DRender::QRenderTargetSelector{118/<no_name>}) [ (outputs:[ (DepthStencil:{59[D24S8]/<no_name>), (Color0:{58[RGBA16F]/<no_name>) ]) ]
-      (Qt3DRender::QBlitFramebuffer{119/MsaaBlitFramebuffer}) [D]
-        (Qt3DRender::QNoDraw{120/<no_name>})
-      (Qt3DRender::QBlitFramebuffer{121/MsaaDepthBlitFramebuffer}) [D]
-        (Qt3DRender::QNoDraw{122/<no_name>})
-      (Qt3DRender::QNoDraw{123/depth::NoDraw}) [D]
-        (Qt3DRender::QSubtreeEnabler{124/depth::SubtreeEnabler})
-          (Qt3DRender::QLayerFilter{126/<no_name>}) [ (AcceptAnyMatchingLayers:[ {125/depth::Layer} ]) ]
-            (Qt3DRender::QRenderTargetSelector{127/<no_name>}) [ (outputs:[ (Color0:{129[RGB8_UNorm]/depth::mColorTexture) ]) ]
-              (Qt3DRender::QRenderCapture{131/<no_name>})
-      (Qt3DRender::QNoDraw{144/ambient_occlusion::NoDraw}) [D]
-        (Qt3DRender::QSubtreeEnabler{145/ambient_occlusion::SubtreeEnabler})
-          (Qt3DRender::QRenderStateSet{148/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-            (Qt3DRender::QLayerFilter{151/<no_name>}) [ (AcceptAnyMatchingLayers:[ {146/ambient_occlusion::Layer(AO)} ]) ]
-              (Qt3DRender::QRenderTargetSelector{155/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{153[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
-          (Qt3DRender::QRenderStateSet{178/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-            (Qt3DRender::QLayerFilter{181/<no_name>}) [ (AcceptAnyMatchingLayers:[ {147/ambient_occlusion::Layer(Blur)} ]) ]
-              (Qt3DRender::QRenderTargetSelector{185/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{183[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
-      (Qt3DRender::QNoDraw{198/bloom::NoDraw})
-        (Qt3DRender::QSubtreeEnabler{199/bloom::SubtreeEnabler}) [D]
-          (Qt3DRender::QRenderStateSet{202/<no_name>}) [  ]
-            (Qt3DRender::QRenderTargetSelector{207/<no_name>}) [ (outputs:[ (Color0:{206[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QClearBuffers{208/<no_name>})
-                (Qt3DRender::QLayerFilter{209/<no_name>}) [ (AcceptAnyMatchingLayers:[ {203/bloom::Layer(DownsamplePass1)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{226/<no_name>}) [ (outputs:[ (Color0:{225[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QClearBuffers{227/<no_name>})
-                (Qt3DRender::QLayerFilter{228/<no_name>}) [ (AcceptAnyMatchingLayers:[ {222/bloom::Layer(DownsamplePass2)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{245/<no_name>}) [ (outputs:[ (Color0:{244[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QClearBuffers{246/<no_name>})
-                (Qt3DRender::QLayerFilter{247/<no_name>}) [ (AcceptAnyMatchingLayers:[ {241/bloom::Layer(DownsamplePass3)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{264/<no_name>}) [ (outputs:[ (Color0:{263[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QClearBuffers{265/<no_name>})
-                (Qt3DRender::QLayerFilter{266/<no_name>}) [ (AcceptAnyMatchingLayers:[ {260/bloom::Layer(DownsamplePass4)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{283/<no_name>}) [ (outputs:[ (Color0:{282[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QClearBuffers{284/<no_name>})
-                (Qt3DRender::QLayerFilter{285/<no_name>}) [ (AcceptAnyMatchingLayers:[ {279/bloom::Layer(DownsamplePass5)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{301/<no_name>}) [ (outputs:[ (Color0:{263[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QRenderStateSet{302/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                (Qt3DRender::QLayerFilter{317/<no_name>}) [ (AcceptAnyMatchingLayers:[ {298/bloom::Layer(UpsamplePass4)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{321/<no_name>}) [ (outputs:[ (Color0:{244[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QRenderStateSet{322/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                (Qt3DRender::QLayerFilter{337/<no_name>}) [ (AcceptAnyMatchingLayers:[ {318/bloom::Layer(UpsamplePass3)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{341/<no_name>}) [ (outputs:[ (Color0:{225[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QRenderStateSet{342/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                (Qt3DRender::QLayerFilter{357/<no_name>}) [ (AcceptAnyMatchingLayers:[ {338/bloom::Layer(UpsamplePass2)} ]) ]
-            (Qt3DRender::QRenderTargetSelector{361/<no_name>}) [ (outputs:[ (Color0:{206[RG11B10F]/<no_name>) ]) ]
-              (Qt3DRender::QRenderStateSet{362/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
-                (Qt3DRender::QLayerFilter{377/<no_name>}) [ (AcceptAnyMatchingLayers:[ {358/bloom::Layer(UpsamplePass1)} ]) ]
-      (Qt3DRender::QNoDraw{378/post_processing::NoDraw}) [D]
-        (Qt3DRender::QSubtreeEnabler{379/post_processing::SubtreeEnabler})
-          (Qt3DRender::QRenderTargetSelector{380/post_processing::RenderTargetSelector}) [D] [ (outputs:[ (Color0:{383[RGB8_UNorm]/post_processing::ColorTarget), (Depth:{385[DepthFormat]/post_processing::DepthTarget) ]) ]
-            (Qt3DRender::QLayerFilter{386/post_processing::Sub pass::Postprocessing}) [ (AcceptAnyMatchingLayers:[ {387/<no_name>} ]) ]
-              (Qt3DRender::QClearBuffers{388/<no_name>})
-            (Qt3DRender::QNoDraw{423/post_processing::Sub pass::OverlayTexture::NoDraw})
-              (Qt3DRender::QSubtreeEnabler{424/post_processing::Sub pass::OverlayTexture::SubtreeEnabler}) [D]
-                (Qt3DRender::QLayerFilter{426/<no_name>}) [ (AcceptAnyMatchingLayers:[ {425/post_processing::Sub pass::OverlayTexture::Layer} ]) ]
-                  (Qt3DRender::QRenderStateSet{427/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
-            (Qt3DRender::QNoDraw{430/post_processing::Sub pass::RenderCapture})
-              (Qt3DRender::QRenderCapture{431/<no_name>})
-      (Qt3DRender::QRenderTargetSelector{432/<no_name>}) [ (outputs:[ (DepthStencil:{59[D24S8]/<no_name>), (Color0:{58[RGBA16F]/<no_name>) ]) ]
-        (Qt3DRender::QClearBuffers{433/<no_name>}) [D]
-          (Qt3DRender::QNoDraw{434/<no_name>})
+      (Qt3DRender::QNoDraw{111/rubber_band::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{112/rubber_band::SubtreeEnabler})
+          (Qt3DRender::QCameraSelector{114/rubber_band::CameraSelector}) [ (Qt3DRender::QCamera:{0/<no_name>}) ]
+            (Qt3DRender::QLayerFilter{115/<no_name>}) [ (AcceptAnyMatchingLayers:[ {113/rubber_band::Layer} ]) ]
+              (Qt3DRender::QRenderStateSet{116/<no_name>}) [ (QDepthTest:Always), (QBlendEquationArguments:[ (sourceRgb:SourceAlpha), (destinationRgb:Source1Alpha), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]), (QBlendEquation:Add) ]
+                (Qt3DRender::QRenderTargetSelector{120/<no_name>}) [ (outputs:[ (DepthStencil:{58[D24S8]/<no_name>), (Color0:{57[RGBA16F]/<no_name>) ]) ]
+      (Qt3DRender::QBlitFramebuffer{122/MsaaBlitFramebuffer}) [D]
+        (Qt3DRender::QNoDraw{123/<no_name>})
+      (Qt3DRender::QBlitFramebuffer{124/MsaaDepthBlitFramebuffer}) [D]
+        (Qt3DRender::QNoDraw{125/<no_name>})
+      (Qt3DRender::QNoDraw{126/depth::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{127/depth::SubtreeEnabler})
+          (Qt3DRender::QLayerFilter{129/<no_name>}) [ (AcceptAnyMatchingLayers:[ {128/depth::Layer} ]) ]
+            (Qt3DRender::QRenderTargetSelector{130/<no_name>}) [ (outputs:[ (Color0:{132[RGB8_UNorm]/depth::mColorTexture) ]) ]
+              (Qt3DRender::QRenderCapture{134/<no_name>})
+      (Qt3DRender::QNoDraw{147/ambient_occlusion::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{148/ambient_occlusion::SubtreeEnabler})
+          (Qt3DRender::QRenderStateSet{151/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+            (Qt3DRender::QLayerFilter{154/<no_name>}) [ (AcceptAnyMatchingLayers:[ {149/ambient_occlusion::Layer(AO)} ]) ]
+              (Qt3DRender::QRenderTargetSelector{158/ambient_occlusion::RenderTargetSelector(AO)}) [ (outputs:[ (Color0:{156[R32F]/ambient_occlusion::ColorTarget(AO)) ]) ]
+          (Qt3DRender::QRenderStateSet{181/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+            (Qt3DRender::QLayerFilter{184/<no_name>}) [ (AcceptAnyMatchingLayers:[ {150/ambient_occlusion::Layer(Blur)} ]) ]
+              (Qt3DRender::QRenderTargetSelector{188/ambient_occlusion::RenderTargetSelector(Blur)}) [ (outputs:[ (Color0:{186[R32F]/ambient_occlusion::ColorTarget(blur)) ]) ]
+      (Qt3DRender::QNoDraw{201/bloom::NoDraw})
+        (Qt3DRender::QSubtreeEnabler{202/bloom::SubtreeEnabler}) [D]
+          (Qt3DRender::QRenderStateSet{205/<no_name>}) [  ]
+            (Qt3DRender::QRenderTargetSelector{210/<no_name>}) [ (outputs:[ (Color0:{209[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QClearBuffers{211/<no_name>})
+                (Qt3DRender::QLayerFilter{212/<no_name>}) [ (AcceptAnyMatchingLayers:[ {206/bloom::Layer(DownsamplePass1)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{229/<no_name>}) [ (outputs:[ (Color0:{228[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QClearBuffers{230/<no_name>})
+                (Qt3DRender::QLayerFilter{231/<no_name>}) [ (AcceptAnyMatchingLayers:[ {225/bloom::Layer(DownsamplePass2)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{248/<no_name>}) [ (outputs:[ (Color0:{247[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QClearBuffers{249/<no_name>})
+                (Qt3DRender::QLayerFilter{250/<no_name>}) [ (AcceptAnyMatchingLayers:[ {244/bloom::Layer(DownsamplePass3)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{267/<no_name>}) [ (outputs:[ (Color0:{266[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QClearBuffers{268/<no_name>})
+                (Qt3DRender::QLayerFilter{269/<no_name>}) [ (AcceptAnyMatchingLayers:[ {263/bloom::Layer(DownsamplePass4)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{286/<no_name>}) [ (outputs:[ (Color0:{285[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QClearBuffers{287/<no_name>})
+                (Qt3DRender::QLayerFilter{288/<no_name>}) [ (AcceptAnyMatchingLayers:[ {282/bloom::Layer(DownsamplePass5)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{304/<no_name>}) [ (outputs:[ (Color0:{266[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QRenderStateSet{305/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                (Qt3DRender::QLayerFilter{320/<no_name>}) [ (AcceptAnyMatchingLayers:[ {301/bloom::Layer(UpsamplePass4)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{324/<no_name>}) [ (outputs:[ (Color0:{247[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QRenderStateSet{325/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                (Qt3DRender::QLayerFilter{340/<no_name>}) [ (AcceptAnyMatchingLayers:[ {321/bloom::Layer(UpsamplePass3)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{344/<no_name>}) [ (outputs:[ (Color0:{228[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QRenderStateSet{345/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                (Qt3DRender::QLayerFilter{360/<no_name>}) [ (AcceptAnyMatchingLayers:[ {341/bloom::Layer(UpsamplePass2)} ]) ]
+            (Qt3DRender::QRenderTargetSelector{364/<no_name>}) [ (outputs:[ (Color0:{209[RG11B10F]/<no_name>) ]) ]
+              (Qt3DRender::QRenderStateSet{365/<no_name>}) [ (QBlendEquation:Add), (QBlendEquationArguments:[ (sourceRgb:One), (destinationRgb:One), (sourceAlpha:One), (destinationAlpha:Zero), (bufferIndex:-1) ]) ]
+                (Qt3DRender::QLayerFilter{380/<no_name>}) [ (AcceptAnyMatchingLayers:[ {361/bloom::Layer(UpsamplePass1)} ]) ]
+      (Qt3DRender::QNoDraw{381/post_processing::NoDraw}) [D]
+        (Qt3DRender::QSubtreeEnabler{382/post_processing::SubtreeEnabler})
+          (Qt3DRender::QRenderTargetSelector{383/post_processing::RenderTargetSelector}) [D] [ (outputs:[ (Color0:{386[RGB8_UNorm]/post_processing::ColorTarget), (Depth:{388[DepthFormat]/post_processing::DepthTarget) ]) ]
+            (Qt3DRender::QLayerFilter{389/post_processing::Sub pass::Postprocessing}) [ (AcceptAnyMatchingLayers:[ {390/<no_name>} ]) ]
+              (Qt3DRender::QClearBuffers{391/<no_name>})
+            (Qt3DRender::QNoDraw{426/post_processing::Sub pass::OverlayTexture::NoDraw})
+              (Qt3DRender::QSubtreeEnabler{427/post_processing::Sub pass::OverlayTexture::SubtreeEnabler}) [D]
+                (Qt3DRender::QLayerFilter{429/<no_name>}) [ (AcceptAnyMatchingLayers:[ {428/post_processing::Sub pass::OverlayTexture::Layer} ]) ]
+                  (Qt3DRender::QRenderStateSet{430/<no_name>}) [ (QDepthTest:Always), (QCullFace:NoCulling) ]
+            (Qt3DRender::QNoDraw{433/post_processing::Sub pass::RenderCapture})
+              (Qt3DRender::QRenderCapture{434/<no_name>})
+      (Qt3DRender::QRenderTargetSelector{435/<no_name>}) [ (outputs:[ (DepthStencil:{58[D24S8]/<no_name>), (Color0:{57[RGBA16F]/<no_name>) ]) ]
+        (Qt3DRender::QClearBuffers{436/<no_name>}) [D]
+          (Qt3DRender::QNoDraw{437/<no_name>})


### PR DESCRIPTION
This PR is part of <https://github.com/qgis/QGIS-Enhancement-Proposals/issues/259> QEP (relates to https://github.com/qgis/QGIS-Enhancement-Proposals/issues/252) and follows #60159.

It extracts the rubberband render view into a dedicated class.

cc @ptitjano @mkrus 

Funded by CEA/DAM @renardf