### PR TITLE
Fix field displayString on primitive JSON values

### DIFF
--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -432,7 +432,12 @@ QString QgsField::displayString( const QVariant &v ) const
   else if ( d->typeName.compare( "json"_L1, Qt::CaseInsensitive ) == 0 || d->typeName == "jsonb"_L1 )
   {
     const QJsonDocument doc = QJsonDocument::fromVariant( v );
-    return QString::fromUtf8( doc.toJson().constData() );
+    if ( !doc.isNull() )
+    {
+      return QString::fromUtf8( doc.toJson().constData() );
+    }
+    //on invalid json or primitive values (like string, number, boolean or null) it does not return it as parsed json but the raw value instead
+    return v.toString();
   }
   else if ( d->type == QMetaType::Type::QByteArray )
   {

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -570,6 +570,44 @@ void TestQgsField::displayString()
   QCOMPARE( stringArrayField.displayString( QStringList() << "A" << "B" << "C" ), u"A, B, C"_s );
   const QgsField intArrayField( u"intArray"_s, QMetaType::Type::QVariantList, u"IntArray"_s );
   QCOMPARE( intArrayField.displayString( QVariantList() << 1 << 2 << 3 ), u"1, 2, 3"_s );
+
+  // Test string-based json display strings
+  {
+    const QgsField jsonField( u"json"_s, QMetaType::Type::QString, u"json"_s );
+    QVariant jsonValue = QVariant::fromValue( QVariantList() << 1 << 5 << 8 );
+    QCOMPARE( jsonField.displayString( jsonValue ), QString( "[\n    1,\n    5,\n    8\n]\n" ) );
+    QVariantMap variantMap;
+    variantMap.insert( u"a"_s, 1 );
+    variantMap.insert( u"c"_s, 3 );
+    jsonValue = QVariant::fromValue( variantMap );
+    QCOMPARE( jsonField.displayString( jsonValue ), QString( "{\n    \"a\": 1,\n    \"c\": 3\n}\n" ) );
+    //primitive values fall back to the original value
+    jsonValue = QVariant::fromValue( QString( "foo" ) );
+    QCOMPARE( jsonField.displayString( jsonValue ), QString( "foo" ) );
+    jsonValue = QVariant::fromValue( QString( "42" ) );
+    QCOMPARE( jsonField.displayString( jsonValue ), QString( "42" ) );
+    jsonValue = QVariant::fromValue( QString( "true" ) );
+    QCOMPARE( jsonField.displayString( jsonValue ), QString( "true" ) );
+  }
+
+  // Test map-based json field (i.e. OGR geopackage or Postgres JSON fields) display strings
+  {
+    const QgsField jsonField( u"json"_s, QMetaType::Type::QVariantMap, u"json"_s );
+    QVariant jsonValue = QVariant::fromValue( QVariantList() << 1 << 5 << 8 );
+    QCOMPARE( jsonField.displayString( jsonValue ), QString( "[\n    1,\n    5,\n    8\n]\n" ) );
+    QVariantMap variantMap;
+    variantMap.insert( u"a"_s, 1 );
+    variantMap.insert( u"c"_s, 3 );
+    jsonValue = QVariant::fromValue( variantMap );
+    QCOMPARE( jsonField.displayString( jsonValue ), QString( "{\n    \"a\": 1,\n    \"c\": 3\n}\n" ) );
+    //primitive values fall back to the original value
+    jsonValue = QVariant::fromValue( QString( "foo" ) );
+    QCOMPARE( jsonField.displayString( jsonValue ), QString( "foo" ) );
+    jsonValue = QVariant::fromValue( QString( "42" ) );
+    QCOMPARE( jsonField.displayString( jsonValue ), QString( "42" ) );
+    jsonValue = QVariant::fromValue( QString( "true" ) );
+    QCOMPARE( jsonField.displayString( jsonValue ), QString( "true" ) );
+  }
 }
 
 void TestQgsField::convertCompatible()


### PR DESCRIPTION
When having a primitive JSON value like `bool`, `string`, `number` or `null` (or an invalid value) it used to return empty string, what could be interpreted as empty value. 

This fix returns the fallback value (raw value converted to string) if it cannot convert the value to a JSON object or array (and format accordingly).

## AI tool usage

None