### PR TITLE
Fix QgsImageCache lossy conversion of images, loss of color bit depth/hdr image data

### DIFF
--- a/src/3d/materials/qgsmetalroughtexturedmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsmetalroughtexturedmaterial3dhandler.cpp
@@ -115,14 +115,13 @@ Qt3DRender::QTexture2D *QgsMetalRoughTexturedMaterial3DHandler::loadTexture( con
 
   Qt3DRender::QTexture2D *texture = new Qt3DRender::QTexture2D();
 
-  if ( isSrgb )
+  bool requiresConversionToRgb = false;
+  Qt3DRender::QAbstractTexture::TextureFormat textureFormat = Qgs3DUtils::determineTextureFormat( image.format(), isSrgb, requiresConversionToRgb );
+  if ( requiresConversionToRgb )
   {
-    texture->setFormat( Qt3DRender::QAbstractTexture::SRGB8_Alpha8 );
+    image.convertTo( QImage::Format::Format_ARGB32_Premultiplied );
   }
-  else
-  {
-    texture->setFormat( Qt3DRender::QAbstractTexture::RGBA8_UNorm );
-  }
+  texture->setFormat( textureFormat );
 
   texture->wrapMode()->setX( Qt3DRender::QTextureWrapMode::Repeat );
   texture->wrapMode()->setY( Qt3DRender::QTextureWrapMode::Repeat );

--- a/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
+++ b/src/3d/materials/qgsphongtexturedmaterial3dhandler.cpp
@@ -58,7 +58,7 @@ QgsMaterial *QgsPhongTexturedMaterial3DHandler::toMaterial( const QgsAbstractMat
       }
 
       bool fitsInCache = false;
-      const QImage textureSourceImage = QgsApplication::imageCache()->pathAsImage( phongSettings->diffuseTexturePath(), QSize(), true, 1.0, fitsInCache );
+      QImage textureSourceImage = QgsApplication::imageCache()->pathAsImage( phongSettings->diffuseTexturePath(), QSize(), true, 1.0, fitsInCache );
       ( void ) fitsInCache;
 
       // No texture image was provided.
@@ -89,9 +89,16 @@ QgsMaterial *QgsPhongTexturedMaterial3DHandler::toMaterial( const QgsAbstractMat
       // TODO : if ( context.isSelected() ) dampen the color of diffuse texture
       // with context.map().selectionColor()
       Qt3DRender::QTexture2D *texture = new Qt3DRender::QTexture2D();
+
+      bool requiresConversionToRgb = false;
+      Qt3DRender::QAbstractTexture::TextureFormat textureFormat = Qgs3DUtils::determineTextureFormat( textureSourceImage.format(), true, requiresConversionToRgb );
+      if ( requiresConversionToRgb )
+      {
+        textureSourceImage.convertTo( QImage::Format::Format_ARGB32_Premultiplied );
+      }
+      texture->setFormat( textureFormat );
       texture->wrapMode()->setX( Qt3DRender::QTextureWrapMode::Repeat );
       texture->wrapMode()->setY( Qt3DRender::QTextureWrapMode::Repeat );
-      texture->setFormat( Qt3DRender::QAbstractTexture::SRGB8_Alpha8 );
       Qgs3DUtils::setTextureFiltering( texture, context );
 
       texture->addTextureImage( new QgsImageTexture( textureSourceImage ) );
@@ -138,7 +145,7 @@ QgsMaterial *QgsPhongTexturedMaterial3DHandler::toInstancedMaterial(
   material->setOpacity( static_cast<float>( phongSettings->opacity() ) );
 
   bool fitsInCache = false;
-  const QImage textureSourceImage = QgsApplication::imageCache()->pathAsImage( phongSettings->diffuseTexturePath(), QSize(), true, 1.0, fitsInCache );
+  QImage textureSourceImage = QgsApplication::imageCache()->pathAsImage( phongSettings->diffuseTexturePath(), QSize(), true, 1.0, fitsInCache );
   ( void ) fitsInCache;
 
   if ( !textureSourceImage.isNull() )
@@ -146,7 +153,15 @@ QgsMaterial *QgsPhongTexturedMaterial3DHandler::toInstancedMaterial(
     Qt3DRender::QTexture2D *texture = new Qt3DRender::QTexture2D();
     texture->wrapMode()->setX( Qt3DRender::QTextureWrapMode::Repeat );
     texture->wrapMode()->setY( Qt3DRender::QTextureWrapMode::Repeat );
-    texture->setFormat( Qt3DRender::QAbstractTexture::SRGB8_Alpha8 );
+
+    bool requiresConversionToRgb = false;
+    Qt3DRender::QAbstractTexture::TextureFormat textureFormat = Qgs3DUtils::determineTextureFormat( textureSourceImage.format(), true, requiresConversionToRgb );
+    if ( requiresConversionToRgb )
+    {
+      textureSourceImage.convertTo( QImage::Format::Format_ARGB32_Premultiplied );
+    }
+    texture->setFormat( textureFormat );
+
     Qgs3DUtils::setTextureFiltering( texture, context );
     texture->addTextureImage( new QgsImageTexture( textureSourceImage ) );
     material->setDiffuseTexture( texture );

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -1318,3 +1318,70 @@ void Qgs3DUtils::setTextureFiltering( Qt3DRender::QAbstractTexture *texture, con
       break;
   }
 }
+
+Qt3DRender::QAbstractTexture::TextureFormat Qgs3DUtils::determineTextureFormat( QImage::Format imageFormat, bool isSrgb, bool &requiresConversionToRgb )
+{
+  requiresConversionToRgb = false;
+  switch ( imageFormat )
+  {
+    case QImage::Format_RGBA32FPx4:
+    case QImage::Format_RGBA32FPx4_Premultiplied:
+      return Qt3DRender::QAbstractTexture::RGBA32F;
+
+    case QImage::Format_RGBX32FPx4:
+      return Qt3DRender::QAbstractTexture::RGB32F;
+
+    case QImage::Format_RGBA16FPx4:
+    case QImage::Format_RGBA16FPx4_Premultiplied:
+      return Qt3DRender::QAbstractTexture::RGBA16F;
+
+    case QImage::Format_RGBX16FPx4:
+      return Qt3DRender::QAbstractTexture::RGB16F;
+
+    case QImage::Format_RGBA8888:
+    case QImage::Format_RGBA8888_Premultiplied:
+    case QImage::Format_ARGB32:
+    case QImage::Format_ARGB32_Premultiplied:
+      return isSrgb ? Qt3DRender::QAbstractTexture::SRGB8_Alpha8 : Qt3DRender::QAbstractTexture::RGBA8_UNorm;
+
+    case QImage::Format_RGB32:
+    case QImage::Format_RGB888:
+      return isSrgb ? Qt3DRender::QAbstractTexture::SRGB8 : Qt3DRender::QAbstractTexture::RGB8_UNorm;
+
+    case QImage::Format_Grayscale8:
+    case QImage::Format_Alpha8:
+      return Qt3DRender::QAbstractTexture::R8_UNorm;
+    case QImage::Format_Grayscale16:
+      return Qt3DRender::QAbstractTexture::R16_UNorm;
+
+    case QImage::Format_Invalid:
+    case QImage::Format_Mono:
+    case QImage::Format_MonoLSB:
+    case QImage::Format_Indexed8:
+    case QImage::Format_RGB16:
+    case QImage::Format_ARGB8565_Premultiplied:
+    case QImage::Format_RGB666:
+    case QImage::Format_ARGB6666_Premultiplied:
+    case QImage::Format_RGB555:
+    case QImage::Format_ARGB8555_Premultiplied:
+    case QImage::Format_RGB444:
+    case QImage::Format_ARGB4444_Premultiplied:
+    case QImage::Format_RGBX8888:
+    case QImage::Format_BGR30:
+    case QImage::Format_A2BGR30_Premultiplied:
+    case QImage::Format_RGB30:
+    case QImage::Format_A2RGB30_Premultiplied:
+    case QImage::Format_RGBX64:
+    case QImage::Format_RGBA64:
+    case QImage::Format_RGBA64_Premultiplied:
+    case QImage::Format_BGR888:
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
+    case QImage::Format_CMYK8888:
+#endif
+    case QImage::NImageFormats:
+      // image format isn't compatible, it needs converting by caller
+      requiresConversionToRgb = true;
+      break;
+  }
+  return isSrgb ? Qt3DRender::QAbstractTexture::SRGB8_Alpha8 : Qt3DRender::QAbstractTexture::RGBA8_UNorm;
+}

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -198,6 +198,7 @@ class _3D_EXPORT Qgs3DUtils
     /**
      * Given a QImage \a format, returns the most appropriate corresponding texture format.
      *
+     * \param format QImage format to convert
      * \param isSrgb determines whether RGB formats should be interpreted as SRGB color spaces.
      * \param requiresConversionToRgb will be set to TRUE if the image format is not appropriate for a 3D texture and the image requires conversion to RGB by the caller.
      *

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -195,6 +195,16 @@ class _3D_EXPORT Qgs3DUtils
      */
     static QColor srgbToLinear( const QColor &color );
 
+    /**
+     * Given a QImage \a format, returns the most appropriate corresponding texture format.
+     *
+     * \param isSrgb determines whether RGB formats should be interpreted as SRGB color spaces.
+     * \param requiresConversionToRgb will be set to TRUE if the image format is not appropriate for a 3D texture and the image requires conversion to RGB by the caller.
+     *
+     * \since QGIS 4.2
+     */
+    static Qt3DRender::QAbstractTexture::TextureFormat determineTextureFormat( QImage::Format format, bool isSrgb, bool &requiresConversionToRgb );
+
     //! Calculates (x,y,z) positions of (multi)point from the given feature
     static void extractPointPositions(
       const QgsFeature &f,

--- a/src/3d/qgsskyboxentity.cpp
+++ b/src/3d/qgsskyboxentity.cpp
@@ -194,21 +194,37 @@ namespace
     constexpr int WIDTH = 32;
     constexpr int HEIGHT = 32;
 
-    const QImage img = data.image;
+    QImage img = data.image;
     if ( img.isNull() )
       return result;
 
-    QImage scaledImage = img.scaled( WIDTH, HEIGHT, Qt::IgnoreAspectRatio, Qt::SmoothTransformation );
-    if ( scaledImage.format() != QImage::Format_RGB32 )
+    bool isSrgb = true;
+    switch ( img.format() )
     {
-      // do we need to consider transparency here? probably not, if someone specifies a skybox texture
-      // with semi-transparent pixels then they get what they deserve...
-      scaledImage = scaledImage.convertToFormat( QImage::Format_RGB32 );
+      case QImage::Format_RGBA32FPx4:
+      case QImage::Format_RGBA32FPx4_Premultiplied:
+      case QImage::Format_RGBX32FPx4:
+      case QImage::Format_RGBA16FPx4:
+      case QImage::Format_RGBA16FPx4_Premultiplied:
+      case QImage::Format_RGBX16FPx4:
+        // float based image formats won't be in sRGB color space
+        isSrgb = false;
+        break;
+      default:
+        break;
     }
+
+    if ( img.format() != QImage::Format_RGBA32FPx4 )
+    {
+      // convert image to float
+      img = img.convertToFormat( QImage::Format_RGBA32FPx4 );
+    }
+
+    QImage scaledImage = img.scaled( WIDTH, HEIGHT, Qt::IgnoreAspectRatio, Qt::SmoothTransformation );
     for ( int y = 0; y < HEIGHT; ++y )
     {
       const float v = ( ( static_cast< float >( y ) + 0.5f ) / static_cast< float >( HEIGHT ) ) * 2.0f - 1.0f;
-      const QRgb *line = reinterpret_cast<const QRgb *>( scaledImage.constScanLine( y ) );
+      const float *line = reinterpret_cast<const float *>( scaledImage.constScanLine( y ) );
       for ( int x = 0; x < WIDTH; ++x )
       {
         // map pixel coordinate to [-1, 1] range
@@ -220,7 +236,11 @@ namespace
         float weight = 1.0f / std::pow( 1.0f + u * u + v * v, 1.5f );
         result.totalWeight += weight;
 
-        const QColor color = Qgs3DUtils::srgbToLinear( line[x] );
+        QColor color = QColor::fromRgbF( line[x * 4 + 0], line[x * 4 + 1], line[x * 4 + 2], 1 );
+        if ( isSrgb )
+        {
+          color = Qgs3DUtils::srgbToLinear( color );
+        }
         const QVector3D weightedColor( color.redF() * weight, color.greenF() * weight, color.blueF() * weight );
 
         constexpr float Y00 = 0.282095f;

--- a/src/3d/qgsskyboxentity.cpp
+++ b/src/3d/qgsskyboxentity.cpp
@@ -287,7 +287,6 @@ void QgsCubeFacesSkyboxEntity::updateEnvironmentLight( QgsEnvironmentLight *envL
   lightCubeMap->setMinificationFilter( Qt3DRender::QTextureCubeMap::LinearMipMapLinear );
   lightCubeMap->setGenerateMipMaps( true );
   lightCubeMap->setWrapMode( Qt3DRender::QTextureWrapMode( Qt3DRender::QTextureWrapMode::ClampToEdge ) );
-  lightCubeMap->setFormat( Qt3DRender::QAbstractTexture::SRGB8_Alpha8 );
 
   int maxSize = 0;
   for ( const QString &texturePath : { mSourcePosX, mSourcePosY, mSourcePosZ, mSourceNegX, mSourceNegY, mSourceNegZ } )
@@ -318,6 +317,14 @@ void QgsCubeFacesSkyboxEntity::updateEnvironmentLight( QgsEnvironmentLight *envL
     else if ( config.mirrorHorizontal || config.mirrorVertical )
     {
       finalImage = finalImage.mirrored( config.mirrorHorizontal, config.mirrorVertical );
+    }
+
+    bool requiresConversionToRgb = false;
+    Qt3DRender::QAbstractTexture::TextureFormat textureFormat = Qgs3DUtils::determineTextureFormat( finalImage.format(), true, requiresConversionToRgb );
+    lightCubeMap->setFormat( textureFormat );
+    if ( requiresConversionToRgb )
+    {
+      finalImage.convertTo( QImage::Format::Format_ARGB32_Premultiplied );
     }
 
     auto textureImage = new QgsImageTexture( finalImage, lightCubeMap );
@@ -359,7 +366,6 @@ void QgsCubeFacesSkyboxEntity::reloadTexture()
   newCubeMap->setMinificationFilter( Qt3DRender::QTextureCubeMap::Linear );
   newCubeMap->setGenerateMipMaps( false );
   newCubeMap->setWrapMode( Qt3DRender::QTextureWrapMode( Qt3DRender::QTextureWrapMode::ClampToEdge ) );
-  newCubeMap->setFormat( Qt3DRender::QAbstractTexture::SRGB8_Alpha8 );
 
   // all faces must have the SAME size, so take the maximum size from the input images
   int maxSize = 0;
@@ -399,6 +405,14 @@ void QgsCubeFacesSkyboxEntity::reloadTexture()
     else if ( config.mirrorHorizontal || config.mirrorVertical )
     {
       finalImage = finalImage.mirrored( config.mirrorHorizontal, config.mirrorVertical );
+    }
+
+    bool requiresConversionToRgb = false;
+    Qt3DRender::QAbstractTexture::TextureFormat textureFormat = Qgs3DUtils::determineTextureFormat( finalImage.format(), true, requiresConversionToRgb );
+    newCubeMap->setFormat( textureFormat );
+    if ( requiresConversionToRgb )
+    {
+      finalImage.convertTo( QImage::Format::Format_ARGB32_Premultiplied );
     }
 
     auto textureImage = new QgsImageTexture( finalImage, newCubeMap );

--- a/src/core/qgsimagecache.cpp
+++ b/src/core/qgsimagecache.cpp
@@ -508,13 +508,137 @@ QImage QgsImageCache::renderImage(
     }
   }
 
-  if (
-    !im.hasAlphaChannel()
+  if ( !im.hasAlphaChannel() )
+  {
+    // different logic below depending on whether caller has explicitly
+    // asked for opacity reduction or not
+    if ( opacity < 1.0 )
+    {
+      // dropping the opacity, so image MUST have an alpha channel
+      switch ( im.format() )
+      {
+        case QImage::Format_Invalid:
+        case QImage::NImageFormats:
+          // don't auto-add alpha for these
+          break;
+
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
-    && im.format() != QImage::Format_CMYK8888
+        case QImage::Format_CMYK8888:
+          // never auto-add alpha for CMYK -- this is not supported
+          break;
 #endif
-  )
-    im = im.convertToFormat( QImage::Format_ARGB32 );
+
+        case QImage::Format_RGBX64:
+        case QImage::Format_RGBA64:
+        case QImage::Format_RGBA64_Premultiplied:
+        case QImage::Format_Grayscale16:
+          // 64 bit source, convert to 64 bit Premultiplied
+          im = im.convertToFormat( QImage::Format_RGBA64_Premultiplied );
+          break;
+
+        case QImage::Format_RGBX16FPx4:
+        case QImage::Format_RGBA16FPx4:
+        case QImage::Format_RGBA16FPx4_Premultiplied:
+          // 16 bit floating point source, convert to 64 bit Premultiplied
+          im = im.convertToFormat( QImage::Format_RGBA16FPx4_Premultiplied );
+          break;
+
+        case QImage::Format_RGBX32FPx4:
+        case QImage::Format_RGBA32FPx4:
+        case QImage::Format_RGBA32FPx4_Premultiplied:
+          // 32 bit floating point source, convert to 64 bit Premultiplied
+          im = im.convertToFormat( QImage::Format_RGBA32FPx4_Premultiplied );
+          break;
+
+        case QImage::Format_Mono:
+        case QImage::Format_MonoLSB:
+        case QImage::Format_Indexed8:
+        case QImage::Format_RGB32:
+        case QImage::Format_ARGB32:
+        case QImage::Format_ARGB32_Premultiplied:
+        case QImage::Format_RGB16:
+        case QImage::Format_ARGB8565_Premultiplied:
+        case QImage::Format_RGB666:
+        case QImage::Format_ARGB6666_Premultiplied:
+        case QImage::Format_RGB555:
+        case QImage::Format_ARGB8555_Premultiplied:
+        case QImage::Format_RGB888:
+        case QImage::Format_RGB444:
+        case QImage::Format_ARGB4444_Premultiplied:
+        case QImage::Format_RGBX8888:
+        case QImage::Format_RGBA8888:
+        case QImage::Format_RGBA8888_Premultiplied:
+        case QImage::Format_BGR30:
+        case QImage::Format_A2BGR30_Premultiplied:
+        case QImage::Format_RGB30:
+        case QImage::Format_A2RGB30_Premultiplied:
+        case QImage::Format_Alpha8:
+        case QImage::Format_Grayscale8:
+        case QImage::Format_BGR888:
+          im = im.convertToFormat( QImage::Format_ARGB32 );
+          break;
+      }
+    }
+    else
+    {
+      // for RGB images only, we automatically add an alpha channel.
+      // this is partly to maintain api, but mostly for convenience
+      // so that painting operations on the result "just work"
+      // without every caller needing to worry about adding alpha
+      // channels
+
+      // for non-rgb (or for HDR image formats) we don't auto-add alpha
+      // channels -- this would be a lossy operation
+      switch ( im.format() )
+      {
+        case QImage::Format_Invalid:
+        case QImage::Format_RGBX64:
+        case QImage::Format_RGBA64:
+        case QImage::Format_RGBA64_Premultiplied:
+        case QImage::Format_Grayscale16:
+        case QImage::Format_RGBX16FPx4:
+        case QImage::Format_RGBA16FPx4:
+        case QImage::Format_RGBA16FPx4_Premultiplied:
+        case QImage::Format_RGBX32FPx4:
+        case QImage::Format_RGBA32FPx4:
+        case QImage::Format_RGBA32FPx4_Premultiplied:
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
+        case QImage::Format_CMYK8888:
+#endif
+        case QImage::NImageFormats:
+          // don't auto-add alpha for these
+          break;
+
+        case QImage::Format_Mono:
+        case QImage::Format_MonoLSB:
+        case QImage::Format_Indexed8:
+        case QImage::Format_RGB32:
+        case QImage::Format_ARGB32:
+        case QImage::Format_ARGB32_Premultiplied:
+        case QImage::Format_RGB16:
+        case QImage::Format_ARGB8565_Premultiplied:
+        case QImage::Format_RGB666:
+        case QImage::Format_ARGB6666_Premultiplied:
+        case QImage::Format_RGB555:
+        case QImage::Format_ARGB8555_Premultiplied:
+        case QImage::Format_RGB888:
+        case QImage::Format_RGB444:
+        case QImage::Format_ARGB4444_Premultiplied:
+        case QImage::Format_RGBX8888:
+        case QImage::Format_RGBA8888:
+        case QImage::Format_RGBA8888_Premultiplied:
+        case QImage::Format_BGR30:
+        case QImage::Format_A2BGR30_Premultiplied:
+        case QImage::Format_RGB30:
+        case QImage::Format_A2RGB30_Premultiplied:
+        case QImage::Format_Alpha8:
+        case QImage::Format_Grayscale8:
+        case QImage::Format_BGR888:
+          im = im.convertToFormat( QImage::Format_ARGB32 );
+          break;
+      }
+    }
+  }
 
   if ( opacity < 1.0 )
     QgsImageOperation::multiplyOpacity( im, opacity );

--- a/tests/src/3d/testqgs3dutils.cpp
+++ b/tests/src/3d/testqgs3dutils.cpp
@@ -96,6 +96,8 @@ class TestQgs3DUtils : public QgsTest
     void testCalculateCascadeSplits();
     void testCalculateViewSpaceOrthographicBounds_data();
     void testCalculateViewSpaceOrthographicBounds();
+    void testDetermineTextureFormat_data();
+    void testDetermineTextureFormat();
 
   private:
     QgsRasterLayer *mLayerRgb;
@@ -700,6 +702,52 @@ void TestQgs3DUtils::testCalculateViewSpaceOrthographicBounds()
   QGSCOMPARENEAR( actualFar, expectedFar, 0.0001f );
 }
 
+void TestQgs3DUtils::testDetermineTextureFormat_data()
+{
+  QTest::addColumn<QImage::Format>( "imageFormat" );
+  QTest::addColumn<bool>( "useSrgbFor8Bit" );
+  QTest::addColumn<Qt3DRender::QAbstractTexture::TextureFormat>( "expectedFormat" );
+  QTest::addColumn<bool>( "expectedRequiresConversion" );
+
+  QTest::newRow( "RGBA32FPx4" ) << QImage::Format_RGBA32FPx4 << false << Qt3DRender::QAbstractTexture::RGBA32F << false;
+  QTest::newRow( "RGBA32FPx4_Premultiplied" ) << QImage::Format_RGBA32FPx4_Premultiplied << true << Qt3DRender::QAbstractTexture::RGBA32F << false;
+  QTest::newRow( "RGBX32FPx4" ) << QImage::Format_RGBX32FPx4 << false << Qt3DRender::QAbstractTexture::RGB32F << false;
+  QTest::newRow( "RGBA16FPx4" ) << QImage::Format_RGBA16FPx4 << false << Qt3DRender::QAbstractTexture::RGBA16F << false;
+  QTest::newRow( "RGBA16FPx4_Premultiplied" ) << QImage::Format_RGBA16FPx4_Premultiplied << true << Qt3DRender::QAbstractTexture::RGBA16F << false;
+  QTest::newRow( "RGBX16FPx4" ) << QImage::Format_RGBX16FPx4 << false << Qt3DRender::QAbstractTexture::RGB16F << false;
+  QTest::newRow( "RGBA8888 sRGB" ) << QImage::Format_RGBA8888 << true << Qt3DRender::QAbstractTexture::SRGB8_Alpha8 << false;
+  QTest::newRow( "RGBA8888 UNorm" ) << QImage::Format_RGBA8888 << false << Qt3DRender::QAbstractTexture::RGBA8_UNorm << false;
+  QTest::newRow( "ARGB32 sRGB" ) << QImage::Format_ARGB32 << true << Qt3DRender::QAbstractTexture::SRGB8_Alpha8 << false;
+  QTest::newRow( "ARGB32_Premultiplied UNorm" ) << QImage::Format_ARGB32_Premultiplied << false << Qt3DRender::QAbstractTexture::RGBA8_UNorm << false;
+  QTest::newRow( "RGB32 sRGB" ) << QImage::Format_RGB32 << true << Qt3DRender::QAbstractTexture::SRGB8 << false;
+  QTest::newRow( "RGB32 UNorm" ) << QImage::Format_RGB32 << false << Qt3DRender::QAbstractTexture::RGB8_UNorm << false;
+  QTest::newRow( "RGB888 sRGB" ) << QImage::Format_RGB888 << true << Qt3DRender::QAbstractTexture::SRGB8 << false;
+  QTest::newRow( "RGB888 UNorm" ) << QImage::Format_RGB888 << false << Qt3DRender::QAbstractTexture::RGB8_UNorm << false;
+  QTest::newRow( "Grayscale8" ) << QImage::Format_Grayscale8 << true << Qt3DRender::QAbstractTexture::R8_UNorm << false;
+  QTest::newRow( "Alpha8" ) << QImage::Format_Alpha8 << false << Qt3DRender::QAbstractTexture::R8_UNorm << false;
+  QTest::newRow( "Grayscale16" ) << QImage::Format_Grayscale16 << true << Qt3DRender::QAbstractTexture::R16_UNorm << false;
+  QTest::newRow( "Invalid format sRGB" ) << QImage::Format_Invalid << true << Qt3DRender::QAbstractTexture::SRGB8_Alpha8 << true;
+  QTest::newRow( "Invalid format UNorm" ) << QImage::Format_Invalid << false << Qt3DRender::QAbstractTexture::RGBA8_UNorm << true;
+  QTest::newRow( "Mono format" ) << QImage::Format_Mono << false << Qt3DRender::QAbstractTexture::RGBA8_UNorm << true;
+  QTest::newRow( "Indexed8 format" ) << QImage::Format_Indexed8 << true << Qt3DRender::QAbstractTexture::SRGB8_Alpha8 << true;
+  QTest::newRow( "RGB16 format" ) << QImage::Format_RGB16 << false << Qt3DRender::QAbstractTexture::RGBA8_UNorm << true;
+  QTest::newRow( "RGBA64 format" ) << QImage::Format_RGBA64 << true << Qt3DRender::QAbstractTexture::SRGB8_Alpha8 << true;
+  QTest::newRow( "BGR888 format" ) << QImage::Format_BGR888 << false << Qt3DRender::QAbstractTexture::RGBA8_UNorm << true;
+}
+
+void TestQgs3DUtils::testDetermineTextureFormat()
+{
+  QFETCH( QImage::Format, imageFormat );
+  QFETCH( bool, useSrgbFor8Bit );
+  QFETCH( Qt3DRender::QAbstractTexture::TextureFormat, expectedFormat );
+  QFETCH( bool, expectedRequiresConversion );
+
+  bool requiresConversionToRgb = false;
+  Qt3DRender::QAbstractTexture::TextureFormat actualFormat = Qgs3DUtils::determineTextureFormat( imageFormat, useSrgbFor8Bit, requiresConversionToRgb );
+
+  QCOMPARE( actualFormat, expectedFormat );
+  QCOMPARE( requiresConversionToRgb, expectedRequiresConversion );
+}
 
 QGSTEST_MAIN( TestQgs3DUtils )
 #include "testqgs3dutils.moc"

--- a/tests/src/python/test_qgsimagecache.py
+++ b/tests/src/python/test_qgsimagecache.py
@@ -14,12 +14,14 @@ import http.server
 import os
 import shutil
 import socketserver
+import tempfile
 import threading
 import time
 import unittest
 
 from qgis.core import QgsApplication
-from qgis.PyQt.QtCore import QCoreApplication, QSize
+from qgis.PyQt.QtCore import QCoreApplication, QSize, Qt
+from qgis.PyQt.QtGui import QColor, QImage, qRgba
 from qgis.testing import QgisTestCase, start_app
 from utilities import unitTestDataPath
 
@@ -186,6 +188,246 @@ class TestQgsImageCache(QgisTestCase):
         image, in_cache = cache.pathAsImage(temp_image_path, QSize(200, 200), True, 1.0)
         self.assertFalse(image.isNull())
         self.assertTrue(in_cache)
+
+    def test_formats(self):
+        """
+        Test reading images in a wide range of formats, to ensure we can retrieve floating point
+        images losslessly
+        """
+        TEST_DATA = {
+            QImage.Format.Format_RGBX64: (
+                "tif",
+                QImage.Format.Format_RGBX64,
+                QImage.Format.Format_RGBA64_Premultiplied,
+            ),
+            QImage.Format.Format_RGBA64: (
+                "tif",
+                QImage.Format.Format_RGBA64,
+                QImage.Format.Format_RGBA64,
+            ),
+            QImage.Format.Format_RGBA64_Premultiplied: (
+                "tif",
+                QImage.Format.Format_RGBA64_Premultiplied,
+                QImage.Format.Format_RGBA64_Premultiplied,
+            ),
+            QImage.Format.Format_Grayscale16: (
+                "png",
+                QImage.Format.Format_Grayscale16,
+                QImage.Format.Format_RGBA64_Premultiplied,
+            ),
+            QImage.Format.Format_RGBX16FPx4: (
+                "tif",
+                QImage.Format.Format_RGBX16FPx4,
+                QImage.Format.Format_RGBA16FPx4_Premultiplied,
+            ),
+            QImage.Format.Format_RGBA16FPx4: (
+                "tif",
+                QImage.Format.Format_RGBA16FPx4,
+                QImage.Format.Format_RGBA16FPx4,
+            ),
+            QImage.Format.Format_RGBA16FPx4_Premultiplied: (
+                "tif",
+                QImage.Format.Format_RGBA16FPx4_Premultiplied,
+                QImage.Format.Format_RGBA16FPx4_Premultiplied,
+            ),
+            QImage.Format.Format_RGBX32FPx4: (
+                "tif",
+                QImage.Format.Format_RGBX32FPx4,
+                QImage.Format.Format_RGBA32FPx4_Premultiplied,
+            ),
+            QImage.Format.Format_RGBA32FPx4: (
+                "tif",
+                QImage.Format.Format_RGBA32FPx4,
+                QImage.Format.Format_RGBA32FPx4,
+            ),
+            QImage.Format.Format_RGBA32FPx4_Premultiplied: (
+                "tif",
+                QImage.Format.Format_RGBA32FPx4_Premultiplied,
+                QImage.Format.Format_RGBA32FPx4_Premultiplied,
+            ),
+            QImage.Format.Format_Mono: (
+                "png",
+                QImage.Format.Format_Mono,
+                QImage.Format.Format_Mono,
+            ),
+            QImage.Format.Format_MonoLSB: (
+                "png",
+                QImage.Format.Format_Mono,
+                QImage.Format.Format_Mono,
+            ),
+            QImage.Format.Format_Indexed8: (
+                "png",
+                QImage.Format.Format_Indexed8,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_RGB32: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_ARGB32: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_ARGB32_Premultiplied: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_RGB16: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_ARGB8565_Premultiplied: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_RGB666: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_ARGB6666_Premultiplied: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_RGB555: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_ARGB8555_Premultiplied: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_RGB888: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_RGB444: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_ARGB4444_Premultiplied: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_RGBX8888: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_RGBA8888: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_RGBA8888_Premultiplied: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_BGR30: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_A2BGR30_Premultiplied: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_RGB30: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_A2RGB30_Premultiplied: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_Alpha8: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_Grayscale8: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+            QImage.Format.Format_BGR888: (
+                "png",
+                QImage.Format.Format_ARGB32,
+                QImage.Format.Format_ARGB32,
+            ),
+        }
+
+        for image_format, v in TEST_DATA.items():
+            (
+                file_format,
+                expected_read_format_no_opacity,
+                expected_read_format_opacity,
+            ) = v
+            with tempfile.TemporaryDirectory() as temp_dir:
+                img = QImage(16, 16, image_format)
+
+                if image_format in (
+                    QImage.Format.Format_Mono,
+                    QImage.Format.Format_MonoLSB,
+                    QImage.Format.Format_Indexed8,
+                ):
+                    img.setColorCount(2)
+                    img.setColor(0, qRgba(0, 0, 0, 255))
+                    img.setColor(1, qRgba(255, 0, 0, 128))
+                    img.fill(1)
+                else:
+                    try:
+                        img.fill(QColor(255, 0, 0, 128))
+                    except Exception:
+                        img.fill(Qt.GlobalColor.white)
+
+                image_file = os.path.join(temp_dir, f"test.{file_format}")
+                self.assertTrue(img.save(image_file))
+
+                # re-read the image via the cache
+
+                # first with no opacity reduction
+                res_image, _ = QgsApplication.imageCache().pathAsImage(
+                    image_file,
+                    QSize(16, 16),
+                    True,
+                    1,
+                )
+                self.assertFalse(res_image.isNull())
+                self.assertEqual(
+                    res_image.format(),
+                    expected_read_format_no_opacity,
+                    f"Retrieving image of original format {image_format} got unexpected format when reading with no opacity change. Got {res_image.format()}, expected {expected_read_format_no_opacity}",
+                )
+
+                # now with opacity reduction
+                res_image, _ = QgsApplication.imageCache().pathAsImage(
+                    image_file,
+                    QSize(16, 16),
+                    True,
+                    0.5,
+                )
+                self.assertFalse(res_image.isNull())
+                self.assertEqual(
+                    res_image.format(),
+                    expected_read_format_opacity,
+                    f"Retrieving image of original format {image_format} got unexpected format when reading with opacity change. Got {res_image.format()}, expected {expected_read_format_opacity}",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR incorporates two related fixes:

1. It removes a forced conversion to ARGB32 images in QgsImageCache. This meant that it was impossible to load images with greater color depth, or floating point image data using the cache. There was an existing hardcoded logic to prevent this conversion for CMYK images, which has now been extended to correctly bypass the conversion for all formats where it would be lossy.
2. We no longer assume all image textures are RGB8 when creating 3d textures. Now we correctly match the texture format to the actual image format.

Together these two fixes mean that it's possible to load HDR images for use in 3d skyboxes/materials without loss of HDR color data.

## AI tool usage

 - [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
