### PR TITLE
[qt6][attribute form] Provide a partial fix to broken HTML editor widgets when built using Qt6

### DIFF
--- a/python/PyQt6/gui/auto_generated/editorwidgets/qgshtmlwidgetwrapper.sip.in
+++ b/python/PyQt6/gui/auto_generated/editorwidgets/qgshtmlwidgetwrapper.sip.in
@@ -61,8 +61,6 @@ Returns true if the widget needs feature geometry
 
 };
 
-
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/src/gui/editorwidgets/qgshtmlwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshtmlwidgetwrapper.cpp
@@ -31,7 +31,7 @@ using namespace Qt::StringLiterals;
 QgsHtmlWidgetWrapper::QgsHtmlWidgetWrapper( QgsVectorLayer *layer, QWidget *editor, QWidget *parent )
   : QgsWidgetWrapper( layer, editor, parent )
 {
-  connect( this, &QgsWidgetWrapper::contextChanged, this, &QgsHtmlWidgetWrapper::setHtmlContext );
+  connect( this, &QgsWidgetWrapper::contextChanged, this, &QgsHtmlWidgetWrapper::updateHtmlCode );
 }
 
 bool QgsHtmlWidgetWrapper::valid() const
@@ -49,11 +49,12 @@ QWidget *QgsHtmlWidgetWrapper::createWidget( QWidget *parent )
     connect( form, &QgsAttributeForm::widgetValueChanged, this, [this]( const QString &attribute, const QVariant &newValue, bool attributeChanged ) {
       if ( attributeChanged )
       {
+        mFeature.setAttribute( attribute, newValue );
         if ( mRequiresFormScope )
         {
           mFormFeature.setAttribute( attribute, newValue );
-          setHtmlContext();
         }
+        updateHtmlCode();
       }
     } );
   }
@@ -68,9 +69,7 @@ void QgsHtmlWidgetWrapper::initWidget( QWidget *editor )
   if ( !mWidget )
     return;
 
-  mWidget->setHtml( mHtmlCode.replace( "\n", " " ) );
-
-  checkGeometryNeeds();
+  updateHtmlCode();
 }
 
 void QgsHtmlWidgetWrapper::reinitWidget()
@@ -81,54 +80,38 @@ void QgsHtmlWidgetWrapper::reinitWidget()
   initWidget( mWidget );
 }
 
-void QgsHtmlWidgetWrapper::checkGeometryNeeds()
-{
-  if ( !mWidget )
-    return;
-
-  // initialize a temporary QgsWebView to render HTML code and check if one evaluated expression
-  // needs geometry
-  QgsWebView webView;
-  NeedsGeometryEvaluator evaluator;
-
-  const QgsAttributeEditorContext attributecontext = context();
-  if ( QgsVectorLayer *vl = layer() )
-  {
-    const QgsExpressionContext expressionContext = vl->createExpressionContext();
-    evaluator.setExpressionContext( expressionContext );
-  }
-
-  auto frame = webView.page()->mainFrame();
-  connect( frame, &QWebFrame::javaScriptWindowObjectCleared, frame, [frame, &evaluator] { frame->addToJavaScriptWindowObject( u"expression"_s, &evaluator ); } );
-
-  webView.setHtml( mHtmlCode );
-
-  mNeedsGeometry = evaluator.needsGeometry();
-}
-
 void QgsHtmlWidgetWrapper::setHtmlCode( const QString &htmlCode )
 {
   mHtmlCode = htmlCode;
 
-  bool ok = false;
+  mRequiresFormScope = false;
+  mNeedsGeometry = false;
+
+  QgsExpressionContext expressionContext = layer() ? layer()->createExpressionContext() : QgsExpressionContext();
   const thread_local QRegularExpression
     expRe( QStringLiteral( R"re(expression.evaluate\s*\(\s*"(.*)"\))re" ), QRegularExpression::PatternOption::MultilineOption | QRegularExpression::PatternOption::DotMatchesEverythingOption );
   QRegularExpressionMatchIterator matchIt = expRe.globalMatch( mHtmlCode );
-  while ( !ok && matchIt.hasNext() )
+  while ( matchIt.hasNext() && ( !mRequiresFormScope || !mNeedsGeometry ) )
   {
     const QRegularExpressionMatch match = matchIt.next();
-    const QgsExpression exp = match.captured( 1 );
-    ok = QgsValueRelationFieldFormatter::expressionRequiresFormScope( exp );
-  }
-  mRequiresFormScope = ok;
+    QString expression = match.captured( 1 );
+    expression = expression.replace( "\\\""_L1, "\""_L1 );
 
-  checkGeometryNeeds();
+    QgsExpression exp = QgsExpression( expression );
+    mRequiresFormScope |= QgsValueRelationFieldFormatter::expressionRequiresFormScope( exp );
+    exp.prepare( &expressionContext );
+    mNeedsGeometry |= exp.needsGeometry();
+  }
+
+  updateHtmlCode();
 }
 
