### PR TITLE
Fix redundant plugin update message when welcome screen is visible FIXIS #65653

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2060,13 +2060,15 @@ QgisApp::QgisApp(
     {
       mWelcomeScreen->pluginUpdatesAvailableReceived( plugins );
     }
-
-    // Be extra visible, show in message bar too
-    QgsMessageBarItem *messageWidget = QgsMessageBar::createMessage( tr( "Plugins" ), updateMessage );
-    QPushButton *updateButton = new QPushButton( tr( "Install Updates…" ) );
-    connect( updateButton, &QPushButton::clicked, []() { QgisApp::instance()->showPluginManager( static_cast<int>( QgsPluginManager::Tabs::UpgradeablePlugins ) ); } );
-    messageWidget->layout()->addWidget( updateButton );
-    messageBar()->pushWidget( messageWidget, Qgis::MessageLevel::Warning, 0 );
+    else
+    {
+      // Only show in message bar if welcome screen is not visible avoiding duplicate messages
+      QgsMessageBarItem *messageWidget = QgsMessageBar::createMessage( tr( "Plugins" ), updateMessage );
+      QPushButton *updateButton = new QPushButton( tr( "Install Updates…" ) );
+      connect( updateButton, &QPushButton::clicked, []() { QgisApp::instance()->showPluginManager( static_cast<int>( QgsPluginManager::Tabs::UpgradeablePlugins ) ); } );
+      messageWidget->layout()->addWidget( updateButton );
+      messageBar()->pushWidget( messageWidget, Qgis::MessageLevel::Warning, 0 );
+    }
   } );
 
   QgsWelcomeScreen::registerTypes();


### PR DESCRIPTION
## Description

Fix redundant plugin update message bar when welcome screen is visible.
(This is my first pull request, so please bear with me if I'm making any mistakes!)

## AI tool usage

 - [ Gemini] 


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
