### PR TITLE
fix global settings on QgsSettingsEntry

### DIFF
--- a/python/PyQt6/core/auto_additions/qgssettingsentry.py
+++ b/python/PyQt6/core/auto_additions/qgssettingsentry.py
@@ -1,5 +1,6 @@
 # The following has been generated automatically from src/core/settings/qgssettingsentry.h
 try:
+    QgsSettingsEntryBase.setGlobalSettingsPath = staticmethod(QgsSettingsEntryBase.setGlobalSettingsPath)
     QgsSettingsEntryBase.dynamicKeyPartToList = staticmethod(QgsSettingsEntryBase.dynamicKeyPartToList)
     QgsSettingsEntryBase.__virtual_methods__ = ['typeId', 'settingsType', 'checkValueVariant']
     QgsSettingsEntryBase.__group__ = ['settings']

--- a/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
+++ b/python/PyQt6/core/auto_generated/settings/qgssettingsentry.sip.in
@@ -55,6 +55,27 @@ settings description for the gui.
 %End
   public:
 
+    static bool setGlobalSettingsPath( const QString &path );
+%Docstring
+Sets the path to the global settings INI file and loads all keys into an
+in-memory hash for use as default values by
+:py:class:`QgsSettingsEntry`.
+
+This must be called once at application startup, before
+:py:class:`QgsApplication` initialization, and only from the main
+thread.
+
+:param path: the path to the global settings INI file.
+
+:return: ``True`` if the file was successfully loaded, ``False`` if the
+         path was empty or the file did not exist.
+
+.. versionadded:: 4.2
+%End
+
+
+
+
 
 
     static QStringList dynamicKeyPartToList( const QString &dynamicKeyPart );
@@ -182,6 +203,11 @@ Returns the origin of the setting if it exists
 .. note::
 
    it will return :py:class:`Qgis`.SettingsOrigin.Any if the key doesn't exist
+
+.. note::
+
+   Global takes precedence: if the key is defined in the global settings file,
+   the origin is :py:class:`Qgis`.SettingsOrigin.Global regardless of whether the user also overrides it.
 
 .. versionadded:: 3.30
 %End

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -85,6 +85,7 @@ typedef SInt32 SRefCon;
 
 #include "qgscustomization.h"
 #include "qgssettings.h"
+#include "qgssettingsentry.h"
 #include "qgsfontutils.h"
 #include "qgsmessagelog.h"
 #include "qgspythonrunner.h"