-void QgsHtmlWidgetWrapper::setHtmlContext()
+void QgsHtmlWidgetWrapper::updateHtmlCode()
 {
   if ( !mWidget )
     return;
+
+  QString htmlCode = mHtmlCode;
 
   const QgsAttributeEditorContext attributecontext = context();
   QgsExpressionContext expressionContext = layer()->createExpressionContext();
@@ -137,15 +120,41 @@ void QgsHtmlWidgetWrapper::setHtmlContext()
   {
     expressionContext << QgsExpressionContextUtils::parentFormScope( attributecontext.parentFormFeature() );
   }
-
   expressionContext.setFeature( mFeature );
 
-  HtmlExpression *htmlExpression = new HtmlExpression();
-  htmlExpression->setExpressionContext( expressionContext );
-  auto frame = mWidget->page()->mainFrame();
-  connect( frame, &QWebFrame::javaScriptWindowObjectCleared, frame, [frame, htmlExpression] { frame->addToJavaScriptWindowObject( u"expression"_s, htmlExpression ); } );
+  const thread_local QRegularExpression
+    expRe( QStringLiteral( R"re(<script>\s*document\.write\(\s*expression.evaluate\s*\(\s*"(.*)"\s*\)\s*\)\s*;\s*<\/script>)re" ), QRegularExpression::PatternOption::MultilineOption | QRegularExpression::PatternOption::DotMatchesEverythingOption );
+  QRegularExpressionMatch match = expRe.match( htmlCode );
+  while ( match.hasMatch() )
+  {
+    QString expression = match.captured( 1 );
+    expression = expression.replace( "\\\""_L1, "\""_L1 );
 
-  mWidget->setHtml( mHtmlCode );
+    QgsExpression exp = QgsExpression( expression );
+    exp.prepare( &expressionContext );
+    QVariant result = exp.evaluate( &expressionContext );
+
+    QString resultString;
+    switch ( static_cast<QMetaType::Type>( result.typeId() ) )
+    {
+      case QMetaType::Bool:
+        resultString = result.toBool() ? u"true"_s : u"false"_s;
+        break;
+      case QMetaType::Int:
+      case QMetaType::UInt:
+      case QMetaType::Double:
+      case QMetaType::LongLong:
+      case QMetaType::ULongLong:
+      case QMetaType::QString:
+      default:
+        resultString = result.toString();
+        break;
+    }
+    htmlCode = htmlCode.mid( 0, match.capturedStart( 0 ) ) + resultString + htmlCode.mid( match.capturedEnd( 0 ) );
+    match = expRe.match( htmlCode );
+  }
+
+  mWidget->setHtml( htmlCode );
 }
 
 void QgsHtmlWidgetWrapper::setFeature( const QgsFeature &feature )
@@ -155,39 +164,10 @@ void QgsHtmlWidgetWrapper::setFeature( const QgsFeature &feature )
 
   mFeature = feature;
   mFormFeature = feature;
-  setHtmlContext();
+  updateHtmlCode();
 }
 
 bool QgsHtmlWidgetWrapper::needsGeometry() const
 {
   return mNeedsGeometry;
 }
