### PR TITLE
GeoJSON profiles support (RFC7946,  JSON-FG JSON-FG-PLUS  core support)

### DIFF
--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -8712,6 +8712,22 @@ Qgis.LegendJsonRenderFlags = lambda flags=0: Qgis.LegendJsonRenderFlag(flags)
 Qgis.LegendJsonRenderFlags.baseClass = Qgis
 LegendJsonRenderFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
+Qgis.GeoJsonProfile.Rfc7946.__doc__ = "GeoJson profile compliant with RFC7946 standard \"http://www.opengis.net/def/profile/OGC/0/rfc7946\""
+Qgis.GeoJsonProfile.JsonFg.__doc__ = "GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg\""
+Qgis.GeoJsonProfile.JsonFgPlus.__doc__ = "GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg-plus\""
+Qgis.GeoJsonProfile.__doc__ = """GeoJson export Profile according to OGC Features and Geometries JSON - Part 1: Core
+https://docs.ogc.org/is/21-045r1/21-045r1.html
+
+.. versionadded:: 4.2
+
+* ``Rfc7946``: GeoJson profile compliant with RFC7946 standard \"http://www.opengis.net/def/profile/OGC/0/rfc7946\"
+* ``JsonFg``: GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg\"
+* ``JsonFgPlus``: GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg-plus\"
+
+"""
+# --
+Qgis.GeoJsonProfile.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.ActionType.Invalid.__doc__ = "Invalid"
 Qgis.ActionType.MapLayerAction.__doc__ = "Standard actions (defined by core or plugins), corresponds to QgsMapLayerAction class."
 Qgis.ActionType.AttributeAction.__doc__ = "Custom actions (manually defined in layer properties), corresponds to QgsAction class."

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -8712,6 +8712,7 @@ Qgis.LegendJsonRenderFlags = lambda flags=0: Qgis.LegendJsonRenderFlag(flags)
 Qgis.LegendJsonRenderFlags.baseClass = Qgis
 LegendJsonRenderFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
+Qgis.GeoJsonProfile.Legacy.__doc__ = ""
 Qgis.GeoJsonProfile.Rfc7946.__doc__ = "GeoJson profile compliant with RFC7946 standard \"http://www.opengis.net/def/profile/OGC/0/rfc7946\""
 Qgis.GeoJsonProfile.JsonFg.__doc__ = "GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg\""
 Qgis.GeoJsonProfile.JsonFgPlus.__doc__ = "GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg-plus\""
@@ -8720,6 +8721,7 @@ https://docs.ogc.org/is/21-045r1/21-045r1.html
 
 .. versionadded:: 4.2
 
+* ``Legacy``: 
 * ``Rfc7946``: GeoJson profile compliant with RFC7946 standard \"http://www.opengis.net/def/profile/OGC/0/rfc7946\"
 * ``JsonFg``: GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg\"
 * ``JsonFgPlus``: GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg-plus\"

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -8712,7 +8712,7 @@ Qgis.LegendJsonRenderFlags = lambda flags=0: Qgis.LegendJsonRenderFlag(flags)
 Qgis.LegendJsonRenderFlags.baseClass = Qgis
 LegendJsonRenderFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
-Qgis.GeoJsonProfile.Legacy.__doc__ = ""
+Qgis.GeoJsonProfile.Legacy.__doc__ = "Legacy GeoJson profile used in QGIS prior to 4.2, which included some non-standard extensions and deviations from the RFC7946 standard, such as support for  transforming geometries to a CRS different than CRS84. This profile is still available for backward compatibility but is not recommended for new projects."
 Qgis.GeoJsonProfile.Rfc7946.__doc__ = "GeoJson profile compliant with RFC7946 standard \"http://www.opengis.net/def/profile/OGC/0/rfc7946\""
 Qgis.GeoJsonProfile.JsonFg.__doc__ = "GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg\""
 Qgis.GeoJsonProfile.JsonFgPlus.__doc__ = "GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg-plus\""
@@ -8721,7 +8721,7 @@ https://docs.ogc.org/is/21-045r1/21-045r1.html
 
 .. versionadded:: 4.2
 
-* ``Legacy``: 
+* ``Legacy``: Legacy GeoJson profile used in QGIS prior to 4.2, which included some non-standard extensions and deviations from the RFC7946 standard, such as support for  transforming geometries to a CRS different than CRS84. This profile is still available for backward compatibility but is not recommended for new projects.
 * ``Rfc7946``: GeoJson profile compliant with RFC7946 standard \"http://www.opengis.net/def/profile/OGC/0/rfc7946\"
 * ``JsonFg``: GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg\"
 * ``JsonFgPlus``: GeoJson profile from OGC Features and Geometries JSON Part 1: core \"http://www.opengis.net/def/profile/OGC/0/jsonfg-plus\"

--- a/python/PyQt6/core/auto_additions/qgscircularstring.py
+++ b/python/PyQt6/core/auto_additions/qgscircularstring.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/geometry/qgscircularstring.h
 try:
     QgsCircularString.fromTwoPointsAndCenter = staticmethod(QgsCircularString.fromTwoPointsAndCenter)
-    QgsCircularString.__overridden_methods__ = ['geometryType', 'clone', 'clear', 'asGml2', 'asGml3', 'isValid', 'indexOf', 'length', 'curveToLine', 'snappedToGrid', 'simplifyByDistance', 'removeDuplicateNodes', 'draw', 'addToPainterPath', 'drawAsPolygon', 'insertVertex', 'deleteVertex', 'deleteVertices', 'closestSegment', 'pointAt', 'sumUpArea', 'sumUpArea3D', 'hasCurvedSegments', 'vertexAngle', 'segmentLength', 'distanceBetweenVertices', 'reversed', 'interpolatePoint', 'curveSubstring', 'createEmptyWithSameType', 'calculateBoundingBox3D']
+    QgsCircularString.__overridden_methods__ = ['geometryType', 'clone', 'clear', 'asGml2', 'asGml3', 'isEmpty', 'isValid', 'indexOf', 'length', 'curveToLine', 'snappedToGrid', 'simplifyByDistance', 'removeDuplicateNodes', 'draw', 'addToPainterPath', 'drawAsPolygon', 'insertVertex', 'deleteVertex', 'deleteVertices', 'closestSegment', 'pointAt', 'sumUpArea', 'sumUpArea3D', 'hasCurvedSegments', 'vertexAngle', 'segmentLength', 'distanceBetweenVertices', 'reversed', 'interpolatePoint', 'curveSubstring', 'createEmptyWithSameType', 'calculateBoundingBox3D']
     QgsCircularString.__group__ = ['geometry']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_additions/qgscircularstring.py
+++ b/python/PyQt6/core/auto_additions/qgscircularstring.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/geometry/qgscircularstring.h
 try:
     QgsCircularString.fromTwoPointsAndCenter = staticmethod(QgsCircularString.fromTwoPointsAndCenter)
-    QgsCircularString.__overridden_methods__ = ['geometryType', 'clone', 'clear', 'asGml2', 'asGml3', 'isEmpty', 'isValid', 'indexOf', 'length', 'curveToLine', 'snappedToGrid', 'simplifyByDistance', 'removeDuplicateNodes', 'draw', 'addToPainterPath', 'drawAsPolygon', 'insertVertex', 'deleteVertex', 'deleteVertices', 'closestSegment', 'pointAt', 'sumUpArea', 'sumUpArea3D', 'hasCurvedSegments', 'vertexAngle', 'segmentLength', 'distanceBetweenVertices', 'reversed', 'interpolatePoint', 'curveSubstring', 'createEmptyWithSameType', 'calculateBoundingBox3D']
+    QgsCircularString.__overridden_methods__ = ['geometryType', 'clone', 'clear', 'asGml2', 'asGml3', 'isValid', 'indexOf', 'length', 'curveToLine', 'snappedToGrid', 'simplifyByDistance', 'removeDuplicateNodes', 'draw', 'addToPainterPath', 'drawAsPolygon', 'insertVertex', 'deleteVertex', 'deleteVertices', 'closestSegment', 'pointAt', 'sumUpArea', 'sumUpArea3D', 'hasCurvedSegments', 'vertexAngle', 'segmentLength', 'distanceBetweenVertices', 'reversed', 'interpolatePoint', 'curveSubstring', 'createEmptyWithSameType', 'calculateBoundingBox3D']
     QgsCircularString.__group__ = ['geometry']
 except (NameError, AttributeError):
     pass

--- a/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -360,12 +360,12 @@ Returns a GeoJSON representation of the geometry as a string.
 .. seealso:: :py:func:`asJsonObject`
 %End
 
-    QString asGeoJson(int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 );
+    QString asGeoJson(int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy );
 %Docstring
 Export the geometry to a GeoJSON string, with the given ``precision``
 and following the specified GeoJSON ``profile``. Note: this is identical
-to :py:func:`~QgsAbstractGeometry.asJson` when using the Rfc7946
-profile, but differs when using other profiles.
+to :py:func:`~QgsAbstractGeometry.asJson` when using the Legacy profile,
+but differs when using other profiles.
 
 .. versionadded:: 4.2
 %End

--- a/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -360,6 +360,16 @@ Returns a GeoJSON representation of the geometry as a string.
 .. seealso:: :py:func:`asJsonObject`
 %End
 
+    QString asGeoJson(int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 );
+%Docstring
+Export the geometry to a GeoJSON string, with the given ``precision``
+and following the specified GeoJSON ``profile``. Note: this is identical
+to :py:func:`~QgsAbstractGeometry.asJson` when using the Rfc7946
+profile, but differs when using other profiles.
+
+.. versionadded:: 4.2
+%End
+
 
     virtual QString asKml( int precision = 17 ) const = 0;
 %Docstring

--- a/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -367,7 +367,7 @@ and following the specified GeoJSON ``profile``. Note: this is identical
 to :py:func:`~QgsAbstractGeometry.asJson` when using the Legacy profile,
 but differs when using other profiles.
 
-.. versionadded:: 4.2
+.. versionadded:: 4.4
 %End
 
 

--- a/python/PyQt6/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -86,6 +86,8 @@ winding the other way around the circle).
 
     virtual QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const;
 
+    virtual bool isEmpty() const /HoldGIL/;
+
     virtual bool isValid( QString &error /Out/, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;
 
     int indexOf( const QgsPoint &point ) const final;

--- a/python/PyQt6/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -86,8 +86,6 @@ winding the other way around the circle).
 
     virtual QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const;
 
-    virtual bool isEmpty() const /HoldGIL/;
-
     virtual bool isValid( QString &error /Out/, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const;
 
     int indexOf( const QgsPoint &point ) const final;

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2533,15 +2533,19 @@ Exports the geometry to WKT
 
     QString asJson( int precision = 17 ) const;
 %Docstring
-Exports the geometry to a GeoJSON string.
+Exports the geometry to a GeoJSON RFC7946 string.
+
+.. seealso:: :py:func:`asGeoJson` for exporting using other GeoJSON profiles
 %End
 
-    QString asGeoJson( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const;
+    QString asGeoJson( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const;
 %Docstring
 Export the geometry to a GeoJSON string, with the given ``precision``
 and following the specified GeoJSON ``profile``. Note: this is identical
-to :py:func:`~QgsGeometry.asJson` when using the Rfc7946 profile, but
-differs when using other profiles.
+to :py:func:`~QgsGeometry.asJson` when using the Legacy and Rfc7946
+profile, but differs when using other profiles with "CircularString,"
+"CompoundCurve," "CurvePolygon," "MultiCurve," or "MultiSurface"
+geometries.
 
 .. versionadded:: 4.2
 %End

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2547,7 +2547,7 @@ profile, but differs when using other profiles with "CircularString,"
 "CompoundCurve," "CurvePolygon," "MultiCurve," or "MultiSurface"
 geometries.
 
-.. versionadded:: 4.2
+.. versionadded:: 4.4
 %End
 
 

--- a/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/PyQt6/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -2536,6 +2536,16 @@ Exports the geometry to WKT
 Exports the geometry to a GeoJSON string.
 %End
 
+    QString asGeoJson( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const;
+%Docstring
+Export the geometry to a GeoJSON string, with the given ``precision``
+and following the specified GeoJSON ``profile``. Note: this is identical
+to :py:func:`~QgsGeometry.asJson` when using the Rfc7946 profile, but
+differs when using other profiles.
+
+.. versionadded:: 4.2
+%End
+
 
     QVector< QgsGeometry > coerceToType( Qgis::WkbType type, double defaultZ = 0, double defaultM = 0, bool avoidDuplicates = true ) const;
 %Docstring

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2792,6 +2792,13 @@ The development version
     typedef QFlags<Qgis::LegendJsonRenderFlag> LegendJsonRenderFlags;
 
 
+    enum class GeoJsonProfile /BaseType=IntEnum/
+    {
+      Rfc7946,
+      JsonFg,
+      JsonFgPlus,
+    };
+
     enum class ActionType /BaseType=IntEnum/
     {
       Invalid,

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2794,6 +2794,7 @@ The development version
 
     enum class GeoJsonProfile /BaseType=IntEnum/
     {
+      Legacy,
       Rfc7946,
       JsonFg,
       JsonFgPlus,

--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -277,7 +277,6 @@ Returns a GeoJSON string representation of a feature.
 %End
 
 
-
     QString exportFeatures( const QgsFeatureList &features, int indent = -1 ) const;
 %Docstring
 Returns a GeoJSON string representation of a list of features (feature
@@ -304,6 +303,20 @@ when the automatic geometry transformation is active (it is by default).
 .. seealso:: :py:func:`setSourceCrs`
 
 .. versionadded:: 3.30
+%End
+
+    Qgis::GeoJsonProfile geoJsonProfile() const;
+%Docstring
+Returns the GeoJSON profile to use for export.
+
+.. versionadded:: 4.2
+%End
+
+    void setGeoJsonProfile( Qgis::GeoJsonProfile profile );
+%Docstring
+Sets the GeoJSON profile to use for export. Default profile is RFC7946.
+
+.. versionadded:: 4.2
 %End
 
 };

--- a/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/PyQt6/core/auto_generated/qgsjsonutils.sip.in
@@ -309,14 +309,14 @@ when the automatic geometry transformation is active (it is by default).
 %Docstring
 Returns the GeoJSON profile to use for export.
 
-.. versionadded:: 4.2
+.. versionadded:: 4.4
 %End
 
     void setGeoJsonProfile( Qgis::GeoJsonProfile profile );
 %Docstring
 Sets the GeoJSON profile to use for export. Default profile is RFC7946.
 
-.. versionadded:: 4.2
+.. versionadded:: 4.4
 %End
 
 };

--- a/src/core/geometry/qgsabstractgeometry.cpp
+++ b/src/core/geometry/qgsabstractgeometry.cpp
@@ -241,6 +241,7 @@ QString QgsAbstractGeometry::asGeoJson( int precision, Qgis::GeoJsonProfile prof
 
 json QgsAbstractGeometry::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
+  Q_UNUSED( profile )
   Q_UNUSED( precision )
   return nullptr;
 }

--- a/src/core/geometry/qgsabstractgeometry.cpp
+++ b/src/core/geometry/qgsabstractgeometry.cpp
@@ -231,10 +231,15 @@ QString QgsAbstractGeometry::wktTypeStr() const
 
 QString QgsAbstractGeometry::asJson( int precision )
 {
-  return QString::fromStdString( asJsonObject( precision ).dump() );
+  return asGeoJson( precision, Qgis::GeoJsonProfile::Rfc7946 );
 }
 
-json QgsAbstractGeometry::asJsonObject( int precision ) const
+QString QgsAbstractGeometry::asGeoJson( int precision, Qgis::GeoJsonProfile profile )
+{
+  return QString::fromStdString( asJsonObject( precision, profile ).dump() );
+}
+
+json QgsAbstractGeometry::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   Q_UNUSED( precision )
   return nullptr;

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -393,7 +393,14 @@ class CORE_EXPORT QgsAbstractGeometry
     QString asJson( int precision = 17 );
 
     /**
-     * Returns a json object representation of the geometry.
+      * Export the geometry to a GeoJSON string, with the given \a precision and following the specified GeoJSON \a profile.
+      * Note: this is identical to asJson() when using the Rfc7946 profile, but differs when using other profiles.
+      * \since QGIS 4.2
+      */
+    QString asGeoJson(int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 );
+
+    /**
+     * Returns a json object representation of the geometry with the given \a precision and \a profile.
      * \see asWkb()
      * \see asWkt()
      * \see asGml2()
@@ -402,7 +409,7 @@ class CORE_EXPORT QgsAbstractGeometry
      * \note not available in Python bindings
      * \since QGIS 3.10
      */
-    virtual json asJsonObject( int precision = 17 ) SIP_SKIP const;
+    virtual json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) SIP_SKIP const;
 
     /**
      * Returns a KML representation of the geometry.

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -394,10 +394,10 @@ class CORE_EXPORT QgsAbstractGeometry
 
     /**
       * Export the geometry to a GeoJSON string, with the given \a precision and following the specified GeoJSON \a profile.
-      * Note: this is identical to asJson() when using the Rfc7946 profile, but differs when using other profiles.
+      * Note: this is identical to asJson() when using the Legacy profile, but differs when using other profiles.
       * \since QGIS 4.2
       */
-    QString asGeoJson(int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 );
+    QString asGeoJson(int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy );
 
     /**
      * Returns a json object representation of the geometry with the given \a precision and \a profile.
@@ -409,7 +409,7 @@ class CORE_EXPORT QgsAbstractGeometry
      * \note not available in Python bindings
      * \since QGIS 3.10
      */
-    virtual json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) SIP_SKIP const;
+    virtual json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) SIP_SKIP const;
 
     /**
      * Returns a KML representation of the geometry.

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -395,7 +395,7 @@ class CORE_EXPORT QgsAbstractGeometry
     /**
       * Export the geometry to a GeoJSON string, with the given \a precision and following the specified GeoJSON \a profile.
       * Note: this is identical to asJson() when using the Legacy profile, but differs when using other profiles.
-      * \since QGIS 4.2
+      * \since QGIS 4.4
       */
     QString asGeoJson(int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy );
 

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -322,11 +322,24 @@ QDomElement QgsCircularString::asGml3( QDomDocument &doc, int precision, const Q
 }
 
 
-json QgsCircularString::asJsonObject( int precision ) const
+json QgsCircularString::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
-  // GeoJSON does not support curves
-  std::unique_ptr< QgsLineString > line( curveToLine() );
-  return line->asJsonObject( precision );
+  switch ( profile )
+  {
+    case Qgis::GeoJsonProfile::Rfc7946:
+    {
+      std::unique_ptr< QgsLineString > line( curveToLine() );
+      return line->asJsonObject( precision, profile );
+    }
+    case Qgis::GeoJsonProfile::JsonFg:
+    case Qgis::GeoJsonProfile::JsonFgPlus:
+    {
+      QgsPointSequence pts;
+      points( pts );
+      return { { "type", "CircularString" }, { "coordinates", QgsGeometryUtils::pointsToJson( pts, precision ) } };
+    }
+  }
+  BUILTIN_UNREACHABLE
 }
 
 bool QgsCircularString::isValid( QString &error, Qgis::GeometryValidityFlags flags ) const

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -357,7 +357,7 @@ json QgsCircularString::asJsonObject( int precision, Qgis::GeoJsonProfile profil
           }
         }
         // Last one (if any)
