### PR TITLE
[Backport 3.44] [GDAL provider] Fix crash in buildPyramidList() on broken layers

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2490,6 +2490,9 @@ QList<QgsRasterPyramid> QgsGdalProvider::buildPyramidList()
 
 QList<QgsRasterPyramid> QgsGdalProvider::buildPyramidList( const QList<int> &list )
 {
+  if ( !mGdalDataset )
+    return QList<QgsRasterPyramid>();
+
   QList< int > overviewList = list;
   QMutexLocker locker( mpMutex );
 


### PR DESCRIPTION
Fixes #66496

Backport of https://github.com/qgis/QGIS/pull/66510