### PR TITLE
Show actual layer/map units in combo box for simplify tool unit combo

### DIFF
--- a/src/app/qgsmaptoolsimplify.cpp
+++ b/src/app/qgsmaptoolsimplify.cpp
@@ -36,8 +36,9 @@
 
 using namespace Qt::StringLiterals;
 
-QgsSimplifyUserInputWidget::QgsSimplifyUserInputWidget( QWidget *parent )
+QgsSimplifyUserInputWidget::QgsSimplifyUserInputWidget( QgsMapCanvas *canvas, QWidget *parent )
   : QWidget( parent )
+  , mCanvas( canvas )
 {
   setupUi( this );
 
@@ -48,7 +49,10 @@ QgsSimplifyUserInputWidget::QgsSimplifyUserInputWidget( QWidget *parent )
 
   mToleranceUnitsComboBox->addItem( tr( "Layer Units" ), QVariant::fromValue( Qgis::MapToolUnit::Layer ) );
   mToleranceUnitsComboBox->addItem( tr( "Pixels" ), QVariant::fromValue( Qgis::MapToolUnit::Pixels ) );
-  mToleranceUnitsComboBox->addItem( tr( "Map Units" ), QVariant::fromValue( Qgis::MapToolUnit::Project ) );
+  mToleranceUnitsComboBox->addItem( mapUnitComboText(), QVariant::fromValue( Qgis::MapToolUnit::Project ) );
+  connect( mCanvas, &QgsMapCanvas::destinationCrsChanged, this, [this] {
+    mToleranceUnitsComboBox->setItemText( mToleranceUnitsComboBox->findData( QVariant::fromValue( Qgis::MapToolUnit::Project ) ), mapUnitComboText() );
+  } );
 
   mToleranceSpinBox->setShowClearButton( false );
 
@@ -97,6 +101,20 @@ void QgsSimplifyUserInputWidget::setConfig( QgsMapToolSimplify::Method method, d
   mIterationsSpin->setValue( smoothIterations );
 }
 
+void QgsSimplifyUserInputWidget::setTargetLayer( QgsMapLayer *layer )
+{
+  QString layerUnitText;
+  if ( layer && layer->crs().mapUnits() != Qgis::DistanceUnit::Unknown )
+  {
+    layerUnitText = tr( "Layer Units (%1)" ).arg( QgsUnitTypes::toString( layer->crs().mapUnits() ) );
+  }
+  else
+  {
+    layerUnitText = tr( "Layer Units" );
+  }
+  mToleranceUnitsComboBox->setItemText( mToleranceUnitsComboBox->findData( QVariant::fromValue( Qgis::MapToolUnit::Layer ) ), layerUnitText );
+}
+
 void QgsSimplifyUserInputWidget::updateStatusText( const QString &text )
 {
   labelStatus->setText( text );
@@ -136,6 +154,20 @@ void QgsSimplifyUserInputWidget::keyReleaseEvent( QKeyEvent *event )
     return;
   }
   QWidget::keyReleaseEvent( event );
+}
+
+QString QgsSimplifyUserInputWidget::mapUnitComboText() const
+{
+  QString mapUnit;
+  if ( mCanvas )
+  {
+    const Qgis::DistanceUnit mapUnits = mCanvas->mapUnits();
+    if ( mapUnits != Qgis::DistanceUnit::Unknown )
+    {
+      mapUnit = QgsUnitTypes::toString( mapUnits );
+    }
+  }
+  return mapUnit.isEmpty() ? tr( "Map Units" ) : tr( "Map Units (%1)" ).arg( mapUnit );
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -212,7 +244,7 @@ void QgsMapToolSimplify::updateSimplificationPreview()
 
 void QgsMapToolSimplify::createUserInputWidget()
 {
-  mSimplifyUserWidget = new QgsSimplifyUserInputWidget();
+  mSimplifyUserWidget = new QgsSimplifyUserInputWidget( canvas() );
   mSimplifyUserWidget->setConfig( method(), tolerance(), toleranceUnits(), smoothOffset(), smoothIterations() );
 
   connect( mSimplifyUserWidget, &QgsSimplifyUserInputWidget::methodChanged, this, &QgsMapToolSimplify::setMethod );
@@ -222,6 +254,9 @@ void QgsMapToolSimplify::createUserInputWidget()
   connect( mSimplifyUserWidget, &QgsSimplifyUserInputWidget::smoothIterationsChanged, this, &QgsMapToolSimplify::setSmoothIterations );
   connect( mSimplifyUserWidget, &QgsSimplifyUserInputWidget::accepted, this, &QgsMapToolSimplify::storeSimplified );
   connect( mSimplifyUserWidget, &QgsSimplifyUserInputWidget::rejected, this, &QgsMapToolSimplify::clearSelection );
+
+  mSimplifyUserWidget->setTargetLayer( currentVectorLayer() );
+  connect( canvas(), &QgsMapCanvas::currentLayerChanged, this, [this]( QgsMapLayer *layer ) { mSimplifyUserWidget->setTargetLayer( layer ); } );
 
   QgisApp::instance()->addUserInputWidget( mSimplifyUserWidget );
   mSimplifyUserWidget->setFocus( Qt::TabFocusReason );

--- a/src/app/qgsmaptoolsimplify.h
+++ b/src/app/qgsmaptoolsimplify.h
@@ -134,12 +134,13 @@ class APP_EXPORT QgsSimplifyUserInputWidget : public QWidget, private Ui::Simpli
     Q_OBJECT
 
   public:
-    QgsSimplifyUserInputWidget( QWidget *parent = nullptr );
+    QgsSimplifyUserInputWidget( QgsMapCanvas *canvas, QWidget *parent = nullptr );
 
     void updateStatusText( const QString &text );
     void enableOkButton( bool enabled );
 
     void setConfig( QgsMapToolSimplify::Method method, double tolerance, Qgis::MapToolUnit units, double smoothOffset, int smoothIterations );
+    void setTargetLayer( QgsMapLayer *layer );
 
   signals:
     void accepted();
@@ -153,6 +154,11 @@ class APP_EXPORT QgsSimplifyUserInputWidget : public QWidget, private Ui::Simpli
   protected:
     bool eventFilter( QObject *object, QEvent *ev ) override;
     void keyReleaseEvent( QKeyEvent *event ) override;
+
+  private:
+    QString mapUnitComboText() const;
+
+    QPointer< QgsMapCanvas > mCanvas;
 };
 
 #endif


### PR DESCRIPTION
Instead of just the raw "Map Units" / "Layer Units" text, suffix the combo item text with the actual units (eg "Map Units (meters)") so that it's immediately clear what unit the simplify tool operates on.

Helps avoid user confusion with seemingly broken results when simplifying layers in geographic CRS

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
