### PR TITLE
[Customization] Fix user defined toolbar position loss

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1682,9 +1682,8 @@ int main( int argc, char *argv[] )
     QApplication::setFont( defaultFont );
   }
 
-  QgisApp *qgis = new QgisApp( mypSplash, qgisAppOptions, rootProfileFolder, profileName ); // "QgisApp" used to find canonical instance
+  QgisApp *qgis = new QgisApp( mypSplash, qgisAppOptions, rootProfileFolder, profileName, nullptr, Qt::Window, std::move( customization ) ); // "QgisApp" used to find canonical instance
   qgis->setObjectName( u"QgisApp"_s );
-  qgis->setCustomization( std::move( customization ) );
 
   /////////////////////////////////////////////////////////////////////
   // Load a project file if one was specified

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1015,7 +1015,9 @@ const QgsSettingsEntryBool *QgisApp::settingsDisplayWaylandWarning
 const QgsSettingsEntryBool *QgisApp::settingsRestoreDefaultWindowState
   = new QgsSettingsEntryBool( u"restore-default-window-state"_s, QgsSettingsTree::sTreeApp, false, u"Whether to restore the default window state on next QGIS startup"_s );
 
-QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
+QgisApp::QgisApp(
+  QSplashScreen *splash, AppOptions options, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl, std::unique_ptr<QgsCustomization> customization
+)
   : QMainWindow( parent, fl )
   , mSplash( splash )
 {
@@ -1781,6 +1783,9 @@ QgisApp::QgisApp( QSplashScreen *splash, AppOptions options, const QString &root
 
   // setup drag drop
   setAcceptDrops( true );
+
+  // must be done before show() to properly restore state
+  setCustomization( std::move( customization ) );
 
   mFullScreenMode = false;
   mPrevScreenModeMaximized = false;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5750,7 +5750,9 @@ QString QgisApp::getVersionString()
 void QgisApp::setCustomization( std::unique_ptr<QgsCustomization> customization )
 {
   mCustomization = std::move( customization );
-  mCustomization->setQgisApp( this );
+
+  if ( mCustomization )
+    mCustomization->setQgisApp( this );
 }
 
 QgsCustomization *QgisApp::customization() const

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -167,7 +167,6 @@ class QgsAppGpsSettingsMenu;
 class Qgs3DMapScene;
 class Qgs3DMapCanvas;
 class QgsAppCanvasFiltering;
-class QgsCustomization;
 class QgsCustomizationDialog;
 
 #include "qgsconfig.h"
@@ -181,6 +180,7 @@ class QgsCustomizationDialog;
 #include "qgsattributetablefiltermodel.h"
 #include "qgsauthmanager.h"
 #include "qgsbrowserdockwidget.h"
+#include "qgscustomization.h"
 #include "qgslayertreeregistrybridge.h"
 #include "qgslayoutdesignerinterface.h"
 #include "qgsmaplayeractionregistry.h"
@@ -270,7 +270,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
       const QString &rootProfileLocation = QString(),
       const QString &activeProfile = QString(),
       QWidget *parent = nullptr,
-      Qt::WindowFlags fl = Qt::Window
+      Qt::WindowFlags fl = Qt::Window,
+      std::unique_ptr<QgsCustomization> customization = nullptr
     );
     //! Constructor for unit tests
     QgisApp();

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -1693,6 +1693,7 @@ void QgsCustomization::applyToToolBars() const
     return;
 
   const auto toolBarWidgets = mQgisApp->findChildren<QToolBar *>( QString(), Qt::FindDirectChildrenOnly );
+  QMap<QString, QToolBar *> userToolBars;
   for ( QToolBar *tb : toolBarWidgets )
   {
     if ( !tb )
@@ -1700,9 +1701,10 @@ void QgsCustomization::applyToToolBars() const
 
     if ( tb->property( USER_TOOLBAR_PROPERTY ).toBool() )
     {
-      // delete old toolbar, will recreate it later
-      QgisApp::instance()->removeToolBar( tb );
-      delete tb;
+      // we don't delete toolbar (yet) in order to keep their actual position if they still exists
+      // after we finish to create user defined tool bars
+      userToolBars[tb->objectName()] = tb;
+      tb->clear();
     }
     else if ( QgsToolBarItem *t = mToolBars->getChild<QgsToolBarItem>( tb->objectName() ) )
     {
@@ -1716,10 +1718,18 @@ void QgsCustomization::applyToToolBars() const
   {
     if ( QgsCustomization::QgsUserToolBarItem *userToolBar = dynamic_cast<QgsCustomization::QgsUserToolBarItem *>( childItem.get() ); userToolBar && userToolBar->isVisible() )
     {
-      QToolBar *toolBar = new QToolBar( userToolBar->title(), QgisApp::instance() );
-      toolBar->setProperty( USER_TOOLBAR_PROPERTY, true );
-      toolBar->setObjectName( userToolBar->name() );
-      QgisApp::instance()->addToolBar( toolBar );
+      QToolBar *toolBar = nullptr;
+      if ( userToolBars.contains( userToolBar->name() ) )
+      {
+        toolBar = userToolBars.take( userToolBar->name() );
+      }
+      else
+      {
+        toolBar = new QToolBar( userToolBar->title(), QgisApp::instance() );
+        toolBar->setProperty( USER_TOOLBAR_PROPERTY, true );
+        toolBar->setObjectName( userToolBar->name() );
+        QgisApp::instance()->addToolBar( toolBar );
+      }
 
       for ( const std::unique_ptr<QgsCustomization::QgsItem> &actionRefItem : userToolBar->childItemList() )
       {
@@ -1734,6 +1744,13 @@ void QgsCustomization::applyToToolBars() const
 
       updateActionVisibility( userToolBar, toolBar );
     }
+  }
+
+  // delete user tool bar not existing anymore
+  for ( QToolBar *toolBar : userToolBars )
+  {
+    QgisApp::instance()->removeToolBar( toolBar );
+    delete toolBar;
   }
 }
 

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -1701,8 +1701,8 @@ void QgsCustomization::applyToToolBars() const
 
     if ( tb->property( USER_TOOLBAR_PROPERTY ).toBool() )
     {
-      // we don't delete toolbar (yet) in order to keep their actual position if they still exists
-      // after we finish to create user defined tool bars
+      // we don't delete user defined toolbar (yet) in order to keep their actual position if they
+      // still exists after we finish to create them
       userToolBars[tb->objectName()] = tb;
       tb->clear();
     }

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -1746,7 +1746,7 @@ void QgsCustomization::applyToToolBars() const
     }
   }
 
-  // delete user tool bar not existing anymore
+  // delete user defined tool bar not existing anymore
   for ( QToolBar *toolBar : userToolBars )
   {
     QgisApp::instance()->removeToolBar( toolBar );

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -1151,12 +1151,17 @@ QgsCustomization::QgsProcessingProvidersItem *QgsCustomization::processingProvid
 
 void QgsCustomization::addActions( QgsItem *item, QWidget *widget ) const
 {
-  if ( !item || !widget )
+  if ( !item
+       || !widget
+       // don't load user defined widget, we already hold any valuable information in QgsCustomization
+       || isUserDefined( widget ) )
     return;
 
   for ( QgsQActionsIterator::Info it : QgsQActionsIterator( widget ) )
   {
-    if ( it.name.isEmpty() )
+    if ( it.name.isEmpty() ||
+         // don't load user defined widget, we already hold any valuable information in QgsCustomization
+         isUserDefined( it.widget ) )
       continue;
 
     // submenu
@@ -1175,6 +1180,12 @@ void QgsCustomization::addActions( QgsItem *item, QWidget *widget ) const
       }
 
       childItem = item->lastChild<QgsActionItem>();
+    }
+
+    if ( !childItem )
+    {
+      QgsDebugError( "Null customization child action item" );
+      continue;
     }
 
     childItem->setIcon( it.icon );
@@ -1536,6 +1547,12 @@ QAction *QgsCustomization::findQAction( const QString &path )
   const QList<QAction *>::const_iterator actionIt = std::find_if( actions.cbegin(), actions.cend(), [&actionName]( QAction *action ) { return action->objectName() == actionName; } );
   return actionIt != actions.cend() ? *actionIt : nullptr;
 }
+
+bool QgsCustomization::isUserDefined( QWidget *widget )
+{
+  return widget && ( widget->property( USER_MENU_PROPERTY ).toBool() || widget->property( USER_TOOLBAR_PROPERTY ).toBool() );
+}
+
 
 template<class WidgetType> void QgsCustomization::updateMenuActionVisibility( QgsCustomization::QgsItem *parentItem, WidgetType *parentWidget ) const
 {

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -1223,7 +1223,14 @@ void QgsCustomization::loadProcessingProviders()
 
   for ( QgsProcessingProvider *provider : QgsApplication::processingRegistry()->providers() )
   {
-    auto providerItem = std::make_unique<QgsProcessingProviderItem>( provider->id(), provider->name(), mProcessingProviders.get() );
+    QgsProcessingProviderItem *providerItem = mProcessingProviders->getChild<QgsProcessingProviderItem>( provider->id() );
+    if ( !providerItem )
+    {
+      auto p = std::make_unique<QgsProcessingProviderItem>( provider->id(), provider->name(), mProcessingProviders.get() );
+      mProcessingProviders->addChild( std::move( p ) );
+      providerItem = mProcessingProviders->lastChild<QgsProcessingProviderItem>();
+    }
+
     providerItem->setIcon( provider->icon() );
     for ( const QgsProcessingAlgorithm *algorithm : provider->algorithms() )
     {
@@ -1231,17 +1238,18 @@ void QgsCustomization::loadProcessingProviders()
       QgsProcessingGroupItem *group = providerItem->getChild<QgsProcessingGroupItem>( groupId );
       if ( !group )
       {
-        auto g = std::make_unique<QgsProcessingGroupItem>( groupId, algorithm->group(), providerItem.get() );
+        auto g = std::make_unique<QgsProcessingGroupItem>( groupId, algorithm->group(), providerItem );
         providerItem->addChild( std::move( g ) );
         group = providerItem->lastChild<QgsProcessingGroupItem>();
       }
 
-      auto processingItem = std::make_unique<QgsProcessingAlgorithmItem>( algorithm->id(), algorithm->displayName(), group );
-      processingItem->setIcon( algorithm->icon() );
-      group->addChild( std::move( processingItem ) );
+      if ( !group->getChild<QgsProcessingAlgorithmItem>( algorithm->id() ) )
+      {
+        auto processingItem = std::make_unique<QgsProcessingAlgorithmItem>( algorithm->id(), algorithm->displayName(), group );
+        processingItem->setIcon( algorithm->icon() );
+        group->addChild( std::move( processingItem ) );
+      }
     }
-
-    mProcessingProviders->addChild( std::move( providerItem ) );
   }
 }
 

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -1159,6 +1159,11 @@ class APP_EXPORT QgsCustomization
      */
     static QAction *findQAction( const QString &path );
 
+    /**
+     * Returns true if \a widget is a user defined menu or toolbar
+     */
+    static bool isUserDefined( QWidget *widget );
+
     QString uniqueItemName( const QString &baseName ) const;
     QAction *findAction( const QString &path ) const;
 

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -952,7 +952,7 @@ class APP_EXPORT QgsCustomization
     void apply() const;
 
     /**
-     * Update customization model with current application customization elements (actions, menus, dockWidgets...)
+     * Updates customization model with current application customization elements (actions, menus, dockWidgets...)
      */
     void load();
 

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -468,13 +468,13 @@ class APP_EXPORT QgsCustomization
         QgsToolBarItem( const QString &name, const QString &title, QgsItem *parent );
 
         /**
-         * Sets original dock widget visible state
+         * Sets original toolbar visible state
          * \see wasVisible()
          */
         void setWasVisible( const bool &wasVisible );
 
         /**
-         * Returns original dock widget visible state
+         * Returns original toolbar visible state
          * \see setWasVisible()
          */
         bool wasVisible() const;

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -952,6 +952,11 @@ class APP_EXPORT QgsCustomization
     void apply() const;
 
     /**
+     * Update customization model with current application customization elements (actions, menus, dockWidgets...)
+     */
+    void load();
+
+    /**
      * Reads customization file (given at construction time) to update customization content
      */
     void read();
@@ -1015,11 +1020,6 @@ class APP_EXPORT QgsCustomization
      * Add action items as children of \a item for each \a widget actions
      */
     void addActions( QgsItem *item, QWidget *widget ) const;
-
-    /**
-     * Update customization model with current application customization elements (actins, menus, dockWidgets...)
-     */
-    void load();
 
     /**
      * Update customization model with current application QgsBrowserDockWidget elements

--- a/src/app/qgscustomizationdialog.cpp
+++ b/src/app/qgscustomizationdialog.cpp
@@ -223,6 +223,7 @@ int QgsCustomizationDialog::QgsCustomizationModel::columnCount( const QModelInde
 void QgsCustomizationDialog::QgsCustomizationModel::init()
 {
   mCustomization = std::make_unique<QgsCustomization>( *mQgisApp->customization() );
+  mCustomization->load();
   mRootItems.clear();
   switch ( mMode )
   {

--- a/tests/src/app/testqgscustomization.cpp
+++ b/tests/src/app/testqgscustomization.cpp
@@ -160,6 +160,7 @@ void TestQgsCustomization::init()
   mQgisApp->show();
 
   QVERIFY( findQWidget<QMenu>( "Menus/mHelpMenu" ) );
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mHelpToolBar" ) );
 
   mCustomizationFile = std::make_unique<QTemporaryFile>();
   QVERIFY( mCustomizationFile->open() ); // fileName is not available until open
@@ -654,6 +655,11 @@ void TestQgsCustomization::testModel()
 {
   mQgisApp->customization()->setEnabled( true );
 
+  // We change visibility of help toolbar, it has to stay invisible all the time we use the model
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mHelpToolBar" ) );
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mHelpToolBar" )->isVisible() );
+  findQWidget<QToolBar>( "ToolBars/mHelpToolBar" )->setVisible( false );
+
   QgsCustomizationDialog::QgsCustomizationModel model( mQgisApp.get(), QgsCustomizationDialog::QgsCustomizationModel::Mode::ItemVisibility );
   QAbstractItemModelTester modelTester( &model, QAbstractItemModelTester::FailureReportingMode::Fatal );
 
@@ -678,12 +684,16 @@ void TestQgsCustomization::testModel()
 
   QVERIFY( findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
   QVERIFY( findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->isVisible() );
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mHelpToolBar" ) );
+  QVERIFY( !findQWidget<QToolBar>( "ToolBars/mHelpToolBar" )->isVisible() );
 
   // revert values
   model.reset();
 
   QVERIFY( findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
   QVERIFY( findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->isVisible() );
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mHelpToolBar" ) );
+  QVERIFY( !findQWidget<QToolBar>( "ToolBars/mHelpToolBar" )->isVisible() );
 
   {
     QModelIndex toolBarsIndex = model.index( 4, 0 );
@@ -719,8 +729,10 @@ void TestQgsCustomization::testModel()
 
   QVERIFY( findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
   QVERIFY( findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" )->isVisible() );
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mHelpToolBar" ) );
+  QVERIFY( !findQWidget<QToolBar>( "ToolBars/mHelpToolBar" )->isVisible() );
 
-  // revert values
+  // apply values
   model.apply();
 
   {
@@ -741,6 +753,9 @@ void TestQgsCustomization::testModel()
 
   // the action is no longer visible
   QVERIFY( !findQAction( "ToolBars/mLayerToolBar/mActionAddRasterLayer" ) );
+
+  QVERIFY( findQWidget<QToolBar>( "ToolBars/mHelpToolBar" ) );
+  QVERIFY( !findQWidget<QToolBar>( "ToolBars/mHelpToolBar" )->isVisible() );
 
   // test add/setVisible/setHidden/delete for user menu
   {

--- a/tests/src/app/testqgscustomization.cpp
+++ b/tests/src/app/testqgscustomization.cpp
@@ -53,6 +53,7 @@ class TestQgsCustomization : public QgsTest
     void testClone();
     void testModel();
     void testModelProcessing();
+    void testToolBarPosition();
 
   private:
     template<class T> T *getItem( QgsCustomization *customization, const QString &path ) const { return dynamic_cast<T *>( getItem( customization, path ) ); }
@@ -928,6 +929,39 @@ void TestQgsCustomization::testModelProcessing()
     QVERIFY( !getItem<QgsCustomization::QgsProcessingAlgorithmRefItem>( "ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1" ) );
     QVERIFY( !findQAction( u"ToolBars/UserToolBar_1/ProcessingAlgorithmRef_buffer_1"_s ) );
   }
+}
+
+void TestQgsCustomization::testToolBarPosition()
+{
+  // check that we keep toolbar position when we call apply()
+
+  mQgisApp->customization()->setEnabled( true );
+
+  const QString name = "my_super_toolbar";
+  mQgisApp->customization()->toolBarsItem()->addChild( std::make_unique<QgsCustomization::QgsUserToolBarItem>( name, name, mQgisApp->customization()->toolBarsItem() ) );
+
+  QVERIFY( getItem<QgsCustomization::QgsUserToolBarItem>( "ToolBars/my_super_toolbar" ) );
+
+  mQgisApp->customization()->apply();
+
+  QWidget *mySuperToolBar = findQWidget( "ToolBars/my_super_toolbar" );
+  QVERIFY( mySuperToolBar );
+
+  QToolBar *newToolBar = new QToolBar( "another_toolbar", QgisApp::instance() );
+  newToolBar->addAction( new QAction( "new_action" ) );
+  QgisApp::instance()->addToolBar( newToolBar );
+
+  QApplication::processEvents();
+  QPoint mySuperToolBarPos = mySuperToolBar->mapToGlobal( QPoint( 0, 0 ) );
+
+  mQgisApp->customization()->apply();
+
+  QApplication::processEvents();
+
+  mySuperToolBar = findQWidget( "ToolBars/my_super_toolbar" );
+  QVERIFY( mySuperToolBar );
+
+  QCOMPARE( mySuperToolBarPos, mySuperToolBar->mapToGlobal( QPoint( 0, 0 ) ) );
 }
 
 


### PR DESCRIPTION
## Description

This PR proposes to:
- Load customization before show() because QGIS restoreState in showEvent() and user defined toolbar and
menus need to be already created so we could restore their old position.
- Load customization on model init to update toolbar and dockwidget current visible state (mWasVisible). 
- Don't delete toolbar but clean them instead in order to keep toolbar position when we call apply()

Fix #65862

More incoming fixes on customization when this one would be merged

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