@@ -1114,9 +1115,10 @@ int main( int argc, char *argv[] )
 
   if ( !globalsettingsfile.isEmpty() )
   {
-    bool ok = QgsSettings::setGlobalSettingsPath( globalsettingsfile );
+    const bool ok1 = QgsSettingsEntryBase::setGlobalSettingsPath( globalsettingsfile );
+    const bool ok2 = QgsSettings::setGlobalSettingsPath( globalsettingsfile );
 
-    if ( !ok )
+    if ( !ok1 || !ok2 )
     {
       preApplicationWarningMessages << QObject::tr( "Invalid globalsettingsfile path: %1" ).arg( globalsettingsfile ), u"QGIS"_s;
     }

--- a/src/core/settings/qgssettingsentry.cpp
+++ b/src/core/settings/qgssettingsentry.cpp
@@ -20,7 +20,9 @@
 #include "qgssettingstreenode.h"
 #include "qgsthreadingutils.h"
 
+#include <QCoreApplication>
 #include <QDir>
+#include <QFile>
 #include <QRegularExpression>
 #include <QSettings>
 #include <QString>
@@ -64,6 +66,89 @@ void QgsSettingsEntryBase::setupUserSettings( const QString &profilePath )
 QSettings &QgsSettingsEntryBase::userSettings()
 {
   return sUserSettings();
+}
+
+QHash<QString, QVariant> QgsSettingsEntryBase::sGlobalDefaults;
+
+bool QgsSettingsEntryBase::setGlobalSettingsPath( const QString &path )
+{
+  // if this is called before the application is created
+  if ( QCoreApplication::instance() )
+  {
+    QGIS_CHECK_MAIN_THREAD_ACCESS
+  }
+
+  static bool sGlobalDefaultsLoaded = false;
+  if ( sGlobalDefaultsLoaded )
+    QgsDebugMsgLevel( u"Global settings are being reloaded from %1"_s.arg( path ), 2 );
+  sGlobalDefaultsLoaded = true;
+
+  sGlobalDefaults.clear();
+  if ( path.isEmpty() || !QFile::exists( path ) )
+    return false;
+
+  const QSettings globalSettings( path, QSettings::IniFormat );
+  const QStringList keys = globalSettings.allKeys();
+  sGlobalDefaults.reserve( keys.size() );
+  for ( const QString &key : keys )
+  {
+    sGlobalDefaults.insert( key, globalSettings.value( key ) );
+  }
+
+  return true;
+}
+
+bool QgsSettingsEntryBase::hasGlobalDefault( const QString &key )
+{
+  return sGlobalDefaults.contains( sanitizeGlobalKey( key ) );
+}
+
+QVariant QgsSettingsEntryBase::globalDefault( const QString &key )
+{
+  return sGlobalDefaults.value( sanitizeGlobalKey( key ) );
+}
+
+QStringList QgsSettingsEntryBase::globalChildGroups( const QString &prefix )
+{
+  QString normalizedPrefix = sanitizeGlobalKey( prefix );
+  if ( !normalizedPrefix.endsWith( '/' ) )
+    normalizedPrefix.append( '/' );
+
+  const int prefixLen = normalizedPrefix.size();
+  QStringList result;
+
+  for ( QHash<QString, QVariant>::const_iterator it = sGlobalDefaults.constBegin(); it != sGlobalDefaults.constEnd(); ++it )
+  {
+    if ( it.key().startsWith( normalizedPrefix ) )
+    {
+      const int slashPos = it.key().indexOf( '/', prefixLen );
+      const QString group = ( slashPos < 0 ) ? it.key().mid( prefixLen ) : it.key().mid( prefixLen, slashPos - prefixLen );
+      if ( !group.isEmpty() && !result.contains( group ) )
+        result.append( group );
+    }
+  }
+  return result;
+}
+
+QString QgsSettingsEntryBase::sanitizeGlobalKey( const QString &key )
+{
+  if ( key.startsWith( '/' ) )
+    return key.mid( 1 );
+  return key;
+}
+
+QVariant QgsSettingsEntryBase::valueFromSettingsWithGlobalDefault( const QString &resolvedKey, const QVariant &defaultValue ) const
+{
+  if ( sUserSettings().contains( resolvedKey ) )
+    return sUserSettings().value( resolvedKey );
+
+  // sGlobalDefaults is populated once on the main thread before any worker
+  // threads start, so concurrent reads are safe (no concurrent modification).
+  const QHash<QString, QVariant>::const_iterator it = sGlobalDefaults.constFind( sanitizeGlobalKey( resolvedKey ) );
+  if ( it != sGlobalDefaults.constEnd() )
+    return it.value();
+
+  return defaultValue;
 }
 
 QgsSettingsEntryBase::QgsSettingsEntryBase( const QString &key, QgsSettingsTreeNode *parent, const QVariant &defaultValue, const QString &description, Qgis::SettingsOptions options )
@@ -159,17 +244,24 @@ bool QgsSettingsEntryBase::hasDynamicKey() const
 
 bool QgsSettingsEntryBase::exists( const QString &dynamicKeyPart ) const
 {
-  return sUserSettings().contains( key( dynamicKeyPart ) );
+  const QString resolvedKey = key( dynamicKeyPart );
+  return sUserSettings().contains( resolvedKey ) || sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) );
 }
 
 bool QgsSettingsEntryBase::exists( const QStringList &dynamicKeyPartList ) const
 {
-  return sUserSettings().contains( key( dynamicKeyPartList ) );
+  const QString resolvedKey = key( dynamicKeyPartList );
+  return sUserSettings().contains( resolvedKey ) || sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) );
 }
 
 Qgis::SettingsOrigin QgsSettingsEntryBase::origin( const QStringList &dynamicKeyPartList ) const
 {
-  if ( sUserSettings().contains( key( dynamicKeyPartList ) ) )
+  const QString resolvedKey = key( dynamicKeyPartList );
+
+  if ( sGlobalDefaults.contains( sanitizeGlobalKey( resolvedKey ) ) )
+    return Qgis::SettingsOrigin::Global;
+
+  if ( sUserSettings().contains( resolvedKey ) )
     return Qgis::SettingsOrigin::Local;
 
   return Qgis::SettingsOrigin::Any;
@@ -212,7 +304,16 @@ bool QgsSettingsEntryBase::setVariantValue( const QVariant &value, const QString
     }
   }
 
