### PR TITLE
[Backport queued_ltr_backports] set file filters for output in the Generate elevation profile image algorithm (fix #64915)

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsprocessingutils.py
+++ b/python/PyQt6/core/auto_additions/qgsprocessingutils.py
@@ -78,6 +78,8 @@ try:
     QgsProcessingUtils.removePointerValuesFromMap = staticmethod(QgsProcessingUtils.removePointerValuesFromMap)
     QgsProcessingUtils.preprocessQgisProcessParameters = staticmethod(QgsProcessingUtils.preprocessQgisProcessParameters)
     QgsProcessingUtils.resolveDefaultEncoding = staticmethod(QgsProcessingUtils.resolveDefaultEncoding)
+    QgsProcessingUtils.supportedImageFormats = staticmethod(QgsProcessingUtils.supportedImageFormats)
+    QgsProcessingUtils.supportedImageFileFilters = staticmethod(QgsProcessingUtils.supportedImageFileFilters)
     QgsProcessingUtils.__group__ = ['processing']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/PyQt6/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -681,6 +681,28 @@ encoding system (mostly UTF-8 on Unix-like, windows-1252 on Windows).
 .. versionadded:: 3.32
 %End
 
+    static QStringList supportedImageFormats();
+%Docstring
+Returns a list of image format extensions supported by QImageWriter.
+
+The returned list excludes SVG as it is typically handled via other
+exporters, and has the PNG format listed first as the recommended
+default. Remaining formats are sorted alphabetically.
+
+.. versionadded:: 4.2
+%End
+
+    static QString supportedImageFileFilters();
+%Docstring
+Returns a file filter string of all supported image formats, suitable
+for use in file picker dialogs.
+
+The returned string excludes SVG formats and prioritizes the PNG format
+as the recommended default. Remaining filters are sorted alphabetically.
+
+.. versionadded:: 4.2
+%End
+
 };
 
 class QgsProcessingFeatureSource : QgsFeatureSource

--- a/python/core/auto_additions/qgsprocessingutils.py
+++ b/python/core/auto_additions/qgsprocessingutils.py
@@ -78,6 +78,8 @@ try:
     QgsProcessingUtils.removePointerValuesFromMap = staticmethod(QgsProcessingUtils.removePointerValuesFromMap)
     QgsProcessingUtils.preprocessQgisProcessParameters = staticmethod(QgsProcessingUtils.preprocessQgisProcessParameters)
     QgsProcessingUtils.resolveDefaultEncoding = staticmethod(QgsProcessingUtils.resolveDefaultEncoding)
+    QgsProcessingUtils.supportedImageFormats = staticmethod(QgsProcessingUtils.supportedImageFormats)
+    QgsProcessingUtils.supportedImageFileFilters = staticmethod(QgsProcessingUtils.supportedImageFileFilters)
     QgsProcessingUtils.__group__ = ['processing']
 except (NameError, AttributeError):
     pass

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -681,6 +681,28 @@ encoding system (mostly UTF-8 on Unix-like, windows-1252 on Windows).
 .. versionadded:: 3.32
 %End
 
+    static QStringList supportedImageFormats();
+%Docstring
+Returns a list of image format extensions supported by QImageWriter.
+
+The returned list excludes SVG as it is typically handled via other
+exporters, and has the PNG format listed first as the recommended
+default. Remaining formats are sorted alphabetically.
+
+.. versionadded:: 4.2
+%End
+
+    static QString supportedImageFileFilters();
+%Docstring
+Returns a file filter string of all supported image formats, suitable
+for use in file picker dialogs.
+
+The returned string excludes SVG formats and prioritizes the PNG format
+as the recommended default. Remaining filters are sorted alphabetically.
+
+.. versionadded:: 4.2
+%End
+
 };
 
 class QgsProcessingFeatureSource : QgsFeatureSource

