### PR TITLE
update qHash() overloads to use size_t

### DIFF
--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -4214,7 +4214,7 @@ QFlags<Qgis::SensorThingsExtension> operator|(Qgis::SensorThingsExtension f1, QF
 
 
 
-uint qHash( const QVariant &variant );
+size_t qHash( const QVariant &variant );
 %Docstring
 Hash for QVariant
 %End

--- a/python/PyQt6/core/auto_generated/symbology/qgssymbollayerreference.sip.in
+++ b/python/PyQt6/core/auto_generated/symbology/qgssymbollayerreference.sip.in
@@ -169,9 +169,9 @@ The symbol layer's id
 
 };
 
-uint qHash( const QgsSymbolLayerId &id );
+size_t qHash( const QgsSymbolLayerId &id );
 
-uint qHash( const QgsSymbolLayerReference &r );
+size_t qHash( const QgsSymbolLayerReference &r );
 
 typedef QList<QgsSymbolLayerReference> QgsSymbolLayerReferenceList;
 

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -56,7 +56,7 @@
 
 using namespace Qt::StringLiterals;
 
-uint qHash( const Vertex &v )
+size_t qHash( const Vertex &v )
 {
   return qHash( v.layer ) ^ qHash( v.fid ) ^ qHash( v.vertexId );
 }

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -57,7 +57,7 @@ struct Vertex
 };
 
 //! qHash implementation - we use Vertex in QSet
-uint qHash( const Vertex &v );
+size_t qHash( const Vertex &v );
 
 
 class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing

--- a/src/core/actions/qgsactionscope.cpp
+++ b/src/core/actions/qgsactionscope.cpp
@@ -78,9 +78,9 @@ void QgsActionScope::setDescription( const QString &description )
   mDescription = description;
 }
 
-uint qHash( const QgsActionScope &key, uint seed )
+size_t qHash( const QgsActionScope &key, size_t seed )
 {
-  uint hash = seed;
+  size_t hash = seed;
 
   hash |= qHash( key.expressionContextScope().variableNames().join( ',' ), seed );
   hash |= qHash( key.id(), seed );

--- a/src/core/actions/qgsactionscope.h
+++ b/src/core/actions/qgsactionscope.h
@@ -171,6 +171,6 @@ class CORE_EXPORT QgsActionScope
     QgsExpressionContextScope mExpressionContextScope;
 };
 
-CORE_EXPORT uint qHash( const QgsActionScope &key, uint seed = 0 ) SIP_SKIP;
+CORE_EXPORT size_t qHash( const QgsActionScope &key, size_t seed = 0 ) SIP_SKIP;
 
 #endif // QGSACTIONSCOPE_H

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -608,10 +608,10 @@ QString qgsVsiPrefix( const QString &path )
   return QgsGdalUtils::vsiPrefixForPath( path );
 }
 
-uint qHash( const QVariant &variant )
+size_t qHash( const QVariant &variant )
 {
   if ( !variant.isValid() || variant.isNull() )
-    return std::numeric_limits<uint>::max();
+    return std::numeric_limits<size_t>::max();
 
   switch ( variant.userType() )
   {
@@ -651,7 +651,7 @@ uint qHash( const QVariant &variant )
       break;
   }
 
-  return std::numeric_limits<uint>::max();
+  return std::numeric_limits<size_t>::max();
 }
 
 bool qgsVariantEqual( const QVariant &lhs, const QVariant &rhs )

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -48,7 +48,7 @@ int QgisEvent = QEvent::User + 1;
 // qHash implementation for scoped enum type
 // https://gitlab.com/frostasm/programming-knowledge-base/-/snippets/20120
 #define QHASH_FOR_CLASS_ENUM( T )                                                     \
-  inline uint qHash( const T &t, uint seed )                                          \
+  inline size_t qHash( const T &t, size_t seed )                                      \
   {                                                                                   \
     return ::qHash( static_cast<typename std::underlying_type<T>::type>( t ), seed ); \
   }
@@ -7237,7 +7237,7 @@ template<class Object> inline QgsSignalBlocker<Object> whileBlocking( Object *ob
 }
 
 //! Hash for QVariant
