### PR TITLE
[app] Fix status bar coordinates widget not updating when switching from extent to coordinate

### DIFF
--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -100,12 +100,12 @@ void QgsStatusBarCoordinatesWidget::setMapCanvas( QgsMapCanvas *mapCanvas )
 {
   if ( mMapCanvas )
   {
-    disconnect( mMapCanvas, &QgsMapCanvas::xyCoordinates, this, &QgsStatusBarCoordinatesWidget::showMouseCoordinates );
+    disconnect( mMapCanvas, &QgsMapCanvas::xyCoordinates, this, &QgsStatusBarCoordinatesWidget::updateMouseCoordinates );
     disconnect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsStatusBarCoordinatesWidget::showExtent );
   }
 
   mMapCanvas = mapCanvas;
-  connect( mMapCanvas, &QgsMapCanvas::xyCoordinates, this, &QgsStatusBarCoordinatesWidget::showMouseCoordinates );
+  connect( mMapCanvas, &QgsMapCanvas::xyCoordinates, this, &QgsStatusBarCoordinatesWidget::updateMouseCoordinates );
   connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsStatusBarCoordinatesWidget::showExtent );
 }
 
@@ -355,6 +355,7 @@ void QgsStatusBarCoordinatesWidget::extentsViewToggled( bool flag )
     mToggleExtentsViewButton->setIcon( QgsApplication::getThemeIcon( u"extents.svg"_s ) );
     mLineEdit->setToolTip( tr( "Map coordinates for the current view extents" ) );
     mLineEdit->setReadOnly( true );
+    mLabel->setText( tr( "Extents" ) );
     showExtent();
   }
   else
@@ -364,6 +365,7 @@ void QgsStatusBarCoordinatesWidget::extentsViewToggled( bool flag )
     mLineEdit->setToolTip( tr( "Map coordinates at mouse cursor position" ) );
     mLineEdit->setReadOnly( false );
     mLabel->setText( tr( "Coordinate" ) );
+    showMouseCoordinates();
   }
 }
 
@@ -377,11 +379,27 @@ void QgsStatusBarCoordinatesWidget::refreshMapCanvas()
   mMapCanvas->redrawAllLayers();
 }
 
-void QgsStatusBarCoordinatesWidget::showMouseCoordinates( const QgsPointXY &mapPoint )
+void QgsStatusBarCoordinatesWidget::updateMouseCoordinates( const QgsPointXY &mapPoint )
 {
   mLastCoordinate = mapPoint;
   mLastCoordinateCrs = mMapCanvas->mapSettings().destinationCrs();
-  updateCoordinateDisplay();
+
+  showMouseCoordinates();
+}
+
+void QgsStatusBarCoordinatesWidget::showMouseCoordinates()
+{
+  if ( mToggleExtentsViewButton->isChecked() )
+  {
+    return;
+  }
+
+  if ( mLastCoordinate.isEmpty() || !QgsProject::instance()->crs().isSameCelestialBody( mLastCoordinateCrs ) )
+    mLineEdit->clear();
+  else
+    mLineEdit->setText( QgsCoordinateUtils::formatCoordinateForProject( QgsProject::instance(), mLastCoordinate, mLastCoordinateCrs, static_cast<int>( mMousePrecisionDecimalPlaces ) ) );
+
+  ensureCoordinatesVisible();
 }
 
 void QgsStatusBarCoordinatesWidget::showExtent()
@@ -391,7 +409,6 @@ void QgsStatusBarCoordinatesWidget::showExtent()
     return;
   }
 
-  mLabel->setText( tr( "Extents" ) );
   mLineEdit->setText( QgsCoordinateUtils::formatExtentForProject( QgsProject::instance(), mMapCanvas->extent(), mMapCanvas->mapSettings().destinationCrs(), mMousePrecisionDecimalPlaces ) );
 
   ensureCoordinatesVisible();
@@ -428,21 +445,6 @@ void QgsStatusBarCoordinatesWidget::ensureCoordinatesVisible()
   }
 }
 
