### PR TITLE
Expose 3D map projectionType to Python

### DIFF
--- a/python/PyQt6/3d/auto_generated/qgs3dmapsettings.sip.in
+++ b/python/PyQt6/3d/auto_generated/qgs3dmapsettings.sip.in
@@ -752,7 +752,19 @@ Sets the camera lens' field of view
 .. versionadded:: 3.8
 %End
 
+    Qgis::Map3DProjectionType projectionType() const;
+%Docstring
+Returns the camera lens' projection type
 
+.. versionadded:: 4.2
+%End
+
+    void setProjectionType( const Qgis::Map3DProjectionType projectionType );
+%Docstring
+Sets the camera lens' projection type
+
+.. versionadded:: 4.2
+%End
 
 
     double cameraMovementSpeed() const;

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -7772,14 +7772,14 @@ Qgis.Map3DDebugFlags = lambda flags=0: Qgis.Map3DDebugFlag(flags)
 Qgis.Map3DDebugFlags.baseClass = Qgis
 Map3DDebugFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
-Qgis.Map3DProjectionType.OrthographicProjection.__doc__ = "Orthogonal projection"
-Qgis.Map3DProjectionType.PerspectiveProjection.__doc__ = "Perspective projection"
+Qgis.Map3DProjectionType.Orthographic.__doc__ = "Orthogonal projection"
+Qgis.Map3DProjectionType.Perspective.__doc__ = "Perspective projection"
 Qgis.Map3DProjectionType.__doc__ = """3D map projection type
 
 .. versionadded:: 4.2
 
-* ``OrthographicProjection``: Orthogonal projection
-* ``PerspectiveProjection``: Perspective projection
+* ``Orthographic``: Orthogonal projection
+* ``Perspective``: Perspective projection
 
 """
 # --

--- a/python/PyQt6/core/auto_additions/qgis.py
+++ b/python/PyQt6/core/auto_additions/qgis.py
@@ -7772,6 +7772,19 @@ Qgis.Map3DDebugFlags = lambda flags=0: Qgis.Map3DDebugFlag(flags)
 Qgis.Map3DDebugFlags.baseClass = Qgis
 Map3DDebugFlags = Qgis  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
+Qgis.Map3DProjectionType.OrthographicProjection.__doc__ = "Orthogonal projection"
+Qgis.Map3DProjectionType.PerspectiveProjection.__doc__ = "Perspective projection"
+Qgis.Map3DProjectionType.__doc__ = """3D map projection type
+
+.. versionadded:: 4.2
+
+* ``OrthographicProjection``: Orthogonal projection
+* ``PerspectiveProjection``: Perspective projection
+
+"""
+# --
+Qgis.Map3DProjectionType.baseClass = Qgis
+# monkey patching scoped based enum
 Qgis.Point3DShape.Cylinder.__doc__ = "Cylinder"
 Qgis.Point3DShape.Sphere.__doc__ = "Sphere"
 Qgis.Point3DShape.Cone.__doc__ = "Cone"

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2429,8 +2429,8 @@ The development version
 
     enum class Map3DProjectionType /BaseType=IntEnum/
     {
-      OrthographicProjection,
-      PerspectiveProjection,
+      Orthographic,
+      Perspective,
     };
 
     enum class Point3DShape /BaseType=IntEnum/

--- a/python/PyQt6/core/auto_generated/qgis.sip.in
+++ b/python/PyQt6/core/auto_generated/qgis.sip.in
@@ -2427,6 +2427,12 @@ The development version
     typedef QFlags<Qgis::Map3DDebugFlag> Map3DDebugFlags;
 
 
