### PR TITLE
[sld][labels] Improve handling of AnchorPoint property when converting SLD TextSymbolizer to labeling settings

### DIFF
--- a/src/core/vector/qgsvectorlayer.cpp
+++ b/src/core/vector/qgsvectorlayer.cpp
@@ -5842,26 +5842,63 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
       QDomElement anchorPointElem = pointPlacementElem.firstChildElement( u"AnchorPoint"_s );
       if ( !anchorPointElem.isNull() )
       {
+        bool xOffsetOk = false;
+        double xOffset = 0.0;
+        bool yOffsetOk = false;
+        double yOffset = 0.0;
+
         QDomElement anchorPointXElem = anchorPointElem.firstChildElement( u"AnchorPointX"_s );
         if ( !anchorPointXElem.isNull() )
         {
-          bool ok;
-          double xOffset = anchorPointXElem.text().toDouble( &ok );
-          if ( ok )
-          {
-            settings.xOffset = xOffset;
-            settings.offsetUnits = sldUnitSize;
-          }
+          xOffset = anchorPointXElem.text().toDouble( &xOffsetOk );
         }
         QDomElement anchorPointYElem = anchorPointElem.firstChildElement( u"AnchorPointY"_s );
         if ( !anchorPointYElem.isNull() )
         {
-          bool ok;
-          double yOffset = anchorPointYElem.text().toDouble( &ok );
-          if ( ok )
+          yOffset = anchorPointYElem.text().toDouble( &yOffsetOk );
+        }
+
+        if ( xOffsetOk & yOffsetOk )
+        {
+          // Round values in increments of 0.5
+          xOffset = std::round( xOffset * 2.0 ) / 2.0;
+          yOffset = std::round( yOffset * 2.0 ) / 2.0;
+
+          if ( xOffset == 1.0 && yOffset == 0.0 )
           {
-            settings.yOffset = yOffset;
-            settings.offsetUnits = sldUnitSize;
+            settings.pointSettings().setQuadrant( Qgis::LabelQuadrantPosition::AboveLeft );
+          }
+          else if ( xOffset == 0.5 && yOffset == 0.0 )
+          {
+            settings.pointSettings().setQuadrant( Qgis::LabelQuadrantPosition::Above );
+          }
+          else if ( xOffset == 0.0 && yOffset == 0.0 )
+          {
+            settings.pointSettings().setQuadrant( Qgis::LabelQuadrantPosition::AboveRight );
+          }
+          else if ( xOffset == 1.0 && yOffset == 0.5 )
+          {
+            settings.pointSettings().setQuadrant( Qgis::LabelQuadrantPosition::Left );
+          }
+          else if ( xOffset == 0.5 && yOffset == 0.5 )
+          {
+            settings.pointSettings().setQuadrant( Qgis::LabelQuadrantPosition::Over );
+          }
+          else if ( xOffset == 0.0 && yOffset == 0.5 )
+          {
+            settings.pointSettings().setQuadrant( Qgis::LabelQuadrantPosition::Right );
+          }
+          else if ( xOffset == 1.0 && yOffset == 1.0 )
+          {
+            settings.pointSettings().setQuadrant( Qgis::LabelQuadrantPosition::BelowLeft );
+          }
+          else if ( xOffset == 0.5 && yOffset == 1.0 )
+          {
+            settings.pointSettings().setQuadrant( Qgis::LabelQuadrantPosition::Below );
+          }
+          else
+          {
+            settings.pointSettings().setQuadrant( Qgis::LabelQuadrantPosition::BelowRight );
           }
         }
       }

--- a/tests/src/python/test_qgssymbollayer_readsld.py
+++ b/tests/src/python/test_qgssymbollayer_readsld.py
@@ -445,6 +445,28 @@ class TestQgsSymbolLayerReadSld(QgisTestCase):
         self.assertEqual(first_size, second_size)
         self.assertEqual(first_unit, second_unit)
 