-        if ( subCs["coordinates"].size() > 0 )
+        if ( subCs["coordinates"].size() > 1 )
         {
           geometries.push_back( subCs );
         }

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -337,7 +337,36 @@ json QgsCircularString::asJsonObject( int precision, Qgis::GeoJsonProfile profil
     {
       QgsPointSequence pts;
       points( pts );
-      return { { "type", "CircularString" }, { "coordinates", QgsGeometryUtils::pointsToJson( pts, precision, profile ) } };
+      // Work around the 11 points limit
+      constexpr int MAX_POINT = 11;
+      if ( pts.size() > MAX_POINT )
+      {
+        json geometries = json::array();
+        json subCs = { { "type", "CircularString" } };
+        subCs["coordinates"] = json::array();
+        for ( int i = 0; i < pts.size(); i++ )
+        {
+          const json pointCoords = pts[i].asJsonObject( precision, profile )["coordinates"];
+          subCs["coordinates"].push_back( pointCoords );
+          if ( subCs["coordinates"].size() == MAX_POINT )
+          {
+            geometries.push_back( subCs );
+            // Clear array
+            subCs["coordinates"] = json::array();
+            subCs["coordinates"].push_back( pointCoords );
+          }
+        }
+        // Last one (if any)
+        if ( subCs["coordinates"].size() > 0 )
+        {
+          geometries.push_back( subCs );
+        }
+        return { { "type", "CompoundCurve" }, { "geometries", geometries } };
+      }
+      else
+      {
+        return { { "type", "CircularString" }, { "coordinates", QgsGeometryUtils::pointsToJson( pts, precision, profile ) } };
+      }
     }
   }
   BUILTIN_UNREACHABLE

