### PR TITLE
fix build on Qt 6.8 (debian trixie and ubuntu plucky)

### DIFF
--- a/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
+++ b/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp
@@ -231,7 +231,7 @@ long long QgsSensorThingsSharedData::featureCount( QgsFeedback *feedback ) const
       auto rootContent = json::parse( content.content().toStdString() );
       if ( !rootContent.contains( countKey ) )
       {
-        mError = QObject::tr( "No '%1' value in response" ).arg( countKey );
+        mError = QObject::tr( "No '%1' value in response" ).arg( QString::fromStdString( countKey ) );
         return mFeatureCount;
       }
 


### PR DESCRIPTION
fixes:

```
/build/qgis-4.1.0/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp: In member function 'long long int QgsSensorThingsSharedData::featureCount(QgsFeedback*) const':
/build/qgis-4.1.0/src/core/providers/sensorthings/qgssensorthingsshareddata.cpp:234:64: error: no matching function for call to 'QString::arg(const std::string&)'                            
  234 |         mError = QObject::tr( "No '%1' value in response" ).arg( countKey );           
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~                                                                                                           
In file included from /usr/include/x86_64-linux-gnu/qt6/QtCore/qhashfunctions.h:9,                                                                                                                             from /usr/include/x86_64-linux-gnu/qt6/QtCore/qfloat16.h:10,        
                 from /usr/include/x86_64-linux-gnu/qt6/QtCore/qmetatype.h:14,                 
                 from /usr/include/x86_64-linux-gnu/qt6/QtCore/qvariant.h:10,                                                                                                                 
                 from /usr/include/x86_64-linux-gnu/qt6/QtCore/qmetaobject.h:10,                                                                                                              
                 from /usr/include/x86_64-linux-gnu/qt6/QtCore/QMetaEnum:1,                    
                 from ../../src/core/qgis.h:29,                                                                                                                                               
                 from ./src/core/CMakeFiles/qgis_core.dir/cmake_pch.hxx:5,                                                                                                                    
                 from <command-line>:                                                          
```