-  sUserSettings().setValue( resolvedKey, value );
+  // If the new value matches a global default, remove the user override
+  const QString sanitizedKey = sanitizeGlobalKey( resolvedKey );
+  if ( sGlobalDefaults.contains( sanitizedKey ) && sGlobalDefaults.value( sanitizedKey ) == value )
+  {
+    sUserSettings().remove( resolvedKey );
+  }
+  else
+  {
+    sUserSettings().setValue( resolvedKey, value );
+  }
   return true;
 }
 
@@ -231,7 +332,7 @@ QVariant QgsSettingsEntryBase::valueAsVariant( const QString &dynamicKeyPart ) c
 
 QVariant QgsSettingsEntryBase::valueAsVariant( const QStringList &dynamicKeyPartList ) const
 {
-  return sUserSettings().value( key( dynamicKeyPartList ), mDefaultValue );
+  return valueFromSettingsWithGlobalDefault( key( dynamicKeyPartList ), mDefaultValue );
 }
 
 QVariant QgsSettingsEntryBase::valueAsVariant( const QString &dynamicKeyPart, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const
@@ -244,19 +345,19 @@ QVariant QgsSettingsEntryBase::valueAsVariant( const QString &dynamicKeyPart, bo
 QVariant QgsSettingsEntryBase::valueAsVariant( const QStringList &dynamicKeyPartList, bool useDefaultValueOverride, const QVariant &defaultValueOverride ) const
 {
   if ( useDefaultValueOverride )
-    return sUserSettings().value( key( dynamicKeyPartList ), defaultValueOverride );
+    return valueFromSettingsWithGlobalDefault( key( dynamicKeyPartList ), defaultValueOverride );
   else
-    return sUserSettings().value( key( dynamicKeyPartList ), mDefaultValue );
+    return valueFromSettingsWithGlobalDefault( key( dynamicKeyPartList ), mDefaultValue );
 }
 
 QVariant QgsSettingsEntryBase::valueAsVariantWithDefaultOverride( const QVariant &defaultValueOverride, const QString &dynamicKeyPart ) const
 {
-  return sUserSettings().value( key( dynamicKeyPart ), defaultValueOverride );
+  return valueFromSettingsWithGlobalDefault( key( dynamicKeyPart ), defaultValueOverride );
 }
 
 QVariant QgsSettingsEntryBase::valueAsVariantWithDefaultOverride( const QVariant &defaultValueOverride, const QStringList &dynamicKeyPartList ) const
 {
-  return sUserSettings().value( key( dynamicKeyPartList ), defaultValueOverride );
+  return valueFromSettingsWithGlobalDefault( key( dynamicKeyPartList ), defaultValueOverride );
 }
 
 QVariant QgsSettingsEntryBase::defaultValueAsVariant() const

--- a/src/core/settings/qgssettingsentry.h
+++ b/src/core/settings/qgssettingsentry.h
@@ -23,6 +23,7 @@
 #include "qgis_sip.h"
 
 #include <QColor>
+#include <QHash>
 #include <QSettings>
 #include <QString>
 
@@ -73,6 +74,48 @@ class CORE_EXPORT QgsSettingsEntryBase
 #endif
 
   public:
+
+    /**
+     * Sets the path to the global settings INI file and loads all keys
+     * into an in-memory hash for use as default values by QgsSettingsEntry.
+     *
+     * This must be called once at application startup, before QgsApplication
+     * initialization, and only from the main thread.
+     *
+     * \param path the path to the global settings INI file.
+     * \return TRUE if the file was successfully loaded, FALSE if the path was empty or the file did not exist.
+     *
+     * \since QGIS 4.2
+     */
+    static bool setGlobalSettingsPath( const QString &path );
+
+    /**
+     * Returns TRUE if the global settings INI file contains a value for the given \a key.
+     *
+     * \since QGIS 4.2
+     */
+    static bool hasGlobalDefault( const QString &key ) SIP_SKIP;
+
+    /**
+     * Returns the global default value for the given \a key,
+     * or an invalid QVariant if not found.
+     *
+     * \since QGIS 4.2
+     */
+    static QVariant globalDefault( const QString &key ) SIP_SKIP;
+
+    /**
+     * Returns the list of child group names found under \a prefix
+     * in the global defaults hash.
+     *
+     * The \a prefix is a tree-based key (may start with '/').
+     * A trailing '/' is added automatically if not present.
+     *
+     * \note This is intended for internal use by QgsSettingsTreeNamedListNode.
+     *
+     * \since QGIS 4.2
+     */
+    static QStringList globalChildGroups( const QString &prefix ) SIP_SKIP;
 
     /**
      * Configures QSettings to use IniFormat at the given \a profilePath
@@ -220,6 +263,8 @@ class CORE_EXPORT QgsSettingsEntryBase
     /**
      * Returns the origin of the setting if it exists
      * \note it will return Qgis::SettingsOrigin::Any if the key doesn't exist
+     * \note Global takes precedence: if the key is defined in the global settings file,
+     * the origin is Qgis::SettingsOrigin::Global regardless of whether the user also overrides it.
      * \since QGIS 3.30
      */
     Qgis::SettingsOrigin origin( const QStringList &dynamicKeyPartList ) const;
@@ -382,9 +427,14 @@ class CORE_EXPORT QgsSettingsEntryBase
     bool hasChanged() const { return mHasChanged; }
 
   private:
+    QVariant valueFromSettingsWithGlobalDefault( const QString &resolvedKey, const QVariant &defaultValue ) const SIP_SKIP;
     QString formerValuekey( const QStringList &dynamicKeyPartList ) const;
 
     QString completeKeyPrivate( const QString &key, const QStringList &dynamicKeyPartList ) const;
+
+    static QString sanitizeGlobalKey( const QString &key );
+
+    static QHash<QString, QVariant> sGlobalDefaults;
 
     QgsSettingsTreeNode *mParentTreeElement = nullptr;
     QString mName;

--- a/src/core/settings/qgssettingstreenode.cpp
+++ b/src/core/settings/qgssettingstreenode.cpp
@@ -175,8 +175,6 @@ QStringList QgsSettingsTreeNamedListNode::items( const QStringList &parentsNamed
 
 QStringList QgsSettingsTreeNamedListNode::items( Qgis::SettingsOrigin origin, const QStringList &parentsNamedItems ) const
 {
-  Q_UNUSED( origin )
-
   if ( namedNodesCount() - 1 != parentsNamedItems.count() )
     throw QgsSettingsException(
       QObject::tr( "The number of given parent named items (%1) for the node '%2' doesn't match with the number of named items in the key (%3)." )
@@ -185,10 +183,28 @@ QStringList QgsSettingsTreeNamedListNode::items( Qgis::SettingsOrigin origin, co
 
   const QString completeKeyParam = completeKeyWithNamedItems( mItemsCompleteKey, parentsNamedItems );
 
-  QSettings &settings = QgsSettingsEntryBase::userSettings();
-  settings.beginGroup( completeKeyParam );
-  const QStringList res = settings.childGroups();
-  settings.endGroup();
+  QStringList res;
+
+  // Collect items from the user QSettings
+  if ( origin != Qgis::SettingsOrigin::Global )
+  {
+    QSettings &settings = QgsSettingsEntryBase::userSettings();
+    settings.beginGroup( completeKeyParam );
+    res = settings.childGroups();
+    settings.endGroup();
+  }
+
+  // Collect items from the global defaults hash
+  if ( origin != Qgis::SettingsOrigin::Local )
+  {
+    const QStringList globalGroups = QgsSettingsEntryBase::globalChildGroups( completeKeyParam );
+    for ( const QString &group : globalGroups )
+    {
+      if ( !res.contains( group ) )
+        res.append( group );
+    }
+  }
+
   return res;
 }
 

--- a/src/process/main.cpp
+++ b/src/process/main.cpp
@@ -46,6 +46,8 @@ typedef SInt32 SRefCon;
 #include "qgsprocess.h"
 #include "qgsapplication.h"
 #include "qgsproviderregistry.h"
+#include "qgssettings.h"
+#include "qgssettingsentry.h"
 
 #ifdef HAVE_OPENCL
 #include "qgsopenclutils.h"
@@ -119,6 +121,13 @@ int main( int argc, char *argv[] )
   }
 
   QgsApplication app( argc, argv, false, QString(), u"qgis_process"_s );
+
+  if ( const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" ) )
+  {
+    const QString path = QString::fromLocal8Bit( globalSettingsFile );
+    QgsSettings::setGlobalSettingsPath( path );
+    QgsSettingsEntryBase::setGlobalSettingsPath( path );
+  }
 
   // Build a local QCoreApplication from arguments. This way, arguments are correctly parsed from their native locale
   // It will use QString::fromLocal8Bit( argv ) under Unix and GetCommandLine() under Windows.

--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -26,6 +26,8 @@
 #include "qgsfcgiserverrequest.h"
 #include "qgsfcgiserverresponse.h"
 #include "qgsserver.h"
+#include "qgssettings.h"
+#include "qgssettingsentry.h"
 
 #include <QFontDatabase>
 #include <QString>
@@ -76,6 +78,14 @@ int main( int argc, char *argv[] )
   }
   // since version 3.0 QgsServer now needs a qApp so initialize QgsApplication
   const QgsApplication app( argc, argv, withDisplay, QString(), u"server"_s );
+
+  if ( const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" ) )
+  {
+    const QString path = QString::fromLocal8Bit( globalSettingsFile );
+    QgsSettings::setGlobalSettingsPath( path );
+    QgsSettingsEntryBase::setGlobalSettingsPath( path );
+  }
+
   QgsServer server;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
   server.initPython();

--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -37,6 +37,8 @@ using namespace Qt::StringLiterals;
 #include "qgscommandlineutils.h"
 #include "qgsconfig.h"
 #include "qgsserver.h"
+#include "qgssettings.h"
+#include "qgssettingsentry.h"
 #include "qgsbufferserverrequest.h"
 #include "qgsbufferserverresponse.h"
 #include "qgsapplication.h"
@@ -499,6 +501,13 @@ int main( int argc, char *argv[] )
 
   // since version 3.0 QgsServer now needs a qApp so initialize QgsApplication
   const QgsApplication app( argc, argv, withDisplay, QString(), u"QGIS Development Server"_s );
+
+  if ( const char *globalSettingsFile = getenv( "QGIS_GLOBAL_SETTINGS_FILE" ) )
+  {
+    const QString path = QString::fromLocal8Bit( globalSettingsFile );
+    QgsSettings::setGlobalSettingsPath( path );
+    QgsSettingsEntryBase::setGlobalSettingsPath( path );
+  }
 
   QCoreApplication::setOrganizationName( QgsApplication::QGIS_ORGANIZATION_NAME );
   QCoreApplication::setOrganizationDomain( QgsApplication::QGIS_ORGANIZATION_DOMAIN );

--- a/tests/src/core/testqgssettingsentry.cpp
+++ b/tests/src/core/testqgssettingsentry.cpp
@@ -21,6 +21,8 @@
 #include <QObject>
 #include <QSettings>
 #include <QString>
+#include <QTemporaryDir>
+#include <QThread>
 
 using namespace Qt::StringLiterals;
 
@@ -42,6 +44,13 @@ class TestQgsSettingsEntry : public QObject
     void flagValue();
     void testFormerValue();
     void testChanged();
+    void testGlobalDefault();
+    void testGlobalDefaultOverriddenByUser();
+    void testGlobalOrigin();
+    void testGlobalExists();
+    void testLoadGlobalDefaults();
+    void testSetValueGlobalDefaultCleanup();
+    void testThreadSafety();
 };
 
 void TestQgsSettingsEntry::settingsKey()
@@ -229,6 +238,218 @@ void TestQgsSettingsEntry::testChanged()
 
   settingsEntryInteger.copyValueToKeyIfChanged( u"testSetting"_s );
   QCOMPARE( QgsSettingsEntryBase::userSettings().value( u"testSetting"_s ).toInt(), 11111 );
+}
+
+void TestQgsSettingsEntry::testGlobalDefault()
+{
+  // Create a temporary INI file with a known key
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"globaltest/myint"_s, 42 );
+    globalIni.setValue( u"globaltest/mystring"_s, u"hello"_s );
+    globalIni.sync();
+  }
+
+  QVERIFY( QgsSettingsEntryBase::setGlobalSettingsPath( iniPath ) );
+
+  // Setting defined only in global INI — no user value set
+  const QgsSettingsEntryInteger intEntry( u"myint"_s, u"globaltest"_s, 0 );
+  QCOMPARE( intEntry.value(), 42 );
+
+  const QgsSettingsEntryString strEntry( u"mystring"_s, u"globaltest"_s, QString() );
+  QCOMPARE( strEntry.value(), u"hello"_s );
+
+  // Clean up
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+}
+
+void TestQgsSettingsEntry::testGlobalDefaultOverriddenByUser()
+{
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"globaltest/overridden"_s, 100 );
+    globalIni.sync();
+  }
+
+  QVERIFY( QgsSettingsEntryBase::setGlobalSettingsPath( iniPath ) );
+
+  const QgsSettingsEntryInteger entry( u"overridden"_s, u"globaltest"_s, 0 );
+
+  // User overrides the global value
+  entry.setValue( 999 );
+  QCOMPARE( entry.value(), 999 );
+
+  // Clean up
+  entry.remove();
+  // With user value removed, global default should return
+  QCOMPARE( entry.value(), 100 );
+
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+}
+
+void TestQgsSettingsEntry::testGlobalOrigin()
+{
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"globaltest/globalonly"_s, 1 );
+    globalIni.setValue( u"globaltest/both"_s, 10 );
+    globalIni.sync();
+  }
+
+  QVERIFY( QgsSettingsEntryBase::setGlobalSettingsPath( iniPath ) );
+
+  // Global-only key
+  const QgsSettingsEntryInteger globalOnly( u"globalonly"_s, u"globaltest"_s, 0 );
+  QCOMPARE( globalOnly.origin( QStringList() ), Qgis::SettingsOrigin::Global );
+
+  // Key in both: Global takes precedence for origin
+  const QgsSettingsEntryInteger both( u"both"_s, u"globaltest"_s, 0 );
+  both.setValue( 20 );
+  QCOMPARE( both.origin( QStringList() ), Qgis::SettingsOrigin::Global );
+
+  // User-only key (not in global)
+  const QgsSettingsEntryInteger userOnly( u"useronly"_s, u"globaltest"_s, 0 );
+  userOnly.setValue( 5 );
+  QCOMPARE( userOnly.origin( QStringList() ), Qgis::SettingsOrigin::Local );
+
+  // Non-existent key
+  const QgsSettingsEntryInteger absent( u"absent"_s, u"globaltest"_s, 0 );
+  QCOMPARE( absent.origin( QStringList() ), Qgis::SettingsOrigin::Any );
+
+  // Clean up
+  both.remove();
+  userOnly.remove();
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+}
+
+void TestQgsSettingsEntry::testGlobalExists()
+{
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"globaltest/existskey"_s, u"val"_s );
+    globalIni.sync();
+  }
+
+  QVERIFY( QgsSettingsEntryBase::setGlobalSettingsPath( iniPath ) );
+
+  const QgsSettingsEntryString entry( u"existskey"_s, u"globaltest"_s, QString() );
+  // exists() should return true even though no user value is set
+  QVERIFY( entry.exists() );
+
+  const QgsSettingsEntryString absent( u"nope"_s, u"globaltest"_s, QString() );
+  QVERIFY( !absent.exists() );
+
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+}
+
+void TestQgsSettingsEntry::testLoadGlobalDefaults()
+{
+  // Empty path should not crash
+  QVERIFY( !QgsSettingsEntryBase::setGlobalSettingsPath( QString() ) );
+
+  // Non-existent file should not crash
+  QVERIFY( !QgsSettingsEntryBase::setGlobalSettingsPath( u"/nonexistent/path/file.ini"_s ) );
+
+  // Verify hash is empty after non-existent path
+  const QgsSettingsEntryInteger entry( u"testkey"_s, u"test"_s, 99 );
+  QCOMPARE( entry.value(), 99 );
+}
+
+void TestQgsSettingsEntry::testSetValueGlobalDefaultCleanup()
+{
+  // When setting a value equal to the global default, the user key
+  // should be removed so the global default takes effect naturally.
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"globaltest/cleanup"_s, 50 );
+    globalIni.sync();
+  }
+
+  QVERIFY( QgsSettingsEntryBase::setGlobalSettingsPath( iniPath ) );
+
+  const QgsSettingsEntryInteger entry( u"cleanup"_s, u"globaltest"_s, 0 );
+
+  // Set a different value — should write to user QSettings
+  entry.setValue( 999 );
+  QVERIFY( QgsSettingsEntryBase::userSettings().contains( entry.key() ) );
+  QCOMPARE( entry.value(), 999 );
+
+  // Set value back to the global default — should remove user key
+  entry.setValue( 50 );
+  QVERIFY( !QgsSettingsEntryBase::userSettings().contains( entry.key() ) );
+  // Value should still be 50 (from global hash)
+  QCOMPARE( entry.value(), 50 );
+
+  // Set a value when no user key exists and value differs — should write
+  entry.setValue( 123 );
+  QVERIFY( QgsSettingsEntryBase::userSettings().contains( entry.key() ) );
+  QCOMPARE( entry.value(), 123 );
+
+  // Set the same value again — should still be there
+  entry.setValue( 123 );
+  QVERIFY( QgsSettingsEntryBase::userSettings().contains( entry.key() ) );
+  QCOMPARE( entry.value(), 123 );
+
+  // Clean up
+  entry.remove();
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
+}
+
+void TestQgsSettingsEntry::testThreadSafety()
+{
+  // Verify that global defaults populated on the main thread are readable
+  // from a worker thread, and that a value written in a worker thread
+  // is visible from the main thread afterwards.
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString iniPath = tempDir.path() + u"/global.ini"_s;
+  {
+    QSettings globalIni( iniPath, QSettings::IniFormat );
+    globalIni.setValue( u"threadtest/globalval"_s, 77 );
+    globalIni.sync();
+  }
+
+  QVERIFY( QgsSettingsEntryBase::setGlobalSettingsPath( iniPath ) );
+
+  const QgsSettingsEntryInteger entry( u"globalval"_s, u"threadtest"_s, 0 );
+
+  // Main thread sees the global default
+  QCOMPARE( entry.value(), 77 );
+
+  // Worker thread reads global default and writes a user override
+  int workerReadValue = 0;
+  QThread *thread = QThread::create( [&] {
+    workerReadValue = static_cast<int>( entry.value() );
+    entry.setValue( 123 );
+  } );
+  thread->start();
+  thread->wait();
+  delete thread;
+
+  // Worker saw the global default
+  QCOMPARE( workerReadValue, 77 );
+
+  // Main thread sees the value written by the worker
+  QCOMPARE( entry.value(), 123 );
+
+  // Clean up
+  entry.remove();
+  QgsSettingsEntryBase::setGlobalSettingsPath( QString() );
 }
 
 

