### PR TITLE
Adding QGIS User Group India to the user group data

### DIFF
--- a/resources/data/user_groups_data.json
+++ b/resources/data/user_groups_data.json
@@ -364,6 +364,17 @@
         "year": 2025
       },
       "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "IN",
+        "name": "QGIS India User Group",
+        "logo_url": "https:\/\/in.qgis.org\/img\/qgis_in.png",
+        "website": "https:\/\/in.qgis.org",
+        "year": 2026
+      },
+      "geometry": null
     }
   ]
 }


### PR DESCRIPTION
## Description

This adds the User Group India to the json data which is used for the 'user groups' easter egg.

(I actually wanted to add the User Group Algeria but they are not yet listed on the qgis.org website so the logo is not available @Xpirix)

There is no code involved and I didn't even compile QGIS to test this. Just loaded the updated json and everything looks well with India showing up on the map in green and the image and link working.

I found the links here: https://qgis.org/community/groups/

<img width="628" height="465" alt="image" src="https://github.com/user-attachments/assets/5cc5d858-adee-409c-934a-9985c29fa07f" />

@spatialthoughts