-void QgsStatusBarCoordinatesWidget::updateCoordinateDisplay()
-{
-  if ( mToggleExtentsViewButton->isChecked() )
-  {
-    return;
-  }
-
-  if ( mLastCoordinate.isEmpty() || !QgsProject::instance()->crs().isSameCelestialBody( mLastCoordinateCrs ) )
-    mLineEdit->clear();
-  else
-    mLineEdit->setText( QgsCoordinateUtils::formatCoordinateForProject( QgsProject::instance(), mLastCoordinate, mLastCoordinateCrs, static_cast<int>( mMousePrecisionDecimalPlaces ) ) );
-
-  ensureCoordinatesVisible();
-}
-
 void QgsStatusBarCoordinatesWidget::coordinateDisplaySettingsChanged()
 {
   const QgsCoordinateReferenceSystem coordinateCrs = QgsProject::instance()->displaySettings()->coordinateCrs();
@@ -468,5 +470,12 @@ void QgsStatusBarCoordinatesWidget::coordinateDisplaySettingsChanged()
       break;
   }
 
-  updateCoordinateDisplay();
+  if ( mToggleExtentsViewButton->isChecked() )
+  {
+    showExtent();
+  }
+  else
+  {
+    showMouseCoordinates();
+  }
 }

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -56,7 +56,6 @@ QgsStatusBarCoordinatesWidget::QgsStatusBarCoordinatesWidget( QWidget *parent )
   mLabel->setAlignment( Qt::AlignCenter );
   mLabel->setFrameStyle( QFrame::NoFrame );
   mLabel->setText( tr( "Coordinate" ) );
-  mLabel->setToolTip( tr( "Current map coordinate" ) );
 
   mLineEdit = new QLineEdit( this );
   mLineEdit->setMinimumWidth( 10 );
@@ -64,8 +63,6 @@ QgsStatusBarCoordinatesWidget::QgsStatusBarCoordinatesWidget( QWidget *parent )
   mLineEdit->setContentsMargins( 0, 0, 0, 0 );
   mLineEdit->setAlignment( Qt::AlignCenter );
   connect( mLineEdit, &QLineEdit::returnPressed, this, &QgsStatusBarCoordinatesWidget::validateCoordinates );
-
-  mLineEdit->setToolTip( tr( "Current map coordinate (longitude latitude or east north)" ) );
 
   //toggle to switch between mouse pos and extents display in status bar widget
   mToggleExtentsViewButton = new QToolButton( this );
@@ -89,11 +86,11 @@ QgsStatusBarCoordinatesWidget::QgsStatusBarCoordinatesWidget( QWidget *parent )
   mDizzyTimer = new QTimer( this );
   connect( mDizzyTimer, &QTimer::timeout, this, &QgsStatusBarCoordinatesWidget::dizzy );
 
-  connect( QgsProject::instance()->displaySettings(), &QgsProjectDisplaySettings::coordinateCrsChanged, this, &QgsStatusBarCoordinatesWidget::coordinateDisplaySettingsChanged );
-  connect( QgsProject::instance()->displaySettings(), &QgsProjectDisplaySettings::geographicCoordinateFormatChanged, this, &QgsStatusBarCoordinatesWidget::coordinateDisplaySettingsChanged );
-  connect( QgsProject::instance()->displaySettings(), &QgsProjectDisplaySettings::coordinateTypeChanged, this, &QgsStatusBarCoordinatesWidget::coordinateDisplaySettingsChanged );
+  connect( QgsProject::instance()->displaySettings(), &QgsProjectDisplaySettings::coordinateCrsChanged, this, &QgsStatusBarCoordinatesWidget::applyCoordinateDisplaySettings );
+  connect( QgsProject::instance()->displaySettings(), &QgsProjectDisplaySettings::geographicCoordinateFormatChanged, this, &QgsStatusBarCoordinatesWidget::applyCoordinateDisplaySettings );
+  connect( QgsProject::instance()->displaySettings(), &QgsProjectDisplaySettings::coordinateTypeChanged, this, &QgsStatusBarCoordinatesWidget::applyCoordinateDisplaySettings );
 
-  coordinateDisplaySettingsChanged();
+  applyCoordinateDisplaySettings();
 }
 
 void QgsStatusBarCoordinatesWidget::setMapCanvas( QgsMapCanvas *mapCanvas )
