### PR TITLE
Concave hull (by feature): skip single-point features instead of emitting null geometries

### DIFF
--- a/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
+++ b/src/analysis/processing/qgsalgorithmconcavehullbyfeature.cpp
@@ -115,8 +115,8 @@ QgsFeatureList QgsConcaveHullByFeatureAlgorithm::processFeature( const QgsFeatur
     const QgsGeometryCollection *collection = qgsgeometry_cast< const QgsGeometryCollection * >( inputGeometry );
     if ( !collection || collection->numGeometries() == 1 )
     {
-      feedback->reportError( QObject::tr( "Cannot calculate convex hull for a single point feature (%1) (try 'Concave hull (by layer)' algorithm instead)." ).arg( f.id() ) );
-      f.clearGeometry();
+      feedback->reportError( QObject::tr( "Cannot calculate concave hull for a single point feature (%1) (try 'Concave hull (by layer)' algorithm instead)." ).arg( f.id() ) );
+      return QgsFeatureList();
     }
     else
     {


### PR DESCRIPTION
Description
-----------

The `Concave hull (by feature)` algorithm (`native:concavehullbyfeature`) cannot compute a hull for single-point input features. Previously it reported an error for such features but **still emitted an output feature with a cleared (null) geometry** and null `area`/`perimeter` attributes.

This left geometryless rows in the output layer. Trying to zoom to them gives:

> Zoom to feature id failed: Feature does not have a geometry

Fix
---

Return an empty `QgsFeatureList` for single-point features so they are skipped and not added to the output. This matches the documented contract of `QgsProcessingFeatureBasedAlgorithm::processFeature()`:

> Returning an empty list will indicate that this feature should be 'skipped', and will not be added to the algorithm's output.

Also corrects the error message wording from "convex hull" to "concave hull".

Fixes #65899