-CORE_EXPORT uint qHash( const QVariant &variant );
+CORE_EXPORT size_t qHash( const QVariant &variant );
 
 /**
  * Returns a string representation of a double

--- a/src/core/qgsattributes.cpp
+++ b/src/core/qgsattributes.cpp
@@ -30,10 +30,10 @@ QgsAttributeMap QgsAttributes::toMap() const
   return map;
 }
 
-uint qHash( const QgsAttributes &attributes )
+size_t qHash( const QgsAttributes &attributes )
 {
   if ( attributes.isEmpty() )
-    return std::numeric_limits<uint>::max();
+    return std::numeric_limits<size_t>::max();
   else
     return qHash( attributes.at( 0 ) );
 }

--- a/src/core/qgsattributes.h
+++ b/src/core/qgsattributes.h
@@ -134,7 +134,7 @@ class QgsAttributes : public QVector<QVariant>
 };
 
 //! Hash for QgsAttributes
-CORE_EXPORT uint qHash( const QgsAttributes &attributes );
+CORE_EXPORT size_t qHash( const QgsAttributes &attributes );
 
 #endif
 

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -444,9 +444,9 @@ QDataStream &operator>>( QDataStream &in, QgsFeature &feature )
   return in;
 }
 
-uint qHash( const QgsFeature &key, uint seed )
+size_t qHash( const QgsFeature &key, size_t seed )
 {
-  uint hash = seed;
+  size_t hash = seed;
   const auto constAttributes = key.attributes();
   for ( const QVariant &attr : constAttributes )
   {

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -1288,7 +1288,7 @@ typedef QMap<qint64, QgsGeometry> QgsGeometryMap;
 
 typedef QList<QgsFeature> QgsFeatureList;
 
-CORE_EXPORT uint qHash( const QgsFeature &key, uint seed = 0 )  SIP_SKIP;
+CORE_EXPORT size_t qHash( const QgsFeature &key, size_t seed = 0 )  SIP_SKIP;
 
 Q_DECLARE_METATYPE( QgsFeature )
 Q_DECLARE_METATYPE( QgsFeatureList )

--- a/src/core/qgsmaplayerdependency.h
+++ b/src/core/qgsmaplayerdependency.h
@@ -93,7 +93,7 @@ class CORE_EXPORT QgsMapLayerDependency
 /**
  * global qHash function for QgsMapLayerDependency, so that it can be used in a QSet
  */
-inline uint qHash( const QgsMapLayerDependency &dep )
+inline size_t qHash( const QgsMapLayerDependency &dep )
 {
   return qHash( dep.layerId() ) + dep.origin() + dep.type();
 }

--- a/src/core/qgsmaplayerlistutils_p.h
+++ b/src/core/qgsmaplayerlistutils_p.h
@@ -142,7 +142,7 @@ inline static QgsMapLayer *_qgis_findLayer( const QList< QgsMapLayer *> &layers,
   }
 }
 
-inline uint qHash( const QgsWeakMapLayerPointer &key )
+inline size_t qHash( const QgsWeakMapLayerPointer &key )
 {
   return qHash( key ? key->id() : QString() );
 }

--- a/src/core/qgspointxy.h
+++ b/src/core/qgspointxy.h
@@ -398,7 +398,7 @@ class CORE_EXPORT QgsPointXY
     //! is point empty?
     bool mIsEmpty = true;
 
-    friend uint qHash( const QgsPointXY &pnt );
+    friend size_t qHash( const QgsPointXY &pnt );
 
 }; // class QgsPointXY
 
@@ -411,11 +411,11 @@ inline std::ostream &operator << ( std::ostream &os, const QgsPointXY &p ) SIP_S
   return os;
 }
 
-inline uint qHash( const QgsPointXY &p ) SIP_SKIP
+inline size_t qHash( const QgsPointXY &p ) SIP_SKIP
 {
-  uint hash;
-  const uint h1 = qHash( static_cast< quint64 >( p.mX ) );
-  const uint h2 = qHash( static_cast< quint64 >( p.mY ) );
+  size_t hash;
+  const size_t h1 = qHash( static_cast< quint64 >( p.mX ) );
+  const size_t h2 = qHash( static_cast< quint64 >( p.mY ) );
   hash = h1 ^ ( h2 << 1 );
   return hash;
 }

--- a/src/core/qgsscreenproperties.h
+++ b/src/core/qgsscreenproperties.h
@@ -129,7 +129,7 @@ __pragma( warning( push ) ) __pragma( warning( disable : 4273 ) )
  *
  * \since QGIS 3.32
  */