+    enum class Map3DProjectionType /BaseType=IntEnum/
+    {
+      OrthographicProjection,
+      PerspectiveProjection,
+    };
+
     enum class Point3DShape /BaseType=IntEnum/
     {
       Cylinder,

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -403,7 +403,7 @@ bool Qgs3DMapScene::updateScene( bool forceUpdate )
   QMatrix4x4 projMatrix;
   switch ( mMap.projectionType() )
   {
-    case Qgis::Map3DProjectionType::PerspectiveProjection:
+    case Qgis::Map3DProjectionType::Perspective:
     {
       float fovRadians = ( camera->fieldOfView() / 2.0f ) * static_cast<float>( M_PI ) / 180.0f;
       float fovCotan = std::cos( fovRadians ) / std::sin( fovRadians );
@@ -417,7 +417,7 @@ bool Qgs3DMapScene::updateScene( bool forceUpdate )
       // clang-format on
       break;
     }
-    case Qgis::Map3DProjectionType::OrthographicProjection:
+    case Qgis::Map3DProjectionType::Orthographic:
     {
       Qt3DRender::QCameraLens *lens = camera->lens();
       // clang-format off

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -403,7 +403,7 @@ bool Qgs3DMapScene::updateScene( bool forceUpdate )
   QMatrix4x4 projMatrix;
   switch ( mMap.projectionType() )
   {
-    case Qt3DRender::QCameraLens::PerspectiveProjection:
+    case Qgis::Map3DProjectionType::PerspectiveProjection:
     {
       float fovRadians = ( camera->fieldOfView() / 2.0f ) * static_cast<float>( M_PI ) / 180.0f;
       float fovCotan = std::cos( fovRadians ) / std::sin( fovRadians );
@@ -417,7 +417,7 @@ bool Qgs3DMapScene::updateScene( bool forceUpdate )
       // clang-format on
       break;
     }
-    case Qt3DRender::QCameraLens::OrthographicProjection:
+    case Qgis::Map3DProjectionType::OrthographicProjection:
     {
       Qt3DRender::QCameraLens *lens = camera->lens();
       // clang-format off
@@ -729,7 +729,7 @@ void Qgs3DMapScene::updateLights()
 void Qgs3DMapScene::updateCameraLens()
 {
   mEngine->camera()->lens()->setFieldOfView( static_cast< float >( mMap.fieldOfView() ) );
-  mEngine->camera()->lens()->setProjectionType( mMap.projectionType() );
+  mEngine->camera()->lens()->setProjectionType( static_cast<Qt3DRender::QCameraLens::ProjectionType>( mMap.projectionType() ) );
   onCameraChanged();
 }
 

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -149,7 +149,7 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
   if ( !elemCamera.isNull() )
   {
     mFieldOfView = elemCamera.attribute( u"field-of-view"_s, u"45"_s ).toDouble();
-    mProjectionType = static_cast<Qt3DRender::QCameraLens::ProjectionType>( elemCamera.attribute( u"projection-type"_s, u"1"_s ).toInt() );
+    mProjectionType = static_cast<Qgis::Map3DProjectionType>( elemCamera.attribute( u"projection-type"_s, u"1"_s ).toInt() );
     QString cameraNavigationMode = elemCamera.attribute( u"camera-navigation-mode"_s, u"basic-navigation"_s );
     if ( cameraNavigationMode == "terrain-based-navigation"_L1 )
       mCameraNavigationMode = Qgis::NavigationMode::TerrainBased;
@@ -1267,14 +1267,14 @@ void Qgs3DMapSettings::setFieldOfView( const double fieldOfView )
   emit fieldOfViewChanged();
 }
 
-Qt3DRender::QCameraLens::ProjectionType Qgs3DMapSettings::projectionType() const
+Qgis::Map3DProjectionType Qgs3DMapSettings::projectionType() const
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 
   return mProjectionType;
 }
 
-void Qgs3DMapSettings::setProjectionType( const Qt3DRender::QCameraLens::ProjectionType projectionType )
+void Qgs3DMapSettings::setProjectionType( const Qgis::Map3DProjectionType projectionType )
 {
   QGIS_PROTECT_QOBJECT_THREAD_ACCESS
 

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -637,15 +637,15 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
 
     /**
      * Returns the camera lens' projection type
-     * \since QGIS 3.18
+     * \since QGIS 4.2
      */
-    Qt3DRender::QCameraLens::ProjectionType projectionType() const SIP_SKIP;
+    Qgis::Map3DProjectionType projectionType() const;
 
     /**
      * Sets the camera lens' projection type
-     * \since QGIS 3.18
+     * \since QGIS 4.2
      */
-    void setProjectionType( const Qt3DRender::QCameraLens::ProjectionType projectionType ) SIP_SKIP;
+    void setProjectionType( const Qgis::Map3DProjectionType projectionType );
 
 #ifndef SIP_RUN
 
@@ -1268,11 +1268,11 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     QgsPhongMaterialSettings mTerrainShadingMaterial; //!< Material to use for the terrain (if shading is enabled). Diffuse color is ignored.
     QString mTerrainMapTheme;                         //!< Name of map theme used for terrain's texture (empty means use the current map theme)
     Qgis::Map3DDebugFlags mDebugFlags;
-    bool mShowLabels = false;                                                                                 //!< Whether to display labels on terrain tiles
-    bool mStopUpdates = false;                                                                                //!< Whether to stop updating scene on zoom
-    QList<QgsLightSource *> mLightSources;                                                                    //!< List of light sources in the scene (owned by the settings)
-    double mFieldOfView = 45.0;                                                                               //!< Camera lens field of view value
-    Qt3DRender::QCameraLens::ProjectionType mProjectionType = Qt3DRender::QCameraLens::PerspectiveProjection; //!< Camera lens projection type
+    bool mShowLabels = false;                                                                     //!< Whether to display labels on terrain tiles
+    bool mStopUpdates = false;                                                                    //!< Whether to stop updating scene on zoom
+    QList<QgsLightSource *> mLightSources;                                                        //!< List of light sources in the scene (owned by the settings)
+    double mFieldOfView = 45.0;                                                                   //!< Camera lens field of view value
+    Qgis::Map3DProjectionType mProjectionType = Qgis::Map3DProjectionType::PerspectiveProjection; //!< Camera lens projection type
     Qgis::NavigationMode mCameraNavigationMode = Qgis::NavigationMode::TerrainBased;
     double mCameraMovementSpeed = 5.0;
     QList<QgsMapLayerRef> mLayers; //!< Layers to be rendered

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -1268,11 +1268,11 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     QgsPhongMaterialSettings mTerrainShadingMaterial; //!< Material to use for the terrain (if shading is enabled). Diffuse color is ignored.
     QString mTerrainMapTheme;                         //!< Name of map theme used for terrain's texture (empty means use the current map theme)
     Qgis::Map3DDebugFlags mDebugFlags;
-    bool mShowLabels = false;                                                                     //!< Whether to display labels on terrain tiles
-    bool mStopUpdates = false;                                                                    //!< Whether to stop updating scene on zoom
-    QList<QgsLightSource *> mLightSources;                                                        //!< List of light sources in the scene (owned by the settings)
-    double mFieldOfView = 45.0;                                                                   //!< Camera lens field of view value
-    Qgis::Map3DProjectionType mProjectionType = Qgis::Map3DProjectionType::PerspectiveProjection; //!< Camera lens projection type
+    bool mShowLabels = false;                                                           //!< Whether to display labels on terrain tiles
+    bool mStopUpdates = false;                                                          //!< Whether to stop updating scene on zoom
+    QList<QgsLightSource *> mLightSources;                                              //!< List of light sources in the scene (owned by the settings)
+    double mFieldOfView = 45.0;                                                         //!< Camera lens field of view value
+    Qgis::Map3DProjectionType mProjectionType = Qgis::Map3DProjectionType::Perspective; //!< Camera lens projection type
     Qgis::NavigationMode mCameraNavigationMode = Qgis::NavigationMode::TerrainBased;
     double mCameraMovementSpeed = 5.0;
     QList<QgsMapLayerRef> mLayers; //!< Layers to be rendered

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -461,7 +461,7 @@ void QgsCameraController::updateOrthographicProjectionPlane()
 {
   // When using orthographic projection, reuse the distance to center (which
   // ordinarily wouldn't do anything) to set the viewport size in the world.
-  if ( mScene->mapSettings()->projectionType() == Qt3DRender::QCameraLens::OrthographicProjection )
+  if ( mScene->mapSettings()->projectionType() == Qgis::Map3DProjectionType::OrthographicProjection )
   {
     const QSize viewportRect = mScene->engine()->size();
     const float viewWidthFromCenter = distance();
@@ -641,10 +641,10 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     // Choose threshold angle based on projection type so it "feels right".
     switch ( mScene->mapSettings()->projectionType() )
     {
-      case Qt3DRender::QCameraLens::PerspectiveProjection:
+      case Qgis::Map3DProjectionType::PerspectiveProjection:
         changeAltitude = angle < M_PI / 30;
         break;
-      case Qt3DRender::QCameraLens::OrthographicProjection:
+      case Qgis::Map3DProjectionType::OrthographicProjection:
         changeAltitude = angle < M_PI / 3;
         break;
       default:
@@ -656,7 +656,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     else
       switch ( mScene->mapSettings()->projectionType() )
       {
-        case Qt3DRender::QCameraLens::OrthographicProjection:
+        case Qgis::Map3DProjectionType::OrthographicProjection:
         {
           // Project change to XY plane.
           // This isn't quite accurate at higher angles, "desyncing" the mouse
@@ -664,7 +664,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
           shiftVector = { mDragPoint.x() - moveToPosition.x(), mDragPoint.y() - moveToPosition.y(), 0 };
           break;
         }
-        case Qt3DRender::QCameraLens::PerspectiveProjection:
+        case Qgis::Map3DProjectionType::PerspectiveProjection:
         {
           QVector3D cameraBeforeToMoveToPos = ( moveToPosition - mCameraBefore->position() ).normalized();
           QVector3D cameraBeforeToDragPointPos = ( mDragPoint - mCameraBefore->position() ).normalized();

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -461,7 +461,7 @@ void QgsCameraController::updateOrthographicProjectionPlane()
 {
   // When using orthographic projection, reuse the distance to center (which
   // ordinarily wouldn't do anything) to set the viewport size in the world.
-  if ( mScene->mapSettings()->projectionType() == Qgis::Map3DProjectionType::OrthographicProjection )
+  if ( mScene->mapSettings()->projectionType() == Qgis::Map3DProjectionType::Orthographic )
   {
     const QSize viewportRect = mScene->engine()->size();
     const float viewWidthFromCenter = distance();
@@ -641,10 +641,10 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     // Choose threshold angle based on projection type so it "feels right".
     switch ( mScene->mapSettings()->projectionType() )
     {
-      case Qgis::Map3DProjectionType::PerspectiveProjection:
+      case Qgis::Map3DProjectionType::Perspective:
         changeAltitude = angle < M_PI / 30;
         break;
-      case Qgis::Map3DProjectionType::OrthographicProjection:
+      case Qgis::Map3DProjectionType::Orthographic:
         changeAltitude = angle < M_PI / 3;
         break;
       default:
@@ -656,7 +656,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
     else
       switch ( mScene->mapSettings()->projectionType() )
       {
-        case Qgis::Map3DProjectionType::OrthographicProjection:
+        case Qgis::Map3DProjectionType::Orthographic:
         {
           // Project change to XY plane.
           // This isn't quite accurate at higher angles, "desyncing" the mouse
@@ -664,7 +664,7 @@ void QgsCameraController::onPositionChangedTerrainNavigation( Qt3DInput::QMouseE
           shiftVector = { mDragPoint.x() - moveToPosition.x(), mDragPoint.y() - moveToPosition.y(), 0 };
           break;
         }
-        case Qgis::Map3DProjectionType::PerspectiveProjection:
+        case Qgis::Map3DProjectionType::Perspective:
         {
           QVector3D cameraBeforeToMoveToPos = ( moveToPosition - mCameraBefore->position() ).normalized();
           QVector3D cameraBeforeToDragPointPos = ( mDragPoint - mCameraBefore->position() ).normalized();

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -91,10 +91,10 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   mMeshSymbolWidget = new QgsMesh3DSymbolWidget( nullptr, groupMeshTerrainShading );
   mMeshSymbolWidget->configureForTerrain();
 
-  cboCameraProjectionType->addItem( tr( "Perspective Projection" ), Qt3DRender::QCameraLens::PerspectiveProjection );
-  cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), Qt3DRender::QCameraLens::OrthographicProjection );
+  cboCameraProjectionType->addItem( tr( "Perspective Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::PerspectiveProjection ) );
+  cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::OrthographicProjection ) );
   connect( cboCameraProjectionType, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, [this]() {
-    spinCameraFieldOfView->setEnabled( cboCameraProjectionType->currentIndex() == cboCameraProjectionType->findData( Qt3DRender::QCameraLens::PerspectiveProjection ) );
+    spinCameraFieldOfView->setEnabled( cboCameraProjectionType->currentIndex() == cboCameraProjectionType->findData( QVariant::fromValue( Qgis::Map3DProjectionType::PerspectiveProjection ) ) );
   } );
 
   mCameraMovementSpeed->setClearValue( 4 );
@@ -179,7 +179,7 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   }
 
   spinCameraFieldOfView->setValue( mMap->fieldOfView() );
-  cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( mMap->projectionType() ) );
+  cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( QVariant::fromValue( mMap->projectionType() ) ) );
   mCameraNavigationModeCombo->setCurrentIndex( mCameraNavigationModeCombo->findData( QVariant::fromValue( mMap->cameraNavigationMode() ) ) );
   mCameraMovementSpeed->setValue( mMap->cameraMovementSpeed() );
 
@@ -384,7 +384,7 @@ void Qgs3DMapConfigWidget::apply()
   }
 
   mMap->setFieldOfView( spinCameraFieldOfView->value() );
-  mMap->setProjectionType( cboCameraProjectionType->currentData().value<Qt3DRender::QCameraLens::ProjectionType>() );
+  mMap->setProjectionType( cboCameraProjectionType->currentData().value<Qgis::Map3DProjectionType>() );
   mMap->setCameraNavigationMode( mCameraNavigationModeCombo->currentData().value<Qgis::NavigationMode>() );
   mMap->setCameraMovementSpeed( mCameraMovementSpeed->value() );
   mMap->setShowLabels( chkShowLabels->isChecked() );

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -91,10 +91,10 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   mMeshSymbolWidget = new QgsMesh3DSymbolWidget( nullptr, groupMeshTerrainShading );
   mMeshSymbolWidget->configureForTerrain();
 
-  cboCameraProjectionType->addItem( tr( "Perspective Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::PerspectiveProjection ) );
-  cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::OrthographicProjection ) );
+  cboCameraProjectionType->addItem( tr( "Perspective Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::Perspective ) );
+  cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::Orthographic ) );
   connect( cboCameraProjectionType, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, [this]() {
-    spinCameraFieldOfView->setEnabled( cboCameraProjectionType->currentIndex() == cboCameraProjectionType->findData( QVariant::fromValue( Qgis::Map3DProjectionType::PerspectiveProjection ) ) );
+    spinCameraFieldOfView->setEnabled( cboCameraProjectionType->currentIndex() == cboCameraProjectionType->findData( QVariant::fromValue( Qgis::Map3DProjectionType::Perspective ) ) );
   } );
 
   mCameraMovementSpeed->setClearValue( 4 );

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -45,8 +45,8 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   mCameraNavigationModeCombo->addItem( tr( "Terrain Based" ), QVariant::fromValue( Qgis::NavigationMode::TerrainBased ) );
   mCameraNavigationModeCombo->addItem( tr( "Walk Mode (First Person)" ), QVariant::fromValue( Qgis::NavigationMode::Walk ) );
 
-  cboCameraProjectionType->addItem( tr( "Perspective Projection" ), Qt3DRender::QCameraLens::PerspectiveProjection );
-  cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), Qt3DRender::QCameraLens::OrthographicProjection );
+  cboCameraProjectionType->addItem( tr( "Perspective Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::PerspectiveProjection ) );
+  cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::OrthographicProjection ) );
 
   mVerticalAxisInversionComboBox->setDefaultText( tr( "Do not invert" ) );
   mVerticalAxisInversionComboBox->addItem( tr( "When rotating (mouse captured)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenRotatingCaptured ) );
@@ -77,8 +77,8 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   mVerticalAxisInversionComboBox->setItemCheckState( 1, ( axisInversion & Qgis::VerticalAxisInversion::WhenRotatingDragging ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
   mVerticalAxisInversionComboBox->setItemCheckState( 2, ( axisInversion & Qgis::VerticalAxisInversion::WhenPivoting ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
 
-  const Qt3DRender::QCameraLens::ProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qt3DRender::QCameraLens::PerspectiveProjection, QgsSettings::App );
-  cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( static_cast<int>( defaultProjection ) ) );
+  const Qgis::Map3DProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qgis::Map3DProjectionType::PerspectiveProjection, QgsSettings::App );
+  cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( QVariant::fromValue( defaultProjection ) ) );
 
   mCameraMovementSpeed->setValue( settings.value( u"map3d/defaultMovementSpeed"_s, 5, QgsSettings::App ).toDouble() );
   spinCameraFieldOfView->setValue( settings.value( u"map3d/defaultFieldOfView"_s, 45, QgsSettings::App ).toInt() );
@@ -102,7 +102,7 @@ void Qgs3DOptionsWidget::apply()
 {
   QgsSettings settings;
   settings.setEnumValue( u"map3d/defaultNavigation"_s, mCameraNavigationModeCombo->currentData().value<Qgis::NavigationMode>(), QgsSettings::App );
-  settings.setValue( u"map3d/defaultProjection"_s, static_cast<Qt3DRender::QCameraLens::ProjectionType>( cboCameraProjectionType->currentData().toInt() ), QgsSettings::App );
+  settings.setEnumValue( u"map3d/defaultProjection"_s, cboCameraProjectionType->currentData().value<Qgis::Map3DProjectionType>(), QgsSettings::App );
   settings.setValue( u"map3d/defaultMovementSpeed"_s, mCameraMovementSpeed->value(), QgsSettings::App );
   settings.setValue( u"map3d/defaultFieldOfView"_s, spinCameraFieldOfView->value(), QgsSettings::App );
 

--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -45,8 +45,8 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   mCameraNavigationModeCombo->addItem( tr( "Terrain Based" ), QVariant::fromValue( Qgis::NavigationMode::TerrainBased ) );
   mCameraNavigationModeCombo->addItem( tr( "Walk Mode (First Person)" ), QVariant::fromValue( Qgis::NavigationMode::Walk ) );
 
-  cboCameraProjectionType->addItem( tr( "Perspective Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::PerspectiveProjection ) );
-  cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::OrthographicProjection ) );
+  cboCameraProjectionType->addItem( tr( "Perspective Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::Perspective ) );
+  cboCameraProjectionType->addItem( tr( "Orthogonal Projection" ), QVariant::fromValue( Qgis::Map3DProjectionType::Orthographic ) );
 
   mVerticalAxisInversionComboBox->setDefaultText( tr( "Do not invert" ) );
   mVerticalAxisInversionComboBox->addItem( tr( "When rotating (mouse captured)" ), QVariant::fromValue( Qgis::VerticalAxisInversion::WhenRotatingCaptured ) );
@@ -77,7 +77,7 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
   mVerticalAxisInversionComboBox->setItemCheckState( 1, ( axisInversion & Qgis::VerticalAxisInversion::WhenRotatingDragging ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
   mVerticalAxisInversionComboBox->setItemCheckState( 2, ( axisInversion & Qgis::VerticalAxisInversion::WhenPivoting ) ? Qt::CheckState::Checked : Qt::CheckState::Unchecked );
 
-  const Qgis::Map3DProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qgis::Map3DProjectionType::PerspectiveProjection, QgsSettings::App );
+  const Qgis::Map3DProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qgis::Map3DProjectionType::Perspective, QgsSettings::App );
   cboCameraProjectionType->setCurrentIndex( cboCameraProjectionType->findData( QVariant::fromValue( defaultProjection ) ) );
 
   mCameraMovementSpeed->setValue( settings.value( u"map3d/defaultMovementSpeed"_s, 5, QgsSettings::App ).toDouble() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13578,7 +13578,7 @@ Qgs3DMapCanvas *QgisApp::createNewMapCanvas3D( const QString &name, Qgis::SceneM
     map->setCameraNavigationMode( defaultNavMode );
 
     map->setCameraMovementSpeed( settings.value( u"map3d/defaultMovementSpeed"_s, 5, QgsSettings::App ).toDouble() );
-    const Qgis::Map3DProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qgis::Map3DProjectionType::PerspectiveProjection, QgsSettings::App );
+    const Qgis::Map3DProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qgis::Map3DProjectionType::Perspective, QgsSettings::App );
     map->setProjectionType( defaultProjection );
     map->setFieldOfView( settings.value( u"map3d/defaultFieldOfView"_s, 45, QgsSettings::App ).toInt() );
     map->setMsaaEnabled( Qgs3D::settingMsaaEnabled->value() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13578,7 +13578,7 @@ Qgs3DMapCanvas *QgisApp::createNewMapCanvas3D( const QString &name, Qgis::SceneM
     map->setCameraNavigationMode( defaultNavMode );
 
     map->setCameraMovementSpeed( settings.value( u"map3d/defaultMovementSpeed"_s, 5, QgsSettings::App ).toDouble() );
-    const Qt3DRender::QCameraLens::ProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qt3DRender::QCameraLens::PerspectiveProjection, QgsSettings::App );
+    const Qgis::Map3DProjectionType defaultProjection = settings.enumValue( u"map3d/defaultProjection"_s, Qgis::Map3DProjectionType::PerspectiveProjection, QgsSettings::App );
     map->setProjectionType( defaultProjection );
     map->setFieldOfView( settings.value( u"map3d/defaultFieldOfView"_s, 45, QgsSettings::App ).toInt() );
     map->setMsaaEnabled( Qgs3D::settingMsaaEnabled->value() );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4331,6 +4331,18 @@ int QgisEvent = QEvent::User + 1;
     Q_FLAG( Map3DDebugFlags )
 
     /**
+     * 3D map projection type
+     *
+     * \since QGIS 4.2
+     */
+    enum class Map3DProjectionType : int
+    {
+      OrthographicProjection = 0, //!< Orthogonal projection
+      PerspectiveProjection = 1,  //!< Perspective projection
+    };
+    Q_ENUM( Map3DProjectionType )
+
+    /**
      * 3D point shape types.
      *
      * \note Prior to QGIS 3.36 this was available as QgsPoint3DSymbol::Shape

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -4337,8 +4337,8 @@ int QgisEvent = QEvent::User + 1;
      */
     enum class Map3DProjectionType : int
     {
-      OrthographicProjection = 0, //!< Orthogonal projection
-      PerspectiveProjection = 1,  //!< Perspective projection
+      Orthographic = 0, //!< Orthogonal projection
+      Perspective = 1,  //!< Perspective projection
     };
     Q_ENUM( Map3DProjectionType )
 

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -1293,7 +1293,7 @@ void TestQgs3DCameraController::testOrthographic()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *mapSettings, &engine );
   engine.setRootEntity( scene );
 
-  mapSettings->setProjectionType( Qt3DRender::QCameraLens::ProjectionType::OrthographicProjection );
+  mapSettings->setProjectionType( Qgis::Map3DProjectionType::OrthographicProjection );
 
   // look from the top
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 0 ), 2500, 0, 0 );

--- a/tests/src/3d/testqgs3dcameracontroller.cpp
+++ b/tests/src/3d/testqgs3dcameracontroller.cpp
@@ -1293,7 +1293,7 @@ void TestQgs3DCameraController::testOrthographic()
   Qgs3DMapScene *scene = new Qgs3DMapScene( *mapSettings, &engine );
   engine.setRootEntity( scene );
 
-  mapSettings->setProjectionType( Qgis::Map3DProjectionType::OrthographicProjection );
+  mapSettings->setProjectionType( Qgis::Map3DProjectionType::Orthographic );
 
   // look from the top
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 0 ), 2500, 0, 0 );


### PR DESCRIPTION
This PR exposes 3D camera lens projection type to SIP.

Projection type can now be set using Python:
```
canvas3d = iface.mapCanvases3D()[0]
canvas3d.mapSettings().setProjectionType(Qgis.Map3DProjectionType.OrthographicProjection)
```

## AI tool usage

 - [x] used AI to verify nothing was missed.