### PR TITLE
Add support for custom CRS parameter in XYZ tile layers

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -93,7 +93,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
     mActiveSubLayerVisibility.clear();
     mFeatureCount = 0;
     mImageMimeType.clear();
-    mCrsId = u"EPSG:3857"_s;
+    mCrsId = uri.hasParam( u"crs"_s ) ? uri.param( u"crs"_s ) : u"EPSG:3857"_s;
     mEnableContextualLegend = false;
 
     mIsMBTiles = uri.param( u"type"_s ) == "mbtiles"_L1;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1785,7 +1785,10 @@ bool QgsWmsProvider::setupXyzCapabilities( const QString &uri, const QgsRectangl
   QgsDataSourceUri parsedUri;
   parsedUri.setEncodedUri( uri );
 
-  QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ), QgsCoordinateReferenceSystem( mSettings.mCrsId ), transformContext() );
+  // tile grid coordinates (z/x/y) always follow the EPSG:3857 numbering scheme,
+  // so we use EPSG:3857 here regardless of layer's CRS. Custom "crs" parameter
+  // that's read to mSettings.mCrsId will then affect how the returned tile data is interpreted
+  QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( u"EPSG:4326"_s ), QgsCoordinateReferenceSystem( u"EPSG:3857"_s ), transformContext() );
 
   // the whole world is projected to a square:
   // X going from 180 W to 180 E


### PR DESCRIPTION
Reopening [staled-closed PR](https://github.com/qgis/QGIS/pull/65434) due to no vocal rejection.

## Description

As of now, for XYZ tile servers that serve tiles in a different projection (while using the same EPSG:3857-grid), there is no way to pass-and-parse the custom "crs" param through the uri-string.

This PR allows to do it, always using 3857 to figure out which tiles to request, and, if present, use custom "crs" value to fill wms settings for it to be used down the interpretation and reprojection pipeline. 

Testing tile server with different projection (EPSG:3395): 

```
iface.addRasterLayer("crs=EPSG:3395&type=xyz&url=https://core-renderer-tiles.maps.yandex.net/tiles?l%3Dmap%26x%3D%7Bx%7D%26y%3D%7By%7D%26z%3D%7Bz%7D%26scale%3D1%26lang%3Dru_RU&zmax=21&zmin=0", "Yandex", "wms")
```

It can then be compared with the usual OSM to check if overlay is correct

<img width="1741" height="908" alt="image" src="https://github.com/user-attachments/assets/ccb84127-ec48-4bca-88de-ed6b273ca931" />

<img width="1741" height="908" alt="image" src="https://github.com/user-attachments/assets/661325dd-531d-4bc9-b708-efa32e75004a" />
