### PR TITLE
Ignore -Wsfinae-incomplete on GCC16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -843,6 +843,11 @@ if (PEDANTIC)
       set(_warnings "${_warnings} -Wno-deprecated-copy")
     endif()
 
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+      # GCC16 sets -Wsfinae-incomplete by default which throws warnings for some Qt headers (qmetatype.h)
+      set(_warnings "${_warnings} -Wno-sfinae-incomplete")
+    endif()
+
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_warnings}")
 
     # Qt produces lots of warnings with strict aliasing (as of Qt 4.4.0 & GCC 4.3)


### PR DESCRIPTION
GCC 16 enables `-Wsfinae-incomplete` by default. 

see https://github.com/qgis/QGIS/issues/66139 for more info and the console output.

I would like someone to verify this, but this seems like a Qt issue which would be difficult to fix in QGIS they way we have things set.

If this is indeed something harmless, then I'd like to ignore it.
It is quite annoying seeing all those warnings in console, even on some partial rebuilds (depending on which files I touch), when I fail to exclude the check when running cmake.