### PR TITLE
When creating a feature using the QgsVectorLayerUtils createFeature(s) function, defer fields with default values referencing other columns

### DIFF
--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -607,8 +607,13 @@ QgsFeatureList QgsVectorLayerUtils::createFeatures( const QgsVectorLayer *layer,
 
     // initialize attributes
     newFeature.initAttributes( fields.count() );
-    for ( int idx = 0; idx < fields.count(); ++idx )
+    QList<int> deferredFieldIndexes;
+    QList<int> fieldIndexes( fields.count() );
+    std::iota( fieldIndexes.begin(), fieldIndexes.end(), 0 );
+    while ( !fieldIndexes.isEmpty() )
     {
+      const int idx = fieldIndexes.takeFirst();
+
       QVariant v;
       bool checkUnique = true;
       const bool hasUniqueConstraint { static_cast<bool>( fields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique ) };
@@ -625,10 +630,21 @@ QgsFeatureList QgsVectorLayerUtils::createFeatures( const QgsVectorLayer *layer,
       QgsDefaultValue defaultValueDefinition = layer->defaultValueDefinition( idx );
       if ( ( QgsVariantUtils::isNull( v ) || ( hasUniqueConstraint && checkUniqueValue( idx, v ) ) || defaultValueDefinition.applyOnUpdate() ) && defaultValueDefinition.isValid() )
       {
-        // client side default expression set - takes precedence over all. Why? Well, this is the only default
-        // which QGIS users have control over, so we assume that they're deliberately overriding any
-        // provider defaults for some good reason and we should respect that
-        v = layer->defaultValue( idx, newFeature, evalContext );
+        QgsExpression defaultValueExpression( defaultValueDefinition.expression() );
+        if ( defaultValueExpression.referencedColumns().isEmpty() || deferredFieldIndexes.contains( idx ) )
+        {
+          // client side default expression set - takes precedence over all. Why? Well, this is the only default
+          // which QGIS users have control over, so we assume that they're deliberately overriding any
+          // provider defaults for some good reason and we should respect that
+          v = layer->defaultValue( idx, newFeature, evalContext );
+        }
+        else
+        {
+          // the default value relies on order field(s) value, defer until the end
+          deferredFieldIndexes << idx;
+          fieldIndexes << idx;
+          continue;
+        }
       }
 
       // 3. provider side default value clause

--- a/src/core/vector/qgsvectorlayerutils.cpp
+++ b/src/core/vector/qgsvectorlayerutils.cpp
@@ -607,6 +607,8 @@ QgsFeatureList QgsVectorLayerUtils::createFeatures( const QgsVectorLayer *layer,
 
     // initialize attributes
     newFeature.initAttributes( fields.count() );
+
+    // Avoid endless looping for recursive expression dependencies by keeping track of fields already deferred
     QList<int> deferredFieldIndexes;
     QList<int> fieldIndexes( fields.count() );
     std::iota( fieldIndexes.begin(), fieldIndexes.end(), 0 );

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -443,6 +443,23 @@ class TestQgsVectorLayerUtils(QgisTestCase):
             QgsVectorLayerUtils.createUniqueValue(layer, 0, "superpig"), "superpig_1"
         )
 
+    def testCreateFeatureDefaultValueOrdering(self):
+        """test creating a unique value"""
+        layer = QgsVectorLayer(
+            "Point?field=flda:string&field=fldb:integer&field=fldc:double",
+            "addfeat",
+            "memory",
+        )
+
+        layer.setDefaultValueDefinition(
+            0, QgsDefaultValue("if(fldb > 10, 'big', 'small')", True)
+        )
+
+        feature = QgsVectorLayerUtils.createFeature(layer, attributes={1: 20, 2: 1.0})
+        self.assertEqual(feature.attribute(0), "big")
+        self.assertEqual(feature.attribute(1), 20)
+        self.assertEqual(feature.attribute(2), 1.0)
+
     def testCreateFeature(self):
         """test creating a feature respecting defaults and constraints"""
         layer = QgsVectorLayer(


### PR DESCRIPTION
## Description

This PR fixes https://github.com/qgis/QGIS/issues/66207 by insuring that default values that refer to attributes within a newly created feature being prepared in QgsVectorLayerUtils::createFeature(s) are evaluated _after_ manually provided attribute values (or 'standalone' default value expression generated values) are added to the feature.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