--- a/src/analysis/processing/qgsalgorithmgenerateelevationprofile.cpp
+++ b/src/analysis/processing/qgsalgorithmgenerateelevationprofile.cpp
@@ -125,7 +125,7 @@ void QgsGenerateElevationProfileAlgorithm::initAlgorithm( const QVariantMap & )
   dpiParam->setFlags( dpiParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( dpiParam.release() );
 
-  addParameter( new QgsProcessingParameterFileDestination( u"OUTPUT"_s, QObject::tr( "Output image" ), QgsProcessingUtils::supportedImageFileFilters() ) );
+  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output image" ), QgsProcessingUtils::supportedImageFileFilters() ) );
 }
 
 QString QgsGenerateElevationProfileAlgorithm::name() const

--- a/src/analysis/processing/qgsalgorithmgenerateelevationprofile.cpp
+++ b/src/analysis/processing/qgsalgorithmgenerateelevationprofile.cpp
@@ -28,6 +28,7 @@
 #include "qgsprofilerequest.h"
 #include "qgsterrainprovider.h"
 #include "qgscurve.h"
+#include <QImageWriter>
 
 ///@cond PRIVATE
 
@@ -124,7 +125,29 @@ void QgsGenerateElevationProfileAlgorithm::initAlgorithm( const QVariantMap & )
   dpiParam->setFlags( dpiParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( dpiParam.release() );
 
-  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output image" ) ) );
+  QStringList fileFilters;
+  const auto supportedFormats { QImageWriter::supportedImageFormats() };
+  for ( const QByteArray &format : supportedFormats )
+  {
+    if ( format == "svg" )
+    {
+      continue;
+    }
+
+    const QString longName = format.toUpper() + QObject::tr( " format" );
+    const QString glob = QStringLiteral( "*." ) + format;
+
+    if ( format == "png" && !fileFilters.empty() )
+    {
+      fileFilters.insert( 0, QStringLiteral( "%1 (%2 %3)" ).arg( longName, glob.toLower(), glob.toUpper() ) );
+    }
+    else
+    {
+      fileFilters.append( QStringLiteral( "%1 (%2 %3)" ).arg( longName, glob.toLower(), glob.toUpper() ) );
+    }
+  }
+
+  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output image" ), fileFilters.join( QLatin1String( ";;" ) ) ) );
 }
 
 QString QgsGenerateElevationProfileAlgorithm::name() const

--- a/src/analysis/processing/qgsalgorithmgenerateelevationprofile.cpp
+++ b/src/analysis/processing/qgsalgorithmgenerateelevationprofile.cpp
@@ -125,29 +125,7 @@ void QgsGenerateElevationProfileAlgorithm::initAlgorithm( const QVariantMap & )
   dpiParam->setFlags( dpiParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( dpiParam.release() );
 
-  QStringList fileFilters;
-  const auto supportedFormats { QImageWriter::supportedImageFormats() };
-  for ( const QByteArray &format : supportedFormats )
-  {
-    if ( format == "svg" )
-    {
-      continue;
-    }
-
-    const QString longName = format.toUpper() + QObject::tr( " format" );
-    const QString glob = QStringLiteral( "*." ) + format;
-
-    if ( format == "png" && !fileFilters.empty() )
-    {
-      fileFilters.insert( 0, QStringLiteral( "%1 (%2 %3)" ).arg( longName, glob.toLower(), glob.toUpper() ) );
-    }
-    else
-    {
-      fileFilters.append( QStringLiteral( "%1 (%2 %3)" ).arg( longName, glob.toLower(), glob.toUpper() ) );
-    }
-  }
-
-  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Output image" ), fileFilters.join( QLatin1String( ";;" ) ) ) );
+  addParameter( new QgsProcessingParameterFileDestination( u"OUTPUT"_s, QObject::tr( "Output image" ), QgsProcessingUtils::supportedImageFileFilters() ) );
 }
 
 QString QgsGenerateElevationProfileAlgorithm::name() const

