### PR TITLE
[Backport queued_ltr_backports]  add optional parameter to the "layer_property" expression function to allow returning untraslated string for "type" property (fix #65009)

### DIFF
--- a/resources/function_help/json/layer_property
+++ b/resources/function_help/json/layer_property
@@ -13,7 +13,7 @@
     "arg": "translate",
     "optional": true,
     "default": "true",
-    "description": "whether to return translated string. Currently affects only 'type' property."
+    "description": "whether to return translated string. Currently affects only 'type' property. By default translated strings are returned. Setting this to false will disable translation, always returning English strings."
   }],
   "examples": [{
     "expression": "layer_property('streets','title')",

--- a/resources/function_help/json/layer_property
+++ b/resources/function_help/json/layer_property
@@ -9,6 +9,11 @@
   }, {
     "arg": "property",
     "description": "a string corresponding to the property to return. Valid options are:<br /><ul><li>name: layer name</li><li>id: layer ID</li><li>title: metadata title string</li><li>abstract: metadata abstract string</li><li>keywords: metadata keywords</li><li>data_url: metadata URL</li><li>attribution: metadata attribution string</li><li>attribution_url: metadata attribution URL</li><li>source: layer source</li><li>min_scale: minimum display scale for layer</li><li>max_scale: maximum display scale for layer</li><li>is_editable: if layer is in edit mode</li><li>crs: layer CRS</li><li>crs_definition: layer CRS full definition</li><li>crs_description: layer CRS description</li><li>crs_ellipsoid: acronym of the layer CRS ellipsoid</li><li>extent: layer extent (as a geometry object)</li><li>distance_units: layer distance units</li><li>type: layer type, e.g., Vector or Raster</li><li>storage_type: storage format (vector layers only)</li><li>geometry_type: geometry type, e.g., Point (vector layers only)</li><li>feature_count: approximate feature count for layer (vector layers only)</li><li>path: File path to the layer data source. Only available for file based layers.</li></ul>"
+  }, {
+    "arg": "translate",
+    "optional": true,
+    "default": "true",
+    "description": "whether to return translated string. Currently affects only 'type' property."
   }],
   "examples": [{
     "expression": "layer_property('streets','title')",

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6728,9 +6728,9 @@ static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpres
   const QString layerProperty = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
 
   bool translate = true;
-  if ( values.length() == 3 )
+  if ( values.length() >= 3 )
   {
-    translate = QgsExpressionUtils::getIntValue( values.at( 2 ), parent );
+    translate = QgsExpressionUtils::getTVLValue( values.at( 2 ), parent ) == QgsExpressionUtils::TVL::True;
   }
 
   bool foundLayer = false;

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -6727,8 +6727,14 @@ static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpres
 {
   const QString layerProperty = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
 
+  bool translate = true;
+  if ( values.length() == 3 )
+  {
+    translate = QgsExpressionUtils::getIntValue( values.at( 2 ), parent );
+  }
+
   bool foundLayer = false;
-  const QVariant res = QgsExpressionUtils::runMapLayerFunctionThreadSafe( values.at( 0 ), context, parent, [layerProperty]( QgsMapLayer * layer )-> QVariant
+  const QVariant res = QgsExpressionUtils::runMapLayerFunctionThreadSafe( values.at( 0 ), context, parent, [layerProperty, translate]( QgsMapLayer * layer ) -> QVariant
   {
     if ( !layer )
       return QVariant();
@@ -6796,23 +6802,23 @@ static QVariant fcnGetLayerProperty( const QVariantList &values, const QgsExpres
       switch ( layer->type() )
       {
         case Qgis::LayerType::Vector:
-          return QCoreApplication::translate( "expressions", "Vector" );
+          return translate ? QCoreApplication::translate( "expressions", "Vector" ) : QStringLiteral( "Vector" );
         case Qgis::LayerType::Raster:
-          return QCoreApplication::translate( "expressions", "Raster" );
+          return translate ? QCoreApplication::translate( "expressions", "Raster" ) : QStringLiteral( "Raster" );
         case Qgis::LayerType::Mesh:
-          return QCoreApplication::translate( "expressions", "Mesh" );
+          return translate ?  QCoreApplication::translate( "expressions", "Mesh" ) : QStringLiteral( "Mesh" );
         case Qgis::LayerType::VectorTile:
-          return QCoreApplication::translate( "expressions", "Vector Tile" );
+          return translate ?  QCoreApplication::translate( "expressions", "Vector Tile" ) : QStringLiteral( "Vector Tile" );
         case Qgis::LayerType::Plugin:
-          return QCoreApplication::translate( "expressions", "Plugin" );
+          return translate ?  QCoreApplication::translate( "expressions", "Plugin" ) : QStringLiteral( "Plugin" );
         case Qgis::LayerType::Annotation:
-          return QCoreApplication::translate( "expressions", "Annotation" );
+          return translate ?  QCoreApplication::translate( "expressions", "Annotation" ) : QStringLiteral( "Annotation" );
         case Qgis::LayerType::PointCloud:
-          return QCoreApplication::translate( "expressions", "Point Cloud" );
+          return translate ?  QCoreApplication::translate( "expressions", "Point Cloud" ) : QStringLiteral( "Point Cloud" );
         case Qgis::LayerType::Group:
-          return QCoreApplication::translate( "expressions", "Group" );
+          return translate ?  QCoreApplication::translate( "expressions", "Group" ) : QStringLiteral( "Group" );
         case Qgis::LayerType::TiledScene:
-          return QCoreApplication::translate( "expressions", "Tiled Scene" );
+          return translate ?  QCoreApplication::translate( "expressions", "Tiled Scene" ) : QStringLiteral( "Tiled Scene" );
       }
     }
     else
@@ -9462,7 +9468,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
     // **General** functions
     functions
         << new QgsStaticExpressionFunction( QStringLiteral( "layer_property" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "layer" ) )
-                                            << QgsExpressionFunction::Parameter( QStringLiteral( "property" ) ),
+                                            << QgsExpressionFunction::Parameter( QStringLiteral( "property" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "translate" ), true, true ),
                                             fcnGetLayerProperty, QStringLiteral( "Map Layers" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "decode_uri" ),
                                             QgsExpressionFunction::ParameterList()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2589,6 +2589,51 @@ class TestQgsExpression : public QObject
       run_evaluation_test( exp4, evalError, result );
     }
 
+    void layer_property_type_i18n_data()
+    {
+      QTest::addColumn<QString>( "string" );
+      QTest::addColumn<QLocale::Language>( "language" );
+      QTest::addColumn<QVariant>( "expected" );
+
+      QTest::newRow( "layer_property type English" ) << QStringLiteral( "layer_property('%1','type')" ).arg( mPointsLayer->name() ) << QLocale::English << QVariant( "Vector" );
+      QTest::newRow( "layer_property type French" ) << QStringLiteral( "layer_property('%1','type')" ).arg( mPointsLayer->name() ) << QLocale::French << QVariant( "Vecteur" );
+      QTest::newRow( "layer_property type explicit translation English" ) << QStringLiteral( "layer_property('%1','type', true)" ).arg( mPointsLayer->name() ) << QLocale::English << QVariant( "Vector" );
+      QTest::newRow( "layer_property type explicit translation French" ) << QStringLiteral( "layer_property('%1','type', true)" ).arg( mPointsLayer->name() ) << QLocale::French << QVariant( "Vecteur" );
+      QTest::newRow( "layer_property type no translation English" ) << QStringLiteral( "layer_property('%1','type', false)" ).arg( mPointsLayer->name() ) << QLocale::English << QVariant( "Vector" );
+      QTest::newRow( "layer_property type no translation French" ) << QStringLiteral( "layer_property('%1','type', false)" ).arg( mPointsLayer->name() ) << QLocale::French << QVariant( "Vector" );
+    }
+
+    void layer_property_type_i18n()
+    {
+      QFETCH( QString, string );
+      QFETCH( QLocale::Language, language );
+      QFETCH( QVariant, expected );
+
+      QgsExpression exp( string );
+
+      QLocale::setDefault( language );
+      QTranslator translator;
+      const bool ok = translator.load( "qgis_" + QLocale().name(), QgsApplication::i18nPath() );
+      QVERIFY( ok );
+      QCoreApplication::installTranslator( &translator );
+
+      if ( exp.hasParserError() )
+      {
+        qDebug() << exp.parserErrorString();
+      }
+      QCOMPARE( exp.hasParserError(), false );
+
+      QVariant result = exp.evaluate();
+      if ( exp.hasEvalError() )
+      {
+        qDebug() << exp.evalErrorString();
+      }
+
+      QCOMPARE( result, expected );
+
+      QLocale::setDefault( QLocale::English );
+    }
+
     void eval_columns()
     {
       QgsFields fields;


### PR DESCRIPTION
## Description

Manual backport of #66300.

The layer_property (layer, 'type') expression returns result which depends on the QGIS locale, e.g. "Vector" or "Вектор". This makes expressions break. As we can't change the behavior of the function, let's add an optional parameter as suggested in https://github.com/qgis/QGIS/issues/65009#issuecomment-3931907161.

Fixes #65009.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.