### PR TITLE
[vector tiles] add slice operator

### DIFF
--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -3942,15 +3942,42 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
       context.pushWarning( QObject::tr( "%1: Could not interpret slice list" ).arg( context.layerId() ) );
       return QString();
     }
+
+    // When the indices are constant integers
+    // we can fold the index arithmetic at conversion time
+    const auto constantInt = []( const QVariant &value, int &result ) -> bool {
+      switch ( value.userType() )
+      {
+        case QMetaType::Int:
+        case QMetaType::UInt:
+        case QMetaType::LongLong:
+        case QMetaType::ULongLong:
+        {
+          bool ok = false;
+          result = value.toInt( &ok );
+          return ok;
+        }
+        default:
+          return false;
+      }
+    };
+
+    int startValue = 0;
+    const bool startIsConstant = constantInt( expression.value( 2 ), startValue );
     const QString startExpression = parseValue( expression.value( 2 ), context );
+    const QString startOffset = startIsConstant ? QString::number( startValue + 1 ) : u"(%1) + 1"_s.arg( startExpression );
+
     if ( expression.size() > 3 )
     {
+      int endValue = 0;
+      const bool endIsConstant = constantInt( expression.value( 3 ), endValue );
       const QString endExpression = parseValue( expression.value( 3 ), context );
-      return u"substr(%1, (%2) + 1, (%3) - (%2))"_s.arg( inputExpression, startExpression, endExpression );
+      const QString length = ( startIsConstant && endIsConstant ) ? QString::number( endValue - startValue ) : u"(%1) - (%2)"_s.arg( endExpression, startExpression );
+      return u"substr(%1, %2, %3)"_s.arg( inputExpression, startOffset, length );
     }
     else
     {
-      return u"substr(%1, (%2) + 1)"_s.arg( inputExpression, startExpression );
+      return u"substr(%1, %2)"_s.arg( inputExpression, startOffset );
     }
   }
   else

--- a/src/core/vectortile/qgsmapboxglstyleconverter.cpp
+++ b/src/core/vectortile/qgsmapboxglstyleconverter.cpp
@@ -3931,6 +3931,28 @@ QString QgsMapBoxGlStyleConverter::parseExpression( const QVariantList &expressi
   {
     return u"0"_s;
   }
+  else if ( op == "slice"_L1 )
+  {
+    // ["slice", input, startIndex, endIndex?] returns a substring/sublist of input.
+    // MapBox indices are 0-based and endIndex is exclusive, while QGIS substr() is
+    // 1-based and takes a length
+    const QString inputExpression = parseValue( expression.value( 1 ), context );
+    if ( inputExpression.isEmpty() )
+    {
+      context.pushWarning( QObject::tr( "%1: Could not interpret slice list" ).arg( context.layerId() ) );
+      return QString();
+    }
+    const QString startExpression = parseValue( expression.value( 2 ), context );
+    if ( expression.size() > 3 )
+    {
+      const QString endExpression = parseValue( expression.value( 3 ), context );
+      return u"substr(%1, (%2) + 1, (%3) - (%2))"_s.arg( inputExpression, startExpression, endExpression );
+    }
+    else
+    {
+      return u"substr(%1, (%2) + 1)"_s.arg( inputExpression, startExpression );
+    }
+  }
   else
   {
     context.pushWarning( QObject::tr( "%1: Skipping unsupported expression \"%2\"" ).arg( context.layerId(), op ) );

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -22,14 +22,12 @@ from qgis.core import (
     QgsPalLayerSettings,
     QgsRasterLayer,
     QgsRasterPipe,
-    QgsSettings,
     QgsSymbol,
     QgsSymbolLayer,
     QgsWkbTypes,
     qgsDoubleNear,
 )
 from qgis.PyQt.QtCore import (
-    QCoreApplication,
     QSize,
     QSizeF,
     Qt,
@@ -846,6 +844,57 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
                 False,
             ),
             """concat("numero", "indice_de_repetition")""",
+        )
+
+        # slice with start and end index
+        self.assertEqual(
+            QgsMapBoxGlStyleConverter.parseExpression(
+                ["slice", ["get", "ue_kz"], 0, 1],
+                conversion_context,
+                False,
+            ),
+            """substr("ue_kz", (0) + 1, (1) - (0))""",
+        )
+
+        # slice with start index only
+        self.assertEqual(
+            QgsMapBoxGlStyleConverter.parseExpression(
+                ["slice", ["get", "ue_kz"], 2],
+                conversion_context,
+                False,
+            ),
+            """substr("ue_kz", (2) + 1)""",
+        )
+
+        # slice used within a filter expression
+        self.assertEqual(
+            QgsMapBoxGlStyleConverter.parseExpression(
+                [
+                    "all",
+                    ["==", ["get", "art"], "T"],
+                    [
+                        "in",
+                        ["slice", ["get", "ue_kz"], 0, 1],
+                        [
+                            "literal",
+                            ["A", "B", "C", "D", "E", "F", "G", "H", "U", "V"],
+                        ],
+                    ],
+                ],
+                conversion_context,
+                False,
+            ),
+            """("art" IS 'T') AND (substr("ue_kz", (0) + 1, (1) - (0)) IN ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'U', 'V'))""",
+        )
+
+        # slice compared with == within a filter expression
+        self.assertEqual(
+            QgsMapBoxGlStyleConverter.parseExpression(
+                ["==", ["slice", ["get", "ue_kz"], 0, 1], "T"],
+                conversion_context,
+                False,
+            ),
+            """substr("ue_kz", (0) + 1, (1) - (0)) IS 'T'""",
         )
 
         self.assertEqual(

--- a/tests/src/python/test_qgsmapboxglconverter.py
+++ b/tests/src/python/test_qgsmapboxglconverter.py
@@ -853,7 +853,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
                 conversion_context,
                 False,
             ),
-            """substr("ue_kz", (0) + 1, (1) - (0))""",
+            """substr("ue_kz", 1, 1)""",
         )
 
         # slice with start index only
@@ -863,7 +863,17 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
                 conversion_context,
                 False,
             ),
-            """substr("ue_kz", (2) + 1)""",
+            """substr("ue_kz", 3)""",
+        )
+
+        # slice with non-constant (expression) indices: arithmetic cannot be folded
+        self.assertEqual(
+            QgsMapBoxGlStyleConverter.parseExpression(
+                ["slice", ["get", "ue_kz"], ["get", "start"], ["get", "end"]],
+                conversion_context,
+                False,
+            ),
+            """substr("ue_kz", ("start") + 1, ("end") - ("start"))""",
         )
 
         # slice used within a filter expression
@@ -884,7 +894,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
                 conversion_context,
                 False,
             ),
-            """("art" IS 'T') AND (substr("ue_kz", (0) + 1, (1) - (0)) IN ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'U', 'V'))""",
+            """("art" IS 'T') AND (substr("ue_kz", 1, 1) IN ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'U', 'V'))""",
         )
 
         # slice compared with == within a filter expression
@@ -894,7 +904,7 @@ class TestQgsMapBoxGlStyleConverter(QgisTestCase):
                 conversion_context,
                 False,
             ),
-            """substr("ue_kz", (0) + 1, (1) - (0)) IS 'T'""",
+            """substr("ue_kz", 1, 1) IS 'T'""",
         )
 
         self.assertEqual(


### PR DESCRIPTION
and make Austrian BEV Cadastre work with QGIS  @mach0 


## AI tool usage

 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
