### PR TITLE
validate custom CRS definition when changing between CRs and warn user about invalid definition (fix #57806)

### DIFF
--- a/src/app/options/qgscustomprojectionoptions.cpp
+++ b/src/app/options/qgscustomprojectionoptions.cpp
@@ -220,11 +220,33 @@ void QgsCustomProjectionOptionsWidget::pbnRemove_clicked()
 
 void QgsCustomProjectionOptionsWidget::leNameList_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous )
 {
+  if ( mBlockUpdates )
+  {
+    return;
+  }
+
   //Store the modifications made to the current element before moving on
   int currentIndex, previousIndex;
   if ( previous )
   {
     previousIndex = leNameList->indexOfTopLevelItem( previous );
+
+    if ( !mCrsDefinitionWidget->crs().isValid() )
+    {
+      QMessageBox::warning( this, tr( "Custom Coordinate Reference System" ), tr( "Current definition of '%1' is not valid." ).arg( leName->text() ) );
+
+      mBlockUpdates++;
+      QMetaObject::invokeMethod(
+        this,
+        [this, previous]() {
+          leNameList->setCurrentItem( previous );
+          leNameList->selectionModel()->select( leNameList->indexFromItem( previous ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+          mBlockUpdates--;
+        },
+        Qt::QueuedConnection
+      );
+      return;
+    }
 
     mDefinitions[previousIndex].name = leName->text();
     switch ( mCrsDefinitionWidget->format() )


### PR DESCRIPTION
## Description

When user changes custom CRS definition to invalid, then selects another custom CRS in the list and returns back to the previously changed CRS, the definition string will be lost.

This is because we update custom CRS definition when current item changes and do not check if CRS created from the definition is valid.

To prevent silent lost of definition we check validity of the CRS, warn user if it is invalid and block changing to another  CRS. 

Fixes #57806.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.