### PR TITLE
qgsvectorlayerprofilegenerator: Fix intersection for collinear polygons

### DIFF
--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -1479,7 +1479,7 @@ bool QgsVectorLayerProfileGenerator::generateProfileForPolygons()
           if ( triangleIsCollinearInXYPlane( triangle ) )
           {
             wasCollinear = true;
-            const QgsLineString *ring = qgsgeometry_cast< const QgsLineString * >( polygon->exteriorRing() );
+            const QgsLineString *ring = qgsgeometry_cast< const QgsLineString * >( triangle->exteriorRing() );
 
             QString lastError;
             if ( const QgsLineString *ls = qgsgeometry_cast< const QgsLineString * >( mProfileCurve.get() ) )
@@ -1490,24 +1490,33 @@ bool QgsVectorLayerProfileGenerator::generateProfileForPolygons()
                 const QgsPoint p2 = ls->pointN( curveSegmentIndex + 1 );
 
                 QgsPoint intersectionPoint;
+                bool intersectionFound = false;
                 double minZ = std::numeric_limits< double >::max();
                 double maxZ = std::numeric_limits< double >::lowest();
 
                 for ( auto vertexPair : std::array<std::pair<int, int>, 3> { { { 0, 1 }, { 1, 2 }, { 2, 0 } } } )
                 {
                   bool isIntersection = false;
-                  if ( QgsGeometryUtils::segmentIntersection( ring->pointN( vertexPair.first ), ring->pointN( vertexPair.second ), p1, p2, intersectionPoint, isIntersection ) )
+                  QgsPoint edgeIntersectionPoint;
+                  if ( QgsGeometryUtils::segmentIntersection( ring->pointN( vertexPair.first ), ring->pointN( vertexPair.second ), p1, p2, edgeIntersectionPoint, isIntersection ) )
                   {
+                    if ( !edgeIntersectionPoint.isEmpty() && !intersectionFound )
+                    {
+                      intersectionPoint = edgeIntersectionPoint;
+                      intersectionFound = true;
+                    }
+
+
                     const double fraction = QgsGeometryUtilsBase::pointFractionAlongLine(
-                      ring->xAt( vertexPair.first ), ring->yAt( vertexPair.first ), ring->xAt( vertexPair.second ), ring->yAt( vertexPair.second ), intersectionPoint.x(), intersectionPoint.y()
+                      ring->xAt( vertexPair.first ), ring->yAt( vertexPair.first ), ring->xAt( vertexPair.second ), ring->yAt( vertexPair.second ), edgeIntersectionPoint.x(), edgeIntersectionPoint.y()
                     );
-                    const double intersectionZ = ring->zAt( vertexPair.first ) + ( ring->zAt( vertexPair.second ) - ring->zAt( vertexPair.first ) ) * fraction;
+                    double intersectionZ = ring->zAt( vertexPair.first ) + ( ring->zAt( vertexPair.second ) - ring->zAt( vertexPair.first ) ) * fraction;
                     minZ = std::min( minZ, intersectionZ );
                     maxZ = std::max( maxZ, intersectionZ );
                   }
                 }
 
-                if ( !intersectionPoint.isEmpty() )
+                if ( intersectionFound )
                 {
                   // need z?
                   mResults->mRawPoints.append( intersectionPoint );

--- a/tests/src/python/test_qgsvectorlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsvectorlayerprofilegenerator.py
@@ -898,6 +898,40 @@ class TestQgsVectorLayerProfileGenerator(QgisTestCase):
         self.assertAlmostEqual(results.zRange().lower(), 15.0, 2)
         self.assertAlmostEqual(results.zRange().upper(), 22.5000, 2)
 
+    def testPolygonGenerationFollowingLinestringZExactly(self):
+        """
+        Test that a purely vertical line from a polygon is correctly
+        handled by the generator
+        """
+        vl = QgsVectorLayer("PolygonZ?crs=EPSG:3857", "polygon", "memory")
+        self.assertTrue(vl.isValid())
+
+        polygon_wkt = "Polygon Z ((547405.88 6150237.19 0, 547405.88 6150237.19 5, 547413.39 6150203.24 5, 547413.39 6150203.24 0, 547405.88 6150237.19 0))"
+        feature = QgsFeature()
+        feature.setGeometry(QgsGeometry.fromWkt(polygon_wkt))
+        self.assertTrue(vl.dataProvider().addFeature(feature))
+
+        vl.elevationProperties().setClamping(Qgis.AltitudeClamping.Absolute)
+
+        curve = QgsLineString()
+        curve.fromWkt(
+            "LineString (547394.297515 6150220.613784, 547416.10922 6150225.219982)"
+        )
+        req = QgsProfileRequest(curve)
+        req.setCrs(QgsCoordinateReferenceSystem("EPSG:3857"))
+
+        generator = vl.createProfileGenerator(req)
+        self.assertTrue(generator.generateProfile())
+        results = generator.takeResults()
+
+        self.assertEqual(
+            self.round_dict(results.distanceToHeightMap(), 1, 1),
+            {14.9: 5.0},
+        )
+
+        self.assertAlmostEqual(results.zRange().lower(), 0.0, 2)
+        self.assertAlmostEqual(results.zRange().upper(), 5.0, 2)
+
     def testPolygonGenerationTerrain(self):
         vl = QgsVectorLayer("PolygonZ?crs=EPSG:27700", "lines", "memory")
         self.assertTrue(vl.isValid())


### PR DESCRIPTION
## Description

With tolerance at 0, when a triangle from the tessellated polygon is collinear In the XY plane, the `processTriangleLineIntersect` worflow does not work and a special case is required.

In that case, the intersection between the profile line and the profile line is computed. For every intersection, the Z value is extracted. For each intersection, a Z value is calculated along the edge. The lowest and highest Z values are then used to build the vertical profile segment represented by the triangle.

This changes fixes 2 issues when iterating over the triangle edges:
1. Use the triangle, instead of the input polygon is used to compute intersection
2. Preserve the first valid intersection point when processing collinear triangles. Otherwise, a subsequent failed edge intersection test may overwrite a previously valid intersection point, causing profile segments to be skipped.

## AI tool usage

No AI Tool used

## Example 

<img width="1107" height="759" alt="Capture d’écran du 2026-06-10 19-36-12" src="https://github.com/user-attachments/assets/8ca452eb-b915-4214-bb7e-28d928cc0cfa" />


### Bug

<img width="1098" height="807" alt="Capture d’écran du 2026-06-10 19-36-34" src="https://github.com/user-attachments/assets/37bb2aab-6c69-468b-9b9d-e8d94a83cf75" />


### Fixed

<img width="1098" height="807" alt="Capture d’écran du 2026-06-10 19-37-56" src="https://github.com/user-attachments/assets/d855e8c2-b3ab-456d-861e-ce22069d314f" />