--- a/tests/src/python/test_qgssettingsentry.py
+++ b/tests/src/python/test_qgssettingsentry.py
@@ -9,6 +9,8 @@ the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
 
+import os
+import tempfile
 import unittest
 
 from qgis import core as qgis_core
@@ -16,6 +18,7 @@ from qgis.core import (
     Qgis,
     QgsMapLayerProxyModel,
     QgsSettings,
+    QgsSettingsEntryBase,
     QgsSettingsEntryBool,
     QgsSettingsEntryColor,
     QgsSettingsEntryDouble,
@@ -29,7 +32,7 @@ from qgis.core import (
     QgsSettingsTree,
     QgsUnitTypes,
 )
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import QSettings, Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.testing import QgisTestCase, start_app
 
@@ -637,6 +640,135 @@ class TestQgsSettingsEntry(QgisTestCase):
         settingsEntrySrc.copyValueToKey(f"plugins/{self.pluginName}/{settingsDestKey}")
         self.assertTrue(settingsEntryDest.exists())
         self.assertEqual(settingsEntryDest.value(), settingsEntryDest.value())
+
+    def test_global_default(self):
+        """Global INI value used when no user value is set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ini_path = os.path.join(tmpdir, "global.ini")
+            gs = QSettings(ini_path, QSettings.Format.IniFormat)
+            gs.setValue("plugins/globaltest/myint", 42)
+            gs.setValue("plugins/globaltest/mystring", "hello")
+            gs.sync()
+            del gs
+
+            self.assertTrue(QgsSettingsEntryBase.setGlobalSettingsPath(ini_path))
+
+            int_entry = QgsSettingsEntryInteger("myint", "globaltest", 0)
+            self.assertEqual(int_entry.value(), 42)
+
+            str_entry = QgsSettingsEntryString("mystring", "globaltest", "")
+            self.assertEqual(str_entry.value(), "hello")
+
+            QgsSettingsEntryBase.setGlobalSettingsPath("")
+
+    def test_global_default_overridden_by_user(self):
+        """User value takes precedence over global default."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ini_path = os.path.join(tmpdir, "global.ini")
+            gs = QSettings(ini_path, QSettings.Format.IniFormat)
+            gs.setValue("plugins/globaltest/overridden", 100)
+            gs.sync()
+            del gs
+
+            self.assertTrue(QgsSettingsEntryBase.setGlobalSettingsPath(ini_path))
+
+            entry = QgsSettingsEntryInteger("overridden", "globaltest", 0)
+            entry.setValue(999)
+            self.assertEqual(entry.value(), 999)
+
+            # Remove user value -> global should return
+            entry.remove()
+            self.assertEqual(entry.value(), 100)
+
+            QgsSettingsEntryBase.setGlobalSettingsPath("")
+
+    def test_global_origin(self):
+        """origin() returns Global/Local/Any correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ini_path = os.path.join(tmpdir, "global.ini")
+            gs = QSettings(ini_path, QSettings.Format.IniFormat)
+            gs.setValue("plugins/globaltest/globalonly", 1)
+            gs.setValue("plugins/globaltest/both", 10)
+            gs.sync()
+            del gs
+
+            self.assertTrue(QgsSettingsEntryBase.setGlobalSettingsPath(ini_path))
+
+            global_only = QgsSettingsEntryInteger("globalonly", "globaltest", 0)
+            self.assertEqual(global_only.origin([]), Qgis.SettingsOrigin.Global)
+
+            both = QgsSettingsEntryInteger("both", "globaltest", 0)
+            both.setValue(20)
+            self.assertEqual(both.origin([]), Qgis.SettingsOrigin.Global)
+
+            user_only = QgsSettingsEntryInteger("useronly", "globaltest", 0)
+            user_only.setValue(5)
+            self.assertEqual(user_only.origin([]), Qgis.SettingsOrigin.Local)
+
+            absent = QgsSettingsEntryInteger("absent", "globaltest", 0)
+            self.assertEqual(absent.origin([]), Qgis.SettingsOrigin.Any)
+
+            # Clean up
+            both.remove()
+            user_only.remove()
+            QgsSettingsEntryBase.setGlobalSettingsPath("")
+
+    def test_global_exists(self):
+        """exists() returns True for global-only keys."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ini_path = os.path.join(tmpdir, "global.ini")
+            gs = QSettings(ini_path, QSettings.Format.IniFormat)
+            gs.setValue("plugins/globaltest/existskey", "val")
+            gs.sync()
+            del gs
+
+            self.assertTrue(QgsSettingsEntryBase.setGlobalSettingsPath(ini_path))
+
+            entry = QgsSettingsEntryString("existskey", "globaltest", "")
+            self.assertTrue(entry.exists())
+
+            absent = QgsSettingsEntryString("nope", "globaltest", "")
+            self.assertFalse(absent.exists())
+
+            QgsSettingsEntryBase.setGlobalSettingsPath("")
+
+    def test_load_global_defaults(self):
+        """Empty or invalid paths are handled gracefully."""
+        self.assertFalse(QgsSettingsEntryBase.setGlobalSettingsPath(""))
+        self.assertFalse(
+            QgsSettingsEntryBase.setGlobalSettingsPath("/nonexistent/path/file.ini")
+        )
+
+        entry = QgsSettingsEntryInteger("testkey", "globaltest", 99)
+        self.assertEqual(entry.value(), 99)
+
+    def test_set_value_global_default_cleanup(self):
+        """Setting a value equal to the global default removes the user key."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ini_path = os.path.join(tmpdir, "global.ini")
+            gs = QSettings(ini_path, QSettings.Format.IniFormat)
+            gs.setValue("plugins/globaltest/cleanup", 50)
+            gs.sync()
+            del gs
+
+            self.assertTrue(QgsSettingsEntryBase.setGlobalSettingsPath(ini_path))
+
+            entry = QgsSettingsEntryInteger("cleanup", "globaltest", 0)
+
+            # Set a different value — should write to user QSettings
+            entry.setValue(999)
+            self.assertTrue(QSettings().contains(entry.key()))
+            self.assertEqual(entry.value(), 999)
+
+            # Set value back to the global default — should remove user key
+            entry.setValue(50)
+            self.assertFalse(QSettings().contains(entry.key()))
+            # Value should still be 50 (from global hash)
+            self.assertEqual(entry.value(), 50)
+
+            # Clean up
+            entry.remove()
+            QgsSettingsEntryBase.setGlobalSettingsPath("")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is fixing (implementing) the use of global settings in QgsSettingsEntry when using the singleton (see #65722).
This was originally part of #65590 , so this PR is bringing the missing part.

The approach is making things indepedently in QgsSettingsEntry* from QgsSettings (once every setting is migrated QgsSettingsEntry, QgsSettings entry could be safely removed).

fixes #66424 (successfully tested)

## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