+    def testAnchorPoint(self):
+        # create a layer
+        layer = createLayerWithOnePoint()
+
+        sld = "symbol_layer/AnchorPointBelowLeft.sld"
+        sld_path = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(sld_path)
+        quadrant = layer.labeling().settings().pointSettings().quadrant()
+        self.assertEqual(quadrant, Qgis.LabelQuadrantPosition.BelowLeft)
+
+        sld = "symbol_layer/AnchorPointOver.sld"
+        sld_path = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(sld_path)
+        quadrant = layer.labeling().settings().pointSettings().quadrant()
+        self.assertEqual(quadrant, Qgis.LabelQuadrantPosition.Over)
+
+        sld = "symbol_layer/AnchorPointAboveRight.sld"
+        sld_path = os.path.join(TEST_DATA_DIR, sld)
+        layer.loadSldStyle(sld_path)
+        quadrant = layer.labeling().settings().pointSettings().quadrant()
+        self.assertEqual(quadrant, Qgis.LabelQuadrantPosition.AboveRight)
+
     def test_Literal_within_CSSParameter_and_Text(self):
         layer = createLayerWithOneLine()
         mFilePath = os.path.join(

--- a/tests/testdata/symbol_layer/AnchorPointAboveRight.sld
+++ b/tests/testdata/symbol_layer/AnchorPointAboveRight.sld
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" version="1.1.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <se:Name>TestText</se:Name>
+    <UserStyle>
+      <se:Name>TestText</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Single symbol</se:Name>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#b7484b</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke>
+                  <se:SvgParameter name="stroke">#232323</se:SvgParameter>
+                  <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+                </se:Stroke>
+              </se:Mark>
+              <se:Size>7</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:TextSymbolizer>
+            <se:Label>
+              <ogc:PropertyName>name</ogc:PropertyName>
+            </se:Label>
+            <se:Font>
+              <se:SvgParameter name="font-family">Open Sans</se:SvgParameter>
+              <se:SvgParameter name="font-size">13</se:SvgParameter>
+            </se:Font>
+            <se:LabelPlacement>
+              <se:PointPlacement>
+                <se:AnchorPoint>
+                  <se:AnchorPointX>0</se:AnchorPointX>
+                  <se:AnchorPointY>0</se:AnchorPointY>
+                </se:AnchorPoint>
+                <se:Displacement>
+                  <se:DisplacementX>10</se:DisplacementX>
+                  <se:DisplacementY>20</se:DisplacementY>
+                </se:Displacement>
+              </se:PointPlacement>
+            </se:LabelPlacement>
+            <se:Fill>
+              <se:SvgParameter name="fill">#323232</se:SvgParameter>
+            </se:Fill>
+          </se:TextSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/tests/testdata/symbol_layer/AnchorPointBelowLeft.sld
+++ b/tests/testdata/symbol_layer/AnchorPointBelowLeft.sld
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" version="1.1.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <se:Name>TestText</se:Name>
+    <UserStyle>
+      <se:Name>TestText</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Single symbol</se:Name>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#b7484b</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke>
+                  <se:SvgParameter name="stroke">#232323</se:SvgParameter>
+                  <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+                </se:Stroke>
+              </se:Mark>
+              <se:Size>7</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:TextSymbolizer>
+            <se:Label>
+              <ogc:PropertyName>name</ogc:PropertyName>
+            </se:Label>
+            <se:Font>
+              <se:SvgParameter name="font-family">Open Sans</se:SvgParameter>
+              <se:SvgParameter name="font-size">13</se:SvgParameter>
+            </se:Font>
+            <se:LabelPlacement>
+              <se:PointPlacement>
+                <se:AnchorPoint>
+                  <se:AnchorPointX>1.0</se:AnchorPointX>
+                  <se:AnchorPointY>1.0</se:AnchorPointY>
+                </se:AnchorPoint>
+                <se:Displacement>
+                  <se:DisplacementX>10</se:DisplacementX>
+                  <se:DisplacementY>20</se:DisplacementY>
+                </se:Displacement>
+              </se:PointPlacement>
+            </se:LabelPlacement>
+            <se:Fill>
+              <se:SvgParameter name="fill">#323232</se:SvgParameter>
+            </se:Fill>
+          </se:TextSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/tests/testdata/symbol_layer/AnchorPointOver.sld
+++ b/tests/testdata/symbol_layer/AnchorPointOver.sld
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" version="1.1.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <se:Name>TestText</se:Name>
+    <UserStyle>
+      <se:Name>TestText</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Single symbol</se:Name>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#b7484b</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke>
+                  <se:SvgParameter name="stroke">#232323</se:SvgParameter>
+                  <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+                </se:Stroke>
+              </se:Mark>
+              <se:Size>7</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:TextSymbolizer>
+            <se:Label>
+              <ogc:PropertyName>name</ogc:PropertyName>
+            </se:Label>
+            <se:Font>
+              <se:SvgParameter name="font-family">Open Sans</se:SvgParameter>
+              <se:SvgParameter name="font-size">13</se:SvgParameter>
+            </se:Font>
+            <se:LabelPlacement>
+              <se:PointPlacement>
+                <se:AnchorPoint>
+                  <se:AnchorPointX>0.5</se:AnchorPointX>
+                  <se:AnchorPointY>0.5</se:AnchorPointY>
+                </se:AnchorPoint>
+                <se:Displacement>
+                  <se:DisplacementX>10</se:DisplacementX>
+                  <se:DisplacementY>20</se:DisplacementY>
+                </se:Displacement>
+              </se:PointPlacement>
+            </se:LabelPlacement>
+            <se:Fill>
+              <se:SvgParameter name="fill">#323232</se:SvgParameter>
+            </se:Fill>
+          </se:TextSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/tests/testdata/symbol_layer/external_sld/simple_line_with_text.sld
+++ b/tests/testdata/symbol_layer/external_sld/simple_line_with_text.sld
@@ -29,10 +29,10 @@
       </se:Font>
       <se:LabelPlacement>
        <se:PointPlacement>
-        <se:AnchorPoint>
-          <se:AnchorPointX>1</se:AnchorPointX>
-          <se:AnchorPointY>0</se:AnchorPointY>
-        </se:AnchorPoint>
+        <se:Displacement>
+          <se:DisplacementX>1</se:DisplacementX>
+          <se:DisplacementY>0</se:DisplacementY>
+        </se:Displacement>
        </se:PointPlacement>
       </se:LabelPlacement>
       <se:Fill>


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/66479

When reading SLD files, we were mishandling the AnchorPoint property by transposing that into an x and y offset of 0 to 1 pixel instead of migrating it to the best of our ability into quadrants. Worse, if the SLD also had a Displacement property, the AnchorPoint would overwrite that.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

