### PR TITLE
qgsvectorlayerprofilegenerator: Fix generateProfileForLines for null tolerance

### DIFF
--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -1087,7 +1087,21 @@ bool QgsVectorLayerProfileGenerator::generateProfileForLines()
       }
       else if ( const QgsLineString *intersectionCurve = qgsgeometry_cast< const QgsLineString * >( *it ) )
       {
-        processIntersectionCurve( intersectionCurve, feature );
+        // Intersection geometries may not preserve the original Z values
+        // Rebuild the intersection curve by recovering the 3D coordinates from featGeomPart
+        auto lineInterpolated = std::make_unique<QgsLineString>();
+        for ( int i = 0; i < intersectionCurve->numPoints(); ++i )
+        {
+          const QgsPoint pt = intersectionCurve->pointN( i );
+
+          QString err;
+          const double distance = featGeomPartGeos.lineLocatePoint( pt, &err );
+
+          std::unique_ptr<QgsPoint> pointWithInterpolatedZM( featGeomPart->interpolatePoint( distance ) );
+          lineInterpolated->addVertex( *pointWithInterpolatedZM );
+        }
+
+        processIntersectionCurve( lineInterpolated.get(), feature );
       }
     }
   };

--- a/src/core/vector/qgsvectorlayerprofilegenerator.cpp
+++ b/src/core/vector/qgsvectorlayerprofilegenerator.cpp
@@ -1058,11 +1058,17 @@ bool QgsVectorLayerProfileGenerator::generateProfileForLines()
     if ( mFeedback->isCanceled() )
       return;
 
-
+    // Vertical line case
     // Intersection is empty : GEOS issue for vertical intersection : use feature geometry as intersection
     if ( intersection->isEmpty() )
     {
       intersection.reset( featGeomPart->clone() );
+      for ( auto it = intersection->const_parts_begin(); !mFeedback->isCanceled() && it != intersection->const_parts_end(); ++it )
+      {
+        if ( const QgsLineString *intersectionCurve = qgsgeometry_cast< const QgsLineString * >( *it ) )
+          processIntersectionCurve( intersectionCurve, feature );
+      }
+      return;
     }
 
     QgsGeos featGeomPartGeos( featGeomPart );

--- a/tests/src/python/test_qgsvectorlayerprofilegenerator.py
+++ b/tests/src/python/test_qgsvectorlayerprofilegenerator.py
@@ -2847,6 +2847,7 @@ class TestQgsVectorLayerProfileGenerator(QgisTestCase):
         layer: QgsVectorLayer,
         expectedFeatures: list[list[tuple[int, int]]],
         geomType: Qgis.GeometryType,
+        allowNullHeight: bool = False,
     ):
         """
         The expectedFeatures is a list of valid features, with each tuple
@@ -2873,7 +2874,10 @@ class TestQgsVectorLayerProfileGenerator(QgisTestCase):
             self.assertEqual(feat.geometry.type(), geomType)
 
         for _, height in enumerate(results.distanceToHeightMap()):
-            self.assertTrue(math.isnan(height) or height > 0.0)
+            if allowNullHeight:
+                self.assertTrue(math.isnan(height) or height >= 0.0)
+            else:
+                self.assertTrue(math.isnan(height) or height > 0.0)
 
         return results
 
@@ -2969,6 +2973,46 @@ class TestQgsVectorLayerProfileGenerator(QgisTestCase):
         self.doCheckLine(
             req, 50, vl, [[(1, 1), (0, 1), (2, 1)]], Qgis.GeometryType.Line
         )
+
+    def testLineGenerationFeatureIsCurve(self):
+        """
+        Test that a purely vertical feature matching the profile curve is
+        correctly handled by the generator.
+        """
+        line_wkt = (
+            "LineString Z (389688.6 4601015.0 266.1, 389690.6 4601015.4 266.4, "
+            "389695.1 4601016.3 266.4, 389696.8 4601016.6 266.2, "
+            "389698.0 4601016.9 266.2, 389705.2 4601018.4 266.3, "
+            "389707.4 4601018.8 266.3, 389710.4 4601019.4 266.4, "
+            "389714.7 4601020.3 266.7, 389719.1 4601021.2 267.0, "
+            "389721.5 4601021.7 267.1, 389723.5 4601022.1 267.3, "
+            "389733.7 4601024.3 267.9, 389746.4 4601027.0 268.7, "
+            "389753.9 4601029.0 269.3, 389759.1 4601030.9 269.8)"
+        )
+
+        vl = QgsVectorLayer("LineStringZ?crs=epsg:3857", "line", "memory")
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.crs().authid(), "EPSG:3857")
+        vl.elevationProperties().setClamping(Qgis.AltitudeClamping.Absolute)
+        vl.elevationProperties().setExtrusionEnabled(False)
+
+        vl_feature = QgsFeature()
+        vl_feature.setGeometry(QgsGeometry.fromWkt(line_wkt))
+        self.assertTrue(vl.dataProvider().addFeature(vl_feature))
+
+        # Do an intersection
+        curve = QgsLineString()
+        curve.fromWkt(line_wkt)
+        req = QgsProfileRequest(curve)
+
+        req.setCrs(QgsCoordinateReferenceSystem("EPSG:3857"))
+        generator = vl.createProfileGenerator(req)
+        self.assertTrue(generator.generateProfile())
+
+        # Check the result
+        results = generator.takeResults().asGeometries()
+        self.assertEqual(len(results), 15)
+        self.doCheckLine(req, 0, vl, [[(1, 15)]], Qgis.GeometryType.Line, True)
 
     @unittest.skipIf(
         Qgis.geosVersionMajor() == 3 and Qgis.geosVersionMinor() == 11,


### PR DESCRIPTION
## Description

Intersection geometries returned by GEOS may contain incorrect Z
values. This will result in incorrect profile lines.

This issue is fixed by rebuilding the intersection curves from the
original feature geometry.

Closes: https://github.com/qgis/QGIS/issues/65850

### Broken

<img width="1321" height="358" alt="image" src="https://github.com/user-attachments/assets/54854068-f909-440d-8d5c-eb625f5d616e" />

### Fixed

<img width="1338" height="430" alt="image" src="https://github.com/user-attachments/assets/b475d658-1263-4001-afd3-3e31b68d404a" />


## AI tool usage

No AI tool used