### PR TITLE
do not override icon for common image mime types like JPG and TIF (fixes #60911)

### DIFF
--- a/debian/qgis.xml
+++ b/debian/qgis.xml
@@ -93,7 +93,6 @@
   <mime-type type="image/tiff">
     <comment>TIFF raster data</comment>
     <comment xml:lang="de">TIFF-Rasterdaten</comment>
-    <icon name="qgis-mime"/>
     <magic priority="50">
       <match type="string" offset="0" value="MM">
         <match type="little16" offset="2" value="42"/>
@@ -109,7 +108,6 @@
   <mime-type type="image/jpeg">
     <comment>JPEG raster data</comment>
     <comment xml:lang="de">JPEG-Rasterdaten</comment>
-    <icon name="qgis-mime"/>
     <magic priority="50">
        <match type="big16" offset="0" value="65496"/>
     </magic>


### PR DESCRIPTION
## Description

The `debian/qgis.xml` file describes some MIME types that are used by QGIS. Among QGIS-specific files like projects, styles, layer definitions, etc, we also define some common formats like JPEG and TIFF.

Currently we override system-wide/file-manager icons for  JPEG and TIFF files, but these are widely used outside GIS workflows and often are not GIS-ready at all (e.g. photos or scanned documents). Forcing QGIS icon for these formats can cause inconsistency and confusion, for instance, user expect standard photo and image formats to look like images/use the default image icon rather than QGIS icon. This also can make a false impression that some images are georeferenced while they are normal pictures.

Removing QGIS icon for these files allows the desktop environment or file manager to use standard, native image icons.

Fixes #60911.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.