@@ -101,12 +98,12 @@ void QgsStatusBarCoordinatesWidget::setMapCanvas( QgsMapCanvas *mapCanvas )
   if ( mMapCanvas )
   {
     disconnect( mMapCanvas, &QgsMapCanvas::xyCoordinates, this, &QgsStatusBarCoordinatesWidget::updateMouseCoordinates );
-    disconnect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsStatusBarCoordinatesWidget::showExtent );
+    disconnect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsStatusBarCoordinatesWidget::updateCoordinates );
   }
 
   mMapCanvas = mapCanvas;
   connect( mMapCanvas, &QgsMapCanvas::xyCoordinates, this, &QgsStatusBarCoordinatesWidget::updateMouseCoordinates );
-  connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsStatusBarCoordinatesWidget::showExtent );
+  connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsStatusBarCoordinatesWidget::updateCoordinates );
 }
 
 void QgsStatusBarCoordinatesWidget::setFont( const QFont &myFont )
@@ -353,20 +350,18 @@ void QgsStatusBarCoordinatesWidget::extentsViewToggled( bool flag )
   {
     //extents view mode!
     mToggleExtentsViewButton->setIcon( QgsApplication::getThemeIcon( u"extents.svg"_s ) );
-    mLineEdit->setToolTip( tr( "Map coordinates for the current view extents" ) );
     mLineEdit->setReadOnly( true );
     mLabel->setText( tr( "Extents" ) );
-    showExtent();
   }
   else
   {
     //mouse cursor pos view mode!
     mToggleExtentsViewButton->setIcon( QgsApplication::getThemeIcon( u"tracking.svg"_s ) );
-    mLineEdit->setToolTip( tr( "Map coordinates at mouse cursor position" ) );
     mLineEdit->setReadOnly( false );
     mLabel->setText( tr( "Coordinate" ) );
-    showMouseCoordinates();
   }
+
+  applyCoordinateDisplaySettings();
 }
 
 void QgsStatusBarCoordinatesWidget::refreshMapCanvas()
@@ -384,32 +379,26 @@ void QgsStatusBarCoordinatesWidget::updateMouseCoordinates( const QgsPointXY &ma
   mLastCoordinate = mapPoint;
   mLastCoordinateCrs = mMapCanvas->mapSettings().destinationCrs();
 
-  showMouseCoordinates();
+  updateCoordinates();
 }
 
-void QgsStatusBarCoordinatesWidget::showMouseCoordinates()
+void QgsStatusBarCoordinatesWidget::updateCoordinates()
 {
   if ( mToggleExtentsViewButton->isChecked() )
   {
-    return;
+    mLineEdit->setText( QgsCoordinateUtils::formatExtentForProject( QgsProject::instance(), mMapCanvas->extent(), mMapCanvas->mapSettings().destinationCrs(), mMousePrecisionDecimalPlaces ) );
   }
-
-  if ( mLastCoordinate.isEmpty() || !QgsProject::instance()->crs().isSameCelestialBody( mLastCoordinateCrs ) )
-    mLineEdit->clear();
   else
-    mLineEdit->setText( QgsCoordinateUtils::formatCoordinateForProject( QgsProject::instance(), mLastCoordinate, mLastCoordinateCrs, static_cast<int>( mMousePrecisionDecimalPlaces ) ) );
-
-  ensureCoordinatesVisible();
-}
-
-void QgsStatusBarCoordinatesWidget::showExtent()
-{
-  if ( !mToggleExtentsViewButton->isChecked() )
   {
-    return;
+    if ( mLastCoordinate.isEmpty() || !QgsProject::instance()->crs().isSameCelestialBody( mLastCoordinateCrs ) )
+    {
+      mLineEdit->clear();
+    }
+    else
+    {
+      mLineEdit->setText( QgsCoordinateUtils::formatCoordinateForProject( QgsProject::instance(), mLastCoordinate, mLastCoordinateCrs, static_cast<int>( mMousePrecisionDecimalPlaces ) ) );
+    }
   }
-
-  mLineEdit->setText( QgsCoordinateUtils::formatExtentForProject( QgsProject::instance(), mMapCanvas->extent(), mMapCanvas->mapSettings().destinationCrs(), mMousePrecisionDecimalPlaces ) );
 
   ensureCoordinatesVisible();
 }
@@ -445,37 +434,31 @@ void QgsStatusBarCoordinatesWidget::ensureCoordinatesVisible()
   }
 }
 
