### PR TITLE
Fix bad behavior on widget detection of JSON fields

### DIFF
--- a/src/gui/editorwidgets/qgsjsoneditwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsjsoneditwidgetfactory.cpp
@@ -38,25 +38,13 @@ QgsEditorConfigWidget *QgsJsonEditWidgetFactory::configWidget( QgsVectorLayer *v
 
 unsigned int QgsJsonEditWidgetFactory::fieldScore( const QgsVectorLayer *vl, int fieldIdx ) const
 {
-  const QMetaType::Type type = vl->fields().field( fieldIdx ).type();
-
-  switch ( type )
+  const QgsField field = vl->fields().field( fieldIdx );
+  // Handle the json field
+  if ( field.typeName().compare( u"json"_s, Qt::CaseInsensitive ) == 0 || field.typeName().compare( u"jsonb"_s, Qt::CaseInsensitive ) == 0 )
   {
-    case QMetaType::Type::QVariantMap:
-    {
-      const QString typeName = vl->fields().field( fieldIdx ).typeName();
-      if ( typeName == "json"_L1 || typeName == "jsonb"_L1 )
-        return 21;
-      return 15;
-    }
-    break;
-    case QMetaType::Type::QVariantList:
-      return 10;
-      break;
-    default:
-      return 5;
-      break;
+    return 15;
   }
+  return 5;
 }
 
 bool QgsJsonEditWidgetFactory::isReadOnly() const

--- a/src/gui/editorwidgets/qgskeyvaluewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetfactory.cpp
@@ -46,9 +46,10 @@ QgsEditorConfigWidget *QgsKeyValueWidgetFactory::configWidget( QgsVectorLayer *v
 unsigned int QgsKeyValueWidgetFactory::fieldScore( const QgsVectorLayer *vl, int fieldIdx ) const
 {
   const QgsField field = vl->fields().field( fieldIdx );
-  if ( field.type() == QMetaType::Type::QVariantMap && ( field.typeName().compare( u"JSON"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 || field.subType() == QMetaType::Type::QString ) )
+  // Handle the json field
+  if ( field.typeName().compare( u"json"_s, Qt::CaseInsensitive ) == 0 || field.typeName().compare( u"jsonb"_s, Qt::CaseInsensitive ) == 0 )
   {
-    // Look for the first not-null value (limiting to the first 20 features) and check if it is really a map
+    // Look for the values in the first 20 features check if it contains only maps
     const int MAX_FEATURE_LIMIT { 20 };
     QgsFeatureRequest req;
     req.setFlags( Qgis::FeatureRequestFlag::NoGeometry );
@@ -58,6 +59,8 @@ unsigned int QgsKeyValueWidgetFactory::fieldScore( const QgsVectorLayer *vl, int
     QgsFeatureIterator featureIt { vl->getFeatures( req ) };
     // The counter is an extra safety measure in case the provider does not respect the limit
     int featureCount = 0;
+    bool foundNotNull = false;
+    bool foundInvalidValue = false; // An invalid value is any value that is not a JSON object (map) or an object with nested or invalid values
     while ( featureIt.nextFeature( f ) )
     {
       ++featureCount;
@@ -69,28 +72,73 @@ unsigned int QgsKeyValueWidgetFactory::fieldScore( const QgsVectorLayer *vl, int
       const QVariant value( f.attribute( fieldIdx ) );
       if ( !value.isNull() )
       {
-        switch ( value.type() )
+        foundNotNull = true;
+
+        // Read the object from string or map
+        QJsonObject jsonObject;
+        bool validObject = false;
+        if ( value.type() == QVariant::Type::Map )
         {
-          case QVariant::Type::Map:
+          validObject = true;
+          jsonObject = QJsonObject::fromVariantMap( value.toMap() );
+        }
+        else
+        {
+          const QJsonDocument doc = QJsonDocument::fromJson( value.toString().toUtf8() );
+          if ( doc.isObject() )
           {
-            return 20;
+            validObject = true;
+            jsonObject = doc.object();
           }
-          default:
-          case QVariant::Type::String:
+        }
+        if ( validObject ) // empty object {} counts as valid as well
+        {
+          // It's a map, check the first 20 entries if flat (not nested)
+          int count = 0;
+          for ( auto it = jsonObject.begin(); it != jsonObject.end(); ++it )
           {
-            const QJsonDocument doc = QJsonDocument::fromJson( value.toString().toUtf8() );
-            if ( doc.isObject() )
+            if ( count >= 20 )
             {
-              return 20;
+              break;
             }
-            else
+            count++;
+            QJsonValue childValue = it.value();
+            if ( childValue.isObject() || childValue.isArray() || childValue.isUndefined() )
             {
-              return 0;
+              // Stop when we find the first nested object
+              foundInvalidValue = true;
+              break;
             }
           }
+          if ( foundInvalidValue )
+          {
+            break;
+          }
+        }
+        else
+        {
+          // Stop when we find the first non-map value
+          foundInvalidValue = true;
+          break;
         }
       }
     }
+    if ( foundNotNull )
+    {
+      if ( !foundInvalidValue )
+      {
+        return 20;
+      }
+      else
+      {
+        return 5;
+      }
+    }
+    else
+    {
+      return 10;
+    }
   }
+
   return field.type() == QMetaType::Type::QVariantMap && field.subType() != QMetaType::Type::UnknownType ? 20 : 0;
 }

--- a/src/gui/editorwidgets/qgskeyvaluewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetfactory.cpp
@@ -102,7 +102,7 @@ unsigned int QgsKeyValueWidgetFactory::fieldScore( const QgsVectorLayer *vl, int
               break;
             }
             count++;
-            QJsonValue childValue = it.value();
+            const QJsonValue childValue = it.value();
             if ( childValue.isObject() || childValue.isArray() || childValue.isUndefined() )
             {
               // Stop when we find the first nested object

--- a/src/gui/editorwidgets/qgslistwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetfactory.cpp
@@ -24,6 +24,7 @@
 #include <QSettings>
 #include <QString>
 #include <QVariant>
+#include <qjsonarray.h>
 
 using namespace Qt::StringLiterals;
 
@@ -44,8 +45,8 @@ QgsEditorConfigWidget *QgsListWidgetFactory::configWidget( QgsVectorLayer *vl, i
 unsigned int QgsListWidgetFactory::fieldScore( const QgsVectorLayer *vl, int fieldIdx ) const
 {
   const QgsField field = vl->fields().field( fieldIdx );
-  // Check if this is a JSON field misinterpreted as a map
-  if ( field.type() == QMetaType::Type::QVariantMap && ( field.typeName().compare( u"JSON"_s, Qt::CaseSensitivity::CaseInsensitive ) == 0 || field.subType() == QMetaType::Type::QString ) )
+  // Handle the json field
+  if ( field.typeName().compare( u"json"_s, Qt::CaseInsensitive ) == 0 || field.typeName().compare( u"jsonb"_s, Qt::CaseInsensitive ) == 0 )
   {
     // Look the first not-null value (limiting to the first 20 features) and check if it is really an array
     const int MAX_FEATURE_LIMIT { 20 };
@@ -57,6 +58,8 @@ unsigned int QgsListWidgetFactory::fieldScore( const QgsVectorLayer *vl, int fie
     QgsFeatureIterator featureIt { vl->getFeatures( req ) };
     // The counter is an extra safety measure in case the provider does not respect the limit
     int featureCount = 0;
+    bool foundNotNull = false;
+    bool foundInvalidValue = false; // An invalid value is any value that is not a JSON list or a list with nested or invalid values
     while ( featureIt.nextFeature( f ) )
     {
       ++featureCount;
@@ -68,29 +71,75 @@ unsigned int QgsListWidgetFactory::fieldScore( const QgsVectorLayer *vl, int fie
       const QVariant value( f.attribute( fieldIdx ) );
       if ( !value.isNull() )
       {
-        switch ( value.type() )
+        foundNotNull = true;
+
+        // Read the list from a string or a list
+        QJsonArray jsonArray;
+        bool validArray = false;
+        if ( value.type() == QVariant::Type::List )
         {
-          case QVariant::Type::List:
+          validArray = true;
+          jsonArray = QJsonArray::fromVariantList( value.toList() );
+        }
+        else
+        {
+          const QJsonDocument doc = QJsonDocument::fromJson( value.toString().toUtf8() );
+          if ( doc.isArray() )
           {
-            return 20;
+            validArray = true;
+            jsonArray = doc.array();
           }
-          default:
-          case QVariant::Type::String:
+        }
+
+        if ( validArray ) // empty array [] counts as valid as well
+        {
+          // It's a array(list), check the first 20 entries if flat (not nested)
+          int count = 0;
+          for ( auto it = jsonArray.begin(); it != jsonArray.end(); ++it )
           {
-            const QJsonDocument doc = QJsonDocument::fromJson( value.toString().toUtf8() );
-            if ( doc.isArray() )
+            if ( count >= 20 )
             {
-              return 20;
+              break;
             }
-            else
+            count++;
+
+            QJsonValue childValue = *it;
+            if ( childValue.isObject() || childValue.isArray() || childValue.isUndefined() )
             {
-              return 0;
+              foundInvalidValue = true;
+              break;
             }
           }
+          if ( foundInvalidValue )
+          {
+            break;
+          }
+        }
+        else
+        {
+          // Stop when we find the first not-array
+          foundInvalidValue = true;
+          break;
         }
       }
     }
+    if ( foundNotNull )
+    {
+      if ( !foundInvalidValue )
+      {
+        return 20;
+      }
+      else
+      {
+        return 5;
+      }
+    }
+    else
+    {
+      return 10;
+    }
   }
+
   return ( field.type() == QMetaType::Type::QVariantList || field.type() == QMetaType::Type::QStringList || field.type() == QMetaType::Type::QVariantMap )
              && field.subType() != QMetaType::Type::UnknownType
            ? 20

--- a/tests/src/python/test_qgsattributeformeditorwidget.py
+++ b/tests/src/python/test_qgsattributeformeditorwidget.py
@@ -278,8 +278,6 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
         layer = QgsVectorLayer("Point?", "test", "memory")
         field_typename = "JSON"
         self.verifyJSONTypeFindBest(QVariant.Map, layer, field_typename)
-        # TODO: self.verifyJSONTypeFindBest(QVariant.List, layer, field_typename)
-        # TODO: self.verifyJSONTypeFindBest(QVariant.String, layer, field_typename)
 
     def testJSONPostgresLikeLayer(self):
         # we make a memory layer but pass the type json and jsonb
@@ -292,8 +290,6 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
         jsonb_layer = QgsVectorLayer("Point?", "test", "memory")
         field_typename = "jsonb"
         self.verifyJSONTypeFindBest(QVariant.Map, jsonb_layer, field_typename)
-        # TODO: self.verifyJSONTypeFindBest(QVariant.List, layer, field_typename)
-        # TODO: self.verifyJSONTypeFindBest(QVariant.String, layer, field_typename)
 
     def testJSONGeoPackageLayer(self):
         temp_dir = QTemporaryDir()
@@ -309,8 +305,6 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
         layer = QgsVectorLayer(uri, "test", "ogr")
         field_typename = "JSON"
         self.verifyJSONTypeFindBest(QVariant.Map, layer, field_typename)
-        # TODO: self.verifyJSONTypeFindBest(QVariant.List, layer, field_typename)
-        # TODO: self.verifyJSONTypeFindBest(QVariant.String, layer, field_typename)
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsattributeformeditorwidget.py
+++ b/tests/src/python/test_qgsattributeformeditorwidget.py
@@ -284,8 +284,6 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
         json_layer = QgsVectorLayer("Point?", "test", "memory")
         field_typename = "json"
         self.verifyJSONTypeFindBest(QVariant.Map, json_layer, field_typename)
-        # TODO: self.verifyJSONTypeFindBest(QVariant.List, layer, field_typename)
-        # TODO: self.verifyJSONTypeFindBest(QVariant.String, layer, field_typename)
 
         jsonb_layer = QgsVectorLayer("Point?", "test", "memory")
         field_typename = "jsonb"

--- a/tests/src/python/test_qgsattributeformeditorwidget.py
+++ b/tests/src/python/test_qgsattributeformeditorwidget.py
@@ -197,11 +197,20 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
         self.assertEqual(setup.type(), "JsonEdit")
         self.assertTrue(layer.rollBack())
 
-        # Add a string record which is neither a list nor a map (meaning no valid JSON at all). It's not really editable, so - to show it's a JSON field - should take JSON edit.
+        # Add string records that are a primitive types like a string, a number or a boolean or no valid JSON at all, so it should take JSON edit.
         self.assertTrue(layer.startEditing())
         self.assertTrue(layer.addAttribute(field))
         feature = QgsFeature(layer.fields())
-        feature.setAttribute("json", "not a valid json value")
+        feature.setAttribute("json", "1")
+        self.assertTrue(layer.addFeature(feature))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", "true")
+        self.assertTrue(layer.addFeature(feature))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", '"Hello"')
+        self.assertTrue(layer.addFeature(feature))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", "not a valid {json: value]")
         self.assertTrue(layer.addFeature(feature))
         setup = registry.findBest(layer, "json")
         self.assertEqual(setup.type(), "JsonEdit")

--- a/tests/src/python/test_qgsattributeformeditorwidget.py
+++ b/tests/src/python/test_qgsattributeformeditorwidget.py
@@ -111,21 +111,23 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
             "\"fldtext\"<'2013-05-06' OR \"fldtext\">'2013-05-16'",
         )
 
-    def verifyJSONTypeFindBest(self, field_type, layer):
-
+    def verifyJSONTypeFindBest(self, field_type, layer, field_typename):
         # Create a JSON field
-        field = QgsField("json", field_type, "JSON", 0, 0, "comment", QVariant.String)
+        field = QgsField(
+            "json", field_type, field_typename, 0, 0, "comment", QVariant.String
+        )
+
+        # No records, so should default to json edit
         self.assertTrue(layer.startEditing())
         self.assertTrue(layer.addAttribute(field))
-        self.assertTrue(layer.commitChanges())
-
-        # No records, so should default to key/value
         registry = QgsGui.editorWidgetRegistry()
         setup = registry.findBest(layer, "json")
-        self.assertEqual(setup.type(), "KeyValue")
+        self.assertEqual(setup.type(), "JsonEdit")
+        self.assertTrue(layer.rollBack())
 
-        # Add a key/value record
-        layer.startEditing()
+        # Add a flat map record, so should take key/value
+        self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
         feature = QgsFeature(layer.fields())
         feature.setAttribute("json", '{"key": "value"}')
         self.assertTrue(layer.addFeature(feature))
@@ -133,8 +135,9 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
         self.assertEqual(setup.type(), "KeyValue")
         layer.rollBack()
 
-        # Add an array record
+        # Add a flat array record, so should take list
         self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
         feature = QgsFeature(layer.fields())
         feature.setAttribute("json", '["value", "another_value"]')
         self.assertTrue(layer.addFeature(feature))
@@ -142,23 +145,45 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
         self.assertEqual(setup.type(), "List")
         self.assertTrue(layer.rollBack())
 
-        # Add a null record followed by a map record followed by a list record
+        # Add an empty map record (not null), so should take key/value
         self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
         feature = QgsFeature(layer.fields())
-        feature.setAttribute("json", None)
-        self.assertTrue(layer.addFeature(feature))
-        feature = QgsFeature(layer.fields())
-        feature.setAttribute("json", '{"key": "value"}')
-        self.assertTrue(layer.addFeature(feature))
-        feature = QgsFeature(layer.fields())
-        feature.setAttribute("json", '["value", "another_value"]')
+        feature.setAttribute("json", "{}")
         self.assertTrue(layer.addFeature(feature))
         setup = registry.findBest(layer, "json")
         self.assertEqual(setup.type(), "KeyValue")
         self.assertTrue(layer.rollBack())
 
-        # Add a null record followed by A list record followed by a map record
+        # Add an empty array record (not null), so should take list
         self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", "[]")
+        self.assertTrue(layer.addFeature(feature))
+        setup = registry.findBest(layer, "json")
+        self.assertEqual(setup.type(), "List")
+        self.assertTrue(layer.rollBack())
+
+        # Add a null record followed by a flat map record followed by a flat list record, so should take json edit
+        self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", None)
+        self.assertTrue(layer.addFeature(feature))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", '{"key": "value"}')
+        self.assertTrue(layer.addFeature(feature))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", '["value", "another_value"]')
+        self.assertTrue(layer.addFeature(feature))
+        setup = registry.findBest(layer, "json")
+        self.assertEqual(setup.type(), "JsonEdit")
+        self.assertTrue(layer.rollBack())
+
+        # Add a null record followed by a flat list record followed by a flat map record, so should take json edit
+        self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
         feature = QgsFeature(layer.fields())
         feature.setAttribute("json", None)
         self.assertTrue(layer.addFeature(feature))
@@ -169,21 +194,33 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
         feature.setAttribute("json", '{"key": "value"}')
         self.assertTrue(layer.addFeature(feature))
         setup = registry.findBest(layer, "json")
-        self.assertEqual(setup.type(), "List")
+        self.assertEqual(setup.type(), "JsonEdit")
         self.assertTrue(layer.rollBack())
 
-        # Add a string record which is neither a list or a map
+        # Add a string record which is neither a list nor a map (meaning no valid JSON at all). It's not really editable, so - to show it's a JSON field - should take JSON edit.
         self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
         feature = QgsFeature(layer.fields())
-        feature.setAttribute("json", "not a list or map")
+        feature.setAttribute("json", "not a valid json value")
         self.assertTrue(layer.addFeature(feature))
         setup = registry.findBest(layer, "json")
-        self.assertNotEqual(setup.type(), "List")
-        self.assertNotEqual(setup.type(), "KeyValue")
+        self.assertEqual(setup.type(), "JsonEdit")
         self.assertTrue(layer.rollBack())
 
-        # Add 21 records with a JSON field, only the last is NOT NULL
+        # Add 5 records with NULL values, so should default to json edit
         self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
+        for i in range(5):
+            feature = QgsFeature(layer.fields())
+            feature.setAttribute("json", None)
+            self.assertTrue(layer.addFeature(feature))
+        setup = registry.findBest(layer, "json")
+        self.assertEqual(setup.type(), "JsonEdit")
+        self.assertTrue(layer.rollBack())
+
+        # Add 20 records with NULL values in JSON field, and one last is NOT NULL (a flat list), so should default to json edit
+        self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
         for i in range(20):
             feature = QgsFeature(layer.fields())
             feature.setAttribute("json", None)
@@ -192,24 +229,64 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
         feature.setAttribute("json", '["value", "another_value"]')
         self.assertTrue(layer.addFeature(feature))
         setup = registry.findBest(layer, "json")
-        self.assertNotEqual(setup.type(), "List")
-        # KeyValue is the default,
-        self.assertEqual(setup.type(), "KeyValue")
+        self.assertEqual(setup.type(), "JsonEdit")
+        self.assertTrue(layer.rollBack())
+
+        # Add a flat and a complex map, so should default to json edit
+        self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", '{"key": "value"}')
+        self.assertTrue(layer.addFeature(feature))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", '{"key": ["value", "another_value"]}')
+        self.assertTrue(layer.addFeature(feature))
+        setup = registry.findBest(layer, "json")
+        self.assertEqual(setup.type(), "JsonEdit")
+        self.assertTrue(layer.rollBack())
+
+        # Add a flat and a complex list, so should default to json edit
+        self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", '["value", "another_value"]')
+        self.assertTrue(layer.addFeature(feature))
+        feature = QgsFeature(layer.fields())
+        feature.setAttribute("json", '["value", {"key": "value"}]')
+        self.assertTrue(layer.addFeature(feature))
+        setup = registry.findBest(layer, "json")
+        self.assertEqual(setup.type(), "JsonEdit")
         self.assertTrue(layer.rollBack())
 
         # Cleanup removing the field
         self.assertTrue(layer.startEditing())
+        self.assertTrue(layer.addAttribute(field))
         field_idx = layer.fields().indexOf("json")
         self.assertTrue(layer.deleteAttribute(field_idx))
         self.assertTrue(layer.commitChanges())
 
     def testJSONMemoryLayer(self):
-
         layer = QgsVectorLayer("Point?", "test", "memory")
-        self.verifyJSONTypeFindBest(QVariant.Map, layer)
+        field_typename = "JSON"
+        self.verifyJSONTypeFindBest(QVariant.Map, layer, field_typename)
+        # TODO: self.verifyJSONTypeFindBest(QVariant.List, layer, field_typename)
+        # TODO: self.verifyJSONTypeFindBest(QVariant.String, layer, field_typename)
+
+    def testJSONPostgresLikeLayer(self):
+        # we make a memory layer but pass the type json and jsonb
+        json_layer = QgsVectorLayer("Point?", "test", "memory")
+        field_typename = "json"
+        self.verifyJSONTypeFindBest(QVariant.Map, json_layer, field_typename)
+        # TODO: self.verifyJSONTypeFindBest(QVariant.List, layer, field_typename)
+        # TODO: self.verifyJSONTypeFindBest(QVariant.String, layer, field_typename)
+
+        jsonb_layer = QgsVectorLayer("Point?", "test", "memory")
+        field_typename = "jsonb"
+        self.verifyJSONTypeFindBest(QVariant.Map, jsonb_layer, field_typename)
+        # TODO: self.verifyJSONTypeFindBest(QVariant.List, layer, field_typename)
+        # TODO: self.verifyJSONTypeFindBest(QVariant.String, layer, field_typename)
 
     def testJSONGeoPackageLayer(self):
-
         temp_dir = QTemporaryDir()
         uri = temp_dir.filePath("test.gpkg")
         # Create a new geopackage layer using ogr
@@ -221,7 +298,10 @@ class PyQgsAttributeFormEditorWidget(QgisTestCase):
         del layer
         del ds
         layer = QgsVectorLayer(uri, "test", "ogr")
-        self.verifyJSONTypeFindBest(QVariant.Map, layer)
+        field_typename = "JSON"
+        self.verifyJSONTypeFindBest(QVariant.Map, layer, field_typename)
+        # TODO: self.verifyJSONTypeFindBest(QVariant.List, layer, field_typename)
+        # TODO: self.verifyJSONTypeFindBest(QVariant.String, layer, field_typename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

On fieldScore it checks the `typeName` only for json (JSON) and jsonb. It generally returns a `fieldScore` of 15 for `JsonEdit` and is only scooped with 20 by `KeyValue` or `List` widgets on **flat objects or arrays** only in the first 20 entries. This fixes #62377 

This fixes unaligned behavior on widget detection on JSON fields. Depending on the provider, a different widget was detected for what is essentially the same data type. PostgreSQL exclusively used `JsonEdit` (Json View), whereas OGR fields were mapped sometimes as `List` or `KeyValue`.

Furthermore, this fixes an issue where more complex structures (non-flat arrays and objects), meaning nested JSON structures based on OGR, were also mapped as `List` or `KeyValue` widgets. This could lead to data corruption when editing (and consequently overwriting) such a field, as the widgets cannot represent the more complex structures at all.

This PR changes nothing on the JSON field handling on the providers.

## Implementation

### Use cases 

1. No records, so should take **json edit** (this is a change on GPKG from key/value to json edit (same as on PG))
2. Only NULL records, so should take **json edit** (this is a change on GPKG from key/value to json edit (same as on PG))
3. Flat object (map) record *only* in the first 20 records (and empty objects {} count as flat objects), so should take **key/value** (this is a change on PG from json edit to key/value (same as on GPKG))
4. Flat array record *only* in the first 20 records  (and empty arrays [] count as flat arrays), so should take **list** (this is a change on PG from json edit to list (same as on GPKG))
5. Flat arrays and objects (maps) mixed in the first 20 records, so should take **json edit** (this is a change on both because it used to take the first one found, which was bad misbehavior)
6. Record which is neither a list nor a map but primitive types instead (numbers, strings, boolean or json-null) should take **json edit** (this is a change on GPKG from key/value to json edit (same as on PG))
7. Record which is no valid JSON at all should take **json edit** (this is a change on GPKG from key/value to json edit (same as on PG))
8. Complex objects (maps) (with nested objects) in the first 20 records, so should take **json edit** (this is a change on GPKG because it used to take widgets that cannot display and would overwrite data)
9. Complex arrays (with nested objects) mixed in the first 20 records, so should take **json edit** (this is a change on GPKG because it used to take widgets that cannot display and would overwrite data)

### Field score returned in specific use cases:

| Use Case | JsonEdit | KeyValue | List | TextEdit |
| ---      | ---      | ---      | ---  | ---      |
| **1**    | 15       | 10       | 10   | 10       |
| **2**    | 15       | 10       | 10   | 10       |
| **3**    | 10       | 20       |  5   | 10       |
| **4**    | 10       |  5       | 20   | 10       |
| **5**    | 15       |  5       |  5   | 10       |
| **6**    | 15       |  5       |  5   | 10       |
| **7**    | 15       |  5       |  5   | 10       |
| **8**    | 15       |  5       |  5   | 10       |
| **9**    | 15       |  5       |  5   | 10       |

From the docstring of `fieldScore`:
``` 
- 0: not supported
- 5: maybe support (for example, Datetime support strings depending on their content)
- 10: basic support (this is what returns TextEdit for example, since it supports everything in a crude way)
- 20: specialized support
```

### Summary
- `JsonEdit` returns 15 on all the json fields and will be scooped in case **3** and and **4**.
- `KeyValue` returns 10 on null or none (case **1** and **2**) and will be scooped out by `JsonEdit`, but on case **3** it will get it with 20 by finding only flat or empty maps in the first 20 entries
- `List` returns 10 on null or none (case **1** and **2**) and will be scooped out by `JsonEdit`, but on case **4** it will get it with 20 by finding only flat or empty maps in the first 20 **entries**

## AI tool usage

Internet research including Google Gemini AI, but not used code written by it.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
