### PR TITLE
Adding QGIS Algeria User Group to the user group json

### DIFF
--- a/resources/data/user_groups_data.json
+++ b/resources/data/user_groups_data.json
@@ -364,6 +364,17 @@
         "year": 2025
       },
       "geometry": null
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "country": "DZ",
+        "name": "QGIS Algeria User Group",
+        "logo_url": "https:\/\/dz.qgis.org\/img\/QGIS_DZ.png",
+        "website": "https:\/\/dz.qgis.org",
+        "year": 2026
+      },
+      "geometry": null
     }
   ]
 }


### PR DESCRIPTION
## Description

Adds the user group to the json file, including a link to the new website and logo. No change in code, just data. Tested the file manually in QGIS and looking good:

<img width="724" height="430" alt="image" src="https://github.com/user-attachments/assets/2394bcdc-a924-4f71-8ff6-4d7b4c963d35" />
