### PR TITLE
Fix default Planimetric Measure value

### DIFF
--- a/src/core/settings/qgssettingsregistrycore.cpp
+++ b/src/core/settings/qgssettingsregistrycore.cpp
@@ -184,7 +184,7 @@ const QgsSettingsEntryStringList *QgsSettingsRegistryCore::settingsCodeExecution
   = new QgsSettingsEntryStringList( u"code-execution-denied-projects-folders"_s, QgsSettingsTree::sTreeCore, QStringList(), u"Projects and folders that are untrusted and denied execution of embedded scripts"_s );
 
 const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsMeasurePlanimetric
-  = new QgsSettingsEntryBool( u"planimetric"_s, QgsSettingsTree::sTreeMeasure, true, u"Whether measurements should be planimetric (ellipsoid off) or use the ellipsoid"_s );
+  = new QgsSettingsEntryBool( u"planimetric"_s, QgsSettingsTree::sTreeMeasure, false, u"Whether measurements should be planimetric (ellipsoid off) or use the ellipsoid"_s );
 
 const QgsSettingsEntryBool *QgsSettingsRegistryCore::settingsMeasureKeepBaseUnit
   = new QgsSettingsEntryBool( u"keep-base-unit"_s, QgsSettingsTree::sTreeMeasure, true, u"Whether to keep base measurement units instead of converting to larger units"_s );


### PR DESCRIPTION
## Description

Recent change introduced in https://github.com/qgis/QGIS/commit/8097eb6ab0ecc4cdf469d98abc0e2ae40c08febf set the default value of `planimetric` to `true`. Which means that any newly created user profile will have it turned on. This leads to all newly created projects (from those profiles) not set ellipsoid from the data, but instead going to `GEO_NONE` which defaults to planimetric calculation. Also it is quite inconsistent with older profiles, where this was set to `false` and if you create a new profile the behaviour of use of measuring tools changes significantly.

Prior to https://github.com/qgis/QGIS/commit/8097eb6ab0ecc4cdf469d98abc0e2ae40c08febf the approach was a bit inconsistent, which was mostly fixed by the mentioned commit. But the current state settings is probably worse and can lead to errors on user's side. This should likely be considered an error while it is not present in the code for too long.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. 

linking @3nids (as the original creator of the change) and @wonder-sk (with whom did i discussed this)
