### PR TITLE
Raster attribute table: convert empty DateTime as string coming from GDAL to NULL value

### DIFF
--- a/src/core/raster/qgsrasterattributetable.cpp
+++ b/src/core/raster/qgsrasterattributetable.cpp
@@ -488,12 +488,17 @@ bool QgsRasterAttributeTable::insertRow( int position, const QVariantList &rowDa
 
   for ( int idx = 0; idx < mFields.count(); ++idx )
   {
+    const QMetaType::Type type = mFields.at( idx ).type;
     QVariant cell( rowData[idx] );
-    if ( !cell.canConvert( mFields.at( idx ).type ) || !cell.convert( mFields.at( idx ).type ) )
+    if ( type == QMetaType::Type::QDateTime && cell.toString().isEmpty() )
+    {
+      dataValid.append( QVariant() );
+    }
+    else if ( !cell.canConvert( type ) || !cell.convert( type ) )
     {
       if ( errorMessage )
       {
-        *errorMessage = tr( "Row data at column %1 cannot be converted to field type (%2)." ).arg( idx ).arg( QVariant::typeToName( mFields.at( idx ).type ) );
+        *errorMessage = tr( "Row data at column %1 cannot be converted to field type (%2)." ).arg( idx ).arg( QVariant::typeToName( type ) );
       }
       return false;
     }

--- a/tests/src/python/test_qgsrasterattributetable.py
+++ b/tests/src/python/test_qgsrasterattributetable.py
@@ -20,6 +20,7 @@ import unittest
 import numpy as np
 from osgeo import gdal, osr
 from qgis.core import (
+    NULL,
     Qgis,
     QgsPalettedRasterRenderer,
     QgsPresetSchemeColorRamp,
@@ -1539,6 +1540,13 @@ class TestQgsRasterAttributeTable(QgisTestCase):
     <F>XXXXXX</F>
     <F>2023/06/01 12:30:45+00</F>
   </Row>
+  <Row index="2">
+    <F>3</F>
+    <F>false</F>
+    <F>0</F>
+    <F></F>
+    <F></F>
+  </Row>
 </GDALRasterAttributeTable>
 </PAMRasterBand>
 </PAMDataset>
@@ -1591,6 +1599,12 @@ class TestQgsRasterAttributeTable(QgisTestCase):
                     QDateTime.fromString(
                         "2023/06/01 12:30:45+00", Qt.DateFormat.ISODate
                     ),
+                ],
+                [
+                    3,
+                    False,
+                    0.0,
+                    NULL,
                 ],
             ],
         )


### PR DESCRIPTION
instead of dropping the entire row

Fixes #66544
