### PR TITLE
fix: reset coordinate display and field width when leaving extent mode

### DIFF
--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -364,6 +364,9 @@ void QgsStatusBarCoordinatesWidget::extentsViewToggled( bool flag )
     mLineEdit->setToolTip( tr( "Map coordinates at mouse cursor position" ) );
     mLineEdit->setReadOnly( false );
     mLabel->setText( tr( "Coordinate" ) );
+    mLineEdit->setMinimumWidth( mMinimumWidth );
+    mLineEdit->setMaximumWidth( QWIDGETSIZE_MAX );
+    updateCoordinateDisplay();
   }
 }
 


### PR DESCRIPTION
Fixes [#66418](https://github.com/qgis/QGIS/issues/66418)

## What needed to be fixed?
When toggling the status bar coordinate widget from extent mode back to coordinate mode, the extent text persisted and the field stayed as wide as the extent text.

## What did I change?
- Calls `updateCoordinateDisplay()` to restore coordinate text
- Resets min/max width before `updateCoordinateDisplay()` so the field shrinks from extent width to coordinate width immediately

## AI tool usage
 - [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
 
### Additional information about AI use
- AI was used to locate the issue in the code
- AI was used to run compile the application for manual end-to-end testing on Windows and Linux
- AI was used to translate into the English language