### PR TITLE
[fix] Proper handling of EMPTY geometries in 'Detect dataset changes' algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
+++ b/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsalgorithmdetectdatasetchanges.h"
 
+#include "qgsgeometryfactory.h"
 #include "qgsspatialindex.h"
 #include "qgsvectorlayer.h"
 
@@ -201,7 +202,6 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
   QHash<QgsFeatureId, QgsAttributes> originalAttributes;
   QHash<QgsAttributes, QgsFeatureId> originalNullGeometryAttributes;
   QHash<QgsAttributes, QgsFeatureId> originalEmptyGeometryAttributes;
-  QgsGeometry emptyGeometry = QgsGeometry(); // if an EMPTY geom is found, we'll store it here
   long current = 0;
 
   QgsAttributes attrs;
@@ -227,11 +227,6 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
     }
     else if ( f.hasGeometry() && f.geometry().isEmpty() )
     {
-      if ( emptyGeometry.isNull() )
-      {
-        emptyGeometry = f.geometry(); // save geometry to use it later
-      }
-
       if ( originalEmptyGeometryAttributes.contains( attrs ) )
       {
         feedback->reportError(
@@ -415,11 +410,11 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
     if ( feedback->isCanceled() )
       break;
 
-    // attempt to use already fetched geometry
+    // attempt to use already fetched geometry or use Null/Empty geometry
     g = originalGeometries.value( f.id(), QgsGeometry() );
     if ( g.isNull() && emptyGeometryIds.contains( f.id() ) )
     {
-      g = emptyGeometry;
+      g = QgsGeometry( QgsGeometryFactory::geomFromWkbType( mOriginal->wkbType() ) );
     }
     f.setGeometry( g );
 

--- a/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
+++ b/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
@@ -201,6 +201,7 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
   QHash<QgsFeatureId, QgsAttributes> originalAttributes;
   QHash<QgsAttributes, QgsFeatureId> originalNullGeometryAttributes;
   QHash<QgsAttributes, QgsFeatureId> originalEmptyGeometryAttributes;
+  QgsGeometry emptyGeometry = QgsGeometry(); // if an EMPTY geom is found, we'll store it here
   long current = 0;
 
   QgsAttributes attrs;
@@ -226,6 +227,11 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
     }
     else if ( f.hasGeometry() && f.geometry().isEmpty() )
     {
+      if ( emptyGeometry.isNull() )
+      {
+        emptyGeometry = f.geometry(); // save geometry to use it later
+      }
+
       if ( originalEmptyGeometryAttributes.contains( attrs ) )
       {
         feedback->reportError(
@@ -401,13 +407,21 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
   current = 0;
   long deleted = 0;
   QgsFeature f;
+  QgsGeometry g;
+  QList<QgsFeatureId> emptyGeometryIds = originalEmptyGeometryAttributes.values();
+
   while ( it.nextFeature( f ) )
   {
     if ( feedback->isCanceled() )
       break;
 
-    // use already fetched geometry
-    f.setGeometry( originalGeometries.value( f.id(), QgsGeometry() ) );
+    // attempt to use already fetched geometry
+    g = originalGeometries.value( f.id(), QgsGeometry() );
+    if ( g.isNull() && emptyGeometryIds.contains( f.id() ) )
+    {
+      g = emptyGeometry;
+    }
+    f.setGeometry( g );
 
     if ( unchangedOriginalIds.contains( f.id() ) )
     {

--- a/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
+++ b/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
@@ -200,6 +200,7 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
   QHash<QgsFeatureId, QgsGeometry> originalGeometries;
   QHash<QgsFeatureId, QgsAttributes> originalAttributes;
   QHash<QgsAttributes, QgsFeatureId> originalNullGeometryAttributes;
+  QHash<QgsAttributes, QgsFeatureId> originalEmptyGeometryAttributes;
   long current = 0;
 
   QgsAttributes attrs;
@@ -208,11 +209,6 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
   const QgsSpatialIndex index( it, [&]( const QgsFeature &f ) -> bool {
     if ( feedback->isCanceled() )
       return false;
-
-    if ( f.hasGeometry() )
-    {
-      originalGeometries.insert( f.id(), f.geometry() );
-    }
 
     if ( !mFieldsToCompare.empty() )
     {
@@ -224,7 +220,29 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
       originalAttributes.insert( f.id(), attrs );
     }
 
-    if ( !f.hasGeometry() )
+    if ( f.hasGeometry() && !f.geometry().isEmpty() )
+    {
+      originalGeometries.insert( f.id(), f.geometry() );
+    }
+    else if ( f.hasGeometry() && f.geometry().isEmpty() )
+    {
+      if ( originalEmptyGeometryAttributes.contains( attrs ) )
+      {
+        feedback->reportError(
+          QObject::tr(
+            "A non-unique set of comparison attributes was found for "
+            "one or more features with EMPTY geometries - results may be misleading (features %1 and %2)"
+          )
+            .arg( f.id() )
+            .arg( originalEmptyGeometryAttributes.value( attrs ) )
+        );
+      }
+      else
+      {
+        originalEmptyGeometryAttributes.insert( attrs, f.id() );
+      }
+    }
+    else // no geometry
     {
       if ( originalNullGeometryAttributes.contains( attrs ) )
       {
@@ -282,7 +300,16 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
         matched = true;
       }
     }
-    else
+    else if ( revisedFeature.hasGeometry() && revisedFeature.geometry().isEmpty() )
+    {
+      if ( originalEmptyGeometryAttributes.contains( attrs ) )
+      {
+        // found a match for feature
+        unchangedOriginalIds.insert( originalEmptyGeometryAttributes.value( attrs ) );
+        matched = true;
+      }
+    }
+    else // revised feature has non-empty geometry
     {
       // can we match this feature?
       const QList<QgsFeatureId> candidates = index.intersects( revisedFeature.geometry().boundingBox() );

--- a/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
+++ b/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
@@ -227,7 +227,8 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
     }
     else if ( f.hasGeometry() && f.geometry().isEmpty() )
     {
-      if ( originalEmptyGeometryAttributes.contains( attrs ) )
+      auto emptyGeomIt = originalEmptyGeometryAttributes.constFind( attrs );
+      if ( emptyGeomIt != originalEmptyGeometryAttributes.constEnd() )
       {
         feedback->reportError(
           QObject::tr(
@@ -235,7 +236,7 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
             "one or more features with EMPTY geometries - results may be misleading (features %1 and %2)"
           )
             .arg( f.id() )
-            .arg( originalEmptyGeometryAttributes.value( attrs ) )
+            .arg( emptyGeomIt.value() )
         );
       }
       else
@@ -303,10 +304,11 @@ QVariantMap QgsDetectVectorChangesAlgorithm::processAlgorithm( const QVariantMap
     }
     else if ( revisedFeature.hasGeometry() && revisedFeature.geometry().isEmpty() )
     {
-      if ( originalEmptyGeometryAttributes.contains( attrs ) )
+      auto emptyIt = originalEmptyGeometryAttributes.constFind( attrs );
+      if ( emptyIt != originalEmptyGeometryAttributes.constEnd() )
       {
         // found a match for feature
-        unchangedOriginalIds.insert( originalEmptyGeometryAttributes.value( attrs ) );
+        unchangedOriginalIds.insert( emptyIt.value() );
         matched = true;
       }
     }

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -4984,6 +4984,9 @@ void TestQgsProcessingAlgsPt1::compareDatasets()
   QCOMPARE( results.value( u"ADDED_COUNT"_s ).toLongLong(), 2LL );
   QCOMPARE( results.value( u"DELETED_COUNT"_s ).toLongLong(), 0LL );
 
+  // Prepare an empty geometry for subsequent checks
+  std::unique_ptr< QgsAbstractGeometry > emptyGeom( f.geometry().constGet()->createEmptyWithSameType() );
+
   // null geometry comparisons
   f.setAttributes( QgsAttributes() << 5 << u"d1"_s << u"g1"_s );
   f.clearGeometry();
@@ -5009,6 +5012,32 @@ void TestQgsProcessingAlgsPt1::compareDatasets()
   QCOMPARE( results.value( u"UNCHANGED_COUNT"_s ).toLongLong(), 4LL );
   QCOMPARE( results.value( u"ADDED_COUNT"_s ).toLongLong(), 2LL );
   QCOMPARE( results.value( u"DELETED_COUNT"_s ).toLongLong(), 1LL );
+
+  // empty geometry comparisons
+  f.setAttributes( QgsAttributes() << 7 << u"g1"_s << u"a1"_s );
+  f.setGeometry( std::move( emptyGeom ) );
+  originalLayer->dataProvider()->addFeature( f );
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+  QCOMPARE( results.value( u"UNCHANGED_COUNT"_s ).toLongLong(), 4LL );
+  QCOMPARE( results.value( u"ADDED_COUNT"_s ).toLongLong(), 2LL );
+  QCOMPARE( results.value( u"DELETED_COUNT"_s ).toLongLong(), 2LL );
+
+  f.setAttributes( QgsAttributes() << 7 << u"g1"_s << u"c1"_s );
+  originalLayer->dataProvider()->addFeature( f );
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+  QCOMPARE( results.value( u"UNCHANGED_COUNT"_s ).toLongLong(), 4LL );
+  QCOMPARE( results.value( u"ADDED_COUNT"_s ).toLongLong(), 2LL );
+  QCOMPARE( results.value( u"DELETED_COUNT"_s ).toLongLong(), 3LL );
+
+  f.setAttributes( QgsAttributes() << 7 << u"g1"_s << u"a1"_s );
+  revisedLayer->dataProvider()->addFeature( f );
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+  QCOMPARE( results.value( u"UNCHANGED_COUNT"_s ).toLongLong(), 5LL );
+  QCOMPARE( results.value( u"ADDED_COUNT"_s ).toLongLong(), 2LL );
+  QCOMPARE( results.value( u"DELETED_COUNT"_s ).toLongLong(), 2LL );
 }
 
 void TestQgsProcessingAlgsPt1::shapefileEncoding()

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -5038,6 +5038,13 @@ void TestQgsProcessingAlgsPt1::compareDatasets()
   QCOMPARE( results.value( u"UNCHANGED_COUNT"_s ).toLongLong(), 5LL );
   QCOMPARE( results.value( u"ADDED_COUNT"_s ).toLongLong(), 2LL );
   QCOMPARE( results.value( u"DELETED_COUNT"_s ).toLongLong(), 2LL );
+
+  // check EMPTY geometry in output layer
+  QgsFeatureIterator featIt = qobject_cast<QgsVectorLayer *>( context->getMapLayer( results.value( u"UNCHANGED"_s ).toString() ) )->getFeatures( u"pk = 7"_s );
+  QgsFeature outputFeat;
+  QVERIFY( featIt.nextFeature( outputFeat ) );
+  QVERIFY( outputFeat.isValid() );
+  QVERIFY( outputFeat.geometry().isEmpty() && !outputFeat.geometry().isNull() );
 }
 
 void TestQgsProcessingAlgsPt1::shapefileEncoding()

--- a/tests/src/analysis/testqgsprocessingalgspt1.cpp
+++ b/tests/src/analysis/testqgsprocessingalgspt1.cpp
@@ -28,6 +28,7 @@
 #include "qgsfillsymbol.h"
 #include "qgsfontutils.h"
 #include "qgsgdalutils.h"
+#include "qgsgeometryfactory.h"
 #include "qgslayoutitemmap.h"
 #include "qgslayoutitemscalebar.h"
 #include "qgslayoutmanager.h"
@@ -4984,9 +4985,6 @@ void TestQgsProcessingAlgsPt1::compareDatasets()
   QCOMPARE( results.value( u"ADDED_COUNT"_s ).toLongLong(), 2LL );
   QCOMPARE( results.value( u"DELETED_COUNT"_s ).toLongLong(), 0LL );
 
-  // Prepare an empty geometry for subsequent checks
-  std::unique_ptr< QgsAbstractGeometry > emptyGeom( f.geometry().constGet()->createEmptyWithSameType() );
-
   // null geometry comparisons
   f.setAttributes( QgsAttributes() << 5 << u"d1"_s << u"g1"_s );
   f.clearGeometry();
@@ -5014,6 +5012,7 @@ void TestQgsProcessingAlgsPt1::compareDatasets()
   QCOMPARE( results.value( u"DELETED_COUNT"_s ).toLongLong(), 1LL );
 
   // empty geometry comparisons
+  auto emptyGeom = QgsGeometryFactory::geomFromWkbType( originalLayer->wkbType() );
   f.setAttributes( QgsAttributes() << 7 << u"g1"_s << u"a1"_s );
   f.setGeometry( std::move( emptyGeom ) );
   originalLayer->dataProvider()->addFeature( f );


### PR DESCRIPTION

Includes unit tests.

Fix #66461 

---------------

_No AI was used._