--- a/src/core/geometry/qgscircularstring.cpp
+++ b/src/core/geometry/qgscircularstring.cpp
@@ -326,6 +326,7 @@ json QgsCircularString::asJsonObject( int precision, Qgis::GeoJsonProfile profil
 {
   switch ( profile )
   {
+    case Qgis::GeoJsonProfile::Legacy:
     case Qgis::GeoJsonProfile::Rfc7946:
     {
       std::unique_ptr< QgsLineString > line( curveToLine() );
@@ -336,7 +337,7 @@ json QgsCircularString::asJsonObject( int precision, Qgis::GeoJsonProfile profil
     {
       QgsPointSequence pts;
       points( pts );
-      return { { "type", "CircularString" }, { "coordinates", QgsGeometryUtils::pointsToJson( pts, precision ) } };
+      return { { "type", "CircularString" }, { "coordinates", QgsGeometryUtils::pointsToJson( pts, precision, profile ) } };
     }
   }
   BUILTIN_UNREACHABLE

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -95,7 +95,6 @@ class CORE_EXPORT QgsCircularString : public QgsSimpleCurve
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
-    bool isEmpty() const override SIP_HOLDGIL;
     bool isValid( QString &error SIP_OUT, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const override;
     int indexOf( const QgsPoint &point ) const final;
 

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -94,7 +94,8 @@ class CORE_EXPORT QgsCircularString : public QgsSimpleCurve
 
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    bool isEmpty() const override SIP_HOLDGIL;
     bool isValid( QString &error SIP_OUT, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const override;
     int indexOf( const QgsPoint &point ) const final;
 

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -94,7 +94,7 @@ class CORE_EXPORT QgsCircularString : public QgsSimpleCurve
 
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     bool isEmpty() const override SIP_HOLDGIL;
     bool isValid( QString &error SIP_OUT, Qgis::GeometryValidityFlags flags = Qgis::GeometryValidityFlags() ) const override;
     int indexOf( const QgsPoint &point ) const final;

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -346,9 +346,26 @@ QDomElement QgsCompoundCurve::asGml3( QDomDocument &doc, int precision, const QS
 
 json QgsCompoundCurve::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
-  // GeoJSON does not support curves
-  std::unique_ptr< QgsLineString > line( curveToLine() );
-  return line->asJsonObject( precision );
+  switch ( profile )
+  {
+    case Qgis::GeoJsonProfile::Rfc7946:
+    case Qgis::GeoJsonProfile::Legacy:
+    {
+      std::unique_ptr< QgsLineString > line( curveToLine() );
+      return line->asJsonObject( precision );
+    }
+    case Qgis::GeoJsonProfile::JsonFg:
+    case Qgis::GeoJsonProfile::JsonFgPlus:
+    {
+      json geometries = json::array();
+      for ( const QgsCurve *curve : mCurves )
+      {
+        geometries.push_back( curve->asJsonObject( precision, profile ) );
+      }
+      return { { "type", "CompoundCurve" }, { "geometries", geometries } };
+    }
+  }
+  BUILTIN_UNREACHABLE
 }
 
 double QgsCompoundCurve::length() const

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -344,7 +344,7 @@ QDomElement QgsCompoundCurve::asGml3( QDomDocument &doc, int precision, const QS
   return compoundCurveElem;
 }
 
-json QgsCompoundCurve::asJsonObject( int precision ) const
+json QgsCompoundCurve::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   // GeoJSON does not support curves
   std::unique_ptr< QgsLineString > line( curveToLine() );

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -105,7 +105,7 @@ class CORE_EXPORT QgsCompoundCurve : public QgsCurve
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
 
     //curve interface
     double length() const override SIP_HOLDGIL;

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -105,7 +105,7 @@ class CORE_EXPORT QgsCompoundCurve : public QgsCurve
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
 
     //curve interface
     double length() const override SIP_HOLDGIL;

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -405,7 +405,7 @@ json QgsCurvePolygon::asJsonObject( int precision, Qgis::GeoJsonProfile profile 
     case Qgis::GeoJsonProfile::Rfc7946:
     {
       json coordinates( json::array() );
-      if ( QgsCurve *lExteriorRing = exteriorRing() )
+      if ( const QgsCurve *lExteriorRing = exteriorRing() )
       {
         std::unique_ptr< QgsLineString > exteriorLineString( lExteriorRing->curveToLine() );
         QgsPointSequence exteriorPts;
@@ -427,7 +427,7 @@ json QgsCurvePolygon::asJsonObject( int precision, Qgis::GeoJsonProfile profile 
     case Qgis::GeoJsonProfile::JsonFgPlus:
     {
       json geometries = json::array();
-      if ( QgsCurve *lExteriorRing = exteriorRing() )
+      if ( const QgsCurve *lExteriorRing = exteriorRing() )
       {
         geometries.push_back( lExteriorRing->asJsonObject( precision, profile ) );
         for ( int i = 0, n = numInteriorRings(); i < n; ++i )

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -405,7 +405,7 @@ json QgsCurvePolygon::asJsonObject( int precision, Qgis::GeoJsonProfile profile 
     case Qgis::GeoJsonProfile::Rfc7946:
     {
       json coordinates( json::array() );
-      if ( auto *lExteriorRing = exteriorRing() )
+      if ( QgsCurve *lExteriorRing = exteriorRing() )
       {
         std::unique_ptr< QgsLineString > exteriorLineString( lExteriorRing->curveToLine() );
         QgsPointSequence exteriorPts;
@@ -427,7 +427,7 @@ json QgsCurvePolygon::asJsonObject( int precision, Qgis::GeoJsonProfile profile 
     case Qgis::GeoJsonProfile::JsonFgPlus:
     {
       json geometries = json::array();
-      if ( auto *lExteriorRing = exteriorRing() )
+      if ( QgsCurve *lExteriorRing = exteriorRing() )
       {
         geometries.push_back( lExteriorRing->asJsonObject( precision, profile ) );
         for ( int i = 0, n = numInteriorRings(); i < n; ++i )

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -397,7 +397,7 @@ QDomElement QgsCurvePolygon::asGml3( QDomDocument &doc, int precision, const QSt
   return elemCurvePolygon;
 }
 
-json QgsCurvePolygon::asJsonObject( int precision ) const
+json QgsCurvePolygon::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   json coordinates( json::array() );
   if ( auto *lExteriorRing = exteriorRing() )

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -399,24 +399,46 @@ QDomElement QgsCurvePolygon::asGml3( QDomDocument &doc, int precision, const QSt
 
 json QgsCurvePolygon::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
-  json coordinates( json::array() );
-  if ( auto *lExteriorRing = exteriorRing() )
+  switch ( profile )
   {
-    std::unique_ptr< QgsLineString > exteriorLineString( lExteriorRing->curveToLine() );
-    QgsPointSequence exteriorPts;
-    exteriorLineString->points( exteriorPts );
-    coordinates.push_back( QgsGeometryUtils::pointsToJson( exteriorPts, precision ) );
-
-    std::unique_ptr< QgsLineString > interiorLineString;
-    for ( int i = 0, n = numInteriorRings(); i < n; ++i )
+    case Qgis::GeoJsonProfile::Legacy:
+    case Qgis::GeoJsonProfile::Rfc7946:
     {
-      interiorLineString.reset( interiorRing( i )->curveToLine() );
-      QgsPointSequence interiorPts;
-      interiorLineString->points( interiorPts );
-      coordinates.push_back( QgsGeometryUtils::pointsToJson( interiorPts, precision ) );
+      json coordinates( json::array() );
+      if ( auto *lExteriorRing = exteriorRing() )
+      {
+        std::unique_ptr< QgsLineString > exteriorLineString( lExteriorRing->curveToLine() );
+        QgsPointSequence exteriorPts;
+        exteriorLineString->points( exteriorPts );
+        coordinates.push_back( QgsGeometryUtils::pointsToJson( exteriorPts, precision, profile ) );
+
+        std::unique_ptr< QgsLineString > interiorLineString;
+        for ( int i = 0, n = numInteriorRings(); i < n; ++i )
+        {
+          interiorLineString.reset( interiorRing( i )->curveToLine() );
+          QgsPointSequence interiorPts;
+          interiorLineString->points( interiorPts );
+          coordinates.push_back( QgsGeometryUtils::pointsToJson( interiorPts, precision, profile ) );
+        }
+      }
+      return { { "type", "Polygon" }, { "coordinates", coordinates } };
+    }
+    case Qgis::GeoJsonProfile::JsonFg:
+    case Qgis::GeoJsonProfile::JsonFgPlus:
+    {
+      json geometries = json::array();
+      if ( auto *lExteriorRing = exteriorRing() )
+      {
+        geometries.push_back( lExteriorRing->asJsonObject( precision, profile ) );
+        for ( int i = 0, n = numInteriorRings(); i < n; ++i )
+        {
+          geometries.push_back( interiorRing( i )->asJsonObject( precision, profile ) );
+        }
+      }
+      return { { "type", "CurvePolygon" }, { "geometries", geometries } };
     }
   }
-  return { { "type", "Polygon" }, { "coordinates", coordinates } };
+  BUILTIN_UNREACHABLE
 }
 
 QString QgsCurvePolygon::asKml( int precision ) const

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -133,7 +133,7 @@ class CORE_EXPORT QgsCurvePolygon : public QgsSurface
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
     void normalize() final SIP_HOLDGIL;
 

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -133,7 +133,7 @@ class CORE_EXPORT QgsCurvePolygon : public QgsSurface
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
     void normalize() final SIP_HOLDGIL;
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1825,6 +1825,11 @@ QString QgsGeometry::asJson( int precision ) const
   return asGeoJson( precision, Qgis::GeoJsonProfile::Rfc7946 );
 }
 
+QString QgsGeometry::asGeoJson( int precision, Qgis::GeoJsonProfile profile ) const
+{
+  return QString::fromStdString( asJsonObject( precision, profile ).dump() );
+}
+
 json QgsGeometry::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   if ( !d->geometry )

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1822,16 +1822,16 @@ QString QgsGeometry::asWkt( int precision ) const
 
 QString QgsGeometry::asJson( int precision ) const
 {
-  return QString::fromStdString( asJsonObject( precision ).dump() );
+  return asGeoJson( precision, Qgis::GeoJsonProfile::Rfc7946 );
 }
 
-json QgsGeometry::asJsonObject( int precision ) const
+json QgsGeometry::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   if ( !d->geometry )
   {
     return nullptr;
   }
-  return d->geometry->asJsonObject( precision );
+  return d->geometry->asJsonObject( precision, profile );
 }
 
 QVector<QgsGeometry> QgsGeometry::coerceToType( const Qgis::WkbType type, double defaultZ, double defaultM, bool avoidDuplicates ) const

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2383,11 +2383,18 @@ class CORE_EXPORT QgsGeometry
     QString asJson( int precision = 17 ) const;
 
     /**
+     * Export the geometry to a GeoJSON string, with the given \a precision and following the specified GeoJSON \a profile.
+     * Note: this is identical to asJson() when using the Rfc7946 profile, but differs when using other profiles.
+     * \since QGIS 4.2
+     */
+    QString asGeoJson( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const;
+
+    /**
      * Exports the geometry to a json object.
      * \note not available in Python bindings
      * \since QGIS 3.8
      */
-    virtual json asJsonObject( int precision = 17 ) const SIP_SKIP;
+    virtual json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const SIP_SKIP;
 
     /**
      * Attempts to coerce this geometry into the specified destination \a type.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2386,7 +2386,7 @@ class CORE_EXPORT QgsGeometry
     /**
      * Export the geometry to a GeoJSON string, with the given \a precision and following the specified GeoJSON \a profile.
      * Note: this is identical to asJson() when using the Legacy and Rfc7946 profile, but differs when using other profiles with "CircularString," "CompoundCurve," "CurvePolygon," "MultiCurve," or "MultiSurface" geometries.
-     * \since QGIS 4.2
+     * \since QGIS 4.4
      */
     QString asGeoJson( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const;
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -2378,23 +2378,24 @@ class CORE_EXPORT QgsGeometry
 #endif
 
     /**
-    * Exports the geometry to a GeoJSON string.
+    * Exports the geometry to a GeoJSON RFC7946 string.
+    * \see asGeoJson() for exporting using other GeoJSON profiles
     */
     QString asJson( int precision = 17 ) const;
 
     /**
      * Export the geometry to a GeoJSON string, with the given \a precision and following the specified GeoJSON \a profile.
-     * Note: this is identical to asJson() when using the Rfc7946 profile, but differs when using other profiles.
+     * Note: this is identical to asJson() when using the Legacy and Rfc7946 profile, but differs when using other profiles with "CircularString," "CompoundCurve," "CurvePolygon," "MultiCurve," or "MultiSurface" geometries.
      * \since QGIS 4.2
      */
-    QString asGeoJson( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const;
+    QString asGeoJson( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const;
 
     /**
-     * Exports the geometry to a json object.
+     * Exports the geometry to a json object with the give \a precision and following the specified GeoJSON \a profile.
      * \note not available in Python bindings
      * \since QGIS 3.8
      */
-    virtual json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const SIP_SKIP;
+    virtual json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const SIP_SKIP;
 
     /**
      * Attempts to coerce this geometry into the specified destination \a type.

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -500,7 +500,7 @@ json QgsGeometryCollection::asJsonObject( int precision, Qgis::GeoJsonProfile pr
   json coordinates( json::array() );
   for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
   {
-    coordinates.push_back( geom->asJsonObject( precision ) );
+    coordinates.push_back( geom->asJsonObject( precision, profile ) );
   }
   return { { "type", "GeometryCollection" }, { "geometries", coordinates } };
 }

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -495,7 +495,7 @@ QDomElement QgsGeometryCollection::asGml3( QDomDocument &doc, int precision, con
   return elemMultiGeometry;
 }
 
-json QgsGeometryCollection::asJsonObject( int precision ) const
+json QgsGeometryCollection::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   json coordinates( json::array() );
   for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -281,7 +281,7 @@ class CORE_EXPORT QgsGeometryCollection : public QgsAbstractGeometry
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
 
     QgsBox3D boundingBox3D() const override;

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -281,7 +281,7 @@ class CORE_EXPORT QgsGeometryCollection : public QgsAbstractGeometry
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
 
     QgsBox3D boundingBox3D() const override;

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1071,18 +1071,47 @@ QString QgsGeometryUtils::pointsToJSON( const QgsPointSequence &points, int prec
 }
 
 
-json QgsGeometryUtils::pointsToJson( const QgsPointSequence &points, int precision )
+json QgsGeometryUtils::pointsToJson( const QgsPointSequence &points, int precision, Qgis::GeoJsonProfile profile )
 {
   json coordinates( json::array() );
   for ( const QgsPoint &p : points )
   {
-    if ( p.is3D() )
+    switch ( profile )
     {
-      coordinates.push_back( { qgsRound( p.x(), precision ), qgsRound( p.y(), precision ), qgsRound( p.z(), precision ) } );
-    }
-    else
-    {
-      coordinates.push_back( { qgsRound( p.x(), precision ), qgsRound( p.y(), precision ) } );
+      case Qgis::GeoJsonProfile::Rfc7946:
+      case Qgis::GeoJsonProfile::Legacy:
+      {
+        if ( p.is3D() )
+        {
+          coordinates.push_back( { qgsRound( p.x(), precision ), qgsRound( p.y(), precision ), qgsRound( p.z(), precision ) } );
+        }
+        else
+        {
+          coordinates.push_back( { qgsRound( p.x(), precision ), qgsRound( p.y(), precision ) } );
+        }
+        break;
+      }
+      case Qgis::GeoJsonProfile::JsonFg:
+      case Qgis::GeoJsonProfile::JsonFgPlus:
+      {
+        if ( p.is3D() && p.isMeasure() )
+        {
+          coordinates.push_back( { qgsRound( p.x(), precision ), qgsRound( p.y(), precision ), qgsRound( p.z(), precision ), qgsRound( p.m(), precision ) } );
+        }
+        else if ( p.is3D() )
+        {
+          coordinates.push_back( { qgsRound( p.x(), precision ), qgsRound( p.y(), precision ), qgsRound( p.z(), precision ) } );
+        }
+        else if ( p.isMeasure() )
+        {
+          coordinates.push_back( { qgsRound( p.x(), precision ), qgsRound( p.y(), precision ), qgsRound( p.m(), precision ) } );
+        }
+        else
+        {
+          coordinates.push_back( { qgsRound( p.x(), precision ), qgsRound( p.y(), precision ) } );
+        }
+        break;
+      }
     }
   }
   return coordinates;

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -345,14 +345,15 @@ class CORE_EXPORT QgsGeometryUtils
     /**
      * Returns a geoJSON coordinates string.
      * \note not available in Python bindings
+     * \deprecated QGIS 4.2. Use pointsToJson() instead.
      */
-    static QString pointsToJSON( const QgsPointSequence &points, int precision ) SIP_SKIP;
+    Q_DECL_DEPRECATED static QString pointsToJSON( const QgsPointSequence &points, int precision ) SIP_SKIP;
 
     /**
      * Returns coordinates as json object.
      * \note not available in Python bindings
      */
-    static json pointsToJson( const QgsPointSequence &points, int precision ) SIP_SKIP;
+    static json pointsToJson( const QgsPointSequence &points, int precision, Qgis::GeoJsonProfile profile ) SIP_SKIP;
 
     /**
      * Parses a WKT block of the format "TYPE( contents )" and returns a pair of geometry type to contents ("Pair(wkbType, "contents")")

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -800,7 +800,7 @@ QDomElement QgsLineString::asGml3( QDomDocument &doc, int precision, const QStri
   return elemLineString;
 }
 
-json QgsLineString::asJsonObject( int precision ) const
+json QgsLineString::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   QgsPointSequence pts;
   points( pts );

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -802,9 +802,13 @@ QDomElement QgsLineString::asGml3( QDomDocument &doc, int precision, const QStri
 
 json QgsLineString::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
+  // The current profiles do not make any difference for LineString,
+  // but we keep the parameter in case we need to add specific handling
+  // for future profiles
+  Q_UNUSED( profile )
   QgsPointSequence pts;
   points( pts );
-  return { { "type", "LineString" }, { "coordinates", QgsGeometryUtils::pointsToJson( pts, precision ) } };
+  return { { "type", "LineString" }, { "coordinates", QgsGeometryUtils::pointsToJson( pts, precision, profile ) } };
 }
 
 QString QgsLineString::asKml( int precision ) const

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -391,7 +391,7 @@ class CORE_EXPORT QgsLineString : public QgsSimpleCurve
 
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
 
     //curve interface

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -391,7 +391,7 @@ class CORE_EXPORT QgsLineString : public QgsSimpleCurve
 
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
 
     //curve interface

--- a/src/core/geometry/qgsmulticurve.cpp
+++ b/src/core/geometry/qgsmulticurve.cpp
@@ -126,18 +126,38 @@ QDomElement QgsMultiCurve::asGml3( QDomDocument &doc, int precision, const QStri
 
 json QgsMultiCurve::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
-  json coordinates( json::array() );
-  for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
+  switch ( profile )
   {
-    if ( qgsgeometry_cast<const QgsCurve *>( geom ) )
+    case Qgis::GeoJsonProfile::Rfc7946:
     {
-      std::unique_ptr< QgsLineString > lineString( static_cast<const QgsCurve *>( geom )->curveToLine() );
-      QgsPointSequence pts;
-      lineString->points( pts );
-      coordinates.push_back( QgsGeometryUtils::pointsToJson( pts, precision ) );
+      json coordinates( json::array() );
+      for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
+      {
+        if ( qgsgeometry_cast<const QgsCurve *>( geom ) )
+        {
+          std::unique_ptr< QgsLineString > lineString( static_cast<const QgsCurve *>( geom )->curveToLine() );
+          QgsPointSequence pts;
+          lineString->points( pts );
+          coordinates.push_back( QgsGeometryUtils::pointsToJson( pts, precision, profile ) );
+        }
+      }
+      return { { "type", "MultiLineString" }, { "coordinates", coordinates } };
+    }
+    case Qgis::GeoJsonProfile::JsonFg:
+    case Qgis::GeoJsonProfile::JsonFgPlus:
+    {
+      json geometries( json::array() );
+      for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
+      {
+        if ( qgsgeometry_cast<const QgsCurve *>( geom ) )
+        {
+          geometries.push_back( static_cast<const QgsCurve *>( geom )->asJsonObject( precision, profile ) );
+        }
+      }
+      return { { "type", "MultiCurve" }, { "geometries", geometries } };
     }
   }
-  return { { "type", "MultiLineString" }, { "coordinates", coordinates } };
+  BUILTIN_UNREACHABLE
 }
 
 bool QgsMultiCurve::addGeometry( QgsAbstractGeometry *g )

--- a/src/core/geometry/qgsmulticurve.cpp
+++ b/src/core/geometry/qgsmulticurve.cpp
@@ -124,7 +124,7 @@ QDomElement QgsMultiCurve::asGml3( QDomDocument &doc, int precision, const QStri
   return elemMultiCurve;
 }
 
-json QgsMultiCurve::asJsonObject( int precision ) const
+json QgsMultiCurve::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   json coordinates( json::array() );
   for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )

--- a/src/core/geometry/qgsmulticurve.cpp
+++ b/src/core/geometry/qgsmulticurve.cpp
@@ -128,6 +128,7 @@ json QgsMultiCurve::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) 
 {
   switch ( profile )
   {
+    case Qgis::GeoJsonProfile::Legacy:
     case Qgis::GeoJsonProfile::Rfc7946:
     {
       json coordinates( json::array() );

--- a/src/core/geometry/qgsmulticurve.cpp
+++ b/src/core/geometry/qgsmulticurve.cpp
@@ -134,9 +134,9 @@ json QgsMultiCurve::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) 
       json coordinates( json::array() );
       for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
       {
-        if ( qgsgeometry_cast<const QgsCurve *>( geom ) )
+        if ( auto curveGeom = qgsgeometry_cast<const QgsCurve *>( geom ) )
         {
-          std::unique_ptr< QgsLineString > lineString( static_cast<const QgsCurve *>( geom )->curveToLine() );
+          std::unique_ptr< QgsLineString > lineString( curveGeom->curveToLine() );
           QgsPointSequence pts;
           lineString->points( pts );
           coordinates.push_back( QgsGeometryUtils::pointsToJson( pts, precision, profile ) );
@@ -150,9 +150,9 @@ json QgsMultiCurve::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) 
       json geometries( json::array() );
       for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
       {
-        if ( qgsgeometry_cast<const QgsCurve *>( geom ) )
+        if ( auto curveGeom = qgsgeometry_cast<const QgsCurve *>( geom ) )
         {
-          geometries.push_back( static_cast<const QgsCurve *>( geom )->asJsonObject( precision, profile ) );
+          geometries.push_back( curveGeom->asJsonObject( precision, profile ) );
         }
       }
       return { { "type", "MultiCurve" }, { "geometries", geometries } };

--- a/src/core/geometry/qgsmulticurve.h
+++ b/src/core/geometry/qgsmulticurve.h
@@ -89,7 +89,7 @@ class CORE_EXPORT QgsMultiCurve : public QgsGeometryCollection
     bool fromWkt( const QString &wkt ) override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
     bool addGeometries( const QVector< QgsAbstractGeometry * > &geometries SIP_TRANSFER ) override;
     bool insertGeometry( QgsAbstractGeometry *g SIP_TRANSFER, int index ) override;

--- a/src/core/geometry/qgsmulticurve.h
+++ b/src/core/geometry/qgsmulticurve.h
@@ -89,7 +89,7 @@ class CORE_EXPORT QgsMultiCurve : public QgsGeometryCollection
     bool fromWkt( const QString &wkt ) override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
     bool addGeometries( const QVector< QgsAbstractGeometry * > &geometries SIP_TRANSFER ) override;
     bool insertGeometry( QgsAbstractGeometry *g SIP_TRANSFER, int index ) override;

--- a/src/core/geometry/qgsmultilinestring.cpp
+++ b/src/core/geometry/qgsmultilinestring.cpp
@@ -149,7 +149,7 @@ json QgsMultiLineString::asJsonObject( int precision, Qgis::GeoJsonProfile profi
       const QgsLineString *lineString = static_cast<const QgsLineString *>( geom );
       QgsPointSequence pts;
       lineString->points( pts );
-      coordinates.push_back( QgsGeometryUtils::pointsToJson( pts, precision ) );
+      coordinates.push_back( QgsGeometryUtils::pointsToJson( pts, precision, profile ) );
     }
   }
   return { { "type", "MultiLineString" }, { "coordinates", coordinates } };

--- a/src/core/geometry/qgsmultilinestring.cpp
+++ b/src/core/geometry/qgsmultilinestring.cpp
@@ -139,7 +139,7 @@ QDomElement QgsMultiLineString::asGml3( QDomDocument &doc, int precision, const 
   return elemMultiCurve;
 }
 
-json QgsMultiLineString::asJsonObject( int precision ) const
+json QgsMultiLineString::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   json coordinates( json::array() );
   for ( const QgsAbstractGeometry *geom : mGeometries )

--- a/src/core/geometry/qgsmultilinestring.h
+++ b/src/core/geometry/qgsmultilinestring.h
@@ -110,7 +110,7 @@ class CORE_EXPORT QgsMultiLineString : public QgsMultiCurve
     bool fromWkt( const QString &wkt ) override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
     bool addGeometries( const QVector< QgsAbstractGeometry * > &geometries SIP_TRANSFER ) final;
     bool insertGeometry( QgsAbstractGeometry *g SIP_TRANSFER, int index ) override;

--- a/src/core/geometry/qgsmultilinestring.h
+++ b/src/core/geometry/qgsmultilinestring.h
@@ -110,7 +110,7 @@ class CORE_EXPORT QgsMultiLineString : public QgsMultiCurve
     bool fromWkt( const QString &wkt ) override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
     bool addGeometries( const QVector< QgsAbstractGeometry * > &geometries SIP_TRANSFER ) final;
     bool insertGeometry( QgsAbstractGeometry *g SIP_TRANSFER, int index ) override;

--- a/src/core/geometry/qgsmultipoint.cpp
+++ b/src/core/geometry/qgsmultipoint.cpp
@@ -213,10 +213,16 @@ json QgsMultiPoint::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) 
   for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
   {
     const QgsPoint *point = static_cast<const QgsPoint *>( geom );
+    json coords = { qgsRound( point->x(), precision ), qgsRound( point->y(), precision ) };
     if ( point->is3D() )
-      j["coordinates"].push_back( { qgsRound( point->x(), precision ), qgsRound( point->y(), precision ), qgsRound( point->z(), precision ) } );
-    else
-      j["coordinates"].push_back( { qgsRound( point->x(), precision ), qgsRound( point->y(), precision ) } );
+    {
+      coords.push_back( qgsRound( point->z(), precision ) );
+    }
+    if ( isMeasure() && ( profile == Qgis::GeoJsonProfile::JsonFg || profile == Qgis::GeoJsonProfile::JsonFgPlus ) )
+    {
+      coords.push_back( qgsRound( point->m(), precision ) );
+    }
+    j["coordinates"].push_back( coords );
   }
   return j;
 }

--- a/src/core/geometry/qgsmultipoint.cpp
+++ b/src/core/geometry/qgsmultipoint.cpp
@@ -204,7 +204,7 @@ QDomElement QgsMultiPoint::asGml3( QDomDocument &doc, int precision, const QStri
   return elemMultiPoint;
 }
 
-json QgsMultiPoint::asJsonObject( int precision ) const
+json QgsMultiPoint::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   json j {
     { "type", "MultiPoint" },

--- a/src/core/geometry/qgsmultipoint.h
+++ b/src/core/geometry/qgsmultipoint.h
@@ -343,7 +343,7 @@ class CORE_EXPORT QgsMultiPoint : public QgsGeometryCollection
     void clear() override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     int nCoordinates() const override SIP_HOLDGIL;
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
     bool addGeometries( const QVector< QgsAbstractGeometry * > &geometries SIP_TRANSFER ) final;

--- a/src/core/geometry/qgsmultipoint.h
+++ b/src/core/geometry/qgsmultipoint.h
@@ -343,7 +343,7 @@ class CORE_EXPORT QgsMultiPoint : public QgsGeometryCollection
     void clear() override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     int nCoordinates() const override SIP_HOLDGIL;
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
     bool addGeometries( const QVector< QgsAbstractGeometry * > &geometries SIP_TRANSFER ) final;

--- a/src/core/geometry/qgsmultipolygon.cpp
+++ b/src/core/geometry/qgsmultipolygon.cpp
@@ -153,7 +153,7 @@ json QgsMultiPolygon::asJsonObject( int precision, Qgis::GeoJsonProfile profile 
       std::unique_ptr< QgsLineString > exteriorLineString( polygon->exteriorRing()->curveToLine() );
       QgsPointSequence exteriorPts;
       exteriorLineString->points( exteriorPts );
-      coordinates.push_back( QgsGeometryUtils::pointsToJson( exteriorPts, precision ) );
+      coordinates.push_back( QgsGeometryUtils::pointsToJson( exteriorPts, precision, profile ) );
 
       std::unique_ptr< QgsLineString > interiorLineString;
       for ( int i = 0, n = polygon->numInteriorRings(); i < n; ++i )
@@ -161,7 +161,7 @@ json QgsMultiPolygon::asJsonObject( int precision, Qgis::GeoJsonProfile profile 
         interiorLineString.reset( polygon->interiorRing( i )->curveToLine() );
         QgsPointSequence interiorPts;
         interiorLineString->points( interiorPts );
-        coordinates.push_back( QgsGeometryUtils::pointsToJson( interiorPts, precision ) );
+        coordinates.push_back( QgsGeometryUtils::pointsToJson( interiorPts, precision, profile ) );
       }
       polygons.push_back( coordinates );
     }

--- a/src/core/geometry/qgsmultipolygon.cpp
+++ b/src/core/geometry/qgsmultipolygon.cpp
@@ -140,7 +140,7 @@ QDomElement QgsMultiPolygon::asGml3( QDomDocument &doc, int precision, const QSt
   return elemMultiSurface;
 }
 
-json QgsMultiPolygon::asJsonObject( int precision ) const
+json QgsMultiPolygon::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   json polygons( json::array() );
   for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )

--- a/src/core/geometry/qgsmultipolygon.h
+++ b/src/core/geometry/qgsmultipolygon.h
@@ -110,7 +110,7 @@ class CORE_EXPORT QgsMultiPolygon : public QgsMultiSurface
     bool fromWkt( const QString &wkt ) override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision  = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision  = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
     bool addGeometries( const QVector< QgsAbstractGeometry * > &geometries SIP_TRANSFER ) final;
     bool insertGeometry( QgsAbstractGeometry *g SIP_TRANSFER, int index ) override;

--- a/src/core/geometry/qgsmultipolygon.h
+++ b/src/core/geometry/qgsmultipolygon.h
@@ -110,7 +110,7 @@ class CORE_EXPORT QgsMultiPolygon : public QgsMultiSurface
     bool fromWkt( const QString &wkt ) override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision  = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision  = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
     bool addGeometries( const QVector< QgsAbstractGeometry * > &geometries SIP_TRANSFER ) final;
     bool insertGeometry( QgsAbstractGeometry *g SIP_TRANSFER, int index ) override;

--- a/src/core/geometry/qgsmultisurface.cpp
+++ b/src/core/geometry/qgsmultisurface.cpp
@@ -126,6 +126,7 @@ json QgsMultiSurface::asJsonObject( int precision, Qgis::GeoJsonProfile profile 
 {
   switch ( profile )
   {
+    case Qgis::GeoJsonProfile::Legacy:
     case Qgis::GeoJsonProfile::Rfc7946:
     {
       json polygons( json::array() );

--- a/src/core/geometry/qgsmultisurface.cpp
+++ b/src/core/geometry/qgsmultisurface.cpp
@@ -122,7 +122,7 @@ QDomElement QgsMultiSurface::asGml3( QDomDocument &doc, int precision, const QSt
 }
 
 
-json QgsMultiSurface::asJsonObject( int precision ) const
+json QgsMultiSurface::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   json polygons( json::array() );
   for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )

--- a/src/core/geometry/qgsmultisurface.cpp
+++ b/src/core/geometry/qgsmultisurface.cpp
@@ -124,30 +124,47 @@ QDomElement QgsMultiSurface::asGml3( QDomDocument &doc, int precision, const QSt
 
 json QgsMultiSurface::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
-  json polygons( json::array() );
-  for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
+  switch ( profile )
   {
-    if ( qgsgeometry_cast<const QgsCurvePolygon *>( geom ) )
+    case Qgis::GeoJsonProfile::Rfc7946:
     {
-      json coordinates( json::array() );
-      std::unique_ptr< QgsPolygon > polygon( static_cast<const QgsCurvePolygon *>( geom )->surfaceToPolygon() );
-      std::unique_ptr< QgsLineString > exteriorLineString( polygon->exteriorRing()->curveToLine() );
-      QgsPointSequence exteriorPts;
-      exteriorLineString->points( exteriorPts );
-      coordinates.push_back( QgsGeometryUtils::pointsToJson( exteriorPts, precision ) );
-
-      std::unique_ptr< QgsLineString > interiorLineString;
-      for ( int i = 0, n = polygon->numInteriorRings(); i < n; ++i )
+      json polygons( json::array() );
+      for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
       {
-        interiorLineString.reset( polygon->interiorRing( i )->curveToLine() );
-        QgsPointSequence interiorPts;
-        interiorLineString->points( interiorPts );
-        coordinates.push_back( QgsGeometryUtils::pointsToJson( interiorPts, precision ) );
+        if ( qgsgeometry_cast<const QgsCurvePolygon *>( geom ) )
+        {
+          json coordinates( json::array() );
+          std::unique_ptr< QgsPolygon > polygon( static_cast<const QgsCurvePolygon *>( geom )->surfaceToPolygon() );
+          std::unique_ptr< QgsLineString > exteriorLineString( polygon->exteriorRing()->curveToLine() );
+          QgsPointSequence exteriorPts;
+          exteriorLineString->points( exteriorPts );
+          coordinates.push_back( QgsGeometryUtils::pointsToJson( exteriorPts, precision, profile ) );
+
+          std::unique_ptr< QgsLineString > interiorLineString;
+          for ( int i = 0, n = polygon->numInteriorRings(); i < n; ++i )
+          {
+            interiorLineString.reset( polygon->interiorRing( i )->curveToLine() );
+            QgsPointSequence interiorPts;
+            interiorLineString->points( interiorPts );
+            coordinates.push_back( QgsGeometryUtils::pointsToJson( interiorPts, precision, profile ) );
+          }
+          polygons.push_back( coordinates );
+        }
       }
-      polygons.push_back( coordinates );
+      return { { "type", "MultiPolygon" }, { "coordinates", polygons } };
+    }
+    case Qgis::GeoJsonProfile::JsonFg:
+    case Qgis::GeoJsonProfile::JsonFgPlus:
+    {
+      json geometries( json::array() );
+      for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
+      {
+        geometries.push_back( geom->asJsonObject( precision, profile ) );
+      }
+      return { { "type", "MultiSurface" }, { "geometries", geometries } };
     }
   }
-  return { { "type", "MultiPolygon" }, { "coordinates", polygons } };
+  BUILTIN_UNREACHABLE
 }
 
 bool QgsMultiSurface::addGeometry( QgsAbstractGeometry *g )

--- a/src/core/geometry/qgsmultisurface.cpp
+++ b/src/core/geometry/qgsmultisurface.cpp
@@ -132,10 +132,10 @@ json QgsMultiSurface::asJsonObject( int precision, Qgis::GeoJsonProfile profile 
       json polygons( json::array() );
       for ( const QgsAbstractGeometry *geom : std::as_const( mGeometries ) )
       {
-        if ( qgsgeometry_cast<const QgsCurvePolygon *>( geom ) )
+        if ( auto curveGeom = qgsgeometry_cast<const QgsCurvePolygon *>( geom ) )
         {
           json coordinates( json::array() );
-          std::unique_ptr< QgsPolygon > polygon( static_cast<const QgsCurvePolygon *>( geom )->surfaceToPolygon() );
+          std::unique_ptr< QgsPolygon > polygon( curveGeom->surfaceToPolygon() );
           std::unique_ptr< QgsLineString > exteriorLineString( polygon->exteriorRing()->curveToLine() );
           QgsPointSequence exteriorPts;
           exteriorLineString->points( exteriorPts );

--- a/src/core/geometry/qgsmultisurface.h
+++ b/src/core/geometry/qgsmultisurface.h
@@ -89,7 +89,7 @@ class CORE_EXPORT QgsMultiSurface : public QgsGeometryCollection
     bool fromWkt( const QString &wkt ) override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
     bool addGeometries( const QVector< QgsAbstractGeometry * > &geometries SIP_TRANSFER ) override;
     bool insertGeometry( QgsAbstractGeometry *g SIP_TRANSFER, int index ) override;

--- a/src/core/geometry/qgsmultisurface.h
+++ b/src/core/geometry/qgsmultisurface.h
@@ -89,7 +89,7 @@ class CORE_EXPORT QgsMultiSurface : public QgsGeometryCollection
     bool fromWkt( const QString &wkt ) override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
     bool addGeometries( const QVector< QgsAbstractGeometry * > &geometries SIP_TRANSFER ) override;
     bool insertGeometry( QgsAbstractGeometry *g SIP_TRANSFER, int index ) override;

--- a/src/core/geometry/qgsnurbscurve.cpp
+++ b/src/core/geometry/qgsnurbscurve.cpp
@@ -1748,7 +1748,7 @@ QDomElement QgsNurbsCurve::asGml3( QDomDocument &doc, int precision, const QStri
   return line->asGml3( doc, precision, ns, axisOrder );
 }
 
-json QgsNurbsCurve::asJsonObject( int precision ) const
+json QgsNurbsCurve::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   std::unique_ptr<QgsLineString> line( curveToLine() );
   if ( !line )

--- a/src/core/geometry/qgsnurbscurve.cpp
+++ b/src/core/geometry/qgsnurbscurve.cpp
@@ -1750,6 +1750,10 @@ QDomElement QgsNurbsCurve::asGml3( QDomDocument &doc, int precision, const QStri
 
 json QgsNurbsCurve::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
+  // The current profiles do not make any difference for NURBS curves, as GeoJSON does not support them,
+  // so we convert to LineString but we keep the parameter in case we need to add specific handling
+  // for future profiles
+  Q_UNUSED( profile )
   std::unique_ptr<QgsLineString> line( curveToLine() );
   if ( !line )
     return json::object();

--- a/src/core/geometry/qgsnurbscurve.h
+++ b/src/core/geometry/qgsnurbscurve.h
@@ -179,7 +179,7 @@ class CORE_EXPORT QgsNurbsCurve : public QgsCurve
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
     int dimension() const override SIP_HOLDGIL;
     bool isEmpty() const override SIP_HOLDGIL;

--- a/src/core/geometry/qgsnurbscurve.h
+++ b/src/core/geometry/qgsnurbscurve.h
@@ -179,7 +179,7 @@ class CORE_EXPORT QgsNurbsCurve : public QgsCurve
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
     int dimension() const override SIP_HOLDGIL;
     bool isEmpty() const override SIP_HOLDGIL;

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -369,6 +369,10 @@ json QgsPoint::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
     {
       j["coordinates"].push_back( qgsRound( mZ, precision ) );
     }
+    if ( isMeasure() && ( profile == Qgis::GeoJsonProfile::JsonFg || profile == Qgis::GeoJsonProfile::JsonFgPlus ) )
+    {
+      j["coordinates"].push_back( qgsRound( mM, precision ) );
+    }
   }
   return j;
 }

--- a/src/core/geometry/qgspoint.cpp
+++ b/src/core/geometry/qgspoint.cpp
@@ -355,7 +355,7 @@ QDomElement QgsPoint::asGml3( QDomDocument &doc, int precision, const QString &n
 }
 
 
-json QgsPoint::asJsonObject( int precision ) const
+json QgsPoint::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   json j {
     { "type", "Point" },

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -646,7 +646,7 @@ class CORE_EXPORT QgsPoint : public QgsAbstractGeometry
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
     void draw( QPainter &p ) const override;
     QPainterPath asQPainterPath() const override;

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -646,7 +646,7 @@ class CORE_EXPORT QgsPoint : public QgsAbstractGeometry
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
     void draw( QPainter &p ) const override;
     QPainterPath asQPainterPath() const override;

--- a/src/core/geometry/qgspolygon.cpp
+++ b/src/core/geometry/qgspolygon.cpp
@@ -17,6 +17,8 @@
 
 #include "qgspolygon.h"
 
+#include <nlohmann/json.hpp>
+
 #include "qgsapplication.h"
 #include "qgsgeometryutils.h"
 #include "qgslinestring.h"
@@ -377,4 +379,27 @@ QgsCurvePolygon *QgsPolygon::toCurveType() const
     }
   }
   return curvePolygon;
+}
+
+
+json QgsPolygon::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
+{
+  json coordinates = json::array();
+  if ( exteriorRing() )
+  {
+    std::unique_ptr< QgsLineString > exteriorLineString( exteriorRing()->curveToLine() );
+    QgsPointSequence exteriorPts;
+    exteriorLineString->points( exteriorPts );
+    coordinates.push_back( QgsGeometryUtils::pointsToJson( exteriorPts, precision, profile ) );
+
+    std::unique_ptr< QgsLineString > interiorLineString;
+    for ( int i = 0, n = numInteriorRings(); i < n; ++i )
+    {
+      interiorLineString.reset( interiorRing( i )->curveToLine() );
+      QgsPointSequence interiorPts;
+      interiorLineString->points( interiorPts );
+      coordinates.push_back( QgsGeometryUtils::pointsToJson( interiorPts, precision, profile ) );
+    }
+  }
+  return { { "type", "Polygon" }, { "coordinates", coordinates } };
 }

--- a/src/core/geometry/qgspolygon.h
+++ b/src/core/geometry/qgspolygon.h
@@ -123,6 +123,9 @@ class CORE_EXPORT QgsPolygon : public QgsCurvePolygon
         return static_cast<QgsPolygon *>( geom );
       return nullptr;
     }
+
+    json asJsonObject(int precision, Qgis::GeoJsonProfile profile) const override;
+
 #endif
 
     QgsPolygon *createEmptyWithSameType() const override SIP_FACTORY;

--- a/src/core/geometry/qgspolygon.h
+++ b/src/core/geometry/qgspolygon.h
@@ -124,7 +124,7 @@ class CORE_EXPORT QgsPolygon : public QgsCurvePolygon
       return nullptr;
     }
 
-    json asJsonObject(int precision, Qgis::GeoJsonProfile profile) const override;
+    json asJsonObject(int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override;
 
 #endif
 

--- a/src/core/geometry/qgspolyhedralsurface.cpp
+++ b/src/core/geometry/qgspolyhedralsurface.cpp
@@ -310,6 +310,8 @@ QDomElement QgsPolyhedralSurface::asGml3( QDomDocument &doc, int precision, cons
 
 json QgsPolyhedralSurface::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
+  // JSON-FG profile is not supported yet for PolyhedralSurface geometry
+  Q_UNUSED( profile );
   // GeoJSON format does not support PolyhedralSurface geometry
   // Return a multipolygon instead;
   std::unique_ptr<QgsMultiPolygon> multiPolygon( toMultiPolygon() );

--- a/src/core/geometry/qgspolyhedralsurface.cpp
+++ b/src/core/geometry/qgspolyhedralsurface.cpp
@@ -308,7 +308,7 @@ QDomElement QgsPolyhedralSurface::asGml3( QDomDocument &doc, int precision, cons
   return elemPolyhedralSurface;
 }
 
-json QgsPolyhedralSurface::asJsonObject( int precision ) const
+json QgsPolyhedralSurface::asJsonObject( int precision, Qgis::GeoJsonProfile profile ) const
 {
   // GeoJSON format does not support PolyhedralSurface geometry
   // Return a multipolygon instead;

--- a/src/core/geometry/qgspolyhedralsurface.h
+++ b/src/core/geometry/qgspolyhedralsurface.h
@@ -126,7 +126,7 @@ class CORE_EXPORT QgsPolyhedralSurface : public QgsSurface
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
     void normalize() override SIP_HOLDGIL;
 

--- a/src/core/geometry/qgspolyhedralsurface.h
+++ b/src/core/geometry/qgspolyhedralsurface.h
@@ -126,7 +126,7 @@ class CORE_EXPORT QgsPolyhedralSurface : public QgsSurface
     QString asWkt( int precision = 17 ) const override;
     QDomElement asGml2( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
-    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Rfc7946 ) const override SIP_SKIP;
+    json asJsonObject( int precision = 17, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) const override SIP_SKIP;
     QString asKml( int precision = 17 ) const override;
     void normalize() override SIP_HOLDGIL;
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5030,7 +5030,7 @@ int QgisEvent = QEvent::User + 1;
      */
     enum class GeoJsonProfile : int
     {
-      Legacy, //! Legacy GeoJson profile used in QGIS prior to 4.2, which included some non-standard extensions and deviations from the RFC7946 standard, such as support for  tranforming geometries to a CRS different than CRS84. This profile is still available for backward compatibility but is not recommended for new projects.
+      Legacy, //! Legacy GeoJson profile used in QGIS prior to 4.2, which included some non-standard extensions and deviations from the RFC7946 standard, such as support for  transforming geometries to a CRS different than CRS84. This profile is still available for backward compatibility but is not recommended for new projects.
       Rfc7946,    //!< GeoJson profile compliant with RFC7946 standard "http://www.opengis.net/def/profile/OGC/0/rfc7946"
       JsonFg,     //!< GeoJson profile from OGC Features and Geometries JSON Part 1: core "http://www.opengis.net/def/profile/OGC/0/jsonfg"
       JsonFgPlus, //!< GeoJson profile from OGC Features and Geometries JSON Part 1: core "http://www.opengis.net/def/profile/OGC/0/jsonfg-plus"

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5030,6 +5030,7 @@ int QgisEvent = QEvent::User + 1;
      */
     enum class GeoJsonProfile : int
     {
+      Legacy, //! Legacy GeoJson profile used in QGIS prior to 4.2, which included some non-standard extensions and deviations from the RFC7946 standard, such as support for  tranforming geometries to a CRS different than CRS84. This profile is still available for backward compatibility but is not recommended for new projects.
       Rfc7946,    //!< GeoJson profile compliant with RFC7946 standard "http://www.opengis.net/def/profile/OGC/0/rfc7946"
       JsonFg,     //!< GeoJson profile from OGC Features and Geometries JSON Part 1: core "http://www.opengis.net/def/profile/OGC/0/jsonfg"
       JsonFgPlus, //!< GeoJson profile from OGC Features and Geometries JSON Part 1: core "http://www.opengis.net/def/profile/OGC/0/jsonfg-plus"

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5024,6 +5024,19 @@ int QgisEvent = QEvent::User + 1;
     Q_FLAG( LegendJsonRenderFlags )
 
     /**
+     * GeoJson export Profile according to OGC Features and Geometries JSON - Part 1: Core
+     * https://docs.ogc.org/is/21-045r1/21-045r1.html
+     * \since QGIS 4.2
+     */
+    enum class GeoJsonProfile : int
+    {
+      Rfc7946,    //!< GeoJson profile compliant with RFC7946 standard "http://www.opengis.net/def/profile/OGC/0/rfc7946"
+      JsonFg,     //!< GeoJson profile from OGC Features and Geometries JSON Part 1: core "http://www.opengis.net/def/profile/OGC/0/jsonfg"
+      JsonFgPlus, //!< GeoJson profile from OGC Features and Geometries JSON Part 1: core "http://www.opengis.net/def/profile/OGC/0/jsonfg-plus"
+    };
+    Q_ENUM( GeoJsonProfile )
+
+    /**
      * Action types.
      *
      * Prior to QGIS 3.30 this was available as QgsActionMenu::ActionType

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -5030,7 +5030,7 @@ int QgisEvent = QEvent::User + 1;
      */
     enum class GeoJsonProfile : int
     {
-      Legacy, //! Legacy GeoJson profile used in QGIS prior to 4.2, which included some non-standard extensions and deviations from the RFC7946 standard, such as support for  transforming geometries to a CRS different than CRS84. This profile is still available for backward compatibility but is not recommended for new projects.
+      Legacy, //!< Legacy GeoJson profile used in QGIS prior to 4.2, which included some non-standard extensions and deviations from the RFC7946 standard, such as support for  transforming geometries to a CRS different than CRS84. This profile is still available for backward compatibility but is not recommended for new projects.
       Rfc7946,    //!< GeoJson profile compliant with RFC7946 standard "http://www.opengis.net/def/profile/OGC/0/rfc7946"
       JsonFg,     //!< GeoJson profile from OGC Features and Geometries JSON Part 1: core "http://www.opengis.net/def/profile/OGC/0/jsonfg"
       JsonFgPlus, //!< GeoJson profile from OGC Features and Geometries JSON Part 1: core "http://www.opengis.net/def/profile/OGC/0/jsonfg-plus"

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -927,7 +927,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
 
     if ( coords.empty() )
     {
-      return std::move( std::make_unique< QgsCircularString >() );
+      return std::make_unique< QgsCircularString >();
     }
 
     if ( !coords.is_array() || coords.size() % 2 == 0 || coords.size() < 3 )
@@ -964,7 +964,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
       if ( hasM )
         m.append( point->m() );
     }
-    return std::move( std::make_unique< QgsCircularString >( x, y, z, m ) );
+    return std::make_unique< QgsCircularString >( x, y, z, m );
   }
   else if ( type.compare( "CompoundCurve"_L1, Qt::CaseInsensitive ) == 0 )
   {
@@ -995,7 +995,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
       }
       compoundCurve->addCurve( static_cast< QgsCurve * >( object.release() ) );
     }
-    return std::move( compoundCurve );
+    return compoundCurve;
   }
   else if ( type.compare( "CurvePolygon"_L1, Qt::CaseInsensitive ) == 0 )
   {
@@ -1035,7 +1035,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
         curvePolygon->addInteriorRing( static_cast< QgsCurve * >( object.release() ) );
       }
     }
-    return std::move( curvePolygon );
+    return curvePolygon;
   }
   else if ( type.compare( "MultiCurve"_L1, Qt::CaseInsensitive ) == 0 )
   {
@@ -1066,7 +1066,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
       }
       multiCurve->addGeometry( static_cast< QgsCurve * >( object.release() ) );
     }
-    return std::move( multiCurve );
+    return multiCurve;
   }
   else if ( type.compare( "MultiSurface"_L1, Qt::CaseInsensitive ) == 0 )
   {
@@ -1097,7 +1097,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
       }
       multiSurface->addGeometry( static_cast< QgsSurface * >( object.release() ) );
     }
-    return std::move( multiSurface );
+    return multiSurface;
   }
   else if ( type.compare( "GeometryCollection"_L1, Qt::CaseInsensitive ) == 0 )
   {

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -116,7 +116,7 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
   transformToCRS84.setDestinationCrs( QgsCoordinateReferenceSystem( u"OGC:CRS84"_s ) );
 
   const bool destinationCrsIsRfc7946Compliant = mDestinationCrs.authid() == "OGC:CRS84";
-  const bool sourceCrsIsRfc7946Compliant = mCrs.authid() == "OGC:CRS84";
+  const bool sourceCrsIsRfc7946Compliant = ( mCrs.authid() == "OGC:CRS84" || mCrs.authid() == "EPSG:4326" );
   const bool requiresCRS84geom = mGeoJsonProfile == Qgis::GeoJsonProfile::Rfc7946 || mGeoJsonProfile == Qgis::GeoJsonProfile::JsonFgPlus;
 
   QgsGeometry geom = feature.geometry();
@@ -127,13 +127,8 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
   const bool mainGeometryIsRfc7946Compliant {
     !featureHasM
     && destinationCrsIsRfc7946Compliant
-    && flatType != Qgis::WkbType::CircularString
-    && flatType != Qgis::WkbType::CompoundCurve
-    && flatType != Qgis::WkbType::CurvePolygon
-    && flatType != Qgis::WkbType::MultiCurve
-    && flatType != Qgis::WkbType::MultiSurface
+    && ( flatType == Qgis::WkbType::LineString || flatType == Qgis::WkbType::MultiLineString || flatType == Qgis::WkbType::Polygon || flatType == Qgis::WkbType::MultiPolygon || flatType == Qgis::WkbType::Point || flatType == Qgis::WkbType::MultiPoint || flatType == Qgis::WkbType::GeometryCollection )
   };
-
 
   json featureJson {
     { "type", "Feature" },
@@ -223,17 +218,60 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
       }
     }
 
+    std::function<void( json & )> invertCoords;
+    invertCoords = [&invertCoords]( json &geometry ) {
+      if ( geometry.contains( "coordinates" ) )
+      {
+        invertCoords( geometry["coordinates"] );
+      }
+      else if ( geometry.contains( "geometries" ) )
+      {
+        for ( json &geom : geometry["geometries"] )
+        {
+          invertCoords( geom );
+        }
+      }
+      else if ( geometry.is_array() && geometry.size() > 0 )
+      {
+        if ( geometry[0].is_array() )
+        {
+          for ( json &geom : geometry )
+          {
+            invertCoords( geom );
+          }
+        }
+        else
+        {
+          if ( geometry.size() >= 2 && geometry[0].is_number() && geometry[1].is_number() )
+          {
+            std::swap( geometry[0], geometry[1] );
+          }
+        }
+      }
+    };
+
+    auto addBbox = [&featureJson, &flatType]( const QgsGeometry &geometry ) {
+      if ( flatType == Qgis::WkbType::Point )
+      {
+        // For points, the bbox is just the coordinates of the point (or the points)
+        return;
+      }
+      auto bbox = geometry.boundingBox();
+      featureJson["bbox"] = { bbox.xMinimum(), bbox.yMinimum(), bbox.xMaximum(), bbox.yMaximum() };
+    };
+
     switch ( mGeoJsonProfile )
     {
       case Qgis::GeoJsonProfile::Rfc7946:
+      {
+        featureJson["geometry"] = transformedCRS84Geom.asJsonObject( mPrecision, Qgis::GeoJsonProfile::Rfc7946 );
+        addBbox( transformedCRS84Geom );
+        break;
+      }
       case Qgis::GeoJsonProfile::Legacy:
       {
-        if ( flatType != Qgis::WkbType::Point )
-        {
-          const QgsRectangle box = geom.boundingBox();
-          featureJson["bbox"] = { qgsRound( box.xMinimum(), mPrecision ), qgsRound( box.yMinimum(), mPrecision ), qgsRound( box.xMaximum(), mPrecision ), qgsRound( box.yMaximum(), mPrecision ) };
-        }
         featureJson["geometry"] = geom.asJsonObject( mPrecision, Qgis::GeoJsonProfile::Rfc7946 );
+        addBbox( geom );
         break;
       }
       case Qgis::GeoJsonProfile::JsonFgPlus:
@@ -245,10 +283,15 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
         // PLUS version: always add the fallback geometry as "geometry" member, so that the output is always compliant with RFC7946.
         // If the geometry is not compliant with RFC7946 also add the original geometry as "place" member.
         featureJson["geometry"] = transformedCRS84Geom.asJsonObject( mPrecision, Qgis::GeoJsonProfile::Rfc7946 );
-
+        addBbox( transformedCRS84Geom );
         if ( !mainGeometryIsRfc7946Compliant )
         {
-          featureJson["place"] = geom.asJsonObject( mPrecision, mGeoJsonProfile );
+          json place = geom.asJsonObject( mPrecision, mGeoJsonProfile );
+          if ( mDestinationCrs.hasAxisInverted() )
+          {
+            invertCoords( place );
+          }
+          featureJson["place"] = place;
         }
         break;
       }
@@ -259,7 +302,12 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
         // In the latter case, the "geometry" member is omitted.
         if ( !mainGeometryIsRfc7946Compliant )
         {
-          featureJson["place"] = geom.asJsonObject( mPrecision, mGeoJsonProfile );
+          json place = geom.asJsonObject( mPrecision, mGeoJsonProfile );
+          if ( mDestinationCrs.hasAxisInverted() )
+          {
+            invertCoords( place );
+          }
+          featureJson["place"] = place;
         }
         else
         {
@@ -599,9 +647,9 @@ std::unique_ptr< QgsPoint> parsePointFromGeoJson( const json &coords, bool hasM 
   {
     const double zOrM = coords[2].get< double >();
     if ( hasM )
-      return std::make_unique< QgsPoint >( x, y, std::numeric_limits<double>::quiet_NaN(), z_or_m );
+      return std::make_unique< QgsPoint >( x, y, std::numeric_limits<double>::quiet_NaN(), zOrM );
     else
-      return std::make_unique< QgsPoint >( x, y, z_or_m );
+      return std::make_unique< QgsPoint >( x, y, zOrM );
   }
   else
   {
@@ -721,7 +769,7 @@ std::unique_ptr< QgsPolygon > parsePolygonFromGeoJson( const json &coords, bool 
 
 std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geometry, bool hasMIn = false )
 {
-  const auto hasM = hasM_in || ( geometry.contains( "measures" ) && geometry["measures"].contains( "enabled" ) && geometry["measures"]["enabled"].get<bool>() );
+  const auto hasM = hasMIn || ( geometry.contains( "measures" ) && geometry["measures"].contains( "enabled" ) && geometry["measures"]["enabled"].get<bool>() );
 
   if ( !geometry.is_object() )
   {

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -597,7 +597,7 @@ std::unique_ptr< QgsPoint> parsePointFromGeoJson( const json &coords, bool hasM 
   }
   else if ( coords.size() == 3 )
   {
-    const double z_or_m = coords[2].get< double >();
+    const double zOrM = coords[2].get< double >();
     if ( hasM )
       return std::make_unique< QgsPoint >( x, y, std::numeric_limits<double>::quiet_NaN(), z_or_m );
     else
@@ -719,7 +719,7 @@ std::unique_ptr< QgsPolygon > parsePolygonFromGeoJson( const json &coords, bool 
   return polygon;
 }
 
-std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geometry, bool hasM_in = false )
+std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geometry, bool hasMIn = false )
 {
   const auto hasM = hasM_in || ( geometry.contains( "measures" ) && geometry["measures"].contains( "enabled" ) && geometry["measures"]["enabled"].get<bool>() );
 

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -253,14 +253,15 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
       }
     };
 
-    auto addBbox = [&featureJson, &flatType]( const QgsGeometry &geometry ) {
+    auto addBbox = [&featureJson, &flatType, this]( const QgsGeometry &geometry ) {
       if ( flatType == Qgis::WkbType::Point )
       {
         // For points, the bbox is just the coordinates of the point (or the points)
         return;
       }
       auto bbox = geometry.boundingBox();
-      featureJson["bbox"] = { bbox.xMinimum(), bbox.yMinimum(), bbox.xMaximum(), bbox.yMaximum() };
+      featureJson["bbox"]
+        = { qgsRound( bbox.xMinimum(), this->mPrecision ), qgsRound( bbox.yMinimum(), this->mPrecision ), qgsRound( bbox.xMaximum(), this->mPrecision ), qgsRound( bbox.yMaximum(), this->mPrecision ) };
     };
 
     switch ( mGeoJsonProfile )

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -18,6 +18,9 @@
 #include <nlohmann/json.hpp>
 
 #include "qgsapplication.h"
+#include "qgscircularstring.h"
+#include "qgscompoundcurve.h"
+#include "qgscurvepolygon.h"
 #include "qgsexception.h"
 #include "qgsfeatureid.h"
 #include "qgsfeatureiterator.h"
@@ -26,9 +29,11 @@
 #include "qgsgeometry.h"
 #include "qgslinestring.h"
 #include "qgslogger.h"
+#include "qgsmulticurve.h"
 #include "qgsmultilinestring.h"
 #include "qgsmultipoint.h"
 #include "qgsmultipolygon.h"
+#include "qgsmultisurface.h"
 #include "qgsogrutils.h"
 #include "qgspolygon.h"
 #include "qgsproject.h"
@@ -55,8 +60,8 @@ QgsJsonExporter::QgsJsonExporter( QgsVectorLayer *vectorLayer, int precision )
     mTransform.setSourceCrs( mCrs );
   }
 
-  // Default 4326
-  mDestinationCrs = QgsCoordinateReferenceSystem( u"EPSG:4326"_s );
+  // Default CRS84
+  mDestinationCrs = QgsCoordinateReferenceSystem( u"OGC:CRS84"_s );
   mTransform.setDestinationCrs( mDestinationCrs );
 }
 
@@ -106,9 +111,37 @@ QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVarian
 
 json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, const QVariantMap &extraProperties, const QVariant &id, const QVariantMap &extraMembers ) const
 {
+  // Required by RFC7946, but also needed for JSON-FG profiles if the source (or destination) CRS is not CRS84
+  QgsCoordinateTransform transformToCRS84 { mTransform };
+  transformToCRS84.setDestinationCrs( QgsCoordinateReferenceSystem( u"OGC:CRS84"_s ) );
+
+  const bool destinationCrsIsRfc7946Compliant = mDestinationCrs.authid() == "OGC:CRS84";
+  const bool sourceCrsIsRfc7946Compliant = mCrs.authid() == "OGC:CRS84";
+  const bool requiresCRS84geom = mGeoJsonProfile == Qgis::GeoJsonProfile::Rfc7946 || mGeoJsonProfile == Qgis::GeoJsonProfile::JsonFgPlus;
+
+  QgsGeometry geom = feature.geometry();
+  const bool includeGeometryInformation { !geom.isNull() && mIncludeGeometry };
+
+  bool featureHasM { QgsWkbTypes::hasM( geom.wkbType() ) };
+
+
   json featureJson {
     { "type", "Feature" },
   };
+
+  if ( !mOmitCollectionLevelInformation && ( mGeoJsonProfile == Qgis::GeoJsonProfile::JsonFgPlus || mGeoJsonProfile == Qgis::GeoJsonProfile::JsonFg ) )
+  {
+    featureJson["conformsTo"] = { "http://www.opengis.net/spec/json-fg-1/1.0/conf/core" };
+    if ( includeGeometryInformation )
+    {
+      if ( featureHasM )
+      {
+        featureJson["conformsTo"].push_back( "http://www.opengis.net/spec/json-fg-1/1.0/conf/measures" );
+        featureJson["measures"] = { { "enabled", true } };
+      }
+      QgsJsonUtils::addCrsInfo( featureJson, mDestinationCrs, mGeoJsonProfile );
+    }
+  }
 
   //foreign members
   if ( !extraMembers.isEmpty() )
@@ -142,29 +175,80 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
     featureJson["id"] = feature.id();
   }
 
-  QgsGeometry geom = feature.geometry();
-  if ( !geom.isNull() && mIncludeGeometry )
+  // ////////////////////////////////////////
+  // Geometry handling
+
+  if ( includeGeometryInformation )
   {
-    if ( mCrs.isValid() )
+    // If it is JSON-FG plus we need both CRS84 and the requested CRS
+    QgsGeometry transformedCRS84Geom = geom;
+    if ( mCrs.isValid() && !sourceCrsIsRfc7946Compliant && ( requiresCRS84geom || destinationCrsIsRfc7946Compliant ) )
     {
       try
       {
-        QgsGeometry transformed = geom;
-        if ( mTransformGeometries && transformed.transform( mTransform ) == Qgis::GeometryOperationResult::Success )
-          geom = transformed;
+        transformedCRS84Geom.transform( transformToCRS84 );
       }
       catch ( QgsCsException &cse )
       {
         Q_UNUSED( cse )
       }
     }
-    QgsRectangle box = geom.boundingBox();
-
-    if ( QgsWkbTypes::flatType( geom.wkbType() ) != Qgis::WkbType::Point )
+    // Do we need to transform the main geometry to the destination CRS?
+    if ( mGeoJsonProfile != Qgis::GeoJsonProfile::Rfc7946 )
     {
-      featureJson["bbox"] = { qgsRound( box.xMinimum(), mPrecision ), qgsRound( box.yMinimum(), mPrecision ), qgsRound( box.xMaximum(), mPrecision ), qgsRound( box.yMaximum(), mPrecision ) };
+      if ( destinationCrsIsRfc7946Compliant )
+      {
+        geom = transformedCRS84Geom;
+      }
+      else if ( mCrs.isValid() && mTransformGeometries )
+      {
+        try
+        {
+          geom.transform( mTransform );
+        }
+        catch ( QgsCsException &cse )
+        {
+          Q_UNUSED( cse )
+        }
+      }
     }
-    featureJson["geometry"] = geom.asJsonObject( mPrecision );
+
+    switch ( mGeoJsonProfile )
+    {
+      case Qgis::GeoJsonProfile::Rfc7946:
+      case Qgis::GeoJsonProfile::Legacy:
+      {
+        if ( QgsWkbTypes::flatType( geom.wkbType() ) != Qgis::WkbType::Point )
+        {
+          const QgsRectangle box = geom.boundingBox();
+          featureJson["bbox"] = { qgsRound( box.xMinimum(), mPrecision ), qgsRound( box.yMinimum(), mPrecision ), qgsRound( box.xMaximum(), mPrecision ), qgsRound( box.yMaximum(), mPrecision ) };
+        }
+        featureJson["geometry"] = geom.asJsonObject( mPrecision, Qgis::GeoJsonProfile::Rfc7946 );
+        break;
+      }
+      case Qgis::GeoJsonProfile::JsonFgPlus:
+      {
+        featureJson["geometry"] = transformedCRS84Geom.asJsonObject( mPrecision, Qgis::GeoJsonProfile::Rfc7946 );
+        [[fallthrough]];
+      }
+      case Qgis::GeoJsonProfile::JsonFg:
+      {
+        // If the geometry is a valid GeoJSON geometry (that is, conformant to the GeoJSON RFC7946 specification),
+        // the geometry is encoded as the value of the "geometry" member. The "place" member then has the value null or is omitted.
+        const Qgis::WkbType flatType = QgsWkbTypes::flatType( geom.wkbType() );
+        if ( featureHasM
+             || !destinationCrsIsRfc7946Compliant
+             || ( flatType == Qgis::WkbType::CircularString || flatType == Qgis::WkbType::CompoundCurve || flatType == Qgis::WkbType::CurvePolygon || flatType == Qgis::WkbType::MultiCurve || flatType == Qgis::WkbType::MultiSurface ) )
+        {
+          featureJson["place"] = geom.asJsonObject( mPrecision, mGeoJsonProfile );
+        }
+        else if ( mGeoJsonProfile != Qgis::GeoJsonProfile::JsonFgPlus )
+        {
+          featureJson["geometry"] = geom.asJsonObject( mPrecision, mGeoJsonProfile );
+        }
+        break;
+      }
+    }
   }
   else
   {
@@ -250,6 +334,7 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
     }
   }
   featureJson["properties"] = properties;
+
   return featureJson;
 }
 
@@ -261,13 +346,54 @@ QString QgsJsonExporter::exportFeatures( const QgsFeatureList &features, int ind
 json QgsJsonExporter::exportFeaturesToJsonObject( const QgsFeatureList &features ) const
 {
   json data { { "type", "FeatureCollection" }, { "features", json::array() } };
-
-  QgsJsonUtils::addCrsInfo( data, mDestinationCrs );
-
-  for ( const QgsFeature &feature : std::as_const( features ) )
+  QgsJsonUtils::addCrsInfo( data, mDestinationCrs, mGeoJsonProfile );
+  const bool omitCollectionLevelInformation = mOmitCollectionLevelInformation;
+  mOmitCollectionLevelInformation = true;
+  switch ( mGeoJsonProfile )
   {
-    data["features"].push_back( exportFeatureToJsonObject( feature ) );
+    case Qgis::GeoJsonProfile::Legacy:
+    case Qgis::GeoJsonProfile::Rfc7946:
+    {
+      for ( const QgsFeature &feature : features )
+      {
+        data["features"].push_back( exportFeatureToJsonObject( feature ) );
+      }
+      break;
+    }
+    case Qgis::GeoJsonProfile::JsonFg:
+    case Qgis::GeoJsonProfile::JsonFgPlus:
+    {
+      json conformsTo = json::array( { { "http://www.opengis.net/spec/json-fg-1/1.0/conf/core" } } );
+
+      bool hasCircularArcs = false;
+      bool hasMeasure = false;
+      for ( const QgsFeature &feature : features )
+      {
+        const Qgis::WkbType flatType = QgsWkbTypes::flatType( feature.geometry().wkbType() );
+        if ( flatType == Qgis::WkbType::CircularString || flatType == Qgis::WkbType::CompoundCurve || flatType == Qgis::WkbType::CurvePolygon )
+        {
+          hasCircularArcs = true;
+        }
+        if ( QgsWkbTypes::hasM( feature.geometry().wkbType() ) )
+        {
+          hasMeasure = true;
+        }
+        data["features"].push_back( exportFeatureToJsonObject( feature ) );
+      }
+      if ( hasCircularArcs )
+      {
+        conformsTo.push_back( { "http://www.opengis.net/spec/json-fg-1/1.0/conf/circular-arcs" } );
+      }
+      if ( hasMeasure )
+      {
+        conformsTo.push_back( { "http://www.opengis.net/spec/json-fg-1/1.0/conf/measures" } );
+        data["measures"] = { { "enabled", true } };
+      }
+      data["conformsTo"] = conformsTo;
+      break;
+    }
   }
+  mOmitCollectionLevelInformation = omitCollectionLevelInformation;
   return data;
 }
 
@@ -275,6 +401,16 @@ void QgsJsonExporter::setDestinationCrs( const QgsCoordinateReferenceSystem &des
 {
   mDestinationCrs = destinationCrs;
   mTransform.setDestinationCrs( mDestinationCrs );
+}
+
+Qgis::GeoJsonProfile QgsJsonExporter::geoJsonProfile() const
+{
+  return mGeoJsonProfile;
+}
+
+void QgsJsonExporter::setGeoJsonProfile( Qgis::GeoJsonProfile profile )
+{
+  mGeoJsonProfile = profile;
 }
 
 //
@@ -426,11 +562,11 @@ QVariantList QgsJsonUtils::parseArray( const QString &json, QVariant::Type type 
   return parseArray( json, QgsVariantUtils::variantTypeToMetaType( type ) );
 }
 
-std::unique_ptr< QgsPoint> parsePointFromGeoJson( const json &coords )
+std::unique_ptr< QgsPoint> parsePointFromGeoJson( const json &coords, bool hasM = false )
 {
-  if ( !coords.is_array() || coords.size() < 2 || coords.size() > 3 )
+  if ( !coords.is_array() || coords.size() < 2 || coords.size() > 4 )
   {
-    QgsDebugError( u"JSON Point geometry coordinates must be an array of two or three numbers"_s );
+    QgsDebugError( u"JSON Point geometry coordinates must be an array of two, three or four numbers"_s );
     return nullptr;
   }
 
@@ -440,48 +576,86 @@ std::unique_ptr< QgsPoint> parsePointFromGeoJson( const json &coords )
   {
     return std::make_unique< QgsPoint >( x, y );
   }
+  else if ( coords.size() == 3 )
+  {
+    const double z_or_m = coords[2].get< double >();
+    if ( hasM )
+      return std::make_unique< QgsPoint >( x, y, std::numeric_limits<double>::quiet_NaN(), z_or_m );
+    else
+      return std::make_unique< QgsPoint >( x, y, z_or_m );
+  }
   else
   {
     const double z = coords[2].get< double >();
-    return std::make_unique< QgsPoint >( x, y, z );
+    const double m = coords[3].get< double >();
+    return std::make_unique< QgsPoint >( x, y, z, m );
   }
 }
 
-std::unique_ptr< QgsLineString> parseLineStringFromGeoJson( const json &coords )
+std::unique_ptr< QgsLineString> parseLineStringFromGeoJson( const json &coords, bool hasM = false )
 {
-  if ( !coords.is_array() || coords.size() < 2 )
+  if ( !coords.is_array() )
   {
-    QgsDebugError( u"JSON LineString geometry coordinates must be an array of at least two points"_s );
+    QgsDebugError( u"JSON LineString geometry coordinates must be an array"_s );
     return nullptr;
   }
 
   const std::size_t coordsSize = coords.size();
 
+  if ( coordsSize == 0 )
+  {
+    // Empty LineString is valid, return an empty geometry
+    return std::make_unique< QgsLineString >();
+  }
+
+  if ( coordsSize < 2 )
+  {
+    QgsDebugError( u"JSON LineString geometry coordinates must contain at least two positions"_s );
+    return nullptr;
+  }
+
   QVector< double > x;
   QVector< double > y;
   QVector< double > z;
+  QVector< double > m;
   x.resize( coordsSize );
   y.resize( coordsSize );
   z.resize( coordsSize );
+  m.resize( coordsSize );
 
   double *xOut = x.data();
   double *yOut = y.data();
   double *zOut = z.data();
+  double *mOut = m.data();
   bool hasZ = false;
   for ( const auto &coord : coords )
   {
-    if ( !coord.is_array() || coord.size() < 2 || coord.size() > 3 )
+    if ( !coord.is_array() || coord.size() < 2 || coord.size() > 4 )
     {
-      QgsDebugError( u"JSON LineString geometry coordinates must be an array of two or three numbers"_s );
+      QgsDebugError( u"JSON LineString geometry coordinates must be an array of two, three or four numbers"_s );
       return nullptr;
     }
 
     *xOut++ = coord[0].get< double >();
     *yOut++ = coord[1].get< double >();
-    if ( coord.size() == 3 )
+    if ( coord.size() == 4 )
     {
       *zOut++ = coord[2].get< double >();
-      hasZ = true;
+      *mOut++ = coord[3].get< double >();
+    }
+    else if ( coord.size() == 3 )
+    {
+      if ( hasM )
+      {
+        *mOut++ = coord[2].get< double >();
+        *zOut++ = std::numeric_limits< double >::quiet_NaN();
+      }
+      else
+      {
+        *zOut++ = coord[2].get< double >();
+        *mOut++ = std::numeric_limits< double >::quiet_NaN();
+        hasZ = true;
+      }
     }
     else
     {
@@ -489,19 +663,25 @@ std::unique_ptr< QgsLineString> parseLineStringFromGeoJson( const json &coords )
     }
   }
 
-  return std::make_unique< QgsLineString >( x, y, hasZ ? z : QVector<double>() );
+  return std::make_unique< QgsLineString >( x, y, hasZ ? z : QVector<double>(), hasM ? m : QVector<double>() );
 }
 
-std::unique_ptr< QgsPolygon > parsePolygonFromGeoJson( const json &coords )
+std::unique_ptr< QgsPolygon > parsePolygonFromGeoJson( const json &coords, bool hasM = false )
 {
-  if ( !coords.is_array() || coords.size() < 1 )
+  if ( !coords.is_array() )
   {
     QgsDebugError( u"JSON Polygon geometry coordinates must be an array"_s );
     return nullptr;
   }
 
+  if ( coords.empty() )
+  {
+    // Empty polygon
+    return std::make_unique< QgsPolygon >();
+  }
+
   const std::size_t coordsSize = coords.size();
-  std::unique_ptr< QgsLineString > exterior = parseLineStringFromGeoJson( coords[0] );
+  std::unique_ptr< QgsLineString > exterior = parseLineStringFromGeoJson( coords[0], hasM );
   if ( !exterior )
   {
     return nullptr;
@@ -510,7 +690,7 @@ std::unique_ptr< QgsPolygon > parsePolygonFromGeoJson( const json &coords )
   auto polygon = std::make_unique< QgsPolygon >( exterior.release() );
   for ( std::size_t i = 1; i < coordsSize; ++i )
   {
-    std::unique_ptr< QgsLineString > ring = parseLineStringFromGeoJson( coords[i] );
+    std::unique_ptr< QgsLineString > ring = parseLineStringFromGeoJson( coords[i], hasM );
     if ( !ring )
     {
       return nullptr;
@@ -520,8 +700,10 @@ std::unique_ptr< QgsPolygon > parsePolygonFromGeoJson( const json &coords )
   return polygon;
 }
 
-std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geometry )
+std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geometry, bool hasM_in = false )
 {
+  const auto hasM = hasM_in || ( geometry.contains( "measures" ) && geometry["measures"].contains( "enabled" ) && geometry["measures"]["enabled"].get<bool>() );
+
   if ( !geometry.is_object() )
   {
     QgsDebugError( u"JSON geometry value must be an object"_s );
@@ -544,7 +726,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
     }
 
     const json &coords = geometry["coordinates"];
-    return parsePointFromGeoJson( coords );
+    return parsePointFromGeoJson( coords, hasM );
   }
   else if ( type.compare( "MultiPoint"_L1, Qt::CaseInsensitive ) == 0 )
   {
@@ -566,7 +748,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
     multiPoint->reserve( static_cast< int >( coords.size() ) );
     for ( const auto &pointCoords : coords )
     {
-      std::unique_ptr< QgsPoint > point = parsePointFromGeoJson( pointCoords );
+      std::unique_ptr< QgsPoint > point = parsePointFromGeoJson( pointCoords, hasM );
       if ( !point )
       {
         return nullptr;
@@ -585,7 +767,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
     }
 
     const json &coords = geometry["coordinates"];
-    return parseLineStringFromGeoJson( coords );
+    return parseLineStringFromGeoJson( coords, hasM );
   }
   else if ( type.compare( "MultiLineString"_L1, Qt::CaseInsensitive ) == 0 )
   {
@@ -607,7 +789,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
     multiLineString->reserve( static_cast< int >( coords.size() ) );
     for ( const auto &lineCoords : coords )
     {
-      std::unique_ptr< QgsLineString > line = parseLineStringFromGeoJson( lineCoords );
+      std::unique_ptr< QgsLineString > line = parseLineStringFromGeoJson( lineCoords, hasM );
       if ( !line )
       {
         return nullptr;
@@ -626,9 +808,9 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
     }
 
     const json &coords = geometry["coordinates"];
-    if ( !coords.is_array() || coords.size() < 1 )
+    if ( !coords.is_array() )
     {
-      QgsDebugError( u"JSON Polygon geometry coordinates must be an array of at least one ring"_s );
+      QgsDebugError( u"JSON Polygon geometry coordinates must be an array"_s );
       return nullptr;
     }
 
@@ -664,6 +846,192 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
 
     return multiPolygon;
   }
+  // //////////////////////////////////////////////////////////////////////////////////////////////
+  // Handle JSON-FG types CircularString, CompoundCurve, CurvePolygon, MultiCurve, or MultiSurface.
+  else if ( type.compare( "CircularString"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "coordinates" ) )
+    {
+      QgsDebugError( u"JSON CircularString geometry must contain 'coordinates'"_s );
+      return nullptr;
+    }
+
+    const json &coords = geometry["coordinates"];
+
+    if ( coords.empty() )
+    {
+      return std::move( std::make_unique< QgsCircularString >() );
+    }
+
+    if ( !coords.is_array() || coords.size() % 2 == 0 || coords.size() < 3 )
+    {
+      QgsDebugError( u"JSON CircularString geometry coordinates must be an array of at least 3 coordinates and the total number must be an odd number"_s );
+      return nullptr;
+    }
+
+    const bool hasZ = coords[0].is_array() && ( coords[0].size() > 3 || ( coords[0].size() == 3 && !hasM ) );
+
+    QVector<double> x;
+    x.reserve( coords.size() );
+    QVector<double> y;
+    y.reserve( coords.size() );
+    QVector<double> z;
+    if ( hasZ )
+      z.reserve( coords.size() );
+    QVector<double> m;
+    if ( hasM )
+      m.reserve( coords.size() );
+
+    for ( const auto &pointCoords : coords )
+    {
+      std::unique_ptr< QgsPoint > point = parsePointFromGeoJson( pointCoords, hasM );
+      if ( !point )
+      {
+        QgsDebugError( u"Invalid point in CircularString geometry"_s );
+        return nullptr;
+      }
+      x.append( point->x() );
+      y.append( point->y() );
+      if ( hasZ )
+        z.append( point->z() );
+      if ( hasM )
+        m.append( point->m() );
+    }
+    return std::move( std::make_unique< QgsCircularString >( x, y, z, m ) );
+  }
+  else if ( type.compare( "CompoundCurve"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "geometries" ) )
+    {
+      QgsDebugError( u"JSON CompoundCurve geometry must contain 'geometries'"_s );
+      return nullptr;
+    }
+    const json &geometries = geometry["geometries"];
+    if ( !geometries.is_array() )
+    {
+      QgsDebugError( u"JSON CompoundCurve geometry geometries must be an array"_s );
+      return nullptr;
+    }
+    auto compoundCurve = std::make_unique< QgsCompoundCurve >();
+    for ( const auto &geometry : geometries )
+    {
+      std::unique_ptr< QgsAbstractGeometry > object = parseGeometryFromGeoJson( geometry, hasM );
+      if ( !object )
+      {
+        return nullptr;
+      }
+      const Qgis::WkbType flatType = QgsWkbTypes::flatType( object->wkbType() );
+      if ( flatType != Qgis::WkbType::LineString && flatType != Qgis::WkbType::CircularString )
+      {
+        QgsDebugError( u"JSON CompoundCurve geometries must be of type LineString or CircularString"_s );
+        return nullptr;
+      }
+      compoundCurve->addCurve( static_cast< QgsCurve * >( object.release() ) );
+    }
+    return std::move( compoundCurve );
+  }
+  else if ( type.compare( "CurvePolygon"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "geometries" ) )
+    {
+      QgsDebugError( u"JSON CurvePolygon geometry must contain 'geometries'"_s );
+      return nullptr;
+    }
+    const json &geometries = geometry["geometries"];
+    if ( !geometries.is_array() )
+    {
+      QgsDebugError( u"JSON CurvePolygon geometries must be an array"_s );
+      return nullptr;
+    }
+    auto curvePolygon = std::make_unique< QgsCurvePolygon>();
+    bool isExterior = true;
+    for ( const auto &geometry : geometries )
+    {
+      std::unique_ptr< QgsAbstractGeometry > object = parseGeometryFromGeoJson( geometry, hasM );
+      if ( !object )
+      {
+        return nullptr;
+      }
+      const Qgis::WkbType flatType = QgsWkbTypes::flatType( object->wkbType() );
+      if ( flatType != Qgis::WkbType::LineString && flatType != Qgis::WkbType::CircularString && flatType != Qgis::WkbType::CompoundCurve )
+      {
+        QgsDebugError( u"JSON CurvePolygon geometries must be of type LineString, CircularString or CompoundCurve"_s );
+        return nullptr;
+      }
+      if ( isExterior )
+      {
+        curvePolygon->setExteriorRing( static_cast< QgsCurve * >( object.release() ) );
+        isExterior = false;
+      }
+      else
+      {
+        curvePolygon->addInteriorRing( static_cast< QgsCurve * >( object.release() ) );
+      }
+    }
+    return std::move( curvePolygon );
+  }
+  else if ( type.compare( "MultiCurve"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "geometries" ) )
+    {
+      QgsDebugError( u"JSON MultiCurve geometry must contain 'geometries'"_s );
+      return nullptr;
+    }
+    const json &geometries = geometry["geometries"];
+    if ( !geometries.is_array() )
+    {
+      QgsDebugError( u"JSON MultiCurve geometries must be an array"_s );
+      return nullptr;
+    }
+    auto multiCurve = std::make_unique< QgsMultiCurve>();
+    for ( const auto &geometry : geometries )
+    {
+      std::unique_ptr< QgsAbstractGeometry > object = parseGeometryFromGeoJson( geometry, hasM );
+      if ( !object )
+      {
+        return nullptr;
+      }
+      const Qgis::WkbType flatType = QgsWkbTypes::flatType( object->wkbType() );
+      if ( flatType != Qgis::WkbType::LineString && flatType != Qgis::WkbType::CircularString && flatType != Qgis::WkbType::CompoundCurve )
+      {
+        QgsDebugError( u"JSON MultiCurve geometries must be of type LineString, CircularString or CompoundCurve"_s );
+        return nullptr;
+      }
+      multiCurve->addGeometry( static_cast< QgsCurve * >( object.release() ) );
+    }
+    return std::move( multiCurve );
+  }
+  else if ( type.compare( "MultiSurface"_L1, Qt::CaseInsensitive ) == 0 )
+  {
+    if ( !geometry.contains( "geometries" ) )
+    {
+      QgsDebugError( u"JSON MultiSurface geometry must contain 'geometries'"_s );
+      return nullptr;
+    }
+    const json &geometries = geometry["geometries"];
+    if ( !geometries.is_array() )
+    {
+      QgsDebugError( u"JSON MultiSurface geometries must be an array"_s );
+      return nullptr;
+    }
+    auto multiSurface = std::make_unique< QgsMultiSurface >();
+    for ( const auto &geometry : geometries )
+    {
+      std::unique_ptr< QgsAbstractGeometry > object = parseGeometryFromGeoJson( geometry, hasM );
+      if ( !object )
+      {
+        return nullptr;
+      }
+      const Qgis::WkbType flatType = QgsWkbTypes::flatType( object->wkbType() );
+      if ( flatType != Qgis::WkbType::Polygon && flatType != Qgis::WkbType::CurvePolygon )
+      {
+        QgsDebugError( u"JSON MultiSurface geometries must be of type Polygon or CurvePolygon"_s );
+        return nullptr;
+      }
+      multiSurface->addGeometry( static_cast< QgsSurface * >( object.release() ) );
+    }
+    return std::move( multiSurface );
+  }
   else if ( type.compare( "GeometryCollection"_L1, Qt::CaseInsensitive ) == 0 )
   {
     if ( !geometry.contains( "geometries" ) )
@@ -684,7 +1052,7 @@ std::unique_ptr< QgsAbstractGeometry > parseGeometryFromGeoJson( const json &geo
     collection->reserve( static_cast< int >( geometries.size() ) );
     for ( const auto &geometry : geometries )
     {
-      std::unique_ptr< QgsAbstractGeometry > object = parseGeometryFromGeoJson( geometry );
+      std::unique_ptr< QgsAbstractGeometry > object = parseGeometryFromGeoJson( geometry, hasM );
       if ( !object )
       {
         return nullptr;
@@ -928,13 +1296,24 @@ json QgsJsonUtils::exportAttributesToJsonObject( const QgsFeature &feature, QgsV
   return attrs;
 }
 
-void QgsJsonUtils::addCrsInfo( json &value, const QgsCoordinateReferenceSystem &crs )
+void QgsJsonUtils::addCrsInfo( json &value, const QgsCoordinateReferenceSystem &crs, Qgis::GeoJsonProfile profile )
 {
-  // When user request EPSG:4326 we return a compliant CRS84 lon/lat GeoJSON
-  // so no need to add CRS information
-  if ( crs.authid() == "OGC:CRS84" || crs.authid() == "EPSG:4326" )
+  if ( !crs.isValid() )
     return;
 
-  value["crs"]["type"] = "name";
-  value["crs"]["properties"]["name"] = crs.toOgcUrn().toStdString();
+  switch ( profile )
+  {
+    case Qgis::GeoJsonProfile::Rfc7946:
+    {
+      value["crs"]["type"] = "name";
+      value["crs"]["properties"]["name"] = crs.toOgcUrn().toStdString();
+      break;
+    }
+    case Qgis::GeoJsonProfile::JsonFg:
+    case Qgis::GeoJsonProfile::JsonFgPlus:
+    {
+      value["coordRefSys"] = crs.toOgcUri().toStdString();
+      break;
+    }
+  }
 }

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -1368,6 +1368,12 @@ void QgsJsonUtils::addCrsInfo( json &value, const QgsCoordinateReferenceSystem &
   if ( !crs.isValid() )
     return;
 
+  if ( crs.authid() == "EPSG:4326" || crs.authid() == "CRS:84" )
+  {
+    // per spec, default is WGS84, so no need to add anything
+    return;
+  }
+
   switch ( profile )
   {
     case Qgis::GeoJsonProfile::Legacy:

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -115,8 +115,8 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
   QgsCoordinateTransform transformToCRS84 { mTransform };
   transformToCRS84.setDestinationCrs( QgsCoordinateReferenceSystem( u"OGC:CRS84"_s ) );
 
-  const bool destinationCrsIsRfc7946Compliant = mDestinationCrs.authid() == "OGC:CRS84";
-  const bool sourceCrsIsRfc7946Compliant = ( mCrs.authid() == "OGC:CRS84" || mCrs.authid() == "EPSG:4326" );
+  const bool destinationCrsIsRfc7946Compliant = mDestinationCrs.authid() == "OGC:CRS84" || mDestinationCrs.authid() == "EPSG:4326" || mDestinationCrs.authid() == "CRS:84";
+  const bool sourceCrsIsRfc7946Compliant = ( mCrs.authid() == "OGC:CRS84" || mCrs.authid() == "CRS:84" || mCrs.authid() == "EPSG:4326" );
   const bool requiresCRS84geom = mGeoJsonProfile == Qgis::GeoJsonProfile::Rfc7946 || mGeoJsonProfile == Qgis::GeoJsonProfile::JsonFgPlus;
 
   QgsGeometry geom = feature.geometry();
@@ -187,33 +187,36 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
   {
     // If it is JSON-FG plus we need both CRS84 and the requested CRS
     QgsGeometry transformedCRS84Geom = geom;
-    if ( mCrs.isValid() && !sourceCrsIsRfc7946Compliant && ( requiresCRS84geom || destinationCrsIsRfc7946Compliant ) )
+    if ( mTransformGeometries )
     {
-      try
-      {
-        transformedCRS84Geom.transform( transformToCRS84 );
-      }
-      catch ( QgsCsException &cse )
-      {
-        Q_UNUSED( cse )
-      }
-    }
-    // Do we need to transform the main geometry to the destination CRS?
-    if ( mGeoJsonProfile != Qgis::GeoJsonProfile::Rfc7946 )
-    {
-      if ( destinationCrsIsRfc7946Compliant )
-      {
-        geom = transformedCRS84Geom;
-      }
-      else if ( mCrs.isValid() && mTransformGeometries )
+      if ( mCrs.isValid() && !sourceCrsIsRfc7946Compliant && ( requiresCRS84geom || destinationCrsIsRfc7946Compliant ) )
       {
         try
         {
-          geom.transform( mTransform );
+          transformedCRS84Geom.transform( transformToCRS84 );
         }
         catch ( QgsCsException &cse )
         {
           Q_UNUSED( cse )
+        }
+      }
+      // Do we need to transform the main geometry to the destination CRS?
+      if ( mGeoJsonProfile != Qgis::GeoJsonProfile::Rfc7946 )
+      {
+        if ( destinationCrsIsRfc7946Compliant )
+        {
+          geom = transformedCRS84Geom;
+        }
+        else if ( mCrs.isValid() && mTransformGeometries )
+        {
+          try
+          {
+            geom.transform( mTransform );
+          }
+          catch ( QgsCsException &cse )
+          {
+            Q_UNUSED( cse )
+          }
         }
       }
     }
@@ -1368,7 +1371,7 @@ void QgsJsonUtils::addCrsInfo( json &value, const QgsCoordinateReferenceSystem &
   if ( !crs.isValid() )
     return;
 
-  if ( crs.authid() == "EPSG:4326" || crs.authid() == "CRS:84" )
+  if ( crs.authid() == "EPSG:4326" || crs.authid() == "CRS:84" || crs.authid() == "OGC:CRS84" )
   {
     // per spec, default is WGS84, so no need to add anything
     return;

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -120,9 +120,19 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
   const bool requiresCRS84geom = mGeoJsonProfile == Qgis::GeoJsonProfile::Rfc7946 || mGeoJsonProfile == Qgis::GeoJsonProfile::JsonFgPlus;
 
   QgsGeometry geom = feature.geometry();
-  const bool includeGeometryInformation { !geom.isNull() && mIncludeGeometry };
 
-  bool featureHasM { QgsWkbTypes::hasM( geom.wkbType() ) };
+  const bool includeGeometryInformation { !geom.isNull() && mIncludeGeometry };
+  const Qgis::WkbType flatType = QgsWkbTypes::flatType( feature.geometry().wkbType() );
+  const bool featureHasM { QgsWkbTypes::hasM( geom.wkbType() ) };
+  const bool mainGeometryIsRfc7946Compliant {
+    !featureHasM
+    && destinationCrsIsRfc7946Compliant
+    && flatType != Qgis::WkbType::CircularString
+    && flatType != Qgis::WkbType::CompoundCurve
+    && flatType != Qgis::WkbType::CurvePolygon
+    && flatType != Qgis::WkbType::MultiCurve
+    && flatType != Qgis::WkbType::MultiSurface
+  };
 
 
   json featureJson {
@@ -218,7 +228,7 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
       case Qgis::GeoJsonProfile::Rfc7946:
       case Qgis::GeoJsonProfile::Legacy:
       {
-        if ( QgsWkbTypes::flatType( geom.wkbType() ) != Qgis::WkbType::Point )
+        if ( flatType != Qgis::WkbType::Point )
         {
           const QgsRectangle box = geom.boundingBox();
           featureJson["bbox"] = { qgsRound( box.xMinimum(), mPrecision ), qgsRound( box.yMinimum(), mPrecision ), qgsRound( box.xMaximum(), mPrecision ), qgsRound( box.yMaximum(), mPrecision ) };
@@ -228,21 +238,30 @@ json QgsJsonExporter::exportFeatureToJsonObject( const QgsFeature &feature, cons
       }
       case Qgis::GeoJsonProfile::JsonFgPlus:
       {
-        featureJson["geometry"] = transformedCRS84Geom.asJsonObject( mPrecision, Qgis::GeoJsonProfile::Rfc7946 );
-        [[fallthrough]];
-      }
-      case Qgis::GeoJsonProfile::JsonFg:
-      {
+        // See: https://docs.ogc.org/is/21-045r1/21-045r1.html#_use_of_geometry_andor_place
         // If the geometry is a valid GeoJSON geometry (that is, conformant to the GeoJSON RFC7946 specification),
         // the geometry is encoded as the value of the "geometry" member. The "place" member then has the value null or is omitted.
-        const Qgis::WkbType flatType = QgsWkbTypes::flatType( geom.wkbType() );
-        if ( featureHasM
-             || !destinationCrsIsRfc7946Compliant
-             || ( flatType == Qgis::WkbType::CircularString || flatType == Qgis::WkbType::CompoundCurve || flatType == Qgis::WkbType::CurvePolygon || flatType == Qgis::WkbType::MultiCurve || flatType == Qgis::WkbType::MultiSurface ) )
+
+        // PLUS version: always add the fallback geometry as "geometry" member, so that the output is always compliant with RFC7946.
+        // If the geometry is not compliant with RFC7946 also add the original geometry as "place" member.
+        featureJson["geometry"] = transformedCRS84Geom.asJsonObject( mPrecision, Qgis::GeoJsonProfile::Rfc7946 );
+
+        if ( !mainGeometryIsRfc7946Compliant )
         {
           featureJson["place"] = geom.asJsonObject( mPrecision, mGeoJsonProfile );
         }
-        else if ( mGeoJsonProfile != Qgis::GeoJsonProfile::JsonFgPlus )
+        break;
+      }
+      case Qgis::GeoJsonProfile::JsonFg:
+      {
+        // See: https://docs.ogc.org/is/21-045r1/21-045r1.html#_use_of_geometry_andor_place
+        // Add "geometry" or "place" depending on whether the geometry is compliant with RFC7946 or not.
+        // In the latter case, the "geometry" member is omitted.
+        if ( !mainGeometryIsRfc7946Compliant )
+        {
+          featureJson["place"] = geom.asJsonObject( mPrecision, mGeoJsonProfile );
+        }
+        else
         {
           featureJson["geometry"] = geom.asJsonObject( mPrecision, mGeoJsonProfile );
         }
@@ -346,7 +365,6 @@ QString QgsJsonExporter::exportFeatures( const QgsFeatureList &features, int ind
 json QgsJsonExporter::exportFeaturesToJsonObject( const QgsFeatureList &features ) const
 {
   json data { { "type", "FeatureCollection" }, { "features", json::array() } };
-  QgsJsonUtils::addCrsInfo( data, mDestinationCrs, mGeoJsonProfile );
   const bool omitCollectionLevelInformation = mOmitCollectionLevelInformation;
   mOmitCollectionLevelInformation = true;
   switch ( mGeoJsonProfile )
@@ -364,12 +382,13 @@ json QgsJsonExporter::exportFeaturesToJsonObject( const QgsFeatureList &features
     case Qgis::GeoJsonProfile::JsonFgPlus:
     {
       json conformsTo = json::array( { { "http://www.opengis.net/spec/json-fg-1/1.0/conf/core" } } );
-
+      QgsJsonUtils::addCrsInfo( data, mDestinationCrs, mGeoJsonProfile );
       bool hasCircularArcs = false;
       bool hasMeasure = false;
       for ( const QgsFeature &feature : features )
       {
-        const Qgis::WkbType flatType = QgsWkbTypes::flatType( feature.geometry().wkbType() );
+        const QgsGeometry geom = feature.geometry();
+        const Qgis::WkbType flatType = QgsWkbTypes::flatType( geom.wkbType() );
         if ( flatType == Qgis::WkbType::CircularString || flatType == Qgis::WkbType::CompoundCurve || flatType == Qgis::WkbType::CurvePolygon )
         {
           hasCircularArcs = true;
@@ -1303,6 +1322,7 @@ void QgsJsonUtils::addCrsInfo( json &value, const QgsCoordinateReferenceSystem &
 
   switch ( profile )
   {
+    case Qgis::GeoJsonProfile::Legacy:
     case Qgis::GeoJsonProfile::Rfc7946:
     {
       value["crs"]["type"] = "name";

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -272,13 +272,13 @@ class CORE_EXPORT QgsJsonExporter
 
     /**
      * Returns the GeoJSON profile to use for export.
-     * \since QGIS 4.2
+     * \since QGIS 4.4
      */
     Qgis::GeoJsonProfile geoJsonProfile() const;
 
     /**
      * Sets the GeoJSON profile to use for export. Default profile is RFC7946.
-     * \since QGIS 4.2
+     * \since QGIS 4.4
      */
     void setGeoJsonProfile( Qgis::GeoJsonProfile profile );
 

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -229,7 +229,7 @@ class CORE_EXPORT QgsJsonExporter
     ) const;
 
     /**
-     * Returns a QJsonObject representation of a feature.
+     * Returns a GeoJson representation of a feature.
      * \param feature feature to convert
      * \param extraProperties map of extra attributes to include in feature's properties
      * \param id optional ID to use as GeoJSON feature's ID instead of input feature's ID. If omitted, feature's
@@ -241,7 +241,6 @@ class CORE_EXPORT QgsJsonExporter
     json exportFeatureToJsonObject( const QgsFeature &feature, const QVariantMap &extraProperties = QVariantMap(), const QVariant &id = QVariant(), const QVariantMap &extraMembers = QVariantMap() ) const
       SIP_SKIP;
 
-
     /**
      * Returns a GeoJSON string representation of a list of features (feature collection).
      * \param features features to convert
@@ -252,7 +251,7 @@ class CORE_EXPORT QgsJsonExporter
     QString exportFeatures( const QgsFeatureList &features, int indent = -1 ) const;
 
     /**
-     * Returns a JSON object representation of a list of features (feature collection).
+     * Returns a GeoJSON object representation of a list of features (feature collection).
      * \param features features to convert
      * \returns json object
      * \see exportFeatures()
@@ -270,6 +269,18 @@ class CORE_EXPORT QgsJsonExporter
      * \since QGIS 3.30
      */
     void setDestinationCrs( const QgsCoordinateReferenceSystem &destinationCrs );
+
+    /**
+     * Returns the GeoJSON profile to use for export.
+     * \since QGIS 4.2
+     */
+    Qgis::GeoJsonProfile geoJsonProfile() const;
+
+    /**
+     * Sets the GeoJSON profile to use for export. Default profile is RFC7946.
+     * \since QGIS 4.2
+     */
+    void setGeoJsonProfile( Qgis::GeoJsonProfile profile );
 
   private:
     //! Maximum number of decimal places for geometry coordinates
@@ -307,6 +318,11 @@ class CORE_EXPORT QgsJsonExporter
     QgsCoordinateReferenceSystem mDestinationCrs;
 
     bool mUseFieldFormatters = true;
+
+    //! Whether to omit collection level information (e.g. "measures": "coordRefSys") when exporting a list of features. Default is false.
+    mutable bool mOmitCollectionLevelInformation = false;
+
+    Qgis::GeoJsonProfile mGeoJsonProfile = Qgis::GeoJsonProfile::Legacy;
 };
 
 /**
@@ -455,7 +471,7 @@ class CORE_EXPORT QgsJsonUtils
      * is assumed to be OGC:CRS84 but when user specifically request a different CRS, this method
      * adds this information in the JSON output
      */
-    static void addCrsInfo( json &value, const QgsCoordinateReferenceSystem &crs ) SIP_SKIP;
+    static void addCrsInfo( json &value, const QgsCoordinateReferenceSystem &crs, Qgis::GeoJsonProfile profile = Qgis::GeoJsonProfile::Legacy ) SIP_SKIP;
 };
 
 #endif // QGSJSONUTILS_H

--- a/tests/src/python/test_qgsjsonutils.py
+++ b/tests/src/python/test_qgsjsonutils.py
@@ -1966,8 +1966,10 @@ class TestQgsJsonUtils(QgisTestCase):
         _test_rfc7946_crs(self, 32632, (1315361.91, 4809599.55))
         _test_rfc7946_crs(self, 3857, (2115070.32, 5311971.84))
 
-    def test_circularstring_export_15_point(self):
+    def test_circularstring_export_11_points_limit(self):
+        # Test > 11 points circularstring is exported correctly with the 11 points limit in JSON-FG+ profile
 
+        # 15 points
         wkt = "CIRCULARSTRING M (0 0 2, 1 1 4, 2 0 5, 3 1 6, 4 0 7, 5 1 8, 6 0 9, 7 1 10, 8 0 11, 9 1 12, 10 0 13, 11 1 14, 12 0 15, 13 1 16, 14 0 17)"
         vl = QgsVectorLayer(f"{wkt}?crs=epsg:4326", "test", "memory")
         f = QgsFeature()
@@ -2013,6 +2015,18 @@ class TestQgsJsonUtils(QgisTestCase):
                 },
             ],
         )
+
+        # 11 points
+        wkt = "CIRCULARSTRING M (0 0 2, 1 1 4, 2 0 5, 3 1 6, 4 0 7, 5 1 8, 6 0 9, 7 1 10, 8 0 11, 9 1 12, 10 0 13)"
+        vl = QgsVectorLayer(f"{wkt}?crs=epsg:4326", "test", "memory")
+        f = QgsFeature()
+        f.setGeometry(QgsGeometry.fromWkt(wkt))
+        self.assertTrue(vl.dataProvider().addFeatures([f]))
+        exporter = QgsJsonExporter(vl)
+        exporter.setGeoJsonProfile(Qgis.GeoJsonProfile.JsonFgPlus)
+        j = json.loads(exporter.exportFeatures([f]))
+        self.assertEqual(j["features"][0]["place"]["type"], "CircularString")
+        self.assertEqual(len(j["features"][0]["place"]["coordinates"]), 11)
 
     def test_no_geometry_features(self):
 

--- a/tests/src/python/test_qgsjsonutils.py
+++ b/tests/src/python/test_qgsjsonutils.py
@@ -17,6 +17,8 @@ from qgis.core import (
     NULL,
     Qgis,
     QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsCoordinateTransformContext,
     QgsEditorWidgetSetup,
     QgsFeature,
     QgsField,
@@ -1648,12 +1650,20 @@ class TestQgsJsonUtils(QgisTestCase):
         )
         self.assertTrue(res.isNull())
 
-    def _round_trip(self, wkt, expected=None, profile=Qgis.GeoJsonProfile.JsonFg):
+    def _round_trip(
+        self,
+        wkt,
+        expected=None,
+        profile=Qgis.GeoJsonProfile.JsonFg,
+        in_crs=None,
+        out_crs=None,
+    ):
 
         geom = QgsGeometry.fromWkt(wkt)
         wkb_type = geom.wkbType()
         exporter = QgsJsonExporter()
         exporter.setGeoJsonProfile(profile)
+
         f = QgsFeature()
         f.setGeometry(geom)
 
@@ -1833,11 +1843,10 @@ class TestQgsJsonUtils(QgisTestCase):
             "GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4), LINESTRING ZM (0 0 1 2, 1 1 3 4), POLYGON ZM ((0 0 1 2, 4 0 1 2, 4 4 1 2, 0 4 1 2, 0 0 1 2)))"
         )
 
-    def test_jsonfg_crs(self):
-
-        vl = QgsVectorLayer("Point?crs=epsg:3857", "test", "memory")
+    def _test_jsonfg_crs(self, crs, coords):
+        vl = QgsVectorLayer(f"Point?crs=epsg:{crs}", "test", "memory")
         f = QgsFeature()
-        f.setGeometry(QgsGeometry.fromWkt("POINT (2116003 5323382)"))
+        f.setGeometry(QgsGeometry.fromWkt(f"POINT ( {coords[0]} {coords[1]} )"))
         vl.dataProvider().addFeatures([f])
 
         exporter = QgsJsonExporter(vl)
@@ -1867,12 +1876,8 @@ class TestQgsJsonUtils(QgisTestCase):
         self.assertAlmostEqual(
             j["features"][0]["geometry"]["coordinates"][1], 43, places=0
         )
-        self.assertAlmostEqual(
-            j["features"][0]["place"]["coordinates"][0], 2116003, places=0
-        )
-        self.assertAlmostEqual(
-            j["features"][0]["place"]["coordinates"][1], 5323382, places=0
-        )
+        self.assertEqual(int(j["features"][0]["place"]["coordinates"][0]), 2115070)
+        self.assertEqual(int(j["features"][0]["place"]["coordinates"][1]), 5311971)
 
         # Export to EPSG:3111
         exporter.setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:32632"))
@@ -1880,24 +1885,133 @@ class TestQgsJsonUtils(QgisTestCase):
         self.assertEqual(
             j["coordRefSys"], "http://www.opengis.net/def/crs/EPSG/0/32632"
         )
-        self.assertAlmostEqual(
-            j["features"][0]["geometry"]["coordinates"][0], 19, places=0
-        )
-        self.assertAlmostEqual(
-            j["features"][0]["geometry"]["coordinates"][1], 43, places=0
-        )
-        self.assertAlmostEqual(
-            j["features"][0]["place"]["coordinates"][0], 1315042, places=0
-        )
-        self.assertAlmostEqual(
-            j["features"][0]["place"]["coordinates"][1], 4818009, places=0
-        )
+        self.assertEqual(int(j["features"][0]["geometry"]["coordinates"][0]), 19)
+        self.assertEqual(int(j["features"][0]["geometry"]["coordinates"][1]), 43)
+        self.assertEqual(int(j["features"][0]["place"]["coordinates"][0]), 1315361)
+        self.assertEqual(int(j["features"][0]["place"]["coordinates"][1]), 4809599)
 
         # Loading back the JSON should give us the geometry in 32632
         features = QgsJsonUtils.stringToFeatureList(json.dumps(j))
         self.assertEqual(len(features), 1)
         self.assertTrue(
-            compareWkt(features[0].geometry().asWkt(), "POINT (1315042 4818009)", tol=1)
+            compareWkt(features[0].geometry().asWkt(), "POINT (1315361 4809599)", tol=1)
+        )
+
+        # Export to 4258 which has lat/long order
+        exporter.setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:4258"))
+
+        j = json.loads(exporter.exportFeatures([f]))
+        self.assertEqual(j["coordRefSys"], "http://www.opengis.net/def/crs/EPSG/0/4258")
+        self.assertEqual(int(j["features"][0]["geometry"]["coordinates"][0]), 19)
+        self.assertEqual(int(j["features"][0]["geometry"]["coordinates"][1]), 43)
+        self.assertEqual(int(j["features"][0]["place"]["coordinates"][0]), 43)
+        self.assertEqual(int(j["features"][0]["place"]["coordinates"][1]), 19)
+
+    def test_jsonfg_plus_crs(self):
+
+        self._test_jsonfg_crs(4326, (19, 43))
+        self._test_jsonfg_crs(4258, (19, 43))
+        self._test_jsonfg_crs(32632, (1315361.91, 4809599.55))
+        self._test_jsonfg_crs(3857, (2115070.32, 5311971.84))
+
+        # Test complex geometries ZM coordinates are exported in the correct order and with the correct CRS
+        # MULTISURFACE in 4258
+        wkt = "MULTISURFACE ZM (CURVEPOLYGON ZM (CIRCULARSTRING ZM ( 0 0 1 2, 4 0 1 2, 4 4 1 2, 0 4 1 2, 0 0 1 2),(1 1 3 4, 3 3 3 4, 3 1 3 4, 1 1 3 4)), CURVEPOLYGON ZM ((10 10 3 4, 14 12 3 4, 11 10 3 4, 10 10 3 4), (11 11 4 1, 11.5 11 4 2, 11 11.5 4 2, 11 11 4 1)))"
+        vl = QgsVectorLayer(f"{wkt}?crs=epsg:4258", "test", "memory")
+        f = QgsFeature()
+        f.setGeometry(QgsGeometry.fromWkt(wkt))
+        self.assertTrue(vl.dataProvider().addFeatures([f]))
+
+        # Export to 32632 and check we get the expected geometry back when loading the JSON
+        exporter = QgsJsonExporter(vl)
+        exporter.setGeoJsonProfile(Qgis.GeoJsonProfile.JsonFgPlus)
+        exporter.setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:32632"))
+        j_str = exporter.exportFeatures([f])
+        features = QgsJsonUtils.stringToFeatureList(j_str)
+        geom = features[0].geometry()
+        geom.transform(
+            QgsCoordinateTransform(
+                QgsCoordinateReferenceSystem("EPSG:32632"),
+                QgsCoordinateReferenceSystem("EPSG:4258"),
+                QgsCoordinateTransformContext(),
+            )
+        )
+        geom_wkt = geom.asWkt()
+        self.assertTrue(
+            compareWkt(geom_wkt, wkt, tol=0.01), f"Expected {wkt} but got {geom_wkt}"
+        )
+
+    def test_rfc7946_crs(self):
+        """Test that when exporting to RFC7946, the CRS is always CRS84 and coordinates are in longitude/latitude order"""
+
+        def _test_rfc7946_crs(self, crs, coords):
+            vl = QgsVectorLayer(f"Point?crs=epsg:{crs}", "test", "memory")
+            f = QgsFeature()
+            f.setGeometry(QgsGeometry.fromWkt(f"POINT ( {coords[0]} {coords[1]} )"))
+            vl.dataProvider().addFeatures([f])
+
+            exporter = QgsJsonExporter(vl)
+            exporter.setGeoJsonProfile(Qgis.GeoJsonProfile.Rfc7946)
+            j = json.loads(exporter.exportFeatures([f]))
+
+            self.assertAlmostEqual(
+                j["features"][0]["geometry"]["coordinates"][0], 19, places=0
+            )
+            self.assertAlmostEqual(
+                j["features"][0]["geometry"]["coordinates"][1], 43, places=0
+            )
+
+        _test_rfc7946_crs(self, 4326, (19, 43))
+        _test_rfc7946_crs(self, 4258, (19, 43))
+        _test_rfc7946_crs(self, 32632, (1315361.91, 4809599.55))
+        _test_rfc7946_crs(self, 3857, (2115070.32, 5311971.84))
+
+    def test_circularstring_export_15_point(self):
+
+        wkt = "CIRCULARSTRING M (0 0 2, 1 1 4, 2 0 5, 3 1 6, 4 0 7, 5 1 8, 6 0 9, 7 1 10, 8 0 11, 9 1 12, 10 0 13, 11 1 14, 12 0 15, 13 1 16, 14 0 17)"
+        vl = QgsVectorLayer(f"{wkt}?crs=epsg:4326", "test", "memory")
+        f = QgsFeature()
+        f.setGeometry(QgsGeometry.fromWkt(wkt))
+        self.assertTrue(vl.dataProvider().addFeatures([f]))
+        exporter = QgsJsonExporter(vl)
+        exporter.setGeoJsonProfile(Qgis.GeoJsonProfile.JsonFgPlus)
+        j = json.loads(exporter.exportFeatures([f]))
+        self.assertEqual(
+            len(j["features"][0]["place"]["geometries"][0]["coordinates"]), 11
+        )
+        self.assertEqual(
+            len(j["features"][0]["place"]["geometries"][1]["coordinates"]), 5
+        )
+        self.assertEqual(
+            j["features"][0]["place"]["geometries"],
+            [
+                {
+                    "coordinates": [
+                        [0.0, 0.0, 2.0],
+                        [1.0, 1.0, 4.0],
+                        [2.0, 0.0, 5.0],
+                        [3.0, 1.0, 6.0],
+                        [4.0, 0.0, 7.0],
+                        [5.0, 1.0, 8.0],
+                        [6.0, 0.0, 9.0],
+                        [7.0, 1.0, 10.0],
+                        [8.0, 0.0, 11.0],
+                        [9.0, 1.0, 12.0],
+                        [10.0, 0.0, 13.0],
+                    ],
+                    "type": "CircularString",
+                },
+                {
+                    "coordinates": [
+                        [10.0, 0.0, 13.0],
+                        [11.0, 1.0, 14.0],
+                        [12.0, 0.0, 15.0],
+                        [13.0, 1.0, 16.0],
+                        [14.0, 0.0, 17.0],
+                    ],
+                    "type": "CircularString",
+                },
+            ],
         )
 
     def test_no_geometry_features(self):

--- a/tests/src/python/test_qgsjsonutils.py
+++ b/tests/src/python/test_qgsjsonutils.py
@@ -1781,6 +1781,20 @@ class TestQgsJsonUtils(QgisTestCase):
             "MULTISURFACE M (CURVEPOLYGON M (CIRCULARSTRING M ( 0 0 1, 4 0 1, 4 4 1, 0 4 1, 0 0 1),(1 1 2, 3 3 2, 3 1 2, 1 1 2)), CURVEPOLYGON M ((10 10 3, 14 12 3, 11 10 3, 10 10 3), (11 11 4, 11.5 11 4, 11 11.5 4, 11 11 4)))"
         )
 
+        # Multi
+        self._round_trip_jsonfg_profiles("MULTIPOINT M ((1 2 3), (4 5 6))")
+        self._round_trip_jsonfg_profiles(
+            "MULTILINESTRING M ((0 0 1, 1 1 2), (2 2 3, 3 3 4))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "MULTIPOLYGON M (((0 0 1, 4 0 1, 4 4 1, 0 4 1, 0 0 1)), ((10 10 3, 14 12 3, 11 10 3, 10 10 3), (11 11 4, 11.5 11 4, 11 11.5 4, 11 11 4)))"
+        )
+
+        # Geometry collection
+        self._round_trip_jsonfg_profiles(
+            "GEOMETRYCOLLECTION M (POINT M (1 2 3), LINESTRING M (0 0 1, 1 1 2))"
+        )
+
     def test_jsonfg_zm_values(self):
 
         # Test ZM values are preserved in round trip
@@ -1803,6 +1817,20 @@ class TestQgsJsonUtils(QgisTestCase):
         )
         self._round_trip_jsonfg_profiles(
             "MULTISURFACE ZM (CURVEPOLYGON ZM (CIRCULARSTRING ZM ( 0 0 1 2, 4 0 1 2, 4 4 1 2, 0 4 1 2, 0 0 1 2),(1 1 3 4, 3 3 3 4, 3 1 3 4, 1 1 3 4)), CURVEPOLYGON ZM ((10 10 3 4, 14 12 3 4, 11 10 3 4, 10 10 3 4), (11 11 4 1, 11.5 11 4 2, 11 11.5 4 2, 11 11 4 1)))"
+        )
+
+        # Multi
+        self._round_trip_jsonfg_profiles("MULTIPOINT ZM ((1 2 3 4), (5 6 7 8))")
+        self._round_trip_jsonfg_profiles(
+            "MULTILINESTRING ZM ((0 0 1 2, 1 1 3 4), (2 2 5 6, 3 3 7 8))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "MULTIPOLYGON ZM (((0 0 1 2, 4 0 1 2, 4 4 1 2, 0 4 1 2, 0 0 1 2)), ((10 10 3 4, 14 12 3 4, 11 10 3 4, 10 10 3 4), (11 11 4 1, 11.5 11 4 2, 11 11.5 4 2, 11 11 4 1)))"
+        )
+
+        # Geometry collection
+        self._round_trip_jsonfg_profiles(
+            "GEOMETRYCOLLECTION ZM (POINT ZM (1 2 3 4), LINESTRING ZM (0 0 1 2, 1 1 3 4), POLYGON ZM ((0 0 1 2, 4 0 1 2, 4 4 1 2, 0 4 1 2, 0 0 1 2)))"
         )
 
     def test_jsonfg_crs(self):
@@ -1845,6 +1873,54 @@ class TestQgsJsonUtils(QgisTestCase):
         self.assertAlmostEqual(
             j["features"][0]["place"]["coordinates"][1], 5323382, places=0
         )
+
+        # Export to EPSG:3111
+        exporter.setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:32632"))
+        j = json.loads(exporter.exportFeatures([f]))
+        self.assertEqual(
+            j["coordRefSys"], "http://www.opengis.net/def/crs/EPSG/0/32632"
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["geometry"]["coordinates"][0], 19, places=0
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["geometry"]["coordinates"][1], 43, places=0
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["place"]["coordinates"][0], 1315042, places=0
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["place"]["coordinates"][1], 4818009, places=0
+        )
+
+        # Loading back the JSON should give us the geometry in 32632
+        features = QgsJsonUtils.stringToFeatureList(json.dumps(j))
+        self.assertEqual(len(features), 1)
+        self.assertTrue(
+            compareWkt(features[0].geometry().asWkt(), "POINT (1315042 4818009)", tol=1)
+        )
+
+    def test_no_geometry_features(self):
+
+        # Test that features with no geometry are exported correctly
+        vl = QgsVectorLayer("NoGeometry?field=name:string", "test", "memory")
+
+        f1 = QgsFeature(vl.fields())
+        f1.setAttribute("name", "Feature 1")
+        f2 = QgsFeature(vl.fields())
+        f2.setAttribute("name", "Feature 2")
+        vl.dataProvider().addFeatures([f1, f2])
+
+        exporter = QgsJsonExporter(vl)
+        exporter.setGeoJsonProfile(Qgis.GeoJsonProfile.JsonFgPlus)
+        j = json.loads(exporter.exportFeatures([f1, f2]))
+
+        self.assertEqual(len(j["features"]), 2)
+
+        self.assertEqual(j["features"][0]["properties"]["name"], "Feature 1")
+        self.assertEqual(j["features"][0]["geometry"], None)
+        self.assertEqual(j["features"][1]["properties"]["name"], "Feature 2")
+        self.assertEqual(j["features"][1]["geometry"], None)
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsjsonutils.py
+++ b/tests/src/python/test_qgsjsonutils.py
@@ -10,10 +10,12 @@ __author__ = "Nyall Dawson"
 __date__ = "3/05/2016"
 __copyright__ = "Copyright 2016, The QGIS Project"
 
+import json
 import unittest
 
 from qgis.core import (
     NULL,
+    Qgis,
     QgsCoordinateReferenceSystem,
     QgsEditorWidgetSetup,
     QgsFeature,
@@ -1103,7 +1105,7 @@ class TestQgsJsonUtils(QgisTestCase):
                     "coordinates": [1,2,3,4]
                 }"""
         )
-        self.assertTrue(res.isNull())
+        self.assertEqual(res.wkbType(), Qgis.WkbType.PointZM)
         res = QgsJsonUtils.geometryFromGeoJson(
             """{
                     "type": "Point"
@@ -1160,6 +1162,13 @@ class TestQgsJsonUtils(QgisTestCase):
             """{
                     "type": "MultiPoint",
                     "coordinates": [[1,2,3,4]]
+                }"""
+        )
+        self.assertEqual(res.wkbType(), Qgis.WkbType.MultiPointZM)
+        res = QgsJsonUtils.geometryFromGeoJson(
+            """{
+                    "type": "MultiPoint",
+                    "coordinates": [[1,2,3,4,5]]
                 }"""
         )
         self.assertTrue(res.isNull())
@@ -1639,16 +1648,203 @@ class TestQgsJsonUtils(QgisTestCase):
         )
         self.assertTrue(res.isNull())
 
+    def _round_trip(self, wkt, expected=None, profile=Qgis.GeoJsonProfile.JsonFg):
+
+        geom = QgsGeometry.fromWkt(wkt)
+        wkb_type = geom.wkbType()
+        exporter = QgsJsonExporter()
+        exporter.setGeoJsonProfile(profile)
+        f = QgsFeature()
+        f.setGeometry(geom)
+
+        # Export single feature
+        j = json.loads(exporter.exportFeature(f))
+        features = QgsJsonUtils.stringToFeatureList(json.dumps(j))
+        self.assertEqual(len(features), 1)
+
+        if expected is None:
+            self.assertEqual(
+                features[0].geometry().wkbType(),
+                wkb_type,
+                f"WKB type {profile} mismatch: {features[0].geometry().wkbType()} != {wkb_type}\n{j}",
+            )
+
+        if expected is not None:
+            wkt = expected
+
+        if expected == "":
+            self.assertIn(
+                features[0].geometry().asWkt(),
+                "EMPTY",
+                f"Expected empty geometry for {profile} but got: {features[0].geometry().asWkt()}\n{j}",
+            )
+
+        # Now export the features as a collection
+        j = json.loads(exporter.exportFeatures([features[0]]))
+        features = QgsJsonUtils.stringToFeatureList(json.dumps(j))
+        self.assertEqual(len(features), 1)
+
+        if expected is None:
+            self.assertEqual(
+                features[0].geometry().wkbType(),
+                wkb_type,
+                f"WKB type mismatch for collection: {features[0].geometry().wkbType()} != {wkb_type}\n{j}",
+            )
+
+        self.assertTrue(
+            compareWkt(features[0].geometry().asWkt(), wkt),
+            f"Round trip failed for collection: {features[0].geometry().asWkt()} != {wkt}\n{j}",
+        )
+
+        return j
+
+    def _round_trip_jsonfg_profiles(self, wkt, expected=None):
+        for profile in (Qgis.GeoJsonProfile.JsonFg, Qgis.GeoJsonProfile.JsonFgPlus):
+            self._round_trip(wkt, expected, profile)
+
     def test_as_geojson(self):
         """Test GeoJson round trip with JSON-FG profile"""
 
         # CircularString
-        wkt = "CIRCULARSTRING (0 0, 1 1, 2 2)"
-        geom = QgsGeometry.fromWkt(wkt)
-        self.assertTrue(compareWkt(geom.asWkt(), wkt))
-        j = geom.asGeoJson(0, Qgis.GeoJsonProfile.JsonFg)
-        geom2 = QgsJsonUtils.geometryFromGeoJson(j)
-        self.assertTrue(compareWkt(geom2.asWkt(), wkt))
+        self._round_trip_jsonfg_profiles("CIRCULARSTRING (0 0, 1 1, 2 0)")
+        # CompoundCurve
+        self._round_trip_jsonfg_profiles(
+            "COMPOUNDCURVE (CIRCULARSTRING (0 0, 1 1, 2 0), (2 0, 3 1, 3 2))"
+        )
+        # CurvePolygon
+        self._round_trip_jsonfg_profiles(
+            "CURVEPOLYGON(CIRCULARSTRING(0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 3 3, 3 1, 1 1))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING (0 0,1 -1,2 0),(2 0,0 0)))"
+        )
+        # Note: this is not GEOS valid (example taken from https://postgis.net/docs/using_postgis_dbmanagement.html#MultiSurface)
+        self._round_trip_jsonfg_profiles(
+            "CURVEPOLYGON((10 10, 14 12, 11 10, 10 10), (11 11, 11.5 11, 11 11.5, 11 11))"
+        )
+        # MultiCurve
+        self._round_trip_jsonfg_profiles(
+            "MULTICURVE(LINESTRING(0 0, 2 2), CIRCULARSTRING(2 2, 4 1, 6 2))"
+        )
+        # MultiSurfaces
+        self._round_trip_jsonfg_profiles(
+            "MULTISURFACE (CURVEPOLYGON(CIRCULARSTRING( 0 0, 4 0, 4 4, 0 4, 0 0),(1 1, 3 3, 3 1, 1 1)), CURVEPOLYGON((10 10, 14 12, 11 10, 10 10), (11 11, 11.5 11, 11 11.5, 11 11)))"
+        )
+
+        # Test empty geometries
+        self._round_trip_jsonfg_profiles("POLYGON EMPTY")
+        self._round_trip_jsonfg_profiles("CIRCULARSTRING EMPTY")
+        self._round_trip_jsonfg_profiles("COMPOUNDCURVE EMPTY")
+        self._round_trip_jsonfg_profiles("CURVEPOLYGON EMPTY")
+        self._round_trip_jsonfg_profiles("MULTICURVE EMPTY")
+        self._round_trip_jsonfg_profiles("MULTISURFACE EMPTY")
+
+        # Test Z values - should be preserved in round trip
+        self._round_trip_jsonfg_profiles("LINESTRING Z (0 0 1, 1 1 2)")
+        self._round_trip_jsonfg_profiles(
+            "POLYGON Z ((0 0 1, 4 0 1, 4 4 1, 0 4 1, 0 0 1))"
+        )
+        self._round_trip("POINT Z (1 2 3)")
+        self._round_trip("CIRCULARSTRING Z (0 0 1, 1 1 2, 2 0 3)")
+        self._round_trip_jsonfg_profiles(
+            "COMPOUNDCURVE Z (CIRCULARSTRING Z (0 0 1, 1 1 2, 2 0 3), (2 0 3, 3 1 4, 3 2 5))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "CURVEPOLYGON Z (CIRCULARSTRING Z (0 0 1, 4 0 1, 4 4 1, 0 4 1, 0 0 1), (1 1 2, 3 3 2, 3 1 2, 1 1 2))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "MULTICURVE Z (LINESTRING Z (0 0 1, 2 2 3), CIRCULARSTRING Z (2 2 3, 4 1 4, 6 2 5))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "MULTISURFACE Z (CURVEPOLYGON Z (CIRCULARSTRING Z ( 0 0 1, 4 0 1, 4 4 1, 0 4 1, 0 0 1),(1 1 2, 3 3 2, 3 1 2, 1 1 2)), CURVEPOLYGON Z ((10 10 3, 14 12 3, 11 10 3, 10 10 3), (11 11 4, 11.5 11 4, 11 11.5 4, 11 11 4)))"
+        )
+
+    def test_jsonfg_m_values(self):
+
+        # Test M values are preserved in round trip
+        self._round_trip_jsonfg_profiles("POINT M (1 2 3)")
+        self._round_trip_jsonfg_profiles("LINESTRING M (0 0 1, 1 1 2)")
+        self._round_trip_jsonfg_profiles(
+            "POLYGON M ((0 0 1, 4 0 1, 4 4 1, 0 4 1, 0 0 1))"
+        )
+        self._round_trip_jsonfg_profiles("CIRCULARSTRING M (0 0 1, 1 1 2, 2 0 3)")
+        self._round_trip_jsonfg_profiles(
+            "COMPOUNDCURVE M (CIRCULARSTRING M (0 0 1, 1 1 2, 2 0 3), (2 0 3, 3 1 4, 3 2 5))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "CURVEPOLYGON M (CIRCULARSTRING M (0 0 1, 4 0 1, 4 4 1, 0 4 1, 0 0 1), (1 1 2, 3 3 2, 3 1 2, 1 1 2))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "MULTICURVE M (LINESTRING M (0 0 1, 2 2 3), CIRCULARSTRING M (2 2 3, 4 1 4, 6 2 5))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "MULTISURFACE M (CURVEPOLYGON M (CIRCULARSTRING M ( 0 0 1, 4 0 1, 4 4 1, 0 4 1, 0 0 1),(1 1 2, 3 3 2, 3 1 2, 1 1 2)), CURVEPOLYGON M ((10 10 3, 14 12 3, 11 10 3, 10 10 3), (11 11 4, 11.5 11 4, 11 11.5 4, 11 11 4)))"
+        )
+
+    def test_jsonfg_zm_values(self):
+
+        # Test ZM values are preserved in round trip
+        self._round_trip_jsonfg_profiles("POINT ZM (1 2 3 4)")
+        self._round_trip_jsonfg_profiles("LINESTRING ZM (0 0 1 2, 1 1 3 4)")
+        self._round_trip_jsonfg_profiles(
+            "POLYGON ZM ((0 0 1 2, 4 0 1 2, 4 4 1 2, 0 4 1 2, 0 0 1 2))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "CIRCULARSTRING ZM (0 0 1 2, 1 1 3 4, 2 0 5 6)"
+        )
+        self._round_trip_jsonfg_profiles(
+            "COMPOUNDCURVE ZM (CIRCULARSTRING ZM (0 0 1 2, 1 1 3 4, 2 0 5 6), (2 0 5 6, 3 1 7 8, 3 2 9 10))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "CURVEPOLYGON ZM (CIRCULARSTRING ZM (0 0 1 2, 4 0 1 2, 4 4 1 2, 0 4 1 2, 0 0 1 2), (1 1 3 4, 3 3 3 4, 3 1 3 4, 1 1 3 4))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "MULTICURVE ZM (LINESTRING ZM (0 0 1 2, 2 2 3 4), CIRCULARSTRING ZM (2 2 3 4, 4 1 5 6, 6 2 7 8))"
+        )
+        self._round_trip_jsonfg_profiles(
+            "MULTISURFACE ZM (CURVEPOLYGON ZM (CIRCULARSTRING ZM ( 0 0 1 2, 4 0 1 2, 4 4 1 2, 0 4 1 2, 0 0 1 2),(1 1 3 4, 3 3 3 4, 3 1 3 4, 1 1 3 4)), CURVEPOLYGON ZM ((10 10 3 4, 14 12 3 4, 11 10 3 4, 10 10 3 4), (11 11 4 1, 11.5 11 4 2, 11 11.5 4 2, 11 11 4 1)))"
+        )
+
+    def test_jsonfg_crs(self):
+
+        vl = QgsVectorLayer("Point?crs=epsg:3857", "test", "memory")
+        f = QgsFeature()
+        f.setGeometry(QgsGeometry.fromWkt("POINT (2116003 5323382)"))
+        vl.dataProvider().addFeatures([f])
+
+        exporter = QgsJsonExporter(vl)
+        exporter.setGeoJsonProfile(Qgis.GeoJsonProfile.JsonFgPlus)
+        j = json.loads(exporter.exportFeatures([f]))
+        self.assertAlmostEqual(
+            j["features"][0]["geometry"]["coordinates"][0], 19, places=0
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["geometry"]["coordinates"][1], 43, places=0
+        )
+        self.assertEqual(
+            j["conformsTo"], [["http://www.opengis.net/spec/json-fg-1/1.0/conf/core"]]
+        )
+        self.assertEqual(
+            j["coordRefSys"], "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        )
+
+        # Export to 3857
+        exporter.setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:3857"))
+        j = json.loads(exporter.exportFeatures([f]))
+        # Check we have both geometry and place
+        self.assertEqual(j["coordRefSys"], "http://www.opengis.net/def/crs/EPSG/0/3857")
+        self.assertAlmostEqual(
+            j["features"][0]["geometry"]["coordinates"][0], 19, places=0
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["geometry"]["coordinates"][1], 43, places=0
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["place"]["coordinates"][0], 2116003, places=0
+        )
+        self.assertAlmostEqual(
+            j["features"][0]["place"]["coordinates"][1], 5323382, places=0
+        )
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsjsonutils.py
+++ b/tests/src/python/test_qgsjsonutils.py
@@ -31,6 +31,7 @@ from qgis.core import (
 )
 from qgis.PyQt.QtCore import QT_VERSION_STR, QLocale, Qt, QVariant
 from qgis.testing import QgisTestCase, start_app
+from utilities import compareWkt
 
 start_app()
 
@@ -1637,6 +1638,17 @@ class TestQgsJsonUtils(QgisTestCase):
                 }"""
         )
         self.assertTrue(res.isNull())
+
+    def test_as_geojson(self):
+        """Test GeoJson round trip with JSON-FG profile"""
+
+        # CircularString
+        wkt = "CIRCULARSTRING (0 0, 1 1, 2 2)"
+        geom = QgsGeometry.fromWkt(wkt)
+        self.assertTrue(compareWkt(geom.asWkt(), wkt))
+        j = geom.asGeoJson(0, Qgis.GeoJsonProfile.JsonFg)
+        geom2 = QgsJsonUtils.geometryFromGeoJson(j)
+        self.assertTrue(compareWkt(geom2.asWkt(), wkt))
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsjsonutils.py
+++ b/tests/src/python/test_qgsjsonutils.py
@@ -1861,9 +1861,7 @@ class TestQgsJsonUtils(QgisTestCase):
         self.assertEqual(
             j["conformsTo"], [["http://www.opengis.net/spec/json-fg-1/1.0/conf/core"]]
         )
-        self.assertEqual(
-            j["coordRefSys"], "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-        )
+        self.assertNotIn("coordRefSys", j)
 
         # Export to 3857
         exporter.setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:3857"))

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -687,6 +687,49 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
         )
 
     def testGetFeatureInfoJSON(self):
+
+        # simple test with geometry with underlying layer in 4326 and CRS is OGC:CRS84
+        self.wms_request_compare(
+            "GetFeatureInfo",
+            "&layers=testlayer%20%C3%A8%C3%A9&styles=&"
+            + "info_format=application%2Fjson&transparent=true&"
+            + "width=600&height=400&srs=OGC:CRS84&"
+            + "bbox=8.2034387,44.9014173,8.2036094,44.9015094&"
+            + "query_layers=testlayer2&X=203&Y=116&"
+            + "with_geometry=true",
+            "wms_getfeatureinfo_geometry_CRS84_json",
+            "test_project.qgs",
+            normalizeJson=True,
+        )
+
+        # simple test with geometry with underlying layer in 4326 and CRS is CRS:84
+        self.wms_request_compare(
+            "GetFeatureInfo",
+            "&layers=testlayer%20%C3%A8%C3%A9&styles=&"
+            + "info_format=application%2Fjson&transparent=true&"
+            + "width=600&height=400&srs=CRS:84&"
+            + "bbox=8.2034387,44.9014173,8.2036094,44.9015094&"
+            + "query_layers=testlayer2&X=203&Y=116&"
+            + "with_geometry=true",
+            "wms_getfeatureinfo_geometry_CRS84_json",
+            "test_project.qgs",
+            normalizeJson=True,
+        )
+
+        # simple test with geometry with underlying layer in 3857
+        self.wms_request_compare(
+            "GetFeatureInfo",
+            "&layers=testlayer%20%C3%A8%C3%A9&styles=&"
+            + "info_format=application%2Fjson&transparent=true&"
+            + "width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C"
+            + "5606005.488876367%2C913235.426296057%2C5606035.347090538&"
+            + "query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320&"
+            + "with_geometry=true",
+            "wms_getfeatureinfo_geometry_json",
+            "test_project_epsg3857.qgs",
+            normalizeJson=True,
+        )
+
         # simple test without geometry and info_format=application/json
         self.wms_request_compare(
             "GetFeatureInfo",
@@ -721,20 +764,6 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
             + "query_layers=testlayer%20%C3%A8%C3%A9,fields_alias,exclude_attribute&"
             + "X=190&Y=320&FEATURE_COUNT=2&FI_POINT_TOLERANCE=200",
             "wms_getfeatureinfo_multiple_json",
-            normalizeJson=True,
-        )
-
-        # simple test with geometry with underlying layer in 3857
-        self.wms_request_compare(
-            "GetFeatureInfo",
-            "&layers=testlayer%20%C3%A8%C3%A9&styles=&"
-            + "info_format=application%2Fjson&transparent=true&"
-            + "width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C"
-            + "5606005.488876367%2C913235.426296057%2C5606035.347090538&"
-            + "query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320&"
-            + "with_geometry=true",
-            "wms_getfeatureinfo_geometry_json",
-            "test_project_epsg3857.qgs",
             normalizeJson=True,
         )
 
@@ -795,20 +824,6 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
             + "info_format=application%2Fjson&transparent=true&"
             + "width=600&height=400&srs=EPSG:4326&"
             + "bbox=44.9014173,8.2034387,44.9015094,8.2036094&"
-            + "query_layers=testlayer2&X=203&Y=116&"
-            + "with_geometry=true",
-            "wms_getfeatureinfo_geometry_CRS84_json",
-            "test_project.qgs",
-            normalizeJson=True,
-        )
-
-        # simple test with geometry with underlying layer in 4326 and CRS is CRS84
-        self.wms_request_compare(
-            "GetFeatureInfo",
-            "&layers=testlayer%20%C3%A8%C3%A9&styles=&"
-            + "info_format=application%2Fjson&transparent=true&"
-            + "width=600&height=400&srs=OGC:CRS84&"
-            + "bbox=8.2034387,44.9014173,8.2036094,44.9015094&"
             + "query_layers=testlayer2&X=203&Y=116&"
             + "with_geometry=true",
             "wms_getfeatureinfo_geometry_CRS84_json",


### PR DESCRIPTION
Partial implementation of https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-414-server-oapif-jsonfg-flatgeobuf.md

This PR implements 4 profiles for GeoJSON export:

- Legacy : QGIS default behavior since this PR (i.e. supports different CRS than CRS84)
- RFC7946: GeoJSON compliant with RFC7946
- JSON-FG:  OGC Features and Geometries JSON Part 1: core  http://www.opengis.net/def/profile/OGC/0/jsonfg
- JSON-FG-PLUS: OGC Features and Geometries JSON Part 1: core http://www.opengis.net/def/profile/OGC/0/jsonfg-plus

Default behavior for existing JSON export methods exposed to API has not changed but it is now possible to specify which profile has to be used by calling ` QgsAbstractGeometry::asGeoJson()` (on the real geometry classes).

### Main new possibilities with  JsonFg(Plus) profiles:
- Lossless export of the curve geometries
- Ability to export `M` (measures) and `ZM` geometries

This work is the result a collective funding effort from:
Funded by: QGIS Anwendergruppe Deutschland e.V. (QGIS-DE e.V.)
Funded by: Gis3W
Funded by: QTIBIA
Funded by: Oslandia


