### PR TITLE
Fix crash with unavailable WMS layers

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2378,7 +2378,7 @@ Qgis::RasterInterfaceCapabilities QgsWmsProvider::capabilities() const
       if ( mActiveSubLayerVisibility.find( *it ).value() )
       {
         // Is sublayer queryable?
-        if ( mCaps.mQueryableForLayer.find( *it ).value() )
+        if ( mCaps.isValid() && mCaps.mQueryableForLayer.find( *it ).value() )
         {
           QgsDebugMsgLevel( '\'' + ( *it ) + "' is queryable.", 2 );
           canIdentify = true;
@@ -3509,7 +3509,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, Qgis:
 
 
       // Is sublayer queryable?
-      if ( !mCaps.mQueryableForLayer.find( *layers ).value() )
+      if ( !mCaps.isValid() || !mCaps.mQueryableForLayer.find( *layers ).value() )
       {
         results.insert( urls.size(), false );
         continue;

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -17,6 +17,7 @@
 #include "qgsproviderregistry.h"
 #include "qgsprovidersublayerdetails.h"
 #include "qgsproviderutils.h"
+#include "qgsrasteridentifyresult.h"
 #include "qgsrasterlayer.h"
 #include "qgssinglebandgrayrenderer.h"
 #include "qgstest.h"
@@ -99,6 +100,8 @@ class TestQgsWmsProvider : public QgsTest
     void testMaxTileSize();
 
     void testWmstTemporalCapabilities();
+
+    void testWmsUnreachableCapabilitiesWithVisibleSubLayer();
 
   private:
     QgsWmsCapabilities *mCapabilities = nullptr;
@@ -1383,5 +1386,25 @@ void TestQgsWmsProvider::testWmstTemporalCapabilities()
     QCOMPARE( query.queryItemValue( "TIME" ), QString( "2020-06-15" ) );
   }
 }
+
+void TestQgsWmsProvider::testWmsUnreachableCapabilitiesWithVisibleSubLayer()
+{
+  // test for https://github.com/qgis/QGIS/issues/62372
+  QString failingAddress( "http://localhost:8380/mapserv?xxx&layers=agri_zones&styles=&format=image/jpg" );
+  auto capabilities = std::make_unique<QgsWmsCapabilities>();
+  QgsWmsProvider provider( failingAddress, QgsDataProvider::ProviderOptions(), capabilities.get() );
+
+  // Simulating a saved layer with unreachable capabilities. Sublayer is visible
+  provider.mActiveSubLayerVisibility.insert( u"agri_zones"_s, true );
+
+  // capabilities should not crash
+  ( void ) provider.capabilities();
+
+  // identify should not crash
+  provider.mLayerExtent = QgsRectangle( 0, 0, 2, 2 );
+  provider.mCaps.mIdentifyFormats.insert( Qgis::RasterIdentifyFormat::Text, u"text"_s );
+  ( void ) provider.identify( QgsPointXY( 1., 1. ), Qgis::RasterIdentifyFormat::Text, QgsRectangle( 0, 0, 2, 2 ), 10, 10, 42 );
+}
+
 QGSTEST_MAIN( TestQgsWmsProvider )
 #include "testqgswmsprovider.moc"


### PR DESCRIPTION
## Description
Fixes #65913 which seems to be the same as #62372 which had an unsuccessful fix.

The wms provider would consider that the capabilities' `mQueryableForLayer` is populated even when the capabilities were unreachable/invalid.


## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
