### PR TITLE
Copy plugin from temp so that files inherit target folder permissions

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -860,7 +860,12 @@ class QgsPluginInstaller(QObject):
                 success = False
 
             try:
-                shutil.move(extractDir.filePath(pluginName), pluginsDirectory)
+                # we copy instead of move, so that the target files inherit parent folder persmissions on windows
+                shutil.copytree(
+                    extractDir.filePath(pluginName),
+                    pluginDirectory,
+                    copy_function=shutil.copy,
+                )
             except:
                 infoString = (
                     self.tr("Could not store plugin to the plugin directory:")

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -860,7 +860,7 @@ class QgsPluginInstaller(QObject):
                 success = False
 
             try:
-                # we copy instead of move, so that the target files inherit parent folder persmissions on windows
+                # we copy instead of move, so that the target files inherit parent folder permissions on windows
                 shutil.copytree(
                     extractDir.filePath(pluginName),
                     pluginDirectory,

--- a/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
+++ b/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
@@ -222,7 +222,7 @@ class QgsPluginInstallerInstallingDialog(
             return
 
         # Copy extracted plugin to plugins folder
-        # we copy instead of move, so that the target files inherit parent folder persmissions on windows
+        # we copy instead of move, so that the target files inherit parent folder permissions on windows
         try:
             shutil.copytree(
                 extractDir.filePath(self.plugin["id"]),

--- a/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
+++ b/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
@@ -221,14 +221,19 @@ class QgsPluginInstallerInstallingDialog(
             self.reject()
             return
 
-        # move extracted plugin to plugins folder
+        # Copy extracted plugin to plugins folder
+        # we copy instead of move, so that the target files inherit parent folder persmissions on windows
         try:
-            shutil.move(extractDir.filePath(self.plugin["id"]), pluginsDirectory)
+            shutil.copytree(
+                extractDir.filePath(self.plugin["id"]),
+                pluginTargetDirectory,
+                copy_function=shutil.copy,
+            )
         except:
             self.mResult = (
                 self.tr("Could not store plugin to the plugin directory:")
                 + "\n"
-                + pluginsDirectory
+                + pluginTargetDirectory
             )
             self.reject()
             return


### PR DESCRIPTION
## Description
This should be fixing #66515

QT uses strict permissions for the extracted `QTemporaryDir`. When the temp folder was moved to the plugins folder, the ACLs were preserved.
By copying instead of moving, the parent plugins folder permissions should be inherited instead.

@agiudiceandrea could you please verify this fixes #66515 for you?

## AI tool usage

 - [x] AI tool(s): Claude was used to explain how ACLs are inherited in windows when moving vs copying files


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
