### PR TITLE
[attribute table] Do not crash when sort field was removed

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -149,7 +149,11 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
   mLayer = layer;
 
   // Keep fields order in sync: force config reset
-  connect( mLayer, &QgsVectorLayer::updatedFields, this, [this] { mFilterModel->setAttributeTableConfig( attributeTableConfig(), /* force */ true ); } );
+  connect( mLayer, &QgsVectorLayer::updatedFields, this, [this] {
+    // Prevent crash if a field was deleted when the sort expression contained a reference to it.
+    mConfig.update( mLayer->fields() );
+    mFilterModel->setAttributeTableConfig( attributeTableConfig(), /* force */ true );
+  } );
 
   mEditorContext = context;
 

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -73,7 +73,7 @@ class TestQgsDualView : public QObject
     QgsMapCanvas *mCanvas = nullptr;
     QgsVectorLayer *mPointsLayer = nullptr;
     QString mTestDataDir;
-    QgsDualView *mDualView = nullptr;
+    std::unique_ptr<QgsDualView> mDualView;
 };
 
 void TestQgsDualView::initTestCase()
@@ -107,14 +107,12 @@ void TestQgsDualView::cleanupTestCase()
 
 void TestQgsDualView::init()
 {
-  mDualView = new QgsDualView();
+  mDualView = std::make_unique<QgsDualView>();
   mDualView->init( mPointsLayer, mCanvas );
 }
 
 void TestQgsDualView::cleanup()
-{
-  delete mDualView;
-}
+{}
 
 void TestQgsDualView::testColumnCount()
 {
@@ -237,6 +235,19 @@ void TestQgsDualView::testSort()
     const QModelIndex index = mDualView->tableView()->model()->index( i, 1 );
     QCOMPARE( mDualView->tableView()->model()->data( index ).toString(), headings.at( i ) );
   }
+
+  // Test crash when a field was added, sorted by and removed
+  const int fieldsCount = mPointsLayer->fields().count();
+  const int columnsCount = mDualView->attributeTableConfig().columns().size();
+  const QgsField newField( u"newField"_s, QMetaType::Type::QString );
+  mPointsLayer->startEditing();
+  mPointsLayer->addAttribute( newField );
+  QCOMPARE( mDualView->attributeTableConfig().columns().size(), columnsCount + 1 );
+  QCOMPARE( mPointsLayer->fields().count(), fieldsCount + 1 );
+  mDualView->setSortExpression( u"newField"_s );
+  mPointsLayer->rollBack();
+  QCOMPARE( mPointsLayer->fields().count(), fieldsCount );
+  QCOMPARE( mDualView->attributeTableConfig().columns().size(), columnsCount );
 }
 
 void TestQgsDualView::testAttributeFormSharedValueScanning()


### PR DESCRIPTION
The lack of sync between the attr table config and the added fields after an undo in the edit buffer was leading to the removed field not being removed in the attr table config, the prefetching of sort data on a missing field was causing the crash.

Fixes #66268  and probably #66507 (I couldn't reproduce but the stacktrace is almost identical to the other issue and the scenario seems similar)
