### PR TITLE
Force "respect screen dpi" setting to default to on

### DIFF
--- a/src/gui/settings/qgssettingsregistrygui.cpp
+++ b/src/gui/settings/qgssettingsregistrygui.cpp
@@ -39,7 +39,7 @@
 
 using namespace Qt::StringLiterals;
 
-const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsRespectScreenDPI = new QgsSettingsEntryBool( u"respect-screen-dpi"_s, QgsSettingsTree::sTreeGui, false );
+const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsRespectScreenDPI = new QgsSettingsEntryBool( u"canvas-inherits-screen-dpi"_s, QgsSettingsTree::sTreeGui, true );
 
 const QgsSettingsEntryBool *QgsSettingsRegistryGui::settingsCadFloaterActive
   = new QgsSettingsEntryBool( u"floater-active"_s, QgsSettingsTree::sTreeCad, false, u"Whether the CAD floater widget is active"_s );

--- a/tests/src/app/testqgsmapsavedialog.cpp
+++ b/tests/src/app/testqgsmapsavedialog.cpp
@@ -57,6 +57,9 @@ class TestQgsMapSaveDialog : public QgsTest
       canvas.show(); // to make the canvas resize
       canvas.hide();
       canvas.setExtent( QgsRectangle( 623913, 5720967, 1215325, 6068610 ) );
+      canvas.mapSettings().setDpiTarget( 96 );
+      canvas.mapSettings().setOutputDpi( 96 );
+      canvas.mapSettings().setDevicePixelRatio( 1 );
 
       // Set up dialog
       QgsMapSaveDialog dialog( nullptr, &canvas );


### PR DESCRIPTION
Without this setting symbol sizes in the canvas are incorrect on screens with device pixel ratio > 1.

In 2026 and under Qt6 we should be in a place where we can safely assume hidpi rendering issues are all resolved.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
