### PR TITLE
Fix transformation unavailable in QgsCoordinateOperationWidget

### DIFF
--- a/src/gui/proj/qgscoordinateoperationwidget.cpp
+++ b/src/gui/proj/qgscoordinateoperationwidget.cpp
@@ -81,10 +81,11 @@ void QgsCoordinateOperationWidget::setMapCanvas( QgsMapCanvas *canvas )
     QgsGeometry g = QgsGeometry::fromQPolygonF( mainCanvasPoly );
     // close polygon
     mainCanvasPoly << mainCanvasPoly.at( 0 );
-    if ( QgsProject::instance()->crs() != QgsCoordinateReferenceSystem::fromEpsgId( 4326 ) )
+    const QgsCoordinateReferenceSystem projectCrs = QgsProject::instance()->crs();
+    if ( projectCrs.isEarthCrs() && projectCrs != QgsCoordinateReferenceSystem::fromEpsgId( 4326 ) )
     {
       // reproject extent
-      QgsCoordinateTransform ct( QgsProject::instance()->crs(), QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), QgsProject::instance() );
+      QgsCoordinateTransform ct( projectCrs, QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), QgsProject::instance() );
       ct.setBallparkTransformsAreAppropriate( true );
       g = g.densifyByCount( 5 );
       try


### PR DESCRIPTION
## Description

A small leftover after #65000 and #65026 that would still produce the the message that non-Earth CRS cannot be transformed to EPSG:4326. Only try to do that for Earth CRS.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. 
