### PR TITLE
Fix camera control widget wrong Z value when changing position through the dialog

### DIFF
--- a/src/app/3d/qgs3dcameracontrolswidget.cpp
+++ b/src/app/3d/qgs3dcameracontrolswidget.cpp
@@ -68,9 +68,8 @@ Qgs3DCameraControlsWidget::Qgs3DCameraControlsWidget( Qgs3DMapCanvas *canvas, QW
 
 void Qgs3DCameraControlsWidget::updateCameraLookingAt()
 {
-  QgsVector3D mapLookingAt( mCameraX->value(), mCameraY->value(), mCameraX->value() );
+  QgsVector3D mapLookingAt( mCameraX->value(), mCameraY->value(), mCameraZ->value() );
   QgsVector3D worldLookingAt = m3DMapCanvas->mapSettings()->mapToWorldCoordinates( mapLookingAt );
-  worldLookingAt.setZ( mCameraZ->value() );
 
   m3DMapCanvas->cameraController()->setLookingAtPoint( worldLookingAt, m3DMapCanvas->cameraController()->distance(), m3DMapCanvas->cameraController()->pitch(), m3DMapCanvas->cameraController()->yaw() );
 }


### PR DESCRIPTION
No wonder I was explicitly setting Z value just a line after, I didn't notice I was passing X value for Z :facepalm: 
But I also missed the origin offset which is taken into account in that method.

No AI used.

Behavior prior to the fix:
 
[Screencast_20260623_134630.webm](https://github.com/user-attachments/assets/fb299ea7-1d85-4fe5-aef4-a1ac95126de3)