-CORE_EXPORT inline uint qHash( const QgsScreenProperties &properties ) SIP_SKIP
+CORE_EXPORT inline size_t qHash( const QgsScreenProperties &properties ) SIP_SKIP
 {
   return qHash( properties.devicePixelRatio() ) + qHash( properties.physicalDpi() );
 }

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -303,7 +303,7 @@ class CORE_EXPORT QgsTessellator
         inline bool operator==( const VertexPoint &other ) const { return position == other.position && normal == other.normal && tangent == other.tangent; }
     };
 
-    friend uint qHash( const VertexPoint &key, size_t seed )
+    friend size_t qHash( const VertexPoint &key, size_t seed )
     {
       return qHashMulti( seed, key.position.x(), key.position.y(), key.position.z(), key.normal.x(), key.normal.y(), key.normal.z(), key.tangent.x(), key.tangent.y(), key.tangent.z(), key.tangent.w() );
     }

--- a/src/core/qgstiles.h
+++ b/src/core/qgstiles.h
@@ -95,11 +95,11 @@ __pragma( warning( push ) ) __pragma( warning( disable : 4273 ) )
  *
  * \since QGIS 3.32
  */
-CORE_EXPORT inline uint qHash( QgsTileXYZ id ) SIP_SKIP
+CORE_EXPORT inline size_t qHash( QgsTileXYZ id ) SIP_SKIP
 {
-  const uint h1 = qHash( static_cast< quint64 >( id.column() ) );
-  const uint h2 = qHash( static_cast< quint64 >( id.row() ) );
-  const uint h3 = qHash( static_cast< quint64 >( id.zoomLevel() ) );
+  const size_t h1 = qHash( static_cast< quint64 >( id.column() ) );
+  const size_t h2 = qHash( static_cast< quint64 >( id.row() ) );
+  const size_t h3 = qHash( static_cast< quint64 >( id.zoomLevel() ) );
   return h1 ^ ( h2 << 1 ) ^ ( h3 << 2 );
 }
 

--- a/src/core/symbology/qgssymbollayerreference.h
+++ b/src/core/symbology/qgssymbollayerreference.h
@@ -205,12 +205,12 @@ class CORE_EXPORT QgsSymbolLayerReference
     QString mSymbolLayerId;
 };
 
-inline uint qHash( const QgsSymbolLayerId &id )
+inline size_t qHash( const QgsSymbolLayerId &id )
 {
   return qHash( id.symbolKey() ) ^ qHash( id.symbolLayerIndexPath() );
 }
 
-inline uint qHash( const QgsSymbolLayerReference &r )
+inline size_t qHash( const QgsSymbolLayerReference &r )
 {
   return qHash( r.layerId() ) ^ qHash( r.symbolLayerIdV2() );
 }

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -785,9 +785,9 @@ void QgsWmsProvider::fetchOtherResTiles(
   );
 }
 
-uint qHash( QgsWmsProvider::TilePosition tp )
+size_t qHash( QgsWmsProvider::TilePosition tp )
 {
-  return ( uint ) tp.col + ( ( uint ) tp.row << 16 );
+  return ( size_t ) tp.col + ( ( size_t ) tp.row << 16 );
 }
 
 static void _drawDebugRect( QPainter &p, const QRectF &rect, const QColor &color )

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -1133,7 +1133,7 @@ void TestQgsExpressionContext::uniqueHash()
   feature.setAttributes( QgsAttributes() << 5 << 11 );
   context.setFeature( feature );
 
-  QCOMPARE( context.uniqueHash( ok, vars ), u"11||~~||18646899||~~||var1=b string||~~||var2=5||~~||"_s );
+  QCOMPARE( context.uniqueHash( ok, vars ), u"11||~~||13209806757982668659||~~||var1=b string||~~||var2=5||~~||"_s );
   QVERIFY( ok );
 
   // a value which can't be converted to string


### PR DESCRIPTION
## Description

In Qt 6 qHash() signature was changed to use `size_t` both for return value and `seed`, instead of `uint`. Looking at the code, we still have a few custom `qHash()` implementations using `uint` for return and `seed` values. While the code continue to compile on Qt6, these implemenetations do not match Qt6 API and potentially may lead to inconsistent overload resolution or narrowing conversions.

This PR updates remaining `qHash()` overloads to use `size_t` for return type and `seed`.

Fixes #44351.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.