--- a/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
@@ -168,16 +168,9 @@ QVariantMap QgsLayoutAtlasToImageAlgorithm::processAlgorithm( const QVariantMap 
   const QString directory = parameterAsFileOutput( parameters, QStringLiteral( "FOLDER" ), context );
   const QString fileName = QDir( directory ).filePath( QStringLiteral( "atlas" ) );
 
-  QStringList imageFormats;
-  const QList<QByteArray> supportedImageFormats { QImageWriter::supportedImageFormats() };
-  for ( const QByteArray &format : supportedImageFormats )
-  {
-    if ( format == QByteArray( "svg" ) )
-      continue;
-    imageFormats << QString( format );
-  }
+  const QStringList imageFormats = QgsProcessingUtils::supportedImageFormats();
   const int idx = parameterAsEnum( parameters, QStringLiteral( "EXTENSION" ), context );
-  const QString extension = '.' + imageFormats.at( idx );
+  const QString extension = '.' + imageFormats.at( idx ).toLower();
 
   QgsLayoutExporter::ImageExportSettings settings;
 

--- a/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
@@ -83,15 +83,7 @@ void QgsLayoutAtlasToImageAlgorithm::initAlgorithm( const QVariantMap & )
   layersParam->setFlags( layersParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( layersParam.release() );
 
-  QStringList imageFormats;
-  const QList<QByteArray> supportedImageFormats { QImageWriter::supportedImageFormats() };
-  for ( const QByteArray &format : supportedImageFormats )
-  {
-    if ( format == QByteArray( "svg" ) )
-      continue;
-    imageFormats << QString( format );
-  }
-  auto extensionParam = std::make_unique<QgsProcessingParameterEnum>( QStringLiteral( "EXTENSION" ), QObject::tr( "Image format" ), imageFormats, false, imageFormats.indexOf( QLatin1String( "png" ) ) );
+  auto extensionParam = std::make_unique<QgsProcessingParameterEnum>( u"EXTENSION"_s, QObject::tr( "Image format" ), QgsProcessingUtils::supportedImageFormats(), false, 0 );
   extensionParam->setFlags( extensionParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( extensionParam.release() );
 

--- a/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayoutatlastoimage.cpp
@@ -83,7 +83,7 @@ void QgsLayoutAtlasToImageAlgorithm::initAlgorithm( const QVariantMap & )
   layersParam->setFlags( layersParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( layersParam.release() );
 
-  auto extensionParam = std::make_unique<QgsProcessingParameterEnum>( u"EXTENSION"_s, QObject::tr( "Image format" ), QgsProcessingUtils::supportedImageFormats(), false, 0 );
+  auto extensionParam = std::make_unique<QgsProcessingParameterEnum>( QStringLiteral( "EXTENSION" ), QObject::tr( "Image format" ), QgsProcessingUtils::supportedImageFormats(), false, 0 );
   extensionParam->setFlags( extensionParam->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( extensionParam.release() );
 

--- a/src/analysis/processing/qgsalgorithmlayouttoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayouttoimage.cpp
@@ -84,7 +84,7 @@ void QgsLayoutToImageAlgorithm::initAlgorithm( const QVariantMap & )
   antialias->setFlags( antialias->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( antialias.release() );
 
-  addParameter( new QgsProcessingParameterFileDestination( u"OUTPUT"_s, QObject::tr( "Image file" ), QgsProcessingUtils::supportedImageFileFilters() ) );
+  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Image file" ), QgsProcessingUtils::supportedImageFileFilters() ) );
 }
 
 Qgis::ProcessingAlgorithmFlags QgsLayoutToImageAlgorithm::flags() const

--- a/src/analysis/processing/qgsalgorithmlayouttoimage.cpp
+++ b/src/analysis/processing/qgsalgorithmlayouttoimage.cpp
@@ -84,23 +84,7 @@ void QgsLayoutToImageAlgorithm::initAlgorithm( const QVariantMap & )
   antialias->setFlags( antialias->flags() | Qgis::ProcessingParameterFlag::Advanced );
   addParameter( antialias.release() );
 
-  QStringList imageFilters;
-  const auto supportedImageFormats { QImageWriter::supportedImageFormats() };
-  for ( const QByteArray &format : supportedImageFormats )
-  {
-    if ( format == "svg" )
-      continue;
-
-    const QString longName = format.toUpper() + QObject::tr( " format" );
-    const QString glob = QStringLiteral( "*." ) + format;
-
-    if ( format == "png" && !imageFilters.empty() )
-      imageFilters.insert( 0, QStringLiteral( "%1 (%2 %3)" ).arg( longName, glob.toLower(), glob.toUpper() ) );
-    else
-      imageFilters.append( QStringLiteral( "%1 (%2 %3)" ).arg( longName, glob.toLower(), glob.toUpper() ) );
-  }
-
-  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Image file" ), imageFilters.join( QLatin1String( ";;" ) ) ) );
+  addParameter( new QgsProcessingParameterFileDestination( u"OUTPUT"_s, QObject::tr( "Image file" ), QgsProcessingUtils::supportedImageFileFilters() ) );
 }
 
 Qgis::ProcessingAlgorithmFlags QgsLayoutToImageAlgorithm::flags() const

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -38,6 +38,7 @@
 #include "qgspointcloudlayer.h"
 #include "qgsannotationlayer.h"
 #include "qgstiledscenelayer.h"
+#include <QImageWriter>
 #include <QRegularExpression>
 #include <QTextCodec>
 #include <QUuid>
@@ -1746,6 +1747,54 @@ QString QgsProcessingUtils::resolveDefaultEncoding( const QString &defaultEncodi
   }
 
   return defaultEncoding;
+}
+
+QStringList QgsProcessingUtils::supportedImageFormats()
+{
+  const QList<QByteArray> supportedFormats = QImageWriter::supportedImageFormats();
+  QStringList formats;
+  formats.reserve( supportedFormats.size() );
+
+  for ( const QByteArray &format : supportedFormats )
+  {
+    if ( format == "svg" )
+    {
+      continue;
+    }
+    formats.append( QString::fromUtf8( format ).toUpper() );
+  }
+
+  std::sort( formats.begin(), formats.end(), []( const QString & a, const QString & b ) -> bool
+  {
+    if ( a ==  QLatin1String( "PNG" ) )
+    {
+      return true;
+    }
+    if ( b == QLatin1String( "PNG" ) )
+    {
+      return false;
+    }
+    return a.localeAwareCompare( b ) < 0;
+  } );
+
+  return formats;
+}
+
+QString QgsProcessingUtils::supportedImageFileFilters()
+{
+  const QStringList formats = supportedImageFormats();
+  QStringList fileFilters;
+  fileFilters.reserve( formats.size() );
+
+  for ( const QString &format : formats )
+  {
+    const QString longName = format + QObject::tr( " format" );
+    const QString glob = QStringLiteral( "*." ) + format;
+
+    fileFilters.append( QStringLiteral( "%1 (%2 %3)" ).arg( longName, glob.toLower(), glob ) );
+  }
+
+  return fileFilters.join( QLatin1String( ";;" ) );
 }
 
 //

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -617,6 +617,26 @@ class CORE_EXPORT QgsProcessingUtils
      */
     static QString resolveDefaultEncoding( const QString &defaultEncoding = "System" );
 
+    /**
+    * Returns a list of image format extensions supported by QImageWriter.
+    *
+    * The returned list excludes SVG as it is typically handled via other exporters, and has the PNG format
+    * listed first as the recommended default. Remaining formats are sorted alphabetically.
+    *
+    * \since QGIS 4.2
+    */
+    static QStringList supportedImageFormats();
+
+    /**
+     * Returns a file filter string of all supported image formats, suitable for use in file picker dialogs.
+     *
+     * The returned string excludes SVG formats and prioritizes the PNG format as the recommended default.
+     * Remaining filters are sorted alphabetically.
+     *
+     * \since QGIS 4.2
+     */
+    static QString supportedImageFileFilters();
+
   private:
     static bool canUseLayer( const QgsRasterLayer *layer );
     static bool canUseLayer( const QgsMeshLayer *layer );


### PR DESCRIPTION
## Description

Manual backport of #66286.

Add file filters with supported image formats to the Generate elevation profile image Processing algorithm.
Fixes #64915.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.