-
-
-///@cond PRIVATE
-void HtmlExpression::setExpressionContext( const QgsExpressionContext &context )
-{
-  mExpressionContext = context;
-}
-
-QString HtmlExpression::evaluate( const QString &expression ) const
-{
-  QgsExpression exp { expression };
-  exp.prepare( &mExpressionContext );
-  return exp.evaluate( &mExpressionContext ).toString();
-}
-
-void NeedsGeometryEvaluator::evaluate( const QString &expression )
-{
-  QgsExpression exp { expression };
-  exp.prepare( &mExpressionContext );
-  mNeedsGeometry |= exp.needsGeometry();
-}
-
-void NeedsGeometryEvaluator::setExpressionContext( const QgsExpressionContext &context )
-{
-  mExpressionContext = context;
-}
-
-
-///@endcond

--- a/src/gui/editorwidgets/qgshtmlwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgshtmlwidgetwrapper.h
@@ -62,13 +62,10 @@ class GUI_EXPORT QgsHtmlWidgetWrapper : public QgsWidgetWrapper
     void setFeature( const QgsFeature &feature ) override;
 
   private slots:
-    //! sets the html context with the current values
-    void setHtmlContext();
+    //! Updates the HTML code with the current values
+    void updateHtmlCode();
 
   private:
-    //! checks if HTML contains geometry related expression
-    void checkGeometryNeeds();
-
     QString mHtmlCode;
     QgsWebView *mWidget = nullptr;
     QgsFeature mFeature;
@@ -78,59 +75,5 @@ class GUI_EXPORT QgsHtmlWidgetWrapper : public QgsWidgetWrapper
 
     friend class TestQgsHtmlWidgetWrapper;
 };
-
-
-#ifndef SIP_RUN
-///@cond PRIVATE
-
-/**
- * \ingroup gui
- * \brief To pass the QgsExpression functionality and it's context to the context of the QWebView
- * \since QGIS 3.8
- */
-class HtmlExpression : public QObject
-{
-    Q_OBJECT
-
-  public:
-    //! set the \a context of the expression
-    void setExpressionContext( const QgsExpressionContext &context );
-
-  public:
-    //! evaluates the value regarding the \a expression and the context
-    Q_INVOKABLE QString evaluate( const QString &expression ) const;
-
-  private:
-    QgsExpressionContext mExpressionContext;
-};
-
-/**
- * \ingroup gui
- * Evaluate expression when rendering the html content to determine whether we need feature
- * geometry or not for later evaluation
- * \since QGIS 3.20
- */
-class NeedsGeometryEvaluator : public QObject
-{
-    Q_OBJECT
-
-  public:
-    //! Returns true if the widget needs feature geometry
-    bool needsGeometry() const { return mNeedsGeometry; }
-
-    //! set context use when evaluating expression
-    void setExpressionContext( const QgsExpressionContext &context );
-
-    //! evaluates the value regarding the \a expression and the context
-    Q_INVOKABLE void evaluate( const QString &expression );
-
-  private:
-    bool mNeedsGeometry = false;
-    QgsExpressionContext mExpressionContext;
-};
-
-
-///@endcond
-#endif //SIP_RUN
 
 #endif // QGSHTMLWIDGETWRAPPER_H


### PR DESCRIPTION
## Description

This PR provides a practical fix for https://github.com/qgis/QGIS/issues/66111 which aims at fixing HTML editor widget configuration under Qt6 by replacing the dead javascript object injection with regular expression string replacement within the HTML source code directly.

This is obviously not a complete fix as more elaborate block of javascript code that go beyond the default value injection template (i.e. <script>document.write(expression.evaluate("..."));</script>) will not work (no javascript code runs in the QgsWebView under Qt6). Nevertheless, I believe this is a good fix to push to heal quite a few preexisting projects out there.

_If_ we want to re-enable Javascript support in the HTML editor widget, we'll need to spend more time reinventing the wheel using QtWebEngineView and its QWebChannel support. 

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