-void QgsStatusBarCoordinatesWidget::coordinateDisplaySettingsChanged()
+void QgsStatusBarCoordinatesWidget::applyCoordinateDisplaySettings()
 {
   const QgsCoordinateReferenceSystem coordinateCrs = QgsProject::instance()->displaySettings()->coordinateCrs();
 
   const Qgis::CoordinateOrder projectOrder = QgsProject::instance()->displaySettings()->coordinateAxisOrder();
   const Qgis::CoordinateOrder order = projectOrder == Qgis::CoordinateOrder::Default ? QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( coordinateCrs ) : projectOrder;
 
+  const bool isExtent = mToggleExtentsViewButton->isChecked();
   switch ( order )
   {
     case Qgis::CoordinateOrder::XY:
       if ( coordinateCrs.isGeographic() )
-        mLineEdit->setToolTip( tr( "Current map coordinate (Longitude, Latitude)" ) );
+        mLineEdit->setToolTip( isExtent ? tr( "Current map extent (Longitude, Latitude : Longitude, Latitude)" ) : tr( "Current map coordinate (Longitude, Latitude)" ) );
       else
-        mLineEdit->setToolTip( tr( "Current map coordinate (Easting, Northing)" ) );
+        mLineEdit->setToolTip( isExtent ? tr( "Current map extent (Easting, Northing : Easting, Northing)" ) : tr( "Current map coordinate (Easting, Northing)" ) );
       break;
     case Qgis::CoordinateOrder::YX:
       if ( coordinateCrs.isGeographic() )
-        mLineEdit->setToolTip( tr( "Current map coordinate (Latitude, Longitude)" ) );
+        mLineEdit->setToolTip( isExtent ? tr( "Current map coordinate (Latitude, Longitude : Latitude, Longitude)" ) : tr( "Current map coordinate (Latitude, Longitude)" ) );
       else
-        mLineEdit->setToolTip( tr( "Current map coordinate (Northing, Easting)" ) );
+        mLineEdit->setToolTip( isExtent ? tr( "Current map coordinate (Northing, Easting : Northing, Easting)" ) : tr( "Current map coordinate (Northing, Easting)" ) );
       break;
     case Qgis::CoordinateOrder::Default:
       break;
   }
 
-  if ( mToggleExtentsViewButton->isChecked() )
-  {
-    showExtent();
-  }
-  else
-  {
-    showMouseCoordinates();
-  }
+  updateCoordinates();
 }

--- a/src/app/qgsstatusbarcoordinateswidget.h
+++ b/src/app/qgsstatusbarcoordinateswidget.h
@@ -58,7 +58,7 @@ class APP_EXPORT QgsStatusBarCoordinatesWidget : public QWidget
     void weAreBored();
 
   private slots:
-    void showMouseCoordinates( const QgsPointXY &mapPoint );
+    void updateMouseCoordinates( const QgsPointXY &mapPoint );
     void extentsViewToggled( bool flag );
     void validateCoordinates();
     void dizzy();
@@ -67,8 +67,8 @@ class APP_EXPORT QgsStatusBarCoordinatesWidget : public QWidget
     void hackfests();
     void userGroups();
     void showExtent();
+    void showMouseCoordinates();
     void ensureCoordinatesVisible();
-    void updateCoordinateDisplay();
     void coordinateDisplaySettingsChanged();
 
   private:

--- a/src/app/qgsstatusbarcoordinateswidget.h
+++ b/src/app/qgsstatusbarcoordinateswidget.h
@@ -66,10 +66,9 @@ class APP_EXPORT QgsStatusBarCoordinatesWidget : public QWidget
     void contributors();
     void hackfests();
     void userGroups();
-    void showExtent();
-    void showMouseCoordinates();
+    void updateCoordinates();
     void ensureCoordinatesVisible();
-    void coordinateDisplaySettingsChanged();
+    void applyCoordinateDisplaySettings();
 
   private:
     void refreshMapCanvas();


### PR DESCRIPTION
## Description

Fixes https://github.com/qgis/QGIS/issues/66418

While at it, I also fixed another unreported issue whereas the extent text is not updated when the project coordinate display settings is changed. Finally a couple of functions were renamed to make the overall class feel more consistent.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

